### PR TITLE
goout: implement SetMemCardError state flow

### DIFF
--- a/include/ffcc/goout.h
+++ b/include/ffcc/goout.h
@@ -26,7 +26,7 @@ public:
     void SetMemCardSaveBuff(void*);
     void GetMemCardResult();
     void CalcMemCardProc();
-    void SetMemCardError();
+    int SetMemCardError();
     void SetMenu(short, long);
     void SetMenuStr(long, int, ...);
     void CalcMenu();

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -83,12 +83,89 @@ void CGoOutMenu::CalcMemCardProc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8016c564
+ * PAL Size: 1156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGoOutMenu::SetMemCardError()
+int CGoOutMenu::SetMemCardError()
 {
-	// TODO
+    int result = 1;
+    const int memCardResult = field_0x4;
+
+    if (memCardResult == -5) {
+        field_0x36 = -1;
+        field_0x40 = 0;
+        field_0x44 = 1;
+        field_0x45 = 0;
+        field_0x34 = 3;
+        field_0x48 = 0;
+        field_0x3c = 0;
+    } else if (memCardResult < -5) {
+        if (memCardResult == -13 || memCardResult == -6) {
+            SetGoOutMode(3);
+            return 1;
+        }
+
+        if ((memCardResult == -999 || memCardResult == -1000) && field_0x1 == 1) {
+            field_0x36 = -1;
+            field_0x40 = 0;
+            field_0x44 = 1;
+        } else if (field_0x1 == 3) {
+            field_0x36 = -1;
+            field_0x40 = 0;
+            field_0x44 = 1;
+            field_0x45 = 0;
+            field_0x34 = 0xd;
+            field_0x48 = 0;
+            field_0x3c = 0;
+        } else if (field_0x1 == 2) {
+            field_0x36 = -1;
+            field_0x40 = 0;
+            field_0x44 = 1;
+            field_0x45 = 0;
+            field_0x34 = 0xf;
+            field_0x48 = 0;
+            field_0x3c = 0;
+        }
+    } else if (memCardResult == -1 || memCardResult == -3) {
+        field_0x36 = -1;
+        field_0x40 = 0;
+        field_0x44 = 1;
+        field_0x45 = 0;
+        field_0x34 = 1;
+        field_0x48 = 0;
+        field_0x3c = 0;
+    } else if (memCardResult == -2) {
+        field_0x36 = -1;
+        field_0x40 = 0;
+        field_0x44 = 1;
+        field_0x45 = 0;
+        field_0x34 = 2;
+        field_0x48 = 0;
+        field_0x3c = 0;
+    } else if (memCardResult == -4) {
+        if (field_0x1 != 1) {
+            field_0x36 = -1;
+            field_0x40 = 0;
+            field_0x44 = 1;
+            field_0x45 = 0;
+            field_0x34 = 0x13;
+            field_0x48 = 0;
+            field_0x3c = 0;
+        } else {
+            field_0x36 = -1;
+            field_0x40 = 0;
+            field_0x44 = 1;
+        }
+    } else if (memCardResult == 1) {
+        result = 0;
+    }
+
+    field_0x18 = 2;
+    return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGoOutMenu::SetMemCardError` in `src/goout.cpp` as a concrete memory-card error state handler instead of a TODO stub.
- Updated the function signature in `include/ffcc/goout.h` from `void` to `int` to match observed call/return behavior in decompilation flow.
- Added PAL metadata block for this function:
  - PAL Address: `0x8016c564`
  - PAL Size: `1156b`

## Functions improved
- Unit: `main/goout`
- Symbol: `SetMemCardError__10CGoOutMenuFv`
- Size: `1156b`

## Match evidence
- objdiff before: `0.34602076%`
- objdiff after: `25.730104%`
- Delta: `+25.38408324%`

Measured via:
```sh
build/tools/objdiff-cli diff -p . -u main/goout -o - SetMemCardError__10CGoOutMenuFv
```

## Plausibility rationale
- The implementation follows a plausible original high-level structure for memory-card error handling:
  - branches on memory-card result codes,
  - transitions go-out mode for specific errors,
  - updates menu-related state fields in grouped blocks.
- The code uses existing class members and existing menu-state conventions from this unit, avoiding compiler-coaxing patterns or artificial temporaries.

## Technical details
- Implemented the main control-flow cases visible in decompilation:
  - explicit handling for `-13`, `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `1`, `-999`, `-1000`.
  - shared post-processing state write to `field_0x18`.
- Kept the first pass focused on behavior/state flow to secure measurable assembly alignment before tackling deeper `MenuPcs` data access reconstruction.
