### PR TITLE
Implement THPSimple init/quit/audio-state functions

### DIFF
--- a/include/ffcc/THPSimple.h
+++ b/include/ffcc/THPSimple.h
@@ -12,11 +12,11 @@ extern "C" {
 
 void checkError();
 void _kami_DVDREAD(DVDFileInfo*, void*, long, long);
-void THPSimpleInit(void);
+s32 THPSimpleInit(s32);
 void THPSimpleQuit(void);
 s32 THPSimpleOpen(const char*);
 s32 THPSimpleClose(void);
-void THPSimpleCalcNeedMemory(void);
+s32 THPSimpleCalcNeedMemory(void);
 void THPSimpleSetBuffer(void);
 void ReadFrameAsync();
 void __THPSimpleDVDCallback(long, DVDFileInfo*);


### PR DESCRIPTION
## Summary
Implemented five `THPSimple` functions from TODO stubs into plausible source-level implementations based on existing engine patterns and THP API usage:
- `THPSimpleInit(s32)`
- `THPSimpleQuit()`
- `THPSimpleCalcNeedMemory()`
- `THPSimpleAudioStart()`
- `THPSimpleAudioStop()`

Also updated `include/ffcc/THPSimple.h` signatures for `THPSimpleInit` and `THPSimpleCalcNeedMemory` to match the implemented behavior and C linkage.

## Functions Improved
Unit: `main/THPSimple`

- `THPSimpleInit`: **1.3889% -> 97.0139%** (288b)
- `THPSimpleQuit`: **4.7619% -> 100.0000%** (84b)
- `THPSimpleCalcNeedMemory`: **3.1250% -> 81.5625%** (128b)
- `THPSimpleAudioStart`: **20.0000% -> 100.0000%** (20b)
- `THPSimpleAudioStop`: **20.0000% -> 100.0000%** (20b)

Unit fuzzy match improved from **16.7925% -> 24.5060%**.

## Match Evidence
- `ninja` progress increased matched code bytes from `187980` to `188104` (+124 bytes), and matched functions from `1316` to `1319`.
- `objdiff-cli diff -p . -u main/THPSimple THPSimpleInit` now reports `THPSimpleInit` at `96.59722%` symbol match.
- `objdiff` symbol matches for this unit now show:
  - `THPSimpleQuit`: `100%`
  - `THPSimpleAudioStart`: `100%`
  - `THPSimpleAudioStop`: `100%`
  - `THPSimpleCalcNeedMemory`: `81.5625%`

## Plausibility Rationale
These changes are source-plausible and align with existing codebase conventions:
- use of `File.CheckQueue()`, THP initialization flow, and DMA callback registration/restoration patterns;
- interrupt-guarded callback setup/teardown using existing Dolphin OS/AI APIs;
- memory-size computation derived from THP header/video/audio metadata with expected alignment rounding;
- simple state toggles for audio-start/stop fields already used by other THPSimple logic.

No contrived temporary variables or artificial control-flow was introduced.

## Technical Notes
- Added PAL address/size INFO blocks for the newly implemented functions.
- Kept implementation in existing `THPSimpleControl` semantics (`isBufferSet`, `hasAudio`, `isOpen`, etc.) without introducing ad-hoc offset math.