### PR TITLE
mapmesh: improve GetTexture match shape

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -88,36 +88,6 @@ static inline CMaterialSet* DefaultMaterialSet()
 
 /*
  * --INFO--
- * PAL Address: 0x800287a0
- * PAL Size: 32b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-template <>
-CMaterial* CPtrArray<CMaterial*>::operator[](unsigned long index)
-{
-    return GetAt(index);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800287c0
- * PAL Size: 16b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-template <>
-CMaterial* CPtrArray<CMaterial*>::GetAt(unsigned long index)
-{
-    return m_items[index];
-}
-
-/*
- * --INFO--
  * Address:	TODO
  * Size:	TODO
  */
@@ -402,18 +372,53 @@ void CMapMesh::DrawPart(CMaterialSet* materialSet, int drawMaterialPart)
  */
 void* CMapMesh::GetTexture(CMaterialSet* materialSet, int& textureIndex)
 {
+    int* drawEntry;
+
     if (U16At(this, 0xA) == 0) {
         return 0;
     }
 
-    MeshDrawEntry* entry = DrawEntries(this);
-    if (entry->size == 0) {
+    drawEntry = reinterpret_cast<int*>(PtrAt(this, 0x40));
+    if (*drawEntry == 0) {
         return 0;
     }
 
-    textureIndex = entry->materialIdx;
-    CMaterial* material = (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[entry->materialIdx];
+    unsigned short materialIdx = *reinterpret_cast<unsigned short*>(drawEntry + 2);
+    textureIndex = materialIdx;
+
+    CMaterial* material =
+        (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[materialIdx];
     return *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(material) + 0x3C);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800287a0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMaterial* CPtrArray<CMaterial*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800287c0
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMaterial* CPtrArray<CMaterial*>::GetAt(unsigned long index)
+{
+    return m_items[index];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CMapMesh::GetTexture` in `src/mapmesh.cpp` to follow original pointer/halfword access and control-flow shape.
- Switched to `int*` draw-entry access (`field19_0x40` style) with explicit `materialIdx` extraction from entry offset `+0x8`.
- Moved `CPtrArray<CMaterial*>` specialization definitions (`operator[]`/`GetAt`) after use to avoid over-inlining in `GetTexture` and better match original call shape.

## Functions Improved
- Unit: `main/mapmesh`
- Symbol: `GetTexture__8CMapMeshFP12CMaterialSetRi`

## Match Evidence
- `GetTexture__8CMapMeshFP12CMaterialSetRi`: **41.727272% -> 65.681816%**
- Symbol size unchanged: `88b -> 88b`
- Instruction diffs reduced: `21 -> 13`
- Validation command:
  - `tools/objdiff-cli diff -p . -u main/mapmesh -o - GetTexture__8CMapMeshFP12CMaterialSetRi`

## Plausibility Rationale
- The update preserves straightforward original-source intent: early outs on empty mesh/display-list entry, material index extraction, material lookup, and texture pointer return.
- Changes are type/flow alignment and de-inlining oriented, not contrived temporary shuffling.

## Technical Details
- `GetTexture` now matches the decomp reference structure more closely:
  - `unkCount` zero guard
  - draw-entry base load from mesh field `0x40`
  - first-entry size guard
  - halfword material index load at entry `+0x8`
  - material lookup through `CPtrArray<CMaterial*>` indexing
  - texture pointer load at material `+0x3C`
