### PR TITLE
main/pppAngMove: fix pppAngMoveCon offset indirection

### DIFF
--- a/src/pppAngMove.cpp
+++ b/src/pppAngMove.cpp
@@ -6,28 +6,32 @@ extern int lbl_8032ED70;
  * --INFO--
  * PAL Address: 0x80064e80
  * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppAngMove(void* dest, void* src, void* param1, void* param2)
 {
     if (lbl_8032ED70 != 0) {
         return;
     }
-    
+
     int* param2Ptr = (int*)param2;
     int destOffset = param2Ptr[0];
     int srcOffset = param2Ptr[1];
     int* destPtr = (int*)((char*)dest + destOffset + 0x80);
     int* srcPtr = (int*)((char*)dest + srcOffset + 0x80);
-    
+
     if (param1 != 0) {
         int* param1Ptr = (int*)param1;
         if (param1Ptr[3] == ((int*)dest)[3]) {
             srcPtr[0] += param1Ptr[2];
-            srcPtr[1] += param1Ptr[3]; 
+            srcPtr[1] += param1Ptr[3];
             srcPtr[2] += param1Ptr[4];
         }
     }
-    
+
     destPtr[0] += srcPtr[0];
     destPtr[1] += srcPtr[1];
     destPtr[2] += srcPtr[2];
@@ -37,11 +41,15 @@ void pppAngMove(void* dest, void* src, void* param1, void* param2)
  * --INFO--
  * PAL Address: 0x80064e5c
  * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppAngMoveCon(void* dest, void* param)
 {
     int* paramPtr = (int*)param;
-    int offset = paramPtr[3];
+    int offset = ((int*)paramPtr[3])[1];
     int* ptr = (int*)((char*)dest + offset + 0x80);
     ptr[2] = 0;
     ptr[1] = 0;


### PR DESCRIPTION
## Summary
- Updated `pppAngMoveCon` to read the offset through the nested data pointer (`param[3]`) before applying the `+0x80` base adjustment.
- Kept `pppAngMove` behavior intact and only added the standard per-version TODO fields in INFO headers.

## Functions improved
- Unit: `main/pppAngMove`
- Function targeted: `pppAngMoveCon`
- Function set status moved from `0/2` matched to `1/2` matched in build progress reporting.

## Match evidence
- `ninja` progress before change: `Code: 170144 / 1855300 bytes (1102 / 4733 functions)`
- `ninja` progress after change:  `Code: 170180 / 1855300 bytes (1103 / 4733 functions)`
- Net improvement: `+36` matched code bytes and `+1` matched function.

## Plausibility rationale
- The new indirection mirrors common data-layout usage in nearby `ppp*` effect code paths where runtime parameter blocks store pointers to per-effect offset tables.
- Change is minimal and source-plausible (type/offset interpretation), not compiler-coaxing control-flow churn.

## Technical details
- Verified via rebuild (`ninja`) and targeted objdiff runs on `main/pppAngMove`.
- Disassembly confirms `pppAngMoveCon` now emits the additional pointer dereference before the offset add, aligning better with target code layout.