### PR TITLE
main/pppScaleLoopAuto: improve pppScaleLoopAutoCon match

### DIFF
--- a/src/pppScaleLoopAuto.cpp
+++ b/src/pppScaleLoopAuto.cpp
@@ -120,19 +120,16 @@ void pppScaleLoopAutoCon(void* arg1, void* arg2)
 	float* targetData = (float*)targetPtr;
 	char* targetBytes = (char*)targetPtr;
 	
-	// Initialize float values to 0.0f - including 0x24 offset
-	targetData[0] = 0.0f;
-	targetData[1] = 0.0f; 
 	targetData[2] = 0.0f;
-	targetData[4] = 0.0f;
-	targetData[5] = 0.0f;
+	targetData[1] = 0.0f;
+	targetData[0] = 0.0f;
 	targetData[6] = 0.0f;
-	targetData[9] = 0.0f;
-	
-	// Initialize byte values to 0 - complete sequence
+	targetData[5] = 0.0f;
+	targetData[4] = 0.0f;
 	targetBytes[28] = 0;
 	targetBytes[29] = 0;
-	*(short*)(targetBytes + 30) = 0;  // Use 16-bit store for 30-31
-	targetBytes[32] = 0;
+	*(short*)(targetBytes + 30) = 0;
 	targetBytes[33] = 0;
+	targetBytes[32] = 0;
+	targetData[9] = 0.0f;
 }


### PR DESCRIPTION
## Summary
Reordered initialization stores in `pppScaleLoopAutoCon` to better match expected Metrowerks codegen while keeping behavior unchanged:
- Reordered float zero-initialization stores to descending index groups (`2,1,0` and `6,5,4`)
- Reordered trailing byte stores (`33` before `32`)
- Moved `targetData[9] = 0.0f` to the end of the sequence

## Functions improved
- Unit: `main/pppScaleLoopAuto`
- Symbol: `pppScaleLoopAutoCon`

## Match evidence
Measured with:
`build/tools/objdiff-cli diff -p . -u main/pppScaleLoopAuto -o - <symbol>`

- `pppScaleLoopAutoCon`: **88.89474% -> 99.73684%**
- Diff markers: **9 -> 1**
- Remaining mismatch is a single `lfs` relocation target-symbol difference on the `0.0f` constant; instruction shape/flow now aligns.
- `pppScaleLoopAuto` unchanged: 70.577774%

## Plausibility rationale
The change is source-plausible and idiomatic for this codebase:
- It uses natural field initialization without artificial temporaries.
- It follows existing style used in nearby constructors (e.g. descending store order in `pppScaleCon`).
- It does not introduce compiler-coaxing constructs or readability regressions.

## Technical details
The previous version had ordering-based store mismatches (float stores and byte stores). Aligning the store order produced near-complete instruction alignment for `pppScaleLoopAutoCon` with no behavioral change.
