### PR TITLE
cflat_r2class: first-pass onClassSystemFunc decomp

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1,4 +1,9 @@
 #include "ffcc/cflat_r2class.h"
+#include "ffcc/gobject.h"
+
+extern "C" int __cntlzw(unsigned int);
+extern "C" int IsAnimFinished__8CGObjectFi(CGObject*, int);
+extern "C" void push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(CFlatRuntime2*, CFlatRuntime::CObject*, int);
 
 namespace {
 
@@ -17,6 +22,14 @@ static inline unsigned int CallEngineFlags(void* engineObject)
 	return fn(engineObject);
 }
 
+static inline unsigned int CallEngineFunc48Arg(void* engineObject, unsigned int arg0)
+{
+	typedef unsigned int (*EngineFn)(void*, unsigned int);
+	void** vtable = *reinterpret_cast<void***>(reinterpret_cast<u8*>(engineObject) + 0x48);
+	EngineFn fn = reinterpret_cast<EngineFn>(vtable[2]);
+	return fn(engineObject, arg0);
+}
+
 } // namespace
 
 /*
@@ -31,12 +44,57 @@ void SAFE_CAST_MON_WORK(CGObjWork*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800bb700
+ * PAL Size: 8520b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&)
+void CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int command, int& outResult)
 {
-	// TODO
+	CGObject* engineObject = reinterpret_cast<CGObject*>(object->m_engineObject);
+	unsigned int* localBase = object->m_localBase;
+
+	switch (command) {
+		case -0x9F: {
+			unsigned int finished = static_cast<unsigned int>(IsAnimFinished__8CGObjectFi(engineObject, 0));
+			int topBit = __cntlzw(finished);
+			push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(this, object, (topBit >> 5) & 0xFF);
+			outResult = 0;
+			break;
+		}
+		case -0x9E:
+			engineObject->m_groundHitOffset.x += static_cast<float>(localBase[0]);
+			engineObject->m_groundHitOffset.y += static_cast<float>(localBase[1]);
+			engineObject->m_groundHitOffset.z += static_cast<float>(localBase[2]);
+			push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x9D:
+			push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(
+			    this, object, static_cast<int>(CallEngineFunc48Arg(engineObject, localBase[0])));
+			outResult = 0;
+			break;
+		case -0x9C:
+			push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(this, object, static_cast<int>(engineObject->m_bgColMask));
+			outResult = 0;
+			break;
+		case -0x9A:
+			engineObject->PlayAnim(
+			    static_cast<int>(localBase[0]), 1, 1, static_cast<short>(localBase[1]), static_cast<short>(localBase[2]), 0);
+			push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x99:
+			engineObject->PlayAnim(
+			    static_cast<int>(localBase[0]), 0, 1, static_cast<short>(localBase[1]), static_cast<short>(localBase[2]), 0);
+			push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(this, object, 0);
+			outResult = 0;
+			break;
+		default:
+			break;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented an initial, source-plausible first pass of `CFlatRuntime2::onClassSystemFunc` in `src/cflat_r2class.cpp` using the PAL Ghidra reference as guidance for control flow and data access.

Changes include:
- Added PAL metadata block for the function (`0x800bb700`, `8520b`).
- Replaced stub body with the first opcode cases (`-0x9F`, `-0x9E`, `-0x9D`, `-0x9C`, `-0x9A`, `-0x99`).
- Added explicit external symbol declarations for `__cntlzw`, `IsAnimFinished__8CGObjectFi`, and `push__12CFlatRuntime...` to preserve original calling behavior.
- Added a helper for the vtable `+0x48` virtual dispatch path used by one opcode.

## Functions improved
- Unit: `main/cflat_r2class`
- Symbol: `onClassSystemFunc__13CFlatRuntime2FPQ212CFlatRuntime7CObjectiiRi`

## Match evidence
`tools/objdiff-cli diff -p . -u main/cflat_r2class -o - onClassSystemFunc__13CFlatRuntime2FPQ212CFlatRuntime7CObjectiiRi`

Before:
- `onClassSystemFunc...`: `0.04694836%`
- unit `.text`: `4.0976253%`

After:
- `onClassSystemFunc...`: `4.474648%`
- unit `.text`: `6.8625035%`

## Plausibility rationale
This is a direct first-pass reconstruction of real script-command handling logic rather than compiler-only coaxing:
- Uses existing object fields/methods (`m_groundHitOffset`, `m_bgColMask`, `PlayAnim`) aligned with observed engine semantics.
- Preserves expected runtime behavior (command switch + stack push + out-result signaling).
- Keeps changes localized and readable while establishing structure for follow-up case coverage.

## Technical details
- The function was previously a TODO stub; the new body now emits meaningful command-dispatch code paths.
- One Ghidra-indicated model-field write case (`-0x9B`) was intentionally deferred because the current public `CModel` header does not expose that field yet; this keeps the patch compile-safe and plausible while still delivering measurable codegen alignment.
