### PR TITLE
main/pppSRandHCV: improve pppSRandHCV match to 85.56%

### DIFF
--- a/src/pppSRandHCV.cpp
+++ b/src/pppSRandHCV.cpp
@@ -2,19 +2,11 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern float lbl_803300A0;
 extern s16 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
-
-typedef struct SRandHCVParams {
-	int index;
-	int colorOffset;
-	s16 base[4];
-	u8 flag;
-	u8 pad[3];
-} SRandHCVParams;
 
 /*
  * --INFO--
@@ -56,59 +48,59 @@ void randf(unsigned char flag)
  */
 void pppSRandHCV(void* data1, void* data2, void* data3)
 {
-	SRandHCVParams* params = (SRandHCVParams*)data2;
-	float* rand_values;
-
 	if (lbl_8032ED70 != 0) {
 		return;
 	}
 
-	if (params->index == *(int*)((char*)data1 + 0xc)) {
+	float* target;
+
+	if (*(int*)data2 == *((int*)data1 + 3)) {
 		int** base_ptr = (int**)((char*)data3 + 0xc);
 		int offset = **base_ptr;
-		u8 flag = params->flag;
+		target = (float*)((char*)data1 + offset + 0x80);
+
+		u8 flag = *((u8*)data2 + 0x10);
 		float value;
-		rand_values = (float*)((char*)data1 + offset + 0x80);
 
-		value = RandF__5CMathFv(&math);
+		value = RandF__5CMathFv(math);
 		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
+			value = value + RandF__5CMathFv(math);
 		} else {
 			value = value * lbl_803300A0;
 		}
-		rand_values[0] = value;
+		target[0] = value;
 
-		value = RandF__5CMathFv(&math);
+		value = RandF__5CMathFv(math);
 		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
+			value = value + RandF__5CMathFv(math);
 		} else {
 			value = value * lbl_803300A0;
 		}
-		rand_values[1] = value;
+		target[1] = value;
 
-		value = RandF__5CMathFv(&math);
+		value = RandF__5CMathFv(math);
 		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
+			value = value + RandF__5CMathFv(math);
 		} else {
 			value = value * lbl_803300A0;
 		}
-		rand_values[2] = value;
+		target[2] = value;
 
-		value = RandF__5CMathFv(&math);
+		value = RandF__5CMathFv(math);
 		if (flag != 0) {
-			value = value + RandF__5CMathFv(&math);
+			value = value + RandF__5CMathFv(math);
 		} else {
 			value = value * lbl_803300A0;
 		}
-		rand_values[3] = value;
-	} else if (params->index != *(int*)((char*)data1 + 0xc)) {
+		target[3] = value;
+	} else if (*(int*)data2 != *((int*)data1 + 3)) {
 		int** base_ptr = (int**)((char*)data3 + 0xc);
 		int offset = **base_ptr;
-		rand_values = (float*)((char*)data1 + offset + 0x80);
+		target = (float*)((char*)data1 + offset + 0x80);
 	}
 
+	int color_offset = *((int*)data2 + 1);
 	s16* target_color;
-	int color_offset = params->colorOffset;
 	if (color_offset == -1) {
 		target_color = lbl_801EADC8;
 	} else {
@@ -117,29 +109,29 @@ void pppSRandHCV(void* data1, void* data2, void* data3)
 
 	{
 		s16 current = target_color[0];
-		s16 base = params->base[0];
-		s8 delta = (s8)((float)base * rand_values[0] - (float)current);
+		s16 base = *(s16*)((char*)data2 + 8);
+		s8 delta = (s8)((float)base * target[0] - (float)current);
 		target_color[0] = (s16)(current + delta);
 	}
 
 	{
 		s16 current = target_color[1];
-		s16 base = params->base[1];
-		s8 delta = (s8)((float)base * rand_values[1] - (float)current);
+		s16 base = *(s16*)((char*)data2 + 0xa);
+		s8 delta = (s8)((float)base * target[1] - (float)current);
 		target_color[1] = (s16)(current + delta);
 	}
 
 	{
 		s16 current = target_color[2];
-		s16 base = params->base[2];
-		s8 delta = (s8)((float)base * rand_values[2] - (float)current);
+		s16 base = *(s16*)((char*)data2 + 0xc);
+		s8 delta = (s8)((float)base * target[2] - (float)current);
 		target_color[2] = (s16)(current + delta);
 	}
 
 	{
 		s16 current = target_color[3];
-		s16 base = params->base[3];
-		s8 delta = (s8)((float)base * rand_values[3] - (float)current);
+		s16 base = *(s16*)((char*)data2 + 0xe);
+		s8 delta = (s8)((float)base * target[3] - (float)current);
 		target_color[3] = (s16)(current + delta);
 	}
 }


### PR DESCRIPTION
## Summary
- Refactored `pppSRandHCV` to use direct raw-offset field access, matching patterns used in neighboring PPP units.
- Switched math global access to `extern CMath math[]` and call sites to `RandF__5CMathFv(math)`.
- Kept behavior unchanged while improving codegen alignment and preserving object size.

## Functions improved
- Unit: `main/pppSRandHCV`
- Symbol: `pppSRandHCV`

## Match evidence
- Before: `82.0%` (`736b`)
- After: `85.559784%` (`736b`)
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/pppSRandHCV -o - pppSRandHCV`

## Plausibility rationale
- Changes are source-plausible and idiomatic for this codebase: pointer/offset field access and consistent math-global calling style already appear in nearby `pppSRand*` units.
- No contrived reordering or hardcoded hacks were introduced; the function remains readable and semantically equivalent.

## Technical details
- The improvement came from reducing addressing/register-allocation drift in the random-value generation and color-update paths.
- Remaining mismatch is primarily register/arg ordering noise rather than large control-flow divergence.
