### PR TITLE
Improve pppDestructYmDrawMdlTexAnm UV restore logic

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -81,11 +81,35 @@ void pppConstructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmO
  */
 void pppDestructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOffsets* param2, void* param3)
 {
-    (void)param1;
-    (void)param2;
     (void)param3;
-    // Reset texture animation state
-    // Reset animation counters and UV coordinates
+    pppYmDrawMdlTexAnmWork* work;
+    CMapMesh* mapMesh;
+    CMapMeshUVLayout* uvLayout;
+    s16* uvPairs;
+    u32 frameIndex;
+    u32 frameU;
+    u32 i;
+
+    work = (pppYmDrawMdlTexAnmWork*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2]);
+    frameIndex = work->m_frame;
+    if ((frameIndex != 0) && ((mapMesh = pppEnvStPtr->m_mapMeshPtr) != NULL)) {
+        uvLayout = (CMapMeshUVLayout*)mapMesh;
+        uvPairs = uvLayout->m_uvPairs;
+        frameU = frameIndex / work->m_tilesU;
+
+        for (i = 0; i < (u32)uvLayout->m_uvCount; i++) {
+            uvPairs[0] = (s16)(-((f32)(frameIndex - frameU * work->m_tilesU) * work->m_perU) - (f32)uvPairs[0]);
+            uvPairs[1] = (s16)(-((f32)frameU * work->m_perV) - (f32)uvPairs[1]);
+            uvPairs += 2;
+        }
+
+        DCFlushRange(uvLayout->m_uvPairs, (u32)uvLayout->m_uvCount << 2);
+    }
+
+    work->m_frame = 0;
+    work->m_tilesV = 0;
+    work->m_tilesU = 0;
+    work->m_wait = 0x200;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement `pppDestructYmDrawMdlTexAnm` in `src/pppYmDrawMdlTexAnm.cpp` instead of the placeholder no-op.

The new implementation:
- resolves per-object work state from serialized offsets
- restores map mesh UV pairs based on saved animation frame / tile dimensions / per-tile UV scale
- flushes updated UV memory with `DCFlushRange`
- resets animation state fields (`frame`, `tilesU`, `tilesV`, `wait`)

## Functions improved
- Unit: `main/pppYmDrawMdlTexAnm`
- Symbol: `pppDestructYmDrawMdlTexAnm`

## Match evidence
- `pppDestructYmDrawMdlTexAnm`: **1.2195122% -> 57.73171%** (report)
- Unit `main/pppYmDrawMdlTexAnm` fuzzy: **9.154285% -> 17.980953%** (report)
- objdiff symbol match (oneshot): **57.67073%** for `pppDestructYmDrawMdlTexAnm`

Build verification:
- `ninja` succeeds in this branch (`build/GCCP01/main.dol: OK` baseline already established)

## Plausibility rationale
This change is source-plausible because it restores the expected destructor behavior for a UV-scrolling effect:
- undo previously applied UV offsets from tracked frame/tile state
- flush mesh UV data after mutation
- clear runtime counters back to defaults

It uses existing local mesh overlay conventions already present in this file (`m_uvCount` / `m_uvPairs`) and follows nearby ppp-effect code patterns for state access via serialized offsets.

## Technical details
- Work buffer location: `(u8*)obj + 0x80 + serializedDataOffsets[2]`
- UV writeback iterates `m_uvCount` pairs and updates U/V as signed 16-bit mesh UVs
- Writes match decomp-intended field usage (`frame`, `wait`, `tilesU`, `tilesV`, `perU`, `perV`) without introducing contrived helper abstractions
