### PR TITLE
math: implement CMath::MTXGetScale

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -490,12 +490,49 @@ void CMath::MTX44MultVec4(float (*) [4], Vec4d*, Vec4d*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001b544
+ * PAL Size: 360b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::MTXGetScale(float (*) [4], Vec*)
+void CMath::MTXGetScale(float (*mtx)[4], Vec* outScale)
 {
-	// TODO
+    Vec xAxis;
+    Vec yAxis;
+    Vec zAxis;
+    Vec temp;
+
+    xAxis.x = mtx[0][0];
+    xAxis.y = mtx[1][0];
+    xAxis.z = mtx[2][0];
+    yAxis.x = mtx[0][1];
+    yAxis.y = mtx[1][1];
+    yAxis.z = mtx[2][1];
+    zAxis.x = mtx[0][2];
+    zAxis.y = mtx[1][2];
+    zAxis.z = mtx[2][2];
+
+    outScale->x = PSVECMag(&xAxis);
+    PSVECNormalize(&xAxis, &xAxis);
+
+    PSVECScale(&xAxis, &temp, PSVECDotProduct(&xAxis, &yAxis));
+    PSVECSubtract(&yAxis, &temp, &yAxis);
+    outScale->y = PSVECMag(&yAxis);
+    PSVECNormalize(&yAxis, &yAxis);
+
+    PSVECScale(&yAxis, &temp, PSVECDotProduct(&yAxis, &zAxis));
+    PSVECSubtract(&zAxis, &temp, &zAxis);
+    PSVECScale(&xAxis, &temp, PSVECDotProduct(&xAxis, &zAxis));
+    PSVECSubtract(&zAxis, &temp, &zAxis);
+    outScale->z = PSVECMag(&zAxis);
+    PSVECNormalize(&zAxis, &zAxis);
+
+    PSVECCrossProduct(&yAxis, &zAxis, &temp);
+    if (PSVECDotProduct(&xAxis, &temp) < 0.0f) {
+        PSVECScale(outScale, outScale, -1.0f);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMath::MTXGetScale(float(*)[4], Vec*)` in `src/math.cpp` using a Gram-Schmidt style extraction of basis vector scales.
- Added PAL function metadata block for the function (`0x8001b544`, `360b`).
- Used Dolphin vector APIs (`PSVECMag`, `PSVECNormalize`, `PSVECDotProduct`, `PSVECScale`, `PSVECSubtract`, `PSVECCrossProduct`) to keep implementation style/source plausibility aligned with existing code.

## Functions improved
- Unit: `main/math`
- Symbol: `MTXGetScale__5CMathFPA4_fP3Vec`
  - Before: `1.1%` (selector baseline)
  - After: `99.27778%` (`objdiff-cli v3.6.1`)

## Match evidence
- `tools/objdiff-cli diff -p . -u main/math -o - MTXGetScale__5CMathFPA4_fP3Vec`
  - reports `match_percent: 99.27778` for `MTXGetScale__5CMathFPA4_fP3Vec`.
- Unit fuzzy score moved from selector baseline `21.8%` to `26.052004%` in `build/GCCP01/report.json`.

## Plausibility rationale
- The implementation is the expected source-level way to recover per-axis scale from a 3x3 basis matrix with non-uniform scaling/shear removal.
- It avoids contrived compiler-only temporaries and uses standard vector math calls already present in this codebase.

## Technical details
- Reads basis vectors from matrix columns.
- Computes X/Y/Z magnitudes after orthogonalization.
- Applies handedness sign fix via cross/dot check (`dot(x, cross(y, z)) < 0`) and negates output scale when needed.
