### PR TITLE
main/mes: implement Next/GetWait/useFlag for match gains

### DIFF
--- a/include/ffcc/mes.h
+++ b/include/ffcc/mes.h
@@ -23,11 +23,11 @@ public:
     void addString(char**, int);
     void GET_2(char**);
     void GET_1(char**);
-    void GetWait();
+    int GetWait();
     void Calc();
     void Draw();
     void SetPosition(float, float);
-    void useFlag(int, int);
+    int useFlag(int, int);
     void addFlag(class CFlag&);
     void MakeAgbString(char*, char*, int, int);
     void drawTagString(CFont*, char*, int, int, int);


### PR DESCRIPTION
## Summary
- Implemented `CMes::Next`, `CMes::GetWait`, and `CMes::useFlag` in `src/mes.cpp` using control flow and state updates consistent with the PAL Ghidra references.
- Updated `include/ffcc/mes.h` signatures for `GetWait` and `useFlag` from `void` to `int` to match observed function behavior.
- Updated function documentation blocks to the required PAL/EN/JP address-size format for edited functions.

## Functions improved
- Unit: `main/mes`
- `GetWait__4CMesFv`: `12.5% -> 100.0%`
- `useFlag__4CMesFii`: `2.0833% -> 52.0833%`
- `Next__4CMesFv`: `0.7519% -> 55.5188%`

## Match evidence
- Unit fuzzy match (`main/mes`): `3.2709577% -> 6.53124%`
- Matched functions in unit: `2/12 -> 3/12`
- Matched code bytes in unit: `72/12740 -> 104/12740`
- Global progress changed from `1370/4733` to `1371/4733` matched functions.

## Plausibility rationale
- Changes are semantic implementations of existing TODO stubs, not compiler-only reshaping.
- Logic follows expected message-flag processing behavior: advancing flag operations, restoring temporary flag state around string reparse, and returning wait/flag status values.
- The code uses existing project style (direct offset-based state access already present in this file), minimizing artificial constructs.

## Technical details
- `Next` now applies pending flag operations, reinitializes parsing state, reruns `addString`, and performs per-run alignment adjustment over generated glyph entries.
- `GetWait` now returns active wait-state when wait counter has not reached its bound.
- `useFlag` now iterates pending flag commands and returns early on unmet conditional flags (`type < 5`) when requested.
