### PR TITLE
main/pppParHitSphMat: restore callback signature and hit flow

### DIFF
--- a/include/ffcc/pppParHitSphMat.h
+++ b/include/ffcc/pppParHitSphMat.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void pppParHitSphMat(void);
+void pppParHitSphMat(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }

--- a/src/pppParHitSphMat.cpp
+++ b/src/pppParHitSphMat.cpp
@@ -1,74 +1,65 @@
 #include "ffcc/pppParHitSphMat.h"
+#include "ffcc/graphic.h"
+#include "ffcc/partMng.h"
+#include "ffcc/pppPart.h"
+
+#include <dolphin/mtx.h>
+
+extern unsigned char* lbl_8032ED50;
+extern unsigned char CFlat[];
 
 /*
  * --INFO--
  * PAL Address: 0x8014139c
  * PAL Size: 436b
  */
-void pppParHitSphMat(void)
+void pppParHitSphMat(void* param1, void* param2, void* param3)
 {
-    extern int lbl_8032ED70;
-    extern void* lbl_80431DC0[];
-    extern float lbl_8032ED50[];
-    extern int lbl_80431E00;
-    extern float sqrtf(float);
-    
-    if (lbl_8032ED70 == 0) return;
-    
-    void* particle_data = lbl_80431DC0[0];
-    if (particle_data == 0) return;
-    
-    // Simple particle loop
-    for (int i = 0; i < lbl_80431E00; i++) {
-        void* current_particle = (void*)((unsigned char*)particle_data + i * 0x40);
-        if (current_particle == 0) continue;
-        
-        // Basic sphere collision check
-        void* sphere_data = (void*)((unsigned char*)current_particle + 0x20);
-        if (sphere_data == 0) continue;
-        
-        float* sphere_pos = (float*)sphere_data;
-        float radius = sphere_pos[3];
-        float radius_sq = radius * radius;
-        
-        // Simple distance check
-        float dx = 0.0f;  // TODO: Get from particle position
-        float dy = 0.0f;
-        float dz = 0.0f;
-        float dist_sq = dx * dx + dy * dy + dz * dz;
-        
-        if (dist_sq <= radius_sq) {
-            // Set collision flag
-            unsigned int* flags = (unsigned int*)((unsigned char*)current_particle + 0x8);
-            *flags |= 0x1;
-            
-            if (dist_sq > 0.001f) {
-                float dist = sqrtf(dist_sq);
-                float inv_dist = 1.0f / dist;
-                float nx = dx * inv_dist;
-                float ny = dy * inv_dist; 
-                float nz = dz * inv_dist;
-                
-                // Apply material matrix transform
-                float* matrix = &lbl_8032ED50[32];
-                float result_x = nx * matrix[0] + ny * matrix[4] + nz * matrix[8];
-                float result_y = nx * matrix[1] + ny * matrix[5] + nz * matrix[9];
-                float result_z = nx * matrix[2] + ny * matrix[6] + nz * matrix[10];
-                
-                // Update velocity
-                float* velocity = (float*)((unsigned char*)current_particle + 0x30);
-                float bounce = matrix[15];
-                velocity[0] = result_x * bounce;
-                velocity[1] = result_y * bounce;
-                velocity[2] = result_z * bounce;
-                
-                // Update color
-                unsigned char* color = (unsigned char*)((unsigned char*)current_particle + 0x3C);
-                color[0] = (unsigned char)(matrix[12] * 255.0f);
-                color[1] = (unsigned char)(matrix[13] * 255.0f);
-                color[2] = (unsigned char)(matrix[14] * 255.0f);
-                color[3] = 255;
-            }
-        }
+    s32* offsets = *(s32**)((u8*)param3 + 0xC);
+    Vec local_a0;
+    Vec local_94;
+    Vec local_88;
+    _GXColor local_7c;
+    Mtx MStack_78;
+    Mtx local_48;
+
+    local_88.x = 0.0f;
+    local_88.y = 0.0f;
+    local_88.z = 0.0f;
+
+    if (((u8*)param2)[0xC] != 0) {
+        Vec* src = (Vec*)((u8*)param1 + offsets[1] + 0x80);
+        PSMTXMultVec((MtxPtr)((u8*)lbl_8032ED50 + 0x78), src, &local_94);
+    } else {
+        local_94.x = *(f32*)((u8*)lbl_8032ED50 + 0x84);
+        local_94.y = *(f32*)((u8*)lbl_8032ED50 + 0x94);
+        local_94.z = *(f32*)((u8*)lbl_8032ED50 + 0xA4);
+
+        Vec* src = (Vec*)((u8*)param1 + offsets[1] + 0x80);
+        local_94.x = local_94.x + src->x;
+        local_94.y = local_94.y + src->y;
+        local_94.z = local_94.z + src->z;
+    }
+
+    if (*(f32*)((u8*)param2 + 4) != 0.0f) {
+        PSVECSubtract((Vec*)((u8*)lbl_8032ED50 + 8), (Vec*)((u8*)lbl_8032ED50 + 0x48), &local_88);
+    }
+
+    f32 radius = *(f32*)((u8*)lbl_8032ED50 + 0x64) * *(f32*)((u8*)param2 + 8);
+    pppHitCylinderSendSystem((_pppMngSt*)lbl_8032ED50, &local_94, &local_88, radius, *(f32*)((u8*)param2 + 4));
+
+    if ((*(u32*)(CFlat + 0x129c) & 0x200000) != 0) {
+        local_7c = *(_GXColor*)((u8*)param2 + 0xC);
+        PSMTXIdentity(MStack_78);
+        PSMTXIdentity(local_48);
+        local_48[0][0] = radius;
+        local_48[1][1] = radius;
+        local_48[2][2] = radius;
+        PSMTXConcat(ppvCameraMatrix0, MStack_78, MStack_78);
+        PSMTXMultVec(MStack_78, &local_94, &local_a0);
+        local_48[0][3] = local_a0.x;
+        local_48[1][3] = local_a0.y;
+        local_48[2][3] = local_a0.z;
+        Graphic.DrawSphere(local_48, local_7c);
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `pppParHitSphMat` from a placeholder/no-arg loop into a callback-style implementation aligned with existing particle collision codepaths.
- Corrected the function signature to the expected 3-argument callback form and updated the header declaration.
- Implemented the core flow using existing engine helpers: optional local->world transform, fallback world-position path, cylinder-hit dispatch, and debug sphere rendering.

## Functions improved
- Unit: `main/pppParHitSphMat`
- Symbol: `pppParHitSphMat`

## Match evidence
- Before: `15.385321%` (`build/tools/objdiff-cli diff -p . -u main/pppParHitSphMat -o - pppParHitSphMat`)
- After: `77.477066%` (`tools/objdiff-cli diff -p . -u main/pppParHitSphMat -o - pppParHitSphMat`)
- Size now aligns with target symbol size (`436` bytes reported for built symbol).

## Plausibility rationale
- The updated implementation follows existing nearby code (`pppParHitSph`) and established `ppp*` callback conventions in this repo.
- Changes are semantic and structural (correct call signature and runtime flow), not compiler-coaxing temporaries.
- Uses existing matrix/vector and hit APIs already used throughout particle modules.

## Technical details
- Updated declaration:
  - `void pppParHitSphMat(void* param1, void* param2, void* param3);`
- Replaced placeholder logic with:
  - serialized offset lookup from callback context (`param3 + 0xC`)
  - transform path via `PSMTXMultVec` when configured
  - fallback world-position composition from manager fields
  - hit dispatch through `pppHitCylinderSendSystem`
  - conditional debug draw path using `PSMTXIdentity`, `PSMTXConcat`, `PSMTXMultVec`, and `Graphic.DrawSphere`
- Verified build with `ninja`.
