### PR TITLE
GXGeometry: improve GXSetCullMode decomp match

### DIFF
--- a/src/gx/GXGeometry.c
+++ b/src/gx/GXGeometry.c
@@ -104,22 +104,38 @@ void GXEnableTexOffsets(GXTexCoordID coord, u8 line_enable, u8 point_enable) {
     __GXData->bpSentNot = 0;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A2728
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void GXSetCullMode(GXCullMode mode) {
-    GXCullMode hwMode;
+    u32 reg;
 
     CHECK_GXBEGIN(557, "GXSetCullMode");
 #if DEBUG
+    GXCullMode hwMode;
+
     switch (mode) {
     case GX_CULL_FRONT: hwMode = GX_CULL_BACK;  break;
     case GX_CULL_BACK:  hwMode = GX_CULL_FRONT; break;
     default:            hwMode = mode;          break;
     }
-#else
-    hwMode = (mode >> 1) & 1;
-    __rlwimi(hwMode, mode, 1, 30, 30);
-#endif
-
     SET_REG_FIELD(570, __GXData->genMode, 2, 14, hwMode);
+#else
+    if (mode == GX_CULL_BACK) {
+        mode = GX_CULL_FRONT;
+    } else if ((mode < GX_CULL_BACK) && (mode > GX_CULL_NONE)) {
+        mode = GX_CULL_BACK;
+    }
+
+    reg = __GXData->genMode;
+    __GXData->genMode = (reg & 0xFFFF3FFF) | ((u32)mode << 14);
+#endif
     __GXData->dirtyState |= 4;
 }
 


### PR DESCRIPTION
## Summary
- Reworked `GXSetCullMode` in `src/gx/GXGeometry.c` to use explicit front/back remapping in release builds.
- Replaced bit-twiddle coercion with direct bitfield update to `genMode` using a local `reg` temporary.
- Added function metadata header with PAL address/size for the updated function.

## Functions improved
- Unit: `main/gx/GXGeometry`
- Symbol: `GXSetCullMode`
- Size: 76 bytes

## Match evidence
- `GXSetCullMode` match improved from **35.1579%** to **72.1579%** via `objdiff-cli` oneshot diff.
- This improvement came from better alignment of control-flow shape and register-field write sequence, not renames/format-only changes.

## Plausibility rationale
- The new logic expresses the same hardware-facing mode remap that GX code typically performs (front/back swap) in a straightforward branch form.
- The resulting C remains idiomatic and maintainable, avoiding contrived compiler-coax patterns.
- Direct bitfield composition for `genMode` matches expected low-level register semantics and keeps intent clear.

## Technical details
- Command used for symbol diffing:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXGeometry -o - GXSetCullMode`
- Build verification:
  - `ninja` completed successfully with updated object rebuilt and progress regenerated.
