### PR TITLE
system: match DumpMapFile signature/return behavior

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -59,7 +59,7 @@ public:
     COrder* GetOrder(int);
     unsigned int GetCounter();
     bool IsGdev();
-    void DumpMapFile(void*);
+    CSystem* DumpMapFile(void*);
     static void errorHandler(unsigned short, OSContext*, unsigned long, unsigned long);
 
     // void* vtable;             // 0x0000 (4 bytes)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -336,12 +336,13 @@ bool CSystem::IsGdev()
  * Address:	TODO
  * Size:	TODO
  */
-void CSystem::DumpMapFile(void*)
+CSystem* CSystem::DumpMapFile(void* name)
 {
 	// TODO: Where the hell do we get these from?
 	// There is very obviously <not> a stopwatch at position 0 in this class. Maybe leftover debug code?
-	OSInitStopwatch((OSStopwatch*)this, (char*)nullptr);
+	OSInitStopwatch((OSStopwatch*)this, (char*)name);
 	OSResetStopwatch((OSStopwatch*)this);
+	return this;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CSystem::DumpMapFile` signature and implementation to better match original codegen.
- Changed return type from `void` to `CSystem*` and returned `this`.
- Passed through the incoming pointer argument to `OSInitStopwatch` instead of forcing `nullptr`.

## Functions improved
- Unit: `main/system`
- Symbol: `DumpMapFile__7CSystemFPv`
  - Before: `85.71429%`
  - After: `100.0%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/system -o - DumpMapFile__7CSystemFPv`
  - Removed the prior instruction deltas around forced `li r4, 0` and missing return register restore.
  - Function now reports full instruction match.
- Unit `.text` match also improved:
  - Before: `21.300396%`
  - After: `21.498024%`

## Plausibility rationale
- The updated source expresses a natural behavior for a debug stopwatch helper:
  - use caller-provided name pointer,
  - initialize/reset stopwatch state,
  - return the object pointer for chaining-style usage.
- This is a straightforward type/signature correction rather than contrived compiler coaxing.

## Technical details
- Files changed:
  - `include/ffcc/system.h`
  - `src/system.cpp`
- No assembly comments/debug artifacts were added.
- Full build verified with `ninja`.
