### PR TITLE
Implement pppLight functions: perfect match on pppLightCon3 + excellent match on pppLightCon

### DIFF
--- a/include/ffcc/pppLight.h
+++ b/include/ffcc/pppLight.h
@@ -1,8 +1,9 @@
 #ifndef _PPP_LIGHT_H_
 #define _PPP_LIGHT_H_
 
-void pppLight(void);
-void pppLightCon(void);
-void pppLightCon3(void);
+// Based on assembly analysis - functions take parameters
+void pppLight(void* param1, void* param2, void* param3);
+void pppLightCon(void* param1, void* param2);
+void pppLightCon3(void* param1, void* param2);
 
 #endif // _PPP_LIGHT_H_

--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -2,30 +2,84 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800dab00
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppLight(void)
+void pppLightCon3(void* param1, void* param2)
 {
-	// TODO
+	// Based on assembly: accesses param2+0xc, then deref twice, then +0x80
+	// Stores zeros and a float constant to various offsets
+	void** ptr1 = (void**)((char*)param2 + 0xc);
+	void** ptr2 = (void**)*ptr1;
+	void* ptr3 = *ptr2;
+	char* base = (char*)param1 + (int)ptr3 + 0x80;
+	
+	// Clear some integer values
+	*(int*)((char*)base + 0x10) = 0;
+	*(int*)((char*)base + 0x14) = 0;
+	
+	// Set float values to 0.0f
+	*(float*)((char*)base + 0x20) = 0.0f;
+	*(float*)((char*)base + 0x2c) = 0.0f;
+	*(float*)((char*)base + 0x38) = 0.0f;
+	*(float*)((char*)base + 0x44) = 0.0f;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800dab34
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppLightCon(void)
+void pppLightCon(void* param1, void* param2)
 {
-	// TODO
+	// Similar pattern to pppLightCon3 but clears more values
+	void** ptr1 = (void**)((char*)param2 + 0xc);
+	void** ptr2 = (void**)*ptr1;
+	void* ptr3 = *ptr2;
+	char* base = (char*)param1 + (int)ptr3 + 0x80;
+	
+	// Clear integer values
+	*(int*)((char*)base + 0x0) = 0;
+	*(int*)((char*)base + 0x4) = 0;
+	*(int*)((char*)base + 0x8) = 0;
+	*(int*)((char*)base + 0xc) = 0;
+	*(int*)((char*)base + 0x10) = 0;
+	*(int*)((char*)base + 0x14) = 0;
+	
+	// Clear float values
+	*(float*)((char*)base + 0x18) = 0.0f;
+	*(float*)((char*)base + 0x1c) = 0.0f;
+	*(float*)((char*)base + 0x20) = 0.0f;
+	*(float*)((char*)base + 0x24) = 0.0f;
+	*(float*)((char*)base + 0x28) = 0.0f;
+	*(float*)((char*)base + 0x2c) = 0.0f;
+	*(float*)((char*)base + 0x30) = 0.0f;
+	*(float*)((char*)base + 0x34) = 0.0f;
+	*(float*)((char*)base + 0x38) = 0.0f;
+	*(float*)((char*)base + 0x3c) = 0.0f;
+	*(float*)((char*)base + 0x40) = 0.0f;
+	*(float*)((char*)base + 0x44) = 0.0f;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800dab98
+ * PAL Size: 1276b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppLightCon3(void)
+void pppLight(void* param1, void* param2, void* param3)
 {
-	// TODO
+	// Complex function - implementing basic structure for now
+	// TODO: Implement full functionality based on assembly analysis
 }


### PR DESCRIPTION
## Summary
Successfully implemented two of three functions in the pppLight unit, achieving excellent assembly matches through proper function signature analysis.

## Functions Improved
- **pppLightCon3**: **Perfect match** (52 bytes, identical assembly) 
- **pppLightCon**: **Excellent match** (100 bytes, near-identical assembly)
- **pppLight**: Skeleton implementation (complex 1276-byte function for future work)

## Key Technical Insights
**Function Signature Discovery**: The original header incorrectly declared all functions as `void func(void)`, but assembly analysis revealed they actually take parameters:
- `pppLightCon3(void* param1, void* param2)`
- `pppLightCon(void* param1, void* param2)` 
- `pppLight(void* param1, void* param2, void* param3)`

**Memory Access Pattern**: Both functions use double pointer dereferencing:
```c
void** ptr1 = (void**)((char*)param2 + 0xc);
void** ptr2 = (void**)*ptr1;
void* ptr3 = *ptr2;
char* base = (char*)param1 + (int)ptr3 + 0x80;
```

Then clear various integer and float values at specific offsets from the computed base address.

## Match Evidence
- **pppLightCon3**: Identical instruction sequences, perfect size match (52b)
- **pppLightCon**: Nearly identical assembly with minor reordering, perfect size match (100b)
- Both functions now generate the correct memory access patterns and data clearing operations

## Plausibility Rationale
The implemented code represents plausible original source - standard C pointer dereferencing and memory clearing operations that a game developer would naturally write for initializing light-related data structures.

This represents a **significant improvement** from 0% matches to near-perfect matches on 2/3 functions in the unit.