### PR TITLE
textureman: add stage-routed operator new overloads

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -17,6 +17,8 @@ public:
     CTexture();
     ~CTexture();
 
+    static void* operator new(unsigned long, CMemory::CStage*, char*, int);
+
     void InitTexObj();
     void Create(CChunkFile&, CMemory::CStage*, CAmemCacheSet*, int, int);
     void CacheLoadTexture(CAmemCacheSet*);
@@ -41,6 +43,8 @@ public:
     CTextureSet();
     ~CTextureSet();
 
+    static void* operator new(unsigned long, CMemory::CStage*, char*, int);
+
     void Create(void*, CMemory::CStage*, int, CAmemCacheSet*, int, int);
     void Create(CChunkFile&, CMemory::CStage*, int, CAmemCacheSet*, int, int);
     void Find(char*);
@@ -56,6 +60,9 @@ public:
     void Quit();
     void SetTexture(_GXTexMapID, CTexture*);
     void SetTextureTev(CTexture*);
+
+    friend class CTexture;
+    friend class CTextureSet;
 
 private:
     void* m_vtable;

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/textureman.h"
 
+extern CTextureMan TextureMan;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -296,4 +298,32 @@ void CTextureSet::ReleaseTextureIdx(int, CAmemCacheSet*)
 void CTexture::GetNumTlut()
 {
 	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003B894
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* CTexture::operator new(unsigned long size, CMemory::CStage*, char* file, int line)
+{
+	return ::operator new(size, TextureMan.m_memoryStage, file, line);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003AC74
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* CTextureSet::operator new(unsigned long size, CMemory::CStage*, char* file, int line)
+{
+	return ::operator new(size, TextureMan.m_memoryStage, file, line);
 }


### PR DESCRIPTION
## Summary
Implemented class-specific allocator overloads for `CTexture` and `CTextureSet` in `textureman` so allocations route through `TextureMan`'s texture memory stage, matching the PAL decomp behavior.

## Functions improved
- `__nw__8CTextureFUlPQ27CMemory6CStagePci` (PAL 0x8003B894, 68b)
- `__nw__11CTextureSetFUlPQ27CMemory6CStagePci` (PAL 0x8003AC74, 68b)

## Match evidence
- Unit `.text` match (`main/textureman`):
  - Before: `3.860845%`
  - After: `4.9650702%`
- Symbol match results after change (`objdiff-cli diff -u main/textureman -o - <symbol>`):
  - `__nw__8CTextureFUlPQ27CMemory6CStagePci`: `57.64706%`
  - `__nw__11CTextureSetFUlPQ27CMemory6CStagePci`: `57.64706%`

## Plausibility rationale
These overloads are source-plausible: texture/man-set objects typically allocate from the texture manager stage, and the implementation uses existing project allocation APIs instead of compiler-coaxing patterns. The change aligns with Ghidra's high-level behavior while keeping readable game-style source.

## Technical details
- Added declarations for class-specific `operator new(unsigned long, CMemory::CStage*, char*, int)` in `include/ffcc/textureman.h`.
- Implemented both overloads in `src/textureman.cpp`.
- Added friend declarations so the overloads can access `CTextureMan::m_memoryStage` directly.
