### PR TITLE
RedSound: implement SetWaveData standby-ID dispatch

### DIFF
--- a/include/ffcc/RedSound/RedSound.h
+++ b/include/ffcc/RedSound/RedSound.h
@@ -63,7 +63,7 @@ public:
 	void StreamVolume(int, int, int);
 	void StreamPause(int, int);
 
-	void SetWaveData(int, void*, int);
+	unsigned int SetWaveData(int, void*, int);
 	void ClearWaveData(int);
 	void ClearWaveDataM(int, int, int, int);
 	void ClearWaveBank(int);

--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -603,12 +603,23 @@ void CRedSound::StreamPause(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd728
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetWaveData(int, void*, int)
+unsigned int CRedSound::SetWaveData(int waveID, void* waveData, int waveSize)
 {
-	// TODO
+	unsigned int id = GetAutoID();
+	int* standbyID = EntryStandbyID(id);
+
+	if (standbyID != 0) {
+		CRedDriver_8032f4c0.SetWaveData((int)standbyID, waveID, waveData, waveSize);
+	}
+
+	return id;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedSound::SetWaveData(int, void*, int)` in `src/RedSound/RedSound.cpp` from a TODO stub to real control flow.
- Updated declaration in `include/ffcc/RedSound/RedSound.h` to return `unsigned int` so the function returns the generated standby ID.
- Added PAL metadata block for the function (`0x801cd728`, `124b`).

## Functions improved
- Unit: `main/RedSound/RedSound`
- Symbol: `SetWaveData__9CRedSoundFiPvi`

## Match evidence
- Before: `3.2%` (from `tools/agent_select_target.py` target listing)
- After: `100%` (in `build/GCCP01/report.json`, `SetWaveData__9CRedSoundFiPvi` has no `fuzzy_match_percent`, which indicates an exact match in this report format)
- Function size: `124b`

## Plausibility rationale
- The new body follows natural engine-side logic: generate request ID, reserve standby slot, then dispatch wave registration to `CRedDriver` when slot allocation succeeds.
- This is straightforward source behavior for an audio driver front-end and avoids compiler-coaxing patterns.

## Technical details
- Implemented flow:
  1. `id = GetAutoID();`
  2. `standbyID = EntryStandbyID(id);`
  3. `if (standbyID != 0) CRedDriver_8032f4c0.SetWaveData((int)standbyID, waveID, waveData, waveSize);`
  4. `return id;`
- Verified by successful full build with `ninja` and updated function metrics in `build/GCCP01/report.json`.