### PR TITLE
main/cflat_data: improve dtor_800980B4 decomp match

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -73,62 +73,61 @@ extern "C" CFlatData* dtor_800980B4(CFlatData* flatData, short shouldDelete)
 
 	FlatDataLayout* self;
 	FlatDataLayout* layout;
+	int i;
 
-	if (flatData == nullptr)
+	if (flatData != nullptr)
 	{
-		return flatData;
-	}
+		layout = (FlatDataLayout*)flatData;
+		self = layout;
+		for (i = 0; i < layout->m_dataCount; i++)
+		{
+			if (self->m_data[0].m_data != nullptr)
+			{
+				operator delete(self->m_data[0].m_data);
+				self->m_data[0].m_data = nullptr;
+			}
+			if (self->m_data[0].m_strings != nullptr)
+			{
+				operator delete(self->m_data[0].m_strings);
+				self->m_data[0].m_strings = (char**)nullptr;
+			}
+			if (self->m_data[0].m_stringBuf != nullptr)
+			{
+				operator delete(self->m_data[0].m_stringBuf);
+				self->m_data[0].m_stringBuf = (char*)nullptr;
+			}
+			self = (FlatDataLayout*)&self->m_data[0].m_stringBuf;
+		}
+		layout->m_dataCount = 0;
 
-	layout = (FlatDataLayout*)flatData;
-	self = layout;
-	for (int i = 0; i < layout->m_dataCount; i++)
-	{
-		if (self->m_data[0].m_data != nullptr)
+		self = layout;
+		for (i = 0; i < layout->m_tableCount; i++)
 		{
-			operator delete(self->m_data[0].m_data);
-			self->m_data[0].m_data = nullptr;
+			if (self->m_tabl[0].m_strings != nullptr)
+			{
+				operator delete(self->m_tabl[0].m_strings);
+				self->m_tabl[0].m_strings = (char**)nullptr;
+			}
+			if (self->m_tabl[0].m_stringBuf != nullptr)
+			{
+				operator delete(self->m_tabl[0].m_stringBuf);
+				self->m_tabl[0].m_stringBuf = (char*)nullptr;
+			}
+			self = (FlatDataLayout*)&self->m_data[0].m_numStrings;
 		}
-		if (self->m_data[0].m_strings != nullptr)
-		{
-			operator delete(self->m_data[0].m_strings);
-			self->m_data[0].m_strings = (char**)nullptr;
-		}
-		if (self->m_data[0].m_stringBuf != nullptr)
-		{
-			operator delete(self->m_data[0].m_stringBuf);
-			self->m_data[0].m_stringBuf = (char*)nullptr;
-		}
-		self = (FlatDataLayout*)&self->m_data[0].m_stringBuf;
-	}
-	layout->m_dataCount = 0;
+		layout->m_tableCount = 0;
 
-	self = layout;
-	for (int i = 0; i < layout->m_tableCount; i++)
-	{
-		if (self->m_tabl[0].m_strings != nullptr)
+		if (layout->m_mesBuffer != nullptr)
 		{
-			operator delete(self->m_tabl[0].m_strings);
-			self->m_tabl[0].m_strings = (char**)nullptr;
+			operator delete(layout->m_mesBuffer);
+			layout->m_mesBuffer = (char*)nullptr;
 		}
-		if (self->m_tabl[0].m_stringBuf != nullptr)
+		layout->m_mesCount = 0;
+
+		if (0 < shouldDelete)
 		{
-			operator delete(self->m_tabl[0].m_stringBuf);
-			self->m_tabl[0].m_stringBuf = (char*)nullptr;
+			operator delete(flatData);
 		}
-		self = (FlatDataLayout*)&self->m_data[0].m_numStrings;
-	}
-	layout->m_tableCount = 0;
-
-	if (layout->m_mesBuffer != nullptr)
-	{
-		operator delete(layout->m_mesBuffer);
-		layout->m_mesBuffer = (char*)nullptr;
-	}
-	layout->m_mesCount = 0;
-
-	if (shouldDelete > 0)
-	{
-		operator delete(flatData);
 	}
 	return flatData;
 }


### PR DESCRIPTION
## Summary
Restructured `dtor_800980B4` in `src/cflat_data.cpp` to use a tighter cleanup/control-flow shape while preserving behavior.

Key changes:
- Removed redundant early-return + duplicate base pointer state.
- Consolidated cleanup under `if (flatData != nullptr)`.
- Kept pointer-stepping loops for `m_data` and `m_tabl` entries, but simplified local variable usage/order.
- Used `if (0 < shouldDelete)` and retained delete/null-reset semantics.

## Functions Improved
- Unit: `main/cflat_data`
- Symbol: `dtor_800980B4`

## Match Evidence
Objdiff command:
```sh
build/tools/objdiff-cli diff -p . -u main/cflat_data -o - dtor_800980B4
```

Before:
- `dtor_800980B4`: `88.08219%`, size `304`

After:
- `dtor_800980B4`: `93.21918%`, size `300`

Notes:
- `Create__9CFlatDataFPv` remained unchanged at `56.211727%` (size `1272`), so this PR is isolated to destructor progress.

## Plausibility Rationale
This change reflects plausible original source cleanup style:
- Straightforward null-guarded destructor body.
- Natural per-entry free-and-null loops.
- No contrived temporaries or compiler-only tricks.
- No hardcoded offset hacks beyond existing structure-based stepping already in current decomp style.

## Technical Details
The main gain came from aligning destructor control flow and local-state usage with expected Metrowerks output patterns (fewer unnecessary state transitions), reducing generated size by 4 bytes and increasing instruction alignment in objdiff.
