### PR TITLE
gx/GXBump: improve GXSetIndTexOrder match

### DIFF
--- a/src/gx/GXBump.c
+++ b/src/gx/GXBump.c
@@ -131,16 +131,17 @@ void GXSetIndTexCoordScale(GXIndTexStageID ind_state, GXIndTexScale scale_s, GXI
     __GXData->bpSentNot = 0;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801a4ebc
+ * PAL Size: 276b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void GXSetIndTexOrder(GXIndTexStageID ind_stage, GXTexCoordID tex_coord, GXTexMapID tex_map) {
     CHECK_GXBEGIN(302, "GXSetIndTexOrder");
-
-    if (tex_map == GX_TEXMAP_NULL) {
-        tex_map = GX_TEXMAP0;
-    }
-
-    if (tex_coord == GX_TEXCOORD_NULL) {
-        tex_coord = GX_TEXCOORD0;
-    }
 
     ASSERTMSGLINE(314, tex_map < GX_MAX_TEXMAP, "GXSetIndTexOrder: Invalid direct texture Id");
     ASSERTMSGLINE(315, tex_coord < GX_MAX_TEXCOORD, "GXSetIndTexOrder: Invalid texture coord");


### PR DESCRIPTION
## Summary
- Removed the `GX_TEXMAP_NULL` and `GX_TEXCOORD_NULL` remap branches in `GXSetIndTexOrder`.
- Kept the existing validation/assert and stage switch updates intact.
- Added function metadata block with PAL address/size from decomp reference.

## Functions improved
- Unit: `main/gx/GXBump`
- Symbol: `GXSetIndTexOrder`

## Match evidence
- `GXSetIndTexOrder`: `58.318840% -> 67.246376%` (`+8.927536%`)
- `GXSetTevIndirect`: unchanged at `31.692308%`
- `GXSetIndTexMtx`: unchanged at `62.693180%`
- No other symbol regressions in `GXBump.o` from this change set.

## Plausibility rationale
- The updated function shape is closer to low-level target behavior (direct stage-field writes without pre-remapping NULL IDs) while preserving the function's core responsibilities.
- This is source-plausible for Nintendo SDK-style GX register setup code, where argument validity is asserted and register fields are updated directly.

## Technical details
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXBump -o - GXSetIndTexOrder`
- Diff showed localized assembly alignment improvement for `GXSetIndTexOrder` with no collateral drops in neighboring target symbols.