### PR TITLE
alloc: improve link_new_block match in MSL alloc

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -323,6 +323,7 @@ void deallocate_from_fixed_pools(__mem_pool_obj* pool_obj, void* ptr, unsigned l
  */
 static Block* link_new_block(__mem_pool_obj* pool_obj, unsigned long size) {
     Block* block;
+    Block* start;
     unsigned long aligned_size;
 
     aligned_size = (size + 0x1FUL) & 0xFFFFFFF8;
@@ -336,17 +337,17 @@ static Block* link_new_block(__mem_pool_obj* pool_obj, unsigned long size) {
     }
 
     Block_construct(block, aligned_size);
-    if (pool_obj->start_ == 0) {
-        pool_obj->start_ = block;
+    start = pool_obj->start_;
+    if (start == 0) {
         block->prev = block;
         block->next = block;
     } else {
-        block->prev = pool_obj->start_->prev;
+        block->prev = start->prev;
         block->prev->next = block;
-        block->next = pool_obj->start_;
+        block->next = start;
         block->next->prev = block;
-        pool_obj->start_ = block;
     }
+    pool_obj->start_ = block;
     return block;
 }
 


### PR DESCRIPTION
## Summary
- Refactored link_new_block in src/MSL_C/PPCEABI/bare/H/alloc.c to use a canonical circular-list insertion flow.
- Introduced a local start pointer and moved pool_obj->start_ = block to a single post-branch assignment.
- Kept behavior identical while changing control flow and store ordering to better match original codegen.

## Functions improved
- Unit: main/MSL_C/PPCEABI/bare/H/alloc
- Symbol: link_new_block

## Match evidence
- link_new_block: **81.62222% -> 88.35555%**
- Unit symbol deltas: only link_new_block changed; no regressions in other functions within the unit.
- Validation command:
  - uild/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/alloc -o - link_new_block

## Plausibility rationale
- The new code uses a standard circular doubly-linked-list prepend pattern that is idiomatic for allocator block rings.
- No contrived temporaries, offset tricks, or non-idiomatic constructs were introduced.
- The edit is source-plausible and maintainable while improving assembly alignment.

## Technical notes
- This specifically aligns conditional structure and write sequencing for list head updates.
- Full project build remains successful with 
inja.