### PR TITLE
TRK: improve TRK__read_aram match via qualifier cleanup

### DIFF
--- a/include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk.h
+++ b/include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk.h
@@ -12,7 +12,7 @@ DSError TRKInitializeTarget();
 
 void EnableMetroTRKInterrupts();
 u32 TRKTargetTranslate(u32 param_0);
-void TRK__read_aram(register u32 param_1, register u32 param_2, u32* param_3);
+void TRK__read_aram(u32 param_1, u32 param_2, u32* param_3);
 void TRK__write_aram(register u32 param_1, register u32 param_2, u32* param_3);
 
 void __TRK_copy_vectors(void);

--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -325,7 +325,7 @@ LAB_801adc44:
 	}
 }
 
-void TRK__read_aram(register u32 param_1, register u32 param_2, u32* param_3)
+void TRK__read_aram(u32 param_1, u32 param_2, u32* param_3)
 {
 	u32 uVar1;
 	u32 uVar2;


### PR DESCRIPTION
## Summary
- Removed `register` qualifiers from the `TRK__read_aram` declaration and definition.
- No behavioral logic changes were made to DMA/cache handling.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk`
- Symbol: `TRK__read_aram` (308 bytes)
- Match: `58.57143%` -> `58.701298%`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - TRK__read_aram`
- Instruction-level diff delta for `TRK__read_aram`:
  - `DIFF_ARG_MISMATCH`: `24` -> `23`
  - Other diff-kind counts unchanged.

## Plausibility rationale
- `register` is a compiler hint and not part of program semantics.
- Removing it is source-plausible for original code while preserving readability and behavior.
- The change improves codegen alignment without introducing contrived control flow or artificial temporaries.

## Technical details
- Updated files:
  - `include/TRK_MINNOW_DOLPHIN/Os/dolphin/dolphin_trk.h`
  - `src/TRK_MINNOW_DOLPHIN/dolphin_trk.c`
- Build verification:
  - `ninja` succeeds after the change.
