### PR TITLE
main/pppVertexAttend: improve indexed vertex table access match

### DIFF
--- a/src/pppVertexAttend.cpp
+++ b/src/pppVertexAttend.cpp
@@ -42,18 +42,19 @@ void pppVertexAttend(void* r3, void* r4, void* r5)
 
     VertexAttendStream* stream = *(VertexAttendStream**)((u8*)r5 + 0xC);
     Vec transformed;
-    s16 modelIndex = *(s16*)((u8*)lbl_8032ED54->vertexSetTable + (entryIndex << 3));
-    u16 sourceIndex = *(u16*)((u8*)r3 + stream->sourceOffset + 0x80);
-    u16 vertexIndex = *(u16*)((u8*)stream->destOffset + (sourceIndex << 1));
-    Vec* sourceVertex = (Vec*)((u8*)lbl_8032ED54->modelTable[modelIndex]->vertexData + (vertexIndex * 0xC));
+    Vec* transformedPtr = &transformed;
     u8* output = (u8*)r3 + stream->destOffset;
+    u16 sourceIndex = *(u16*)((u8*)r3 + stream->sourceOffset + 0x80);
+    s16 modelIndex = ((s16*)lbl_8032ED54->vertexSetTable)[(u32)entryIndex * 4];
+    u16 vertexIndex = *(u16*)(output + ((u32)sourceIndex << 1));
+    Vec* sourceVertex =
+        (Vec*)((u8*)lbl_8032ED54->modelTable[modelIndex]->vertexData + (vertexIndex * sizeof(Vec)));
 
     transformed.x = sourceVertex->x;
     transformed.y = sourceVertex->y;
     transformed.z = sourceVertex->z;
 
-    Mtx* mtx = (Mtx*)((u8*)*(void**)((u8*)r3 + 4) + 0x10);
-    PSMTXMultVec(*mtx, &transformed, &transformed);
+    PSMTXMultVec(*(Mtx*)((u8*)*(void**)((u8*)r3 + 4) + 0x10), transformedPtr, transformedPtr);
 
     *(f32*)((u8*)output + 0x80) = transformed.x;
     *(f32*)((u8*)output + 0x84) = transformed.y;


### PR DESCRIPTION
## Summary
- Refined pppVertexAttend pointer/index math to follow the object-local table access pattern.
- Fixed destination-table lookup to index from 3 + destOffset rather than treating destOffset as an absolute pointer.
- Reordered local computations for stream offsets / model index lookup to better align compiler register usage while keeping source natural.

## Functions improved
- Unit: main/pppVertexAttend
- Symbol: pppVertexAttend

## Match evidence
- pppVertexAttend: **74.12% -> 74.62%** (uild/tools/objdiff-cli diff -p . -u main/pppVertexAttend -o - pppVertexAttend)
- Improvement is in real instruction alignment around indexed loads and destination table addressing (not formatting-only changes).

## Plausibility rationale
- The new code models a standard game-engine vertex remap flow: read source index, remap through per-object table, fetch source vertex, transform by model matrix, then store transformed output.
- Changes remove an implausible pointer treatment (destOffset as direct address) and use semantics that match existing FFCC-style object-relative data access.

## Technical details
- Introduced explicit output = (u8*)r3 + stream->destOffset base and used it consistently for indexed halfword lookup.
- Kept PAL info header unchanged; only implementation body updated.
- Verified build success with 
inja and validated symbol diff with objdiff CLI.