### PR TITLE
main/pppFilter: implement pppRenderFilter decomp logic

### DIFF
--- a/include/ffcc/pppFilter.h
+++ b/include/ffcc/pppFilter.h
@@ -1,6 +1,19 @@
 #ifndef _PPP_FILTER_H_
 #define _PPP_FILTER_H_
 
+struct pppFilter {
+    char padding[0x90];
+};
+
+struct UnkB {
+    unsigned int m_dataValIndex;
+};
+
+struct UnkC {
+    char padding[0x0c];
+    int* m_serializedDataOffsets;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -8,7 +21,7 @@ extern "C" {
 void pppConstructFilter(void);
 void pppDestructFilter(void);
 void pppFrameFilter(void);
-void pppRenderFilter(void);
+void pppRenderFilter(pppFilter* pppFilter, UnkB* param_2, UnkC* param_3);
 
 #ifdef __cplusplus
 }

--- a/src/pppFilter.cpp
+++ b/src/pppFilter.cpp
@@ -1,6 +1,26 @@
 #include "ffcc/pppFilter.h"
+#include "ffcc/mapmesh.h"
+#include "ffcc/util.h"
 
-extern volatile int lbl_8032ED70;
+class CMaterialSet;
+struct _pppEnvStLite {
+    void* m_stagePtr;
+    CMaterialSet* m_materialSetPtr;
+    CMapMesh* m_mapMeshPtr;
+};
+
+extern _pppEnvStLite* pppEnvStPtr;
+extern float FLOAT_803320c8;
+extern float FLOAT_803320cc;
+extern float FLOAT_803320d0;
+extern CUtil DAT_8032ec70;
+
+extern "C" {
+int GetTexture__8CMapMeshFP12CMaterialSetRi(CMapMesh* mapMesh, CMaterialSet* materialSet, int& textureIndex);
+void RenderTextureQuad__5CUtilFffffP9_GXTexObjP5Vec2dP5Vec2dP8_GXColor14_GXBlendFactor14_GXBlendFactor(
+    CUtil* util, float x0, float y0, float x1, float y1, _GXTexObj* texObj, Vec2d* uv0, Vec2d* uv1, _GXColor* color,
+    _GXBlendFactor srcFactor, _GXBlendFactor dstFactor);
+}
 
 /*
  * --INFO--
@@ -33,7 +53,7 @@ void pppDestructFilter(void)
  */
 void pppFrameFilter(void)
 {
-	(void)(lbl_8032ED70 == 0);
+	return;
 }
 
 /*
@@ -41,7 +61,20 @@ void pppFrameFilter(void)
  * Address:	TODO
  * Size:	TODO
  */
-void pppRenderFilter(void)
+void pppRenderFilter(pppFilter* pppFilterObj, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+	int serializedOffset = *param_3->m_serializedDataOffsets;
+
+	if (param_2->m_dataValIndex == 0xFFFF) {
+		_GXColor color = *(_GXColor*)((char*)pppFilterObj + serializedOffset + 0x88);
+		DAT_8032ec70.RenderColorQuad(FLOAT_803320c8, FLOAT_803320c8, FLOAT_803320cc, FLOAT_803320d0, color);
+		return;
+	}
+
+	int textureIndex = 0;
+	int textureBase = GetTexture__8CMapMeshFP12CMaterialSetRi(
+	    &pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex], pppEnvStPtr->m_materialSetPtr, textureIndex);
+	RenderTextureQuad__5CUtilFffffP9_GXTexObjP5Vec2dP5Vec2dP8_GXColor14_GXBlendFactor14_GXBlendFactor(
+	    &DAT_8032ec70, FLOAT_803320c8, FLOAT_803320c8, FLOAT_803320cc, FLOAT_803320d0, (_GXTexObj*)(textureBase + 0x28),
+	    0, 0, (_GXColor*)((char*)pppFilterObj + serializedOffset + 0x88), GX_BL_SRCALPHA, GX_BL_INVSRCALPHA);
 }


### PR DESCRIPTION
## Summary
- Added minimal `pppFilter`/`UnkB`/`UnkC` type scaffolding in `include/ffcc/pppFilter.h`.
- Updated `pppRenderFilter` signature to the 3-argument PPP form and implemented the two-path render flow in `src/pppFilter.cpp`:
  - solid-color quad path when `m_dataValIndex == 0xFFFF`
  - textured quad path using `GetTexture__8CMapMeshFP12CMaterialSetRi` + `RenderTextureQuad__5CUtil...`
- Kept `pppFrameFilter`, `pppConstructFilter`, and `pppDestructFilter` simple/stub-safe.

## Functions Improved
- Unit: `main/pppFilter`
- `pppRenderFilter` (196b): **2.04% -> 75.82%** (objdiff symbol score)
- Unit fuzzy score: **9.3% -> 75.09%** (selector baseline vs current `build/GCCP01/report.json`)

## Match Evidence
- Baseline (`agent_select_target.py`): `main/pppFilter` at 9.3% with `pppRenderFilter` at 2.0%.
- After change:
  - `build/tools/objdiff-cli diff -p . -u main/pppFilter -o - pppRenderFilter` reports `75.81633%`.
  - `ninja` report shows `main/pppFilter` fuzzy `75.09259%` and `pppRenderFilter` fuzzy `76.63265%`.

## Plausibility Rationale
- The new body follows Ghidra's control flow and data access pattern for this function (serialized offset lookup, color-vs-texture branch, util render calls), instead of synthetic compiler-coaxing constructs.
- Data accesses use byte offsets consistent with existing PPP decomp style in this repository.

## Technical Notes
- Used explicit mangled externs for the known map-mesh texture fetch and textured-quad util call to preserve expected call targets.
- Used a minimal local `_pppEnvSt` subset for required fields (`m_materialSetPtr`, `m_mapMeshPtr`) to avoid broad unrelated type churn.
