### PR TITLE
mapmesh: improve GetTexture match via control-flow cleanup

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -379,18 +379,22 @@ void CMapMesh::DrawPart(CMaterialSet* materialSet, int drawMaterialPart)
  */
 void* CMapMesh::GetTexture(CMaterialSet* materialSet, int& textureIndex)
 {
-    int* drawEntry = reinterpret_cast<int*>(PtrAt(this, 0x40));
-    if ((U16At(this, 0xA) == 0) || (*drawEntry == 0)) {
-        return 0;
+    void* texture = 0;
+
+    if (U16At(this, 0xA) != 0) {
+        int* drawEntry = reinterpret_cast<int*>(PtrAt(this, 0x40));
+        if (*drawEntry != 0) {
+            unsigned short materialIdx = *reinterpret_cast<unsigned short*>(drawEntry + 2);
+            textureIndex = materialIdx;
+            texture = *reinterpret_cast<void**>(
+                reinterpret_cast<unsigned char*>(
+                    (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[materialIdx]
+                ) +
+                0x3C);
+        }
     }
 
-    unsigned short materialIdx = *reinterpret_cast<unsigned short*>(drawEntry + 2);
-    textureIndex = materialIdx;
-    return *reinterpret_cast<void**>(
-        reinterpret_cast<unsigned char*>(
-            (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))[materialIdx]
-        ) +
-        0x3C);
+    return texture;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refactored `CMapMesh::GetTexture` in `src/mapmesh.cpp` to use explicit nested guard checks and a single return variable.
- Preserved behavior (return null unless draw list exists, then return material texture pointer at offset `0x3C`) while aligning control flow to target assembly.

## Functions improved
- Unit: `main/mapmesh`
- Function: `GetTexture__8CMapMeshFP12CMaterialSetRi`

## Match evidence
- Before: `66.13636%`
- After: `75.0%`
- Measurement command:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/mapmesh -o - GetTexture__8CMapMeshFP12CMaterialSetRi`
- Build verification:
  - `ninja` succeeds after the change.

## Plausibility rationale
- The new structure is idiomatic original-source C++: straightforward nested checks (`count != 0`, `entry->size != 0`) and a local return pointer.
- No contrived temporaries or compiler-only tricks were introduced; the logic remains readable and semantically equivalent.

## Technical details
- Replaced short-circuit `||` return path with two explicit conditions and a final `return texture;`.
- Kept existing data access pattern (entry material index lookup and `CPtrArray<CMaterial*>` indexing), only changing control-flow shape.
