### PR TITLE
pppYmMelt: first-pass implementation of pppFrameYmMelt

### DIFF
--- a/include/ffcc/pppYmMelt.h
+++ b/include/ffcc/pppYmMelt.h
@@ -26,6 +26,15 @@ struct PYmMeltDataOffsets {
     s32* m_serializedDataOffsets;
 };
 
+struct YmMeltCtrl {
+    s32 m_graphId;
+    u16 m_dataValIndex;
+    u16 m_initWOrk;
+    f32 m_stepValue;
+    f32 m_arg3;
+    u8 m_payload[0x20];
+};
+
 void InitPolygonData(PYmMelt*, VERTEX_DATA*, short);
 void CalcPolygonHeight(PYmMelt*, VERTEX_DATA*, _GXColor*, float);
 
@@ -35,7 +44,7 @@ extern "C" {
 
 void pppConstructYmMelt(PYmMelt*, PYmMeltDataOffsets*);
 void pppDestructYmMelt(PYmMelt*, PYmMeltDataOffsets*);
-void pppFrameYmMelt(void);
+void pppFrameYmMelt(PYmMelt*, YmMeltCtrl*, PYmMeltDataOffsets*);
 void pppRenderYmMelt(void);
 
 #ifdef __cplusplus

--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -2,23 +2,44 @@
 #include "ffcc/pppPart.h"
 #include "ffcc/map.h"
 #include "ffcc/maphit.h"
+#include "dolphin/mtx.h"
 
+extern int DAT_8032ed70;
 extern float lbl_80330AF0;
+extern float FLOAT_80330af0;
+extern float FLOAT_80330b08;
+extern float FLOAT_80330b0c;
+extern double DOUBLE_80330af8;
+extern double DOUBLE_80330b00;
 extern float FLOAT_80330b10;
 extern float FLOAT_80330b14;
 extern float FLOAT_80330b18;
 extern CMapMng MapMng;
 
 extern "C" {
+int rand(void);
 int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned int);
 void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
 void DCFlushRange(void*, unsigned long);
+void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+void pppCalcFrameShape__FPlRsRsRss(long*, short&, short&, short&, short);
 }
 
 struct YmMeltVertex
 {
     Vec m_position;
     u8 m_color[4];
+};
+
+struct YmMeltWork {
+    YmMeltVertex* m_vertexData;
+    s16 m_shapeFrame;
+    s16 m_shapeAge;
+    s16 m_shapeNext;
+    s16 m_phaseOffset;
+    f32 m_phase;
+    f32 m_phaseVelocity;
+    f32 m_phaseAccel;
 };
 
 /*
@@ -156,12 +177,72 @@ void pppDestructYmMelt(PYmMelt* pppYmMelt, PYmMeltDataOffsets* param_2)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800A5A40
+ * PAL Size: 680b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameYmMelt(void)
+void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offsets)
 {
-	// TODO
+    static char s_pppYmMelt_cpp[] = "pppYmMelt.cpp";
+
+    if (DAT_8032ed70 != 0) {
+        return;
+    }
+
+    YmMeltWork* work = (YmMeltWork*)((u8*)ymMelt + *offsets->m_serializedDataOffsets + 0x80);
+    int grid = (int)((u16)((u8*)&ctrl->m_initWOrk)[2]) + 1;
+    float matrixY = pppMngStPtr->m_matrix.value[1][3];
+
+    if (work->m_vertexData == nullptr) {
+        int pointCount = grid * grid;
+        work->m_vertexData = (YmMeltVertex*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            (unsigned long)pointCount * sizeof(YmMeltVertex), pppEnvStPtr->m_stagePtr, s_pppYmMelt_cpp, 0xA9);
+
+        YmMeltVertex* vtx = work->m_vertexData;
+        s16 phaseDiv = *(s16*)((u8*)&ctrl->m_arg3 + 2);
+        int angleSeed = rand();
+        work->m_phaseOffset = (phaseDiv != 0) ? (s16)(angleSeed - (angleSeed / phaseDiv) * phaseDiv) : 0;
+
+        float halfWidth = ctrl->m_stepValue * FLOAT_80330b08;
+        float step = ctrl->m_stepValue / ((float)((u16)((u8*)&ctrl->m_initWOrk)[2]) - (float)DOUBLE_80330af8);
+        float rot = FLOAT_80330b0c * ((float)(work->m_phaseOffset) - (float)DOUBLE_80330b00);
+
+        for (float z = -halfWidth; z <= halfWidth; z += step) {
+            for (float x = -halfWidth; x <= halfWidth; x += step) {
+                vtx->m_position.x = x;
+                vtx->m_position.y = FLOAT_80330af0;
+                vtx->m_position.z = z;
+
+                if (work->m_phaseOffset != 0) {
+                    Mtx rotMtx;
+                    PSMTXRotRad(rotMtx, 'y', rot);
+                    PSMTXMultVec(rotMtx, &vtx->m_position, &vtx->m_position);
+                }
+
+                vtx++;
+            }
+        }
+
+        CalcPolygonHeight(ymMelt, (VERTEX_DATA*)ctrl, (_GXColor*)work->m_vertexData, matrixY);
+    }
+
+    work->m_phaseVelocity = work->m_phaseVelocity + work->m_phaseAccel;
+    work->m_phase = work->m_phase + work->m_phaseVelocity;
+
+    if (ctrl->m_graphId == *(s32*)ymMelt) {
+        work->m_phase += *(float*)&ctrl->m_payload[0];
+        work->m_phaseVelocity += *(float*)&ctrl->m_payload[4];
+        work->m_phaseAccel += *(float*)&ctrl->m_payload[8];
+    }
+
+    if (ctrl->m_dataValIndex != 0xFFFF) {
+        long* shape = *(long**)(*(u32*)&pppEnvStPtr->m_particleColors[0] + ctrl->m_dataValIndex * 4);
+        pppCalcFrameShape__FPlRsRsRss(shape, work->m_shapeFrame, work->m_shapeAge, work->m_shapeNext,
+                                      (s16)ctrl->m_initWOrk);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented pppFrameYmMelt in src/pppYmMelt.cpp from stub to a working first-pass decomp.
- Added YmMeltCtrl in include/ffcc/pppYmMelt.h and updated pppFrameYmMelt prototype to typed parameters.
- Added PAL address/size metadata block for pppFrameYmMelt.
- Kept pppRenderYmMelt unchanged to isolate match movement to one function.

## Functions improved
- Unit: main/pppYmMelt
- pppFrameYmMelt: **0.6% -> 63.44706%** (selector baseline to current report)
- pppRenderYmMelt: unchanged at ~0.23%
- CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf: unchanged at ~44.13%

## Match evidence
- Build: 
inja succeeds.
- Current report (uild/GCCP01/report.json):
  - pppFrameYmMelt fuzzy match: 63.44706% (size 680b)
  - main/pppYmMelt unit fuzzy match: 26.366072%
- Pre-change selector output showed pppFrameYmMelt at 