### PR TITLE
Improve pppFrameCrystal2 match and parameter layout

### DIFF
--- a/include/ffcc/pppCrystal2.h
+++ b/include/ffcc/pppCrystal2.h
@@ -23,16 +23,18 @@ struct pppCrystal2 {
 };
 
 struct UnkB {
-    u32 m_dataValIndex;
+    s32 m_graphId;
+    s32 m_dataValIndex;
     u16 m_initWOrk;
-    char pad[6];
-    u32 m_stepValue;
+    u8 _pad0[2];
+    f32 m_stepValue;
     u8 m_arg3;
-    char pad2[3];
-    u8 m_payload[28];  // payload array
+    u8 m_payload[6];
+    u8 _pad1[1];
 };
 
 struct UnkC {
+    u8 _pad0[0xC];
     s32* m_serializedDataOffsets;
 };
 

--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -1,6 +1,15 @@
 #include "ffcc/pppCrystal2.h"
 #include "ffcc/pppPart.h"
 
+#include <math.h>
+#include <dolphin/gx.h>
+
+extern int DAT_8032ed70;
+extern "C" unsigned int __cvt_fp2unsigned(double);
+extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+
+static char s_pppCrystal2Cpp[] = "pppCrystal2.cpp";
+
 /*
  * --INFO--
  * Address:	TODO
@@ -32,11 +41,11 @@ void MakeRefractionMap(HSD_ImageBuffer*)
  */
 void pppConstructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
 {
-    s32 iVar1 = (*(s32**)param_2)[2];
-    u32* data = (u32*)((char*)pppCrystal2 + iVar1);
+    s32 iVar1 = param_2->m_serializedDataOffsets[2];
+    u32* data = (u32*)((char*)pppCrystal2 + iVar1 + 8);
 
-    data[2] = 0;
-    data[3] = 0;
+    data[0] = 0;
+    data[1] = 0;
 }
 
 /*
@@ -82,8 +91,84 @@ void pppDestructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
  */
 void pppFrameCrystal2(pppCrystal2* pppCrystal2, UnkB* param_2, UnkC* param_3)
 {
-    // TODO: Implement complex texture generation logic for crystal refraction
-    // This function generates dynamic textures for crystal rendering effects
+    int* refractionData;
+    u32 y;
+    u32 x;
+
+    if ((DAT_8032ed70 != 0) || (param_2->m_payload[0] == 0)) {
+        return;
+    }
+
+    refractionData = (int*)((char*)pppCrystal2 + param_3->m_serializedDataOffsets[2] + 8);
+    if (refractionData[0] != 0) {
+        return;
+    }
+
+    refractionData[0] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(0x18, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xA8);
+    if (refractionData[0] == 0) {
+        return;
+    }
+
+    int* textureInfo = (int*)refractionData[0];
+    const int textureSize = (int)GXGetTexBufferSize(0x20, 0x20, GX_TF_IA8, GX_FALSE, 0);
+    textureInfo[0] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(textureSize, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xAD);
+    textureInfo[1] = GX_TF_IA8;
+    textureInfo[2] = 0x20;
+    textureInfo[3] = 0x20;
+    textureInfo[4] = 0x100;
+    textureInfo[5] = textureSize;
+
+    if (textureInfo[0] == 0) {
+        return;
+    }
+
+    const float start = -1.0f;
+    const float step = 2.0f / (float)(textureInfo[2] - 1);
+    float yy = start;
+
+    for (y = 0; y < (u32)textureInfo[3]; ++y) {
+        float xx = start;
+        const float y2 = yy * yy;
+
+        for (x = 0; x < (u32)textureInfo[2]; ++x) {
+            float magnitude = xx * xx + y2;
+            if (magnitude < 0.0f) {
+                magnitude = 0.0f;
+            }
+
+            float normal = 0.0f;
+            if (magnitude > 1.0f) {
+                normal = 1.0f / sqrtf(magnitude);
+            } else if (magnitude > 0.0f) {
+                normal = sqrtf(magnitude);
+            }
+
+            if (normal > 0.8f) {
+                normal = 0.8f;
+            }
+
+            const u8 nx = (u8)__cvt_fp2unsigned((double)(xx * normal * 127.0f + 128.0f));
+            const u8 ny = (u8)__cvt_fp2unsigned((double)(yy * normal * 127.0f + 128.0f));
+            u8* pixel = (u8*)(textureInfo[0] +
+                (y >> 2) * (textureInfo[2] & 0x1ffffffcU) * 8 +
+                (x & 0x1ffffffc) * 8 +
+                ((x & 3) + (y & 3) * 4) * 2);
+
+            pixel[0] = nx;
+            pixel[1] = ny;
+            xx += step;
+        }
+
+        yy += step;
+    }
+
+    DCFlushRange((void*)textureInfo[0], textureInfo[5]);
+    refractionData[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(0x20, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xB5);
+
+    if (refractionData[1] != 0) {
+        GXInitTexObj((GXTexObj*)refractionData[1], (void*)textureInfo[0], (u16)textureInfo[2], (u16)textureInfo[3],
+                     GX_TF_IA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `pppCrystal2` parameter layout in `include/ffcc/pppCrystal2.h` so `UnkB` and `UnkC` match observed call-site offsets (`m_dataValIndex` at +0x4 and serialized offsets pointer at +0xC).
- Replaced the `pppFrameCrystal2` TODO stub in `src/pppCrystal2.cpp` with a concrete refraction texture setup path:
  - stage allocations for refraction state and texture object
  - 32x32 IA8 refraction map generation
  - texture cache flush and `GXInitTexObj` initialization
- Updated `pppConstructCrystal2` to initialize the runtime state block at `+8 + serializedOffsets[2]` consistently with `pppDestructCrystal2` and frame usage.

## Functions Improved
- Unit: `main/pppCrystal2`
- Function: `pppFrameCrystal2`

## Match Evidence
- `pppFrameCrystal2`: **0.43290043% -> 50.294373%** (`tools/objdiff-cli diff -p . -u main/pppCrystal2 -o - pppFrameCrystal2`)
- `pppRenderCrystal2`: unchanged at **0.330033%**
- Unit-level fuzzy match (`build/GCCP01/report.json`, `main/pppCrystal2`): **7.3% -> 27.657986%**

## Plausibility Rationale
- The changes focus on source-plausible corrections rather than compiler coercion:
  - fixed ABI-relevant field offsets in parameter structs
  - straightforward resource allocation and initialization flow
  - idiomatic loop-based IA8 normal/refraction map construction
- No contrived temporary/control-flow patterns were introduced solely for score manipulation.

## Technical Notes
- Verified build with `ninja` (PAL `GCCP01`) after edits.
- Verified function-level delta via `objdiff-cli` JSON diff on the specific symbol.
