### PR TITLE
partMng: implement CPartMng::pppPartInit traversal

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/partMng.h"
+#include "ffcc/pppPart.h"
 
 extern "C" void __dl__FPv(void* ptr);
 
@@ -621,12 +622,27 @@ void CPartMng::pppPartDead()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80059c44
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CPartMng::pppPartInit()
 {
-	// TODO
+	char* pppMngSt = reinterpret_cast<char*>(this);
+	int i = 0;
+
+	*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x8) = 0;
+	do {
+		int baseTime = *reinterpret_cast<int*>(pppMngSt + 0x14);
+		if (baseTime != -0x1000 && baseTime < 0) {
+			_pppInitPart(reinterpret_cast<_pppMngSt*>(pppMngSt));
+		}
+		pppMngSt += 0x158;
+		i++;
+	} while (i < 0x180);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CPartMng::pppPartInit()` in `src/partMng.cpp` using the recovered manager-state traversal pattern:
- zeroes the manager field at `this + 0x8`
- iterates `0x180` `_pppMngSt` entries with `0x158` stride
- reads base time at offset `0x14`
- calls `_pppInitPart` when `baseTime != -0x1000 && baseTime < 0`

Also updated the function INFO header with PAL address/size from the exported reference and added the missing `_pppInitPart` declaration include.

## Functions Improved
- Unit: `main/partMng`
- Symbol: `pppPartInit__8CPartMngFv`

## Match Evidence
`objdiff-cli report generate` before/after:
- `pppPartInit__8CPartMngFv`: **0.7407407% -> 16.474073%** fuzzy match
- `main/partMng` unit fuzzy match: **1.6168832% -> 1.8771135%**

## Plausibility Rationale
The implementation follows source-plausible engine behavior for particle manager initialization:
- uses a fixed-size manager-state table walk
- initializes only entries in the expected negative-time state
- delegates per-entry reset/init to `_pppInitPart`

This is not compiler coaxing; it restores recognizable game-side logic with existing data layout assumptions already used elsewhere in this codebase.

## Technical Details
- Kept access pattern offset-based (`+0x14`, `+0x158`) to match current WIP `_pppMngSt` declarations and avoid inventing unverified struct fields.
- Verified `src/partMng.cpp` compiles via `ninja build/GCCP01/src/partMng.o`.
- Full `ninja` is currently blocked by an unrelated existing compile error in `src/maptexanim.cpp` (incomplete `CMaterial`).