### PR TITLE
chara_fur: decompile CChara::TimeMogFur first pass

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -155,6 +155,8 @@ class CChara
     void SetAmemStage(CMemory::CStage*);
     void GetMemoryStage();
     void ResetAmem(int);
+    void TimeMogFur();
+    void CalcMogScore();
 };
 
 #endif // _FFCC_CHARA_H_

--- a/src/chara_fur.cpp
+++ b/src/chara_fur.cpp
@@ -1,6 +1,93 @@
 #include "ffcc/chara_fur.h"
 #include "ffcc/chara.h"
 #include "ffcc/charaobj.h"
+#include "ffcc/system.h"
+
+#include <string.h>
+
+/*
+ * --INFO--
+ * PAL Address: 0x800df618
+ * PAL Size: 480b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CChara::TimeMogFur()
+{
+	unsigned int* const timeStamp = reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(this) + 0x2014);
+	unsigned short* const texels = reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(this) + 4);
+
+	if (*timeStamp + 0x1A5E0 < System.m_frameCounter) {
+		*timeStamp = System.m_frameCounter;
+		if (static_cast<unsigned int>(System.m_execParam) > 2U) {
+			System.Printf("");
+		}
+		if (static_cast<unsigned int>(System.m_execParam) > 2U) {
+			System.Printf("");
+		}
+		if (static_cast<unsigned int>(System.m_execParam) > 2U) {
+			System.Printf("");
+		}
+	}
+
+	memset(reinterpret_cast<unsigned char*>(this) + 0x2018, 0, 0x40);
+
+	for (unsigned int y = 0; y < 0x40; y++) {
+		for (unsigned int x = 0; x < 0x40; x++) {
+			int light;
+			int r;
+			int g;
+			int b;
+			int a;
+			unsigned int newA;
+			unsigned int tileIndex = ((((x >> 2) & 1) + (((y >> 2) & 1) * 4) + (x >> 3) * 0x10 + (y >> 3) * 0x100) * 2) +
+			                         (((x & 3) + ((y & 3) * 4)) * 2);
+			unsigned short packed = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(texels) + tileIndex);
+
+			a = (packed >> 12) & 7;
+			light = 7 - a;
+			r = light + ((packed >> 8) & 0xF) + 4;
+			g = light + ((packed >> 4) & 0xF) + 4;
+			b = light + (packed & 0xF) + 4;
+
+			if (r > 0xF) {
+				r = 0xF;
+			}
+			if (g > 0xF) {
+				g = 0xF;
+			}
+			if (b > 0xF) {
+				b = 0xF;
+			}
+
+			newA = static_cast<unsigned int>(a + 2);
+			if (newA > 7) {
+				newA = 7;
+			}
+
+			*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(texels) + tileIndex) =
+			    static_cast<unsigned short>((b & 0xF) | ((g & 0xF) << 4) | ((r & 0xF) << 8) | ((newA & 7) << 12));
+		}
+	}
+
+	CalcMogScore();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800df7f8
+ * PAL Size: 2224b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CChara::CalcMogScore()
+{
+	// TODO
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added missing `CChara` method declarations for Mog fur processing in `include/ffcc/chara.h`.
- Implemented a first-pass decomp of `CChara::TimeMogFur()` in `src/chara_fur.cpp` using the PAL Ghidra control flow and buffer math.
- Added PAL address/size info blocks for `TimeMogFur` and `CalcMogScore` and introduced a placeholder `CChara::CalcMogScore()` to emit the correct mangled symbol for follow-up work.

## Functions Improved
- Unit: `main/chara_fur`
- `TimeMogFur__6CCharaFv` (size 480b)
  - Before: 0.0% (target selector)
  - After: 54.825% (`objdiff-cli v3.6.1` symbol diff)
  - Report fuzzy match: 55.033333%
- `CalcMogScore__6CCharaFv` now emitted with correct symbol (0.17985612% first-pass placeholder).

## Match Evidence
- `tools/objdiff-cli diff -p . -u main/chara_fur -o - TimeMogFur__6CCharaFv`
  - `match_percent`: `54.825`
- `build/GCCP01/report.json` (`main/chara_fur`)
  - `TimeMogFur__6CCharaFv.fuzzy_match_percent`: `55.033333`

## Plausibility Rationale
- The implementation follows natural source-level behavior for the function: frame-gated fur aging, clearing a small state buffer, iterating 64x64 texels in tiled layout, clamping color/alpha channels, and dispatching score recomputation.
- Changes prioritize recovering expected original game logic and symbol ownership (`CChara` methods) rather than artificial compiler coaxing.

## Technical Details
- `TimeMogFur` is implemented as a `CChara` member to emit `TimeMogFur__6CCharaFv` instead of unrelated stub symbols.
- Fur texture access is performed via object-relative offsets (`+0x4`, `+0x2014`, `+0x2018`) consistent with the current decomp stage and Ghidra reference.
- Full PAL build verified after change: `build/GCCP01/main.dol: OK`.
