### PR TITLE
Decompile pppKeLnsLpCon and pppKeLnsLpCon2

### DIFF
--- a/include/ffcc/pppKeLns.h
+++ b/include/ffcc/pppKeLns.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
-void pppKeLnsLpCon(void);
-void pppKeLnsLpCon2(void);
+void pppKeLnsLpCon(void* pObject, void* pPart);
+void pppKeLnsLpCon2(void* pObject, void* pPart);
 void pppKeLnsLpDraw(void);
 void pppKeLnsFlsCon(void);
 void pppKeLnsFlsDraw(void);

--- a/src/pppKeLns.cpp
+++ b/src/pppKeLns.cpp
@@ -1,23 +1,44 @@
 #include "ffcc/pppKeLns.h"
+#include "ffcc/KeLns.h"
+#include "dolphin/types.h"
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800957d4
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppKeLnsLpCon(void)
+void pppKeLnsLpCon(void* pObject, void* pPart)
 {
-	// TODO
+	u32 offset = *(u32*)*(u32*)((u8*)pPart + 0xC);
+	_KeLnsLp* keLnsLp = (_KeLnsLp*)((u8*)pObject + offset + 0x80);
+	f32 zero = 0.0f;
+
+	KeLnsLp_Init(keLnsLp);
+	*(f32*)((u8*)keLnsLp + 0x8C) = zero;
+	*(f32*)((u8*)keLnsLp + 0x98) = zero;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800957b4
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppKeLnsLpCon2(void)
+void pppKeLnsLpCon2(void* pObject, void* pPart)
 {
-	// TODO
+	u32 offset = *(u32*)*(u32*)((u8*)pPart + 0xC);
+	u8* keLnsLp = (u8*)pObject + offset + 0x80;
+	f32 zero = 0.0f;
+
+	*(f32*)(keLnsLp + 0x8C) = zero;
+	*(f32*)(keLnsLp + 0x98) = zero;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppKeLnsLpCon` and `pppKeLnsLpCon2` in `src/pppKeLns.cpp` instead of TODO stubs.
- Updated `include/ffcc/pppKeLns.h` signatures to accept object/part pointers used by the original codegen path.
- Added PAL address/size metadata comments for both updated functions.

## Functions improved
- Unit: `main/pppKeLns`
- `pppKeLnsLpCon`: `5.6%` -> `99.72222%` (72b)
- `pppKeLnsLpCon2`: `12.5%` -> `99.375%` (32b)

## Match evidence
- Unit `main/pppKeLns` moved from ~`17.2%` fuzzy match (selector baseline) to `100.0%` fuzzy match in report.
- Remaining symbol-level deltas are relocation-arg identity on the shared `lfs ...@sda21` constant load; instruction flow/structure now aligns.
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/pppKeLns -o - pppKeLnsLpCon`
  - `build/tools/objdiff-cli diff -p . -u main/pppKeLns -o - pppKeLnsLpCon2`
  - `build/tools/objdiff-cli report generate -p .`

## Plausibility rationale
- Code now reflects a straightforward constructor pattern seen in nearby particle helpers:
  - resolve per-object effect data from `(part + 0xC)->0` and `+0x80`
  - call `KeLnsLp_Init` where expected
  - initialize two float fields (`0x8C`, `0x98`) to zero
- No contrived control flow or compiler-only tricks were introduced; implementation remains readable and consistent with surrounding source style.

## Technical details
- `objdiff` target instructions for both functions show exact pointer chase and store offsets.
- Implementing with `_KeLnsLp` + typed offset writes produced near-exact assembly and complete unit-level fuzzy match.
