### PR TITLE
partMng: add CFlatRuntime::CObject::onNewFinished()

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -31,6 +31,7 @@ public:
 	public:
 		CObject();
 		~CObject();
+		void onNewFinished();
 
 		unsigned int m_id;         // 0x0
 		void** m_freeListNode;     // 0x4

--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -1,7 +1,21 @@
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
+#include "ffcc/cflat_runtime.h"
 
 extern "C" void __dl__FPv(void* ptr);
+
+/*
+ * --INFO--
+ * PAL Address: 0x8005f618
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CFlatRuntime::CObject::onNewFinished()
+{
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Declared `CFlatRuntime::CObject::onNewFinished()` in `include/ffcc/cflat_runtime.h`.
- Added `CFlatRuntime::CObject::onNewFinished()` definition in `src/partMng.cpp` as an empty body (matching a 4-byte `blr` target).
- Added PAL metadata block for the function in `src/partMng.cpp`.

## Functions Improved
- Unit: `main/partMng`
- Symbol: `onNewFinished__Q212CFlatRuntime7CObjectFv`
- Result: unmatched (`-1`) -> `100.0%` match

## Match Evidence
- `objdiff` (`main/partMng`, symbol `onNewFinished__Q212CFlatRuntime7CObjectFv`) reports `match_percent: 100.0` with single `blr` instruction.
- Project progress changed from `195088` -> `195092` matched code bytes (`+4`).
- Matched function count changed from `1408` -> `1409` (`+1`).
- `main/partMng` matched functions changed from `3/69` -> `4/69`.
- `main/partMng` matched code changed from `152` -> `156` bytes.

## Plausibility Rationale
- Ghidra metadata for `onNewFinished__Q212CFlatRuntime7CObjectFv` indicates a 4-byte function, consistent with an empty method implementation.
- Implementing this as an empty C++ member method is plausible original source and avoids artificial compiler-coaxing patterns.

## Technical Details
- Added the member declaration to make the symbol explicit in the type system.
- Defined it in `partMng.cpp` to satisfy the unresolved/absent symbol slot already tracked under the `main/partMng` unit.
- Verified with full `ninja` rebuild and unit-level `objdiff` oneshot JSON output.
