### PR TITLE
gx: improve GXSetCoPlanar decomp match

### DIFF
--- a/src/gx/GXGeometry.c
+++ b/src/gx/GXGeometry.c
@@ -174,7 +174,9 @@ void GXSetCoPlanar(GXBool enable) {
 
     CHECK_GXBEGIN(613, "GXSetCoPlanar");
 
-    SET_REG_FIELD(615, __GXData->genMode, 1, 19, enable);
+    reg = __GXData->genMode;
+    reg = (reg & 0xFFF7FFFF) | ((u32)enable << 19);
+    __GXData->genMode = reg;
     reg = 0xFE080000;
     GX_WRITE_RAS_REG(reg);
     GX_WRITE_RAS_REG(__GXData->genMode);


### PR DESCRIPTION
## Summary
Refactored `GXSetCoPlanar` in `src/gx/GXGeometry.c` to update `genMode` through an explicit local register value before issuing BP writes.

## Functions Improved
- Unit: `main/gx/GXGeometry`
- Function: `GXSetCoPlanar`

## Match Evidence
- `GXSetCoPlanar`: **59.333332% -> 99.666664%** (size 60b)
- Objdiff diff-kinds for this symbol:
  - Before: `2x DIFF_ARG_MISMATCH`, `4x DIFF_DELETE`, `2x DIFF_INSERT`
  - After: `1x DIFF_ARG_MISMATCH` (remaining global symbol relocation naming mismatch)
- Neighbor functions remained unchanged:
  - `GXEnableTexOffsets`: `58.347828%`
  - `GXSetLineWidth`: `70.55556%`
  - `GXSetPointSize`: `70.55556%`

## Plausibility Rationale
This change preserves expected GX register semantics and mirrors common source style used in SDK-era code: read register -> apply bitfield mask/update -> write back -> emit FIFO writes. It is a straightforward C-level bitfield update rather than contrived compiler-only shaping.

## Technical Details
- Replaced macro-based in-place field write with explicit:
  - `reg = __GXData->genMode;`
  - `reg = (reg & 0xFFF7FFFF) | ((u32)enable << 19);`
  - `__GXData->genMode = reg;`
- BP command emission sequence is unchanged (`0xFE080000` followed by updated `genMode`).
