### PR TITLE
pppYmMelt: improve CalcPolygonHeight match by per-vertex world base reload

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -103,16 +103,16 @@ void CalcPolygonHeight(PYmMelt*, VERTEX_DATA* param_2, _GXColor* param_3, float 
     pointCount *= pointCount;
     savedY = ((Vec*)((u8*)pppMngStPtr + 0x58))->y;
 
-    worldBase.x = pppMngStPtr->m_matrix.value[0][3];
-    worldBase.y = pppMngStPtr->m_matrix.value[1][3] + param_2->m_collisionYOffset;
-    worldBase.z = pppMngStPtr->m_matrix.value[2][3];
-
     for (i = 0; i < pointCount; i++) {
         vertex = (YmMeltVertex*)param_3 + i;
         vertex->m_color[0] = param_3->r;
         vertex->m_color[1] = param_3->g;
         vertex->m_color[2] = param_3->b;
         vertex->m_color[3] = param_3->a;
+
+        worldBase.x = pppMngStPtr->m_matrix.value[0][3];
+        worldBase.y = pppMngStPtr->m_matrix.value[1][3] + param_2->m_collisionYOffset;
+        worldBase.z = pppMngStPtr->m_matrix.value[2][3];
 
         pppAddVector(vertex->m_position, vertex->m_position, worldBase);
 


### PR DESCRIPTION
## Summary
- Adjusted `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf` in `src/pppYmMelt.cpp` to reload world-space base translation inside the per-vertex loop.
- Kept behavior identical (same inputs/outputs and side effects), but changed dataflow to better match original codegen.

## Functions improved
- Unit: `main/pppYmMelt`
- Function: `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf`

## Match evidence
- `main/pppYmMelt` fuzzy match: `50.052296% -> 53.26148%` (+3.209184)
- `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf` fuzzy match: `44.134617% -> 60.26282%` (+16.128203)
- Objdiff size alignment for this function improved from `572` bytes to `576` bytes against target `624` bytes.

## Plausibility rationale
- Recomputing matrix translation per vertex is plausible original source for this particle/collision path because collision/map interaction in the same loop is stateful and often coded with per-iteration world transforms in this codebase.
- The change avoids artificial compiler-coax patterns and keeps idiomatic, readable code.

## Technical details
- The previous version hoisted world-base computation before the loop.
- The revised version computes:
  - `worldBase.x = pppMngStPtr->m_matrix.value[0][3]`
  - `worldBase.y = pppMngStPtr->m_matrix.value[1][3] + param_2->m_collisionYOffset`
  - `worldBase.z = pppMngStPtr->m_matrix.value[2][3]`
  inside the loop just before `pppAddVector(...)`, improving instruction scheduling/layout toward the original assembly.
