### PR TITLE
base/PPCArch: simplify PPCDisableSpeculation asm

### DIFF
--- a/src/base/PPCArch.c
+++ b/src/base/PPCArch.c
@@ -317,15 +317,9 @@ void PPCMtwpar(register u32 newWPAR)
 asm void PPCDisableSpeculation(void)
 {
     nofralloc
-    mflr r0
-    stw r0, 0x4(r1)
-    stwu r1, -0x8(r1)
-    bl PPCMfhid0
+    mfspr r3, HID0
     ori r3, r3, HID0_SPD
-    bl PPCMthid0
-    lwz r0, 0xc(r1)
-    addi r1, r1, 0x8
-    mtlr r0
+    mtspr HID0, r3
     blr
 }
 


### PR DESCRIPTION
## Summary
Simplifies `PPCDisableSpeculation` to a direct HID0 read/modify/write asm sequence and removes stack+call scaffolding.

## Functions improved
- Unit: `main/base/PPCArch`
- Symbol: `PPCDisableSpeculation`

## Match evidence
- `PPCDisableSpeculation`: `27.0% -> 28.0%` (objdiff symbol match)
- `main/base/PPCArch` fuzzy match: `89.42029% -> 89.565216%` (from `build/GCCP01/report.json`)

## Plausibility rationale
This change is source-plausible for low-level PPC arch code: disabling speculation is naturally expressed as direct HID0 bit manipulation and avoids unnecessary call/stack overhead.

## Technical details
- Replaced call-based sequence (`bl PPCMfhid0` / `bl PPCMthid0`) with inline `mfspr` + `ori` + `mtspr`.
- Verified build with `ninja` and measured with objdiff/report tooling.
