### PR TITLE
p_MaterialEditor: match GetTable to m_table layout

### DIFF
--- a/include/ffcc/p_MaterialEditor.h
+++ b/include/ffcc/p_MaterialEditor.h
@@ -20,7 +20,7 @@ public:
 
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void createViewer();
     void destroyViewer();

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -6,6 +6,7 @@
 extern "C" int __cntlzw(unsigned int);
 
 extern CUSBPcs USBPcs;
+extern unsigned char m_table__18CMaterialEditorPcs[];
 extern class CCameraPcs {
 public:
     Mtx m_cameraMatrix;
@@ -186,9 +187,9 @@ void CMaterialEditorPcs::Quit()
  * Address:	TODO
  * Size:	TODO
  */
-void CMaterialEditorPcs::GetTable(unsigned long)
+int CMaterialEditorPcs::GetTable(unsigned long index)
 {
-	// TODO
+    return reinterpret_cast<int>(m_table__18CMaterialEditorPcs + index * 0x15C);
 }
 
 /*


### PR DESCRIPTION
## Summary
- changed `CMaterialEditorPcs::GetTable` to return `int` and implemented table lookup logic
- switched lookup base from global instance assumptions to the explicit `m_table__18CMaterialEditorPcs` symbol
- kept the implementation aligned with existing process-table patterns used in other units

## Functions improved
- Unit: `main/p_MaterialEditor`
- Symbol: `GetTable__18CMaterialEditorPcsFUl`
- Size: 20 bytes
- Match: **20.0% -> 97.0%**

## Match evidence
- objdiff now shows the expected instruction shape for the function:
  - `mulli r4, r4, 0x15c`
  - base-address load (`lis`/`addi`)
  - `add r3, r0, r4`
- Remaining mismatch is limited to relocation/arg differences on the base symbol load sequence.

## Plausibility rationale
- Process `GetTable` methods in this codebase conventionally return an indexed address into a dedicated `m_table__*` array.
- Using `m_table__18CMaterialEditorPcs` is source-plausible and consistent with neighboring process implementations rather than a compiler-coaxing rewrite.

## Technical details
- Header signature updated: `void GetTable(unsigned long)` -> `int GetTable(unsigned long)`.
- Function body now returns `reinterpret_cast<int>(m_table__18CMaterialEditorPcs + index * 0x15C)`.
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - GetTable__18CMaterialEditorPcsFUl`.
