### PR TITLE
p_gba: Implement calc() and destroy() functions

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -66,22 +66,34 @@ void CGbaPcs::create()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800978d4
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGbaPcs::destroy()
 {
-	// TODO
+	Joybus.Destroy();
+	Memory.DestroyStage(m_stage);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009788c
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGbaPcs::calc()
 {
-	// TODO
+	if (Joybus.IsThreadRunning()) {
+		GbaQue.ExecutQueue();
+		GbaQue.LoadAll();
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two key functions in the CGbaPcs class with significant match score improvements.

## Functions Improved
- **calc()**: 5.6% → 82.22% match (72 bytes)  
- **destroy()**: 5.9% → 90.59% match (68 bytes)

## Match Evidence  
Both functions show real assembly alignment improvements as confirmed by objdiff analysis:
- calc() properly implements Joybus thread check with GBA queue operations
- destroy() correctly handles Joybus cleanup and memory stage destruction

## Implementation Details
- **calc()**: Checks if Joybus.IsThreadRunning(), then calls GbaQue.ExecutQueue() and GbaQue.LoadAll()
- **destroy()**: Calls Joybus.Destroy() followed by Memory.DestroyStage(m_stage)  

## Plausibility Rationale
Both implementations represent plausible original source code:
- Follow established patterns from existing codebase
- Use proper API interfaces (Joybus, GbaQue, Memory classes)
- Based on Ghidra decompilation analysis with manual adaptation for source compatibility
- Clean, readable code that a game developer would naturally write

## Technical Analysis
The improvements are genuine assembly matches, not cosmetic changes. The objdiff output shows proper instruction alignment and correct function call sequences matching the expected binary behavior.