### PR TITLE
os/OSRtc: improve OSGetProgressiveMode match

### DIFF
--- a/src/os/OSRtc.c
+++ b/src/os/OSRtc.c
@@ -315,7 +315,7 @@ u32 OSGetProgressiveMode(void) {
     u32 on;
 
     sram = __OSLockSram();
-    on = (sram->flags & 0x80) >> 7;
+    on = (sram->flags & 0x80) ? 1 : 0;
     __OSUnlockSram(FALSE);
     return on;
 }


### PR DESCRIPTION
## Summary
- Update `OSGetProgressiveMode` in `src/os/OSRtc.c` to compute the return value with boolean masking (`(flags & 0x80) ? 1 : 0`) instead of shift extraction.
- Keep behavior unchanged while producing codegen closer to the target.

## Functions improved
- Unit: `main/os/OSRtc`
- Symbol: `OSGetProgressiveMode`

## Match evidence
- `OSGetProgressiveMode`: **63.682926% -> 68.07317%** (`+4.390244`)
- No regressions observed in nearby low-match functions in the same unit:
  - `OSGetSoundMode`: `68.07317% -> 68.07317%`
  - `OSSetSoundMode`: `45.035713% -> 45.035713%`
  - `OSSetProgressiveMode`: `43.703705% -> 43.703705%`
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/os/OSRtc -o - OSSetProgressiveMode`

## Plausibility rationale
- This is an idiomatic SDK-style boolean bit-test for a flag bit and matches source-level intent clearly.
- The change is minimal, readable, and does not introduce compiler-coaxing constructs.

## Technical details
- The prior form used right-shift extraction from a masked byte.
- The new form preserves semantics but better aligns generated compare/normalize code in this function with the target object.
