### PR TITLE
chunkfile: improve GetF4 match to 100%

### DIFF
--- a/src/chunkfile.cpp
+++ b/src/chunkfile.cpp
@@ -201,12 +201,13 @@ unsigned int CChunkFile::Get4()
  */
 float CChunkFile::GetF4()
 {
-    float value;
-    unsigned int* cursor = (unsigned int*)m_cursor;
-    unsigned int bits = *cursor;
-    m_cursor = (unsigned char*)(cursor + 1);
-    *(unsigned int*)&value = bits;
-    return value;
+    union {
+        unsigned int bits;
+        float value;
+    } u;
+
+    u.bits = Get4();
+    return u.value;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CChunkFile::GetF4()` in `src/chunkfile.cpp` to read raw bits through `Get4()` and reinterpret via a local union.
- Kept behavior source-plausible and local to one function (no API or layout changes).

## Functions improved
- Unit: `main/chunkfile`
- Function: `GetF4__10CChunkFileFv`
  - Before: `75.888885%`
  - After: `100.0%`

## Match evidence
- `main/chunkfile` unit fuzzy match:
  - Before: `94.5468%`
  - After: `95.61576%`
- Project progress (`ninja` report):
  - Matched code bytes: `197368 -> 197404`
  - Matched functions: `1444 -> 1445`
- `objdiff-cli diff -p . -u main/chunkfile GetF4__10CChunkFileFv` shows `100.00%` and fully aligned instructions.

## Plausibility rationale
- Reading the 32-bit payload with `Get4()` and reinterpreting as `float` is consistent with chunk-stream parsing patterns and preserves exact bit representation.
- This avoids contrived control-flow or layout tricks and keeps code readable/original-source plausible.

## Technical details
- Prior implementation manually advanced `m_cursor` and wrote bits via pointer cast.
- New implementation centralizes the raw read in existing `Get4()` and only performs bit reinterpretation locally, which improved instruction selection/alignment for this symbol.
