### PR TITLE
main/card/CARDOpen: improve CARDFastOpen match

### DIFF
--- a/src/card/CARDOpen.c
+++ b/src/card/CARDOpen.c
@@ -123,7 +123,10 @@ s32 CARDFastOpen(s32 chan, s32 fileNo, CARDFileInfo* fileInfo) {
 
     dir = __CARDGetDirBlock(card);
     ent = &dir[fileNo];
-    result = __CARDIsReadable(card, ent);
+    result = __CARDIsWritable(card, ent);
+    if (result == CARD_RESULT_NOPERM && (ent->permission & 0x4))
+        result = CARD_RESULT_READY;
+
     if (0 <= result) {
         if (!CARDIsValidBlockNo(card, ent->startBlock))
             result = CARD_RESULT_BROKEN;


### PR DESCRIPTION
## Summary
- Updated `CARDFastOpen` in `src/card/CARDOpen.c` to call `__CARDIsWritable` and then apply the readable-permission fallback inline.
- Preserved behavior while changing call/codegen shape to better align with original object output.

## Functions improved
- Unit: `main/card/CARDOpen`
- Function: `CARDFastOpen`

## Match evidence
- `CARDFastOpen`: **52.55682% -> 56.772728%** (`+4.215908`)
- `__CARDAccess`: 76.052635% (unchanged)
- `CARDOpen`: 72.35107% (unchanged)
- Unit `.text` match moved from ~76.7% baseline (selector/objdiff baseline) to **77.73151%** in current diff output.

## Plausibility rationale
- The change mirrors natural source-level structure: write-check first, then explicit readable permission handling.
- No contrived temporaries or unnatural ordering tricks were introduced.
- Behavior remains equivalent to the previous readable check path.

## Technical details
- Objdiff mismatch patterns indicated target call flow in `CARDFastOpen` is centered around `__CARDIsWritable` with a follow-up permission-bit branch.
- Replacing direct `__CARDIsReadable` call with writable+fallback reduced key call-structure mismatches and improved function-level score.
