### PR TITLE
chunkfile: improve GetF4 match

### DIFF
--- a/src/chunkfile.cpp
+++ b/src/chunkfile.cpp
@@ -195,9 +195,10 @@ unsigned int CChunkFile::Get4()
 float CChunkFile::GetF4()
 {
     float value;
-    unsigned int* cursorPtr = (unsigned int*)m_cursor;
-    *(unsigned int*)&value = *cursorPtr;
-    m_cursor += 4;
+    unsigned int* cursor = (unsigned int*)m_cursor;
+    unsigned int bits = *cursor;
+    m_cursor = (unsigned char*)(cursor + 1);
+    *(unsigned int*)&value = bits;
     return value;
 }
 


### PR DESCRIPTION
## Summary
- Refined `CChunkFile::GetF4()` in `src/chunkfile.cpp` to use explicit cursor/value temporaries while keeping behavior unchanged.
- Kept the change minimal and source-plausible (normal pointer read + cursor advance), avoiding contrived control flow.

## Functions improved
- Unit: `main/chunkfile`
- Symbol: `GetF4__10CChunkFileFv`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/chunkfile GetF4__10CChunkFileFv`
- Before: `74.77778%`
- After: `75.888885%`
- Net: `+1.111105%`

## Plausibility rationale
- The updated implementation still represents idiomatic source for chunk stream reads:
  - load 32-bit payload from current cursor
  - advance cursor by one `float`
  - reinterpret bits as `float`
- No artificial sequencing or non-idiomatic tricks were introduced.

## Technical details
- The adjustment improves alignment of load/store ordering around cursor advancement in generated code for this function.
- Build validation: `ninja` completed successfully after the change.