### PR TITLE
Implement pppVertexApCon with perfect assembly match

### DIFF
--- a/include/ffcc/pppVertexAp.h
+++ b/include/ffcc/pppVertexAp.h
@@ -5,7 +5,7 @@ struct _pppPObject;
 class PVertexAp;
 struct Vec;
 
-void pppVertexApCon(void);
+void pppVertexApCon(_pppPObject*, PVertexAp*);
 void apea(_pppPObject*, PVertexAp*, Vec*);
 void pppVertexAp(void);
 

--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -2,12 +2,21 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80064ae8
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppVertexApCon(void)
+void pppVertexApCon(_pppPObject* pobj, PVertexAp* vtxAp)
 {
-	// TODO
+	int* vtxApPtr = (int*)vtxAp;
+	int offset = vtxApPtr[3]; // 0xc offset (12 bytes / 4 = index 3)
+	int* basePtr = (int*)offset;
+	short* ptr = (short*)((char*)pobj + *basePtr + 0x80);
+	ptr[0] = 0;
+	ptr[1] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary

Implemented  function with **100% assembly match** (0% → 100% improvement).

### Functions Improved
- **pppVertexApCon**: 0% → 100% match (32 bytes, perfect assembly alignment)

### Technical Details

**Function signature correction:**
- Changed from  to 
- Assembly analysis revealed clear parameter usage in r3 and r4 registers

**Implementation approach:**
1. Access offset 0xc (12 bytes) from second parameter (PVertexAp*)
2. Dereference the resulting pointer to get base address  
3. Add 0x80 offset to the first parameter (_pppPObject*)
4. Store zero values at consecutive halfword locations (offsets 0 and 2)

**Assembly verification:**
- Exact instruction sequence match:  →  →  →  →  →  →  → 
- Size match: 32 bytes exactly
- All relocations and instruction encoding identical

### Plausibility Rationale

This represents **plausible original source** because:
- Function performs straightforward initialization of structure members to zero
- Pointer arithmetic pattern is typical for accessing nested data structures  
- Code style matches other initialization functions in the codebase
- No contrived optimizations or compiler-coaxing patterns

The implementation reads naturally as initialization code that a game developer would write to reset vertex application state.