### PR TITLE
main/stopwatch: improve ProfEnd match via signed frame counter

### DIFF
--- a/include/ffcc/stopwatch.h
+++ b/include/ffcc/stopwatch.h
@@ -31,7 +31,7 @@ public:
 	u8 _pad_0x30[0x30];
 	float m_lastTime; // 0x60
 	float m_maxTime;  // 0x64
-	u32 m_frame;      // 0x68
+	int m_frame;      // 0x68
 };
 
 #endif // _FFCC_STOPWATCH_H

--- a/src/stopwatch.cpp
+++ b/src/stopwatch.cpp
@@ -94,8 +94,12 @@ void CProfile::ProfStart() { OSResetStopwatch(this); }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80022ec8
+ * PAL Size: 200b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CProfile::ProfEnd()
 {
@@ -106,7 +110,7 @@ void CProfile::ProfEnd()
 	float denom = (float)(OS_TIMER_CLOCK / 125000);
 	m_lastTime = (8.0f * ticks) / denom;
 
-	u32 next = m_frame + 1;
+	int next = m_frame + 1;
 	m_frame = next;
 	if (next == 0x5A)
 	{


### PR DESCRIPTION
## Summary
- Changed `CProfile::m_frame` from `u32` to `int` in `include/ffcc/stopwatch.h`.
- Added PAL address/size metadata for `CProfile::ProfEnd` in `src/stopwatch.cpp` using the required INFO block format.

## Functions improved
- Unit: `main/stopwatch`
- Function: `ProfEnd__8CProfileFv`
- Match: `85.08% -> 86.28%` (+1.20)

## Match evidence
- Built with `ninja` successfully (`build/GCCP01/main.dol: OK` stage remains green in normal build flow).
- `objdiff` oneshot after change:
  - `build/tools/objdiff-cli diff -p . -u main/stopwatch -o - ProfEnd__8CProfileFv`
  - Reports `86.28%` on the target symbol.
- `Get__10CStopWatchFv` remains unchanged at `73.4%`.

## Plausibility rationale
- `m_frame` is used as a frame counter with increment/compare/reset semantics; signed `int` is source-plausible and idiomatic for this usage.
- This directly aligns the compare sequence in `ProfEnd` to use signed comparison (`cmpwi`) instead of unsigned (`cmplwi`), improving real instruction alignment without contrived control-flow changes.

## Technical details
- The improvement came from ABI/codegen-sensitive signedness in the class field type, not from artificial temporary insertion or non-idiomatic sequencing.
- No debug code, assembly comments, or synthetic scaffolding were introduced.
