### PR TITLE
main/cflat_data: add deleting destructor shim for dtor_800980B4

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -36,6 +36,29 @@ CFlatData::~CFlatData()
 
 /*
  * --INFO--
+ * PAL Address: 0x800980b4
+ * PAL Size: 292b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CFlatData* dtor_800980B4(CFlatData* flatData, short shouldDelete)
+{
+	if (flatData != nullptr)
+	{
+		flatData->Destroy();
+		if (shouldDelete > 0)
+		{
+			operator delete(flatData);
+		}
+	}
+
+	return flatData;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x80097be8
  * PAL Size: 1228b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added an explicit deleting-destructor shim `dtor_800980B4(CFlatData*, short)` in `src/cflat_data.cpp`.
- The shim follows established project patterns: null-check, call `Destroy()`, conditionally call `operator delete` when `shouldDelete > 0`.
- Kept existing class destructor (`~CFlatData`) intact for source plausibility and readability.

## Functions improved
- Unit: `main/cflat_data`
- Function: `dtor_800980B4` (PAL 0x800980b4, 292b)

## Match evidence
- Before: unresolved/0% (reported as `None` in `build/GCCP01/report.json` for `dtor_800980B4`)
- After: `21.013699%` fuzzy match for `dtor_800980B4`
- Other functions in unit remained stable (`Destroy__9CFlatDataFv` 100%, `__ct__9CFlatDataFv` 100%, `Create__9CFlatDataFPv` 56.895767%)

## Plausibility rationale
- This object file already uses paired patterns of normal destructor + explicit deleting-destructor wrappers in other units.
- The change models typical Metrowerks deleting-destructor behavior without contrived control flow or artificial temporaries.
- Cleanup logic remains centralized in `Destroy()`, preserving maintainable and plausible original-source structure.

## Technical notes
- `objdiff-cli diff` in this environment does not accept the runbook `-o` JSON flag and enters interactive mode, so progress was validated via `build/GCCP01/report.json` function metrics before/after.