### PR TITLE
math: implement CrossCheckSphereVector and CrossCheckEllipseCapsule

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -41,7 +41,7 @@ public:
     void MTX44MultVec4(float(*)[4], Vec*, Vec4d*);
     void MTX44MultVec4(float(*)[4], Vec4d*, Vec4d*);
     void MTXGetScale(float(*)[4], Vec*);
-    void CrossCheckSphereVector(Vec*, float*, Vec*, Vec*, Vec*, float);
+    int CrossCheckSphereVector(Vec*, float*, Vec*, Vec*, Vec*, float);
     void CrossCheckEllipseCapsule(Vec*, float*, Vec*, Vec*, float, Vec*, float, float);
     void CalcSpline(Vec*, Vec*, Vec*, Vec*, Vec*, float, float, float, float, float);
     void MakeSpline1Dtable(int, float*, float*, float*);


### PR DESCRIPTION
## Summary
- Implemented `CMath::CrossCheckSphereVector` and `CMath::CrossCheckEllipseCapsule` in `src/math.cpp` based on PAL decomp behavior.
- Updated `CMath::CrossCheckSphereVector` declaration in `include/ffcc/math.h` to return `int` (success flag), matching observed control-flow behavior.
- Added PAL address/size metadata blocks for both functions.

## Functions improved
- Unit: `main/math`
- `CrossCheckSphereVector__5CMathFP3VecPfP3VecP3VecP3Vecf`
- `CrossCheckEllipseCapsule__5CMathFP3VecPfP3VecP3VecfP3Vecff`

## Match evidence
- `CrossCheckSphereVector`: ~0.5% -> 65.2228% (`objdiff-cli`)
- `CrossCheckEllipseCapsule`: ~0.7% -> 50.110294% (`objdiff-cli`)
- Built with `ninja` successfully after changes.

## Plausibility rationale
- Changes replace TODO stubs with straightforward geometric intersection/math code and vector operations already idiomatic in this codebase (`PSVEC*`, `Mtx44` usage).
- The implementation follows decompiled control flow and data transforms rather than contrived compiler-coaxing patterns.

## Technical details
- Sphere/vector path now computes relative vector, projected distance, discriminant, and optional hit outputs (`outT`, `outPos`) with early-out failure checks.
- Ellipse/capsule path now builds cubic coefficients and control matrix, then multiplies via `MTX44MultVec4` to emit output coefficients.
- All changes are localized to `math` headers/source with no unrelated file edits.
