### PR TITLE
gx/GXTev: improve KColor and alpha compare match

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -262,15 +262,8 @@ void GXSetTevKColor(GXTevKColorID id, GXColor color) {
 
     CHECK_GXBEGIN(833, "GXSetTevKColor");
 
-    regRA = (0xE0 + id * 2) << 24;
-    regRA |= color.r;
-    regRA |= color.a << 12;
-    regRA |= 8 << 20;
-
-    regBG = (0xE1 + id * 2) << 24;
-    regBG |= color.b;
-    regBG |= color.g << 12;
-    regBG |= 8 << 20;
+    regRA = ((0xE0 + id * 2) << 24) | color.r | (color.a << 12) | (8 << 20);
+    regBG = ((0xE1 + id * 2) << 24) | color.b | (color.g << 12) | (8 << 20);
 
     GX_WRITE_RAS_REG(regRA);
     GX_WRITE_RAS_REG(regBG);
@@ -354,10 +347,7 @@ void GXSetAlphaCompare(GXCompare comp0, u8 ref0, GXAlphaOp op, GXCompare comp1, 
     u32 reg;
 
     CHECK_GXBEGIN(1046, "GXSetAlphaCompare");
-    reg = 0xF3000000;
-
-    reg |= ref0 & 0xFF;
-    reg |= (ref1 & 0xFF) << 8;
+    reg = 0xF3000000 | (ref0 & 0xFF) | ((ref1 & 0xFF) << 8);
     reg |= (comp0 & 7) << 16;
     reg |= (comp1 & 7) << 19;
     reg |= (op & 3) << 22;


### PR DESCRIPTION
## Summary
Refactored two TEV register-packing routines in `src/gx/GXTev.c` to use direct packed expressions instead of incremental `|=` updates.

## Functions improved
- `GXSetTevKColor`: **50.275864% -> 56.517242%**
- `GXSetAlphaCompare`: **59.04762% -> 60.238094%**

Unit-level `.text` match for `main/gx/GXTev` also improved:
- **78.926735% -> 79.334656%**

## Match evidence
Validated with:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/gx/GXTev -o - GXSetTevKColor`
- `build/tools/objdiff-cli diff -p . -u main/gx/GXTev -o - GXSetAlphaCompare`

The improvement is from instruction-shape alignment in register packing, not symbol renames or formatting-only churn.

## Plausibility rationale
The new code remains straightforward and idiomatic for low-level GX BP register writes: build packed values directly and emit them. This is consistent with existing SDK-style code in this file and avoids artificial control-flow tricks.

## Technical details
- `GXSetTevKColor`: collapsed multi-step OR composition into single packed RA/BG expressions including fixed `8 << 20` bits.
- `GXSetAlphaCompare`: initialized `reg` with a packed base expression (`0xF3000000`, `ref0`, `ref1`) before applying compare/op fields.
- Kept `GXSetTevColor` unchanged after testing showed that similar rewriting there regressed its symbol match.
