### PR TITLE
Decomp: rewrite pppMatrixYZX to match offset-based matrix path

### DIFF
--- a/include/ffcc/pppMatrixYZX.h
+++ b/include/ffcc/pppMatrixYZX.h
@@ -1,13 +1,11 @@
 #ifndef _PPP_MATRIXYZX_H_
 #define _PPP_MATRIXYZX_H_
 
-#include "ffcc/partMng.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppMatrixYZX(pppFMATRIX& out, pppIVECTOR4* angle);
+void pppMatrixYZX(void* target, void* unused, void* param);
 
 #ifdef __cplusplus
 }

--- a/src/pppMatrixYZX.cpp
+++ b/src/pppMatrixYZX.cpp
@@ -1,25 +1,56 @@
 #include "ffcc/pppMatrixYZX.h"
-
-#include "ffcc/pppsintbl.h"
-#include "ffcc/pppGetRotMatrixX.h"
-#include "ffcc/pppGetRotMatrixY.h"
-#include "ffcc/pppGetRotMatrixZ.h"
+#include "ffcc/pppGetRotMatrixYZX.h"
+#include <dolphin/mtx.h>
 
 /*
  * --INFO--
- * PAL Address: TODO
+ * PAL Address: 0x80065758
  * PAL Size: 320b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppMatrixYZX(pppFMATRIX& out, pppIVECTOR4* angle)
+void pppMatrixYZX(void* target, void* unused, void* param)
 {
-    pppFMATRIX mY;
-    pppFMATRIX mZ;
-    pppFMATRIX yz;
-    pppFMATRIX mX;
+    (void)unused;
 
-    pppGetRotMatrixY(mY, angle->y);
-    pppGetRotMatrixZ(mZ, angle->z);
-    PSMTXConcat(mY.value, mZ.value, yz.value);
-    pppGetRotMatrixX(mX, angle->x);
-    PSMTXConcat(yz.value, mX.value, out.value);
+    f32* matrix = (f32*)target;
+    u32* offsets = (u32*)*(void**)((u8*)param + 0xC);
+    pppIVECTOR4* angle = (pppIVECTOR4*)((u8*)target + offsets[1] + 0x80);
+    f32* scale = (f32*)((u8*)target + offsets[2] + 0x80);
+    f32* translation = (f32*)((u8*)target + offsets[0] + 0x80);
+    Vec temp1;
+    Vec temp2;
+    Vec temp3;
+
+    pppGetRotMatrixYZX(*(pppFMATRIX*)(matrix + 4), angle);
+
+    temp1.x = matrix[4];
+    temp1.y = matrix[8];
+    temp1.z = matrix[12];
+    PSVECScale(&temp1, &temp1, scale[0]);
+    matrix[4] = temp1.x;
+    matrix[8] = temp1.y;
+    matrix[12] = temp1.z;
+
+    temp2.x = matrix[5];
+    temp2.y = matrix[9];
+    temp2.z = matrix[13];
+    PSVECScale(&temp2, &temp2, scale[1]);
+    matrix[5] = temp2.x;
+    matrix[9] = temp2.y;
+    matrix[13] = temp2.z;
+
+    temp3.x = matrix[6];
+    temp3.y = matrix[10];
+    temp3.z = matrix[14];
+    PSVECScale(&temp3, &temp3, scale[2]);
+    matrix[6] = temp3.x;
+    matrix[10] = temp3.y;
+    matrix[14] = temp3.z;
+
+    matrix[7] = translation[0];
+    matrix[11] = translation[1];
+    matrix[15] = translation[2];
 }


### PR DESCRIPTION
## Summary
- Replaced the placeholder Y*Z*X matrix concat implementation with the offset-driven matrix-builder flow used by the surrounding ppp matrix pipeline.
- Updated `pppMatrixYZX` signature to a 3-argument C linkage form (`void* target, void* unused, void* param`) so argument registers and memory access pattern line up with the target object.
- Reworked body to:
  - fetch offset table from `param + 0xC`
  - build rotation matrix with `pppGetRotMatrixYZX(target+0x10, angle_ptr)`
  - scale each matrix basis column with `PSVECScale`
  - write translation from the translation pointer into `[0x1C, 0x2C, 0x3C]`

## Functions improved
- Unit: `main/pppMatrixYZX`
- Function: `pppMatrixYZX`

## Match evidence
- `pppMatrixYZX`: **26.8125% -> 99.6%** (`320b`)
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppMatrixYZX -o - pppMatrixYZX`
- Build status:
  - `ninja` passes

## Plausibility rationale
- The new code follows the same dataflow style as neighboring matrix builders (`pppMatrixLoc`, `pppMatrixScl`, and other axis-order matrix units): object-relative offset table, matrix at `+0x10`, and column-wise scaling + translation writeback.
- No contrived temporaries were added for compiler coercion; the structure reflects a straightforward engine-side transform composition routine.

## Technical details
- The prior version only concatenated axis matrices, which did not match target behavior or prologue/register usage.
- This rewrite aligns with the target’s observed load/use sequence for offsets at `[0], [1], [2]`, and the three scalar reads used by `PSVECScale` across matrix columns.
- Remaining small delta is register-allocation-level (`99.6%`) rather than behavioral structure.
