### PR TITLE
main/charaobj: match CGPrgObj onDamaged/onAttacked stubs

### DIFF
--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -15,6 +15,8 @@ public:
     void bonus(int, int, CGPrgObj*);
     void onFrameAlways();
     void onFrameAlwaysAfter();
+    void onDamaged(CGPrgObj*);
+    void onAttacked(CGPrgObj*);
     void onCancelStat(int);
     void onChangeStat(int);
     void onFramePreCalc();

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -41,6 +41,32 @@ void CGPrgObj::onFrameAlwaysAfter()
 
 /*
  * --INFO--
+ * PAL Address: 0x8010B688
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onDamaged(CGPrgObj*)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8010B68C
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGPrgObj::onAttacked(CGPrgObj*)
+{
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added missing `CGPrgObj` declarations for `onDamaged(CGPrgObj*)` and `onAttacked(CGPrgObj*)` in `include/ffcc/prgobj.h`.
- Added corresponding empty method definitions in `src/charaobj.cpp` with PAL metadata:
  - `onDamaged__8CGPrgObjFP8CGPrgObj` (0x8010B688, 4b)
  - `onAttacked__8CGPrgObjFP8CGPrgObj` (0x8010B68C, 4b)

## Functions Improved
- Unit: `main/charaobj`
- Symbols:
  - `onDamaged__8CGPrgObjFP8CGPrgObj`: unmatched -> 100.0%
  - `onAttacked__8CGPrgObjFP8CGPrgObj`: unmatched -> 100.0%

## Match Evidence
Objdiff report delta (before -> after):
- Global matched code: `187656 -> 187664` (+8 bytes)
- Global matched functions: `1308 -> 1310` (+2)
- Global fuzzy match: `22.583477 -> 22.583908`

Unit `main/charaobj` delta:
- Fuzzy match: `0.5909628 -> 0.6172337`
- Matched code: `40 -> 48` bytes
- Matched functions: `10 -> 12`

## Plausibility Rationale
These are tiny 4-byte no-op virtual hooks listed in the PAL MAP for `charaobj.o`. Adding explicit declarations/definitions is consistent with common base-class event hooks used throughout this codebase and avoids compiler-coaxing patterns.

## Technical Notes
- Used PAL symbol + Ghidra references for exact symbol names and sizes.
- Kept implementation as canonical empty stubs to match expected codegen for 4-byte return-only functions.