### PR TITLE
pppKeShpTail: improve pppKeShpTail match to 93.1%

### DIFF
--- a/src/pppKeShpTail.cpp
+++ b/src/pppKeShpTail.cpp
@@ -19,7 +19,8 @@ void pppKeShpTail(void* obj, void* param_2)
 		return;
 	}
 
-	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
+	int serializedOffset = **(int**)((u8*)param_2 + 0xc);
+	u8* tail = (u8*)obj + serializedOffset + 0x80;
 	if (*(u32*)((u8*)obj + 0xc) == 0) {
 		Vec local_14;
 		Vec local_30;
@@ -28,17 +29,17 @@ void pppKeShpTail(void* obj, void* param_2)
 		local_14.z = *(f32*)((u8*)obj + 0x3c);
 		pppCopyVector(local_30, local_14);
 
-		u8* tail = (u8*)obj + serializedOffset + 0x80;
 		u8 count = tail[0];
-		u8* tailVec = tail + 8;
-		while (count != 0) {
-			pppCopyVector(*(Vec*)tailVec, local_30);
-			tailVec += 0xc;
-			count--;
+		Vec* tailVec = (Vec*)(tail + 8);
+		if (count != 0) {
+			do {
+				pppCopyVector(*tailVec, local_30);
+				tailVec++;
+				count--;
+			} while (count != 0);
 		}
 	}
 
-	u8* tail = (u8*)obj + serializedOffset + 0x80;
 	if (tail[1] == 0) {
 		tail[1] = tail[0];
 	}


### PR DESCRIPTION
## Summary
- Refined `pppKeShpTail` control-flow and local typing in `src/pppKeShpTail.cpp`.
- Switched serialized offset type to `int`, materialized tail workspace pointer once, and converted the tail copy loop to guarded `do-while` with `Vec*` stepping.
- Kept behavior unchanged while producing assembly closer to target.

## Functions improved
- Unit: `main/pppKeShpTail`
- Function: `pppKeShpTail`

## Match evidence
- `pppKeShpTail`: `75.80645%` -> `93.1129%`
- Unit `main/pppKeShpTail`: `80.0%` -> `94.30666%`
- Verified via `ninja` report generation (`build/GCCP01/report.json`).

## Plausibility rationale
- Changes are source-plausible and idiomatic for this codebase: explicit typed workspace pointer, structured loop over vector entries, and straightforward state updates.
- No contrived temporaries, magic reorderings, or readability regressions were introduced.

## Technical details
- The main gain came from matching loop form and pointer arithmetic shape (`Vec*` increment + counted `do-while`) while preserving the same data flow.
- Build remains clean with `ninja`.