### PR TITLE
main/mapshadow: improve Init matching via conversion sequencing

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -89,7 +89,6 @@ void CMapShadow::Init()
 	cvt.parts.hi = 0x43300000;
 	cvt.parts.lo = uVar8;
 	fVar1 = (float)(cvt.d - dVar5);
-	cvt.parts.hi = 0x43300000;
 	cvt.parts.lo = uVar7;
 	fVar2 = (float)(cvt.d - dVar5);
 	fVar3 = *(float*)((char*)this + 0xa8);


### PR DESCRIPTION
## Summary
- Adjusted CMapShadow::Init() in src/mapshadow.cpp to tighten the integer-to-double conversion sequence used for map-shadow projection parameters.
- Removed a redundant reinitialization of the conversion union high word before the second conversion, while preserving behavior.

## Functions improved
- Unit: main/mapshadow
- Function: Init__10CMapShadowFv (CMapShadow::Init())

## Match evidence
- Init__10CMapShadowFv: **35.881355% -> 39.77966%** (+3.898305)
- main/mapshadow unit fuzzy match: **70.24599% -> 71.47594%** (+1.22995)
- Evidence generated with:
  - uild/tools/objdiff-cli report generate -p . -f json-pretty -o _tmp_report_before_mapshadow_agent.json
  - uild/tools/objdiff-cli report generate -p . -f json-pretty -o _tmp_report_after_mapshadow_try1_agent.json
  - uild/tools/objdiff-cli report changes -f json-pretty _tmp_report_before_mapshadow_agent.json _tmp_report_after_mapshadow_try1_agent.json

## Plausibility rationale
- The change reflects a source-plausible cleanup rather than compiler coaxing: it keeps the same data flow and math, but avoids redundant setup in a common bit-pattern conversion idiom.
- No control-flow manipulation, magic constants, or readability regressions were introduced.