### PR TITLE
astar: make CalcLength parameter const

### DIFF
--- a/include/ffcc/astar.h
+++ b/include/ffcc/astar.h
@@ -15,7 +15,7 @@ public:
 	class CAPos
 	{
 	public:
-		float CalcLength(CAPos&);
+		float CalcLength(const CAPos&);
 		unsigned char GetOthers(int group);
 		int IsExist(int group);
 

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -879,7 +879,7 @@ CAStar::CATemp::CATemp()
  * Address:	TODO
  * Size:	TODO
  */
-float CAStar::CAPos::CalcLength(CAStar::CAPos& other)
+float CAStar::CAPos::CalcLength(const CAStar::CAPos& other)
 {
 	return PSVECDistance(&this->m_position, &other.m_position);
 }


### PR DESCRIPTION
- Changed CalcLength parameter from 'CAPos&' to 'const CAPos&' since function only reads
- Updated both source and header declarations
- Improved const correctness and potential compiler optimizations