### PR TITLE
map: add missing CPtrArray specializations in map.cpp

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -178,6 +178,36 @@ void CPtrArray<CMapLightHolder*>::RemoveAll()
 
 /*
  * --INFO--
+ * PAL Address: 0x80033de0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapLightHolder*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80033ed8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimRun*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray` specializations in `src/map.cpp` for:
  - `CPtrArray<CMapLightHolder*>::SetStage(CMemory::CStage*)`
  - `CPtrArray<CMapAnimRun*>::GetSize()`
- Both are tiny, source-plausible methods consistent with existing explicit specializations in the same file.

## Functions Improved
- `SetStage__29CPtrArray<P15CMapLightHolder>FPQ27CMemory6CStage`
- `GetSize__25CPtrArray<P11CMapAnimRun>Fv`

## Match Evidence
- Prior state (target selector + prior report): both functions were effectively unmatched (`0%`/`null`).
- New report (`build/GCCP01/report.json`):
  - `SetStage__29CPtrArray<P15CMapLightHolder>FPQ27CMemory6CStage`: `99.5%`
  - `GetSize__25CPtrArray<P11CMapAnimRun>Fv`: `100.0%`
- Project progress moved from `1453/4733` to `1454/4733` matched functions, and matched code from `197964` to `197972` bytes.

## Plausibility Rationale
- These are straightforward member operations (`m_stage = stage;` and `return m_numItems;`) and match the established style and behavior of adjacent `CPtrArray` specializations in `map.cpp`.
- No contrived control flow or compiler-coaxing constructs were introduced.

## Technical Notes
- Added PAL address/size `--INFO--` blocks from the Ghidra export for both functions.
- Verified with `ninja` and report regeneration in PAL (`GCCP01`).