### PR TITLE
pppMatrixScl: Fix C function linkage to achieve 99.85% match

### DIFF
--- a/include/ffcc/pppMatrixScl.h
+++ b/include/ffcc/pppMatrixScl.h
@@ -3,6 +3,14 @@
 
 #include "dolphin/mtx.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void pppMatrixScl(void* mtx, void* data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _PPP_MATRIXSCL_H_

--- a/src/pppMatrixScl.cpp
+++ b/src/pppMatrixScl.cpp
@@ -12,9 +12,8 @@ void pppMatrixScl(void* mtx, void* data)
     Mtx* mtxPtr = (Mtx*)((u8*)matrix + 16);
     
     void* dataPtr = ((void**)data)[3];
-    u32* indices = (u32*)dataPtr;
-    u32 index1 = indices[0];
-    u32 index2 = indices[1];
+    u32 index1 = ((u32*)dataPtr)[0];
+    u32 index2 = ((u32*)dataPtr)[1];
     
     f32* scale1 = (f32*)((u8*)matrix + index1 + 0x80);
     f32* scale2 = (f32*)((u8*)matrix + index2 + 0x80);


### PR DESCRIPTION
## Summary
Fixed function signature and linkage to achieve near-perfect assembly match for pppMatrixScl.

## Functions Improved
- **pppMatrixScl**: 0.0% → 99.85% match (140 bytes)

## Match Evidence
- **Before**: 0% match - function compiled as C++ with name mangling (pppMatrixScl__FPvPv)
- **After**: 99.85% match - function compiles as C function (pppMatrixScl)
- Only 1 instruction difference: register assignment (lwz r4,0xc(r4) vs lwz r4,0xc(r5))

## Plausibility Rationale  
The implementation represents **plausible original source**:
- Uses standard C function declaration with proper extern "C" linkage
- Follows typical matrix scaling pattern: PSMTXIdentity + scale value assignment
- Accesses data through structured offset pattern (data[3] → indices → scale values)
- Matrix assignments follow standard 3D transformation layout (diagonal + translation)

## Technical Details
**Key change**: Added extern "C" wrapper to header to prevent C++ name mangling
- Original assembly expects plain C function symbol
- Previous version was compiling as C++ with mangled name
- Assembly instructions are now nearly identical
- Remaining 0.14% difference appears to be compiler optimization/register allocation

**Function behavior**: Matrix scaling transformation that:
1. Initializes 4x4 matrix to identity
2. Extracts two sets of 3D scale values from data structure  
3. Applies scale values to matrix diagonal and translation components
4. Produces standard 3D transformation matrix for scaling operations