### PR TITLE
Improve stack-layout match in pppCallBackDistance callbacks

### DIFF
--- a/src/pppCallBackDistance.cpp
+++ b/src/pppCallBackDistance.cpp
@@ -24,8 +24,8 @@ static s32 GetGraphFrameFromId(u32 graphId)
 void pppConstructCallBackDistance(pppCallBackDistance* param1, UnkC* param2)
 {
     u8* pppMngSt;
-    Vec local_28;
     Vec local_1c;
+    Vec local_28;
     s32 dataOffset;
     f32* distancePtr;
 
@@ -71,8 +71,8 @@ void pppFrameCallBackDistance(pppCallBackDistance* param1, UnkB* param2, UnkC* p
     u32 graphId;
     f32 distance;
     f32* oldDistance;
-    Vec local_28;
     Vec local_1c;
+    Vec local_28;
 
     pppMngSt = lbl_8032ED50;
     local_1c.x = *(f32*)(pppMngSt + 0x84);


### PR DESCRIPTION
## Summary
Reordered local Vec declarations in src/pppCallBackDistance.cpp to better match original stack layout/register assignment in:
- pppConstructCallBackDistance
- pppFrameCallBackDistance

No logic changes were introduced; this is a source-plausible variable layout adjustment.

## Functions Improved
- main/pppCallBackDistance::pppConstructCallBackDistance
  - 86.333336% -> 86.545456%
- main/pppCallBackDistance::pppFrameCallBackDistance
  - 54.558823% -> 54.661766%

## Match Evidence (objdiff)
Command used:
- 	ools/objdiff-cli diff -p . -u main/pppCallBackDistance -o <out.json> <symbol> --format json

Instruction diff-kind deltas:
- pppConstructCallBackDistance
  - DIFF_ARG_MISMATCH: 12 -> 5
- pppFrameCallBackDistance
  - DIFF_ARG_MISMATCH: 24 -> 17

These changes indicate improved register/stack argument alignment rather than formatting-only churn.

## Plausibility Rationale
This patch keeps behavior identical and only changes local declaration ordering, which is a normal source-level choice that directly affects stack slot layout under this compiler. That makes it consistent with likely original author intent and avoids contrived compiler coaxing patterns.

## Technical Notes
- Full 
inja is currently blocked in this branch by an existing compile error in src/maptexanim.cpp (incomplete CMaterial use).
- Target unit validation was completed by rebuilding uild/GCCP01/src/pppCallBackDistance.o and re-running objdiff for both symbols.