### PR TITLE
Improve pppSRandDownFV match by correcting CMath global shape

### DIFF
--- a/src/pppSRandDownFV.cpp
+++ b/src/pppSRandDownFV.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppSRandDownFV.h"
 #include "ffcc/math.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern float lbl_80330080;
 extern float lbl_801EADC8[];
@@ -50,21 +50,21 @@ void pppSRandDownFV(void* param1, void* param2, void* param3)
         unsigned char blendTwice = cfg->blendTwice;
         randVec = reinterpret_cast<float*>(self + offset + 0x80);
 
-        float value = -RandF__5CMathFv(&math);
+        float value = -RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330080;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330080;
         }
         randVec[0] = value;
 
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330080;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330080;
         }
         randVec[1] = value;
 
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330080;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330080;
         }
         randVec[2] = value;
     } else {


### PR DESCRIPTION
## Summary
Adjusted pppSRandDownFV to use the project-consistent CMath math[] declaration and pass math directly to RandF__5CMathFv.

## Functions improved
- Unit: main/pppSRandDownFV
- Function: pppSRandDownFV

## Match evidence
- pppSRandDownFV: **85.37383% -> 92.009346%** (+6.635516)
- Verified via:
  - 
inja (rebuild + report generation)
  - uild/tools/objdiff-cli report changes --format json-pretty _tmp_report_before_os.json build/GCCP01/report.json -o _tmp_changes_pppSRandDownFV.json

## Plausibility rationale
This change aligns with common usage across nearby particle randomization units, where CMath is treated as an array/object storage and passed as a pointer value (math) rather than taking &math from a scalar declaration. It improves ABI/codegen shape without introducing artificial control-flow tweaks.

## Technical notes
- Source change is isolated to src/pppSRandDownFV.cpp.
- No behavioral logic changes were introduced; only declaration/call form was adjusted to match surrounding code patterns.