### PR TITLE
system: use CProcess descriptor block lookup in scenegraph ops

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -200,8 +200,10 @@ void CSystem::ExecScenegraph()
  */
 unsigned int CSystem::AddScenegraph(CProcess* process, int arg)
 {
+    typedef void* (*GetScenegraphBlockFn)(CProcess*, int);
+    GetScenegraphBlockFn getScenegraphBlock = *(GetScenegraphBlockFn*)((u8*)*(void**)process + 0x10);
     int insertIndex = 0;
-    u32* description = (u32*)this; // process->GetScenegraphBlock(arg));
+    u32* description = (u32*)getScenegraphBlock(process, arg);
     u32* entry = description + 7;
 	
     if (__ptmf_test((__ptmf*)(description + 1)))
@@ -259,7 +261,9 @@ unsigned int CSystem::AddScenegraph(CProcess* process, int arg)
  */
 void CSystem::RemoveScenegraph(CProcess* process, int arg)
 {
-    void* descBlock = (void*)this; // proc->GetScenegraphBlock(arg);
+    typedef void* (*GetScenegraphBlockFn)(CProcess*, int);
+    GetScenegraphBlockFn getScenegraphBlock = *(GetScenegraphBlockFn*)((u8*)*(void**)process + 0x10);
+    void* descBlock = getScenegraphBlock(process, arg);
     COrder* order = m_orderSentinel.m_next;
 	
     while (order != &m_orderSentinel)
@@ -279,10 +283,9 @@ void CSystem::RemoveScenegraph(CProcess* process, int arg)
         order = next;
     }
 	
-	// TODO: Obviously wrong
-    if (__ptmf_test((__ptmf*)descBlock + 0x10) != 0)
+    if (__ptmf_test((__ptmf*)((u8*)descBlock + 0x10)) != 0)
     {
-        __ptmf_scall();
+        __ptmf_scall(process);
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated `CSystem::AddScenegraph` and `CSystem::RemoveScenegraph` to fetch the process scenegraph descriptor block through the CProcess vtable entry at `+0x10` (instead of the previous placeholder using `this`).
- Fixed `RemoveScenegraph` to call `__ptmf_scall(process)` with the correct receiver, and adjusted the `__ptmf_test` address calculation to test the descriptor block callback slot.

## Functions improved
- Unit: `main/system`
- Symbol: `RemoveScenegraph__7CSystemFP8CProcessi`
  - Before: `57.47059%`
  - After: `76.21568%`
- Symbol: `AddScenegraph__7CSystemFP8CProcessi`
  - Before: `64.48485%`
  - After: `67.30303%`

## Match evidence
- Measured with `build/tools/objdiff-cli diff -p . -u main/system -o - --format json` and symbol-level extraction.
- Controlled before/after was captured by rebuilding `system.o` once without the patch and once with the patch in the same branch/session.

## Plausibility rationale
- The previous code paths were explicit placeholders (`this` used as descriptor block source, and a clearly marked incorrect `__ptmf_scall()` call).
- The new code mirrors the observed engine pattern: descriptor block retrieved from a process virtual function and used for order registration/removal callbacks.
- This is a source-plausible correction of API flow and callback ownership, not compiler-coaxing.

## Technical details
- `AddScenegraph` now uses a typed function pointer loaded from `*(process->vtable + 0x10)` to resolve the descriptor block before PTMF checks and entry insertion.
- `RemoveScenegraph` uses the same descriptor block lookup for block identity removal, then performs PTMF teardown callback check at `descBlock + 0x10` and invokes `__ptmf_scall(process)` when present.
- Build verification: `ninja` passes.