### PR TITLE
main/ME_AppRequest: implement GetRsdItem and SetRsdFlag

### DIFF
--- a/include/ffcc/ME_AppRequest.h
+++ b/include/ffcc/ME_AppRequest.h
@@ -12,7 +12,7 @@ public:
     void DeleteRsdItem(RSDLISTITEM*);
     void DeleteColAnmData(ZCANMGRP**, int);
     void AddRsdList(ZLIST*);
-    void SetRsdFlag();
+    int SetRsdFlag();
     void GetRsdItemR();
     int SetRsdIndex();
     void GetRsdItem();

--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -43,12 +43,24 @@ void CMaterialEditorPcs::AddRsdList(ZLIST*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004dd70
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMaterialEditorPcs::SetRsdFlag()
+int CMaterialEditorPcs::SetRsdFlag()
 {
-	// TODO
+    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xB4);
+    int index = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC4);
+    int* rsd = reinterpret_cast<int*>(list->GetDataIdx(index));
+
+    if (rsd != nullptr) {
+        rsd[3] = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC0);
+    }
+
+    return rsd != nullptr;
 }
 
 /*
@@ -89,10 +101,16 @@ int CMaterialEditorPcs::SetRsdIndex()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004dce8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMaterialEditorPcs::GetRsdItem()
 {
-	// TODO
+    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xC8);
+    int index = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x9C);
+    list->GetDataIdx(index);
 }


### PR DESCRIPTION
## Summary
- Implemented `CMaterialEditorPcs::GetRsdItem()` using the inferred `ZLIST::GetDataIdx` call path from PAL decomp reference.
- Implemented `CMaterialEditorPcs::SetRsdFlag()` with index lookup + flag writeback behavior.
- Added PAL address/size metadata blocks for both functions.
- Updated declaration of `SetRsdFlag` to return `int` (0/1), matching observed decomp behavior.

## Functions improved
- Unit: `main/ME_AppRequest` (`src/ME_AppRequest.cpp`)
- `GetRsdItem__18CMaterialEditorPcsFv`: `10.0% -> 100.0%` (40b)
- `SetRsdFlag__18CMaterialEditorPcsFv`: `5.0% -> 75.85%` (80b)
- Unit fuzzy match now reports `27.182796%` in `build/GCCP01/report.json`.

## Match evidence
- Rebuilt with `ninja` (successful).
- Verified with `tools/objdiff-cli.exe diff -p . -u main/ME_AppRequest -o - --format json <symbol>`:
  - `GetRsdItem` now full instruction alignment.
  - `SetRsdFlag` now aligns in control flow and data access pattern with only residual mismatches.

## Plausibility rationale
- Changes follow natural source behavior for a material editor list-management path:
  - fetch list element by stored index,
  - update a flag field when entry exists,
  - return success/failure.
- No compiler-coaxing constructs were introduced; implementation remains straightforward and idiomatic relative to existing offset-based reconstruction in this unit.

## Technical details
- `GetRsdItem` was implemented as a direct list index lookup call (matching observed call sequence and stack shape for this symbol).
- `SetRsdFlag` mirrors the same list/index access style used by `SetRsdIndex`, then writes to the fourth `int` slot (`+0xC`) and returns non-null status.