### PR TITLE
main/map: add CPtrArray<CMapAnim*> specializations

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -189,6 +189,149 @@ void CPtrArray<CMapLightHolder*>::SetStage(CMemory::CStage* stage)
 
 /*
  * --INFO--
+ * PAL Address: 0x80033f54
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+bool CPtrArray<CMapAnim*>::Add(CMapAnim* item)
+{
+    bool success = setSize(m_numItems + 1);
+    if (success) {
+        m_items[m_numItems] = item;
+        m_numItems++;
+    }
+    return success;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80033fc4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnim*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80033fcc
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnim*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034018
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnim* CPtrArray<CMapAnim*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034038
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnim*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034040
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+bool CPtrArray<CMapAnim*>::setSize(unsigned long newSize)
+{
+    CMapAnim** newItems;
+
+    if (m_size < newSize) {
+        if (m_size == 0) {
+            m_size = m_defaultSize;
+        } else {
+            m_size = m_size << 1;
+        }
+
+        newItems = new CMapAnim*[m_size];
+        if (newItems == 0) {
+            return false;
+        }
+
+        if (m_items != 0) {
+            for (unsigned long i = 0; i < m_numItems; i++) {
+                newItems[i] = m_items[i];
+            }
+        }
+
+        if (m_items != 0) {
+            __dla__FPv(m_items);
+            m_items = 0;
+        }
+
+        m_items = newItems;
+    }
+
+    return true;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034260
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnim* CPtrArray<CMapAnim*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
Add missing `CPtrArray<CMapAnim*>` specializations in `src/map.cpp` for the map unit, including:
- `Add`
- `GetSize`
- `RemoveAll`
- `operator[]` (`__vc`)
- `SetStage`
- `setSize`
- `GetAt`

Also added PAL `--INFO--` address/size blocks for these functions.

## Functions improved
Unit: `main/map`

- `Add__21CPtrArray<P8CMapAnim>FP8CMapAnim`
- `GetSize__21CPtrArray<P8CMapAnim>Fv`
- `RemoveAll__21CPtrArray<P8CMapAnim>Fv`
- `__vc__21CPtrArray<P8CMapAnim>FUl`
- `SetStage__21CPtrArray<P8CMapAnim>FPQ27CMemory6CStage`
- `setSize__21CPtrArray<P8CMapAnim>FUl`
- `GetAt__21CPtrArray<P8CMapAnim>FUl`

## Match evidence
Before these symbols were reported with `fuzzy_match_percent: null` in `build/GCCP01/report.json` (unmatched/missing in this unit).

After:
- `Add__21CPtrArray<P8CMapAnim>FP8CMapAnim`: `86.75`
- `GetSize__21CPtrArray<P8CMapAnim>Fv`: `100.0`
- `RemoveAll__21CPtrArray<P8CMapAnim>Fv`: `99.8421`
- `__vc__21CPtrArray<P8CMapAnim>FUl`: `100.0`
- `SetStage__21CPtrArray<P8CMapAnim>FPQ27CMemory6CStage`: `99.5`
- `setSize__21CPtrArray<P8CMapAnim>FUl`: `48.1`
- `GetAt__21CPtrArray<P8CMapAnim>FUl`: `99.75`

Global progress output from `ninja` also increased:
- matched code: `198796 -> 198836` bytes
- matched functions: `1465 -> 1467`

## Plausibility rationale
These are direct, idiomatic template specializations for pointer array behavior already present for adjacent map types in this file (`CMapLightHolder*`, `CMapAnimRun*`).

The changes avoid contrived control-flow tricks and keep behavior/source style consistent with existing `CPtrArray` usage patterns in the codebase.

## Technical details
- Implementations are source-plausible translations of the expected pointer-array operations from the decomp reference for `P8CMapAnim`.
- `RemoveAll` uses `__dla__FPv` consistently with neighboring specialized implementations in `map.cpp`.
- Verified with full rebuild: `ninja` completes and report updates accordingly.
