### PR TITLE
Improve pppDrawMatrixLoc stack layout match

### DIFF
--- a/src/pppDrawMatrixLoc.cpp
+++ b/src/pppDrawMatrixLoc.cpp
@@ -15,8 +15,8 @@ extern float FLOAT_803331d8;
  */
 void pppDrawMatrixLoc(_pppPObject* param_1)
 {
-    Vec local_38;
     Vec local_2c;
+    Vec local_38;
     Vec local_20[2];
     
     local_2c.z = FLOAT_803331d8;


### PR DESCRIPTION
## Summary
- Reordered local variable declarations in `pppDrawMatrixLoc` so stack slot layout better matches the original PAL binary.
- No logic changes: vector initialization, matrix copy, world transform, and writeback are unchanged.

## Functions improved
- Unit: `main/pppDrawMatrixLoc`
- Symbol: `pppDrawMatrixLoc`
- Match: `89.23684% -> 89.47369%`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawMatrixLoc -o - pppDrawMatrixLoc`
- Key assembly effect:
  - Local stack offsets for `local_2c` and `local_38` aligned more closely to target calling/argument setup for `PSMTXMultVec` and `PSVECAdd`.
  - Reduced arg/offset mismatches in the middle of the function.

## Plausibility rationale
- Reordering local declarations is a normal source-level change that preserves behavior while affecting stack layout.
- This is consistent with plausible original code structure and avoids contrived compiler-coaxing patterns.

## Technical details
- Changed only one line pair in `src/pppDrawMatrixLoc.cpp`:
  - `Vec local_2c;` now declared before `Vec local_38;`
- Build verification passed with `ninja`.
