### PR TITLE
map: decompile missing CPtrArray specializations in main/map

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -181,6 +181,28 @@ void CPtrArray<CMapLightHolder*>::RemoveAll()
  * Address:	TODO
  * Size:	TODO
  */
+template <>
+void CPtrArray<CMapLightHolder*>::SetStage(CMemory::CStage* stage)
+{
+    *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(this) + 0x14) = stage;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+template <>
+int CPtrArray<CMapAnimRun*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
 int CMapKeyFrame::Get(int& key0, int& key1, float& blend)
 {
     const unsigned char mode = *reinterpret_cast<unsigned char*>(Ptr(this, 0));


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray` specializations in `src/map.cpp` for:
  - `CPtrArray<CMapLightHolder*>::SetStage(CMemory::CStage*)`
  - `CPtrArray<CMapAnimRun*>::GetSize()`
- Replaced TODO/implicit-missing state with concrete implementations so `map.o` emits the expected symbols.

## Functions improved
- `SetStage__29CPtrArray<P15CMapLightHolder>FPQ27CMemory6CStage`
  - Before: target existed but current symbol was effectively missing from this unit (reported as 0% target in selector)
  - After: **100.0%** (8b)
- `GetSize__25CPtrArray<P11CMapAnimRun>Fv`
  - Before: target existed but current symbol was effectively missing from this unit (reported as 0% target in selector)
  - After: **100.0%** (8b)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/map -o - 'SetStage__29CPtrArray<P15CMapLightHolder>FPQ27CMemory6CStage'`
  - Final result: 100.0%
- `build/tools/objdiff-cli diff -p . -u main/map -o - 'GetSize__25CPtrArray<P11CMapAnimRun>Fv'`
  - Final result: 100.0%
- `ninja` progress moved game code matched bytes from `197992` to `198000`.
- `main/map` report now shows `matched_functions: 10/94`.

## Plausibility rationale
- Both functions are canonical `CPtrArray` member operations used across the codebase (`SetStage` stores stage pointer, `GetSize` returns item count).
- Implementations are minimal and source-plausible for FFCC-era container helpers, with no compiler-coaxing temporaries or artificial control flow.

## Technical notes
- The `SetStage` specialization uses the field offset that matches the target unit layout for this instantiation, which was required to reach exact assembly parity.
- Build succeeds (`ninja`) after the change.
