### PR TITLE
RedSound: implement DMA/SE wrapper stubs

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -226,12 +226,16 @@ int CRedSound::ReportStandby(int id)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cce34
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::DMAEntry(int, int, int, int, int, void (*) (void*), void*)
+void CRedSound::DMAEntry(int type, int src, int dst, int length, int flags, void (*callback)(void*), void* userData)
 {
-	// TODO
+	RedDmaEntry(type, src, dst, length, flags, callback, userData);
 }
 
 /*
@@ -416,12 +420,16 @@ void CRedSound::ClearSeSepData(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd200
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::ClearSeSepDataMG(int, int, int, int)
+void CRedSound::ClearSeSepDataMG(int bank, int sep, int group, int kind)
 {
-	// TODO
+	CRedDriver_8032f4c0.ClearSeSepDataMG(bank, sep, group, kind);
 }
 
 /*
@@ -456,12 +464,16 @@ void CRedSound::SeStop(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd2c8
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SeStopMG(int, int, int, int)
+void CRedSound::SeStopMG(int bank, int sep, int group, int kind)
 {
-	// TODO
+	CRedDriver_8032f4c0.SeStopMG(bank, sep, group, kind);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three `CRedSound` passthrough wrapper methods in `src/RedSound/RedSound.cpp` and filled in PAL metadata headers for each updated function:
- `DMAEntry__9CRedSoundFiiiiiPFPv_vPv`
- `ClearSeSepDataMG__9CRedSoundFiiii`
- `SeStopMG__9CRedSoundFiiii`

## Functions Improved
Unit: `main/RedSound/RedSound`
- `DMAEntry__9CRedSoundFiiiiiPFPv_vPv` (88b): **4.5455% -> 35.9545%**
- `ClearSeSepDataMG__9CRedSoundFiiii` (68b): **5.8824% -> 52.4118%**
- `SeStopMG__9CRedSoundFiiii` (68b): **5.8824% -> 52.4118%**

Unit fuzzy match:
- `main/RedSound/RedSound`: **27.3220% -> 29.7299%**

## Match Evidence
Validated with:
- `ninja`
- `build/tools/objdiff-cli report generate -p . -o _tmp_report_before_redsound.json -f json-pretty`
- `build/tools/objdiff-cli report generate -p . -o _tmp_report_after_redsound.json -f json-pretty`
- `build/tools/objdiff-cli report changes _tmp_report_before_redsound.json _tmp_report_after_redsound.json`

`ninja` completed successfully and project progress remained valid.

## Plausibility Rationale
These three functions are thin API-to-driver forwarding points in the RedSound layer. Implementing them as direct wrappers is consistent with existing architecture and naming:
- `CRedSound::DMAEntry` forwards to `RedDmaEntry`
- `CRedSound::ClearSeSepDataMG` forwards to `CRedDriver::ClearSeSepDataMG`
- `CRedSound::SeStopMG` forwards to `CRedDriver::SeStopMG`

No contrived control-flow or compiler-coaxing constructs were introduced; changes preserve source readability and align with likely original author intent for this interface layer.

## Technical Details
- Added concrete parameter names to avoid anonymous placeholder signatures.
- Updated function headers to include PAL address/size metadata from decomp references.
- Scope intentionally limited to wrapper-level behavior for a low-risk first pass on this unit.