### PR TITLE
mapanim: improve CMapAnim::Calc match score

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -578,11 +578,8 @@ void CMapAnim::ReadOtmAnim(CChunkFile& chunkFile)
  */
 void CMapAnim::Calc(long frame)
 {
-    CPtrArray<CMapAnimNode*>* mapAnimNodes = reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this);
-    int count = mapAnimNodes->GetSize();
-
-    for (int i = 0; i < count; i++) {
-        CMapAnimNode* node = (*mapAnimNodes)[i];
+    for (int i = 0; i < reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this)->GetSize(); i++) {
+        CMapAnimNode* node = reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this)->m_items[i];
         node->Interp((int)frame);
     }
 }


### PR DESCRIPTION
## Summary
- Simplified `CMapAnim::Calc(long)` in `src/mapanim.cpp` to iterate directly over `CPtrArray<CMapAnimNode*>::m_items`.
- Removed unnecessary local `CPtrArray`/count temporaries so codegen follows the existing object layout access pattern used elsewhere in the project.

## Functions improved
- Unit: `main/mapanim`
- Symbol: `Calc__8CMapAnimFl` (`CMapAnim::Calc(long)`, PAL size 120b)

## Match evidence
- `Calc__8CMapAnimFl`: **34.966667% -> 64.066666%** (`+29.099999`)
- Other checked symbols in `main/mapanim` were unchanged:
  - `ReadOtmAnim__8CMapAnimFR10CChunkFile`: `15.4175825% -> 15.4175825%`
  - `Calc__11CMapAnimRunFl`: `43.642857% -> 43.642857%`
  - `__ct__8CMapAnimFv`: `5.882353% -> 5.882353%`
  - `__dt__8CMapAnimFv`: `30.708334% -> 30.708334%`

## Plausibility rationale
- Accessing the backing pointer array directly (`m_items[i]`) is a normal implementation for pointer-array iteration and aligns with the struct layout already used in this file.
- The change removes indirection from helper accessors and keeps behavior identical: same loop bounds, same call to `CMapAnimNode::Interp` with the same frame value.
- The result is cleaner source and closer assembly without introducing contrived control flow.

## Technical details
- Build verification: `ninja` passes.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/mapanim -o - __ct__8CMapAnimFv`
- For `Calc__8CMapAnimFl`, diff categories moved toward target (fewer inserts/deletes/replaces/op mismatches), consistent with the large match increase.