### PR TITLE
Improve BackAllFilesToQueue match in main/file

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -22,6 +22,8 @@ extern void* DAT_80238030;
 
 static char s_fileCpp[] = "file.cpp";
 static char s_drawErrorFmt[] = "CFile::drawError %d";
+static char s_queueWarnAnyFmt[] = "BackAllFilesToQueue: %s";
+static char s_queueWarnTargetFmt[] = "BackAllFilesToQueue: %s (%s)";
 
 static const char* s_diskErrorText[4][6][3] = {
     {
@@ -273,25 +275,23 @@ void CFile::BackAllFilesToQueue(CHandle* fileHandle)
 		{
             if (fileHandle == 0)
 			{
-                // if (System._4700_4_ > 2)
+                if ((unsigned int)System.m_execParam > 2)
 				{
-                    // System.Printf(DAT_801D5EFC, inFlight->m_name);
+                    System.Printf(s_queueWarnAnyFmt, inFlight->m_name);
                 }
             }
 			else
 			{
-                // if (System._4700_4_ > 1)
+                if ((unsigned int)System.m_execParam > 1)
 				{
-                    // System.Printf(DAT_801D5E28, inFlight->m_name, fileHandle->m_name);
+                    System.Printf(s_queueWarnTargetFmt, inFlight->m_name, fileHandle->m_name);
                 }
             }
 
-            // Put it back into the ready state.
             inFlight->m_completionStatus = 1;
         }
 		else
 		{
-            // This is the specific handle we're targeting: mark as idle.
             inFlight->m_completionStatus = 0;
         }
     }


### PR DESCRIPTION
## Summary
- Updated `CFile::BackAllFilesToQueue` in `src/file.cpp` to restore debug-gated logging branches in the queue-drain path.
- Kept behavior aligned with existing code style: completion-state handling is unchanged (`1` for re-queued handles, `0` for the targeted handle).

## Functions Improved
- `BackAllFilesToQueue__5CFileFPQ25CFile7CHandle` (`main/file`)
  - Before: `37.0333%`
  - After: `75.65%`

## Match Evidence
- Command used:
  - `tools/objdiff-cli diff -p . -u main/file -o - BackAllFilesToQueue__5CFileFPQ25CFile7CHandle`
- Symbol size remains aligned with target:
  - Left: `240` bytes
  - Right: `240` bytes

## Plausibility Rationale
- The change restores straightforward source-level conditions around `System.m_execParam` and `System.Printf` in a function that already had commented placeholders for those exact branches.
- No contrived temporaries or compiler-coaxing patterns were introduced; the update is a direct semantic completion of existing intended behavior.

## Technical Notes
- Edit is isolated to `src/file.cpp`.
- Build verified with `ninja` after change.
