### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ compile_commands.json
 # Miscellaneous
 /*.txt
 *.exe
+
+# macOS system files
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
## Summary
Prevent macOS .DS_Store system files from being accidentally committed to the repository.

## Changes
- Added `.DS_Store` pattern to .gitignore
- Added `**/.DS_Store` pattern to catch .DS_Store files in all subdirectories
- Placed in "Miscellaneous" section of .gitignore

## Why This is Needed
- .DS_Store files are macOS system files that store folder metadata
- They serve no purpose in version control and clutter the repository
- They can accidentally get committed when using `git add .` or similar commands
- This prevents future accidental commits of these system files

This is a standard practice for any repository that might be used on macOS systems.