### PR TITLE
prgobj: implement changeStat and reqAnim

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -151,12 +151,27 @@ void CGPrgObj::onChangePrg(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127838
+ * PAL Size: 164b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::changeStat(int, int, int)
+void CGPrgObj::changeStat(int state, int subState, int stateArg)
 {
-	// TODO
+	int oldState = getReplaceStat(state);
+	if (oldState != -1) {
+		onCancelStat(state);
+		m_stateArg = stateArg;
+		onChangeStat(state);
+		m_lastStateId = oldState;
+		m_stateFrame = 0;
+		m_stateFrameGate = 1;
+		m_subState = subState;
+		m_subFrame = 0;
+		m_subFrameGate = 1;
+	}
 }
 
 /*
@@ -185,12 +200,19 @@ void CGPrgObj::addSubStat()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801277C8
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::reqAnim(int, int, int)
+void CGPrgObj::reqAnim(int animId, int loop, int direct)
 {
-	// TODO
+	m_animFlags = (m_animFlags & 0x7f) | 0x80;
+	m_reqAnimId = animId;
+	m_animFlags = ((loop << 6) & 0x40) | (m_animFlags & 0xbf);
+	m_animFlags = ((direct << 5) & 0x20) | (m_animFlags & 0xdf);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement two previously-stubbed `CGPrgObj` state/animation helpers in `src/prgobj.cpp` and update their function metadata blocks with PAL address/size info.

- Implemented `CGPrgObj::changeStat(int state, int subState, int stateArg)`
- Implemented `CGPrgObj::reqAnim(int animId, int loop, int direct)`
- Added PAL metadata blocks for both functions

## Functions improved
Unit: `main/prgobj`

- `reqAnim__8CGPrgObjFiii`: **7.142857% -> 62.142857%**
- `changeStat__8CGPrgObjFiii`: **2.4390244% -> 37.02439%**
- Unit fuzzy score (`main/prgobj`): **12.441217% -> 15.467497%**

## Match evidence
Built with `ninja` successfully (including report generation), then compared `build/GCCP01/report.json` against a pre-change report:

- Before: `/tmp/report_before.json`
- After: `build/GCCP01/report.json`

This change improves real generated code alignment for two formerly TODO stubs and raises the unit-level fuzzy score by ~3.03 points.

## Plausibility rationale
The implementation follows existing codebase semantics rather than compiler-coax patterns:

- `changeStat` now uses the expected state-transition flow (`getReplaceStat`, cancel/change callbacks, frame/substate gate resets).
- `reqAnim` now sets animation request flags/fields with straightforward bitmask updates matching established `m_animFlags` usage in `CGPrgObj::onFrame`.

No contrived temporaries, hardcoded offsets, or assembly-shaped control flow were introduced.

## Technical details
- `changeStat` updates:
  - `m_stateArg`, `m_lastStateId`
  - `m_stateFrame`, `m_stateFrameGate`
  - `m_subState`, `m_subFrame`, `m_subFrameGate`
- `reqAnim` updates:
  - sets request bit `0x80`
  - writes `m_reqAnimId`
  - applies loop/direct bits (`0x40`, `0x20`)
