### PR TITLE
pppVertexApMtx: fix constructor indirection for full match

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -2,16 +2,18 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800de6d0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppVertexApMtxCon(_pppPObject* obj, PVertexApMtx* vtx)
 {
-	// Get base address from vtx offset 0xc
-	char* base = *(char**)((char*)vtx + 0xc);
-	// Calculate final address: obj + base + 0x80
-	char* target = (char*)obj + (int)base + 0x80;
-	// Zero out two shorts at the target location
+	int offset = **(int**)((char*)vtx + 0xc);
+	char* target = (char*)obj + offset + 0x80;
+
 	*(short*)target = 0;
 	*(short*)(target + 2) = 0;
 }


### PR DESCRIPTION
## Summary
- Updated `pppVertexApMtxCon` in `src/pppVertexApMtx.cpp` to use the extra pointer indirection observed in target assembly (`**(int**)((char*)vtx + 0xC)`).
- Kept behavior plausible/original-source style: compute an offset from vertex-ap data and clear two shorts at `obj + offset + 0x80`.
- Replaced TODO metadata for this function with PAL address/size info.

## Functions improved
- Unit: `main/pppVertexApMtx`
- Symbol: `pppVertexApMtxCon`
- Match: **87.5% -> 100.0%**

## Match evidence
- Command used: `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o - pppVertexApMtxCon`
- Before: one remaining instruction mismatch (`lwz r4, 0x0(r4)` missing).
- After: all instructions match for `pppVertexApMtxCon` (100.0%).

## Plausibility rationale
- The new code models a realistic data layout where `vtx+0xC` points to a table/record whose first word is an offset.
- This is simpler and more plausible than forcing compiler artifacts: one explicit double dereference naturally explains the missing `lwz` and yields exact assembly alignment.

## Technical details
- Previous code treated `*(vtx+0xC)` as the final offset value; this skipped one memory load in codegen.
- New code reads `offset = **(int**)` and then computes `target = (char*)obj + offset + 0x80`, matching the expected load-add-store sequence.