### PR TITLE
exi: improve EXIIntrruptHandler codegen alignment

### DIFF
--- a/src/exi/EXIBios.c
+++ b/src/exi/EXIBios.c
@@ -520,16 +520,14 @@ int EXIDeselect(s32 chan) {
 
 static void EXIIntrruptHandler(__OSInterrupt interrupt, OSContext* context) {
     s32 chan;
-    EXIControl* exi;
     EXICallback callback;
 
-    chan = (interrupt - 9) / 3;
+    chan = ((s16)interrupt - 9) / 3;
 
     ASSERTLINE(1071, 0 <= chan && chan < MAX_CHAN);
-    exi = &Ecb[chan];
-    EXIClearInterrupts(chan, 1, 0, 0);
+    REG(chan, 0) = (REG(chan, 0) & 0x7F5) | 2;
 
-    callback = exi->exiCallback;
+    callback = Ecb[chan].exiCallback;
     if (callback) {
         OSContext exceptionContext;
 


### PR DESCRIPTION
## Summary
Adjusted `EXIIntrruptHandler` in `src/exi/EXIBios.c` to better match original SDK-style control flow/codegen:
- compute channel using explicit `(s16)` interrupt narrowing before division
- clear EXI interrupt by direct register bit update (`REG(chan, 0) = (REG(chan, 0) & 0x7F5) | 2`) instead of helper indirection
- read callback directly from `Ecb[chan]` in the handler

## Functions improved
- Unit: `main/exi/EXIBios`
- Symbol: `EXIIntrruptHandler`
- Match: **37.10% -> 37.32%**

## Match evidence
Objdiff JSON oneshot (`tools/objdiff-cli v3.6.1`):
- Before: `tools/objdiff-cli diff -p . -u main/exi/EXIBios -o - EXIIntrruptHandler`
- After:  same command after patch
- Unit `.text` match: **68.352264% -> 68.35891%**

## Plausibility rationale
This change moves the handler closer to how Dolphin EXI interrupt handlers are typically written in-source: direct register clear operations in the interrupt path and straightforward callback dispatch with temporary exception context. It avoids contrived temporaries and keeps source readability while improving alignment.

## Technical details
- No behavior changes intended; only handler expression/operation shape changed.
- Build verified with `ninja`.
