### PR TITLE
prgobj: implement putParticle helper methods

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -8,7 +8,15 @@
 #include <math.h>
 
 extern "C" int PlaySe3D__6CSoundFiP3Vecffi(CSound*, int, Vec*, float, float, int);
+extern "C" void ResetParticleWork__13CFlatRuntime2Fii(void*, int, int);
+extern "C" void SetParticleWorkScale__13CFlatRuntime2Ff(void*, float);
+extern "C" void SetParticleWorkBind__13CFlatRuntime2FPQ212CFlatRuntime7CObject(void*, void*);
+extern "C" void SetParticleWorkTrace__13CFlatRuntime2FPQ212CFlatRuntime7CObject(void*, void*);
+extern "C" void SetParticleWorkPos__13CFlatRuntime2FR3Vecf(void*, Vec&, float);
+extern "C" void SetParticleWorkSe__13CFlatRuntime2Fiii(void*, int, int, int);
+extern "C" void PutParticleWork__13CFlatRuntime2Fv(void*);
 extern CMath Math;
+extern unsigned char CFlat[];
 
 /*
  * --INFO--
@@ -287,42 +295,83 @@ void CGPrgObj::changePrg(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801275AC
+ * PAL Size: 164b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::putParticle(int, int, Vec*, float, int)
+void CGPrgObj::putParticle(int no, int dataNo, Vec* pos, float scale, int seNo)
 {
-	// TODO
+	ResetParticleWork__13CFlatRuntime2Fii(CFlat, no, dataNo);
+	SetParticleWorkScale__13CFlatRuntime2Ff(CFlat, scale);
+	SetParticleWorkPos__13CFlatRuntime2FR3Vecf(CFlat, *pos, 0.0f);
+	if (seNo != 0) {
+		SetParticleWorkSe__13CFlatRuntime2Fiii(CFlat, seNo, 2, 0);
+	}
+	PutParticleWork__13CFlatRuntime2Fv(CFlat);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127510
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::putParticle(int, int, CGObject*, float, int)
+void CGPrgObj::putParticle(int no, int dataNo, CGObject* traceObj, float scale, int seNo)
 {
-	// TODO
+	ResetParticleWork__13CFlatRuntime2Fii(CFlat, no, dataNo);
+	SetParticleWorkScale__13CFlatRuntime2Ff(CFlat, scale);
+	SetParticleWorkBind__13CFlatRuntime2FPQ212CFlatRuntime7CObject(CFlat, this);
+	if (seNo != 0) {
+		SetParticleWorkSe__13CFlatRuntime2Fiii(CFlat, seNo, 2, 0);
+	}
+	PutParticleWork__13CFlatRuntime2Fv(CFlat);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127474
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::putParticleTrace(int, int, CGObject*, float, int)
+void CGPrgObj::putParticleTrace(int no, int dataNo, CGObject* obj, float scale, int seNo)
 {
-	// TODO
+	ResetParticleWork__13CFlatRuntime2Fii(CFlat, no, dataNo);
+	SetParticleWorkScale__13CFlatRuntime2Ff(CFlat, scale);
+	SetParticleWorkTrace__13CFlatRuntime2FPQ212CFlatRuntime7CObject(CFlat, this);
+	PutParticleWork__13CFlatRuntime2Fv(CFlat);
+	if (seNo != 0) {
+		SetParticleWorkSe__13CFlatRuntime2Fiii(CFlat, seNo, 2, 0);
+	}
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801273BC
+ * PAL Size: 184b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::putParticleBindTrace(int, int, CGObject*, float, int)
+void CGPrgObj::putParticleBindTrace(int no, int dataNo, CGObject* obj, float scale, int seNo)
 {
-	// TODO
+	ResetParticleWork__13CFlatRuntime2Fii(CFlat, no, dataNo);
+	SetParticleWorkScale__13CFlatRuntime2Ff(CFlat, scale);
+	SetParticleWorkBind__13CFlatRuntime2FPQ212CFlatRuntime7CObject(CFlat, this);
+	SetParticleWorkTrace__13CFlatRuntime2FPQ212CFlatRuntime7CObject(CFlat, obj);
+	PutParticleWork__13CFlatRuntime2Fv(CFlat);
+	if (seNo != 0) {
+		SetParticleWorkSe__13CFlatRuntime2Fiii(CFlat, seNo, 2, 0);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented the four `CGPrgObj` particle helper methods in `src/prgobj.cpp` using existing `CFlatRuntime2` runtime entrypoints and added PAL metadata blocks:
- `putParticle(int,int,Vec*,float,int)`
- `putParticle(int,int,CGObject*,float,int)`
- `putParticleTrace(int,int,CGObject*,float,int)`
- `putParticleBindTrace(int,int,CGObject*,float,int)`

## Functions Improved
Unit: `main/prgobj`
- `putParticleBindTrace__8CGPrgObjFiiP8CGObjectfi`: `2.173913% -> 100.0%`
- `putParticleTrace__8CGPrgObjFiiP8CGObjectfi`: `2.5641026% -> 100.0%`
- `putParticle__8CGPrgObjFiiP8CGObjectfi`: `2.5641026% -> 100.0%`
- `putParticle__8CGPrgObjFiiP3Vecfi`: `2.4390244% -> 99.87805%`

## Match Evidence
- `ninja` rebuilt successfully.
- Global matched code increased from `192892` to `193552` bytes (`+660`).
- Objdiff (v3.6.1 JSON oneshot) confirms near/full symbol-level alignment for all four targeted methods.

## Plausibility Rationale
The new implementations are straightforward gameplay-side wrappers around existing particle runtime operations (`ResetParticleWork`, `SetParticleWorkScale`, bind/trace/pos setters, `SetParticleWorkSe`, `PutParticleWork`) and follow expected method intent from names and class context rather than compiler-coax patterns.

## Technical Details
- Used direct mangled C entrypoints already present in the codebase style (same pattern as `PlaySe3D__6CSound...`) to preserve call ABI.
- Preserved operation ordering where it impacts codegen and behavior (notably the `PutParticleWork` vs `SetParticleWorkSe` sequencing differences across overloads).