### PR TITLE
map: implement CMapKeyFrame core methods

### DIFF
--- a/include/ffcc/map.h
+++ b/include/ffcc/map.h
@@ -28,10 +28,10 @@ public:
     CMapKeyFrame();
     ~CMapKeyFrame();
 
-    void Get();
-    void Get(int&, int&, float&);
+    float Get();
+    int Get(int&, int&, float&);
     void Calc();
-    void IsRun();
+    int IsRun();
     void ReadJun(CChunkFile&, int);
     void ReadFrame(CChunkFile&, int);
     void ReadKey(CChunkFile&, int);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,8 +1,25 @@
 #include "ffcc/map.h"
+#include "ffcc/chunkfile.h"
+#include "ffcc/math.h"
+#include "ffcc/memory.h"
 #include "ffcc/maptexanim.h"
 
 extern "C" unsigned long UnkMaterialSetGetter(void*);
 extern "C" void __dla__FPv(void*);
+extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+extern "C" float Spline1D__5CMathFifPfPfPf(CMath*, int, float, float*, float*, float*);
+extern "C" float Line1D__5CMathFifPfPf(CMath*, int, float, float*, float*);
+extern "C" void MakeSpline1Dtable__5CMathFiPfPfPf(CMath*, int, float*, float*, float*);
+extern CMath Math;
+
+static char s_map_cpp[] = "map.cpp";
+
+namespace {
+static inline unsigned char* Ptr(void* p, unsigned int offset)
+{
+    return reinterpret_cast<unsigned char*>(p) + offset;
+}
+}
 
 /*
  * --INFO--
@@ -11,7 +28,16 @@ extern "C" void __dla__FPv(void*);
  */
 CMapKeyFrame::CMapKeyFrame()
 {
-	// TODO
+    *reinterpret_cast<int*>(Ptr(this, 0)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 4)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 8)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0xC)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0x10)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0x14)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0x18)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0x1C)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0x20)) = 0;
+    *reinterpret_cast<int*>(Ptr(this, 0x24)) = 0;
 }
 
 /*
@@ -21,7 +47,27 @@ CMapKeyFrame::CMapKeyFrame()
  */
 CMapKeyFrame::~CMapKeyFrame()
 {
-	// TODO
+    void*& junTable = *reinterpret_cast<void**>(Ptr(this, 0x18));
+    void*& keyFrame = *reinterpret_cast<void**>(Ptr(this, 0x1C));
+    void*& keyValue = *reinterpret_cast<void**>(Ptr(this, 0x20));
+    void*& splineTable = *reinterpret_cast<void**>(Ptr(this, 0x24));
+
+    if (junTable != 0) {
+        __dla__FPv(junTable);
+        junTable = 0;
+    }
+    if (keyFrame != 0) {
+        __dla__FPv(keyFrame);
+        keyFrame = 0;
+    }
+    if (keyValue != 0) {
+        __dla__FPv(keyValue);
+        keyValue = 0;
+    }
+    if (splineTable != 0) {
+        __dla__FPv(splineTable);
+        splineTable = 0;
+    }
 }
 
 /*
@@ -29,9 +75,21 @@ CMapKeyFrame::~CMapKeyFrame()
  * Address:	TODO
  * Size:	TODO
  */
-void CMapKeyFrame::Get()
+float CMapKeyFrame::Get()
 {
-	// TODO
+    const int keyCount = static_cast<int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2)));
+    const int currentFrame = *reinterpret_cast<int*>(Ptr(this, 8));
+    float* keyValue = reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x20)));
+    float* keyFrame = reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x1C)));
+    float* splineTable = reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x24)));
+
+    if (*reinterpret_cast<unsigned char*>(Ptr(this, 0)) == 1) {
+        return Spline1D__5CMathFifPfPfPf(&Math, keyCount - 1, static_cast<float>(currentFrame), keyValue, keyFrame, splineTable);
+    }
+    if (*reinterpret_cast<unsigned char*>(Ptr(this, 0)) == 0) {
+        return Line1D__5CMathFifPfPf(&Math, keyCount - 1, static_cast<float>(currentFrame), keyValue, keyFrame);
+    }
+    return 0.0f;
 }
 
 /*
@@ -123,9 +181,52 @@ void CPtrArray<CMapLightHolder*>::RemoveAll()
  * Address:	TODO
  * Size:	TODO
  */
