### PR TITLE
main/pppParMoveLine: improve pppParMoveLine match

### DIFF
--- a/src/pppParMoveLine.cpp
+++ b/src/pppParMoveLine.cpp
@@ -19,28 +19,26 @@ void pppParMoveLine(_pppPObject* param_1, int param_2)
     Vec local_1c;
     Vec VStack_28;
     float fVar1 = 0.0f;
-    
-    // Calculate direction vector - need to find correct field offsets
-    // Based on objdiff, using position as both src and dst for now
-    PSVECSubtract(&pppMngSt->m_position, &pppMngSt->m_position, &local_1c);
-    
-    // Store previous position (copying x,y,z individually based on assembly)
-    Vec previousPos = pppMngSt->m_position;
-    
-    // Check if direction vector is non-zero
+    Vec* position = (Vec*)((char*)pppMngSt + 0x8);
+    Vec* previousPosition = (Vec*)((char*)pppMngSt + 0x48);
+
+    PSVECSubtract((Vec*)((char*)pppMngSt + 0x68), (Vec*)((char*)pppMngSt + 0x58), &local_1c);
+
+    previousPosition->x = position->x;
+    previousPosition->y = position->y;
+    previousPosition->z = position->z;
+
     if ((fVar1 != local_1c.x) || (fVar1 != local_1c.y) || (fVar1 != local_1c.z)) {
         PSVECNormalize(&local_1c, &VStack_28);
-        
-        // Scale by value from param_2 + 4 times m_paramC (field offset likely wrong)
-        float scaleValue = *(float*)(param_2 + 4) * 1.0f; // placeholder for m_paramC
+
+        float scaleValue = *(float*)(param_2 + 4) * *(float*)((char*)pppMngSt + 0x54);
         PSVECScale(&VStack_28, &local_1c, scaleValue);
-        PSVECAdd(&local_1c, &pppMngSt->m_position, &pppMngSt->m_position);
+        PSVECAdd(&local_1c, position, position);
     }
-    
-    // Update matrix with new position - offsets from objdiff suggest different layout
-    pppMngSt->m_matrix.value[0][3] = pppMngSt->m_position.x;
-    pppMngSt->m_matrix.value[1][3] = pppMngSt->m_position.y; 
-    pppMngSt->m_matrix.value[2][3] = pppMngSt->m_position.z;
-    
+
+    pppMngStPtr->m_matrix.value[0][3] = position->x;
+    pppMngStPtr->m_matrix.value[1][3] = position->y;
+    pppMngStPtr->m_matrix.value[2][3] = position->z;
+
     pppSetFpMatrix(pppMngSt);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppParMoveLine` to use offset-accurate vector fields in `_pppMngSt` for motion delta and previous-position tracking.
- Reintroduced missing motion state updates (previous position stores at `0x48/0x4c/0x50`) and scale multiply using manager field at `0x54`.
- Kept matrix translation updates via `pppMngStPtr->m_matrix` and preserved existing function metadata header.

## Functions improved
- Unit: `main/pppParMoveLine`
- Symbol: `pppParMoveLine`

## Match evidence
- `pppParMoveLine`: **72.36207% -> 84.293106%**
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppParMoveLine -o - pppParMoveLine`
- Improvement reflects real instruction alignment (restored missing stores and multiply path), not formatting-only changes.

## Plausibility rationale
- Changes align with existing project style for partially-reconstructed PPP manager layouts (explicit offset-based field access where struct layout is still WIP).
- The updated control flow and data movement are behaviorally coherent for line-motion particles: compute direction delta, snapshot previous position, optionally normalize/scale/apply movement, then publish matrix translation.
- No compiler-coaxing-only constructs were introduced; edits are straightforward source-level logic consistent with nearby PPP code.

## Technical notes
- Build validated with `ninja`.
- The function is still not a full match (`84.29%`), but this is a concrete, measurable step forward with plausible source reconstruction.
