### PR TITLE
targimpl: improve TRKTargetAccessFP error flow

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -441,11 +441,15 @@ DSError TRKTargetAccessFP(u32 firstRegister, u32 lastRegister, TRKBuffer* b,
          (current <= lastRegister) && (error == DS_NoError);
          current++, *registersLengthPtr += sizeof(f64)) {
         if (read) {
-            TRKPPCAccessFPRegister(&temp, current, read);
-            error = TRKAppendBuffer1_ui64(b, temp);
-        } else {
-            TRKReadBuffer1_ui64(b, &temp);
             error = TRKPPCAccessFPRegister(&temp, current, read);
+            if (error == DS_NoError) {
+                error = TRKAppendBuffer1_ui64(b, temp);
+            }
+        } else {
+            error = TRKReadBuffer1_ui64(b, &temp);
+            if (error == DS_NoError) {
+                error = TRKPPCAccessFPRegister(&temp, current, read);
+            }
         }
     }
 
@@ -1035,7 +1039,6 @@ DSError TRKTargetStepOutOfRange(u32 rangeStart, u32 rangeEnd, BOOL stepOver)
         error = DS_UnsupportedError;
     } else {
         gTRKStepStatus.type = DSSTEP_IntoRange;
-        // gTRKStepStatus.active = TRUE;
         gTRKStepStatus.rangeStart = rangeStart;
         gTRKStepStatus.rangeEnd   = rangeEnd;
         error                     = TRKTargetDoStep();


### PR DESCRIPTION
## Summary
This updates `TRKTargetAccessFP` in `src/TRK_MINNOW_DOLPHIN/targimpl.c` to propagate return codes from lower-level FP register/buffer access calls before continuing to the next operation.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/targimpl`
- Symbol: `TRKTargetAccessFP`

## Match evidence
- `TRKTargetAccessFP` match percent: **22.866873% -> 23.733746%** (`tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/targimpl -o - TRKTargetAccessFP --format json`)
- Checked for regressions in nearby low-match candidates:
  - `TRKValidMemory32`: **38.12426% -> 38.12426%** (no change)
  - `TRKTargetStepOutOfRange`: **44.086956% -> 44.086956%** (no change)

## Plausibility rationale
The new flow is source-plausible because it preserves straightforward error handling semantics expected in debugger transport code:
- read path now stops append on FP access failure
- write path now stops FP write on buffer read failure

This avoids using invalid intermediate values and mirrors conventional defensive C coding style, without introducing contrived compiler-only patterns.

## Technical details
- File: `src/TRK_MINNOW_DOLPHIN/targimpl.c`
- Changed logic in the loop over FP registers to conditionally chain operations only when `error == DS_NoError`.
- No changes to interfaces, struct layouts, or calling conventions.
- Build/check executed with `ninja` in PAL (`GCCP01`) worktree.
