### PR TITLE
main/RedSound: implement RedSound->RedDriver wrapper stubs

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -506,102 +506,142 @@ int CRedSound::SePlay(int seID, int sepID, int unk, int volume, int pitch)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd378
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SeMasterVolume(int)
+void CRedSound::SeMasterVolume(int volume)
 {
-	// TODO
+	CRedDriver_8032f4c0.SeMasterVolume(volume);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd3a4
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SeFadeOut(int, int)
+void CRedSound::SeFadeOut(int seID, int frameCount)
 {
-	// TODO
+	CRedDriver_8032f4c0.SeFadeOut(seID, frameCount);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd3d8
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SeVolume(int, int, int)
+void CRedSound::SeVolume(int seID, int volume, int frameCount)
 {
-	// TODO
+	CRedDriver_8032f4c0.SeVolume(seID, volume, frameCount);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd414
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SePan(int, int, int)
+void CRedSound::SePan(int seID, int pan, int frameCount)
 {
-	// TODO
+	CRedDriver_8032f4c0.SePan(seID, pan, frameCount);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd450
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SePitch(int, int, int)
+void CRedSound::SePitch(int seID, int pitch, int frameCount)
 {
-	// TODO
+	CRedDriver_8032f4c0.SePitch(seID, pitch, frameCount);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd48c
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SePause(int, int)
+void CRedSound::SePause(int seID, int pause)
 {
-	// TODO
+	CRedDriver_8032f4c0.SePause(seID, pause);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd4c0
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::GetSeVolume(int, int)
+void CRedSound::GetSeVolume(int seID, int outVolume)
 {
-	// TODO
+	CRedDriver_8032f4c0.GetSeVolume(seID, outVolume);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd4f4
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::ReportSeLoop(int)
+void CRedSound::ReportSeLoop(int mode)
 {
-	// TODO
+	CRedDriver_8032f4c0.ReportSeLoop(mode);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd520
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CRedSound::DisplaySePlayInfo()
 {
-	// TODO
+	CRedDriver_8032f4c0.DisplaySePlayInfo();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd544
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::StreamPlayState(int)
+void CRedSound::StreamPlayState(int streamID)
 {
-	// TODO
+	CRedDriver_8032f4c0.StreamPlayState(streamID);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a cluster of previously stubbed `CRedSound` methods in `src/RedSound/RedSound.cpp` as direct `CRedDriver` forwarders, and added PAL address/size metadata blocks for each updated function.

Updated methods:
- `SeMasterVolume`
- `SeFadeOut`
- `SeVolume`
- `SePan`
- `SePitch`
- `SePause`
- `GetSeVolume`
- `ReportSeLoop`
- `DisplaySePlayInfo`
- `StreamPlayState`

## Functions improved
Unit: `main/RedSound/RedSound`
- `SeVolume__9CRedSoundFiii`: 6.7% -> 59.07%
- `SePan__9CRedSoundFiii`: 6.7% -> 59.07%
- `SePitch__9CRedSoundFiii`: 6.7% -> 59.07%
- `GetSeVolume__9CRedSoundFii`: 7.69% -> 68.38%
- `DisplaySePlayInfo__9CRedSoundFv`: now 99.44%
- `SeMasterVolume__9CRedSoundFi`: now 80.82%
- `SeFadeOut__9CRedSoundFii`: now 68.38%
- `SePause__9CRedSoundFii`: now 68.38%
- `ReportSeLoop__9CRedSoundFi`: now 80.82%
- `StreamPlayState__9CRedSoundFi`: now 80.82%

## Match evidence
- Selector baseline for unit (`main/RedSound/RedSound`): **42.5%** fuzzy
- Post-change report (`ninja`): **50.945976%** fuzzy
- Objdiff on individual symbols shows large gains from stub-level matches to multi-instruction forwarding wrappers.

## Plausibility rationale
These changes replace TODO stubs with idiomatic pass-through methods that match the existing engine architecture (`CRedSound` as facade over `CRedDriver`) and align with Ghidra-decompiled call patterns for the same symbols. No contrived control flow or compiler-coaxing constructs were introduced.

## Technical details
- Kept signatures and argument order consistent with existing headers and `CRedDriver` API.
- Used direct member calls to preserve original-style source readability while improving codegen alignment.
- Added PAL metadata (`PAL Address`/`PAL Size`) for each touched function block per project runbook.
