### PR TITLE
gx/GXMisc: match GXPeekZ bitfield address composition

### DIFF
--- a/src/gx/GXMisc.c
+++ b/src/gx/GXMisc.c
@@ -287,11 +287,12 @@ void GXPokeARGB(u16 x, u16 y, u32 color) {
 }
 
 void GXPeekZ(u16 x, u16 y, u32* z) {
-    u32 addr = (u32)OSPhysicalToUncached(0x08000000);
+    u32 addr;
 
-    SET_REG_FIELD(812, addr, 10, 2, x);
-    SET_REG_FIELD(813, addr, 10, 12, y);
-    SET_REG_FIELD(813, addr, 2, 22, 1);
+    addr = (u32)OSPhysicalToUncached(0x08000000);
+    addr = (addr & ~(0x3FF << 2)) | ((u32)x << 2);
+    addr = (addr & ~(0x3FF << 12)) | ((u32)y << 12);
+    addr = (addr & ~(0x3 << 22)) | (1 << 22);
     *z = *(u32*)addr;
 }
 


### PR DESCRIPTION
## Summary
Reworked `GXPeekZ` in `src/gx/GXMisc.c` to build the EFB address with explicit bitfield composition instead of `SET_REG_FIELD` macro expansion.

## Functions improved
- Unit: `main/gx/GXMisc`
- Function: `GXPeekZ`
  - Before: `54.0%`
  - After: `100.0%`

## Match evidence
- `main/gx/GXMisc` unit metrics:
  - Fuzzy match: `89.2045%` -> `90.145195%`
  - Matched code: `300` -> `340`
  - Matched functions: `7` -> `8`
- `objdiff` for `GXPeekZ` now reports `0` instruction mismatches.

## Plausibility rationale
The change is source-plausible for original SDK-style C: it computes the poke/peek MMIO address by applying explicit masks and shifts for x/y/selector fields, which directly reflects hardware register bit layout rather than introducing compiler-coaxing temporaries.

## Technical details
- Replaced three `SET_REG_FIELD` calls with equivalent masked-or operations:
  - `x` into bits `[2..11]`
  - `y` into bits `[12..21]`
  - Z selector (`1`) into bits `[22..23]`
- Kept function behavior and IO semantics unchanged (`*z = *(u32*)addr`).
