### PR TITLE
main/stopwatch: improve CProfile constructor match

### DIFF
--- a/src/stopwatch.cpp
+++ b/src/stopwatch.cpp
@@ -61,8 +61,12 @@ float CStopWatch::Get()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80022FEC
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CProfile::CProfile(char* name)
 {
@@ -73,8 +77,9 @@ CProfile::CProfile(char* name)
 	OSInitStopwatch(&tmp, name);
 	OSResetStopwatch(&tmp);
 
-	m_maxTime = lbl_8032F854;
-	m_lastTime = lbl_8032F854;
+	float time = lbl_8032F854;
+	m_maxTime = time;
+	m_lastTime = time;
 	m_frame = 0;
 }
 


### PR DESCRIPTION
## Summary
- Refined `CProfile::CProfile(char* name)` initialization in `src/stopwatch.cpp` by introducing a local float temporary used for both `m_maxTime` and `m_lastTime` stores.
- Updated the function info block to the project-required PAL/EN/JP format.

## Functions improved
- Unit: `main/stopwatch`
- Symbol: `__ct__8CProfileFPc`
- Before: `96.42857%`
- After: `100.0%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/stopwatch -o - __ct__8CProfileFPc`
  - Before had one remaining `DIFF_INSERT` between float field stores.
  - After change, symbol fully matches (`100.0%`, `112b`).
- Unit `.text` fuzzy match improved from selector baseline `81.6%` to current `82.09412%`.

## Plausibility rationale
- The change is source-plausible: using a local `float` temporary for repeated zero initialization is a normal constructor pattern and does not introduce compiler-coaxing artifacts.
- Runtime behavior is unchanged.

## Technical details
- The prior constructor emitted one unmatched instruction around adjacent `stfs` writes for `m_maxTime` and `m_lastTime`.
- Reusing a local `float time` aligned register use and removed the remaining constructor mismatch.
