### PR TITLE
main/pppChangeBGColor: improve pppFrameChangeBGColor match

### DIFF
--- a/src/pppChangeBGColor.cpp
+++ b/src/pppChangeBGColor.cpp
@@ -1,8 +1,8 @@
 #include "ffcc/pppChangeBGColor.h"
-#include "ffcc/map.h"
 
 // External global variables 
 extern int DAT_8032ed70;
+extern unsigned char MapMng[];
 
 /*
  * --INFO--
@@ -15,13 +15,17 @@ extern int DAT_8032ed70;
  */
 void pppFrameChangeBGColor(struct pppChangeBGColor* pppChangeBGColor, struct UnkB* param_2, struct UnkC* param_3)
 {
+	int iVar1;
+	unsigned char* data;
+	unsigned char* mapMng;
+
 	if (DAT_8032ed70 != 0) {
 		return;
 	}
 
-	unsigned char* mapMng = (unsigned char*)&MapMng;
-	unsigned char* data = (unsigned char*)pppChangeBGColor + param_3->m_serializedDataOffsets[1] + 0x80;
-
+	iVar1 = param_3->m_serializedDataOffsets[1];
+	mapMng = MapMng;
+	data = (unsigned char*)pppChangeBGColor + iVar1 + 0x80;
 	mapMng += 0x20000;
 	mapMng[0x2989] = 1;
 	mapMng[0x2990] = data[8];


### PR DESCRIPTION
## Summary
- Reworked pppFrameChangeBGColor in src/pppChangeBGColor.cpp to mirror the original pointer/arithmetic flow more closely.
- Switched to a raw byte-view of MapMng in this TU and explicit local temporaries (iVar1, data, mapMng) to align instruction generation.
- Kept behavior identical: early return on DAT_8032ed70, then write 4 BG color bytes and enable flag.

## Functions improved
- Unit: main/pppChangeBGColor
- Symbol: pppFrameChangeBGColor
- Size: 84 bytes

## Match evidence
- objdiff (tools/objdiff-cli v3.6.1) before: 68.33%
- objdiff after: 97.86%
- Remaining diffs are relocation/symbol argument mismatches only (DIFF_ARG_MISMATCH), with instruction flow aligned.

## Plausibility rationale
- Change uses straightforward byte-level field writes that match how this codebase frequently accesses serialized particle/map data.
- No artificial control-flow tricks or opaque coercions were introduced; only representation and temporary structure were adjusted.

## Technical details
- Kept the original +0x20000 plus 0x2989..0x2993 map byte addressing pattern.
- Reintroduced explicit serialized offset local (iVar1) and data pointer construction (base + offset + 0x80) to match expected address-use sequence.
- Verified full project build remains green with ninja.
