### PR TITLE
runtime: match duhandler by invoking terminate handler directly

### DIFF
--- a/src/Runtime.PPCEABI.H/NMWException.cp
+++ b/src/Runtime.PPCEABI.H/NMWException.cp
@@ -22,7 +22,7 @@ static terminate_handler thandler = dthandler;
  * @note Address: N/A
  * @note Size: 0x28
  */
-static void duhandler() { terminate(); }
+static void duhandler() { thandler(); }
 
 static unexpected_handler uhandler = duhandler;
 


### PR DESCRIPTION
## Summary
- Updated duhandler__3stdFv in src/Runtime.PPCEABI.H/NMWException.cp to call 	handler() directly instead of routing through 	erminate().
- This aligns generated code with the PAL decomp shape where duhandler directly invokes the terminate handler function pointer.

## Functions Improved
- Unit: main/Runtime.PPCEABI.H/NMWException
- Function: duhandler__3stdFv
  - Before: 74.0%
  - After: 100.0%

## Match Evidence
- 
inja progress moved from:
  - Code: 193564 / 1855300 bytes (1385 / 4733 functions)
  - to Code: 193604 / 1855300 bytes (1386 / 4733 functions)
- Post-change report confirms:
  - duhandler__3stdFv: 100.0%
  - 	erminate__3stdFv: 100.0%

## Plausibility Rationale
- Calling the terminate handler directly in the unexpected-handler trampoline is plausible original runtime source behavior and consistent with compiler runtime style.
- This is a semantic no-op relative to the surrounding handler chain, but improves low-level codegen alignment without introducing contrived control flow.

## Technical Details
- The previous implementation added an extra call indirection (duhandler -> terminate -> thandler).
- The new implementation removes that extra wrapper call in duhandler, matching expected runtime-level thunk generation.