### PR TITLE
mes: correct CMes::SetPosition storage offsets

### DIFF
--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -172,11 +172,8 @@ void CMes::Draw()
  */
 void CMes::SetPosition(float x, float y)
 {
-	// Store position in data array (using offsets that might match original)
-	float* xPos = (float*)&mData[0x0C];
-	float* yPos = (float*)&mData[0x10];
-	*xPos = x;
-	*yPos = y;
+	*(float*)&mData[0x3c90] = x;
+	*(float*)&mData[0x3c94] = y;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CMes::SetPosition(float, float)` in `src/mes.cpp` to store coordinates at the decomp-validated message state offsets.
- Removed temporary local pointer indirection and wrote directly to the backing data region.

## Functions improved
- `main/mes`
- `SetPosition__4CMesFff`

## Match evidence
- `SetPosition__4CMesFff`: **99.333336% -> 100.0%**
- Instruction alignment now matches target exactly:
  - target/current: `stfs f1, 0x3c9c(r3)`
  - target/current: `stfs f2, 0x3ca0(r3)`

## Plausibility rationale
- This change reflects a source-plausible correction: the method writes message position into the intended persistent state block, rather than low offsets that conflict with observed target layout.
- No compiler-coaxing patterns were added; the change is a direct semantic fix to member storage offsets.

## Technical details
- Previous implementation stored to `mData[0x0C]`/`mData[0x10]` (`0x18/0x1C` from `this`), which produced a consistent two-instruction mismatch.
- New implementation stores to `mData[0x3C90]`/`mData[0x3C94]`, yielding target stores at `0x3C9C/0x3CA0` and full function match.
