### PR TITLE
Improve match for pppRandDownInt by fixing parameter typing/flow

### DIFF
--- a/include/ffcc/pppRandDownInt.h
+++ b/include/ffcc/pppRandDownInt.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void pppRandDownInt(int, void*, void*);
+void pppRandDownInt(void*, void*, void*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- changed `pppRandDownInt` first parameter type from `int` to `void*` to match pointer-style addressing in the unit
- rewrote the function body to use consistent pointer-based field access and early returns
- aligned argument role usage (`param1` state block, `param2` control block, `param3` index block) and removed non-source-like temporary/address hacks

## Functions improved
- Unit: `main/pppRandDownInt`
- Symbol: `pppRandDownInt`

## Match evidence
- `.text` match: **63.36% -> 73.026665%** (+9.666665)
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandDownInt -o - pppRandDownInt`
- Instruction diff kind counts (before -> after):
  - `DIFF_DELETE`: 18 -> 12
  - `DIFF_INSERT`: 4 -> 3
  - `DIFF_ARG_MISMATCH`: 24 -> 22
  - `DIFF_OP_MISMATCH`: 2 -> 1

## Plausibility rationale
- the update removes contrived stack/address arithmetic around an `int`-typed first parameter and uses normal pointer-based object access
- control flow now follows straightforward game-code style (global guard, primary branch, early-exit checks)
- changes are type/control-flow corrections rather than compiler-coaxing artifacts

## Technical details
- header + definition signature now match pointer semantics (`void*, void*, void*`)
- result writeback/update paths now compute offsets from the first object parameter directly
- function metadata header (`--INFO--`) remains intact with PAL address/size
