### PR TITLE
game: match LoadInit/LoadFinished caravan loops

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -460,22 +460,34 @@ void CGame::LoadScript(char*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001458c
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::LoadInit()
 {
-	// TODO
+	for (int i = 0; i < 8; ++i) {
+		m_caravanWorkArr[i].LoadInit();
+	}
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80014540
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::LoadFinished()
 {
-	// TODO
+	for (int i = 0; i < 8; ++i) {
+		m_caravanWorkArr[i].LoadFinished();
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CGame::LoadInit()` and `CGame::LoadFinished()` in `src/game.cpp` as explicit loops that dispatch to `CCaravanWork::LoadInit()` / `CCaravanWork::LoadFinished()` across the first 8 caravan work entries.

Also updated both function info blocks with PAL address/size metadata.

## Functions improved
- `LoadInit__5CGameFv` (76b): **5.263% -> 100.0%**
- `LoadFinished__5CGameFv` (76b): **5.263% -> 100.0%**

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/game -o - LoadInit__5CGameFv`
  - right symbol shows `size: 76`, `match_percent: 100.0`
- `build/tools/objdiff-cli diff -p . -u main/game -o - LoadFinished__5CGameFv`
  - right symbol shows `size: 76`, `match_percent: 100.0`
- Unit-level effect (`main/game`):
  - fuzzy match: **11.351913 -> 12.849418**
  - matched functions: **6/45 -> 8/45**

## Plausibility rationale
This change reflects a straightforward, source-plausible gameplay-manager pattern: iterate caravan slots and delegate per-caravan load state transitions.

The generated code shape aligns with expected original behavior:
- fixed loop bound of 8
- contiguous `CCaravanWork` stride stepping (`0xC30`)
- direct member dispatch calls for each entry

No compiler-coaxing patterns or non-idiomatic control flow were introduced.

## Technical details
- File changed: `src/game.cpp`
- Functions:
  - `CGame::LoadInit()`
  - `CGame::LoadFinished()`
- Build verification: `ninja` completed successfully.
