### PR TITLE
system: fix OSPanic linkage/signature and match symbol

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -60,7 +60,6 @@ public:
     unsigned int GetCounter();
     bool IsGdev();
     void DumpMapFile(void*);
-    void OSPanic(...);
     static void errorHandler(unsigned short, OSContext*, unsigned long, unsigned long);
 
     // void* vtable;             // 0x0000 (4 bytes)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -356,10 +356,14 @@ void CSystem::errorHandler(unsigned short, OSContext*, unsigned long, unsigned l
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800223dc
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void OSPanic(...)
+void OSPanic(const char* file, int line, const char* msg, ...)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Removed an incorrect `CSystem::OSPanic(...)` declaration from `include/ffcc/system.h`.
- Updated `src/system.cpp` to define the global OS panic shim with the proper C-compatible signature:
  - `void OSPanic(const char* file, int line, const char* msg, ...)`
- Added the standard function info header for PAL address/size metadata.

## Functions improved
- Unit: `main/system` (`system.o`)
- Symbol: `OSPanic`
  - Before: unresolved/unmatched symbol in objdiff output (`target_symbol: null`, `match_percent: null`)
  - After: `match_percent: 100.0`, `target_symbol: 19`

## Match evidence
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/system -o - OSPanic`
- Extracted symbol status:
  - Before: `OSPanic` had no target linkage (`target_symbol: null`)
  - After: `OSPanic` linked and matched exactly (`100.0%`)
- Project progress delta from rebuild:
  - Functions matched: `1170 -> 1171`
  - Code bytes matched: `177056 -> 177136`

## Plausibility rationale
- This change aligns the source with the SDK-facing OS API already declared in `dolphin/os.h` (`extern "C"` panic prototype).
- The previous form looked like a decomp placeholder (`void OSPanic(...)`) and produced mismatched symbol identity.
- The updated declaration/definition reflects plausible original source usage and improves match by correcting ABI/signature semantics rather than compiler coaxing.

## Technical details
- The mismatch stemmed from symbol identity/linkage, not algorithmic logic.
- Fixing declaration scope and function signature allowed `objdiff` to map the function to the expected target symbol in `system.o`.
