### PR TITLE
RedStream: implement first-pass StreamPlay decomp

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -1,15 +1,24 @@
 #include "ffcc/RedSound/RedStream.h"
+#include "ffcc/RedSound/RedCommand.h"
 #include "ffcc/RedSound/RedDriver.h"
+#include "ffcc/RedSound/RedEntry.h"
 #include "ffcc/RedSound/RedExecute.h"
+#include "ffcc/RedSound/RedMemory.h"
 #include <string.h>
 
 extern void* DAT_8032f438;
 extern int DAT_8021d1a8;
+extern int DAT_8032f408;
+extern CRedEntry DAT_8032e154;
+extern CRedMemory DAT_8032f480;
+extern unsigned int* DAT_8032f444;
+extern void* DAT_8032f474;
 
 extern "C" {
 void RedDelete__FPv(void*);
 void RedDeleteA__Fi(int);
 int PitchCompute__Fiiii(int, int, int, int);
+int SearchSeEmptyTrack__Fiii(int, int, int);
 int fflush(void*);
 }
 
@@ -271,12 +280,131 @@ void StreamStop(int param_1)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cc034
+ * PAL Size: 1280b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void StreamPlay(int, void*, int, int, int)
+void StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5)
 {
-	// TODO
+	int* streamData = (int*)_SearchEmptyStreamData();
+	if (streamData != (int*)0) {
+		memcpy(streamData + 4, param_2, 0x20);
+		*streamData = SearchSeEmptyTrack__Fiii(*(short*)((int)streamData + 0x2a), 0xff, 0);
+		streamData[3] = RedNew(0x4000);
+
+		int amemSize = *(short*)((int)streamData + 0x2a) << 0xd;
+		int arOffset = DAT_8032f480.GetABufferSize() < 0x800000 ? 0 : 0x300000;
+		streamData[0x4b] = RedNewA(amemSize, 0, arOffset);
+		if (streamData[0x4b] == 0) {
+			DAT_8032e154.WaveOldClear(0, arOffset);
+			streamData[0x4b] = RedNewA(amemSize, 0, arOffset);
+		}
+
+		if ((*streamData == 0) || (streamData[3] == 0) || (streamData[0x4b] == 0)) {
+			if (streamData[3] != 0) {
+				RedDelete__FPv((void*)streamData[3]);
+			}
+			if (streamData[0x4b] != 0) {
+				RedDeleteA(streamData[0x4b]);
+			}
+			if (DAT_8032f408 != 0) {
+				fflush(&DAT_8021d1a8);
+			}
+			return;
+		}
+
+		*(short*)((int)param_2 + 0x42) = (short)*(char*)((int)param_2 + 0x1000);
+		*(unsigned short*)((int)param_2 + 0x46) = 0;
+		*(unsigned short*)((int)param_2 + 0x44) = 0;
+
+		if (*(short*)((int)streamData + 0x2a) == 2) {
+			int iVar2;
+			if (streamData[8] < 0) {
+				iVar2 = 0x2000;
+			} else {
+				iVar2 = 0x1008;
+			}
+			*(short*)((int)param_2 + 0x70) = (short)*(char*)((int)param_2 + iVar2);
+			*(unsigned short*)((int)param_2 + 0x74) = 0;
+			*(unsigned short*)((int)param_2 + 0x72) = 0;
+		}
+
+		streamData[0x43] = param_1;
+		streamData[0x47] = 0;
+		streamData[0x48] = 0x1000;
+		streamData[0x49] = 0;
+		streamData[1] = (int)DAT_8032f444 + *(char*)(*streamData + 0x14e) * 0xc0;
+		streamData[2] = (int)param_2;
+		streamData[0x46] = param_3;
+
+		if (param_5 != 0) {
+			param_5 = ((param_5 + 1) * 0x100 - 1) * 0x1000;
+		}
+		streamData[0x3c] = param_5;
+		streamData[0x3e] = 0;
+
+		int pitch = PitchCompute__Fiiii(0x3c00000, 0, streamData[9], 0);
+		int iVar2 = 0;
+		do {
+			int* voice = (int*)(streamData[1] + iVar2 * 0xc0);
+			*voice = *streamData + iVar2 * 0x154;
+			*(unsigned char*)(*voice + 0x26) |= 2;
+			*(unsigned char*)((int)voice + 0x1a) |= 2;
+			voice[0x25] = 0xc01;
+			if (*(short*)(streamData + 0xb) != 0) {
+				voice[0x25] |= 0x3000;
+			}
+			*(int*)(*voice + 0xfc) = 1;
+			voice[0x2c] = 0x8000;
+			voice[1] = (int)(streamData + iVar2 * 0x18 + 0xc);
+			voice[0x27] = pitch;
+			*(int*)(*voice + 0x68) = *(int*)((int)DAT_8032f474 + 0xc);
+			*(int*)(*voice + 0x70) = 0;
+
+			if (*(short*)((int)streamData + 0x2a) == 2) {
+				if (iVar2 == 0) {
+					streamData[0x40] = 0;
+					streamData[0x42] = 0;
+				} else {
+					streamData[0x40] = 0x7f000;
+					streamData[0x42] = 0;
+				}
+			} else {
+				streamData[0x40] = param_4 << 0xc;
+				streamData[0x42] = 0;
+			}
+
+			SetVoiceVolumeMix((RedVoiceDATA*)(streamData[1] + iVar2 * 0xc0), streamData[0x40] >> 0xc,
+				streamData[0x3c] >> 0xc);
+			*(int*)(*streamData + iVar2 * 0x154 + 0x11c) = streamData[0x4b] + iVar2 * 0x2000;
+			memset(streamData + iVar2 * 0x18 + 0xc, 0, 0x60);
+			memcpy((void*)((int)streamData + iVar2 * 0x60 + 0x52), (void*)((int)param_2 + 0x20 + iVar2 * 0x2e), 0x2e);
+			*(unsigned char*)((int)voice + 0x5a) = 0;
+			*(unsigned char*)((int)voice + 0x59) = 0;
+			*(unsigned char*)(voice + 0x16) = 0;
+			*(unsigned char*)((int)voice + 0x5b) = 0x7f;
+			*(unsigned short*)(voice + 0x15) = 0;
+			*(unsigned short*)((int)voice + 0x52) = 0;
+			*(unsigned short*)(voice + 0x14) = 0;
+			*(unsigned short*)((int)voice + 0x56) = 10;
+			streamData[iVar2 * 0x18 + 0xd] = 0;
+			streamData[iVar2 * 0x18 + 0xf] = 0x3fff;
+			streamData[iVar2 * 0x18 + 0xe] = 2;
+			iVar2 += 1;
+		} while (iVar2 < *(short*)((int)streamData + 0x2a));
+
+		if (streamData[8] < 0) {
+			streamData[0x45] = _ArrangeStreamDataNoLoop((RedStreamDATA*)streamData, 0, 0x2000);
+		} else {
+			streamData[0x45] = _ArrangeStreamDataLoop((RedStreamDATA*)streamData, 0, 0x2000);
+		}
+
+		streamData[0x4a] = 0x1000;
+		streamData[0x44] = 3;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a first-pass decomp for `StreamPlay__FiPviii` in `src/RedSound/RedStream.cpp` and replaced the previous TODO stub with executable logic aligned to the PAL Ghidra reference.

Key updates:
- Added full stream setup/control flow for `StreamPlay(int, void*, int, int, int)`.
- Added required RedSound dependencies and extern symbols used by this path (`CRedMemory`, `CRedEntry`, track search symbol, stream globals).
- Added function metadata block with PAL address/size:
  - `PAL Address: 0x801cc034`
  - `PAL Size: 1280b`

## Functions Improved
- `StreamPlay__FiPviii`
  - Before: `0.3%` (selector baseline)
  - After: `48.0625%` (`build/GCCP01/report.json`)

Unit impact:
- `main/RedSound/RedStream`
  - Before: `43.3%` (selector baseline)
  - After: `57.403316%` (`build/GCCP01/report.json`)

## Match Evidence
- Verified with `ninja` (successful build) and objdiff/report outputs.
- `StreamPlay__FiPviii` now has correct target size alignment on left (`1280` bytes) and materially higher fuzzy match.
- Neighbor functions kept stable:
  - `_SearchEmptyStreamData__Fv`: `42.0%`
  - `StreamControl__Fv`: `22.578947%`

## Plausibility Rationale
This change is source-plausible for original FFCC code because it restores expected gameplay/runtime behavior rather than synthetic compiler coaxing:
- Allocates and initializes stream/AR buffers through existing RedSound APIs.
- Configures voice state using existing engine data structures and helper routines.
- Uses project-native calls and semantics (`RedNewA`, `WaveOldClear`, `PitchCompute`, `SetVoiceVolumeMix`, `_ArrangeStreamData*`).
- No contrived temporaries or offset tricks were introduced beyond existing decomp style in this file.

## Technical Notes
- `SearchSeEmptyTrack` is currently a TODO in this repo and declared as `void` there; `StreamPlay` references its expected symbol form (`SearchSeEmptyTrack__Fiii`) to match actual callsite behavior during this phase.
- This is a first-pass on a large function, so there is still substantial room to tighten control-flow/types toward closer assembly.
