### PR TITLE
Improve match for pppFrameYmCheckBGHeight

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -58,52 +58,43 @@ void pppConstructYmCheckBGHeight(void)
  */
 struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pppYmCheckBGHeight, struct UnkC* param_2)
 {
-    _pppMngSt* pppMngSt;
+    _pppMngSt* pppMngSt = pppMngStPtr;
+    int hitResult;
+    double currentY;
     CMapCylinderRaw cyl;
     Vec hitPos;
-    double currentY;
-
-    pppMngSt = pppMngStPtr;
-    if (DAT_8032ed70 != 0) {
-        return pppYmCheckBGHeight;
+    if (DAT_8032ed70 == 0) {
+        cyl.m_direction.x = FLOAT_80330ed0;
+        cyl.m_direction.y = FLOAT_80330ed4;
+        cyl.m_direction.z = FLOAT_80330ed0;
+        currentY = (double)pppMngStPtr->m_matrix.value[1][3];
+        cyl.m_bottom.x = pppMngStPtr->m_matrix.value[0][3];
+        cyl.m_bottom.z = pppMngStPtr->m_matrix.value[2][3];
+        cyl.m_bottom.y = (float)(currentY + (double)param_2->m_unk0x4);
+        cyl.m_direction2.x = FLOAT_80330ed8;
+        cyl.m_direction2.y = FLOAT_80330ed8;
+        cyl.m_direction2.z = FLOAT_80330ed8;
+        cyl.m_radius2 = FLOAT_80330edc;
+        cyl.m_height2 = FLOAT_80330edc;
+        cyl.m_radius = FLOAT_80330edc;
+        cyl.m_top.x = FLOAT_80330ed0;
+        cyl.m_top.y = FLOAT_80330ed4;
+        cyl.m_top.z = FLOAT_80330ed0;
+        cyl.m_height = FLOAT_80330ed0;
+        hitResult = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, (CMapCylinder*)&cyl, &cyl.m_direction, 0xffffffff);
+        if ((hitResult != 0) &&
+            (CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A88), &hitPos),
+             (float)(currentY - (double)param_2->m_serializedDataOffsets) <= hitPos.y)) {
+            currentY = (double)(hitPos.y + param_2->m_unk0x8);
+        }
+        pppMngSt->m_position.y = (float)currentY;
+        *((float*)pppMngSt + 0x17) = (float)currentY;
+        *((float*)pppMngSt + 0x1B) = (float)currentY;
+        *((float*)pppMngSt + 0x13) = (float)currentY;
+        pppMngStPtr->m_matrix.value[0][3] = pppMngSt->m_position.x;
+        pppMngStPtr->m_matrix.value[1][3] = pppMngSt->m_position.y;
+        pppMngStPtr->m_matrix.value[2][3] = pppMngSt->m_position.z;
+        pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
-
-    cyl.m_direction.x = FLOAT_80330ed0;
-    cyl.m_direction.y = FLOAT_80330ed4;
-    cyl.m_direction.z = FLOAT_80330ed0;
-
-    currentY = (double)pppMngSt->m_matrix.value[1][3];
-    cyl.m_bottom.x = pppMngSt->m_matrix.value[0][3];
-    cyl.m_bottom.z = pppMngSt->m_matrix.value[2][3];
-    cyl.m_bottom.y = (float)(currentY + (double)param_2->m_unk0x4);
-
-    cyl.m_direction2.x = FLOAT_80330ed8;
-    cyl.m_direction2.y = FLOAT_80330ed8;
-    cyl.m_direction2.z = FLOAT_80330ed8;
-
-    cyl.m_radius2 = FLOAT_80330edc;
-    cyl.m_height2 = FLOAT_80330edc;
-    cyl.m_radius = FLOAT_80330edc;
-
-    cyl.m_top.x = FLOAT_80330ed0;
-    cyl.m_top.y = FLOAT_80330ed4;
-    cyl.m_top.z = FLOAT_80330ed0;
-    cyl.m_height = FLOAT_80330ed0;
-
-    if ((CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, (CMapCylinder*)&cyl, &cyl.m_direction, 0xffffffff) != 0) &&
-        (CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A88), &hitPos),
-         (float)(currentY - (double)param_2->m_serializedDataOffsets) <= hitPos.y)) {
-        currentY = (double)(hitPos.y + param_2->m_unk0x8);
-    }
-
-    pppMngSt->m_position.y = (float)currentY;
-    *((float*)pppMngSt + 0x17) = (float)currentY;
-    *((float*)pppMngSt + 0x1B) = (float)currentY;
-    *((float*)pppMngSt + 0x13) = (float)currentY;
-
-    pppMngSt->m_matrix.value[0][3] = pppMngSt->m_position.x;
-    pppMngSt->m_matrix.value[1][3] = pppMngSt->m_position.y;
-    pppMngSt->m_matrix.value[2][3] = pppMngSt->m_position.z;
-
-    return (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
+    return pppYmCheckBGHeight;
 }


### PR DESCRIPTION
## Summary
Reworked `pppFrameYmCheckBGHeight` in `src/pppYmCheckBGHeight.cpp` to better match original control/data flow:
- switched to a single guarded body (`if (DAT_8032ed70 == 0)`) with late return
- aligned temporary flow (`currentY`/hit result) to mirror original branch structure
- aligned matrix source usage to `pppMngStPtr` for cylinder setup and final matrix writeback
- preserved existing pointer-offset Y writes for unresolved `_pppMngSt` fields

## Functions improved
- Unit: `main/pppYmCheckBGHeight`
- Function: `pppFrameYmCheckBGHeight`

## Match evidence
- `objdiff-cli` one-shot (`tools/objdiff-cli diff -p . -u main/pppYmCheckBGHeight -o - pppFrameYmCheckBGHeight`)
  - before (origin/main file): `63.67816%`
  - after (this branch): `68.9885%`
  - net: `+5.31034`

## Plausibility rationale
This change removes decompiler-style early exits and reorders state updates into a straightforward game-loop style block while preserving behavior. The edits are type/control-flow cleanups and consistent with surrounding PPP source style, not artificial compiler-coaxing constructs.

## Technical details
- verified build with `ninja`
- measured improvement directly on the target symbol with objdiff one-shot mode
- no unrelated source changes included