### PR TITLE
cflat_r2system: add ReqScreenCapture and CMesMenu::IsUse wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -599,6 +599,56 @@ extern "C" void Read__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
     File.Read(fileHandle);
 }
 
+extern "C" int GetWait__4CMesFv(void*);
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9478
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void ReqScreenCapture__11CGraphicPcsFv(void* graphicPcs)
+{
+    *(int*)((char*)graphicPcs + 0xBC) = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9484
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsUse__8CMesMenuFv(void* mesMenu)
+{
+    if (*(int*)((char*)mesMenu + 8) != 0 && *(int*)((char*)mesMenu + 0xC) < 2 &&
+        GetWait__4CMesFv((char*)mesMenu + 0x1C) != 4) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B94DC
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int GetErrorLevel__7CSystemFv(void* system)
+{
+    int index = *(int*)((char*)system + 0x125C);
+    return *(int*)((char*)system + index * 4 + 0x3CDC);
+}
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- Added missing C-linkage wrapper implementation for `ReqScreenCapture__11CGraphicPcsFv` in `src/cflat_r2system.cpp`.
- Added missing C-linkage wrapper implementation for `IsUse__8CMesMenuFv`, including the `CMes::GetWait()` gate used by the original logic.
- Added `GetErrorLevel__7CSystemFv` wrapper from the same PAL address block (still unresolved in report naming/mapping, see notes below).

## Functions improved
- Unit: `main/cflat_r2system`
- `ReqScreenCapture__11CGraphicPcsFv`: `-1` -> `100.0%` (12b)
- `IsUse__8CMesMenuFv`: `-1` -> `84.0%` (88b)

## Match evidence
- Overall matched code bytes: `199496 -> 199508` (+12)
- Overall matched functions: `1482 -> 1483` (+1)
- Unit fuzzy match: `~3.0% -> 3.229676%`

## Plausibility rationale
- Both added wrappers are straightforward state/query accessors with idiomatic control flow and direct member access, consistent with nearby `cflat_r2system.cpp` shim-style functions.
- No compiler-coaxing temporaries or unnatural sequencing were introduced.

## Technical details
- `ReqScreenCapture__11CGraphicPcsFv` follows Ghidra’s PAL block at `0x800B9478` and sets the screen-capture request flag at offset `0xBC`.
- `IsUse__8CMesMenuFv` follows the `0x800B9484` logic: active/open-state checks plus `CMes::GetWait() != 4`.
- `GetErrorLevel__7CSystemFv` is present in source/object (`nm`), but remains unresolved in report matching (`-1`), likely due symbol/mapping naming divergence around the `0x800B94DC` entry.
