### PR TITLE
Match TRK UDP_Stubs return behavior and symbol layout

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/UDP_Stubs.c
+++ b/src/TRK_MINNOW_DOLPHIN/UDP_Stubs.c
@@ -2,126 +2,126 @@
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c931c
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_post_stop(void)
+int udp_cc_initialize(void)
 {
-	// TODO
+	return -1;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c9314
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_pre_continue(void)
+int udp_cc_shutdown(void)
 {
-	// TODO
+	return -1;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c930c
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_peek(void)
+int udp_cc_open(void)
 {
-	// TODO
+	return -1;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c9304
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_write(void)
+int udp_cc_close(void)
 {
-	// TODO
+	return -1;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c92fc
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_read(void)
+int udp_cc_read(void)
 {
-	// TODO
+	return 0;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c92f4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_close(void)
+int udp_cc_write(void)
 {
-	// TODO
+	return 0;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c92ec
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_open(void)
+int udp_cc_peek(void)
 {
-	// TODO
+	return 0;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c92e4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_shutdown(void)
+int udp_cc_pre_continue(void)
 {
-	// TODO
+	return -1;
 }
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801c92dc
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void udp_cc_initialize(void)
+int udp_cc_post_stop(void)
 {
-	// TODO
+	return -1;
 }


### PR DESCRIPTION
## Summary
- Updated `src/TRK_MINNOW_DOLPHIN/UDP_Stubs.c` to match PAL stub behavior by:
  - changing stub signatures from `void` to `int`
  - returning explicit constants (`-1` for init/control/close stubs, `0` for read/write/peek stubs)
  - reordering function definitions to align with CodeWarrior emission order in this unit
- Filled PAL address/size metadata in each function header.

## Functions improved
Unit: `main/TRK_MINNOW_DOLPHIN/UDP_Stubs`

- `udp_cc_post_stop`: 50.0% -> 100.0%
- `udp_cc_pre_continue`: 50.0% -> 100.0%
- `udp_cc_peek`: 50.0% -> 100.0%
- `udp_cc_write`: 50.0% -> 100.0%
- `udp_cc_read`: 50.0% -> 100.0%
- `udp_cc_close`: 50.0% -> 100.0%
- `udp_cc_open`: 50.0% -> 100.0%
- `udp_cc_shutdown`: 50.0% -> 100.0%
- `udp_cc_initialize`: 50.0% -> 100.0%

## Match evidence
- `objdiff` before: each symbol had 50.0% match due instruction mismatch against target (`blr` only vs missing return immediate in comparison orientation).
- `objdiff` after: `.text` match is 100.0% for unit and all nine symbols are 100.0% with exact `li r3, <const>; blr` sequences.
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/UDP_Stubs -o - udp_cc_initialize`
  - `ninja` (build passes; progress increased accordingly).

## Plausibility rationale
- This is a straightforward TRK UDP stub implementation pattern: unimplemented control functions returning failure (`-1`) and read/write/peek stubs returning neutral success (`0`).
- No compiler-coaxing constructs were introduced; code remains simple and maintainable.

## Technical details
- In this compilation context, function emission order is reversed from source order for this file. Reordering definitions was necessary to align symbol layout with the expected object.
- Final full build result remains clean with improved SDK code match.
