### PR TITLE
Improve pppFrameLerpPos match by aligning control flow

### DIFF
--- a/src/pppLerpPos.cpp
+++ b/src/pppLerpPos.cpp
@@ -78,8 +78,7 @@ void pppDestructLerpPos(struct pppLerpPos* pppLerpPos, struct UnkC* param_2)
  */
 void pppFrameLerpPos(struct pppLerpPos* pppLerpPos, struct UnkB* param_2, struct UnkC* param_3)
 {
-    _pppMngSt* pppMngSt;
-    s32 dataOffset;
+    _pppMngSt* pppMngSt = pppMngStPtr;
     s32 iVar1;
     s32 iVar2;
     s32 iVar4;
@@ -91,59 +90,53 @@ void pppFrameLerpPos(struct pppLerpPos* pppLerpPos, struct UnkB* param_2, struct
     u32 count;
     Vec** historyPtr;
 
-    if (DAT_8032ed70 != 0) {
-        return;
-    }
+    if (DAT_8032ed70 == 0) {
+        iVar2 = *param_3->m_serializedDataOffsets;
+        historyPtr = (Vec**)((u8*)pppLerpPos + 0x80 + iVar2);
+        if (*historyPtr == 0) {
+            *historyPtr = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                (u32)(u8)param_2->m_dataValIndex * 0xc, pppEnvStPtr->m_stagePtr, s_pppLerpPos_cpp_801dd418,
+                0x37);
+            iVar5 = 0;
+            for (iVar7 = 0; iVar7 < (s32)(u8)param_2->m_dataValIndex; iVar7 = iVar7 + 1) {
+                iVar4 = iVar5 + 4;
+                iVar1 = iVar5 + 8;
+                *(f32*)((u8*)*historyPtr + iVar5) = pppMngStPtr->m_matrix.value[0][3];
+                iVar5 = iVar5 + 0xc;
+                *(f32*)((u8*)*historyPtr + iVar4) = pppMngStPtr->m_matrix.value[1][3];
+                *(f32*)((u8*)*historyPtr + iVar1) = pppMngStPtr->m_matrix.value[2][3];
+            }
+        } else {
+            local_2c.z = FLOAT_80331bf8;
+            local_2c.y = FLOAT_80331bf8;
+            local_2c.x = FLOAT_80331bf8;
 
-    pppMngSt = pppMngStPtr;
-    dataOffset = *param_3->m_serializedDataOffsets;
-    historyPtr = (Vec**)((u8*)pppLerpPos + 0x80 + dataOffset);
+            iVar5 = (u8)param_2->m_dataValIndex - 1;
+            iVar7 = iVar5 * 0xc;
+            for (; 0 < iVar5; iVar5 = iVar5 - 1) {
+                pfVar6 = (f32*)((u8*)*historyPtr + iVar7 - 0xc);
+                local_38.x = *pfVar6;
+                local_38.y = pfVar6[1];
+                local_38.z = pfVar6[2];
+                pppCopyVector__FR3Vec3Vec((void*)((u8*)*historyPtr + iVar7), &local_38);
+                iVar7 = iVar7 - 0xc;
+            }
 
-    if (*historyPtr == 0) {
-        *historyPtr = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            (u32)(u8)param_2->m_dataValIndex * 0xc, pppEnvStPtr->m_stagePtr, s_pppLerpPos_cpp_801dd418, 0x37);
+            (*historyPtr)->x = pppMngStPtr->m_matrix.value[0][3];
+            *(f32*)((u8*)*historyPtr + 4) = pppMngStPtr->m_matrix.value[1][3];
+            *(f32*)((u8*)*historyPtr + 8) = pppMngStPtr->m_matrix.value[2][3];
 
-        iVar5 = 0;
-        for (iVar7 = 0; iVar7 < (s32)(u8)param_2->m_dataValIndex; iVar7 = iVar7 + 1) {
-            iVar4 = iVar5 + 4;
-            iVar1 = iVar5 + 8;
-            *(f32*)((u8*)*historyPtr + iVar5) = pppMngStPtr->m_matrix.value[0][3];
-            iVar5 = iVar5 + 0xc;
-            *(f32*)((u8*)*historyPtr + iVar4) = pppMngStPtr->m_matrix.value[1][3];
-            *(f32*)((u8*)*historyPtr + iVar1) = pppMngStPtr->m_matrix.value[2][3];
+            iVar7 = 0;
+            for (iVar5 = 0, count = (u32)(u8)param_2->m_dataValIndex; iVar5 < (s32)count; iVar5 = iVar5 + 1) {
+                PSVECAdd((Vec*)((u8*)*historyPtr + iVar7), &local_2c, &local_2c);
+                iVar7 = iVar7 + 0xc;
+            }
+
+            PSVECScale(&local_2c, &local_2c, FLOAT_80331bfc / (f32)count);
+            pppMngStPtr->m_matrix.value[0][3] = local_2c.x;
+            pppMngStPtr->m_matrix.value[1][3] = local_2c.y;
+            pppMngStPtr->m_matrix.value[2][3] = local_2c.z;
+            pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
         }
-    } else {
-        local_2c.x = FLOAT_80331bf8;
-        local_2c.y = FLOAT_80331bf8;
-        local_2c.z = FLOAT_80331bf8;
-
-        iVar5 = (u8)param_2->m_dataValIndex - 1;
-        iVar7 = iVar5 * 0xc;
-        while (0 < iVar5) {
-            pfVar6 = (f32*)((u8*)*historyPtr + iVar7 - 0xc);
-            local_38.x = *pfVar6;
-            local_38.y = pfVar6[1];
-            local_38.z = pfVar6[2];
-            pppCopyVector__FR3Vec3Vec((void*)((u8*)*historyPtr + iVar7), &local_38);
-            iVar7 = iVar7 - 0xc;
-            iVar5 = iVar5 - 1;
-        }
-
-        (*(Vec**)((u8*)pppLerpPos + 0x80 + dataOffset))->x = pppMngStPtr->m_matrix.value[0][3];
-        *(f32*)((u8*)*historyPtr + 4) = pppMngStPtr->m_matrix.value[1][3];
-        *(f32*)((u8*)*historyPtr + 8) = pppMngStPtr->m_matrix.value[2][3];
-
-        iVar7 = 0;
-        for (iVar5 = 0, count = (u32)(u8)param_2->m_dataValIndex; iVar5 < (s32)count; iVar5 = iVar5 + 1) {
-            PSVECAdd((Vec*)((u8*)*historyPtr + iVar7), &local_2c, &local_2c);
-            iVar7 = iVar7 + 0xc;
-        }
-
-        iVar2 = (s32)count;
-        PSVECScale(&local_2c, &local_2c, FLOAT_80331bfc / (f32)iVar2);
-        pppMngStPtr->m_matrix.value[0][3] = local_2c.x;
-        pppMngStPtr->m_matrix.value[1][3] = local_2c.y;
-        pppMngStPtr->m_matrix.value[2][3] = local_2c.z;
-        pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
 }


### PR DESCRIPTION
## Summary
- Reworked pppFrameLerpPos control-flow to match the original guard structure.
- Aligned history update and accumulation ordering to reduce compiler output divergence.
- Kept behavior unchanged while normalizing data movement and loop structure.

## Functions Improved
- Unit: main/pppLerpPos
- Symbol: pppFrameLerpPos

## Match Evidence
- pppFrameLerpPos: **86.22581% -> 87.47581%** (+1.25%)
- Verified using 	ools/objdiff-cli diff -p . -u main/pppLerpPos --format json symbol metrics.
- Rebuild passes with 
inja.

## Plausibility Rationale
- The change is source-plausible: no artificial temporaries for coaxing, no hardcoded assembly artifacts, and code remains readable/idiomatic for the existing unit.
- Edits focus on control-flow and variable ordering consistent with likely original implementation patterns.

## Technical Details
- Improvement primarily came from aligning CFG shape and assignment order in the history shift/centroid computation block.
