### PR TITLE
main/TRK_MINNOW_DOLPHIN/mem_TRK: improve TRK_fill_mem match

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/mem_TRK.c
+++ b/src/TRK_MINNOW_DOLPHIN/mem_TRK.c
@@ -8,7 +8,8 @@
 #pragma dont_inline on
 /* 8036F580-8036F638 369EC0 00B8+00 0/0 1/1 0/0 .text            TRK_fill_mem */
 void TRK_fill_mem(void* dst, int val, u32 n) {
-    u32 v, i, j;
+    u32 v, i;
+    u32* p;
     v = (u8)val;
 
     ((u8*)dst) = ((u8*)dst) - 1;
@@ -27,29 +28,43 @@ void TRK_fill_mem(void* dst, int val, u32 n) {
         if (v)
             v |= v << 24 | v << 16 | v << 8;
 
-        ((u32*)dst) = ((u32*)(((u8*)dst) + 4)) - 1;
-        ((u32*)dst) = ((u32*)(((u8*)dst) + 1)) - 1;
+        p = (u32*)(((u8*)dst) - 3);
 
-        i = n / 32;
-
-        if (i) {
-            do {
-                for (j = 0; j < 8; j++)
-                    *++((u32*)dst) = v;
-            } while (--i);
-        }
-
-        i = (n / 4) % 8;
+        i = n >> 5;
 
         if (i) {
             do {
-                *++((u32*)dst) = v;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
+                p[1] = v;
+                p = p + 1;
             } while (--i);
         }
 
-        ((u8*)dst) = ((u8*)(((u32*)dst) + 1)) - 1;
+        i = (n >> 2) & 7;
 
-        n %= 4;
+        if (i) {
+            do {
+                p[1] = v;
+                p = p + 1;
+            } while (--i);
+        }
+
+        ((u8*)dst) = ((u8*)(p + 1)) - 1;
+
+        n = n - (n / 4) * 4;
     }
 
     if (n)


### PR DESCRIPTION
## Summary
- Reworked `TRK_fill_mem` word-fill path in `src/TRK_MINNOW_DOLPHIN/mem_TRK.c` to use an explicit 8-word unrolled store sequence with a dedicated `u32*` pointer.
- Kept byte-alignment handling intact, but changed loop expressions to shifts for block/remainder counts and expressed final byte remainder as `n - (n / 4) * 4`.
- Removed the inner `for (j = 0; j < 8; j++)` loop to better reflect the target's fixed unrolled store behavior.

## Functions Improved
- Unit: `main/TRK_MINNOW_DOLPHIN/mem_TRK`
- Symbol: `TRK_fill_mem`

## Match Evidence
- `tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/mem_TRK -o - TRK_fill_mem`
- Before: `82.391304%` (`.text`, 184b)
- After: `91.95652%` (`.text`, 184b)
- Delta: `+9.565216` percentage points

## Plausibility Rationale
- This is low-level runtime memory fill code where manual unrolling and explicit pointer stepping are normal source patterns.
- The change improves instruction selection in the hot word-fill loop without introducing opaque hacks, magic offsets outside existing pointer math, or unnatural control flow.

## Technical Notes
- The improvement came from making the 32-byte path explicit (`p[1] = v; p = p + 1` repeated 8 times), which aligns closer to the target's unrolled store structure.
- The final tail-byte reduction now mirrors a divide/multiply/subtract remainder form (`n - (n / 4) * 4`) rather than `% 4`, reducing mismatch in the tail path.
