### PR TITLE
THPSimple: implement DVD error handling in checkError

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -68,7 +68,11 @@ extern s16 WorkBuffer_32_[];
  */
 void checkError()
 {
-	// TODO
+    s32 status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+
+    if ((status == 0xB) || ((status - 4U) < 3) || (status == -1)) {
+        File.DrawError(SimpleControl.fileInfo, status);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `checkError()` in `src/THPSimple.cpp` to match the DVD error handling pattern already used in other THPSimple read/decode paths.
- `checkError()` now checks `DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb)` and calls `File.DrawError(SimpleControl.fileInfo, status)` on error statuses (`0xB`, `4..6`, `-1`).

## Functions improved
- Unit: `main/THPSimple`
- Symbol: `THPSimpleOpen`

## Match evidence
- `THPSimpleOpen`: **37.1983% -> 57.87252%** (`1412b`)
- objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/THPSimple -o diff.json THPSimpleOpen`
- Assembly alignment indicators from symbol diff:
  - matched instruction entries increased from `55` to `112`
  - `DIFF_DELETE` entries reduced from `183` to `78`

## Plausibility rationale
- The change restores source-plausible behavior: failed/in-progress DVD command states are checked and routed through the existing project error renderer (`CFile::DrawError`), which is consistent with the rest of this translation unit (e.g. `THPSimplePreLoad`, `THPSimpleDecode`).
- No contrived control-flow or compiler-coaxing patterns were introduced; this is a direct functional fill-in of a stubbed helper that `THPSimpleOpen` already relied on.

## Technical details
- `THPSimpleOpen` repeatedly calls `checkError()` inside read/wait loops. With the helper stubbed, those loops missed the status side-path in generated code.
- Implementing the helper restores this branch behavior and materially improves codegen alignment for the open path.