### PR TITLE
Improve pppRandFV fuzzy match to 91.79%

### DIFF
--- a/src/pppRandFV.cpp
+++ b/src/pppRandFV.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "types.h"
 
-extern CMath math;
+extern CMath math[];
 extern s32 lbl_8032ED70;
 extern f32 lbl_8032FF90;
 extern f32 lbl_801EADC8[];
@@ -39,15 +39,15 @@ void pppRandFV(void* param1, void* param2, void* param3)
     }
 
     u8* base = (u8*)param1;
-    PppRandFVParam2* in = (PppRandFVParam2*)param2;
     PppRandFVParam3* out = (PppRandFVParam3*)param3;
+    PppRandFVParam2* in = (PppRandFVParam2*)param2;
     f32* valuePtr;
 
     s32 state = *(s32*)(base + 0xC);
     if (state == 0) {
-        f32 value = RandF__5CMathFv(&math);
+        f32 value = RandF__5CMathFv(math);
         if (in->field18 != 0) {
-            value += RandF__5CMathFv(&math);
+            value += RandF__5CMathFv(math);
         } else {
             value *= lbl_8032FF90;
         }
@@ -69,7 +69,7 @@ void pppRandFV(void* param1, void* param2, void* param3)
     }
 
     f32 scale = *valuePtr;
-    target[0] = target[0] + in->field8 * scale;
-    target[1] = target[1] + in->fieldC * scale;
-    target[2] = target[2] + in->field10 * scale;
+    target[0] = in->field8 * scale + target[0];
+    target[1] = in->fieldC * scale + target[1];
+    target[2] = in->field10 * scale + target[2];
 }


### PR DESCRIPTION
## Summary
- Refined `pppRandFV` local ordering and expression forms to better align generated code with the target object.
- Switched `math` declaration/usage in this unit from scalar `extern CMath math` + `&math` calls to array-style `extern CMath math[]` + direct pointer calls, matching common `pppRand*` patterns.
- Reordered vector accumulation expressions to compiler-friendly multiply-add form.

## Functions improved
- Unit: `main/pppRandFV`
- Function: `pppRandFV`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/pppRandFV -o - pppRandFV`
- Before: `87.05195%` fuzzy match (`size 308`)
- After: `91.792206%` fuzzy match (`size 308`)
- Additional diff reduction observed in oneshot JSON:
  - `DIFF_REPLACE`: 10 -> 6
  - `DIFF_DELETE`: 10 -> 6
  - `DIFF_ARG_MISMATCH`: 30 -> 16

## Plausibility rationale
- The update keeps behavior and code intent consistent with adjacent `pppRand*` implementations already present in the codebase.
- Changes are type/use and expression-shape corrections, not contrived temporary insertion or unnatural control-flow forcing.
- The result is cleaner source that remains readable while improving assembly alignment.

## Technical notes
- Verified with `ninja` build after edits.
- Verified function-level improvement through objdiff v3.6.1 oneshot JSON output and project report fuzzy percent.