### PR TITLE
Improve pppScreenQuake frame match via ABI-correct layout/signature

### DIFF
--- a/include/ffcc/pppScreenQuake.h
+++ b/include/ffcc/pppScreenQuake.h
@@ -26,6 +26,9 @@ typedef struct {
 } UnkB;
 
 typedef struct {
+    int m_unk0;
+    int m_unk4;
+    int m_unk8;
     int *m_serializedDataOffsets;
 } UnkC;
 

--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -1,12 +1,10 @@
 #include "ffcc/pppScreenQuake.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/partMng.h"
+#include "ffcc/pppYmEnv.h"
 
 extern float FLOAT_80331fc8;
 extern int DAT_8032ed70;
-
-void CalcGraphValue(float param1, _pppPObject *param2, int param3, float *param4, float *param5, float *param6, float *param7, float *param8);
-extern "C" void SetQuakeParameter__10CCameraPcsFiissffffffi(CCameraPcs*, int, int, short, short, float, float, float, float, float, float, int);
 
 /*
  * --INFO--
@@ -70,7 +68,7 @@ void pppCon2ScreenQuake(pppScreenQuake *quake, UnkC *param2)
 void pppDesScreenQuake(void)
 {
 	float value = FLOAT_80331fc8;
-	SetQuakeParameter__10CCameraPcsFiissffffffi(&CameraPcs, 0, 0, 0, 0, value, value, value, value, value, value, 1);
+	CameraPcs.SetQuakeParameter(0, 0, 0, 0, value, value, value, value, value, value, 1);
 }
 
 /*
@@ -85,22 +83,13 @@ void pppDesScreenQuake(void)
 void pppFrameScreenQuake(pppScreenQuake *quake, UnkB *param2, UnkC *param3)
 {
 	if (DAT_8032ed70 == 0) {
-		float *value = (float *)((int)(&quake->field0_0x0 + 2) + *param3->m_serializedDataOffsets);
-		
-		CalcGraphValue(param2->m_dataValIndex, (_pppPObject*)&quake->field0_0x0, param2->m_graphId, 
-		               value, value + 1, value + 2, &param2->m_initWOrk, &param2->m_stepValue);
-		               
-		CalcGraphValue(param2->m_arg3, (_pppPObject*)&quake->field0_0x0, param2->m_graphId,
-		               value + 3, value + 4, value + 5, &param2->m_initWOrk2, &param2->m_stepValue2);
-		               
-		CalcGraphValue(param2->m_arg4, (_pppPObject*)&quake->field0_0x0, param2->m_graphId,
-		               value + 6, value + 7, value + 8, &param2->m_initWOrk3, &param2->m_stepValue3);
-		               
-		SetQuakeParameter__10CCameraPcsFiissffffffi(&CameraPcs, 1, 0, 0, 0,
-		                                            *value, value[3], value[6],
-		                                            param2->m_quakeParam0,
-		                                            param2->m_quakeParam1,
-		                                            param2->m_quakeParam2, 1);
+		float *value = (float *)((char *)quake + 0x80 + *param3->m_serializedDataOffsets);
+
+		CalcGraphValue((_pppPObject *)&quake->field0_0x0, param2->m_graphId, value[0], value[1], value[2], param2->m_dataValIndex, param2->m_initWOrk, param2->m_stepValue);
+		CalcGraphValue((_pppPObject *)&quake->field0_0x0, param2->m_graphId, value[3], value[4], value[5], param2->m_arg3, param2->m_initWOrk2, param2->m_stepValue2);
+		CalcGraphValue((_pppPObject *)&quake->field0_0x0, param2->m_graphId, value[6], value[7], value[8], param2->m_arg4, param2->m_initWOrk3, param2->m_stepValue3);
+
+		CameraPcs.SetQuakeParameter(1, 0, 0, 0, value[0], value[3], value[6], param2->m_quakeParam0, param2->m_quakeParam1, param2->m_quakeParam2, 1);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Corrected `pppScreenQuake` frame/update call ABI to match object code expectations.
- Updated `UnkC` layout so `m_serializedDataOffsets` is read from offset `0xC`.
- Switched `pppFrameScreenQuake` to use the reference-based `CalcGraphValue(_pppPObject*, long, float&, float&, float&, float, float&, float&)` signature and argument order.
- Fixed frame work-buffer base calculation to `base + 0x80 + *m_serializedDataOffsets`.
- Replaced manual external quake-call declaration with `CameraPcs.SetQuakeParameter(...)` member call usage.

## Functions Improved
- Unit: `main/pppScreenQuake`
- `pppFrameScreenQuake`: **74.8871% -> 93.548386%**
- `pppDesScreenQuake`: **60.666668% -> 60.666668%** (unchanged)

## Match Evidence
- `tools/objdiff-cli diff -p . -u main/pppScreenQuake -o - pppFrameScreenQuake`
- Before patch, frame function mismatches showed incorrect data-offset load path and call ABI setup.
- After patch, call setup and data-offset addressing align with target sequence; frame score increased by ~18.66 points.

## Plausibility Rationale
- Changes are type/layout corrections and normal API usage, not compiler-coaxing.
- `UnkC` offset alignment and `CalcGraphValue` reference-argument usage are consistent with neighboring particle modules and symbol signatures.
- Resulting C++ is straightforward and maintainable while improving assembly alignment.

## Technical Notes
- The original binary sequence loads serialized offset through a pointer at `param3 + 0xC`; this was previously modeled incorrectly.
- The target uses the `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf` call form; matching that signature/order substantially reduced divergence in `pppFrameScreenQuake`.
