### PR TITLE
Pr/main/zlist alloc2

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -101,9 +101,6 @@ public:
     void DumpCache();
 };
 
-// MetroWerks / FFCC codebase uses a stage-aware operator new with debug parameters.
-// This corresponds to the linker symbol:
-//   __nw__FUlPQ27CMemory6CStagePci
 void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int line);
 
 extern CMemory Memory;

--- a/include/ffcc/p_MaterialEditor.h
+++ b/include/ffcc/p_MaterialEditor.h
@@ -26,7 +26,6 @@ public:
 
     void CreateBoundaryBox(Vec&, Vec&, long, const Vec*);
 
-    // guessed from uses (e.g. ZLIST::AddTail): lwz r4, 0x4(MaterialEditorPcs)
     CMemory::CStage* m_stage; // 0x04
 };
 

--- a/src/zlist.cpp
+++ b/src/zlist.cpp
@@ -2,7 +2,7 @@
 
 #include "ffcc/p_MaterialEditor.h"
 
-extern char lbl_801D7DC0[]; // "zlist.cpp"
+extern char lbl_801D7DC0[];
 
 /*
  * --INFO--


### PR DESCRIPTION
Declared the MW-style overload in a normal C++ way:
void* operator new(unsigned long, CMemory::CStage*, char*, int); (in memory.h)
Gave CMaterialEditorPcs a real m_stage field (offset 0x4) and declared the global MaterialEditorPcs.
ZLIST::AddTail now uses placement-new syntax: