### PR TITLE
mapocttree: implement ClearShadow_r traversal

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -223,12 +223,29 @@ void COctTree::InsertLight(long, Vec&, float, unsigned long)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002da40
+ * PAL Size: 408b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void ClearShadow_r(COctNode*)
+void ClearShadow_r(COctNode* node)
 {
-	// TODO
+	unsigned char* nodeBytes = (unsigned char*)node;
+
+	if (*(unsigned short*)(nodeBytes + 0x3e) != 0) {
+		*(void**)(nodeBytes + 0x44) = 0;
+	}
+
+	COctNode** children = (COctNode**)(nodeBytes + 0x1c);
+	for (int i = 0; i < 8; i++) {
+		COctNode* child = children[i];
+		if (child == 0) {
+			return;
+		}
+		ClearShadow_r(child);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `ClearShadow_r__FP8COctNode` in `src/mapocttree.cpp` with a recursive octree traversal using the existing raw-offset node layout.

## Functions improved
- Unit: `main/mapocttree`
- Symbol: `ClearShadow_r__FP8COctNode`
- Baseline (target selector): `0.4%`
- After change (objdiff): `86.65686%`

## Match evidence
- Build passes with `ninja`.
- Objdiff command:
  - `build/tools/objdiff-cli diff -p . -u main/mapocttree -o - ClearShadow_r__FP8COctNode`
- Result: strong instruction alignment improvement and function now mostly matched versus prior near-0% stub.

## Plausibility rationale
This change replaces a TODO stub with straightforward source-plausible logic:
- clear shadow bitfield state only for nodes that have mesh data
- recurse through child nodes in natural octree order
- stop traversal when child slots are exhausted

The implementation follows the existing style in this unit (raw offsets due incomplete class field reconstruction), without adding compiler-coaxing artifacts.

## Technical details
- Added version metadata block for `ClearShadow_r`:
  - PAL Address: `0x8002da40`
  - PAL Size: `408b`
- Used node offsets consistent with existing file usage:
  - mesh index: `+0x3e`
  - shadow pointer/bitfield storage: `+0x44`
  - child array base: `+0x1c`
