### PR TITLE
pppShape: align texture cache scan loops

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -189,7 +189,7 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     char textureUsed[256];
     void* animData = shapeSt->m_animData;
 
-    memset(textureUsed, 0, 256);
+    memset(textureUsed, 0, 0x100);
 
     void* currentFrame = animData;
     for (int frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex++) {
@@ -204,11 +204,15 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
         currentFrame = (void*)((int)currentFrame + 8);
     }
 
-    for (unsigned int textureIndex = 0; textureIndex < 256; textureIndex++) {
-        if (textureUsed[textureIndex] != 0) {
+    char* texturePtr = textureUsed;
+    unsigned int textureIndex = 0;
+    do {
+        if (*texturePtr != 0) {
             materialSet->CacheLoadTexture(textureIndex, (CAmemCacheSet*)CAMemCacheSet);
         }
-    }
+        textureIndex++;
+        texturePtr++;
+    } while (textureIndex < 0x100);
 }
 
 /*
@@ -245,7 +249,7 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     char textureUsed[256];
     void* animData = shapeSt->m_animData;
     
-    memset(textureUsed, 0, 256);
+    memset(textureUsed, 0, 0x100);
     
     void* currentFrame = animData;
     for (int frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex++) {
@@ -260,11 +264,15 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
         currentFrame = (void*)((int)currentFrame + 8);
     }
     
-    for (unsigned int textureIndex = 0; textureIndex < 256; textureIndex++) {
-        if (textureUsed[textureIndex] != 0) {
+    char* texturePtr = textureUsed;
+    unsigned int textureIndex = 0;
+    do {
+        if (*texturePtr != 0) {
             CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet(materialSet, textureIndex, CAMemCacheSet);
         }
-    }
+        textureIndex++;
+        texturePtr++;
+    } while (textureIndex < 0x100);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked the final texture-scan loop in `pppCacheLoadShapeTexture` and `pppCacheDumpShapeTexture` to use a pointer walk with an explicit `do/while`.
- Normalized `memset` length literals to `0x100` to match the 256-byte usage bitmap intent.
- Kept behavior unchanged: both functions still gather per-frame texture usage and call the same cache load/dump APIs.

## Functions improved
- `pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`
- `pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet`

## Match evidence
Measured with:
`build/tools/objdiff-cli diff -p . -u main/pppShape -o - <symbol>`

- `pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`: **78.666664% -> 78.75%**
- `pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet`: **78.666664% -> 78.75%**

This is a small but real assembly alignment improvement in both symmetric functions.

## Plausibility rationale
- Pointer-walk scanning of a compact usage bitmap is idiomatic and source-plausible for this codebase.
- The update does not introduce contrived temporaries, magic offsets, or behavior-only compiler coaxing.
- The two functions remain symmetrical (load vs dump), which matches their intended design.

## Technical details
- Switched from indexed `for` loops (`textureUsed[i]`) to `char*` pointer traversal (`*p; p++`) with a `do/while` upper bound at `0x100`.
- This nudges register/update ordering closer to target assembly in the post-collection scan section.
- Build verified with `ninja` after the change.
