### PR TITLE
Improve pppVtMime matching with typed state access

### DIFF
--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -1,5 +1,53 @@
 #include "ffcc/pppVtMime.h"
 
+struct VtMimeCtrl
+{
+    unsigned char pad0[0xC];
+    int* stateOffset;
+};
+
+struct VtMimeState
+{
+    float value;
+    float velocity;
+    float accel;
+    void* vertexBuffer;
+};
+
+struct VtMimeData
+{
+    int id;
+    int sourceA;
+    int sourceB;
+    float addX;
+    float addY;
+    float addZ;
+};
+
+struct VtMimeSource
+{
+    short vertexCount;
+    unsigned char pad2[0x2A];
+    float* positions;
+};
+
+struct VtMimeEnv
+{
+    void* stage;
+    void** sourceTable;
+};
+
+extern int lbl_8032ED70;
+extern VtMimeEnv* lbl_8032ED54;
+extern void* Graphic;
+
+extern "C" {
+void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long size, void* stage, char* file, int line);
+void _WaitDrawDone__8CGraphicFPci(void* graphic, const char* file, int line);
+void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
+void DCFlushRange(void* addr, unsigned long nBytes);
+}
+
 /*
  * --INFO--
  * PAL Address: 800652d0
@@ -11,31 +59,20 @@
  */
 void pppVtMime(void* param1, void* param2, void* param3)
 {
-	// Get data structure from param3 and param1
-	void** dataPtr = (void**)((char*)param3 + 0xC);
-	void* data = *dataPtr;
-	void* dataBase = *(void**)data;
-	
-	// Calculate offset and get target structure  
-	char* target = (char*)param1 + (int)dataBase + 0x80;
-	
-	// Check if global flag is set (early return if not zero)
-	extern int lbl_8032ED70;
-	if (lbl_8032ED70 != 0) return;
-	
-	// Add values from target structure (looks like accumulation)
-	float* targetFloats = (float*)target;
-	targetFloats[1] += targetFloats[2];  // f1 + f0 -> f1  
-	targetFloats[0] += targetFloats[1];  // f1 + f0 -> f0
-	
-	// Get values from param2 and add to target
-	int* param2Ints = (int*)param2;
-	if (param2Ints[0] == *(int*)((char*)param1 + 0xC)) {
-		float* param2Floats = (float*)param2;
-		targetFloats[0] += param2Floats[3];  // param2[0xC] -> target[0x0]
-		targetFloats[1] += param2Floats[4];  // param2[0x10] -> target[0x4] 
-		targetFloats[2] += param2Floats[5];  // param2[0x14] -> target[0x8]
-	}
+    VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param3 + 0xC) + 0x80);
+    VtMimeData* data = (VtMimeData*)param2;
+
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
+
+    state->velocity += state->accel;
+    state->value += state->velocity;
+    if (data->id == *(int*)((char*)param1 + 0xC)) {
+        state->value += data->addX;
+        state->velocity += data->addY;
+        state->accel += data->addZ;
+    }
 }
 
 /*
@@ -49,75 +86,55 @@ void pppVtMime(void* param1, void* param2, void* param3)
  */
 void pppDrawVtMime(void* param1, void* param2, void* param3)
 {
-	// Clear result pointer
-	*(void**)((char*)param1 + 0x70) = 0;
-	
-	// Check validity of vertex data indices
-	int vertIdx1 = *(int*)((char*)param2 + 0x4);
-	int vertIdx2 = *(int*)((char*)param2 + 0x8);
-	
-	if ((vertIdx1 & 0xFFFF0000) == 0xFFFF0000) return;
-	if ((vertIdx2 & 0xFFFF0000) == 0xFFFF0000) return;
-	
-	// Get data structures
-	void** dataPtr = (void**)((char*)param3 + 0xC);
-	void* data = *dataPtr;
-	void* dataBase = *(void**)data;
-	char* target = (char*)param1 + (int)dataBase + 0x80;
-	
-	// Get global vertex data pointers
-	extern void* lbl_8032ED54;
-	void* globalData = *(void**)((char*)lbl_8032ED54 + 0x8);
-	
-	// Get vertex data for interpolation
-	void* vert1Data = *(void**)((char*)globalData + (vertIdx1 * 4));
-	void* vert2Data = *(void**)((char*)globalData + (vertIdx2 * 4));
-	
-	float* vert1Pos = (float*)((char*)vert1Data + 0x2C);
-	float* vert2Pos = (float*)((char*)vert2Data + 0x2C);
-	
-	short vertCount = *(signed short*)vert1Data;
-	
-	// Check if memory needs allocation
-	void** memPtr = (void**)((char*)target + 0xC);
-	if (*memPtr == 0) {
-		// Allocate memory for vertex data
-		extern void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long size, void* stage, char* info, int param);
-		extern void* lbl_8032ED54;
-		void* stage = *(void**)lbl_8032ED54;
-		
-		*memPtr = pppMemAlloc__FUlPQ27CMemory6CStagePci(vertCount * 0xC, stage, "Unknown", 0x2B);
-	}
-	
-	// Perform vertex interpolation
-	if (vertCount > 0) {
-		float* outputVerts = (float*)*memPtr;
-		float interpFactor = *(float*)target;
-		
-		// Loop through vertices and interpolate
-		int i;
-		for (i = 0; i < vertCount; i++) {
-			// Interpolate X, Y, Z coordinates
-			float v1X = vert1Pos[i * 6 + 0];
-			float v2X = vert2Pos[i * 6 + 0];
-			outputVerts[i * 3 + 0] = v1X + interpFactor * (v2X - v1X);
-			
-			float v1Y = vert1Pos[i * 6 + 1];
-			float v2Y = vert2Pos[i * 6 + 1];
-			outputVerts[i * 3 + 1] = v1Y + interpFactor * (v2Y - v1Y);
-			
-			float v1Z = vert1Pos[i * 6 + 2];
-			float v2Z = vert2Pos[i * 6 + 2];
-			outputVerts[i * 3 + 2] = v1Z + interpFactor * (v2Z - v1Z);
-		}
-		
-		// Flush data cache
-		extern void DCFlushRange(void* ptr, unsigned long size);
-		DCFlushRange(*memPtr, vertCount * 0xC);
-	}
-	
-	// Set result pointer
-	*(void**)((char*)param1 + 0x70) = *memPtr;
+    *(void**)((char*)param1 + 0x70) = 0;
+
+    int vertIdx1 = *(int*)((char*)param2 + 0x4);
+    int vertIdx2 = *(int*)((char*)param2 + 0x8);
+
+    if ((vertIdx1 & 0xFFFF0000) == 0xFFFF0000) {
+        return;
+    }
+    if ((vertIdx2 & 0xFFFF0000) == 0xFFFF0000) {
+        return;
+    }
+
+    void* dataBase = *(void**)*(void**)((char*)param3 + 0xC);
+    char* target = (char*)param1 + (int)dataBase + 0x80;
+    void* globalData = *(void**)((char*)lbl_8032ED54 + 0x8);
+    void* vert1Data = *(void**)((char*)globalData + (vertIdx1 * 4));
+    void* vert2Data = *(void**)((char*)globalData + (vertIdx2 * 4));
+    float* vert1Pos = (float*)((char*)vert1Data + 0x2C);
+    float* vert2Pos = (float*)((char*)vert2Data + 0x2C);
+    short vertCount = *(short*)vert1Data;
+    void** memPtr = (void**)(target + 0xC);
+
+    if (*memPtr == 0) {
+        *memPtr = pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(vertCount * 0xC), * (void**)lbl_8032ED54, "Unknown", 0x2B);
+    }
+
+    if (vertCount > 0) {
+        float* outputVerts = (float*)*memPtr;
+        float interpFactor = *(float*)target;
+        int i;
+
+        for (i = 0; i < vertCount; i++) {
+            float v1X = vert1Pos[i * 6 + 0];
+            float v2X = vert2Pos[i * 6 + 0];
+            outputVerts[i * 3 + 0] = v1X + interpFactor * (v2X - v1X);
+
+            float v1Y = vert1Pos[i * 6 + 1];
+            float v2Y = vert2Pos[i * 6 + 1];
+            outputVerts[i * 3 + 1] = v1Y + interpFactor * (v2Y - v1Y);
+
+            float v1Z = vert1Pos[i * 6 + 2];
+            float v2Z = vert2Pos[i * 6 + 2];
+            outputVerts[i * 3 + 2] = v1Z + interpFactor * (v2Z - v1Z);
+        }
+
+        DCFlushRange(*memPtr, (unsigned long)(vertCount * 0xC));
+    }
+
+    *(void**)((char*)param1 + 0x70) = *memPtr;
 }
 
 /*
@@ -131,21 +148,12 @@ void pppDrawVtMime(void* param1, void* param2, void* param3)
  */
 void pppVtMimeCon(void* param1, void* param2, void* param3)
 {
-	// Get data structure from param2 and param1
-	void** dataPtr = (void**)((char*)param2 + 0xC);
-	void* data = *dataPtr;
-	void* dataBase = *(void**)data;
-	
-	// Calculate offset and get target structure  
-	char* target = (char*)param1 + (int)dataBase + 0x80;
-	
-	// Initialize three consecutive float values to 0.0f
-	*(float*)((char*)target + 0x0) = 0.0f;
-	*(float*)((char*)target + 0x4) = 0.0f;
-	*(float*)((char*)target + 0x8) = 0.0f;
-	
-	// Also set integer value at offset 0xC to 0
-	*(int*)((char*)target + 0xC) = 0;
+    VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
+
+    state->value = 0.0f;
+    state->velocity = 0.0f;
+    state->accel = 0.0f;
+    state->vertexBuffer = 0;
 }
 
 /*
@@ -159,18 +167,11 @@ void pppVtMimeCon(void* param1, void* param2, void* param3)
  */
 void pppVtMimeCon2(void* param1, void* param2, void* param3)
 {
-	// Get data structure from param2 and param1
-	void** dataPtr = (void**)((char*)param2 + 0xC);
-	void* data = *dataPtr;
-	void* dataBase = *(void**)data;
-	
-	// Calculate offset and get target structure  
-	char* target = (char*)param1 + (int)dataBase + 0x80;
-	
-	// Initialize three consecutive float values to 0.0f
-	*(float*)((char*)target + 0x0) = 0.0f;
-	*(float*)((char*)target + 0x4) = 0.0f;
-	*(float*)((char*)target + 0x8) = 0.0f;
+    VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
+
+    state->value = 0.0f;
+    state->velocity = 0.0f;
+    state->accel = 0.0f;
 }
 
 /*
@@ -184,27 +185,11 @@ void pppVtMimeCon2(void* param1, void* param2, void* param3)
  */
 void pppVtMimeDes(void* param1, void* param2)
 {
-	// Get data structure from param2
-	void** dataPtr = (void**)((char*)param2 + 0xC);
-	void* data = *dataPtr;
-	void* dataBase = *(void**)data;
-	
-	// Calculate target offset and check memory allocation
-	int offset = (int)dataBase + 0x80 + 0xC; // Direct offset calculation
-	void** memPtr = (void**)((char*)param1 + offset);
-	
-	// Check if memory is allocated
-	if (*memPtr != 0) {
-		// Graphics wait and memory cleanup
-		extern void _WaitDrawDone__8CGraphicFPci(void*, const char*, int);
-		extern void* Graphic;
-		_WaitDrawDone__8CGraphicFPci(Graphic, "Unknown", 0x50);
-		
-		// Heap usage reporting
-		extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
-		pppHeapUseRate__FPQ27CMemory6CStage(*memPtr);
-		
-		// Clear the pointer
-		*memPtr = 0;
-	}
+    VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
+
+    if (state->vertexBuffer != 0) {
+        _WaitDrawDone__8CGraphicFPci(Graphic, "Unknown", 0x50);
+        pppHeapUseRate__FPQ27CMemory6CStage(state->vertexBuffer);
+        state->vertexBuffer = 0;
+    }
 }


