### PR TITLE
main/ansi_files: improve __flush_line_buffered_output_files to 96.57%

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/ansi_files.c
+++ b/src/MSL_C/PPCEABI/bare/H/ansi_files.c
@@ -214,16 +214,12 @@ void __init_file(FILE* file, file_modes mode, unsigned char* buffer, int buffer_
  * JP Size: TODO
  */
 int __flush_line_buffered_output_files(void) {
-    FILE* file = &__files[0];
     int result = 0;
+    FILE* file = &__files[0];
     unsigned char* file_bytes;
     unsigned short mode_bits;
 
-    while (1) {
-        if (file == NULL) {
-            break;
-        }
-
+    while (file != NULL) {
         file_bytes = (unsigned char*)file;
         mode_bits = *(unsigned short*)(file_bytes + 4);
         if ((((mode_bits >> 6) & 7) != 0) && (((file_bytes[4] >> 1) & 1) != 0) &&


### PR DESCRIPTION
## Summary
- Refactored `__flush_line_buffered_output_files` loop shape from `while (1) { if (file == NULL) break; ... }` to `while (file != NULL) { ... }`.
- Reordered local declarations so `result` is initialized before `file`.
- Kept behavior identical; no added comments or debug artifacts.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/ansi_files`
- Function: `__flush_line_buffered_output_files` (PAL 0x801b2cc4, 140b)
- Match: **82.85714% -> 96.57143%** (+13.71429)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/ansi_files -o - __flush_line_buffered_output_files`
- Diff profile moved from:
  - before: 6 `DIFF_REPLACE`, 7 `DIFF_ARG_MISMATCH`, 1 `DIFF_INSERT`, 1 `DIFF_DELETE`
  - after: 2 `DIFF_REPLACE` only
- Other functions in this unit remained unchanged (`__init_file` 77.96364%, `__find_unopened_file` 78.888885).

## Plausibility rationale
- This is a source-natural cleanup (direct loop condition + straightforward local ordering), not compiler-coaxing.
- The resulting C is idiomatic for file list traversal and matches existing project style.
- Remaining mismatch is confined to two instructions in one condition-extraction sequence, suggesting expression-lowering detail rather than structural divergence.

## Technical details
- The prior loop form emitted extra branch/loop-control differences and register-usage mismatches in objdiff.
- Converting to `while (file != NULL)` aligned the loop control flow and eliminated all arg/insert/delete diffs in this function.
