### PR TITLE
pppLocationTitle: improve frame match in particle shape initialization

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -136,14 +136,9 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, Un
             memcpy(&particle->m_color, (u8*)pppLocationTitle + 0x88 + colorOffset, 4);
             particle->m_frame = work->m_cur;
 
-            if (*(s16*)((u8*)shapeTable + 6) != 0) {
-                s16 shape = (s16)(rand() % *(s16*)((u8*)shapeTable + 6));
-                particle->m_shapeA = shape;
-                particle->m_shapeB = shape;
-            } else {
-                particle->m_shapeA = 0;
-                particle->m_shapeB = 0;
-            }
+            s16 shape = (s16)(rand() % *(s16*)((u8*)shapeTable + 6));
+            particle->m_shapeA = shape;
+            particle->m_shapeB = shape;
 
             particle++;
         }


### PR DESCRIPTION
## Summary
- Updated `pppFrameLocationTitle` in `src/pppLocationTitle.cpp` to initialize particle shape indices with a direct modulo assignment.
- Removed the local zero-check branch around shape index selection and kept both shape fields synchronized from one sampled value.

## Functions improved
- Unit: `main/pppLocationTitle`
- Symbol: `pppFrameLocationTitle`

## Match evidence
- `pppFrameLocationTitle` match: **37.690556% -> 41.221497%** (`+3.530941`)
- `pppLocationTitle.o` `.text` match: **47.440914% -> 49.904545%** (`+2.463631`)
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o - pppFrameLocationTitle`

## Plausibility rationale
- The updated code path better aligns with decompilation-derived control flow in this loop by avoiding a defensive branch and using one sampled shape index for both fields.
- The resulting source remains straightforward and idiomatic for this codebase's particle initialization logic.

## Technical details
- Build and verification completed with `ninja`.
- Improvement is localized to frame-time particle initialization in `pppFrameLocationTitle`; no debug comments or analysis artifacts were introduced.
