### PR TITLE
maphit: implement __sinit_maphit_cpp globals init

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -1,5 +1,8 @@
 #include "ffcc/maphit.h"
 
+extern CMapCylinder g_hit_cyl;
+extern CMapCylinder g_hit_cyl_min;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -228,4 +231,30 @@ CMapHitFace::CMapHitFace()
     m_boundsMax.z = 1.0f;
     m_boundsMax.y = 1.0f;
     m_boundsMax.x = 1.0f;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80027728
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_maphit_cpp()
+{
+    g_hit_cyl.m_direction2.y = 0.0f;
+    g_hit_cyl.m_direction2.x = 0.0f;
+    g_hit_cyl.m_top.z = 0.0f;
+    g_hit_cyl.m_height2 = 1.0f;
+    g_hit_cyl.m_radius2 = 1.0f;
+    g_hit_cyl.m_direction2.z = 1.0f;
+
+    g_hit_cyl_min.m_direction2.y = 0.0f;
+    g_hit_cyl_min.m_direction2.x = 0.0f;
+    g_hit_cyl_min.m_top.z = 0.0f;
+    g_hit_cyl_min.m_height2 = 1.0f;
+    g_hit_cyl_min.m_radius2 = 1.0f;
+    g_hit_cyl_min.m_direction2.z = 1.0f;
 }


### PR DESCRIPTION
## Summary
- Added `__sinit_maphit_cpp` in `src/maphit.cpp` with explicit initialization for `g_hit_cyl` and `g_hit_cyl_min` fields.
- Declared the two globals used by the static initializer.
- Included PAL address/size metadata block for the new function.

## Functions Improved
- Unit: `main/maphit`
- Function: `__sinit_maphit_cpp` (76 bytes)
  - Before: `fuzzy_match_percent = null` (not decompiled/matched)
  - After: `fuzzy_match_percent = 100.0`

## Match Evidence
- Project progress after rebuild:
  - Code matched bytes: `190800 -> 190876` (**+76 bytes**)
  - Matched functions: `1351 -> 1352` (**+1 function**)
- `build/GCCP01/report.json` now reports `__sinit_maphit_cpp` at 100%.
- Objdiff symbol diff for `__sinit_maphit_cpp` shows only symbol/relocation argument index differences, with functional instruction sequence aligned.

## Plausibility Rationale
- The implementation is a straightforward static data initializer for collision globals.
- It uses direct field assignments to canonical default values (`0.0f` / `1.0f`) in the observed order, which is consistent with plausible original source for startup setup code.
- No artificial compiler-coaxing temporaries or unreadable control-flow rewrites were introduced.

## Technical Notes
- Build verified with `ninja` in GCCP01 configuration.
- Change is isolated to `src/maphit.cpp` and does not add debug artifacts or analysis comments.