### PR TITLE
LocationTitle2: align constructor work layout and offsets

### DIFF
--- a/include/ffcc/LocationTitle2.h
+++ b/include/ffcc/LocationTitle2.h
@@ -21,6 +21,7 @@ struct UnkB {
 };
 
 struct UnkC {
+    char pad[0xC];
     s32* m_serializedDataOffsets;
 };
 

--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -18,16 +18,24 @@ extern int DAT_8032ed70;
  */
 void pppConstructLocationTitle2(struct pppLocationTitle2* locationTitle, struct UnkC* unkC)
 {
-    float fVar1;
-    u32* puVar2;
-    
-    fVar1 = 1.0f; // FLOAT_80330f48 constant placeholder
-    puVar2 = (u32*)((char*)locationTitle + 8 + *unkC->m_serializedDataOffsets);
-    *puVar2 = 0;
-    *(u16*)(puVar2 + 1) = 0;
-    puVar2[4] = *(u32*)&fVar1;
-    puVar2[3] = *(u32*)&fVar1;
-    puVar2[2] = *(u32*)&fVar1;
+    struct LocationTitle2Work {
+        void* data;
+        u16 count;
+        u16 pad;
+        float scaleX;
+        float scaleY;
+        float scaleZ;
+    };
+    float one;
+    LocationTitle2Work* work;
+
+    one = 1.0f;
+    work = (LocationTitle2Work*)((char*)locationTitle + 8 + *unkC->m_serializedDataOffsets);
+    work->data = 0;
+    work->count = 0;
+    work->scaleZ = one;
+    work->scaleY = one;
+    work->scaleX = one;
 }
 
 /*


### PR DESCRIPTION
Summary
- Corrected `UnkC` layout in `LocationTitle2` so `m_serializedDataOffsets` is read from offset `0xC` (matches observed codegen usage).
- Rewrote `pppConstructLocationTitle2` to use a typed local work layout (`pointer + u16 + 3 floats`) with direct stores.
- Removed integer bit-cast style float writes in constructor and replaced them with natural float assignments.

Functions improved
- Unit: `main/LocationTitle2`
- Symbol: `pppConstructLocationTitle2` (48 bytes)
- Before: `21.666666%`
- After: `99.5%`

Match evidence
- `objdiff-cli diff -p . -u main/LocationTitle2 -o - pppConstructLocationTitle2`
- Symbol diff ops reduced from `16` to `2`.
- Unit `.text` match improved from `8.51282%` to `10.227106%`.

Plausibility rationale
- The new code models an explicit serialized work block with concrete fields that are directly used by constructor initialization.
- Field offset correction for `UnkC` aligns with decomp access pattern (`param_2 + 0xC`) and avoids ad-hoc coercions.
- Constructor writes are straightforward initialization code a developer would plausibly author.

Technical details
- `UnkC` now includes `pad[0xC]` before `m_serializedDataOffsets`.
- Constructor initializes:
  - `work->data = 0`
  - `work->count = 0`
  - `work->scaleX/Y/Z = 1.0f`
- This emits the expected `stw/sth/stfs` pattern and near-matching instruction stream for the target symbol.
