### PR TITLE
map: implement SetMapObjWorldMapLightID

### DIFF
--- a/include/ffcc/map.h
+++ b/include/ffcc/map.h
@@ -4,6 +4,7 @@
 #include "ffcc/mapobj.h"
 
 #include <dolphin/gx.h>
+#include <dolphin/mtx.h>
 
 class CChunkFile;
 class CMapObj;
@@ -16,7 +17,6 @@ class CMapAnimNode;
 class CMapAnimKeyDt;
 class CMapShadow;
 class CMemory;
-struct Vec;
 
 void setDbgLight(int, Vec&, _GXColor&);
 void GXSetTexCoordGen();
@@ -105,8 +105,8 @@ public:
     void ShowMapMeshID(int, int);
     void SetMapObjPrioID(int, unsigned char);
     void SetMapObjTransRate(int, float, float, float);
-    void SetMapObjWorldMapLightIdx(int, _GXColor, Vec&);
-    void SetMapObjWorldMapLightID(int, _GXColor, Vec&);
+    void SetMapObjWorldMapLightIdx(int, _GXColor, Vec);
+    void SetMapObjWorldMapLightID(int, _GXColor, Vec);
     void SetDrawRangeOctTree(float);
     void SetDrawRangeMapObj(float);
     void SetDraw(unsigned char);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -685,19 +685,62 @@ void CMapMng::SetMapObjTransRate(int, float, float, float)
  * Address:	TODO
  * Size:	TODO
  */
-void CMapMng::SetMapObjWorldMapLightIdx(int, _GXColor, Vec&)
+void CMapMng::SetMapObjWorldMapLightIdx(int, _GXColor, Vec)
 {
 	// TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002f47c
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::SetMapObjWorldMapLightID(int, _GXColor, Vec&)
+void CMapMng::SetMapObjWorldMapLightID(int id, _GXColor color, Vec position)
 {
-	// TODO
+	int i;
+	int objCount;
+	int objIndex;
+	unsigned int packedColor;
+	unsigned int posX;
+	unsigned int posY;
+	unsigned int posZ;
+	unsigned char* mapObj;
+	unsigned char* mapObjLight;
+
+	objCount = *(short*)((unsigned char*)this + 0xC);
+	objIndex = 0;
+	for (i = 0; i < objCount; i++) {
+		mapObj = (unsigned char*)this + 0x70 + i * 0xF0;
+		if (*(unsigned short*)(mapObj + 0x2E) == (unsigned short)id) {
+			objIndex = i;
+			goto found;
+		}
+	}
+	objIndex = -1;
+
+found:
+	packedColor = *(unsigned int*)&color;
+	posX = *(unsigned int*)((unsigned char*)&position + 0);
+	posY = *(unsigned int*)((unsigned char*)&position + 4);
+	posZ = *(unsigned int*)((unsigned char*)&position + 8);
+
+	mapObj = (unsigned char*)this + 0x70 + objIndex * 0xF0;
+	mapObjLight = *(unsigned char**)(mapObj + 0xEC);
+	if (*(int*)(mapObjLight + 4) == 1) {
+		*(unsigned char*)(mapObjLight + 8) = (unsigned char)(packedColor >> 24);
+		*(unsigned char*)(mapObjLight + 9) = (unsigned char)(packedColor >> 16);
+		*(unsigned char*)(mapObjLight + 10) = (unsigned char)(packedColor >> 8);
+		*(unsigned char*)(mapObjLight + 0xB) = (unsigned char)packedColor;
+		*(unsigned int*)(mapObj + 0x70) = posX;
+		*(unsigned int*)(mapObj + 0x74) = posY;
+		*(unsigned int*)(mapObj + 0x78) = posZ;
+		*(unsigned char*)(mapObj + 0x1C) = 1;
+		*(unsigned char*)(mapObj + 0x1B) = 1;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapMng::SetMapObjWorldMapLightID` in `src/map.cpp` using recovered map-object runtime layout and ID-based lookup.
- Updated world-map light setter signatures in `include/ffcc/map.h`/`src/map.cpp` to match PAL symbol mangling:
  - `SetMapObjWorldMapLightIdx(int, _GXColor, Vec)`
  - `SetMapObjWorldMapLightID(int, _GXColor, Vec)`
- Added function metadata block for PAL (`0x8002f47c`, `204b`).

## Functions Improved
- Unit: `main/map`
- Function: `SetMapObjWorldMapLightID__7CMapMngFi8_GXColor3Vec`

## Match Evidence
- `SetMapObjWorldMapLightID__7CMapMngFi8_GXColor3Vec`: **0.0% -> 53.80392% fuzzy**
- Unit `main/map` fuzzy score: **1.131719 -> 1.6351129**
- `ninja` build and report generation both pass.

## Plausibility Rationale
- Existing declaration used `Vec&`, but PAL mangling is `...3Vec` (by-value), which prevents correct symbol pairing and hard-blocks meaningful matching.
- The implemented function behavior mirrors expected game-side logic: find map object by ID, update light color/position for world-map light type, and set object update flags.
- This is a source-plausible first pass for a low-match unit, not synthetic compiler-only reordering.

## Technical Details
- Local `objdiff-cli` is v3.4.1 (no JSON `-o` mode from AGENTS examples), so per-function validation used `build/GCCP01/report.json` after rebuild.
- The current implementation uses offset-based field access because this unit’s class field layouts are still largely unrecovered.