### PR TITLE
pppRandDownInt: fix lbl_801EADC8 fallback pointer form

### DIFF
--- a/src/pppRandDownInt.cpp
+++ b/src/pppRandDownInt.cpp
@@ -6,7 +6,7 @@ extern CMath math;
 extern s32 lbl_8032ED70;
 extern f32 lbl_8032FF58;
 extern f64 lbl_8032FF60;
-extern s32 lbl_801EADC8;
+extern s32 lbl_801EADC8[];
 
 extern "C" {
 f32 RandF__5CMathFv(CMath*);
@@ -62,7 +62,7 @@ void pppRandDownInt(void* param1, void* param2, void* param3)
 
     s32* target;
     if (in->field4 == -1) {
-        target = &lbl_801EADC8;
+        target = lbl_801EADC8;
     } else {
         target = (s32*)(base + in->field4 + 0x80);
     }


### PR DESCRIPTION
## Summary
Adjust `pppRandDownInt` fallback target declaration/use for `lbl_801EADC8` from scalar-address form to array-pointer form.

## Functions improved
- Unit: `main/pppRandDownInt`
- Symbol: `pppRandDownInt`

## Match evidence
- Before: `88.26667%`
- After: `90.46667%`
- Measurement command:
  - `build/tools/objdiff-cli diff -p . -u main/pppRandDownInt -o - pppRandDownInt`

## Plausibility rationale
`lbl_801EADC8` is used as a pointer target buffer when `field4 == -1`. Modeling it as an array and assigning it directly as a pointer is a natural source-level representation and avoids taking the address of a scalar sentinel.

## Technical details
- Changed declaration from `extern s32 lbl_801EADC8;` to `extern s32 lbl_801EADC8[];`
- Changed assignment from `target = &lbl_801EADC8;` to `target = lbl_801EADC8;`
- No control-flow or algorithm changes; this is a type/linkage-shape correction aimed at codegen alignment.
