### PR TITLE
pppEraseCharaParts: improve constructor match via serialized offset access

### DIFF
--- a/src/pppEraseCharaParts.cpp
+++ b/src/pppEraseCharaParts.cpp
@@ -56,13 +56,15 @@ void EraseCharaParts_DrawMeshDLCallback(CChara::CModel* model, void* param_2, vo
  */
 void pppConstructEraseCharaParts(pppEraseCharaParts* pppEraseCharaParts, UnkC* param_2)
 {
+    s32* serializedDataOffsets;
     void* handle;
     int model;
     u8* colorPtr;
     void* gObject;
 
+    serializedDataOffsets = *(s32**)((u8*)param_2 + 0xC);
     gObject = *(void**)((char*)pppMngStPtr + 0x8);
-    colorPtr = (u8*)((int)(&pppEraseCharaParts->field0_0x0 + 2) + param_2->m_serializedDataOffsets[1]);
+    colorPtr = (u8*)pppEraseCharaParts + 0x80 + serializedDataOffsets[1];
     colorPtr[0] = 0x80;
     colorPtr[1] = 0x80;
     colorPtr[2] = 0x80;


### PR DESCRIPTION
## Summary
- Refined `pppConstructEraseCharaParts` to load serialized offset metadata from `param_2 + 0xC`.
- Rewrote color work pointer calculation to `base + 0x80 + offsets[1]`, matching the surrounding PPP serialization pattern.
- Kept behavior identical (initializes 4-byte color to `0x80` and installs the mesh draw callback).

## Functions improved
- Unit: `main/pppEraseCharaParts`
- `pppConstructEraseCharaParts`: **86.4% -> 98.36%** (`100b`)

## Match evidence
- Per-function fuzzy match from `build/GCCP01/report.json` improved for constructor only.
- Neighboring functions in the unit remained stable:
  - `pppFrameEraseCharaParts`: `99.809525%`
  - `EraseCharaParts_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: `78.44681%`
- Build verification passes: `ninja` completes and `build/GCCP01/main.dol: OK` was previously verified in this run.

## Plausibility rationale
- The update removes ad-hoc pointer arithmetic (`&field0 + 2`) and uses the same serialized offset layout style already used across many PPP units (`base + 0x80 + serializedOffset`).
- Accessing serialized offset metadata from `+0xC` is consistent with other PPP codepaths that treat these command structs as having a small header before the offset pointer.

## Technical details
- Key assembly delta addressed: constructor now emits the offset-load and base-add pattern expected for this unit, which significantly reduced instruction mismatch in objdiff for the constructor symbol.
