### PR TITLE
math: add static init for global CMath singleton

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -2,6 +2,28 @@
 
 #include "dolphin/mtx.h"
 #include "string.h"
+
+CMath math;
+
+extern void* __vt__8CManager;
+extern void* __vt__5CMath;
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001c2d0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_math_cpp()
+{
+    char* const base = reinterpret_cast<char*>(&math);
+    *reinterpret_cast<void**>(base) = &__vt__8CManager;
+    *reinterpret_cast<void**>(base) = &__vt__5CMath;
+}
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- define the global `CMath` singleton in `src/math.cpp` as `math`
- add explicit `__sinit_math_cpp` initializer matching the project pattern used by other singleton modules
- initialize the singleton vtable sequence in static init (`__vt__8CManager` then `__vt__5CMath`)

## Functions improved
- Unit: `main/math`
- Symbol: `__sinit_math_cpp`
  - before: `0.0%`
  - after: `32.5%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/math -o - __sinit_math_cpp`
  - symbol match increased from `0.0%` to `32.5%`
- unit `.text` match (objdiff section metric) increased from `1.8105916` to `1.9346374`

## Plausibility rationale
- this change restores a canonical game-singleton pattern already present in the codebase (`<module>.cpp` defines a global manager object plus explicit `__sinit_<module>_cpp` vtable setup)
- the initializer writes only class vtable pointers and does not add coercive/unnatural control flow

## Technical details
- the initializer is emitted with C linkage as `__sinit_math_cpp`
- stores are performed directly on global `math` in the static init function to align with target startup semantics
