### PR TITLE
p_map: match CRelProfile deleting destructor

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -1,5 +1,9 @@
 #include "ffcc/p_map.h"
 
+extern "C" void __dl__FPv(void*);
+
+struct CRelProfile;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -218,4 +222,22 @@ void CMapPcs::drawAfterViewer()
 void CMapPcs::GetMapLightHolder(long, _GXColor*, Vec*)
 {
 	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80036254
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CRelProfile* __dt__11CRelProfileFv(CRelProfile* self, short shouldDelete)
+{
+	if ((self != 0) && (shouldDelete > 0))
+	{
+		__dl__FPv(self);
+	}
+	return self;
 }


### PR DESCRIPTION
## Summary
- Added the missing deleting-destructor symbol __dt__11CRelProfileFv in src/p_map.cpp.
- Implemented standard Metrowerks deleting-destructor behavior: return 	his, and call __dl__FPv(this) only when shouldDelete > 0.
- Added PAL metadata block for this updated function.

## Functions improved
- Unit: main/p_map
- Symbol: __dt__11CRelProfileFv (CRelProfile::~CRelProfile())

## Match evidence
- uild/tools/objdiff-cli diff -p . -u main/p_map -o - __dt__11CRelProfileFv
- Before: symbol absent from source object (symbol_in_source_before=False)
- After: symbol present at exact size (60b) and match_percent=100.0
- Unit .text match (from saved objdiff JSON): 1.1235955 -> 2.059925
- 
inja progress moved code matched by +60 bytes and +1 function (195512 -> 195572, 1415 -> 1416).

## Plausibility rationale
- The change is a canonical CodeWarrior deleting-destructor pattern used throughout this codebase and ABI (	his pointer + delete flag).
- No contrived control-flow or compiler-coaxing patterns were introduced.

## Technical notes
- Used __dl__FPv directly to match project conventions for deleting destructors.
- Kept implementation isolated to one symbol to reduce noise while producing a measurable unit-level improvement.