### PR TITLE
Improve DBGEXIImm structural match in DebuggerDriver

### DIFF
--- a/src/OdemuExi2/DebuggerDriver.c
+++ b/src/OdemuExi2/DebuggerDriver.c
@@ -48,28 +48,80 @@ static BOOL DBGEXISync() {
 }
 
 static BOOL DBGEXIImm(void* buffer, s32 bytecounter, u32 write) {
-    u8* tempPointer;
-    u32 writeOutValue;
-    int i;
+    s32 i;
+    s32 rem;
+    u32 value;
+    u8* p;
+    u32 chunkCount;
 
-    if (write) {
-        tempPointer = buffer;
-        writeOutValue = 0;
-        for (i = 0; i < bytecounter; i++) {
-            u8* temp = ((u8*)buffer) + i;
-            writeOutValue |= *temp << ((3 - i) << 3);
+    if (write != 0) {
+        i = 0;
+        value = 0;
+        if (0 < bytecounter) {
+            if ((8 < bytecounter) && (chunkCount = ((u32)bytecounter - 1) >> 3, p = buffer, 0 < bytecounter - 8)) {
+                do {
+                    value |= (u32)p[0] << ((3 - i) * 8);
+                    value |= (u32)p[1] << ((3 - (i + 1)) * 8);
+                    value |= (u32)p[2] << ((3 - (i + 2)) * 8);
+                    value |= (u32)p[3] << ((3 - (i + 3)) * 8);
+                    value |= (u32)p[4] << ((3 - (i + 4)) * 8);
+                    value |= (u32)p[5] << ((3 - (i + 5)) * 8);
+                    value |= (u32)p[6] << ((3 - (i + 6)) * 8);
+                    value |= (u32)p[7] << ((3 - (i + 7)) * 8);
+                    p += 8;
+                    i += 8;
+                    chunkCount--;
+                } while (chunkCount != 0);
+            }
+
+            p = (u8*)buffer + i;
+            rem = bytecounter - i;
+            if (i < bytecounter) {
+                do {
+                    value |= (u32)(*p) << ((3 - i) * 8);
+                    p++;
+                    i++;
+                    rem--;
+                } while (rem != 0);
+            }
         }
-        __EXIRegs[14] = writeOutValue;
+        __EXIRegs[14] = value;
     }
 
-    __EXIRegs[13] = 1 | write << 2 | (bytecounter - 1) << 4;
-    DBGEXISync();
+    __EXIRegs[13] = (write << 2) | 1U | ((bytecounter - 1) << 4);
+    do {
+        value = __EXIRegs[13];
+    } while (value & 1);
 
-    if (!write) {
-        writeOutValue = __EXIRegs[14];
-        tempPointer = buffer;
-        for (i = 0; i < bytecounter; i++) {
-            *tempPointer++ = writeOutValue >> ((3 - i) << 3);
+    if (write == 0) {
+        i = 0;
+        value = __EXIRegs[14];
+        if (0 < bytecounter) {
+            if ((8 < bytecounter) && (chunkCount = ((u32)bytecounter - 1) >> 3, 0 < bytecounter - 8)) {
+                do {
+                    ((u8*)buffer)[0] = (u8)(value >> ((3 - i) * 8));
+                    ((u8*)buffer)[1] = (u8)(value >> ((3 - (i + 1)) * 8));
+                    ((u8*)buffer)[2] = (u8)(value >> ((3 - (i + 2)) * 8));
+                    ((u8*)buffer)[3] = (u8)(value >> ((3 - (i + 3)) * 8));
+                    ((u8*)buffer)[4] = (u8)(value >> ((3 - (i + 4)) * 8));
+                    ((u8*)buffer)[5] = (u8)(value >> ((3 - (i + 5)) * 8));
+                    ((u8*)buffer)[6] = (u8)(value >> ((3 - (i + 6)) * 8));
+                    ((u8*)buffer)[7] = (u8)(value >> ((3 - (i + 7)) * 8));
+                    buffer = (u8*)buffer + 8;
+                    i += 8;
+                    chunkCount--;
+                } while (chunkCount != 0);
+            }
+
+            rem = bytecounter - i;
+            if (i < bytecounter) {
+                do {
+                    *(u8*)buffer = (u8)(value >> ((3 - i) * 8));
+                    buffer = (u8*)buffer + 1;
+                    i++;
+                    rem--;
+                } while (rem != 0);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Reworked `DBGEXIImm` in `src/OdemuExi2/DebuggerDriver.c` to use explicit EXI word packing/unpacking flow that mirrors the target binary structure.
- Replaced the compact byte loop + `DBGEXISync` helper call pattern with the in-function wait loop and two-phase transfer loops (8-byte chunk path + tail path).
- Kept behavior source-plausible by expressing transfer semantics directly (command issue, wait for transfer completion, write/read byte extraction).

## Functions improved
- Unit: `main/OdemuExi2/DebuggerDriver`
- Function: `DBGEXIImm`
  - Before: `0.0%`
  - After: `38.801205%`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/OdemuExi2/DebuggerDriver -o - DBGEXIImm`
  - `DBGEXIImm` moved from a complete mismatch to partial structural alignment (`0.0% -> 38.801205%`).
- Unit fuzzy match moved from selector-reported `41.8%` to report value `51.39732%` after this change.

## Plausibility rationale
- The new implementation models realistic EXI transfer code structure used in SDK-style low-level drivers: staged command emission, busy-bit polling, and explicit byte-lane pack/unpack operations.
- Changes are type/control-flow driven rather than synthetic no-op coaxing.

## Technical details
- Introduced explicit packed-word accumulation/extraction with shift expressions matching byte lane handling.
- Added in-function EXI status polling loop immediately after issuing the transfer command.
- Structured loops into chunked and remainder phases, which materially improved instruction-level ordering and branch structure against target assembly.