-void CMapKeyFrame::Get(int&, int&, float&)
+int CMapKeyFrame::Get(int& key0, int& key1, float& blend)
 {
-	// TODO
+    const unsigned char mode = *reinterpret_cast<unsigned char*>(Ptr(this, 0));
+    const int keyCount = static_cast<int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2)));
+    const int currentFrame = *reinterpret_cast<int*>(Ptr(this, 8));
+    unsigned char* junTable = *reinterpret_cast<unsigned char**>(Ptr(this, 0x18));
+    float* keyFrame = reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x1C)));
+    float* keyValue = reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x20)));
+    float* splineTable = reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x24)));
+
+    if (mode == 1) {
+        blend = Spline1D__5CMathFifPfPfPf(&Math, keyCount - 1, static_cast<float>(currentFrame), keyValue, keyFrame, splineTable);
+    } else if (mode == 0) {
+        blend = Line1D__5CMathFifPfPf(&Math, keyCount - 1, static_cast<float>(currentFrame), keyValue, keyFrame);
+    } else {
+        blend = 0.0f;
+        key0 = junTable[0];
+        key1 = key0;
+        return 0;
+    }
+
+    if (blend > 0.0f) {
+        const float junMax = static_cast<float>(*reinterpret_cast<unsigned char*>(Ptr(this, 1)) - 1);
+        if (blend < junMax) {
+            key0 = static_cast<int>(blend);
+            key1 = static_cast<int>(1.0f + blend);
+            blend = blend - static_cast<float>(key0);
+            key0 = junTable[key0];
+            if (blend == 0.0f) {
+                key1 = key0;
+                return 0;
+            }
+            key1 = junTable[key1];
+            return 1;
+        }
+
+        key0 = junTable[*reinterpret_cast<unsigned char*>(Ptr(this, 1)) - 1];
+        key1 = key0;
+        blend = 1.0f;
+        return 0;
+    }
+
+    key0 = junTable[0];
+    key1 = key0;
+    blend = 0.0f;
+    return 0;
 }
 
 /*
@@ -135,7 +236,27 @@ void CMapKeyFrame::Get(int&, int&, float&)
  */
 void CMapKeyFrame::Calc()
 {
-	// TODO
+    int& currentFrame = *reinterpret_cast<int*>(Ptr(this, 8));
+    const int startFrame = *reinterpret_cast<int*>(Ptr(this, 0xC));
+    const int endFrame = *reinterpret_cast<int*>(Ptr(this, 0x10));
+    unsigned char& loop = *reinterpret_cast<unsigned char*>(Ptr(this, 3));
+    unsigned char& isRun = *reinterpret_cast<unsigned char*>(Ptr(this, 4));
+
+    currentFrame++;
+    if (currentFrame <= endFrame) {
+        return;
+    }
+    if (startFrame == endFrame) {
+        isRun = 0;
+        return;
+    }
+    if (loop != 0) {
+        currentFrame = startFrame;
+        return;
+    }
+
+    currentFrame = endFrame;
+    isRun = 0;
 }
 
 /*
@@ -143,9 +264,9 @@ void CMapKeyFrame::Calc()
  * Address:	TODO
  * Size:	TODO
  */
-void CMapKeyFrame::IsRun()
+int CMapKeyFrame::IsRun()
 {
-	// TODO
+    return *reinterpret_cast<unsigned char*>(Ptr(this, 4));
 }
 
 /*
@@ -153,9 +274,16 @@ void CMapKeyFrame::IsRun()
  * Address:	TODO
  * Size:	TODO
  */
