### PR TITLE
mapanim: improve CPtrArray<CMapAnimNode*> matching

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -32,6 +32,7 @@ public:
 extern "C" void __dl__FPv(void*);
 extern "C" void __dla__FPv(void*);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
+extern "C" void* lbl_801EA488[];
 
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
 static char s_ptrarray_grow_error[] = "CPtrArray grow error";
@@ -48,9 +49,9 @@ static char s_ptrarray_grow_error[] = "CPtrArray grow error";
 template <>
 CPtrArray<CMapAnimNode*>::CPtrArray()
 {
-    m_vtable = 0;
-    m_size = 0;
+    m_vtable = lbl_801EA488;
     m_numItems = 0;
+    m_size = 0;
     m_defaultSize = 0x10;
     m_items = 0;
     m_stage = 0;
@@ -84,12 +85,13 @@ CPtrArray<CMapAnimNode*>::~CPtrArray()
 template <>
 int CPtrArray<CMapAnimNode*>::Add(CMapAnimNode* item)
 {
-    int success = setSize(m_numItems + 1);
-    if (success != 0) {
-        m_items[m_numItems] = item;
-        m_numItems++;
+    if (setSize(m_numItems + 1) == 0) {
+        return 0;
     }
-    return success;
+
+    m_items[m_numItems] = item;
+    m_numItems++;
+    return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CPtrArray<CMapAnimNode*>` initialization in `src/mapanim.cpp` to set the vtable pointer (`lbl_801EA488`) and preserve member write order used by the original constructor.
- Simplified `CPtrArray<CMapAnimNode*>::Add` to an explicit fail-fast shape (`if (setSize(...) == 0) return 0; ... return 1;`) to better match original branch/return structure.

## Functions improved
- `__ct__26CPtrArray<P12CMapAnimNode>Fv`
  - Before: `79.46154%`
  - After: `100.0%`
  - Size: `52b`
- `Add__26CPtrArray<P12CMapAnimNode>FP12CMapAnimNode`
  - Before: `88.78571%`
  - After: `99.85714%`
  - Size: `112b`

## Match evidence
- Unit: `main/mapanim`
- `.text` match percent improved:
  - Before: `17.338863%`
  - After: `18.022512%`
- Project progress changed from `1203` to `1204` matched functions after rebuild.

## Plausibility rationale
- Initializing the class vtable pointer in constructor is normal original-source behavior for this hand-rolled array class and is consistent with shipped symbol metadata.
- The `Add` change is an idiomatic control-flow expression of the same logic and avoids contrived coercion patterns.

## Technical details
- `orig/GCCP01/game.MAP` confirms the constructor and vtable symbols for this specialization (`__ct__26CPtrArray<P12CMapAnimNode>Fv`, `__vt__26CPtrArray<P12CMapAnimNode>`).
- Objdiff showed constructor mismatch around vtable setup and store order; the constructor now emits the expected relocation to `lbl_801EA488` and matched fully.
