### PR TITLE
pppYmMiasma: align particle type mangling for real function matching

### DIFF
--- a/include/ffcc/pppYmMiasma.h
+++ b/include/ffcc/pppYmMiasma.h
@@ -15,11 +15,11 @@ struct VYmMiasma;
 struct PYmMiasma;
 struct _pppPObject;
 struct _pppCtrlTable;
-struct _PARTICLE_DATA;
+struct PARTICLE_DATA;
 
-void InitParticleData(VYmMiasma*, _pppPObject*, PYmMiasma*, _PARTICLE_DATA*);
-void UpdateParticleData(_pppPObject*, _pppCtrlTable*, PYmMiasma*, _PARTICLE_DATA*);
-void RenderParticle(_pppPObject*, PYmMiasma*, _PARTICLE_DATA*);
+void InitParticleData(VYmMiasma*, _pppPObject*, PYmMiasma*, PARTICLE_DATA*);
+void UpdateParticleData(_pppPObject*, _pppCtrlTable*, PYmMiasma*, PARTICLE_DATA*);
+void RenderParticle(_pppPObject*, PYmMiasma*, PARTICLE_DATA*);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -44,7 +44,7 @@ extern "C" void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, u
  * JP Address: TODO
  * JP Size: TODO
  */
-void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* pYmMiasma, _PARTICLE_DATA* particleData)
+void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
 {
     u8* vData = (u8*)vYmMiasma;
     u8* ymData = (u8*)pYmMiasma;
@@ -136,38 +136,38 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
  * Address:	80090e3c
  * Size:	1016b
  */
-void UpdateParticleData(_pppPObject* pppPObject, _pppCtrlTable* pppCtrlTable, PYmMiasma* pYmMiasma, _PARTICLE_DATA* particleData)
+void UpdateParticleData(_pppPObject* pppPObject, _pppCtrlTable* pppCtrlTable, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
 {
-    float deltaTime;
-    Vec velocity;
-    
-    if (!particleData || !pYmMiasma) return;
-    
-    // Age the particle
-    particleData->m_age++;
-    
-    // Early exit if particle is dead
-    if (particleData->m_age >= particleData->m_lifeTime) {
+    u8* particle;
+    s32 lifeTime;
+    s32 age;
+    float lifeFactor;
+
+    (void)pppPObject;
+    (void)pppCtrlTable;
+
+    if (particleData == NULL || pYmMiasma == NULL) {
         return;
     }
-    
-    // Apply velocity to position
-    deltaTime = 1.0f; // Frame time
-    velocity.x = particleData->m_matrix[1][0] * deltaTime;
-    velocity.y = particleData->m_matrix[1][1] * deltaTime;
-    velocity.z = particleData->m_matrix[1][2] * deltaTime;
-    
-    // Update position matrix
-    particleData->m_matrix[0][3] += velocity.x;
-    particleData->m_matrix[1][3] += velocity.y;  
-    particleData->m_matrix[2][3] += velocity.z;
-    
-    // Apply gravity or other forces
-    particleData->m_velocity.y -= 0.01f; // Gravity
-    
-    // Update size over lifetime
-    float lifeFactor = (float)particleData->m_age / (float)particleData->m_lifeTime;
-    particleData->m_sizeVal = particleData->m_sizeStart * (1.0f - lifeFactor) + particleData->m_sizeEnd * lifeFactor;
+
+    particle = (u8*)particleData;
+
+    age = *(s32*)(particle + 0x68) + 1;
+    *(s32*)(particle + 0x68) = age;
+    lifeTime = *(s32*)(particle + 0x64);
+    if (age >= lifeTime) {
+        return;
+    }
+
+    *(float*)(particle + 0x0C) += *(float*)(particle + 0x10);
+    *(float*)(particle + 0x1C) += *(float*)(particle + 0x14);
+    *(float*)(particle + 0x2C) += *(float*)(particle + 0x18);
+
+    *(float*)(particle + 0x34) -= 0.01f;
+
+    lifeFactor = (float)age / (float)lifeTime;
+    *(float*)(particle + 0x60) =
+        *(float*)(particle + 0x58) * (1.0f - lifeFactor) + *(float*)(particle + 0x5C) * lifeFactor;
 }
 
 /*
@@ -175,7 +175,7 @@ void UpdateParticleData(_pppPObject* pppPObject, _pppCtrlTable* pppCtrlTable, PY
  * Address:	TODO
  * Size:	TODO
  */
-void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, _PARTICLE_DATA* particleData)
+void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
 {
     // Basic rendering setup
     if (!particleData) return;
@@ -283,7 +283,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, UnkB* param_2, UnkC* param_3)
             (unsigned long)count * 0x50, pppEnvStPtr->m_stagePtr, sPppYmMiasmaCpp, 0x18d);
         particle = (u8*)(u32) * (u32*)workBytes;
         for (i = 0; i < count; i++) {
-            InitParticleData((VYmMiasma*)workBytes, (_pppPObject*)pppYmMiasma_, (PYmMiasma*)step, (_PARTICLE_DATA*)particle);
+            InitParticleData((VYmMiasma*)workBytes, (_pppPObject*)pppYmMiasma_, (PYmMiasma*)step, (PARTICLE_DATA*)particle);
             particle += 0x50;
         }
     }
