### PR TITLE
main/pppPointAp: match pppPointApCon addressing form

### DIFF
--- a/src/pppPointAp.cpp
+++ b/src/pppPointAp.cpp
@@ -31,8 +31,8 @@ extern _pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
 void pppPointApCon(void* param1, void* param2)
 {
     _pppPointApOffsets* data = *(_pppPointApOffsets**)((u8*)param2 + 0xC);
-    u32 offset = data->targetOffset + 0x81;
-    ((u8*)param1)[offset] = 0;
+    u8* target = (u8*)param1 + data->targetOffset;
+    target[0x81] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
Adjust `pppPointApCon` pointer arithmetic to use a base pointer plus fixed byte offset form.

- Before: computed `targetOffset + 0x81` then indexed `param1[offset]`
- After: computed base `target = (u8*)param1 + targetOffset` then wrote `target[0x81] = 0`

## Functions improved
- Unit: `main/pppPointAp`
- Symbol: `pppPointApCon`

## Match evidence
- `pppPointApCon`: **79.166664% -> 100.0%** (24b symbol)
- Unit `.text` match (`main/pppPointAp`): **95.28169% -> 97.04225%**
- `objdiff` now shows no instruction diffs for `pppPointApCon`.

## Plausibility rationale
The new source is natural C/C++ pointer arithmetic and preserves behavior exactly while matching the expected addressing pattern. This is a readability-neutral cleanup, not contrived compiler coaxing.

## Technical details
The prior form encouraged indexed store codegen (`addi` + `stbx`). Rewriting to a pre-adjusted base pointer moved the constant displacement into the store address, yielding the target instruction sequence for this function.