### PR TITLE
cflat_r2system: add 3 matched system wrapper accessors

### DIFF
--- a/include/ffcc/p_camera.h
+++ b/include/ffcc/p_camera.h
@@ -66,6 +66,7 @@ public:
     void drawShadowEnd();
     void drawShadowChrBegin();
     void SetFullScreenShadow(float (*)[4], long);
+    void SetFullScreenShadowCamLen(float);
     void drawShadowEndAll();
 
     // Material editor

--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -206,6 +206,7 @@ public:
     void GetMaxAnimWait();
     void BindMcObj();
     void DrawFilter(unsigned char, unsigned char, unsigned char, unsigned char);
+    CFont* GetFont22();
     void CopyNowCaravanDat(Mc::SaveDat*);
     void SetCaravanWork(Mc::SaveDat*);
     void GetSameCharaData(Mc::SaveDat*, Mc::SaveDat*, int, int);

--- a/include/ffcc/sound.h
+++ b/include/ffcc/sound.h
@@ -19,6 +19,7 @@ public:
     void SetStereo(int);
     void SetBgmMasterVolume(int);
     void SetSeMasterVolume(int);
+    void SeMaxVolume(int);
     void create(int);
     void destroy();
     void Realloc(int);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1,5 +1,8 @@
 #include "ffcc/cflat_r2system.h"
 #include "ffcc/game.h"
+#include "ffcc/p_camera.h"
+#include "ffcc/p_menu.h"
+#include "ffcc/sound.h"
 
 /*
  * --INFO--
@@ -13,6 +16,48 @@
 void CGame::SetNextScriptNewGame()
 {
     m_nextScript.m_flags = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8F90
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetFullScreenShadowCamLen(float len)
+{
+    *(float*)((char*)this + 0x430) = len;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8F98
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CFont* CMenuPcs::GetFont22()
+{
+    return *(CFont**)((char*)this + 0xF8);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8FA0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CSound::SeMaxVolume(int volume)
+{
+    *(int*)((char*)this + 0x22BC) = volume;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added three missing C++ methods used by `main/cflat_r2system` system scripting wrappers.
- Declared and implemented:
  - `CCameraPcs::SetFullScreenShadowCamLen(float)`
  - `CMenuPcs::GetFont22()`
  - `CSound::SeMaxVolume(int)`
- Implementations mirror the recovered PAL 8-byte behaviors from Ghidra references and are documented with PAL address/size blocks.

## Functions Improved
Unit: `main/cflat_r2system`

- `SetFullScreenShadowCamLen__10CCameraPcsFf`: `0.0% -> 100.0%` (8b)
- `GetFont22__8CMenuPcsFv`: `0.0% -> 100.0%` (8b)
- `SeMaxVolume__6CSoundFi`: `0.0% -> 100.0%` (8b)

## Match Evidence
- Build succeeds with `ninja`.
- Verified with one-shot objdiff:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - SetFullScreenShadowCamLen__10CCameraPcsFf`
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - GetFont22__8CMenuPcsFv`
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - SeMaxVolume__6CSoundFi`
- Extracted symbol results show `match_percent: 100.0` for all three symbols.

## Plausibility Rationale
- These are canonical tiny accessor/mutator wrappers (single field load/store), a common original-source pattern for engine subsystem state.
- Changes add missing named APIs to their owning classes rather than introducing contrived control flow.
- Behavior matches decomp intent exactly (single assignment/load, no side effects).

## Technical Details
- Added method declarations to:
  - `include/ffcc/p_camera.h`
  - `include/ffcc/p_menu.h`
  - `include/ffcc/sound.h`
- Implemented methods in `src/cflat_r2system.cpp` with PAL INFO headers:
  - `0x800B8F90` / `8b`
  - `0x800B8F98` / `8b`
  - `0x800B8FA0` / `8b`
