### PR TITLE
pppPart: implement pppInitBlendMode

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -16,6 +16,7 @@ static const float kPppZero = 0.0; // FLOAT_8032fddc
 static const float kPppOne = 1.0; // FLOAT_8032fdfc
 static const double kScaleConstA = 4503601774854144.0; // DOUBLE_803304b0
 static const float kScaleConstB = 0.017453292f; // FLOAT_803304a8
+extern "C" unsigned char lbl_8032ED85;
 
 /*
  * --INFO--
@@ -1210,7 +1211,7 @@ void pppDrawMesh(pppModelSt*, Vec*, int)
  */
 void pppInitBlendMode()
 {
-	// TODO
+	lbl_8032ED85 = 0xFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppInitBlendMode()` in `src/pppPart.cpp`.
- Added an extern for the SDA global used by the function and wrote `0xFF` to it, replacing the prior TODO stub.

## Functions improved
- Unit: `main/pppPart`
- Symbol: `pppInitBlendMode__Fv`
- Size: 12 bytes

## Match evidence
- Build/progress before change:
  - Code: `190876 / 1855300` bytes
  - Functions: `1352 / 4733`
- Build/progress after change:
  - Code: `190888 / 1855300` bytes
  - Functions: `1353 / 4733`
- `objdiff` symbol check (`tools/objdiff-cli diff -p . -u main/pppPart -o - pppInitBlendMode__Fv`):
  - Left size: `12`, Right size: `12`
  - Left instructions: `3`, Right instructions: `3`
  - Non-matching diff entries: `0` (left and right)

## Plausibility rationale
- The implementation is source-plausible and idiomatic for this codebase: initialization of a draw/blend state byte to fully enabled (`0xFF`) via an existing SDA global.
- No control-flow tricks or compiler-coaxing patterns were introduced.

## Technical details
- The target object (`build/GCCP01/obj/pppPart.o`) shows `pppInitBlendMode__Fv` as:
  - `li r0, 255`
  - `stb r0, lbl_8032ED85@sda21`
  - `blr`
- Updated C emits the same instruction shape and relocation target in `build/GCCP01/src/pppPart.o`.
