### PR TITLE
main/maphit: match deleting dtor symbol dtor_80026D5C

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -85,6 +85,39 @@ CMapHit::~CMapHit()
 
 /*
  * --INFO--
+ * PAL Address: 0x80026d5c
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CMapHit* dtor_80026D5C(CMapHit* mapHit, short shouldDelete)
+{
+    if (mapHit != 0) {
+        if (mapHit->m_vertices != 0) {
+            delete[] mapHit->m_vertices;
+            mapHit->m_vertices = 0;
+        }
+
+        if (mapHit->m_faces != 0) {
+            delete[] mapHit->m_faces;
+            mapHit->m_faces = 0;
+        }
+
+        mapHit->m_vertexCount = 0;
+        mapHit->m_faceCount = 0;
+
+        if (shouldDelete > 0) {
+            operator delete(mapHit);
+        }
+    }
+
+    return mapHit;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added explicit deleting-destructor wrapper dtor_80026D5C(CMapHit*, short) in src/maphit.cpp.
- Kept behavior source-plausible: free owned buffers, clear pointers/counts, conditionally call operator delete when shouldDelete > 0.
- Left existing class destructor intact.

## Functions Improved
- Unit: main/maphit
- Function: dtor_80026D5C (size 144b)

## Match Evidence
- main/maphit fuzzy match: **2.0920503% -> 3.4613922%**
- main/maphit matched code: **172 -> 316**
- main/maphit matched functions: **4 -> 5**
- dtor_80026D5C: **0%/unmatched -> 100.0%**

## Plausibility Rationale
- This codebase already uses explicit deleting-dtor wrappers with (T*, short) signatures (for example in src/cflat_data.cpp).
- The new wrapper follows that established pattern and models standard Metrowerks deleting-destructor semantics rather than artificial compiler coaxing.
- Ownership cleanup logic is straightforward and consistent with CMapHit fields (m_vertices, m_faces, count resets).

## Technical Details
- Target selected via 	ools/agent_select_target.py from low-match candidates.
- Verified with objdiff-cli report generate + objdiff-cli report changes using before/after reports generated in this branch run.
- Rebuilt object with 
inja build/GCCP01/src/maphit.o and validated project state with 
inja.