### PR TITLE
Fix pppWDrawMatrixFrontLoop size and data types

### DIFF
--- a/src/pppWDrawMatrixFrontLoop.cpp
+++ b/src/pppWDrawMatrixFrontLoop.cpp
@@ -29,7 +29,7 @@ void pppWDrawMatrixFrontLoop(struct _pppPObject* param_1)
 	
 	PSMTXMultVec(ppvCameraMatrix0, &local_18, &local_18);
 	
-	*(s32*)((char*)param_1 + 0x4c) = (s32)local_18.x;
+	*(float*)((char*)param_1 + 0x4c) = local_18.x;
 	*(float*)((char*)param_1 + 0x5c) = local_18.y;
 	*(float*)((char*)param_1 + 0x6c) = local_18.z;
 }


### PR DESCRIPTION
## Summary
Fixed function size and data type issues in pppWDrawMatrixFrontLoop

## Changes Made
- **Data type fix**: Changed final  storage from integer cast to float
- **Size reduction**: Eliminated complex float-to-int conversion sequence
- **Stack frame correction**: Reduced from 0x30 to 0x20 bytes

## Technical Details
- **Before**: 148 bytes with  +  +  + 
- **After**: 136 bytes with simple  
- **Function size**: Now matches target exactly (136 bytes)
- **Stack frame**: Now matches target (0x20 bytes)

## Functions Improved
- : Fixed from 148→136 bytes, corrected data types

## Match Evidence  
- Size now matches target exactly (136 bytes vs previous 148 bytes)
- Stack frame size corrected (0x20 vs previous 0x30)
- Eliminated unnecessary float→int→storage conversion
- Assembly structure now closely matches expected pattern

## Plausibility Rationale
The change represents more plausible original source - storing a float value directly as a float rather than converting it to integer. The original code likely intended to store coordinate values as floats, not integers. The elimination of the complex conversion sequence suggests the compiler was generating unnecessary instructions due to the incorrect cast.