### PR TITLE
main/cflat_runtime2: add CGBaseObj::InitFinished implementation

### DIFF
--- a/include/ffcc/baseobj.h
+++ b/include/ffcc/baseobj.h
@@ -9,6 +9,7 @@ class CGBaseObj : public CFlatRuntime::CObject
 	virtual ~CGBaseObj();                       // vtable entry 0x4
 	
     virtual void onNewFinished(int) = 0;        // vtable entry 0x8
+	void InitFinished();
     virtual int GetCID();                       // vtable entry 0x10
 	virtual void onPush(CGBaseObj* other, int); // vtable entry 0x14
 	virtual void onTalk(CGBaseObj* other, int); // vtable entry 0x18

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1,4 +1,18 @@
 #include "ffcc/cflat_runtime2.h"
+#include "ffcc/baseobj.h"
+
+/*
+ * --INFO--
+ * PAL Address: 0x8006a058
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGBaseObj::InitFinished()
+{
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added missing declaration for `CGBaseObj::InitFinished()` in `include/ffcc/baseobj.h`.
- Implemented `CGBaseObj::InitFinished()` as a no-op in `src/cflat_runtime2.cpp`.
- Added PAL metadata block for the implemented function using the exported Ghidra reference.

## Functions improved
- Unit: `main/cflat_runtime2`
- Symbol: `InitFinished__9CGBaseObjFv`
- Size: `4b`
- Match: `0.0% -> 100.0%`

## Match evidence
- Before (selector output): `InitFinished__9CGBaseObjFv` reported at `0.0%` in `main/cflat_runtime2`.
- After (`build/GCCP01/report.json`):
  - `InitFinished__9CGBaseObjFv`: `100.0%`
  - Unit `main/cflat_runtime2`: `matched_functions 0 -> 1`, `matched_code 0 -> 4`
- Overall project progress from `ninja`:
  - `matched_code 192832 -> 192836`
  - `matched_functions 1377 -> 1378`

## Plausibility rationale
- The implemented behavior is source-plausible: an explicit empty method body for a class hook-style function (`InitFinished`) is common in this codebase.
- This is not compiler coercion: no contrived temporaries, control-flow tricks, or ABI-changing layout hacks are used.
- The change aligns with the known PAL symbol and decomp reference for this exact function.

## Technical details
- Used `resources/ghidra-decomp-1-31-2026/8006a058_InitFinished__9CGBaseObjFv.c` for PAL address/size and no-op behavior.
- Avoided introducing `InitFinished` as a virtual method after validating that doing so caused global regressions (class ABI/vtable side effects).
- Final implementation keeps class ABI stable while emitting the missing symbol in the expected unit.
