### PR TITLE
os/OSReset: improve OSGetResetCode match with direct-return flow

### DIFF
--- a/src/os/OSReset.c
+++ b/src/os/OSReset.c
@@ -277,16 +277,11 @@ void OSResetSystem(BOOL reset, u32 resetCode, BOOL forceMenu) {
 }
 
 u32 OSGetResetCode() {
-    u32 resetCode;
     if (*(volatile u8*)0x800030e2 != 0) {
-        resetCode = 0x80000000;
-    } else {
-        resetCode = *(volatile u32*)0xCC003024;
-        resetCode &= ~7;
-        resetCode >>= 3;
+        return 0x80000000;
     }
 
-    return resetCode;
+    return *(volatile u32*)0xCC003024 >> 3;
 }
 
 u32 OSSetBootDol(u32 dolOffset) {


### PR DESCRIPTION
## Summary
- Rewrote `OSGetResetCode` in `src/os/OSReset.c` to a direct-return form.
- Removed the temporary variable and explicit low-bit mask before shifting.

## Functions Improved
- Unit: `main/os/OSReset`
- Symbol: `OSGetResetCode`

## Match Evidence
- `OSGetResetCode`: **76.583336% -> 77.416664%** (`build/tools/objdiff-cli diff -p . -u main/os/OSReset -o - OSGetResetCode`)
- Unit `.text` match: **76.25297% -> 76.29249%**

## Plausibility Rationale
- This matches the common Dolphin SDK pattern for reset-code reads: early return for the SRAM flag path, otherwise direct hardware read and right shift.
- The resulting C is simpler and more idiomatic than the prior temporary/mask sequence, and aligns with decomp reference intent.

## Technical Details
- The previous implementation used:
  - temp assignment + `resetCode &= ~7` + `resetCode >>= 3`
- The new implementation uses:
  - `if (flag) return 0x80000000;`
  - `return *(volatile u32*)0xCC003024 >> 3;`
- This changed branch/register shaping enough to improve objdiff alignment for the symbol.
