### PR TITLE
game: implement GetFoodLevel and GetTargetCursor

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -117,7 +117,7 @@ public:
     void LoadInit();
     void LoadFinished();
     void GetBossArtifact(int, int);
-    void GetFoodLevel(int, int);
+    int GetFoodLevel(int, int);
     void GetTargetCursor(int, Vec&, Vec&);
     void GetParticleSpecialInfo(PPPIFPARAM&, int&, int&);
     CGPartyObj* GetPartyObj(int);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -517,22 +517,39 @@ void CGame::GetBossArtifact(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800143ec
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGame::GetFoodLevel(int, int)
+int CGame::GetFoodLevel(int playerIndex, int foodIndex)
 {
-	// TODO
+    s16 level = reinterpret_cast<s16*>(m_scriptFoodBase[playerIndex] + 0x3B8)[foodIndex];
+    return level;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800143a4
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGame::GetTargetCursor(int, Vec&, Vec&)
+void CGame::GetTargetCursor(int playerIndex, Vec& posA, Vec& posB)
 {
-	// TODO
+    f32* cursorPos = reinterpret_cast<f32*>(m_scriptFoodBase[playerIndex] + 0xBAC);
+
+    posA.x = cursorPos[0];
+    posA.y = cursorPos[1];
+    posA.z = cursorPos[2];
+
+    posB.x = cursorPos[3];
+    posB.y = cursorPos[4];
+    posB.z = cursorPos[5];
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two previously stubbed `CGame` methods in `src/game.cpp` using straightforward field-based access that matches existing class layout and calling patterns:
- `CGame::GetFoodLevel(int, int)`
- `CGame::GetTargetCursor(int, Vec&, Vec&)`

Also updated `include/ffcc/game.h` so `GetFoodLevel` returns `int`, matching the compiled calling convention used by this object.

## Functions improved
Unit: `main/game`
- `GetFoodLevel__5CGameFii` (32b)
- `GetTargetCursor__5CGameFiR3VecR3Vec` (72b)

## Match evidence
From `build/GCCP01/report.json`:
- `GetFoodLevel__5CGameFii`: **12.5% -> 92.5%**
- `GetTargetCursor__5CGameFiR3VecR3Vec`: **5.5555553% -> 93.888885%**

Objdiff confirms both functions now align closely in instruction flow and memory access pattern, with only minor remaining opcode/register differences.

## Plausibility rationale
These changes are source-plausible and not compiler-coaxing:
- Both methods now perform direct reads from existing `m_scriptFoodBase[playerIndex]` data regions using stable offsets.
- Control flow is simple and idiomatic for accessor helpers.
- No artificial temporaries, no hardcoded assembly tricks, and no readability regressions.

## Technical details
- `GetFoodLevel` now computes `m_scriptFoodBase[playerIndex] + 0x3B8` and indexes 16-bit entries by `foodIndex`.
- `GetTargetCursor` now reads two contiguous 3-float vectors at offsets `0xBAC..0xBC0` into output references.
- Function metadata comments were updated with PAL address/size for both methods.
