### PR TITLE
ME_AppRequest: match SetRsdFlag

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -129,11 +129,12 @@ int CMaterialEditorPcs::SetRsdFlag()
     int index = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC4);
     int* rsd = reinterpret_cast<int*>(list->GetDataIdx(index));
 
-    if (rsd != nullptr) {
-        rsd[3] = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC0);
+    if (rsd == 0) {
+        return 0;
     }
 
-    return rsd != nullptr;
+    rsd[3] = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0xC0);
+    return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CMaterialEditorPcs::SetRsdFlag()` control flow in `src/ME_AppRequest.cpp` to use an explicit null-check return path.
- Kept behavior unchanged: if `GetDataIdx` returns null, return `0`; otherwise write the flag and return `1`.

## Functions Improved
- Unit: `main/ME_AppRequest`
- Symbol: `SetRsdFlag__18CMaterialEditorPcsFv`

## Match Evidence
- `objdiff` before: `75.9%`
- `objdiff` after: `100.0%`
- `ninja` progress delta: code matched increased by `80` bytes and `1` function (`195352 -> 195432`, `1413 -> 1414`).

## Plausibility Rationale
- The updated code is a straightforward, idiomatic C++ null-check/write/return sequence.
- It avoids compiler-coaxing constructs and matches how nearby functions in the same file use explicit success/failure returns.

## Technical Details
- Prior form used `return rsd != nullptr;`, which lowered to a different boolean materialization pattern.
- Switching to explicit early return aligned branch/return shape to the target assembly for this symbol.