### PR TITLE
Implement CMcPcs::calc state machine

### DIFF
--- a/src/p_mc.cpp
+++ b/src/p_mc.cpp
@@ -1,4 +1,20 @@
 #include "ffcc/p_mc.h"
+#include "ffcc/goout.h"
+#include "ffcc/math.h"
+#include "ffcc/wm_menu.h"
+
+extern CMath math;
+extern "C" int Format__6McCtrlFi(McCtrl* mcCtrl, int slot);
+
+struct MenuPcsMcLayout
+{
+    unsigned char unk14[0x14];
+    unsigned char field14;
+    unsigned char unk15[3];
+    signed char field18;
+    unsigned char unk19[7];
+    McCtrl m_mcCtrl;
+};
 
 /*
  * --INFO--
@@ -65,10 +81,74 @@ void CMcPcs::destroy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80124998
+ * PAL Size: 312b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMcPcs::calc()
 {
-	// TODO
+    MenuPcsMcLayout* menuPcsLayout = reinterpret_cast<MenuPcsMcLayout*>(&MenuPcs);
+    int result;
+    int worldParam;
+
+    math.Rand(0x7FFFFFFF);
+
+    if (menuPcsLayout->field14 != 1)
+    {
+        if (menuPcsLayout->field18 == 0x13)
+        {
+            result = Format__6McCtrlFi(&menuPcsLayout->m_mcCtrl, 1);
+            if (result != 0)
+            {
+                if (result == 1)
+                {
+                    worldParam = 1;
+                }
+                else if (result == -1)
+                {
+                    worldParam = 4;
+                }
+                else
+                {
+                    worldParam = 6;
+                }
+
+                MenuPcs.CallWorldParam(6, worldParam, 0);
+                menuPcsLayout->field18 = 0;
+            }
+        }
+        else if (menuPcsLayout->field18 == 0x12)
+        {
+            result = menuPcsLayout->m_mcCtrl.ChkEmpty(0);
+            if (result != 0)
+            {
+                if (result == 1)
+                {
+                    worldParam = 1;
+                }
+                else if (result == -1)
+                {
+                    worldParam = 4;
+                }
+                else if (result == -2)
+                {
+                    worldParam = 5;
+                }
+                else if (result == -3 || result == -4)
+                {
+                    worldParam = 2;
+                }
+                else
+                {
+                    worldParam = 6;
+                }
+
+                MenuPcs.CallWorldParam(5, worldParam, 0);
+                menuPcsLayout->field18 = 0;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Implemented `CMcPcs::calc()` in `src/p_mc.cpp` using the decompiled control flow for memory-card format/empty checks.
- Added a local `MenuPcs` layout overlay in `p_mc.cpp` to access the observed PAL offsets used by this routine (`+0x14`, `+0x18`, and `McCtrl` at `+0x20`).
- Added PAL metadata block for the function.

## Functions improved
- Unit: `main/p_mc`
- Function: `calc__6CMcPcsFv` (`CMcPcs::calc()`)
- Size: `312b`

## Match evidence
- Before: `1.2820513%`
- After: `84.97436%`
- Improvement: `+83.6923087%`

`objdiff` command used:
```sh
build/tools/objdiff-cli diff -p . -u main/p_mc -o - calc__6CMcPcsFv
```

Assembly alignment highlights:
- Prologue/epilogue now align.
- Control-flow for both `Format` and `ChkEmpty` result mapping aligns with target branch structure.
- `CallWorldParam` call sites and state reset (`stb` to mode byte) now align.

## Plausibility rationale
- Logic matches expected game behavior: run RNG tick, gate on menu state bytes, invoke memory-card operations, map return codes to menu world parameters, then clear pending state.
- The code keeps readable high-level flow while preserving target-observed state-machine behavior.
- Offset usage is limited to a local overlay for currently-unknown `CMenuPcs` member layout and is directly justified by objdiff-observed target access patterns.

## Technical details
- Used Ghidra decomp only as a behavioral guide and verified against objdiff instruction-level output.
- Refined control flow to match target branching structure and return-code mapping.
