### PR TITLE
card/CARDOpen: match __CARDIsPublic

### DIFF
--- a/src/card/CARDOpen.c
+++ b/src/card/CARDOpen.c
@@ -55,16 +55,14 @@ s32 __CARDIsWritable(CARDControl* card, CARDDir* ent) {
 }
 
 s32 __CARDIsPublic(CARDDir* ent) {
-    u8 perm;
-
     if (ent->gameName[0] == 0xFF) {
         return CARD_RESULT_NOFILE;
     }
 
-    perm = ent->permission & __CARDPermMask;
-    if (perm & 0x4) {
+    if ((ent->permission & 4) != 0) {
         return CARD_RESULT_READY;
     }
+
     return CARD_RESULT_NOPERM;
 }
 


### PR DESCRIPTION
## Summary
- Simplified `__CARDIsPublic` in `src/card/CARDOpen.c` by removing the temporary masked permission variable.
- Replaced:
  - `perm = ent->permission & __CARDPermMask;`
  - `if (perm & 0x4)`
  with a direct check:
  - `if ((ent->permission & 4) != 0)`

## Functions improved
- Unit: `main/card/CARDOpen`
- Function: `__CARDIsPublic`

## Match evidence
- `__CARDIsPublic`: **82.916664% -> 100.0%**
- Size: **48b -> 48b** (unchanged)
- Objdiff instruction diffs: **3 -> 0**
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/card/CARDOpen -o - __CARDIsPublic`

## Plausibility rationale
- The new form is more idiomatic and directly expresses the existing permission check semantics.
- Behavior is unchanged (same no-file check, same public bit check, same return codes).
- This removes an unnecessary temporary and mask operation rather than introducing compiler-driven control-flow tricks.

## Technical details
- Prior mismatch came from an extra mask/temporary sequence in the generated code around `ent->permission`.
- Using the direct bit test aligned the generated instruction sequence exactly with target assembly.
