### PR TITLE
Improve __ieee754_acos match with inline reciprocal-sqrt refinement

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/e_acos.c
+++ b/src/MSL_C/PPCEABI/bare/H/e_acos.c
@@ -52,13 +52,27 @@ qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 	    z = 0.5*(one+x);
 	    p = z*(pS0+z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))));
 	    q = one+z*(qS1+z*(qS2+z*(qS3+z*qS4)));
-	    s = sqrt(z);
+	    {
+		double guess = __frsqrte(z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		s = z * guess;
+	    }
 	    r = p/q;
 	    w = r*s-pio2_lo;
 	    return pi - (s+w)*2.0;
 	} else {			/* x > 0.5 */
 	    z = 0.5*(one-x);
-	    s = sqrt(z);
+	    {
+		double guess = __frsqrte(z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		guess = 0.5 * guess * (3.0 - guess * guess * z);
+		s = z * guess;
+	    }
 	    df = s;
 	    __LO(df) = 0;
 	    c  = (z-df*df)/(s+df);


### PR DESCRIPTION
## Summary
- Updated `__ieee754_acos` in `src/MSL_C/PPCEABI/bare/H/e_acos.c` to replace both `sqrt(z)` paths with explicit `__frsqrte` + Newton-Raphson refinement steps.
- Kept the original polynomial/rational approximation and control-flow structure intact.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/e_acos`
- Symbol: `__ieee754_acos`

## Match evidence
- `__ieee754_acos` before: **36.9021%**
- `__ieee754_acos` after: **45.335663%**
- Net gain: **+8.433563 points**

Objdiff evidence:
- Removed `bl sqrt` call sites from this function (target uses inlined reciprocal-sqrt instruction flow).
- Instruction diff counts improved (notably fewer inserts/arg mismatches):
  - Before: `DIFF_ARG_MISMATCH=88`, `DIFF_INSERT=67`, `DIFF_DELETE=14`, `DIFF_REPLACE=3`, `DIFF_OP_MISMATCH=1`
  - After:  `DIFF_ARG_MISMATCH=77`, `DIFF_INSERT=49`, `DIFF_DELETE=17`, `DIFF_REPLACE=8`

## Plausibility rationale
- This is source-plausible for GC/Wii-era PowerPC math code: reciprocal-sqrt refinement is a standard implementation strategy and aligns with other codegen patterns in this repo/toolchain.
- The change targets numeric implementation shape instead of introducing artificial temporary-variable churn or non-idiomatic ordering purely to force a match.

## Technical details
- In both `x < -0.5` and `x > 0.5` branches, `sqrt(z)` was replaced by:
  1. `guess = __frsqrte(z)`
  2. Four Newton-Raphson refinement steps
  3. `s = z * guess`
- This aligns emitted code with expected frsqrte-based sequences for this platform/compiler combination.
