### PR TITLE
pppWDrawMatrixFront: Fix float casting to achieve 99.47% match

### DIFF
--- a/src/pppWDrawMatrixFront.cpp
+++ b/src/pppWDrawMatrixFront.cpp
@@ -29,7 +29,7 @@ void pppWDrawMatrixFront(struct _pppPObject* param_1)
 	
 	PSMTXMultVec(ppvCameraMatrix0, &local_18, &local_18);
 	
-	*(s32*)((char*)param_1 + 0x4c) = (s32)local_18.x;
+	*(float*)((char*)param_1 + 0x4c) = local_18.x;
 	*(float*)((char*)param_1 + 0x5c) = local_18.y;
 	*(float*)((char*)param_1 + 0x6c) = local_18.z;
 }


### PR DESCRIPTION
## Summary

Fixed type casting issue in pppWDrawMatrixFront function by changing s32 cast to float cast for the X coordinate storage.

## Functions Improved

- **pppWDrawMatrixFront**: 89.1% → 99.47% match (+10.37%)

## Match Evidence

Assembly analysis via objdiff revealed that our code was generating float-to-int conversion instructions (fctiwz, stfd, lwz, stw sequence) while the original code performs a direct float store (stfs). This indicated a type mismatch.

**Before**: `*(s32*)((char*)param_1 + 0x4c) = (s32)local_18.x;`
**After**: `*(float*)((char*)param_1 + 0x4c) = local_18.x;`

## Plausibility Rationale

The change represents plausible original source code. The struct field at offset 0x4c was likely intended to store a float value (transformed camera coordinates) rather than an integer. The original cast to s32 was an incorrect assumption about the data type, and the corrected float cast matches the expected assembly pattern.

## Technical Details

- Eliminated 3 unnecessary assembly instructions (fctiwz, stfd, lwz) 
- Reduced stack frame requirements
- Assembly now matches the expected direct float-store pattern
- No changes to function logic, only corrected data type assumption