### PR TITLE
Improve pppYmTraceMove frame match with typed params

### DIFF
--- a/include/ffcc/pppYmTraceMove.h
+++ b/include/ffcc/pppYmTraceMove.h
@@ -1,15 +1,35 @@
 #ifndef _FFCC_PPP_YMTRACEMOVE_H_
 #define _FFCC_PPP_YMTRACEMOVE_H_
 
-struct Vec;
-class CGObject;
+#include <dolphin/types.h>
+
+struct pppYmTraceMove {
+    union {
+        void* ptr;
+        s32 m_graphId;
+    } field0_0x0;
+};
+
+struct UnkB {
+    s32 m_graphId;
+    f32 m_dataValIndex;
+    s16 m_initWOrk;
+    f32 m_stepValue;
+    s16 m_arg3;
+    u16 pad;
+    f32* m_payload;
+};
+
+struct UnkC {
+    s32* m_serializedDataOffsets;
+};
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppConstructYmTraceMove(void);
-void pppFrameYmTraceMove(void);
+void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2);
+void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* param_3);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -1,44 +1,44 @@
 #include "ffcc/pppYmTraceMove.h"
+#include "ffcc/partMng.h"
 #include "dolphin/mtx.h"
 
+extern int DAT_8032ed70;
+
 extern "C" {
-	// Forward declarations for ppp vector functions
 	void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
 	void pppSubVector__FR3Vec3Vec3Vec(Vec*, const Vec*, const Vec*);
 }
 
 /*
  * --INFO--
- * PAL Address: 800d4bd0
+ * PAL Address: 0x800d4bd0
  * PAL Size: 172b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructYmTraceMove(void)
+void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
 {
-	// Vector initialization and manipulation based on Ghidra decomp patterns
-	Vec local_38, local_2c, dest;
-	Vec temp1, temp2, temp3;
-	
-	// Initialize saved position vectors
+	Vec local_38;
+	Vec local_2c;
+	Vec dest;
+	Vec temp1;
+
+	(void)pppYmTraceMove;
+	(void)param_2;
+
 	local_2c.x = 0.0f;
-	local_2c.y = 0.0f; 
+	local_2c.y = 0.0f;
 	local_2c.z = 0.0f;
-	
-	// Initialize param vectors
 	temp1.x = 1.0f;
 	temp1.y = 1.0f;
 	temp1.z = 1.0f;
-	
-	// Vector subtraction operation 
 	pppSubVector__FR3Vec3Vec3Vec(&dest, &temp1, &local_2c);
-	
-	// Copy operations
 	local_38.x = dest.x;
 	local_38.y = dest.y;
 	local_38.z = dest.z;
-	
 	pppCopyVector__FR3Vec3Vec(&dest, &local_38);
-	
-	// Float constant assignments like in decomp
 	dest.x = 0.0f;
 	dest.y = 0.0f;
 	dest.z = 0.0f;
@@ -46,30 +46,42 @@ void pppConstructYmTraceMove(void)
 
 /*
  * --INFO--
- * PAL Address: 800d4828  
+ * PAL Address: 0x800d4828
  * PAL Size: 936b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameYmTraceMove(void)
+void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* param_3)
 {
-	// Frame processing - basic framework with some vector operations
-	Vec local_128, local_11c, local_98, local_8c;
-	Vec local_2c, local_20;
-	
-	// Basic vector initialization patterns
-	local_128.x = 0.0f;
-	local_128.y = 0.0f;
-	local_128.z = 0.0f;
-	
-	local_8c.x = 1.0f;
-	local_8c.y = 1.0f; 
-	local_8c.z = 1.0f;
-	
-	// Vector copy operations like in Ghidra decomp
+	Vec* dest;
+	Vec local_98;
+	Vec local_8c;
+	Vec local_2c;
+	Vec local_20;
+
+	if (DAT_8032ed70 != 0) {
+		return;
+	}
+
+	dest = (Vec*)((u8*)(&pppYmTraceMove->field0_0x0 + 2) + *param_3->m_serializedDataOffsets);
+	dest[2].z = dest[2].z + dest[3].x;
+	dest[2].y = dest[2].y + dest[2].z;
+
+	if (param_2->m_graphId == pppYmTraceMove->field0_0x0.m_graphId) {
+		dest[2].y = dest[2].y + (f32)param_2->m_initWOrk;
+		dest[2].z = dest[2].z + param_2->m_stepValue;
+		dest[3].x = dest[3].x + (f32)param_2->m_arg3;
+	}
+
+	local_8c.x = dest->x;
+	local_8c.y = dest->y;
+	local_8c.z = dest->z;
 	pppCopyVector__FR3Vec3Vec(&local_20, &local_8c);
-	
-	local_98.x = 0.0f;
-	local_98.y = 0.0f;
-	local_98.z = 1.0f;
-	
+
+	local_98.x = dest[1].y;
+	local_98.y = dest[1].z;
+	local_98.z = dest[2].x;
 	pppCopyVector__FR3Vec3Vec(&local_2c, &local_98);
 }


### PR DESCRIPTION
## Summary
- Added concrete `pppYmTraceMove`/`UnkB`/`UnkC` type declarations in `include/ffcc/pppYmTraceMove.h` and updated function prototypes to match the constructor/frame calling pattern used by neighboring ppp units.
- Reworked `pppFrameYmTraceMove` to use serialized work data and graph-conditioned accumulator updates instead of placeholder constant-vector logic.
- Kept constructor behavior stable while aligning source formatting and metadata blocks to project conventions.

## Functions Improved
- Unit: `main/pppYmTraceMove`
- `pppFrameYmTraceMove`: `8.358974%` -> `17.19658%`
- `pppConstructYmTraceMove`: `52.162792%` -> `52.162792%` (no regression)
- Unit `.text` match: `15.158845%` -> `22.624548%`

## Match Evidence
Measured with:
`tools/objdiff-cli diff -p . -u main/pppYmTraceMove -o - <symbol>`

- Before: `/tmp/trace_frame_before.json`, `/tmp/trace_construct_before.json`
- After: `/tmp/trace_frame_after3.json`, `/tmp/trace_construct_after3.json`

The improvement is concentrated in the frame function instruction stream (state update and conditional graph application paths), not just formatting or symbol renames.

## Plausibility Rationale
- The updated frame routine now follows established ppp source patterns used across this repo: serialized state access via `m_serializedDataOffsets`, conditional graph-id application, and vector staging through `pppCopyVector__FR3Vec3Vec`.
- Changes favor source-likely control/data flow over contrived compiler coercion.

## Technical Notes
- Added full `--INFO--` metadata fields (PAL + TODO EN/JP) to match the project’s function doc style.
- Kept external function names and pointer math style consistent with existing low-match ppp translation units.
