### PR TITLE
RedMemory: implement getter stubs and align pointer delete overloads

### DIFF
--- a/include/ffcc/RedSound/RedMemory.h
+++ b/include/ffcc/RedSound/RedMemory.h
@@ -3,10 +3,10 @@
 
 int RedNew(int);
 void RedDelete(int);
-void RedDelete(unsigned int);
+void RedDelete(void*);
 int RedNewA(int, int, int);
 void RedDeleteA(int);
-void RedDeleteA(unsigned int);
+void RedDeleteA(void*);
 
 class CRedMemory
 {
@@ -15,12 +15,12 @@ public:
 	~CRedMemory();
 
 	void Init(int, int, int, int);
-	void GetMainBufferAddress();
-	void GetMainBufferSize();
-	void GetMainBankAddress();
-	void GetABufferAddress();
-	void GetABufferSize();
-	void GetABankAddress();
+	int GetMainBufferAddress();
+	int GetMainBufferSize();
+	int* GetMainBankAddress();
+	int GetABufferAddress();
+	int GetABufferSize();
+	int* GetABankAddress();
 };
 
 #endif // _FFCC_REDSOUND_REDMEMORY_H

--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -152,7 +152,7 @@ void RedDelete(int address)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RedDelete(unsigned int param_1)
+void RedDelete(void* param_1)
 {
 	RedDelete((int)param_1);
 }
@@ -297,7 +297,7 @@ void RedDeleteA(int address)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RedDeleteA(unsigned int param_1)
+void RedDeleteA(void* param_1)
 {
 	RedDeleteA((int)param_1);
 }
@@ -325,60 +325,84 @@ void CRedMemory::Init(int param1, int param2, int param3, int param4)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c05c8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedMemory::GetMainBufferAddress()
+int CRedMemory::GetMainBufferAddress()
 {
-	// TODO
+	return DAT_8032f490;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c05d0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedMemory::GetMainBufferSize()
+int CRedMemory::GetMainBufferSize()
 {
-	// TODO
+	return DAT_8032f498;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c05d8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedMemory::GetMainBankAddress()
+int* CRedMemory::GetMainBankAddress()
 {
-	// TODO
+	return DAT_8032f4a0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c05e0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedMemory::GetABufferAddress()
+int CRedMemory::GetABufferAddress()
 {
-	// TODO
+	return DAT_8032f494;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c05e8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedMemory::GetABufferSize()
+int CRedMemory::GetABufferSize()
 {
-	// TODO
+	return DAT_8032f49c;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c05f0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedMemory::GetABankAddress()
+int* CRedMemory::GetABankAddress()
 {
-	// TODO
+	return DAT_8032f4a4;
 }


### PR DESCRIPTION
## Summary
- Implemented the six `CRedMemory` getter stubs in `src/RedSound/RedMemory.cpp` and updated declarations in `include/ffcc/RedSound/RedMemory.h`.
- Updated `RedDelete`/`RedDeleteA` pointer overloads to use `void*` signatures to align with mapped symbol naming.
- Filled PAL address/size metadata blocks for the updated getter functions.

## Functions Improved
Unit: `main/RedSound/RedMemory`
- `GetMainBufferAddress__10CRedMemoryFv`: 50.0% -> 100.0%
- `GetMainBufferSize__10CRedMemoryFv`: 50.0% -> 100.0%
- `GetMainBankAddress__10CRedMemoryFv`: 50.0% -> 100.0%
- `GetABufferAddress__10CRedMemoryFv`: 50.0% -> 100.0%
- `GetABufferSize__10CRedMemoryFv`: 50.0% -> 100.0%
- `GetABankAddress__10CRedMemoryFv`: 50.0% -> 100.0%

## Match Evidence
From `build/GCCP01/report.json` before/after this change:
- Unit fuzzy match: **51.95612% -> 53.3418%**
- Unit matched code: **4 -> 52 bytes**
- Unit matched functions: **1/15 -> 7/15**
- Global code matched: **177304 -> 177352 bytes**

`ninja` build succeeds after the change.

## Plausibility Rationale
- The getter methods now return the corresponding global state directly, which matches the expected simple accessor style and avoids stub placeholders.
- `void*` pointer overloads for delete wrappers are consistent with the symbol map naming (`RedDelete__FPv` / `RedDeleteA__FPv`) and with common original-source API design for memory wrappers.

## Technical Details
- Accessors are implemented as direct returns of `DAT_8032f490/f498/f4a0/f494/f49c/f4a4`, producing compact accessor code for these tiny functions.
- Pointer-overload declarations/definitions were adjusted in both header and source to keep mangled signatures coherent across translation units.
