### PR TITLE
fontman: implement CFont::DrawQuit

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -1,9 +1,11 @@
 #include "ffcc/fontman.h"
 #include "PowerPC_EABI_Support/Runtime/NMWException.h"
+#include <dolphin/mtx.h>
 
 extern CFontMan FontMan;
 extern void* ARRAY_802ea170;
 extern "C" void __dt__8CFontManFv(void*);
+extern unsigned char CameraPcs[];
 
 /*
  * --INFO--
@@ -227,12 +229,19 @@ void CFont::DrawInit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800925d0
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CFont::DrawQuit()
 {
-	// TODO
+    Mtx44 screenMtx;
+
+    PSMTX44Copy((float(*)[4])(CameraPcs + 0x48), screenMtx);
+    GXSetProjection(screenMtx, GX_PERSPECTIVE);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CFont::DrawQuit()` in `src/fontman.cpp` using the Ghidra PAL reference flow: copy `CameraPcs` screen projection matrix to a local matrix and restore perspective projection via `GXSetProjection`. Also updated function metadata block with PAL address/size.

## Functions improved
- Unit: `main/fontman`
- Symbol: `DrawQuit__5CFontFv`
- Before: `6.6666665%`
- After: `99.6%`

## Match evidence
Measured with:
`tools/objdiff-cli diff -p . -u main/fontman -o - DrawQuit__5CFontFv`

Before/after shows the function body now aligns with the target implementation structure (matrix copy + projection restore), with only a minor residual mismatch.

## Plausibility rationale
The change is source-plausible and idiomatic for this codebase: font drawing setup/teardown commonly saves/restores projection state around orthographic rendering. `DrawQuit` restoring the camera perspective matrix is straightforward original-source behavior, not compiler coaxing.

## Technical details
- Uses `PSMTX44Copy` to copy the active screen projection matrix into a local `Mtx44` stack variable.
- Calls `GXSetProjection(..., GX_PERSPECTIVE)` to restore normal rendering projection after font draw mode.
- Kept implementation minimal and aligned with existing project style and types in nearby rendering code.
