### PR TITLE
Decompile pppLerpPos constructors and first-pass frame logic

### DIFF
--- a/src/pppLerpPos.cpp
+++ b/src/pppLerpPos.cpp
@@ -1,78 +1,146 @@
 #include "ffcc/pppLerpPos.h"
+#include "ffcc/memory.h"
+#include "ffcc/partMng.h"
+#include "dolphin/mtx.h"
 #include "dolphin/types.h"
 
-// Structure definitions based on Ghidra decompilation analysis
 struct pppLerpPos {
-    char field0_0x0[0x80]; // Placeholder for unknown fields before the important data at offset 0x80
-    // Additional fields will be added as needed
+    u8 m_pad[0x80];
 };
 
 struct UnkB {
-    u8 m_dataValIndex; // Byte value used in loops
-    // Additional fields will be added as needed
+    u8 m_pad[4];
+    u8 m_dataValIndex;
 };
 
 struct UnkC {
-    char padding[0x0C]; // Padding to match expected offset
-    u32* m_serializedDataOffsets; // Pointer to offset data at 0xC
-    // Additional fields will be added as needed  
+    u8 m_pad[0x0C];
+    s32* m_serializedDataOffsets;
 };
 
-// External references that need to be resolved
-// These are referenced in Ghidra but not yet defined properly
-extern void* pppMemAlloc__FUlPQ27CMemory6CStagePci(u32 size, void* stage, char* file, int line);
-extern void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
-extern void pppCopyVector__FR3Vec3Vec(void* dst, void* src);
-extern void PSVECAdd(void* a, void* b, void* result);
-extern void PSVECScale(float scale, void* src, void* dst);
-
-// External global variables referenced in the code
-extern void* pppEnvStPtr; // Environment stage pointer
-extern struct _pppMngSt* pppMngStPtr; // Management state pointer
-
-// Constants referenced in Ghidra
+extern "C" {
+void* pppMemAlloc__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
+void pppHeapUseRate__FPQ27CMemory6CStage(CMemory::CStage* stage);
+void pppCopyVector__FR3Vec3Vec(void* dst, void* src);
+void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt* pppMngSt);
+}
+extern _pppEnvSt* pppEnvStPtr;
+extern _pppMngSt* pppMngStPtr;
 extern float FLOAT_80331bf8;
 extern float FLOAT_80331bfc;
-extern double DOUBLE_80331c00;
 extern char s_pppLerpPos_cpp_801dd418[];
