### PR TITLE
RedSound: implement GetAutoID and EntryStandbyID

### DIFF
--- a/include/ffcc/RedSound/RedSound.h
+++ b/include/ffcc/RedSound/RedSound.h
@@ -7,8 +7,8 @@ public:
 	CRedSound();
 	~CRedSound();
 
-	void GetAutoID();
-	void EntryStandbyID(int);
+	unsigned int GetAutoID();
+	int* EntryStandbyID(int);
 	void Init(void*, int, int, int);
 	void Start();
 	void End();

--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -16,6 +16,7 @@ extern CRedDriver CRedDriver_8032f4c0;
 extern CRedMemory DAT_8032f480;
 extern CRedEntry DAT_8032e154;
 extern int DAT_8032f408; // Debug flag
+extern unsigned int DAT_8032f4c4; // Auto ID counter
 extern char DAT_8032e17c[]; // Buffer for memset
 extern void* DAT_8032e170; // Registration memory
 extern FILE DAT_8021d1a8; // File handle for fflush
@@ -45,9 +46,13 @@ CRedSound::~CRedSound()
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::GetAutoID()
+unsigned int CRedSound::GetAutoID()
 {
-	// TODO
+	do {
+		DAT_8032f4c4 = (DAT_8032f4c4 + 1) & 0x7FFFFFFF;
+	} while (DAT_8032f4c4 == 0);
+
+	return DAT_8032f4c4;
 }
 
 /*
@@ -55,9 +60,20 @@ void CRedSound::GetAutoID()
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::EntryStandbyID(int)
+int* CRedSound::EntryStandbyID(int id)
 {
-	// TODO
+	int* slot = (int*)DAT_8032e17c;
+	int* end = (int*)(DAT_8032e17c + 0x100);
+
+	while (slot < end) {
+		if (*slot == 0) {
+			*slot = id;
+			return slot;
+		}
+		++slot;
+	}
+
+	return 0;
 }
 
 /*
@@ -643,10 +659,10 @@ void CRedSound::TestProcess(int)
  * Size:	TODO
  */
 // Forward declaration
+extern "C" void* __ct__10CRedDriverFv(void*);
 extern "C" void __dt__10CRedDriverFv(void*);
 
 void __sinit_RedSound_cpp(void)
 {
-	// Initialize the global CRedDriver object and register for destruction
-	__register_global_object(&CRedDriver_8032f4c0, __dt__10CRedDriverFv, &DAT_8032e170);
+	__register_global_object(__ct__10CRedDriverFv(&CRedDriver_8032f4c0), __dt__10CRedDriverFv, &DAT_8032e170);
 }


### PR DESCRIPTION
## Summary
- Implemented `CRedSound::GetAutoID` and `CRedSound::EntryStandbyID` in `src/RedSound/RedSound.cpp`.
- Corrected declarations in `include/ffcc/RedSound/RedSound.h` to return `unsigned int` and `int*` (previously `void`).
- Updated `__sinit_RedSound_cpp` to call the `CRedDriver` constructor before global destructor registration.

## Functions improved
- Unit: `main/RedSound/RedSound`
- `GetAutoID__9CRedSoundFv`: **9.090909% -> 47.727272%**
- `EntryStandbyID__9CRedSoundFi`: **5.0% -> 12.45%**

## Match evidence
- Unit fuzzy match (`main/RedSound/RedSound`): **13.896187 -> 14.504237**
- Verified with `ninja` and objdiff (`report generate` + per-symbol `diff`).

## Plausibility rationale
- The changes are straightforward source-level behavior (auto-ID increment/wrap guard and linear standby-slot allocation) and align with expected ABI/return semantics.
- No compiler-coaxing patterns were introduced.

## Technical details
- `GetAutoID` increments global `DAT_8032f4c4`, masks with `0x7FFFFFFF`, and skips zero.
- `EntryStandbyID` scans the 0x100-byte standby table (`DAT_8032e17c`) as `int` slots, stores the first free ID entry, and returns the slot pointer (or `0`).
