### PR TITLE
main/pppVertexApAt: improve pppVertexApAt match via type tightening

### DIFF
--- a/src/pppVertexApAt.cpp
+++ b/src/pppVertexApAt.cpp
@@ -110,7 +110,7 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
                         state[0] = outValue + 1;
 
                         s32 childId = vtxData->childId;
-                        if ((childId + 0x10000) != 0xFFFF) {
+                        if ((u16)childId != 0xFFFF) {
                             _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
                             _pppPObject* child;
 
@@ -127,10 +127,10 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
                     break;
                 case 1:
                     do {
-                        s32 outValue = (s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue);
+                        u16 outValue = (u16)(RandF__5CMathFv(&math) * (f32)entry->maxValue);
                         s32 childId = vtxData->childId;
 
-                        if ((childId + 0x10000) != 0xFFFF) {
+                        if ((u16)childId != 0xFFFF) {
                             _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
                             _pppPObject* child;
 
@@ -141,7 +141,7 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
                                 *(void**)((u8*)child + 0x4) = parent;
                             }
 
-                            *(u16*)((u8*)child + vtxData->childValueOffset + 0x80) = (u16)outValue;
+                            *(u16*)((u8*)child + vtxData->childValueOffset + 0x80) = outValue;
                         }
                     } while (count-- != 0);
                     break;


### PR DESCRIPTION
## Summary
- Adjusted `pppVertexApAt` type/control-flow details to better reflect likely original source semantics.
- Replaced child-id sentinel checks from arithmetic form to explicit `u16` sentinel comparison (`0xFFFF`).
- Kept random output in case-1 as `u16` through assignment path.

## Functions Improved
- Unit: `main/pppVertexApAt`
- Symbol: `pppVertexApAt`

## Match Evidence
- `pppVertexApAt` before: `85.40179%`
- `pppVertexApAt` after:  `86.33929%`
- Delta: `+0.93750%` (same 448-byte function size)
- Diff signal improvement: instruction stream moved from `62` to `64` matching instructions, and `DIFF_ARG_MISMATCH` count dropped from `38` to `34`.

## Plausibility Rationale
- Using `0xFFFF` as a 16-bit invalid/sentinel id is consistent with particle/object child-id handling patterns.
- Holding the generated value as `u16` matches how the value is ultimately stored and avoids unnecessary widen/narrow behavior.
- Changes preserve readability and gameplay intent while reducing compiler output drift.

## Technical Details
- Updated `src/pppVertexApAt.cpp` only.
- No build-system or flag adjustments.
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/pppVertexApAt -o - pppVertexApAt`.
