### PR TITLE
Implement pppFrameAlignmentScale callback logic

### DIFF
--- a/include/ffcc/pppAlignmentScale.h
+++ b/include/ffcc/pppAlignmentScale.h
@@ -1,11 +1,20 @@
 #ifndef _FFCC_PPPALIGNMENTSCALE_H_
 #define _FFCC_PPPALIGNMENTSCALE_H_
 
+struct pppAlignmentScale;
+
+struct pppAlignmentScaleData
+{
+    float m_unk0x0;
+    float m_unk0x4;
+    float m_unk0x8;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 void pppConstructAlignmentScale(void);
-void pppFrameAlignmentScale(void);
+struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale*, struct pppAlignmentScaleData*);
 
 #ifdef __cplusplus
 }

--- a/src/pppAlignmentScale.cpp
+++ b/src/pppAlignmentScale.cpp
@@ -1,21 +1,84 @@
 #include "ffcc/pppAlignmentScale.h"
+#include "ffcc/partMng.h"
 
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void pppConstructAlignmentScale(void)
-{
-	// TODO
+#include <dolphin/mtx.h>
+
+extern int DAT_8032ed70;
+extern float FLOAT_80331920;
+extern float FLOAT_80331924;
+extern struct _pppMngSt* pppMngStPtr;
+
+extern class CCameraPcs {
+public:
+    float _224_4_;
+    float _228_4_;
+    float _232_4_;
+} CameraPcs;
+
+extern "C" {
+void* pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8010992c
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameAlignmentScale(void)
+void pppConstructAlignmentScale(void)
 {
-	// TODO
+    return;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80109810
+ * PAL Size: 284b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* alignmentScale, struct pppAlignmentScaleData* data)
+{
+    float scale;
+    float distanceScale;
+    double distance;
+    Vec cameraPos;
+    Vec objPos;
+    Mtx scaleMtx;
+
+    if (DAT_8032ed70 == 0) {
+        cameraPos.x = CameraPcs._224_4_;
+        cameraPos.y = CameraPcs._228_4_;
+        cameraPos.z = CameraPcs._232_4_;
+
+        objPos.x = pppMngStPtr->m_matrix.value[0][3];
+        objPos.y = pppMngStPtr->m_matrix.value[1][3];
+        objPos.z = pppMngStPtr->m_matrix.value[2][3];
+
+        distance = PSVECDistance(&cameraPos, &objPos);
+        distanceScale = (float)(distance / (double)data->m_unk0x4);
+        scale = FLOAT_80331920;
+        if (scale < distanceScale) {
+            scale = (distanceScale - FLOAT_80331920) * data->m_unk0x8 + FLOAT_80331920;
+        }
+
+        PSMTXScale(scaleMtx, scale, scale, scale);
+
+        pppMngStPtr->m_matrix.value[0][3] = FLOAT_80331924;
+        pppMngStPtr->m_matrix.value[1][3] = FLOAT_80331924;
+        pppMngStPtr->m_matrix.value[2][3] = FLOAT_80331924;
+        PSMTXConcat(scaleMtx, pppMngStPtr->m_matrix.value, pppMngStPtr->m_matrix.value);
+        pppMngStPtr->m_matrix.value[0][3] = objPos.x;
+        pppMngStPtr->m_matrix.value[1][3] = objPos.y;
+        pppMngStPtr->m_matrix.value[2][3] = objPos.z;
+
+        alignmentScale = (struct pppAlignmentScale*)pppSetFpMatrix__FP9_pppMngSt(pppMngStPtr);
+    }
+
+    return alignmentScale;
 }


### PR DESCRIPTION
## Summary
- Implemented `pppFrameAlignmentScale` in `src/pppAlignmentScale.cpp` using the Ghidra-guided control flow and math operations.
- Added minimal parameter struct typing for this script callback in `include/ffcc/pppAlignmentScale.h`.
- Filled PAL metadata headers for `pppConstructAlignmentScale` and `pppFrameAlignmentScale`.

## Functions improved
- Unit: `main/pppAlignmentScale`
- Symbol: `pppFrameAlignmentScale`
  - Before: `1.4084507%`
  - After: `80.07042%`
  - Current output size: `280b` vs target `284b`
- Symbol: `pppConstructAlignmentScale`
  - Match: `100%` (4b)

## Match evidence
- Built with `ninja` and verified with:
  - `tools/objdiff-cli diff -p . -u main/pppAlignmentScale -o - pppFrameAlignmentScale`
- The previous symbol was effectively a 4-byte stub (`blr`) and now emits a full body with matrix/scale operations and expected function calls.

## Plausibility rationale
- The implementation follows the established ppp callback pattern already used in this repo:
  - gate on `DAT_8032ed70`
  - operate on `pppMngStPtr->m_matrix`
  - finalize with `pppSetFpMatrix__FP9_pppMngSt`
- The code uses existing engine math APIs (`PSVECDistance`, `PSMTXScale`, `PSMTXConcat`) and preserves object translation while applying scale, which is plausible original gameplay/render pipeline behavior.

## Technical details
- Computed camera-to-object distance and normalized by callback parameter `m_unk0x4`.
- Applied thresholded scaling using constants `FLOAT_80331920` / `FLOAT_80331924` and blend factor `m_unk0x8`.
- Temporarily zeroed translation before matrix concat, then restored original translation components.
