### PR TITLE
p_sample: match CProcess on* handlers in p_sample.o

### DIFF
--- a/include/ffcc/p_sample.h
+++ b/include/ffcc/p_sample.h
@@ -17,11 +17,6 @@ public:
 
     void func0();
     void func1();
-
-    virtual void onScriptChanging(char*);
-    virtual void onScriptChanged(char*, int);
-    virtual void onMapChanging(int, int);
-    virtual void onMapChanged(int, int, int);
 };
 
 #endif

--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -13,6 +13,10 @@ class CProcess : public CManager
 {
 public:
     CProcess();
+    void onScriptChanging(char*);
+    void onScriptChanged(char*, int);
+    void onMapChanging(int, int);
+    void onMapChanged(int, int, int);
 
     virtual void ScriptChanging(char*);
     virtual void ScriptChanged(char*, int);

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -81,40 +81,56 @@ void CSamplePcs::func1()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	4
+ * PAL Address: 0x8001fe74
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSamplePcs::onScriptChanging(char*)
+void CProcess::onScriptChanging(char*)
 {
 	return;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	4
+ * PAL Address: 0x8001fe78
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSamplePcs::onScriptChanged(char*, int)
+void CProcess::onScriptChanged(char*, int)
 {
 	return;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	4
+ * PAL Address: 0x8001fe7c
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSamplePcs::onMapChanging(int, int)
+void CProcess::onMapChanging(int, int)
 {
 	return;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	4
+ * PAL Address: 0x8001fe80
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSamplePcs::onMapChanged(int, int, int)
+void CProcess::onMapChanged(int, int, int)
 {
 	return;
 }


### PR DESCRIPTION
## Summary
- Moves `onScriptChanging/onScriptChanged/onMapChanging/onMapChanged` ownership from `CSamplePcs` to `CProcess` in `p_sample`.
- Adds the corresponding `CProcess::on*` declarations in `include/ffcc/system.h`.
- Removes `CSamplePcs` `on*` declarations from `include/ffcc/p_sample.h` so the object emits the expected symbol ownership.
- Updates the four function info blocks to PAL address/size format.

## Functions improved
Unit: `main/p_sample`
- `onScriptChanging__8CProcessFPc`: now 100.0%
- `onScriptChanged__8CProcessFPci`: now 100.0%
- `onMapChanging__8CProcessFii`: now 100.0%
- `onMapChanged__8CProcessFiii`: now 100.0%

## Match evidence
- Objdiff unit text match for `main/p_sample` improved from **11.290322%** to **17.741936%**.
- Selector baseline previously showed these four handlers at 0.0% in this unit; after change they are symbol-matched and fully aligned in objdiff.

## Plausibility rationale
- PAL symbols for `p_sample.o` place these handlers on `CProcess`, not `CSamplePcs`.
- This change aligns function ownership with the shipped symbol map rather than introducing compiler-coaxing constructs.
- The resulting source is simpler and more consistent with class-responsibility expectations in this unit.

## Technical details
- The improvement comes from correcting symbol identity/mangling targets instead of instruction-level trickery.
- No behavior changes were introduced: all four handlers remain 4-byte no-op stubs (`blr` equivalent).
- Build verified with `ninja`, and improvement validated via `build/tools/objdiff-cli diff -p . -u main/p_sample -o -`.
