### PR TITLE
Improve SetRsdIndex match in ME_AppRequest

### DIFF
--- a/include/ffcc/ME_AppRequest.h
+++ b/include/ffcc/ME_AppRequest.h
@@ -14,7 +14,7 @@ public:
     void AddRsdList(ZLIST*);
     void SetRsdFlag();
     void GetRsdItemR();
-    void SetRsdIndex();
+    int SetRsdIndex();
     void GetRsdItem();
 };
 

--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/ME_AppRequest.h"
+#include "ffcc/zlist.h"
 
 /*
  * --INFO--
@@ -62,12 +63,28 @@ void CMaterialEditorPcs::GetRsdItemR()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004dd10
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMaterialEditorPcs::SetRsdIndex()
+int CMaterialEditorPcs::SetRsdIndex()
 {
-	// TODO
+    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xB4);
+    int index = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC4);
+    int* rsd = reinterpret_cast<int*>(list->GetDataIdx(index));
+
+    if (rsd == nullptr) {
+        return 0;
+    }
+    if (*rsd == 0) {
+        return 0;
+    }
+
+    *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xBC) = *rsd;
+    return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMaterialEditorPcs::SetRsdIndex` in `src/ME_AppRequest.cpp` instead of the TODO stub.
- Updated declaration in `include/ffcc/ME_AppRequest.h` from `void` to `int` to match observed behavior (`0/1` return).
- Added `ZLIST` include and implemented index lookup + guarded writeback flow.
- Added PAL function metadata block for the implemented function.

## Functions improved
- Unit: `main/ME_AppRequest`
- Function: `SetRsdIndex__18CMaterialEditorPcsFv` (96b)

## Match evidence
- Before: `4.2%` (from `tools/agent_select_target.py` baseline for this symbol)
- After: `97.458336%` (`build/tools/objdiff-cli diff -p . -u main/ME_AppRequest -o - SetRsdIndex__18CMaterialEditorPcsFv`)

## Plausibility rationale
- The implementation follows expected engine semantics: retrieve current list element by index, reject null/zero entries, update the cached rsd index field, and return success/failure.
- Change is type/signature and control-flow correctness, not compiler-coaxing sequencing.
- Uses existing project container API (`ZLIST::GetDataIdx`) and straightforward guard branches consistent with this codebase style.

## Technical details
- Implemented with explicit object-relative field access for currently unidentified `CMaterialEditorPcs` member layout (`+0xB4`, `+0xBC`, `+0xC4`) inferred from PAL decomp context.
- Structured branches as separate null and zero guards to better align emitted control flow with target assembly.
- Verified build via `ninja` and measured per-symbol diff with objdiff JSON output.
