### PR TITLE
main/game: match CGame::GetPartyObj accessor

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -119,7 +119,7 @@ public:
     void GetFoodLevel(int, int);
     void GetTargetCursor(int, Vec&, Vec&);
     void GetParticleSpecialInfo(PPPIFPARAM&, int&, int&);
-    void GetPartyObj(int);
+    CGPartyObj* GetPartyObj(int);
     void MakeArtItemName(char*, int, int);
     void MakeArtsItemNames(char*, int);
     void MakeNumItemName(char*, int, int);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -523,9 +523,9 @@ void CGame::GetParticleSpecialInfo(PPPIFPARAM&, int&, int&)
  * Address:	TODO
  * Size:	TODO
  */
-void CGame::GetPartyObj(int)
+CGPartyObj* CGame::GetPartyObj(int index)
 {
-	// TODO
+    return m_partyObjArr[index];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected CGame::GetPartyObj declaration/definition to return CGPartyObj*.
- Implemented it as a direct indexed accessor of m_partyObjArr.

## Functions improved
- Unit: main/game
- Symbol: GetPartyObj__5CGameFi (20 bytes)

## Match evidence
- GetPartyObj__5CGameFi: **20.0% -> 100.0%** fuzzy match
- main/game matched code: **216 -> 236 bytes** (+20)
- main/game fuzzy match: **11.185524 -> 11.351913**
- Overall matched code: **191100 -> 191120 bytes** (+20)

## Plausibility rationale
- CGame owns m_partyObjArr[4]; returning an indexed entry is the natural original-source implementation for a GetPartyObj(int) accessor.
- The change improves readability and type correctness (previous oid TODO stub could not represent original behavior).

## Technical details
- Updated signature in include/ffcc/game.h.
- Implemented in src/game.cpp as eturn m_partyObjArr[index];.
- Verified by rebuilding with 
inja and comparing objdiff report metrics before/after.
