### PR TITLE
mapmesh: match deleting destructor at 0x80028648

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -153,24 +153,32 @@ CMapMesh::CMapMesh()
  * JP Address: TODO
  * JP Size: TODO
  */
-CMapMesh::~CMapMesh()
+extern "C" CMapMesh* dtor_80028648(CMapMesh* mapMesh, short param_2)
 {
-    if (PtrAt(this, 0x24) != 0) {
-        __dla__FPv(PtrAt(this, 0x24));
-        PtrAt(this, 0x24) = 0;
+    if (mapMesh != 0) {
+        if (PtrAt(mapMesh, 0x24) != 0) {
+            __dla__FPv(PtrAt(mapMesh, 0x24));
+            PtrAt(mapMesh, 0x24) = 0;
+        }
+
+        if (PtrAt(mapMesh, 0x28) != 0) {
+            __dla__FPv(PtrAt(mapMesh, 0x28));
+            PtrAt(mapMesh, 0x28) = 0;
+        }
+
+        U16At(mapMesh, 0x0) = 0;
+        U16At(mapMesh, 0x2) = 0;
+        U16At(mapMesh, 0x4) = 0;
+        U16At(mapMesh, 0x8) = 0;
+        U16At(mapMesh, 0x6) = 0;
+        U16At(mapMesh, 0xA) = 0;
+
+        if (0 < param_2) {
+            __dl__FPv(mapMesh);
+        }
     }
 
-    if (PtrAt(this, 0x28) != 0) {
-        __dla__FPv(PtrAt(this, 0x28));
-        PtrAt(this, 0x28) = 0;
-    }
-
-    U16At(this, 0x0) = 0;
-    U16At(this, 0x2) = 0;
-    U16At(this, 0x4) = 0;
-    U16At(this, 0x8) = 0;
-    U16At(this, 0x6) = 0;
-    U16At(this, 0xA) = 0;
+    return mapMesh;
 }
 
 /*


### PR DESCRIPTION
﻿## Summary
- Reworked `src/mapmesh.cpp` destructor implementation at PAL `0x80028648` into an explicit deleting-destructor style entrypoint: `dtor_80028648(CMapMesh*, short)`.
- Preserved behavior (free two owned arrays, clear mesh counters/fields, conditionally call `__dl__FPv` when `param_2 > 0`).
- Kept existing `Destroy__8CMapMeshFv` unchanged.

## Functions improved
- Unit: `main/mapmesh`
- Symbol: `dtor_80028648`
  - Before: `0.0%` (from target selector output)
  - After: `100.0%` (`tools/objdiff-cli diff -p . -u main/mapmesh dtor_80028648`)

## Match evidence
- `ninja` progress changed from:
  - `Code: 187316 / 1855300 bytes (1301 / 4733 functions)`
- to:
  - `Code: 187468 / 1855300 bytes (1302 / 4733 functions)`
- This is a real +152 byte / +1 function match gain, not formatting-only churn.

## Plausibility rationale
- The change follows common Metrowerks-era deleting-destructor patterns used throughout this codebase (see other `dtor_*` shims).
- Control flow and memory ownership semantics are straightforward and source-plausible:
  - null-guard object
  - free owned buffers when present
  - zero relevant fields
  - optional object delete for positive destructor mode

## Technical details
- Root issue was symbol pairing mismatch around the destructor entrypoint name/signature.
- Converting this function to the unit's expected `dtor_80028648` form allowed objdiff to pair and score the function correctly.
- Verified with full rebuild (`ninja`) and symbol-scoped objdiff check.
