### PR TITLE
memorycard: define global to restore static init matching

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -8,6 +8,7 @@
 #include "string.h"
 
 extern unsigned char Game[];
+CMemoryCardMan MemoryCardMan;
 
 // CRC32 lookup table
 static const unsigned int crcTable[256] = {


### PR DESCRIPTION
## Summary
- Define `MemoryCardMan` in `src/memorycard.cpp` so the memorycard translation unit emits the expected static initialization sequence.
- This is a minimal, source-plausible fix aligned with the Ghidra `__sinit_memorycard_cpp` behavior.

## Functions Improved
- `main/memorycard`
- `__sinit_memorycard_cpp` (PAL 0x800c4db8, 32b)
  - Before: `0.0%` (from `tools/agent_select_target.py` target listing)
  - After: `98.75%` (`tools/objdiff-cli diff -p . -u main/memorycard -o - __sinit_memorycard_cpp`)

## Match Evidence
- Unit progress impact from `ninja`/report:
  - Code matched: `192836 -> 192868` bytes (`+32`)
  - Functions matched: `1378 -> 1379` (`+1`)
- Objdiff now shows near-complete instruction alignment for `__sinit_memorycard_cpp`.

## Plausibility Rationale
- `MemoryCardMan` is the module's manager singleton and is already declared in the header and referenced across the codebase.
- Defining it in the owning translation unit is a natural original-source layout and directly explains the expected static init/vtable setup pattern.
- The change is not compiler coaxing; it restores a missing object-definition relationship.

## Technical Details
- One-line addition in `src/memorycard.cpp`:
  - `CMemoryCardMan MemoryCardMan;`
- This causes the TU to emit the static initializer sequence matching the target `__sinit_memorycard_cpp` body.
