### PR TITLE
Match pppWDrawMatrix to 99.17%

### DIFF
--- a/src/pppWDrawMatrix.cpp
+++ b/src/pppWDrawMatrix.cpp
@@ -14,12 +14,13 @@
  */
 void pppWDrawMatrix(_pppPObject* pppPObject)
 {
-    char* base = (char*)pppPObject;
-    Mtx* worldMtx = (Mtx*)(base + 0x40);
+    register char* p = (char*)pppPObject;
 
-    PSMTXConcat(ppvCameraMatrix0, *(Mtx*)(base + 0x4), *worldMtx);
-
-    PSVECScale((Vec*)worldMtx, (Vec*)worldMtx, *(float*)((char*)pppMngStPtr + 0x64));
-    PSVECScale((Vec*)(base + 0x50), (Vec*)(base + 0x50), *(float*)((char*)pppMngStPtr + 0x68));
-    PSVECScale((Vec*)(base + 0x60), (Vec*)(base + 0x60), *(float*)((char*)pppMngStPtr + 0x6c));
+    PSMTXConcat(ppvCameraMatrix0, *(Mtx*)(p + 0x10), *(Mtx*)(p + 0x40));
+    PSVECScale((Vec*)(p + 0x40), (Vec*)(p + 0x40),
+               *(float*)((char*)pppMngStPtr + 0x28));
+    PSVECScale((Vec*)(p + 0x50), (Vec*)(p + 0x50),
+               *(float*)((char*)pppMngStPtr + 0x2c));
+    PSVECScale((Vec*)(p + 0x60), (Vec*)(p + 0x60),
+               *(float*)((char*)pppMngStPtr + 0x30));
 }


### PR DESCRIPTION
## Summary
- Reworked `pppWDrawMatrix` to use pointer offsets that match the PAL object layout used by this unit.
- Adjusted expression shape so CodeWarrior emits the same callee-saved register pattern and call argument setup as the target.
- Kept function behavior unchanged (camera/world concat, then per-axis scale of matrix basis vectors).

## Functions improved
- Unit: `main/pppWDrawMatrix`
- Symbol: `pppWDrawMatrix`
- Before: `60.666668%`
- After: `99.166664%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/pppWDrawMatrix -o - pppWDrawMatrix`
- Remaining diffs are relocation-name mismatches only:
  - `ppvCameraMatrix02` vs `ppvCameraMatrix0`
  - `lbl_8032ED50` vs `pppMngStPtr`
- Instruction flow/stack frame now aligns (`0x78`-byte function with only `r31` saved).

## Plausibility rationale
- Changes are consistent with existing codebase style in nearby `ppp*DrawMatrix*` functions (raw offset matrix/vector access is already used heavily in this area).
- The resulting source expresses expected game logic directly, without no-op temporaries or artificial dead code.
- Register allocation improvement follows from source form and does not require inline assembly.

## Technical details
- Matrix source argument changed to object offset `+0x10` and destination to `+0x40`.
- Scale factors are loaded from manager state offsets `+0x28/+0x2c/+0x30`, aligning with the in-progress `_pppMngSt` offset map.
- A local `register` base pointer was used to produce the target prologue/epilogue and remove extra `r30` save/restore.
