### PR TITLE
maptexanim: improve SetMapTexAnim control-flow match

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -235,37 +235,40 @@ void CMapTexAnimSet::Calc()
  */
 void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd, int wrapMode)
 {
-    bool found = false;
-    const short count = S16At(this, 0x8);
+    bool found;
+    int iVar4;
+    int iVar6;
 
-    for (int i = 0; i < count; i++) {
-        CMapTexAnim* anim = AnimAt(this, i);
-        if (S16At(anim, 0x12) != static_cast<short>(materialId)) {
-            continue;
-        }
+    found = false;
+    iVar4 = (int)this;
+    for (iVar6 = 0; iVar6 < *(short*)((unsigned char*)this + 8); iVar6++) {
+        int iVar5 = *(int*)(iVar4 + 0xC);
+        if (*(short*)(iVar5 + 0x12) == (short)materialId) {
+            if (*(char*)(iVar5 + 0x15) == '\0') {
+                *(short*)(iVar5 + 0xE) = (short)frameStart;
+                *(float*)(iVar5 + 0x1C) = (float)((short)frameStart);
 
-        if (U8At(anim, 0x15) == 0) {
-            S16At(anim, 0xE) = static_cast<short>(frameStart);
-            F32At(anim, 0x1C) = static_cast<float>(S16At(anim, 0xE));
-            int clampedEnd = frameEnd;
-            if (S16At(anim, 0xC) < frameEnd) {
-                clampedEnd = S16At(anim, 0xC);
+                int iVar2 = frameEnd;
+                if (*(short*)(iVar5 + 0xC) < frameEnd) {
+                    iVar2 = (int)*(short*)(iVar5 + 0xC);
+                }
+                *(short*)(iVar5 + 0x10) = (short)iVar2;
+                *(unsigned char*)(iVar5 + 0x16) = (unsigned char)wrapMode;
+            } else {
+                *(int*)(iVar5 + 0x30) = frameStart;
+                *(int*)(iVar5 + 0x2C) = frameStart;
+
+                int iVar2 = frameEnd;
+                if (*(int*)(iVar5 + 0x38) < frameEnd) {
+                    iVar2 = *(int*)(iVar5 + 0x38);
+                }
+                *(int*)(iVar5 + 0x34) = iVar2;
+                *(unsigned char*)(iVar5 + 0x27) = (unsigned char)wrapMode;
+                *(unsigned char*)(iVar5 + 0x28) = 1;
             }
-            S16At(anim, 0x10) = static_cast<short>(clampedEnd);
-            U8At(anim, 0x16) = static_cast<unsigned char>(wrapMode);
-        } else {
-            S32At(anim, 0x30) = frameStart;
-            S32At(anim, 0x2C) = frameStart;
-            int clampedKeyEnd = frameEnd;
-            if (S32At(anim, 0x38) < frameEnd) {
-                clampedKeyEnd = S32At(anim, 0x38);
-            }
-            S32At(anim, 0x34) = clampedKeyEnd;
-            U8At(anim, 0x27) = static_cast<unsigned char>(wrapMode);
-            U8At(anim, 0x28) = 1;
+            found = true;
         }
-
-        found = true;
+        iVar4 = iVar4 + 4;
     }
 
     if (!found && System.m_execParam != 0) {


### PR DESCRIPTION
## Summary
- Reworked `CMapTexAnimSet::SetMapTexAnim(int,int,int,int)` to follow the original low-level loop/control-flow shape more closely.
- Switched to explicit pointer-arithmetic field writes and branch-local clamp temporaries matching the decompiled structure.
- Kept behavior unchanged: same material-id filtering, non-key/keyframe update paths, and debug print fallback.

## Functions improved
- Unit: `main/maptexanim`
- Function: `SetMapTexAnim__14CMapTexAnimSetFiiii`

## Match evidence
- `SetMapTexAnim__14CMapTexAnimSetFiiii`: **41.855072% -> 42.681160%** (`+0.826088`)
- Unit `main/maptexanim`: **26.278970% -> 26.360516%** (`+0.081546`)
- Build verification: `ninja` completed successfully after the change.

## Plausibility rationale
- The update removes abstraction-heavy helper access in favor of direct layout-level access used throughout partially decompiled units.
- Loop progression and branch sequencing now better reflect the probable original Metrowerks-era source style for this engine code path.
- No synthetic no-op logic or compiler-coaxing constructs were introduced.

## Technical notes
- The key alignment changes were:
  - Iteration via incrementing base pointer (`+4` stride) with per-entry pointer load from `+0xC`.
  - Branch-local clamping for both regular and keyframe animation modes.
  - Explicit field writes at offsets `0xE/0x10/0x16` and `0x2C/0x30/0x34/0x27/0x28`.