### PR TITLE
os/OSTime: unguard time/tick asm symbols

### DIFF
--- a/src/os/OSTime.c
+++ b/src/os/OSTime.c
@@ -10,7 +10,6 @@ static int YearDays[MONTH_MAX] = {0,   31,  59,  90,  120, 151,
 static int LeapYearDays[MONTH_MAX] = {0,   31,  60,  91,  121, 152,
                                       182, 213, 244, 274, 305, 335};
 
-#ifdef __GEKKO__
 asm OSTime OSGetTime(void) {
 jump:
     nofralloc
@@ -41,7 +40,6 @@ asm static void __SetTime(OSTime time) {
     mttbl r4
     blr
 }
-#endif
 
 void __OSSetTime(OSTime time) {
     BOOL enabled;
@@ -80,13 +78,11 @@ OSTime __OSTimeToSystemTime(OSTime time) {
     return result;
 }
 
-#ifdef __GEKKO__
 asm void __OSSetTick(register OSTick newTicks) {
     nofralloc
     mttbl newTicks
     blr
 }
-#endif
 
 static int IsLeapYear(int year) {
     return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);


### PR DESCRIPTION
## Summary
- Removed `__GEKKO__` guards around the existing asm definitions in `src/os/OSTime.c` for `OSGetTime`, `OSGetTick`, `__SetTime`, and `__OSSetTick`.
- This makes the intended OSTime low-level symbols emit from `OSTime.o` in the current build configuration instead of staying unresolved externs.

## Functions Improved
- `main/os/OSTime`
- `OSGetTime` (24b): **0.0% -> 100.0%** (objdiff symbol diff)
- `OSGetTick` (8b): **0.0% -> 100.0%** (objdiff symbol diff)

## Match Evidence
- Before this change, target selection reported:
  - `OSGetTime` 0.0%
  - `OSGetTick` 0.0%
- After change:
  - `objdiff-cli diff -p . -u main/os/OSTime OSGetTime` reports `match_percent: 100.0`
  - `objdiff-cli diff -p . -u main/os/OSTime OSGetTick` reports `match_percent: 100.0`
- Project progress moved from:
  - `Code: 180460 / 1855300 bytes (1203 / 4733 functions)`
  - to `Code: 181520 / 1855300 bytes (1208 / 4733 functions)`

## Plausibility Rationale
- This is not compiler coaxing: the asm implementations were already present and canonical for Dolphin OS timebase access.
- The previous guard prevented symbol emission in this build setup, causing unresolved extern behavior and 0% match for the two target functions.
- Unguarding restores plausible original-source intent: `OSTime.c` owns these low-level time/tick routines.

## Technical Notes
- Verified symbol emission with `nm` after the change:
  - `T OSGetTime`
  - `T OSGetTick`
  - `T __OSSetTick`
- Build and report pass with `ninja`.
