### PR TITLE
chara_anim: reconstruct CAnim ctor/dtor and InitQuantize

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -1,6 +1,16 @@
 #include "ffcc/chara_anim.h"
 #include "ffcc/chunkfile.h"
 
+#include <PowerPC_EABI_Support/Runtime/MWCPlusLib.h>
+
+extern "C" void __ct__4CRefFv(void*);
+extern "C" void __dt__4CRefFv(void*, int);
+extern "C" void __dt__Q26CChara9CAnimNodeFv(void*, int);
+extern "C" void __dla__FPv(void*);
+extern "C" void gqrInit__6CCharaFUlUlUl(void*, unsigned long, unsigned long, unsigned long);
+
+extern "C" unsigned char Chara[];
+extern "C" void* PTR_PTR_s_CChara_CAnim_80210534;
 
 /*
  * --INFO--
@@ -64,40 +74,65 @@ void i2f_5(float*, unsigned short*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800BFDE0
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CChara::CAnim::CAnim()
 {
-	// Initialize base CRef
-	
-	// Set member variables to default values
-	*(unsigned short*)((char*)this + 0xe) = 0;
-	*(int*)((char*)this + 0x14) = 0;
-	*(void**)((char*)this + 0x20) = 0;
-	
-	// Set various flags and values
-	*(unsigned char*)((char*)this + 0x9) = 0x80 | 0x0; // Set bit 7, clear bit 6
-	*(unsigned char*)((char*)this + 0xa) = 5;
-	*(unsigned char*)((char*)this + 0xb) = 0xb;
-	*(unsigned char*)((char*)this + 0xc) = 10;
-	*(unsigned char*)((char*)this + 0xd) = 0;
-	
-	*(void**)((char*)this + 0x18) = 0;
-	*(void**)((char*)this + 0x28) = 0;
-	*(int*)((char*)this + 0x1c) = 0;
-	*(void**)((char*)this + 0x2c) = 0;
-	*(int*)((char*)this + 0x24) = 0;
+	unsigned char* const p = (unsigned char*)this;
+
+	__ct__4CRefFv(this);
+	*(void**)p = &PTR_PTR_s_CChara_CAnim_80210534;
+	*(unsigned short*)(p + 0xE) = 0;
+	*(int*)(p + 0x14) = 0;
+	*(void**)(p + 0x20) = 0;
+	p[9] = (unsigned char)((p[9] & 0x7F) | 0x80);
+	p[9] = (unsigned char)(p[9] & 0xBF);
+	p[0xA] = 5;
+	p[0xB] = 0xB;
+	p[0xC] = 10;
+	p[0xD] = 0;
+	*(void**)(p + 0x18) = 0;
+	*(void**)(p + 0x28) = 0;
+	*(int*)(p + 0x1C) = 0;
+	*(int*)(p + 0x24) = 0;
+	*(void**)(p + 0x2C) = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800BFD44
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CChara::CAnim::~CAnim()
 {
-	// TODO
+	unsigned char* const p = (unsigned char*)this;
+	void* nodeArray;
+	void* bank;
+
+	*(void**)p = &PTR_PTR_s_CChara_CAnim_80210534;
+
+	nodeArray = *(void**)(p + 0x14);
+	if (nodeArray != 0) {
+		__destroy_new_array(nodeArray, (ConstructorDestructor)__dt__Q26CChara9CAnimNodeFv);
+		*(void**)(p + 0x14) = 0;
+	}
+
+	bank = *(void**)(p + 0x20);
+	if (bank != 0) {
+		__dla__FPv(bank);
+		*(void**)(p + 0x20) = 0;
+	}
+
+	__dt__4CRefFv(this, 0);
 }
 
 /*
@@ -124,22 +159,37 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800BF910
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CChara::CAnim::InitQuantize()
 {
-	// TODO
+	unsigned char* const p = (unsigned char*)this;
+	unsigned long qx = ((unsigned long)p[0xA] << 0x18) | 0x70000 | ((unsigned long)p[0xA] << 8) | 7;
+	unsigned long qy = ((unsigned long)p[0xB] << 0x18) | 0x70000 | ((unsigned long)p[0xB] << 8) | 7;
+	unsigned long qz = ((unsigned long)p[0xC] << 0x18) | 0x70000 | ((unsigned long)p[0xC] << 8) | 7;
+
+	gqrInit__6CCharaFUlUlUl(Chara, qx, qy, qz);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800BF8F0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CChara::CAnimNode::CAnimNode()
 {
-	// TODO
+	unsigned char* const p = (unsigned char*)this;
+	p[0x14] = (unsigned char)(p[0x14] & 0x7F);
+	*(unsigned int*)(p + 0x14) &= 0x80001FFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented decomp-informed logic for four `main/chara_anim` functions in `src/chara_anim.cpp`:
- `CChara::CAnimNode::CAnimNode`
- `CChara::CAnim::InitQuantize`
- `CChara::CAnim::CAnim`
- `CChara::CAnim::~CAnim`

Changes include restoring constructor/destructor initialization/cleanup behavior, quantize register setup call flow, and updating function headers with PAL address/size metadata.

## Functions improved
Unit: `main/chara_anim`

- `__ct__Q26CChara9CAnimNodeFv`: 12.5% -> 72.5% (+60.0)
- `InitQuantize__Q26CChara5CAnimFv`: 3.4483% -> 100.0% (+96.5517)
- `__dt__Q26CChara5CAnimFv`: 37.7949% -> 95.8974% (+58.1026)
- `__ct__Q26CChara5CAnimFv`: 34.6316% -> 85.6579% (+51.0263)

## Match evidence
- Unit `main/chara_anim` fuzzy match: **26.0730% -> 40.0899%** (+14.0169)
- Matched code bytes: **60 -> 176**
- Matched functions in unit: **1 -> 2**
- `ninja` build succeeded after changes.

## Plausibility rationale
These updates follow observed constructor/destructor and quantize setup patterns from existing project code and symbol-resolved decomp output:
- Constructor/destructor now perform expected base/vtable setup and owned-resource cleanup.
- `InitQuantize` computes the three quantize control words from stored byte parameters and forwards them through the existing `gqrInit__6CCharaFUlUlUl` path.
- No contrived control-flow coercion or opaque compiler-only tricks were introduced.

## Technical details
- Added explicit external declarations for runtime helpers used by these functions (`__ct__4CRefFv`, `__dt__4CRefFv`, `__destroy_new_array`, `__dla__FPv`, `gqrInit__6CCharaFUlUlUl`).
- Updated `--INFO--` headers for the edited functions with PAL address/size values from reference decomp.
- Verified targeted symbol improvement via `objdiff-cli report generate` and direct `objdiff-cli diff` on `InitQuantize__Q26CChara5CAnimFv`.