### PR TITLE
itemobj: add missing CGPrgObj::getReplaceStat(int)

### DIFF
--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -30,6 +30,7 @@ public:
     void putParticle(int, int, CGObject*, float, int);
     void putParticleTrace(int, int, CGObject*, float, int);
     void putParticleBindTrace(int, int, CGObject*, float, int);
+    int getReplaceStat(int);
     void getTargetRot(CGPrgObj*);
     void rotTarget(CGPrgObj*);
     void dstTargetRot(CGPrgObj*);

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1,4 +1,19 @@
 #include "ffcc/itemobj.h"
+#include "ffcc/prgobj.h"
+
+/*
+ * --INFO--
+ * PAL Address: 0x80124b80
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CGPrgObj::getReplaceStat(int state)
+{
+	return state;
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added the missing `CGPrgObj::getReplaceStat(int)` declaration in `include/ffcc/prgobj.h`.
- Implemented `CGPrgObj::getReplaceStat(int)` in `src/itemobj.cpp` as a simple passthrough return.
- Added function metadata block with PAL address/size for the new implementation.

## Functions improved
- Unit: `main/itemobj`
- Symbol: `getReplaceStat__8CGPrgObjFi` (`CGPrgObj::getReplaceStat(int)`)
- Before: symbol absent from current object (`before_has_symbol=false` in objdiff output)
- After: `100.0%` match for this symbol

## Match evidence
- `main/itemobj` `.text` fuzzy match improved from `2.167094` to `2.2525642`.
- objdiff instruction match for the symbol is now exact:
  - `mr r3, r4`
  - `blr`

## Plausibility rationale
- Ghidra for this symbol (`resources/ghidra-decomp-1-31-2026/80124b80_getReplaceStat__8CGPrgObjFi.c`) indicates a pure passthrough implementation returning the input state.
- The implemented source is the minimal, idiomatic C++ form of that behavior (`return state;`), not compiler-coaxing.
- The symbol is expected in `main/itemobj` for this decomp layout, and adding this concrete method definition resolves that gap directly.

## Technical details
- Build verified with `ninja` after changes.
- objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/itemobj -o - getReplaceStat__8CGPrgObjFi`
