### PR TITLE
mapanim: add dtor_8004AE60 deleting-destructor thunk

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -75,6 +75,27 @@ CPtrArray<CMapAnimNode*>::~CPtrArray()
 
 /*
  * --INFO--
+ * PAL Address: 0x8004ae60
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CPtrArray<CMapAnimNode*>* dtor_8004AE60(CPtrArray<CMapAnimNode*>* ptrArray, short param_2)
+{
+    if (ptrArray != 0) {
+        ptrArray->m_vtable = lbl_801EA488;
+        ptrArray->RemoveAll();
+        if (0 < param_2) {
+            __dl__FPv(ptrArray);
+        }
+    }
+    return ptrArray;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x8004aebc
  * PAL Size: 112b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added `dtor_8004AE60` in `src/mapanim.cpp` as a C-linkage deleting-destructor thunk for `CPtrArray<CMapAnimNode*>`.
- Implemented behavior to match expected source semantics: null-check, reset vtable, call `RemoveAll()`, and call `__dl__FPv` when delete flag (`param_2`) is positive.
- Kept existing class code readable and source-plausible (no compiler-coaxing temporaries or assembly artifacts).

## Functions Improved
- Unit: `main/mapanim`
- Function: `dtor_8004AE60`
  - Before: unmatched (`-1` in report for this symbol)
  - After: `100.0%` fuzzy match

## Match Evidence
- `main/mapanim` unit fuzzy match:
  - Before: `27.900475%`
  - After: `30.625593%`
- `main/mapanim` matched code:
  - Before: `360 / 3376`
  - After: `452 / 3376` (+92 bytes)
- `main/mapanim` matched functions:
  - Before: `5 / 16`
  - After: `6 / 16`
- Project-wide code matched:
  - Before: `184020 / 1855300`
  - After: `184112 / 1855300` (+92 bytes)

## Plausibility Rationale
- The target object already expects a standalone `dtor_8004AE60` symbol at this address/size.
- The implemented logic follows normal Metrowerks deleting-destructor patterns seen elsewhere in this repo (`dtor_*` thunks with delete flag handling).
- Change is localized to one function and does not introduce synthetic control flow or non-idiomatic constructs.

## Technical Notes
- Build verified with `ninja`.
- Post-build report confirms exact symbol-level recovery for `dtor_8004AE60` and net positive unit/global progress.
