### PR TITLE
main/mapshadow: improve Init__10CMapShadowFv match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -11,6 +11,17 @@ extern double DOUBLE_8032fce8;
 extern float FLOAT_8032fcf0;
 extern float FLOAT_8032fce0;
 
+static inline float U32ToFloatViaDouble(u32 value, double bias)
+{
+    union {
+        u64 u;
+        double d;
+    } cvt;
+
+    cvt.u = 0x4330000000000000ULL | (u64)value;
+    return (float)(cvt.d - bias);
+}
+
 class CMapMng;
 extern CMapMng MapMng;
 
@@ -74,7 +85,6 @@ void CMapShadow::Init()
 	float fVar1;
 	float fVar2;
 	float fVar3;
-	float fVar4;
 	double dVar5;
 	int iVar6;
 	u32 uVar7;
@@ -86,17 +96,20 @@ void CMapShadow::Init()
 	uVar8 = *(u32*)(iVar6 + 100);
 	uVar7 = *(u32*)(iVar6 + 0x68);
 	*((char*)this + 7) = (char)*(u32*)(iVar6 + 0x6c);
-	fVar1 = (float)((double)((long long)uVar8 + 0x4330000000000000ULL) - dVar5);
-	fVar2 = (float)((double)((long long)uVar7 + 0x4330000000000000ULL) - dVar5);
+	fVar1 = U32ToFloatViaDouble(uVar8, dVar5);
+	fVar2 = U32ToFloatViaDouble(uVar7, dVar5);
 	fVar3 = *(float*)((char*)this + 0xa8);
-	fVar4 = (float)(DOUBLE_8032fce8 * (double)fVar3);
-	fVar3 = (float)((double)FLOAT_8032fcf0 * (double)fVar3);
 	if (*((char*)this + 6) == 0) {
-		C_MTXLightOrtho((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1, fVar4, fVar3,
+		C_MTXLightOrtho((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,
+		                (float)(DOUBLE_8032fce8 * (double)fVar3),
+		                (float)((double)FLOAT_8032fcf0 * (double)fVar3),
 		                FLOAT_8032fcf0, FLOAT_8032fcf0);
 	} else {
 		C_MTXLightFrustum((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,
-		                  *(float*)((char*)this + 0xac), fVar4, fVar3, FLOAT_8032fcf0, FLOAT_8032fcf0);
+		                  *(float*)((char*)this + 0xac),
+		                  (float)(DOUBLE_8032fce8 * (double)fVar3),
+		                  (float)((double)FLOAT_8032fcf0 * (double)fVar3),
+		                  FLOAT_8032fcf0, FLOAT_8032fcf0);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Refined `CMapShadow::Init()` in `src/mapshadow.cpp` to better match expected MWCC codegen while keeping behavior unchanged.
- Replaced ad-hoc integer-to-double casting with a small `U32ToFloatViaDouble` helper using the existing 0x4330 conversion idiom.
- Inlined branch-local light scale expressions in the `C_MTXLightOrtho` / `C_MTXLightFrustum` calls to better reflect likely original source structure.

## Functions improved
- Unit: `main/mapshadow`
- Symbol: `Init__10CMapShadowFv` (`CMapShadow::Init()`)

## Match evidence
- `Init__10CMapShadowFv`: **6.220339% -> 30.728813%** (`+24.508474`)
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/mapshadow -o - Init__10CMapShadowFv`
- Neighboring symbols in the same unit remained unchanged:
  - `CMapShadowInsertOctTree__FQ210CMapShadow6TARGETR8COctTree`: `60.508476% -> 60.508476%`
  - `Draw__10CMapShadowFv`: `91.541664% -> 91.541664%`
  - `Calc__10CMapShadowFv`: `93.809525% -> 93.809525%`

## Plausibility rationale
- The change uses a standard GameCube-era numeric conversion idiom already present elsewhere in this repo, rather than contrived compiler coaxing.
- Control-flow and APIs are unchanged; edits only reshape expression form and temporary usage in a way consistent with decompilation cleanup toward plausible original source.

## Technical details
- Added:
  - `static inline float U32ToFloatViaDouble(u32 value, double bias)`
- Updated `CMapShadow::Init()`:
  - `fVar1/fVar2` now come from helper conversion.
  - Removed one temporary (`fVar4`) and moved scale calculations directly into the light matrix calls.
