### PR TITLE
main/pppScreenQuake: match pppCon initializers

### DIFF
--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -18,17 +18,17 @@ extern int lbl_8032ED70;
 void pppConScreenQuake(pppScreenQuake *quake, UnkC *param2)
 {
 	float val = lbl_80331FC8;
-	float *data = (float *)((char *)&quake->field0_0x0 + 128 + *param2->m_serializedDataOffsets);
+	float* data = (float*)((char *)&quake->field0_0x0 + 128 + *param2->m_serializedDataOffsets);
 	
-	data[0] = val;
-	data[1] = val;
 	data[2] = val;
-	data[3] = val;
-	data[4] = val;
+	data[1] = val;
+	data[0] = val;
 	data[5] = val;
-	data[6] = val;
-	data[7] = val;
+	data[4] = val;
+	data[3] = val;
 	data[8] = val;
+	data[7] = val;
+	data[6] = val;
 }
 
 /*
@@ -43,17 +43,17 @@ void pppConScreenQuake(pppScreenQuake *quake, UnkC *param2)
 void pppCon2ScreenQuake(pppScreenQuake *quake, UnkC *param2)
 {
 	float val = lbl_80331FC8;
-	float *data = (float *)((char *)&quake->field0_0x0 + 128 + *param2->m_serializedDataOffsets);
+	float* data = (float*)((char *)&quake->field0_0x0 + 128 + *param2->m_serializedDataOffsets);
 	
-	data[0] = val;
-	data[1] = val;
 	data[2] = val;
-	data[3] = val;
-	data[4] = val;
+	data[1] = val;
+	data[0] = val;
 	data[5] = val;
-	data[6] = val;
-	data[7] = val;
+	data[4] = val;
+	data[3] = val;
 	data[8] = val;
+	data[7] = val;
+	data[6] = val;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated the initialization write order in `pppConScreenQuake` and `pppCon2ScreenQuake` in `src/pppScreenQuake.cpp`.
- Kept logic unchanged (all nine quake values are still initialized to `lbl_80331FC8`).
- Reshaped source statement order to match original compiler store scheduling.

## Functions Improved
- Unit: `main/pppScreenQuake`
- `pppConScreenQuake`: **99.6% -> 100.0%**
- `pppCon2ScreenQuake`: **99.6% -> 100.0%**

## Match Evidence
- Before (`objdiff`):
  - `pppConScreenQuake`: 99.6
  - `pppCon2ScreenQuake`: 99.6
  - unit `.text`: 89.18421
- After (`objdiff`):
  - `pppConScreenQuake`: 100.0
  - `pppCon2ScreenQuake`: 100.0
  - unit `.text`: 89.289474

## Plausibility Rationale
- This is source-plausible cleanup of assignment sequencing for a fixed-size parameter block.
- No synthetic temporaries, magic offsets, or non-idiomatic control flow were introduced.
- Behavior remains equivalent while improving binary correspondence.

## Technical Details
- `objdiff` mismatches were limited to argument/store-offset ordering in both constructor helpers.
- Reordering source stores to align with Metrowerks scheduling removed those diffs and closed both symbols to 100%.
