### PR TITLE
Improve matching for main/pppScreenBlur offset-table accesses

### DIFF
--- a/src/pppScreenBlur.cpp
+++ b/src/pppScreenBlur.cpp
@@ -4,38 +4,53 @@
 #include "global.h"
 #include <dolphin/gx.h>
 
+typedef struct {
+    int unk0;
+    int unk1;
+    int unk2;
+    int* m_serializedDataOffsets;
+} UnkC;
+
 /*
  * --INFO--
  * PAL Address: 0x801555d8
  * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConScreenBlur(void* param1, void* param2)
 {
-    int iVar1;
-    
-    void** param2_offsets = (void**)param2;
-    iVar1 = (int)param2_offsets[3]; // offset from struct
-    
+    UnkC* param = (UnkC*)param2;
+    int iVar1 = param->m_serializedDataOffsets[1] + 0x80;
+
     Graphic.InitBlurParameter();
-    
-    unsigned char* param1_base = (unsigned char*)param1;
-    param1_base[iVar1 + 0x80] = 0;
+
+    ((u8*)param1)[iVar1] = 0;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x801555d4
  * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppCon2ScreenBlur(void)
 {
-    return;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x801555ac
  * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDesScreenBlur(void)
 {
@@ -46,55 +61,47 @@ void pppDesScreenBlur(void)
  * --INFO--
  * PAL Address: 0x801555a0
  * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppFrameScreenBlur(void)
 {
-    // Check global state before processing
-    extern int pppScreenBlurEnabled; // Placeholder global variable
-    if (pppScreenBlurEnabled == 0) {
+    extern int lbl_8032ED70;
+    if (lbl_8032ED70 == 0) {
         return;
     }
-    return;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x80155504
  * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppRenderScreenBlur(void* param1, void* param2, void* param3)
 {
-    unsigned int uVar1;
-    int iVar2;
-    int iVar3;
-    
-    void** param3_offsets = (void**)param3;
-    iVar3 = (int)param3_offsets[3]; // offset from struct at index 3
-    iVar2 = *(int*)param3_offsets[0]; // dereference pointer at index 0
-    
-    unsigned char* param2_base = (unsigned char*)param2;
-    unsigned char* param1_base = (unsigned char*)param1;
-    
-    // Set byte at offset 6 in param2 to 0
+    UnkC* param = (UnkC*)param3;
+    int iVar3 = param->m_serializedDataOffsets[1];
+    int iVar2 = param->m_serializedDataOffsets[0];
+    u8* param2_base = (u8*)param2;
+    u8* pppScreenBlur = (u8*)param1;
+    u8* blurState = pppScreenBlur + iVar3 + 0x80;
+    u8* blurData = pppScreenBlur + iVar2 + 0x80;
+    u32 uVar1;
+
     param2_base[6] = 0;
-    
-    // Count leading zeros on the byte at param1 + iVar3 + 0x80
-    unsigned char blur_byte = param1_base[iVar3 + 0x80];
-    // cntlzw pattern: if byte is 0, result is 8; if non-zero, result is less
-    uVar1 = (blur_byte == 0) ? 8 : 0;
-    
-    Graphic.RenderBlur(uVar1 >> 5,
-                      param2_base[4],
-                      param2_base[5], 
-                      param2_base[6],
-                      param1_base[iVar2 + 0x80 + 0xb],
-                      *(short*)&param2_base[8]);
-    
+    uVar1 = __cntlzw((u32)blurState[0]);
+
+    Graphic.RenderBlur(uVar1 >> 5, param2_base[4], param2_base[5], param2_base[6], blurData[0xb], *(s16*)&param2_base[8]);
     pppInitBlendMode();
-    
+
     extern float ppvScreenMatrix[4][4];
     GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
-    
-    // Set the blur flag to 1
-    param1_base[iVar3 + 0x80] = 1;
+
+    blurState[0] = 1;
 }


### PR DESCRIPTION
## Summary
- Rewrote `pppConScreenBlur` and `pppRenderScreenBlur` to use the serialized offset table through the pointer at `+0xC` (`m_serializedDataOffsets`) before indexing.
- Replaced placeholder-style pointer arithmetic with direct, source-plausible offset math (`+0x80` region accesses).
- Added missing version metadata placeholders in INFO blocks (EN/JP TODOs) for touched functions.
- Kept `pppFrameScreenBlur` wired to `lbl_8032ED70` to preserve exact match.

## Functions improved
- `pppRenderScreenBlur`: **83.666664% -> 90.20513%**
- `pppConScreenBlur`: **79.71429% -> 80.0%**
- `pppFrameScreenBlur`: remains **100.0%**
- `pppDesScreenBlur`: remains **84.0%**

## Match evidence
- Unit `main/pppScreenBlur` `.text` match: **83.47298% -> 87.0%** (`objdiff-cli diff -p . -u main/pppScreenBlur -o - pppConScreenBlur`)
- `pppRenderScreenBlur` now aligns on the key dataflow around:
  - offset table load from `0xC(param3)`
  - separate `[0]` / `[1]` offset loads
  - `+0x80` base computation and `0x0B` byte fetch
  - final state writeback through computed blur-state index

## Plausibility rationale
- The change models what the engine likely did originally: use serialized-data offset tables rather than raw ad-hoc pointer reinterpretation.
- The resulting code is simpler and more consistent with neighboring PPP units that read `m_serializedDataOffsets` and then apply fixed in-object offsets.
- No contrived compiler-coaxing control flow was added; improvements come from correcting data structure access semantics.
