### PR TITLE
pppMiasma: implement constructor state clears

### DIFF
--- a/include/ffcc/pppMiasma.h
+++ b/include/ffcc/pppMiasma.h
@@ -40,9 +40,9 @@ void CreateScaleMatrix(_pppPObject*, float);
 extern "C" {
 #endif
 
-void pppRenderMiasma(void);
-void pppConstructMiasma(void);
-void pppConstruct2Miasma(void);
+void pppRenderMiasma(pppMiasma*, void*, pppMiasmaCtrl*);
+void pppConstructMiasma(pppMiasma*, pppMiasmaCtrl*);
+void pppConstruct2Miasma(pppMiasma*, pppMiasmaCtrl*);
 void pppDestructMiasma(void);
 void pppFrameMiasma(pppMiasma*, pppMiasmaFrameStep*, pppMiasmaCtrl*);
 

--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/pppMiasma.h"
 
+#include <string.h>
+
 extern int DAT_8032ed70;
 
 /*
@@ -24,22 +26,35 @@ void CreateScaleMatrix(_pppPObject*, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80109b6c
+ * PAL Size: 5604b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppRenderMiasma(void)
+void pppRenderMiasma(pppMiasma*, void*, pppMiasmaCtrl*)
 {
 	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80109b08
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructMiasma(void)
+void pppConstructMiasma(pppMiasma* pppMiasma, pppMiasmaCtrl* param_2)
 {
-	// TODO
+    u8* work;
+
+    work = (u8*)pppMiasma + 0x80 + param_2->m_serializedDataOffsets[2];
+    memset(work, 0, 8);
+    memset(work + 8, 0, 8);
+    memset(work + 0x10, 0, 8);
 }
 
 /*
@@ -51,9 +66,14 @@ void pppConstructMiasma(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppConstruct2Miasma(void)
+void pppConstruct2Miasma(pppMiasma* pppMiasma, pppMiasmaCtrl* param_2)
 {
-	return;
+    u8* work;
+
+    work = (u8*)pppMiasma + 0x80 + param_2->m_serializedDataOffsets[2];
+    memset(work, 0, 8);
+    memset(work + 8, 0, 8);
+    memset(work + 0x10, 0, 8);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `pppMiasma` constructor signatures to use object/control parameters consistent with other `ppp*` units.
- Implemented `pppConstructMiasma` and `pppConstruct2Miasma` initialization logic as three 8-byte clears at the serialized work offset.
- Added PAL address/size metadata for `pppConstructMiasma` and `pppRenderMiasma` comments.

## Functions Improved
- Unit: `main/pppMiasma`
- `pppConstructMiasma`: `4.0%` -> `99.4%` (`100b`)
- `pppConstruct2Miasma`: `4.0%` -> `99.4%` (`100b`)

## Match Evidence
- Command: `build/tools/objdiff-cli diff -p . -u main/pppMiasma -o - pppConstructMiasma`
- Unit `.text` match: `6.205311%` -> `9.294689%`
- Remaining constructor diffs are only `DIFF_ARG_MISMATCH` on `bl memset` calls (relocation/arg-level, not control-flow divergence).

## Plausibility Rationale
- The new code follows a straightforward constructor pattern used throughout the codebase: initialize per-instance serialized state with deterministic zeroing.
- The layout basis (`(u8*)obj + 0x80 + offset`) is already used in the existing matched `pppFrameMiasma` implementation, so this does not introduce contrived coercion.
- No artificial reordering or compiler-coaxing temporaries were added.

## Technical Details
- Pointer target: `work = (u8*)pppMiasma + 0x80 + param_2->m_serializedDataOffsets[2]`
- Initialization sequence:
  - `memset(work, 0, 8)`
  - `memset(work + 8, 0, 8)`
  - `memset(work + 0x10, 0, 8)`
- Verified build with `ninja` after changes.
