### PR TITLE
main/pppKeShpTail2X: match constructor/destructor init logic

### DIFF
--- a/include/ffcc/pppKeShpTail2X.h
+++ b/include/ffcc/pppKeShpTail2X.h
@@ -9,8 +9,8 @@ extern "C" {
 
 void pppKeShpTail2X(void);
 void pppKeShpTail2XDraw(void);
-void pppKeShpTail2XCon(void);
-void pppKeShpTail2XDes(void);
+void pppKeShpTail2XCon(void*, void*);
+void pppKeShpTail2XDes(void*, void*);
 void U8ToF32(pppFVECTOR4*, unsigned char*);
 
 #ifdef __cplusplus

--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -1,9 +1,15 @@
 #include "ffcc/pppKeShpTail2X.h"
+#include <dolphin/types.h>
+#include <string.h>
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80088e4c
+ * PAL Size: 992b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppKeShpTail2X(void)
 {
@@ -12,8 +18,12 @@ void pppKeShpTail2X(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80088748
+ * PAL Size: 1796b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppKeShpTail2XDraw(void)
 {
@@ -22,28 +32,56 @@ void pppKeShpTail2XDraw(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800886f0
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppKeShpTail2XCon(void)
+void pppKeShpTail2XCon(void* obj, void* param_2)
 {
-	// TODO
+	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
+	u8* tail = (u8*)obj + serializedOffset + 0x80;
+
+	*(u16*)(tail + 2) = 0;
+	*(u16*)(tail + 4) = 0;
+	*(u16*)(tail + 6) = 0;
+	tail[1] = 0;
+	tail[0] = 0x1f;
+	memset(tail + 8, 0, 0x174);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80088698
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppKeShpTail2XDes(void)
+void pppKeShpTail2XDes(void* obj, void* param_2)
 {
-	// TODO
+	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
+	u8* tail = (u8*)obj + serializedOffset + 0x80;
+
+	*(u16*)(tail + 2) = 0;
+	*(u16*)(tail + 4) = 0;
+	*(u16*)(tail + 6) = 0;
+	tail[1] = 0;
+	tail[0] = 0x1f;
+	memset(tail + 8, 0, 0x174);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void U8ToF32(pppFVECTOR4*, unsigned char*)
 {


### PR DESCRIPTION
## Summary
- Updated `pppKeShpTail2XCon` and `pppKeShpTail2XDes` signatures to accept object/config pointers used by the object system callback path.
- Implemented the shared tail initialization routine (offset decode, header reset, count seed, and `memset` of work area) in both functions.
- Added PAL address/size metadata in the project-standard INFO block format for this unit.

## Functions Improved
- Unit: `main/pppKeShpTail2X`
- Symbols:
  - `pppKeShpTail2XCon`
  - `pppKeShpTail2XDes`

## Match Evidence
- Before (selector baseline): `0/4` functions matched, unit match `0.5%`.
- After (`ninja` report): `2/4` functions matched, `matched_code=176/2964` (`5.94%`), fuzzy match `6.207827%`.
- Global progress delta from build output: function matches increased by `+2` (`1337 -> 1339`) and matched code by `+176` bytes (`190028 -> 190204`).

## Plausibility Rationale
- The implementation follows the existing coding pattern used in `pppKeShpTailCon`, including serialized offset decoding and tail buffer layout (`+0x80` base, control bytes, and cleared payload region).
- The code uses straightforward field initialization and library `memset`, which is consistent with plausible original game-source style rather than compiler-coaxing transformations.

## Technical Details
- objdiff target analysis for `main/pppKeShpTail2X` showed expected prologue/call sequence for `Con`/`Des` with `memset(..., 0x174)` and matching fixed field writes.
- Implemented exactly that control/data initialization sequence, leaving large `pppKeShpTail2X` and `pppKeShpTail2XDraw` TODO bodies unchanged for future focused passes.
