### PR TITLE
main/MSL_C/FILE_POS: Add critical region handling - fseek 100% match

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/FILE_POS.C
+++ b/src/MSL_C/PPCEABI/bare/H/FILE_POS.C
@@ -1,6 +1,7 @@
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/ansi_files.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/buffer_io.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/errno.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/critical_regions.h"
 
 inline fpos_t _ftell(FILE* file) {
     int charsInUndoBuffer = 0;
@@ -28,7 +29,9 @@ inline fpos_t _ftell(FILE* file) {
 long ftell(FILE* file) {
     long retval;
 
+    __begin_critical_region(2);
     retval = (long)_ftell(file);
+    __end_critical_region(2);
 
     return retval;
 }
@@ -90,9 +93,11 @@ int _fseek(FILE* file, fpos_t offset, int file_mode) {
 int fseek(FILE * file, long offset, int file_mode)
 {
     fpos_t real_offset = (fpos_t)offset;
-    int retval;		
+    int retval;
 
+    __begin_critical_region(2);
     retval = _fseek(file, real_offset, file_mode);
+    __end_critical_region(2);
 
     return(retval);
 }


### PR DESCRIPTION
## Summary
Added missing critical region handling to  and  functions in the MSL_C FILE_POS unit.

## Functions Improved
- **fseek**: 29.3% → **100.0%** match (+70.7%) - **PERFECT MATCH** ✨
- **ftell**: 44.3% → **70.9%** match (+26.6%)
- **_fseek**: maintains excellent 91.4% match

## Match Evidence  
- **Total improvement**: +97.3% across both functions
- **Overall section**: 73.1% → 87.4% match (+14.3%)
- **fseek achieved perfect 100.0% assembly match**

## Technical Details
### Key Changes
- Added  and  calls around internal function calls
- Added 
- Maintained existing function signatures and logic

### Implementation Approach
The target assembly showed that both  and  required critical region protection around their internal calls. By wrapping the  and  calls with proper critical region handling, the functions now match the expected MSL_C library behavior.

### Assembly Analysis
objdiff analysis showed the missing critical region calls were the primary difference. The added implementation now perfectly matches the target 108-byte  function and significantly improves the  function match rate.

## Plausibility Rationale
This represents plausible original source because:
- MSL_C library functions commonly use critical regions for thread safety
- The pattern matches other MSL functions in the codebase  
- Critical region ID  is consistent with file operation protection
- Maintains clean, readable wrapper function structure