### PR TITLE
gx: improve GXSetFieldMode bit packing

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -332,12 +332,12 @@ void GXSetFieldMode(GXBool field_mode, GXBool half_aspect_ratio) {
 
     CHECK_GXBEGIN(637, "GXSetFieldMode");
     lp_size = __GXData->lpSize;
-    lp_size &= ~0x200;
-    lp_size |= (u32)(u8)half_aspect_ratio << 9;
+    lp_size &= ~0x00400000;
+    lp_size |= (u32)(u8)half_aspect_ratio << 22;
     __GXData->lpSize = lp_size;
     GX_WRITE_RAS_REG(lp_size);
     __GXFlushTextureState();
-    reg = field_mode | 0x68000000;
+    reg = (u32)(u8)field_mode | 0x68000000;
     GX_WRITE_RAS_REG(reg);
     __GXFlushTextureState();
 }


### PR DESCRIPTION
## Summary
- Adjusted `GXSetFieldMode` BP register packing in `src/gx/GXPixel.c`.
- Updated `half_aspect_ratio` write from bit 9 to bit 22 in the packed register value.
- Cast `field_mode` to byte-width before ORing with `0x68000000`.

## Functions improved
- Unit: `main/gx/GXPixel`
- Symbol: `GXSetFieldMode` (size 124b)

## Match evidence
- `GXSetFieldMode`: **91.58064% -> 92.064514%**
- Verified via:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXPixel -o - GXSetFieldMode`
  - `ninja` (build succeeds)

## Plausibility rationale
- The change aligns with packed BP register semantics used throughout GX code: field bits are written in full-register coordinates, not low 10-bit-only form.
- This is a type/bitfield correction (not contrived control-flow coaxing), and matches the expected SDK-style register update pattern.

## Technical details
- Previous code modified `0x00000200` and shifted by 9, which maps to low-field coordinates only.
- Updated code now modifies `0x00400000` and shifts by 22, consistent with the encoded register layout written through `GX_WRITE_RAS_REG`.
- Objdiff instruction alignment improved in the field mode packing region after this correction.
