### PR TITLE
maptexanim: decompile CMapTexAnimSet::Create first pass

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -1,11 +1,23 @@
 #include "ffcc/maptexanim.h"
+#include "ffcc/chunkfile.h"
+#include "ffcc/map.h"
+#include "ffcc/memory.h"
 #include "ffcc/system.h"
 
 extern "C" void Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet(CMapTexAnim*, CMaterialSet*, CTextureSet*);
+extern "C" void ReadJun__12CMapKeyFrameFR10CChunkFilei(CMapKeyFrame*, CChunkFile*, int);
+extern "C" void ReadFrame__12CMapKeyFrameFR10CChunkFilei(CMapKeyFrame*, CChunkFile*, int);
+extern "C" void ReadKey__12CMapKeyFrameFR10CChunkFilei(CMapKeyFrame*, CChunkFile*, int);
+extern "C" void __ct__4CRefFv(void*);
 extern "C" void __dt__4CRefFv(void*, int);
+extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void __dl__FPv(void*);
 extern "C" void* PTR_PTR_s_CMapTexAnimSet_801e896c;
 extern "C" void* PTR_PTR_s_CMapTexAnim_801ea9a4;
+extern "C" char s_maptexanim_cpp_801d7ec4[];
+extern "C" float FLOAT_8032fd48;
+extern "C" float FLOAT_8032fd4c;
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)
@@ -16,6 +28,11 @@ static inline unsigned char* Ptr(void* p, unsigned int offset)
 static inline short& S16At(void* p, unsigned int offset)
 {
     return *reinterpret_cast<short*>(Ptr(p, offset));
+}
+
+static inline unsigned short& U16At(void* p, unsigned int offset)
+{
+    return *reinterpret_cast<unsigned short*>(Ptr(p, offset));
 }
 
 static inline int& S32At(void* p, unsigned int offset)
@@ -85,9 +102,81 @@ CMapTexAnimSet::~CMapTexAnimSet()
  * Address:	TODO
  * Size:	TODO
  */
