### PR TITLE
Complete MSL_C ctype module: Implement toupper() function

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/ctype.c
+++ b/src/MSL_C/PPCEABI/bare/H/ctype.c
@@ -76,3 +76,8 @@ int tolower(int __c)
 {
 	return __c == -1 ? -1 : __lower_map[(unsigned char)__c];
 }
+
+int toupper(int __c)
+{
+	return __c == -1 ? -1 : __upper_map[(unsigned char)__c];
+}


### PR DESCRIPTION
## Summary
Implemented the missing `toupper()` function in the MSL_C character type module, achieving 100% completion for this unit.

## Functions Improved  
- **fn_801b52a0** → **toupper()**: 0% → 100% match (36 bytes)
- **Unit completion**: 0/1 → 1/1 functions (100% match rate)

## Match Evidence
**Before**: 
- `fn_801b52a0` placeholder function with generic symbol references
- 0% assembly match, 36 bytes unmatched

**After**:
- Perfect 100% assembly match with `objdiff-cli`
- Correct symbol resolution (`__upper_map@ha`/`__upper_map@l`)
- Function properly identified as `toupper` in objdiff output

## Implementation Details
The `toupper()` implementation follows the exact pattern established by the existing `tolower()` function:

```c
int toupper(int __c)
{
    return __c == -1 ? -1 : __upper_map[(unsigned char)__c];
}
```

**Key technical aspects**:
- EOF (-1) handling for standard C library compliance  
- Lookup table approach using existing `__upper_map` array
- Consistent with MSL PowerPC EABI conventions
- Identical assembly structure to `tolower()` implementation

## Plausibility Rationale
This represents highly plausible original source code:
- **Standard library pattern**: Follows canonical C library implementation style
- **Consistent with existing code**: Matches the exact pattern used in `tolower()`
- **Idiomatic implementation**: Uses efficient lookup table approach typical of embedded systems
- **No compiler coaxing**: Clean, readable code that any C library developer would write

The implementation leverages the existing character mapping infrastructure (`__upper_map` array) that was already present in the module, indicating this was the intended approach for the original `toupper()` function.

**Unit status**: MSL_C/PPCEABI/bare/H/ctype module is now 100% complete (1/1 functions matched).