### PR TITLE
Fix crystal destructor work offsets

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -58,10 +58,12 @@ void pppConstructCrystal(struct pppCrystal* pppCrystal, struct UnkC* param_2)
  */
 void pppDestructCrystal(struct pppCrystal* pppCrystal, struct UnkC* param_2)
 {
+	s32 serializedOffset;
 	CMemory::CStage* stage;
 	u32* puVar1;
 	
-	puVar1 = (u32*)((char*)pppCrystal + 8 + param_2->m_serializedDataOffsets[2]);
+	serializedOffset = param_2->m_serializedDataOffsets[2];
+	puVar1 = (u32*)((char*)pppCrystal + 0x80 + serializedOffset);
 	stage = (CMemory::CStage*)puVar1[0];
 	if ((stage != 0) && (*(CMemory::CStage**)stage != 0)) {
 		pppHeapUseRate(*(CMemory::CStage**)stage);

--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -62,7 +62,7 @@ void pppDestructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
     u32* puVar1;
     CMemory::CStage* stage;
 
-    puVar1 = (u32*)((u8*)pppCrystal2 + param_2->m_serializedDataOffsets[2] + 8);
+    puVar1 = (u32*)((u8*)pppCrystal2 + param_2->m_serializedDataOffsets[2] + 0x80);
     stage = (CMemory::CStage*)puVar1[0];
     
     if ((CMemory::CStage*)puVar1[1] != 0) {


### PR DESCRIPTION
## Summary
Adjusted serialized work-area base offsets in crystal destructor routines from + 8 to + 0x80, aligning with surrounding particle-object layout usage and existing patterns across PPP units.

## Functions Improved
- main/pppCrystal :: pppDestructCrystal
  - Match: 98.17647% -> 98.20588%
- main/pppCrystal2 :: pppDestructCrystal2
  - Match: 99.97059% -> 100.00000%

## Match Evidence
- Verified with 	ools/objdiff-cli v3.6.1 one-shot JSON diffs on each symbol.
- Project progress after rebuild (
inja):
  - Code matched bytes: 191480 -> 191616 (+136)
  - Matched functions: 1360 -> 1361 (+1)

## Plausibility Rationale
- PPP serialized runtime work data is consistently addressed from a 