### PR TITLE
mapmesh: implement CMapMesh constructor

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -37,6 +37,11 @@ static inline int& S32At(CMapMesh* self, unsigned int offset)
     return *reinterpret_cast<int*>(Ptr(self, offset));
 }
 
+static inline float& F32At(CMapMesh* self, unsigned int offset)
+{
+    return *reinterpret_cast<float*>(Ptr(self, offset));
+}
+
 static inline unsigned short& U16At(CMapMesh* self, unsigned int offset)
 {
     return *reinterpret_cast<unsigned short*>(Ptr(self, offset));
@@ -80,7 +85,25 @@ CMaterial* CPtrArray<CMaterial*>::GetAt(unsigned long index)
  */
 CMapMesh::CMapMesh()
 {
-	// TODO
+    const float minInit = 10000000000.0f;
+    const float maxInit = -10000000000.0f;
+
+    F32At(this, 0x14) = minInit;
+    F32At(this, 0x10) = minInit;
+    F32At(this, 0xC) = minInit;
+    F32At(this, 0x20) = maxInit;
+    F32At(this, 0x1C) = maxInit;
+    F32At(this, 0x18) = maxInit;
+
+    S32At(this, 0x24) = 0;
+    S32At(this, 0x28) = 0;
+    S32At(this, 0x2C) = 0;
+    S32At(this, 0x30) = 0;
+    S32At(this, 0x34) = 0;
+    S32At(this, 0x3C) = 0;
+    S32At(this, 0x38) = 0;
+    S32At(this, 0x40) = 0;
+    U16At(this, 0xA) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapMesh::CMapMesh()` in `src/mapmesh.cpp` instead of the previous TODO stub.
- Initialized bounding-box float fields to the original constructor defaults (`+1.0e10f` and `-1.0e10f`) and zeroed pointer/index fields in original store order.
- Added a local `F32At` helper to keep offset-based field writes consistent with the existing file style.

## Functions improved
- Unit: `main/mapmesh`
- Function: `__ct__8CMapMeshFv`
  - Before: `5.263158%`
  - After: `99.47369%`

## Match evidence
- `main/mapmesh` `.text` match improved:
  - Before: `11.1509075%`
  - After: `12.860554%`
- Remaining constructor diffs are relocation-name mismatches only (`lbl_8032F930/@64`, `lbl_8032F934/@65`), with instruction sequence otherwise aligned.

## Plausibility rationale
- This change restores normal constructor semantics for a mesh object: initialize bounds and clear owned pointers/state.
- The code uses straightforward source-level initialization patterns rather than compiler-coaxing tricks.
- Field initialization order was kept aligned with expected code generation and existing decomp style in this file.

## Technical details
- Constructor constants were validated against PAL `main.dol` at `0x8032F930` / `0x8032F934`.
- objdiff was rerun after a full `ninja` rebuild and checked specifically on `__ct__8CMapMeshFv` and unit-level `.text` match.
