### PR TITLE
main/pppParHitSphMat: hardcode debug sphere color

### DIFF
--- a/src/pppParHitSphMat.cpp
+++ b/src/pppParHitSphMat.cpp
@@ -57,7 +57,10 @@ void pppParHitSphMat(void* param1, void* param2, void* param3)
     pppHitCylinderSendSystem((_pppMngSt*)pppMngSt, &local_94, &local_88, radius, hitLength);
 
     if ((*(u32*)(CFlat + 0x129c) & 0x200000) != 0) {
-        local_7c = *(_GXColor*)(step + 0xC);
+        local_7c.r = 0xFF;
+        local_7c.g = 0xFF;
+        local_7c.b = 0xFF;
+        local_7c.a = 0xFF;
         PSMTXIdentity(MStack_78);
         PSMTXIdentity(local_48);
         local_48[0][0] = radius;


### PR DESCRIPTION
## Summary
- Updated `pppParHitSphMat` debug draw color initialization to use explicit white RGBA components (`0xFF, 0xFF, 0xFF, 0xFF`) instead of reading bytes from step data.
- Kept behavior and control flow otherwise unchanged.

## Functions Improved
- Unit: `main/pppParHitSphMat`
- Function: `pppParHitSphMat` (436 bytes)

## Match Evidence
- `pppParHitSphMat` fuzzy match: **81.414705% -> 85.348625%** (`+3.933920`)
- Verified with rebuilt `build/GCCP01/report.json` after `ninja`.

## Plausibility Rationale
- The function section is guarded by a debug draw flag and target assembly initializes the color as immediate `0xFF` bytes.
- Using a fixed white color for debug sphere rendering is source-plausible and avoids compiler-coaxing patterns.

## Technical Notes
- This change aligns the color setup instruction pattern with the target object by removing step-data color loads in this block.
- Full build verification passed (`ninja`).
