### PR TITLE
axfx/delay: improve AXFXDelayShutdown to 99.58%

### DIFF
--- a/src/axfx/delay.c
+++ b/src/axfx/delay.c
@@ -123,6 +123,15 @@ int AXFXDelayInit(AXFX_DELAY* delay) {
     AXFXDelaySettings(delay);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x80196934
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 int AXFXDelayShutdown(AXFX_DELAY* delay) {
     BOOL old;
 
@@ -138,10 +147,6 @@ int AXFXDelayShutdown(AXFX_DELAY* delay) {
     if (delay->sur) {
         __AXFXFree(delay->sur);
     }
-
-    delay->left = NULL;
-    delay->right = NULL;
-    delay->sur = NULL;
 
     OSRestoreInterrupts(old);
     return 1;


### PR DESCRIPTION
## Summary
- Updated `AXFXDelayShutdown` in `src/axfx/delay.c` to better match original codegen.
- Removed post-free pointer NULL stores (`left/right/sur`) that introduced extra instructions.
- Added function metadata header with PAL address/size.

## Functions improved
- Unit: `main/axfx/delay`
- Symbol: `AXFXDelayShutdown`
- Match: **88.47% -> 99.58%**

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/axfx/delay -o - AXFXDelayShutdown`
- Before: `88.47222`
- After: `99.583336`
- Remaining diffs are three relocation-argument mismatches for SDA21 loads of the free-function pointer symbol label.

## Plausibility rationale
- The removed pointer-reset stores are not required for deallocation correctness in this shutdown path and align with the reconstructed target routine shape.
- Change is small, readable, and source-plausible rather than artificial compiler coaxing.

## Technical details
- Main improvement came from removing three explicit NULL assignments after conditional frees, which eliminated extra `li/stw` sequence in generated assembly.
- Build verification succeeded with `ninja`.
