### PR TITLE
main/ax/AXOut: improve __AXOutAiCallback match

### DIFF
--- a/src/ax/AXOut.c
+++ b/src/ax/AXOut.c
@@ -85,9 +85,13 @@ void __AXOutNewFrame(u32 lessDspCycles) {
 }
 
 void __AXOutAiCallback(void) {
+    OSTime time = __AXOsTime;
+
     if (__AXOutDspReady == 0) {
-        __AXOsTime = OSGetTime();
+        time = OSGetTime();
     }
+
+    __AXOsTime = time;
 
     if (__AXOutDspReady == 1) {
         __AXOutDspReady = 0;
@@ -95,12 +99,6 @@ void __AXOutAiCallback(void) {
     } else {
         __AXOutDspReady = 2;
         DSPAssertTask(&__AXDSPTask);
-    }
-
-    if (__AXOutputBufferMode == 1) {
-        AIInitDMA((u32)__AXOutBuffer[__AXAiDmaFrame], 0x280);
-        __AXAiDmaFrame++;
-        __AXAiDmaFrame %= 3;
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated `__AXOutAiCallback` in `src/ax/AXOut.c` to align callback control flow and state updates with expected AXOut behavior.
- Removed callback-local DMA initialization logic from this function.
- Reworked `__AXOsTime` update flow to use a single conditional capture/store path.

## Functions improved
- Unit: `main/ax/AXOut`
- Symbol: `__AXOutAiCallback`

## Match evidence
- `__AXOutAiCallback`: `15.384615%` -> `90.38461%` (`tools/objdiff-cli diff -p . -u main/ax/AXOut -o - --format json-pretty __AXOutAiCallback`)
- Unit `.text` section match (AXOut object in one-shot output): `80.20993%` -> `84.61174%`

## Plausibility rationale
- The previous callback mixed AI DMA scheduling into the AI interrupt callback path, which did not align with the recovered function shape for `__AXOutAiCallback`.
- The updated code keeps the callback focused on DSP-ready state transitions and frame kick behavior, which is a cleaner and more plausible original source structure.

## Technical details
- Ensured `__AXOutDspReady` transition handling remains unchanged for `0/1/2` state usage.
- Preserved call ordering around `OSGetTime`, `__AXOutNewFrame(0)`, and `DSPAssertTask(&__AXDSPTask)` while eliminating unrelated DMA-side logic from this symbol.