### PR TITLE
memory: add missing stage new/new[] wrappers

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -18,7 +18,7 @@ public:
     public:
         void initBlock();
         void quitBlock();
-        void alloc(unsigned long, char*, unsigned long, int);
+        void* alloc(unsigned long, char*, unsigned long, int);
         void setDefaultParam(unsigned long);
         void resDefaultParam();
         void setParam(void*, unsigned long);
@@ -102,6 +102,7 @@ public:
 };
 
 void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int line);
+void* operator new[](unsigned long size, CMemory::CStage* stage, char* file, int line);
 
 extern CMemory Memory;
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,5 +1,41 @@
 #include "ffcc/memory.h"
 
+static char s_memory_cpp[] = "memory.cpp";
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FD8C
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int line)
+{
+    if (file == (char*)nullptr) {
+        file = s_memory_cpp;
+    }
+    return stage->alloc(size, file, line, 0);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FD4C
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* operator new[](unsigned long size, CMemory::CStage* stage, char* file, int line)
+{
+    if (file == (char*)nullptr) {
+        file = s_memory_cpp;
+    }
+    return stage->alloc(size, file, line, 0);
+}
+
 /*
  * --INFO--
  * Address:	TODO
@@ -215,9 +251,9 @@ void CMemory::CStage::quitBlock()
  * Address:	TODO
  * Size:	TODO
  */
-void CMemory::CStage::alloc(unsigned long, char*, unsigned long, int)
+void* CMemory::CStage::alloc(unsigned long, char*, unsigned long, int)
 {
-	// TODO
+	return (void*)nullptr;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added missing stage-aware allocation wrappers in `memory.cpp`:
  - `operator new(unsigned long, CMemory::CStage*, char*, int)` (`__nw__FUlPQ27CMemory6CStagePci`)
  - `operator new[](unsigned long, CMemory::CStage*, char*, int)` (`__nwa__FUlPQ27CMemory6CStagePci`)
- Added null-file fallback to a local `memory.cpp` filename string before dispatching to `CMemory::CStage::alloc`.
- Updated declarations so `CMemory::CStage::alloc` returns `void*`, matching allocator usage in these wrappers.

## Functions Improved
- Unit: `main/memory`
- Symbols:
  - `__nw__FUlPQ27CMemory6CStagePci` (64b)
  - `__nwa__FUlPQ27CMemory6CStagePci` (64b)

## Match Evidence
- `objdiff-cli` (v3.6.1) after this change:
  - `__nw__FUlPQ27CMemory6CStagePci`: **66.875%**
  - `__nwa__FUlPQ27CMemory6CStagePci`: **66.875%**
- Baseline context before this patch:
  - `tools/agent_select_target.py` showed `__nwa__FUlPQ27CMemory6CStagePci` at **0.0%** in `main/memory`.
  - In the previous state, these wrappers were not materialized as matching decomp symbols (report entries were null).

## Plausibility Rationale
- These are idiomatic game-code memory wrappers: they normalize a null file pointer and forward allocation to a stage allocator.
- The change avoids contrived instruction coaxing and uses straightforward source-level behavior expected for custom stage-based allocation APIs.

## Technical Details
- Compared symbol-level output with `objdiff-cli diff -p . -u main/memory` on each wrapper.
- Current remaining mismatch appears to come from small-data placement/control-flow details around the fallback filename load, not from wrapper intent or call target.
