### PR TITLE
Match pppMatrixLoc by restoring original data-flow shape

### DIFF
--- a/src/pppMatrixLoc.cpp
+++ b/src/pppMatrixLoc.cpp
@@ -10,17 +10,14 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppMatrixLoc(void* target, void* param)
-{
-    // Initialize matrix to identity (matrix is at offset 0x10)
-    PSMTXIdentity((MtxPtr)((char*)target + 0x10));
-    
-    // Get position data pointer from param+0xc, then add target+0x80  
-    int dataOffset = *(int*)((char*)param + 0xc);
-    f32* posData = (f32*)((char*)target + dataOffset + 0x80);
-    
-    // Store position values in matrix translation column
-    *(f32*)((char*)target + 0x1c) = posData[0];  // X translation  
-    *(f32*)((char*)target + 0x2c) = posData[1];  // Y translation
-    *(f32*)((char*)target + 0x3c) = posData[2];  // Z translation
+void pppMatrixLoc(void* target, void* param) {
+    char* t = (char*)target;
+    char* p = (char*)param;
+    f32* pos;
+
+    PSMTXIdentity((MtxPtr)(t + 0x10));
+    pos = (f32*)(t + *(int*)(p + 0xC) + 0x80);
+    *(f32*)(t + 0x1C) = pos[0];
+    *(f32*)(t + 0x2C) = pos[1];
+    *(f32*)(t + 0x3C) = pos[2];
 }


### PR DESCRIPTION
## Summary
- Reworked `pppMatrixLoc` to use a simple local pointer flow that matches the target codegen shape.
- Removed non-source-style explanatory comments and kept the implementation concise and plausible.

## Functions Improved
- Unit: `main/pppMatrixLoc`
- Symbol: `pppMatrixLoc`
- Size: `96b`

## Match Evidence
- `build/tools/objdiff-cli diff -p . -u main/pppMatrixLoc -o - pppMatrixLoc`
- Before: `66.041664%`
- After: `100.0%`

## Plausibility Rationale
- The updated function reflects straightforward original-source intent: build identity matrix, compute translation source pointer from the parameter block offset, and write XYZ translation components.
- Changes are semantic cleanup and data-flow ordering, not contrived compiler coaxing.

## Technical Details
- Delayed offset/pointer materialization until after `PSMTXIdentity` so the emitted register lifetimes match the target.
- Used explicit local pointers for the target object and parameter block to match the expected load/store sequence at offsets `0x0C`, `0x1C`, `0x2C`, and `0x3C`.
