### PR TITLE
pppRandUpIV: restore linkage and replace placeholder logic

### DIFF
--- a/include/ffcc/pppRandUpIV.h
+++ b/include/ffcc/pppRandUpIV.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 void randint(int, float);
-void pppRandUpIV(void);
+void pppRandUpIV(void*, void*, void*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Replaced the placeholder `pppRandUpIV` implementation with typed, source-plausible logic aligned with nearby `pppRand*` units.
- Corrected callback signature to `void pppRandUpIV(void*, void*, void*)` in the header to match actual usage.
- Kept behavior idiomatic to this codebase: gate on global disable flag, ID check, random value generation/scaling, store scalar, then apply scaled integer deltas to target vector.

## Functions Improved
- Unit: `main/pppRandUpIV`
- Symbol: `pppRandUpIV`
- Size: `404b`

## Match Evidence
- Baseline (`objdiff` `.text`): **0.00%**
- After change (`objdiff` `.text`): **79.14851%**
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandUpIV -o - pppRandUpIV`

## Plausibility Rationale
- The new code follows existing project patterns from adjacent effects functions (`pppRandDownIV`, `pppRandIV`, `pppRandUpHCV`) rather than contrived compiler coercion.
- Changes are type/layout/control-flow corrections consistent with expected original source style, not unnatural temporary-driven tuning.

## Technical Details
- Introduced local param structs to represent input and context layout used by the callback.
- Switched random call site to explicit `RandF__5CMathFv(&math)` and preserved optional second-random scaling path.
- Applied per-axis integer accumulation using scaled random factor, matching the expected scalar-to-vector update shape for this effect family.
