### PR TITLE
pppYmLaser: improve pppConstructYmLaser match alignment

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppYmLaser.h"
 #include "ffcc/math.h"
 
-extern CMath math;
+extern CMath Math;
 extern "C" float RandF__5CMathFf(float param, CMath* math);
 extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
 
@@ -29,26 +29,24 @@ extern "C" void pppConstructYmLaser(void* pppYmLaser, void* param_2)
 	float one = 1.0f;
 	float* work = (float*)((unsigned char*)pppYmLaser + 0x88 + data->offsets->m_serializedDataOffsets[2]);
 
-	*work = one;
-	work[1] = one;
-	work[2] = one;
-	work[3] = one;
-	work[4] = one;
-	work[5] = one;
+	*work = 1.0f;
 	work[6] = one;
+	work[5] = one;
+	work[4] = one;
+	work[3] = one;
+	work[2] = one;
+	work[1] = one;
 	work[7] = 0.0f;
-	work[8] = one;
-	work[9] = one;
 	work[10] = one;
-
+	work[9] = one;
+	work[8] = one;
 	*((unsigned char*)work + 0x2c) = 0;
 	*((unsigned char*)work + 0x2d) = 0;
 	*((unsigned char*)work + 0x2e) = 0;
-	*((unsigned short*)work + 0x18) = 0;
-	*((unsigned short*)work + 0x19) = 0;
-	*((unsigned short*)work + 0x1a) = 0;
-
-	work[14] = RandF__5CMathFf(1.0f, &math);
+	*((unsigned short*)((unsigned char*)work + 0x30)) = 0;
+	*((unsigned short*)((unsigned char*)work + 0x34)) = 0;
+	*((unsigned short*)((unsigned char*)work + 0x32)) = 0;
+	work[14] = RandF__5CMathFf(1.0f, &Math);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `src/pppYmLaser.cpp` in `pppConstructYmLaser` to better match original store sequencing and data access widths.
- Switched this unit to use `extern CMath Math` (and `&Math`) for `RandF__5CMathFf`, matching the PAL symbol naming used by the original build.

## Functions Improved
- Unit: `main/pppYmLaser`
- Function: `pppConstructYmLaser` (PAL 0x800d3780, 152b)

## Match Evidence
- `pppConstructYmLaser`: **79.447365% -> 79.52631%** (`+0.078945`)
- `main/pppYmLaser` unit fuzzy: **5.343452% -> 5.3460536%** (`+0.0026016`)
- Other functions in unit unchanged (`pppConstruct2YmLaser`, `pppDestructYmLaser`, `pppFrameYmLaser`, `pppRenderYmLaser`).

Measured from objdiff reports:
- Before: `_report_before_pppYmLaser.json`
- After: `build/GCCP01/report.json`

## Plausibility Rationale
- The change is source-plausible and follows observed original coding patterns:
  - Uses the project-wide `Math` global symbol naming seen in PAL MAP data.
  - Keeps logic unchanged while adjusting write ordering/access form to match likely original compiler output.
- No contrived control-flow tricks or artificial temporaries were introduced.

## Technical Notes
- The repo currently has `objdiff-cli 3.4.1`, so JSON one-shot diff (`-o`) from AGENTS.md is unavailable; comparison used `objdiff report generate` output instead.
