### PR TITLE
map: specialize CMapAnimRun ptrarray helpers

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -200,6 +200,71 @@ int CPtrArray<CMapAnimRun*>::GetSize()
 
 /*
  * --INFO--
+ * PAL Address: 0x800340f0
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnimRun*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003413c
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimRun* CPtrArray<CMapAnimRun*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034170
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnimRun*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034a44
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimRun* CPtrArray<CMapAnimRun*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray<CMapAnimRun*>` specializations in `src/map.cpp` for:
  - `RemoveAll`
  - `operator[]`
  - `SetStage`
  - `GetAt`
- Kept implementations aligned with existing `CPtrArray` specializations already used in this codebase (same control flow/member access style as `CMapAnimNode*` and `CMapLightHolder*`).

## Functions improved
Unit: `main/map`
- `RemoveAll__25CPtrArray<P11CMapAnimRun>Fv`
- `__vc__25CPtrArray<P11CMapAnimRun>FUl`
- `SetStage__25CPtrArray<P11CMapAnimRun>FPQ27CMemory6CStage`
- `GetAt__25CPtrArray<P11CMapAnimRun>FUl`

## Match evidence
From `objdiff-cli report generate` / per-symbol diffing:
- `RemoveAll__25CPtrArray<P11CMapAnimRun>Fv`: `0.0%` -> `99.8421%`
- `__vc__25CPtrArray<P11CMapAnimRun>FUl`: `0.0%` -> `100.0%`
- `SetStage__25CPtrArray<P11CMapAnimRun>FPQ27CMemory6CStage`: `0.0%` -> `99.5%`
- `GetAt__25CPtrArray<P11CMapAnimRun>FUl`: `0.0%` -> `99.75%`

Unit-level `main/map` fuzzy match:
- `9.64502` -> `10.2494955`

## Plausibility rationale
These are straightforward container helper methods and match the established source patterns in nearby files:
- `RemoveAll`: delete buffer and zero size/count.
- `operator[]`: delegate to `GetAt`.
- `SetStage`: assign memory stage pointer.
- `GetAt`: indexed access into pointer storage.

No compiler-coaxing patterns were introduced; the code remains idiomatic and consistent with existing FFCC decomp style.

## Technical details
- The `main/map` TU previously emitted weak/generic template forms for these `CPtrArray<CMapAnimRun*>` helpers, which remained unmatched.
- Providing explicit specializations in `src/map.cpp` stabilized codegen for these symbols and produced the observed assembly-level alignment improvements.
- `ninja` build passes after change.
