### PR TITLE
Implement CMcPcs::GetTable function - 100% match

### DIFF
--- a/include/ffcc/p_mc.h
+++ b/include/ffcc/p_mc.h
@@ -10,7 +10,7 @@ public:
 
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    void* GetTable(unsigned long);
 
     void create();
     void destroy();

--- a/src/p_mc.cpp
+++ b/src/p_mc.cpp
@@ -35,9 +35,12 @@ void CMcPcs::Quit()
  * Address:	TODO
  * Size:	TODO
  */
-void CMcPcs::GetTable(unsigned long)
+void* CMcPcs::GetTable(unsigned long index)
 {
-	// TODO
+	// Based on assembly: mulli r4, r4, 0x15c; add to base address
+	// 0x15c = 348 bytes per entry
+	extern char lbl_80211DAC[];
+	return lbl_80211DAC + (index * 0x15c);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented the GetTable function in the p_mc (memory card PCS) unit, achieving perfect 100% match.

## Functions Improved
- **GetTable__6CMcPcsFUl**: 20% → 100% match (20 bytes)

## Match Evidence  
**Before**: 20% match, incorrect implementation
**After**: 100% match with perfect assembly alignment

**Assembly analysis**: All 5 instructions match exactly:
1. `mulli r4, r4, 0x15c` - Multiply index by struct size (348 bytes)
2. `lis r3, lbl_80211DAC@ha` - Load high address of data table
3. `addi r0, r3, lbl_80211DAC@l` - Add low address offset
4. `add r3, r0, r4` - Calculate final pointer (base + offset)  
5. `blr` - Return

## Plausibility Rationale
The implementation represents **plausible original source** for array indexing:

**What changed:**
- Fixed return type from `void` to `void*` (function returns pointer)
- Implemented standard array indexing: `base_address + (index * element_size)`
- Used extern reference to global data table (`lbl_80211DAC`)
- Added proper parameter naming (`unsigned long index`)

**Why this is plausible:**
- Simple, idiomatic C array access pattern that game developers would naturally write
- 0x15c (348 bytes) suggests structured data, likely memory card slot information
- External data table reference is standard for game configuration data
- Function name suggests lookup table functionality (GetTable)

## Technical Details
- **Unit improvement**: Text section match 5.0% → 8.33% 
- **Pattern**: Array indexing with fixed-size elements (348 bytes each)
- **Global reference**: `lbl_80211DAC` appears to be memory card data table
- **Compiler behavior**: Metrowerks generates optimal multiply-add sequence