### PR TITLE
Improve MemFree match in ME_USB_process

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -57,10 +57,11 @@ static inline CMemory::CStage* MaterialEditorStage()
  */
 extern "C" CMaterialEditorPcs* MemFree__18CMaterialEditorPcsFPv(CMaterialEditorPcs* materialEditorPcs, void* ptr)
 {
-    if (ptr != 0) {
-        materialEditorPcs = Free__7CMemoryFPv(&Memory, ptr);
+    if (ptr == nullptr) {
+        return materialEditorPcs;
     }
-    return materialEditorPcs;
+
+    return Free__7CMemoryFPv(&Memory, ptr);
 }
 
 /*


### PR DESCRIPTION
## Summary
Refined `MemFree__18CMaterialEditorPcsFPv` in `src/ME_USB_process.cpp` to use an explicit early-return path for null pointers and direct return of the `Free__7CMemoryFPv` call for non-null pointers.

## Functions improved
- Unit: `main/ME_USB_process`
- Symbol: `MemFree__18CMaterialEditorPcsFPv`
- Size: 48 bytes

## Match evidence
- Before: `86.666664%`
- After: `89.166664%`
- Delta: `+2.5%`

Measured with:
`build/tools/objdiff-cli diff -p . -u main/ME_USB_process -o -`

`SetUSBData__18CMaterialEditorPcsFv` remained unchanged (`14.965719%`).

## Plausibility rationale
The update is source-plausible and idiomatic C++: null case returns immediately, and the non-null case returns the allocator free result directly. This removes an unnecessary temporary assignment while preserving behavior.

## Technical details
The change alters control-flow/register usage in the tiny wrapper, improving objdiff alignment for the function without introducing coercive or non-idiomatic constructs.
