### PR TITLE
pppYmEnv: implement model helper/graph stubs

### DIFF
--- a/include/ffcc/pppYmEnv.h
+++ b/include/ffcc/pppYmEnv.h
@@ -13,12 +13,12 @@ struct CGObject;
 struct CTexture;
 struct Vec;
 
-void GetModelPtr(CGObject*);
+CChara::CModel* GetModelPtr(CGObject*);
 void GetCharaNodeFrameMatrix(_pppMngSt*, float, float (*)[4]);
 void CalcGraphValue(_pppPObject*, long, float&, float&, float&, float, float&, float&);
 void GetTextureFromRSD(int, _pppEnvSt*);
-void GetCharaModelPtr(CCharaPcs::CHandle*);
-void GetCharaHandlePtr(CGObject*, long);
+CChara::CModel* GetCharaModelPtr(CCharaPcs::CHandle*);
+CCharaPcs::CHandle* GetCharaHandlePtr(CGObject*, long);
 void DisableIndWarp(_GXTevStageID, _GXIndTexStageID);
 void SetUpPaletteEnv(CTexture*);
 void genParaboloidMap(void*, unsigned long*, unsigned short, _GXVtxFmt);

--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/pppYmEnv.h"
+#include "ffcc/gobject.h"
 #include "ffcc/mapmesh.h"
 #include "ffcc/partMng.h"
 
@@ -36,14 +37,26 @@ struct CTextureLite {
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800e602c
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GetModelPtr(CGObject*)
+CChara::CModel* GetModelPtr(CGObject* gObject)
 {
-	// TODO
-}
+    if (gObject == 0) {
+        return 0;
+    }
 
+    CCharaPcs::CHandle* handle = gObject->m_charaModelHandle;
+    if (handle == 0) {
+        return 0;
+    }
+
+    return handle->m_model;
+}
 /*
  * --INFO--
  * Address:	TODO
@@ -56,14 +69,25 @@ void GetCharaNodeFrameMatrix(_pppMngSt*, float, float (*) [4])
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800e58c0
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CalcGraphValue(_pppPObject*, long, float&, float&, float&, float, float&, float&)
+void CalcGraphValue(_pppPObject* object, long graphId, float& value, float& velocity, float& acceleration, float addValue,
+                    float& velocityAdd, float& accelerationAdd)
 {
-	// TODO
-}
+    velocity += acceleration;
+    value += velocity;
 
+    if (graphId == object->m_graphId) {
+        value += addValue;
+        velocity += velocityAdd;
+        acceleration += accelerationAdd;
+    }
+}
 /*
  * --INFO--
  * PAL Address: 0x800e5870
@@ -88,24 +112,51 @@ void GetTextureFromRSD(int mapMeshIndex, _pppEnvSt* env)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800e5858
+ * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GetCharaModelPtr(CCharaPcs::CHandle*)
+CChara::CModel* GetCharaModelPtr(CCharaPcs::CHandle* handle)
 {
-	// TODO
+    if (handle == 0) {
+        return 0;
+    }
+
+    return handle->m_model;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800e57f0
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GetCharaHandlePtr(CGObject*, long)
+CCharaPcs::CHandle* GetCharaHandlePtr(CGObject* gObject, long modelType)
 {
-	// TODO
-}
+    if (gObject == 0) {
+        return 0;
+    }
 
+    if (modelType == 1) {
+        if (gObject->m_weaponModelHandle != 0) {
+            return gObject->m_weaponModelHandle;
+        }
+    } else if (modelType < 1) {
+        if (modelType >= 0 && gObject->m_charaModelHandle != 0) {
+            return gObject->m_charaModelHandle;
+        }
+    } else if (modelType < 3 && gObject->m_shieldModelHandle != 0) {
+        return gObject->m_shieldModelHandle;
+    }
+
+    return 0;
+}
 /*
  * --INFO--
  * PAL Address: 0x800e5780


### PR DESCRIPTION
## Summary
- implement four previously TODO utility routines in pppYmEnv with plausible control flow matching surrounding engine usage
- update corresponding prototypes in include/ffcc/pppYmEnv.h to typed return values used by the implementations
- add PAL address/size metadata blocks for the implemented functions

## Functions improved
Unit: main/pppYmEnv
- GetModelPtr__FP8CGObject: 7.6923% -> 84.2308%
- GetCharaHandlePtr__FP8CGObjectl: 3.8462% -> 70.9231%
- GetCharaModelPtr__FPQ29CCharaPcs7CHandle: 16.6667% -> 31.6667%
- CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf: 4.3478% -> 99.9565%

Unit .text match:
- main/pppYmEnv: 12.0680% -> 15.1470%

## Match evidence
Measured with:
- tools/objdiff-cli diff -p . -u main/pppYmEnv -o - --format json <symbol> | jq ...

The improved symbols now emit expected non-trivial control flow and field accesses instead of stub bodies, and CalcGraphValue is effectively full match.

## Plausibility rationale
These changes are source-plausible rather than compiler coaxing:
- direct model/handle access via existing CGObject and CCharaPcs::CHandle fields
- straightforward graph-value integration pattern already used by other particle/PPP components
- no synthetic temporaries or offset tricks; logic mirrors ordinary gameplay helper utilities
