### PR TITLE
Improve CGObject::onDestroy decomp match

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1,6 +1,9 @@
 #include "ffcc/gobject.h"
 
 #include "ffcc/p_game.h"
+#include "ffcc/partMng.h"
+
+extern CPartMng PartMng;
 
 static const float sBgDefaultGravityY = 0.0;
 static bool sBgCollisionActive;
@@ -41,12 +44,43 @@ void CGObject::onCreate()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80081dd8
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGObject::onDestroy()
 {
-	// TODO
+    if (m_charaModelHandle != (CCharaPcs::CHandle*)0) {
+        PartMng.pppDeleteCHandle(m_charaModelHandle);
+    }
+
+    if (m_weaponModelHandle != (CCharaPcs::CHandle*)0) {
+        PartMng.pppDeleteCHandle(m_weaponModelHandle);
+    }
+
+    if (m_shieldModelHandle != (CCharaPcs::CHandle*)0) {
+        PartMng.pppDeleteCHandle(m_shieldModelHandle);
+    }
+
+    if (m_charaModelHandle != (CCharaPcs::CHandle*)0) {
+        delete m_charaModelHandle;
+        m_charaModelHandle = (CCharaPcs::CHandle*)0;
+    }
+
+    if (m_weaponModelHandle != (CCharaPcs::CHandle*)0) {
+        delete m_weaponModelHandle;
+        m_weaponModelHandle = (CCharaPcs::CHandle*)0;
+    }
+
+    if (m_shieldModelHandle != (CCharaPcs::CHandle*)0) {
+        delete m_shieldModelHandle;
+        m_shieldModelHandle = (CCharaPcs::CHandle*)0;
+    }
+
+    m_scriptHandle = (void**)0;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented CGObject::onDestroy in src/gobject.cpp using the PAL Ghidra reference for cleanup behavior.

Changes:
- Added partMng include and extern CPartMng PartMng usage.
- Replaced TODO body with model-handle teardown flow:
  - call PartMng.pppDeleteCHandle(...) for chara/weapon/shield handles when present
  - delete each handle and clear to null
  - clear m_scriptHandle
- Updated function info block with PAL address/size metadata.

## Functions Improved
- Unit: main/gobject
- Function: onDestroy__8CGObjectFv (204 bytes)

## Match Evidence
From uild/GCCP01/report.json before and after:
- onDestroy__8CGObjectFv: 1.9607843% -> 90.588234%
- main/gobject unit fuzzy: 2.1390707% -> 2.8437793%


inja build passes after the change.

## Plausibility Rationale
The new implementation matches expected engine ownership semantics for model handles:
- unregister handles from particle/part manager before destruction
- destroy owned handles
- null stored pointers to avoid stale references
- clear script handle on object destroy

This is consistent with likely original source intent and the available PAL decomp guidance, not compiler-coaxing.