### PR TITLE
main/pppYmMiasma: match pppConstruct2YmMiasma to 100%

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -175,12 +175,12 @@ void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
  */
 void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 {
-    int offset = param_2->m_serializedDataOffsets[2];
+    u8* workBytes = (u8*)pppYmMiasma_ + 0x80 + param_2->m_serializedDataOffsets[2];
     float fVar1 = FLOAT_80330644;
 
-    *(float*)((u8*)pppYmMiasma_ + 0x9c + offset) = FLOAT_80330644;
-    *(float*)((u8*)pppYmMiasma_ + 0xa0 + offset) = fVar1;
-    *(float*)((u8*)pppYmMiasma_ + 0xa4 + offset) = fVar1;
+    *(float*)(workBytes + 0x1c) = FLOAT_80330644;
+    *(float*)(workBytes + 0x20) = fVar1;
+    *(float*)(workBytes + 0x24) = fVar1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppConstruct2YmMiasma` pointer arithmetic to compute the serialized work base once (`pppYmMiasma_ + 0x80 + offset`) and then write fixed field offsets.
- Kept behavior unchanged (same three `FLOAT_80330644` writes), but aligned emitted code shape with the original object.

## Functions Improved
- Unit: `main/pppYmMiasma`
- Function: `pppConstruct2YmMiasma`

## Match Evidence
- `pppConstruct2YmMiasma`: **85.22222% -> 100.0%** (`build/GCCP01/report.json` before/after)
- Unit `main/pppYmMiasma`: **20.85553% -> 21.005644%**
- Build verification: `ninja` succeeded and regenerated report.

## Plausibility Rationale
- This is source-plausible cleanup: compute a typed work-region base pointer once and access local fields by stable offsets.
- No contrived temporaries or no-op flow changes were introduced.

## Technical Notes
- Objdiff previously showed an address-arithmetic mismatch in this function around base setup.
- Refactoring to base+field-offset form removed that mismatch and produced a full fuzzy match for the symbol.