### PR TITLE
Improve pppDrawMatrixWood match with full transform body

### DIFF
--- a/src/pppDrawMatrixWood.cpp
+++ b/src/pppDrawMatrixWood.cpp
@@ -13,6 +13,21 @@
  */
 void pppDrawMatrixWood(_pppPObject* param_1)
 {
-    // TODO: Full implementation - facing Mtx type compatibility issues
-    // PSMTXScaleApply requires investigation of proper casting approach
+    PSMTXScaleApply(
+        (MtxPtr)((char*)param_1 + 0x10),
+        (MtxPtr)((char*)param_1 + 0x40),
+        *(float*)((char*)pppMngStPtr + 0x28),
+        *(float*)((char*)pppMngStPtr + 0x2C),
+        *(float*)((char*)pppMngStPtr + 0x30)
+    );
+
+    *(float*)((char*)param_1 + 0x4C) = *(float*)((char*)param_1 + 0x1C);
+    *(float*)((char*)param_1 + 0x5C) = *(float*)((char*)param_1 + 0x2C);
+    *(float*)((char*)param_1 + 0x6C) = *(float*)((char*)param_1 + 0x3C);
+
+    PSMTXConcat(
+        ppvWorldMatrixWood,
+        (MtxPtr)((char*)param_1 + 0x40),
+        (MtxPtr)((char*)param_1 + 0x40)
+    );
 }


### PR DESCRIPTION
## Summary
- Implemented `pppDrawMatrixWood` in `src/pppDrawMatrixWood.cpp`, replacing the placeholder stub body.
- Added the expected matrix flow for this unit:
  - scale application from object-local matrix to output matrix,
  - translation component propagation,
  - concatenation with `ppvWorldMatrixWood`.
- Used explicit offset-based access for `_pppPObject` and manager scale values to match current decomp layout constraints.

## Functions improved
- Unit: `main/pppDrawMatrixWood`
- Symbol: `pppDrawMatrixWood`
- Before: `3.5714285%` (stub body, effectively `blr`)
- After: `79.35714%`

## Match evidence
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawMatrixWood -o - pppDrawMatrixWood`
- Objdiff now shows the function body is structurally aligned (size/signature path improved from stub to near-match), with remaining deltas primarily in register allocation and instruction scheduling around prologue/setup and concat call preparation.

## Plausibility rationale
- The implementation is a direct, plausible game-source style matrix update routine for a "wood world matrix" draw path.
- Changes are semantic and engine-consistent (transform application + translation forwarding + world concat), not synthetic no-op coaxing.
- Residual mismatch appears attributable to compiler codegen choices and incomplete struct layout knowledge rather than unnatural source constructs.

## Technical notes
- Target requires offsets that do not currently map cleanly to typed fields in this decomp state; this patch uses explicit offsets to avoid introducing misleading field definitions.
- This is an incremental decomp step that meaningfully increases assembly alignment while preserving readable control flow.
