### PR TITLE
pppYmTracer: align serialized-offset access in construct/destruct paths

### DIFF
--- a/include/ffcc/pppYmTracer.h
+++ b/include/ffcc/pppYmTracer.h
@@ -3,9 +3,20 @@
 
 #include <dolphin/types.h>
 
-// Forward declarations
-struct UnkB;
-struct UnkC;
+struct UnkB {
+    s32 m_graphId;
+    u32 m_dataValIndex;
+    s32 m_initWOrk;
+    f32 m_stepValue;
+    s32 m_arg3;
+    u8 m_payload[0x20];
+};
+
+struct UnkC {
+    u8 _pad[0xC];
+    s32* m_serializedDataOffsets;
+};
+
 struct TRACE_POLYGON;
 
 // Basic structure for pppYmTracer - based on Ghidra analysis

--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -46,7 +46,7 @@ void pppConstructYmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
     f32* pfVar2;
     
     fVar1 = FLOAT_803306e8;
-    pfVar2 = (f32*)((int)(&pppYmTracer->field0_0x0 + 2) + *(int*)param_2);
+    pfVar2 = (f32*)((int)(&pppYmTracer->field0_0x0 + 2) + *param_2->m_serializedDataOffsets);
     
     pfVar2[10] = 0.0f;
     pfVar2[9] = 0.0f;
@@ -78,7 +78,7 @@ void pppConstruct2YmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
 {
     int iVar1;
     
-    iVar1 = *(int*)param_2;
+    iVar1 = *param_2->m_serializedDataOffsets;
     *(u16*)((char*)pppYmTracer + 0xae + iVar1) = 0;
     *(u16*)((char*)pppYmTracer + 0xac + iVar1) = 0;
 }
@@ -94,7 +94,7 @@ void pppConstruct2YmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
  */
 void pppDestructYmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
 {
-    CMemory::CStage** stagePtr = (CMemory::CStage**)((char*)pppYmTracer + 0xa8 + *(int*)param_2);
+    CMemory::CStage** stagePtr = (CMemory::CStage**)((char*)pppYmTracer + 0xa8 + *param_2->m_serializedDataOffsets);
     if (*stagePtr != nullptr) {
         pppHeapUseRate(*stagePtr);
     }


### PR DESCRIPTION
## Summary
- Defined concrete `UnkB`/`UnkC` layouts in `include/ffcc/pppYmTracer.h` to reflect serialized offset access used by this unit.
- Updated `pppConstructYmTracer`, `pppConstruct2YmTracer`, and `pppDestructYmTracer` to read offsets via `param_2->m_serializedDataOffsets` instead of treating `UnkC*` as a raw `int*`.

## Functions improved
- Unit: `main/pppYmTracer`
- Symbol: `pppConstruct2YmTracer`

## Match evidence
- Selector baseline: `pppConstruct2YmTracer` at `69.6%`.
- After this change (`build/tools/objdiff-cli diff -p . -u main/pppYmTracer -o - pppConstruct2YmTracer`): `82.25%`.
- Additional check after rebuild: `pppDestructYmTracer` reports `100.0%` in the same unit diff output.

## Plausibility rationale
- The change replaces type-punning (`*(int*)param_2`) with explicit field-based access (`m_serializedDataOffsets`) consistent with nearby PPP units and with the Ghidra-recovered access pattern for these exact symbols.
- This is an ABI/type correction rather than compiler coaxing; it improves readability and reflects likely original source intent.

## Technical details
- `UnkC` now has a `0xC` pad and serialized offset pointer, matching the calling convention expected by the constructor/destructor family in this unit.
- The constructor/destructor offset arithmetic remains unchanged apart from using the correct source offset field, preserving behavior while improving codegen alignment.
- Validation performed with `ninja` and targeted objdiff runs for `pppConstructYmTracer`, `pppConstruct2YmTracer`, and `pppDestructYmTracer`.
