### PR TITLE
gx: improve GXSetCopyClear match in GXFrameBuf

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -322,21 +322,13 @@ void GXSetCopyClear(GXColor clear_clr, u32 clear_z) {
     CHECK_GXBEGIN(1596, "GXSetCopyClear");
     ASSERTMSGLINE(1598, clear_z <= 0xFFFFFF, "GXSetCopyClear: Z clear value is out of range");
 
-    reg = 0;
-    SET_REG_FIELD(1601, reg, 8, 0, clear_clr.r);
-    SET_REG_FIELD(1602, reg, 8, 8, clear_clr.a);
-    SET_REG_FIELD(1602, reg, 8, 24, 0x4F);
+    reg = ((u32)clear_clr.a << 8) | clear_clr.r | 0x4F000000;
     GX_WRITE_RAS_REG(reg);
 
-    reg = 0;
-    SET_REG_FIELD(1607, reg, 8, 0, clear_clr.b);
-    SET_REG_FIELD(1608, reg, 8, 8, clear_clr.g);
-    SET_REG_FIELD(1608, reg, 8, 24, 0x50);
+    reg = ((u32)clear_clr.g << 8) | clear_clr.b | 0x50000000;
     GX_WRITE_RAS_REG(reg);
 
-    reg = 0;
-    SET_REG_FIELD(1613, reg, 24, 0, clear_z);
-    SET_REG_FIELD(1613, reg, 8, 24, 0x51);
+    reg = (clear_z & 0xFFFFFF) | 0x51000000;
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
## Summary
- Reworked `GXSetCopyClear` in `src/gx/GXFrameBuf.c` to build BP words with direct bit packing instead of repeated `SET_REG_FIELD` calls.
- Kept behavior identical: same three BP register writes (`0x4F`, `0x50`, `0x51` payloads), same range assert, and same `bpSentNot` invalidation.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Symbol: `GXSetCopyClear`

## Match evidence
- `GXSetCopyClear`: **25.692308% -> 60.884617%** (`+35.192309`)
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetCopyClear | jq -r '.left.symbols[] | select(.name=="GXSetCopyClear") | .match_percent'`
- Nearby check (no regression in inspected neighbors):
  - `GXSetCopyFilter`: `42.630436%` (unchanged)
  - `GXSetDispCopyGamma`: `53.42857%` (unchanged)

## Plausibility rationale
- The new code matches expected SDK-style source for this routine: direct packing of 8-bit color fields and 24-bit Z into BP words, then writing via `GX_WRITE_RAS_REG`.
- This is source-plausible and cleaner than coercive temporaries; it removes macro expansion noise without introducing unnatural control flow.

## Technical details
- Packed `A:R` into `0x4Fxxxxxx`, `G:B` into `0x50xxxxxx`, and masked `clear_z` into `0x51xxxxxx`.
- Preserved existing argument validation and state invalidation side effect.
