### PR TITLE
gx: improve GXSetProjectionv match in GXTransform

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -99,18 +99,28 @@ void GXSetProjection(const Mtx44 mtx, GXProjectionType type) {
 }
 
 void GXSetProjectionv(const f32* ptr) {
+    GXData* gx = __GXData;
+
     CHECK_GXBEGIN(339, "GXSetProjectionv");
 
-    __GXData->projType = __cvt_fp2unsigned((f64)ptr[0]);
-    __GXData->projMtx[0] = ptr[1];
-    __GXData->projMtx[1] = ptr[2];
-    __GXData->projMtx[2] = ptr[3];
-    __GXData->projMtx[3] = ptr[4];
-    __GXData->projMtx[4] = ptr[5];
-    __GXData->projMtx[5] = ptr[6];
+    gx->projType = __cvt_fp2unsigned((f64)ptr[0]);
+    gx->projMtx[0] = ptr[1];
+    gx->projMtx[1] = ptr[2];
+    gx->projMtx[2] = ptr[3];
+    gx->projMtx[3] = ptr[4];
+    gx->projMtx[4] = ptr[5];
+    gx->projMtx[5] = ptr[6];
 
-    __GXSetProjection();
-    __GXData->bpSentNot = 1;
+    GX_WRITE_U8(0x10);
+    GX_WRITE_U32(0x00061020);
+    GX_WRITE_F32(gx->projMtx[0]);
+    GX_WRITE_F32(gx->projMtx[1]);
+    GX_WRITE_F32(gx->projMtx[2]);
+    GX_WRITE_F32(gx->projMtx[3]);
+    GX_WRITE_F32(gx->projMtx[4]);
+    GX_WRITE_F32(gx->projMtx[5]);
+    GX_WRITE_U32(gx->projType);
+    gx->bpSentNot = 1;
 }
 
 #define qr0 0


### PR DESCRIPTION
## Summary
- Refactored `GXSetProjectionv` in `src/gx/GXTransform.c` to emit XF projection data directly via FIFO writes after updating cached `GXData` fields.
- Kept behavior and API unchanged while shifting to a source shape that more closely matches the target code generation pattern.

## Functions Improved
- Unit: `main/gx/GXTransform`
- Function: `GXSetProjectionv`
  - Before: `64.50000%`
  - After: `77.08334%`
  - Delta: `+12.58334%`

## Match Evidence
- `build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetProjectionv`
  - Result now reports `GXSetProjectionv` at `77.083336`.
- Unit `.text` match for `main/gx/GXTransform` also improved:
  - Before: `77.912605%`
  - After: `79.14024%`

## Plausibility Rationale
- The new implementation writes projection registers in a straightforward, hardware-facing sequence that is idiomatic for GX internals.
- The change removes indirection through `__GXSetProjection` only in this call path, matching a plausible original handwritten fast path rather than compiler-coaxing artifacts.

## Technical Details
- Introduced a local `GXData* gx` and retained existing cached-state updates.
- Replaced helper call with explicit `GX_WRITE_U8/U32/F32` emissions for six projection matrix values and `projType`.
- Preserved `bpSentNot` update semantics.
