### PR TITLE
main/pppRandDownChar: decompile full function logic

### DIFF
--- a/src/pppRandDownChar.cpp
+++ b/src/pppRandDownChar.cpp
@@ -1,7 +1,25 @@
 #include "ffcc/pppRandDownChar.h"
 #include "ffcc/math.h"
+#include "types.h"
 
 extern CMath math;
+extern s32 lbl_8032ED70;
+extern f32 lbl_8032FF18;
+extern f64 lbl_8032FF20;
+extern u8 lbl_801EADC8;
+extern "C" f32 RandF__5CMathFv(CMath* instance);
+
+struct RandDownCharParam {
+    s32 targetId;
+    s32 sourceOffset;
+    u8 scale;
+    u8 randomTwice;
+};
+
+struct RandDownCharCtx {
+    u8 _pad[0xC];
+    s32* outputOffset;
+};
 
 /*
  * --INFO--
@@ -14,6 +32,48 @@ extern CMath math;
  */
 extern "C" void pppRandDownChar(void* param1, void* param2, void* param3)
 {
-    // Basic placeholder implementation - needs refinement based on objdiff results
-    math.RandF(); // Generate random number - stored in math object state
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
+
+    u8* base = (u8*)param1;
+    RandDownCharParam* in = (RandDownCharParam*)param2;
+    RandDownCharCtx* ctx = (RandDownCharCtx*)param3;
+    f32* valuePtr;
+
+    s32 state = *(s32*)(base + 0xC);
+    if (state == 0) {
+        f32 value = -RandF__5CMathFv(&math);
+        if (in->randomTwice != 0) {
+            value = (value - RandF__5CMathFv(&math)) * lbl_8032FF18;
+        }
+
+        valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
+        *valuePtr = value;
+    } else {
+        if (in->targetId != state) {
+            return;
+        }
+        valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
+    }
+
+    u8* target;
+    if (in->sourceOffset == -1) {
+        target = &lbl_801EADC8;
+    } else {
+        target = base + in->sourceOffset + 0x80;
+    }
+
+    union {
+        f64 d;
+        struct {
+            u32 hi;
+            u32 lo;
+        } parts;
+    } cvt;
+    cvt.parts.hi = 0x43300000;
+    cvt.parts.lo = in->scale;
+
+    s32 delta = (s32)((cvt.d - lbl_8032FF20) * *valuePtr);
+    *target = (u8)(*target + delta);
 }


### PR DESCRIPTION
## Summary
- Replaced the `pppRandDownChar` stub with a full decomp implementation based on the target control flow.
- Implemented both execution paths:
  - random output generation path when state is zero
  - state-gated accumulation path when IDs match
- Added proper global/constant usage and byte-delta accumulation semantics.

## Functions improved
- Unit: `main/pppRandDownChar`
- Function: `pppRandDownChar`

## Match evidence
- Baseline (selector report before edits): **10.2%** for `pppRandDownChar` (300b).
- After this change (`ninja` + `build/tools/objdiff-cli diff -p . -u main/pppRandDownChar -o -`):
  - `.text` match: **88.26667%**
  - Unit fuzzy match in `build/GCCP01/report.json`: **89.73333%**
- Current build remains green (`ninja` succeeds).

## Plausibility rationale
- The new source follows the same dataflow used across neighboring `pppRand*` implementations:
  - uses typed parameter structs with offsets matching observed accesses
  - preserves the same random scaling/update behavior for down variants
  - uses the expected byte accumulation model (`u8` destination plus computed delta)
- No contrived reorder-only changes or artificial temporaries were introduced solely to coax codegen.

## Technical details
- Implemented the shared update tail used by both branches, including:
  - output float fetch from context-provided offset (`+0x80` base adjustment)
  - source pointer selection (`-1` sentinel to static fallback)
  - `0x4330`-based integer-to-float conversion idiom for the byte scale factor before multiplication and truncation
- Assembly alignment substantially improved; remaining diffs are primarily register/allocation/addressing-form differences.
