### PR TITLE
main/pppYmMoveCircle: improve pppFrameYmMoveCircle match by removing redundant copy

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -78,7 +78,6 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
 extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleStep* stepData, pppYmMoveCircleOffsets* offsetData)
 {
     pppYmMoveCircleWork* work;
-    Vec currentPos;
     Vec nextPos;
     s32 tableIndex;
 
@@ -114,8 +113,7 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
     nextPos.y = *(f32*)((u8*)lbl_8032ED50 + 0xC);
     nextPos.z = (work->m_radius * -(*(f32*)((u8*)lbl_801EC9F0 + (tableIndex & 0xFFFC)))) + work->m_center.z;
 
-    pppCopyVector(currentPos, *(Vec*)((u8*)lbl_8032ED50 + 0x8));
-    pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x48), currentPos);
+    pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x48), *(Vec*)((u8*)lbl_8032ED50 + 0x8));
     pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x8), nextPos);
 
     *(f32*)((u8*)lbl_8032ED50 + 0x84) = nextPos.x;


### PR DESCRIPTION
## Summary
- Simplified `pppFrameYmMoveCircle` in `src/pppYmMoveCircle.cpp` by removing an intermediate `Vec currentPos` temporary.
- Replaced two-step copy (`m_position -> currentPos -> m_prevPosition`) with a direct copy (`m_position -> m_prevPosition`).
- No behavioral change: data flow and write targets are unchanged.

## Functions improved
- Unit: `main/pppYmMoveCircle`
- `pppFrameYmMoveCircle`: **73.36429% -> 78.62857%**
- `pppConstructYmMoveCircle`: **72.666664% -> 72.666664%** (unchanged)

## Match evidence
- `ninja` build passes.
- `objdiff-cli` before/after (`build/tools/objdiff-cli diff -p . -u main/pppYmMoveCircle -o - pppFrameYmMoveCircle`):
  - `MATCH` instructions: **45 -> 54**
  - `DIFF_INSERT`: **14 -> 5**
  - `DIFF_ARG_MISMATCH`: **73 -> 62**
- Improvement is concentrated in the frame update/copy section, not just cosmetic renaming.

## Plausibility rationale
- The removed temporary was redundant and non-idiomatic for this codebase's vector copy helpers.
- Directly copying from current position to previous position is the natural source-level representation and preserves intent/readability.
- Change avoids compiler-coaxing constructs and keeps function structure aligned with existing PPP update code style.

## Technical details
- File changed: `src/pppYmMoveCircle.cpp`
- Edit scope is minimal (one local removed, one copy call simplified) to reduce risk and keep the resulting source plausible.
