### PR TITLE
Improve pppFrameYmMoveParabola motion/state update matching

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -97,10 +97,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
             direction.x = FLOAT_80330e18;
             direction.z = FLOAT_80330e1c;
         } else {
-            // Simplified direction calculation
-            direction.x = pppMngSt->m_position.x;
-            direction.y = pppMngSt->m_position.y;
-            direction.z = pppMngSt->m_position.z;
+            PSVECSubtract((Vec*)((u8*)pppMngSt + 0x68), (Vec*)((u8*)pppMngSt + 0x58), &direction);
         }
         
         // Normalize the direction vector
@@ -130,15 +127,18 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
             pppAddVector(newPosition, offset, basePos);
         } else {
             Vec basePos;
-            basePos.x = pppMngSt->m_position.x;
-            basePos.y = pppMngSt->m_position.y;
-            basePos.z = pppMngSt->m_position.z;
+            basePos.x = *(f32*)((u8*)pppMngSt + 0x58);
+            basePos.y = *(f32*)((u8*)pppMngSt + 0x5c);
+            basePos.z = *(f32*)((u8*)pppMngSt + 0x60);
             Vec offset;
             offset.x = horizontalX;
             offset.y = verticalY;
             offset.z = horizontalZ;
             pppAddVector(newPosition, offset, basePos);
         }
+
+        pppCopyVector(*(Vec*)((u8*)pppMngSt + 0x48), *(Vec*)((u8*)pppMngSt + 0x8));
+        pppCopyVector(*(Vec*)((u8*)pppMngSt + 0x8), newPosition);
         
         // Update matrix with new position
         pppMngStPtr->m_matrix.value[0][3] = newPosition.x;


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmMoveParabola` to use the manager delta vector (`paramVec0 - savedPosition`) for direction in non-scene-7 paths.
- Switched non-scene-7 base position to the saved-position vector (offset `0x58`) instead of current position.
- Restored position state propagation by copying current position to previous (`0x48`) and writing the newly computed position to current (`0x8`) before matrix translation updates.

## Functions improved
- Unit: `main/pppYmMoveParabola`
- Symbol: `pppFrameYmMoveParabola`
  - Before: `46.869564%`
  - After: `51.47826%`
- Symbol: `pppConstructYmMoveParabola`
  - Before: `57.47945%`
  - After: `57.47945%` (no regression)

## Match evidence
- `objdiff` shows a real improvement on the frame function while keeping constructor match stable.
- Unit `.text` match also increased from the pre-change measurement to `53.18288%` after this change set.

## Plausibility rationale
- These changes restore behavior already implied by neighboring particle movement code: derive direction from saved/param vectors, keep previous/current position bookkeeping in sync, and then update render matrix translation.
- No artificial temporaries or compiler-coaxing patterns were introduced; changes are straightforward movement/state flow fixes.

## Technical details
- Kept existing serialized work layout and constants untouched.
- Focused only on control/data flow points that were clearly divergent from the decomp reference and manager offset conventions used in nearby `pppYm*` implementations.
