### PR TITLE
stopwatch: improve CProfile ctor match to 96.43%

### DIFF
--- a/src/stopwatch.cpp
+++ b/src/stopwatch.cpp
@@ -2,7 +2,7 @@
 
 extern "C" float __cvt_sll_flt(u32 lo, u32 hi);
 
-extern char lbl_8032F860[]; // small-data string used by target
+extern char lbl_8032F860;
 extern float lbl_8032F854;  // 0.0f
 
 /*
@@ -51,7 +51,6 @@ void CStopWatch::Stop() { OSStopStopwatch(this); }
  */
 float CStopWatch::Get()
 {
-	// Match target: convert accumulated ticks (total) into microseconds as float.
 	u32* p = (u32*)&this->total;
 	u32 lo = p[0];
 	u32 hi = p[1];
@@ -67,7 +66,7 @@ float CStopWatch::Get()
  */
 CProfile::CProfile(char* name)
 {
-	OSInitStopwatch(this, lbl_8032F860);
+	OSInitStopwatch(this, &lbl_8032F860);
 	OSResetStopwatch(this);
 
 	OSStopwatch tmp;


### PR DESCRIPTION
## Summary
- Updated `src/stopwatch.cpp` constructor setup for `CProfile` by changing the symbol declaration/usage for `lbl_8032F860` from array form to address-of a single symbol.
- This adjusts how the compiler materializes the pointer argument passed into `OSInitStopwatch` in `CProfile::CProfile(char*)`.

## Functions improved
- Unit: `main/stopwatch`
- Symbol: `__ct__8CProfileFPc`
- Match: **87.14286% -> 96.42857%**

## Match evidence
- `objdiff` now reports only one remaining constructor difference (`DIFF_INSERT`) for `__ct__8CProfileFPc`.
- Other key stopwatch symbols remain stable:
  - `Get__10CStopWatchFv`: `73.4%`
  - `ProfEnd__8CProfileFv`: `85.08%`

## Plausibility rationale
- The change is source-plausible and semantic-preserving: it only refines the external symbol declaration/usage pattern and does not alter runtime behavior.
- This is consistent with legitimate original-source variation in how external string/symbol addresses were represented in Metrowerks-era code.

## Technical details
- `extern char lbl_8032F860[];` + direct pass was changed to `extern char lbl_8032F860;` + address pass (`&lbl_8032F860`).
- This narrowed constructor prologue/address-materialization mismatch while keeping logic and data flow intact.
