### PR TITLE
Improve match for pppFrameYmCheckBGHeight

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -15,6 +15,18 @@ extern float FLOAT_80330ed4;
 extern float FLOAT_80330ed8;
 extern float FLOAT_80330edc;
 
+struct CMapCylinderRaw
+{
+    Vec m_bottom;
+    Vec m_direction;
+    float m_radius;
+    float m_height;
+    Vec m_top;
+    Vec m_direction2;
+    float m_radius2;
+    float m_height2;
+};
+
 extern "C" {
     int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(struct CMapMng*, CMapCylinder*, Vec*, unsigned int);
     void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
@@ -46,53 +58,52 @@ void pppConstructYmCheckBGHeight(void)
  */
 struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pppYmCheckBGHeight, struct UnkC* param_2)
 {
-    struct _pppMngSt* pppMngSt;
-    CMapCylinder cyl;
+    _pppMngSt* pppMngSt;
+    CMapCylinderRaw cyl;
     Vec hitPos;
-    double posY;
+    double currentY;
 
     pppMngSt = pppMngStPtr;
-    if (DAT_8032ed70 == 0) {
-        cyl.m_direction.x = FLOAT_80330ed0;
-        cyl.m_direction.y = FLOAT_80330ed4;
-        cyl.m_direction.z = FLOAT_80330ed0;
-
-        posY = (double)pppMngStPtr->m_matrix.value[1][3];
-        cyl.m_bottom.x = pppMngStPtr->m_matrix.value[0][3];
-        cyl.m_bottom.z = pppMngStPtr->m_matrix.value[2][3];
-        cyl.m_bottom.y = (float)(posY + (double)(float)param_2->m_unk0x4);
-
-        cyl.m_direction2.x = FLOAT_80330ed8;
-        cyl.m_direction2.y = FLOAT_80330ed8;
-        cyl.m_direction2.z = FLOAT_80330ed8;
-
-        cyl.m_radius2 = FLOAT_80330edc;
-        cyl.m_height2 = FLOAT_80330edc;
-        cyl.m_radius = FLOAT_80330edc;
-
-        cyl.m_top.x = FLOAT_80330ed0;
-        cyl.m_top.y = FLOAT_80330ed4;
-        cyl.m_top.z = FLOAT_80330ed0;
-        cyl.m_height = FLOAT_80330ed0;
-
-        if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &cyl, &cyl.m_direction, 0xffffffff) != 0) {
-            CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A88), &hitPos);
-            if ((float)(posY - (double)(float)param_2->m_serializedDataOffsets) <= hitPos.y) {
-                posY = (double)(hitPos.y + (float)param_2->m_unk0x8);
-            }
-        }
-
-        pppMngSt->m_position.y = (float)posY;
-        *((float*)pppMngSt + 0x17) = (float)posY; // m_savedPosition.y
-        *((float*)pppMngSt + 0x1B) = (float)posY; // m_paramVec0.y
-        *((float*)pppMngSt + 0x13) = (float)posY; // m_previousPosition.y
-
-        pppMngStPtr->m_matrix.value[0][3] = pppMngSt->m_position.x;
-        pppMngStPtr->m_matrix.value[1][3] = pppMngSt->m_position.y;
-        pppMngStPtr->m_matrix.value[2][3] = pppMngSt->m_position.z;
-
-        pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
+    if (DAT_8032ed70 != 0) {
+        return pppYmCheckBGHeight;
     }
 
-    return pppYmCheckBGHeight;
+    cyl.m_direction.x = FLOAT_80330ed0;
+    cyl.m_direction.y = FLOAT_80330ed4;
+    cyl.m_direction.z = FLOAT_80330ed0;
+
+    currentY = (double)pppMngSt->m_matrix.value[1][3];
+    cyl.m_bottom.x = pppMngSt->m_matrix.value[0][3];
+    cyl.m_bottom.z = pppMngSt->m_matrix.value[2][3];
+    cyl.m_bottom.y = (float)(currentY + (double)param_2->m_unk0x4);
+
+    cyl.m_direction2.x = FLOAT_80330ed8;
+    cyl.m_direction2.y = FLOAT_80330ed8;
+    cyl.m_direction2.z = FLOAT_80330ed8;
+
+    cyl.m_radius2 = FLOAT_80330edc;
+    cyl.m_height2 = FLOAT_80330edc;
+    cyl.m_radius = FLOAT_80330edc;
+
+    cyl.m_top.x = FLOAT_80330ed0;
+    cyl.m_top.y = FLOAT_80330ed4;
+    cyl.m_top.z = FLOAT_80330ed0;
+    cyl.m_height = FLOAT_80330ed0;
+
+    if ((CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, (CMapCylinder*)&cyl, &cyl.m_direction, 0xffffffff) != 0) &&
+        (CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A88), &hitPos),
+         (float)(currentY - (double)param_2->m_serializedDataOffsets) <= hitPos.y)) {
+        currentY = (double)(hitPos.y + param_2->m_unk0x8);
+    }
+
+    pppMngSt->m_position.y = (float)currentY;
+    *((float*)pppMngSt + 0x17) = (float)currentY;
+    *((float*)pppMngSt + 0x1B) = (float)currentY;
+    *((float*)pppMngSt + 0x13) = (float)currentY;
+
+    pppMngSt->m_matrix.value[0][3] = pppMngSt->m_position.x;
+    pppMngSt->m_matrix.value[1][3] = pppMngSt->m_position.y;
+    pppMngSt->m_matrix.value[2][3] = pppMngSt->m_position.z;
+
+    return (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppFrameYmCheckBGHeight` in `src/pppYmCheckBGHeight.cpp` to align more closely with expected PPC codegen.
- Replaced local `CMapCylinder` object usage with a POD-equivalent stack layout (`CMapCylinderRaw`) to avoid class-constructor codegen noise.
- Restructured control flow to early-return on `DAT_8032ed70 != 0` and used direct return from `pppSetFpMatrix__FP9_pppMngSt`.
- Consolidated matrix accesses through the cached `_pppMngSt*` local and kept collision/hit-position logic identical.

## Functions Improved
- Unit: `main/pppYmCheckBGHeight`
- Symbol: `pppFrameYmCheckBGHeight`

## Match Evidence
- `pppFrameYmCheckBGHeight`: **57.402298% -> 68.9885%** (`build/tools/objdiff-cli diff -p . -u main/pppYmCheckBGHeight -o - pppFrameYmCheckBGHeight`)
- Unit `.text` match: **57.886364% -> 69.340904%**

## Plausibility Rationale
- The resulting source remains natural gameplay/collision logic, not compiler-coaxing artifacts.
- The POD cylinder shape directly represents the cylinder data consumed by `CheckHitCylinderNear` and matches the decompiled stack-object pattern.
- The early-return and direct-return form is idiomatic and preserves behavior while improving generated assembly.

## Technical Notes
- The largest gain came from reducing C++ object semantics and register churn in the stack setup / branch structure.
- No behavioral changes were introduced: the same map hit query, threshold compare, Y adjustment, and matrix update sequence are preserved.
