### PR TITLE
main/file: improve CFile::Close decomp match

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -26,6 +26,7 @@ static char s_cFile[] = "CFile";
 static char s_drawErrorFmt[] = "CFile::drawError %d";
 static char s_queueWarnAnyFmt[] = "BackAllFilesToQueue: %s";
 static char s_queueWarnTargetFmt[] = "BackAllFilesToQueue: %s (%s)";
+static char s_closeWarnFmt[] = "Close: %s";
 
 static const char* s_diskErrorText[4][6][3] = {
     {
@@ -356,9 +357,9 @@ void CFile::ReadASync(CFile::CHandle* fileHandle)
  */
 void CFile::Close(CFile::CHandle* fileHandle)
 {
-	if (fileHandle->m_completionStatus == 2) //  && (1 < (uint)System._4700_4_)
+	if ((fileHandle->m_completionStatus == 2) && (1 < (unsigned int)System.m_execParam))
 	{
-		// Printf(&System,&DAT_801d5e04,fileHandle->name);
+		System.Printf(s_closeWarnFmt, fileHandle->m_name);
 	}
 
 	DVDClose(&fileHandle->m_dvdFileInfo);


### PR DESCRIPTION
## Summary
- Restored the debug warning path in `CFile::Close` for in-flight handles.
- Added a dedicated format string and reinstated the guarded `System.Printf` call.
- Kept close/list-unlink behavior unchanged.

## Functions improved
- Unit: `main/file`
- Symbol: `Close__5CFileFPQ25CFile7CHandle`

## Match evidence
- Before: `66.666664%`
- After: `99.589745%`
- Instruction diffs: `13 -> 4`
- Main improvement: previously-missing conditional logging block now matches expected control-flow and call shape.

## Plausibility rationale
- The restored condition and print call align with the existing codebase convention of gated debug logging by `System.m_execParam`.
- This is a source-plausible recovery of original behavior rather than compiler-only coaxing.

## Technical details
- Implemented:
  - `if ((fileHandle->m_completionStatus == 2) && (1 < (unsigned int)System.m_execParam)) { System.Printf(...); }`
- Remaining minor mismatches are in branch/op form and string symbol relocation only.
