### PR TITLE
gx: improve __GXSetTmemConfig match in GXTexture

### DIFF
--- a/src/gx/GXTexture.c
+++ b/src/gx/GXTexture.c
@@ -1233,33 +1233,7 @@ void __GXGetSUTexSize(GXTexCoordID coord, u16* width, u16* height) {
 }
 
 void __GXSetTmemConfig(u32 config) {
-    switch (config) {
-    case 2:
-        GX_WRITE_RAS_REG(0x8c0d8000);
-        GX_WRITE_RAS_REG(0x900dc000);
-
-        GX_WRITE_RAS_REG(0x8d0d8800);
-        GX_WRITE_RAS_REG(0x910dc800);
-
-        GX_WRITE_RAS_REG(0x8e0d9000);
-        GX_WRITE_RAS_REG(0x920dd000);
-
-        GX_WRITE_RAS_REG(0x8f0d9800);
-        GX_WRITE_RAS_REG(0x930dd800);
-
-        GX_WRITE_RAS_REG(0xac0da000);
-        GX_WRITE_RAS_REG(0xb00dc400);
-
-        GX_WRITE_RAS_REG(0xad0da800);
-        GX_WRITE_RAS_REG(0xb10dcc00);
-
-        GX_WRITE_RAS_REG(0xae0db000);
-        GX_WRITE_RAS_REG(0xb20dd400);
-
-        GX_WRITE_RAS_REG(0xaf0db800);
-        GX_WRITE_RAS_REG(0xb30ddc00);
-        break;
-    case 1:
+    if (config == 1) {
         GX_WRITE_RAS_REG(0x8c0d8000);
         GX_WRITE_RAS_REG(0x900dc000);
 
@@ -1283,10 +1257,7 @@ void __GXSetTmemConfig(u32 config) {
 
         GX_WRITE_RAS_REG(0xaf0db800);
         GX_WRITE_RAS_REG(0xb30df800);
-
-        break;
-    case 0:
-    default:
+    } else {
         GX_WRITE_RAS_REG(0x8c0d8000);
         GX_WRITE_RAS_REG(0x900dc000);
 
@@ -1310,7 +1281,5 @@ void __GXSetTmemConfig(u32 config) {
 
         GX_WRITE_RAS_REG(0xaf0d9c00);
         GX_WRITE_RAS_REG(0xb30ddc00);
-
-        break;
     }
 }


### PR DESCRIPTION
## Summary
- Simplified `__GXSetTmemConfig` in `src/gx/GXTexture.c` to the two-path form (`config == 1` and default) used by the target binary.
- Removed the extra `case 2` branch and equivalent register write sequence that did not appear in the original output.

## Functions Improved
- Unit: `main/gx/GXTexture`
- Symbol: `__GXSetTmemConfig` (576 bytes)
  - Before: `52.04861%`
  - After: `98.125%`

## Match Evidence
- `build/tools/objdiff-cli diff -p . -u main/gx/GXTexture -o - __GXSetTmemConfig`
  - Residual diffs are minimal: `2x DIFF_DELETE`, `1x DIFF_OP_MISMATCH`, `1x DIFF_REPLACE`.
- Unit `.text` match for `main/gx/GXTexture` improved to `84.693375%`.

## Plausibility Rationale
- The updated implementation matches the decompilation structure and expected SDK-style behavior for TMEM config setup: special handling for one configuration and a default path.
- Removing the extra branch is source-plausible and improves correspondence without introducing compiler-coaxing constructs or unnatural control flow.

## Technical Details
- Change was intentionally limited to control flow in one function; register constants and write ordering within each retained path were preserved.
- Verified with full `ninja` build and symbol-scoped objdiff on `__GXSetTmemConfig`.
