### PR TITLE
main/pppVtMime: improve pppDrawVtMime match via ABI type fixes

### DIFF
--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -82,7 +82,7 @@ void pppDrawVtMime(void* param1, void* param2, void* param3)
 	void** memPtr = (void**)((char*)target + 0xC);
 	if (*memPtr == 0) {
 		// Allocate memory for vertex data
-		extern void* pppMemAlloc__FUlPQ27CMemory6CStagePci(int size, void* stage, const char* info, int param);
+		extern void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long size, void* stage, char* info, int param);
 		extern void* lbl_8032ED54;
 		void* stage = *(void**)lbl_8032ED54;
 		
@@ -112,7 +112,7 @@ void pppDrawVtMime(void* param1, void* param2, void* param3)
 		}
 		
 		// Flush data cache
-		extern void DCFlushRange(void* ptr, int size);
+		extern void DCFlushRange(void* ptr, unsigned long size);
 		DCFlushRange(*memPtr, vertCount * 0xC);
 	}
 	


### PR DESCRIPTION
## Summary
- Adjusted two extern signatures in `pppDrawVtMime` (`src/pppVtMime.cpp`) to match PAL symbol argument types more closely:
  - `pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int)`
  - `DCFlushRange(void*, unsigned long)`
- No control-flow or behavior changes were made.

## Functions Improved
- Unit: `main/pppVtMime`
- Symbol improved: `pppDrawVtMime`

## Match Evidence
- `pppDrawVtMime`: **70.65289% -> 73.04958%** (`+2.39669`)
- `pppVtMimeDes`: **82.53846% -> 82.53846%** (no regression)
- `pppVtMimeCon`: **99.36364% -> 99.36364%**
- `pppVtMimeCon2`: **99.22222% -> 99.22222%**
- `pppVtMime`: **100.0% -> 100.0%**

Objdiff instruction deltas on `pppDrawVtMime` include callsite alignment improvements:
- `bl pppMemAlloc__FUlPQ27CMemory6CStagePci`: `DIFF_ARG_MISMATCH -> OK`
- `bl DCFlushRange`: `DIFF_ARG_MISMATCH -> OK`

## Plausibility Rationale
- The updated types follow the mangled PAL symbol contract (`FUl...` indicates an unsigned long first arg).
- This is a source-plausible ABI/type correction, not control-flow coercion.

## Technical Notes
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/pppVtMime -o - pppDrawVtMime`
