### PR TITLE
main/pppKeShpTail3X: improve pppKeShpTail3XCon match

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -175,11 +175,13 @@ void pppKeShpTail3XCon(struct pppKeShpTail3X* obj, struct UnkC* param_2)
         char pad[0xc];
         int* m_serializedDataOffsets;
     };
-    unsigned char* work;
     unsigned char* anglePtr;
+    unsigned char* work;
+    int* serializedDataOffsets;
     int i;
 
-    work = (unsigned char*)((char*)&obj->pppPObject + 8 + *(reinterpret_cast<KeShpTail3XConArg*>(param_2)->m_serializedDataOffsets));
+    serializedDataOffsets = reinterpret_cast<KeShpTail3XConArg*>(param_2)->m_serializedDataOffsets;
+    work = (unsigned char*)((u32)obj + (u32)(*serializedDataOffsets + 8));
     work[0x1c3] = 0;
     work[0x1c2] = 0;
     *(u16*)(work + 0x1bc) = 0;


### PR DESCRIPTION
## Summary
- Refined `pppKeShpTail3XCon` pointer setup and local variable flow to better match original codegen.
- Switched work-pointer address construction to explicit serialized offset arithmetic while preserving behavior.

## Functions improved
- Unit: `main/pppKeShpTail3X`
- Symbol: `pppKeShpTail3XCon`

## Match evidence
- Before: `97.947365%`
- After: `99.52631%`
- Objdiff mismatch count: `27 -> 8` (`DIFF_ARG_MISMATCH` only)
- Verification commands:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o - pppKeShpTail3XCon`

## Plausibility rationale
- The change keeps the original initialization semantics intact and improves ABI-relevant pointer arithmetic shape rather than introducing contrived control flow.
- Resulting code remains straightforward constructor-style setup for the unit work buffer.

## Technical details
- Introduced a typed `serializedDataOffsets` local and adjusted work-pointer computation to mirror expected address formation.
- Kept loop and state initialization logic unchanged to avoid behavior risk while reducing assembly drift.