### PR TITLE
p_usb: improve __sinit_p_usb_cpp initializer match

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -258,18 +258,23 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
  */
 extern "C" void __sinit_p_usb_cpp()
 {
-    void** base = (void**)&USBPcs;
-    base[0] = &__vt__8CManager;
-    base[0] = &lbl_801E8668;
-    base[0] = &lbl_801E8830;
+    volatile void** base = (volatile void**)&USBPcs;
+    *base = &__vt__8CManager;
+    *base = &lbl_801E8668;
+    *base = &lbl_801E8830;
 
-    lbl_801E86B4[1] = lbl_801E8690[0];
-    lbl_801E86B4[2] = lbl_801E8690[1];
-    lbl_801E86B4[3] = lbl_801E8690[2];
-    lbl_801E86B4[4] = lbl_801E869C[0];
-    lbl_801E86B4[5] = lbl_801E869C[1];
-    lbl_801E86B4[6] = lbl_801E869C[2];
-    lbl_801E86B4[7] = lbl_801E86A8[0];
-    lbl_801E86B4[8] = lbl_801E86A8[1];
-    lbl_801E86B4[9] = lbl_801E86A8[2];
+    u32* dst = lbl_801E86B4 + 1;
+    u32* src0 = lbl_801E8690;
+    u32* src1 = lbl_801E869C;
+    u32* src2 = lbl_801E86A8;
+
+    dst[0] = src0[0];
+    dst[1] = src0[1];
+    dst[2] = src0[2];
+    dst[3] = src1[0];
+    dst[4] = src1[1];
+    dst[5] = src1[2];
+    dst[6] = src2[0];
+    dst[7] = src2[1];
+    dst[8] = src2[2];
 }


### PR DESCRIPTION
## Summary
- Reworked `__sinit_p_usb_cpp` in `src/p_usb.cpp` to use direct pointer writes and grouped table-copy temporaries.
- Preserved behavior while changing expression/assignment shape to better reflect expected static initialization codegen.

## Functions improved
- Unit: `main/p_usb`
- Symbol: `__sinit_p_usb_cpp` (PAL 0x800203e4, 176b)

## Match evidence
- `__sinit_p_usb_cpp`: **72.77273% -> 73.90909%** (`build/tools/objdiff-cli diff -p . -u main/p_usb -o - __sinit_p_usb_cpp`)
- Instruction diff mix moved in the right direction:
  - `MATCH`: 15 -> 24
  - `DIFF_ARG_MISMATCH`: 19 -> 10
- No regression in the two nearby tracked symbols during symbol-specific checks:
  - `SendDataCode__7CUSBPcsFiPvii`: 70.95489% -> 70.95489%
  - `IsBigAlloc__7CUSBPcsFi`: 77.72727% -> 77.72727%

## Plausibility rationale
- This change is source-plausible and maintainable: it models a normal static initializer pattern (vtable pointer writes plus table entry propagation) rather than introducing contrived control-flow tricks.
- The edit does not add hardcoded offsets or target-specific hacks; it keeps intent clear while improving binary correspondence.

## Technical details
- Switched from repeated indexed writes on global arrays to explicit `dst/src` pointers in `__sinit_p_usb_cpp`.
- Used volatile base-pointer writes for the object vtable transitions, consistent with nearby initialization patterns in this codebase.
