### PR TITLE
p_chara_viewer: decompile destroyViewer (0% -> 87.1%)

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -1,1 +1,65 @@
 #include "ffcc/p_chara_viewer.h"
+
+extern "C" int DAT_8032edc0;
+extern "C" unsigned char Chara[];
+extern "C" unsigned char LightPcs[];
+extern "C" unsigned char Memory[];
+extern "C" void Destroy__6CCharaFv(void*);
+extern "C" void DestroyBumpLightAll__9CLightPcsFQ29CLightPcs6TARGET(void*, int);
+extern "C" void DestroyStage__7CMemoryFPQ27CMemory6CStage(void*, void*);
+
+namespace {
+static void releaseRef(void** slot)
+{
+    int* ref = (int*)*slot;
+    if (ref != 0) {
+        int count = ref[1] - 1;
+        ref[1] = count;
+        if (count == 0) {
+            (*(void (**)(void*, int))(*(int*)ref + 8))(ref, 1);
+        }
+        *slot = 0;
+    }
+}
+} // namespace
+
+/*
+ * --INFO--
+ * PAL Address: 0x800BEE50
+ * PAL Size: 580b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void destroyViewer__9CCharaPcsFv(void* param_1)
+{
+    unsigned char* p = (unsigned char*)param_1;
+    unsigned int i;
+
+    Destroy__6CCharaFv(Chara);
+    DestroyBumpLightAll__9CLightPcsFQ29CLightPcs6TARGET(LightPcs, 0);
+    DAT_8032edc0 = 0;
+
+    releaseRef((void**)(p + 0x1A0));
+
+    i = 0;
+    do {
+        releaseRef((void**)(p + 0x190 + i * 4));
+        releaseRef((void**)(p + 0x198 + i * 4));
+        releaseRef((void**)(p + 0x2B0 + i * 4));
+        i++;
+    } while (i < 2);
+
+    releaseRef((void**)(p + 0x2B8));
+
+    i = 0;
+    do {
+        releaseRef((void**)(p + 0x1B0 + i * 4));
+        i++;
+    } while (i < 0x40);
+
+    DestroyStage__7CMemoryFPQ27CMemory6CStage(Memory, *(void**)(p + 0xCC));
+    DestroyStage__7CMemoryFPQ27CMemory6CStage(Memory, *(void**)(p + 0xD0));
+    DestroyStage__7CMemoryFPQ27CMemory6CStage(Memory, *(void**)(p + 0xD4));
+}


### PR DESCRIPTION
## Summary
Implemented destroyViewer__9CCharaPcsFv in src/p_chara_viewer.cpp as a first-pass decompilation matching the existing low-level style used in this codebase.

Main changes:
- Added explicit release/decref flow for viewer-owned refs at expected offsets.
- Added teardown of model/anim/texture refs for both viewer slots.
- Added cleanup loop for 64 animation-bank refs.
- Added stage teardown calls for model/texture/anim memory stages.
- Preserved existing global teardown behavior (Chara, bump lights, viewer state flag).

## Functions improved
- Unit: main/p_chara_viewer
- Function: destroyViewer__9CCharaPcsFv (PAL 0x800BEE50, 580b)

## Match evidence
Before (target selector):
- main/p_chara_viewer: 0.0%
- destroyViewer__9CCharaPcsFv: 0.0%

After (
inja report + objdiff):
- main/p_chara_viewer: 6.615% fuzzy match
- destroyViewer__9CCharaPcsFv: 87.1% fuzzy match (report: 87.13793, objdiff diff: 87.10345)

Validation commands used:
- 
inja
- uild/tools/objdiff-cli.exe diff -p . -u main/p_chara_viewer -o - --format json-pretty destroyViewer__9CCharaPcsFv

## Plausibility rationale
This change follows the expected original-source teardown semantics for this subsystem:
- deterministic refcount decrements and destruction when count reaches zero,
- explicit cleanup of all viewer-owned resource slots,
- destruction of per-viewer memory stages at shutdown.

No contrived compiler-coaxing patterns were introduced; the implementation is a straightforward reconstruction of lifecycle logic for this object.

## Technical details
- Introduced a small local eleaseRef helper to centralize repeated decrement/dtor sequence used by this unit.
- Kept pointer-offset accesses exactly aligned with observed object layout usage in the decomp for this file.
- Kept scope focused to one function for a clean, reviewable first-pass improvement in a previously 0%-matched unit.