### PR TITLE
pppCharaBreak: add callback symbols and match small hook funcs

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -2,6 +2,50 @@
 
 /*
  * --INFO--
+ * PAL Address: 0x801411DC
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void CharaBreak_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f(void)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x801411E0
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void CharaBreak_BeforeMeshLockEnvCallback__FPQ26CChara6CModelPvPvi(void)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x801411E4
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" u32 CharaBreak_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv(u32 value, void* modelData, void* meshData)
+{
+    if (*(u32*)((u8*)modelData + 0x44) == 0) {
+        return value;
+    }
+
+    return (u32)__cntlzw(1 - (u32)*((u8*)meshData + 0x42)) >> 5;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added missing `CharaBreak_*` callback symbols in `src/pppCharaBreak.cpp` with PAL address/size metadata blocks.
- Implemented the two 4-byte no-op callbacks as empty functions.
- Implemented `CharaBreak_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv` with the same `__cntlzw` boolean pattern seen in decomp.

## Functions Improved
- `CharaBreak_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: `0.0% -> 100.0%` (4b)
- `CharaBreak_BeforeMeshLockEnvCallback__FPQ26CChara6CModelPvPvi`: `0.0% -> 100.0%` (4b)
- `CharaBreak_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`: `0.0% -> 100.0%` (32b)

## Match Evidence
- Unit selected at start: `main/pppCharaBreak` with selector-reported current score `0.5%`.
- After changes (`build/GCCP01/report.json`):
  - `fuzzy_match_percent`: `1.16204`
  - `matched_code`: `40 / 6196`
  - `matched_functions`: `3 / 12`
- `objdiff-cli` JSON diff confirms the three callback symbols now fully match.

## Plausibility Rationale
- These callbacks are real game symbols present in the original binary and currently absent from source.
- The two tiny callbacks are true no-op hooks in decomp and are represented as straightforward empty functions.
- The before-calc callback keeps the idiomatic FFCC/SDK `__cntlzw(...) >> 5` boolean-style check already used elsewhere in this codebase.

## Technical Details
- Used exact exported symbol names with `extern "C"` to avoid C++ mangling mismatch for these callback symbols.
- Kept argument typing minimal (`void*` + offset reads) to avoid speculative struct reconstruction at this stage.
- Verified with full `ninja` and per-unit `objdiff-cli diff` JSON inspection.
