### PR TITLE
wmm_str: improve MC message language dispatch matching

### DIFF
--- a/src/wmm_str.cpp
+++ b/src/wmm_str.cpp
@@ -47,23 +47,18 @@ extern "C" int GetWidth__5CFontFPc(CFont*, const char*);
  */
 const char* CMenuPcs::GetMcStr(int index)
 {
-    const unsigned int languageId = Game.game.m_gameWork.m_languageId;
-    if (languageId == 3) {
+    switch (Game.game.m_gameWork.m_languageId) {
+    case 2:
+        return lbl_80215BE8[index];
+    case 3:
         return lbl_80215BF8[index];
+    case 4:
+        return lbl_80215C08[index];
+    case 5:
+        return lbl_80215C18[index];
+    default:
+        return lbl_80215BD8[index];
     }
-    if (languageId < 3) {
-        if ((languageId != 1) && (languageId != 0)) {
-            return lbl_80215BE8[index];
-        }
-    } else {
-        if (languageId == 5) {
-            return lbl_80215C18[index];
-        }
-        if (languageId < 5) {
-            return lbl_80215C08[index];
-        }
-    }
-    return lbl_80215BD8[index];
 }
 
 /*
@@ -77,59 +72,47 @@ const char* CMenuPcs::GetMcStr(int index)
  */
 const char* const* CMenuPcs::GetMcWinMessBuff(int group)
 {
-    const unsigned int languageId = Game.game.m_gameWork.m_languageId;
-    if (group != 0) {
-        if (group != 1) {
-            if (languageId == 3) {
-                return lbl_802161BC;
-            }
-            if (languageId < 3) {
-                if ((languageId != 1) && (languageId != 0)) {
-                    return lbl_80216140;
-                }
-            } else {
-                if (languageId == 5) {
-                    return lbl_802162B4;
-                }
-                if (languageId < 5) {
-                    return lbl_80216238;
-                }
-            }
+    switch (group) {
+    case 0:
+        switch (Game.game.m_gameWork.m_languageId) {
+        case 2:
+            return lbl_80215D14;
+        case 3:
+            return lbl_80215E00;
+        case 4:
+            return lbl_80215EEC;
+        case 5:
+            return lbl_80215FD8;
+        default:
+            return lbl_80215C28;
+        }
+    case 1:
+        switch (Game.game.m_gameWork.m_languageId) {
+        case 2:
+            return lbl_8021636C;
+        case 3:
+            return lbl_802163A8;
+        case 4:
+            return lbl_802163E4;
+        case 5:
+            return lbl_80216420;
+        default:
+            return lbl_80216330;
+        }
+    default:
+        switch (Game.game.m_gameWork.m_languageId) {
+        case 2:
+            return lbl_80216140;
+        case 3:
+            return lbl_802161BC;
+        case 4:
+            return lbl_80216238;
+        case 5:
+            return lbl_802162B4;
+        default:
             return lbl_802160C4;
         }
-        if (languageId == 3) {
-            return lbl_802163A8;
-        }
-        if (languageId < 3) {
-            if ((languageId != 1) && (languageId != 0)) {
-                return lbl_8021636C;
-            }
-        } else {
-            if (languageId == 5) {
-                return lbl_80216420;
-            }
-            if (languageId < 5) {
-                return lbl_802163E4;
-            }
-        }
-        return lbl_80216330;
     }
-    if (languageId == 3) {
-        return lbl_80215E00;
-    }
-    if (languageId < 3) {
-        if ((languageId != 1) && (languageId != 0)) {
-            return lbl_80215D14;
-        }
-    } else {
-        if (languageId == 5) {
-            return lbl_80215FD8;
-        }
-        if (languageId < 5) {
-            return lbl_80215EEC;
-        }
-    }
-    return lbl_80215C28;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rewrote language-selection logic in `CMenuPcs::GetMcStr` and `CMenuPcs::GetMcWinMessBuff` in `src/wmm_str.cpp`.
- Replaced nested mixed comparisons with explicit `switch`-based dispatch for language IDs (`0/1/default`, `2`, `3`, `4`, `5`) while preserving behavior.
- Kept data source tables unchanged (`lbl_80215*`, `lbl_80216*`) and only adjusted control flow shape.

## Functions Improved
- `GetMcStr__8CMenuPcsFi`
  - before: `52.666668%`
  - after: `96.17949%`
- `GetMcWinMessBuff__8CMenuPcsFi`
  - before: `41.18%`
  - after: `64.24%`

## Match Evidence
Measured with:
- `tools/objdiff-cli diff -p . -u main/wmm_str -o <json> --format json <symbol>`

Improvements are from symbol-level objdiff match percentages for the two touched symbols.

## Plausibility Rationale
- This change is source-plausible for original game code: language dispatch over a small fixed enum-like domain is naturally expressed as a switch table.
- No contrived temporaries, forced aliasing tricks, or non-idiomatic compiler coaxing were introduced.
- String tables and externally referenced message arrays remain unchanged; only branch structure was normalized.

## Validation Notes
- Target object build passes: `ninja build/GCCP01/src/wmm_str.o`
- Full `ninja` is currently blocked in this workspace by an unrelated pre-existing failure in `src/maptexanim.cpp` (`illegal use of incomplete struct/union/class 'CMaterial'`).