### PR TITLE
main/system: improve CSystem::Quit match with full teardown sequence

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -132,34 +132,36 @@ void CSystem::Init()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80021fb4
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CSystem::Quit()
 {
-	if (m_mapBuffer != nullptr)
-	{
-		delete[]m_mapBuffer;
-		m_mapBuffer = nullptr;
-	}
-	
-	if (m_mapStage != (CStage*)0x0)
-	{
-		// DestroyStage__7CMemoryFPQ27CMemory6CStage(&Memory,m_mapStage);
-	}
-	
-	/*
-	Quit__14CMemoryCardManFv(&MemoryCardMan);
-	Quit__8CFontManFv(&FontMan);
-	Quit__11CTextureManFv(&TextureMan);
-	Quit__12CMaterialManFv(&MaterialMan);
-	Quit__8CGraphicFv(&Graphic);
-	Quit__4CPadFv(&Pad);
-	Quit__5CFileFv(&File);
-	Quit__6CSoundFv(&Sound);
-	Quit__7CMemoryFv(&Memory);
-	Quit__5CMathFv(&Math);
-	*/
+    if (m_mapBuffer != nullptr)
+    {
+        delete[](unsigned char*)m_mapBuffer;
+        m_mapBuffer = nullptr;
+    }
+
+    if (m_mapStage != nullptr)
+    {
+        Memory.DestroyStage((CMemory::CStage*)m_mapStage);
+    }
+
+    MemoryCardMan.Quit();
+    FontMan.Quit();
+    TextureMan.Quit();
+    MaterialMan.Quit();
+    Graphic.Quit();
+    Pad.Quit();
+    File.Quit();
+    Sound.Quit();
+    Memory.Quit();
+    Math.Quit();
 }
 
 /*


### PR DESCRIPTION
## Summary
Replaced the `CSystem::Quit()` stub in `src/system.cpp` with a full shutdown sequence consistent with project patterns and Ghidra guidance.

Changes:
- Added versioned function info header for `CSystem::Quit()`.
- Implemented map buffer cleanup and map stage destruction.
- Restored subsystem shutdown order (`MemoryCardMan`, `FontMan`, `TextureMan`, `MaterialMan`, `Graphic`, `Pad`, `File`, `Sound`, `Memory`, `Math`).

## Functions improved
- Unit: `main/system`
- Symbol: `Quit__7CSystemFv`
- Size: `204b`

## Match evidence
- `Quit__7CSystemFv`: `31.156862%` -> `78.039215%`
- `main/system` unit fuzzy match: `46.886364%` -> `49.249012%`
- Verified with:
  - `ninja build/GCCP01/src/system.o build/GCCP01/report.json`
  - `tools/objdiff-cli diff -p . -u main/system -o - Quit__7CSystemFv --format json-pretty`

## Plausibility rationale
This patch removes placeholder/commented-out teardown calls and replaces them with direct, idiomatic object method calls in a realistic shutdown order used by the engine. The result is more plausible original source (actual subsystem teardown logic) rather than compiler-coaxing transformations.

## Technical details
- Preserved explicit `m_mapBuffer` nulling after free.
- Used `Memory.DestroyStage((CMemory::CStage*)m_mapStage)` to match declared type relationships in current headers.
- Kept the function focused on teardown logic only; no synthetic temporaries or non-idiomatic control-flow tricks were introduced.
