### PR TITLE
pppVertexApMtx: reconstruct main routine and fix prototype

### DIFF
--- a/include/ffcc/pppVertexApMtx.h
+++ b/include/ffcc/pppVertexApMtx.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void pppVertexApMtxCon(_pppPObject* obj, PVertexApMtx* vtx);
-void pppVertexApMtx(void);
+void pppVertexApMtx(_pppPObject*, PVertexApMtx*, void*);
 
 #ifdef __cplusplus
 }

--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -1,4 +1,66 @@
 #include "ffcc/pppVertexApMtx.h"
+#include "ffcc/math.h"
+#include "ffcc/partMng.h"
+
+#include <dolphin/mtx.h>
+#include <dolphin/types.h>
+
+struct VertexApMtxEntry
+{
+	s16 vertexSetIndex;
+	s16 maxValue;
+	u16* vertexIndices;
+};
+
+struct VertexApMtxEnv
+{
+	u8 unk0[0x8];
+	void* unk8;
+	u8 unkC[0x4];
+	VertexApMtxEntry* entries;
+};
+
+struct VertexApMtxData
+{
+	u8 unk0[0x4];
+	s16 entryIndex;
+	u8 spawnCount;
+	u8 spawnDelay;
+	u8 mode;
+	u8 useWorldMtx;
+	u32 childId;
+	u32 childMtxOffset;
+};
+
+struct VertexApMtxState
+{
+	u16 index;
+	u16 countdown;
+};
+
+struct VertexApMtxCtrl
+{
+	u8 unk0[0xC];
+	s32* stateOffset;
+};
+
+struct VertexApMtxSource
+{
+	u8 unk0[0x2C];
+	Vec* points;
+};
+
+struct _pppPDataVal;
+
+extern CMath math;
+extern int lbl_8032ED70;
+extern u8* lbl_8032ED50;
+extern VertexApMtxEnv* lbl_8032ED54;
+
+extern "C" {
+f32 RandF__5CMathFv(CMath*);
+_pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
+}
 
 /*
  * --INFO--
@@ -11,29 +73,149 @@
  */
 void pppVertexApMtxCon(_pppPObject* obj, PVertexApMtx* vtx)
 {
-	int offset = **(int**)((char*)vtx + 0xc);
-	char* target = (char*)obj + offset + 0x80;
+	s32 offset = **(s32**)((u8*)vtx + 0xC);
+	u16* state = (u16*)((u8*)obj + offset + 0x80);
 
-	*(short*)target = 0;
-	*(short*)(target + 2) = 0;
+	state[0] = 0;
+	state[1] = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void apea(_pppPObject*, PVertexApMtx*, Vec*)
 {
-	// TODO
+	// Intentionally empty.
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800de360
+ * PAL Size: 880b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppVertexApMtx(void)
+void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 {
-	// TODO
+	VertexApMtxData* data = (VertexApMtxData*)dataRaw;
+	VertexApMtxCtrl* ctrl = (VertexApMtxCtrl*)ctrlRaw;
+	s32 stateOffset = *ctrl->stateOffset;
+	VertexApMtxState* state = (VertexApMtxState*)((u8*)parent + stateOffset + 0x80);
+
+	if (lbl_8032ED70 != 0) {
+		return;
+	}
+
+	if (data->entryIndex < 0) {
+		return;
+	}
+
+	if (state->countdown == 0) {
+		VertexApMtxEntry* entry = &lbl_8032ED54->entries[data->entryIndex];
+		Vec* points = *(Vec**)((u8*)parent + 0x70);
+
+		if (points == 0) {
+			u32* srcTable = *(u32**)((u8*)lbl_8032ED54 + 0x8);
+			VertexApMtxSource* src = *(VertexApMtxSource**)((u8*)srcTable + (entry->vertexSetIndex * 4));
+			points = src->points;
+		}
+
+		u8 count = data->spawnCount;
+
+		if (data->mode == 0) {
+			do {
+				if (state->index >= (u16)entry->maxValue) {
+					state->index = 0;
+				}
+
+				u16 vertexIndex = entry->vertexIndices[state->index];
+				state->index++;
+
+				Vec vtx = points[vertexIndex];
+
+				if ((data->childId + 0x10000) != 0xFFFF) {
+					_pppPObject* child;
+					_pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
+
+					if (childData == 0) {
+						child = 0;
+					} else {
+						child = pppCreatePObject((_pppMngSt*)lbl_8032ED50, childData);
+						*(void**)((u8*)child + 0x4) = parent;
+					}
+
+					Vec transformed;
+					Mtx* outMtx = (Mtx*)((u8*)child + data->childMtxOffset + 0x80);
+
+					PSMTXMultVec(*(Mtx*)((u8*)parent + 0x10), &vtx, &transformed);
+
+					if (data->useWorldMtx == 0) {
+						PSMTXIdentity(*outMtx);
+						(*outMtx)[0][3] = transformed.x;
+						(*outMtx)[1][3] = transformed.y;
+						(*outMtx)[2][3] = transformed.z;
+					} else {
+						Mtx* worldMtx = (Mtx*)((u8*)lbl_8032ED50 + 0x78);
+						Vec worldPos;
+
+						PSMTXCopy(*worldMtx, *outMtx);
+						PSMTXMultVec(*worldMtx, &transformed, &worldPos);
+						(*outMtx)[0][3] = worldPos.x;
+						(*outMtx)[1][3] = worldPos.y;
+						(*outMtx)[2][3] = worldPos.z;
+					}
+				}
+			} while (count-- != 0);
+		} else if (data->mode == 1) {
+			do {
+				u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
+				Vec vtx = points[vertexIndex];
+
+				if ((data->childId + 0x10000) != 0xFFFF) {
+					_pppPObject* child;
+					_pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
+
+					if (childData == 0) {
+						child = 0;
+					} else {
+						child = pppCreatePObject((_pppMngSt*)lbl_8032ED50, childData);
+						*(void**)((u8*)child + 0x4) = parent;
+					}
+
+					Vec transformed;
+					Mtx* outMtx = (Mtx*)((u8*)child + data->childMtxOffset + 0x80);
+
+					PSMTXMultVec(*(Mtx*)((u8*)parent + 0x10), &vtx, &transformed);
+
+					if (data->useWorldMtx == 0) {
+						PSMTXIdentity(*outMtx);
+						(*outMtx)[0][3] = transformed.x;
+						(*outMtx)[1][3] = transformed.y;
+						(*outMtx)[2][3] = transformed.z;
+					} else {
+						Mtx* worldMtx = (Mtx*)((u8*)lbl_8032ED50 + 0x78);
+						Vec worldPos;
+
+						PSMTXCopy(*worldMtx, *outMtx);
+						PSMTXMultVec(*worldMtx, &transformed, &worldPos);
+						(*outMtx)[0][3] = worldPos.x;
+						(*outMtx)[1][3] = worldPos.y;
+						(*outMtx)[2][3] = worldPos.z;
+					}
+				}
+			} while (count-- != 0);
+		}
+
+		state->countdown = data->spawnDelay;
+	}
+
+	state->countdown--;
 }


### PR DESCRIPTION
## Summary
- Reconstructed `pppVertexApMtx` from the target assembly shape into plausible source-level control flow.
- Updated `pppVertexApMtx` prototype to the correct callable form: `(_pppPObject*, PVertexApMtx*, void*)`.
- Kept `pppVertexApMtxCon` intact semantically while standardizing types/offset handling used by this unit.
- Added explicit local structs for data/state/env layouts used by this routine so field access maps to observed ABI offsets.

## Functions improved
- Unit: `main/pppVertexApMtx`
- Function: `pppVertexApMtx` (`0x800D2250`, size `0x370`)
- Companion function: `pppVertexApMtxCon` (`0x800D25C0`, size `0x20`)

## Match evidence
- Selector baseline before edits: `pppVertexApMtx` reported at **0.5%** match (target listing from `tools/agent_select_target.py`).
- After reconstruction (`ninja` + report):
  - `pppVertexApMtx` fuzzy match: **65.586365%** (`build/GCCP01/report.json`)
  - `pppVertexApMtxCon` fuzzy match: **100%** (`build/GCCP01/report.json`)
- Objdiff oneshot for the symbol reports `.text` section fuzzy match around **66.7%** for the unit and **~65.5%** on `pppVertexApMtx`.

## Plausibility rationale
- The new implementation follows existing particle-system patterns already used in neighboring units (`pppVertexApAt`, `pppPointApMtx`):
  - state countdown gating,
  - per-spawn child creation through `pppCreatePObject`,
  - matrix setup via `PSMTXIdentity`/`PSMTXCopy`/`PSMTXMultVec`,
  - translation assignment into `[0][3]/[1][3]/[2][3]`.
- Changes are type/layout corrections and control-flow reconstruction, not artificial compiler-coaxing temporaries.

## Technical details
- Implemented both mode paths seen in assembly (`mode == 0` sequential index and `mode == 1` random index).
- Preserved global gate behavior (`lbl_8032ED70`) and state initialization/update semantics (`index`, `countdown`).
- Mapped data fields with compact local structs at observed offsets (`entryIndex`, `spawnCount`, `spawnDelay`, `mode`, `useWorldMtx`, `childId`, `childMtxOffset`).

## Validation
- `ninja` succeeds for GCCP01.
