### PR TITLE
prgobj: match CGPrgObj::onDestroy

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -40,12 +40,16 @@ void CGPrgObj::onCreate()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80127AD0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGPrgObj::onDestroy()
 {
-	// TODO
+	CGObject::onDestroy();
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CGPrgObj::onDestroy()` in `src/prgobj.cpp` and updated the function info block with PAL address/size metadata.

## Functions Improved
- Unit: `main/prgobj`
- Symbol: `onDestroy__8CGPrgObjFv`
- Size: 32 bytes

## Match Evidence
- Before: `12.5%`
- After: `100.0%`
- Objdiff change: function now matches full prologue/epilogue and base call sequence (`bl onDestroy__8CGObjectFv`).

## Plausibility Rationale
This change restores straightforward C++ inheritance behavior: a derived object destructor hook calling its base-class destroy method. This is idiomatic and source-plausible, and replaces a placeholder TODO stub.

## Technical Details
- Added `CGObject::onDestroy();` in `CGPrgObj::onDestroy()`.
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/prgobj -o - onDestroy__8CGPrgObjFv`.