### PR TITLE
main/pppCharaZEnvCtrl: match pppFrameCharaZEnvCtrl

### DIFF
--- a/src/pppCharaZEnvCtrl.cpp
+++ b/src/pppCharaZEnvCtrl.cpp
@@ -2,7 +2,8 @@
 #include "ffcc/partMng.h"
 #include "dolphin/gx/GXPixel.h"
 
-extern unsigned int DAT_8032ed70;
+extern int lbl_8032ED70;
+extern u8* lbl_8032ED50;
 
 extern "C" {
 void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
@@ -35,7 +36,7 @@ void CharaZEnvCtrl_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void* data,
  */
 void pppConCharaZEnvCtrl(void)
 {
-	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)(lbl_8032ED50 + 0xd8), 0);
 	GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
 }
 
@@ -50,7 +51,7 @@ void pppConCharaZEnvCtrl(void)
  */
 void pppDesCharaZEnvCtrl(void)
 {
-	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0x8), 0);
+	void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)(lbl_8032ED50 + 0xd8), 0);
 	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
 	*(void**)(model + 0xe4) = 0;
 	*(void**)(model + 0xe8) = 0;
@@ -68,16 +69,18 @@ void pppDesCharaZEnvCtrl(void)
  */
 void pppFrameCharaZEnvCtrl(pppCharaZEnvCtrl* pppCharaZEnvCtrl, UnkB* param_2, UnkC* param_3)
 {
-	if (DAT_8032ed70 != 0U) {
+	void* dataPtr;
+	void* handle;
+	int model;
+
+	if (lbl_8032ED70 != 0) {
 		return;
 	}
 
-	::pppCharaZEnvCtrl* self = pppCharaZEnvCtrl;
-	int dataOffset = (int)*(void**)((char*)param_3 + 0xc);
-	void* owner = *(void**)((char*)pppMngStPtr + 0x8);
-	void* handle = GetCharaHandlePtr__FP8CGObjectl(owner, 0);
-	int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
-	*(void**)(model + 0xe4) = (void*)((char*)self + dataOffset + 0x10);
+	dataPtr = (void*)((char*)pppCharaZEnvCtrl + **(int**)((char*)param_3 + 0xc) + 0x80);
+	handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)(lbl_8032ED50 + 0xd8), 0);
+	model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+	*(void**)(model + 0xe4) = dataPtr;
 	*(UnkB**)(model + 0xe8) = param_2;
 	*(void (**)(CChara::CModel*, void*, void*, int))(model + 0xf4) = CharaZEnvCtrl_BeforeMeshLockEnvCallback;
 }


### PR DESCRIPTION
## Summary
- Updated `src/pppCharaZEnvCtrl.cpp` globals and pointer paths to use the particle manager storage used by the target object (`lbl_8032ED50`, `lbl_8032ED70`).
- Reworked `pppFrameCharaZEnvCtrl` to match original data pointer derivation from serialized offsets (`+0x80`) and callback setup ordering.
- Simplified locals so register lifetimes and prologue match the original function shape.

## Functions Improved
- Unit: `main/pppCharaZEnvCtrl`
- Function: `pppFrameCharaZEnvCtrl`
- Match: `57.6%` (selector baseline) -> `100.00%` (objdiff)

## Match Evidence
- Baseline from `tools/agent_select_target.py`: `pppFrameCharaZEnvCtrl (57.6% match, 116b)`.
- Post-change from objdiff: `build/tools/objdiff-cli diff -p . -u main/pppCharaZEnvCtrl pppFrameCharaZEnvCtrl` reports `100.00%`.
- Full build/progress after change: `ninja` succeeds and overall code matched bytes increased.

## Plausibility Rationale
- Changes are type/offset corrections and control-flow cleanup that align with surrounding code patterns (global manager access, callback field assignment), not artificial compiler coaxing.
- The rewritten code expresses the same gameplay intent: compute callback data pointer from serialized particle data and install model callback fields.

## Technical Details
- `pppFrameCharaZEnvCtrl` now emits the same short-stack prologue and register usage as target.
- Callback data writes now use `base + serializedOffset + 0x80`, matching target object addressing.
- Manager-owner object access now goes through `lbl_8032ED50 + 0xD8`, matching target relocation/symbol usage.
