### PR TITLE
main: improve game__FiPPc script-name writes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ void game(int argc, char** argv)
     char** argument;
 
     Game.game.Init();
-    strcpy(reinterpret_cast<char*>(0x8022b7b4), lbl_801d6a40);
+    strcpy(Game.game.m_currentScriptName, lbl_801d6a40);
 
     if (argc != 0) {
         argument = argv + 1;
@@ -40,7 +40,7 @@ void game(int argc, char** argv)
         parseLanguage = false;
         for (i = 1; i < argc; i++) {
             if (copyScriptName) {
-                strcpy(reinterpret_cast<char*>(0x8022b7b4), *argument);
+                strcpy(Game.game.m_currentScriptName, *argument);
                 copyScriptName = false;
             } else if (parseLanguage) {
                 cmp = strcmp(*argument, lbl_801d6a48);


### PR DESCRIPTION
## Summary
- replaced hardcoded script-name destination address in `game(int, char**)` with the named `CGame` member field `Game.game.m_currentScriptName`
- updated both initialization and `-f` argument copy paths to write through the same field

## Functions improved
- Unit: `main/main`
- Symbol: `game__FiPPc`

## Match evidence
- `game__FiPPc`: `77.08403%` -> `82.2437%` (`+5.15967`)
- `main`: `87.72549%` -> `87.72549%` (no regression)
- Evidence command:
  - `build/tools/objdiff-cli diff -p . -u main/main -o - game__FiPPc`

## Plausibility rationale
- `CGame` already defines `m_currentScriptName` (`char[256]`) and this function is clearly populating the current script name.
- Writing via the named member is more likely original source than writing to a fixed absolute address.
- This keeps behavior unchanged while aligning object-relative addressing with the target.

## Technical details
- The previous hardcoded pointer forced a different addressing pattern in generated code.
- Using `Game.game.m_currentScriptName` moves both `strcpy` callsites to object-member addressing, which materially improved the `game__FiPPc` assembly alignment.
