### PR TITLE
main/pppScreenBreak: implement SB_DrawMeshDLCallback

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/pppScreenBreak.h"
 
 #include "ffcc/graphic.h"
+#include "ffcc/materialman.h"
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
 
@@ -37,12 +38,27 @@ struct UnkC {
 extern int DAT_8032ed70;
 extern int DAT_802381a0;
 extern float FLOAT_80331cc0;
+extern char MaterialMan[];
 extern char s_pppScreenBreak_cpp_801dd4d4[];
 extern CGraphic GraphicsPcs;
 extern _pppMngSt* pppMngStPtr;
 extern _pppEnvSt* pppEnvStPtr;
 
 extern "C" {
+void SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(void*, void*, unsigned int, int, int);
+void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int stage, int texCoord, int texMap,
+                                                                                 int colorChannel);
+void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(
+    int stage, int a, int b, int c, int d);
+void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int stage, int op, int bias,
+                                                                                           int scale, int clamp,
+                                                                                           int reg);
+void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(
+    int stage, int a, int b, int c, int d);
+void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int stage, int op, int bias,
+                                                                                           int scale, int clamp,
+                                                                                           int reg);
+void* __ct__6CColorFUcUcUcUc(void*, unsigned char, unsigned char, unsigned char, unsigned char);
 void SetBlurParameter__11CGraphicPcsFiUcUcUcUcUcs(CGraphic*, int, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, short);
 void* GetCharaHandlePtr__FP8CGObjectl(void*, long);
 int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void*);
@@ -72,12 +88,71 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012de28
+ * PAL Size: 776b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SB_DrawMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*) [4])
+void SB_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void*, int meshIndex, int drawListIndex, float (*) [4])
 {
-	// TODO
+    u8* meshData = *(u8**)((u8*)model + 0xAC) + (meshIndex * 0x14);
+    u8* refData = *(u8**)(meshData + 8);
+    u8* displayList = *(u8**)(refData + 0x50) + (drawListIndex * 0xC);
+
+    if (*(char*)((u8*)param_2 + 0x24) != '\0') {
+        void* colorPtr;
+        u8 colorStorage0[4];
+        u32 colorPacked0;
+        u8 colorStorage1[4];
+        u32 colorPacked1;
+        void* material;
+        void* materialSet = *(void**)((u8*)*(u8**)((u8*)model + 0xA4) + 0x24);
+        unsigned short materialIdx = *(unsigned short*)(displayList + 8);
+        material = (*(void***)((u8*)materialSet + 0x18))[materialIdx];
+
+        SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(MaterialMan, materialSet, materialIdx, 1, 0);
+        GXSetArray((GXAttr)0xB, (void*)((u8*)param_2 + 0x28), 4);
+
+        if (*(short*)((u8*)material + 0x18) == 1) {
+            GXSetNumChans(1);
+            _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
+            colorPtr = __ct__6CColorFUcUcUcUc(colorStorage0, 0xA0, 0xA0, 0xA0, 0xA0);
+            colorPacked0 = *(u32*)colorPtr;
+            GXSetTevKColor((GXTevKColorID)0, *(GXColor*)&colorPacked0);
+            GXSetTevKColorSel((GXTevStageID)0, (GXTevKColorSel)0xC);
+            GXSetTevKAlphaSel((GXTevStageID)0, (GXTevKAlphaSel)0x1C);
+            _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 10, 0xE, 10, 0xF);
+            _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0xC, 0, 0, 1, 0);
+            _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 7, 4, 5, 7);
+            _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+
+            _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(1, 0, 0, 4);
+            colorPtr = __ct__6CColorFUcUcUcUc(colorStorage1, 0x60, 0x60, 0x60, *(u8*)((u8*)param_2 + 0x2B));
+            colorPacked1 = *(u32*)colorPtr;
+            GXSetTevKColor((GXTevKColorID)1, *(GXColor*)&colorPacked1);
+            GXSetTevKColorSel((GXTevStageID)1, (GXTevKColorSel)0xD);
+            GXSetTevKAlphaSel((GXTevStageID)1, (GXTevKAlphaSel)0x1D);
+            _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(1, 0xF, 0xE, 0, 0xF);
+            _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 0, 1, 0);
+            _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(1, 7, 4, 5, 7);
+            _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 0, 1, 0);
+
+            _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(2, 0, 0, 4);
+            GXSetTevKAlphaSel((GXTevStageID)2, (GXTevKAlphaSel)0x1D);
+            _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(2, 0xF, 0xC, 8, 0);
+            _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(2, 0, 0, 0, 1, 0);
+            _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(2, 7, 7, 7, 6);
+            _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(2, 0, 0, 0, 1, 0);
+
+            GXSetNumTevStages(3);
+            GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);
+            GXLoadTexObj((_GXTexObj*)*(void**)((u8*)param_2 + 0x10), (GXTexMapID)0);
+        }
+
+        GXCallDisplayList(*(void**)displayList, *(unsigned int*)(displayList + 4));
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `SB_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f` in `src/pppScreenBreak.cpp` using existing callback and pointer-layout patterns.
- Added required TEV/material helper extern declarations used by this callback.
- Updated the function INFO block with PAL address/size metadata.

## Functions improved
- Unit: `main/pppScreenBreak`
- Symbol: `SB_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`
- Size: `776b`

## Match evidence
- Before: `0.5%` (from `tools/agent_select_target.py` for this symbol)
- After: `83.798965%`
- Command: `build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - SB_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`

## Plausibility rationale
- The flow matches established PPP render-callback patterns already used in this codebase: material bind, GX setup, conditional TEV path, and display-list draw.
- Offset-based field access style is consistent with nearby partially recovered model/material code.
- The change avoids artificial compiler coaxing and follows expected source-level render logic.

## Technical details
- Reconstructed control flow as: fetch display-list entry -> gate on active flag -> bind material -> optional TEV override when material flag at `+0x18` is `1` -> draw display list.
- Preserved constant values/call order from reference decomp for instruction alignment while keeping the code maintainable.
- Verified with `ninja` build and objdiff oneshot JSON.
