### PR TITLE
Improve pppFrameAlignmentScale objdiff match via float distance math

### DIFF
--- a/src/pppAlignmentScale.cpp
+++ b/src/pppAlignmentScale.cpp
@@ -46,7 +46,6 @@ struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* align
 {
     float scale;
     float distanceScale;
-    double distance;
     float zero;
     struct _pppMngSt* pppMngSt;
     Vec cameraPos;
@@ -63,8 +62,7 @@ struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* align
         objPos.y = pppMngStPtr->m_matrix.value[1][3];
         objPos.z = pppMngStPtr->m_matrix.value[2][3];
 
-        distance = (double)PSVECDistance(&cameraPos, &objPos);
-        distanceScale = (float)(distance / (double)data->m_unk0x4);
+        distanceScale = PSVECDistance(&cameraPos, &objPos) / data->m_unk0x4;
         scale = FLOAT_80331920;
         if (distanceScale > FLOAT_80331920) {
             scale = (distanceScale - FLOAT_80331920) * data->m_unk0x8 + FLOAT_80331920;


### PR DESCRIPTION
﻿## Summary
- Updated `pppFrameAlignmentScale` in `src/pppAlignmentScale.cpp` to compute `distanceScale` directly in float precision.
- Removed the intermediate `double distance` temporary and the explicit double casts.
- Kept control flow and matrix update behavior unchanged.

## Functions Improved
- Unit: `main/pppAlignmentScale`
- Symbol: `pppFrameAlignmentScale`

## Match Evidence
- `objdiff-cli` (`diff -p . -u main/pppAlignmentScale -o - pppFrameAlignmentScale`):
  - Before: `82.97183%`
  - After: `85.22535%`
  - Delta: `+2.25352%`
- `ninja` build passes after the change.

## Plausibility Rationale
- This is source-plausible cleanup: distance scaling naturally uses float values in this particle path, and the original code likely avoided unnecessary double promotion.
- No contrived temporaries or artificial ordering were introduced.

## Technical Details
- The improvement comes from changing the arithmetic shape around `PSVECDistance` and scale normalization:
  - old: `double` temporary + casted division
  - new: direct float division
- This reduces mismatches around floating-point conversion/division instructions while preserving semantics.
