### PR TITLE
pppCrystal: restore destruct cleanup and tighten construct pointer setup

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/pppCrystal.h"
 #include "ffcc/memory.h"
+#include "ffcc/pppPart.h"
 
 /*
  * --INFO--
@@ -28,11 +29,11 @@ void MakeRefractionMap(HSD_ImageBuffer*)
  */
 void pppConstructCrystal(struct pppCrystal* pppCrystal, struct UnkC* param_2)
 {
-	int iVar1;
-	
-	iVar1 = param_2->m_serializedDataOffsets[2];
-	*(unsigned int*)((char*)pppCrystal + 8 + iVar1) = 0;
-	*(unsigned int*)((char*)pppCrystal + 8 + iVar1 + 4) = 0;
+	s32 iVar1 = param_2->m_serializedDataOffsets[2];
+	u32* data = (u32*)((char*)pppCrystal + iVar1 + 8);
+
+	data[0] = 0;
+	data[1] = 0;
 }
 
 /*
@@ -46,20 +47,20 @@ void pppConstructCrystal(struct pppCrystal* pppCrystal, struct UnkC* param_2)
  */
 void pppDestructCrystal(struct pppCrystal* pppCrystal, struct UnkC* param_2)
 {
-	void* stage;
-	void** puVar1;
+	CMemory::CStage* stage;
+	u32* puVar1;
 	
-	puVar1 = (void**)((char*)(pppCrystal) + 8 + param_2->m_serializedDataOffsets[2]);
-	stage = puVar1[0];
-	if ((stage != 0) && (*(void**)stage != 0)) {
-		// TODO: pppHeapUseRate((CMemory::CStage*)*(void**)stage);
-		*(void**)stage = 0;
+	puVar1 = (u32*)((char*)pppCrystal + 8 + param_2->m_serializedDataOffsets[2]);
+	stage = (CMemory::CStage*)puVar1[0];
+	if ((stage != 0) && (*(CMemory::CStage**)stage != 0)) {
+		pppHeapUseRate(*(CMemory::CStage**)stage);
+		*(u32*)stage = 0;
 	}
 	if (stage != 0) {
-		// TODO: pppHeapUseRate((CMemory::CStage*)stage);
+		pppHeapUseRate(stage);
 	}
-	if (puVar1[1] != 0) {
-		// TODO: pppHeapUseRate((CMemory::CStage*)puVar1[1]);
+	if ((CMemory::CStage*)puVar1[1] != 0) {
+		pppHeapUseRate((CMemory::CStage*)puVar1[1]);
 		puVar1[1] = 0;
 	}
 }


### PR DESCRIPTION
## Summary
- Updated `src/pppCrystal.cpp` to restore the missing heap-release behavior in `pppDestructCrystal`.
- Replaced TODO placeholders with real `pppHeapUseRate` calls and preserved the original cleanup order (`stage inner pointer` -> `stage` -> secondary pointer).
- Normalized `pppConstructCrystal` pointer setup to a direct `u32*` work pointer form consistent with the existing `pppCrystal2` implementation style.
- Added `ffcc/pppPart.h` include to use the canonical `pppHeapUseRate` declaration.

## Functions Improved
- Unit: `main/pppCrystal`
- `pppDestructCrystal`: **48.764706% -> 98.17647%** (`136b`)
- `pppConstructCrystal`: **82.125% -> 99.75%** (`32b`)
- Unit fuzzy match: **5.05052% -> 7.756315%**

## Match Evidence
- Baseline: `objdiff-cli report generate -p . -o /tmp/report.json`
- After changes/build: `ninja` (regenerated `build/GCCP01/report.json`)
- Post-change symbol diff (`build/tools/objdiff-cli diff -p . -u main/pppCrystal -o - pppDestructCrystal`) reports `match_percent: 98.17647` for `pppDestructCrystal`, with remaining differences limited to argument-level mismatches.

## Plausibility Rationale
- The previous implementation had explicit TODO placeholders where memory cleanup calls should occur.
- Restoring `pppHeapUseRate` is behaviorally and stylistically consistent with neighboring effect teardown functions in this codebase and with the corresponding `pppCrystal2` destruction path.
- Changes improve semantic correctness (resource release bookkeeping) while remaining straightforward source-level logic, not artificial compiler-shaping rewrites.

## Technical Notes
- Kept the destruction sequencing compatible with the Ghidra reference for this unit.
- Used typed pointers (`CMemory::CStage*`, `u32*`) to better match expected loads/stores and reduce unnecessary casts.
