### PR TITLE
pppYmMoveCircle: improve construct match via explicit direction setup

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -38,12 +38,18 @@ extern f32 lbl_80330D90;
  */
 extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleOffsets* offsetData)
 {
-    Vec temp1, temp2;
+    Vec temp1;
+    Vec temp2;
+    u8* pppMngSt = lbl_8032ED50;
     pppYmMoveCircleWork* work = (pppYmMoveCircleWork*)((u8*)basePtr + *offsetData->m_serializedDataOffsets + 0x80);
 
-    PSVECSubtract(&temp1, &temp2, &temp1);
+    PSVECSubtract((Vec*)(pppMngSt + 0x68), (Vec*)(pppMngSt + 0x58), &temp1);
     PSVECNormalize(&temp1, &temp1);
-    work->m_angle = lbl_80330D90 * (f32)acos(PSVECDotProduct(&temp1, &temp2));
+
+    temp2.x = lbl_80330D7C;
+    temp2.y = lbl_80330D8C;
+    temp2.z = lbl_80330D7C;
+    work->m_angle = lbl_80330D90 * (f32)acos(PSVECDotProduct(&temp2, &temp1));
 
     if (!((temp1.x <= lbl_80330D7C && temp1.z >= lbl_80330D7C) ||
           (temp1.x > lbl_80330D7C && temp1.z < lbl_80330D7C))) {
@@ -56,7 +62,7 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
     work->m_radius = lbl_80330D7C;
     work->m_radiusStep = lbl_80330D7C;
     work->m_radiusStepStep = lbl_80330D7C;
-    pppCopyVector(work->m_center, *(Vec*)((u8*)lbl_8032ED50 + 0x58));
+    pppCopyVector(work->m_center, *(Vec*)(pppMngSt + 0x58));
     work->m_hasInit = 0;
 }
 


### PR DESCRIPTION
## Summary
- Reworked `pppConstructYmMoveCircle` to use explicit manager-space source vectors for the initial direction calculation.
- Initialized the dot-product basis vector as `{0, 1, 0}` before `PSVECDotProduct`.
- Kept existing control flow/field writes intact and only adjusted source-plausible vector setup and addressing.

## Functions improved
- Unit: `main/pppYmMoveCircle`
- Symbol: `pppConstructYmMoveCircle`
  - Before: `69.973335%`
  - After: `72.666664%`
  - Delta: `+2.693329%`
- Symbol: `pppFrameYmMoveCircle`
  - Before: `73.36429%`
  - After: `73.36429%` (no change)

## Match evidence
- Built successfully with `ninja`.
- Objdiff command used:
  - `tools/objdiff-cli diff -p . -u main/pppYmMoveCircle -o -`
- Construct diff profile shifted toward better alignment:
  - `MATCH` instructions: `30 -> 45`
  - `DIFF_ARG_MISMATCH`: `28 -> 19`
  - `DIFF_DELETE`: `12 -> 9`

## Plausibility rationale
- The new code uses data already present in manager state (`+0x68` and `+0x58`) to compute a direction vector, which is a natural source-level way to derive the circle angle.
- Using a `{0, 1, 0}` basis for the dot/acos angle step is consistent with common game-engine axis-angle setup and avoids contrived compiler-only transformations.
- No synthetic temporaries or non-idiomatic sequencing were added beyond what is required to represent the inferred behavior.

## Technical notes
- The change specifically targets early construct math/argument setup, where prior code was using uninitialized local vectors.
- Matrix/copy/update behavior in `pppFrameYmMoveCircle` was intentionally left unchanged in this pass.