### PR TITLE
goout: first-pass decomp for CGoOutMenu::SetDelMode

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -497,12 +497,112 @@ void CGoOutMenu::DrawGoOut()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80169c18
+ * PAL Size: 1108b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGoOutMenu::SetDelMode(unsigned char)
+void CGoOutMenu::SetDelMode(unsigned char mode)
 {
-	// TODO
+    signed char& delMode = reinterpret_cast<signed char&>(field_0x24[0]);
+    signed char& initSelChar = reinterpret_cast<signed char&>(field_0x24[2]);
+    int& selectedChara = *reinterpret_cast<int*>(&field_0x24[4]);
+
+    delMode = mode;
+    switch (delMode) {
+    case 1:
+        break;
+    case 2:
+        field_0x45 = 0;
+        field_0x34 = -1;
+        field_0x48 = 0;
+        field_0x3c = 0;
+        field_0x40 = 0;
+        if (initSelChar == 0) {
+            MenuPcs.InitSaveLoadMenu();
+        }
+        MenuPcs.SetMenuCharaAnim(selectedChara, 0);
+        initSelChar = 1;
+        break;
+    case 3: {
+        if (Game.game.m_caravanWorkArr[selectedChara].m_caravanLocalFlags == 0) {
+            int activeMainCharacterCount = 0;
+            for (int i = 0; i < 8; i++) {
+                const CCaravanWork& caravanWork = Game.game.m_caravanWorkArr[i];
+                if (caravanWork.m_objType != 0 && caravanWork.m_caravanLocalFlags == 0) {
+                    activeMainCharacterCount++;
+                }
+            }
+
+            if (activeMainCharacterCount < 2) {
+                SetMenuStr(0, 4,
+                           "This character cannot be deleted.",
+                           "",
+                           "At least one non-guest character",
+                           "must remain.");
+                reinterpret_cast<signed char&>(field_0x24[1]) = 2;
+                SetDelMode(0);
+                return;
+            }
+        }
+
+        SetMenuStr(0, 2, "Delete this character?", "  Yes   No");
+        field_0x46 = 1;
+        break;
+    }
+    case 4:
+        SetMenuStr(0, 4,
+                   "Deleted characters",
+                   "cannot be restored.",
+                   "Are you sure?",
+                   "  Yes   No");
+        field_0x46 = 1;
+        break;
+    case 5:
+        if (Game.game.m_caravanWorkArr[selectedChara].m_caravanLocalFlags == 0) {
+            SetMenuStr(0, 1, "The character has been deleted.");
+        } else {
+            SetMenuStr(0, 8,
+                       "The guest character has been deleted.",
+                       "",
+                       "Please restore the character's",
+                       "original save data.",
+                       "",
+                       "To restore a character who is abroad,",
+                       "first select \"Delete Character\" and",
+                       "select the character you wish to restore.");
+        }
+        field_0x46 = 1;
+        MenuPcs.SetMenuCharaAnim(selectedChara, 5);
+        break;
+    case 6:
+        SetMenuStr(0, 6,
+                   "This character is currently abroad",
+                   "and cannot be deleted here. If you",
+                   "wish to delete the character's",
+                   "original data, you must first",
+                   "restore it. Proceed?",
+                   "  Yes   No");
+        field_0x46 = 1;
+        break;
+    case 7:
+        SetMenuStr(0, 5,
+                   "This will restore the character",
+                   "to the state it was in before transfer.",
+                   "It will also prevent the transferred data",
+                   "from returning to this save location.",
+                   "  Yes   No");
+        field_0x46 = 1;
+        break;
+    case 8:
+        MenuPcs.SetMenuCharaAnim(selectedChara, 3);
+        SetMenuStr(0, 1, "The character has been restored.");
+        break;
+    default:
+        break;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced `CGoOutMenu::SetDelMode(unsigned char)` TODO body with a first-pass implementation based on the PAL decomp flow.
- Added version metadata block for the function (`PAL 0x80169c18`, `1108b`).
- Implemented mode switch handling for delete/restore paths, menu text setup, and character animation state transitions using existing typed APIs.

## Functions Improved
- Unit: `main/goout`
- Symbol: `SetDelMode__10CGoOutMenuFUc`

## Match Evidence
- `SetDelMode__10CGoOutMenuFUc`: **0.36101082% -> 49.126354%** (`build/tools/objdiff-cli diff -p . -u main/goout -o - SetDelMode__10CGoOutMenuFUc`)
- Build verification: `ninja` succeeds and reports `build/GCCP01/main.dol: OK`.

## Plausibility Rationale
- The implementation uses existing project structures (`CGoOutMenu` state fields, `Game.game.m_caravanWorkArr`, `MenuPcs` APIs) rather than synthetic helper artifacts.
- Control flow mirrors expected game-menu behavior: mode transition setup, yes/no gating, guest/non-guest handling, and animation mode updates.
- This is a first-pass decomp intended to move from near-0% while keeping source readable and idiomatic for follow-up refinement.

## Technical Details
- Adopted packed-state access already implied by class layout (`field_0x24` region) to drive mode/selection behavior.
- Added explicit call paths for `MenuPcs::InitSaveLoadMenu` and `MenuPcs::SetMenuCharaAnim` in the same state transitions as the reference flow.
- Retained function-local branching structure to improve assembly alignment while avoiding non-source-like compiler coaxing patterns.
