### PR TITLE
Improve pppParHitSph match via typed GXColor setup

### DIFF
--- a/src/pppParHitSph.cpp
+++ b/src/pppParHitSph.cpp
@@ -21,8 +21,7 @@ void pppParHitSph(struct _pppPObject* param_1, int param_2)
 {
     _pppMngSt* pppMngSt;
     float radius;
-    u32 local_a8;
-    u32 local_a4;
+    _GXColor local_a8;
     Vec local_a0;
     Vec local_94;
     Vec local_88;
@@ -44,7 +43,10 @@ void pppParHitSph(struct _pppPObject* param_1, int param_2)
     }
     
     if ((*(unsigned int*)(CFlat + 0x129c) & 0x200000) != 0) {
-        local_a4 = 0xFFFFFFFF;
+        local_a8.r = 0xFF;
+        local_a8.g = 0xFF;
+        local_a8.b = 0xFF;
+        local_a8.a = 0xFF;
         PSMTXIdentity(MStack_78);
         PSMTXIdentity(local_48);
         local_48[0][0] = radius;
@@ -55,7 +57,6 @@ void pppParHitSph(struct _pppPObject* param_1, int param_2)
         local_48[0][3] = local_a0.x;
         local_48[1][3] = local_a0.y;
         local_48[2][3] = local_a0.z;
-        local_a8 = local_a4;
-        Graphic.DrawSphere(local_48, *(_GXColor*)&local_a8);
+        Graphic.DrawSphere(local_48, local_a8);
     }
 }


### PR DESCRIPTION
## Summary
- Updated `pppParHitSph` debug-sphere color setup to use explicit `_GXColor` channel assignment instead of `u32` aliasing.
- Kept behavior identical while aligning generated code with expected byte-store pattern.

## Functions Improved
- Unit: `main/pppParHitSph`
- Function: `pppParHitSph`
- Match: **86.82796% -> 95.96774%**

## Match Evidence
- Baseline: `tools/objdiff-cli diff -p . -u main/pppParHitSph --format json-pretty -o _diff_pppParHitSph_before.json pppParHitSph`
- After: `tools/objdiff-cli diff -p . -u main/pppParHitSph --format json-pretty -o _diff_pppParHitSph_after1.json pppParHitSph`
- Objdiff shows improved instruction alignment in the debug draw block, particularly around color construction and call argument materialization.

## Plausibility Rationale
- Replacing integer reinterpret-cast color packing with direct `_GXColor` channel writes is source-plausible and idiomatic for this codebase.
- This avoids compiler-coaxing patterns and makes type intent clearer while preserving output behavior.

## Technical Details
- Removed intermediate `u32` color temporaries (`0xFFFFFFFF` pack/unpack).
- Assigned `r/g/b/a` as `0xFF` directly and passed `_GXColor` by value to `Graphic.DrawSphere`.
- Build validated with `ninja` and match validated via objdiff JSON one-shot mode.