### PR TITLE
main/pppRandHCV: improve pppRandHCV fuzzy match

### DIFF
--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -17,25 +17,6 @@ typedef struct RandHCVParams {
     u8 pad[3];
 } RandHCVParams;
 
-typedef union DoubleConv {
-    struct {
-        unsigned int hi;
-        unsigned int lo;
-    } parts;
-    double d;
-} DoubleConv;
-
-typedef struct RandHCVConv {
-    DoubleConv d0;
-    DoubleConv c0;
-    DoubleConv d1;
-    DoubleConv c1;
-    DoubleConv d2;
-    DoubleConv c2;
-    DoubleConv d3;
-    DoubleConv c3;
-} RandHCVConv;
-
 /*
  * --INFO--
  * PAL Address: TODO
@@ -104,63 +85,29 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
     }
 
     float scale = *scalePtr;
-    const double bias = lbl_8032FFA0;
-    RandHCVConv conv;
 
     {
-        s16 delta = params->delta[0];
         s16 current = target[0];
-        conv.d0.parts.hi = 0x43300000;
-        conv.d0.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-        conv.c0.parts.hi = 0x43300000;
-        conv.c0.parts.lo = (unsigned int)((int)current ^ 0x8000);
-        double value = conv.d0.d - bias;
-        double baseValue = conv.c0.d - bias;
-        double result = value * (double)scale - baseValue;
-        int add = (int)result;
-        target[0] = (s16)(current + add);
+        s16 base = params->delta[0];
+        target[0] = (s16)(current + (int)((float)base * scale - (float)current));
     }
 
     {
-        s16 delta = params->delta[1];
         s16 current = target[1];
-        conv.d1.parts.hi = 0x43300000;
-        conv.d1.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-        conv.c1.parts.hi = 0x43300000;
-        conv.c1.parts.lo = (unsigned int)((int)current ^ 0x8000);
-        double value = conv.d1.d - bias;
-        double baseValue = conv.c1.d - bias;
-        double result = value * (double)scale - baseValue;
-        int add = (int)result;
-        target[1] = (s16)(current + add);
+        s16 base = params->delta[1];
+        target[1] = (s16)(current + (int)((float)base * scale - (float)current));
     }
 
     {
-        s16 delta = params->delta[2];
         s16 current = target[2];
-        conv.d2.parts.hi = 0x43300000;
-        conv.d2.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-        conv.c2.parts.hi = 0x43300000;
-        conv.c2.parts.lo = (unsigned int)((int)current ^ 0x8000);
-        double value = conv.d2.d - bias;
-        double baseValue = conv.c2.d - bias;
-        double result = value * (double)scale - baseValue;
-        int add = (int)result;
-        target[2] = (s16)(current + add);
+        s16 base = params->delta[2];
+        target[2] = (s16)(current + (int)((float)base * scale - (float)current));
     }
 
     {
-        s16 delta = params->delta[3];
         s16 current = target[3];
-        conv.d3.parts.hi = 0x43300000;
-        conv.d3.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-        conv.c3.parts.hi = 0x43300000;
-        conv.c3.parts.lo = (unsigned int)((int)current ^ 0x8000);
-        double value = conv.d3.d - bias;
-        double baseValue = conv.c3.d - bias;
-        double result = value * (double)scale - baseValue;
-        int add = (int)result;
-        target[3] = (s16)(current + add);
+        s16 base = params->delta[3];
+        target[3] = (s16)(current + (int)((float)base * scale - (float)current));
     }
 }
 


### PR DESCRIPTION
## Summary
- Reworked `pppRandHCV` channel update math to use direct float arithmetic for the per-channel blend/update step.
- Removed the manual double-bit conversion scaffolding (`DoubleConv`/`RandHCVConv`) that was only emulating int-to-float conversion patterns.
- Kept control flow and data access layout intact (same index checks, random factor generation, offset-based target selection).

## Functions improved
- Unit: `main/pppRandHCV`
- Function: `pppRandHCV` (PAL `0x80061f88`, size `524b`)

## Match evidence
- `pppRandHCV` fuzzy match: **72.35114% -> 80.52672%** (`+8.17558`)
- Unit `main/pppRandHCV` fuzzy match: **72.35114% -> 80.52672%**
- Verified by rebuilding and checking `build/GCCP01/report.json`.

## Plausibility rationale
- The updated expression is the direct source-level operation for "interpolate/add channel toward scaled base", and matches patterns already used in nearby `ppp*HCV` routines.
- The previous version used explicit IEEE-double packing helpers that are generally decompiler artifacts rather than likely hand-written original game code.
- Resulting code is simpler and more idiomatic while improving codegen similarity.

## Technical details
- The old implementation used repeated per-channel temporary double conversions and bias subtraction.
- The new implementation computes each channel as:
  - `current + (int)((float)base * scale - (float)current)`
- This keeps signedness and truncation behavior explicit at source level while producing closer assembly.
