### PR TITLE
gx: improve GXSetScissor match in GXTransform

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -571,7 +571,8 @@ void GXSetZScaleOffset(f32 scale, f32 offset) {
 void GXSetScissor(u32 left, u32 top, u32 wd, u32 ht) {
     u32 topOrigin;
     u32 leftOrigin;
-    GXData* gx;
+    u32 bottom;
+    u32 right;
 
     CHECK_GXBEGIN(1048, "GXSetScissor");
     ASSERTMSGLINE(1049, left < 1706, "GXSetScissor: Left origin > 1708");
@@ -579,18 +580,19 @@ void GXSetScissor(u32 left, u32 top, u32 wd, u32 ht) {
     ASSERTMSGLINE(1051, left + wd < 1706, "GXSetScissor: right edge > 1708");
     ASSERTMSGLINE(1052, top + ht < 1706, "GXSetScissor: bottom edge > 1708");
 
-    gx = __GXData;
-    topOrigin = top + 0x156;
     leftOrigin = left + 0x156;
+    topOrigin = top + 0x156;
+    right = (leftOrigin + wd) - 1;
+    bottom = (topOrigin + ht) - 1;
 
-    gx->suScis0 = (gx->suScis0 & 0xFFFFF800) | topOrigin;
-    gx->suScis0 = (gx->suScis0 & 0xFF800FFF) | (leftOrigin << 12);
-    gx->suScis1 = (gx->suScis1 & 0xFFFFF800) | (topOrigin + ht - 1);
-    gx->suScis1 = (gx->suScis1 & 0xFF800FFF) | ((leftOrigin + wd - 1) << 12);
+    __GXData->suScis0 = (__GXData->suScis0 & 0xFFFFF800) | topOrigin;
+    __GXData->suScis0 = (__GXData->suScis0 & 0xFF800FFF) | (leftOrigin << 12);
+    __GXData->suScis1 = (__GXData->suScis1 & 0xFFFFF800) | bottom;
+    __GXData->suScis1 = (__GXData->suScis1 & 0xFF800FFF) | (right << 12);
 
-    GX_WRITE_RAS_REG(gx->suScis0);
-    GX_WRITE_RAS_REG(gx->suScis1);
-    gx->bpSentNot = 0;
+    GX_WRITE_RAS_REG(__GXData->suScis0);
+    GX_WRITE_RAS_REG(__GXData->suScis1);
+    __GXData->bpSentNot = 0;
 }
 
 void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht) {


### PR DESCRIPTION
## Summary
- Reworked `GXSetScissor` in `src/gx/GXTransform.c` to remove the local `GXData*` temporary and write directly through `__GXData`.
- Introduced explicit `right`/`bottom` temporaries and reordered scissor bounds calculations to align emitted instruction order with the target object.
- Kept behavior unchanged and retained existing assertion and register-write flow.

## Functions improved
- Unit: `main/gx/GXTransform`
- Symbol: `GXSetScissor`

## Match evidence
- `GXSetScissor`: **79.02778% -> 99.861115%** (`build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o -`)
- Residual mismatch is a relocation symbol-name difference at function start (`gx@sda21` vs `__GXData@sda21`), with instruction stream otherwise aligned.
- Project progress after build:
  - `All` code: `198652 -> 198796` matched bytes
  - `SDK Code`: `164604 -> 164748` matched bytes

## Plausibility rationale
- Change is source-plausible and idiomatic for GX SDK-style code: direct global state updates and straightforward intermediate bounds variables.
- No contrived control-flow tricks or artificial compiler coaxing were introduced.

## Technical details
- The previous variant encouraged different register allocation and operation sequencing.
- Using direct `__GXData` accesses and explicit bounds temporaries produced near-identical generated assembly for all arithmetic and BP writes in this function.
