### PR TITLE
main/system: place System singleton back in system.o

### DIFF
--- a/src/ffcc_globals.cpp
+++ b/src/ffcc_globals.cpp
@@ -30,5 +30,4 @@ CCharaPcs CharaPcs;
 CGamePcs Game;
 CPad Pad;
 CSound Sound;
-CSystem System;
 CUSB USB;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -20,6 +20,7 @@ extern CMath Math;
 extern CTextureMan TextureMan;
 extern CMaterialMan MaterialMan;
 extern CFontMan FontMan;
+CSystem System;
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Moved the CSystem System definition from src/ffcc_globals.cpp to src/system.cpp.
- Kept declaration-only usage in headers unchanged.
- This aligns the singleton ownership with symbol extraction showing System is part of system.o.

## Functions improved
- Unit: main/system
- Function: __sinit_system_cpp (PAL size 32b)
- Before: 