### PR TITLE
RedSound: forward CRedSound music wrappers to CRedDriver

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -317,9 +317,9 @@ void CRedSound::ReentryMusicData(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicStop(int)
+void CRedSound::MusicStop(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicStop(id);
 }
 
 /*
@@ -327,9 +327,9 @@ void CRedSound::MusicStop(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicPlay(int, int, int)
+void CRedSound::MusicPlay(int id, int vol, int fadeTime)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicPlay(id, vol, fadeTime);
 }
 
 /*
@@ -337,9 +337,9 @@ void CRedSound::MusicPlay(int, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicCrossPlay(int, int, int)
+void CRedSound::MusicCrossPlay(int id, int vol, int fadeTime)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicCrossPlay(id, vol, fadeTime);
 }
 
 /*
@@ -347,9 +347,9 @@ void CRedSound::MusicCrossPlay(int, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicNextPlay(int, int, int)
+void CRedSound::MusicNextPlay(int id, int vol, int fadeTime)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicNextPlay(id, vol, fadeTime);
 }
 
 /*
@@ -357,9 +357,9 @@ void CRedSound::MusicNextPlay(int, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicMasterVolume(int)
+void CRedSound::MusicMasterVolume(int volume)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicMasterVolume(volume);
 }
 
 /*
@@ -367,9 +367,9 @@ void CRedSound::MusicMasterVolume(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicFadeOut(int, int)
+void CRedSound::MusicFadeOut(int id, int fadeTime)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicFadeOut(id, fadeTime);
 }
 
 /*
@@ -377,9 +377,9 @@ void CRedSound::MusicFadeOut(int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::MusicVolume(int, int, int)
+void CRedSound::MusicVolume(int id, int volume, int fadeTime)
 {
-	// TODO
+	CRedDriver_8032f4c0.MusicVolume(id, volume, fadeTime);
 }
 
 /*
@@ -387,9 +387,9 @@ void CRedSound::MusicVolume(int, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::SetMusicPhraseStop(int)
+void CRedSound::SetMusicPhraseStop(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetMusicPhraseStop(id);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented the `CRedSound` music-control stubs in `src/RedSound/RedSound.cpp` as direct forwarders to `CRedDriver_8032f4c0`, matching the existing wrapper style already used by nearby functions (for example `SetReverbDepth`).

## Functions Improved
Unit: `main/RedSound/RedSound`
- `MusicStop__9CRedSoundFi`
- `MusicPlay__9CRedSoundFiii`
- `MusicCrossPlay__9CRedSoundFiii`
- `MusicNextPlay__9CRedSoundFiii`
- `MusicMasterVolume__9CRedSoundFi`
- `MusicFadeOut__9CRedSoundFii`
- `MusicVolume__9CRedSoundFiii`
- `SetMusicPhraseStop__9CRedSoundFi`

## Match Evidence
From `build/GCCP01/report.json` before/after rebuilding this commit:
- `MusicStop__9CRedSoundFi`: `9.090909%` -> `81.27273%`
- `MusicPlay__9CRedSoundFiii`: `6.6666665%` -> `59.4%`
- `MusicCrossPlay__9CRedSoundFiii`: `6.6666665%` -> `59.4%`
- `MusicNextPlay__9CRedSoundFiii`: `6.6666665%` -> `59.4%`
- `MusicMasterVolume__9CRedSoundFi`: `9.090909%` -> `81.27273%`
- `MusicFadeOut__9CRedSoundFii`: `7.6923075%` -> `68.76923%`
- `MusicVolume__9CRedSoundFiii`: `6.6666665%` -> `59.4%`
- `SetMusicPhraseStop__9CRedSoundFi`: `9.090909%` -> `81.27273%`

Unit fuzzy match improved:
- `main/RedSound/RedSound`: `33.292374%` -> `40.008476%`

Build verification:
- `ninja` succeeds

## Plausibility Rationale
These are straightforward API-layer pass-through methods (`CRedSound` -> `CRedDriver`) with no artificial control-flow coaxing. This aligns with existing code patterns in the same file and preserves clean, maintainable source that is plausible as original game code.

## Technical Notes
- No signature tricks or contrived temporaries were introduced.
- Changes are localized to one translation unit and only replace TODO stubs with direct forwarding calls.
