### PR TITLE
astar: improve calcPolygonGroup mask selection path

### DIFF
--- a/include/ffcc/p_dbgmenu.h
+++ b/include/ffcc/p_dbgmenu.h
@@ -43,6 +43,9 @@ public:
     void Add();
     void Add(int, int, CDMParam&);
     void Delete(int);
+    int GetDbgFlag();
 };
+
+extern CDbgMenuPcs DbgMenuPcs;
 
 #endif // _FFCC_P_DBGMENU_H_

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -5,6 +5,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/pad.h"
 #include "ffcc/partyobj.h"
+#include "ffcc/p_dbgmenu.h"
 #include "ffcc/system.h"
 #include "ffcc/vector.h"
 
@@ -917,6 +918,12 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 {
 	unsigned char polygonGroup = 0;
+	unsigned long mask = static_cast<unsigned long>(hitAttributeMask);
+
+	if ((DbgMenuPcs.GetDbgFlag() & 1) != 0)
+	{
+		mask = m_hitAttributeMask;
+	}
 
 	CVector bottom(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 	CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
@@ -939,9 +946,10 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 	cyl.m_radius2 = 0.0f;
 	cyl.m_height2 = 0.0f;
 
-	unsigned long mask = static_cast<unsigned long>(hitAttributeMask);
-
-	MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), mask);
+	if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), mask) != 0)
+	{
+		polygonGroup = lbl_8032EC90[0x47];
+	}
 
 	return polygonGroup;
 }


### PR DESCRIPTION
## Summary
- Added missing debug-flag API declaration for `CDbgMenuPcs` and exposed global `DbgMenuPcs` declaration in `include/ffcc/p_dbgmenu.h`.
- Updated `CAStar::calcPolygonGroup(Vec*, int)` to:
  - choose the collision mask from `hitAttributeMask` in normal mode
  - switch to `m_hitAttributeMask` when debug flag bit 0 is set
  - assign `polygonGroup` from `lbl_8032EC90[0x47]` when `CheckHitCylinderNear` reports a hit

## Functions improved
- Unit: `main/astar`
- Function: `calcPolygonGroup__6CAStarFP3Veci`

## Match evidence
- `main/astar` unit fuzzy match: **68.279495% -> 68.45132%**
- `calcPolygonGroup__6CAStarFP3Veci`: **35.581196% -> 38.145298%**
- `calcSpecialPolygonGroup__6CAStarFP3Vec`: unchanged at **47.333332%**

## Plausibility rationale
- The new flow matches existing game code style by using the existing debug menu flag getter (`GetDbgFlag`) rather than hardcoded address arithmetic.
- Selecting between per-call mask and member mask based on a debug flag is behaviorally plausible for debug collision inspection.
- The hit-result assignment restores observable gameplay behavior (nonzero polygon group on hit), which aligns with surrounding `CAStar` pathing logic.

## Technical details
- Build validated with `ninja`.
- Match deltas were measured from `build/GCCP01/report.json` function-level fuzzy metrics after rebuild.