### PR TITLE
main/pppRyjMegaBirth: implement pppRyjMegaBirth allocation/frame path

### DIFF
--- a/include/ffcc/pppRyjMegaBirth.h
+++ b/include/ffcc/pppRyjMegaBirth.h
@@ -15,6 +15,12 @@ struct VRyjMegaBirth
     Vec m_accelerationAxis;
 };
 
+struct PRyjMegaBirthOffsets
+{
+    u8 _pad0[0xC];
+    s32* m_serializedDataOffsets;
+};
+
 void get_rand(void);
 void get_noise(unsigned char);
 void alloc_check(VRyjMegaBirth*, PRyjMegaBirth*);
@@ -28,7 +34,7 @@ void set_matrix(_pppPObject*, pppFMATRIX&, PRyjMegaBirth*, VRyjMegaBirth*, _PART
 extern "C" {
 #endif
 
-void pppRyjMegaBirth(void);
+void pppRyjMegaBirth(_pppPObject*, PRyjMegaBirth*, PRyjMegaBirthOffsets*);
 void pppRyjDrawMegaBirth(void);
 void pppRyjMegaBirthCon(void);
 void pppRyjMegaBirthDes(void);

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -1,4 +1,9 @@
 #include "ffcc/pppRyjMegaBirth.h"
+#include <string.h>
+
+extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+
+static char s_pppRyjMegaBirth_cpp[] = "pppRyjMegaBirth.cpp";
 
 /*
  * --INFO--
@@ -69,9 +74,93 @@ void calc_particle(_pppPObject*, VRyjMegaBirth*, PRyjMegaBirth*, VColor*)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRyjMegaBirth(void)
+void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMegaBirthOffsets* offsets)
 {
-	// Main particle system entry point
+	bool hasRequiredMemory;
+	u8* payload = (u8*)particleData;
+	s32 colorOffset = offsets->m_serializedDataOffsets[1];
+	VRyjMegaBirth* work =
+		(VRyjMegaBirth*)((u8*)pObject + 8 + offsets->m_serializedDataOffsets[2]);
+
+	if (work->m_particleBlock == 0)
+	{
+		work->m_numParticles = *(u16*)(payload + 0xC);
+
+		work->m_particleBlock = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+			work->m_numParticles * 0x60, pppEnvStPtr->m_stagePtr, s_pppRyjMegaBirth_cpp, 0x262);
+		if (work->m_particleBlock != 0)
+		{
+			memset(work->m_particleBlock, 0, work->m_numParticles * 0x60);
+		}
+
+		if ((payload[0xD8] == 1) || (payload[0xD8] == 2))
+		{
+			work->m_worldMatrixBlock = (PARTICLE_WMAT*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+				work->m_numParticles * 0x30, pppEnvStPtr->m_stagePtr, s_pppRyjMegaBirth_cpp, 0x269);
+			if (work->m_worldMatrixBlock != 0)
+			{
+				memset(work->m_worldMatrixBlock, 0, work->m_numParticles * 0x30);
+			}
+		}
+
+		if (payload[0xD5] != 0)
+		{
+			work->m_colorBlock = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+				work->m_numParticles << 5, pppEnvStPtr->m_stagePtr, s_pppRyjMegaBirth_cpp, 0x271);
+			if (work->m_colorBlock != 0)
+			{
+				memset(work->m_colorBlock, 0, work->m_numParticles << 5);
+			}
+		}
+
+		work->m_accelerationAxis.x = *(float*)(payload + 0x9C);
+		work->m_accelerationAxis.y = *(float*)(payload + 0xA0);
+		work->m_accelerationAxis.z = *(float*)(payload + 0xA4);
+		PSVECNormalize(&work->m_accelerationAxis, &work->m_accelerationAxis);
+	}
+
+	if (work->m_particleBlock == 0)
+	{
+		hasRequiredMemory = false;
+	}
+	else if (((payload[0xD8] == 1) || (payload[0xD8] == 2)) && (work->m_worldMatrixBlock == 0))
+	{
+		hasRequiredMemory = false;
+	}
+	else if ((payload[0xD5] == 0) || (work->m_colorBlock != 0))
+	{
+		hasRequiredMemory = true;
+	}
+	else
+	{
+		hasRequiredMemory = false;
+	}
+
+	if (hasRequiredMemory)
+	{
+		switch (payload[0x16])
+		{
+		default:
+			PSMTXCopy(pppMngStPtr->m_matrix.value, work->m_worldMatrix);
+			break;
+		case 1:
+		case 3:
+		case 5:
+		case 7:
+		case 9:
+			PSMTXIdentity(work->m_worldMatrix);
+			work->m_worldMatrix[0][0] = pppMngStPtr->m_scale.x;
+			work->m_worldMatrix[1][1] = pppMngStPtr->m_scale.y;
+			work->m_worldMatrix[2][2] = pppMngStPtr->m_scale.z;
+			work->m_worldMatrix[0][3] = pppMngStPtr->m_position.x;
+			work->m_worldMatrix[1][3] = pppMngStPtr->m_position.y;
+			work->m_worldMatrix[2][3] = pppMngStPtr->m_position.z;
+			break;
+		}
+
+		calc_particle(
+			pObject, work, particleData, (VColor*)((u8*)pObject + 8 + colorOffset));
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented pppRyjMegaBirth in src/pppRyjMegaBirth.cpp using the current Ghidra flow as a source-level reconstruction.
- Added explicit operation offsets struct and corrected function signature in include/ffcc/pppRyjMegaBirth.h to the (object, step, offsets) form.
- Reconstructed the function's core behavior:
  - lazy allocation/zero-init of particle, world-matrix, and optional color blocks
  - acceleration axis load + normalize
  - allocation-success gating logic
  - world matrix setup branch (PSMTXCopy vs identity+scale+translation)
  - call into calc_particle

## Functions Improved
- Unit: main/pppRyjMegaBirth
- Function: pppRyjMegaBirth (636 bytes)

## Match Evidence
Using objdiff-cli report generate + objdiff-cli report changes:
- main/pppRyjMegaBirth fuzzy match: **0.19890602% -> 6.8115363%**
- pppRyjMegaBirth fuzzy match: **0.6289308% -> 84.26415%**
- Global fuzzy match: **24.01669% -> 24.04536%**

## Plausibility Rationale
- The changes are type/flow-accurate reconstruction work, not compiler-coaxing.
- Control flow, allocation guards, matrix-mode switch cases, and data access patterns align with established ppp* runtime conventions in this codebase.
- Added only minimal structural typing needed to represent serialized offset access used by this unit.

## Technical Notes
- Build validation: 
inja succeeds after changes.
- This PR intentionally focuses on one operation function (pppRyjMegaBirth) to create a clean, measurable increment before tackling the remaining stubs (calc_particle, calc, irth, draw/con/des).