### PR TITLE
main/pppMatrixXYZ: align data access pattern with sibling matrix builders

### DIFF
--- a/src/pppMatrixXYZ.cpp
+++ b/src/pppMatrixXYZ.cpp
@@ -1,6 +1,5 @@
 #include "ffcc/pppMatrixXYZ.h"
 #include "ffcc/pppGetRotMatrixXYZ.h"
-#include "ffcc/partMng.h"
 #include <dolphin/mtx.h>
 
 /*
@@ -14,48 +13,41 @@
  */
 void pppMatrixXYZ(pppFMATRIX& matrix, PPPCREATEPARAM* param)
 {
+    u32* offsets = (u32*)*(void**)((u8*)param + 0xC);
+    pppIVECTOR4* angle = (pppIVECTOR4*)((u8*)&matrix + offsets[1] + 0x80);
+    f32* scale = (f32*)((u8*)&matrix + offsets[2] + 0x80);
+    f32* translation = (f32*)((u8*)&matrix + offsets[0] + 0x80);
     Vec tempVec1;
-    Vec tempVec2; 
+    Vec tempVec2;
     Vec tempVec3;
-    
-    // Get rotation matrix from angle data 
-    pppGetRotMatrixXYZ(matrix, (pppIVECTOR4*)param->m_extraPositionPtr);
 
-    // Extract and scale first column vector (X-axis)
+    pppGetRotMatrixXYZ(matrix, angle);
+
     tempVec1.x = matrix.value[0][0];
-    tempVec1.y = matrix.value[1][0]; 
+    tempVec1.y = matrix.value[1][0];
     tempVec1.z = matrix.value[2][0];
-    
-    PSVECScale(&tempVec1, &tempVec1, param->m_scalePtr->x);
-    
+    PSVECScale(&tempVec1, &tempVec1, scale[0]);
     matrix.value[0][0] = tempVec1.x;
     matrix.value[1][0] = tempVec1.y;
     matrix.value[2][0] = tempVec1.z;
-    
-    // Extract and scale second column vector (Y-axis)
+
     tempVec2.x = matrix.value[0][1];
     tempVec2.y = matrix.value[1][1];
     tempVec2.z = matrix.value[2][1];
-    
-    PSVECScale(&tempVec2, &tempVec2, param->m_scalePtr->y);
-    
+    PSVECScale(&tempVec2, &tempVec2, scale[1]);
     matrix.value[0][1] = tempVec2.x;
-    matrix.value[1][1] = tempVec2.y; 
+    matrix.value[1][1] = tempVec2.y;
     matrix.value[2][1] = tempVec2.z;
-    
-    // Extract and scale third column vector (Z-axis)
+
     tempVec3.x = matrix.value[0][2];
-    tempVec3.y = matrix.value[1][2]; 
+    tempVec3.y = matrix.value[1][2];
     tempVec3.z = matrix.value[2][2];
-
-    PSVECScale(&tempVec3, &tempVec3, param->m_scalePtr->z);
-
+    PSVECScale(&tempVec3, &tempVec3, scale[2]);
     matrix.value[0][2] = tempVec3.x;
     matrix.value[1][2] = tempVec3.y;
     matrix.value[2][2] = tempVec3.z;
 
-    // Set translation components from position
-    matrix.value[0][3] = param->m_positionOffsetPtr->x;
-    matrix.value[1][3] = param->m_positionOffsetPtr->y;
-    matrix.value[2][3] = param->m_positionOffsetPtr->z;
+    matrix.value[0][3] = translation[0];
+    matrix.value[1][3] = translation[1];
+    matrix.value[2][3] = translation[2];
 }


### PR DESCRIPTION
## Summary
- Reworked `pppMatrixXYZ` to use the same offset-table access pattern used by sibling `pppMatrix*` routines.
- Derived `angle`, `scale`, and `translation` from `*(void**)((u8*)param + 0xC)` and `&matrix + offset + 0x80` instead of using direct `PPPCREATEPARAM` member pointers.
- Kept the existing rotation + column-scale + translation-write structure, but removed non-informative inline commentary.

## Functions improved
- Unit: `main/pppMatrixXYZ`
- Function: `pppMatrixXYZ` (320b)

## Match evidence
- Before: `75.7%` (from `tools/agent_select_target.py` target selection)
- After: `98.025%` (`build/GCCP01/report.json` and `objdiff-cli` for `main/pppMatrixXYZ`)
- `objdiff` oneshot (`build/tools/objdiff-cli diff -p . -u main/pppMatrixXYZ -o - pppMatrixXYZ`) reports `.text` `match_percent: 98.025` (size `320`).

## Plausibility rationale
- This change mirrors the established source pattern already present in adjacent matrix-order constructors (`pppMatrixXZY`, `pppMatrixYZX`, `pppMatrixZXY`) rather than adding compiler-only coercions.
- The resulting code reflects a plausible shared engine convention: compute rotation from indexed parameter blocks, scale basis columns, then write translation.

## Technical details
- Key improvement came from correcting parameter interpretation/layout (offset-table indirection at `param + 0xC`), which better matches the object-memory access style seen across this subsystem.
- No artificial temporaries, dummy branches, or codegen-only tricks were introduced.
