### PR TITLE
pppConstrainCameraDir2: fix GetDirectVector ABI and improve match

### DIFF
--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -16,7 +16,7 @@ extern float FLOAT_803331e8;
 extern int DAT_8032ec70;
 
 void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, pppConstrainCameraDir*, int, float*, float*, float*, float*, float*);
-void GetDirectVector__5CUtilFP3VecP3Vec3Vec(void*, Vec*, Vec*, Vec*);
+void GetDirectVector__5CUtilFP3VecP3Vec3Vec(void*, Vec*, Vec*, Vec);
 void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
 
 /*
@@ -37,9 +37,7 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, UnkB* param_2, 
 	double dVar3;
 	double dVar4;
 	double dVar5;
-	float local_108;
-	float local_104;
-	float local_100;
+	Vec local_108;
 	Vec local_fc;
 	Vec local_f0;
 	float local_e4;
@@ -105,11 +103,11 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, UnkB* param_2, 
 			
 			dVar2 = (double)((_pppPObject*)param_1)->m_localMatrix.value[0][3];
 			dVar3 = (double)((_pppPObject*)param_1)->m_localMatrix.value[1][3];
-			local_108 = local_cc;
-			local_104 = local_c8;
-			local_100 = local_c4;
+			local_108.x = local_cc;
+			local_108.y = local_c8;
+			local_108.z = local_c4;
 			
-			GetDirectVector__5CUtilFP3VecP3Vec3Vec((void*)&DAT_8032ec70, (Vec*)&local_d8, (Vec*)&local_e4, (Vec*)&local_108);
+			GetDirectVector__5CUtilFP3VecP3Vec3Vec((void*)&DAT_8032ec70, (Vec*)&local_d8, (Vec*)&local_e4, local_108);
 			
 			local_f0.x = (float)(dVar2 * (double)local_d8);
 			local_f0.y = (float)(dVar2 * (double)local_d4);


### PR DESCRIPTION
## Summary
- Corrected the GetDirectVector__5CUtilFP3VecP3Vec3Vec declaration in pppConstrainCameraDir2 to match its mangled ABI (Vec by value for the third vector argument).
- Updated the call site in pppFrameConstrainCameraDir2 to pass a Vec value instead of a pointer, and represented the camera direction temp as a Vec (x/y/z) to match that call shape.

## Functions improved
- Unit: main/pppConstrainCameraDir2
- Function: pppFrameConstrainCameraDir2

## Match evidence
- 	ools/objdiff-cli diff -p . -u main/pppConstrainCameraDir2 pppFrameConstrainCameraDir2
- Before: 58.63372%
- After: 64.1686%
- Delta: +5.53488

## Plausibility rationale
- CUtil::GetDirectVector is declared in include/ffcc/util.h as GetDirectVector(Vec*, Vec*, Vec).
- The updated extern/call now matches the known method signature and mangled name, instead of relying on an incorrect pointer-based prototype.
- This is an ABI/type-correctness fix rather than artificial control-flow coaxing.

## Technical details
- The change aligns calling convention and stack argument layout for the GetDirectVector call inside pppFrameConstrainCameraDir2.
- Rebuilt with 
inja successfully and validated with objdiff.