### PR TITLE
os: reconstruct OSReboot reboot/apploader path

### DIFF
--- a/src/os/OSReboot.c
+++ b/src/os/OSReboot.c
@@ -2,28 +2,176 @@
 #include <dolphin/os.h>
 
 #include "dolphin/os/__os.h"
+#include <dolphin/dvd/__dvd.h>
+
+extern volatile u32 BOOT_REGION_START AT_ADDRESS(0x812FDFF0);
+extern volatile u32 BOOT_REGION_END AT_ADDRESS(0x812FDFEC);
+extern volatile u8 g_unk_800030E2 AT_ADDRESS(0x800030E2);
+extern volatile u32 g_unk_817FFFFC AT_ADDRESS(0x817FFFFC);
+extern volatile u32 g_unk_817FFFF8 AT_ADDRESS(0x817FFFF8);
+
+static int Prepared;
 
 static void* SaveStart;
 static void* SaveEnd;
 
+typedef struct {
+    char date[16];
+    u32 entry;
+    u32 size;
+    u32 rebootSize;
+    u32 reserved2;
+} AppLoaderStruct;
+
+static AppLoaderStruct FatalParam;
+
+#ifdef __GEKKO__
+static asm void Run(register void* entryPoint) {
+    nofralloc
+
+    sync
+    isync
+    mtlr entryPoint
+    blr
+}
+#endif
+
+static void Callback(s32, DVDCommandBlock*) {
+    Prepared = TRUE;
+}
+
+static int IsStreamEnabled(void) {
+    if (DVDGetCurrentDiskID()->streaming) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8017F138
+ * PAL Size: 832b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void __OSReboot(u32 resetCode, u32 bootDol) {
     OSContext exceptionContext;
-    char* argvToPass;
+    DVDCommandBlock streamCancelBlock;
+    DVDCommandBlock appLoaderReadBlock;
+    DVDCommandBlock rebootReadBlock;
+    u32 rebootSize;
+#if SDK_REVISION < 1
+    OSTime start;
+#endif
 
-	OSDisableInterrupts();
-    OSSetArenaLo((void*)0x81280000);
-    OSSetArenaHi((void*)0x812f0000);
+    (void)resetCode;
+    (void)bootDol;
+
+    OSDisableInterrupts();
+
+    g_unk_817FFFFC = 0;
+    g_unk_817FFFF8 = 0;
+    g_unk_800030E2 = 1;
+    BOOT_REGION_START = (u32)__OSRebootParams.regionStart;
+    BOOT_REGION_END = (u32)__OSRebootParams.regionEnd;
+
     OSClearContext(&exceptionContext);
     OSSetCurrentContext(&exceptionContext);
-    argvToPass = NULL;
-    __OSBootDol(bootDol, resetCode | 0x80000000, &argvToPass);
+
+    DVDInit();
+    DVDSetAutoInvalidation(TRUE);
+    DVDResume();
+
+    Prepared = FALSE;
+    __DVDPrepareResetAsync(Callback);
+    __OSMaskInterrupts(0xFFFFFFE0);
+    __OSUnmaskInterrupts(0x400);
+    OSEnableInterrupts();
+
+#if SDK_REVISION < 1
+    start = OSGetTime();
+#endif
+
+    while (Prepared != TRUE) {
+#if SDK_REVISION < 1
+        if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+#else
+        if (!DVDCheckDisk())
+#endif
+        {
+            __OSDoHotReset(g_unk_817FFFFC);
+        }
+    }
+
+    if (!__OSIsGcam && IsStreamEnabled()) {
+        AISetStreamVolLeft(0);
+        AISetStreamVolRight(0);
+        DVDCancelStreamAsync(&streamCancelBlock, NULL);
+
+#if SDK_REVISION < 1
+        start = OSGetTime();
+#endif
+
+        while (DVDGetCommandBlockStatus(&streamCancelBlock)) {
+#if SDK_REVISION < 1
+            if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+#else
+            if (!DVDCheckDisk())
+#endif
+            {
+                __OSDoHotReset(g_unk_817FFFFC);
+            }
+        }
+
+        AISetStreamPlayState(AI_STREAM_STOP);
+    }
+
+    DVDReadAbsAsyncPrio(&appLoaderReadBlock, &FatalParam, sizeof(AppLoaderStruct), 0x2440, NULL, 0);
+
+#if SDK_REVISION < 1
+    start = OSGetTime();
+#endif
+
+    while (DVDGetCommandBlockStatus(&appLoaderReadBlock)) {
+#if SDK_REVISION < 1
+        if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+#else
+        if (!DVDCheckDisk())
+#endif
+        {
+            __OSDoHotReset(g_unk_817FFFFC);
+        }
+    }
+
+    rebootSize = OSRoundUp32B(FatalParam.rebootSize);
+    DVDReadAbsAsyncPrio(&rebootReadBlock, (void*)0x81300000, rebootSize, FatalParam.size + 0x2460, NULL, 0);
+
+#if SDK_REVISION < 1
+    start = OSGetTime();
+#endif
+
+    while (DVDGetCommandBlockStatus(&rebootReadBlock)) {
+#if SDK_REVISION < 1
+        if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+#else
+        if (!DVDCheckDisk())
+#endif
+        {
+            __OSDoHotReset(g_unk_817FFFFC);
+        }
+    }
+
+    ICInvalidateRange((void*)0x81300000, rebootSize);
+
+    OSDisableInterrupts();
+    ICFlashInvalidate();
+    Run((void*)0x81300000);
 }
 
 void OSSetSaveRegion(void* start, void* end) {
-    ASSERTMSGLINE(134, (u32)start >= 0x80700000 || start == NULL, "OSSetSaveRegion(): start address should be NULL or higher than 0x80700000\n");
-    ASSERTMSGLINE(135, 0x81200000 >= (u32)end || end == NULL, "OSSetSaveRegion(): end address should be NULL or lower than 0x81200000\n");
-    ASSERTMSGLINE(136, ((start == NULL) ^ (end == NULL)) == 0, "OSSetSaveRegion(): if either start or end is NULL, both should be NULL\n");
-
     SaveStart = start;
     SaveEnd = end;
 }


### PR DESCRIPTION
## Summary
- Replaced placeholder `__OSReboot` implementation in `src/os/OSReboot.c` with a full SDK-style reboot sequence.
- Added reboot flow state used by the original binary: reset-prep callback synchronization, disk/time-based failure handling, stream-stop handling, apploader header read, reboot image read, cache invalidation, and transfer to reboot entry.
- Added the small `Run` asm helper and `Callback` state callback used by the reboot path.
- Simplified `OSSetSaveRegion` to direct stores (release-style behavior) to match expected symbol shape.
- Added function info header for `__OSReboot` with PAL address/size metadata.

## Functions improved
Unit: `main/os/OSReboot`
- `__OSReboot`: **11.466% -> 73.389%**
- `Callback`: now emitted and near-complete (**98.333%**)
- Unit `.text` match: **11.093% -> 72.372%**

## Match evidence
- Baseline (before change): `objdiff` showed a tiny placeholder `__OSReboot` body and unit `.text` match around 11%.
- After change: `objdiff` now shows a full 832-byte `__OSReboot` body with substantial instruction alignment and a large unit-level jump.

## Plausibility rationale
- The new implementation follows existing code patterns already present in this codebase (`src/os/OSExec.c`) and Dolphin SDK conventions:
  - callback-based reset preparation (`__DVDPrepareResetAsync`)
  - timeout-based disk polling with `OSGetTime`/`OS_TIMER_CLOCK`
  - streaming shutoff via `AISetStreamVol*` + `DVDCancelStreamAsync`
  - reboot image load and `ICInvalidateRange`/`ICFlashInvalidate` before transfer
- Changes are source-plausible and readable, not contrived compiler-only coaxing.

## Technical notes
- Used the Ghidra reference only as a structural guide and validated progress with `build/tools/objdiff-cli`.
- Key emitted symbols/objects now include `FatalParam`, `Prepared`, `Callback`, and the reboot control path expected by the target object.
