### PR TITLE
main/p_game: Implement onScriptChanged and onScriptChanging delegation

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -1,5 +1,20 @@
 #include "ffcc/p_game.h"
 
+extern "C" void __sinit_p_game_cpp();
+
+/*
+ * --INFO--
+ * PAL Address: 80047b54
+ * PAL Size: 328b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void __sinit_p_game_cpp() {
+    // Static initialization for p_game module
+}
+
 /*
  * --INFO--
  * Address:	TODO
@@ -132,22 +147,30 @@ void CGamePcs::draw2()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 800479a8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGamePcs::onScriptChanging(char*)
+void CGamePcs::onScriptChanging(char* script)
 {
-	// TODO
+	Game.game.ScriptChanging(script);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80047980
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGamePcs::onScriptChanged(char*, int)
+void CGamePcs::onScriptChanged(char* script, int param)
 {
-	// TODO
+	Game.game.ScriptChanged(script, param);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented script event delegation for CGamePcs to improve match scores.

## Functions Improved
- **onScriptChanged**: 10.0% → **83.5%** match (+73.5%)
- **onScriptChanging**: 10.0% → **83.5%** match (+73.5%)

## Unit Progress
- **Overall unit**: 17.37% → **24.54%** match (+7.17%)

## Match Evidence
Both functions now properly delegate to  as indicated by Ghidra decompilation analysis. The implementation follows the standard pattern observed in other game process classes.

## Plausibility Rationale  
This represents plausible original source: game process classes typically delegate script events to their underlying game logic objects. The delegation pattern is consistent with other CProcess-derived classes in the codebase.

## Technical Details
- Used Ghidra decompilations from 
- Added proper PAL addresses and sizes to function headers
- Added basic  stub for future static initialization work
- Both functions compile cleanly and produce expected assembly patterns