### PR TITLE
pppConstrainCameraDir: align serialized data base addressing

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -15,7 +15,7 @@ void pppConstructConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir
     extern float DAT_803320c4;
     
     float uVar1 = DAT_803320c4;
-    float* puVar2 = (float*)((int)(&pppConstrainCameraDir->field0_0x0 + 2) + *param_2->m_serializedDataOffsets);
+    float* puVar2 = (float*)((char*)pppConstrainCameraDir + *param_2->m_serializedDataOffsets + 0x80);
     puVar2[2] = DAT_803320c4;
     puVar2[1] = uVar1;
     puVar2[0] = uVar1;
@@ -35,7 +35,7 @@ void pppConstruct2ConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDi
     extern float DAT_803320c4;
     
     float uVar1 = DAT_803320c4;
-    float* puVar2 = (float*)((int)(&pppConstrainCameraDir->field0_0x0 + 2) + *param_2->m_serializedDataOffsets);
+    float* puVar2 = (float*)((char*)pppConstrainCameraDir + *param_2->m_serializedDataOffsets + 0x80);
     puVar2[2] = DAT_803320c4;
     puVar2[1] = uVar1;
     puVar2[0] = uVar1;
@@ -77,7 +77,7 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, Un
     _pppMngSt* pppMngSt = pppMngStPtr;
 
     if (DAT_8032ed70 == 0) {
-        float* value = (float*)((int)(&pppConstrainCameraDir->field0_0x0 + 2) + *param_3->m_serializedDataOffsets);
+        float* value = (float*)((char*)pppConstrainCameraDir + *param_3->m_serializedDataOffsets + 0x80);
         
         // Call CalcGraphValue function
         extern void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, float*, int, float*, float*, float*, float*, float*);


### PR DESCRIPTION
## Summary
- Updated serialized-data pointer calculations in `pppConstrainCameraDir` to use the standard object data base offset form: `(char*)obj + serializedOffset + 0x80`.
- Applied this consistently in:
  - `pppConstructConstrainCameraDir`
  - `pppConstruct2ConstrainCameraDir`
  - `pppFrameConstrainCameraDir`

## Functions improved
- Unit: `main/pppConstrainCameraDir`
- Symbols:
  - `pppConstructConstrainCameraDir`: `84.55556%` -> `99.333336%`
  - `pppConstruct2ConstrainCameraDir`: `84.55556%` -> `99.333336%`
  - `pppFrameConstrainCameraDir`: `86.85827%` -> `88.43307%`

## Match evidence
- `objdiff-cli` command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir -o - pppConstructConstrainCameraDir`
- Constructor diffs now align on the expected `addi ..., 0x80` pointer-base step and improved overall instruction alignment.
- Frame symbol also improved from the same base-address correction pattern.

## Plausibility rationale
- This change reflects an existing codebase-wide idiom for PPP serialized data access (`base + offset + 0x80`) rather than introducing coercive or contrived patterns.
- No artificial temporaries, control-flow hacks, or readability regressions were introduced.

## Technical details
- Previous form used `(&field0_0x0 + 2)` to imply the same base; rewriting to explicit byte-address math produced more faithful codegen.
- Behavior is unchanged; only address arithmetic form was clarified to match expected ABI/layout usage.
