### PR TITLE
p_gba: improve create__7CGbaPcsFv match via execParam compare form

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -72,7 +72,7 @@ void CGbaPcs::create()
 	m_stage = Memory.CreateStage(0x56000, "CGbaPcs", 0);
 	Joybus.CreateInit();
 	int result = Joybus.LoadBin();
-	if (result != 0 && System.m_execParam > 1) {
+	if (result != 0 && (unsigned int)System.m_execParam >= 2u) {
 		System.Printf("JoyBus::LoadBin() error");
 	}
 	Joybus.ThreadInit();


### PR DESCRIPTION
## Summary
- Updated `CGbaPcs::create()` in `src/p_gba.cpp` to use an unsigned threshold form for the existing debug-print gate.
- No behavioral intent change: still gates `System.Printf("JoyBus::LoadBin() error")` on nonzero `LoadBin()` result and exec-param level.

## Functions improved
- Unit: `main/p_gba`
- Symbol: `create__7CGbaPcsFv`
- Match: **85.871796% -> 89.46154%** (`+3.589744`)
- Size: `156b` (unchanged)

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/p_gba -o - create__7CGbaPcsFv`
- Before: `85.871796%`
- After: `89.46154%`
- Diff profile tightened from broader structural mismatches to mostly register/arg-level differences.

## Plausibility rationale
- The change aligns with existing codebase style in Joybus paths that already use explicit unsigned compare forms against `System.m_execParam`.
- This is source-plausible cleanup (type/compare expression shaping), not contrived control-flow distortion.

## Technical details
- Replaced `System.m_execParam > 1` with `(unsigned int)System.m_execParam >= 2u` in `CGbaPcs::create()`.
- Build verified with `ninja` after edit.
