### PR TITLE
os/OSReset: compile Reset asm unconditionally

### DIFF
--- a/src/os/OSReset.c
+++ b/src/os/OSReset.c
@@ -97,7 +97,6 @@ int __OSCallResetFunctions(BOOL final) {
     return 1;
 }
 
-#ifdef __GEKKO__
 static asm void Reset(u32 resetCode) {
     nofralloc
     b L_000001BC
@@ -138,7 +137,6 @@ L_00000200:
 L_00000208:
     b L_000001A0
 }
-#endif
 
 static void KillThreads(void) {
     OSThread* thread;


### PR DESCRIPTION
## Summary
- Removed the `#ifdef __GEKKO__` guard around `Reset` in `src/os/OSReset.c` so the local asm implementation is always emitted in this decomp build.
- This fixes `Reset` being unresolved in the unit (`U Reset`) and restores in-unit code generation expected by objdiff.

## Functions improved
- Unit: `main/os/OSReset`
- `Reset`: `0.0%` (unmatched / missing mapping) -> `100.0%`
- `__OSDoHotReset`: `91.05556%` -> `100.0%`
- `OSResetSystem`: `84.53086%` -> `96.75926%`
- `OSGetResetCode`: `77.416664%` -> `82.416664%`

## Match evidence
- `ninja` progress after change:
  - Total code matched: `194880` -> `195064` bytes
  - Matched functions: `1405` -> `1407`
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/os/OSReset -o - Reset`

## Plausibility rationale
- `Reset` is a low-level hardware reset routine (HID0/timebase/PI reset register path) that is expected to exist as a local asm function in this unit.
- Guarding it behind `__GEKKO__` in this environment caused an unresolved external and distorted surrounding codegen; removing the guard restores plausible original source structure rather than compiler coaxing.

## Technical details
- Before this fix, `nm build/GCCP01/src/os/OSReset.o` showed `U Reset`.
- After the fix, `Reset` is emitted in `OSReset.o`, allowing direct symbol mapping and improved downstream callsite matching.
