### PR TITLE
mtx44vec: match PSMTX44MultVec

### DIFF
--- a/src/mtx/mtx44vec.c
+++ b/src/mtx/mtx44vec.c
@@ -1,15 +1,44 @@
-
+#include "dolphin/mtx.h"
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x80186bfc
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void PSMTX44MultVec(void)
-{
-	// TODO
+asm void PSMTX44MultVec(const register Mtx44 m, const register Vec* src, register Vec* dst) {
+    nofralloc
+    psq_l f0, 0(src), 0, 0
+    psq_l f2, 0x30(m), 0, 0
+    psq_l f1, 8(src), 1, 0
+    ps_mul f4, f0, f2
+    psq_l f3, 0x38(m), 0, 0
+    ps_madd f5, f1, f3, f4
+    ps_merge11 f12, f1, f1
+    ps_sum0 f13, f5, f5, f5
+    psq_l f4, 0(m), 0, 0
+    ps_merge00 f13, f13, f13
+    psq_l f5, 8(m), 0, 0
+    ps_div f13, f12, f13
+    psq_l f6, 0x10(m), 0, 0
+    psq_l f7, 0x18(m), 0, 0
+    psq_l f8, 0x20(m), 0, 0
+    psq_l f9, 0x28(m), 0, 0
+    ps_mul f4, f0, f4
+    ps_madd f2, f1, f5, f4
+    ps_mul f6, f0, f6
+    ps_madd f3, f1, f7, f6
+    ps_mul f8, f0, f8
+    ps_sum0 f2, f2, f2, f2
+    ps_madd f9, f1, f9, f8
+    ps_sum1 f2, f3, f2, f3
+    ps_sum0 f3, f9, f9, f9
+    ps_mul f2, f2, f13
+    psq_st f2, 0(dst), 0, 0
+    ps_mul f3, f3, f13
+    psq_st f3, 8(dst), 1, 0
+    blr
 }


### PR DESCRIPTION
## Summary
- Replaced the `PSMTX44MultVec` stub in `src/mtx/mtx44vec.c` with a concrete paired-single MWCC asm implementation.
- Added/filled function metadata block (`PAL Address: 0x80186bfc`, `PAL Size: 120b`).
- Kept scope strictly to `mtx44vec.c`.

## Functions improved
- Unit: `main/mtx/mtx44vec`
- Symbol: `PSMTX44MultVec`
- Match: `3.3% -> 100.0%`
- Size: `4b stub -> 120b` (matches target size)

## Match evidence
- `tools/objdiff-cli diff -p . -u main/mtx/mtx44vec -o - PSMTX44MultVec`
  - Reports `match_percent: 100.0` for `PSMTX44MultVec`
  - Left/right instruction streams are identical for all 30 instructions in the function.
- Full build/progress after change:
  - `All Code: 170144 -> 170264` bytes matched
  - `Functions matched: 1102 -> 1103`

## Plausibility rationale
- This is a Dolphin SDK matrix/vector routine that is expected to be paired-single asm.
- The previous body was a TODO stub; replacing it with the canonical low-level implementation is source-plausible and aligns with surrounding `mtx`/`vec` SDK files that already use MWCC asm style.

## Technical details
- Implemented the reciprocal-w divide path and XYZ transform using `psq_l`, `ps_madd`, `ps_sum0/ps_sum1`, and `psq_st` sequence.
- The resulting instruction ordering, opcodes, and function size now match exactly under objdiff.
