### PR TITLE
main/pppBindOnlyPos: improve pppFrameBindOnlyPos match

### DIFF
--- a/src/pppBindOnlyPos.cpp
+++ b/src/pppBindOnlyPos.cpp
@@ -3,8 +3,6 @@
 extern int DAT_8032ed70;
 extern int* DAT_8032ed50;
 
-static int temp_state;
-
 /*
  * --INFO--
  * PAL Address: 0x80127b70
@@ -33,6 +31,6 @@ void pppFrameBindOnlyPos(void)
 	if (DAT_8032ed70 != 0) {
 		return;
 	}
-	
-	temp_state = (*(unsigned int*)((char*)DAT_8032ed50 + 0xd8) == 0);
+
+	(void)(*(volatile unsigned int*)((char*)DAT_8032ed50 + 0xd8) == 0);
 }


### PR DESCRIPTION
## Summary
- Refined `pppFrameBindOnlyPos` to remove the synthetic `temp_state` store path.
- Replaced the stored boolean expression with a read/compare expression over a `volatile` dereference to preserve the expected load sequence without adding an artificial `.sbss` symbol.

## Functions improved
- Unit: `main/pppBindOnlyPos`
- Function: `pppFrameBindOnlyPos`
- Match: **61.43% -> 84.29%**

## Match evidence
`objdiff` (`build/tools/objdiff-cli diff -p . -u main/pppBindOnlyPos -o - pppFrameBindOnlyPos`):
- Before: emitted `lwz/cmpwi/bnelr/lwz/lwz/cntlzw/extrwi/stw/blr`
- After: emitted `lwz/cmpwi/bnelr/lwz/lwz/blr`
- Target sequence includes `lwz/cmpwi/bnelr/lwz/lwz/cmplwi/blr`, so this PR removes the most divergent bool-materialization/store block and aligns instruction flow/shape substantially.

## Plausibility rationale
- The previous implementation introduced `static int temp_state` solely to force codegen, which is unlikely to be intentional gameplay logic.
- The updated code keeps the observed runtime read of the object field while removing an artificial state write, making the source more plausible as original intent and closer to target assembly.

## Technical details
- File changed: `src/pppBindOnlyPos.cpp`
- Removed `.sbss` contributor (`temp_state`) and its store-side instructions.
- Preserved the early return guard on `DAT_8032ed70` and the follow-up field access from `DAT_8032ed50 + 0xD8`.
