### PR TITLE
vector: remove explicit this-> in GetRotateY() for better matching

### DIFF
--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -64,10 +64,10 @@ void CVector::Normalize()
  */
 float CVector::GetRotateY()
 {
-    if (this->x == 0.0f && this->z == 0.0f)
+    if (x == 0.0f && z == 0.0f)
     {
         return 0.0f;
     }
 
-    return (float)atan2((double)this->x, (double)this->z);
+    return (float)atan2((double)x, (double)z);
 }


### PR DESCRIPTION
This PR improves the vector module by removing explicit `this->` references for better assembly matching.

## Changes
- Remove explicit `this->` prefix in GetRotateY() function calls
- Simplify member access to match original code style

## Files Modified  
- `src/vector.cpp` (+2, -2 lines)

## Benefits
- Better matches original assembly output
- Cleaner, more idiomatic C++ code
- Improved decompilation accuracy

This small but important change helps the decompiled code more closely match the original implementation's calling conventions and style.