### PR TITLE
card: improve __CARDAccess match in CARDOpen unit

### DIFF
--- a/src/card/CARDOpen.c
+++ b/src/card/CARDOpen.c
@@ -21,14 +21,14 @@ BOOL __CARDCompareFileName(CARDDir* ent, const char* fileName) {
 }
 
 s32 __CARDAccess(CARDControl* card, CARDDir* ent) {
-    const DVDDiskID* diskID = card->diskID;
-
     if (ent->gameName[0] == 0xFF)
         return CARD_RESULT_NOFILE;
 
-    if (diskID == &__CARDDiskNone
-     || (memcmp(ent->gameName, diskID->gameName, sizeof(ent->gameName)) == 0
-      && memcmp(ent->company, diskID->company, sizeof(ent->company)) == 0))
+    if (card->diskID == &__CARDDiskNone)
+        return CARD_RESULT_READY;
+
+    if (memcmp(ent->gameName, card->diskID->gameName, sizeof(ent->gameName)) == 0
+     && memcmp(ent->company, card->diskID->company, sizeof(ent->company)) == 0)
         return CARD_RESULT_READY;
 
     return CARD_RESULT_NOPERM;


### PR DESCRIPTION
## Summary
- Reworked `__CARDAccess` in `src/card/CARDOpen.c` to remove a local `diskID` temporary and compare directly against `card->diskID`.
- Split the previous combined OR condition into a direct early return for `__CARDDiskNone`, followed by explicit game/company `memcmp` checks.
- No behavior change intended; this is a source-plausible control-flow and data-flow cleanup.

## Functions improved
- Unit: `main/card/CARDOpen`
- `__CARDAccess`: **76.052635% -> 92.63158%** (+16.578945)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/card/CARDOpen -o - __CARDAccess`
- Before diff markers: `DIFF_ARG_MISMATCH=6`, `DIFF_DELETE=4`, `DIFF_INSERT=3`, `DIFF_REPLACE=3`
- After diff markers: `DIFF_ARG_MISMATCH=2`, `DIFF_INSERT=2`, `DIFF_OP_MISMATCH=1`, `DIFF_REPLACE=1`
- Other unit targets checked unchanged:
  - `CARDFastOpen`: 52.55682%
  - `CARDOpen`: 72.35107%

## Plausibility rationale
- The new form matches normal SDK-style C structure: early exit for sentinel disk ID, then direct content checks.
- It removes a non-essential local pointer and keeps field access explicit, which is idiomatic and more likely to reflect original authored source.
- The improvement comes from cleaner control/register flow rather than contrived temporaries or artificial coercions.

## Technical details
- This change specifically improves register allocation and branch structure around `memcmp` call setup in `__CARDAccess`.
- Build verified with `ninja` after the edit.
