### PR TITLE
math: implement CMath::DstRot

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -48,7 +48,7 @@ public:
     void Spline1D(int, float, float*, float*, float*);
     void Line1D(int, float, float*, float*);
     unsigned int Hsb2Rgb(int, int, int);
-    void DstRot(float, float);
+    float DstRot(float, float);
 };
 
 #endif // _FFCC_CMATH_H_

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -790,10 +790,37 @@ unsigned int CMath::Hsb2Rgb(int hue, int saturation, int brightness)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001a2f8
+ * PAL Size: 236b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::DstRot(float, float)
+float CMath::DstRot(float from, float to)
 {
-	// TODO
+    const double s0 = (double)(float)sin((double)from);
+    const double c0 = (double)(float)cos((double)from);
+    const double s1 = (double)(float)sin((double)to);
+    const double c1 = (double)(float)cos((double)to);
+
+    const double dot = (double)(float)(s0 * s1 + (double)(float)(c0 * c1));
+    double angle = 0.0;
+
+    if (angle != dot) {
+        angle = -1.0;
+        if (angle <= dot) {
+            angle = dot;
+            if (1.0 < dot) {
+                angle = 1.0;
+            }
+        }
+
+        angle = (double)(float)acos(angle);
+        if ((float)(s0 * c1 - (double)(float)(s1 * c0)) < 0.0f) {
+            angle = -angle;
+        }
+    }
+
+    return (float)angle;
 }


### PR DESCRIPTION
## Summary
- Implemented CMath::DstRot(float, float) in src/math.cpp using trig-dot/acos/sign flow inferred from decomp.
- Updated declaration in include/ffcc/math.h from oid to loat to match symbol behavior.
- Added function metadata block with PAL address/size.

## Functions improved
- Unit: main/math
- Symbol: DstRot__5CMathFff

## Match evidence
- Before: 1.7% (from 	ools/agent_select_target.py target listing)
- After: 76.61017% (objdiff-cli diff -p . -u main/math -o - DstRot__5CMathFff)
- Build: 
inja succeeds after changes.

## Plausibility rationale
- DstRot is used as an angle-difference utility; returning a float angle is source-plausible and consistent with decomp call-site behavior.
- Implementation uses standard game math operations (sin, cos, cos, sign by cross-term) and avoids compiler-coaxing-only constructs.

## Technical details
- Uses cosine identity cos(a-b) = sin(a)sin(b)+cos(a)cos(b) to derive angular distance.
- Clamps acos input into [-1, 1] and applies orientation sign from sin(a)cos(b)-sin(b)cos(a).
