### PR TITLE
pppRandHCV: use array-form math symbol to improve codegen match

### DIFF
--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern float lbl_8032FF98;
 extern double lbl_8032FFA0;
@@ -56,9 +56,9 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
     }
 
     if (params->index == id) {
-        float randValue = RandF__5CMathFv(&math);
+        float randValue = RandF__5CMathFv(math);
         if (params->flag != 0) {
-            randValue = randValue + RandF__5CMathFv(&math);
+            randValue = randValue + RandF__5CMathFv(math);
         } else {
             randValue = randValue * lbl_8032FF98;
         }


### PR DESCRIPTION
## Summary
- Changed `math` declaration in `src/pppRandHCV.cpp` from object form to array form (`extern CMath math[]`).
- Updated `RandF__5CMathFv` call sites to pass `math` directly instead of `&math`.
- No control-flow or semantic behavior changes were made in `pppRandHCV`.

## Functions improved
- Unit: `main/pppRandHCV`
- Symbol: `pppRandHCV`

## Match evidence
- `objdiff` oneshot symbol diff (`build/tools/objdiff-cli diff -p . -u main/pppRandHCV -o - pppRandHCV`)
  - Before: `78.12977%`
  - After: `80.458015%`
  - Delta: `+2.328245`
- Project report (`build/GCCP01/report.json`) now shows `pppRandHCV` fuzzy match at `82.854965%`.

## Plausibility rationale
- This aligns with existing neighboring particle rand units that already use `extern CMath math[]` and call `RandF__5CMathFv(math)`.
- The change is ABI/plausibility-oriented (symbol/access form), not artificial control-flow coaxing.

## Technical details
- The improvement comes from closer codegen around the random-value call sequence by matching symbol access conventions used elsewhere in this codebase.
- Build validation: `ninja` succeeds after the change.