### PR TITLE
gxfunc: use packed entry access in Tev input cache wrappers

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -132,12 +132,14 @@ void _GXSetTevOp(_GXTevStageID stage, _GXTevMode mode)
  */
 void _GXSetTevColorIn(_GXTevStageID stage, _GXTevColorArg a, _GXTevColorArg b, _GXTevColorArg c, _GXTevColorArg d)
 {
-	if (s_GXSetTevColorIn_Reg[stage].a != a || s_GXSetTevColorIn_Reg[stage].b != b || s_GXSetTevColorIn_Reg[stage].c != c ||
-	    s_GXSetTevColorIn_Reg[stage].d != d) {
-		s_GXSetTevColorIn_Reg[stage].a = a;
-		s_GXSetTevColorIn_Reg[stage].b = b;
-		s_GXSetTevColorIn_Reg[stage].c = c;
-		s_GXSetTevColorIn_Reg[stage].d = d;
+	int stageOff = stage * 0x10;
+	int* entry = (int*)((char*)s_GXSetTevColorIn_Reg + stageOff);
+
+	if (entry[0] != a || entry[1] != b || entry[2] != c || entry[3] != d) {
+		entry[0] = a;
+		entry[1] = b;
+		entry[2] = c;
+		entry[3] = d;
 		GXSetTevColorIn(stage, a, b, c, d);
 	}
 }
@@ -153,12 +155,14 @@ void _GXSetTevColorIn(_GXTevStageID stage, _GXTevColorArg a, _GXTevColorArg b, _
  */
 void _GXSetTevAlphaIn(_GXTevStageID stage, _GXTevAlphaArg a, _GXTevAlphaArg b, _GXTevAlphaArg c, _GXTevAlphaArg d)
 {
-	if (s_GXSetTevAlphaIn_Reg[stage].a != a || s_GXSetTevAlphaIn_Reg[stage].b != b || s_GXSetTevAlphaIn_Reg[stage].c != c ||
-	    s_GXSetTevAlphaIn_Reg[stage].d != d) {
-		s_GXSetTevAlphaIn_Reg[stage].a = a;
-		s_GXSetTevAlphaIn_Reg[stage].b = b;
-		s_GXSetTevAlphaIn_Reg[stage].c = c;
-		s_GXSetTevAlphaIn_Reg[stage].d = d;
+	int stageOff = stage * 0x10;
+	int* entry = (int*)((char*)s_GXSetTevAlphaIn_Reg + stageOff);
+
+	if (entry[0] != a || entry[1] != b || entry[2] != c || entry[3] != d) {
+		entry[0] = a;
+		entry[1] = b;
+		entry[2] = c;
+		entry[3] = d;
 		GXSetTevAlphaIn(stage, a, b, c, d);
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked `_GXSetTevColorIn` and `_GXSetTevAlphaIn` in `src/gxfunc.cpp` to use packed `int*` cache entry access.
- Preserved behavior: compare cached args, update cache, then call GX only when inputs changed.

## Functions improved
- `_GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg`
- `_GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg`

## Match evidence
`objdiff-cli report generate` before/after on unit `main/gxfunc`:
- Fuzzy match: **74.322334% -> 77.72335%**
- Matched code: **392/1576 -> 616/1576**
- Matched functions: **4/11 -> 6/11**
- `_GXSetTevColorIn...`: **76.07143% -> 100.0%**
- `_GXSetTevAlphaIn...`: **76.07143% -> 100.0%**

## Plausibility rationale
- This matches the existing register-cache style already used by neighboring wrappers in the same file (`_GXSetTevOrder`, `_GXSetTevSwapMode`, `_GXSetTevSwapModeTable`).
- No contrived compiler-only constructs were introduced.

## Technical details
- Stage-local offset math (`stage * 0x10`) + `int* entry` for 4-field compare/store.
- Call sites and cache invalidation behavior unchanged.