### PR TITLE
main/OdemuExi2/DebuggerDriver: improve DBGHandler callback ABI matching

### DIFF
--- a/src/OdemuExi2/DebuggerDriver.c
+++ b/src/OdemuExi2/DebuggerDriver.c
@@ -6,7 +6,7 @@ typedef void (*MTRCallbackType)(int);
 
 static MTRCallbackType MTRCallback;
 
-static void (*DBGCallback)(u32, OSContext*);
+static void (*DBGCallback)(s16);
 
 static u32 SendMailData;
 
@@ -242,7 +242,7 @@ static BOOL DBGReadStatus(u32* p1) {
 }
 #pragma dont_inline reset
 
-static void MWCallback(u32 a, OSContext* b) {
+static void MWCallback(s16 a) {
     EXIInputFlag = TRUE;
     if (MTRCallback) {
         MTRCallback(0);
@@ -252,7 +252,7 @@ static void MWCallback(u32 a, OSContext* b) {
 static void DBGHandler(s16 a, OSContext* b) {
     *__PIRegs = 0x1000;
     if (DBGCallback) {
-        DBGCallback(a, b);
+        DBGCallback(a);
     }
 }
 


### PR DESCRIPTION
## Summary
- Refined callback typing in `src/OdemuExi2/DebuggerDriver.c` for the interrupt forwarding path.
- Changed `DBGCallback` to `void (*)(s16)`.
- Updated `MWCallback` signature to accept the forwarded interrupt argument while preserving behavior.

## Functions improved
- Unit: `main/OdemuExi2/DebuggerDriver`
- Symbol: `DBGHandler` (`64b`)

## Match evidence
- `DBGHandler`: **46.0625% -> 51.375%** (`+5.3125`)
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/OdemuExi2/DebuggerDriver -o - --format json DBGHandler`
- Build verified with `ninja`.

## Plausibility rationale
- Uses explicit interrupt callback typing and direct interrupt forwarding, which is a plausible original-source pattern for this module.
- Runtime behavior is unchanged: PI interrupt ACK write (`0x1000`) and conditional callback dispatch are preserved.

## Technical details
- Primary gain is in `DBGHandler` indirect call codegen alignment.
- Neighbor symbols (`MWCallback`, `DBInitInterrupts`) remained stable.