### PR TITLE
main/pppChangeBGColor: improve pppFrameChangeBGColor match

### DIFF
--- a/src/pppChangeBGColor.cpp
+++ b/src/pppChangeBGColor.cpp
@@ -6,16 +6,28 @@ extern int DAT_8032ed70;
 
 /*
  * --INFO--
- * PAL Address: 0x8012d454
- * PAL Size: 4b
+ * PAL Address: 0x8012d3fc
+ * PAL Size: 84b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppConChangeBGColor(void)
+void pppFrameChangeBGColor(struct pppChangeBGColor* pppChangeBGColor, struct UnkB* param_2, struct UnkC* param_3)
 {
-	return;
+	if (DAT_8032ed70 != 0) {
+		return;
+	}
+
+	unsigned char* mapMng = (unsigned char*)&MapMng;
+	unsigned char* data = (unsigned char*)pppChangeBGColor + param_3->m_serializedDataOffsets[1] + 0x80;
+
+	mapMng += 0x20000;
+	mapMng[0x2989] = 1;
+	mapMng[0x2990] = data[8];
+	mapMng[0x2991] = data[9];
+	mapMng[0x2992] = data[10];
+	mapMng[0x2993] = data[11];
 }
 
 /*
@@ -34,30 +46,14 @@ void pppDesChangeBGColor(void)
 
 /*
  * --INFO--
- * PAL Address: 0x8012d3fc
- * PAL Size: 84b
+ * PAL Address: 0x8012d454
+ * PAL Size: 4b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameChangeBGColor(struct pppChangeBGColor* pppChangeBGColor, struct UnkB* param_2, struct UnkC* param_3)
+void pppConChangeBGColor(void)
 {
-	if (DAT_8032ed70 != 0) {
-		return;
-	}
-	
-	int iVar1 = param_3->m_serializedDataOffsets[1];
-	iVar1 += 0x80;  // Add offset first
-	
-	// Access MapMng fields using byte pointer arithmetic to match assembly
-	char* mapMngPtr = (char*)&MapMng;
-	char* indexedPtr = (char*)pppChangeBGColor + iVar1;
-	
-	*(mapMngPtr + 0x22989) = 1;  // _141705_1_
-	*(mapMngPtr + 0x22990) = *(indexedPtr + 0x8);  // _141712_1_
-	*(mapMngPtr + 0x22991) = *(indexedPtr + 0x9);  // _141713_1_
-	*(mapMngPtr + 0x22992) = *(indexedPtr + 0xa);  // _141714_1_
-	*(mapMngPtr + 0x22993) = *(indexedPtr + 0xb);  // _141715_1_
 	return;
 }


### PR DESCRIPTION
## Summary
- Reworked `pppFrameChangeBGColor` to use clearer byte-pointer flow around serialized data and `MapMng` color writes.
- Removed coercive offset comments and preserved plausible game-source structure.
- Reordered definitions in `src/pppChangeBGColor.cpp` to match target symbol layout (frame/des/con).

## Functions improved
- Unit: `main/pppChangeBGColor`
- Function: `pppFrameChangeBGColor`

## Match evidence
- `pppFrameChangeBGColor`: **61.714287% -> 68.333336%** (+6.619049)
- Unit `.text` match: **65.04348% -> 71.08696%** (+6.04348)

Measured with:
- `build/tools/objdiff-cli diff -p . -u main/pppChangeBGColor -o - pppFrameChangeBGColor`

## Plausibility rationale
- The updated code expresses straightforward source-level intent: early-out on a global flag, read serialized offset data, then copy 4 color bytes into map-manager state.
- This removes opaque offset comments and keeps logic consistent with other ppp frame callbacks that index serialized data blocks.

## Technical details
- The generated sequence now aligns more closely with target flow around offset loading and byte stores.
- Main remaining differences appear tied to `MapMng` addressing mode selection (`sda21` versus `lis/addi`), likely a compiler/unit-flag effect rather than behavioral mismatch.
