### PR TITLE
main/mapmesh: add CPtrArray<CMaterial*> accessor specializations

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -1,5 +1,53 @@
 #include "ffcc/mapmesh.h"
 
+class CMaterial;
+
+template <class T>
+class CPtrArray
+{
+public:
+    void** m_vtable;
+    int m_size;
+    int m_numItems;
+    int m_defaultSize;
+    T* m_items;
+    CMemory::CStage* m_stage;
+    int m_growCapacity;
+
+    T GetAt(unsigned long index);
+    T operator[](unsigned long index);
+};
+
+/*
+ * --INFO--
+ * PAL Address: 0x800287a0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMaterial* CPtrArray<CMaterial*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800287c0
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMaterial* CPtrArray<CMaterial*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
Added explicit `CPtrArray<CMaterial*>` template specializations in `src/mapmesh.cpp` for:
- `CPtrArray<CMaterial*>::operator[](unsigned long)`
- `CPtrArray<CMaterial*>::GetAt(unsigned long)`

These are implemented in the same style already used by other unit-local `CPtrArray<T>` specializations (e.g. `mapanim`).

## Functions improved
Unit: `main/mapmesh`
- `__vc__22CPtrArray<P9CMaterial>FUl`: **0.0% -> 100.0%**
- `GetAt__22CPtrArray<P9CMaterial>FUl`: **0.0% -> 100.0%**

## Match evidence
`build/tools/objdiff-cli diff -p . -u main/mapmesh -o - '__vc__22CPtrArray<P9CMaterial>FUl'`
- `__vc__22CPtrArray<P9CMaterial>FUl`: `100.0`
- `GetAt__22CPtrArray<P9CMaterial>FUl`: `100.0`

Unit report (`build/GCCP01/report.json`) now also shows both functions as fully matched under `main/mapmesh`.

## Plausibility rationale
This is source-plausible recovery, not compiler coaxing:
- `operator[]` forwarding to `GetAt` and `GetAt` returning `m_items[index]` are canonical pointer-array semantics.
- The pattern matches other decompiled FFCC units that define explicit `CPtrArray<T>` specializations per translation unit.
- No artificial control-flow tricks, hardcoded offsets, or non-idiomatic temporaries were introduced.

## Technical details
- Kept signatures as `unsigned long` to match mangled symbol forms (`FUl`).
- Added PAL address/size metadata blocks for the recovered functions:
  - `0x800287a0` (`32b`)
  - `0x800287c0` (`16b`)
