### PR TITLE
gx: improve GXSetNumTexGens match in GXAttr

### DIFF
--- a/src/gx/GXAttr.c
+++ b/src/gx/GXAttr.c
@@ -671,7 +671,9 @@ void GXSetTexCoordGen2(GXTexCoordID dst_coord, GXTexGenType func, GXTexGenSrc sr
 
 void GXSetNumTexGens(u8 nTexGens) {
     CHECK_GXBEGIN(1172, "GXSetNumTexGens");
-    SET_REG_FIELD(1174, __GXData->genMode, 4, 0, nTexGens);
-    GX_WRITE_XF_REG(0x3F, nTexGens);
+    __GXData->genMode = (__GXData->genMode & ~0xF) | nTexGens;
+    GX_WRITE_U8(0x10);
+    GX_WRITE_U32(0x103F);
+    GX_WRITE_U32(nTexGens);
     __GXData->dirtyState |= 4;
 }


### PR DESCRIPTION
## Summary
- Reworked GXSetNumTexGens in src/gx/GXAttr.c to use direct register updates instead of macro-expanded writes.
- Replaced GX_WRITE_XF_REG call with explicit FIFO writes (GX_WRITE_U8, GX_WRITE_U32, GX_WRITE_U32) matching SDK-style sequencing.

## Functions Improved
- Unit: main/gx/GXAttr
- Function: GXSetNumTexGens (64 bytes)

## Match Evidence
- GXSetNumTexGens fuzzy match: **67.6875% -> 97.375%**
- Unit main/gx/GXAttr fuzzy match: **64.69086% -> 65.116486%**
- 
inja build/report completed successfully after the change.

## Plausibility Rationale
- The update keeps behavior identical while expressing the register writes in a straightforward low-level style commonly used in GX SDK code.
- No contrived temporaries or unnatural control flow were introduced.

## Technical Details
- Prior objdiff showed structural differences (insert/delete regions) around the genMode write and XF FIFO write sequence.
- After the change, those structural gaps are gone; remaining differences are primarily register allocation/symbol naming and the existing dirtyState field offset discrepancy in current decomp state.