### PR TITLE
Improve LocationTitle2 render decomp match

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -1,5 +1,10 @@
 #include "ffcc/LocationTitle2.h"
 #include "ffcc/pppPart.h"
+#include "ffcc/pppShape.h"
+#include "ffcc/p_game.h"
+
+#include <dolphin/gx.h>
+#include <dolphin/mtx.h>
 #include <string.h>
 
 // External function declarations
@@ -7,6 +12,42 @@ extern "C" int rand(void);
 
 // External data references
 extern int DAT_8032ed70;
+
+extern struct {
+    float _212_4_;
+    float _216_4_;
+    float _220_4_;
+    float _224_4_;
+    float _228_4_;
+    float _232_4_;
+    Mtx m_cameraMatrix;
+} CameraPcs;
+
+static int GetGraphFrameFromId(u32 graphId)
+{
+    return ((int)graphId >> 12) + (int)((graphId & 0x80000000) != 0 && (graphId & 0xFFF) != 0);
+}
+
+struct LocationTitle2Work {
+    void* m_particles;
+    u16 m_count;
+    u16 m_pad;
+    float m_cur;
+    float m_vel;
+    float m_acc;
+};
+
+struct LocationTitle2Particle {
+    Vec m_pos;
+    u32 m_color;
+    float m_scaleX;
+    float m_scaleY;
+    float m_scaleZ;
+    s16 m_frame;
+    s16 m_pad0;
+    s16 m_shape;
+    s16 m_pad1;
+};
 
 /*
  * --INFO--
@@ -92,7 +133,7 @@ void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, struct UnkB
             if (unkB->m_initWOrk == locationTitle->pad[0]) { // field0_0x0.m_graphId
                 piVar12[2] = (int)((float)piVar12[2] + (float)unkB->m_arg3);
                 piVar12[3] = (int)((float)piVar12[3] + *(float*)unkB->m_payload);
-                piVar12[4] = (int)((float)piVar12[4] + *(float*)(unkB->m_payload + 4));
+                piVar12[4] = (int)((float)piVar12[4] + *(float*)((u8*)unkB->m_payload + 4));
             }
             
             // Memory allocation logic if needed
@@ -114,19 +155,102 @@ void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, struct UnkB
  */
 void pppRenderLocationTitle2(struct pppLocationTitle2* locationTitle, struct UnkB* unkB, struct UnkC* unkC)
 {
-    u32 uVar1;
-    int iVar2;
-    int iVar3;
-    void* source;
-    u32* puVar4;
-    
-    iVar2 = *unkC->m_serializedDataOffsets;
-    if (unkB->m_dataValIndex != 0xffff) {
-        uVar1 = locationTitle->pad[0]; // field0_0x0.m_graphId
-        source = *(void**)((char*)locationTitle + 8 + iVar2);
-        // puVar4 = *(u32**)(*(int*)pppEnvStPtr->m_particleColors[0].m_colorRGBA + unkB->m_dataValIndex * 4);
-        
-        // Basic rendering logic based on decomp
-        // Complex rendering operations would go here
+    int serializedOffset = *unkC->m_serializedDataOffsets;
+
+    if (unkB->m_dataValIndex != 0xFFFF) {
+        u32 graphId = *(u32*)locationTitle;
+        int graphFrame = GetGraphFrameFromId(graphId);
+        LocationTitle2Work* work = (LocationTitle2Work*)((u8*)locationTitle + 8 + serializedOffset);
+        LocationTitle2Particle* particle = (LocationTitle2Particle*)work->m_particles;
+        long* shapeTable = *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + unkB->m_dataValIndex * 4);
+        u8 blendMode = *((u8*)&unkB->m_stepValue + 1);
+
+        pppSetBlendMode(blendMode);
+
+        if (Game.game.m_currentSceneId != 7) {
+            Vec matrixPos;
+            Vec cameraPos;
+            Vec look;
+            Vec side;
+            Vec up;
+
+            matrixPos.x = pppMngStPtr->m_matrix.value[0][3];
+            matrixPos.y = pppMngStPtr->m_matrix.value[1][3];
+            matrixPos.z = pppMngStPtr->m_matrix.value[2][3];
+
+            cameraPos.x = CameraPcs._224_4_;
+            cameraPos.y = CameraPcs._228_4_;
+            cameraPos.z = CameraPcs._232_4_;
+
+            PSVECSubtract(&cameraPos, &matrixPos, &look);
+            if ((look.x == 0.0f) && (look.y == 0.0f) && (look.z == 0.0f)) {
+                return;
+            }
+
+            PSVECNormalize(&look, &look);
+            side.x = look.z;
+            side.y = 0.0f;
+            side.z = -look.x;
+
+            if ((look.z == 0.0f) && (side.z == 0.0f)) {
+                side.x = 1.0f;
+                side.z = 0.0f;
+                up.x = 0.0f;
+                up.y = 0.0f;
+                up.z = 1.0f;
+            } else {
+                PSVECNormalize(&side, &side);
+                PSVECCrossProduct(&look, &side, &up);
+                PSVECNormalize(&up, &up);
+            }
+
+            pppMngStPtr->m_matrix.value[0][0] = side.x;
+            pppMngStPtr->m_matrix.value[1][0] = side.y;
+            pppMngStPtr->m_matrix.value[2][0] = side.z;
+            pppMngStPtr->m_matrix.value[0][1] = up.x;
+            pppMngStPtr->m_matrix.value[1][1] = up.y;
+            pppMngStPtr->m_matrix.value[2][1] = up.z;
+            pppMngStPtr->m_matrix.value[0][2] = look.x;
+            pppMngStPtr->m_matrix.value[1][2] = look.y;
+            pppMngStPtr->m_matrix.value[2][2] = look.z;
+        }
+
+        for (u16 i = 0; i < work->m_count; i++) {
+            Mtx model;
+            Vec transformedPos;
+            GXColor color;
+
+            if (graphFrame <= particle->m_frame) {
+                PSMTXIdentity(model);
+                model[0][0] = pppMngStPtr->m_scale.x * particle->m_scaleX;
+                model[1][1] = pppMngStPtr->m_scale.y * particle->m_scaleY;
+                model[2][2] = pppMngStPtr->m_scale.z * particle->m_scaleZ;
+
+                PSMTXMultVec(pppMngStPtr->m_matrix.value, &particle->m_pos, &transformedPos);
+                PSMTXMultVec(ppvCameraMatrix0, &transformedPos, &transformedPos);
+
+                model[0][3] = transformedPos.x;
+                model[1][3] = transformedPos.y;
+                model[2][3] = transformedPos.z;
+
+                pppSetDrawEnv((pppCVECTOR*)&particle->m_color, (pppFMATRIX*)0, 0.0f, 0, 0, 0, 0, 1, 1, 1);
+                GXSetCullMode(GX_CULL_NONE);
+                GXSetColorUpdate(GX_FALSE);
+                GXLoadPosMtxImm(model, 0);
+
+                if (((u8*)unkB->m_payload)[0xE] != 0) {
+                    GXSetColorUpdate(GX_TRUE);
+                }
+
+                *(u32*)&color = particle->m_color;
+                GXSetChanMatColor(GX_COLOR0A0, color);
+                pppDrawShp(shapeTable, particle->m_shape, pppEnvStPtr->m_materialSetPtr, blendMode);
+            }
+
+            particle++;
+        }
+
+        GXSetColorUpdate(GX_TRUE);
+        GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
     }
 }


