### PR TITLE
game: implement LoadLogoWaitingData

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -21,11 +21,17 @@ void Quit__18CMaterialEditorPcsFv(void*);
 void Quit__14CFunnyShapePcsFv(void*);
 void Quit__11CGraphicPcsFv(void*);
 void Quit__10CCameraPcsFv(void*);
+void createLoad__9CSoundPcsFv(void*);
+void createLoad__9CCharaPcsFv(void*);
+void createLoad__8CPartPcsFv(void*);
+void Printf__7CSystemFPce(CSystem* system, const char* format, ...);
 unsigned char CFlat[];
 unsigned char McPcs[];
 unsigned char GbaPcs[];
 unsigned char MenuPcs[];
 unsigned char USBPcs[];
+unsigned char SoundPcs[];
+unsigned char PartPcs[];
 unsigned char Chara[];
 unsigned char LightPcs[];
 unsigned char MapPcs[];
@@ -33,6 +39,7 @@ unsigned char MaterialEditorPcs[];
 unsigned char FunnyShapePcs[];
 unsigned char GraphicsPcs[];
 unsigned char CameraPcs[];
+extern const char DAT_801d61dc[];
 }
 
 static const float FLOAT_8032f688 = 1.0E+10;
@@ -113,7 +120,15 @@ void CGame::Quit()
  */
 void CGame::LoadLogoWaitingData()
 {
-	// TODO
+	if (m_assetsLoadedFlag == 0) {
+		createLoad__9CSoundPcsFv(SoundPcs);
+		createLoad__9CCharaPcsFv(&CharaPcs);
+		createLoad__8CPartPcsFv(&PartPcs);
+		m_assetsLoadedFlag = 1;
+		if (System.m_execParam > 2) {
+			Printf__7CSystemFPce(&System, DAT_801d61dc);
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented CGame::LoadLogoWaitingData() in src/game.cpp using the existing engine call flow:
- one-time load gate via m_assetsLoadedFlag
- calls into sound/chara/part createLoad routines
- sets m_assetsLoadedFlag = 1
- preserves debug print behavior for System.m_execParam > 2

## Functions improved
- Unit: main/game
- Symbol: LoadLogoWaitingData__5CGameFv
- Match: **2.941176% -> 88.382355%** (+85.441179)

## Match evidence
Measured with:
uild/tools/objdiff-cli diff -p . -u main/game -o -

Before/after for key symbol:
- LoadLogoWaitingData__5CGameFv: 2.941176 -> 88.382355

## Plausibility rationale
The implementation follows the expected source-level behavior for this subsystem: lazy one-time asset preload during logo wait, then flag update to avoid repeated work. The control flow and calls are consistent with other CGame lifecycle methods and existing process module interfaces.

## Technical details
- Added explicit extern declarations for known create-load entry points and debug printf entry point in game.cpp.
- Hooked the function into existing globals (SoundPcs, CharaPcs, PartPcs, System) without introducing synthetic temporaries or non-idiomatic coercions.
- Verified build and objdiff after change.
