### PR TITLE
main/p_system: match CSystemPcs::GetTable to 100%

### DIFF
--- a/src/p_system.cpp
+++ b/src/p_system.cpp
@@ -2,6 +2,8 @@
 #include "ffcc/pad.h"
 #include "ffcc/p_dbgmenu.h"
 
+extern unsigned char lbl_801EA0F4[];
+
 /*
  * --INFO--
  * PAL Address: 0x80047d7c
@@ -57,7 +59,9 @@ void CSystemPcs::Quit()
  */
 int CSystemPcs::GetTable(unsigned long index)
 {
-	return index * 0x15c + -0x7fe15f0c;
+	unsigned char* table = lbl_801EA0F4;
+	unsigned long offset = index * 0x15c;
+	return (int)(table + offset);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CSystemPcs::GetTable(unsigned long)` in `src/p_system.cpp` to compute the table address through explicit table/offset temporaries.
- Replaced the prior folded immediate arithmetic form with source that naturally emits relocation-based base load + add.

## Functions Improved
- Unit: `main/p_system`
- Symbol: `GetTable__10CSystemPcsFUl`
- Match: **64.0% -> 100.0%**

## Match Evidence
- Before: `build/tools/objdiff-cli diff -p . -u main/p_system -o - GetTable__10CSystemPcsFUl` reported 64.0%.
- After: same command reports 100.0% for `GetTable__10CSystemPcsFUl`.
- Instruction shape now aligns exactly with target sequence (`mulli`, `lis`, `addi`, `add`, `blr`).

## Plausibility Rationale
- The change reflects plausible original C++ source structure: obtain a table base, compute per-entry byte offset (`0x15c`), return base + offset.
- This avoids contrived compiler coaxing patterns and aligns with address-table access style already used in the codebase.

## Technical Details
- Added `extern unsigned char lbl_801EA0F4[];` and used:
  - `unsigned char* table = lbl_801EA0F4;`
  - `unsigned long offset = index * 0x15c;`
  - `return (int)(table + offset);`
- This preserves behavior while generating the expected relocation + register-add codegen.
