### PR TITLE
pppSRandDownHCV: improve match via branch/flag cleanup

### DIFF
--- a/src/pppSRandDownHCV.cpp
+++ b/src/pppSRandDownHCV.cpp
@@ -29,7 +29,7 @@ void pppSRandDownHCV(void* param1, void* param2, void* param3)
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);
 
-		u8 flag = *((u8*)param2 + 0x10);
+		int flag = *((u8*)param2 + 0x10);
 		float value;
 
 		value = -RandF__5CMathFv(&math);
@@ -55,7 +55,7 @@ void pppSRandDownHCV(void* param1, void* param2, void* param3)
 			value = (value - RandF__5CMathFv(&math)) * 0.5f;
 		}
 		target[3] = value;
-	} else if (*(int*)param2 != *((int*)param1 + 3)) {
+	} else {
 		int** base_ptr = (int**)((char*)param3 + 0xc);
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);


### PR DESCRIPTION
## Summary
- Updated `pppSRandDownHCV` control-flow to use a plain `else` fallback instead of a redundant `else if` recheck.
- Kept the randomization flag in a single local integer (`flag`) used across all four channel updates.

## Functions improved
- Unit: `main/pppSRandDownHCV`
- Symbol: `pppSRandDownHCV`

## Match evidence
- Before: `85.335365%`
- After: `86.310974%`
- Net: `+0.975609` percentage points
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/pppSRandDownHCV -o - pppSRandDownHCV`

## Plausibility rationale
- The updated branch shape is more idiomatic original-source C (`if (...) { ... } else { ... }`) and removes a logically redundant condition.
- Keeping `flag` as a local read-once value is natural game-code style and avoids repeated memory reloads in generated code.

## Technical notes
- This change reduced objdiff instruction deltas around the branch split and flag-handling sections while preserving behavior.
- Build remains green with `ninja`.