### PR TITLE
main/RedSound: implement sound mode/reverb wrappers

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -250,32 +250,44 @@ void CRedSound::DMACheck(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cceb4
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetSoundMode(int)
+void CRedSound::SetSoundMode(int mode)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetSoundMode(mode);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccee0
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CRedSound::GetSoundMode()
 {
-	// TODO
+	CRedDriver_8032f4c0.GetSoundMode();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccf04
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetReverb(int, int)
+void CRedSound::SetReverb(int bank, int kind)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetReverb(bank, kind);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three previously stubbed CRedSound wrappers in src/RedSound/RedSound.cpp:
  - SetSoundMode__9CRedSoundFi
  - GetSoundMode__9CRedSoundFv
  - SetReverb__9CRedSoundFii
- Each now forwards directly to the corresponding CRedDriver method.
- Filled in PAL address/size metadata blocks for these functions.

## Functions Improved
- Unit: main/RedSound/RedSound
- Symbols:
  - SetSoundMode__9CRedSoundFi
  - GetSoundMode__9CRedSoundFv
  - SetReverb__9CRedSoundFii

## Match Evidence
objdiff-cli diff -p . -u main/RedSound/RedSound <symbol> before/after:
- SetSoundMode__9CRedSoundFi: 9.09% -> 80.82%
- GetSoundMode__9CRedSoundFv: 11.11% -> 99.44%
- SetReverb__9CRedSoundFii: 7.69% -> 68.38%

Additional project progress evidence from ninja:
- Code bytes matched increased from 199256 to 199292
- Functions matched increased from 1471 to 1472

## Plausibility Rationale
These are straightforward API pass-through wrappers from CRedSound to CRedDriver, consistent with nearby code in the same file (for example SetReverbDepth and StreamPause).
The changes replace placeholder TODO stubs with natural source-level behavior, without compiler-coaxing constructs.

## Technical Details
- Ghidra references used:
  - 801cceb4_SetSoundMode__9CRedSoundFi.c
  - 801ccee0_GetSoundMode__9CRedSoundFv.c
  - 801ccf04_SetReverb__9CRedSoundFii.c
- Assembly alignment improved from single-instruction stubs (blr) to expected call-wrapper prolog/call/epilog structure in all three functions.
