### PR TITLE
gx: improve GXSetZCompLoc match to near-complete

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -250,10 +250,14 @@ void GXSetZMode(GXBool compare_enable, GXCompare func, GXBool update_enable) {
 }
 
 void GXSetZCompLoc(GXBool before_tex) {
+    GXData *gx;
+
     CHECK_GXBEGIN(474, "GXSetZCompLoc");
-    SET_REG_FIELD(475, __GXData->peCtrl, 1, 6, before_tex);
-    GX_WRITE_RAS_REG(__GXData->peCtrl);
-    __GXData->bpSentNot = 0;
+
+    gx = __GXData;
+    gx->peCtrl = (gx->peCtrl & 0xFFFFFFBF) | ((u32)(u8)before_tex << 6);
+    GX_WRITE_RAS_REG(gx->peCtrl);
+    gx->bpSentNot = 0;
 }
 
 void GXSetPixelFmt(GXPixelFmt pix_fmt, GXZFmt16 z_fmt) {


### PR DESCRIPTION
## Summary
- Rewrote `GXSetZCompLoc` in `src/gx/GXPixel.c` to use an explicit local GX context pointer and direct masked writeback to `peCtrl`.
- Kept behavior unchanged while matching the compiler/output shape more closely.

## Functions Improved
- Unit: `main/gx/GXPixel`
- Symbol: `GXSetZCompLoc`

## Match Evidence
- `GXSetZCompLoc` improved from **73.57143%** to **99.64286%** (`objdiff-cli` symbol diff).
- Build status remains successful with `ninja` and project progress reporting.

## Plausibility Rationale
- The change is source-plausible and idiomatic for this codebase: local `GXData*`, mask/shift update of a register shadow, then hardware write and dirty flag update.
- No contrived temporaries or unnatural reordering were introduced; this is a straightforward register-field update implementation likely consistent with original SDK-style code.

## Technical Details
- Prior mismatch showed extra instruction shape differences around register-field packing.
- Replacing macro-style field update with explicit `(gx->peCtrl & 0xFFFFFFBF) | ((u32)(u8)before_tex << 6)` aligned nearly all instructions with target.
- Remaining mismatch appears to be a non-functional SDA symbol naming/relocation difference only.