### PR TITLE
menu_compa: implement CompaInit/Open/Close first pass

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -1,13 +1,105 @@
 #include "ffcc/menu_compa.h"
+#include <string.h>
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 801620f8
+ * PAL Size: 616b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::CompaInit()
 {
-	// TODO
+	int menuData = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x850);
+	memset(reinterpret_cast<void*>(menuData), 0, 0x1008);
+
+	float one = 1.0f;
+	int block = menuData + 8;
+	for (int i = 0; i < 8; ++i) {
+		*reinterpret_cast<float*>(block + 0x14) = one;
+		*reinterpret_cast<float*>(block + 0x54) = one;
+		*reinterpret_cast<float*>(block + 0x94) = one;
+		*reinterpret_cast<float*>(block + 0xd4) = one;
+		*reinterpret_cast<float*>(block + 0x114) = one;
+		*reinterpret_cast<float*>(block + 0x154) = one;
+		*reinterpret_cast<float*>(block + 0x194) = one;
+		*reinterpret_cast<float*>(block + 0x1d4) = one;
+		block += 0x200;
+	}
+
+	*reinterpret_cast<int*>(menuData + 0x24) = 0x52;
+	*reinterpret_cast<int*>(menuData + 0x20) = 4;
+	*reinterpret_cast<short*>(menuData + 8) = 0x28;
+	*reinterpret_cast<short*>(menuData + 10) = 0x30;
+	*reinterpret_cast<short*>(menuData + 0xc) = 0x198;
+	*reinterpret_cast<short*>(menuData + 0xe) = 0x18;
+	*reinterpret_cast<float*>(menuData + 0x10) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x14) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x1c) = 1.0f;
+	*reinterpret_cast<int*>(menuData + 0x2c) = 5;
+	*reinterpret_cast<int*>(menuData + 0x30) = 5;
+
+	*reinterpret_cast<int*>(menuData + 100) = 0x51;
+	*reinterpret_cast<short*>(menuData + 0x48) = 0x28;
+	*reinterpret_cast<short*>(menuData + 0x4a) = 0x48;
+	*reinterpret_cast<short*>(menuData + 0x4c) = 0x198;
+	*reinterpret_cast<short*>(menuData + 0x4e) = 200;
+	*reinterpret_cast<float*>(menuData + 0x50) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x54) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x5c) = 1.0f;
+	*reinterpret_cast<int*>(menuData + 0x6c) = 5;
+	*reinterpret_cast<int*>(menuData + 0x70) = 5;
+
+	*reinterpret_cast<int*>(menuData + 0xa4) = 0x52;
+	*reinterpret_cast<short*>(menuData + 0x88) = 0x28;
+	*reinterpret_cast<short*>(menuData + 0x8a) = 0x110;
+	*reinterpret_cast<short*>(menuData + 0x8c) = 0x198;
+	*reinterpret_cast<short*>(menuData + 0x8e) = 0x18;
+	*reinterpret_cast<float*>(menuData + 0x90) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x94) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x9c) = 1.0f;
+	*reinterpret_cast<int*>(menuData + 0xac) = 5;
+	*reinterpret_cast<int*>(menuData + 0xb0) = 5;
+
+	*reinterpret_cast<int*>(menuData + 0xe4) = 0x5e;
+	*reinterpret_cast<short*>(menuData + 200) = 0x10;
+	*reinterpret_cast<short*>(menuData + 0xca) = 0xe;
+	*reinterpret_cast<short*>(menuData + 0xcc) = 0x30;
+	*reinterpret_cast<short*>(menuData + 0xce) = 0x30;
+	*reinterpret_cast<float*>(menuData + 0xd0) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0xd4) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0xdc) = 1.0f;
+	*reinterpret_cast<int*>(menuData + 0xec) = 0;
+	*reinterpret_cast<int*>(menuData + 0xf0) = 5;
+
+	*reinterpret_cast<int*>(menuData + 0x124) = 0x5e;
+	*reinterpret_cast<short*>(menuData + 0x108) = 0x15;
+	*reinterpret_cast<short*>(menuData + 0x10c) = 0x30;
+	*reinterpret_cast<short*>(menuData + 0x10e) = 0x30;
+	*reinterpret_cast<short*>(menuData + 0x10a) = static_cast<short>(0x150 - *reinterpret_cast<short*>(menuData + 0x10e));
+	*reinterpret_cast<float*>(menuData + 0x110) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x114) = 0.0f;
+	*reinterpret_cast<float*>(menuData + 0x11c) = -13.0f;
+	*reinterpret_cast<int*>(menuData + 300) = 0;
+	*reinterpret_cast<int*>(menuData + 0x130) = 5;
+
+	*reinterpret_cast<int*>(menuData + 0x174) = 2;
+	*reinterpret_cast<int*>(menuData + 0x164) = 0x2e;
+	*reinterpret_cast<short*>(menuData + 0x148) = 0x10;
+	*reinterpret_cast<short*>(menuData + 0x14a) = 8;
+	*reinterpret_cast<short*>(menuData + 0x14c) = 0x30;
+	*reinterpret_cast<short*>(menuData + 0x14e) = 0x140;
+	*reinterpret_cast<float*>(menuData + 0x150) = 6.0f;
+	*reinterpret_cast<float*>(menuData + 0x154) = 0.0f;
+	*reinterpret_cast<int*>(menuData + 0x16c) = 0;
+	*reinterpret_cast<int*>(menuData + 0x170) = 5;
+
+	**reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850) = 6;
+	int menuState = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c);
+	*reinterpret_cast<short*>(menuState + 0x26) = 0;
+	*reinterpret_cast<char*>(menuState + 0xb) = 1;
 }
 
 /*
@@ -22,12 +114,48 @@ void CMenuPcs::CompaInit0()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80161f48
+ * PAL Size: 432b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::CompaOpen()
 {
-	// TODO
+	int menuState = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c);
+	if (*reinterpret_cast<char*>(menuState + 0xb) == 0) {
+		CompaInit();
+	}
+
+	*reinterpret_cast<short*>(menuState + 0x22) = static_cast<short>(*reinterpret_cast<short*>(menuState + 0x22) + 1);
+	int time = static_cast<int>(*reinterpret_cast<short*>(menuState + 0x22));
+
+	int entryCount = static_cast<int>(**reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850));
+	short* entry = *reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850) + 4;
+	for (int i = 0; i < entryCount; ++i) {
+		if (*reinterpret_cast<int*>(entry + 0x12) <= time) {
+			int duration = *reinterpret_cast<int*>(entry + 0x14);
+			if (time < *reinterpret_cast<int*>(entry + 0x12) + duration) {
+				*reinterpret_cast<int*>(entry + 0x10) = *reinterpret_cast<int*>(entry + 0x10) + 1;
+				float t = static_cast<float>(*reinterpret_cast<int*>(entry + 0x10)) / static_cast<float>(duration);
+				*reinterpret_cast<float*>(entry + 8) = t;
+
+				if ((*reinterpret_cast<unsigned int*>(entry + 0x16) & 2) == 0) {
+					*reinterpret_cast<float*>(entry + 0x18) =
+						(*reinterpret_cast<float*>(entry + 0x1c) - static_cast<float>(*entry)) * t;
+					*reinterpret_cast<float*>(entry + 0x1a) =
+						(*reinterpret_cast<float*>(entry + 0x1e) - static_cast<float>(entry[1])) * t;
+				}
+			} else {
+				*reinterpret_cast<float*>(entry + 8) = 1.0f;
+				*reinterpret_cast<float*>(entry + 0x18) = 0.0f;
+				*reinterpret_cast<float*>(entry + 0x1a) = 0.0f;
+			}
+		}
+
+		entry += 0x20;
+	}
 }
 
 /*
@@ -42,12 +170,45 @@ void CMenuPcs::CompaCtrl()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80161aac
+ * PAL Size: 380b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::CompaClose()
 {
-	// TODO
+	int menuState = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c);
+	*reinterpret_cast<short*>(menuState + 0x22) = static_cast<short>(*reinterpret_cast<short*>(menuState + 0x22) + 1);
+	int time = static_cast<int>(*reinterpret_cast<short*>(menuState + 0x22));
+
+	int entryCount = static_cast<int>(**reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850));
+	short* entry = *reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850) + 4;
+	for (int i = 0; i < entryCount; ++i) {
+		if (*reinterpret_cast<int*>(entry + 0x12) <= time) {
+			int duration = *reinterpret_cast<int*>(entry + 0x14);
+			if (time < *reinterpret_cast<int*>(entry + 0x12) + duration) {
+				*reinterpret_cast<int*>(entry + 0x10) = *reinterpret_cast<int*>(entry + 0x10) + 1;
+				float t = static_cast<float>(*reinterpret_cast<int*>(entry + 0x10)) / static_cast<float>(duration);
+				float fade = 1.0f - t;
+				*reinterpret_cast<float*>(entry + 8) = fade;
+
+				if ((*reinterpret_cast<unsigned int*>(entry + 0x16) & 2) == 0) {
+					*reinterpret_cast<float*>(entry + 0x18) =
+						(*reinterpret_cast<float*>(entry + 0x1c) - static_cast<float>(*entry)) * fade;
+					*reinterpret_cast<float*>(entry + 0x1a) =
+						(*reinterpret_cast<float*>(entry + 0x1e) - static_cast<float>(entry[1])) * fade;
+				}
+			} else {
+				*reinterpret_cast<float*>(entry + 8) = 0.0f;
+				*reinterpret_cast<float*>(entry + 0x18) = 0.0f;
+				*reinterpret_cast<float*>(entry + 0x1a) = 0.0f;
+			}
+		}
+
+		entry += 0x20;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented first-pass decomp for CMenuPcs::CompaInit, CMenuPcs::CompaOpen, and CMenuPcs::CompaClose in src/menu_compa.cpp, replacing TODO stubs with plausible menu animation/state setup logic and adding PAL address/size headers.

## Functions Improved
- CompaInit__8CMenuPcsFv: 0.64935064% -> 18.512987%
- CompaOpen__8CMenuPcsFv: 0.9259259% -> 41.537037%
- CompaClose__8CMenuPcsFv: 1.0526316% -> 43.86316%

Unit-level:
- main/menu_compa fuzzy: 0.3808073% -> 8.913938%

## Match Evidence
- Rebuilt with 
inja (success).
- Post-change report from uild/GCCP01/report.json shows large function-level assembly alignment gains in the three implemented functions.
- Remaining TODO functions in unit (CompaCtrl, CompaDraw) are unchanged and remain low-match.

## Plausibility Rationale
- Uses existing codebase conventions for partial decomp work in menu units (pointer-offset access via einterpret_cast and straightforward data table initialization).
- Implements behavior consistent with expected original source intent: menu element table initialization plus open/close interpolation of per-entry transform/alpha state.
- Avoids artificial compiler-coaxing patterns; changes are directly behavior-oriented and structurally aligned with existing menu function style.