### PR TITLE
main/pppLensFlare: improve pppFrameLensFlare alpha clamp match

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -152,7 +152,7 @@ void pppFrameLensFlare(void* obj, void* param2, void* param3)
 			*alphaPtr = 0xff;
 		} else {
 			unsigned int scaledAlpha = *alphaPtr * (0xff / totalSamples);
-			if ((scaledAlpha & 0xff) < 0x100) {
+			if (scaledAlpha < 0x100) {
 				*alphaPtr = (unsigned char)scaledAlpha;
 			} else {
 				*alphaPtr = 0xff;


### PR DESCRIPTION
## Summary
- Adjusted the alpha clamp condition in `pppFrameLensFlare` to use the computed 32-bit value directly (`scaledAlpha < 0x100`) instead of masking then comparing.
- This removes a decomp-artifact-style condition and aligns better with the expected overflow clamp pattern for byte alpha conversion.

## Functions improved
- Unit: `main/pppLensFlare`
- Function: `pppFrameLensFlare` (`PAL 0x800de8c4`, size `844b`)

## Match evidence
- `pppFrameLensFlare`: **58.99052% -> 59.203793%** (+0.213273)
- `pppRenderLensFlare`: unchanged at **56.523365%**
- Build verifies successfully (`build/GCCP01/main.dol: OK`).

## Plausibility rationale
- The new condition is a natural C overflow clamp idiom and avoids a masked compare form that is unlikely to be intentional original source.
- Change is minimal and localized to alpha scaling logic, preserving readability and behavior intent.

## Technical details
- Baseline and after diffs were taken with:
  - `tools/objdiff-cli diff -p . -u main/pppLensFlare -o - pppFrameLensFlare`
  - `tools/objdiff-cli diff -p . -u main/pppLensFlare -o - pppRenderLensFlare`
- Only `src/pppLensFlare.cpp` changed.
