### PR TITLE
textureman: implement CTextureMan Init/Quit

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -56,6 +56,10 @@ public:
     void Quit();
     void SetTexture(_GXTexMapID, CTexture*);
     void SetTextureTev(CTexture*);
+
+private:
+    void* m_vtable;
+    CMemory::CStage* m_memoryStage;
 };
 
 #endif // _FFCC_PPP_TEXTUREMAN_H_

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -12,22 +12,30 @@ CTextureMan::CTextureMan()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003BDF4
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CTextureMan::Init()
 {
-	// TODO
+	m_memoryStage = Memory.CreateStage(0x40000, (char*)"CTexture.texture", 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003BDC4
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CTextureMan::Quit()
 {
-	// TODO
+	Memory.DestroyStage(m_memoryStage);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement `CTextureMan::Init` and `CTextureMan::Quit` in `textureman` using the expected memory-stage create/destroy flow, and add the minimal class state required for those methods (`vtable` slot + stage pointer).

## Functions improved
- `Init__11CTextureManFv`: 5.5555553% -> 87.22222%
- `Quit__11CTextureManFv`: 8.333333% -> 36.666668%

## Match evidence
- Unit `main/textureman` `.text` match: 2.8411267% -> 3.860845%
- Objdiff confirms these are real instruction-level gains (replacing stub `blr` bodies with stage allocation/teardown calls and matching call structure to `CMemory::CreateStage` / `CMemory::DestroyStage`).

## Plausibility rationale
- The new logic is standard engine lifecycle code: allocate a dedicated texture stage during init and destroy it during quit.
- Changes are type- and API-consistent with surrounding code that uses `CMemory::CreateStage`/`DestroyStage`.
- No contrived control-flow or compiler coaxing was introduced.

## Technical details
- Added `CTextureMan` fields in header to support decompiled access pattern: a leading `vtable` pointer slot and `CMemory::CStage*` storage.
- Updated function info blocks with PAL address/size metadata for the two touched functions.
