### PR TITLE
pppSRandCV: improve match via pointer/type flow cleanup

### DIFF
--- a/src/pppSRandCV.cpp
+++ b/src/pppSRandCV.cpp
@@ -7,15 +7,6 @@ extern int lbl_8032ED70;
 extern u8 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
 
-struct SRandCVParams
-{
-	int index;
-	int colorOffset;
-	s8 base[4];
-	u8 flag;
-	u8 pad[3];
-};
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,92 +22,92 @@ extern "C" {
  */
 void pppSRandCV(void* param1, void* param2, void* param3)
 {
-	SRandCVParams* params = (SRandCVParams*)param2;
-	float* rand_values;
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
 
-	if (lbl_8032ED70 != 0) {
-		return;
-	}
+    float* target;
 
-	if (params->index == *(int*)((char*)param1 + 0xc)) {
-		int** base_ptr = (int**)((char*)param3 + 0xc);
-		int offset = **base_ptr;
-		u8 flag = params->flag;
-		float value;
-		rand_values = (float*)((char*)param1 + offset + 0x80);
+    if (*(int*)param2 == *((int*)param1 + 3)) {
+        int** base_ptr = (int**)((char*)param3 + 0xc);
+        int offset = **base_ptr;
+        target = (float*)((char*)param1 + offset + 0x80);
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
-		} else {
-			value = value * 2.0f;
-		}
-		rand_values[0] = value;
+        u8 flag = *((u8*)param2 + 0xc);
+        float value;
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
-		} else {
-			value = value * 2.0f;
-		}
-		rand_values[1] = value;
+        value = RandF__5CMathFv(&math);
+        if (flag != 0) {
+            value = value + RandF__5CMathFv(&math);
+        } else {
+            value = value * 2.0f;
+        }
+        target[0] = value;
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
-		} else {
-			value = value * 2.0f;
-		}
-		rand_values[2] = value;
+        value = RandF__5CMathFv(&math);
+        if (flag != 0) {
+            value = value + RandF__5CMathFv(&math);
+        } else {
+            value = value * 2.0f;
+        }
+        target[1] = value;
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
-		} else {
-			value = value * 2.0f;
-		}
-		rand_values[3] = value;
-	} else if (params->index != *(int*)((char*)param1 + 0xc)) {
-		int** base_ptr = (int**)((char*)param3 + 0xc);
-		int offset = **base_ptr;
-		rand_values = (float*)((char*)param1 + offset + 0x80);
-	}
+        value = RandF__5CMathFv(&math);
+        if (flag != 0) {
+            value = value + RandF__5CMathFv(&math);
+        } else {
+            value = value * 2.0f;
+        }
+        target[2] = value;
 
-	u8* target_color;
-	int color_offset = params->colorOffset;
-	if (color_offset == -1) {
-		target_color = lbl_801EADC8;
-	} else {
-		target_color = (u8*)((char*)param1 + color_offset + 0x80);
-	}
+        value = RandF__5CMathFv(&math);
+        if (flag != 0) {
+            value = value + RandF__5CMathFv(&math);
+        } else {
+            value = value * 2.0f;
+        }
+        target[3] = value;
+    } else if (*(int*)param2 != *((int*)param1 + 3)) {
+        int** base_ptr = (int**)((char*)param3 + 0xc);
+        int offset = **base_ptr;
+        target = (float*)((char*)param1 + offset + 0x80);
+    }
 
-	{
-		u8 current = target_color[0];
-		s8 base = params->base[0];
-		s8 delta = (s8)((float)base * rand_values[0] - (float)current);
-		target_color[0] = (u8)(current + delta);
-	}
+    int color_offset = *((int*)param2 + 1);
+    u8* target_color;
+    if (color_offset == -1) {
+        target_color = lbl_801EADC8;
+    } else {
+        target_color = (u8*)((char*)param1 + color_offset + 0x80);
+    }
 
-	{
-		u8 current = target_color[1];
-		s8 base = params->base[1];
-		s8 delta = (s8)((float)base * rand_values[1] - (float)current);
-		target_color[1] = (u8)(current + delta);
-	}
+    {
+        u8 current = target_color[0];
+        s8 base = *(s8*)((char*)param2 + 8);
+        int delta = (int)((float)base * target[0] - (float)current);
+        target_color[0] = (u8)(current + delta);
+    }
 
-	{
-		u8 current = target_color[2];
-		s8 base = params->base[2];
-		s8 delta = (s8)((float)base * rand_values[2] - (float)current);
-		target_color[2] = (u8)(current + delta);
-	}
+    {
+        u8 current = target_color[1];
+        s8 base = *(s8*)((char*)param2 + 9);
+        int delta = (int)((float)base * target[1] - (float)current);
+        target_color[1] = (u8)(current + delta);
+    }
 
-	{
-		u8 current = target_color[3];
-		s8 base = params->base[3];
-		s8 delta = (s8)((float)base * rand_values[3] - (float)current);
-		target_color[3] = (u8)(current + delta);
-	}
+    {
+        u8 current = target_color[2];
+        s8 base = *(s8*)((char*)param2 + 0xa);
+        int delta = (int)((float)base * target[2] - (float)current);
+        target_color[2] = (u8)(current + delta);
+    }
+
+    {
+        u8 current = target_color[3];
+        s8 base = *(s8*)((char*)param2 + 0xb);
+        int delta = (int)((float)base * target[3] - (float)current);
+        target_color[3] = (u8)(current + delta);
+    }
 }
 
 /*
@@ -126,7 +117,7 @@ void pppSRandCV(void* param1, void* param2, void* param3)
  */
 void randchar(char, float)
 {
-	// TODO
+    // TODO
 }
 
 /*
@@ -136,7 +127,7 @@ void randchar(char, float)
  */
 void randf(unsigned char)
 {
-	// TODO
+    // TODO
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- Reworked `pppSRandCV` to use direct pointer/cast access patterns consistent with neighboring `ppp*CV` implementations.
- Removed the local `SRandCVParams` struct dependency and switched to explicit field-offset access for index, color offset, signed channel bases, and flag.
- Kept behavior intact: random generation still uses the same `flag` split (`+ RandF` when set, `* 2.0f` when clear), and channel updates still apply `base * random - current` before accumulation.

## Functions Improved
- Unit: `main/pppSRandCV`
- Symbol: `pppSRandCV`

## Match Evidence
- `pppSRandCV` match improved from **76.929344%** to **77.445656%** (`objdiff-cli v3.6.1`, oneshot JSON mode).
- Object size remained stable at `700` bytes for the compared symbol, with improved instruction alignment in the random/color update flow.

## Plausibility Rationale
- The changes move the function toward style already present in this codebase (`pppSRandUpCV`/`pppRandCV`-style raw offset access and simple per-channel blocks), rather than introducing contrived compiler-only control flow.
- Type usage is now ABI-plausible for this module: signed per-channel deltas are promoted to `int` for arithmetic, then narrowed back to color bytes.

## Technical Details
- Standardized pointer derivation for output random buffer and destination color buffer.
- Normalized per-channel update blocks to `current/base/delta` temporaries, reducing unnecessary signed-byte truncation artifacts.
- Verified full build with `ninja` (`build/GCCP01/main.dol: OK`) before submission.
