### PR TITLE
gx: improve GXSetFieldMode match in GXPixel

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -315,15 +315,13 @@ void GXSetFieldMask(GXBool odd_mask, GXBool even_mask) {
 }
 
 void GXSetFieldMode(GXBool field_mode, GXBool half_aspect_ratio) {
+    GXData* gx;
     u32 reg;
-    u32 lp_size;
 
     CHECK_GXBEGIN(637, "GXSetFieldMode");
-    lp_size = __GXData->lpSize;
-    lp_size &= ~0x00400000;
-    lp_size |= (u32)(u8)half_aspect_ratio << 22;
-    __GXData->lpSize = lp_size;
-    GX_WRITE_RAS_REG(lp_size);
+    gx = __GXData;
+    gx->lpSize = (gx->lpSize & ~0x00400000) | ((u32)(u8)half_aspect_ratio << 22);
+    GX_WRITE_RAS_REG(gx->lpSize);
     __GXFlushTextureState();
     reg = (u32)(u8)field_mode | 0x68000000;
     GX_WRITE_RAS_REG(reg);


### PR DESCRIPTION
## Summary
Refactored GXSetFieldMode in src/gx/GXPixel.c to use a direct GXData* gx update path instead of a detached local lp_size temporary.

## Functions improved
- Unit: main/gx/GXPixel
- Symbol: GXSetFieldMode

## Match evidence
- GXSetFieldMode: **92.064514% -> 99.83871%**
- Unit .text match (main/gx/GXPixel): **79.84422% -> 80.449745%**
- Build progress impact from 
inja:
  - Matched code bytes: **187684 -> 187808** (+124)
  - Matched functions: **1311 -> 1312**

## Plausibility rationale
The change is source-plausible and idiomatic for this GX module: many nearby functions operate directly through __GXData/GXData* and update cached register state in-place before pushing BP writes. This is a readability-neutral structural cleanup, not contrived temporary shuffling.

## Technical details
- Replaced:
  - u32 lp_size load/mask/store sequence through __GXData
- With:
  - GXData* gx = __GXData;
  - in-place gx->lpSize bitfield update and BP write from gx->lpSize
- This produced assembly that aligns almost exactly with target flow/register usage for GXSetFieldMode while preserving behavior.