### PR TITLE
pad: reconstruct Init/Quit and improve match

### DIFF
--- a/include/ffcc/pad.h
+++ b/include/ffcc/pad.h
@@ -2,9 +2,7 @@
 #ifndef _FFCC_PAD_H_
 #define _FFCC_PAD_H_
 
-struct PADStatus
-{
-};
+#include "dolphin/pad.h"
 
 class CPad
 {

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -1,23 +1,43 @@
 #include "ffcc/pad.h"
 
+#include "ffcc/memory.h"
+#include "ffcc/system.h"
+
+#include "dolphin/pad.h"
+
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/file_io.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/FILE_POS.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/direct_io.h"
+
+#include <string.h>
+
 CPad Pad;
+
+void* operator new[](unsigned long, CMemory::CStage*, char*, int);
 
 /*
  * --INFO--
  * PAL Address: 0x800211a8
  * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 extern "C" void __sinit_pad_cpp()
 {
-	// Static initialization - setup vtable and clear member variables
 	Pad._448_4_ = 0;
 	Pad._452_4_ = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CPad::CPad()
 {
@@ -26,31 +46,108 @@ CPad::CPad()
 
 /*
  * --INFO--
- * PAL Address: TODO
+ * PAL Address: 0x80021008
  * PAL Size: 416b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CPad::Init()
 {
-	_4_2_ = 0;
-	_8_2_ = 0;
-	_448_4_ = 0;
-	_452_4_ = 0;
+	char* const base = reinterpret_cast<char*>(this);
+	PADInit();
+	memset(base + 4, 0, 0x1A4);
+
+	*reinterpret_cast<unsigned int*>(base + 0x1A8) = 0;
+	*reinterpret_cast<unsigned int*>(base + 0x1AC) = 0;
+	*reinterpret_cast<unsigned int*>(base + 0x1B0) = 0;
+	*reinterpret_cast<unsigned int*>(base + 0x1BC) = 0;
+	*reinterpret_cast<unsigned int*>(base + 0x1C0) = 0xFFFFFFFF;
+	*reinterpret_cast<unsigned int*>(base + 0x1C8) = 1;
+
+	if (!System.IsGdev())
+	{
+		return;
+	}
+
+	CMemory::CStage* stage = Memory.CreateStage(0x800000, (char*)"pad.cpp", 1);
+	*reinterpret_cast<CMemory::CStage**>(base + 0x1AC) = stage;
+	if (stage == nullptr)
+	{
+		return;
+	}
+
+	unsigned char* replayBuf = new (stage, (char*)"pad.cpp", 0x54) unsigned char[0x69780C];
+	*reinterpret_cast<unsigned char**>(base + 0x1B0) = replayBuf;
+	if (replayBuf == nullptr)
+	{
+		return;
+	}
+
+	if ((*reinterpret_cast<int*>(base + 0x1B4) == 0))
+	{
+		reinterpret_cast<int*>(replayBuf)[0] = 0xC;
+		reinterpret_cast<int*>(replayBuf)[1] = 1;
+		reinterpret_cast<int*>(replayBuf)[2] = 0;
+		return;
+	}
+
+	FILE* fp = fopen("replay.dat", "rb");
+	if (fp == nullptr)
+	{
+		reinterpret_cast<int*>(replayBuf)[0] = 0xC;
+		reinterpret_cast<int*>(replayBuf)[1] = 1;
+		reinterpret_cast<int*>(replayBuf)[2] = 0;
+		return;
+	}
+
+	fseek(fp, 0, 2);
+	unsigned int size = ftell(fp);
+	fseek(fp, 0, 0);
+	fread(replayBuf, 1, size, fp);
+	fclose(fp);
+
+	reinterpret_cast<unsigned int*>(replayBuf)[1] = 0;
+	int frames = reinterpret_cast<int*>(replayBuf)[2];
+	frames = frames / 0x1E + (frames >> 0x1F);
+	System.Printf((char*)"replay frames=%d\n", frames - (frames >> 0x1F));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80020fb0
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CPad::Quit()
 {
-	// TODO
+	char* const base = reinterpret_cast<char*>(this);
+	void* replayBuf = *reinterpret_cast<void**>(base + 0x1B0);
+	if (replayBuf != nullptr)
+	{
+		operator delete(replayBuf);
+		*reinterpret_cast<void**>(base + 0x1B0) = nullptr;
+	}
+
+	CMemory::CStage* stage = *reinterpret_cast<CMemory::CStage**>(base + 0x1AC);
+	if (stage != nullptr)
+	{
+		Memory.DestroyStage(stage);
+	}
 }
 
 /*
  * --INFO--
  * PAL Address: TODO
  * PAL Size: 2844b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CPad::Frame()
 {
@@ -59,8 +156,12 @@ void CPad::Frame()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CPad::SaveReplayData()
 {


### PR DESCRIPTION
## Summary
- Reconstructed `CPad::Init()` and `CPad::Quit()` in `src/pad.cpp` from the available PAL decomp/shape instead of placeholder logic.
- Added the missing runtime interactions used by this unit: `PADInit`, pad-state initialization block writes, optional replay buffer bootstrap on GDEV, replay file read path, and stage/replay cleanup in `Quit`.
- Switched `include/ffcc/pad.h` to use Dolphin's canonical `PADStatus` definition to avoid duplicate type definitions and keep pad ABI usage consistent.

## Functions Improved
- Unit: `main/pad`
- `Init__4CPadFv`: **4.0% -> 53.8173%**
- `Quit__4CPadFv`: **4.5% -> 92.7273%**

## Match Evidence
- Build passes with `ninja`.
- Objdiff commands used:
  - `build/tools/objdiff-cli diff -p . -u main/pad -o - Init__4CPadFv`
  - `build/tools/objdiff-cli diff -p . -u main/pad -o - Quit__4CPadFv`
- Current report (`build/GCCP01/report.json`) confirms higher fuzzy matches for both symbols.
- Improvement is instruction-level, not rename/format-only; both functions now emit substantial control flow and call patterns matching the target (allocator/stage and teardown paths).

## Plausibility Rationale
- The updates reflect source-plausible game code patterns already used in this codebase: explicit subsystem init (`PADInit`), stage-backed allocation for large replay data, guarded debug-device path handling, and symmetric resource release in `Quit`.
- The change removes placeholder behavior and replaces it with straightforward engine-style lifecycle logic rather than contrived compiler-only coercions.

## Technical Notes
- `CPad` layout is still partially unknown, so this pass uses offset-based field access where required by current headers.
- `Frame__4CPadFv` remains the major unmatched symbol in this unit and is unchanged in this PR.
