### PR TITLE
RedSound: improve SetWaveData match by disabling inlining

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -682,6 +682,7 @@ void CRedSound::StreamPause(int streamID, int pause)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 unsigned int CRedSound::SetWaveData(int waveID, void* waveData, int waveSize)
 {
 	unsigned int id = GetAutoID();
@@ -691,6 +692,7 @@ unsigned int CRedSound::SetWaveData(int waveID, void* waveData, int waveSize)
 	}
 	return id;
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Wrapped `CRedSound::SetWaveData(int, void*, int)` with Metrowerks `#pragma dont_inline` guards.
- Kept function logic unchanged; this targets codegen shape only for the selected symbol.

## Functions improved
- Unit: `main/RedSound/RedSound`
- Symbol: `SetWaveData__9CRedSoundFiPvi`

## Match evidence
- `SetWaveData__9CRedSoundFiPvi`: **0.0% -> 63.677418%** fuzzy match (`build/GCCP01/report.json`)
- `main/RedSound/RedSound` unit fuzzy match: **31.201271% -> 33.292374%**
- Rebuild passes: `ninja` succeeds and regenerates `build/GCCP01/report.json`.

## Plausibility rationale
- This codebase already uses `#pragma dont_inline` in multiple files to preserve original Metrowerks codegen behavior.
- The change preserves source behavior and avoids contrived control-flow rewrites.
- Applying the pragma only around this function is a targeted, plausible original-source style adjustment for a near-match scenario.

## Technical details
- The previous compiler output was aggressively inlining helper calls in this function.
- Disabling inlining at function scope produced a significantly closer instruction shape for this symbol while keeping call-level logic intact.
