### PR TITLE
pppSRandUpFV: improve match by normalizing math global access

### DIFF
--- a/src/pppSRandUpFV.cpp
+++ b/src/pppSRandUpFV.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppSRandUpFV.h"
 #include "ffcc/math.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern float lbl_803300C0;
 extern float lbl_801EADC8[];
@@ -69,21 +69,21 @@ extern "C" void pppSRandUpFV(void* param1, void* param2, void* param3)
         unsigned char blendTwice = cfg->blendTwice;
         randVec = reinterpret_cast<float*>(self + offset + 0x80);
 
-        float value = RandF__5CMathFv(&math);
+        float value = RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = (value + RandF__5CMathFv(&math)) * lbl_803300C0;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300C0;
         }
         randVec[0] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = (value + RandF__5CMathFv(&math)) * lbl_803300C0;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300C0;
         }
         randVec[1] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (blendTwice != 0) {
-            value = (value + RandF__5CMathFv(&math)) * lbl_803300C0;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300C0;
         }
         randVec[2] = value;
     } else {


### PR DESCRIPTION
## Summary
- Updated `src/pppSRandUpFV.cpp` to use the same global math object access style used by nearby ppp random helpers (`extern CMath math[]` + `RandF__5CMathFv(math)`).
- Kept behavior intact while simplifying the generated access/call sequence in `pppSRandUpFV`.

## Functions improved
- Unit: `main/pppSRandUpFV`
- Symbol: `pppSRandUpFV`
- Size: `428b`

## Match evidence
- Before: `85.37383%`
- After: `92.009346%`
- Improvement: `+6.635516` percentage points
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/pppSRandUpFV -o - pppSRandUpFV`

## Plausibility rationale
- The change aligns this function with the established source style used across adjacent `ppp*Rand*` code paths.
- It is a type/linkage correction and call-style normalization rather than contrived compiler coaxing.
- Control flow and math semantics are unchanged.

## Technical details
- Switched the external `math` declaration from scalar form to array form for ABI/codegen consistency in this codebase.
- Updated the three `RandF__5CMathFv` call sites to use the normalized `math` expression.
- No debug comments, no dead code, and no unrelated edits.
