### PR TITLE
pppRandUpFV: improve near-match pointer/expr structure

### DIFF
--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -47,7 +47,7 @@ void pppRandUpFV(void* param1, void* param2, void* param3)
     if (state == 0) {
         f32 value = RandF__5CMathFv(math);
         if (in->field18 != 0) {
-            value = (value + RandF__5CMathFv(math)) * lbl_80330000;
+            value = lbl_80330000 * (value + RandF__5CMathFv(math));
         }
 
         valuePtr = (f32*)(base + *out->fieldC + 0x80);
@@ -59,13 +59,7 @@ void pppRandUpFV(void* param1, void* param2, void* param3)
         valuePtr = (f32*)(base + *out->fieldC + 0x80);
     }
 
-    f32* target;
-    if (in->field4 == -1) {
-        target = lbl_801EADC8;
-    } else {
-        target = (f32*)(base + in->field4 + 0x80);
-    }
-
+    f32* target = (in->field4 == -1) ? lbl_801EADC8 : (f32*)(base + in->field4 + 0x80);
     f32 scale = *valuePtr;
     f32 value = in->field8 * scale;
     target[0] = target[0] + value;


### PR DESCRIPTION
## Summary
- Reshaped two source-level expressions in `pppRandUpFV` to better match Metrowerks register allocation without changing behavior.
- Switched the random-scale multiply to `lbl_80330000 * (...)` form.
- Collapsed `target` pointer selection into a single conditional initializer.

## Functions Improved
- Unit: `main/pppRandUpFV`
- Symbol: `pppRandUpFV`

## Match Evidence
- `pppRandUpFV`: **97.86842% -> 99.25%**
- Objdiff mismatch entries reduced from **8 -> 6**.
- Removed the branch-path register move mismatch around the `lbl_801EADC8` pointer selection path.

## Plausibility Rationale
- Changes are source-plausible cleanup/refactor patterns (equivalent arithmetic ordering and equivalent pointer initialization), not artificial control-flow coercion.
- Behavior and data flow are unchanged; only expression form/variable shaping was adjusted to align generated code.

## Technical Details
- The update eliminates one extra register move in the `field4 == -1` target selection sequence.
- Remaining mismatches are register assignment differences in the first component update and one multiply operand-register ordering case.
- `ninja` passes after the change.
