### PR TITLE
axfx/delay: improve AXFXDelayShutdown match

### DIFF
--- a/src/axfx/delay.c
+++ b/src/axfx/delay.c
@@ -123,6 +123,15 @@ int AXFXDelayInit(AXFX_DELAY* delay) {
     AXFXDelaySettings(delay);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x80196934
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 int AXFXDelayShutdown(AXFX_DELAY* delay) {
     BOOL old;
 
@@ -138,10 +147,6 @@ int AXFXDelayShutdown(AXFX_DELAY* delay) {
     if (delay->sur) {
         __AXFXFree(delay->sur);
     }
-
-    delay->left = NULL;
-    delay->right = NULL;
-    delay->sur = NULL;
 
     OSRestoreInterrupts(old);
     return 1;


### PR DESCRIPTION
## Summary
- Updated `AXFXDelayShutdown` in `src/axfx/delay.c` to remove post-free pointer zeroing (`left/right/sur`) so the emitted control/data flow aligns with PAL codegen.
- Added the required function metadata header block for the updated function.

## Functions improved
- Unit: `main/axfx/delay`
- Function: `AXFXDelayShutdown`
  - Before: `88.47222%`
  - After: `99.583336%`

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/axfx/delay -o - AXFXDelaySettings`
- Observed reduction of mismatch in `AXFXDelayShutdown`; remaining delta is minor relocation/call-target noise.
- `AXFXDelaySettings` remained unchanged at `55.054264%` in this PR.

## Plausibility rationale
- This change removes cleanup behavior that appears to be a decomp-added safety pattern rather than required original behavior in this PAL build.
- The resulting shutdown routine matches the expected minimal SDK-style interrupt-guarded free sequence and avoids contrived control-flow tweaks.

## Technical details
- Kept function structure and interrupt guard intact.
- No artificial temporaries or reordering to coerce codegen.
- Rebuilt with `ninja` and confirmed no regressions in build/verification output.
