### PR TITLE
pad: match reset callback symbol OnReset2

### DIFF
--- a/src/pad/Pad.c
+++ b/src/pad/Pad.c
@@ -67,7 +67,7 @@ static void SPEC1_MakeStatus(s32 chan, PADStatus *status, u32 data[2]);
 static s8 ClampS8(s8 var, s8 org);
 static u8 ClampU8(u8 var, u8 org);
 static void SPEC2_MakeStatus(s32 chan, PADStatus *status, u32 data[2]);
-static BOOL OnReset(BOOL f);
+static BOOL OnReset2(BOOL f);
 void __PADDisableXPatch(void);
 BOOL __PADDisableRumble(BOOL disable);
 
@@ -80,7 +80,7 @@ static u32 CmdCalibrate = 0x42000000;
 static u32 CmdProbeDevice[4];
 
 static OSResetFunctionInfo ResetFunctionInfo = {
-    OnReset,
+    OnReset2,
     127,
     NULL,
     NULL,
@@ -784,7 +784,7 @@ void PADSetAnalogMode(u32 mode) {
 
 static void (*SamplingCallback)();
 
-static BOOL OnReset(BOOL final) {
+static BOOL OnReset2(BOOL final) {
     BOOL sync;
     static BOOL recalibrated = FALSE;
 


### PR DESCRIPTION
## Summary
- Renamed the PAD reset callback symbol from `OnReset` to `OnReset2` in `src/pad/Pad.c`.
- Updated the forward declaration, `ResetFunctionInfo` initializer, and function definition consistently.

## Functions Improved
- Unit: `main/pad/Pad`
- Function: `OnReset2` (404 bytes)

## Match Evidence
- `OnReset2`: **0.0% -> 90.346535%** (previously unmatched in selector output, now matched in report)
- `main/pad/Pad` unit fuzzy: **87.2764 -> 92.9441**

## Plausibility Rationale
- This change corrects symbol identity and linkage intent rather than introducing compiler-coaxing control-flow tricks.
- The callback is wired through `OSResetFunctionInfo`; using the expected symbol name (`OnReset2`) is consistent with the target function table and existing SDK-style structure in this file.

## Technical Details
- The prior state left `OnReset2` as an unmatched target despite having a corresponding callback body.
- After renaming, objdiff/report now maps and scores the function, indicating real assembly alignment rather than superficial source formatting changes.
- No behavioral logic was changed; only symbol naming/connectivity was corrected.
