### PR TITLE
alloc: improve link_new_block control-flow matching

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -338,14 +338,14 @@ static Block* link_new_block(__mem_pool_obj* pool_obj, unsigned long size) {
 
     Block_construct(block, aligned_size);
     start = pool_obj->start_;
-    if (start == 0) {
-        block->prev = block;
-        block->next = block;
-    } else {
+    if (start != 0) {
         block->prev = start->prev;
         block->prev->next = block;
         block->next = start;
         block->next->prev = block;
+    } else {
+        block->prev = block;
+        block->next = block;
     }
     pool_obj->start_ = block;
     return block;


### PR DESCRIPTION
## Summary
- Reordered the `link_new_block` branch to handle the non-empty list path first.
- Kept behavior identical while aligning control flow and store ordering with the target assembly.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/alloc`
- Symbol: `link_new_block`

## Match evidence
- `link_new_block`: **88.35555% -> 94.48889%**
- `link_new_block` diff instructions: **17 -> 12**
- Unit `.text` match: **80.04% -> 80.33053%**

## Plausibility rationale
- This is a source-plausible refactor: it only flips the `start == 0`/`start != 0` branch ordering without introducing artificial temporaries or non-idiomatic constructs.
- Pointer-link updates remain idiomatic intrusive-list insertion logic and preserve readability.

## Technical details
- The revised control-flow shape better matches the original branch direction (`bne` fast-path) and reduces mismatches in the block-linking sequence.
- No behavior changes outside `link_new_block`; build and object diff checks were run after the edit.
