### PR TITLE
main/mapshadow: improve Draw__10CMapShadowFv stack slot ordering

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -90,10 +90,10 @@ void CMapShadow::Calc()
 void CMapShadow::Draw()
 {
 	int iVar1;
-	Vec VStack_38;
-	Vec local_2c;
-	Vec local_20;
 	Vec local_14;
+	Vec local_20;
+	Vec local_2c;
+	Vec VStack_38;
 	
 	iVar1 = *(int*)((char*)this + 0xc);
 	local_14.x = *(float*)(iVar1 + 0xc4);


### PR DESCRIPTION
## Summary
- Reordered local `Vec` declarations in `CMapShadow::Draw()` to better match the original stack slot layout.
- No logic or data-flow changes were introduced; this is a layout-only decomp refinement.

## Functions improved
- Unit: `main/mapshadow`
- Symbol: `Draw__10CMapShadowFv`
  - Before: `91.1875%`
  - After: `91.541664%`

## Match evidence
- `objdiff` command used:
  - `build/tools/objdiff-cli diff -p . -u main/mapshadow -o - Draw__10CMapShadowFv`
- Unit `.text` match moved from `37.609627%` to `37.700535%`.
- Improvement corresponds to better alignment of stack offsets for local vector temporaries.

## Plausibility rationale
- Reordering local declarations is source-plausible and consistent with original-style code evolution.
- The change avoids compiler-coaxing patterns (no contrived temporaries, no artificial control-flow changes).

## Technical details
- Remaining diffs are still concentrated in register allocation / prologue choices and other functions in the unit.
- This PR focuses on a narrow, measurable increment in `Draw__10CMapShadowFv` while preserving readability and behavior.
