### PR TITLE
menu_equip: implement first-pass EquipOpen

### DIFF
--- a/include/ffcc/menu_equip.h
+++ b/include/ffcc/menu_equip.h
@@ -7,7 +7,7 @@ public:
     void EquipInit();
     void EquipInit0();
     void EquipInit1();
-    void EquipOpen();
+    int EquipOpen();
     void EquipCtrl();
     void EquipClose();
     void EquipDraw();

--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -1,4 +1,11 @@
 #include "ffcc/menu_equip.h"
+#include "ffcc/joybus.h"
+#include <string.h>
+
+typedef signed short s16;
+typedef unsigned char u8;
+
+extern "C" int GetItemType__8CMenuPcsFii(CMenuPcs*, int, int);
 
 extern float FLOAT_80332eb8;
 extern float FLOAT_80332ee0;
@@ -210,12 +217,173 @@ void CMenuPcs::EquipInit1()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8015d108
+ * PAL Size: 948b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::EquipOpen()
+int CMenuPcs::EquipOpen()
 {
-	// TODO
+	u8* self = reinterpret_cast<u8*>(this);
+	u8* equipState = *reinterpret_cast<u8**>(self + 0x82c);
+
+	if (equipState[0xb] == 0) {
+		memset(*reinterpret_cast<void**>(self + 0x850), 0, 0x1008);
+
+		float fVar = FLOAT_80332ee0;
+		int scalePtr = *reinterpret_cast<int*>(self + 0x850) + 8;
+		for (int i = 0; i < 8; i++) {
+			*reinterpret_cast<float*>(scalePtr + 0x14) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0x54) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0x94) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0xd4) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0x114) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0x154) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0x194) = fVar;
+			*reinterpret_cast<float*>(scalePtr + 0x1d4) = fVar;
+			scalePtr += 0x200;
+		}
+
+		int menuIndex = 0;
+		s16* entry = reinterpret_cast<s16*>(*reinterpret_cast<int*>(self + 0x850) + 8);
+		for (int i = 0; i < 2; i++) {
+			*reinterpret_cast<int*>(entry + 0xe) = 0x34;
+			entry[2] = 200;
+			entry[3] = 0x28;
+			*entry = static_cast<s16>(-((static_cast<double>(entry[2]) * 0.5) - 320.0));
+			entry[1] = static_cast<s16>(menuIndex * (entry[3] - 8) + 0x60);
+			*reinterpret_cast<float*>(entry + 4) = FLOAT_80332eb8;
+			*reinterpret_cast<float*>(entry + 6) = FLOAT_80332eb8;
+			*reinterpret_cast<int*>(entry + 0x12) = menuIndex;
+			*reinterpret_cast<int*>(entry + 0x14) = 3;
+
+			*reinterpret_cast<int*>(entry + 0x2e) = 0x34;
+			entry[0x22] = 200;
+			entry[0x23] = 0x28;
+			entry[0x20] = static_cast<s16>(-((static_cast<double>(entry[0x22]) * 0.5) - 320.0));
+			entry[0x21] = static_cast<s16>((menuIndex + 1) * (entry[0x23] - 8) + 0x60);
+			*reinterpret_cast<float*>(entry + 0x24) = FLOAT_80332eb8;
+			*reinterpret_cast<float*>(entry + 0x26) = FLOAT_80332eb8;
+			*reinterpret_cast<int*>(entry + 0x32) = menuIndex + 1;
+			*reinterpret_cast<int*>(entry + 0x34) = 3;
+
+			entry += 0x40;
+			menuIndex += 2;
+		}
+
+		**reinterpret_cast<s16**>(self + 0x850) = 4;
+		EquipInit1();
+
+		s16* letterBuf = reinterpret_cast<s16*>(Joybus.GetLetterBuffer(0));
+		s16 itemCount = 0;
+		for (int i = 0; i < 0x40; i++) {
+			if (GetItemType__8CMenuPcsFii(this, i, 0) == 1) {
+				letterBuf++;
+				*letterBuf = static_cast<s16>(i);
+				itemCount++;
+			}
+		}
+
+		*reinterpret_cast<s16*>(Joybus.GetLetterBuffer(0)) = itemCount + 1;
+		*reinterpret_cast<s16*>(equipState + 0x26) = 0;
+		equipState[0xb] = 1;
+	}
+
+	int doneCount = 0;
+	*reinterpret_cast<s16*>(equipState + 0x22) = *reinterpret_cast<s16*>(equipState + 0x22) + 1;
+
+	s16* entries = *reinterpret_cast<s16**>(self + 0x850);
+	u32 count = static_cast<u32>(entries[0]);
+	s16* entry = entries + 4;
+	int timer = static_cast<int>(*reinterpret_cast<s16*>(equipState + 0x22));
+
+	for (u32 i = 0; i < count; i++) {
+		if (*reinterpret_cast<int*>(entry + 0x12) <= timer) {
+			if (timer < (*reinterpret_cast<int*>(entry + 0x12) + *reinterpret_cast<int*>(entry + 0x14))) {
+				*reinterpret_cast<int*>(entry + 0x10) = *reinterpret_cast<int*>(entry + 0x10) + 1;
+				*reinterpret_cast<float*>(entry + 8) = static_cast<float>(
+					(1.0 / static_cast<double>(*reinterpret_cast<int*>(entry + 0x14))) *
+					static_cast<double>(*reinterpret_cast<int*>(entry + 0x10)));
+			} else {
+				doneCount++;
+				*reinterpret_cast<float*>(entry + 8) = FLOAT_80332ee0;
+			}
+		}
+		entry += 0x20;
+	}
+
+	if (entries[0] == doneCount) {
+		entry = entries + 4;
+		if (count != 0) {
+			u32 blockCount = count >> 3;
+			if (blockCount != 0) {
+				do {
+					entry[0x12] = 0;
+					entry[0x13] = 0;
+					entry[0x14] = 0;
+					entry[0x15] = 1;
+					*reinterpret_cast<float*>(entry + 8) = FLOAT_80332ee0;
+					entry[0x32] = 0;
+					entry[0x33] = 0;
+					entry[0x34] = 0;
+					entry[0x35] = 1;
+					*reinterpret_cast<float*>(entry + 0x28) = FLOAT_80332ee0;
+					entry[0x52] = 0;
+					entry[0x53] = 0;
+					entry[0x54] = 0;
+					entry[0x55] = 1;
+					*reinterpret_cast<float*>(entry + 0x48) = FLOAT_80332ee0;
+					entry[0x72] = 0;
+					entry[0x73] = 0;
+					entry[0x74] = 0;
+					entry[0x75] = 1;
+					*reinterpret_cast<float*>(entry + 0x68) = FLOAT_80332ee0;
+					entry[0x92] = 0;
+					entry[0x93] = 0;
+					entry[0x94] = 0;
+					entry[0x95] = 1;
+					*reinterpret_cast<float*>(entry + 0x88) = FLOAT_80332ee0;
+					entry[0xb2] = 0;
+					entry[0xb3] = 0;
+					entry[0xb4] = 0;
+					entry[0xb5] = 1;
+					*reinterpret_cast<float*>(entry + 0xa8) = FLOAT_80332ee0;
+					entry[0xd2] = 0;
+					entry[0xd3] = 0;
+					entry[0xd4] = 0;
+					entry[0xd5] = 1;
+					*reinterpret_cast<float*>(entry + 200) = FLOAT_80332ee0;
+					entry[0xf2] = 0;
+					entry[0xf3] = 0;
+					entry[0xf4] = 0;
+					entry[0xf5] = 1;
+					*reinterpret_cast<float*>(entry + 0xe8) = FLOAT_80332ee0;
+					entry += 0x100;
+					blockCount--;
+				} while (blockCount != 0);
+
+				count &= 7;
+				if (count == 0) {
+					return 1;
+				}
+			}
+
+			do {
+				entry[0x12] = 0;
+				entry[0x13] = 0;
+				entry[0x14] = 0;
+				entry[0x15] = 1;
+				*reinterpret_cast<float*>(entry + 8) = FLOAT_80332ee0;
+				entry += 0x20;
+				count--;
+			} while (count != 0);
+		}
+		return 1;
+	}
+
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a full first-pass body for `CMenuPcs::EquipOpen()` in `src/menu_equip.cpp`, replacing the TODO.

