### PR TITLE
pppYmTracer2: improve construct state layout matching

### DIFF
--- a/include/ffcc/pppYmTracer2.h
+++ b/include/ffcc/pppYmTracer2.h
@@ -6,15 +6,17 @@
 struct PYmTracer2;
 struct TRACE_POLYGON;
 
-// Forward declarations
-struct UnkB;
-struct UnkC;
+struct UnkB {
+    u32 m_dataValIndex;
+};
+
+struct UnkC {
+    u8 _pad[0xC];
+    s32* m_serializedDataOffsets;
+};
 
 struct pppYmTracer2 {
-    // Based on Ghidra analysis - contains serialized data
-    u8* m_serializedData;
-    // Add padding for pppPObject structure
-    char pad[0x80]; // Placeholder - actual structure size may differ
+    u8 _pad[0x80];
 };
 
 #ifdef __cplusplus

--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -1,5 +1,4 @@
 #include "ffcc/pppYmTracer2.h"
-#include "ffcc/pppColum.h"
 #include "ffcc/pppPart.h"
 
 /*
@@ -34,13 +33,12 @@ void copyPolygonData(TRACE_POLYGON*, TRACE_POLYGON*)
 void pppConstructYmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
 {
 	float fVar1 = 1.0f; // FLOAT_80331840 placeholder
-	unsigned char* puVar2 = pppYmTracer2->m_serializedData + *param_2->m_serializedDataOffsets;
+	unsigned char* puVar2 = (unsigned char*)pppYmTracer2 + 0x80 + *param_2->m_serializedDataOffsets;
 	
-	*(float*)(puVar2 + 0x28) = 0.0f;
-	*(float*)(puVar2 + 0x24) = 0.0f;
-	*(float*)(puVar2 + 0x20) = 0.0f;
-	puVar2[0x2c] = 0;
-	puVar2[0x2d] = 0;
+	*(u32*)(puVar2 + 0x28) = 0;
+	*(u32*)(puVar2 + 0x24) = 0;
+	*(u32*)(puVar2 + 0x20) = 0;
+	*(u16*)(puVar2 + 0x2c) = 0;
 	
 	*(float*)(puVar2 + 0xc) = fVar1;
 	*(float*)(puVar2 + 8) = fVar1;
@@ -51,12 +49,9 @@ void pppConstructYmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
 	*(float*)(puVar2 + 0x14) = fVar1;
 	*(float*)(puVar2 + 0x10) = fVar1;
 	
-	puVar2[0x2e] = 0;
-	puVar2[0x2f] = 0;
-	puVar2[0x30] = 0;
-	puVar2[0x31] = 0;
-	puVar2[0x32] = 0;
-	puVar2[0x33] = 0;
+	*(u16*)(puVar2 + 0x2e) = 0;
+	*(u16*)(puVar2 + 0x30) = 0;
+	*(u16*)(puVar2 + 0x32) = 0;
 }
 
 /*
@@ -70,7 +65,7 @@ void pppConstructYmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
  */
 void pppConstruct2YmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
 {
-	unsigned char* iVar1 = pppYmTracer2->m_serializedData + *param_2->m_serializedDataOffsets;
+	unsigned char* iVar1 = (unsigned char*)pppYmTracer2 + 0x80 + *param_2->m_serializedDataOffsets;
 	
 	*(short*)(iVar1 + 0x2c) = 0;
 	*(short*)(iVar1 + 0x2e) = 0;
@@ -88,7 +83,7 @@ void pppConstruct2YmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
  */
 void pppDestructYmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
 {
-	void** memPtr = (void**)(pppYmTracer2->m_serializedData + *param_2->m_serializedDataOffsets + 0x28);
+	void** memPtr = (void**)((unsigned char*)pppYmTracer2 + 0x80 + *param_2->m_serializedDataOffsets + 0x28);
 	if (*memPtr != 0) {
 		pppHeapUseRate((CMemory::CStage*)*memPtr);
 	}


### PR DESCRIPTION
## Summary
- Updated `pppYmTracer2` state access to use object-relative serialized state (`obj + 0x80 + offset`) instead of a speculative `m_serializedData` pointer.
- Defined module-local `UnkC` layout with `m_serializedDataOffsets` at offset `0xC`, matching observed codegen expectations.
- Aligned zero-initialization store widths in `pppConstructYmTracer2` (`u32`/`u16` clears) with target instruction patterns.

## Functions improved
- Unit: `main/pppYmTracer2`
- `pppConstructYmTracer2`: **16.863636% -> 77.5%**
- `pppConstruct2YmTracer2`: **88.55556% -> 88.666664%**
- `pppDestructYmTracer2`: **91.28571% -> 91.35714%**

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppConstructYmTracer2`
- Overall project progress from `ninja` report changed from:
  - Code matched: `178440 / 1855300` -> `178584 / 1855300`
  - Functions matched: `1187 / 4733` -> `1189 / 4733`

## Plausibility rationale
- The new addressing model (`base + 0x80 + serialized offset`) matches existing conventions used across other `ppp*` units and removes a speculative pointer indirection.
- The updated `UnkC` field offset and initialization store widths reflect ABI/layout-driven behavior rather than contrived code motion.
- Changes improve readability and consistency while reducing reliance on incorrect placeholder structure guesses.

## Technical notes
- This pass intentionally leaves `pppFrameYmTracer2` and `pppRenderYmTracer2` as future work; they remain near-0% and represent the largest remaining opportunity in this unit.
