### PR TITLE
wind: first-pass Frame decomp implementation

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -11,6 +11,20 @@
 extern CGraphic Graphic;
 extern CCameraPcs CameraPcs;
 extern u32 CFlat; // Temporary - needs proper declaration
+extern CMath Math;
+
+extern "C" int Rand__5CMathFUl(CMath*, unsigned long);
+extern "C" float RandF__5CMathFv(CMath*);
+
+extern float FLOAT_80330ef0;
+extern float FLOAT_80330f20;
+extern float FLOAT_80330f24;
+extern float FLOAT_80330f28;
+extern float FLOAT_80330f2c;
+extern float FLOAT_80330f30;
+extern float FLOAT_80330f34;
+extern float FLOAT_80330f38;
+extern double DOUBLE_80330f40;
 
 /*
  * --INFO--
@@ -32,13 +46,89 @@ void CWind::ClearAll()
  */
 void CWind::Frame()
 {
-	// Basic loop structure to get started
-	for (int i = 0; i < 32; i++) {
-		WindObject* obj = &m_objects[i];
-		if (obj->flags & 0x80) {
-			// Wind object processing - TODO: implement full logic
-		}
-	}
+    u8* obj = (u8*)this;
+
+    for (int i = 0; i < 32; i++, obj += 100) {
+        if ((s8)obj[0] >= 0) {
+            continue;
+        }
+
+        int rnd = Rand__5CMathFUl(&Math, 10);
+        if (rnd == 0) {
+            float rate = FLOAT_80330f24;
+            if (Rand__5CMathFUl(&Math, 3) == 0) {
+                rate = FLOAT_80330f20;
+            }
+
+            *(float*)(obj + 0x54) = *(float*)(obj + 0x54) + (*(float*)(obj + 0x4C) * rate);
+
+            float clamped = FLOAT_80330ef0;
+            float value = *(float*)(obj + 0x54);
+            if (clamped <= value) {
+                clamped = value;
+                if (*(float*)(obj + 0x4C) < value) {
+                    clamped = *(float*)(obj + 0x4C);
+                }
+            }
+            *(float*)(obj + 0x54) = clamped;
+        }
+
+        int type = *(int*)(obj + 0x1C);
+        if (((type == 0) || (type == 1)) &&
+            (Rand__5CMathFUl(&Math, 0x1E) == 0) &&
+            (*(float*)(obj + 0x50) < (FLOAT_80330f28 * *(float*)(obj + 0x4C)))) {
+            float rate = FLOAT_80330f30;
+            if (Rand__5CMathFUl(&Math, 3) == 0) {
+                rate = FLOAT_80330f2c;
+            }
+
+            *(float*)(obj + 0x48) = *(float*)(obj + 0x48) + (*(float*)(obj + 0x40) * rate);
+
+            float value = *(float*)(obj + 0x48);
+            float clamped = *(float*)(obj + 0x40);
+            if (clamped <= value) {
+                float max = FLOAT_80330f34 + clamped;
+                clamped = value;
+                if (max < value) {
+                    clamped = max;
+                }
+            }
+            *(float*)(obj + 0x48) = clamped;
+        }
+
+        if (type == 2) {
+            *(int*)(obj + 0x28) = *(int*)(obj + 0x28) + 1;
+            if (*(u32*)(obj + 0x24) <= *(u32*)(obj + 0x28)) {
+                obj[0] = obj[0] & 0x7F;
+                continue;
+            }
+
+            *(float*)(obj + 0x38) =
+                (float)(((double)*(int*)(obj + 0x28) - DOUBLE_80330f40) /
+                        ((double)*(int*)(obj + 0x24) - DOUBLE_80330f40));
+            *(float*)(obj + 0x30) = *(float*)(obj + 0x2C) * *(float*)(obj + 0x38);
+            *(float*)(obj + 0x34) = *(float*)(obj + 0x30) * *(float*)(obj + 0x30);
+            *(float*)(obj + 0x0C) = *(float*)(obj + 4) - *(float*)(obj + 0x30);
+            *(float*)(obj + 0x10) = *(float*)(obj + 8) - *(float*)(obj + 0x30);
+            *(float*)(obj + 0x14) = *(float*)(obj + 4) + *(float*)(obj + 0x30);
+            *(float*)(obj + 0x18) = *(float*)(obj + 8) + *(float*)(obj + 0x30);
+        }
+
+        *(float*)(obj + 0x50) =
+            *(float*)(obj + 0x50) + (FLOAT_80330f38 * (*(float*)(obj + 0x54) - *(float*)(obj + 0x50)));
+
+        *(float*)(obj + 0x44) = *(float*)(obj + 0x44) +
+                                ((FLOAT_80330f2c * RandF__5CMathFv(&Math)) +
+                                 ((FLOAT_80330f38 * (*(float*)(obj + 0x48) - *(float*)(obj + 0x44))) -
+                                  FLOAT_80330f28));
+
+        if ((type == 0) || (type == 1)) {
+            *(float*)(obj + 0x58) = *(float*)(obj + 0x50) * (float)sin((double)*(float*)(obj + 0x44));
+            *(float*)(obj + 0x5C) = *(float*)(obj + 0x50) *
+                                    (FLOAT_80330f20 * RandF__5CMathFv(&Math) + FLOAT_80330f24);
+            *(float*)(obj + 0x60) = *(float*)(obj + 0x50) * (float)cos((double)*(float*)(obj + 0x44));
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced the placeholder loop in `CWind::Frame()` with a first-pass decomp implementation based on the Ghidra control flow.
- Added the wind-frame random/update pipeline for active wind objects (flag/type checks, bounded intensity updates, type-2 lifetime progression, and sin/cos directional output updates).
- Kept changes scoped to `src/wind.cpp` and only `Frame__5CWindFv` logic.

## Functions improved
- Unit: `main/wind`
- Symbol: `Frame__5CWindFv`
- Match: `0.5235602% -> 1.0471205%`

## Match evidence
- Built with `ninja` after each measurement.
- Measured via:
  - `build/tools/objdiff-cli diff -p . -u main/wind -o - Frame__5CWindFv`
- Before metric taken from parent commit (`HEAD^`) and after metric from this branch head (`HEAD`).

## Plausibility rationale
- This is not compiler coaxing; it restores concrete runtime logic that the game likely had (object-state gating, randomized modulation, bounded accumulation, and directional vector generation).
- The implementation follows the observed data layout and control-flow structure from the decomp reference rather than artificial temporary/ordering tricks.

## Technical details
- Operates directly on per-object 100-byte records (matching observed object stride).
- Implements:
  - active-object gating via top bit in flags
  - randomized updates to amplitude/frequency-like fields with clamping
  - type-2 timed progression and radius/bounds recomputation
  - smoothing and phase updates
  - final directional component generation via `sin`/`cos`
