### PR TITLE
gbaque: fix __sinit_gbaque_cpp C linkage and metadata

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -4,7 +4,7 @@
 #include <Runtime.PPCEABI.H/NMWException.h>
 
 extern void* ARRAY_802f49b0;
-extern void __dt__8GbaQueueFv(void*);
+extern "C" void __dt__8GbaQueueFv(void*);
 
 /*
  * --INFO--
@@ -1366,10 +1366,14 @@ void GbaQueue::ClrStartBonusFlg(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d15c8
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __sinit_gbaque_cpp(void)
+extern "C" void __sinit_gbaque_cpp(void)
 {
 	GbaQue.Init();
 	__register_global_object(&GbaQue, __dt__8GbaQueueFv, ARRAY_802f49b0);


### PR DESCRIPTION
## Summary
- Updated `__sinit_gbaque_cpp` in `src/gbaque.cpp` to use C linkage (`extern "C"`) so objdiff can resolve the symbol name correctly.
- Updated the destructor extern declaration to C linkage (`extern "C" void __dt__8GbaQueueFv(void*);`) so the initializer references the expected destructor symbol form.
- Replaced the generic TODO info block on `__sinit_gbaque_cpp` with PAL address/size metadata in project format.

## Functions Improved
- Unit: `main/gbaque`
- Function: `__sinit_gbaque_cpp`
- Before: `0.0%` (from `tools/agent_select_target.py` target output)
- After: `60.588234%` (`build/GCCP01/report.json`)

## Match Evidence
- `objdiff` now maps `__sinit_gbaque_cpp` directly (instead of leaving it as a mangled, unmatched symbol), with instruction match at `60.294117%`.
- Remaining differences are instruction-sequence-level (`Init__8GbaQueueFv` call/argument materialization), not symbol-resolution failures.

## Plausibility Rationale
- This is a source-plausible correction: static initializer entry points (`__sinit_*`) are linker/runtime-facing symbols and should have exact external linkage.
- The previous C++ linkage emitted a mismatched symbol form that prevented meaningful matching. Correcting linkage aligns with known Metrowerks symbol constraints and project guidance around parameter/linkage mismatches.

## Technical Details
- File changed: `src/gbaque.cpp`
- Key fix was eliminating C++ mangling for `__sinit_gbaque_cpp` and `__dt__8GbaQueueFv` declarations used in `__register_global_object` setup.
- Build verification: `ninja` passes (`build/GCCP01/main.dol: OK` already established in this worktree; post-change rebuild/report completed cleanly).
