### PR TITLE
main/p_graphic: match SetDOFParameter signature and implementation

### DIFF
--- a/include/ffcc/p_graphic.h
+++ b/include/ffcc/p_graphic.h
@@ -15,7 +15,7 @@ public:
     void create();
     void destroy();
 
-    void SetDOFParameter(char, char, float, float, float, float, float, int);
+    void SetDOFParameter(signed char, signed char, float, float, float, float, float, int);
     void SetBlurParameter(int, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, short);
 
     void calc();

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -52,12 +52,23 @@ void CGraphicPcs::create()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004769c
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphicPcs::SetDOFParameter(char, char, float, float, float, float, float, int)
+void CGraphicPcs::SetDOFParameter(signed char flagA, signed char flagB, float nearZ, float farZ, float focus, float blurNear, float blurFar, int mode)
 {
-	// TODO
+	*(char*)((char*)this + 0xc4) = flagB;
+	*(float*)((char*)this + 0xc8) = nearZ;
+	*(float*)((char*)this + 0xcc) = farZ;
+	*(char*)((char*)this + 0xe0) = flagA;
+	*(int*)((char*)this + 0xd0) = mode;
+	*(float*)((char*)this + 0xd4) = focus;
+	*(float*)((char*)this + 0xd8) = blurNear;
+	*(float*)((char*)this + 0xdc) = blurFar;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGraphicPcs::SetDOFParameter` in `src/p_graphic.cpp` using direct field writes that match the recovered PAL layout/ordering.
- Corrected the first two parameter types from `char` to `signed char` in both declaration and definition so the emitted Metrowerks symbol matches PAL (`FScSc...`).
- Updated the function info block with PAL address/size metadata.

## Functions Improved
- Unit: `main/p_graphic`
- Symbol: `SetDOFParameter__11CGraphicPcsFScScfffffi`

## Match Evidence
- Before: selector reported `SetDOFParameter__11CGraphicPcsFScScfffffi` at **0.0%** (36b) in `main/p_graphic`.
- After: `build/tools/objdiff-cli diff -p . -u main/p_graphic -o - SetDOFParameter__11CGraphicPcsFScScfffffi` reports:
  - `match_percent: 100.0`
  - `size: 36`
- Project progress (`ninja`) increased from **1177** to **1178** matched functions and code bytes increased by 36 (177316 -> 177352).

## Plausibility Rationale
- The change is source-plausible: it defines a previously stubbed function as straightforward member state assignment in a natural order.
- Type correction to `signed char` is ABI/signature-alignment work, not compiler coaxing, and directly resolves symbol mismatch.
- No artificial temporaries or unnatural control flow were introduced.

## Technical Details
- Function implementation follows the PAL Ghidra reference for offset targets and store ordering:
  - byte stores at `0xc4` and `0xe0`
  - float stores at `0xc8`, `0xcc`, `0xd4`, `0xd8`, `0xdc`
  - int store at `0xd0`
- Key unblocker was symbol identity: without `signed char` parameters, the function failed to pair reliably with target expectations.
