### PR TITLE
Improve TRKTargetTranslate matching in dolphin_trk

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -103,6 +103,10 @@ u32 TRKTargetTranslate(u32 param_0)
 		}
 	}
 
+	if ((param_0 >= 0x7E000000) && (param_0 <= 0x80000000)) {
+		return param_0;
+	}
+
 	return param_0 & 0x3FFFFFFF | 0x80000000;
 }
 


### PR DESCRIPTION
## Summary
- Updated `TRKTargetTranslate` in `src/TRK_MINNOW_DOLPHIN/dolphin_trk.c` to preserve addresses in the debug memory window (`0x7E000000..0x80000000`) instead of always remapping.
- Kept the existing DBAT3U/locked-cache translation behavior unchanged.

## Functions Improved
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk`
- `TRKTargetTranslate`: **72.045% -> 99.318%**
- `__TRK_copy_vectors`: **84.800% -> 96.667%**

## Match Evidence
- Rebuilt with `ninja` after edit.
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - TRKTargetTranslate`
- Function-level progress now reports:
  - `TRKTargetTranslate 99.318184`
  - `__TRK_copy_vectors 96.666664`

## Plausibility Rationale
- The inserted condition is straightforward target-address gating logic expected in TRK address translation, not compiler coaxing.
- The change aligns with both current objdiff instruction deltas and the available decomp reference behavior.
- Source readability and intent are preserved.

## Technical Details
- Before the change, the fallback path always remapped with `param_0 & 0x3FFFFFFF | 0x80000000` when not in the LC/DBAT3U path.
- Objdiff showed missing comparison/early-return instructions around `0x7E000000` and `0x80000000`.
- Adding this explicit range check recovered those instructions and materially improved symbol alignment.
