### PR TITLE
main/pppYmMiasma: fix control block offset layout for ctor/dtor paths

### DIFF
--- a/include/ffcc/pppYmMiasma.h
+++ b/include/ffcc/pppYmMiasma.h
@@ -8,7 +8,8 @@ struct pppYmMiasma {
 };
 struct UnkB;
 struct UnkC {
-    s32 m_serializedDataOffsets[3];
+    u8 m_pad_0x0[0xc];
+    s32* m_serializedDataOffsets;
 };
 struct VYmMiasma;
 struct PYmMiasma;

--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -118,8 +118,12 @@ void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, _PARTICLE_DAT
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80090dec
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 {
@@ -142,8 +146,12 @@ void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80090dc8
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 {
@@ -157,8 +165,12 @@ void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80090d90
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDestructYmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 {


### PR DESCRIPTION
## Summary
- Corrected `UnkC` layout in `pppYmMiasma` to match PPP control blocks used elsewhere (`+0xC` pointer to serialized offsets).
- Kept constructor/destructor logic source-plausible and updated PAL address/size doc blocks for these functions.

## Functions improved
Unit: `main/pppYmMiasma`
- `pppDestructYmMiasma`: 92.71429% -> 99.92857%
- `pppConstruct2YmMiasma`: 74.0% -> 85.22222%
- `pppConstructYmMiasma`: 74.65% -> 79.2%
- Unit fuzzy: 4.4209933% -> 4.751693%

## Match evidence
- Rebuilt with `ninja` and regenerated `build/GCCP01/report.json`.
- Improvement came from corrected serialized-offset addressing, not cosmetic changes.

## Plausibility rationale
- This aligns with established control-struct layout patterns already used in similar PPP units (padding then `m_serializedDataOffsets` pointer).
- The change removes a likely parameter-layout mismatch that was forcing incorrect memory addressing in ctor/dtor work-state access.

## Technical details
- Updated `include/ffcc/pppYmMiasma.h`:
  - `UnkC` from inline `s32 m_serializedDataOffsets[3]` to:
    - `u8 m_pad_0x0[0xc];`
    - `s32* m_serializedDataOffsets;`
- Updated metadata comments in `src/pppYmMiasma.cpp` for:
  - `pppConstructYmMiasma`
  - `pppConstruct2YmMiasma`
  - `pppDestructYmMiasma`