### PR TITLE
gx/GXPixel: improve GXSetFieldMask match

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -301,12 +301,17 @@ void GXSetDstAlpha(GXBool enable, u8 alpha) {
 }
 
 void GXSetFieldMask(GXBool odd_mask, GXBool even_mask) {
+    GXData *gx;
     u32 reg;
 
     CHECK_GXBEGIN(608, "GXSetFieldMask");
-    reg = ((u32)(u8)odd_mask << 1) | (u32)(u8)even_mask | 0x44000000;
+    gx = __GXData;
+
+    reg = (u32)(u8)even_mask;
+    reg = (reg & ~2) | ((u32)(u8)odd_mask << 1);
+    reg = (reg & 0x00FFFFFF) | 0x44000000;
     GX_WRITE_RAS_REG(reg);
-    __GXData->bpSentNot = 0;
+    gx->bpSentNot = 0;
 }
 
 void GXSetFieldMode(GXBool field_mode, GXBool half_aspect_ratio) {


### PR DESCRIPTION
## Summary
- rewrote `GXSetFieldMask` bitfield assembly to follow original BP register composition order
- introduced a local `GXData* gx` and explicit intermediate masks (`& ~2`, `& 0x00FFFFFF`) before final register tag OR
- preserved behavior while improving compiler output alignment

## Functions improved
- Unit: `main/gx/GXPixel`
- Symbol: `GXSetFieldMask`

## Match evidence
- Before: `77.5%` (selector baseline)
- After: `96.79%` in `objdiff-cli diff -p . -u main/gx/GXPixel GXSetFieldMask`
- Report now shows `GXSetFieldMask fuzzy=97.14286%` in `build/GCCP01/report.json`

## Plausibility rationale
- change is source-plausible SDK-style bitfield code, not contrived reorder-only coaxing
- register fields are still expressed as straightforward mask/shift/or operations used throughout Dolphin GX code

## Technical details
- target asm uses an intermediate clear of bit 1 in the even mask path and an explicit 24-bit clear before ORing `0x44000000`
- updated C shape reproduces this dataflow, bringing instruction selection and ordering much closer to target
