### PR TITLE
pppCorona: reconstruct pppConstructCorona serialized init

### DIFF
--- a/include/ffcc/pppCorona.h
+++ b/include/ffcc/pppCorona.h
@@ -1,14 +1,30 @@
 #ifndef _FFCC_PPPCORONA_H_
 #define _FFCC_PPPCORONA_H_
 
+#include <dolphin/types.h>
+
+struct pppCorona {
+    union {
+        void* ptr;
+        struct {
+            u32 m_graphId;
+        };
+    } field0_0x0;
+};
+
+struct UnkC {
+    u8 _pad0[0xC];
+    s32* m_serializedDataOffsets;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppConstructCorona(void* param1, void* param2);
+void pppConstructCorona(pppCorona* param1, UnkC* param2);
 void pppDestructCorona(void);
-void pppFrameCorona(void* param1, void* param2);
-void pppRenderCorona(void* param1, void* param2);
+void pppFrameCorona(pppCorona* param1, UnkC* param2);
+void pppRenderCorona(pppCorona* param1, UnkC* param2);
 
 #ifdef __cplusplus
 }

--- a/src/pppCorona.cpp
+++ b/src/pppCorona.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/pppCorona.h"
 
+extern float lbl_803310C8;
+
 /*
  * --INFO--
  * PAL Address: 0x800df5e4
@@ -9,31 +11,16 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppConstructCorona(void* param1, void* param2)
+void pppConstructCorona(pppCorona* param1, UnkC* param2)
 {
-    // Based on objdiff expected assembly pattern  
-    // Function works with offsets and stores shorts/floats
-    char* p1 = (char*)param1;
-    char** p2 = (char**)param2;
-    
-    if (p2) {
-        char** base = (char**)*(p2 + 3); // offset 0xc from param2
-        if (base) {
-            int offset_val = (int)*(base + 3); // offset 0xc from base
-            char* target = p1 + offset_val + 0x80;
-            
-            // Store three shorts as 0
-            *((short*)target) = 0;
-            *((short*)(target + 2)) = 0;
-            *((short*)(target + 4)) = 0;
-            
-            // Store three floats with a constant value  
-            float constant = 0.0f; // Will need to find the right constant
-            *((float*)(target + 8)) = constant;
-            *((float*)(target + 0xc)) = constant; 
-            *((float*)(target + 0x10)) = constant;
-        }
-    }
+    float fVar1 = lbl_803310C8;
+    u16* puVar2 = (u16*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[3]);
+    puVar2[2] = 0;
+    puVar2[1] = 0;
+    puVar2[0] = 0;
+    *(float*)(puVar2 + 8) = fVar1;
+    *(float*)(puVar2 + 6) = fVar1;
+    *(float*)(puVar2 + 4) = fVar1;
 }
 
 /*
@@ -58,7 +45,7 @@ void pppDestructCorona(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameCorona(void* param1, void* param2)
+void pppFrameCorona(pppCorona* param1, UnkC* param2)
 {
     // Placeholder implementation - complex function with many operations
 }
@@ -72,7 +59,7 @@ void pppFrameCorona(void* param1, void* param2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRenderCorona(void* param1, void* param2)
+void pppRenderCorona(pppCorona* param1, UnkC* param2)
 {
     // Placeholder implementation - very complex rendering function
 }


### PR DESCRIPTION
## Summary
- Reworked `pppConstructCorona` from placeholder-style pointer/null-check logic into a direct serialized-data initialization routine matching established `ppp*` constructor patterns.
- Added concrete local type definitions in `include/ffcc/pppCorona.h` (`pppCorona`, `UnkC`) and updated function signatures to use typed parameters.
- Removed unnecessary defensive branches and aligned store ordering with expected constructor behavior.

## Functions improved
- Unit: `main/pppCorona`
- Symbol: `pppConstructCorona`

## Match evidence
- Before: `53.153847%` (`build/tools/objdiff-cli diff -p . -u main/pppCorona -o - pppConstructCorona`)
- After: `99.53846%` (same command after changes)
- Improvement is from real instruction alignment: constructor prologue/branch noise removed, halfword/float store sequence now aligns with target order.

## Plausibility rationale
- New code follows the same serialized offset + `0x80` data-area access pattern already used across nearby `ppp*` modules.
- The constructor now performs straightforward field initialization (three `u16` zeros + three float constant stores), which is plausible original gameplay/render state setup rather than contrived compiler coaxing.

## Technical details
- Constructor now computes destination as `(u8*)obj + 0x80 + serializedDataOffsets[3]`.
- Writes are emitted in descending-index order to match target instruction sequence.
- Uses a shared scalar constant symbol reference for the three float stores.