Key updates:
- Added PAL metadata block for the function (`0x8015d108`, `948b`).
- Ported the open-animation initialization and per-frame progression logic from the PAL decomp structure.
- Added initial item list population using `Joybus.GetLetterBuffer(0)` and `GetItemType__8CMenuPcsFii`.
- Kept the existing raw-offset style used in menu decomp units to preserve ABI/layout behavior.
- Updated `include/ffcc/menu_equip.h` so `EquipOpen` returns `int` (matches recovered behavior).

## Functions Improved
- Unit: `main/menu_equip`
- Function: `EquipOpen__8CMenuPcsFv`

## Match Evidence
Pre-change (from target selection output before edits):
- `main/menu_equip`: `3.6%` fuzzy
- `EquipOpen__8CMenuPcsFv`: `0.4%` fuzzy

Post-change (from `build/GCCP01/report.json` after rebuild):
- `main/menu_equip`: `6.3402777%` fuzzy
- `EquipOpen__8CMenuPcsFv`: `28.983122%` fuzzy

## Plausibility Rationale
This is a source-plausible reconstruction pass, not compiler coaxing:
- Uses normal menu-state/timer/list setup patterns already present in nearby menu units.
- Uses straightforward animation state transitions (setup, advance, done-reset) rather than contrived temporaries.
- Keeps implementation in the project’s established decomp style (explicit offsets and typed casts), which is common in this codebase while class layouts are still incomplete.

## Technical Notes
- The local `objdiff-cli` in this workspace is `v3.4.1` (no JSON oneshot `-o`), so post-change metrics were taken from generated `report.json` after `ninja`.
- Build result: `build/GCCP01/main.dol: OK`.
