### PR TITLE
Improve pppDrawShape2 match by restructuring lookup flow

### DIFF
--- a/src/pppDrawShape2.cpp
+++ b/src/pppDrawShape2.cpp
@@ -136,15 +136,14 @@ void pppDrawShape2(void* param1, void* param2, void* param3)
     ShapeControlData* controlData = (ShapeControlData*)param2;
     ShapeState* shapeData = (ShapeState*)((u8*)param1 + runtimeData->shapeDataOffset + 0x80);
     void* posData = (u8*)param1 + runtimeData->posDataOffset + 0x80;
-    s16 type = controlData->type;
 
-    if ((u16)type == 0xFFFF) {
+    if ((u16)controlData->type == 0xFFFF) {
         return;
     }
 
-    void* shapeSpec = ((void**)*(void**)((u8*)lbl_8032ED54 + 0xC))[type];
-    void* currentShape = (u8*)shapeSpec + ((u32)shapeData->currentId << 3) + 0x10;
-    void* materialData = *(void**)((u8*)lbl_8032ED54 + 0x4);
+    void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
+    void* shapeSpec = *(void**)((u8*)shapeTables + ((u32)controlData->type << 2));
+    ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->currentId << 3) + 0x10);
 
     pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
         posData,
@@ -160,6 +159,5 @@ void pppDrawShape2(void* param1, void* param2, void* param3)
     );
 
     pppSetBlendMode__FUc(controlData->blendMode);
-
-    pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(currentShape, materialData, controlData->blendMode);
+    pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(shape, *(void**)((u8*)lbl_8032ED54 + 0x4), controlData->blendMode);
 }


### PR DESCRIPTION
## Summary
- Refactored `pppDrawShape2` lookup flow to use explicit shape-table and shape-entry temporaries.
- Removed an unnecessary `type` local and collapsed material access into the `pppDrawShp` call.
- Kept behavior unchanged; this is a code-shape alignment pass for compiler output.

## Functions improved
- Unit: `main/pppDrawShape2`
- Function: `pppDrawShape2`
- Match: `69.15094%` -> `76.43396%` (`+7.28302`)

## Match evidence
- Baseline command:
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawShape2 -o /tmp/pppdrawshape2_before.json pppDrawShape2`
- After command:
  - `build/tools/objdiff-cli diff -p . -u main/pppDrawShape2 -o /tmp/pppdrawshape2_try2.json pppDrawShape2`
- `pppCalcShape2` remained stable at `80.43137%`.

## Plausibility rationale
- The change is source-plausible C/C++ cleanup: explicit intermediate pointers for table indirection and direct material fetch at use-site.
- No contrived no-op expressions or artificial reordering were introduced; control flow and called APIs are unchanged.

## Technical details
- Main improvement comes from changing expression structure around:
  - shape-table lookup (`lbl_8032ED54 + 0xC`),
  - current-shape entry construction (`currentId << 3` + header offset),
  - material pointer use in `pppDrawShp`.
- This reduced structural divergence in objdiff and produced a significant function-level match increase.
