### PR TITLE
pppRandUpChar: improve match to 96.47%

### DIFF
--- a/src/pppRandUpChar.cpp
+++ b/src/pppRandUpChar.cpp
@@ -2,11 +2,11 @@
 #include "ffcc/math.h"
 #include "types.h"
 
-extern CMath math;
+extern CMath math[];
 extern s32 lbl_8032ED70;
-extern f32 lbl_8032FF08;
-extern f64 lbl_8032FF10;
-extern u8 lbl_801EADC8;
+extern f32 lbl_8032FFD8;
+extern f64 lbl_8032FFE0;
+extern u8 lbl_801EADC8[32];
 extern "C" f32 RandF__5CMathFv(CMath* instance);
 
 struct RandUpCharParam {
@@ -32,20 +32,22 @@ struct RandUpCharCtx {
  */
 extern "C" void pppRandUpChar(void* param1, void* param2, void* param3)
 {
+    u8* base = (u8*)param1;
+    RandUpCharParam* in = (RandUpCharParam*)param2;
+    RandUpCharCtx* ctx = (RandUpCharCtx*)param3;
+    u8* target;
+    f32* valuePtr;
+
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    u8* base = (u8*)param1;
-    RandUpCharParam* in = (RandUpCharParam*)param2;
-    RandUpCharCtx* ctx = (RandUpCharCtx*)param3;
-    f32* valuePtr;
-
     s32 state = *(s32*)(base + 0xC);
     if (state == 0) {
-        f32 value = RandF__5CMathFv(&math);
+        f32 value = RandF__5CMathFv(math);
         if (in->randomTwice != 0) {
-            value = (value + RandF__5CMathFv(&math)) * lbl_8032FF08;
+            value += RandF__5CMathFv(math);
+            value *= lbl_8032FFD8;
         }
 
         valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
@@ -57,9 +59,8 @@ extern "C" void pppRandUpChar(void* param1, void* param2, void* param3)
         valuePtr = (f32*)(base + *ctx->outputOffset + 0x80);
     }
 
-    u8* target;
     if (in->sourceOffset == -1) {
-        target = &lbl_801EADC8;
+        target = lbl_801EADC8;
     } else {
         target = base + in->sourceOffset + 0x80;
     }
@@ -74,6 +75,7 @@ extern "C" void pppRandUpChar(void* param1, void* param2, void* param3)
     cvt.parts.hi = 0x43300000;
     cvt.parts.lo = in->scale;
 
-    s32 delta = (s32)((cvt.d - lbl_8032FF10) * *valuePtr);
+    f32 value = *valuePtr;
+    s32 delta = (s32)((cvt.d - lbl_8032FFE0) * value);
     *target = (u8)(*target + delta);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRandUpChar` extern declarations to match neighboring `pppRandUpCV` address materialization patterns (`math[]`, `lbl_801EADC8[32]`).
- Updated constant symbol usage to align with object relocations (`lbl_8032FFD8`, `lbl_8032FFE0`).
- Reshaped local expression flow (`value += ...; value *= ...`) and value/target handling to improve register/instruction alignment.

## Functions improved
- Unit: `main/pppRandUpChar`
- Symbol: `pppRandUpChar`

## Match evidence
- Before: `88.13333%` (size 300b)
- After: `96.46667%` (size 300b)
- Instruction diff reduction:
  - `DIFF_ARG_MISMATCH`: 24 -> 9
  - `DIFF_DELETE`: 3 -> 0
  - `DIFF_REPLACE`: 7 -> 2
  - `DIFF_INSERT`: 0 -> 1

## Plausibility rationale
- Changes are source-plausible and consistent with adjacent particle-randomization code (`pppRandUpCV`) rather than compiler-only coercion.
- The function behavior remains the same: gated random value generation, optional second random sample scaling, resolved output offset write, and additive char update.

## Technical details
- Addressing mode alignment was the largest gain: this switch removed multiple `SDA21`-vs-`HA/LO` mismatches for globals used in call/setup paths.
- Minor arithmetic/control flow reshaping improved FP instruction argument ordering and reduced downstream register pressure mismatches.

## Validation
- `ninja` completed successfully.
- `tools/objdiff-cli diff -p . -u main/pppRandUpChar -o ... pppRandUpChar` used for before/after verification.
