### PR TITLE
cflat_runtime: add dtor_80069A2C deleting destructor thunk

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2,6 +2,7 @@
 
 extern "C" {
 void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
+void __dl__FPv(void*);
 char s_cflat_runtime_cpp_801d8ef8[];
 void* __vt__12CFlatRuntime[];
 void* __vt__Q212CFlatRuntime7CObject[];
@@ -39,6 +40,30 @@ CFlatRuntime::CFlatRuntime()
 CFlatRuntime::~CFlatRuntime()
 {
 	Quit();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80069a2c
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CFlatRuntime* dtor_80069A2C(CFlatRuntime* flatRuntime, short shouldDelete)
+{
+	if (flatRuntime != 0) {
+		typedef void (*QuitFn)(CFlatRuntime*);
+
+		*(void***)flatRuntime = __vt__12CFlatRuntime;
+		reinterpret_cast<QuitFn>((*reinterpret_cast<void***>(flatRuntime))[4])(flatRuntime);
+		if (0 < shouldDelete) {
+			__dl__FPv(flatRuntime);
+		}
+	}
+
+	return flatRuntime;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented the missing deleting-destructor thunk `dtor_80069A2C` for `CFlatRuntime` in `src/cflat_runtime.cpp`.
- Added the `__dl__FPv` extern and implemented the thunk in the project’s existing destructor-thunk style: null-check, vtable reset, destructor-path call, conditional delete by `short shouldDelete`.

## Functions improved
- Unit: `main/cflat_runtime`
- Symbol: `dtor_80069A2C` (PAL `0x80069a2c`, `104b`)

## Match evidence
- `dtor_80069A2C` before: `0.0%` (from target selection/report)
- `dtor_80069A2C` after: `99.42308%` (`build/GCCP01/report.json`)
- Symbol diff one-shot (`objdiff-cli diff`) reports ~`99.03846%` instruction match for this symbol.
- Unit fuzzy match increased from about `2.3%` (selector baseline) to `2.9789526%` after this change.

## Plausibility rationale
- This mirrors canonical CodeWarrior deleting-destructor output already used in this codebase (`dtor_*` patterns in other units):
  - reset class vtable
  - run destructor cleanup path
  - free object only when delete flag is positive
- No compiler-coaxing temporaries or non-idiomatic control-flow changes were introduced.

## Technical details
- Implemented `extern "C" CFlatRuntime* dtor_80069A2C(CFlatRuntime*, short)`.
- Kept normal C++ destructor (`~CFlatRuntime`) intact and focused only on the missing thunk symbol.
- Validation:
  - `ninja` passes
  - `tools/objdiff-cli diff -p . -u main/cflat_runtime -o - --format json dtor_80069A2C`
