### PR TITLE
pppRain: mask serialized drop count in pppFrameRain

### DIFF
--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -182,7 +182,7 @@ void pppFrameRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_DA
     }
 
     rain = (RainParam*)param_2;
-    count = *(u16*)&param_2->payload[0];
+    count = *(u16*)&param_2->payload[0] & 0x7fff;
     work = (RainWork*)((u8*)pppRain + 0x80 + param_3->m_serializedDataOffsets[2]);
     if (work->drops == 0) {
         work->drops = (float*)pppMemAlloc__FUlPQ27CMemory6CStagePci(


### PR DESCRIPTION
## Summary
- Mask the serialized drop count to 15 bits in `pppFrameRain`.
- Change: `count = *(u16*)&param_2->payload[0];` -> `count = *(u16*)&param_2->payload[0] & 0x7fff;`

## Functions improved
- Unit: `main/pppRain`
- Symbol: `pppFrameRain`

## Match evidence
- `pppFrameRain`: **61.093285% -> 62.384327%** (+1.291042)
- `pppRenderRain`: 70.45255% (unchanged)
- `pppConstructRain`: 100.0% (unchanged)
- `pppDestructRain`: 100.0% (unchanged)

Instruction-level signal from objdiff for `pppFrameRain`:
- Exact matches (`null` diff kind): 49 -> 76
- `DIFF_ARG_MISMATCH`: 140 -> 114
- `DIFF_DELETE`: 54 -> 52
- `DIFF_INSERT`: 30 -> 29
- `DIFF_OP_MISMATCH`: 4 -> 3

## Plausibility rationale
- This unit already treats the leading 16-bit rain count as packed serialized data.
- Using `& 0x7fff` is a plausible original-source interpretation for a count field with a reserved high bit, and it aligns generated code more closely without introducing contrived temporaries or control-flow artifacts.

## Technical notes
- Build/verify steps run:
  - `python3 configure.py --version GCCP01` (in clean worktree)
  - `ninja`
  - `tools/objdiff-cli diff -p . -u main/pppRain -o - pppFrameRain`
