### PR TITLE
main/axfx/reverb_std: improve ReverbSTDFree cleanup match

### DIFF
--- a/src/axfx/reverb_std.c
+++ b/src/axfx/reverb_std.c
@@ -437,27 +437,26 @@ static void ReverbSTDCallback(s32* left, s32* right, s32* surround, AXFX_REVSTD_
 
 static void ReverbSTDFree(AXFX_REVSTD_WORK* rv) {
     u8 i;
+    AXFX_REVSTD_DELAYLINE* dl;
+    f32** preDelayLine;
 
+    dl = rv->AP;
     for (i = 0; i < 6; i++) {
-		if (rv->AP[i].inputs != 0) {
-			DLdelete(&rv->AP[i]);
-			rv->AP[i].inputs = NULL;
-		}
+        __AXFXFree(dl->inputs);
+        dl++;
     }
 
+    dl = rv->C;
     for (i = 0; i < 6; i++) {
-        if (rv->C[i].inputs != 0) {
-			DLdelete(&rv->C[i]);
-			rv->C[i].inputs = NULL;
-		}
+        __AXFXFree(dl->inputs);
+        dl++;
     }
 
     if (rv->preDelayTime) {
+        preDelayLine = rv->preDelayLine;
         for (i = 0; i < 3; i++) {
-            if (rv->preDelayLine[i] != 0) {
-				__AXFXFree(rv->preDelayLine[i]);
-				rv->preDelayLine[i] = NULL;
-			}
+            __AXFXFree(*preDelayLine);
+            preDelayLine++;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rewrote `ReverbSTDFree` in `src/axfx/reverb_std.c` to use pointer-increment loops for delayline cleanup.
- Removed guard checks and post-free null writes inside this function so cleanup emits direct free calls over contiguous fields.
- Kept behavior and call sites unchanged (`AXFXReverbStdShutdown`, `ReverbSTDModify`).

## Functions Improved
- Unit: `main/axfx/reverb_std`
- Symbol: `ReverbSTDFree`
  - Before: `61.904762%`
  - After: `88.14286%`
  - Delta: `+26.238098%`

## Match Evidence
- `objdiff` symbol diff (`build/tools/objdiff-cli diff -p . -u main/axfx/reverb_std -o - ReverbSTDFree`)
  - Non-matching instruction entries reduced from `44` to `17`.
- Unit `.text` match improved:
  - Before: `89.39896%`
  - After: `91.55411%`

## Plausibility Rationale
- The revised implementation aligns with expected low-level layout traversal for `AXFX_REVSTD_WORK` delayline arrays.
- Pointer-walk cleanup loops are idiomatic for hand-written C in this codebase and avoid synthetic index math that looked less source-plausible for this module.
- The change is consistent with the decompilation reference for this routine (direct frees over AP/C/preDelay arrays).

## Technical Details
- Introduced `AXFX_REVSTD_DELAYLINE* dl` to iterate AP and C arrays in-place.
- Introduced `f32** preDelayLine` for the pre-delay cleanup loop.
- Maintained existing interrupt/initialization flow and did not alter function signatures or structure layouts.