### PR TITLE
Improve pppDrawMatrixFrontLnr match to 99.47%

### DIFF
--- a/src/pppDrawMatrixFrontLnr.cpp
+++ b/src/pppDrawMatrixFrontLnr.cpp
@@ -19,9 +19,9 @@ void pppDrawMatrixFrontLnr(_pppPObject* param_1)
     PSMTXScaleApply(
         *(Mtx*)((char*)param_1 + 0x10),
         *(Mtx*)((char*)param_1 + 0x40),
-        (pppMngStPtr->m_scale).x,
-        (pppMngStPtr->m_scale).y,
-        (pppMngStPtr->m_scale).z
+        *(float*)((char*)pppMngStPtr + 0x28),
+        *(float*)((char*)pppMngStPtr + 0x2c),
+        *(float*)((char*)pppMngStPtr + 0x30)
     );
     
     local_18.x = *(float*)((char*)param_1 + 0x1c);
@@ -30,8 +30,7 @@ void pppDrawMatrixFrontLnr(_pppPObject* param_1)
     
     PSMTXMultVec(ppvCameraMatrix0, &local_18, &local_18);
     
-    f32 temp = local_18.x;
-    *(s32*)((char*)param_1 + 0x4c) = (s32)temp;
+    *(float*)((char*)param_1 + 0x4c) = local_18.x;
     *(float*)((char*)param_1 + 0x5c) = local_18.y;
     *(float*)((char*)param_1 + 0x6c) = local_18.z;
 }


### PR DESCRIPTION
## Summary
- Updated `pppDrawMatrixFrontLnr` to use explicit manager scale offsets (`+0x28/+0x2C/+0x30`) instead of the current `_pppMngSt` field mapping.
- Removed the temporary float-to-int cast path for the `+0x4C` write and store the transformed x component directly as `float`.

## Functions improved
- Unit: `main/pppDrawMatrixFrontLnr`
- Symbol: `pppDrawMatrixFrontLnr`

## Match evidence
- Before: `88.70588%`
- After: `99.47059%`
- Size alignment improved from `148b` output to `136b`, matching the PAL symbol size for this function.
- Remaining differences are relocation/symbol-name level (`pppMngStPtr` vs `lbl_8032ED50`, `ppvCameraMatrix0` vs `ppvCameraMatrix02`) rather than control-flow/instruction-shape issues.

## Plausibility rationale
- The change removes a decompilation artifact (float->int conversion) and aligns with direct floating-point matrix/vector data flow used by nearby matrix draw routines.
- Using explicit offsets for `_pppMngSt` access is consistent with current project practice where struct layout is still being reconstructed and local field mappings are known to be incomplete.

## Technical details
- Verified with explicit object diff:
  - `build/tools/objdiff-cli diff -1 build/GCCP01/obj/pppDrawMatrixFrontLnr.o -2 build/GCCP01/src/pppDrawMatrixFrontLnr.o -o - pppDrawMatrixFrontLnr`
- Verified full build:
  - `ninja` completes and updates report/progress successfully.
