### PR TITLE
pppCrystal2: improve pppDestructCrystal2 match to 99.97%

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -59,10 +59,10 @@ void pppConstructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
  */
 void pppDestructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
 {
-    CMemory::CStage* stage;
     u32* puVar1;
-    
-    puVar1 = (u32*)((char*)&pppCrystal2->field0_0x0 + 2*4 + param_2->m_serializedDataOffsets[2]);
+    CMemory::CStage* stage;
+
+    puVar1 = (u32*)((u8*)pppCrystal2 + param_2->m_serializedDataOffsets[2] + 8);
     stage = (CMemory::CStage*)puVar1[0];
     
     if ((CMemory::CStage*)puVar1[1] != 0) {


### PR DESCRIPTION
## Summary
- Updated `pppDestructCrystal2` pointer math to compute serialized data base from the object base pointer plus serialized offset (`+ 8`) directly.
- Reordered local declarations to better align register allocation with original codegen.

## Functions improved
- Unit: `main/pppCrystal2`
- Symbol: `pppDestructCrystal2`
- Size: `136b`

## Match evidence
- Before: `98.20588%`
- After: `99.97059%`
- Tool: `build/tools/objdiff-cli diff -p . -u main/pppCrystal2 -o - pppDestructCrystal2`

## Plausibility rationale
- The previous code derived the data pointer through `&pppCrystal2->field0_0x0` and emitted an extra constant offset in codegen.
- The new version uses direct object-base byte addressing with the serialized offset table, which is a simpler and more plausible original-source expression for this subsystem's serialized payload access pattern.
- No compiler-coaxing constructs were introduced; behavior remains equivalent while assembly alignment improves.

## Technical details
- The change removes an unintended base offset contribution in emitted address calculation.
- `objdiff` now shows a single residual argument mismatch only; all other instructions for `pppDestructCrystal2` match.
- Verified with full `ninja` build after reverting unrelated experiment branches.
