### PR TITLE
card: improve CARDFastOpen match by simplifying permission fallback

### DIFF
--- a/src/card/CARDOpen.c
+++ b/src/card/CARDOpen.c
@@ -104,7 +104,6 @@ s32 CARDFastOpen(s32 chan, s32 fileNo, CARDFileInfo* fileInfo) {
     CARDControl* card;
     CARDDir* dir;
     CARDDir* ent;
-    u8 perm;
     s32 result;
 
     ASSERTLINE(278, 0 <= fileNo && fileNo < CARD_MAX_FILE);
@@ -121,22 +120,8 @@ s32 CARDFastOpen(s32 chan, s32 fileNo, CARDFileInfo* fileInfo) {
     dir = __CARDGetDirBlock(card);
     ent = &dir[fileNo];
     result = __CARDAccess(card, ent);
-    if (result == CARD_RESULT_NOPERM) {
-        perm = ent->permission & __CARDPermMask;
-        if (perm & CARD_ATTR_GLOBAL
-         && (memcmp(ent->gameName, __CARDDiskNone.gameName, sizeof(ent->gameName)) == 0
-          && memcmp(ent->company, __CARDDiskNone.company, sizeof(ent->company)) == 0))
-        {
-            result = CARD_RESULT_READY;
-        } else if (perm & CARD_ATTR_COMPANY
-                && (memcmp(ent->gameName, __CARDDiskNone.gameName, sizeof(ent->gameName)) == 0
-                 && memcmp(ent->company, card->diskID->company, sizeof(ent->company)) == 0))
-        {
-            result = CARD_RESULT_READY;
-        }
-    }
-    if (result == CARD_RESULT_NOPERM && (ent->permission & CARD_ATTR_PUBLIC))
-        result = CARD_RESULT_READY;
+    if (result == CARD_RESULT_NOPERM)
+        result = __CARDIsPublic(ent);
 
     if (0 <= result) {
         if (!CARDIsValidBlockNo(card, ent->startBlock))


### PR DESCRIPTION
## Summary
- Simplified `CARDFastOpen` permission fallback logic in `src/card/CARDOpen.c`.
- Removed inline global/company permission checks from this function and used `__CARDIsPublic(ent)` when `__CARDAccess` returns `CARD_RESULT_NOPERM`.

## Functions Improved
- Unit: `main/card/CARDOpen`
- Function: `CARDFastOpen`

## Match Evidence
- `CARDFastOpen` match: **53.386364% -> 99.88636%**
- Unit `.text` match: **88.67945% -> 99.89041%**
- Instruction diff markers in `CARDFastOpen`: **82 -> 2**

## Plausibility Rationale
- `CARDFastOpen` now follows a direct open/read path: access check first, then public-file fallback.
- The removed global/company path was over-expanded for this function and produced unnecessary control-flow/register divergence.
- Resulting code is cleaner and consistent with expected helper-driven style in this module.

## Technical Details
- The key change was replacing inlined permission branches with one helper call (`__CARDIsPublic`).
- This significantly improved control-flow and stack/register alignment in objdiff.