### PR TITLE
Improve pppBlurChara lifecycle function matches

### DIFF
--- a/include/ffcc/pppBlurChara.h
+++ b/include/ffcc/pppBlurChara.h
@@ -2,6 +2,27 @@
 #define _FFCC_PPPBLURCHARA_H_
 
 #include "ffcc/chara.h"
+#include <dolphin/types.h>
+
+struct pppBlurChara {
+    int field0_0x0[2];
+};
+
+struct UnkB {
+    s32 m_graphId;
+    s32 m_dataValIndex;
+    u16 m_initWOrk;
+    u8 _pad0[2];
+    float m_stepValue;
+    u8 m_arg3;
+    u8 m_payload[6];
+    u8 _pad1[1];
+};
+
+struct UnkC {
+    u8 _pad0[0xC];
+    s32* m_serializedDataOffsets;
+};
 
 void BlurChara_SetBeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int);
 void BlurChara_AfterDrawModelCallback(CChara::CModel*, void*, void*);
@@ -10,10 +31,10 @@ void BlurChara_AfterDrawModelCallback(CChara::CModel*, void*, void*);
 extern "C" {
 #endif
 
-void pppConstructBlurChara(void);
-void pppDestructBlurChara(void);
-void pppFrameBlurChara(void);
-void pppRenderBlurChara(void);
+void pppConstructBlurChara(pppBlurChara*, UnkC*);
+void pppDestructBlurChara(pppBlurChara*, UnkC*);
+void pppFrameBlurChara(pppBlurChara*, UnkB*, UnkC*);
+void pppRenderBlurChara(pppBlurChara*, UnkB*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -1,13 +1,32 @@
 #include "ffcc/pppBlurChara.h"
+#include "ffcc/partMng.h"
+#include <dolphin/gx.h>
+
+extern unsigned int DAT_8032ed70;
+extern unsigned char MaterialMan[];
+extern _pppEnvSt* pppEnvStPtr;
+extern _pppMngSt* pppMngStPtr;
+
+extern "C" {
+void* GetCharaHandlePtr__FP8CGObjectl(void*, long);
+int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void*);
+void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+void pppHeapUseRate__FPQ27CMemory6CStage(void*);
+}
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800de6d8
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void BlurChara_SetBeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int)
 {
-	// TODO
+	GXSetZMode(0, GX_LEQUAL, 0);
+	*(unsigned int*)(MaterialMan + 0x48) |= 0x10000;
 }
 
 /*
@@ -32,12 +51,94 @@ void GXSetTexCoordGen(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800de22c
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructBlurChara(void)
+void pppConstructBlurChara(pppBlurChara* blurChara, UnkC* data)
 {
-	// TODO
+	int dataOffset = data->m_serializedDataOffsets[2];
+	unsigned int* state = (unsigned int*)((char*)blurChara + dataOffset + 0x80);
+	void* charaObj = *(void**)((char*)pppMngStPtr + 0x8);
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(charaObj, 0);
+	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+
+	state[1] = (unsigned int)charaObj;
+	*(void**)(model + 0x108) = (void*)BlurChara_AfterDrawModelCallback;
+	state[0] = 0;
+	state[2] = 0;
+	state[3] = *(unsigned int*)(model + 0x9c);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800de194
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppDestructBlurChara(pppBlurChara* blurChara, UnkC* data)
+{
+	int dataOffset = data->m_serializedDataOffsets[2];
+	unsigned int* state = (unsigned int*)((char*)blurChara + dataOffset + 0x80);
+	void* handle = GetCharaHandlePtr__FP8CGObjectl((void*)state[1], 0);
+	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+
+	*(void**)(model + 0x108) = 0;
+	*(void**)(model + 0xe4) = 0;
+	*(void**)(model + 0xe8) = 0;
+
+	if (state[0] != 0) {
+		pppHeapUseRate__FPQ27CMemory6CStage((void*)state[0]);
+		state[0] = 0;
+	}
+	if (state[2] != 0) {
+		pppHeapUseRate__FPQ27CMemory6CStage((void*)state[2]);
+		state[2] = 0;
+	}
+
+	*(unsigned int*)(model + 0x9c) = state[3];
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800de0ac
+ * PAL Size: 232b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppFrameBlurChara(pppBlurChara* blurChara, UnkB* stepData, UnkC* data)
+{
+	if (DAT_8032ed70 != 0) {
+		return;
+	}
+
+	int dataOffset = data->m_serializedDataOffsets[2];
+	unsigned int* state = (unsigned int*)((char*)blurChara + dataOffset + 0x80);
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+
+	*(void**)(model + 0xe4) = state;
+	*(UnkB**)(model + 0xe8) = stepData;
+
+	if (state[0] == 0) {
+		unsigned int size = GXGetTexBufferSize(0x140, 0xe0, GX_TF_RGBA8, GX_FALSE, 0);
+		state[0] = (unsigned int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+		    size, pppEnvStPtr->m_stagePtr, (char*)"pppBlurChara.cpp", 0xd5);
+		state[2] = (unsigned int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+		    0x20, pppEnvStPtr->m_stagePtr, (char*)"pppBlurChara.cpp", 0xd7);
+
+		*(void**)(model + 0xe4) = state;
+		*(UnkB**)(model + 0xe8) = stepData;
+		*(void (**)(CChara::CModel*, void*, void*, int))(model + 0xf4) = BlurChara_SetBeforeMeshLockEnvCallback;
+	}
 }
 
 /*
@@ -45,27 +146,7 @@ void pppConstructBlurChara(void)
  * Address:	TODO
  * Size:	TODO
  */
