### PR TITLE
pppBindOnlyPos: improve pppFrameBindOnlyPos match

### DIFF
--- a/src/pppBindOnlyPos.cpp
+++ b/src/pppBindOnlyPos.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppBindOnlyPos.h"
 
-extern int DAT_8032ed70;
-extern int* DAT_8032ed50;
+extern int lbl_8032ED70;
+extern int* lbl_8032ED50;
 
 /*
  * --INFO--
@@ -28,9 +28,9 @@ void pppConstructBindOnlyPos(void)
  */
 void pppFrameBindOnlyPos(void)
 {
-	if (DAT_8032ed70 != 0) {
+	if (lbl_8032ED70 != 0) {
 		return;
 	}
 
-	(void)(*(volatile unsigned int*)((char*)DAT_8032ed50 + 0xd8) == 0);
+	*(volatile unsigned int*)((char*)lbl_8032ED50 + 0xd8);
 }


### PR DESCRIPTION
## Summary
- Updated `src/pppBindOnlyPos.cpp` to use the established global symbol names (`lbl_8032ED70`, `lbl_8032ED50`) in `pppFrameBindOnlyPos`.
- Kept behavior unchanged: early return when the global flag is non-zero, then perform the volatile read at `+0xD8`.

## Functions improved
- Unit: `main/pppBindOnlyPos`
- Function: `pppFrameBindOnlyPos`
- Match: `84.28571% -> 85.71429%`

## Match evidence
- Baseline (`tools/objdiff-cli`): `pppFrameBindOnlyPos` = `84.28571%`
- After change (`tools/objdiff-cli`): `pppFrameBindOnlyPos` = `85.71429%`
- Improvement is tied to relocation/symbol alignment and cleaner generated sequence for the volatile tail read.

## Plausibility rationale
- Using the same global symbol naming (`lbl_8032ED70` / `lbl_8032ED50`) seen throughout neighboring ppp modules is more consistent with likely original source conventions.
- The code remains straightforward and source-plausible; no contrived control-flow or compiler-coaxing temporaries were introduced.

## Technical details
- Build verified with `ninja`.
- Diff verified with `tools/objdiff-cli diff -p . -u main/pppBindOnlyPos -o - pppFrameBindOnlyPos`.