### PR TITLE
main/gx/GXFrameBuf: improve GXSetCopyClear match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -349,19 +349,20 @@ u32 GXSetDispCopyYScale(f32 vscale) {
 }
 
 void GXSetCopyClear(GXColor clear_clr, u32 clear_z) {
-    GXData* gx;
     u32 regA;
     u32 regGB;
 
     CHECK_GXBEGIN(1596, "GXSetCopyClear");
     ASSERTMSGLINE(1598, clear_z <= 0xFFFFFF, "GXSetCopyClear: Z clear value is out of range");
 
-    regA = ((u32)clear_clr.a << 8) | clear_clr.r;
+    regA = clear_clr.a;
+    regA = (regA << 8) | clear_clr.r;
     regA = (regA & 0xFFFF) | 0x4F000000;
     GX_WRITE_U8(0x61);
     GX_WRITE_U32(regA);
 
-    regGB = ((u32)clear_clr.g << 8) | clear_clr.b;
+    regGB = clear_clr.g;
+    regGB = (regGB << 8) | clear_clr.b;
     regGB = (regGB & 0xFFFF) | 0x50000000;
     GX_WRITE_U8(0x61);
     GX_WRITE_U32(regGB);
@@ -370,8 +371,7 @@ void GXSetCopyClear(GXColor clear_clr, u32 clear_z) {
     GX_WRITE_U8(0x61);
     GX_WRITE_U32(regA);
 
-    gx = __GXData;
-    gx->bpSentNot = 0;
+    __GXData->bpSentNot = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
Adjusted `GXSetCopyClear` packing code in `src/gx/GXFrameBuf.c` to a source-plausible two-step shift/or form and removed an unnecessary local pointer temporary.

## Functions Improved
- Unit: `main/gx/GXFrameBuf`
- Function: `GXSetCopyClear`

## Match Evidence
- `GXSetCopyClear`: **62.23077% -> 62.807693%** (+0.576923)
- `main/gx/GXFrameBuf` `.text`: **80.10369% -> 80.121574%**
- Instruction-level diff entries for `GXSetCopyClear`: **24 -> 23**

Objdiff command used:
```sh
tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXSetCopyFilter
```
(then inspected `GXSetCopyClear` in the JSON output)

## Plausibility Rationale
The change preserves behavior and keeps idiomatic SDK-style bit packing, while only reshaping expression form (split shift/or assignment) to better reflect plausible original hand-written code rather than contrived compiler-only tricks.

## Technical Details
- Replaced single-expression byte packing with explicit stepwise packing for `regA`/`regGB`.
- Left register tag composition and FIFO writes unchanged.
- Kept assertion and clear-z handling semantics unchanged.
