### PR TITLE
main/ME_AppRequest: implement ResetRsdList/AddRsdList

### DIFF
--- a/include/ffcc/ME_AppRequest.h
+++ b/include/ffcc/ME_AppRequest.h
@@ -11,7 +11,7 @@ public:
     void ResetRsdList(ZLIST*);
     void DeleteRsdItem(RSDLISTITEM*);
     void DeleteColAnmData(ZCANMGRP**, int);
-    void AddRsdList(ZLIST*);
+    int AddRsdList(ZLIST*);
     int SetRsdFlag();
     void GetRsdItemR();
     int SetRsdIndex();

--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -1,14 +1,70 @@
 #include "ffcc/ME_AppRequest.h"
+#include "ffcc/memory.h"
 #include "ffcc/zlist.h"
+
+extern "C" {
+void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+void __dl__FPv(void*);
+void __dla__FPv(void*);
+void* memset(void*, int, unsigned int);
+}
+
+extern unsigned char MaterialEditorPcs[];
+
+static char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
 
 /*
  * --INFO--
  * Address:	TODO
  * Size:	TODO
  */
-void CMaterialEditorPcs::ResetRsdList(ZLIST*)
+void CMaterialEditorPcs::ResetRsdList(ZLIST* zlist)
 {
-	// TODO
+	_ZLISTITEM* it = zlist->m_root.m_previous;
+
+	while (it != 0) {
+		int* listItem = (int*)zlist->GetDataNext(&it);
+		int rsdItem = *listItem;
+
+		if (rsdItem != 0) {
+			if (*(void**)(rsdItem + 0xc) != 0) {
+				__dla__FPv(*(void**)(rsdItem + 0xc));
+				*(int*)(rsdItem + 0xc) = 0;
+			}
+			if (*(void**)(rsdItem + 0x10) != 0) {
+				__dla__FPv(*(void**)(rsdItem + 0x10));
+				*(int*)(rsdItem + 0x10) = 0;
+			}
+			if (*(void**)(rsdItem + 0x14) != 0) {
+				__dla__FPv(*(void**)(rsdItem + 0x14));
+				*(int*)(rsdItem + 0x14) = 0;
+			}
+			if (*(void**)(rsdItem + 0x18) != 0) {
+				__dla__FPv(*(void**)(rsdItem + 0x18));
+				*(int*)(rsdItem + 0x18) = 0;
+			}
+			__dl__FPv((void*)rsdItem);
+		}
+
+		unsigned int* colAnmData = (unsigned int*)listItem[1];
+		int colAnmCount = listItem[2];
+		if (colAnmData != 0) {
+			for (int i = 0; i < colAnmCount; i++) {
+				if ((void*)*colAnmData != 0) {
+					__dla__FPv((void*)*colAnmData);
+					*colAnmData = 0;
+				}
+				colAnmData += 5;
+			}
+			if ((void*)listItem[1] != 0) {
+				__dla__FPv((void*)listItem[1]);
+				listItem[1] = 0;
+			}
+		}
+		__dl__FPv(listItem);
+	}
+
+	zlist->DeleteList();
 }
 
 /*
@@ -36,9 +92,26 @@ void CMaterialEditorPcs::DeleteColAnmData(ZCANMGRP **, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CMaterialEditorPcs::AddRsdList(ZLIST*)
+int CMaterialEditorPcs::AddRsdList(ZLIST* zlist)
 {
-	// TODO
+	CMemory::CStage* stage = *(CMemory::CStage**)(MaterialEditorPcs + 4);
+	int* entry = (int*)__nw__FUlPQ27CMemory6CStagePci(0x10, stage, s_ME_AppRequest_cpp_801d7da8, 0x61);
+	if (entry == 0) {
+		return 0;
+	}
+
+	memset(entry, 0, 0x10);
+	int rsdItem = (int)__nw__FUlPQ27CMemory6CStagePci(0x1c, stage, s_ME_AppRequest_cpp_801d7da8, 0x67);
+	if (rsdItem == 0) {
+		__dl__FPv(entry);
+		return 0;
+	}
+
+	memset((void*)rsdItem, 0, 0x1c);
+	entry[0] = rsdItem;
+	entry[3] = 1;
+	zlist->AddTail(entry);
+	return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMaterialEditorPcs::ResetRsdList(ZLIST*)` with full cleanup logic for RSD entries and column-animation buffers.
- Implemented `CMaterialEditorPcs::AddRsdList(ZLIST*)` allocation/initialization flow using stage allocator, entry initialization, and list insertion.
- Updated declaration of `AddRsdList` in `include/ffcc/ME_AppRequest.h` from `void` to `int` to match actual success/failure return behavior.

## Functions improved
Unit: `main/ME_AppRequest` (`src/ME_AppRequest.cpp`)
- `ResetRsdList__18CMaterialEditorPcsFP5ZLIST`
  - Before: `1.2658228%` (stub `4b`)
  - After: `87.341774%` (`308b`)
- `AddRsdList__18CMaterialEditorPcsFP5ZLIST`
  - Before: `1.8867924%` (stub `4b`)
  - After: `78.73585%` (`208b`)

## Match evidence
- Rebuilt with `ninja`.
- Verified symbol-level diff with:
  - `build/tools/objdiff-cli diff -p . -u main/ME_AppRequest -o - 'SetRsdFlag__18CMaterialEditorPcsFv'`
- Current objdiff symbol matches:
  - `ResetRsdList__18CMaterialEditorPcsFP5ZLIST`: `87.341774%`
  - `AddRsdList__18CMaterialEditorPcsFP5ZLIST`: `78.73585%`

## Plausibility rationale
- The new implementations follow game-style ownership and allocator patterns already used in this codebase:
  - stage-aware allocation (`__nw__FUlPQ27CMemory6CStagePci`)
  - paired cleanup (`__dl__FPv`, `__dla__FPv`)
  - list operations via `ZLIST` methods (`AddTail`, `GetDataNext`, `DeleteList`)
- The resulting code is direct resource-management logic rather than compiler-coaxing temporaries or unnatural control flow.

## Technical notes
- `ResetRsdList` now walks list nodes, frees per-entry nested buffers (including strided column-animation storage), deletes each node payload, then clears the list.
- `AddRsdList` now allocates both container and RSD payload, zero-initializes, sets default enable flag, and appends to the provided list.
