### PR TITLE
Improve match for pppSRandDownFV

### DIFF
--- a/src/pppSRandDownFV.cpp
+++ b/src/pppSRandDownFV.cpp
@@ -37,16 +37,18 @@ void pppSRandDownFV(void* param1, void* param2, void* param3)
 
     unsigned char* self = reinterpret_cast<unsigned char*>(param1);
     Param* cfg = reinterpret_cast<Param*>(param2);
-    SelectInfo* sel = reinterpret_cast<SelectInfo*>(param3);
     float* randVec;
+    int currentIndex;
 
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    if (*reinterpret_cast<int*>(self + 0xC) == 0) {
-        randVec = reinterpret_cast<float*>(self + *sel->offsetPtr + 0x80);
+    currentIndex = *reinterpret_cast<int*>(self + 0xC);
+    if (currentIndex == 0) {
+        int offset = *reinterpret_cast<SelectInfo*>(param3)->offsetPtr;
         unsigned char blendTwice = cfg->blendTwice;
+        randVec = reinterpret_cast<float*>(self + offset + 0x80);
 
         float value = -RandF__5CMathFv(&math);
         if (blendTwice != 0) {
@@ -66,10 +68,10 @@ void pppSRandDownFV(void* param1, void* param2, void* param3)
         }
         randVec[2] = value;
     } else {
-        if (cfg->index != *reinterpret_cast<int*>(self + 0xC)) {
+        if (cfg->index != currentIndex) {
             return;
         }
-        randVec = reinterpret_cast<float*>(self + *sel->offsetPtr + 0x80);
+        randVec = reinterpret_cast<float*>(self + *reinterpret_cast<SelectInfo*>(param3)->offsetPtr + 0x80);
     }
 
     float* target;
@@ -79,7 +81,16 @@ void pppSRandDownFV(void* param1, void* param2, void* param3)
         target = reinterpret_cast<float*>(self + cfg->offset + 0x80);
     }
 
-    target[0] += cfg->x * randVec[0];
-    target[1] += cfg->y * randVec[1];
-    target[2] += cfg->z * randVec[2];
+    {
+        float value = cfg->x * randVec[0];
+        target[0] = target[0] + value;
+    }
+    {
+        float value = cfg->y * randVec[1];
+        target[1] = target[1] + value;
+    }
+    {
+        float value = cfg->z * randVec[2];
+        target[2] = target[2] + value;
+    }
 }


### PR DESCRIPTION
## Summary
- Refined `pppSRandDownFV` control flow to better match original branch structure by caching `self + 0xC` state and reusing it across the early-return path.
- Reworked random-vector setup to keep offset/flag usage localized and reduce extra reload patterns.
- Replaced compound vector updates with explicit multiply-then-add blocks to match non-fused arithmetic emission more closely.

## Functions improved
- Unit: `main/pppSRandDownFV`
- Symbol: `pppSRandDownFV`
- Size: `428b`

## Match evidence
- `pppSRandDownFV` fuzzy match: **80.46729% -> 85.37383%** (`+4.90654`)
- Verified with:
  - `ninja`
  - `tools/objdiff-cli diff -p . -u main/pppSRandDownFV -o - pppSRandDownFV`

## Plausibility rationale
- Changes are source-plausible cleanup (state caching, clearer branch conditions, explicit arithmetic staging) rather than artificial compiler coaxing.
- The resulting code keeps behavior and readability consistent with nearby `pppSRand*` implementations while improving emitted control-flow/arithmetic alignment.

## Technical details
- Reduced divergence in the branch tree around the `currentIndex == 0` generation path versus reuse path.
- Aligned final target updates toward separate mul/add instruction sequences instead of fused forms.
- Remaining gaps are primarily register allocation/global-access form differences, likely tied to broader TU/compiler settings.