### PR TITLE
main/pppAngMove: match pppAngMove to 100%

### DIFF
--- a/src/pppAngMove.cpp
+++ b/src/pppAngMove.cpp
@@ -2,6 +2,32 @@
 
 extern int lbl_8032ED70;
 
+struct PppAngMoveObj {
+    int x;
+    int y;
+    int z;
+};
+
+struct PppAngMoveOffsets {
+    int a;
+    int b;
+};
+
+struct PppAngMoveData {
+    void* field_0;
+    void* field_4;
+    int field_8;
+    void* ptrData;
+};
+
+struct PppAngMoveInput {
+    int field_0;
+    int field_4;
+    int x;
+    int y;
+    int z;
+};
+
 /*
  * --INFO--
  * PAL Address: 0x80064e80
@@ -11,30 +37,31 @@ extern int lbl_8032ED70;
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppAngMove(void* dest, void* src, void* param1, void* param2)
+void pppAngMove(void* basePtr, void* input, void* data1, void* data2)
 {
+    PppAngMoveOffsets* offsets = (PppAngMoveOffsets*)((PppAngMoveData*)data1)->ptrData;
+    PppAngMoveObj* a = (PppAngMoveObj*)((char*)basePtr + offsets->a + 0x80);
+    PppAngMoveObj* b = (PppAngMoveObj*)((char*)basePtr + offsets->b + 0x80);
+    PppAngMoveInput* inputData = (PppAngMoveInput*)input;
+
+    (void)data2;
+
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    int* param2Ptr = (int*)param2;
-    int destOffset = param2Ptr[0];
-    int srcOffset = param2Ptr[1];
-    int* destPtr = (int*)((char*)dest + destOffset + 0x80);
-    int* srcPtr = (int*)((char*)dest + srcOffset + 0x80);
+    int inputId = *(int*)inputData;
+    int baseId = *(int*)((char*)basePtr + 0xc);
 
-    if (param1 != 0) {
-        int* param1Ptr = (int*)param1;
-        if (param1Ptr[3] == ((int*)dest)[3]) {
-            srcPtr[0] += param1Ptr[2];
-            srcPtr[1] += param1Ptr[3];
-            srcPtr[2] += param1Ptr[4];
-        }
+    if (inputId == baseId) {
+        b->x += inputData->x;
+        b->y += inputData->y;
+        b->z += inputData->z;
     }
 
-    destPtr[0] += srcPtr[0];
-    destPtr[1] += srcPtr[1];
-    destPtr[2] += srcPtr[2];
+    a->x += b->x;
+    a->y += b->y;
+    a->z += b->z;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppAngMove` to use explicit data/input layouts that match the object-level calling/data pattern.
- Aligned control/data flow with nearby `ppp*` movement helpers: load serialized offsets from arg3 data block, derive two vector slots, apply input delta when IDs match, then accumulate.
- Kept `pppAngMoveCon` behavior unchanged.

## Functions improved
- Unit: `main/pppAngMove`
- `pppAngMove`: **77.92308% -> 100.0%**
- `pppAngMoveCon`: remains **100.0%**

## Match evidence
- `ninja` build succeeds.
- `build/tools/objdiff-cli diff -p . -u main/pppAngMove -o - pppAngMove` reports:
  - `pppAngMove: 100.0%`
  - `pppAngMoveCon: 100.0%`
- Unit `.text` section reaches full match in objdiff output.

## Plausibility rationale
- The resulting code is idiomatic for this codebase’s particle/move helpers: typed offset payload + typed input payload + straightforward vector accumulation.
- No contrived temporaries, no hardcoded member-offset tricks beyond existing serialized offsets, and no compiler-only artifacts were introduced.

## Technical details
- Introduced local structs (`PppAngMoveObj`, `PppAngMoveOffsets`, `PppAngMoveData`, `PppAngMoveInput`) to express the effective data layout.
- Replaced ad-hoc pointer arithmetic/null-guard flow with direct ID-compare gating and deterministic x/y/z accumulation order that aligns with target assembly.
