### PR TITLE
Reconstruct pppVertexApLc control flow and data layout

### DIFF
--- a/include/ffcc/pppVertexApLc.h
+++ b/include/ffcc/pppVertexApLc.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 
 void pppVertexApLcCon(_pppPObject*, PVertexApLc*);
-void pppVertexApLc(_pppPObject*, PVertexApLc*, Vec*);
+void pppVertexApLc(_pppPObject*, PVertexApLc*, void*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Reworked `pppVertexApLc` from placeholder logic into a structured implementation matching the existing `pppVertexApAt`/`pppVertexApMtx` pattern.
- Added typed local layouts for entry/env/data/state/control/source blocks to express the original field usage and offsets.
- Fixed `pppVertexApLcCon` to initialize state via the control-derived offset pattern used by sibling units.
- Updated `pppVertexApLc` declaration to use a control pointer (`void*`) for its third parameter.

## Functions improved
- `main/pppVertexApLc::pppVertexApLc`
- `main/pppVertexApLc::pppVertexApLcCon`

## Match evidence
- `pppVertexApLc`: **8.679739% -> 65.01961%** (objdiff symbol match)
- `pppVertexApLcCon`: **98.125% -> 100.0%** (objdiff symbol match)
- Unit `.text` section match for `main/pppVertexApLc`: **66.75777%** (objdiff)

## Plausibility rationale
- The new code follows the same high-level control-flow and data-access conventions already present in adjacent particle units (`VertexApAt`/`VertexApMtx`), rather than introducing compiler-only tricks.
- Changes are primarily type/offset reconstruction, signedness/loop semantics, and branch structure that align with the observed assembly behavior.

## Technical details
- Reconstructed countdown/state-index loop semantics, including sequential/random vertex selection modes.
- Reintroduced parent-child spawn path and child output writes using data-driven offsets.
- Preserved expected early exits (global flag and negative entry index) and post-frame countdown decrement behavior.
