### PR TITLE
menu_item: decompile ItemOpen__8CMenuPcsFv first pass

### DIFF
--- a/include/ffcc/menu_item.h
+++ b/include/ffcc/menu_item.h
@@ -6,7 +6,7 @@ class CMenuPcs
 public:
     void ItemInit();
     void ItemInit1();
-    void ItemOpen();
+    bool ItemOpen();
     int ItemCtrl();
     void ItemClose();
     void ItemDraw();

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -3,34 +3,87 @@
 typedef signed short s16;
 typedef unsigned char u8;
 
+struct MenuItemOpenAnim {
+    s16 x;
+    s16 y;
+    s16 w;
+    s16 h;
+    float alpha;
+    float scale;
+    int frame;
+    int duration;
+    unsigned int flags;
+    float progress;
+    float dx;
+    float dy;
+    float targetX;
+    float targetY;
+};
+
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * Address:\tTODO
+ * Size:\tTODO
  */
 void CMenuPcs::ItemInit()
 {
-	// TODO
+    // TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * Address:\tTODO
+ * Size:\tTODO
  */
 void CMenuPcs::ItemInit1()
 {
-	// TODO
+    // TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8015aa98
+ * PAL Size: 444b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::ItemOpen()
+bool CMenuPcs::ItemOpen()
 {
-	// TODO
+    s16* itemState = *reinterpret_cast<s16**>(reinterpret_cast<u8*>(this) + 0x82C);
+    s16* itemList = *reinterpret_cast<s16**>(reinterpret_cast<u8*>(this) + 0x850);
+    int finished = 0;
+    int count = itemList[0];
+    MenuItemOpenAnim* anim = reinterpret_cast<MenuItemOpenAnim*>(reinterpret_cast<u8*>(itemList) + 8);
+
+    if (*reinterpret_cast<u8*>(itemState + 5) == 0) {
+        SingLifeInit(-1);
+        ItemInit();
+    }
+
+    itemState[0x11]++;
+
+    for (int i = 0; i < count; i++, anim++) {
+        if (anim->frame <= itemState[0x11]) {
+            if (itemState[0x11] < anim->frame + anim->duration) {
+                anim->frame++;
+                anim->progress = (float)anim->frame / (float)anim->duration;
+                if ((anim->flags & 2) == 0) {
+                    float t = (float)anim->frame / (float)anim->duration;
+                    anim->dx = (anim->targetX - (float)anim->x) * t;
+                    anim->dy = (anim->targetY - (float)anim->y) * t;
+                }
+            } else {
+                finished++;
+                anim->progress = 1.0f;
+                anim->dx = 0.0f;
+                anim->dy = 0.0f;
+            }
+        }
+    }
+
+    return count == finished;
 }
 
 /*
@@ -74,28 +127,28 @@ int CMenuPcs::ItemCtrl()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * Address:\tTODO
+ * Size:\tTODO
  */
 void CMenuPcs::ItemClose()
 {
-	// TODO
+    // TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * Address:\tTODO
+ * Size:\tTODO
  */
 void CMenuPcs::ItemDraw()
 {
-	// TODO
+    // TODO
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * Address:\tTODO
+ * Size:\tTODO
  */
 int CMenuPcs::ItemCtrlCur()
 {


### PR DESCRIPTION
## Summary
Implemented a first-pass decomp for `CMenuPcs::ItemOpen()` in `src/menu_item.cpp` and updated the declaration in `include/ffcc/menu_item.h` to the recovered `bool` return type.

## Functions improved
- Unit: `main/menu_item`
- Symbol: `ItemOpen__8CMenuPcsFv` (PAL 0x8015aa98, 444b)

## Match evidence
`build/GCCP01/report.json` fuzzy-match changes:
- `main/menu_item`: **3.4962406% -> 5.947947%**
- `ItemOpen__8CMenuPcsFv`: **0.9009009% -> 39.09009%**

## Plausibility rationale
- Uses existing menu state pointers/offsets already present in this TU (`0x82C`, `0x850`).
- Implements straightforward open-animation progression logic from recovered control flow (counter advance, per-entry progress, interpolation, completion check), without compiler-coaxing patterns.
- Keeps remaining item functions untouched as TODO for incremental follow-up.

## Technical notes
- Local `build/tools/objdiff-cli` in this tree is `v3.4.1` (no JSON oneshot support from AGENTS examples), so progress evidence above is from `report.json` symbol fuzzy-match metrics after rebuild.
