### PR TITLE
alloc: add __pool_alloc and malloc implementations

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -620,6 +620,52 @@ static void* allocate_from_fixed_pools(__mem_pool_obj* pool_obj, unsigned long s
     return (char*)sub_block + 4;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801b1f30
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* __pool_alloc(__mem_pool* pool, unsigned long size) {
+    __mem_pool_obj* pool_obj;
+
+    if (size == 0) {
+        return 0;
+    }
+
+    if (size >= 0xFFFFFFD0UL) {
+        return 0;
+    }
+
+    pool_obj = (__mem_pool_obj*)pool;
+    if (size <= 68) {
+        return allocate_from_fixed_pools(pool_obj, size);
+    }
+
+    return allocate_from_var_pools(pool_obj, size);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x801b1e5c
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* malloc(size_t size) {
+    void* ptr;
+
+    __begin_critical_region(malloc_pool_access);
+    ptr = __pool_alloc(get_malloc_pool(), size);
+    __end_critical_region(malloc_pool_access);
+    return ptr;
+}
+
 void __pool_free(__mem_pool* pool, void* ptr) {
     __mem_pool_obj* pool_obj;
     unsigned long size;


### PR DESCRIPTION
## Summary
- Added explicit `__pool_alloc` and `malloc` implementations in `src/MSL_C/PPCEABI/bare/H/alloc.c`.
- Kept allocator routing source-plausible and aligned with existing pool helpers:
  - `__pool_alloc` now handles zero-size and oversized guards, then routes to fixed/variable pools.
  - `malloc` now enters/leaves the malloc critical region and allocates through `__pool_alloc(get_malloc_pool(), size)`.
- Included PAL address/size info blocks for both functions.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/alloc`
- `malloc` (PAL 0x801b1e5c, 124b): now present and decompiled with `fuzzy_match_percent: 100.0`.
- `__pool_alloc` (PAL 0x801b1f30, 84b): now present and decompiled with `fuzzy_match_percent: 99.71429`.

## Match evidence
- Build/progress delta after this change:
  - Code bytes matched: `170144 -> 170268` (`+124`)
  - Matched functions: `1102 -> 1103` (`+1`)
- Unit report now shows `main/MSL_C/PPCEABI/bare/H/alloc` at:
  - `matched_code: 1328 / 3800`
  - `matched_functions: 5 / 12`
  - `fuzzy_match_percent: 59.090527`

## Plausibility rationale
- The added logic reflects canonical MSL allocator behavior (guard + fixed/var pool dispatch + critical section in `malloc`) and uses existing project structures/helpers rather than contrived compiler-coaxing patterns.
- No debug artifacts, no commented-out code, and no manual assembly inserted.

## Technical details
- `objdiff`/report now resolves both symbols in `alloc.o` with high-fidelity matches.
- The remaining tiny mismatch in `__pool_alloc` is a minor branch/immediate selection difference while preserving expected control flow.
