### PR TITLE
main/pppRandUpChar: implement pppRandUpChar logic

### DIFF
--- a/src/pppRandUpChar.cpp
+++ b/src/pppRandUpChar.cpp
@@ -1,7 +1,25 @@
 #include "ffcc/pppRandUpChar.h"
 #include "ffcc/math.h"
+#include "types.h"
 
 extern CMath math;
+extern s32 lbl_8032ED70;
+extern f32 lbl_8032FF08;
+extern f64 lbl_8032FF10;
+extern u8 lbl_801EADC8;
+extern "C" f32 RandF__5CMathFv(CMath* instance);
+
+struct RandUpCharParam {
+    s32 targetId;
+    s32 sourceOffset;
+    u8 scale;
+    u8 randomTwice;
+};
+
+struct RandUpCharCtx {
+    u8 _pad[0xC];
+    s32* outputOffset;
+};
 
 /*
  * --INFO--
@@ -14,6 +32,48 @@ extern CMath math;
  */
 extern "C" void pppRandUpChar(void* param1, void* param2, void* param3)
 {
-    // Basic placeholder implementation - needs refinement based on objdiff results
-    math.RandF(); // Generate random number - stored in math object state
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
+
+    u8* base = (u8*)param1;
+    RandUpCharParam* in = (RandUpCharParam*)param2;
+    RandUpCharCtx* ctx = (RandUpCharCtx*)param3;
+    f32* valuePtr;
+
+    s32 state = *(s32*)(base + 0xC);
+    if (state == 0) {
+        f32 value = RandF__5CMathFv(&math);
+        if (in->randomTwice != 0) {
+            value = (value + RandF__5CMathFv(&math)) * lbl_8032FF08;
+        }
+
+        valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
+        *valuePtr = value;
+    } else {
+        if (in->targetId != state) {
+            return;
+        }
+        valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
+    }
+
+    u8* target;
+    if (in->sourceOffset == -1) {
+        target = &lbl_801EADC8;
+    } else {
+        target = base + in->sourceOffset + 0x80;
+    }
+
+    union {
+        f64 d;
+        struct {
+            u32 hi;
+            u32 lo;
+        } parts;
+    } cvt;
+    cvt.parts.hi = 0x43300000;
+    cvt.parts.lo = in->scale;
+
+    s32 delta = (s32)((cvt.d - lbl_8032FF10) * *valuePtr);
+    *target = (u8)(*target + delta);
 }


### PR DESCRIPTION
## Summary
- Replaced the placeholder `pppRandUpChar` body with a typed implementation that follows existing `pppRand*` patterns.
- Added explicit parameter/context structs, state gating via `lbl_8032ED70`, cached random factor storage, and char target accumulation logic.
- Switched random generation to explicit `RandF__5CMathFv(&math)` calls and used the unit's scale/bias constants (`lbl_8032FF08`, `lbl_8032FF10`).

## Functions Improved
- Unit: `main/pppRandUpChar`
- Symbol: `pppRandUpChar`
- Before: `10.2%` (from `tools/agent_select_target.py`)
- After: `88.13333%` (from `objdiff-cli`)

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandUpChar -o - pppRandUpChar`
- Result:
  - `.text` / symbol `pppRandUpChar` now reports `88.13333%` match.
- Assembly alignment improved substantially in control flow shape and floating-point conversion sequence for char accumulation.

## Plausibility Rationale
- The implementation mirrors established source patterns in nearby units (`pppRandUpInt`, `pppRandDownChar`) rather than introducing artificial compiler coaxing.
- Control flow and data access are idiomatic for this codebase (state check, output-offset indirection, optional global fallback target).
- Type choices (`u8` target/scale, `f32` cached factor, `f64` conversion bias) are consistent with related random update handlers.
