### PR TITLE
gx: improve GXSetDispCopyDst match with stride/reg shape

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -142,20 +142,22 @@ void GXSetTexCopySrc(u16 left, u16 top, u16 wd, u16 ht) {
 }
 
 void GXSetDispCopyDst(u16 wd, u16 ht) {
+    GXData* gx;
     u16 stride;
     u32 reg;
 
     ASSERTMSGLINE(1293, (wd & 0xF) == 0, "GXSetDispCopyDst: Width must be a multiple of 16");
     CHECK_GXBEGIN(1294, "GXSetDispCopyDst");
+    gx = __GXData;
 
-    stride = (int)wd * 2;
-    __GXData->cpDispStride = 0;
-    reg = __GXData->cpDispStride;
+    stride = (wd & 0x7FFF) << 1;
+    gx->cpDispStride = 0;
+    reg = gx->cpDispStride;
     reg = (reg & 0xFFFFFC00) | ((u32)stride >> 5);
-    __GXData->cpDispStride = reg;
-    reg = __GXData->cpDispStride;
+    gx->cpDispStride = reg;
+    reg = gx->cpDispStride;
     reg = (reg & 0x00FFFFFF) | 0x4D000000;
-    __GXData->cpDispStride = reg;
+    gx->cpDispStride = reg;
 }
 
 void GXSetTexCopyDst(u16 wd, u16 ht, GXTexFmt fmt, GXBool mipmap) {


### PR DESCRIPTION
Refines GXSetDispCopyDst shape to improve match (local GXData* and stride expression update).\n\n- GXSetDispCopyDst: 80.333336% -> 83.8%\n- Unit main/gx/GXFrameBuf: 75.537544% -> 75.599525%\n- Build verified with ninja