### PR TITLE
main/gx/GXTev: improve GXSetAlphaCompare bitfield match

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -347,10 +347,8 @@ void GXSetAlphaCompare(GXCompare comp0, u8 ref0, GXAlphaOp op, GXCompare comp1, 
     u32 reg;
 
     CHECK_GXBEGIN(1046, "GXSetAlphaCompare");
-    reg = 0xF3000000 | (ref0 & 0xFF) | ((ref1 & 0xFF) << 8);
-    reg |= (comp0 & 7) << 16;
-    reg |= (comp1 & 7) << 19;
-    reg |= (op & 3) << 22;
+    reg = ((ref1 & 0xFF) << 8) | (ref0 & 0xFF) | 0xF3000000 | ((comp0 & 0xFFC7) << 16) | (comp1 << 19);
+    reg = (reg & 0xFF3FFFFF) | (op << 22);
 
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;


### PR DESCRIPTION
## Summary
Refined `GXSetAlphaCompare` bitfield composition in `src/gx/GXTev.c` to mirror the original register-pack expression shape (single packed expression with final mask/insert), while keeping behavior equivalent.

## Functions improved
- Unit: `main/gx/GXTev`
- Symbol: `GXSetAlphaCompare`

## Match evidence
- `GXSetAlphaCompare`: **60.238094% -> 76.904760%** (`84b`)
- `GXSetTevKColor`: kept at baseline (**56.517242%**) after reverting a regressing variant.
- Full build succeeds with `ninja`.

## Plausibility rationale
The change keeps the same hardware register semantics and uses a straightforward packed-bit construction consistent with SDK-style GX register writes, rather than introducing compiler-coaxing temporaries.

## Technical details
- Replaced incremental OR-based field packing with expression form:
  - combine refs and base tag (`0xF3000000`)
  - insert compare fields via shifts/mask
  - apply final alpha-op insertion with `0xFF3FFFFF` mask
- This reduced structural assembly differences in the target function without changing surrounding control flow.
