### PR TITLE
pppConstrainCameraForLoc: correct CalcGraphValue prototype/call order

### DIFF
--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -13,8 +13,8 @@ extern int DAT_8032ed70;
 
 // Function signatures from Ghidra decomp
 extern "C" int GetModelPtr__FP8CGObject(CGObject*);
-extern "C" void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, pppConstrainCameraForLoc*, int,
-                                                            float*, float*, float*, float*, float*);
+extern "C" void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(pppConstrainCameraForLoc*, int, float*,
+                                                             float*, float*, float, float*, float*);
 
 /*
  * --INFO--
@@ -155,11 +155,9 @@ void pppDestructConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCameraF
 		*(float**)(modelPtr + 0xe4) = value;
 		*(pppConstrainCameraForLocParams**)(modelPtr + 0xe8) = params;
 		*(void**)(modelPtr + 0xec) = (void*)CC_BeforeCalcMatrixCallback;
-		float dataValIndex = params->m_dataValIndex;
-		int graphId = params->m_graphId;
 
-		CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(dataValIndex, constrainCameraForLoc,
-		                                             graphId, value, value + 1, value + 2,
+		CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(constrainCameraForLoc, params->m_graphId, value,
+		                                             value + 1, value + 2, params->m_dataValIndex,
 		                                             &params->m_initWork, &params->m_stepValue);
 	}
 }


### PR DESCRIPTION
## Summary
- Corrected `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf` declaration to match Metrowerks mangling order.
- Updated the call in `pppDestructConstrainCameraForLoc` to pass arguments in that decoded order.
- Removed no-op local temporaries that only mirrored `params` fields.

## Functions improved
- Unit: `main/pppConstrainCameraForLoc`
- Symbol: `pppDestructConstrainCameraForLoc` (PAL 0x80167DD4, 156b)

## Match evidence
- `pppDestructConstrainCameraForLoc`: **94.61539% -> 99.74359%**
- Remaining differences are only 2 `DIFF_ARG_MISMATCH` entries from SDA21 relocation symbol naming on globals.
- Build remains green with `ninja`.

## Plausibility rationale
- The change follows the encoded signature from the known Metrowerks symbol name (`FP11_pppPObjectlRfRfRffRfRf`), which indicates object pointer + long + float refs + float ordering.
- Using the decoded ABI-consistent parameter order is more plausible as original source than keeping a mismatched prototype and compensating call shape.

## Technical details
- Old declaration had `float` as the first argument, which forced a non-canonical C signature versus the mangled symbol.
- New declaration/call align integer register and FP argument placement with the target call sequence in objdiff, removing the call-site mismatch noise and improving codegen alignment.
