### PR TITLE
pppKeDMat: simplify pppKeDMatDraw matrix composition

### DIFF
--- a/src/pppKeDMat.cpp
+++ b/src/pppKeDMat.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/pppKeDMat.h"
-#include "ffcc/pppPart.h"
 #include "ffcc/partMng.h"
+
+#include <dolphin/mtx.h>
 
 /*
  * --INFO--
@@ -13,19 +14,5 @@
  */
 void pppKeDMatDraw(_pppPObject* pObject)
 {
-    pppFMATRIX localMatrix;
-    pppFMATRIX worldMatrix;
-    pppFMATRIX resultMatrix;
-    
-    // Load local matrix from pObject structure at offset 0x10
-    localMatrix = *(pppFMATRIX*)((char*)pObject + 0x10);
-    
-    // Copy world matrix from global matrix
-    worldMatrix = *(pppFMATRIX*)&ppvWorldMatrix;
-    
-    // Multiply matrices: result = world * local
-    pppMulMatrix(resultMatrix, worldMatrix, localMatrix);
-    
-    // Copy result to target location at offset 0x80
-    pppCopyMatrix(*(pppFMATRIX*)((char*)pObject + 0x80), resultMatrix);
+    PSMTXConcat(ppvWorldMatrix, pObject->m_localMatrix.value, *(Mtx*)((char*)pObject + 0x80));
 }


### PR DESCRIPTION
## Summary
- Rewrote pppKeDMatDraw in src/pppKeDMat.cpp to use direct PSMTXConcat with _pppPObject::m_localMatrix into the destination matrix at +0x80.
- Removed intermediate matrix temporaries and helper-call sequence (pppMulMatrix + pppCopyMatrix) that produced noisier codegen.
- Dropped now-unused fcc/pppPart.h include and added <dolphin/mtx.h> for the concat call.

## Functions improved
- Unit: main/pppKeDMat
- Symbol: pppKeDMatDraw

## Match evidence
- pppKeDMatDraw match percent improved from **11.810526%** to **12.505263%** via objdiff-cli oneshot JSON diff on main/pppKeDMat.
- Improvement is instruction-level (not just formatting): fewer matrix-copy helper call patterns and better alignment around the matrix composition path.

## Plausibility rationale
- The new implementation is a straightforward source-level matrix composition that matches common patterns used in neighboring PPP draw helpers (PSMTXConcat/direct matrix ops).
- It removes contrived temporary copies and expresses the likely original intent: world * local -> output matrix.

## Technical details
- Before: copied world matrix into a local struct, multiplied into another local, then copied again to output.
- After: direct concat from ppvWorldMatrix and pObject->m_localMatrix.value into destination matrix.
- This narrows stack usage and call/argument shuffling, improving assembly alignment.