### PR TITLE
Improve pppSRandCV match by aligning math/context typing

### DIFF
--- a/src/pppSRandCV.cpp
+++ b/src/pppSRandCV.cpp
@@ -2,10 +2,24 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
+extern float lbl_80330060;
 extern u8 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
+
+typedef struct SRandCVParams {
+    int index;
+    int colorOffset;
+    s8 delta[4];
+    u8 flag;
+    u8 pad[3];
+} SRandCVParams;
+
+typedef struct SRandCVCtx {
+    u8 pad[0xC];
+    int* outputOffset;
+} SRandCVCtx;
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,86 +40,85 @@ void pppSRandCV(void* param1, void* param2, void* param3)
         return;
     }
 
+    u8* base = (u8*)param1;
+    SRandCVParams* params = (SRandCVParams*)param2;
+    SRandCVCtx* ctx = (SRandCVCtx*)param3;
     float* target;
 
-    if (*(int*)param2 == *((int*)param1 + 3)) {
-        int** base_ptr = (int**)((char*)param3 + 0xc);
-        int offset = **base_ptr;
-        target = (float*)((char*)param1 + offset + 0x80);
+    if (params->index == *(int*)(base + 0xC)) {
+        target = (float*)(base + *ctx->outputOffset + 0x80);
 
-        u8 flag = *((u8*)param2 + 0xc);
+        u8 flag = params->flag;
         float value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
-            value = value * 2.0f;
+            value = value * lbl_80330060;
         }
         target[0] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
-            value = value * 2.0f;
+            value = value * lbl_80330060;
         }
         target[1] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
-            value = value * 2.0f;
+            value = value * lbl_80330060;
         }
         target[2] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = value + RandF__5CMathFv(&math);
+            value = value + RandF__5CMathFv(math);
         } else {
-            value = value * 2.0f;
+            value = value * lbl_80330060;
         }
         target[3] = value;
-    } else if (*(int*)param2 != *((int*)param1 + 3)) {
-        int** base_ptr = (int**)((char*)param3 + 0xc);
-        int offset = **base_ptr;
-        target = (float*)((char*)param1 + offset + 0x80);
+    } else if (params->index != *(int*)(base + 0xC)) {
+        target = (float*)(base + *ctx->outputOffset + 0x80);
     }
 
-    int color_offset = *((int*)param2 + 1);
+    int color_offset = params->colorOffset;
     u8* target_color;
     if (color_offset == -1) {
         target_color = lbl_801EADC8;
     } else {
-        target_color = (u8*)((char*)param1 + color_offset + 0x80);
+        target_color = base + color_offset + 0x80;
     }
 
     {
         u8 current = target_color[0];
-        s8 base = *(s8*)((char*)param2 + 8);
-        int delta = (int)((float)base * target[0] - (float)current);
+        s8 baseValue = params->delta[0];
+        int delta = (int)((float)baseValue * target[0] - (float)current);
         target_color[0] = (u8)(current + delta);
     }
 
     {
         u8 current = target_color[1];
-        s8 base = *(s8*)((char*)param2 + 9);
-        int delta = (int)((float)base * target[1] - (float)current);
+        s8 baseValue = params->delta[1];
+        int delta = (int)((float)baseValue * target[1] - (float)current);
         target_color[1] = (u8)(current + delta);
     }
 
     {
         u8 current = target_color[2];
-        s8 base = *(s8*)((char*)param2 + 0xa);
-        int delta = (int)((float)base * target[2] - (float)current);
+        s8 baseValue = params->delta[2];
+        int delta = (int)((float)baseValue * target[2] - (float)current);
         target_color[2] = (u8)(current + delta);
     }
 
     {
         u8 current = target_color[3];
-        s8 base = *(s8*)((char*)param2 + 0xb);
-        int delta = (int)((float)base * target[3] - (float)current);
+        s8 baseValue = params->delta[3];
+        int delta = (int)((float)baseValue * target[3] - (float)current);
         target_color[3] = (u8)(current + delta);
     }
 }


### PR DESCRIPTION
## Summary
- Refactored pppSRandCV to use typed parameter/context structs for field access consistency.
- Switched math declaration/calls to CMath math[] and RandF__5CMathFv(math).
- Replaced literal 2.0f with shared symbol lbl_80330060 to align constant emission.
- Preserved behavior while restructuring control/data flow to match expected codegen.

## Functions improved
- Unit: main/pppSRandCV
- Function: pppSRandCV

## Match evidence
- Before: 76.929344% (objdiff symbol match)
- After: 81.08696% (objdiff symbol match)
- Delta: +4.157616%

## Plausibility rationale
- Changes are source-plausible and consistent with sibling particle randomization units (pppRandCV/pppSRandHCV style): typed field access, shared constants, and standard CMath usage.
- No contrived temporaries or non-idiomatic compiler-coaxing patterns were introduced.

## Technical details
- Improved alignment came primarily from matching math pointer setup/call patterns and data layout access (param/context field extraction), reducing repeated diff hotspots in the random generation and color-update sections.