### PR TITLE
pppAlignmentScale: improve pppFrameAlignmentScale match via compare form

### DIFF
--- a/src/pppAlignmentScale.cpp
+++ b/src/pppAlignmentScale.cpp
@@ -66,7 +66,7 @@ struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* align
         distance = (double)PSVECDistance(&cameraPos, &objPos);
         distanceScale = (float)(distance / (double)data->m_unk0x4);
         scale = FLOAT_80331920;
-        if (FLOAT_80331920 < distanceScale) {
+        if (distanceScale > FLOAT_80331920) {
             scale = (distanceScale - FLOAT_80331920) * data->m_unk0x8 + FLOAT_80331920;
         }
 


### PR DESCRIPTION
Summary
- Rewrote one equivalent comparison in `pppFrameAlignmentScale` from `FLOAT_80331920 < distanceScale` to `distanceScale > FLOAT_80331920`.
- No behavior change; this is a control-flow/codegen-shape adjustment only.

Functions improved
- Unit: `main/pppAlignmentScale`
- Function: `pppFrameAlignmentScale`
- Fuzzy match: `83.76057 -> 83.901405` (+0.140835)
- Unit fuzzy match: `83.986115 -> 84.125`

Match evidence
- `tools/objdiff-cli report changes _tmp_report_before_osreset.json _tmp_report_after_pppAlignmentScale_final.json`
- Relevant entry shows only `pppFrameAlignmentScale` improvement in this unit.

Plausibility rationale
- The change is source-plausible and idiomatic C/C++ (`a > b` vs `b < a`), with equivalent semantics.
- It avoids contrived temporaries or unnatural sequencing and preserves readability.

Technical details
- This target had branch-shape mismatches around the compare block; the equivalent compare form improves emitted branch pattern without introducing non-original-looking code.