### PR TITLE
Implement fn_801b52a0 ctype function (98.33% match)

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/ctype.c
+++ b/src/MSL_C/PPCEABI/bare/H/ctype.c
@@ -81,3 +81,11 @@ int toupper(int __c)
 {
 	return __c == -1 ? -1 : __upper_map[(unsigned char)__c];
 }
+
+unsigned int fn_801b52a0(int c)
+{
+	if (c == -1) {
+		return -1;
+	}
+	return __ctype_map[(unsigned char)c];
+}


### PR DESCRIPTION
## Summary
Implemented the missing  function in the MSL_C ctype module.

## Functions Improved
- **fn_801b52a0**: 0% → 98.33% match (36 bytes)

## Technical Details
- Function returns raw character classification byte from 
- Properly handles EOF (-1) case by returning -1
- Uses unsigned char cast for safe array indexing
- Assembly matches target almost perfectly except for symbol name differences

## Implementation Approach
The function serves as a helper to access the  table directly:


## Match Evidence
- objdiff shows 98.33% match with perfect control flow
- Only remaining differences are symbol naming ( vs )
- Function size and behavior match exactly

## Plausibility Rationale
This implementation represents plausible original source - a simple, clean helper function that provides direct access to character classification data. The pattern matches other MSL_C ctype functions and is consistent with library design.