### PR TITLE
gx/GXBump: improve GXSetIndTexCoordScale match

### DIFF
--- a/src/gx/GXBump.c
+++ b/src/gx/GXBump.c
@@ -95,27 +95,27 @@ void GXSetIndTexCoordScale(GXIndTexStageID ind_state, GXIndTexScale scale_s, GXI
 
     switch (ind_state) {
     case GX_INDTEXSTAGE0:
-        SET_REG_FIELD(253, __GXData->IndTexScale0, 4, 0, scale_s);
-        SET_REG_FIELD(254, __GXData->IndTexScale0, 4, 4, scale_t);
-        SET_REG_FIELD(254, __GXData->IndTexScale0, 8, 24, 0x25);
+        __GXData->IndTexScale0 = (__GXData->IndTexScale0 & 0xFFFFFFF0) | (u32)scale_s;
+        __GXData->IndTexScale0 = (__GXData->IndTexScale0 & 0xFFFFFF0F) | ((u32)scale_t << 4);
+        __GXData->IndTexScale0 = (__GXData->IndTexScale0 & 0x00FFFFFF) | 0x25000000;
         GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, __GXData->IndTexScale0);
         break;
     case GX_INDTEXSTAGE1:
-        SET_REG_FIELD(259, __GXData->IndTexScale0, 4, 8, scale_s);
-        SET_REG_FIELD(260, __GXData->IndTexScale0, 4, 12, scale_t);
-        SET_REG_FIELD(260, __GXData->IndTexScale0, 8, 24, 0x25);
+        __GXData->IndTexScale0 = (__GXData->IndTexScale0 & 0xFFFFF0FF) | ((u32)scale_s << 8);
+        __GXData->IndTexScale0 = (__GXData->IndTexScale0 & 0xFFFF0FFF) | ((u32)scale_t << 12);
+        __GXData->IndTexScale0 = (__GXData->IndTexScale0 & 0x00FFFFFF) | 0x25000000;
         GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, __GXData->IndTexScale0);
         break;
     case GX_INDTEXSTAGE2:
-        SET_REG_FIELD(265, __GXData->IndTexScale1, 4, 0, scale_s);
-        SET_REG_FIELD(266, __GXData->IndTexScale1, 4, 4, scale_t);
-        SET_REG_FIELD(266, __GXData->IndTexScale1, 8, 24, 0x26);
+        __GXData->IndTexScale1 = (__GXData->IndTexScale1 & 0xFFFFFFF0) | (u32)scale_s;
+        __GXData->IndTexScale1 = (__GXData->IndTexScale1 & 0xFFFFFF0F) | ((u32)scale_t << 4);
+        __GXData->IndTexScale1 = (__GXData->IndTexScale1 & 0x00FFFFFF) | 0x26000000;
         GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, __GXData->IndTexScale1);
         break;
     case GX_INDTEXSTAGE3:
-        SET_REG_FIELD(0x10F, __GXData->IndTexScale1, 4, 8, scale_s);
-        SET_REG_FIELD(0x110, __GXData->IndTexScale1, 4, 12, scale_t);
-        SET_REG_FIELD(0x110, __GXData->IndTexScale1, 8, 24, 0x26);
+        __GXData->IndTexScale1 = (__GXData->IndTexScale1 & 0xFFFFF0FF) | ((u32)scale_s << 8);
+        __GXData->IndTexScale1 = (__GXData->IndTexScale1 & 0xFFFF0FFF) | ((u32)scale_t << 12);
+        __GXData->IndTexScale1 = (__GXData->IndTexScale1 & 0x00FFFFFF) | 0x26000000;
         GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, __GXData->IndTexScale1);
         break;
     default:


### PR DESCRIPTION
## Summary
- Reworked `GXSetIndTexCoordScale` in `src/gx/GXBump.c` to use explicit masked bitfield updates for `IndTexScale0` and `IndTexScale1`.
- Kept behavior identical while aligning register-write construction with the expected SDK-style output.

## Functions improved
- Unit: `main/gx/GXBump`
- Function: `GXSetIndTexCoordScale`
  - Before: ~65.7% (selector baseline)
  - After: 100.0% (`build/GCCP01/report.json` fuzzy match)

## Match evidence
- Unit fuzzy match (`main/gx/GXBump`): 83.2% -> 90.96437%
- Project progress changed during rebuild:
  - Code matched: `196896 / 1855300` -> `197276 / 1855300`
  - Matched functions: `1439 / 4733` -> `1440 / 4733`
- Objdiff check for symbol diff confirms near/full alignment for this function (`~99.74%` one-shot diff view) and report-level 100.0%.

## Plausibility rationale
- The change removes macro-heavy field writes and replaces them with direct bitmask operations that are idiomatic for low-level GX register programming.
- No artificial temporaries or non-idiomatic control-flow tricks were introduced.
- Resulting code remains readable and consistent with surrounding GX code style.

## Technical details
- Replaced `SET_REG_FIELD` sequences with explicit masks/shifts for each indirect stage case:
  - Stage0/1 -> `__GXData->IndTexScale0`
  - Stage2/3 -> `__GXData->IndTexScale1`
- Preserved register tag writes (`0x25` / `0x26`) and BP FIFO emission path.
