### PR TITLE
main/p_minigame: implement __sinit_p_minigame_cpp

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1,6 +1,40 @@
 #include "ffcc/p_minigame.h"
 
 extern CMiniGamePcs MiniGamePcs;
+extern unsigned int lbl_802121A8[];
+extern unsigned int lbl_802121B4[];
+extern unsigned int lbl_802121C0[];
+extern unsigned int lbl_802121CC[];
+extern unsigned int lbl_80212348[];
+
+/*
+ * --INFO--
+ * PAL Address: 0x8012b19c
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_minigame_cpp(void)
+{
+    unsigned int* table = lbl_802121CC;
+    unsigned int* desc0 = lbl_802121A8;
+    unsigned int* desc1 = lbl_802121B4;
+    unsigned int* desc2 = lbl_802121C0;
+
+    *reinterpret_cast<unsigned int*>(&MiniGamePcs) = reinterpret_cast<unsigned int>(lbl_80212348);
+
+    table[1] = desc0[0];
+    table[2] = desc0[1];
+    table[3] = desc0[2];
+    table[4] = desc1[0];
+    table[5] = desc1[1];
+    table[6] = desc1[2];
+    table[7] = desc2[0];
+    table[8] = desc2[1];
+    table[9] = desc2[2];
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Implemented `__sinit_p_minigame_cpp` in `src/p_minigame.cpp` with PAL address metadata.
- Added initializer wiring for `MiniGamePcs` and copied 3 descriptor triplets into the unit table (`lbl_802121CC`) using existing unit symbols.

## Functions improved
- Unit: `main/p_minigame`
- Symbol: `__sinit_p_minigame_cpp`
- Size: 176 bytes

## Match evidence
- Before: symbol was not implemented in `src/p_minigame.cpp`, and objdiff could not pair it (`target_symbol = null`, no match%).
- After: objdiff pairs the symbol and reports `match_percent = 58.954544` (`target_symbol = 1`).
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/p_minigame -o - __sinit_p_minigame_cpp`

## Plausibility rationale
- Pattern matches existing source style used in other process init units (`p_system`, `p_game`): static `__sinit_*` function initializes process table descriptors from `.data` label triplets.
- Uses existing project symbols and straightforward table assignments rather than compiler-coaxing constructs.

## Technical details
- Added externs for `lbl_802121A8`, `lbl_802121B4`, `lbl_802121C0`, `lbl_802121CC`, and `lbl_80212348`.
- `__sinit_p_minigame_cpp` now writes descriptor entries `table[1..9]` from the three source triplets, with the process base pointer initialized first.
