### PR TITLE
menu: implement CMenu deleting destructor wrapper

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,5 +1,9 @@
 #include "ffcc/menu.h"
 
+extern "C" void __dl__FPv(void*);
+extern "C" void* __vt__5CMenu;
+extern "C" CRef* dtor_80043D10(CRef* ref, short param_2);
+
 /*
  * --INFO--
  * PAL Address: 0x8009b4a8
@@ -16,8 +20,8 @@ CMenu::CMenu()
 
 /*
  * --INFO--
- * PAL Address: 0x8009b488
- * PAL Size: 72b
+ * PAL Address: 0x8009b448
+ * PAL Size: 96b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
@@ -25,6 +29,28 @@ CMenu::CMenu()
  */
 CMenu::~CMenu()
 {
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8009b448
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CMenu* dtor_8009B448(CMenu* menu, short param_2)
+{
+	if (menu != 0) {
+		*(void**)menu = &__vt__5CMenu;
+		dtor_80043D10(menu, 0);
+		if (0 < param_2) {
+			__dl__FPv(menu);
+		}
+	}
+
+	return menu;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added explicit deleting-destructor wrapper dtor_8009B448(CMenu*, short) in src/menu.cpp.
- Wired it to restore CMenu vtable, call base destructor wrapper dtor_80043D10, and conditionally call __dl__FPv when param_2 > 0.
- Updated destructor metadata block to PAL address/size from the target symbol (