### PR TITLE
mapanim: implement CMapAnimKeyDt destructor

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -378,12 +378,39 @@ CMapAnimKeyDt::CMapAnimKeyDt()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004ad98
+ * PAL Size: 148b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CMapAnimKeyDt::~CMapAnimKeyDt()
 {
-	// TODO
+    struct CMapAnimKeyDtData
+    {
+        unsigned int positionCount;
+        CMapAnimNodeTrackKey* position;
+        unsigned int rotationCount;
+        CMapAnimNodeTrackKey* rotation;
+        unsigned int scaleCount;
+        CMapAnimNodeTrackKey* scale;
+    };
+
+    CMapAnimKeyDtData* keyData = reinterpret_cast<CMapAnimKeyDtData*>(this);
+
+    if (keyData->position != 0) {
+        __dla__FPv(keyData->position);
+        keyData->position = 0;
+    }
+    if (keyData->rotation != 0) {
+        __dla__FPv(keyData->rotation);
+        keyData->rotation = 0;
+    }
+    if (keyData->scale != 0) {
+        __dla__FPv(keyData->scale);
+        keyData->scale = 0;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMapAnimKeyDt::~CMapAnimKeyDt` in `src/mapanim.cpp` using the existing key-track layout used by `ReadOtmAnim`, freeing each allocated track buffer (`position`, `rotation`, `scale`) and nulling pointers.

## Functions improved
- Unit: `main/mapanim`
- Symbol: `__dt__13CMapAnimKeyDtFv`

## Match evidence
Objdiff (unit `main/mapanim`) before/after:
- `__dt__13CMapAnimKeyDtFv`: **39.837837% -> 100.0%**
- `__dt__8CMapAnimFv`: 30.708334% -> 30.708334% (no regression)
- `ReadOtmAnim__8CMapAnimFR10CChunkFile`: 15.4175825% -> 15.4175825% (no regression)

Build progress also increased matched functions:
- `1452 / 4733` -> `1453 / 4733`

## Plausibility rationale
This change models natural source behavior for an owning key-data container: deallocate owned arrays in destructor and clear the members. It aligns with how the buffers are allocated in `ReadOtmAnim` and avoids compiler-coaxing patterns.

## Technical notes
- Uses the same 0x18-byte key-data layout already implied by `ReadOtmAnim` (count/pointer pairs for position/rotation/scale).
- Keeps scope small to a single destructor to isolate and verify assembly impact cleanly.
