### PR TITLE
cflat_r2system: add missing CFile thunk wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -559,6 +559,48 @@ extern "C" void Close__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9418
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void* GetBuffer__5CFileFv(CFile* file)
+{
+    return file->m_readBuffer;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9420
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SyncCompleted__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
+{
+    File.SyncCompleted(fileHandle);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B944C
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void Read__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
+{
+    File.Read(fileHandle);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
Add three missing C-linkage thunk wrappers in `src/cflat_r2system.cpp` for file API symbols that are expected in this unit.

- `GetBuffer__5CFileFv`
- `SyncCompleted__Q25CFile7CHandleFv`
- `Read__Q25CFile7CHandleFv`

Each wrapper now forwards directly to existing `CFile` data/methods in a minimal, source-plausible way.

## Functions Improved
Unit: `main/cflat_r2system`

- `GetBuffer__5CFileFv`: `0.0% -> 100.0%`
- `SyncCompleted__Q25CFile7CHandleFv`: `0.0% -> 100.0%`
- `Read__Q25CFile7CHandleFv`: `0.0% -> 100.0%`

Additional context:
- `main/cflat_r2system` matched functions: `17/84 -> 20/84`

## Match Evidence
- Build verified with `ninja`.
- `objdiff-cli` symbol checks now report full matches:
  - `Close__Q25CFile7CHandleFv 100.0`
  - `GetBuffer__5CFileFv 100.0`
  - `SyncCompleted__Q25CFile7CHandleFv 100.0`
  - `Read__Q25CFile7CHandleFv 100.0`

## Plausibility Rationale
This change adds straightforward wrappers that match the codebase pattern already used in this same file (`Close__Q25CFile7CHandleFv`).

- No compiler-coaxing constructs were introduced.
- No control-flow trickery or opaque temporaries were added.
- Behavior mirrors natural original-source thunks: direct field return / direct method forward.

## Technical Notes
- Included PAL address/size comments in the project’s standard `--INFO--` format:
  - `0x800B9418` (`GetBuffer`, 8b)
  - `0x800B9420` (`SyncCompleted`, 44b)
  - `0x800B944C` (`Read`, 44b)
