### PR TITLE
pppSRandDownHCV: improve function match to 97.62%

### DIFF
--- a/src/pppSRandDownHCV.cpp
+++ b/src/pppSRandDownHCV.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern s16 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
@@ -29,32 +29,41 @@ void pppSRandDownHCV(void* param1, void* param2, void* param3)
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);
 
-		int flag = *((u8*)param2 + 0x10);
-		float value;
-
-		value = -RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value - RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = -RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value - RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[0] = value;
 		}
-		target[0] = value;
 
-		value = -RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value - RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = -RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value - RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[1] = value;
 		}
-		target[1] = value;
 
-		value = -RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value - RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = -RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value - RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[2] = value;
 		}
-		target[2] = value;
 
-		value = -RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value - RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = -RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value - RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[3] = value;
 		}
-		target[3] = value;
 	} else {
 		int** base_ptr = (int**)((char*)param3 + 0xc);
 		int offset = **base_ptr;


### PR DESCRIPTION
## Summary
- Updated `pppSRandDownHCV` in `src/pppSRandDownHCV.cpp` to better match original codegen while keeping behavior intact.
- Switched `math` declaration to `extern CMath math[]` and passed `math` directly to `RandF__5CMathFv`.
- Restructured the four per-channel random updates into scoped blocks with per-block `flag` loads, matching the repeated load/codegen pattern.

## Functions improved
- Unit: `main/pppSRandDownHCV`
- Symbol: `pppSRandDownHCV`
- Size: `656b`

## Match evidence
- Before: `86.310974%`
- After: `97.62195%`
- Delta: `+11.310976` points
- Verification command:
  - `tools/objdiff-cli diff -p . -u main/pppSRandDownHCV -o - pppSRandDownHCV`

## Plausibility rationale
- Changes are source-plausible and idiomatic for this codebase: type/signature alignment (`CMath` extern form) and explicit per-component update blocks.
- No artificial temporaries, no hardcoded assembly tricks, and no behavior-only compiler coercion patterns were introduced.

## Technical details
- Objdiff diffs dropped from many `DIFF_DELETE/DIFF_INSERT` events to near-clean output, leaving only a small number of argument/replacement mismatches.
- The largest gain came from matching the repeated per-component load/use structure in the random update section.
