### PR TITLE
Fix pppMove functions with C linkage (100% match on pppMoveCon)

### DIFF
--- a/include/ffcc/pppMove.h
+++ b/include/ffcc/pppMove.h
@@ -18,7 +18,15 @@ struct PppMoveInput {
     f32 z;           // 0x10
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void pppMoveCon(void* basePtr, PppMoveData* data);
 void pppMove(void* basePtr, PppMoveInput* input, PppMoveData* data1, PppMoveData* data2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _PPP_MOVE_H_


### PR DESCRIPTION
## Summary
Fixed function signature issues in pppMove unit by applying C linkage to prevent C++ name mangling.

## Functions Improved
- **pppMoveCon**: 0% → **100%** (perfect match, 36b)
- **pppMove**: 0% → **63.8%** (significant improvement, 156b)

## Match Evidence
### Before (C++ mangled names):
- Target: `pppMoveCon`, `pppMove`
- Current: `pppMoveCon__FPvP11PppMoveData`, `pppMove__FPvP12PppMoveInputP11PppMoveDataP11PppMoveData`
- Result: 0% match due to name mismatch

### After (C linkage applied):
- Target: `pppMoveCon`, `pppMove`
- Current: `pppMoveCon`, `pppMove`
- **pppMoveCon**: Perfect 100% assembly match
- **pppMove**: 63.8% match with register allocation differences

## Plausibility Rationale
This change represents plausible original source because:

1. **Historical precedent**: The original FFCC codebase likely used C linkage for ppp* functions to maintain ABI compatibility with other components
2. **Function naming pattern**: The `ppp` prefix suggests these are C-style utility functions that would naturally use C linkage
3. **Perfect match result**: The 100% match on pppMoveCon indicates this approach aligns with the original compilation strategy
4. **Consistent pattern**: Previous successful PRs (#137 pppDrawShape2) used identical C linkage approach

## Technical Details
**Implementation**: Added `extern "C"` wrapper around function declarations in `include/ffcc/pppMove.h`

**Root cause**: C++ name mangling was preventing objdiff from matching function symbols, causing 0% matches despite functionally correct implementations.

**Key insight**: Function signature resolution is critical - even perfect assembly can show 0% match if function names don't align.

**Assembly analysis**: pppMoveCon now shows identical instruction sequences and register usage. pppMove shows substantial improvement with remaining differences primarily in register allocation patterns that may require additional source adjustments.