### PR TITLE
pppSRandDownCV: improve match by aligning RandF call/style

### DIFF
--- a/src/pppSRandDownCV.cpp
+++ b/src/pppSRandDownCV.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern u8 lbl_801EADC8[];
 extern float lbl_80330070;
@@ -33,30 +33,30 @@ void pppSRandDownCV(void* param1, void* param2, void* param3)
         u8 flag = *((u8*)param2 + 0xC);
         float value;
 
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330070;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330070;
         }
         target[0] = value;
 
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330070;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330070;
         }
         target[1] = value;
 
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330070;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330070;
         }
         target[2] = value;
 
-        value = -RandF__5CMathFv(&math);
+        value = -RandF__5CMathFv(math);
         if (flag != 0) {
-            value = (value - RandF__5CMathFv(&math)) * lbl_80330070;
+            value = (value - RandF__5CMathFv(math)) * lbl_80330070;
         }
         target[3] = value;
-    } else {
+    } else if (*(int*)param2 != *((int*)param1 + 3)) {
         int** base_ptr = (int**)((char*)param3 + 0xC);
         int offset = **base_ptr;
         target = (float*)((char*)param1 + offset + 0x80);


### PR DESCRIPTION
## Summary
- Updated `src/pppSRandDownCV.cpp` to mirror the already-better-matching `pppSRandUpCV` codegen style while preserving behavior.
- Switched `math` declaration/use from scalar+address form to array-decay form (`extern CMath math[]` and `RandF__5CMathFv(math)`).
- Kept the non-equal branch as explicit `else if (*(int*)param2 != *((int*)param1 + 3))` to match existing pattern used in sibling random-color functions.

## Functions improved
- Unit: `main/pppSRandDownCV`
- Symbol: `pppSRandDownCV`
- Before: `88.53658%`
- After: `93.018295%`
- Delta: `+4.481715%`

## Match evidence
- `ninja` rebuild succeeds and regenerates `build/GCCP01/report.json`.
- Function fuzzy match increased from `88.53658` to `93.018295` after this patch.

## Plausibility rationale
- This is source-plausible cleanup: it aligns `pppSRandDownCV` with the same coding pattern used by adjacent/symmetric units (`pppSRandUpCV`, `pppSRandCV`), rather than introducing contrived temporaries or non-idiomatic compiler-coaxing constructs.
- No algorithm changes: random generation/sign behavior and color-channel accumulation remain the same.

## Technical details
- Main codegen-sensitive changes were at repeated `RandF__5CMathFv` call sites and branch shape normalization.
- Changes are local to one function/file and do not alter interfaces outside this unit.