### PR TITLE
gx/GXMisc: improve GXPokeAlphaRead and GXPokeDstAlpha matches

### DIFF
--- a/src/gx/GXMisc.c
+++ b/src/gx/GXMisc.c
@@ -197,11 +197,17 @@ void GXPokeAlphaMode(GXCompare func, u8 threshold) {
 
 void GXPokeAlphaRead(GXAlphaReadMode mode) {
     u32 reg;
+    u32 mode_bits;
+    u32 one;
+    u32 out;
 
     reg = 0;
-    SET_REG_FIELD(693, reg, 2, 0, mode);
-    SET_REG_FIELD(693, reg, 1, 2, 1);
-    GX_SET_PE_REG(4, reg);
+    mode_bits = mode;
+    SET_REG_FIELD(693, reg, 2, 0, mode_bits);
+    one = 1;
+    out = reg;
+    SET_REG_FIELD(693, out, 1, 2, one);
+    GX_SET_PE_REG(4, out);
 }
 
 void GXPokeAlphaUpdate(GXBool update_enable) {
@@ -235,11 +241,18 @@ void GXPokeColorUpdate(GXBool update_enable) {
 }
 
 void GXPokeDstAlpha(GXBool enable, u8 alpha) {
-    u32 reg = 0;
+    u32 reg;
+    u32 alpha_bits;
+    u32 enable_bits;
+    u32 out;
 
-    SET_REG_FIELD(747, reg, 8, 0, alpha);
-    SET_REG_FIELD(748, reg, 1, 8, enable);
-    GX_SET_PE_REG(2, reg);
+    reg = 0;
+    alpha_bits = alpha;
+    SET_REG_FIELD(747, reg, 8, 0, alpha_bits);
+    enable_bits = enable;
+    out = reg;
+    SET_REG_FIELD(748, out, 1, 8, enable_bits);
+    GX_SET_PE_REG(2, out);
 }
 
 void GXPokeDither(GXBool dither) {


### PR DESCRIPTION
## Summary
Refined register-construction code shape in `src/gx/GXMisc.c` for two low-match PE poke helpers by introducing explicit temporaries for field values and final writeback value.

## Functions improved
- Unit: `main/gx/GXMisc`
- `GXPokeAlphaRead`: **13.0% -> 34.0%**
- `GXPokeDstAlpha`: **0.0% -> 42.0%**
- Secondary improvement from symbol alignment in same unit:
  - `GXPokeBlendMode`: **41.14706% -> 43.794117%**

## Match evidence
Objdiff commands used:
- `build/tools/objdiff-cli diff -p . -u main/gx/GXMisc -o - GXPokeAlphaRead`
- `build/tools/objdiff-cli diff -p . -u main/gx/GXMisc -o - GXPokeDstAlpha`

Unit text match:
- `main/gx/GXMisc .text`: **87.17996% -> 88.00818%**

Build verification:
- `ninja` succeeds (`build/GCCP01/main.dol: OK` via normal build pipeline output)

## Plausibility rationale
Changes are source-plausible and idiomatic for this codebase: they keep the same logical register fields and hardware writes, but use explicit intermediate variables (`mode_bits`, `alpha_bits`, `enable_bits`, `out`) instead of relying on tighter expression folding. This mirrors common original-source patterns in low-level SDK-style code while improving compiler output alignment.

## Technical details
- `GXPokeAlphaRead`: split mode field composition and constant-bit composition into separate temporaries before final store.
- `GXPokeDstAlpha`: split alpha and enable field composition with explicit intermediate writeback register.
- No behavior change intended; only register build shape was adjusted.
