### PR TITLE
ref: match CRef destructor vtable store

### DIFF
--- a/src/ref.cpp
+++ b/src/ref.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/ref.h"
 
 extern "C" void __dl__FPv(void*);
-extern "C" void* __vt__4CRef;
+extern "C" void* __vt__4CRef[];
 
 /*
  * --INFO--
@@ -29,7 +29,7 @@ CRef::CRef()
 extern "C" CRef* dtor_80043D10(CRef* ref, short param_2)
 {
 	if (ref != 0) {
-		*(void**)ref = &__vt__4CRef;
+		*(void**)ref = __vt__4CRef;
 		if (0 < param_2) {
 			__dl__FPv(ref);
 		}


### PR DESCRIPTION
## Summary
- Adjusted `src/ref.cpp` vtable declaration to an array form and stored it directly in `dtor_80043D10`.
- This preserves source plausibility (standard C++ vtable pointer store) while aligning codegen for the destructor path.

## Functions improved
- Unit: `main/ref`
- `dtor_80043D10` (PAL 0x80043d10, 72b)
- Unit-level status moved from partial to full match.

## Match evidence
- `main/ref` before: `fuzzy_match_percent=93.125`, `matched_functions=1/2`.
- `main/ref` after: `fuzzy_match_percent=100.0`, `matched_functions=2/2`, `matched_code=96/96`.
- Global progress changed from `198940` to `199012` matched code bytes (`+72`) and from `1468` to `1469` matched functions (`+1`).

## Plausibility rationale
- The change reflects a normal vtable write pattern in a destructor and avoids non-source-like compiler-coaxing constructs.
- No behavioral logic changed; only symbol typing and vtable assignment form were corrected.

## Technical details
- Objdiff previously showed the remaining mismatch around the vtable store sequence in `dtor_80043D10`.
- Declaring `__vt__4CRef` as an array and assigning `__vt__4CRef` directly resolved the final function match at the unit level.
