### PR TITLE
p_gba: add missing CGbaPcs global/static init scaffold

### DIFF
--- a/include/ffcc/p_gba.h
+++ b/include/ffcc/p_gba.h
@@ -28,4 +28,6 @@ private:
     CMemory::CStage* m_stage;
 };
 
+extern CGbaPcs GbaPcs;
+
 #endif // _FFCC_P_GBA_H_

--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -5,14 +5,15 @@
 #include "ffcc/system.h"
 #include <dolphin/gba/GBA.h>
 
+CGbaPcs GbaPcs;
+
 /*
  * --INFO--
  * Address:	TODO
  * Size:	TODO
  */
-CGbaPcs::CGbaPcs()
+CGbaPcs::CGbaPcs() : CProcess()
 {
-	// TODO
 }
 
 /*


### PR DESCRIPTION
## Summary
- declare and define the missing `GbaPcs` process singleton for the `p_gba` unit
- make `CGbaPcs` constructor explicitly initialize its `CProcess` base
- keep existing function bodies unchanged; this change targets missing static-init/constructor symbols only

## Functions improved
- Unit: `main/p_gba`
- Symbol: `__sinit_p_gba_cpp`
  - now emitted and matching at `16.45283%`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/p_gba -o -`
  - `.text` match: `68.026596%` -> `72.664894%`
- `ninja` progress snapshot also reflects extra matched data bytes (`64` -> `68`)

## Plausibility rationale
- `CGbaPcs` is a `CProcess`-derived module object and should exist as a global singleton like other process modules.
- Emitting its constructor/static init is consistent with original game startup patterns, and is more source-plausible than compiler-coaxing transformations.

## Technical details
- Added `extern CGbaPcs GbaPcs;` in `include/ffcc/p_gba.h`.
- Added `CGbaPcs GbaPcs;` definition in `src/p_gba.cpp`.
- Updated `CGbaPcs::CGbaPcs()` to use base initializer `: CProcess()`.
- Rebuilt with `ninja` and verified with objdiff JSON oneshot (`tools/objdiff-cli` v3.6.1).
