### PR TITLE
pppLaser: improve pppConstructLaser work layout and state offsets

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -9,7 +9,7 @@
 
 extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 extern struct _pppMngSt* pppMngStPtr;
-extern CMath Math;
+extern CMath math;
 extern f32 FLOAT_80333428;
 extern f32 FLOAT_80333448;
 extern f32 FLOAT_8033344c;
@@ -101,40 +101,35 @@ struct CMapCylinderRaw {
  */
 void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
-    f32 fVar1 = FLOAT_80333428;
-    f32* pfVar3 = (f32*)((u8*)pppLaser + 0x88 + param_2->offsets->m_serializedDataOffsets[2]);
-    int local_24;
+    f32* pfVar3 = (f32*)((u8*)pppLaser + 0x80 + param_2->offsets->m_serializedDataOffsets[2]);
     int local_28;
-    Vec local_20;
+    int local_24;
     Vec local_14;
+    Vec local_20;
 
     *pfVar3 = FLOAT_80333428;
-    pfVar3[6] = fVar1;
-    pfVar3[5] = fVar1;
-    pfVar3[4] = fVar1;
-    pfVar3[3] = fVar1;
-    pfVar3[2] = fVar1;
-    pfVar3[1] = fVar1;
-    pfVar3[7] = 0.0f;
-    pfVar3[10] = fVar1;
-    pfVar3[9] = fVar1;
-    pfVar3[8] = fVar1;
+    pfVar3[6] = FLOAT_80333428;
+    pfVar3[5] = FLOAT_80333428;
+    pfVar3[4] = FLOAT_80333428;
+    pfVar3[3] = FLOAT_80333428;
+    pfVar3[2] = FLOAT_80333428;
+    pfVar3[1] = FLOAT_80333428;
+    *(u32*)((u8*)pfVar3 + 0x1c) = 0;
+    pfVar3[10] = FLOAT_80333428;
+    pfVar3[9] = FLOAT_80333428;
+    pfVar3[8] = FLOAT_80333428;
 
     *((u8*)pfVar3 + 0x2c) = 0;
     *((u8*)pfVar3 + 0x2d) = 0;
     *((u8*)pfVar3 + 0x2e) = 0;
-    *((u16*)pfVar3 + 0xc) = 0;
-    *((u16*)pfVar3 + 0xd) = 0;
+    *((u16*)((u8*)pfVar3 + 0x30)) = 0;
+    *((u16*)((u8*)pfVar3 + 0x34)) = 0;
     *((u16*)((u8*)pfVar3 + 0x32)) = 0;
 
-    pfVar3[14] = RandF__5CMathFf(FLOAT_8033345c, &Math);
+    pfVar3[14] = RandF__5CMathFf(FLOAT_8033345c, &math);
     *((u8*)pfVar3 + 0x4c) = 1;
 
-    if (GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(&Game.game, (PPPIFPARAM*)((u8*)pppMngStPtr + 0x130), &local_24, &local_28) == 0) {
-        pfVar3[15] = FLOAT_80333448;
-        *(u8*)((u8*)pppMngStPtr + 0x118) = 1;
-        pppStopSe__FP9_pppMngStP7PPPSEST(pppMngStPtr, (PPPSEST*)((u8*)pppMngStPtr + 0x11c));
-    } else {
+    if (GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(&Game.game, (PPPIFPARAM*)((u8*)pppMngStPtr + 0x130), &local_24, &local_28) != 0) {
         GetTargetCursor__5CGameFiR3VecR3Vec(&Game.game, local_28, (Vec*)(pfVar3 + 0x10), &local_20);
 
         u8* partyObj = (u8*)GetPartyObj__5CGameFi(&Game.game, local_28);
@@ -147,6 +142,10 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
         } else {
             pfVar3[15] = FLOAT_80333448;
         }
+    } else {
+        pfVar3[15] = FLOAT_80333448;
+        *(u8*)((u8*)pppMngStPtr + 0xe8) = 1;
+        pppStopSe__FP9_pppMngStP7PPPSEST(pppMngStPtr, (PPPSEST*)((u8*)pppMngStPtr + 0x11c));
     }
 }
 


### PR DESCRIPTION
## Summary
- Refined `pppConstructLaser` in `src/pppLaser.cpp` to better match original work-buffer layout and control-flow shape.
- Switched the function's work base from `+0x88` to `+0x80` and corrected zero-initialization writes to the observed field offsets (`0x1c`, `0x30`, `0x32`, `0x34`).
- Updated the RNG call to use `math` and corrected the manager flag write from `+0x118` to `+0xe8` in the no-target path.
- Reordered the `GetParticleSpecialInfo` branch to follow original assembly flow (`!= 0` fast path first).

## Functions improved
- Unit: `main/pppLaser`
- Function: `pppConstructLaser`

## Match evidence
- `pppConstructLaser` fuzzy match: **62.261906% -> 71.63095%** (`build/GCCP01/report.json`)
- Supporting assembly alignment improvements observed in `build/GCCP01/src/pppLaser.o` vs `build/GCCP01/obj/pppLaser.o`:
  - work pointer base now aligns to `+0x80`
  - halfword clear offsets align to `0x30/0x32/0x34`
  - no-target manager flag write aligns to `+0xe8`

## Plausibility rationale
- These updates correct clearly structured particle-work and state offsets rather than adding compiler-only coercions.
- The resulting code remains readable and idiomatic for this codebase while aligning better with the original object behavior.

## Technical notes
- Verified with `ninja` in a clean worktree configured for `GCCP01`.
- No additional source files were changed.
