### PR TITLE
pppMatrixLoc: match callback ABI and pointer load sequence

### DIFF
--- a/include/ffcc/pppMatrixLoc.h
+++ b/include/ffcc/pppMatrixLoc.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-void pppMatrixLoc(void* target, void* param);
+void pppMatrixLoc(void* target, void* unused, void* param);
 
 #ifdef __cplusplus
 }

--- a/src/pppMatrixLoc.cpp
+++ b/src/pppMatrixLoc.cpp
@@ -10,17 +10,15 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppMatrixLoc(void* target, void* param)
+void pppMatrixLoc(void* target, void* unused, void* param)
 {
-    // Initialize matrix to identity (matrix is at offset 0x10)
+    (void)unused;
+
+    int* offsetPtr = *(int**)((char*)param + 0xC);
+    f32* posData = (f32*)((char*)target + *offsetPtr + 0x80);
+
     PSMTXIdentity((MtxPtr)((char*)target + 0x10));
-    
-    // Get position data pointer from param+0xc, then add target+0x80  
-    int dataOffset = *(int*)((char*)param + 0xc);
-    f32* posData = (f32*)((char*)target + dataOffset + 0x80);
-    
-    // Store position values in matrix translation column
-    *(f32*)((char*)target + 0x1c) = posData[0];  // X translation  
-    *(f32*)((char*)target + 0x2c) = posData[1];  // Y translation
-    *(f32*)((char*)target + 0x3c) = posData[2];  // Z translation
+    *(f32*)((char*)target + 0x1C) = posData[0];
+    *(f32*)((char*)target + 0x2C) = posData[1];
+    *(f32*)((char*)target + 0x3C) = posData[2];
 }


### PR DESCRIPTION
## Summary
- Updated `pppMatrixLoc` callback signature to a 3-argument PPP-style ABI and explicitly ignored the middle argument.
- Reworked pointer indirection to match expected data access (`*(int**)(param + 0xC)` then dereference) before matrix initialization.
- Removed nonessential explanatory comments so the function body stays clean and source-plausible.

## Functions improved
- Unit: `main/pppMatrixLoc`
- Symbol: `pppMatrixLoc`
- Size: `96b`

## Match evidence
- Before: `66.041664%` (`build/tools/objdiff-cli diff -p . -u main/pppMatrixLoc -o - pppMatrixLoc`)
- After: `100.000000%` (same command)
- Instruction-level diff markers after change: `0`

## Plausibility rationale
- PPP callbacks in this codebase commonly use a 3-parameter calling convention with an unused middle argument; adopting that form here is consistent with nearby source patterns.
- The corrected double-indirection from `param + 0xC` reflects likely original data layout usage rather than artificial compiler coaxing.

## Technical details
- Pre-change assembly mismatches showed argument-register drift (`r4` vs expected `r5`) and pointer base-register mismatch (`r3` vs expected saved `r31`).
- Making the callback ABI explicit and materializing `posData` before `PSMTXIdentity` aligned register allocation and instruction order to target.
