### PR TITLE
main/graphic: Implement RenderNoTexQuadGrouad and RenderTexQuadGrouad

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -414,22 +414,66 @@ void CGraphic::GetBackBufferRect2(void*, _GXTexObj*, int, int, int, int, int, _G
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 800178a4
+ * PAL Size: 220b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphic::RenderTexQuadGrouad(Vec&, Vec&, _GXColor, _GXColor, _GXColor, _GXColor)
+void CGraphic::RenderTexQuadGrouad(Vec& pos1, Vec& pos2, _GXColor color1, _GXColor color2, _GXColor color3, _GXColor color4)
 {
-	// TODO
+	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+	
+	// Vertex 1
+	GXPosition3f32(pos1.x, pos1.y, pos1.z);
+	GXColor1u32(*(u32*)&color1);
+	GXTexCoord2f32(0.0f, 0.0f);
+	
+	// Vertex 2
+	GXPosition3f32(pos2.x, pos1.y, pos1.z);
+	GXColor1u32(*(u32*)&color2);
+	GXTexCoord2f32(1.0f, 0.0f);
+	
+	// Vertex 3
+	GXPosition3f32(pos2.x, pos2.y, pos1.z);
+	GXColor1u32(*(u32*)&color4);
+	GXTexCoord2f32(1.0f, 1.0f);
+	
+	// Vertex 4
+	GXPosition3f32(pos1.x, pos2.y, pos1.z);
+	GXColor1u32(*(u32*)&color3);
+	GXTexCoord2f32(0.0f, 1.0f);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 800177f0
+ * PAL Size: 180b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphic::RenderNoTexQuadGrouad(Vec&, Vec&, _GXColor, _GXColor, _GXColor, _GXColor)
+void CGraphic::RenderNoTexQuadGrouad(Vec& pos1, Vec& pos2, _GXColor color1, _GXColor color2, _GXColor color3, _GXColor color4)
 {
-	// TODO
+	GXBegin(GX_QUADS, GX_VTXFMT6, 4);
+	
+	// Vertex 1
+	GXPosition3f32(pos1.x, pos1.y, pos1.z);
+	GXColor1u32(*(u32*)&color1);
+	
+	// Vertex 2  
+	GXPosition3f32(pos2.x, pos1.y, pos1.z);
+	GXColor1u32(*(u32*)&color2);
+	
+	// Vertex 3
+	GXPosition3f32(pos2.x, pos2.y, pos1.z);
+	GXColor1u32(*(u32*)&color4);
+	
+	// Vertex 4
+	GXPosition3f32(pos1.x, pos2.y, pos1.z);
+	GXColor1u32(*(u32*)&color3);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two quad rendering functions in the main/graphic unit based on Ghidra decompilation patterns.

## Functions Improved
- **RenderNoTexQuadGrouad** (180 bytes, PAL: 800177f0): Renders untextured quads
- **RenderTexQuadGrouad** (220 bytes, PAL: 800178a4): Renders textured quads

## Technical Details
### RenderNoTexQuadGrouad
- Uses  primitive with 
- Vertex data: 3D position + color per vertex  
- Four vertices forming a quad from pos1/pos2 rectangle

### RenderTexQuadGrouad  
- Uses  primitive with 
- Vertex data: 3D position + color + 2D texture coordinates
- Texture coords: (0,0) → (1,0) → (1,1) → (0,1) mapping

## Implementation Approach
- Based on Ghidra decompilation patterns showing GXBegin() calls and vertex data writes
- Used proper GameCube color format conversion with  for GXColor1u32
- Added PAL addresses and byte sizes from Ghidra decomp headers
- Both functions compile successfully with current build system

## Match Evidence
- Implementation follows Ghidra assembly patterns for vertex data ordering
- Proper GameCube GX graphics API usage for quad rendering
- Color parameter handling matches GameCube calling conventions
- Functions represent plausible original source for quad rendering utilities

These functions are foundational graphics primitives that would be used throughout the game for UI elements, effects, and geometry rendering.