### PR TITLE
pppYmLookOn: improve pppConstructYmLookOn match

### DIFF
--- a/src/pppYmLookOn.cpp
+++ b/src/pppYmLookOn.cpp
@@ -21,7 +21,8 @@ void pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
  */
 void pppConstructYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkC* param_2)
 {
-    *((int*)((char*)(&pppYmLookOn->field0_0x0[2]) + *param_2->m_serializedDataOffsets)) = 0;
+    int dataOffset = **(int**)param_2;
+    *(int*)((char*)pppYmLookOn + dataOffset + 8) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refined pppConstructYmLookOn address calculation to use an explicit serialized offset local and direct base+offset+8 store.
- Kept function behavior identical (zeroing the same per-instance work field).

## Functions Improved
- Unit: main/pppYmLookOn
- Function: pppConstructYmLookOn
  - Before: 79.0%
  - After: 99.666664%
  - Size: 24b

## Match Evidence
- Verified with:
  - build/tools/objdiff-cli diff -p . -u main/pppYmLookOn -o - pppConstructYmLookOn
- Current objdiff status for target symbols:
  - pppConstructYmLookOn: 99.666664%
  - pppFrameYmLookOn: 78.117645% (unchanged)

## Plausibility Rationale
- The change is source-plausible: it is a straightforward pointer/offset expression rewrite for serialized work data access.
- No artificial temporaries, no hardcoded magic beyond existing known work offset semantics (+8 from object base), and no non-functional compiler-coaxing patterns.

## Technical Details
- The prior decomp expression used nested field-address arithmetic through placeholder struct fields.
- Rewriting the expression produced significantly better instruction/operand alignment in objdiff for this constructor-sized function while preserving behavior.
