### PR TITLE
main/pppYmCheckBGHeight: improve pppFrameYmCheckBGHeight match

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -93,9 +93,9 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pp
         *((float*)pppMngSt + 0x17) = currentY;
         *((float*)pppMngSt + 0x1B) = currentY;
         *((float*)pppMngSt + 0x13) = currentY;
-        pppMngSt->m_matrix.value[0][3] = pppMngSt->m_position.x;
-        pppMngSt->m_matrix.value[1][3] = pppMngSt->m_position.y;
-        pppMngSt->m_matrix.value[2][3] = pppMngSt->m_position.z;
+        pppMngStPtr->m_matrix.value[0][3] = pppMngSt->m_position.x;
+        pppMngStPtr->m_matrix.value[1][3] = pppMngSt->m_position.y;
+        pppMngStPtr->m_matrix.value[2][3] = pppMngSt->m_position.z;
         pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
     return pppYmCheckBGHeight;


### PR DESCRIPTION
## Summary
- Updated matrix writeback in `pppFrameYmCheckBGHeight` to write through `pppMngStPtr` instead of the local alias.
- Kept behavior identical while improving generated code alignment.

## Functions improved
- Unit: `main/pppYmCheckBGHeight`
- Symbol: `pppFrameYmCheckBGHeight`

## Match evidence
- `pppFrameYmCheckBGHeight`: **72.425285% -> 75.873566%** (`+3.448281`)
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmCheckBGHeight -o - pppFrameYmCheckBGHeight`

## Plausibility rationale
- The change is source-plausible and idiomatic for this codebase: matrix state is globally rooted at `pppMngStPtr`, while position data continues to use the local manager pointer.
- No contrived temporaries or unnatural sequencing were introduced.

## Technical details
- Code change is limited to 3 assignments in `src/pppYmCheckBGHeight.cpp`.
- Build verified with `ninja`.
