### PR TITLE
pppVertexAp: align spawn loop decrement control flow

### DIFF
--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -124,7 +124,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
         u8 count = data->spawnCount;
 
         if (data->mode == 0) {
-            while (count != 0) {
+            do {
                 if (state->index >= (u16)entry->maxValue) {
                     state->index = 0;
                 }
@@ -158,10 +158,9 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     }
                 }
 
-                count--;
-            }
+            } while (--count != 0);
         } else if (data->mode == 1) {
-            while (count != 0) {
+            do {
                 u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
                 Vec vtx = points[vertexIndex];
 
@@ -189,8 +188,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     }
                 }
 
-                count--;
-            }
+            } while (--count != 0);
         }
 
         state->countdown = data->spawnDelay;


### PR DESCRIPTION
## Summary
- Updated `pppVertexAp` spawn loops in `src/pppVertexAp.cpp` to use post-decrement `u8` loop control (`do { ... } while (--count != 0)`) for both mode paths.
- Kept behavior and data flow intact otherwise; no layout or API changes.

## Functions improved
- Unit: `main/pppVertexAp`
- Symbol: `pppVertexAp`

## Match evidence
- `pppVertexAp` match: **61.737114% -> 61.958763%** (`+0.221649`)
- Instruction-level diff entries: **139 -> 138**
- Measured with:
  - `tools/objdiff-cli diff -p . -u main/pppVertexAp -o - pppVertexAp`

## Plausibility rationale
- Post-decrement loop style is already used in neighboring particle code and is a plausible original-source pattern for small spawn counters.
- Change is source-natural (control-flow style only), not compiler-coaxing through unnatural temporaries or opaque reordering.

## Technical details
- The previous `while (count != 0) { ... count--; }` shape was replaced with `do/while (--count != 0)` in both mode branches.
- This better aligns branch/back-edge shape and low-byte countdown handling in generated assembly.
