### PR TITLE
ringmenu: restore CRingMenu inheritance from CMenu

### DIFF
--- a/include/ffcc/ringmenu.h
+++ b/include/ffcc/ringmenu.h
@@ -1,6 +1,8 @@
 #ifndef _FFCC_PPP_RINGMENU_H_
 #define _FFCC_PPP_RINGMENU_H_
 
+#include "ffcc/menu.h"
+
 class CFont;
 class CCaravanWork;
 class CGame;
@@ -8,7 +10,7 @@ class CMenuPcs;
 
 void drawCommand(int, CFont*, float, float, CCaravanWork*, int, float, float);
 
-class CRingMenu
+class CRingMenu : public CMenu
 {
 public:
     CRingMenu();


### PR DESCRIPTION
## Summary
- Restored `CRingMenu` class hierarchy so it derives from `CMenu`.
- Added `#include "ffcc/menu.h"` in `include/ffcc/ringmenu.h` to make the inheritance explicit and compile-time correct.

## Functions improved
Unit: `main/ringmenu`
- `__ct__9CRingMenuFv`: **6.6667% -> 99.3333%** (`60b`)
- `__dt__9CRingMenuFv`: **20.3333% -> 23.7222%** (`216b`)

## Match evidence
`objdiff-cli` (`tools/objdiff-cli v3.6.1`), unit diff:
- Unit `.text` match: **1.0348% -> 1.6864%**
- Constructor alignment improved from near-stub emission to near-complete match.

## Plausibility rationale
`CRingMenu` using `CMenu` lifecycle/virtual behavior is consistent with existing menu architecture (`CMenu` has virtual `onCalc/onDraw/onScript...`).
Restoring inheritance is a source-plausible correction to type structure, not a compiler-coaxing reorder.

## Technical details
- Previous declaration treated `CRingMenu` as a standalone class with no base.
- This prevented expected base constructor/destructor and vtable setup codegen from materializing.
- Declaring `class CRingMenu : public CMenu` corrected emitted constructor/destructor sequences and improved symbol alignment.
