### PR TITLE
p_mc: implement __sinit_p_mc_cpp static initializer

### DIFF
--- a/src/p_mc.cpp
+++ b/src/p_mc.cpp
@@ -5,6 +5,14 @@
 
 extern CMath math;
 extern "C" int Format__6McCtrlFi(McCtrl* mcCtrl, int slot);
+extern "C" void __sinit_p_mc_cpp(void);
+
+extern unsigned int lbl_80211D88[];
+extern unsigned int lbl_80211D94[];
+extern unsigned int lbl_80211DA0[];
+extern unsigned char lbl_80211DAC[];
+extern unsigned char lbl_80211F28[];
+extern unsigned int lbl_8032EE88;
 
 struct MenuPcsMcLayout
 {
@@ -15,6 +23,35 @@ struct MenuPcsMcLayout
     unsigned char unk19[7];
     McCtrl m_mcCtrl;
 };
+
+/*
+ * --INFO--
+ * PAL Address: 0x80124af4
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_mc_cpp(void)
+{
+    unsigned int* table = reinterpret_cast<unsigned int*>(lbl_80211DAC);
+    unsigned int* desc0 = lbl_80211D88;
+    unsigned int* desc1 = lbl_80211D94;
+    unsigned int* desc2 = lbl_80211DA0;
+
+    lbl_8032EE88 = reinterpret_cast<unsigned int>(lbl_80211F28);
+
+    table[1] = desc0[0];
+    table[2] = desc0[1];
+    table[3] = desc0[2];
+    table[4] = desc1[0];
+    table[5] = desc1[1];
+    table[6] = desc1[2];
+    table[7] = desc2[0];
+    table[8] = desc2[1];
+    table[9] = desc2[2];
+}
 
 /*
  * --INFO--
@@ -55,7 +92,6 @@ void* CMcPcs::GetTable(unsigned long index)
 {
 	// Based on assembly: mulli r4, r4, 0x15c; add to base address
 	// 0x15c = 348 bytes per entry
-	extern char lbl_80211DAC[];
 	return lbl_80211DAC + (index * 0x15c);
 }
 


### PR DESCRIPTION
## Summary
- Implemented `__sinit_p_mc_cpp` in `src/p_mc.cpp` with C linkage.
- Added module static table wiring for `m_table__6CMcPcs` entries using existing symbol labels.
- Wired `McPcs` process pointer storage to the expected static object pointer.

## Functions improved
- Unit: `main/p_mc`
- Symbol: `__sinit_p_mc_cpp`

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` output for `main/p_mc` target list)
- After: `97.878784%` (`build/tools/objdiff-cli diff -p . -u main/p_mc -o - __sinit_p_mc_cpp`)
- Build verification: `ninja` passes after change.

## Plausibility rationale
- Change is a standard static initializer pattern already used in this repository (`p_system`, `p_light`): assign process table entries from descriptor triples and initialize the global process pointer slot.
- No contrived control flow or optimizer-coaxing temporaries were introduced; this is straightforward module startup wiring.

## Technical details
- Added PAL info block for `__sinit_p_mc_cpp` (`0x80124af4`, `132b`) from decomp reference.
- Uses label-backed descriptor groups (`lbl_80211D88`, `lbl_80211D94`, `lbl_80211DA0`) and table base (`lbl_80211DAC`) to fill slots `1..9`.
- Stores `lbl_80211F28` into `lbl_8032EE88` to match expected static process pointer setup.
