### PR TITLE
pppDrawMdl: improve codegen match for draw path

### DIFF
--- a/src/pppDrawMdl.cpp
+++ b/src/pppDrawMdl.cpp
@@ -1,5 +1,14 @@
 #include "ffcc/pppDrawMdl.h"
 #include "ffcc/pppPart.h"
+#include "dolphin/types.h"
+
+extern "C" {
+extern void* lbl_8032ED54;
+void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+    void*, void*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char);
+void pppSetBlendMode__FUc(unsigned char);
+void pppDrawMesh__FP10pppModelStP3Veci(void*, void*, int);
+}
 
 /*
  * --INFO--
@@ -24,29 +33,25 @@ void pppDrawMdl(_pppPObject* pObject, PDrawMdl* drawMdl, _pppCtrlTable* ctrlTabl
 {
     _pppPObject* obj = pObject;
     PDrawMdl* mdl = drawMdl;
-    unsigned int value = *(unsigned int*)((char*)mdl + 0x4);
-    if ((value >> 16) == 0xFFFF) {
+
+    if ((*(u32*)((u8*)mdl + 4) >> 16) == 0xFFFF) {
         return;
     }
 
-    typedef void (*SetDrawEnvFn)(pppFMATRIX*, pppCVECTOR*, float, unsigned char, unsigned char,
-                                 unsigned char, unsigned char, unsigned char, unsigned char, unsigned char);
-    SetDrawEnvFn setDrawEnv = (SetDrawEnvFn)pppSetDrawEnv;
-    setDrawEnv((pppFMATRIX*)((char*)obj + *(int*)*(int**)((char*)ctrlTable + 0xC) + 0x88),
-               (pppCVECTOR*)((char*)obj + 0x40),
-               *(float*)((char*)mdl + 0x10),
-               *(unsigned char*)((char*)mdl + 0x14),
-               *(unsigned char*)((char*)mdl + 0xA),
-               *(unsigned char*)((char*)mdl + 0x9),
-               *(unsigned char*)((char*)mdl + 0xB),
-               *(unsigned char*)((char*)mdl + 0xC),
-               *(unsigned char*)((char*)mdl + 0xD),
-               *(unsigned char*)((char*)mdl + 0xE));
+    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+        (u8*)obj + *(int*)*(int**)((u8*)ctrlTable + 0xC) + 0x88,
+        (u8*)obj + 0x40,
+        *(float*)((u8*)mdl + 0x10),
+        *(u8*)((u8*)mdl + 0x14),
+        *(u8*)((u8*)mdl + 0xA),
+        *(u8*)((u8*)mdl + 0x9),
+        *(u8*)((u8*)mdl + 0xB),
+        *(u8*)((u8*)mdl + 0xC),
+        *(u8*)((u8*)mdl + 0xD),
+        *(u8*)((u8*)mdl + 0xE));
 
-    pppSetBlendMode(*(unsigned char*)((char*)mdl + 0x9));
+    pppSetBlendMode__FUc(*(u8*)((u8*)mdl + 0x9));
 
-    extern void* lbl_8032ED54;
-    void** modelsArray = (void**)*(void**)((char*)&lbl_8032ED54 + 0x8);
-    pppDrawMesh((pppModelSt*)modelsArray[*(unsigned int*)((char*)mdl + 0x4)],
-                *(Vec**)((char*)obj + 0x70), 1);
+    void** modelsArray = *(void***)((u8*)lbl_8032ED54 + 0x8);
+    pppDrawMesh__FP10pppModelStP3Veci(modelsArray[*(u32*)((u8*)mdl + 0x4)], *(void**)((u8*)obj + 0x70), 1);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppDrawMdl` to use the PPP mangled draw entry points directly (`pppSetDrawEnv__...`, `pppSetBlendMode__FUc`, `pppDrawMesh__...`) instead of the previous indirect function-pointer call shape.
- Switched raw access code to consistent `u8`/`u32` offset-based loads used throughout PPP units.
- Kept behavior unchanged while aligning instruction ordering for draw-env setup, blend mode setup, and mesh table lookup.

## Functions improved
- Unit: `main/pppDrawMdl`
- Symbol: `pppDrawMdl`
- Before: `74.88095%`
- After: `98.09524%`
- Function size now matches target (`168b`).

## Match evidence
- `objdiff` before showed major drift from:
  - indirect call sequence for draw env (`lis/addi/mtctr/bctrl`) vs expected direct `bl`
  - global/model table access ordering
  - argument/register ordering in the draw call block
- `objdiff` after aligns the full main draw path and reaches near-match, with only a small early-guard/codegen pattern difference and relocation target naming drift remaining.

## Plausibility rationale
- The final code uses established patterns already present in nearby PPP decomp units:
  - explicit mangled PPP entry points
  - offset-based struct access with `u8*` + fixed offsets
  - straightforward control flow and argument passing
- No contrived temporaries or unnatural sequencing were introduced; changes are consistent with likely original source style for this module.

## Technical details
- The largest gain came from removing the function-pointer indirection path and forcing direct draw-env/blend/mesh call sites.
- Accessing `lbl_8032ED54` as a runtime pointer to the model array (`+0x8`) now generates the expected load/lookup sequence used by the original.
