### PR TITLE
mapmesh: improve DrawMesh/GetTexture match quality

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -269,19 +269,18 @@ void CMapMesh::SetRenderArray()
  */
 void CMapMesh::DrawMesh(unsigned short startIdx, unsigned short count)
 {
-    unsigned int remaining = count;
-    MeshDrawEntry* entry = DrawEntries(this) + startIdx;
+    unsigned int remaining = count & 0xFFFF;
+    MeshDrawEntry* entry = DrawEntries(this) + (startIdx & 0xFFFF);
 
     while (remaining != 0) {
+        remaining--;
         if (entry->size != 0) {
-            CMaterialSet* materialSet = DefaultMaterialSet();
-            SetBlendMode__12CMaterialManFP12CMaterialSeti(MaterialMan, materialSet, entry->materialIdx);
-            SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(MaterialMan, materialSet, entry->materialIdx, 0,
-                                                                       1);
+            SetBlendMode__12CMaterialManFP12CMaterialSeti(MaterialMan, DefaultMaterialSet(), entry->materialIdx);
+            SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(MaterialMan, DefaultMaterialSet(),
+                                                                       entry->materialIdx, 0, 1);
             GXCallDisplayList(entry->displayList, entry->size);
         }
         entry++;
-        remaining--;
     }
 }
 
@@ -380,23 +379,18 @@ void CMapMesh::DrawPart(CMaterialSet* materialSet, int drawMaterialPart)
  */
 void* CMapMesh::GetTexture(CMaterialSet* materialSet, int& textureIndex)
 {
-    int* drawEntry;
-
-    if (U16At(this, 0xA) == 0) {
-        return 0;
-    }
-
-    drawEntry = reinterpret_cast<int*>(PtrAt(this, 0x40));
-    if (*drawEntry == 0) {
+    int* drawEntry = reinterpret_cast<int*>(PtrAt(this, 0x40));
+    if ((U16At(this, 0xA) == 0) || (*drawEntry == 0)) {
         return 0;
     }
 
     unsigned short materialIdx = *reinterpret_cast<unsigned short*>(drawEntry + 2);
     textureIndex = materialIdx;
-
-    CMaterial* material =
-        (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[materialIdx];
-    return *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(material) + 0x3C);
+    return *reinterpret_cast<void**>(
+        reinterpret_cast<unsigned char*>(
+            (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[materialIdx]
+        ) +
+        0x3C);
 }
 
 /*


### PR DESCRIPTION
## Summary
Adjusted CMapMesh::DrawMesh and CMapMesh::GetTexture control/data flow in src/mapmesh.cpp to more closely reflect original code generation patterns.

## Functions improved
- Unit: main/mapmesh
- DrawMesh__8CMapMeshFUsUs: **48.8182% -> 59.7273%**
- GetTexture__8CMapMeshFP12CMaterialSetRi: **65.6818% -> 66.1364%**
- Unit fuzzy score: **36.9551% -> 37.4231%**

## Match evidence
From uild/GCCP01/report.json after 
inja:
- Before: main/mapmesh fuzzy 36.95511
- After: main/mapmesh fuzzy 37.423115
- Largest improvement is in DrawMesh.

## Plausibility rationale
- No contrived temporaries or unnatural sequencing were added.
- No new magic offsets were introduced; existing struct/accessor semantics were preserved.
- Changes are limited to type/control-flow expression consistent with surrounding CMapMesh code.

## Technical details
- DrawMesh: reshaped loop/decrement and explicit 16-bit masking on start/count handling; direct default-material-set usage at call sites.
- GetTexture: collapsed guard checks and simplified material lookup/texture pointer extraction path.

## Validation
- 
inja passes.
