### PR TITLE
main/util: implement RenderColorQuad

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -446,12 +446,77 @@ void CUtil::ClearZBufferRect(float x, float y, float width, float height)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80023b4c
+ * PAL Size: 900b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::RenderColorQuad(float, float, float, float, _GXColor)
+void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColor color)
 {
-	// TODO
+    Mtx modelMtx;
+    Mtx cameraMtx;
+    Mtx44 orthoMtx;
+    Mtx44 screenMtx;
+    float indMtx[2][3] = {
+        {0.0f, 0.0f, 0.0f},
+        {0.0f, 0.0f, 0.0f},
+    };
+    GXColor white = {0xFF, 0xFF, 0xFF, 0xFF};
+    float x2 = x + width;
+    float y2 = y + height;
+
+    PSMTXIdentity(modelMtx);
+    GXLoadPosMtxImm(modelMtx, 0);
+    GXSetCurrentMtx(0);
+
+    C_MTXOrtho(orthoMtx, lbl_8032f888, lbl_8032f8a0, lbl_8032f888, lbl_8032f8a4, lbl_8032f888, lbl_8032f88c);
+    GXSetProjection(orthoMtx, GX_ORTHOGRAPHIC);
+
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetNumTexGens(1);
+    GXSetNumChans(1);
+    GXSetNumTevStages(1);
+    GXSetZMode(GX_FALSE, GX_LEQUAL, GX_FALSE);
+    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_SET);
+    _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+    _GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+    GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, 0x7d);
+    GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_SPEC);
+    GXSetTevDirect(GX_TEVSTAGE0);
+    GXSetNumIndStages(0);
+
+    GXSetIndTexMtx(GX_ITM_0, indMtx, 1);
+    GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
+    GXSetIndTexMtx(GX_ITM_2, indMtx, 1);
+
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
+    _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    _GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
+    GXSetNumTexGens(0);
+    GXSetChanAmbColor(GX_COLOR0A0, white);
+    GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_SPEC);
+    GXSetNumChans(1);
+
+    GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT7, 4);
+    GXPosition3f32(x, y, lbl_8032f888);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+    GXPosition3f32(x2, y, lbl_8032f888);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+    GXPosition3f32(x2, y2, lbl_8032f888);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+    GXPosition3f32(x, y2, lbl_8032f888);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+
+    PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
+    PSMTX44Copy(CameraPcs.m_screenMatrix, screenMtx);
+    GXLoadPosMtxImm(cameraMtx, 0);
+    GXSetProjection(screenMtx, GX_PERSPECTIVE);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CUtil::RenderColorQuad` in `src/util.cpp` (previously TODO stub).
- Added PAL metadata block for the function (`0x80023b4c`, `900b`).
- Reconstructed GX setup and immediate-mode quad emission path using existing codebase style and APIs.

## Functions improved
- Unit: `main/util`
- Symbol: `RenderColorQuad__5CUtilFffff8_GXColor`

## Match evidence
- `objdiff-cli` command used:
  - `tools/objdiff-cli diff -p . -u main/util -o - RenderColorQuad__5CUtilFffff8_GXColor`
- Before: `0.44444445%`
- After: `71.524445%`
- Net improvement: `+71.08000055%`

## Plausibility rationale
- The implementation follows the same rendering pipeline style already present in this file (`ClearZBufferRect`, `RenderQuad`, `RenderQuadTex2`).
- Uses idiomatic GX API sequencing for orthographic quad rendering and restores camera/screen matrices at the end, matching surrounding engine patterns.
- Avoids contrived compiler-only coaxing; code is readable and consistent with source intent.

## Technical details
- Added orthographic projection setup and fixed-function GX channel/TEV configuration.
- Emitted a 4-vertex triangle strip with direct position/color writes.
- Preserved matrix restoration back to camera perspective projection after draw.
- Verified with full `ninja` build in PAL (`GCCP01`) after change.
