### PR TITLE
partMng: decompile SetGrow__21CPtrArray

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -19,6 +19,20 @@ void CFlatRuntime::CObject::onNewFinished()
 
 /*
  * --INFO--
+ * PAL Address: 0x8005f61c
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetGrow__21CPtrArray(void* ptrArray, unsigned int growCapacity)
+{
+    *reinterpret_cast<unsigned int*>(reinterpret_cast<char*>(ptrArray) + 0x18) = growCapacity;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x80059220
  * PAL Size: 24b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added a concrete implementation for `SetGrow__21CPtrArray` in `src/partMng.cpp`.
- Used the PAL-addressed function doc block (`0x8005f61c`, `8b`) and implemented the exact field write used by the original object.

## Functions improved
- Unit: `main/partMng`
- Function: `SetGrow__21CPtrArray` (`8b`)
- Before: unmatched (`null` / 0%)
- After: `100.0%` in objdiff for this symbol

## Match evidence
- objdiff instruction diff before fix showed:
  - target: `stw r4, 0x18(r3)`
  - current: `stw r4, 0x0(r3)`
- After fix, objdiff shows exact match for both instructions (`stw r4, 0x18(r3)` and `blr`).
- Project progress change after rebuild:
  - matched code: `199496 -> 199504` (+8 bytes)
  - matched functions: `1482 -> 1483` (+1)
- Unit-level impact (`main/partMng`): matched functions `4/69 -> 5/69`.

## Plausibility rationale
- This is a direct, source-plausible setter implementation (single field assignment) rather than compiler coaxing.
- The final offset (`+0x18`) is justified by target assembly and aligns with existing codebase style for partially-reconstructed internal layouts.

## Technical details
- Added an `extern "C"` symbol-matching function body in `src/partMng.cpp`.
- Stored `growCapacity` via `reinterpret_cast<char*>(ptrArray) + 0x18` to match the original store offset exactly.
