### PR TITLE
fontman: implement CFont operator new and static init

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -1,4 +1,9 @@
 #include "ffcc/fontman.h"
+#include "PowerPC_EABI_Support/Runtime/NMWException.h"
+
+extern CFontMan FontMan;
+extern void* ARRAY_802ea170;
+extern "C" void __dt__8CFontManFv(void*);
 
 /*
  * --INFO--
@@ -292,10 +297,28 @@ void CFont::getNextChar(char **, unsigned short*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80092d2c
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __sinit_fontman_cpp(void)
+void* CFont::operator new(unsigned long size, CMemory::CStage* stage, char* file, int line)
 {
-	// TODO
+	return ::operator new(size, stage, file, line);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800930e0
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_fontman_cpp(void)
+{
+	__register_global_object(&FontMan, __dt__8CFontManFv, &ARRAY_802ea170);
 }


### PR DESCRIPTION
## Summary
- Implemented `CFont::operator new(unsigned long, CMemory::CStage*, char*, int)` in `src/fontman.cpp` instead of leaving it as an implicit missing symbol.
- Implemented `__sinit_fontman_cpp` with C linkage and global destructor registration via `__register_global_object`.
- Added PAL address/size metadata blocks for both implemented functions.

## Functions improved
- Unit: `main/fontman`
- `__nw__5CFontFUlPQ27CMemory6CStagePci`
  - Before: `null` (symbol mismatch / not diffable)
  - After: `44.444443%`
- `__sinit_fontman_cpp`
  - Before: `null` (was emitted as `__sinit_fontman_cpp__Fv`)
  - After: `52.894737%`

## Match evidence
- `main/fontman` unit fuzzy match:
  - Before: `4.459751%`
  - After: `5.9576764%`
- These changes convert two previously non-comparable symbols into directly compared functions with non-zero match scores.

## Plausibility rationale
- Both implementations are source-plausible baseline implementations:
  - `operator new` delegates to the project-wide placement allocator interface.
  - `__sinit_fontman_cpp` performs standard static object destructor-chain registration used elsewhere in this codebase.
- The change primarily fixes linkage/symbol identity issues and restores expected runtime initialization behavior, rather than introducing contrived control-flow tuning.

## Technical details
- Included `PowerPC_EABI_Support/Runtime/NMWException.h` for `__register_global_object`.
- Declared external symbols used by static initialization (`FontMan`, `ARRAY_802ea170`, `__dt__8CFontManFv`).
- Changed `__sinit_fontman_cpp` to `extern "C"` to avoid C++ mangling and align with target symbol naming.
