### PR TITLE
Improve CFunnyShape cleanup decomp matches

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -1,5 +1,27 @@
 #include "ffcc/FunnyShape.h"
-#include <string.h>  // for memset
+#include "types.h"
+
+#include <string.h>
+
+extern "C" void __dl__FPv(void* ptr);
+extern "C" void __dla__FPv(void* ptr);
+
+namespace {
+static inline u8* Ptr(CFunnyShape* self, u32 offset)
+{
+    return reinterpret_cast<u8*>(self) + offset;
+}
+
+static inline void*& PtrAt(CFunnyShape* self, u32 offset)
+{
+    return *reinterpret_cast<void**>(Ptr(self, offset));
+}
+
+static inline u32& U32At(CFunnyShape* self, u32 offset)
+{
+    return *reinterpret_cast<u32*>(Ptr(self, offset));
+}
+}
 
 /*
  * --INFO--
@@ -22,12 +44,42 @@ CFunnyShape::CFunnyShape()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80051d80
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CFunnyShape::~CFunnyShape()
 {
-	// TODO
+    if (PtrAt(this, 0x6010) != 0) {
+        __dla__FPv(PtrAt(this, 0x6010));
+        PtrAt(this, 0x6010) = 0;
+    }
+
+    if (PtrAt(this, 0x600C) != 0) {
+        __dla__FPv(PtrAt(this, 0x600C));
+        PtrAt(this, 0x600C) = 0;
+    }
+
+    for (s32 i = 0; i < 0x10; i++) {
+        u32 offs = static_cast<u32>(i) * 4;
+        if (PtrAt(this, 0x6094 + offs) != 0) {
+            __dla__FPv(PtrAt(this, 0x6094 + offs));
+            PtrAt(this, 0x6094 + offs) = 0;
+        }
+
+        if (PtrAt(this, 0x6014 + offs) != 0) {
+            __dl__FPv(PtrAt(this, 0x6014 + offs));
+            PtrAt(this, 0x6014 + offs) = 0;
+        }
+
+        if (PtrAt(this, 0x6054 + offs) != 0) {
+            __dl__FPv(PtrAt(this, 0x6054 + offs));
+            PtrAt(this, 0x6054 + offs) = 0;
+        }
+    }
 }
 
 /*
@@ -82,22 +134,57 @@ void CFunnyShape::RenderShape()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800510b0
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CFunnyShape::ClearAnmData()
 {
-	// TODO
+    if (PtrAt(this, 0x600C) != 0) {
+        __dla__FPv(PtrAt(this, 0x600C));
+        PtrAt(this, 0x600C) = 0;
+    }
+
+    memset(this, 0, 0x30);
+    memset(Ptr(this, 0x6000), 0, 0x10);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80051020
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CFunnyShape::ClearTextureData()
 {
-	// TODO
+    U32At(this, 0x60D4) = 0;
+    u8* iter = reinterpret_cast<u8*>(this);
+    for (s32 i = 0; i < 0x10; i++) {
+        void** texData = reinterpret_cast<void**>(iter + 0x6094);
+        if (*texData != 0) {
+            __dla__FPv(*texData);
+            *texData = 0;
+        }
+
+        void** texObj = reinterpret_cast<void**>(iter + 0x6014);
+        if (*texObj != 0) {
+            __dl__FPv(*texObj);
+            *texObj = 0;
+        }
+
+        void** rawData = reinterpret_cast<void**>(iter + 0x6054);
+        if (*rawData != 0) {
+            __dl__FPv(*rawData);
+            *rawData = 0;
+        }
+        iter += 4;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented first-pass decomp for `CFunnyShape` cleanup paths in `src/FunnyShape.cpp` and replaced TODO stubs with plausible original-style logic.

- Added concrete implementations for:
  - `CFunnyShape::ClearAnmData()`
  - `CFunnyShape::ClearTextureData()`
- Added matching PAL metadata blocks for these functions.
- Kept implementation style aligned with existing offset-based reconstruction patterns used in nearby FunnyShape-related code.

## Functions Improved
Unit: `main/FunnyShape`

- `ClearAnmData__11CFunnyShapeFv`
- `ClearTextureData__11CFunnyShapeFv`

## Match Evidence
Measured with direct object diff (`build/tools/objdiff-cli diff -1 build/GCCP01/obj/FunnyShape.o -2 build/GCCP01/src/FunnyShape.o`):

- `ClearAnmData__11CFunnyShapeFv`
  - Before: `4.1666665%` (size `4`)
  - After: `99.458336%` (size `96`)
- `ClearTextureData__11CFunnyShapeFv`
  - Before: `2.7777777%` (size `4`)
  - After: `98.333336%` (size `144`)

Build verification:
- `ninja` succeeds after the changes.

## Plausibility Rationale
These changes reconstruct straightforward cleanup behavior that is consistent with plausible production source:

- Free-and-null pointer ownership cleanup (array delete / delete)
- Fixed-count cleanup loop over 16 entries
- Explicit zeroing of per-instance state and buffer regions via `memset`

No compiler-coaxing constructs were introduced; the code follows existing project patterns for partially-known layouts using byte-offset accessors.

## Technical Notes
- The implementation follows Ghidra only as structural guidance and validates against objdiff outputs.
- Cleanup logic uses explicit offsets because class member layout is not fully reconstructed in headers yet.
