### PR TITLE
p_game: implement __sinit_p_game_cpp table initialization

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -1,6 +1,17 @@
 #include "ffcc/p_game.h"
 
 extern "C" void __sinit_p_game_cpp();
+extern unsigned int lbl_801E9EC0[];
+extern unsigned int lbl_801E9ECC[];
+extern unsigned int lbl_801E9ED8[];
+extern unsigned int lbl_801E9EE4[];
+extern unsigned int lbl_801E9EF0[];
+extern unsigned int lbl_801E9EFC[];
+extern unsigned int lbl_801E9F08[];
+extern unsigned int lbl_801E9F14[];
+extern unsigned int lbl_801E9F20[];
+extern unsigned int lbl_801EA0A8[];
+extern unsigned int GamePcs;
 extern "C" char lbl_801E9F2C[];
 
 /*
@@ -13,7 +24,46 @@ extern "C" char lbl_801E9F2C[];
  * JP Size: TODO
  */
 void __sinit_p_game_cpp() {
-    // Static initialization for p_game module
+    unsigned int* table = reinterpret_cast<unsigned int*>(lbl_801E9F2C);
+    unsigned int* desc0 = lbl_801E9EC0;
+    unsigned int* desc1 = lbl_801E9ECC;
+    unsigned int* desc2 = lbl_801E9ED8;
+    unsigned int* desc3 = lbl_801E9EE4;
+    unsigned int* desc4 = lbl_801E9EF0;
+    unsigned int* desc5 = lbl_801E9EFC;
+    unsigned int* desc6 = lbl_801E9F08;
+    unsigned int* desc7 = lbl_801E9F14;
+    unsigned int* desc8 = lbl_801E9F20;
+
+    GamePcs = reinterpret_cast<unsigned int>(lbl_801EA0A8);
+
+    table[1] = desc0[0];
+    table[2] = desc0[1];
+    table[3] = desc0[2];
+    table[4] = desc1[0];
+    table[5] = desc1[1];
+    table[6] = desc1[2];
+    table[7] = desc2[0];
+    table[8] = desc2[1];
+    table[9] = desc2[2];
+    table[10] = desc3[0];
+    table[11] = desc3[1];
+    table[12] = desc3[2];
+    table[13] = desc4[0];
+    table[14] = desc4[1];
+    table[15] = desc4[2];
+    table[16] = desc5[0];
+    table[17] = desc5[1];
+    table[18] = desc5[2];
+    table[19] = desc6[0];
+    table[20] = desc6[1];
+    table[21] = desc6[2];
+    table[22] = desc7[0];
+    table[23] = desc7[1];
+    table[24] = desc7[2];
+    table[25] = desc8[0];
+    table[26] = desc8[1];
+    table[27] = desc8[2];
 }
 
 /*
@@ -156,8 +206,12 @@ void CGamePcs::draw0()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800479f8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::draw1()
 {
@@ -166,8 +220,12 @@ void CGamePcs::draw1()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800479d0
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGamePcs::draw2()
 {


### PR DESCRIPTION
## Summary
- Implemented `__sinit_p_game_cpp` in `src/p_game.cpp` with explicit static table setup.
- Added symbol externs for the `p_game` descriptor blocks and vtable pointer target used by init.
- Added PAL address/size metadata for `CGamePcs::draw1` and `CGamePcs::draw2` from the PAL Ghidra export.

## Functions improved
- Unit: `main/p_game`
- Symbol: `__sinit_p_game_cpp` (328b)

## Match evidence
- `__sinit_p_game_cpp`: **1.2% -> 61.19512%**
  - Before value from `tools/agent_select_target.py` for `main/p_game`.
  - After value from `build/tools/objdiff-cli diff -p . -u main/p_game -o - __sinit_p_game_cpp`.
- No regression in nearby target wrappers:
  - `draw1__8CGamePcsFv`: 84.0%
  - `draw2__8CGamePcsFv`: 84.0%

## Plausibility rationale
- The new source follows existing project style for static process-table initializers (same explicit word-copy structure seen in other `__sinit_*` implementations such as `p_system`/`p_usb`).
- Changes represent concrete initialization semantics (table and pointer setup), not compiler-coaxing reorder tricks.

## Technical details
- `__sinit_p_game_cpp` now:
  - sets `GamePcs` to the `CGamePcs` vtable block pointer.
  - copies 9 descriptor triplets into `m_table__8CGamePcs` slots `[1..27]`.
- Verified with `ninja` build and per-symbol `objdiff-cli` checks on `main/p_game`.
