### PR TITLE
gx: improve TEV K selector register packing

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -276,9 +276,9 @@ void GXSetTevKColorSel(GXTevStageID stage, GXTevKColorSel sel) {
 
     Kreg = &__GXData->tevKsel[stage >> 1];
     if (stage & 1) {
-        SET_REG_FIELD(0x36E, *Kreg, 5, 14, sel);
+        *Kreg = (*Kreg & 0xFFF83FFF) | ((u32)sel << 14);
     } else {
-        SET_REG_FIELD(0x370, *Kreg, 5, 4, sel);
+        *Kreg = (*Kreg & 0xFFFFFE0F) | ((u32)sel << 4);
     }
 
     GX_WRITE_RAS_REG(*Kreg);
@@ -293,9 +293,9 @@ void GXSetTevKAlphaSel(GXTevStageID stage, GXTevKAlphaSel sel) {
 
     Kreg = &__GXData->tevKsel[stage >> 1];
     if (stage & 1) {
-        SET_REG_FIELD(911, *Kreg, 5, 19, sel);
+        *Kreg = (*Kreg & 0xFF07FFFF) | ((u32)sel << 19);
     } else {
-        SET_REG_FIELD(913, *Kreg, 5, 9, sel);
+        *Kreg = (*Kreg & 0xFFFFC1FF) | ((u32)sel << 9);
     }
 
     GX_WRITE_RAS_REG(*Kreg);


### PR DESCRIPTION
## Summary
- Reworked GXSetTevKColorSel and GXSetTevKAlphaSel in src/gx/GXTev.c to use explicit bitmask/shift writes for __GXData->tevKsel[].
- Kept behavior and write order identical (modify cached BP reg -> GX_WRITE_RAS_REG -> mark pSentNot dirty).

## Functions Improved
- main/gx/GXTev::GXSetTevKColorSel
  - before: **80.00%**
  - after: **99.62963%**
- main/gx/GXTev::GXSetTevKAlphaSel
  - before: **80.00%**
  - after: **99.62963%**

## Match Evidence
- Unit main/gx/GXTev .text match improved:
  - before: **80.82772%**
  - after: **82.926735%**
- 
inja rebuilt uild/GCCP01/src/gx/GXTev.o successfully.
- objdiff-cli confirmed both target functions moved from heavy instruction diffs to near-match.

## Plausibility Rationale
- The new form is a standard, readable hardware register update style for GX BP fields (clear mask then insert shifted value).
- This avoids contrived control-flow or temporary coercion and matches how adjacent low-level GX code typically manipulates packed registers.

## Technical Notes
- Replaced SET_REG_FIELD invocations with direct masks that match TEV selector bit layouts:
  - color sel: bits 4..8 or 14..18
  - alpha sel: bits 9..13 or 19..23
- The change is limited to two functions in one source file.