### PR TITLE
pppYmDeformationScreen: implement first-pass render path

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -1,7 +1,12 @@
 #include "ffcc/pppYmDeformationScreen.h"
+#include "ffcc/graphic.h"
+#include "ffcc/mapmesh.h"
 #include "ffcc/p_game.h"
 #include "ffcc/partMng.h"
+#include "ffcc/pppYmEnv.h"
+#include "ffcc/util.h"
 
+#include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 
 struct pppYmDeformationScreen;
@@ -40,8 +45,21 @@ struct YmDeformationScreenStep {
 	char m_payloadBytes[0x1a];
 };
 
+struct pppCVECTOR {
+	unsigned int m_rgba;
+};
+
+struct _pppEnvStYmDeformationScreen {
+	void* m_stagePtr;
+	CMaterialSet* m_materialSetPtr;
+	CMapMesh** m_mapMeshPtr;
+};
+
 extern int DAT_8032ed70;
 extern char DAT_8032ed78;
+extern void* DAT_80238030;
+extern CUtil DAT_8032ec70;
+extern float ppvScreenMatrix[4][4];
 
 extern struct {
 	float _212_4_;
@@ -58,6 +76,21 @@ extern "C" {
 void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
 void MTX44MultVec4__5CMathFPA4_fP5Vec4dP5Vec4d(void*, Mtx44, Vec4d*, Vec4d*);
 void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
+int GetTexture__8CMapMeshFP12CMaterialSetRi(CMapMesh*, CMaterialSet*, int&);
+void pppInitBlendMode__Fv(void);
+void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+	pppCVECTOR*, pppFMATRIX*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char,
+	unsigned char, unsigned char);
+void pppSetBlendMode__FUc(unsigned char);
+void _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(int, int, int, int);
+void _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(int, int, int, int, int);
+void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(int, int, int, int, int);
+void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int, int);
+void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(int, int, int, int, int);
+void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int, int);
+void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 }
 
 /*
@@ -194,7 +227,137 @@ void pppFrameYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, v
  */
 void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, void* param3)
 {
-	// TODO - implement based on Ghidra decomp
+	YmDeformationScreenStep* step = (YmDeformationScreenStep*)param2;
+	_pppEnvStYmDeformationScreen* env = (_pppEnvStYmDeformationScreen*)pppEnvStPtr;
+	float* work = (float*)((char*)param1 + 0x80 + ((YmDeformationScreenData*)param3)->m_serializedDataOffsets[2]);
+	int textureIndex = 0;
+	GXTexObj backTexObj;
+	Mtx identity;
+	Mtx44 orthoMtx;
+	Mtx rot;
+	float indMtx[2][3];
+	float depth;
+	float texU;
+	float texV;
+	pppCVECTOR color;
+	int textureBase;
+
+	if (step->m_dataValIndex == 0xFFFF) {
+		return;
+	}
+
+	textureBase = GetTexture__8CMapMeshFP12CMaterialSetRi(
+		env->m_mapMeshPtr[step->m_dataValIndex], env->m_materialSetPtr, textureIndex);
+
+	_GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 1, 5, 1);
+	GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
+	GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_TEX1, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
+	color.m_rgba = 0x40404040;
+	pppSetBlendMode__FUc(0);
+	pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+		&color, (pppFMATRIX*)0, 0.0f, (unsigned char)0, (unsigned char)0, (unsigned char)0, (unsigned char)0,
+		(unsigned char)1, (unsigned char)1, (unsigned char)0);
+	_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+	GXSetNumTexGens(2);
+	GXSetNumChans(1);
+	_GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(1, 0, 1, 2, 0);
+	_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 1);
+	_GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 0xF, 8, 9, 0xF);
+	_GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+	_GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 7, 7, 7, 4);
+	_GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+	_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(1, 0, 1, 0xFF);
+	_GXSetTevOp__F13_GXTevStageID10_GXTevMode(1, 0);
+
+	DAT_8032ec70.BeginQuadEnv();
+	DAT_8032ec70.SetVtxFmt_POS_CLR_TEX0_TEX1();
+	GXSetNumTevStages(1);
+	GXSetNumTexGens(2);
+	GXSetNumChans(1);
+	PSMTXIdentity(identity);
+	GXLoadPosMtxImm(identity, 0);
+	GXSetCurrentMtx(0);
+
+	PSMTX44Identity(orthoMtx);
+	orthoMtx[0][0] = 2.0f / 640.0f;
+	orthoMtx[1][1] = -2.0f / 480.0f;
+	orthoMtx[2][2] = 1.0f;
+	orthoMtx[0][3] = -1.0f;
+	orthoMtx[1][3] = 1.0f;
+	GXSetProjection(orthoMtx, GX_ORTHOGRAPHIC);
+	GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
+	_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
+	_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 3);
+	GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
+
+	depth = work[0];
+	GXSetNumIndStages(1);
+	GXSetIndTexOrder(GX_INDTEXSTAGE0, GX_TEXCOORD0, GX_TEXMAP1);
+	GXSetTevIndWarp(GX_TEVSTAGE0, GX_INDTEXSTAGE0, GX_TRUE, GX_ITW_0, GX_ITM_1);
+	GXSetIndTexCoordScale(GX_INDTEXSTAGE0, GX_ITS_1, GX_ITS_1);
+
+	if ((*(short*)(work + 1) == 0) || (*(short*)(work + 1) == 0x168)) {
+		*(short*)(work + 1) = 1;
+	}
+
+	PSMTXRotRad(rot, 'z', 0.017453292f * (float)(*(short*)(work + 1)));
+	indMtx[0][0] = rot[0][0] * work[2];
+	indMtx[0][1] = rot[0][1] * work[2];
+	indMtx[0][2] = 0.0f;
+	indMtx[1][0] = rot[1][0] * work[2];
+	indMtx[1][1] = rot[1][1] * work[2];
+	indMtx[1][2] = 0.0f;
+	GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
+
+	texU = 640.0f / (float)*(unsigned int*)(textureBase + 100);
+	texV = 448.0f / (float)*(unsigned int*)(textureBase + 0x68);
+
+	Graphic.GetBackBufferRect2(DAT_80238030, &backTexObj, 0, 0, 640, 224, 0, GX_LINEAR, GX_TF_RGBA8, 0);
+	GXLoadTexObj(&backTexObj, GX_TEXMAP0);
+	GXLoadTexObj((GXTexObj*)(textureBase + 0x28), GX_TEXMAP1);
+	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+	GXPosition3f32(0.0f, 0.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(0.0f, 0.0f);
+	GXTexCoord2f32(0.0f, 0.0f);
+	GXPosition3f32(640.0f, 0.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(texU, 0.0f);
+	GXTexCoord2f32(1.0f, 0.0f);
+	GXPosition3f32(640.0f, 224.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(texU, texV);
+	GXTexCoord2f32(1.0f, 1.0f);
+	GXPosition3f32(0.0f, 224.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(0.0f, texV);
+	GXTexCoord2f32(0.0f, 1.0f);
+
+	Graphic.GetBackBufferRect2(DAT_80238030, &backTexObj, 0, 224, 640, 224, 0, GX_LINEAR, GX_TF_RGBA8, 0);
+	GXLoadTexObj(&backTexObj, GX_TEXMAP0);
+	depth = work[0];
+	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+	GXPosition3f32(0.0f, 224.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(0.0f, 0.0f);
+	GXTexCoord2f32(0.0f, 0.0f);
+	GXPosition3f32(640.0f, 224.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(texU, 0.0f);
+	GXTexCoord2f32(1.0f, 0.0f);
+	GXPosition3f32(640.0f, 448.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(texU, texV);
+	GXTexCoord2f32(1.0f, 1.0f);
+	GXPosition3f32(0.0f, 448.0f, depth);
+	GXColor1u32(color.m_rgba);
+	GXTexCoord2f32(0.0f, texV);
+	GXTexCoord2f32(0.0f, 1.0f);
+
+	DAT_8032ec70.EndQuadEnv();
+	DisableIndWarp(GX_TEVSTAGE1, GX_INDTEXSTAGE0);
+	GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
+	pppInitBlendMode__Fv();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppRenderYmDeformationScreen` in `src/pppYmDeformationScreen.cpp` from the PAL Ghidra reference as a first-pass plausible source reconstruction.
- Added required GX/render setup calls, texture fetch wiring, quad pass rendering for top/bottom backbuffer regions, and teardown/projection restore.
- Kept existing constructor/frame/destructor behavior intact.

## Functions improved
- Unit: `main/pppYmDeformationScreen`
- Function: `pppRenderYmDeformationScreen`
  - Before: `0.2%` (from target selector baseline)
  - After: `75.30174%` (`build/GCCP01/report.json`)

## Match evidence
- `ninja` builds successfully after the change.
- `objdiff-cli diff -p . -u main/pppYmDeformationScreen pppRenderYmDeformationScreen` reports ~`75.10%` in diff view.
- Unit report now shows:
  - `pppRenderYmDeformationScreen`: `75.30174%`
  - `pppFrameYmDeformationScreen`: `61.736435%` (unchanged target context)

## Plausibility rationale
- The implementation follows existing codebase patterns used by other particle/GX effect renderers (blend setup, TEV/indirect warp setup, quad env usage, projection restore) rather than contrived compiler-only transformations.
- Data flow is kept consistent with existing offset-based effect state conventions in nearby `pppYm*` units.

## Technical details
- Added explicit extern signatures for currently decompiled GX helper entry points and render helpers already used elsewhere in the codebase.
- Implemented two-pass screen-quad submission with backbuffer capture, matching the decomp structure and preserving scene projection restoration (`GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE)`) plus blend re-init.
