### PR TITLE
MSL mem: match .init memcpy/memset and fix section placement

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/mem.c
+++ b/src/MSL_C/PPCEABI/bare/H/mem.c
@@ -1,4 +1,4 @@
-#include "string.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/string.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/mem_funcs.h"
 
 void* memmove(void* dst, const void* src, size_t n)
@@ -60,20 +60,22 @@ void* memchr(const void* ptr, int ch, size_t count)
 	return NULL;
 }
 
-unsigned char* __memrchr(unsigned char* s, int c, size_t n){ // credit to CelestialAmber
-    int n_count;
+void* __memrchr(const void* ptr, int c, size_t n)
+{
+	int n_count;
 	size_t char_check;
-    
-    char_check = (unsigned char)c;
-    s = &s[n];
-    n_count = n + 1;
-	
-    while(--n_count){
-		if(*--s == char_check){
-            return s;
-        }
-    }
-	
+	const unsigned char* s;
+
+	char_check = (unsigned char)c;
+	s = (const unsigned char*)ptr + n;
+	n_count = n + 1;
+
+	while (--n_count) {
+		if (*--s == char_check) {
+			return (void*)s;
+		}
+	}
+
 	return 0;
 }
 
@@ -97,42 +99,47 @@ void* memcpy(void* dst, const void* src, size_t count)
 	unsigned char* dstPtr;
 	int n;
 
-	if (dst <= src) {
-		srcPtr = (unsigned char*)src - 1;
-		dstPtr = (unsigned char*)dst - 1;
-		n = count + 1;
-		while (--n != 0) {
-			*++dstPtr = *++srcPtr;
-		}
-	} else {
-		srcPtr = (unsigned char*)src + count;
-		dstPtr = (unsigned char*)dst + count;
-		n = count + 1;
-		while (--n != 0) {
-			*--dstPtr = *--srcPtr;
-		}
+	if ((unsigned int)src < (unsigned int)dst) {
+		goto reverse_copy;
+	}
+
+	srcPtr = (unsigned char*)src - 1;
+	dstPtr = (unsigned char*)dst - 1;
+	n = count + 1;
+	while (--n != 0) {
+		*++dstPtr = *++srcPtr;
+	}
+	return dst;
+
+reverse_copy:
+	srcPtr = (unsigned char*)src + count;
+	dstPtr = (unsigned char*)dst + count;
+	n = count + 1;
+	while (--n != 0) {
+		*--dstPtr = *--srcPtr;
 	}
 	return dst;
 }
 
-void __fill_mem(void* dst, unsigned char c, size_t count)
+void __fill_mem(void* dst, int c, size_t count)
 {
-	unsigned int fillValue;
+	unsigned int alignBytes;
 	unsigned int* wordPtr;
 	unsigned char* bytePtr;
-	unsigned int alignBytes;
+	unsigned int fillValue;
 	unsigned int words;
 
-	fillValue = (unsigned int)c;
+	c &= 0xFF;
 	bytePtr = (unsigned char*)dst - 1;
+	fillValue = c;
 
-	if (count > 31) {
-		alignBytes = (~(unsigned int)bytePtr) & 3;
+	if (count >= 0x20) {
+		alignBytes = ~(unsigned int)bytePtr & 3;
 		if (alignBytes != 0) {
 			count -= alignBytes;
 			do {
-				*++bytePtr = c;
 				alignBytes--;
+				*++bytePtr = c;
 			} while (alignBytes != 0);
 		}
 
@@ -154,23 +161,26 @@ void __fill_mem(void* dst, unsigned char c, size_t count)
 		}
 
 		for (words = (count >> 2) & 7; words != 0; words--) {
-			*++wordPtr = fillValue;
+			wordPtr++;
+			*wordPtr = fillValue;
 		}
 
-		bytePtr = (unsigned char*)((int)wordPtr + 3);
+		bytePtr = (unsigned char*)((unsigned int)wordPtr + 3);
 		count = count & 3;
 	}
 
-	if (count != 0) {
-		do {
-			*++bytePtr = (unsigned char)fillValue;
-			count--;
-		} while (count != 0);
+	if (count == 0) {
+		return;
 	}
+
+	do {
+		count--;
+		*++bytePtr = fillValue;
+	} while (count != 0);
 }
 
 void* memset(void* dst, int c, size_t count)
 {
-	__fill_mem(dst, (unsigned char)c, count);
+	__fill_mem(dst, c, count);
 	return dst;
 }


### PR DESCRIPTION
## Summary
- Switched `src/MSL_C/PPCEABI/bare/H/mem.c` to include the MSL string header with `.init` function declarations, so `memset`, `__fill_mem`, and `memcpy` are emitted in the correct section.
- Updated `__memrchr` signature to match the declared prototype (`void* __memrchr(const void*, int, size_t)`) so the MSL header can be used cleanly.
- Restructured `memcpy`/`memset` call shape and `__fill_mem` signature/call site (`int` value path) to align with expected ABI/control-flow style.

## Functions improved
Unit: `main/MSL_C/PPCEABI/bare/H/mem`
- `memcpy`: `0.0% -> 100.0%`
- `memset`: `0.0% -> 100.0%`
- `__fill_mem`: remains `0.0%`

## Match evidence
- Selector baseline for this unit: `54.1%` matched code (`4/7` functions matched).
- After this change (`ninja` report): `72.94%` matched code, `85.71%` matched functions (`6/7`).
- Net code improvement in global progress: `+128` matched code bytes (from `170144` to `170272`), consistent with `memcpy` (80b) + `memset` (48b).

## Plausibility rationale
- The key correction is section/ABI correctness (`.init` placement and prototype consistency), which is a source-plausible SDK fix rather than artificial compiler coaxing.
- The remaining edits use standard MSL-style control flow and pointer arithmetic.

## Technical details
- `objdiff` now maps the previously unmapped `.init` symbols correctly.
- Current symbol status in this unit:
  - `memcpy` `100.0%`
  - `memset` `100.0%`
  - `__fill_mem` `0.0%`
  - other functions unchanged at `100.0%`.
