### PR TITLE
pppPart: correct pppMulMatrix parameter passing signature

### DIFF
--- a/include/ffcc/pppPart.h
+++ b/include/ffcc/pppPart.h
@@ -43,7 +43,7 @@ void pppSetRowVector(pppFMATRIX& pppFMtx, Vec& vecA, Vec& vecB, Vec& vecC, Vec& 
 void pppNormalize(Vec& dest, Vec source);
 void pppOuterProduct(Vec& ab, Vec a, Vec b);
 void pppCopyMatrix(pppFMATRIX& dest, pppFMATRIX source);
-void pppMulMatrix(pppFMATRIX& ab, pppFMATRIX& a, pppFMATRIX& );
+void pppMulMatrix(pppFMATRIX& ab, pppFMATRIX a, pppFMATRIX b);
 void pppCopyVector(Vec& dest, Vec source);
 void pppSubVector(Vec& dest, Vec a, Vec b);
 float pppVectorLength(Vec vec);

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -188,7 +188,7 @@ void pppCopyMatrix(pppFMATRIX& dest, pppFMATRIX source)
  * Address:	TODO
  * Size:	TODO
  */
-void pppMulMatrix(pppFMATRIX& ab, pppFMATRIX& a, pppFMATRIX& b)
+void pppMulMatrix(pppFMATRIX& ab, pppFMATRIX a, pppFMATRIX b)
 { 
 	PSMTXConcat(a.value, b.value, ab.value);
 }


### PR DESCRIPTION
## Summary
- Adjusted `pppMulMatrix` declaration and definition to match the PAL symbol signature.
- Kept implementation logic unchanged (`PSMTXConcat` call remains identical).

## Functions improved
- Unit: `main/pppPart`
- Symbol: `pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX`

## Match evidence
- Before: `0.0%` (selector output)
- After: `100.0%` (`objdiff-cli` symbol match, size `52`)
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppPart -o - pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX`

## Plausibility rationale
- The change aligns parameter passing with the recovered Metrowerks mangled symbol instead of introducing compiler-coaxing control flow.
- Source remains straightforward and idiomatic for this wrapper around `PSMTXConcat`.

## Technical details
- Updated signature from `(pppFMATRIX& ab, pppFMATRIX& a, pppFMATRIX& b)` to `(pppFMATRIX& ab, pppFMATRIX a, pppFMATRIX b)` in:
  - `include/ffcc/pppPart.h`
  - `src/pppPart.cpp`
- Verified with full `ninja` build and objdiff JSON output.
