### PR TITLE
main/pppSRandDownCV: add non-matching source and align logic

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -537,6 +537,7 @@ config.libs = [
             Object(NonMatching, "pppShape.cpp"),
             Object(NonMatching, "pppSpMatrix.cpp"),
             Object(NonMatching, "pppSRandCV.cpp"),
+            Object(NonMatching, "pppSRandDownCV.cpp"),
             Object(NonMatching, "pppSRandDownFV.cpp"),
             Object(NonMatching, "pppSRandDownHCV.cpp"),
             Object(NonMatching, "pppSRandFV.cpp"),

--- a/include/ffcc/pppSRandDownCV.h
+++ b/include/ffcc/pppSRandDownCV.h
@@ -7,7 +7,7 @@ extern "C" {
 
 void randchar(char, float);
 void randf(unsigned char);
-void pppSRandDownCV(void* param1, void* param2);
+void pppSRandDownCV(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Added missing `Object(NonMatching, "pppSRandDownCV.cpp")` entry in `configure.py` so the unit builds from source in non-matching mode.
- Updated `pppSRandDownCV` declaration/definition to the 3-argument SRand calling convention used by sibling units.
- Replaced placeholder logic in `src/pppSRandDownCV.cpp` with a plausible implementation consistent with `pppSRandUpCV`/`pppSRandDownHCV` patterns:
  - per-channel negative random generation (optional second-random blend)
  - output vector writeback via `param3` offset indirection
  - signed-byte deltas applied to 4-byte CV target

## Functions improved
- Unit: `main/pppSRandDownCV`
- Function: `pppSRandDownCV` (PAL `0x800635b0`, size `656b`)

## Match evidence
- Selector baseline (before): `0.0%` for `pppSRandDownCV`.
- After enabling/compiling source and diffing:
  - `objdiff-cli diff -p . -u main/pppSRandDownCV pppSRandDownCV` reports symbol `match_percent: 88.506096`.
  - `objdiff-cli report changes` shows function/unit `fuzzy_match_percent: 88.53658`.

## Plausibility rationale
- The new code follows the same control-flow and data-shape conventions as adjacent SRand units, using consistent offsets/types (`index`, `colorOffset`, `s8 delta[4]`, flag byte).
- Changes are type/signature corrections and straightforward algorithm reconstruction, not contrived compiler coaxing.

## Technical details
- Previous target was effectively non-diffable from source due missing non-matching object configuration for this file.
- Adding the config entry made the unit compile from `src/pppSRandDownCV.cpp`, enabling proper objdiff comparison and measurable progress.