### PR DESCRIPTION
## Summary
- Reworked `src/pppVtMime.cpp` to use explicit local structs for control/state/data access instead of scattered raw pointer arithmetic.
- Simplified `pppVtMime`, `pppVtMimeCon`, and `pppVtMimeCon2` state updates/initialization to direct field writes.
- Reworked `pppVtMimeDes` to read/write the state buffer pointer directly and keep teardown sequencing explicit.
- Kept `pppDrawVtMime` behavior and shape intact while integrating cleaner data access around it.

## Functions Improved
- Unit: `main/pppVtMime`
- `pppDrawVtMime`: `70.65289%` -> `73.04958%` (`+2.39669`)
- `pppVtMimeDes`: `82.53846%` -> `87.46154%` (`+4.92308`)
- Unit `.text` match: `79.80402%` -> `81.904526%`

## Match Evidence
- Measured with:
  - `tools/objdiff-cli diff -p . -u main/pppVtMime -o - pppDrawVtMime`
- Before/after JSON diff snapshots were compared for symbol match percentages and overall unit `.text` match.
- Improvement is concentrated on real instruction alignment in `pppDrawVtMime` and `pppVtMimeDes` (not naming/format-only edits).

## Plausibility Rationale
- The changes move toward likely original source structure: typed state/control/data objects, direct field semantics, and straightforward control flow.
- Avoids contrived compiler-coaxing tricks (no artificial temp chains or odd reordering).
- Keeps behavior and call sequencing consistent with existing ppp module patterns.

## Technical Details
- `pppVtMimeDes` now computes the per-object state pointer once and uses the buffer field directly for wait/heap-rate/reset operations.
- `pppDrawVtMime` retains the interpolation flow and allocation/flush behavior while preserving the improved match delta.
