### PR TITLE
Implement first-pass pppFrameChangeTex logic

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -1,6 +1,8 @@
 #include "ffcc/pppChangeTex.h"
 #include "ffcc/graphic.h"
 #include "dolphin/gx.h"
+#include <string.h>
+#include <dolphin/os/OSCache.h>
 
 struct _pppMngStChangeTex {
 	char _pad0[0xd8];
@@ -18,16 +20,31 @@ extern void SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(void*, vo
 extern void GXCallDisplayList(void*, unsigned int);
 extern _pppMngStChangeTex* pppMngStPtr;
 extern _pppEnvStChangeTex* lbl_8032ED54;
+extern _pppEnvStChangeTex* pppEnvStPtr;
 extern float FLOAT_80332040;
+extern float FLOAT_80332020;
+extern float FLOAT_80332028;
+extern double DOUBLE_80332030;
+extern double DOUBLE_80332038;
+extern char DAT_80332024[];
+extern char DAT_8032ec70[];
+extern int DAT_8032ed70;
+extern char DAT_8032ed78;
+extern char s_pppChangeTex_cpp_801dd660[];
 
 extern "C" {
-	int GetTexture__8CMapMeshFP12CMaterialSetRi(CMapMesh* mapMesh, CMaterialSet* materialSet, int& textureIndex);
-	void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int stage, int rasSel, int texSel);
-	void pppInitBlendMode__Fv(void);
+		int GetTexture__8CMapMeshFP12CMaterialSetRi(CMapMesh* mapMesh, CMaterialSet* materialSet, int& textureIndex);
+		void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int stage, int rasSel, int texSel);
+		void pppInitBlendMode__Fv(void);
 	void _WaitDrawDone__8CGraphicFPci(CGraphic* graphic, const char* file, int line);
-	void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
-	int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
-	void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
+		void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
+		int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
+		void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
+		void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
+		int GetTextureFromRSD__FiP9_pppEnvSt(int, _pppEnvStChangeTex*);
+		void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
+		void ReWriteDisplayList__5CUtilFPvUlUl(void*, void*, unsigned long, unsigned long);
+		void CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl(void*, void*, void*, void*, unsigned long, unsigned long);
 }
 
 /*
@@ -307,25 +324,144 @@ void pppDestructChangeTex(pppChangeTex* changeTex, UnkC* data)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameChangeTex(pppChangeTex*, UnkB*, UnkC*)
+void pppFrameChangeTex(pppChangeTex* changeTex, UnkB* step, UnkC* data)
 {
-	// TODO: This is a very complex function that needs proper type definitions
-	// Basic structure from Ghidra decomp shows:
-	// - Checks DAT_8032ed70 == 0
-	// - Gets character handles and models
-	// - Calls CalcGraphValue
-	// - Sets up callback functions
-	// - Allocates memory for display list modifications
-	// - Processes texture animations based on vertex positions
-	// - Handles different payload types (0x01, 0x02)
-	
-	// This requires extensive type definitions and external function declarations
-	// that aren't available yet. Will need:
-	// - pppChangeTex type definition
-	// - UnkB, UnkC type definitions  
-	// - Various ppp* functions
-	// - Character system functions
-	// - Memory allocation functions
+	if (DAT_8032ed70 != 0) {
+		return;
+	}
+
+	int dataValOffset = data->m_serializedDataOffsets[1];
+	float* value = (float*)((char*)changeTex + data->m_serializedDataOffsets[2] + 0x80);
+
+	void* handle0 = GetCharaHandlePtr__FP8CGObjectl(pppMngStPtr->m_charaObj, 0);
+	int model0 = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle0);
+
+	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+	    (float)step->m_initWOrk, &changeTex->field0_0x0, step->m_graphId, value, value + 1, value + 2,
+	    &step->m_stepValue, (float*)&step->m_arg3);
+
+	((int*)value)[6] = (int)pppMngStPtr->m_charaObj;
+	((int*)value)[9] = (int)pppEnvStPtr;
+	*(float**)(model0 + 0xE4) = value;
+	*(UnkB**)(model0 + 0xE8) = step;
+	*(void**)(model0 + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback;
+	*(void**)(model0 + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback;
+
+	value[7] = (float)GetTextureFromRSD__FiP9_pppEnvSt(step->m_dataValIndex, pppEnvStPtr);
+
+	void* handle1 = GetCharaHandlePtr__FP8CGObjectl((void*)((int*)value)[6], 1);
+	void* handle2 = GetCharaHandlePtr__FP8CGObjectl((void*)((int*)value)[6], 2);
+
+	if (handle1 != 0) {
+		int model1 = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle1);
+		if (model1 != 0) {
+			*(float**)(model1 + 0xE4) = value;
+			*(UnkB**)(model1 + 0xE8) = step;
+			*(void**)(model1 + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback;
+			*(void**)(model1 + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback;
+		}
+	}
+
+	if (handle2 != 0) {
+		int model2 = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle2);
+		if (model2 != 0) {
+			*(float**)(model2 + 0xE4) = value;
+			*(UnkB**)(model2 + 0xE8) = step;
+			*(void**)(model2 + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback;
+			*(void**)(model2 + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback;
+		}
+	}
+
+	if (step->m_payload[0] == 0) {
+		return;
+	}
+
+	float texObj = (float)GetTextureFromRSD__FiP9_pppEnvSt(step->m_dataValIndex, pppEnvStPtr);
+	if (texObj == 0.0f) {
+		return;
+	}
+	value[7] = texObj;
+
+	int meshList = *(int*)(model0 + 0xAC);
+	unsigned int meshCount = *(unsigned int*)(*(int*)(model0 + 0xA4) + 0xC);
+
+	if (((int*)value)[3] == 0 && ((int*)value)[4] == 0) {
+		value[17] = FLOAT_80332020;
+		((int*)value)[3] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+		    meshCount << 2, pppEnvStPtr->m_stagePtr, s_pppChangeTex_cpp_801dd660, 0x163);
+		((int*)value)[4] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+		    meshCount << 2, pppEnvStPtr->m_stagePtr, s_pppChangeTex_cpp_801dd660, 0x166);
+
+		int* meshColorArrays = (int*)((int*)value)[3];
+		int allocIndex = 0;
+		int curMesh = meshList;
+		for (unsigned int meshIdx = 0; meshIdx < meshCount; meshIdx++) {
+			int meshHdr = *(int*)(curMesh + 8);
+			if (strcmp((char*)meshHdr, DAT_80332024) == 0) {
+				CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl(
+				    DAT_8032ec70, value + 10, value + 14, *(void**)(curMesh + 0xC), *(unsigned long*)(meshHdr + 0x14),
+				    *(unsigned long*)(*(int*)(model0 + 0xA4) + 0x34));
+			}
+
+			*(int*)(((int*)value)[4] + allocIndex) = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+			    *(int*)(meshHdr + 0x4C) << 2, pppEnvStPtr->m_stagePtr, s_pppChangeTex_cpp_801dd660, 0x181);
+
+			int dlCount = *(int*)(meshHdr + 0x4C);
+			int* dlInfo = (int*)(*(int*)(meshHdr + 0x50));
+			int* dlEntry = (int*)(*(int*)(((int*)value)[4] + allocIndex) + (dlCount - 1) * 4);
+			for (int dlIdx = dlCount - 1; dlIdx >= 0; dlIdx--) {
+				int dlPair = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+				    8, pppEnvStPtr->m_stagePtr, s_pppChangeTex_cpp_801dd660, 0x18B);
+				*dlEntry = dlPair;
+				*(int*)(dlPair + 4) = dlInfo[0];
+				*(int*)dlPair = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+				    dlInfo[0], pppEnvStPtr->m_stagePtr, s_pppChangeTex_cpp_801dd660, 0x18D);
+				memcpy(*(void**)dlPair, (void*)dlInfo[1], dlInfo[0]);
+				ReWriteDisplayList__5CUtilFPvUlUl(DAT_8032ec70, *(void**)dlPair, (unsigned long)dlInfo[0], 1);
+				dlEntry--;
+				dlInfo += 3;
+			}
+
+			meshColorArrays[meshIdx] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+			    *(int*)(meshHdr + 0x14) << 2, pppEnvStPtr->m_stagePtr, s_pppChangeTex_cpp_801dd660, 0x196);
+			memset((void*)meshColorArrays[meshIdx], 0, *(int*)(meshHdr + 0x14) << 2);
+
+			allocIndex += 4;
+			curMesh += 0x14;
+		}
+	}
+
+	if (DAT_8032ed78 == 0) {
+		float currentValue = value[0] * (value[15] - value[11]) + value[11];
+		short splitY = (short)(int)(currentValue * (float)((double)(1 << *(int*)(*(int*)(model0 + 0xA4) + 0x34)) - DOUBLE_80332030));
+		if (value[17] != currentValue) {
+			value[17] = currentValue;
+
+			double d = (double)(unsigned char)*((char*)changeTex + dataValOffset + 0x8B);
+			double alphaBase = (double)(FLOAT_80332028 * ((float)(d - DOUBLE_80332038) / FLOAT_80332028));
+
+			int meshColorOffset = 0;
+			int curMesh = meshList;
+			for (unsigned int meshIdx = 0; meshIdx < meshCount; meshIdx++) {
+				int pointOffset = 0;
+				int colorPtr = *(int*)(((int*)value)[3] + meshColorOffset);
+				unsigned int vertCount = *(unsigned int*)(*(int*)(curMesh + 8) + 0x14);
+				for (unsigned int v = 0; v < vertCount; v++) {
+					short y = *(short*)(*(int*)(curMesh + 0xC) + pointOffset + 2);
+					if (step->m_payload[0] == 1) {
+						*(unsigned char*)(colorPtr + 3) = (y < splitY) ? (unsigned char)(int)alphaBase : 0;
+					} else if (step->m_payload[0] == 2) {
+						*(unsigned char*)(colorPtr + 3) = (splitY < y) ? (unsigned char)(int)alphaBase : 0;
+					}
+					pointOffset += 6;
+					colorPtr += 4;
+				}
+				DCFlushRange(*(void**)(((int*)value)[3] + meshColorOffset), vertCount << 2);
+				meshColorOffset += 4;
+				curMesh += 0x14;
+			}
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass body for `pppFrameChangeTex` in `src/pppChangeTex.cpp`, replacing the prior TODO stub.
- Added required external declarations and includes (`<string.h>`, `OSCache`) used by the function body.
- Wired runtime behavior consistent with surrounding effect code: graph value update, model callback setup, texture lookup, staged allocation for per-mesh display-list/color data, and per-vertex alpha updates with cache flush.

## Functions Improved
- Unit: `main/pppChangeTex`
- Symbol: `pppFrameChangeTex`

## Match Evidence
- `pppFrameChangeTex` match improved from **0.30959752%** to **54.727554%** (`objdiff-cli diff -p . -u main/pppChangeTex -o - pppFrameChangeTex`).
- Improvement is structural: function now emits substantial control-flow/data-flow aligned with original behavior instead of a stub.

## Plausibility Rationale
- The new implementation follows the same source patterns used in nearby decomped particle/effect units (notably `pppYmChangeTex`) and the provided Ghidra reference for this symbol.
- Changes are behavior-oriented (callback wiring, memory ownership, per-vertex update path) rather than artificial compiler coaxing.
- This is an intentional first pass on a previously near-empty large function, prioritizing restoring plausible original logic before fine-grained instruction matching.

## Technical Notes
- This function remains a large candidate for iterative refinement (types/aliasing/temporary shaping) to close the remaining gap.
- Full build verification passed: `build/GCCP01/main.dol: OK`.
