### PR TITLE
RedStream: implement _ArrangeStreamDataNoLoop

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -28,9 +28,56 @@ void _StreamStop(RedStreamDATA*)
  * Address:	TODO
  * Size:	TODO
  */
-void _ArrangeStreamDataNoLoop(RedStreamDATA*, int, int)
+void _ArrangeStreamDataNoLoop(RedStreamDATA* param_1, int param_2, int param_3)
 {
-	// TODO
+	unsigned char* dstBuffer;
+	int streamStruct;
+	int dmaDstOffset;
+
+	param_2 &= 1;
+
+	do {
+		dstBuffer = (unsigned char*)(*(int*)((int)param_1 + 0xc) + param_2 * 0x1000);
+		streamStruct = *(int*)((int)param_1 + 4);
+
+		memcpy(dstBuffer, (void*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120)), 0x1000);
+		*(int*)((int)param_1 + 0x120) += 0x1000;
+		if (*(int*)((int)param_1 + 0x118) <= *(int*)((int)param_1 + 0x120)) {
+			*(int*)((int)param_1 + 0x120) = 0;
+		}
+
+		if (*(short*)((int)param_1 + 0x2a) == 2) {
+			memcpy(dstBuffer + 0x2000, (void*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120)), 0x1000);
+			*(int*)((int)param_1 + 0x120) += 0x1000;
+			if (*(int*)((int)param_1 + 0x118) <= *(int*)((int)param_1 + 0x120)) {
+				*(int*)((int)param_1 + 0x120) = 0;
+			}
+		}
+
+		dmaDstOffset = *(int*)((int)param_1 + 0x12c) + param_2 * 0x1000;
+		RedDmaEntry(0x8001, 0, (int)dstBuffer, dmaDstOffset, 0x1000, 0, 0);
+
+		if ((param_2 == 0) && (*(int*)(streamStruct + 0x14) != 0)) {
+			*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1ec) = (unsigned short)*dstBuffer;
+			*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1f0) = 0;
+			*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1ee) = 0;
+			*(unsigned int*)(*(int*)(streamStruct + 0x14) + 0x1c) |= 0x100000;
+		}
+
+		if (*(short*)((int)param_1 + 0x2a) == 2) {
+			RedDmaEntry(0x8001, 0, (int)(dstBuffer + 0x2000), dmaDstOffset + 0x2000, 0x1000, 0, 0);
+			if ((param_2 == 0) && (*(int*)(streamStruct + 0xd4) != 0)) {
+				*(unsigned short*)(*(int*)(streamStruct + 0xd4) + 0x1ec) = (unsigned short)dstBuffer[0x2000];
+				*(unsigned short*)(*(int*)(streamStruct + 0xd4) + 0x1f0) = 0;
+				*(unsigned short*)(*(int*)(streamStruct + 0xd4) + 0x1ee) = 0;
+				*(unsigned int*)(*(int*)(streamStruct + 0xd4) + 0x1c) |= 0x100000;
+			}
+		}
+
+		param_3 -= 0x1000;
+		param_2 ^= 1;
+		*(int*)((int)param_1 + 0x124) += 0x200;
+	} while (0 < param_3);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `_ArrangeStreamDataNoLoop__FP13RedStreamDATAii` in `src/RedSound/RedStream.cpp` using the current decomp reference flow.
- Added PCM/ADPCM branch handling, ring-buffer offset advancement, DMA submission, and stream voice register updates.
- Kept implementation style consistent with nearby RedSound code (pointer-offset field access and existing helper calls).

## Functions improved
- Unit: `main/RedSound/RedStream`
- Symbol: `_ArrangeStreamDataNoLoop__FP13RedStreamDATAii`

## Match evidence
- Before (selector baseline): `_ArrangeStreamDataNoLoop__FP13RedStreamDATAii` at **0.0%**.
- After (`objdiff-cli`): `_ArrangeStreamDataNoLoop__FP13RedStreamDATAii` at **79.30252%** (size 476b).
- Unit fuzzy match moved from the selector baseline **0.7%** to **9.343462%** in `build/GCCP01/report.json`.
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream -o - _ArrangeStreamDataNoLoop__FP13RedStreamDATAii`

## Plausibility rationale
- The change restores expected original gameplay/audio behavior rather than compiler-only coaxing: staged stream buffer copies, conditional second-channel handling for mode `== 2`, DMA queueing, and hardware voice flag updates.
- Control flow and arithmetic (0x1000 chunk stride, 0x200 play-point step, ping-pong bank toggle) mirror the surrounding RedStream logic and hardware-facing conventions.
- No artificial temporaries, no hardcoded assembly mimicry comments, and no readability regressions introduced.

## Technical details
- Implemented the full non-loop arrangement path:
  - copy current chunk from source ring to DMA staging buffer
  - wrap source offset at stream data size boundary
  - optionally copy/deploy second channel when stream mode is 2
  - enqueue one or two DMA transfers depending on mode
  - update voice ADPCM registers/flags for active output voices
  - advance playback bookkeeping (`+0x200` each 0x1000 chunk)
