### PR TITLE
pppParHitSphMat: improve match by aligning pointer and stack flow

### DIFF
--- a/src/pppParHitSphMat.cpp
+++ b/src/pppParHitSphMat.cpp
@@ -15,41 +15,49 @@ extern unsigned char CFlat[];
  */
 void pppParHitSphMat(void* param1, void* param2, void* param3)
 {
-    s32* offsets = *(s32**)((u8*)param3 + 0xC);
-    Vec local_a0;
-    Vec local_94;
     Vec local_88;
+    Vec local_94;
+    Vec local_a0;
     _GXColor local_7c;
     Mtx MStack_78;
     Mtx local_48;
+    u8* pppMngSt = lbl_8032ED50;
+    u8* data = (u8*)param1;
+    u8* step = (u8*)param2;
+    f32 hitLength;
+    f32 radius;
 
     local_88.x = 0.0f;
     local_88.y = 0.0f;
     local_88.z = 0.0f;
 
-    if (((u8*)param2)[0xC] != 0) {
-        Vec* src = (Vec*)((u8*)param1 + offsets[1] + 0x80);
-        PSMTXMultVec((MtxPtr)((u8*)lbl_8032ED50 + 0x78), src, &local_94);
-    } else {
-        local_94.x = *(f32*)((u8*)lbl_8032ED50 + 0x84);
-        local_94.y = *(f32*)((u8*)lbl_8032ED50 + 0x94);
-        local_94.z = *(f32*)((u8*)lbl_8032ED50 + 0xA4);
+    if (step[0xC] != 0) {
+        s32* offsets = *(s32**)((u8*)param3 + 0xC);
+        Vec* src = (Vec*)(data + offsets[1] + 0x80);
 
-        Vec* src = (Vec*)((u8*)param1 + offsets[1] + 0x80);
+        PSMTXMultVec((MtxPtr)(pppMngSt + 0x78), src, &local_94);
+    } else {
+        s32* offsets = *(s32**)((u8*)param3 + 0xC);
+        Vec* src = (Vec*)(data + offsets[1] + 0x80);
+
+        local_94.x = *(f32*)(pppMngSt + 0x84);
+        local_94.y = *(f32*)(pppMngSt + 0x94);
+        local_94.z = *(f32*)(pppMngSt + 0xA4);
         local_94.x = local_94.x + src->x;
         local_94.y = local_94.y + src->y;
         local_94.z = local_94.z + src->z;
     }
 
-    if (*(f32*)((u8*)param2 + 4) != 0.0f) {
-        PSVECSubtract((Vec*)((u8*)lbl_8032ED50 + 8), (Vec*)((u8*)lbl_8032ED50 + 0x48), &local_88);
+    hitLength = *(f32*)(step + 4);
+    if (hitLength != 0.0f) {
+        PSVECSubtract((Vec*)(pppMngSt + 8), (Vec*)(pppMngSt + 0x48), &local_88);
     }
 
-    f32 radius = *(f32*)((u8*)lbl_8032ED50 + 0x64) * *(f32*)((u8*)param2 + 8);
-    pppHitCylinderSendSystem((_pppMngSt*)lbl_8032ED50, &local_94, &local_88, radius, *(f32*)((u8*)param2 + 4));
+    radius = *(f32*)(pppMngSt + 0x64) * *(f32*)(step + 8);
+    pppHitCylinderSendSystem((_pppMngSt*)pppMngSt, &local_94, &local_88, radius, hitLength);
 
     if ((*(u32*)(CFlat + 0x129c) & 0x200000) != 0) {
-        local_7c = *(_GXColor*)((u8*)param2 + 0xC);
+        local_7c = *(_GXColor*)(step + 0xC);
         PSMTXIdentity(MStack_78);
         PSMTXIdentity(local_48);
         local_48[0][0] = radius;


### PR DESCRIPTION
## Summary
- Refactored `pppParHitSphMat` to keep original behavior but better match expected compiler output.
- Delayed serialized-offset loads into branch-local scopes.
- Introduced explicit manager/data/step pointer locals and reused `hitLength`/`radius` values.
- Reordered local variable usage/lifetimes to better align stack slot layout and register flow.

## Functions improved
- Unit: `main/pppParHitSphMat`
- Function: `pppParHitSphMat`
- Before: `77.61468%`
- After: `81.366974%`
- Delta: `+3.752294%`

## Match evidence
- `ninja` succeeded after the change and regenerated `build/GCCP01/report.json`.
- Objdiff TUI also reflects the improved fuzzy score (`81.18%` shown in diff view).
- Improvement is in instruction ordering/register assignment and stack shaping, not cosmetic renames.

## Plausibility rationale
- The update keeps idiomatic source-level logic (same control flow and calls) while clarifying data flow through named pointers and reused scalar intermediates.
- No compiler-coaxing constructs were introduced; the resulting code is still readable and plausible original game source.

## Technical notes
- Remaining differences appear concentrated in register choices and a few local stack offsets (for vector temp ordering), but the prologue/body alignment is measurably closer than before.
