### PR TITLE
main/pppScreenQuake: improve pppDesScreenQuake match

### DIFF
--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -6,6 +6,7 @@ extern float FLOAT_80331fc8;
 extern int DAT_8032ed70;
 
 void CalcGraphValue(float param1, _pppPObject *param2, int param3, float *param4, float *param5, float *param6, float *param7, float *param8);
+extern "C" void SetQuakeParameter__10CCameraPcsFiissffffffi(CCameraPcs*, int, int, short, short, float, float, float, float, float, float, int);
 
 /*
  * --INFO--
@@ -68,10 +69,8 @@ void pppCon2ScreenQuake(pppScreenQuake *quake, UnkC *param2)
  */
 void pppDesScreenQuake(void)
 {
-	double dVar1 = (double)FLOAT_80331fc8;
-	CameraPcs.SetQuakeParameter((int)dVar1, (int)dVar1, (short)dVar1, (short)dVar1, 
-	                            (float)dVar1, (float)dVar1, (float)dVar1, (float)dVar1, 
-	                            (float)dVar1, (float)dVar1, 1);
+	float value = FLOAT_80331fc8;
+	SetQuakeParameter__10CCameraPcsFiissffffffi(&CameraPcs, 0, 0, 0, 0, value, value, value, value, value, value, 1);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppDesScreenQuake` to call `SetQuakeParameter__10CCameraPcsFiissffffffi` directly with explicit argument types.
- Removed the previous double-cast based argument path and switched to a single float source value with integer/short zero literals.

## Functions Improved
- Unit: `main/pppScreenQuake`
- Symbol: `pppDesScreenQuake` (84 bytes)
- Match: **44.57143% -> 60.666668%**

## Match Evidence
- Baseline command:
  - `./tools/objdiff-cli diff -p . -u main/pppScreenQuake -o - pppDesScreenQuake`
- Result after change:
  - `pppDesScreenQuake` improved by about **+16.10 percentage points**.
- Assembly impact:
  - Eliminated the extra float-to-int conversion stack sequence from the old implementation and moved closer to the target call setup pattern.

## Plausibility Rationale
- The new implementation is source-plausible: it expresses the same high-level intent (reset quake parameters) while using direct, explicit typed arguments that align with the camera API call ABI.
- This is not formatting-only churn; it materially changes generated code shape toward the target without introducing contrived control flow or artificial temporaries.

## Technical Notes
- Full `ninja` build passes after the change.
- Change is isolated to `src/pppScreenQuake.cpp` and does not introduce debug artifacts.
