### PR TITLE
cflat_r2system: implement minigame param helpers and ClearEvtWork

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -41,6 +41,7 @@ public:
         void Init();
         void InitNewGame();
         void ClearScriptChange();
+        void ClearEvtWork();
 
         unsigned char m_menuStageMode;                   // 0x00
         unsigned char m_gameInitFlag;                    // 0x01

--- a/include/ffcc/p_minigame.h
+++ b/include/ffcc/p_minigame.h
@@ -54,6 +54,8 @@ public:
     void MiniGameEnd();
 
     void CallMiniGameParam(int, int, int);
+    int GetMiniGameParam(int);
+    void SetMiniGameParam(int, int);
     void SetNumPlayer();
 };
 

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -6,9 +6,11 @@
 #include "ffcc/p_camera.h"
 #include "ffcc/p_map.h"
 #include "ffcc/p_menu.h"
+#include "ffcc/p_minigame.h"
 #include "ffcc/p_tina.h"
 #include "ffcc/sound.h"
 #include "ffcc/USBStreamData.h"
+#include <string.h>
 
 static inline CUSBStreamData* UsbStream(CPartPcs* self)
 {
@@ -160,6 +162,76 @@ extern "C" int CheckHitCylinderNear__7CMapPcsFP3VecP3VecfUl(
 extern "C" unsigned char* GetTmpFrameBuffer__8CGraphicFv(CGraphic* graphic)
 {
     return *(unsigned char**)((char*)graphic + 0x7208);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9068
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CMiniGamePcs::GetMiniGameParam(int id)
+{
+    if (id == 0x2002) {
+        return *(signed char*)((char*)this + 0x649A);
+    }
+    if (id < 0x2002) {
+        if (id == 0x2000) {
+            return *(signed char*)((char*)this + 0x6498);
+        }
+        if (id > 0x1FFF) {
+            return *(signed char*)((char*)this + 0x6499);
+        }
+    } else if (id < 0x2004) {
+        return *(signed char*)((char*)this + 0x649B);
+    }
+    return 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B90C8
+ * PAL Size: 220b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CMiniGamePcs::SetMiniGameParam(int id, int value)
+{
+    if ((unsigned int)System.m_execParam > 2U) {
+        System.Printf("SetMiniGameParam no 0x%04x data[%d]\n", id, value);
+    }
+
+    if (id == 0x1202) {
+        *(unsigned char*)((char*)this + 0x134B) |= (unsigned char)(1 << value);
+    } else if (id < 0x1202) {
+        if (id == 0x1102) {
+            *(unsigned char*)((char*)this + 0x1348) = 1;
+        } else if (id > 0x1100 && id < 0x1102) {
+            *(signed char*)((char*)this + 0x1350) = (signed char)value;
+        }
+    } else if (id < 0x1204) {
+        *(unsigned char*)((char*)this + 0x134B) &= (unsigned char)~(1 << value);
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B91A4
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGame::CGameWork::ClearEvtWork()
+{
+    memset(m_eventFlags, 0, sizeof(m_eventFlags));
+    memset(m_eventWork, 0, sizeof(m_eventWork));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added `CMiniGamePcs::GetMiniGameParam(int)` and `CMiniGamePcs::SetMiniGameParam(int, int)` implementations in `src/cflat_r2system.cpp` using the existing object layout offsets already used in this unit.
- Added `CGame::CGameWork::ClearEvtWork()` implementation to clear event arrays with `memset`.
- Added missing declarations in `include/ffcc/p_minigame.h` and `include/ffcc/game.h`.

## Functions improved
- Unit: `main/cflat_r2system`
- `GetMiniGameParam__12CMiniGamePcsFi`
  - Before: selector reported `0.0%`
  - After: objdiff `36.96%`
- `SetMiniGameParam__12CMiniGamePcsFii`
  - Before: selector reported `0.0%`
  - After: objdiff `51.15%`
- `ClearEvtWork__Q25CGame9CGameWorkFv`
  - Before: selector reported `0.0%`
  - After: objdiff `99.33%`

## Match evidence
- Rebuilt with `ninja` successfully (`build/GCCP01/main.dol: OK`).
- Verified each symbol with:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system <symbol>`
- Observed real instruction-level alignment in objdiff for all three symbols (not formatting-only changes).

## Plausibility rationale
- Implementations are direct, source-plausible utility methods:
  - Parameter getter/setter logic mirrors expected script/system ID dispatch behavior.
  - Event work clearing uses idiomatic `memset` over clearly named contiguous arrays.
- No compiler-coaxing temporaries or unnatural control flow were introduced.

## Technical notes
- This is a first-pass recovery of missing implementations for symbols listed as 0% in the selected target unit.
- `ClearEvtWork` is near-complete already, while the minigame parameter helpers now have substantial initial alignment and can be iterated further.
