### PR TITLE
Improve pppSRandUpHCV match by aligning RandF block structure

### DIFF
--- a/src/pppSRandUpHCV.cpp
+++ b/src/pppSRandUpHCV.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/math.h"
 #include "dolphin/types.h"
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern s16 lbl_801EADC8[];
 extern "C" float RandF__5CMathFv(CMath* instance);
@@ -49,32 +49,41 @@ void pppSRandUpHCV(void* param1, void* param2, void* param3)
 		int offset = **base_ptr;
 		target = (float*)((char*)param1 + offset + 0x80);
 
-		int flag = *((u8*)param2 + 0x10);
-		float value;
-
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value + RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value + RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[0] = value;
 		}
-		target[0] = value;
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value + RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value + RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[1] = value;
 		}
-		target[1] = value;
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value + RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value + RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[2] = value;
 		}
-		target[2] = value;
 
-		value = RandF__5CMathFv(&math);
-		if (flag != 0) {
-			value = (value + RandF__5CMathFv(&math)) * 0.5f;
+		{
+			u8 flag = *((u8*)param2 + 0x10);
+			float value = RandF__5CMathFv(math);
+			if (flag != 0) {
+				value = (value + RandF__5CMathFv(math)) * 0.5f;
+			}
+			target[3] = value;
 		}
-		target[3] = value;
 	} else {
 		int** base_ptr = (int**)((char*)param3 + 0xc);
 		int offset = **base_ptr;


### PR DESCRIPTION
## Summary
- Updated `src/pppSRandUpHCV.cpp` to align with established sibling `pppSRand*HCV` source patterns.
- Switched `math` declaration/call site to `extern CMath math[]` and `RandF__5CMathFv(math)`.
- Reworked per-channel random generation into scoped blocks with local `u8 flag` and local `value`, matching the source shape used in nearby matched units.

## Functions improved
- Unit: `main/pppSRandUpHCV`
- Function: `pppSRandUpHCV`

## Match evidence
- Before: `86.310974%` (objdiff)
- After: `97.62195%` (objdiff)
- Additional diff reduction:
  - Inserts: `6 -> 1`
  - Deletes: `9 -> 1`
  - Replaces: `4 -> 2`
  - Arg mismatches: `24 -> 10`

## Plausibility rationale
- The change adopts the same coding idioms already present in `pppSRandDownHCV` and related `pppSRand*` files.
- No contrived compiler-only constructs were introduced; control flow and types are consistent with neighboring original-style source.

## Technical details
- The previous layout produced a non-ideal call/flag-use pattern around repeated `RandF__5CMathFv` calls.
- Mirroring sibling structure (scoped blocks with local flag/value) significantly improved instruction alignment while preserving behavior.
