### PR TITLE
os/OSReboot: expose Run asm helper for matching

### DIFF
--- a/src/os/OSReboot.c
+++ b/src/os/OSReboot.c
@@ -25,8 +25,7 @@ typedef struct {
 
 static AppLoaderStruct FatalParam;
 
-#ifdef __GEKKO__
-static asm void Run(register void* entryPoint) {
+asm void Run(register void* entryPoint) {
     nofralloc
 
     sync
@@ -34,7 +33,6 @@ static asm void Run(register void* entryPoint) {
     mtlr entryPoint
     blr
 }
-#endif
 
 static void Callback(s32, DVDCommandBlock*) {
     Prepared = TRUE;


### PR DESCRIPTION
## Summary
- Updated `src/os/OSReboot.c` so the `Run` asm helper is always emitted and not file-local:
  - removed `#ifdef __GEKKO__` guard around `Run`
  - changed `static asm void Run(...)` to `asm void Run(...)`
- Kept logic/instructions in `Run` unchanged.

## Functions improved
- Unit: `main/os/OSReboot`
- `Run`
  - before: 0.0%
  - after: 100.0%
- `__OSReboot`
  - before: 73.85096%
  - after: 95.875%

## Match evidence
Using `objdiff-cli report changes /tmp/objreport_try1.json /tmp/objreport_after.json`:
- `main/os/OSReboot` fuzzy match percent: **72.84186 -> 96.0093**
- matched functions: **1/3 -> 2/3**
- matched code bytes: **12/860 -> 28/860**

## Plausibility rationale
- `Run` is a low-level jump helper used by reboot path and is a natural global asm helper in this SDK-style code.
- The previous guarded/static form prevented symbol alignment in this build configuration; removing guard/local linkage restores symbol presence without changing behavior.
- Change is source-plausible and minimal, not compiler-coaxing.

## Technical details
- Before change, objdiff could not map `Run` to a target symbol in this unit.
- After change, `Run` matches fully and `__OSReboot` alignment also improves due corrected call/symbol structure.
