### PR TITLE
gx/GXFrameBuf: improve GXSetDispCopyDst match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -137,14 +137,19 @@ void GXSetTexCopySrc(u16 left, u16 top, u16 wd, u16 ht) {
 
 void GXSetDispCopyDst(u16 wd, u16 ht) {
     u16 stride;
+    u32 reg;
 
     ASSERTMSGLINE(1293, (wd & 0xF) == 0, "GXSetDispCopyDst: Width must be a multiple of 16");
     CHECK_GXBEGIN(1294, "GXSetDispCopyDst");
 
     stride = (int)wd * 2;
     __GXData->cpDispStride = 0;
-    SET_REG_FIELD(1300, __GXData->cpDispStride, 10,  0, (stride >> 5) );
-    SET_REG_FIELD(1300, __GXData->cpDispStride,  8, 24, 0x4D);
+    reg = __GXData->cpDispStride;
+    reg = (reg & 0xFFFFFC00) | ((u32)stride >> 5);
+    __GXData->cpDispStride = reg;
+    reg = __GXData->cpDispStride;
+    reg = (reg & 0x00FFFFFF) | 0x4D000000;
+    __GXData->cpDispStride = reg;
 }
 
 void GXSetTexCopyDst(u16 wd, u16 ht, GXTexFmt fmt, GXBool mipmap) {


### PR DESCRIPTION
## Summary
- Refined `GXSetDispCopyDst` in `src/gx/GXFrameBuf.c` to use explicit register-word updates instead of two `SET_REG_FIELD` macro calls for `cpDispStride`.
- Kept behavior identical while reshaping generated code toward the target instruction pattern.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Symbol: `GXSetDispCopyDst`
- Match: `58.8% -> 84.13333%`
- Diff markers: `11 -> 9`

## Match evidence
- `objdiff` oneshot command:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetDispCopyDst`
- Unit `.text` match improved from `71.35519` to `71.808105`.

## Plausibility rationale
- The change stays source-plausible: it expresses straightforward register bitfield composition using temporary locals, with no contrived control flow or unnatural coercions.
- Semantics remain the same: clear register, set stride low bits, then set register ID in top byte.

## Technical details
- Introduced local `u32 reg` staging variable and performed two masked updates:
  - `(reg & 0xFFFFFC00) | ((u32)stride >> 5)`
  - `(reg & 0x00FFFFFF) | 0x4D000000`
- This reduced mismatch operations in the symbol while preserving ABI/signature and callsite behavior.
