### PR TITLE
cflat_r2system: add missing SetUseDOF/SetCharaAllocStage/Close wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -517,6 +517,48 @@ extern "C" void SetDefaultGroup__7CMemoryFi(void* memory, int group)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B93DC
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetCharaAllocStage__9CCharaPcsFi(void* charaPcs, int stage)
+{
+    *(int*)((char*)charaPcs + 0xE4) = stage;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B93E4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetUseDOF__11CGraphicPcsFi(void* graphicPcs, int enabled)
+{
+    *(int*)((char*)graphicPcs + 0xC0) = enabled;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B93EC
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void Close__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
+{
+    File.Close(fileHandle);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added three missing PAL-exported wrapper/setter functions in `src/cflat_r2system.cpp`.
- Implemented minimal source-plausible bodies that match existing wrapper style in this unit.
- Added full PAL address/size INFO blocks for each function.

## Functions Improved
- `SetCharaAllocStage__9CCharaPcsFi` (`0x800B93DC`, 8b)
- `SetUseDOF__11CGraphicPcsFi` (`0x800B93E4`, 8b)
- `Close__Q25CFile7CHandleFv` (`0x800B93EC`, 44b)

## Match Evidence
- Per-function (objdiff):
  - `SetCharaAllocStage__9CCharaPcsFi`: `0.0% -> 100.0%`
  - `SetUseDOF__11CGraphicPcsFi`: `0.0% -> 100.0%`
  - `Close__Q25CFile7CHandleFv`: `0.0% -> 100.0%`
- Unit context (`main/cflat_r2system`):
  - Selector baseline: `14/84` fully matched functions, `2.5%` unit match
  - After rebuild/report: `17/84` fully matched functions

## Plausibility Rationale
- These are thin API glue functions that forward directly to existing fields/system services and are idiomatic for this codebase.
- Implementations avoid contrived control-flow and use the same low-level offset style already used throughout `cflat_r2system.cpp`.

## Technical Notes
- Verified clean build with `ninja`.
- Verified each symbol with `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - <symbol>` and confirmed `100.0%` match.
