### PR TITLE
vector: match CVector::Identity store order

### DIFF
--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -42,9 +42,9 @@ CVector::CVector(const Vec& vec)
  */
 void CVector::Identity()
 {
-	this->x = 0.0f;
-	this->y = 0.0f;
 	this->z = 0.0f;
+	this->y = 0.0f;
+	this->x = 0.0f;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated CVector::Identity() in src/vector.cpp to assign zero in z -> y -> x order.
- This is a minimal, source-plausible control over store ordering in a tiny leaf function.

## Functions improved
- Unit: main/vector
- Function: Identity__7CVectorFv (20 bytes)
  - Before: 99.6%
  - After: 100.0%

## Match evidence
- main/vector unit fuzzy match: 95.37778% -> 95.422226%
- Matched functions in main/vector: 4 -> 5
- 
inja builds cleanly after the change.

## Plausibility rationale
- The function semantically initializes vector components to zero; assigning fields in either order is plausible original source.
- The chosen order matches the original object’s store sequence without contrived compiler-coaxing artifacts.

## Technical details
- Previous output emitted store order z, y, x and did not match the base object.
- Reordering assignments in source to z, y, x produced the expected emitted order for this compiler/flags combination and closed the remaining diff for this symbol.