### PR TITLE
Improve pppScale match by correcting control flow and offsets

### DIFF
--- a/src/pppScale.cpp
+++ b/src/pppScale.cpp
@@ -9,26 +9,20 @@ extern int DAT_8032ed70;
  */
 void pppScale(void* obj, void* param2, void* param3)
 {
-	void* dataPtr = *((void**)((char*)param3 + 0x0c));
-	
 	if (DAT_8032ed70 != 0) {
 		return;
 	}
 	
-	if (*((int*)((char*)param2 + 0x08)) == *((int*)((char*)obj + 0x08))) {
-		float scale = *((float*)((char*)param2 + 0x0c));
-		float* pfVar2 = (float*)((char*)obj + *((int*)((char*)dataPtr + 0x04)) + 0x80);
-		pfVar2[0] += scale;
-		pfVar2[1] += scale;  
-		pfVar2[2] += scale;
+	if (*((int*)((char*)param2 + 0x00)) != *((int*)((char*)obj + 0x0c))) {
+		return;
 	}
-	
-	float* pfVar1 = (float*)((char*)obj + *((int*)((char*)dataPtr + 0x00)) + 0x80);
-	float* pfVar2 = (float*)((char*)obj + *((int*)((char*)dataPtr + 0x04)) + 0x80);
-	
-	pfVar1[0] = pfVar2[0];
-	pfVar1[1] = pfVar2[1];
-	pfVar1[2] = pfVar2[2];
+
+	void* dataPtr = *((void**)((char*)param3 + 0x0c));
+	float* dst = (float*)((char*)obj + *((int*)((char*)dataPtr + 0x00)) + 0x80);
+
+	dst[0] += *((float*)((char*)param2 + 0x08));
+	dst[1] += *((float*)((char*)param2 + 0x0c));
+	dst[2] += *((float*)((char*)param2 + 0x10));
 }
 
 /*


### PR DESCRIPTION
## Summary
This PR refines `pppScale` in `src/pppScale.cpp` to match the original control flow and data layout usage:
- Early return now checks `param2 + 0x0` against `obj + 0x0c`.
- Removes non-matching copy-back block.
- Applies additive updates directly to destination vector using three float components from `param2 + {0x08,0x0c,0x10}`.

## Functions Improved
- Unit: `main/pppScale`
- Symbol: `pppScale` (PAL `0x800630f0`, 96b)
  - Before: `34.208332%`
  - After: `99.791664%`
- Symbol: `pppScaleCon` remains near-matching at `99.333336%`

## Match Evidence
`objdiff-cli` (`build/tools/objdiff-cli diff -p . -u main/pppScale -o -`) now reports:
- `pppScaleCon: 99.333336%`
- `pppScale: 99.791664%`
- Unit `.text` match: `99.666664%`

This is a real assembly alignment improvement (not formatting-only), with corrected branch behavior and field offsets in generated code.

## Plausibility Rationale
The update improves source plausibility by aligning to straightforward game/runtime semantics instead of compiler-coaxing:
- Uses consistent offset-based field access patterns already common in nearby `ppp*` units.
- Simplifies behavior to a single gated vector accumulation path.
- Removes the extra copy path that produced non-matching control flow and non-matching memory access sequence.

## Technical Notes
The key shift was matching the observed instruction-level pattern for:
- compare-and-early-return branch shape
- destination pointer selection from `param3->0xc` base offset `+0x00`
- three independent float additions using contiguous parameter fields
