### PR TITLE
main/pppLaser: first-pass decomp for pppFrameLaser

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -1,14 +1,24 @@
 #include "ffcc/pppLaser.h"
 #include "ffcc/math.h"
+#include "ffcc/map.h"
 #include "ffcc/p_game.h"
 #include "ffcc/partMng.h"
+
+#include <string.h>
 
 extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 extern struct _pppMngSt* pppMngStPtr;
 extern CMath Math;
 extern f32 FLOAT_80333428;
 extern f32 FLOAT_80333448;
+extern f32 FLOAT_8033344c;
+extern f32 FLOAT_80333450;
+extern f32 FLOAT_80333454;
+extern f32 FLOAT_80333458;
 extern f32 FLOAT_8033345c;
+extern f64 DOUBLE_80333440;
+extern s32 DAT_8032ed70;
+extern CMapMng MapMng;
 
 extern "C" {
 f32 RandF__5CMathFf(f32, CMath*);
@@ -16,7 +26,40 @@ int GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(CGame*, PPPIFPARAM*, int*, 
 void GetTargetCursor__5CGameFiR3VecR3Vec(CGame*, int, Vec*, Vec*);
 void* GetPartyObj__5CGameFi(CGame*, int);
 void pppStopSe__FP9_pppMngStP7PPPSEST(_pppMngSt*, PPPSEST*);
+void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
+void pppCalcFrameShape__FPlRsRsRss(long*, short&, short&, short&, short);
+void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
+void pppSubVector__FR3Vec3Vec3Vec(Vec*, const Vec*, const Vec*);
+int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, void*, void*, u32);
+void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
+void ParticleFrameCallback__5CGameFiiiiiP3Vec(CGame*, int, int, int, int, int);
+int GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(float, _pppMngSt*, Mtx);
+int pppCreatePObject__FP9_pppMngStP12_pppPDataVal(_pppMngSt*, void*);
+void pppHitCylinderSendSystem__FP9_pppMngStP3VecP3Vecff(_pppMngSt*, Vec*, Vec*, float, float);
 }
