### PR TITLE
main/pppRandFV: improve pppRandFV objdiff alignment

### DIFF
--- a/src/pppRandFV.cpp
+++ b/src/pppRandFV.cpp
@@ -18,62 +18,46 @@ extern float lbl_801EADC8;
 void pppRandFV(void* param1, void* param2, void* param3)
 {
     int* p1 = (int*)param1;
-    void** p3 = (void**)param2;
-    int* p2 = (int*)param3;
+    int* p2 = (int*)param2;
+    int* p3 = (int*)param3;
 
     if (lbl_8032ED70 != 0) {
         return;
     }
 
     if (p1[3] == 0) {
-        float randVal1, randVal2;
+        float randVal = 1.0f;
 
         math.RandF();
-        randVal1 = 1.0f;
 
-        unsigned char* p2_bytes = (unsigned char*)p2;
-        if (p2_bytes[0x18] != 0) {
+        if (((unsigned char*)p3)[0x18] != 0) {
             math.RandF();
-            randVal2 = 1.0f;
-            randVal1 = randVal1 + randVal2;
+            randVal = randVal + 1.0f;
         } else {
-            randVal1 = randVal1 * lbl_8032FF90;
+            randVal = randVal * lbl_8032FF90;
         }
 
-        void** basePtr = (void**)((char*)p3 + 0xC);
-        int* indexPtr = (int*)*basePtr;
-        float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80));
-        *destAddr = randVal1;
-
-    } else {
-        if (p2[0] == p1[3]) {
-            void** basePtr = (void**)((char*)p3 + 0xC);
-            int* indexPtr = (int*)*basePtr;
-            float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80));
-
-            float* srcAddr;
-            if (p2[1] == -1) {
-                srcAddr = &lbl_801EADC8;
-            } else {
-                srcAddr = (float*)((char*)p1 + (p2[1] + 0x80));
-            }
-
-            float destVal = *destAddr;
-
-            float multiplier1 = *(float*)((char*)p2 + 8);
-            float srcVal1 = *srcAddr;
-            float result1 = srcVal1 + (multiplier1 * destVal - multiplier1);
-            *srcAddr = result1;
-
-            float multiplier2 = *(float*)((char*)p2 + 12);
-            float srcVal2 = *(float*)((char*)srcAddr + 4);
-            float result2 = srcVal2 + (multiplier2 * destVal - multiplier2);
-            *(float*)((char*)srcAddr + 4) = result2;
-
-            float multiplier3 = *(float*)((char*)p2 + 16);
-            float srcVal3 = *(float*)((char*)srcAddr + 8);
-            float result3 = srcVal3 + (multiplier3 * destVal - multiplier3);
-            *(float*)((char*)srcAddr + 8) = result3;
-        }
+        int* indexPtr = *(int**)((char*)p2 + 0xC);
+        *(float*)((char*)p1 + *indexPtr + 0x80) = randVal;
+        return;
     }
+
+    if (p3[0] != p1[3]) {
+        return;
+    }
+
+    int* indexPtr = *(int**)((char*)p2 + 0xC);
+    float* destAddr = (float*)((char*)p1 + *indexPtr + 0x80);
+    float* srcAddr;
+    float destVal = *destAddr;
+
+    if (p3[1] == -1) {
+        srcAddr = &lbl_801EADC8;
+    } else {
+        srcAddr = (float*)((char*)p1 + p3[1] + 0x80);
+    }
+
+    srcAddr[0] = srcAddr[0] + (*(float*)((char*)p3 + 8) * destVal - *(float*)((char*)p3 + 8));
+    srcAddr[1] = srcAddr[1] + (*(float*)((char*)p3 + 12) * destVal - *(float*)((char*)p3 + 12));
+    srcAddr[2] = srcAddr[2] + (*(float*)((char*)p3 + 16) * destVal - *(float*)((char*)p3 + 16));
 }


### PR DESCRIPTION
## Summary
- Refactored `pppRandFV` to use argument roles and address calculations that align with current objdiff output.
- Simplified control flow to early-return style and reduced temporary pointer churn.
- Kept behavior plausible to original source while nudging generated code toward expected register usage.

## Functions improved
- Unit: `main/pppRandFV`
- Function: `pppRandFV`

## Match evidence
- `pppRandFV` match percent: **77.53247% -> 78.14286%**
- Target size in objdiff: **292b -> 288b**
- Local size remains 308b, but instruction-level alignment improved.
- Diff-kind count changes for `left.symbols[pppRandFV].instructions`:
  - `DIFF_ARG_MISMATCH`: **15 -> 10**
  - `DIFF_INSERT`: **3 -> 2**

Commands used:
- `tools/objdiff-cli diff -p . -u main/pppRandFV -o - pppRandFV > /tmp/pppRandFV.before.json`
- `tools/objdiff-cli diff -p . -u main/pppRandFV -o - pppRandFV > /tmp/pppRandFV.after.json`

## Plausibility rationale
- Changes primarily correct parameter interpretation and pointer arithmetic layout, which are source-plausible fixes in this decomp stage.
- No contrived compiler-only constructs were introduced; code remains straightforward C/C++ pointer-based game logic.

## Technical details
- Moved to consistent `p1/p2/p3` mapping for `param1/param2/param3` and updated all downstream memory accesses accordingly.
- Switched the zero-case write path to direct indexed store via `*(float*)((char*)p1 + *indexPtr + 0x80)`.
- Consolidated non-zero path into explicit early return + shared setup, then component updates on `srcAddr[0..2]`.
