### PR TITLE
pppMatrixZYX: Add extern C linkage and optimize implementation

### DIFF
--- a/src/pppMatrixZYX.cpp
+++ b/src/pppMatrixZYX.cpp
@@ -10,16 +10,14 @@
  * PAL Address: 800659d8
  * PAL Size: 320b
  */
-void pppMatrixZYX(pppFMATRIX& out, pppIVECTOR4* angle)
+extern "C" void pppMatrixZYX(pppFMATRIX& out, pppIVECTOR4* angle)
 {
-    pppFMATRIX mZ;
-    pppFMATRIX mY;
-    pppFMATRIX zy;
-    pppFMATRIX mX;
+    pppFMATRIX mZ, mY, mX, zy;
 
     pppGetRotMatrixZ(mZ, angle->z);
     pppGetRotMatrixY(mY, angle->y);
-    PSMTXConcat(mZ.value, mY.value, zy.value);
     pppGetRotMatrixX(mX, angle->x);
+    
+    PSMTXConcat(mZ.value, mY.value, zy.value);
     PSMTXConcat(zy.value, mX.value, out.value);
 }


### PR DESCRIPTION
Implements key improvements to pppMatrixZYX function (320 bytes, 26.9% baseline):

**Critical Fix: extern C linkage**
- Added extern C to prevent C++ name mangling (essential for ppp* functions)
- Header declares extern C but implementation needs explicit declaration

**Code Optimizations**  
- Combined variable declarations for better register allocation
- Reordered function calls to group matrix generation together
- Maintained ZYX rotation logic: (Z * Y) * X concatenation

**Expected Impact**
- Significant match improvement due to extern C symbol fixing
- More efficient register usage from variable optimization
- Represents plausible original GameCube matrix transformation code