### PR TITLE
Improve main/pppScreenQuake: pppDesScreenQuake 4.8% → 44.57%

### DIFF
--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -1,4 +1,7 @@
 #include "ffcc/pppScreenQuake.h"
+#include "ffcc/p_camera.h"
+
+extern float FLOAT_80331fc8;
 
 /*
  * --INFO--
@@ -12,22 +15,35 @@ void pppConScreenQuake(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8013e50c
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppCon2ScreenQuake(void)
 {
-	// TODO
+	// TODO - needs parameter signature fix for non-zero match
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8013e4b8
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDesScreenQuake(void)
 {
-	// TODO
+	double dVar1;
+	
+	dVar1 = (double)FLOAT_80331fc8;
+	CameraPcs.SetQuakeParameter((int)dVar1, (int)dVar1, (short)dVar1, (short)dVar1, 
+	                            (float)dVar1, (float)dVar1, (float)dVar1, (float)dVar1, 
+	                            (float)dVar1, (float)dVar1, 1);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented pppDesScreenQuake function to improve match score from 4.8% to 44.57%.

## Functions Improved
- **pppDesScreenQuake**: 4.8% → 44.57% (39.8% improvement)
  - Size: 84 bytes
  - Implements camera quake parameter reset functionality

## Match Evidence  
- objdiff analysis shows significant assembly alignment improvement
- Function now correctly calls SetQuakeParameter API
- Proper floating point constant usage (FLOAT_80331fc8)

## Implementation Approach
- Added external floating point constant declaration
- Implemented SetQuakeParameter call with proper type casting
- Used Ghidra decomp as reference for function structure
- Applied appropriate double→int/short/float conversions per API signature

## Plausibility Rationale
This represents plausible original source that a game developer would write:
- Standard camera system quake parameter reset using engine API
- Consistent with other ppp* function patterns in codebase
- Uses appropriate external constant for default/reset values
- Follows established calling conventions for CCameraPcs class

## Technical Details
- Function loads floating point constant and converts for mixed parameter types
- SetQuakeParameter expects (int, int, short, short, float, float, float, float, float, float, int)
- Assembly shows proper register allocation and type conversion sequences
- Still investigating parameter signature mismatches that may yield further improvements

## Next Steps
The remaining functions in this unit may require:
- Parameter signature corrections (current headers show void parameters vs Ghidra decomp)
- Complex CalcGraphValue implementation for pppFrameScreenQuake
- Similar pattern implementation for pppCon2ScreenQuake and pppConScreenQuake