### PR TITLE
main: improve match for game__FiPPc argument parsing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,9 +24,11 @@ static const char lbl_801d6a5c[] = "sp";
  */
 void game(int argc, char** argv)
 {
+    char c;
+    int cmp;
+    int i;
     bool copyScriptName;
     bool parseLanguage;
-    int i;
     char** argument;
 
     Game.game.Init();
@@ -37,24 +39,40 @@ void game(int argc, char** argv)
         copyScriptName = false;
         parseLanguage = false;
         for (i = 1; i < argc; i++) {
-            char c;
-
             if (copyScriptName) {
                 strcpy(reinterpret_cast<char*>(0x8022b7b4), *argument);
                 copyScriptName = false;
             } else if (parseLanguage) {
-                if ((strcmp(*argument, lbl_801d6a48) == 0) || (strcmp(*argument, lbl_801d6a4c) == 0)) {
+                cmp = strcmp(*argument, lbl_801d6a48);
+                if (cmp == 0) {
                     Game.game.m_gameWork.m_languageId = 1;
-                } else if (strcmp(*argument, lbl_801d6a50) == 0) {
-                    Game.game.m_gameWork.m_languageId = 2;
-                } else if (strcmp(*argument, lbl_801d6a58) == 0) {
-                    Game.game.m_gameWork.m_languageId = 3;
-                } else if (strcmp(*argument, lbl_801d6a5c) == 0) {
-                    Game.game.m_gameWork.m_languageId = 4;
-                } else if (strcmp(*argument, lbl_801d6a54) == 0) {
-                    Game.game.m_gameWork.m_languageId = 5;
                 } else {
-                    Game.game.m_gameWork.m_languageId = 0;
+                    cmp = strcmp(*argument, lbl_801d6a4c);
+                    if (cmp == 0) {
+                        Game.game.m_gameWork.m_languageId = 1;
+                    } else {
+                        cmp = strcmp(*argument, lbl_801d6a50);
+                        if (cmp == 0) {
+                            Game.game.m_gameWork.m_languageId = 2;
+                        } else {
+                            cmp = strcmp(*argument, lbl_801d6a58);
+                            if (cmp == 0) {
+                                Game.game.m_gameWork.m_languageId = 3;
+                            } else {
+                                cmp = strcmp(*argument, lbl_801d6a5c);
+                                if (cmp == 0) {
+                                    Game.game.m_gameWork.m_languageId = 4;
+                                } else {
+                                    cmp = strcmp(*argument, lbl_801d6a54);
+                                    if (cmp == 0) {
+                                        Game.game.m_gameWork.m_languageId = 5;
+                                    } else {
+                                        Game.game.m_gameWork.m_languageId = 0;
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 parseLanguage = false;
             } else {


### PR DESCRIPTION
## Summary
- Updated `game(int argc, char** argv)` in `src/main.cpp` to use a nested `strcmp` decision chain and explicit temporary comparison variable.
- Kept behavior identical while making control flow and expression structure closer to the original compiler output.

## Functions improved
- Unit: `main/main`
- Symbol: `game__FiPPc`

## Match evidence
- `game__FiPPc`: **75.579834% -> 77.08403%** (`+1.504196%`)
- `main`: **87.72549% -> 87.72549%** (no regression)
- Validation command: `tools/objdiff-cli diff -p . -u main/main --format json -o <file> game`

## Plausibility rationale
- The change replaces compact boolean-combined comparisons with an explicit, sequential parse pattern typical of hand-written argument parsers in this codebase.
- No artificial compiler coaxing constructs were introduced; this is a readability-preserving structural adjustment aligned with likely original source style.

## Technical details
- Introduced local `cmp` and reused it across the language-option branch, matching nested compare/branch lowering.
- Preserved existing data flow and side effects (`m_languageId`, script name copy path, and parser flag handling).
- Build verified with `ninja` after changes.