### PR TITLE
GXTransform: improve GXGetViewportv object match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -471,16 +471,12 @@ void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz,
 void GXGetViewportv(f32* vp) {
     ASSERTMSGLINE(968, vp, "GXGet*: invalid null pointer");
 
-#if DEBUG
-    vp[0] = __GXData->vpLeft;
-    vp[1] = __GXData->vpTop;
-    vp[2] = __GXData->vpWd;
-    vp[3] = __GXData->vpHt;
-    vp[4] = __GXData->vpNearz;
-    vp[5] = __GXData->vpFarz;
-#else
-    Copy6Floats(&__GXData->vpLeft, vp);
-#endif
+    ((u32*)vp)[0] = ((u32*)&__GXData->vpLeft)[0];
+    ((u32*)vp)[1] = ((u32*)&__GXData->vpLeft)[1];
+    ((u32*)vp)[2] = ((u32*)&__GXData->vpLeft)[2];
+    ((u32*)vp)[3] = ((u32*)&__GXData->vpLeft)[3];
+    ((u32*)vp)[4] = ((u32*)&__GXData->vpLeft)[4];
+    ((u32*)vp)[5] = ((u32*)&__GXData->vpLeft)[5];
 }
 
 #define GX_WRITE_XF_REG_F_(addr, value) \


### PR DESCRIPTION
## Summary
- Reworked GXGetViewportv in src/gx/GXTransform.c to perform explicit 32-bit word copies from __GXData->vpLeft..vpFarz into the output buffer.
- Removed the previous DEBUG/non-DEBUG split for this function so the generated code follows a single raw-copy path.

## Functions improved
- Unit: main/gx/GXTransform
- Symbol: GXGetViewportv

## Match evidence
- GXGetViewportv: 33.92857% -> 48.214287%
- Unit .text (main/gx/GXTransform): 70.15854% -> 70.56504%
- Verified with: build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o -

## Plausibility rationale
- GXGetViewportv is a viewport readback helper; copying raw 32-bit fields is plausible original SDK-style source and aligns with the decomp reference shape for this function.
- The change avoids contrived control-flow tricks and remains straightforward while improving assembly alignment.

## Technical details
- The previous float-path implementation generated a different load/store shape.
- Casting to u32* for both destination and source fields nudges codegen toward integer word moves, yielding a closer instruction sequence and improved objdiff match.
