### PR TITLE
menu_favo: implement FavoInit for major match gain

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -1,15 +1,242 @@
 #include "ffcc/menu_favo.h"
 #include "ffcc/pad.h"
+#include "ffcc/p_game.h"
 #include "ffcc/sound.h"
+#include <string.h>
+
+static unsigned char s_rank[0x20];
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8016343c
+ * PAL Size: 1296b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::FavoInit()
 {
-	// TODO
+	unsigned char uVar1;
+	unsigned char uVar2;
+	unsigned int uVar3;
+	float fVar4;
+	float fVar5;
+	float fVar7;
+	int iVar8;
+	short sVar9;
+	short sVar10;
+	short sVar11;
+	unsigned char* puVar12;
+	unsigned char* puVar13;
+	short* psVar14;
+	int iVar15;
+	int iVar16;
+	int iVar17;
+
+	uVar3 = Game.game.m_scriptFoodBase[0];
+	memset(*(void**)&field_0x850, 0, 0x1008);
+	fVar4 = 1.0f;
+	iVar8 = *(int*)&field_0x850 + 8;
+	iVar16 = 8;
+	do {
+		*(float*)(iVar8 + 0x14) = fVar4;
+		*(float*)(iVar8 + 0x54) = fVar4;
+		*(float*)(iVar8 + 0x94) = fVar4;
+		*(float*)(iVar8 + 0xd4) = fVar4;
+		*(float*)(iVar8 + 0x114) = fVar4;
+		*(float*)(iVar8 + 0x154) = fVar4;
+		*(float*)(iVar8 + 0x194) = fVar4;
+		*(float*)(iVar8 + 0x1d4) = fVar4;
+		iVar8 = iVar8 + 0x200;
+		iVar16 = iVar16 - 1;
+	} while (iVar16 != 0);
+
+	iVar8 = *(int*)&field_0x850;
+	*(int*)(iVar8 + 0x24) = 0x33;
+	*(int*)(iVar8 + 0x20) = 4;
+	*(short*)(iVar8 + 8) = 0x30;
+	fVar4 = 0.0f;
+	*(short*)(iVar8 + 10) = 0x28;
+	fVar5 = 320.0f;
+	*(short*)(iVar8 + 0xc) = 0x158;
+	*(short*)(iVar8 + 0xe) = 0x20;
+	*(float*)(iVar8 + 0x10) = fVar4;
+	*(float*)(iVar8 + 0x14) = fVar4;
+	*(float*)(iVar8 + 0x1c) = fVar5 / (float)*(short*)(iVar8 + 0xc);
+	*(int*)(iVar8 + 0x2c) = 5;
+	*(int*)(iVar8 + 0x30) = 5;
+
+	iVar8 = *(int*)&field_0x850;
+	*(int*)(iVar8 + 100) = 0x32;
+	*(short*)(iVar8 + 0x48) = 0x30;
+	*(short*)(iVar8 + 0x4a) = 0x48;
+	*(short*)(iVar8 + 0x4c) = 0x158;
+	*(short*)(iVar8 + 0x4e) = 200;
+	*(float*)(iVar8 + 0x50) = fVar4;
+	*(float*)(iVar8 + 0x54) = fVar4;
+	*(float*)(iVar8 + 0x5c) = fVar5 / (float)*(short*)(iVar8 + 0x4c);
+	*(int*)(iVar8 + 0x6c) = 5;
+	*(int*)(iVar8 + 0x70) = 5;
+
+	iVar8 = *(int*)&field_0x850;
+	*(int*)(iVar8 + 0xa4) = 0x33;
+	*(short*)(iVar8 + 0x88) = 0x30;
+	*(short*)(iVar8 + 0x8a) = 0x110;
+	*(short*)(iVar8 + 0x8c) = 0x158;
+	*(short*)(iVar8 + 0x8e) = 0x20;
+	*(float*)(iVar8 + 0x90) = fVar4;
+	*(float*)(iVar8 + 0x94) = fVar4;
+	*(float*)(iVar8 + 0x9c) = fVar5 / (float)*(short*)(iVar8 + 0x8c);
+	*(int*)(iVar8 + 0xac) = 5;
+	*(int*)(iVar8 + 0xb0) = 5;
+
+	iVar8 = *(int*)&field_0x850;
+	*(int*)(iVar8 + 0xe4) = 0x45;
+	fVar5 = 1.0f;
+	sVar9 = 0;
+	*(short*)(iVar8 + 200) = 0x18;
+	fVar7 = 0.5f;
+	sVar11 = 6;
+	*(short*)(iVar8 + 0xca) = 0xe;
+	*(short*)(iVar8 + 0xcc) = 0x30;
+	iVar16 = 0x180;
+	*(short*)(iVar8 + 0xce) = 0x30;
+	*(float*)(iVar8 + 0xd0) = fVar4;
+	*(float*)(iVar8 + 0xd4) = fVar4;
+	*(float*)(iVar8 + 0xdc) = fVar5;
+	*(int*)(iVar8 + 0xec) = 0;
+	*(int*)(iVar8 + 0xf0) = 5;
+
+	iVar8 = *(int*)&field_0x850;
+	*(int*)(iVar8 + 0x124) = 0x45;
+	*(short*)(iVar8 + 0x108) = 0x1d;
+	*(short*)(iVar8 + 0x10c) = 0x30;
+	*(short*)(iVar8 + 0x10e) = 0x30;
+	*(short*)(iVar8 + 0x10a) = 0x150 - *(short*)(iVar8 + 0x10e);
+	*(float*)(iVar8 + 0x110) = fVar4;
+	*(float*)(iVar8 + 0x114) = fVar4;
+	*(float*)(iVar8 + 0x11c) = fVar7;
+	*(int*)(iVar8 + 300) = 0;
+	*(int*)(iVar8 + 0x130) = 5;
+
+	iVar8 = *(int*)&field_0x850;
+	*(int*)(iVar8 + 0x174) = 2;
+	*(int*)(iVar8 + 0x164) = 0x2e;
+	*(short*)(iVar8 + 0x148) = 0x18;
+	*(short*)(iVar8 + 0x14a) = 8;
+	*(short*)(iVar8 + 0x14c) = 0x48;
+	*(short*)(iVar8 + 0x14e) = 0x140;
+	*(float*)(iVar8 + 0x150) = fVar4;
+	*(float*)(iVar8 + 0x154) = fVar4;
+	*(int*)(iVar8 + 0x16c) = 0;
+	*(int*)(iVar8 + 0x170) = 5;
+
+	iVar8 = *(int*)&field_0x850;
+	iVar17 = 4;
+	do {
+		psVar14 = (short*)(*(int*)&field_0x850 + iVar16 + 8);
+		psVar14[0x16] = 0;
+		psVar14[0x17] = 2;
+		psVar14[0xe] = 0;
+		psVar14[0xf] = 0x37;
+		sVar11 = sVar11 + 2;
+		*psVar14 = *(short*)(iVar8 + 8) + 0x28;
+		sVar10 = sVar9 + 0x20;
+		psVar14[1] = *(short*)(iVar8 + 10) + sVar9;
+		psVar14[2] = 200;
+		psVar14[3] = 0x28;
+		*(float*)(psVar14 + 4) = fVar4;
+		*(float*)(psVar14 + 6) = fVar4;
+		psVar14[0x12] = 0;
+		psVar14[0x13] = 7;
+		psVar14[0x14] = 0;
+		psVar14[0x15] = 5;
+
+		iVar15 = iVar16 + 0x48;
+		iVar16 = iVar16 + 0x80;
+		psVar14 = (short*)(*(int*)&field_0x850 + iVar15);
+		psVar14[0x16] = 0;
+		psVar14[0x17] = 2;
+		psVar14[0xe] = 0;
+		psVar14[0xf] = 0x37;
+		*psVar14 = *(short*)(iVar8 + 8) + 0x28;
+		sVar9 = sVar9 + 0x40;
+		psVar14[1] = *(short*)(iVar8 + 10) + sVar10;
+		psVar14[2] = 200;
+		psVar14[3] = 0x28;
+		*(float*)(psVar14 + 4) = fVar4;
+		*(float*)(psVar14 + 6) = fVar4;
+		psVar14[0x12] = 0;
+		psVar14[0x13] = 7;
+		psVar14[0x14] = 0;
+		psVar14[0x15] = 5;
+		iVar17 = iVar17 - 1;
+	} while (iVar17 != 0);
+
+	**(short**)&field_0x850 = sVar11;
+
+	memset(s_rank, 0, 0x20);
+	iVar8 = 0;
+	puVar13 = s_rank;
+	s_rank[1] = 0;
+	*(short*)&s_rank[2] = *(short*)(uVar3 + 0x3b8);
+	s_rank[5] = 1;
+	*(short*)&s_rank[6] = *(short*)(uVar3 + 0x3ba);
+	s_rank[9] = 2;
+	*(short*)&s_rank[10] = *(short*)(uVar3 + 0x3bc);
+	s_rank[0xd] = 3;
+	*(short*)&s_rank[14] = *(short*)(uVar3 + 0x3be);
+	s_rank[0x11] = 4;
+	*(short*)&s_rank[18] = *(short*)(uVar3 + 0x3c0);
+	s_rank[0x15] = 5;
+	*(short*)&s_rank[22] = *(short*)(uVar3 + 0x3c2);
+	s_rank[0x19] = 6;
+	*(short*)&s_rank[26] = *(short*)(uVar3 + 0x3c4);
+	s_rank[0x1d] = 7;
+	*(short*)&s_rank[30] = *(short*)(uVar3 + 0x3c6);
+
+	do {
+		iVar17 = iVar8 + 1;
+		iVar16 = 8 - iVar17;
+		puVar12 = s_rank + iVar17 * 4;
+		if (iVar17 < 8) {
+			do {
+				sVar9 = *(short*)(puVar13 + 2);
+				if (sVar9 < *(short*)(puVar12 + 2)) {
+					uVar1 = *puVar13;
+					uVar2 = puVar13[1];
+					*puVar13 = *puVar12;
+					puVar13[1] = puVar12[1];
+					*(short*)(puVar13 + 2) = *(short*)(puVar12 + 2);
+					*puVar12 = uVar1;
+					puVar12[1] = uVar2;
+					*(short*)(puVar12 + 2) = sVar9;
+				}
+				puVar12 = puVar12 + 4;
+				iVar16 = iVar16 - 1;
+			} while (iVar16 != 0);
+		}
+		iVar8 = iVar8 + 1;
+		puVar13 = puVar13 + 4;
+	} while (iVar8 < 8);
+
+	iVar8 = 0;
+	iVar17 = 0;
+	iVar16 = 8;
+	puVar13 = s_rank;
+	do {
+		if ((iVar17 != 0) && (*(short*)(puVar13 - 2) != *(short*)(puVar13 + 2))) {
+			iVar8 = iVar17;
+		}
+		iVar17 = iVar17 + 1;
+		*puVar13 = (char)iVar8 + 1;
+		puVar13 = puVar13 + 4;
+		iVar16 = iVar16 - 1;
+	} while (iVar16 != 0);
+
+	*(short*)(*(int*)((char*)this + 0x82c) + 0x26) = 0;
+	*(char*)(*(int*)((char*)this + 0x82c) + 0xb) = 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::FavoInit()` in `src/menu_favo.cpp` from the PAL decomp reference, replacing the previous TODO stub.
- Added PAL function metadata block for `FavoInit` (`0x8016343c`, `1296b`).
- Added required runtime dependencies for this function (`ffcc/p_game.h`, `string.h`) and the local rank buffer used by menu ranking initialization.

## Functions improved
- Unit: `main/menu_favo`
- Function: `FavoInit__8CMenuPcsFv` (`1296b`)

## Match evidence
- Selector baseline before edit:
  - `FavoInit__8CMenuPcsFv`: `0.3%`
  - `main/menu_favo` current: `16.2%`
- After edit (`ninja` + objdiff/report):
  - `FavoInit__8CMenuPcsFv`: `63.459877%` (`build/GCCP01/report.json`)
  - Unit weighted fuzzy match (computed from function sizes in report): `31.6622%`
- Verification command used:
  - `build/tools/objdiff-cli diff -p . -u main/menu_favo -o - FavoInit__8CMenuPcsFv`

## Plausibility rationale
- The implementation matches the existing source style used in nearby menu code: direct offset-based layout writes, sequential UI element initialization, and script-food ranking sort/setup logic.
- Changes are source-level and semantically meaningful (state initialization + deterministic ranking prep), not compiler-coaxing temporaries or contrived reorderings.

## Technical details
- Recreated full initialization flow:
  - UI element block reset and default alpha/scale setup.
  - Explicit menu widget descriptors for texture ids/positions/timing windows.
  - Dynamic rank table load from `Game.game.m_scriptFoodBase[0] + 0x3b8..0x3c6`.
  - Descending sort with tie-aware rank numbering.
  - Final state flags update at `this+0x82c` control block.
- Full build passes with `ninja`.
