### PR TITLE
p_chara: recover CPtrArray load-entry template methods

### DIFF
--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -1,7 +1,185 @@
 #include "ffcc/p_chara.h"
 #include "ffcc/memory.h"
 
+#include <string.h>
+
 extern CMemory Memory;
+extern "C" void __dla__FPv(void*);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
+
+static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
+static char s_ptrarray_grow_error[] = "CPtrArray grow error";
+
+template <class T>
+class CPtrArray
+{
+public:
+    void** m_vtable;
+    int m_size;
+    int m_numItems;
+    int m_defaultSize;
+    T* m_items;
+    CMemory::CStage* m_stage;
+    int m_growCapacity;
+
+    CPtrArray();
+    bool Add(T item);
+    int GetSize();
+    void ReleaseAndRemoveAll();
+    void RemoveAt(unsigned long index);
+    T operator[](unsigned long index);
+    void SetStage(CMemory::CStage* stage);
+    void SetDefaultSize(unsigned long defaultSize);
+    void SetGrow(int growCapacity);
+    int setSize(unsigned long newSize);
+    T GetAt(unsigned long index);
+    void RemoveAll();
+};
+
+template <class T>
+CPtrArray<T>::CPtrArray()
+{
+    m_vtable = 0;
+    m_size = 0;
+    m_numItems = 0;
+    m_defaultSize = 0x10;
+    m_items = 0;
+    m_stage = 0;
+    m_growCapacity = 1;
+}
+
+template <class T>
+bool CPtrArray<T>::Add(T item)
+{
+    if (setSize(m_numItems + 1) != 0) {
+        m_items[m_numItems] = item;
+        m_numItems = m_numItems + 1;
+        return true;
+    }
+    return false;
+}
+
+template <class T>
+int CPtrArray<T>::GetSize()
+{
+    return m_numItems;
+}
+
+template <class T>
+void CPtrArray<T>::ReleaseAndRemoveAll()
+{
+    int offset = 0;
+
+    for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
+        int* item = *(int**)((int)m_items + offset);
+        if (item != 0) {
+            int refCount = item[1];
+            item[1] = refCount - 1;
+            if (refCount - 1 == 0 && item != 0) {
+                (*(void (**)(int*, int))(*item + 8))(item, 1);
+            }
+            *(unsigned int*)((int)m_items + offset) = 0;
+        }
+        offset += 4;
+    }
+
+    RemoveAll();
+}
+
+template <class T>
+void CPtrArray<T>::RemoveAt(unsigned long index)
+{
+    int offset = (int)(index * 4);
+
+    m_items[index] = 0;
+    for (; index < (unsigned long)m_numItems; index++) {
+        unsigned int* current = (unsigned int*)((int)m_items + offset);
+        offset += 4;
+        *current = current[1];
+    }
+
+    m_numItems = m_numItems - 1;
+}
+
+template <class T>
+T CPtrArray<T>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+template <class T>
+void CPtrArray<T>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+template <class T>
+void CPtrArray<T>::SetDefaultSize(unsigned long defaultSize)
+{
+    m_defaultSize = defaultSize;
+}
+
+template <class T>
+void CPtrArray<T>::SetGrow(int growCapacity)
+{
+    m_growCapacity = growCapacity;
+}
+
+template <class T>
+int CPtrArray<T>::setSize(unsigned long newSize)
+{
+    T* newItems;
+
+    if ((unsigned long)m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
+            m_size = m_size << 1;
+        }
+
+        newItems = (T*)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, (unsigned long)(m_size << 2), m_stage, s_collection_ptrarray_h, 0xFA, 0);
+        if (newItems == 0) {
+            return 0;
+        }
+
+        if (m_items != 0) {
+            memcpy(newItems, m_items, m_numItems << 2);
+        }
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+        m_items = newItems;
+    }
+
+    return 1;
+}
+
+template <class T>
+T CPtrArray<T>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
+template <class T>
+void CPtrArray<T>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+template class CPtrArray<CCharaPcs::CLoadPdt*>;
+template class CPtrArray<CCharaPcs::CLoadTexture*>;
+template class CPtrArray<CCharaPcs::CLoadAnim*>;
+template class CPtrArray<CCharaPcs::CLoadModel*>;
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added a local `CPtrArray<T>` implementation in `src/p_chara.cpp` that mirrors the existing game-side ptrarray behavior used in other units.
- Implemented constructor + core operations used by `CCharaPcs` load arrays: `Add`, `GetSize`, `ReleaseAndRemoveAll`, `RemoveAt`, `operator[]`, `SetStage`, `SetDefaultSize`, `SetGrow`, `setSize`, `GetAt`, and `RemoveAll`.
- Added explicit template instantiations for:
  - `CPtrArray<CCharaPcs::CLoadPdt*>`
  - `CPtrArray<CCharaPcs::CLoadTexture*>`
  - `CPtrArray<CCharaPcs::CLoadAnim*>`
  - `CPtrArray<CCharaPcs::CLoadModel*>`

## Functions Improved
- Unit: `main/p_chara`
- Added/recovered matching for previously missing (`-1` / effectively 0%) ptrarray helper symbols across all four load-array specializations.
- Representative improved symbols:
  - `GetSize__33CPtrArray<PQ29CCharaPcs8CLoadPdt>Fv`: `-1 -> 99.5%`
  - `ReleaseAndRemoveAll__33CPtrArray<PQ29CCharaPcs8CLoadPdt>Fv`: `-1 -> 92.59%`
  - `setSize__33CPtrArray<PQ29CCharaPcs8CLoadPdt>FUl`: `-1 -> 91.57%` (objdiff one-shot reports ~`91.15%`)
  - `__vc__33CPtrArray<PQ29CCharaPcs8CLoadPdt>FUl`: `-1 -> 100%`
- The same symbol families improved for `CLoadTexture`, `CLoadAnim`, and `CLoadModel` specializations as well.

## Match Evidence
- Unit match moved from selector baseline `2.7%` (`main/p_chara` at selection time) to current report `11.727251%`.
- Build progress improved from `Code: 182812 / 1855300 bytes` to `Code: 183100 / 1855300 bytes`.
- `main/p_chara` now reports `21/101` matched functions.

## Plausibility Rationale
- The change restores a missing container implementation pattern already used in this codebase (`mapanim` and other ptrarray usage), rather than adding contrived control-flow tricks.
- Semantics follow the Ghidra decompilation for these exact symbols (including stage-aware allocation, growth handling, and release/remove behavior) and use existing engine services (`Memory`, `System.Printf`, `_Alloc`, `__dla`).
- The result is a plausible original-source style recovery of expected template specializations for `CCharaPcs` load-entry arrays.

## Technical Notes
- Kept all logic in `src/p_chara.cpp` to localize symbol emission to the correct unit.
- Explicit template instantiation was used to materialize the missing symbols directly in `p_chara.o`.
- Verified with full `ninja` build and unit-level report/objdiff checks.
