### PR TITLE
os: improve __OSReboot match in OSReboot

### DIFF
--- a/src/os/OSReboot.c
+++ b/src/os/OSReboot.c
@@ -97,7 +97,7 @@ void __OSReboot(u32 resetCode, u32 bootDol) {
 
     while (Prepared != TRUE) {
 #if SDK_REVISION < 1
-        if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+        if (!DVDCheckDisk() || (OSGetTime() - start) > OS_TIMER_CLOCK)
 #else
         if (!DVDCheckDisk())
 #endif
@@ -117,7 +117,7 @@ void __OSReboot(u32 resetCode, u32 bootDol) {
 
         while (DVDGetCommandBlockStatus(&streamCancelBlock)) {
 #if SDK_REVISION < 1
-            if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+            if (!DVDCheckDisk() || (OSGetTime() - start) > OS_TIMER_CLOCK)
 #else
             if (!DVDCheckDisk())
 #endif
@@ -137,7 +137,7 @@ void __OSReboot(u32 resetCode, u32 bootDol) {
 
     while (DVDGetCommandBlockStatus(&appLoaderReadBlock)) {
 #if SDK_REVISION < 1
-        if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+        if (!DVDCheckDisk() || (OSGetTime() - start) > OS_TIMER_CLOCK)
 #else
         if (!DVDCheckDisk())
 #endif
@@ -147,7 +147,7 @@ void __OSReboot(u32 resetCode, u32 bootDol) {
     }
 
     rebootSize = OSRoundUp32B(FatalParam.rebootSize);
-    DVDReadAbsAsyncPrio(&rebootReadBlock, (void*)0x81300000, rebootSize, FatalParam.size + 0x2460, NULL, 0);
+    DVDReadAbsAsyncPrio(&rebootReadBlock, (void*)0x81300000, rebootSize, FatalParam.size + 0x20 + 0x2440, NULL, 0);
 
 #if SDK_REVISION < 1
     start = OSGetTime();
@@ -155,7 +155,7 @@ void __OSReboot(u32 resetCode, u32 bootDol) {
 
     while (DVDGetCommandBlockStatus(&rebootReadBlock)) {
 #if SDK_REVISION < 1
-        if (!DVDCheckDisk() || OS_TIMER_CLOCK < (OSGetTime() - start))
+        if (!DVDCheckDisk() || (OSGetTime() - start) > OS_TIMER_CLOCK)
 #else
         if (!DVDCheckDisk())
 #endif


### PR DESCRIPTION
## Summary
- Rewrote SDK_REVISION < 1 timeout checks in __OSReboot to an equivalent form: (OSGetTime() - start) > OS_TIMER_CLOCK.
- Rewrote the reboot payload read offset expression from FatalParam.size + 0x2460 to FatalParam.size + 0x20 + 0x2440.
- No behavior changes intended; these are expression-shape adjustments to better match original codegen.

## Functions improved
- Unit: main/os/OSReboot
- Symbol: __OSReboot

## Match evidence
- __OSReboot match: 73.38942% -> 73.66346% (+0.27404)
- OSReboot.o .text match: 72.372086% -> 72.63721% (+0.265124)
- Measured with:
  - build/tools/objdiff-cli diff -p . -u main/os/OSReboot -o - __OSReboot

## Plausibility rationale
- Both edits preserve semantics and read naturally as production source:
  - Timeout check compares elapsed time against OS_TIMER_CLOCK directly.
  - Offset math is expressed as apploader header (0x20) plus base offset (0x2440), which aligns with adjacent apploader reads.
- No contrived temporaries or non-idiomatic control flow were introduced.

## Technical details
- Objdiff showed better alignment in the reboot read setup block and SDK_REVISION < 1 loop condition codegen.
- Changes were kept minimal and localized to src/os/OSReboot.c to avoid unrelated codegen noise.
