### PR TITLE
wm_menu: implement menu character animation helpers

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -132,7 +132,7 @@ public:
     void CalcGoOutSelChar(unsigned char, unsigned char);
     void CalcGoOutSelCharInit();
     void SetMenuCharaAnim(int, int);
-    void IsMenuCharaAnimIdle(int);
+    unsigned int IsMenuCharaAnimIdle(int);
     void drawWorld();
     void DrawMainMenu();
     void DrawDiaryMenu();

--- a/src/wm_menu.cpp
+++ b/src/wm_menu.cpp
@@ -258,22 +258,36 @@ void CMenuPcs::CalcGoOutSelCharInit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800fc20c
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::SetMenuCharaAnim(int, int)
+void CMenuPcs::SetMenuCharaAnim(int charaIndex, int animIndex)
 {
-	// TODO
+	unsigned char* const bytes = reinterpret_cast<unsigned char*>(this);
+	unsigned char* const menuCharaAnims = *reinterpret_cast<unsigned char**>(bytes + 0x844);
+
+	reinterpret_cast<int*>(menuCharaAnims + charaIndex * 0x14 + 4)[0] = animIndex;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800fc1f4
+ * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::IsMenuCharaAnimIdle(int)
+unsigned int CMenuPcs::IsMenuCharaAnimIdle(int charaIndex)
 {
-	// TODO
+	unsigned char* const bytes = reinterpret_cast<unsigned char*>(this);
+	unsigned char* const menuCharaAnims = *reinterpret_cast<unsigned char**>(bytes + 0x844);
+
+	return static_cast<unsigned int>(__cntlzw(reinterpret_cast<unsigned int*>(menuCharaAnims + charaIndex * 0x14)[0])) >> 5 & 0xff;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented two previously stubbed world-menu animation helpers in `src/wm_menu.cpp`:
  - `CMenuPcs::SetMenuCharaAnim(int, int)`
  - `CMenuPcs::IsMenuCharaAnimIdle(int)`
- Updated `include/ffcc/p_menu.h` so `IsMenuCharaAnimIdle` returns `unsigned int` (matching actual behavior instead of a `void` stub signature).
- Added PAL address/size metadata blocks for both functions.

## Functions Improved
- Unit: `main/wm_menu`
- `SetMenuCharaAnim__8CMenuPcsFii`
  - before: `0.0%` (selector snapshot for this unit)
  - after: `55.0%` (`objdiff-cli`)
- `IsMenuCharaAnimIdle__8CMenuPcsFi`
  - before: stubbed TODO implementation
  - after: `83.333336%` (`objdiff-cli`)

## Match Evidence
- Build passes with `ninja`.
- Project code matched bytes increased from `194880` to `194904` (+24 bytes) during this iteration.
- Symbol checks:
  - `build/tools/objdiff-cli diff -p . -u main/wm_menu -o - SetMenuCharaAnim__8CMenuPcsFii`
  - `build/tools/objdiff-cli diff -p . -u main/wm_menu -o - IsMenuCharaAnimIdle__8CMenuPcsFi`

## Plausibility Rationale
- The new code performs direct per-character animation state access through existing object-memory offsets used throughout this decomp stage.
- Logic is minimal and idiomatic for engine state helpers:
  - set animation index at per-entry offset
  - report idle by zero-check via `cntlzw` booleanization pattern
- No contrived control flow, no artificial temporaries for compiler coercion, and no debug/comment artifacts were introduced.

## Technical Notes
- Remaining mismatch appears tied to minor instruction-form differences (target uses an extra alignment step), but behavior and structure now align with decompiled reference expectations and produce measurable binary progress.
