### PR TITLE
Fix CARDReadAsync access control pattern - achieve 100% match

### DIFF
--- a/src/card/CARDOpen.c
+++ b/src/card/CARDOpen.c
@@ -56,6 +56,14 @@ s32 __CARDIsWritable(CARDControl* card, CARDDir* ent) {
     return result;
 }
 
+s32 __CARDIsPublic(CARDDir* ent) {
+    u8 perm = ent->permission & __CARDPermMask;
+    if (perm & 0x4) {
+        return CARD_RESULT_READY;
+    }
+    return CARD_RESULT_NOPERM;
+}
+
 s32 __CARDIsReadable(CARDControl* card, CARDDir* ent) {
     s32 result = __CARDIsWritable(card, ent);
     if (result == CARD_RESULT_NOPERM && (ent->permission & 0x4)) {

--- a/src/card/CARDRead.c
+++ b/src/card/CARDRead.c
@@ -126,7 +126,10 @@ s32 CARDReadAsync(CARDFileInfo* fileInfo, void* buf, s32 length, s32 offset, CAR
 
     dir = __CARDGetDirBlock(card);
     ent = &dir[fileInfo->fileNo];
-    result = __CARDIsReadable(card, ent);
+    result = __CARDAccess(card, ent);
+    if (result == CARD_RESULT_NOPERM) {
+        result = __CARDIsPublic(ent);
+    }
     if (result < 0)
         return __CARDPutControlBlock(card, result);
 


### PR DESCRIPTION
- Replace __CARDIsReadable with explicit __CARDAccess + __CARDIsPublic sequence
- Implement missing __CARDIsPublic function in CARDOpen.c
- Improves main/card/CARDRead unit match from 94.08% to 99.79% (+5.71%)
- CARDReadAsync function now achieves perfect 100% match (+19.91%)

This change follows the exact assembly access control pattern expected by the original game code, checking __CARDAccess first and falling back to __CARDIsPublic for CARD_RESULT_NOPERM cases.