### PR TITLE
gx: improve GXSetScissorBoxOffset match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -562,22 +562,26 @@ void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht) {
     *ht = bm - tp + 1;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A68C8
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void GXSetScissorBoxOffset(s32 x_off, s32 y_off) {
-    u32 reg = 0;
-    u32 hx;
-    u32 hy;
+    u32 reg;
 
     CHECK_GXBEGIN(1119, "GXSetScissorBoxOffset");
 
     ASSERTMSGLINE(1122, (u32)(x_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid X offset");
     ASSERTMSGLINE(1124, (u32)(y_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid Y offset");
 
-    hx = (u32)(x_off + 342) >> 1;
-    hy = (u32)(y_off + 342) >> 1;
-
-    SET_REG_FIELD(1129, reg, 10, 0, hx);
-    SET_REG_FIELD(1130, reg, 10, 10, hy);
-    SET_REG_FIELD(1131, reg, 8, 24, 0x59);
+    reg = ((u32)(x_off + 342) >> 1) & 0x3FF;
+    reg |= (((u32)(y_off + 342) >> 1) & 0x3FF) << 10;
+    reg |= 0x59000000;
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
## Summary
- Reworked `GXSetScissorBoxOffset` in `src/gx/GXTransform.c` to pack the BP register value directly with explicit bit operations.
- Added FFCC function metadata block (`--INFO--`) for this function using local Ghidra PAL address/size.

## Functions improved
- Unit: `main/gx/GXTransform`
- Function: `GXSetScissorBoxOffset` (`64b`)
- Match: `24.25% -> 48.75%` (+24.50)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetScissorBoxOffset`
  - Before: `24.25%`
  - After: `48.75%`
- Unit `.text` match moved from `66.87195` to `67.6687`.

## Plausibility rationale
- The change replaces generic `SET_REG_FIELD` staging with direct construction of the final BP command word (`0x59000000 | packed offsets`), which matches expected low-level GX register programming style.
- This keeps the original logic and constraints intact (same assertions, same offset math, same write path), while producing code that is simpler and more characteristic of hand-written SDK-era source.

## Technical details
- Previous code built intermediate `hx/hy` fields and populated `reg` via three `SET_REG_FIELD` macro calls.
- Updated code computes:
  - low 10 bits from `((x_off + 342) >> 1)`
  - next 10 bits from `((y_off + 342) >> 1) << 10`
  - BP register index via `| 0x59000000`
- `GX_WRITE_RAS_REG(reg);` and `__GXData->bpSentNot = 0;` remain unchanged.
