### PR TITLE
Improve pppRandCV match with branch/scale cleanup

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -59,9 +59,7 @@ void pppRandCV(void* param1, void* param2, void* param3)
 
         randomValue = (float*)(base + *ctx->outputOffset + 0x80);
         *randomValue = value;
-    }
-
-    if (params->index != *(int*)(base + 0xC)) {
+    } else {
         return;
     }
 
@@ -74,29 +72,27 @@ void pppRandCV(void* param1, void* param2, void* param3)
         target = base + params->colorOffset + 0x80;
     }
 
+    float scale = *randomValue;
+
     {
-        float scale = *randomValue;
         u8 current = target[0];
         s8 delta = params->delta[0];
         target[0] = (u8)(current + (int)((float)delta * scale - (float)current));
     }
 
     {
-        float scale = *randomValue;
         u8 current = target[1];
         s8 delta = params->delta[1];
         target[1] = (u8)(current + (int)((float)delta * scale - (float)current));
     }
 
     {
-        float scale = *randomValue;
         u8 current = target[2];
         s8 delta = params->delta[2];
         target[2] = (u8)(current + (int)((float)delta * scale - (float)current));
     }
 
     {
-        float scale = *randomValue;
         u8 current = target[3];
         s8 delta = params->delta[3];
         target[3] = (u8)(current + (int)((float)delta * scale - (float)current));


### PR DESCRIPTION
## Summary
- Simplified pppRandCV index gating from two separate compares to a single if (...) { ... } else { return; } branch.
- Hoisted the shared random scale load (*randomValue) into one local used by all 4 channel updates.
- Kept behavior/source intent unchanged while making control flow and data use closer to adjacent pppRand*CV implementations.

## Functions improved
- Unit: main/pppRandCV
- Function: pppRandCV

## Match evidence
- pppRandCV: **86.881485% -> 89.73333%** (+2.851845)
- Size unchanged: 540b
- Verified by 
inja report (uild/GCCP01/report.json) after rebuild.

## Plausibility rationale
- The change removes a redundant second index comparison and uses one shared scale value for channel interpolation, which is idiomatic in this codebase and consistent with neighboring particle-randomization functions.
- No contrived temporaries, no hardcoded object offsets beyond existing serialized data access patterns, and no behavior-changing rewrites.

## Technical details
- Previous flow did:
  - compare index for random generation
  - compare index again for early return
- New flow keeps the same branch semantics with one compare/return block.
- Channel updates now reuse a single scale load before applying the per-channel interpolation math.