### PR TITLE
Improve GXSetScissorBoxOffset bitfield packing match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -617,17 +617,14 @@ void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht) {
  */
 void GXSetScissorBoxOffset(s32 x_off, s32 y_off) {
     u32 reg;
-    u32 x;
-    u32 y;
 
     CHECK_GXBEGIN(1119, "GXSetScissorBoxOffset");
 
     ASSERTMSGLINE(1122, (u32)(x_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid X offset");
     ASSERTMSGLINE(1124, (u32)(y_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid Y offset");
 
-    x = (u32)(x_off + 342);
-    y = (u32)(y_off + 342);
-    reg = (((x >> 1) & 0x3FF) | ((((y >> 1) << 10) & 0x0FFC00))) | 0x59000000;
+    reg = ((((u32)(x_off + 0x156) >> 1) & 0x7FF003FF) | (((u32)(y_off + 0x156) << 9) & 0xFFFFFC00)) & 0x00FFFFFF;
+    reg |= 0x59000000;
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
Improves GXSetScissorBoxOffset match by rewriting bitfield packing to SDK-style expression.\n\nMatch evidence:\n- GXSetScissorBoxOffset: 69.375% -> 82.8125%\n- main/gx/GXTransform unit: 81.92277% -> 82.35976%