### PR TITLE
gx/GXLight: improve GXSetNumChans match via local caching

### DIFF
--- a/src/gx/GXLight.c
+++ b/src/gx/GXLight.c
@@ -522,14 +522,19 @@ void GXSetChanMatColor(GXChannelID chan, GXColor mat_color) {
 }
 
 void GXSetNumChans(u8 nChans) {
+    u32 n;
+    GXData* data;
+
     CHECK_GXBEGIN(857, "GXSetNumChans");
     ASSERTMSGLINE(858, nChans <= 2, "GXSetNumChans: nChans > 2");
 
-    __GXData->genMode = (__GXData->genMode & ~0x70) | ((u32)(nChans & 0xFF) << 4);
+    data = __GXData;
+    n = nChans;
+    data->genMode = (data->genMode & ~0x70) | (n << 4);
     GX_WRITE_U8(0x10);
     GX_WRITE_U32(0x1009);
-    GX_WRITE_U32(nChans & 0xFF);
-    __GXData->dirtyState |= 4;
+    GX_WRITE_U32(n);
+    data->dirtyState |= 4;
 }
 
 void GXSetChanCtrl(GXChannelID chan, GXBool enable, GXColorSrc amb_src, GXColorSrc mat_src, u32 light_mask, GXDiffuseFn diff_fn, GXAttnFn attn_fn) {


### PR DESCRIPTION
Summary: Refactored GXSetNumChans in src/gx/GXLight.c to cache __GXData and nChans as locals before register writes; behavior unchanged. Functions improved: main/gx/GXLight::GXSetNumChans. Match evidence: GXSetNumChans 96.35294% -> 99.588234% (+3.235294); unit .text 87.55502% -> 87.6866% (+0.13158) using objdiff-cli one-shot JSON diffs. Plausibility rationale: straightforward local aliasing with preserved register write order and side effects, no contrived control flow or hardcoded offsets. Technical details: reduced repeated __GXData/nChans expressions, improving register allocation/codegen alignment.