### PR TITLE
main/pppFilter: improve pppRenderFilter match

### DIFF
--- a/src/pppFilter.cpp
+++ b/src/pppFilter.cpp
@@ -67,10 +67,14 @@ void pppFrameFilter(void)
  */
 void pppRenderFilter(pppFilter* pppFilterObj, UnkB* param_2, UnkC* param_3)
 {
+	pppFilter* filter = pppFilterObj;
+	unsigned char* filterBytes = (unsigned char*)filter;
 	int serializedOffset = *param_3->m_serializedDataOffsets;
+	int colorOffset = serializedOffset + 0x88;
+	_GXColor* colorPtr = (_GXColor*)(filterBytes + colorOffset);
 
 	if (param_2->m_dataValIndex == 0xFFFF) {
-		_GXColor color = *(_GXColor*)((char*)pppFilterObj + serializedOffset + 0x88);
+		_GXColor color = *colorPtr;
 		DAT_8032ec70.RenderColorQuad(FLOAT_803320c8, FLOAT_803320c8, FLOAT_803320cc, FLOAT_803320d0, color);
 		return;
 	}
@@ -80,5 +84,5 @@ void pppRenderFilter(pppFilter* pppFilterObj, UnkB* param_2, UnkC* param_3)
 	    pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex], pppEnvStPtr->m_materialSetPtr, textureIndex);
 	RenderTextureQuad__5CUtilFffffP9_GXTexObjP5Vec2dP5Vec2dP8_GXColor14_GXBlendFactor14_GXBlendFactor(
 	    &DAT_8032ec70, FLOAT_803320c8, FLOAT_803320c8, FLOAT_803320cc, FLOAT_803320d0, (_GXTexObj*)(textureBase + 0x28),
-	    0, 0, (_GXColor*)((char*)pppFilterObj + serializedOffset + 0x88), GX_BL_SRCALPHA, GX_BL_INVSRCALPHA);
+	    0, 0, colorPtr, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA);
 }


### PR DESCRIPTION
## Summary
- Refactored `pppRenderFilter` pointer flow in `src/pppFilter.cpp` to use explicit local base/color pointers.
- Kept behavior identical while guiding Metrowerks register allocation toward the original code shape.

## Functions improved
- Unit: `main/pppFilter`
- Symbol: `pppRenderFilter`

## Match evidence
- `pppRenderFilter`: **77.18367% -> 91.10204%** (`tools/objdiff-cli diff -p . -u main/pppFilter -o - pppRenderFilter`)
- Unit `.text` match for `main/pppFilter`: **79.296295% -> 91.92593%**

## Plausibility rationale
- The change is source-plausible cleanup: explicit locals for base pointer, serialized color offset, and reusable color pointer.
- No contrived control-flow tricks or hardcoded ABI hacks were introduced.
- Logic and data accesses are unchanged; this is purely a representational improvement aligned with expected original style.

## Technical details
- Improved instruction alignment around color pointer computation and reuse in both render branches.
- Reduced structural diffs in the hot function body while preserving function boundaries and call sequence.