### PR TITLE
Improve pppRandShort match by fixing RandF flow and param typing

### DIFF
--- a/src/pppRandShort.cpp
+++ b/src/pppRandShort.cpp
@@ -1,11 +1,27 @@
 #include "ffcc/pppRandShort.h"
 #include "ffcc/math.h"
+#include "types.h"
 
 extern CMath math;
-extern int lbl_8032ED70;       // Global state flag
-extern float lbl_8032FFC8;     // Float constant 0x8032FFC8
-extern double lbl_8032FFD0;    // Double constant 0x8032FFD0
-extern float lbl_801EADC8[32]; // Array of floats at 0x801EADC8
+extern s32 lbl_8032ED70;
+extern f32 lbl_8032FFC8;
+extern s16 lbl_801EADC8;
+
+extern "C" {
+f32 RandF__5CMathFv(CMath*);
+}
+
+struct PppRandShortParam2 {
+    s32 field0;
+    s32 field4;
+    s16 field8;
+    u8 fieldA;
+};
+
+struct PppRandShortParam3 {
+    u8 field0[0xC];
+    s32* fieldC;
+};
 
 /*
  * --INFO--
@@ -16,90 +32,43 @@ extern float lbl_801EADC8[32]; // Array of floats at 0x801EADC8
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandShort(void* r3, void* r4, void* r5)
+void pppRandShort(void* param1, void* param2, void* param3)
 {
-    // Cast parameters based on memory access patterns from assembly
-    int* p1 = (int*)r3;  
-    
-    struct ParamStruct2 {
-        int field0;           // offset 0
-        int field4;           // offset 4  
-        short field8;         // offset 8 - halfword
-        unsigned char fieldA; // offset 10 - byte
-    }* p2 = (struct ParamStruct2*)r4; 
-    
-    struct ParamStruct3 {
-        void* field0;
-        void* field4;
-        void* field8;
-        void* fieldC;
-    }* p3 = (struct ParamStruct3*)r5; 
-    
-    // Check global state first - if set, return early
+    u8* base = (u8*)param1;
+    PppRandShortParam2* in = (PppRandShortParam2*)param2;
+    PppRandShortParam3* out = (PppRandShortParam3*)param3;
+    f32* valuePtr;
+
     if (lbl_8032ED70 != 0) {
-        return; 
+        return;
     }
-    
-    // Check field at offset 12 of first parameter
-    if (p1[3] == 0) { 
-        // Generate random float
-        math.RandF(); 
-        float randVal = 0.0f; // Placeholder - RandF result stored elsewhere
-        
-        // Check byte at offset 10 of second parameter  
-        if (p2->fieldA != 0) { 
-            // Generate second random and add them
-            math.RandF();
-            randVal += 0.0f; // Second placeholder
+
+    s32 baseState = *(s32*)(base + 0xC);
+    if (baseState == 0) {
+        f32 value = RandF__5CMathFv(&math);
+        if (in->fieldA != 0) {
+            value += RandF__5CMathFv(&math);
         } else {
-            // Multiply by constant at lbl_8032FFC8
-            randVal *= lbl_8032FFC8;
+            value *= lbl_8032FFC8;
         }
-        
-        // Get memory location to store result  
-        void** p3_data = (void**)p3->fieldC;
-        void* base = *p3_data;
-        // Assembly: addi r5, r3, 0x80; add r5, r30, r5  
-        // This means: offset = p1[3] + 0x80, then add base address from r30
-        int offset = p1[3] + 0x80;
-        float* target = (float*)((char*)r3 + offset);  
-        *target = randVal;
-        
-        return;
-    }
-    
-    // Check if first field of second param matches field at offset 12 of first param
-    if (p2->field0 != p1[3]) {
-        return;
-    }
-    
-    // Calculate target memory location
-    void** p3_data = (void**)p3->fieldC;
-    void* base = *p3_data;
-    void* addr_base;
-    
-    // Check field at offset 4 of second parameter
-    if (p2->field4 == -1) {
-        addr_base = &lbl_801EADC8[0];
+
+        valuePtr = (f32*)(base + *out->fieldC + 0x80);
+        *valuePtr = value;
     } else {
-        int offset = p2->field4 + 0x80;
-        addr_base = (char*)r3 + offset;
+        if (in->field0 != baseState) {
+            return;
+        }
+
+        valuePtr = (f32*)(base + *out->fieldC + 0x80);
     }
-    
-    // Load current value and do floating point calculation
-    short current_val = *(short*)addr_base;
-    short range = p2->field8;
-    int mem_offset = p1[3] + 0x80;
-    float* memory_loc = (float*)((char*)r3 + mem_offset);
-    float mem_val = *memory_loc;
-    
-    // Convert to floating point and do calculation:
-    // result = current_val + (range * mem_val - current_val)
-    double range_d = (double)range;
-    double current_d = (double)current_val;
-    double result = current_d + (range_d * mem_val - current_d);
-    
-    // Convert back to short and store
-    short final_result = (short)result;
-    *(short*)addr_base = final_result;
+
+    s16* target;
+    if (in->field4 == -1) {
+        target = &lbl_801EADC8;
+    } else {
+        target = (s16*)(base + in->field4 + 0x80);
+    }
+
+    f32 delta = ((f32)in->field8 * *valuePtr) - (f32)in->field8;
+    *target = (s16)(*target + (s16)delta);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandShort` to use typed input/output structs and explicit `RandF__5CMathFv` return values instead of placeholder `math.RandF()` calls.
- Aligned control flow with sibling `pppRand*` implementations:
  - early global guard
  - state-gated random generation/store phase
  - target-apply phase using `field4 == -1` sentinel fallback
- Simplified arithmetic to the expected rand-scale expression for short destinations.

## Functions Improved
- Unit: `main/pppRandShort`
- Function: `pppRandShort` (PAL size 320b)

## Match Evidence
- `objdiff-cli v3.6.1` before: **64.9625%**
- `objdiff-cli v3.6.1` after: **89.0%**
- Function size remained **320 bytes**

## Plausibility Rationale
- Change follows existing project patterns used in `pppRandUpInt` / `pppRandDownInt` rather than contrived compiler coaxing.
- Uses straightforward field-based parameter access and preserves readable gameplay-style random application logic.
- Removes placeholder behavior and replaces it with deterministic source-level semantics that naturally map to the existing `pppRand*` family.

## Technical Details
- Introduced `PppRandShortParam2` and `PppRandShortParam3` for ABI-consistent member access.
- Switched to `RandF__5CMathFv(CMath*)` declaration to capture floating return values directly.
- Kept `-1` sentinel handling for global short destination (`lbl_801EADC8`) and base-relative writes with `+0x80` addressing.
