### PR TITLE
pppWDrawMatrix: adjust memory offsets to match target assembly

### DIFF
--- a/src/pppWDrawMatrix.cpp
+++ b/src/pppWDrawMatrix.cpp
@@ -16,9 +16,9 @@ void pppWDrawMatrix(_pppPObject* pppPObject)
 {
     Vec* inVec;
     
-    PSMTXConcat(ppvCameraMatrix0, pppPObject->m_localMatrix.value, *(Mtx*)((char*)pppPObject + 0x34));
-    PSVECScale((Vec*)((char*)pppPObject + 0x34), (Vec*)((char*)pppPObject + 0x34), (pppMngStPtr->m_scale).x);
-    PSVECScale((Vec*)((char*)pppPObject + 0x38), (Vec*)((char*)pppPObject + 0x38), (pppMngStPtr->m_scale).y);
-    inVec = (Vec*)((char*)pppPObject + 0x3c);
+    PSMTXConcat(ppvCameraMatrix0, pppPObject->m_localMatrix.value, *(Mtx*)((char*)pppPObject + 0x40));
+    PSVECScale((Vec*)((char*)pppPObject + 0x40), (Vec*)((char*)pppPObject + 0x40), (pppMngStPtr->m_scale).x);
+    PSVECScale((Vec*)((char*)pppPObject + 0x50), (Vec*)((char*)pppPObject + 0x50), (pppMngStPtr->m_scale).y);
+    inVec = (Vec*)((char*)pppPObject + 0x60);
     PSVECScale(inVec, inVec, (pppMngStPtr->m_scale).z);
 }


### PR DESCRIPTION
## Summary
Adjusted memory access offsets in pppWDrawMatrix function to better align with target assembly patterns.

## Functions Improved
- **pppWDrawMatrix**: 46.8% → 46.866665% match (+0.066665%)

## Changes Made
- Updated vector access offsets from 0x34/0x38/0x3c to 0x40/0x50/0x60
- Maintained char* pointer arithmetic approach for memory access
- Preserved existing PSMTXConcat and PSVECScale function calls

## Technical Details
- **Target size**: 120 bytes  
- **Analysis method**: objdiff-cli diff analysis showing target expects different offset calculations
- **Assembly alignment**: 0x50 and 0x60 offsets now match perfectly in objdiff output
- **Plausibility**: Uses standard pointer arithmetic patterns common in GameCube code

## Match Evidence
The objdiff analysis shows improved alignment in memory access patterns:
- Target assembly expects `addi r5, r31, 0x40` (now matches)
- Target assembly expects `addi r3, r31, 0x50` (now matches) 
- Target assembly expects `addi r3, r31, 0x60` (now matches)

## Remaining Issues
- Register allocation differences (r30/r31 vs target patterns)
- Scale value access patterns in pppMngStPtr structure
- Minor instruction ordering differences

This represents incremental progress toward matching the original source implementation of the particle matrix drawing function.