### PR TITLE
Improve pppEmission constructor matching

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -236,6 +236,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
  * JP Size: TODO
  */
 void pppConstructEmission(pppEmission* pppEmission_, UnkC* param_2) {
+    float baseScale = FLOAT_803311f8;
     int offset = param_2->m_serializedDataOffsets[2];
     int* state = (int*)((u8*)pppEmission_ + 8 + offset);
 
@@ -244,9 +245,9 @@ void pppConstructEmission(pppEmission* pppEmission_, UnkC* param_2) {
     *((u8*)state + 9) = 0x80;
     *((u8*)state + 10) = 0x80;
     *((u8*)state + 11) = 0x80;
-    *(float*)(state + 3) = FLOAT_803311f8;
-    *(float*)(state + 4) = FLOAT_803311f8;
-    *(float*)(state + 5) = FLOAT_803311f8;
+    *(float*)(state + 5) = baseScale;
+    *(float*)(state + 4) = baseScale;
+    *(float*)(state + 3) = baseScale;
 
     void* handle = GetCharaHandlePtr__FP8CGObjectl(pppMngStPtr->m_charaObj, 0);
     int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
@@ -267,10 +268,12 @@ void pppConstructEmission(pppEmission* pppEmission_, UnkC* param_2) {
  * JP Size: TODO
  */
 void pppConstruct2Emission(pppEmission* pppEmission_, UnkC* param_2) {
+    float baseScale = FLOAT_803311f8;
     int offset = param_2->m_serializedDataOffsets[2];
-    *(float*)((u8*)pppEmission_ + 0x8C + offset) = FLOAT_803311f8;
-    *(float*)((u8*)pppEmission_ + 0x90 + offset) = FLOAT_803311f8;
-    *(float*)((u8*)pppEmission_ + 0x94 + offset) = FLOAT_803311f8;
+    float* state = (float*)((u8*)pppEmission_ + 0x80 + offset);
+    state[5] = baseScale;
+    state[4] = baseScale;
+    state[3] = baseScale;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refined constructor initialization patterns in `src/pppEmission.cpp` for `pppConstructEmission` and `pppConstruct2Emission`.
- Switched to a shared float local for repeated scale initialization and aligned store ordering with the expected constructor layout.
- Reworked `pppConstruct2Emission` to compute a single base pointer (`+0x80+offset`) and perform indexed stores from that base.

## Functions Improved
- `pppConstruct2Emission`
  - before: `62.444443%`
  - after: `84.666664%`
  - delta: `+22.222221`
- `pppConstructEmission`
  - before: `80.375%`
  - after: `90.45%`
  - delta: `+10.075000`
- `pppFrameEmission`
  - unchanged: `64.90385%`

## Match Evidence
- Unit analyzed with:
  - `build/tools/objdiff-cli diff -p . -u main/pppEmission -o - pppFrameEmission`
- This change improves constructor symbol match percentages substantially without broad unit churn.
- Full rebuild still succeeds with `ninja`.

## Plausibility Rationale
- The edits preserve original behavior while making initialization flow more source-plausible for a hand-written constructor:
  - one reused scalar constant,
  - a single computed per-instance base pointer,
  - contiguous per-field writes.
- No contrived temporary state or non-semantic reordering was introduced beyond constructor-local initialization sequencing.

## Technical Notes
- `pppConstruct2Emission` now maps cleanly to the expected store pattern at offsets `0x0C/0x10/0x14` from a shared base.
- `pppConstructEmission` now uses the same pattern for the three float initializers, which reduced mismatch in the constructor block.
