### PR TITLE
main/pppVtMime: use source filename string in vt mime callbacks

### DIFF
--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -40,6 +40,7 @@ struct VtMimeEnv
 extern int lbl_8032ED70;
 extern VtMimeEnv* lbl_8032ED54;
 extern void* Graphic;
+static char s_pppVtMime_cpp[] = "pppVtMime.cpp";
 
 extern "C" {
 void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long size, void* stage, char* file, int line);
@@ -109,7 +110,7 @@ void pppDrawVtMime(void* param1, void* param2, void* param3)
     void** memPtr = (void**)(target + 0xC);
 
     if (*memPtr == 0) {
-        *memPtr = pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(vertCount * 0xC), * (void**)lbl_8032ED54, "Unknown", 0x2B);
+        *memPtr = pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(vertCount * 0xC), *(void**)lbl_8032ED54, s_pppVtMime_cpp, 0x2B);
     }
 
     if (vertCount > 0) {
@@ -188,7 +189,7 @@ void pppVtMimeDes(void* param1, void* param2)
     VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
 
     if (state->vertexBuffer != 0) {
-        _WaitDrawDone__8CGraphicFPci(Graphic, "Unknown", 0x50);
+        _WaitDrawDone__8CGraphicFPci(Graphic, s_pppVtMime_cpp, 0x50);
         pppHeapUseRate__FPQ27CMemory6CStage(state->vertexBuffer);
         state->vertexBuffer = 0;
     }


### PR DESCRIPTION
## Summary
- add a named source-file string (`s_pppVtMime_cpp`) in `src/pppVtMime.cpp`
- replace two placeholder string literals (`"Unknown"`) with that symbol in:
  - `pppDrawVtMime` allocation call
  - `pppVtMimeDes` draw-sync call

## Functions improved
- Unit: `main/pppVtMime`
- `pppVtMimeDes`: **87.46154% -> 88.84615%**
- `pppDrawVtMime`: **73.04958% -> 74.82645%**

## Match evidence
- `tools/objdiff-cli diff -p . -u main/pppVtMime -o - pppVtMimeDes`
- `tools/objdiff-cli diff -p . -u main/pppVtMime -o - pppDrawVtMime`
- Unit `.text` diff context from `pppDrawVtMime` JSON:
  - **81.904526% -> 83.16583%**

## Plausibility rationale
- using a stable per-file source string is consistent with nearby FFCC decomp patterns (`s_<file>...` labels) and with Metrowerks-era debug/diagnostic call sites
- replacing `"Unknown"` removes placeholder artifacts and makes the call sites look more like plausible original source rather than compiler coaxing

## Technical details
- main improvement comes from relocation/symbol alignment around `_WaitDrawDone__8CGraphicFPci` and `pppMemAlloc__FUlPQ27CMemory6CStagePci` call setup
- no control-flow rewrites or artificial temporaries were introduced; this is a focused data/symbol-shape correction
