### PR TITLE
Decompile RedDriver init and DMA execute

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1,6 +1,9 @@
 #include "ffcc/RedSound/RedDriver.h"
-#include "ffcc/RedSound/RedMemory.h" 
+#include "ffcc/RedSound/RedMemory.h"
 #include "ffcc/RedSound/RedEntry.h"
+#include "dolphin/ar.h"
+#include "dolphin/ax.h"
+#include "dolphin/os.h"
 
 // Global objects that need initialization
 extern CRedMemory DAT_8032f480;
@@ -21,12 +24,74 @@ extern "C" {
     int SearchMusicSequence__9CRedEntryFi(void*, int);
     void MusicStop__Fi(int);
     void MusicPlay__Fiii(int, int, int);
+    void AXSetCompressor(int);
+    void AXFXSetHooks(void (*)(unsigned long), void (*)(void*));
 }
 
 // Global data references from Ghidra
+extern int DAT_8032f3c4;
+extern int DAT_8032f3c0;
+extern int DAT_8032f3c8;
+extern int DAT_8032f408;
+extern int DAT_8032f400;
+extern int DAT_8032f414;
+extern int DAT_8032f404;
+extern int DAT_8032f410;
+extern int DAT_8032f40c;
+extern int DAT_8032f468;
+extern int DAT_8032f434;
+extern int DAT_8032f430;
+extern int DAT_8032f488;
+extern int DAT_8032f44c;
+extern int DAT_8032f448;
+extern int DAT_8032f47c;
+extern int DAT_8032f478;
+extern int DAT_8032f424;
+extern int DAT_8032f43c;
+extern int DAT_8032f3b8;
+extern int DAT_8032e12c;
+extern int DAT_8032f458;
+extern int DAT_8032daac;
 extern void* DAT_8032f3f0;
 extern void* DAT_8032f418;
 extern int DAT_8032f42c;
