### PR TITLE
Improve pppFrameYmCallBack match via manager offset access

### DIFF
--- a/src/pppYmCallBack.cpp
+++ b/src/pppYmCallBack.cpp
@@ -6,6 +6,7 @@
 #include <dolphin/mtx.h>
 
 extern CPartMng PartMng;
+extern unsigned char* lbl_8032ED50;
 
 struct YmCallBackObj {
     u8 m_pad0[0xc];
@@ -49,10 +50,9 @@ void pppDestructYmCallBack(void)
  */
 void pppFrameYmCallBack(void* pppYmCallBack, void* param_2)
 {
-    _pppMngSt* pppMngSt;
-    _pppMngSt* mngStBase;
     YmCallBackObj* ymCallBack;
     YmCallBackParam* frameParam;
+    unsigned char* mngSt;
     Vec position;
     s32 mngStIndex;
     u32 graphId;
@@ -60,19 +60,17 @@ void pppFrameYmCallBack(void* pppYmCallBack, void* param_2)
     ymCallBack = (YmCallBackObj*)pppYmCallBack;
     frameParam = (YmCallBackParam*)param_2;
     graphId = ymCallBack->m_graphId;
-    pppMngSt = pppMngStPtr;
+    mngSt = lbl_8032ED50;
 
-    if ((((s32)graphId >> 0xC) + (((s32)graphId < 0) && ((graphId & 0xFFF) != 0))) ==
-        (s32)frameParam->m_graphId) {
-        position.x = pppMngSt->m_matrix.value[0][3];
-        position.y = pppMngSt->m_matrix.value[1][3];
-        position.z = pppMngSt->m_matrix.value[2][3];
+    if (((s32)graphId / 0x1000) == (s32)frameParam->m_graphId) {
+        position.x = *(f32*)(mngSt + 0x84);
+        position.y = *(f32*)(mngSt + 0x94);
+        position.z = *(f32*)(mngSt + 0xA4);
         PSMTXMultVec(ppvWorldMatrix, &position, &position);
 
-        mngStBase = (_pppMngSt*)((u8*)&PartMng + 0x2A18);
-        mngStIndex = ((s32)((u8*)pppMngSt - (u8*)mngStBase)) / 0x158;
-        Game.game.ParticleFrameCallback(mngStIndex, (s32)pppMngSt->m_kind,
-                                        (s32)pppMngSt->m_nodeIndex,
+        mngStIndex = ((s32)(mngSt - ((u8*)&PartMng + 0x2A18))) / 0x158;
+        Game.game.ParticleFrameCallback(mngStIndex, (s32)*(s16*)(mngSt + 0x74),
+                                        (s32)*(s16*)(mngSt + 0x76),
                                         (s32)frameParam->m_initWOrk, (s32)frameParam->m_graphId,
                                         &position);
     }


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmCallBack` in `src/pppYmCallBack.cpp` to match the original particle manager access pattern.
- Switched from tentative `_pppMngSt` field-based reads to offset-based reads from `lbl_8032ED50` for translation/kind/node fields.
- Rewrote graph-id class extraction as signed division by `0x1000` to produce the target `srawi/addze` form.
- Kept existing control flow and callback behavior while tightening ABI/offset fidelity.

## Functions improved
- Unit: `main/pppYmCallBack`
- Symbol: `pppFrameYmCallBack`
- Match: `49.791668%` -> `70.5625%`

## Match evidence
- Command:
  - `tools/objdiff-cli diff -p . -u main/pppYmCallBack -o - pppFrameYmCallBack`
- Before: `49.791668%`
- After: `70.5625%`
- Assembly alignment improvements include:
  - Correct SDA relocation to `lbl_8032ED50`
  - Matrix translation loads at `+0x84/+0x94/+0xA4`
  - Kind/node loads at `+0x74/+0x76`
  - Signed graph-id bucket compare emitted as `srawi/addze`

## Plausibility rationale
- The change removes dependence on currently unstable `_pppMngSt` struct guesses and follows a direct offset-based style already used in nearby particle code.
- Behavior remains source-plausible for original FFCC code: transform current manager position to world and invoke `ParticleFrameCallback` with manager index/kind/node and callback params.

## Technical details
- File changed: `src/pppYmCallBack.cpp`
- Build validation: `ninja` (passes)
