### PR TITLE
Improve pppRandChar match via direct delta arithmetic

### DIFF
--- a/src/pppRandChar.cpp
+++ b/src/pppRandChar.cpp
@@ -66,20 +66,6 @@ extern "C" void pppRandChar(void* param1, void* param2, void* param3)
         target = base + in->sourceOffset + 0x80;
     }
 
-    union {
-        f64 d;
-        struct {
-            u32 hi;
-            u32 lo;
-        } parts;
-    } cvt;
-
-    u8 current = *target;
-    cvt.parts.hi = 0x43300000;
-    cvt.parts.lo = in->scale;
-    f64 scaled = cvt.d - lbl_8032FF00;
-    cvt.parts.lo = current;
-
-    s32 delta = (s32)(scaled * *valuePtr - (cvt.d - lbl_8032FF00));
-    *target = (u8)(current + delta);
+    s32 delta = (s32)((f32)in->scale * *valuePtr - (f32)*target);
+    *target = (u8)(*target + delta);
 }


### PR DESCRIPTION
## Summary
- Simplified the final `pppRandChar` update arithmetic in `src/pppRandChar.cpp` by replacing the temporary double-conversion union path with direct typed arithmetic.
- Kept behavior/source intent aligned: update target by adding a computed delta derived from scale, random value, and current target.

## Functions improved
- Unit: `main/pppRandChar`
- Symbol: `pppRandChar`

## Match evidence
- `pppRandChar` fuzzy match: **87.7% -> 95.8125%**
- Build verification: `ninja` succeeds after change.

## Plausibility rationale
- The new expression is a straightforward typed form of the same blend/delta pattern used across related `pppRand*` functions.
- It removes decompiler-shaped conversion scaffolding and keeps code in a style a human author would plausibly write.

## Technical details
- Replaced manual `f64` union packing/conversion steps with direct delta arithmetic in typed C++.
- New core expression:
  - `s32 delta = (s32)((f32)in->scale * *valuePtr - (f32)*target);`
  - `*target = (u8)(*target + delta);`