### PR TITLE
Improve pppRandUpFV match with typed rand/update flow

### DIFF
--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -1,10 +1,27 @@
 #include "ffcc/pppRandUpFV.h"
 #include "ffcc/math.h"
+#include "types.h"
 
 extern CMath math;
-extern int lbl_8032ED70;
-extern float lbl_80330000;
-extern float lbl_801EADC8;
+extern s32 lbl_8032ED70;
+extern f32 lbl_80330000;
+extern f32 lbl_801EADC8[];
+extern "C" f32 RandF__5CMathFv(CMath*);
+
+struct PppRandUpFVParam2 {
+    s32 field0;
+    s32 field4;
+    f32 field8;
+    f32 fieldC;
+    f32 field10;
+    u8 unk14[0x18 - 0x14];
+    u8 field18;
+};
+
+struct PppRandUpFVParam3 {
+    u8 unk0[0xC];
+    s32* fieldC;
+};
 
 /*
  * --INFO--
@@ -15,79 +32,41 @@ extern float lbl_801EADC8;
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandUpFV(void* param1, void* param2, void* param3)
-{
-    // Check global flag first
+extern "C" void pppRandUpFV(void* param1, void* param2, void* param3) {
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    int* p1 = (int*)param1;
-    int* p2 = (int*)param2;
-    
-    // Check field at offset 0xC of param1 
-    if (p1[3] == 0) {
-        // Generate random float
-        math.RandF();
-        float randVal = 1.0f; // Placeholder for RandF() result
-        
-        // Check byte at offset 0x18 of param2
-        unsigned char* p2_bytes = (unsigned char*)param2;
-        if (p2_bytes[0x18] != 0) {
-            // Generate second random using separate operations
-            math.RandF();
-            float randVal2 = 0.5f; // Placeholder for second random
-            randVal = randVal + randVal2;
-            randVal = randVal * lbl_80330000;
+    u8* base = (u8*)param1;
+    PppRandUpFVParam2* in = (PppRandUpFVParam2*)param2;
+    PppRandUpFVParam3* out = (PppRandUpFVParam3*)param3;
+    f32* valuePtr;
+
+    s32 baseState = *(s32*)(base + 0xC);
+    if (baseState == 0) {
+        f32 value = RandF__5CMathFv(&math);
+        if (in->field18 != 0) {
+            value = (value + RandF__5CMathFv(&math)) * lbl_80330000;
         }
-        
-        // Store result based on param3
-        void** basePtr = (void**)((char*)param3 + 0xC);
-        int* indexPtr = (int*)*basePtr;
-        int offset = *indexPtr + 0x80;
-        float* target = (float*)((char*)param1 + offset);
-        *target = randVal;
-        
+
+        valuePtr = (f32*)(base + *out->fieldC + 0x80);
+        *valuePtr = value;
     } else {
-        // Check if param2[0] matches param1[3]
-        if (p2[0] != p1[3]) {
+        if (in->field0 != baseState) {
             return;
         }
-        
-        // Get destination address
-        void** basePtr = (void**)((char*)param3 + 0xC);
-        int* indexPtr = (int*)*basePtr;
-        int destOffset = *indexPtr + 0x80;
-        float* destAddr = (float*)((char*)param1 + destOffset);
-        float destVal = *destAddr;
-        
-        // Determine source address
-        float* srcAddr;
-        if (p2[1] == -1) {
-            srcAddr = &lbl_801EADC8;
-        } else {
-            srcAddr = (float*)((char*)param1 + p2[1] + 0x80);
-        }
-        
-        // Update first component using separate operations
-        float multiplier1 = *(float*)((char*)param2 + 8);
-        float srcVal1 = *srcAddr;
-        float temp1 = multiplier1 * destVal;
-        float result1 = srcVal1 + temp1;
-        *srcAddr = result1;
-        
-        // Update second component using separate operations 
-        float multiplier2 = *(float*)((char*)param2 + 12);
-        float srcVal2 = *(float*)((char*)srcAddr + 4);
-        float temp2 = multiplier2 * destVal;
-        float result2 = srcVal2 + temp2;
-        *(float*)((char*)srcAddr + 4) = result2;
-        
-        // Update third component using separate operations
-        float multiplier3 = *(float*)((char*)param2 + 16);
-        float srcVal3 = *(float*)((char*)srcAddr + 8);
-        float temp3 = multiplier3 * destVal;
-        float result3 = srcVal3 + temp3;
-        *(float*)((char*)srcAddr + 8) = result3;
+        valuePtr = (f32*)(base + *out->fieldC + 0x80);
     }
+
+    f32* target;
+    if (in->field4 == -1) {
+        target = lbl_801EADC8;
+    } else {
+        target = (f32*)(base + in->field4 + 0x80);
+    }
+
+    f32 scale = *valuePtr;
+    target[0] = target[0] + in->field8 * scale;
+    target[1] = target[1] + in->fieldC * scale;
+    target[2] = target[2] + in->field10 * scale;
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandUpFV` from placeholder-style logic into a typed, data-structured implementation matching surrounding `pppRand*` patterns.
- Replaced placeholder random calls/values with real `RandF__5CMathFv(&math)` flow.
- Consolidated output value handling (`base + *ctx->fieldC + 0x80`) and target vector update path (`field4 == -1` fallback to `lbl_801EADC8`).

## Functions improved
- Unit: `main/pppRandUpFV`
- Function: `pppRandUpFV`

## Match evidence
- Before: `79.42105%`
- After: `86.75%`
- Delta: `+7.32895%`
- Source of metrics: `build/GCCP01/report.json` after clean `ninja` rebuilds.

## Plausibility rationale
- The updated code follows existing FFCC `pppRand*` conventions (typed input/output blobs, state gate on `*(base + 0xC)`, optional dual-random path, vector target update using serialized offsets).
- Removed clearly non-original placeholder behavior (`math.RandF()` calls with hardcoded `1.0f/0.5f`) and replaced with real engine random function use.
- The resulting control flow and data access are consistent with nearby decompiled modules and represent plausible original source rather than compiler coaxing.

## Technical details
- Introduced explicit param structs (`PppRandUpFVParam2`, `PppRandUpFVParam3`) and `types.h` scalar types to stabilize field access.
- Used a single computed scale value from the output slot and applied additive vector updates for XYZ components.
- Preserved existing PAL info header and function linkage (`extern C`).