### PR TITLE
Improve pppRandDownCV match by aligning control flow and char math

### DIFF
--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -1,7 +1,12 @@
 #include "ffcc/pppRandDownCV.h"
 #include "ffcc/math.h"
+#include "dolphin/types.h"
 
 extern CMath math;
+extern int lbl_8032ED70;
+extern char lbl_801EAC40[];
+extern float lbl_8032FF28;
+extern "C" float RandF__5CMathFv(CMath*);
 
 extern "C" {
 
@@ -26,87 +31,55 @@ void randchar(char value, float multiplier)
  */
 void pppRandDownCV(void* param1, void* param2, void* param3)
 {
-    // External references from assembly
-    extern int lbl_8032ED70;
-    extern char lbl_801EAC40[4]; // Character data from assembly
-    extern float lbl_8032FF44;    // Constant from assembly
-    extern float lbl_8032FF4C;    // Double constant from assembly
-    
-    // Parameter register assignments from assembly
-    void* r30 = param1;  // r30 in original
-    void* r31 = param2;  // r31 in original  
-    void* r29 = param3;  // r29 in original
-    
-    // Check global flag - matches assembly cmpwi r0, 0x0 + bne
-    if (lbl_8032ED70 == 0) {
+    if (lbl_8032ED70 != 0) {
         return;
     }
-    
-    // Assembly: lwz r3, 0x0(r31) vs lwz r0, 0xc(r30) + cmpw
-    int* r31_int = (int*)r31;
-    int* r30_int = (int*)r30; 
-    if (r31_int[0] == r30_int[3]) {
-        // First branch - random generation path
-        math.RandF(); // bl RandF__5CMathFv
-        float randVal = -1.0f; // fneg f31, f1 (placeholder for RandF result)
-        
-        // Assembly: lbz r0, 0x10(r31) + cmplwi r0, 0x0 + beq
-        unsigned char* r31_bytes = (unsigned char*)r31;
-        if (r31_bytes[0x10] != 0) {
-            math.RandF(); // Second RandF call
-            float randVal2 = 1.0f; // Placeholder for second RandF
-            randVal = (-randVal - randVal2) * lbl_8032FF44; // fsubs + fmuls with constant
+
+    if (*(int*)param2 == *((int*)param1 + 3)) {
+        float rand_value = -RandF__5CMathFv(&math);
+        if (*((u8*)param2 + 0xc) != 0) {
+            rand_value = (rand_value - RandF__5CMathFv(&math)) * lbl_8032FF28;
         }
-        
-        // Assembly: lwz r3, 0xc(r29) + lwz r3, 0x0(r3) + addi r5, r3, 0x80
-        int** r29_ptr = (int**)((char*)r29 + 0xc);
-        int* base = *r29_ptr;
-        int offset = *base + 0x80;
-        float* target = (float*)((char*)r30 + offset);
-        
-        // Assembly: stfs f31, 0x0(r5)
-        *target = randVal;
-        
-    } else if (r31_int[0] != r30_int[3]) {
-        // Second branch - direct character value manipulation 
-        int** r29_ptr = (int**)((char*)r29 + 0xc);
-        int* base = *r29_ptr;
-        int offset = *base + 0x80;
-        
-        // Assembly: lwz r3, 0x4(r31) + cmpwi r3, -0x1
-        char* sourceData;
-        if (r31_int[1] == -1) {
-            sourceData = lbl_801EAC40; // Global constant vector
-        } else {
-            sourceData = (char*)((char*)r30 + r31_int[1] + 0x80);
-        }
-        
-        // Get scale factor for character transformations
-        float* scalePtr = (float*)((char*)r30 + offset);
-        float scale = *scalePtr;
-        
-        // Process each character component (assembly shows 4 identical patterns)
-        char* r31_bytes = (char*)r31;
-        
-        // Char 0: lbz r3, 0x8(r31) + math operations + stb r0, 0x0(r4)
-        char srcX = *(char*)(r31_bytes + 0x8);
-        char result = sourceData[0] + (char)(srcX * scale);
-        sourceData[0] = result;
-        
-        // Char 1: lbz r0, 0x9(r31) + math operations + stb r0, 0x1(r4)  
-        char srcY = *(char*)(r31_bytes + 0x9);
-        result = sourceData[1] + (char)(srcY * scale);
-        sourceData[1] = result;
-        
-        // Char 2: lbz r0, 0xa(r31) + math operations + stb r0, 0x2(r4)
-        char srcZ = *(char*)(r31_bytes + 0xa);
-        result = sourceData[2] + (char)(srcZ * scale);
-        sourceData[2] = result;
-        
-        // Char 3: lbz r0, 0xb(r31) + math operations + stb r0, 0x3(r4)
-        char srcW = *(char*)(r31_bytes + 0xb);
-        result = sourceData[3] + (char)(srcW * scale);
-        sourceData[3] = result;
+
+        int data_offset = **(int**)((char*)param3 + 0xc);
+        *(float*)((char*)param1 + data_offset + 0x80) = rand_value;
+    }
+
+    if (*(int*)param2 != *((int*)param1 + 3)) {
+        return;
+    }
+
+    int data_offset = **(int**)((char*)param3 + 0xc);
+    float* random_value = (float*)((char*)param1 + data_offset + 0x80);
+    int color_offset = *((int*)param2 + 1);
+    char* target;
+
+    if (color_offset == -1) {
+        target = lbl_801EAC40;
+    } else {
+        target = (char*)((char*)param1 + color_offset + 0x80);
+    }
+
+    float scale = random_value[0];
+
+    {
+        char base = *(char*)((char*)param2 + 0x8);
+        target[0] = (char)(target[0] + (int)((float)base * scale));
+    }
+
+    {
+        char base = *(char*)((char*)param2 + 0x9);
+        target[1] = (char)(target[1] + (int)((float)base * scale));
+    }
+
+    {
+        char base = *(char*)((char*)param2 + 0xa);
+        target[2] = (char)(target[2] + (int)((float)base * scale));
+    }
+
+    {
+        char base = *(char*)((char*)param2 + 0xb);
+        target[3] = (char)(target[3] + (int)((float)base * scale));
     }
 }
 


### PR DESCRIPTION
## Summary
- Rewrote pppRandDownCV with assembly-aligned control flow and type usage.
- Removed placeholder/decompiler-scaffolding logic and switched to direct RandF__5CMathFv calls.
- Corrected globals/constants used by this unit (lbl_801EAC40, lbl_8032FF28) and gated execution with the expected lbl_8032ED70 check.

## Functions improved
- Unit: main/pppRandDownCV
- Function: pppRandDownCV

## Match evidence
- Objdiff (before): 73.40678% (	ools/objdiff-cli diff -p . -u main/pppRandDownCV ...)
- Objdiff (after): 89.72881%
- Report fuzzy (after): 90.194916% for main/pppRandDownCV

## Plausibility rationale
- The final source follows the same shape as neighboring pppRandDown* implementations (guard, random scalar generation, indexed destination update).
- Changes are type/signedness/control-flow corrections, not compiler-coax temporaries.
- The resulting code is cleaner and consistent with likely original author intent for this function family.

## Technical details
- Split execution into: random value generation when index matches, then a second explicit index check before applying color deltas.
- Used signed char base inputs at offsets 