### PR TITLE
main/pppYmTracer: improve pppConstruct2YmTracer match via pointer addressing

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -117,11 +117,11 @@ void pppConstructYmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
  */
 void pppConstruct2YmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
 {
-    int iVar1;
+    u8* work;
 
-    iVar1 = *param_2->m_serializedDataOffsets;
-    *(u16*)((char*)pppYmTracer + 0xae + iVar1) = 0;
-    *(u16*)((char*)pppYmTracer + 0xac + iVar1) = 0;
+    work = (u8*)pppYmTracer + *param_2->m_serializedDataOffsets;
+    *(u16*)(work + 0xAE) = 0;
+    *(u16*)(work + 0xAC) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refactored pppConstruct2YmTracer in src/pppYmTracer.cpp to use an explicit work pointer derived from m_serializedDataOffsets.
- Kept behavior identical (zeroing the two u16 fields) while changing expression shape to better match original codegen.

## Functions improved
- Unit: main/pppYmTracer
- Symbol: pppConstruct2YmTracer
  - Before: 82.25%
  - After: 85.375%

## Match evidence
- 	ools/objdiff-cli diff -p . -u main/pppYmTracer -o - --format json pppConstruct2YmTracer
  - Match increased by +3.125 points.
- Unit .text match increased:
  - Before: 43.171505%
  - After: 43.204487%

## Plausibility rationale
- The change is source-plausible: it simplifies pointer arithmetic around serialized work-area offsets without introducing contrived temporaries or non-idiomatic flow.
- This aligns with existing codebase patterns where serialized offsets are materialized as a local pointer before field writes.

## Technical details
- Old form used char* + constant + offset directly from the object pointer.
- New form computes a local u8* work once and performs typed stores through it, improving register/address formation in generated assembly.