### PR TITLE
gxfunc: match Tev color/alpha op cache helpers

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -178,16 +178,14 @@ void _GXSetTevAlphaIn(_GXTevStageID stage, _GXTevAlphaArg a, _GXTevAlphaArg b, _
  */
 void _GXSetTevColorOp(_GXTevStageID stage, _GXTevOp op, _GXTevBias bias, _GXTevScale scale, unsigned char clamp, _GXTevRegID outReg)
 {
-	int stageOff = stage * 0x14;
-	char* entry = (char*)s_GXSetTevColorOp_Reg + stageOff;
+	GXTevColorOpReg* entry = &s_GXSetTevColorOp_Reg[stage];
 
-	if (*(int*)(entry + 0x0) != op || *(int*)(entry + 0x4) != bias || *(int*)(entry + 0x8) != scale || *(entry + 0xC) != clamp ||
-	    *(int*)(entry + 0x10) != outReg) {
-		*(int*)(entry + 0x0) = op;
-		*(int*)(entry + 0x4) = bias;
-		*(int*)(entry + 0x8) = scale;
-		*(entry + 0xC) = clamp;
-		*(int*)(entry + 0x10) = outReg;
+	if (entry->op != op || entry->bias != bias || entry->scale != scale || entry->clamp != clamp || entry->outReg != outReg) {
+		entry->op = op;
+		entry->bias = bias;
+		entry->scale = scale;
+		entry->clamp = clamp;
+		entry->outReg = outReg;
 		GXSetTevColorOp(stage, op, bias, scale, clamp, outReg);
 	}
 }
@@ -203,16 +201,14 @@ void _GXSetTevColorOp(_GXTevStageID stage, _GXTevOp op, _GXTevBias bias, _GXTevS
  */
 void _GXSetTevAlphaOp(_GXTevStageID stage, _GXTevOp op, _GXTevBias bias, _GXTevScale scale, unsigned char clamp, _GXTevRegID outReg)
 {
-	int stageOff = stage * 0x14;
-	char* entry = (char*)s_GXSetTevAlphaOp_Reg + stageOff;
+	GXTevAlphaOpReg* entry = &s_GXSetTevAlphaOp_Reg[stage];
 
-	if (*(int*)(entry + 0x0) != op || *(int*)(entry + 0x4) != bias || *(int*)(entry + 0x8) != scale || *(entry + 0xC) != clamp ||
-	    *(int*)(entry + 0x10) != outReg) {
-		*(int*)(entry + 0x0) = op;
-		*(int*)(entry + 0x4) = bias;
-		*(int*)(entry + 0x8) = scale;
-		*(entry + 0xC) = clamp;
-		*(int*)(entry + 0x10) = outReg;
+	if (entry->op != op || entry->bias != bias || entry->scale != scale || entry->clamp != clamp || entry->outReg != outReg) {
+		entry->op = op;
+		entry->bias = bias;
+		entry->scale = scale;
+		entry->clamp = clamp;
+		entry->outReg = outReg;
 		GXSetTevAlphaOp(stage, op, bias, scale, clamp, outReg);
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked `_GXSetTevColorOp` and `_GXSetTevAlphaOp` cache access to use typed struct entries (`GXTevColorOpReg*` / `GXTevAlphaOpReg*`) instead of byte-pointer + integer offset casts.
- Kept behavior identical: same guard condition, same cached writes, same `GXSetTev*Op` call path.

## Functions improved
- `main/gxfunc`:
  - `_GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID`
  - `_GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID`

## Match evidence
- `_GXSetTevColorOp`: `95.15151% -> 100.0%`
- `_GXSetTevAlphaOp`: `95.15151% -> 100.0%`
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/gxfunc -o - _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID`
  - `build/tools/objdiff-cli diff -p . -u main/gxfunc -o - _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID`

## Plausibility rationale
- This change removes low-level byte-offset casts and uses the existing typed cache structs already defined in this file.
- The resulting code is clearer and more idiomatic C/C++ for the established cache pattern, while preserving all runtime semantics.

## Technical details
- The remaining non-match was in the cached `clamp` compare/write sequence.
- Switching to typed field access produced the expected compare/load/store shape for both Tev op helpers, reaching exact matches.