### PR TITLE
Runtime/New: improve std::exception destructor match

### DIFF
--- a/include/PowerPC_EABI_Support/Runtime/New.h
+++ b/include/PowerPC_EABI_Support/Runtime/New.h
@@ -1,1 +1,1 @@
-void operator delete(void* arg0);
+void operator delete(void* arg0) throw();

--- a/src/Runtime.PPCEABI.H/New.cp
+++ b/src/Runtime.PPCEABI.H/New.cp
@@ -1,6 +1,12 @@
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/alloc.h"
 #include "PowerPC_EABI_Support/Runtime/New.h"
 
+inline void operator delete(void* arg0) throw() {
+    if (arg0 != 0) {
+        free(arg0);
+    }
+}
+
 namespace std {
 
 class exception {
@@ -9,6 +15,15 @@ public:
     virtual const char* what() const;
 };
 
+/*
+ * --INFO--
+ * PAL Address: 0x801AF7FC
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 exception::~exception() {
     // Empty virtual destructor - compiler generates vtable setup
 }
@@ -18,9 +33,3 @@ const char* exception::what() const {
 }
 
 } // namespace std
-
-void operator delete(void* arg0) throw() {
-    if (arg0 != 0) {
-        free(arg0);
-    }
-}


### PR DESCRIPTION
## Summary
- Updated the Runtime `operator delete` declaration to include `throw()` in `include/PowerPC_EABI_Support/Runtime/New.h`.
- Moved the `operator delete` definition to the top of `src/Runtime.PPCEABI.H/New.cp` and marked it `inline` so the deleting-destructor path for `std::exception` compiles to the expected inlined `free` sequence.
- Added function info metadata for `std::exception::~exception` (PAL address/size).

## Functions improved
- Unit: `main/Runtime.PPCEABI.H/New`
- Symbol: `__dt__Q23std9exceptionFv`
  - Before: `51.068966%` (size `72`)
  - After: `99.655174%` (size `116`)

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/Runtime.PPCEABI.H/New -o - __dt__Q23std9exceptionFv`
- Remaining differences are two relocation argument mismatches on vtable label references (`lis/addi` pair), with code shape/size matching.

## Plausibility rationale
- The change is ABI/type-driven and source-plausible: correcting the `throw()` signature and allowing a small delete wrapper to inline is consistent with Metrowerks-era runtime codegen.
- No contrived temporaries or unnatural control-flow tricks were introduced.

## Technical details
- Previous output emitted local `__dl__FPv` and a shorter deleting destructor body.
- New output removes local `__dl__FPv` from this TU and emits the expected deleting-destructor structure (including `free`/`__unexpected` behavior), bringing the function to near-match.
