### PR TITLE
menu_item: implement ItemCtrl first-pass decomp

### DIFF
--- a/include/ffcc/menu_item.h
+++ b/include/ffcc/menu_item.h
@@ -7,10 +7,11 @@ public:
     void ItemInit();
     void ItemInit1();
     void ItemOpen();
-    void ItemCtrl();
+    int ItemCtrl();
     void ItemClose();
     void ItemDraw();
-    void ItemCtrlCur();
+    int ItemCtrlCur();
+    void SingLifeInit(int);
 };
 
 #endif // _FFCC_MENU_ITEM_H_

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -1,5 +1,8 @@
 #include "ffcc/menu_item.h"
 
+typedef signed short s16;
+typedef unsigned char u8;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -32,12 +35,41 @@ void CMenuPcs::ItemOpen()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8015a994
+ * PAL Size: 260b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::ItemCtrl()
+int CMenuPcs::ItemCtrl()
 {
-	// TODO
+    s16* itemState = *(s16**)((u8*)this + 0x82C);
+    s16* selectState = *(s16**)((u8*)this + 0x848);
+    int result = 0;
+
+    itemState[0x19] = itemState[0x18];
+
+    if ((itemState[0x18] == 0) || ((itemState[0x18] != 0) && (itemState[0x9] == 1))) {
+        result = ItemCtrlCur();
+    } else if ((itemState[0x18] == 1) && (itemState[0x9] == 0)) {
+        if (selectState[5] == 1) {
+            result = 0;
+            itemState[0x9] = 1;
+        }
+    } else if ((itemState[0x18] == 1) && (itemState[0x9] == 2) && (selectState[5] == 3)) {
+        result = 0;
+        itemState[0x9] = 0;
+        itemState[0x18] = 0;
+        itemState[0x11] = 0;
+    }
+
+    if (result != 0) {
+        SingLifeInit(-1);
+        ItemInit1();
+    }
+
+    return result;
 }
 
 /*
@@ -65,7 +97,7 @@ void CMenuPcs::ItemDraw()
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::ItemCtrlCur()
+int CMenuPcs::ItemCtrlCur()
 {
-	// TODO
+    return 0;
 }


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::ItemCtrl` in `src/menu_item.cpp` from the PAL decomp flow, including state transitions and reset/init calls.
- Updated `include/ffcc/menu_item.h` signatures so `ItemCtrl`/`ItemCtrlCur` return `int` and added `SingLifeInit(int)` declaration used by this unit.
- Added PAL address/size metadata block for `ItemCtrl`.

## Functions improved
- Unit: `main/menu_item`
- Symbol: `ItemCtrl__8CMenuPcsFv`

## Match evidence
- `ItemCtrl__8CMenuPcsFv`: **1.5384616% -> 83.07692%**
- `ItemCtrl__8CMenuPcsFv` current size: **4 -> 240** bytes (target 260)
- Unit fuzzy match (`main/menu_item`) rose to **3.4962406%** after this change.

## Plausibility rationale
- The implementation follows recovered control logic rather than artificial instruction-shaping.
- Behavior is expressed as straightforward state-machine updates (`itemState`/`selectState`) with existing method calls (`ItemCtrlCur`, `SingLifeInit`, `ItemInit1`).
- This is a first-pass decomp step; offset-based field access reflects currently incomplete class layout information in the repo.

## Technical details
- Verified by rebuilding with `ninja` and running objdiff:
  - `build/tools/objdiff-cli diff -p . -u main/menu_item -o - ItemCtrl__8CMenuPcsFv`
