### PR TITLE
p_gba: match Init and GetTable

### DIFF
--- a/include/ffcc/p_gba.h
+++ b/include/ffcc/p_gba.h
@@ -11,7 +11,7 @@ public:
 	
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void SetFirstZone();
 

--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/gbaque.h"
 #include "ffcc/memory.h"
 #include "ffcc/system.h"
+#include <dolphin/gba/GBA.h>
 
 /*
  * --INFO--
@@ -16,12 +17,17 @@ CGbaPcs::CGbaPcs()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800979cc
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGbaPcs::Init()
 {
-	// TODO
+	m_stage = 0;
+	GBAInit();
 }
 
 /*
@@ -36,12 +42,17 @@ void CGbaPcs::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800979b4
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGbaPcs::GetTable(unsigned long)
+int CGbaPcs::GetTable(unsigned long index)
 {
-	// TODO
+	extern char lbl_8020F328[];
+	return (int)(lbl_8020F328 + index * 0x15c);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement missing `CGbaPcs::Init` and `CGbaPcs::GetTable` in `p_gba`, and correct `GetTable` signature to return an `int` as required by the target codegen.

## Functions improved
- `Init__7CGbaPcsFv`: 10.0% -> 100.0%
- `GetTable__7CGbaPcsFUl`: 20.0% -> 100.0%

## Match evidence
- Unit `main/p_gba` `.text` match: 61.111702% -> 68.026596%
- `Init` now emits expected stage reset (`m_stage = 0`) followed by `GBAInit()` call (40-byte target shape).
- `GetTable` now emits expected table-address calculation (`index * 0x15c + lbl_8020F328`) with matching relocation form.

## Plausibility rationale
These changes replace TODO stubs with straightforward process initialization and table lookup logic consistent with neighboring process units (`p_system`, `p_usb`) and with the PAL symbol/decomp intent. No contrived ordering or compiler-coaxing constructs were introduced.

## Technical details
- Added `<dolphin/gba/GBA.h>` include for explicit `GBAInit` declaration.
- Updated function docs with PAL address/size metadata for edited functions.
- Preserved existing matched behavior in other methods; only low-match TODO stubs were touched.
