### PR TITLE
main/pppRandFloat: improve function match with direct RandF flow

### DIFF
--- a/src/pppRandFloat.cpp
+++ b/src/pppRandFloat.cpp
@@ -2,9 +2,24 @@
 #include "ffcc/math.h"
 
 extern CMath math;
-extern int lbl_8032ED70; // Global state flag from assembly
-extern float lbl_8032FF88; // Float constant from assembly 
-extern float lbl_801EADC8; // Another float constant
+extern int lbl_8032ED70;
+extern float lbl_8032FF88;
+extern float lbl_801EADC8;
+extern "C" float RandF__5CMathFv(CMath* instance);
+
+struct RandFloatParam {
+    int targetId;
+    int sourceOffset;
+    float blend;
+    unsigned char randomTwice;
+};
+
+struct RandFloatCtx {
+    void* unk0;
+    void* unk4;
+    void* unk8;
+    int* outputOffset;
+};
 
 /*
  * --INFO--
@@ -17,87 +32,40 @@ extern float lbl_801EADC8; // Another float constant
  */
 void pppRandFloat(void* param1, void* param2, void* param3)
 {
-    // Cast parameters based on memory access patterns in assembly
-    int* p1 = (int*)param1;
-    struct ParamStruct2 {
-        int field0;      // offset 0 
-        int field4;      // offset 4
-        float field8;    // offset 8  
-        unsigned char fieldC; // offset 12
-    }* p2 = (struct ParamStruct2*)param2;
-    
-    struct ParamStruct3 {
-        void* field0;    // offset 0
-        void* field4;    // offset 4  
-        void* field8;    // offset 8
-        void* fieldC;    // offset 12
-    }* p3 = (struct ParamStruct3*)param3;
-    
-    // Check global state first (like assembly does)
+    int* base = (int*)param1;
+    RandFloatParam* data = (RandFloatParam*)param2;
+    RandFloatCtx* ctx = (RandFloatCtx*)param3;
+    int index = base[3];
+
     if (lbl_8032ED70 != 0) {
-        return; // Early exit condition
+        return;
     }
-    
-    // Check field at offset 12 of first parameter
-    if (p1[3] == 0) { // lwz r3, 0xc(r29)
-        // Generate first random float
-        math.RandF(); // This returns float in f1 register
-        float randVal1 = 1.0f; // Placeholder - RandF() return value
-        
-        // Check byte at offset 12 of second parameter  
-        if (p2->fieldC != 0) { // lbz r0, 0xc(r31) + cmplwi r0, 0x0
-            // Generate second random float and add
-            math.RandF();
-            float randVal2 = 1.0f; // Placeholder
-            randVal1 = randVal1 + randVal2; // fadds f0, f31, f1
+
+    if (index == 0) {
+        float out = RandF__5CMathFv(&math);
+
+        if (data->randomTwice != 0) {
+            out += RandF__5CMathFv(&math);
         } else {
-            // Multiply by constant instead
-            randVal1 = randVal1 * lbl_8032FF88; // fmuls f0, f31, f0
+            out *= lbl_8032FF88;
         }
-        
-        // Calculate destination address and store
-        void** basePtr = (void**)p3->fieldC;  // lwz r3, 0xc(r30)
-        if (basePtr) {
-            int* indexPtr = (int*)*basePtr;       // lwz r3, 0x0(r3)
-            float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80)); // Calculate final address
-            *destAddr = randVal1; // stfs f0, 0x0(r4)
+
+        int outputOffset = *ctx->outputOffset;
+        *(float*)((char*)param1 + outputOffset + 0x80) = out;
+        return;
+    }
+
+    if (data->targetId == index) {
+        int outputOffset = *ctx->outputOffset;
+        float* outputValue = (float*)((char*)param1 + outputOffset + 0x80);
+        float* source;
+
+        if (data->sourceOffset == -1) {
+            source = &lbl_801EADC8;
+        } else {
+            source = (float*)((char*)param1 + data->sourceOffset + 0x80);
         }
-        
-    } else {
-        // Different branch - check second parameter fields
-        if (p2->field0 == p1[3]) { // cmpw r0, r3 where r0 = lwz r0, 0x0(r31)
-            // Calculate destination address differently
-            void** basePtr = (void**)p3->fieldC;
-            if (basePtr) {
-                int* indexPtr = (int*)*basePtr;
-                
-                // Check field4 for special case
-                if (p2->field4 == -1) { // cmpwi r3, -0x1
-                    // Use constant address
-                    float* srcAddr = &lbl_801EADC8;
-                    float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80));
-                    
-                    // Complex floating point operation: fmsubs f0, f2, f0, f2
-                    float val2 = p2->field8;   // lfs f2, 0x8(r31)
-                    float val0 = *destAddr;    // lfs f0, 0x0(r4) 
-                    float val1 = *srcAddr;     // lfs f1, 0x0(r3)
-                    
-                    float result = val1 + (val2 * val0 - val2); // fmsubs + fadds
-                    *srcAddr = result; // stfs f0, 0x0(r3)
-                    
-                } else {
-                    // Use computed address
-                    float* srcAddr = (float*)((char*)p1 + (p2->field4 + 0x80));
-                    float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80));
-                    
-                    float val2 = p2->field8;
-                    float val0 = *destAddr;
-                    float val1 = *srcAddr;
-                    
-                    float result = val1 + (val2 * val0 - val2);
-                    *srcAddr = result;
-                }
-            }
-        }
+
+        *source = *source + (data->blend * *outputValue - data->blend);
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandFloat` control flow to be closer to target assembly while keeping source-plausible logic.
- Replaced placeholder random handling with direct `RandF__5CMathFv(&math)` value flow.
- Simplified destination/source address computation and removed defensive branches that were not reflected in target flow.

## Functions Improved
- Unit: `main/pppRandFloat`
- Symbol: `pppRandFloat`

## Match Evidence
- Before: **63.97015%** (`pppRandFloat`, base size 300b)
- After: **76.22388%** (`pppRandFloat`, base size 248b)
- Target size: 268b

Command used for evidence:

```sh
build/tools/objdiff-cli diff -1 build/GCCP01/obj/pppRandFloat.o -2 build/GCCP01/src/pppRandFloat.o -o - --format json pppRandFloat
```

## Plausibility Rationale
- The updated implementation follows the expected gameplay-style logic for this effect node:
  - early global guard check,
  - random write path when index is zero,
  - parameter-gated blend/update path otherwise.
- Changes are semantic cleanups (types/control flow/value flow), not contrived compiler coaxing.
- The blend expression remains readable and idiomatic: `source = source + (blend * out - blend)`.

## Technical Notes
- Full project build passes with `ninja`.
- `objdiff-cli diff -p . -u main/pppRandFloat` appeared stale in this workspace; direct object-path diff was used for authoritative measurement.
