### PR TITLE
main/pppYmLaser: improve pppDestructYmLaser match

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -89,11 +89,11 @@ extern "C" void pppDestructYmLaser(void* pppYmLaser, void* param_2)
 {
 	YmLaserOffsets* offsets = (YmLaserOffsets*)param_2;
 	int dataOffset = offsets->m_serializedDataOffsets[2];
-	void** stage = (void**)((unsigned char*)pppYmLaser + 0x9c + dataOffset);
+	void* stage = *(void**)((unsigned char*)pppYmLaser + 0x9c + dataOffset);
 
-	if (*stage != 0) {
-		pppHeapUseRate__FPQ27CMemory6CStage(*stage);
-		*stage = 0;
+	if (stage != 0) {
+		pppHeapUseRate__FPQ27CMemory6CStage(stage);
+		*(void**)((unsigned char*)pppYmLaser + 0x9c + dataOffset) = 0;
 	}
 }
 


### PR DESCRIPTION
## Summary
Refined `pppDestructYmLaser` pointer handling to match the likely original source flow: load stage pointer value once, branch on that value, call heap cleanup, then write back null.

## Functions improved
- Unit: `main/pppYmLaser`
- Symbol: `pppDestructYmLaser`

## Match evidence
- `pppDestructYmLaser`: **74.052635% -> 88.789474%**
- `pppConstruct2YmLaser`: 90.0% (unchanged)
- `pppConstructYmLaser`: 79.26316% (unchanged)

Measured via:
`build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - <symbol>`

## Plausibility rationale
This change removes an intermediate pointer-to-pointer temporary and uses a direct `void*` stage value, which is a normal C/C++ style for ownership/cleanup checks in this codebase and aligns with similar laser destructors.

## Technical details
- Replaced:
  - `void** stage = (void**)(...)`
  - `if (*stage != 0) { ... *stage = 0; }`
- With:
  - `void* stage = *(void**)(...)`
  - `if (stage != 0) { ... *(void**)(...) = 0; }`

This kept behavior identical while improving generated assembly alignment for the destructor.
