### PR TITLE
prgobj: implement playSe3D and fix return type

### DIFF
--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -29,7 +29,7 @@ public:
     void reqAnim(int, int, int);
     void isLoopAnim();
     void isLoopAnimDirect();
-    void playSe3D(int, int, int, int, Vec*);
+    int playSe3D(int, int, int, int, Vec*);
     void changePrg(int);
     void putParticle(int, int, Vec*, float, int);
     void putParticle(int, int, CGObject*, float, int);

--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -1,6 +1,9 @@
 #include "ffcc/prgobj.h"
 #include "ffcc/charaobj.h"
 #include "ffcc/partyobj.h"
+#include "ffcc/sound.h"
+
+extern "C" int PlaySe3D__6CSoundFiP3Vecffi(CSound*, int, Vec*, float, float, int);
 
 /*
  * --INFO--
@@ -239,12 +242,32 @@ void CGPrgObj::isLoopAnimDirect()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127650
+ * PAL Size: 208b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::playSe3D(int, int, int, int, Vec*)
+int CGPrgObj::playSe3D(int seNo, int volume, int dist, int pitch, Vec* pos)
 {
-	// TODO
+	int handle;
+
+	if (seNo == 0 || seNo == 0xFFFF) {
+		return -1;
+	}
+
+	if (pos == nullptr) {
+		pos = &m_worldPosition;
+	}
+
+	handle = PlaySe3D__6CSoundFiP3Vecffi(&Sound, seNo, pos, (float)volume, (float)dist, 0);
+
+	if (pitch != 0) {
+		Sound.ChangeSe3DPitch(handle, pitch, 0);
+	}
+
+	return handle;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGPrgObj::playSe3D` in `src/prgobj.cpp` using the expected control flow from the PAL decomp reference.
- Corrected `CGPrgObj::playSe3D` declaration/definition return type from `void` to `int` in `include/ffcc/prgobj.h` and `src/prgobj.cpp`.
- Added PAL address/size metadata block for the function.

## Functions improved
- Unit: `main/prgobj`
- Symbol: `playSe3D__8CGPrgObjFiiiiP3Vec`

## Match evidence
- `playSe3D__8CGPrgObjFiiiiP3Vec`: **1.9230769% -> 70.25%**
- Verification command used:
  - `tools/objdiff-cli diff -p . -u main/prgobj -o - playSe3D__8CGPrgObjFiiiiP3Vec`
- Build verification:
  - `ninja` passes and regenerates `build/GCCP01/report.json`.

## Plausibility rationale
- The new implementation reflects natural game code behavior rather than compiler-only coercion:
  - early-out on invalid SFX IDs,
  - default-to-self world position when no explicit `Vec*` is provided,
  - 3D sound play request plus optional pitch adjustment.
- This matches existing engine API usage (`Sound` object methods) and expected gameplay intent.

## Technical details
- Implemented as a direct call sequence:
  1. Validate sound ID (`0`, `0xFFFF` invalid).
  2. Resolve position argument (`nullptr` -> `m_worldPosition`).
  3. Call `PlaySe3D__6CSoundFiP3Vecffi` and keep returned handle.
  4. Apply `ChangeSe3DPitch` when pitch parameter is non-zero.
  5. Return handle.
- Added:
  - `extern "C" int PlaySe3D__6CSoundFiP3Vecffi(CSound*, int, Vec*, float, float, int);`
  to preserve expected symbol usage while keeping changes localized to `prgobj`.
