### PR TITLE
RedStream: fix _ArrangeStreamDataLoop ABI signature

### DIFF
--- a/include/ffcc/RedSound/RedStream.h
+++ b/include/ffcc/RedSound/RedStream.h
@@ -6,7 +6,7 @@ struct RedStreamDATA;
 void _SearchEmptyStreamData();
 void _StreamStop(RedStreamDATA*);
 int _ArrangeStreamDataNoLoop(RedStreamDATA*, int, int);
-int _ArrangeStreamDataLoop(RedStreamDATA*, unsigned int, int);
+int _ArrangeStreamDataLoop(RedStreamDATA*, int, int);
 
 void StreamStop(int);
 void StreamPlay(int, void*, int, int, int);

--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -88,7 +88,7 @@ int _ArrangeStreamDataNoLoop(RedStreamDATA* param_1, int param_2, int param_3)
  * Address:	801cbc6c
  * Size:	856b
  */
-int _ArrangeStreamDataLoop(RedStreamDATA* param_1, unsigned int param_2, int param_3)
+int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
 {
 	unsigned int* puVar1;
 	unsigned int* puVar3;


### PR DESCRIPTION
## Summary
- Updated `_ArrangeStreamDataLoop` argument 2 from `unsigned int` to `int` in both declaration and definition.
- This aligns the function ABI/mangling with the PAL symbol `_ArrangeStreamDataLoop__FP13RedStreamDATAii`.

## Functions improved
- Unit: `main/RedSound/RedStream`
- Function: `_ArrangeStreamDataLoop__FP13RedStreamDATAii`

## Match evidence
- `_ArrangeStreamDataLoop__FP13RedStreamDATAii`
  - Before: effectively unmapped in objdiff (`target_symbol: null`), no function fuzzy score emitted.
  - After: mapped (`target_symbol: 4`) with `match_percent: 78.22897` (objdiff JSON), report fuzzy `78.252335`.
- Unit `main/RedSound/RedStream`
  - Before: `21.074585%`
  - After: `36.494476%`

## Plausibility rationale
- The mangled symbol indicates the second parameter is `int` (`...ii`).
- Using `int` for the side/toggle argument is natural for this codebase and removes an ABI mismatch rather than introducing compiler-coaxing constructs.
- No control-flow or logic changes were introduced; only signature alignment for correct symbol correspondence.

## Technical notes
- Verified via `tools/objdiff-cli v3.6.1` one-shot JSON diff for `_ArrangeStreamDataLoop__FP13RedStreamDATAii`.
- Rebuilt with `ninja`; report regenerated successfully.
