### PR TITLE
Improve pppKeShpTail3X frame/update decomp match

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -5,6 +5,26 @@
 #include <string.h>
 
 extern "C" int rand(void);
+extern int DAT_8032ed70;
+
+struct KeShpTail3XStep {
+    s32 m_graphId;
+    s32 m_dataValIndex;
+    s32 m_initWOrk;
+    s32 m_stepValue;
+    s32 m_arg3;
+    u8* m_payload;
+};
+
+struct KeShpTail3XOffsets {
+    u8 _pad0[0xc];
+    s32* m_serializedDataOffsets;
+};
+
+extern "C" {
+void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
+void pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(pppFMATRIX*, pppFMATRIX*, pppFMATRIX*);
+}
 
 /*
  * --INFO--
@@ -17,7 +37,113 @@ extern "C" int rand(void);
  */
 void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct UnkB* param_2, struct UnkC* param_3)
 {
-	// TODO
+    KeShpTail3XStep* step;
+    s16* work;
+    Vec pos;
+
+    if (DAT_8032ed70 != 0) {
+        return;
+    }
+
+    step = (KeShpTail3XStep*)param_2;
+    work = (s16*)((u8*)&obj->pppPObject + 8 + ((KeShpTail3XOffsets*)param_3)->m_serializedDataOffsets[0]);
+
+    if ((obj->pppPObject.m_graphId == 0) && (obj->field_0x7d != 0)) {
+        ((u8*)work)[0x1c3] = 1;
+
+        pos.x = obj->pppPObject.m_localMatrix.value[0][3];
+        pos.y = obj->pppPObject.m_localMatrix.value[1][3];
+        pos.z = obj->pppPObject.m_localMatrix.value[2][3];
+
+        if (step->m_payload[0x3f] == 1) {
+            pppFMATRIX ownerMatrix;
+            pppFMATRIX partMatrix;
+            pppFMATRIX outMatrix;
+
+            partMatrix = obj->pppPObject.m_localMatrix;
+            ownerMatrix = pppMngStPtr->m_matrix;
+            pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&outMatrix, &ownerMatrix, &partMatrix);
+            pos.x = outMatrix.value[0][3];
+            pos.y = outMatrix.value[1][3];
+            pos.z = outMatrix.value[2][3];
+        }
+
+        Vec* history = (Vec*)(work + 0x18);
+        for (s32 i = 0; i < 0x1c; i++) {
+            pppCopyVector__FR3Vec3Vec(history, &pos);
+            history++;
+        }
+    }
+
+    if (((u8*)work)[0x1c2] == 0) {
+        ((u8*)work)[0x1c2] = 0x1c;
+    }
+    ((u8*)work)[0x1c2]--;
+
+    pos.x = obj->pppPObject.m_localMatrix.value[0][3];
+    pos.y = obj->pppPObject.m_localMatrix.value[1][3];
+    pos.z = obj->pppPObject.m_localMatrix.value[2][3];
+
+    if (step->m_payload[0x3f] == 1) {
+        pppFMATRIX ownerMatrix;
+        pppFMATRIX partMatrix;
+        pppFMATRIX outMatrix;
+
+        partMatrix = obj->pppPObject.m_localMatrix;
+        ownerMatrix = pppMngStPtr->m_matrix;
+        pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&outMatrix, &ownerMatrix, &partMatrix);
+        pos.x = outMatrix.value[0][3];
+        pos.y = outMatrix.value[1][3];
+        pos.z = outMatrix.value[2][3];
+    }
+
+    pppCopyVector__FR3Vec3Vec((Vec*)(work + ((u32)((u8*)work)[0x1c2] * 6) + 0x18), &pos);
+
+    work[8] += work[0xc];
+    work[0] += work[8];
+    work[9] += work[0xd];
+    work[1] += work[9];
+    work[10] += work[0xe];
+    work[2] += work[10];
+    work[0xb] += work[0xf];
+    work[3] += work[0xb];
+    work[0x10] += work[0x14];
+    work[4] += work[0x10];
+    work[0x11] += work[0x15];
+    work[5] += work[0x11];
+    work[0x12] += work[0x16];
+    work[6] += work[0x12];
+    work[0x13] += work[0x17];
+    work[7] += work[0x13];
+
+    if (obj->pppPObject.m_graphId == step->m_graphId) {
+        work[0] += *(s16*)(step->m_payload + 0xc);
+        work[1] += *(s16*)(step->m_payload + 0xe);
+        work[2] += *(s16*)(step->m_payload + 0x10);
+        work[3] += *(s16*)(step->m_payload + 0x12);
+        work[8] += *(s16*)(step->m_payload + 0x1c);
+        work[9] += *(s16*)(step->m_payload + 0x1e);
+        work[10] += *(s16*)(step->m_payload + 0x20);
+        work[0xb] += *(s16*)(step->m_payload + 0x22);
+        work[0xc] += *(s16*)(step->m_payload + 0x24);
+        work[0xd] += *(s16*)(step->m_payload + 0x26);
+        work[0xe] += *(s16*)(step->m_payload + 0x28);
+        work[0xf] += *(s16*)(step->m_payload + 0x2a);
+        work[4] += *(s16*)(step->m_payload + 0x14);
+        work[5] += *(s16*)(step->m_payload + 0x16);
+        work[6] += *(s16*)(step->m_payload + 0x18);
+        work[7] += *(s16*)(step->m_payload + 0x1a);
+        work[0x10] += *(s16*)(step->m_payload + 0x2c);
+        work[0x11] += *(s16*)(step->m_payload + 0x2e);
+        work[0x12] += *(s16*)(step->m_payload + 0x30);
+        work[0x13] += *(s16*)(step->m_payload + 0x32);
+        work[0x14] += *(s16*)(step->m_payload + 0x34);
+        work[0x15] += *(s16*)(step->m_payload + 0x36);
+        work[0x16] += *(s16*)(step->m_payload + 0x38);
+        work[0x17] += *(s16*)(step->m_payload + 0x3a);
+    }
+
+    *(u32*)(work + 0xdc) += (u32)step->m_initWOrk;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented pppKeShpTail3X in src/pppKeShpTail3X.cpp using the existing project conventions for PPP work-buffer layout and matrix helpers.

