### PR TITLE
main: improve game arg-parse match by removing impossible condition

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ void game(int argc, char** argv)
                     c = (*argument)[1];
                     if (c == 'l') {
                         parseLanguage = true;
-                    } else if ((c < 'l') && (c == 'f')) {
+                    } else if (c == 'f') {
                         copyScriptName = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- Simplified command-line flag parsing in `game(int argc, char** argv)` by replacing the impossible condition `(c < 'l') && (c == 'f')` with `c == 'f'`.
- This keeps behavior equivalent while removing decompiler-artifact logic and produces better compiler output alignment.

## Functions Improved
- Unit: `main/main`
- Symbol: `game__FiPPc`
  - Before: `82.2437%`
  - After: `82.579834%`
- Symbol: `main`
  - Before: `87.72549%`
  - After: `87.72549%` (no change)

## Match Evidence
- Objdiff one-shot before/after for `main/main` shows `game__FiPPc` improved by `+0.336134%`.
- Function size remained constant (`476b`), indicating an instruction-selection/control-flow improvement rather than structural source churn.

## Plausibility Rationale
- The previous condition was logically redundant/impossible (`c == 'f'` already implies `c < 'l'`).
- Replacing it with direct `c == 'f'` is more plausible original source style and avoids compiler-coaxing patterns.

## Technical Notes
- Build: `ninja` passes.
- Diff focus: `build/tools/objdiff-cli diff -p . -u main/main -o - game__FiPPc` before/after comparison.