### PR TITLE
main/pppRandUpCV: decompile pppRandUpCV to structured logic

### DIFF
--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -1,7 +1,34 @@
 #include "ffcc/pppRandUpCV.h"
 #include "ffcc/math.h"
+#include "types.h"
 
 extern CMath math;
+extern s32 lbl_8032ED70;
+extern f32 lbl_8032FF08;
+extern f64 lbl_8032FF10;
+extern u8 lbl_801EADC8[32];
+extern "C" f32 RandF__5CMathFv(CMath* instance);
+
+struct RandUpCVParams {
+    s32 index;
+    s32 colorOffset;
+    s8 delta[4];
+    u8 randomTwice;
+    u8 pad[3];
+};
+
+struct RandUpCVCtx {
+    u8 _pad[0xC];
+    s32* valueOffset;
+};
+
+union RandUpCVConv {
+    f64 d;
+    struct {
+        u32 hi;
+        u32 lo;
+    } parts;
+};
 
 /*
  * --INFO--
@@ -12,66 +39,50 @@ extern CMath math;
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandUpCV(void* param1, void* param2, void* param3) {
-    int* p1 = (int*)param1;
-    int* p2 = (int*)param2;
-    int* p3 = (int*)param3;
-    float multiplier;
-    
-    // Check global state variable
-    extern int lbl_8032ED70;
+void pppRandUpCV(void* param1, void* param2, void* param3)
+{
     if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    // Check if first param matches third param offset
-    if (p2[0] != p1[3]) {
-        if (p2[0] == -1) {
-            // Use global default color
-            extern unsigned char lbl_801EADC8[4];
-            unsigned char* color = lbl_801EADC8;
-            
-            // Process color components 
-            if (((unsigned char*)p2)[12] != 0) {
-                math.RandF();
-                math.RandF();
-                multiplier = 0.5f; // Simplified placeholder
-            }
-            
-            // Get base value
-            float* basePtr = (float*)((unsigned char*)p3[3] + 0x80 + p1[0]);
-            float baseValue = *basePtr;
-            
-            // Update color components
-            for (int i = 0; i < 4; i++) {
-                signed char delta = ((signed char*)p2)[8 + i];
-                unsigned char currentColor = color[i];
-                
-                float variation = (float)delta * baseValue;
-                int newValue = currentColor + (int)variation;
-                
-                color[i] = (unsigned char)newValue;
-            }
-        } else {
-            // Use computed base address
-            unsigned char* base = (unsigned char*)p1 + 0x80 + p2[1];
-            
-            // Get base value
-            float* basePtr = (float*)((unsigned char*)p3[3] + 0x80 + p1[0]);
-            float baseValue = *basePtr;
-            
-            // Update color components
-            for (int i = 0; i < 4; i++) {
-                signed char delta = ((signed char*)p2)[8 + i];
-                unsigned char currentColor = base[i];
-                
-                float variation = (float)delta * baseValue;
-                int newValue = currentColor + (int)variation;
-                
-                base[i] = (unsigned char)newValue;
-            }
+
+    u8* base = (u8*)param1;
+    RandUpCVParams* in = (RandUpCVParams*)param2;
+    RandUpCVCtx* ctx = (RandUpCVCtx*)param3;
+    s32 state = *(s32*)(base + 0xC);
+
+    if (in->index == state) {
+        f32 value = RandF__5CMathFv(&math);
+        if (in->randomTwice != 0) {
+            value = (value + RandF__5CMathFv(&math)) * lbl_8032FF08;
         }
+        *(f32*)(base + *ctx->valueOffset + 0x80) = value;
+    } else if (in->index != state) {
+        return;
     }
+
+    f32 scale = *(f32*)(base + *ctx->valueOffset + 0x80);
+
+    u8* target;
+    if (in->colorOffset == -1) {
+        target = lbl_801EADC8;
+    } else {
+        target = base + in->colorOffset + 0x80;
+    }
+
+    RandUpCVConv cvt;
+    cvt.parts.hi = 0x43300000;
+
+    cvt.parts.lo = (u32)((s32)in->delta[0] ^ 0x8000);
+    target[0] = (u8)(target[0] + (s32)((cvt.d - lbl_8032FF10) * scale));
+
+    cvt.parts.lo = (u32)((s32)in->delta[1] ^ 0x8000);
+    target[1] = (u8)(target[1] + (s32)((cvt.d - lbl_8032FF10) * scale));
+
+    cvt.parts.lo = (u32)((s32)in->delta[2] ^ 0x8000);
+    target[2] = (u8)(target[2] + (s32)((cvt.d - lbl_8032FF10) * scale));
+
+    cvt.parts.lo = (u32)((s32)in->delta[3] ^ 0x8000);
+    target[3] = (u8)(target[3] + (s32)((cvt.d - lbl_8032FF10) * scale));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced placeholder logic in `pppRandUpCV` with a structured implementation matching nearby `pppRandUp*` modules.
- Added explicit parameter/context structs, proper extern declarations, and the expected random-generation + color-update flow.
- Implemented per-channel signed-delta conversion using PPC-style double-bias conversion (`0x4330`/`^ 0x8000`) to better align code generation.

## Functions improved
- Unit: `main/pppRandUpCV`
- Symbol: `pppRandUpCV`
- Match: **16.8% -> 62.42373%**

## Match evidence
- Selector baseline (`tools/agent_select_target.py`): `pppRandUpCV` at **16.8%**.
- Post-change objdiff (`build/tools/objdiff-cli diff -p . -u main/pppRandUpCV -o - pppRandUpCV`):
  - `.text`/symbol match for `pppRandUpCV`: **62.42373%**.
- Improvement is from real instruction alignment (control flow + FP/int conversion pattern), not rename/format-only changes.

## Plausibility rationale
- The rewrite follows established local patterns used by adjacent modules (`pppRandUpChar`, `pppRandUpHCV`, `pppRandCV`) rather than ad-hoc compiler coaxing.
- Data flow is source-plausible for effect logic: gate on global state, generate/update a random scale for matching index, then apply 4 signed channel deltas to either object-local color data or global fallback color storage.
- Kept implementation clean: no assembly comments, no dead debug code, and no unrelated file modifications.

## Technical details
- Normalized inputs via:
  - `RandUpCVParams` (`index`, `colorOffset`, `delta[4]`, `randomTwice`)
  - `RandUpCVCtx` (pointer to runtime value offset)
- Random branch now uses `RandF__5CMathFv(&math)` with optional second sample scaled by `lbl_8032FF08`.
- Channel updates now use explicit conversion through a `f64` union with high word `0x43300000` and sign bias subtraction against `lbl_8032FF10` before scaling.
