### PR TITLE
os/OSInterrupt: emit interrupt state helpers for exact symbol matching

### DIFF
--- a/src/os/OSInterrupt.c
+++ b/src/os/OSInterrupt.c
@@ -81,7 +81,6 @@ static void ExternalInterruptHandler(register __OSException exception, register 
 extern void __RAS_OSDisableInterrupts_begin(void);
 extern void __RAS_OSDisableInterrupts_end(void);
 
-#ifdef __GEKKO__
 asm BOOL OSDisableInterrupts(void) {
     nofralloc
 entry    __RAS_OSDisableInterrupts_begin
@@ -118,7 +117,6 @@ _restore:
     rlwinm  r3, r4, 17, 31, 31
     blr
 }
-#endif
 
 __OSInterruptHandler __OSSetInterruptHandler(__OSInterrupt interrupt, __OSInterruptHandler handler) {
     __OSInterruptHandler oldHandler;


### PR DESCRIPTION
## Summary
- Removed the `#ifdef __GEKKO__` guard around the three low-level interrupt helper asm functions in `src/os/OSInterrupt.c`.
- This ensures `OSDisableInterrupts`, `OSEnableInterrupts`, and `OSRestoreInterrupts` are emitted in `OSInterrupt.o` instead of being unresolved extern references.

## Functions improved
- `OSDisableInterrupts` (main/os/OSInterrupt)
- `OSEnableInterrupts` (main/os/OSInterrupt)
- `OSRestoreInterrupts` (main/os/OSInterrupt)

## Match evidence
- `OSDisableInterrupts`: `0.0% -> 100.0%`
- `OSEnableInterrupts`: `0.0% -> 100.0%`
- `OSRestoreInterrupts`: `0.0% -> 100.0%`
- Overall code progress after rebuild: `9.30% -> 9.36%` matched.

## Plausibility rationale
- These are canonical OS interrupt state primitives that belong in this unit and are already authored as direct PPC asm in the source.
- The previous guard prevented symbol emission in this build configuration, forcing external resolution and blocking objdiff matching.
- Removing the guard restores expected object ownership and instruction identity without adding coercive or unnatural source constructs.

## Technical details
- Before change, `nm build/GCCP01/src/os/OSInterrupt.o` showed `OSDisableInterrupts` and `OSRestoreInterrupts` as undefined (`U`).
- After change, all three helpers are defined in the object and matched exactly by objdiff.