### PR TITLE
textureman: decompile CPtrArray<CTexture*> path

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -1,6 +1,311 @@
 #include "ffcc/textureman.h"
+#include "ffcc/system.h"
+
+#include <string.h>
 
 extern CTextureMan TextureMan;
+extern CMemory Memory;
+extern CSystem System;
+
+template <class T>
+class CPtrArray
+{
+public:
+    void** m_vtable;
+    int m_size;
+    int m_numItems;
+    int m_defaultSize;
+    T* m_items;
+    CMemory::CStage* m_stage;
+    int m_growCapacity;
+
+    CPtrArray();
+    ~CPtrArray();
+
+    bool Add(T item);
+    void SetAt(unsigned long index, T item);
+    int GetSize();
+    void RemoveAll();
+    void ReleaseAndRemoveAll();
+    T operator[](unsigned long index);
+    void SetStage(CMemory::CStage* stage);
+    void SetDefaultSize(unsigned long defaultSize);
+    int setSize(unsigned long newSize);
+    T GetAt(unsigned long index);
+};
+
+extern "C" void __dl__FPv(void*);
+extern "C" void __dla__FPv(void*);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
+extern "C" void* lbl_801E9BA0[];
+
+static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
+static char s_ptrarray_grow_error[] = "CPtrArray grow error";
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BE3C
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CTexture*>::CPtrArray()
+{
+    m_vtable = lbl_801E9BA0;
+    m_size = 0;
+    m_numItems = 0;
+    m_defaultSize = 0x10;
+    m_items = 0;
+    m_stage = 0;
+    m_growCapacity = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BE70
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CTexture*>::~CPtrArray()
+{
+    RemoveAll();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BE70
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CPtrArray<CTexture*>* dtor_8003BE70(CPtrArray<CTexture*>* ptrArray, short param_2)
+{
+    if (ptrArray != 0) {
+        ptrArray->m_vtable = lbl_801E9BA0;
+        ptrArray->RemoveAll();
+        if (0 < param_2) {
+            __dl__FPv(ptrArray);
+        }
+    }
+    return ptrArray;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BECC
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+bool CPtrArray<CTexture*>::Add(CTexture* item)
+{
+    if (setSize(m_numItems + 1) != 0) {
+        m_items[m_numItems] = item;
+        m_numItems = m_numItems + 1;
+        return true;
+    }
+    return false;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BF3C
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexture*>::SetAt(unsigned long index, CTexture* item)
+{
+    m_items[index] = item;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BF4C
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CTexture*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BF54
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexture*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003BFA0
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexture*>::ReleaseAndRemoveAll()
+{
+    int offset = 0;
+
+    for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
+        int* item = *(int**)((int)m_items + offset);
+        if (item != 0) {
+            int refCount = item[1];
+            item[1] = refCount - 1;
+            if ((refCount - 1 == 0) && (item != 0)) {
+                (*(void (**)(int*, int))(*item + 8))(item, 1);
+            }
+            *(unsigned int*)((int)m_items + offset) = 0;
+        }
+        offset += 4;
+    }
+
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003C06C
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CTexture* CPtrArray<CTexture*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003C08C
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexture*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003C094
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexture*>::SetDefaultSize(unsigned long defaultSize)
+{
+    m_defaultSize = defaultSize;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003C09C
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CTexture*>::setSize(unsigned long newSize)
+{
+    CTexture** newItems;
+
+    if ((unsigned long)m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
+            m_size = m_size << 1;
+        }
+
+        newItems = (CTexture**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, (unsigned long)(m_size << 2), m_stage, s_collection_ptrarray_h, 0xFA, 0);
+        if (newItems == 0) {
+            return 0;
+        }
+
+        if (m_items != 0) {
+            memcpy(newItems, m_items, m_numItems << 2);
+        }
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+        m_items = newItems;
+    }
+
+    return 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003C18C
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CTexture* CPtrArray<CTexture*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added a local `CPtrArray<T>` implementation in `src/textureman.cpp` and fully specialized it for `CTexture*`.
- Implemented the PAL-addressed `CPtrArray<P8CTexture>` methods and destructor shim used by `textureman.o`:
  - `__ct__21CPtrArray<P8CTexture>Fv`
  - `dtor_8003BE70`
  - `Add__21CPtrArray<P8CTexture>FP8CTexture`
  - `SetAt`, `GetSize`, `RemoveAll`, `ReleaseAndRemoveAll`, `__vc__`, `SetStage`, `SetDefaultSize`, `setSize`, `GetAt`
- Added required runtime hooks and constants (`_Alloc`, `__dl__`, `__dla__`, `lbl_801E9BA0`, ptrarray strings) consistent with existing decomp style used in other units.

## Functions Improved
- Unit: `main/textureman`
- Before (selector): `fuzzy_match_percent = 5.0`, `matched functions = 0/38`
- After (`build/GCCP01/report.json`): `fuzzy_match_percent = 16.467606`, `matched functions = 6/38`

Key symbol improvements:
- `__ct__21CPtrArray<P8CTexture>Fv`: `0.0% -> 99.84615%`
- `dtor_8003BE70`: `0.0% -> 100.0%`
- `Add__21CPtrArray<P8CTexture>FP8CTexture`: `0.0% -> 85.21429%`
- Additional new high matches in same family: `SetAt` 100%, `__vc__` 100%, `GetAt` 100%, `SetStage` 100%, `SetDefaultSize` 100%, `GetSize` 99.5%, `RemoveAll` 99.89474%, `ReleaseAndRemoveAll` 93.56863%, `setSize` 91.566666%.

## Match Evidence
- Build validated with `ninja`.
- Symbol-level verification performed with:
  - `build/tools/objdiff-cli diff -p . -u main/textureman -o - '<symbol>'`
- Objdiff now reports strong opcode/flow alignment for the inserted `CPtrArray<P8CTexture>` path rather than missing-stub output.

## Plausibility Rationale
- This change reconstructs a standard engine container implementation pattern already present in this codebase (`mapanim`, `p_chara`) instead of introducing compiler-coaxing artifacts.
- The code uses expected ABI-level behavior (reference-counted release path, stage allocator usage, growth policy), and preserves readable/source-plausible intent.
