### PR TITLE
Improve match for pppCalcFrameShape in pppShape

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -320,20 +320,18 @@ void pppGetShapeUV(long* animData, short frameIndex, Vec2d& minUv, Vec2d& maxUv,
 void pppCalcFrameShape(long* animData, short& currentFrame, short& drawFrame, short& frameTime,
                        short deltaTime)
 {
-    drawFrame = currentFrame;
-    frameTime += deltaTime;
-
-    short duration = *(short*)((int)animData + currentFrame * 8 + 0x12);
-    if (frameTime < duration) {
+    short frame = currentFrame;
+    drawFrame = frame;
+    frameTime = frameTime + deltaTime;
+    frame = *(short*)((int)animData + frame * 8 + 0x12);
+    if (frameTime < frame) {
         return;
     }
-
-    frameTime -= duration;
-    currentFrame += 1;
+    frameTime = frameTime - frame;
+    currentFrame = currentFrame + 1;
     if (currentFrame < *(short*)((int)animData + 6)) {
         return;
     }
-
     currentFrame = 0;
     frameTime = 0;
 }


### PR DESCRIPTION
## Summary
- Refined `pppCalcFrameShape__FPlRsRsRss` control flow in `src/pppShape.cpp` to match original codegen shape more closely.
- Replaced the duration temporary with a frame-local sequence and explicit arithmetic assignments, preserving behavior.

## Functions improved
- Unit: `main/pppShape`
- Symbol: `pppCalcFrameShape__FPlRsRsRss`
- Size: `100b`
- Before: `57.36%`
- After: `92.12%`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppShape -o -`
- Validation process:
  - Built once with `origin/main` version of `src/pppShape.cpp` and captured baseline JSON.
  - Restored edited file, rebuilt, and captured after JSON.
  - Observed function match increase from `57.36` to `92.12`.

## Plausibility rationale
- The change keeps identical gameplay semantics and data access pattern.
- New structure follows straightforward frame-step logic typical of original handwritten source, rather than contrived compiler-only tricks.

## Technical details
- Updated `pppCalcFrameShape` to:
  - snapshot current frame index once,
  - apply delta to frame timer,
  - fetch frame duration using the snapshotted index,
  - subtract elapsed duration and advance frame with wrap handling.
