### PR TITLE
cflat_r2system: implement tex shadow/event-word wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -288,6 +288,52 @@ extern "C" void SetTexShadowColor__9CCharaPcsF8_GXColor(void* charaPcs, const un
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9228
+ * PAL Size: 28b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetTexShadowPos__9CCharaPcsFP3Vec(void* charaPcs, Vec* vec)
+{
+    float* self = (float*)((char*)charaPcs + 0x17C);
+
+    self[0] = vec->x;
+    self[1] = vec->y;
+    self[2] = vec->z;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9244
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetEvtWord__12CCaravanWorkFis(CCaravanWork* caravanWork, int evtWordIndex, short evtWord)
+{
+    caravanWork->m_evtWordArr[evtWordIndex] = evtWord;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9254
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int GetEvtWord__12CCaravanWorkFi(CCaravanWork* caravanWork, int evtWordIndex)
+{
+    return caravanWork->m_evtWordArr[evtWordIndex];
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added missing `extern C` wrappers in `src/cflat_r2system.cpp` for low-level system symbols:
  - `SetTexShadowPos__9CCharaPcsFP3Vec`
  - `SetEvtWord__12CCaravanWorkFis`
  - `GetEvtWord__12CCaravanWorkFi`
- Used existing class field semantics (`CCaravanWork::m_evtWordArr`) and existing file conventions (PAL metadata headers + offset wrappers for `CCharaPcs`).

## Functions improved
- Unit: `main/cflat_r2system`
- `SetTexShadowPos__9CCharaPcsFP3Vec` (28b): **0.0% -> 100.0%**
- `SetEvtWord__12CCaravanWorkFis` (16b): **0.0% -> 100.0%**
- `GetEvtWord__12CCaravanWorkFi` (16b): now **100.0%**

## Match evidence
- `ninja` build succeeds.
- `build/GCCP01/report.json` now reports:
  - `SetTexShadowPos__9CCharaPcsFP3Vec`: `fuzzy_match_percent = 100.0`
  - `SetEvtWord__12CCaravanWorkFis`: `fuzzy_match_percent = 100.0`
  - `GetEvtWord__12CCaravanWorkFi`: `fuzzy_match_percent = 100.0`
- Unit-level matched functions improved from selector baseline `6/84 (7.1%)` to `9/84 (10.7%)`.

## Plausibility rationale
- Changes are straightforward accessors/mutators consistent with surrounding source style (same wrapper form used by `SetTexShadowRadius` and `SetTexShadowColor`).
- No contrived control-flow or compiler-coaxing temporaries were introduced.
- Field usage aligns with current reconstructed data layout (`m_evtWordArr`).

## Technical notes
- Selector output indicated these tiny symbols were unresolved in this unit.
- Ghidra references were used only to confirm address/size and basic intent, then implemented with existing local type info and naming conventions.