### PR TITLE
mapshadow: improve Init__10CMapShadowFv match by reordering projection branch

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -80,17 +80,17 @@ void CMapShadow::Init()
 	fVar1 = (float)((double)uVar8);
 	fVar2 = (float)((double)uVar7);
 	fVar3 = *(float*)((char*)this + 0xa8);
-	if (*(s8*)((char*)this + 6) == 0) {
-		C_MTXLightOrtho((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,
-		                (float)(DOUBLE_8032fce8 * (double)fVar3),
-		                (float)((double)FLOAT_8032fcf0 * (double)fVar3),
-		                FLOAT_8032fcf0, FLOAT_8032fcf0);
-	} else {
+	if (*(s8*)((char*)this + 6) != 0) {
 		C_MTXLightFrustum((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,
 		                  *(float*)((char*)this + 0xac),
 		                  (float)(DOUBLE_8032fce8 * (double)fVar3),
 		                  (float)((double)FLOAT_8032fcf0 * (double)fVar3),
 		                  FLOAT_8032fcf0, FLOAT_8032fcf0);
+	} else {
+		C_MTXLightOrtho((MtxPtr)((char*)this + 0x48), -fVar2, fVar2, -fVar1, fVar1,
+		                (float)(DOUBLE_8032fce8 * (double)fVar3),
+		                (float)((double)FLOAT_8032fcf0 * (double)fVar3),
+		                FLOAT_8032fcf0, FLOAT_8032fcf0);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reordered the CMapShadow::Init branch on ield_0x6 so the frustum path is emitted first and ortho path is in the else block.
- Kept behavior identical; only control-flow shape changed.

## Functions improved
- Unit: main/mapshadow
- Symbol: Init__10CMapShadowFv

## Match evidence
- Init__10CMapShadowFv: 41.915253% -> 47.949154% (+6.033901)
- CMapShadowInsertOctTree__FQ210CMapShadow6TARGETR8COctTree: unchanged at 78.13559%
- Draw__10CMapShadowFv: unchanged at 91.541664%
- Calc__10CMapShadowFv: unchanged at 93.809525%
- Build verification: 
inja completed successfully after the change.

## Plausibility rationale
- The change is source-plausible: it is a straightforward conditional rewrite with no artificial temporaries, no hardcoded compiler tricks, and no semantic change.
- This aligns with likely original authored logic while improving emitted branch/instruction ordering.

## Technical details
- Objdiff mismatch concentration in Init__10CMapShadowFv indicated branch-path ordering differences around C_MTXLightFrustum/C_MTXLightOrtho call regions.
- Reordering branch structure reduced those mismatches without introducing regressions in sibling functions of the same unit.