### PR TITLE
main/OdemuExi2: improve DBRead match in DebuggerDriver

### DIFF
--- a/src/OdemuExi2/DebuggerDriver.c
+++ b/src/OdemuExi2/DebuggerDriver.c
@@ -258,16 +258,10 @@ static void DBGHandler(s16 a, OSContext* b) {
 
 void DBInitComm(u8** a, MTRCallbackType b) {
     BOOL interrupts = OSDisableInterrupts();
-    {
-        pEXIInputFlag = (u8*)EXIInputFlag;
-        pEXIInputFlag = &EXIInputFlag;
-
-        *a = pEXIInputFlag;
-
-        MTRCallback = b;
-
-        DBGEXIInit();
-    }
+    pEXIInputFlag = &EXIInputFlag;
+    *a = pEXIInputFlag;
+    MTRCallback = b;
+    DBGEXIInit();
     OSRestoreInterrupts(interrupts);
 }
 
@@ -306,9 +300,15 @@ u32 DBQueryData(void) {
 
 BOOL DBRead(u32* buffer, s32 count) {
     u32 interrupts = OSDisableInterrupts();
-    u32 v = SendMailData & 0x10000 ? 0x1000 : 0;
+    u32 v;
 
-    DBGRead(v + 0x1e000, buffer, ROUND_UP(count, 4));
+    if ((SendMailData & 0x10000) == 0) {
+        v = 0;
+    } else {
+        v = 0x1000;
+    }
+
+    DBGRead(v + 0x1e000, buffer, (count + 3U) & ~3U);
 
     RecvDataLeng = 0;
     EXIInputFlag = 0;


### PR DESCRIPTION
## Summary
- Refactored `DBRead` in `src/OdemuExi2/DebuggerDriver.c` to use explicit branch form for mailbox offset selection and explicit 4-byte rounding expression.
- Simplified `DBInitComm` by removing an implausible redundant assignment while preserving behavior.

## Functions improved
- Unit: `main/OdemuExi2/DebuggerDriver`
- Function: `DBRead`
  - Before: `45.085712%`
  - After: `51.057144%`
  - Size: `140b` (unchanged)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/OdemuExi2/DebuggerDriver -o - DBRead`
  - Match increase: `+5.971432` percentage points
  - Diff markers in symbol stream reduced (`31 -> 30`)
- Unit `.text` match percent:
  - Before: `51.25595%`
  - After: `51.566963%`

## Plausibility rationale
- The new `DBRead` structure matches conventional original-source style for SDK-era code (explicit conditionals and direct alignment math), instead of relying on compact ternary/macro expansion.
- `DBInitComm` now expresses the intended global-pointer initialization directly and removes a redundant cast/assignment sequence that is unlikely to be authored intentionally.

## Technical details
- Kept ABI and behavior intact (same parameter types, same call sequence, same side effects).
- Verified with full `ninja` rebuild and objdiff symbol-level checks.
