### PR TITLE
main/pppCallBackDistance: improve callback distance layout usage

### DIFF
--- a/src/pppCallBackDistance.cpp
+++ b/src/pppCallBackDistance.cpp
@@ -19,16 +19,18 @@ void pppConstructCallBackDistance(pppCallBackDistance* param1, UnkC* param2)
     Vec local_1c;
     f64 dVar3;
     s32 iVar1;
+    f32* pDataVal;
 
     iVar1 = *param2->m_serializedDataOffsets;
+    pDataVal = (f32*)((u8*)param1 + 0x80 + iVar1);
     local_28.x = pppMngStPtr->m_matrix.value[0][3];
     local_28.y = pppMngStPtr->m_matrix.value[1][3];
     local_28.z = pppMngStPtr->m_matrix.value[2][3];
-    local_1c.x = pppMngStPtr->m_scale.x;
-    local_1c.y = pppMngStPtr->m_scale.y;
-    local_1c.z = pppMngStPtr->m_scale.z;
+    local_1c.x = *(f32*)((u8*)pppMngStPtr + 0x68);
+    local_1c.y = *(f32*)((u8*)pppMngStPtr + 0x6c);
+    local_1c.z = *(f32*)((u8*)pppMngStPtr + 0x70);
     dVar3 = (f64)PSVECDistance(&local_28, &local_1c);
-    *(f32*)((s32)(&param1->field0_0x0 + 2) + iVar1) = (f32)dVar3;
+    *pDataVal = (f32)dVar3;
 }
 
 /*
@@ -61,16 +63,17 @@ void pppFrameCallBackDistance(pppCallBackDistance* param1, UnkB* param2, UnkC* p
     Vec local_28;
     Vec local_1c;
     f64 dVar4;
+    f32* pDataVal;
 
     local_1c.x = pppMngStPtr->m_matrix.value[0][3];
     iVar3 = *param3->m_serializedDataOffsets;
+    pDataVal = (f32*)((u8*)param1 + 0x80 + iVar3);
     local_1c.y = pppMngStPtr->m_matrix.value[1][3];
     local_1c.z = pppMngStPtr->m_matrix.value[2][3];
-    dVar4 = (f64)PSVECDistance(&local_1c, &pppMngStPtr->m_scale);
+    dVar4 = (f64)PSVECDistance(&local_1c, (Vec*)((u8*)pppMngStPtr + 0x68));
     p_Var1 = pppMngStPtr;
 
-    if ((dVar4 <= (f64)param2->m_dataValIndex) ||
-        ((f64)*(f32*)((s32)(&param1->field0_0x0 + 2) + iVar3) <= dVar4)) {
+    if ((dVar4 <= (f64)param2->m_dataValIndex) || ((f64)*pDataVal <= dVar4)) {
         local_28.x = pppMngStPtr->m_matrix.value[0][3];
         local_28.y = pppMngStPtr->m_matrix.value[1][3];
         local_28.z = pppMngStPtr->m_matrix.value[2][3];


### PR DESCRIPTION
## Summary
- Updated `src/pppCallBackDistance.cpp` to use the serialized data value as `base + 0x80 + offset`, matching common ppp data-value layout patterns used in nearby units.
- Switched distance comparison/reference vector loads from the provisional `m_scale` field to explicit manager offset vector loads at `pppMngSt + 0x68` (`Vec`), which aligns with existing particle manager usage.
- Kept control flow and callback behavior unchanged; this is a typing/offset-layout correction pass.

## Functions Improved
- Unit: `main/pppCallBackDistance`
- `pppFrameCallBackDistance`
  - Before: `43.235294%`
  - After: `45.97059%`
  - Delta: `+2.735296`
- `pppConstructCallBackDistance`
  - Before: `74.48485%`
  - After: `83.181816%`
  - Delta: `+8.696966`

## Match Evidence
- Rebuilt with `ninja` successfully.
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/pppCallBackDistance -o - pppFrameCallBackDistance`
- Objdiff reports improved symbol match percentages above for both callback-distance functions.

## Plausibility Rationale
- The changes are source-plausible data-layout corrections rather than compiler-shaping tricks:
  - `+0x80+offset` data access is already the dominant ppp object/state convention across the codebase.
  - The manager vector at `+0x68` is used by related ppp behaviors for world/param vector state, while `m_scale` in this WIP struct is likely not the true semantic field here.
- No synthetic temporaries or unnatural sequencing was introduced solely to influence codegen.

## Technical Notes
- This pass specifically targets register/offset alignment by correcting the underlying C-side memory model where struct reconstruction is still incomplete.
- Given current partial struct definitions, explicit offset-based vec loads are the least-assumption approach and improved generated assembly similarity.
