### PR TITLE
maphit: improve constructor codegen alignment

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -41,13 +41,13 @@ CMapCylinder::CMapCylinder()
  */
 CMapHit::CMapHit()
 {
-    m_positionMin.x = 0.0f;
-    m_positionMin.y = 0.0f;
     m_positionMin.z = 0.0f;
+    m_positionMin.y = 0.0f;
+    m_positionMin.x = 0.0f;
 
-    m_positionMax.x = 1.0f;
-    m_positionMax.y = 1.0f;
     m_positionMax.z = 1.0f;
+    m_positionMax.y = 1.0f;
+    m_positionMax.x = 1.0f;
 
     m_vertexCount = 0;
     m_faceCount = 0;
@@ -221,11 +221,11 @@ void CMapHit::DrawNormal()
  */
 CMapHitFace::CMapHitFace()
 {
-    m_boundsMin.x = 0.0f;
-    m_boundsMin.y = 0.0f;
     m_boundsMin.z = 0.0f;
+    m_boundsMin.y = 0.0f;
+    m_boundsMin.x = 0.0f;
 
-    m_boundsMax.x = 1.0f;
-    m_boundsMax.y = 1.0f;
     m_boundsMax.z = 1.0f;
+    m_boundsMax.y = 1.0f;
+    m_boundsMax.x = 1.0f;
 }


### PR DESCRIPTION
## Summary
- Reordered vector component initialization order in two constructors in `src/maphit.cpp`.
- Updated `CMapHit::CMapHit()` and `CMapHitFace::CMapHitFace()` to initialize components in `z, y, x` order.
- Kept behavior identical (same constants and fields), while improving emitted instruction argument ordering.

## Functions improved
- `__ct__7CMapHitFv` (`CMapHit::CMapHit()`)
- `__ct__11CMapHitFaceFv` (`CMapHitFace::CMapHitFace()`)
- Unit: `main/maphit`

## Match evidence
Measured with:
- `build/tools/objdiff-cli diff -p . -u main/maphit -o - __ct__7CMapHitFv`
- `build/tools/objdiff-cli diff -p . -u main/maphit -o - __ct__11CMapHitFaceFv`
- `build/tools/objdiff-cli diff -p . -u main/maphit -o -`

Before -> After:
- `__ct__7CMapHitFv`: `99.0%` -> `99.28571%`
- `__ct__11CMapHitFaceFv`: `98.44444%` -> `98.888885%`
- `main/maphit` `.text`: `1.3586916%` -> `1.3617345%`

## Plausibility rationale
- Initializing vector components in reverse component order is common in this codebase/decomp context and is source-plausible.
- No contrived temporaries, no ABI hacks, and no readability regressions were introduced.
- The update is a minimal semantic-preserving source change that improves real instruction alignment.

## Technical details
- Prior diffs were mostly `DIFF_ARG_MISMATCH` on `stfs` offsets in constructor stores.
- Reordering assignment sequence moved emitted store offsets closer to target (`z/y/x` order), reducing those mismatches.
