### PR TITLE
pppCallBackDistance: improve pppFrameCallBackDistance matching

### DIFF
--- a/src/pppCallBackDistance.cpp
+++ b/src/pppCallBackDistance.cpp
@@ -4,6 +4,8 @@
 #include "ffcc/p_game.h"
 #include <dolphin/mtx.h>
 
+extern CPartMng PartMng;
+
 /*
  * --INFO--
  * PAL Address: 0x80141318
@@ -57,45 +59,34 @@ void pppDestructCallBackDistance(void)
  */
 void pppFrameCallBackDistance(pppCallBackDistance* param1, UnkB* param2, UnkC* param3)
 {
-    _pppMngSt* mngSt;
-    u8* mngBytes;
+    _pppMngSt* pppMngSt;
     u32 graphId;
     s32 dataOffset;
-    s32 frameIndex;
-    s32 graphChunk;
-    s32 graphAdjust;
+    f64 distance;
     Vec worldPos;
     Vec particlePos;
-    f32 distance;
 
-    mngSt = pppMngStPtr;
-    mngBytes = (u8*)mngSt;
-    particlePos.x = *(f32*)(mngBytes + 0x10);
+    particlePos.x = pppMngStPtr->m_matrix.value[0][3];
     dataOffset = *param3->m_serializedDataOffsets;
-    particlePos.y = *(f32*)(mngBytes + 0x20);
-    particlePos.z = *(f32*)(mngBytes + 0x30);
-    distance = PSVECDistance(&particlePos, (Vec*)(mngBytes + 0x64));
-    mngSt = pppMngStPtr;
-    mngBytes = (u8*)mngSt;
+    particlePos.y = pppMngStPtr->m_matrix.value[1][3];
+    particlePos.z = pppMngStPtr->m_matrix.value[2][3];
+    distance = (f64)PSVECDistance(&particlePos, (Vec*)((u8*)pppMngStPtr + 0x64));
+    pppMngSt = pppMngStPtr;
 
-    if ((distance <= param2->m_dataValIndex) || (*(f32*)((u8*)param1 + dataOffset + 8) <= distance)) {
-        worldPos.x = *(f32*)(mngBytes + 0x10);
-        worldPos.y = *(f32*)(mngBytes + 0x20);
-        worldPos.z = *(f32*)(mngBytes + 0x30);
+    if ((distance <= (double)(f32)param2->m_dataValIndex) ||
+        ((double)*(f32*)((u8*)(&param1->field0_0x0 + 2) + dataOffset) <= distance)) {
+        worldPos.x = pppMngStPtr->m_matrix.value[0][3];
+        worldPos.y = pppMngStPtr->m_matrix.value[1][3];
+        worldPos.z = pppMngStPtr->m_matrix.value[2][3];
         PSMTXMultVec(ppvWorldMatrix, &worldPos, &worldPos);
 
-        frameIndex = (s32)(mngBytes + 0x42E55C58) / 0x158 + ((s32)(mngBytes + 0x42E55C58) >> 0x1f);
-        frameIndex = frameIndex - (frameIndex >> 0x1f);
-
         graphId = *(u32*)&param1->field0_0x0;
-        graphChunk = (s32)graphId >> 0xc;
-        graphAdjust = 0;
-        if (((s32)graphId < 0) && ((graphId & 0xfff) != 0)) {
-            graphAdjust = 1;
-        }
+        dataOffset = ((s32)((u8*)pppMngSt - ((u8*)&PartMng + 0x2A18))) / 0x158;
 
-        Game.game.ParticleFrameCallback(frameIndex, (s32)*(s16*)(mngBytes + 0xb0),
-                                        (s32)*(s16*)(mngBytes + 0xb2), (s32)param2->m_initWOrk,
-                                        graphChunk + graphAdjust, &worldPos);
+        Game.game.ParticleFrameCallback(dataOffset, (s32)pppMngSt->m_kind, (s32)pppMngSt->m_nodeIndex,
+                                        (s32)*(s16*)&param2->m_initWOrk,
+                                        ((s32)graphId >> 0xC) +
+                                            (((s32)graphId < 0) && ((graphId & 0xFFF) != 0)),
+                                        &worldPos);
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `pppFrameCallBackDistance` to use matrix/member access patterns used by nearby PPP callback code instead of raw manager byte-offset access.
- Replaced the opaque frame-index pointer arithmetic with a `PartMng`-relative manager index calculation (`((u8*)pppMngSt - ((u8*)&PartMng + 0x2A18)) / 0x158`).
- Kept behavior equivalent while aligning comparisons and graph-id conversion with existing PPP-style signed conversion logic.

## Functions improved
- Unit: `main/pppCallBackDistance`
- Symbol: `pppFrameCallBackDistance`

## Match evidence
- `objdiff` symbol match (`build/tools/objdiff-cli diff -p . -u main/pppCallBackDistance -o - pppFrameCallBackDistance`):
  - Before: `47.5%`
  - After: `52.57353%`
  - Delta: `+5.07353`
- Instruction-level diff markers in objdiff JSON for this symbol:
  - Before: `64`
  - After: `59`

## Plausibility rationale
- The updated code follows the same source style already used in `pppYmCallBack` for particle callback setup and manager-index derivation, which is more likely to reflect original FFCC source than hardcoded pointer constants inside arithmetic expressions.
- Changes are type/control-flow cleanups and expression shaping, not contrived no-op temporaries or readability regressions.

## Technical details
- Added `extern CPartMng PartMng;` and used it only to compute callback manager index in PPP callback frame path.
- Reshaped the distance threshold branch to use explicit double comparisons against serialized state and `m_dataValIndex`.
- Preserved world-space transform + `ParticleFrameCallback` argument semantics while improving instruction alignment with target assembly.
