### PR TITLE
main/pppPoint: match pppPoint and pppPointCon

### DIFF
--- a/src/pppPoint.cpp
+++ b/src/pppPoint.cpp
@@ -1,49 +1,50 @@
 #include "ffcc/pppPoint.h"
 
-// Based on assembly analysis - global enabled state
-static int pppPointEnabled = 0;
+extern int lbl_8032ED70;
 
 /*
  * --INFO--
  * PAL Address: 0x80065cd8
  * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppPointCon(PppData* a, PppData* b)
 {
-	// Assembly shows access to b offset 0xc (which is &values[2]), then deref as pointer
-	void** ptrLoc = (void**)&b->values[2];
-	void* ptr = *ptrLoc;
-	float* dst = (float*)((char*)ptr + 0x80);
-	
-	dst[0] = 0.0f; 
-	dst[1] = 0.0f; 
-	dst[2] = 0.0f;
+	int* dataOffset = *(int**)&b->values[2];
+	float* dst = (float*)((char*)a + *dataOffset + 0x80);
+	float value = 0.0f;
+
+	dst[2] = value;
+	dst[1] = value;
+	dst[0] = value;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x80065cfc
  * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppPoint(PppData* a, PppData* b, PppData* c)
 {
-	// Original checks global enabled state
-	if (pppPointEnabled == 0) {
+	if (lbl_8032ED70 != 0) {
 		return;
 	}
-	
-	// Compare b->id with a->values[2] (reinterpreted as int)
+
 	if (b->id != *(int*)&a->values[2]) {
 		return;
 	}
-	
-	// Access c pointer stored at values[2] location + 0x80 offset
-	void** ptrLoc = (void**)&c->values[2];
-	void* ptr = *ptrLoc;
-	float* dst = (float*)((char*)ptr + 0x80);
-	
-	// Vector addition
-	dst[0] += b->values[2]; // x 
-	dst[1] += b->values[3]; // y  
-	dst[2] += b->values[2]; // z - reuses values[2]
+
+	int* dataOffset = *(int**)&c->values[2];
+	float* dst = (float*)((char*)a + *dataOffset + 0x80);
+
+	dst[0] += b->values[1];
+	dst[1] += b->values[2];
+	dst[2] += b->values[3];
 }


### PR DESCRIPTION
## Summary
- Reworked `src/pppPoint.cpp` to use the shared PPP global flag (`lbl_8032ED70`) instead of a local static.
- Updated pointer/addressing logic to the standard PPP pattern: `obj + *offset + 0x80`.
- Corrected component indexing/order for `pppPoint` accumulation and `pppPointCon` initialization.
- Normalized function info headers to include PAL/EN/JP fields with TODO placeholders for non-PAL versions.

## Functions improved
- Unit: `main/pppPoint`
- `pppPointCon`
  - Before: `63.555557%` (size `24`)
  - After: `100.0%` (size `36`)
- `pppPoint`
  - Before: `85.25%` (size `84`)
  - After: `100.0%` (size `96`)

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppPoint -o - pppPointCon`
  - `build/tools/objdiff-cli diff -p . -u main/pppPoint -o - pppPoint`
- Current diff results show both target symbols at exact size and `100%` instruction match.

## Plausibility rationale
- The new code follows established patterns already used across `ppp*` units in this repo (global state guard + base-object offset addressing).
- Changes are type/control-flow corrections rather than compiler-only coercions, and produce source that reads as normal gameplay runtime logic.

## Technical details
- `pppPointCon` now resolves an offset through `b->values[2]`, applies `+0x80`, then zeros the 3-float vector in reverse store order to match codegen.
- `pppPoint` now exits when `lbl_8032ED70 != 0`, compares `b->id` with `*(int*)&a->values[2]`, resolves destination via `c->values[2]`, and accumulates from `b->values[1..3]`.
