### PR TITLE
main/cflat_runtime: improve Init and constructor matching

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -1,5 +1,12 @@
 #include "ffcc/cflat_runtime.h"
 
+extern "C" {
+void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
+char s_cflat_runtime_cpp_801d8ef8[];
+void* __vt__12CFlatRuntime[];
+void* __vt__Q212CFlatRuntime7CObject[];
+}
+
 /*
  * --INFO--
  * Address:	TODO
@@ -7,7 +14,17 @@
  */
 CFlatRuntime::CFlatRuntime()
 {
-	// TODO
+	unsigned char* const self = reinterpret_cast<unsigned char*>(this);
+
+	*reinterpret_cast<void***>(self) = __vt__12CFlatRuntime;
+	*reinterpret_cast<void***>(self + 0x1204) = __vt__Q212CFlatRuntime7CObject;
+	self[0x123C] &= 0xEF;
+	*reinterpret_cast<void***>(self + 0x124C) = __vt__Q212CFlatRuntime7CObject;
+	self[0x1284] &= 0xEF;
+	self[0x1294] = 0;
+	self[0x1298] = 1;
+
+	clear();
 }
 
 /*
@@ -21,6 +38,7 @@ CFlatRuntime::CFlatRuntime()
  */
 CFlatRuntime::~CFlatRuntime()
 {
+	Quit();
 }
 
 /*
@@ -30,7 +48,13 @@ CFlatRuntime::~CFlatRuntime()
  */
 void CFlatRuntime::Init()
 {
-	// TODO
+	typedef void* (*GetStageFn)(CFlatRuntime*);
+	GetStageFn getStage = reinterpret_cast<GetStageFn>((*reinterpret_cast<void***>(this))[0x11]);
+
+	*reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0xC) =
+		__nwa__FUlPQ27CMemory6CStagePci(0x3000, getStage(this), s_cflat_runtime_cpp_801d8ef8, 0x2A);
+	*reinterpret_cast<void**>(reinterpret_cast<char*>(this) + 0x10) =
+		__nwa__FUlPQ27CMemory6CStagePci(0x14880, getStage(this), s_cflat_runtime_cpp_801d8ef8, 0x2B);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFlatRuntime::Init()` in `src/cflat_runtime.cpp` using the runtime vtable callback and the two original staged allocations.
- Implemented constructor setup for `CFlatRuntime::CFlatRuntime()` with explicit vtable/embedded-object initialization and startup flags, then `clear()`.
- Updated `CFlatRuntime::~CFlatRuntime()` to call `Quit()`.

## Functions improved
Unit: `main/cflat_runtime`
- `Init__12CFlatRuntimeFv` (size 136): **2.9411764% -> 81.32353%**
- `__ct__12CFlatRuntimeFv` (size 116): **3.4482758% -> 80.655174%**

## Match evidence
`objdiff-cli report changes` (before vs after):
- Overall fuzzy match: **23.983526 -> 23.994099**
- Unit `main/cflat_runtime` fuzzy match: **1.1024805 -> 2.3312452**

## Plausibility rationale
- Changes align with observed original patterns in this codebase: vtable initialization via explicit symbols, flag masking, and stage-based allocations with file/line metadata.
- Logic is source-plausible for a runtime subsystem constructor/init path and avoids contrived compiler-only transformations.

## Technical details
- Used `build/tools/objdiff-cli report generate` + `report changes` for deterministic JSON evidence in this environment.
- `Init()` now retrieves stage from vtable slot `0x44` and allocates buffers at offsets `0xC` and `0x10` with original allocation sizes/line markers.