### PR TITLE
p_usb: improve Init/IsBigAlloc match via stage name symbol usage

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -18,6 +18,7 @@ extern u32 lbl_801E8690[];
 extern u32 lbl_801E869C[];
 extern u32 lbl_801E86A8[];
 extern u32 lbl_801E86B4[];
+extern char lbl_8032F810[];
 extern CUSBPcs USBPcs;
 
 
@@ -37,7 +38,7 @@ CUSBPcs::CUSBPcs()
  */
 void CUSBPcs::Init()
 { 
-	m_smallStage = Memory.CreateStage(0x2000, "CUSBPcs", 0);
+	m_smallStage = Memory.CreateStage(0x2000, lbl_8032F810, 0);
 	m_bigStage = (CMemory::CStage*)nullptr;
 
 	strcpy(m_rootPath, "plot/kmitsuru/");
@@ -80,14 +81,9 @@ void* CUSBPcs::GetTable(unsigned long param)
  */
 void CUSBPcs::IsBigAlloc(int param_2)
 {
-    if (param_2 != 0) {
-        if (m_bigStage == (CMemory::CStage*)nullptr) {
-            m_bigStage = Memory.CreateStage(0x100000, "CUSBPcs", 0);
-        }
-        return;
-    }
-
-    if (m_bigStage != (CMemory::CStage*)nullptr) {
+    if ((param_2 != 0) && (m_bigStage == (CMemory::CStage*)nullptr)) {
+        m_bigStage = Memory.CreateStage(0x100000, lbl_8032F810, 0);
+    } else if ((param_2 == 0) && (m_bigStage != (CMemory::CStage*)nullptr)) {
         Memory.DestroyStage(m_bigStage);
         m_bigStage = (CMemory::CStage*)nullptr;
     }


### PR DESCRIPTION
## Summary
- Replaced `"CUSBPcs"` string literals passed to `CreateStage` with the existing global symbol `lbl_8032F810`.
- Reworked `CUSBPcs::IsBigAlloc` condition layout to match the original create/destroy branch structure while preserving behavior.

## Functions improved
- Unit: `main/p_usb`
- `IsBigAlloc__7CUSBPcsFi`: **77.878784% -> 85.30303%**
- `Init__7CUSBPcsFv`: **87.24138% -> 88.62069%**
- Unit fuzzy match: **84.90606% -> 85.7697%**

## Match evidence
- After rebuilding (`ninja`) and checking `build/GCCP01/report.json`, both `IsBigAlloc` and `Init` increased.
- `IsBigAlloc` gained structural alignment in branch ordering and stage-name symbol relocation usage (global symbol path instead of local string literal path).

## Plausibility rationale
- Using a shared global stage-name symbol for repeated stage creation is source-plausible and consistent with this codebase’s generated symbol usage in init code.
- The `IsBigAlloc` rewrite expresses the same original intent (allocate on demand; destroy when disabled) with conventional control flow rather than compiler-coaxing constructs.

## Technical details
- Added `extern char lbl_8032F810[];` and used it in `Init` and `IsBigAlloc` `CreateStage` calls.
- Updated `IsBigAlloc` to explicit create-vs-destroy branches:
  - create when `param_2 != 0 && m_bigStage == nullptr`
  - destroy when `param_2 == 0 && m_bigStage != nullptr`
