### PR TITLE
cflat_runtime2: implement stage accessors and particle work setters

### DIFF
--- a/include/ffcc/cflat_runtime2.h
+++ b/include/ffcc/cflat_runtime2.h
@@ -2,6 +2,7 @@
 #define _FFCC_CFLAT_RUNTIME2_H_
 
 #include "ffcc/cflat_runtime.h"
+#include "ffcc/memory.h"
 #include "ffcc/p_chara.h"
 
 #include <dolphin/gx.h>
@@ -24,8 +25,8 @@ class CFlatRuntime2
 	CFlatRuntime2();
 	~CFlatRuntime2();
 
-	void getStage();
-	void getDebugStage();
+	CMemory::CStage* getStage();
+	CMemory::CStage* getDebugStage();
 
 	void onNewObject(CFlatRuntime::CObject*);
 	void onDeleteObject(CFlatRuntime::CObject*);

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1,5 +1,102 @@
 #include "ffcc/cflat_runtime2.h"
 #include "ffcc/baseobj.h"
+#include "ffcc/p_game.h"
+
+namespace {
+
+typedef unsigned char u8;
+
+static inline float& ParticleWorkSpeed(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x16F0);
+}
+
+static inline float* &ParticleWorkScalePtr(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float**>(reinterpret_cast<u8*>(runtime) + 0x16D4);
+}
+
+static inline float& ParticleWorkScaleX(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1758);
+}
+
+static inline float& ParticleWorkScaleY(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x175C);
+}
+
+static inline float& ParticleWorkScaleZ(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1760);
+}
+
+static inline float* &ParticleWorkTargetPtr(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float**>(reinterpret_cast<u8*>(runtime) + 0x16D8);
+}
+
+static inline float& ParticleWorkTargetX(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1764);
+}
+
+static inline float& ParticleWorkTargetY(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1768);
+}
+
+static inline float& ParticleWorkTargetZ(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x176C);
+}
+
+static inline CFlatRuntime::CObject*& ParticleWorkBind(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<CFlatRuntime::CObject**>(reinterpret_cast<u8*>(runtime) + 0x16E0);
+}
+
+static inline int& ParticleWorkColor0(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(runtime) + 0x16E8);
+}
+
+static inline int& ParticleWorkColor1(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(runtime) + 0x16EC);
+}
+
+static inline float& ParticleWorkColorLerp(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x16F4);
+}
+
+static inline int& ParticleWorkSeNo(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(runtime) + 0x16FC);
+}
+
+static inline u8& ParticleWorkSeKind(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<u8*>(reinterpret_cast<u8*>(runtime) + 0x1701);
+}
+
+static inline int& ParticleWorkSeParam(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(runtime) + 0x1704);
+}
+
+static inline int& ParticleWorkParamNo(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(runtime) + 0x1710);
+}
+
+static inline short& ParticleWorkParamId(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<short*>(reinterpret_cast<u8*>(runtime) + 0x1714);
+}
+
+} // namespace
 
 /*
  * --INFO--
@@ -46,22 +143,30 @@ CFlatRuntime2::CParticleWork::CParticleWork()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006E09C
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::getStage()
+CMemory::CStage* CFlatRuntime2::getStage()
 {
-	// TODO
+	return Game.game.m_mainStage;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006E088
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::getDebugStage()
+CMemory::CStage* CFlatRuntime2::getDebugStage()
 {
-	// TODO
+	return Game.game.m_debugStage;
 }
 
 /*
@@ -376,12 +481,19 @@ void CFlatRuntime2::SetParticleWorkPos(Vec&, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A2D8
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkTarget(Vec&)
+void CFlatRuntime2::SetParticleWorkTarget(Vec& vec)
 {
-	// TODO
+	ParticleWorkTargetX(this) = vec.x;
+	ParticleWorkTargetY(this) = vec.y;
+	ParticleWorkTargetZ(this) = vec.z;
+	ParticleWorkTargetPtr(this) = &ParticleWorkTargetX(this);
 }
 
 /*
@@ -396,22 +508,35 @@ void CFlatRuntime2::SetParticleWorkVector(float, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A1F8
+ * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkScale(float)
+void CFlatRuntime2::SetParticleWorkScale(float scale)
 {
-	// TODO
+	ParticleWorkScaleZ(this) = scale;
+	ParticleWorkScaleY(this) = scale;
+	ParticleWorkScaleX(this) = scale;
+	ParticleWorkScalePtr(this) = &ParticleWorkScaleX(this);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A1E8
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkCol(int, int, float)
+void CFlatRuntime2::SetParticleWorkCol(int color0, int color1, float lerp)
 {
-	// TODO
+	ParticleWorkColor0(this) = color0;
+	ParticleWorkColor1(this) = color1;
+	ParticleWorkColorLerp(this) = lerp;
 }
 
 /*
@@ -426,42 +551,65 @@ void CFlatRuntime2::SetParticleWorkTrace(CFlatRuntime::CObject*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A1D8
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkSpeed(float)
+void CFlatRuntime2::SetParticleWorkSpeed(float speed)
 {
-	// TODO
+	ParticleWorkSpeed(this) = speed;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A1D0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkBind(CFlatRuntime::CObject*)
+void CFlatRuntime2::SetParticleWorkBind(CFlatRuntime::CObject* object)
 {
-	// TODO
+	ParticleWorkBind(this) = object;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A1B0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkParam(int, CFlatRuntime::CObject*)
+void CFlatRuntime2::SetParticleWorkParam(int paramNo, CFlatRuntime::CObject* object)
 {
-	// TODO
+	ParticleWorkParamNo(this) = paramNo;
+	if (object == 0) {
+		ParticleWorkParamId(this) = 0;
+	} else {
+		ParticleWorkParamId(this) = *reinterpret_cast<short*>(reinterpret_cast<u8*>(object) + 0x30);
+	}
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A1A0
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkSe(int, int, int)
+void CFlatRuntime2::SetParticleWorkSe(int seNo, int seKind, int seParam)
 {
-	// TODO
+	ParticleWorkSeNo(this) = seNo;
+	ParticleWorkSeKind(this) = static_cast<u8>(seKind);
+	ParticleWorkSeParam(this) = seParam;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `CFlatRuntime2::getStage` and `getDebugStage` signatures to return `CMemory::CStage*` and implemented both to return `Game.game` stage pointers.
- Implemented a first set of particle-work mutators in `cflat_runtime2.cpp` using runtime field offsets already used elsewhere in this decomp style:
  - `SetParticleWorkBind`
  - `SetParticleWorkSpeed`
  - `SetParticleWorkScale`
  - `SetParticleWorkCol`
  - `SetParticleWorkParam`
  - `SetParticleWorkSe`
  - `SetParticleWorkTarget`
- Added PAL address/size metadata blocks for the implemented functions.

## Functions Improved
Unit: `main/cflat_runtime2`

Per-symbol objdiff fuzzy match improvements:
- `SetParticleWorkBind__13CFlatRuntime2FPQ212CFlatRuntime7CObject`: `50.0 -> 100.0`
- `SetParticleWorkCol__13CFlatRuntime2Fiif`: `25.0 -> 100.0`
- `SetParticleWorkParam__13CFlatRuntime2FiPQ212CFlatRuntime7CObject`: `12.5 -> 36.25`
- `SetParticleWorkScale__13CFlatRuntime2Ff`: `16.666666 -> 98.333336`
- `SetParticleWorkSe__13CFlatRuntime2Fiii`: `25.0 -> 100.0`
- `SetParticleWorkSpeed__13CFlatRuntime2Ff`: `50.0 -> 100.0`
- `SetParticleWorkTarget__13CFlatRuntime2FR3Vec`: `11.111111 -> 98.888885`
- `getDebugStage__13CFlatRuntime2Fv`: `20.0 -> 95.8`
- `getStage__13CFlatRuntime2Fv`: `20.0 -> 95.8`

Overall progress impact from `ninja`:
- Total matched code bytes: `199300 -> 199348` (+48)
- Matched functions: `1472 -> 1476` (+4)

Current `main/cflat_runtime2` report snapshot:
- Fuzzy match: `1.9421762%`
- Matched code: `52 / 20476`
- Matched functions: `5 / 64`

## Match Evidence
- Built successfully with `ninja` after edits.
- Used `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - getStage__13CFlatRuntime2Fv` and extracted before/after symbol percentages from the JSON output.
- The improvement is not just formatting; several target functions now reach or approach full symbol-level matches.

## Plausibility Rationale
- Changes are source-plausible field and pointer assignments matching observed runtime layout usage in existing code (`reinterpret_cast` + known offsets in this module).
- No synthetic control-flow tricks or compiler-coaxing temporaries were introduced.
- Implementations reflect direct behavior seen in decomp references: simple setters/accessors for runtime particle state and stage pointers.
