### PR TITLE
mtx: improve C_MTXLookAt decomp match

### DIFF
--- a/src/mtx/mtx.c
+++ b/src/mtx/mtx.c
@@ -1202,7 +1202,7 @@ void PSMTXReflect(register Mtx m, const register Vec *p, const register Vec *n)
 }
 #endif
 
-void C_MTXLookAt(Mtx m, const Vec *camPos, const Vec *camUp, const Vec *target)
+void C_MTXLookAt(Mtx m, const Point3d* camPos, const Vec* camUp, const Point3d* target)
 {
     Vec vLook, vRight, vUp;
 
@@ -1217,17 +1217,17 @@ void C_MTXLookAt(Mtx m, const Vec *camPos, const Vec *camUp, const Vec *target)
     m[0][0] = vRight.x;
     m[0][1] = vRight.y;
     m[0][2] = vRight.z;
-    m[0][3] = -(camPos->x * vRight.x + camPos->y * vRight.y + camPos->z * vRight.z);
+    m[0][3] = -camPos->x * vRight.x - camPos->y * vRight.y - camPos->z * vRight.z;
 
     m[1][0] = vUp.x;
     m[1][1] = vUp.y;
     m[1][2] = vUp.z;
-    m[1][3] = -(camPos->x * vUp.x + camPos->y * vUp.y + camPos->z * vUp.z);
+    m[1][3] = -camPos->x * vUp.x - camPos->y * vUp.y - camPos->z * vUp.z;
 
     m[2][0] = vLook.x;
     m[2][1] = vLook.y;
     m[2][2] = vLook.z;
-    m[2][3] = -(camPos->x * vLook.x + camPos->y * vLook.y + camPos->z * vLook.z);
+    m[2][3] = -camPos->x * vLook.x - camPos->y * vLook.y - camPos->z * vLook.z;
 }
 
 void C_MTXLightFrustum(Mtx m, float t, float b, float l, float r, float n, float scaleS, float scaleT, float transS, float transT)


### PR DESCRIPTION
## Summary
- Updated `C_MTXLookAt` in `src/mtx/mtx.c` to better match original code generation.
- Switched function parameter typedefs from `Vec*` to the equivalent header-native `Point3d*` aliases for camera position and target.
- Rewrote each translation term from `-(a + b + c)` to `-a - b - c`, which changed FPU instruction selection/order in a source-plausible way.

## Functions Improved
- Unit: `main/mtx/mtx`
- Function: `C_MTXLookAt`
- Match: `67.44444%` -> `74.36364%` (`+6.91919`)

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/mtx/mtx -o - C_MTXLookAt`
- Unit `.text` match (objdiff section summary):
  - `24.277863%` -> `25.323664%`
- Build status:
  - `ninja` succeeds after changes.

## Plausibility Rationale
- `Point3d` is a typedef alias already used by the Dolphin MTX API in `include/dolphin/mtx.h`, so this change reflects existing source conventions rather than compiler-forcing tricks.
- The dot-product rewrite is mathematically identical and idiomatic C for explicit signed accumulation, improving codegen without introducing artificial temporaries or non-human control flow.

## Technical Notes
- The major alignment gain came from the translation row computations in `C_MTXLookAt` (better FMADD/FNMADD patterning).
- No behavioral changes intended; only expression/typing refinements.
