### PR TITLE
Match pppMatrixZYX to full matrix callback flow

### DIFF
--- a/include/ffcc/pppMatrixZYX.h
+++ b/include/ffcc/pppMatrixZYX.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-void pppMatrixZYX(pppFMATRIX& out, pppIVECTOR4* angle);
+void pppMatrixZYX(void* target, void* unused, void* param);
 
 #ifdef __cplusplus
 }

--- a/src/pppMatrixZYX.cpp
+++ b/src/pppMatrixZYX.cpp
@@ -1,25 +1,60 @@
 #include "ffcc/pppMatrixZYX.h"
 
-#include "ffcc/pppsintbl.h"
-#include "ffcc/pppGetRotMatrixX.h"
-#include "ffcc/pppGetRotMatrixY.h"
-#include "ffcc/pppGetRotMatrixZ.h"
+#include "ffcc/pppGetRotMatrixZYX.h"
+#include <dolphin/mtx.h>
 
 /*
  * --INFO--
- * PAL Address: 800659d8
+ * PAL Address: 0x800659D8
  * PAL Size: 320b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppMatrixZYX(pppFMATRIX& out, pppIVECTOR4* angle)
+void pppMatrixZYX(void* target, void* unused, void* param)
 {
-    pppFMATRIX mZ;
-    pppFMATRIX mY;
-    pppFMATRIX zy;
-    pppFMATRIX mX;
+    (void)unused;
 
-    pppGetRotMatrixZ(mZ, angle->z);
-    pppGetRotMatrixY(mY, angle->y);
-    PSMTXConcat(mZ.value, mY.value, zy.value);
-    pppGetRotMatrixX(mX, angle->x);
-    PSMTXConcat(zy.value, mX.value, out.value);
+    f32* matrix = (f32*)target;
+    u32* offsets = (u32*)*(void**)((u8*)param + 0xC);
+    u32 translationOffset = offsets[0];
+    u32 scaleOffset = offsets[2];
+    u32 angleOffset = offsets[1];
+    f32* translation = (f32*)((u8*)target + translationOffset + 0x80);
+    f32* scale = (f32*)((u8*)target + scaleOffset + 0x80);
+    pppIVECTOR4* angle = (pppIVECTOR4*)((u8*)target + angleOffset + 0x80);
+    Vec temp1;
+    Vec temp2;
+    Vec temp3;
+
+    pppGetRotMatrixZYX(*(pppFMATRIX*)(matrix + 4), angle);
+
+    temp1.x = matrix[4];
+    temp1.y = matrix[8];
+    temp1.z = matrix[12];
+    PSVECScale(&temp1, &temp1, scale[0]);
+    matrix[4] = temp1.x;
+    matrix[8] = temp1.y;
+    matrix[12] = temp1.z;
+
+    temp2.x = matrix[5];
+    temp2.y = matrix[9];
+    temp2.z = matrix[13];
+    PSVECScale(&temp2, &temp2, scale[1]);
+    matrix[5] = temp2.x;
+    matrix[9] = temp2.y;
+    matrix[13] = temp2.z;
+
+    temp3.x = matrix[6];
+    temp3.y = matrix[10];
+    temp3.z = matrix[14];
+    PSVECScale(&temp3, &temp3, scale[2]);
+    matrix[6] = temp3.x;
+    matrix[10] = temp3.y;
+    matrix[14] = temp3.z;
+
+    matrix[7] = translation[0];
+    matrix[11] = translation[1];
+    matrix[15] = translation[2];
 }


### PR DESCRIPTION
## Summary
- Reworked `pppMatrixZYX` to match the project’s matrix-construction callback pattern used by other `pppMatrix*` units.
- Updated the declaration/signature from a 2-arg rotation helper form to the expected 3-arg callback form (`target`, `unused`, `param`).
- Implemented full transform flow: rotation build (`pppGetRotMatrixZYX`), per-axis scale with `PSVECScale`, and translation writeback.

## Functions improved
- Unit: `main/pppMatrixZYX`
- Symbol: `pppMatrixZYX`
- Match: **26.8125% -> 100.0%**

## Match evidence
- Build: `ninja` completed successfully.
- `objdiff` command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppMatrixZYX -o - pppMatrixZYX`
- Before/after extracted from objdiff JSON (`left.symbols[].match_percent` for `pppMatrixZYX`):
  - Before: `26.8125`
  - After: `100.0`

## Plausibility rationale
- This change aligns `pppMatrixZYX` with the same source-level structure used by sibling functions (`pppMatrixYZX`, `pppMatrixZXY`, etc.), which strongly indicates original-source plausibility rather than artificial compiler coaxing.
- The implementation follows a standard and readable game-engine transform path (rotation matrix + scale columns + translation column), consistent with the rest of this module family.

## Technical details
- `offsets` are read from `param + 0xC` and interpreted in the same order observed in matching siblings:
  - `offsets[0]`: translation
  - `offsets[2]`: scale
  - `offsets[1]`: angle
- Rotation matrix is written at `target + 0x10` (`matrix + 4` as `f32*`), then scaled per basis vector and translation stored in `[7], [11], [15]`.
