### PR TITLE
Implement __ctype_b function for MSL ctype library

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/ctype.c
+++ b/src/MSL_C/PPCEABI/bare/H/ctype.c
@@ -81,3 +81,11 @@ int toupper(int __c)
 {
 	return __c == -1 ? -1 : __upper_map[(unsigned char)__c];
 }
+
+int __ctype_b(int __c)
+{
+	if (__c == -1) {
+		return -1;
+	}
+	return (int)__ctype_map[(unsigned char)__c];
+}


### PR DESCRIPTION
## Summary
Implements the missing `__ctype_b` function in the MSL ctype library, providing raw character type flags lookup.

## Functions Improved  
- **fn_801b52a0** (36 bytes): 0% → 100% match
- Unit: main/MSL_C/PPCEABI/bare/H/ctype

## Match Evidence
- Perfect assembly alignment confirmed via objdiff-cli
- Identical instruction sequence including register usage and branching
- Correct symbol references to __ctype_map array

## Plausibility Rationale
The `__ctype_b` function is a standard internal function in MSL (Metrowerks Standard Library) that returns the raw ctype flags for character classification. This implementation:

- Follows the established MSL pattern of returning -1 for EOF input
- Uses direct __ctype_map array lookup for character flags  
- Matches the calling convention and behavior of other ctype functions
- Represents plausible original source that a game developer would use

## Technical Details
- Function takes int parameter, returns raw ctype flags as int
- Assembly shows standard PowerPC pattern: compare with -1, branch, load immediate vs. array lookup
- Uses `clrlwi r0, r3, 24` to mask input to 8 bits (unsigned char cast)
- Leverages existing __ctype_map symbol for consistent data access