### PR TITLE
util: define DAT_8032ec70 global and improve __sinit match

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,8 @@ struct Vec2d {
 	float x, y;
 };
 
+CUtil DAT_8032ec70;
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- Added a concrete definition for the global utility instance `DAT_8032ec70` in `src/util.cpp`.
- This restores source-level ownership of the util singleton used across multiple callsites (`extern CUtil DAT_8032ec70`).

## Functions improved
- Unit: `main/util`
- Symbol: `__sinit_util_cpp`
  - Before: unrated / unmatched (`None` in local report parse)
  - After: `25.0%` fuzzy match

## Match evidence
- `main/util` unit fuzzy match increased:
  - Before: `8.655914`
  - After: `8.695739`
- Overall matched data increased in progress output:
  - Before: `72` bytes
  - After: `76` bytes
- Validation steps:
  - `ninja`
  - `tools/objdiff-cli diff -p . -u main/util -o <file> __sinit_util_cpp`

## Plausibility rationale
- Multiple source files already declare and use `extern CUtil DAT_8032ec70` as the canonical utility object.
- Defining it in `util.cpp` is a plausible original-source arrangement and aligns ownership with the class implementation file.
- No contrived control-flow or compiler-coaxing patterns were introduced.

## Technical details
- Change is intentionally minimal (single global definition) to avoid unrelated binary churn while improving symbol/data alignment.
- The generated static-init path for `util` now aligns better with the target symbol map for `__sinit_util_cpp`.