### PR TITLE
pppRyjMegaBirthModel: implement Con/Des callbacks

### DIFF
--- a/include/ffcc/pppRyjMegaBirthModel.h
+++ b/include/ffcc/pppRyjMegaBirthModel.h
@@ -10,6 +10,12 @@ struct VRyjMegaBirthModel
 
 };
 
+struct PRyjMegaBirthModelOffsets
+{
+    u8 _pad0[0xC];
+    s32* m_serializedDataOffsets;
+};
+
 void get_rand(void);
 void get_noise(unsigned char);
 void alloc_check(VRyjMegaBirthModel*, PRyjMegaBirthModel*);
@@ -25,8 +31,8 @@ extern "C" {
 
 void pppRyjMegaBirthModel(void);
 void pppRyjDrawMegaBirthModel(void);
-void pppRyjMegaBirthModelCon(void);
-void pppRyjMegaBirthModelDes(void);
+void pppRyjMegaBirthModelCon(_pppPObject*, PRyjMegaBirthModelOffsets*);
+void pppRyjMegaBirthModelDes(_pppPObject*, PRyjMegaBirthModelOffsets*);
 
 #ifdef __cplusplus
 }

--- a/src/pppRyjMegaBirthModel.cpp
+++ b/src/pppRyjMegaBirthModel.cpp
@@ -1,4 +1,9 @@
 #include "ffcc/pppRyjMegaBirthModel.h"
+#include <string.h>
+
+extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
+extern float FLOAT_80330498;
+extern float FLOAT_8033049c;
 
 /*
  * --INFO--
@@ -125,20 +130,59 @@ void set_matrix(_pppPObject*, pppFMATRIX, pppFMATRIX, PRyjMegaBirthModel*, _PART
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80084260
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppRyjMegaBirthModelCon(void)
+void pppRyjMegaBirthModelCon(_pppPObject* pObject, PRyjMegaBirthModelOffsets* offsets)
 {
-	// TODO
+    u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+    float value0 = FLOAT_80330498;
+    float value1 = FLOAT_8033049c;
+
+    memset(work, 0, 0xC);
+    *(void**)(work + 0xC) = 0;
+    *(void**)(work + 0x10) = 0;
+    *(void**)(work + 0x14) = 0;
+    *(void**)(work + 0x18) = 0;
+    *(u16*)(work + 0x1C) = 10000;
+    *(u16*)(work + 0x1E) = 0;
+    *(float*)(work + 0x20) = value0;
+    *(float*)(work + 0x24) = value1;
+    *(float*)(work + 0x28) = value0;
+    *(float*)(work + 0x2C) = value0;
+    *(float*)(work + 0x30) = value1;
+    *(float*)(work + 0x34) = value0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800841e4
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppRyjMegaBirthModelDes(void)
+void pppRyjMegaBirthModelDes(_pppPObject* pObject, PRyjMegaBirthModelOffsets* offsets)
 {
-	// TODO
+    u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+
+    if (*(void**)(work + 0xC) != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0xC));
+        *(void**)(work + 0xC) = 0;
+    }
+
+    if (*(void**)(work + 0x10) != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x10));
+        *(void**)(work + 0x10) = 0;
+    }
+
+    if (*(void**)(work + 0x14) != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x14));
+        *(void**)(work + 0x14) = 0;
+    }
 }


### PR DESCRIPTION
## Summary
- Implemented `pppRyjMegaBirthModelCon` and `pppRyjMegaBirthModelDes` in `src/pppRyjMegaBirthModel.cpp`.
- Added callback offset type `PRyjMegaBirthModelOffsets` and updated callback prototypes in `include/ffcc/pppRyjMegaBirthModel.h`.
- Added PAL address/size metadata blocks for both functions.

## Functions Improved
- `pppRyjMegaBirthModelDes`
  - objdiff symbol match: `3.2258065% -> 100.0%`
- `pppRyjMegaBirthModelCon`
  - objdiff symbol match: `3.030303% -> 75.0%`

## Match Evidence
- Unit selector baseline before change: `main/pppRyjMegaBirthModel` at `1.2%` current.
- Current report (`build/GCCP01/report.json`) now shows `main/pppRyjMegaBirthModel` fuzzy match `2.4430509%`.
- objdiff (`tools/objdiff-cli diff -p . -u main/pppRyjMegaBirthModel -o - pppRyjDrawMegaBirthModel`) `.text` section match improved:
  - `1.2260046 -> 2.6017404`
- objdiff instruction diff now shows `pppRyjMegaBirthModelDes` fully aligned, with `pppRyjMegaBirthModelCon` mostly aligned and remaining differences concentrated around constant-load/store sequencing.

## Plausibility Rationale
- The new callback code follows established patterns already used in nearby particle units (`pppRyjMegaBirth`, `pppYmMegaBirthShpTail*`):
  - work-area access via `0x80 + m_serializedDataOffsets[2]`
  - staged pointer cleanup through `pppHeapUseRate__FPQ27CMemory6CStage`
  - deterministic initialization of callback work fields
- Changes are source-plausible gameplay/engine callback logic, not compiler-only coercion.

## Technical Notes
- This pass intentionally limited scope to Con/Des callbacks for a clean measurable increment in a large low-match unit.
- `pppRyjMegaBirthModelCon` still has partial mismatch; follow-up work can tune constant load/store ordering to chase full match.
