### PR TITLE
Add missing CGBaseObj::GetCID() and CPtrArray template for main/game unit

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -20,6 +20,22 @@ class CMapLightHolder;
 class CBound;
 class PPPIFPARAM;
 
+template <class T>
+class CPtrArray
+{
+public:
+    CPtrArray() : m_size(0) {}
+    
+    unsigned long GetSize() const { return m_size; }
+    
+    T& operator[](unsigned long index) { return m_data[index]; }
+    const T& operator[](unsigned long index) const { return m_data[index]; }
+
+private:
+    T* m_data;
+    unsigned long m_size;
+};
+
 class CGame : public CManager
 {
 public:

--- a/src/baseobj.cpp
+++ b/src/baseobj.cpp
@@ -75,6 +75,16 @@ void CGBaseObj::Destroy()
  * Address:	TODO
  * Size:	TODO
  */
+int CGBaseObj::GetCID()
+{
+	return 0;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
 void CGBaseObj::Create()
 {
 	onCreate();


### PR DESCRIPTION
## Summary
This PR implements missing template functions for the main/game unit that were causing compilation failures and missing function symbols.

## Functions Improved
- **GetCID__9CGBaseObjFv**: missing → present (8 bytes)
- **GetSize__29CPtrArray<P15CMapLightHolder>Fv**: missing → present (8 bytes) 
- **__vc__29CPtrArray<P15CMapLightHolder>FUl**: missing → present (32 bytes)

## Changes Made
1. **CGBaseObj::GetCID() implementation**
   - Added missing virtual function implementation in src/baseobj.cpp
   - Returns 0 as base case (consistent with CGObject::GetCID())

2. **CPtrArray template class**
   - Added template definition to include/ffcc/game.h
   - Implements GetSize() returning m_size member
   - Implements operator[](unsigned long) for element access
   - Basic template structure matching mangled function signatures

## Match Evidence
**Before**: Functions were completely missing from build (compilation errors)
**After**: Functions now compile and appear in build report with N/A% match status

This represents progress from build failure to successful compilation. The N/A% match indicates the functions are present but need further refinement for assembly-level matching.

## Plausibility Rationale
- **CGBaseObj::GetCID()**: Standard virtual function pattern, returns 0 as base implementation (matches other CG*Obj classes)
- **CPtrArray template**: Simple container template with standard STL-like interface (GetSize/operator[])
- **Function signatures**: Match exactly with mangled names from symbol analysis

## Technical Details
The missing functions were identified through target selection as 0% match 8-32 byte functions. These were template instantiations and virtual function implementations that needed to be added to achieve successful compilation.

## Next Steps
Functions are now successfully compiling. Future work should focus on refining the implementations to achieve better assembly-level match scores through objdiff analysis.