+extern void* DAT_8032f3cc;
+extern void* DAT_8032f3d0;
+extern void* DAT_8032f41c;
+extern void* DAT_8032f420;
+extern void* DAT_8032f3d4;
+extern void* DAT_8032f3d8;
+extern void* DAT_8032f3dc;
+extern void* DAT_8032f3f4;
+extern void* DAT_8032f3fc;
+extern unsigned int* DAT_8032f444;
+extern void* DAT_8032f450;
+extern void* DAT_8032f474;
+extern void** DAT_8032f428;
+extern void* DAT_8032f438;
+extern void* DAT_8032f3e0;
+extern void* DAT_8032f3e8;
+extern void* DAT_8032f3e4;
+extern void* DAT_8032f3ec;
+extern void* DAT_8032f464;
+extern void* DAT_8032f45c;
+extern void* DAT_8032f46c;
+extern void* DAT_8032f454;
+extern void* DAT_8032b860;
+extern void* DAT_8032c660;
+extern OSSemaphore DAT_8032ddd8;
+extern OSSemaphore DAT_8032daa0;
+extern OSSemaphore DAT_8032e120;
+extern OSSemaphore DAT_8032d778;
+extern OSThread DAT_8032dac0;
+extern OSThread DAT_8032d788;
+extern OSThread DAT_8032de08;
+extern OSThread DAT_8032d460;
+extern ARQRequest DAT_8032dde4;
+
+extern void ReverbAreaAlloc(unsigned long);
+extern void ReverbAreaFree(void*);
+extern void InitReverb();
 
 /*
  * --INFO--
@@ -499,12 +564,82 @@ void RedDmaSearchID(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801be2dc
+ * PAL Size: 496b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void _DmaExecute()
 {
-	// TODO
+    unsigned int uVar1;
+    int iVar2;
+    int iVar3;
+    int* piVar4;
+    int** ppiVar5;
+    int* piVar6;
+    int* piVar7;
+    int* piVar8;
+
+    do {
+        do {
+            if ((DAT_8032f3e0 == DAT_8032f3e8) && (DAT_8032f3e4 == DAT_8032f3ec)) {
+                DAT_8032f488 = 0;
+                return;
+            }
+            if (DAT_8032f3e0 == DAT_8032f3e8) {
+                ppiVar5 = (int**)&DAT_8032f3ec;
+                piVar4 = (int*)&DAT_8032c660;
+            } else {
+                ppiVar5 = (int**)&DAT_8032f3e8;
+                piVar4 = (int*)&DAT_8032b860;
+            }
+            piVar7 = *ppiVar5;
+            DAT_8032f488 = 2;
+            piVar6 = 0;
+            if (*piVar7 != 0) {
+                DAT_8032f468 = 1;
+                if (piVar7[1] == 0) {
+                    DCFlushRange((void*)piVar7[2], (u32)piVar7[4]);
+                    iVar3 = piVar7[2];
+                    iVar2 = piVar7[3];
+                } else {
+                    DCInvalidateRange((void*)piVar7[2], (u32)piVar7[4]);
+                    iVar3 = piVar7[3];
+                    iVar2 = piVar7[2];
+                }
+                DAT_8032f488 = 3;
+                ARQSetChunkSize((u32)piVar7[4]);
+                ARQPostRequest(&DAT_8032dde4, 0x469, (u32)piVar7[1], 1, (u32)iVar3, (u32)iVar2,
+                               (u32)piVar7[4], _DmaCallback);
+                piVar6 = piVar7;
+            }
+            piVar8 = piVar7 + 7;
+            if (piVar4 + 0x380 <= piVar7 + 7) {
+                piVar8 = piVar4;
+            }
+            *ppiVar5 = piVar8;
+        } while (piVar6 == 0);
+        while (piVar6 != 0) {
+            DAT_8032f488 = 7;
+            if (DAT_8032f468 == 0) {
+                DAT_8032f488 = 8;
+                if (piVar6[5] != 0) {
+                    uVar1 = OSDisableInterrupts();
+                    ((void (*)(void*))piVar6[5])((void*)piVar6[6]);
+                    OSRestoreInterrupts(uVar1);
+                }
+                DAT_8032f488 = 9;
+                if (piVar6[1] == 1) {
+                    DCFlushRange((void*)piVar6[2], (u32)piVar6[4]);
+                }
+                *piVar6 = 0;
+                break;
+            }
+            RedSleep(0);
+        }
+    } while (true);
 }
 
 /*
@@ -559,12 +694,142 @@ CRedDriver::~CRedDriver()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801be654
+ * PAL Size: 1316b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CRedDriver::Init()
 {
-	// TODO
+    char cVar1;
+    int iVar2;
+    int iVar4;
+    int iVar5;
+    int iVar6;
+    void* uVar3;
+
+    DAT_8032f3c4 = 0;
+    DAT_8032f3c0 = 1;
+    DAT_8032f408 = 1;
+    DAT_8032f3c8 = 0;
+    GetSoundMode();
+    if (DAT_8032f400 == 2) {
+        AXSetMode(2);
+    } else {
+        AXSetMode(0);
+    }
+    DAT_8032f3cc = RedNew__Fi(400);
+    memset(DAT_8032f3cc, 0, 400);
+    AXSetCompressor(0);
+    DAT_8032f414 = 0;
+    DAT_8032f404 = 0;
+    DAT_8032f410 = 0;
+    DAT_8032f40c = 0;
+    DAT_8032f468 = 0;
+    DAT_8032f42c = 0;
+    DAT_8032f434 = 0x1ff;
+    DAT_8032f430 = 0x1ff;
+    iVar6 = 0;
+    do {
+        iVar5 = iVar6 + 1;
+        (&DAT_8032e12c)[iVar6] = 0;
+        iVar6 = iVar5;
+    } while (iVar5 < 4);
+    DAT_8032f3d0 = RedNew__Fi(0x1000);
+    memset(DAT_8032f3d0, 0, 0x1000);
+    DAT_8032f418 = RedNew__Fi(0x400);
+    memset(DAT_8032f418, 0, 0x400);
+    DAT_8032f41c = RedNew__Fi(0xc);
+    memset(DAT_8032f41c, 0, 0xc);
+    DAT_8032f420 = RedNew__Fi(0xc);
+    memset(DAT_8032f420, 0, 0xc);
+    DAT_8032f3d4 = RedNew__Fi(0x2000);
+    DAT_8032f3d8 = DAT_8032f3d4;
+    DAT_8032f3dc = DAT_8032f3d4;
+    memset(DAT_8032f3d4, 0, 0x2000);
+    DAT_8032f3f0 = RedNew__Fi(0x1250);
+    DAT_8032f3f4 = DAT_8032f3f0;
+    memset(DAT_8032f3f0, 0, 0x1250);
+    *(int*)((char*)DAT_8032f3f4 + 0xdd8) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0x944) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0x4b0) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0x1c) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0x1210) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0xd7c) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0x8e8) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0x454) = 0x1ff000;
+    *(int*)((char*)DAT_8032f3f4 + 0xd98) = -1;
+    *(int*)((char*)DAT_8032f3f4 + 0x904) = -1;
+    *(int*)((char*)DAT_8032f3f4 + 0x470) = -1;
+    DAT_8032f3fc = RedNew__Fi(0x600);
+    memset(DAT_8032f3fc, 0, 0x600);
+    DAT_8032f444 = (unsigned int*)RedNew__Fi(0x3000);
+    memset(DAT_8032f444, 0, 0x3000);
+    iVar6 = 0;
+    do {
+        iVar2 = iVar6 * 0xc0;
+        iVar5 = iVar6 * 0x8000000;
+        iVar4 = iVar6 >> 0x1f;
+        iVar6 = iVar6 + 1;
+        *(unsigned int*)((char*)DAT_8032f444 + iVar2 + 0xa8) =
+            (iVar4 * 0x20 | (unsigned int)(iVar5 + iVar4) >> 0x1b) - iVar4;
+    } while (iVar6 < 0x40);
+    DAT_8032f44c = 0;
+    DAT_8032f448 = 0;
+    uVar3 = RedNew__Fi(0x2a80);
+    *(void**)((char*)DAT_8032f3f0 + 0xdbc) = uVar3;
+    memset(*(void**)((char*)DAT_8032f3f0 + 0xdbc), 0, 0x2a80);
+    iVar5 = 0;
+    iVar6 = (int)*(void**)((char*)DAT_8032f3f0 + 0xdbc);
+    do {
+        iVar4 = iVar5 * 0x154;
+        cVar1 = (char)iVar5;
+        iVar5 = iVar5 + 1;
+        *(char*)(iVar6 + iVar4 + 0x14e) = (char)(cVar1 + ' ');
+    } while (iVar5 < 0x20);
+    DAT_8032f450 = RedNew__Fi(0x154);
+    memset(DAT_8032f450, 0, 0x154);
+    DAT_8032f474 = RedNew__Fi(0x18);
+    memset(DAT_8032f474, 0, 0x18);
+    DAT_8032f47c = 0;
+    DAT_8032f478 = 0;
+    DAT_8032f428 = (void**)RedNew__Fi(0x10);
+    *DAT_8032f428 = (void*)-1;
+    DAT_8032f424 = 0;
+    DAT_8032f438 = RedNew__Fi(0x4c0);
+    memset(DAT_8032f438, 0, 0x4c0);
+    DAT_8032f43c = 0;
+    memset(&DAT_8032b860, 0, 0x1c00);
+    DAT_8032f3e0 = &DAT_8032b860;
+    DAT_8032f3e8 = &DAT_8032b860;
+    DAT_8032f3e4 = &DAT_8032c660;
+    DAT_8032f3ec = &DAT_8032c660;
+    DAT_8032f3b8 = 0;
+    AXRegisterCallback(_RedAXCallback);
+    AXFXSetHooks(ReverbAreaAlloc, ReverbAreaFree);
+    InitReverb();
+    OSInitSemaphore(&DAT_8032ddd8, 0);
+    DAT_8032f464 = RedNew__Fi(0x1000);
+    OSCreateThread(&DAT_8032dac0, (void* (*)(void*))_DmaExecuteThread, 0, (char*)DAT_8032f464 + 0x1000, 0x1000,
+                   3, 1);
+    OSResumeThread(&DAT_8032dac0);
+    OSInitSemaphore(&DAT_8032daa0, 0);
+    DAT_8032f45c = RedNew__Fi(0x1000);
+    OSCreateThread(&DAT_8032d788, (void* (*)(void*))_WaveSettingThread, &DAT_8032daac,
+                   (char*)DAT_8032f45c + 0x1000, 0x1000, 4, 1);
+    OSResumeThread(&DAT_8032d788);
+    OSInitSemaphore(&DAT_8032e120, 0);
+    DAT_8032f46c = RedNew__Fi(0x1000);
+    OSCreateThread(&DAT_8032de08, (void* (*)(void*))_MusicSkipThread, 0, (char*)DAT_8032f46c + 0x1000, 0x1000,
+                   4, 1);
+    OSResumeThread(&DAT_8032de08);
+    OSInitSemaphore(&DAT_8032d778, 0);
+    DAT_8032f458 = 0;
+    DAT_8032f454 = RedNew__Fi(0x1000);
+    OSCreateThread(&DAT_8032d460, (void* (*)(void*))_MainThread, 0, (char*)DAT_8032f454 + 0x1000, 0x1000, 4, 1);
+    OSResumeThread(&DAT_8032d460);
 }
 
 /*


### PR DESCRIPTION
Summary:\n- Implemented CRedDriver::Init and _DmaExecute based on Ghidra reference.\n- Added required externs/includes and PAL address/size headers.\n\nFunctions improved:\n- Init__10CRedDriverFv\n- _DmaExecute__Fv\n\nMatch evidence:\n- Init__10CRedDriverFv: 0.3% -> 62.288754% (objdiff oneshot)\n- _DmaExecute__Fv: 0.8% -> 65.435486% (objdiff oneshot)\n\nPlausibility rationale:\n- Changes follow straightforward allocation/init patterns and DMA queue handling visible in decomp; no compiler-coaxing constructs added.\n\nTechnical details:\n- Mirrors Ghidra control flow/constant usage, fills init of RedSound globals, and reproduces DMA loop semantics (ARQ request, cache ops, interrupt-guarded callback).