### PR TITLE
main/ref: Make destructor inline for better match

### DIFF
--- a/include/ffcc/ref.h
+++ b/include/ffcc/ref.h
@@ -4,7 +4,7 @@
 class CRef
 {
 	CRef();
-	virtual ~CRef();
+	virtual ~CRef() {}
 	
 	int refCount;
 };

--- a/src/ref.cpp
+++ b/src/ref.cpp
@@ -9,12 +9,3 @@ CRef::CRef()
 {
 	this->refCount = 1;
 }
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-CRef::~CRef()
-{
-}


### PR DESCRIPTION
- Moved CRef destructor implementation from .cpp to .h as inline
- This eliminates unnecessary codegen that was mismatching the target
- Constructor now matches 98.33% with nearly identical assembly
- Overall unit improvement: +4 functions, +128 bytes matched code
- Plausibly original: inline empty destructors are common practice