### PR TITLE
wmm_str: improve GetYesNoXPos codegen match

### DIFF
--- a/src/wmm_str.cpp
+++ b/src/wmm_str.cpp
@@ -190,7 +190,7 @@ apply_font_yes:
 
     const int yesWidth = GetWidth__5CFontFPc(font, yesText + 1);
     short* windowInfo = *(short**)((char*)this + 0x848);
-    int x = (int)((windowInfo[2] - yesWidth) * 0.5f + windowInfo[0]);
+    int x = (int)(((double)(windowInfo[2] - yesWidth) * 0.5) + (double)windowInfo[0]);
     if (right != 0) {
         const int noWidth = GetWidth__5CFontFPc(font, lbl_8021672C[languageId - 1]);
         x += yesWidth - noWidth;


### PR DESCRIPTION
## Summary
- Adjusted `CMenuPcs::GetYesNoXPos` x-position calculation to use explicit double-based midpoint arithmetic before the integer cast.
- Kept control flow and data selection logic unchanged.

## Functions improved
- Unit: `main/wmm_str`
- Function: `GetYesNoXPos__8CMenuPcsFi`

## Match evidence
- `GetYesNoXPos__8CMenuPcsFi`: **53.604168% -> 55.218750%** (`+1.614582`)
- Checked with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/wmm_str -o - GetYesNoXPos__8CMenuPcsFi`
- Neighbor functions were rechecked and remained unchanged in score:
  - `GetSlotABXPos__8CMenuPcsFi`: 58.191917%
  - `GetMcWinMessBuff__8CMenuPcsFi`: 41.18%
  - `GetMcStr__8CMenuPcsFi`: 52.666668%

## Plausibility rationale
- This change models a typical original-source pattern in older C/C++ UI code: perform midpoint layout math in double precision, then truncate to integer pixel coordinates.
- No contrived temporaries, hardcoded offsets, or unnatural ordering were introduced.

## Technical details
- Updated expression in `src/wmm_str.cpp` within `CMenuPcs::GetYesNoXPos`:
  - from: `(int)((windowInfo[2] - yesWidth) * 0.5f + windowInfo[0])`
  - to: `(int)(((double)(windowInfo[2] - yesWidth) * 0.5) + (double)windowInfo[0])`
- This alters FP conversion/codegen shape in a way that improves objdiff alignment for the target symbol.
