### PR TITLE
main/texanim: implement CPtrArray specializations for CTexAnim/CTexAnimSeq

### DIFF
--- a/include/ffcc/texanim.h
+++ b/include/ffcc/texanim.h
@@ -2,7 +2,6 @@
 #define _FFCC_PPP_TEXANIM_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/ptrarray.h"
 
 class CMaterialSet;
 class CChunkFile;

--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -1,10 +1,467 @@
 #include "ffcc/texanim.h"
+#include "ffcc/system.h"
+
+#include <string.h>
+
+template <class T>
+class CPtrArray
+{
+public:
+    int m_size;
+    int m_numItems;
+    int m_defaultSize;
+    T* m_items;
+    CMemory::CStage* m_stage;
+    int m_growCapacity;
+
+    CPtrArray();
+    virtual ~CPtrArray();
+
+    bool Add(T item);
+    int GetSize();
+    void RemoveAll();
+    void ReleaseAndRemoveAll();
+    T operator[](unsigned long index);
+    void SetStage(CMemory::CStage* stage);
+    int setSize(unsigned long newSize);
+    T GetAt(unsigned long index);
+};
+
+extern "C" void __dl__FPv(void*);
+extern "C" void __dla__FPv(void*);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
+
+extern CMemory Memory;
+extern CSystem System;
+
+static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
+static char s_ptrarray_grow_error[] = "CPtrArray grow error";
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80044ae8
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
+template <>
+CPtrArray<CTexAnimSeq*>::CPtrArray()
+{
+    m_size = 0;
+    m_numItems = 0;
+    m_defaultSize = 0x10;
+    m_items = 0;
+    m_stage = 0;
+    m_growCapacity = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044b1c
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CTexAnimSeq*>::~CPtrArray()
+{
+    RemoveAll();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044b78
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+bool CPtrArray<CTexAnimSeq*>::Add(CTexAnimSeq* item)
+{
+    if (setSize(m_numItems + 1) != 0) {
+        m_items[m_numItems] = item;
+        m_numItems = m_numItems + 1;
+        return true;
+    }
+    return false;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044be8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CTexAnimSeq*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044bf0
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexAnimSeq*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044c3c
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexAnimSeq*>::ReleaseAndRemoveAll()
+{
+    int offset = 0;
+
+    for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
+        int* item = *(int**)((int)m_items + offset);
+        if (item != 0) {
+            int refCount = item[1];
+            item[1] = refCount - 1;
+            if ((refCount - 1 == 0) && (item != 0)) {
+                (*(void (**)(int*, int))(*item + 8))(item, 1);
+            }
+            *(unsigned int*)((int)m_items + offset) = 0;
+        }
+        offset += 4;
+    }
+
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044d08
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CTexAnimSeq* CPtrArray<CTexAnimSeq*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044d28
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexAnimSeq*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044d30
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CTexAnimSeq*>::setSize(unsigned long newSize)
+{
+    CTexAnimSeq** newItems;
+
+    if ((unsigned long)m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
+            m_size = m_size << 1;
+        }
+
+        newItems = (CTexAnimSeq**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, (unsigned long)(m_size << 2), m_stage, s_collection_ptrarray_h, 0xFA, 0);
+        if (newItems == 0) {
+            return 0;
+        }
+
+        if (m_items != 0) {
+            memcpy(newItems, m_items, m_numItems << 2);
+        }
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+        m_items = newItems;
+    }
+
+    return 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80045158
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CTexAnimSeq* CPtrArray<CTexAnimSeq*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044e20
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CTexAnim*>::CPtrArray()
+{
+    m_size = 0;
+    m_numItems = 0;
+    m_defaultSize = 0x10;
+    m_items = 0;
+    m_stage = 0;
+    m_growCapacity = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044e54
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CPtrArray<CTexAnim*>::~CPtrArray()
+{
+    RemoveAll();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044eb0
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+bool CPtrArray<CTexAnim*>::Add(CTexAnim* item)
+{
+    if (setSize(m_numItems + 1) != 0) {
+        m_items[m_numItems] = item;
+        m_numItems = m_numItems + 1;
+        return true;
+    }
+    return false;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044f20
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CTexAnim*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044f28
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexAnim*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80044f74
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexAnim*>::ReleaseAndRemoveAll()
+{
+    int offset = 0;
+
+    for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
+        int* item = *(int**)((int)m_items + offset);
+        if (item != 0) {
+            int refCount = item[1];
+            item[1] = refCount - 1;
+            if ((refCount - 1 == 0) && (item != 0)) {
+                (*(void (**)(int*, int))(*item + 8))(item, 1);
+            }
+            *(unsigned int*)((int)m_items + offset) = 0;
+        }
+        offset += 4;
+    }
+
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80045040
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CTexAnim* CPtrArray<CTexAnim*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80045060
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CTexAnim*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80045068
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CTexAnim*>::setSize(unsigned long newSize)
+{
+    CTexAnim** newItems;
+
+    if ((unsigned long)m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
+            m_size = m_size << 1;
+        }
+
+        newItems = (CTexAnim**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, (unsigned long)(m_size << 2), m_stage, s_collection_ptrarray_h, 0xFA, 0);
+        if (newItems == 0) {
+            return 0;
+        }
+
+        if (m_items != 0) {
+            memcpy(newItems, m_items, m_numItems << 2);
+        }
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+        m_items = newItems;
+    }
+
+    return 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80045168
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CTexAnim* CPtrArray<CTexAnim*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
 CTexAnimSet::CTexAnimSet()
 {
 	// TODO


### PR DESCRIPTION
## Summary
- Implemented explicit `CPtrArray` template specializations in `src/texanim.cpp` for `CTexAnimSeq*` and `CTexAnim*`.
- Added missing methods emitted by the original object (`__ct__`, `__dt__`, `Add`, `GetSize`, `RemoveAll`, `ReleaseAndRemoveAll`, `operator[]`, `SetStage`, `setSize`, `GetAt`).
- Added PAL address/size metadata blocks for each newly implemented function.
- Removed unused `#include "ffcc/ptrarray.h"` from `include/ffcc/texanim.h` so `texanim.cpp` can define the object-local `CPtrArray` layout used in this unit.

## Functions Improved
Unit: `main/texanim`

Primary targeted symbols (selector baseline -> current objdiff):
- `__ct__25CPtrArray<P11CTexAnimSeq>Fv`: `0.0%` -> `98.76923%`
- `__dt__25CPtrArray<P11CTexAnimSeq>Fv`: `0.0%` -> `99.521736%`
- `Add__25CPtrArray<P11CTexAnimSeq>FP11CTexAnimSeq`: `0.0%` -> `85.32143%`

Additional newly implemented symbols now matching strongly:
- `GetSize__25CPtrArray<P11CTexAnimSeq>Fv`: `100.0%`
- `RemoveAll__25CPtrArray<P11CTexAnimSeq>Fv`: `99.8421%`
- `setSize__25CPtrArray<P11CTexAnimSeq>FUl`: `91.05%`
- `__ct__21CPtrArray<P8CTexAnim>Fv`: `98.76923%`
- `__dt__21CPtrArray<P8CTexAnim>Fv`: `99.521736%`
- `Add__21CPtrArray<P8CTexAnim>FP8CTexAnim`: `85.32143%`
- `GetAt/__vc__/SetStage` variants for both arrays: up to `100.0%`

## Match Evidence
- Selector baseline for `main/texanim`: `5.1%` (reported by `tools/agent_select_target.py`).
- After this change (`build/GCCP01/report.json`):
  - `fuzzy_match_percent`: `35.921215`
  - `total_functions`: `31`

Objdiff command form used:
- `build/tools/objdiff-cli diff -p . -u main/texanim -o - <symbol>`

## Plausibility Rationale
- The implementation follows established in-repo patterns for object-local `CPtrArray` specializations (`textureman.cpp`, `mapanim.cpp`): same field semantics, allocation path via `_Alloc__7CMemory...`, growth logic, release/removal behavior, and stage propagation.
- Changes are structural/type-correct for this module and avoid compiler-only coercion tricks.

## Technical Notes
- The TU-local `CPtrArray` uses a virtual destructor so Metrowerks emits the expected vtable-bearing layout for this unit.
- `setSize` and `ReleaseAndRemoveAll` follow known engine idioms (`System.Printf` on zero grow-capacity, memcpy + `__dla__` swap, refcount decrement + virtual release when count reaches zero).
