### PR TITLE
math: implement CMath::Hsb2Rgb with corrected signature

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -47,7 +47,7 @@ public:
     void MakeSpline1Dtable(int, float*, float*, float*);
     void Spline1D(int, float, float*, float*, float*);
     void Line1D(int, float, float*, float*);
-    void Hsb2Rgb(int, int, int);
+    unsigned int Hsb2Rgb(int, int, int);
     void DstRot(float, float);
 };
 

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -634,12 +634,68 @@ void CMath::Line1D(int, float, float*, float*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001a3e4
+ * PAL Size: 412b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::Hsb2Rgb(int, int, int)
+unsigned int CMath::Hsb2Rgb(int hue, int saturation, int brightness)
 {
-	// TODO
+    int sat = (saturation * 0xFF) / 100;
+    int val = (brightness * 0xFF) / 100;
+
+    if (sat < 0) {
+        sat = -sat;
+    }
+    if (val < 0) {
+        val = -val;
+    }
+
+    unsigned char v = (unsigned char)val;
+    unsigned int rgba;
+    if (sat == 0) {
+        rgba = ((unsigned int)v << 24) | ((unsigned int)v << 16) | ((unsigned int)v << 8);
+    }
+    else {
+        int m = ((0xFF - sat) * val) / 0xFF;
+        int sector = hue / 60;
+        int fraction = (hue - (sector * 60)) * (val - m);
+        int x = fraction / 60;
+
+        unsigned char lo = (unsigned char)m;
+        unsigned char hi = (unsigned char)val;
+        unsigned char midUp = (unsigned char)(m + x);
+        unsigned char midDown = (unsigned char)(val - x);
+
+        if (hue < 60) {
+            rgba = ((unsigned int)midUp << 24) | ((unsigned int)lo << 16) | ((unsigned int)lo << 8);
+        }
+        else if (hue < 120) {
+            rgba = ((unsigned int)hi << 24) | ((unsigned int)lo << 16) | ((unsigned int)midDown << 8);
+        }
+        else if (hue < 180) {
+            rgba = ((unsigned int)hi << 16) | ((unsigned int)midUp << 8) | (unsigned int)lo;
+            rgba <<= 8;
+        }
+        else if (hue < 240) {
+            rgba = ((unsigned int)midDown << 16) | ((unsigned int)hi << 8) | (unsigned int)lo;
+            rgba <<= 8;
+        }
+        else if (hue < 300) {
+            rgba = ((unsigned int)lo << 16) | ((unsigned int)hi << 8) | (unsigned int)midUp;
+            rgba <<= 8;
+        }
+        else if (hue < 360) {
+            rgba = ((unsigned int)lo << 24) | ((unsigned int)midDown << 16) | ((unsigned int)hi << 8);
+        }
+        else {
+            rgba = 0;
+        }
+    }
+
+    return rgba | 0xFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `CMath::Hsb2Rgb` declaration/definition to return `unsigned int` instead of `void`.
- Replaced the TODO stub with an integer HSV/HSB-to-RGBA implementation using 6 hue sectors and fixed `0xFF` alpha.
- Added PAL function metadata block for this function.

## Functions improved
- Unit: `main/math`
- Function: `Hsb2Rgb__5CMathFiii`

## Match evidence
- Before: `1.0%` (`tools/agent_select_target.py` target listing for `main/math`)
- After: `47.08738%` (`build/GCCP01/report.json` and `objdiff-cli diff` for `Hsb2Rgb__5CMathFiii`)
- Build status: `ninja` passes.

## Plausibility rationale
- This change converts a decomp TODO stub into straightforward production-style color conversion logic that is consistent with the symbol meaning and existing integer-heavy style in this codebase.
- The return-value correction is ABI-plausible for a color-pack function and aligns with the observed decomp behavior (packed RGBA return).

## Technical details
- Used one-shot objdiff to validate the exact symbol:
  - `build/tools/objdiff-cli diff -p . -u main/math -o - --format json-pretty Hsb2Rgb__5CMathFiii`
- Implemented integer paths that map directly to sector branches (`<60`, `<120`, `<180`, `<240`, `<300`, `<360`) and grayscale special-case for zero saturation.
