### PR TITLE
mapshadow: improve Init__10CMapShadowFv match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -73,7 +73,10 @@ void CMapShadow::Init()
 	u32 uVar7;
 	u32 uVar8;
 	union {
-		u64 u;
+		struct {
+			u32 hi;
+			u32 lo;
+		} parts;
 		double d;
 	} cvt;
 
@@ -83,9 +86,11 @@ void CMapShadow::Init()
 	uVar8 = *(u32*)(iVar6 + 100);
 	uVar7 = *(u32*)(iVar6 + 0x68);
 	*((char*)this + 7) = (char)*(u32*)(iVar6 + 0x6c);
-	cvt.u = 0x4330000000000000ULL | (u64)uVar8;
+	cvt.parts.hi = 0x43300000;
+	cvt.parts.lo = uVar8;
 	fVar1 = (float)(cvt.d - dVar5);
-	cvt.u = 0x4330000000000000ULL | (u64)uVar7;
+	cvt.parts.hi = 0x43300000;
+	cvt.parts.lo = uVar7;
 	fVar2 = (float)(cvt.d - dVar5);
 	fVar3 = *(float*)((char*)this + 0xa8);
 	if (*((char*)this + 6) == 0) {


### PR DESCRIPTION
﻿## Summary
- Updated `CMapShadow::Init` in `src/mapshadow.cpp` to use a high/low word union layout for the integer-to-double conversion sequence.
- Replaced the `u64` OR-based conversion with explicit `0x43300000` high-word + value low-word assignments.

## Functions improved
- Unit: `main/mapshadow`
- Function: `Init__10CMapShadowFv` (236 bytes)

## Match evidence
- `objdiff-cli` oneshot (`tools/objdiff-cli.exe diff -p . -u main/mapshadow -o - Init__10CMapShadowFv`):
  - Before: `30.728813%`
  - After: `34.35593%`
  - Delta: `+3.627117` points
- Project report (`build/GCCP01/report.json`) for `Init__10CMapShadowFv`:
  - Before: `32.25424%`
  - After: `35.881355%`
  - Delta: `+3.627115` points

## Plausibility rationale
- This change matches a common Metrowerks-era source pattern for integer-to-double conversion (`0x43300000` high word + integer low word) used to control exact floating-point codegen.
- The logic and data flow are unchanged; only representation of the same calculation was adjusted.
- The resulting source remains readable and plausible as original developer code, not compiler-only coercion.

## Technical details
- `union { struct { u32 hi; u32 lo; } parts; double d; } cvt;`
- Conversion steps now assign:
  - `cvt.parts.hi = 0x43300000;`
  - `cvt.parts.lo = value;`
- Applied to both width/height conversions in `CMapShadow::Init`.
