### PR TITLE
p_game: match GetTable table-base arithmetic

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/p_game.h"
 
 extern "C" void __sinit_p_game_cpp();
+extern "C" char lbl_801E9F2C[];
 
 /*
  * --INFO--
@@ -56,7 +57,7 @@ void CGamePcs::Quit()
  */
 int CGamePcs::GetTable(unsigned long param)
 {
-    return param * 0x15c - 0x7fe160d4;
+    return (int)(lbl_801E9F2C + param * 0x15c);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CGamePcs::GetTable(unsigned long)` in `src/p_game.cpp` to use direct table-base pointer arithmetic via `lbl_801E9F2C`.
- Replaced a hardcoded arithmetic constant expression with an explicit base-address expression that better reflects original source intent.

## Functions improved
- Unit: `main/p_game`
- Symbol: `GetTable__8CGamePcsFUl`
- Match: **64.0% -> 100.0%**
- Size: 20 bytes (unchanged)

## Match evidence
- Before (`build/tools/objdiff-cli diff -p . -u main/p_game -o - GetTable__8CGamePcsFUl`):
  - `match 64.0% size 20`
  - Key diffs included relocation/base-address sequence mismatches.
- After:
  - `GetTable match: 100.0% size 20`
  - Instruction sequence now matches exactly (`mulli`, `lis/addi` with `lbl_801E9F2C`, `add`, `blr`).

## Plausibility rationale
- Returning `table_base + index * stride` is the natural original-source form for table lookup code.
- This removes an opaque magic constant form and aligns with straightforward authored C/C++ intent rather than compiler-coaxing.

## Technical details
- Added `extern "C" char lbl_801E9F2C[];` and changed return to:
  - `(int)(lbl_801E9F2C + param * 0x15c)`
- Verified with targeted object build:
  - `ninja build/GCCP01/src/p_game.o`
- Note: full `ninja` currently fails in unrelated file `src/TRK_MINNOW_DOLPHIN/targimpl.c` due existing redefinition error (`TRKTargetAccessARAM`).
