### PR TITLE
pppShape: align GetTexture symbol to pppShapeSt method

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -39,6 +39,8 @@ struct pppShapeSt
     char m_name[32];         // 0x8
     short m_refCount;        // 0x28
     unsigned char m_inUse;   // 0x2a
+
+    void* GetTexture(long*, CMaterialSet*, int&);
 }; // Size 0x2c
 
 struct pppModelSt

--- a/include/ffcc/pppShape.h
+++ b/include/ffcc/pppShape.h
@@ -14,7 +14,6 @@ extern "C" {
     void CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet(CMaterialSet*, unsigned int, void*);
 }
 
-void* pppShapeSt_GetTexture(long*, CMaterialSet*, int&);
 void pppDrawShp(long*, short, CMaterialSet*, unsigned char);
 void pppDrawShp(tagOAN3_SHAPE*, CMaterialSet*, unsigned char);
 void pppSetShapeMaterial0(pppShapeSt*, tagOAN3_SHAPE*, CMaterialSet*, char **);

--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -18,7 +18,7 @@ extern "C" {
  * JP Address: TODO
  * JP Size: TODO
  */
-void* pppShapeSt_GetTexture(long* animData, CMaterialSet* materialSet, int& textureIndex)
+void* pppShapeSt::GetTexture(long* animData, CMaterialSet* materialSet, int& textureIndex)
 {
     int shapePtr = (int)animData + *(short*)((int)animData + 0x10) + 8;
     textureIndex = (unsigned int)*(unsigned char*)(shapePtr + 2);


### PR DESCRIPTION
## Summary
- Converted `pppShapeSt_GetTexture(...)` into `pppShapeSt::GetTexture(...)` so the emitted symbol matches the PAL target (`GetTexture__10pppShapeStFPlP12CMaterialSetRi`).
- Added the method declaration to `pppShapeSt` and removed the stale free-function prototype from `pppShape.h`.
- Kept function behavior unchanged (same small first-pass implementation), focusing on symbol/ABI alignment.

## Functions improved
- Unit: `main/pppShape`
- Function: `GetTexture__10pppShapeStFPlP12CMaterialSetRi`

## Match evidence
- Before: function was emitted as `pppShapeSt_GetTexture__FPlP12CMaterialSetRi` and did not map to target (`match: null` / effectively 0% in selector output).
- After: function emits/matches as `GetTexture__10pppShapeStFPlP12CMaterialSetRi` with `25.9375%` match in objdiff.
- Unit fuzzy score moved from selector baseline `25.3%` to `26.3602%` (`build/GCCP01/report.json`).

## Plausibility rationale
- This change aligns the function with the known Metrowerks class-method symbol naming and existing project symbol maps.
- No contrived temporaries/reordering were introduced; this is a structural declaration fix that reflects likely original source organization (`pppShapeSt` method, not global helper).

## Technical notes
- Verified with `nm` that the object now exports `GetTexture__10pppShapeStFPlP12CMaterialSetRi`.
- Verified with `build/tools/objdiff-cli diff -p . -u main/pppShape -o - GetTexture__10pppShapeStFPlP12CMaterialSetRi`.
