### PR TITLE
pppEmission: align serialized state offsets in construct/frame/destruct

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -248,7 +248,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
 void pppConstructEmission(pppEmission* pppEmission_, UnkC* param_2) {
     float baseScale = FLOAT_803311f8;
     int offset = param_2->m_serializedDataOffsets[2];
-    int* state = (int*)((u8*)pppEmission_ + 8 + offset);
+    int* state = (int*)((u8*)pppEmission_ + 0x80 + offset);
 
     state[1] = 0;
     *(u8*)(state + 2) = 0x80;
@@ -296,7 +296,7 @@ void pppConstruct2Emission(pppEmission* pppEmission_, UnkC* param_2) {
  * JP Size: TODO
  */
 void pppDestructEmission(pppEmission* pppEmission_, UnkC* param_2) {
-    int* state = (int*)((u8*)pppEmission_ + 8 + param_2->m_serializedDataOffsets[2]);
+    int* state = (int*)((u8*)pppEmission_ + 0x80 + param_2->m_serializedDataOffsets[2]);
     void* handle = GetCharaHandlePtr__FP8CGObjectl(pppMngStPtr->m_charaObj, 0);
     int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
 
@@ -331,7 +331,7 @@ void pppFrameEmission(pppEmission* pppEmission_, UnkB* param_2, UnkC* param_3) {
     }
 
     int dataSet = param_3->m_serializedDataOffsets[1];
-    int* state = (int*)((u8*)pppEmission_ + 8 + param_3->m_serializedDataOffsets[2]);
+    int* state = (int*)((u8*)pppEmission_ + 0x80 + param_3->m_serializedDataOffsets[2]);
 
     void* handle = GetCharaHandlePtr__FP8CGObjectl(pppMngStPtr->m_charaObj, 0);
     int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);


### PR DESCRIPTION
## Summary
- Adjusted serialized runtime state pointer base in `pppConstructEmission`, `pppFrameEmission`, and `pppDestructEmission` from `+ 8` to `+ 0x80`.
- Kept behavior otherwise unchanged.

## Functions Improved
- `pppFrameEmission`
- `pppDestructEmission`
- `pppConstructEmission`

## Match Evidence (objdiff-cli v3.6.1)
Unit: `main/pppEmission`

- `pppFrameEmission`: `65.969230%` -> `65.973076%` (+`0.003846`)
- `pppDestructEmission`: `85.400000%` -> `85.425000%` (+`0.025000`)
- `pppConstructEmission`: `90.450000%` -> `90.475000%` (+`0.025000`)

Build status:
- `ninja` passes
- `build/GCCP01/main.dol: OK`

## Plausibility Rationale
- The change is a straightforward offset correction for serialized state access and is consistent across all lifecycle functions (construct/frame/destruct), rather than a contrived per-function coaxing.
- No synthetic control-flow or temporary-variable tricks were introduced.

## Technical Details
- Verified with `tools/objdiff-cli diff -p . -u main/pppEmission -o -` before and after.
- Improvement is small but repeatable and localized to expected symbols without regressions in the unit.
