### PR TITLE
Improve CC_BeforeCalcMatrixCallback match in pppConstrainCameraForLoc

### DIFF
--- a/include/ffcc/pppConstrainCameraForLoc.h
+++ b/include/ffcc/pppConstrainCameraForLoc.h
@@ -25,7 +25,7 @@ typedef struct pppConstrainCameraForLocData {
     int* m_serializedDataOffsets;
 } pppConstrainCameraForLocData;
 
-void CC_BeforeCalcMatrixCallback(CChara::CModel*, void*, void*);
+int CC_BeforeCalcMatrixCallback(CChara::CModel*, void*, void*);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -20,37 +20,83 @@ void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, void*, void*
  * PAL Address: 80167eec
  * PAL Size: 580b
  */
-void CC_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void*)
+int CC_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void*)
 {
     float* params = (float*)param_2;
-    
-    // Load scale parameter
-    float scale = *params;
-    
-    // Load camera direction and position
-    float dirX = *(float*)((char*)&CameraPcs + 0xec);
-    float dirY = *(float*)((char*)&CameraPcs + 0xf0);
-    float dirZ = *(float*)((char*)&CameraPcs + 0xf4);
-    
+    float sceneValue = params[0];
+    float camDirX = *(float*)((char*)&CameraPcs + 0xec);
+    float camDirY = *(float*)((char*)&CameraPcs + 0xf0);
+    float camDirZ = *(float*)((char*)&CameraPcs + 0xf4);
+    float* graph = *(float**)((char*)params + 0x40);
+    float graphForward = graph[7];
+    float graphUp = graph[11];
     Vec cameraPos;
+    Vec cameraDir;
+    Vec offset;
+    Vec forwardDir;
+    Vec upDir;
+    Vec scaledForward;
+    Vec scaledUp;
+    Mtx cameraMtx;
+    Mtx inverseMtx;
+
     cameraPos.x = *(float*)((char*)&CameraPcs + 0xe0);
     cameraPos.y = *(float*)((char*)&CameraPcs + 0xe4);
     cameraPos.z = *(float*)((char*)&CameraPcs + 0xe8);
-    
-    // Calculate scaled direction
-    Vec scaledDir;
-    scaledDir.x = scale * dirX;
-    scaledDir.y = scale * dirY;
-    scaledDir.z = scale * dirZ;
-    
-    // Add position to scaled direction
-    Vec result;
-    PSVECAdd(&cameraPos, &scaledDir, &result);
-    
-    // Store results in params 
-    params[7] = result.x;
-    params[11] = result.y;
-    params[15] = result.z;
+    cameraDir.x = camDirX;
+    cameraDir.y = camDirY;
+    cameraDir.z = camDirZ;
+
+    PSMTXCopy(*(Mtx*)((char*)&CameraPcs + 4), cameraMtx);
+
+    offset.x = sceneValue * camDirX;
+    offset.y = sceneValue * camDirY;
+    offset.z = sceneValue * camDirZ;
+
+    if (Game.game.m_currentSceneId == 7) {
+        PSMTXInverse(ppvCameraMatrix0, inverseMtx);
+    } else {
+        PSMTXInverse(cameraMtx, inverseMtx);
+    }
+
+    PSMTXIdentity(*(Mtx*)((char*)model + 0x68));
+    PSMTXIdentity(*(Mtx*)((char*)model + 0x38));
+    PSMTXConcat(inverseMtx, *(Mtx*)((char*)model + 0x38), *(Mtx*)((char*)model + 0x38));
+
+    PSVECAdd(&cameraPos, &offset, &offset);
+
+    GetDirectVector__5CUtilFP3VecP3Vec3Vec((void*)&DAT_8032ec70, &forwardDir, &upDir, &cameraDir);
+
+    scaledForward.x = graphForward * forwardDir.x;
+    scaledForward.y = graphForward * forwardDir.y;
+    scaledForward.z = graphForward * forwardDir.z;
+    scaledUp.x = graphUp * upDir.x;
+    scaledUp.y = graphUp * upDir.y;
+    scaledUp.z = graphUp * upDir.z;
+
+    PSVECAdd(&offset, &scaledForward, &offset);
+    PSVECAdd(&offset, &scaledUp, &offset);
+
+    *(float*)((char*)model + 0x44) = FLOAT_803331a8;
+    *(float*)((char*)model + 0x54) = FLOAT_803331a8;
+    *(float*)((char*)model + 0x64) = FLOAT_803331a8;
+
+    if (Game.game.m_currentSceneId == 7) {
+        *(float*)((char*)model + 0x74) = FLOAT_803331a8;
+        *(float*)((char*)model + 0x84) = FLOAT_803331a8;
+        *(float*)((char*)model + 0x94) = FLOAT_803331a8;
+    } else {
+        *(float*)((char*)model + 0x74) = offset.x;
+        *(float*)((char*)model + 0x84) = offset.y;
+        *(float*)((char*)model + 0x94) = offset.z;
+    }
+
+    PSMTXCopy(*(Mtx*)((char*)model + 0x38), *(Mtx*)((char*)params + 0x10));
+
+    params[7] = offset.x;
+    params[11] = offset.y;
+    params[15] = offset.z;
+    return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CC_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv` in `src/pppConstrainCameraForLoc.cpp` to follow the target matrix/vector flow.
- Updated the callback signature to return `int` in both declaration and definition, matching the function's ABI/return behavior.
- Implemented scene-conditional matrix inverse path, model matrix identity/concat setup, direct-vector based offset accumulation, and final callback output writes.

## Functions improved
- Unit: `main/pppConstrainCameraForLoc`
- Symbol: `CC_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`
  - Before: `22.0%` match (selector/objdiff baseline)
  - After: `62.131035%` match (`build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraForLoc -o -`)
  - Size: `580b` (unchanged)

## Match evidence
- The callback now includes the missing major code regions seen in the target assembly:
  - camera matrix copy + inverse branch for scene `7`
  - model matrix initialization and concat into world-base matrix slots
  - two-stage directional offset accumulation using `GetDirectVector__5CUtilFP3VecP3Vec3Vec`
  - scene-dependent translation writes and callback output matrix/position writes
- Unit-level fuzzy match moved from `29.3%` (selector baseline) to `58.279068%` in `build/GCCP01/report.json`.

## Plausibility rationale
- Changes are type/ABI and control-flow alignment that reflect expected original gameplay callback behavior (camera-relative transform setup), rather than contrived compiler-only temporaries.
- Kept field access pattern consistent with current decomp conventions (offset-based model/camera access where full type layouts are not yet reconstructed).

## Technical notes
- Preserved existing constructor/destructor helpers; only touched callback declaration and implementation.
- Build validated with `ninja`.
