### PR TITLE
main/pppSRandHCV: improve typed param access and codegen match

### DIFF
--- a/src/pppSRandHCV.cpp
+++ b/src/pppSRandHCV.cpp
@@ -8,6 +8,14 @@ extern float lbl_803300A0;
 extern s16 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
 
+typedef struct SRandHCVParams {
+	int index;
+	int colorOffset;
+	s16 base[4];
+	u8 flag;
+	u8 pad[3];
+} SRandHCVParams;
+
 /*
  * --INFO--
  * PAL Address: TODO
@@ -48,16 +56,17 @@ void randf(unsigned char flag)
  */
 void pppSRandHCV(void* data1, void* data2, void* data3)
 {
+	SRandHCVParams* params = (SRandHCVParams*)data2;
 	float* rand_values;
 
 	if (lbl_8032ED70 != 0) {
 		return;
 	}
 
-	if (*(int*)data2 == *((int*)data1 + 3)) {
+	if (params->index == *(int*)((char*)data1 + 0xc)) {
 		int** base_ptr = (int**)((char*)data3 + 0xc);
 		int offset = **base_ptr;
-		u8 flag = *((u8*)data2 + 0x10);
+		u8 flag = params->flag;
 		float value;
 		rand_values = (float*)((char*)data1 + offset + 0x80);
 
@@ -92,14 +101,14 @@ void pppSRandHCV(void* data1, void* data2, void* data3)
 			value = value * lbl_803300A0;
 		}
 		rand_values[3] = value;
-	} else {
+	} else if (params->index != *(int*)((char*)data1 + 0xc)) {
 		int** base_ptr = (int**)((char*)data3 + 0xc);
 		int offset = **base_ptr;
 		rand_values = (float*)((char*)data1 + offset + 0x80);
 	}
 
 	s16* target_color;
-	int color_offset = *((int*)data2 + 1);
+	int color_offset = params->colorOffset;
 	if (color_offset == -1) {
 		target_color = lbl_801EADC8;
 	} else {
@@ -107,29 +116,29 @@ void pppSRandHCV(void* data1, void* data2, void* data3)
 	}
 
 	{
-		s16 base = *(s16*)((char*)data2 + 0x8);
 		s16 current = target_color[0];
+		s16 base = params->base[0];
 		s8 delta = (s8)((float)base * rand_values[0] - (float)current);
 		target_color[0] = (s16)(current + delta);
 	}
 
 	{
-		s16 base = *(s16*)((char*)data2 + 0xa);
 		s16 current = target_color[1];
+		s16 base = params->base[1];
 		s8 delta = (s8)((float)base * rand_values[1] - (float)current);
 		target_color[1] = (s16)(current + delta);
 	}
 
 	{
-		s16 base = *(s16*)((char*)data2 + 0xc);
 		s16 current = target_color[2];
+		s16 base = params->base[2];
 		s8 delta = (s8)((float)base * rand_values[2] - (float)current);
 		target_color[2] = (s16)(current + delta);
 	}
 
 	{
-		s16 base = *(s16*)((char*)data2 + 0xe);
 		s16 current = target_color[3];
+		s16 base = params->base[3];
 		s8 delta = (s8)((float)base * rand_values[3] - (float)current);
 		target_color[3] = (s16)(current + delta);
 	}


### PR DESCRIPTION
## Summary
- Refactored `src/pppSRandHCV.cpp` to use an explicit `SRandHCVParams` struct for index/color/base/flag access.
- Aligned control flow with neighboring `pppSRand*` patterns by using explicit `if (...) { ... } else if (...) { ... }` pointer setup.
- Reordered per-channel local loads (`current` then `base`) while preserving behavior.

## Functions improved
- Unit: `main/pppSRandHCV`
- Symbol: `pppSRandHCV` (736 bytes)

## Match evidence
- `tools/objdiff-cli.exe diff -p . -u main/pppSRandHCV -o - pppSRandHCV`
- Before (HEAD^): `81.483696%`
- After (this branch): `82.0%`
- Delta: `+0.516304%`

## Plausibility rationale
- The change replaces repeated raw byte-offset casts with a typed parameter layout that matches surrounding particle parameter code in this repository.
- Control flow and data access now more closely follow existing `pppSRandDownHCV`/`pppSRandUpHCV` idioms, improving readability without introducing contrived compiler-only tricks.

## Technical details
- Introduced:
  - `index` -> compare against object index at `+0xC`
  - `colorOffset` -> select between `lbl_801EADC8` and object-relative color buffer
  - `base[4]` + `flag` -> channel math input
- Preserved PAL metadata block and existing function interfaces.
- Verified build success with `ninja` (`build/GCCP01/main.dol: OK`).