### PR TITLE
Improve matching for pppGetRotMatrixX

### DIFF
--- a/src/pppGetRotMatrixX.cpp
+++ b/src/pppGetRotMatrixX.cpp
@@ -1,18 +1,22 @@
 #include "ffcc/pppGetRotMatrixX.h"
 
-#include "ffcc/pppsintbl.h"
+extern float ppvSinTbl[];
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8005f794
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppGetRotMatrixX(pppFMATRIX& mtx, long angle)
 {
-    float zero = 0.0f; // FLOAT_8032feb4
-    float one = 1.0f; // FLOAT_8032feb0
-    float sinValue = pppSinFromTable(angle);
-    float cosValue = pppCosFromTable(angle);
+    float one = 1.0f;
+    float zero = 0.0f;
+    float sinValue = *(float*)((unsigned char*)ppvSinTbl + (angle & 0xFFFC));
+    float cosValue = *(float*)((unsigned char*)ppvSinTbl + ((angle + 0x4000) & 0xFFFC));
 
     mtx.value[0][0] = one;
     mtx.value[0][1] = zero;
@@ -23,7 +27,7 @@ void pppGetRotMatrixX(pppFMATRIX& mtx, long angle)
     mtx.value[1][1] = cosValue;
     mtx.value[1][2] = -sinValue;
     mtx.value[1][3] = zero;
-	
+
     mtx.value[2][0] = zero;
     mtx.value[2][1] = sinValue;
     mtx.value[2][2] = cosValue;


### PR DESCRIPTION
## Summary
- Reworked `pppGetRotMatrixX` to load sine/cosine directly from `ppvSinTbl` with masked angle indexing.
- Removed dependency on inline trig helpers/table from `pppsintbl.h` for this unit.
- Updated the function `--INFO--` block with PAL address/size metadata.

## Functions improved
- Unit: `main/pppGetRotMatrixX`
- Symbol: `pppGetRotMatrixX__FR10pppFMATRIXl`

## Match evidence
- Before: `50.695652%` (`build/tools/objdiff-cli diff -p . -u main/pppGetRotMatrixX -o - pppGetRotMatrixX__FR10pppFMATRIXl`)
- After: `98.695656%` (same command after change)
- Residual diff: 6 `DIFF_ARG_MISMATCH` entries; no structural instruction insert/delete mismatches.

## Plausibility rationale
- Direct table lookup via `ppvSinTbl` is consistent with other ppp codepaths and with Ghidra’s recovered access pattern for this symbol.
- The resulting implementation remains straightforward source-level math for constructing an X-rotation matrix, rather than contrived compiler coaxing.

## Technical details
- Used byte-offset indexing: `(angle & 0xFFFC)` for sine and `((angle + 0x4000) & 0xFFFC)` for cosine.
- Kept matrix write layout unchanged except for data source alignment to the expected table path.
