### PR TITLE
main/wind: implement CWind::AddAmbient

### DIFF
--- a/include/ffcc/wind.h
+++ b/include/ffcc/wind.h
@@ -27,7 +27,7 @@ public:
     void Calc(Vec*, const Vec*, int);
     void searchFreeObj();
     void getObj(int);
-    void AddAmbient(float, float);
+    int AddAmbient(float, float);
     int AddDiffuse(const Vec*, float, float, float);
     int AddSphere(const Vec*, float, float, int);
     void ChangePower(int, float);

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -37,6 +37,7 @@ extern double DOUBLE_80330f40;
 extern double DAT_8032ec20;
 extern char DAT_801db528[];
 extern char DAT_801db548[];
+extern char DAT_801db568[];
 
 /*
  * --INFO--
@@ -270,12 +271,84 @@ void CWind::getObj(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d96d8
+ * PAL Size: 360b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CWind::AddAmbient(float, float)
+int CWind::AddAmbient(float dir, float speed)
 {
-	// TODO
+	u8* freeObj = 0;
+	u8* scan = (u8*)this;
+
+	for (int group = 0; group < 4; group++) {
+		freeObj = scan;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 100;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 200;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 300;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 400;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 500;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 600;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		freeObj = scan + 700;
+		if ((s8)freeObj[0] >= 0) {
+			break;
+		}
+
+		scan += 800;
+		freeObj = 0;
+	}
+
+	if (freeObj == 0) {
+		System.Printf(DAT_801db568);
+		return -1;
+	}
+
+	*(s32*)(freeObj + 0x1C) = 0;
+	freeObj[0] = (freeObj[0] & 0x7F) | 0x80;
+
+	int id = *(s32*)((u8*)this + 0xC80);
+	*(s32*)((u8*)this + 0xC80) = id + 1;
+	*(s32*)(freeObj + 0x20) = id;
+
+	*(float*)(freeObj + 0x48) = dir;
+	*(float*)(freeObj + 0x44) = dir;
+	*(float*)(freeObj + 0x40) = dir;
+
+	*(float*)(freeObj + 0x54) = speed;
+	*(float*)(freeObj + 0x50) = speed;
+	*(float*)(freeObj + 0x4C) = speed;
+
+	return *(s32*)(freeObj + 0x20);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CWind::AddAmbient(float, float)` in `src/wind.cpp` using the current decomp reference control flow and object-slot allocation pattern already used by `AddDiffuse`/`AddSphere`.
- Updated the declaration in `include/ffcc/wind.h` from `void` to `int` to match observed behavior (returns allocated wind object id or `-1`).
- Added PAL metadata block and missing external format string declaration `DAT_801db568` used by the failure `System.Printf` path.

## Functions improved
- Unit: `main/wind`
- Symbol: `AddAmbient__5CWindFff`

## Match evidence
- Before: `1.1%` (from `tools/agent_select_target.py` output for this exact symbol)
- After: `33.788887%` from:
  - `build/tools/objdiff-cli diff -p . -u main/wind -o - AddAmbient__5CWindFff`
- Binary size now matches target symbol size (`360` bytes reported on left symbol in objdiff output).

## Plausibility rationale
- The implementation follows existing source conventions in this file:
  - same 32-object scan stride and free-slot checks used in `AddDiffuse`/`AddSphere`
  - same flag/id initialization pattern and duplicated state assignment style
- No compiler-coaxing constructs were introduced; this is straightforward gameplay allocation/init logic consistent with neighboring code.

## Technical details
- The function searches the 4x8 ambient object slots in-order, allocates first free slot, marks type 0, updates global wind id counter (`+0xC80`), and initializes direction/speed triples.
- Failure path logs through `System.Printf` with `DAT_801db568` and returns `-1`.
- Verified with full rebuild: `ninja` succeeds after change.
