### PR TITLE
pppYmTracer: fix construct2 serialized offset addressing

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -119,9 +119,9 @@ void pppConstruct2YmTracer(pppYmTracer* pppYmTracer, UnkC* param_2)
 {
     u8* work;
 
-    work = (u8*)pppYmTracer + *param_2->m_serializedDataOffsets;
-    *(u16*)(work + 0xAE) = 0;
-    *(u16*)(work + 0xAC) = 0;
+    work = (u8*)pppYmTracer + 0x80 + *param_2->m_serializedDataOffsets;
+    *(u16*)(work + 0x2E) = 0;
+    *(u16*)(work + 0x2C) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppConstruct2YmTracer` pointer math to use the same two-step addressing pattern as the original object layout.
- Kept behavior identical (zeroing the same two `u16` fields), but expressed offsets as `base + 0x80 + serializedOffset` then `+0x2C/+0x2E`.

## Functions improved
- Unit: `main/pppYmTracer`
- Symbol: `pppConstruct2YmTracer`

## Match evidence
- `objdiff` (symbol-targeted): `pppConstruct2YmTracer` improved from **85.375%** to **100.0%**.
- Build report (`ninja`):
  - Code matched bytes: **196716 -> 196748** (+32)
  - Matched functions: **1432 -> 1433** (+1)

## Plausibility rationale
- This is a type/layout correction, not compiler coaxing: the function now uses serialized work-area base addressing consistent with nearby constructor/destructor code in `pppYmTracer`.
- The change preserves readability and intent while aligning with expected object field placement.

## Technical details
- `objdiff` initially showed a missing `+0x80` base-adjust sequence in `pppConstruct2YmTracer`.
- Rewriting the stores around the explicit serialized work base restored the expected store pattern and closed the remaining diff for this symbol.