### PR TITLE
pppShape: implement draw shape and UV helpers

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -36,17 +36,65 @@ void* pppShapeSt::GetTexture(long* animData, CMaterialSet* materialSet, int& tex
  */
 void pppDrawShp(long* animData, short frameIndex, CMaterialSet* materialSet, unsigned char blendMode)
 {
-    // TODO: Implement function body
+    int shapePtr = (int)animData + *(short*)((int)animData + frameIndex * 8 + 0x10);
+
+    *(int*)((char*)&MaterialMan + 296) = *(int*)((char*)&MaterialMan + 284);
+    *(int*)((char*)&MaterialMan + 300) = *(int*)((char*)&MaterialMan + 288);
+    *(int*)((char*)&MaterialMan + 304) = *(int*)((char*)&MaterialMan + 292);
+    *(int*)((char*)&MaterialMan + 64) = *(int*)((char*)&MaterialMan + 72);
+
+    SetMaterialPart__12CMaterialManFP12CMaterialSetii(&MaterialMan, materialSet,
+                                                      *(unsigned char*)(shapePtr + 10), 0);
+
+    GXClearVtxDesc();
+    GXSetVtxDesc((GXAttr)9, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)11, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)13, GX_DIRECT);
+
+    int current = shapePtr;
+    for (int i = 0; i < *(short*)(shapePtr + 2); i++) {
+        if (blendMode == 0xFF) {
+            pppSetBlendMode__FUc(*(unsigned char*)(current + 8));
+        }
+        GXCallDisplayList(*(void**)(current + 0xc), 0x60);
+        current += 8;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80065a94
+ * PAL Size: 224b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDrawShp(tagOAN3_SHAPE*, CMaterialSet*, unsigned char)
+void pppDrawShp(tagOAN3_SHAPE* shape, CMaterialSet* materialSet, unsigned char blendMode)
 {
-	// TODO
+    int shapePtr = (int)shape;
+
+    *(int*)((char*)&MaterialMan + 296) = *(int*)((char*)&MaterialMan + 284);
+    *(int*)((char*)&MaterialMan + 300) = *(int*)((char*)&MaterialMan + 288);
+    *(int*)((char*)&MaterialMan + 304) = *(int*)((char*)&MaterialMan + 292);
+    *(int*)((char*)&MaterialMan + 64) = *(int*)((char*)&MaterialMan + 72);
+
+    SetMaterialPart__12CMaterialManFP12CMaterialSetii(&MaterialMan, materialSet,
+                                                      *(unsigned char*)(shapePtr + 10), 0);
+
+    GXClearVtxDesc();
+    GXSetVtxDesc((GXAttr)9, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)11, GX_DIRECT);
+    GXSetVtxDesc((GXAttr)13, GX_DIRECT);
+
+    int current = shapePtr;
+    for (int i = 0; i < *(short*)(shapePtr + 2); i++) {
+        if (blendMode == 0xFF) {
+            pppSetBlendMode__FUc(*(unsigned char*)(current + 8));
+        }
+        GXCallDisplayList(*(void**)(current + 0xc), 0x60);
+        current += 8;
+    }
 }
 
 /*
@@ -191,12 +239,25 @@ void pppGetShapePos(long* animData, short frameIndex, Vec& minPos, Vec& maxPos, 
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800656dc
+ * PAL Size: 184b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppGetShapeUV(long*, short, Vec2d&, Vec2d&, int)
+void pppGetShapeUV(long* animData, short frameIndex, Vec2d& minUv, Vec2d& maxUv, int shapeIndex)
 {
-	// TODO
+    int shapeBase = *(short*)((int)animData + frameIndex * 8 + 0x10);
+    int shapeEntry = *(int*)((int)animData + shapeBase + 0xc + shapeIndex * 8);
+    float* minUvF = (float*)&minUv;
+    float* maxUvF = (float*)&maxUv;
+    const float uvScale = 1.0f / 4096.0f;
+
+    minUvF[0] = (float)*(short*)(shapeEntry + 0x13) * uvScale;
+    minUvF[1] = (float)*(short*)(shapeEntry + 0x15) * uvScale;
+    maxUvF[0] = (float)*(short*)(shapeEntry + 0x3b) * uvScale;
+    maxUvF[1] = (float)*(short*)(shapeEntry + 0x3d) * uvScale;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three previously stubbed shape functions in `src/pppShape.cpp`:
  - `pppDrawShp(long*, short, CMaterialSet*, unsigned char)`
  - `pppDrawShp(tagOAN3_SHAPE*, CMaterialSet*, unsigned char)`
  - `pppGetShapeUV(long*, short, Vec2d&, Vec2d&, int)`
- Added PAL metadata headers for `pppDrawShp(tagOAN3_SHAPE*, ...)` and `pppGetShapeUV(...)`.
- Used existing project style (byte-offset reads, explicit GX setup, and existing mangled helper calls) rather than introducing synthetic helper layers.

## Functions Improved
Unit: `main/pppShape`
- `pppDrawShp__FPlsP12CMaterialSetUc`
- `pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc`
- `pppGetShapeUV__FPlsR5Vec2dR5Vec2di`

## Match Evidence
Before values from `tools/agent_select_target.py` for this unit:
- `pppDrawShp__FPlsP12CMaterialSetUc`: **1.6%**
- `pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc`: **1.8%**
- `pppGetShapeUV__FPlsR5Vec2dR5Vec2di`: **2.2%**

After (`tools/objdiff-cli diff -p . -u main/pppShape -o - <symbol>`):
- `pppDrawShp__FPlsP12CMaterialSetUc`: **72.09677%**
- `pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc`: **72.89286%**
- `pppGetShapeUV__FPlsR5Vec2dR5Vec2di`: **98.26087%**

Build validation:
- `ninja` passes on this branch.

## Plausibility Rationale
- The implementations follow expected original source behavior for this module: material-part setup, GX vertex descriptor initialization, per-entry display list submission, and short-to-UV scaling semantics.
- Changes align with existing code conventions in nearby PPP rendering code (direct offset-based serialized data access and explicit GX API calls).
- No coercive compiler-only constructs or artificial control-flow tricks were added.

## Technical Notes
- `pppDrawShp` overloads share the same operational flow, with one overload resolving frame-relative shape data and the other using a direct shape pointer.
- `pppGetShapeUV` now reads UV shorts from shape entries and converts to normalized UVs with `1.0f / 4096.0f`, matching expected fixed-point texture coordinate conversion.