### PR TITLE
pppDrawShape2: improve pppCalcShape2 signed field matching

### DIFF
--- a/src/pppDrawShape2.cpp
+++ b/src/pppDrawShape2.cpp
@@ -21,7 +21,7 @@ typedef struct ShapeRuntimeData {
 
 typedef struct ShapeSpecEntry {
     s16 offset;
-    u16 maxValue;
+    s16 maxValue;
     u8 flags;
 } ShapeSpecEntry;
 
@@ -75,14 +75,14 @@ void pppCalcShape2(void* param1, void* param2, void* param3)
     ShapeRuntimeData* runtimeData = *(ShapeRuntimeData**)((u8*)param3 + 0xC);
     ShapeControlData* controlData = (ShapeControlData*)param2;
     ShapeState* shapeData = (ShapeState*)((u8*)param1 + runtimeData->shapeDataOffset + 0x80);
-    u32 type = controlData->type;
+    s16 type = *(s16*)((u8*)controlData + 0x4);
 
-    if (type == 0xFFFF) {
+    if (type == -1) {
         return;
     }
 
     void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
-    void* shapeSpec = *(void**)((u8*)shapeTables + (type << 2));
+    void* shapeSpec = *(void**)((u8*)shapeTables + ((u16)type << 2));
     ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->counter << 3) + 0x10);
 
     shapeData->currentId = shapeData->counter;
@@ -93,7 +93,7 @@ void pppCalcShape2(void* param1, void* param2, void* param3)
     shapeData->value = (u16)(shapeData->value - shape->maxValue);
 
     shapeData->counter++;
-    if (shapeData->counter < (u16)*(s16*)((u8*)shapeSpec + 0x6)) {
+    if (shapeData->counter < *(s16*)((u8*)shapeSpec + 0x6)) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Adjust ShapeSpecEntry::maxValue from u16 to s16 to match signed halfword compare behavior.
- Keep ShapeControlData::type layout stable as 32-bit, but read it as signed halfword in pppCalcShape2 where the target code uses signed 16-bit semantics.
- Normalize related 	ype comparisons/indexing in pppCalcShape2 (-1 sentinel + (u16) table index) while preserving pppDrawShape2 behavior.

## Functions improved
- main/pppDrawShape2::pppCalcShape2
  - Before: 82.254906%
  - After: 91.960785%
  - Size: 204b
- main/pppDrawShape2::pppDrawShape2
  - Before: 88.20755%
  - After: 88.20755% (no regression)

## Match evidence
- Objdiff one-shot measurements were taken before/after with:
  - 	ools/objdiff-cli diff -p . -u main/pppDrawShape2 -o - pppCalcShape2
  - 	ools/objdiff-cli diff -p . -u main/pppDrawShape2 -o - pppDrawShape2
- pppCalcShape2 diff moved multiple mismatches into matched signed-compare patterns (notably around maxValue/counter threshold handling), with a +9.705879 point gain.

## Plausibility rationale
- The change reflects plausible original source intent: these fields behave as signed 16-bit control/spec values in comparison logic.
- The update avoids contrived reordering and keeps surrounding code style/structure intact.

## Technical details
- Key matching improvement came from aligning signedness at data boundaries:
  - ShapeSpecEntry::maxValue now compiles to signed halfword compare paths.
  - pppCalcShape2 reads 	ype as signed halfword from the control block while leaving the control struct layout unchanged for other callsites.
- Build verified with 
inja after change.