-extern int DAT_8032ed70;
+extern s32 DAT_8032ed70;
 
 /*
  * --INFO--
- * PAL Address: 8012b490
+ * PAL Address: 0x8012b490
  * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConstructLerpPos(struct pppLerpPos* pppLerpPos, struct UnkC* param_2)
 {
-    u32* dataOffsets = param_2->m_serializedDataOffsets;
-    u32** targetPtr = (u32**)((char*)&pppLerpPos->field0_0x0 + 0x80 + *dataOffsets);
-    *targetPtr = 0;
+    s32 dataOffset = *param_2->m_serializedDataOffsets;
+    Vec** work = (Vec**)((u8*)pppLerpPos + 0x80 + dataOffset);
+    *work = 0;
 }
 
 /*
  * --INFO--
- * PAL Address: 8012b43c
+ * PAL Address: 0x8012b43c
  * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDestructLerpPos(struct pppLerpPos* pppLerpPos, struct UnkC* param_2)
 {
-    int iVar1 = *param_2->m_serializedDataOffsets;
-    void** stagePtr = (void**)((char*)&pppLerpPos->field0_0x0 + 0x80 + iVar1);
-    
-    if (*stagePtr != 0) {
-        pppHeapUseRate__FPQ27CMemory6CStage(*stagePtr);
-        *stagePtr = 0;
+    s32 dataOffset = *param_2->m_serializedDataOffsets;
+    void** work = (void**)((u8*)pppLerpPos + 0x80 + dataOffset);
+
+    if (*work != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage((CMemory::CStage*)*work);
+        *work = 0;
     }
 }
 
 /*
  * --INFO--
- * PAL Address: 8012b24c  
+ * PAL Address: 0x8012b24c
  * PAL Size: 496b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppFrameLerpPos(struct pppLerpPos* pppLerpPos, struct UnkB* param_2, struct UnkC* param_3)
 {
-    // TODO: Complex position lerping implementation
-    // This function needs matrix operations and vector math
-    // Will implement incrementally based on build feedback
+    _pppMngSt* pppMngSt;
+    s32 i;
+    s32 dataOffset;
+    s32 countMinusOne;
+    s32 step;
+    Vec* history;
+    float* prevFloat;
+    Vec sum;
+    Vec prev;
+    u32 count;
+
+    if (DAT_8032ed70 != 0) {
+        return;
+    }
+
+    pppMngSt = pppMngStPtr;
+    dataOffset = *param_3->m_serializedDataOffsets;
+    history = *(Vec**)((u8*)pppLerpPos + 0x80 + dataOffset);
+
+    if (history == 0) {
+        count = (u32)param_2->m_dataValIndex;
+        history = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            count * (u32)sizeof(Vec), pppEnvStPtr->m_stagePtr, s_pppLerpPos_cpp_801dd418, 0x37);
+        *(Vec**)((u8*)pppLerpPos + 0x80 + dataOffset) = history;
+        step = 0;
+        for (i = 0; i < (s32)count; i++) {
+            *(f32*)((u8*)history + step) = pppMngStPtr->m_matrix.value[0][3];
+            *(f32*)((u8*)history + step + 4) = pppMngStPtr->m_matrix.value[1][3];
+            *(f32*)((u8*)history + step + 8) = pppMngStPtr->m_matrix.value[2][3];
+            step += sizeof(Vec);
+        }
+    } else {
+        sum.x = FLOAT_80331bf8;
+        sum.y = FLOAT_80331bf8;
+        sum.z = FLOAT_80331bf8;
+
+        countMinusOne = (s32)param_2->m_dataValIndex - 1;
+        step = countMinusOne * (s32)sizeof(Vec);
+        while (0 < countMinusOne) {
+            prevFloat = (float*)((u8*)history + step - (s32)sizeof(Vec));
+            prev.x = prevFloat[0];
+            prev.y = prevFloat[1];
+            prev.z = prevFloat[2];
+            pppCopyVector__FR3Vec3Vec((void*)((u8*)history + step), &prev);
+            step -= sizeof(Vec);
+            countMinusOne--;
+        }
+
+        history[0].x = pppMngStPtr->m_matrix.value[0][3];
+        history[0].y = pppMngStPtr->m_matrix.value[1][3];
+        history[0].z = pppMngStPtr->m_matrix.value[2][3];
+
+        count = (u32)param_2->m_dataValIndex;
+        step = 0;
+        for (i = 0; i < (s32)count; i++) {
+            PSVECAdd((Vec*)((u8*)history + step), &sum, &sum);
+            step += sizeof(Vec);
+        }
+
+        PSVECScale(&sum, &sum, FLOAT_80331bfc / (f32)count);
+        pppMngStPtr->m_matrix.value[0][3] = sum.x;
+        pppMngStPtr->m_matrix.value[1][3] = sum.y;
+        pppMngStPtr->m_matrix.value[2][3] = sum.z;
+        pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
+    }
 }


### PR DESCRIPTION
## Summary
- Replaced placeholder scaffolding in `src/pppLerpPos.cpp` with typed implementations for `pppConstructLerpPos`, `pppDestructLerpPos`, and a first-pass `pppFrameLerpPos`.
- Aligned serialized-work offset handling to the object-local work area at `+0x80` and cleaned up memory-stage allocation/free usage.
- Implemented the frame path structure from decomp: lazy history allocation, history shift/copy, vector accumulation, averaging, and matrix writeback.

## Functions improved
- Unit: `main/pppLerpPos`
- `pppFrameLerpPos`
  - Before: `0.8%` (from `tools/agent_select_target.py` target output)
  - After: `6.314516%` (`build/tools/objdiff-cli diff -p . -u main/pppLerpPos -o - pppFrameLerpPos`)
- `pppConstructLerpPos`: now `100.0%`
- `pppDestructLerpPos`: now `100.0%`

## Match evidence
- Build verification: `ninja` succeeds and report regenerates.
- Objdiff verification command:
  - `build/tools/objdiff-cli diff -p . -u main/pppLerpPos -o - pppFrameLerpPos`
- Extracted symbol match results from diff JSON:
  - `pppFrameLerpPos 6.314516`
  - `pppDestructLerpPos 100.0`
  - `pppConstructLerpPos 100.0`

## Plausibility rationale
- Changes are type/layout corrections and control-flow reconstruction based on existing project patterns (`ppp*` work buffers, stage alloc/free, and matrix/vector helpers), not contrived compiler coaxing.
- The function remains readable and source-plausible while preserving room for future narrowing passes.

## Technical details
- Corrected `m_dataValIndex` usage to byte offset `+0x4` in `UnkB`.
- Switched helper signatures to C linkage where appropriate for stable symbol calls.
- Replaced stub logic with direct buffer-step loops (`sizeof(Vec)` stepping) to better reflect observed codegen shape.
