### PR TITLE
map: specialize CPtrArray<CMapLightHolder> Add/RemoveAll

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2,6 +2,7 @@
 #include "ffcc/maptexanim.h"
 
 extern "C" unsigned long UnkMaterialSetGetter(void*);
+extern "C" void __dla__FPv(void*);
 
 /*
  * --INFO--
@@ -75,6 +76,46 @@ template <>
 void CPtrArray<CMaterial*>::SetGrow(int growCapacity)
 {
     *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x14) = growCapacity;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80033d24
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+bool CPtrArray<CMapLightHolder*>::Add(CMapLightHolder* item)
+{
+    bool success = setSize(m_numItems + 1);
+    if (success) {
+        m_items[m_numItems] = item;
+        m_numItems++;
+    }
+    return success;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80033d94
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapLightHolder*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray<CMapLightHolder*>` specializations for `Add` and `RemoveAll` in `src/map.cpp`.
- Added PAL `--INFO--` metadata from Ghidra export for both functions.
- Declared `extern "C" void __dla__FPv(void*);` so `RemoveAll` uses the same delete-array helper pattern as existing ptrarray decomp code.

## Functions improved
- Unit: `main/map`
- `Add__29CPtrArray<P15CMapLightHolder>FP15CMapLightHolder`
  - Before: `0.0%` (selector baseline)
  - After: `86.75%` (`objdiff-cli v3.6.1`)
- `RemoveAll__29CPtrArray<P15CMapLightHolder>Fv`
  - Before: `0.0%` (selector baseline)
  - After: `99.84%` (`objdiff-cli v3.6.1`)

## Match evidence
- Build: `ninja` passes and regenerates report.
- Diff commands used:
  - `tools/objdiff-cli diff -p . -u main/map -o - 'Add__29CPtrArray<P15CMapLightHolder>FP15CMapLightHolder'`
  - `tools/objdiff-cli diff -p . -u main/map -o - 'RemoveAll__29CPtrArray<P15CMapLightHolder>Fv'`

## Plausibility rationale
- The new code follows the same established `CPtrArray` specialization style already present in the codebase (`mapanim.cpp`, `textureman.cpp`, `texanim.cpp`).
- Control flow is idiomatic and source-plausible: resize check, append/update count, and array cleanup/reset.
- No compiler-coaxing temporaries or unnatural ordering were introduced.

## Technical details
- `Add` now emits a dedicated symbol in `map.o` with the expected branch structure around `setSize` success/failure.
- `RemoveAll` now matches the canonical ptrarray cleanup sequence (`__dla__FPv`, null pointer store, size/item count reset) used by other specialized arrays.
