### PR TITLE
GXLight: improve GXSetNumChans register write matching

### DIFF
--- a/src/gx/GXLight.c
+++ b/src/gx/GXLight.c
@@ -525,8 +525,10 @@ void GXSetNumChans(u8 nChans) {
     CHECK_GXBEGIN(857, "GXSetNumChans");
     ASSERTMSGLINE(858, nChans <= 2, "GXSetNumChans: nChans > 2");
 
-    SET_REG_FIELD(860, __GXData->genMode, 3, 4, nChans);
-    GX_WRITE_XF_REG(9, nChans);
+    __GXData->genMode = (__GXData->genMode & ~0x70) | ((u32)(nChans & 0xFF) << 4);
+    GX_WRITE_U8(0x10);
+    GX_WRITE_U32(0x1009);
+    GX_WRITE_U32(nChans & 0xFF);
     __GXData->dirtyState |= 4;
 }
 


### PR DESCRIPTION
## Summary
- Updated GXSetNumChans in src/gx/GXLight.c to use direct bitfield masking on __GXData->genMode and explicit XF FIFO writes.
- Kept behavior identical while aligning emitted code more closely with the expected SDK instruction pattern.

## Functions improved
- Unit: main/gx/GXLight
- Function: GXSetNumChans

## Match evidence
- GXSetNumChans fuzzy match: **76.94118% -> 96.64706%**
- main/gx/GXLight unit fuzzy match: **87.303825% -> 88.10526%**
- Unit matched code bytes/functions counts are unchanged, but assembly similarity improved significantly for the targeted function.

## Plausibility rationale
- The new implementation is source-plausible SDK-style code: explicit register masking and FIFO writes are idiomatic for GX low-level setup routines.
- No contrived temporaries or unnatural control-flow were introduced.

## Technical details
- Replaced SET_REG_FIELD(... genMode ...) with (__GXData->genMode & ~0x70) | ((nChans & 0xFF) << 4).
- Replaced GX_WRITE_XF_REG(9, nChans) with explicit writes of command, register ID (