### PR TITLE
pppScreenBlur: align serialized offsets with particle data base

### DIFF
--- a/src/pppScreenBlur.cpp
+++ b/src/pppScreenBlur.cpp
@@ -38,7 +38,7 @@ void pppConScreenBlur(void* param1, void* param2)
 {
     pppScreenBlur* blur = (pppScreenBlur*)param1;
     pppScreenBlurOffsets* offsets = (pppScreenBlurOffsets*)param2;
-    s32 blurOffset = offsets->m_serializedDataOffsets[1];
+    s32 blurOffset = offsets->m_serializedDataOffsets[1] + 0x80;
 
     Graphic.InitBlurParameter();
     blur->data[blurOffset] = 0;
@@ -103,14 +103,14 @@ void pppRenderScreenBlur(void* param1, void* param2, void* param3)
     pppScreenBlur* blur = (pppScreenBlur*)param1;
     pppScreenBlurParam* blurParam = (pppScreenBlurParam*)param2;
     pppScreenBlurOffsets* offsets = (pppScreenBlurOffsets*)param3;
-    s32 blurActiveOffset = offsets->m_serializedDataOffsets[1];
-    s32 blurValueOffset = offsets->m_serializedDataOffsets[0];
+    s32 blurActiveOffset = offsets->m_serializedDataOffsets[1] + 0x80;
+    s32 blurValueOffset = offsets->m_serializedDataOffsets[0] + 0x80;
     u32 blurMask;
 
     blurParam->m_blurB = 0;
     blurMask = __cntlzw((u32)blur->data[blurActiveOffset]);
     Graphic.RenderBlur(blurMask >> 5, blurParam->m_blurR, blurParam->m_blurG, blurParam->m_blurB,
-                       blur->data[blurValueOffset + 0x8B], blurParam->m_initWOrk);
+                       blur->data[blurValueOffset + 0x0B], blurParam->m_initWOrk);
     pppInitBlendMode();
     GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
     blur->data[blurActiveOffset] = 1;


### PR DESCRIPTION
## Summary
- Applied the standard PPP serialized data base adjustment (`+0x80`) when accessing runtime blur state offsets.
- Updated `pppRenderScreenBlur` byte access to use the adjusted base (`+0x0B` after base-adjusted offset), keeping semantics equivalent while improving generated code alignment.

## Functions improved
- Unit: `main/pppScreenBlur`
- `pppRenderScreenBlur`: `83.666664% -> 89.948715%` (`+6.282051`)
- `pppConScreenBlur`: `79.714290% -> 80.476190%` (`+0.761900`)
- `pppDesScreenBlur`: `84.000000% -> 84.000000%` (no change)

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppScreenBlur -o - pppConScreenBlur`
  - `build/tools/objdiff-cli diff -p . -u main/pppScreenBlur -o - pppRenderScreenBlur`
  - `build/tools/objdiff-cli diff -p . -u main/pppScreenBlur -o - pppDesScreenBlur`
- `ninja` build passes after the change.

## Plausibility rationale
- Across PPP modules in this codebase, serialized offsets are typically relative to object data at `param + 0x80`.
- This change follows that existing source pattern instead of introducing synthetic control-flow or compiler-coaxing temporaries.
- The edit is small and idiomatic (offset-base correction), matching expected data layout usage in neighboring PPP code.