### PR TITLE
main/prgobj: implement CGPrgObj::onFrame first-pass decomp

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -22,12 +22,53 @@ void CGPrgObj::onDestroy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801278DC
+ * PAL Size: 500b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGPrgObj::onFrame()
 {
-	// TODO
+	if ((m_weaponNodeFlags & 0x8000) != 0) {
+		m_animFlags &= 0x7f;
+		onFramePreCalc();
+
+		if (m_stateFrameGate == 0) {
+			m_stateFrame++;
+		} else {
+			m_stateFrameGate = 0;
+		}
+
+		if (m_subFrameGate == 0) {
+			m_subFrame++;
+		} else {
+			m_subFrameGate = 0;
+		}
+
+		onFrameStat();
+		onFramePostCalc();
+
+		if ((m_animFlags & 0x80) != 0) {
+			if (m_reqAnimId == -1) {
+				if (m_currentAnimSlot > -1) {
+					*reinterpret_cast<float*>(m_lastBgAttr) = 0.0f;
+					CancelAnim(0);
+				}
+			} else {
+				if ((m_animFlags & 0x20) != 0) {
+					*reinterpret_cast<float*>(m_lastBgAttr) = 1.0f;
+				} else {
+					*reinterpret_cast<float*>(m_lastBgAttr) = 0.0f;
+				}
+
+				PlayAnim(m_reqAnimId, (m_animFlags & 0x40) ? -1 : 0, 0, -1, -1, 0);
+			}
+
+			m_animFlags &= 0x7f;
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGPrgObj::onFrame()` in `src/prgobj.cpp` from current TODO stub using reconstructed control flow.
- Added PAL metadata header for the function (`0x801278DC`, `500b`).
- Implemented frame-gate progression and animation request handling using existing class fields/methods.

## Functions Improved
- Unit: `main/prgobj`
- Symbol: `onFrame__8CGPrgObjFv`

## Match Evidence
- `objdiff-cli` (v3.6.1) symbol diff:
  - Before: **0.8%**
  - After: **40.968%**
- `build/GCCP01/report.json` fuzzy match for symbol after build:
  - **41.56%**

## Plausibility Rationale
- Uses existing object lifecycle/frame APIs and field semantics.
- No hardcoded object offsets, no synthetic temp variables, no compiler-coaxing-only constructs.

## Technical Details
- First pass omits unresolved `PartPcs` frame-block gate because that global/member typing is not available in current headers.
- Despite that, assembly alignment improved substantially and provides a strong baseline for follow-up tuning.