### PR TITLE
gx/GXMisc: improve GXPokeAlphaRead and GXPokeDstAlpha matching

### DIFF
--- a/src/gx/GXMisc.c
+++ b/src/gx/GXMisc.c
@@ -205,18 +205,7 @@ void GXPokeAlphaMode(GXCompare func, u8 threshold) {
  * JP Size: TODO
  */
 void GXPokeAlphaRead(GXAlphaReadMode mode) {
-    u32 reg;
-    u32 mode_bits;
-    u32 one;
-    u32 out;
-
-    reg = 0;
-    mode_bits = mode;
-    SET_REG_FIELD(693, reg, 2, 0, mode_bits);
-    one = 1;
-    out = reg;
-    SET_REG_FIELD(693, out, 1, 2, one);
-    GX_SET_PE_REG(4, out);
+    GX_SET_PE_REG(4, (mode & 0xFFFB) | 4);
 }
 
 void GXPokeAlphaUpdate(GXBool update_enable) {
@@ -259,18 +248,7 @@ void GXPokeColorUpdate(GXBool update_enable) {
  * JP Size: TODO
  */
 void GXPokeDstAlpha(GXBool enable, u8 alpha) {
-    u32 reg;
-    u32 alpha_bits;
-    u32 enable_bits;
-    u32 out;
-
-    reg = 0;
-    alpha_bits = alpha;
-    SET_REG_FIELD(747, reg, 8, 0, alpha_bits);
-    enable_bits = enable;
-    out = reg;
-    SET_REG_FIELD(748, out, 1, 8, enable_bits);
-    GX_SET_PE_REG(2, out);
+    GX_SET_PE_REG(2, (u16)((u16)alpha | ((u16)enable << 8)));
 }
 
 void GXPokeDither(GXBool dither) {


### PR DESCRIPTION
## Summary
Reworked two small PE-register poke helpers in `src/gx/GXMisc.c` to use direct masked register writes instead of staged `SET_REG_FIELD` temporaries.

- `GXPokeAlphaRead`: now writes `GX_SET_PE_REG(4, (mode & 0xFFFB) | 4)`
- `GXPokeDstAlpha`: now writes `GX_SET_PE_REG(2, (u16)((u16)alpha | ((u16)enable << 8)))`

## Functions improved
Unit: `main/gx/GXMisc`

- `GXPokeAlphaRead`: **34.0% -> 88.0%**
- `GXPokeDstAlpha`: **42.0% -> 100.0%**
- `GXPokeBlendMode`: unchanged at 41.14706% (checked as control)

## Match evidence
Symbol-level `objdiff` was run before and after:

- `build/tools/objdiff-cli diff -p . -u main/gx/GXMisc -o - GXPokeAlphaRead`
- `build/tools/objdiff-cli diff -p . -u main/gx/GXMisc -o - GXPokeDstAlpha`
- `build/tools/objdiff-cli diff -p . -u main/gx/GXMisc -o - GXPokeBlendMode`

Project progress from `ninja` after changes:
- SDK code matched bytes: `154704 -> 154724`
- SDK matched functions: `750 -> 751`

## Plausibility rationale
These are straightforward hardware-register write helpers where the direct mask/or form is idiomatic SDK-style source. The rewrite removes compiler-coaxing temporaries and expresses the exact register value construction directly, which is both clearer and more likely to reflect original source intent.

## Technical details
- `GXPokeDstAlpha` now exactly matches as a single halfword write combining `alpha` and `enable<<8`.
- `GXPokeAlphaRead` now differs by one instruction pattern but aligns closely in final mask/or/store sequence.
