### PR TITLE
Improve CSoundPcs matching in main/p_sound

### DIFF
--- a/include/ffcc/p_sound.h
+++ b/include/ffcc/p_sound.h
@@ -10,7 +10,7 @@ public:
 
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    void* GetTable(unsigned long);
 
     void create();
     void createLoad();

--- a/src/p_sound.cpp
+++ b/src/p_sound.cpp
@@ -1,5 +1,9 @@
 #include "ffcc/p_sound.h"
 
+#include "ffcc/sound.h"
+
+extern unsigned char CFlat[];
+
 /*
  * --INFO--
  * Address:	TODO
@@ -12,80 +16,115 @@ CSoundPcs::CSoundPcs()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d8808
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::Init()
 {
-	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d8804
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::Quit()
 {
-	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d87f0
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSoundPcs::GetTable(unsigned long)
+void* CSoundPcs::GetTable(unsigned long index)
 {
-	// TODO
+    extern unsigned char lbl_802105B0[];
+    return lbl_802105B0 + (index * 0x15C);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d87ec
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::create()
 {
-	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d87c4
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::createLoad()
 {
-	// TODO
+    Sound.LoadBlock();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d8774
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::destroy()
 {
-	// TODO
+    Sound.CancelLoadWaveASync();
+    Sound.StopStream();
+    Sound.StopAndFreeAllSe(1);
+    Sound.FreeBlock();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d874c
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::calc()
 {
-	// TODO
+    Sound.Frame();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d8710
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSoundPcs::draw()
 {
-	// TODO
+    if ((*(unsigned int*)(CFlat + 0x129C) & 0x400000) != 0) {
+        Sound.Draw();
+    }
 }


### PR DESCRIPTION
## Summary
- Replaced `CSoundPcs` TODO stubs in `src/p_sound.cpp` with concrete method bodies for core runtime behavior.
- Added direct `CSound` call flow for `createLoad`, `destroy`, `calc`, and `draw`.
- Updated `CSoundPcs::GetTable` to return the table base + indexed stride (`0x15C`) and aligned declaration in `include/ffcc/p_sound.h`.
- Added PAL address/size metadata comments for updated methods.

## Functions improved
Unit: `main/p_sound`
- `draw__9CSoundPcsFv`: `6.6667% -> 89.3333%`
- `calc__9CSoundPcsFv`: `10.0% -> 84.0%`
- `destroy__9CSoundPcsFv`: `5.0% -> 67.7%`
- `createLoad__9CSoundPcsFv`: `10.0% -> 84.0%`
- `GetTable__9CSoundPcsFUl`: `20.0% -> 100.0%`

## Match evidence
- Unit `.text` match for `main/p_sound` improved from `7.2727%` to `47.0364%` (objdiff).
- Improvements are from instruction-level alignment (call targets, control-flow gate, and address arithmetic), not formatting-only changes.

## Plausibility rationale
- The new method bodies are straightforward manager wrappers over `CSound` operations and match established `C*Pcs` patterns in this codebase.
- `draw()` uses the existing CFlat flag gate convention (`CFlat + 0x129C` mask) already present in other units, making behavior and style consistent with plausible original source.
- `destroy()` follows an expected shutdown order for audio resources (cancel async load, stop stream, stop/free SE, free block), matching engine lifecycle semantics.

## Technical details
- `createLoad()` now emits the expected `LoadBlock__6CSoundFv` call path.
- `destroy()` now emits the expected sequence of `CSound` calls with immediate argument `1` for `StopAndFreeAllSe`.
- `calc()` now emits `Frame__6CSoundFv` dispatch.
- `draw()` now conditionally calls `Draw__6CSoundFv` when the runtime flag is set.
- `GetTable()` now computes `lbl_802105B0 + index * 0x15C`, matching expected pointer arithmetic.
