### PR TITLE
itemobj: implement small CGItemObj state handlers

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -32,32 +32,61 @@ void CGItemObj::onFramePreCalc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80126f08
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::onFramePostCalc()
 {
-	// TODO
+	unsigned char* self = (unsigned char*)this;
+	unsigned int stateBits = ((unsigned int)self[0x50] << 0x1c) | ((unsigned int)self[0x50] >> 4);
+
+	if ((int)stateBits < 0 && *(int*)(self + 0x550) == 0) {
+		*(int*)(self + 0x94) = *(int*)(self + 0x94) - 1;
+	}
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80126ee0
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGItemObj::onChangeStat(int)
+void CGItemObj::onChangeStat(int state)
 {
-	// TODO
+	unsigned char* self = (unsigned char*)this;
+
+	if (state >= 0x26 && state <= 0x27) {
+		*(unsigned int*)(self + 0x1c0) = *(unsigned int*)(self + 0x1c0) & 0xfff7fffe;
+	}
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80126eb4
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::onCancelStat(int)
 {
-	// TODO
+	extern float FLOAT_80331b18;
+	unsigned char* self = (unsigned char*)this;
+
+	if (*(int*)(self + 0x520) == 0x1b) {
+		*(unsigned int*)(self + 0x1c0) = *(unsigned int*)(self + 0x1c0) | 2;
+		*(float*)(self + 0x17c) = FLOAT_80331b18;
+		*(float*)(self + 0x178) = FLOAT_80331b18;
+		*(float*)(self + 0x174) = FLOAT_80331b18;
+	}
 }
 
 /*
@@ -182,12 +211,21 @@ void CGItemObj::loadModel()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80124fac
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::onNewFinished()
 {
-	// TODO
+	extern int DAT_8032ee90;
+	unsigned char* self = (unsigned char*)this;
+
+	*(int*)(self + 0x568) = *(int*)(self + 0x144);
+	*(unsigned short*)(self + 0x560) = (unsigned short)((DAT_8032ee90 >> 3) & 1);
+	loadModel();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGItemObj::onChangeStat`, `CGItemObj::onCancelStat`, `CGItemObj::onFramePostCalc`, and `CGItemObj::onNewFinished` in `src/itemobj.cpp`.
- Replaced TODO stubs with behavior from PAL decomp references, using existing object layout offsets.
- Added PAL address/size metadata blocks for the four updated functions.

## Functions improved
- `onChangeStat__9CGItemObjFi`: `10.0% -> 98.8%` (40b)
- `onCancelStat__9CGItemObjFi`: `9.090909% -> 63.636364%` (44b)
- `onFramePostCalc__9CGItemObjFv`: `8.333333% -> 79.583336%` (48b)
- `onNewFinished__9CGItemObjFv`: `7.6923075% -> 40.692307%` (52b)

## Match evidence
- Verified with `build/tools/objdiff-cli diff -p . -u main/itemobj -o - onCancelStat__9CGItemObjFi` and symbol-level JSON comparisons before/after.
- Improvements come from control-flow and memory-access alignment (state gating, bitmask ops, and fixed field writes), not formatting-only changes.

## Plausibility rationale
- Changes reflect normal game-object state transitions and initialization behavior:
  - stat-range gate + mask clear in `onChangeStat`
  - state-based rotation reset and collision flag restore in `onCancelStat`
  - post-calc decrement under state/flag gate in `onFramePostCalc`
  - model sync + load trigger in `onNewFinished`
- No contrived compiler coaxing patterns were added; behavior matches expected object logic and existing code style constraints in this file.

## Build
- `ninja` passes after the change.
