### PR TITLE
pppAngle: match pppAngleCon initialization order

### DIFF
--- a/src/pppAngle.cpp
+++ b/src/pppAngle.cpp
@@ -43,7 +43,7 @@ void pppAngleCon(void* dest, void* param)
     int offset = offsetPtr[0];
     
     int* ptr = (int*)((char*)dest + offset + 0x80);
-    ptr[0] = 0;
-    ptr[1] = 0;
     ptr[2] = 0;
+    ptr[1] = 0;
+    ptr[0] = 0;
 }


### PR DESCRIPTION
## Summary
- Adjusted initialization store order in `pppAngleCon` to match original codegen ordering.
- No logic changes; only assignment sequencing inside `src/pppAngle.cpp`.

## Functions Improved
- Unit: `main/pppAngle`
- Function: `pppAngleCon` (36b)
  - Before: `99.77778%`
  - After: `100.0%`

## Match Evidence
- `objdiff-cli v3.6.1` one-shot diff for `main/pppAngle pppAngleCon` now reports `match 100.0` and `diffs 0`.
- Unit fuzzy match improved from ~`99.48485%` to `99.54546%`.
- Project progress increased:
  - Code matched bytes: `184020 -> 184056`
  - Matched functions: `1265 -> 1266`

## Plausibility Rationale
- The change preserves identical behavior (zero-initialize 3 contiguous fields) and only reflects plausible original assignment ordering.
- No compiler-coaxing constructs, no synthetic temporaries, and no readability loss.

## Technical Notes
- Prior objdiff showed only argument-order mismatches in the three zero stores (`stw` offsets order).
- Reordering source assignments fixed those final mismatches and produced an exact symbol match.