### PR TITLE
mtx: improve C_MTXLightOrtho match via expression ordering

### DIFF
--- a/src/mtx/mtx.c
+++ b/src/mtx/mtx.c
@@ -1285,13 +1285,13 @@ void C_MTXLightOrtho(Mtx m, f32 t, f32 b, f32 l, f32 r, float scaleS, float scal
     m[0][0] = (2.0f * tmp * scaleS);
     m[0][1] = 0.0f;
     m[0][2] = 0.0f;
-    m[0][3] = ((-(r + l) * tmp) * scaleS) + transS;
+    m[0][3] = transS + scaleS * tmp * -(r + l);
 
     tmp = 1.0f / (t - b);
     m[1][0] = 0.0f;
     m[1][1] = (2.0f * tmp) * scaleT;
     m[1][2] = 0.0f;
-    m[1][3] = ((-(t + b) * tmp) * scaleT) + transT;
+    m[1][3] = transT + scaleT * tmp * -(t + b);
 
     m[2][0] = 0.0f;
     m[2][1] = 0.0f;


### PR DESCRIPTION
## Summary
- Updated C_MTXLightOrtho in src/mtx/mtx.c to use translation-term expression ordering that better matches original codegen.
- Changed only m[0][3] and m[1][3] from ((-(a+b)*tmp)*scale)+trans to 	rans + scale * tmp * -(a+b).
- Behavioral intent is unchanged (algebraically equivalent expressions).

## Functions improved
- Unit: main/mtx/mtx
- Function: C_MTXLightOrtho (136b)
  - Before: 78.67647%
  - After: 82.50000%

## Match evidence
- Unit fuzzy match (main/mtx/mtx) improved:
  - Before: 25.407633%
  - After: 25.606108%
- Build/progress remained stable globally (
inja passes; no linked regressions introduced by this patch).

## Plausibility rationale
- The change is source-plausible and readable C, not contrived compiler coaxing.
- It aligns arithmetic grouping/order with SDK-style matrix projection code patterns used elsewhere.

## Technical details
- Translation terms now place the translation constant as the leading addend and keep multiplicative factors grouped consistently.
- This altered FP operation ordering in the generated code and improved alignment for C_MTXLightOrtho.