### PR TITLE
main/gx/GXBump: improve GXSetNumIndStages match to 99.3%

### DIFF
--- a/src/gx/GXBump.c
+++ b/src/gx/GXBump.c
@@ -167,9 +167,15 @@ void GXSetIndTexOrder(GXIndTexStageID ind_stage, GXTexCoordID tex_coord, GXTexMa
 }
 
 void GXSetNumIndStages(u8 nIndStages) {
+    u32 reg;
+
     CHECK_GXBEGIN(353, "GXSetNumIndStages");
     ASSERTMSGLINE(355, nIndStages <= 4, "GXSetNumIndStages: Exceeds max. number of indirect texture stages");
-    SET_REG_FIELD(356, __GXData->genMode, 3, 16, nIndStages);
+
+    reg = __GXData->genMode;
+    reg = (reg & 0xFFF8FFFFU) | ((u32)nIndStages << 16);
+    __GXData->genMode = reg;
+
     __GXData->dirtyState |= 6;
 }
 


### PR DESCRIPTION
## Summary
- Reworked `GXSetNumIndStages` in `src/gx/GXBump.c` to update `genMode` via explicit bitmask/shift assignment instead of `SET_REG_FIELD`.
- Kept behavior unchanged (`nIndStages` validation and `dirtyState` update remain identical).

## Functions improved
- Unit: `main/gx/GXBump`
- Symbol: `GXSetNumIndStages`

## Match evidence
- `GXSetNumIndStages`: **76.8% -> 99.3%** (size 40b)
- Neighboring tracked symbols remained stable:
  - `GXSetIndTexMtx`: 65.454544%
  - `GXSetIndTexCoordScale`: 65.4%

## Plausibility rationale
- This change expresses the same register-field update in straightforward SDK-style bit operations.
- No contrived control flow or artificial temporaries were introduced; code remains idiomatic for GX register packing.

## Technical details
- Old pattern relied on macro expansion for field insertion.
- New pattern computes:
  - `reg = __GXData->genMode`
  - `reg = (reg & 0xFFF8FFFFU) | ((u32)nIndStages << 16)`
  - `__GXData->genMode = reg`
- This improved instruction selection/alignment in objdiff for the target function while preserving semantics.
