### PR TITLE
main/pppRandUpShort: improve RandF object reference matching

### DIFF
--- a/src/pppRandUpShort.cpp
+++ b/src/pppRandUpShort.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "types.h"
 
-extern CMath math;
+extern CMath math[];
 extern s32 lbl_8032ED70;
 extern f32 lbl_80330038;
 extern f64 lbl_80330040;
@@ -43,9 +43,9 @@ extern "C" void pppRandUpShort(void* param1, void* param2, void* param3)
 
     s32 state = *(s32*)(base + 0xC);
     if (state == 0) {
-        f32 value = RandF__5CMathFv(&math);
+        f32 value = RandF__5CMathFv(&math[0]);
         if (in->randomTwice != 0) {
-            value = (value + RandF__5CMathFv(&math)) * lbl_80330038;
+            value = (value + RandF__5CMathFv(&math[0])) * lbl_80330038;
         }
 
         valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);


### PR DESCRIPTION
## Summary
- Updated `src/pppRandUpShort.cpp` to reference `math` as an array (`extern CMath math[]`) and call `RandF__5CMathFv(&math[0])`.
- No logic change; this is a symbol/reference form alignment to better match the original object code address-loading pattern.

## Functions Improved
- Unit: `main/pppRandUpShort`
- Symbol: `pppRandUpShort`
- Size: `300b`

## Match Evidence
- `pppRandUpShort`: **86.26667% -> 91.333336%** (`+5.066666%`)
- Objdiff mismatch reduction:
  - `DIFF_ARG_MISMATCH`: `22 -> 13`
  - `DIFF_DELETE`: `3 -> 1`
  - `DIFF_REPLACE`: `8 -> 6`
  - `DIFF_INSERT`: `1 -> 1`

## Plausibility Rationale
- The change is source-plausible and idiomatic in this codebase: nearby rand units often treat `math` as array-backed storage and pass `&math[0]` to `RandF__5CMathFv`.
- Behavior is unchanged; only object-addressing form changed, which aligns with decompilation matching goals without introducing contrived control flow.

## Technical Details
- The previous form emitted less-aligned address setup around RandF calls.
- Switching to array-form access produced improved instruction-level alignment in objdiff while preserving code readability and semantics.
- Full build verified with `ninja` after the change.
