### PR TITLE
Improve matching for pppDrawShape2 unit

### DIFF
--- a/src/pppDrawShape2.cpp
+++ b/src/pppDrawShape2.cpp
@@ -9,9 +9,9 @@ extern void pppSetBlendMode__FUc(unsigned char);
 extern void pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(void*, void*, unsigned char);
 
 typedef struct ShapeState {
-    s16 value;
-    s16 counter;
-    s16 currentId;
+    u16 value;
+    u16 counter;
+    u16 currentId;
 } ShapeState;
 
 typedef struct ShapeRuntimeData {
@@ -20,24 +20,22 @@ typedef struct ShapeRuntimeData {
 } ShapeRuntimeData;
 
 typedef struct ShapeSpecEntry {
-    s16 _unk0;
-    s16 maxValue;
+    s16 offset;
+    u16 maxValue;
     u8 flags;
 } ShapeSpecEntry;
 
 typedef struct ShapeControlData {
     u8 _pad0[4];
-    s16 type;
-    u8 _pad1[2];
-    s32 step;
+    u32 type;
+    u32 step;
     u8 _pad2[1];
     u8 blendMode;
-    u8 alpha;
+    u8 paramE;
     u8 _pad3[1];
     f32 scale;
-    u8 _pad4[4];
-    u8 red;
-    u8 green;
+    u8 param14;
+    u8 param15;
 } ShapeControlData;
 
 /*
@@ -70,55 +68,43 @@ void pppDrawShape2Construct(void* param1, void* param2)
  */
 void pppCalcShape2(void* param1, void* param2, void* param3)
 {
-    ShapeState* shapeData;
-    ShapeRuntimeData* runtimeData;
-    ShapeControlData* controlData;
-    s16 currentId;
-    s16 value;
-    s16 maxValue;
-    s16 counter;
-    void* shapeSpec;
-    ShapeSpecEntry* currentShape;
-
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    runtimeData = *(ShapeRuntimeData**)((u8*)param3 + 0xC);
-    controlData = (ShapeControlData*)param2;
-    shapeData = (ShapeState*)((u8*)param1 + runtimeData->shapeDataOffset + 0x80);
+    ShapeRuntimeData* runtimeData = *(ShapeRuntimeData**)((u8*)param3 + 0xC);
+    ShapeControlData* controlData = (ShapeControlData*)param2;
+    ShapeState* shapeData = (ShapeState*)((u8*)param1 + runtimeData->shapeDataOffset + 0x80);
+    u32 type = controlData->type;
 
-    if ((u16)controlData->type == 0xFFFF) {
+    if (type == 0xFFFF) {
         return;
     }
 
-    shapeSpec = ((void**)*(void**)((u8*)lbl_8032ED54 + 0xC))[controlData->type];
+    void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
+    void* shapeSpec = *(void**)((u8*)shapeTables + (type << 2));
+    ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->counter << 3) + 0x10);
 
-    currentId = shapeData->counter;
-    shapeData->currentId = currentId;
-    currentShape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)currentId << 3) + 0x10);
+    shapeData->currentId = shapeData->counter;
+    shapeData->value = (u16)(shapeData->value + controlData->step);
+    if (shapeData->value < shape->maxValue) {
+        return;
+    }
+    shapeData->value = (u16)(shapeData->value - shape->maxValue);
 
-    value = shapeData->value + controlData->step;
-    shapeData->value = value;
-
-    maxValue = currentShape->maxValue;
-    if (value >= maxValue) {
-        value -= maxValue;
-        shapeData->value = value;
+    shapeData->counter++;
+    if (shapeData->counter < (u16)*(s16*)((u8*)shapeSpec + 0x6)) {
+        return;
     }
 
-    counter = shapeData->counter + 1;
-    shapeData->counter = counter;
-
-    if (counter >= *(s16*)((u8*)shapeSpec + 0x6)) {
-        if ((currentShape->flags & 0x80) != 0) {
-            shapeData->value = 0;
-            shapeData->counter = 0;
-        } else {
-            shapeData->value = 0;
-            shapeData->counter = currentId;
-        }
+    if ((shape->flags & 0x80) != 0) {
+        shapeData->counter = 0;
+        shapeData->value = 0;
+        return;
     }
+
+    shapeData->value = 0;
+    shapeData->counter--;
 }
 
 /*
@@ -136,28 +122,30 @@ void pppDrawShape2(void* param1, void* param2, void* param3)
     ShapeControlData* controlData = (ShapeControlData*)param2;
     ShapeState* shapeData = (ShapeState*)((u8*)param1 + runtimeData->shapeDataOffset + 0x80);
     void* posData = (u8*)param1 + runtimeData->posDataOffset + 0x80;
+    u32 type = controlData->type;
 
-    if ((u16)controlData->type == 0xFFFF) {
+    if (type == 0xFFFF) {
         return;
     }
 
     void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
-    void* shapeSpec = *(void**)((u8*)shapeTables + ((u32)controlData->type << 2));
+    void* shapeSpec = *(void**)((u8*)shapeTables + (type << 2));
     ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->currentId << 3) + 0x10);
+    void* drawShape = (u8*)shapeSpec + shape->offset;
 
     pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
-        posData,
+        (u8*)posData + 8,
         (u8*)param1 + 0x40,
         controlData->scale,
+        controlData->param15,
+        controlData->paramE,
         controlData->blendMode,
-        controlData->alpha,
-        controlData->blendMode,
-        controlData->red,
-        controlData->green,
         0,
+        controlData->param14,
+        1,
         0
     );
 
     pppSetBlendMode__FUc(controlData->blendMode);
-    pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(shape, *(void**)((u8*)lbl_8032ED54 + 0x4), controlData->blendMode);
+    pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(drawShape, *(void**)((u8*)lbl_8032ED54 + 0x4), controlData->blendMode);
 }


### PR DESCRIPTION
## Summary
- Reworked `src/pppDrawShape2.cpp` state/control structs to match observed unsigned/sized field usage in generated code.
- Aligned `pppCalcShape2` flow with expected progression semantics: early return before frame advance, wrap handling, and terminal counter behavior.
- Aligned `pppDrawShape2` draw path with expected shape selection and draw-env argument ordering, including draw-shape offset usage and color/env flag packing.

## Functions improved
- `main/pppDrawShape2::pppDrawShape2`: **76.71698% -> 88.49056%**
- `main/pppDrawShape2::pppCalcShape2`: **80.43137% -> 82.254906%**
- Unit `main/pppDrawShape2`: **80.24779% -> 86.59292%**

## Match evidence
- Objdiff indicated prior mismatches in signed-vs-unsigned loads (`lha`/`extsh` vs `lhz`), control-flow shape (`blt` branch body vs `bltlr` early return), and terminal counter writeback (`counter = currentId` vs post-increment decrement path).
- After changes, both symbols moved substantially toward target assembly, with the largest gain in `pppDrawShape2` from corrected draw-shape pointer and call argument packing.

## Plausibility rationale
- Changes follow established source patterns already present in sibling unit `src/pppDrawShape.cpp` rather than introducing contrived compiler-only constructs.
- Updated logic/typing represents plausible original gameplay code (state machine wrap and frame stepping), while preserving readability and existing codebase conventions.

## Technical details
- `ShapeState` and `ShapeSpecEntry` converted to unsigned counter/value semantics where assembly expects zero-extension.
- `ShapeControlData::type` and `step` handling adjusted to match 32-bit access pattern used in generated code.
- `pppDrawShape2` now derives `drawShape` from per-entry offset and passes draw-env bytes in observed register order.
