### PR TITLE
main/mapmesh: implement core draw/material paths

### DIFF
--- a/include/ffcc/mapmesh.h
+++ b/include/ffcc/mapmesh.h
@@ -26,7 +26,7 @@ public:
     void DrawMeshCharaShadow(unsigned short, unsigned short);
     void Draw(CMaterialSet*);
     void DrawPart(CMaterialSet*, int);
-    void GetTexture(CMaterialSet*, int&);
+    void* GetTexture(CMaterialSet*, int&);
     void SetDisplayListMaterial(CMaterialSet*, char**, CAmemCacheSet*);
     void pppCacheLoadModelTexture(CMaterialSet*, CAmemCacheSet*);
     void pppCacheUnLoadModelTexture(CMaterialSet*, CAmemCacheSet*);

--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -1,9 +1,28 @@
 #include "ffcc/mapmesh.h"
 
+#include <dolphin/gx.h>
+
 class CMaterial;
 
 extern "C" void __dl__FPv(void* ptr);
 extern "C" void __dla__FPv(void* ptr);
+extern char MaterialMan[];
+extern unsigned char MapMng[];
+
+extern "C" {
+void SetBlendMode__12CMaterialManFP12CMaterialSeti(void* materialMan, CMaterialSet* materialSet, unsigned int materialIdx);
+void SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(void* materialMan, CMaterialSet* materialSet,
+                                                                 unsigned int materialIdx, int materialPart,
+                                                                 int tevScale);
+void SetMaterialPart__12CMaterialManFP12CMaterialSetii(void* materialMan, CMaterialSet* materialSet,
+                                                        unsigned int materialIdx, int partIdx);
+void SetMaterialCharaShadow__12CMaterialManFP9CMaterial(void* materialMan, void* material);
+unsigned short FindTexName__12CMaterialSetFPcPl(CMaterialSet* materialSet, char* textureName, long* outIndex);
+void CacheLoadTexture__12CMaterialSetFiP13CAmemCacheSet(CMaterialSet* materialSet, unsigned int materialIdx,
+                                                         CAmemCacheSet* cacheSet);
+void CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet(CMaterialSet* materialSet, unsigned int materialIdx,
+                                                         CAmemCacheSet* cacheSet);
+}
 
 template <class T>
 class CPtrArray
@@ -40,6 +59,25 @@ static inline int& S32At(CMapMesh* self, unsigned int offset)
 static inline unsigned short& U16At(CMapMesh* self, unsigned int offset)
 {
     return *reinterpret_cast<unsigned short*>(Ptr(self, offset));
+}
+
+struct MeshDrawEntry
+{
+    unsigned int size;
+    void* displayList;
+    unsigned short materialIdx;
+    unsigned short _padA;
+    unsigned int _padB;
+};
+
+static inline MeshDrawEntry* DrawEntries(CMapMesh* self)
+{
+    return reinterpret_cast<MeshDrawEntry*>(PtrAt(self, 0x40));
+}
+
+static inline CMaterialSet* DefaultMaterialSet()
+{
+    return *reinterpret_cast<CMaterialSet**>(MapMng + 0x21434);
 }
 }
 
