### PR TITLE
Implement pppSpMatrix: 0% → 58.6% match with PSMTXConcat

### DIFF
--- a/include/ffcc/pppSpMatrix.h
+++ b/include/ffcc/pppSpMatrix.h
@@ -1,6 +1,14 @@
 #ifndef _PPP_SPMATRIX_H_
 #define _PPP_SPMATRIX_H_
 
-void pppSpMatrix(void);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void pppSpMatrix(void* mtx, void* src, void* data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _PPP_SPMATRIX_H_

--- a/src/pppSpMatrix.cpp
+++ b/src/pppSpMatrix.cpp
@@ -1,11 +1,16 @@
 #include "ffcc/pppSpMatrix.h"
+#include <dolphin/mtx.h>
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d3818
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppSpMatrix(void)
+void pppSpMatrix(void* mtx, void* src, void* data)
 {
-	// TODO
+    PSMTXConcat(*(Mtx*)((char*)src + 0x80), *(Mtx*)((char*)mtx + 0x10), *(Mtx*)((char*)src + *(u32*)((char*)data + 0xc)));
 }


### PR DESCRIPTION
Implements pppSpMatrix function with PSMTXConcat call. Corrected function signature from void to 3 parameters. Added C linkage. Achieved 58.6% match improvement from 0%.