### PR TITLE
astar: improve calcPolygonGroup match via direct debug flag

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -924,7 +924,7 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
  */
 unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 {
-	if ((DbgMenuPcs.GetDbgFlag() & 1) == 0)
+	if ((DAT_8032ed70 & 1) == 0)
 	{
 		CVector bottom(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);


### PR DESCRIPTION
## Summary
- Updated `CAStar::calcPolygonGroup` in `src/astar.cpp` to use `DAT_8032ed70` bit 0 directly instead of calling `DbgMenuPcs.GetDbgFlag()`.
- No logic change intended; this aligns flag access with the decomp pattern (direct debug-flag word read).

## Functions improved
- Unit: `main/astar`
- Symbol: `calcPolygonGroup__6CAStarFP3Veci`

## Match evidence
- `objdiff` command used:
  - `objdiff-cli diff -1 build/GCCP01/src/astar.o -2 build/GCCP01/obj/astar.o calcPolygonGroup__6CAStarFP3Veci`
- Before: `46.99145%`
- After: `47.439655%`
- Diff-marked instruction entries: `113 -> 111`
- Neighbor symbol check (`calcSpecialPolygonGroup__6CAStarFP3Vec`): unchanged at `55.967743%`

## Plausibility rationale
- The updated code reads an existing debug-flag global already used in the same translation unit (`drawAStar`), avoiding a method call where decompilation indicates direct flag access.
- This is source-plausible and improves codegen without introducing contrived temporaries or hardcoded object offsets.

## Technical details
- Build verified with `ninja`.
- Improvement is isolated to a single conditional expression in `calcPolygonGroup`.
