### PR TITLE
RedDriver: implement stream command wrappers

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/RedSound/RedDriver.h"
 #include "ffcc/RedSound/RedMemory.h"
 #include "ffcc/RedSound/RedEntry.h"
+#include "ffcc/RedSound/RedStream.h"
 #include "dolphin/ar.h"
 #include "dolphin/ax.h"
 #include "dolphin/os.h"
@@ -404,42 +405,58 @@ void _SePause(int*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bda34
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _StreamStop(int*)
+void _StreamStop(int* param_1)
 {
-	// TODO
+	StreamStop(*param_1);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bda64
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _StreamPlay(int*)
+void _StreamPlay(int* param_1)
 {
-	// TODO
+	StreamPlay(param_1[0], (void*)param_1[1], param_1[2], param_1[3], param_1[4]);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bdaa4
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _StreamVolume(int*)
+void _StreamVolume(int* param_1)
 {
-	// TODO
+	SetStreamVolume(param_1[0], param_1[1], param_1[2]);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bdadc
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _StreamPause(int*)
+void _StreamPause(int* param_1)
 {
-	// TODO
+	StreamPause(param_1[0], param_1[1]);
 }
 
 /*
@@ -1174,22 +1191,30 @@ void CRedDriver::GetStreamPlayPoint(int, int*, int*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bfa74
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::StreamStop(int)
+void CRedDriver::StreamStop(int param_1)
 {
-	// TODO
+	_EntryExecCommand(_StreamStop, param_1, 0, 0, 0, 0, 0, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bfabc
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::StreamPlay(int, void*, int, int, int)
+void CRedDriver::StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5)
 {
-	// TODO
+	_EntryExecCommand(_StreamPlay, param_1, (int)param_2, param_3, param_4, param_5, 0, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented the RedSound stream command wrapper functions in `src/RedSound/RedDriver.cpp` and updated function info blocks with PAL address/size metadata.

Changes:
- Added `#include "ffcc/RedSound/RedStream.h"` for stream API declarations.
- Implemented `_StreamStop`, `_StreamPlay`, `_StreamVolume`, and `_StreamPause` as direct parameter-forwarding wrappers.
- Implemented `CRedDriver::StreamStop` and `CRedDriver::StreamPlay` as command enqueuing wrappers via `_EntryExecCommand`.

## Functions improved
Unit: `main/RedSound/RedDriver`

- `_StreamStop__FPi` (48b): **8.333333% -> 75.0%**
- `_StreamPlay__FPi` (64b): **6.25% -> 73.4375%**
- `_StreamVolume__FPi` (56b): **7.142857% -> 69.14286%**
- `_StreamPause__FPi` (52b): **7.6923075% -> 68.46154%**

No measurable change yet on:
- `StreamStop__10CRedDriverFi` (72b): 5.5555553%
- `StreamPlay__10CRedDriverFiPviii` (96b): 4.1666665%

## Match evidence
- Rebuilt with `ninja` successfully.
- Verified updated scores in `build/GCCP01/report.json` for `main/RedSound/RedDriver`.
- Collected targeted objdiff snapshots for changed symbols:
  - `_diff_RedDriver__StreamStop_after.json`
  - `_diff_RedDriver_StreamStopMethod_after.json`
  - `_diff_RedDriver_StreamPlayMethod_after.json`

## Plausibility rationale
These changes are source-plausible because they restore straightforward driver wrapper behavior:
- `_Stream*` functions simply unpack command parameters and forward to the stream API.
- `CRedDriver::Stream*` methods enqueue driver commands with the same argument layout used throughout RedDriver.

No contrived temporaries or compiler-coaxing patterns were introduced; the code reflects idiomatic command-dispatch wrappers expected in this subsystem.
