### PR TITLE
TRK targimpl: add ReadFPSCR and FPSCR read/write path

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -119,12 +119,34 @@ asm void __TRK_set_MSR(register u32 msr) {
  * --INFO--
  * PAL Address: 0x801abed4
  * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 asm void WriteFPSCR(register f64* fpscr) {
 #ifdef __MWERKS__ // clang-format off
     nofralloc
     lfd f0, 0(r3)
     mtfsf 0xff, f0
+    blr
+#endif // clang-format on
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x801abeb0
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+asm void ReadFPSCR(register f64* fpscr) {
+#ifdef __MWERKS__ // clang-format off
+    nofralloc
+    mffs f0
+    stfd f0, 0(r3)
     blr
 #endif // clang-format on
 }
@@ -1127,7 +1149,13 @@ DSError TRKPPCAccessFPRegister(void* srcDestPtr, u32 fpr, BOOL read)
 
         error = TRKPPCAccessSpecialReg(srcDestPtr, instructionData1, read);
     } else if (fpr == 0x20) {
-        *(u64*)srcDestPtr &= 0xFFFFFFFF;
+        if (read) {
+            ReadFPSCR(srcDestPtr);
+        } else {
+            WriteFPSCR(srcDestPtr);
+        }
+
+        DSFetch_u64(srcDestPtr) &= 0xFFFFFFFF;
     } else if (fpr == 0x21) {
         if (!read) {
             *(u32*)srcDestPtr = *((u32*)(srcDestPtr) + 1);


### PR DESCRIPTION
## Summary
- Added `ReadFPSCR` as a Metrowerks asm helper in `src/TRK_MINNOW_DOLPHIN/targimpl.c`.
- Updated `TRKPPCAccessFPRegister` handling for register `0x20` (FPSCR) to perform real register access:
  - read path now calls `ReadFPSCR`
  - write path now calls `WriteFPSCR`
- Kept existing low-32-bit normalization (`&= 0xFFFFFFFF`) to preserve buffer format conventions in this unit.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/targimpl`
- Function: `ReadFPSCR` (PAL size 36b)

## Match evidence
From `build/GCCP01/report.json` after rebuild:
- `ReadFPSCR`: **-1 (unmatched/missing) -> 32.22222%**
- `TRKTargetAccessFP`: 23.114552% (unchanged in this step)
- `TRKTargetAccessARAM`: still unmatched in this step

## Plausibility rationale
- Accessing FPSCR via `mffs`/`stfd` and `lfd`/`mtfsf` is the expected low-level implementation style for MetroTRK on PPC.
- Replacing the placeholder mask-only path with real FPSCR register operations is source-plausible and aligns with the existing `WriteFPSCR` helper pattern.
- The change is narrowly scoped to one register path and avoids contrived compiler-coaxing structure.

## Technical details
- Added function info block for `ReadFPSCR` with PAL metadata (`0x801abeb0`, 36b).
- Expanded the `WriteFPSCR` info block to include EN/JP TODO fields for consistency with project format.
- Verified clean build with `ninja` after edit.
