### PR TITLE
RedSound: improve ReportStandby and implement SePlay

### DIFF
--- a/include/ffcc/RedSound/RedSound.h
+++ b/include/ffcc/RedSound/RedSound.h
@@ -45,7 +45,7 @@ public:
 	void SePlayState(int);
 	void SeStop(int);
 	void SeStopMG(int, int, int, int);
-	void SePlay(int, int, int, int, int);
+	int SePlay(int, int, int, int, int);
 	void SeMasterVolume(int);
 	void SeFadeOut(int, int);
 	void SeVolume(int, int, int);

--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -205,19 +205,22 @@ int CRedSound::ReportStandby(int id)
 	int i;
 
 	if (id == 0) {
-		for (i = 0; i < 0x40; i++) {
-			if (((int*)DAT_8032e17c)[i] != 0) {
+		i = 0;
+		do {
+			if (DAT_8032e17c[i] != 0) {
 				return 1;
 			}
-		}
+			i++;
+		} while (i < 0x40);
 	} else {
-		for (i = 0; i < 0x40; i++) {
-			if (((int*)DAT_8032e17c)[i] == id) {
+		i = 0;
+		do {
+			if (id == DAT_8032e17c[i]) {
 				return 1;
 			}
-		}
+			i++;
+		} while (i < 0x40);
 	}
-
 	return 0;
 }
 
@@ -466,9 +469,11 @@ void CRedSound::SeStopMG(int, int, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::SePlay(int, int, int, int, int)
+int CRedSound::SePlay(int seID, int sepID, int unk, int volume, int pitch)
 {
-	// TODO
+	int autoID = GetAutoID();
+	CRedDriver_8032f4c0.SePlay(seID, sepID, autoID, unk, volume, pitch);
+	return autoID;
 }
 
 /*
@@ -664,10 +669,10 @@ void CRedSound::StreamPause(int streamID, int pause)
 unsigned int CRedSound::SetWaveData(int waveID, void* waveData, int waveSize)
 {
 	unsigned int id = GetAutoID();
-	int* standbyID = EntryStandbyID(id);
+	int standbyID = (int)EntryStandbyID(id);
 
 	if (standbyID != 0) {
-		CRedDriver_8032f4c0.SetWaveData((int)standbyID, waveID, waveData, waveSize);
+		CRedDriver_8032f4c0.SetWaveData(standbyID, waveID, waveData, waveSize);
 	}
 
 	return id;


### PR DESCRIPTION
## Summary
- Updated `CRedSound::ReportStandby` to scan standby slots as byte entries in `DAT_8032e17c` using explicit do-while control flow.
- Implemented `CRedSound::SePlay` as an ID-allocating wrapper that forwards to `CRedDriver::SePlay` and returns the generated ID.
- Updated `CRedSound` declaration so `SePlay` returns `int`, matching implementation and symbol behavior.
- Kept `SetWaveData` pointer-to-int staging cleanup aligned with current codegen expectations (no score change yet).

## Functions Improved
- Unit: `main/RedSound/RedSound`
- `ReportStandby__9CRedSoundFi`: **0.0% -> 42.763157%** (`152b`)
- `SePlay__9CRedSoundFiiiii`: **3.7037036% -> 50.333332%** (`108b`)
- `SetWaveData__9CRedSoundFiPvi`: `0.0% -> 0.0%` (`124b`) (no regression, no gain)

## Match Evidence
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/RedSound/RedSound -o - --format json ReportStandby__9CRedSoundFi`
  - `tools/objdiff-cli diff -p . -u main/RedSound/RedSound -o - --format json SePlay__9CRedSoundFiiiii`
  - `tools/objdiff-cli diff -p . -u main/RedSound/RedSound -o - --format json SetWaveData__9CRedSoundFiPvi`
- Real assembly alignment improved in both `ReportStandby` and `SePlay` (substantial jump from near-zero fuzzy matches).

## Plausibility Rationale
- `ReportStandby` now treats standby state as compact slot data (`DAT_8032e17c` byte entries), which is consistent with the existing standby pool usage and avoids contrived compiler-only transformations.
- `SePlay` now follows a natural game-audio wrapper pattern: generate an ID, pass through to driver, return the ID to caller.
- Changes are source-plausible gameplay/audio code cleanups rather than unnatural reordering for compiler coaxing.

## Technical Notes
- Main gain came from correcting semantic data width and API signature/return behavior.
- `SetWaveData` was normalized for pointer/int handoff style but still needs further work for codegen match.
