### PR TITLE
textureman: define TextureMan and derive CTextureMan from CManager

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -1,6 +1,7 @@
 #ifndef _FFCC_PPP_TEXTUREMAN_H_
 #define _FFCC_PPP_TEXTUREMAN_H_
 
+#include "ffcc/manager.h"
 #include "ffcc/memory.h"
 
 #include <dolphin/gx.h>
@@ -51,11 +52,9 @@ public:
     void ReleaseTextureIdx(int, CAmemCacheSet*);
 };
 
-class CTextureMan
+class CTextureMan : public CManager
 {
 public:
-    CTextureMan();
-
     void Init();
     void Quit();
     void SetTexture(_GXTexMapID, CTexture*);
@@ -65,7 +64,6 @@ public:
     friend class CTextureSet;
 
 private:
-    void* m_vtable;
     CMemory::CStage* m_memoryStage;
 };
 

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -3,7 +3,7 @@
 
 #include <string.h>
 
-extern CTextureMan TextureMan;
+CTextureMan TextureMan;
 extern CMemory Memory;
 extern CSystem System;
 
@@ -305,16 +305,6 @@ template <>
 CTexture* CPtrArray<CTexture*>::GetAt(unsigned long index)
 {
     return m_items[index];
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-CTextureMan::CTextureMan()
-{
-	// TODO
 }
 
 /*


### PR DESCRIPTION
## Summary
- changed `CTextureMan` to derive from `CManager` in `include/ffcc/textureman.h`
- removed the manual `m_vtable` placeholder field and dropped the explicit empty `CTextureMan::CTextureMan()` definition
- replaced `extern CTextureMan TextureMan;` with a real definition `CTextureMan TextureMan;` in `src/textureman.cpp`

## Functions improved
- Unit: `main/textureman`
- Function: `__sinit_textureman_cpp` (28 bytes)
  - Before: not matched / effectively 0% (no fuzzy score)
  - After: **100.0% fuzzy match**

## Match evidence
- `main/textureman` unit fuzzy match: **16.467606 -> 16.86197**
- `main/textureman` matched functions: **6/38 -> 7/38**
- Global progress from `ninja`:
  - Matched code bytes: **192112 -> 192140**
  - Matched functions: **1364 -> 1365**
  - Matched data bytes: **80 -> 84**

## Plausibility rationale
- The target object contains a TU static initializer for `TextureMan` that writes the base/derived vtable sequence.
- Modeling `CTextureMan` as a real `CManager`-derived type and defining the global `TextureMan` object in `textureman.cpp` is source-plausible and consistent with this codegen pattern.
- This avoids compiler-coaxing artifacts and aligns object ownership/layout with expected game-side manager patterns.

## Technical notes
- Rebuilt with `ninja` (success).
- Disassembly check of `build/GCCP01/src/textureman.o` now shows `__sinit_textureman_cpp` emitted with the expected `TextureMan@sda21` vtable stores.