### PR TITLE
stopwatch: add matching delete thunk for dtor_80021440

### DIFF
--- a/src/stopwatch.cpp
+++ b/src/stopwatch.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/stopwatch.h"
 
 extern "C" float __cvt_sll_flt(u32 lo, u32 hi);
+extern "C" void __dl__FPv(void* ptr);
 
 extern char lbl_8032F860;
 extern float lbl_8032F850;
@@ -23,6 +24,24 @@ CStopWatch::CStopWatch(char* name)
  * Size:	TODO
  */
 CStopWatch::~CStopWatch() {}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80021440
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CStopWatch* dtor_80021440(CStopWatch* stopWatch, short shouldDelete)
+{
+	if ((stopWatch != nullptr) && (shouldDelete > 0))
+	{
+		__dl__FPv(stopWatch);
+	}
+	return stopWatch;
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added the missing delete-thunk helper `dtor_80021440` for `CStopWatch` in `src/stopwatch.cpp`.
- Implemented the expected Metrowerks-style `extern C` wrapper signature:
  - Returns `this` pointer
  - Calls `__dl__FPv` only when `this != nullptr` and `shouldDelete > 0`
- Added PAL function metadata block for address/size.

## Functions improved
- Unit: `main/stopwatch`
- Function: `dtor_80021440` (size 60b)
  - Before: unmapped / 0% (listed as non-matching)
  - After: 100.0% fuzzy match

## Match evidence
- `main/stopwatch` fuzzy match percent:
  - Before: `89.87059%`
  - After: `98.694115%`
- Unit gained one fully matched function (6/9 -> 7/9 matched functions).
- Global progress impact observed in `ninja`:
  - Code matched bytes: `191040 -> 191100`
  - Matched functions: `1355 -> 1356`

## Plausibility rationale
- This is a standard deleting-destructor thunk pattern used throughout this repo (e.g. `dtor_...` wrappers in other units).
- The implementation aligns with expected compiler output semantics rather than contrived source transformations:
  - conditional free gate by signed delete flag
  - no extra control flow or artificial temporaries
  - direct allocation API thunk (`__dl__FPv`) consistent with existing codebase style.

## Technical details
- Ghidra reference for PAL `0x80021440` indicates a tiny wrapper with only delete-flag logic and return of the original pointer.
- The source now models that exact shape, allowing objdiff to map and match the previously missing function cleanly.