### PR TITLE
main/p_sample: restore GetTable and static init flow

### DIFF
--- a/include/ffcc/p_sample.h
+++ b/include/ffcc/p_sample.h
@@ -6,11 +6,9 @@
 class CSamplePcs : public CProcess
 {
 public:
-    CSamplePcs();
-
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void create();
     void destroy();

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -1,18 +1,21 @@
 #include "ffcc/p_sample.h"
 
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-CSamplePcs::CSamplePcs()
-{
-}
+extern unsigned int lbl_801E8498[];
+extern unsigned int lbl_801E84A4[];
+extern unsigned int lbl_801E84B0[];
+extern unsigned int lbl_801E84BC[];
+extern unsigned char lbl_801E84C8[];
+extern unsigned int lbl_801E8644[];
+extern unsigned int lbl_8032EC60;
 
 /*
  * --INFO--
- * Address:	8001feac
- * Size:	4
+ * PAL Address: 0x8001FEAC
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSamplePcs::Init()
 {
@@ -21,8 +24,12 @@ void CSamplePcs::Init()
 
 /*
  * --INFO--
- * Address:	8001fea8
- * Size:	4
+ * PAL Address: 0x8001FEA8
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSamplePcs::Quit()
 {
@@ -31,18 +38,26 @@ void CSamplePcs::Quit()
 
 /*
  * --INFO--
- * Address:	8001fe94
- * Size:	4
+ * PAL Address: 0x8001FE94
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSamplePcs::GetTable(unsigned long)
+int CSamplePcs::GetTable(unsigned long index)
 {
-	return;
+	return (int)(lbl_801E84C8 + index * 0x15C);
 }
 
 /*
  * --INFO--
- * Address:	8001fe90
- * Size:	4
+ * PAL Address: 0x8001FE90
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSamplePcs::create()
 {
@@ -51,8 +66,12 @@ void CSamplePcs::create()
 
 /*
  * --INFO--
- * Address:	8001fe8c
- * Size:	4
+ * PAL Address: 0x8001FE8C
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSamplePcs::destroy()
 {
@@ -61,8 +80,12 @@ void CSamplePcs::destroy()
 
 /*
  * --INFO--
- * Address:	8001fe88
- * Size:	4
+ * PAL Address: 0x8001FE88
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSamplePcs::func0()
 {
@@ -71,12 +94,57 @@ void CSamplePcs::func0()
 
 /*
  * --INFO--
- * Address:	8001fe84
- * Size:	4
+ * PAL Address: 0x8001FE84
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSamplePcs::func1()
 {
 	return;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FEB0
+ * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_sample_cpp(void)
+{
+	unsigned int a0 = lbl_801E8498[0];
+	unsigned int a1 = lbl_801E8498[1];
+	unsigned int a2 = lbl_801E8498[2];
+	unsigned int b0 = lbl_801E84A4[0];
+	unsigned int b1 = lbl_801E84A4[1];
+	unsigned int b2 = lbl_801E84A4[2];
+	unsigned int c0 = lbl_801E84B0[0];
+	unsigned int c1 = lbl_801E84B0[1];
+	unsigned int c2 = lbl_801E84B0[2];
+	unsigned int d0 = lbl_801E84BC[0];
+	unsigned int d1 = lbl_801E84BC[1];
+	unsigned int d2 = lbl_801E84BC[2];
+	unsigned int* table = (unsigned int*)lbl_801E84C8;
+
+	lbl_8032EC60 = (unsigned int)&lbl_801E8644;
+
+	table[1] = a0;
+	table[2] = a1;
+	table[3] = a2;
+	table[4] = b0;
+	table[5] = b1;
+	table[6] = b2;
+	table[7] = c0;
+	table[8] = c1;
+	table[9] = c2;
+	table[12] = d0;
+	table[13] = d1;
+	table[14] = d2;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `main/p_sample` to restore the original process-table behavior instead of stubbed logic.
- Changed `CSamplePcs::GetTable` to return `lbl_801E84C8 + index * 0x15C`.
- Added `__sinit_p_sample_cpp` to copy descriptor triplets from `lbl_801E8498/84A4/84B0/84BC` into `lbl_801E84C8` and set `lbl_8032EC60` to `lbl_801E8644`.
- Removed explicit `CSamplePcs` constructor declaration/definition so this TU no longer emits extra constructor/vtable code that is not present in the target object.

## Functions Improved
- Unit: `main/p_sample`
- `GetTable__10CSamplePcsFUl`: **20.0% -> 100.0%**
- `__sinit_p_sample_cpp`: **0.0% -> 72.21277%**

## Match Evidence
- Objdiff (`main/p_sample`, symbol-focused): `.text` match **17.741936% -> 78.935486%**
- Unit fuzzy match from report: **17.7% (selector baseline) -> 81.51613%**

## Plausibility Rationale
- The changes follow existing project patterns used by other process units (`p_system`, `p_sound`): table-stride `0x15C` access and static descriptor copy during `__sinit`.
- The source remains straightforward and readable (type/signature fixes plus static init wiring), rather than using contrived ordering-only tricks.

## Technical Details
- Used existing linker symbols (`lbl_801E8498`, `lbl_801E84A4`, `lbl_801E84B0`, `lbl_801E84BC`, `lbl_801E84C8`, `lbl_801E8644`, `lbl_8032EC60`) to drive the same relocation pattern as target assembly.
- Preserved PAL metadata blocks for edited functions and converted legacy `Address/Size` comments to the project’s `PAL/EN/JP` format.
- Validation: `ninja` succeeds and `build/tools/objdiff-cli diff -p . -u main/p_sample -o - __sinit_p_sample_cpp` confirms assembly-level improvement.
