### PR TITLE
mapobj: implement CMapObj deleting destructor wrapper

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -39,6 +39,8 @@ static inline float& F32At(CMapObj* self, unsigned int offset)
 }
 }
 
+extern "C" void __dl__FPv(void*);
+
 /*
  * --INFO--
  * PAL Address: 0x8002BE10
@@ -78,12 +80,49 @@ CMapObj::CMapObj()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002BE7C
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMapObj::~CMapObj()
 {
-	// TODO
+    void* attr = PtrAt(this, 0xEC);
+    if (attr != 0) {
+        (*(void (**)(void*, int))(*reinterpret_cast<unsigned int*>(attr) + 8))(attr, 1);
+        PtrAt(this, 0xEC) = 0;
+    }
+
+    Init();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8002BE7C
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CMapObj* dtor_8002BE7C(CMapObj* mapObj, short param_2)
+{
+    if (mapObj != 0) {
+        void* attr = PtrAt(mapObj, 0xEC);
+        if (attr != 0) {
+            (*(void (**)(void*, int))(*reinterpret_cast<unsigned int*>(attr) + 8))(attr, 1);
+            PtrAt(mapObj, 0xEC) = 0;
+        }
+
+        mapObj->Init();
+        if (0 < param_2) {
+            __dl__FPv(mapObj);
+        }
+    }
+
+    return mapObj;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapObj::~CMapObj()` with recovered PAL behavior: destroy attribute object at offset `0xEC`, clear the pointer, then reinitialize via `Init()`.
- Added explicit deleting-destructor wrapper `dtor_8002BE7C(CMapObj*, short)` to match expected symbol/codegen path.
- Added PAL address/size metadata blocks for the implemented destructor path.

## Functions improved
- Unit: `main/mapobj`
- Symbol: `dtor_8002BE7C`
- Before: `null` (unmatched in report)
- After: `96.5625%`

## Match evidence
- `main/mapobj` fuzzy match: `4.30309%` -> `5.066996%`.
- `dtor_8002BE7C` moved from unresolved to high fuzzy alignment, indicating real assembly alignment for the deleting-destructor path (not formatting-only changes).

## Plausibility rationale
- Behavior matches typical original C++ deleting-destructor flow for this codebase:
  - release owned subobject (`m_attr` at `0xEC`) via vtable destructor call,
  - clear owning pointer,
  - reinitialize object state,
  - conditionally free `this` when delete-flag (`short param_2`) is set.
- No contrived temporaries, hardcoded instruction tricks, or unnatural control-flow changes were introduced.

## Technical details
- Source file changed: `src/mapobj.cpp`.
- Build verification: `ninja` succeeds.
- Validation source of truth: `build/GCCP01/report.json` function-level fuzzy score for `main/mapobj`.