### PR TITLE
astar: improve calcSpecialPolygonGroup match

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -884,9 +884,8 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
  */
 unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 {
-	unsigned char polygonGroup = 0;
 	unsigned long mask = m_hitAttributeMask;
-	
+
 	CVector bottom(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 	CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
 	CMapCylinder cyl;
@@ -908,10 +907,10 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 
 	if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), mask) != 0)
 	{
-		polygonGroup = lbl_8032EC90[0x47];
+		return lbl_8032EC90[0x47];
 	}
 
-	return polygonGroup;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
Simplified the return path in CAStar::calcSpecialPolygonGroup(Vec*) in src/astar.cpp by removing the temporary polygonGroup variable and returning directly on hit.

## Functions improved
- Unit: main/astar
- Symbol: calcSpecialPolygonGroup__6CAStarFP3Vec

## Match evidence
- Before: 49.634922% (_report_baseline_astar.json)
- After: 52.650795% (_report_after_astar_try2.json)
- Delta: +3.015873
- No regression observed in checked neighboring targets:
  - calcPolygonGroup__6CAStarFP3Veci: 42.666668% -> 42.666668%
  - drawAStar__6CAStarFv: 58.845715% -> 58.845715%

## Plausibility rationale
The updated form is conventional original-source style: direct early return from a boolean hit check and explicit eturn 0 fallback, without introducing contrived temporaries or reorderings.

## Technical details
- Built with 
inja successfully after change.
- Measured function-level fuzzy match deltas via uild/tools/objdiff-cli report generate and compared baseline vs post-change reports.