### PR TITLE
Improve pppSRandUpHCV match via control-flow/type cleanup

### DIFF
--- a/src/pppSRandUpHCV.cpp
+++ b/src/pppSRandUpHCV.cpp
@@ -49,7 +49,7 @@ void pppSRandUpHCV(void* param1, void* param2, void* param3)
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);
 
-		u8 flag = *((u8*)param2 + 0x10);
+		int flag = *((u8*)param2 + 0x10);
 		float value;
 
 		value = RandF__5CMathFv(&math);
@@ -75,7 +75,7 @@ void pppSRandUpHCV(void* param1, void* param2, void* param3)
 			value = (value + RandF__5CMathFv(&math)) * 0.5f;
 		}
 		target[3] = value;
-	} else if (*(int*)param2 != *((int*)param1 + 3)) {
+	} else {
 		int** base_ptr = (int**)((char*)param3 + 0xc);
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);


### PR DESCRIPTION
## Summary
- Updated `pppSRandUpHCV` in `src/pppSRandUpHCV.cpp` to better match original codegen.
- Replaced a redundant `else if` guard with `else` in the non-refresh path.
- Widened the local `flag` temporary from `u8` to `int` to align register/control behavior with nearby matched patterns.

## Functions improved
- Unit: `main/pppSRandUpHCV`
- Symbol: `pppSRandUpHCV`

## Match evidence
- Before: `85.335365%`
- After: `86.310974%`
- Delta: `+0.975609%`
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/pppSRandUpHCV -o - pppSRandUpHCV | jq '.left.symbols[] | select(.name=="pppSRandUpHCV") | .match_percent'`

## Plausibility rationale
- The change keeps behavior identical and removes an unnecessary condition (`x != y` in `else if` immediately after `if (x == y)`), which is a natural source-level cleanup.
- Using `int` for the local flag mirrors common Metrowerks C/C++ promotion behavior and existing patterns in sibling `pppSRand*HCV` implementations.

## Technical details
- This change targets codegen shape only (branch formation and promoted temporary type), avoiding contrived reorderings or non-idiomatic constructs.
- No debug artifacts/comments were introduced; source remains readable and consistent with adjacent units.
