### PR TITLE
os: improve OSRegisterVersion match

### DIFF
--- a/src/os/OS.c
+++ b/src/os/OS.c
@@ -635,5 +635,5 @@ u32 __OSGetDIConfig(void) {
 }
 
 void OSRegisterVersion(const char* id) {
-    OSReport("%s\n", id);
+    OSReport(id);
 }


### PR DESCRIPTION
## Summary
- Simplified `OSRegisterVersion` to call `OSReport(id)` directly.
- Kept the change minimal and localized to `src/os/OS.c`.

## Functions improved
- Unit: `main/os/OS`
- Function: `OSRegisterVersion`

## Match evidence
- `OSRegisterVersion` fuzzy match: **63.18182% -> 63.636364%**
- Function size: 44 bytes
- Build verification: `ninja` completed successfully.

## Plausibility rationale
- `OSRegisterVersion` is a thin reporting wrapper used to print a version string.
- Directly forwarding the version string to `OSReport` is source-plausible for SDK-style code and keeps intent clear.
- No control-flow or data-flow complexity was introduced.

## Technical details
- Objdiff still shows remaining deltas in `OSRegisterVersion`, but the call shape now aligns better than before and improves fuzzy score.
- Change is isolated to one call-site expression with no collateral edits.
