### PR TITLE
pppLight: add debug-flag early return and fix base pointer chain

### DIFF
--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/pppLight.h"
 
 extern float lbl_80330F60;
+extern int lbl_8032ED70;
 
 /*
  * --INFO--
@@ -84,20 +85,17 @@ void pppLightCon(void* param1, void* param2)
  */
 void pppLight(void* param1, void* param2, void* param3)
 {
-	// Based on assembly analysis - complex lighting calculation function
 	char* r28 = (char*)param1;
 	char* r29 = (char*)param2;
-	
-	// Get base pointer from param3 structure  
+
+	if (lbl_8032ED70 != 0) {
+		return;
+	}
+
 	void** ptr1 = (void**)((char*)param3 + 0xc);
-	void** ptr2 = (void**)*ptr1;
-	void* ptr3 = *ptr2;
-	char* r30 = r28 + (int)ptr3 + 0x80;
-	
-	// Early return check - appears to check some global flag
-	// if (some_global_flag != 0) return;
-	
-	// Float accumulation operations from assembly
+	void* ptr2 = *ptr1;
+	char* r30 = r28 + (int)ptr2 + 0x80;
+
 	float f1, f0;
 	
 	// Load and accumulate float values at various offsets


### PR DESCRIPTION
## Summary
- Added the missing early return in `pppLight` when `lbl_8032ED70` is non-zero.
- Corrected the effect-data base pointer chain in `pppLight` to use the same dereference pattern as the matching constructor functions.
- Kept the change minimal and source-plausible (no artificial control-flow shaping or compiler-only temporaries).

## Functions improved
- Unit: `main/pppLight`
- Symbol: `pppLight`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/pppLight -o diff_result_before.json pppLight`
  - before: `36.58621%`
- `tools/objdiff-cli diff -p . -u main/pppLight -o diff_result_after.json pppLight`
  - after: `37.21003%`
- Net improvement: `+0.62382%`

## Plausibility rationale
- The debug-flag early return aligns with observed global-gated behavior in similar runtime update routines.
- The pointer-chain fix matches existing constructor access style in the same unit (`pppLightCon`, `pppLightCon3`), indicating a likely original data path.
- Changes improve generated assembly alignment without introducing unnatural source patterns.

## Technical details
- Updated externs in `src/pppLight.cpp` to reference `lbl_8032ED70`.
- Inserted immediate return branch at function top.
- Replaced triple-dereference temporary chain with a direct two-step load to compute `r30` base.
- Rebuilt with `ninja`; match re-checked using objdiff v3.6.1 oneshot JSON output.
