### PR TITLE
main/util: implement + ABI-correct GetSplinePos

### DIFF
--- a/include/ffcc/util.h
+++ b/include/ffcc/util.h
@@ -21,7 +21,7 @@ public:
     void SetVtxFmt_POS_CLR_TEX0_TEX1();
     void SetOrthoEnv();
     void GetNoise(unsigned char);
-    void GetSplinePos(Vec&, Vec&, Vec&, Vec&, Vec&, float, float);
+    void GetSplinePos(Vec&, Vec, Vec, Vec, Vec, float, float);
     void ConvI2FVector(Vec&, S16Vec, long);
     void ConvF2IVector(S16Vec&, Vec, long);
     void ConvF2IVector2d(S16Vec2d&, Vec2d, long);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -99,12 +99,39 @@ void CUtil::GetNoise(unsigned char)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800249ac
+ * PAL Size: 396b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::GetSplinePos(Vec&, Vec&, Vec&, Vec&, Vec&, float, float)
+void CUtil::GetSplinePos(Vec& out, Vec p0, Vec p1, Vec p2, Vec p3, float t, float scale)
 {
-	// TODO
+	Vec tan0;
+	Vec tan1;
+
+	PSVECSubtract(&p2, &p0, &tan0);
+	PSVECScale(&tan0, &tan0, scale);
+	PSVECSubtract(&p3, &p1, &tan1);
+	PSVECScale(&tan1, &tan1, scale);
+
+	float t2 = t * t;
+	float t3 = t2 * t;
+
+	extern float lbl_8032f8ac;
+	extern float lbl_8032f8b0;
+	extern float lbl_8032f8b4;
+	extern float lbl_8032f88c;
+
+	float h01 = (lbl_8032f8b4 * t3) + (lbl_8032f8b0 * t2);
+	float h00 = lbl_8032f88c + (lbl_8032f8ac * t3) - (lbl_8032f8b0 * t2);
+	float h10 = t - ((lbl_8032f8ac * t2) - t3);
+	float h11 = t3 - t2;
+
+	out.x = (h11 * tan1.x) + (h10 * tan0.x) + (h00 * p1.x) + (h01 * p2.x);
+	out.y = (h11 * tan1.y) + (h10 * tan0.y) + (h00 * p1.y) + (h01 * p2.y);
+	out.z = (h11 * tan1.z) + (h10 * tan0.z) + (h00 * p1.z) + (h01 * p2.z);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CUtil::GetSplinePos` in `src/util.cpp` using Hermite spline interpolation with tangent vectors derived from control point deltas.
- Corrected the function signature in `include/ffcc/util.h` and `src/util.cpp` to match shipped PAL ABI/mangling: first param by reference, remaining control points by value.
- Added versioned function header metadata for PAL address/size in `src/util.cpp`.

## Functions Improved
- Unit: `main/util`
- Symbol: `GetSplinePos__5CUtilFR3Vec3Vec3Vec3Vec3Vecff`

## Match Evidence
- Selector baseline for this symbol: `0.0%` (`tools/agent_select_target.py` output)
- Current symbol diff (`build/tools/objdiff-cli diff -p . -u main/util -o - GetSplinePos__5CUtilFR3Vec3Vec3Vec3Vec3Vecff`): `73.90909%`
- The symbol now resolves to a concrete target (`target_symbol: 10`) instead of unresolved/null matching caused by signature mismatch.

## Plausibility Rationale
- By-value `Vec` parameters are confirmed by the PAL map symbol name (`orig/GCCP01/game.MAP`), so this aligns ABI and likely original source intent.
- The implemented body follows standard Hermite spline basis math and uses existing Dolphin vector routines (`PSVECSubtract`, `PSVECScale`), which is idiomatic for this codebase.

## Technical Notes
- Prior to ABI fix, the emitted symbol was `GetSplinePos__5CUtilFR3VecR3VecR3VecR3VecR3Vecff` and could not match PAL symbol target.
- After ABI correction, mangling matches PAL symbol exactly and objdiff can compare real assembly.
