### PR TITLE
main/THPSimple: improve THPSimpleClose match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -207,16 +207,18 @@ s32 THPSimpleOpen(const char* path)
  */
 s32 THPSimpleClose(void)
 {
-    if ((SimpleControl.isOpen != 0) && (SimpleControl.isPreLoaded == 0)) {
-        if (SimpleControl.hasAudio == 0) {
-            SimpleControl.isBufferSet = 0;
-        } else if (SimpleControl.isBufferSet == 1) {
+    THPSimpleControl* control = &SimpleControl;
+
+    if ((control->isOpen != 0) && (control->isPreLoaded == 0)) {
+        if (control->hasAudio == 0) {
+            control->isBufferSet = 0;
+        } else if (control->isBufferSet == 1) {
             return 0;
         }
 
-        if (SimpleControl.isReadFrameAsync == 0) {
-            SimpleControl.isOpen = 0;
-            DVDClose(&SimpleControl.fileInfo);
+        if (control->isReadFrameAsync == 0) {
+            control->isOpen = 0;
+            DVDClose(&control->fileInfo);
             return 1;
         }
     }


### PR DESCRIPTION
## Summary
- Refactored THPSimpleClose to use a local THPSimpleControl* control = &SimpleControl and route field access through that local pointer.
- Kept behavior unchanged: same open/preload checks, audio/buffer handling, async-read gate, and close path.

## Functions Improved
- Unit: main/THPSimple
- Symbol: THPSimpleClose
- Before: 