### PR TITLE
menu_favo: implement CMenuPcs::FavoCtrl

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/menu_favo.h"
+#include "ffcc/pad.h"
+#include "ffcc/sound.h"
 
 /*
  * --INFO--
@@ -141,12 +143,51 @@ void CMenuPcs::FavoOpen()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80162e94
+ * PAL Size: 400b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::FavoCtrl()
 {
-	// TODO
+	bool activeInput = false;
+	unsigned short press;
+	bool doReset;
+
+	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+		activeInput = true;
+	}
+
+	if (activeInput) {
+		press = 0;
+	} else {
+		press = Pad._8_2_;
+	}
+
+	doReset = false;
+	if (press != 0) {
+		if ((press & 0x20) != 0) {
+			*(short *)(*(int *)((char *)this + 0x82c) + 0x1e) = 1;
+			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
+			doReset = true;
+		} else if ((press & 0x40) != 0) {
+			*(short *)(*(int *)((char *)this + 0x82c) + 0x1e) = -1;
+			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
+			doReset = true;
+		} else if ((press & 0x100) != 0) {
+			Sound.PlaySe(4, 0x40, 0x7f, 0);
+		} else if ((press & 0x200) != 0) {
+			*(char *)(*(int *)((char *)this + 0x82c) + 0xd) = 1;
+			Sound.PlaySe(3, 0x40, 0x7f, 0);
+			doReset = true;
+		}
+	}
+
+	if (doReset) {
+		FavoInit0();
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMenuPcs::FavoCtrl()` in `src/menu_favo.cpp` and wired required includes (`pad.h`, `sound.h`).

Key changes:
- Added PAL metadata block for `FavoCtrl` (`0x80162e94`, `400b`)
- Implemented pad-triggered menu input handling using existing menu-controller patterns
- Added state writes for decision/cancel paths and corresponding `Sound.PlaySe(...)` calls
- Calls `FavoInit0()` when an action requires animation state reset

## Functions improved
- Unit: `main/menu_favo`
- Function: `FavoCtrl__8CMenuPcsFv`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/menu_favo FavoCtrl__8CMenuPcsFv`
  - Fuzzy match after: **73.01%**
- Unit snapshot (`tools/objdiff-cli report generate`)
  - `main/menu_favo` fuzzy match: **9.637918%**

Note: prior source for `FavoCtrl` was a TODO stub (`blr`-equivalent), so this is a substantial real alignment step rather than formatting-only churn.

## Plausibility rationale
This implementation follows existing codebase conventions used in other menu controllers (`TmpArtiCtrl`, `MoneyCtrlCur`):
- Input gating via `Pad._452_4_` / `Pad._448_4_`
- Trigger-mask branching (`0x20`, `0x40`, `0x100`, `0x200`)
- Menu state updates through known offsets on menu state storage
- Sound effect dispatch matching observed menu UX patterns

The result is source-plausible game menu logic, not compiler-coaxing.

## Technical details
- No contrived temporaries or reorder-only edits
- Kept function signature and surrounding structure intact
- Build verified with `ninja`