### PR TITLE
pppDrawShape: gate pppCalcShape counter on rollover

### DIFF
--- a/src/pppDrawShape.cpp
+++ b/src/pppDrawShape.cpp
@@ -88,9 +88,10 @@ void pppCalcShape(void* pppShape, void* data, void* additionalData)
 
 	shapeData->currentId = shapeData->counter;
 	shapeData->value = (u16)(shapeData->value + controlData->step);
-	if (shapeData->value >= (u16)shape->maxValue) {
-		shapeData->value = (u16)(shapeData->value - shape->maxValue);
+	if (shapeData->value < (u16)shape->maxValue) {
+		return;
 	}
+	shapeData->value = (u16)(shapeData->value - shape->maxValue);
 
 	shapeData->counter++;
 	if (shapeData->counter < (u16)*(s16*)((u8*)shapeSpec + 0x6)) {


### PR DESCRIPTION
## Summary
- Updated `pppCalcShape` in `src/pppDrawShape.cpp` to return early when accumulated `value` has not crossed the current shape entry threshold.
- Counter progression and sequence-advance logic now run only on rollover, matching the neighboring `pppCalcShape2` flow pattern and producing closer codegen.

## Functions improved
- Unit: `main/pppDrawShape`
- Symbol: `pppCalcShape`
- Match: `78.92157%` -> `80.09804%` (+1.17647)

## Match evidence
- `objdiff-cli diff -p . -u main/pppDrawShape pppCalcShape`
  - before: `78.92157%`
  - after: `80.09804%`
- `objdiff-cli diff -p . -u main/pppDrawShape`
  - unit `.text` after: `82.73451%`

## Plausibility rationale
- The new flow is source-plausible and idiomatic for stepped animation state: only advance frame/counter after overflow of the accumulated value.
- This also aligns with the same-size sibling implementation (`pppCalcShape2`), reducing the chance this is compiler-coaxing rather than intended logic.

## Technical details
- Replaced unconditional post-add counter path with rollover-gated path:
  - `if (value < maxValue) return;`
  - then subtract `maxValue`, increment `counter`, and continue existing wrap/end logic.
- No artificial temporaries, no layout hacks, and no behavior-only no-op edits.