### PR TITLE
targimpl: decompile TRKTargetAccessARAM

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -336,6 +336,38 @@ DSError TRKTargetReadInstruction(void* data, u32 start)
     return error;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801abef8
+ * PAL Size: 196b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+DSError TRKTargetAccessARAM(u32 p1, u32 p2, u32* p3, BOOL read)
+{
+    DSError error = DS_NoError;
+    TRKExceptionStatus tempExceptionStatus = gTRKExceptionStatus;
+
+    gTRKExceptionStatus.exceptionDetected = FALSE;
+
+    if (read) {
+        TRK__read_aram((int)p1, p2, p3);
+    } else {
+        TRK__write_aram((int)p1, p2, p3);
+    }
+
+    if (gTRKExceptionStatus.exceptionDetected) {
+        error = DS_CWDSException;
+        *p3 = 0;
+    }
+
+    gTRKExceptionStatus = tempExceptionStatus;
+
+    return error;
+}
+
 DSError TRKTargetAccessDefault(u32 firstRegister, u32 lastRegister,
                                TRKBuffer* b, size_t* registersLengthPtr,
                                BOOL read)


### PR DESCRIPTION
## Summary
- Added a first-pass C implementation of `TRKTargetAccessARAM` in `src/TRK_MINNOW_DOLPHIN/targimpl.c`.
- Implemented ARAM read/write dispatch via `TRK__read_aram` / `TRK__write_aram`.
- Preserved TRK exception semantics by saving/restoring `gTRKExceptionStatus`, clearing per-call exception state, and returning `DS_CWDSException` with zeroed length on exception.
- Added PAL metadata block for the function.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/targimpl`
- Symbol: `TRKTargetAccessARAM` (PAL 0x801abef8, 196b)

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` target listing for this unit/symbol)
- After: `98.57143%` from:
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/targimpl -o - TRKTargetAccessARAM`
- Remaining mismatch shape: arg-level differences only (`DIFF_ARG_MISMATCH` x14), no major control-flow divergence.

## Plausibility rationale
- The implementation follows established MetroTRK coding patterns already present in this file (`TRKTargetAccessDefault`, `TRKTargetAccessFP`, `TRKTargetAccessExtended*`): local exception snapshot, operation dispatch, exception-to-`DSError` mapping, state restore.
- No contrived temporaries or non-idiomatic control flow were introduced; behavior matches expected debugger memory-access semantics for ARAM.

## Validation
- `ninja` completed successfully.
- Symbol-level objdiff run completed and reports the above match improvement.
