### PR TITLE
Improve decomp match for pppDrawMatrixWood

### DIFF
--- a/src/pppDrawMatrixWood.cpp
+++ b/src/pppDrawMatrixWood.cpp
@@ -13,21 +13,17 @@
  */
 void pppDrawMatrixWood(_pppPObject* param_1)
 {
-    PSMTXScaleApply(
-        (MtxPtr)((char*)param_1 + 0x10),
-        (MtxPtr)((char*)param_1 + 0x40),
-        *(float*)((char*)pppMngStPtr + 0x28),
-        *(float*)((char*)pppMngStPtr + 0x2C),
-        *(float*)((char*)pppMngStPtr + 0x30)
-    );
+	PSMTXScaleApply(
+		param_1->m_localMatrix.value,
+		param_1[1].m_localMatrix.value,
+		(pppMngStPtr->m_scale).x,
+		(pppMngStPtr->m_scale).y,
+		(pppMngStPtr->m_scale).z
+	);
 
-    *(float*)((char*)param_1 + 0x4C) = *(float*)((char*)param_1 + 0x1C);
-    *(float*)((char*)param_1 + 0x5C) = *(float*)((char*)param_1 + 0x2C);
-    *(float*)((char*)param_1 + 0x6C) = *(float*)((char*)param_1 + 0x3C);
+	param_1[1].m_localMatrix.value[0][3] = (param_1->m_localMatrix).value[0][3];
+	param_1[1].m_localMatrix.value[1][3] = (param_1->m_localMatrix).value[1][3];
+	param_1[1].m_localMatrix.value[2][3] = (param_1->m_localMatrix).value[2][3];
 
-    PSMTXConcat(
-        ppvWorldMatrixWood,
-        (MtxPtr)((char*)param_1 + 0x40),
-        (MtxPtr)((char*)param_1 + 0x40)
-    );
+	PSMTXConcat(ppvWorldMatrixWood, param_1[1].m_localMatrix.value, param_1[1].m_localMatrix.value);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppDrawMatrixWood` to use typed `_pppPObject` field access (`m_localMatrix`) instead of byte-offset pointer casts.
- Switched scale reads to `pppMngStPtr->m_scale` members and kept matrix calls in the same high-level structure.
- Preserved behavior while making source layout closer to likely original code style used by neighboring `ppp*` draw functions.

## Functions improved
- Unit: `main/pppDrawMatrixWood`
- Symbol: `pppDrawMatrixWood`

## Match evidence
- Before: **79.6%** (from `tools/agent_select_target.py` target report)
- After: **99.39286%** (`build/tools/objdiff-cli diff -p . -u main/pppDrawMatrixWood -o - pppDrawMatrixWood`)
- Remaining diffs are limited to argument-level mismatches (no insertion/deletion blocks in symbol diff).

## Plausibility rationale
- The new implementation matches existing project idioms in similar particle matrix functions (`pppWDrawMatrixFront`, `pppDrawMatrixFront`) by using typed struct fields and direct matrix component assignments.
- This is more plausible as original source than raw `(char*)` offset arithmetic while still producing much closer machine code.

## Technical details
- Key improvement came from replacing cast-heavy expressions with direct field/member expressions that better guide Metrowerks register and argument setup.
- Matrix translation components are copied through `param_1[1].m_localMatrix.value[..][3]` assignments, then concatenated in place with `PSMTXConcat`.
- Build verification: `ninja` completed successfully.
