### PR TITLE
main/FunnyShape: improve ctor and deleting dtor match

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -34,12 +34,20 @@ static inline u32& U32At(CFunnyShape* self, u32 offset)
  */
 CFunnyShape::CFunnyShape()
 {
-    // Large class structure with multiple buffers
-    // Clear main buffer area first
+    PtrAt(this, 0x6010) = 0;
     memset(this, 0, 0x6000);
-    
-    // Initialize specific buffer areas (from Ghidra decomp analysis)
-    // Note: exact field layout unknown, using byte offsets from decomp
+    memset(Ptr(this, 0x6000), 0, 0x10);
+    memset(Ptr(this, 0x60D8), 0, 0x10);
+    memset(Ptr(this, 0x6014), 0, 0x40);
+
+    for (s32 i = 0; i < 0x10; i++) {
+        u32 offs = static_cast<u32>(i) * 4;
+        PtrAt(this, 0x6014 + offs) = 0;
+        PtrAt(this, 0x6054 + offs) = 0;
+        PtrAt(this, 0x6094 + offs) = 0;
+    }
+
+    U32At(this, 0x60D4) = 0;
 }
 
 /*
@@ -80,6 +88,54 @@ CFunnyShape::~CFunnyShape()
             PtrAt(this, 0x6054 + offs) = 0;
         }
     }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80051d80
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CFunnyShape* dtor_80051D80(CFunnyShape* funnyShape, short shouldDelete)
+{
+    if (funnyShape != 0) {
+        if (PtrAt(funnyShape, 0x6010) != 0) {
+            __dla__FPv(PtrAt(funnyShape, 0x6010));
+            PtrAt(funnyShape, 0x6010) = 0;
+        }
+
+        if (PtrAt(funnyShape, 0x600C) != 0) {
+            __dla__FPv(PtrAt(funnyShape, 0x600C));
+            PtrAt(funnyShape, 0x600C) = 0;
+        }
+
+        for (s32 i = 0; i < 0x10; i++) {
+            u32 offs = static_cast<u32>(i) * 4;
+            if (PtrAt(funnyShape, 0x6094 + offs) != 0) {
+                __dla__FPv(PtrAt(funnyShape, 0x6094 + offs));
+                PtrAt(funnyShape, 0x6094 + offs) = 0;
+            }
+
+            if (PtrAt(funnyShape, 0x6014 + offs) != 0) {
+                __dl__FPv(PtrAt(funnyShape, 0x6014 + offs));
+                PtrAt(funnyShape, 0x6014 + offs) = 0;
+            }
+
+            if (PtrAt(funnyShape, 0x6054 + offs) != 0) {
+                __dl__FPv(PtrAt(funnyShape, 0x6054 + offs));
+                PtrAt(funnyShape, 0x6054 + offs) = 0;
+            }
+        }
+
+        if (shouldDelete > 0) {
+            __dl__FPv(funnyShape);
+        }
+    }
+
+    return funnyShape;
 }
 
 /*


### PR DESCRIPTION
## Summary
- completed constructor zero-initialization in `CFunnyShape::CFunnyShape()` using existing offset helpers and array-style initialization loops.
- added explicit deleting-destructor wrapper `dtor_80051D80(CFunnyShape*, short)` following existing repo patterns used in other units.
- kept destructor behavior source-plausible (free-and-null cleanup across three pointer tables, optional `operator delete` when `shouldDelete > 0`).

## Functions improved
- Unit: `main/FunnyShape`
- `dtor_80051D80`: fuzzy match improved from effectively 0% (unmatched in report) to **79.17647%**.
- `__ct__11CFunnyShapeFv`: fuzzy match improved from **22.711864%** to **58.98305%**.

## Match evidence
- `main/FunnyShape` unit fuzzy match: **4.6540995% -> 8.351287%**.
- unchanged near-matching functions remained stable:
  - `ClearTextureData__11CFunnyShapeFv`: 98.333336%
  - `ClearAnmData__11CFunnyShapeFv`: 99.875%

## Plausibility rationale
- mirrors existing FFCC-Decomp destructor-wrapper style (`extern C dtor_...(..., short)` with null checks and conditional delete).
- uses straightforward initialization and cleanup logic expected in original game source, without contrived compiler-only sequencing.
- relies on existing offset helper utilities already present in this file rather than introducing ad-hoc hacks.

## Technical details
- Build/test: `ninja` passes and progress report generates successfully.
- Objdiff/report workflow used:
  - baseline and post-change reports via `tools/objdiff-cli report generate`.
  - function-level check via `tools/objdiff-cli diff -p . -u main/FunnyShape ... dtor_80051D80`.