### PR TITLE
Improve match for pppFrameYmCallBack via local-init refactor

### DIFF
--- a/src/pppYmCallBack.cpp
+++ b/src/pppYmCallBack.cpp
@@ -50,19 +50,13 @@ void pppDestructYmCallBack(void)
  */
 void pppFrameYmCallBack(void* pppYmCallBack, void* param_2)
 {
-    YmCallBackObj* ymCallBack;
-    YmCallBackParam* frameParam;
-    unsigned char* mngSt;
+    YmCallBackParam* frameParam = (YmCallBackParam*)param_2;
+    YmCallBackObj* ymCallBack = (YmCallBackObj*)pppYmCallBack;
+    unsigned char* mngSt = lbl_8032ED50;
     Vec position;
     s32 mngStIndex;
-    u32 graphId;
 
-    ymCallBack = (YmCallBackObj*)pppYmCallBack;
-    frameParam = (YmCallBackParam*)param_2;
-    graphId = ymCallBack->m_graphId;
-    mngSt = lbl_8032ED50;
-
-    if (((s32)graphId / 0x1000) == (s32)frameParam->m_graphId) {
+    if (((s32)ymCallBack->m_graphId / 0x1000) == (s32)frameParam->m_graphId) {
         position.x = *(f32*)(mngSt + 0x84);
         position.y = *(f32*)(mngSt + 0x94);
         position.z = *(f32*)(mngSt + 0xA4);


### PR DESCRIPTION
## Summary
- Refactored `pppFrameYmCallBack` local setup to initialize casted pointers at declaration and removed an unnecessary intermediate `graphId` local.
- Kept logic and data access unchanged; this is a code-shape cleanup aimed at compiler output alignment.

## Functions Improved
- Unit: `main/pppYmCallBack`
- Symbol: `pppFrameYmCallBack`

## Match Evidence
- `objdiff-cli v3.6.1` (`tools/objdiff-cli`) for `main/pppYmCallBack:pppFrameYmCallBack`
- Before: `45.979168%`
- After: `70.5625%`
- Delta: `+24.583332%`
- Current report fuzzy for symbol: `71.583336`

## Plausibility Rationale
- The change removes redundant temporaries and uses straightforward declaration-time initialization, which is typical hand-written C/C++ style in this codebase.
- No behavior changes, magic constants, or unnatural sequencing were introduced.

## Technical Details
- The previous shape generated additional register shuffling/prologue differences.
- Declaration-time initialization reduced those mismatches and improved instruction alignment in objdiff for the target symbol.