### PR TITLE
RedSound: implement _SeTrackDataExecute

### DIFF
--- a/include/ffcc/RedSound/RedExecute.h
+++ b/include/ffcc/RedSound/RedExecute.h
@@ -13,7 +13,7 @@ struct RedSoundCONTROL;
 struct RedKeyOnDATA;
 
 u8 GetRandomData();
-void PitchCompute(int, int, int, int);
+int PitchCompute(int, int, int, int);
 void _ReverbNullCallback(AXFX_BUFFERUPDATE*, void*);
 void ReverbAreaAlloc(unsigned long);
 void ReverbAreaFree(void*);

--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -2,6 +2,9 @@
 #include "types.h"
 #include <string.h>
 
+extern u32* DAT_8032f444;
+extern unsigned int DAT_8032ec30;
+
 /*
  * --INFO--
  * PAL Address: 0x801c2fc4
@@ -26,9 +29,10 @@ u8 GetRandomData()
  * Address:	TODO
  * Size:	TODO
  */
-void PitchCompute(int, int, int, int)
+int PitchCompute(int, int, int, int)
 {
 	// TODO
+	return 0;
 }
 
 /*
@@ -254,8 +258,6 @@ void _AdsrDataExecute(RedVoiceDATA*)
  */
 void _VoiceDropedCallback(void* param_1)
 {
-    extern u32* DAT_8032f444;
-    
     u32* puVar1;
     int iParam1 = (int)param_1;
     
@@ -372,12 +374,183 @@ void MusicSkipFunction()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c6ab4
+ * PAL Size: 1416b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _SeTrackDataExecute(RedTrackDATA*, int)
+void _SeTrackDataExecute(RedTrackDATA* track, int frames)
 {
-	// TODO
+	int* trackData = (int*)track;
+	unsigned char* trackBytes = (unsigned char*)trackData;
+	int voiceBase;
+	int step;
+	short* trackShorts = (short*)trackData;
+
+	if ((trackBytes[0x26] & 2) != 0) {
+		return;
+	}
+
+	voiceBase = (int)((unsigned char*)DAT_8032f444 + (s8)trackBytes[0x14E] * 0xC0);
+	if (0 < frames) {
+		trackData[0x43] += frames;
+	}
+
+	if (trackData[0x0C] != 0) {
+		step = frames;
+		if (trackData[0x0C] <= frames) {
+			step = trackData[0x0C];
+		}
+		trackData[0x0C] -= step;
+		trackData[0x0A] += trackData[0x0B] * step;
+		*(unsigned int*)(voiceBase + 0xB8) |= 2;
+	}
+
+	if (trackData[0x0F] != 0) {
+		step = frames;
+		if (trackData[0x0F] <= frames) {
+			step = trackData[0x0F];
+		}
+		trackData[0x0F] -= step;
+		trackData[0x0D] += trackData[0x0E] * step;
+		*(unsigned int*)(voiceBase + 0xB8) |= 2;
+	}
+
+	if (trackData[0x12] != 0) {
+		step = frames;
+		if (trackData[0x12] <= frames) {
+			step = trackData[0x12];
+		}
+		trackData[0x12] -= step;
+		trackData[0x10] += trackData[0x11] * step;
+		*(unsigned int*)(voiceBase + 0xB8) |= 2;
+	}
+
+	if (trackData[0x1C] != 0) {
+		step = frames;
+		if (trackData[0x1C] <= frames) {
+			step = trackData[0x1C];
+		}
+		trackData[0x1C] -= step;
+		trackData[0x1A] += trackData[0x1B] * step;
+		*(unsigned int*)(voiceBase + 0xB8) |= 2;
+	}
+
+	if (trackData[0x15] != 0) {
+		step = frames;
+		if (trackData[0x15] <= frames) {
+			step = trackData[0x15];
+		}
+		trackData[0x15] -= step;
+		if ((trackData[0x15] == 0) && (trackData[0x16] == 1)) {
+			trackData[0] = (int)&DAT_8032ec30;
+			trackData[0x42] = 1;
+		}
+		trackData[0x13] += trackData[0x14] * step;
+		*(unsigned int*)(voiceBase + 0xB8) |= 2;
+	}
+
+	if (trackData[0x19] != 0) {
+		step = frames;
+		if (trackData[0x19] <= frames) {
+			step = trackData[0x19];
+		}
+		trackData[0x19] -= step;
+		trackData[0x17] += trackData[0x18] * step;
+		*(unsigned int*)(voiceBase + 0xB8) |= 1;
+	}
+
+	if (trackData[0x44] != 0) {
+		step = frames;
+		if (trackData[0x44] <= frames) {
+			step = trackData[0x44];
+		}
+		trackData[0x44] -= step;
+		trackData[0x48] += step * trackData[0x45];
+		*(unsigned int*)(voiceBase + 0xB8) |= 1;
+		*(int*)(voiceBase + 0xA0) += step * trackData[0x45];
+	}
+
+	if (((*(unsigned int*)(voiceBase + 0xB8) & 1) != 0) && (*(int*)(voiceBase + 4) != 0)) {
+		*(int*)(voiceBase + 0x98) = PitchCompute(
+			*(int*)(voiceBase + 0xA0) + trackData[0x17], (int)trackShorts[0xA1] + (int)trackShorts[0x9F],
+			*(int*)(*(int*)(voiceBase + 4) + 0x14), (int)(s8)trackBytes[0x148]);
+	}
+
+	if (trackData[0x1D] != 0) {
+		if (trackShorts[0x46] != 0) {
+			step = frames;
+			if (trackShorts[0x46] <= frames) {
+				step = trackShorts[0x46];
+			}
+			trackShorts[0x46] = trackShorts[0x46] - (short)step;
+			trackData[0x1E] += trackData[0x1F] * step;
+		}
+		if (*(short*)(trackBytes + 0x8E) != 0) {
+			step = frames;
+			if (*(short*)(trackBytes + 0x8E) <= frames) {
+				step = *(short*)(trackBytes + 0x8E);
+			}
+			*(short*)(trackBytes + 0x8E) = *(short*)(trackBytes + 0x8E) - (short)step;
+			trackData[0x20] += trackData[0x21] * step;
+		}
+	}
+
+	if (trackData[0x25] != 0) {
+		if (trackShorts[0x56] != 0) {
+			step = frames;
+			if (trackShorts[0x56] <= frames) {
+				step = trackShorts[0x56];
+			}
+			trackShorts[0x56] = trackShorts[0x56] - (short)step;
+			trackData[0x26] += trackData[0x27] * step;
+		}
+		if (*(short*)(trackBytes + 0xAE) != 0) {
+			step = frames;
+			if (*(short*)(trackBytes + 0xAE) <= frames) {
+				step = *(short*)(trackBytes + 0xAE);
+			}
+			*(short*)(trackBytes + 0xAE) = *(short*)(trackBytes + 0xAE) - (short)step;
+			trackData[0x28] += trackData[0x29] * step;
+		}
+	}
+
+	if (trackData[0x2D] != 0) {
+		if (trackShorts[0x68] != 0) {
+			step = frames;
+			if (trackShorts[0x68] <= frames) {
+				step = trackShorts[0x68];
+			}
+			trackShorts[0x68] = trackShorts[0x68] - (short)step;
+			trackData[0x2E] += trackData[0x2F] * step;
+		}
+		if (*(short*)(trackBytes + 0xD2) != 0) {
+			step = frames;
+			if (*(short*)(trackBytes + 0xD2) <= frames) {
+				step = *(short*)(trackBytes + 0xD2);
+			}
+			*(short*)(trackBytes + 0xD2) = *(short*)(trackBytes + 0xD2) - (short)step;
+			trackData[0x30] += trackData[0x31] * step;
+		}
+	}
+
+	if (*(short*)(voiceBase + 0x28) != 0) {
+		step = frames;
+		if (*(short*)(voiceBase + 0x28) <= frames) {
+			step = *(short*)(voiceBase + 0x28);
+		}
+		*(short*)(voiceBase + 0x28) = *(short*)(voiceBase + 0x28) - (short)step;
+	}
+
+	if (*(short*)(voiceBase + 0x38) != 0) {
+		step = frames;
+		if (*(short*)(voiceBase + 0x38) <= frames) {
+			step = *(short*)(voiceBase + 0x38);
+		}
+		*(short*)(voiceBase + 0x38) = *(short*)(voiceBase + 0x38) - (short)step;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `_SeTrackDataExecute` in `src/RedSound/RedExecute.cpp` from the current PAL decomp baseline, replacing a TODO stub with full track/voice update logic.
- Updated the function metadata block with PAL address/size.
- Corrected `PitchCompute` declaration/definition to return `int` (matching its usage from track update code).

## Functions Improved
- Unit: `main/RedSound/RedExecute`
- Symbol: `_SeTrackDataExecute__FP12RedTrackDATAi`
- Size: `1416b`

## Match Evidence
- Before: `0.3%` (selector output for `_SeTrackDataExecute`)
- After: `60.943504%` (from `build/tools/objdiff-cli diff -p . -u main/RedSound/RedExecute -o - _SeTrackDataExecute__FP12RedTrackDATAi`)
- Build verification: `ninja` passes.

## Plausibility Rationale
- This change follows the existing RedSound code style (raw offset-based field access over speculative struct rewrites) and mirrors expected runtime behavior for envelope/pitch/pan/vibrate step-down updates.
- The implementation avoids contrived compiler-coaxing patterns and uses direct state-machine style logic that matches how adjacent RedSound runtime code is written.

## Technical Details
- Added step-based clamped decrements for time-sliced counters and corresponding accumulator updates.
- Preserved voice dirty-bit updates and conditional pitch recompute path.
- Preserved per-field short countdown behavior and voice-side short countdown updates.
