### PR TITLE
cflat_r2system: add missing group/mask wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -475,6 +475,48 @@ extern "C" void SetMapShadeColor__9CCharaPcsFi6CColor(void* charaPcs, int shadeI
 
 /*
  * --INFO--
+ * PAL Address: 0x800B93C0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetNoFreeMergeMask__9CCharaPcsFi(void* charaPcs, int mask)
+{
+    *(int*)((char*)charaPcs + 0x718) = mask;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B93C8
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void ResetDefaultGroup__7CMemoryFv(void* memory)
+{
+    *(int*)((char*)memory + 0x779C) = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B93D4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetDefaultGroup__7CMemoryFi(void* memory, int group)
+{
+    *(int*)((char*)memory + 0x779C) = group;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added three missing PAL wrapper functions in `src/cflat_r2system.cpp` with version metadata blocks.
- Implemented direct field writes matching current decomp style and Ghidra-referenced offsets:
  - `SetNoFreeMergeMask__9CCharaPcsFi`
  - `ResetDefaultGroup__7CMemoryFv`
  - `SetDefaultGroup__7CMemoryFi`

## Functions improved
- Unit: `main/cflat_r2system`
- Symbols:
  - `SetNoFreeMergeMask__9CCharaPcsFi`: `-1` (missing) -> `100.0%`
  - `ResetDefaultGroup__7CMemoryFv`: `-1` (missing) -> `100.0%`
  - `SetDefaultGroup__7CMemoryFi`: `-1` (missing) -> `100.0%`

## Match evidence
- `ninja` progress changed from:
  - Code: `198368 / 1855300` -> `198396 / 1855300` (`+28` matched code bytes)
  - Functions: `1457 / 4733` -> `1460 / 4733` (`+3` matched functions)
- `tools/objdiff-cli v3.6.1` oneshot diff confirms each symbol now resolves at `100.0` match.

## Plausibility rationale
- These are tiny setter/resetter wrappers that map directly to existing object fields and naming in the run-time layer.
- The implementation style is consistent with nearby wrappers in the same file (extern C wrappers + offset-backed field access), avoiding compiler-coaxing patterns.

## Technical details
- Added explicit PAL info blocks for each function using the current decomp addresses/sizes.
- Confirmed target symbol behavior against Ghidra helper outputs for `0x800B93C0`, `0x800B93C8`, and `0x800B93D4`.
