### PR TITLE
main/game: improve GetLangString decomp match

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -536,13 +536,17 @@ void CGame::MakeNumMonName(char*, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80013e70
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 const char* CGame::GetLangString()
 {
     static const char* const sLangDirs[] =
-	{
+    {
         "jp/",
         "uk/",
         "gr/",
@@ -550,14 +554,16 @@ const char* CGame::GetLangString()
         "fr/",
         "sp/"
     };
+    const char* localLangDirs[6];
 
-    // Safety in case languageId is out of range.
-    if (m_gameWork.m_languageId >= sizeof(sLangDirs) / sizeof(sLangDirs[0]))
-	{
-        return sLangDirs[0];
-    }
+    localLangDirs[0] = sLangDirs[0];
+    localLangDirs[1] = sLangDirs[1];
+    localLangDirs[2] = sLangDirs[2];
+    localLangDirs[3] = sLangDirs[3];
+    localLangDirs[4] = sLangDirs[4];
+    localLangDirs[5] = sLangDirs[5];
 
-    return sLangDirs[m_gameWork.m_languageId];
+    return localLangDirs[m_gameWork.m_languageId];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CGame::GetLangString()` in `src/game.cpp` to follow the observed original code shape more closely.
- Replaced bounds-checked direct table indexing with a static language string table copied into a local pointer array, then returned via `m_gameWork.m_languageId` index.
- Added PAL function metadata block for this function.

## Functions Improved
- Unit: `main/game`
- Symbol: `GetLangString__5CGameFv`

## Match Evidence
- Before: `4.7%`
- After: `57.0%`
- Verification:
  - `ninja` passes
  - `build/tools/objdiff-cli diff -p . -u main/game -o -` confirms improved symbol match

## Plausibility Rationale
- The new implementation reflects a plausible original source pattern for this codebase: fixed language literals, local pointer-array setup, then indexed return.
- The change removes defensive modern-style bounds checking and restores a simpler direct-index behavior that better matches the shipped binary pattern.
- No compiler-coaxing artifacts were introduced (no contrived temporaries beyond table copy shape required by the matched code form).

## Technical Details
- The previous implementation emitted different control-flow and addressing due to bounds checking and direct static indexing.
- The updated structure aligns better with the decompilation pattern (global literal pointers loaded and copied into a local array before indexed return), which reduced assembly-level diff substantially.
