### PR TITLE
mapobj: improve SetMime condition shape in SetMime

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -390,7 +390,7 @@ void CMapObj::SetMime(int mode, int target, int type)
     *reinterpret_cast<int*>(mime + 0x20) = mode;
     *reinterpret_cast<int*>(mime + 0x1C) = mode;
 
-    if (*reinterpret_cast<int*>(mime + 0x28) < target) {
+    if (target > *reinterpret_cast<int*>(mime + 0x28)) {
         target = *reinterpret_cast<int*>(mime + 0x28);
     }
 


### PR DESCRIPTION
## Summary
- Adjusted the clamp condition in `CMapObj::SetMime(int mode, int target, int type)` to use `target > limit` form.
- No behavior change: this still clamps `target` to `mime[0x28]` before writing `mime[0x24]`.

## Functions improved
- Unit: `main/mapobj`
- Function: `SetMime__7CMapObjFiii`

## Match evidence
- Before: `98.75%` (`build/tools/objdiff-cli diff -p . -u main/mapobj -o /tmp/setmime.json SetMime__7CMapObjFiii`)
- After: `100.0%` (`build/tools/objdiff-cli diff -p . -u main/mapobj -o /tmp/setmime_after.json SetMime__7CMapObjFiii`)
- Key asm alignment: compare/branch shape now matches target control flow for the clamp block.

## Plausibility rationale
- This is idiomatic source-level clamp logic (`if (target > limit) target = limit;`) and is at least as natural as the previous equivalent form.
- The change improves assembly alignment without introducing compiler-coaxing artifacts or readability regressions.

## Technical details
- The only source change is one comparison direction in `src/mapobj.cpp`.
- Build status: `ninja` reports up-to-date after rebuilding the touched object.
