### PR TITLE
pppYmMelt: implement first-pass pppRenderYmMelt

### DIFF
--- a/include/ffcc/pppYmMelt.h
+++ b/include/ffcc/pppYmMelt.h
@@ -45,7 +45,7 @@ extern "C" {
 void pppConstructYmMelt(PYmMelt*, PYmMeltDataOffsets*);
 void pppDestructYmMelt(PYmMelt*, PYmMeltDataOffsets*);
 void pppFrameYmMelt(PYmMelt*, YmMeltCtrl*, PYmMeltDataOffsets*);
-void pppRenderYmMelt(void);
+void pppRenderYmMelt(PYmMelt*, YmMeltCtrl*, PYmMeltDataOffsets*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Implemented a first-pass decomp of `pppRenderYmMelt` in `src/pppYmMelt.cpp` using existing project rendering patterns (draw env setup, blend mode, shape texture fetch, GX state setup, UV sampling, and quad emission across the melt grid).
- Updated the function prototype to include the expected runtime arguments:
  - `include/ffcc/pppYmMelt.h`
  - `src/pppYmMelt.cpp`
- Added PAL address/size documentation for `pppRenderYmMelt`.

## Functions improved
- Unit: `main/pppYmMelt`
- Function: `pppRenderYmMelt` (`1716b`)

## Match evidence
- `pppRenderYmMelt`: **0.2% -> 43.519814%** fuzzy match
- Unit `main/pppYmMelt` fuzzy match: **26.4% -> 50.052296%**
- Build verification: `ninja` succeeds and report regenerates.

## Plausibility rationale
- The implementation follows the same renderer structure already used in neighboring PPP YM effects (`pppYmTracer`/`pppYmTracer2`):
  - `pppSetDrawEnv` / `pppSetBlendMode`
  - shape texture resolution from PPP shape data
  - standard GX descriptor + TEV setup
  - per-cell quad submission with UV interpolation
- Changes are source-oriented (control/data flow and typing/prototype alignment), not artificial reordering for score-only gains.

## Technical details
- Reused existing runtime data layout already implied by `pppFrameYmMelt` (`YmMeltWork` at serialized offset + `0x80`, vertex payload at `+0x88+colorOffset`).
- Implemented palette path handling for texture formats `8/9` via `SetUpPaletteEnv` and teardown via `_GXSetTevSwapMode`.
- Preserved melt phase deformation behavior by blending X/Z toward current manager matrix translation when phase is active.
