### PR TITLE
graphic: implement draw-sync debug methods

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -39,7 +39,7 @@ public:
     void SetViewport();
     void BeginFrame();
     void EndFrame();
-    void SetDrawDoneDebugData(char);
+    void SetDrawDoneDebugData(signed char);
     void SetDrawDoneDebugDataPartControl(int);
     void _WaitDrawDone(char*, int);
     void Thread();

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/graphic.h"
 
 #include "ffcc/pppfunctbl.h"
+#include "ffcc/system.h"
 
 /*
  * --INFO--
@@ -134,22 +135,30 @@ void CGraphic::EndFrame()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800196e0
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphic::SetDrawDoneDebugData(char)
+void CGraphic::SetDrawDoneDebugData(signed char drawDoneId)
 {
-	// TODO
+	GXSetDrawSync((u16)(((System.m_currentOrderIndex & 0xFF) << 8) | (drawDoneId & 0xFF)));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800196b8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphic::SetDrawDoneDebugDataPartControl(int)
+void CGraphic::SetDrawDoneDebugDataPartControl(int partControl)
 {
-	// TODO
+	GXSetDrawSync((u16)(partControl | 0x8000));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGraphic::SetDrawDoneDebugData` and `CGraphic::SetDrawDoneDebugDataPartControl` in `src/graphic.cpp`.
- Added required `System` include to access `System.m_currentOrderIndex`.
- Corrected `SetDrawDoneDebugData` signature in `include/ffcc/graphic.h` to `signed char` so the method resolves to the expected symbol.
- Replaced placeholder INFO blocks for both functions with PAL address/size metadata (EN/JP left as TODO).

## Functions Improved
- Unit: `main/graphic` (`graphic.o`)
- `SetDrawDoneDebugDataPartControl__8CGraphicFi`: **0.0% -> 100.0%** (40b)
- `SetDrawDoneDebugData__8CGraphicFSc`: **0.0% -> 83.92857%** (56b)

## Match Evidence
- Build: `ninja` passes.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/graphic -o -`
- Current per-symbol matches from objdiff:
  - `SetDrawDoneDebugDataPartControl__8CGraphicFi`: `match_percent: 100.0`
  - `SetDrawDoneDebugData__8CGraphicFSc`: `match_percent: 83.92857`

## Plausibility Rationale
- The implemented logic directly reflects expected engine behavior:
  - `SetDrawDoneDebugDataPartControl` sets the high-bit marker (`0x8000`) before `GXSetDrawSync`.
  - `SetDrawDoneDebugData` combines low 8 bits of debug tag with `System.m_currentOrderIndex` in the high 8 bits.
- These are straightforward API-facing operations with idiomatic code and no contrived control-flow or artificial temporaries.

## Technical Details
- `SetDrawDoneDebugDataPartControl` now instruction-matches fully against target code.
- `SetDrawDoneDebugData` now resolves to the target symbol and substantially aligns in generated assembly; remaining delta is localized to register/mask instruction selection, not placeholder/stub structure.
