### PR TITLE
pppParMatrix: Perfect assembly match via Ghidra decomp adaptation

### DIFF
--- a/include/ffcc/pppParMatrix.h
+++ b/include/ffcc/pppParMatrix.h
@@ -1,6 +1,6 @@
 #ifndef _PPP_PARMATRIX_H_
 #define _PPP_PARMATRIX_H_
 
-void pppParMatrix(void* param);
+void pppParMatrix(int param);
 
 #endif // _PPP_PARMATRIX_H_

--- a/src/pppParMatrix.cpp
+++ b/src/pppParMatrix.cpp
@@ -6,21 +6,18 @@
  * Address:	TODO
  * Size:	108
  */
-void pppParMatrix(void* param)
+void pppParMatrix(int param)
 {
-	MtxPtr matrix = *(MtxPtr*)((u32)param + 0x4);
-	Vec source, destination;
+	Vec local_vec;
+	int* matrix_ptr = *(int**)(param + 4);
 	
-	// Load source vector from offsets 0x1c, 0x2c, 0x3c
-	source.x = *(f32*)((u32)param + 0x1c);
-	source.y = *(f32*)((u32)param + 0x2c);  
-	source.z = *(f32*)((u32)param + 0x3c);
+	local_vec.x = *(f32*)(param + 0x1c);
+	local_vec.y = *(f32*)(param + 0x2c);
+	local_vec.z = *(f32*)(param + 0x3c);
 	
-	// Multiply matrix by vector (matrix + 0x10 in assembly)
-	PSMTXMultVec((f32(*)[4])((u8*)matrix + 0x10), &source, &destination);
+	PSMTXMultVec((f32(*)[4])((u8*)matrix_ptr + 0x10), &local_vec, &local_vec);
 	
-	// Store result back to same offsets
-	*(f32*)((u32)param + 0x1c) = destination.x;
-	*(f32*)((u32)param + 0x2c) = destination.y;
-	*(f32*)((u32)param + 0x3c) = destination.z;
+	*(f32*)(param + 0x1c) = local_vec.x;
+	*(f32*)(param + 0x2c) = local_vec.y;
+	*(f32*)(param + 0x3c) = local_vec.z;
 }


### PR DESCRIPTION
## Summary
Achieved **identical assembly output** for pppParMatrix function by adapting the Ghidra decompilation approach.

## Functions Improved
- **pppParMatrix** (108b): Complete assembly alignment ✅
  - All 27 instructions now match exactly
  - Stack frame, register usage, memory operations identical

## Match Evidence
**Before**: Different stack frame (-0x30 vs -0x20), separate source/destination vectors
**After**: Identical assembly instruction sequence verified via objdiff-cli

**Key Changes**:
- Parameter type: `void* param` → `int param` (matches symbol data)
- Vector handling: Single `Vec local_vec` used for input/output (not separate variables)  
- Instruction ordering: Matrix pointer loaded at correct sequence point

## Plausibility Rationale
The new implementation represents **plausible original source** because:
- Uses idiomatic C++ pattern (single variable for input/output transformation)
- Parameter type matches symbol analysis from game.MAP files
- Follows common matrix multiplication patterns in game engines
- No contrived temporaries or compiler coaxing techniques
- Clean, readable code that a game developer would naturally write

## Technical Details
Ghidra decompilation provided the key insight: original code used a single `Vec` variable passed as both source and destination to `PSMTXMultVec`, not separate variables. The compiler optimization patterns matched once this approach was adopted.

**Objdiff Analysis**: Complete instruction-level alignment achieved - this represents a perfect functional match.