### PR TITLE
pppLensFlare: improve pppConstructLensFlare match

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -36,25 +36,21 @@ void pppConstructLensFlare(void* obj, void* param)
 {
 	void* dataPtr = *((void**)((char*)param + 0x0c));
 	int offset = *((int*)((char*)dataPtr + 0x08));
-	
+
 	float initValue = FLOAT_80331060;
-	
-	// Initialize float fields
-	*((float*)((char*)obj + offset + 0x98)) = initValue;
+
+	*((float*)((char*)obj + offset + 0x98)) = FLOAT_80331060;
 	*((float*)((char*)obj + offset + 0x94)) = initValue;
 	*((float*)((char*)obj + offset + 0x90)) = initValue;
 	*((float*)((char*)obj + offset + 0xa8)) = initValue;
 	*((float*)((char*)obj + offset + 0xa4)) = initValue;
 	*((float*)((char*)obj + offset + 0xa0)) = initValue;
-	*((float*)((char*)obj + offset + 0xb4)) = initValue;
-	
-	// Initialize short fields
+
 	*((short*)((char*)obj + offset + 0xb0)) = 0;
 	*((short*)((char*)obj + offset + 0xae)) = 0;
 	*((short*)((char*)obj + offset + 0xac)) = 0;
-	
-	// Initialize byte field
 	*((char*)obj + offset + 0xb2) = 0;
+	*((float*)((char*)obj + offset + 0xb4)) = initValue;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adjusted pppConstructLensFlare initialization sequence in src/pppLensFlare.cpp to better match original codegen.
- Reordered writes so  xb4 is initialized last and changed the first  x98 assignment to direct FLOAT_80331060 (with remaining fields using local temp).
- Removed non-essential explanatory comments in the touched block.

## Functions Improved
- Unit: main/pppLensFlare
- Symbol: pppConstructLensFlare

## Match Evidence
- pppConstructLensFlare: **79.44444 -> 90.22222** (+10.77778 points)
- Command used:
  - 	ools/objdiff-cli diff -p . -u main/pppLensFlare -o - > _diff_pppLensFlare_after1.json

## Plausibility Rationale
- The change preserves behavior and only adjusts expression/assignment ordering to a form consistent with surrounding FFCC decomp style.
- No contrived temporaries, no synthetic control flow, and no readability regressions were introduced.

## Technical Notes
- Full 
inja currently fails in this tree at src/maptexanim.cpp with an existing compile error unrelated to this PR target.
- Target object build and objdiff validation for main/pppLensFlare succeed.
