### PR TITLE
RedMemory: improve delete pointer-wrapper matching

### DIFF
--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -152,10 +152,12 @@ void RedDelete(int address)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 void RedDelete(void* param_1)
 {
 	RedDelete((int)param_1);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--
@@ -297,10 +299,12 @@ void RedDeleteA(int address)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 void RedDeleteA(void* param_1)
 {
 	RedDeleteA((int)param_1);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added `#pragma dont_inline` guards around `RedDelete(void*)` and `RedDeleteA(void*)` in `src/RedSound/RedMemory.cpp`.
- Kept function behavior unchanged; wrappers still forward to the integer overloads.
- This prevents Metrowerks from inlining the full delete bodies into the pointer wrappers.

## Functions improved
- Unit: `main/RedSound/RedMemory`
- Symbols:
  - `RedDelete__FPv`: `0.0%` -> `79.4%`
  - `RedDeleteA__FPv`: `0.0%` -> `79.4%`

## Match evidence
- `objdiff` symbol check (`build/tools/objdiff-cli diff -p . -u main/RedSound/RedMemory -o - RedDelete__FPv`): both pointer-wrapper symbols now partially match instead of 0%.
- Unit `.text` match improved from `53.006927` to `56.674366`.
- Build still passes (`ninja`).

## Plausibility rationale
- These are small overload wrappers whose intended role is to forward pointer inputs to existing integer-based delete routines.
- Using Metrowerks `dont_inline` pragma in this context is source-plausible and aligns with existing codebase usage where inlining control is needed for exact binary shape.

## Technical details
- Before this change, wrapper compilation produced non-matching codegen for these tiny overloads.
- Disassembly/objdiff confirmed the wrappers were not compiling to the expected callable form for the target binary; forcing non-inline emission moved both functions off 0% and improved unit-level text match.
