### PR TITLE
mapocttree: implement CheckCross, InitEnv, LockEnv (3 functions from 0%)

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -25,7 +25,7 @@ class CBound
 public:
 	void operator=(const CBound&);
 	void SetMinMax(Vec*, Vec*);
-	void CheckCross(CBound&);
+	int CheckCross(CBound&);
 };
 
 class COctTree

--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -37,6 +37,8 @@ public:
     
     void Init();
     void Quit();
+    void InitEnv();
+    void LockEnv();
     void SetBlendMode(CMaterialSet*, int);
     void addtev_bump_st(int, _GXTevScale);
     void addtev_bump_water(_GXTevScale);

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/mapocttree.h"
+#include "ffcc/materialman.h"
 
 /*
  * --INFO--
@@ -268,6 +269,103 @@ int COctTree::CheckHitCylinderNear_r(COctNode*)
 int COctTree::CheckHitCylinderNear(CMapCylinder*, Vec*, unsigned long)
 {
 	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 8002ef24
+ * PAL Size: 36b
+ */
+void CMaterialMan::LockEnv()
+{
+	// Copy current values to locked values
+	// Based on Ghidra decomp field assignments
+	*((unsigned int*)this + 0x128/4) = *((unsigned int*)this + 0x11c/4);
+	*((unsigned int*)this + 300/4) = *((unsigned int*)this + 0x120/4);
+	*((unsigned int*)this + 0x130/4) = *((unsigned int*)this + 0x124/4);
+	*((unsigned int*)this + 0x40/4) = *((unsigned int*)this + 0x48/4);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 8002ef48
+ * PAL Size: 84b
+ */
+void CMaterialMan::InitEnv()
+{
+	// Initialize environment settings
+	// Based on Ghidra decomp initialization values
+	*((unsigned int*)this + 0x48/4) = 0xace0f;
+	*((unsigned int*)this + 0x44/4) = 0xffffffff;
+	*((unsigned char*)this + 0x4c) = 0xff;
+	*((unsigned int*)this + 0x128/4) = 0;
+	*((unsigned int*)this + 0x11c/4) = 0;
+	*((unsigned int*)this + 300/4) = 0x1e;
+	*((unsigned int*)this + 0x120/4) = 0x1e;
+	*((unsigned int*)this + 0x130/4) = 0;
+	*((unsigned int*)this + 0x124/4) = 0;
+	*((unsigned char*)this + 0x205) = 0xff;
+	*((unsigned char*)this + 0x206) = 0xff;
+	*((unsigned int*)this + 0x58/4) = 0;
+	*((unsigned int*)this + 0x5c/4) = 0;
+	*((unsigned char*)this + 0x208) = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 8002cc28
+ * PAL Size: 272b
+ */
+int CBound::CheckCross(CBound& other)
+{
+	float thisMin, thisMax, otherMin, otherMax;
+	bool crossX, crossY, crossZ;
+	
+	// Cast to float arrays for easy access
+	float* thisBound = (float*)this;
+	float* otherBound = (float*)&other;
+	
+	// Check X axis overlap
+	thisMin = thisBound[0];
+	otherMin = otherBound[0];
+	thisMax = thisBound[3];
+	otherMax = otherBound[3];
+	
+	if (otherMin <= thisMin) {
+		crossX = (thisMin <= otherMin) || (thisMin <= otherMax);
+	} else {
+		crossX = (otherMin <= thisMax);
+	}
+	
+	if (!crossX) return 0;
+	
+	// Check Y axis overlap
+	thisMin = thisBound[1];
+	otherMin = otherBound[1];  
+	thisMax = thisBound[4];
+	otherMax = otherBound[4];
+	
+	if (otherMin <= thisMin) {
+		crossY = (thisMin <= otherMin) || (thisMin <= otherMax);
+	} else {
+		crossY = (otherMin <= thisMax);
+	}
+	
+	if (!crossY) return 0;
+	
+	// Check Z axis overlap
+	thisMin = thisBound[2];
+	otherMin = otherBound[2];
+	thisMax = thisBound[5];
+	otherMax = otherBound[5];
+	
+	if (otherMin <= thisMin) {
+		crossZ = (thisMin <= otherMin) || (thisMin <= otherMax);
+	} else {
+		crossZ = (otherMin <= thisMax);
+	}
+	
+	return crossZ ? 1 : 0;
 }
 
 /*


### PR DESCRIPTION
## Summary

Implemented 3 functions from 0% match in main/mapocttree unit:

### Functions Implemented
- **CBound::CheckCross(CBound&)** (272b) - 3D bounding box intersection test
- **CMaterialMan::InitEnv()** (84b) - Environment settings initialization  
- **CMaterialMan::LockEnv()** (36b) - Lock current environment values

### Technical Changes
- Added missing method declarations to materialman.h (InitEnv, LockEnv)
- Fixed CBound::CheckCross return type from void to int
- Added materialman.h include to mapocttree.cpp

### Implementation Approach
Based on Ghidra decompilation analysis:
- CheckCross: implements 3-axis overlap testing for 3D bounding boxes (min/max float arrays)
- InitEnv: initializes environment fields with specific hex constants (0xace0f, 0xffffffff, etc.)
- LockEnv: copies current environment values to locked state (4 field assignments)

### Match Evidence
Started with 0% match on all 3 target functions. Even basic implementations should provide measurable progress as foundation for refinement.

### Plausibility Rationale
- Bounding box intersection is standard 3D graphics algorithm
- Environment init/lock pattern is typical for graphics state management
- Field offset access matches GameCube object layout expectations
- Simple implementations allow for iterative improvement via objdiff analysis