### PR TITLE
gobjwork: match ChgEquipPos and improve CanAddComList

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -82,7 +82,7 @@ public:
     void FGPutGil(int);
     void ChgCmdLst(int, int);
     void ChgEquipPos(int, int);
-    void CanAddComList(int);
+    int CanAddComList(int);
     void AddComList(int, int*);
     void DeleteCmdList(int, int);
     void AddItem(int, int*);

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -216,9 +216,9 @@ void CCaravanWork::ChgCmdLst(int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CCaravanWork::ChgEquipPos(int, int)
+void CCaravanWork::ChgEquipPos(int idx, int equip)
 {
-	// TODO
+	m_equipment[idx] = equip;
 }
 
 /*
@@ -226,9 +226,21 @@ void CCaravanWork::ChgEquipPos(int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CCaravanWork::CanAddComList(int)
+int CCaravanWork::CanAddComList(int count)
 {
-	// TODO
+	int slotCount = m_numCmdListSlots;
+	unsigned short* slot = m_commandListInventorySlotRef;
+
+	if (slotCount > 2) {
+		for (int i = slotCount - 2; i != 0; i--) {
+			if ((*slot == 0xFFFF) && (--count == 0)) {
+				break;
+			}
+			slot++;
+		}
+	}
+
+	return count == 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CCaravanWork::ChgEquipPos(int, int)` with direct equipment-slot assignment.
- Corrected `CCaravanWork::CanAddComList(int)` to return `int` and implemented command-slot availability scanning logic.
- Kept changes scoped to source-plausible gameplay/workflow logic (no compiler-coaxing constructs).

## Functions Improved
- Unit: `main/gobjwork`
- `ChgEquipPos__12CCaravanWorkFii`: **25.0% -> 100.0%**
- `CanAddComList__12CCaravanWorkFi`: **6.25% -> 65.875%**

## Match Evidence
- `objdiff-cli` symbol diffs show instruction alignment gains for both edited functions.
- Unit `.text` match moved from **2.0858493% -> 2.343397%**.
- Build verification: `ninja` passed after changes.

## Plausibility Rationale
- `ChgEquipPos` now reflects straightforward member-array assignment consistent with class layout.
- `CanAddComList` now expresses a natural scan for free command slots and returns success/failure directly, matching expected gameplay semantics.
- No artificial temporaries, no hardcoded object-offset arithmetic in source, and no readability regressions.

## Technical Notes
- `CanAddComList` improvements were driven by matching observed control flow:
  - slot-count guard (`> 2`),
  - iteration over command-list slot references,
  - early exit on Nth available slot,
  - boolean-like integer return.