### PR TITLE
main/pppSRandCV: improve match with typed control flow

### DIFF
--- a/include/ffcc/pppSRandCV.h
+++ b/include/ffcc/pppSRandCV.h
@@ -7,7 +7,7 @@ extern "C" {
 
 void randchar(char, float);
 void randf(unsigned char);
-void pppSRandCV(void* param1, void* param2);
+void pppSRandCV(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Reworked `pppSRandCV` from placeholder-style logic into typed control flow that matches the unit's observed assembly shape.
- Updated the function prototype to accept the third context pointer used for source-offset lookup.
- Replaced fake random placeholders with real `RandF__5CMathFv(&math)` calls and correct branch behavior (`+RandF` vs `*2.0f`).
- Implemented byte color updates using signed delta, float source values, and explicit float/double conversion arithmetic in the non-index-match path.

## Functions Improved
- Unit: `main/pppSRandCV`
- Symbol: `pppSRandCV`
- `pppSRandCV`: **39.173912% -> 64.532610%** (**+25.358698%**)

## Match Evidence
- Before:
  - `build/tools/objdiff-cli diff -p . -u main/pppSRandCV -o - pppSRandCV`
  - `.text` match for `pppSRandCV`: `39.173912%`
- After:
  - same command after changes
  - `.text` match for `pppSRandCV`: `64.532610%`
- Build verification:
  - `ninja` passes successfully
  - Unit remains at PAL size target (`736b`)

## Plausibility Rationale
- The new version uses consistent, source-plausible data layout (`index`, `colorOffset`, per-channel deltas, value offset pointer, flag) rather than synthetic constants.
- Control flow now follows expected game-code structure: global gate, index-match random-write path, and alternate color-adjust path.
- Arithmetic logic is expressed in normal C-style operations that naturally lower to the observed FPU conversion pattern.

## Technical Details
- Added typed param struct and explicit `dolphin/types.h` scalar usage.
- Wired `lbl_801EADC8` fallback for `colorOffset == -1`.
- Kept `randchar`/`randf` stubs unchanged (still TODO), while focusing this PR on measurable `pppSRandCV` assembly alignment.
