### PR TITLE
Match pppYmDeformationScreen constructor functions

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -1,6 +1,16 @@
 #include "ffcc/pppYmDeformationScreen.h"
 
 struct pppYmDeformationScreen;
+struct YmDeformationScreenOffsetData {
+	int unk0;
+	int unk1;
+	int offset;
+};
+
+struct YmDeformationScreenParam {
+	char pad[0xc];
+	YmDeformationScreenOffsetData* offsetData;
+};
 
 /*
  * --INFO--
@@ -9,20 +19,18 @@ struct pppYmDeformationScreen;
  */
 void pppConstructYmDeformationScreen(pppYmDeformationScreen* obj, void* param2)
 {
-	// Get offset directly from param2 structure
-	int offset = *(int*)((char*)param2 + 8);
-	char* basePtr = (char*)obj + offset;
+	int offset = ((YmDeformationScreenParam*)param2)->offsetData->offset;
+	char* basePtr = (char*)obj + offset + 0x80;
 	float zero = 0.0f;
-	
-	// Initialize fields
-	*(short*)(basePtr + 0x84) = 0;
-	*(char*)(basePtr + 0x86) = 1;
-	*(float*)(basePtr + 0x88) = zero;
-	*(float*)(basePtr + 0x8c) = zero;
-	*(float*)(basePtr + 0x90) = zero;
-	*(float*)(basePtr + 0x94) = zero;
-	*(float*)(basePtr + 0x98) = zero;
-	*(float*)(basePtr + 0x9c) = zero;
+
+	*(short*)(basePtr + 0x4) = 0;
+	*(char*)(basePtr + 0x6) = 1;
+	*(float*)(basePtr + 0x10) = zero;
+	*(float*)(basePtr + 0xc) = zero;
+	*(float*)(basePtr + 0x8) = zero;
+	*(float*)(basePtr + 0x1c) = zero;
+	*(float*)(basePtr + 0x18) = zero;
+	*(float*)(basePtr + 0x14) = zero;
 }
 
 /*
@@ -32,18 +40,16 @@ void pppConstructYmDeformationScreen(pppYmDeformationScreen* obj, void* param2)
  */
 void pppConstruct2YmDeformationScreen(pppYmDeformationScreen* obj, void* param2)
 {
-	// Get offset directly from param2 structure
-	int offset = *(int*)((char*)param2 + 8);
-	char* basePtr = (char*)obj + offset;
 	float zero = 0.0f;
-	
-	// Initialize float fields only
-	*(float*)(basePtr + 0x88) = zero;
-	*(float*)(basePtr + 0x8c) = zero;
-	*(float*)(basePtr + 0x90) = zero;
-	*(float*)(basePtr + 0x94) = zero;
-	*(float*)(basePtr + 0x98) = zero;
-	*(float*)(basePtr + 0x9c) = zero;
+	int offset = ((YmDeformationScreenParam*)param2)->offsetData->offset;
+	char* basePtr = (char*)obj + offset + 0x80;
+
+	*(float*)(basePtr + 0x10) = zero;
+	*(float*)(basePtr + 0xc) = zero;
+	*(float*)(basePtr + 0x8) = zero;
+	*(float*)(basePtr + 0x1c) = zero;
+	*(float*)(basePtr + 0x18) = zero;
+	*(float*)(basePtr + 0x14) = zero;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked pppConstructYmDeformationScreen and pppConstruct2YmDeformationScreen to use an explicit serialized-offset indirection layout from the parameter block.
- Updated write base/ordering to mirror expected constructor initialization sequence (+0x80 base, then field stores at +0x4/+0x6/+0x10/+0xc/+0x8/+0x1c/+0x18/+0x14).
- Kept changes localized to src/pppYmDeformationScreen.cpp with no debug artifacts.

## Functions improved
- main/pppYmDeformationScreen::pppConstruct2YmDeformationScreen:
  - Before: **79.0%**
  - After: **100.0%**
- main/pppYmDeformationScreen::pppConstructYmDeformationScreen:
  - Before: **84.125%**
  - After: **100.0%**

## Match evidence
- Unit main/pppYmDeformationScreen:
  - Before fuzzy match: **4.6404295%**
  - After fuzzy match: **5.545617%**
  - Matched code bytes: **4 -> 116**
  - Matched functions: **1/5 -> 3/5**
- Global matched code bytes (ninja progress): **187160 -> 187272**.

## Plausibility rationale
- The parameter-driven offset indirection is plausible for this particle/deformation system’s serialized setup path.
- Constructor writes remain semantically straightforward initialization of the same state fields, now expressed in a layout/order that better reflects likely original source and compiler output rather than artificial coercion.

## Technical details
- Verified with 
inja report output (uild/GCCP01/report.json) after each iteration.
- Used 	ools/objdiff-cli.exe v3.6.1 one-shot diffs during tuning to align load/store shape with original instruction pattern.