### PR TITLE
Improve pppRandDownIV match with pointer access and float accumulation

### DIFF
--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -2,11 +2,11 @@
 #include "ffcc/math.h"
 #include "types.h"
 
-extern CMath math;
+extern CMath math[];
 extern s32 lbl_8032ED70;
 extern f32 lbl_8032FF68;
 extern f64 lbl_8032FF70;
-extern s32 lbl_801EADC8;
+extern s32 lbl_801EADC8[];
 
 extern "C" {
 f32 RandF__5CMathFv(CMath*);
@@ -50,9 +50,9 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     }
 
     if (in->field0 == *(s32*)(base + 0xC)) {
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(&math[0]);
         if (in->field18 != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_8032FF68;
+            value = (value - RandF__5CMathFv(&math[0])) * lbl_8032FF68;
         }
 
         valuePtr = (f32*)(base + *out->fieldC + 0x80);
@@ -65,15 +65,15 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
 
     valuePtr = (f32*)(base + *out->fieldC + 0x80);
     if (in->field4 == -1) {
-        target = &lbl_801EADC8;
+        target = &lbl_801EADC8[0];
     } else {
         target = (s32*)(base + in->field4 + 0x80);
     }
 
     {
         f32 randValue = *valuePtr;
-        target[0] += (s32)((f64)in->field8 * (f64)randValue);
-        target[1] += (s32)((f64)in->fieldC * (f64)randValue);
-        target[2] += (s32)((f64)in->field10 * (f64)randValue);
+        target[0] += (s32)(in->field8 * randValue);
+        target[1] += (s32)(in->fieldC * randValue);
+        target[2] += (s32)(in->field10 * randValue);
     }
 }


### PR DESCRIPTION
## Summary
- Updated `pppRandDownIV` to use pointer-style extern declarations for `math` and `lbl_801EADC8`.
- Switched call sites to `&math[0]` / `&lbl_801EADC8[0]`.
- Replaced the final accumulation math from double-cast multiplies to float-domain multiplies before integer cast.

## Functions improved
- Unit: `main/pppRandDownIV`
- Function: `pppRandDownIV`

## Match evidence
- `pppRandDownIV` fuzzy match: **84.435646% -> 91.41584%** (+6.980194)
- Validation: rebuilt and regenerated `build/GCCP01/report.json`, then read unit/function metrics from report.

## Plausibility rationale
- The updated code reflects plausible original source semantics:
  - global symbols used as addressable storage (`array[0]` style pointer access)
  - scalar particle updates performed via straightforward float scaling and integer accumulation
- No contrived temporaries, hardcoded offset tricks, or readability regressions were introduced.

## Technical details
- The change shifts emitted code toward the target in two key places:
  - symbol-address access form (`ADDR16_HA/LO`-style address materialization for globals)
  - arithmetic shape in the accumulation block (float multiply path instead of explicit double-cast multiply sequence)
- This reduced major instruction-form differences and raised the function-level fuzzy score meaningfully.
