### PR TITLE
pppWDrawMatrix: improve match by aligning raw matrix/scale accesses

### DIFF
--- a/src/pppWDrawMatrix.cpp
+++ b/src/pppWDrawMatrix.cpp
@@ -14,11 +14,12 @@
  */
 void pppWDrawMatrix(_pppPObject* pppPObject)
 {
-    Vec* inVec;
-    
-    PSMTXConcat(ppvCameraMatrix0, pppPObject->m_localMatrix.value, *(Mtx*)((char*)pppPObject + 0x40));
-    PSVECScale((Vec*)((char*)pppPObject + 0x40), (Vec*)((char*)pppPObject + 0x40), (pppMngStPtr->m_scale).x);
-    PSVECScale((Vec*)((char*)pppPObject + 0x50), (Vec*)((char*)pppPObject + 0x50), (pppMngStPtr->m_scale).y);
-    inVec = (Vec*)((char*)pppPObject + 0x60);
-    PSVECScale(inVec, inVec, (pppMngStPtr->m_scale).z);
+    char* base = (char*)pppPObject;
+    Mtx* worldMtx = (Mtx*)(base + 0x40);
+
+    PSMTXConcat(ppvCameraMatrix0, *(Mtx*)(base + 0x4), *worldMtx);
+
+    PSVECScale((Vec*)worldMtx, (Vec*)worldMtx, *(float*)((char*)pppMngStPtr + 0x64));
+    PSVECScale((Vec*)(base + 0x50), (Vec*)(base + 0x50), *(float*)((char*)pppMngStPtr + 0x68));
+    PSVECScale((Vec*)(base + 0x60), (Vec*)(base + 0x60), *(float*)((char*)pppMngStPtr + 0x6c));
 }


### PR DESCRIPTION
## Summary
- Reworked `pppWDrawMatrix` pointer math to mirror likely original raw-layout access.
- Switched from struct-field based matrix source access to explicit byte offsets (`+0x4`, `+0x40`).
- Read scale factors from `pppMngStPtr` using direct offsets (`+0x64`, `+0x68`, `+0x6c`).

## Functions improved
- Unit: `main/pppWDrawMatrix`
- Symbol: `pppWDrawMatrix`

## Match evidence
- `pppWDrawMatrix`: **46.866665% -> 60.666668%**
- Size relationship improved toward target call/argument ordering while preserving behavior.

## Technical details
- Objdiff now aligns the matrix and scale access pattern much more closely:
  - world matrix pointer at `obj + 0x40`
  - source matrix at `obj + 0x4`
  - three `PSVECScale` calls using sequential scale offsets in manager state.
- Remaining mismatches are mostly symbol-binding/prologue details, not the core pointer arithmetic flow.

## Plausibility rationale
- The resulting code is straightforward engine-style pointer/offset access for packed runtime objects.
- No contrived temporaries or compiler-coax-only tricks were introduced; changes reflect plausible original low-level source style.
