### PR TITLE
pppSRandFV: align control flow and data layout for better match

### DIFF
--- a/src/pppSRandFV.cpp
+++ b/src/pppSRandFV.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppSRandFV.h"
 #include "ffcc/math.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern float lbl_80330098;
 extern float lbl_801EADC8[];
@@ -36,77 +36,78 @@ void randf(unsigned char)
  * JP Address: TODO
  * JP Size: TODO
  */
+struct PppSRandFVParam2 {
+    int field0;
+    int field4;
+    float field8;
+    float fieldC;
+    float field10;
+    unsigned char _pad14[0x18 - 0x14];
+    unsigned char field18;
+};
+
+struct PppSRandFVParam3 {
+    unsigned char _pad0[0xC];
+    int* fieldC;
+};
+
 void pppSRandFV(void* param1, void* param2, void* param3)
 {
-    struct Param {
-        int index;
-        int offset;
-        float x;
-        float y;
-        float z;
-        unsigned char _pad[4];
-        unsigned char blendTwice;
-    };
-    struct SelectInfo {
-        int _pad0;
-        int _pad1;
-        int _pad2;
-        int* offsetPtr;
-    };
-    unsigned char* self = reinterpret_cast<unsigned char*>(param1);
-    Param* cfg = reinterpret_cast<Param*>(param2);
-    SelectInfo* sel = reinterpret_cast<SelectInfo*>(param3);
-    float* randVec;
-
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    if (*reinterpret_cast<int*>(self + 0xC) == 0) {
-        randVec = reinterpret_cast<float*>(self + *sel->offsetPtr + 0x80);
-        unsigned char blendTwice = cfg->blendTwice;
-        float value;
+    unsigned char* base = (unsigned char*)param1;
+    PppSRandFVParam2* in = (PppSRandFVParam2*)param2;
+    PppSRandFVParam3* out = (PppSRandFVParam3*)param3;
+    float* valuePtr;
 
-        value = RandF__5CMathFv(&math);
+    int state = *(int*)(base + 0xC);
+    if (state == 0) {
+        unsigned char blendTwice = in->field18;
+        valuePtr = (float*)(base + *out->fieldC + 0x80);
+
+        float value = RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
             value = value * lbl_80330098;
         }
-        randVec[0] = value;
+        valuePtr[0] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
             value = value * lbl_80330098;
         }
-        randVec[1] = value;
+        valuePtr[1] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
             value = value * lbl_80330098;
         }
-        randVec[2] = value;
-        return;
-    }
-
-    if (cfg->index != *reinterpret_cast<int*>(self + 0xC)) {
-        return;
-    }
-
-    randVec = reinterpret_cast<float*>(self + *sel->offsetPtr + 0x80);
-    float* targetVec;
-
-    if (cfg->offset == -1) {
-        targetVec = lbl_801EADC8;
+        valuePtr[2] = value;
     } else {
-        targetVec = reinterpret_cast<float*>(self + cfg->offset + 0x80);
+        if (in->field0 != state) {
+            return;
+        }
+        valuePtr = (float*)(base + *out->fieldC + 0x80);
     }
 
-    targetVec[0] += cfg->x * randVec[0] - cfg->x;
-    targetVec[1] += cfg->y * randVec[1] - cfg->y;
-    targetVec[2] += cfg->z * randVec[2] - cfg->z;
+    float* target;
+    if (in->field4 == -1) {
+        target = lbl_801EADC8;
+    } else {
+        target = (float*)(base + in->field4 + 0x80);
+    }
+
+    float value = in->field8 * valuePtr[0] - in->field8;
+    target[0] = target[0] + value;
+    value = in->fieldC * valuePtr[1] - in->fieldC;
+    target[1] = target[1] + value;
+    value = in->field10 * valuePtr[2] - in->field10;
+    target[2] = target[2] + value;
 }


### PR DESCRIPTION
## Summary
- Refactored pppSRandFV to follow the same source-plausible control-flow structure used by neighboring pppRand*/pppSRand* implementations.
- Replaced ad-hoc local structs with explicit parameter structs (PppSRandFVParam2, PppSRandFVParam3) and normalized field-based access.
- Switched math declaration/call style to CMath math[] and RandF__5CMathFv(math) to match expected ABI/codegen shape.
- Kept random generation semantics intact while expressing tail updates through explicit temporaries for stable codegen.

## Functions Improved
- Unit: main/pppSRandFV
- Function: pppSRandFV

## Match Evidence
- Before: 76.3% (from 	ools/agent_select_target.py output for main/pppSRandFV)
- After: 91.954544% (from uild/GCCP01/report.json after 
inja)
- Absolute gain: +15.654544%

## Plausibility Rationale
- The new layout mirrors existing decompiled patterns in adjacent modules (pppRandFV, pppSRandUpFV, pppSRandDownFV) rather than introducing compiler-coaxing-only constructs.
- Changes are type/flow normalization and field semantics cleanup, consistent with likely original source organization.

## Technical Notes
- Build/verification command: 
inja
- Verified function score directly from uild/GCCP01/report.json for main/pppSRandFV.