### PR TITLE
dolphin_trk: improve __TRK_copy_vectors match

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -193,7 +193,7 @@ void __TRK_copy_vectors(void)
 	mask = *(u32*)TRKTargetTranslate(0x44);
 
 	for (i = 0; i <= 14; ++i) {
-		if (mask & (1 << i)) {
+		if ((mask & (1 << i)) && i != 4) {
 			TRK_copy_vector(TRK_ISR_OFFSETS[i]);
 		}
 	}


### PR DESCRIPTION
Summary:
- Updated `__TRK_copy_vectors` in `src/TRK_MINNOW_DOLPHIN/dolphin_trk.c` to skip copying vector index 4 (external interrupt), matching known MetroTRK vector setup behavior.
- No structural refactors; single-condition adjustment only.

Functions improved:
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk`
- Symbol: `__TRK_copy_vectors`
- Fuzzy match: `97.333336% -> 100%` (from `ninja` report)
- Objdiff one-shot symbol match: `96.666664% -> 99.333336%`

Match evidence:
- Project progress moved from `1361 -> 1362` matched functions.
- Matched code bytes moved from `191616 -> 191916` (+300 bytes), consistent with this 300-byte function reaching full fuzzy match.
- Objdiff confirms tighter instruction alignment for `__TRK_copy_vectors` after the condition update.

Plausibility rationale:
- Excluding the external interrupt vector in MetroTRK copy setup is source-plausible and consistent with debug monitor vector handling patterns.
- The change is minimal and semantically coherent, not compiler-coaxing.

Technical details:
- Changed loop condition from `if (mask & (1 << i))` to `if ((mask & (1 << i)) && i != 4)`.
- This aligns generated control flow with the reference decompilation behavior while preserving readability and intent.