### PR TITLE
wm_menu: decompile EffectInfo ctor vtable initialization

### DIFF
--- a/src/wm_menu.cpp
+++ b/src/wm_menu.cpp
@@ -2,6 +2,30 @@
 
 #include "ffcc/p_game.h"
 
+extern "C" void* __vt__Q212CFlatRuntime7CObject[];
+extern "C" void* __vt__8CGBaseObj[];
+extern "C" void* __vt__8CGObject[];
+
+/*
+ * --INFO--
+ * PAL Address: 0x80102e9c
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CMenuPcs::EffectInfo::EffectInfo()
+{
+	unsigned char* const bytes = reinterpret_cast<unsigned char*>(this);
+	void*** const vtable = reinterpret_cast<void***>(bytes + 0x54);
+
+	*vtable = __vt__Q212CFlatRuntime7CObject;
+	bytes[0x44] &= 0xEF;
+	*vtable = __vt__8CGBaseObj;
+	*vtable = __vt__8CGObject;
+}
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::EffectInfo::EffectInfo()` in `src/wm_menu.cpp` using explicit vtable-pointer initialization and flag-bit setup.
- Added PAL metadata block for the function (`0x80102e9c`, `56b`).
- Kept implementation minimal and source-plausible for a constructor stub in this decomp stage.

## Functions improved
- Unit: `main/wm_menu`
- Symbol: `__ct__Q28CMenuPcs10EffectInfoFv`
- Match: `0.0% -> 81.07143%`

## Match evidence
- Command: `build/tools/objdiff-cli diff -p . -u main/wm_menu -o - __ct__Q28CMenuPcs10EffectInfoFv`
- Result shows correct constructor shape with sequential vtable stores and flag-bit clear at offset `0x44`.
- Current gap is limited to a small instruction-form difference around the bit-clear operation (`andi.` vs expected `rlwimi` form).

## Plausibility rationale
- The emitted sequence aligns with a typical engine object constructor path in this codebase: base vtable progression (`CFlatRuntime::CObject` -> `CGBaseObj` -> `CGObject`) plus one flag-bit normalization.
- The change avoids artificial control-flow or compiler-coaxing temporaries; it models observed object-layout behavior directly.

## Technical details
- Uses explicit offset writes (`0x54` for vtable slot, `0x44` for flag byte) matching the decomp-guided constructor behavior.
- Reuses existing vtable symbols already produced by the build (`__vt__Q212CFlatRuntime7CObject`, `__vt__8CGBaseObj`, `__vt__8CGObject`).
- Build status: `ninja` passes for `GCCP01` after the change.
