### PR TITLE
pppRandDownInt: Fix memory access pattern for 1.32% improvement

### DIFF
--- a/src/pppRandDownInt.cpp
+++ b/src/pppRandDownInt.cpp
@@ -25,7 +25,7 @@ void pppRandDownInt(int index, void* param2, void* param3)
     int* p2 = (int*)param2;
     int* p3 = (int*)param3;
     
-    // Check if p2[3] (fieldC) is null
+    // Check if p2[3] (fieldC) is null  
     if (p2[3] == 0) {
         // Generate random value
         float randValue = RandF__5CMathFv();
@@ -39,9 +39,9 @@ void pppRandDownInt(int index, void* param2, void* param3)
             randValue = randValue * 100.0f; // Constant from lbl_8032FF58
         }
         
-        // Store result
-        if (p3[3] != 0) { // If p3->fieldC exists
-            int* p3_data = (int*)p3[3]; // p3->fieldC
+        // Store result - access pattern from objdiff
+        if (p3[3] != 0) {
+            int* p3_data = (int*)p3[3];
             int offset = p3_data[0] + 0x80;
             float* target = (float*)((char*)&index + offset);
             *target = randValue;
@@ -53,22 +53,23 @@ void pppRandDownInt(int index, void* param2, void* param3)
             if (p3[3] != 0) {
                 int* p3_data = (int*)p3[3];
                 int offset = p3_data[0] + 0x80;
-                // Store result here too
             }
         }
     }
     
-    // Process p2[1] (field4)
+    // Process p2[1] (field4) - reorder based on objdiff analysis
     if (p2[1] != -1) {
-        int offset1 = p2[1] + 0x80;
-        int* target = (int*)((char*)&index + offset1);
-        
-        int multiplier = p2[2]; // field8
-        
-        // Get value from p3 structure
+        // Pre-calculate key values to match original order
+        int multiplier = p2[2];
         int* p3_data = (int*)p3[3];
-        int offset2 = p3_data[0] + 0x80;
-        float* source = (float*)((char*)p3_data + offset2);
+        int base_offset = p3_data[0] + 0x80;
+        
+        // Source calculation - this was a key difference in objdiff
+        float* source = (float*)((char*)&index + base_offset);
+        
+        // Target calculation
+        int target_offset = p2[1] + 0x80;
+        int* target = (int*)((char*)&index + target_offset);
         
         // Calculate result
         int result = (int)(*source * (float)multiplier) + *target;


### PR DESCRIPTION
## Summary
Fixed memory access pattern in final section of pppRandDownInt function.

## Functions Improved  
- pppRandDownInt: 62.04% → 63.36% (+1.32% improvement, 300 bytes)

## Technical Details
- Changed source calculation from p3_data-relative to index-relative addressing
- Pre-calculated key values to match original assembly order
- Better variable sequencing in final calculation section  

## Plausibility
The fix represents plausible original source using natural index-relative addressing for runtime structure member access. The original assembly shows source calculation relative to the first parameter.