### PR TITLE
gx: improve GXCopyDisp match in GXFrameBuf

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -501,11 +501,19 @@ static void __GXVerifCopy(void* dest, u8 clear) {
 }
 #endif
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A31E0
+ * PAL Size: 348b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void GXCopyDisp(void* dest, GXBool clear) {
+    GXData* gx;
     u32 reg;
-    u32 tempPeCtrl;
-    u32 phyAddr;
-    u8 changePeCtrl;
+    GXBool changePeCtrl;
 
     CHECK_GXBEGIN(1833, "GXCopyDisp");
 
@@ -513,52 +521,58 @@ void GXCopyDisp(void* dest, GXBool clear) {
     __GXVerifCopy(dest, clear);
 #endif
 
+    gx = __GXData;
     if (clear) {
-        reg = __GXData->zmode;
-        SET_REG_FIELD(0, reg, 1, 0, 1);
-        SET_REG_FIELD(0, reg, 3, 1, 7);
-        GX_WRITE_RAS_REG(reg);
-
-        reg = __GXData->cmode0;
-        SET_REG_FIELD(0, reg, 1, 0, 0);
-        SET_REG_FIELD(0, reg, 1, 1, 0);
-        GX_WRITE_RAS_REG(reg);
+        GX_WRITE_U8(0x61);
+        GX_WRITE_U32((gx->zmode & 0xFFFFFFF0) | 0xF);
+        GX_WRITE_U8(0x61);
+        GX_WRITE_U32(gx->cmode0 & 0xFFFFFFFC);
     }
 
     changePeCtrl = FALSE;
-
-    if ((clear || (u32)GET_REG_FIELD(__GXData->peCtrl, 3, 0) == 3) && (u32)GET_REG_FIELD(__GXData->peCtrl, 1, 6) == 1) {
-        changePeCtrl = TRUE;
-        tempPeCtrl = __GXData->peCtrl;
-        SET_REG_FIELD(0, tempPeCtrl, 1, 6, 0);
-        GX_WRITE_RAS_REG(tempPeCtrl);
+    if (!clear) {
+        if ((gx->peCtrl & 7) != 3) {
+            goto skipPeCtrlWrite;
+        }
     }
 
-    GX_WRITE_RAS_REG(__GXData->cpDispSrc);
-    GX_WRITE_RAS_REG(__GXData->cpDispSize);
-    GX_WRITE_RAS_REG(__GXData->cpDispStride);
+    if (((gx->peCtrl >> 6) & 1) == 1) {
+        changePeCtrl = TRUE;
+        GX_WRITE_U8(0x61);
+        GX_WRITE_U32(gx->peCtrl & 0xFFFFFFBF);
+    }
 
-    phyAddr = (u32)dest & 0x3FFFFFFF;
-    reg = 0;
-    SET_REG_FIELD(1872, reg, 21, 0, phyAddr >> 5);
-    SET_REG_FIELD(1876, reg, 8, 24, 0x4B);
-    GX_WRITE_RAS_REG(reg);
+skipPeCtrlWrite:
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(gx->cpDispSrc);
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(gx->cpDispSize);
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(gx->cpDispStride);
 
-    SET_REG_FIELD(1876, __GXData->cpDisp, 1, 11, clear);
-    SET_REG_FIELD(1876, __GXData->cpDisp, 1, 14, 1);
-    SET_REG_FIELD(1876, __GXData->cpDisp, 8, 24, 0x52);
-    GX_WRITE_RAS_REG(__GXData->cpDisp);
+    reg = (((u32)dest >> 5) & 0xFFFFFF) | 0x4B000000;
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(reg);
+
+    gx->cpDisp = (gx->cpDisp & 0xFFFFF7FF) | ((u32)clear << 11);
+    gx->cpDisp = (gx->cpDisp & 0xFFFFBFFF) | 0x4000;
+    gx->cpDisp = (gx->cpDisp & 0x00FFFFFF) | 0x52000000;
+    GX_WRITE_U8(0x61);
+    GX_WRITE_U32(gx->cpDisp);
 
     if (clear) {
-        GX_WRITE_RAS_REG(__GXData->zmode);
-        GX_WRITE_RAS_REG(__GXData->cmode0);
+        GX_WRITE_U8(0x61);
+        GX_WRITE_U32(gx->zmode);
+        GX_WRITE_U8(0x61);
+        GX_WRITE_U32(gx->cmode0);
     }
 
     if (changePeCtrl) {
-        GX_WRITE_RAS_REG(__GXData->peCtrl);
+        GX_WRITE_U8(0x61);
+        GX_WRITE_U32(gx->peCtrl);
     }
 
-    __GXData->bpSentNot = 0;
+    gx->bpSentNot = 0;
 }
 
 void GXCopyTex(void* dest, GXBool clear) {


### PR DESCRIPTION
## Summary
- Reworked `GXCopyDisp` in `src/gx/GXFrameBuf.c` to use direct BP write sequencing and explicit bitmask operations matching the target control flow more closely.
- Added the PAL metadata header block for `GXCopyDisp` (`0x801A31E0`, `348b`) per runbook format.
- Kept the change scoped to one function and one file.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Function: `GXCopyDisp`
  - Before: `68.873566%`
  - After: `79.586205%`

## Match evidence
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXCopyDisp`
- Unit `.text` match (same diff output):
  - Before: `75.82598%`
  - After: `76.93683%`
- Neighbor checks in same unit:
  - `GXSetCopyFilter`: unchanged at `42.630436%`
  - `GXSetCopyClear`: unchanged at `62.23077%`

## Plausibility rationale
- The revised code follows the hardware register transaction pattern reflected in decomp data: explicit `0x61` BP writes and direct mask/or updates of `cpDisp`/`peCtrl` state.
- Changes are semantic-preserving and keep intent readable (no contrived temporaries or opaque compiler coercion patterns).
- Control-flow split for PE state write (`clear` and pixel format checks) now matches expected behavior layout without adding non-source-like artifacts.

## Technical details
- Replaced `SET_REG_FIELD`/`GX_WRITE_RAS_REG` composition in `GXCopyDisp` with direct masks and `GX_WRITE_U8`/`GX_WRITE_U32` pairs to better align instruction selection.
- Switched to a local `GXData* gx` anchor and explicit branch structure around PE control update (`skipPeCtrlWrite` label) to match target branch shape.
- Confirmed successful build with `ninja` before/after measurement.
