### PR TITLE
chara: give __sinit_chara_cpp C linkage for objdiff alignment

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -620,7 +620,7 @@ extern "C" void* PTR_PTR_s_CChara_801fcd24;
  * PAL Address: 80073ad4
  * PAL Size: 32b
  */
-void __sinit_chara_cpp(void)
+extern "C" void __sinit_chara_cpp(void)
 {
 	Chara.field0_0x0.object.base_object.object.m_id = (u32)&PTR_PTR_s_CChara_801fcd24;
 }


### PR DESCRIPTION
## Summary
- Change `__sinit_chara_cpp` in `src/chara.cpp` to explicit C linkage (`extern C`).
- Keep function behavior unchanged (same vtable pointer assignment to `Chara`).

## Functions improved
- Unit: `main/chara`
- Symbol: `__sinit_chara_cpp`
- Match: `0.0%` -> `41.125%`

## Match evidence
- Objdiff command used:
  - `tools/objdiff-cli diff -p . -u main/chara -o - --format json-pretty __sinit_chara_cpp`
- Before change: emitted symbol name was C++ mangled (`__sinit_chara_cpp__Fv`) while target symbol is unmangled (`__sinit_chara_cpp`).
- After change: symbol emission aligns to target name and match improved to `41.125%`.

## Plausibility rationale
- This is an ABI/linkage correction, not control-flow coercion.
- It matches existing `__sinit_*` C-linkage patterns in the codebase and keeps readable/plausible source.

## Technical details
- One-line signature update:
  - `void __sinit_chara_cpp(void)` -> `extern C void __sinit_chara_cpp(void)`
- `ninja` build completed successfully after the change.