### PR TITLE
main/util: implement Conv* helpers and fix symbol signatures

### DIFF
--- a/include/ffcc/util.h
+++ b/include/ffcc/util.h
@@ -22,9 +22,9 @@ public:
     void SetOrthoEnv();
     void GetNoise(unsigned char);
     void GetSplinePos(Vec&, Vec&, Vec&, Vec&, Vec&, float, float);
-    void ConvI2FVector(Vec&, S16Vec&, long);
-    void ConvF2IVector(S16Vec&, Vec&, long);
-    void ConvF2IVector2d(S16Vec2d&, Vec2d&, long);
+    void ConvI2FVector(Vec&, S16Vec, long);
+    void ConvF2IVector(S16Vec&, Vec, long);
+    void ConvF2IVector2d(S16Vec2d&, Vec2d, long);
     void RenderQuadNoTex(Vec, Vec, _GXColor);
     void RenderQuad(Vec, Vec, _GXColor, Vec2d*, Vec2d*);
     void RenderQuadTex2(Vec, Vec, _GXColor, Vec2d*, Vec2d*);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -107,32 +107,55 @@ void CUtil::GetSplinePos(Vec&, Vec&, Vec&, Vec&, Vec&, float, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800248fc
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::ConvI2FVector(Vec&, S16Vec&, long)
+void CUtil::ConvI2FVector(Vec& out, S16Vec in, long shift)
 {
-	// TODO
+	float scale = (float)(1 << shift);
+
+	out.x = (float)in.x / scale;
+	out.y = (float)in.y / scale;
+	out.z = (float)in.z / scale;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024864
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::ConvF2IVector(S16Vec&, Vec&, long)
+void CUtil::ConvF2IVector(S16Vec& out, Vec in, long shift)
 {
-	// TODO
+	float scale = (float)(1 << shift);
+
+	out.x = (short)(in.x * scale);
+	out.y = (short)(in.y * scale);
+	out.z = (short)(in.z * scale);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800247f4
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::ConvF2IVector2d(S16Vec2d&, Vec2d&, long)
+void CUtil::ConvF2IVector2d(S16Vec2d& out, Vec2d in, long shift)
 {
-	// TODO
+	float scale = (float)(1 << shift);
+
+	out.x = (short)(in.x * scale);
+	out.y = (short)(in.y * scale);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three previously stubbed `CUtil` vector conversion helpers in `src/util.cpp`.
- Corrected the function parameter passing style in `include/ffcc/util.h` and `src/util.cpp` so emitted Metrowerks mangled names match the target symbols (second args are by-value, not by-reference).
- Added PAL address/size INFO blocks for the updated functions.

## Functions improved
- `ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl` (main/util)
- `ConvF2IVector__5CUtilFR6S16Vec3Vecl` (main/util)
- `ConvI2FVector__5CUtilFR3Vec6S16Vecl` (main/util)

## Match evidence
Before:
- `ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl`: 0.00%
- `ConvF2IVector__5CUtilFR6S16Vec3Vecl`: 0.00%
- `ConvI2FVector__5CUtilFR3Vec6S16Vecl`: 0.00%
- `main/util` unit fuzzy (selector): 7.1%

After (`build/GCCP01/report.json`):
- `ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl`: 31.25%
- `ConvF2IVector__5CUtilFR6S16Vec3Vecl`: 28.578947%
- `ConvI2FVector__5CUtilFR3Vec6S16Vecl`: 43.522728%
- `main/util` unit fuzzy: 8.655914%

## Plausibility rationale
- The new implementations are straightforward fixed-point quantize/dequantize helpers using power-of-two scaling, which is a plausible original engine pattern for compact vector storage.
- Signature correction is ABI/symbol-driven rather than contrived code shaping: it aligns declarations with the known Metrowerks symbol names so objdiff can compare the intended functions.

## Technical details
- Verified emitted symbols in `util.o` now exactly match the report targets:
  - `ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl`
  - `ConvF2IVector__5CUtilFR6S16Vec3Vecl`
  - `ConvI2FVector__5CUtilFR3Vec6S16Vecl`
- Build verification: `ninja` passes.
