### PR TITLE
Implement pppCacheLoadShapeTexture in pppShape

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -81,12 +81,38 @@ void pppShapeSetUseTexture(tagOAN3_SHAPE*, unsigned char*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800658fc
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppCacheLoadShapeTexture(pppShapeSt*, CMaterialSet*)
+void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
 {
-	// TODO
+    char textureUsed[256];
+    void* animData = shapeSt->m_animData;
+
+    memset(textureUsed, 0, 256);
+
+    void* currentFrame = animData;
+    for (int frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex++) {
+        short shapeOffset = *(short*)((int)currentFrame + 0x10);
+        int shapeEntryOffset = 0;
+
+        for (int shapeIndex = 0; shapeIndex < *(short*)((int)animData + shapeOffset + 2); shapeIndex++) {
+            int entryPtr = shapeEntryOffset + shapeOffset;
+            shapeEntryOffset += 8;
+            textureUsed[*(unsigned char*)((int)animData + entryPtr + 10)] = 1;
+        }
+        currentFrame = (void*)((int)currentFrame + 8);
+    }
+
+    for (unsigned int textureIndex = 0; textureIndex < 256; textureIndex++) {
+        if (textureUsed[textureIndex] != 0) {
+            materialSet->CacheLoadTexture(textureIndex, (CAmemCacheSet*)CAMemCacheSet);
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppCacheLoadShapeTexture` in `src/pppShape.cpp` using the same frame/shape-entry traversal pattern already used by `pppCacheDumpShapeTexture`.
- Added PAL metadata block for the function (`0x800658fc`, `240b`).
- Replaced TODO stub with real texture usage collection and per-texture cache-load dispatch.

## Functions improved
- Unit: `main/pppShape`
- Symbol: `pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`

## Match evidence
- `pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`: `1.6666666%` -> `78.666664%` (size `240`)
- Built successfully with `ninja` after change.

## Plausibility rationale
- The implementation follows source-plausible game code patterns already present in this file:
  - stack `textureUsed[256]` bitmap
  - animation-frame iteration via shape offsets
  - per-texture cache operation only when marked used
- It avoids contrived compiler-only reshaping and mirrors existing decomp style in neighboring cache functions.

## Technical details
- Match delta comes from replacing a 4-byte stub body with full control flow that now aligns with target traversal and call structure.
- Cache operation call is emitted via `CMaterialSet::CacheLoadTexture(textureIndex, (CAmemCacheSet*)CAMemCacheSet)` to preserve intended API semantics.
