### PR TITLE
Improve pppYmDeformationMdl matching via UnkB layout correction

### DIFF
--- a/include/ffcc/pppYmDeformationMdl.h
+++ b/include/ffcc/pppYmDeformationMdl.h
@@ -12,11 +12,15 @@ struct UnkC {
 
 struct UnkB {
     s32 m_graphId;
-    u16 m_dataValIndex;
-    s16 m_initWOrk;
+    s32 m_dataValIndex;
+    f32 m_initWOrk;
     f32 m_stepValue;
     f32 m_arg3;
-    f32* m_payload;
+    f32 m_payload0;
+    f32 m_payload1;
+    f32 m_payload2;
+    s16 m_payload3;
+    u8 m_payloadBytes[0x1A];
 };
 
 struct pppYmDeformationMdl {

--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -157,21 +157,21 @@ void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* pa
         psVar1 = (s16*)((u8*)pppYmDeformationMdl + 0x80 + param_3->m_serializedDataOffsets[2]);
 
         CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-            (float)param_2->m_initWOrk, pppYmDeformationMdl, param_2->m_graphId, (float*)(psVar1 + 2),
+            param_2->m_initWOrk, pppYmDeformationMdl, param_2->m_graphId, (float*)(psVar1 + 2),
             (float*)(psVar1 + 4), (float*)(psVar1 + 6), &param_2->m_stepValue, &param_2->m_arg3);
         CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-            *param_2->m_payload, pppYmDeformationMdl, param_2->m_graphId, (float*)(psVar1 + 8),
-            (float*)(psVar1 + 10), (float*)(psVar1 + 0xC), param_2->m_payload + 1, param_2->m_payload + 2);
+            param_2->m_payload0, pppYmDeformationMdl, param_2->m_graphId, (float*)(psVar1 + 8),
+            (float*)(psVar1 + 10), (float*)(psVar1 + 0xC), &param_2->m_payload1, &param_2->m_payload2);
 
         if (DAT_8032ed78 == 0) {
             if (*(u8*)(psVar1 + 1) == 0) {
                 *psVar1 = *psVar1 - (s16)(int)*(float*)(psVar1 + 8);
-                if ((int)*psVar1 < -(int)(s16)param_2->m_payload[3]) {
+                if ((int)*psVar1 < -(int)param_2->m_payload3) {
                     *(u8*)(psVar1 + 1) = 1;
                 }
             } else {
                 *psVar1 = *psVar1 + (s16)(int)*(float*)(psVar1 + 8);
-                if ((s16)param_2->m_payload[3] < *psVar1) {
+                if (param_2->m_payload3 < *psVar1) {
                     *(u8*)(psVar1 + 1) = 0;
                 }
             }
@@ -191,7 +191,7 @@ void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* pa
 void pppRenderYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, UnkB* param_2, UnkC* param_3)
 {
     short* state = (short*)((u8*)pppYmDeformationMdl + 0x80 + param_3->m_serializedDataOffsets[2]);
-    u8* control = (u8*)param_2->m_payload;
+    u8* control = (u8*)&param_2->m_payload0;
     int textureIndex = 0;
 
     if (param_2->m_dataValIndex == 0xFFFF) {


### PR DESCRIPTION
## Summary
- Updated `UnkB` field layout in `pppYmDeformationMdl` to better match observed PAL access patterns.
- Replaced pointer-based payload access with inline field access in frame/render paths.
- Kept behavior intact while changing type/layout semantics to align with emitted load/store offsets.

## Functions Improved
- `pppFrameYmDeformationMdl`
  - Before: `27.246754%`
  - After:  `49.532467%`
- `pppRenderYmDeformationMdl`
  - Before: `82.51734%`
  - After:  `83.4711%`

## Unit Match Evidence
- Unit: `main/pppYmDeformationMdl`
- `.text` match before: `73.86283%`
- `.text` match after:  `78.38938%`

## Objdiff Notes
- `pppFrameYmDeformationMdl` diff markers were reduced significantly in key categories:
  - `DIFF_INSERT`: `34 -> 19`
  - `DIFF_ARG_MISMATCH`: `29 -> 13`
  - `DIFF_REPLACE`: `9 -> 3`
- Remaining differences are concentrated in control-flow tail and a subset of branch-local operations.

## Plausibility Rationale
- The previous model treated payload data as an indirect pointer, but PAL assembly accesses those values via direct offsets from `param_2`.
- Modeling these values as inline fields is a source-plausible correction consistent with packed effect parameter structs used in adjacent particle/ppp code.
