### PR TITLE
cflat_r2system: add MapPcs/Graphic system wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1,6 +1,10 @@
 #include "ffcc/cflat_r2system.h"
 #include "ffcc/game.h"
+#include "ffcc/graphic.h"
+#include "ffcc/map.h"
+#include "ffcc/maphit.h"
 #include "ffcc/p_camera.h"
+#include "ffcc/p_map.h"
 #include "ffcc/p_menu.h"
 #include "ffcc/p_tina.h"
 #include "ffcc/sound.h"
@@ -9,6 +13,23 @@
 static inline CUSBStreamData* UsbStream(CPartPcs* self)
 {
     return reinterpret_cast<CUSBStreamData*>((char*)self + 0x8);
+}
+
+struct CMapCylinderRaw
+{
+    Vec m_bottom;
+    Vec m_direction;
+    float m_radius;
+    float m_height;
+    Vec m_top;
+    Vec m_direction2;
+    float m_radius2;
+    float m_height2;
+};
+
+extern "C" {
+int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned long);
+void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
 }
 
 /*
@@ -79,6 +100,66 @@ void CSound::SeMaxVolume(int volume)
 void CPartPcs::pppSetDebugHide(unsigned char hide)
 {
     UsbStream(this)->m_disableShokiDraw = hide;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8FB0
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void CalcHitPosition__7CMapPcsFP3Vec(CMapPcs*, Vec* hitPosition)
+{
+    CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A78), hitPosition);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B8FE0
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int CheckHitCylinderNear__7CMapPcsFP3VecP3VecfUl(
+    CMapPcs*, Vec* cylinderBottom, Vec* direction, float radius, unsigned long hitMask)
+{
+    CMapCylinderRaw cylinder;
+
+    cylinder.m_direction.x = 0.0f;
+    cylinder.m_direction.y = 0.0f;
+    cylinder.m_direction.z = 0.0f;
+    cylinder.m_direction2.x = 1.0f;
+    cylinder.m_direction2.y = 1.0f;
+    cylinder.m_direction2.z = 1.0f;
+
+    cylinder.m_bottom = *cylinderBottom;
+    cylinder.m_top = *direction;
+    cylinder.m_radius = radius;
+    cylinder.m_height = 0.0f;
+    cylinder.m_radius2 = 0.0f;
+    cylinder.m_height2 = 0.0f;
+
+    return CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(
+        &MapMng, reinterpret_cast<CMapCylinder*>(&cylinder), direction, hitMask);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9060
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" unsigned char* GetTmpFrameBuffer__8CGraphicFv(CGraphic* graphic)
+{
+    return *(unsigned char**)((char*)graphic + 0x7208);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three small system-wrapper functions in src/cflat_r2system.cpp that are referenced by CFlatRuntime2::onSystemFunc but were previously missing/0%:
- CalcHitPosition__7CMapPcsFP3Vec
- CheckHitCylinderNear__7CMapPcsFP3VecP3VecfUl
- GetTmpFrameBuffer__8CGraphicFv

The implementation uses existing project conventions (raw struct/offset wrappers and direct symbol calls) and includes PAL address/size metadata blocks.

## Functions Improved
Unit: main/cflat_r2system

- CalcHitPosition__7CMapPcsFP3Vec:  .0% -> 86.666664% (48b)
- CheckHitCylinderNear__7CMapPcsFP3VecP3VecfUl:  .0% -> 80.96875% (128b)
- GetTmpFrameBuffer__8CGraphicFv:  .0% -> 99.5% (8b)

## Match Evidence
- Baseline from selector (	ools/agent_select_target.py) listed these targets at  .0%.
- Post-change objdiff-cli report entries now show the percentages above.
- main/cflat_r2system fuzzy match now reports  .682243% with these symbols present and scored.

## Plausibility Rationale
These are thin forwarding/accessor wrappers that match how the game code uses these helpers:
- CMapPcs wrappers delegate to map manager/object collision internals.
- CGraphic wrapper returns the temp framebuffer pointer used by system script rendering paths.

No contrived control-flow tricks or unnatural compiler coaxing were introduced.

## Technical Details
- Added a local CMapCylinderRaw layout matching existing collision call patterns in the codebase.
- Reused existing mangled symbol calls already used elsewhere:
  - CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl
  - CalcHitPosition__7CMapObjFP3Vec
- Used the existing MapMng offset-based map-object pointer access pattern.

Validation:
- 
inja succeeds.
- objdiff-cli report generate -p . -o tmp_objdiff_report.json -f json-pretty used to verify function-level improvements.