### PR TITLE
main/gxfunc: match _GXSetAlphaCompare store ordering

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -224,11 +224,11 @@ void _GXSetAlphaCompare(_GXCompare comp0, unsigned char ref0, _GXAlphaOp op, _GX
 {
 	if (s_GXSetAlphaCompare_Reg.comp0 != comp0 || s_GXSetAlphaCompare_Reg.alphaOp != op || s_GXSetAlphaCompare_Reg.comp1 != comp1 ||
 	    s_GXSetAlphaCompare_Reg.ref0 != ref0 || s_GXSetAlphaCompare_Reg.ref1 != ref1) {
-		s_GXSetAlphaCompare_Reg.ref0 = ref0;
-		s_GXSetAlphaCompare_Reg.ref1 = ref1;
 		s_GXSetAlphaCompare_Reg.comp0 = comp0;
 		s_GXSetAlphaCompare_Reg.alphaOp = op;
 		s_GXSetAlphaCompare_Reg.comp1 = comp1;
+		s_GXSetAlphaCompare_Reg.ref0 = ref0;
+		s_GXSetAlphaCompare_Reg.ref1 = ref1;
 		GXSetAlphaCompare(comp0, ref0, op, comp1, ref1);
 	}
 }


### PR DESCRIPTION
## Summary
- Updated `src/gxfunc.cpp` in `_GXSetAlphaCompare` to write cache fields in struct order (`comp0`, `alphaOp`, `comp1`, then `ref0`, `ref1`) before calling `GXSetAlphaCompare`.
- No logic or control-flow changes; this is a store-order/type-layout alignment change.

## Functions Improved
- Unit: `main/gxfunc`
- Function: `_GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc`

## Match Evidence
- `main/gxfunc` unit fuzzy match: **77.72335% -> 79.56345%**
- `main/gxfunc` matched code bytes: **616 -> 756**
- `main/gxfunc` matched functions: **6/11 -> 7/11**
- `_GXSetAlphaCompare` fuzzy match: **79.28571% -> 100.0%**
- `objdiff diff` symbol `match_percent`: **75.14286 -> 98.71429**

## Plausibility Rationale
- The change matches natural C struct-write behavior: store fields in declared layout order and then issue the GX call.
- This avoids compiler-coaxing patterns and keeps the function idiomatic and readable.

## Technical Notes
- The previous ordering wrote `ref0/ref1` before the first three 32-bit fields, which produced non-matching store sequencing in generated PPC.
- Reordering assignments to mirror the cached struct layout removed the remaining mismatch for this wrapper.