### PR TITLE
p_dbgmenu: implement changeVtxFmt GX state setup

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/p_dbgmenu.h"
+#include "ffcc/gxfunc.h"
 #include "ffcc/graphic.h"
 #include "ffcc/system.h"
 #include <dolphin/gx.h>
@@ -240,11 +241,29 @@ void CDbgMenuPcs::drawMenu(CDbgMenuPcs::CDM*)
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::changeVtxFmt(int)
+void CDbgMenuPcs::changeVtxFmt(int vtxFmt)
 {
-	// TODO
-}
+    int& currentVtxFmt = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x2A68);
 
+    if (currentVtxFmt != vtxFmt) {
+        if (vtxFmt == 1) {
+            GXClearVtxDesc();
+            GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+            GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+            GXSetVtxAttrFmt(GX_VTXFMT1, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+            GXSetVtxAttrFmt(GX_VTXFMT1, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
+            GXSetChanCtrl(GX_COLOR0A0, GX_FALSE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_SPEC);
+            _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+            _GXSetTevOp(GX_TEVSTAGE0, GX_MODULATE);
+        } else if (vtxFmt == 0) {
+            GXSetChanCtrl(GX_COLOR0A0, GX_FALSE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_SPEC);
+            _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
+            _GXSetTevOp(GX_TEVSTAGE0, GX_REPLACE);
+        }
+
+        currentVtxFmt = vtxFmt;
+    }
+}
 /*
  * --INFO--
  * PAL Address: 0x8012c274


### PR DESCRIPTION
## Summary
Implemented `CDbgMenuPcs::changeVtxFmt(int)` in `src/p_dbgmenu.cpp` and wired in `ffcc/gxfunc.h` so the function now applies the expected GX vertex/TEV state transitions for debug menu rendering.

## Functions improved
- `main/p_dbgmenu`:
- `changeVtxFmt__11CDbgMenuPcsFi` (PAL 0x8012c7ac, 300b)

## Match evidence
- Before (from `tools/agent_select_target.py` run before edits):
- Unit `main/p_dbgmenu`: **37.0%**
- `changeVtxFmt__11CDbgMenuPcsFi`: **1.3%**
- After (`objdiff-cli report generate`):
- Unit `main/p_dbgmenu`: **40.45435%**
- `changeVtxFmt__11CDbgMenuPcsFi`: **74.17333%**

## Plausibility rationale
- The implementation follows existing project patterns in nearby debug-menu rendering code: explicit GX pipeline configuration keyed by a local current-format state.
- The logic is straightforward source code a game UI/debug renderer would naturally use (state guard plus two known format setups), rather than contrived compiler-only transformations.

## Technical details
- Added format 1 setup path: direct position/color descriptors, VTXFMT1 attr layout, channel control, TEV order/op.
- Added format 0 setup path: channel/TEV setup for texture-based path.
- Preserved cached state update at offset `0x2A68` to avoid redundant GX reconfiguration.
