### PR TITLE
prgobj: implement ClassControl state dispatch

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/prgobj.h"
+#include "ffcc/charaobj.h"
+#include "ffcc/partyobj.h"
 
 /*
  * --INFO--
@@ -327,12 +329,60 @@ void CGPrgObj::dstTargetRot(CGPrgObj*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127084
+ * PAL Size: 348b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::ClassControl(int, int)
+void CGPrgObj::ClassControl(int classControl, int value)
 {
-	// TODO
+	switch (classControl) {
+	case 0:
+		reinterpret_cast<CGPartyObj*>(this)->ChangeCommandMode(value);
+		break;
+	case 1:
+		reinterpret_cast<CGPartyObj*>(this)->changeMotionMode(value);
+		break;
+	case 2:
+		if ((((char)m_weaponNodeFlags) >> 7) != value) {
+			onChangePrg(value);
+			m_weaponNodeFlags = (m_weaponNodeFlags & 0x7FFF) | ((value & 1) << 15);
+		}
+		break;
+	case 3:
+	{
+		unsigned char* classFlags = reinterpret_cast<unsigned char*>(this) + 0x6B8;
+		*classFlags = (*classFlags & 0xF7) | ((value & 1) << 3);
+		break;
+	}
+	case 4:
+	{
+		int oldState = getReplaceStat(value);
+		if (oldState != -1) {
+			onCancelStat(value);
+			m_stateArg = 0;
+			onChangeStat(value);
+			m_lastStateId = oldState;
+			m_stateFrame = 0;
+			m_stateFrameGate = 1;
+			m_subState = 0;
+			m_subFrame = 0;
+			m_subFrameGate = 1;
+		}
+		break;
+	}
+	case 5:
+		reinterpret_cast<CGCharaObj*>(this)->ClearAllSta();
+		break;
+	case 6:
+		*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x560) = value;
+		break;
+	case 7:
+		reinterpret_cast<CGPartyObj*>(this)->setAlive(1, 0);
+		break;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CGPrgObj::ClassControl(int, int)` in `src/prgobj.cpp` and replaced the TODO stub with state-dispatch logic reconstructed from PAL assembly behavior.

Key updates:
- Added explicit switch handling for class control cases `0..7`
- Routed party/chara control cases through existing methods (`ChangeCommandMode`, `changeMotionMode`, `setAlive`, `ClearAllSta`)
- Recreated state transition path (replace-state check, cancel/change hooks, frame/substate resets)
- Recreated bitfield toggles for weapon-node enable and class-control flag bit
- Recreated class-control storage write at offset `0x560`

## Functions improved
- Unit: `main/prgobj`
- Function: `ClassControl__8CGPrgObjFii`
  - Before: `1.1494253%`
  - After: `59.068966%`

Unit-level fuzzy score:
- `main/prgobj` before: `15.467497%`
- `main/prgobj` after: `22.437067%`

## Match evidence
Built with `ninja` and compared function/unit fuzzy metrics from `build/GCCP01/report.json` before vs after.

## Plausibility rationale
The implementation follows source-plausible gameplay/control logic rather than compiler-only transformations:
- Uses existing object methods for party/chara behavior
- Uses existing `CGPrgObj` state members for transition/reset behavior already used elsewhere in this file
- Uses direct bit/flag updates that align with existing member semantics (`m_weaponNodeFlags` and class-control flags)

## Technical notes
- `ClassControl` behavior was mapped from `build/GCCP01/asm/prgobj.s` at `0x80127084` (size `348b`)
- Added PAL metadata block for the implemented function
- No unrelated file changes