### PR TITLE
pppRandCV: improve symbol match by aligning control flow and CV math

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -1,39 +1,25 @@
 #include "ffcc/pppRandCV.h"
 #include "ffcc/math.h"
+#include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern float lbl_8032FF08;
-extern double lbl_8032FF10;
-extern unsigned char lbl_801EADC8[32];
+extern u8 lbl_801EADC8[32];
 extern "C" float RandF__5CMathFv(CMath* instance);
 
 typedef struct RandCVParams {
-	int index;
-	int colorOffset;
-	signed char delta[4];
-	unsigned char flag;
-	unsigned char pad[3];
+    int index;
+    int colorOffset;
+    s8 delta[4];
+    u8 flag;
+    u8 pad[3];
 } RandCVParams;
 
-typedef union DoubleConv {
-	struct {
-		unsigned int hi;
-		unsigned int lo;
-	} parts;
-	double d;
-} DoubleConv;
-
-typedef struct RandCVConv {
-	DoubleConv d0;
-	DoubleConv c0;
-	DoubleConv d1;
-	DoubleConv c1;
-	DoubleConv d2;
-	DoubleConv c2;
-	DoubleConv d3;
-	DoubleConv c3;
-} RandCVConv;
+typedef struct RandCVCtx {
+    u8 pad[0xC];
+    int* outputOffset;
+} RandCVCtx;
 
 /*
  * --INFO--
@@ -54,102 +40,65 @@ void randchar(char range, float factor)
  */
 void pppRandCV(void* param1, void* param2, void* param3)
 {
-	void* p1 = param1;
-	void* p2 = param2;
-	void* p3 = param3;
-	RandCVParams* params = (RandCVParams*)p2;
-	int* baseIndex;
-	int baseOffset;
-	float* randValuePtr;
+    u8* base = (u8*)param1;
+    RandCVParams* params = (RandCVParams*)param2;
+    RandCVCtx* ctx = (RandCVCtx*)param3;
+    float* randomValue;
 
-	if (lbl_8032ED70 != 0) {
-		return;
-	}
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
 
-	if (params->index == *(int*)((char*)p1 + 0xc)) {
-		baseIndex = *(int**)((char*)p3 + 0xc);
-		baseOffset = *baseIndex;
-		randValuePtr = (float*)((char*)p1 + baseOffset + 0x80);
+    if (params->index == *(int*)(base + 0xC)) {
+        float value = RandF__5CMathFv(math);
+        if (params->flag != 0) {
+            value += RandF__5CMathFv(math);
+        } else {
+            value *= lbl_8032FF08;
+        }
 
-		float randVal = RandF__5CMathFv(&math);
-		if (params->flag != 0) {
-			float randVal2 = RandF__5CMathFv(&math);
-			randVal = randVal + randVal2;
-		} else {
-			randVal = randVal * lbl_8032FF08;
-		}
-		*randValuePtr = randVal;
-		return;
-	}
+        randomValue = (float*)(base + *ctx->outputOffset + 0x80);
+        *randomValue = value;
+    }
 
-	baseIndex = *(int**)((char*)p3 + 0xc);
-	baseOffset = *baseIndex;
-	randValuePtr = (float*)((char*)p1 + baseOffset + 0x80);
+    if (params->index != *(int*)(base + 0xC)) {
+        return;
+    }
 
-	unsigned char* colors;
-	if (params->colorOffset == -1) {
-		colors = lbl_801EADC8;
-	} else {
-		colors = (unsigned char*)p1 + params->colorOffset + 0x80;
-	}
+    randomValue = (float*)(base + *ctx->outputOffset + 0x80);
 
-	float scale = *randValuePtr;
-	const double bias = lbl_8032FF10;
-	RandCVConv conv;
+    u8* target;
+    if (params->colorOffset == -1) {
+        target = lbl_801EADC8;
+    } else {
+        target = base + params->colorOffset + 0x80;
+    }
 
-	{
-		signed char delta = params->delta[0];
-		unsigned char current = colors[0];
-		conv.d0.parts.hi = 0x43300000;
-		conv.d0.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-		conv.c0.parts.hi = 0x43300000;
-		conv.c0.parts.lo = (unsigned int)(current ^ 0x8000);
-		double value = conv.d0.d - bias;
-		double baseValue = conv.c0.d - bias;
-		double result = value * (double)scale - baseValue;
-		int add = (int)result;
-		colors[0] = (unsigned char)(current + add);
-	}
+    {
+        float scale = *randomValue;
+        u8 current = target[0];
+        s8 delta = params->delta[0];
+        target[0] = (u8)(current + (int)((float)delta * scale - (float)current));
+    }
 
-	{
-		signed char delta = params->delta[1];
-		unsigned char current = colors[1];
-		conv.d1.parts.hi = 0x43300000;
-		conv.d1.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-		conv.c1.parts.hi = 0x43300000;
-		conv.c1.parts.lo = (unsigned int)(current ^ 0x8000);
-		double value = conv.d1.d - bias;
-		double baseValue = conv.c1.d - bias;
-		double result = value * (double)scale - baseValue;
-		int add = (int)result;
-		colors[1] = (unsigned char)(current + add);
-	}
+    {
+        float scale = *randomValue;
+        u8 current = target[1];
+        s8 delta = params->delta[1];
+        target[1] = (u8)(current + (int)((float)delta * scale - (float)current));
+    }
 
-	{
-		signed char delta = params->delta[2];
-		unsigned char current = colors[2];
-		conv.d2.parts.hi = 0x43300000;
-		conv.d2.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-		conv.c2.parts.hi = 0x43300000;
-		conv.c2.parts.lo = (unsigned int)(current ^ 0x8000);
-		double value = conv.d2.d - bias;
-		double baseValue = conv.c2.d - bias;
-		double result = value * (double)scale - baseValue;
-		int add = (int)result;
-		colors[2] = (unsigned char)(current + add);
-	}
+    {
+        float scale = *randomValue;
+        u8 current = target[2];
+        s8 delta = params->delta[2];
+        target[2] = (u8)(current + (int)((float)delta * scale - (float)current));
+    }
 
-	{
-		signed char delta = params->delta[3];
-		unsigned char current = colors[3];
-		conv.d3.parts.hi = 0x43300000;
-		conv.d3.parts.lo = (unsigned int)((int)delta ^ 0x8000);
-		conv.c3.parts.hi = 0x43300000;
-		conv.c3.parts.lo = (unsigned int)(current ^ 0x8000);
-		double value = conv.d3.d - bias;
-		double baseValue = conv.c3.d - bias;
-		double result = value * (double)scale - baseValue;
-		int add = (int)result;
-		colors[3] = (unsigned char)(current + add);
-	}
+    {
+        float scale = *randomValue;
+        u8 current = target[3];
+        s8 delta = params->delta[3];
+        target[3] = (u8)(current + (int)((float)delta * scale - (float)current));
+    }
 }


### PR DESCRIPTION
## Summary
- Reworked pppRandCV in src/pppRandCV.cpp to use typed param/context structs and the same two-stage flow pattern used by adjacent pppRand* units.
- Removed the manual union-based double conversion scaffolding and expressed the color update as direct (delta * scale - current) math per channel.
- Updated type usage (u8/s8, CMath math[]) to better match expected ABI/codegen.

## Functions improved
- Unit: main/pppRandCV
- Symbol: pppRandCV

## Match evidence
- Command: tools/objdiff-cli diff -p . -u main/pppRandCV -o - pppRandCV
- Before: 75.22222%
- After: 86.844444%
- Net: +11.622224 percentage points

## Plausibility rationale
- The new implementation matches existing style in nearby particle randomizer units (pppRandHCV, pppRandIV, pppRandUpCV) rather than introducing compiler-only tricks.
- Changes are semantic/type-correct and idiomatic for original game-side source (typed structs, clear state gate, per-component update blocks).

## Technical details
- The biggest gain came from removing an early return in the matched-id path and using the same follow-up guard (if index != state return) pattern as sibling functions.
- Objdiff now shows tighter alignment in branch layout and float/int conversion sequences across the 4 CV channels.
