### PR TITLE
main/wmm_str: implement memory-card string selectors

### DIFF
--- a/include/ffcc/wmm_str.h
+++ b/include/ffcc/wmm_str.h
@@ -4,9 +4,9 @@
 class CMenuPcs
 {
 public:
-    void GetMcStr(int);
-    void GetMcWinMessBuff(int);
-    void GetWinMess(int);
+    const char* GetMcStr(int);
+    const char* const* GetMcWinMessBuff(int);
+    const char* GetWinMess(int);
     void GetYesNoXPos(int);
     void GetSlotABXPos(int);
 };

--- a/src/wmm_str.cpp
+++ b/src/wmm_str.cpp
@@ -1,39 +1,150 @@
 #include "ffcc/wmm_str.h"
+#include "ffcc/p_game.h"
+
+extern const char* lbl_80215BD8[];
+extern const char* lbl_80215BE8[];
+extern const char* lbl_80215BF8[];
+extern const char* lbl_80215C08[];
+extern const char* lbl_80215C18[];
+
+extern const char* lbl_80215C28[];
+extern const char* lbl_80215D14[];
+extern const char* lbl_80215E00[];
+extern const char* lbl_80215EEC[];
+extern const char* lbl_80215FD8[];
+
+extern const char* lbl_802160C4[];
+extern const char* lbl_80216140[];
+extern const char* lbl_802161BC[];
+extern const char* lbl_80216238[];
+extern const char* lbl_802162B4[];
+
+extern const char* lbl_80216330[];
+extern const char* lbl_8021636C[];
+extern const char* lbl_802163A8[];
+extern const char* lbl_802163E4[];
+extern const char* lbl_80216420[];
+
+extern const char lbl_8021645C[];
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017b3f8
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetMcStr(int)
+const char* CMenuPcs::GetMcStr(int index)
 {
-	// TODO
+    const unsigned int languageId = Game.game.m_gameWork.m_languageId;
+    if (languageId == 3) {
+        return lbl_80215BF8[index];
+    }
+    if (languageId < 3) {
+        if ((languageId != 1) && (languageId != 0)) {
+            return lbl_80215BE8[index];
+        }
+    } else {
+        if (languageId == 5) {
+            return lbl_80215C18[index];
+        }
+        if (languageId < 5) {
+            return lbl_80215C08[index];
+        }
+    }
+    return lbl_80215BD8[index];
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017b268
+ * PAL Size: 400b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetMcWinMessBuff(int)
+const char* const* CMenuPcs::GetMcWinMessBuff(int group)
 {
-	// TODO
+    const unsigned int languageId = Game.game.m_gameWork.m_languageId;
+    if (group != 0) {
+        if (group != 1) {
+            if (languageId == 3) {
+                return lbl_802161BC;
+            }
+            if (languageId < 3) {
+                if ((languageId != 1) && (languageId != 0)) {
+                    return lbl_80216140;
+                }
+            } else {
+                if (languageId == 5) {
+                    return lbl_802162B4;
+                }
+                if (languageId < 5) {
+                    return lbl_80216238;
+                }
+            }
+            return lbl_802160C4;
+        }
+        if (languageId == 3) {
+            return lbl_802163A8;
+        }
+        if (languageId < 3) {
+            if ((languageId != 1) && (languageId != 0)) {
+                return lbl_8021636C;
+            }
+        } else {
+            if (languageId == 5) {
+                return lbl_80216420;
+            }
+            if (languageId < 5) {
+                return lbl_802163E4;
+            }
+        }
+        return lbl_80216330;
+    }
+    if (languageId == 3) {
+        return lbl_80215E00;
+    }
+    if (languageId < 3) {
+        if ((languageId != 1) && (languageId != 0)) {
+            return lbl_80215D14;
+        }
+    } else {
+        if (languageId == 5) {
+            return lbl_80215FD8;
+        }
+        if (languageId < 5) {
+            return lbl_80215EEC;
+        }
+    }
+    return lbl_80215C28;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017b220
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetWinMess(int)
+const char* CMenuPcs::GetWinMess(int index)
 {
-	// TODO
+    return &lbl_8021645C[index * 0x14];
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017b0a0
+ * PAL Size: 384b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::GetYesNoXPos(int)
 {
@@ -42,8 +153,12 @@ void CMenuPcs::GetYesNoXPos(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017af14
+ * PAL Size: 396b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::GetSlotABXPos(int)
 {


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::GetMcStr`, `CMenuPcs::GetMcWinMessBuff`, and `CMenuPcs::GetWinMess` in `src/wmm_str.cpp`.
- Switched these functions from TODO stubs to language-dispatch logic that selects existing in-binary message tables.
- Updated `include/ffcc/wmm_str.h` return types to match the implemented behavior.
- Added PAL address/size metadata blocks for all functions in this unit.

## Functions improved
- `GetMcStr__8CMenuPcsFi`
- `GetMcWinMessBuff__8CMenuPcsFi`
- `GetWinMess__8CMenuPcsFi`

## Match evidence
- Unit baseline from target selector: `main/wmm_str` at **1.4%** current match.
- Current unit `.text` match (objdiff): **19.522728%**.
- Function-level (objdiff):
  - `GetMcStr__8CMenuPcsFi`: **52.666668%**
  - `GetMcWinMessBuff__8CMenuPcsFi`: **41.18%**
  - `GetWinMess__8CMenuPcsFi`: **27.777779%**

Commands used:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/wmm_str -o - GetMcStr__8CMenuPcsFi`
- `build/tools/objdiff-cli diff -p . -u main/wmm_str -o - GetMcWinMessBuff__8CMenuPcsFi`
- `build/tools/objdiff-cli diff -p . -u main/wmm_str -o - GetWinMess__8CMenuPcsFi`

## Plausibility rationale
- The implementation maps directly to language ID dispatch patterns used in the decomp reference.
- It references existing game data labels (`lbl_...`) rather than inventing new runtime behavior.
- Control flow is straightforward and source-plausible (branching by language and message group), not compiler-coaxing.

## Technical details
- Preserved JP/UK shared fallback behavior and distinct branches for GR/IT/FR/SP.
- Preserved grouped message-table selection in `GetMcWinMessBuff` (`group == 0`, `group == 1`, fallback group).
- `GetWinMess` now resolves fixed-stride entries from the base window-message table (`+ 0x14 * index`).
