### PR TITLE
Restore powf wrapper in math_ppc

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/math_ppc.c
+++ b/src/MSL_C/PPCEABI/bare/H/math_ppc.c
@@ -1,20 +1,22 @@
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/math_ppc.h"
-float acosf(float arg0) {
-    return (float) acos(arg0);
-}
+double pow(double, double);
 
-float atan2f(float arg0) {
-    return (float) atan2(arg0);
+float acosf(float arg0) {
+    return (float)acos(arg0);
 }
 
 float cosf(float arg0) {
-    return (float) cos(arg0);
+    return (float)cos(arg0);
 }
 
 float sinf(float arg0) {
-    return (float) sin(arg0);
+    return (float)sin(arg0);
 }
 
 float tanf(float arg0) {
-    return (float) tan(arg0);
+    return (float)tan(arg0);
+}
+
+float powf(float arg0, float arg1) {
+    return (float)pow(arg0, arg1);
 }


### PR DESCRIPTION
## Summary
- Replaced an incorrect `atan2f` wrapper in `src/MSL_C/PPCEABI/bare/H/math_ppc.c` with the expected `powf(float, float)` wrapper.
- Added the missing external declaration for `pow(double, double)`.
- Kept the wrapper style consistent with the rest of this SDK translation unit (`(float)<double-math-call>` pattern).

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/math_ppc`
- Symbol: `powf`
  - Before: `0.0%` (missing/mismatched implementation)
  - After: `100.0%`

## Match evidence
- Objdiff command:
  - `build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/math_ppc -o - powf`
- Before this change:
  - Unit `.text` match: `80.0%`
  - `powf` unmatched (target present, local implementation mismatched)
- After this change:
  - Unit `.text` match: `100.0%`
  - `powf` match: `100.0%`
- Build progress confirmation after rebuild:
  - Matched functions increased from `1153` to `1154`
  - Matched code bytes increased from `175756` to `175792`

## Plausibility rationale
- `math_ppc` is a standard SDK wrapper unit around double-precision libm calls.
- A one-argument `atan2f` wrapper in this file is implausible and inconsistent with both libm signatures and the PAL target object, while `powf(float, float)` is expected.
- The final code is simple, idiomatic wrapper source rather than compiler-coaxing.

## Technical notes
- Verified with `nm` that the built object exports `powf` and no longer exports `atan2f`.
- Verified with objdiff that the PAL target `powf` wrapper sequence matches exactly (`stwu/mflr/.../bl pow/.../frsp`).
