### PR TITLE
main/ME_AppRequest: match SetRsdIndex and improve RSD list access

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -125,7 +125,7 @@ int CMaterialEditorPcs::AddRsdList(ZLIST* zlist)
  */
 int CMaterialEditorPcs::SetRsdFlag()
 {
-    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xB4);
+    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xD8);
     int index = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC4);
     int* rsd = reinterpret_cast<int*>(list->GetDataIdx(index));
 
@@ -157,9 +157,9 @@ void CMaterialEditorPcs::GetRsdItemR()
  */
 int CMaterialEditorPcs::SetRsdIndex()
 {
-    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xB4);
+    ZLIST* list = reinterpret_cast<ZLIST*>(reinterpret_cast<char*>(this) + 0xD8);
     int index = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC4);
-    int* rsd = reinterpret_cast<int*>(list->GetDataIdx(index));
+    unsigned int* rsd = reinterpret_cast<unsigned int*>(list->GetDataIdx(index));
 
     if (rsd == nullptr) {
         return 0;
@@ -168,7 +168,7 @@ int CMaterialEditorPcs::SetRsdIndex()
         return 0;
     }
 
-    *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xBC) = *rsd;
+    *reinterpret_cast<unsigned int*>(reinterpret_cast<char*>(this) + 0xBC) = *rsd;
     return 1;
 }
 


### PR DESCRIPTION
## Summary
- Updated `CMaterialEditorPcs::SetRsdFlag()` and `CMaterialEditorPcs::SetRsdIndex()` in `src/ME_AppRequest.cpp` to use the same RSD list base offset (`this + 0xD8`) inferred from objdiff.
- Adjusted `SetRsdIndex()` pointer types to unsigned for the loaded/stored RSD handle value, improving generated compare/store instruction selection.

## Functions improved
- `SetRsdIndex__18CMaterialEditorPcsFv`
  - Before: 97.458336% (objdiff)
  - After: 100.0% (objdiff)
- `SetRsdFlag__18CMaterialEditorPcsFv`
  - Before: 75.85% (objdiff)
  - After: 75.9% (objdiff)

## Match evidence
- `tools/objdiff-cli diff -p . -u main/ME_AppRequest -o - SetRsdIndex__18CMaterialEditorPcsFv`
  - Remaining diffs reduced to none (`100.0%`).
- Full project progress after rebuild:
  - Code matched: `194068 -> 194164` bytes
  - Functions matched: `1391 -> 1392`

## Plausibility rationale
- The change is type/signedness and field-offset alignment rather than contrived control-flow coercion.
- Using the same list base offset for both routines is consistent with shared data-path behavior (`GetDataIdx(index)` on the same RSD list state).
- Unsigned compare/store for a handle-like value is source-plausible and yields the expected instruction form.

## Technical details
- Key improvement came from correcting list offset usage in `SetRsdIndex` from `+0xB4` to `+0xD8` and using `unsigned int*` for `rsd`.
- A tested alternative control-flow rewrite in `SetRsdFlag` reduced match score and was reverted.