### PR TITLE
Improve match for pppRandDownHCV

### DIFF
--- a/src/pppRandDownHCV.cpp
+++ b/src/pppRandDownHCV.cpp
@@ -1,7 +1,12 @@
 #include "ffcc/pppRandDownHCV.h"
 #include "ffcc/math.h"
+#include "dolphin/types.h"
 
 extern CMath math;
+extern int lbl_8032ED70;
+extern s16 lbl_801EADC8[];
+extern float lbl_8032FF48;
+extern "C" float RandF__5CMathFv(CMath* instance);
 
 extern "C" {
 
@@ -12,7 +17,7 @@ extern "C" {
  */
 void randshort(short value, float multiplier)
 {
-    // Simple random short generation function
+    return;
 }
 
 /*
@@ -26,87 +31,51 @@ void randshort(short value, float multiplier)
  */
 void pppRandDownHCV(void* param1, void* param2, void* param3)
 {
-    // External references from assembly
-    extern int lbl_8032ED70;
-    extern short lbl_801EADC8[4]; // Vector data from assembly
-    extern float lbl_8032FF48;    // Constant 0.5f from assembly
-    extern float lbl_8032FF50;    // Double constant from assembly
-    
-    // Parameter register assignments from assembly
-    void* r30 = param1;  // r30 in original
-    void* r31 = param2;  // r31 in original  
-    void* r29 = param3;  // r29 in original
-    
-    // Check global flag - matches assembly cmpwi r0, 0x0 + bne
-    if (lbl_8032ED70 == 0) {
+    if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    // Assembly: lwz r3, 0x0(r31) vs lwz r0, 0xc(r30) + cmpw
-    int* r31_int = (int*)r31;
-    int* r30_int = (int*)r30; 
-    if (r31_int[0] == r30_int[3]) {
-        // First branch - random generation path
-        math.RandF(); // bl RandF__5CMathFv
-        float randVal = -1.0f; // fneg f31, f1 (placeholder for RandF result)
-        
-        // Assembly: lbz r0, 0x10(r31) + cmplwi r0, 0x0 + beq
-        unsigned char* r31_bytes = (unsigned char*)r31;
-        if (r31_bytes[0x10] != 0) {
-            math.RandF(); // Second RandF call
-            float randVal2 = 1.0f; // Placeholder for second RandF
-            randVal = (-randVal - randVal2) * lbl_8032FF48; // fsubs + fmuls with 0.5f
+
+    if (*(int*)param2 == *((int*)param1 + 3)) {
+        float rand_value = -RandF__5CMathFv(&math);
+        if (*((u8*)param2 + 0x10) != 0) {
+            rand_value = (rand_value - RandF__5CMathFv(&math)) * lbl_8032FF48;
         }
-        
-        // Assembly: lwz r3, 0xc(r29) + lwz r3, 0x0(r3) + addi r5, r3, 0x80
-        int** r29_ptr = (int**)((char*)r29 + 0xc);
-        int* base = *r29_ptr;
-        int offset = *base + 0x80;
-        float* target = (float*)((char*)r30 + offset);
-        
-        // Assembly: stfs f31, 0x0(r5)
-        *target = randVal;
-        
-    } else if (r31_int[0] != r30_int[3]) {
-        // Second branch - direct coordinate manipulation 
-        int** r29_ptr = (int**)((char*)r29 + 0xc);
-        int* base = *r29_ptr;
-        int offset = *base + 0x80;
-        
-        // Assembly: lwz r3, 0x4(r31) + cmpwi r3, -0x1
-        short* sourceData;
-        if (r31_int[1] == -1) {
-            sourceData = lbl_801EADC8; // Global constant vector
+
+        int data_offset = **(int**)((char*)param3 + 0xc);
+        *(float*)((char*)param1 + data_offset + 0x80) = rand_value;
+    } else if (*(int*)param2 != *((int*)param1 + 3)) {
+        int data_offset = **(int**)((char*)param3 + 0xc);
+        float* random_value = (float*)((char*)param1 + data_offset + 0x80);
+        int color_offset = *((int*)param2 + 1);
+        s16* target;
+
+        if (color_offset == -1) {
+            target = lbl_801EADC8;
         } else {
-            sourceData = (short*)((char*)r30 + r31_int[1] + 0x80);
+            target = (s16*)((char*)param1 + color_offset + 0x80);
         }
-        
-        // Get scale factor for coordinate transformations
-        float* scalePtr = (float*)((char*)r30 + offset);
-        float scale = *scalePtr;
-        
-        // Process each coordinate component (assembly shows 4 identical patterns)
-        char* r31_bytes = (char*)r31;
-        
-        // X: lha r3, 0x8(r31) + math operations + sth r0, 0x0(r4)
-        short srcX = *(short*)(r31_bytes + 0x8);
-        short result = sourceData[0] + (short)(srcX * scale);
-        sourceData[0] = result;
-        
-        // Y: lha r0, 0xa(r31) + math operations + sth r0, 0x2(r4)  
-        short srcY = *(short*)(r31_bytes + 0xa);
-        result = sourceData[1] + (short)(srcY * scale);
-        sourceData[1] = result;
-        
-        // Z: lha r0, 0xc(r31) + math operations + sth r0, 0x4(r4)
-        short srcZ = *(short*)(r31_bytes + 0xc);
-        result = sourceData[2] + (short)(srcZ * scale);
-        sourceData[2] = result;
-        
-        // W: lha r0, 0xe(r31) + math operations + sth r0, 0x6(r4)
-        short srcW = *(short*)(r31_bytes + 0xe);
-        result = sourceData[3] + (short)(srcW * scale);
-        sourceData[3] = result;
+
+        float scale = random_value[0];
+
+        {
+            s16 base = *(s16*)((char*)param2 + 0x8);
+            target[0] = (s16)(target[0] + (int)((float)base * scale));
+        }
+
+        {
+            s16 base = *(s16*)((char*)param2 + 0xa);
+            target[1] = (s16)(target[1] + (int)((float)base * scale));
+        }
+
+        {
+            s16 base = *(s16*)((char*)param2 + 0xc);
+            target[2] = (s16)(target[2] + (int)((float)base * scale));
+        }
+
+        {
+            s16 base = *(s16*)((char*)param2 + 0xe);
+            target[3] = (s16)(target[3] + (int)((float)base * scale));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Rewrote `pppRandDownHCV` to follow the observed PAL control flow and data access pattern.
- Replaced placeholder logic with concrete random-scalar generation and signed short channel updates.
- Kept `randshort` as a stub return while removing placeholder comments.

## Functions Improved
- Unit: `main/pppRandDownHCV`
- Symbol: `pppRandDownHCV`

## Match Evidence
- `objdiff` symbol match: **72.307% -> 90.333%** (`+18.026`)
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandDownHCV -o - pppRandDownHCV`
- Improvement is instruction-level, including better prologue/branch structure and arithmetic/dataflow alignment.

## Plausibility Rationale
- The rewrite uses idiomatic game-code style pointer/offset access already common in adjacent `ppp*HCV` code.
- Changes are type and control-flow corrections (global gate, compare path split, per-channel short accumulation), not contrived compiler-only scaffolding.
- Arithmetic behavior matches expected author intent: compute one random scale path, otherwise apply scaled signed deltas into target channels.

## Technical Details
- Preserved the two-way compare structure (`if (...) { ... } else if (...) { ... }`) used by the original object layout.
- Aligned random path to unary-negated first sample plus optional second-sample blend via `lbl_8032FF48`.
- Aligned non-random path to indexed target selection (`-1` sentinel to `lbl_801EADC8`) and four signed-short updates from offsets `0x8..0xe`.
