### PR TITLE
os/OSCache: compile Gekko cache asm path for major match gain

### DIFF
--- a/src/os/OSCache.c
+++ b/src/os/OSCache.c
@@ -4,6 +4,10 @@
 
 #include "dolphin/os/__os.h"
 
+#ifndef __GEKKO__
+#define __GEKKO__
+#endif
+
 #define HID2 920
 
 // prototypes


### PR DESCRIPTION
## Summary
- Enabled the __GEKKO__ path in src/os/OSCache.c for this unit by defining __GEKKO__ locally when not already set.
- This compiles the existing low-level cache/locked-cache asm routines (DC*, IC*, LC*) that were previously excluded from OSCache.o.

## Functions improved
Unit: main/os/OSCache
- DCEnable
- DCInvalidateRange
- DCFlushRange
- DCStoreRange
- DCFlushRangeNoSync
- DCZeroRange
- ICInvalidateRange
- ICFlashInvalidate
- ICEnable
- __LCEnable
- LCEnable
- LCDisable
- LCStoreBlocks
- LCStoreData
- LCQueueWait
- L2GlobalInvalidate
- DMAErrorHandler
- __OSCacheInit

## Match evidence
- 
inja progress moved from:
  - Code matched: 185548 / 1855300 (10.00097%)
  - to 187160 / 1855300 (10.087047%)
- main/os/OSCache report moved from:
  - fuzzy match 42.560795%
  - to fuzzy match 100.0% and matched functions 18/18
- objdiff-cli one-shot (main/os/OSCache) now reports section match 99.75186%, with residual diffs in:
  - L2GlobalInvalidate (99.60526%)
  - DMAErrorHandler (99.375%)
  - __OSCacheInit (99.508194%)

## Plausibility rationale
- Source-plausible fix: the asm implementations already existed in the file and are canonical Dolphin/Gekko cache-control routines.
- The mismatch came from build-path selection (__GEKKO__ undefined for this unit), not from compiler-coaxing rewrites.
- This restores the intended GameCube platform path in OSCache.

## Technical details
- Only a file-local preprocessor guard was added:
  - #ifndef __GEKKO__
  - #define __GEKKO__
  - #endif
- Build verification: 
inja completed and uild/GCCP01/main.dol: OK.