### PR TITLE
Improve pppSRandDownFV callback ABI and flow

### DIFF
--- a/include/ffcc/pppSRandDownFV.h
+++ b/include/ffcc/pppSRandDownFV.h
@@ -7,7 +7,7 @@ extern "C" {
 
 void randfloat(float, float);
 void randf(unsigned char);
-void pppSRandDownFV(void* param1, void* param2);
+void pppSRandDownFV(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Reworked `pppSRandDownFV` to follow the real callback ABI and control flow used by the PAL binary.
- Updated the declaration to use three callback parameters (`param1`, `param2`, `param3`) and aligned source logic to the two-path behavior:
  - initialize random vector when `*(param1 + 0xC) == 0`
  - reuse cached vector when indices match
- Corrected downstream accumulation semantics to additive float updates (`target += cfg * randVec`) and preserved the `-1` global fallback target.

## Functions improved
- Unit: `main/pppSRandDownFV`
- Symbol: `pppSRandDownFV`

## Match evidence
- `pppSRandDownFV` improved from **10.317757%** to **72.990654%** (objdiff symbol match).
- Improvement validated with:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppSRandDownFV -o - pppSRandDownFV`

## Plausibility rationale
- Changes reflect expected game-engine callback structure already used by sibling `pppSRand*` units (init-vs-apply split, per-component random scaling, and offset-based target writes).
- Update removes placeholder behavior and replaces it with coherent data-flow through typed callback records, improving readability while matching the known binary behavior.

## Technical details
- Fixed ABI mismatch by adding the missing third callback argument, which removed early prologue/control-flow divergence.
- Matched the PAL routine’s negative-random path and optional second-sample blend using `lbl_80330080`.
- Aligned pointer/offset usage around `sel->offsetPtr` and `cfg->offset` to match assembly access patterns (`+0x80` base adjustment, `-1` global target case).
