### PR TITLE
base/PPCArch: implement PPC register helper stubs

### DIFF
--- a/src/base/PPCArch.c
+++ b/src/base/PPCArch.c
@@ -1,309 +1,338 @@
-
+#include "dolphin.h"
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B494
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMfmsr(void)
+u32 PPCMfmsr(void)
 {
-	// TODO
+    asm { mfmsr r3 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B49C
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtmsr(void)
+void PPCMtmsr(register u32 newMSR)
 {
-	// TODO
+    asm { mtmsr newMSR }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4A4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMfhid0(void)
+u32 PPCMfhid0(void)
 {
-	// TODO
+    asm { mfspr r3, HID0 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4AC
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMthid0(void)
+void PPCMthid0(register u32 newHID0)
 {
-	// TODO
+    asm { mtspr HID0, newHID0 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4B4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMfl2cr(void)
+u32 PPCMfl2cr(void)
 {
-	// TODO
+    asm { mfspr r3, L2CR }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4BC
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtl2cr(void)
+void PPCMtl2cr(register u32 newL2cr)
 {
-	// TODO
+    asm { mtspr L2CR, newL2cr }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4C4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtdec(void)
+void PPCMtdec(register u32 newDec)
 {
-	// TODO
+    asm { mtdec newDec }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4CC
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void PPCSync(void)
 {
-	// TODO
+    asm { sc }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4D4
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void PPCHalt(void)
 {
-	// TODO
+    asm {
+        sync
+    loop:
+        nop
+        li r3, 0
+        nop
+        b loop
+    }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4E8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtmmcr0(void)
+void PPCMtmmcr0(register u32 newMMCR0)
 {
-	// TODO
+    asm { mtspr MMCR0, newMMCR0 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4F0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtmmcr1(void)
+void PPCMtmmcr1(register u32 newMMCR1)
 {
-	// TODO
+    asm { mtspr MMCR1, newMMCR1 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B4F8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtpmc1(void)
+void PPCMtpmc1(register u32 newPMC1)
 {
-	// TODO
+    asm { mtspr PMC1, newPMC1 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B500
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtpmc2(void)
+void PPCMtpmc2(register u32 newPMC2)
 {
-	// TODO
+    asm { mtspr PMC2, newPMC2 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B508
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtpmc3(void)
+void PPCMtpmc3(register u32 newPMC3)
 {
-	// TODO
+    asm { mtspr PMC3, newPMC3 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B510
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtpmc4(void)
+void PPCMtpmc4(register u32 newPMC4)
 {
-	// TODO
+    asm { mtspr PMC4, newPMC4 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B518
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMffpscr(void)
+u32 PPCMffpscr(void)
 {
-	// TODO
+    register u32 out;
+
+    asm {
+        stwu r1, -0x18(r1)
+        stfd f31, 0x10(r1)
+        mffs f31
+        stfd f31, 0x8(r1)
+        lwz out, 0xc(r1)
+        lfd f31, 0x10(r1)
+        addi r1, r1, 0x18
+    }
+
+    return out;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B538
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtfpscr(void)
+void PPCMtfpscr(register u32 newFPSCR)
 {
-	// TODO
+    asm {
+        stwu r1, -0x20(r1)
+        stfd f31, 0x18(r1)
+        li r4, 0
+        stw r4, 0x10(r1)
+        stw newFPSCR, 0x14(r1)
+        lfd f31, 0x10(r1)
+        mtfsf 255, f31
+        lfd f31, 0x18(r1)
+        addi r1, r1, 0x20
+    }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B560
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMfhid2(void)
+u32 PPCMfhid2(void)
 {
-	// TODO
+    asm { mfspr r3, HID2 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B568
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMthid2(void)
+void PPCMthid2(register u32 newHID2)
 {
-	// TODO
+    asm { mtspr HID2, newHID2 }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B570
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PPCMtwpar(void)
+void PPCMtwpar(register u32 newWPAR)
 {
-	// TODO
+    asm { mtspr WPAR, newWPAR }
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B578
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void PPCDisableSpeculation(void)
 {
-	// TODO
+    PPCMthid0(PPCMfhid0() | HID0_SPD);
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x8017B5A0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void PPCSetFpNonIEEEMode(void)
 {
-	// TODO
+    asm { mtfsb1 29 }
 }


### PR DESCRIPTION
## Summary
- Replaced `src/base/PPCArch.c` TODO stubs with concrete Metrowerks-style inline assembly implementations.
- Corrected function signatures to match `include/dolphin/base/PPCArch.h` ABI (`u32` returns and `u32` parameters where expected).
- Added PAL address/size metadata comments for each implemented symbol.

## Functions improved
Unit: `main/base/PPCArch`

Notable symbol improvements:
- `PPCMfmsr`: 50.0% -> 100.0%
- `PPCMtmsr`: 50.0% -> 100.0%
- `PPCMfhid0`: 50.0% -> 100.0%
- `PPCMthid0`: 50.0% -> 100.0%
- `PPCMfl2cr`: 50.0% -> 100.0%
- `PPCMtl2cr`: 50.0% -> 100.0%
- `PPCMtdec`: 50.0% -> 100.0%
- `PPCSync`: 50.0% -> 100.0%
- `PPCHalt`: 8.0% -> 100.0%
- `PPCMtmmcr0`: 50.0% -> 100.0%
- `PPCMtmmcr1`: 50.0% -> 100.0%
- `PPCMtpmc1`: 50.0% -> 100.0%
- `PPCMtpmc2`: 50.0% -> 100.0%
- `PPCMtpmc3`: 50.0% -> 100.0%
- `PPCMtpmc4`: 50.0% -> 100.0%
- `PPCMfhid2`: 50.0% -> 100.0%
- `PPCMthid2`: 50.0% -> 100.0%
- `PPCMtwpar`: 50.0% -> 100.0%
- `PPCSetFpNonIEEEMode`: 50.0% -> 100.0%
- `PPCMffpscr`: 12.5% -> 49.75%
- `PPCMtfpscr`: 10.0% -> 59.8%
- `PPCDisableSpeculation`: 10.0% -> 27.0%

## Match evidence
- Unit match (`main/base/PPCArch`): **31.014492% -> 77.76811%**
- Validation commands:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/base/PPCArch -o -`

## Plausibility rationale
- The replacements are direct, idiomatic SDK-style PPC helper wrappers (MSR/HID/L2CR/PMC/FPSCR register access and control operations).
- Signatures were aligned with the header ABI rather than introducing compiler-coaxing temporaries.
- Control flow and register operations correspond to expected low-level architecture helper implementations used by Dolphin-era codebases.

## Technical details
- Used explicit Metrowerks inline assembly to produce expected instruction forms for small wrappers.
- For `PPCMffpscr`/`PPCMtfpscr`, implemented stack/FPR save-restore and transfer sequences with concrete asm blocks to move FPSCR through FPR state.
- `PPCDisableSpeculation` now performs HID0 SPD bit update via existing helper calls, improving instruction alignment while staying readable and source-plausible.
