### PR TITLE
main/pppWDrawMatrixLoop: improve pppWDrawMatrixLoop match to 99.0%

### DIFF
--- a/src/pppWDrawMatrixLoop.cpp
+++ b/src/pppWDrawMatrixLoop.cpp
@@ -13,8 +13,12 @@
  */
 void pppWDrawMatrixLoop(_pppPObject* param_1)
 {
-    PSMTXConcat(ppvCameraMatrix0, param_1->m_localMatrix.value, (param_1 + 1)->m_localMatrix.value);
-    PSVECScale((Vec*)((char*)param_1 + 0x40), (Vec*)((char*)param_1 + 0x40), (pppMngStPtr->m_scale).x);
-    PSVECScale((Vec*)((char*)param_1 + 0x50), (Vec*)((char*)param_1 + 0x50), (pppMngStPtr->m_scale).y);
-    PSVECScale((Vec*)((char*)param_1 + 0x60), (Vec*)((char*)param_1 + 0x60), (pppMngStPtr->m_scale).z);
+    char* base = (char*)param_1;
+    Mtx* worldMtx = (Mtx*)(base + 0x38);
+
+    PSMTXConcat(ppvCameraMatrix0, *(Mtx*)(base + 0x4), *worldMtx);
+
+    PSVECScale((Vec*)(base + 0x40), (Vec*)(base + 0x40), *(float*)((char*)pppMngStPtr + 0x64));
+    PSVECScale((Vec*)(base + 0x50), (Vec*)(base + 0x50), *(float*)((char*)pppMngStPtr + 0x68));
+    PSVECScale((Vec*)(base + 0x60), (Vec*)(base + 0x60), *(float*)((char*)pppMngStPtr + 0x6c));
 }


### PR DESCRIPTION
## Summary
- Updated `pppWDrawMatrixLoop` to use explicit object-relative offsets for matrix source/destination and manager scale loads.
- Kept behavior identical while aligning codegen with expected PAL object layout usage.

## Functions improved
- Unit: `main/pppWDrawMatrixLoop`
- Symbol: `pppWDrawMatrixLoop`
- Match: **78.4% -> 99.0%**

## Match evidence
- `objdiff` before: argument/order mismatches around `PSMTXConcat` setup and `PSVECScale` scale loads.
- `objdiff` after: core instruction flow aligned; remaining diffs are primarily symbol/relocation naming (`ppvCameraMatrix0` vs `ppvCameraMatrix02`, `pppMngStPtr` label naming).
- Build remains successful with `ninja` after the change.

## Plausibility rationale
- The new form matches surrounding PPP code patterns that already use explicit offset-based matrix/vector access in this module family (for example, draw-matrix helpers).
- This is a source-plausible ABI/layout correction rather than compiler-coaxing: no contrived temporaries, no artificial control flow, and no debug artifacts.

## Technical details
- Adjusted `PSMTXConcat` operands to object-relative matrix offsets used by the original object (`+0x4` source, `+0x38` destination).
- Switched scale reads to direct manager-state offsets (`+0x64`, `+0x68`, `+0x6c`) to match expected `lfs` accesses feeding `PSVECScale`.
