### PR TITLE
pppSRandCV: fix callback signature and improve match to 77%

### DIFF
--- a/include/ffcc/pppSRandCV.h
+++ b/include/ffcc/pppSRandCV.h
@@ -7,7 +7,7 @@ extern "C" {
 
 void randchar(char, float);
 void randf(unsigned char);
-void pppSRandCV(void* param1, void* param2);
+void pppSRandCV(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Corrected `pppSRandCV` callback signature to use three parameters (`param1`, `param2`, `param3`), matching the unit's calling convention and register usage.
- Replaced placeholder logic with a typed implementation aligned to sibling `pppSRand*CV/HCV` routines:
  - typed parameter layout (`index`, `colorOffset`, 4 signed channel bases, flag)
  - random vector generation via `RandF__5CMathFv`
  - flag-dependent scaling path (`* 2.0f` when single-rand mode)
  - color target selection (`-1` sentinel to `lbl_801EADC8`, else object-relative)
  - per-channel signed delta application against current channel values

## Functions Improved
- Unit: `main/pppSRandCV`
- Symbol: `pppSRandCV`

## Match Evidence
- `tools/agent_select_target.py` baseline: `pppSRandCV` at **40.4%** match (736b)
- Post-change `build/GCCP01/report.json`: `pppSRandCV` at **77.038%** fuzzy match
- Post-change `objdiff-cli v3.6.1` one-shot diff: **76.929%** match for `pppSRandCV`

## Plausibility Rationale
- The change removes placeholder/random stub behavior and adopts control flow and data-shape conventions already used by nearby source-plausible particle randomization callbacks (`pppSRandHCV`, `pppSRandUpCV`).
- This is not compiler coaxing: it is a direct correction of callback ABI/signature plus coherent typed logic for RNG + channel delta updates.

## Technical Notes
- Added typed local `SRandCVParams` for stable field access and ABI-consistent reads.
- Switched RNG calls to explicit `RandF__5CMathFv(&math)` to match other units in this family.
- Kept helper stubs (`randchar`, `randf`) unchanged since they are currently out-of-scope for the measured symbol.