### PR TITLE
mapocttree: implement ClearFlag mask setup and octree flag clear dispatch

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -3,6 +3,7 @@
 
 extern float lbl_8032F96C;
 extern float lbl_8032F970;
+static unsigned long s_clearFlagMask;
 
 /*
  * --INFO--
@@ -149,12 +150,16 @@ void ClearLight_r(COctNode*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8002e004
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void COctTree::ClearLight()
 {
-	// TODO
+	ClearLight_r(*(COctNode**)((unsigned char*)this + 0x4));
 }
 
 /*
@@ -189,12 +194,16 @@ void ClearShadow_r(COctNode*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8002da1c
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void COctTree::ClearShadow()
 {
-	// TODO
+	ClearShadow_r(*(COctNode**)((unsigned char*)this + 0x4));
 }
 
 /*
@@ -239,12 +248,17 @@ void ClearFlag_r(COctNode*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8002d2dc
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void COctTree::ClearFlag(unsigned long)
+void COctTree::ClearFlag(unsigned long flag)
 {
-	// TODO
+	s_clearFlagMask = ~flag;
+	ClearFlag_r(*(COctNode**)((unsigned char*)this + 0x4));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `COctTree::ClearFlag(unsigned long)` in `src/mapocttree.cpp`.
- Added the per-call clear-mask store (`~flag`) and dispatch to `ClearFlag_r` from the octree root.
- Added PAL `--INFO--` metadata for `ClearFlag`, `ClearLight`, and `ClearShadow` using current Ghidra export addresses/sizes.

## Functions improved
- Unit: `main/mapocttree`
- Symbol: `ClearFlag__8COctTreeFUl` (PAL `0x8002d2dc`, 44b)

## Match evidence
- `ClearFlag__8COctTreeFUl`: **9.090909% -> 26.818182%**
- Instruction diff summary changed from:
  - before: `DIFF_DELETE=10, MATCH=1`
  - after: `DIFF_DELETE=8, MATCH=2, DIFF_ARG_MISMATCH=1`
- Measured with:
  - `tools/objdiff-cli.exe diff -p . -u main/mapocttree -o - ClearFlag__8COctTreeFUl`

## Plausibility rationale
- The updated source follows expected game-code behavior for a flag-clear operation: compute inverse mask, store it once, then recurse from the root.
- This is source-plausible and consistent with nearby octree traversal entrypoints, not a contrived reordering for compiler coaxing.

## Technical details
- Build validation: `ninja` passes after the change.
- `ClearLight`/`ClearShadow` wrappers were also filled and documented in this pass; they are source-clean but did not move binary match yet because their recursive helpers are still TODO in this translation unit.