### PR TITLE
pppYmDrawMdlTexAnm: implement first-pass constructor

### DIFF
--- a/include/ffcc/pppYmDrawMdlTexAnm.h
+++ b/include/ffcc/pppYmDrawMdlTexAnm.h
@@ -1,14 +1,35 @@
 #ifndef _PPP_YMDRAWMDLTEXANM_H_
 #define _PPP_YMDRAWMDLTEXANM_H_
 
+#include "ffcc/partMng.h"
+
+struct pppYmDrawMdlTexAnm {
+    _pppPObject field0_0x0;
+};
+
+struct pppYmDrawMdlTexAnmStep {
+    s32 m_graphId;
+    s32 m_dataValIndex;
+    s16 m_initWOrk;
+    u16 _pad0;
+    f32 m_stepValue;
+    f32 m_arg3;
+    u8 m_payload[8];
+};
+
+struct pppYmDrawMdlTexAnmOffsets {
+    u8 _pad0[0x0C];
+    s32* m_serializedDataOffsets;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppConstructYmDrawMdlTexAnm(void* param1, void* param2, void* param3);
-void pppDestructYmDrawMdlTexAnm(void* param1, void* param2, void* param3);
-void pppFrameYmDrawMdlTexAnm(void* param1, void* param2, void* param3);
-void pppRenderYmDrawMdlTexAnm(void* param1, void* param2, void* param3);
+void pppConstructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOffsets* param2, void* param3);
+void pppDestructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOffsets* param2, void* param3);
+void pppFrameYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep* param2, pppYmDrawMdlTexAnmOffsets* param3);
+void pppRenderYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep* param2, pppYmDrawMdlTexAnmOffsets* param3);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -1,20 +1,73 @@
 #include "ffcc/pppYmDrawMdlTexAnm.h"
 #include "dolphin/os.h"
 
+struct pppYmDrawMdlTexAnmWork {
+    u32 m_frame;
+    u32 m_wait;
+    u32 m_tilesU;
+    u32 m_tilesV;
+    f32 m_perU;
+    f32 m_perV;
+};
+
+struct CMapMeshUVLayout {
+    u8 _pad0[0x06];
+    u16 m_uvCount;
+    u8 _pad1[0x30];
+    s16* m_uvPairs;
+};
+
+extern f32 FLOAT_8033054c;
+extern _pppEnvSt* pppEnvStPtr;
+extern char DAT_801d9c54[];
+extern char s_PerU___0_2f_PerV___0_2f_801d9c38[];
+
 extern "C" {
 
 /*
  * --INFO--
- * PAL Address: 8008aa84
- * PAL Size: TODO
+ * PAL Address: 0x8008aa84
+ * PAL Size: 316b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppConstructYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
+void pppConstructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOffsets* param2, void* param3)
 {
-    // Basic constructor - initialize texture animation system
+    pppYmDrawMdlTexAnmWork* work;
+    CMapMesh* mapMesh;
+    CMapMeshUVLayout* uvLayout;
+    s16* uvPairs;
+    int i;
+
+    (void)param3;
+    work = (pppYmDrawMdlTexAnmWork*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2]);
+    work->m_frame = 0;
+    work->m_wait = 0x200;
+
+    OSReport(DAT_801d9c54);
+
+    work->m_perU = FLOAT_8033054c;
+    work->m_perV = FLOAT_8033054c;
+
+    mapMesh = pppEnvStPtr->m_mapMeshPtr;
+    if (mapMesh != NULL) {
+        uvLayout = (CMapMeshUVLayout*)mapMesh;
+        uvPairs = uvLayout->m_uvPairs;
+        for (i = 0; i < (int)uvLayout->m_uvCount; i++) {
+            const f32 u = (f32)uvPairs[0];
+            const f32 v = (f32)uvPairs[1];
+            if (work->m_perU < u) {
+                work->m_perU = u;
+            }
+            if (work->m_perV < v) {
+                work->m_perV = v;
+            }
+            uvPairs += 2;
+        }
+        OSReport(s_PerU___0_2f_PerV___0_2f_801d9c38, work->m_perU, work->m_perV);
+    }
 }
 
 /*
@@ -26,8 +79,11 @@ void pppConstructYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppDestructYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
+void pppDestructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOffsets* param2, void* param3)
 {
+    (void)param1;
+    (void)param2;
+    (void)param3;
     // Reset texture animation state
     // Reset animation counters and UV coordinates
 }
@@ -41,8 +97,11 @@ void pppDestructYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
+void pppFrameYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep* param2, pppYmDrawMdlTexAnmOffsets* param3)
 {
+    (void)param1;
+    (void)param2;
+    (void)param3;
     // Update texture animation frame
     // Handle UV coordinate updates and frame counting
 }
@@ -56,8 +115,11 @@ void pppFrameYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRenderYmDrawMdlTexAnm(void* param1, void* param2, void* param3)
+void pppRenderYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep* param2, pppYmDrawMdlTexAnmOffsets* param3)
 {
+    (void)param1;
+    (void)param2;
+    (void)param3;
     // Render texture animated models
     // Matrix transformations and model drawing
 }


### PR DESCRIPTION
## Summary
- Replaced the placeholder `pppConstructYmDrawMdlTexAnm` body with a first-pass implementation that initializes texture-animation work state and scans mesh UV pairs to derive `PerU` / `PerV` maxima.
- Added concrete data structs and typed function signatures in `include/ffcc/pppYmDrawMdlTexAnm.h` so the implementation matches existing PPP conventions used elsewhere in the repo.
- Kept frame/render/destruct untouched in this pass to isolate constructor progress.

## Functions Improved
- Unit: `main/pppYmDrawMdlTexAnm`
- Symbol: `pppConstructYmDrawMdlTexAnm`
- Current symbol match (objdiff): **56.594936%**

## Match Evidence
- Selector baseline for unit before change: **0.8%** (`main/pppYmDrawMdlTexAnm`)
- Current report fuzzy match for unit after change: **9.154285%** (`build/GCCP01/report.json`)
- `objdiff` command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmDrawMdlTexAnm -o - pppConstructYmDrawMdlTexAnm`
- `objdiff` now reports constructor symbol match at **56.594936%**, indicating real assembly alignment from the prior stub.

## Plausibility Rationale
- The implementation follows established codebase patterns for PPP constructors:
  - work memory accessed via `+0x80 + serializedDataOffsets[2]`
  - initialization of per-effect state in a compact work struct
  - UV scan from map mesh data and post-scan `OSReport` diagnostics
- This is source-plausible game code behavior, not synthetic compiler coaxing.

## Technical Details
- Introduced a local `CMapMesh` UV view with offsets matching current decomp assumptions (`uvCount` at `0x6`, UV pair pointer at `0x38`).
- Constructor now:
  - initializes frame/wait counters
  - seeds `m_perU` / `m_perV`
  - iterates UV short pairs and updates maxima
  - logs the final values through existing format strings
