### PR TITLE
main/pppKeDMat: improve pppKeDMatDraw match via offset arithmetic shaping

### DIFF
--- a/src/pppKeDMat.cpp
+++ b/src/pppKeDMat.cpp
@@ -13,10 +13,11 @@
  */
 void pppKeDMatDraw(_pppPObject* pObject, void*, _pppCtrlTable* ctrlTable)
 {
-    unsigned int targetOffset = *(unsigned int*)(*(char**)((char*)ctrlTable + 0xC) + 4) + 0x80;
-    pppFMATRIX* targetMatrix = (pppFMATRIX*)((char*)pObject + targetOffset);
-    pppFMATRIX* resultMatrix = (pppFMATRIX*)((char*)pObject + 0x40);
+    int targetOffset = *(int*)(*(char**)((char*)ctrlTable + 0xC) + 4);
+    char* object = (char*)pObject;
+    pppFMATRIX* resultMatrix = (pppFMATRIX*)(object + 0x40);
+    pppFMATRIX* targetMatrix = (pppFMATRIX*)(object + targetOffset + 0x80);
 
-    pppMulMatrix(*resultMatrix, *(pppFMATRIX*)&ppvWorldMatrix, *(pppFMATRIX*)((char*)pObject + 0x10));
+    pppMulMatrix(*resultMatrix, *(pppFMATRIX*)&ppvWorldMatrix, *(pppFMATRIX*)(object + 0x10));
     pppCopyMatrix(*targetMatrix, *resultMatrix);
 }


### PR DESCRIPTION
## Summary
- Refined `pppKeDMatDraw` pointer/offset arithmetic in `src/pppKeDMat.cpp` without changing behavior.
- Switched `targetOffset` to signed `int` and staged object-base pointer arithmetic (`char* object`) before matrix address derivation.
- Kept function semantics identical: multiply local matrix by `ppvWorldMatrix`, then copy to the target serialized matrix slot.

## Functions improved
- Unit: `main/pppKeDMat`
- Symbol: `pppKeDMatDraw`

## Match evidence
- `pppKeDMatDraw`: **84.926315% -> 87.55789%** (`+2.631575`)
- Build verification: `ninja` succeeds and regenerates report/progress.
- Objdiff oneshot command used:
  - `tools/objdiff-cli diff -p . -u main/pppKeDMat -o - pppKeDMatDraw`

## Assembly analysis notes
- Diff kind counts moved in the right direction for structural alignment:
  - `DIFF_REPLACE`: 10 -> 6
  - `DIFF_INSERT`: 12 -> 10
  - `DIFF_DELETE`: 8 -> 6
- Some arg mismatches remain (`DIFF_ARG_MISMATCH`), but the reduced replace/insert/delete noise indicates better control-flow/register shaping around matrix setup and copy.

## Plausibility rationale
- Change is source-plausible and idiomatic C/C++ cleanup, not compiler coaxing:
  - explicit signed offset for serialized data access
  - explicit object-base pointer used consistently for derived pointers
  - no contrived temporaries, no unnatural ordering, no magic-behavior edits
- The function still reads naturally as original game code: compute work matrix locations, multiply world/local matrices, copy result to destination.
