### PR TITLE
main/gxfunc: improve Tev op cache wrappers

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -178,13 +178,16 @@ void _GXSetTevAlphaIn(_GXTevStageID stage, _GXTevAlphaArg a, _GXTevAlphaArg b, _
  */
 void _GXSetTevColorOp(_GXTevStageID stage, _GXTevOp op, _GXTevBias bias, _GXTevScale scale, unsigned char clamp, _GXTevRegID outReg)
 {
-	if (s_GXSetTevColorOp_Reg[stage].op != op || s_GXSetTevColorOp_Reg[stage].bias != bias || s_GXSetTevColorOp_Reg[stage].scale != scale ||
-	    s_GXSetTevColorOp_Reg[stage].clamp != clamp || s_GXSetTevColorOp_Reg[stage].outReg != outReg) {
-		s_GXSetTevColorOp_Reg[stage].op = op;
-		s_GXSetTevColorOp_Reg[stage].bias = bias;
-		s_GXSetTevColorOp_Reg[stage].scale = scale;
-		s_GXSetTevColorOp_Reg[stage].clamp = clamp;
-		s_GXSetTevColorOp_Reg[stage].outReg = outReg;
+	int stageOff = stage * 0x14;
+	char* entry = (char*)s_GXSetTevColorOp_Reg + stageOff;
+
+	if (*(int*)(entry + 0x0) != op || *(int*)(entry + 0x4) != bias || *(int*)(entry + 0x8) != scale || *(entry + 0xC) != clamp ||
+	    *(int*)(entry + 0x10) != outReg) {
+		*(int*)(entry + 0x0) = op;
+		*(int*)(entry + 0x4) = bias;
+		*(int*)(entry + 0x8) = scale;
+		*(entry + 0xC) = clamp;
+		*(int*)(entry + 0x10) = outReg;
 		GXSetTevColorOp(stage, op, bias, scale, clamp, outReg);
 	}
 }
@@ -200,13 +203,16 @@ void _GXSetTevColorOp(_GXTevStageID stage, _GXTevOp op, _GXTevBias bias, _GXTevS
  */
 void _GXSetTevAlphaOp(_GXTevStageID stage, _GXTevOp op, _GXTevBias bias, _GXTevScale scale, unsigned char clamp, _GXTevRegID outReg)
 {
-	if (s_GXSetTevAlphaOp_Reg[stage].op != op || s_GXSetTevAlphaOp_Reg[stage].bias != bias || s_GXSetTevAlphaOp_Reg[stage].scale != scale ||
-	    s_GXSetTevAlphaOp_Reg[stage].clamp != clamp || s_GXSetTevAlphaOp_Reg[stage].outReg != outReg) {
-		s_GXSetTevAlphaOp_Reg[stage].op = op;
-		s_GXSetTevAlphaOp_Reg[stage].bias = bias;
-		s_GXSetTevAlphaOp_Reg[stage].scale = scale;
-		s_GXSetTevAlphaOp_Reg[stage].clamp = clamp;
-		s_GXSetTevAlphaOp_Reg[stage].outReg = outReg;
+	int stageOff = stage * 0x14;
+	char* entry = (char*)s_GXSetTevAlphaOp_Reg + stageOff;
+
+	if (*(int*)(entry + 0x0) != op || *(int*)(entry + 0x4) != bias || *(int*)(entry + 0x8) != scale || *(entry + 0xC) != clamp ||
+	    *(int*)(entry + 0x10) != outReg) {
+		*(int*)(entry + 0x0) = op;
+		*(int*)(entry + 0x4) = bias;
+		*(int*)(entry + 0x8) = scale;
+		*(entry + 0xC) = clamp;
+		*(int*)(entry + 0x10) = outReg;
 		GXSetTevAlphaOp(stage, op, bias, scale, clamp, outReg);
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked `_GXSetTevColorOp` and `_GXSetTevAlphaOp` cache checks/stores in `src/gxfunc.cpp` to use explicit stage-offset memory access (`stage * 0x14`) and byte-exact field writes.
- Kept function signatures and behavior unchanged; only internal compare/store shape was updated.

## Functions improved
- `main/gxfunc::_GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID`
- `main/gxfunc::_GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID`

## Match evidence
- Unit `main/gxfunc` fuzzy match: **79.56345% -> 82.304565%**
- `_GXSetTevAlphaOp...`: **78.78788% -> 95.15151%**
- `_GXSetTevColorOp...`: **78.78788% -> 95.15151%**
- Build verification: `build/GCCP01/main.dol: OK`

## Plausibility rationale
- The updated code shape matches the existing FFCC wrapper style used in nearby functions (`_GXSetTevColorIn`, `_GXSetTevAlphaIn`, `_GXSetTevOrder`): stage-offset cache compare then SDK call.
- This is a source-plausible cache-wrapper implementation, not a contrived control-flow trick.

## Technical details
- Converted struct-member access to explicit offset-based compare/store at offsets `0x0, 0x4, 0x8, 0xC, 0x10`, matching observed target layout for these wrapper records.
- Preserved one-call behavior to `GXSetTevColorOp`/`GXSetTevAlphaOp` only on cache miss.
