### PR TITLE
main/memory: implement __dl/__dla wrappers using Memory::Free

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -38,6 +38,38 @@ void* operator new[](unsigned long size, CMemory::CStage* stage, char* file, int
 
 /*
  * --INFO--
+ * PAL Address: 0x8001FC24
+ * PAL Size: 296b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void operator delete(void* ptr) throw()
+{
+    if (ptr != (void*)nullptr) {
+        Memory.Free(ptr);
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FAFC
+ * PAL Size: 296b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void operator delete[](void* ptr) throw()
+{
+    if (ptr != (void*)nullptr) {
+        Memory.Free(ptr);
+    }
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added `operator delete(void*)` and `operator delete[](void*)` implementations in `src/memory.cpp`.
- Both operators now route through `Memory.Free(ptr)` with null guards, matching the project’s memory manager ownership model.
- Added PAL address/size INFO blocks for both functions.

## Functions improved
- Unit: `main/memory`
- `__dl__FPv` (operator delete): previously unmatched in this unit, now matched at 11.581081% in objdiff (12.324325% fuzzy in report).
- `__dla__FPv` (operator delete[]): previously unmatched in this unit, now matched at 11.581081% in objdiff (12.324325% fuzzy in report).

## Match evidence
- `main/memory` `.text` match: **2.012339% -> 2.1617222%** (`objdiff-cli diff -u main/memory`).
- `__dl__FPv`: **n/a (no target binding) -> 11.581081%**.
- `__dla__FPv`: **n/a (no target binding) -> 11.581081%**.
- Build verified with `ninja`.

## Plausibility rationale
- Routing delete operators through `CMemory` is source-plausible for FFCC’s custom allocator architecture.
- The change avoids contrived compiler-coaxing patterns and expresses expected engine ownership semantics directly.

## Technical details
- Implemented both operators in `memory.cpp` near the custom stage-aware new/new[] overloads.
- Used null checks before forwarding to `Memory.Free` to preserve standard delete behavior.
- `__sinit_memory_cpp` remains unmatched and is intentionally untouched in this PR.
