### PR TITLE
pppSRandHCV: improve match by fixing color delta arithmetic

### DIFF
--- a/src/pppSRandHCV.cpp
+++ b/src/pppSRandHCV.cpp
@@ -110,28 +110,28 @@ void pppSRandHCV(void* data1, void* data2, void* data3)
 	{
 		s16 current = target_color[0];
 		s16 base = *(s16*)((char*)data2 + 8);
-		s8 delta = (s8)((float)base * target[0] - (float)current);
+		s8 delta = (s8)((float)base * target[0] - (float)base);
 		target_color[0] = (s16)(current + delta);
 	}
 
 	{
 		s16 current = target_color[1];
 		s16 base = *(s16*)((char*)data2 + 0xa);
-		s8 delta = (s8)((float)base * target[1] - (float)current);
+		s8 delta = (s8)((float)base * target[1] - (float)base);
 		target_color[1] = (s16)(current + delta);
 	}
 
 	{
 		s16 current = target_color[2];
 		s16 base = *(s16*)((char*)data2 + 0xc);
-		s8 delta = (s8)((float)base * target[2] - (float)current);
+		s8 delta = (s8)((float)base * target[2] - (float)base);
 		target_color[2] = (s16)(current + delta);
 	}
 
 	{
 		s16 current = target_color[3];
 		s16 base = *(s16*)((char*)data2 + 0xe);
-		s8 delta = (s8)((float)base * target[3] - (float)current);
+		s8 delta = (s8)((float)base * target[3] - (float)base);
 		target_color[3] = (s16)(current + delta);
 	}
 }


### PR DESCRIPTION
## Summary
- Adjusted per-channel delta computation in `pppSRandHCV` to match target arithmetic shape.
- Kept existing control flow and data access pattern intact; only changed the subtraction term used in delta.

## Functions improved
- Unit: `main/pppSRandHCV`
- Symbol: `pppSRandHCV`
- Match: `85.56%` -> `93.21%` (objdiff CLI TUI)

## Match evidence
- Before: objdiff diff view showed ~85.56% match.
- After: objdiff diff view shows ~93.21% match.
- Improvement comes from the color-update math blocks now emitting closer floating-point conversion/fmsubs sequences.

## Plausibility rationale
- The change is type/arithmetics-oriented (signed short to float math) and aligns with the observed target instruction pattern.
- No contrived temporaries or structure-breaking rewrites were introduced.

## Technical details
- In 4 channel update blocks, changed delta from:
  - `(s8)((float)base * target[i] - (float)current)`
  to:
  - `(s8)((float)base * target[i] - (float)base)`
- This better matches the target code generation around integer->double conversion and `fmsubs` use.

## Validation
- `ninja` completed successfully after the change.
