### PR TITLE
chara_fur: match CHairSet constructor

### DIFF
--- a/include/ffcc/chara_fur.h
+++ b/include/ffcc/chara_fur.h
@@ -3,6 +3,7 @@
 
 #include "ffcc/charaobj.h"
 #include "ffcc/color.h"
+#include "ffcc/vector.h"
 
 #include <dolphin/gx.h>
 
@@ -24,6 +25,10 @@ class CHairSet
 {
 public:
     CHairSet();
+
+    CVector m_vec0;
+    CVector m_vec1;
+    CColor m_colors[2];
 };
 
 #endif // _FFCC_CGCHARAOBJ_H_

--- a/src/chara_fur.cpp
+++ b/src/chara_fur.cpp
@@ -58,9 +58,8 @@ void nearColor(CColor, CColor)
  * Size:	TODO
  */
 CHairSet::CHairSet()
-{
-	// TODO
-}
+    : m_vec0(), m_vec1()
+{}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Reconstructed `CHairSet` data layout in `include/ffcc/chara_fur.h` to match observed constructor codegen.
- Implemented `CHairSet::CHairSet()` in `src/chara_fur.cpp` using member initialization for the two `CVector` members.
- Kept the implementation source-plausible (real member semantics + default constructors), without compiler-only coercion patterns.

## Functions improved
- Unit: `main/chara_fur`
- Function: `__ct__8CHairSetFv` (`CHairSet::CHairSet()`), size `84b`

## Match evidence
- `__ct__8CHairSetFv`: **4.7619047% -> 100.0%**
- `main/chara_fur` `.text` fuzzy match: **0.038692202% -> 0.42561424%**
- `main/chara_fur` matched functions: **0/14 -> 1/14**

## Plausibility rationale
- Constructor now reflects a natural class definition: two vectors and an inline color array.
- Generated sequence (`CVector` ctor x2 + `__construct_array` for `CColor[2]`) is exactly what a normal Metrowerks C++ class constructor would emit.
- No artificial temp/reordering or opaque coercion was introduced.

## Technical details
- Added `#include "ffcc/vector.h"` and explicit members:
  - `CVector m_vec0;`
  - `CVector m_vec1;`
  - `CColor m_colors[2];`
- Used member-init form: `CHairSet::CHairSet() : m_vec0(), m_vec1() {}`
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/chara_fur -o - __ct__8CHairSetFv`
