### PR TITLE
pppMana2: implement pppRenderMana2 render-state setup

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1,4 +1,8 @@
 #include "ffcc/pppMana2.h"
+#include "ffcc/graphic.h"
+#include "ffcc/pppPart.h"
+
+extern char lbl_801DC4D0[];
 
 /*
  * --INFO--
@@ -42,12 +46,21 @@ void pppFrameMana2(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80107e48
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppRenderMana2(void)
 {
-	// TODO
+    Graphic.Printf(lbl_801DC4D0);
+    GXSetNumTevStages(1);
+    GXSetNumTexGens(1);
+    GXSetNumChans(1);
+    Graphic.SetViewport();
+    pppInitBlendMode();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppRenderMana2` in `src/pppMana2.cpp` using the target call sequence.
- Added required includes (`ffcc/graphic.h`, `ffcc/pppPart.h`) and referenced existing rodata label `lbl_801DC4D0` for the debug print string.
- Updated the function info block with PAL address/size metadata.

## Functions improved
- Unit: `main/pppMana2`
- Function: `pppRenderMana2`

## Match evidence
- `pppRenderMana2` fuzzy match: **4.347826% -> 85.434784%**
- `main/pppMana2` unit fuzzy match: **0.32320622% -> 0.92598575%**
- Validation steps:
  - `ninja`
  - Compared report measures for the unit/function

## Plausibility rationale
- The implementation is source-plausible: it sets GX stage counts, restores viewport, and initializes blend mode.
- Call ordering and symbol usage follow target object disassembly for `pppRenderMana2` (PAL `0x80107E48`, size `0x5C`), without contrived compiler-coaxing.

## Technical details
- Implemented sequence:
  1. `Graphic.Printf(lbl_801DC4D0)`
  2. `GXSetNumTevStages(1)`
  3. `GXSetNumTexGens(1)`
  4. `GXSetNumChans(1)`
  5. `Graphic.SetViewport()`
  6. `pppInitBlendMode()`