### PR TITLE
pppConstrainCameraForLoc: improve destruct call-site match

### DIFF
--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -13,8 +13,8 @@ extern int DAT_8032ed70;
 
 // Function signatures from Ghidra decomp
 extern "C" int GetModelPtr__FP8CGObject(CGObject*);
-void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, pppConstrainCameraForLoc*, int, float*,
-                                                 float*, float*, float*, float*);
+extern "C" void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, pppConstrainCameraForLoc*, int,
+                                                            float*, float*, float*, float*, float*);
 
 /*
  * --INFO--
@@ -149,15 +149,17 @@ void pppDestructConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCameraF
 	int modelPtr;
 
 	if (DAT_8032ed70 == 0) {
-		float* value = (float*)((char*)constrainCameraForLoc + 0x80 + data->m_serializedDataOffsets[2]);
+		value = (float*)((char*)constrainCameraForLoc + 0x80 + data->m_serializedDataOffsets[2]);
 		CGObject* obj = *(CGObject**)((char*)pppMngStPtr + 0xd8);
-		int modelPtr = GetModelPtr__FP8CGObject(obj);
+		modelPtr = GetModelPtr__FP8CGObject(obj);
 		*(float**)(modelPtr + 0xe4) = value;
 		*(pppConstrainCameraForLocParams**)(modelPtr + 0xe8) = params;
 		*(void**)(modelPtr + 0xec) = (void*)CC_BeforeCalcMatrixCallback;
+		float dataValIndex = params->m_dataValIndex;
+		int graphId = params->m_graphId;
 
-		CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(params->m_dataValIndex, constrainCameraForLoc,
-		                                             params->m_graphId, value, value + 1, value + 2,
+		CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(dataValIndex, constrainCameraForLoc,
+		                                             graphId, value, value + 1, value + 2,
 		                                             &params->m_initWork, &params->m_stepValue);
 	}
 }


### PR DESCRIPTION
## Summary
- Updated `src/pppConstrainCameraForLoc.cpp` to improve generated code in `pppDestructConstrainCameraForLoc`.
- Declared `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf` with `extern "C"` linkage.
- Removed local shadowing in `pppDestructConstrainCameraForLoc` and introduced explicit local temporaries for `m_dataValIndex` and `m_graphId` before the `CalcGraphValue` call.

## Functions Improved
- Unit: `main/pppConstrainCameraForLoc`
- Symbol: `pppDestructConstrainCameraForLoc`
  - Before: `94.48718%`
  - After: `94.61539%`

## Match Evidence
- Verified via:
  - `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraForLoc -o - pppDestructConstrainCameraForLoc`
- At the call site near address `0x7c` in-function (`instruction 124` in objdiff output), the call changed from `DIFF_ARG_MISMATCH` to `OK` for `bl CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf`.

## Plausibility Rationale
- Changes are source-plausible cleanup:
  - Proper C linkage declaration for a known external symbol.
  - Removal of local variable shadowing.
  - Explicit temporary locals for existing parameter fields without changing behavior.
- This aligns better with expected original coding style while producing measurable assembly alignment improvement.

## Technical Notes
- Build passes with `ninja`.
- Improvement is concentrated at the `CalcGraphValue` call setup in `pppDestructConstrainCameraForLoc`.
