### PR TITLE
TRK: implement InitializeProgramEndTrap

### DIFF
--- a/include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk_glue.h
+++ b/include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk_glue.h
@@ -39,6 +39,7 @@ int InitMetroTRKCommTable(int hwId);
 void EnableEXI2Interrupts(void);
 void TRK_board_display(char* str);
 void TRKUARTInterruptHandler();
+void InitializeProgramEndTrap(void);
 
 #ifdef __cplusplus
 }

--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk_glue.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk_glue.c
@@ -2,6 +2,7 @@
 #include "TRK_MINNOW_DOLPHIN/ppc/Generic/targimpl.h"
 #include "OdemuExi2/odemuexi/DebuggerDriver.h"
 #include "amcstubs/AmcExi2Stubs.h"
+#include "dolphin/base/PPCArch.h"
 #include "PowerPC_EABI_Support/MetroTRK/trk.h"
 
 #define BUFF_LEN 4362
@@ -176,6 +177,25 @@ UARTError TRKReadUARTPoll(u8* arg0)
 void ReserveEXI2Port(void) { gDBCommTable.open_func(); }
 
 void UnreserveEXI2Port(void) { gDBCommTable.close_func(); }
+
+/*
+ * --INFO--
+ * PAL Address: 0x801AE160
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void InitializeProgramEndTrap(void)
+{
+    static const u32 EndofProgramInstruction = 0x00454E44;
+    register u8* ppcHalt = (u8*)PPCHalt;
+
+    TRK_memcpy(ppcHalt + 4, &EndofProgramInstruction, 4);
+    ICInvalidateRange(ppcHalt + 4, 4);
+    DCFlushRange(ppcHalt + 4, 4);
+}
 
 void TRK_board_display(char* str) { OSReport(str); }
 


### PR DESCRIPTION
## Summary
- Implemented `InitializeProgramEndTrap` in `src/TRK_MINNOW_DOLPHIN/dolphin_trk_glue.c` and declared it in `include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk_glue.h`.
- Added the function info block with PAL address/size metadata.
- The implementation patches the second instruction in `PPCHalt` with the original 4-byte program-end trap value (`0x00454E44`), then invalidates I-cache and flushes D-cache for that range.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk_glue`
- Symbol: `InitializeProgramEndTrap`
- Selector baseline: `0.0%` (missing/unmatched in source before this change)
- Current direct objdiff match (`-1 obj -2 src`): `99.545456%` for `InitializeProgramEndTrap` (88b)

## Match evidence
- `ninja` builds successfully after the change.
- `objdiff` now pairs `InitializeProgramEndTrap` by symbol and produces near-identical assembly and size parity (88 bytes).
- Remaining mismatch is limited to the local literal symbol label (`EndofProgramInstruction$...`) rather than functional/control-flow differences.

## Plausibility rationale
- `InitializeProgramEndTrap` is called from `TRKInitializeNub` and is expected behavior in MetroTRK startup.
- The implementation follows normal SDK-style source structure:
  - small local literal for trap instruction bytes
  - `TRK_memcpy` patch into `PPCHalt + 4`
  - `ICInvalidateRange`/`DCFlushRange` synchronization
- No contrived control flow or readability regressions were introduced.

## Technical details
- The trap constant was verified against `orig/GCCP01/sys/main.dol` at PAL address `0x801E6BA0` (`00 45 4E 44`).
- Using a `register` base pointer for `PPCHalt` aligns generated register usage with target output and closed the majority of assembly diffs.
