### PR TITLE
main/p_light: first-pass decomp for CLightPcs::Add

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -217,12 +217,54 @@ void CLightPcs::Clear()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80049acc
+ * PAL Size: 1032b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CLightPcs::Add(CLightPcs::CLight*)
+void CLightPcs::Add(CLightPcs::CLight* light)
 {
-	// TODO
+    float radius = *(float*)((char*)light + 0x1c);
+    float maxDist = *(float*)((char*)light + 0x20);
+    float intensity = *(float*)((char*)light + 0x28);
+    unsigned int colorMask = 0x01010101;
+
+    if (maxDist >= FLOAT_8032fc14) {
+        maxDist = radius;
+    }
+
+    float absRadius = radius;
+    if (radius < FLOAT_8032fc14) {
+        absRadius = -radius;
+    }
+
+    if (*(int*)((char*)light + 0x50) == 0) {
+        reinterpret_cast<unsigned char*>(&colorMask)[0] = 0;
+    }
+    if (*(int*)((char*)light + 0x54) == 0) {
+        reinterpret_cast<unsigned char*>(&colorMask)[1] = 0;
+    }
+    if (*(int*)((char*)light + 0x58) == 0) {
+        reinterpret_cast<unsigned char*>(&colorMask)[2] = 0;
+    }
+
+    int index = *(int*)((char*)this + 0xb8);
+    *(int*)((char*)this + 0xb8) = index + 1;
+
+    unsigned int* dst = (unsigned int*)((char*)this + 0x63c + index * 0xb0);
+    unsigned int* src = (unsigned int*)light;
+    for (int i = 0; i < 0x2c; i++) {
+        dst[i] = src[i];
+    }
+
+    float atten = absRadius * FLOAT_8032fc18 * intensity;
+    float radiusSq = radius * radius;
+    dst[8] = *(unsigned int*)&maxDist;
+    dst[9] = *(unsigned int*)&atten;
+    dst[0x18] = colorMask;
+    dst[0x2b] = *(unsigned int*)&radiusSq;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass decompilation of `CLightPcs::Add(CLightPcs::CLight*)` in `src/p_light.cpp`.
- Replaced the previous `// TODO` body with offset-accurate light-slot append logic.
- Added PAL metadata header for the function (`0x80049acc`, `1032b`).

## Functions Improved
- Unit: `main/p_light`
- Symbol: `Add__9CLightPcsFPQ29CLightPcs6CLight`

## Match Evidence
- Before: `0.4%` (from `tools/agent_select_target.py` target report)
- After: `22.627907%` via:
  - `build/tools/objdiff-cli diff -p . -u main/p_light -o - Add__9CLightPcsFPQ29CLightPcs6CLight`
- Function size matched target size: `1032b`

## Plausibility Rationale
- The implementation follows existing `p_light.cpp` style already used elsewhere in this unit (offset-based field access with low-level GX-era data layout handling).
- Logic mirrors expected game-side intent rather than artificial compiler coaxing:
  - append incoming light to the active light array,
  - compute derived attenuation/range fields,
  - compute per-channel mask from enable flags,
  - store squared radius cache.
- No debug scaffolding or non-source artifacts were introduced.

## Technical Details
- Reads light parameters from source record offsets (`0x1c`, `0x20`, `0x28`, `0x50/0x54/0x58`).
- Allocates destination slot from `this + 0x63c + index * 0xb0` and increments active count at `this + 0xb8`.
- Copies full 0xB0-byte light record (44 words), then patches derived fields:
  - `dst[8]` clamped max-distance,
  - `dst[9]` attenuation scalar,
  - `dst[0x18]` channel color mask,
  - `dst[0x2B]` radius squared.