+
+static char s_pppLaser_cpp[] = "pppLaser.cpp";
+
+struct LaserStep {
+    s32 m_graphId;
+    s32 m_dataValIndex;
+    u16 m_initWOrk;
+    u16 m_stepValue;
+    s32 m_arg3;
+    u8* m_payload;
+};
+
+struct CMapCylinderRaw {
+    Vec m_bottom;
+    Vec m_direction;
+    float m_radius;
+    float m_height;
+    Vec m_top;
+    Vec m_direction2;
+    float m_radius2;
+    float m_height2;
+};
 
 /*
  * --INFO--
@@ -136,7 +179,135 @@ void pppDestructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
  */
 void pppFrameLaser(struct pppLaser *pppLaser, struct UnkB *param_2, struct UnkC *param_3)
 {
-	// TODO
+    LaserStep* step = (LaserStep*)param_2;
+    float* work;
+    _pppPObject* baseObj = (_pppPObject*)pppLaser;
+    Vec localA;
+    Vec localB;
+    Vec localPos;
+    CMapCylinderRaw cyl;
+    Mtx charaMtx;
+    Mtx tempMtx;
+
+    if ((DAT_8032ed70 != 0) || (step->m_stepValue == 1)) {
+        return;
+    }
+
+    work = (float*)((u8*)&pppLaser->field_0x88 + param_3->offsets->m_serializedDataOffsets[2]);
+    if (work[0xf] == FLOAT_80333448) {
+        return;
+    }
+
+    if (work[7] == 0.0f) {
+        work[7] = (float)(u32)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            (u32)step->m_payload[0x1e] * 0xc, pppEnvStPtr->m_stagePtr, s_pppLaser_cpp, 0x7d);
+        memset((void*)(u32)work[7], 0, (u32)step->m_payload[0x1e] * 0xc);
+    }
+
+    CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+        *(float*)(step->m_payload + 0x10), baseObj, step->m_graphId, work + 4, work + 5, work + 6,
+        (float*)(step->m_payload + 0x14), (float*)(step->m_payload + 0x18));
+    CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
+        *(float*)(step->m_payload + 4), baseObj, step->m_graphId, work + 1, work + 2, work + 3,
+        (float*)(step->m_payload + 8), (float*)(step->m_payload + 0xc));
+
+    pppCalcFrameShape__FPlRsRsRss(
+        *(long**)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)step->m_stepValue * 4), *(short*)((u8*)work + 0x32),
+        *(short*)(work + 0xd), *(short*)(work + 0xc), *(short*)(step->m_payload + 0x2c));
+
+    for (u32 i = 0; i < (u32)step->m_payload[0x3a] + 1; i++) {
+        Vec* points = (Vec*)(u32)work[7];
+        int max = (int)step->m_payload[0x1e] - 2;
+
+        for (int j = max; (int)i <= j; j--) {
+            localA = points[j];
+            pppCopyVector__FR3Vec3Vec(&points[j + 1], &localA);
+        }
+
+        localB.x = FLOAT_80333428;
+        localB.y = FLOAT_80333428;
+        localB.z = work[0];
+
+        if (i == 0) {
+            PSMTXConcat(pppMngStPtr->m_matrix.value, baseObj->m_localMatrix.value, tempMtx);
+            work[8] = tempMtx[0][3];
+            work[9] = tempMtx[1][3];
+            work[10] = tempMtx[2][3];
+            PSMTXMultVec(tempMtx, &localB, points);
+        } else {
+            double denom = ((double)(int)step->m_payload[0x3a] + 1.0) - DOUBLE_80333440;
+            double t = (FLOAT_80333448 / (float)denom) * ((double)(int)i - DOUBLE_80333440);
+            if (GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f((float)t, pppMngStPtr, charaMtx) == 0) {
+                for (int k = 0; k < (int)(u32)step->m_payload[0x1e]; k++) {
+                    points[k] = points[0];
+                }
+                return;
+            }
+            PSMTXConcat(charaMtx, baseObj->m_localMatrix.value, charaMtx);
+            PSMTXMultVec(charaMtx, &localB, &points[i]);
+        }
+
+        localPos.x = work[8];
+        localPos.y = work[9];
+        localPos.z = work[10];
+        pppSubVector__FR3Vec3Vec3Vec(&localA, &points[i], &localPos);
+        PSVECScale(&localA, &localA, FLOAT_8033344c);
+
+        cyl.m_bottom = localPos;
+        cyl.m_direction = localA;
+        cyl.m_radius = FLOAT_80333428;
+        cyl.m_height = FLOAT_80333450;
+        cyl.m_radius2 = FLOAT_80333454;
+        cyl.m_height2 = FLOAT_80333454;
+
+        bool hit = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(
+                       &MapMng, &cyl, &cyl.m_direction, 0xffffffff) != 0;
+        if (hit) {
+            CalcHitPosition__7CMapObjFP3Vec(*(void**)((u8*)&MapMng + 0x22A88), &points[i]);
+            work[0] = PSVECDistance(&points[i], (Vec*)(work + 8));
+        } else if (i == 0 && *((u8*)work + 0x4c) != 0) {
+            if (work[0xf] - FLOAT_80333458 < work[0]) {
+                work[0] = work[0xf] - FLOAT_80333458;
+                ParticleFrameCallback__5CGameFiiiiiP3Vec(
+                    &Game.game, 0, (int)pppMngStPtr->m_kind, (int)pppMngStPtr->m_nodeIndex, 3,
+                    (int)((u32)baseObj->m_graphId >> 12));
+                *((u8*)work + 0x4c) = 0;
+            }
+            if (*((u8*)work + 0x4c) != 0) {
+                work[0] += work[1];
+            }
+        }
+
+        if (i == 0) {
+            localB.z = work[0];
+            PSMTXMultVec(tempMtx, &localB, &points[0]);
+        }
+
+        if (step->m_payload[0x3b] == 0) {
+            pppHitCylinderSendSystem__FP9_pppMngStP3VecP3Vecff(
+                pppMngStPtr, (Vec*)(work + 8), &localA, pppMngStPtr->m_ownerScale * *(float*)(step->m_payload + 0x24),
+                *(float*)(step->m_payload + 0x20));
+        }
+
+        if ((step->m_payload[0x3c] == 0) && hit && step->m_arg3 != -1) {
+            u8* hitFrame = ((u8*)work + 0x2d);
+            if (*hitFrame >= step->m_payload[0x1d]) {
+                *hitFrame = 0;
+                u8* dataVals = *(u8**)((u8*)pppMngStPtr + 0xc8);
+                if (dataVals != 0) {
+                    int created =
+                        pppCreatePObject__FP9_pppMngStP12_pppPDataVal(pppMngStPtr, dataVals + step->m_arg3 * 0x10);
+                    if (created != 0) {
+                        *(struct pppLaser**)(created + 4) = pppLaser;
+                        *(Vec*)(created + *(int*)step->m_payload + 0x80) = points[i];
+                        *(float*)(created + *(int*)step->m_payload + 0x84) += *(float*)(step->m_payload + 0x34);
+                    }
+                }
+            } else {
+                (*hitFrame)++;
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced `pppFrameLaser` TODO stub in `src/pppLaser.cpp` with a first-pass reconstructed implementation.
- Added control/work layout handling, graph-value updates, trail buffer allocation/shift, map hit handling, node-matrix interpolation, and hit-spawn callback wiring.
- Kept `pppRenderLaser` unchanged in this PR.

## Functions Improved
- Unit: `main/pppLaser`
- Symbol: `pppFrameLaser`

## Match Evidence
- Before (selector): `0.3%`
- After (`objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser`): `44.234333%`
- Build status: `ninja` passes.

## Plausibility Rationale
- This is a first-pass recovery of a large 1468-byte function, focused on restoring likely original behavior paths (frame graph updates, per-segment history movement, collision/hit side effects).
- The changes prefer behavior-anchored structure over compiler-only coaxing.
- A follow-up pass can tighten type/layout fidelity and reduce offset-based accesses for higher match quality.

## Technical Notes
- Ported core flow from Ghidra reference into project style and available symbols.
- Used existing engine calls for matrix transforms, graph evaluation, map cylinder collision, and particle side-effect dispatch.
- Introduced minimal local structs (`LaserStep`, `CMapCylinderRaw`) and required extern declarations to keep scope limited to this unit.
