### PR TITLE
main/pppRandUpInt: improve decomp match with control-flow/type reconstruction

### DIFF
--- a/include/ffcc/pppRandUpInt.h
+++ b/include/ffcc/pppRandUpInt.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void pppRandUpInt(int index, void* param2, void* param3);
+void pppRandUpInt(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandUpInt` to mirror original control flow and data flow instead of placeholder logic.
- Corrected function signature to use a pointer base parameter (`void* param1`) in both declaration and definition.
- Added explicit parameter structs and typed globals/constants used by the routine.
- Implemented the observed two-branch behavior:
  - gate on `lbl_8032ED70`
  - random value path when base state is zero (including optional second `RandF` scale)
  - compare-and-accumulate path when base state is non-zero.
- Preserved the integer accumulation via 0x4330 conversion-union pattern to align with generated PPC code shape.

## Functions Improved
- Unit: `main/pppRandUpInt`
- Symbol: `pppRandUpInt`

## Match Evidence
- `objdiff` `.text` match before: **48.24%**
- `objdiff` `.text` match after: **87.666664%**

Command used:
```sh
build/tools/objdiff-cli diff -p . -u main/pppRandUpInt -o - pppRandUpInt
```

## Plausibility Rationale
- Replaced non-original placeholder comments/logic with straightforward field-based behavior consistent with neighboring `pppRand*` routines.
- Data access and branch structure now follow expected game-source idioms (state gate, optional random blend, offset-based target selection, integer accumulation).
- Changes improve match by aligning probable original semantics, not by introducing contrived compiler-only rewrites.

## Technical Notes
- Significant mismatches removed by:
  - fixing the first argument type and pointer arithmetic base,
  - removing invalid null-guard branch structure,
  - restoring branch-specific output pointer selection,
  - using explicit globals/constants and the conversion path expected by PPC output.
