### PR TITLE
Improve __sinit_p_sample_cpp static table initialization match

### DIFF
--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -117,38 +117,19 @@ void CSamplePcs::func1()
  */
 extern "C" void __sinit_p_sample_cpp(void)
 {
-	unsigned int* a = lbl_801E8498;
-	unsigned int* b = lbl_801E84A4;
-	unsigned int* table = (unsigned int*)lbl_801E84C8;
-	unsigned int* c = lbl_801E84B0;
-	unsigned int* d = lbl_801E84BC;
-
-	unsigned int a1 = a[1];
-	unsigned int a2 = a[2];
-	unsigned int b0 = b[0];
-	unsigned int b1 = b[1];
-	unsigned int b2 = b[2];
-	unsigned int c0 = c[0];
-	unsigned int c1 = c[1];
-	unsigned int c2 = c[2];
-	unsigned int d0 = d[0];
-	unsigned int d1 = d[1];
-	unsigned int d2 = d[2];
-	unsigned int a0 = a[0];
-
 	lbl_8032EC60 = (unsigned int)&lbl_801E8644;
-	table[1] = a0;
-	table[2] = a1;
-	table[3] = a2;
-	table[4] = b0;
-	table[5] = b1;
-	table[6] = b2;
-	table[7] = c0;
-	table[8] = c1;
-	table[9] = c2;
-	table[12] = d0;
-	table[13] = d1;
-	table[14] = d2;
+	((unsigned int*)lbl_801E84C8)[1] = lbl_801E8498[0];
+	((unsigned int*)lbl_801E84C8)[2] = lbl_801E8498[1];
+	((unsigned int*)lbl_801E84C8)[3] = lbl_801E8498[2];
+	((unsigned int*)lbl_801E84C8)[4] = lbl_801E84A4[0];
+	((unsigned int*)lbl_801E84C8)[5] = lbl_801E84A4[1];
+	((unsigned int*)lbl_801E84C8)[6] = lbl_801E84A4[2];
+	((unsigned int*)lbl_801E84C8)[7] = lbl_801E84B0[0];
+	((unsigned int*)lbl_801E84C8)[8] = lbl_801E84B0[1];
+	((unsigned int*)lbl_801E84C8)[9] = lbl_801E84B0[2];
+	((unsigned int*)lbl_801E84C8)[12] = lbl_801E84BC[0];
+	((unsigned int*)lbl_801E84C8)[13] = lbl_801E84BC[1];
+	((unsigned int*)lbl_801E84C8)[14] = lbl_801E84BC[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
Refactors __sinit_p_sample_cpp in src/p_sample.cpp to use direct global-to-global assignments in declaration order, removing unnecessary local temporaries.

## Functions improved
- Unit: main/p_sample
- Symbol: __sinit_p_sample_cpp

## Match evidence
- Before: 75.40426%
- After: 97.97872%
- Delta: +22.57446 percentage points

Measured with:
uild/tools/objdiff-cli diff -p . -u main/p_sample -o - __sinit_p_sample_cpp

## Plausibility rationale
The new code matches the likely original static-init style for Metrowerks-era C++: straightforward assignment of function table entries from known static symbols, without artificial temporaries or control-flow tricks.

## Technical details
- Removed temporary pointer/value staging that introduced extra loads/stores and register pressure.
- Kept the same destination slots ([1..9], [12..14]) and same source symbols.
- Preserved behavior while improving instruction ordering/alignment.

## Validation
- 
inja completed successfully after change.
