### PR TITLE
astar: improve drawAStar match via RNG-based group colors

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/charaobj.h"
 #include "ffcc/color.h"
 #include "ffcc/graphic.h"
+#include "ffcc/math.h"
 #include "ffcc/pad.h"
 #include "ffcc/partyobj.h"
 #include "ffcc/p_dbgmenu.h"
@@ -23,6 +24,7 @@ static const float kDrawAStarSphereRadius = 5.0f;
 extern Mtx gFlatPosMtx;
 extern int DAT_8032ed70;
 extern unsigned char lbl_8032EC90[];
+extern CMath Math;
 
 CAStar AStar;
 
@@ -516,9 +518,9 @@ void CAStar::drawAStar()
 	{
 		for (int group = 0; group < 64; ++group)
 		{
-			unsigned char r = static_cast<unsigned char>((group * 41 + System.m_frameCounter) & 0xFF);
-			unsigned char g = static_cast<unsigned char>((group * 71 + (System.m_frameCounter >> 1)) & 0xFF);
-			unsigned char b = static_cast<unsigned char>((group * 17 + (System.m_frameCounter >> 2)) & 0xFF);
+			unsigned char b = static_cast<unsigned char>(Math.Rand(0xff));
+			unsigned char g = static_cast<unsigned char>(Math.Rand(0xff));
+			unsigned char r = static_cast<unsigned char>(Math.Rand(0xff));
 			CColor color(r, g, b, 0xFF);
 			MapMng.SetIdGrpColor(group, 0, color.color);
 		}


### PR DESCRIPTION
## Summary
- Updated `CAStar::drawAStar` in `src/astar.cpp` to generate debug group colors using `Math.Rand(0xff)` values instead of deterministic arithmetic.
- Added the missing `ffcc/math.h` include and `extern CMath Math;` declaration used by this function.

## Functions improved
- Unit: `main/astar`
- Symbol: `drawAStar__6CAStarFv`

## Match evidence
- `drawAStar__6CAStarFv`: **57.56% -> 63.622856%** (`build/tools/objdiff-cli diff -p . -u main/astar -o - drawAStar__6CAStarFv`)
- Spot-checks for nearby symbols in the same unit showed no regression:
  - `calcPolygonGroup__6CAStarFP3Veci`: 42.7094% (unchanged)
  - `calcSpecialPolygonGroup__6CAStarFP3Vec`: 51.301586% (unchanged)

## Plausibility rationale
- Ghidra decomp for `drawAStar` shows per-group debug colors built from repeated random byte generation before `SetIdGrpColor`, not a deterministic formula.
- Using `Math.Rand(0xff)` is consistent with existing codebase patterns and represents plausible original source behavior for debug visualization.

## Technical details
- The revised color block calls RNG three times per group and feeds values into `CColor(r, g, b, 0xFF)`, matching the observed decomp structure where random values are generated each refresh cycle.
- Change is localized to the color generation block in `drawAStar`; render/control flow logic is otherwise unchanged.
