### PR TITLE
mesmenu: fix SetPos signature to match Fff symbol

### DIFF
--- a/include/ffcc/mesmenu.h
+++ b/include/ffcc/mesmenu.h
@@ -20,7 +20,7 @@ public:
     void Open(char*, int, int, int, int, int, int);
     void CloseRequest(int);
     void close(int);
-    void SetPos(float, float, float);
+    void SetPos(float, float);
 };
 
 #endif // _FFCC_MESMENU_H_

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -129,7 +129,7 @@ void CMesMenu::CloseRequest(int)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMesMenu::SetPos(float x, float y, float z)
+void CMesMenu::SetPos(float x, float y)
 {
 	*(float*)((char*)this + 0x3d74) = x;
 	*(float*)((char*)this + 0x3d78) = y;


### PR DESCRIPTION
## Summary
- Corrected `CMesMenu::SetPos` signature from three floats to two floats in declaration and definition.
- Kept function behavior unchanged (stores `x` and `y` to object fields at `0x3d74` and `0x3d78`).

## Functions improved
- Unit: `main/mesmenu`
- Symbol: `SetPos__8CMesMenuFff`
- Before: selector showed `SetPos__8CMesMenuFff` at `0.0%` in `main/mesmenu` (`1/13` functions matched in unit).
- After: `SetPos__8CMesMenuFff` is `100.0%` (`size: 12`), and unit moved to `2/13` functions matched.

## Match evidence
- `ninja` rebuilt successfully.
- `build/tools/objdiff-cli diff -p . -u main/mesmenu -o - SetPos__8CMesMenuFff` now shows exact instruction sequence match for the symbol (`stfs`, `stfs`, `blr`).
- `build/GCCP01/report.json` now reports:
  - `main/mesmenu` `matched_functions`: `2`
  - `SetPos__8CMesMenuFff` `fuzzy_match_percent`: `100.0`

## Plausibility rationale
- The MAP/symbol naming expects `SetPos__8CMesMenuFff` (two float args).
- Using the corresponding C++ signature is the plausible original source form and removes a signature mismatch that prevented symbol-level matching.
- No coercive compiler tricks were introduced; this is a straightforward ABI/signature correction.

## Technical details
- Updated:
  - `include/ffcc/mesmenu.h`
  - `src/mesmenu.cpp`
- Change is minimal and localized to type/signature alignment for the target function.
