### PR TITLE
Improve pppColMove unit: pppColMoveCon 97.5%→100%

### DIFF
--- a/src/pppColMove.cpp
+++ b/src/pppColMove.cpp
@@ -10,8 +10,7 @@ void pppColMoveCon(void* param1, void* param2)
     int** ptr_array = (int**)param2;
     int* temp_ptr = ptr_array[3];  // Load from offset 0xC
     temp_ptr = (int*)temp_ptr[1]; // Load from offset 0x4 
-    temp_ptr = (int*)((char*)temp_ptr + 0x80);
-    short* target = (short*)((char*)param1 + (int)temp_ptr);
+    short* target = (short*)((char*)param1 + (int)temp_ptr + 0x80);
     
     target[3] = 0;  // offset 0x6
     target[2] = 0;  // offset 0x4
@@ -28,7 +27,6 @@ void pppColMove(void* param1, void* param2, void* param3)
 {
     extern int lbl_8032ED70;
     
-    // Load pointers first (like target assembly)
     int** ptr_array = (int**)param3;
     int* ptr0 = ptr_array[3];  // Load from offset 0xC
     
@@ -39,7 +37,7 @@ void pppColMove(void* param1, void* param2, void* param3)
     int* ptr_src = (int*)ptr0[0]; // Load from offset 0x0
     int* ptr_dest = (int*)ptr0[1]; // Load from offset 0x4
     
-    // Calculate offsets separately to match expected assembly
+    // Calculate offsets
     ptr_src = (int*)((char*)ptr_src + 0x80);
     ptr_dest = (int*)((char*)ptr_dest + 0x80);
     short* src = (short*)((char*)param1 + (int)ptr_src);


### PR DESCRIPTION
Improved pppColMove unit by achieving 100% match on pppColMoveCon function through simplified pointer arithmetic.

Functions Improved:
- pppColMoveCon: 97.5% → 100% ✅

Technical Details:
- Combined pointer arithmetic operations for cleaner assembly output
- Eliminated intermediate pointer assignment to better match target
- Overall unit improvement: 74.4% → 74.8%

Match Evidence:
- objdiff shows perfect 100% match for pppColMoveCon (40 bytes)
- Unit-level improvement demonstrates real progress

Plausibility Rationale:
The simplified pointer arithmetic represents more natural C code - combining the cast and offset addition in one expression rather than using an intermediate pointer variable.