### PR TITLE
astar: improve polygon group collision match

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -875,8 +875,12 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80141724
+ * PAL Size: 252b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 {
@@ -901,8 +905,6 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 	cyl.m_direction2.x = kPolyGroupAabbMin;
 	cyl.m_direction2.y = kPolyGroupAabbMin;
 	cyl.m_direction2.z = kPolyGroupAabbMin;
-	cyl.m_radius2 = 0.0f;
-	cyl.m_height2 = 0.0f;
 
 	if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), mask) != 0)
 	{
@@ -943,10 +945,8 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		cyl.m_direction2.x = kPolyGroupAabbMin;
 		cyl.m_direction2.y = kPolyGroupAabbMin;
 		cyl.m_direction2.z = kPolyGroupAabbMin;
-		cyl.m_radius2 = 0.0f;
-		cyl.m_height2 = 0.0f;
 
-		if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), static_cast<unsigned long>(hitAttributeMask)) != 0)
+		if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), hitAttributeMask) != 0)
 		{
 			return lbl_8032EC90[0x47];
 		}
@@ -971,8 +971,6 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		cyl.m_direction2.x = kPolyGroupAabbMin;
 		cyl.m_direction2.y = kPolyGroupAabbMin;
 		cyl.m_direction2.z = kPolyGroupAabbMin;
-		cyl.m_radius2 = 0.0f;
-		cyl.m_height2 = 0.0f;
 
 		if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), m_hitAttributeMask) != 0)
 		{


### PR DESCRIPTION
## Summary
- Refined CAStar::calcPolygonGroup and CAStar::calcSpecialPolygonGroup cylinder setup to better match original codegen.
- Removed explicit writes to CMapCylinder::m_radius2 and m_height2 in these stack-constructed query cylinders.
- Kept control flow and semantics unchanged for collision group lookup.
- Added PAL metadata header for calcSpecialPolygonGroup.

## Functions Improved
- Unit: main/astar
- calcPolygonGroup__6CAStarFP3Veci: **37.521366% -> 41.811966%** (+4.290600)
- calcSpecialPolygonGroup__6CAStarFP3Vec: **45.984127% -> 48.365078%** (+2.380951)

## Match Evidence
Measured with:
- 	ools/objdiff-cli diff -p . -u main/astar -o _diff_calcPolygonGroup_before.json --format json-pretty calcPolygonGroup__6CAStarFP3Veci
- 	ools/objdiff-cli diff -p . -u main/astar -o _diff_calcPolygonGroup_after_final.json --format json-pretty calcPolygonGroup__6CAStarFP3Veci

Observed weighted unit-level function average improvement in this diff snapshot:
- 70.041785 -> 70.414997 (+0.373211)

## Plausibility Rationale
- The removed assignments are plausible original source behavior for temporary collision query cylinders where only the fields consumed by CheckHitCylinderNear are explicitly initialized in this call pattern.
- No contrived temporary variables or unnatural reordering were introduced.
- Changes align with existing idioms in this file: explicit per-field stack object setup and direct map collision query calls.

## Technical Notes
- Full 
inja is currently blocked by an unrelated pre-existing compile error in src/maptexanim.cpp (incomplete CMaterial usage).
- star.o was rebuilt successfully via 
inja build/GCCP01/src/astar.o for verification of this unit.