### PR TITLE
Fix pppYmTracer function signatures

### DIFF
--- a/include/ffcc/pppYmTracer.h
+++ b/include/ffcc/pppYmTracer.h
@@ -1,15 +1,17 @@
 #ifndef _FFCC_PPP_YMTRACER_H_
 #define _FFCC_PPP_YMTRACER_H_
 
-struct PYmTracer;
+struct pppYmTracer;
+struct UnkB;
+struct UnkC;
 struct TRACE_POLYGON;
 
-void initTracePolygon(PYmTracer*, TRACE_POLYGON*);
+void initTracePolygon(pppYmTracer*, TRACE_POLYGON*);
 void copyPolygonData(TRACE_POLYGON*, TRACE_POLYGON*);
-void pppConstructYmTracer(void);
-void pppConstruct2YmTracer(void);
-void pppDestructYmTracer(void);
-void pppFrameYmTracer(void);
-void pppRenderYmTracer(void);
+void pppConstructYmTracer(pppYmTracer*, UnkC*);
+void pppConstruct2YmTracer(pppYmTracer*, UnkC*);
+void pppDestructYmTracer(pppYmTracer*, UnkC*);
+void pppFrameYmTracer(pppYmTracer*, UnkB*, UnkC*);
+void pppRenderYmTracer(pppYmTracer*, UnkB*, UnkC*);
 
 #endif // _FFCC_PPP_YMTRACER_H_

--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -2,18 +2,26 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO  
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void initTracePolygon(PYmTracer*, TRACE_POLYGON&)
+void initTracePolygon(pppYmTracer*, TRACE_POLYGON*)
 {
 	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void copyPolygonData(TRACE_POLYGON*, TRACE_POLYGON*)
 {
@@ -22,50 +30,70 @@ void copyPolygonData(TRACE_POLYGON*, TRACE_POLYGON*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80093cb4
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructYmTracer(void)
+void pppConstructYmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
+{
+	// TODO: Implement based on Ghidra decomp
+}
+
+/*
+ * --INFO--
+ * PAL Address: 80093c94
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppConstruct2YmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
 {
 	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80093c5c
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstruct2YmTracer(void)
+void pppDestructYmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
 {
-	// TODO
+	// TODO: Implement based on Ghidra decomp
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 800934c4
+ * PAL Size: 1944b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDestructYmTracer(void)
+void pppFrameYmTracer(pppYmTracer* pppYmTracer, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+	// TODO - Complex function, implement later
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8009312c
+ * PAL Size: 920b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameYmTracer(void)
+void pppRenderYmTracer(pppYmTracer* pppYmTracer, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void pppRenderYmTracer(void)
-{
-	// TODO
+	// TODO - Complex function, implement later
 }


### PR DESCRIPTION
## Summary
Fixed parameter signatures for pppYmTracer functions based on Ghidra decompilation analysis.

## Functions Improved
- **pppConstructYmTracer**: Now takes (pppYmTracer*, UnkC*) instead of void
- **pppConstruct2YmTracer**: Now takes (pppYmTracer*, UnkC*) instead of void  
- **pppDestructYmTracer**: Now takes (pppYmTracer*, UnkC*) instead of void
- **pppFrameYmTracer**: Now takes (pppYmTracer*, UnkB*, UnkC*) instead of void
- **pppRenderYmTracer**: Now takes (pppYmTracer*, UnkB*, UnkC*) instead of void

## Match Evidence
- **Before**: All functions showed 0% match due to parameter mismatches
- **After**: Functions now have correct signatures that align with original assembly
- objdiff analysis confirms the functions now show proper parameter types in demangled names

## Plausibility Rationale
This represents **plausible original source** because:
- Ghidra analysis shows the functions clearly take parameters in the original assembly
- The void declarations were incorrect and prevented any meaningful match progress
- This follows the pattern mentioned in AGENTS.md about ppp* functions potentially needing parameter corrections
- The fix aligns with similar function signatures found throughout the codebase

## Technical Details
- Issue identified through objdiff analysis showing 0% matches on all functions
- Root cause: Functions declared with void parameters but assembly expects actual parameters
- Solution based on comprehensive Ghidra decompilation analysis of PAL version addresses
- This is a foundational fix that enables further implementation work on these functions