### PR TITLE
pppMiasma: implement pppFrameMiasma core update path

### DIFF
--- a/include/ffcc/pppMiasma.h
+++ b/include/ffcc/pppMiasma.h
@@ -1,8 +1,37 @@
 #ifndef _PPP_MIASMA_H_
 #define _PPP_MIASMA_H_
 
+#include <dolphin/types.h>
+
 struct Vec;
 struct _pppPObject;
+
+typedef struct {
+    s32 m_graphId;
+    u8 m_pad_0x4[0x7c];
+} pppMiasma;
+
+typedef struct {
+    s32 m_unk0;
+    s16 m_addPosX;
+    s16 m_addPosY;
+    s32 m_graphId;
+    s16 m_addPosZ;
+    s16 m_addPosW;
+    s16 m_addVelX;
+    s16 m_addVelY;
+    s16 m_addVelZ;
+    s16 m_addVelW;
+    s16 m_addAccX;
+    s16 m_addAccY;
+    s16 m_addAccZ;
+    s16 m_addAccW;
+} pppMiasmaFrameStep;
+
+typedef struct {
+    u8 m_pad_0x0[0xc];
+    s32* m_serializedDataOffsets;
+} pppMiasmaCtrl;
 
 void CalcSphereRadius(Vec*, unsigned short);
 void CreateScaleMatrix(_pppPObject*, float);
@@ -15,7 +44,7 @@ void pppRenderMiasma(void);
 void pppConstructMiasma(void);
 void pppConstruct2Miasma(void);
 void pppDestructMiasma(void);
-void pppFrameMiasma(void);
+void pppFrameMiasma(pppMiasma*, pppMiasmaFrameStep*, pppMiasmaCtrl*);
 
 #ifdef __cplusplus
 }

--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/pppMiasma.h"
 
+extern int DAT_8032ed70;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -77,9 +79,40 @@ void pppDestructMiasma(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameMiasma(void)
+void pppFrameMiasma(pppMiasma* pppMiasma, pppMiasmaFrameStep* param_2, pppMiasmaCtrl* param_3)
 {
-	return;
+    s16* work;
+
+    if (DAT_8032ed70 != 0) {
+        return;
+    }
+
+    work = (s16*)((u8*)pppMiasma + 0x80 + param_3->m_serializedDataOffsets[2]);
+    work[4] = work[4] + work[8];
+    work[0] = work[0] + work[4];
+    work[5] = work[5] + work[9];
+    work[1] = work[1] + work[5];
+    work[6] = work[6] + work[10];
+    work[2] = work[2] + work[6];
+    work[7] = work[7] + work[11];
+    work[3] = work[3] + work[7];
+
+    if (pppMiasma->m_graphId != param_2->m_graphId) {
+        return;
+    }
+
+    work[0] = work[0] + param_2->m_addPosX;
+    work[1] = work[1] + param_2->m_addPosY;
+    work[2] = work[2] + param_2->m_addPosZ;
+    work[3] = work[3] + param_2->m_addPosW;
+    work[4] = work[4] + param_2->m_addVelX;
+    work[5] = work[5] + param_2->m_addVelY;
+    work[6] = work[6] + param_2->m_addVelZ;
+    work[7] = work[7] + param_2->m_addVelW;
+    work[8] = work[8] + param_2->m_addAccX;
+    work[9] = work[9] + param_2->m_addAccY;
+    work[10] = work[10] + param_2->m_addAccZ;
+    work[11] = work[11] + param_2->m_addAccW;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `pppFrameMiasma` using the observed object/control-table data flow and per-axis `s16` accumulation logic, and added minimal typed parameter/layout structs in `include/ffcc/pppMiasma.h` to represent the callback inputs.

## Functions improved
- Unit: `main/pppMiasma`
- Function: `pppFrameMiasma`

## Match evidence
- `pppFrameMiasma` (objdiff symbol match): **1.0869565% -> 99.79348%**
- Unit `.text` match for `main/pppMiasma` (objdiff section match): **0.3238342% -> 6.205311%**
- Other major symbols in the unit were unchanged (`pppRenderMiasma`, `pppConstructMiasma`).

## Plausibility rationale
The new code is source-plausible for original game code:
- Uses normal typed fields for callback inputs and serialized offsets
- Mirrors the existing particle/ppp pattern used in adjacent units (`DAT_8032ed70` gate, serialized work area at `+0x80 + offset`)
- Keeps straightforward arithmetic/control flow without contrived compiler-coaxing constructs

## Technical details
- Added `pppMiasma`, `pppMiasmaFrameStep`, and `pppMiasmaCtrl` layout structs in `include/ffcc/pppMiasma.h`
- Updated `pppFrameMiasma` signature to take object/step/control pointers
- Implemented:
  - early return on `DAT_8032ed70`
  - integration of velocity/acceleration terms in the serialized `s16` work block
  - graph-id gated additive updates from frame step payload
