### PR TITLE
gx/GXBump: improve GXSetIndTexMtx match by 2.76%

### DIFF
--- a/src/gx/GXBump.c
+++ b/src/gx/GXBump.c
@@ -39,9 +39,9 @@ void GXSetTevIndirect(GXTevStageID tev_stage, GXIndTexStageID ind_stage, GXIndTe
 #pragma dont_inline reset
 
 void GXSetIndTexMtx(GXIndTexMtxID mtx_id, const f32 offset[2][3], s8 scale_exp) {
-    s32 mtx[6];
-    u32 reg;
     u32 id;
+    u32 scale;
+    u32 reg;
 
     CHECK_GXBEGIN(186, "GXSetIndTexMtx");
 
@@ -66,32 +66,25 @@ void GXSetIndTexMtx(GXIndTexMtxID mtx_id, const f32 offset[2][3], s8 scale_exp) 
         break;
     }
 
-    mtx[0] = (int)(1024.0f * offset[0][0]) & 0x7FF;
-    mtx[1] = (int)(1024.0f * offset[1][0]) & 0x7FF;
-    scale_exp += 17;
-    reg = 0;
-    SET_REG_FIELD(208, reg, 11, 0, mtx[0]);
-    SET_REG_FIELD(209, reg, 11, 11, mtx[1]);
-    SET_REG_FIELD(210, reg, 2, 22, scale_exp & 3);
-    SET_REG_FIELD(211, reg, 8, 24, id * 3 + 6);
+    id *= 3;
+    scale = (u8)(s8)(scale_exp + 17);
+
+    reg = ((s32)(1024.0f * offset[0][0]) & 0x7FF);
+    reg |= ((s32)(1024.0f * offset[1][0]) & 0x7FF) << 11;
+    reg |= (scale & 3) << 22;
+    reg |= (id + 6) << 24;
     GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, reg);
 
-    mtx[2] = (int)(1024.0f * offset[0][1]) & 0x7FF;
-    mtx[3] = (int)(1024.0f * offset[1][1]) & 0x7FF;
-    reg = 0;
-    SET_REG_FIELD(217, reg, 11, 0, mtx[2]);
-    SET_REG_FIELD(218, reg, 11, 11, mtx[3]);
-    SET_REG_FIELD(219, reg, 2, 22, (scale_exp >> 2) & 3);
-    SET_REG_FIELD(220, reg, 8, 24, id * 3 + 7);
+    reg = ((s32)(1024.0f * offset[0][1]) & 0x7FF);
+    reg |= ((s32)(1024.0f * offset[1][1]) & 0x7FF) << 11;
+    reg |= (scale & 0xC) << 20;
+    reg |= (id + 7) << 24;
     GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, reg);
 
-    mtx[4] = (int)(1024.0f * offset[0][2]) & 0x7FF;
-    mtx[5] = (int)(1024.0f * offset[1][2]) & 0x7FF;
-    reg = 0;
-    SET_REG_FIELD(226, reg, 11, 0, mtx[4]);
-    SET_REG_FIELD(227, reg, 11, 11, mtx[5]);
-    SET_REG_FIELD(228, reg, 2, 22, (scale_exp >> 4) & 3);
-    SET_REG_FIELD(229, reg, 8, 24, id * 3 + 8);
+    reg = ((s32)(1024.0f * offset[0][2]) & 0x7FF);
+    reg |= ((s32)(1024.0f * offset[1][2]) & 0x7FF) << 11;
+    reg |= (scale & 0x30) << 18;
+    reg |= (id + 8) << 24;
     GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, reg);
 
     __GXData->bpSentNot = 0;


### PR DESCRIPTION
## Summary
- Reworked `GXSetIndTexMtx` register construction to use direct packed bit composition instead of temporary matrix arrays and `SET_REG_FIELD` staging.
- Kept behavior equivalent while reshaping code to match likely original SDK expression/control-flow patterns.

## Functions Improved
- Unit: `main/gx/GXBump`
- Symbol: `GXSetIndTexMtx`

## Match Evidence
- `GXSetIndTexMtx`: **62.69318% -> 65.454544%** (`+2.761364`)
- Checked neighbor symbols for regressions in the same unit:
  - `GXSetIndTexCoordScale`: 65.4% -> 65.4% (no change)
  - `GXSetIndTexOrder`: 67.246376% -> 67.246376% (no change)
- Validation commands used:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXBump -o - GXSetIndTexMtx`

## Plausibility Rationale
- The update removes decompiler-style temporaries and expresses register packing in the direct style typical of Nintendo GX SDK code.
- Scale exponent bits are now packed with mask/shift patterns that mirror expected hardware register layout.
- No artificial control-flow tricks or readability regressions were introduced.

## Technical Details
- Changed scale handling to a signed-8-bit-adjusted value before bit extraction.
- Replaced three `SET_REG_FIELD` groups with direct composition:
  - matrix coefficients packed into 11-bit fields
  - scale bits packed as `(scale & 3) << 22`, `(scale & 0xC) << 20`, `(scale & 0x30) << 18`
  - BP register ID packed using `id * 3 + {6,7,8}`
