### PR TITLE
main/pppDrawMdlTs: bring pppDrawMdlTs to 100% match

### DIFF
--- a/src/pppDrawMdlTs.cpp
+++ b/src/pppDrawMdlTs.cpp
@@ -70,8 +70,11 @@ void pppDrawMdlTsCon3(struct _pppPObject* obj, struct PDrawMdlTs* data)
  */
 void pppDrawMdlTs(struct _pppPObject* obj, struct PDrawMdlTs* data, struct PDrawMdlTs* param)
 {
+    struct PDrawMdlTs* stream = param;
+    struct PDrawMdlTs* input = data;
+
     // Get texture coordinate offset 
-    void* inner = *((void**)((char*)data + 0xc));
+    void* inner = *((void**)((char*)stream + 0xc));
     void* inner2 = *((void**)((char*)inner + 0x8));
     float* texCoords = (float*)((char*)obj + (int)inner2 + 0x80);
     
@@ -87,19 +90,19 @@ void pppDrawMdlTs(struct _pppPObject* obj, struct PDrawMdlTs* data, struct PDraw
     texCoords[3] += texCoords[4];  // offset 0xc += offset 0x10
     
     // Check if object id matches
-    int objId = *((int*)param);
+    int objId = *((int*)input);
     int objFieldC = *((int*)((char*)obj + 0xc));
     if (objId != objFieldC) {
         return;
     }
     
     // Apply parameter offsets to texture coordinates
-    texCoords[0] += *((float*)((char*)param + 0x14));  // offset 0x0
-    texCoords[1] += *((float*)((char*)param + 0x18));  // offset 0x4
-    texCoords[2] += *((float*)((char*)param + 0x1c));  // offset 0x8
-    texCoords[3] += *((float*)((char*)param + 0x20));  // offset 0xc
-    texCoords[4] += *((float*)((char*)param + 0x24));  // offset 0x10
-    texCoords[5] += *((float*)((char*)param + 0x28));  // offset 0x14
+    texCoords[0] += *((float*)((char*)input + 0x14));  // offset 0x0
+    texCoords[1] += *((float*)((char*)input + 0x18));  // offset 0x4
+    texCoords[2] += *((float*)((char*)input + 0x1c));  // offset 0x8
+    texCoords[3] += *((float*)((char*)input + 0x20));  // offset 0xc
+    texCoords[4] += *((float*)((char*)input + 0x24));  // offset 0x10
+    texCoords[5] += *((float*)((char*)input + 0x28));  // offset 0x14
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `pppDrawMdlTs` argument usage in `src/pppDrawMdlTs.cpp` to reflect distinct roles for the two `PDrawMdlTs*` inputs.
- Introduced local aliases (`stream` and `input`) and used them consistently for stream-offset lookup vs additive input values.
- No behavioral expansion; this is a parameter-role alignment/refactor for matching.

## Functions Improved
- Unit: `main/pppDrawMdlTs`
- Symbol: `pppDrawMdlTs` (208b)
  - Before: `98.65385%`
  - After: `100.0%`

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawMdlTs -o - pppDrawMdlTs`
- Function result:
  - `pppDrawMdlTs`: `98.65385% -> 100.0%`
- Unit `.text` result:
  - `87.60156% -> 88.14844%`

## Plausibility Rationale
- Both non-object parameters are the same pointer type and appear to represent different logical data streams.
- Separating them into explicit local roles (`stream` vs `input`) is source-plausible and matches common original-code intent better than anonymous offset arithmetic.
- This is not compiler coaxing via contrived temporaries; it clarifies data-flow semantics while improving exact assembly match.

## Technical Details
- The prior near-match had persistent argument-level mismatches in the second half of `pppDrawMdlTs`.
- Rebinding argument roles aligned register/data-flow usage for the stream pointer lookup (`+0xc/+0x8`) and additive value loads (`+0x14..+0x28`), resolving the remaining mismatch to full match.

## Validation
- `ninja` succeeds.
- objdiff verification was run after rebuild.