-void CMapKeyFrame::ReadJun(CChunkFile&, int)
+void CMapKeyFrame::ReadJun(CChunkFile& chunkFile, int count)
 {
-	// TODO
+    *reinterpret_cast<unsigned char*>(Ptr(this, 1)) = static_cast<unsigned char>(count);
+    *reinterpret_cast<void**>(Ptr(this, 0x18)) = __nwa__FUlPQ27CMemory6CStagePci(
+        static_cast<unsigned long>(*reinterpret_cast<unsigned char*>(Ptr(this, 1))),
+        *reinterpret_cast<CMemory::CStage**>(&MapMng), s_map_cpp, 0xC1);
+
+    for (int i = 0; i < static_cast<int>(*reinterpret_cast<unsigned char*>(Ptr(this, 1))); i++) {
+        (*reinterpret_cast<unsigned char**>(Ptr(this, 0x18)))[i] = chunkFile.Get1();
+    }
 }
 
 /*
@@ -163,9 +291,16 @@ void CMapKeyFrame::ReadJun(CChunkFile&, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CMapKeyFrame::ReadFrame(CChunkFile&, int)
+void CMapKeyFrame::ReadFrame(CChunkFile& chunkFile, int)
 {
-	// TODO
+    const int startFrame = static_cast<int>(chunkFile.Get4());
+    const int endFrame = static_cast<int>(chunkFile.Get4());
+
+    *reinterpret_cast<int*>(Ptr(this, 0xC)) = startFrame;
+    *reinterpret_cast<int*>(Ptr(this, 8)) = startFrame;
+    *reinterpret_cast<int*>(Ptr(this, 0x10)) = endFrame;
+    *reinterpret_cast<int*>(Ptr(this, 0x14)) = endFrame;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 0)) = static_cast<unsigned char>(chunkFile.Get4());
 }
 
 /*
@@ -173,9 +308,31 @@ void CMapKeyFrame::ReadFrame(CChunkFile&, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CMapKeyFrame::ReadKey(CChunkFile&, int)
+void CMapKeyFrame::ReadKey(CChunkFile& chunkFile, int count)
 {
-	// TODO
+    *reinterpret_cast<unsigned char*>(Ptr(this, 4)) = 1;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 2)) = static_cast<unsigned char>(count);
+    *reinterpret_cast<void**>(Ptr(this, 0x1C)) = __nwa__FUlPQ27CMemory6CStagePci(
+        static_cast<unsigned long>(static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2))) << 2),
+        *reinterpret_cast<CMemory::CStage**>(&MapMng), s_map_cpp, 0xD5);
+    *reinterpret_cast<void**>(Ptr(this, 0x20)) = __nwa__FUlPQ27CMemory6CStagePci(
+        static_cast<unsigned long>(static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2))) << 2),
+        *reinterpret_cast<CMemory::CStage**>(&MapMng), s_map_cpp, 0xD6);
+
+    for (int i = 0; i < static_cast<int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2))); i++) {
+        reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x1C)))[i] = chunkFile.GetF4();
+        reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x20)))[i] = chunkFile.GetF4();
+    }
+
+    if (*reinterpret_cast<unsigned char*>(Ptr(this, 0)) == 1) {
+        *reinterpret_cast<void**>(Ptr(this, 0x24)) = __nwa__FUlPQ27CMemory6CStagePci(
+            static_cast<unsigned long>(static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2))) << 2),
+            *reinterpret_cast<CMemory::CStage**>(&MapMng), s_map_cpp, 0xDE);
+        MakeSpline1Dtable__5CMathFiPfPfPf(&Math, static_cast<int>(*reinterpret_cast<unsigned char*>(Ptr(this, 2))) - 1,
+            reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x20))),
+            reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x1C))),
+            reinterpret_cast<float*>(*reinterpret_cast<void**>(Ptr(this, 0x24))));
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMapKeyFrame` core behavior in `main/map` and aligned method signatures with actual usage:
- Implemented constructor/destructor cleanup for keyframe-owned buffers
- Implemented `Get()`, `Get(int&, int&, float&)`, `Calc()`, `IsRun()`, `ReadJun()`, `ReadFrame()`, `ReadKey()`
- Added required allocator/math/chunk externs and includes used by these methods
- Updated `CMapKeyFrame` declarations in `include/ffcc/map.h` to return values used by callsites (`float`/`int`)

## Functions improved
Unit: `main/map`
- `Get__12CMapKeyFrameFv`: **2.0408163% -> 50.77551%**
- `Get__12CMapKeyFrameFRiRiRf`: **0.7246377% -> 51.557972%**
- `Calc__12CMapKeyFrameFv`: **4.5454545% -> 81.13636%**
- `IsRun__12CMapKeyFrameFv`: **50.0% -> 100.0%**
- `ReadJun__12CMapKeyFrameFR10CChunkFilei`: **2.9411764% -> 82.79412%**
- `ReadFrame__12CMapKeyFrameFR10CChunkFilei`: **4.1666665% -> 55.666668%**
- `ReadKey__12CMapKeyFrameFR10CChunkFilei`: **1.4084507% -> 82.95775%**

Unit-level fuzzy score:
- `main/map`: **~4.1% -> 9.314805%**

## Match evidence
- Build passes with `ninja`
- `objdiff` on `main/map` now emits near-target sizes/op patterns for keyframe methods instead of prior 4-byte TODO stubs
- Significant instruction-level alignment gains across all emitted `CMapKeyFrame` methods

## Plausibility rationale
These changes replace placeholder TODO bodies with source-plausible keyframe runtime logic (frame read/key read/interpolation/run-state) that is directly consumed by `maptexanim` callsites. The implementation uses existing engine conventions (stage allocator, chunk readers, interpolation helpers, explicit cleanup), rather than artificial compiler-only transformations.
