### PR TITLE
TRK: match dolphin_trk_glue comm table selection flow

### DIFF
--- a/include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk_glue.h
+++ b/include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk_glue.h
@@ -18,11 +18,14 @@ typedef int (*DBCommWriteFunc)(const void*, size_t);
 typedef struct DBCommTable {
 	DBCommInitFunc initialize_func;
 	DBCommFunc init_interrupts_func;
+	DBCommFunc shutdown_func;
 	DBPollFunc peek_func;
 	DBCommReadFunc read_func;
 	DBCommWriteFunc write_func;
 	DBCommFunc open_func;
 	DBCommFunc close_func;
+	DBCommFunc pre_continue_func;
+	DBCommFunc post_stop_func;
 } DBCommTable;
 
 DSError TRKInitializeIntDrivenUART(u32 param_0, u32 param_1, u32 param_2,


### PR DESCRIPTION
## Summary
- Expanded `DBCommTable` in `dolphin_trk_glue` to include the missing MetroTRK communication callbacks (`shutdown`, `pre_continue`, `post_stop`) so table layout matches the PAL target.
- Reworked `InitMetroTRKCommTable` to follow the PAL control flow:
  - logs selected hardware ID,
  - handles `HARDWARE_BBA`, `HARDWARE_GDEV`, `HARDWARE_AMC_DDH`, and unknown IDs,
  - assigns the full communication callback table per hardware mode,
  - updates `TRK_Use_BBA` for BBA mode.
- Updated `TRKInitializeIntDrivenUART` to call both `initialize_func(...)` and `open_func()`.
- Updated `TRK_board_display` to report through a fixed format string (`%s`) instead of passing input as a format string.

## Functions Improved
Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk_glue`

- `InitMetroTRKCommTable`: **35.16129% -> 82.62581%**
- `TRKInitializeIntDrivenUART`: **75.0% -> 100.0%**
- `TRK_board_display`: **75.0% -> 99.166664%**
- `TRKPollUART`: **99.5% -> 100.0%**
- `TRKReadUARTN`: **99.6% -> 100.0%**
- `TRKWriteUARTN`: **99.6% -> 100.0%**

Unit `.text` match for this object improved from **68.1579% -> 92.032166%**.

## Match Evidence
- Built with `ninja` after edits.
- Compared with `tools/objdiff-cli.exe diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk_glue` before and after edits.
- Changes are instruction-level structural matches (branch/control-flow/table layout/call sequence), not symbol renames or formatting-only edits.

## Plausibility Rationale
The new code follows expected MetroTRK architecture behavior rather than compiler coaxing:
- Hardware mode selection now maps to the communication backends used elsewhere in this codebase (`udp_cc_*`, `gdev_cc_*`, `ddh_cc_*`).
- Callback table shape now reflects the operations consumed by the TRK runtime (init, interrupts, shutdown, read/write, open/close, pre/post hooks).
- UART init now performs both initialization and open in a natural startup sequence.
- Board display now uses explicit format-string reporting, which is consistent with standard SDK/diagnostic call sites.