### PR TITLE
Improve pppFrameCharaZEnvCtrl match score

### DIFF
--- a/src/pppCharaZEnvCtrl.cpp
+++ b/src/pppCharaZEnvCtrl.cpp
@@ -68,12 +68,16 @@ void pppDesCharaZEnvCtrl(void)
  */
 void pppFrameCharaZEnvCtrl(pppCharaZEnvCtrl* pppCharaZEnvCtrl, UnkB* param_2, UnkC* param_3)
 {
-	if (DAT_8032ed70 == 0) {
-		int dataOffset = *(int*)((char*)param_3 + 0xc);
-		void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
-		int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
-		*(void**)(model + 0xe4) = (void*)((int)(&pppCharaZEnvCtrl->field0_0x0 + 2) + dataOffset);
-		*(UnkB**)(model + 0xe8) = param_2;
-		*(void (**)(CChara::CModel*, void*, void*, int))(model + 0xf4) = CharaZEnvCtrl_BeforeMeshLockEnvCallback;
+	if (DAT_8032ed70 != 0U) {
+		return;
 	}
+
+	::pppCharaZEnvCtrl* self = pppCharaZEnvCtrl;
+	int dataOffset = (int)*(void**)((char*)param_3 + 0xc);
+	void* owner = *(void**)((char*)pppMngStPtr + 0x8);
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(owner, 0);
+	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+	*(void**)(model + 0xe4) = (void*)((char*)self + dataOffset + 0x10);
+	*(UnkB**)(model + 0xe8) = param_2;
+	*(void (**)(CChara::CModel*, void*, void*, int))(model + 0xf4) = CharaZEnvCtrl_BeforeMeshLockEnvCallback;
 }


### PR DESCRIPTION
## Summary
- Refined `pppFrameCharaZEnvCtrl` in `src/pppCharaZEnvCtrl.cpp` to better align generated code with the target object.
- Reworked the early-exit branch and local value flow used to compute the model callback data pointer.
- Kept behavior plausible/original-source style: same function calls and side effects, only tightened pointer/value expression forms.

## Functions Improved
- Unit: `main/pppCharaZEnvCtrl`
- Symbol: `pppFrameCharaZEnvCtrl`
- Before: `55.517242%`
- After: `57.41379%`
- Delta: `+1.896548` percentage points

## Match Evidence
- Measured with:
  - `objdiff-cli diff -p . -u main/pppCharaZEnvCtrl -o <file> --format json-pretty pppFrameCharaZEnvCtrl`
- Improvement is in the function-level `match_percent` value above.
- Function size still reports `124` bytes on the left versus target symbol size `116` bytes, so this is an incremental pass, not a full match.

## Plausibility Rationale
- Changes are source-plausible cleanup/refinement rather than artificial compiler coaxing:
  - explicit early return on global disable flag,
  - explicit owner/handle/model local flow,
  - pointer-offset computation written in a direct, idiomatic form used elsewhere in particle callbacks.
- No debug artifacts, assembly comments, or contrived control-flow tricks were introduced.

## Technical Notes
- The target function remains non-matching in prologue/stack allocation shape, but instruction alignment improved enough to raise score.
- Follow-up work likely needs additional type/layout correction around `UnkC` serialized offset access and surrounding callback data structures.
