### PR TITLE
pppRain: match construct/destruct signatures and state access

### DIFF
--- a/include/ffcc/pppRain.h
+++ b/include/ffcc/pppRain.h
@@ -1,9 +1,22 @@
 #ifndef _PPP_RAIN_H_
 #define _PPP_RAIN_H_
 
+#include <dolphin/types.h>
+
+struct pppRain {
+    u8 field_0x0[0x80];
+};
+
 struct VRain;
-struct PRain;
-struct RAIN_DATA;
+
+struct PRain {
+    u8 payload[0x60];
+};
+
+struct RAIN_DATA {
+    u8 padding[0xc];
+    s32* m_serializedDataOffsets;
+};
 
 void InitRainData(VRain*, PRain*, RAIN_DATA*);
 void UpdateRain(VRain*, PRain*, RAIN_DATA*);
@@ -12,10 +25,10 @@ void UpdateRain(VRain*, PRain*, RAIN_DATA*);
 extern "C" {
 #endif
 
-void pppConstructRain(void);
-void pppDestructRain(void);
-void pppFrameRain(void);
-void pppRenderRain(void);
+void pppConstructRain(struct pppRain*, struct RAIN_DATA*);
+void pppDestructRain(struct pppRain*, struct RAIN_DATA*);
+void pppFrameRain(struct pppRain*, struct PRain*, struct RAIN_DATA*);
+void pppRenderRain(struct pppRain*, struct PRain*, struct RAIN_DATA*);
 
 #ifdef __cplusplus
 }

--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -1,5 +1,9 @@
 #include "ffcc/pppRain.h"
+#include "ffcc/memory.h"
+#include "ffcc/pppPart.h"
 #include "dolphin/gx.h"
+
+extern float lbl_80331018;
 
 /*
  * --INFO--
@@ -30,8 +34,17 @@ void UpdateRain(VRain*, PRain*, RAIN_DATA*)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppConstructRain(void)
+void pppConstructRain(struct pppRain* pppRain, struct RAIN_DATA* param_2)
 {
+    float fVar1;
+    float* puVar2;
+    
+    fVar1 = lbl_80331018;
+    puVar2 = (float*)((u8*)pppRain + 0x80 + param_2->m_serializedDataOffsets[2]);
+    *(u32*)puVar2 = 0;
+    puVar2[3] = fVar1;
+    puVar2[2] = fVar1;
+    puVar2[1] = fVar1;
 }
 
 /*
@@ -43,8 +56,15 @@ void pppConstructRain(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppDestructRain(void)
+void pppDestructRain(struct pppRain* pppRain, struct RAIN_DATA* param_2)
 {
+    int iVar1;
+    
+    iVar1 = param_2->m_serializedDataOffsets[2];
+    if (*(void**)((u8*)pppRain + 0x80 + iVar1) != 0) {
+        pppHeapUseRate((CMemory::CStage*)*(void**)((u8*)pppRain + 0x80 + iVar1));
+        *(u32*)((u8*)pppRain + 0x80 + iVar1) = 0;
+    }
 }
 
 /*
@@ -56,7 +76,7 @@ void pppDestructRain(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameRain(void)
+void pppFrameRain(struct pppRain*, struct PRain*, struct RAIN_DATA*)
 {
 }
 
@@ -69,6 +89,6 @@ void pppFrameRain(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRenderRain(void)
+void pppRenderRain(struct pppRain*, struct PRain*, struct RAIN_DATA*)
 {
 }


### PR DESCRIPTION
## Summary
- Added concrete `pppRain`/`PRain`/`RAIN_DATA` layout stubs in `include/ffcc/pppRain.h` so serialized state offsets are addressed at the correct ABI location.
- Updated rain function prototypes to match the expected calling convention/signature (`pppRain*`, step data, serialized-data table).
- Implemented `pppConstructRain` and `pppDestructRain` in `src/pppRain.cpp` using the same state-slot initialization/freeing flow seen in the target binary.

## Functions improved
- Unit: `main/pppRain`
- `pppConstructRain`: **9.090909% -> 100.0%**
- `pppDestructRain`: **4.7619047% -> 100.0%**
- `pppFrameRain`: unchanged at `0.37313432%`
- `pppRenderRain`: unchanged at `0.729927%`

## Match evidence
- Baseline (before edits):
  - `build/tools/objdiff-cli diff -p . -u main/pppRain -o - pppDestructRain`
- After edits:
  - same command reports `pppConstructRain 100.0`, `pppDestructRain 100.0`
- Build/progress check via `ninja` also reflects +2 matched functions for this iteration.

## Plausibility rationale
- Changes are ABI/type corrections and straightforward state lifecycle logic (initialize state block on construct, free pointer and null it on destruct), which is consistent with existing PPP unit patterns.
- No contrived sequencing or readability regressions were introduced; the code is direct and source-plausible for original engine code.

## Technical details
- Key matching fixes were:
  - placing `m_serializedDataOffsets` at `+0xC` in `RAIN_DATA` to match observed access pattern,
  - switching from a manually mangled extern call to canonical `pppHeapUseRate(...)` declaration,
  - using `lbl_80331018` for the sdata float constant loaded in construct.
