### PR TITLE
TRK: match ReadFPSCR and WriteFPSCR in targimpl

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -127,8 +127,14 @@ asm void __TRK_set_MSR(register u32 msr) {
 asm void WriteFPSCR(register f64* fpscr) {
 #ifdef __MWERKS__ // clang-format off
     nofralloc
-    lfd f0, 0(r3)
-    mtfsf 0xff, f0
+    stwu r1, -0x40(r1)
+    stfd f31, 0x10(r1)
+    psq_st f31, 0x20(r1), 0, 0
+    lfd f31, 0(r3)
+    mtfsf 0xff, f31
+    psq_l f31, 0x20(r1), 0, 0
+    lfd f31, 0x10(r1)
+    addi r1, r1, 0x40
     blr
 #endif // clang-format on
 }
@@ -145,8 +151,14 @@ asm void WriteFPSCR(register f64* fpscr) {
 asm void ReadFPSCR(register f64* fpscr) {
 #ifdef __MWERKS__ // clang-format off
     nofralloc
-    mffs f0
-    stfd f0, 0(r3)
+    stwu r1, -0x40(r1)
+    stfd f31, 0x10(r1)
+    psq_st f31, 0x20(r1), 0, 0
+    mffs f31
+    stfd f31, 0(r3)
+    psq_l f31, 0x20(r1), 0, 0
+    lfd f31, 0x10(r1)
+    addi r1, r1, 0x40
     blr
 #endif // clang-format on
 }


### PR DESCRIPTION
## Summary
- Updated `ReadFPSCR` and `WriteFPSCR` in `src/TRK_MINNOW_DOLPHIN/targimpl.c` to use the expected FPR-preserving prologue/epilogue sequence around FPSCR access.
- Switched temporary register usage from `f0` to `f31` and added matching paired-single save/restore instructions (`psq_st`/`psq_l`) and stack frame setup/teardown.

## Functions Improved
- `ReadFPSCR` (unit: `main/TRK_MINNOW_DOLPHIN/targimpl`)
  - Before: `32.22222%`
  - After: `100.0%`
- `WriteFPSCR` (unit: `main/TRK_MINNOW_DOLPHIN/targimpl`)
  - Before: `32.22222%`
  - After: `100.0%`

## Match Evidence
- Unit `.text` match (`main/TRK_MINNOW_DOLPHIN/targimpl`)
  - Before: `73.15088%`
  - After: `73.84288%`
- Validation steps run:
  - `ninja` (build succeeds)
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/targimpl -o - ReadFPSCR`
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/targimpl -o - WriteFPSCR`

## Plausibility Rationale
- This change aligns with standard Metrowerks ABI-preserving behavior for FPR usage in asm stubs, especially use of non-volatile `f31` with explicit save/restore.
- The final code is straightforward and maintainable, and mirrors expected original source intent (read/write FPSCR through a pointer) rather than contrived compiler-driven transformations.

## Technical Notes
- objdiff showed the previous implementation missed 7 instructions in each function (prologue/epilogue and paired-single preservation).
- After adding those exact structural instructions, both symbols reached full instruction-level match.
