### PR TITLE
card/CARDDir: Complete unit match (33.33% -> 100%)

### DIFF
--- a/src/card/CARDDir.c
+++ b/src/card/CARDDir.c
@@ -3,21 +3,25 @@
 #include "dolphin/card/__card.h"
 
 // prototypes
-static void WriteCallback(s32 chan, s32 result);
-static void EraseCallback(s32 chan, s32 result);
+static void WriteCallback2(s32 chan, s32 result);
+static void EraseCallback2(s32 chan, s32 result);
 
 CARDDir* __CARDGetDirBlock(CARDControl* card) {
     ASSERTLINE(54, card->currentDir);
     return card->currentDir;
 }
 
-static void WriteCallback(s32 chan, s32 result) {
-    CARDControl* card = &__CARDBlock[chan];
+static void WriteCallback2(s32 chan, s32 result) {
+    CARDControl* card;
     CARDCallback callback;
 
+    card = &__CARDBlock[chan];
     if (result >= 0) {
-        CARDDir* dir0 = (CARDDir*)((u8*)card->workArea + 0x2000);
-        CARDDir* dir1 = (CARDDir*)((u8*)card->workArea + 0x4000);
+        CARDDir* dir0;
+        CARDDir* dir1;
+        
+        dir0 = (CARDDir*)((u8*)card->workArea + 0x2000);
+        dir1 = (CARDDir*)((u8*)card->workArea + 0x4000);
 
         ASSERTLINE(79, card->currentDir);
 
@@ -31,8 +35,9 @@ static void WriteCallback(s32 chan, s32 result) {
         }
     }
 
-    if (!card->apiCallback)
+    if (!card->apiCallback) {
         __CARDPutControlBlock(card, result);
+    }
 
     callback = card->eraseCallback;
     if (callback) {
@@ -41,22 +46,25 @@ static void WriteCallback(s32 chan, s32 result) {
     }
 }
 
-static void EraseCallback(s32 chan, s32 result) {
-    CARDControl* card = &__CARDBlock[chan];
+static void EraseCallback2(s32 chan, s32 result) {
+    CARDControl* card;
     CARDCallback callback;
     CARDDir* dir;
     u32 addr;
 
+    card = &__CARDBlock[chan];
     if (result >= 0) {
         dir = __CARDGetDirBlock(card);
         addr = ((u32)dir - (u32)card->workArea) / 0x2000 * card->sectorSize;
-        result = __CARDWrite(chan, addr, 0x2000, dir, WriteCallback);
-        if (result >= 0)
+        result = __CARDWrite(chan, addr, 0x2000, dir, WriteCallback2);
+        if (result >= 0) {
             return;
+        }
     }
 
-    if (!card->apiCallback)
+    if (!card->apiCallback) {
         __CARDPutControlBlock(card, result);
+    }
 
     callback = card->eraseCallback;
     if (callback) {
@@ -85,5 +93,5 @@ s32 __CARDUpdateDir(s32 chan, CARDCallback callback) {
 
     card->eraseCallback = callback;
     addr = ((u32)dir - (u32)card->workArea) / 0x2000 * card->sectorSize;
-    return __CARDEraseSector(chan, addr, EraseCallback);
+    return __CARDEraseSector(chan, addr, EraseCallback2);
 }


### PR DESCRIPTION
## Summary

Fixes the callback function names and variable declaration patterns in CARDDir.c to achieve 100% unit match.

## Functions Improved

**WriteCallback2** (208b at 0x8006EE14): 0% -> 100% match
**EraseCallback2** (200b at 0x8006EF24): 0% -> 100% match  

## Changes Made

1. **Function naming**: Renamed `WriteCallback` -> `WriteCallback2` and `EraseCallback` -> `EraseCallback2` to match expected symbol names
2. **Variable declarations**: Separated variable declarations to match original source patterns:
   - `CARDControl* card = &__CARDBlock[chan];` -> separate declaration and assignment
   - Moved pointer declarations to separate lines where appropriate
3. **Code structure**: Minor adjustments to match original source style (braces, return statements)

## Match Evidence  

- **Before**: 33.33% unit match (2/4 functions)
- **After**: 100% unit match (4/4 functions)  
- **Total improvement**: 66.7% gap eliminated
- **Code bytes**: 204/612 -> 612/612 (100% code match)

## Plausibility Rationale

The changes represent plausible original source patterns:
- Function naming with "2" suffix suggests versioned callback implementations, common in GameCube SDK
- Separate variable declarations match typical Metrowerks C coding patterns
- All structural changes follow established patterns found elsewhere in the FFCC codebase

## Technical Details

Key insight: The original symbols expected "WriteCallback2" and "EraseCallback2" names, not "WriteCallback"/"EraseCallback". This suggests either:
- Multiple callback versions in the original codebase
- Build system configuration that appends version suffixes
- SDK version differences requiring specific naming conventions

The variable declaration changes suggest the original authors used more explicit declaration patterns rather than inline initialization, which is consistent with GameCube-era C programming practices.