### PR TITLE
exi: improve EXIIntrruptHandler match in EXIBios

### DIFF
--- a/src/exi/EXIBios.c
+++ b/src/exi/EXIBios.c
@@ -537,20 +537,17 @@ int EXIDeselect(s32 chan) {
 
 static void EXIIntrruptHandler(__OSInterrupt interrupt, OSContext* context) {
     s32 chan;
-    EXICallback callback;
+    OSContext exceptionContext;
 
     chan = ((s16)interrupt - 9) / 3;
 
     ASSERTLINE(1071, 0 <= chan && chan < MAX_CHAN);
     REG(chan, 0) = (REG(chan, 0) & 0x7F5) | 2;
 
-    callback = Ecb[chan].exiCallback;
-    if (callback) {
-        OSContext exceptionContext;
-
+    if (Ecb[chan].exiCallback) {
         OSClearContext(&exceptionContext);
         OSSetCurrentContext(&exceptionContext);
-        callback(chan, context);
+        Ecb[chan].exiCallback(chan, context);
         OSClearContext(&exceptionContext);
         OSSetCurrentContext(context);
     }


### PR DESCRIPTION
## Summary
- Refactored `EXIIntrruptHandler` in `src/exi/EXIBios.c` to use direct callback access from `Ecb[chan]` instead of storing an extra temporary callback variable.
- Kept behavior identical: clear/set temporary OS context around callback invocation.

## Functions improved
- Unit: `main/exi/EXIBios`
- Function: `EXIIntrruptHandler` (PAL size ~200b)

## Match evidence
- `EXIIntrruptHandler`: **37.32% -> 42.22%** (`tools/objdiff-cli diff -p . -u main/exi/EXIBios -o - EXIIntrruptHandler`)
- Unit `.text` (`EXIBios.o`): **68.44834% -> 68.596375%**
- `TCIntrruptHandler` and `EXTIntrruptHandler` remained unchanged in score.

## Plausibility rationale
- The change removes an unnecessary local temporary and uses a direct callback read/call pattern that is idiomatic for SDK interrupt handlers.
- Control flow and side effects are unchanged (same interrupt clear, context swap, callback invocation, and context restore semantics).

## Technical details
- The previous version introduced extra register/stack pressure by copying `Ecb[chan].exiCallback` into a local before branching.
- Using direct callback access produced better prologue/register allocation alignment in objdiff while preserving readable, plausible source.
