### PR TITLE
pppYmLookOn: fix pppSetFpMatrix linkage for closer symbol match

### DIFF
--- a/src/pppYmLookOn.cpp
+++ b/src/pppYmLookOn.cpp
@@ -8,7 +8,7 @@ extern float FLOAT_80330ecc;
 struct _pppMngSt;
 extern struct _pppMngSt* pppMngStPtr;
 
-void pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
+extern "C" void pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Updated the forward declaration of `pppSetFpMatrix__FP9_pppMngSt` in `src/pppYmLookOn.cpp` to use `extern C` linkage.
- No control-flow or logic changes were made to `pppFrameYmLookOn`; this is a symbol-linkage correction.

## Functions improved
- Unit: `main/pppYmLookOn`
- Symbol: `pppFrameYmLookOn`

## Match evidence
- `pppFrameYmLookOn` match improved from **78.117645%** to **78.15966%** (objdiff CLI, oneshot JSON mode).
- Improvement is tied to callsite symbol alignment for `pppSetFpMatrix__FP9_pppMngSt`.

## Plausibility rationale
- `pppSetFpMatrix__FP9_pppMngSt` is a C-style symbol name used across `ppp*` units.
- Declaring it without C linkage in a C++ translation unit can produce a different mangled call target.
- Using `extern C` is the plausible original-source fix for this kind of API boundary.

## Technical details
- File changed: `src/pppYmLookOn.cpp`
- Edit: `void pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);` -> `extern C void pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);`
- Build verification: `ninja` succeeded.
- Match verification command:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmLookOn -o - pppFrameYmLookOn`