### PR TITLE
Implement C_QUATLerp function (0% -> 74.4%)

### DIFF
--- a/src/mtx/quat.c
+++ b/src/mtx/quat.c
@@ -182,6 +182,14 @@ void C_QUATMtx(Quaternion *r, const Mtx m)
     }
 }
 
+void C_QUATLerp(const Quaternion *p, const Quaternion *q, Quaternion *r, f32 t)
+{
+    r->x = p->x + (t * (q->x - p->x));
+    r->y = p->y + (t * (q->y - p->y));
+    r->z = p->z + (t * (q->z - p->z));
+    r->w = p->w + (t * (q->w - p->w));
+}
+
 void C_QUATSlerp(const Quaternion *p, const Quaternion *q, Quaternion *r, f32 t)
 {
     f32 ratioA, ratioB;


### PR DESCRIPTION
## Summary
Implemented the missing C_QUATLerp function for quaternion linear interpolation.

## Functions Improved
- **C_QUATLerp**: 0% → 74.4% match (100 bytes) - **New implementation**

## Match Evidence
Added complete function implementation from Ghidra decompilation. The function performs linear interpolation between two quaternions using the formula  for each component (x, y, z, w).

## Assembly Analysis
Objdiff shows the compiler optimized the linear interpolation into fused multiply-add instructions (), which is mathematically equivalent but more efficient than separate multiply and add operations.

## Plausibility Rationale
This is standard quaternion linear interpolation (LERP) - a fundamental operation in 3D graphics. The implementation follows the expected mathematical formula and uses appropriate GameCube floating-point types. The compiler optimization to fused multiply-add is standard for PowerPC architecture.