### PR TITLE
mapshadow: improve CMapShadow::Init codegen match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -73,10 +73,7 @@ void CMapShadow::Init()
 	u32 uVar7;
 	u32 uVar8;
 	union {
-		struct {
-			u32 hi;
-			u32 lo;
-		} parts;
+		u64 bits;
 		double d;
 	} cvt;
 
@@ -85,14 +82,13 @@ void CMapShadow::Init()
 	iVar6 = *(int*)(iVar6 + 0x3c);
 	uVar8 = *(u32*)(iVar6 + 100);
 	uVar7 = *(u32*)(iVar6 + 0x68);
-	*((char*)this + 7) = (char)*(u32*)(iVar6 + 0x6c);
-	cvt.parts.hi = 0x43300000;
-	cvt.parts.lo = uVar8;
+	*((u8*)this + 7) = *(u8*)(iVar6 + 0x6c);
+	cvt.bits = 0x4330000000000000ULL | (u64)uVar8;
 	fVar1 = (float)(cvt.d - dVar5);
-	cvt.parts.lo = uVar7;
+	cvt.bits = 0x4330000000000000ULL | (u64)uVar7;
 	fVar2 = (float)(cvt.d - dVar5);
 	fVar3 = *(float*)((char*)this + 0xa8);
-	if (*((char*)this + 6) == 0) {
+	if (*(s8*)((char*)this + 6) == 0) {
 		C_MTXLightOrtho((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,
 		                (float)(DOUBLE_8032fce8 * (double)fVar3),
 		                (float)((double)FLOAT_8032fcf0 * (double)fVar3),


### PR DESCRIPTION
## Summary
- Refined CMapShadow::Init conversion/sign handling to better match original code generation while preserving behavior.
- Replaced split hi/lo union writes with a 64-bit bit-pattern conversion path for the u32 -> double -> float steps.
- Tightened byte field loads/stores (u8) and signed mode check (s8) for the branch controlling ortho vs frustum setup.

## Functions Improved
- Unit: main/mapshadow
- Function: Init__10CMapShadowFv

## Match Evidence
- Init__10CMapShadowFv: **39.77966% -> 43.525425%** (+3.745765)
- Unit main/mapshadow fuzzy match: **71.47594% -> 72.65775%** (+1.18181)
- Build verification: 
inja succeeds after change.

## Plausibility Rationale
- Changes are type-correct and source-plausible (signedness and integer/float conversion detail), not artificial temp-variable coercion.
- No control-flow restructuring beyond expressing the existing signed flag semantics more explicitly.

## Technical Details
- Conversion now uses 