### PR TITLE
main/p_FunnyShape: use table symbol in GetTable

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -41,6 +41,7 @@ extern f32 lbl_8032FD28;
 extern f32 lbl_8032FD2C;
 extern CMemory Memory;
 extern CUSBPcs USBPcs;
+extern unsigned char m_table__14CFunnyShapePcs[];
 
 namespace {
 static char s_CFunnyShapePcs[] = "CFunnyShapePcs";
@@ -188,7 +189,7 @@ void CFunnyShapePcs::Quit()
  */
 int CFunnyShapePcs::GetTable(unsigned long index)
 {
-    return static_cast<int>(index) * 0x15c + -0x7fe15858;
+    return reinterpret_cast<int>(m_table__14CFunnyShapePcs + index * 0x15C);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced `CFunnyShapePcs::GetTable` hardcoded address arithmetic with the named table symbol `m_table__14CFunnyShapePcs`.
- Kept behavior identical (`table_base + index * 0x15C`) while restoring relocation-driven source style used across other `p_*::GetTable` implementations.

## Functions improved
- Unit: `main/p_FunnyShape`
- Function: `GetTable__14CFunnyShapePcsFUl` (20 bytes)
  - Before: 64.00%
  - After: 100.00%

## Match evidence
- `main/p_FunnyShape` unit fuzzy match:
  - Before: 60.705585%
  - After: 61.01015%
- Overall progress moved from 1369 matched functions to 1370 matched functions in `ninja` progress output.

## Plausibility rationale
- `GetTable` in nearby process units (`p_system`, `p_game`, `p_sample`) returns a base table symbol plus `index * 0x15C`.
- Using the explicit `m_table__14CFunnyShapePcs` symbol is the plausible original source expression and avoids compiler-coaxing constants.

## Technical details
- Added `extern unsigned char m_table__14CFunnyShapePcs[];` in `src/p_FunnyShape.cpp`.
- Rewrote return to `reinterpret_cast<int>(m_table__14CFunnyShapePcs + index * 0x15C);`.
- Verified with `ninja` rebuild and `build/GCCP01/report.json` function/unit percentage checks.