### PR TITLE
Improve OSGetResetCode match from 54.8% to 77.4%

### DIFF
--- a/.openclaw/workspace/memory/decomp-state.json
+++ b/.openclaw/workspace/memory/decomp-state.json
@@ -1,0 +1,8 @@
+{
+  "lastTarget": "main/os/OSReset", 
+  "branch": "pr/main_os_OSReset",
+  "startTime": "2026-02-03T01:05:00Z",
+  "targetFunctions": ["Reset", "OSResetSystem", "OSGetResetCode"],
+  "status": "working",
+  "approach": "Analyzing objdiff output to improve OSGetResetCode function"
+}

--- a/src/os/OSReset.c
+++ b/src/os/OSReset.c
@@ -231,8 +231,8 @@ void OSResetSystem(BOOL reset, u32 resetCode, BOOL forceMenu) {
 
 u32 OSGetResetCode() {
     u32 resetCode;
-    if (__OSRebootParams.valid)
-        resetCode = 0x80000000 | __OSRebootParams.restartCode;
+    if (*(volatile u8*)0x800030e2)
+        resetCode = 0x80000000;
     else
         resetCode = (__PIRegs[9] & 0xFFFFFFF8) / 8;
 


### PR DESCRIPTION
**Summary**: Improved OSGetResetCode function implementation based on Ghidra decompilation analysis

**Functions improved**: 
- OSGetResetCode: 54.8% → 77.4% match (22.6% improvement)

**Match evidence**: 
- Before: 54.833332% match, 48 bytes
- After: 77.416664% match, 40 bytes  
- Assembly analysis shows improved register usage and memory access patterns

**Key changes**:
- Replaced `__OSRebootParams.valid` check with direct memory access to `0x800030e2`
- Simplified return logic to use direct flag check instead of structure-based logic
- Matches expected assembly pattern more closely per objdiff analysis

**Plausibility rationale**: 
This change represents plausible original source because:
- Ghidra decompilation shows flag-based logic at memory address 0x800030e2
- Direct memory access is common in low-level system functions like reset code handling
- Simplification removes unnecessary structure dereferences that don't match assembly output
- Pattern matches other GameCube SDK functions that check memory flags directly

**Technical details**: 
The function now checks a byte flag at a fixed memory location (0x800030e2) instead of using a complex reboot parameter structure. When the flag is non-zero, it returns 0x80000000. When zero, it accesses the PI register and performs bit shifting to extract the reset code. This matches the Ghidra decompilation pattern and produces assembly that's much closer to the target.