### PR TITLE
RedSound: implement SetReverbDepth/ClearWaveDataM wrappers and simplify SetWaveData

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -280,12 +280,16 @@ void CRedSound::SetReverb(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccf38
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetReverbDepth(int, int, int)
+void CRedSound::SetReverbDepth(int bank, int sep, int depth)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetReverbDepth(bank, sep, depth);
 }
 
 /*
@@ -680,34 +684,11 @@ void CRedSound::StreamPause(int streamID, int pause)
  */
 unsigned int CRedSound::SetWaveData(int waveID, void* waveData, int waveSize)
 {
-	unsigned int id;
-	int* slot;
-	int* end;
-
-	do {
-		DAT_8032f4c4 = (DAT_8032f4c4 + 1) & 0x7FFFFFFF;
-	} while (DAT_8032f4c4 == 0);
-
-	id = DAT_8032f4c4;
-	slot = (int*)DAT_8032e17c;
-	end = (int*)(DAT_8032e17c + 0x100);
-
-	while (slot < end) {
-		if (*slot == 0) {
-			*slot = id;
-			break;
-		}
-		++slot;
-	}
-
-	if (slot >= end) {
-		slot = 0;
-	}
-
+	unsigned int id = GetAutoID();
+	int* slot = EntryStandbyID(id);
 	if (slot != 0) {
 		CRedDriver_8032f4c0.SetWaveData((int)slot, waveID, waveData, waveSize);
 	}
-
 	return id;
 }
 
@@ -723,12 +704,16 @@ void CRedSound::ClearWaveData(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd7d0
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::ClearWaveDataM(int, int, int, int)
+void CRedSound::ClearWaveDataM(int bank, int sep, int group, int kind)
 {
-	// TODO
+	CRedDriver_8032f4c0.ClearWaveDataM(bank, sep, group, kind);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedSound::SetReverbDepth` as a direct `CRedDriver` wrapper.
- Implemented `CRedSound::ClearWaveDataM` as a direct `CRedDriver` wrapper.
- Reworked `CRedSound::SetWaveData` to use the existing `GetAutoID` + `EntryStandbyID` flow instead of duplicating standby slot scan logic inline.
- Added PAL address/size metadata blocks for the two wrapper functions.

## Functions improved
- Unit: `main/RedSound/RedSound`
- `SetReverbDepth__9CRedSoundFiii`: **6.6666665% -> 59.4%**
- `ClearWaveDataM__9CRedSoundFiiii`: **5.882353% -> 52.411766%**
- `SetWaveData__9CRedSoundFiPvi`: moved from **6.225806%** to no `fuzzy_match_percent` field in current report (symbol remains present); unit-level fuzzy still improved overall.

## Match evidence
- Unit fuzzy match (`main/RedSound/RedSound`): **29.729874% -> 31.201271%**.
- Build/regeneration succeeded with `ninja` in the PR worktree before commit.
- Updated function symbols are emitted with expected names in `RedSound.o`:
  - `SetReverbDepth__9CRedSoundFiii`
  - `SetWaveData__9CRedSoundFiPvi`
  - `ClearWaveDataM__9CRedSoundFiiii`

## Plausibility rationale
- These are direct forwarding APIs in the `CRedSound` facade over `CRedDriver`; implementing them as thin wrappers is source-plausible and consistent with surrounding code.
- The `SetWaveData` change removes bespoke slot-allocation logic in favor of existing helper methods already used by this class (`GetAutoID`, `EntryStandbyID`), which is cleaner and more likely original structure.

## Technical details
- Changes were limited to `src/RedSound/RedSound.cpp`.
- No debug-only comments, assembly comments, or temporary scaffolding were introduced.
