### PR TITLE
GXTransform: match GXSetViewport wrapper call shape

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -443,6 +443,11 @@ void __GXSetViewport(void) {
     GX_WRITE_XF_REG_F(31, oz);
 }
 
+void GXSetViewport(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz) {
+    GXSetViewportJitter(left, top, wd, ht, nearz, farz, 1);
+}
+
+#pragma dont_inline on
 void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz, u32 field) {
     CHECK_GXBEGIN(903, "GXSetViewport");  // not the correct function name
 
@@ -461,9 +466,7 @@ void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz,
     __GXData->bpSentNot = 1;
 }
 
-void GXSetViewport(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz) {
-    GXSetViewportJitter(left, top, wd, ht, nearz, farz, 1);
-}
+#pragma dont_inline reset
 
 void GXGetViewportv(f32* vp) {
     ASSERTMSGLINE(968, vp, "GXGet*: invalid null pointer");


### PR DESCRIPTION
## Summary
- Updated `src/gx/GXTransform.c` to keep `GXSetViewport` as a thin wrapper that calls `GXSetViewportJitter(..., 1)`.
- Reordered definitions so `GXSetViewport` appears before `GXSetViewportJitter`.
- Added a local `#pragma dont_inline on/reset` block around `GXSetViewportJitter` to preserve the wrapper call shape expected by the target binary.

## Functions Improved
- Unit: `main/gx/GXTransform`
- Symbol: `GXSetViewport` (36b)

## Match Evidence
- `GXSetViewport`: **0.0% -> 100.0%**
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetViewport`
- Build/progress result confirms net code-match gain:
  - SDK code matched bytes: `150392 -> 150428`
  - SDK matched functions: `721 -> 722`

## Plausibility Rationale
- The resulting code is a natural API-layer shape: a non-jitter setter delegating to the jitter-aware setter with `field=1`.
- The change does not introduce synthetic temporaries or unnatural control flow; it only restores expected call boundaries/inlining behavior.

## Technical Notes
- Prior code was semantically correct but compiled into an inlined/specialized body for `GXSetViewport`, preventing symbol-level match.
- Reordering plus `dont_inline` keeps the wrapper call sequence and register setup consistent with target assembly.
