### PR TITLE
Improve RedStream helper/control function matching

### DIFF
--- a/include/ffcc/RedSound/RedStream.h
+++ b/include/ffcc/RedSound/RedStream.h
@@ -3,7 +3,7 @@
 
 struct RedStreamDATA;
 
-void _SearchEmptyStreamData();
+unsigned int _SearchEmptyStreamData();
 void _StreamStop(RedStreamDATA*);
 int _ArrangeStreamDataNoLoop(RedStreamDATA*, int, int);
 int _ArrangeStreamDataLoop(RedStreamDATA*, int, int);


### PR DESCRIPTION
## Summary
Implemented four previously stubbed RedStream control/helper functions using decomp-guided logic and existing module conventions:
- _SearchEmptyStreamData__Fv
- _StreamStop__FP13RedStreamDATA
- SetStreamVolume__Fiii
- StreamPause__Fii

Also updated the declaration of _SearchEmptyStreamData in RedStream.h to return the stream-slot address (unsigned int) to match function behavior.

## Functions Improved
Unit: main/RedSound/RedStream

- _SearchEmptyStreamData__Fv: **5.882353% -> 41.705883%**
- _StreamStop__FP13RedStreamDATA: **1.4705882% -> 82.867645%**
- SetStreamVolume__Fiii: **1.9607843% -> 57.627453%**
- StreamPause__Fii: **1.0204082% -> 59.040817%**

Control comparisons:
- StreamStop__Fi: **3.5714285% -> 3.5714285%** (unchanged)
- StreamPlay__FiPviii: **0.3125% -> 0.3125%** (unchanged)

## Match Evidence
Measured with:
	ools/objdiff-cli diff -p . -u main/RedSound/RedStream -o -

Pre/post symbol match percentages above were taken from objdiff JSON outputs before and after this patch.

## Plausibility Rationale
The new implementations are plausible original source for this module because they:
- follow the existing RedSound data-layout usage pattern (explicit field offsets and slot scanning loops)
- use established driver/memory APIs already used elsewhere in RedSound (RedDelete, RedDeleteA, PitchCompute)
- preserve expected stream control behavior (resource release, stream state transitions, volume ramp setup, pause/resume pitch handling)

No compiler-coaxing temporaries or unnatural control-flow tricks were introduced; this is straightforward logic reconstruction aligned with nearby code style.

## Technical Notes
- Build verified with 
inja.
- objdiff version used: 3.6.1.
- Scope intentionally limited to symbols with clear low-risk gains; StreamPlay__FiPviii remains for a dedicated follow-up pass.