### PR TITLE
main/math: implement CMath::Init

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/math.h"
 
+#include "dolphin/mtx.h"
+#include "string.h"
 /*
  * --INFO--
  * Address:	TODO
@@ -22,12 +24,17 @@ CMath::CMath()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001c290
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMath::Init()
 {
-	// TODO
+	PSMTXIdentity((MtxPtr)((char*)this + 4));
+	memset((char*)this + 0x34, 0, 0x30);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMath::Init` in `src/math.cpp` using the expected matrix identity + state zeroing sequence.
- Added PAL address/size metadata for the function comment block.
- Included required headers for `PSMTXIdentity` and `memset` usage.

## Functions improved
- Unit: `main/math`
- Symbol: `Init__5CMathFv` (`CMath::Init`)

## Match evidence
- Before: `6.25%` (`size=4`, stub/return-only shape)
- After: `99.6875%` (`size=64`, target-sized implementation)
- Objdiff now reports only one remaining instruction-level mismatch (`DIFF_ARG_MISMATCH`) on the `memset` call.

## Plausibility rationale
- The implementation is source-plausible for an engine math singleton initializer: initialize transform matrix to identity, then clear cached state fields.
- No contrived control-flow or artificial temporaries were introduced.

## Technical details
- Implemented:
  - `PSMTXIdentity((MtxPtr)((char*)this + 4));`
  - `memset((char*)this + 0x34, 0, 0x30);`
- This aligns with the expected PAL function structure/size from decomp resources while keeping the C++ straightforward and idiomatic for this codebase.
