### PR TITLE
sound: decompile CSound stereo/master-volume setters

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/sound.h"
 
+#include "ffcc/RedSound/RedSound.h"
+
 /*
  * --INFO--
  * Address:	TODO
@@ -42,32 +44,46 @@ void CSound::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c7f20
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSound::SetStereo(int)
+void CSound::SetStereo(int stereo)
 {
-	// TODO
+    reinterpret_cast<CRedSound*>(this)->SetSoundMode((u32)__cntlzw(stereo) >> 5);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c7ef8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSound::SetBgmMasterVolume(int)
+void CSound::SetBgmMasterVolume(int volume)
 {
-	// TODO
+    *reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + 0x22B0) = volume;
+    reinterpret_cast<CRedSound*>(this)->MusicMasterVolume(volume);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c7ed0
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CSound::SetSeMasterVolume(int)
+void CSound::SetSeMasterVolume(int volume)
 {
-	// TODO
+    *reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + 0x22B4) = volume;
+    reinterpret_cast<CRedSound*>(this)->SeMasterVolume(volume);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement three small `CSound` methods in `src/sound.cpp` that were still TODO stubs:
- `SetStereo__6CSoundFi`
- `SetBgmMasterVolume__6CSoundFi`
- `SetSeMasterVolume__6CSoundFi`

The implementations follow the current project style for early sound decomp work: direct field writes via known offsets plus calls into `CRedSound` methods.

## Functions improved
Unit: `main/sound` (`sound.o`)
- `SetStereo__6CSoundFi` -> `90.90909%` match (44b)
- `SetBgmMasterVolume__6CSoundFi` -> `90.0%` match (40b)
- `SetSeMasterVolume__6CSoundFi` -> `90.0%` match (40b)

## Match evidence
Objdiff oneshot commands used:
- `build/tools/objdiff-cli diff -p . -u main/sound -o - SetStereo__6CSoundFi`
- `build/tools/objdiff-cli diff -p . -u main/sound -o - SetBgmMasterVolume__6CSoundFi`
- `build/tools/objdiff-cli diff -p . -u main/sound -o - SetSeMasterVolume__6CSoundFi`

All three symbols now reduce to a single remaining instruction-level delta each (`DIFF_DELETE`), indicating close alignment.

## Plausibility rationale
These changes model likely original source behavior:
- `SetStereo` computes a 0/1 mode and forwards to `CRedSound::SetSoundMode`.
- The master-volume setters store class state and forward to corresponding `CRedSound` APIs.

No artificial control-flow tricks were introduced; this is a straightforward first-pass decomp of small setter methods.

## Technical details
- Added `ffcc/RedSound/RedSound.h` include.
- Updated function headers with PAL address/size metadata from the Ghidra export.
- Kept `SeMaxVolume` untouched in this unit after confirming it is already implemented in `src/cflat_r2system.cpp`.
