### PR TITLE
main/chara_fur: implement ChangeMogMode

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -157,6 +157,7 @@ class CChara
     void ResetAmem(int);
     void TimeMogFur();
     void CalcMogScore();
+    void ChangeMogMode(int);
 };
 
 #endif // _FFCC_CHARA_H_

--- a/src/chara_fur.cpp
+++ b/src/chara_fur.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/chara_fur.h"
 #include "ffcc/chara.h"
 #include "ffcc/charaobj.h"
+#include "ffcc/sound.h"
 #include "ffcc/system.h"
 
 #include <string.h>
@@ -87,6 +88,32 @@ void CChara::TimeMogFur()
 void CChara::CalcMogScore()
 {
 	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800e10c0
+ * PAL Size: 136b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CChara::ChangeMogMode(int mogMode)
+{
+	int* const mogSoundHandle = reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x200c);
+
+	if (mogMode == 0) {
+		if (*mogSoundHandle != 0) {
+			Sound.StopSe(*mogSoundHandle);
+			*mogSoundHandle = 0;
+		}
+	} else {
+		memset(reinterpret_cast<unsigned char*>(this) + 0x1FE8, 0, 0x2C);
+		*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(this) + 0x200c) = 0x140;
+		*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(this) + 0x2010) = 0xE0;
+		*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(this) + 0x2004) = 0;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added `CChara::ChangeMogMode(int)` in `src/chara_fur.cpp` using the PAL decomp behavior.
- Added the missing method declaration in `include/ffcc/chara.h`.
- Used existing offset-based field access style in this unit to keep source plausibility and avoid artificial compiler coercion.

## Functions improved
- Unit: `main/chara_fur`
- Symbol: `ChangeMogMode__6CCharaFi`
- Before: `0.0%` (from target selector output)
- After: `50.911766%` fuzzy in `build/GCCP01/report.json` (`49.17647%` from direct `objdiff-cli diff`)

## Match evidence
- `ninja` completed successfully and regenerated report.
- Direct objdiff query now returns a concrete match for `ChangeMogMode__6CCharaFi` with non-zero alignment.
- The unit now includes a partial match for this previously-unmatched function.

## Plausibility rationale
- Behavior follows decomp intent directly:
  - mode `0`: stop active mog-related SE handle and clear it
  - mode non-zero: clear mog work block and set initial control fields
- Changes are limited to natural member logic and signature restoration, not temporary-variable shaping or unnatural control flow.

## Technical details
- Implemented using byte-offset access already used in `chara_fur.cpp` (`reinterpret_cast<unsigned char*>(this) + ...`) due incomplete class field reconstruction.
- Added only required dependency include (`ffcc/sound.h`) for `Sound.StopSe`.
