### PR TITLE
dvd: align stateBusy symbol with target symbol mapping

### DIFF
--- a/src/dvd/dvd.c
+++ b/src/dvd/dvd.c
@@ -77,7 +77,7 @@ static void cbForStateCoverClosed(u32 intType);
 static void stateMotorStopped();
 static void cbForStateMotorStopped(u32 intType);
 static void stateReady();
-static void stateBusy(DVDCommandBlock* block);
+static void stateBusy_80189D04(DVDCommandBlock* block);
 static BOOL IsImmCommandWithResult(u32 command);
 static int IsDmaCommand(u32 command);
 static void cbForStateBusy(u32 intType);
@@ -510,7 +510,7 @@ static void cbForStateCheckID3(u32 intType) {
         NumInternalRetry = 0;
         if (CheckCancel(0) == FALSE) {
             executing->state = DVD_STATE_BUSY;
-            stateBusy(executing);
+            stateBusy_80189D04(executing);
         }
         return;
     }
@@ -645,15 +645,15 @@ static void stateReady() {
 
     if (MotorState == 0) {
         executing->state = DVD_STATE_BUSY;
-        stateBusy(executing);
+        stateBusy_80189D04(executing);
     } else {
         stateCoverClosed();
     }
 }
 
-static void stateBusy(DVDCommandBlock* block) {
+static void stateBusy_80189D04(DVDCommandBlock* block) {
     DVDCommandBlock* finished;
-    LastState = stateBusy;
+    LastState = stateBusy_80189D04;
 
     switch(block->command) {
     case DVD_COMMAND_READID:
@@ -866,7 +866,7 @@ static void cbForStateBusy(u32 intType) {
 
         if (IsDmaCommand(CurrCommand)) {
             if (executing->transferredSize != executing->length) {
-                stateBusy(executing);
+                stateBusy_80189D04(executing);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Renamed local static DVD busy-state handler symbol from stateBusy to stateBusy_80189D04.
- Updated all internal callsites and LastState assignment to use the renamed symbol.
- No behavioral logic changes; this is symbol alignment to allow objdiff/report pairing with the target function symbol.

## Functions improved
- Unit: main/dvd/dvd
- Function: stateBusy_80189D04 (800 bytes)

## Match evidence
- Unit fuzzy match: **86.332664% -> 94.02766%**
- Function fuzzy match: **unmatched (no fuzzy score)** -> **95.995%**
- Verified via 
inja regenerated uild/GCCP01/report.json after the rename.

## Plausibility rationale
- This change aligns symbol identity for an existing static function already used throughout the DVD state machine.
- Control flow and data behavior are unchanged; only the local function symbol name and references were updated so the decomp function maps to the shipped symbol.

## Technical details
- Updated declaration, definition, and three callsites in src/dvd/dvd.c.
- Updated LastState = stateBusy_80189D04 to preserve function-pointer behavior with the same implementation.