### PR TITLE
Improve match for pppFrameYmCheckBGHeight

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -58,18 +58,19 @@ void pppConstructYmCheckBGHeight(void)
  */
 struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pppYmCheckBGHeight, struct UnkC* param_2)
 {
-    _pppMngSt* pppMngSt = pppMngStPtr;
-    int hitResult;
-    double currentY;
-    CMapCylinderRaw cyl;
-    Vec hitPos;
     if (DAT_8032ed70 == 0) {
+        _pppMngSt* pppMngSt = pppMngStPtr;
+        int hitResult;
+        double currentY;
+        CMapCylinderRaw cyl;
+        Vec hitPos;
+
         cyl.m_direction.x = FLOAT_80330ed0;
         cyl.m_direction.y = FLOAT_80330ed4;
         cyl.m_direction.z = FLOAT_80330ed0;
-        currentY = (double)pppMngStPtr->m_matrix.value[1][3];
-        cyl.m_bottom.x = pppMngStPtr->m_matrix.value[0][3];
-        cyl.m_bottom.z = pppMngStPtr->m_matrix.value[2][3];
+        currentY = (double)pppMngSt->m_matrix.value[1][3];
+        cyl.m_bottom.x = pppMngSt->m_matrix.value[0][3];
+        cyl.m_bottom.z = pppMngSt->m_matrix.value[2][3];
         cyl.m_bottom.y = (float)(currentY + (double)param_2->m_unk0x4);
         cyl.m_direction2.x = FLOAT_80330ed8;
         cyl.m_direction2.y = FLOAT_80330ed8;
@@ -82,18 +83,19 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pp
         cyl.m_top.z = FLOAT_80330ed0;
         cyl.m_height = FLOAT_80330ed0;
         hitResult = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, (CMapCylinder*)&cyl, &cyl.m_direction, 0xffffffff);
-        if ((hitResult != 0) &&
-            (CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A78), &hitPos),
-             (float)(currentY - (double)param_2->m_serializedDataOffsets) <= hitPos.y)) {
-            currentY = (double)(hitPos.y + param_2->m_unk0x8);
+        if (hitResult != 0) {
+            CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A78), &hitPos);
+            if ((float)(currentY - (double)param_2->m_serializedDataOffsets) <= hitPos.y) {
+                currentY = (double)(hitPos.y + param_2->m_unk0x8);
+            }
         }
         pppMngSt->m_position.y = (float)currentY;
         *((float*)pppMngSt + 0x17) = (float)currentY;
         *((float*)pppMngSt + 0x1B) = (float)currentY;
         *((float*)pppMngSt + 0x13) = (float)currentY;
-        pppMngStPtr->m_matrix.value[0][3] = pppMngSt->m_position.x;
-        pppMngStPtr->m_matrix.value[1][3] = pppMngSt->m_position.y;
-        pppMngStPtr->m_matrix.value[2][3] = pppMngSt->m_position.z;
+        pppMngSt->m_matrix.value[0][3] = pppMngSt->m_position.x;
+        pppMngSt->m_matrix.value[1][3] = pppMngSt->m_position.y;
+        pppMngSt->m_matrix.value[2][3] = pppMngSt->m_position.z;
         pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
     return pppYmCheckBGHeight;


### PR DESCRIPTION
## Summary
- Refactored `pppFrameYmCheckBGHeight` control/data flow to better mirror expected original codegen while preserving behavior.
- Delayed `pppMngStPtr` load until inside the active branch and used a single `_pppMngSt*` consistently for matrix reads/writes.
- Expanded the hit-check condition into explicit nested checks around `CalcHitPosition` and comparison.

## Functions improved
- Unit: `main/pppYmCheckBGHeight`
- Symbol: `pppFrameYmCheckBGHeight`

## Match evidence
- `pppFrameYmCheckBGHeight`: **68.9885% -> 70.28735%** (`objdiff-cli diff -p . -u main/pppYmCheckBGHeight -o - pppFrameYmCheckBGHeight`)
- Function size remains 348 bytes.

## Plausibility rationale
- Changes are source-plausible cleanup: tighter local pointer lifetime, explicit control flow, and consistent member access.
- No contrived temporaries or artificial sequencing were introduced solely for score manipulation.

## Technical details
- Early mismatches were dominated by register/argument differences around manager pointer and branch structure.
- Moving manager acquisition into the guarded branch and normalizing matrix access reduced those differences enough to produce a measurable symbol-level improvement.