### PR TITLE
p_game: improve __sinit_p_game_cpp match by direct table initialization

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -24,46 +24,35 @@ extern "C" char lbl_801E9F2C[];
  * JP Size: TODO
  */
 void __sinit_p_game_cpp() {
-    unsigned int* table = reinterpret_cast<unsigned int*>(lbl_801E9F2C);
-    unsigned int* desc0 = lbl_801E9EC0;
-    unsigned int* desc1 = lbl_801E9ECC;
-    unsigned int* desc2 = lbl_801E9ED8;
-    unsigned int* desc3 = lbl_801E9EE4;
-    unsigned int* desc4 = lbl_801E9EF0;
-    unsigned int* desc5 = lbl_801E9EFC;
-    unsigned int* desc6 = lbl_801E9F08;
-    unsigned int* desc7 = lbl_801E9F14;
-    unsigned int* desc8 = lbl_801E9F20;
-
     GamePcs = reinterpret_cast<unsigned int>(lbl_801EA0A8);
 
-    table[1] = desc0[0];
-    table[2] = desc0[1];
-    table[3] = desc0[2];
-    table[4] = desc1[0];
-    table[5] = desc1[1];
-    table[6] = desc1[2];
-    table[7] = desc2[0];
-    table[8] = desc2[1];
-    table[9] = desc2[2];
-    table[10] = desc3[0];
-    table[11] = desc3[1];
-    table[12] = desc3[2];
-    table[13] = desc4[0];
-    table[14] = desc4[1];
-    table[15] = desc4[2];
-    table[16] = desc5[0];
-    table[17] = desc5[1];
-    table[18] = desc5[2];
-    table[19] = desc6[0];
-    table[20] = desc6[1];
-    table[21] = desc6[2];
-    table[22] = desc7[0];
-    table[23] = desc7[1];
-    table[24] = desc7[2];
-    table[25] = desc8[0];
-    table[26] = desc8[1];
-    table[27] = desc8[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[1] = lbl_801E9EC0[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[2] = lbl_801E9EC0[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[3] = lbl_801E9EC0[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[4] = lbl_801E9ECC[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[5] = lbl_801E9ECC[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[6] = lbl_801E9ECC[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[7] = lbl_801E9ED8[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[8] = lbl_801E9ED8[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[9] = lbl_801E9ED8[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[10] = lbl_801E9EE4[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[11] = lbl_801E9EE4[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[12] = lbl_801E9EE4[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[13] = lbl_801E9EF0[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[14] = lbl_801E9EF0[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[15] = lbl_801E9EF0[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[16] = lbl_801E9EFC[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[17] = lbl_801E9EFC[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[18] = lbl_801E9EFC[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[19] = lbl_801E9F08[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[20] = lbl_801E9F08[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[21] = lbl_801E9F08[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[22] = lbl_801E9F14[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[23] = lbl_801E9F14[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[24] = lbl_801E9F14[2];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[25] = lbl_801E9F20[0];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[26] = lbl_801E9F20[1];
+    reinterpret_cast<unsigned int*>(lbl_801E9F2C)[27] = lbl_801E9F20[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
This updates `__sinit_p_game_cpp` in `src/p_game.cpp` to use direct symbol-to-table assignments instead of temporary pointer aliases. The initialization logic is unchanged, but the emitted code now aligns more closely with the original static initializer pattern.

## Functions Improved
- Unit: `main/p_game`
- Function: `__sinit_p_game_cpp`

## Match Evidence
- `__sinit_p_game_cpp`: **61.19512% -> 77.585365%** (`tools/objdiff-cli diff -p . -u main/p_game __sinit_p_game_cpp`)
- Spot-check regression guard:
  - `draw1__8CGamePcsFv`: **84.0% -> 84.0%**

## Plausibility Rationale
The change removes decomp-style temporary pointer plumbing and expresses initialization as straightforward global table population, which is consistent with how static init code is typically authored/compiled in this codebase. No control-flow tricks or compiler-coaxing constructs were added.

## Technical Details
- Kept `GamePcs` initialization as a direct assignment.
- Replaced intermediate `table`/`descN` locals with direct indexed writes to `lbl_801E9F2C` from the descriptor symbols (`lbl_801E9EC0` ... `lbl_801E9F20`).
- Preserved the exact write order and values.