### PR TITLE
MSL: implement __ieee754_sqrt in e_sqrt

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/e_sqrt.c
+++ b/src/MSL_C/PPCEABI/bare/H/e_sqrt.c
@@ -1,15 +1,124 @@
 
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/Math/fdlibm.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/errno.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/math.h"
 
 /*
  * --INFO--
- * JP Address: 
- * JP Size: 
- * PAL Address: 
- * PAL Size: 
- * EN Address: 
- * EN Size: 
+ * PAL Address: 0x801D677C
+ * PAL Size: 548b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __ieee754_sqrt(void)
-{
-	// TODO
+double __ieee754_sqrt(double x) {
+    int ix0;
+    int s0;
+    int i;
+    int q;
+    int m;
+    unsigned ix1;
+    unsigned q1;
+    unsigned s1;
+    unsigned r;
+    double z;
+
+    ix0 = __HI(x);
+    ix1 = __LO(x);
+
+    if ((ix0 & 0x7ff00000) == 0x7ff00000) {
+        errno = 0x21;
+        return x * x + x;
+    }
+
+    if (ix0 <= 0) {
+        if (((ix0 & (~0x80000000)) | ix1) == 0) {
+            return x;
+        }
+        if (ix0 < 0) {
+            errno = 0x21;
+            return NAN;
+        }
+    }
+
+    m = (ix0 >> 20);
+    if (m == 0) {
+        while (ix0 == 0) {
+            m -= 21;
+            ix0 |= (ix1 >> 11);
+            ix1 <<= 21;
+        }
+
+        for (i = 0; (ix0 & 0x00100000) == 0; i++) {
+            ix0 <<= 1;
+        }
+        m -= i - 1;
+        ix0 |= (ix1 >> (32 - i));
+        ix1 <<= i;
+    }
+
+    m -= 1023;
+    ix0 = (ix0 & 0x000fffff) | 0x00100000;
+    if (m & 1) {
+        ix0 += ix0 + ((ix1 & 0x80000000) >> 31);
+        ix1 += ix1;
+    }
+    m >>= 1;
+
+    ix0 += ix0 + ((ix1 & 0x80000000) >> 31);
+    ix1 += ix1;
+    q = q1 = s0 = s1 = 0;
+    r = 0x00200000;
+
+    while (r != 0) {
+        int t = s0 + r;
+        if (t <= ix0) {
+            s0 = t + r;
+            ix0 -= t;
+            q += r;
+        }
+        ix0 += ix0 + ((ix1 & 0x80000000) >> 31);
+        ix1 += ix1;
+        r >>= 1;
+    }
+
+    r = 0x80000000;
+    while (r != 0) {
+        unsigned t1 = s1 + r;
+        int t = s0;
+        if ((t < ix0) || ((t == ix0) && (t1 <= ix1))) {
+            s1 = t1 + r;
+            if (((t1 & 0x80000000) == 0x80000000) && ((s1 & 0x80000000) == 0)) {
+                s0 += 1;
+            }
+            ix0 -= t;
+            if (ix1 < t1) {
+                ix0 -= 1;
+            }
+            ix1 -= t1;
+            q1 += r;
+        }
+        ix0 += ix0 + ((ix1 & 0x80000000) >> 31);
+        ix1 += ix1;
+        r >>= 1;
+    }
+
+    if ((ix0 | ix1) != 0) {
+        if (q1 == 0xffffffff) {
+            q1 = 0;
+            q += 1;
+        } else {
+            q1 += (q1 & 1);
+        }
+    }
+
+    ix0 = (q >> 1) + 0x3fe00000 + (m << 20);
+    ix1 = q1 >> 1;
+    if ((q & 1) != 0) {
+        ix1 |= 0x80000000;
+    }
+    __HI(z) = ix0;
+    __LO(z) = ix1;
+    return z;
 }


### PR DESCRIPTION
## Summary
Implemented `__ieee754_sqrt(double)` in `src/MSL_C/PPCEABI/bare/H/e_sqrt.c` using fdlibm-style bitwise square-root logic and proper exceptional-case handling.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/e_sqrt`
- Symbol: `__ieee754_sqrt`

## Match evidence
- Before: `0.729927%` (`build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/e_sqrt -o - __ieee754_sqrt`)
- After: `89.0365%` (same command after change)
- Built symbol size changed from a near-empty implementation to `532` bytes against target `548` bytes.

## Plausibility rationale
This change follows canonical fdlibm implementation style already used by nearby MSL math files (`e_acos.c`, `e_pow.c`):
- same `__HI/__LO` bit-manipulation patterns
- same errno domain handling (`0x21`) for invalid domains
- same normalization/restoring-square-root bit algorithm expected for this routine

The resulting C reads as plausible original runtime-library source rather than compiler-coaxing code.

## Technical details
- Added fdlibm/math/errno includes.
- Updated function signature to `double __ieee754_sqrt(double x)`.
- Implemented IEEE special-case paths (NaN/Inf, signed zero, negative-domain).
- Implemented mantissa normalization, bit-by-bit sqrt extraction, rounding, and result repacking.
