### PR TITLE
gxfunc: fully match _GXSetTevSwapModeTable

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -277,12 +277,13 @@ void _GXSetTevSwapMode(_GXTevStageID stage, _GXTevSwapSel rasSel, _GXTevSwapSel 
  */
 void _GXSetTevSwapModeTable(_GXTevSwapSel table, _GXTevColorChan red, _GXTevColorChan green, _GXTevColorChan blue, _GXTevColorChan alpha)
 {
-	if (s_GXSetTevSwapModeTable_Reg[table].red != red || s_GXSetTevSwapModeTable_Reg[table].green != green ||
-	    s_GXSetTevSwapModeTable_Reg[table].blue != blue || s_GXSetTevSwapModeTable_Reg[table].alpha != alpha) {
-		s_GXSetTevSwapModeTable_Reg[table].red = red;
-		s_GXSetTevSwapModeTable_Reg[table].green = green;
-		s_GXSetTevSwapModeTable_Reg[table].blue = blue;
-		s_GXSetTevSwapModeTable_Reg[table].alpha = alpha;
+	int tableOff = table * 0x10;
+	int* entry = (int*)((char*)s_GXSetTevSwapModeTable_Reg + tableOff);
+	if (entry[0] != red || entry[1] != green || entry[2] != blue || entry[3] != alpha) {
+		entry[0] = red;
+		entry[1] = green;
+		entry[2] = blue;
+		entry[3] = alpha;
 		GXSetTevSwapModeTable(table, red, green, blue, alpha);
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked _GXSetTevSwapModeTable cache checks/updates in src/gxfunc.cpp to use explicit 32-bit slot access via computed table offset.
- Behavior is unchanged; this only changes expression form and access pattern.

## Functions Improved
- Unit: main/gxfunc
- Symbol: _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan

## Match Evidence
- _GXSetTevSwapModeTable...: **76.07143% -> 100.0%** (objdiff)
- Global build progress after 
inja:
  - Code matched bytes: **187380 -> 187492**
  - Matched functions: **1303 -> 1304**

## Plausibility Rationale
- The new form mirrors the object-layout access pattern already used in this unit (e.g. direct int stores in _InitGxFunc).
- It keeps the same cache semantics (compare 4 fields, update same 4 fields, then call GXSetTevSwapModeTable) without contrived control-flow edits.

## Technical Notes
- Rebuilt with 
inja and validated with objdiff-cli v3.6.1.