### PR TITLE
pppLensFlare: improve construct function match via work-pointer addressing

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -35,22 +35,22 @@ extern "C" void GXPeekZ(unsigned short, unsigned short, unsigned int*);
 void pppConstructLensFlare(void* obj, void* param)
 {
 	void* dataPtr = *((void**)((char*)param + 0x0c));
-	int offset = *((int*)((char*)dataPtr + 0x08));
+	char* work = (char*)obj + *((int*)((char*)dataPtr + 0x08)) + 0x80;
 
 	float initValue = FLOAT_80331060;
 
-	*((float*)((char*)obj + offset + 0x98)) = FLOAT_80331060;
-	*((float*)((char*)obj + offset + 0x94)) = initValue;
-	*((float*)((char*)obj + offset + 0x90)) = initValue;
-	*((float*)((char*)obj + offset + 0xa8)) = initValue;
-	*((float*)((char*)obj + offset + 0xa4)) = initValue;
-	*((float*)((char*)obj + offset + 0xa0)) = initValue;
+	*((float*)(work + 0x18)) = initValue;
+	*((float*)(work + 0x14)) = initValue;
+	*((float*)(work + 0x10)) = initValue;
+	*((float*)(work + 0x28)) = initValue;
+	*((float*)(work + 0x24)) = initValue;
+	*((float*)(work + 0x20)) = initValue;
 
-	*((short*)((char*)obj + offset + 0xb0)) = 0;
-	*((short*)((char*)obj + offset + 0xae)) = 0;
-	*((short*)((char*)obj + offset + 0xac)) = 0;
-	*((char*)obj + offset + 0xb2) = 0;
-	*((float*)((char*)obj + offset + 0xb4)) = initValue;
+	*((short*)(work + 0x30)) = 0;
+	*((short*)(work + 0x2e)) = 0;
+	*((short*)(work + 0x2c)) = 0;
+	*(work + 0x32) = 0;
+	*((float*)(work + 0x34)) = initValue;
 }
 
 /*


### PR DESCRIPTION
## Summary
- refactored `pppConstructLensFlare` to compute a single `work` pointer (`obj + offset + 0x80`)
- rewrote field writes using compact offsets from `work` instead of repeated large absolute offsets
- kept behavior unchanged (same initialized fields and values)

## Functions improved
- Unit: `main/pppLensFlare`
- Symbol: `pppConstructLensFlare`

## Match evidence
- `pppConstructLensFlare` improved from ~90% (selector reported 90.5%, local objdiff baseline 90.22%) to 100.0% in `build/GCCP01/report.json`
- Project progress increased from 1371 to 1372 matched functions after rebuild

## Plausibility rationale
- This rewrite reflects normal original-source style: compute a local work-structure pointer once, then initialize adjacent fields via relative offsets.
- No coercive compiler hacks were used; this is a readability and structure improvement consistent with surrounding particle/ppp code.

## Technical details
- objdiff previously showed instruction-form differences around pointer setup (`add`/offset form).
- After the rewrite, emitted stores align with the target offset pattern from the computed work pointer, producing near/complete function alignment.
