### PR TITLE
gobjwork: implement caravan load/event/gil helpers

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -94,7 +94,7 @@ public:
     void DeleteItemIdx(int, int);
     void DeleteItem(int, int);
     void AddTmpArtifact(int, int*);
-    void CanAddGil(int);
+    int CanAddGil(int);
     void AddGil(int);
     void GetFoodRank(int);
     void SearchRomLetterWork(CRomLetterWork**, int);

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/gobjwork.h"
 #include "ffcc/p_game.h"
+#include <string.h>
 
 /*
  * --INFO--
@@ -83,22 +84,36 @@ void CCaravanWork::LoadInit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a2994
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCaravanWork::ClearEvtWork()
 {
-	// TODO
+	memset(m_evtWorkArr, 0, sizeof(m_evtWorkArr));
+	memset(m_evtWordArr, 0, sizeof(m_evtWordArr));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a293c
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCaravanWork::LoadFinished()
 {
-	// TODO
+	if (m_shopState == 0) {
+		return;
+	}
+
+	m_baseDataIndex = (m_id / 100) - 1;
+	m_romWorkPtr = reinterpret_cast<unsigned short*>(Game.game.unkCFlatData0[0] + (m_baseDataIndex * 0x1D0) + 0x10);
 }
 
 /*
@@ -355,12 +370,17 @@ void CCaravanWork::AddTmpArtifact(int, int*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a1bb0
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CCaravanWork::CanAddGil(int)
+int CCaravanWork::CanAddGil(int gilAmount)
 {
-	// TODO
+	int totalGil = m_gil + gilAmount;
+	return (totalGil >= 0 && totalGil < 100000000);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three `CCaravanWork` helpers in `gobjwork` from the PAL Ghidra reference and corrected one method signature to match behavior:
- Implemented `LoadFinished__12CCaravanWorkFv`
- Implemented `ClearEvtWork__12CCaravanWorkFv`
- Implemented `CanAddGil__12CCaravanWorkFi`
- Updated declaration/definition of `CanAddGil` from `void` to `int`
- Added PAL address/size metadata blocks for the updated functions

## Functions improved
Unit: `main/gobjwork`
- `LoadFinished__12CCaravanWorkFv`: **4.5454545% -> 99.954544%**
- `ClearEvtWork__12CCaravanWorkFv`: **5.5555553% -> 99.94444%**
- `CanAddGil__12CCaravanWorkFi`: **7.142857% -> 78.14286%**

## Match evidence
- Unit fuzzy match (`main/gobjwork`): **2.3528445% -> 3.3370302%**
- Rebuilt and regenerated report with `ninja build/GCCP01/report.json`
- Verified project still builds with `ninja`

## Plausibility rationale
These edits are source-plausible game logic rather than compiler-coaxing:
- `LoadFinished` now performs the expected post-load base-data pointer setup when shop state is active
- `ClearEvtWork` zeroes event arrays using straightforward `memset` calls
- `CanAddGil` now returns a bounded-range validity check for gil totals

## Technical details
- `LoadFinished` computes `m_baseDataIndex` from `m_id`, then derives `m_romWorkPtr` from `Game.game.unkCFlatData0[0]` with the expected stride/offset
- `ClearEvtWork` clears `m_evtWorkArr` and `m_evtWordArr` using array-size based lengths
- `CanAddGil` returns whether `m_gil + gilAmount` is within `[0, 100000000)`
