### PR TITLE
main/pppScreenQuake: align frame step data layout and quake call

### DIFF
--- a/include/ffcc/pppScreenQuake.h
+++ b/include/ffcc/pppScreenQuake.h
@@ -10,12 +10,19 @@ typedef struct {
 } pppScreenQuake;
 
 typedef struct {
-    int m_dataValIndex;
     int m_graphId;
-    int m_arg3;
+    float m_dataValIndex;
     float m_initWOrk;
     float m_stepValue;
-    float *m_payload;
+    float m_arg3;
+    float m_initWOrk2;
+    float m_stepValue2;
+    float m_arg4;
+    float m_initWOrk3;
+    float m_stepValue3;
+    float m_quakeParam0;
+    float m_quakeParam1;
+    float m_quakeParam2;
 } UnkB;
 
 typedef struct {

--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -87,24 +87,20 @@ void pppFrameScreenQuake(pppScreenQuake *quake, UnkB *param2, UnkC *param3)
 	if (DAT_8032ed70 == 0) {
 		float *value = (float *)((int)(&quake->field0_0x0 + 2) + *param3->m_serializedDataOffsets);
 		
-		CalcGraphValue((float)param2->m_dataValIndex, (_pppPObject*)&quake->field0_0x0, param2->m_graphId, 
+		CalcGraphValue(param2->m_dataValIndex, (_pppPObject*)&quake->field0_0x0, param2->m_graphId, 
 		               value, value + 1, value + 2, &param2->m_initWOrk, &param2->m_stepValue);
 		               
-		CalcGraphValue((float)param2->m_arg3, (_pppPObject*)&quake->field0_0x0, param2->m_graphId,
-		               value + 3, value + 4, value + 5, param2->m_payload, param2->m_payload + 4);
+		CalcGraphValue(param2->m_arg3, (_pppPObject*)&quake->field0_0x0, param2->m_graphId,
+		               value + 3, value + 4, value + 5, &param2->m_initWOrk2, &param2->m_stepValue2);
 		               
-		CalcGraphValue(*(float*)(param2->m_payload + 8), (_pppPObject*)&quake->field0_0x0, param2->m_graphId,
-		               value + 6, value + 7, value + 8, param2->m_payload + 0xc, param2->m_payload + 0x10);
+		CalcGraphValue(param2->m_arg4, (_pppPObject*)&quake->field0_0x0, param2->m_graphId,
+		               value + 6, value + 7, value + 8, &param2->m_initWOrk3, &param2->m_stepValue3);
 		               
-		CameraPcs.SetQuakeParameter((int)*value, (int)value[3], (short)value[6], 
-		                            (short)*(float*)(param2->m_payload + 0x14),
-		                            *(float*)(param2->m_payload + 0x18),
-		                            *(float*)(param2->m_payload + 0x1c),
-		                            *(float*)(param2->m_payload + 0x20),
-		                            *(float*)(param2->m_payload + 0x24),
-		                            *(float*)(param2->m_payload + 0x28),
-		                            *(float*)(param2->m_payload + 0x2c),
-		                            1);
+		SetQuakeParameter__10CCameraPcsFiissffffffi(&CameraPcs, 1, 0, 0, 0,
+		                                            *value, value[3], value[6],
+		                                            param2->m_quakeParam0,
+		                                            param2->m_quakeParam1,
+		                                            param2->m_quakeParam2, 1);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Updated `UnkB` in `pppScreenQuake` to reflect observed PAL field ordering and scalar types used by `pppFrameScreenQuake`.
- Reworked `pppFrameScreenQuake` to use in-struct float work values instead of an indirect payload pointer path.
- Switched quake application to the direct `SetQuakeParameter__10CCameraPcsFiissffffffi` call with argument pattern matching the target call shape.

## Functions improved
- Unit: `main/pppScreenQuake`
- Function: `pppFrameScreenQuake`

## Match evidence
Measured with:
`build/tools/objdiff-cli diff -1 build/GCCP01/obj/pppScreenQuake.o -2 build/GCCP01/src/pppScreenQuake.o -o - pppFrameScreenQuake`

- Before: `23.064516%`
- After: `74.8871%`
- Target size: `248` bytes
- Current size: `244` bytes

## Plausibility rationale
- The change is type/layout correction driven by observed access patterns (float loads/work buffers at contiguous offsets), not artificial control-flow coaxing.
- The resulting source is simpler and consistent with other ppp frame-step data usage: sequential scalar fields and direct work-state references.
- Quake parameters are now passed in a straightforward, human-written form aligned with the existing explicit symbol declaration.

## Technical details
- Removed integer-to-float conversion artifacts by changing `m_dataValIndex`/`m_arg3` path to direct float fields.
- Replaced `m_payload` pointer indirection with explicit struct work fields (`m_initWOrk2`/`m_stepValue2`, `m_initWOrk3`/`m_stepValue3`).
- Set quake function scalar params from local graph outputs (`value`, `value[3]`, `value[6]`) plus contiguous quake parameter fields (`0x28..0x30` equivalent).
