### PR TITLE
Decompile pppYmMoveCircle frame/construct with inferred data layout

### DIFF
--- a/include/ffcc/pppYmMoveCircle.h
+++ b/include/ffcc/pppYmMoveCircle.h
@@ -1,12 +1,34 @@
 #ifndef _FFCC_PPP_YMMOVECIRCLE_H_
 #define _FFCC_PPP_YMMOVECIRCLE_H_
 
+struct pppYmMoveCircle {
+    char m_padding[0xC];
+    int m_graphId;
+};
+
+struct pppYmMoveCircleStep {
+    int m_graphId;
+    float m_angle;
+    float m_angleStep;
+    float m_angleStepStep;
+    float m_radius;
+    float m_radiusStep;
+    float m_radiusStepStep;
+};
+
+struct pppYmMoveCircleOffsets {
+    int m_pad0;
+    int m_pad1;
+    int m_pad2;
+    int* m_serializedDataOffsets;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppConstructYmMoveCircle(void);
-void pppFrameYmMoveCircle(void);
+void pppConstructYmMoveCircle(struct pppYmMoveCircle* basePtr, struct pppYmMoveCircleOffsets* offsetData);
+void pppFrameYmMoveCircle(struct pppYmMoveCircle* basePtr, struct pppYmMoveCircleStep* stepData, struct pppYmMoveCircleOffsets* offsetData);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -4,42 +4,116 @@
 #include "dolphin/mtx.h"
 #include <math.h>
 
+struct pppYmMoveCircleWork {
+    f32 m_angle;
+    f32 m_angleStep;
+    f32 m_angleStepStep;
+    f32 m_angleStepStepStep;
+    f32 m_radius;
+    f32 m_radiusStep;
+    f32 m_radiusStepStep;
+    Vec m_center;
+    u8 m_hasInit;
+};
+
+extern s32 DAT_8032ed70;
+extern unsigned char* lbl_8032ED50;
+extern f32 lbl_801EC9F0[];
+extern f32 lbl_80330D78;
+extern f32 lbl_80330D7C;
+extern f32 lbl_80330D80;
+extern f32 lbl_80330D84;
+extern f32 lbl_80330D88;
+extern f32 lbl_80330D8C;
+extern f32 lbl_80330D90;
+
 /*
  * --INFO--
  * PAL Address: 0x800d183c
  * PAL Size: 300b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructYmMoveCircle(void)
+extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleOffsets* offsetData)
 {
     Vec temp1, temp2;
-    float angle;
-    
-    // PSVECSubtract call observed in assembly
+    pppYmMoveCircleWork* work = (pppYmMoveCircleWork*)((u8*)basePtr + *offsetData->m_serializedDataOffsets + 0x80);
+
     PSVECSubtract(&temp1, &temp2, &temp1);
-    
-    // PSVECNormalize call observed
     PSVECNormalize(&temp1, &temp1);
-    
-    // PSVECDotProduct and acos calls for angle calculation
-    angle = PSVECDotProduct(&temp1, &temp2);
-    angle = acos(angle);
+    work->m_angle = lbl_80330D90 * (f32)acos(PSVECDotProduct(&temp1, &temp2));
+
+    if (!((temp1.x <= lbl_80330D7C && temp1.z >= lbl_80330D7C) ||
+          (temp1.x > lbl_80330D7C && temp1.z < lbl_80330D7C))) {
+        work->m_angle = lbl_80330D78 - work->m_angle;
+    }
+
+    work->m_angleStep = lbl_80330D7C;
+    work->m_angleStepStep = lbl_80330D7C;
+    work->m_angleStepStepStep = lbl_80330D7C;
+    work->m_radius = lbl_80330D7C;
+    work->m_radiusStep = lbl_80330D7C;
+    work->m_radiusStepStep = lbl_80330D7C;
+    pppCopyVector(work->m_center, *(Vec*)((u8*)lbl_8032ED50 + 0x58));
+    work->m_hasInit = 0;
 }
 
 /*
  * --INFO--
- * PAL Address: 0x800d160c  
+ * PAL Address: 0x800d160c
  * PAL Size: 560b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameYmMoveCircle(void)
+extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleStep* stepData, pppYmMoveCircleOffsets* offsetData)
 {
-    Vec position;
-    float angleStep;
-    
-    // Vector operations observed in assembly
-    pppCopyVector(position, position);
-    
-    // Floating point math for circular movement
-    position.x += angleStep;
-    position.y += angleStep; 
-    position.z += angleStep;
+    pppYmMoveCircleWork* work;
+    Vec currentPos;
+    Vec nextPos;
+    s32 tableIndex;
+
+    if (DAT_8032ed70 != 0) {
+        return;
+    }
+
+    work = (pppYmMoveCircleWork*)((u8*)basePtr + *offsetData->m_serializedDataOffsets + 0x80);
+
+    work->m_radiusStep += work->m_radiusStepStep;
+    work->m_radius += work->m_radiusStep;
+    work->m_angleStep += work->m_angleStepStep;
+    work->m_angle += work->m_angleStep;
+
+    if (stepData->m_graphId == basePtr->m_graphId) {
+        work->m_radius += stepData->m_radius;
+        work->m_radiusStep += stepData->m_radiusStep;
+        work->m_radiusStepStep += stepData->m_radiusStepStep;
+        work->m_angle += stepData->m_angle;
+        work->m_angleStep += stepData->m_angleStep;
+        work->m_angleStepStep += stepData->m_angleStepStep;
+    }
+
+    if (work->m_angle > lbl_80330D78) {
+        work->m_angle -= lbl_80330D78;
+    }
+    if (work->m_angle < lbl_80330D7C) {
+        work->m_angle += lbl_80330D78;
+    }
+
+    tableIndex = (s32)((lbl_80330D80 * (lbl_80330D84 * work->m_angle)) / lbl_80330D88);
+    nextPos.x = (work->m_radius * *(f32*)((u8*)lbl_801EC9F0 + ((tableIndex + 0x4000) & 0xFFFC))) + work->m_center.x;
+    nextPos.y = *(f32*)((u8*)lbl_8032ED50 + 0xC);
+    nextPos.z = (work->m_radius * -(*(f32*)((u8*)lbl_801EC9F0 + (tableIndex & 0xFFFC)))) + work->m_center.z;
+
+    pppCopyVector(currentPos, *(Vec*)((u8*)lbl_8032ED50 + 0x8));
+    pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x48), currentPos);
+    pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x8), nextPos);
+
+    *(f32*)((u8*)lbl_8032ED50 + 0x84) = nextPos.x;
+    *(f32*)((u8*)lbl_8032ED50 + 0x94) = nextPos.y;
+    *(f32*)((u8*)lbl_8032ED50 + 0xA4) = nextPos.z;
+    pppSetFpMatrix((_pppMngSt*)lbl_8032ED50);
 }


### PR DESCRIPTION
## Summary
- Replaced placeholder implementations in `src/pppYmMoveCircle.cpp` with first-pass decompilation logic for the two PAL-targeted symbols.
- Updated `include/ffcc/pppYmMoveCircle.h` with concrete parameter/data structs and matching `extern "C"` prototypes.
- Implemented the observed serialized work-buffer access pattern (`base + *offset + 0x80`), motion accumulator updates, angle wrapping, sin-table position calculation, and matrix/position synchronization.

## Functions Improved
- `pppConstructYmMoveCircle`
- `pppFrameYmMoveCircle`

## Match Evidence
- `pppConstructYmMoveCircle`: **22.706667% -> 69.973335%**
- `pppFrameYmMoveCircle`: **13.364285% -> 73.36429%**
- `main/pppYmMoveCircle` `.text`: **16.623257% -> 72.1814%**
- Verified with:
  - `ninja` (build passes)
  - `build/tools/objdiff-cli diff -p . -u main/pppYmMoveCircle -o - pppConstructYmMoveCircle`

## Plausibility Rationale
- The rewrite follows source-plausible particle behavior used elsewhere in `pppYm*` units: serialized per-object work state, graph-id-gated step injection, accumulated velocity-style updates, angle normalization, and trig-table driven circular offsets.
- Changes avoid compiler-coaxing patterns and instead model consistent gameplay-side data flow through existing engine helpers (`pppCopyVector`, `pppSetFpMatrix`).

## Technical Details
- Construct path now initializes circle work state and center position from manager state while preserving the observed vector-angle setup calls.
- Frame path now:
  - exits early on global pause flag (`DAT_8032ed70`)
  - updates angle/radius accumulators in the observed order
  - applies optional graph-matched per-step deltas
  - computes circle offsets using the shared sine table (`lbl_801EC9F0`)
  - updates manager position/matrix translation fields and commits with `pppSetFpMatrix`
