### PR TITLE
pppCorona: implement frame/render behavior and fix callback signatures

### DIFF
--- a/include/ffcc/pppCorona.h
+++ b/include/ffcc/pppCorona.h
@@ -17,14 +17,32 @@ struct UnkC {
     s32* m_serializedDataOffsets;
 };
 
+struct CoronaParam {
+    s32 m_graphId;
+    u16 m_dataValIndex;
+    u8 m_colorR;
+    u8 m_colorG;
+    u8 m_colorB;
+    s16 m_shapeStep;
+    float m_distMin;
+    float m_distMax;
+    float m_distRange;
+    float m_addX;
+    float m_addY;
+    float m_addZ;
+    u8 m_blendMode;
+    u8 m_drawB;
+    u8 m_drawA;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void pppConstructCorona(pppCorona* param1, UnkC* param2);
 void pppDestructCorona(void);
-void pppFrameCorona(pppCorona* param1, UnkC* param2);
-void pppRenderCorona(pppCorona* param1, UnkC* param2);
+void pppFrameCorona(pppCorona* param1, CoronaParam* param2, UnkC* param3);
+void pppRenderCorona(pppCorona* param1, CoronaParam* param2, UnkC* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Corrected `pppFrameCorona` and `pppRenderCorona` function signatures to the 3-argument pattern used by ppp frame/render callbacks.
- Replaced placeholder bodies with concrete logic based on real object code flow:
  - runtime work pointer resolution via serialized offsets
  - frame-time scale accumulation and shape frame updates
  - conditional graph-id driven additive updates
  - render-time matrix/color setup, blend/env setup, and shape draw call
- Kept constructor/destructor behavior unchanged.

## Functions Improved
Unit: `main/pppCorona`
- `pppFrameCorona`: **1.6666666% -> 95.333336%**
- `pppRenderCorona`: **0.86206895% -> 58.655174%**

## Match Evidence
Measured with:
- `tools/objdiff-cli diff -p . -u main/pppCorona -o - --format json pppFrameCorona`
- `tools/objdiff-cli diff -p . -u main/pppCorona -o - --format json pppRenderCorona`

After this change, project progress output also moved upward (code-matched bytes/functions increased) during `ninja`.

## Plausibility Rationale
- Changes align with existing source style in nearby ppp modules (`pppRain`, `pppLensFlare`, `pppYm*`) that use serialized offset tables and 3-argument frame/render callbacks.
- Logic follows engine-level idioms already present in this codebase: `pppCalcFrameShape`, `pppSetDrawEnv`, `pppSetBlendMode`, `pppDrawShp`, and matrix/vector ops through Dolphin SDK APIs.
- No contrived instruction coaxing or readability-hostile patterns were introduced; structure reflects likely original gameplay/render flow.
