### PR TITLE
Improve pppRandDownIV decomp match and logic shape

### DIFF
--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -2,10 +2,26 @@
 #include "ffcc/math.h"
 
 extern CMath math;
-extern int lbl_8032ED70;       // Global state flag
-extern float lbl_8032FF68;     // Float constant 2.0f
-extern double lbl_8032FF70;    // Double constant for conversion
-extern float lbl_801EADC8[32]; // Array of floats
+extern int lbl_8032ED70;
+extern float lbl_8032FF68;
+extern float lbl_801EADC8[32];
+extern "C" float RandF__5CMathFv(CMath* instance);
+
+struct RandDownIVParam {
+    int targetId;
+    int sourceOffset;
+    int x;
+    int y;
+    int z;
+    unsigned char randomTwice;
+};
+
+struct RandDownIVCtx {
+    void* unk0;
+    void* unk4;
+    void* unk8;
+    int* outputOffset;
+};
 
 /*
  * --INFO--
@@ -18,7 +34,6 @@ extern float lbl_801EADC8[32]; // Array of floats
  */
 void randint(int param1, float param2)
 {
-	// Function appears to be unused based on assembly analysis
 }
 
 /*
@@ -32,77 +47,36 @@ void randint(int param1, float param2)
  */
 void pppRandDownIV(void* arg1, void* arg2, void* arg3)
 {
-	int* data1 = (int*)arg1;
-	int* data2 = (int*)arg2;
-	int* data3 = (int*)arg3;
-	float randVal;
-	
-	// Early exit if global flag is set
-	if (lbl_8032ED70 != 0) {
-		return;
-	}
-	
-	// Check if data2[0] == data1[3]
-	if (data2[0] == data1[3]) {
-		// Get random float - assume RandF stores result in a member or global
-		math.RandF();
-		// Assume the random value is available somehow - use placeholder
-		randVal = -1.0f; // Negative placeholder for now
-		
-		// Check flag at offset 0x18 in data2
-		if (*(unsigned char*)((char*)data2 + 0x18) != 0) {
-			math.RandF();
-			float randVal2 = -1.0f; // Second random placeholder
-			randVal = (randVal - randVal2) * lbl_8032FF68; // 2.0f
-		}
-		
-		// Get base pointer from data3[3] and store result
-		void** data3_ptr = (void**)&data3[3];
-		void* base = *data3_ptr;
-		int base_offset = *((int*)base);
-		float* resultPtr = (float*)((char*)data1 + base_offset + 0x80);
-		*resultPtr = randVal;
-		return;
-	}
-	
-	// Get base address for vector operations
-	void* addr_base;
-	if (data2[1] == -1) {
-		addr_base = &lbl_801EADC8[0];
-	} else {
-		int offset = data2[1] + 0x80;
-		addr_base = (char*)data1 + offset;
-	}
-	
-	// Process vector component operations
-	int sourceVal = data2[2]; // Get value from offset 8
-	
-	// Convert signed integer to float with bias adjustment
-	float signedVal = (float)((int)(sourceVal ^ 0x80000000)) - (float)lbl_8032FF70;
-	
-	// Get current component value from addr_base
-	float currentVal = *((float*)addr_base);
-	
-	// Multiply and convert back to int
-	float result = signedVal * currentVal;
-	int resultInt = (int)result;
-	
-	// Store back to source array
-	*((int*)addr_base) += resultInt;
-	
-	// Process Y component
-	sourceVal = data2[3]; // Get value from offset 0xc
-	signedVal = (float)((int)(sourceVal ^ 0x80000000)) - (float)lbl_8032FF70;
-	currentVal = *((float*)((char*)addr_base + 4));
-	result = signedVal * currentVal;
-	resultInt = (int)result;
-	*((int*)((char*)addr_base + 4)) += resultInt;
-	
-	// Process Z component  
-	sourceVal = data2[4]; // Get value from offset 0x10
-	signedVal = (float)((int)(sourceVal ^ 0x80000000)) - (float)lbl_8032FF70;
-	currentVal = *((float*)((char*)addr_base + 8));
-	result = signedVal * currentVal;
-	resultInt = (int)result;
-	*((int*)((char*)addr_base + 8)) += resultInt;
+    int* objectWords = (int*)arg1;
+    RandDownIVParam* data = (RandDownIVParam*)arg2;
+    RandDownIVCtx* ctx = (RandDownIVCtx*)arg3;
+    float* output;
+    int* source;
+    float randomValue;
+
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
+
+    if (data->targetId != objectWords[3]) {
+        return;
+    }
+
+    randomValue = -RandF__5CMathFv(&math);
+    if (data->randomTwice != 0) {
+        randomValue = (randomValue - RandF__5CMathFv(&math)) * lbl_8032FF68;
+    }
+
+    output = (float*)((char*)arg1 + *ctx->outputOffset + 0x80);
+    *output = randomValue;
+
+    if (data->sourceOffset == -1) {
+        source = (int*)&lbl_801EADC8[0];
+    } else {
+        source = (int*)((char*)arg1 + data->sourceOffset + 0x80);
+    }
+
+    source[0] += (int)((float)data->x * *output);
+    source[1] += (int)((float)data->y * *output);
+    source[2] += (int)((float)data->z * *output);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandDownIV` in `src/pppRandDownIV.cpp` from placeholder-style logic to a structured implementation matching the unit's established runtime behavior.
- Added explicit parameter/context structs for field access instead of ad-hoc casts.
- Replaced fake random placeholders with real `RandF__5CMathFv(&math)` flow, including the optional second random path and scale by `lbl_8032FF68`.
- Implemented gated vector updates (x/y/z) using integer-to-float scaling against the computed output value.
- Removed non-informative/decomp-debug comments and cleaned unused declaration noise.

## Functions Improved
- Unit: `main/pppRandDownIV`
- Symbol: `pppRandDownIV`
- Match change: **59.752476% -> 81.72277%** (**+21.970294**)

## Match Evidence
- Baseline command:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandDownIV -o - pppRandDownIV > /tmp/pppRandDownIV_before.json`
- Updated command:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandDownIV -o - pppRandDownIV > /tmp/pppRandDownIV_after2.json`
- Objdiff structural signal:
  - Diff-marked instruction count reduced from **76** to **41**.
- Build verification:
  - `ninja` completes successfully after the change.

## Plausibility Rationale
- The new code follows plausible original game-side authoring patterns for this codebase:
  - Properly typed field access through compact structs.
  - Straightforward control flow (`global disable` check, `targetId` gate, then effect application).
  - Natural random + scaling behavior without contrived temporaries or compiler-coaxing constructs.
  - Readable arithmetic updates to source vector components that map directly to the observed PPC conversion/multiply/add pattern.
