### PR TITLE
main/goout: Initial SetGoOutMode implementation (+4.84% improvement)

### DIFF
--- a/include/ffcc/goout.h
+++ b/include/ffcc/goout.h
@@ -53,6 +53,24 @@ public:
     void EndMemCardProc();
 
 private:
+    char field_0x1;
+    char field_0x2;
+    char field_0x3;
+    int field_0x4;
+    int field_0x8;
+    int field_0xc;
+    int field_0x10;
+    int field_0x14;
+    char field_0x18;
+    char field_0x19;
+    char field_0x1a;
+    char field_0x1b;
+    char field_0x1c;
+    char field_0x1d;
+    char field_0x1e;
+    char field_0x1f;
+    int field_0x20;
+    char field_0x24[8];
     char field_0x2c;
     char field_0x2d;
     int field_0x30;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -223,12 +223,36 @@ void CGoOutMenu::Destroy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8016b8d4
+ * PAL Size: 2256b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO  
+ * JP Size: TODO
  */
-void CGoOutMenu::SetGoOutMode(unsigned char)
+void CGoOutMenu::SetGoOutMode(unsigned char mode)
 {
-	// TODO
+	field_0x18 = mode;
+	switch(field_0x18) {
+	case 1:
+		field_0x1c = 0;
+		// Menu state initialization
+		break;
+	case 3:
+		field_0x45 = 0;
+		field_0x34 = 4;
+		field_0x48 = 0;
+		field_0x3c = 0;
+		field_0x46 = 1;
+		break;
+	case 4:
+		field_0x45 = 0;
+		field_0x34 = 5;
+		field_0x48 = 0;
+		field_0x3c = 0;
+		field_0x46 = 1;
+		break;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Basic implementation of SetGoOutMode function in main/goout unit with switch case structure and field assignments.

## Functions Improved
- **SetGoOutMode__10CGoOutMenuFUc**: 0.2% → 5.04% match (+4.84% improvement, 2256b function)

## Technical Details
- Implemented switch statement framework for mode parameter handling
- Added cases 1, 3, and 4 with proper field assignments
- Extended CGoOutMenu class with missing fields (field_0x18, field_0x1c, etc.)
- Established compilation baseline with basic control flow matching

## Implementation Approach  
- Used Ghidra decompilation (8016b8d4_SetGoOutMode__10CGoOutMenuFUc.c) as structural reference
- Implemented simplified field access patterns to establish working baseline
- Focused on core switch logic before complex external function calls

## Match Evidence
objdiff shows real assembly improvements:
- Switch case comparisons matching target (cmpwi, beq/bge patterns)
- Field assignment instructions working (stb field_0x18, etc.)
- Basic control flow structure aligned with target
- Remaining work: implement additional cases and MenuPcs integration

## Plausibility Rationale
The implementation represents plausible original source - a straightforward switch statement handling different menu modes with field assignments. The structure follows typical game menu state management patterns without contrived compiler coaxing.

**Next Steps**: Continue implementing remaining switch cases (5, 6, 7, 0xc, etc.) and integrate MenuPcs external calls for full functionality.