### PR TITLE
mapobj: decompile CBound::CBound and wire declarations

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -23,6 +23,7 @@ public:
 class CBound
 {
 public:
+	CBound();
 	void operator=(const CBound&);
 	void SetMinMax(Vec*, Vec*);
 	int CheckCross(CBound&);

--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -10,6 +10,7 @@ void VECMultAdd(Vec*, Vec*, Vec*, float);
 class CBound
 {
 public:
+    CBound();
     void SetFrustum(Vec&, float(*)[4]);
     void CheckFrustum0(CBound&);
     void CheckFrustum0(float);

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1,4 +1,31 @@
 #include "ffcc/mapobj.h"
+#include "ffcc/math.h"
+
+extern float lbl_8032F938;
+extern float lbl_8032F93C;
+
+/*
+ * --INFO--
+ * PAL Address: 0x8002BE10
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CBound::CBound()
+{
+    float* bounds = (float*)this;
+    float max = lbl_8032F93C;
+    float min = lbl_8032F938;
+
+    bounds[2] = min;
+    bounds[1] = min;
+    bounds[0] = min;
+    bounds[5] = max;
+    bounds[4] = max;
+    bounds[3] = max;
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added an explicit `CBound::CBound()` declaration to both `include/ffcc/math.h` and `include/ffcc/mapocttree.h`.
- Implemented `CBound::CBound()` in `src/mapobj.cpp` at PAL `0x8002BE10`.
- Constructor initializes bound mins/maxes using existing SDA2 constants (`lbl_8032F938`, `lbl_8032F93C`) and assignment ordering aligned to target codegen.

## Functions improved
- Unit: `main/mapobj`
- Function: `__ct__6CBoundFv` (`CBound::CBound()`)

## Match evidence
- Before: `__ct__6CBoundFv` at **0.0%** (from `tools/agent_select_target.py` target listing)
- After: `__ct__6CBoundFv` at **96.67%** (`build/GCCP01/report.json`)
- Unit fuzzy match (`main/mapobj`): from selector-reported ~**2.6%** to **2.859827%** (`build/GCCP01/report.json`)

## Plausibility rationale
- The change is source-plausible: a straightforward default constructor that sets a 3D min/max bound pair to large sentinel values.
- Uses project-existing float symbols rather than contrived constants or unusual control-flow tricks.
- No artificial temporaries for compiler coaxing beyond normal local variables used to express clear constructor intent.

## Technical details
- Target assembly for PAL `0x8002BE10` is a short constructor writing six floats (`0x0..0x14`) from two SDA2 constants.
- Implemented stores in matching semantic order (`min` for first three fields, `max` for next three fields), producing a near-match and moving this symbol off 0%.
