### PR TITLE
main/file: add __sinit_file_cpp static initializer

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -700,3 +700,18 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
     Sound.PauseDiscError(0);
     m_isDiskError = 0;
 }
+
+/*
+ * --INFO--
+ * PAL Address: 0x80013d50
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_file_cpp(void)
+{
+    extern void* __vt__5CFile[];
+    *(void**)&File = __vt__5CFile;
+}


### PR DESCRIPTION
## Summary
- Add __sinit_file_cpp in src/file.cpp with PAL metadata and an explicit static initializer write to File's vtable pointer.
- Keep change scoped to one missing 32-byte target function in main/file.

## Functions improved
- Unit: main/file
- Symbol: __sinit_file_cpp

## Match evidence
- Before: 