### PR TITLE
stopwatch: improve CStopWatch::Get codegen match

### DIFF
--- a/src/stopwatch.cpp
+++ b/src/stopwatch.cpp
@@ -52,7 +52,7 @@ void CStopWatch::Stop() { OSStopStopwatch(this); }
  */
 float CStopWatch::Get()
 {
-	u32* p = (u32*)&this->total;
+	volatile u32* p = (volatile u32*)&this->total;
 	u32 lo = p[0];
 	u32 hi = p[1];
 	float ticks = __cvt_sll_flt(lo, hi);


### PR DESCRIPTION
## Summary
- Adjust CStopWatch::Get() tick-word access to use a volatile 32-bit view of OSStopwatch::total.
- This keeps source behavior unchanged while nudging load/arg codegen closer to the target object.

## Functions improved
- Unit: main/stopwatch
- Function: Get__10CStopWatchFv
  - Before: 94.26667%
  - After: 94.433334%

## Match evidence
- Unit main/stopwatch fuzzy match:
  - Before: 89.84118%
  - After: 89.87059%
- Project fuzzy match:
  - Before: 22.628197%
  - After: 22.671066%
- Validation commands:
  - 
inja
  - 	ools/objdiff-cli report generate -p . -o <report>.json -f json-pretty
  - 	ools/objdiff-cli diff -p . -u main/stopwatch Get__10CStopWatchFv -o <diff>.json --format json-pretty

## Plausibility rationale
- Reading split 32-bit words from a 64-bit timer field via typed pointer access is plausible original code in this codebase.
- The change avoids contrived control flow or artificial temporaries and keeps the function straightforward.

## Technical details
- The previous form still produced argument/load ordering differences around __cvt_sll_flt.
- Marking the word pointer volatile reduced ordering-related mismatch and improved symbol-level fuzzy score.