### PR TITLE
gobject: fix PlayAnim signed-char signature for objdiff matching

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -63,7 +63,7 @@ public:
     bool IsLoopAnim(int mode);
     void IsAnimFinished(int);
     void CancelAnim(int);
-    void PlayAnim(int, int, int, int, int, char*);
+    void PlayAnim(int, int, int, int, int, signed char*);
     void SetDispItemName(int);
     void DrawDebug(CFont*);
     void SetPosBG(Vec*, int);

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -571,7 +571,7 @@ void CGObject::CancelAnim(int)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGObject::PlayAnim(int slot, int param2, int param3, int param4, int param5, char* animData)
+void CGObject::PlayAnim(int slot, int param2, int param3, int param4, int param5, signed char* animData)
 {
 	m_currentAnimSlot = m_animQueue[slot - 0x41];
 	


### PR DESCRIPTION
## Summary
- Updated `CGObject::PlayAnim` declaration/definition parameter type from `char*` to `signed char*`.
- This corrects C++ mangling to the expected symbol for PAL decomp matching.

## Functions improved
- Unit: `main/gobject`
- Function: `PlayAnim__8CGObjectFiiiiiPSc`

## Match evidence
- Before: function was effectively unmatched for target symbol (`0.0%` in selector output for `PlayAnim__8CGObjectFiiiiiPSc`), with produced symbol `PlayAnim__8CGObjectFiiiiiPc`.
- After: target symbol now resolves and matches at `29.52174%` via:
  - `tools/objdiff-cli diff -p . -u main/gobject -o - --format json PlayAnim__8CGObjectFiiiiiPSc`

## Plausibility rationale
- `signed char*` is source-plausible for raw animation byte data and aligns with the shipped symbol naming (`PSc`), rather than an artificial compiler-only construct.
- No control-flow or logic-coaxing changes were introduced; only ABI-significant type correction.

## Technical details
- Header change: `include/ffcc/gobject.h`
- Implementation change: `src/gobject.cpp`
- The adjustment fixes symbol identity mismatch (name mangling), which was the primary blocker preventing objdiff from mapping this function to its intended target.
