### PR TITLE
main/quadobj: Improve isInner and onDraw function matching (+4.94%)

### DIFF
--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -37,24 +37,22 @@ void CGQuadObj::onDestroy()
 void CGQuadObj::onDraw()
 {
     if (m_vertexCount != 0 && (CFlatFlags & 0x10000) != 0) {
-        GXColor white = { 0xFF, 0xFF, 0xFF, 0xFF };
-        GXSetChanMatColor(GX_COLOR0A0, white);
+        u32 white = 0xFFFFFFFF;
+        GXSetChanMatColor(GX_COLOR0A0, *(GXColor*)&white);
         GXLoadPosMtxImm(gFlatPosMtx, GX_PNMTX0);
         GXBegin(GX_TRIANGLES, GX_VTXFMT0, (u32)m_vertexCount * 6);
 
         int i = 0;
-        QuadVertex* pVert = m_vertices;
         while (i < (int)m_vertexCount) {
             int next = (i + 1) % (int)m_vertexCount;
             
-            GXPosition3f32(pVert->x, m_yBase, pVert->z);
+            GXPosition3f32(m_vertices[i].x, m_yBase, m_vertices[i].z);
             GXPosition3f32(m_vertices[next].x, m_yBase, m_vertices[next].z);
-            GXPosition3f32(pVert->x, m_yBase + m_yHeight, pVert->z);
+            GXPosition3f32(m_vertices[i].x, m_yBase + m_yHeight, m_vertices[i].z);
             GXPosition3f32(m_vertices[next].x, m_yBase + m_yHeight, m_vertices[next].z);
-            GXPosition3f32(pVert->x, m_yBase, pVert->z);
-            GXPosition3f32(pVert->x, m_yBase + m_yHeight, pVert->z);
+            GXPosition3f32(m_vertices[i].x, m_yBase, m_vertices[i].z);
+            GXPosition3f32(m_vertices[i].x, m_yBase + m_yHeight, m_vertices[i].z);
             
-            pVert++;
             i++;
         }
     }
@@ -97,7 +95,7 @@ bool CGQuadObj::isInner(Vec* vec)
                     float cross = (m_vertices[next].x - x0) * (pz - z0) - 
                                   (m_vertices[next].z - z0) * (px - x0);
                     
-                    if (!(EPS <= cross)) {
+                    if (cross < EPS) {
                         break;
                     }
                     


### PR DESCRIPTION
## Summary
Improved match scores for two target functions in the main/quadobj unit through targeted assembly-level optimizations.

## Functions Improved
- **isInner__9CGQuadObjFP3Vec**: 88.59% → **91.56%** (+2.97%)
- **onDraw__9CGQuadObjFv**: 67.25% → **69.22%** (+1.97%)
- **Total improvement**: +4.94%

## Match Evidence
### isInner Function
- **Before**: 88.59% match
- **After**: 91.56% match
- **Key fix**: Changed cross-product comparison from `!(EPS <= cross)` to `cross < EPS`
- **Assembly impact**: Now generates correct `blt` instruction instead of `bne`

### onDraw Function  
- **Before**: 67.25% match
- **After**: 69.22% match
- **Key fixes**:
  - Replaced GXColor struct initialization with direct u32 cast
  - Simplified vertex loop using array indexing instead of pointer arithmetic

## Plausibility Rationale
- **Cross-product comparison**: The simplified condition `cross < EPS` is more natural than the double-negative `!(EPS <= cross)` and matches typical point-in-polygon algorithms
- **Color initialization**: Direct u32 cast for white color (0xFFFFFFFF) avoids constructor overhead and matches GameCube graphics patterns
- **Array indexing**: Using `m_vertices[i]` instead of pointer arithmetic is cleaner and more typical in game code

## Technical Details
The changes focused on matching assembly patterns identified through objdiff analysis:
- Eliminated unnecessary register usage in isInner comparison
- Streamlined color setup in onDraw to avoid function call overhead
- Both changes maintain original functionality while improving compiler output alignment