### PR TITLE
main/pppYmMegaBirthShpTail2: implement ctor/dtor cleanup path

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail2.h
+++ b/include/ffcc/pppYmMegaBirthShpTail2.h
@@ -28,6 +28,12 @@ struct VYmMegaBirthShpTail2
     Vec m_tailScaleDirection;           // 0x44
 };
 
+struct UnkB;
+struct UnkC {
+    u8 m_pad_0x0[0xc];
+    s32* m_serializedDataOffsets;
+};
+
 void get_rand(void);
 void U8ToF32(pppFVECTOR4*, unsigned char*);
 void alloc_check(VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*);
@@ -39,10 +45,10 @@ void calc_particle(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, V
 extern "C" {
 #endif
 
-void pppConstructYmMegaBirthShpTail2(void);
-void pppDestructYmMegaBirthShpTail2(void);
-void pppFrameYmMegaBirthShpTail2(void);
-void pppRenderYmMegaBirthShpTail2(void);
+void pppConstructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2*, UnkC*);
+void pppDestructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2*, UnkC*);
+void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, UnkC*);
+void pppRenderYmMegaBirthShpTail2(pppYmMegaBirthShpTail2*, UnkB*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -1,6 +1,11 @@
 #include "ffcc/pppYmMegaBirthShpTail2.h"
 #include "ffcc/pppPart.h"
 
+extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
+extern "C" void pppUnitMatrix__FR10pppFMATRIX(pppFMATRIX*);
+extern float lbl_80330560;
+extern pppFMATRIX g_matUnit2;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -37,22 +42,62 @@ void alloc_check(VYmMegaBirthShpTail2* vdata, PYmMegaBirthShpTail2* param)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8008ca1c
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConstructYmMegaBirthShpTail2(void)
+void pppConstructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* param1, UnkC* param2)
 {
-	// TODO
+    pppFMATRIX* work = (pppFMATRIX*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2]);
+    float initVal;
+
+    pppUnitMatrix__FR10pppFMATRIX(work);
+    initVal = lbl_80330560;
+
+    work[1].value[0][2] = initVal;
+    work[1].value[0][1] = initVal;
+    work[1].value[0][0] = initVal;
+    work[1].value[0][3] = 0.0f;
+    work[1].value[1][0] = 0.0f;
+    work[1].value[1][1] = 0.0f;
+    work[1].value[1][2] = 0.0f;
+    *(u16*)(work[1].value[1] + 3) = 0;
+    *(u16*)((u8*)work[1].value[1] + 0xe) = 0;
+    *(u16*)(work[1].value[1] + 3) = 10000;
+    pppUnitMatrix__FR10pppFMATRIX(&g_matUnit2);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8008c9a0
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDestructYmMegaBirthShpTail2(void)
+void pppDestructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* param1, UnkC* param2)
 {
-	// TODO
+    u8* work = (u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2];
+    void** ptrBc = (void**)(work + 0x3c);
+    void** ptrC0 = (void**)(work + 0x40);
+    void** ptrC4 = (void**)(work + 0x44);
+
+    if (*ptrBc != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*ptrBc);
+        *ptrBc = 0;
+    }
+    if (*ptrC0 != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*ptrC0);
+        *ptrC0 = 0;
+    }
+    if (*ptrC4 != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*ptrC4);
+        *ptrC4 = 0;
+    }
 }
 
 /*
@@ -90,7 +135,7 @@ void calc_particle(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, V
  * PAL Address: 0x8008b3f4
  * PAL Size: 1072b
  */
-void pppFrameYmMegaBirthShpTail2(void)
+void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, UnkC*)
 {
 	// TODO: Implement frame processing
 }
@@ -100,7 +145,7 @@ void pppFrameYmMegaBirthShpTail2(void)
  * PAL Address: 0x8008acc4
  * PAL Size: 1840b
  */
-void pppRenderYmMegaBirthShpTail2(void)
+void pppRenderYmMegaBirthShpTail2(pppYmMegaBirthShpTail2*, UnkB*, UnkC*)
 {
 	// TODO: Implement rendering
 }


### PR DESCRIPTION
## Summary
- Updated `pppYmMegaBirthShpTail2` entrypoint signatures in `include/ffcc/pppYmMegaBirthShpTail2.h` to use typed parameters (`UnkC*` / `UnkB*`) instead of `void` prototypes.
- Implemented `pppConstructYmMegaBirthShpTail2` using offset-based work data setup from the decomp reference:
  - resolves work area via `0x80 + m_serializedDataOffsets[2]`
  - initializes matrices/fields and short flags
  - calls `pppUnitMatrix__FR10pppFMATRIX` for work and `g_matUnit2`
- Implemented `pppDestructYmMegaBirthShpTail2` cleanup logic:
  - frees and nulls three stage pointers in the work block (`+0x3c`, `+0x40`, `+0x44`) via `pppHeapUseRate__FPQ27CMemory6CStage`.

## Functions improved
- Unit: `main/pppYmMegaBirthShpTail2`
- `pppDestructYmMegaBirthShpTail2`: **3.2258065% -> 100.0%**
- `pppConstructYmMegaBirthShpTail2`: **3.2258065% -> 66.51613%**

## Match evidence
`build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail2 -o - pppConstructYmMegaBirthShpTail2`

Current key symbol results:
- `pppDestructYmMegaBirthShpTail2: 100.0%`
- `pppConstructYmMegaBirthShpTail2: 66.51613%`
- (Untouched) `pppFrameYmMegaBirthShpTail2: 0.37313432%`
- (Untouched) `pppRenderYmMegaBirthShpTail2: 0.2173913%`

## Plausibility rationale
- Changes align with existing project idioms for ppp modules: offset-driven per-instance work blocks and explicit stage pointer cleanup.
- Logic mirrors decomp structure (typed offsets, matrix initialization path, stage pointer teardown) rather than compiler-coaxing transforms.
- The resulting source remains readable and structurally consistent with neighboring ppp code.

## Technical details
- Address/size docs for the two implemented functions were updated to PAL values from decomp headers.
- External symbols used follow existing conventions in this codebase:
  - `pppUnitMatrix__FR10pppFMATRIX`
  - `pppHeapUseRate__FPQ27CMemory6CStage`
  - `lbl_80330560`, `g_matUnit2`
