### PR TITLE
astar: make CATemp ctor responsible for zero-init

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -449,7 +449,6 @@ void CAStar::calcAStar()
 			m_bestPath.m_cost = kInfiniteCost;
 
 			CATemp temp;
-			memset(&temp, 0, sizeof(temp));
 
 			check(from, to, temp);
 
@@ -875,7 +874,8 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
  */
 CAStar::CATemp::CATemp()
 {
-	// TODO
+	// Plausible original behavior: zero-initialize the temp path structure.
+	memset(this, 0, sizeof(*this));
 }
 
 /*


### PR DESCRIPTION
Removes redundant memset(&temp,0,sizeof(temp)) after constructing CATemp.
Implements CAStar::CATemp::CATemp() as memset(this,0,sizeof(*this)) (plausible original pattern).
Improves objdiff alignment for calcAStar__6CAStarFv (and slightly nudges unit fuzzy).