### PR DESCRIPTION
## Summary
- Replaced placeholder pppRenderLocationTitle2 logic with a full render path based on current decomp patterns already used in nearby PPP effect units.
- Added explicit particle/work structs and graph-frame helper used by the render path.
- Implemented camera-facing basis setup, per-particle model matrix setup, draw env setup, shape draw call, and GX state restore in pppRenderLocationTitle2.
- Kept pppFrameLocationTitle2 behavior unchanged except for a C++-safe payload pointer arithmetic fix.

## Functions improved
- Unit: main/LocationTitle2
- Function: pppRenderLocationTitle2

## Match evidence
Baseline (before):
- main/LocationTitle2: **12.626373%**
- pppRenderLocationTitle2: **0.4784689%**
- pppFrameLocationTitle2: **11.5%**

After this change:
- main/LocationTitle2: **44.201466%**
- pppRenderLocationTitle2: **82.96651%**
- pppFrameLocationTitle2: **11.5%** (no regression)

Validation:
- 
inja succeeds.
- Metrics read from uild/GCCP01/report.json after rebuild.

## Plausibility rationale
- The new code uses the same idiomatic rendering patterns already present in nearby PPP units (pppLocationTitle, pppLensFlare, etc.): camera-facing basis construction, matrix transforms through pppMngStPtr/ppvCameraMatrix0, draw env + blend mode setup, and pppDrawShp calls.
- The implementation avoids synthetic compiler-coaxing patterns and keeps source style consistent with existing FFCC decomp code.

## Technical details
- Added GetGraphFrameFromId to match signed graph-id frame extraction semantics used in related code.
- Draw loop now gates by frame, applies manager scale to particle axis scale, uploads model matrix, and restores GX color/z state at end.
