### PR TITLE
main/pppPObjPoint: improve pppPObjPoint match to 83.78%

### DIFF
--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -3,6 +3,7 @@
 
 extern s32 lbl_8032ED70;
 extern void* lbl_8032ED50;
+extern u32 lbl_801EADC8;
 
 /*
  * --INFO--
@@ -15,28 +16,23 @@ void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* co
         return;
     }
 
-    u8* pointBase = (u8*)pointData;
-    s32 pointOffset = *(s32*)container->ptrData;
-    PppPointObj* objPtr = (PppPointObj*)(pointBase + pointOffset + 0x80);
+    PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + *(s32*)container->ptrData + 0x80);
 
     if (objData->id == pointData->id) {
-        void* vectorPtr;
+        float* vectorPtr;
 
         if ((objData->field_4 + 0x10000) == 0xFFFF) {
-            extern u32 lbl_801EADC8;
-            vectorPtr = (void*)&lbl_801EADC8;
+            vectorPtr = (float*)(u32)&lbl_801EADC8;
         } else {
             void* arrayPtr = *(void**)((u8*)lbl_8032ED50 + 0xD4);
             u32 index = objData->field_4 << 4;
-            u32 baseOffset = *(u32*)((u8*)arrayPtr + index + 4);
-            vectorPtr = (u8*)objData->data + baseOffset + 0x80;
+            vectorPtr = (float*)((u8*)objData->data + *(u32*)((u8*)arrayPtr + index + 4) + 0x80);
         }
 
         objPtr->vecPtr = vectorPtr;
     }
 
-    f32* src = (f32*)objPtr->vecPtr;
-    objPtr->x = src[0];
-    objPtr->y = src[1];
-    objPtr->z = src[2];
+    objPtr->x = ((f32*)objPtr->vecPtr)[0];
+    objPtr->y = ((f32*)objPtr->vecPtr)[1];
+    objPtr->z = ((f32*)objPtr->vecPtr)[2];
 }


### PR DESCRIPTION
## Summary
- Reworked `pppPObjPoint` to use a lower-level pointer flow that better matches the original codegen.
- Collapsed temporary variables around the container offset and source vector resolution.
- Adjusted final component writes to reload through `vecPtr` each time, aligning with expected instruction shape.

## Functions improved
- Unit: `main/pppPObjPoint`
- Symbol: `pppPObjPoint`

## Match evidence
- `pppPObjPoint`: **78.37838% -> 83.78378%** (`+5.40540%`)
- Measured via:
  - `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o - pppPObjPoint`

## Plausibility rationale
- Changes keep original gameplay behavior and represent plausible source cleanup an FFCC developer might write:
  - Direct pointer math for packed effect data access.
  - Reduced unnecessary locals while preserving the same data dependencies.
  - Explicit vec component copy from resolved pointer.

## Technical details
- Improved alignment in objdiff by matching:
  - Branch and compare structure around object-id check.
  - Post-resolution vec copy sequence.
  - Data address computation using `container->ptrData` and object table lookup offsets.
- Remaining differences are concentrated around constant/address materialization for `lbl_801EADC8` and a subset of index computation instructions.
