### PR TITLE
pppYmDeformationShp: implement construct/construct2/frame pass

### DIFF
--- a/include/ffcc/pppYmDeformationShp.h
+++ b/include/ffcc/pppYmDeformationShp.h
@@ -1,11 +1,25 @@
 #ifndef _PPP_YMDEFORMATIONSHP_H_
 #define _PPP_YMDEFORMATIONSHP_H_
 
+#include <dolphin/types.h>
+
 struct _pppPObject;
+struct pppYmDeformationShp;
 struct VYmDeformationShp;
 struct Vec;
 struct Vec2d;
 struct Vec4d;
+struct UnkB {
+    s32 m_graphId;
+    s32 m_dataValIndex;
+    f32 m_payload[6];
+    s16 m_payload3;
+    u8 m_pad_0x22[0x1a];
+};
+struct UnkC {
+    u8 m_pad_0x0[0xc];
+    s32* m_serializedDataOffsets;
+};
 
 void SetUpIndWarp(VYmDeformationShp*);
 void calcBoundaryBox(Vec&, Vec&, Vec4d*);
@@ -20,11 +34,11 @@ void RenderDeformationShape(_pppPObject*, VYmDeformationShp*, Vec*, Vec2d*);
 extern "C" {
 #endif
 
-void pppConstructYmDeformationShp(void);
-void pppConstruct2YmDeformationShp(void);
+void pppConstructYmDeformationShp(pppYmDeformationShp*, UnkC*);
+void pppConstruct2YmDeformationShp(pppYmDeformationShp*, UnkC*);
 void pppDestructYmDeformationShp(void);
-void pppFrameYmDeformationShp(void);
-void pppRenderYmDeformationShp(void);
+void pppFrameYmDeformationShp(pppYmDeformationShp*, UnkB*, UnkC*);
+void pppRenderYmDeformationShp(pppYmDeformationShp*, UnkB*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -1,5 +1,10 @@
 #include "ffcc/pppYmDeformationShp.h"
 
+extern int DAT_8032ed70;
+extern u8 DAT_8032ed78;
+extern float FLOAT_803305f4;
+extern "C" void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
+
 /*
  * --INFO--
  * Address:	TODO
@@ -55,7 +60,7 @@ void setVertexUV(Vec2d*, float, float, float, float)
  * Address:	TODO
  * Size:	TODO
  */
-void calcScreenPos(Vec4d&, Vec&, float (*) [4], float (*) [4])
+void calcScreenPos(Vec4d&, Vec&, float (*)[4], float (*)[4])
 {
 	// TODO
 }
@@ -72,42 +77,108 @@ void oddToEven(float&)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80090590
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructYmDeformationShp(void)
+void pppConstructYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, UnkC* param_2)
 {
-	// TODO
+	float fVar1 = FLOAT_803305f4;
+	u32* work = (u32*)((u8*)pppYmDeformationShp_ + 0x80 + param_2->m_serializedDataOffsets[2]);
+
+	work[0] = 0;
+	work[1] = 0;
+	work[2] = 0;
+	*(u16*)(work + 3) = 0;
+	*(u8*)((u8*)(work + 3) + 2) = 1;
+	((float*)work)[6] = fVar1;
+	((float*)work)[5] = fVar1;
+	((float*)work)[4] = fVar1;
+	((float*)work)[9] = fVar1;
+	((float*)work)[8] = fVar1;
+	((float*)work)[7] = fVar1;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80090560
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstruct2YmDeformationShp(void)
+void pppConstruct2YmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, UnkC* param_2)
 {
-	// TODO
+	int offset = param_2->m_serializedDataOffsets[2];
+	float fVar1 = FLOAT_803305f4;
+
+	*(float*)((u8*)pppYmDeformationShp_ + 0x98 + offset) = FLOAT_803305f4;
+	*(float*)((u8*)pppYmDeformationShp_ + 0x94 + offset) = fVar1;
+	*(float*)((u8*)pppYmDeformationShp_ + 0x90 + offset) = fVar1;
+	*(float*)((u8*)pppYmDeformationShp_ + 0xa4 + offset) = fVar1;
+	*(float*)((u8*)pppYmDeformationShp_ + 0xa0 + offset) = fVar1;
+	*(float*)((u8*)pppYmDeformationShp_ + 0x9c + offset) = fVar1;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009055c
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppDestructYmDeformationShp(void)
 {
-	// TODO
+	return;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80090438
+ * PAL Size: 292b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppFrameYmDeformationShp(void)
+void pppFrameYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+	s16* angle;
+
+	if (DAT_8032ed70 != 0) {
+		return;
+	}
+
+	angle = (s16*)((u8*)pppYmDeformationShp_ + 0x8c + param_3->m_serializedDataOffsets[2]);
+
+	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+		param_2->m_payload[0], pppYmDeformationShp_, param_2->m_graphId, (float*)(angle + 2), (float*)(angle + 4),
+		(float*)(angle + 6), &param_2->m_payload[1], &param_2->m_payload[2]);
+	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+		param_2->m_payload[3], pppYmDeformationShp_, param_2->m_graphId, (float*)(angle + 8), (float*)(angle + 10),
+		(float*)(angle + 12), &param_2->m_payload[4], &param_2->m_payload[5]);
+
+	if (DAT_8032ed78 != 0) {
+		return;
+	}
+
+	if (*(u8*)(angle + 1) == 0) {
+		*angle = *angle - (s16)(int)*(float*)(angle + 8);
+		if ((int)*angle < -(int)param_2->m_payload3) {
+			*(u8*)(angle + 1) = 1;
+		}
+	} else {
+		*angle = *angle + (s16)(int)*(float*)(angle + 8);
+		if (param_2->m_payload3 < *angle) {
+			*(u8*)(angle + 1) = 0;
+		}
+	}
 }
 
 /*
@@ -125,7 +196,7 @@ void RenderDeformationShape(_pppPObject*, VYmDeformationShp*, Vec*, Vec2d*)
  * Address:	TODO
  * Size:	TODO
  */
