### PR TITLE
Decompile pppEraseCharaParts lifecycle and mesh callback

### DIFF
--- a/include/ffcc/pppEraseCharaParts.h
+++ b/include/ffcc/pppEraseCharaParts.h
@@ -2,6 +2,22 @@
 #define _PPP_ERASECHARAPARTS_H_
 
 #include "ffcc/chara.h"
+#include <dolphin/types.h>
+
+struct pppEraseCharaParts {
+    u8 field0_0x0[8];
+    u8 pad_0x8[0x80];
+    u8 field_0x88[4];
+};
+
+struct UnkB {
+    u8 m_unk0[4];
+    s8 m_meshIndex;
+};
+
+struct UnkC {
+    s32* m_serializedDataOffsets;
+};
 
 void EraseCharaParts_DrawMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*)[4]);
 
@@ -9,9 +25,9 @@ void EraseCharaParts_DrawMeshDLCallback(CChara::CModel*, void*, void*, int, int,
 extern "C" {
 #endif
 
-void pppConstructEraseCharaParts(void);
+void pppConstructEraseCharaParts(pppEraseCharaParts*, UnkC*);
 void pppDestructEraseCharaParts(void);
-void pppFrameEraseCharaParts(void);
+void pppFrameEraseCharaParts(pppEraseCharaParts*, UnkB*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppEraseCharaParts.cpp
+++ b/src/pppEraseCharaParts.cpp
@@ -1,41 +1,131 @@
 #include "ffcc/pppEraseCharaParts.h"
+#include "ffcc/materialman.h"
+#include "ffcc/partMng.h"
 
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void EraseCharaParts_DrawMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*) [4])
-{
-	// TODO
+#include <dolphin/gx.h>
+
+extern CMaterialMan MaterialMan;
+extern unsigned int DAT_8032ed70;
+
+extern "C" {
+void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
+int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
+void DCFlushRange(void* ptr, unsigned long size);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8010400C
+ * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructEraseCharaParts(void)
+void EraseCharaParts_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void* param_3,
+                                        int meshIndex, int param_5, float (*) [4])
 {
-	// TODO
+    void* meshData;
+    void* displayList;
+    int modelData;
+    int meshList;
+
+    meshList = *(int*)((char*)model + 0xAC);
+    meshData = *(void**)(meshList + meshIndex * 0x14 + 8);
+    displayList = (void*)(*(int*)((char*)meshData + 0x50) + param_5 * 0xC);
+
+    modelData = *(int*)((char*)model + 0xA4);
+    MaterialMan.SetMaterial(*(CMaterialSet**)(modelData + 0x24), *(u16*)((char*)displayList + 8), 0,
+                            (_GXTevScale)0);
+
+    if ((*(s8*)((char*)param_3 + 4) != -1) && (meshIndex == *(s8*)((char*)param_3 + 4))) {
+        GXSetArray((GXAttr)0xB, param_2, 4);
+    }
+
+    GXCallDisplayList(*(void**)displayList, *(u32*)((char*)displayList + 4));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80103FA8
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppConstructEraseCharaParts(pppEraseCharaParts* pppEraseCharaParts, UnkC* param_2)
+{
+    void* handle;
+    int model;
+    u8* colorPtr;
+    void* gObject;
+
+    gObject = *(void**)((char*)pppMngStPtr + 0x8);
+    colorPtr = (u8*)((int)(&pppEraseCharaParts->field0_0x0 + 2) + param_2->m_serializedDataOffsets[1]);
+    colorPtr[0] = 0x80;
+    colorPtr[1] = 0x80;
+    colorPtr[2] = 0x80;
+    colorPtr[3] = 0x80;
+
+    handle = GetCharaHandlePtr__FP8CGObjectl(gObject, 0);
+    model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+    *(void (**)(CChara::CModel*, void*, void*, int, int, float (*)[4]))(model + 0xFC) =
+        EraseCharaParts_DrawMeshDLCallback;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80103F68
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDestructEraseCharaParts(void)
 {
-	// TODO
+    void* handle;
+    int model;
+
+    handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+    model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+    *(void**)(model + 0xE4) = 0;
+    *(void**)(model + 0xE8) = 0;
+    *(void**)(model + 0xFC) = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80103EC0
+ * PAL Size: 168b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameEraseCharaParts(void)
+void pppFrameEraseCharaParts(pppEraseCharaParts* pppEraseCharaParts, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+    void* handle;
+    int model;
+    int colorIndex;
+    u8* colorPtr;
+
+    if (DAT_8032ed70 == 0) {
+        colorIndex = *param_3->m_serializedDataOffsets;
+        colorPtr =
+            (u8*)((int)(&pppEraseCharaParts->field0_0x0 + 2) + param_3->m_serializedDataOffsets[1]);
+        handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+        model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+
+        *(u8**)(model + 0xE4) = colorPtr;
+        *(UnkB**)(model + 0xE8) = param_2;
+
+        colorPtr[0] = pppEraseCharaParts->field_0x88[colorIndex];
+        colorPtr[1] = pppEraseCharaParts->field_0x88[colorIndex + 1];
+        colorPtr[2] = pppEraseCharaParts->field_0x88[colorIndex + 2];
+        colorPtr[3] = pppEraseCharaParts->field_0x88[colorIndex + 3];
+
+        DCFlushRange(colorPtr, 4);
+    }
 }


### PR DESCRIPTION
## Summary
- Replaced `main/pppEraseCharaParts` stub implementations with functional code for:
  - `pppConstructEraseCharaParts`
  - `pppDestructEraseCharaParts`
  - `pppFrameEraseCharaParts`
  - `EraseCharaParts_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`
- Added concrete struct/prototype definitions in `include/ffcc/pppEraseCharaParts.h` so constructor/frame signatures match actual call shape.
- Wired the expected character-model callback plumbing, material setup, mesh display-list call, and color-buffer cache flush behavior.

## Functions Improved
- `EraseCharaParts_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: `2.1276596% -> 78.42553%`
- `pppConstructEraseCharaParts`: `4.0% -> 86.2%`
- `pppDestructEraseCharaParts`: `6.25% -> 99.625%`
- `pppFrameEraseCharaParts`: `2.3809524% -> 76.88095%`

## Match Evidence
- Unit `.text` match for `main/pppEraseCharaParts`: `3.0769231% -> 82.03077%` via `objdiff-cli diff -p . -u main/pppEraseCharaParts ...`.
- Improvements are from real instruction alignment (prologues, global loads, callback assignment, display-list flow), not identifier-only changes.

## Plausibility Rationale
- Uses existing project patterns from nearby ppp callback units (`pppCharaZEnvCtrl`, `pppChangeTex`) for model handle lookup and callback installation.
- Keeps behavior source-plausible: straightforward pointer-offset data access, callback registration, and GX/material calls expected for a draw callback path.
- Avoids contrived control-flow tricks; code is readable and matches established decomp style in this repository.

## Technical Details
- Implemented constructor/frame color-work pointer math using serialized offsets (`+0x80` data region pattern) and model callback fields (`+0xE4/+0xE8/+0xFC`).
- Implemented draw callback mesh/display-list traversal with material selection and conditional `GXSetArray`, then `GXCallDisplayList`.
- Added missing PAL info blocks for all four functions using decomp-exported addresses/sizes.
