### PR TITLE
pppVertexApMtx: Improve pppVertexApMtxCon match from 71.6% to 87.5%

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -7,13 +7,13 @@
  */
 void pppVertexApMtxCon(_pppPObject* obj, PVertexApMtx* vtx)
 {
-	// Initialize vertex matrix state to zero
-	int* vtx_base = (int*)((char*)vtx + 0xc);
-	int* data_base = (int*)*vtx_base;
-	int offset = (int)data_base + 0x80;
-	char* ptr = (char*)obj + offset;
-	*(short*)ptr = 0;
-	*(short*)(ptr + 2) = 0;
+	// Get base address from vtx offset 0xc
+	char* base = *(char**)((char*)vtx + 0xc);
+	// Calculate final address: obj + base + 0x80
+	char* target = (char*)obj + (int)base + 0x80;
+	// Zero out two shorts at the target location
+	*(short*)target = 0;
+	*(short*)(target + 2) = 0;
 }
 
 /*


### PR DESCRIPTION
**Summary**: Improved match score for pppVertexApMtxCon function through simplified pointer calculation logic.

**Functions improved**: 
- pppVertexApMtxCon: 71.6% → 87.5% (+15.9% improvement)

**Match evidence**:
- Before: 71.625% match with argument mismatches in pointer calculations  
- After: 87.5% match with only one remaining DIFF_DELETE instruction
- Objdiff analysis shows cleaner register allocation and fewer instruction differences

**Plausibility rationale**: 
The new implementation represents more plausible original source by:
- Using direct pointer dereferencing instead of multiple intermediate variables
- Following common C patterns for struct member access
- Eliminating unnecessary pointer arithmetic steps that a developer wouldn't naturally write

**Technical details**:
- Replaced multi-step pointer calculation with direct access to vtx data member
- Simplified offset calculation using direct cast instead of intermediate variables  
- Maintained identical functionality while achieving better compiler output alignment
- One DIFF_DELETE instruction remains, likely due to compiler optimization differences