### PR TITLE
RedDriver: fix __sinit_RedDriver_cpp linkage

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -103,7 +103,7 @@ extern void InitReverb();
  * JP Address: TODO
  * JP Size: TODO
  */
-void __sinit_RedDriver_cpp()
+extern "C" void __sinit_RedDriver_cpp(void)
 {
     void* uVar1;
     


### PR DESCRIPTION
## Summary
- Changed `__sinit_RedDriver_cpp` in `src/RedSound/RedDriver.cpp` to explicit C linkage.
- No logic changes; only symbol linkage/signature form was updated.

## Functions Improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `__sinit_RedDriver_cpp`
- Match: `0.0%` (target selector baseline) -> `74.04348%` (objdiff after change)

## Match Evidence
- Selector output prior to edit listed `__sinit_RedDriver_cpp` at `0.0%` in `main/RedSound/RedDriver`.
- Post-change objdiff command:
  - `tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - __sinit_RedDriver_cpp`
- Post-change symbol result: `match_percent: 74.04348`, `size: 92`.

## Plausibility Rationale
- `__sinit_*` static initializer functions are compiler/runtime-facing entry points and are expected to use unmangled/C linkage in this codebase.
- The function body already matched the expected construction/registration sequence from Ghidra; linkage mismatch was blocking symbol-level alignment.

## Technical Details
- Updated declaration from:
  - `void __sinit_RedDriver_cpp()`
  to:
  - `extern C void __sinit_RedDriver_cpp(void)`
- Rebuilt with `ninja` and verified improvement with symbol-level objdiff.