### PR TITLE
main/gx/GXFrameBuf: improve copy-src function matches

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -107,32 +107,38 @@ void GXAdjustForOverscan(const GXRenderModeObj* rmin, GXRenderModeObj* rmout, u1
 }
 
 void GXSetDispCopySrc(u16 left, u16 top, u16 wd, u16 ht) {
+    GXData* gx;
+
     CHECK_GXBEGIN(1235, "GXSetDispCopySrc");
+    gx = __GXData;
 
-    __GXData->cpDispSrc = 0;
-    SET_REG_FIELD(1238, __GXData->cpDispSrc, 10,  0, left);
-    SET_REG_FIELD(1239, __GXData->cpDispSrc, 10, 10, top);
-    SET_REG_FIELD(1239, __GXData->cpDispSrc,  8, 24, 0x49);
+    gx->cpDispSrc = 0;
+    OLD_SET_REG_FIELD(1238, gx->cpDispSrc, 10, 0, left);
+    OLD_SET_REG_FIELD(1239, gx->cpDispSrc, 10, 10, top);
+    OLD_SET_REG_FIELD(1239, gx->cpDispSrc, 8, 24, 0x49);
 
-    __GXData->cpDispSize = 0;
-    SET_REG_FIELD(1243, __GXData->cpDispSize, 10,  0, wd - 1);
-    SET_REG_FIELD(1244, __GXData->cpDispSize, 10, 10, ht - 1);
-    SET_REG_FIELD(1244, __GXData->cpDispSize,  8, 24, 0x4A);
+    gx->cpDispSize = 0;
+    OLD_SET_REG_FIELD(1243, gx->cpDispSize, 10, 0, wd - 1);
+    OLD_SET_REG_FIELD(1244, gx->cpDispSize, 10, 10, ht - 1);
+    OLD_SET_REG_FIELD(1244, gx->cpDispSize, 8, 24, 0x4A);
 }
 
 
 void GXSetTexCopySrc(u16 left, u16 top, u16 wd, u16 ht) {
+    GXData* gx;
+
     CHECK_GXBEGIN(1263, "GXSetTexCopySrc");
+    gx = __GXData;
 
-    __GXData->cpTexSrc = 0;
-    SET_REG_FIELD(1266, __GXData->cpTexSrc, 10,  0, left);
-    SET_REG_FIELD(1267, __GXData->cpTexSrc, 10, 10, top);
-    SET_REG_FIELD(1267, __GXData->cpTexSrc,  8, 24, 0x49);
+    gx->cpTexSrc = 0;
+    OLD_SET_REG_FIELD(1266, gx->cpTexSrc, 10, 0, left);
+    OLD_SET_REG_FIELD(1267, gx->cpTexSrc, 10, 10, top);
+    OLD_SET_REG_FIELD(1267, gx->cpTexSrc, 8, 24, 0x49);
 
-    __GXData->cpTexSize = 0;
-    SET_REG_FIELD(1271, __GXData->cpTexSize, 10,  0, wd - 1);
-    SET_REG_FIELD(1272, __GXData->cpTexSize, 10, 10, ht - 1);
-    SET_REG_FIELD(1272, __GXData->cpTexSize,  8, 24, 0x4A);
+    gx->cpTexSize = 0;
+    OLD_SET_REG_FIELD(1271, gx->cpTexSize, 10, 0, wd - 1);
+    OLD_SET_REG_FIELD(1272, gx->cpTexSize, 10, 10, ht - 1);
+    OLD_SET_REG_FIELD(1272, gx->cpTexSize, 8, 24, 0x4A);
 }
 
 void GXSetDispCopyDst(u16 wd, u16 ht) {


### PR DESCRIPTION
## Summary
- Refactored `GXSetDispCopySrc` and `GXSetTexCopySrc` in `src/gx/GXFrameBuf.c` to use a local `GXData* gx = __GXData` and explicit `OLD_SET_REG_FIELD` writes.
- Kept behavior identical (same register fields and constants), but aligned emitted masking/or patterns with target assembly.

## Functions Improved
- `GXSetDispCopySrc`: `59.166668%` -> `96.80556%`
- `GXSetTexCopySrc`: `59.166668%` -> `96.80556%`
- Unit `.text` (`main/gx/GXFrameBuf`): `72.116806%` -> `75.34684%`

## Match Evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetDispCopySrc`
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetTexCopySrc`
- Remaining mismatches are register-allocation arg mismatches; major structural opcode diffs were removed.

## Plausibility Rationale
- This is a source-plausible change for GX SDK-style code: explicit register bitfield masking with local GX state is common and clearer than compiler-specific coercion.
- No contrived temporaries, no hardcoded struct offsets, and no behavior changes.

## Technical Details
- Switching these two functions from `SET_REG_FIELD` to `OLD_SET_REG_FIELD` produced the expected clear-mask/or codegen form for these register writes.
- Using a local `GXData*` reduced repeated global accesses and improved operand/register mapping toward the target.
