### PR TITLE
menu: derive CMenu from CRef for ctor match

### DIFF
--- a/include/ffcc/menu.h
+++ b/include/ffcc/menu.h
@@ -1,7 +1,9 @@
 #ifndef _FFCC_MENU_H_
 #define _FFCC_MENU_H_
 
-class CMenu
+#include "ffcc/ref.h"
+
+class CMenu : public CRef
 {
 public:
     CMenu();

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -2,8 +2,12 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009b4a8
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMenu::CMenu()
 {
@@ -12,8 +16,12 @@ CMenu::CMenu()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009b488
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMenu::~CMenu()
 {


### PR DESCRIPTION
## Summary
- Make `CMenu` derive from `CRef` in `include/ffcc/menu.h` and include `ffcc/ref.h`.
- Keep `CMenu` ctor/dtor definitions in `src/menu.cpp` (no coercion logic), allowing Metrowerks to emit base ctor/dtor + vtable setup naturally.
- Update ctor/dtor INFO blocks to PAL-format metadata style used by the project.

## Functions improved
- Unit: `main/menu`
- Symbol: `__ct__5CMenuFv` (`CMenu::CMenu()`)

## Match evidence
- `__ct__5CMenuFv`: **25.666666% -> 99.333336%** (`build/tools/objdiff-cli diff -p . -u main/menu -o - __ct__5CMenuFv`).
- No intentional compiler-coaxing changes were introduced; improvement comes from corrected class relationship and natural codegen.

## Plausibility rationale
- Ghidra reference for PAL ctor (`0x8009b4a8`, 60b) shows `CMenu` constructing `CRef` and setting its own vtable.
- Modeling `CMenu` as `CRef`-derived is a source-level correction consistent with expected OO layout and other code in the repo, not an artificial instruction-order tweak.

## Technical details
- Prior state emitted a short ctor variant and mismatched destructor shape because `CMenu` lacked the base-class relationship.
- After inheriting from `CRef`, ctor codegen aligns with expected base ctor call + vtable store sequence, producing the large objdiff gain.