### PR TITLE
pppDrawMatrixNoRot: fix translated component store offsets

### DIFF
--- a/src/pppDrawMatrixNoRot.cpp
+++ b/src/pppDrawMatrixNoRot.cpp
@@ -24,8 +24,8 @@ void pppDrawMatrixNoRot(struct _pppPObject* param_1)
     *(float*)((char*)param_1 + 0x4c) = 
         (*(float*)((char*)param_1 + 0x1c)) * (pppMngStPtr->m_scale).x +
         ppvWorldMatrix[0][3];
-    *(float*)((char*)param_1 + 0x4c) =
-        (*(float*)((char*)param_1 + 0x2c)) * (pppMngStPtr->m_scale).y + ppvWorldMatrix[1][3];
     *(float*)((char*)param_1 + 0x5c) =
+        (*(float*)((char*)param_1 + 0x2c)) * (pppMngStPtr->m_scale).y + ppvWorldMatrix[1][3];
+    *(float*)((char*)param_1 + 0x6c) =
         (*(float*)((char*)param_1 + 0x3c)) * (pppMngStPtr->m_scale).z + ppvWorldMatrix[2][3];
 }


### PR DESCRIPTION
## Summary
- Corrected translated matrix output writes in `pppDrawMatrixNoRot` to store X/Y/Z components to distinct slots.
- Updated byte offsets from duplicate stores (`0x4c`, `0x4c`, `0x5c`) to sequential component stores (`0x4c`, `0x5c`, `0x6c`).

## Functions Improved
- Unit: `main/pppDrawMatrixNoRot`
- Symbol: `pppDrawMatrixNoRot`

## Match Evidence
- Before: `99.78378%` fuzzy match
- After: `99.83784%` fuzzy match
- Delta: `+0.05406%`

## Plausibility Rationale
- The function computes transformed XYZ values from source offsets `0x1c/0x2c/0x3c`; writing those back to `0x4c/0x5c/0x6c` is the natural and consistent object-layout mapping used across adjacent particle matrix code.
- This removes duplicated writes to Y and preserves straightforward source intent rather than introducing coaxing constructs.

## Technical Details
- Verified with `ninja` rebuild and project report generation.
- Checked function-level progress in `build/GCCP01/report.json` for `main/pppDrawMatrixNoRot`.