### PR TITLE
pppLaser: first-pass decomp for pppConstructLaser

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -1,6 +1,22 @@
 #include "ffcc/pppLaser.h"
+#include "ffcc/math.h"
+#include "ffcc/p_game.h"
+#include "ffcc/partMng.h"
 
 extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
+extern struct _pppMngSt* pppMngStPtr;
+extern CMath Math;
+extern f32 FLOAT_80333428;
+extern f32 FLOAT_80333448;
+extern f32 FLOAT_8033345c;
+
+extern "C" {
+f32 RandF__5CMathFf(f32, CMath*);
+int GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(CGame*, PPPIFPARAM*, int*, int*);
+void GetTargetCursor__5CGameFiR3VecR3Vec(CGame*, int, Vec*, Vec*);
+void* GetPartyObj__5CGameFi(CGame*, int);
+void pppStopSe__FP9_pppMngStP7PPPSEST(_pppMngSt*, PPPSEST*);
+}
 
 /*
  * --INFO--
@@ -13,12 +29,14 @@ extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
  */
 void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
-    f32 fVar1 = 1.0f;
-    int iVar2 = param_2->m_serializedDataOffsets[2];
-    f32 *pfVar3 = (f32*)((u8*)&pppLaser->field_0x88 + iVar2);
-    
-    // Initialize all float values to 1.0 or 0.0
-    *pfVar3 = 1.0f;
+    f32 fVar1 = FLOAT_80333428;
+    f32* pfVar3 = (f32*)((u8*)&pppLaser->field_0x88 + param_2->m_serializedDataOffsets[2]);
+    int local_24;
+    int local_28;
+    Vec local_20;
+    Vec local_14;
+
+    *pfVar3 = FLOAT_80333428;
     pfVar3[1] = fVar1;
     pfVar3[2] = fVar1;
     pfVar3[3] = fVar1;
@@ -29,27 +47,47 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
     pfVar3[8] = fVar1;
     pfVar3[9] = fVar1;
     pfVar3[10] = fVar1;
-    
-    // Initialize byte values to 0
+
     *((u8*)pfVar3 + 0x2c) = 0;
     *((u8*)pfVar3 + 0x2d) = 0;
     *((u8*)pfVar3 + 0x2e) = 0;
     *((u16*)pfVar3 + 0x18) = 0;
-    *((u16*)pfVar3 + 0x1a) = 0;
     *((u16*)pfVar3 + 0x19) = 0;
-    
-    // Set some random value and flags
-    pfVar3[14] = 50.0f; // simplified random
+    *((u16*)pfVar3 + 0x1a) = 0;
+
+    pfVar3[14] = RandF__5CMathFf(FLOAT_8033345c, &Math);
     *((u8*)pfVar3 + 0x4c) = 1;
-    
-    // Set distance value
-    pfVar3[15] = 0.0f;
+
+    if (GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(&Game.game, (PPPIFPARAM*)((u8*)pppMngStPtr + 0x130), &local_24, &local_28) == 0) {
+        pfVar3[15] = FLOAT_80333448;
+        *(u8*)((u8*)pppMngStPtr + 0x118) = 1;
+        pppStopSe__FP9_pppMngStP7PPPSEST(pppMngStPtr, (PPPSEST*)((u8*)pppMngStPtr + 0x11c));
+    } else {
+        GetTargetCursor__5CGameFiR3VecR3Vec(&Game.game, local_28, (Vec*)(pfVar3 + 0x10), &local_20);
+
+        {
+            u8* partyObj = (u8*)GetPartyObj__5CGameFi(&Game.game, local_28);
+            local_14.x = *(f32*)(partyObj + 0x15c);
+            local_14.y = *(f32*)(partyObj + 0x160);
+            local_14.z = *(f32*)(partyObj + 0x164);
+        }
+
+        if (local_24 == 0x200) {
+            pfVar3[15] = PSVECDistance((Vec*)(pfVar3 + 0x10), &local_14);
+        } else {
+            pfVar3[15] = FLOAT_80333448;
+        }
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 801766a8
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConstruct2Laser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {


### PR DESCRIPTION
## Summary
- Reworked `pppConstructLaser` in `src/pppLaser.cpp` from placeholder initialization into a decomp-aligned first pass.
- Added explicit constructor-side state initialization for the serialized laser block, including byte/short flag fields and random angle setup.
- Added particle-special handling path and fallback logic that populates target/cursor-derived distance state.
- Filled in PAL metadata for `pppConstruct2Laser` (`801766a8`, `68b`).

## Functions improved
- Unit: `main/pppLaser`
- Symbol: `pppConstructLaser`

## Match evidence
- Selector baseline before edits: `pppConstructLaser` at `23.8%` (from `python3 tools/agent_select_target.py`).
- Post-change objdiff (`build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppConstructLaser`):
  - `pppConstructLaser`: `59.02381%`
  - (`pppConstruct2Laser`: `84.05882%`, `pppDestructLaser`: `88.52631%` in same unit snapshot)
- Build verified with `ninja`.

## Plausibility rationale
- Changes focus on source-level behavior expected for a particle laser constructor: deterministic field initialization, runtime randomization through project math API, and game-state driven special-target setup.
- No contrived control-flow tricks or artificial temporaries were added solely to game the compiler.
- Logic aligns with neighboring particle units and known symbol relationships (`CGame`, `_pppMngSt`, `PPPIFPARAM`).

## Technical details
- Introduced mangled extern callsites used by the constructor path:
  - `RandF__5CMathFf`
  - `GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi`
  - `GetTargetCursor__5CGameFiR3VecR3Vec`
  - `GetPartyObj__5CGameFi`
  - `pppStopSe__FP9_pppMngStP7PPPSEST`
- Kept `pppFrameLaser` / `pppRenderLaser` untouched in this PR to isolate constructor matching progress and simplify review.
