### PR TITLE
pppBreathModel: match pppConstructBreathModel

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -217,26 +217,26 @@ extern "C" void pppRenderBreathModel(void)
  */
 extern "C" void pppConstructBreathModel(pppBreathModel* pppBreathModel, UnkC* param_2)
 {
-    Mtx* work = (Mtx*)((unsigned char*)pppBreathModel + 0x80 + *param_2->m_serializedDataOffsets);
-    unsigned char* state = (unsigned char*)work;
+    unsigned char* state = (unsigned char*)pppBreathModel + 0x80 + *param_2->m_serializedDataOffsets;
     float fVar1;
 
-    PSMTXIdentity(*work);
+    PSMTXIdentity(*(Mtx*)state);
     fVar1 = lbl_80330F70;
 
-    work[1][2][0] = lbl_80330F70;
-    work[1][1][3] = fVar1;
-    work[1][1][2] = fVar1;
-    work[1][0][0] = fVar1;
-    work[1][0][1] = fVar1;
-    work[1][0][2] = fVar1;
-    work[1][0][3] = fVar1;
-    work[1][1][0] = fVar1;
+    *(float*)(state + 0x50) = lbl_80330F70;
+    *(float*)(state + 0x4C) = fVar1;
+    *(float*)(state + 0x48) = fVar1;
 
-    *(short*)(state + 0x46) = 10000;
-    *(short*)(state + 0x4A) = 0;
-    *(short*)(state + 0x4E) = 0;
-    *(unsigned char*)(state + 0x50) = 0;
+    *(int*)(state + 0x30) = 0;
+    *(int*)(state + 0x34) = 0;
+    *(int*)(state + 0x38) = 0;
+    *(int*)(state + 0x3C) = 0;
+    *(int*)(state + 0x40) = 0;
+
+    *(short*)(state + 0x44) = 10000;
+    *(short*)(state + 0x54) = 0;
+    *(short*)(state + 0x56) = 0;
+    *(unsigned char*)(state + 0x58) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refined `pppConstructBreathModel` initialization in `src/pppBreathModel.cpp` to use explicit field-offset initialization that matches the object layout used by this unit.
- Kept scope intentionally narrow: one function, no behavior expansion, no cleanup-only churn.

## Functions improved
- Unit: `main/pppBreathModel`
- Function: `pppConstructBreathModel` (PAL `0x800db18c`, size `120b`)

## Match evidence
- `pppConstructBreathModel`: **89.13333% -> 100.0%** (`tools/objdiff-cli diff -p . -u main/pppBreathModel -o - pppConstructBreathModel`)
- Build/report progress moved from `1457/4733` to `1458/4733` matched code functions in this checkout after the change.

## Plausibility rationale
- The update aligns with plausible original source intent for a constructor path: initialize matrix state, clear pointer-like slots, and set small control/lifetime fields.
- This is a semantic/layout correction rather than compiler-coaxing. The resulting code remains straightforward and consistent with neighboring offset-based initialization style in this file.

## Technical details
- Converted mixed matrix/index writes into explicit initialization at the expected state offsets (`0x30..0x40`, `0x44`, `0x48..0x50`, `0x54..0x58`).
- Preserved existing constants (`lbl_80330F70`, `10000`) while matching store placement and field usage reflected by objdiff.
