### PR TITLE
RedMemory: align RedNewA A-bank-full debug path

### DIFF
--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -177,6 +177,7 @@ int RedNewA(int size, int offset, int maxSize)
 	if (DAT_8032f4a4[0x7FF] >= 1) {
 		if (DAT_8032f408) {
 			OSReport(s__s_sA_Memory_Bank_Full____s_801e78b5, &DAT_801e78a3, &DAT_80333d20, &DAT_80333d28);
+			fflush(&DAT_8021d1a8);
 		}
 		return 0;
 	}


### PR DESCRIPTION
## Summary
- Updated `RedNewA(int size, int offset, int maxSize)` in `src/RedSound/RedMemory.cpp` to flush debug output in the A-bank-full path.
- Added `fflush(&DAT_8021d1a8);` immediately after `OSReport(...)` when `DAT_8032f408 != 0` and the A memory bank allocation table is full.

## Functions improved
- Unit: `main/RedSound/RedMemory`
- Function: `RedNewA__Fiii`

## Match evidence
- `RedNewA__Fiii`: **56.458332% -> 56.520832%** (`tools/objdiff-cli diff -p . -u main/RedSound/RedMemory -o - RedNewA__Fiii`)
- Instruction alignment improved by one instruction (`MATCH` count 32 -> 33 in objdiff JSON instruction diff summary).
- Collateral checks:
  - `RedNew__Fi`: unchanged at 34.6%
  - `Init__10CRedMemoryFiiii`: unchanged at 48.0%

## Plausibility rationale
- The same memory-full diagnostic path in `RedNew__Fi` already performs `OSReport(...)` followed by `fflush(&DAT_8021d1a8)`.
- Adding the matching flush in `RedNewA__Fiii` is consistent with the existing coding pattern in this unit and with the decomp reference, rather than a compiler-only coercion.

## Technical details
- Build verified with `ninja` (GCCP01): `build/GCCP01/main.dol: OK`.
- Objdiff version used for one-shot JSON evidence: `tools/objdiff-cli v3.6.1`.
