### PR TITLE
main/ME_USB_process: improve SetUSBData packet handling match

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -2,6 +2,7 @@
 #include "ffcc/p_MaterialEditor.h"
 #include "ffcc/USBStreamData.h"
 #include "ffcc/memory.h"
+#include "ffcc/zlist.h"
 #include "ffcc/system.h"
 #include "dolphin/os/OSCache.h"
 
@@ -10,8 +11,17 @@
 #define BSWAP32(val) ((u32)(((u32)(val) << 24) | (((u32)(val) & 0xff00) << 8) | (((u32)(val) & 0xff0000) >> 8) | ((u32)(val) >> 24)))
 
 extern "C" void ClearTextureData__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialEditorPcs);
+extern "C" void* GetRsdItem__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialEditorPcs);
+extern "C" void __dla__FPv(void* ptr);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory* memory, unsigned long size, CMemory::CStage* stage, char* file, int line, int align);
+extern "C" void Printf__7CSystemFPce(CSystem* system, char* format, ...);
+extern "C" void ResetRsdList__18CMaterialEditorPcsFP5ZLIST(CMaterialEditorPcs* materialEditorPcs, ZLIST* zlist);
+extern "C" int AddRsdList__18CMaterialEditorPcsFP5ZLIST(CMaterialEditorPcs* materialEditorPcs, ZLIST* zlist);
 extern "C" void SetRsdIndex__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialEditorPcs);
 extern "C" void SetRsdFlag__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialEditorPcs);
+
+static char s_ME_USB_process_cpp_801d7d78[] = "ME_USB_process.cpp";
+static char s_MemAlloc_Error____size__d_801d7d8c[] = "MemAlloc Error : size=%d";
 
 namespace {
 static inline u8* Ptr(CMaterialEditorPcs* self, u32 offset)
@@ -27,6 +37,11 @@ static inline CUSBStreamData* UsbStream(CMaterialEditorPcs* self)
 static inline u32& U32At(CMaterialEditorPcs* self, u32 offset)
 {
     return *reinterpret_cast<u32*>(Ptr(self, offset));
+}
+
+static inline CMemory::CStage* MaterialEditorStage()
+{
+    return *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<u8*>(&MaterialEditorPcs) + 4);
 }
 }
 
@@ -75,12 +90,114 @@ extern "C" void SetUSBData__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialE
     case 4:
         U32At(materialEditorPcs, 0x1C) = 0;
         break;
+    case 0x10: {
+        u32** rsdItemRef = reinterpret_cast<u32**>(GetRsdItem__18CMaterialEditorPcsFv(materialEditorPcs));
+        u32* rsdItem = *rsdItemRef;
+        u32 size = usb->m_sizeBytes;
+        u32 dataSize = size * 0xC;
+        float* xyzData;
+
+        if (rsdItem[4] != 0) {
+            __dla__FPv(reinterpret_cast<void*>(rsdItem[4]));
+            rsdItem[4] = 0;
+        }
+
+        rsdItem[0] = size;
+        rsdItem[4] = reinterpret_cast<u32>(_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, dataSize, MaterialEditorStage(), s_ME_USB_process_cpp_801d7d78, 0x31, 0));
+        if (rsdItem[4] == 0) {
+            Printf__7CSystemFPce(&System, s_MemAlloc_Error____size__d_801d7d8c, dataSize);
+        }
+
+        memcpy(reinterpret_cast<void*>(rsdItem[4]), usb->m_data, dataSize);
+
+        xyzData = reinterpret_cast<float*>(rsdItem[4]);
+        for (u32 i = 0; i < size; i++) {
+            u32 id = BSWAP32(*reinterpret_cast<u32*>(xyzData + 0));
+            float y = -static_cast<float>(BSWAP32(*reinterpret_cast<u32*>(xyzData + 1)));
+            float z = -static_cast<float>(BSWAP32(*reinterpret_cast<u32*>(xyzData + 2)));
+
+            *reinterpret_cast<u32*>(xyzData + 0) = id;
+            xyzData[1] = y;
+            xyzData[2] = z;
+            xyzData += 3;
+        }
+        DCStoreRange(reinterpret_cast<void*>(rsdItem[4]), dataSize);
+        break;
+    }
+    case 0x12: {
+        u32** rsdItemRef = reinterpret_cast<u32**>(GetRsdItem__18CMaterialEditorPcsFv(materialEditorPcs));
+        u32* rsdItem = *rsdItemRef;
+        u32 size = usb->m_sizeBytes;
+        u32 dataSize = size * 0xC;
+        float* xyzData;
+
+        if (rsdItem[5] != 0) {
+            __dla__FPv(reinterpret_cast<void*>(rsdItem[5]));
+            rsdItem[5] = 0;
+        }
+
+        rsdItem[1] = size;
+        rsdItem[5] = reinterpret_cast<u32>(_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, dataSize, MaterialEditorStage(), s_ME_USB_process_cpp_801d7d78, 0x31, 0));
+        if (rsdItem[5] == 0) {
+            Printf__7CSystemFPce(&System, s_MemAlloc_Error____size__d_801d7d8c, dataSize);
+        }
+
+        memcpy(reinterpret_cast<void*>(rsdItem[5]), usb->m_data, dataSize);
+
+        xyzData = reinterpret_cast<float*>(rsdItem[5]);
+        for (u32 i = 0; i < size; i++) {
+            u32 id = BSWAP32(*reinterpret_cast<u32*>(xyzData + 0));
+            float y = -static_cast<float>(BSWAP32(*reinterpret_cast<u32*>(xyzData + 1)));
+            float z = -static_cast<float>(BSWAP32(*reinterpret_cast<u32*>(xyzData + 2)));
+
+            *reinterpret_cast<u32*>(xyzData + 0) = id;
+            xyzData[1] = y;
+            xyzData[2] = z;
+            xyzData += 3;
+        }
+        DCStoreRange(reinterpret_cast<void*>(rsdItem[5]), dataSize);
+        break;
+    }
     case 0x21:
         U32At(materialEditorPcs, 0xE8) = 1;
         ClearTextureData__18CMaterialEditorPcsFv(materialEditorPcs);
         break;
     case 0x22:
         U32At(materialEditorPcs, 0xE8) = 0;
