### PR TITLE
gx: improve __GXSetDirtyState codegen in GXGeometry

### DIFF
--- a/src/gx/GXGeometry.c
+++ b/src/gx/GXGeometry.c
@@ -5,24 +5,22 @@
 #include "dolphin/gx/__gx.h"
 
 void __GXSetDirtyState(void) {
-    u32 dState = __GXData->dirtyState;
-
-    if (dState & 1) {
+    if (__GXData->dirtyState & 1) {
         __GXSetSUTexRegs();
     }
-    if (dState & 2) {
+    if (__GXData->dirtyState & 2) {
         __GXUpdateBPMask();
     }
-    if (dState & 4) {
+    if (__GXData->dirtyState & 4) {
         __GXSetGenMode();
     }
-    if (dState & 8) {
+    if (__GXData->dirtyState & 8) {
         __GXSetVCD();
     }
-    if (dState & 0x10) {
+    if (__GXData->dirtyState & 0x10) {
         __GXSetVAT();
     }
-    if (dState & 0x18) {
+    if (__GXData->dirtyState & 0x18) {
         __GXCalculateVLim();
     }
 


### PR DESCRIPTION
## Summary
- Reworked `__GXSetDirtyState` in `src/gx/GXGeometry.c` to read `__GXData->dirtyState` directly in each branch check.
- Removed the cached local `dState` temporary that was forcing a different load/use pattern from target codegen.

## Functions improved
- Unit: `main/gx/GXGeometry`
- Symbol: `__GXSetDirtyState`

## Match evidence
- `__GXSetDirtyState`: **68.75% -> 98.95%** (`build/tools/objdiff-cli diff -p . -u main/gx/GXGeometry -o - __GXSetDirtyState`)
- Assembly alignment improvement is structural (reload/test pattern now matches target) rather than formatting-only churn.

## Plausibility rationale
- The change is source-plausible: checking a mutable global state field directly between helper calls is idiomatic and avoids stale cached state assumptions.
- No contrived temporaries or unnatural ordering were introduced.

## Technical details
- Previous code cached `__GXData->dirtyState` into `dState` once and tested that snapshot for all flags.
- Updated code tests `__GXData->dirtyState` per condition, which better matches expected call-clobber/memory access behavior in the original build.
