### PR TITLE
main/pppWDrawMatrixFront: improve pppWDrawMatrixFront match

### DIFF
--- a/src/pppWDrawMatrixFront.cpp
+++ b/src/pppWDrawMatrixFront.cpp
@@ -29,7 +29,7 @@ void pppWDrawMatrixFront(struct _pppPObject* param_1)
 	
 	PSMTXMultVec(ppvCameraMatrix0, &local_18, &local_18);
 	
-	param_1[1].m_graphId = (s32)local_18.x;
-	param_1[1].m_localMatrix.value[0][3] = local_18.y;
-	param_1[1].m_localMatrix.value[1][3] = local_18.z;
+	param_1[1].m_localMatrix.value[0][3] = local_18.x;
+	param_1[1].m_localMatrix.value[1][3] = local_18.y;
+	param_1[1].m_localMatrix.value[2][3] = local_18.z;
 }


### PR DESCRIPTION
## Summary
- Updated `pppWDrawMatrixFront` output writes to store all transformed vector components into the destination matrix translation slots.
- Removed the incorrect float-to-int conversion/store path by replacing the `m_graphId` write with `m_localMatrix.value[0][3]`.

## Functions improved
- Unit: `main/pppWDrawMatrixFront`
- Symbol: `pppWDrawMatrixFront`
- Match: `88.5%` -> `99.23529%`

## Match evidence
- Baseline objdiff (`build/tools/objdiff-cli diff -p . -u main/pppWDrawMatrixFront -o - pppWDrawMatrixFront`):
  - `match_percent: 88.5`
  - diff kinds: `DIFF_REPLACE: 1`, `DIFF_INSERT: 3`, `DIFF_ARG_MISMATCH: 19`
- After change:
  - `match_percent: 99.23529`
  - diff kinds: `DIFF_REPLACE: 0`, `DIFF_INSERT: 0`, `DIFF_ARG_MISMATCH: 14`
- Assembly impact: removed the `fctiwz/stfd/lwz/stw` conversion chain and restored float stores for all three transformed components.

## Plausibility rationale
- The new code is more source-plausible for this matrix-front draw helper: all transformed vector components are written as matrix translation floats, consistent with neighboring Y/Z writes and expected graphics math flow.
- This avoids compiler-coaxing patterns and aligns with likely original intent (matrix translation propagation) rather than using an unrelated integer graph-id field.

## Technical details
- File changed: `src/pppWDrawMatrixFront.cpp`
- Key edit:
  - from `param_1[1].m_graphId = (s32)local_18.x;`
  - to `param_1[1].m_localMatrix.value[0][3] = local_18.x;`
- Build status: `ninja` succeeds.
