### PR TITLE
Improve pppRandUpFloat match with unified update flow

### DIFF
--- a/src/pppRandUpFloat.cpp
+++ b/src/pppRandUpFloat.cpp
@@ -35,11 +35,12 @@ void pppRandUpFloat(void* param1, void* param2, void* param3) {
         return;
     }
 
-    int* p1 = (int*)param1;
+    char* base = (char*)param1;
     RandUpFloatParam* p2 = (RandUpFloatParam*)param2;
     RandUpFloatCtx* p3 = (RandUpFloatCtx*)param3;
+    float* valuePtr;
 
-    int id = p1[3];
+    int id = *(int*)(base + 0xC);
     if (id == 0) {
         float value = RandF__5CMathFv(&math);
 
@@ -47,27 +48,19 @@ void pppRandUpFloat(void* param1, void* param2, void* param3) {
             value = (value + RandF__5CMathFv(&math)) * lbl_8032FFF8;
         }
 
-        int outIndex = *p3->outputOffset;
-        float* outValue = (float*)((char*)param1 + outIndex + 0x80);
-        *outValue = value;
-        return;
+        valuePtr = (float*)(base + *p3->outputOffset + 0x80);
+        *valuePtr = value;
+    } else {
+        if (p2->targetId != id) {
+            return;
+        }
+        valuePtr = (float*)(base + *p3->outputOffset + 0x80);
     }
 
-    if (p2->targetId != id) {
-        return;
-    }
-
-    int outIndex = *p3->outputOffset;
-    float* outValue = (float*)((char*)param1 + outIndex + 0x80);
-
-    int sourceIndex = p2->sourceOffset;
     float* source = &lbl_801EADC8;
-    if (sourceIndex != -1) {
-        source = (float*)((char*)param1 + sourceIndex + 0x80);
+    if (p2->sourceOffset != -1) {
+        source = (float*)(base + p2->sourceOffset + 0x80);
     }
 
-    float blend = p2->blend;
-    float current = *source;
-    float output = *outValue;
-    *source = current + (blend * output);
+    *source = *source + (p2->blend * *valuePtr);
 }


### PR DESCRIPTION
## Summary
- Refactored `pppRandUpFloat` to use a single `valuePtr` flow shared by both `id == 0` and `id != 0` paths.
- Removed the early return after random-value generation so source accumulation happens in the shared tail path.
- Simplified pointer math to use a single `base` pointer and direct field reads for state/source offsets.

## Functions improved
- Unit: `main/pppRandUpFloat`
- Symbol: `pppRandUpFloat`

## Match evidence
- Before: `75.30303%`
- After: `83.56061%`
- Absolute gain: `+8.25758%`
- Instruction diff markers reduced from `30` to `25` (objdiff symbol-level diff).

## Plausibility rationale
- The new structure matches the existing `pppRandUp*` family pattern in the codebase: compute/store output value first, then apply the source update in a shared tail block.
- This removes a decompilation artifact style early return and yields more natural original-source control flow.

## Technical details
- Retained behavior for `lbl_8032ED70` guard and `targetId` filtering.
- Kept source fallback to `lbl_801EADC8` for `sourceOffset == -1`.
- Used a common `float* valuePtr` so both branches feed the same accumulation expression (`*source = *source + (blend * *valuePtr)`).

Validation run:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppRandUpFloat -o - pppRandUpFloat`
