### PR TITLE
gx/GXAttr: improve GXSetArray matching

### DIFF
--- a/src/gx/GXAttr.c
+++ b/src/gx/GXAttr.c
@@ -535,9 +535,8 @@ void GXGetVtxAttrFmtv(GXVtxFmt fmt, GXVtxAttrFmtList* vat) {
 
 void GXSetArray(GXAttr attr, void* base_ptr, u8 stride) {
     GXAttr cpAttr;
+    s32 regAddr;
     u32 phyAddr;
-
-    attr;  // needed to match
 
     CHECK_GXBEGIN(963, "GXSetArray");
     if (attr == GX_VA_NBT) {
@@ -549,7 +548,16 @@ void GXSetArray(GXAttr attr, void* base_ptr, u8 stride) {
     phyAddr = (u32)base_ptr & 0x3FFFFFFF;
 
     GX_WRITE_SOME_REG2(8, cpAttr | 0xA0, phyAddr, cpAttr - 12);
+    regAddr = cpAttr - 12;
+    if (regAddr >= 0 && regAddr < 4) {
+        __GXData->indexBase[regAddr] = phyAddr;
+    }
+
     GX_WRITE_SOME_REG3(8, cpAttr | 0xB0, stride, cpAttr - 12);
+    regAddr = cpAttr - 12;
+    if (regAddr >= 0 && regAddr < 4) {
+        __GXData->indexStride[regAddr] = stride;
+    }
 }
 
 void GXInvalidateVtxCache(void) {


### PR DESCRIPTION
## Summary
- Updated `GXSetArray` in `src/gx/GXAttr.c` to restore `__GXData->indexBase` and `__GXData->indexStride` updates for the CP attribute window handled by the hardware index registers.
- Kept existing FIFO register writes and added explicit guarded stores using the same `regAddr >= 0 && regAddr < 4` logic expected by the original codegen.

## Functions improved
- Unit: `main/gx/GXAttr`
- Function: `GXSetArray`

## Match evidence
- `GXSetArray`: **44.37143% -> 99.71429%** (`140b`)
- Instruction-level diffs in objdiff dropped from **30 -> 2** for `GXSetArray`.
- Validation command used:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXAttr -o -`

## Plausibility rationale
- The added writes mirror expected GX runtime state tracking (`indexBase/indexStride`) alongside CP register writes.
- This is consistent with SDK-style GX code paths and avoids contrived compiler-only transformations.

## Technical details
- Added `regAddr` range checks around `cpAttr - 12` and wrote:
  - `__GXData->indexBase[regAddr] = phyAddr`
  - `__GXData->indexStride[regAddr] = stride`
- Rebuilt with `ninja` and confirmed improvement via `objdiff-cli`.
