### PR TITLE
Improve pppYmDeformationMdl construct2/frame decomp match

### DIFF
--- a/include/ffcc/pppYmDeformationMdl.h
+++ b/include/ffcc/pppYmDeformationMdl.h
@@ -5,15 +5,21 @@
 
 // Forward declarations
 struct VYmDeformationMdl;
-struct UnkB;
 
 struct UnkC {
     s32* m_serializedDataOffsets;
 };
 
+struct UnkB {
+    s32 m_graphId;
+    u16 m_dataValIndex;
+    s16 m_initWOrk;
+    f32 m_stepValue;
+    f32 m_arg3;
+    f32* m_payload;
+};
+
 struct pppYmDeformationMdl {
-    u8* m_serializedData;
-    // Add padding for pppPObject structure + field_0x80 offset
     char pad[0x80];
 };
 
@@ -25,9 +31,9 @@ extern "C" {
 #endif
 
 void pppConstructYmDeformationMdl(pppYmDeformationMdl*, struct UnkC*);
-void pppConstruct2YmDeformationMdl(void);
+void pppConstruct2YmDeformationMdl(pppYmDeformationMdl*, struct UnkC*);
 void pppDestructYmDeformationMdl(void);
-void pppFrameYmDeformationMdl(void* pppYmDeformationMdl, void* param_2, void* param_3);
+void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* param_2, UnkC* param_3);
 void pppRenderYmDeformationMdl(void* pppYmDeformationMdl, void* param_2, void* param_3);
 
 #ifdef __cplusplus

--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -1,5 +1,10 @@
 #include "ffcc/pppYmDeformationMdl.h"
 
+extern int DAT_8032ed70;
+extern u8 DAT_8032ed78;
+
+extern void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
+
 /*
  * --INFO--
  * Address:	TODO
@@ -49,9 +54,19 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, str
  * Address:	TODO
  * Size:	TODO
  */
-void pppConstruct2YmDeformationMdl(void)
+void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, UnkC* param_2)
 {
-	// TODO
+    float fVar1;
+    int iVar2;
+
+    fVar1 = 1.0f;
+    iVar2 = param_2->m_serializedDataOffsets[2];
+    *(float*)((u8*)pppYmDeformationMdl_ + 0x8C + iVar2) = 1.0f;
+    *(float*)((u8*)pppYmDeformationMdl_ + 0x88 + iVar2) = fVar1;
+    *(float*)((u8*)pppYmDeformationMdl_ + 0x84 + iVar2) = fVar1;
+    *(float*)((u8*)pppYmDeformationMdl_ + 0x98 + iVar2) = fVar1;
+    *(float*)((u8*)pppYmDeformationMdl_ + 0x94 + iVar2) = fVar1;
+    *(float*)((u8*)pppYmDeformationMdl_ + 0x90 + iVar2) = fVar1;
 }
 
 /*
@@ -77,9 +92,34 @@ void pppDestructYmDeformationMdl(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameYmDeformationMdl(void* pppYmDeformationMdl, void* param_2, void* param_3)
+void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+    s16* psVar1;
+
+    if ((DAT_8032ed70 == 0) && (param_2->m_dataValIndex != 0xFFFF)) {
+        psVar1 = (s16*)((u8*)pppYmDeformationMdl + 0x80 + param_3->m_serializedDataOffsets[2]);
+
+        CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+            (float)param_2->m_initWOrk, pppYmDeformationMdl, param_2->m_graphId, (float*)(psVar1 + 2),
+            (float*)(psVar1 + 4), (float*)(psVar1 + 6), &param_2->m_stepValue, &param_2->m_arg3);
+        CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+            *param_2->m_payload, pppYmDeformationMdl, param_2->m_graphId, (float*)(psVar1 + 8),
+            (float*)(psVar1 + 10), (float*)(psVar1 + 0xC), param_2->m_payload + 1, param_2->m_payload + 2);
+
+        if (DAT_8032ed78 == 0) {
+            if (*(u8*)(psVar1 + 1) == 0) {
+                *psVar1 = *psVar1 - (s16)(int)*(float*)(psVar1 + 8);
+                if ((int)*psVar1 < -(int)(s16)param_2->m_payload[3]) {
+                    *(u8*)(psVar1 + 1) = 1;
+                }
+            } else {
+                *psVar1 = *psVar1 + (s16)(int)*(float*)(psVar1 + 8);
+                if ((s16)param_2->m_payload[3] < *psVar1) {
+                    *(u8*)(psVar1 + 1) = 0;
+                }
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added concrete `UnkB` step layout and corrected function signatures for `pppConstruct2YmDeformationMdl` and `pppFrameYmDeformationMdl` in `pppYmDeformationMdl` interfaces.
- Implemented `pppConstruct2YmDeformationMdl` work initialization using serialized-data offset writes that mirror the existing construct path.
- Implemented first-pass `pppFrameYmDeformationMdl` graph update logic and short-state ping-pong behavior based on payload thresholds.

## Functions improved
Unit: `main/pppYmDeformationMdl`
- `pppConstruct2YmDeformationMdl`: **8.333333% -> 86.916664%**
- `pppFrameYmDeformationMdl`: **1.2987013% -> 27.246754%**
- `pppConstructYmDeformationMdl`: unchanged at 99.625%
- `pppRenderYmDeformationMdl`: unchanged at 0.28901735%

## Match evidence
Measured with:
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o /tmp/ffcc_before_ym_unit.json --format json-pretty`
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o /tmp/ffcc_after_ym_unit.json --format json-pretty`

The diff moved two previously near-stubbed symbols into substantial instruction alignment, indicating real assembly convergence rather than formatting-only changes.

## Plausibility rationale
- The updated signatures and field usage follow established PPP step/data patterns already present in nearby units.
- The frame logic uses straightforward graph-driven state updates and bounded oscillation on a short work value, which is consistent with source-style gameplay effect code.
- No artificial compiler-coaxing constructs were added; changes are readable and reflect likely original intent.

## Validation
- `ninja` passes for PAL (`GCCP01`).
