### PR TITLE
pppGetRotMatrixXZY: correct rotation composition order

### DIFF
--- a/src/pppGetRotMatrixXZY.cpp
+++ b/src/pppGetRotMatrixXZY.cpp
@@ -12,14 +12,14 @@
  */
 void pppGetRotMatrixXZY(pppFMATRIX& out, pppIVECTOR4* angle)
 {
-	pppFMATRIX mZ;
 	pppFMATRIX mY;
-	pppFMATRIX yz;
+	pppFMATRIX mZ;
+	pppFMATRIX zy;
 	pppFMATRIX mX;
 
-	pppGetRotMatrixZ(mZ, angle->z);
 	pppGetRotMatrixY(mY, angle->y);
-	PSMTXConcat(mY.value, mZ.value, yz.value);
+	pppGetRotMatrixZ(mZ, angle->z);
+	PSMTXConcat(mZ.value, mY.value, zy.value);
 	pppGetRotMatrixX(mX, angle->x);
-	PSMTXConcat(mX.value, yz.value, out.value);
+	PSMTXConcat(mX.value, zy.value, out.value);
 }


### PR DESCRIPTION
## Summary
- Corrected `pppGetRotMatrixXZY` rotation composition order to match XZY semantics.
- Reordered temporary matrices and concatenation from `Y * Z` intermediate to `Z * Y` intermediate, then applied `X`.
- No behavior-unrelated edits were included.

## Functions improved
- Unit: `main/pppGetRotMatrixXZY`
- Symbol: `pppGetRotMatrixXZY__FR10pppFMATRIXP11pppIVECTOR4`

## Match evidence
- Before: `93.666664%` (5 instruction diffs)
- After: `94.0%` (3 instruction diffs)
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/pppGetRotMatrixXZY --format json -o ... pppGetRotMatrixXZY__FR10pppFMATRIXP11pppIVECTOR4`

## Assembly analysis
- Eliminated two call-argument mismatches:
  - `bl pppGetRotMatrixY__FR10pppFMATRIXl :: DIFF_ARG_MISMATCH`
  - `bl pppGetRotMatrixZ__FR10pppFMATRIXl :: DIFF_ARG_MISMATCH`
- Remaining 3 diffs are angle-load replacements (`lwz`) shared across the `pppGetRotMatrix*` family and likely tied to common type/layout reconstruction work.

## Plausibility rationale
- For an `XZY` routine, composing `X * Z * Y` is source-plausible and consistent with the naming pattern used by sibling rotation-order functions.
- The previous code path matched `XYZ` ordering and was inconsistent with the function’s name and surrounding family patterns.
