### PR TITLE
joybus: improve SendAllStat match

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5748,20 +5748,41 @@ int JoyBus::GBAReady(int portIndex)
  */
 int JoyBus::SendAllStat(int portIndex)
 {
-    ThreadParam& threadParam = m_threadParams[portIndex];
-    const int port = threadParam.m_portIndex;
+    ThreadParam* threadParam = &m_threadParams[portIndex];
+    int port = threadParam->m_portIndex;
 
-    threadParam.m_state = 0;
-    threadParam.m_altState = 0;
+    threadParam->m_state = 0;
+    threadParam->m_altState = 0;
 
     OSWaitSemaphore(&m_accessSemaphores[port]);
-	
-	// TODO: The compiler is either somehow unrolling this, or our assumptions are wrong about recvQueue format
-    for (int i = 0; i < 64; i++)
+
+    unsigned int* cmdQueue = m_cmdQueueData[port];
+    unsigned int* recvQueue = m_recvQueueEntriesArr[port];
+    int i = 8;
+
+    do
     {
-        m_cmdQueueData[port][i] = 0;
-        m_recvQueueEntriesArr[port][i] = 0;
-    }
+        cmdQueue[0] = 0;
+        recvQueue[0] = 0;
+        cmdQueue[1] = 0;
+        recvQueue[1] = 0;
+        cmdQueue[2] = 0;
+        recvQueue[2] = 0;
+        cmdQueue[3] = 0;
+        recvQueue[3] = 0;
+        cmdQueue[4] = 0;
+        recvQueue[4] = 0;
+        cmdQueue[5] = 0;
+        recvQueue[5] = 0;
+        cmdQueue[6] = 0;
+        recvQueue[6] = 0;
+        cmdQueue[7] = 0;
+        recvQueue[7] = 0;
+
+        cmdQueue += 8;
+        recvQueue += 8;
+        i--;
+    } while (i != 0);
 
     m_cmdCount[port] = 0;
     m_secCmdCount[port] = 0;


### PR DESCRIPTION
## Summary
Refined `JoyBus::SendAllStat(int)` in `src/joybus.cpp` to use pointer-based queue clearing with explicit 8-word unrolling per iteration, while preserving behavior.

## Functions improved
- Unit: `main/joybus`
- Symbol: `SendAllStat__6JoyBusFi`

## Match evidence
- `SendAllStat__6JoyBusFi`: **2.264% -> 18.872%** (`build/GCCP01/report.json` fuzzy match)
- The improvement came from codegen alignment in the queue reset block (command/recv arrays and index reset path), not from renaming or formatting.

## Plausibility rationale
This is plausible original source for MWCC-era code: clearing paired queue buffers in fixed-size chunks with explicit word writes is a common pattern and matches the observed assembly shape (loop body with repeated stores and fixed-trip count).

## Technical details
- Replaced high-level element loop over 64 entries with an explicit fixed-count `do { ... } while` clearing 8 words per iteration for both `m_cmdQueueData` and `m_recvQueueEntriesArr`.
- Kept semaphore boundaries and `m_cmdCount`/`m_secCmdCount` reset behavior unchanged.
- Kept state initialization (`m_state`, `m_altState`) and port selection semantics unchanged.
