### PR TITLE
main/pppConformBGNormal: improve pppConstructConformBGNormal to 99.55%

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -26,14 +26,16 @@ extern void* MapMng;
  */
 void pppConstructConformBGNormal(struct pppConformBGNormal* conformBG, struct UnkC* param2)
 {
-    f32 fVar1;
+    int* serializedDataOffsets;
     f32* pfVar2;
-    
-    fVar1 = FLOAT_80331908;
-    pfVar2 = (f32*)((int)(&conformBG->field0_0x0 + 2) + *param2->m_serializedDataOffsets);
-    pfVar2[2] = FLOAT_80331908;
-    pfVar2[1] = fVar1;
-    *pfVar2 = fVar1;
+    f32 scale;
+
+    serializedDataOffsets = *(int**)((u8*)param2 + 0xc);
+    pfVar2 = (f32*)((u8*)conformBG + 0x80 + *serializedDataOffsets);
+    scale = FLOAT_80331908;
+    pfVar2[2] = scale;
+    pfVar2[1] = scale;
+    pfVar2[0] = scale;
     *(u8*)(pfVar2 + 3) = 0;
 }
 


### PR DESCRIPTION
## Summary
Adjusted `pppConstructConformBGNormal` pointer math and initialization flow to align with expected serialized-offset access and data layout.

## Functions improved
- Unit: `main/pppConformBGNormal`
- Symbol: `pppConstructConformBGNormal`
- Before: `87.72727%`
- After: `99.545456%`

## Match evidence
- Ran:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/pppConformBGNormal -o - pppConstructConformBGNormal`
- The updated function now emits the expected `lwz r4, 0xc(r4)` -> `lwz r4, 0(r4)` -> `addi r4, 0x80` sequence and keeps a single constant load reused across the 3 stores.
- Unit-level code match increased (from ~`3.155%` to ~`3.481%` in objdiff output for this unit).

## Plausibility rationale
This change is source-plausible: it models serialized data as an offset table behind a context pointer, then writes three equal float components plus a byte flag at a per-instance data block (`base + 0x80 + offset`). This is consistent with surrounding particle/PPP constructors in the codebase using offset-table based initialization.

## Technical details
- Replaced `*param2->m_serializedDataOffsets` with access through the pointer located at `param2 + 0xC` (matching generated access path for this module).
- Used a single local float (`scale`) to prevent duplicate constant reloads and match original instruction structure.
- Kept changes localized to `src/pppConformBGNormal.cpp` and verified successful rebuild with `ninja`.
