### PR TITLE
memory: implement __sinit_memory_cpp initializer

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,6 +1,8 @@
 #include "ffcc/memory.h"
 
 static char s_memory_cpp[] = "memory.cpp";
+extern void* PTR_PTR_s_CMemory_801e8488;
+extern CMemory Memory;
 
 /*
  * --INFO--
@@ -17,6 +19,20 @@ void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int l
         file = s_memory_cpp;
     }
     return stage->alloc(size, file, line, 0);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FE54
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_memory_cpp(void)
+{
+    *reinterpret_cast<void**>(&Memory) = &PTR_PTR_s_CMemory_801e8488;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__sinit_memory_cpp` in `src/memory.cpp` with PAL address/size metadata.
- Added explicit static initializer assignment for `Memory`'s first word to the vtable pointer label used by this translation unit.

## Functions improved
- Unit: `main/memory`
- Symbol: `__sinit_memory_cpp`

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` output for this symbol)
- After: `22.5%` (from `build/tools/objdiff-cli diff -p . -u main/memory -o - __sinit_memory_cpp`)
- The new implementation now produces the expected direct initializer store pattern for `Memory` rather than a pure stub.

## Plausibility rationale
- This is source-plausible startup code: `__sinit_*` functions in this codebase initialize singleton/class runtime state.
- The change follows existing project patterns for explicit static init functions and avoids contrived compiler-only tricks.

## Technical details
- Added:
  - `extern void* PTR_PTR_s_CMemory_801e8488;`
  - `extern C void __sinit_memory_cpp(void)`
- Implementation sets the first word of `Memory` via `reinterpret_cast<void**>(&Memory)` to match known init intent from decomp references.
- Verified build success with `ninja`.