### PR TITLE
card/CARDRdwr: match write path with fixed CARD_PAGE_SIZE semantics

### DIFF
--- a/src/card/CARDRdwr.c
+++ b/src/card/CARDRdwr.c
@@ -59,9 +59,9 @@ static void BlockWriteCallback(s32 chan, s32 result) {
 
     card = &__CARDBlock[chan];
     if (result >= 0) {
-        card->xferred += card->pageSize;
-        card->addr += card->pageSize;
-        ((u8*)card->buffer) += card->pageSize;
+        card->xferred += CARD_PAGE_SIZE;
+        card->addr += CARD_PAGE_SIZE;
+        card->buffer = (u8*)card->buffer + CARD_PAGE_SIZE;
 
         if (--card->repeat > 0) {
             result = __CARDWritePage(chan, BlockWriteCallback);
@@ -86,14 +86,14 @@ s32 __CARDWrite(s32 chan, u32 addr, s32 length, void* dst, CARDCallback callback
     CARDControl* card;
     card = &__CARDBlock[chan];
 
-    ASSERTLINE(153, 0 < length && length % card->pageSize == 0);
+    ASSERTLINE(153, 0 < length && length % CARD_PAGE_SIZE == 0);
     ASSERTLINE(154, 0 <= chan && chan < 2);
     
     if (card->attached == 0) {
         return CARD_RESULT_NOCARD;
     }
     card->xferCallback = callback;
-    card->repeat = (length / card->pageSize);
+    card->repeat = (length / CARD_PAGE_SIZE);
     card->addr = addr;
     card->buffer = dst;
     return __CARDWritePage(chan, BlockWriteCallback);


### PR DESCRIPTION
## Summary
- Updated `src/card/CARDRdwr.c` write-path arithmetic/counting to use `CARD_PAGE_SIZE` (`0x80`) explicitly.
- Replaced cast-assignment buffer increment with explicit pointer reassignment: `card->buffer = (u8*)card->buffer + CARD_PAGE_SIZE`.
- Kept behavior and control flow unchanged.

## Functions improved
- `main/card/CARDRdwr::BlockWriteCallback`: **77.545456% -> 100.0%**
- `main/card/CARDRdwr::__CARDWrite`: **79.6% -> 100.0%**

## Match evidence
- Unit `main/card/CARDRdwr` now has all four functions at 100% in `build/GCCP01/report.json`.
- Project code match moved from **170,144 -> 170,464** bytes.
- Matched functions moved from **1102 -> 1104**.

## Plausibility rationale
- Card page writes are fixed-size hardware operations (`CARD_PAGE_SIZE = 0x80`), so using the constant in transfer accounting and repeat calculation is source-plausible for this SDK path.
- The change removes dependence on runtime `card->pageSize` in this low-level page-write path while preserving semantics.

## Technical details
- Adjusted in `src/card/CARDRdwr.c`:
  - `card->xferred`, `card->addr`, and `card->buffer` increments in `BlockWriteCallback`
  - write precondition assert and `card->repeat` computation in `__CARDWrite`
- `ninja` build passes; report/objdiff show real assembly alignment improvements.
