### PR TITLE
RedSound: recover dtor_801CCA38 and __sinit symbol linkage

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -20,6 +20,7 @@ extern unsigned int DAT_8032f4c4; // Auto ID counter
 extern char DAT_8032e17c[]; // Buffer for memset
 extern void* DAT_8032e170; // Registration memory
 extern FILE DAT_8021d1a8; // File handle for fflush
+extern "C" void __dl__FPv(void*);
 
 /*
  * --INFO--
@@ -39,6 +40,23 @@ CRedSound::CRedSound()
 CRedSound::~CRedSound()
 {
 	End();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x801cca38
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CRedSound* dtor_801CCA38(CRedSound* redSound, short param_2)
+{
+    if ((redSound != 0) && (0 < param_2)) {
+        __dl__FPv(redSound);
+    }
+    return redSound;
 }
 
 /*
@@ -655,14 +673,18 @@ void CRedSound::TestProcess(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd8bc
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 // Forward declaration
 extern "C" void* __ct__10CRedDriverFv(void*);
 extern "C" void __dt__10CRedDriverFv(void*);
 
-void __sinit_RedSound_cpp(void)
+extern "C" void __sinit_RedSound_cpp(void)
 {
 	__register_global_object(__ct__10CRedDriverFv(&CRedDriver_8032f4c0), __dt__10CRedDriverFv, &DAT_8032e170);
 }


### PR DESCRIPTION
## Summary
- Added the missing deleting-destructor wrapper `dtor_801CCA38` for `CRedSound` using the Ghidra-recovered signature/behavior.
- Switched `__sinit_RedSound_cpp` to explicit C linkage so it emits the expected unmangled symbol.
- Added PAL address/size metadata blocks for both updated functions.

## Functions Improved
- Unit: `main/RedSound/RedSound`
- `dtor_801CCA38` (72b): now tracked at **79.666664%** fuzzy match.
- `__sinit_RedSound_cpp` (56b): now tracked at **87.85714%** fuzzy match.

## Match Evidence
- `objdiff` unit `.text` match for `main/RedSound/RedSound` improved from **14.128178%** to **16.93962%**.
- `report.json` unit fuzzy match is now **17.326271%**.
- Before these edits, both target functions were unresolved in report output (no fuzzy percentage shown).

## Plausibility Rationale
- `dtor_801CCA38` matches the expected Metrowerks deleting-destructor wrapper pattern: null-check + delete-on-positive-flag + return `this`.
- `__sinit_RedSound_cpp` should be emitted as a C symbol in this codebase; forcing C linkage aligns with other `__sinit_*` startup entrypoints and expected map symbol naming.

## Technical Notes
- Verified symbol emission in `build/GCCP01/src/RedSound/RedSound.o` with `powerpc-eabi-nm`:
  - `dtor_801CCA38`
  - `__sinit_RedSound_cpp`
- Build passes with `ninja`, including report/progress regeneration.
