### PR TITLE
Improve match quality for main/pppScreenBlur

### DIFF
--- a/src/pppScreenBlur.cpp
+++ b/src/pppScreenBlur.cpp
@@ -4,28 +4,54 @@
 #include "global.h"
 #include <dolphin/gx.h>
 
+typedef struct {
+    u8 data[0x80];
+} pppScreenBlur;
+
+typedef struct {
+    u32 m_dataValIndex; // 0x00
+    u8 m_blurR;         // 0x04
+    u8 m_blurG;         // 0x05
+    u8 m_blurB;         // 0x06
+    u8 m_pad7;          // 0x07
+    s16 m_initWOrk;     // 0x08
+} pppScreenBlurParam;
+
+typedef struct {
+    u8 pad[0x0C];
+    s32* m_serializedDataOffsets; // 0x0C
+} pppScreenBlurOffsets;
+
+extern float ppvScreenMatrix[4][4];
+extern int lbl_8032ED70;
+
 /*
  * --INFO--
  * PAL Address: 0x801555d8
  * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConScreenBlur(void* param1, void* param2)
 {
-    int iVar1;
-    
-    void** param2_offsets = (void**)param2;
-    iVar1 = (int)param2_offsets[3]; // offset from struct
-    
+    pppScreenBlur* blur = (pppScreenBlur*)param1;
+    pppScreenBlurOffsets* offsets = (pppScreenBlurOffsets*)param2;
+    s32 blurOffset = offsets->m_serializedDataOffsets[1];
+
     Graphic.InitBlurParameter();
-    
-    unsigned char* param1_base = (unsigned char*)param1;
-    param1_base[iVar1 + 0x80] = 0;
+    blur->data[blurOffset] = 0;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x801555d4
  * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppCon2ScreenBlur(void)
 {
@@ -36,6 +62,10 @@ void pppCon2ScreenBlur(void)
  * --INFO--
  * PAL Address: 0x801555ac
  * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDesScreenBlur(void)
 {
@@ -46,12 +76,14 @@ void pppDesScreenBlur(void)
  * --INFO--
  * PAL Address: 0x801555a0
  * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppFrameScreenBlur(void)
 {
-    // Check global state before processing
-    extern int pppScreenBlurEnabled; // Placeholder global variable
-    if (pppScreenBlurEnabled == 0) {
+    if (lbl_8032ED70 == 0) {
         return;
     }
     return;
@@ -61,40 +93,25 @@ void pppFrameScreenBlur(void)
  * --INFO--
  * PAL Address: 0x80155504
  * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppRenderScreenBlur(void* param1, void* param2, void* param3)
 {
-    unsigned int uVar1;
-    int iVar2;
-    int iVar3;
-    
-    void** param3_offsets = (void**)param3;
-    iVar3 = (int)param3_offsets[3]; // offset from struct at index 3
-    iVar2 = *(int*)param3_offsets[0]; // dereference pointer at index 0
-    
-    unsigned char* param2_base = (unsigned char*)param2;
-    unsigned char* param1_base = (unsigned char*)param1;
-    
-    // Set byte at offset 6 in param2 to 0
-    param2_base[6] = 0;
-    
-    // Count leading zeros on the byte at param1 + iVar3 + 0x80
-    unsigned char blur_byte = param1_base[iVar3 + 0x80];
-    // cntlzw pattern: if byte is 0, result is 8; if non-zero, result is less
-    uVar1 = (blur_byte == 0) ? 8 : 0;
-    
-    Graphic.RenderBlur(uVar1 >> 5,
-                      param2_base[4],
-                      param2_base[5], 
-                      param2_base[6],
-                      param1_base[iVar2 + 0x80 + 0xb],
-                      *(short*)&param2_base[8]);
-    
+    pppScreenBlur* blur = (pppScreenBlur*)param1;
+    pppScreenBlurParam* blurParam = (pppScreenBlurParam*)param2;
+    pppScreenBlurOffsets* offsets = (pppScreenBlurOffsets*)param3;
+    s32 blurActiveOffset = offsets->m_serializedDataOffsets[1];
+    s32 blurValueOffset = offsets->m_serializedDataOffsets[0];
+    u32 blurMask;
+
+    blurParam->m_blurB = 0;
+    blurMask = __cntlzw((u32)blur->data[blurActiveOffset]);
+    Graphic.RenderBlur(blurMask >> 5, blurParam->m_blurR, blurParam->m_blurG, blurParam->m_blurB,
+                       blur->data[blurValueOffset + 0x8B], blurParam->m_initWOrk);
     pppInitBlendMode();
-    
-    extern float ppvScreenMatrix[4][4];
     GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
-    
-    // Set the blur flag to 1
-    param1_base[iVar3 + 0x80] = 1;
+    blur->data[blurActiveOffset] = 1;
 }


### PR DESCRIPTION
## Summary
- Reworked `src/pppScreenBlur.cpp` to use explicit local structs for serialized offsets and blur parameters instead of placeholder pointer arithmetic.
- Replaced placeholder logic in `pppRenderScreenBlur` with a plausible source implementation using `__cntlzw`, `Graphic.RenderBlur`, `pppInitBlendMode`, and `GXSetProjection`.
- Cleaned `pppConScreenBlur` and `pppFrameScreenBlur` to match observed control flow and removed placeholder/debug-style comments.
- Added full INFO blocks with PAL metadata and TODOs for EN/JP on all touched functions.

## Functions improved
Unit: `main/pppScreenBlur`
- `pppRenderScreenBlur`: **56.641026% -> 83.666664%**
- `pppConScreenBlur`: **69.09524% -> 79.71429%**
- `pppFrameScreenBlur`: **98.333336% -> 100.0%**
- `pppDesScreenBlur`: 84.0% (unchanged)
- `pppCon2ScreenBlur`: 100.0% (unchanged)

## Match evidence
- Unit `.text` match improved from **66.14865% -> 83.47298%** (`build/tools/objdiff-cli diff -p . -u main/pppScreenBlur -o -`).
- Objdiff instruction deltas in `pppRenderScreenBlur` now align significantly better around:
  - serialized offset loads,
  - blur byte handling via `cntlzw >> 5`,
  - call argument setup for `RenderBlur`.

## Plausibility rationale
- Changes are type/layout and control-flow corrections consistent with nearby PPP decomp patterns, not compiler-coaxing artifacts.
- Field accesses now reflect inferred serialized data semantics (`m_serializedDataOffsets`, blur color bytes, init work short) instead of contrived temporaries.
- The final source is cleaner and closer to likely original game code style while also improving assembly match.

## Validation
- `ninja` passes after the change.
