### PR TITLE
main/OdemuExi2/DebuggerDriver: improve DBGEXIImm match

### DIFF
--- a/src/OdemuExi2/DebuggerDriver.c
+++ b/src/OdemuExi2/DebuggerDriver.c
@@ -47,7 +47,16 @@ static BOOL DBGEXISync() {
     return TRUE;
 }
 
-static BOOL DBGEXIImm(void* buffer, s32 bytecounter, u32 write) {
+/*
+ * --INFO--
+ * PAL Address: 0x801bcc74
+ * PAL Size: 664b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+static BOOL DBGEXIImm(void* buffer, s32 bytecounter, s32 write) {
     s32 i;
     s32 rem;
     u32 value;
@@ -196,26 +205,34 @@ static BOOL DBGRead(u32 count, u32* buffer, s32 param3) {
     return ((u32)__cntlzw(result)) >> 5;
 }
 
-static BOOL DBGWrite(u32 count, void* buffer, s32 param3) {
+/*
+ * --INFO--
+ * PAL Address: 0x801bca10
+ * PAL Size: 220b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+static BOOL DBGWrite(u32 count, u32* buffer, s32 param3) {
     u32 busyFlag;
     u32 regs;
     u32 result;
-    u32* data;
-    u32 value;
+    u32 cmd;
+    u32 word;
 
-    value = ((count & 0x1fffc) << 8) | 0xa0000000;
+    cmd = ((count & 0x1fffc) << 8) | 0xa0000000;
     regs = __EXIRegs[10];
     __EXIRegs[10] = (regs & 0x405) | 0xc0;
 
-    result = ((u32)__cntlzw(DBGEXIImm(&value, 4, TRUE))) >> 5;
+    result = ((u32)__cntlzw(DBGEXIImm(&cmd, 4, TRUE))) >> 5;
     do {
         busyFlag = __EXIRegs[13];
     } while (busyFlag & 1);
 
-    data = (u32*)buffer;
     while (param3 != 0) {
-        value = *data++;
-        result |= ((u32)__cntlzw(DBGEXIImm(&value, 4, TRUE))) >> 5;
+        word = *buffer++;
+        result |= ((u32)__cntlzw(DBGEXIImm(&word, 4, TRUE))) >> 5;
         do {
             busyFlag = __EXIRegs[13];
         } while (busyFlag & 1);


### PR DESCRIPTION
## Summary
- Updated `DBGEXIImm` parameter typing to use signed transfer mode (`s32 write`) and added function info metadata.
- Reshaped `DBGWrite` local variable usage and source-pointer typing to a form closer to recovered original flow (`cmd`/`word` locals, typed transfer pointer).
- Kept behavior unchanged while improving compiler output alignment.

## Functions improved
- Unit: `main/OdemuExi2/DebuggerDriver`
- Symbol improved: `DBGEXIImm`
  - Before: **38.801205%**
  - After: **39.590363%**
- Neighboring symbols checked for regression:
  - `DBGWrite`: 48.272728% (unchanged)
  - `DBWrite`: 64.20395% (unchanged)

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/OdemuExi2/DebuggerDriver -o - | jq -r '.left.symbols[] | select(.name=="DBGEXIImm" or .name=="DBGWrite" or .name=="DBWrite") | "\(.name) \(.match_percent)"'`
- Result confirms symbol-level gain on `DBGEXIImm` with no regressions on adjacent key symbols.

## Plausibility rationale
- Changes are type/control-flow cleanups consistent with the existing implementation style in this file, not contrived instruction-forcing.
- The rewrite keeps semantic behavior intact (same EXI command words, sync loops, and transfer loop structure), while making data movement and mode flags explicit in source form likely used by original developers.

## Technical details
- `DBGEXIImm` now uses an `s32` transfer-mode parameter and preserves all register writes and loop conditions.
- `DBGWrite` separates command word issuance from payload words in a straightforward loop, improving codegen alignment without hardcoded offsets or unnatural sequencing.
