### PR TITLE
main/pppColum: improve pppFrameColum match via buffer/layout alignment

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -43,10 +43,11 @@ void pppConstructColum(pppColum *column, UnkC *param_2)
  */
 void pppDestructColum(pppColum *column, UnkC *param_2)
 {
-    int iVar1 = param_2->m_serializedDataOffsets[3];
-    if (*(CStage**)(&column->field_0x88 + iVar1) != 0) {
-        pppHeapUseRate(*(CMemory::CStage**)(&column->field_0x88 + iVar1));
-        *(void**)(&column->field_0x88 + iVar1) = 0;
+    char* work = (char*)column + 0x80 + param_2->m_serializedDataOffsets[3];
+
+    if (*(CMemory::CStage**)(work + 8) != 0) {
+        pppHeapUseRate(*(CMemory::CStage**)(work + 8));
+        *(void**)(work + 8) = 0;
     }
 }
 
@@ -61,34 +62,36 @@ void pppDestructColum(pppColum *column, UnkC *param_2)
  */
 void pppFrameColum(pppColum *column, UnkB *param_2, UnkC *param_3)
 {
-    unsigned char* work = (unsigned char*)((char*)column + 0x80 + param_3->m_serializedDataOffsets[3]);
-
     if (lbl_8032ED70 == 0) {
-        unsigned char count = *((unsigned char*)&param_2->m_arg3 + 1);
+        unsigned char* work = (unsigned char*)((char*)column + 0x80 + param_3->m_serializedDataOffsets[3]);
 
         if (*(void**)(work + 8) == 0) {
-            float* values;
-            char* payload = param_2->m_payload;
-            unsigned int i;
+            float* values = (float*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                (unsigned long)(*((unsigned char*)&param_2->m_arg3 + 1) * 0xc),
+                pppEnvStPtr->m_stagePtr, (char*)"pppColum.cpp", 0x7d);
+            int i;
+            unsigned char count = *((unsigned char*)&param_2->m_arg3 + 1);
 
-            *(void**)(work + 8) = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-                (unsigned long)count * 0xc, pppEnvStPtr->m_stagePtr, (char*)"pppColum.cpp", 0x7d);
-
-            values = (float*)*(void**)(work + 8);
+            *(void**)(work + 8) = values;
             for (i = 0; i < count; i++) {
-                values[0] = RandF__5CMathFf(*(float*)(payload + 4), &Math) + *(float*)payload;
-                values[1] = RandF__5CMathFf(*(float*)(payload + 0xc), &Math) + *(float*)(payload + 8);
-                ((unsigned char*)values)[8] = GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)payload[0x16]);
-                ((unsigned char*)values)[9] = GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)payload[0x17]);
-                ((unsigned char*)values)[10] = GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)payload[0x18]);
+                values[0] = RandF__5CMathFf(*(float*)(param_2->m_payload + 4), &Math);
+                values[0] += *(float*)param_2->m_payload;
+                values[1] = RandF__5CMathFf(*(float*)(param_2->m_payload + 0xc), &Math);
+                values[1] += *(float*)(param_2->m_payload + 8);
+                ((unsigned char*)values)[8] =
+                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x16]);
+                ((unsigned char*)values)[9] =
+                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x17]);
+                ((unsigned char*)values)[10] =
+                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x18]);
                 values += 3;
             }
         }
 
         if (param_2->m_dataValIndex != 0xffff) {
-            short* shape = (short*)work;
             long* shapeTable = *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4);
-            pppCalcFrameShape__FPlRsRsRss(shapeTable, shape[0], shape[1], shape[2], (short)param_2->m_initWOrk);
+            pppCalcFrameShape__FPlRsRsRss(shapeTable, *(short*)(work + 0), *(short*)(work + 2),
+                                          *(short*)(work + 4), (short)param_2->m_initWOrk);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refined `pppFrameColum` work-buffer handling to follow existing column data layout (`column + 0x80 + serializedOffset`) within the active-flag branch.
- Reworked allocation/initialization flow for per-particle column values to use explicit staged assignments (`RandF` then base add), with byte-level noise channel writes preserved.
- Updated frame-shape call arguments to explicit short loads from the work buffer.
- Aligned `pppDestructColum` pointer access to the same byte-based work-buffer layout used by constructor/frame paths.

## Functions Improved
- Unit: `main/pppColum`
- Symbol: `pppFrameColum`
  - Before: `61.209877%`
  - After: `70.06173%`
  - Delta: `+8.851853` points

## Match Evidence
- `ninja` rebuild succeeds after changes.
- `objdiff` symbol score for `pppFrameColum` improved from `61.209877%` -> `70.06173%`.
- Instruction-level trend for `pppFrameColum`:
  - `MATCH`: `23` -> `37`
  - `DIFF_DELETE`: `14` -> `6`
  - `DIFF_REPLACE`: `10` -> `7`
  - `DIFF_ARG_MISMATCH`: `34` -> `31`

## Plausibility Rationale
- Changes are type/layout corrections and control-flow shaping consistent with surrounding source patterns, not artificial compiler coaxing.
- Byte-offset work buffer usage is already the established model in `pppConstructColum` and naturally extends to frame/destruct paths.
- The updated arithmetic and call ordering reflects straightforward game-side initialization logic for particle column data.

## Technical Details
- Consolidated `work` base calculation into the active branch to better match register lifetimes.
- Kept allocation size and source literal (`"pppColum.cpp", 0x7d`) intact while adjusting variable lifetimes and assignment forms.
- Preserved existing semantics for `GetNoise__5CUtilFUc` channel generation and `pppCalcFrameShape__FPlRsRsRss` invocation.
