### PR TITLE
Improve pppScaleLoopAuto matching for scale-loop accumulator path

### DIFF
--- a/src/pppScaleLoopAuto.cpp
+++ b/src/pppScaleLoopAuto.cpp
@@ -50,9 +50,9 @@ void pppScaleLoopAuto(void* arg1, void* arg2, void* arg3)
 		if (counter <= 0) return;
 		scaleTarget[32] = counter - 1;
 		float deltaValue = scaleData[9];
-		scaleData[0] += deltaValue;
-		scaleData[1] += deltaValue;
-		scaleData[2] += deltaValue;
+		scaleData[4] += deltaValue;
+		scaleData[5] += deltaValue;
+		scaleData[6] += deltaValue;
 		return;
 	}
 	
@@ -61,9 +61,9 @@ void pppScaleLoopAuto(void* arg1, void* arg2, void* arg3)
 		if (counter <= 0) return;
 		scaleTarget[33] = counter - 1;
 		float deltaValue = scaleData[9];
-		scaleData[0] += deltaValue;
-		scaleData[1] += deltaValue;
-		scaleData[2] += deltaValue;
+		scaleData[4] += deltaValue;
+		scaleData[5] += deltaValue;
+		scaleData[6] += deltaValue;
 		return;
 	}
 	
@@ -71,7 +71,7 @@ void pppScaleLoopAuto(void* arg1, void* arg2, void* arg3)
 	scaleTarget[29]++;
 	unsigned char cycleLimit = ((char*)arg2)[28];
 	signed char currentCycle = scaleTarget[29];
-	if ((unsigned char)currentCycle >= cycleLimit) {
+	if ((unsigned char)currentCycle > cycleLimit) {
 		scaleTarget[29] = 0;
 		*(short*)(scaleTarget + 30) = 0;
 		scaleTarget[32] = ((char*)arg2)[29];
@@ -96,9 +96,9 @@ void pppScaleLoopAuto(void* arg1, void* arg2, void* arg3)
 	float scaleFactor = baseScale * sineValue * scaleRange;
 	
 	scaleData[9] = scaleFactor;
-	scaleData[0] += scaleFactor;
-	scaleData[1] += scaleFactor;
-	scaleData[2] += scaleFactor;
+	scaleData[4] += scaleFactor;
+	scaleData[5] += scaleFactor;
+	scaleData[6] += scaleFactor;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated pppScaleLoopAuto to apply loop delta updates to the runtime scale accumulator triplet (scaleData[4..6]) rather than the base triplet.
- Adjusted cycle wrap logic from >= to > to match observed branch behavior around the cycle-limit check.
- Kept behavior/source style plausible (field-offset semantic fixes, not compiler-only reshaping).

## Functions improved
- Unit: main/pppScaleLoopAuto
- Function: pppScaleLoopAuto

## Match evidence
- pppScaleLoopAuto fuzzy: **70.577774% -> 70.62222%** (objdiff-cli one-shot JSON for symbol pppScaleLoopAuto)
- Unit main/pppScaleLoopAuto fuzzy: **74.20779% -> 74.24675%** (uild/GCCP01/report.json)

## Plausibility rationale
- The edited lines reflect likely original data-layout semantics: distinct base-scale vs accumulated-scale fields and cycle counter threshold behavior.
- No artificial temporaries/reordering were introduced solely to coerce codegen; changes are direct logic corrections in existing readable code.

## Technical notes
- Build verified with 
inja (uild/GCCP01/main.dol: OK from prior full build; incremental rebuild succeeded after edits).
- Analysis used 	ools/objdiff-cli.exe v3.6.1 one-shot diff output (-o -) for symbol-level validation.