### PR TITLE
pppMove: use signed comparisons to reach 100% match

### DIFF
--- a/src/pppMove.cpp
+++ b/src/pppMove.cpp
@@ -1,6 +1,6 @@
 #include "ffcc/pppMove.h"
 
-extern u32 lbl_8032ED70;   // Global enable flag
+extern s32 lbl_8032ED70;   // Global enable flag
 extern f32 lbl_8032FED8;   // Zero constant
 
 struct PppMoveObj {
@@ -54,12 +54,12 @@ void pppMove(void* basePtr, PppMoveInput* input, PppMoveData* data1, PppMoveData
 
     (void)data2;
 
-    if (lbl_8032ED70 != 0U) {
+    if (lbl_8032ED70 != 0) {
         return;
     }
 
-    u32 inputId = *(u32*)input;
-    u32 baseId = *(u32*)((u8*)basePtr + 0xc);
+    s32 inputId = *(s32*)input;
+    s32 baseId = *(s32*)((u8*)basePtr + 0xc);
 
     if (inputId == baseId) {
         b->x += input->x;


### PR DESCRIPTION
## Summary
- Updated signedness in `src/pppMove.cpp` for the global enable flag and ID comparison operands.
- No control-flow or behavior changes; only type corrections to match ABI/comparison semantics.

## Functions improved
- Unit: `main/pppMove`
- Function: `pppMove`

## Match evidence
- `main/pppMove` fuzzy match: **97.5% -> 100.0%**
- `pppMove` fuzzy match: **96.92308% -> 100.0%**
- Build/progress impact: code matched functions increased (`1350 -> 1351` in `ninja` progress output).

## Plausibility rationale
- The updated types are source-plausible: an enable flag and IDs are naturally signed integral compares in this code path.
- The change removes unsigned compare codegen (`cmplwi`/`cmplw`) in favor of signed compare codegen (`cmpwi`/`cmpw`), aligning with target output.

## Technical details
- Changed `lbl_8032ED70` declaration from `u32` to `s32`.
- Changed local `inputId` and `baseId` in `pppMove` from `u32` to `s32`.
- Kept all pointer math and vector accumulation logic intact.
