### PR TITLE
Improve GXSetTevKColor match in GXTev

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -254,13 +254,35 @@ void GXSetTevColorS10(GXTevRegID id, GXColorS10 color) {
 }
 
 void GXSetTevKColor(GXTevKColorID id, GXColor color) {
+    u8* c;
+    u8 a;
+    u8 r;
+    u8 g;
+    u8 b;
+    u32 id2;
+    u32 reg;
     u32 regRA;
     u32 regBG;
 
     CHECK_GXBEGIN(833, "GXSetTevKColor");
+    c = (u8*)&color;
+    b = c[2];
+    r = c[0];
+    a = c[3];
+    g = c[1];
+    id2 = id * 2;
 
-    regRA = ((0xE0 + id * 2) << 24) | color.r | (color.a << 12) | (8 << 20);
-    regBG = ((0xE1 + id * 2) << 24) | color.b | (color.g << 12) | (8 << 20);
+    regRA = r;
+    SOME_SET_REG_MACRO(regRA, 8, 24, id2 + 0xE0);
+    reg = regRA;
+    SOME_SET_REG_MACRO(reg, 8, 12, a);
+    regRA = reg | (8 << 20);
+
+    regBG = b;
+    SOME_SET_REG_MACRO(regBG, 8, 24, id2 + 0xE1);
+    reg = regBG;
+    SOME_SET_REG_MACRO(reg, 8, 12, g);
+    regBG = reg | (8 << 20);
 
     GX_WRITE_RAS_REG(regRA);
     GX_WRITE_RAS_REG(regBG);


### PR DESCRIPTION
## Summary
- Reworked `GXSetTevKColor` register assembly in `src/gx/GXTev.c` to build TEV BP words through explicit byte extraction and field insertion steps.
- Kept behavior identical while improving code generation alignment with target assembly.

## Functions Improved
- Unit: `main/gx/GXTev`
- Function: `GXSetTevKColor`
  - Before: `56.517242%`
  - After: `66.620690%`
  - Delta: `+10.103448%`

## Match Evidence
- Full unit `.text` match:
  - Before: `82.926735%`
  - After: `83.506930%`
  - Delta: `+0.580195%`
- Symbol-level diff comparison shows only `GXSetTevKColor` changed match score in this unit.

## Plausibility Rationale
- The change is source-plausible for low-level GX register setup code: it uses explicit color-byte extraction and deterministic bitfield assembly before BP writes.
- No contrived control flow or artificial compiler coaxing patterns were introduced outside normal register composition logic.

## Technical Details
- Converted direct packed-expression construction into staged composition:
  - load byte channels from `GXColor`
  - apply register-id field insertion
  - apply channel field insertion
  - set K-color mode bits and emit BP writes
- Verified by rebuilding (`ninja`) and running objdiff in full-unit mode:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXTev -o -`
