### PR TITLE
pppSRandCV: improve match by aligning SRandCV codegen pattern

### DIFF
--- a/src/pppSRandCV.cpp
+++ b/src/pppSRandCV.cpp
@@ -8,19 +8,6 @@ extern float lbl_80330060;
 extern u8 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
 
-typedef struct SRandCVParams {
-    int index;
-    int colorOffset;
-    s8 delta[4];
-    u8 flag;
-    u8 pad[3];
-} SRandCVParams;
-
-typedef struct SRandCVCtx {
-    u8 pad[0xC];
-    int* outputOffset;
-} SRandCVCtx;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -40,15 +27,14 @@ void pppSRandCV(void* param1, void* param2, void* param3)
         return;
     }
 
-    u8* base = (u8*)param1;
-    SRandCVParams* params = (SRandCVParams*)param2;
-    SRandCVCtx* ctx = (SRandCVCtx*)param3;
     float* target;
 
-    if (params->index == *(int*)(base + 0xC)) {
-        target = (float*)(base + *ctx->outputOffset + 0x80);
+    if (*(int*)param2 == *((int*)param1 + 3)) {
+        int** base_ptr = (int**)((char*)param3 + 0xc);
+        int offset = **base_ptr;
+        target = (float*)((char*)param1 + offset + 0x80);
 
-        u8 flag = params->flag;
+        u8 flag = *((u8*)param2 + 0xc);
         float value;
 
         value = RandF__5CMathFv(math);
@@ -82,44 +68,42 @@ void pppSRandCV(void* param1, void* param2, void* param3)
             value = value * lbl_80330060;
         }
         target[3] = value;
-    } else if (params->index != *(int*)(base + 0xC)) {
-        target = (float*)(base + *ctx->outputOffset + 0x80);
+    } else if (*(int*)param2 != *((int*)param1 + 3)) {
+        int** base_ptr = (int**)((char*)param3 + 0xc);
+        int offset = **base_ptr;
+        target = (float*)((char*)param1 + offset + 0x80);
     }
 
-    int color_offset = params->colorOffset;
-    u8* target_color;
+    int color_offset = *((int*)param2 + 1);
+    u8* target_colors;
     if (color_offset == -1) {
-        target_color = lbl_801EADC8;
+        target_colors = lbl_801EADC8;
     } else {
-        target_color = base + color_offset + 0x80;
+        target_colors = (u8*)((char*)param1 + color_offset + 0x80);
     }
 
     {
-        u8 current = target_color[0];
-        s8 baseValue = params->delta[0];
-        int delta = (int)((float)baseValue * target[0] - (float)current);
-        target_color[0] = (u8)(current + delta);
+        s8 base = *(s8*)((char*)param2 + 0x8);
+        int delta = (int)(base * target[0]);
+        target_colors[0] = (u8)(target_colors[0] + delta);
     }
 
     {
-        u8 current = target_color[1];
-        s8 baseValue = params->delta[1];
-        int delta = (int)((float)baseValue * target[1] - (float)current);
-        target_color[1] = (u8)(current + delta);
+        s8 base = *(s8*)((char*)param2 + 0x9);
+        int delta = (int)(base * target[1]);
+        target_colors[1] = (u8)(target_colors[1] + delta);
     }
 
     {
-        u8 current = target_color[2];
-        s8 baseValue = params->delta[2];
-        int delta = (int)((float)baseValue * target[2] - (float)current);
-        target_color[2] = (u8)(current + delta);
+        s8 base = *(s8*)((char*)param2 + 0xA);
+        int delta = (int)(base * target[2]);
+        target_colors[2] = (u8)(target_colors[2] + delta);
     }
 
     {
-        u8 current = target_color[3];
-        s8 baseValue = params->delta[3];
-        int delta = (int)((float)baseValue * target[3] - (float)current);
-        target_color[3] = (u8)(current + delta);
+        s8 base = *(s8*)((char*)param2 + 0xB);
+        int delta = (int)(base * target[3]);
+        target_colors[3] = (u8)(target_colors[3] + delta);
     }
 }
 


### PR DESCRIPTION
## Summary
- Reworked `pppSRandCV` in `src/pppSRandCV.cpp` to follow the same pointer-access and control-flow shape used by sibling functions (`pppSRandUpCV` / `pppSRandDownCV`).
- Removed struct-based local views and switched to direct offset reads to better match existing codegen style in this unit family.
- Simplified per-channel color delta updates to the same arithmetic form as sibling SRandCV functions.

## Functions Improved
- Unit: `main/pppSRandCV`
- Symbol: `pppSRandCV` (PAL addr `0x800632d0`, size `736b`)

## Match Evidence
- `objdiff` symbol match for `pppSRandCV`:
  - Before: `81.08696%`
  - After: `82.86413%`
  - Delta: `+1.77717%`
- Unit report (`build/GCCP01/report.json`) now shows `main/pppSRandCV` fuzzy match at `82.891304%`.
- Build verification: `ninja` passes after the change.

## Plausibility Rationale
- The rewrite intentionally matches neighboring SRandCV implementations already present in the codebase rather than introducing bespoke temporaries or compiler-specific tricks.
- No behavior-only coaxing patterns were added; changes are primarily type/access/control-flow normalization consistent with existing style.

## Technical Notes
- Key alignment points were:
  - condition and index checks written in the same form as `pppSRandUpCV`/`pppSRandDownCV`
  - matching stack/use patterns by using direct `(char*)` offset addressing
  - matching channel update expression shape (`target_colors[i] += (int)(base * target[i])`)
