### PR TITLE
texanim: implement CTexAnimSet constructor

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -29,13 +29,28 @@ public:
 
 extern "C" void __dl__FPv(void*);
 extern "C" void __dla__FPv(void*);
+extern "C" void __ct__4CRefFv(void*);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
+extern "C" void* PTR_PTR_s_CTexAnimSet_801e9c6c;
+extern "C" float FLOAT_8032fb38;
 
 extern CMemory Memory;
 extern CSystem System;
 
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
 static char s_ptrarray_grow_error[] = "CPtrArray grow error";
+
+namespace {
+static inline unsigned char* Ptr(void* p, unsigned int offset)
+{
+    return reinterpret_cast<unsigned char*>(p) + offset;
+}
+
+static inline float& F32At(void* p, unsigned int offset)
+{
+    return *reinterpret_cast<float*>(Ptr(p, offset));
+}
+}
 
 /*
  * --INFO--
@@ -462,9 +477,27 @@ CTexAnim* CPtrArray<CTexAnim*>::GetAt(unsigned long index)
 {
     return m_items[index];
 }
+/*
+ * --INFO--
+ * PAL Address: 0x80044a9c
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 CTexAnimSet::CTexAnimSet()
 {
-	// TODO
+    __ct__4CRefFv(this);
+    *reinterpret_cast<void**>(this) = &PTR_PTR_s_CTexAnimSet_801e9c6c;
+    CPtrArray<CTexAnim*>* const arr = reinterpret_cast<CPtrArray<CTexAnim*>*>(Ptr(this, 8));
+    arr->m_size = 0;
+    arr->m_numItems = 0;
+    arr->m_defaultSize = 0x10;
+    arr->m_items = 0;
+    arr->m_stage = 0;
+    arr->m_growCapacity = 1;
+    F32At(this, 0x24) = FLOAT_8032fb38;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CTexAnimSet::CTexAnimSet()` in `src/texanim.cpp` using a source-plausible CRef/CPtrArray initialization sequence.
- Added PAL function metadata block for the constructor (`0x80044a9c`, `76b`).
- Kept destructor and other methods untouched to avoid regressions.

## Functions improved
- Unit: `main/texanim`
- Symbol: `__ct__11CTexAnimSetFv` (`CTexAnimSet::CTexAnimSet()`)

## Match evidence
- `__ct__11CTexAnimSetFv` match: **5.263158% -> 37.63158%**
- Unit `.text` match (objdiff run scoped to this symbol): **35.851013% -> 36.330734%**
- Build result: `ninja` passes.

## Plausibility rationale
- The new constructor follows the same patterns seen across existing decomp code:
  - explicit `CRef` base construction
  - explicit vtable assignment
  - deterministic member initialization with standard default values (`size=0`, `defaultSize=0x10`, `growCapacity=1`)
  - default frame value init to known float constant
- No contrived temporaries or compiler-coax control flow was introduced.

## Technical details
- Implemented initialization with byte-offset access helpers already common in this codebase style.
- Verified improvement with `build/tools/objdiff-cli diff -p . -u main/texanim -o - __ct__11CTexAnimSetFv`.
- Avoided extending scope into destructor or parsing methods after confirming those changes regressed match in this pass.
