### PR TITLE
main/MSL_C/PPCEABI/bare/H/misc_io: Implement clearerr function (0% → 100%)

### DIFF
--- a/include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/misc_io.h
+++ b/include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/misc_io.h
@@ -1,11 +1,14 @@
 #ifndef _MSL_COMMON_MISC_IO_H
 #define _MSL_COMMON_MISC_IO_H
 
+#include "ansi_files.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void __stdio_atexit(void);
+void clearerr(FILE* stream);
 
 #ifdef __cplusplus
 }

--- a/src/MSL_C/PPCEABI/bare/H/misc_io.c
+++ b/src/MSL_C/PPCEABI/bare/H/misc_io.c
@@ -4,3 +4,8 @@
 void __stdio_atexit(void) {
     __stdio_exit = __close_all;
 }
+
+void clearerr(FILE* stream) {
+    stream->file_state.eof = 0;
+    stream->file_state.error = 0;
+}


### PR DESCRIPTION
**Summary**: Implements the missing clearerr standard library function in misc_io unit.

**Functions Improved**:
- **clearerr**: 0% → **100%** match (16 bytes)
- **Unit completion**: 1/2 → **2/2** functions (100% total match)

**Match Evidence**:
- Build report shows 100% fuzzy match on clearerr function
- Complete unit now shows 100% overall match  
- All functions compile without errors

**Technical Implementation**:
- **Source**: Added clearerr implementation to `src/MSL_C/PPCEABI/bare/H/misc_io.c`
- **Header**: Added function declaration to `include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/misc_io.h`
- **Logic**: Clears `stream->file_state.eof` and `stream->file_state.error` flags per C standard
- **Integration**: Includes ansi_files.h for FILE structure definitions

**Plausibility Rationale**:
Standard C library clearerr function that clears error and end-of-file indicators for a FILE stream. Implementation follows standard semantics by setting the eof and error flags in the file_state structure to 0, which matches the expected behavior for GameCube MSL C library.