### PR TITLE
pppDrawShape: improve pppCalcShape match via cast alignment

### DIFF
--- a/src/pppDrawShape.cpp
+++ b/src/pppDrawShape.cpp
@@ -89,7 +89,7 @@ void pppCalcShape(void* pppShape, void* data, void* additionalData)
 
 	shapeData->currentId = shapeData->counter;
 	shapeData->value = (u16)(shapeData->value + controlData->step);
-	if (shapeData->value < (u16)shape->maxValue) {
+	if (shapeData->value < shape->maxValue) {
 		return;
 	}
 	shapeData->value = (u16)(shapeData->value - shape->maxValue);
@@ -131,7 +131,7 @@ void pppDrawShape(void* pppShape, void* data, void* additionalData)
 	}
 
 	void** shapeTables = *(void***)((u8*)lbl_8032ED54 + 0xC);
-	void* shapeSpec = *(void**)((u8*)shapeTables + ((u32)type << 2));
+	void* shapeSpec = *(void**)((u8*)shapeTables + (type << 2));
 	ShapeSpecEntry* shape = (ShapeSpecEntry*)((u8*)shapeSpec + ((u32)shapeData->currentId << 3) + 0x10);
 	void* drawShape = (u8*)shapeSpec + shape->offset;
 


### PR DESCRIPTION
## Summary
- Updated `src/pppDrawShape.cpp` to align two expressions with the already-better-matching `pppDrawShape2` implementation.
- Removed an unnecessary cast in `pppCalcShape` comparison (`shapeData->value < shape->maxValue`).
- Simplified table index expression in `pppDrawShape` (`type << 2` without redundant cast).

## Functions improved
- Unit: `main/pppDrawShape`
- `pppCalcShape`
  - Before: `88.039215%` (build report)
  - After: `91.960785%` (build report)

## Match evidence
- Unit `main/pppDrawShape` fuzzy match:
  - Before: `87.38053%`
  - After: `89.150444%`
- `tools/objdiff-cli` (v3.6.1) oneshot JSON confirms current per-symbol score:
  - `pppCalcShape`: `91.960785%`

## Plausibility rationale
- The edits are type/cast normalization only, not compiler-coaxing control-flow rewrites.
- `pppDrawShape` and `pppDrawShape2` are equivalent code paths; making the former use the same signedness/cast shape as the latter is a plausible original-source alignment.

## Technical details
- Build validated with `ninja` after edit.
- Targeted diff generated with `tools/objdiff-cli diff -p . -u main/pppDrawShape -o - pppCalcShape`.
