### PR TITLE
gx/GXTransform: match GXSetViewport wrapper by preventing jitter inlining

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -443,6 +443,7 @@ void __GXSetViewport(void) {
     GX_WRITE_XF_REG_F(31, oz);
 }
 
+#pragma dont_inline on
 void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz, u32 field) {
     CHECK_GXBEGIN(903, "GXSetViewport");  // not the correct function name
 
@@ -460,6 +461,7 @@ void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz,
     __GXSetViewport();
     __GXData->bpSentNot = 1;
 }
+#pragma dont_inline reset
 
 void GXSetViewport(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz) {
     GXSetViewportJitter(left, top, wd, ht, nearz, farz, 1);


### PR DESCRIPTION
## Summary
- Added `#pragma dont_inline on/reset` around `GXSetViewportJitter` in `src/gx/GXTransform.c`.
- This prevents inlining into `GXSetViewport`, restoring the original small wrapper shape (`li r3, 1; bl GXSetViewportJitter`).

## Functions improved
- Unit: `main/gx/GXTransform`
- Symbol: `GXSetViewport`
- Match: `0.0% -> 100.0%` (36 bytes)

## Match evidence
- Objdiff oneshot (`objdiff-cli v3.6.1`):
  - Before: `GXSetViewport` at `0.0%`
  - After: `GXSetViewport` at `100.0%`
- Build progress moved from:
  - Code: `170144 / 1855300` (1102 / 4733 functions)
  - to `170180 / 1855300` (1103 / 4733 functions)

## Plausibility rationale
- The produced assembly now matches the original target wrapper exactly, including call structure and register usage.
- The change is compiler-behavior-oriented but source-plausible for this SDK codebase, which already uses `#pragma dont_inline` in multiple translation units.

## Technical details
- Without the pragma, `GXSetViewportJitter` was inlined at `-O4,p`, expanding `GXSetViewport` and preventing symbol alignment.
- With inlining disabled for that function, `GXSetViewport` compiles to the expected 36-byte wrapper and matches target.
