### PR TITLE
Improve pppParMoveLine match via local flow reshaping

### DIFF
--- a/src/pppParMoveLine.cpp
+++ b/src/pppParMoveLine.cpp
@@ -15,23 +15,28 @@
  */
 void pppParMoveLine(_pppPObject* param_1, int param_2)
 {
-    _pppMngSt* pppMngSt = pppMngStPtr;
+    _pppMngSt* pppMngSt;
+    void* moveParam;
     Vec local_1c;
     Vec VStack_28;
-    float fVar1 = 0.0f;
-    Vec* position = (Vec*)((char*)pppMngSt + 0x8);
-    Vec* previousPosition = (Vec*)((char*)pppMngSt + 0x48);
+    Vec* position;
+    float fVar1;
+
+    moveParam = (void*)param_2;
+    pppMngSt = pppMngStPtr;
+    position = (Vec*)((char*)pppMngSt + 0x8);
+    fVar1 = 0.0f;
 
     PSVECSubtract((Vec*)((char*)pppMngSt + 0x68), (Vec*)((char*)pppMngSt + 0x58), &local_1c);
 
-    previousPosition->x = position->x;
-    previousPosition->y = position->y;
-    previousPosition->z = position->z;
+    *(float*)((char*)pppMngSt + 0x48) = position->x;
+    *(float*)((char*)pppMngSt + 0x4C) = position->y;
+    *(float*)((char*)pppMngSt + 0x50) = position->z;
 
     if ((fVar1 != local_1c.x) || (fVar1 != local_1c.y) || (fVar1 != local_1c.z)) {
         PSVECNormalize(&local_1c, &VStack_28);
 
-        float scaleValue = *(float*)(param_2 + 4) * *(float*)((char*)pppMngSt + 0x54);
+        float scaleValue = *(float*)((char*)moveParam + 4) * *(float*)((char*)pppMngSt + 0x54);
         PSVECScale(&VStack_28, &local_1c, scaleValue);
         PSVECAdd(&local_1c, position, position);
     }


### PR DESCRIPTION
## Summary
This PR improves `main/pppParMoveLine` by reshaping `pppParMoveLine` local/value flow without changing behavior:
- split declaration/assignment order to better match original register lifetimes
- kept an explicit local alias for `param_2` to preserve use across vector calls
- rewrote previous-position copy using explicit offsets (`0x48/0x4C/0x50`) to match observed access shape

## Functions improved
- Unit: `main/pppParMoveLine`
- Symbol: `pppParMoveLine`
- Match: **84.293106% -> 86.27586%** (+1.982754)

## Match evidence
- Baseline: `build/tools/objdiff-cli diff -p . -u main/pppParMoveLine -o - pppParMoveLine`
  - `pppParMoveLine` match `84.293106`
- After change: same command
  - `pppParMoveLine` match `86.27586`

Objdiff shows tighter alignment in prologue/local setup and value flow around the position/previous-position update path.

## Plausibility rationale
The change is source-plausible for original code style:
- no contrived dead code or artificial compiler tricks
- uses straightforward local variables and offset-based field writes already common in WIP ppp manager code
- keeps function semantics intact while improving generated layout

## Technical details
- Edited: `src/pppParMoveLine.cpp`
- Build: `ninja` passes
- Validation: objdiff CLI JSON oneshot against `main/pppParMoveLine::pppParMoveLine`
