### PR TITLE
mapanim: map CMapAnimKeyDt ptrarray symbols and improve matching

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -10,8 +10,8 @@ class CPtrArray
 {
 public:
     void** m_vtable;
-    int m_size;
     int m_numItems;
+    int m_size;
     int m_defaultSize;
     T* m_items;
     CMemory::CStage* m_stage;
@@ -50,8 +50,8 @@ template <>
 CPtrArray<CMapAnimNode*>::CPtrArray()
 {
     m_vtable = lbl_801EA488;
-    m_numItems = 0;
     m_size = 0;
+    m_numItems = 0;
     m_defaultSize = 0x10;
     m_items = 0;
     m_stage = 0;
@@ -199,7 +199,71 @@ int CPtrArray<CMapAnimNode*>::setSize(unsigned long newSize)
         }
 
         newItems = (CMapAnimNode**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
-            &Memory, m_size << 2, m_stage, s_collection_ptrarray_h, 0xFA, 0);
+            &Memory, (unsigned long)(m_size << 2), m_stage, s_collection_ptrarray_h, 0xFA, 0);
+        if (newItems == 0) {
+            return 0;
+        }
+
+        if (m_items != 0) {
+            memcpy(newItems, m_items, m_numItems << 2);
+        }
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+        m_items = newItems;
+    }
+
+    return 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004b070
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimKeyDt*>::Add(CMapAnimKeyDt* item)
+{
+    if (setSize(m_numItems + 1) == 0) {
+        return 0;
+    }
+
+    m_items[m_numItems] = item;
+    m_numItems++;
+    return 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004b0e0
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimKeyDt*>::setSize(unsigned long newSize)
+{
+    CMapAnimKeyDt** newItems;
+
+    if ((unsigned long)m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
+            m_size = m_size << 1;
+        }
+
+        newItems = (CMapAnimKeyDt**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, (unsigned long)(m_size << 2), m_stage, s_collection_ptrarray_h, 0xFA, 0);
         if (newItems == 0) {
             return 0;
         }


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray<CMapAnimKeyDt*>` specializations for `Add` and `setSize` in `src/mapanim.cpp`.
- Aligned local `CPtrArray` member ordering/initialization and allocation-size typing with the existing compiled pattern used in this TU.
- Kept changes constrained to `main/mapanim` behavior and template instantiation/mangling alignment.

## Functions Improved
- `Add__27CPtrArray<P13CMapAnimKeyDt>FP13CMapAnimKeyDt`: `null (unmapped)` -> `100.0%`
- `setSize__27CPtrArray<P13CMapAnimKeyDt>FUl`: `null (unmapped)` -> `91.25%`
- `Add__26CPtrArray<P12CMapAnimNode>FP12CMapAnimNode`: `99.85714%` -> `100.0%`
- `setSize__26CPtrArray<P12CMapAnimNode>FUl`: `91.15%` -> `91.25%`
- `RemoveAll__26CPtrArray<P12CMapAnimNode>Fv`: `99.89474%` -> `100.0%`
- Minor regression: `__ct__26CPtrArray<P12CMapAnimNode>Fv`: `100.0%` -> `99.84615%`

## Match Evidence
- Unit code match (`main/mapanim`, `.text`): `18.022512%` -> `27.838863%`
- Project progress (`ninja`):
  - Code bytes: `183228` -> `183528` (+300)
  - Functions matched: `1251` -> `1254` (+3)

## Plausibility Rationale
- The new `CMapAnimKeyDt*` specialization bodies mirror the already-existing `CMapAnimNode*` specialization pattern in the same source file (same allocator path, growth logic, and copy/free sequence).
- Member ordering and initializer sequencing align with emitted access patterns rather than introducing contrived control flow.
- No debug artifacts, no assembly comments, and no behaviorally exotic coercions were introduced.

## Technical Notes
- The key gap was unmapped P13 `CPtrArray` symbols in this unit; adding explicit specializations allowed objdiff symbol mapping and substantial section-level improvement.
- A small constructor regression remains (`__ct__26...`); net effect is strongly positive due newly mapped and improved high-size functions.
