### PR TITLE
memorycard: improve CalcCrc/ChkCrc matching

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -736,28 +736,48 @@ void CMemoryCardMan::SetLoadData()
  */
 unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
 {
+    unsigned char byte;
+    int i;
+    unsigned char* ptr;
+    unsigned int crc;
     unsigned char* data = (unsigned char*)saveData;
-    if (data == nullptr) {
+
+    if (data == nullptr)
+    {
         data = (unsigned char*)m_saveBuffer;
     }
-    
-    unsigned int crc = 0xFFFFFFFF;
-    
-    // Process first 0x1c (28) bytes
-    for (int i = 0; i < 0x1c; i++) {
-        unsigned char byte = data[i];
+
+    crc = 0xFFFFFFFF;
+    i = 0x1C;
+    ptr = data;
+    while (true)
+    {
+        i--;
+        if (i < 0)
+        {
+            break;
+        }
+
+        byte = *ptr;
+        ptr++;
         crc = (crc << 8) ^ crcTable[(crc >> 24) ^ byte];
     }
-    
-    // Skip 4 bytes (CRC location at 0x1c), continue from 0x20
-    data += 0x20;
-    
-    // Process remaining 0x8bb0 (35760) bytes
-    for (int i = 0; i < 0x8bb0; i++) {
-        unsigned char byte = data[i];
+
+    ptr = data + 0x20;
+    i = 0x8BB0;
+    while (true)
+    {
+        i--;
+        if (i < 0)
+        {
+            break;
+        }
+
+        byte = *ptr;
+        ptr++;
         crc = (crc << 8) ^ crcTable[(crc >> 24) ^ byte];
     }
-    
+
     return ~crc;
 }
 
@@ -772,37 +792,42 @@ unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
  */
 unsigned int CMemoryCardMan::ChkCrc(Mc::SaveDat* saveData)
 {
+    unsigned char byte;
+    unsigned int crc;
+    int i;
+    unsigned char* ptr;
     unsigned char* data = (unsigned char*)saveData;
-    if (data == nullptr) {
+
+    if (data == nullptr)
+    {
         data = (unsigned char*)m_saveBuffer;
     }
-    if (data == nullptr) {
-        data = (unsigned char*)m_saveBuffer;
+
+    ptr = data;
+    if (data == nullptr)
+    {
+        ptr = (unsigned char*)m_saveBuffer;
     }
-    
-    unsigned int crc = 0xFFFFFFFF;
-    
-    // Process first 0x1c (28) bytes
-    for (int i = 0; i < 0x1c; i++) {
-        unsigned char byte = data[i];
+
+    crc = 0xFFFFFFFF;
+    i = 0x1C;
+    while (i = i - 1, -1 < i)
+    {
+        byte = *ptr;
+        ptr++;
         crc = (crc << 8) ^ crcTable[(crc >> 24) ^ byte];
     }
-    
-    // Skip 4 bytes (CRC location at 0x1c), continue from 0x20
-    unsigned char* dataPtr = data + 0x20;
-    
-    // Process remaining 0x8bb0 (35760) bytes
-    for (int i = 0; i < 0x8bb0; i++) {
-        unsigned char byte = dataPtr[i];
+
+    ptr += 0x20 - 0x1C;
+    i = 0x8BB0;
+    while (i = i - 1, -1 < i)
+    {
+        byte = *ptr;
+        ptr++;
         crc = (crc << 8) ^ crcTable[(crc >> 24) ^ byte];
     }
-    
-    // Get stored CRC from offset 0x1c
-    unsigned int storedCrc = *(unsigned int*)(data + 0x1c);
-    
-    // Compare calculated CRC with stored CRC
-    // Return 1 if they match, 0 if they don't
-    return (~crc == storedCrc) ? 1 : 0;
+
+    return (unsigned int)__cntlzw((~crc) - *(unsigned int*)(data + 0x1C)) >> 5;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CMemoryCardMan::CalcCrc` and `CMemoryCardMan::ChkCrc` in `src/memorycard.cpp` to use pointer-walk/decrement-loop control flow and variable lifetimes that better match the original codegen.
- Replaced branch-based CRC equality in `ChkCrc` with the `__cntlzw(... ) >> 5` idiom seen in PPC codegen.
- Kept behavior identical: both functions still compute CRC over bytes `[0x00..0x1B]` and `[0x20..0x8BCF]`, skipping the stored CRC field at `0x1C`.

## Functions Improved
- Unit: `main/memorycard`
- `CalcCrc__14CMemoryCardManFPQ22Mc7SaveDat`
  - Before: `0.0%`
  - After: `79.5946%`
- `ChkCrc__14CMemoryCardManFPQ22Mc7SaveDat`
  - Before: `0.0%`
  - After: `77.45652%`

## Match Evidence
- Build: `ninja` passes.
- Objdiff commands used:
  - `build/tools/objdiff-cli diff -p . -u main/memorycard -o - CalcCrc__14CMemoryCardManFPQ22Mc7SaveDat`
  - `build/tools/objdiff-cli diff -p . -u main/memorycard -o - ChkCrc__14CMemoryCardManFPQ22Mc7SaveDat`
- Result: both functions moved from complete mismatch to substantial instruction alignment.

## Plausibility Rationale
- Changes are source-plausible and align with common Metrowerks-era patterns:
  - explicit pointer iterators over fixed-length binary blobs,
  - decrement-and-test loop forms,
  - branchless equality test via `cntlzw` idiom.
- No artificial offsets, dummy temporaries, or readability-hostile compiler coercion were introduced beyond normal low-level style for CRC routines.
