### PR TITLE
configure: enable GEKKO path for dolphin mtx

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -656,9 +656,12 @@ config.libs = [
             Object(NonMatching, "db/db.c"),
         ],
     ),
-    DolphinLib(
-        "mtx",
-        [
+    {
+        "lib": "mtx",
+        "mw_version": "GC/1.2.5n",
+        "cflags": [*cflags_base, "-DGEKKO"],
+        "progress_category": "sdk",
+        "objects": [
             Object(NonMatching, "mtx/mtx.c"),
             Object(NonMatching, "mtx/mtxvec.c"),
             Object(NonMatching, "mtx/mtx44.c"),
@@ -667,7 +670,7 @@ config.libs = [
             Object(NonMatching, "mtx/quat.c"),
             Object(NonMatching, "mtx/psmtx.c"),
         ],
-    ),
+    },
     DolphinLib(
         "dvd",
         [


### PR DESCRIPTION
## Summary
- Updated `configure.py` so the Dolphin `mtx` library compiles with `-DGEKKO`.
- This enables the intended `#ifdef GEKKO` PS/paired-single code paths in `src/mtx/mtx.c`.
- No source logic was rewritten; this is a build-environment correction for this SDK unit.

## Functions improved
Unit: `main/mtx/mtx`

Key mapped functions after this change include:
- `PSMTXIdentity`: 99.09091%
- `PSMTXCopy`: 100.0%
- `PSMTXConcat`: 99.803925%
- `PSMTXTranspose`: 99.75%
- `PSMTXInverse`: 100.0%
- `PSMTXRotRad`: 100.0%
- `PSMTXTransApply`: 100.0%
- `PSMTXScaleApply`: 100.0%
- `PSMTXQuat`: 99.87805%
- `PSMTXReflect`: 99.82143%

## Match evidence
- `objdiff` unit `.text` match for `main/mtx/mtx` before: **25.522137%**
- `objdiff` unit `.text` match for `main/mtx/mtx` after: **83.97099%**
- Improvement: **+58.448853 percentage points**

Verification command used:
```sh
build/tools/objdiff-cli diff -p . -u main/mtx/mtx -o - PSMTXIdentity
```

## Plausibility rationale
- The target unit expects `PSMTX*` symbols and GEKKO-specific paired-single implementations.
- `src/mtx/mtx.c` gates those implementations under `#ifdef GEKKO`.
- Defining `GEKKO` for this SDK library aligns compilation with the likely original GameCube build environment rather than introducing compiler-coaxing source changes.

## Technical details
- Previously, most `PSMTX*` symbols did not map in objdiff for `main/mtx/mtx`; only a few `C_MTX*` symbols were contributing score.
- After enabling `-DGEKKO` for the mtx library, objdiff maps and compares the expected `PSMTX*` symbol set with high fidelity.
