### PR TITLE
RedSound: implement stream driver wrapper functions

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -573,22 +573,30 @@ void CRedSound::StreamPlayState(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd570
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::GetStreamPlayPoint(int, int*, int*)
+void CRedSound::GetStreamPlayPoint(int streamID, int* point1, int* point2)
 {
-	// TODO
+	CRedDriver_8032f4c0.GetStreamPlayPoint(streamID, point1, point2);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd5ac
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::StreamStop(int)
+void CRedSound::StreamStop(int streamID)
 {
-	// TODO
+	CRedDriver_8032f4c0.StreamStop(streamID);
 }
 
 /*
@@ -618,22 +626,30 @@ int CRedSound::StreamPlay(void* data, int param_3, int param_4, int param_5)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd6b8
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::StreamVolume(int, int, int)
+void CRedSound::StreamVolume(int streamID, int volume, int frameCount)
 {
-	// TODO
+	CRedDriver_8032f4c0.StreamVolume(streamID, volume, frameCount);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd6f4
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::StreamPause(int, int)
+void CRedSound::StreamPause(int streamID, int pause)
 {
-	// TODO
+	CRedDriver_8032f4c0.StreamPause(streamID, pause);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement four missing `CRedSound` stream wrapper methods in `src/RedSound/RedSound.cpp` by forwarding to `CRedDriver_8032f4c0`.

Implemented:
- `CRedSound::GetStreamPlayPoint(int, int*, int*)`
- `CRedSound::StreamStop(int)`
- `CRedSound::StreamVolume(int, int, int)`
- `CRedSound::StreamPause(int, int)`

Also updated each function doc block with PAL address/size metadata from Ghidra references.

## Functions Improved
Unit: `main/RedSound/RedSound`

- `GetStreamPlayPoint__9CRedSoundFiPiPi` (60b): ~6.67% -> **59.07%**
- `StreamStop__9CRedSoundFi` (44b): ~9.09% -> **80.82%**
- `StreamVolume__9CRedSoundFiii` (60b): ~6.67% -> **59.07%**
- `StreamPause__9CRedSoundFii` (52b): ~7.69% -> **68.38%**

## Match Evidence
- Verified with direct `objdiff-cli diff -p . -u main/RedSound/RedSound <symbol>` checks for each symbol after the rebuild.
- These are assembly-level deltas (not formatting-only changes): TODO stubs now emit proper call sequences into `CRedDriver` methods, including argument forwarding and call sites that align with target shape.

## Plausibility Rationale
These methods are thin API-layer pass-throughs in `CRedSound`, and forwarding to `CRedDriver` is the most plausible original source structure for this subsystem. The change removes placeholder stubs and restores idiomatic class-wrapper behavior without contrived control-flow or compiler-coaxing artifacts.

## Build
- `ninja` passes.
