### PR TITLE
mtx: match PSMTXRotAxisRad by separating internal helper

### DIFF
--- a/src/mtx/mtx.c
+++ b/src/mtx/mtx.c
@@ -821,13 +821,21 @@ void C_MTXRotAxisRad(Mtx m, const Vec *axis, f32 rad)
 #ifdef GEKKO
 #define qr0 0
 
-void PSMTXRotAxisRad(register Mtx m, const Vec *axis, register f32 rad)
+/*
+ * --INFO--
+ * PAL Address: 0x80185d4c
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void __PSMTXRotAxisRadInternal(register f32 sT, register f32 cT, register Mtx m, const Vec *axis)
 {
+    register f32 rad;
     register f32 tmp0, tmp1, tmp2, tmp3, tmp4;
     register f32 tmp5, tmp6, tmp7, tmp8, tmp9;
 
-    register f32 sT;
-    register f32 cT;
     register f32 oneMinusCosT;
     register f32 zero;
     Vec axisNormalized;
@@ -835,8 +843,6 @@ void PSMTXRotAxisRad(register Mtx m, const Vec *axis, register f32 rad)
 
     zero = 0.0f;
     axisNormalizedPtr = &axisNormalized;
-    sT = sinf(rad);
-    cT = cosf(rad);
     oneMinusCosT = 1.0f - cT;
 
     PSVECNormalize(axis, axisNormalizedPtr);
@@ -871,6 +877,25 @@ void PSMTXRotAxisRad(register Mtx m, const Vec *axis, register f32 rad)
 		psq_st     tmp5, 0x28(m), 0, qr0
   }
 #endif // clang-format on
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80185dfc
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void PSMTXRotAxisRad(register Mtx m, const Vec *axis, register f32 rad)
+{
+    register f32 sT;
+    register f32 cT;
+
+    sT = sinf(rad);
+    cT = cosf(rad);
+    __PSMTXRotAxisRadInternal(sT, cT, m, axis);
 }
 
 #endif


### PR DESCRIPTION
## Summary
- Split `PSMTXRotAxisRad` into a thin wrapper plus explicit `__PSMTXRotAxisRadInternal` helper.
- Kept the existing GEKKO math/asm body intact, moved it into the internal helper, and made wrapper only compute `sinf/cosf` and delegate.
- Added function info headers with PAL address/size for both updated symbols.

## Functions improved
- Unit: `main/mtx/mtx` (`src/mtx/mtx.c`)
- `PSMTXRotAxisRad`: **0.0% -> 100.0%** (size 112)

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/mtx/mtx -o - | jq ...`
- Before:
  - `PSMTXRotAxisRad 0.0`
- After:
  - `PSMTXRotAxisRad 100.0`
- Build/progress also improved accordingly:
  - code bytes matched increased by 112 (from 190204 to 190316 in `ninja` progress output).

## Plausibility rationale
- This change reflects a credible original-source structure used in SDK-style math code: a public wrapper that computes trig values and an internal helper that performs the heavy matrix construction.
- No contrived temporaries were introduced solely for score manipulation; the math/asm body was preserved and relocated.

## Technical details
- The prior monolithic function shape produced a non-matching wrapper despite equivalent operations.
- Refactoring into explicit helper + wrapper aligned calling/prologue shape for `PSMTXRotAxisRad` while preserving behavior.
- `__PSMTXRotAxisRadInternal` now maps as a standalone symbol (still 0.0%), providing a cleaner next target for future matching work.
