### PR TITLE
Implement prgobj control and loop-anim query logic

### DIFF
--- a/include/ffcc/partyobj.h
+++ b/include/ffcc/partyobj.h
@@ -59,8 +59,8 @@ public:
     void putTargetParticle(int, int);
     void endTargetParticle();
 
-    void isDispTarget();
-    void isRideTarget();
+    int isDispTarget();
+    int isRideTarget();
     void checkTargetParticle();
     void moveCenterTargetParticle();
 

--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -27,8 +27,8 @@ public:
     void changeSubStat(int subState);
     void addSubStat();
     void reqAnim(int, int, int);
-    void isLoopAnim();
-    void isLoopAnimDirect();
+    int isLoopAnim();
+    int isLoopAnimDirect();
     int playSe3D(int, int, int, int, Vec*);
     void changePrg(int);
     void putParticle(int, int, Vec*, float, int);
@@ -40,7 +40,7 @@ public:
     void rotTarget(CGPrgObj*);
     void dstTargetRot(CGPrgObj*);
     void ClassControl(int, int);
-    void GetClassControl(int);
+    int GetClassControl(int);
     int GetCID();
 
     int m_stateFrameGate;      // 0x518

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -262,22 +262,41 @@ void CGPartyObj::endTargetParticle()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8011F574
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPartyObj::isDispTarget()
+int CGPartyObj::isDispTarget()
 {
-	// TODO
+	if ((m_lastStateId == 2 || m_lastStateId == 6) &&
+	    (*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x668) != 0)) {
+		return 1;
+	}
+
+	return 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8011F520
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPartyObj::isRideTarget()
+int CGPartyObj::isRideTarget()
 {
-	// TODO
+	if ((m_lastStateId == 2 || m_lastStateId == 6) &&
+	    (*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x668) != 0) &&
+	    ((*reinterpret_cast<unsigned char*>(this) + 0x6B8) & 0x80) != 0) {
+		return 1;
+	}
+
+	return 0;
 }
 
 /*

--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -20,12 +20,22 @@ extern unsigned char CFlat[];
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127AF0
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGPrgObj::onCreate()
 {
-	// TODO
+	CGObject::onCreate();
+	m_lastStateId = 0;
+	m_stateArg = 0;
+	m_animFlags &= 0x7F;
+	m_animFlags &= 0xBF;
+	m_animFlags &= 0xDF;
+	m_reqAnimId = -1;
 }
 
 /*
@@ -235,22 +245,38 @@ void CGPrgObj::reqAnim(int animId, int loop, int direct)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012776C
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::isLoopAnim()
+int CGPrgObj::isLoopAnim()
 {
-	// TODO
+	if ((m_animFlags & 0x80) != 0 || (m_animFlags & 0x40) != 0 || !IsLoopAnim(2)) {
+		return 0;
+	}
+
+	return 1;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127720
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::isLoopAnimDirect()
+int CGPrgObj::isLoopAnimDirect()
 {
-	// TODO
+	if ((m_animFlags & 0x40) != 0 || !IsLoopAnim(2)) {
+		return 0;
+	}
+
+	return 1;
 }
 
 /*
@@ -509,12 +535,28 @@ void CGPrgObj::ClassControl(int classControl, int value)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127028
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGPrgObj::GetClassControl(int)
+int CGPrgObj::GetClassControl(int classControl)
 {
-	// TODO
+	if (classControl == 9) {
+		return reinterpret_cast<CGPartyObj*>(this)->isRideTarget();
+	}
+
+	if (classControl < 9) {
+		if (classControl > 7) {
+			return reinterpret_cast<CGPartyObj*>(this)->isDispTarget();
+		}
+	} else if (classControl < 11) {
+		return *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x560);
+	}
+
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented previously stubbed `CGPrgObj` control/animation query functions using PAL Ghidra references and existing class semantics.
- Corrected return signatures in `CGPrgObj` for `isLoopAnim`, `isLoopAnimDirect`, and `GetClassControl` from `void` to `int` to match symbol behavior.
- Implemented `CGPartyObj::isDispTarget` and `CGPartyObj::isRideTarget` (and updated signatures to `int`) because `CGPrgObj::GetClassControl` dispatches to these in PAL.
- Added PAL address/size metadata blocks for all implemented functions.

## Functions Improved
- Unit: `main/prgobj`
  - `onCreate__8CGPrgObjFv`: **4.0% -> 91.72%**
  - `GetClassControl__8CGPrgObjFi`: **4.3% -> 63.869564%**
  - `isLoopAnim__8CGPrgObjFv`: **4.3% -> 74.78261%**
  - `isLoopAnimDirect__8CGPrgObjFv`: now **83.1579%**
- Supporting unit: `main/partyobj`
  - `isDispTarget__10CGPartyObjFv`: now **65.416664%**
  - `isRideTarget__10CGPartyObjFv`: now **43.761906%**

## Match Evidence
- Build passes (`ninja`) after changes.
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - <symbol>` confirms large assembly alignment gains for all touched `CGPrgObj` symbols.
- `main/prgobj` report measure is now `fuzzy_match_percent: 70.33887`.

## Plausibility Rationale
- Changes are source-plausible and semantics-driven rather than compiler coercion:
  - Restored missing game-logic state initialization in `onCreate`.
  - Restored boolean animation-state query behavior in `isLoopAnim` / `isLoopAnimDirect`.
  - Restored class-control query routing through party-object helpers and state flag reads.
  - Used existing object layout and class methods already present in this codebase.

## Technical Details
- `GetClassControl` now follows PAL control flow: class control `9` routes to ride-target query, `8` routes to display-target query, `10` returns control value at `this + 0x560`, otherwise `0`.
- Party target query helpers now check expected state id / target pointer / ride flag fields (`0x520`, `0x668`, `0x6B8`) consistent with PAL decomp behavior.
