### PR TITLE
gx/GXBump: improve GXSetIndTexOrder match via explicit bitfield updates

### DIFF
--- a/src/gx/GXBump.c
+++ b/src/gx/GXBump.c
@@ -135,6 +135,8 @@ void GXSetIndTexCoordScale(GXIndTexStageID ind_state, GXIndTexScale scale_s, GXI
  * JP Size: TODO
  */
 void GXSetIndTexOrder(GXIndTexStageID ind_stage, GXTexCoordID tex_coord, GXTexMapID tex_map) {
+    u32 iref;
+
     CHECK_GXBEGIN(302, "GXSetIndTexOrder");
 
     ASSERTMSGLINE(314, tex_map < GX_MAX_TEXMAP, "GXSetIndTexOrder: Invalid direct texture Id");
@@ -142,20 +144,28 @@ void GXSetIndTexOrder(GXIndTexStageID ind_stage, GXTexCoordID tex_coord, GXTexMa
 
     switch (ind_stage) {
     case GX_INDTEXSTAGE0:
-        SET_REG_FIELD(319, __GXData->iref, 3, 0, tex_map);
-        SET_REG_FIELD(320, __GXData->iref, 3, 3, tex_coord);
+        iref = __GXData->iref;
+        iref = (iref & 0xFFFFFFF8) | (u32)tex_map;
+        iref = (iref & 0xFFFFFFC7) | ((u32)tex_coord << 3);
+        __GXData->iref = iref;
         break;
     case GX_INDTEXSTAGE1:
-        SET_REG_FIELD(323, __GXData->iref, 3, 6, tex_map);
-        SET_REG_FIELD(324, __GXData->iref, 3, 9, tex_coord);
+        iref = __GXData->iref;
+        iref = (iref & 0xFFFFFE3F) | ((u32)tex_map << 6);
+        iref = (iref & 0xFFFFF1FF) | ((u32)tex_coord << 9);
+        __GXData->iref = iref;
         break;
     case GX_INDTEXSTAGE2:
-        SET_REG_FIELD(327, __GXData->iref, 3, 12, tex_map);
-        SET_REG_FIELD(328, __GXData->iref, 3, 15, tex_coord);
+        iref = __GXData->iref;
+        iref = (iref & 0xFFFF8FFF) | ((u32)tex_map << 12);
+        iref = (iref & 0xFFFC7FFF) | ((u32)tex_coord << 15);
+        __GXData->iref = iref;
         break;
     case GX_INDTEXSTAGE3:
-        SET_REG_FIELD(331, __GXData->iref, 3, 18, tex_map);
-        SET_REG_FIELD(332, __GXData->iref, 3, 21, tex_coord);
+        iref = __GXData->iref;
+        iref = (iref & 0xFFE3FFFF) | ((u32)tex_map << 18);
+        iref = (iref & 0xFF1FFFFF) | ((u32)tex_coord << 21);
+        __GXData->iref = iref;
         break;
     default:
         ASSERTMSGLINE(335, 0, "GXSetIndTexOrder: Invalid Indirect Stage Id");


### PR DESCRIPTION
## Summary
- Reworked GXSetIndTexOrder in src/gx/GXBump.c to use explicit iref bitfield mask/shift updates per indirect stage.
- Kept existing validation and BP write flow intact; only changed how __GXData->iref fields are updated.

## Functions improved
- Unit: main/gx/GXBump
- Symbol: GXSetIndTexOrder

## Match evidence
- Before: **67.246376%** (uild/tools/objdiff-cli diff -p . -u main/gx/GXBump -o - GXSetIndTexOrder)
- After: **88.014496%**
- Delta: **+20.76812 percentage points**

## Plausibility rationale
- The new code reflects a natural low-level SDK coding style for GX register packing: read-modify-write with explicit masks/shifts.
- Behavior is unchanged: same stage routing, same field widths/offsets, same final register write + dirty flag updates.

## Technical notes
- Objdiff previously showed repeated replace/delete patterns around SET_REG_FIELD macro expansion.
- Switching to direct mask/shift operations aligned emitted instruction shape substantially better (fewer synthetic field-helper patterns, closer to expected branch-local RMW sequences).