### PR TITLE
main/pppPart: implement pppCreatePObject first-pass

### DIFF
--- a/include/ffcc/pppPart.h
+++ b/include/ffcc/pppPart.h
@@ -57,7 +57,7 @@ unsigned long pppMngStHeapCheckLeak(CMemory::CStage* stage);
 void pppMngStHeapCheck(CMemory::CStage* stage);
 void callCon2Prog(_pppPObject*);
 void callConProg(_pppPObject*);
-void pppCreatePObject(_pppMngSt*, _pppPDataVal*);
+_pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
 void pppDeletePObject(_pppPObject*);
 void _pppAllFreePObject(_pppMngSt*);
 void pppSetBindChrSync(_pppMngSt*);


### PR DESCRIPTION
## Summary
- Implemented `pppCreatePObject__FP9_pppMngStP12_pppPDataVal` in `src/pppPart.cpp` (previously a TODO stub).
- Added local raw layout structs for `_pppPDataVal`, program-set entries, and manager-slot scanning to match observed PAL behavior while avoiding broad header churn.
- Aligned the function declaration in `include/ffcc/pppPart.h` to return `_pppPObject*`, matching existing call sites.

## Functions Improved
- Unit: `main/pppPart`
- Symbol: `pppCreatePObject__FP9_pppMngStP12_pppPDataVal`

## Match Evidence
- Before: `0.4%` (from `tools/agent_select_target.py` output on this unit/symbol)
- After: `34.039288%` (`objdiff-cli diff -p . -u main/pppPart -o - pppCreatePObject__FP9_pppMngStP12_pppPDataVal`)
- Improvement is from real code generation movement (function transitioned from stub to full control-flow and constructor/destructor path logic).

## Plausibility Rationale
- Behavior now follows expected particle-object lifecycle semantics:
  - staged allocation with pressure fallback
  - reclaiming eligible objects from other active managers by priority
  - sorted insertion by program sort key
  - per-stage init work setup and constructor/destructor callbacks
- Changes are source-plausible for original game code (types, linked-list handling, allocator usage), not just synthetic instruction coaxing.

## Technical Details
- Uses `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii` with the same allocation-site string/line conventions already used in this source.
- Preserves diagnostic/failure behavior through `heapWalker`, `pppDumpMngSt`, and `lbl_8032ED85` flag toggling.
- Keeps raw offset-based handling scoped to this function, minimizing cross-file ABI risk while improving emitted assembly.
