### PR TITLE
main/pppKeZCrctShp: improve pppKeZCrctShpDraw match

### DIFF
--- a/src/pppKeZCrctShp.cpp
+++ b/src/pppKeZCrctShp.cpp
@@ -13,74 +13,73 @@
  */
 void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
 {
-	Vec rowX, rowY, rowZ, rowPos;
-	Vec scaledX, scaledY, scaledZ;
-	Vec transformedPos;
-	Vec neutralVec = {0.0f, 0.0f, 0.0f};
-	pppFMATRIX transformMatrix;
-	pppFMATRIX worldMatrix;
-	pppFMATRIX cameraMatrix;
-	pppFMATRIX mgrMatrix;
-	
-	// Extract row vectors from object's local matrix
-	pppGetRowVector(pObject->m_localMatrix, rowX, rowY, rowZ, rowPos);
-	
-	// Scale the basis vectors
-	pppScaleVector(scaledX, rowX, pppMngStPtr->m_scale.x);
-	pppScaleVector(scaledY, rowY, pppMngStPtr->m_scale.y);
-	pppScaleVector(scaledZ, rowZ, pppMngStPtr->m_scale.z);
-	
-	// Set up transform matrix with scaled basis vectors
-	pppSetRowVector(transformMatrix, scaledX, scaledY, scaledZ, neutralVec);
-	
-	// Copy position vector
-	pppCopyVector(transformedPos, rowPos);
-	
-	// Apply scaling to position
-	transformedPos.x *= *(float *)(param2 + 0x18);
-	transformedPos.y *= *(float *)(param2 + 0x1c);
-	transformedPos.z *= *(float *)(param2 + 0x20);
-	
-	// Transform based on mode byte
-	unsigned char mode = *(unsigned char *)(param2 + 0x28);
-	
-	if (mode == 1) {
-		// Use world matrix directly
-		for (int i = 0; i < 3; i++) {
-			for (int j = 0; j < 4; j++) {
-				worldMatrix.value[i][j] = ppvWorldMatrix[i][j];
-			}
-		}
-		pppApplyMatrix(neutralVec, worldMatrix, transformedPos);
-	} else if (mode == 0) {
-		// Add offset and use world matrix
-		transformedPos.x += *(float *)(param2 + 8);
-		transformedPos.y += *(float *)(param2 + 0xc);
-		transformedPos.z += *(float *)(param2 + 0x10);
-		for (int i = 0; i < 3; i++) {
-			for (int j = 0; j < 4; j++) {
-				worldMatrix.value[i][j] = ppvWorldMatrix[i][j];
-			}
-		}
-		pppApplyMatrix(transformedPos, worldMatrix, transformedPos);
-	} else if (mode == 2) {
-		// Use manager matrix, then apply scaling and camera
-		for (int i = 0; i < 3; i++) {
-			for (int j = 0; j < 4; j++) {
-				mgrMatrix.value[i][j] = pppMngStPtr->m_matrix.value[i][j];
-			}
-		}
-		pppApplyMatrix(neutralVec, mgrMatrix, transformedPos);
-		
-		neutralVec.x = *(float *)(param2 + 8) * pppMngStPtr->m_scale.x + neutralVec.x;
-		neutralVec.y = *(float *)(param2 + 0xc) * pppMngStPtr->m_scale.y + neutralVec.y;
-		neutralVec.z = *(float *)(param2 + 0x10) * pppMngStPtr->m_scale.z + neutralVec.z;
-		
-		for (int i = 0; i < 3; i++) {
-			for (int j = 0; j < 4; j++) {
-				cameraMatrix.value[i][j] = ppvCameraMatrix0[i][j];
-			}
-		}
-		pppApplyMatrix(neutralVec, cameraMatrix, neutralVec);
-	}
+    Vec rowX;
+    Vec rowY;
+    Vec rowZ;
+    Vec rowPos;
+    Vec scaledX;
+    Vec scaledY;
+    Vec scaledZ;
+    Vec zeroVec;
+    Vec transformedPos;
+    pppFMATRIX transformMatrix;
+    pppFMATRIX cameraMatrix;
+    pppFMATRIX managerMatrix;
+    pppFMATRIX worldMatrixA;
+    pppFMATRIX worldMatrixB;
+
+    pppGetRowVector(pObject->m_localMatrix, rowX, rowY, rowZ, rowPos);
+
+    pppScaleVector(scaledX, rowX, pppMngStPtr->m_scale.x);
+    pppScaleVector(scaledY, rowY, pppMngStPtr->m_scale.y);
+    pppScaleVector(scaledZ, rowZ, pppMngStPtr->m_scale.z);
+
+    zeroVec.x = 0.0f;
+    zeroVec.y = 0.0f;
+    zeroVec.z = 0.0f;
+    pppSetRowVector(transformMatrix, scaledX, scaledY, scaledZ, zeroVec);
+
+    pppCopyVector(transformedPos, rowPos);
+
+    float scaledPosX = transformedPos.x * *(float*)(param2 + 0x18);
+    float scaledPosY = transformedPos.y * *(float*)(param2 + 0x1c);
+    float scaledPosZ = transformedPos.z * *(float*)(param2 + 0x20);
+
+    u8 mode = *(u8*)(param2 + 0x28);
+    transformedPos.x = scaledPosX;
+    transformedPos.y = scaledPosY;
+    transformedPos.z = scaledPosZ;
+
+    if (mode == 1) {
+        worldMatrixA = *(pppFMATRIX*)&ppvWorldMatrix;
+
+        Vec modePos;
+        modePos.x = scaledPosX;
+        modePos.y = scaledPosY;
+        modePos.z = scaledPosZ;
+        pppApplyMatrix(zeroVec, worldMatrixA, modePos);
+    } else if (mode == 0) {
+        float offsetPosX = scaledPosX + *(float*)(param2 + 8);
+        float offsetPosY = scaledPosY + *(float*)(param2 + 0xc);
+        float offsetPosZ = scaledPosZ + *(float*)(param2 + 0x10);
+
+        worldMatrixB = *(pppFMATRIX*)&ppvWorldMatrix;
+        transformedPos.x = offsetPosX;
+        transformedPos.y = offsetPosY;
+        transformedPos.z = offsetPosZ;
+        pppApplyMatrix(transformedPos, worldMatrixB, transformedPos);
+    } else if (mode < 3) {
+        managerMatrix = pppMngStPtr->m_matrix;
+        pppApplyMatrix(zeroVec, managerMatrix, transformedPos);
+
+        float cameraPosX = *(float*)(param2 + 8) * pppMngStPtr->m_scale.x + zeroVec.x;
+        float cameraPosY = *(float*)(param2 + 0xc) * pppMngStPtr->m_scale.y + zeroVec.y;
+        float cameraPosZ = *(float*)(param2 + 0x10) * pppMngStPtr->m_scale.z + zeroVec.z;
+
+        cameraMatrix = *(pppFMATRIX*)&ppvCameraMatrix0;
+        zeroVec.x = cameraPosX;
+        zeroVec.y = cameraPosY;
+        zeroVec.z = cameraPosZ;
+        pppApplyMatrix(zeroVec, cameraMatrix, zeroVec);
+    }
 }


### PR DESCRIPTION
## Summary
- Reworked `pppKeZCrctShpDraw` in `src/pppKeZCrctShp.cpp` to better match original code generation shape.
- Replaced loop-based matrix element copies with direct matrix assignments for world/camera/manager matrices.
- Adjusted temporary/local value flow to mirror decomp structure: explicit scaled position temporaries, branch-local vectors, and mode-specific transform paths.

## Functions improved
- Unit: `main/pppKeZCrctShp`
- Symbol: `pppKeZCrctShpDraw`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/pppKeZCrctShp -o - pppKeZCrctShpDraw`
- `.text` match before: `26.505226%`
- `.text` match after: `31.522648%`
- Improvement: `+5.017422%` on a 1148-byte function.

## Plausibility rationale
- The update moves the implementation away from compiler-coaxing loops and toward straightforward source patterns used in this codebase (direct matrix copies and explicit transform branches).
- Semantics remain aligned with existing behavior (same mode branches and transform operations), but local-variable and copy structure now better reflect likely original source layout.

## Technical details
- Build passes with `ninja`.
- Objdiff delta was measured on the symbol itself to confirm real assembly improvement rather than formatting-only changes.
