### PR TITLE
Improve __sinit_usb_cpp match in usb unit

### DIFF
--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -2,6 +2,8 @@
 
 #include "ffcc/system.h"
 
+extern void* __vt__8CManager;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -188,5 +190,6 @@ void CUSB::Printf(char*, ...)
  */
 extern "C" void __sinit_usb_cpp()
 {
-	USB.m_managerStringTable = &PTR_PTR_DAT_801e88a4;
+	*(volatile void**)&USB = &__vt__8CManager;
+	*(volatile void**)&USB = &PTR_PTR_DAT_801e88a4;
 }


### PR DESCRIPTION
## Summary
- Updated `__sinit_usb_cpp` in `src/usb.cpp` to perform explicit initialization writes for the global `USB` object.
- Added explicit `CManager` vtable pointer write before setting the USB manager string-table pointer.

## Functions improved
- Unit: `main/usb`
- Symbol: `__sinit_usb_cpp`
- Match change: **41.125% -> 57.5%**

## Match evidence
- Before:
  - `build/tools/objdiff-cli diff -p . -u main/usb -o - __sinit_usb_cpp`
  - `match_percent = 41.125`
- After:
  - `build/tools/objdiff-cli diff -p . -u main/usb -o - __sinit_usb_cpp`
  - `match_percent = 57.5`
- The instruction stream now includes both initialization stores in `__sinit_usb_cpp`, reducing structural diff noise in this function.

## Plausibility rationale
- This matches an existing local pattern in this codebase (`__sinit_p_usb_cpp`) where static init writes a base manager vtable pointer and then writes a unit-specific table pointer.
- The change keeps behavior simple and consistent with observed initialization style for manager-like global objects.

## Technical details
- Added:
  - `extern void* __vt__8CManager;`
  - two explicit pointer writes in `__sinit_usb_cpp`:
    - `*(volatile void**)&USB = &__vt__8CManager;`
    - `*(volatile void**)&USB = &PTR_PTR_DAT_801e88a4;`
- Verified with a clean `ninja` build after the change.
