### PR TITLE
gx: match GXSetCurrentMtx matrix index update

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -358,8 +358,8 @@ void GXLoadNrmMtxIndx3x3(u16 mtx_indx, u32 id) {
 
 void GXSetCurrentMtx(u32 id) {
     CHECK_GXBEGIN(708, "GXSetCurrentMtx");
-    SET_REG_FIELD(712, __GXData->matIdxA, 6, 0, id);
-    __GXSetMatrixIndex(GX_VA_PNMTXIDX);
+    __GXData->matIdxA = (__GXData->matIdxA & 0xFFFFFFC0) | id;
+    __GXSetMatrixIndex(0);
 }
 
 void GXLoadTexMtxImm(const f32 mtx[][4], u32 id, GXTexMtxType type) {


### PR DESCRIPTION
## Summary
- Updated `GXSetCurrentMtx` in `src/gx/GXTransform.c` to use direct 6-bit mask/write on `matIdxA`.
- Switched matrix-index update call to `__GXSetMatrixIndex(0)` to match the original SDK-style callsite encoding.

## Functions improved
- Unit: `main/gx/GXTransform`
- Function: `GXSetCurrentMtx`

## Match evidence
- `GXSetCurrentMtx`: **70.0% -> 100.0%** (size 56b unchanged)
- Unit `main/gx/GXTransform`:
  - fuzzy match: **82.35976 -> 83.21342**
  - matched code: **548 -> 604** bytes
  - matched functions: **6/15 -> 7/15**

Measured with:
- baseline: `_tmp_report_before_gxtransform_current.json`
- after: `_tmp_report_after_gxtransform_current.json`
- delta: `_tmp_changes_gxtransform_current.json`

## Plausibility rationale
- This change replaces macro-based field writing with explicit bit-masking that reflects the hardware register layout for the current matrix index.
- Calling `__GXSetMatrixIndex(0)` directly aligns with known SDK control flow for PN matrix index updates and avoids compiler artifacts from enum-valued constants.

## Technical details
- Old code used `SET_REG_FIELD(..., 6, 0, id)` and `GX_VA_PNMTXIDX`.
- New code emits the equivalent but more direct expression:
  - `__GXData->matIdxA = (__GXData->matIdxA & 0xFFFFFFC0) | id;`
  - `__GXSetMatrixIndex(0);`