### PR TITLE
main/pppRyjMegaBirth: implement Con/Des and align signatures

### DIFF
--- a/include/ffcc/pppRyjMegaBirth.h
+++ b/include/ffcc/pppRyjMegaBirth.h
@@ -36,8 +36,8 @@ extern "C" {
 
 void pppRyjMegaBirth(_pppPObject*, PRyjMegaBirth*, PRyjMegaBirthOffsets*);
 void pppRyjDrawMegaBirth(void);
-void pppRyjMegaBirthCon(void);
-void pppRyjMegaBirthDes(void);
+void pppRyjMegaBirthCon(_pppPObject*, PRyjMegaBirthOffsets*);
+void pppRyjMegaBirthDes(_pppPObject*, PRyjMegaBirthOffsets*);
 
 #ifdef __cplusplus
 }

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -2,6 +2,9 @@
 #include <string.h>
 
 extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
+
+static Mtx g_matUnit;
 
 static char s_pppRyjMegaBirth_cpp[] = "pppRyjMegaBirth.cpp";
 
@@ -202,9 +205,23 @@ void pppRyjDrawMegaBirth(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRyjMegaBirthCon(void)
+void pppRyjMegaBirthCon(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
 {
-	// Constructor implementation
+	u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+
+	PSMTXIdentity(*(Mtx*)work);
+	*(f32*)(work + 0x30) = 0.0f;
+	*(f32*)(work + 0x34) = 0.0f;
+	*(f32*)(work + 0x38) = 0.0f;
+	*(void**)(work + 0x3C) = 0;
+	*(void**)(work + 0x40) = 0;
+	*(void**)(work + 0x44) = 0;
+	*(void**)(work + 0x48) = 0;
+	*(u16*)(work + 0x4C) = 0;
+	*(u16*)(work + 0x4E) = 0;
+	*(u16*)(work + 0x4C) = 10000;
+
+	PSMTXIdentity(g_matUnit);
 }
 
 /*
@@ -216,7 +233,25 @@ void pppRyjMegaBirthCon(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRyjMegaBirthDes(void)
+void pppRyjMegaBirthDes(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
 {
-	// Destructor - cleanup particle memory allocations
+	u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+
+	if (*(void**)(work + 0x3C) != 0)
+	{
+		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x3C));
+		*(void**)(work + 0x3C) = 0;
+	}
+
+	if (*(void**)(work + 0x40) != 0)
+	{
+		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x40));
+		*(void**)(work + 0x40) = 0;
+	}
+
+	if (*(void**)(work + 0x44) != 0)
+	{
+		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x44));
+		*(void**)(work + 0x44) = 0;
+	}
 }


### PR DESCRIPTION
## Summary
- Implemented `pppRyjMegaBirthCon` and `pppRyjMegaBirthDes` in `src/pppRyjMegaBirth.cpp` instead of stub bodies.
- Updated C linkage declarations in `include/ffcc/pppRyjMegaBirth.h` so Con/Des use object + offset parameters (`_pppPObject*`, `PRyjMegaBirthOffsets*`).
- Added offset-based initialization and cleanup matching the object layout used by this unit.

## Functions Improved
- Unit: `main/pppRyjMegaBirth`
- Symbols:
  - `pppRyjMegaBirthCon`
  - `pppRyjMegaBirthDes`

## Match Evidence
- Build: `ninja` passes.
- Objdiff verification (explicit objects):
  - `build/tools/objdiff-cli diff -1 build/GCCP01/obj/pppRyjMegaBirth.o -2 build/GCCP01/src/pppRyjMegaBirth.o -o - pppRyjMegaBirthCon`
    - Match: **99.77419%**
  - `build/tools/objdiff-cli diff -1 build/GCCP01/obj/pppRyjMegaBirth.o -2 build/GCCP01/src/pppRyjMegaBirth.o -o - pppRyjMegaBirthDes`
    - Match: **100.0%**
- Prior to this change, these were placeholder stub implementations (function bodies were TODO stubs), with objdiff showing low matching behavior.

## Plausibility Rationale
- Uses the serialized data offset path already used in this unit to locate runtime work data.
- Constructor now performs concrete state initialization (matrix identity + pointer/timer init) rather than compiler-coaxing reorders.
- Destructor now frees/nulls the three stage allocations via existing `pppHeapUseRate__FPQ27CMemory6CStage` usage pattern seen across related particle units.

## Technical Details
- `Con` now initializes the work block at `pObject + 0x80 + offsets->m_serializedDataOffsets[2]` and sets:
  - world matrix identity,
  - runtime pointer slots and counters,
  - local identity matrix initialization path.
- `Des` now releases and clears the three heap-backed blocks at `+0x3C`, `+0x40`, `+0x44` in the same work block.
