### PR TITLE
gx: improve GXSetDispCopyFrame2Field match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -221,11 +221,11 @@ void GXSetDispCopyFrame2Field(GXCopyMode mode) {
     gx = __GXData;
 
     reg = gx->cpDisp;
-    reg = (u32)__rlwimi(reg, mode, 12, 18, 19);
+    reg = (reg & 0xFFFFCFFF) | ((u32)mode << 12);
     gx->cpDisp = reg;
 
     reg = gx->cpTex;
-    reg = (u32)__rlwimi(reg, 0, 12, 18, 19);
+    reg &= 0xFFFFCFFF;
     gx->cpTex = reg;
 }
 


### PR DESCRIPTION
## Summary
- Reworked `GXSetDispCopyFrame2Field` in `src/gx/GXFrameBuf.c` to use explicit bitmask/or operations instead of `__rlwimi` helper calls.
- Behavior is unchanged: update `cpDisp` frame2field bits from `mode`, then clear the same bits in `cpTex`.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Symbol: `GXSetDispCopyFrame2Field`

## Match evidence
- `GXSetDispCopyFrame2Field`: **63.9% -> 93.4%** (`+29.5`)
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetDispCopyFrame2Field`
- Remaining symbol diff is very small (2 arg mismatches, 1 replace) indicating closer instruction shape/alignment.

## Plausibility rationale
- The new code is idiomatic low-level C for hardware register bitfield updates (`reg & mask`, `| value<<shift`).
- This style is common in original SDK-era source and avoids contrived compiler-coaxing constructs.
- The transformation improves codegen while keeping semantics straightforward and maintainable.

## Technical details
- Prior version used `__rlwimi` wrapper assignments for both register updates.
- Rewriting to explicit mask/or produced much closer PPC instruction selection for this symbol.