### PR TITLE
main/p_usb: match GetTable and improve __sinit_p_usb_cpp

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -4,9 +4,19 @@
 
 #include <dolphin/os.h>
 #include "string.h"
+#include "types.h"
 
 char DAT_8032ec6c;
 int DAT_8032ec68;
+
+extern void* __vt__8CManager;
+extern void* lbl_801E8668;
+extern void* lbl_801E8830;
+extern u32 lbl_801E8690[];
+extern u32 lbl_801E869C[];
+extern u32 lbl_801E86A8[];
+extern u32 lbl_801E86B4[];
+extern CUSBPcs USBPcs;
 
 
 /*
@@ -58,7 +68,7 @@ void CUSBPcs::Quit()
  */
 void* CUSBPcs::GetTable(unsigned long param)
 {
-    return (void*)(param * 0x15c - 0x7fe1794c);
+    return (void*)((char*)lbl_801E86B4 + (param * 0x15c));
 }
 
 /*
@@ -241,10 +251,27 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
  */
 extern "C" void __sinit_p_usb_cpp()
 {
-    // Static initialization for CUSBPcs global object
-    // Sets up USBPcs process manager vtable and function pointers
-    extern CUSBPcs USBPcs;
-    
-    // Initialize vtable entries based on Ghidra decompilation
-    // This sets up the virtual function table for the global USBPcs instance
+    *(void**)&USBPcs = &__vt__8CManager;
+    *(void**)&USBPcs = &lbl_801E8668;
+
+    u32 a0 = lbl_801E8690[0];
+    u32 a1 = lbl_801E8690[1];
+    u32 a2 = lbl_801E8690[2];
+    u32 b0 = lbl_801E869C[0];
+    u32 b1 = lbl_801E869C[1];
+    u32 b2 = lbl_801E869C[2];
+    u32 c0 = lbl_801E86A8[0];
+    u32 c1 = lbl_801E86A8[1];
+    u32 c2 = lbl_801E86A8[2];
+
+    *(void**)&USBPcs = &lbl_801E8830;
+    lbl_801E86B4[1] = a0;
+    lbl_801E86B4[2] = a1;
+    lbl_801E86B4[3] = a2;
+    lbl_801E86B4[4] = b0;
+    lbl_801E86B4[5] = b1;
+    lbl_801E86B4[6] = b2;
+    lbl_801E86B4[7] = c0;
+    lbl_801E86B4[8] = c1;
+    lbl_801E86B4[9] = c2;
 }


### PR DESCRIPTION
## Summary
- Replaced the placeholder `__sinit_p_usb_cpp` body in `src/p_usb.cpp` with an assembly-faithful static init sequence.
- Switched `CUSBPcs::GetTable` to use the explicit table base symbol (`lbl_801E86B4`) plus indexed stride.
- Added explicit extern symbol declarations used by these routines.

## Functions improved
- `GetTable__7CUSBPcsFUl` (main/p_usb)
- `__sinit_p_usb_cpp` (main/p_usb)

## Match evidence
Using `tools/objdiff-cli diff -p . -u main/p_usb -o -`:
- `GetTable__7CUSBPcsFUl`: **64.0% -> 100.0%** (size 20b)
- `__sinit_p_usb_cpp`: **2.2727273% -> 68.045456%** (size 176b)

## Plausibility rationale
- The `GetTable` implementation now expresses an obvious table-base-plus-stride pattern, which is idiomatic and source-plausible.
- The `__sinit` rewrite follows normal static initialization behavior for process/vtable setup and table copy wiring, matching the surrounding codebase’s `__sinit` style without introducing contrived compiler-coaxing patterns.

## Technical details
- `__sinit_p_usb_cpp` now performs the three manager/vtable pointer stores in order and copies three 3-word blocks from `lbl_801E8690`, `lbl_801E869C`, and `lbl_801E86A8` into `lbl_801E86B4[1..9]`.
- Build and verification run completed with `ninja` and objdiff in PAL (`GCCP01`).
