### PR TITLE
gx/GXFrameBuf: improve GXSetCopyClamp match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -197,20 +197,31 @@ void GXSetDispCopyFrame2Field(GXCopyMode mode) {
     SET_REG_FIELD(1411, __GXData->cpTex, 2, 12, 0);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A2BCC
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void GXSetCopyClamp(GXFBClamp clamp) {
-    u8 clmpB;
-    u8 clmpT;
+    GXData* gx;
+    u32 clmpB;
+    u32 clmpT;
 
     CHECK_GXBEGIN(1431, "GXSetCopyClamp");
+    gx = __GXData;
 
-    clmpT = (clamp & GX_CLAMP_TOP) == 1;
-    clmpB = (clamp & GX_CLAMP_BOTTOM) == 2;
+    clmpT = ((u32)__cntlzw((clamp & GX_CLAMP_TOP) - GX_CLAMP_TOP) >> 5) & 0xFF;
+    clmpB = ((u32)__cntlzw((clamp & GX_CLAMP_BOTTOM) - GX_CLAMP_BOTTOM) >> 4) & 0x1FE;
 
-    SET_REG_FIELD(1435, __GXData->cpDisp, 1, 0, clmpT);
-    SET_REG_FIELD(1436, __GXData->cpDisp, 1, 1, clmpB);
+    gx->cpDisp = (gx->cpDisp & ~1) | clmpT;
+    gx->cpDisp = (gx->cpDisp & ~2) | clmpB;
 
-    SET_REG_FIELD(1438, __GXData->cpTex, 1, 0, clmpT);
-    SET_REG_FIELD(1439, __GXData->cpTex, 1, 1, clmpB);
+    gx->cpTex = (gx->cpTex & ~1) | clmpT;
+    gx->cpTex = (gx->cpTex & ~2) | clmpB;
 }
 
 static u32 __GXGetNumXfbLines(u32 efbHt, u32 iScale) {


### PR DESCRIPTION
## Summary
- Reworked `GXSetCopyClamp` in `src/gx/GXFrameBuf.c` to use `__cntlzw`-based clamp normalization and direct masked register updates for `cpDisp`/`cpTex`.
- Added the standard function metadata header for the updated function.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Symbol: `GXSetCopyClamp` (`104b`)
- Match: **35.576923% -> 90.76923%**

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetCopyClamp`
  - Before: `GXSetCopyClamp 35.576923 104`
  - After: `GXSetCopyClamp 90.76923 104`
- Unit `.text` match also improved during this change set:
  - Before: `68.55423%`
  - After: `70.2646%`

## Plausibility rationale
- The new implementation follows the existing project idiom using `__cntlzw` to derive boolean field values from bit tests, consistent with other GX code.
- Register writes are now straightforward masked updates to the same fields represented in the target assembly, which is a plausible original-source form for this SDK-style function.
- No contrived control-flow or compiler-only coercion was introduced.

## Technical details
- `clmpT` derived from `(clamp & GX_CLAMP_TOP)` through `__cntlzw(... - GX_CLAMP_TOP)`.
- `clmpB` derived from `(clamp & GX_CLAMP_BOTTOM)` through `__cntlzw(... - GX_CLAMP_BOTTOM)`.
- Field writes now directly update bits 0 and 1 in `cpDisp` and `cpTex` via masks instead of `SET_REG_FIELD`, aligning generated instruction shape with the target.
