### PR TITLE
memorycard: improve CalcSaveDatHpMax match by restoring artifact HP reads

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1796,19 +1796,19 @@ void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)
             
             // Calculate total HP bonus from equipped accessories
             unsigned int totalHpBonus = 0;
+            unsigned int itemData = *(unsigned int*)(Game + 0xC5B8);
             
             if (equippedItems[0] >= 0) {
-                // TODO: Access Game.game.unkCFlatData0[2] + itemID * 0x48 + 6
-                totalHpBonus += 0; // Placeholder
+                totalHpBonus = (unsigned int)*(unsigned short*)(itemData + equippedItems[0] * 0x48 + 6);
             }
             if (equippedItems[1] >= 0) {
-                totalHpBonus += 0; // Placeholder
+                totalHpBonus += *(unsigned short*)(itemData + equippedItems[1] * 0x48 + 6);
             }
             if (equippedItems[2] >= 0) {
-                totalHpBonus += 0; // Placeholder
+                totalHpBonus += *(unsigned short*)(itemData + equippedItems[2] * 0x48 + 6);
             }
             if (equippedItems[3] >= 0) {
-                totalHpBonus += 0; // Placeholder
+                totalHpBonus += *(unsigned short*)(itemData + equippedItems[3] * 0x48 + 6);
             }
             
             // Calculate final HP max (base 8 + bonuses, capped at 16)


### PR DESCRIPTION
## Summary
Restore `CMemoryCardMan::CalcSaveDatHpMax` to read artifact HP bonus values from the game flat-data table instead of placeholder `+0` values.

## Functions improved
- Unit: `main/memorycard`
- Symbol: `CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`

## Match evidence
- Before: `31.530865%`
- After: `63.851852%`
- Delta: `+32.320987` points
- Checked with:
  - `tools/objdiff-cli diff -p . -u main/memorycard -o - CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`

## Plausibility rationale
The previous code had explicit TODO placeholders where accessory HP values should be accumulated. This change restores plausible original behavior by summing per-item HP bonus fields from the artifact table (`Game + 0xC5B8`, item stride `0x48`, value offset `+6`) and preserving the existing cap logic.

## Technical details
- No control-flow restructuring.
- No synthetic temporaries added for compiler coaxing.
- Single-function logic completion with existing bitmask/equipment selection flow unchanged.
- Full project build passes with `ninja` after the change.
