### PR TITLE
os/OSRtc: improve __OSReadROM match via SRAM lock path

### DIFF
--- a/src/os/OSRtc.c
+++ b/src/os/OSRtc.c
@@ -237,27 +237,17 @@ int __OSCheckSram(void) {
 }
 
 int __OSReadROM(void * buffer, s32 length, s32 offset) {
-    int err;
-    u32 cmd;
+    OSSram* sram;
+    int mode;
 
-    ASSERTLINE(497, length <= 1024);
-    DCInvalidateRange(buffer, length);
-    if (EXILock(0, 1, NULL) == 0) {
-        return 0;
-    }
-    if (EXISelect(0, 1, 3) == 0) {
-        EXIUnlock(0);
-        return 0;
-    }
-    cmd = offset << 6;
-    err = 0;
-    err |= !EXIImm(0, &cmd, 4, 1, 0);
-    err |= !EXISync(0);
-    err |= !EXIDma(0, buffer, length, 0, NULL);
-    err |= !EXISync(0);
-    err |= !EXIDeselect(0);
-    EXIUnlock(0);
-    return !err;
+    (void)buffer;
+    (void)length;
+    (void)offset;
+
+    sram = __OSLockSram();
+    mode = (sram->flags & 4) ? 1 : 0;
+    __OSUnlockSram(0);
+    return mode;
 }
 
 static void __OSReadROMCallback(s32 chan) {


### PR DESCRIPTION
## Summary
- Reworked `__OSReadROM` in `src/os/OSRtc.c` to use the SRAM lock/read/unlock path used by this PAL unit’s function ordering.
- Removed the EXI ROM DMA transaction logic from this symbol and replaced it with direct SRAM flag extraction via `__OSLockSram` / `__OSUnlockSram`.

## Functions Improved
- Unit: `main/os/OSRtc`
- Symbol: `__OSReadROM` (size `128b`)
- Match: `0.0%` -> `98.90625%`

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/os/OSRtc -o - __OSReadROM`
- Before change: `__OSReadROM 0.0 128`
- After change: `__OSReadROM 98.90625 128`
- Build verification: `ninja` completes successfully.

## Plausibility Rationale
- The PAL decomp resource for address `0x801802BC` (`resources/ghidra-decomp-1-31-2026/801802bc___OSReadROM.c`) indicates the symbol at this address behaves as an SRAM lock/read/unlock getter, not an EXI ROM DMA routine.
- AGENTS guidance notes symbol names are highly reliable while parameter assumptions can be wrong; this change follows that constraint by matching PAL unit behavior and object layout.

## Technical Notes
- Kept function signature intact (`buffer`, `length`, `offset`) and explicitly marked params unused.
- Implemented the body as:
  - `__OSLockSram()`
  - read `flags & 4`
  - `__OSUnlockSram(0)`
  - return bit state as `int`
