### PR TITLE
usb: improve callback function matching in CUSB

### DIFF
--- a/include/ffcc/usb.h
+++ b/include/ffcc/usb.h
@@ -18,7 +18,7 @@ typedef void (*MessageCallback)(unsigned long, void*, MCCChannel);
 struct CUSBCallbackEntry
 {
     int m_inUse;           // 0x0
-    void* m_callback;      // 0x4
+    MessageCallback m_callback; // 0x4
     void* m_callerContext; // 0x8
 };
 

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -94,12 +94,8 @@ void CUSB::AddMessageCallback(MessageCallback callback, void* callerContext)
 {
 	CUSBCallbackEntry* callbackEntry;
 	int i;
-	int remaining;
 
-	callbackEntry = m_callbacks;
-	i = 0;
-	remaining = 8;
-	while (true)
+	for (callbackEntry = m_callbacks, i = 0; i < 8; callbackEntry++, i++)
 	{
 		if (callbackEntry->m_inUse == 0)
 		{
@@ -112,14 +108,6 @@ void CUSB::AddMessageCallback(MessageCallback callback, void* callerContext)
 		if (callbackEntry->m_callback == callback)
 		{
 			System.Printf("CUSB.AddMessageCallback: 同じ");
-			break;
-		}
-
-		i++;
-		callbackEntry++;
-		remaining--;
-		if (remaining == 0)
-		{
 			break;
 		}
 	}
@@ -137,55 +125,22 @@ void CUSB::AddMessageCallback(MessageCallback callback, void* callerContext)
  */
 void CUSB::RemoveMessageCallback(MessageCallback callback)
 {
-    if (m_callbacks[0].m_inUse && m_callbacks[0].m_callback == callback)
+    CUSBCallbackEntry* callbackEntry;
+    int i;
+
+    for (callbackEntry = m_callbacks, i = 0; i < 8; callbackEntry++, i++)
     {
-        m_callbacks[0].m_inUse = 0;
-        return;
+        if (callbackEntry->m_inUse != 0 && callbackEntry->m_callback == callback)
+        {
+            callbackEntry->m_inUse = 0;
+            break;
+        }
     }
 
-    if (m_callbacks[1].m_inUse && m_callbacks[1].m_callback == callback)
+    if (i == 8)
     {
-        m_callbacks[1].m_inUse = 0;
-        return;
+        System.Printf("RemoveMessageCallback: callback not found\n");
     }
-
-    if (m_callbacks[2].m_inUse && m_callbacks[2].m_callback == callback)
-    {
-        m_callbacks[2].m_inUse = 0;
-        return;
-    }
-
-    if (m_callbacks[3].m_inUse && m_callbacks[3].m_callback == callback)
-    {
-        m_callbacks[3].m_inUse = 0;
-        return;
-    }
-
-    if (m_callbacks[4].m_inUse && m_callbacks[4].m_callback == callback)
-    {
-        m_callbacks[4].m_inUse = 0;
-        return;
-    }
-
-    if (m_callbacks[5].m_inUse && m_callbacks[5].m_callback == callback)
-    {
-        m_callbacks[5].m_inUse = 0;
-        return;
-    }
-
-    if (m_callbacks[6].m_inUse && m_callbacks[6].m_callback == callback)
-    {
-        m_callbacks[6].m_inUse = 0;
-        return;
-    }
-
-    if (m_callbacks[7].m_inUse && m_callbacks[7].m_callback == callback)
-    {
-        m_callbacks[7].m_inUse = 0;
-        return;
-    }
-
-    System.Printf("RemoveMessageCallback: callback not found\n");
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CUSBCallbackEntry::m_callback` to use the existing `MessageCallback` function-pointer typedef instead of `void*`.
- Reworked `CUSB::AddMessageCallback` and `CUSB::RemoveMessageCallback` to use index-based callback table scans over 8 entries.
- Kept logic source-plausible: same insertion/removal behavior and same diagnostic print paths.

## Functions improved
- `AddMessageCallback__4CUSBFPFUlPv10MCCChannel_vPv`
- `RemoveMessageCallback__4CUSBFPFUlPv10MCCChannel_v`
- Unit: `main/usb` (`usb.o`)

## Match evidence (objdiff)
- `AddMessageCallback__4CUSBFPFUlPv10MCCChannel_vPv`: **67.61905% -> 72.5%**
- `RemoveMessageCallback__4CUSBFPFUlPv10MCCChannel_v`: **88.072914% -> 99.270836%**
- `main/usb` `.text` section: **84.36813% -> 85.49451%**

## Plausibility rationale
- Callback fields in this table are semantically function pointers; storing them as `MessageCallback` is consistent with intended type usage and ABI expectations.
- Indexed fixed-size table scans are idiomatic original-source code for this era/module and avoid contrived compiler-coaxing constructs.

## Technical details
- objdiff deltas for callback functions indicated mismatches in compare/store codegen around callback entries and control-flow shape of entry scans.
- Aligning field typing and scan structure reduced those mismatches substantially, especially in `RemoveMessageCallback` where assembly now nearly fully aligns.
