### PR TITLE
Decompile core pppCharaZEnvCtrl handlers

### DIFF
--- a/include/ffcc/pppCharaZEnvCtrl.h
+++ b/include/ffcc/pppCharaZEnvCtrl.h
@@ -3,6 +3,14 @@
 
 #include "ffcc/chara.h"
 
+struct UnkB;
+struct UnkC;
+
+struct pppCharaZEnvCtrl
+{
+    int field0_0x0[2];
+};
+
 void CharaZEnvCtrl_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int);
 
 #ifdef __cplusplus
@@ -11,7 +19,7 @@ extern "C" {
 
 void pppConCharaZEnvCtrl(void);
 void pppDesCharaZEnvCtrl(void);
-void pppFrameCharaZEnvCtrl(void);
+void pppFrameCharaZEnvCtrl(pppCharaZEnvCtrl*, UnkB*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppCharaZEnvCtrl.cpp
+++ b/src/pppCharaZEnvCtrl.cpp
@@ -1,9 +1,21 @@
 #include "ffcc/pppCharaZEnvCtrl.h"
+#include "ffcc/partMng.h"
+
+extern unsigned int DAT_8032ed70;
+
+extern "C" {
+void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
+int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
+}
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CharaZEnvCtrl_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int)
 {
@@ -12,30 +24,54 @@ void CharaZEnvCtrl_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8013e638
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConCharaZEnvCtrl(void)
 {
-	// TODO
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+	GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8013e5f8
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDesCharaZEnvCtrl(void)
 {
-	// TODO
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+	*(void**)(model + 0xe4) = 0;
+	*(void**)(model + 0xe8) = 0;
+	*(void**)(model + 0xf4) = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8013e584
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameCharaZEnvCtrl(void)
+void pppFrameCharaZEnvCtrl(pppCharaZEnvCtrl* pppCharaZEnvCtrl, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+	if (DAT_8032ed70 == 0) {
+		int dataOffset = *(int*)((char*)param_3 + 0xc);
+		void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+		int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+		*(void**)(model + 0xe4) = (void*)((int)(&pppCharaZEnvCtrl->field0_0x0 + 2) + dataOffset);
+		*(UnkB**)(model + 0xe8) = param_2;
+		*(void (**)(CChara::CModel*, void*, void*, int))(model + 0xf4) = CharaZEnvCtrl_BeforeMeshLockEnvCallback;
+	}
 }


### PR DESCRIPTION
## Summary
Implemented core `pppCharaZEnvCtrl` runtime handlers from the PAL Ghidra references:
- Added concrete implementations for `pppConCharaZEnvCtrl`, `pppDesCharaZEnvCtrl`, and `pppFrameCharaZEnvCtrl`.
- Updated `pppFrameCharaZEnvCtrl` signature in header/source to accept `(pppCharaZEnvCtrl*, UnkB*, UnkC*)`.
- Added PAL address/size metadata comments for the implemented functions.
- Kept implementation style consistent with nearby PPP code (raw offset access and external helper calls).

## Functions Improved
Unit: `main/pppCharaZEnvCtrl` (`src/pppCharaZEnvCtrl.cpp`)
- `pppFrameCharaZEnvCtrl`: **3.4% -> 55.517242%** (116b)
- `pppDesCharaZEnvCtrl`: **6.2% -> 99.625%** (64b)
- `pppConCharaZEnvCtrl`: **8.3% -> 99.5%** (48b)

## Match Evidence
Validated with:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppCharaZEnvCtrl -o - pppFrameCharaZEnvCtrl`

Current symbol metrics from objdiff JSON:
- `pppFrameCharaZEnvCtrl`: 55.517242
- `pppDesCharaZEnvCtrl`: 99.625
- `pppConCharaZEnvCtrl`: 99.5

## Plausibility Rationale
The change replaces TODO stubs with straightforward logic that mirrors established patterns in adjacent PPP modules:
- resolve character handle/model through existing runtime helpers,
- store/remove model callback/data pointers at known model offsets,
- guard frame updates behind the standard `DAT_8032ed70 == 0` check.

These are normal gameplay-engine operations for environment control hooks and avoid contrived compiler-only transformations.

## Technical Notes
- Used symbol-accurate helper calls already present in the codebase:
  - `GetCharaHandlePtr__FP8CGObjectl`
  - `GetCharaModelPtr__FPQ29CCharaPcs7CHandle`
- Accessed serialized data offset from `UnkC` using raw offset (`+0xc`) to remain consistent with current incomplete PPP type recovery.
