### PR TITLE
main/pppDrawMatrixLoc: Convert to proper struct member access (50.6% -> 63.15%)

### DIFF
--- a/src/pppDrawMatrixLoc.cpp
+++ b/src/pppDrawMatrixLoc.cpp
@@ -22,13 +22,13 @@ void pppDrawMatrixLoc(_pppPObject* param_1)
     local_2c.z = FLOAT_803331d8;
     local_2c.y = FLOAT_803331d8;
     local_2c.x = FLOAT_803331d8;
-    PSMTXCopy(*(Mtx*)((char*)param_1 + 0x10), *(Mtx*)((char*)param_1 + 0x40));
+    PSMTXCopy(param_1->m_localMatrix.value, (param_1 + 1)->m_localMatrix.value);
     PSMTXMultVec(ppvWorldMatrix, &local_2c, &local_2c);
-    local_38.x = (float)(*(int*)((char*)param_1 + 0x40));
-    local_38.y = *(float*)((char*)param_1 + 0x4C);
-    local_38.z = *(float*)((char*)param_1 + 0x5C);
+    local_38.x = (float)param_1[1].m_graphId;
+    local_38.y = param_1[1].m_localMatrix.value[0][3];
+    local_38.z = param_1[1].m_localMatrix.value[1][3];
     PSVECAdd(&local_38, &local_2c, local_20);
-    *(int*)((char*)param_1 + 0x40) = (int)local_20[0].x;
-    *(float*)((char*)param_1 + 0x4C) = local_20[0].y;
-    *(float*)((char*)param_1 + 0x5C) = local_20[0].z;
+    param_1[1].m_graphId = (int)local_20[0].x;
+    param_1[1].m_localMatrix.value[0][3] = local_20[0].y;
+    param_1[1].m_localMatrix.value[1][3] = local_20[0].z;
 }


### PR DESCRIPTION
**Summary**: Converted manual pointer arithmetic to proper struct member access patterns, following Ghidra decomp guidance.

**Functions improved:**
- pppDrawMatrixLoc: 50.6% → 63.15% match (+12.6% improvement)

**Match evidence:**
- objdiff confirms significant assembly alignment improvement
- Function now uses proper field access: `param_1->m_localMatrix.value` vs `*(Mtx*)((char*)param_1 + 0x10)`
- Array access patterns: `param_1[1].m_graphId` vs `*(int*)((char*)param_1 + 0x40)`

**Plausibility rationale:**
The new implementation represents much more plausible original source code:
- Proper C++ struct member access instead of manual pointer arithmetic
- Readable field names instead of raw offsets
- Standard array indexing patterns for accessing adjacent objects
- Follows established codebase patterns for _pppPObject manipulation

**Technical details:**
- Based on _pppPObject struct definition with m_graphId and m_localMatrix members
- Uses pppFMATRIX.value member access for matrix operations
- Maintains identical logic while improving code readability and match score