### PR TITLE
Improve pppFrameCrystal2 match by aligning allocation control flow

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -91,83 +91,72 @@ void pppDestructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
  */
 void pppFrameCrystal2(pppCrystal2* pppCrystal2, UnkB* param_2, UnkC* param_3)
 {
-    int* refractionData;
-    u32 y;
-    u32 x;
+    if ((DAT_8032ed70 == 0) && (param_2->m_payload[0] != 0)) {
+        int* refractionData = (int*)((char*)pppCrystal2 + param_3->m_serializedDataOffsets[2] + 8);
+        if (refractionData[0] == 0) {
+            u32 y;
+            u32 x;
+            refractionData[0] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                0x18, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xA8);
 
-    if ((DAT_8032ed70 != 0) || (param_2->m_payload[0] == 0)) {
-        return;
-    }
+            int* textureInfo = (int*)refractionData[0];
+            const int textureSize = (int)GXGetTexBufferSize(0x20, 0x20, GX_TF_IA8, GX_FALSE, 0);
+            textureInfo[0] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                textureSize, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xAD);
+            textureInfo[1] = GX_TF_IA8;
+            textureInfo[2] = 0x20;
+            textureInfo[3] = 0x20;
+            textureInfo[4] = 0x100;
+            textureInfo[5] = textureSize;
 
-    refractionData = (int*)((char*)pppCrystal2 + param_3->m_serializedDataOffsets[2] + 8);
-    if (refractionData[0] != 0) {
-        return;
-    }
+            const float start = -1.0f;
+            const float stepX = 2.0f / (float)(textureInfo[2] - 1);
+            const float stepY = 2.0f / (float)(textureInfo[3] - 1);
+            float yy = start;
 
-    refractionData[0] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(0x18, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xA8);
-    if (refractionData[0] == 0) {
-        return;
-    }
-
-    int* textureInfo = (int*)refractionData[0];
-    const int textureSize = (int)GXGetTexBufferSize(0x20, 0x20, GX_TF_IA8, GX_FALSE, 0);
-    textureInfo[0] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(textureSize, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xAD);
-    textureInfo[1] = GX_TF_IA8;
-    textureInfo[2] = 0x20;
-    textureInfo[3] = 0x20;
-    textureInfo[4] = 0x100;
-    textureInfo[5] = textureSize;
-
-    if (textureInfo[0] == 0) {
-        return;
-    }
-
-    const float start = -1.0f;
-    const float step = 2.0f / (float)(textureInfo[2] - 1);
-    float yy = start;
-
-    for (y = 0; y < (u32)textureInfo[3]; ++y) {
-        float xx = start;
+            for (y = 0; y < (u32)textureInfo[3]; ++y) {
+                float xx = start;
         const float y2 = yy * yy;
 
-        for (x = 0; x < (u32)textureInfo[2]; ++x) {
-            float magnitude = xx * xx + y2;
-            if (magnitude < 0.0f) {
-                magnitude = 0.0f;
+                for (x = 0; x < (u32)textureInfo[2]; ++x) {
+                    float magnitude = xx * xx + y2;
+                    if (magnitude < 0.0f) {
+                        magnitude = 0.0f;
+                    }
+
+                    float normal = 0.0f;
+                    if (magnitude > 1.0f) {
+                        normal = 1.0f / sqrtf(magnitude);
+                    } else if (magnitude > 0.0f) {
+                        normal = sqrtf(magnitude);
+                    }
+
+                    if (normal > 0.8f) {
+                        normal = 0.8f;
+                    }
+
+                    const u8 nx = (u8)__cvt_fp2unsigned((double)(xx * normal * 127.0f + 128.0f));
+                    const u8 ny = (u8)__cvt_fp2unsigned((double)(yy * normal * 127.0f + 128.0f));
+                    u8* pixel = (u8*)(textureInfo[0] +
+                        (y >> 2) * (textureInfo[2] & 0x1ffffffcU) * 8 +
+                        (x & 0x1ffffffc) * 8 +
+                        ((x & 3) + (y & 3) * 4) * 2);
+
+                    pixel[0] = nx;
+                    pixel[1] = ny;
+                    xx += stepX;
+                }
+
+                yy += stepY;
             }
 
-            float normal = 0.0f;
-            if (magnitude > 1.0f) {
-                normal = 1.0f / sqrtf(magnitude);
-            } else if (magnitude > 0.0f) {
-                normal = sqrtf(magnitude);
-            }
-
-            if (normal > 0.8f) {
-                normal = 0.8f;
-            }
-
-            const u8 nx = (u8)__cvt_fp2unsigned((double)(xx * normal * 127.0f + 128.0f));
-            const u8 ny = (u8)__cvt_fp2unsigned((double)(yy * normal * 127.0f + 128.0f));
-            u8* pixel = (u8*)(textureInfo[0] +
-                (y >> 2) * (textureInfo[2] & 0x1ffffffcU) * 8 +
-                (x & 0x1ffffffc) * 8 +
-                ((x & 3) + (y & 3) * 4) * 2);
-
-            pixel[0] = nx;
-            pixel[1] = ny;
-            xx += step;
-        }
-
-        yy += step;
-    }
-
-    DCFlushRange((void*)textureInfo[0], textureInfo[5]);
-    refractionData[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(0x20, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xB5);
-
-    if (refractionData[1] != 0) {
+            DCFlushRange((void*)textureInfo[0], textureInfo[5]);
+            refractionData[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                0x20, pppEnvStPtr->m_stagePtr, s_pppCrystal2Cpp, 0xB5);
+            
         GXInitTexObj((GXTexObj*)refractionData[1], (void*)textureInfo[0], (u16)textureInfo[2], (u16)textureInfo[3],
                      GX_TF_IA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Reworked pppFrameCrystal2 setup flow in src/pppCrystal2.cpp to better match original allocation/init sequencing.
- Removed extra defensive early-return branches in this routine and kept texture object init in the main setup path.
- Kept changes local to refraction texture setup/generation.

## Functions improved
- Unit: main/pppCrystal2
- Symbol: pppFrameCrystal2
- Match: 50.294373% -> 69.49351%

## Match evidence
- Command: build/tools/objdiff-cli diff -p . -u main/pppCrystal2 -o - pppFrameCrystal2
- Before: 50.294373%
- After: 69.49351%
- Improvement reflects better control-flow/call-order alignment in the setup block.

## Plausibility rationale
- The previous version had additional null-check exits in this path that diverged from the reference flow.
- The updated version uses a straightforward initialization sequence: allocate data, fill texture metadata, generate texels, flush cache, initialize GX texture object.
- No contrived temporaries or non-idiomatic coercions were introduced.

## Technical details
- Unified top-level gating on effect-enabled state and missing cached data.
- Aligned allocation order and GXInitTexObj call placement with the decompilation reference.
- Split X/Y stepping expressions by width/height-based increments.
