### PR TITLE
main/THPSimple: implement THPSimpleDrawCurrentFrame

### DIFF
--- a/include/ffcc/THPSimple.h
+++ b/include/ffcc/THPSimple.h
@@ -1,7 +1,14 @@
 #ifndef _FFCC_PPP_THPSIMPLE_H_
 #define _FFCC_PPP_THPSIMPLE_H_
 
+#include "types.h"
+#include "dolphin/gx/GXStruct.h"
+
 struct DVDFileInfo;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void checkError();
 void _kami_DVDREAD(DVDFileInfo*, void*, long, long);
@@ -20,8 +27,12 @@ void THPSimpleLoadStop(void);
 void THPSimpleDecode(void);
 void CheckPrefetch();
 void VideoDecode(unsigned char*);
-void THPSimpleDrawCurrentFrame(void);
+s32 THPSimpleDrawCurrentFrame(GXRenderModeObj*, int, int, int, int);
 void MixAudio(short*, short*, unsigned long);
 void THPAudioMixCallback();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _FFCC_PPP_THPSIMPLE_H_

--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -1,4 +1,18 @@
 #include "ffcc/THPSimple.h"
+#include "dolphin/thp/THPDraw.h"
+
+struct THPSimpleControl {
+    u8 pad0[0x80];
+    s32 texWidth;
+    s32 texHeight;
+    u8 pad88[0xAC];
+    u32* yImage;
+    u32* uImage;
+    u32* vImage;
+    s32 curFrame;
+};
+
+THPSimpleControl SimpleControl;
 
 /*
  * --INFO--
@@ -172,12 +186,28 @@ void VideoDecode(unsigned char*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80104594
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void THPSimpleDrawCurrentFrame(void)
+s32 THPSimpleDrawCurrentFrame(GXRenderModeObj* obj, int x, int y, int polyWidth, int polyHeight)
 {
-	// TODO
+	s16 drawHeight;
+
+	if (SimpleControl.curFrame < 0) {
+		return -1;
+	}
+
+	THPGXYuv2RgbSetup(obj);
+	drawHeight = static_cast<s16>(polyHeight);
+	THPGXYuv2RgbDraw(SimpleControl.yImage, SimpleControl.uImage, SimpleControl.vImage, static_cast<s16>(x),
+	                 static_cast<s16>(y), static_cast<s16>(SimpleControl.texWidth),
+	                 static_cast<s16>(SimpleControl.texHeight), static_cast<s16>(polyWidth), drawHeight);
+	THPGXRestore();
+	return SimpleControl.curFrame;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `THPSimpleDrawCurrentFrame` in `src/THPSimple.cpp` and aligned its interface in `include/ffcc/THPSimple.h`.

Key changes:
- Added C linkage block for THPSimple API declarations so this unit can emit expected unmangled symbols.
- Corrected `THPSimpleDrawCurrentFrame` signature to take render mode + draw rectangle arguments and return status.
- Implemented the THP draw flow:
  - early return `-1` when current frame is invalid
  - `THPGXYuv2RgbSetup(obj)`
  - `THPGXYuv2RgbDraw(...)` using frame buffers and texture dimensions from `SimpleControl`
  - `THPGXRestore()`
- Added PAL address/size info block for the implemented function.

## Functions Improved
- Unit: `main/THPSimple`
- Symbol: `THPSimpleDrawCurrentFrame`
  - before: selector reported `0.0%`
  - after: objdiff fuzzy match `69.86842%`

## Match Evidence
- Baseline objdiff showed target/original symbol `THPSimpleDrawCurrentFrame` (152b) while our build emitted mismatched C++ symbol form and did not align with the target function body.
- After this change, objdiff compares the same symbol directly and reports:
  - target size: `152`
  - current size: `160`
  - fuzzy match: `69.86842%`
- Build verification: `ninja` passes.

## Plausibility Rationale
This is source-plausible decomp work rather than compiler coaxing:
- It restores a normal THP draw call path that matches existing Dolphin THP APIs (`THPGXYuv2RgbSetup/Draw`, `THPGXRestore`).
- It uses inferred control fields (frame validity, Y/U/V image pointers, texture dimensions) in a straightforward way consistent with the function’s role.
- No contrived reorderings or opaque hacks were introduced; the implementation reads like expected game-side wrapper code around THP rendering.

## Technical Notes
- The first argument is intentionally forwarded into `THPGXYuv2RgbSetup`, matching the observed calling convention in the target assembly.
- The function still has a residual gap (160b vs 152b), so additional register/allocation tuning may improve it further in follow-up.
