### PR TITLE
Refine pppMove data access and vector initialization

### DIFF
--- a/src/pppMove.cpp
+++ b/src/pppMove.cpp
@@ -1,13 +1,6 @@
 #include "ffcc/pppMove.h"
 
-extern u32 lbl_8032ED70;   // Global enable flag
-extern f32 lbl_8032FED8;   // Zero constant
-
-struct PppMoveObj {
-    f32 x;           // 0x0
-    f32 y;           // 0x4
-    f32 z;           // 0x8
-};
+extern u32 lbl_8032ED70;
 
 /*
  * --INFO--
@@ -15,21 +8,17 @@ struct PppMoveObj {
  * PAL Size: 36b
  * EN Address: TODO
  * EN Size: TODO
- * JP Address: TODO  
+ * JP Address: TODO
  * JP Size: TODO
  */
 void pppMoveCon(void* basePtr, PppMoveData* data)
 {
-    // Get object pointer from data structure
-    void* objPtr = data->ptrData;
-    u32 offset = *((u32*)((u8*)objPtr + 0x4));
-    PppMoveObj* moveObj = (PppMoveObj*)((u8*)basePtr + offset + 0x80);
-    
-    // Initialize to zero (store order: z, y, x to match assembly)
-    f32 zero = lbl_8032FED8;
-    moveObj->z = zero;
-    moveObj->y = zero;
-    moveObj->x = zero;
+    u32 dataOffset = *(u32*)((u8*)data->ptrData + 0x4);
+    f32* move = (f32*)((u8*)basePtr + dataOffset + 0x80);
+
+    move[2] = 0.0f;
+    move[1] = 0.0f;
+    move[0] = 0.0f;
 }
 
 /*
@@ -37,7 +26,7 @@ void pppMoveCon(void* basePtr, PppMoveData* data)
  * PAL Address: 0x80065b3c
  * PAL Size: 156b
  * EN Address: TODO
- * EN Size: TODO  
+ * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
@@ -46,25 +35,20 @@ void pppMove(void* basePtr, PppMoveInput* input, PppMoveData* data1, PppMoveData
     if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    // Get data structure pointers  
-    void* data2Ptr = data2->ptrData;
-    void* data1Ptr = data1->ptrData;
-    
+
     u32 inputId = *(u32*)input;
-    u32 baseId = *((u32*)((u8*)basePtr + 0xc));
-    
-    // Direct address calculation for data objects
-    f32* data2Obj = (f32*)((u8*)basePtr + *(u32*)data2Ptr + 0x80);
-    f32* data1Obj = (f32*)((u8*)basePtr + *(u32*)data1Ptr + 0x80);
-    
+    u32 baseId = *(u32*)((u8*)basePtr + 0xC);
+
+    f32* move1 = (f32*)((u8*)basePtr + *(u32*)data1->ptrData + 0x80);
+    f32* move2 = (f32*)((u8*)basePtr + *(u32*)data2->ptrData + 0x80);
+
     if (inputId == baseId) {
-        data2Obj[0] += input->x;
-        data2Obj[1] += input->y;
-        data2Obj[2] += input->z;
+        move2[0] += input->x;
+        move2[1] += input->y;
+        move2[2] += input->z;
     }
-    
-    data1Obj[0] += data2Obj[0];
-    data1Obj[1] += data2Obj[1];
-    data1Obj[2] += data2Obj[2];
+
+    move1[0] += move2[0];
+    move1[1] += move2[1];
+    move1[2] += move2[2];
 }


### PR DESCRIPTION
### Motivation
- Make `pppMoveCon` and `pppMove` look more like plausible original source by removing decompiler scaffolding and simplifying pointer math. 
- Align the code shape with other `ppp*` helpers to improve chances of better codegen/match scores. 
- Keep the change narrow and behavior-preserving so it is safe to evaluate with build/objdiff tooling. 

### Description
- Simplified `pppMoveCon` pointer math to compute the movement vector base with `u32 dataOffset = *(u32*)((u8*)data->ptrData + 0x4)` and `f32* move = (f32*)((u8*)basePtr + dataOffset + 0x80)`. 
- Replaced use of an external zero constant with explicit `0.0f` stores in the observed z/y/x order to match assembly store ordering. 
- Simplified `pppMove` local setup to compute `inputId`, `baseId`, and the two movement vectors `move1` and `move2` directly from `data1->ptrData` and `data2->ptrData`. 
- Preserved original behavior: conditional accumulation into the per-instance accumulator and then adding the accumulator into the destination vector (functions touched: `pppMoveCon` PAL 0x80065b18 and `pppMove` PAL 0x80065b3c). 

### Testing
- Ran `python3 configure.py --version GCCP01`, which completed successfully. 
- Ran `python3 tools/extract_symbols.py pppMove.o`, which completed successfully and provided symbol context. 
- Attempted `python3 tools/agent_select_target.py`, which failed because `build/GCCP01/report.json` is not present (requires a successful build). 
- Attempted `ninja` to build and validate, which failed due to a network download error when `tools/download_tool.py` tried to fetch `dtk` from GitHub (`URLError: Tunnel connection failed: 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984381f3a6083278b9a7f9def06ae0b)