### PR TITLE
Improve pppFrameAlignmentScale codegen match

### DIFF
--- a/src/pppAlignmentScale.cpp
+++ b/src/pppAlignmentScale.cpp
@@ -47,10 +47,13 @@ struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* align
     float scale;
     float distanceScale;
     double distance;
+    float zero;
+    struct _pppMngSt* pppMngSt;
     Vec cameraPos;
     Vec objPos;
     Mtx scaleMtx;
 
+    pppMngSt = pppMngStPtr;
     if (DAT_8032ed70 == 0) {
         cameraPos.x = CameraPcs._224_4_;
         cameraPos.y = CameraPcs._228_4_;
@@ -60,24 +63,25 @@ struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* align
         objPos.y = pppMngStPtr->m_matrix.value[1][3];
         objPos.z = pppMngStPtr->m_matrix.value[2][3];
 
-        distance = PSVECDistance(&cameraPos, &objPos);
+        distance = (double)PSVECDistance(&cameraPos, &objPos);
         distanceScale = (float)(distance / (double)data->m_unk0x4);
         scale = FLOAT_80331920;
-        if (scale < distanceScale) {
+        if (FLOAT_80331920 < distanceScale) {
             scale = (distanceScale - FLOAT_80331920) * data->m_unk0x8 + FLOAT_80331920;
         }
 
         PSMTXScale(scaleMtx, scale, scale, scale);
 
+        zero = FLOAT_80331924;
         pppMngStPtr->m_matrix.value[0][3] = FLOAT_80331924;
-        pppMngStPtr->m_matrix.value[1][3] = FLOAT_80331924;
-        pppMngStPtr->m_matrix.value[2][3] = FLOAT_80331924;
+        pppMngStPtr->m_matrix.value[1][3] = zero;
+        pppMngStPtr->m_matrix.value[2][3] = zero;
         PSMTXConcat(scaleMtx, pppMngStPtr->m_matrix.value, pppMngStPtr->m_matrix.value);
         pppMngStPtr->m_matrix.value[0][3] = objPos.x;
         pppMngStPtr->m_matrix.value[1][3] = objPos.y;
         pppMngStPtr->m_matrix.value[2][3] = objPos.z;
 
-        alignmentScale = (struct pppAlignmentScale*)pppSetFpMatrix__FP9_pppMngSt(pppMngStPtr);
+        alignmentScale = (struct pppAlignmentScale*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
 
     return alignmentScale;


### PR DESCRIPTION
## Summary
- Refined `pppFrameAlignmentScale` local variable and constant value flow to better match original codegen.
- Cached `pppMngStPtr` into a local for the final matrix submit call site.
- Adjusted float/double conversion placement and threshold comparison form.
- Reused a local temporary for `FLOAT_80331924` assignments to mirror observed value lifetime.

## Functions improved
- Unit: `main/pppAlignmentScale`
- Function: `pppFrameAlignmentScale` (284b)

## Match evidence
- `pppFrameAlignmentScale`: **81.056335% -> 83.76057%** (+2.704235)
- Unit `main/pppAlignmentScale` fuzzy match: **81.31944% -> 83.986115%** (+2.666675)
- Build verification: `build/GCCP01/main.dol: OK`

## Plausibility rationale
- Changes are source-plausible and keep normal gameplay code style.
- No contrived sequencing or hardcoded offset tricks were introduced.
- The edits align variable lifetime/type behavior likely expected from original source and compiler behavior.

## Technical details
- Explicit `(double)PSVECDistance(...)` conversion.
- Comparison shape changed to `FLOAT_80331920 < distanceScale`.
- Shared constant temp used for repeated matrix translation components.
- Local `_pppMngSt*` is used at `pppSetFpMatrix__FP9_pppMngSt` call.