### PR TITLE
gxfunc: match _GXSetTevOrder/_GXSetTevSwapMode wrappers

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -240,10 +240,13 @@ void _GXSetAlphaCompare(_GXCompare comp0, unsigned char ref0, _GXAlphaOp op, _GX
  */
 void _GXSetTevOrder(_GXTevStageID stage, _GXTexCoordID coord, _GXTexMapID map, _GXChannelID channel)
 {
-	if (s_GXSetTevOrder_Reg[stage].coord != coord || s_GXSetTevOrder_Reg[stage].map != map || s_GXSetTevOrder_Reg[stage].channel != channel) {
-		s_GXSetTevOrder_Reg[stage].coord = coord;
-		s_GXSetTevOrder_Reg[stage].map = map;
-		s_GXSetTevOrder_Reg[stage].channel = channel;
+	int stageOff = stage * 0xC;
+	int* entry = (int*)((char*)s_GXSetTevOrder_Reg + stageOff);
+
+	if (entry[0] != coord || entry[1] != map || entry[2] != channel) {
+		entry[0] = coord;
+		entry[1] = map;
+		entry[2] = channel;
 		GXSetTevOrder(stage, coord, map, channel);
 	}
 }
@@ -259,9 +262,12 @@ void _GXSetTevOrder(_GXTevStageID stage, _GXTexCoordID coord, _GXTexMapID map, _
  */
 void _GXSetTevSwapMode(_GXTevStageID stage, _GXTevSwapSel rasSel, _GXTevSwapSel texSel)
 {
-	if (s_GXSetTevSwapMode_Reg[stage].rasSel != rasSel || s_GXSetTevSwapMode_Reg[stage].texSel != texSel) {
-		s_GXSetTevSwapMode_Reg[stage].rasSel = rasSel;
-		s_GXSetTevSwapMode_Reg[stage].texSel = texSel;
+	int stageOff = stage * 8;
+	int* entry = (int*)((char*)s_GXSetTevSwapMode_Reg + stageOff);
+
+	if (entry[0] != rasSel || entry[1] != texSel) {
+		entry[0] = rasSel;
+		entry[1] = texSel;
 		GXSetTevSwapMode(stage, rasSel, texSel);
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked cache access in `src/gxfunc.cpp` for `_GXSetTevOrder` and `_GXSetTevSwapMode` to use explicit stage byte offsets and `int*` entries.
- Kept behavior unchanged: still short-circuits on unchanged register-cache state, then calls the corresponding GX function on change.

## Functions Improved
- Unit: `main/gxfunc`
- `_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel`
- `_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID`

## Match Evidence
- `_GXSetTevSwapMode...`: **67.5% -> 100.0%**
- `_GXSetTevOrder...`: **72.5% -> 100.0%**
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/gxfunc -o - <symbol>`

## Plausibility Rationale
- This matches the decompilation-era coding pattern used in nearby wrappers: computing a per-stage byte offset, then reading/writing packed cache words directly.
- The change is source-plausible and idiomatic for SDK-era register-cache wrappers, rather than compiler-coaxing.

## Technical Notes
- Replaced field-based struct indexing with offset-based pointer indexing to better align generated addressing and update sequence.
- No control-flow or semantic changes beyond equivalent addressing form.
