### PR TITLE
main/quadobj: improve onDraw matching

### DIFF
--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/quadobj.h"
+#include "ffcc/color.h"
 
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
@@ -31,29 +32,36 @@ void CGQuadObj::onDestroy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80119788
+ * PAL Size: 424b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGQuadObj::onDraw()
 {
     if (m_vertexCount != 0 && (CFlatFlags & 0x10000) != 0) {
-        u32 white = 0xFFFFFFFF;
-        GXSetChanMatColor(GX_COLOR0A0, *(GXColor*)&white);
+        CColor white(0xFF, 0xFF, 0xFF, 0xFF);
+        GXSetChanMatColor(GX_COLOR0A0, white.color);
         GXLoadPosMtxImm(gFlatPosMtx, GX_PNMTX0);
         GXBegin(GX_TRIANGLES, GX_VTXFMT0, (u32)m_vertexCount * 6);
 
         int i = 0;
-        while (i < (int)m_vertexCount) {
-            int next = (i + 1) % (int)m_vertexCount;
-            
-            GXPosition3f32(m_vertices[i].x, m_yBase, m_vertices[i].z);
-            GXPosition3f32(m_vertices[next].x, m_yBase, m_vertices[next].z);
-            GXPosition3f32(m_vertices[i].x, m_yBase + m_yHeight, m_vertices[i].z);
-            GXPosition3f32(m_vertices[next].x, m_yBase + m_yHeight, m_vertices[next].z);
-            GXPosition3f32(m_vertices[i].x, m_yBase, m_vertices[i].z);
-            GXPosition3f32(m_vertices[i].x, m_yBase + m_yHeight, m_vertices[i].z);
-            
+        QuadVertex* pVertex = m_vertices;
+        while (i < (int)(u32)m_vertexCount) {
+            int nextIdx = i + 1;
             i++;
+            GXPosition3f32(pVertex->x, m_yBase, pVertex->z);
+            int next = nextIdx - (nextIdx / (int)(u32)m_vertexCount) * (u32)m_vertexCount;
+            GXPosition3f32(m_vertices[next].x, m_yBase, m_vertices[next].z);
+            GXPosition3f32(pVertex->x, m_yBase + m_yHeight, pVertex->z);
+            next = nextIdx - (nextIdx / (int)(u32)m_vertexCount) * (u32)m_vertexCount;
+            GXPosition3f32(m_vertices[next].x, m_yBase + m_yHeight, m_vertices[next].z);
+            GXPosition3f32(pVertex->x, m_yBase, pVertex->z);
+            QuadVertex* current = pVertex;
+            pVertex++;
+            GXPosition3f32(current->x, m_yBase + m_yHeight, current->z);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `CGQuadObj::onDraw` in `src/quadobj.cpp` to better match original codegen shape.
- Switched channel color setup to `CColor(0xFF, 0xFF, 0xFF, 0xFF)` and passed `white.color` to `GXSetChanMatColor`.
- Restructured vertex emission loop to pointer-walk vertices and use explicit modulo arithmetic pattern for the next index.
- Added PAL metadata block for `onDraw` (`0x80119788`, `424b`).

## Functions Improved
- Unit: `main/quadobj`
- Symbol: `onDraw__9CGQuadObjFv`

## Match Evidence
- `onDraw__9CGQuadObjFv`: `69.21698%` -> `88.36793%` (`+19.15095%`)
- `isInner__9CGQuadObjFP3Vec`: unchanged at `91.5625%`
- Validation command used:
  - `build/tools/objdiff-cli diff -p . -u main/quadobj -o - onDraw__9CGQuadObjFv`

## Plausibility Rationale
- Changes are type/control-flow aligned with existing engine style (stack color object, straightforward pointer iteration over fixed-size vertex arrays).
- No artificial temporaries tied to raw offsets; logic remains readable and consistent with original function intent (emit two-triangle wall faces per edge).

## Technical Details
- Main improvement came from aligning instruction layout in the draw loop (fewer structural inserts/deletes in objdiff).
- Diff profile shifted from many structural mismatches to mostly argument-level register/allocation differences.
