### PR TITLE
map: match CMapMng draw-range setters

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -747,22 +747,30 @@ found:
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002f46c
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::SetDrawRangeOctTree(float)
+void CMapMng::SetDrawRangeOctTree(float drawRange)
 {
-	// TODO
+    *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(this) + 0x22A70) = -drawRange;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002f45c
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::SetDrawRangeMapObj(float)
+void CMapMng::SetDrawRangeMapObj(float drawRange)
 {
-	// TODO
+    *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(this) + 0x22A74) = -drawRange;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapMng::SetDrawRangeOctTree(float)` and `CMapMng::SetDrawRangeMapObj(float)` in `src/map.cpp`.
- Both functions now store the negated draw range into the expected `CMapMng` fields using verified in-object offsets.
- Updated both function headers to include PAL address/size metadata.

## Functions improved
- Unit: `main/map`
- `SetDrawRangeOctTree__7CMapMngFf` (`16b`): **25.0% -> 100.0%**
- `SetDrawRangeMapObj__7CMapMngFf` (`16b`): **25.0% -> 100.0%**

## Match evidence
- Symbol-level objdiff (post-change):
  - `SetDrawRangeOctTree__7CMapMngFf`: `100.0%`
  - `SetDrawRangeMapObj__7CMapMngFf`: `100.0%`
- Unit text match (`main/map`, `.text`) improved from **1.789213%** to **1.8992845%**.
- Expected instruction shape for both symbols (`fneg` + `stfs` to the corresponding field) is now matched.

## Plausibility rationale
- The implementation is straightforward, idiomatic setter behavior consistent with the original engine naming and usage in map runtime logic (`SetDrawRange*` called before map reads/calc).
- Change is semantic (actual field update) rather than compiler-coax restructuring.

## Technical details
- Verified target codegen/instruction pattern with `objdiff-cli` before edits.
- Used concrete offsets derived from symbol diff:
  - `SetDrawRangeOctTree`: store to `this + 0x22A70`
  - `SetDrawRangeMapObj`: store to `this + 0x22A74`
- Rebuilt successfully with `ninja` and re-ran objdiff for unit + symbols.
