### PR TITLE
ax/AXOut: match __AXOutAiCallback control flow

### DIFF
--- a/src/ax/AXOut.c
+++ b/src/ax/AXOut.c
@@ -85,13 +85,9 @@ void __AXOutNewFrame(u32 lessDspCycles) {
 }
 
 void __AXOutAiCallback(void) {
-    OSTime time = __AXOsTime;
-
     if (__AXOutDspReady == 0) {
-        time = OSGetTime();
+        __AXOsTime = OSGetTime();
     }
-
-    __AXOsTime = time;
 
     if (__AXOutDspReady == 1) {
         __AXOutDspReady = 0;


### PR DESCRIPTION
## Summary
- Simplified `__AXOutAiCallback` in `src/ax/AXOut.c` to only update `__AXOsTime` when `__AXOutDspReady == 0`.
- Removed the local `OSTime` temporary and unconditional store back to `__AXOsTime`.

## Functions improved
- Unit: `main/ax/AXOut`
- Function: `__AXOutAiCallback`

## Match evidence
- Selector baseline (before): `main/ax/AXOut` unit `87.5%`, `__AXOutAiCallback` `91.9%`.
- Current `ninja` report (`build/GCCP01/report.json`):
  - `main/ax/AXOut` fuzzy match: `87.94131%`
  - matched functions: `6/9` (up from `5/9` baseline)
  - `__AXOutAiCallback`: `100.0%`
- Global progress increase in this build: code `193564 -> 193668`, functions `1385 -> 1386`.

## Plausibility rationale
- The change reflects straightforward, natural callback logic: update the timestamp only when DSP isn’t ready and then branch on ready-state handling.
- No compiler-coaxing constructs, no artificial temporaries, and behavior remains consistent with the AX callback state machine.

## Technical details
- Matched callback control flow to target assembly block in `build/GCCP01/asm/ax/AXOut.s` (`__AXOutAiCallback`), specifically removing the unconditional timestamp write path and preserving expected branch structure.
