### PR TITLE
main/goout: first-pass CalcGoOut state/input flow

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1,5 +1,14 @@
 #include "ffcc/goout.h"
 
+static unsigned short GetGoOutInputMask()
+{
+    if (Pad._452_4_ != 0 || Pad._448_4_ != -1) {
+        return 0;
+    }
+
+    return static_cast<unsigned short>(Pad._8_2_);
+}
+
 /*
  * --INFO--
  * Address:	TODO
@@ -334,12 +343,146 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8016a06c
+ * PAL Size: 6248b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGoOutMenu::CalcGoOut()
 {
-	// TODO
+    unsigned short input;
+    unsigned char next;
+
+    switch (field_0x18) {
+    case 0:
+        if (field_0x45 == 0) {
+            break;
+        }
+
+        input = GetGoOutInputMask();
+        if ((input & 0x100) != 0) {
+            Sound.PlaySe(2, 0x40, 0x7f, 0);
+            if (field_0x19 == -1) {
+                SetMainMode(1);
+            } else {
+                SetGoOutMode(field_0x19);
+            }
+        }
+        break;
+    case 2:
+        if (field_0x45 == 0) {
+            break;
+        }
+
+        input = GetGoOutInputMask();
+        if ((input & 0x100) != 0) {
+            Sound.PlaySe(2, 0x40, 0x7f, 0);
+            SetMainMode(1);
+        }
+        break;
+    case 3:
+        if (field_0x45 == 0) {
+            break;
+        }
+
+        field_0x47 = 1;
+        field74_0x4a = 0xcf;
+        field75_0x4c = 0xe7;
+        field_0x49 = 0;
+        next = 0;
+        input = GetGoOutInputMask();
+
+        if ((input & 3) == 0) {
+            if ((input & 0x100) != 0) {
+                if (field_0x46 == 0) {
+                    Sound.PlaySe(2, 0x40, 0x7f, 0);
+                } else if (field_0x46 == 1) {
+                    Sound.PlaySe(3, 0x40, 0x7f, 0);
+                }
+
+                next = static_cast<unsigned char>(field_0x46 + 1);
+            }
+        } else {
+            field_0x46 ^= 1;
+            Sound.PlaySe(1, 0x40, 0x7f, 0);
+        }
+
+        if (next == 2) {
+            SetMainMode(1);
+        } else if (next == 1) {
+            SetGoOutMode(4);
+        }
+        break;
+    case 4:
+        if (field_0x45 == 0) {
+            break;
+        }
+
+        field_0x47 = 1;
+        field74_0x4a = 0xce;
+        field75_0x4c = 0xde;
+        field_0x49 = 0;
+        next = 0;
+        input = GetGoOutInputMask();
+
+        if ((input & 3) == 0) {
+            if ((input & 0x100) != 0) {
+                if (field_0x46 == 0) {
+                    Sound.PlaySe(2, 0x40, 0x7f, 0);
+                } else if (field_0x46 == 1) {
+                    Sound.PlaySe(3, 0x40, 0x7f, 0);
+                }
+
+                next = static_cast<unsigned char>(field_0x46 + 1);
+            }
+        } else {
+            field_0x46 ^= 1;
+            Sound.PlaySe(1, 0x40, 0x7f, 0);
+        }
+
+        if (next == 2) {
+            SetMainMode(1);
+        } else if (next == 1) {
+            SetGoOutMode(5);
+        }
+        break;
+    case 5:
+        if (field_0x45 == 0 || field_0x4 == 0) {
+            break;
+        }
+
+        if (SetMemCardError() != 0) {
+            return;
+        }
+        SetGoOutMode(6);
+        break;
+    case 6:
+        if (field_0x45 == 0) {
+            break;
+        }
+
+        input = GetGoOutInputMask();
+        if ((input & 0x100) != 0) {
+            Sound.PlaySe(2, 0x40, 0x7f, 0);
+            SetMainMode(1);
+        }
+        break;
+    case 7:
+        if (field_0x45 == 0) {
+            break;
+        }
+
+        input = GetGoOutInputMask();
+        if ((input & 0x100) != 0) {
+            Sound.PlaySe(2, 0x40, 0x7f, 0);
+            SetGoOutMode(8);
+        }
+        break;
+    default:
+        break;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass `CGoOutMenu::CalcGoOut()` state/input handler in `src/goout.cpp`.
- Added core mode transitions and button handling for go-out flow states (0, 2, 3, 4, 5, 6, 7).
- Added PAL function metadata block for `CalcGoOut__10CGoOutMenuFv`.
- Introduced a small local input-mask helper to mirror existing pad gating behavior used in menu code.

## Functions improved
- Unit: `main/goout`
- Primary symbol: `CalcGoOut__10CGoOutMenuFv`

## Match evidence
- Selector baseline before edit: `CalcGoOut__10CGoOutMenuFv` at **0.1%** (size 6248b), unit `main/goout` at **3.2%**.
- After this change (`ninja` report):
  - `CalcGoOut__10CGoOutMenuFv`: **20.696543%** fuzzy match (`build/GCCP01/report.json`)
  - `main/goout`: **10.335196%** fuzzy match (`build/GCCP01/report.json`)
- Direct objdiff oneshot check:
  - `build/tools/objdiff-cli diff -1 build/GCCP01/obj/goout.o -2 build/GCCP01/src/goout.o -o - CalcGoOut__10CGoOutMenuFv`
  - Result: **20.417414%** match for `CalcGoOut__10CGoOutMenuFv`.

## Plausibility rationale
- The change follows the existing source style used throughout menu code:
  - state machine driven by `field_0x18`
  - pad-input gating via global `Pad` repeat/disconnect fields
  - sound-effect dispatch through `Sound.PlaySe(...)`
  - mode transitions via existing `SetMainMode`/`SetGoOutMode` methods
- This is an intentionally incremental first pass for a very large 6248-byte function; it improves structural behavior without introducing synthetic compiler-coaxing constructs.

## Technical details
- Implemented per-state logic matching decomp patterns for confirmation/cancel and yes/no toggle states.
- Added transitions to memcard error handling path (`SetMemCardError`) before progressing to mode 6.
- Kept edits contained to `src/goout.cpp` to avoid broad side effects while increasing assembly alignment.
