### PR TITLE
main/menu_compa: implement first-pass CompaCtrl

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/menu_compa.h"
+#include "ffcc/pad.h"
+#include "ffcc/sound.h"
 #include <string.h>
 
 /*
@@ -160,12 +162,81 @@ void CMenuPcs::CompaOpen()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80161c28
+ * PAL Size: 800b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::CompaCtrl()
 {
-	// TODO
+	bool activeInput = false;
+	unsigned short press;
+	unsigned short hold;
+	bool doReset = false;
+
+	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+		activeInput = true;
+	}
+
+	if (activeInput) {
+		press = 0;
+	} else {
+		press = Pad._8_2_;
+	}
+
+	if (activeInput) {
+		hold = 0;
+	} else {
+		hold = *reinterpret_cast<unsigned short*>(reinterpret_cast<char*>(&Pad) + 0x20);
+	}
+
+	if (hold != 0) {
+		if ((press & 0x20) != 0) {
+			*reinterpret_cast<short*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c) + 0x1e) = 1;
+			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
+			doReset = true;
+		} else if ((press & 0x40) != 0) {
+			*reinterpret_cast<short*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c) + 0x1e) = -1;
+			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
+			doReset = true;
+		} else if ((press & 0x100) != 0) {
+			Sound.PlaySe(4, 0x40, 0x7f, 0);
+		} else if ((press & 0x200) != 0) {
+			*reinterpret_cast<char*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c) + 0xd) = 1;
+			Sound.PlaySe(3, 0x40, 0x7f, 0);
+			doReset = true;
+		}
+	}
+
+	if (!doReset) {
+		return;
+	}
+
+	int menuData = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x850);
+	*reinterpret_cast<int*>(menuData + 0x2c) = 2;
+	*reinterpret_cast<int*>(menuData + 0x30) = 5;
+	*reinterpret_cast<int*>(menuData + 0x6c) = 2;
+	*reinterpret_cast<int*>(menuData + 0x70) = 5;
+	*reinterpret_cast<int*>(menuData + 0xac) = 2;
+	*reinterpret_cast<int*>(menuData + 0xb0) = 5;
+	*reinterpret_cast<int*>(menuData + 0xec) = 7;
+	*reinterpret_cast<int*>(menuData + 0xf0) = 5;
+	*reinterpret_cast<int*>(menuData + 300) = 7;
+	*reinterpret_cast<int*>(menuData + 0x130) = 5;
+	*reinterpret_cast<int*>(menuData + 0x174) = 2;
+	*reinterpret_cast<int*>(menuData + 0x16c) = 7;
+	*reinterpret_cast<int*>(menuData + 0x170) = 5;
+
+	int entryCount = static_cast<int>(**reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850));
+	short* entry = *reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850) + 4;
+	for (int i = 0; i < entryCount; ++i) {
+		*reinterpret_cast<int*>(entry + 0x10) = 0;
+		*reinterpret_cast<int*>(entry + 0x12) = 0;
+		*reinterpret_cast<float*>(entry + 8) = 1.0f;
+		entry += 0x20;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::CompaCtrl()` in `src/menu_compa.cpp` from the PAL decomp reference as a first-pass source-plausible reconstruction.
- Added required includes for `Pad` and `Sound` usage and replaced the TODO metadata block with PAL address/size info.
- Kept logic aligned with existing menu-control patterns used in `menu_favo.cpp` and `menu_tmparti.cpp` (input gating, navigation/confirm SFX, menu-state flags, and post-action animation reset).

## Functions Improved
- Unit: `main/menu_compa`
- Symbol: `CompaCtrl__8CMenuPcsFv` (PAL size 800b)

## Match Evidence
- `CompaCtrl__8CMenuPcsFv`: **0.5% -> 45.57%** (`build/tools/objdiff-cli diff -p . -u main/menu_compa -o - CompaCtrl__8CMenuPcsFv`)
- Unit `main/menu_compa` fuzzy match: **8.9% -> 15.7936%** (before from `tools/agent_select_target.py`, after from `build/GCCP01/report.json`)
- Build status: `ninja` passes cleanly after change.

## Plausibility Rationale
- The implementation follows established FFCC menu code conventions already present in this repository (same button masks, same `Sound.PlaySe(...)` conventions, same pointer-based menu state writes).
- The reset/update path writes coherent menu animation state fields in the same structure region initialized by `CompaInit`, rather than introducing synthetic temporaries or compiler-coaxing constructs.

## Technical Details
- Input handling mirrors other menu controllers: disable direct pad read during replay/remote state, then react to `press`/`hold` masks for left/right/back/confirm behavior.
- On state-changing input, the code resets per-entry transition counters and alpha terms (`entry + 0x10`, `entry + 0x12`, `entry + 8`) and restores key menu item timing values (`+0x2c`, `+0x30`, `+0x6c`, etc.).