### PR TITLE
FS_USB_Process: Add function stubs and analysis

### DIFF
--- a/include/ffcc/FS_USB_Process.h
+++ b/include/ffcc/FS_USB_Process.h
@@ -1,6 +1,10 @@
 #ifndef _FFCC_FS_USB_PROCESS_H_
 #define _FFCC_FS_USB_PROCESS_H_
 
+// Forward declarations
+class CFunnyShapePcs;
+class CDataHeader;
+
 class OSFS_SHAPE_ST
 {
 public:
@@ -17,6 +21,8 @@ class CFunnyShape
 {
 public:
 	void SetDisplay(FS_DISPLAY_STATUS);
+	void SetUSBData();
+	void USBDataCallback(CDataHeader*);
 };
 
 #endif // _FFCC_FS_USB_PROCESS_H_

--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -1,4 +1,28 @@
 #include "ffcc/FS_USB_Process.h"
+#include "ffcc/p_FunnyShape.h"
+#include "ffcc/p_usb.h"
+
+/*
+ * --INFO--
+ * PAL Address: 80052bc0
+ * PAL Size: 3524b
+ */
+void CFunnyShape::SetUSBData()
+{
+	// TODO: Complex USB data processing function
+	// Handles packet codes 4,5,6,10,11,12,15,16 for different data types
+}
+
+/*
+ * --INFO--
+ * PAL Address: UNUSED  
+ * PAL Size: 52b
+ */
+void CFunnyShape::USBDataCallback(CDataHeader* dataHeader)
+{
+	// TODO: USB data callback processing
+	// Small 52-byte function
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
Adds initial function signatures and stub implementations for SetUSBData and USBDataCallback.

SetUSBData is extremely complex (3524 bytes) with USB packet processing for codes 4,5,6,10,11,12,15,16. 
USBDataCallback is smaller (52 bytes) and should be tackled first.

Ghidra decompilation available for reference. Functions compile successfully as stubs.
Requires dedicated multi-session approach due to complexity.