### PR TITLE
Improve pppRandFloat match with liveness/order cleanup

### DIFF
--- a/src/pppRandFloat.cpp
+++ b/src/pppRandFloat.cpp
@@ -27,45 +27,40 @@ struct RandFloatCtx {
  * PAL Size: 268b
  * EN Address: TODO
  * EN Size: TODO
- * JP Address: TODO  
+ * JP Address: TODO
  * JP Size: TODO
  */
 void pppRandFloat(void* param1, void* param2, void* param3)
 {
     int* base = (int*)param1;
-    RandFloatParam* data = (RandFloatParam*)param2;
-    RandFloatCtx* ctx = (RandFloatCtx*)param3;
     int index = base[3];
 
-    if (lbl_8032ED70 != 0) {
-        return;
-    }
+    if (lbl_8032ED70 == 0) {
+        RandFloatParam* data = (RandFloatParam*)param2;
+        RandFloatCtx* ctx = (RandFloatCtx*)param3;
 
-    if (index == 0) {
-        float out = RandF__5CMathFv(&math);
+        if (index == 0) {
+            float out = RandF__5CMathFv(&math);
 
-        if (data->randomTwice != 0) {
-            out += RandF__5CMathFv(&math);
-        } else {
-            out *= lbl_8032FF88;
+            if (data->randomTwice != 0) {
+                out = out + RandF__5CMathFv(&math);
+            } else {
+                out = out * lbl_8032FF88;
+            }
+
+            *(float*)((char*)base + (*ctx->outputOffset + 0x80)) = out;
+        } else if (data->targetId == index) {
+            int outputOffset = *ctx->outputOffset;
+            int sourceOffset = data->sourceOffset;
+            float* source;
+
+            if (sourceOffset == -1) {
+                source = &lbl_801EADC8;
+            } else {
+                source = (float*)((char*)base + (sourceOffset + 0x80));
+            }
+
+            *source = *source + (data->blend * *(float*)((char*)base + (outputOffset + 0x80)) - data->blend);
         }
-
-        int outputOffset = *ctx->outputOffset;
-        *(float*)((char*)param1 + outputOffset + 0x80) = out;
-        return;
-    }
-
-    if (data->targetId == index) {
-        int outputOffset = *ctx->outputOffset;
-        float* outputValue = (float*)((char*)param1 + outputOffset + 0x80);
-        float* source;
-
-        if (data->sourceOffset == -1) {
-            source = &lbl_801EADC8;
-        } else {
-            source = (float*)((char*)param1 + data->sourceOffset + 0x80);
-        }
-
-        *source = *source + (data->blend * *outputValue - data->blend);
     }
 }


### PR DESCRIPTION
## Summary
- Refactored `pppRandFloat` local variable setup and control-flow structure to better align with original register/dataflow.
- Delayed `param2`/`param3` struct casts until after the global gate check, and preserved direct indexed memory expressions in both write/read paths.
- Kept behavior intact while making code generation closer to target assembly.

## Functions improved
- Unit: `main/pppRandFloat`
- Symbol: `pppRandFloat`

## Match evidence
- `objdiff` command: `build/tools/objdiff-cli diff -p . -u main/pppRandFloat -o - pppRandFloat`
- Before: `76.22388%`
- After: `78.656715%`
- Function size remains `268` bytes

## Plausibility rationale
- The change is source-plausible C/C++ cleanup: local declaration placement and straightforward control-flow expression, without contrived temporaries or artificial ordering hacks.
- Data access semantics are unchanged; adjustments focus on idiomatic structure that naturally influences register allocation/liveness.

## Technical details
- The largest gain came from changing liveness of `data`/`ctx` locals relative to the global guard and `index` load.
- This improved alignment in early prologue/setup and subsequent indexed load/store usage in objdiff, producing a measurable function-level match increase.
