### PR TITLE
gx/GXPixel: improve GXSetFieldMask match to 50%

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -317,9 +317,10 @@ void GXSetFieldMask(GXBool odd_mask, GXBool even_mask) {
     u32 reg;
 
     CHECK_GXBEGIN(608, "GXSetFieldMask");
-    reg = 0x44000000;
-    reg |= even_mask;
-    reg |= odd_mask << 1;
+    reg = 0;
+    SET_REG_FIELD(611, reg, 1, 0, even_mask);
+    SET_REG_FIELD(612, reg, 1, 1, odd_mask);
+    SET_REG_FIELD(613, reg, 8, 24, 0x44);
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
## Summary
- Updated `GXSetFieldMask` in `src/gx/GXPixel.c` to build the BP register value via `SET_REG_FIELD` instead of manual OR/shift composition.
- Kept behavior identical: writes BP command `0x44` with `even_mask` bit0 and `odd_mask` bit1, then clears `__GXData->bpSentNot`.

## Functions improved
- Unit: `main/gx/GXPixel`
- Function: `GXSetFieldMask`
  - Before: `48.57143%`
  - After: `50.00000%`
  - Delta: `+1.42857%`

## Match evidence
- Built with `ninja` before and after.
- Compared with:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXPixel -o - GXSetFieldMask`
- Diff profile moved toward target:
  - `DIFF_REPLACE`: `3 -> 1`
  - `DIFF_ARG_MISMATCH`: unchanged at `6`
- Spot-check on another symbol in the unit showed no regression:
  - `GXSetFogRangeAdj`: unchanged at `59.8125%`

## Plausibility rationale
- `SET_REG_FIELD` register packing is the dominant style in this GX codebase for BP register construction.
- The change improves assembly alignment without introducing contrived temporaries, ordering hacks, or readability regressions.
- Resulting code remains natural SDK-style source, not compiler coaxing.

## Technical details
- New bit packing explicitly sets:
  - bit 0: `even_mask`
  - bit 1: `odd_mask`
  - bits 24-31: BP register address `0x44`
- This nudged instruction selection closer to the target sequence while preserving semantics.
