### PR TITLE
THPSimple: fix DVD callback symbol linkage for objdiff

### DIFF
--- a/include/ffcc/THPSimple.h
+++ b/include/ffcc/THPSimple.h
@@ -19,7 +19,7 @@ s32 THPSimpleClose(void);
 s32 THPSimpleCalcNeedMemory(void);
 s32 THPSimpleSetBuffer(u8*);
 void ReadFrameAsync();
-void __THPSimpleDVDCallback(long, DVDFileInfo*);
+void __THPSimpleDVDCallback__FlP11DVDFileInfo(long, DVDFileInfo*);
 s32 THPSimplePreLoad(s32);
 void THPSimpleAudioStart(void);
 void THPSimpleAudioStop(void);
@@ -33,6 +33,7 @@ void THPAudioMixCallback__Fv();
 
 #define MixAudio MixAudio__FPsPsUl
 #define THPAudioMixCallback THPAudioMixCallback__Fv
+#define __THPSimpleDVDCallback __THPSimpleDVDCallback__FlP11DVDFileInfo
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Adjusted THPSimple callback declaration to use the encoded symbol name under C linkage and aliased the readable identifier via macro.
- This removes a symbol-linkage/name mismatch that prevented objdiff from comparing the intended function symbol.

## Functions improved
- Unit: `main/THPSimple`
- Symbol: `__THPSimpleDVDCallback__FlP11DVDFileInfo` (PAL size 380b)

## Match evidence
- Before: target callback symbol was unmatched in objdiff due to emitted symbol name mismatch (`__THPSimpleDVDCallback`), so the expected mangled symbol had no usable comparison.
- After: callback is emitted as `__THPSimpleDVDCallback__FlP11DVDFileInfo` and now compares at ~`90.67%` in one-shot objdiff (`build/tools/objdiff-cli diff -p . -u main/THPSimple -o - __THPSimpleDVDCallback__FlP11DVDFileInfo`).
- Report view after change: `build/GCCP01/report.json` shows `__THPSimpleDVDCallback__FlP11DVDFileInfo` at `90.83158%` fuzzy match.

## Plausibility rationale
- The codebase already uses this exact strategy for symbols like `MixAudio__FPsPsUl` and `THPAudioMixCallback__Fv` in `THPSimple.h`.
- This change is ABI/linkage-corrective and source-plausible (it aligns declaration naming with known Metrowerks symbol conventions) rather than compiler-coaxing control-flow changes.

## Technical details
- File changed: `include/ffcc/THPSimple.h`
- Replaced callback declaration:
  - `void __THPSimpleDVDCallback(long, DVDFileInfo*);`
  - -> `void __THPSimpleDVDCallback__FlP11DVDFileInfo(long, DVDFileInfo*);`
- Added alias macro:
  - `#define __THPSimpleDVDCallback __THPSimpleDVDCallback__FlP11DVDFileInfo`
- Validation:
  - `ninja` passes successfully.
  - Objdiff confirms symbol-level improvement and correct symbol alignment.
