### PR TITLE
main/maphit: recover CMapHit and CMapHitFace constructor state

### DIFF
--- a/include/ffcc/maphit.h
+++ b/include/ffcc/maphit.h
@@ -31,6 +31,12 @@ class CMapHitFace
 {
 public:
     CMapHitFace();
+
+    // TODO: decode concrete fields used by collision and rendering.
+    unsigned char _unk0[0x10]; // 0x00
+    Vec m_boundsMin;            // 0x10
+    Vec m_boundsMax;            // 0x1c
+    unsigned char _unk28[0x28]; // 0x28
 };
 
 class CMapHit
@@ -51,6 +57,13 @@ public:
     void Draw();
     void DrawWire();
     void DrawNormal();
+
+    unsigned short m_vertexCount; // 0x00
+    unsigned short m_faceCount;   // 0x02
+    Vec m_positionMin;            // 0x04
+    Vec m_positionMax;            // 0x10
+    Vec* m_vertices;              // 0x1c
+    CMapHitFace* m_faces;         // 0x20
 };
 
 #endif // _FFCC_MAPHIT_H_

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -32,22 +32,52 @@ CMapCylinder::CMapCylinder()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80026dec
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMapHit::CMapHit()
 {
-	// TODO
+    m_positionMin.x = 0.0f;
+    m_positionMin.y = 0.0f;
+    m_positionMin.z = 0.0f;
+
+    m_positionMax.x = 1.0f;
+    m_positionMax.y = 1.0f;
+    m_positionMax.z = 1.0f;
+
+    m_vertexCount = 0;
+    m_faceCount = 0;
+    m_vertices = 0;
+    m_faces = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80026d5c
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMapHit::~CMapHit()
 {
-	// TODO
+    if (m_vertices != 0) {
+        delete[] m_vertices;
+        m_vertices = 0;
+    }
+
+    if (m_faces != 0) {
+        delete[] m_faces;
+        m_faces = 0;
+    }
+
+    m_vertexCount = 0;
+    m_faceCount = 0;
 }
 
 /*
@@ -182,10 +212,20 @@ void CMapHit::DrawNormal()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80026d38
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMapHitFace::CMapHitFace()
 {
-	// TODO
+    m_boundsMin.x = 0.0f;
+    m_boundsMin.y = 0.0f;
+    m_boundsMin.z = 0.0f;
+
+    m_boundsMax.x = 1.0f;
+    m_boundsMax.y = 1.0f;
+    m_boundsMax.z = 1.0f;
 }


### PR DESCRIPTION
## Summary
- Added concrete `CMapHit` and `CMapHitFace` member layout in `include/ffcc/maphit.h` from observed object offsets.
- Implemented `CMapHit::CMapHit()` and `CMapHitFace::CMapHitFace()` initialization patterns from decomp behavior.
- Implemented `CMapHit::~CMapHit()` cleanup of allocated vertex/face arrays and reset counters/pointers.
- Updated touched function info blocks with PAL address/size metadata.

## Functions Improved
- Unit: `main/maphit`
- `__ct__11CMapHitFaceFv`: **11.111111% -> 98.44444%**
- `__ct__7CMapHitFv`: **7.142857% -> 99.0%**

## Match Evidence
- `objdiff-cli diff -p . -u main/maphit -o - __ct__11CMapHitFaceFv`
- Unit `.text` match moved from **0.57055914% -> 1.3586916%** after this patch.

## Plausibility Rationale
- The change restores natural object state initialization (zero/one vector defaults, null pointers, zero counts), which is standard game runtime source behavior for collision containers.
- Added member fields instead of pointer-offset writes, preserving readable and maintainable source while matching observed binary field offsets.

## Technical Details
- Constructor values and field offsets were derived from `ReadOtmHit__7CMapHitFR10CChunkFile`, `__ct__7CMapHitFv`, and `__ct__11CMapHitFaceFv` decomp references.
- `CMapHit` layout now aligns with observed accesses at offsets `0x00/0x02/0x04/0x10/0x1c/0x20`.
- `CMapHitFace` includes explicit `0x10` and `0x1c` vector fields used by constructor setup, with remaining bytes kept as unknown placeholders pending deeper recovery.
