### PR TITLE
Reconstruct pppVertexAp callback flow and signature

### DIFF
--- a/include/ffcc/pppVertexAp.h
+++ b/include/ffcc/pppVertexAp.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void pppVertexApCon(_pppPObject*, PVertexAp*);
-void pppVertexAp(void);
+void pppVertexAp(_pppPObject*, PVertexAp*, void*);
 
 #ifdef __cplusplus
 }

--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -1,4 +1,67 @@
 #include "ffcc/pppVertexAp.h"
+#include "ffcc/math.h"
+#include "ffcc/partMng.h"
+
+#include <dolphin/mtx.h>
+#include <dolphin/types.h>
+
+struct VertexApEntry
+{
+    s16 vertexSetIndex;
+    s16 maxValue;
+    u16* vertexIndices;
+};
+
+struct VertexApEnv
+{
+    u8 unk0[0x8];
+    void* unk8;
+    u8 unkC[0x4];
+    VertexApEntry* entries;
+};
+
+struct VertexApData
+{
+    u8 unk0[0x4];
+    s16 entryIndex;
+    u8 spawnCount;
+    u8 spawnDelay;
+    u8 mode;
+    u8 useWorldMtx;
+    u8 unkA[0x2];
+    u32 childId;
+    u32 childPosOffset;
+};
+
+struct VertexApState
+{
+    u16 index;
+    u16 countdown;
+};
+
+struct VertexApCtrl
+{
+    u8 unk0[0xC];
+    s32* stateOffset;
+};
+
+struct VertexApSource
+{
+    u8 unk0[0x2C];
+    Vec* points;
+};
+
+struct _pppPDataVal;
+
+extern CMath math;
+extern int lbl_8032ED70;
+extern u8* lbl_8032ED50;
+extern VertexApEnv* lbl_8032ED54;
+
+extern "C" {
+f32 RandF__5CMathFv(CMath*);
+_pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
+}
 
 /*
  * --INFO--
@@ -24,17 +87,114 @@ void pppVertexApCon(_pppPObject* pobj, PVertexAp* vtxAp)
  * Address:	TODO
  * Size:	TODO
  */
-void apea(_pppPObject*, PVertexAp*, Vec*)
-{
-	// TODO
-}
-
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800647e0
+ * PAL Size: 776b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppVertexAp(void)
+void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 {
-	// TODO
+    VertexApData* data = (VertexApData*)dataRaw;
+    VertexApCtrl* ctrl = (VertexApCtrl*)ctrlRaw;
+    s32 stateOffset = *ctrl->stateOffset;
+    VertexApState* state = (VertexApState*)((u8*)parent + stateOffset + 0x80);
+
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
+
+    if (data->entryIndex < 0) {
+        return;
+    }
+
+    if (state->countdown == 0) {
+        VertexApEntry* entry = &lbl_8032ED54->entries[data->entryIndex];
+        Vec* points = *(Vec**)((u8*)parent + 0x70);
+
+        if (points == 0) {
+            u32* srcTable = *(u32**)((u8*)lbl_8032ED54 + 0x8);
+            VertexApSource* src = *(VertexApSource**)((u8*)srcTable + (entry->vertexSetIndex * 4));
+            points = src->points;
+        }
+
+        u8 count = data->spawnCount;
+
+        if (data->mode == 0) {
+            while (count != 0) {
+                if (state->index >= (u16)entry->maxValue) {
+                    state->index = 0;
+                }
+
+                u16 vertexIndex = entry->vertexIndices[state->index];
+                state->index++;
+
+                Vec vtx = points[vertexIndex];
+
+                if ((data->childId + 0x10000) != 0xFFFF) {
+                    _pppPObject* child;
+                    _pppPDataVal* childData =
+                        (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
+
+                    if (childData == 0) {
+                        child = 0;
+                    } else {
+                        child = pppCreatePObject((_pppMngSt*)lbl_8032ED50, childData);
+                        *(void**)((u8*)child + 0x4) = parent;
+                    }
+
+                    Vec transformed;
+                    Vec* outPos = (Vec*)((u8*)child + data->childPosOffset + 0x80);
+
+                    PSMTXMultVec(*(Mtx*)((u8*)parent + 0x10), &vtx, &transformed);
+
+                    if (data->useWorldMtx == 0) {
+                        *outPos = transformed;
+                    } else {
+                        PSMTXMultVec(*(Mtx*)((u8*)lbl_8032ED50 + 0x78), &transformed, outPos);
+                    }
+                }
+
+                count--;
+            }
+        } else if (data->mode == 1) {
+            while (count != 0) {
+                u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
+                Vec vtx = points[vertexIndex];
+
+                if ((data->childId + 0x10000) != 0xFFFF) {
+                    _pppPObject* child;
+                    _pppPDataVal* childData =
+                        (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
+
+                    if (childData == 0) {
+                        child = 0;
+                    } else {
+                        child = pppCreatePObject((_pppMngSt*)lbl_8032ED50, childData);
+                        *(void**)((u8*)child + 0x4) = parent;
+                    }
+
+                    Vec transformed;
+                    Vec* outPos = (Vec*)((u8*)child + data->childPosOffset + 0x80);
+
+                    PSMTXMultVec(*(Mtx*)((u8*)parent + 0x10), &vtx, &transformed);
+
+                    if (data->useWorldMtx == 0) {
+                        *outPos = transformed;
+                    } else {
+                        PSMTXMultVec(*(Mtx*)((u8*)lbl_8032ED50 + 0x78), &transformed, outPos);
+                    }
+                }
+
+                count--;
+            }
+        }
+
+        state->countdown = data->spawnDelay;
+    }
+
+    state->countdown--;
 }


### PR DESCRIPTION
## Summary
- Corrected pppVertexAp prototype to the expected particle callback signature: (_pppPObject*, PVertexAp*, void*).
- Reconstructed pppVertexAp control flow and data layout from target assembly in uild/GCCP01/asm/pppVertexAp.s.
- Implemented vertex selection/spawn logic for mode 0 (sequential) and mode 1 (random), including child creation, local->world transform via PSMTXMultVec, and state countdown handling.
- Added PAL address/size metadata block for pppVertexAp.

## Functions Improved
- Unit: main/pppVertexAp
- Symbol: pppVertexAp

## Match Evidence
- pppVertexAp match: **0.5154639% -> 61.737114%**
- Unit .text match: **4.455446% -> 63.252476%**

## Plausibility Rationale
- Changes align with established source patterns already present in pppVertexApLc.cpp and pppVertexApMtx.cpp:
  - state-at-offset control blocks
  - spawn-mode branching
  - child object creation through pppCreatePObject
  - vector transform/writeback flow
- No contrived compiler-coaxing constructs were introduced; the implementation follows natural gameplay particle logic and consistent existing module style.

## Technical Details
- Recovered field offsets from disassembly for data/state/env structs (entryIndex, spawnCount, spawnDelay, mode, childId, childPosOffset, control stateOffset).
- Implemented fallback vertex source path through environment table when parent point array is null.
- Preserved countdown semantics: execute spawn block only when countdown is zero, then reload from spawnDelay, and decrement each frame.