### PR TITLE
Improve prgobj target rotation function matches

### DIFF
--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -36,7 +36,7 @@ public:
     void putParticleTrace(int, int, CGObject*, float, int);
     void putParticleBindTrace(int, int, CGObject*, float, int);
     int getReplaceStat(int);
-    void getTargetRot(CGPrgObj*);
+    float getTargetRot(CGPrgObj*);
     void rotTarget(CGPrgObj*);
     void dstTargetRot(CGPrgObj*);
     void ClassControl(int, int);

--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -1,9 +1,14 @@
 #include "ffcc/prgobj.h"
 #include "ffcc/charaobj.h"
+#include "ffcc/math.h"
 #include "ffcc/partyobj.h"
 #include "ffcc/sound.h"
+#include "ffcc/vector.h"
+
+#include <math.h>
 
 extern "C" int PlaySe3D__6CSoundFiP3Vecffi(CSound*, int, Vec*, float, float, int);
+extern CMath Math;
 
 /*
  * --INFO--
@@ -322,32 +327,77 @@ void CGPrgObj::putParticleBindTrace(int, int, CGObject*, float, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012732C
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::getTargetRot(CGPrgObj*)
+float CGPrgObj::getTargetRot(CGPrgObj* target)
 {
-	// TODO
+	float targetRot;
+	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
+	CVector deltaPos;
+
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	targetRot = 0.0f;
+	if (deltaPos.x != 0.0f && deltaPos.z != 0.0f) {
+		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
+	}
+
+	return targetRot;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127290
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::rotTarget(CGPrgObj*)
+void CGPrgObj::rotTarget(CGPrgObj* target)
 {
-	// TODO
+	float targetRot;
+	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
+	CVector deltaPos;
+
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	targetRot = 0.0f;
+	if (deltaPos.x != 0.0f && deltaPos.z != 0.0f) {
+		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
+	}
+
+	m_rotTargetY = targetRot;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801271E0
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::dstTargetRot(CGPrgObj*)
+void CGPrgObj::dstTargetRot(CGPrgObj* target)
 {
-	// TODO
+	float targetRot;
+	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
+	CVector deltaPos;
+
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	targetRot = 0.0f;
+	if (deltaPos.x != 0.0f && deltaPos.z != 0.0f) {
+		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
+	}
+
+	Math.DstRot(m_rotBaseY, 3.1415927f + targetRot);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGPrgObj` target-rotation helpers in `src/prgobj.cpp`:
  - `getTargetRot(CGPrgObj*)`
  - `rotTarget(CGPrgObj*)`
  - `dstTargetRot(CGPrgObj*)`
- Updated declaration in `include/ffcc/prgobj.h` so `getTargetRot` returns `float`.
- Added PAL address/size metadata blocks for the three functions.

## Functions improved
Unit: `main/prgobj`
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: `2.7777777%` -> `78.5%`
- `rotTarget__8CGPrgObjFP8CGPrgObj`: `2.5641026%` -> `71.871796%`
- `dstTargetRot__8CGPrgObjFP8CGPrgObj`: `2.2727273%` -> `67.11364%`

## Match evidence
Measured with:
- `tools/objdiff-cli diff -p . -u main/prgobj -o - --format json <symbol>`

The improvements are instruction-level (not symbol rename noise): each function moved from near-empty stub output to control flow that now aligns with original subtraction/`atan2`/rotation update patterns.

## Plausibility rationale
These changes model common gameplay-facing behavior used by character/object logic:
- compute horizontal facing delta from world positions
- convert to yaw with `atan2`
- either return yaw, assign target yaw, or feed yaw into `CMath::DstRot`

This is source-plausible object logic and avoids non-idiomatic compiler coaxing.

## Technical notes
- Used `PSVECSubtract` + `CVector` temporaries consistent with surrounding codebase style.
- Kept constants and branches simple (`0.0f` checks, `3.1415927f` offset for destination rotation path).
- Build passes with `ninja` on `GCCP01` after the change.
