### PR TITLE
main/pppFilter: improve pppRenderFilter by correcting data layout

### DIFF
--- a/include/ffcc/pppFilter.h
+++ b/include/ffcc/pppFilter.h
@@ -6,6 +6,7 @@ struct pppFilter {
 };
 
 struct UnkB {
+    unsigned int m_unk0;
     unsigned int m_dataValIndex;
 };
 

--- a/src/pppFilter.cpp
+++ b/src/pppFilter.cpp
@@ -6,7 +6,7 @@ class CMaterialSet;
 struct _pppEnvStLite {
     void* m_stagePtr;
     CMaterialSet* m_materialSetPtr;
-    CMapMesh* m_mapMeshPtr;
+    CMapMesh** m_mapMeshPtr;
 };
 
 extern _pppEnvStLite* pppEnvStPtr;
@@ -73,7 +73,7 @@ void pppRenderFilter(pppFilter* pppFilterObj, UnkB* param_2, UnkC* param_3)
 
 	int textureIndex = 0;
 	int textureBase = GetTexture__8CMapMeshFP12CMaterialSetRi(
-	    &pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex], pppEnvStPtr->m_materialSetPtr, textureIndex);
+	    pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex], pppEnvStPtr->m_materialSetPtr, textureIndex);
 	RenderTextureQuad__5CUtilFffffP9_GXTexObjP5Vec2dP5Vec2dP8_GXColor14_GXBlendFactor14_GXBlendFactor(
 	    &DAT_8032ec70, FLOAT_803320c8, FLOAT_803320c8, FLOAT_803320cc, FLOAT_803320d0, (_GXTexObj*)(textureBase + 0x28),
 	    0, 0, (_GXColor*)((char*)pppFilterObj + serializedOffset + 0x88), GX_BL_SRCALPHA, GX_BL_INVSRCALPHA);


### PR DESCRIPTION
## Summary
- Corrected `UnkB` layout so `m_dataValIndex` is read from offset `0x4`.
- Corrected `_pppEnvStLite::m_mapMeshPtr` to `CMapMesh**` and updated the call site to index pointer entries directly.
- Kept functional behavior intact while aligning generated access patterns with expected assembly.

## Functions improved
- Unit: `main/pppFilter`
- Symbol: `pppRenderFilter`
  - Before: `75.81633%`
  - After: `77.18367%`

## Match evidence
- `objdiff-cli diff -p . -u main/pppFilter -o -` now reports `pppRenderFilter` at `77.18367%` (previous run was `75.81633%`).
- Improvement is tied to real instruction-shape alignment from corrected field offsets/indirection (not renaming or formatting changes).

## Plausibility rationale
- These changes represent more plausible original source structure:
  - the filter input index appears to be a second word field,
  - and map-mesh storage appears to be pointer table based (indexed then dereferenced),
  which is consistent with the observed generated addressing pattern.

## Technical details
- `UnkB` gained a leading unknown word (`m_unk0`) before `m_dataValIndex`.
- `_pppEnvStLite::m_mapMeshPtr` changed from `CMapMesh*` to `CMapMesh**`.
- `GetTexture__8CMapMeshFP12CMaterialSetRi` call now uses `pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex]` instead of taking the address of an element from a flat object array.
