### PR TITLE
main/cflat_r2system: implement SetNextScriptNewGame

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -128,6 +128,7 @@ public:
     void MakeNumMonName(char*, int, int);
     const char* GetLangString();
     void SetNextScript(CGame::CNextScript* nextScript);
+    void SetNextScriptNewGame();
     void IsWorldMap();
     void IsPartyExist(int);
     void GetItemName(int);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1,4 +1,19 @@
 #include "ffcc/cflat_r2system.h"
+#include "ffcc/game.h"
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8F80
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGame::SetNextScriptNewGame()
+{
+    m_nextScript.m_flags = 1;
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Implemented `CGame::SetNextScriptNewGame()` in `src/cflat_r2system.cpp`.
- Added the method declaration in `include/ffcc/game.h`.
- Used the PAL decomp reference for address/size and behavior (`m_nextScript.m_flags = 1`).

## Functions Improved
- Unit: `main/cflat_r2system`
- Symbol: `SetNextScriptNewGame__5CGameFv`

## Match Evidence
- Before: `0.0%` (from `tools/agent_select_target.py` target list)
- After: `100.0%` via:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - SetNextScriptNewGame__5CGameFv`
  - Parsed result: `match_percent: 100.0`, `size: 16`

## Plausibility Rationale
- This is a straightforward class method setting a known game state flag (`CGame::m_nextScript.m_flags`).
- It uses existing named structure members from `CGame` rather than compiler-coaxing patterns or hardcoded object offsets.
- The resulting code is minimal and consistent with likely original source intent.

## Technical Details
- Added the required version metadata block with PAL address/size in the function comment.
- Verified full build success with `ninja` after the change.
