### PR TITLE
main/pppDrawMatrixFront: fix scale loads to reach exact match

### DIFF
--- a/src/pppDrawMatrixFront.cpp
+++ b/src/pppDrawMatrixFront.cpp
@@ -14,26 +14,22 @@
 void pppDrawMatrixFront(_pppPObject* param_1)
 {
     Vec localPos;
-    
-    // Apply scale transformation from global manager state  
+
     PSMTXScaleApply(
         *(Mtx*)((char*)param_1 + 0x10),
         *(Mtx*)((char*)param_1 + 0x40),
-        pppMngStPtr->m_scale.x,
-        pppMngStPtr->m_scale.y, 
-        pppMngStPtr->m_scale.z
+        *(f32*)((char*)pppMngStPtr + 0x28),
+        *(f32*)((char*)pppMngStPtr + 0x2C),
+        *(f32*)((char*)pppMngStPtr + 0x30)
     );
-    
-    // Extract position from local matrix (offsets from assembly analysis)
+
     localPos.x = *(float*)((char*)param_1 + 0x1c);
-    localPos.y = *(float*)((char*)param_1 + 0x2c);  
+    localPos.y = *(float*)((char*)param_1 + 0x2c);
     localPos.z = *(float*)((char*)param_1 + 0x3c);
-    
-    // Transform position to world space
+
     PSMTXMultVec(ppvWorldMatrix, &localPos, &localPos);
-    
-    // Store transformed position (offsets from assembly analysis)
+
     *(float*)((char*)param_1 + 0x4c) = localPos.x;
-    *(float*)((char*)param_1 + 0x5c) = localPos.y; 
+    *(float*)((char*)param_1 + 0x5c) = localPos.y;
     *(float*)((char*)param_1 + 0x6c) = localPos.z;
 }


### PR DESCRIPTION
## Summary
- Updated `pppDrawMatrixFront` to load manager scale using direct offsets (`+0x28/+0x2C/+0x30`) instead of the current tentative struct field layout.
- Removed non-essential explanatory comments so the function is a clean source-style implementation.

## Functions improved
- Unit: `main/pppDrawMatrixFront`
- Symbol: `pppDrawMatrixFront`

## Match evidence
- Before: `matched_code_percent = 0.0%` for `main/pppDrawMatrixFront` (only fuzzy match reported: `99.911766%`).
- After: `matched_code_percent = 100.0%`, `matched_functions_percent = 100.0%` (136/136 code bytes, 1/1 function).
- `objdiff-cli diff` symbol check: left/right `pppDrawMatrixFront` are both `136` bytes with `34` instructions.
- Assembly-level comparison showed the resolved mismatch was scale loads from manager offsets (`0x64/0x68/0x6C` -> `0x28/0x2C/0x30`).

## Plausibility rationale
- This change aligns with existing nearby PPP code patterns that already use direct manager offsets for this data path (for example `pppWDrawMatrix`).
- The fix corrects likely interim struct-guess drift rather than introducing compiler-coaxing logic; behavior remains straightforward and source-plausible.

## Technical details
- Root cause: `_pppMngSt` is still partially reconstructed, and using `pppMngStPtr->m_scale` emitted incorrect field offsets in this TU.
- Implementation: switched only the three scale loads in `PSMTXScaleApply` to explicit pointer-offset loads, preserving control flow and call structure.