### PR TITLE
pppPart: implement heap check leak helper

### DIFF
--- a/include/ffcc/pppPart.h
+++ b/include/ffcc/pppPart.h
@@ -53,7 +53,7 @@ void pppMemAlloc(unsigned long, CMemory::CStage*, char*, int);
 void pppMemFree(void*);
 void pppHeapUseRate(CMemory::CStage* stage);
 void pppHeapCheckLeak(CMemory::CStage* stage);
-void pppMngStHeapCheckLeak(CMemory::CStage* stage);
+unsigned long pppMngStHeapCheckLeak(CMemory::CStage* stage);
 void pppMngStHeapCheck(CMemory::CStage* stage);
 void callCon2Prog(_pppPObject*);
 void callConProg(_pppPObject*);

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -280,7 +280,7 @@ void pppMemFree(void*)
  */
 void pppHeapUseRate(CMemory::CStage* stage)
 { 
-	if (stage != (CMemory::CStage *)nullptr)
+	if (stage != (CMemory::CStage*)0)
 	{
 		Memory.Free(stage);
 	}
@@ -305,8 +305,20 @@ void pppHeapCheckLeak(CMemory::CStage* stage)
  * Address:	TODO
  * Size:	TODO
  */
-void pppMngStHeapCheckLeak(CMemory::CStage* stage)
+unsigned long pppMngStHeapCheckLeak(CMemory::CStage* stage)
 {
+	unsigned long heapTotal;
+	unsigned long heapUseRate;
+	unsigned long heapUnused;
+
+	stage->heapInfo(heapTotal, heapUseRate, heapUnused);
+	if (heapTotal == 0) {
+		heapTotal = 10000;
+	} else {
+		heapTotal = (heapUseRate * 10000) / heapTotal;
+	}
+
+	return heapTotal;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated the heap-check helper in `main/pppPart` from a stub to a concrete heap-usage computation.
- Changed `pppMngStHeapCheckLeak` to return an `unsigned long` usage ratio and implemented `heapInfo`-based percent logic.
- Kept `pppHeapUseRate` in old-style null-check form to align with surrounding Metrowerks-era patterns.

## Functions improved
- Unit: `main/pppPart`
- Updated source function: `pppMngStHeapCheckLeak(CMemory::CStage*)`

## Match evidence
- `main/pppPart` fuzzy match: `16.363127 -> 18.899412`
- `main/pppPart` matched code: `720 -> 732`
- `main/pppPart` matched functions: `13 -> 14`
- Built successfully with `ninja` after the change.

## Plausibility rationale
- The new implementation follows a conventional heap diagnostic pattern (`heapInfo`, zero-guard, scaled ratio) and avoids compiler-coaxing constructs.
- Signature/body now reflect source-intent semantics for a "heap check leak" helper, rather than an empty stub.

## Technical details
- `stage->heapInfo(total, used, unused)` is used to gather heap counters.
- The function returns `10000` when total is zero; otherwise `(used * 10000) / total`.
- This keeps the ratio in fixed-point style used broadly in this codebase.
