### PR TITLE
p_game: implement draw1/draw2 CGamePcs wrappers

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -132,7 +132,7 @@ void CGamePcs::draw0()
  */
 void CGamePcs::draw1()
 {
-	// TODO
+    game.Draw2();
 }
 
 /*
@@ -142,7 +142,7 @@ void CGamePcs::draw1()
  */
 void CGamePcs::draw2()
 {
-	// TODO
+    game.Draw3();
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two missing `CGamePcs` draw wrappers in `src/p_game.cpp`:
- `CGamePcs::draw1()` now calls `game.Draw2()`
- `CGamePcs::draw2()` now calls `game.Draw3()`

## Functions improved
Unit: `main/p_game`
- `draw1__8CGamePcsFv`: `10.0%` -> `83.5%`
- `draw2__8CGamePcsFv`: `10.0%` -> `83.5%`

## Match evidence
Measured with:
`build/tools/objdiff-cli diff -p . -u main/p_game -o - draw1__8CGamePcsFv`

Before:
- `"name":"draw1__8CGamePcsFv" ... "match_percent":10.0`
- `"name":"draw2__8CGamePcsFv" ... "match_percent":10.0`

After:
- `"name":"draw1__8CGamePcsFv" ... "match_percent":83.5`
- `"name":"draw2__8CGamePcsFv" ... "match_percent":83.5`

Objdiff now shows the expected callsites to `Draw2__5CGameFv` and `Draw3__5CGameFv` with wrapper prologue/epilogue alignment.

## Plausibility rationale
These are straightforward member wrapper methods delegating to the embedded `CGame` instance (`game`). This is natural source-level behavior for `CGamePcs` and avoids compiler-coaxing patterns.

## Technical details
The previous `TODO` stubs compiled as empty returns, which explained the very low match. Replacing them with direct `CGame` method calls restores expected behavior and significantly improves function-level assembly alignment.
