### PR TITLE
ax/AXOut: fix AXRegisterCallback signature to match target

### DIFF
--- a/include/dolphin/ax.h
+++ b/include/dolphin/ax.h
@@ -282,7 +282,7 @@ u32 AXGetMode(void);
 extern AXPROFILE __AXLocalProfile;
 
 void AXSetStepMode(u32 i);
-AXCallback AXRegisterCallback(AXCallback callback);
+void AXRegisterCallback(AXCallback callback);
 
 // AXProf
 void AXInitProfile(AXPROFILE* profile, u32 maxProfiles);

--- a/src/ax/AXOut.c
+++ b/src/ax/AXOut.c
@@ -225,8 +225,15 @@ void __AXOutQuit(void) {
     OSRestoreInterrupts(old);
 }
 
-AXCallback AXRegisterCallback(AXCallback callback) {
-    AXCallback oldCB = __AXUserFrameCallback;
+/*
+ * --INFO--
+ * PAL Address: 0x80192D98
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void AXRegisterCallback(AXCallback callback) {
     __AXUserFrameCallback = callback;
-    return oldCB;
 }


### PR DESCRIPTION
## Summary
- Changed AXRegisterCallback declaration/definition from returning AXCallback to returning void.
- Simplified function body to direct callback store only.
- Added PAL metadata header for the updated function.

## Functions improved
- Unit: main/ax/AXOut
- Symbol: AXRegisterCallback

## Match evidence
- objdiff (build/tools/objdiff-cli diff -p . -u main/ax/AXOut -o - AXRegisterCallback):
  - Before: 0.0%
  - After: 97.5%
  - Remaining delta: relocation target label mismatch only (stw r3, ...@sda21), instruction shape/size now matches (8b).
- build/GCCP01/report.json function fuzzy match:
  - AXRegisterCallback: 100.0% (size 8)
- Unit fuzzy match (selector/report context):
  - main/ax/AXOut improved from ~82.6% to 83.07%.

## Plausibility rationale
- The callsite in src/RedSound/RedDriver.cpp does not use a return value, so void is source-plausible.
- Ghidra PAL reference (resources/ghidra-decomp-1-31-2026/80192d98_AXRegisterCallback.c) shows an 8-byte function that only writes the callback pointer and returns.
- The change removes a non-observed temporary/return path instead of adding compiler-coaxing constructs.

## Technical details
- Updated API declaration in include/dolphin/ax.h and implementation in src/ax/AXOut.c consistently.
- Rebuilt with ninja and re-verified with objdiff and report.json.
