### PR TITLE
Improve main/pppVtMime: pppVtMimeDes 63.7% → 82.5% (+18.8%)

### DIFF
--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -76,7 +76,7 @@ void pppDrawVtMime(void* param1, void* param2, void* param3)
 	float* vert1Pos = (float*)((char*)vert1Data + 0x2C);
 	float* vert2Pos = (float*)((char*)vert2Data + 0x2C);
 	
-	short vertCount = *(short*)vert1Data;
+	short vertCount = *(signed short*)vert1Data;
 	
 	// Check if memory needs allocation
 	void** memPtr = (void**)((char*)target + 0xC);
@@ -184,17 +184,17 @@ void pppVtMimeCon2(void* param1, void* param2, void* param3)
  */
 void pppVtMimeDes(void* param1, void* param2)
 {
-	// Get data structure from param2 and param1
+	// Get data structure from param2
 	void** dataPtr = (void**)((char*)param2 + 0xC);
 	void* data = *dataPtr;
 	void* dataBase = *(void**)data;
 	
-	// Calculate offset and get target structure  
-	char* target = (char*)param1 + (int)dataBase + 0x80;
-	void** targetPtr = (void**)((char*)target + 0xC);
+	// Calculate target offset and check memory allocation
+	int offset = (int)dataBase + 0x80 + 0xC; // Direct offset calculation
+	void** memPtr = (void**)((char*)param1 + offset);
 	
 	// Check if memory is allocated
-	if (*targetPtr != 0) {
+	if (*memPtr != 0) {
 		// Graphics wait and memory cleanup
 		extern void _WaitDrawDone__8CGraphicFPci(void*, const char*, int);
 		extern void* Graphic;
@@ -202,9 +202,9 @@ void pppVtMimeDes(void* param1, void* param2)
 		
 		// Heap usage reporting
 		extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
-		pppHeapUseRate__FPQ27CMemory6CStage(*targetPtr);
+		pppHeapUseRate__FPQ27CMemory6CStage(*memPtr);
 		
 		// Clear the pointer
-		*targetPtr = 0;
+		*memPtr = 0;
 	}
 }


### PR DESCRIPTION
## Summary
Significant improvement to **pppVtMimeDes** function through simplified memory pointer calculation and better register allocation.

## Functions Improved
- **pppVtMimeDes**: 63.7% → **82.5%** match (+18.8 percentage points)
- pppDrawVtMime: 70.7% → 70.7% match (unchanged)

## Match Evidence
**Before:** 63.7% match on pppVtMimeDes
**After:** 82.5% match on pppVtMimeDes

Verified with objdiff-cli showing substantial assembly improvement.

## Technical Details
**Key optimization:** Simplified target memory pointer calculation from multi-step pointer arithmetic to direct offset computation.

**Changes:**
1. **Combined offset calculation**: Changed from separate target calculation + offset access to single expression `(int)dataBase + 0x80 + 0xC`
2. **Direct memory access**: Eliminated intermediate `target` variable and calculate final pointer directly
3. **Improved variable naming**: Changed `targetPtr` to `memPtr` to better reflect usage
4. **Type precision**: Used `signed short` for vertex count to match expected assembly patterns

## Plausibility Rationale
The new implementation represents **more plausible original source** because:
- **Simpler arithmetic**: Original developers would likely use direct offset calculations rather than complex multi-step pointer manipulation
- **Better register allocation**: Simplified approach allows compiler to generate more efficient assembly
- **Cleaner variable usage**: Eliminates unnecessary intermediate variables
- **Performance-oriented**: Direct offset calculation is more efficient and typical of game development practices

The 18.8 percentage point improvement demonstrates that this approach better matches the original compilation patterns while maintaining readable, maintainable source code.