### PR TITLE
pppLaser: fix struct layout and offset indirection

### DIFF
--- a/include/ffcc/pppLaser.h
+++ b/include/ffcc/pppLaser.h
@@ -4,7 +4,7 @@
 #include "dolphin/types.h"
 
 struct pppLaser {
-    u8 field_0x0[0x98];
+    u8 field_0x0[0x84];
     f32 field_0x84;     // 0x84
     f32 field_0x88;     // 0x88
     f32 field_0x8c;     // 0x8c
@@ -23,8 +23,13 @@ struct UnkB {
     u8 placeholder[0x100];
 };
 
-struct UnkC {
+struct UnkCLaserOffsets {
     int m_serializedDataOffsets[3];
+};
+
+struct UnkC {
+    u8 unk_00[0xc];
+    UnkCLaserOffsets* offsets;
 };
 
 #ifdef __cplusplus

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -30,23 +30,23 @@ void pppStopSe__FP9_pppMngStP7PPPSEST(_pppMngSt*, PPPSEST*);
 void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
     f32 fVar1 = FLOAT_80333428;
-    f32* pfVar3 = (f32*)((u8*)&pppLaser->field_0x88 + param_2->m_serializedDataOffsets[2]);
+    f32* pfVar3 = (f32*)((u8*)&pppLaser->field_0x88 + param_2->offsets->m_serializedDataOffsets[2]);
     int local_24;
     int local_28;
     Vec local_20;
     Vec local_14;
 
     *pfVar3 = FLOAT_80333428;
-    pfVar3[1] = fVar1;
-    pfVar3[2] = fVar1;
-    pfVar3[3] = fVar1;
-    pfVar3[4] = fVar1;
-    pfVar3[5] = fVar1;
     pfVar3[6] = fVar1;
+    pfVar3[5] = fVar1;
+    pfVar3[4] = fVar1;
+    pfVar3[3] = fVar1;
+    pfVar3[2] = fVar1;
+    pfVar3[1] = fVar1;
     pfVar3[7] = 0.0f;
-    pfVar3[8] = fVar1;
-    pfVar3[9] = fVar1;
     pfVar3[10] = fVar1;
+    pfVar3[9] = fVar1;
+    pfVar3[8] = fVar1;
 
     *((u8*)pfVar3 + 0x2c) = 0;
     *((u8*)pfVar3 + 0x2d) = 0;
@@ -91,8 +91,8 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
  */
 void pppConstruct2Laser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
-    f32 fVar1 = 1.0f; // FLOAT_80333428 placeholder
-    int iVar2 = param_2->m_serializedDataOffsets[2];
+    f32 fVar1 = FLOAT_80333428;
+    int iVar2 = param_2->offsets->m_serializedDataOffsets[2];
     
     *(f32*)((u8*)&pppLaser->field_0x98 + iVar2) = fVar1;
     *(f32*)((u8*)&pppLaser->field_0x94 + iVar2) = fVar1;
@@ -117,7 +117,7 @@ void pppConstruct2Laser(struct pppLaser *pppLaser, struct UnkC *param_2)
  */
 void pppDestructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
-    int iVar1 = param_2->m_serializedDataOffsets[2];
+    int iVar1 = param_2->offsets->m_serializedDataOffsets[2];
     void *pfVar3 = *(void **)((u8*)&pppLaser->field_0x9c + iVar1);
     if (pfVar3 != 0) {
         pppHeapUseRate__FPQ27CMemory6CStage(pfVar3);


### PR DESCRIPTION
## Summary
- Corrected `pppLaser` base layout so named members begin at the documented offsets (`field_0x84` now starts at `0x84`).
- Updated `UnkC` to model the observed serialized-offset indirection (`unk_00[0xc]` + `offsets` pointer) and switched laser constructors/destructor to use `param_2->offsets->m_serializedDataOffsets[2]`.
- Replaced the temporary `1.0f` placeholder in `pppConstruct2Laser` with `FLOAT_80333428` and reordered initialization stores in `pppConstructLaser` to better match expected store ordering.

## Functions Improved
- Unit: `main/pppLaser` (`src/pppLaser.cpp`)
- `pppConstructLaser`: `59.02381%` -> `60.107143%`
- `pppConstruct2Laser`: `84.05882%` -> `90.0%`
- `pppDestructLaser`: `88.52631%` -> `93.8421%`

## Match Evidence
- Rebuilt with `ninja` after changes.
- Compared with:
  - `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppConstructLaser`
- Improvement is instruction-level and localized to the corrected offset/addressing paths rather than formatting-only edits.

## Plausibility Rationale
- The new `UnkC` access path matches existing project patterns in similar PPP units that pass an offset table pointer through effect params.
- Fixing the `pppLaser` struct base size resolves a clear offset contradiction in the previous source and makes member comments consistent with actual layout.
- Changes are type/layout corrections and natural initialization ordering, not synthetic compiler-coaxing constructs.

## Technical Details
- Pre-change code indexed offsets directly from `UnkC`, which generated an inconsistent access sequence relative to expected parameter indirection.
- Post-change code dereferences `param_2->offsets` and uses corrected object field offsets, improving codegen alignment for constructor/destructor data setup paths.
