### PR TITLE
pppKeDMat: correct draw callback signature and target matrix offset

### DIFF
--- a/include/ffcc/pppKeDMat.h
+++ b/include/ffcc/pppKeDMat.h
@@ -2,12 +2,13 @@
 #define _PPP_KEDMAT_H_
 
 struct _pppPObject;
+struct _pppCtrlTable;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppKeDMatDraw(_pppPObject* pObject);
+void pppKeDMatDraw(_pppPObject* pObject, void* data, _pppCtrlTable* ctrlTable);
 
 #ifdef __cplusplus
 }

--- a/src/pppKeDMat.cpp
+++ b/src/pppKeDMat.cpp
@@ -11,21 +11,12 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeDMatDraw(_pppPObject* pObject)
+void pppKeDMatDraw(_pppPObject* pObject, void*, _pppCtrlTable* ctrlTable)
 {
-    pppFMATRIX localMatrix;
-    pppFMATRIX worldMatrix;
-    pppFMATRIX resultMatrix;
-    
-    // Load local matrix from pObject structure at offset 0x10
-    localMatrix = *(pppFMATRIX*)((char*)pObject + 0x10);
-    
-    // Copy world matrix from global matrix
-    worldMatrix = *(pppFMATRIX*)&ppvWorldMatrix;
-    
-    // Multiply matrices: result = world * local
-    pppMulMatrix(resultMatrix, worldMatrix, localMatrix);
-    
-    // Copy result to target location at offset 0x80
-    pppCopyMatrix(*(pppFMATRIX*)((char*)pObject + 0x80), resultMatrix);
+    unsigned int targetOffset = *(unsigned int*)(*(char**)((char*)ctrlTable + 0xC) + 4) + 0x80;
+    pppFMATRIX* targetMatrix = (pppFMATRIX*)((char*)pObject + targetOffset);
+    pppFMATRIX* resultMatrix = (pppFMATRIX*)((char*)pObject + 0x40);
+
+    pppMulMatrix(*resultMatrix, *(pppFMATRIX*)&ppvWorldMatrix, *(pppFMATRIX*)((char*)pObject + 0x10));
+    pppCopyMatrix(*targetMatrix, *resultMatrix);
 }


### PR DESCRIPTION
## Summary
- Updated pppKeDMatDraw to use the callback-style signature used by particle draw functions.
- Replaced placeholder matrix flow with control-table-driven destination addressing and in-object temporary matrix usage.
- Kept implementation in plausible source form while matching observed calling/offset behavior.

## Functions improved
- Unit: main/pppKeDMat
- Function: pppKeDMatDraw

## Match evidence
- uild/GCCP01/report.before.json: 18.378948%
- uild/GCCP01/report.json: 85.494736%
- objdiff (uild/tools/objdiff-cli diff -p . -u main/pppKeDMat -o - pppKeDMatDraw): 84.926315%

## Plausibility rationale
- The function now follows the project's callback convention (object, data, ctrl) used in draw/update pipelines.
- Destination matrix selection is driven by control-table offsets rather than hardcoded immediate object offsets.
- Matrix operations remain idiomatic to the codebase (pppMulMatrix then pppCopyMatrix) without contrived coercion-only rewrites.

## Technical notes
- Grounded reconstruction against uild/GCCP01/asm/pppKeDMat.s for register/offset usage (ctrl + 0xC, nested +4, final +0x80).
- Preserved existing INFO header metadata block and extern C linkage semantics through header declaration updates.