### PR TITLE
pppVertexApLc: align vertex copy with float Vec semantics

### DIFF
--- a/src/pppVertexApLc.cpp
+++ b/src/pppVertexApLc.cpp
@@ -48,13 +48,6 @@ struct VertexApLcSource
     Vec* points;
 };
 
-struct VecWord3
-{
-    u32 x;
-    u32 y;
-    u32 z;
-};
-
 struct _pppPDataVal;
 
 extern CMath math;
@@ -64,8 +57,8 @@ extern VertexApLcEnv* lbl_8032ED54;
 
 extern "C" {
 f32 RandF__5CMathFv(CMath*);
-_pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
 }
+_pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
 
 /*
  * --INFO--
@@ -117,7 +110,6 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
             points = src->points;
         }
 
-        VecWord3* pointWords = (VecWord3*)points;
         u8 count = data->spawnCount;
 
         if (data->mode == 0) {
@@ -128,7 +120,10 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
 
                 u16 vertexIndex = entry->vertexIndices[state->index];
                 state->index++;
-                VecWord3 vtxWords = pointWords[vertexIndex];
+                Vec* vertex = &points[vertexIndex];
+                f32 x = vertex->x;
+                f32 y = vertex->y;
+                f32 z = vertex->z;
 
                 if ((data->childId + 0x10000) != 0xFFFF) {
                     _pppPObject* child;
@@ -141,16 +136,19 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
                         *(void**)((u8*)child + 0x4) = parent;
                     }
 
-                    u32* dst = (u32*)((u8*)child + data->childPosOffset + 0x80);
-                    dst[0] = vtxWords.x;
-                    dst[1] = vtxWords.y;
-                    dst[2] = vtxWords.z;
+                    Vec* dst = (Vec*)((u8*)child + data->childPosOffset + 0x80);
+                    dst->x = x;
+                    dst->y = y;
+                    dst->z = z;
                 }
             } while (count-- != 0);
         } else if (data->mode == 1) {
             do {
                 u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
-                VecWord3 vtxWords = pointWords[vertexIndex];
+                Vec* vertex = &points[vertexIndex];
+                f32 x = vertex->x;
+                f32 y = vertex->y;
+                f32 z = vertex->z;
 
                 if ((data->childId + 0x10000) != 0xFFFF) {
                     _pppPObject* child;
@@ -163,10 +161,10 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
                         *(void**)((u8*)child + 0x4) = parent;
                     }
 
-                    u32* dst = (u32*)((u8*)child + data->childPosOffset + 0x80);
-                    dst[0] = vtxWords.x;
-                    dst[1] = vtxWords.y;
-                    dst[2] = vtxWords.z;
+                    Vec* dst = (Vec*)((u8*)child + data->childPosOffset + 0x80);
+                    dst->x = x;
+                    dst->y = y;
+                    dst->z = z;
                 }
             } while (count-- != 0);
         }


### PR DESCRIPTION
## Summary
- Reworked `pppVertexApLc` vertex position transfer to use `Vec`/`f32` components instead of raw `u32` word copies.
- Kept the existing control-flow shape while preserving coordinates in local float temporaries across `pppCreatePObject` calls.
- Removed `extern "C"` linkage for `pppCreatePObject` declaration in this unit to match surrounding ppp units and symbol expectations.

## Functions Improved
- Unit: `main/pppVertexApLc`
- Symbol: `pppVertexApLc`

## Match Evidence
- `pppVertexApLc` match improved from **66.84314%** to **83.82353%** (`tools/objdiff-cli diff -p . -u main/pppVertexApLc -o - pppVertexApLc`).
- Improvement is from instruction-level alignment (not formatting): generated code now follows float load/store patterns for XYZ transfer and closer register allocation around the child-spawn path.

## Plausibility Rationale
- Particle vertex positions are semantically `Vec` coordinates, so float-based handling is more plausible original source than treating them as packed integer words.
- The change improves readability and intent while moving emitted code toward the original assembly shape.

## Technical Notes
- Before: compiler emitted integer word staging for copied positions in this path.
- After: compiler emits float-value handling with temporaries that survive object-creation call boundaries, reducing several structural mismatches in the diff.
