### PR TITLE
main/pppYmBreath: implement constructor/destructor first pass

### DIFF
--- a/include/ffcc/pppYmBreath.h
+++ b/include/ffcc/pppYmBreath.h
@@ -2,6 +2,8 @@
 #define _PPP_YMBREATH_H_
 
 struct _pppPObject;
+struct pppYmBreath;
+struct UnkC;
 struct VYmBreath;
 struct PYmBreath;
 struct VColor;
@@ -21,9 +23,9 @@ extern "C" {
 
 void pppFrameYmBreath(void);
 void pppRenderYmBreath(void);
-void pppConstructYmBreath(void);
+void pppConstructYmBreath(pppYmBreath*, UnkC*);
 void pppConstruct2YmBreath(void);
-void pppDestructYmBreath(void);
+void pppDestructYmBreath(pppYmBreath*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -1,4 +1,16 @@
 #include "ffcc/pppYmBreath.h"
+#include "dolphin/mtx.h"
+
+extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
+
+struct UnkC {
+    unsigned char _pad[0xC];
+    int* m_serializedDataOffsets;
+};
+
+struct pppYmBreath {
+    unsigned char _pad[8];
+};
 
 /*
  * --INFO--
@@ -69,11 +81,33 @@ extern "C" void pppRenderYmBreath(void)
 
 /*
  * --INFO--
- * Address:	800bff74
- * Size:	120
+ * PAL Address: 0x800bff74
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-extern "C" void pppConstructYmBreath(void)
+extern "C" void pppConstructYmBreath(pppYmBreath* ymBreath, UnkC* dataOffsets)
 {
+    Mtx* work = (Mtx*)((unsigned char*)ymBreath + 0x80 + *dataOffsets->m_serializedDataOffsets);
+    unsigned char* state = (unsigned char*)work;
+
+    PSMTXIdentity(*work);
+
+    work[1][2][0] = 0.0f;
+    work[1][1][3] = 0.0f;
+    work[1][1][2] = 0.0f;
+    work[1][0][0] = 0.0f;
+    work[1][0][1] = 0.0f;
+    work[1][0][2] = 0.0f;
+    work[1][0][3] = 0.0f;
+    work[1][1][0] = 0.0f;
+
+    *(short*)(state + 0x46) = 10000;
+    *(short*)(state + 0x4A) = 0;
+    *(short*)(state + 0x4E) = 0;
+    *(unsigned char*)(state + 0x50) = 0;
 }
 
 /*
@@ -87,11 +121,56 @@ void pppConstruct2YmBreath(void)
 
 /*
  * --INFO--
- * Address:	800bfe78
- * Size:	248
+ * PAL Address: 0x800bfe78
+ * PAL Size: 248b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-extern "C" void pppDestructYmBreath(void)
+extern "C" void pppDestructYmBreath(pppYmBreath* ymBreath, UnkC* dataOffsets)
 {
+    unsigned char* work = (unsigned char*)ymBreath + 0x80 + *dataOffsets->m_serializedDataOffsets;
+    void** particleData = (void**)(work + 0x30);
+
+    if (particleData[0] != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[0]);
+        particleData[0] = 0;
+    }
+
+    if (particleData[1] != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[1]);
+        particleData[1] = 0;
+    }
+
+    if (particleData[2] != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[2]);
+        particleData[2] = 0;
+    }
+
+    if (particleData[3] != 0) {
+        int i;
+        unsigned char* group = (unsigned char*)particleData[3];
+
+        for (i = 0; i < *(short*)(work + 0x54); i++) {
+            void** groupData = (void**)(group + 4);
+
+            if (groupData[0] != 0) {
+                pppHeapUseRate__FPQ27CMemory6CStage(groupData[0]);
+                groupData[0] = 0;
+            }
+
+            if (groupData[1] != 0) {
+                pppHeapUseRate__FPQ27CMemory6CStage(groupData[1]);
+                groupData[1] = 0;
+            }
+
+            group += 0x5C;
+        }
+
+        pppHeapUseRate__FPQ27CMemory6CStage(particleData[3]);
+        particleData[3] = 0;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `pppYmBreath` constructor/destructor signatures to typed forms: `pppConstructYmBreath(pppYmBreath*, UnkC*)` and `pppDestructYmBreath(pppYmBreath*, UnkC*)`.
- Implemented first-pass bodies for `pppConstructYmBreath` and `pppDestructYmBreath` in `src/pppYmBreath.cpp`.
- Added versioned INFO headers (PAL/EN/JP fields) for the updated functions.

## Functions improved
- Unit: `main/pppYmBreath`
- Symbols:
  - `pppConstructYmBreath`: **3.3333333% -> 88.96667%**
  - `pppDestructYmBreath`: **1.6129032% -> 96.370964%**

## Match evidence
- Built with `ninja` successfully after changes.
- Used objdiff CLI JSON mode:
  - Before: `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - pppRenderYmBreath`
  - After: same command on this branch
- The two implemented functions moved from near-empty stubs to near-match assembly, while unrelated large stubs (`pppFrameYmBreath`, `pppRenderYmBreath`) remained unchanged at low match.

## Plausibility rationale
- Logic follows the same offset-based object layout and memory-release patterns already present in neighboring particle modules (notably `pppBreathModel`).
- Changes are straightforward source-level reconstruction (matrix init/state init in constructor, staged pointer cleanup in destructor) without artificial temporaries or non-idiomatic ordering.
- No hardcoded assembly tricks or compiler-coaxing constructs were introduced.

## Technical details
- Constructor now initializes work matrix/state block at `base + 0x80 + serializedOffset` and sets control fields expected by the runtime.
- Destructor now frees particle blocks and per-group sub-buffers (`0x5C` stride), nulling pointers after `pppHeapUseRate` calls.
