### PR TITLE
mapobj: fix CPtrArray template ABI and emit missing instantiations

### DIFF
--- a/include/ffcc/ptrarray.h
+++ b/include/ffcc/ptrarray.h
@@ -12,18 +12,18 @@ public:
     ~CPtrArray();
     
     int GetSize();
-    bool Add(T* item);
+    bool Add(T item);
     void RemoveAll();
-    T* GetAt(unsigned long index);
-    T* operator[](unsigned long index);
+    T GetAt(unsigned long index);
+    T operator[](unsigned long index);
     
 private:
-    bool setSize(unsigned int newSize);
+    bool setSize(unsigned long newSize);
             
     unsigned long m_size;
     unsigned long m_numItems;
     unsigned long m_defaultSize;
-    T** m_items;
+    T* m_items;
     CMemory::CStage* m_stage;
     int m_growCapacity;
 };
@@ -52,19 +52,19 @@ int CPtrArray<T>::GetSize()
 }
 
 template <class T>
-T* CPtrArray<T>::GetAt(unsigned long index)
+T CPtrArray<T>::GetAt(unsigned long index)
 {
     return m_items[index];
 }
 
 template <class T>
-T* CPtrArray<T>::operator[](unsigned long index)
+T CPtrArray<T>::operator[](unsigned long index)
 {
     return GetAt(index);
 }
 
 template <class T>
-bool CPtrArray<T>::Add(T* item)
+bool CPtrArray<T>::Add(T item)
 {
     bool success = setSize(m_numItems + 1);
     if (success) {
@@ -86,9 +86,9 @@ void CPtrArray<T>::RemoveAll()
 }
 
 template <class T>
-bool CPtrArray<T>::setSize(unsigned int newSize)
+bool CPtrArray<T>::setSize(unsigned long newSize)
 {
-    T** newItems;
+    T* newItems;
     
     if (m_size < newSize) {
         if (m_size == 0) {
@@ -101,7 +101,7 @@ bool CPtrArray<T>::setSize(unsigned int newSize)
         }
         
         // Allocate new buffer (simplified - would need proper memory management)
-        newItems = new T*[m_size];
+        newItems = new T[m_size];
         if (newItems == 0) {
             return false;
         }

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -41,6 +41,9 @@ static inline float& F32At(CMapObj* self, unsigned int offset)
 
 extern "C" void __dl__FPv(void*);
 
+template class CPtrArray<CMapAnimRun*>;
+template class CPtrArray<CMapShadow*>;
+
 /*
  * --INFO--
  * PAL Address: 0x8002BE10


### PR DESCRIPTION
## Summary
- Corrected CPtrArray template signatures in include/ffcc/ptrarray.h to match expected instantiated ABI used by map object arrays:
  - Add(T) (instead of Add(T*))
  - GetAt/ operator[] return T (instead of T*)
  - setSize(unsigned long) (instead of unsigned int)
  - internal storage uses T* and 
ew T[m_size].
- Added explicit template instantiations in src/mapobj.cpp for:
  - CPtrArray<CMapAnimRun*>
  - CPtrArray<CMapShadow*>

## Functions improved
Unit: main/mapobj
- Add__25CPtrArray<P11CMapAnimRun>FP11CMapAnimRun: None -> 86.75%
- setSize__25CPtrArray<P11CMapAnimRun>FUl: None -> 48.1%
- Add__24CPtrArray<P10CMapShadow>FP10CMapShadow: None -> 86.75%
- setSize__24CPtrArray<P10CMapShadow>FUl: None -> 48.1%

## Match evidence
- main/mapobj fuzzy match: 5.066996% -> 7.694932%.
- Build remains green with 
inja.

## Plausibility rationale
- This change restores type-level ABI consistency for pointer-element CPtrArray instantiations, which is a source-correct fix (not sequencing/temporary coercion).
- Explicit instantiations are a standard way to ensure these template methods are emitted in the owning unit, matching expected symbol presence for this object.

## Technical notes
- The prior Add(T*) form creates one extra pointer indirection for pointer-based arrays and prevents expected symbol alignment for mapobj's CMapAnimRun* and CMapShadow* arrays.
- After signature correction + explicit instantiation, previously unresolved target symbols are now emitted and scored by report.