### PR TITLE
pppAngAccele: Improve register allocation and achieve better assembly match

### DIFF
--- a/src/pppAngAccele.cpp
+++ b/src/pppAngAccele.cpp
@@ -13,14 +13,11 @@ void pppAngAccele(void* particleSystem, void* particleData)
         return;
     }
     
-    void** systemPtr = (void**)particleSystem;
-    void** particlePtr = (void**)particleData;
-    void* systemData = systemPtr[3];
-    void* particleIdPtr = particlePtr[0];
-    void** systemDataPtr = (void**)systemData;
-    void* angularVelocityPtr = systemDataPtr[0];
+    void** systemData = (void**)((void**)particleSystem)[3];
+    void* particleIdPtr = ((void**)particleData)[0];
+    void* angularVelocityPtr = systemData[0];
     int particleId = *(int*)particleIdPtr;
-    void* angularAccelerationPtr = systemDataPtr[1];
+    void* angularAccelerationPtr = systemData[1];
     
     char* angularVelocityBase = (char*)particleSystem + (int)angularVelocityPtr + 0x80;
     char* angularAccelBase = (char*)particleSystem + (int)angularAccelerationPtr + 0x80;
@@ -43,10 +40,8 @@ void pppAngAccele(void* particleSystem, void* particleData)
  */
 void pppAngAcceleCon(void* particleSystem)
 {
-    void** systemPtr = (void**)particleSystem;
-    void* systemData = systemPtr[3];
-    void** systemDataPtr = (void**)systemData;
-    void* angularAccelerationPtr = systemDataPtr[1];
+    void** systemData = (void**)((void**)particleSystem)[3];
+    void* angularAccelerationPtr = systemData[1];
     
     char* ptr = (char*)particleSystem + (int)angularAccelerationPtr + 0x80;
     *(int*)(ptr + 0x8) = 0;


### PR DESCRIPTION
## Summary
Improved the pppAngAccele unit by simplifying variable access patterns to better match the expected assembly output.

## Functions Improved
- **pppAngAcceleCon**: Achieved 100% assembly match (36b)
- **pppAngAccele**: Significantly improved register allocation and instruction ordering (156b)

## Match Evidence  
- pppAngAcceleCon: Assembly output now matches exactly with expected target
- pppAngAccele: Much closer instruction sequence and register usage patterns
- Reduced intermediate variables improved compiler register allocation
- Overall unit progress improved from 0% baseline

## Plausibility Rationale
The changes represent plausible original source patterns:
- Inline system data access reduces unnecessary temporary variables
- Direct pointer dereferencing is common in performance-critical game code
- Simplified variable scope matches typical C++ optimization practices
- Code remains readable while improving match accuracy

## Technical Details
**Key implementation changes:**
- Replaced multi-step pointer access with inline dereferencing: `(void**)((void**)particleSystem)[3]`
- Reduced intermediate variable storage for system data pointers
- Maintained original function logic and parameter usage patterns
- Assembly analysis shows improved register allocation efficiency

**objdiff analysis results:**
- pppAngAcceleCon: Perfect assembly match achieved
- pppAngAccele: Significantly improved instruction ordering and register usage
- No extraneous instructions generated
- Clean function boundaries maintained