### PR TITLE
gx: improve GXLoadTexObjPreLoaded match

### DIFF
--- a/src/gx/GXTexture.c
+++ b/src/gx/GXTexture.c
@@ -599,26 +599,13 @@ u32 GXGetTexObjTlut(const GXTexObj* tex_obj) {
 
 void GXLoadTexObjPreLoaded(GXTexObj* obj, GXTexRegion* region, GXTexMapID id) {
     __GXTlutRegionInt* tlr;
-    u32 m0;
-    u32 m1;
-    u32 img0;
-    u32 img1;
-    u32 img2;
-    u32 img3;
     __GXTexObjInt* t = (__GXTexObjInt*)obj;
     __GXTexRegionInt* r = (__GXTexRegionInt*)region;
 
     ASSERTMSGLINE(1257, obj, "Texture Object Pointer is null");
-    ASSERTMSGLINE(1257, region, "TexRegion Object Pointer is null");
+    ASSERTMSGLINE(1258, region, "TexRegion Object Pointer is null");
     CHECK_GXBEGIN(1259, "GXLoadTexObjPreLoaded");
     ASSERTMSGLINEV(1260, id < GX_MAX_TEXMAP, "%s: invalid texture map ID", "GXLoadTexObj");
-
-    m0 = t->mode0;
-    m1 = t->mode1;
-    img0 = t->image0;
-    img1 = r->image1;
-    img2 = r->image2;
-    img3 = t->image3;
 
     SET_REG_FIELD(1271, t->mode0, 8, 24, GXTexMode0Ids[id]);
     SET_REG_FIELD(1272, t->mode1, 8, 24, GXTexMode1Ids[id]);


### PR DESCRIPTION
## Summary
- Simplified `GXLoadTexObjPreLoaded` in `src/gx/GXTexture.c` by removing six redundant temporary assignments (`m0`, `m1`, `img0`, `img1`, `img2`, `img3`) that were never used.
- Corrected the second null-assert line constant from `1257` to `1258` for the `region` check.

## Functions improved
- Unit: `main/gx/GXTexture`
- Function: `GXLoadTexObjPreLoaded`

## Match evidence
- `main/gx/GXTexture` fuzzy match: **87.172104% -> 87.18002%**
- `GXLoadTexObjPreLoaded` fuzzy match: **76.039215% -> 76.117645%**
- Validation flow:
  - Build: `ninja` (passes)
  - Reports: `build/tools/objdiff-cli report generate -p . -f json-pretty`

## Plausibility rationale
- Removing dead stores to unused locals is source-plausible cleanup and aligns with the low-level decomp shape (direct register-field updates and writes without intermediate snapshot variables).
- No behavioral logic changed: register ID assignment and hardware writes remain in the same order.

## Technical notes
- Attempts to tune `__SetSURegs` and `GXInitTexCacheRegion` caused measurable regressions and were discarded.
- Final change keeps only the net-positive adjustment.