### PR TITLE
p_game: improve draw1/draw2 call-site matching

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -204,7 +204,7 @@ void CGamePcs::draw0()
  */
 void CGamePcs::draw1()
 {
-    game.Draw2();
+    Game.game.Draw2();
 }
 
 /*
@@ -218,7 +218,7 @@ void CGamePcs::draw1()
  */
 void CGamePcs::draw2()
 {
-    game.Draw3();
+    Game.game.Draw3();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CGamePcs::draw1()` and `CGamePcs::draw2()` in `src/p_game.cpp` to dispatch through the global `Game.game` path.
- This aligns call-site code shape with neighboring `CGamePcs` wrappers in the same file (`create`, `destroy`, `calc0/1/2`, `draw0`, etc.).

## Functions improved
- Unit: `main/p_game`
- `draw1__8CGamePcsFv`: `84.0% -> 89.5%`
- `draw2__8CGamePcsFv`: `84.0% -> 89.5%`

## Match evidence
- `objdiff-cli report changes` shows:
  - `main/p_game` fuzzy match: `85.53425 -> 86.03653`
  - changed symbols: `draw1__8CGamePcsFv`, `draw2__8CGamePcsFv`
- No size deltas; this is an instruction-selection/alignment improvement for both 40-byte functions.

## Plausibility rationale
- This file consistently routes process callbacks through the singleton-style global `Game` object.
- Using `Game.game` in `draw1/draw2` matches that established style and avoids contrived compiler-only transformations.

## Technical details
- Change is intentionally minimal (2-line behavior-preserving call target expression update).
- Validation used `objdiff-cli report generate` + `objdiff-cli report changes` because local `objdiff-cli` is v3.4.1 and does not support JSON one-shot `diff -o`.
- Full `ninja` currently fails in unrelated `src/maptexanim.cpp` on this checkout; `src/p_game.cpp` compiles and the match report reflects the updated object.