### PR TITLE
Improve pppConstructCrystal2 match in main/pppCrystal2

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -32,9 +32,11 @@ void MakeRefractionMap(HSD_ImageBuffer*)
  */
 void pppConstructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
 {
-    s32 iVar1 = param_2->m_serializedDataOffsets[2];
-    *(u32*)((char*)&pppCrystal2->field0_0x0 + 2*4 + iVar1) = 0;
-    *(u32*)((char*)&pppCrystal2->field0_0x0 + 2*4 + iVar1 + 4) = 0;
+    s32 iVar1 = (*(s32**)param_2)[2];
+    u32* data = (u32*)((char*)pppCrystal2 + iVar1);
+
+    data[2] = 0;
+    data[3] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `pppConstructCrystal2` in `src/pppCrystal2.cpp` to access serialized offset data via direct pointer-to-offset-table semantics.
- Replaced field-based writes with explicit indexed writes on a computed data base pointer.
- Kept the change minimal and localized to one 32-byte function.

## Functions improved
- Unit: `main/pppCrystal2`
- Symbol: `pppConstructCrystal2`
- Match change: `82.125%` -> `85.25%`
- Function size: `32b`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppCrystal2 -o - pppConstructCrystal2`
- Before: `82.125%`
- After: `85.25%`
- Observed asm alignment improvement: reduced instruction mismatches, with remaining deltas concentrated in argument/register allocation and one address-form difference.

## Plausibility rationale
- The new code models serialized data offsets as an offset-table pointer, which matches patterns seen across other PPP construct/destruct/frame code.
- The change is source-plausible (type/access correction) rather than compiler-coaxing: no contrived temporaries, no artificial reordering, and no non-idiomatic constructs.

## Technical details
- Old version used `param_2->m_serializedDataOffsets[2]` plus direct struct-field-relative writes.
- New version loads offset index 2 via `(*(s32**)param_2)[2]`, computes a base data pointer from `pppCrystal2 + offset`, then zeroes two consecutive words (`data[2]` and `data[3]`).
- This shifts generated code closer to target by improving how serialized data base/offset access is represented in C.
