### PR TITLE
Improve match for pppColMove via typed data flow cleanup

### DIFF
--- a/src/pppColMove.cpp
+++ b/src/pppColMove.cpp
@@ -1,68 +1,76 @@
 #include "ffcc/pppColMove.h"
 
+extern int lbl_8032ED70;
+
+typedef struct {
+    short x;
+    short y;
+    short z;
+    short w;
+} pppColMoveVec4S;
+
+typedef struct {
+    int id;
+    int pad;
+    pppColMoveVec4S move;
+} pppColMoveInput;
+
 /*
  * --INFO--
  * PAL Address: 0x80065000
  * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppColMoveCon(void* param1, void* param2)
 {
-    int** ptr_array = (int**)param2;
-    int* temp_ptr = ptr_array[3];  // Load from offset 0xC
-    temp_ptr = (int*)temp_ptr[1]; // Load from offset 0x4 
-    short* target = (short*)((char*)param1 + (int)temp_ptr + 0x80);
-    
-    target[3] = 0;  // offset 0x6
-    target[2] = 0;  // offset 0x4
-    target[1] = 0;  // offset 0x2 
-    target[0] = 0;  // offset 0x0
+    int* data = ((int**)param2)[3];
+    pppColMoveVec4S* target = (pppColMoveVec4S*)((char*)param1 + data[1] + 0x80);
+
+    target->w = 0;
+    target->z = 0;
+    target->y = 0;
+    target->x = 0;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x80065028
  * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppColMove(void* param1, void* param2, void* param3)
 {
-    extern int lbl_8032ED70;
-    
-    int** ptr_array = (int**)param3;
-    int* ptr0 = ptr_array[3];  // Load from offset 0xC
-    
-    if (lbl_8032ED70 != 0) {
+    int state = lbl_8032ED70;
+    int* work = ((int**)param3)[3];
+    pppColMoveInput* input = (pppColMoveInput*)param2;
+    pppColMoveVec4S* src;
+    pppColMoveVec4S* dst;
+
+    if (state != 0) {
         return;
     }
-    
-    int* ptr_src = (int*)ptr0[0]; // Load from offset 0x0
-    int* ptr_dest = (int*)ptr0[1]; // Load from offset 0x4
-    
-    // Calculate offsets
-    ptr_src = (int*)((char*)ptr_src + 0x80);
-    ptr_dest = (int*)((char*)ptr_dest + 0x80);
-    short* src = (short*)((char*)param1 + (int)ptr_src);
-    short* dest = (short*)((char*)param1 + (int)ptr_dest);
-    
-    int* param2_int = (int*)param2;
-    int* param1_int = (int*)param1;
-    
-    if (param2_int[0] == param1_int[3]) {  // Inverted comparison
-        // Skip the movement update section
-        goto do_final_add;
-    }
-    
-    // Update movement values
-    short* movement = (short*)((char*)param2 + 0x8);
-    
-    dest[0] += movement[0];  // x
-    dest[1] += movement[1];  // y
-    dest[2] += movement[2];  // z
-    dest[3] += movement[3];  // w
 
-do_final_add:
-    // Always perform this addition
-    src[0] += dest[0];  // x
-    src[1] += dest[1];  // y  
-    src[2] += dest[2];  // z
-    src[3] += dest[3];  // w
+    src = (pppColMoveVec4S*)((char*)param1 + work[0] + 0x80);
+    dst = (pppColMoveVec4S*)((char*)param1 + work[1] + 0x80);
+
+    if (input->id == ((int*)param1)[3]) {
+        goto add_src;
+    }
+
+    dst->x += input->move.x;
+    dst->y += input->move.y;
+    dst->z += input->move.z;
+    dst->w += input->move.w;
+
+add_src:
+    src->x += dst->x;
+    src->y += dst->y;
+    src->z += dst->z;
+    src->w += dst->w;
 }


### PR DESCRIPTION
## Summary
- Refactored `src/pppColMove.cpp` to use small local data structs for the input payload and 4x `s16` vector fields.
- Reworked `pppColMove` control flow to keep the global state gate early and keep src/dst accumulation logic explicit and stable.
- Updated function info headers to include PAL metadata plus TODO placeholders for EN/JP fields.

## Functions improved
- Unit: `main/pppColMove`
- Symbol: `pppColMove`
  - Before: `69.46809%`
  - After: `70.319145%`
  - Delta: `+0.851055`

## Match evidence
- Unit `.text` match in `main/pppColMove`:
  - Before: `74.82456%`
  - After: `75.52631%`
  - Delta: `+0.70175`
- `pppColMoveCon` remains at `100%`.
- Objdiff indicates better alignment in the early setup/gating sequence and reduced diff noise around pointer arithmetic + typed short-vector updates.

## Plausibility rationale
- Changes model the data flow as likely original source constructs (id field + 4-component short movement vector) rather than contrived temp/register coercion.
- The resulting code is cleaner and behaviorally straightforward: optional movement accumulation followed by unconditional src+=dst integration.
- No assembly comments, hardcoded register tricks, or non-source-like compiler coaxing were introduced.

## Technical details
- Introduced `pppColMoveVec4S` and `pppColMoveInput` local structs to better represent observed memory layout and load/store widths.
- Reordered `pppColMove` locals and control-flow blocks to improve instruction scheduling around global-state check and src/dst address derivation.
