### PR TITLE
Decompile main/main bootstrap and CLI parsing

### DIFF
--- a/include/ffcc/main.h
+++ b/include/ffcc/main.h
@@ -2,6 +2,6 @@
 #define _FFCC_MAIN_H_
 
 void game(int, char**);
-void main(void);
+void main(int, char**);
 
 #endif // _FFCC_MAIN_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,101 @@
 #include "ffcc/main.h"
+#include "ffcc/p_game.h"
+#include "ffcc/pad.h"
+#include "ffcc/system.h"
+
+#include <string.h>
+
+static const char lbl_801d6a40[] = "ffcc_0";
+static const char lbl_801d6a48[] = "us";
+static const char lbl_801d6a4c[] = "uk";
+static const char lbl_801d6a50[] = "gr";
+static const char lbl_801d6a54[] = "it";
+static const char lbl_801d6a58[] = "fr";
+static const char lbl_801d6a5c[] = "sp";
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001a054
+ * PAL Size: 476b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void game(int, char **)
+void game(int argc, char** argv)
 {
-	// TODO
+    bool copyScriptName = false;
+    bool parseLanguage = false;
+
+    Game.game.Init();
+    strcpy(reinterpret_cast<char*>(0x8022b7b4), lbl_801d6a40);
+
+    if (argc != 0) {
+        for (int i = 1; i < argc; i++) {
+            char* argument = argv[i];
+
+            if (copyScriptName) {
+                strcpy(reinterpret_cast<char*>(0x8022b7b4), argument);
+                copyScriptName = false;
+            } else if (parseLanguage) {
+                if ((strcmp(argument, lbl_801d6a48) == 0) || (strcmp(argument, lbl_801d6a4c) == 0)) {
+                    Game.game.m_gameWork.m_languageId = 1;
+                } else if (strcmp(argument, lbl_801d6a50) == 0) {
+                    Game.game.m_gameWork.m_languageId = 2;
+                } else if (strcmp(argument, lbl_801d6a58) == 0) {
+                    Game.game.m_gameWork.m_languageId = 3;
+                } else if (strcmp(argument, lbl_801d6a5c) == 0) {
+                    Game.game.m_gameWork.m_languageId = 4;
+                } else if (strcmp(argument, lbl_801d6a54) == 0) {
+                    Game.game.m_gameWork.m_languageId = 5;
+                } else {
+                    Game.game.m_gameWork.m_languageId = 0;
+                }
+                parseLanguage = false;
+            } else if ((argument[0] == '-') || (argument[0] == '/')) {
+                if (argument[1] == 'f') {
+                    copyScriptName = true;
+                } else if (argument[1] == 'l') {
+                    parseLanguage = true;
+                }
+            }
+        }
+    }
+
+    Game.game.Exec();
+    Game.game.Quit();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80019f88
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void main(void)
+void main(int argc, char** argv)
 {
-	// TODO
+    if (argc != 0) {
+        for (int i = 1; i < argc; i++) {
+            const char* argument = argv[i];
+            char command;
+
+            if ((argument[0] != '-') && (argument[0] != '/')) {
+                continue;
+            }
+
+            command = argument[1];
+            if (command == 'w') {
+                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&Pad) + 0x1B8) = 1;
+            } else if (command == 'r') {
+                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&Pad) + 0x1B4) = 1;
+            }
+        }
+    }
+
+    System.Init();
+    game(argc, argv);
+    System.Quit();
 }


### PR DESCRIPTION
## Summary
- Replaced stubbed `main` and `game` implementations in `src/main.cpp` with decomp-derived logic.
- Added PAL metadata blocks for both functions.
- Updated `include/ffcc/main.h` so `main` takes `(int, char**)`, matching startup call shape.

## Functions Improved
- Unit: `main/main`
- `main` (PAL 0x80019f88, 204b): **2.0% -> 87.82%**
- `game__FiPPc` (PAL 0x8001a054, 476b): **0.8% -> 66.82%**

## Match Evidence
- `objdiff` interactive diff after rebuild showed:
  - `main`: **87.73%**
  - `game__FiPPc`: **64.88%**
- Project report (`build/GCCP01/report.json`) records current fuzzy match:
  - `main`: **87.82353%**
  - `game__FiPPc`: **66.815125%**

## Plausibility Rationale
- Control flow follows expected startup/bootstrap behavior: parse CLI options, initialize `System`, run `game`, and shut down.
- `game` uses straightforward argument-driven state changes (`-f` script override, `-l` language selection), then calls `Init/Exec/Quit` on `Game.game`.
- Changes avoid artificial compiler-coaxing patterns and keep logic readable as plausible original game-side source.

## Technical Details
- Implemented option scanning for `/` and `-` prefixed args.
- Implemented language token mapping (`us`, `uk`, `gr`, `fr`, `sp`, `it`) and default script token initialization (`ffcc_0`) for the script name buffer.
- Retained direct global interactions (`Game`, `System`, `Pad`) consistent with nearby decomp style and symbol usage.
