### PR TITLE
pppCorona: correct CoronaParam data index width

### DIFF
--- a/include/ffcc/pppCorona.h
+++ b/include/ffcc/pppCorona.h
@@ -19,7 +19,7 @@ struct UnkC {
 
 struct CoronaParam {
     s32 m_graphId;
-    u16 m_dataValIndex;
+    s32 m_dataValIndex;
     u8 m_colorR;
     u8 m_colorG;
     u8 m_colorB;


### PR DESCRIPTION
## Summary
- Updated `CoronaParam::m_dataValIndex` from `u16` to `s32` in `include/ffcc/pppCorona.h`.
- This aligns the parameter layout with observed 32-bit access patterns in `pppFrameCorona` and `pppRenderCorona`.

## Functions improved
- Unit: `main/pppCorona`
- `pppRenderCorona` (size 464b)
- `pppFrameCorona` (size 240b)

## Match evidence
- Baseline (selector/report before change):
  - `pppRenderCorona`: `59.1%`
  - `pppFrameCorona`: `95.5%`
- After change (`ninja` -> `build/GCCP01/report.json`):
  - `pppRenderCorona`: `61.96552%`
  - `pppFrameCorona`: `96.566666%`
- Improvement indicates real instruction alignment from corrected argument/field access width and offsets, not formatting-only edits.

## Plausibility rationale
- A resource index field used for object lookup is plausibly 32-bit in original source.
- Using `s32` matches common engine-side index conventions and avoids artificial packing that shifts subsequent fields.
- This is a source-plausible type correction (ABI/layout fix), not contrived compiler coaxing.

## Technical details
- Existing code loads the data index as a full word in both render and frame paths; `u16` forced a narrower model and mismatched downstream layout.
- Correcting the field width improved generated code for both functions in the unit while keeping behavior readable and idiomatic.
