### PR TITLE
menu_cmd: first-pass CmdClose close animation

### DIFF
--- a/include/ffcc/menu_cmd.h
+++ b/include/ffcc/menu_cmd.h
@@ -24,7 +24,7 @@ public:
     void CmdDismantle(int);
     void DrawUniteList();
     void UniteOpenAnim(int);
-    void UniteCloseAnim(int);
+    int UniteCloseAnim(int);
     void CmdOpen1();
     void CmdClose1();
     void CmdOpen2();

--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -83,7 +83,59 @@ void CMenuPcs::CmdCtrl()
  */
 int CMenuPcs::CmdClose()
 {
-	// TODO: Implement CmdClose 
+	u8* self = reinterpret_cast<u8*>(this);
+	u8* cmd = *reinterpret_cast<u8**>(self + 0x82c);
+	if (cmd[8] == 0) {
+		if (UniteCloseAnim(-1) != 0) {
+			*reinterpret_cast<s16*>(cmd + 0x22) = 0;
+			cmd[8] = 1;
+		}
+		return 0;
+	}
+
+	s16& closeTimer = *reinterpret_cast<s16*>(cmd + 0x22);
+	closeTimer++;
+
+	s16* list = *reinterpret_cast<s16**>(self + 0x850);
+	u16 count = static_cast<u16>(list[0]);
+	s16* entry = list + 4;
+	int doneCount = 0;
+
+	for (u16 i = 0; i < count; i++) {
+		s32 start = *reinterpret_cast<s32*>(entry + 0x12);
+		s32 duration = *reinterpret_cast<s32*>(entry + 0x14);
+		if (start <= closeTimer) {
+			if (closeTimer < (start + duration)) {
+				s32& frame = *reinterpret_cast<s32*>(entry + 0x10);
+				frame++;
+				float t = 1.0f;
+				if (duration > 0) {
+					t -= static_cast<float>(frame) / static_cast<float>(duration);
+				}
+				if (t < 0.0f) {
+					t = 0.0f;
+				}
+				*reinterpret_cast<float*>(entry + 8) = t;
+			} else {
+				doneCount++;
+				*reinterpret_cast<float*>(entry + 8) = 0.0f;
+			}
+		}
+		entry += 0x20;
+	}
+
+	if (doneCount == count) {
+		entry = list + 4;
+		for (u16 i = 0; i < count; i++) {
+			*reinterpret_cast<s32*>(entry + 0x12) = 0;
+			*reinterpret_cast<s32*>(entry + 0x14) = 0;
+			*reinterpret_cast<s32*>(entry + 0x10) = 1;
+			*reinterpret_cast<float*>(entry + 8) = 0.0f;
+			entry += 0x20;
+		}
+		return 1;
+	}
+
 	return 0;
 }
 
@@ -260,9 +312,10 @@ void CMenuPcs::UniteOpenAnim(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::UniteCloseAnim(int)
+int CMenuPcs::UniteCloseAnim(int)
 {
 	// TODO
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
This PR implements a first-pass decompilation for `CMenuPcs::CmdClose()` in `src/menu_cmd.cpp` and corrects the local signature mismatch for `UniteCloseAnim(int)` (from `void` to `int`) in both `include/ffcc/menu_cmd.h` and `src/menu_cmd.cpp`.

The new `CmdClose` body now performs plausible close-flow behavior:
- waits for `UniteCloseAnim(-1)` to complete,
- advances close timer state,
- updates per-entry fade values during close animation,
- resets close animation entry state when all entries are complete,
- returns completion state (`0/1`) accordingly.

## Functions Improved
- Unit: `main/menu_cmd`
- Symbol: `CmdClose__8CMenuPcsFv`
- PAL size: `512b`

## Match Evidence
Measured with:
`tools/objdiff-cli diff -p . -u main/menu_cmd -o - CmdClose__8CMenuPcsFv`

Before:
- `match_percent`: **1.09375%**
- instruction summary: total `128`, `126` deletes

After:
- `match_percent`: **42.757812%**
- instruction summary: total `164`, `21` deletes, `36` inserts

Net:
- **+41.664062 percentage points** for `CmdClose__8CMenuPcsFv`
- substantial reduction in unmatched/deleted instruction regions

## Plausibility Rationale
This change is a plausible source reconstruction rather than compiler coaxing:
- aligns method return semantics with observed call-site usage (`UniteCloseAnim` used as an integer completion check),
- uses straightforward animation/control-flow updates expected in menu close logic,
- avoids contrived temporaries or artificial ordering solely to chase codegen.

Given `menu_cmd.cpp` is still early-stage/placeholder-heavy, this is intentionally a first-pass implementation that improves structural behavior and matching while keeping code maintainable.

## Technical Notes
- Access to menu state uses existing object-offset pattern already necessary in this partially reconstructed file.
- Fade progression follows a linear normalized decrement with clamp to 0.0 for completed entries.
- Build validation: full `ninja` passes after changes (`build/GCCP01/main.dol: OK`).
