### PR TITLE
main/pppSRandDownHCV: improve pppSRandDownHCV match

### DIFF
--- a/include/ffcc/pppSRandDownHCV.h
+++ b/include/ffcc/pppSRandDownHCV.h
@@ -7,7 +7,7 @@ extern "C" {
 
 void randshort(short, float);
 void randf(unsigned char);
-void pppSRandDownHCV(void* param1, void* param2);
+void pppSRandDownHCV(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Updated `pppSRandDownHCV` to use the target callback calling pattern with three parameters.
- Reworked control flow and random generation to match the observed down-variant behavior (`-RandF`, optional second random blended by `0.5f`).
- Switched from placeholder local-random logic to explicit global `math` + `RandF__5CMathFv` usage and signed delta writes to HCV output channels.
- Updated `include/ffcc/pppSRandDownHCV.h` prototype to match the implementation.

## Functions improved
- Unit: `main/pppSRandDownHCV`
- Function: `pppSRandDownHCV`
- Fuzzy match: **41.146343% -> 85.48781%**
- Symbol match (objdiff oneshot): **85.335365%** (`pppSRandDownHCV`, size 656)

## Match evidence
- `ninja` report before this change: `main/pppSRandDownHCV` fuzzy `41.146343%`.
- `ninja` report after this change: `main/pppSRandDownHCV` fuzzy `85.48781%`.
- `build/tools/objdiff-cli diff -p . -u main/pppSRandDownHCV -o - pppSRandDownHCV` now reports paired left/right symbols and an 85.335365% symbol match.

## Plausibility rationale
- The changes remove placeholder behavior and align with plausible original code patterns already used in nearby PPP random-modifier units:
  - callback-style third context parameter for data pointer lookup,
  - consistent signed short input to signed 8-bit delta conversion,
  - repeated per-channel random generation and writeback structure.
- The resulting code is simpler and more source-plausible than compiler-coaxing transformations.

## Technical details
- Added `dolphin/types.h` usage for explicit `u8/s8/s16` behavior.
- Added explicit externs for `math`, `lbl_8032ED70`, `lbl_801EADC8`, and `RandF__5CMathFv`.
- Replaced loop-based placeholder arithmetic with explicit per-channel blocks to better mirror target codegen shape.
