### PR TITLE
graphic: fix Render*QuadGrouad Vec ABI signatures

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -74,8 +74,8 @@ public:
     void GetBackBufferRect(int&, int&, int&, int&, int);
     void GetBackBufferRect2(void*, _GXTexObj*, int, int, int, int, int, _GXTexFilter, _GXTexFmt, int);
 
-    void RenderTexQuadGrouad(Vec&, Vec&, _GXColor, _GXColor, _GXColor, _GXColor);
-    void RenderNoTexQuadGrouad(Vec&, Vec&, _GXColor, _GXColor, _GXColor, _GXColor);
+    void RenderTexQuadGrouad(Vec, Vec, _GXColor, _GXColor, _GXColor, _GXColor);
+    void RenderNoTexQuadGrouad(Vec, Vec, _GXColor, _GXColor, _GXColor, _GXColor);
 
     void RenderDOF(char, char, float, float, Vec&, int);
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -421,7 +421,7 @@ void CGraphic::GetBackBufferRect2(void*, _GXTexObj*, int, int, int, int, int, _G
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGraphic::RenderTexQuadGrouad(Vec& pos1, Vec& pos2, _GXColor color1, _GXColor color2, _GXColor color3, _GXColor color4)
+void CGraphic::RenderTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor color2, _GXColor color3, _GXColor color4)
 {
 	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
 	
@@ -455,7 +455,7 @@ void CGraphic::RenderTexQuadGrouad(Vec& pos1, Vec& pos2, _GXColor color1, _GXCol
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGraphic::RenderNoTexQuadGrouad(Vec& pos1, Vec& pos2, _GXColor color1, _GXColor color2, _GXColor color3, _GXColor color4)
+void CGraphic::RenderNoTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor color2, _GXColor color3, _GXColor color4)
 {
 	GXBegin(GX_QUADS, GX_VTXFMT6, 4);
 	


### PR DESCRIPTION
## Summary
- Fix `CGraphic::RenderTexQuadGrouad` and `CGraphic::RenderNoTexQuadGrouad` parameter ABI from `Vec&` to `Vec` in declarations and definitions.
- This corrects mangled symbol names from `...FR3VecR3Vec...` (reference) to `...F3Vec3Vec...` (by value), which matches PAL symbols.
- No control-flow or rendering logic changed.

## Functions improved
- `RenderNoTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor`
- `RenderTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor`

## Match evidence
- Before: both functions were reported at `0.0%` in target selection output and compiled under the wrong symbols (`FR3VecR3Vec`).
- After (`objdiff-cli v3.6.1`):
  - `RenderNoTexQuadGrouad...`: `48.555557%`
  - `RenderTexQuadGrouad...`: `43.581818%`
- Verification command used:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/graphic -o /tmp/graphic_after_no_tex.json --format json RenderNoTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor`
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/graphic -o /tmp/graphic_after_tex.json --format json RenderTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor`

## Plausibility rationale
- Passing small POD vectors by value for immediate GX FIFO emission is plausible original source style.
- The change aligns with recovered Metrowerks symbol signatures rather than introducing compiler coaxing.

## Technical details
- Header update: `include/ffcc/graphic.h`
- Definition update: `src/graphic.cpp`
- Symbol check moved from:
  - `Render*__8CGraphicFR3VecR3Vec...`
- To:
  - `Render*__8CGraphicF3Vec3Vec...`
