### PR TITLE
main/usb: fix __sinit_usb_cpp linkage for objdiff matching

### DIFF
--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -179,10 +179,14 @@ void CUSB::Printf(char*, ...)
 
 /*
  * --INFO--
- * Address: 80022704
- * Size: 32b
+ * PAL Address: 0x80022704
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __sinit_usb_cpp()
+extern "C" void __sinit_usb_cpp()
 {
 	USB.m_managerStringTable = &PTR_PTR_DAT_801e88a4;
 }


### PR DESCRIPTION
## Summary
- Updated `__sinit_usb_cpp` in `src/usb.cpp` to use C linkage (`extern "C"`).
- Updated the function info header to the project-standard PAL/EN/JP format.

## Functions improved
- Unit: `main/usb`
- Symbol: `__sinit_usb_cpp`

## Match evidence
Direct objdiff on object files:

```sh
build/tools/objdiff-cli diff -1 build/GCCP01/obj/usb.o -2 build/GCCP01/src/usb.o -o - __sinit_usb_cpp
```

Before (without C linkage):
- Left symbol: `__sinit_usb_cpp` (32b), `target_symbol: null`
- Right symbol: `__sinit_usb_cpp__Fv` (16b), `target_symbol: null`
- Result: symbol could not be paired (no function match metric)

After (with C linkage):
- Left symbol: `__sinit_usb_cpp` (32b), `target_symbol: 12`
- Right symbol: `__sinit_usb_cpp` (16b), `target_symbol: 20`
- Result: paired function with `match_percent: 41.125`

## Plausibility rationale
- `__sinit_*` initialization thunks are compiler/runtime generated entrypoints and are expected to have fixed external symbol names.
- Using C linkage here is a source-plausible correction to symbol ABI/linkage, not an artificial control-flow or temporary-variable rewrite.
- The function body remains semantically unchanged.

## Technical details
- Root cause was symbol-name mismatch (`__sinit_usb_cpp` vs `__sinit_usb_cpp__Fv`) preventing objdiff mapping.
- Fixing linkage enables proper symbol pairing and measurable assembly comparison for this function.
