### PR TITLE
main/pppVtMime: improve pppVtMimeCon init matching

### DIFF
--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/pppVtMime.h"
+#include "ffcc/graphic.h"
 
 struct VtMimeCtrl
 {
@@ -39,7 +40,6 @@ struct VtMimeEnv
 
 extern int lbl_8032ED70;
 extern VtMimeEnv* lbl_8032ED54;
-extern void* Graphic;
 static char s_pppVtMime_cpp[] = "pppVtMime.cpp";
 
 extern "C" {
@@ -151,9 +151,9 @@ void pppVtMimeCon(void* param1, void* param2, void* param3)
 {
     VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
 
-    state->value = 0.0f;
-    state->velocity = 0.0f;
     state->accel = 0.0f;
+    state->velocity = 0.0f;
+    state->value = 0.0f;
     state->vertexBuffer = 0;
 }
 
@@ -170,9 +170,9 @@ void pppVtMimeCon2(void* param1, void* param2, void* param3)
 {
     VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
 
-    state->value = 0.0f;
-    state->velocity = 0.0f;
     state->accel = 0.0f;
+    state->velocity = 0.0f;
+    state->value = 0.0f;
 }
 
 /*
@@ -189,7 +189,7 @@ void pppVtMimeDes(void* param1, void* param2)
     VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
 
     if (state->vertexBuffer != 0) {
-        _WaitDrawDone__8CGraphicFPci(Graphic, s_pppVtMime_cpp, 0x50);
+        _WaitDrawDone__8CGraphicFPci(&Graphic, s_pppVtMime_cpp, 0x50);
         pppHeapUseRate__FPQ27CMemory6CStage(state->vertexBuffer);
         state->vertexBuffer = 0;
     }


### PR DESCRIPTION
## Summary
- Updated `src/pppVtMime.cpp` to use the shared `Graphic` declaration from `ffcc/graphic.h` and pass `&Graphic` in `pppVtMimeDes`.
- Reordered zero-initialization writes in `pppVtMimeCon` and `pppVtMimeCon2` to match observed store ordering.

## Functions improved
- Unit: `main/pppVtMime`
- `pppVtMimeCon`: `99.36364%` -> `99.545456%` (44b)
- `pppVtMimeCon2`: `99.22222%` -> `99.44444%` (36b)

## Match evidence
- Before (`/tmp/pppVtMime_all.json`):
  - `pppVtMimeCon` = `99.36364%`
  - `pppVtMimeCon2` = `99.22222%`
- After (`/tmp/pppVtMime_finalcheck.json`):
  - `pppVtMimeCon` = `99.545456%`
  - `pppVtMimeCon2` = `99.44444%`
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/pppVtMime -o -`.

## Plausibility rationale
- The edits preserve straightforward constructor/destructor-style initialization logic.
- Using `&Graphic` is consistent with the global `CGraphic Graphic` object declaration used throughout the codebase.
- Assignment reordering is a plausible original-source variation and improves alignment without contrived compiler coercion.

## Technical details
- `pppVtMimeCon2` now emits `stfs` in `+8, +4, +0` order, aligning more closely with target instruction flow.
- No behavior changes; only initialization order and symbol typing/call form were adjusted.
