### PR TITLE
math: implement CMath::SRTToMatrix

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -87,12 +87,41 @@ void CMath::rotateToMatrix(float (*) [4], Vec*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001c124
+ * PAL Size: 360b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::SRTToMatrix(float (*) [4], SRT*)
+void CMath::SRTToMatrix(float (*out)[4], SRT* srt)
 {
-	// TODO
+    float* const s = reinterpret_cast<float*>(srt);
+    Mtx rot;
+
+    PSMTXScale(out, s[6], s[7], s[8]);
+
+    const double sx = (double)(float)sin((double)s[3]);
+    const double cx = (double)(float)cos((double)s[3]);
+    const double sy = (double)(float)sin((double)s[4]);
+    const double cy = (double)(float)cos((double)s[4]);
+    const double sz = (double)(float)sin((double)s[5]);
+    const double cz = (double)(float)cos((double)s[5]);
+
+    rot[1][0] = (float)(cy * sz);
+    rot[2][0] = (float)-sy;
+    rot[0][0] = (float)(cy * cz);
+    rot[0][1] = (float)(cz * (double)(float)(sx * sy) - (double)(float)(cx * sz));
+    rot[1][1] = (float)(sz * (double)(float)(sx * sy) + (double)(float)(cx * cz));
+    rot[2][1] = (float)(sx * cy);
+    rot[2][2] = (float)(cx * cy);
+    rot[0][2] = (float)(cz * (double)(float)(cx * sy) + (double)(float)(sx * sz));
+    rot[1][2] = (float)(sz * (double)(float)(cx * sy) - (double)(float)(sx * cz));
+    rot[0][3] = s[0];
+    rot[1][3] = s[1];
+    rot[2][3] = s[2];
+
+    PSMTXConcat(rot, out, out);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented CMath::SRTToMatrix(float(*)[4], SRT*) in src/math.cpp.
- Replaced the TODO stub with a full SRT-to-matrix path: scale setup, trig-based rotation terms, translation assignment, and final matrix concat.
- Updated the function info block with PAL metadata from the Ghidra export (