### PR TITLE
Pr/main/baseobj

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -1,13 +1,17 @@
 #ifndef _FFCC_CFLAT_RUNTIME_H_
 #define _FFCC_CFLAT_RUNTIME_H_
 
+#include "global.h"
+
 class CChunkFile;
 
 class CFlatRuntime
 {
 public:
-	class CStack
+	struct CStack
 	{
+		u32 m_word;
+
 		void operator=(const CStack&);
 	};
 

--- a/src/baseobj.cpp
+++ b/src/baseobj.cpp
@@ -1,7 +1,5 @@
 #include "ffcc/baseobj.h"
 
-#include "global.h"
-
 extern __declspec(section ".data") CFlatRuntime CFlat;
 
 /*
@@ -11,10 +9,10 @@ extern __declspec(section ".data") CFlatRuntime CFlat;
  */
 void CGBaseObj::onPush(CGBaseObj* other, int param_3)
 {
-	u32 stack[2];
-	stack[0] = (u32)other->m_particleId;
-	stack[1] = (u32)param_3;
-	CFlat.SystemCall(this, 2, 4, 2, (CFlatRuntime::CStack*)stack, 0);
+	CFlatRuntime::CStack stack[2];
+	stack[0].m_word = (u32)other->m_particleId;
+	stack[1].m_word = (u32)param_3;
+	CFlat.SystemCall(this, 2, 4, 2, stack, 0);
 }
 
 /*
@@ -24,10 +22,10 @@ void CGBaseObj::onPush(CGBaseObj* other, int param_3)
  */
 void CGBaseObj::onTalk(CGBaseObj* other, int param_3)
 {
-	u32 stack[2];
-	stack[0] = (u32)other->m_particleId;
-	stack[1] = (u32)param_3;
-	CFlat.SystemCall(this, 2, 6, 2, (CFlatRuntime::CStack*)stack, 0);
+	CFlatRuntime::CStack stack[2];
+	stack[0].m_word = (u32)other->m_particleId;
+	stack[1].m_word = (u32)param_3;
+	CFlat.SystemCall(this, 2, 6, 2, stack, 0);
 }
 
 void CGBaseObj::onCreate()


### PR DESCRIPTION
Implemented CGBaseObj::onPush and CGBaseObj::onTalk to call CFlat.SystemCall(...) with the expected 2-word stack arg block (particleId, param_3).
Made CFlatRuntime methods public in include/ffcc/cflat_runtime.h (it was implicitly private: before, which prevented calling SystemCall).