### PR TITLE
pppBindOnlyPos: match pppFrameBindOnlyPos compare flow

### DIFF
--- a/src/pppBindOnlyPos.cpp
+++ b/src/pppBindOnlyPos.cpp
@@ -32,5 +32,7 @@ void pppFrameBindOnlyPos(void)
 		return;
 	}
 
-	*(volatile unsigned int*)((char*)lbl_8032ED50 + 0xd8);
+	if (*(volatile unsigned int*)((char*)lbl_8032ED50 + 0xd8) != 0) {
+		return;
+	}
 }


### PR DESCRIPTION
## Summary
- Updated `pppFrameBindOnlyPos` in `src/pppBindOnlyPos.cpp` to explicitly branch on the loaded owner pointer state after the existing global guard.
- Preserved behavior while shaping control flow to match original codegen.

## Functions improved
- Unit: `main/pppBindOnlyPos`
- Symbol: `pppFrameBindOnlyPos`
- Before: `85.71%`
- After: `100.00%`

## Match evidence
- `objdiff-cli diff -p . -u main/pppBindOnlyPos pppFrameBindOnlyPos` now reports `100.00%` for the symbol (was `85.71%`).
- Full build still verifies (`build/GCCP01/main.dol: OK`).
- Project progress moved from 1443 to 1444 matched functions after this change.

## Plausibility rationale
- The change is source-plausible: it keeps a straightforward guard and volatile read while making the compare explicit, which is a natural C style for this pattern.
- No artificial temporaries, no hardcoded offsets beyond existing decomp conventions, and no readability regressions.

## Technical details
- Previous output was missing a `cmplwi` compare after loading `*(lbl_8032ED50 + 0xd8)`.
- Rewriting the tail as:
  - `if (*(volatile unsigned int*)((char*)lbl_8032ED50 + 0xd8) != 0) { return; }`
  produces the missing compare and aligns the function body to target assembly.