### PR TITLE
alloc: improve link_new_block match in MSL pool allocator

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -325,25 +325,27 @@ static Block* link_new_block(__mem_pool_obj* pool_obj, unsigned long size) {
     Block* block;
     unsigned long aligned_size;
 
-    aligned_size = (size + 0x1F) & 0xFFFFFFF8;
+    aligned_size = (size + 0x1FUL) & 0xFFFFFFF8;
     if (aligned_size < 0x10000) {
         aligned_size = 0x10000;
     }
 
     block = (Block*)__sys_alloc(aligned_size);
-    if (block != 0) {
-        Block_construct(block, aligned_size);
-        if (pool_obj->start_ == 0) {
-            pool_obj->start_ = block;
-            block->prev = block;
-            block->next = block;
-        } else {
-            block->prev = pool_obj->start_->prev;
-            block->prev->next = block;
-            block->next = pool_obj->start_;
-            block->next->prev = block;
-            pool_obj->start_ = block;
-        }
+    if (block == 0) {
+        return 0;
+    }
+
+    Block_construct(block, aligned_size);
+    if (pool_obj->start_ == 0) {
+        pool_obj->start_ = block;
+        block->prev = block;
+        block->next = block;
+    } else {
+        block->prev = pool_obj->start_->prev;
+        block->prev->next = block;
+        block->next = pool_obj->start_;
+        block->next->prev = block;
+        pool_obj->start_ = block;
     }
     return block;
 }


### PR DESCRIPTION
## Summary
- Updated `link_new_block` in `src/MSL_C/PPCEABI/bare/H/alloc.c` to better match original allocator control flow.
- Replaced nested allocation-success branch with an explicit early return on null allocation.
- Preserved circular-list insertion semantics and field updates.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/alloc`
- Function: `link_new_block` (PAL `0x801B27F4`, `180b`)

## Match evidence
- `link_new_block`: **75.86667% -> 81.62222%** (`+5.75555`)
- Unit `main/MSL_C/PPCEABI/bare/H/alloc` fuzzy match: **77.51158% -> 77.78421%** (`+0.27263`)
- Validation: rebuilt with `ninja`; updated metrics from `build/GCCP01/report.json`.

## Plausibility rationale
- The resulting source is a natural allocator implementation style:
  - straightforward null-check/early-exit,
  - direct block construction,
  - explicit doubly-linked circular insertion order.
- No contrived temporaries, hardcoded offsets, or readability regressions added to coerce codegen.

## Technical details
- Alignment expression uses unsigned literal form (`0x1FUL`) while preserving the same arithmetic/mask behavior.
- Pointer-link update sequence is kept explicit and consistent with the expected list wiring order.