### PR TITLE
main/prgobj: add missing CGPrgObj no-op state hooks

### DIFF
--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -12,6 +12,12 @@ public:
     void onCreate();
     void onDestroy();
     void onFrame();
+    void onCancelStat(int);
+    void onChangeStat(int);
+    void onFramePreCalc();
+    void onFramePostCalc();
+    void onFrameStat();
+    void onChangePrg(int);
     void changeStat(int, int, int);
     void changeSubStat(int subState);
     void addSubStat();

--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -32,6 +32,84 @@ void CGPrgObj::onFrame()
 
 /*
  * --INFO--
+ * PAL Address: 0x80127010
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onCancelStat(int)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80127014
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onChangeStat(int)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80127018
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onFramePreCalc()
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8012701C
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onFramePostCalc()
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80127020
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onFrameStat()
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80127024
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onChangePrg(int)
+{
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added missing `CGPrgObj` method declarations in `include/ffcc/prgobj.h` for state hook functions present in PAL symbols.
- Implemented six no-op method definitions in `src/prgobj.cpp` with PAL address/size annotations:
  - `onCancelStat(int)`
  - `onChangeStat(int)`
  - `onFramePreCalc()`
  - `onFramePostCalc()`
  - `onFrameStat()`
  - `onChangePrg(int)`

## Functions improved
Unit: `main/prgobj`
- `onCancelStat__8CGPrgObjFi`: `0.0% -> 100.0%`
- `onChangeStat__8CGPrgObjFi`: `0.0% -> 100.0%`
- `onFramePreCalc__8CGPrgObjFv`: `0.0% -> 100.0%`
- `onFramePostCalc__8CGPrgObjFv`: `0.0% -> 100.0%`
- `onFrameStat__8CGPrgObjFv`: `0.0% -> 100.0%`
- `onChangePrg__8CGPrgObjFi`: `0.0% -> 100.0%`

## Match evidence
- Unit fuzzy match (from selector/report): `4.6% -> 5.394%`.
- Matched functions in `main/prgobj`: `3/26 -> 9/26`.
- Full build and report generation pass with `ninja`.

## Plausibility rationale
- These symbols are explicit PAL methods in the `prgobj` object and are 4-byte functions in Ghidra output (no-op returns).
- Declaring and defining them as empty member functions is a straightforward source-plausible reconstruction of original virtual hooks.
- No compiler-coaxing patterns were introduced; this is a structural class definition correction that aligns declarations with known symbols.

## Technical details
- Root cause was missing class API surface in `prgobj.h` and missing out-of-line definitions in `prgobj.cpp`.
- Added address-tagged no-op definitions to generate the expected tiny hook functions and improve symbol-level matching.