@@ -322,7 +322,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, UnkB* param_2, UnkC* param_3)
 
     particle = (u8*)(u32) * (u32*)workBytes;
     for (i = 0; i < count; i++) {
-        UpdateParticleData((_pppPObject*)pppYmMiasma_, (_pppCtrlTable*)param_3, (PYmMiasma*)step, (_PARTICLE_DATA*)particle);
+        UpdateParticleData((_pppPObject*)pppYmMiasma_, (_pppCtrlTable*)param_3, (PYmMiasma*)step, (PARTICLE_DATA*)particle);
         particle += 0x50;
     }
 


### PR DESCRIPTION
## Summary
- Switched `pppYmMiasma` particle helper signatures from `_PARTICLE_DATA*` to `PARTICLE_DATA*` in `pppYmMiasma.h/.cpp` so generated symbols align with the unit's expected mangled names.
- Updated `UpdateParticleData` to byte-offset field updates (same behavioral intent as prior placeholder: age/lifetime, position integration, gravity, size interpolation) so it compiles with the `PARTICLE_DATA` forward declaration.
- Updated call sites in `pppFrameYmMiasma` to use the same `PARTICLE_DATA*` type.

## Functions improved
- `UpdateParticleData__FP11_pppPObjectP13_pppCtrlTableP9PYmMiasmaP13PARTICLE_DATA`: `0.0% -> 12.08%`
- `InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA`: `0.0% -> 47.19%`
- `pppFrameYmMiasma`: `45.88% -> 48.30%`

## Match evidence
- Unit `main/pppYmMiasma` fuzzy match: `27.08% -> 42.67%` (`build/GCCP01/report.json`)
- Objdiff one-shot (`tools/objdiff-cli diff -p . -u main/pppYmMiasma ...`) `.text` match percent: `26.90% -> 42.35%`
- Symbol alignment check now resolves both sides to:
  - `UpdateParticleData__FP11_pppPObjectP13_pppCtrlTableP9PYmMiasmaP13PARTICLE_DATA`

## Plausibility rationale
- This is a type-signature correction rather than compiler coaxing: the previous signature generated mismatched mangled symbol names for the unit, which blocks meaningful function-level diffing/matching even when implementation work exists.
- Byte-offset updates in `UpdateParticleData` are consistent with the existing decomp style in this file (`InitParticleData`/`pppFrameYmMiasma`), where packed particle data is manipulated by explicit offsets.

## Technical details
- Root cause identified via objdiff symbol inspection: previous build emitted `...P14_PARTICLE_DATA`, while target unit expected `...P13PARTICLE_DATA`.
- Signature/type updates were applied only in `pppYmMiasma` declarations/definitions and matching call sites to keep scope tight.
