### PR TITLE
Improve pppFrameYmCheckBGHeight match with typed collision locals

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/pppYmCheckBGHeight.h"
 #include "ffcc/map.h"
+#include "ffcc/maphit.h"
 #include "ffcc/pppPart.h"
 
 #include <dolphin/types.h>
@@ -15,8 +16,8 @@ extern float FLOAT_80330ed8;
 extern float FLOAT_80330edc;
 
 extern "C" {
-    int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(struct CMapMng*, void*, void*, unsigned int);
-    void CalcHitPosition__7CMapObjFP3Vec(void*, void*);
+    int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(struct CMapMng*, CMapCylinder*, Vec*, unsigned int);
+    void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
     void* pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
 }
 
@@ -45,65 +46,53 @@ void pppConstructYmCheckBGHeight(void)
  */
 struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pppYmCheckBGHeight, struct UnkC* param_2)
 {
-	struct _pppMngSt* pppMngSt;
-	int iVar1;
-	double dVar2;
-	unsigned char auStack_78[4];
-	float local_74;
-	float local_6c;
-	float local_68;
-	float local_64;
-	float local_60;
-	float local_5c;
-	float local_58;
-	float local_48;
-	float local_44;
-	float local_40;
-	float local_3c;
-	float local_38;
-	float local_34;
-	float local_30;
-	float local_2c;
-	float local_28;
-	float local_24;
-	
-	pppMngSt = pppMngStPtr;
-	if (DAT_8032ed70 == 0) {
-		local_6c = FLOAT_80330ed0;
-		local_68 = FLOAT_80330ed4;
-		local_64 = FLOAT_80330ed0;
-		dVar2 = (double)(pppMngStPtr->m_matrix).value[1][3];
-		local_60 = (pppMngStPtr->m_matrix).value[0][3];
-		local_58 = (pppMngStPtr->m_matrix).value[2][3];
-		local_5c = (float)(dVar2 + (double)(float)param_2->m_unk0x4);
-		local_30 = FLOAT_80330ed8;
-		local_34 = FLOAT_80330ed8;
-		local_38 = FLOAT_80330ed8;
-		local_24 = FLOAT_80330edc;
-		local_28 = FLOAT_80330edc;
-		local_2c = FLOAT_80330edc;
-		local_48 = FLOAT_80330ed0;
-		local_44 = FLOAT_80330ed4;
-		local_40 = FLOAT_80330ed0;
-		local_3c = FLOAT_80330ed0;
-		
-		iVar1 = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &local_60, &local_6c, 0xffffffff);
-		if (iVar1 != 0) {
-			CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A88), auStack_78);
-			if ((float)(dVar2 - (double)(float)param_2->m_serializedDataOffsets) <= local_74) {
-				dVar2 = (double)(local_74 + (float)param_2->m_unk0x8);
-			}
-		}
-		(pppMngSt->m_position).y = (float)dVar2;
-		*((float*)pppMngSt + 0x17) = (float)dVar2; // m_savedPosition.y
-		*((float*)pppMngSt + 0x1B) = (float)dVar2; // m_paramVec0.y
-		*((float*)pppMngSt + 0x13) = (float)dVar2; // m_previousPosition.y
-		
-		(pppMngStPtr->m_matrix).value[0][3] = (pppMngSt->m_position).x;
-		(pppMngStPtr->m_matrix).value[1][3] = (pppMngSt->m_position).y;
-		(pppMngStPtr->m_matrix).value[2][3] = (pppMngSt->m_position).z;
-		
-		pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
-	}
-	return pppYmCheckBGHeight;
+    struct _pppMngSt* pppMngSt;
+    CMapCylinder cyl;
+    Vec hitPos;
+    double posY;
+
+    pppMngSt = pppMngStPtr;
+    if (DAT_8032ed70 == 0) {
+        cyl.m_direction.x = FLOAT_80330ed0;
+        cyl.m_direction.y = FLOAT_80330ed4;
+        cyl.m_direction.z = FLOAT_80330ed0;
+
+        posY = (double)pppMngStPtr->m_matrix.value[1][3];
+        cyl.m_bottom.x = pppMngStPtr->m_matrix.value[0][3];
+        cyl.m_bottom.z = pppMngStPtr->m_matrix.value[2][3];
+        cyl.m_bottom.y = (float)(posY + (double)(float)param_2->m_unk0x4);
+
+        cyl.m_direction2.x = FLOAT_80330ed8;
+        cyl.m_direction2.y = FLOAT_80330ed8;
+        cyl.m_direction2.z = FLOAT_80330ed8;
+
+        cyl.m_radius2 = FLOAT_80330edc;
+        cyl.m_height2 = FLOAT_80330edc;
+        cyl.m_radius = FLOAT_80330edc;
+
+        cyl.m_top.x = FLOAT_80330ed0;
+        cyl.m_top.y = FLOAT_80330ed4;
+        cyl.m_top.z = FLOAT_80330ed0;
+        cyl.m_height = FLOAT_80330ed0;
+
+        if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &cyl, &cyl.m_direction, 0xffffffff) != 0) {
+            CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A88), &hitPos);
+            if ((float)(posY - (double)(float)param_2->m_serializedDataOffsets) <= hitPos.y) {
+                posY = (double)(hitPos.y + (float)param_2->m_unk0x8);
+            }
+        }
+
+        pppMngSt->m_position.y = (float)posY;
+        *((float*)pppMngSt + 0x17) = (float)posY; // m_savedPosition.y
+        *((float*)pppMngSt + 0x1B) = (float)posY; // m_paramVec0.y
+        *((float*)pppMngSt + 0x13) = (float)posY; // m_previousPosition.y
+
+        pppMngStPtr->m_matrix.value[0][3] = pppMngSt->m_position.x;
+        pppMngStPtr->m_matrix.value[1][3] = pppMngSt->m_position.y;
+        pppMngStPtr->m_matrix.value[2][3] = pppMngSt->m_position.z;
+
+        pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
+    }
+
+    return pppYmCheckBGHeight;
 }


### PR DESCRIPTION
## Summary
- Refactored `pppFrameYmCheckBGHeight` in `src/pppYmCheckBGHeight.cpp` to use a typed `CMapCylinder` + `Vec` stack layout instead of many scalar temporaries.
- Tightened extern signatures for collision helpers to match their real parameter types (`CMapCylinder*`, `Vec*`).
- Kept behavior intact while aligning local layout/control flow with plausible original source style.

## Functions Improved
- Unit: `main/pppYmCheckBGHeight`
- Function: `pppFrameYmCheckBGHeight`

## Match Evidence
- `objdiff` (`build/tools/objdiff-cli diff -p . -u main/pppYmCheckBGHeight -o - pppFrameYmCheckBGHeight`):
  - Before: `50.24138%`
  - After: `57.402298%`
- Current report snapshot (`build/GCCP01/report.json`):
  - `pppFrameYmCheckBGHeight` fuzzy match: `59.172413%`
  - Unit `main/pppYmCheckBGHeight` fuzzy match: `59.636364%`

## Plausibility Rationale
- The new form models collision input as an explicit `CMapCylinder` object and hit output as `Vec`, which is consistent with usage patterns in other map-hit callsites in this codebase.
- Changes focus on type/layout correctness and ordinary control flow, rather than artificial compiler-coaxing temporaries.

## Technical Details
- Included `ffcc/maphit.h` so `CMapCylinder` can be instantiated directly.
- Replaced `void*` helper prototypes with typed equivalents for cleaner ABI-consistent calls.
- Preserved all matrix/position updates and `pppSetFpMatrix` behavior after the collision height adjustment path.
- Verified build success with `ninja`.