### PR TITLE
TRK UART Functions: Remove inline keywords for 99.9%+ matches

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk_glue.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk_glue.c
@@ -104,15 +104,18 @@ DSError TRKInitializeIntDrivenUART(u32 param_0, u32 param_1, u32 param_2,
 
 void EnableEXI2Interrupts(void) { gDBCommTable.init_interrupts_func(); }
 
-inline int TRKPollUART(void) { return gDBCommTable.peek_func(); }
+int TRKPollUART(void) 
+{
+    return gDBCommTable.peek_func();
+}
 
-inline UARTError TRKReadUARTN(void* bytes, u32 length)
+UARTError TRKReadUARTN(void* bytes, u32 length)
 {
     int readErr = gDBCommTable.read_func(bytes, length);
     return readErr == 0 ? 0 : -1;
 }
 
-inline UARTError TRKWriteUARTN(const void* bytes, u32 length)
+UARTError TRKWriteUARTN(const void* bytes, u32 length)
 {
     int writeErr = gDBCommTable.write_func(bytes, length);
     return writeErr == 0 ? 0 : -1;


### PR DESCRIPTION
**Target Unit:** main/TRK_MINNOW_DOLPHIN/dolphin_trk_glue

**Summary:** Removed `inline` keywords from TRK UART functions to enable proper object code generation and achieve near-perfect assembly matches.

**Functions Improved:**
- **TRKPollUART**: 0.0% → **99.916664%** (+99.916664% improvement!)
- **TRKReadUARTN**: 0.0% → **99.933334%** (+99.933334% improvement!)
- **TRKWriteUARTN**: 0.0% → **99.933334%** (+99.933334% improvement!)

**Unit Progress:** 48.7% → **60.97661%** (+12.27661% improvement)

**Technical Details:**
The target functions were previously declared as `inline`, which prevented the compiler from generating proper object code for matching analysis. By removing the `inline` keywords, these functions now compile as regular functions and achieve near-perfect matches with the original assembly.

**Plausibility Rationale:**
This change represents plausible original source - the functions are simple wrappers around function pointers and don't need to be inlined. The original developers likely implemented these as regular functions rather than inline, as evidenced by the near-perfect assembly matches when compiled normally.

**Match Evidence:** 
- Build passes successfully with `ninja`
- All three target functions achieve 99.9%+ assembly matches
- Unit overall improvement of 12.27661%
- No functionality changes, just compilation approach