### PR TITLE
main/textureman: implement SetTextureTev and raise match to 90.06%

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -58,7 +58,7 @@ public:
     void Init();
     void Quit();
     void SetTexture(_GXTexMapID, CTexture*);
-    void SetTextureTev(CTexture*);
+    int SetTextureTev(CTexture*);
 
     friend class CTexture;
     friend class CTextureSet;

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -38,6 +38,19 @@ extern "C" void __dl__FPv(void*);
 extern "C" void __dla__FPv(void*);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void* lbl_801E9BA0[];
+extern "C" void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+extern "C" void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
+extern "C" void _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(
+    int, int, int, int, int);
+extern "C" void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(
+    int, int, int, int, int);
+extern "C" void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int,
+                                                                                                       int, int);
+extern "C" void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+extern "C" void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(
+    int, int, int, int, int);
+extern "C" void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int,
+                                                                                                       int, int);
 
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
 static char s_ptrarray_grow_error[] = "CPtrArray grow error";
@@ -347,12 +360,88 @@ void CTextureMan::SetTexture(_GXTexMapID, CTexture*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003B9EC
+ * PAL Size: 804b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CTextureMan::SetTextureTev(CTexture*)
+int CTextureMan::SetTextureTev(CTexture* texture)
 {
-	// TODO
+    GXColorS10 tevColor1;
+    GXColorS10 tevColor2;
+    bool usePalette;
+
+    GXSetNumIndStages(0);
+    if (texture == 0) {
+        GXSetNumTevStages(1);
+        _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
+        _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);
+        return 1;
+    }
+
+    usePalette = *(u8*)((u8*)texture + 0x60) == 9 || *(u8*)((u8*)texture + 0x60) == 8;
+    if (usePalette) {
+        tevColor1.r = -1;
+        tevColor1.g = 0;
+        tevColor1.b = 0;
+        tevColor1.a = -1;
+        GXSetTevColorS10((GXTevRegID)1, tevColor1);
+
+        tevColor2.r = 0;
+        tevColor2.g = 0;
+        tevColor2.b = 0;
+        tevColor2.a = -1;
+        GXSetTevColorS10((GXTevRegID)2, tevColor2);
+
+        _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(
+            0, 0, 1, 2, 3);
+        _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(
+            1, 0, 3, 3, 3);
+        _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(
+            2, 2, 2, 2, 3);
+
+        GXSetTevKAlphaSel(GX_TEVSTAGE0, GX_TEV_KASEL_1);
+        GXSetTevKAlphaSel(GX_TEVSTAGE1, GX_TEV_KASEL_1);
+        GXSetTevKAlphaSel(GX_TEVSTAGE2, GX_TEV_KASEL_1);
+
+        GXSetNumTevStages(3);
+        GXSetTevDirect(GX_TEVSTAGE0);
+        _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 0xF, 8,
+                                                                                                              2, 0xF);
+        _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 0, 0);
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 1);
+        _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 0xFF);
+
+        GXSetTevDirect(GX_TEVSTAGE1);
+        _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(1, 0xF, 8,
+                                                                                                              4, 0);
+        _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(1, 7, 6,
+                                                                                                              4, 7);
+        _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 0, 1, 0);
+        _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 0, 1, 0);
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 2);
+        _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(1, 0, 1, 0xFF);
+
+        GXSetTevDirect(GX_TEVSTAGE2);
+        _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(2, 0xF, 0,
+                                                                                                              10, 0xF);
+        _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(2, 7, 0,
+                                                                                                              5, 7);
+        _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(2, 0, 0, 0, 1, 0);
+        _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(2, 0, 0, 0, 1, 0);
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(2, 0, 0);
+        _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(2, 0xFF, 0xFF, 4);
+        return 3;
+    }
+
+    GXSetNumTevStages(1);
+    GXSetTevDirect(GX_TEVSTAGE0);
+    _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 0);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+    return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CTextureMan::SetTextureTev(CTexture*)` in `src/textureman.cpp` using the PAL Ghidra reference behavior for null, paletted, and non-paletted texture paths.
- Corrected the method signature to return `int` in `include/ffcc/textureman.h` so the function can return the configured TEV stage count (`1` or `3`) as in original behavior.
- Added PAL metadata block for the function (`0x8003B9EC`, `804b`).

## Functions improved
- Unit: `main/textureman`
- Symbol: `SetTextureTev__11CTextureManFP8CTexture`
- Size: `804b`

## Match evidence
- Before: `0.5%` (from `tools/agent_select_target.py` target listing)
- After: `90.064674%` (from `build/tools/objdiff-cli diff -p . -u main/textureman -o - SetTextureTev__11CTextureManFP8CTexture`)
- Build status: `ninja` passes.

## Plausibility rationale
- Changes are behavior-driven and API-consistent with in-repo GX usage patterns: TEV swap tables, TEV orders, TEV ops, and palette handling are configured in the same style as similar rendering paths (e.g. palette TEV setup code paths elsewhere).
- The return value correction is semantically plausible because this routine naturally computes the active TEV stage count and Ghidra callsites treat it as a returned value.
- No compiler-coaxing patterns were introduced; implementation is direct rendering state setup logic.

## Technical details
- Added explicit calls to `_GXSetTev*` wrappers and `GXSetTevColorS10` to reproduce palette TEV combiner setup.
- Palette branch selection uses the texture format byte at offset `0x60` (`8`/`9`), consistent with existing code that checks the same field via pointer offset.
- Null texture and non-paletted paths both resolve to single-stage TEV setup with appropriate ordering/op mode.