-void pppDestructBlurChara(void)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void pppFrameBlurChara(void)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void pppRenderBlurChara(void)
+void pppRenderBlurChara(pppBlurChara*, UnkB*, UnkC*)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Implemented first-pass, source-plausible lifecycle logic for `pppBlurChara` instead of stubs.
- Added concrete `pppBlurChara`, `UnkB`, and `UnkC` type/prototype definitions in the header.
- Implemented:
  - `BlurChara_SetBeforeMeshLockEnvCallback`
  - `pppConstructBlurChara`
  - `pppDestructBlurChara`
  - `pppFrameBlurChara`
- Left the large render/callback path (`pppRenderBlurChara`, `BlurChara_AfterDrawModelCallback`) as TODO for a later pass.

## Functions improved
Unit: `main/pppBlurChara`

Objdiff symbol match improvements:
- `BlurChara_SetBeforeMeshLockEnvCallback__FPQ26CChara6CModelPvPvi`: `6.25% -> 100.0%`
- `pppConstructBlurChara`: `3.5714285% -> 66.17857%`
- `pppDestructBlurChara`: `2.631579% -> 89.31579%`
- `pppFrameBlurChara`: `1.7241379% -> 98.24138%`

Unit-level report snapshot after change:
- `main/pppBlurChara` matched code percent is now `2.0618556%` (from stubbed baseline where selector reported `0.8% current`).

## Match evidence
- `ninja` build succeeds and updates report/progress.
- Objdiff shows real assembly alignment changes in prologue/epilogue, callback setup, model field writes, and heap allocation/free paths for the touched symbols.

## Plausibility rationale
- Changes follow existing codebase conventions used in other ppp modules:
  - offset-based model field access (`model + 0xe4/e8/f4/108/9c`)
  - existing engine calls for chara handle/model resolution
  - stage allocator/free usage through existing ppp memory APIs
- This is a first-pass reconstruction of lifecycle/control wiring rather than compiler-coaxing rewrites.

## Technical notes
- Used `DAT_8032ed70` early-out guard pattern consistent with nearby modules.
- Restored original model callback/owner state in destructor and reattached mesh callback in frame path after lazy allocation.
