### PR TITLE
pad: improve __sinit_pad_cpp match via CPad layout fix

### DIFF
--- a/include/ffcc/pad.h
+++ b/include/ffcc/pad.h
@@ -18,10 +18,21 @@ public:
     void Frame();
     void SaveReplayData();
 
+    void* _0_4_;
     short _4_2_;
+    short _6_2_;
     short _8_2_;
+    short _a_2_;
+    unsigned char _c_1_[0x19c];
+    unsigned int _1a8_4_;
+    void* _1ac_4_;
+    unsigned char* _1b0_4_;
     int _448_4_;
     int _452_4_;
+    int _1bc_4_;
+    unsigned int _1c0_4_;
+    unsigned int _1c4_4_;
+    unsigned int _1c8_4_;
 };
 
 extern CPad Pad;

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -14,6 +14,8 @@
 CPad Pad;
 
 void* operator new[](unsigned long, CMemory::CStage*, char*, int);
+extern void* __vt__8CManager;
+extern void* lbl_801E8864;
 
 /*
  * --INFO--
@@ -26,6 +28,9 @@ void* operator new[](unsigned long, CMemory::CStage*, char*, int);
  */
 extern "C" void __sinit_pad_cpp()
 {
+	char* const base = reinterpret_cast<char*>(&Pad);
+	*reinterpret_cast<void**>(base) = &__vt__8CManager;
+	*reinterpret_cast<void**>(base) = &lbl_801E8864;
 	Pad._448_4_ = 0;
 	Pad._452_4_ = 0;
 }


### PR DESCRIPTION
## Summary
- Corrected `CPad` field layout in `include/ffcc/pad.h` so members used by pad debug/replay logic map to the observed object offsets.
- Updated `__sinit_pad_cpp` in `src/pad.cpp` to perform explicit static initialization writes expected by this unit:
  - write base manager vtable pointer,
  - write pad vtable pointer,
  - zero the two pad state fields at `+0x1B4` and `+0x1B8`.

## Functions Improved
- Unit: `main/pad`
- Symbol: `__sinit_pad_cpp`
  - Before: `32.272728%`
  - After: `52.272728%`

## Match Evidence
- `build/tools/objdiff-cli diff -p . -u main/pad -o /tmp/pad_baseline.json __sinit_pad_cpp`
- `build/tools/objdiff-cli diff -p . -u main/pad -o /tmp/pad_after_sinit.json __sinit_pad_cpp`
- Unit `.text` match improved:
  - Before: `9.507075%`
  - After: `9.766509%`

## Plausibility Rationale
- The change matches existing project style for static manager-like object init (`p_usb`, `p_light`): explicit vtable stores and field initialization in `__sinit_*` functions.
- The offset alignment reflects existing raw offset accesses already present in `CPad::Init` and related code paths, improving source consistency rather than adding compiler-coax constructs.

## Technical Notes
- Build validated with `ninja`.
- No behavior-only scaffolding or debug artifacts were introduced.
