### PR TITLE
mapshadow: improve Init__10CMapShadowFv match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -68,25 +68,17 @@ void CMapShadow::Init()
 	float fVar1;
 	float fVar2;
 	float fVar3;
-	double dVar5;
 	int iVar6;
 	u32 uVar7;
 	u32 uVar8;
-	union {
-		u64 bits;
-		double d;
-	} cvt;
 
 	iVar6 = (int)(((CPtrArray<CMaterial>*)((char*)&MapMng + 8))->operator[](*(u16*)((char*)this + 4)));
-	dVar5 = DOUBLE_8032fcf8;
 	iVar6 = *(int*)(iVar6 + 0x3c);
 	uVar8 = *(u32*)(iVar6 + 100);
 	uVar7 = *(u32*)(iVar6 + 0x68);
 	*((u8*)this + 7) = *(u8*)(iVar6 + 0x6c);
-	cvt.bits = 0x4330000000000000ULL | (u64)uVar8;
-	fVar1 = (float)(cvt.d - dVar5);
-	cvt.bits = 0x4330000000000000ULL | (u64)uVar7;
-	fVar2 = (float)(cvt.d - dVar5);
+	fVar1 = (float)((double)uVar8);
+	fVar2 = (float)((double)uVar7);
 	fVar3 = *(float*)((char*)this + 0xa8);
 	if (*(s8*)((char*)this + 6) == 0) {
 		C_MTXLightOrtho((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,


### PR DESCRIPTION
## Summary
- Refactored `CMapShadow::Init()` in `src/mapshadow.cpp` to a tighter, source-plausible form.
- Simplified temporary usage and integer-to-float conversion flow.
- Kept behavior unchanged while improving code generation alignment for the target function.

## Functions Improved
- Unit: `main/mapshadow`
- Symbol: `Init__10CMapShadowFv`
- Size: 236 bytes

## Match Evidence
- Before: `41.915253%`
- After: `53.440678%`
- Delta: `+11.525425` points

Objdiff command used:
`build/tools/objdiff-cli diff -p . -u main/mapshadow -o - Init__10CMapShadowFv`

## Plausibility Rationale
- The change avoids contrived compiler-coaxing patterns and keeps straightforward game-side math/control flow.
- It uses normal local variables and existing API calls (`C_MTXLightOrtho`/`C_MTXLightFrustum`) without introducing unnatural sequencing.

## Technical Notes
- Prior attempt changing only branch ordering was neutral.
- The effective improvement came from tightening temporary/conversion structure in `Init()`, which shifted FP setup and call-site codegen to better align with target assembly.