### PR TITLE
mapanim: initialize CMapAnim constructor state

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -37,6 +37,7 @@ extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*,
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void* lbl_801EA488[];
+extern "C" CPtrArray<CMapAnimNode*>* __ct__26CPtrArray_P12CMapAnimNode_Fv(CPtrArray<CMapAnimNode*>*);
 extern unsigned char MapMng[];
 
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
@@ -464,7 +465,10 @@ void CMapAnimNode::interp(Vec*, CMapAnimKey*, int, int)
  */
 CMapAnim::CMapAnim()
 {
-	// TODO
+    typedef CPtrArray<CMapAnimNode*>* (*CtorFn)(CPtrArray<CMapAnimNode*>*);
+    CtorFn ctorFn = __ct__26CPtrArray_P12CMapAnimNode_Fv;
+    CPtrArray<CMapAnimNode*>* mapAnimNodes = ctorFn(reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this));
+    mapAnimNodes->SetStage(*reinterpret_cast<CMemory::CStage**>(MapMng));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapAnim::CMapAnim()` in `src/mapanim.cpp`.
- Constructor now initializes the embedded `CPtrArray<CMapAnimNode*>` storage and sets its stage from `MapMng`, instead of leaving the function empty.
- Added an explicit declaration for the existing `CPtrArray<CMapAnimNode*>` constructor symbol used by this unit.

## Functions improved
- Unit: `main/mapanim`
- Symbol: `__ct__8CMapAnimFv` (`CMapAnim::CMapAnim()`)
- Match: **5.9% -> 60.588234%**

## Match evidence
- Baseline from `tools/agent_select_target.py` for this unit listed `__ct__8CMapAnimFv` at **5.9%**.
- Post-change measurement via:
  - `build/tools/objdiff-cli diff -p . -u main/mapanim -o - __ct__8CMapAnimFv`
- Current objdiff JSON reports `match_percent: 60.588234` for the right-side symbol.
- Instruction diff now aligns on constructor call/stack frame behavior, with remaining mismatch primarily in final size (`68b` target vs `60b` current).

## Plausibility rationale
- The constructor previously had no source-level behavior despite a non-trivial target function.
- The new body expresses expected original intent: initialize node-array state and bind allocator stage for later `ReadOtmAnim` allocations.
- The change uses existing runtime symbols and code patterns already present in this decomp codebase.

## Technical details
- Added:
  - `extern "C" CPtrArray<CMapAnimNode*>* __ct__26CPtrArray_P12CMapAnimNode_Fv(CPtrArray<CMapAnimNode*>*);`
- Implemented constructor as:
  - invoke the `CPtrArray<CMapAnimNode*>` constructor on `this`-backed storage
  - call `SetStage(*reinterpret_cast<CMemory::CStage**>(MapMng))`
- Verified compilation with:
  - `ninja -v build/GCCP01/src/mapanim.o`
