### PR TITLE
pppYmMana: implement pppRenderYmMana

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/pppYmMana.h"
+#include "ffcc/graphic.h"
+#include "ffcc/pppPart.h"
 
 /*
  * --INFO--
@@ -82,12 +84,20 @@ void pppFrameYmMana(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d6908
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void pppRenderYmMana(void)
 {
-	// TODO
+    GXSetNumTevStages(1);
+    GXSetNumTexGens(1);
+    GXSetNumChans(1);
+    Graphic.SetViewport();
+    pppInitBlendMode();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `pppRenderYmMana` in `src/pppYmMana.cpp` from the PAL decomp reference
- Added required includes for `Graphic.SetViewport()` and `pppInitBlendMode()`
- Replaced TODO metadata with PAL address/size block

## Functions improved
- Unit: `main/pppYmMana`
- Function: `pppRenderYmMana` (68b)

## Match evidence
- Before: function was a TODO stub (`// TODO`) and the unit was reported at `0.4%` in target selection output
- After build report:
  - `pppRenderYmMana`: `90.588234%` fuzzy match (`68` bytes)
  - `main/pppYmMana`: `0.75753534%` fuzzy match

## Plausibility rationale
- The implementation is straightforward rendering setup code matching the existing codebase style (GX stage/count setup + viewport + blend init)
- No contrived control-flow or compiler-coaxing temporaries were introduced

## Technical details
- Implemented sequence:
  1. `GXSetNumTevStages(1)`
  2. `GXSetNumTexGens(1)`
  3. `GXSetNumChans(1)`
  4. `Graphic.SetViewport()`
  5. `pppInitBlendMode()`
- Verified with `ninja` and updated `build/GCCP01/report.json` metrics