-void pppRenderYmDeformationShp(void)
+void pppRenderYmDeformationShp(pppYmDeformationShp*, UnkB*, UnkC*)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Implemented first-pass decomp for `main/pppYmDeformationShp` setup/frame path by replacing TODO stubs with concrete logic based on PAL symbol-guided behavior.
- Added concrete typed signatures and step/offset structs for this unit in `include/ffcc/pppYmDeformationShp.h`.
- Implemented:
  - `pppConstructYmDeformationShp`
  - `pppConstruct2YmDeformationShp`
  - `pppDestructYmDeformationShp`
  - `pppFrameYmDeformationShp`

## Functions Improved
Unit: `main/pppYmDeformationShp`
- `pppFrameYmDeformationShp` (292b)
- `pppConstructYmDeformationShp` (76b)
- `pppConstruct2YmDeformationShp` (48b)
- `pppDestructYmDeformationShp` (4b)

## Match Evidence
- Selector baseline for this unit before edits: `0.4%` current match (`99.6%` gap)
- Baseline listed by selector for `pppFrameYmDeformationShp`: `1.4%`
- Post-change report (`ninja` / `build/GCCP01/report.json`):
  - Unit `main/pppYmDeformationShp` fuzzy match: `4.6858497%`
  - `pppFrameYmDeformationShp`: `53.041096%`
  - `pppConstructYmDeformationShp`: `89.47369%`
  - `pppConstruct2YmDeformationShp`: `87.416664%`
  - `pppDestructYmDeformationShp`: `100%`

## Plausibility Rationale
- Changes are source-plausible and follow existing particle/deformation unit patterns already used in nearby files (`pppYmDeformationMdl`, `pppYmDeformationScreen`).
- Improvements come from restoring expected control flow, field layout usage, and typed graph update calls, rather than artificial compiler coaxing.
- No debug-only artifacts or assembly comments were added.

## Technical Details
- Implemented the frame update path with the two `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf` calls, serialized offset addressing, and direction-toggle angle accumulator behavior (`DAT_8032ed78` branch).
- Added PAL address/size metadata blocks for the implemented functions.
- Verified build success with `ninja` after edits.