### PR TITLE
main/pppRandChar: improve pppRandChar match to 87.7%

### DIFF
--- a/src/pppRandChar.cpp
+++ b/src/pppRandChar.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "types.h"
 
-extern CMath math;
+extern CMath math[];
 extern s32 lbl_8032ED70;
 extern f32 lbl_8032FEF8;
 extern f64 lbl_8032FF00;
@@ -43,11 +43,11 @@ extern "C" void pppRandChar(void* param1, void* param2, void* param3)
 
     s32 state = *(s32*)(base + 0xC);
     if (state == 0) {
-        f32 value = RandF__5CMathFv(&math);
+        f32 value = RandF__5CMathFv(math);
         if (in->randomTwice != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value += RandF__5CMathFv(math);
         } else {
-            value = value * lbl_8032FEF8;
+            value *= lbl_8032FEF8;
         }
 
         valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
@@ -77,12 +77,9 @@ extern "C" void pppRandChar(void* param1, void* param2, void* param3)
     u8 current = *target;
     cvt.parts.hi = 0x43300000;
     cvt.parts.lo = in->scale;
-    f64 scaleAsDouble = cvt.d - lbl_8032FF00;
-
-    cvt.parts.hi = 0x43300000;
+    f64 scaled = cvt.d - lbl_8032FF00;
     cvt.parts.lo = current;
-    f64 currentAsDouble = cvt.d - lbl_8032FF00;
 
-    s32 delta = (s32)(scaleAsDouble * *valuePtr - currentAsDouble);
+    s32 delta = (s32)(scaled * *valuePtr - (cvt.d - lbl_8032FF00));
     *target = (u8)(current + delta);
 }


### PR DESCRIPTION
## Summary
- Updated pppRandChar to use the same random source access style as neighboring pppRand* units (extern CMath math[] and RandF__5CMathFv(math)).
- Simplified arithmetic expression flow in the char update path to better match original conversion ordering while keeping source-plausible logic.
- Kept behavior unchanged: same guard, same state gating, same target selection, and same final byte delta update.

## Functions improved
- Unit: main/pppRandChar
- Symbol: pppRandChar

## Match evidence
- pppRandChar: **84.0% -> 87.7%** (	ools/objdiff-cli v3.6.1, one-shot JSON diff)
- Improvement is instruction-level (addressing and FP conversion flow alignment), not formatting-only changes.

## Plausibility rationale
- Changes are consistent with existing codebase patterns used in sibling files (pppRandDownChar, other pppRand* files).
- No contrived temporaries or unnatural control-flow tricks were introduced; logic remains readable and idiomatic for the module family.

## Technical details
- Switched math global declaration/usage to array-style access to match expected small-data addressing pattern.
- Reordered local floating-point conversion expression to reduce divergence in the byte-scale delta section.
- Verified successful rebuild with 
inja before and after objdiff analysis.