### PR TITLE
Improve TRK_fill_mem match in mem_TRK

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/mem_TRK.c
+++ b/src/TRK_MINNOW_DOLPHIN/mem_TRK.c
@@ -8,7 +8,8 @@
 #pragma dont_inline on
 /* 8036F580-8036F638 369EC0 00B8+00 0/0 1/1 0/0 .text            TRK_fill_mem */
 void TRK_fill_mem(void* dst, int val, u32 n) {
-    u32 v, i, j;
+    u32 v, i;
+    u32* p32;
     v = (u8)val;
 
     ((u8*)dst) = ((u8*)dst) - 1;
@@ -27,19 +28,27 @@ void TRK_fill_mem(void* dst, int val, u32 n) {
         if (v)
             v |= v << 24 | v << 16 | v << 8;
 
-        ((u32*)dst) = ((u32*)(((u8*)dst) + 4)) - 1;
         ((u32*)dst) = ((u32*)(((u8*)dst) + 1)) - 1;
 
-        i = n / 32;
+        i = n >> 5;
 
         if (i) {
+            p32 = (u32*)dst;
             do {
-                for (j = 0; j < 8; j++)
-                    *++((u32*)dst) = v;
+                p32[1] = v;
+                p32[2] = v;
+                p32[3] = v;
+                p32[4] = v;
+                p32[5] = v;
+                p32[6] = v;
+                p32[7] = v;
+                p32 += 8;
+                *p32 = v;
             } while (--i);
+            dst = p32;
         }
 
-        i = (n / 4) % 8;
+        i = (n >> 2) & 7;
 
         if (i) {
             do {
@@ -49,7 +58,7 @@ void TRK_fill_mem(void* dst, int val, u32 n) {
 
         ((u8*)dst) = ((u8*)(((u32*)dst) + 1)) - 1;
 
-        n %= 4;
+        n &= 3;
     }
 
     if (n)


### PR DESCRIPTION
## Summary
- Refined `TRK_fill_mem` loop structure in `src/TRK_MINNOW_DOLPHIN/mem_TRK.c` to better match original codegen.
- Replaced inner `for (j = 0; j < 8; j++)` word-fill loop with explicit unrolled word stores via a dedicated `u32*` pointer.
- Switched arithmetic forms to equivalent bitwise/shift forms used by compiler (`n >> 5`, `(n >> 2) & 7`, `n &= 3`).

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/mem_TRK`
- Function: `TRK_fill_mem`

## Match evidence
- Before: `82.391304%` (`build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/mem_TRK -o - TRK_fill_mem`)
- After: `93.478264%` (same command after change)
- Gain: `+11.08696` percentage points

## Plausibility rationale
- This is a low-level fill routine where explicit unrolled stores are natural and common in hand-written SDK/runtime code.
- Changes preserve the original algorithm and semantics while using straightforward pointer math and loop structure, rather than contrived compiler-only tricks.

## Technical details
- The prior nested inner loop shape emitted a less-aligned store/update pattern.
- Explicit unrolled stores plus a stable `u32*` cursor improved instruction alignment in the 32-byte block fill path.
- The resulting object `.text` match for the unit improved accordingly.
