### PR TITLE
Implement pppShape frame/position helpers

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -173,12 +173,20 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80065794
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppGetShapePos(long*, short, Vec&, Vec&, int)
+void pppGetShapePos(long* animData, short frameIndex, Vec& minPos, Vec& maxPos, int shapeIndex)
 {
-	// TODO
+    int shapeBase = *(short*)((int)animData + frameIndex * 8 + 0x10);
+    int shapeEntry = *(int*)((int)animData + shapeBase + 0xc + shapeIndex * 8);
+
+    memcpy(&minPos, (void*)(shapeEntry + 3), 0xc);
+    memcpy(&maxPos, (void*)(shapeEntry + 0x2b), 0xc);
 }
 
 /*
@@ -193,10 +201,30 @@ void pppGetShapeUV(long*, short, Vec2d&, Vec2d&, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80065678
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppCalcFrameShape(long*, short&, short&, short&, short)
+void pppCalcFrameShape(long* animData, short& currentFrame, short& drawFrame, short& frameTime,
+                       short deltaTime)
 {
-	// TODO
+    drawFrame = currentFrame;
+    frameTime += deltaTime;
+
+    short duration = *(short*)((int)animData + currentFrame * 8 + 0x12);
+    if (frameTime < duration) {
+        return;
+    }
+
+    frameTime -= duration;
+    currentFrame += 1;
+    if (currentFrame < *(short*)((int)animData + 6)) {
+        return;
+    }
+
+    currentFrame = 0;
+    frameTime = 0;
 }


### PR DESCRIPTION
## Summary
Implemented two previously TODO `pppShape` helpers in `src/pppShape.cpp` using source-plausible pointer arithmetic and frame timing logic from the PAL decomp context:
- `pppGetShapePos__FPlsR3VecR3Veci`
- `pppCalcFrameShape__FPlRsRsRss`

Also updated `--INFO--` headers for both functions with PAL address/size metadata.

## Functions Improved
- `pppGetShapePos__FPlsR3VecR3Veci` (`main/pppShape`)
- `pppCalcFrameShape__FPlRsRsRss` (`main/pppShape`)

## Match Evidence
From `objdiff-cli diff -p . -u main/pppShape -o -`:
- `pppGetShapePos__FPlsR3VecR3Veci`: **95.8%** match (size 120 in decomp object)
- `pppCalcFrameShape__FPlRsRsRss`: **57.36%** match (size 100)

These functions were TODO stubs in source before this change; this PR replaces stubs with concrete implementations and yields real assembly alignment in the target unit.

## Plausibility Rationale
Changes are consistent with likely original source style and semantics:
- Uses straightforward frame-duration accumulation/wrap logic for animation frame progression.
- Uses direct packed-data pointer traversal and `memcpy` for shape min/max vector extraction.
- No contrived temporaries or artificial reordering solely for compiler coaxing.

## Technical Notes
- Build verified with `ninja`.
- Symbol-level validation performed with `build/tools/objdiff-cli` in JSON mode against `main/pppShape`.
