### PR TITLE
MSL ansi_files: improve __flush_line_buffered_output_files match

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/ansi_files.c
+++ b/src/MSL_C/PPCEABI/bare/H/ansi_files.c
@@ -219,11 +219,7 @@ int __flush_line_buffered_output_files(void) {
     unsigned char* file_bytes;
     unsigned short mode_bits;
 
-    while (1) {
-        if (file == NULL) {
-            break;
-        }
-
+    while (file != NULL) {
         file_bytes = (unsigned char*)file;
         mode_bits = *(unsigned short*)(file_bytes + 4);
         if ((((mode_bits >> 6) & 7) != 0) && (((file_bytes[4] >> 1) & 1) != 0) &&


### PR DESCRIPTION
## Summary
- Simplified loop control in `__flush_line_buffered_output_files` in `src/MSL_C/PPCEABI/bare/H/ansi_files.c`.
- Replaced `while (1) { if (file == NULL) break; ... }` with `while (file != NULL) { ... }` while preserving behavior.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/ansi_files`
- Symbol improved: `__flush_line_buffered_output_files`

## Match evidence
- `__flush_line_buffered_output_files`: **82.85714% -> 83.71429%** (`+0.85715`)
- Unit `.text` match (`ansi_files.o`): **86.87755% -> 87.03061%** (`+0.15306`)
- `__init_file`: 77.96364% (no change)
- `__find_unopened_file`: 78.888885% (no change)
- Build verification: `ninja` succeeds; overall project matched code remained stable at `170144 / 1855300` in this branch.

## Plausibility rationale
- This is an idiomatic control-flow cleanup consistent with surrounding MSL file-iteration code (`while (file != NULL)` pattern) and does not introduce compiler-coaxing constructs.
- The condition and side effects are unchanged; only loop form was normalized.

## Technical details
- Objdiff instruction diff showed branch-shape improvements around loop entry/exit for `__flush_line_buffered_output_files` after removing the explicit `break`-style loop.
