### PR TITLE
pppPointAp: Fix function signatures and implement pppPointApCon

### DIFF
--- a/include/ffcc/pppPointAp.h
+++ b/include/ffcc/pppPointAp.h
@@ -1,7 +1,7 @@
 #ifndef _PPP_POINTAP_H_
 #define _PPP_POINTAP_H_
 
-void pppPointApCon(void);
-void pppPointAp(void);
+void pppPointApCon(void* param1, void* param2);
+void pppPointAp(void* param1, void* param2, void* param3);
 
 #endif // _PPP_POINTAP_H_

--- a/src/pppPointAp.cpp
+++ b/src/pppPointAp.cpp
@@ -2,20 +2,30 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80060d08
+ * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppPointApCon(void)
+void pppPointApCon(void* param1, void* param2)
 {
-	// TODO
+    int* data = (int*)((int*)param2)[3];
+    int value = data[1];
+    *((char*)param1 + value + 0x81) = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80060c04
+ * PAL Size: 260b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppPointAp(void)
+void pppPointAp(void* param1, void* param2, void* param3)
 {
-	// TODO
+    // TODO - Complex function with matrix operations and object creation
 }


### PR DESCRIPTION
## Summary
Fixed critical function parameter mismatches for pppPointAp unit and implemented pppPointApCon with correct size/instruction output.

## Functions Improved
- **pppPointApCon**: 0% → size-matched (24 bytes, 6 instructions)

## Match Evidence
- **Before**: Both functions had void parameter signatures but assembly showed they take 2/3 parameters
- **After**: pppPointApCon generates correct 24-byte, 6-instruction output matching target size
- **Function signatures**: Fixed void() to proper (void*, void*) and (void*, void*, void*)

## Plausibility Rationale
This represents plausible original source because:
- Fixes the parameter mismatch issue specifically mentioned in AGENTS.md for ppp* functions
- Uses simple pointer arithmetic and memory operations typical of game engine code
- Function logic directly matches the assembly pattern: load nested structure values, calculate offset, store zero byte
- Implementation follows established patterns seen in other ppp* functions in codebase

## Technical Details  
- **Key insight**: ppp* functions showing no Metrowerks mangled names actually do take parameters (runbook warning confirmed)
- **pppPointApCon logic**: Loads value from param2[3][1], stores 0 at param1 + value + 0x81
- **Assembly match**: Generated 6 instructions with correct load/store pattern
- **pppPointAp**: Signature fixed but function body left as TODO (complex 260-byte function needs more analysis)

This fixes a fundamental blocking issue that prevented any progress on this unit.