@@ -203,82 +241,210 @@ void CMapMesh::ReadOtmMesh(CChunkFile&, CMemory::CStage*, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80027bd4
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapMesh::SetRenderArray()
 {
-	// TODO
+    GXSetArray((GXAttr)9, PtrAt(this, 0x2C), 0xC);
+    GXSetArray((GXAttr)0xB, PtrAt(this, 0x3C), 4);
+    GXSetArray((GXAttr)0xD, PtrAt(this, 0x38), 4);
+    GXSetArray((GXAttr)0xE, PtrAt(this, 0x38), 4);
+    *reinterpret_cast<void**>(MaterialMan + 4) = PtrAt(this, 0x30);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80027b24
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::DrawMesh(unsigned short, unsigned short)
+void CMapMesh::DrawMesh(unsigned short startIdx, unsigned short count)
 {
-	// TODO
+    unsigned int remaining = count;
+    MeshDrawEntry* entry = DrawEntries(this) + startIdx;
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            CMaterialSet* materialSet = DefaultMaterialSet();
+            SetBlendMode__12CMaterialManFP12CMaterialSeti(MaterialMan, materialSet, entry->materialIdx);
+            SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(MaterialMan, materialSet, entry->materialIdx, 0,
+                                                                       1);
+            GXCallDisplayList(entry->displayList, entry->size);
+        }
+        entry++;
+        remaining--;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80027a7c
+ * PAL Size: 168b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::DrawMeshCharaShadow(unsigned short, unsigned short)
+void CMapMesh::DrawMeshCharaShadow(unsigned short startIdx, unsigned short count)
 {
-	// TODO
+    unsigned int remaining = count;
+    MeshDrawEntry* entry = DrawEntries(this) + startIdx;
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            CMaterial* material = (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(DefaultMaterialSet()) + 8))[entry->materialIdx];
+            if ((material != 0) && ((*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(material) + 0x24) &
+                                     0x100000) != 0)) {
+                SetMaterialCharaShadow__12CMaterialManFP9CMaterial(MaterialMan, material);
+                GXCallDisplayList(entry->displayList, entry->size);
+            }
+        }
+        entry++;
+        remaining--;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800279c4
+ * PAL Size: 184b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::Draw(CMaterialSet*)
+void CMapMesh::Draw(CMaterialSet* materialSet)
 {
-	// TODO
+    MeshDrawEntry* entry = DrawEntries(this);
+    unsigned int remaining = U16At(this, 0xA);
+
+    if (materialSet == 0) {
+        materialSet = DefaultMaterialSet();
+    }
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            SetBlendMode__12CMaterialManFP12CMaterialSeti(MaterialMan, materialSet, entry->materialIdx);
+            SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(MaterialMan, materialSet, entry->materialIdx, 0,
+                                                                       1);
+            GXCallDisplayList(entry->displayList, entry->size);
+        }
+        entry++;
+        remaining--;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80027940
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::DrawPart(CMaterialSet*, int)
+void CMapMesh::DrawPart(CMaterialSet* materialSet, int drawMaterialPart)
 {
-	// TODO
+    MeshDrawEntry* entry = DrawEntries(this);
+    unsigned int remaining = U16At(this, 0xA);
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            if (drawMaterialPart != 0) {
+                SetMaterialPart__12CMaterialManFP12CMaterialSetii(MaterialMan, materialSet, entry->materialIdx, 1);
+            }
+            GXCallDisplayList(entry->displayList, entry->size);
+        }
+        entry++;
+        remaining--;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800278e8
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::GetTexture(CMaterialSet*, int&)
+void* CMapMesh::GetTexture(CMaterialSet* materialSet, int& textureIndex)
 {
-	// TODO
+    if (U16At(this, 0xA) == 0) {
+        return 0;
+    }
+
+    MeshDrawEntry* entry = DrawEntries(this);
+    if (entry->size == 0) {
+        return 0;
+    }
+
+    textureIndex = entry->materialIdx;
+    CMaterial* material = (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[entry->materialIdx];
+    return *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(material) + 0x3C);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80027864
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::SetDisplayListMaterial(CMaterialSet*, char **, CAmemCacheSet*)
+void CMapMesh::SetDisplayListMaterial(CMaterialSet* materialSet, char** textureNames, CAmemCacheSet*)
 {
-	// TODO
+    MeshDrawEntry* entry = DrawEntries(this);
+    unsigned int remaining = U16At(this, 0xA);
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            if (entry->materialIdx == 0xFFFF) {
+                entry->materialIdx = 0;
+            } else {
+                entry->materialIdx = FindTexName__12CMaterialSetFPcPl(materialSet, textureNames[entry->materialIdx], 0);
+            }
+        }
+        entry++;
+        remaining--;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800277ec
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::pppCacheLoadModelTexture(CMaterialSet*, CAmemCacheSet*)
+void CMapMesh::pppCacheLoadModelTexture(CMaterialSet* materialSet, CAmemCacheSet* cacheSet)
 {
-	// TODO
+    MeshDrawEntry* entry = DrawEntries(this);
+    unsigned int remaining = U16At(this, 0xA);
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            if (entry->materialIdx == 0xFFFF) {
+                entry->materialIdx = 0;
+            } else {
+                CacheLoadTexture__12CMaterialSetFiP13CAmemCacheSet(materialSet, entry->materialIdx, cacheSet);
+            }
+        }
+        entry++;
+        remaining--;
+    }
 }
 
 /*
@@ -303,10 +469,27 @@ void CMapMesh::pppCacheRefCnt0UpModelTexture(CMaterialSet*, CAmemCacheSet*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80027774
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMesh::pppCacheDumpModelTexture(CMaterialSet*, CAmemCacheSet*)
+void CMapMesh::pppCacheDumpModelTexture(CMaterialSet* materialSet, CAmemCacheSet* cacheSet)
 {
-	// TODO
+    MeshDrawEntry* entry = DrawEntries(this);
+    unsigned int remaining = U16At(this, 0xA);
+
+    while (remaining != 0) {
+        if (entry->size != 0) {
+            if (entry->materialIdx == 0xFFFF) {
+                entry->materialIdx = 0;
+            } else {
+                CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet(materialSet, entry->materialIdx, cacheSet);
+            }
+        }
+        entry++;
+        remaining--;
+    }
 }


### PR DESCRIPTION
## Summary
Implemented the core `CMapMesh` draw/material path functions in `src/mapmesh.cpp` using source-plausible logic from existing engine call patterns and symbol-guided structure offsets.

- Added concrete implementations for:
  - `SetRenderArray`
  - `DrawMesh`
  - `DrawMeshCharaShadow`
  - `Draw`
  - `DrawPart`
  - `GetTexture`
  - `SetDisplayListMaterial`
  - `pppCacheLoadModelTexture`
  - `pppCacheDumpModelTexture`
- Updated `include/ffcc/mapmesh.h` so `GetTexture` returns `void*` (pointer-sized return consistent with symbol/call usage).
- Added PAL address/size metadata blocks for all updated functions.

## Functions improved
Unit: `main/mapmesh`

- `SetRenderArray__8CMapMeshFv`: 3.3333% -> 100.0%
- `DrawMesh__8CMapMeshFUsUs`: 2.2727% -> 48.8182%
- `DrawMeshCharaShadow__8CMapMeshFUsUs`: 2.3810% -> 71.0476%
- `Draw__8CMapMeshFP12CMaterialSet`: 2.1739% -> 84.9783%
- `DrawPart__8CMapMeshFP12CMaterialSeti`: 3.0303% -> 68.9394%
- `GetTexture__8CMapMeshFP12CMaterialSetRi`: 4.5455% -> 41.7273%
- `SetDisplayListMaterial__8CMapMeshFP12CMaterialSetPPcP13CAmemCacheSet`: 3.0303% -> 70.7576%
- `pppCacheLoadModelTexture__8CMapMeshFP12CMaterialSetP13CAmemCacheSet`: 3.3333% -> 68.0%
- `pppCacheDumpModelTexture__8CMapMeshFP12CMaterialSetP13CAmemCacheSet`: 3.3333% -> 68.0%

## Match evidence
From `build/GCCP01/report.json` comparison (before vs after this branch changes):

- Unit `main/mapmesh` fuzzy match: **11.1509% -> 30.9685%**
- Unit matched code bytes: **164 -> 284** (+120)
- Unit matched functions: **3 -> 4**
- Global code matched bytes (ninja progress): **185352 -> 185472** (+120)

## Plausibility rationale
These edits replace TODO/no-op stubs with straightforward game-engine style loops over map mesh display-list entries and material IDs, calling existing `CMaterialMan`/`CMaterialSet` pathways already used elsewhere in the codebase.

No compiler-coaxing patterns were introduced (no contrived temporary-only reordering, no artificial dead logic); the changes follow expected source intent:
- iterate draw entries
- guard on display-list size
- resolve/assign material indices
- issue material setup and GX display-list calls

## Technical details
- Kept current `CMapMesh` offset-based style and used a small local `MeshDrawEntry` view for entry iteration.
- Used existing symbol names and call conventions (`SetMaterial*`, `SetBlendMode`, `Cache*Texture`, `FindTexName`) to avoid ABI drift.
- Resolved default map material set via `MapMng` offset access consistent with the current decomp style.
- Verified with `ninja` (build passes) and report regeneration.
