### PR TITLE
THPSimple: implement THPAudioMixCallback and align audio symbols

### DIFF
--- a/include/ffcc/THPSimple.h
+++ b/include/ffcc/THPSimple.h
@@ -28,8 +28,11 @@ void THPSimpleDecode(void);
 void CheckPrefetch();
 void VideoDecode(unsigned char*);
 s32 THPSimpleDrawCurrentFrame(GXRenderModeObj*, int, int, int, int);
-void MixAudio(short*, short*, unsigned long);
-void THPAudioMixCallback();
+void MixAudio__FPsPsUl(short*, short*, unsigned long);
+void THPAudioMixCallback__Fv();
+
+#define MixAudio MixAudio__FPsPsUl
+#define THPAudioMixCallback THPAudioMixCallback__Fv
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- implemented `THPAudioMixCallback__Fv` in `src/THPSimple.cpp` following target control flow for DMA toggle, interrupt windows, cache management, and optional input mixing
- added required Dolphin headers for AI/OS/cache routines
- aligned symbol linkage in `include/ffcc/THPSimple.h` by declaring suffixed target symbols and mapping old names with macros

## Functions improved
- `THPAudioMixCallback__Fv` (`main/THPSimple`)
- symbol alignment also maps `MixAudio__FPsPsUl` for future matching work (body still placeholder)

## Match evidence
- `THPAudioMixCallback__Fv`: **0.00% -> 68.40426%**
- `MixAudio__FPsPsUl`: **0.00% -> 0.46948355%** (name alignment only)

Commands used:
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPAudioMixCallback__Fv`
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - MixAudio__FPsPsUl`

## Plausibility rationale
- change is source-plausible: it restores expected audio callback behavior (double-buffer DMA swap + optional decode callback + mix path), instead of compiler-coaxing transforms
- control flow and side effects are consistent with existing `THPSimple` data layout and SDK API usage

## Technical notes
- uses existing sbss/data symbols (`lbl_8032EE4C`, `lbl_8032EE50`, `lbl_8032EE54`, `lbl_8032EE58`, `lbl_8032EE5C`, `WorkBuffer_32_`) and preserves their runtime responsibilities
- this is a first-pass anchor for subsequent `MixAudio__FPsPsUl` decomp work
