### PR TITLE
Improve pppDestructConstrainCameraForLoc match and ABI alignment

### DIFF
--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -13,7 +13,8 @@ extern int DAT_8032ed70;
 
 // Function signatures from Ghidra decomp
 extern "C" int GetModelPtr__FP8CGObject(CGObject*);
-void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, void*, void*, void*, void*, void*);
+void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, pppConstrainCameraForLoc*, int, float*,
+                                                 float*, float*, float*, float*);
 
 /*
  * --INFO--
@@ -89,16 +90,33 @@ void pppConstruct2ConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCamer
  * --INFO--
  * PAL Address: 0x80167DD4
  * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDestructConstrainCameraForLoc(void)
+void pppDestructConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCameraForLoc,
+                                      pppConstrainCameraForLocParams* params,
+                                      pppConstrainCameraForLocData* data)
 {
+	float* value;
+	int modelPtr;
+
 	if (DAT_8032ed70 == 0) {
-		// Based on Ghidra decomp pattern
-		CGObject* obj = *(CGObject**)((char*)pppMngStPtr + 0xd8);
-		int modelPtr = GetModelPtr__FP8CGObject(obj);
-		
-		// Set up callback
+		value = (float*)((char*)constrainCameraForLoc + 0x80 + data->m_serializedDataOffsets[2]);
+		modelPtr = GetModelPtr__FP8CGObject(*(CGObject**)((char*)pppMngStPtr + 0xd8));
+		*(float**)(modelPtr + 0xe4) = value;
+		*(pppConstrainCameraForLocParams**)(modelPtr + 0xe8) = params;
 		*(void**)(modelPtr + 0xec) = (void*)CC_BeforeCalcMatrixCallback;
+		CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+		    params->m_dataValIndex,
+		    constrainCameraForLoc,
+		    params->m_graphId,
+		    value,
+		    value + 1,
+		    value + 2,
+		    &params->m_initWork,
+		    &params->m_stepValue);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Corrected `pppDestructConstrainCameraForLoc` to use the declared C ABI parameters instead of a no-arg stub.
- Implemented the expected teardown/setup behavior for camera-constrained location data:
  - resolve per-instance work buffer from serialized offset
  - write callback context pointers into model state (`+0xe4`, `+0xe8`)
  - install `CC_BeforeCalcMatrixCallback` at `+0xec`
  - run `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf` with parameter graph inputs
- Tightened the local `CalcGraphValue` prototype to concrete pointer types used by this unit.

## Functions Improved
- Unit: `main/pppConstrainCameraForLoc`
- Function: `pppDestructConstrainCameraForLoc` (156b)
- Before: `0.0%` fuzzy match (from `tools/agent_select_target.py` target listing)
- After: `94.87%` fuzzy match (`build/GCCP01/report.json`)

## Match Evidence
- Build status: `ninja` passes.
- Post-change report extraction (`build/GCCP01/report.json`) for the symbol:
  - `pppDestructConstrainCameraForLoc`: `fuzzy_match_percent = 94.871796`
- Unit-level post-change measure:
  - `main/pppConstrainCameraForLoc`: `fuzzy_match_percent = 46.488373`

## Plausibility Rationale
- The old implementation was an obvious placeholder (no parameters, only callback write) and did not align with the declared API.
- New code follows existing `ppp*` patterns in the codebase: serialized-offset work area access, model callback wiring, and graph-value update call.
- The implementation remains readable and source-plausible, avoiding contrived compiler-only coercion.

## Technical Notes
- `objdiff-cli` in this workspace is `v3.4.1` (interactive `diff` only in this environment), so symbol percentage evidence is taken from the generated project report JSON after rebuild.
