### PR TITLE
Fix SaveDat mangling for memorycard symbols

### DIFF
--- a/include/ffcc/goout.h
+++ b/include/ffcc/goout.h
@@ -13,7 +13,7 @@ class McCtrl;
 
 extern CMenuPcs MenuPcs;
 
-void getFreeCaravanIdx(CMemoryCardMan::Mc::SaveDat*);
+void getFreeCaravanIdx(Mc::SaveDat*);
 void CalcGoOutMenu();
 void DrawGoOutMenu();
 

--- a/include/ffcc/memorycard.h
+++ b/include/ffcc/memorycard.h
@@ -6,19 +6,16 @@
 #include "ffcc/manager.h"
 
 class CStage;
+namespace Mc
+{
+class SaveDat
+{
+};
+}
 
 class CMemoryCardMan : public CManager
 {
 public:
-    class Mc
-    {
-    public:
-        class SaveDat
-        {
-            public:
-        };
-    };
-
     CMemoryCardMan();
 
     void Init();
@@ -52,8 +49,8 @@ public:
 
     void MakeSaveData();
     void SetLoadData();
-    unsigned int CalcCrc(Mc::SaveDat*);
-    unsigned int ChkCrc(Mc::SaveDat*);
+    unsigned int CalcCrc(::Mc::SaveDat*);
+    unsigned int ChkCrc(::Mc::SaveDat*);
 
     int DummySave();
     int DummyLoad();
@@ -64,8 +61,8 @@ public:
     void EncodeData();
     void DecodeData();
 
-    void CalcSaveDatHpMax(Mc::SaveDat*);
-    void Odekake(int, Mc::SaveDat&, int, Mc::SaveDat&, int);
+    void CalcSaveDatHpMax(::Mc::SaveDat*);
+    void Odekake(int, ::Mc::SaveDat&, int, ::Mc::SaveDat&, int);
 
     // void* vtable;           // 0x00
     int m_result;              // 0x04

--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -206,10 +206,10 @@ public:
     void GetMaxAnimWait();
     void BindMcObj();
     void DrawFilter(unsigned char, unsigned char, unsigned char, unsigned char);
-    void CopyNowCaravanDat(CMemoryCardMan::Mc::SaveDat*);
-    void SetCaravanWork(CMemoryCardMan::Mc::SaveDat*);
-    void GetSameCharaData(CMemoryCardMan::Mc::SaveDat*, CMemoryCardMan::Mc::SaveDat*, int, int);
-    void CheckSameMcFormatID(CMemoryCardMan::Mc::SaveDat*, CMemoryCardMan::Mc::SaveDat*);
+    void CopyNowCaravanDat(Mc::SaveDat*);
+    void SetCaravanWork(Mc::SaveDat*);
+    void GetSameCharaData(Mc::SaveDat*, Mc::SaveDat*, int, int);
+    void CheckSameMcFormatID(Mc::SaveDat*, Mc::SaveDat*);
     void IsAsyncCharaLoadFinish();
     void AlphaNormal();
     void AlphaAdd();

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -15,7 +15,7 @@ void DrawGoOutMenu()
  * Address:	TODO
  * Size:	TODO
  */
-void getFreeCaravanIdx(CMemoryCardMan::Mc::SaveDat*)
+void getFreeCaravanIdx(Mc::SaveDat*)
 {
 	// TODO
 }

--- a/src/wm_menu.cpp
+++ b/src/wm_menu.cpp
@@ -1007,7 +1007,7 @@ void CMenuPcs::DrawFilter(unsigned char, unsigned char, unsigned char, unsigned 
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::CopyNowCaravanDat(CMemoryCardMan::Mc::SaveDat*)
+void CMenuPcs::CopyNowCaravanDat(Mc::SaveDat*)
 {
 	// TODO
 }
@@ -1017,7 +1017,7 @@ void CMenuPcs::CopyNowCaravanDat(CMemoryCardMan::Mc::SaveDat*)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::SetCaravanWork(CMemoryCardMan::Mc::SaveDat*)
+void CMenuPcs::SetCaravanWork(Mc::SaveDat*)
 {
 	// TODO
 }
@@ -1027,7 +1027,7 @@ void CMenuPcs::SetCaravanWork(CMemoryCardMan::Mc::SaveDat*)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::GetSameCharaData(CMemoryCardMan::Mc::SaveDat*, CMemoryCardMan::Mc::SaveDat*, int, int)
+void CMenuPcs::GetSameCharaData(Mc::SaveDat*, Mc::SaveDat*, int, int)
 {
 	// TODO
 }
@@ -1037,7 +1037,7 @@ void CMenuPcs::GetSameCharaData(CMemoryCardMan::Mc::SaveDat*, CMemoryCardMan::Mc
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::CheckSameMcFormatID(CMemoryCardMan::Mc::SaveDat*, CMemoryCardMan::Mc::SaveDat*)
+void CMenuPcs::CheckSameMcFormatID(Mc::SaveDat*, Mc::SaveDat*)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Moved `SaveDat` to global `Mc` namespace in `include/ffcc/memorycard.h`.
- Updated signatures that referenced `CMemoryCardMan::Mc::SaveDat` to `Mc::SaveDat` in:
  - `include/ffcc/goout.h`
  - `include/ffcc/p_menu.h`
  - `src/goout.cpp`
  - `src/wm_menu.cpp`
- This aligns mangled names with PAL symbols (`...Q22Mc7SaveDat...`) instead of nested-class mangling (`...Q314CMemoryCardMan2Mc7SaveDat...`).

## Functions Improved
- Unit: `main/memorycard`
- Symbols now resolve against target names:
  - `CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`
  - `Odekake__14CMemoryCardManFiRQ22Mc7SaveDatiRQ22Mc7SaveDati`
  - `ChkCrc__14CMemoryCardManFPQ22Mc7SaveDat`
  - `CalcCrc__14CMemoryCardManFPQ22Mc7SaveDat`

## Match Evidence
Before (name mismatch; no target pairing):
- `CalcSaveDatHpMax...`: `null`
- `Odekake...`: `null`
- `ChkCrc...`: `null`
- `CalcCrc...`: `null`

After:
- `CalcSaveDatHpMax...`: `31.530865%`
- `Odekake...`: `0.2544529%`
- `ChkCrc...`: `0.0%`
- `CalcCrc...`: `0.0%`

## Plausibility Rationale
- The PAL symbols clearly indicate `Mc::SaveDat` as a global namespace type.
- Using a nested `CMemoryCardMan::Mc::SaveDat` is an ABI/mangling mismatch, not plausible original source.
- This change restores symbol-level correctness without introducing coercive control-flow tweaks.

## Technical Details
- Verified resulting object exports with `nm build/GCCP01/src/memorycard.o` now show:
  - `CalcCrc__14CMemoryCardManFPQ22Mc7SaveDat`
  - `ChkCrc__14CMemoryCardManFPQ22Mc7SaveDat`
  - `CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`
  - `Odekake__14CMemoryCardManFiRQ22Mc7SaveDatiRQ22Mc7SaveDati`
- Build remains green with `ninja`.
