### PR TITLE
main/cflat_r2system: add CPartPcs::pppSetDebugHide setter

### DIFF
--- a/include/ffcc/p_tina.h
+++ b/include/ffcc/p_tina.h
@@ -74,6 +74,7 @@ public:
     void StartMiruraEvent();
     void EndMiruraEvent();
 
+    void pppSetDebugHide(unsigned char);
     void SetUSBData();
 };
 

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2,7 +2,14 @@
 #include "ffcc/game.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/p_menu.h"
+#include "ffcc/p_tina.h"
 #include "ffcc/sound.h"
+#include "ffcc/USBStreamData.h"
+
+static inline CUSBStreamData* UsbStream(CPartPcs* self)
+{
+    return reinterpret_cast<CUSBStreamData*>((char*)self + 0x8);
+}
 
 /*
  * --INFO--
@@ -58,6 +65,20 @@ CFont* CMenuPcs::GetFont22()
 void CSound::SeMaxVolume(int volume)
 {
     *(int*)((char*)this + 0x22BC) = volume;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8FA8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CPartPcs::pppSetDebugHide(unsigned char hide)
+{
+    UsbStream(this)->m_disableShokiDraw = hide;
 }
 
 /*


### PR DESCRIPTION
﻿## Summary
- Added a missing CPartPcs::pppSetDebugHide(unsigned char) declaration in include/ffcc/p_tina.h.
- Implemented CPartPcs::pppSetDebugHide in src/cflat_r2system.cpp.
- The implementation uses existing USB stream semantics (CUSBStreamData) to set m_disableShokiDraw.

## Functions improved
- Unit: main/cflat_r2system
- Symbol: pppSetDebugHide__8CPartPcsFUc (PAL 0x800B8FA8, 8 bytes)

## Match evidence
- uild/GCCP01/report.before.json: pppSetDebugHide__8CPartPcsFUc had no fuzzy match value (unresolved)
- uild/GCCP01/report.json: pppSetDebugHide__8CPartPcsFUc is now 99.5% fuzzy match

## Plausibility rationale
- This is a direct class-method setter for m_disableShokiDraw, matching behavior visible in nearby CPartPcs decomp snippets.
- The change is narrowly scoped and uses existing project types (CUSBStreamData) rather than synthetic control flow.

## Technical details
- Added #include \"ffcc/p_tina.h\" and #include \"ffcc/USBStreamData.h\" to src/cflat_r2system.cpp.
- Added a small helper to access CPartPcs USB stream data and used it in CPartPcs::pppSetDebugHide.
- Verified by rebuilding (
inja build/GCCP01/src/cflat_r2system.o progress) and checking symbol-level report output.
