### PR TITLE
math: implement CMath::Line1D

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -46,7 +46,7 @@ public:
     void CalcSpline(Vec*, Vec*, Vec*, Vec*, Vec*, float, float, float, float, float);
     void MakeSpline1Dtable(int, float*, float*, float*);
     float Spline1D(int, float, float*, float*, float*);
-    void Line1D(int, float, float*, float*);
+    float Line1D(int, float, float*, float*);
     unsigned int Hsb2Rgb(int, int, int);
     float DstRot(float, float);
 };

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -751,12 +751,41 @@ float CMath::Spline1D(int lastIndex, float t, float* x, float* y, float* secondD
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001a580
+ * PAL Size: 172b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMath::Line1D(int, float, float*, float*)
+float CMath::Line1D(int lastIndex, float x, float* x_arr, float* y_arr)
 {
-	// TODO
+    float period = x_arr[lastIndex] - x_arr[0];
+
+    while (x_arr[lastIndex] < x) {
+        x -= period;
+    }
+
+    while (x < x_arr[0]) {
+        x += period;
+    }
+
+    int low = 0;
+    int high = lastIndex;
+    while (low < high) {
+        int mid = (low + high) / 2;
+        if (x_arr[mid] < x) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+
+    if (low > 0) {
+        low--;
+    }
+
+    return ((x - x_arr[low]) / (x_arr[low + 1] - x_arr[low])) * (y_arr[low + 1] - y_arr[low]) + y_arr[low];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMath::Line1D(int, float, float*, float*)` in `src/math.cpp` using periodic wrapping + binary search + linear interpolation.
- Updated `CMath` declaration in `include/ffcc/math.h` so `Line1D` returns `float` (matching usage and symbol signature).
- Added PAL function metadata block for this function.

## Functions improved
- Unit: `main/math`
- Function: `Line1D__5CMathFifPfPf` (`CMath::Line1D(int, float, float*, float*)`, 172b)

## Match evidence
- Before: `2.3255813%` fuzzy match
- After: `99.65116%` fuzzy match
- Delta: `+97.3255787` points
- Verification: `ninja` rebuild succeeded and regenerated `build/GCCP01/report.json`.

## Plausibility rationale
- The implementation is direct, idiomatic game math utility code: wrap parameter into period, locate segment with binary search, then linearly interpolate.
- No compiler-coaxing constructs were introduced; this is consistent with existing `CMath` spline/curve helpers and with call-site expectations in `map.cpp`.

## Technical details
- Function now uses:
  - `period = x_arr[lastIndex] - x_arr[0]`
  - wrap loops for values above/below range
  - binary search for interval index
  - final lerp formula using neighboring `x_arr`/`y_arr` points
- Signature correction from `void` to `float` aligns with external call sites (`Line1D__5CMathFifPfPf` consumers in `map.cpp`).
