### PR TITLE
map: implement CMapMng::SetMapTexAnim

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/map.h"
+#include "ffcc/maptexanim.h"
 
 /*
  * --INFO--
@@ -605,9 +606,10 @@ void CMapMng::SetMapObjMime(int, int, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CMapMng::SetMapTexAnim(int, int, int, int)
+void CMapMng::SetMapTexAnim(int materialId, int frameStart, int frameEnd, int wrapMode)
 {
-	// TODO
+    CMapTexAnimSet* mapTexAnimSet = reinterpret_cast<CMapTexAnimSet*>(reinterpret_cast<unsigned char*>(this) + 0x213DC);
+    mapTexAnimSet->SetMapTexAnim(materialId, frameStart, frameEnd, wrapMode);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMapMng::SetMapTexAnim(int,int,int,int)` in `src/map.cpp` by forwarding to the embedded `CMapTexAnimSet` at the known manager offset.

## Functions improved
- Unit: `main/map`
- Function: `SetMapTexAnim__7CMapMngFiiii` (`40b`)

## Match evidence
- `SetMapTexAnim__7CMapMngFiiii`: `10.0%` -> `94.0%`
- Unit `main/map` fuzzy match: `1.6351129` -> `1.789213`
- Validation method: `ninja` (which regenerates `build/GCCP01/report.json`) and comparison to pre-change report snapshot.

## Plausibility rationale
This implementation reflects expected original source structure: `CMapMng` owns/contains a `CMapTexAnimSet`, and this API is a simple pass-through setter dispatching to `CMapTexAnimSet::SetMapTexAnim(...)`. The change improves codegen without introducing contrived control flow or compiler-coaxing artifacts.

## Technical details
- Added `#include ffcc/maptexanim.h` in `src/map.cpp`.
- Implemented `CMapMng::SetMapTexAnim(...)` using the manager's tex-anim-set storage offset (`0x213DC`) and direct method call.
- Left unrelated TODO functions unchanged.