### PR TITLE
axfx/reverb_std: align HandleReverb2 symbol mapping

### DIFF
--- a/src/axfx/reverb_std.c
+++ b/src/axfx/reverb_std.c
@@ -11,7 +11,7 @@ static int DLcreate(AXFX_REVSTD_DELAYLINE* dl, s32 max_length);
 static void DLdelete(AXFX_REVSTD_DELAYLINE* dl);
 static int ReverbSTDCreate(AXFX_REVSTD_WORK* rv, f32 coloration, f32 time, f32 mix, f32 damping, f32 predelay);
 static int ReverbSTDModify(AXFX_REVSTD_WORK* rv, f32 coloration, f32 time, f32 mix, f32 damping, f32 predelay);
-static void HandleReverb(s32* sptr, AXFX_REVSTD_WORK* rv);
+static void HandleReverb2(s32* sptr, AXFX_REVSTD_WORK* rv);
 static void ReverbSTDCallback(s32* left, s32* right, s32* surround, AXFX_REVSTD_WORK* rv);
 static void ReverbSTDFree(AXFX_REVSTD_WORK* rv);
 
@@ -170,7 +170,7 @@ const static f32 value0_3 = 0.3f;
 const static f32 value0_6 = 0.6f;
 const static double i2fMagic = 4503601774854144.0;
 
-asm static void HandleReverb(register s32* sptr, register AXFX_REVSTD_WORK* rv) {
+asm static void HandleReverb2(register s32* sptr, register AXFX_REVSTD_WORK* rv) {
     nofralloc
 	stwu r1, -144(r1)
 	stmw r17, 8(r1)
@@ -432,7 +432,7 @@ L_0000090C:
 }
 
 static void ReverbSTDCallback(s32* left, s32* right, s32* surround, AXFX_REVSTD_WORK* rv) {
-    HandleReverb(left, rv);
+    HandleReverb2(left, rv);
 }
 
 static void ReverbSTDFree(AXFX_REVSTD_WORK* rv) {


### PR DESCRIPTION
## Summary
- Renamed the internal reverb processing symbol from `HandleReverb` to `HandleReverb2` in `src/axfx/reverb_std.c`.
- Updated the local prototype and `ReverbSTDCallback` call site accordingly.
- Kept behavior and implementation unchanged (name alignment only).

## Functions improved
- Unit: `main/axfx/reverb_std`
- `HandleReverb2` (948b): unmapped/0% -> **99.87342%**
- `AXFXReverbStdCallback` (48b): **99.583336% -> 100.0%**

## Match evidence
- Unit `.text` match: **58.531944% -> 89.39896%**
- Evidence gathered with:
  - `build/tools/objdiff-cli diff -p . -u main/axfx/reverb_std -o ...`
  - symbol table extraction via `jq` on objdiff JSON output

## Plausibility rationale
- This change aligns source symbol naming with the target object (`HandleReverb2`) without introducing control-flow/type/coaxing changes.
- It preserves the existing implementation and intent while fixing symbol correspondence that prevented objdiff from matching the large function.

## Technical details
- The object previously exported `HandleReverb` while objdiff expected `HandleReverb2`, leaving the 948-byte function effectively unmatched.
- Renaming the static function and its direct call site allowed proper symbol mapping and immediate assembly alignment.
