### PR TITLE
main/gx/GXFrameBuf: improve GXSetDispCopyFrame2Field match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -204,10 +204,29 @@ void GXSetTexCopyDst(u16 wd, u16 ht, GXTexFmt fmt, GXBool mipmap) {
     SET_REG_FIELD(1393, __GXData->cpTex, 3, 4, peTexFmt);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A2BA4
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void GXSetDispCopyFrame2Field(GXCopyMode mode) {
+    GXData* gx;
+    u32 reg;
+
     CHECK_GXBEGIN(1410, "GXSetDispCopyFrame2Field");
-    SET_REG_FIELD(1411, __GXData->cpDisp, 2, 12, mode);
-    SET_REG_FIELD(1411, __GXData->cpTex, 2, 12, 0);
+    gx = __GXData;
+
+    reg = gx->cpDisp;
+    reg = (u32)__rlwimi(reg, mode, 12, 18, 19);
+    gx->cpDisp = reg;
+
+    reg = gx->cpTex;
+    reg = (u32)__rlwimi(reg, 0, 12, 18, 19);
+    gx->cpTex = reg;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `GXSetDispCopyFrame2Field` in `src/gx/GXFrameBuf.c` to use explicit BP register field insertion with `__rlwimi` temporaries.
- Added the required `--INFO--` PAL address/size header for the touched function.

## Functions Improved
- Unit: `main/gx/GXFrameBuf`
- Symbol: `GXSetDispCopyFrame2Field`
- Match: `61.9% -> 63.9%` (+2.0)

## Match Evidence
- `objdiff-cli` command: `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetDispCopyFrame2Field`
- Improvement is at the symbol level with identical function size (`40b`) and closer instruction-level behavior around cpDisp/cpTex field updates.

## Plausibility Rationale
- The change preserves the original GX semantics (writing 2-bit frame/field mode into `cpDisp` and clearing the corresponding `cpTex` bits).
- It uses idiomatic register-field insertion logic consistent with the surrounding GX register code style rather than artificial control-flow manipulation.

## Technical Details
- Replaced two `SET_REG_FIELD` writes with explicit load/modify/store on `GXData` fields.
- Kept the operation strictly local to the target function to minimize global codegen noise.
- Verified with `ninja` build and per-symbol `objdiff-cli` diff.
