### PR TITLE
GXInit: improve __GXDefaultTexRegionCallback decomp match

### DIFF
--- a/src/gx/GXInit.c
+++ b/src/gx/GXInit.c
@@ -100,30 +100,42 @@ static void DisableWriteGatherPipe(void) {
     PPCMthid2(hid2);
 }
 
-static GXTexRegion*__GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapID id) {
-    GXTexFmt fmt;
-    u8 mm;
+/*
+ * --INFO--
+ * PAL Address: 0x8019EF44
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+static GXTexRegion* __GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapID id) {
+    u8* gx;
+    u32* regionCount;
+    u32 count;
+    u32 offset;
 
-    fmt = GXGetTexObjFmt(t_obj);
-    mm = GXGetTexObjMipMap(t_obj);
-    id = (GXTexMapID)(id % GX_MAX_TEXMAP);
+    (void)id;
+    gx = (u8*)__GXData;
 
-    switch (fmt) {
-    case GX_TF_RGBA8:
-        if (mm) {
-            return &__GXData->TexRegions2[id];
-        }
-        return &__GXData->TexRegions1[id];
+    switch (GXGetTexObjFmt(t_obj)) {
     case GX_TF_C4:
     case GX_TF_C8:
     case GX_TF_C14X2:
-        return &__GXData->TexRegions0[id];
+        regionCount = (u32*)(gx + 0x2CC);
+        count = *regionCount;
+        *regionCount = count + 1;
+        offset = ((count & 3) << 4) + 0x288;
+        break;
     default:
-        if (mm) {
-            return &__GXData->TexRegions1[id];
-        }
-        return &__GXData->TexRegions0[id];
+        regionCount = (u32*)(gx + 0x2C8);
+        count = *regionCount;
+        *regionCount = count + 1;
+        offset = ((count & 7) << 4) + 0x208;
+        break;
     }
+
+    return (GXTexRegion*)(gx + offset);
 }
 
 static GXTlutRegion* __GXDefaultTlutRegionCallback(u32 idx) {


### PR DESCRIPTION
## Summary
- Reworked `__GXDefaultTexRegionCallback` in `src/gx/GXInit.c` to use the game-specific texture-region selection behavior observed in the PAL binary.
- Added function metadata header with PAL address/size.
- Removed stock SDK logic that depended on mipmap state and `id % GX_MAX_TEXMAP` for this callback.

## Functions improved
- Unit: `main/gx/GXInit`
- Symbol: `__GXDefaultTexRegionCallback` (124b)

## Match evidence
- Before: `0.0%`
- After: `58.70968%`
- Measurement command:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXInit -o - __GXDefaultTexRegionCallback`

## Technical details
- The updated callback now branches on texture format (`C4/C8/C14X2` vs others) and uses rotating indices backed by words at `GXData + 0x2CC` and `GXData + 0x2C8`.
- Return addresses are computed from `GXData` bases at `+0x288` (4-way rotation) and `+0x208` (8-way rotation), matching target code structure much better than the previous SDK-style path.

## Plausibility rationale
- This change aligns with observed game binary behavior rather than artificial instruction coaxing.
- It keeps the logic compact and domain-appropriate for a low-level GX callback while avoiding unrelated refactors.

## Validation
- `ninja` build completes successfully after the change.
