### PR TITLE
main/pppPointRAp: improve pppPointRApCon match to 100%

### DIFF
--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -31,7 +31,9 @@ static inline float pppTrigSample(s32 angle)
 void pppPointRApCon(_pppMngSt* mngSt, _pppPDataVal* dataVal)
 {
     u32* ctrlData = *(u32**)((u8*)dataVal + 0xC);
-    ((u8*)mngSt)[ctrlData[1] + 0x81] = 0;
+    u32 offset = ctrlData[1];
+    u8* state = (u8*)mngSt + offset;
+    state[0x81] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `pppPointRApCon` in `src/pppPointRAp.cpp` to use an explicit offset temporary and base pointer temporary before the byte store.
- This preserves behavior while steering codegen from indexed store form to the expected base+immediate store sequence.

## Functions improved
- Unit: `main/pppPointRAp`
- Symbol: `pppPointRApCon`
- Size: `24b`
- Match: `79.166664% -> 100.0%`

## Match evidence
- Before (`objdiff`): `lwz r4, 0x4(r4)` then `addi r0, r4, 0x81` + `stbx r5, r3, r0`
- After (`objdiff`): full symbol match at `100.0%`
- Build report impact after rebuild: matched code bytes increased (`190316 -> 190340`) and matched function count increased (`1340 -> 1341`).

## Plausibility rationale
- The new code is idiomatic and source-plausible: materializing `offset` and `state` temporaries is a natural C/C++ style and not compiler-coaxing noise.
- No magic constants or non-semantic control-flow tricks were introduced.

## Technical details
- Change is localized to `pppPointRApCon` only.
- Replaced direct indexed expression with:
  - `u32 offset = ctrlData[1];`
  - `u8* state = (u8*)mngSt + offset;`
  - `state[0x81] = 0;`
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/pppPointRAp -o - pppPointRApCon`.
