### PR TITLE
Improve match for pppRandFloat

### DIFF
--- a/src/pppRandFloat.cpp
+++ b/src/pppRandFloat.cpp
@@ -32,35 +32,46 @@ struct RandFloatCtx {
  */
 void pppRandFloat(void* param1, void* param2, void* param3)
 {
-    int* base = (int*)param1;
-    int index = base[3];
+    int index;
+    int outputOffset;
+    RandFloatCtx* ctx;
+    RandFloatParam* data;
+    float* source;
+    float* output;
+    char* base;
+    float value;
 
-    if (lbl_8032ED70 == 0) {
-        RandFloatParam* data = (RandFloatParam*)param2;
-        RandFloatCtx* ctx = (RandFloatCtx*)param3;
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
 
-        if (index == 0) {
-            float out = RandF__5CMathFv(&math);
+    base = (char*)param1;
+    index = ((int*)base)[3];
+    ctx = (RandFloatCtx*)param3;
+    data = (RandFloatParam*)param2;
 
-            if (data->randomTwice != 0) {
-                out = out + RandF__5CMathFv(&math);
-            } else {
-                out = out * lbl_8032FF88;
-            }
-
-            *(float*)((char*)base + (*ctx->outputOffset + 0x80)) = out;
-        } else if (data->targetId == index) {
-            int outputOffset = *ctx->outputOffset;
-            int sourceOffset = data->sourceOffset;
-            float* source;
-
-            if (sourceOffset == -1) {
-                source = &lbl_801EADC8;
-            } else {
-                source = (float*)((char*)base + (sourceOffset + 0x80));
-            }
-
-            *source = *source + (data->blend * *(float*)((char*)base + (outputOffset + 0x80)) - data->blend);
+    if (index == 0) {
+        value = RandF__5CMathFv(&math);
+        if (data->randomTwice != 0) {
+            value += RandF__5CMathFv(&math);
+        } else {
+            value *= lbl_8032FF88;
         }
+
+        outputOffset = *ctx->outputOffset;
+        output = (float*)(base + outputOffset + 0x80);
+        *output = value;
+        return;
+    }
+
+    if (data->targetId == index) {
+        outputOffset = *ctx->outputOffset;
+        output = (float*)(base + outputOffset + 0x80);
+        if (data->sourceOffset == -1) {
+            source = &lbl_801EADC8;
+        } else {
+            source = (float*)(base + data->sourceOffset + 0x80);
+        }
+        *source = *source + (data->blend * *output - data->blend);
     }
 }


### PR DESCRIPTION
## Summary
- Refactored `pppRandFloat` control-flow to use early return on the global gate, then explicit `index == 0` and `targetId == index` paths.
- Reworked pointer/address calculations through local `base`, `output`, and `source` temporaries to better match original register and access patterns.
- Kept behavior plausible and source-like (no contrived asm-only constructs, no hardcoded object offsets beyond existing `+0x80` field convention already present in this unit).

## Functions improved
- Unit: `main/pppRandFloat`
- Function: `pppRandFloat` (PAL addr `0x80061d48`, size `268b`)

## Match evidence
- Before: `80.29851%` (`main/pppRandFloat` unit and `pppRandFloat` function)
- After: `81.82089%` (`main/pppRandFloat` unit and `pppRandFloat` function)
- Net: `+1.52238%`

## Plausibility rationale
- The update uses straightforward C++ structure: guard/return, then two logical execution paths.
- Type usage remains consistent with existing codebase patterns (`RandFloatParam`, `RandFloatCtx`, pointer-based field access).
- No readability regressions or compiler-coaxing-only artifacts were introduced.

## Technical details
- Matching improved by changing variable lifetimes and ordering so codegen aligns better with expected branch structure and memory access sequencing.
- Output/source address computations now use shared locals, reducing mismatched instruction shape from ad hoc casts.
