### PR TITLE
ax: improve AXInit match by inlining startup sequence

### DIFF
--- a/src/ax/AX.c
+++ b/src/ax/AX.c
@@ -10,7 +10,14 @@ const char* __AXVersion = "<< Dolphin SDK - AX\trelease build: Apr  5 2004 04:15
 #endif
 
 void AXInit(void) {
-    AXInitEx(0);
+    OSRegisterVersion(__AXVersion);
+
+    __AXAllocInit();
+    __AXVPBInit();
+    __AXSPBInit();
+    __AXAuxInit();
+    __AXClInit();
+    __AXOutInit(0);
 }
 
 void AXInitEx(u32 outputBufferMode) {


### PR DESCRIPTION
## Summary
- Reworked `AXInit` in `src/ax/AX.c` to perform the initialization sequence directly instead of delegating through `AXInitEx(0)`.
- Kept behavior equivalent for the PAL build path by preserving the same initialization call order and arguments.

## Functions improved
- Unit: `main/ax/AX`
- Symbol: `AXInit`

## Match evidence
- `AXInit` improved from **46.3%** to **93.0%** (`build/tools/objdiff-cli diff -p . -u main/ax/AX -o - AXInit`)
- `AXInit` size now matches target at **60 bytes**
- Remaining diffs are minor:
  - relocation symbol label naming (`__AXVersion` vs local label)
  - one inserted instruction related to argument setup before `__AXOutInit`

## Plausibility rationale
- The direct startup sequence in `AXInit` is idiomatic SDK source style and reflects a plausible original implementation.
- This avoids artificial compiler-coaxing constructs and keeps code readable/maintainable.

## Technical details
- Inlined calls in `AXInit` in this order:
  - `OSRegisterVersion(__AXVersion)`
  - `__AXAllocInit`, `__AXVPBInit`, `__AXSPBInit`, `__AXAuxInit`, `__AXClInit`, `__AXOutInit(0)`
- `AXInitEx` remains unchanged for callers that provide explicit output buffer mode.
