### PR TITLE
main/RedSound/RedStream: improve _SearchEmptyStreamData match

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -30,16 +30,20 @@ int fflush(void*);
 unsigned int _SearchEmptyStreamData()
 {
 	unsigned int streamData;
+	unsigned int result;
 
 	streamData = (unsigned int)DAT_8032f438;
 	do {
 		if (*(int*)(streamData + 0x10c) == 0) {
-			return streamData;
+			result = streamData;
+			goto done;
 		}
 		streamData += 0x130;
 	} while (streamData < (unsigned int)DAT_8032f438 + 0x4c0);
 
-	return 0;
+	result = 0;
+done:
+	return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refactored `_SearchEmptyStreamData` in `src/RedSound/RedStream.cpp` to use a single exit path via `result` + `goto done`.
- Kept loop/data semantics unchanged; only control-flow form was adjusted.

## Functions improved
- Unit: `main/RedSound/RedStream`
- Symbol: `_SearchEmptyStreamData__Fv`

## Match evidence
- `_SearchEmptyStreamData__Fv`: `41.705883%` -> `47.000000%` (`+5.294117`)
- Build verification: `ninja` completed successfully.

## Plausibility rationale
- The change is source-plausible C/C++: no artificial constants, no offset tricks, and no behavior change.
- It only alters exit structure, which is a realistic original-source variant that affects MWCC codegen.

## Technical details
- Objdiff on `_SearchEmptyStreamData__Fv` improved after replacing early return with a single return block.
- No other function bodies were changed in this PR.
