### PR TITLE
pppYmDrawMdlTexAnm: improve construct/destruct codegen match

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -64,13 +64,11 @@ void pppConstructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmO
         uvLayout = (CMapMeshUVLayout*)mapMesh;
         uvPairs = uvLayout->m_uvPairs;
         for (i = 0; i < (int)uvLayout->m_uvCount; i++) {
-            const f32 u = (f32)uvPairs[0];
-            const f32 v = (f32)uvPairs[1];
-            if (work->m_perU < u) {
-                work->m_perU = u;
+            if (work->m_perU < (f32)uvPairs[0]) {
+                work->m_perU = (f32)uvPairs[0];
             }
-            if (work->m_perV < v) {
-                work->m_perV = v;
+            if (work->m_perV < (f32)uvPairs[1]) {
+                work->m_perV = (f32)uvPairs[1];
             }
             uvPairs += 2;
         }
@@ -95,7 +93,6 @@ void pppDestructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOf
     CMapMeshUVLayout* uvLayout;
     s16* uvPairs;
     u32 frameIndex;
-    u32 frameU;
     u32 i;
 
     work = (pppYmDrawMdlTexAnmWork*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2]);
@@ -103,9 +100,8 @@ void pppDestructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOf
     if ((frameIndex != 0) && ((mapMesh = pppEnvStPtr->m_mapMeshPtr) != NULL)) {
         uvLayout = (CMapMeshUVLayout*)mapMesh;
         uvPairs = uvLayout->m_uvPairs;
-        frameU = frameIndex / work->m_tilesU;
-
         for (i = 0; i < (u32)uvLayout->m_uvCount; i++) {
+            u32 frameU = frameIndex / work->m_tilesU;
             uvPairs[0] = (s16)(-((f32)(frameIndex - frameU * work->m_tilesU) * work->m_perU) - (f32)uvPairs[0]);
             uvPairs[1] = (s16)(-((f32)frameU * work->m_perV) - (f32)uvPairs[1]);
             uvPairs += 2;


### PR DESCRIPTION
## Summary
Refined `pppConstructYmDrawMdlTexAnm` and `pppDestructYmDrawMdlTexAnm` to better match original codegen while preserving behavior.

- Removed temporary UV float locals in `construct` and compared/stored directly from `s16` UV pairs.
- Moved `frameU` derivation inside the UV update loop in `destruct` so division/remainder scheduling aligns better with target code.

## Functions improved
Unit: `main/pppYmDrawMdlTexAnm`

- `pppConstructYmDrawMdlTexAnm`: **57.037975% -> 80.05064%**
- `pppDestructYmDrawMdlTexAnm`: **57.73171% -> 62.109756%**
- Unit fuzzy score: **67.40381% -> 71.550476%**

## Match evidence
`ninja` rebuild + `build/GCCP01/report.json` shows the above function and unit score increases.

Objdiff spot-check after change:
- `pppConstructYmDrawMdlTexAnm`: ~**79.61%**
- `pppDestructYmDrawMdlTexAnm`: ~**62.05%**

## Plausibility rationale
These changes keep logic unchanged and remain source-plausible: they simplify dataflow around UV pair reads and use straightforward per-iteration frame decomposition in destructor UV rollback, both idiomatic for hand-written game code and not compiler-coaxing artifacts.

## Technical details
- No ABI/signature changes.
- No added debug/comment artifacts.
- Verified clean incremental rebuild with `ninja` in GCCP01 configuration.
