### PR TITLE
targimpl: implement TRKTargetAccessARAM

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -279,6 +279,37 @@ out_loop:
 #endif // clang-format on
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801abef8
+ * PAL Size: 196b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+DSError TRKTargetAccessARAM(u32 p1, u32 p2, u32* p3, BOOL read)
+{
+    DSError error = DS_NoError;
+    TRKExceptionStatus tempExceptionStatus = gTRKExceptionStatus;
+
+    gTRKExceptionStatus.exceptionDetected = FALSE;
+
+    if (read) {
+        TRK__read_aram(p1, p2, p3);
+    } else {
+        TRK__write_aram(p1, p2, p3);
+    }
+
+    if (gTRKExceptionStatus.exceptionDetected) {
+        error = DS_CWDSException;
+        *p3   = 0;
+    }
+
+    gTRKExceptionStatus = tempExceptionStatus;
+    return error;
+}
+
 #pragma dont_inline on
 DSError TRKTargetAccessMemory(void* data, u32 start, size_t* length,
                               MemoryAccessOptions accessOptions, BOOL read)


### PR DESCRIPTION
## Summary
- Implemented `TRKTargetAccessARAM` in `src/TRK_MINNOW_DOLPHIN/targimpl.c`.
- Added PAL address/size info block and preserved existing exception-handling pattern used by other target accessors.
- Function now saves/restores `gTRKExceptionStatus`, clears `exceptionDetected`, performs ARAM read/write call, and maps detected exceptions to `DS_CWDSException` while zeroing transferred length.

## Functions Improved
- Unit: `main/TRK_MINNOW_DOLPHIN/targimpl`
- Function: `TRKTargetAccessARAM`
  - Before: 0.0% (missing implementation)
  - After: 98.57143%

## Match Evidence
- `objdiff` symbol score for `TRKTargetAccessARAM`: `0.0% -> 98.57143%`
- Unit `.text` match (`objdiff`, `main/TRK_MINNOW_DOLPHIN/targimpl`): `70.41123% -> 73.15088%`
- Project progress (`ninja`): code matched bytes `180460 -> 180656` and matched functions `1203 -> 1204`.

## Plausibility Rationale
- Implementation follows established MetroTRK access-function structure already present in this file:
  - save/clear/restore exception status
  - perform low-level transfer call
  - convert raised exception into CWDS error + zero length
- No contrived temporaries or compiler-coaxing control flow were introduced.

## Technical Notes
- `read` dispatches to `TRK__read_aram`; write path dispatches to `TRK__write_aram`.
- Remaining non-100% diffs are relocation/symbol-argument related around `gTRKExceptionStatus`; core instruction flow and behavior now align closely.
