### PR TITLE
pppColMove: improve control-flow/pointer setup match

### DIFF
--- a/src/pppColMove.cpp
+++ b/src/pppColMove.cpp
@@ -26,43 +26,34 @@ void pppColMoveCon(void* param1, void* param2)
 void pppColMove(void* param1, void* param2, void* param3)
 {
     extern int lbl_8032ED70;
-    
-    int** ptr_array = (int**)param3;
-    int* ptr0 = ptr_array[3];  // Load from offset 0xC
-    
+
     if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    int* ptr_src = (int*)ptr0[0]; // Load from offset 0x0
-    int* ptr_dest = (int*)ptr0[1]; // Load from offset 0x4
-    
-    // Calculate offsets
-    ptr_src = (int*)((char*)ptr_src + 0x80);
-    ptr_dest = (int*)((char*)ptr_dest + 0x80);
-    short* src = (short*)((char*)param1 + (int)ptr_src);
-    short* dest = (short*)((char*)param1 + (int)ptr_dest);
-    
+
     int* param2_int = (int*)param2;
     int* param1_int = (int*)param1;
-    
-    if (param2_int[0] == param1_int[3]) {  // Inverted comparison
-        // Skip the movement update section
-        goto do_final_add;
-    }
-    
-    // Update movement values
-    short* movement = (short*)((char*)param2 + 0x8);
-    
-    dest[0] += movement[0];  // x
-    dest[1] += movement[1];  // y
-    dest[2] += movement[2];  // z
-    dest[3] += movement[3];  // w
+    int same_target = (param2_int[0] == param1_int[3]);
 
-do_final_add:
-    // Always perform this addition
-    src[0] += dest[0];  // x
-    src[1] += dest[1];  // y  
-    src[2] += dest[2];  // z
-    src[3] += dest[3];  // w
+    int** ptr_array = (int**)param3;
+    int* ptr0 = ptr_array[3];
+
+    int src_offset = ptr0[0];
+    int dest_offset = ptr0[1];
+    short* src = (short*)((char*)param1 + src_offset + 0x80);
+    short* dest = (short*)((char*)param1 + dest_offset + 0x80);
+
+    if (!same_target) {
+        short* movement = (short*)((char*)param2 + 0x8);
+
+        dest[0] += movement[0];
+        dest[1] += movement[1];
+        dest[2] += movement[2];
+        dest[3] += movement[3];
+    }
+
+    src[0] += dest[0];
+    src[1] += dest[1];
+    src[2] += dest[2];
+    src[3] += dest[3];
 }


### PR DESCRIPTION
## Summary
- Refactored `pppColMove` in `src/pppColMove.cpp` to remove `goto`-style flow and use a direct guarded update path.
- Moved the target equality test into an explicit `same_target` condition and kept final accumulation always executed.
- Reworked pointer-offset setup into clear `src_offset`/`dest_offset` integer offsets before halfword vector updates.

## Functions improved
- Unit: `main/pppColMove`
- Symbol: `pppColMove`

## Match evidence
- `pppColMove`: `69.46809%` -> `70.319145%` (+0.851055)
- Unit `.text` match (`main/pppColMove`): `74.82456%` -> `75.52631%`
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/pppColMove -o - pppColMove`

## Plausibility rationale
- The updated code uses straightforward C-style control flow and typed offset math, which is more consistent with plausible original source than compiler-coaxing-only rewrites.
- Changes are behavior-preserving: early global guard remains, destination delta update is still conditional on target mismatch, and source accumulation still runs unconditionally.