### PR TITLE
pppYmLookOn: align control layout and work offsets

### DIFF
--- a/include/ffcc/pppYmLookOn.h
+++ b/include/ffcc/pppYmLookOn.h
@@ -6,14 +6,16 @@ extern "C" {
 #endif
 
 struct pppYmLookOn {
-    int field0_0x0[2]; // Placeholder structure based on Ghidra access patterns
+    int field0_0x0[2];
 };
 
 struct UnkB {
-    int m_dataValIndex;
+    int m_graphId;
+    float m_dataValIndex;
 };
 
 struct UnkC {
+    unsigned char pad[0x0C];
     int* m_serializedDataOffsets;
 };
 

--- a/src/pppYmLookOn.cpp
+++ b/src/pppYmLookOn.cpp
@@ -21,8 +21,8 @@ void pppSetFpMatrix__FP9_pppMngSt(struct _pppMngSt*);
  */
 void pppConstructYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkC* param_2)
 {
-    int dataOffset = **(int**)param_2;
-    *(int*)((char*)pppYmLookOn + dataOffset + 8) = 0;
+    int dataOffset = *param_2->m_serializedDataOffsets;
+    *(int*)((char*)pppYmLookOn + dataOffset + 0x80) = 0;
 }
 
 /*
@@ -53,10 +53,10 @@ void pppFrameYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkB* param_2, str
 
     owner = *(u8**)((u8*)pppMngStPtr + 0xdc);
     dataOffset = *param_3->m_serializedDataOffsets;
-    if ((owner != nullptr) || (*(int*)((u8*)(&pppYmLookOn->field0_0x0[2]) + dataOffset) != 0)) {
-        *(u8**)((u8*)(&pppYmLookOn->field0_0x0[2]) + dataOffset) = owner;
+    if ((owner != nullptr) || (*(int*)((u8*)pppYmLookOn + dataOffset + 0x80) != 0)) {
+        *(u8**)((u8*)pppYmLookOn + dataOffset + 0x80) = owner;
         if (owner == nullptr) {
-            owner = *(u8**)((u8*)(&pppYmLookOn->field0_0x0[2]) + dataOffset);
+            owner = *(u8**)((u8*)pppYmLookOn + dataOffset + 0x80);
         }
 
         local_4c.x = *(f32*)(owner + 0x15c);


### PR DESCRIPTION
## Summary
- Corrected `pppYmLookOn` control/offset metadata layout to match PPP convention:
  - `UnkB` now models `m_graphId` + `m_dataValIndex` (float at +0x4)
  - `UnkC::m_serializedDataOffsets` moved to +0x0C (with leading pad)
- Updated look-on work data accesses to use the PPP object work base at `+0x80`.
- Replaced the construct-time raw double-indirection cast with typed serialized offset access.

## Functions Improved
- Unit: `main/pppYmLookOn`
- `pppConstructYmLookOn` is now recognized as matched in the unit report.

## Match Evidence
- Selector baseline (before edits): `main/pppYmLookOn` reported `Functions: 0/2 (0.0%)`.
- After this change (`ninja` report):
  - `matched_functions`: `1/2` (50.0%)
  - `matched_code`: `24/500` (4.8%)
  - `fuzzy_match_percent`: `86.864`
- `pppFrameYmLookOn` remains at `78.117645%` by objdiff (no regression).

## Plausibility Rationale
- PPP modules in this repo consistently treat serialized offset tables as located at `+0x0C` in control structs and apply object work offsets from `+0x80`.
- This patch removes ad-hoc pointer casting and aligns `pppYmLookOn` with that established source pattern, improving ABI/layout plausibility rather than adding compiler-coaxing constructs.

## Technical Notes
- Build verified with `ninja`.
- Objdiff checks run for `pppFrameYmLookOn` and `pppConstructYmLookOn`.
