### PR TITLE
pppYmMegaBirthShpTail2: first-pass calc implementation

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail2.h
+++ b/include/ffcc/pppYmMegaBirthShpTail2.h
@@ -38,7 +38,6 @@ void get_rand(void);
 void U8ToF32(pppFVECTOR4*, unsigned char*);
 void alloc_check(VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*);
 void birth(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
-void calc(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
 void calc_particle(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- Replaced the `calc` stub in `src/pppYmMegaBirthShpTail2.cpp` with a first-pass implementation guided by PAL decomp flow.
- Added PAL metadata for `calc` and kept behavior-oriented logic instead of placeholder code.
- Aligned the emitted `calc` symbol name so objdiff compares the intended function directly.

## Functions improved
- Unit: `main/pppYmMegaBirthShpTail2`
- Function: `calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`

## Match evidence
- Before: `0.0%` (selector baseline)
- After: `44.34197%` (`objdiff-cli diff` for this symbol)
- Command:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail2 -o - calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`

## Plausibility rationale
- Implements concrete particle update behavior (position accumulation, scale/alpha progression, trail-history transform, frame-table stepping) in place of a TODO stub.
- Keeps source-oriented control flow and data operations used by neighboring particle units.

## Technical details
- `calc` now performs scale accumulation from particle params, world-space trail writes via `PSMTXMultVec`, blend interpolation window handling, and frame progression through env color tables.
- This is a first-pass decomp for a previously 0% large target; further cleanup/typing can follow in later passes.
