### PR TITLE
usb: make callback entry inUse signed

### DIFF
--- a/include/ffcc/usb.h
+++ b/include/ffcc/usb.h
@@ -17,7 +17,7 @@ typedef void (*MessageCallback)(unsigned long, void*, MCCChannel);
 
 struct CUSBCallbackEntry
 {
-    unsigned int m_inUse;  // 0x0
+    int m_inUse;           // 0x0
     void* m_callback;      // 0x4
     void* m_callerContext; // 0x8
 };


### PR DESCRIPTION
objdiff for RemoveMessageCallback is doing signed compares (cmpwi) against 0, so having m_inUse signed is the right C++ type.
This was the lever that improved RemoveMessageCallback match (~83% → ~88%) without doing anything non-humanlike.