### PR TITLE
p_minigame: implement MiniGamePcs wrapper callbacks

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/p_minigame.h"
 
+extern CMiniGamePcs MiniGamePcs;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -42,12 +44,16 @@ void AdjustGbaImageRegistry(char*, char*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012b09c
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _OpenCallback(MgGbaThreadParam*, void*)
+void _OpenCallback(MgGbaThreadParam* param, void* context)
 {
-	// TODO
+    MiniGamePcs.OpenCallback(param, context);
 }
 
 /*
@@ -92,22 +98,30 @@ void GbaThreadReadInitialCode(MgGbaThreadParam*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801290a0
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _GbaThreadMain(void*)
+void _GbaThreadMain(void* param)
 {
-	// TODO
+    MiniGamePcs.GbaThreadMain(param);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80128574
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _MngThreadMain(void*)
+void _MngThreadMain(void* param)
 {
-	// TODO
+    MiniGamePcs.MngThreadMain(param);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three thin wrapper callbacks in src/p_minigame.cpp as direct forwards to the global MiniGamePcs instance:
- _MngThreadMain(void*) -> CMiniGamePcs::MngThreadMain(void*)
- _GbaThreadMain(void*) -> CMiniGamePcs::GbaThreadMain(void*)
- _OpenCallback(MgGbaThreadParam*, void*) -> CMiniGamePcs::OpenCallback(MgGbaThreadParam*, void*)

Also updated these functions to the runbook INFO comment format with PAL address/size metadata.

## Functions improved
Unit: main/p_minigame (src/p_minigame.cpp)
- _MngThreadMain__FPv: 9.090909% -> 99.09091% (44b)
- _GbaThreadMain__FPv: 9.090909% -> 99.09091% (44b)
- _OpenCallback__FP16MgGbaThreadParamPv: 7.6923075% -> 75.0% (52b)

## Match evidence
From objdiff-cli report changes (_report_current.json -> _report_after_run.json):
- main/p_minigame fuzzy match: 