-void CMapTexAnimSet::Create(CChunkFile&, CMaterialSet*, CTextureSet*)
+void CMapTexAnimSet::Create(CChunkFile& chunkFile, CMaterialSet* materialSet, CTextureSet* textureSet)
 {
-	// TODO
+    CMapTexAnim* anim = 0;
+    CChunkFile::CChunk chunk;
+    CMemory::CStage* const stage = *reinterpret_cast<CMemory::CStage**>(&MapMng);
+
+    *reinterpret_cast<CMaterialSet**>(Ptr(this, 0x10C)) = materialSet;
+    *reinterpret_cast<CTextureSet**>(Ptr(this, 0x110)) = textureSet;
+
+    chunkFile.PushChunk();
+    while (chunkFile.GetNextChunk(chunk)) {
+        if (chunk.m_id == 0x4B455920) {
+            ReadKey__12CMapKeyFrameFR10CChunkFilei(
+                reinterpret_cast<CMapKeyFrame*>(Ptr(anim, 0x24)), &chunkFile, static_cast<int>(chunk.m_arg0));
+            U8At(anim, 0x15) = 1;
+        } else if (chunk.m_id < 0x4B455920) {
+            if (chunk.m_id == 0x4A554E20) {
+                ReadJun__12CMapKeyFrameFR10CChunkFilei(
+                    reinterpret_cast<CMapKeyFrame*>(Ptr(anim, 0x24)), &chunkFile, static_cast<int>(chunk.m_arg0));
+            } else if (chunk.m_id == 0x4652414D) {
+                ReadFrame__12CMapKeyFrameFR10CChunkFilei(
+                    reinterpret_cast<CMapKeyFrame*>(Ptr(anim, 0x24)), &chunkFile, static_cast<int>(chunk.m_arg0));
+            }
+        } else if (chunk.m_id == 0x54414E4D) {
+            anim = static_cast<CMapTexAnim*>(__nw__FUlPQ27CMemory6CStagePci(0x4C, stage, s_maptexanim_cpp_801d7ec4, 0x24));
+            if (anim != 0) {
+                __ct__4CRefFv(anim);
+                *reinterpret_cast<void**>(anim) = &PTR_PTR_s_CMapTexAnim_801ea9a4;
+                F32At(anim, 0x18) = FLOAT_8032fd48;
+                F32At(anim, 0x1C) = FLOAT_8032fd4c;
+                U8At(anim, 0x14) = 0;
+                U8At(anim, 0x15) = 0;
+                U16At(anim, 0x12) = 0xFFFF;
+                U8At(anim, 0x16) = 1;
+                S32At(anim, 0x2C) = 0;
+                S32At(anim, 0x30) = 0;
+                *reinterpret_cast<void**>(Ptr(anim, 0x20)) = 0;
+                *reinterpret_cast<void**>(Ptr(anim, 0x40)) = 0;
+                *reinterpret_cast<void**>(Ptr(anim, 0x44)) = 0;
+            }
+
+            U16At(anim, 0x8) = chunkFile.Get2();
+            U16At(anim, 0xA) = chunkFile.Get2();
+            U16At(anim, 0xC) = chunkFile.Get2();
+            U16At(anim, 0x10) = U16At(anim, 0xC);
+            S32At(anim, 0x1C) = static_cast<int>(static_cast<float>(static_cast<short>(chunkFile.Get2())));
+            U16At(anim, 0xE) = 0;
+            F32At(anim, 0x18) = chunkFile.GetF4();
+            U8At(anim, 0x14) = chunkFile.Get1();
+            chunkFile.Get1();
+            chunkFile.Get1();
+            chunkFile.Get1();
+
+            if (chunk.m_version == 0) {
+                chunkFile.Get4();
+                U16At(anim, 0x12) = 0xFFFF;
+            } else {
+                U16At(anim, 0x12) = chunkFile.Get2();
+                chunkFile.Get2();
+            }
+
+            chunkFile.Get4();
+            chunkFile.Get4();
+            *reinterpret_cast<void**>(Ptr(anim, 0x20)) = __nwa__FUlPQ27CMemory6CStagePci(
+                static_cast<unsigned long>(S16At(anim, 0xC) << 1), stage, s_maptexanim_cpp_801d7ec4, 0x3B);
+            for (int i = 0; i < S16At(anim, 0xC); i++) {
+                U16At(*reinterpret_cast<void**>(Ptr(anim, 0x20)), i * 2) = chunkFile.Get2();
+            }
+
+            const short count = S16At(this, 8);
+            S16At(this, 8) = count + 1;
+            AnimAt(this, count) = anim;
+        }
+    }
+    chunkFile.PopChunk();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass decompilation of `CMapTexAnimSet::Create` in `src/maptexanim.cpp`.
- Added chunk parsing and TANM record construction logic, including keyframe read dispatch (`KEY ` / `JUN ` / `FRAM`), per-entry initialization, table allocation, and appending created anim entries into the set.
- Kept implementation style consistent with existing maptexanim code by using the same low-level offset-based field access patterns.

## Functions Improved
- Unit: `main/maptexanim`
- Symbol: `Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet`

## Match Evidence
- Before: `0.5714286%`
- After: `48.205715%`
- Delta: `+47.6342864%`

Command used:
```sh
tools/objdiff-cli diff -p . -u main/maptexanim -o diff_after.json --format json Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet
```

Spot-check on neighboring symbols in the same unit showed no change from this commit:
- `SetMapTexAnim__14CMapTexAnimSetFiiii`: `41.63768%` -> `41.63768%`
- `Calc__14CMapTexAnimSetFv`: `90.76923%` -> `90.76923%`
- `__dt__11CMapTexAnimFv`: `82.09091%` -> `82.09091%`

## Plausibility Rationale
- The new implementation follows expected original-source behavior for chunk-driven asset construction:
  - stores material/texture set pointers on the owning set,
  - iterates child chunks with type-dispatch,
  - allocates and initializes a map tex anim object,
  - consumes serialized fields from the chunk stream,
  - appends created entries into the set's pointer array.
- The change avoids artificial score-only transformations and keeps intent-readable control flow while preserving codebase conventions.

## Technical Notes
- Used the corresponding Ghidra decomp reference (`80050064_Create__14CMapTexAnimSet...`) as structural guidance for chunk IDs, field order, and allocation callsites.
- Retained explicit external symbols (`__nw`, `__nwa`, `CMapKeyFrame` readers, `CRef` ctor) where that aligns with existing decomp style in this repository.