### PR TITLE
main/gx/GXInit: Code style and pattern improvements

### DIFF
--- a/src/gx/GXInit.c
+++ b/src/gx/GXInit.c
@@ -100,7 +100,7 @@ static void DisableWriteGatherPipe(void) {
     PPCMthid2(hid2);
 }
 
-static GXTexRegion*__GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapID id) {
+static GXTexRegion* __GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapID id) {
     GXTexFmt fmt;
     u8 mm;
 
@@ -108,22 +108,21 @@ static GXTexRegion*__GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapI
     mm = GXGetTexObjMipMap(t_obj);
     id = (GXTexMapID)(id % GX_MAX_TEXMAP);
 
-    switch (fmt) {
-    case GX_TF_RGBA8:
+    if (fmt == GX_TF_RGBA8) {
         if (mm) {
             return &__GXData->TexRegions2[id];
         }
         return &__GXData->TexRegions1[id];
-    case GX_TF_C4:
-    case GX_TF_C8:
-    case GX_TF_C14X2:
-        return &__GXData->TexRegions0[id];
-    default:
-        if (mm) {
-            return &__GXData->TexRegions1[id];
-        }
+    }
+    
+    if ((fmt == GX_TF_C4) || (fmt == GX_TF_C8) || (fmt == GX_TF_C14X2)) {
         return &__GXData->TexRegions0[id];
     }
+    
+    if (mm) {
+        return &__GXData->TexRegions1[id];
+    }
+    return &__GXData->TexRegions0[id];
 }
 
 static GXTlutRegion* __GXDefaultTlutRegionCallback(u32 idx) {
@@ -281,12 +280,12 @@ GXFifoObj* GXInit(void* base, u32 size) {
 
     __GXData->genMode = 0;
     SET_REG_FIELD(0, __GXData->genMode, 8, 24, 0);
-    __GXData->bpMask = 255;
+    __GXData->bpMask = 0xFF;
     SET_REG_FIELD(0, __GXData->bpMask, 8, 24, 0x0F);
     __GXData->lpSize = 0;
     SET_REG_FIELD(0, __GXData->lpSize, 8, 24, 0x22);
 
-    for (i = 0; i < 16; ++i) {
+    for (i = 0; i < 16; i++) {
         __GXData->tevc[i] = 0;
         __GXData->teva[i] = 0;
         __GXData->tref[i / 2] = 0;
@@ -300,7 +299,7 @@ GXFifoObj* GXInit(void* base, u32 size) {
     __GXData->iref = 0;
     SET_REG_FIELD(0, __GXData->iref, 8, 24, 0x27);
 
-    for (i = 0; i < 8; ++i) {
+    for (i = 0; i < 8; i++) {
         __GXData->suTs0[i] = 0;
         __GXData->suTs1[i] = 0;
         SET_REG_FIELD(1144, __GXData->suTs0[i], 8, 24, 0x30 + i * 2);
@@ -315,7 +314,7 @@ GXFifoObj* GXInit(void* base, u32 size) {
     SET_REG_FIELD(0, __GXData->peCtrl, 8, 24, 0x43);
     SET_REG_FIELD(0, __GXData->cpTex, 2, 7, 0);
 
-    __GXData->zScale = 1.6777216E7f;
+    __GXData->zScale = 16777216.0f;
     __GXData->zOffset = 0.0f;
     __GXData->dirtyState = 0;
     __GXData->dirtyVAT = FALSE;


### PR DESCRIPTION
## Summary
Code style and pattern improvements to main/gx/GXInit targeting better assembly match through plausible original source patterns.

## Changes Made
- **Function spacing**: Fixed spacing in `__GXDefaultTexRegionCallback` declaration
- **Hex consistency**: Changed `255` to `0xFF` for consistency with project hex notation
- **Loop increment style**: Changed `++i` to `i++` (potential assembly generation difference)
- **Floating-point constants**: Changed `1.6777216E7f` to `16777216.0f` (decimal vs scientific notation)
- **Control flow**: Converted switch statement to if-else chain in `__GXDefaultTexRegionCallback`

## Functions Targeted
- `__GXDefaultTexRegionCallback` (0.0% match, 124b) - signature/assembly pattern issues
- `GXInit` (42.4% match, 2192b) - medium match function with improvement potential
- `__GXInitGX` (90.4% match, 2244b) - very high match, likely build system related

## Match Evidence
- **Before/After**: No immediate match % improvement detected
- **Technical Quality**: All changes represent plausible original source patterns
- **Build Status**: ✅ Compiles successfully with ninja

## Plausibility Rationale
Each change targets patterns that game developers would naturally write:
- Consistent hex notation throughout codebase
- Standard loop increment patterns
- Decimal floating-point constants (more readable than scientific)
- if-else chains for conditional logic (common in GameCube SDK style)

## Technical Notes
- 0% match functions often indicate fundamental signature mismatches
- 90%+ match functions may require build flag changes rather than source modifications
- Medium match functions (40-60%) have best improvement potential through incremental changes

## Automation Session
- **Time**: 45-minute automation window
- **Branch**: Clean from main (0bdcb687)
- **Approach**: Systematic pattern improvements targeting assembly generation