### PR TITLE
TRK_MINNOW_DOLPHIN: implement TRKTargetAccessARAM

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -1227,4 +1227,36 @@ DSError TRKPPCAccessSpecialReg(void* value, u32* access_func, BOOL read)
     return DS_NoError;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801abef8
+ * PAL Size: 196b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+DSError TRKTargetAccessARAM(u32 p1, u32 p2, u32* p3, BOOL read)
+{
+    DSError error = DS_NoError;
+    TRKExceptionStatus exceptionStatus = gTRKExceptionStatus;
+
+    gTRKExceptionStatus.exceptionDetected = FALSE;
+
+    if (read) {
+        TRK__read_aram((int)p1, p2, p3);
+    } else {
+        TRK__write_aram((int)p1, p2, p3);
+    }
+
+    if (gTRKExceptionStatus.exceptionDetected) {
+        error = DS_CWDSException;
+        *p3   = 0;
+    }
+
+    gTRKExceptionStatus = exceptionStatus;
+
+    return error;
+}
+
 void TRKTargetSetInputPendingPtr(void* ptr) { gTRKState.inputPendingPtr = ptr; }


### PR DESCRIPTION
## Summary
- Added a concrete implementation of `TRKTargetAccessARAM` in `src/TRK_MINNOW_DOLPHIN/targimpl.c`.
- Implemented ARAM read/write dispatch using existing `TRK__read_aram` / `TRK__write_aram` helpers.
- Preserved and restored `gTRKExceptionStatus` around the access, while clearing/checking `exceptionDetected` to convert target-side exception state into MetroTRK error reporting.
- Added function metadata block with PAL address/size.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/targimpl`
- Function: `TRKTargetAccessARAM`

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` target output)
- After: `98.57143%` via:
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/targimpl -o - TRKTargetAccessARAM`
- Build status: `ninja` passes.

## Plausibility rationale
- The implementation follows expected MetroTRK behavior for memory-space access wrappers:
  - Perform the requested transfer using the platform ARAM routine.
  - Treat exception detection as `DS_CWDSException` and zero transferred length.
  - Restore global exception status bookkeeping after the temporary probe.
- This is straightforward source-level logic rather than compiler-coaxing patterns.

## Technical details
- Uses the existing signature from `targimpl.h`: `TRKTargetAccessARAM(u32 p1, u32 p2, u32* p3, BOOL read)`.
- Returns `DS_NoError` by default, flips to `DS_CWDSException` when `gTRKExceptionStatus.exceptionDetected` is set post-access.
- Keeps dataflow explicit with local saved copy of `TRKExceptionStatus` and final restore assignment.
