### PR TITLE
Improve pppRandHCV match with control-flow simplification

### DIFF
--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -46,16 +46,13 @@ extern "C" {
 
 void pppRandHCV(void* p1, void* p2, void* p3) {
     RandHCVParams* params = (RandHCVParams*)p2;
-    int id = *(int*)((char*)p1 + 0xc);
-    int* baseIndex;
-    int baseOffset;
     float* scalePtr;
 
     if (lbl_8032ED70 != 0) {
         return;
     }
 
-    if (params->index == id) {
+    if (params->index == *(int*)((char*)p1 + 0xc)) {
         float randValue = RandF__5CMathFv(math);
         if (params->flag != 0) {
             randValue = randValue + RandF__5CMathFv(math);
@@ -63,19 +60,15 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
             randValue = randValue * lbl_8032FF98;
         }
 
-        baseIndex = *(int**)((char*)p3 + 0xc);
-        baseOffset = *baseIndex;
-        scalePtr = (float*)((char*)p1 + baseOffset + 0x80);
+        scalePtr = (float*)((char*)p1 + **(int**)((char*)p3 + 0xc) + 0x80);
         *scalePtr = randValue;
     }
 
-    if (params->index != id) {
+    if (params->index != *(int*)((char*)p1 + 0xc)) {
         return;
     }
 
-    baseIndex = *(int**)((char*)p3 + 0xc);
-    baseOffset = *baseIndex;
-    scalePtr = (float*)((char*)p1 + baseOffset + 0x80);
+    scalePtr = (float*)((char*)p1 + **(int**)((char*)p3 + 0xc) + 0x80);
 
     s16* target;
     if (params->colorOffset == -1) {


### PR DESCRIPTION
## Summary
- Refactored `pppRandHCV` in `src/pppRandHCV.cpp` to better match original control-flow/register pressure.
- Removed cached locals (`id`, intermediate base pointers/offsets) and used direct reloads for key comparisons/offset resolution.
- Kept behavior unchanged while tightening expression shape around scale-pointer calculation.

## Functions Improved
- Unit: `main/pppRandHCV`
- Function: `pppRandHCV`

## Match Evidence
- Before: `82.9%` (from `tools/agent_select_target.py` target report)
- After: `87.0229%` (`build/GCCP01/report.json` fuzzy match percent)
- Build verification: `ninja` passes and regenerates report successfully.

## Plausibility Rationale
- The change removes unnecessary temporaries and keeps straightforward gameplay-side logic intact.
- Updated code remains natural C++ source style (direct field checks and pointer derivation), rather than artificial compiler coaxing constructs.

## Technical Details
- Aligns with original assembly shape by:
  - Re-reading actor id at comparison points instead of preserving an extra local copy.
  - Computing scale target pointer directly from serialized offset expression.
  - Reducing preserved-register pressure and redundant dataflow in early/basic blocks.
