### PR TITLE
pppYmMelt: implement CalcPolygonHeight height/collision update

### DIFF
--- a/include/ffcc/pppYmMelt.h
+++ b/include/ffcc/pppYmMelt.h
@@ -11,7 +11,14 @@ struct PYmMelt
 
 struct VERTEX_DATA
 {
-
+    u8 _pad0[0xA];
+    u16 m_gridSize;
+    u8 _padC[0x14];
+    float m_heightBias;
+    float m_collisionYOffset;
+    float m_maxDropDistance;
+    u8 _pad2C[2];
+    u8 m_hideWhenNoGround;
 };
 
 struct PYmMeltDataOffsets {


### PR DESCRIPTION
## Summary
- Implemented CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf in src/pppYmMelt.cpp (previously TODO).
- Added concrete VERTEX_DATA fields in include/ffcc/pppYmMelt.h to represent grid/collision parameters used by this routine.
- Hooked the function into existing map collision helpers (CheckHitCylinderNear, CalcHitPosition) and flushed updated vertex data via DCFlushRange.

## Functions Improved
- Unit: main/pppYmMelt
- Function: CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf

## Match Evidence
- Selector baseline (before edit):
  - main/pppYmMelt unit fuzzy: **4.1%**
  - CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf: **0.6%**
- After rebuild (
inja + uild/GCCP01/report.json):
  - main/pppYmMelt unit fuzzy: **12.73597%**
  - CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf: **44.134617%**

## Plausibility Rationale
- The implementation follows existing PPP code patterns already used in this repo for map-hit sampling and post-hit vertex correction.
- Changes are type/field and control-flow grounded (grid count, collision probe, fallback to saved Y, optional alpha hide), not artificial compiler coaxing.
- Source readability was preserved with straightforward struct fields and direct use of established engine helpers.

## Technical Details
- Per-vertex path now:
  1. Apply current manager matrix translation and melt Y offset.
  2. Probe ground with a map cylinder near the vertex.
  3. On hit: use map hit position; on miss or excessive drop: clamp to saved Y.
  4. Optionally zero vertex color when no valid ground is found.
  5. Apply melt height bias and camera-relative Y offset, then flush cache.
- Build verification: 
inja completes successfully after the change.