### PR TITLE
gx/GXTexture: improve __SetSURegs wrap-bias evaluation order

### DIFF
--- a/src/gx/GXTexture.c
+++ b/src/gx/GXTexture.c
@@ -1153,17 +1153,20 @@ void GXSetTexCoordBias(GXTexCoordID coord, u8 s_enable, u8 t_enable) {
 static void __SetSURegs(int tmap, int tcoord) {
     u32 image0;
     u32 mode0;
-    u32 bias;
+    u32 bias0;
+    u32 bias1;
 
     image0 = __GXData->tImage0[tmap];
     __GXData->suTs0[tcoord] = (__GXData->suTs0[tcoord] & 0xFFFF0000) | (image0 & 0x3FF);
     __GXData->suTs1[tcoord] = (__GXData->suTs1[tcoord] & 0xFFFF0000) | ((image0 >> 10) & 0x3FF);
 
     mode0 = __GXData->tMode0[tmap];
-    bias = __cntlzw(1 - (mode0 & 3));
-    __GXData->suTs0[tcoord] = (__GXData->suTs0[tcoord] & 0xFFFEFFFF) | ((bias & 0x1FE0) << 11);
-    bias = __cntlzw(1 - ((mode0 >> 2) & 3));
-    __GXData->suTs1[tcoord] = (__GXData->suTs1[tcoord] & 0xFFFEFFFF) | ((bias & 0x1FE0) << 11);
+    bias1 = 1 - ((mode0 >> 2) & 3);
+    bias0 = 1 - (mode0 & 3);
+    bias0 = __cntlzw(bias0);
+    __GXData->suTs0[tcoord] = (__GXData->suTs0[tcoord] & 0xFFFEFFFF) | ((bias0 & 0x1FE0) << 11);
+    bias1 = __cntlzw(bias1);
+    __GXData->suTs1[tcoord] = (__GXData->suTs1[tcoord] & 0xFFFEFFFF) | ((bias1 & 0x1FE0) << 11);
     GX_WRITE_RAS_REG(__GXData->suTs0[tcoord]);
     GX_WRITE_RAS_REG(__GXData->suTs1[tcoord]);
     __GXData->bpSentNot = 0;


### PR DESCRIPTION
## Summary
Refined `__SetSURegs` in `src/gx/GXTexture.c` to better match original code generation by reordering wrap-bias computations.

Changes made:
- Split `bias` into `bias0`/`bias1` temporaries.
- Compute both `1 - wrap` intermediate values first.
- Apply `cntlzw` in the same sequence reflected by the target assembly flow.

## Functions improved
- Unit: `main/gx/GXTexture`
- Function: `__SetSURegs` (184 bytes)
- Fuzzy match: **34.434784% -> 36.173912%**

## Match evidence
- `ninja` rebuild succeeded and regenerated `build/GCCP01/report.json`.
- `jq` extraction from `report.json` shows `__SetSURegs` increased by +1.739128 points.
- Assembly-level check (`powerpc-eabi-objdump`) now aligns more closely in the bias calculation block:
  - both wrap-mode deltas are formed before the first `cntlzw`
  - `cntlzw` usage and dependent bitfield writes are closer to target instruction ordering

## Plausibility rationale
This is a source-plausible cleanup: it does not introduce contrived behavior, magic constants, or unnatural control flow. It simply makes intermediate wrap-bias values explicit and ordered in a way a real SDK author could naturally write while improving codegen alignment.

## Technical details
- File touched: `src/gx/GXTexture.c`
- Localized function-only edit (`__SetSURegs`) with no interface/ABI changes.
- Build/progress verification performed via `ninja` in PAL (`GCCP01`) configuration.
