### PR TITLE
main/pppBreathModel: implement construct/destruct work state

### DIFF
--- a/include/ffcc/pppBreathModel.h
+++ b/include/ffcc/pppBreathModel.h
@@ -3,6 +3,8 @@
 
 struct _pppPObject;
 struct _pppMngSt;
+struct pppBreathModel;
+struct UnkC;
 struct VBreathModel;
 struct PBreathModel;
 struct VColor;
@@ -25,8 +27,8 @@ extern "C" {
 
 void pppFrameBreathModel(void);
 void pppRenderBreathModel(void);
-void pppConstructBreathModel(void);
-void pppDestructBreathModel(void);
+void pppConstructBreathModel(pppBreathModel*, UnkC*);
+void pppDestructBreathModel(pppBreathModel*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -4,6 +4,16 @@
 #include <string.h>
 
 extern CMath math;
+extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
+
+struct UnkC {
+    unsigned char _pad[0xC];
+    int* m_serializedDataOffsets;
+};
+
+struct pppBreathModel {
+    unsigned char _pad[8];
+};
 
 /*
  * --INFO--
@@ -201,22 +211,79 @@ extern "C" void pppRenderBreathModel(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800db18c
+ * PAL Size: 120b
  */
-void pppConstructBreathModel(void)
+extern "C" void pppConstructBreathModel(pppBreathModel* pppBreathModel, UnkC* param_2)
 {
-	// TODO
+    Mtx* work = (Mtx*)((unsigned char*)pppBreathModel + 0x80 + *param_2->m_serializedDataOffsets);
+    unsigned char* state = (unsigned char*)work;
+
+    PSMTXIdentity(*work);
+
+    work[1][2][0] = 0.0f;
+    work[1][1][3] = 0.0f;
+    work[1][1][2] = 0.0f;
+    work[1][0][0] = 0.0f;
+    work[1][0][1] = 0.0f;
+    work[1][0][2] = 0.0f;
+    work[1][0][3] = 0.0f;
+    work[1][1][0] = 0.0f;
+
+    *(short*)(state + 0x46) = 10000;
+    *(short*)(state + 0x4A) = 0;
+    *(short*)(state + 0x4E) = 0;
+    *(state + 0x50) = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800db094
+ * PAL Size: 248b
  */
-void pppDestructBreathModel(void)
+extern "C" void pppDestructBreathModel(pppBreathModel* pppBreathModel, UnkC* param_2)
 {
-	// TODO
+    unsigned char* work = (unsigned char*)pppBreathModel + 0x80 + *param_2->m_serializedDataOffsets;
+    void** particleData = (void**)(work + 0x30);
+
+    if (particleData[0] != NULL) {
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[0]);
+        particleData[0] = NULL;
+    }
+
+    if (particleData[1] != NULL) {
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[1]);
+        particleData[1] = NULL;
+    }
+
+    if (particleData[2] != NULL) {
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[2]);
+        particleData[2] = NULL;
+    }
+
+    if (particleData[3] != NULL) {
+        int i;
+        unsigned char* group = (unsigned char*)particleData[3];
+
+        for (i = 0; i < *(short*)(work + 0x54); i++) {
+            void** groupData = (void**)(group + 4);
+
+            if (groupData[0] != NULL) {
+                pppHeapUseRate__FPQ27CMemory6CStage(groupData[0]);
+                groupData[0] = NULL;
+            }
+
+            if (groupData[1] != NULL) {
+                pppHeapUseRate__FPQ27CMemory6CStage(groupData[1]);
+                groupData[1] = NULL;
+            }
+
+            group += 0x5C;
+        }
+
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[3]);
+        particleData[3] = NULL;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `pppConstructBreathModel` and `pppDestructBreathModel` in `src/pppBreathModel.cpp` using offset-based work-state initialization and teardown consistent with nearby PPP modules.

Key changes:
- Updated `include/ffcc/pppBreathModel.h` prototypes so construct/destruct use object + offset-table parameters.
- Added local `UnkC` offset-table layout and `pppBreathModel` placeholder struct in the source.
- Implemented construction path:
  - Work pointer at `obj + 0x80 + *m_serializedDataOffsets`
  - `PSMTXIdentity` setup
  - Zeroed secondary state fields and initialized lifespan/count fields (including `10000` at `+0x46`)
- Implemented destruction path:
  - Frees per-work buffers at `+0x30/+0x34/+0x38`
  - Iterates group entries in `+0x3c` (`0x5c` stride) and frees nested allocations at `+4/+8`
  - Frees top-level group allocation and clears pointers

## Functions Improved
Unit: `main/pppBreathModel`
- `pppConstructBreathModel`: **3.33% -> 88.97%** (120b)
- `pppDestructBreathModel`: **1.61% -> 96.37%** (248b)

## Match Evidence
- `ninja` succeeds after changes.
- `objdiff` (`build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o - pppConstructBreathModel`) now reports:
  - `pppConstructBreathModel` fuzzy match: `88.96667`
  - `pppDestructBreathModel` fuzzy match: `96.370964`
- Unit-level `main/pppBreathModel` fuzzy match improved from ~9.9% (selector baseline) to **15.201497%** (`build/GCCP01/report.json`).

## Plausibility Rationale
This change replaces no-op stubs with straightforward initialization/cleanup code that mirrors existing PPP source patterns in this repo:
- Offset-table driven work blocks (`obj + 0x80 + offset`)
- Explicit pointer ownership release via `pppHeapUseRate`
- Simple deterministic state initialization (matrix identity + field zeroing)

The implementation improves assembly alignment without introducing contrived control flow or compiler-coaxing constructs.

## Technical Notes
- The new implementations were aligned against Ghidra references:
  - `resources/ghidra-decomp-1-31-2026/800db18c_pppConstructBreathModel.c`
  - `resources/ghidra-decomp-1-31-2026/800db094_pppDestructBreathModel.c`
- Remaining very-low-match functions in this unit (`pppFrameBreathModel`, `pppRenderBreathModel`, particle updates) are still stubs/partial and are unchanged in this PR.
