### PR TITLE
Improve match for pppPObjPoint and pppWDrawMatrixLoop

### DIFF
--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -14,34 +14,29 @@ void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* co
     if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    void* containerData = container->ptrData;
-    s32 objId = objData->id;
-    s32 pointId = pointData->id;  
-    void* dataPtr = *(void**)containerData;
-    
-    if (objId == pointId) {
+
+    u8* pointBase = (u8*)pointData;
+    s32 pointOffset = *(s32*)container->ptrData;
+    PppPointObj* objPtr = (PppPointObj*)(pointBase + pointOffset + 0x80);
+
+    if (objData->id == pointData->id) {
         void* vectorPtr;
-        
+
         if ((objData->field_4 + 0x10000) == 0xFFFF) {
             extern u32 lbl_801EADC8;
             vectorPtr = (void*)&lbl_801EADC8;
         } else {
-            void* globalData = lbl_8032ED50;
-            void* arrayPtr = *((void**)((u8*)globalData + 0xD4));
+            void* arrayPtr = *(void**)((u8*)lbl_8032ED50 + 0xD4);
             u32 index = objData->field_4 << 4;
-            void* entry = (u8*)arrayPtr + index;
-            void* basePtr = *((void**)((u8*)entry + 0x4));
-            vectorPtr = (u8*)objData->data + (u32)basePtr + 0x80;
+            u32 baseOffset = *(u32*)((u8*)arrayPtr + index + 4);
+            vectorPtr = (u8*)objData->data + baseOffset + 0x80;
         }
-        
-        PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + (u32)dataPtr + 0x80);
+
         objPtr->vecPtr = vectorPtr;
     }
-    
-    PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + (u32)dataPtr + 0x80);
+
     f32* src = (f32*)objPtr->vecPtr;
     objPtr->x = src[0];
-    objPtr->y = src[1]; 
+    objPtr->y = src[1];
     objPtr->z = src[2];
 }

--- a/src/pppWDrawMatrixLoop.cpp
+++ b/src/pppWDrawMatrixLoop.cpp
@@ -13,11 +13,8 @@
  */
 void pppWDrawMatrixLoop(_pppPObject* param_1)
 {
-    Vec* inVec;
-    
-    PSMTXConcat(ppvCameraMatrix0, param_1->m_localMatrix.value, *(Mtx*)((char*)param_1 + 0x34));
-    PSVECScale((Vec*)((char*)param_1 + 0x34), (Vec*)((char*)param_1 + 0x34), pppMngStPtr->m_scale.x);
-    PSVECScale((Vec*)((char*)param_1 + 0x38), (Vec*)((char*)param_1 + 0x38), pppMngStPtr->m_scale.y);
-    inVec = (Vec*)((char*)param_1 + 0x3c);
-    PSVECScale(inVec, inVec, pppMngStPtr->m_scale.z);
+    PSMTXConcat(ppvCameraMatrix0, param_1->m_localMatrix.value, (param_1 + 1)->m_localMatrix.value);
+    PSVECScale((Vec*)((char*)param_1 + 0x40), (Vec*)((char*)param_1 + 0x40), (pppMngStPtr->m_scale).x);
+    PSVECScale((Vec*)((char*)param_1 + 0x50), (Vec*)((char*)param_1 + 0x50), (pppMngStPtr->m_scale).y);
+    PSVECScale((Vec*)((char*)param_1 + 0x60), (Vec*)((char*)param_1 + 0x60), (pppMngStPtr->m_scale).z);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppPObjPoint` pointer/dataflow materialization so the point object base is computed once and reused.
- Reworked `pppWDrawMatrixLoop` to match neighboring matrix-loop coding patterns (`(param_1 + 1)->m_localMatrix.value` and direct scale calls without temporary pointer locals).

## Functions improved
- `main/pppPObjPoint` / `pppPObjPoint`
  - Before: `64.675674%` (30 mismatched instruction entries)
  - After: `78.37838%` (14 mismatched instruction entries)
- `main/pppWDrawMatrixLoop` / `pppWDrawMatrixLoop`
  - Before: `46.8%` (27 mismatched instruction entries)
  - After: `78.4%` (14 mismatched instruction entries)

## Match evidence
- Built with `ninja` after edits (build successful).
- Objdiff commands used:
  - `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o - pppPObjPoint`
  - `build/tools/objdiff-cli diff -p . -u main/pppWDrawMatrixLoop -o - pppWDrawMatrixLoop`
- Both symbols show substantial reduction in instruction-level diffs and significantly higher match percentages.

## Plausibility rationale
- Changes are type/signedness/pointer-expression cleanup and control/dataflow simplification rather than contrived compiler coaxing.
- `pppWDrawMatrixLoop` now follows established style already present in related functions (`pppWDrawMatrix`, `pppWDrawMatrixFront`), making it a plausible original-source form.
- `pppPObjPoint` now expresses a natural single-base-object flow with explicit serialized offset use, avoiding repeated recomputation and preserving readability.

## Technical details
- `pppPObjPoint`: computing `PppPointObj*` once and tightening offset reads (`lbl_8032ED50 + 0xD4`, entry `+4`) improved register/alias behavior and removed redundant diff noise.
- `pppWDrawMatrixLoop`: removing the temporary `Vec*` and using direct destination addresses (`+0x40/+0x50/+0x60`) aligned call setup and reduced prologue/register churn in diff output.
