### PR TITLE
partMng: implement pppShapeSt/pppModelSt lifecycle methods

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -40,6 +40,9 @@ struct pppShapeSt
     short m_refCount;        // 0x28
     unsigned char m_inUse;   // 0x2a
 
+    pppShapeSt();
+    ~pppShapeSt();
+
     void* GetTexture(long*, CMaterialSet*, int&);
 }; // Size 0x2c
 
@@ -50,6 +53,9 @@ struct pppModelSt
     short m_refCount;       // 0x64
     short m_cacheId;        // 0x66
     unsigned char m_isUsed; // 0x68
+
+    pppModelSt();
+    ~pppModelSt();
 }; // Size 0x6c
 
 struct PPPCREATEPARAM

--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -1,5 +1,74 @@
 #include "ffcc/partMng.h"
 
+extern "C" void __dl__FPv(void* ptr);
+
+/*
+ * --INFO--
+ * PAL Address: 0x80059220
+ * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+pppShapeSt::pppShapeSt()
+{
+    m_refCount = 0;
+    m_inUse = 0;
+    m_animData = 0;
+    m_displayListData = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800591A4
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+pppShapeSt::~pppShapeSt()
+{
+    if (m_animData != 0) {
+        __dl__FPv(m_animData);
+        m_animData = 0;
+    }
+
+    if (m_displayListData != 0) {
+        __dl__FPv(m_displayListData);
+        m_displayListData = 0;
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8005961C
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+pppModelSt::pppModelSt()
+{
+    m_refCount = 0;
+    m_isUsed = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800595C8
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+pppModelSt::~pppModelSt()
+{
+}
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- Added explicit constructors/destructors for `pppShapeSt` and `pppModelSt` in `partMng`.
- Implemented initialization and cleanup behavior consistent with current type layout and existing memory free conventions (`__dl__FPv`).
- Added PAL address/size metadata blocks for the four implemented functions.

## Functions Improved
Unit: `main/partMng`
- `__ct__10pppShapeStFv`: `0.0% -> 100.0%` (24b)
- `__dt__10pppShapeStFv`: `0.0% -> 100.0%` (124b)
- `__ct__10pppModelStFv`: `0.0% -> 99.86667%` (60b)
- `__dt__10pppModelStFv`: `0.0% -> 99.95238%` (84b)

Unit-level progress:
- `matched_functions`: `1/69 -> 3/69`
- `fuzzy_match_percent`: `~0.7% -> 1.6169%`

## Match Evidence
- Rebuilt with `ninja` successfully after edits.
- Verified updated function-level match percentages in `build/GCCP01/report.json` for `main/partMng`.
- Two functions are now fuzzy 100%; two are near-exact and very close to full match.

## Plausibility Rationale
- These are straightforward, source-plausible object lifecycle methods:
  - constructors initialize usage/refcount state and owned pointers
  - destructor frees owned heap buffers and nulls pointers
  - model constructor initializes runtime state without contrived compiler coaxing
- The code follows existing project conventions and keeps behavior readable/maintainable.

## Technical Notes
- `pppShapeSt` destructor uses `__dl__FPv` for owned pointer cleanup, matching project memory routines.
- `pppModelSt` constructor state writes match decomp expectations while preserving C++ member lifecycle semantics for `CMapMesh`.