### PR TITLE
THPDraw: implement GX YUV setup/restore stubs

### DIFF
--- a/src/THPDraw.cpp
+++ b/src/THPDraw.cpp
@@ -1,6 +1,7 @@
 #include "dolphin/thp/THPDraw.h"
 #include "dolphin/gx.h"
 #include "dolphin/mtx.h"
+#include "ffcc/gxfunc.h"
 
 void THPGXYuv2RgbDraw(u32* yImage, u32* uImage, u32* vImage, s16 x, s16 y, s16 texWidth, s16 texHeight, s16 polyWidth, s16 polyHeight) {
     GXTexObj yTexObj;
@@ -34,12 +35,148 @@ void THPGXYuv2RgbDraw(u32* yImage, u32* uImage, u32* vImage, s16 x, s16 y, s16 t
     GXTexCoord2s16(0, 1);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x80105b58
+ * PAL Size: 1268b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void THPGXYuv2RgbSetup(GXRenderModeObj* rmode) {
-    // Stub implementation - matches Ghidra structure but simplified
-    // TODO: Complete implementation
+    Mtx modelMtx;
+    Mtx44 projMtx;
+    GXColorS10 tevColor;
+    GXColor kColor0;
+    GXColor kColor1;
+    GXColor kColor2;
+    f32 width;
+    f32 height;
+
+    width = (f32)rmode->fbWidth;
+    height = (f32)rmode->efbHeight;
+
+    GXSetPixelFmt(GX_PF_RGB8_Z24, GX_ZC_LINEAR);
+    C_MTXOrtho(projMtx, 0.0f, height, 0.0f, width, 0.0f, 1.0f);
+    GXSetProjection(projMtx, GX_ORTHOGRAPHIC);
+    GXSetViewport(0.0f, 0.0f, width, height, 0.0f, 1.0f);
+    GXSetScissor(0, 0, rmode->fbWidth, rmode->efbHeight);
+
+    PSMTXIdentity(modelMtx);
+    GXLoadPosMtxImm(modelMtx, GX_PNMTX0);
+    GXSetCurrentMtx(GX_PNMTX0);
+
+    GXSetZMode(GX_TRUE, GX_ALWAYS, GX_FALSE);
+    _GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ZERO, GX_LO_CLEAR);
+    GXSetColorUpdate(GX_TRUE);
+    GXSetAlphaUpdate(GX_FALSE);
+    GXSetDispCopyGamma(GX_GM_1_0);
+    GXSetNumChans(0);
+
+    GXSetNumTexGens(2);
+    GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
+    GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
+    GXInvalidateTexAll();
+
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_POS, GX_POS_XY, GX_S16, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_TEX0, GX_TEX_ST, GX_S16, 0);
+
+    GXSetNumTevStages(4);
+
+    _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD1, GX_TEXMAP1, GX_COLOR_NULL);
+    _GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_TEXC, GX_CC_KONST, GX_CC_C0);
+    _GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_FALSE, GX_TEVPREV);
+    _GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_TEXA, GX_CA_KONST, GX_CA_A0);
+    _GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_SUB, GX_TB_ZERO, GX_CS_SCALE_1, GX_FALSE, GX_TEVPREV);
+    GXSetTevKColorSel(GX_TEVSTAGE0, GX_TEV_KCSEL_K0);
+    GXSetTevKAlphaSel(GX_TEVSTAGE0, GX_TEV_KASEL_K0_A);
+    _GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+    _GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD1, GX_TEXMAP2, GX_COLOR_NULL);
+    _GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_TEXC, GX_CC_KONST, GX_CC_CPREV);
+    _GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_2, GX_FALSE, GX_TEVPREV);
+    _GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_TEXA, GX_CA_KONST, GX_CA_APREV);
+    _GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_SUB, GX_TB_ZERO, GX_CS_SCALE_1, GX_FALSE, GX_TEVPREV);
+    GXSetTevKColorSel(GX_TEVSTAGE1, GX_TEV_KCSEL_K1);
+    GXSetTevKAlphaSel(GX_TEVSTAGE1, GX_TEV_KASEL_K1_A);
+    _GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+    _GXSetTevOrder(GX_TEVSTAGE2, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+    _GXSetTevColorIn(GX_TEVSTAGE2, GX_CC_ZERO, GX_CC_TEXC, GX_CC_ONE, GX_CC_CPREV);
+    _GXSetTevColorOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVREG0);
+    _GXSetTevAlphaIn(GX_TEVSTAGE2, GX_CA_TEXA, GX_CA_ZERO, GX_CA_ZERO, GX_CA_APREV);
+    _GXSetTevAlphaOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVREG0);
+    _GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+    _GXSetTevOrder(GX_TEVSTAGE3, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR_NULL);
+    _GXSetTevColorIn(GX_TEVSTAGE3, GX_CC_APREV, GX_CC_CPREV, GX_CC_KONST, GX_CC_ZERO);
+    _GXSetTevColorOp(GX_TEVSTAGE3, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVREG0);
+    _GXSetTevAlphaIn(GX_TEVSTAGE3, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO);
+    _GXSetTevAlphaOp(GX_TEVSTAGE3, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVREG0);
+    _GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
+    GXSetTevKColorSel(GX_TEVSTAGE3, GX_TEV_KCSEL_K2);
+
+    tevColor.r = -90;
+    tevColor.g = 0;
+    tevColor.b = -114;
+    tevColor.a = 135;
+    GXSetTevColorS10(GX_TEVREG0, tevColor);
+
+    kColor0.r = 0;
+    kColor0.g = 0;
+    kColor0.b = 226;
+    kColor0.a = 88;
+    GXSetTevKColor(GX_KCOLOR0, kColor0);
+
+    kColor1.r = 179;
+    kColor1.g = 0;
+    kColor1.b = 0;
+    kColor1.a = 182;
+    GXSetTevKColor(GX_KCOLOR1, kColor1);
+
+    kColor2.r = 0;
+    kColor2.g = 135;
+    kColor2.b = 0;
+    kColor2.a = 0;
+    GXSetTevKColor(GX_KCOLOR2, kColor2);
+
+    _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+
+    GXSetCullMode(GX_CULL_NONE);
+    _GXSetAlphaCompare(GX_GEQUAL, 0, GX_AOP_AND, GX_ALWAYS, 0);
+    _GXSetBlendMode(GX_BM_BLEND, GX_BL_ONE, GX_BL_ZERO, GX_LO_CLEAR);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x8010604c
+ * PAL Size: 304b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void THPGXRestore(void) {
-    // Stub implementation - matches Ghidra structure but simplified
-    // TODO: Complete implementation
+    GXSetZMode(GX_TRUE, GX_ALWAYS, GX_FALSE);
+    _GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ZERO, GX_LO_SET);
+    GXSetNumTexGens(1);
+    GXSetNumChans(0);
+    GXSetNumTevStages(1);
+
+    _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+    _GXSetTevOp(GX_TEVSTAGE0, GX_REPLACE);
+    _GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+    _GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+    _GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP0);
+    _GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+    _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+    _GXSetTevSwapModeTable(GX_TEV_SWAP1, GX_CH_RED, GX_CH_RED, GX_CH_RED, GX_CH_ALPHA);
+    _GXSetTevSwapModeTable(GX_TEV_SWAP2, GX_CH_GREEN, GX_CH_GREEN, GX_CH_GREEN, GX_CH_ALPHA);
+    _GXSetTevSwapModeTable(GX_TEV_SWAP3, GX_CH_BLUE, GX_CH_BLUE, GX_CH_BLUE, GX_CH_ALPHA);
+    _GXSetAlphaCompare(GX_GEQUAL, 0, GX_AOP_AND, GX_ALWAYS, 0);
 }


