### PR TITLE
game: materialize CPtrArray<CMapLightHolder*> matches in game unit

### DIFF
--- a/include/ffcc/ptrarray.h
+++ b/include/ffcc/ptrarray.h
@@ -11,11 +11,11 @@ public:
     CPtrArray();
     ~CPtrArray();
     
-    int GetSize() const;
+    int GetSize();
     bool Add(T* item);
     void RemoveAll();
-    T* GetAt(unsigned int index) const;
-    T* operator[](unsigned int index) const;
+    T* GetAt(unsigned long index);
+    T* operator[](unsigned long index);
     
 private:
     bool setSize(unsigned int newSize);
@@ -46,19 +46,19 @@ CPtrArray<T>::~CPtrArray()
 }
 
 template <class T>
-int CPtrArray<T>::GetSize() const
+int CPtrArray<T>::GetSize()
 {
     return m_numItems;
 }
 
 template <class T>
-T* CPtrArray<T>::GetAt(unsigned int index) const
+T* CPtrArray<T>::GetAt(unsigned long index)
 {
     return m_items[index];
 }
 
 template <class T>
-T* CPtrArray<T>::operator[](unsigned int index) const
+T* CPtrArray<T>::operator[](unsigned long index)
 {
     return GetAt(index);
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -789,3 +789,5 @@ CGame::CGameWork::CGameWork()
 {
 	// TODO
 }
+
+template class CPtrArray<CMapLightHolder*>;


### PR DESCRIPTION
## Summary
- Aligned CPtrArray accessor signatures in include/ffcc/ptrarray.h with emitted game-unit symbols (GetSize, GetAt(unsigned long), operator[](unsigned long) now non-const).
- Explicitly instantiated 	emplate class CPtrArray<CMapLightHolder*>; in src/game.cpp so main/game emits the template methods objdiff expects.

## Functions improved
- Unit: main/game
- GetSize__29CPtrArray<P15CMapLightHolder>Fv: unresolved -> 100.0%
- GetAt__29CPtrArray<P15CMapLightHolder>FUl: unresolved -> 99.75%
- __vc__29CPtrArray<P15CMapLightHolder>FUl: unresolved -> 33.625%

## Match evidence
- main/game fuzzy: 10.824459 -> 11.185524
- main/game matched functions: 4/45 -> 5/45
- Project matched code bytes: 190876 -> 190884

## Plausibility rationale
- This change resolves ABI/signature and instantiation gaps rather than introducing compiler-coaxing control flow.
- Explicit template instantiation is a source-plausible way to ensure methods are emitted in the same unit where target symbols exist.
- No contrived temporaries or behavior-only rewrites were introduced.

## Technical details
- Build validation: 
inja succeeds.
- Objdiff validation used uild/tools/objdiff-cli-3.6.1.exe diff ... --format json to extract match_percent for the three symbols above.
