### PR TITLE
pppPObjPoint: Add C linkage and fix signedness (0% → 64.7%)

### DIFF
--- a/include/ffcc/pppPObjPoint.h
+++ b/include/ffcc/pppPObjPoint.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 
 struct PppObjData {
-    unsigned int id;          // 0x0
+    int id;          // 0x0
     unsigned int field_4;     // 0x4
     void* data;      // 0x8
     unsigned int objId;       // 0xc
@@ -14,7 +14,7 @@ struct PppPointData {
     void* field_0;   // 0x0
     void* matrix;    // 0x4 - points to transformation matrix
     unsigned int field_8;     // 0x8
-    unsigned int id;          // 0xc
+    int id;          // 0xc
     float field_10;    // 0x10
     float field_14;    // 0x14
     float field_18;    // 0x18
@@ -42,6 +42,14 @@ struct PppPointObj {
     void* vecPtr;    // 0x10
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* container);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _PPP_POBJPOINT_H_

--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -1,8 +1,8 @@
 #include "ffcc/pppPObjPoint.h"
 #include "dolphin/mtx.h"
 
-extern u32 lbl_8032ED70; // Global enable flag
-extern void* lbl_8032ED50; // Global data structure
+extern s32 lbl_8032ED70;
+extern void* lbl_8032ED50;
 
 /*
  * --INFO--
@@ -11,45 +11,34 @@ extern void* lbl_8032ED50; // Global data structure
  */
 void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* container)
 {
-    // Check global enable flag - return early if disabled
     if (lbl_8032ED70 != 0) {
         return;
     }
     
-    // Load container data and dereference
     void* containerData = container->ptrData;
-    u32 objId = objData->id;
-    u32 pointId = pointData->id;
+    s32 objId = objData->id;
+    s32 pointId = pointData->id;  
     void* dataPtr = *(void**)containerData;
     
-    // Compare IDs
     if (objId == pointId) {
-        // IDs match - set up vector pointer
         void* vectorPtr;
         
-        // Calculate base object pointer with 0x80 offset
-        PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + (u32)dataPtr + 0x80);
-        
-        // Check for special case (field_4 == 0xFFFF)  
         if ((objData->field_4 + 0x10000) == 0xFFFF) {
-            // Use static/default vector pointer
             extern u32 lbl_801EADC8;
             vectorPtr = (void*)&lbl_801EADC8;
         } else {
-            // Calculate dynamic vector pointer
             void* globalData = lbl_8032ED50;
             void* arrayPtr = *((void**)((u8*)globalData + 0xD4));
-            u32 index = objData->field_4 << 4; // multiply by 16
+            u32 index = objData->field_4 << 4;
             void* entry = (u8*)arrayPtr + index;
             void* basePtr = *((void**)((u8*)entry + 0x4));
             vectorPtr = (u8*)objData->data + (u32)basePtr + 0x80;
         }
         
-        // Store vector pointer
+        PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + (u32)dataPtr + 0x80);
         objPtr->vecPtr = vectorPtr;
     }
     
-    // Always copy vector data (happens regardless of ID match)
     PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + (u32)dataPtr + 0x80);
     f32* src = (f32*)objPtr->vecPtr;
     objPtr->x = src[0];


### PR DESCRIPTION
## Summary
Fixed critical function signature and type issues in pppPObjPoint that prevented any meaningful matching.

## Functions improved
- **pppPObjPoint**: 0.0% → 64.7% match (148b target)

## Match evidence  
- Function name now matches target exactly (removed C++ mangling)
- Comparison instructions now generate correct assembly (cmpw vs cmplw)
- Size reduced from 144b to 140b (target 148b, still 8b gap)

## Plausibility rationale
The changes represent plausible original source improvements:

1. **C linkage**: The ppp* functions likely used C linkage as suggested in AGENTS.md, explaining why target has no mangled name
2. **Signed comparisons**: ID fields should be signed integers to match the target's cmpw instruction rather than cmplw  
3. **Type consistency**: Updated struct definitions to use int instead of unsigned int for ID fields, matching ABI expectations

These are fundamental corrections a developer would make when interfacing C code with assembly expectations, not compiler-coaxing tricks.

## Technical details
- Added extern "C" wrapper in header to prevent C++ name mangling
- Changed lbl_8032ED70 from u32 to s32 to generate cmpwi instead of cmplwi
- Updated PppObjData.id and PppPointData.id from unsigned int to int for signed comparisons
- All changes maintain logical program behavior while improving assembly alignment