### PR TITLE
main/file: improve Read match by preserving call boundary

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -263,6 +263,7 @@ int CFile::GetLength(CFile::CHandle* fileHandle)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma dont_inline on
 void CFile::BackAllFilesToQueue(CHandle* fileHandle)
 {
     CHandle* inFlight;
@@ -296,6 +297,7 @@ void CFile::BackAllFilesToQueue(CHandle* fileHandle)
         }
     }
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added `#pragma dont_inline on/reset` around `CFile::BackAllFilesToQueue` in `src/file.cpp`.
- This prevents the compiler from inlining `BackAllFilesToQueue` into `CFile::Read`, which was causing a major function-shape mismatch.

## Functions improved
- Unit: `main/file`
- Function: `Read__5CFileFPQ25CFile7CHandle`
  - Before: `0.0%`
  - After: `52.166668%`
- Unit fuzzy match:
  - Before: `65.936676%`
  - After: `68.13896%`

## Match evidence
- `ninja` rebuild completed successfully and regenerated `build/GCCP01/report.json`.
- `objdiff-cli` oneshot (`v3.6.1`) for `Read__5CFileFPQ25CFile7CHandle` shows structural alignment improvement:
  - Right-side emitted symbol size moved from `312` to `136` in diff output.
  - Diff insertions reduced from `48` to `4` instructions in the compared function block.

## Plausibility rationale
- The change is localized and does not alter source-level behavior.
- It aligns with expected original function boundaries (explicit `BackAllFilesToQueue` call in `Read`) instead of an inlined merged body.
- This is a compiler-behavior correction that improves decompilation fidelity without contrived source transformations.

## Technical details
- Root cause: compiler settings inlined `BackAllFilesToQueue` into `Read`, making `Read` much larger than target shape.
- Fix: enforce non-inlining only for this function using Metrowerks-compatible pragma already used elsewhere in the repository.