### PR TITLE
pppScreenBreak: decompile SB_BeforeDrawCallback

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -38,6 +38,11 @@ struct UnkC {
 extern int DAT_8032ed70;
 extern int DAT_802381a0;
 extern float FLOAT_80331cc0;
+extern float FLOAT_80331cc4;
+extern float FLOAT_80331cd0;
+extern float FLOAT_80331ce8;
+extern float FLOAT_80331cec;
+extern float FLOAT_80331cf0;
 extern char MaterialMan[];
 extern char s_pppScreenBreak_cpp_801dd4d4[];
 extern CGraphic GraphicsPcs;
@@ -78,12 +83,38 @@ void SB_BeforeCalcMatrixCallback(CChara::CModel*, void*, void*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012e130
+ * PAL Size: 296b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
 {
-	// TODO
+    extern struct {
+        float _224_4_, _228_4_, _232_4_, _236_4_, _240_4_, _244_4_;
+    } CameraPcs;
+
+    Vec local_50;
+    GXLightObj local_44;
+    unsigned char colorStorage[4];
+    unsigned int colorPacked;
+
+    local_50.x = CameraPcs._236_4_ - (FLOAT_80331ce8 + CameraPcs._224_4_);
+    local_50.y = CameraPcs._240_4_ - (FLOAT_80331ce8 + CameraPcs._228_4_);
+    local_50.z = CameraPcs._244_4_ - (FLOAT_80331ce8 + CameraPcs._232_4_);
+    PSVECNormalize(&local_50, &local_50);
+
+    GXInitSpecularDirHA(&local_44, local_50.x, local_50.y, local_50.z, FLOAT_80331cc4, FLOAT_80331cd0, FLOAT_80331cc4);
+    GXInitLightAttn(&local_44, FLOAT_80331cc4, FLOAT_80331cc4, FLOAT_80331cd0, FLOAT_80331cec, FLOAT_80331cc4,
+                    FLOAT_80331cf0);
+
+    colorPacked = *(unsigned int*)__ct__6CColorFUcUcUcUc(colorStorage, 0xFF, 0xFF, 0xFF, 0xFF);
+    GXInitLightColor(&local_44, *(GXColor*)&colorPacked);
+    GXLoadLightObjImm(&local_44, (GXLightID)1);
+    GXSetChanCtrl((GXChannelID)0, 1, (GXColorSrc)0, (GXColorSrc)1, 1, (GXDiffuseFn)2, (GXAttnFn)0);
+    GXSetChanCtrl((GXChannelID)2, 0, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi` in `src/pppScreenBreak.cpp` from the current decomp context.
- Added required float externs used by this callback's light setup path.
- Replaced TODO metadata with PAL function info for the implemented function.

## Functions improved
- Unit: `main/pppScreenBreak`
- Function: `SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi`
  - Before: `1.3513514%`
  - After: `93.675674%`

## Match evidence
- Unit `.text` match:
  - Before: `31.499554%`
  - After: `37.594112%`
- Validation commands:
  - `build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi`
  - `build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o -`

## Plausibility rationale
- The callback now performs a standard GX light setup routine that is coherent with surrounding rendering code:
  - camera-derived light direction vector normalization
  - `GXInitSpecularDirHA` + `GXInitLightAttn`
  - white light color setup and channel control
- The structure and API usage are idiomatic for this codebase and match existing GX usage patterns rather than contrived compiler-coaxing transforms.

## Technical details
- Implemented the function at PAL metadata `0x8012e130`, `296b`.
- Used existing CColor ctor helper (`__ct__6CColorFUcUcUcUc`) to preserve expected color packing behavior before `GXInitLightColor`.
- Build verification: `ninja` passes after change.
