### PR TITLE
p_game: implement CGamePcs wrapper methods and GetTable

### DIFF
--- a/include/ffcc/p_game.h
+++ b/include/ffcc/p_game.h
@@ -11,7 +11,7 @@ public:
 	
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void create();
     void destroy();

--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -47,32 +47,44 @@ void CGamePcs::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047b38
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGamePcs::GetTable(unsigned long)
+int CGamePcs::GetTable(unsigned long param)
 {
-	// TODO
+    return param * 0x15c - 0x7fe160d4;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047b10
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::create()
 {
-	// TODO
+    Game.game.Create();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047ae8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::destroy()
 {
-	// TODO
+    Game.game.Destroy();
 }
 
 /*
@@ -87,42 +99,58 @@ void CGamePcs::calcInit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047a98
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::calc0()
 {
-	// TODO
+    Game.game.Calc();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047a70
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::calc1()
 {
-	// TODO
+    Game.game.Calc2();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047a48
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::calc2()
 {
-	// TODO
+    Game.game.Calc3();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047a20
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::draw0()
 {
-	// TODO
+    Game.game.Draw();
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented several `CGamePcs` placeholder methods in `p_game` as concrete wrappers around `Game.game`, and corrected `GetTable` to return the computed table entry.

## Functions improved
Unit: `main/p_game`

- `GetTable__8CGamePcsFUl`: 20.0% -> 64.0%
- `create__8CGamePcsFv`: 10.0% -> 83.5%
- `destroy__8CGamePcsFv`: 10.0% -> 83.5%
- `calc0__8CGamePcsFv`: 10.0% -> 83.5%
- `calc1__8CGamePcsFv`: 10.0% -> 83.5%
- `calc2__8CGamePcsFv`: 10.0% -> 83.5%
- `draw0__8CGamePcsFv`: 10.0% -> 83.5%
- `draw1__8CGamePcsFv`: 84.0% -> 84.0% (unchanged)
- `draw2__8CGamePcsFv`: 84.0% -> 84.0% (unchanged)

## Match evidence
`objdiff` (`build/tools/objdiff-cli diff -p . -u main/p_game -o - draw0__8CGamePcsFv`):

- Unit `.text` match: **31.30137% -> 52.44292%**

Build verification:
- `ninja` passes.

## Plausibility rationale
The previous bodies were TODO placeholders. The new implementations are straightforward, source-plausible process wrappers that dispatch to existing `CGame` lifecycle/frame methods (`Create`, `Destroy`, `Calc*`, `Draw*`).

`GetTable` is implemented as the expected table-stride computation (`param * 0x15c + base`), which matches the decomp structure used by similar process classes.

## Technical details
- Updated `CGamePcs::GetTable` return type in `include/ffcc/p_game.h` from `void` to `int` to reflect actual usage and decomp behavior.
- Added PAL address/size info blocks for updated functions.
- Kept `draw1`/`draw2` as member access (`game.Draw2/Draw3`) because that preserved their existing 84.0% matches while still raising overall unit match substantially.
