### PR TITLE
Improve AddRsdList match in main/ME_AppRequest

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -94,24 +94,27 @@ void CMaterialEditorPcs::DeleteColAnmData(ZCANMGRP **, int)
  */
 int CMaterialEditorPcs::AddRsdList(ZLIST* zlist)
 {
-	CMemory::CStage* stage = *(CMemory::CStage**)(MaterialEditorPcs + 4);
-	int* entry = (int*)__nw__FUlPQ27CMemory6CStagePci(0x10, stage, s_ME_AppRequest_cpp_801d7da8, 0x61);
-	if (entry == 0) {
-		return 0;
-	}
+    int* tail = (int*)__nw__FUlPQ27CMemory6CStagePci(0x10, *(CMemory::CStage**)(MaterialEditorPcs + 4),
+                                                     s_ME_AppRequest_cpp_801d7da8, 0x61);
+    if (tail == 0) {
+        return 0;
+    }
 
-	memset(entry, 0, 0x10);
-	int rsdItem = (int)__nw__FUlPQ27CMemory6CStagePci(0x1c, stage, s_ME_AppRequest_cpp_801d7da8, 0x67);
-	if (rsdItem == 0) {
-		__dl__FPv(entry);
-		return 0;
-	}
+    memset(tail, 0, 0x10);
+    int rsdItem = (int)__nw__FUlPQ27CMemory6CStagePci(0x1c, *(CMemory::CStage**)(MaterialEditorPcs + 4),
+                                                      s_ME_AppRequest_cpp_801d7da8, 0x67);
+    if (rsdItem == 0) {
+        if (tail != 0) {
+            __dl__FPv(tail);
+        }
+        return 0;
+    }
 
-	memset((void*)rsdItem, 0, 0x1c);
-	entry[0] = rsdItem;
-	entry[3] = 1;
-	zlist->AddTail(entry);
-	return 1;
+    memset((void*)rsdItem, 0, 0x1c);
+    *tail = rsdItem;
+    tail[3] = 1;
+    zlist->AddTail(tail);
+    return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
Aligned CMaterialEditorPcs::AddRsdList control flow and allocation usage with the recovered original pattern.

Key changes:
- Inlined stage pointer loads at each allocation call.
- Switched to tail pointer flow matching original allocation/use sequence.
- Kept the redundant null guard before __dl__ on second-allocation failure to preserve branch structure.
- Used direct *tail assignment for the RSD pointer before AddTail.

## Functions improved
- Unit: main/ME_AppRequest
- Function: AddRsdList__18CMaterialEditorPcsFP5ZLIST

## Match evidence
- Before: 78.73585% (size 212b)
- After: 99.62264% (size 212b)
- Verified with:
  - build/tools/objdiff-cli diff -p . -u main/ME_AppRequest -o - AddRsdList__18CMaterialEditorPcsFP5ZLIST
  - ninja

## Plausibility rationale
The update preserves straightforward source-level semantics and removes decomp-artifact structure (stage temporary reuse) in favor of code flow that is typical for original game code: allocate list entry, zero it, allocate payload, cleanup on failure, then append.

## Technical details
Instruction-level diffs before this change were concentrated in prologue/register setup and the failure-path branch pattern around second allocation. Matching the original-style allocation flow and explicit cleanup check removed those mismatches and produced a near-complete assembly match.
