### PR TITLE
math: implement CBound frustum checks

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -12,9 +12,9 @@ class CBound
 public:
     CBound();
     void SetFrustum(Vec&, float(*)[4]);
-    void CheckFrustum0(CBound&);
-    void CheckFrustum0(float);
-    void CheckFrustum(Vec&, float(*)[4], float);
+    int CheckFrustum0(CBound&);
+    int CheckFrustum0(float);
+    int CheckFrustum(Vec&, float(*)[4], float);
 };
 
 class SRT


### PR DESCRIPTION
## Summary
- Implemented frustum state setup and checks in `math.cpp` for `CBound`.
- Added concrete implementations for:
  - `CBound::SetFrustum`
  - `CBound::CheckFrustum0(CBound&)`
  - `CBound::CheckFrustum0(float)`
  - `CBound::CheckFrustum(Vec&, float(*)[4], float)`
- Updated `CBound` signatures in `include/ffcc/math.h` to return `int` for frustum check methods, matching decomp behavior and preserving return-driven control flow.
- Added PAL address/size metadata blocks for implemented functions.

## Functions Improved
- Unit: `main/math`
- Symbols:
  - `CheckFrustum0__6CBoundFR6CBound`
  - `CheckFrustum0__6CBoundFf`
  - `CheckFrustum__6CBoundFR3VecPA4_ff`
  - `SetFrustum__6CBoundFR3VecPA4_f`

## Match Evidence
- `CheckFrustum0__6CBoundFR6CBound`: **0.4% -> 9.199%**
- `CheckFrustum0__6CBoundFf`: **0.6% -> 46.726%**
- `CheckFrustum__6CBoundFR3VecPA4_ff`: **100.0%** after implementation (was stubbed)
- `SetFrustum__6CBoundFR3VecPA4_f`: **85.0%** after implementation (was stubbed)
- Build verification: `ninja` passes.

## Plausibility Rationale
- The changes implement expected gameplay/math semantics (view-position + matrix setup, AABB corner projection, frustum plane coding, and clip classification) rather than artificial compiler-shaping patterns.
- Logic follows the existing math/MTX usage style already present in the codebase (`PSMTXCopy`, `PSMTXMultVec`, explicit scalar comparisons).
- Signature correction to `int` is source-plausible because the algorithm computes and returns classification status; keeping `void` would drop meaningful control-flow outputs.

## Technical Notes
- Introduced local static frustum context (`s_f_vpos`, `s_f_lvmtx`) in `math.cpp` as indicated by symbol data/decomp references.
- Preserved branch-heavy corner classification structure to align with target assembly behavior.
- Used `__cntlzw`-based mask decoding pattern to mirror original bit classification flow.
