### PR TITLE
map: decompile SetMapObjMime

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -897,12 +897,17 @@ void CMapMng::SetMapAnimID(int, int, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002f6d4
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::SetMapObjMime(int, int, int, int)
+void CMapMng::SetMapObjMime(int mapObjIndex, int mode, int target, int type)
 {
-	// TODO
+    CMapObj* mapObj = reinterpret_cast<CMapObj*>(reinterpret_cast<unsigned char*>(this) + (mapObjIndex * 0xF0) + 0x954);
+    mapObj->SetMime(mode, target, type);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapMng::SetMapObjMime(int, int, int, int)` in `src/map.cpp` as a direct forwarder to `CMapObj::SetMime` on `mapObjArr + mapObjIndex`.
- Added PAL function metadata for the implemented symbol.

## Functions Improved
- Unit: `main/map`
- Symbol: `SetMapObjMime__7CMapMngFiiii`
- Size: `60b`

## Match Evidence
- Before: `6.6666665%` (from unit symbol report)
- After: `100.0%` (`build/tools/objdiff-cli diff -p . -u main/map -o - 'SetMapObjMime__7CMapMngFiiii'`)
- Unit progress impact: `+60` matched code bytes in `ninja` progress output.

## Plausibility Rationale
- The new code is a minimal, source-plausible method body: resolve the indexed map object and call its existing method.
- No compiler-coaxing constructs were introduced; the code follows existing pointer/offset conventions already used in `src/map.cpp`.

## Technical Details
- Used the Ghidra reference for `SetMapObjMime__7CMapMngFiiii` (PAL `0x8002f6d4`, size `60b`) only as a behavioral guide.
- Kept parameter and call structure aligned with existing class declarations (`CMapObj::SetMime(int, int, int)`).
