### PR TITLE
MSL e_sqrt: align __ieee754_sqrt rounding tail with fdlibm

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/e_sqrt.c
+++ b/src/MSL_C/PPCEABI/bare/H/e_sqrt.c
@@ -3,6 +3,8 @@
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/errno.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/math.h"
 
+static const double one = 1.0, tiny = 1.0e-300;
+
 /*
  * --INFO--
  * PAL Address: 0x801D677C
@@ -105,19 +107,24 @@ double __ieee754_sqrt(double x) {
     }
 
     if ((ix0 | ix1) != 0) {
-        if (q1 == 0xffffffff) {
-            q1 = 0;
-            q += 1;
-        } else {
-            q1 += (q1 & 1);
+        z = one - tiny;
+        if (z >= one) {
+            z = one + tiny;
+            if (q1 == 0xffffffff) {
+                q1 = 0;
+                q += 1;
+            } else {
+                q1 += (q1 & 1);
+            }
         }
     }
 
-    ix0 = (q >> 1) + 0x3fe00000 + (m << 20);
+    ix0 = (q >> 1) + 0x3fe00000;
     ix1 = q1 >> 1;
     if ((q & 1) != 0) {
         ix1 |= 0x80000000;
     }
+    ix0 += (m << 20);
     __HI(z) = ix0;
     __LO(z) = ix1;
     return z;


### PR DESCRIPTION
## Summary
- Updated `src/MSL_C/PPCEABI/bare/H/e_sqrt.c` in `__ieee754_sqrt` to use the fdlibm-style inexact/rounding tail (`one`/`tiny` path) instead of the simplified integer-only final rounding block.
- Kept the core bit-by-bit sqrt algorithm intact; changes are limited to end-of-function rounding/exponent assembly sequencing.

## Functions Improved
- Unit: `main/MSL_C/PPCEABI/bare/H/e_sqrt`
- Function: `__ieee754_sqrt`

## Match Evidence
- Before: `89.18248%`
- After: `97.84672%`
- Delta: `+8.66424%`

Objdiff observations for `__ieee754_sqrt`:
- The updated tail now emits the expected floating-point inexact trigger sequence near function end (double store path), matching target control flow much more closely.
- Remaining diffs are primarily register-allocation / symbol-name differences (e.g. `errno`/`__float_nan` symbol naming), with substantially improved instruction alignment in the rounding tail.

## Plausibility Rationale
- This change restores canonical fdlibm behavior for sqrt final rounding/inexact handling, which is source-plausible for MSL math code.
- No contrived control-flow tricks or hardcoded offsets were introduced; the implementation remains idiomatic for fdlibm-derived math routines.

## Technical Details
- Added `static const double one = 1.0, tiny = 1.0e-300;`.
- Replaced final `(ix0|ix1)` handling with the fdlibm `one/tiny` rounding trigger block.
- Split final high-word assembly into:
  - `ix0 = (q >> 1) + 0x3fe00000;`
  - `ix0 += (m << 20);`
  to better align with target codegen ordering.