### PR DESCRIPTION
## Summary
- Replaced stubbed `THPGXYuv2RgbSetup` with a full GX YUV->RGB pipeline setup implementation following the decomp call sequence.
- Replaced stubbed `THPGXRestore` with the full GX state restore sequence.
- Added per-function `--INFO--` blocks with PAL address/size for both updated functions.
- Switched the file to use `ffcc/gxfunc.h` wrappers where the original code path uses `_GX*` helper calls.

## Functions improved
- Unit: `main/THPDraw`
- `THPGXYuv2RgbSetup`: **0.3% -> 74.36909%**
- `THPGXRestore`: **1.3% -> 100.0%**
- `THPGXYuv2RgbDraw`: **84.0% -> 83.90756%** (effectively unchanged; minor rounding-level movement)

## Match evidence
- Build: `ninja` succeeded.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/THPDraw -o - | jq -r '.left.symbols[] | select(.name=="THPGXYuv2RgbSetup" or .name=="THPGXRestore" or .name=="THPGXYuv2RgbDraw") | "\(.name) \(.match_percent)"'`
- Current symbol matches:
  - `THPGXYuv2RgbSetup 74.36909`
  - `THPGXRestore 100.0`
  - `THPGXYuv2RgbDraw 83.90756`

## Plausibility rationale
- The stubs were replaced with a conventional SDK-style GX state setup/restore flow that is consistent with THP YUV-to-RGB rendering usage.
- Call ordering, stage configuration, and GX state transitions were kept aligned to the decomp structure rather than introducing compiler-coaxing-only transformations.
- The resulting source is maintainable and readable as normal game rendering setup code.

## Technical details
- Setup path now configures:
  - orthographic projection + viewport/scissor from `GXRenderModeObj`
  - position matrix and vertex format (`GX_VTXFMT7`, pos/tex0 direct)
  - 4-stage TEV graph for Y/U/V conversion blend
  - K-color/K-alpha selections and swap table
  - final cull/alpha/blend state
- Restore path now re-establishes single-stage default TEV/swap/alpha compare state used outside THP draw setup.
