### PR TITLE
pppYmDeformationMdl: implement first-pass pppRenderYmDeformationMdl

### DIFF
--- a/include/ffcc/pppYmDeformationMdl.h
+++ b/include/ffcc/pppYmDeformationMdl.h
@@ -34,7 +34,7 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl*, struct UnkC*);
 void pppConstruct2YmDeformationMdl(pppYmDeformationMdl*, struct UnkC*);
 void pppDestructYmDeformationMdl(void);
 void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* param_2, UnkC* param_3);
-void pppRenderYmDeformationMdl(void* pppYmDeformationMdl, void* param_2, void* param_3);
+void pppRenderYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* param_2, UnkC* param_3);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -1,9 +1,66 @@
 #include "ffcc/pppYmDeformationMdl.h"
+#include "ffcc/graphic.h"
+#include "ffcc/mapmesh.h"
+
+#include <dolphin/gx.h>
+#include <dolphin/mtx.h>
 
 extern int DAT_8032ed70;
 extern u8 DAT_8032ed78;
 
 extern void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
+extern float FLOAT_80330dac;
+
+struct pppCVECTOR {
+    u8 rgba[4];
+};
+
+struct pppFMATRIX {
+    Mtx value;
+};
+
+struct pppModelSt;
+
+struct _pppEnvStYmDeformationMdl {
+    void* m_stagePtr;
+    CMaterialSet* m_materialSetPtr;
+    CMapMesh** m_mapMeshPtr;
+};
+
+extern _pppEnvStYmDeformationMdl* pppEnvStPtr;
+extern struct {
+    float _212_4_;
+    float _216_4_;
+    float _220_4_;
+    float _224_4_;
+    float _228_4_;
+    float _232_4_;
+    Mtx m_cameraMatrix;
+    Mtx44 m_screenMatrix;
+} CameraPcs;
+extern CGraphic Graphic;
+
+extern "C" {
+int GetTexture__8CMapMeshFP12CMaterialSetRi(CMapMesh* mapMesh, CMaterialSet* materialSet, int& textureIndex);
+void pppInitBlendMode__Fv(void);
+void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+    pppCVECTOR*, pppFMATRIX*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char,
+    unsigned char);
+void pppSetBlendMode__FUc(unsigned char);
+void pppDrawMesh__FP10pppModelStP3Veci(pppModelSt*, Vec*, int);
+void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+void _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(int, int,
+                                                                                                                      int, int,
+                                                                                                                      int);
+void _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(int, int, int, int, int);
+void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(int, int, int, int, int);
+void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int, int);
+void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(int, int, int, int, int);
+void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int, int);
+void _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(int, int, int, int);
+int GetBackBufferRect__8CGraphicFRiRiRiRii(CGraphic*, int&, int&, int&, int&, int);
+}
 
 /*
  * --INFO--
@@ -131,9 +188,125 @@ void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* pa
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRenderYmDeformationMdl(void* pppYmDeformationMdl, void* param_2, void* param_3)
+void pppRenderYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+    short* state = (short*)((u8*)pppYmDeformationMdl + 0x80 + param_3->m_serializedDataOffsets[2]);
+    u8* control = (u8*)param_2->m_payload;
+    int textureIndex = 0;
+
+    if (param_2->m_dataValIndex == 0xFFFF) {
+        return;
+    }
+
+    pppModelSt* model = (pppModelSt*)pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex];
+    int textureBase = GetTexture__8CMapMeshFP12CMaterialSetRi((CMapMesh*)model, pppEnvStPtr->m_materialSetPtr, textureIndex);
+    Mtx cameraMtx;
+    Mtx texMtx;
+    Mtx rotMtx;
+    Mtx44 screenMtx;
+    int left = 0;
+    int top = 0;
+    int width = 0x280;
+    int height = 0x1c0;
+    int backTexture = 0;
+
+    pppInitBlendMode__Fv();
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+
+    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+        (pppCVECTOR*)((u8*)pppYmDeformationMdl + 0x88 + param_3->m_serializedDataOffsets[1]),
+        (pppFMATRIX*)((u8*)pppYmDeformationMdl + 0x40), *(float*)(control + 0x10), control[0x17], control[0x16], control[0x14],
+        control[0x15], (u8)(control[0x18] == 0), 1, 0);
+
+    GXSetNumTevStages(1);
+    GXSetNumTexGens(2);
+    GXSetNumChans(1);
+    _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(7, 0, 1, 7, 0);
+    _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(1, 0, 1, 2, 0);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 1);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 0xFF);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 0xF, 8, 9, 0xF);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 7, 7, 7, 4);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+
+    pppSetBlendMode__FUc(control[0x14]);
+    if (control[0x14] == 0) {
+        _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 1, 5, 1);
+    }
+    if (control[0x14] == 3) {
+        _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(0, 1, 5, 1);
+        GXSetTevOp((GXTevStageID)0, GX_MODULATE);
+    }
+
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(1, 0, 1, 0xFF);
+    GXSetTevOp((GXTevStageID)1, GX_MODULATE);
+    GXClearVtxDesc();
+    GXSetVtxDesc((GXAttr)9, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)10, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)11, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)13, GX_DIRECT);
+
+    backTexture = GetBackBufferRect__8CGraphicFRiRiRiRii(&Graphic, left, top, width, height, 0);
+    if (backTexture != 0) {
+        PSMTXIdentity(texMtx);
+        PSMTX44Copy(CameraPcs.m_screenMatrix, screenMtx);
+        PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
+
+        texMtx[0][0] = screenMtx[0][0] * (2.0f / (float)width);
+        texMtx[1][1] = screenMtx[1][1] * -(2.0f / (float)height);
+        texMtx[1][0] = screenMtx[1][0];
+        texMtx[2][0] = screenMtx[2][0];
+        texMtx[0][1] = screenMtx[0][1];
+        texMtx[2][1] = screenMtx[2][1];
+        texMtx[0][2] = 0.0f;
+        texMtx[1][2] = 0.0f;
+        texMtx[2][2] = 1.0f;
+        Mtx* objectMtx = (Mtx*)((u8*)pppYmDeformationMdl + 0x40);
+        PSMTXConcat(texMtx, *objectMtx, texMtx);
+        GXLoadTexMtxImm(texMtx, 0x1E, GX_MTX3x4);
+        GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX3x4, GX_TG_POS, 0x1E, GX_FALSE, GX_PTIDENTITY);
+        GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
+        GXSetNumIndStages(1);
+        GXSetIndTexOrder(GX_INDTEXSTAGE0, GX_TEXCOORD1, GX_TEXMAP1);
+        GXSetTevIndWarp(GX_TEVSTAGE0, GX_INDTEXSTAGE0, GX_TRUE, GX_ITW_0, GX_ITM_1);
+        GXSetIndTexCoordScale(GX_INDTEXSTAGE0, GX_ITS_1, GX_ITS_1);
+
+        if ((*state == 0) || (*state == 0x168)) {
+            *state = 1;
+        }
+
+        PSMTXRotRad(rotMtx, 'z', 0.017453292f * (float)*state);
+        float indMtx[2][3];
+        indMtx[0][0] = rotMtx[0][0] * *(float*)(state + 2);
+        indMtx[0][1] = rotMtx[0][1] * *(float*)(state + 2);
+        indMtx[1][0] = rotMtx[1][0] * *(float*)(state + 2);
+        indMtx[1][1] = rotMtx[1][1] * *(float*)(state + 2);
+        indMtx[0][2] = FLOAT_80330dac;
+        indMtx[1][2] = FLOAT_80330dac;
+        GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
+
+        GXLoadTexObj((_GXTexObj*)backTexture, GX_TEXMAP0);
+        GXLoadTexObj((_GXTexObj*)(textureBase + 0x28), GX_TEXMAP1);
+        pppDrawMesh__FP10pppModelStP3Veci(model, *(Vec**)((u8*)pppYmDeformationMdl + 0x70), 0);
+
+        GXSetTevDirect((GXTevStageID)1);
+        GXSetNumIndStages(0);
+        GXSetIndTexCoordScale(GX_INDTEXSTAGE0, GX_ITS_1, GX_ITS_1);
+
+        PSMTXRotRad(rotMtx, 'z', FLOAT_80330dac);
+        indMtx[0][0] = FLOAT_80330dac;
+        indMtx[0][1] = FLOAT_80330dac;
+        indMtx[0][2] = FLOAT_80330dac;
+        indMtx[1][0] = FLOAT_80330dac;
+        indMtx[1][1] = FLOAT_80330dac;
+        indMtx[1][2] = FLOAT_80330dac;
+        GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
+
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 0);
+        pppInitBlendMode__Fv();
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a first-pass decomp of `pppRenderYmDeformationMdl` in `src/pppYmDeformationMdl.cpp`, replacing the previous TODO stub with concrete GX/material/texture setup, matrix construction, indirect warp setup, and mesh draw flow based on available PAL symbols + Ghidra guidance.

Also updated the header prototype in `include/ffcc/pppYmDeformationMdl.h` to the concrete typed signature used by the implementation.

## Functions improved
- Unit: `main/pppYmDeformationMdl`
- Function: `pppRenderYmDeformationMdl` (1384b)

## Match evidence
- `pppRenderYmDeformationMdl`: **0.3% -> 82.51734%** (`objdiff-cli diff -u main/pppYmDeformationMdl -o - pppRenderYmDeformationMdl`)
- Unit `main/pppYmDeformationMdl` moved from low-match status (selector reported current 11.0%) to a high fuzzy state in build report (`fuzzy_match_percent: 74.07522`).

## Plausibility rationale
- The new function follows existing project patterns used in nearby PPP/GX units:
  - explicit GX TEV/indirect-stage setup
  - `pppSetDrawEnv` + blend mode path keyed off serialized control bytes
  - backbuffer texture capture + map mesh texture path
  - matrix/texcoord generation and `pppDrawMesh` usage
- Changes avoid synthetic compiler-only tricks and keep behavior-oriented rendering flow, making it a plausible original-source first pass for a previously stubbed large function.

## Technical details
- Added minimal extern wrappers for existing mangled engine helpers (`GetTexture__8CMapMesh...`, TEV helpers, `GetBackBufferRect__8CGraphic...`, etc.) to mirror current codebase style.
- Reconstructed key state from serialized offsets (`+0x80` state block, color/env block from offset table, object matrix at `+0x40`, draw vector at `+0x70`).
- Matched observed assembly patterns including the alpha-flag conversion path and the two-step indirect texture matrix setup/reset around draw.
