### PR TITLE
Improve match for pppRandDownFloat

### DIFF
--- a/src/pppRandDownFloat.cpp
+++ b/src/pppRandDownFloat.cpp
@@ -5,6 +5,21 @@ extern CMath math;
 extern int lbl_8032ED70; // Global state flag
 extern float lbl_8032FF38; // Float constant  
 extern float lbl_801EADC8; // Another float constant
+extern "C" float RandF__5CMathFv(CMath*);
+
+typedef struct {
+    int field0;
+    int field4;
+    float field8;
+    unsigned char fieldC;
+} PppRandDownFloatParam;
+
+typedef struct {
+    void* field0;
+    void* field4;
+    void* field8;
+    int* fieldC;
+} PppRandDownFloatState;
 
 /*
  * --INFO--
@@ -15,82 +30,37 @@ extern float lbl_801EADC8; // Another float constant
  * JP Address: TODO  
  * JP Size: TODO
  */
-void pppRandDownFloat(void* r3, void* r4, void* r5)
-{
-    // Cast parameters based on memory access patterns from assembly
-    int* p1 = (int*)r3;  
-    struct ParamStruct2 {
-        int field0;           
-        int field4;           
-        float field8;         
-        unsigned char fieldC; 
-    }* p2 = (struct ParamStruct2*)r4; 
-    
-    struct ParamStruct3 {
-        void* field0;    
-        void* field4;    
-        void* field8;    
-        void* fieldC;    
-    }* p3 = (struct ParamStruct3*)r5; 
-    
-    // Check global state first
+void pppRandDownFloat(void* r3, void* r4, void* r5) {
+    int* obj = (int*)r3;
+    PppRandDownFloatState* state = (PppRandDownFloatState*)r5;
+    PppRandDownFloatParam* param = (PppRandDownFloatParam*)r4;
+
     if (lbl_8032ED70 != 0) {
-        return; 
+        return;
     }
-    
-    // Check field at offset 12 of first parameter
-    if (p1[3] == 0) { 
-        // Generate random float - using placeholder for now
-        math.RandF(); 
-        float randVal = -0.5f; // Negative placeholder for "down" version
-        
-        // Check byte at offset 12 of second parameter  
-        if (p2->fieldC != 0) { 
-            // Generate second random and do arithmetic
-            math.RandF();
-            float randVal2 = 0.5f; // Second placeholder
-            randVal = randVal - randVal2;
-            // Then multiply by constant 
-            randVal = randVal * lbl_8032FF38;
+
+    if (obj[3] == 0) {
+        float value = RandF__5CMathFv(&math);
+        value = -value;
+
+        if (param->fieldC != 0) {
+            value = (value - RandF__5CMathFv(&math)) * lbl_8032FF38;
         }
-        
-        // Calculate destination and store
-        void** basePtr = (void**)p3->fieldC; 
-        if (basePtr) {
-            int* indexPtr = (int*)*basePtr;       
-            float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80)); 
-            *destAddr = randVal; 
+
+        *(float*)((char*)obj + *state->fieldC + 0x80) = value;
+        return;
+    }
+
+    if (param->field0 == obj[3]) {
+        float* dst = (float*)((char*)obj + *state->fieldC + 0x80);
+        float* src;
+
+        if (param->field4 == -1) {
+            src = &lbl_801EADC8;
+        } else {
+            src = (float*)((char*)obj + param->field4 + 0x80);
         }
-        
-    } else {
-        // Different branch - check second parameter fields
-        if (p2->field0 == p1[3]) { 
-            // Calculate destination address
-            void** basePtr = (void**)p3->fieldC;
-            if (basePtr) {
-                int* indexPtr = (int*)*basePtr;
-                
-                // Determine source address based on field4 
-                float* srcAddr;
-                if (p2->field4 == -1) { 
-                    // Use constant address
-                    srcAddr = &lbl_801EADC8;
-                } else {
-                    // Use computed address 
-                    srcAddr = (float*)((char*)p1 + (p2->field4 + 0x80));
-                }
-                
-                float* destAddr = (float*)((char*)p1 + (*indexPtr + 0x80));
-                
-                // Load values and perform arithmetic
-                float val1 = p2->field8;     
-                float val0 = *destAddr;      
-                float val2 = *srcAddr;       
-                
-                // Multiply and add
-                float result = val2 + (val1 * val0);
-                *srcAddr = result; 
-            }
-        }
+
+        *src += param->field8 * *dst;
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandDownFloat` from placeholder behavior into a source-plausible implementation that matches observed control flow and data access patterns.
- Added concrete local parameter/state structs for field-based access and removed placeholder constants/defensive null branches that were not reflected in target codegen.
- Switched random float calls to the existing symbol `RandF__5CMathFv` with explicit return type usage, aligning emitted call sites and FP arithmetic.

## Functions improved
- Unit: `main/pppRandDownFloat`
- Symbol: `pppRandDownFloat`
- Match: **63.636364% -> 77.151510%** (size 264b)

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandDownFloat -o - pppRandDownFloat`
- Improvement came from better alignment in function structure and register usage (notably saved-register mapping for args and arithmetic/control-flow shape).

## Plausibility rationale
- The updated function now follows straightforward gameplay-style logic: early global gate, random-down write path, and conditional accumulation path.
- Changes are type/layout/control-flow corrections consistent with likely original source, rather than compiler-coaxing constructs.
- No debug artifacts or assembly comments were introduced.

## Technical details
- Introduced `PppRandDownFloatParam` and `PppRandDownFloatState` to model observed field usage.
- Kept PAL info header metadata intact.
- Preserved external symbol usage (`math`, `lbl_8032ED70`, `lbl_8032FF38`, `lbl_801EADC8`) while replacing placeholder math with direct random-float output usage.
