### PR TITLE
pppYmMana: first-pass decomp for CalcWaterReflectionVector

### DIFF
--- a/include/ffcc/pppYmMana.h
+++ b/include/ffcc/pppYmMana.h
@@ -23,7 +23,7 @@ void CreateWaterMesh(Vec*, Vec*, Vec2d*, unsigned short*, float);
 void UpdateWaterMesh(VYmMana*);
 void RenderWaterMesh(VYmMana*);
 void CalculateNormal(VYmMana*);
-void CalcWaterReflectionVector(Vec*, Vec*, Vec*, long, Vec&, float (*)[4], _GXColor*, Vec2d*);
+void CalcWaterReflectionVector(Vec*, Vec*, Vec*, long, Vec, float (*)[4], _GXColor*, Vec2d*);
 void CalcReflectionVector2(Vec*, S16Vec*, S16Vec*, long, unsigned long, unsigned long, float (*)[4], void*, unsigned long, _GXColor*, S16Vec2d*, S16Vec2d*, CChara::CNode*, PYmMana*, VYmMana*);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
Implemented a first-pass source reconstruction of `CalcWaterReflectionVector` in `src/pppYmMana.cpp` using the PAL Ghidra reference flow, including matrix transforms, vector reflection, color assignment, UV generation, and cache flushes.

Also corrected the declaration in `include/ffcc/pppYmMana.h` from `Vec&` to `Vec` to match the symbol form used by this unit.

## Functions improved
- Unit: `main/pppYmMana`
- Symbol: `CalcWaterReflectionVector__FP3VecP3VecP3Vecl3VecPA4_fP8_GXColorP5Vec2d`

## Match evidence
- Before (objdiff): symbol was not pairable due mangling mismatch on the decomp side (`...VeclR3Vec...`), effectively `0.0%` with no target mapping.
- After (objdiff): symbol pairs correctly and reports `68.46286%` match.
- Command used:
  - `tools/objdiff-cli diff -p . -u main/pppYmMana -o - CalcWaterReflectionVector__FP3VecP3VecP3Vecl3VecPA4_fP8_GXColorP5Vec2d`

## Plausibility rationale
The implementation follows expected original-source behavior for this rendering helper:
- Camera-position branch on scene id (`m_currentSceneId == 7`) consistent with other particle/render paths.
- Standard Dolphin matrix/vector APIs (`PSMTX*`, `PSVEC*`, `C_VECReflect`) rather than compiler-coaxing constructs.
- Per-vertex reflected vector normalization, color channel selection, and UV remap logic expressed directly and readably.

## Technical details
- Added PAL metadata comment block for this function (`0x800d50dc`, `700b`).
- Used explicit mangled entrypoint name in `pppYmMana.cpp` so objdiff can pair against the original symbol while keeping source behavior clear.
- Build verified with `ninja` in PAL configuration.
