### PR TITLE
GXTev: improve GXSetNumTevStages match via explicit genMode mask write

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -435,6 +435,6 @@ void GXSetNumTevStages(u8 nStages) {
     CHECK_GXBEGIN(1187, "GXSetNumTevStages");
 
     ASSERTMSGLINE(1189, nStages != 0 && nStages <= 16, "GXSetNumTevStages: Exceed max number of tex stages");
-    SET_REG_FIELD(1190, __GXData->genMode, 4, 10, nStages - 1);
+    __GXData->genMode = (__GXData->genMode & ~0x3C00) | (((nStages & 0xFF) - 1) << 10);
     __GXData->dirtyState |= 4;
 }


### PR DESCRIPTION
## Summary
Reworked the GXSetNumTevStages genMode update to an explicit mask/shift assignment instead of SET_REG_FIELD.

## Functions improved
- Unit: main/gx/GXTev
- Symbol: GXSetNumTevStages

## Match evidence
- GXSetNumTevStages: 77.333336% -> 99.416664% (tools/objdiff-cli diff -p . -u main/gx/GXTev -o - GXSetNumTevStages)
- Nearby spot-checks unchanged:
  - GXSetTevColor: 62.068966% -> 62.068966%
  - GXSetTevKColor: 56.517242% -> 56.517242%

## Plausibility rationale
This is a direct, readable bitfield write in common GX source style: clear field mask and OR in ((nStages & 0xFF) - 1) << 10.

## Technical details
Code change in src/gx/GXTev.c:
- from: SET_REG_FIELD(..., __GXData->genMode, 4, 10, nStages - 1)
- to: __GXData->genMode = (__GXData->genMode & ~0x3C00) | (((nStages & 0xFF) - 1) << 10)

Validation:
- ninja passes
- objdiff confirms significant alignment improvement for target symbol