### PR TITLE
pppRyjMegaBirth: fix PRyjMegaBirth mangling for core particle symbols

### DIFF
--- a/include/ffcc/pppRyjMegaBirth.h
+++ b/include/ffcc/pppRyjMegaBirth.h
@@ -3,7 +3,9 @@
 
 #include "ffcc/partMng.h"
 
-typedef _PARTICLE_DATA PRyjMegaBirth; // Size 0x140
+struct PRyjMegaBirth : _PARTICLE_DATA
+{
+}; // Size 0x140
 
 struct VRyjMegaBirth
 {


### PR DESCRIPTION
## Summary
- Changed PRyjMegaBirth from a typedef alias of _PARTICLE_DATA to a concrete wrapper struct in include/ffcc/pppRyjMegaBirth.h.
- This preserves layout semantics while forcing Metrowerks to mangle function signatures with PRyjMegaBirth* instead of _PARTICLE_DATA*.

## Functions improved
Unit: main/pppRyjMegaBirth
- calc_particle__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColor
  - before: unresolved (None)
  - after: 