### PR TITLE
pppYmCallBack: improve pppFrameYmCallBack match

### DIFF
--- a/src/pppYmCallBack.cpp
+++ b/src/pppYmCallBack.cpp
@@ -7,6 +7,7 @@
 
 extern CPartMng PartMng;
 extern unsigned char* lbl_8032ED50;
+extern "C" void ParticleFrameCallback__5CGameFiiiiiP3Vec(CGame*, int, int, int, int, int, Vec*);
 
 struct YmCallBackObj {
     u8 m_pad0[0xc];
@@ -52,20 +53,20 @@ void pppFrameYmCallBack(void* pppYmCallBack, void* param_2)
 {
     YmCallBackParam* frameParam = (YmCallBackParam*)param_2;
     YmCallBackObj* ymCallBack = (YmCallBackObj*)pppYmCallBack;
-    unsigned char* mngSt = lbl_8032ED50;
+    unsigned char* mngSt;
     Vec position;
     s32 mngStIndex;
 
     if (((s32)ymCallBack->m_graphId / 0x1000) == (s32)frameParam->m_graphId) {
+        mngSt = lbl_8032ED50;
         position.x = *(f32*)(mngSt + 0x84);
         position.y = *(f32*)(mngSt + 0x94);
         position.z = *(f32*)(mngSt + 0xA4);
         PSMTXMultVec(ppvWorldMatrix, &position, &position);
 
         mngStIndex = ((s32)(mngSt - ((u8*)&PartMng + 0x2A18))) / 0x158;
-        Game.game.ParticleFrameCallback(mngStIndex, (s32)*(s16*)(mngSt + 0x74),
-                                        (s32)*(s16*)(mngSt + 0x76),
-                                        (s32)frameParam->m_initWOrk, (s32)frameParam->m_graphId,
-                                        &position);
+        ParticleFrameCallback__5CGameFiiiiiP3Vec(
+            &Game.game, mngStIndex, (s32)*(s16*)(mngSt + 0x74), (s32)*(s16*)(mngSt + 0x76),
+            (s32)frameParam->m_initWOrk, (s32)frameParam->m_graphId, &position);
     }
 }


### PR DESCRIPTION
## Summary
- Refined `pppFrameYmCallBack` control/data flow to better match original codegen.
- Delayed `lbl_8032ED50` load until after graph-id guard succeeds.
- Switched callback dispatch to direct `ParticleFrameCallback__5CGameFiiiiiP3Vec` call form used across other PPP units.

## Functions Improved
- Unit: `main/pppYmCallBack`
- Symbol: `pppFrameYmCallBack`

## Match Evidence
- `pppFrameYmCallBack`: **70.5625% -> 76.3125%** (`tools/objdiff-cli diff -p . -u main/pppYmCallBack -o - pppFrameYmCallBack`)
- Unit `.text` section: **71.74% -> 77.26%**
- Assembly alignment improved around:
  - guard path ordering (conditional branch before manager-state load)
  - callback callsite argument/setup ordering

## Plausibility Rationale
- Changes are source-plausible and idiomatic for this codebase:
  - no artificial temporaries introduced solely for score gaming
  - callback invocation style matches existing PPP code patterns
  - preserves intended behavior while improving compiler output alignment

## Technical Notes
- Verified with full `ninja` build after edits.
- Change is limited to `src/pppYmCallBack.cpp` only.
