### PR TITLE
main/pppParHitSph: raise pppParHitSph match to 84.47%

### DIFF
--- a/src/pppParHitSph.cpp
+++ b/src/pppParHitSph.cpp
@@ -1,17 +1,12 @@
 #include "ffcc/pppParHitSph.h"
+#include "ffcc/graphic.h"
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
 #include <dolphin/mtx.h>
 
 extern _pppMngSt* pppMngStPtr;
 extern float FLOAT_80330700;
-extern int CFlat;
-extern Mtx ppvCameraMatrix0;
-
-// Forward declarations 
-class CGraphic;
-extern CGraphic Graphic;
-void DrawSphere(CGraphic* graphic, Mtx* matrix, void* color);
+extern unsigned char CFlat[];
 
 /*
  * --INFO--
@@ -26,20 +21,19 @@ void pppParHitSph(struct _pppPObject* param_1, int param_2)
 {
     _pppMngSt* p_Var1;
     double dVar2;
-    unsigned int local_a8;
-    unsigned int local_a4;
     Vec local_a0;
     Vec local_94;
     Vec local_88;
+    _GXColor local_7c;
     Mtx MStack_78;
     Mtx local_48;
     
     p_Var1 = pppMngStPtr;
-    PSVECSubtract(&pppMngStPtr->m_position, &pppMngStPtr->m_position, &local_88);
+    PSVECSubtract(&pppMngStPtr->m_position, (Vec*)((char*)pppMngStPtr + 0x48), &local_88);
     local_94.x = (pppMngStPtr->m_matrix).value[0][3];
     local_94.y = (pppMngStPtr->m_matrix).value[1][3];
     local_94.z = (pppMngStPtr->m_matrix).value[2][3];
-    dVar2 = (double)(1.0 /*p_Var1->m_paramD*/ * *(float*)(param_2 + 8));
+    dVar2 = (double)(*(float*)((char*)p_Var1 + 0x84) * *(float*)(param_2 + 8));
     
     if (((FLOAT_80330700 == local_88.x) && (FLOAT_80330700 == local_88.y)) &&
         (FLOAT_80330700 == local_88.z)) {
@@ -48,19 +42,21 @@ void pppParHitSph(struct _pppPObject* param_1, int param_2)
         pppHitCylinderSendSystem(p_Var1, &local_94, &local_88, (float)dVar2, *(float*)(param_2 + 4));
     }
     
-    if ((CFlat & 0x200000) != 0) {
-        local_a4 = 0xffffffff;
-        // PSMTXIdentity(&MStack_78);
-        // PSMTXIdentity(&local_48);
+    if ((*(unsigned int*)(CFlat + 0x129c) & 0x200000) != 0) {
+        PSMTXIdentity(MStack_78);
+        PSMTXIdentity(local_48);
         local_48[0][0] = (float)dVar2;
         local_48[1][1] = (float)dVar2;
         local_48[2][2] = (float)dVar2;
-        // PSMTXConcat(&ppvCameraMatrix0, &MStack_78, &MStack_78);
-        // PSMTXMultVec(&MStack_78, &local_94, &local_a0);
+        PSMTXConcat(ppvCameraMatrix0, MStack_78, MStack_78);
+        PSMTXMultVec(MStack_78, &local_94, &local_a0);
         local_48[0][3] = local_a0.x;
         local_48[1][3] = local_a0.y;
         local_48[2][3] = local_a0.z;
-        local_a8 = local_a4;
-        DrawSphere(&Graphic, &local_48, &local_a8);
+        local_7c.r = 0xff;
+        local_7c.g = 0xff;
+        local_7c.b = 0xff;
+        local_7c.a = 0xff;
+        Graphic.DrawSphere(local_48, local_7c);
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `pppParHitSph` to use motion delta from current vs previous position (`+0x48`) instead of subtracting position from itself.
- Restored matrix setup/transform path in the debug sphere block (`PSMTXIdentity`, `PSMTXConcat`, `PSMTXMultVec`).
- Replaced placeholder scale source with manager field load at `+0x84` for the radius multiplier.
- Switched debug sphere color/path to a `_GXColor` value and `Graphic.DrawSphere` call, and read the display flag from `CFlat + 0x129c`.

## Functions improved
- Unit: `main/pppParHitSph`
- Symbol: `pppParHitSph`

## Match evidence
- Before: `55.075268%`
  - `build/tools/objdiff-cli diff -p . -u main/pppParHitSph -o - pppParHitSph`
- After: `84.47312%`
  - Same objdiff command after edits
- Net: `+29.397852` percentage points

## Plausibility rationale
- Changes align with expected game logic (current/previous position delta, camera-space transform for debug sphere rendering, and normal graphics API usage) rather than compiler-only coaxing.
- The updated code reflects common FFCC particle/render patterns already used in nearby units.

## Technical details
- Remaining diffs are mostly stack-layout/register-allocation level and symbol-selection noise; major control/data-flow mismatches from missing matrix calls and placeholder constants were removed.
- The unit builds cleanly with `ninja`.
