### PR TITLE
MSL_C: improve __find_unopened_file match in ansi_files

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/ansi_files.c
+++ b/src/MSL_C/PPCEABI/bare/H/ansi_files.c
@@ -137,7 +137,7 @@ unsigned int __flush_all() {
  */
 FILE* __find_unopened_file(void) {
     FILE* file = &__files[0];
-    FILE* prev = NULL;
+    FILE* prev;
 
     while (file != NULL) {
         if (file->file_mode.file_kind == __closed_file) {
@@ -148,14 +148,12 @@ FILE* __find_unopened_file(void) {
     }
 
     file = (FILE*)malloc(0x50);
-    if (file == NULL) {
-        return NULL;
+    if (file != NULL) {
+        memset(file, 0, 0x50);
+        file->is_dynamically_allocated = 1;
+
+        prev->next_file_struct = file;
     }
-
-    memset(file, 0, 0x50);
-    file->is_dynamically_allocated = 1;
-
-    prev->next_file_struct = file;
 
     return file;
 }


### PR DESCRIPTION
## Summary
- Refactored `__find_unopened_file` in `src/MSL_C/PPCEABI/bare/H/ansi_files.c` to use a tighter allocation path.
- Removed explicit `prev = NULL` initialization and folded allocation work under `if (file != NULL)`.
- Kept behavior equivalent: function still returns the found/allocated `FILE*` or `NULL` on allocation failure.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/ansi_files`
- Symbol: `__find_unopened_file`
  - Before: `78.888885%`
  - After: `81.94444%`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/ansi_files -o - __find_unopened_file`
- Result:
  - Match increased by `+3.055555` points.
  - Function size remains aligned at `144b` on the target side.
  - Diff markers reduced in control-flow-heavy regions (fewer inserts/opcode branch mismatches in the malloc/failure tail path).

## Plausibility rationale
- The change is idiomatic C and reads as normal library/runtime code, not compiler-coaxing.
- It simplifies control flow around allocation without introducing unnatural temporaries or opaque tricks.
- The logic matches expected intent: find a closed slot, otherwise allocate/zero/init a new slot and link it.

## Technical details
- The rewritten allocation block allows codegen to avoid a separate explicit `return NULL` path and aligns better with original branch structure in objdiff.
- `prev` is only used after the traversal guarantees at least one visited node (`__files[0]`), which matches the static file-list setup in this module.
