### PR TITLE
pppRandHCV: use explicit else-if index guard

### DIFF
--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -69,7 +69,7 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
 
         randomValue = (float*)(base + *ctx->outputOffset + 0x80);
         *randomValue = value;
-    } else {
+    } else if (params->index != *(int*)(base + 0xC)) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Updated `pppRandHCV` control flow in `src/pppRandHCV.cpp` to use an explicit `else if (params->index != *(int*)(base + 0xC))` early return guard.
- No behavioral logic changes; this is a source-plausible branch form already used in sibling `ppp*` functions.

## Functions improved
- Unit: `main/pppRandHCV`
- Symbol: `pppRandHCV`

## Match evidence
- objdiff command:
  - `tools/objdiff-cli diff -p . -u main/pppRandHCV -o - pppRandHCV`
- `pppRandHCV` match percent:
  - Before: `85.0458%`
  - After: `85.541985%`
  - Delta: `+0.496185%`

## Plausibility rationale
- The explicit inverse-condition `else if` guard is idiomatic in this codebase and appears in closely related particle helper functions (for example, patterns in `pppRandUpHCV`/`pppRandDownHCV`).
- Change preserves readability and intent while improving generated control-flow alignment.

## Technical details
- Multiple alternatives were tested (pointer typing and offset-local rewrites); these regressed matching.
- This final change was the only tested variant that yielded a positive objdiff delta for `pppRandHCV` without adding contrived temporaries or non-idiomatic constructs.
