### PR TITLE
main/mapocttree: implement setbit32

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -3,12 +3,23 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8002d9fc
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void setbit32(unsigned long*, unsigned long)
+void setbit32(unsigned long* arg0, unsigned long arg1)
 {
-	// TODO
+	unsigned long* bits;
+	unsigned long offset;
+	unsigned long mask;
+
+	bits = (unsigned long*)((unsigned char*)arg0 + ((arg1 >> 3) & 0x1ffffffc));
+	offset = arg1 & 0x1f;
+	mask = 1UL << offset;
+	*bits |= mask;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `setbit32(unsigned long*, unsigned long)` in `src/mapocttree.cpp` using direct bitset index/mask operations.
- Updated the function info block with PAL address/size metadata from decomp resources.

## Functions improved
- Unit: `main/mapocttree`
- Symbol: `setbit32__FPUlUl`

## Match evidence
- `setbit32__FPUlUl`: **12.5% -> 100.0%** (`objdiff-cli` JSON output)
- Build verification: `ninja` completed successfully after the change.

## Plausibility rationale
- The implementation is a conventional 32-bit bitset setter:
  - word selection from bit index
  - bit mask from low 5 bits
  - OR writeback
- This is source-plausible game code and avoids contrived compiler-coaxing constructs.

## Technical details
- Implementation mirrors the decompilation behavior while preserving idiomatic C/C++ structure.
- Change scope is intentionally minimal (single function) to isolate and verify a real symbol-level match gain.
