### PR TITLE
p_system: implement __sinit_p_system_cpp static wiring

### DIFF
--- a/src/p_system.cpp
+++ b/src/p_system.cpp
@@ -2,7 +2,12 @@
 #include "ffcc/pad.h"
 #include "ffcc/p_dbgmenu.h"
 
+extern unsigned int lbl_801EA0D0[];
+extern unsigned int lbl_801EA0DC[];
+extern unsigned int lbl_801EA0E8[];
+extern unsigned int lbl_801EA270[];
 extern unsigned char lbl_801EA0F4[];
+extern unsigned int lbl_8032ED08;
 
 /*
  * --INFO--
@@ -13,9 +18,24 @@ extern unsigned char lbl_801EA0F4[];
  * JP Address: TODO
  * JP Size: TODO
  */
-void __sinit_p_system_cpp(void)
+extern "C" void __sinit_p_system_cpp(void)
 {
-	// TODO: Static initialization
+    unsigned int* table = reinterpret_cast<unsigned int*>(lbl_801EA0F4);
+    unsigned int* desc0 = lbl_801EA0D0;
+    unsigned int* desc1 = lbl_801EA0DC;
+    unsigned int* desc2 = lbl_801EA0E8;
+
+    lbl_8032ED08 = reinterpret_cast<unsigned int>(lbl_801EA270);
+
+    table[1] = desc0[0];
+    table[2] = desc0[1];
+    table[3] = desc0[2];
+    table[4] = desc1[0];
+    table[5] = desc1[1];
+    table[6] = desc1[2];
+    table[7] = desc2[0];
+    table[8] = desc2[1];
+    table[9] = desc2[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__sinit_p_system_cpp` in `src/p_system.cpp` using existing descriptor tables and process table wiring.
- Switched `__sinit_p_system_cpp` to `extern "C"` so the emitted symbol name matches the target object.
- Added explicit `lbl_*` extern declarations used by the static init routine.

## Functions improved
- Unit: `main/p_system`
- Symbol: `__sinit_p_system_cpp` (PAL 0x80047d7c, 132b)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/p_system -o -`
- Unit `.text` match: **54.325844% -> 87.41573%**
- `__sinit_p_system_cpp` match: previously unresolved on current side (mangled as `__sinit_p_system_cpp__Fv`), now resolved and matching at **97.878784%**.
- `ninja` build passes.

## Plausibility rationale
- The change models expected static module initialization behavior for this codebase: binding the process descriptor pointer and copying descriptor entries into the process table.
- No contrived control-flow tricks were introduced; implementation follows existing repo patterns used in other `__sinit_*` modules.

## Technical details
- `lbl_8032ED08` is set to `lbl_801EA270`.
- Descriptor triplets from `lbl_801EA0D0`, `lbl_801EA0DC`, and `lbl_801EA0E8` are copied into `lbl_801EA0F4` entries `[1..9]`.
- This aligns with target relocation behavior observed in objdiff (`sda21` store + table copy sequence).
