### PR TITLE
GXTransform: improve GXSetProjection match with direct projection FIFO writes

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -79,23 +79,33 @@ void __GXSetProjection(void) {
 }
 
 void GXSetProjection(const Mtx44 mtx, GXProjectionType type) {
+    GXData* gx = __GXData;
+
     CHECK_GXBEGIN(295, "GXSetProjection");
 
-    __GXData->projType = type;
-    __GXData->projMtx[0] = mtx[0][0];
-    __GXData->projMtx[2] = mtx[1][1];
-    __GXData->projMtx[4] = mtx[2][2];
-    __GXData->projMtx[5] = mtx[2][3];
+    gx->projType = type;
+    gx->projMtx[0] = mtx[0][0];
+    gx->projMtx[2] = mtx[1][1];
+    gx->projMtx[4] = mtx[2][2];
+    gx->projMtx[5] = mtx[2][3];
     if (type == GX_ORTHOGRAPHIC) {
-        __GXData->projMtx[1] = mtx[0][3];
-        __GXData->projMtx[3] = mtx[1][3];
+        gx->projMtx[1] = mtx[0][3];
+        gx->projMtx[3] = mtx[1][3];
     } else {
-        __GXData->projMtx[1] = mtx[0][2];
-        __GXData->projMtx[3] = mtx[1][2];
+        gx->projMtx[1] = mtx[0][2];
+        gx->projMtx[3] = mtx[1][2];
     }
 
-    __GXSetProjection();
-    __GXData->bpSentNot = 1;
+    GX_WRITE_U8(0x10);
+    GX_WRITE_U32(0x00061020);
+    GX_WRITE_F32(gx->projMtx[0]);
+    GX_WRITE_F32(gx->projMtx[1]);
+    GX_WRITE_F32(gx->projMtx[2]);
+    GX_WRITE_F32(gx->projMtx[3]);
+    GX_WRITE_F32(gx->projMtx[4]);
+    GX_WRITE_F32(gx->projMtx[5]);
+    GX_WRITE_U32(gx->projType);
+    gx->bpSentNot = 1;
 }
 
 void GXSetProjectionv(const f32* ptr) {


### PR DESCRIPTION
## Summary
- Reworked `GXSetProjection` in `src/gx/GXTransform.c` to emit projection XF registers directly after storing `projMtx`/`projType`.
- Kept existing API behavior and state updates (`bpSentNot`) intact.
- Used a local `GXData*` pointer to align data access and write ordering.

## Functions improved
- Unit: `main/gx/GXTransform`
- Symbol: `GXSetProjection`
- Match: `66.77778%` -> `95.31111%`
- Size: `180b`

## Match evidence
- `ninja` rebuild passes.
- `objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetProjection` shows direct improvement in instruction alignment for the projection register write path.
- Unit `.text` match moved from `79.14024%` to `81.75%`.

## Plausibility rationale
- The updated flow is consistent with GX FIFO programming style already used in neighboring functions (e.g. `GXSetProjectionv`).
- The change is primarily structural reordering of existing semantic operations (store projection fields, write XF projection registers, mark BP dirty), not contrived compiler coaxing.

## Technical details
- Removed the indirect `__GXSetProjection()` call from `GXSetProjection` and inlined equivalent FIFO writes in this function.
- Preserved orthographic/perspective field selection and all projection matrix element assignments.