### PR TITLE
file: match __sinit_file_cpp base+derived vtable init

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -684,6 +684,8 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
  */
 extern "C" void __sinit_file_cpp(void)
 {
+    extern void* __vt__8CManager[];
     extern void* __vt__5CFile[];
+    *(void**)&File = __vt__8CManager;
     *(void**)&File = __vt__5CFile;
 }


### PR DESCRIPTION
## Summary
- Update `__sinit_file_cpp` in `src/file.cpp` to initialize `File` with the base-class vtable (`__vt__8CManager`) before overriding with the derived vtable (`__vt__5CFile`).
- Keep code source-plausible by expressing standard C++ base/derived initialization behavior in static init.

## Functions improved
- Unit: `main/file`
- Function: `__sinit_file_cpp` (`32b`)
  - Before: `60.0%`
  - After: `100.0%`

## Match evidence
- Unit fuzzy match:
  - Before: `75.57608%`
  - After: `75.85752%`
- Project progress delta after rebuild:
  - Matched code: `199496 -> 199528` bytes
  - Matched functions: `1482 -> 1483`
- Assembly alignment detail:
  - Target sequence writes `__vt__8CManager` to `File`, then writes `__vt__5CFile`.
  - Previous source only emitted the second write.
  - New source emits both writes in correct order, matching target instruction pattern for this function.

## Plausibility rationale
- Writing base then derived vtable is the expected behavior for constructor/static-init sequencing in inheritance hierarchies.
- This is not compiler coaxing; it restores a semantically meaningful initialization step consistent with `CFile` deriving from `CManager`.

## Technical details
- Added `extern void* __vt__8CManager[];` and an explicit first assignment before existing `__vt__5CFile` assignment.
- Rebuilt with `ninja`; validated with `build/GCCP01/report.json` and symbol disassembly comparison for `__sinit_file_cpp`.
