### PR TITLE
RedSound: implement StreamPlay flow and standby scan

### DIFF
--- a/include/ffcc/RedSound/RedSound.h
+++ b/include/ffcc/RedSound/RedSound.h
@@ -14,7 +14,7 @@ public:
 	void End();
 	void GetProgramTime();
 	void ReportPrint(int);
-	void ReportStandby(int);
+	int ReportStandby(int);
 
 	void DMAEntry(int, int, int, int, int, void (*)(void*), void*);
 	void DMACheck(int);
@@ -59,7 +59,7 @@ public:
 	void StreamPlayState(int);
 	void GetStreamPlayPoint(int, int*, int*);
 	void StreamStop(int);
-	void StreamPlay(void*, int, int, int);
+	int StreamPlay(void*, int, int, int);
 	void StreamVolume(int, int, int);
 	void StreamPause(int, int);
 

--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -193,12 +193,32 @@ void CRedSound::ReportPrint(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccd9c
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::ReportStandby(int)
+int CRedSound::ReportStandby(int id)
 {
-	// TODO
+	int i;
+
+	if (id == 0) {
+		for (i = 0; i < 0x40; i++) {
+			if (((int*)DAT_8032e17c)[i] != 0) {
+				return 1;
+			}
+		}
+	} else {
+		for (i = 0; i < 0x40; i++) {
+			if (((int*)DAT_8032e17c)[i] == id) {
+				return 1;
+			}
+		}
+	}
+
+	return 0;
 }
 
 /*
@@ -573,12 +593,27 @@ void CRedSound::StreamStop(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd5d8
+ * PAL Size: 224b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::StreamPlay(void*, int, int, int)
+int CRedSound::StreamPlay(void* data, int param_3, int param_4, int param_5)
 {
-	// TODO
+	int id = 0;
+	char* streamData = (char*)data;
+
+	if ((streamData[0] == 'S') && (streamData[1] == 'T') && (streamData[2] == 'R')) {
+		id = GetAutoID();
+		CRedDriver_8032f4c0.StreamPlay(id, data, param_3, param_4, param_5);
+	} else if (DAT_8032f408 != 0) {
+		OSReport("[%s] %s STREAM : This data was not stream data. %s\n", "RedSound", "", "");
+		fflush(&DAT_8021d1a8);
+	}
+
+	return id;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedSound::StreamPlay(void*, int, int, int)` with stream-header validation (`STR`), auto-ID allocation, and dispatch to `CRedDriver::StreamPlay`.
- Implemented `CRedSound::ReportStandby(int)` with standby-table scan and integer status return.
- Updated `RedSound.h` declarations to `int` return types for both methods.
- Added PAL address/size metadata blocks for both functions.

## Functions improved
- Unit: `main/RedSound/RedSound`
- Function: `StreamPlay__9CRedSoundFPviii`

## Match evidence
- `StreamPlay__9CRedSoundFPviii`: **1.7857143% -> 62.035713%**
  - Before: `build/objdiff-report-current-before.json`
  - After: `build/GCCP01/report.json`
- Unit fuzzy (`main/RedSound/RedSound`): **17.220339% -> 20.688559%**

## Plausibility rationale
- Source follows expected game-code semantics: stream magic check, ID generation, and driver command dispatch.
- Error path matches existing debug-gated reporting conventions in this unit (`DAT_8032f408`, `OSReport`, `fflush`).
- No compiler-coaxing constructs; code remains straightforward and maintainable.

## Technical details
- Local `objdiff-cli diff` opens interactively in this environment, so metrics were validated via generated report JSON.
- `ReportStandby__9CRedSoundFi` and `SetWaveData__9CRedSoundFiPvi` still report unresolved/null fuzzy entries and likely need follow-up ABI/signature investigation.