### PR TITLE
wind: implement CWind::Draw for major match gain

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -5,15 +5,18 @@
 #include "ffcc/graphic.h"
 #include "ffcc/color.h"
 #include "ffcc/vector.h"
-#include "ffcc/p_camera.h"
+#include "ffcc/gxfunc.h"
 #include "ffcc/math.h"
 #include "ffcc/goout.h"
 #include "ffcc/p_game.h"
 #include "ffcc/system.h"
 
 extern CGraphic Graphic;
-extern CCameraPcs CameraPcs;
-extern u32 CFlat; // Temporary - needs proper declaration
+extern struct {
+    char _0[4];
+    Mtx m_cameraMatrix;
+} CameraPcs;
+extern unsigned char CFlat[];
 extern CMath Math;
 
 extern "C" int Rand__5CMathFUl(CMath*, unsigned long);
@@ -30,6 +33,7 @@ extern float FLOAT_80330f30;
 extern float FLOAT_80330f34;
 extern float FLOAT_80330f38;
 extern float FLOAT_80330f18;
+extern float FLOAT_80330f1c;
 extern double DOUBLE_80330f00;
 extern double DOUBLE_80330f08;
 extern double DOUBLE_80330f10;
@@ -146,12 +150,52 @@ void CWind::Frame()
 
 /*
  * --INFO--
- * Address:	800d9b2c
- * Size:	564
+ * PAL Address: 0x800d9b2c
+ * PAL Size: 564b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CWind::Draw()
 {
-	// TODO: Implement wind rendering
+    u8* obj = (u8*)this;
+    Mtx viewMtx;
+
+    PSMTXCopy(CameraPcs.m_cameraMatrix, viewMtx);
+    _GXSetBlendMode((_GXBlendMode)1, (_GXBlendFactor)4, (_GXBlendFactor)5, (_GXLogicOp)1);
+    GXSetZCompLoc(0);
+    _GXSetAlphaCompare((_GXCompare)6, 1, (_GXAlphaOp)0, (_GXCompare)7, 0);
+    GXSetZMode(1, (_GXCompare)3, 1);
+    GXSetCullMode((_GXCullMode)1);
+    GXSetNumTevStages(1);
+    _GXSetTevOp((_GXTevStageID)0, (_GXTevMode)4);
+    _GXSetTevOrder((_GXTevStageID)0, (_GXTexCoordID)0xff, (_GXTexMapID)0xff, (_GXChannelID)4);
+    GXSetNumChans(1);
+    GXSetChanCtrl((_GXChannelID)0, 0, (_GXColorSrc)0, (_GXColorSrc)0, 0, (_GXDiffuseFn)2, (_GXAttnFn)1);
+    GXSetChanCtrl((_GXChannelID)2, 0, (_GXColorSrc)0, (_GXColorSrc)0, 0, (_GXDiffuseFn)2, (_GXAttnFn)2);
+    GXClearVtxDesc();
+    GXSetVtxDesc((_GXAttr)9, (_GXAttrType)1);
+    GXSetVtxAttrFmt((_GXVtxFmt)0, (_GXAttr)9, (_GXCompCnt)1, (_GXCompType)4, 0);
+
+    if ((*(u32*)(CFlat + 0x129c) & 0x800000) != 0) {
+        for (int i = 0; i < 32; i++, obj += 100) {
+            if ((s8)obj[0] >= 0) {
+                continue;
+            }
+
+            if (*(s32*)(obj + 0x1C) == 1) {
+                CColor color(0xff, 0xff, 0, 0xff);
+                CVector pos(*(float*)(obj + 4), FLOAT_80330ef0, *(float*)(obj + 8));
+                Graphic.DrawSphere(viewMtx, (Vec*)&pos, *(float*)(obj + 0x30), &color.color);
+            } else {
+                int alpha = (int)(FLOAT_80330f1c * (FLOAT_80330ef8 - *(float*)(obj + 0x38)));
+                CColor color(0xff, 0xff, 0x80, alpha);
+                CVector pos(*(float*)(obj + 4), FLOAT_80330ef0, *(float*)(obj + 8));
+                Graphic.DrawSphere(viewMtx, (Vec*)&pos, *(float*)(obj + 0x30), &color.color);
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
﻿## Summary
- Implemented CWind::Draw() in src/wind.cpp using the PAL Ghidra reference as a guide, including GX render-state setup and sphere draw calls for active wind objects.
- Replaced temporary CFlat/camera declarations with offset-accurate extern access used elsewhere in the project (CFlat + 0x129c debug flag and camera matrix copy).
- Updated function metadata comment to the project-standard PAL/EN/JP format.

## Functions Improved
- Unit: main/wind
- Symbol: Draw__5CWindFv (size: 564b)
- Match changed from **0.7%** (selector baseline) to **82.58%** (uild/GCCP01/report.json after rebuild).

## Match Evidence
- Before: Draw__5CWindFv reported at 0.7% by python3 tools/agent_select_target.py.
- After: Draw__5CWindFv reported at 82.58156% fuzzy match in uild/GCCP01/report.json.
- Build verification: 
inja completes and verifies uild/GCCP01/main.dol: OK.

## Plausibility Rationale
- Uses existing FFCC rendering idioms (GX wrapper state setup, per-object active/type checks, Graphic.DrawSphere(...)) rather than compiler-only coercion.
- Object iteration and field usage align with adjacent CWind functions (Frame, Calc, Add*) and existing object stride/layout assumptions.

## Technical Details
- Enabled draw path only when CFlat + 0x129c includes bit  x800000, matching existing project offset conventions.
- Added missing scalar reference FLOAT_80330f1c used for alpha scaling in type-2 sphere rendering.
