### PR TITLE
main/pad: improve __sinit_pad_cpp match

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -16,6 +16,7 @@
 CPad Pad;
 
 void* operator new[](unsigned long, CMemory::CStage*, char*, int);
+extern void* __vt__8CManager;
 extern void* lbl_801E8864;
 
 /*
@@ -29,7 +30,9 @@ extern void* lbl_801E8864;
  */
 extern "C" void __sinit_pad_cpp()
 {
-	Pad._0_4_ = &lbl_801E8864;
+	volatile void** base = (volatile void**)&Pad;
+	*base = &__vt__8CManager;
+	*base = &lbl_801E8864;
 	Pad._1b4_4_ = 0;
 	Pad._1b8_4_ = 0;
 }


### PR DESCRIPTION
## Summary
- Updated `__sinit_pad_cpp` in `src/pad.cpp` to follow the project’s established manager-initialization pattern.
- Added an explicit initial write of `&__vt__8CManager` before assigning the final `Pad` vtable/data pointer (`&lbl_801E8864`).
- Kept the existing zero-initialization of replay-related fields.

## Functions improved
- Unit: `main/pad`
- Symbol: `__sinit_pad_cpp`
  - Before: **50.454544%**
  - After: **52.272728%**

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/pad -o - __sinit_pad_cpp`
- Instruction-level diff markers reduced from **10** to **7** in this symbol.
- Improvement is from emitted instruction structure (not cosmetic source changes).

## Plausibility rationale
- This matches initialization style already used in other modules (`__sinit_*`) that assign `CManager` vtable first, then overwrite with the concrete manager/object pointer.
- The change is source-plausible and consistent with existing code patterns in the repository.

## Technical details
- Added `extern void* __vt__8CManager;` declaration.
- Reworked initializer to:
  1. write `&__vt__8CManager` through the object base pointer,
  2. then write `&lbl_801E8864`,
  3. then zero `Pad._1b4_4_` and `Pad._1b8_4_`.
- Build verification: `ninja` completed successfully after the change.
