### PR TITLE
main/pppMatrixXYZ: restore Y/Z translation writes

### DIFF
--- a/src/pppMatrixXYZ.cpp
+++ b/src/pppMatrixXYZ.cpp
@@ -56,4 +56,6 @@ void pppMatrixXYZ(pppFMATRIX& matrix, PPPCREATEPARAM* param)
 
     // Set translation components from position
     matrix.value[0][3] = param->m_positionOffsetPtr->x;
+    matrix.value[1][3] = param->m_positionOffsetPtr->y;
+    matrix.value[2][3] = param->m_positionOffsetPtr->z;
 }


### PR DESCRIPTION
## Summary
- completed the translation writeback in `pppMatrixXYZ` by adding Y/Z assignments
- kept existing control flow and scaling logic unchanged

## Functions improved
- Unit: `main/pppMatrixXYZ`
- Symbol: `pppMatrixXYZ`

## Match evidence
- `pppMatrixXYZ` match improved from **73.525%** to **75.6875%**
- current object `.text` size moved from **276b** to **300b** (target is 320b), indicating closer structural alignment
- verification command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppMatrixXYZ -o - pppMatrixXYZ`

## Plausibility rationale
- writing all three translation components (`x`, `y`, `z`) is the natural behavior after matrix scale/rotation updates
- the previous state only wrote `x`, which is likely an incomplete decompilation artifact rather than plausible original game source

## Technical details
- added:
  - `matrix.value[1][3] = param->m_positionOffsetPtr->y;`
  - `matrix.value[2][3] = param->m_positionOffsetPtr->z;`
- no signature/type hacks or compiler-coaxing-only changes were introduced
