### PR TITLE
astar: restore AStar global init path

### DIFF
--- a/include/ffcc/astar.h
+++ b/include/ffcc/astar.h
@@ -67,4 +67,6 @@ public:
 	CATemp m_bestPath;                      // 0x2420
 }; // Size 0x24a8
 
+extern CAStar AStar;
+
 #endif // _FFCC_ASTAR_H_

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -24,6 +24,8 @@ extern Mtx gFlatPosMtx;
 extern int DAT_8032ed70;
 extern unsigned char lbl_8032EC90[];
 
+CAStar AStar;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -31,7 +33,7 @@ extern unsigned char lbl_8032EC90[];
  */
 CAStar::CAStar()
 {
-	// TODO
+	reset();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added the missing global A* manager instance (`AStar`) declaration/definition so the astar unit emits the expected static object initialization path.
- Updated `CAStar::CAStar()` to call `reset()`, which aligns static initialization behavior with the decompiled PAL init sequence (zeroing portal count, portals, and route table after `CATemp` member init).

## Functions Improved
- Unit: `main/astar`
- Function: `__sinit_astar_cpp` (`136b`)
  - Before: `0.0%` (pre-change report had no fuzzy value for this symbol)
  - After: `100.0%`

## Match Evidence
- `main/astar` unit fuzzy match:
  - Before: `68.46964%`
  - After: `70.416954%`
- Global progress (from `ninja`):
  - Matched code: `191120` -> `191256` bytes (`+136`)
  - Matched functions: `1357` -> `1358`

## Plausibility Rationale
- A global `AStar` object is present in symbol data and fits the codebase pattern of global manager objects.
- Calling `reset()` from the constructor is plausible original-source initialization and explains the emitted static init sequence without contrived compiler-forcing changes.

## Technical Details
- Restored expected object shape via `extern` declaration in header and translation-unit definition.
- Constructor now establishes portal and route-table state immediately, producing matching `__sinit_astar_cpp` behavior.
