### PR TITLE
os/OSRtc: improve OSSetProgressiveMode match

### DIFF
--- a/src/os/OSRtc.c
+++ b/src/os/OSRtc.c
@@ -321,9 +321,6 @@ u32 OSGetProgressiveMode(void) {
 }
 
 void OSSetProgressiveMode(u32 on) {
-#ifndef DEBUG
-    u32 padding[1];
-#endif
     OSSram* sram;
 
     ASSERTLINE(670, on == OS_PROGRESSIVE_MODE_OFF || on == OS_PROGRESSIVE_MODE_ON);


### PR DESCRIPTION
## Summary
- Removed the release-only local padding array from OSSetProgressiveMode in src/os/OSRtc.c.
- Kept behavior and control flow unchanged.

## Functions improved
- Unit: main/os/OSRtc
- Symbol: OSSetProgressiveMode

## Match evidence
- OSSetProgressiveMode: **43.703705% -> 43.777780%** (objdiff)
- No function-level regressions in main/os/OSRtc from this edit.

## Plausibility rationale
- The removed local had no semantic purpose and only affected stack shape.
- Eliminating an unused local is consistent with plausible original source cleanup, rather than contrived instruction forcing.

## Technical details
- Validation used one-shot objdiff CLI (	ools/objdiff-cli v3.6.1).
- Full rebuild passed with 
inja before and after the change.