### PR TITLE
Implement first-pass pppFrameLensFlare

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -7,7 +7,25 @@
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 
+extern int DAT_8032ed70;
 extern float FLOAT_80331060;
+extern float FLOAT_80331064;
+extern float FLOAT_80331068;
+extern float FLOAT_8033106c;
+extern double DOUBLE_80331070;
+
+extern struct {
+	float _212_4_;
+	float _216_4_;
+	float _220_4_;
+	float _224_4_;
+	float _228_4_;
+	float _232_4_;
+	Mtx m_cameraMatrix;
+} CameraPcs;
+
+extern "C" unsigned int __cvt_fp2unsigned(double);
+extern "C" void GXPeekZ(unsigned short, unsigned short, unsigned int*);
 
 /*
  * --INFO--
@@ -53,10 +71,110 @@ void pppDestructLensFlare(void)
  * --INFO--
  * PAL Address: 0x800de8c4
  * PAL Size: 844b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppFrameLensFlare(void* obj, void* param2, void* param3)
 {
-	// TODO: Complex frame logic
+	UnkB* unkB = (UnkB*)param2;
+	UnkC* unkC = (UnkC*)param3;
+	int offset2;
+	int offset1;
+	unsigned char* alphaPtr;
+	float viewport[6];
+	float projection[7];
+	Mtx cameraMtx;
+	Vec cameraPos;
+	Vec cameraLookAt;
+	Vec lookDir;
+	Vec objectPos;
+	Vec cameraToObject;
+	unsigned int zAtPixel;
+	unsigned int x;
+	unsigned int y;
+
+	if (DAT_8032ed70 == 0) {
+		offset2 = unkC->m_serializedDataOffsets[2];
+		offset1 = unkC->m_serializedDataOffsets[1];
+		alphaPtr = (unsigned char*)((char*)obj + offset2 + 0xb2);
+
+		GXGetViewportv(viewport);
+		GXGetProjectionv(projection);
+		PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
+
+		GXProject(pppMngStPtr->m_matrix.value[0][3], pppMngStPtr->m_matrix.value[1][3],
+				  pppMngStPtr->m_matrix.value[2][3], cameraMtx, projection, viewport,
+				  (float*)((char*)obj + offset2 + 0x90), (float*)((char*)obj + offset2 + 0x94),
+				  (float*)((char*)obj + offset2 + 0x98));
+
+		*alphaPtr = 0;
+
+		cameraPos.x = CameraPcs._224_4_;
+		cameraPos.y = CameraPcs._228_4_;
+		cameraPos.z = CameraPcs._232_4_;
+		cameraLookAt.x = CameraPcs._212_4_;
+		cameraLookAt.y = CameraPcs._216_4_;
+		cameraLookAt.z = CameraPcs._220_4_;
+
+		PSVECSubtract(&cameraLookAt, &cameraPos, &lookDir);
+
+		objectPos.x = pppMngStPtr->m_matrix.value[0][3];
+		objectPos.y = pppMngStPtr->m_matrix.value[1][3];
+		objectPos.z = pppMngStPtr->m_matrix.value[2][3];
+
+		PSVECSubtract(&cameraPos, &objectPos, &cameraToObject);
+		PSVECScale(&cameraToObject, &cameraToObject, FLOAT_80331068);
+		PSVECNormalize(&lookDir, &lookDir);
+		PSVECNormalize(&cameraToObject, &cameraToObject);
+
+		*(float*)((char*)obj + offset2 + 0xb4) = PSVECDotProduct(&cameraToObject, &lookDir);
+
+		unsigned int halfWidth = ((unsigned char)unkB->m_arg3) >> 1;
+		unsigned int x0 = ((int)*(float*)((char*)obj + offset2 + 0x90)) & 0xffff;
+		unsigned int y0 = ((int)*(float*)((char*)obj + offset2 + 0x94)) & 0xffff;
+		unsigned int z0 = __cvt_fp2unsigned((double)(FLOAT_8033106c * *(float*)((char*)obj + offset2 + 0x98)));
+		int stride = (short)((unsigned short)(unsigned char)unkB->m_arg3 /
+							 (unsigned short)*((unsigned char*)(&unkB->m_arg3) + 1));
+
+		for (y = y0 - halfWidth; (int)y <= (int)(y0 + halfWidth); y += stride) {
+			for (x = x0 - halfWidth; (int)x <= (int)(x0 + halfWidth); x += stride) {
+				if (((-1 < (short)x) && (-1 < (short)y)) && ((short)x < 0x281) && ((short)y < 0x1c1)) {
+					GXPeekZ(x & 0xffff, y & 0xffff, &zAtPixel);
+					if (z0 <= zAtPixel) {
+						*alphaPtr = *alphaPtr + 1;
+					}
+				}
+			}
+		}
+
+		int sampleDiv = *((unsigned char*)(&unkB->m_arg3) + 1) + 1;
+		unsigned int totalSamples = sampleDiv * sampleDiv;
+
+		if (*alphaPtr == totalSamples) {
+			*alphaPtr = 0xff;
+		} else {
+			unsigned int scaledAlpha = *alphaPtr * (0xff / totalSamples);
+			if ((scaledAlpha & 0xff) < 0x100) {
+				*alphaPtr = (unsigned char)scaledAlpha;
+			} else {
+				*alphaPtr = 0xff;
+			}
+		}
+
+		*alphaPtr = (unsigned char)(int)((double)(float)*alphaPtr *
+										 (double)((float)((double)(unsigned char)*((unsigned char*)obj + offset1 + 0x88) - DOUBLE_80331070) *
+												  FLOAT_80331064));
+
+		if (unkB->m_dataValIndex != 0xffff) {
+			long* shapeTable = *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + unkB->m_dataValIndex * 4);
+			pppCalcFrameShape(shapeTable, *(short*)((char*)obj + offset2 + 0xac),
+							  *(short*)((char*)obj + offset2 + 0xae),
+							  *(short*)((char*)obj + offset2 + 0xb0),
+							  (short)unkB->m_initWOrk);
+		}
+	}
 	return;
 }
 


### PR DESCRIPTION
## Summary
- Implemented `pppFrameLensFlare` in `src/pppLensFlare.cpp` (previously TODO).
- Added the required lens-flare frame logic: viewport/projection fetch, camera-space projection, visibility sampling via `GXPeekZ`, alpha scaling, and shape-frame advancement via `pppCalcFrameShape`.
- Added needed extern declarations/constants used by this unit and updated the function info block with EN/JP TODO placeholders per repo format.

## Functions Improved
- Unit: `main/pppLensFlare`
- Symbol: `pppFrameLensFlare`
  - Before: `0.5%` (from `tools/agent_select_target.py` baseline for this unit)
  - After: `58.99052%` (`objdiff-cli v3.6.1`)

## Match Evidence
- Command used:
  - `objdiff-cli diff -p . -u main/pppLensFlare -o - pppFrameLensFlare`
- Result includes `pppFrameLensFlare` match percent of `58.99052`.
- Improvement is driven by substantive control-flow/data-flow alignment (projection setup, dot-product visibility term, screen-space depth sampling loops, and alpha/material frame update), not formatting-only edits.

## Plausibility Rationale
- The implementation follows existing particle-system conventions used across this repo: direct offset-based serialized work areas, Dolphin math/GX helper APIs, and the same `UnkB`/`UnkC` data plumbing style used by neighboring ppp units.
- No compiler-coaxing temporaries or artificial reordering was introduced beyond what is naturally required to represent the observed game logic.