### PR TITLE
gx/GXFrameBuf: improve GXSetCopyClear match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -349,20 +349,29 @@ u32 GXSetDispCopyYScale(f32 vscale) {
 }
 
 void GXSetCopyClear(GXColor clear_clr, u32 clear_z) {
-    u32 reg;
+    GXData* gx;
+    u32 regA;
+    u32 regGB;
 
     CHECK_GXBEGIN(1596, "GXSetCopyClear");
     ASSERTMSGLINE(1598, clear_z <= 0xFFFFFF, "GXSetCopyClear: Z clear value is out of range");
 
-    reg = ((u32)clear_clr.a << 8) | clear_clr.r | 0x4F000000;
-    GX_WRITE_RAS_REG(reg);
+    regA = ((u32)clear_clr.a << 8) | clear_clr.r;
+    regA = (regA & 0xFFFF) | 0x4F000000;
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(regA);
 
-    reg = ((u32)clear_clr.g << 8) | clear_clr.b | 0x50000000;
-    GX_WRITE_RAS_REG(reg);
+    regGB = ((u32)clear_clr.g << 8) | clear_clr.b;
+    regGB = (regGB & 0xFFFF) | 0x50000000;
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(regGB);
 
-    reg = (clear_z & 0xFFFFFF) | 0x51000000;
-    GX_WRITE_RAS_REG(reg);
-    __GXData->bpSentNot = 0;
+    regA = (clear_z & 0xFFFFFF) | 0x51000000;
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(regA);
+
+    gx = __GXData;
+    gx->bpSentNot = 0;
 }
 
 void GXSetCopyFilter(GXBool aa, const u8 sample_pattern[12][2], GXBool vf, const u8 vfilter[7]) {


### PR DESCRIPTION
## Summary
- Reworked GXSetCopyClear register write sequencing in src/gx/GXFrameBuf.c.
- Switched from GX_WRITE_RAS_REG helper calls to explicit FIFO writes (GX_WRITE_U8 + GX_WRITE_U32) with separated color temporaries.
- Kept behavior identical: writes 0x4F/0x50/0x51 BP regs and clears pSentNot.

## Functions Improved
- Unit: main/gx/GXFrameBuf
- Symbol: GXSetCopyClear

## Match Evidence
- GXSetCopyClear: **60.884617% -> 62.230770%** (**+1.346153%**)
- Verified with:
  - 
inja
  - uild/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetCopyClear
- Full unit spot-check showed no regressions in other symbols.

## Plausibility Rationale
- The new source remains idiomatic GX code: explicit BP FIFO packet emission is common in this codebase and SDK-level code.
- Changes are type/sequence shaping only; no contrived control flow or behavior changes were introduced.
- Register payload values and side effects are preserved exactly.