### PR TITLE
joybus: match SendGBA and GBARecvSend command handling

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/gbaque.h"
 #include "ffcc/system.h"
 
+#include <dolphin/gba/GBA.h>
 #include "dolphin/os.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/printf.h"
 
@@ -1193,12 +1194,7 @@ int JoyBus::SendGBA(ThreadParam* threadParam)
 
     OSWaitSemaphore(&m_accessSemaphores[port]);
     count = m_cmdCount[port];
-	
-    if (count > 0)
-	{
-        firstCmd = m_cmdQueueData[port][0];
-	}
-	
+    firstCmd = m_cmdQueueData[port][0];
     OSSignalSemaphore(&m_accessSemaphores[port]);
 
     if (static_cast<int>(count) < 1)
@@ -1206,15 +1202,11 @@ int JoyBus::SendGBA(ThreadParam* threadParam)
         return 0;
 	}
 
+    char isSingle = GbaQue.IsSingleMode(port);
 
-	// TODO
-    // bool isSingle = (IsSingleMode__8GbaQueueFi(&GbaQue, port) != 0);
-    bool isSingle = (bool)this;
-
-    if (!isSingle || port == 1)
+    if (isSingle == 0 || port == 1)
     {
-		// TODO: gba.c
-        threadParam->m_gbaStatus = (int)this; // GBAGetStatus(port, &threadParam->m_unk3);
+        threadParam->m_gbaStatus = GBAGetStatus(port, &threadParam->m_unk3);
     }
     else
     {
@@ -1236,8 +1228,7 @@ int JoyBus::SendGBA(ThreadParam* threadParam)
 		return 0;
 	}
 
-	// TODO: Gba.c
-    int gbaResult = (int)this; // GBAWrite(port, &firstCmd, &threadParam->m_unk3);
+    int gbaResult = GBAWrite(port, (unsigned char*)&firstCmd, &threadParam->m_unk3);
 	
     threadParam->m_gbaStatus = gbaResult;
 
@@ -1324,7 +1315,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
 
             if (sub == 0x03)
             {
-                // TODO: ClrLetterLstFlg__8GbaQueueFi(&GbaQue, port);
+                GbaQue.ClrLetterLstFlg(port);
                 GbaQue.SetQueue(port, prevCmd);
 
                 threadParam->m_state = '!';
@@ -1333,7 +1324,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             }
             else if (sub == 0x02)
             {
-                // TODO: ClrLetterDatFlg__8GbaQueueFi(&GbaQue, port);
+                GbaQue.ClrLetterDatFlg(port);
                 GbaQue.SetQueue(port, prevCmd);
 
                 threadParam->m_state = '%';
@@ -1342,7 +1333,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             }
             else if (sub == 0x06)
             {
-                // TODO: ClrSellFlg__8GbaQueueFi(&GbaQue, port);
+                GbaQue.ClrSellFlg(port);
                 GbaQue.SetQueue(port, prevCmd);
 
                 threadParam->m_state = '5';
@@ -1351,7 +1342,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             }
             else if (sub == 0x07)
             {
-                // TODO: ClrBuyFlg__8GbaQueueFi(&GbaQue, port);
+                GbaQue.ClrBuyFlg(port);
                 GbaQue.SetQueue(port, prevCmd);
 
                 threadParam->m_state = '7';
@@ -1360,7 +1351,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             }
             else if (sub == 0x08)
             {
-                // TODO: ClrMkSmithFlg__8GbaQueueFi(&GbaQue, port);
+                GbaQue.ClrMkSmithFlg(port);
                 GbaQue.SetQueue(port, prevCmd);
 
                 threadParam->m_state = '9';
@@ -1369,7 +1360,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             }
             else if (sub == 0x09)
             {
-                // TODO: ClrArtiDatFlg__8GbaQueueFi(&GbaQue, port);
+                GbaQue.ClrArtiDatFlg(port);
                 GbaQue.SetQueue(port, prevCmd);
 
                 threadParam->m_state = 'A';


### PR DESCRIPTION
## Summary
- Replaced placeholder status/write logic in `SendGBA__6JoyBusFP11ThreadParam` with real JoyBus/GBA flow.
- Switched `SendGBA` single-mode check to explicit `GbaQue.IsSingleMode(port)` result handling.
- Matched command-load behavior more closely by always reading queue slot 0 before the count check in `SendGBA`.
- Replaced placeholder TODO paths in `GBARecvSend__6JoyBusFP11ThreadParamPUi` with concrete queue-flag clear calls:
  - `ClrLetterLstFlg`
  - `ClrLetterDatFlg`
  - `ClrSellFlg`
  - `ClrBuyFlg`
  - `ClrMkSmithFlg`
  - `ClrArtiDatFlg`
- Added the missing GBA header include needed for concrete `GBAGetStatus`/`GBAWrite` calls.

## Functions Improved
- `SendGBA__6JoyBusFP11ThreadParam` (size 504b)
  - Before: `51.333332%`
  - After: `56.134922%`
  - Delta: `+4.801590`
- `GBARecvSend__6JoyBusFP11ThreadParamPUi` (size 2700b)
  - Before: `48.585186%`
  - After: `51.487408%`
  - Delta: `+2.902222`
- `RecvGBA__6JoyBusFP11ThreadParamPUi` held at baseline (`54.23125%`) after narrowing scope to avoid regression.

## Match Evidence
- Rebuilt with `ninja` and compared function-level `fuzzy_match_percent` from `build/GCCP01/report.json` before/after edits.
- Improvements correspond to real control-flow/callsite alignment (status polling + GBA write path + queue-flag handling), not rename/format-only changes.

## Plausibility Rationale
- Changes replace explicit placeholders with semantically correct game-side calls already present in the codebase (`GbaQueue` flag clear APIs and GBA transport APIs).
- Control flow follows the expected JoyBus send/receive model (query status, send command word, clear mode-specific queue flags).
- No compiler-coaxing patterns or readability-degrading hacks were introduced; this is a straightforward source-faithful cleanup of TODO stubs.
