### PR TITLE
main/pppYmCheckBGHeight: Improve pppFrameYmCheckBGHeight from 40.4% to 46.2% (+5.8%)

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -14,6 +14,11 @@ extern float FLOAT_80330ed4;
 extern float FLOAT_80330ed8;
 extern float FLOAT_80330edc;
 
+extern "C" {
+    int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(struct CMapMng*, void*, void*, unsigned int);
+    void* pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
+}
+
 /*
  * --INFO--
  * PAL Address: 800d8c18
@@ -61,7 +66,7 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pp
 		dVar2 = (double)(pppMngStPtr->m_matrix).value[1][3];
 		local_60 = (pppMngStPtr->m_matrix).value[0][3];
 		local_58 = (pppMngStPtr->m_matrix).value[2][3];
-		local_5c = (float)(dVar2 + (double)param_2->m_unk0x4);
+		local_5c = (float)(dVar2 + (double)(float)param_2->m_unk0x4);
 		local_30 = FLOAT_80330ed8;
 		local_34 = FLOAT_80330ed8;
 		local_38 = FLOAT_80330ed8;
@@ -73,24 +78,23 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pp
 		local_40 = FLOAT_80330ed0;
 		local_3c = FLOAT_80330ed0;
 		
-		iVar1 = MapMng.CheckHitCylinderNear((CMapCylinder*)&local_60, (Vec*)&local_6c, 0xffffffff);
+		iVar1 = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &local_60, &local_6c, 0xffffffff);
 		if (iVar1 != 0) {
-			// TODO: Need proper CalcHitPosition call
-			if ((float)(dVar2 - (double)param_2->m_serializedDataOffsets) <= local_74) {
-				dVar2 = (double)(local_74 + param_2->m_unk0x8);
+			// TODO: CalcHitPosition call - need to find correct MapMng member
+			if ((float)(dVar2 - (double)(float)param_2->m_serializedDataOffsets) <= local_74) {
+				dVar2 = (double)(local_74 + (float)param_2->m_unk0x8);
 			}
 		}
-		pppMngSt->m_position.y = (float)dVar2;
-		// Additional position fields based on Ghidra offsets
-		*((float*)pppMngSt + 0x17) = (float)dVar2; // m_savedPosition.y at ~0x5c
-		*((float*)pppMngSt + 0x1B) = (float)dVar2; // m_paramVec0.y at ~0x6c  
-		*((float*)pppMngSt + 0x13) = (float)dVar2; // m_previousPosition.y at ~0x4c
+		(pppMngSt->m_position).y = (float)dVar2;
+		*((float*)pppMngSt + 0x17) = (float)dVar2; // m_savedPosition.y
+		*((float*)pppMngSt + 0x1B) = (float)dVar2; // m_paramVec0.y
+		*((float*)pppMngSt + 0x13) = (float)dVar2; // m_previousPosition.y
 		
-		(pppMngStPtr->m_matrix).value[0][3] = pppMngSt->m_position.x;
-		(pppMngStPtr->m_matrix).value[1][3] = pppMngSt->m_position.y;
-		(pppMngStPtr->m_matrix).value[2][3] = pppMngSt->m_position.z;
+		(pppMngStPtr->m_matrix).value[0][3] = (pppMngSt->m_position).x;
+		(pppMngStPtr->m_matrix).value[1][3] = (pppMngSt->m_position).y;
+		(pppMngStPtr->m_matrix).value[2][3] = (pppMngSt->m_position).z;
 		
-		pppSetFpMatrix(pppMngSt);
+		pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
 	}
 	return pppYmCheckBGHeight;
 }


### PR DESCRIPTION
## Summary
Improved pppFrameYmCheckBGHeight function match score from **40.4% to 46.2%** (+5.8% improvement) through proper function call implementation and type casting fixes.

## Functions Improved
- **pppFrameYmCheckBGHeight**: 40.4% → 46.2% (+5.8%) - 348-byte background height collision function

## Key Changes
- **Mangled function call**: Used proper  mangled name
- **Type casting fixes**: Added proper  casts for  and  
- **Return value assignment**: Corrected  return handling with proper cast
- **Assembly improvements**: Better register allocation and branching patterns

## Technical Details
The function handles background height collision detection for particles/effects:
1. Checks global state flag ()
2. Sets up cylinder collision parameters from matrix positions
3. Calls  for collision detection
4. Updates multiple position fields in the management structure
5. Synchronizes matrix values with position data

## Match Evidence  
**Before**: 40.4% match (baseline)
**After**: 46.2% match (+5.8% improvement)

Objdiff analysis shows real assembly alignment improvements in:
- Function call parameter setup
- Float constant loading
- Position field assignments
- Matrix synchronization

## Plausibility Rationale
Changes represent plausible original source patterns:
- Using proper Metrowerks mangled names for GameCube compilation
- Standard type casting for float arithmetic  
- Consistent with collision detection patterns elsewhere in codebase
- Maintains Ghidra decompilation structure while fixing compiler-specific details