### PR TITLE
maplight: Implement GetLightHolder function (5.3% -> 100% match)

### DIFF
--- a/include/ffcc/maplight.h
+++ b/include/ffcc/maplight.h
@@ -1,13 +1,17 @@
 #ifndef _FFCC_MAPLIGHTHOLDER_H_
 #define _FFCC_MAPLIGHTHOLDER_H_
 
-struct _GXColor;
-struct Vec;
+#include <dolphin/gx/GXStruct.h>
+#include <dolphin/mtx.h>
 
 class CMapLightHolder
 {
 public:
     void GetLightHolder(_GXColor*, Vec*);
+
+private:
+    _GXColor mColor;
+    Vec mVec;
 };
 
 #endif // _FFCC_MAPLIGHTHOLDER_H_

--- a/src/maplight.cpp
+++ b/src/maplight.cpp
@@ -2,10 +2,19 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004b1d0
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapLightHolder::GetLightHolder(_GXColor*, Vec*)
+void CMapLightHolder::GetLightHolder(_GXColor* color, Vec* vec)
 {
-	// TODO
+    if (color != nullptr) {
+        *color = mColor;
+    }
+    if (vec != nullptr) {
+        *vec = mVec;
+    }
 }


### PR DESCRIPTION
## Summary
Implemented the  function to achieve perfect assembly matching.

## Functions Improved
- **GetLightHolder__15CMapLightHolderFP8_GXColorP3Vec**: 5.3% → 100.0% (94.7% improvement)
- Function size: 76 bytes
- PAL Address: 0x8004b1d0

## Match Evidence
- Objdiff analysis shows 100.0% match for both left (target) and right (compiled) assembly
- All 19 assembly instructions match perfectly
- Function performs proper null-pointer checks and member variable copying

## Technical Details
### Changes Made:
1. **Header file updates** ():
   - Added proper includes for  and   
   - Added private member variables:  and 
   - Removed forward declarations in favor of full type definitions

2. **Source implementation** ():
   - Implemented function with null-pointer checks for both parameters
   - Simple member variable assignment:  and 
   - Added PAL address and size documentation

### Plausibility Rationale
This implementation represents **plausible original source** because:
- Uses clean, idiomatic C++ member variable access
- Employs standard null-pointer safety checks consistent with game code patterns
- Simple assignment operations match the function's role as a data accessor
- Member layout (_GXColor followed by Vec) aligns with the assembly's memory access pattern
- No compiler coaxing or artificial constructs - just straightforward getter functionality

### Implementation Approach
Based on Ghidra decompilation analysis, the function copies:
1. 4 bytes (RGBA color components) from  to the  parameter if non-null
2. 3 floats (Vec components) from  offset to the  parameter if non-null

The member variable layout naturally produces this memory access pattern.