### PR TITLE
Improve pppFrameYmTracer2 pointer indexing

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -169,12 +169,12 @@ void pppFrameYmTracer2(pppYmTracer2* pppYmTracer2, UnkB* param_2, UnkC* param_3)
     if (step->m_initWOrk == -1) {
         *(void**)(work + 0x20) = &DAT_801eadc8;
     } else {
-        *(void**)(work + 0x20) = (u8*)pppMngStPtr + step->m_stepValue;
+        *(void**)(work + 0x20) = (u8*)&pppMngStPtr->m_kind + step->m_initWOrk * 0x10 + step->m_stepValue;
     }
     if (step->m_arg3 == -1) {
         *(void**)(work + 0x24) = &DAT_801eadc8;
     } else {
-        *(void**)(work + 0x24) = (u8*)pppMngStPtr + *(s32*)step->m_payload;
+        *(void**)(work + 0x24) = (u8*)&pppMngStPtr->m_kind + step->m_arg3 * 0x10 + *(s32*)step->m_payload;
     }
 
     if (*(void**)(work + 0x28) == nullptr) {


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmTracer2` pointer setup for the two work vectors (`work+0x20` and `work+0x24`) to include both step index (`m_initWOrk`/`m_arg3`) and per-step offset (`m_stepValue`/payload offset).
- Kept fallback behavior (`-1` routes to `DAT_801eadc8`) unchanged.

## Functions improved
- Unit: `main/pppYmTracer2`
- Symbol: `pppFrameYmTracer2`

## Match evidence
- `pppFrameYmTracer2`: **14.111511% -> 14.6690645%** (`build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppFrameYmTracer2`)
- `pppRenderYmTracer2` remained unchanged at **57.247967%**.
- Build verification: `ninja` succeeds after the change.

## Plausibility rationale
- The updated expressions match the expected source pattern for PPP step data where an index selects a data-value slot and a second field applies an additional offset.
- This is a type/layout correction in address formation, not an artificial control-flow rewrite.

## Technical details
- Before: address was computed from base manager pointer + offset only.
- After: address is computed from manager data-value base (`&pppMngStPtr->m_kind`) + `index * 0x10` + offset.
- This aligns with related PPP code that indexes per-step data blocks using 0x10-sized entries.