Key changes:
- Added local step/offset structs for this unit's serialized payload/offset access.
- Implemented history-ring initialization and update logic for tail positions.
- Implemented per-frame accumulator updates for angle/velocity-style short fields.
- Applied conditional graph-matched payload deltas and lifetime counter update.
- Added matrix-mode handling (payload[0x3F]) for world-space position path.

## Functions Improved
- Unit: main/pppKeShpTail3X
- Function: pppKeShpTail3X (PAL size 1516b)

## Match Evidence
Measured with:
- uild/tools/objdiff-cli report generate -p . -f json-pretty -o build/GCCP01/report_before_ke3x.json
- uild/tools/objdiff-cli report generate -p . -f json-pretty -o build/GCCP01/report_after_ke3x.json
- uild/tools/objdiff-cli report changes -f json-pretty build/GCCP01/report_before_ke3x.json build/GCCP01/report_after_ke3x.json -o build/GCCP01/report_changes_ke3x.json

Results:
- pppKeShpTail3X: **0.26385224% -> 79.440636%** fuzzy match
- Unit main/pppKeShpTail3X: **6.9955034% -> 33.981113%** fuzzy match

## Plausibility Rationale
This patch favors source-plausible behavior over compiler coercion:
- Uses straightforward field and ring-buffer updates that align with existing PPP frame functions.
- Uses normal type/sign handling (s16/u8/u32) and byte-offset access patterns already present in this codebase.
- No artificial temporaries or non-idiomatic sequencing added purely to chase codegen.

## Technical Notes
- objdiff-cli diff in this local tool build appears interactive-only; match evidence above uses JSON report change output.
- Compile verification performed with 
inja build/GCCP01/src/pppKeShpTail3X.o and 
inja (no additional rebuild needed after target object compile).
