### PR TITLE
joybus: match _ThreadMain trampoline

### DIFF
--- a/include/ffcc/joybus.h
+++ b/include/ffcc/joybus.h
@@ -72,7 +72,7 @@ public:
     void ReleaseSem(int portIndex);
 
     void ThreadMain(void* arg);
-    static void* _ThreadMain(void* arg);
+    static void _ThreadMain(void* arg);
     void ThreadInit();
     void ThreadSleep(long long);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -878,9 +878,9 @@ void JoyBus::ThreadMain(void* arg)
  * Address:	TODO
  * Size:	TODO
  */
-void* JoyBus::_ThreadMain(void* param)
+void JoyBus::_ThreadMain(void* param)
 {
-	return nullptr;
+    Joybus.ThreadMain(param);
 }
 
 /*
@@ -906,7 +906,7 @@ void JoyBus::ThreadInit()
 
         OSCreateThread(
             thread,
-            JoyBus::_ThreadMain,
+            (void* (*)(void*))JoyBus::_ThreadMain,
             threadParam,
             stackBase,
             sizeof(m_sendBuffer[0]),
@@ -6265,7 +6265,7 @@ void JoyBus::RestartThread()
 
         OSCreateThread(
             &jbA->m_threads[i],
-            JoyBus::_ThreadMain,
+            (void* (*)(void*))JoyBus::_ThreadMain,
             &jbB->m_threadParams[i],
             stackBase,
             sizeof(jbA->m_sendBuffer[0]),


### PR DESCRIPTION
## Summary
- Fixed the JoyBus thread trampoline to match the expected original structure.
- Changed `JoyBus::_ThreadMain` to a void trampoline that calls `Joybus.ThreadMain(param)`.
- Updated `_ThreadMain` declaration and casted thread entry calls at `OSCreateThread` sites to preserve the SDK function pointer type.

## Functions Improved
- Unit: `main/joybus`
- Symbol: `_ThreadMain__6JoyBusFPv` (44b)

## Match Evidence
- `_ThreadMain__6JoyBusFPv`: `12.727273%` -> `100.0%`
- `main/joybus` unit fuzzy match: `33.19278%` -> `33.267643%`
- `main/joybus` matched functions: `15/91` -> `16/91`
- `main/joybus` matched code: `1064/51292` -> `1108/51292`
- `objdiff-cli` (`main/joybus`, `_ThreadMain__6JoyBusFPv`) now shows `11` instructions with `0` diffs.

## Plausibility Rationale
- This is a standard game-thread trampoline pattern used throughout the codebase: static entry wrapper forwards to instance method.
- The explicit cast at `OSCreateThread` is also an existing project pattern when wrappers use non-matching return signatures.
- Change improves matching without introducing contrived temporaries, odd control flow, or readability regressions.

## Technical Details
- Header signature updated: `static void* _ThreadMain(void*)` -> `static void _ThreadMain(void*)`.
- Definition updated to forward call into `Joybus.ThreadMain(param)`.
- Two `OSCreateThread` call sites updated to use `(void* (*)(void*))JoyBus::_ThreadMain`.