### PR TITLE
pppEraseCharaParts: improve frame match via signed pause flag

### DIFF
--- a/src/pppEraseCharaParts.cpp
+++ b/src/pppEraseCharaParts.cpp
@@ -5,7 +5,7 @@
 #include <dolphin/gx.h>
 
 extern CMaterialMan MaterialMan;
-extern unsigned int DAT_8032ed70;
+extern int DAT_8032ed70;
 
 extern "C" {
 void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);


### PR DESCRIPTION
## Summary
- Changed `DAT_8032ed70` in `src/pppEraseCharaParts.cpp` from `unsigned int` to `int`.
- This aligns the pause check with signed compare codegen (`cmpwi`) used by the target function.

## Functions improved
- Unit: `main/pppEraseCharaParts`
- Symbol: `pppFrameEraseCharaParts`
- Before: `76.88095%`
- After: `78.309525%`

## Match evidence
- Objdiff confirms the frame function percentage increase after rebuild.
- The key assembly alignment change is the guard compare form for the pause flag (signedness-driven codegen).

## Plausibility rationale
- `DAT_8032ed70` is used as a boolean-like frame gate across particle frame functions; signed `int` for this gate is source-plausible and consistent with observed compare behavior.
- The change is semantic no-op in normal usage (`0`/non-zero check) and improves ABI/codegen alignment without introducing contrived control flow.

## Technical details
- Modified file: `src/pppEraseCharaParts.cpp`
- Build: `ninja` passes
- Verification command: `build/tools/objdiff-cli diff -p . -u main/pppEraseCharaParts -o - pppFrameEraseCharaParts`