### PR TITLE
gx: improve GXGetViewportv decomp match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -471,12 +471,12 @@ void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz,
 void GXGetViewportv(f32* vp) {
     ASSERTMSGLINE(968, vp, "GXGet*: invalid null pointer");
 
-    ((u32*)vp)[0] = ((u32*)&__GXData->vpLeft)[0];
-    ((u32*)vp)[1] = ((u32*)&__GXData->vpLeft)[1];
-    ((u32*)vp)[2] = ((u32*)&__GXData->vpLeft)[2];
-    ((u32*)vp)[3] = ((u32*)&__GXData->vpLeft)[3];
-    ((u32*)vp)[4] = ((u32*)&__GXData->vpLeft)[4];
-    ((u32*)vp)[5] = ((u32*)&__GXData->vpLeft)[5];
+    vp[0] = __GXData->vpLeft;
+    vp[1] = __GXData->vpTop;
+    vp[2] = __GXData->vpWd;
+    vp[3] = __GXData->vpHt;
+    vp[4] = __GXData->vpNearz;
+    vp[5] = __GXData->vpFarz;
 }
 
 #define GX_WRITE_XF_REG_F_(addr, value) \


### PR DESCRIPTION
## Summary
- Updated `GXGetViewportv` in `src/gx/GXTransform.c` to copy viewport state via direct `f32` assignments instead of bitwise `u32` aliasing.
- Kept API and behavior unchanged; this is a representation-level cleanup that better matches likely original SDK source style.

## Functions improved
- Unit: `main/gx/GXTransform`
- Function: `GXGetViewportv`

## Match evidence
- `GXGetViewportv`: **48.214287% -> 99.21429%**
- Neighbor checks (no regression):
  - `GXSetViewportJitter`: 33.4% (unchanged)
  - `GXProject`: 60.80645% (unchanged)

## Plausibility rationale
- The revised implementation is more idiomatic original source for Dolphin GX: viewport fields are floats and should be copied as floats.
- Removing strict-aliasing-style integer reinterpret copies reduces compiler artifacts and aligns better with expected `lfs/stfs` codegen.

## Technical details
- Prior code used `((u32*)vp)[i] = ((u32*)&__GXData->vpLeft)[i]`, producing mismatched instruction forms.
- New code uses:
  - `vp[0] = __GXData->vpLeft;`
  - `vp[1] = __GXData->vpTop;`
  - `vp[2] = __GXData->vpWd;`
  - `vp[3] = __GXData->vpHt;`
  - `vp[4] = __GXData->vpNearz;`
  - `vp[5] = __GXData->vpFarz;`
- Rebuilt with `ninja` and verified with `build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXGetViewportv`.
