### PR TITLE
main/p_usb: improve SendDataCode match with stage-aware allocation

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -9,6 +9,8 @@
 char DAT_8032ec6c;
 int DAT_8032ec68;
 
+extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
+
 extern void* __vt__8CManager;
 extern void* lbl_801E8668;
 extern void* lbl_801E8830;
@@ -17,6 +19,8 @@ extern u32 lbl_801E869C[];
 extern u32 lbl_801E86A8[];
 extern u32 lbl_801E86B4[];
 extern CUSBPcs USBPcs;
+
+static char s_p_usb_cpp[] = "p_usb.cpp";
 
 
 /*
@@ -168,6 +172,15 @@ static inline unsigned int Swap32(unsigned int x)
     return __lwbrx((void*)&tmp, 4);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x8001ff6c
+ * PAL Size: 532b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 {
     unsigned int count      = (unsigned int)(elemSize * elemCount);
@@ -176,7 +189,7 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     // Prefer big stage if present, else small stage (matches target).
     CMemory::CStage* stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
 
-    unsigned int* packet  = new unsigned int[packetSize >> 2];
+    unsigned int* packet = (unsigned int*)__nwa__FUlPQ27CMemory6CStagePci(packetSize, stage, s_p_usb_cpp, 0x1ca);
     unsigned int* sendBuf = (unsigned int*)nullptr;
 
     int result = 0;
@@ -203,7 +216,7 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 
         unsigned int sendSize = Align32(packet[1]);
 
-        sendBuf = new unsigned int[sendSize >> 2];
+        sendBuf = (unsigned int*)__nwa__FUlPQ27CMemory6CStagePci(sendSize, stage, s_p_usb_cpp, 0x19e);
         memcpy(sendBuf, packet, sendSize);
 
         // Swap only the first two words (matches target doing lwbrx on [0] and [1]).


### PR DESCRIPTION
## Summary
- Updated `CUSBPcs::SendDataCode` in `src/p_usb.cpp` to allocate packet buffers with the stage-aware allocator used by original code paths.
- Added the standard function info block for `SendDataCode` with PAL address/size metadata.
- Kept behavior unchanged (same packet/header construction, copy, flush/invalidate, USB write/message flow, and cleanup).

## Functions improved
- Unit: `main/p_usb`
- Symbol: `SendDataCode__7CUSBPcsFiPvii`

## Match evidence
- `SendDataCode__7CUSBPcsFiPvii`: **60.18045% -> 70.95489%** (`+10.77444` points)
- Validation command used:
  - `build/tools/objdiff-cli diff -p . -u main/p_usb -o - SendDataCode__7CUSBPcsFiPvii`
- Build still succeeds:
  - `ninja`

## Plausibility rationale
- The target decomp for this function shows stage-aware array allocations via `__nwa__FUlPQ27CMemory6CStagePci` with `p_usb.cpp` file/line metadata.
- Switching from plain `new[]` to the stage allocator is source-plausible for this codebase (same allocator pattern is used in other USB-related modules) and matches expected memory-stage semantics.
- No contrived control-flow tricks were introduced; this is a straightforward allocator/API correction.

## Technical details
- Added `extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(...)` declaration.
- Added `static char s_p_usb_cpp[] = "p_usb.cpp"` and used line tags `0x1ca` and `0x19e` to align allocator callsites.
- Replaced two allocations in `SendDataCode`:
  - packet allocation (header+payload buffer)
  - send staging buffer allocation
- Other symbol baselines in the same unit remained stable in this pass:
  - `__sinit_p_usb_cpp`: 68.045456%
  - `IsBigAlloc__7CUSBPcsFi`: 77.72727%
