### PR TITLE
Improve pppSRandUpHCV match to 85.34%

### DIFF
--- a/src/pppSRandUpHCV.cpp
+++ b/src/pppSRandUpHCV.cpp
@@ -49,66 +49,67 @@ void pppSRandUpHCV(void* param1, void* param2, void* param3)
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);
 
-		float rand_val = RandF__5CMathFv(&math);
-		if (*((u8*)param2 + 0x10) != 0) {
-			rand_val = (rand_val + RandF__5CMathFv(&math)) * 0.5f;
-		}
-		target[0] = rand_val;
+		u8 flag = *((u8*)param2 + 0x10);
+		float value;
 
-		rand_val = RandF__5CMathFv(&math);
-		if (*((u8*)param2 + 0x10) != 0) {
-			rand_val = (rand_val + RandF__5CMathFv(&math)) * 0.5f;
+		value = RandF__5CMathFv(&math);
+		if (flag != 0) {
+			value = (value + RandF__5CMathFv(&math)) * 0.5f;
 		}
-		target[1] = rand_val;
+		target[0] = value;
 
-		rand_val = RandF__5CMathFv(&math);
-		if (*((u8*)param2 + 0x10) != 0) {
-			rand_val = (rand_val + RandF__5CMathFv(&math)) * 0.5f;
+		value = RandF__5CMathFv(&math);
+		if (flag != 0) {
+			value = (value + RandF__5CMathFv(&math)) * 0.5f;
 		}
-		target[2] = rand_val;
+		target[1] = value;
 
-		rand_val = RandF__5CMathFv(&math);
-		if (*((u8*)param2 + 0x10) != 0) {
-			rand_val = (rand_val + RandF__5CMathFv(&math)) * 0.5f;
+		value = RandF__5CMathFv(&math);
+		if (flag != 0) {
+			value = (value + RandF__5CMathFv(&math)) * 0.5f;
 		}
-		target[3] = rand_val;
+		target[2] = value;
+
+		value = RandF__5CMathFv(&math);
+		if (flag != 0) {
+			value = (value + RandF__5CMathFv(&math)) * 0.5f;
+		}
+		target[3] = value;
 	} else if (*(int*)param2 != *((int*)param1 + 3)) {
 		int** base_ptr = (int**)((char*)param3 + 0xc);
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);
 	}
 
+	s16* target_colors;
+	int color_offset = *((int*)param2 + 1);
+	if (color_offset == -1) {
+		target_colors = lbl_801EADC8;
+	} else {
+		target_colors = (s16*)((char*)param1 + color_offset + 0x80);
+	}
+
 	{
-		int color_offset = *((int*)param2 + 1);
-		s16* target_colors;
-		if (color_offset == -1) {
-			target_colors = lbl_801EADC8;
-		} else {
-			target_colors = (s16*)((char*)param1 + color_offset + 0x80);
-		}
+		s16 base = *(s16*)((char*)param2 + 0x8);
+		s8 delta = (s8)(base * target[0]);
+		target_colors[0] = (s16)(target_colors[0] + delta);
+	}
 
-		{
-			s16 base = *(s16*)((char*)param2 + 0x8);
-			s8 delta = (s8)(base * target[0]);
-			target_colors[0] = (s16)(target_colors[0] + delta);
-		}
+	{
+		s16 base = *(s16*)((char*)param2 + 0xa);
+		s8 delta = (s8)(base * target[1]);
+		target_colors[1] = (s16)(target_colors[1] + delta);
+	}
 
-		{
-			s16 base = *(s16*)((char*)param2 + 0xa);
-			s8 delta = (s8)(base * target[1]);
-			target_colors[1] = (s16)(target_colors[1] + delta);
-		}
+	{
+		s16 base = *(s16*)((char*)param2 + 0xc);
+		s8 delta = (s8)(base * target[2]);
+		target_colors[2] = (s16)(target_colors[2] + delta);
+	}
 
-		{
-			s16 base = *(s16*)((char*)param2 + 0xc);
-			s8 delta = (s8)(base * target[2]);
-			target_colors[2] = (s16)(target_colors[2] + delta);
-		}
-
-		{
-			s16 base = *(s16*)((char*)param2 + 0xe);
-			s8 delta = (s8)(base * target[3]);
-			target_colors[3] = (s16)(target_colors[3] + delta);
-		}
+	{
+		s16 base = *(s16*)((char*)param2 + 0xe);
+		s8 delta = (s8)(base * target[3]);
+		target_colors[3] = (s16)(target_colors[3] + delta);
 	}
 }


### PR DESCRIPTION
## Summary
- Refactored pppSRandUpHCV in src/pppSRandUpHCV.cpp to align with sibling pppSRandDownHCV control-flow and temporary usage.
- Hoisted the per-call blend flag (param2+0x10) into a local u8 flag reused across four random writes.
- Flattened the color-target selection block to match expected variable lifetime/order before channel updates.

## Functions improved
- Unit: main/pppSRandUpHCV
- Symbol: pppSRandUpHCV

## Match evidence
- pppSRandUpHCV: **80.97561% -> 85.335365%** (+4.359755 points)
- Size remains 656 bytes.
- 
inja build passes and progress report completes.

## Plausibility rationale
- The update preserves original behavior and uses straightforward, idiomatic C++ local temporaries.
- Structure now mirrors existing neighboring implementations (pppSRandDownHCV/pppSRandUpCV) rather than contrived compiler coaxing.
- Changes are type/lifetime/control-flow alignment edits that are consistent with likely original source style.

## Technical details
- Main gain comes from matching register pressure and call ordering around the repeated RandF__5CMathFv(&math) blocks.
- Objdiff indicates fewer insert/replace/delete deltas in the random-generation section after hoisting lag and normalizing block structure.