### PR TITLE
wind: improve AddAmbient slot scan match

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -280,10 +280,11 @@ void CWind::getObj(int)
  */
 int CWind::AddAmbient(float dir, float speed)
 {
-	u8* freeObj = 0;
+	u8* freeObj;
 	u8* scan = (u8*)this;
+	int group = 4;
 
-	for (int group = 0; group < 4; group++) {
+	do {
 		freeObj = scan;
 		if ((s8)freeObj[0] >= 0) {
 			break;
@@ -325,6 +326,10 @@ int CWind::AddAmbient(float dir, float speed)
 		}
 
 		scan += 800;
+		group--;
+	} while (group != 0);
+
+	if (group == 0) {
 		freeObj = 0;
 	}
 


### PR DESCRIPTION
## Summary
- Reworked `CWind::AddAmbient(float dir, float speed)` free-slot scan control flow in `src/wind.cpp` to use a countdown `do/while` scan pattern.
- Kept behavior unchanged (same 8-slot checks per group, same failure path, same object initialization writes).
- No added debug artifacts/comments; code remains source-plausible and consistent with nearby `CWind` routines.

## Functions improved
- Unit: `main/wind`
- Symbol: `AddAmbient__5CWindFff`

## Match evidence
- `AddAmbient__5CWindFff`: **33.788887% -> 59.933334%**
- `main/wind` `.text` (same one-shot diff context): **30.40205% -> 33.082005%**
- Command: `tools/objdiff-cli.exe diff -p . -u main/wind -o - AddAmbient__5CWindFff`

## Plausibility rationale
- The rewrite matches style already used in this file: explicit unrolled slot checks with an outer group iteration.
- It avoids compiler-coaxing artifacts and preserves readable intent.
- This is a control-flow shaping change only; object field writes and return/error paths are preserved.

## Technical notes
- Main mismatch was scan-loop branch/register shape in free-slot lookup.
- Switching loop form improved alignment substantially while keeping the original behavior.