### PR TITLE
Match w_sqrt sqrt wrapper

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/w_sqrt.c
+++ b/src/MSL_C/PPCEABI/bare/H/w_sqrt.c
@@ -1,15 +1,16 @@
+int __ieee754_sqrt(void);
 
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801D6A54
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void sqrt(void)
 {
-	// TODO
+	__ieee754_sqrt();
 }


### PR DESCRIPTION
## Summary
- Implemented the `sqrt` wrapper in `src/MSL_C/PPCEABI/bare/H/w_sqrt.c` as a direct call to `__ieee754_sqrt()`.
- Updated function metadata comment to include PAL address/size from the decomp target.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/w_sqrt`
- Symbol: `sqrt`
- Size: 32 bytes

## Match evidence
- Before: `sqrt` at **12.5%** (target selector / objdiff symbol status)
- After: `sqrt` at **100.0%**
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/w_sqrt -o - sqrt --format json`
  - Parsed result: `sqrt -> match_percent: 100.0`

## Plausibility rationale
- This is the canonical fdlibm wrapper style: `sqrt` forwards to `__ieee754_sqrt`.
- The resulting code is straightforward library-source behavior, not compiler coaxing.

## Technical details
- The previous implementation was a TODO stub body.
- Replacing it with the wrapper restores the expected call sequence and prologue/epilogue pattern, yielding a full symbol match.