+        break;
+    case 0x31: {
+        u32 size = usb->m_sizeBytes;
+        u8* dstBuffer = reinterpret_cast<u8*>(_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+            &Memory, size, MaterialEditorStage(), s_ME_USB_process_cpp_801d7d78, 0x31, 0));
+        u32** rsdItemRef;
+        u8* target;
+
+        if (dstBuffer == 0) {
+            Printf__7CSystemFPce(&System, s_MemAlloc_Error____size__d_801d7d8c, size);
+        }
+
+        rsdItemRef = reinterpret_cast<u32**>(GetRsdItem__18CMaterialEditorPcsFv(materialEditorPcs));
+        target = reinterpret_cast<u8*>(*rsdItemRef ? reinterpret_cast<u8*>((*rsdItemRef)[6]) : 0);
+        memcpy(dstBuffer, usb->m_data, size);
+
+        if (target != 0) {
+            for (u32 i = 0; i < size; i++) {
+                target[i * 0x70 + 0x1A] = dstBuffer[i];
+            }
+        }
+
+        if (dstBuffer != 0) {
+            __dla__FPv(dstBuffer);
+        }
+        break;
+    }
+    case 0x40:
+        ResetRsdList__18CMaterialEditorPcsFP5ZLIST(materialEditorPcs, reinterpret_cast<ZLIST*>(Ptr(materialEditorPcs, 0xC8)));
+        break;
+    case 0x41:
+        AddRsdList__18CMaterialEditorPcsFP5ZLIST(materialEditorPcs, reinterpret_cast<ZLIST*>(Ptr(materialEditorPcs, 0xC8)));
         break;
     case 0x42:
         memcpy(Ptr(materialEditorPcs, 0x20), usb->m_data, 4);


### PR DESCRIPTION
## Summary
- Expanded `SetUSBData__18CMaterialEditorPcsFv` in `main/ME_USB_process` to cover additional packet handlers that were previously missing.
- Added concrete handling paths for packet codes `0x10`, `0x12`, `0x31`, `0x40`, and `0x41`.
- Implemented allocator/free/error-report flow (`_Alloc`, `__dla`, `Printf`) and endian/axis conversion loops for streamed vertex-like data blocks.
- Kept existing handler behavior for packet codes `1`, `3`, `4`, `0x21`, `0x22`, `0x42`, and `0x43` intact.

## Functions Improved
- Unit: `main/ME_USB_process`
- Symbol: `SetUSBData__18CMaterialEditorPcsFv`
  - Before: `6.1145487%`
  - After: `14.965719%`
  - Delta: `+8.8511703%`

## Match Evidence
- Built successfully with `ninja`.
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/ME_USB_process -o - SetUSBData__18CMaterialEditorPcsFv`
- Improvement is from substantial control-flow/body expansion (new switch branches, alloc/copy/convert loops, list ops), not formatting-only changes.

## Plausibility Rationale
- Added behavior follows the existing source style in this module: explicit offset-based field access, direct calls to known mangled symbols, and in-place endian conversion patterns already used in neighboring packet handlers.
- The changes model expected packet-driven data ingestion behavior for Material Editor state (RSD item data updates and list operations), which is consistent with adjacent decompilation context and existing project conventions.

## Technical Notes
- Added wrappers to call symbol-accurate routines used by this object (`GetRsdItem`, `ResetRsdList`, `AddRsdList`, memory allocation/free, system printf).
- Reused global Material Editor stage pointer for allocations to mirror expected runtime allocation domain.
