### PR TITLE
main/pppDrawMdlTs: improve pppDrawDrawMdlTs match

### DIFF
--- a/src/pppDrawMdlTs.cpp
+++ b/src/pppDrawMdlTs.cpp
@@ -122,9 +122,7 @@ void pppDrawDrawMdlTs0(_pppPObject*, PDrawMdlTs*, _pppCtrlTable*)
  */
 void pppDrawDrawMdlTs(struct _pppPObject* obj, struct PDrawMdlTs* data, struct _pppCtrlTable* ctrl)
 {
-    // Check if texture ID is valid (not 0xffff)
-    short texId = *((short*)((char*)data + 0x4));
-    if ((texId & 0xffff0000) == 0xffff0000) {
+    if (*((int*)((char*)data + 0x4)) == -1) {
         return;
     }
     
@@ -155,7 +153,7 @@ void pppDrawDrawMdlTs(struct _pppPObject* obj, struct PDrawMdlTs* data, struct _
     MaterialMan.SetTexScroll(texCoords[0], texCoords[3], 0.0f, 0.0f);
     
     // Set blend mode
-    pppSetBlendMode(blendMode);
+    pppSetBlendMode(*((u8*)((char*)data + 0x9)));
     
     // Draw mesh
     int meshId = *((int*)((char*)data + 0x4));


### PR DESCRIPTION
## Summary
- Refined pppDrawDrawMdlTs in src/pppDrawMdlTs.cpp with two source-plausible fixes:
  - Replaced a non-idiomatic texture-id validity check using a masked short with an int == -1 sentinel check at offset +0x4.
  - Updated blend-mode source for pppSetBlendMode to read from byte offset +0x9, aligning with call-site behavior in objdiff.

## Functions improved
- Unit: main/pppDrawMdlTs
- Symbol: pppDrawDrawMdlTs

## Match evidence
- pppDrawDrawMdlTs fuzzy match improved from **73.23214%** to **82.05357%** (	ools/objdiff-cli diff -p . -u main/pppDrawMdlTs -o - pppDrawDrawMdlTs).
- Instruction diff profile improved materially:
  - MATCH: 20 -> 39
  - DIFF_ARG_MISMATCH: 24 -> 5
  - DIFF_INSERT: 5 -> 1
  - DIFF_REPLACE: 8 -> 8
  - DIFF_DELETE: 4 -> 4

## Plausibility rationale
- Using -1 as an invalid-id sentinel in a 32-bit field is conventional and more likely original-source intent than masking a short with 