### PR TITLE
pppYmMelt: implement construct/destruct from serialized offsets

### DIFF
--- a/include/ffcc/pppYmMelt.h
+++ b/include/ffcc/pppYmMelt.h
@@ -2,6 +2,7 @@
 #define _FFCC_PPP_YMMELT_H_
 
 #include <dolphin/gx.h>
+#include <dolphin/types.h>
 
 struct PYmMelt
 {
@@ -13,6 +14,11 @@ struct VERTEX_DATA
 
 };
 
+struct PYmMeltDataOffsets {
+    u8 _pad[0xC];
+    s32* m_serializedDataOffsets;
+};
+
 void InitPolygonData(PYmMelt*, VERTEX_DATA*, short);
 void CalcPolygonHeight(PYmMelt*, VERTEX_DATA*, _GXColor*, float);
 
@@ -20,8 +26,8 @@ void CalcPolygonHeight(PYmMelt*, VERTEX_DATA*, _GXColor*, float);
 extern "C" {
 #endif
 
-void pppConstructYmMelt(void);
-void pppDestructYmMelt(void);
+void pppConstructYmMelt(PYmMelt*, PYmMeltDataOffsets*);
+void pppDestructYmMelt(PYmMelt*, PYmMeltDataOffsets*);
 void pppFrameYmMelt(void);
 void pppRenderYmMelt(void);
 

--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -1,4 +1,7 @@
 #include "ffcc/pppYmMelt.h"
+#include "ffcc/pppPart.h"
+
+extern float lbl_80330AF0;
 
 /*
  * --INFO--
@@ -22,22 +25,45 @@ void CalcPolygonHeight(PYmMelt*, VERTEX_DATA*, _GXColor*, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800A5D20
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructYmMelt(void)
+void pppConstructYmMelt(PYmMelt* pppYmMelt, PYmMeltDataOffsets* param_2)
 {
-	// TODO
+    f32 value = lbl_80330AF0;
+    u8* work = (u8*)pppYmMelt + *param_2->m_serializedDataOffsets + 0x80;
+
+    *(u32*)(work + 0x0) = 0;
+    *(u16*)(work + 0x4) = 0;
+    *(u16*)(work + 0xA) = 0;
+    *(u16*)(work + 0x8) = 0;
+    *(u16*)(work + 0x6) = 0;
+
+    *(f32*)(work + 0x14) = value;
+    *(f32*)(work + 0x10) = value;
+    *(f32*)(work + 0xC) = value;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800A5CE8
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDestructYmMelt(void)
+void pppDestructYmMelt(PYmMelt* pppYmMelt, PYmMeltDataOffsets* param_2)
 {
-	// TODO
+    CMemory::CStage* stage =
+        *(CMemory::CStage**)((u8*)pppYmMelt + *param_2->m_serializedDataOffsets + 0x80);
+    if (stage != nullptr) {
+        pppHeapUseRate(stage);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppConstructYmMelt` and `pppDestructYmMelt` in `src/pppYmMelt.cpp` using serialized-offset based state access (`+0x80`) and heap stage cleanup behavior.
- Updated `include/ffcc/pppYmMelt.h` with a concrete `PYmMeltDataOffsets` layout and corrected construct/destruct function signatures.
- Added PAL metadata blocks for both implemented functions.

## Functions Improved
- `main/pppYmMelt::pppConstructYmMelt`: **6.6667% -> 100.0%** fuzzy match
- `main/pppYmMelt::pppDestructYmMelt`: **7.1429% -> 100.0%** fuzzy match
- Unit `main/pppYmMelt`: **0.6378% -> 4.0816%** fuzzy match

## Match Evidence
- `ninja` progress increased matched code functions from **1256 -> 1258**.
- `objdiff` for `pppConstructYmMelt` now shows instruction-level alignment including the single `lfs lbl_80330AF0@sda21` load and matching store sequence.
- `objdiff` for `pppDestructYmMelt` now fully matches the expected `lwzx` + null check + `pppHeapUseRate` call flow.

## Plausibility Rationale
- The changes follow established `ppp*` source patterns already used in the repo (`serializedDataOffsets` indirection and `+0x80` object-local work area).
- Cleanup behavior via `pppHeapUseRate` is consistent with adjacent particle/effect units.
- No compiler-coaxing constructs were introduced; implementation is straightforward and source-plausible.
