### PR TITLE
main/mapanim: implement CPtrArray<CMapAnimNode*> core methods

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -1,4 +1,219 @@
 #include "ffcc/mapanim.h"
+#include "ffcc/memory.h"
+#include "ffcc/system.h"
+
+#include <string.h>
+
+template <class T>
+class CPtrArray
+{
+public:
+    void** m_vtable;
+    int m_size;
+    int m_numItems;
+    int m_defaultSize;
+    T* m_items;
+    CMemory::CStage* m_stage;
+    int m_growCapacity;
+
+    CPtrArray();
+    ~CPtrArray();
+
+    int Add(T item);
+    T GetAt(unsigned long index);
+    T operator[](unsigned long index);
+    int GetSize();
+    void RemoveAll();
+    void SetStage(CMemory::CStage* stage);
+    int setSize(unsigned long newSize);
+};
+
+extern "C" void __dl__FPv(void*);
+extern "C" void __dla__FPv(void*);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
+
+static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
+static char s_ptrarray_grow_error[] = "CPtrArray grow error";
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004ae2c
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CMapAnimNode*>::CPtrArray()
+{
+    m_vtable = 0;
+    m_size = 0;
+    m_numItems = 0;
+    m_defaultSize = 0x10;
+    m_items = 0;
+    m_stage = 0;
+    m_growCapacity = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004ae60
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CMapAnimNode*>::~CPtrArray()
+{
+    RemoveAll();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004aebc
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimNode*>::Add(CMapAnimNode* item)
+{
+    int success = setSize(m_numItems + 1);
+    if (success != 0) {
+        m_items[m_numItems] = item;
+        m_numItems++;
+    }
+    return success;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034130
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimNode*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034270
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimNode* CPtrArray<CMapAnimNode*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034138
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimNode* CPtrArray<CMapAnimNode*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004af2c
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnimNode*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004af78
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnimNode*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004af80
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimNode*>::setSize(unsigned long newSize)
+{
+    CMapAnimNode** newItems;
+
+    if ((unsigned long)m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
+            m_size = m_size << 1;
+        }
+
+        newItems = (CMapAnimNode**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, m_size << 2, m_stage, s_collection_ptrarray_h, 0xFA, 0);
+        if (newItems == 0) {
+            return 0;
+        }
+
+        if (m_items != 0) {
+            memcpy(newItems, m_items, m_numItems << 2);
+        }
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+        m_items = newItems;
+    }
+
+    return 1;
+}
+
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added a local `CPtrArray<CMapAnimNode*>` implementation in `src/mapanim.cpp` for the symbols that belong to `mapanim.o`.
- Implemented constructor, destructor, `Add`, `GetSize`, `GetAt`, `operator[]`, `RemoveAll`, `SetStage`, and `setSize` using the existing project memory conventions (`Memory` allocator + `__dla__FPv`).
- Left higher-level `CMapAnim*` gameplay methods unchanged in this pass.

## Functions improved
Unit: `main/mapanim`

Key symbols now matched substantially:
- `__ct__26CPtrArray<P12CMapAnimNode>Fv`: **79.46%**
- `__dt__26CPtrArray<P12CMapAnimNode>Fv`: emitted (previously missing as real implementation)
- `Add__26CPtrArray<P12CMapAnimNode>FP12CMapAnimNode`: **88.79%**
- `RemoveAll__26CPtrArray<P12CMapAnimNode>Fv`: **99.89%**
- `SetStage__26CPtrArray<P12CMapAnimNode>FPQ27CMemory6CStage`: **100.00%**
- `setSize__26CPtrArray<P12CMapAnimNode>FUl`: **91.15%**

## Match evidence
- Selector baseline for `main/mapanim`: **4.2%** text match.
- After this change, unit `.text` match from objdiff: **17.338863%**.
- Improvement is from concrete symbol recovery in `CPtrArray<P12CMapAnimNode>` methods (not from renames/formatting changes).

## Plausibility rationale
- The code models a straightforward pointer-array container with growth, stage-aware allocation, and cleanup semantics that align with existing FFCC code patterns.
- Changes are type/layout driven and preserve readable, source-plausible behavior for an original game codebase.
- This is an incremental first pass on a heavily stubbed unit: it establishes matching infrastructure without introducing contrived control-flow tricks.

## Technical details
- Implemented allocation path via `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(&Memory, ...)` and deallocation via `__dla__FPv`.
- Used direct pointer-array copy with `memcpy` during resize.
- Preserved TODO stubs for large gameplay methods to keep this PR focused on verified low-level symbol progress.
