### PR TITLE
pppBlurChara: improve pppRenderBlurChara render-depth matching

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -340,9 +340,6 @@ void pppRenderBlurChara(pppBlurChara* blurChara, UnkB* param_2, UnkC* param_3)
                                                                pppEnvStPtr->m_materialSetPtr, textureIndex);
     } else {
         unsigned int div = *((unsigned char*)&param_2->m_dataValIndex + 2);
-        if (div == 0) {
-            div = 1;
-        }
         Graphic.CreateSmallBackTexture(DAT_80238030, &smallBackTex, 0x140 / div, 0xE0 / div, GX_NEAR, GX_TF_I8, 0);
     }
 
@@ -431,7 +428,7 @@ void pppRenderBlurChara(pppBlurChara* blurChara, UnkB* param_2, UnkC* param_3)
     PSMTX44Copy(CameraPcs.m_screenMatrix, screenMtx);
     inVec.x = FLOAT_80331030;
     inVec.y = FLOAT_80331030;
-    inVec.z = -param_2->m_stepValue;
+    inVec.z = -(PSVECDistance(&cameraPos, &objPos) - param_2->m_stepValue);
     inVec.w = FLOAT_8033103c;
     MTX44MultVec4__5CMathFPA4_fP5Vec4dP5Vec4d(0, screenMtx, &inVec, &outVec);
 


### PR DESCRIPTION
## Summary
- Updated `pppRenderBlurChara` in `src/pppBlurChara.cpp` to follow the original depth path more closely.
- Reintroduced the camera/object distance term into the projected depth vector (`inVec.z`), instead of using only `m_stepValue`.
- Removed a defensive `div == 0` guard in the small-back-texture path to better reflect release-style source behavior.

## Functions improved
- Unit: `main/pppBlurChara`
- Function: `pppRenderBlurChara`

## Match evidence
- `pppRenderBlurChara`: **69.19178% -> 70.0685%** (+0.87672)
- `main/pppBlurChara` unit fuzzy match: **71.31314% -> 71.72552%** (+0.41238)
- Build/regeneration completed successfully with `ninja`.

## Plausibility rationale
- The change restores a straightforward geometric depth computation (distance minus step offset) that is consistent with the surrounding camera-space math and with the decompilation structure.
- No artificial temporaries or contrived ordering were introduced; the edit keeps behavior-oriented, readable source.

## Technical details
- Before: `inVec.z = -param_2->m_stepValue;`
- After: `inVec.z = -(PSVECDistance(&cameraPos, &objPos) - param_2->m_stepValue);`
- This aligns projected quad depth with world-space camera/object separation before screen-space transform and improved function-level fuzzy alignment.
