### PR TITLE
main/pppDrawShape: reconstruct draw/calc shape callbacks

### DIFF
--- a/include/ffcc/pppDrawShape.h
+++ b/include/ffcc/pppDrawShape.h
@@ -7,7 +7,7 @@ extern "C" {
 
 void pppDrawShapeConstruct(void* pppShape, void* data);
 void pppCalcShape(void* pppShape, void* data, void* additionalData);
-void pppDrawShape(void);
+void pppDrawShape(void* pppShape, void* data, void* additionalData);
 
 #ifdef __cplusplus
 }

--- a/src/pppDrawShape.cpp
+++ b/src/pppDrawShape.cpp
@@ -1,6 +1,44 @@
 #include "ffcc/pppDrawShape.h"
 #include "dolphin/types.h"
 
+extern int lbl_8032ED70;
+extern void* lbl_8032ED54;
+
+extern void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(void*, void*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char);
+extern void pppSetBlendMode__FUc(unsigned char);
+extern void pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(void*, void*, unsigned char);
+
+typedef struct ShapeRuntimeData {
+    u32 shapeDataOffset;
+    u32 posDataOffset;
+} ShapeRuntimeData;
+
+typedef struct ShapeState {
+    u16 value;
+    u16 counter;
+    u16 currentId;
+} ShapeState;
+
+typedef struct ShapeControlData {
+    u8 _pad0[4];
+    u16 type;
+    u8 _pad1[2];
+    u32 step;
+    u8 _pad2[1];
+    u8 blendMode;
+    u8 paramE;
+    u8 _pad3[1];
+    float scale;
+    u8 _pad4[4];
+    u8 param14;
+} ShapeControlData;
+
+typedef struct ShapeSpecEntry {
+    s16 offset;
+    s16 maxValue;
+    u8 flags;
+} ShapeSpecEntry;
+
 /*
  * --INFO--
  * PAL Address: 0x80065654
@@ -33,35 +71,81 @@ void pppDrawShapeConstruct(void* pppShape, void* data)
  */
 void pppCalcShape(void* pppShape, void* data, void* additionalData)
 {
-	// Check a global flag - return early if set
-	extern u32 lbl_8032ED70;
 	if (lbl_8032ED70 != 0) {
 		return;
 	}
 
-	// Get data pointers
-	void** dataPtr = (void**)data;
-	u32* addDataPtr = (u32*)additionalData;
-	void* basePtr = dataPtr[3];
-	u32 indexVal = addDataPtr[1];
-	void* shapePtr = ((void**)basePtr)[0];
-	
-	// Check if shape index is valid
-	if ((indexVal >> 16) == 0xFFFF) {
+	ShapeRuntimeData* runtimeData = *(ShapeRuntimeData**)((u8*)additionalData + 0xC);
+	ShapeControlData* controlData = (ShapeControlData*)data;
+	ShapeState* shapeData = (ShapeState*)((u8*)pppShape + runtimeData->shapeDataOffset + 0x80);
+
+	if ((u16)controlData->type == 0xFFFF) {
 		return;
 	}
 
-	// Access shape data and perform calculations
-	u16* shapeData = (u16*)((u8*)pppShape + (u32)shapePtr + 0x80);
-	// More complex logic would go here...
+	void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
+	void* shapeSpec = *(void**)((u8*)shapeTables + ((u32)controlData->type << 2));
+	ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->counter << 3) + 0x10);
+
+	shapeData->currentId = shapeData->counter;
+	shapeData->value = (u16)(shapeData->value + controlData->step);
+	if (shapeData->value >= (u16)shape->maxValue) {
+		shapeData->value = (u16)(shapeData->value - shape->maxValue);
+	}
+
+	shapeData->counter++;
+	if (shapeData->counter < (u16)*(s16*)((u8*)shapeSpec + 0x6)) {
+		return;
+	}
+
+	if ((shape->flags & 0x80) != 0) {
+		shapeData->counter = 0;
+		shapeData->value = 0;
+		return;
+	}
+
+	shapeData->value = 0;
+	shapeData->counter--;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800654b4
+ * PAL Size: 212b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDrawShape(void)
+void pppDrawShape(void* pppShape, void* data, void* additionalData)
 {
-	// TODO
+	ShapeRuntimeData* runtimeData = *(ShapeRuntimeData**)((u8*)additionalData + 0xC);
+	ShapeControlData* controlData = (ShapeControlData*)data;
+	ShapeState* shapeData = (ShapeState*)((u8*)pppShape + runtimeData->shapeDataOffset + 0x80);
+	void* posData = (u8*)pppShape + runtimeData->posDataOffset + 0x80;
+
+	if ((u16)controlData->type == 0xFFFF) {
+		return;
+	}
+
+	void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
+	void* shapeSpec = *(void**)((u8*)shapeTables + ((u32)controlData->type << 2));
+	ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->currentId << 3) + 0x10);
+	void* drawShape = (u8*)shapeSpec + shape->offset;
+
+	pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+		(u8*)posData + 8,
+		(u8*)pppShape + 0x40,
+		controlData->scale,
+		controlData->param14,
+		controlData->paramE,
+		controlData->blendMode,
+		(u8)0,
+		(u8)1,
+		(u8)1,
+		(u8)0
+	);
+
+	pppSetBlendMode__FUc(controlData->blendMode);
+	pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(drawShape, *(void**)((u8*)lbl_8032ED54 + 4), controlData->blendMode);
 }


### PR DESCRIPTION
## Summary
- Reconstructed `pppDrawShape` with the correct 3-argument runtime signature and full draw-path logic.
- Replaced placeholder `pppCalcShape` body with shape-state update logic that matches the target control flow.
- Added concrete runtime/control/spec struct overlays and aligned global accesses (`lbl_8032ED54`, `lbl_8032ED70`) to observed assembly behavior.

## Functions Improved
- `main/pppDrawShape::pppDrawShape` (PAL 0x800654b4, 212b)
  - Match: `1.8867924% -> 82.33962%`
- `main/pppDrawShape::pppCalcShape` (PAL 0x80065588, 204b)
  - Match: `11.039216% -> 77.05882%`

## Match Evidence
- Rebuilt with `ninja` successfully.
- Verified with objdiff:
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawShape -o - pppDrawShape`
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawShape -o - pppCalcShape`
- The improvement is instruction-level (prologue/epilogue, control flow, global loads, indexed table fetches, draw call sequence), not formatting-only churn.

## Plausibility Rationale
- The update mirrors existing emitter patterns already present in `pppDrawShape2.cpp` (runtime offsets, shape table lookup, state machine update) rather than introducing contrived compiler coaxing.
- Types/signedness were chosen to match ABI-observed operations (`lhz`/`lha` usage, 16-bit wrap and compare behavior).
- Call sequencing remains idiomatic for this codebase: set draw env, set blend mode, then submit shape draw.

## Technical Notes
- Header was updated so `pppDrawShape` uses the runtime callback signature (`void*, void*, void*`), consistent with the generated call/stack usage in target assembly.
- `pppSetDrawEnv` call now passes all trailing `u8` arguments explicitly to preserve calling convention layout.
