### PR TITLE
util: align Vec-value signatures for RenderQuad/GetDirectVector

### DIFF
--- a/include/ffcc/util.h
+++ b/include/ffcc/util.h
@@ -25,9 +25,9 @@ public:
     void ConvI2FVector(Vec&, S16Vec&, long);
     void ConvF2IVector(S16Vec&, Vec&, long);
     void ConvF2IVector2d(S16Vec2d&, Vec2d&, long);
-    void RenderQuadNoTex(Vec&, Vec&, _GXColor);
-    void RenderQuad(Vec&, Vec&, _GXColor, Vec2d*, Vec2d*);
-    void RenderQuadTex2(Vec&, Vec&, _GXColor, Vec2d*, Vec2d*);
+    void RenderQuadNoTex(Vec, Vec, _GXColor);
+    void RenderQuad(Vec, Vec, _GXColor, Vec2d*, Vec2d*);
+    void RenderQuadTex2(Vec, Vec, _GXColor, Vec2d*, Vec2d*);
     void DisableIndMtx();
     void BeginQuadEnv();
     void EndQuadEnv();
@@ -41,7 +41,7 @@ public:
     void ReWriteDisplayList(void*, unsigned long, unsigned long);
     void CalcBoundaryBoxQuantized(Vec*, Vec*, S16Vec*, unsigned long, unsigned long);
     void GetNumPolygonFromDL(void*, unsigned long);
-    void GetDirectVector(Vec*, Vec*, Vec&);
+    void GetDirectVector(Vec*, Vec*, Vec);
     void InitConstantRegister();
     void SSepa(char*);
     void SNl();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -140,7 +140,7 @@ void CUtil::ConvF2IVector2d(S16Vec2d&, Vec2d&, long)
  * Address:	TODO
  * Size:	TODO
  */
-void CUtil::RenderQuadNoTex(Vec&, Vec&, _GXColor)
+void CUtil::RenderQuadNoTex(Vec, Vec, _GXColor)
 {
 	// TODO
 }
@@ -154,7 +154,7 @@ void CUtil::RenderQuadNoTex(Vec&, Vec&, _GXColor)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CUtil::RenderQuad(Vec& pos1, Vec& pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
+void CUtil::RenderQuad(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
 {
 	float u1, v1, u2, v2;
 	
@@ -206,7 +206,7 @@ void CUtil::RenderQuad(Vec& pos1, Vec& pos2, _GXColor color, Vec2d* uv1, Vec2d* 
  * JP Address: TODO
  * JP Size: TODO
  */
-void CUtil::RenderQuadTex2(Vec& pos1, Vec& pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
+void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
 {
 	float u1, v1, u2, v2;
 	
@@ -402,7 +402,7 @@ void CUtil::GetNumPolygonFromDL(void*, unsigned long)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CUtil::GetDirectVector(Vec* param_2, Vec* param_3, Vec& param_4)
+void CUtil::GetDirectVector(Vec* param_2, Vec* param_3, Vec param_4)
 {
 	Vec local_vec;
 	


### PR DESCRIPTION
## Summary
- Updated `CUtil` declarations/definitions to pass `Vec` by value (instead of by reference) where Metrowerks symbol names indicate `3Vec`.
- Kept behavior unchanged; this is ABI/signature alignment work to match original mangling and call ABI.

## Functions improved
- `GetDirectVector__5CUtilFP3VecP3Vec3Vec`
- `RenderQuadTex2__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d`
- `RenderQuad__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d`

## Match evidence
Objdiff command used:
- `tools/objdiff-cli diff -p . -u main/util -o -`

Before:
- All three symbols were unmatched (`target_symbol=none`, no match percentage in diff JSON).

After:
- `GetDirectVector__5CUtilFP3VecP3Vec3Vec`: **70.52631%**
- `RenderQuadTex2__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d`: **77.693184%**
- `RenderQuad__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d`: **75.275%**

## Plausibility rationale
- This change follows symbol-grounded ABI corrections (value vs reference passing), which is a common and plausible source-level discrepancy in decomp work.
- No contrived control-flow or temporary-variable coaxing was introduced.
- Resulting signatures now match the known Metrowerks naming evidence and emit the expected symbol names.

## Technical details
- Updated declarations in `include/ffcc/util.h` and matching definitions in `src/util.cpp` for:
  - `RenderQuadNoTex`
  - `RenderQuad`
  - `RenderQuadTex2`
  - `GetDirectVector`
- Verified rebuilt symbol names in `build/GCCP01/src/util.o` now use `F3Vec3Vec...` / `...3Vec` mangling.
