### PR TITLE
pppLocationTitle: implement pppRenderLocationTitle render path

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -1,6 +1,14 @@
 #include "ffcc/pppLocationTitle.h"
 #include "ffcc/pppPart.h"
 
+extern void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(void*, void*, float,
+                                                                       unsigned char, unsigned char,
+                                                                       unsigned char, unsigned char,
+                                                                       unsigned char, unsigned char,
+                                                                       unsigned char);
+extern void pppSetBlendMode__FUc(unsigned char);
+extern void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, unsigned char);
+
 /*
  * --INFO--
  * PAL Address: 0x800d92cc
@@ -68,6 +76,63 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, Un
  */
 void pppRenderLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, UnkC* param_3)
 {
-    // TODO: Implementation with rendering operations
-    // Based on Ghidra decompilation with GX calls and matrix operations
+    int serializedOffset = *param_3->m_serializedDataOffsets;
+
+    if ((u16)param_2->m_dataValIndex == 0xFFFF) {
+        return;
+    }
+
+    u32 graphId = *(u32*)((u8*)&pppLocationTitle->field0_0x0 + 0);
+    int frameStep = (int)(graphId >> 12);
+    if (((int)graphId < 0) && ((graphId & 0xFFF) != 0)) {
+        frameStep++;
+    }
+
+    u8* state = (u8*)&pppLocationTitle->field0_0x0 + 8 + serializedOffset;
+    Vec* source = *(Vec**)state;
+    u16 sourceCount = *(u16*)(state + 4);
+    u8* payload = (u8*)param_2->m_payload;
+    int fadeDivisor = -1;
+    if (*(u16*)(payload + 10) <= frameStep) {
+        fadeDivisor = *(u16*)(payload + 12) + frameStep - *(u16*)(payload + 10);
+    }
+
+    long** shapeTable = *(long***)((u8*)pppEnvStPtr + 0x0C);
+    long* shape = shapeTable[param_2->m_dataValIndex];
+    u8 blend = *((u8*)&param_2->m_stepValue + 1);
+
+    for (int i = 0; i < sourceCount; i++) {
+        Mtx modelMtx;
+        Vec transformedPos;
+        u32 packedColor;
+
+        PSMTXIdentity(modelMtx);
+        modelMtx[2][2] = ((float*)source)[4];
+        modelMtx[0][0] = pppMngStPtr->m_scale.x * modelMtx[2][2];
+        modelMtx[1][1] = pppMngStPtr->m_scale.y * modelMtx[2][2];
+        modelMtx[2][2] = pppMngStPtr->m_scale.z * modelMtx[2][2];
+
+        PSMTXMultVec(ppvCameraMatrix0, source, &transformedPos);
+        modelMtx[0][3] = transformedPos.x;
+        modelMtx[1][3] = transformedPos.y;
+        modelMtx[2][3] = transformedPos.z;
+
+        pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+            (u8*)source + 0x0C, NULL, 0.0f, 0, 0, 0, 0, 0, 1, 0);
+
+        if (fadeDivisor >= 0) {
+            u8 alpha = *((u8*)source + 0x0F);
+            *((u8*)source + 0x0F) = alpha - (u8)(alpha / fadeDivisor);
+        }
+
+        packedColor = *(u32*)((u8*)source + 0x0C);
+        GXColor chanColor;
+        *(u32*)&chanColor = packedColor;
+        GXSetChanMatColor(GX_COLOR0A0, chanColor);
+        GXLoadPosMtxImm(modelMtx, 0);
+        pppSetBlendMode__FUc(blend);
+        pppDrawShp__FPlsP12CMaterialSetUc(shape, *(short*)((u8*)source + 0x18),
+                                          pppEnvStPtr->m_materialSetPtr, blend);
+        source = (Vec*)((u8*)source + 0x1C);
+    }
 }


### PR DESCRIPTION
## Summary
Implemented `pppRenderLocationTitle` in `src/pppLocationTitle.cpp` by porting the decompiled render loop to real code:
- Reads per-instance runtime state from serialized offsets
- Computes frame window/fade divisor from graph frame and payload thresholds
- Builds per-particle model matrix and camera-space position
- Applies draw environment and blend mode
- Draws shape entries from particle color table with per-entry alpha decay

## Functions improved
Unit: `main/pppLocationTitle`
- `pppRenderLocationTitle` (PAL 0x800d8c1c, 400b)
  - Before: **1.00%**
  - After: **51.64%**
- `pppFrameLocationTitle` unchanged (0.3257329%)

## Match evidence
Objdiff command used:
- `build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o - pppRenderLocationTitle`

Measured with objdiff JSON:
- Before (`/tmp/pppLocationTitle_render_before.json`): `match_percent = 1.0`
- After (`/tmp/pppLocationTitle_render_after.json`): `match_percent = 51.64`

Build validation:
- `ninja` passes successfully after the change.

## Plausibility rationale
This change follows source-plausible behavior for FFCC particle units:
- Uses the unit’s existing runtime data layout and serialized offset table
- Uses standard engine matrix/vector helpers (`PSMTXIdentity`, `PSMTXMultVec`, `GXLoadPosMtxImm`)
- Uses existing render pipeline calls (`pppSetDrawEnv`, `pppSetBlendMode`, `pppDrawShp`)
- Keeps logic in natural gameplay/render terms (frame-based fade, per-instance draw), rather than introducing contrived compiler-only tricks

## Technical details
- Implemented with direct pointer/offset access where project structs are still incomplete, matching existing decomp style in this codebase.
- Preserved symbol-level call patterns used by nearby ppp units for draw env/blend/shape dispatch.
