### PR TITLE
pppSRandUpCV: align payload offset and RNG constant usage

### DIFF
--- a/src/pppSRandUpCV.cpp
+++ b/src/pppSRandUpCV.cpp
@@ -2,9 +2,10 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern u8 lbl_801EADC8[];
+extern float lbl_803300B0;
 extern "C" float RandF__5CMathFv(CMath* instance);
 
 /*
@@ -29,30 +30,30 @@ void pppSRandUpCV(void* param1, void* param2, void* param3)
         int offset = **base_ptr;
         target = (float*)((char*)param1 + offset + 0x80);
 
-        u8 flag = *((u8*)param2 + 0x10);
+        u8 flag = *((u8*)param2 + 0xc);
         float value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value + RandF__5CMathFv(&math)) * 0.5f;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300B0;
         }
         target[0] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value + RandF__5CMathFv(&math)) * 0.5f;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300B0;
         }
         target[1] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value + RandF__5CMathFv(&math)) * 0.5f;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300B0;
         }
         target[2] = value;
 
-        value = RandF__5CMathFv(&math);
+        value = RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value + RandF__5CMathFv(&math)) * 0.5f;
+            value = (value + RandF__5CMathFv(math)) * lbl_803300B0;
         }
         target[3] = value;
     } else if (*(int*)param2 != *((int*)param1 + 3)) {


### PR DESCRIPTION
## Summary
- Updated `pppSRandUpCV` to better match the original PAL codegen by aligning field/constant usage with observed target assembly.
- Kept behavior unchanged while adjusting code generation-sensitive details:
  - Treat `math` as an array pointer (`extern CMath math[]`) and pass `math` directly to `RandF__5CMathFv`.
  - Use the existing named multiplier constant `lbl_803300B0` instead of literal `0.5f`.
  - Read the randomization flag at offset `+0xC` instead of `+0x10`.

## Functions Improved
- Unit: `main/pppSRandUpCV`
- Function: `pppSRandUpCV`

## Match Evidence
- `objdiff` oneshot (`build/tools/objdiff-cli diff -p . -u main/pppSRandUpCV -o - pppSRandUpCV`):
  - Before: `88.95731%`
  - After: `92.98781%`
- Project report (`build/GCCP01/report.json`) now shows:
  - `main/pppSRandUpCV` unit/function fuzzy match: `93.018295%`

## Plausibility Rationale
- Changes are source-plausible and idiomatic for this codebase:
  - Use of shared extern constants/symbols already used throughout `ppp*` effect code.
  - Offset/type correction for the packed step payload field.
  - No contrived temporaries or unnatural control-flow tricks; the function structure remains straightforward and readable.

## Technical Notes
- Objdiff indicated mismatches around:
  - `math` address materialization pattern,
  - random flag byte offset,
  - and multiply-by-half constant reference.
- This patch targets those exact deltas, resulting in a measurable match increase with stable behavior.
