### PR TITLE
math: implement CMath Rand* helpers and fix return types

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -33,11 +33,11 @@ public:
     void rotateToMatrix(float(*)[4], Vec*);
     void SRTToMatrix(float(*)[4], SRT*);
     void SRTToMatrixRT(float(*)[4], SRT*);
-    void Rand(unsigned long);
-    void RandF(float);
-    void RandF();
-    void RandPM(unsigned long);
-    void RandFPM(float);
+    int Rand(unsigned long);
+    float RandF(float);
+    float RandF();
+    int RandPM(unsigned long);
+    float RandFPM(float);
     void MTX44MultVec4(float(*)[4], Vec*, Vec4d*);
     void MTX44MultVec4(float(*)[4], Vec4d*, Vec4d*);
     void MTXGetScale(float(*)[4], Vec*);

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -4,6 +4,8 @@
 #include "math.h"
 #include "string.h"
 
+extern "C" int rand(void);
+
 CMath math;
 
 extern void* __vt__8CManager;
@@ -102,52 +104,91 @@ void CMath::SRTToMatrixRT(float (*) [4], SRT*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001bf9c
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::Rand(unsigned long)
+int CMath::Rand(unsigned long max)
 {
-	// TODO
+    if (max == 0) {
+        return 0;
+    }
+
+    return rand() % max;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001bf30
+ * PAL Size: 108b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::RandF(float)
+float CMath::RandF(float scale)
 {
-	// TODO
+    if (scale == 0.0f) {
+        return 0.0f;
+    }
+
+    return scale * ((float)rand() * (1.0f / 32768.0f));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001beec
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::RandF()
+float CMath::RandF()
 {
-	// TODO
+    return (float)rand() * (1.0f / 32768.0f);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001be98
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::RandPM(unsigned long)
+int CMath::RandPM(unsigned long max)
 {
-	// TODO
+    unsigned int value;
+
+    if (max == 0) {
+        return 0;
+    }
+
+    value = (unsigned int)rand() * 0xFFFE - 0x7FFF;
+    return (int)(value - (value / max) * max);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001be28
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::RandFPM(float)
+float CMath::RandFPM(float scale)
 {
-	// TODO
+    if (scale == 0.0f) {
+        return 0.0f;
+    }
+
+    return scale * (((float)rand() * (2.0f / 32768.0f)) - 1.0f);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `CMath` random helper signatures to return values instead of `void` (`Rand`, `RandF(float)`, `RandF()`, `RandPM`, `RandFPM`).
- Implemented source-plausible bodies for these five functions in `src/math.cpp`.
- Added PAL address/size metadata blocks for the updated functions.

## Functions Improved
- Unit: `main/math`
- `Rand__5CMathFUl`: 5.882353 -> 100.0
- `RandF__5CMathFf`: 3.7037036 -> 100.0
- `RandF__5CMathFv`: 5.882353 -> 100.0
- `RandPM__5CMathFUl`: 4.7619047 -> 99.52381
- `RandFPM__5CMathFf`: 3.5714285 -> 97.85714

## Match Evidence
- `main/math` unit fuzzy match: 7.5386453 -> 12.514791
- `main/math` matched code bytes: 68 -> 312
- `main/math` matched functions: 2/24 -> 5/24
- Overall matched functions: 1365 -> 1369 (from `ninja` progress/report)

## Plausibility Rationale
- The previous `void` signatures were inconsistent with observed symbol behavior and with how these APIs are naturally consumed.
- New implementations follow straightforward SDK-style random helper patterns (`rand()`, range masking/modulo, normalized float scaling), without contrived compiler coaxing.
- Changes are localized to `CMath` declarations/definitions and maintain idiomatic source readability.

## Technical Details
- Used project report deltas from `objdiff-cli report generate` before/after and `ninja` verification.
- Build validated successfully with `ninja`; only `include/ffcc/math.h` and `src/math.cpp` changed.