### PR TITLE
pppPart: match pppHeapCheckLeak to PAL heapWalker impl

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -287,7 +287,7 @@ void pppHeapUseRate(CMemory::CStage* stage)
 /*
  * --INFO--
  * PAL Address: 80056c74
- * PAL Size: 76b
+ * PAL Size: 44b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
@@ -295,21 +295,7 @@ void pppHeapUseRate(CMemory::CStage* stage)
  */
 void pppHeapCheckLeak(CMemory::CStage* stage)
 {
-	unsigned long totalSize;
-	unsigned long usedSize;
-	unsigned long freeSize;
-	
-	stage->heapInfo(totalSize, usedSize, freeSize);
-	
-	if (totalSize == 0) {
-		totalSize = 10000;
-	}
-	else {
-		totalSize = (unsigned long)(usedSize * 10000) / totalSize;
-	}
-	
-	// Note: Original returns the percentage but this signature expects void
-	// The percentage calculation is kept for proper assembly matching
+	stage->heapWalker(2, 0, 0xFFFFFFFF);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppHeapCheckLeak(CMemory::CStage*)` in `src/pppPart.cpp` to call `stage->heapWalker(2, 0, 0xFFFFFFFF)` directly.
- Removed the `heapInfo`-based percentage path that produced a different function body.
- Updated the function metadata header to `PAL Size: 44b` to match the current PAL target for this unit.

## Functions improved
- Unit: `main/pppPart`
- Symbol: `pppHeapCheckLeak__FPQ27CMemory6CStage`
- Match: **0.0% -> 100.0%**
- Size: **44 bytes**

## Match evidence
- Before edit (`objdiff`): `pppHeapCheckLeak__FPQ27CMemory6CStage` was 0.0% and current object emitted an 80-byte `heapInfo` implementation.
- After edit (`objdiff` + rebuild): both target and current symbol are 44 bytes and report 100.0%.
- `ninja` progress increased by one matched function after recompiling `pppPart.o`.

## Plausibility rationale
- This change follows the observed target assembly shape (single `heapWalker` call with constants) and keeps code simple/idiomatic for this codebase.
- It removes a likely cross-build variant (`heapInfo` percentage calculation) in favor of the PAL-matching implementation.

## Technical details
- The `objdiff` trace for the previous version showed inserted `heapInfo` setup/math instructions relative to target.
- Replacing it with `heapWalker(2, 0, 0xFFFFFFFF)` aligns prologue/call/epilogue structure and instruction count with the target.
