### PR TITLE
Improve pppPointRAp match by restoring spawn/trig flow

### DIFF
--- a/include/ffcc/pppPointRAp.h
+++ b/include/ffcc/pppPointRAp.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 void pppPointRApCon(_pppMngSt* mngSt, _pppPDataVal* dataVal);
-void pppPointRAp(_pppMngSt* mngSt, _pppPDataVal* dataVal);
+void pppPointRAp(void* mngSt, void* dataVal, void* ctrlTable);
 
 #ifdef __cplusplus
 }

--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -1,74 +1,99 @@
 #include "ffcc/pppPointRAp.h"
-#include "ffcc/pppPart.h"
+#include "ffcc/partMng.h"
 #include "ffcc/math.h"
-#include "ffcc/pppsintbl.h"
-#include <dolphin/mtx.h>
+#include <dolphin/types.h>
 
 extern CMath math;
+extern int lbl_8032ED70;
+extern unsigned char* lbl_8032ED50;
+extern float lbl_801EC9F0[];
+extern float lbl_8032FEE8;
+extern float lbl_8032FEEC;
+extern float lbl_8032FEF0;
+extern "C" float RandF__5CMathFv(CMath* instance);
+
+extern _pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
+
+static inline float pppTrigSample(s32 angle)
+{
+    return *(float*)((u8*)lbl_801EC9F0 + (angle & 0xFFFC));
+}
 
 /*
  * --INFO--
  * PAL Address: 0x80060ee4
  * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppPointRApCon(_pppMngSt* mngSt, _pppPDataVal* dataVal)
 {
-    u32* dataPtr = (u32*)((char*)dataVal + 0xC);
-    u32 offset = *(u32*)((char*)*dataPtr + 0x4) + 0x81;
-    *((u8*)mngSt + offset) = 0;
+    u32* ctrlData = *(u32**)((u8*)dataVal + 0xC);
+    ((u8*)mngSt)[ctrlData[1] + 0x81] = 0;
 }
 
 /*
  * --INFO--
  * PAL Address: 0x80060d20
  * PAL Size: 452b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppPointRAp(_pppMngSt* mngSt, _pppPDataVal* dataVal)
+void pppPointRAp(void* mngSt, void* dataVal, void* ctrlTable)
 {
-    extern int lbl_8032ED70;
-    
+    u32* ctrlData = *(u32**)((u8*)ctrlTable + 0xC);
+    u8* state = (u8*)mngSt + ctrlData[1] + 0x80;
+
     if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    u32 particleId = *(u32*)((char*)*(u32**)((char*)dataVal + 0xC) + 0x4);
-    u8* particleBase = (u8*)mngSt + particleId + 0x80;
-    
-    if (particleBase[1] == 0) {
-        u32 checkValue = *(u32*)((char*)dataVal + 0xC);
-        if ((checkValue + 0x10000) != 0xFFFF) {
-            pppCreatePObject(mngSt, dataVal);
-            
-            math.RandF();
-            f32 angleRandom = 0.5f; // Placeholder - RandF result accessed elsewhere
-            angleRandom = angleRandom * 65536.0f;
-            s32 angleIndex = (s32)angleRandom & 0xFFFF;
-            
-            f32 posScale = *(f32*)((char*)dataVal + 0x4);
-            f32 sinValue = pppTrigTable[angleIndex & 0x3FFF];
-            f32 cosValue = pppTrigTable[(angleIndex + 0x1000) & 0x3FFF];
-            
-            sinValue *= posScale;
-            cosValue *= posScale;
-            
-            math.RandF();
-            f32 velRandom = 0.3f; // Placeholder - RandF result accessed elsewhere  
-            velRandom = velRandom * 65536.0f;
-            s32 velAngleIndex = (s32)velRandom & 0xFFFF;
-            
-            f32 velScale = *(f32*)((char*)dataVal + 0x8);
-            f32 velSin = pppTrigTable[velAngleIndex & 0x3FFF];
-            f32 velCos = pppTrigTable[(velAngleIndex + 0x1000) & 0x3FFF];
-            
-            velSin *= velScale;
-            velCos *= velScale;
-            
-            u8 lifetime = *(u8*)((char*)dataVal + 0x1C);
-            particleBase[1] = lifetime;
+
+    if (state[1] == 0) {
+        u32 createId = *(u32*)((u8*)dataVal + 0xC);
+        Vec* srcPos = (Vec*)((u8*)mngSt + ctrlData[0] + 0x80);
+
+        if ((createId + 0x10000) == 0xFFFF) {
+            return;
         }
+
+        _pppPObject* obj;
+        _pppPDataVal* objData = (_pppPDataVal*)((u8*)(*(u32*)(lbl_8032ED50 + 0xD4)) + (createId << 4));
+
+        if (objData == 0) {
+            obj = 0;
+        } else {
+            obj = (_pppPObject*)pppCreatePObject((_pppMngSt*)lbl_8032ED50, objData);
+            *(void**)((u8*)obj + 0x4) = mngSt;
+        }
+
+        s32 angleA = (s32)(lbl_8032FEE8 * RandF__5CMathFv(&math) - lbl_8032FEEC);
+        float scaleA = *(float*)((u8*)dataVal + 0x4);
+        float yOff = scaleA * pppTrigSample(angleA);
+        float zOff = scaleA * pppTrigSample(angleA + 0x4000);
+
+        s32 angleB = (s32)(lbl_8032FEF0 * (lbl_8032FEE8 * RandF__5CMathFv(&math)));
+        Vec* dstPos = (Vec*)((u8*)obj + *(u32*)((u8*)dataVal + 0x10) + 0x80);
+        Vec* dstVel = (Vec*)((u8*)obj + *(u32*)((u8*)dataVal + 0x18) + 0x80);
+        float xOff = zOff * pppTrigSample(angleB);
+        zOff *= pppTrigSample(angleB + 0x4000);
+
+        dstPos->x = srcPos->x + xOff;
+        dstPos->y = srcPos->y + yOff;
+        dstPos->z = srcPos->z + zOff;
+
+        {
+            float velocityScale = *(float*)((u8*)dataVal + 0x8);
+            dstVel->x = xOff * velocityScale;
+            dstVel->y = yOff * velocityScale;
+            dstVel->z = zOff * velocityScale;
+        }
+
+        state[1] = *(u8*)((u8*)dataVal + 0x1C);
     }
-    
-    if (particleBase[1] > 0) {
-        particleBase[1]--;
-    }
+
+    state[1]--;
 }


### PR DESCRIPTION
## Summary
- Reworked `pppPointRAp` to match the original 3-argument control-table driven flow (`mngSt`, data, ctrl table) rather than the previous 2-argument placeholder implementation.
- Replaced placeholder random/trig logic with assembly-driven logic:
  - object spawn lookup via `lbl_8032ED50 + 0xD4`
  - owner pointer store at object offset `+0x4`
  - two `RandF__5CMathFv` calls with fixed-point angle conversion
  - trig sampling via `lbl_801EC9F0` byte-indexing (`& 0xFFFC`, `+0x4000` phase shift)
  - position and velocity writes to data-driven destination offsets (`+0x10`, `+0x18`)
- Updated function prototype in `include/ffcc/pppPointRAp.h` to match actual calling convention.
- Added full INFO block fields (`EN/JP TODO`) for both functions.

## Functions improved
- Unit: `main/pppPointRAp`
- Symbol: `pppPointRAp`
  - Before: `17.309734%`
  - After: `84.460175%`
- Symbol: `pppPointRApCon`
  - Before: `79.166664%`
  - After: `79.166664%` (unchanged)

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppPointRAp -o - pppPointRAp`
- JSON extraction confirms `pppPointRAp` moved from ~17.31% to ~84.46% with real instruction alignment, including:
  - correct large-frame prologue/epilogue shape
  - restored create-object path and owner assignment sequence
  - restored floating-point/trig pipeline and data-offset stores

## Plausibility rationale
- The new implementation follows existing codebase patterns (`pppPointAp`, other `pppRand*` functions) and uses project symbols/types directly.
- Changes are source-plausible game logic: corrected parameter/calling convention, data offsets, and random vector generation behavior.
- No artificial compiler-coaxing constructs were introduced; logic is structured around meaningful particle spawn semantics.

## Technical details
- Used DTK disassembly (`build/tools/dtk elf disasm`) of both target and rebuilt object files to drive edits.
- Removed static trig table dependency in this TU and switched to external `lbl_801EC9F0` table access, matching target memory usage.
- Kept constructor behavior and lifetime decrement behavior aligned with observed control flow.
