### PR TITLE
Improve pppRandUpInt match with type-accurate float/double flow

### DIFF
--- a/src/pppRandUpInt.cpp
+++ b/src/pppRandUpInt.cpp
@@ -3,10 +3,9 @@
 #include "types.h"
 
 extern CMath math;
-extern s32 lbl_8032ED70;
 extern f32 lbl_80330018;
 extern f64 lbl_80330020;
-extern s32 lbl_801EADC8;
+extern s32 lbl_801EADC8[];
 extern "C" {
 f32 RandF__5CMathFv(CMath*);
 }
@@ -34,6 +33,8 @@ struct PppRandUpIntParam3 {
  */
 void pppRandUpInt(void* param1, void* param2, void* param3)
 {
+    extern u32 lbl_8032ED70;
+
     if (lbl_8032ED70 != 0) {
         return;
     }
@@ -45,9 +46,9 @@ void pppRandUpInt(void* param1, void* param2, void* param3)
 
     s32 baseState = *(s32*)(base + 0xC);
     if (baseState == 0) {
-        f32 value = RandF__5CMathFv((CMath*)&math);
+        f32 value = RandF__5CMathFv(&math);
         if (in->fieldC != 0) {
-            value = (value + RandF__5CMathFv((CMath*)&math)) * lbl_80330018;
+            value = (value + RandF__5CMathFv(&math)) * lbl_80330018;
         }
 
         valuePtr = (f32*)(base + *out->fieldC + 0x80);
@@ -62,7 +63,7 @@ void pppRandUpInt(void* param1, void* param2, void* param3)
 
     s32* target;
     if (in->field4 == -1) {
-        target = &lbl_801EADC8;
+        target = lbl_801EADC8;
     } else {
         target = (s32*)(base + in->field4 + 0x80);
     }
@@ -77,6 +78,7 @@ void pppRandUpInt(void* param1, void* param2, void* param3)
     cvt.parts.hi = 0x43300000;
     cvt.parts.lo = in->field8;
 
-    s32 delta = (s32)((cvt.d - lbl_80330020) * *valuePtr);
+    f64 source = *valuePtr;
+    s32 delta = (s32)((cvt.d - lbl_80330020) * source);
     *target += delta;
 }


### PR DESCRIPTION
## Summary
- Refined `pppRandUpInt` extern/type usage to better reflect surrounding ppp random-update patterns.
- Switched `lbl_801EADC8` declaration to array form and used pointer form directly in the `field4 == -1` path.
- Removed unnecessary `(CMath*)` casts and used `RandF__5CMathFv(&math)` directly.
- Introduced an explicit `f64` temporary for the post-conversion multiply path, improving generated FP op selection.

## Functions improved
- Unit: `main/pppRandUpInt`
- Symbol: `pppRandUpInt`
- `.text` match: **88.26667% -> 89.666664%** (+1.399994)

## Match evidence
- Built with `ninja` (build passes).
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandUpInt -o - pppRandUpInt`
- Observed improvements are instruction-level (not just renaming/formatting), notably in the numeric conversion/multiply tail where the generated FP sequence moved closer to target form.

## Plausibility rationale
- Changes are source-plausible cleanup rather than compiler-coaxing tricks:
  - ABI-consistent external declarations (`lbl_801EADC8[]`, local external state flag).
  - Removal of unnecessary explicit casts.
  - Clearer typed intermediate (`f64 source`) for mixed float/double arithmetic that naturally occurs in this conversion path.
- The resulting code remains straightforward and idiomatic for this codebase's ppp random update functions.

## Technical details
- The previous body forced less accurate codegen in the final accumulation expression.
- Using a typed double intermediate for `*valuePtr` improved alignment in the final conversion block and yielded the measurable percentage gain above while preserving behavior.
