### PR TITLE
main/usb: improve AddMessageCallback match shape

### DIFF
--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -92,24 +92,42 @@ bool CUSB::IsConnected()
  */
 void CUSB::AddMessageCallback(MessageCallback callback, void* callerContext)
 {
-	for (int i = 0; i < 8; i++)
+	CUSBCallbackEntry* callbackEntry;
+	int i;
+	int remaining;
+
+	callbackEntry = m_callbacks;
+	i = 0;
+	remaining = 8;
+	while (true)
 	{
-		if (m_callbacks[i].m_inUse == 0)
+		if (callbackEntry->m_inUse == 0)
 		{
-			m_callbacks[i].m_inUse = 1;
-			m_callbacks[i].m_callback = callback;
-			m_callbacks[i].m_callerContext = callerContext;
-			return;
+			callbackEntry->m_inUse = 1;
+			callbackEntry->m_callback = callback;
+			callbackEntry->m_callerContext = callerContext;
+			break;
 		}
 
-		if (m_callbacks[i].m_callback == callback)
+		if (callbackEntry->m_callback == callback)
 		{
 			System.Printf("CUSB.AddMessageCallback: 同じ");
-			return;
+			break;
+		}
+
+		i++;
+		callbackEntry++;
+		remaining--;
+		if (remaining == 0)
+		{
+			break;
 		}
 	}
 
-	System.Printf("CUSB.AddMessageCallback: イベント");
+	if (i == 8)
+	{
+		System.Printf("CUSB.AddMessageCallback: イベント");
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CUSB::AddMessageCallback` in `src/usb.cpp` to match the original callback-scan control-flow shape more closely.
- Replaced the `for`-loop with explicit pointer/counter iteration (`callbackEntry`, `i`, `remaining`) and deferred the "イベント" log to a post-loop `i == 8` check.
- Kept callback registration and duplicate-callback behavior unchanged.

## Functions improved
- Unit: `main/usb`
- Function: `AddMessageCallback__4CUSBFPFUlPv10MCCChannel_vPv`
  - Before: `56.761906%`
  - After: `67.61905%`
  - Delta: `+10.857144`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/usb -o - AddMessageCallback__4CUSBFPFUlPv10MCCChannel_vPv`
- Verified with clean rebuild (`ninja`) after the change.
- `RemoveMessageCallback__4CUSBFPFUlPv10MCCChannel_v` remains at `88.072914%` when diffed directly for that symbol.

## Plausibility rationale
- The new structure is source-plausible C++ for an in-place fixed-capacity callback table.
- It uses conventional pointer walk + countdown logic that naturally explains the generated branch shape.
- No contrived temp-only compiler coaxing, magic offsets, or readability regressions were introduced.

## Technical details
- The prior loop form produced a different control-flow graph and register usage around duplicate-found/full-table paths.
- The updated form aligns with the decomp-guided shape and improves instruction-level correspondence in objdiff.
