### PR TITLE
math: implement CMath::Spline1D

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -45,7 +45,7 @@ public:
     void CrossCheckEllipseCapsule(Vec*, float*, Vec*, Vec*, float, Vec*, float, float);
     void CalcSpline(Vec*, Vec*, Vec*, Vec*, Vec*, float, float, float, float, float);
     void MakeSpline1Dtable(int, float*, float*, float*);
-    void Spline1D(int, float, float*, float*, float*);
+    float Spline1D(int, float, float*, float*, float*);
     void Line1D(int, float, float*, float*);
     unsigned int Hsb2Rgb(int, int, int);
     float DstRot(float, float);

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -704,12 +704,49 @@ void CMath::MakeSpline1Dtable(int count, float* x, float* y, float* outSecondDer
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001a62c
+ * PAL Size: 220b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::Spline1D(int, float, float*, float*, float*)
+float CMath::Spline1D(int lastIndex, float t, float* x, float* y, float* secondDerivatives)
 {
-	// TODO
+    float period = x[lastIndex] - x[0];
+
+    while (x[lastIndex] < t) {
+        t -= period;
+    }
+
+    while (t < x[0]) {
+        t += period;
+    }
+
+    int low = 0;
+    int high = lastIndex;
+    while (low < high) {
+        int mid = (low + high) / 2;
+        if (x[mid] < t) {
+            low = mid + 1;
+        }
+        else {
+            high = mid;
+        }
+    }
+
+    if (low > 0) {
+        low--;
+    }
+
+    float sd0 = secondDerivatives[low];
+    float dt = t - x[low];
+    float dx = x[low + 1] - x[low];
+
+    return dt * (dt * (0.5f * sd0 + (dt * (secondDerivatives[low + 1] - sd0)) / dx) -
+                 (dx * (0.33333334f * sd0 + secondDerivatives[low + 1]) -
+                  (y[low + 1] - y[low]) / dx)) +
+           y[low];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMath::Spline1D` in `src/math.cpp` using periodic domain wrap + binary search interval selection + cubic spline evaluation.
- Corrected the declaration/definition return type from `void` to `float` for `CMath::Spline1D` in `include/ffcc/math.h` and `src/math.cpp`.
- Added PAL function metadata comment for the implemented function.

## Functions Improved
- Unit: `main/math`
- Symbol: `Spline1D__5CMathFifPfPfPf`
- Match: **1.8181819% -> 96.454544%**
- Size: `220b` (unchanged)

## Match Evidence
- Built with `ninja` successfully.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/math -o - Spline1D__5CMathFifPfPfPf`
- Residual differences are small (`DIFF_ARG_MISMATCH` dominant) with only minor opcode/replace deltas, indicating strong instruction-level alignment.

## Plausibility Rationale
- The implementation follows standard periodic cubic spline evaluation structure and matches the surrounding code style:
  - wraps parameter into spline period
  - finds segment via binary search
  - evaluates cubic using precomputed second-derivative table from `MakeSpline1Dtable`
- This is a source-plausible correction (algorithm + signature) rather than compiler-coaxing or unnatural control-flow tricks.

## Technical Notes
- `Spline1D` was previously an empty TODO, so this change removes a major semantic gap and aligns generated code closely with expected behavior.
- The updated `float` return type matches runtime use as a scalar spline value and aligns with decompilation behavior.
