### PR TITLE
os: improve OSResetSystem match in OSReset

### DIFF
--- a/src/os/OSReset.c
+++ b/src/os/OSReset.c
@@ -196,7 +196,7 @@ void OSResetSystem(BOOL reset, u32 resetCode, BOOL forceMenu) {
     OSSram* sram;
     OSThread* thread;
     OSThread* next;
-    BOOL disableRecalibration = TRUE;
+    BOOL disableRecalibration;
 
     OSDisableScheduler();
     __OSStopAudioSystem();


### PR DESCRIPTION
## Summary
- Updated `OSResetSystem` in `src/os/OSReset.c` to remove the explicit initializer on `disableRecalibration`.
- This aligns the control/data-flow shape with SDK-era source patterns used in this module.

## Functions improved
- Unit: `main/os/OSReset`
- Symbol: `OSResetSystem`
  - Before: `83.049385%`
  - After: `84.53086%`

## Match evidence
- objdiff command:
  - `tools/objdiff-cli diff -p . -u main/os/OSReset -o - Reset`
- Unit `.text` match:
  - Before: `76.29249%`
  - After: `77.241104%`
- Neighboring symbols unchanged:
  - `__OSDoHotReset`: `91.05556%` -> `91.05556%`
  - `OSGetResetCode`: `77.416664%` -> `77.416664%`

## Plausibility rationale
- The change removes an eager local initialization rather than adding contrived temporaries or ordering hacks.
- This matches plausible original SDK-style C where `disableRecalibration` is assigned on the shutdown path and consumed later.

## Technical details
- A direct VI-register-write variant was tested and rejected because it regressed `__OSDoHotReset` despite improving `OSResetSystem`.
- Final patch is a single-line source-level edit with net positive unit-level match.
- Build verification: `ninja` passes.