### PR TITLE
Improve match for pppMatrixXZY in main/pppMatrixXZY

### DIFF
--- a/src/pppMatrixXZY.cpp
+++ b/src/pppMatrixXZY.cpp
@@ -5,43 +5,50 @@
 
 /*
  * --INFO--
- * PAL Address: 80060380
+ * PAL Address: 0x80060380
  * PAL Size: 320b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppMatrixXZY(pppFMATRIX& mtx, void* param)
 {
-    // Based on assembly analysis:
-    // param is a structure pointer containing data at offset 0xc
-    void** dataPtr = (void**)((char*)param + 0xc);
-    if (dataPtr == nullptr || *dataPtr == nullptr) {
-        return;
-    }
-    
-    // The data structure at *dataPtr contains vectors/scale factors
-    float* data = (float*)*dataPtr;
-    Vec scale = {data[0], data[1], data[2]};
-    
-    // Build rotation matrix
-    pppFMATRIX rotMatrix;
-    pppIVECTOR4 angles = {0, 0, 0, 0}; // Placeholder angles
-    pppGetRotMatrixXZY(rotMatrix, &angles);
-    
-    // Scale the matrix columns based on the data
-    Vec col0 = {rotMatrix.value[0][0], rotMatrix.value[1][0], rotMatrix.value[2][0]};
-    Vec col1 = {rotMatrix.value[0][1], rotMatrix.value[1][1], rotMatrix.value[2][1]};
-    Vec col2 = {rotMatrix.value[0][2], rotMatrix.value[1][2], rotMatrix.value[2][2]};
-    
-    PSVECScale(&col0, &col0, scale.x);
-    PSVECScale(&col1, &col1, scale.y);  
-    PSVECScale(&col2, &col2, scale.z);
-    
-    // Update output matrix
-    mtx.value[0][0] = col0.x; mtx.value[1][0] = col0.y; mtx.value[2][0] = col0.z;
-    mtx.value[0][1] = col1.x; mtx.value[1][1] = col1.y; mtx.value[2][1] = col1.z;
-    mtx.value[0][2] = col2.x; mtx.value[1][2] = col2.y; mtx.value[2][2] = col2.z;
-    
-    // Translation components from assembly
-    mtx.value[0][3] = data[3];
-    mtx.value[1][3] = data[4]; 
-    mtx.value[2][3] = data[5];
+    u32* offsets = (u32*)*(void**)((u8*)param + 0xC);
+    pppIVECTOR4* angle = (pppIVECTOR4*)((u8*)&mtx + offsets[1] + 0x80);
+    f32* scale = (f32*)((u8*)&mtx + offsets[2] + 0x80);
+    f32* translation = (f32*)((u8*)&mtx + offsets[0] + 0x80);
+    Vec temp1;
+    Vec temp2;
+    Vec temp3;
+
+    pppGetRotMatrixXZY(mtx, angle);
+
+    temp1.x = mtx.value[0][0];
+    temp1.y = mtx.value[1][0];
+    temp1.z = mtx.value[2][0];
+    PSVECScale(&temp1, &temp1, scale[0]);
+    mtx.value[0][0] = temp1.x;
+    mtx.value[1][0] = temp1.y;
+    mtx.value[2][0] = temp1.z;
+
+    temp2.x = mtx.value[0][1];
+    temp2.y = mtx.value[1][1];
+    temp2.z = mtx.value[2][1];
+    PSVECScale(&temp2, &temp2, scale[1]);
+    mtx.value[0][1] = temp2.x;
+    mtx.value[1][1] = temp2.y;
+    mtx.value[2][1] = temp2.z;
+
+    temp3.x = mtx.value[0][2];
+    temp3.y = mtx.value[1][2];
+    temp3.z = mtx.value[2][2];
+    PSVECScale(&temp3, &temp3, scale[2]);
+    mtx.value[0][2] = temp3.x;
+    mtx.value[1][2] = temp3.y;
+    mtx.value[2][2] = temp3.z;
+
+    mtx.value[0][3] = translation[0];
+    mtx.value[1][3] = translation[1];
+    mtx.value[2][3] = translation[2];
 }


### PR DESCRIPTION
## Summary
- Replaced placeholder/decompiler-guess implementation in `pppMatrixXZY` with an offset-driven matrix build path consistent with neighboring matrix helpers.
- Added proper INFO metadata formatting for PAL and TODO placeholders for EN/JP.
- Implemented explicit angle/scale/translation pointer derivation from the `param + 0xC` offset table.
- Rebuilt the matrix by:
  - calling `pppGetRotMatrixXZY` with derived angle data,
  - scaling each basis column via `PSVECScale`,
  - copying translation from derived translation data.

## Functions Improved
- Unit: `main/pppMatrixXZY`
- Symbol: `pppMatrixXZY`
- `.text` match: **28.1625% -> 98.025%**

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppMatrixXZY -o - pppMatrixXZY`
- Result:
  - `.text` match increased to `98.025`.
  - Remaining differences are mostly argument/register/stack-placement mismatches with one structural delete, indicating near-match codegen rather than formatting-only change.

## Plausibility Rationale
- The new structure matches existing codebase patterns in related helpers (`pppMatrixYZX`, `pppMatrixZXY`): pointer-table driven data access, rotation generation call, per-column vector scaling, and final translation writeback.
- Removed contrived placeholders (zeroed dummy angles, null-guard scaffolding not evidenced by target asm) in favor of straightforward game-runtime data flow.
- Resulting source reads as normal production-era matrix setup code rather than compiler-coaxing logic.

## Technical Details
- Derived data layout used in function:
  - `offsets = *(u32**)((u8*)param + 0xC)`
  - `angle = base + offsets[1] + 0x80`
  - `scale = base + offsets[2] + 0x80`
  - `translation = base + offsets[0] + 0x80`
- Basis vectors are copied out to stack `Vec` temporaries before scaling and writeback, matching established style in this module family.
