### PR TITLE
Improve main/pppScreenQuake match via canonical global symbol refs

### DIFF
--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -3,8 +3,8 @@
 #include "ffcc/partMng.h"
 #include "ffcc/pppYmEnv.h"
 
-extern float FLOAT_80331fc8;
-extern int DAT_8032ed70;
+extern float lbl_80331FC8;
+extern int lbl_8032ED70;
 
 /*
  * --INFO--
@@ -17,7 +17,7 @@ extern int DAT_8032ed70;
  */
 void pppConScreenQuake(pppScreenQuake *quake, UnkC *param2)
 {
-	float val = FLOAT_80331fc8;
+	float val = lbl_80331FC8;
 	float *data = (float *)((char *)&quake->field0_0x0 + 128 + *param2->m_serializedDataOffsets);
 	
 	data[0] = val;
@@ -42,7 +42,7 @@ void pppConScreenQuake(pppScreenQuake *quake, UnkC *param2)
  */
 void pppCon2ScreenQuake(pppScreenQuake *quake, UnkC *param2)
 {
-	float val = FLOAT_80331fc8;
+	float val = lbl_80331FC8;
 	float *data = (float *)((char *)&quake->field0_0x0 + 128 + *param2->m_serializedDataOffsets);
 	
 	data[0] = val;
@@ -67,7 +67,7 @@ void pppCon2ScreenQuake(pppScreenQuake *quake, UnkC *param2)
  */
 void pppDesScreenQuake(void)
 {
-	float value = FLOAT_80331fc8;
+	float value = lbl_80331FC8;
 	CameraPcs.SetQuakeParameter(0, 0, 0, 0, value, value, value, value, value, value, 1);
 }
 
@@ -82,7 +82,7 @@ void pppDesScreenQuake(void)
  */
 void pppFrameScreenQuake(pppScreenQuake *quake, UnkB *param2, UnkC *param3)
 {
-	if (DAT_8032ed70 == 0) {
+	if (lbl_8032ED70 == 0) {
 		float *value = (float *)((char *)quake + 0x80 + *param3->m_serializedDataOffsets);
 
 		CalcGraphValue((_pppPObject *)&quake->field0_0x0, param2->m_graphId, value[0], value[1], value[2], param2->m_dataValIndex, param2->m_initWOrk, param2->m_stepValue);


### PR DESCRIPTION
## Summary
- Updated `src/pppScreenQuake.cpp` to use canonical PAL symbol names for two globals in this unit:
  - `FLOAT_80331fc8` -> `lbl_80331FC8`
  - `DAT_8032ed70` -> `lbl_8032ED70`
- Kept function behavior and control flow unchanged.

## Functions Improved
- Unit: `main/pppScreenQuake`
- Primary target assessed: `pppDesScreenQuake`
- Additional affected function: `pppFrameScreenQuake`

## Match Evidence
Measured with:
`tools/objdiff-cli.exe diff -p . -u main/pppScreenQuake -o - pppDesScreenQuake`

- `pppFrameScreenQuake`: **93.548386% -> 93.629036%**
- `pppDesScreenQuake`: **60.666668% -> 60.666668%** (unchanged)
- Unit `.text` match: **89.052635% -> 89.184210%**

## Plausibility Rationale
- `lbl_*` extern naming is already common in nearby ppp units and reflects linker symbol conventions in this codebase.
- This change aligns symbol references without introducing contrived codegen hacks.

## Technical Details
- The unit previously emitted symbol/relocation mismatches against expected targets in objdiff.
- Normalizing the two extern names reduced those mismatches and increased the function/unit match percentages above.
