### PR TITLE
RedCommand: implement _EraseTime with correct return semantics

### DIFF
--- a/include/ffcc/RedSound/RedCommand.h
+++ b/include/ffcc/RedSound/RedCommand.h
@@ -6,7 +6,7 @@ struct RedSeINFO;
 struct RedWaveHeadWD;
 
 void _EraseAttribute(int, int);
-void _EraseTime(int);
+int _EraseTime(int);
 void SearchSeEmptyTrack(int, int, int);
 void SeStopID(int);
 void SeStopMG(int, int, int, int);

--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -1,4 +1,11 @@
 #include "ffcc/RedSound/RedCommand.h"
+#include "ffcc/RedSound/RedEntry.h"
+#include "ffcc/RedSound/RedMidiCtrl.h"
+
+extern CRedEntry DAT_8032e154;
+extern void* DAT_8032f3f0;
+extern void* DAT_8032f3fc;
+extern unsigned int* DAT_8032f444;
 
 /*
  * --INFO--
@@ -12,12 +19,81 @@ void _EraseAttribute(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ca1a4
+ * PAL Size: 536b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _EraseTime(int)
+int _EraseTime(int eraseTrack)
 {
-	// TODO
+	unsigned int minTrack = 0x100;
+	int* trackBasePtr = (int*)((char*)DAT_8032f3f0 + 0xdbc);
+	int* track = (int*)*trackBasePtr;
+
+	do {
+		if ((*track != 0) && (*(char*)(track + 0x54) == '\0') &&
+		    ((unsigned int)*(unsigned char*)((char*)track + 0x14f) < minTrack)) {
+			minTrack = *(unsigned char*)((char*)track + 0x14f);
+		}
+		track += 0x55;
+	} while (track < (int*)(*trackBasePtr + 0x2a80));
+
+	if ((int)minTrack < eraseTrack) {
+		eraseTrack = (int)minTrack;
+	}
+
+	track = (int*)*trackBasePtr;
+	int maxWait = 0;
+	int sepId = 0;
+	do {
+		if ((*track != 0) && (*(char*)(track + 0x54) == '\0') &&
+		    ((int)*(unsigned char*)((char*)track + 0x14f) <= eraseTrack) &&
+		    (maxWait < track[0x43])) {
+			maxWait = track[0x43];
+			sepId = track[0x3d];
+		}
+		track += 0x55;
+	} while (track < (int*)(*trackBasePtr + 0x2a80));
+
+	track = (int*)*trackBasePtr;
+	int erasedCount = 0;
+	do {
+		if ((*track != 0) && (*(char*)(track + 0x54) == '\0') &&
+		    ((int)*(unsigned char*)((char*)track + 0x14f) <= eraseTrack) &&
+		    (track[0x43] == maxWait)) {
+			unsigned char trackNo;
+			unsigned int* seTrack;
+
+			KeyOnReserveClear((RedKeyOnDATA*)DAT_8032f3fc, (RedTrackDATA*)track);
+			track[0x3e] = 0;
+			track[0x41] = 0;
+			*track = 0;
+			track[0x16] = 0;
+
+			trackNo = *(unsigned char*)((char*)track + 0x14e);
+			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &=
+			    (unsigned char)0xfa;
+			seTrack = (unsigned int*)((unsigned char*)DAT_8032f444 + trackNo * 0xc0);
+			seTrack[0x25] &= 0xfffffff7;
+			seTrack[0x24] &= 0xfffffffe;
+			seTrack[0x24] |= 2;
+			seTrack[0x23] = 0;
+
+			if (track[6] != 0) {
+				DAT_8032e154.WaveHistoryManager(0, *(short*)(track[6] + 2));
+			}
+			erasedCount++;
+		}
+		track += 0x55;
+	} while (track < (int*)(*trackBasePtr + 0x2a80));
+
+	if (erasedCount != 0) {
+		DAT_8032e154.SeSepHistoryManager(0, sepId);
+	}
+
+	return erasedCount;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `_EraseTime__Fi` in `src/RedSound/RedCommand.cpp` using the current PAL decomp reference as a structural guide.
- Corrected the declaration/definition signature from `void _EraseTime(int)` to `int _EraseTime(int)` to match function behavior.
- Added PAL metadata block for `_EraseTime`.

## Functions Improved
- Unit: `main/RedSound/RedCommand`
- Symbol: `_EraseTime__Fi` (PAL 0x801ca1a4, 536b)
- Match: **0.7% -> 61.53731%**

## Match Evidence
- Build: `ninja` passes (`build/GCCP01/main.dol: OK` already established in baseline; incremental build succeeds after change).
- Objdiff command:
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedCommand -o - _EraseTime__Fi`
- Parsed result from JSON:
  - `_EraseTime__Fi` `match_percent: 61.53731`

## Plausibility Rationale
- Change is source-plausible for original RedSound engine code:
  - Uses existing engine globals and helper APIs (`KeyOnReserveClear`, `WaveHistoryManager`, `SeSepHistoryManager`) already present in this module family.
  - Follows expected track-iteration and cleanup flow rather than compiler-only coercion.
  - Preserves readable control flow and avoids artificial temporaries or hardcoded hacks beyond established struct-offset-style already used throughout current RedSound decomp.

## Technical Notes
- Implementation performs three passes over track data, mirroring expected behavior:
  - compute minimum eligible track group,
  - select highest wait-time among eligible tracks,
  - clear matching tracks and update history/voice state.
