### PR TITLE
main/pppRandUpFloat: improve pppRandUpFloat match to 75.30%

### DIFF
--- a/src/pppRandUpFloat.cpp
+++ b/src/pppRandUpFloat.cpp
@@ -5,6 +5,21 @@ extern CMath math;
 extern int lbl_8032ED70;
 extern float lbl_8032FFF8;
 extern float lbl_801EADC8;
+extern "C" float RandF__5CMathFv(CMath* instance);
+
+struct RandUpFloatParam {
+    int targetId;
+    int sourceOffset;
+    float blend;
+    unsigned char randomTwice;
+};
+
+struct RandUpFloatCtx {
+    void* unk0;
+    void* unk4;
+    void* unk8;
+    int* outputOffset;
+};
 
 /*
  * --INFO--
@@ -21,36 +36,38 @@ void pppRandUpFloat(void* param1, void* param2, void* param3) {
     }
 
     int* p1 = (int*)param1;
-    int* p2 = (int*)param2;
-    int* p3 = (int*)param3;
+    RandUpFloatParam* p2 = (RandUpFloatParam*)param2;
+    RandUpFloatCtx* p3 = (RandUpFloatCtx*)param3;
 
     int id = p1[3];
     if (id == 0) {
-        math.RandF();
-        float value = 1.0f;
+        float value = RandF__5CMathFv(&math);
 
-        if (((unsigned char*)param2)[0xC] != 0) {
-            math.RandF();
-            value = (value + 0.5f) * lbl_8032FFF8;
+        if (p2->randomTwice != 0) {
+            value = (value + RandF__5CMathFv(&math)) * lbl_8032FFF8;
         }
 
-        int outIndex = *(int*)p3[3];
-        *(float*)((char*)param1 + outIndex + 0x80) = value;
+        int outIndex = *p3->outputOffset;
+        float* outValue = (float*)((char*)param1 + outIndex + 0x80);
+        *outValue = value;
         return;
     }
 
-    if (p2[0] != id) {
+    if (p2->targetId != id) {
         return;
     }
 
-    int outIndex = *(int*)p3[3];
+    int outIndex = *p3->outputOffset;
     float* outValue = (float*)((char*)param1 + outIndex + 0x80);
 
-    int sourceIndex = p2[1];
+    int sourceIndex = p2->sourceOffset;
     float* source = &lbl_801EADC8;
     if (sourceIndex != -1) {
         source = (float*)((char*)param1 + sourceIndex + 0x80);
     }
 
-    *source = *source + (*(float*)((char*)param2 + 8) * *outValue);
+    float blend = p2->blend;
+    float current = *source;
+    float output = *outValue;
+    *source = current + (blend * output);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandUpFloat` using typed parameter/context structs to reflect observed field usage.
- Switched random generation to explicit `RandF__5CMathFv(&math)` return-value flow.
- Kept behavior source-plausible while improving codegen shape (random accumulation and blend writeback).

## Functions improved
- Unit: `main/pppRandUpFloat`
- Symbol: `pppRandUpFloat`

## Match evidence
- `pppRandUpFloat`: **57.696968% -> 75.30303%** (`+17.606062`)
- Expected size: `264b` (unchanged target)
- Current decomp size: `220b -> 236b`
- Instruction diff profile (`objdiff`):
  - `MATCH`: `16 -> 34`
  - `DIFF_DELETE`: `16 -> 9`
  - `DIFF_INSERT`: `5 -> 2`
  - `DIFF_ARG_MISMATCH`: `25 -> 16`
  - `DIFF_REPLACE`: `9 -> 7`

## Plausibility rationale
- The update uses normal game-code patterns already present across related `pppRand*` units:
  - explicit typed field access instead of raw ad-hoc indexing,
  - straightforward random/value accumulation logic,
  - direct blend accumulation to the selected source float.
- No contrived compiler-coaxing constructs were introduced; the function remains readable and semantically coherent.

## Technical details
- The main improvement came from restoring a realistic RandF return-value path for the `id == 0` branch and aligning the data flow around output/source selection.
- Remaining mismatch appears mostly register/allocation and addressing-form related rather than semantic.
