### PR TITLE
Improve pppColor functions with proper struct usage

### DIFF
--- a/src/pppColor.cpp
+++ b/src/pppColor.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/pppColor.h"
+#include "types.h"
 
 /*
  * --INFO--
@@ -9,33 +10,33 @@ void pppColor(void* param1, void* param2, void* param3)
 {
     void** ptr_struct2 = (void**)param2;
     void* work_ptr = ((void**)ptr_struct2[3])[0];
-    unsigned char* base_ptr = (unsigned char*)param1 + (unsigned int)work_ptr;
+    _pppColorWork* work = (_pppColorWork*)((char*)param1 + (u32)work_ptr);
     
     extern int lbl_8032ED70;
     if (lbl_8032ED70 != 0) {
-        unsigned int id1 = *(unsigned int*)param2;
-        unsigned int id2 = *(unsigned int*)((unsigned char*)param1 + 12);
+        u32 id1 = *(u32*)param2;
+        u32 id2 = *(u32*)((char*)param1 + 12);
         
         if (id1 == id2) {
-            short* src_colors = (short*)((unsigned char*)param2 + 8);
-            *(short*)(base_ptr + 0) += src_colors[0];
-            *(short*)(base_ptr + 2) += src_colors[1]; 
-            *(short*)(base_ptr + 4) += src_colors[2];
-            *(short*)(base_ptr + 6) += src_colors[3];
+            short* src_colors = (short*)((char*)param2 + 8);
+            work->r += src_colors[0];
+            work->g += src_colors[1]; 
+            work->b += src_colors[2];
+            work->a += src_colors[3];
         }
         
         extern float lbl_8032ED50;
         float* scale_data = &lbl_8032ED50;
         
-        *(unsigned char*)(base_ptr + 8) = (unsigned char)((float)(*(short*)(base_ptr + 0)) / 128.0f * scale_data[14]);
-        *(unsigned char*)(base_ptr + 9) = (unsigned char)((float)(*(short*)(base_ptr + 2)) / 128.0f * scale_data[15]);
-        *(unsigned char*)(base_ptr + 10) = (unsigned char)((float)(*(short*)(base_ptr + 4)) / 128.0f * scale_data[16]);
-        *(unsigned char*)(base_ptr + 11) = (unsigned char)((float)(*(short*)(base_ptr + 6)) / 128.0f * scale_data[17]);
+        work->result.r = (u8)((float)work->r / 128.0f * scale_data[14]);
+        work->result.g = (u8)((float)work->g / 128.0f * scale_data[15]);
+        work->result.b = (u8)((float)work->b / 128.0f * scale_data[16]);
+        work->result.a = (u8)((float)work->a / 128.0f * scale_data[17]);
     } else {
-        *(unsigned char*)(base_ptr + 8) = (unsigned char)(*(short*)(base_ptr + 0) >> 7);
-        *(unsigned char*)(base_ptr + 9) = (unsigned char)(*(short*)(base_ptr + 2) >> 7);
-        *(unsigned char*)(base_ptr + 10) = (unsigned char)(*(short*)(base_ptr + 4) >> 7);
-        *(unsigned char*)(base_ptr + 11) = (unsigned char)(*(short*)(base_ptr + 6) >> 7);
+        work->result.r = (u8)(work->r >> 7);
+        work->result.g = (u8)(work->g >> 7);
+        work->result.b = (u8)(work->b >> 7);
+        work->result.a = (u8)(work->a >> 7);
     }
 }
 
@@ -48,10 +49,10 @@ void pppColorCon(void* param1, void* param2)
 {
     void** ptr_struct = (void**)param2;
     void* work_ptr = ((void**)ptr_struct[3])[0];
-    unsigned char* base_ptr = (unsigned char*)param1 + (unsigned int)work_ptr;
+    _pppColorWork* work = (_pppColorWork*)((char*)param1 + (u32)work_ptr);
     
-    *(short*)(base_ptr + 0) = 0;
-    *(short*)(base_ptr + 2) = 0;
-    *(short*)(base_ptr + 4) = 0;
-    *(short*)(base_ptr + 6) = 0;
+    work->r = 0;
+    work->g = 0;
+    work->b = 0;
+    work->a = 0;
 }


### PR DESCRIPTION
## Summary
Convert raw pointer arithmetic in pppColor functions to use proper `_pppColorWork` struct types for better match rates and more plausible original source.

## Functions Improved  
- **pppColor**: 71.8% → TBD (objdiff technical issues)
- **pppColorCon**: 87.1% → TBD (objdiff technical issues)

## Changes Made
- **Struct usage**: Convert `*(short*)(base_ptr + offset)` to `work->field`
- **Type consistency**: Use `u32`/`u8` instead of `unsigned int`/`unsigned char`
- **Pointer arithmetic**: Change `unsigned char*` to `char*` for consistency
- **Code clarity**: Direct field access instead of manual offset calculations

## Technical Details
Used the existing `_pppColorWork` struct definition from the header:
```c
struct _pppColorWork {
    short r;  // 0x0
    short g;  // 0x2 
    short b;  // 0x4
    short a;  // 0x6
    _pppColor result; // 0x8
}; // Size 0xC
```

## Plausibility Rationale
Game developers would naturally:
- Use struct types instead of manual offset calculations
- Access fields directly rather than through pointer arithmetic
- Maintain type consistency across the codebase

These changes represent more plausible original source while maintaining the same logical operations.

**Note**: objdiff verification failed due to technical issues, but structural improvements are sound.