### PR TITLE
Improve match for main/pppKeShpTail

### DIFF
--- a/src/pppKeShpTail.cpp
+++ b/src/pppKeShpTail.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/pppKeShpTail.h"
+#include "ffcc/pppPart.h"
+#include "dolphin/mtx.h"
 #include "dolphin/types.h"
 
 /*
@@ -10,46 +12,33 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail(void* r3, void* r5)
+void pppKeShpTail(void* obj, void* param_2)
 {
-	// Check global flag first
-	extern u32 lbl_8032ED70;
+	extern int lbl_8032ED70;
 	if (lbl_8032ED70 != 0) {
 		return;
 	}
-	
-	// Get data structures
-	u32* r5_ptr = (u32*)((u8*)r5 + 0xc);
-	u32* r3_ptr = (u32*)((u8*)r3 + 0xc);
-	u32 r4_val = *r5_ptr;
-	r4_val = *(u32*)r4_val;
-	
-	if (*r3_ptr == 0) {
-		// Load vector data from r3
-		float* vec_src = (float*)((u8*)r3 + 0x1c); // f2, f1, f0
-		float vec[3];
-		vec[0] = vec_src[0];    // 0x1c
-		vec[1] = vec_src[4];    // 0x2c  
-		vec[2] = vec_src[8];    // 0x3c
-		
-		// Call pppCopyVector 
-		extern void pppCopyVector__FR3Vec3Vec(void*, void*);
-		pppCopyVector__FR3Vec3Vec(vec, r3);
-		
-		// Get tail structure
-		u8* tail = (u8*)r3 + r4_val + 0x80;
-		u8 count = *tail;
-		
-		// Loop through tail elements
-		u8* current = tail + 8;
-		for (int i = 0; i < count; i++) {
-			pppCopyVector__FR3Vec3Vec(current, vec);
-			current += 12;
+
+	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
+	if (*(u32*)((u8*)obj + 0xc) == 0) {
+		Vec local_14;
+		Vec local_30;
+		local_14.x = *(f32*)((u8*)obj + 0x1c);
+		local_14.y = *(f32*)((u8*)obj + 0x2c);
+		local_14.z = *(f32*)((u8*)obj + 0x3c);
+		pppCopyVector(local_30, local_14);
+
+		u8* tail = (u8*)obj + serializedOffset + 0x80;
+		u8 count = tail[0];
+		u8* tailVec = tail + 8;
+		while (count != 0) {
+			pppCopyVector(*(Vec*)tailVec, local_30);
+			tailVec += 0xc;
+			count--;
 		}
 	}
-	
-	// Tail count management
-	u8* tail = (u8*)r3 + r4_val + 0x80;
+
+	u8* tail = (u8*)obj + serializedOffset + 0x80;
 	if (tail[1] == 0) {
 		tail[1] = tail[0];
 	}
@@ -65,25 +54,16 @@ void pppKeShpTail(void* r3, void* r5)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTailCon(void* r3, void* r4)
+void pppKeShpTailCon(void* obj, void* param_2)
 {
-	// Assembly analysis:
-	// lwz r5, 0xc(r4) -> r5 = *(u32*)(r4 + 0xc)
-	// lwz r5, 0x0(r5) -> r5 = *(u32*)r5  
-	// addi r5, r5, 0x80 -> r5 = r5 + 0x80
-	// add r5, r3, r5 -> r5 = r3 + r5
-	// Zero out bytes at offsets 2,4,6,1 and set byte 0 to 31
-	
-	u32* ptr4 = (u32*)((u8*)r4 + 0xc);
-	u32 offset = *ptr4;
-	offset = *(u32*)offset;
-	u8* target = (u8*)r3 + offset + 0x80;
-	
-	*(u16*)(target + 2) = 0;
-	*(u16*)(target + 4) = 0;
-	*(u16*)(target + 6) = 0;
-	*(u8*)(target + 1) = 0;
-	*(u8*)target = 31;
+	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
+	u8* tail = (u8*)obj + serializedOffset + 0x80;
+
+	*(u16*)(tail + 2) = 0;
+	*(u16*)(tail + 4) = 0;
+	*(u16*)(tail + 6) = 0;
+	tail[1] = 0;
+	tail[0] = 0x1f;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppKeShpTail` to use the existing `pppCopyVector(Vec&, Vec)` path and a decrementing tail loop that better matches original control flow.
- Kept pointer arithmetic/source structure plausible by using serialized offset lookup once and applying the same tail buffer semantics.
- Cleaned `pppKeShpTailCon` to equivalent direct field writes without analysis-comment artifacts.

## Functions improved
- Unit: `main/pppKeShpTail`
- Function: `pppKeShpTail`
  - Before: `42.967743%`
  - After: `75.80645%`

## Match evidence
- Objdiff (`build/tools/objdiff-cli diff -p . -u main/pppKeShpTail`):
  - `.text` match in unit:
    - Before: `52.853333%`
    - After: `80.0%`
- Build status: `ninja` succeeds after the change.

## Plausibility rationale
- The change aligns with existing codebase idioms (`pppCopyVector` by-value usage and serialized offset tail buffer handling) rather than introducing synthetic compiler-coax patterns.
- Control flow remains straightforward and behaviorally consistent (same global guard, tail init/decrement semantics, and copy propagation).

## Technical details
- Switched from pointer-style vector-copy call sites to `pppCopyVector` by-value calls, which materially changed codegen toward target assembly.
- Replaced index-increment loop with a countdown loop over `u8` tail count, reducing mismatch in loop shape and branch pattern.
