### PR TITLE
mapanim: improve CMapAnimRun::Calc matching

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -626,35 +626,23 @@ void CMapAnim::Calc(long frame)
  */
 void CMapAnimRun::Calc(long frame)
 {
-    struct CMapAnimRunData
-    {
-        int currentFrame;
-        int startFrame;
-        int endFrame;
-        int triggerFrame;
-        unsigned char loop;
-        unsigned char _pad11;
-        unsigned short mapAnimIndex;
-    };
+    int* run = reinterpret_cast<int*>(this);
 
-    CMapAnimRunData* run = reinterpret_cast<CMapAnimRunData*>(this);
-    CPtrArray<CMapAnim*>* mapAnims = reinterpret_cast<CPtrArray<CMapAnim*>*>(MapMng + 0x213FC);
-
-    if (run->currentFrame < 0) {
-        if (run->triggerFrame != frame) {
+    if (run[0] < 0) {
+        if (run[3] != frame) {
             return;
         }
-        run->currentFrame = run->startFrame;
+        run[0] = run[1];
     }
 
-    mapAnims->m_items[run->mapAnimIndex]->Calc(run->currentFrame);
-    run->currentFrame++;
+    reinterpret_cast<CMapAnim**>(MapMng + 0x2140C)[reinterpret_cast<unsigned short*>(this)[9]]->Calc(run[0]);
+    run[0] = run[0] + 1;
 
-    if (run->endFrame < run->currentFrame) {
-        if (run->loop == 0) {
-            run->currentFrame = -1;
+    if (run[2] < run[0]) {
+        if (reinterpret_cast<unsigned char*>(this)[0x10] == 0) {
+            run[0] = -1;
         } else {
-            run->currentFrame = 0;
+            run[0] = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
Adjusted `CMapAnimRun::Calc(long)` in `src/mapanim.cpp` to follow the target data access pattern more closely:
- switched to explicit field-index access on the run-state layout
- used direct map animation table indexing from `MapMng`
- preserved original behavior for trigger/start/loop frame transitions

## Functions improved
- `main/mapanim` / `Calc__11CMapAnimRunFl` (PAL `0x8004A4B8`, 168 bytes)

## Match evidence
- `Calc__11CMapAnimRunFl`: **43.642857% -> 51.857143%**
- differing instructions: **34 -> 30**
- validated with:
  - `ninja`
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/mapanim -o - Calc__11CMapAnimRunFl`

## Plausibility rationale
This is a first-pass decomp alignment change that keeps gameplay logic intact while matching the observed memory-layout driven access pattern in the original binary (run-state fields and map animation table indexing).

## Technical notes
The main gain came from removing extra abstraction-induced codegen in `Calc` and aligning branch/dataflow shape with target assembly around:
- negative frame gating + trigger comparison
- direct `mapAnimIndex` lookup and `CMapAnim::Calc` dispatch
- end-frame rollover to `-1` (non-loop) or `0` (loop)
