### PR TITLE
charaobj: add missing CGPrgObj empty stubs for symbol match

### DIFF
--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -12,6 +12,9 @@ public:
     void onCreate();
     void onDestroy();
     void onFrame();
+    void bonus(int, int, CGPrgObj*);
+    void onFrameAlways();
+    void onFrameAlwaysAfter();
     void onCancelStat(int);
     void onChangeStat(int);
     void onFramePreCalc();

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -2,6 +2,45 @@
 
 /*
  * --INFO--
+ * PAL Address: 0x8010b67c
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::bonus(int, int, CGPrgObj*)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8010b680
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onFrameAlways()
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8010b684
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onFrameAlwaysAfter()
+{
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
Added three missing `CGPrgObj` method declarations in `include/ffcc/prgobj.h` and implemented their empty definitions in `src/charaobj.cpp`:
- `bonus(int, int, CGPrgObj*)`
- `onFrameAlways()`
- `onFrameAlwaysAfter()`

These are 4-byte no-op stubs in PAL and were previously unresolved/unmatched in `main/charaobj`.

## Functions improved
Unit: `main/charaobj`
- `bonus__8CGPrgObjFiiP8CGPrgObj`: `None/unmatched` -> `100.0%` (4b)
- `onFrameAlways__8CGPrgObjFv`: `None/unmatched` -> `100.0%` (4b)
- `onFrameAlwaysAfter__8CGPrgObjFv`: `None/unmatched` -> `100.0%` (4b)

## Match evidence
From `ninja` progress output after change:
- Matched code bytes: `187644` -> `187656` (+12)
- Matched functions: `1305` -> `1308` (+3)

From `build/GCCP01/report.json` (`main/charaobj`):
- all three target symbols now report `100.0%` fuzzy match.

## Plausibility rationale
The PAL Ghidra references for these symbols are 4-byte `return` stubs. Adding explicit empty methods for `CGPrgObj` is source-plausible engine hook structure and avoids compiler-coaxing patterns.

## Technical details
- Root cause was missing method declarations for these class hooks in `prgobj.h`, preventing clean symbol mapping for the `charaobj` unit.
- Added PAL metadata comments for each new function with address and size:
  - `0x8010b67c` (4b)
  - `0x8010b680` (4b)
  - `0x8010b684` (4b)
