### PR TITLE
GXTexture: match GXInitTexCacheRegion to 100%

### DIFF
--- a/src/gx/GXTexture.c
+++ b/src/gx/GXTexture.c
@@ -712,7 +712,7 @@ void GXLoadTlut(GXTlutObj* tlut_obj, u32 tlut_name) {
 }
 
 void GXInitTexCacheRegion(GXTexRegion* region, u8 is_32b_mipmap, u32 tmem_even, GXTexCacheSize size_even, u32 tmem_odd, GXTexCacheSize size_odd) {
-    u32 WidthExp2;
+    u32 widthExp2;
     __GXTexRegionInt* t = (__GXTexRegionInt*)region;
 
     ASSERTMSGLINE(1484, region, "TexRegion Object Pointer is null");
@@ -722,13 +722,13 @@ void GXInitTexCacheRegion(GXTexRegion* region, u8 is_32b_mipmap, u32 tmem_even, 
 
     switch (size_even) {
     case GX_TEXCACHE_32K:
-        WidthExp2 = 3;
+        widthExp2 = 3;
         break;
     case GX_TEXCACHE_128K:
-        WidthExp2 = 4;
+        widthExp2 = 4;
         break;
     case GX_TEXCACHE_512K:
-        WidthExp2 = 5;
+        widthExp2 = 5;
         break;
     default:
         ASSERTMSGLINEV(1498, 0, "%s: Invalid %s size", "GXInitTexCacheRegion", "tmem even");
@@ -736,23 +736,23 @@ void GXInitTexCacheRegion(GXTexRegion* region, u8 is_32b_mipmap, u32 tmem_even, 
     }
 
     t->image1 = 0;
-    SET_REG_FIELD(1503, t->image1, 15, 0, tmem_even >> 5);
-    SET_REG_FIELD(1504, t->image1, 3, 15, WidthExp2);
-    SET_REG_FIELD(1505, t->image1, 3, 18, WidthExp2);
-    SET_REG_FIELD(1506, t->image1, 1, 21, 0);
+    t->image1 = (t->image1 & 0xFFFF8000) | (tmem_even >> 5);
+    t->image1 = (t->image1 & 0xFFFC7FFF) | (widthExp2 << 15);
+    t->image1 = (t->image1 & 0xFFE3FFFF) | (widthExp2 << 18);
+    t->image1 &= 0xFFDFFFFF;
 
     switch (size_odd) {
     case GX_TEXCACHE_32K:
-        WidthExp2 = 3;
+        widthExp2 = 3;
         break;
     case GX_TEXCACHE_128K:
-        WidthExp2 = 4;
+        widthExp2 = 4;
         break;
     case GX_TEXCACHE_512K:
-        WidthExp2 = 5;
+        widthExp2 = 5;
         break;
     case GX_TEXCACHE_NONE:
-        WidthExp2 = 0;
+        widthExp2 = 0;
         break;
     default:
         ASSERTMSGLINEV(1514, 0, "%s: Invalid %s size", "GXInitTexCacheRegion", "tmem odd");
@@ -760,9 +760,9 @@ void GXInitTexCacheRegion(GXTexRegion* region, u8 is_32b_mipmap, u32 tmem_even, 
     }
 
     t->image2 = 0;
-    SET_REG_FIELD(1519, t->image2, 15, 0, tmem_odd >> 5);
-    SET_REG_FIELD(1520, t->image2, 3, 15, WidthExp2);
-    SET_REG_FIELD(1521, t->image2, 3, 18, WidthExp2);
+    t->image2 = (t->image2 & 0xFFFF8000) | (tmem_odd >> 5);
+    t->image2 = (t->image2 & 0xFFFC7FFF) | (widthExp2 << 15);
+    t->image2 = (t->image2 & 0xFFE3FFFF) | (widthExp2 << 18);
     t->is32bMipmap = is_32b_mipmap;
     t->isCached = 1;
 }


### PR DESCRIPTION
## Summary
Reworked `GXInitTexCacheRegion` in `src/gx/GXTexture.c` to use direct register-mask updates for `image1`/`image2` instead of `SET_REG_FIELD` macro calls.

## Functions improved
- Unit: `main/gx/GXTexture`
- Function: `GXInitTexCacheRegion`

## Match evidence
- `GXInitTexCacheRegion`: **75.90278% -> 100.0%**
- Unit `.text` match (`main/gx/GXTexture`): **87.061325% -> 88.77745%**
- `ninja` build passes and project progress updated accordingly.

## Plausibility rationale
The new code keeps the same semantics while expressing the exact register programming pattern used by the original code path (clear/insert bitfields in sequence for TMEM base and cache size exponents). This is a source-plausible low-level GX implementation style and avoids contrived coercion.

## Technical notes
- `image1` and `image2` are now built through explicit masks:
  - low 15 bits from `tmem_even >> 5` / `tmem_odd >> 5`
  - width exponent fields at shifts 15 and 18
  - bit 21 explicitly cleared for `image1`
- This eliminated remaining instruction diffs for `GXInitTexCacheRegion` in objdiff.
