### PR TITLE
Improve UnkB layout in pppCallBackDistance callback path

### DIFF
--- a/include/ffcc/pppCallBackDistance.h
+++ b/include/ffcc/pppCallBackDistance.h
@@ -13,8 +13,9 @@ struct pppCallBackDistance {
 };
 
 struct UnkB {
-    u32 m_dataValIndex;
-    u16 m_initWOrk;
+    u32 m_unk0;
+    f32 m_dataValIndex;
+    s16 m_initWOrk;
 };
 
 struct UnkC {

--- a/src/pppCallBackDistance.cpp
+++ b/src/pppCallBackDistance.cpp
@@ -69,7 +69,7 @@ void pppFrameCallBackDistance(pppCallBackDistance* param1, UnkB* param2, UnkC* p
     dVar4 = (f64)PSVECDistance(&local_1c, &pppMngStPtr->m_scale);
     p_Var1 = pppMngStPtr;
 
-    if ((dVar4 <= (f64)(f32)param2->m_dataValIndex) ||
+    if ((dVar4 <= (f64)param2->m_dataValIndex) ||
         ((f64)*(f32*)((s32)(&param1->field0_0x0 + 2) + iVar3) <= dVar4)) {
         local_28.x = pppMngStPtr->m_matrix.value[0][3];
         local_28.y = pppMngStPtr->m_matrix.value[1][3];


### PR DESCRIPTION
## Summary
- Updated `UnkB` in `pppCallBackDistance` to a more plausible serialized layout used by the callback path:
  - Added leading `u32 m_unk0`
  - Changed `m_dataValIndex` to `f32`
  - Changed `m_initWOrk` to `s16`
- Simplified the distance-threshold compare cast in `pppFrameCallBackDistance` to align with the corrected field type.

## Functions improved
- Unit: `main/pppCallBackDistance`
- Symbol: `pppFrameCallBackDistance`

## Match evidence
- `pppFrameCallBackDistance`: **34.367645% -> 43.235294%** (`+8.867649`)
- `pppConstructCallBackDistance`: 74.48485% -> 74.48485% (no regression)
- Build verification: `ninja` completed successfully.

## Plausibility rationale
- This callback parameter appears to come from serialized effect script data, where a leading control word followed by a float threshold and short work/index value is a plausible original packing.
- The previous layout forced less plausible access behavior for this path; the new layout improves structural alignment with expected callback usage while keeping source readability intact.

## Technical details
- Verified changes using `build/tools/objdiff-cli diff -p . -u main/pppCallBackDistance -o - pppFrameCallBackDistance` before and after edit.
- Improvement is symbol-local and tied to generated instruction alignment, not formatting-only changes.
