### PR TITLE
card/CARDOpen: improve __CARDIsPublic match by handling deleted entries

### DIFF
--- a/src/card/CARDOpen.c
+++ b/src/card/CARDOpen.c
@@ -57,7 +57,13 @@ s32 __CARDIsWritable(CARDControl* card, CARDDir* ent) {
 }
 
 s32 __CARDIsPublic(CARDDir* ent) {
-    u8 perm = ent->permission & __CARDPermMask;
+    u8 perm;
+
+    if (ent->gameName[0] == 0xFF) {
+        return CARD_RESULT_NOFILE;
+    }
+
+    perm = ent->permission & __CARDPermMask;
     if (perm & 0x4) {
         return CARD_RESULT_READY;
     }


### PR DESCRIPTION
## Summary
- Update `__CARDIsPublic` in `src/card/CARDOpen.c` to reject deleted directory entries (`gameName[0] == 0xFF`) before permission checks.
- Keep the permission-mask logic unchanged for valid entries.

## Functions improved
- Unit: `main/card/CARDOpen`
- Symbol: `__CARDIsPublic`

## Match evidence
- `__CARDIsPublic`: **52.833332% -> 82.916664%** (`48b`)
- `main/card/CARDOpen` `.text`: **75.72603% -> 76.715065%** (`1460b`)

## Plausibility rationale
- Deleted card directory entries are represented by `gameName[0] == 0xFF`; treating them as `CARD_RESULT_NOFILE` is expected card-file semantics and aligns with decompilation context.
- The change is behaviorally coherent and source-plausible (not compiler-coaxing-only reordering).

## Technical details
- Objdiff initially showed extra target instructions at the start of `__CARDIsPublic` corresponding to an early deleted-entry guard.
- Adding the guard aligned the function prologue/control flow and produced a measurable match gain while keeping the rest of the unit stable.

## Validation
- `ninja` passes for PAL (`GCCP01`).
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/card/CARDOpen -o - __CARDIsPublic`
