### PR TITLE
Fix PRyjMegaBirthModel signatures to enable objdiff matching

### DIFF
--- a/include/ffcc/pppRyjMegaBirthModel.h
+++ b/include/ffcc/pppRyjMegaBirthModel.h
@@ -3,7 +3,7 @@
 
 #include "ffcc/partMng.h"
 
-typedef _PARTICLE_DATA PRyjMegaBirthModel; // Size 0x140
+struct PRyjMegaBirthModel : _PARTICLE_DATA {}; // Size 0x140
 
 struct VRyjMegaBirthModel
 {
@@ -17,7 +17,7 @@ void calc_particle(_pppPObject*, VRyjMegaBirthModel*, PRyjMegaBirthModel*, VColo
 void birth(_pppPObject*, VRyjMegaBirthModel*, PRyjMegaBirthModel*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
 void calc(_pppPObject*, VRyjMegaBirthModel*, PRyjMegaBirthModel*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
 void init_matrix(_pppPObject*, pppFMATRIX&, PRyjMegaBirthModel*, VRyjMegaBirthModel*);
-void set_matrix(_pppPObject*, pppFMATRIX&, pppFMATRIX&, PRyjMegaBirthModel*, _PARTICLE_DATA*, _PARTICLE_WMAT*, pppFMATRIX&, unsigned char);
+void set_matrix(_pppPObject*, pppFMATRIX, pppFMATRIX, PRyjMegaBirthModel*, _PARTICLE_DATA*, _PARTICLE_WMAT*, pppFMATRIX&, unsigned char);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pppRyjMegaBirthModel.cpp
+++ b/src/pppRyjMegaBirthModel.cpp
@@ -118,7 +118,7 @@ void init_matrix(_pppPObject*, pppFMATRIX&, PRyjMegaBirthModel*, VRyjMegaBirthMo
  * Address:	TODO
  * Size:	TODO
  */
-void set_matrix(_pppPObject*, pppFMATRIX&, pppFMATRIX&, PRyjMegaBirthModel*, _PARTICLE_DATA*, _PARTICLE_WMAT*, pppFMATRIX&, unsigned char)
+void set_matrix(_pppPObject*, pppFMATRIX, pppFMATRIX, PRyjMegaBirthModel*, _PARTICLE_DATA*, _PARTICLE_WMAT*, pppFMATRIX&, unsigned char)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Replaced `PRyjMegaBirthModel` from a typedef alias (`_PARTICLE_DATA`) to a distinct struct type deriving from `_PARTICLE_DATA`.
- Updated `set_matrix` declaration/definition to match the expected value/reference ABI shape:
  - `pppFMATRIX, pppFMATRIX, ..., pppFMATRIX&`
- No behavioral logic changes were introduced; this is a type/signature alignment change.

## Functions Improved
Unit: `main/pppRyjMegaBirthModel`

- `calc__FP11_pppPObjectP18VRyjMegaBirthModelP18PRyjMegaBirthModelP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`
- `set_matrix__FP11_pppPObject10pppFMATRIX10pppFMATRIXP18PRyjMegaBirthModelP14_PARTICLE_DATAP14_PARTICLE_WMATR10pppFMATRIXUc`
- `birth__FP11_pppPObjectP18VRyjMegaBirthModelP18PRyjMegaBirthModelP6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR`
- `calc_particle__FP11_pppPObjectP18VRyjMegaBirthModelP18PRyjMegaBirthModelP6VColor`

## Match Evidence
Objdiff previously could not pair these symbols (`match_percent: null`) due mangled-name/type mismatch.

After this change:
- `calc...`: `null -> 11.424581%`
- `set_matrix...`: `null -> 0.1026694%`
- `birth...`: `null -> 0.05608525%`
- `calc_particle...`: `null -> 1.2658228%`

Verification steps run:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppRyjMegaBirthModel -o -`

## Plausibility Rationale
This change aligns C++ type identity and function ABI with the symbol metadata expected by the original build. It removes a decomp artifact (`typedef` alias collapsing `PRyjMegaBirthModel` into `_PARTICLE_DATA`) that prevented correct symbol matching.

## Technical Details
- Root cause: typedef aliasing changed mangled parameter types from `P18PRyjMegaBirthModel` to `P14_PARTICLE_DATA`, and `set_matrix` matrix args were declared as references instead of value params expected by the symbol.
- Fix: preserve layout compatibility (`struct PRyjMegaBirthModel : _PARTICLE_DATA {}`) while restoring expected mangled type identity and parameter passing form.
