### PR TITLE
system: restore scenegraph event virtual dispatch

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -291,13 +291,13 @@ void CSystem::RemoveScenegraph(CProcess* process, int arg)
  * Address:	TODO
  * Size:	TODO
  */
-void CSystem::ScriptChanging(char*)
+void CSystem::ScriptChanging(char* script)
 {
 	for (COrder* order = m_orderSentinel.m_next; order != &m_orderSentinel; order = order->m_next)
 	{
 		if (order->m_entry == (void*)((int)order->m_descBlock + 0x1c))
 		{
-			//(**(code **)((int)*order->m_owner + 0x14))(order->m_owner,param_2);
+			order->m_owner->ScriptChanging(script);
 		}
 	}
 }
@@ -307,13 +307,13 @@ void CSystem::ScriptChanging(char*)
  * Address:	TODO
  * Size:	TODO
  */
-void CSystem::ScriptChanged(char*, int)
+void CSystem::ScriptChanged(char* script, int value)
 {
 	for (COrder* order = m_orderSentinel.m_next; order != &m_orderSentinel; order = order->m_next)
 	{
 		if (order->m_entry == (void*)((int)order->m_descBlock + 0x1c))
 		{
-			//(**(code **)((int)*order->m_owner + 0x18))(order->m_owner,param_2,param_3);
+			order->m_owner->ScriptChanged(script, value);
 		}
 	}
 }
@@ -323,13 +323,13 @@ void CSystem::ScriptChanged(char*, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CSystem::MapChanging(int, int)
+void CSystem::MapChanging(int mapId, int mapVariant)
 {
 	for (COrder* order = m_orderSentinel.m_next; order != &m_orderSentinel; order = order->m_next)
 	{
 		if (order->m_entry == (void*)((int)order->m_descBlock + 0x1c))
 		{
-			//(**(code **)((int)*order->m_owner + 0x1c))(order->m_owner,param_2,param_3)
+			order->m_owner->MapChanging(mapId, mapVariant);
 		}
 	}
 }
@@ -339,13 +339,13 @@ void CSystem::MapChanging(int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CSystem::MapChanged(int, int, int)
+void CSystem::MapChanged(int mapId, int mapVariant, int changedByForce)
 {
 	for (COrder* order = m_orderSentinel.m_next; order != &m_orderSentinel; order = order->m_next)
 	{
 		if (order->m_entry == (void*)((int)order->m_descBlock + 0x1c))
 		{
-			//(**(code **)((int)*order->m_owner + 0x20))(order->m_owner,param_2,param_3,param_4);
+			order->m_owner->MapChanged(mapId, mapVariant, changedByForce);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Restore scenegraph event dispatch in `CSystem` by replacing placeholder commented-out indirect calls with direct virtual calls on `order->m_owner`:
- `CSystem::ScriptChanging(char*)`
- `CSystem::ScriptChanged(char*, int)`
- `CSystem::MapChanging(int, int)`
- `CSystem::MapChanged(int, int, int)`

The loops and event-gating condition (`order->m_entry == (void*)((int)order->m_descBlock + 0x1c)`) are preserved.

## Functions improved
Unit: `main/system`

- `ScriptChanging__7CSystemFPc`: **15.290322% -> 99.96774%**
- `ScriptChanged__7CSystemFPci`: **13.542857% -> 99.97143%**
- `MapChanging__7CSystemFii`: **13.542857% -> 99.97143%**
- `MapChanged__7CSystemFiii`: **19.806452% -> 83.19355%**

## Match evidence
Objdiff now shows expected virtual dispatch sequence in these handlers (`lwz r12, 0(r3)` -> vtable slot load -> `mtctr`/`bctrl`) rather than no-op/comment-placeholder behavior.

For the three ~99.97% functions, remaining differences are minimal (single argument-level mismatch in the vtable slot load). `MapChanged` still has one larger prologue/epilogue shape difference plus one slot mismatch, but is substantially improved.

## Plausibility rationale
This change restores straightforward, source-plausible game-engine behavior: the system iterates scenegraph orders and forwards script/map lifecycle events to each owner process through virtual methods. This is idiomatic C++ for this codebase and consistent with the pre-existing loop structure and naming, rather than compiler-coaxing.

## Technical details
- No ABI/layout hacks, no offset hardcoding additions, no control-flow distortion.
- Only replaced commented pseudo-call stubs with natural typed virtual method calls.
- Preserved existing filtering logic and traversal order.
