### PR TITLE
pppPart: fix pppRotMatrix ABI/signature to match symbol

### DIFF
--- a/include/ffcc/pppPart.h
+++ b/include/ffcc/pppPart.h
@@ -33,7 +33,7 @@ struct pppCVECTOR
 
 _pppMngSt* pppStopSe(_pppMngSt* pppMngSt, PPPSEST* pppSest);
 void pppUnitMatrix(pppFMATRIX& pppFMtx);
-void pppRotMatrix(pppFMATRIX&, pppFMATRIX, Vec&);
+void pppRotMatrix(pppFMATRIX&, pppFMATRIX, Vec);
 void pppApplyMatrix(Vec& destination, pppFMATRIX pppFMatrix, Vec source);
 void pppAddVector(Vec& ab, Vec a, Vec b);
 void pppScaleVectorXYZ(Vec& outVec, Vec inVec, float scale);

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -47,7 +47,7 @@ void pppUnitMatrix(pppFMATRIX& pppFMtx)
  * Address:	TODO
  * Size:	TODO
  */
-void pppRotMatrix(pppFMATRIX& dst, pppFMATRIX& src, const Vec& rot)
+void pppRotMatrix(pppFMATRIX& dst, pppFMATRIX src, Vec rot)
 {
 	pppFMATRIX Rx;
 	pppFMATRIX Ry;


### PR DESCRIPTION
## Summary
- Aligned \pppRotMatrix\ declaration/definition ABI to the symbol signature expected by this unit.
- Changed the third parameter from reference to by-value in \include/ffcc/pppPart.h\.
- Changed definition in \src/pppPart.cpp\ from \pppFMATRIX& src, const Vec& rot\ to \pppFMATRIX src, Vec rot\.

## Functions improved
- Unit: \main/pppPart\
- Symbol: \pppRotMatrix__FR10pppFMATRIX10pppFMATRIX3Vec\

## Match evidence
- Selector baseline before change: \pppRotMatrix\ reported \