### PR TITLE
pppYmCallBack: improve pppFrameYmCallBack matching

### DIFF
--- a/src/pppYmCallBack.cpp
+++ b/src/pppYmCallBack.cpp
@@ -5,9 +5,8 @@
 
 #include <dolphin/mtx.h>
 
-extern CPartMng PartMng;
+extern u8 PartMng[];
 extern unsigned char* lbl_8032ED50;
-extern "C" void ParticleFrameCallback__5CGameFiiiiiP3Vec(CGame*, int, int, int, int, int, Vec*);
 
 struct YmCallBackObj {
     u8 m_pad0[0xc];
@@ -64,9 +63,10 @@ void pppFrameYmCallBack(void* pppYmCallBack, void* param_2)
         position.z = *(f32*)(mngSt + 0xA4);
         PSMTXMultVec(ppvWorldMatrix, &position, &position);
 
-        mngStIndex = ((s32)(mngSt - ((u8*)&PartMng + 0x2A18))) / 0x158;
-        ParticleFrameCallback__5CGameFiiiiiP3Vec(
-            &Game.game, mngStIndex, (s32)*(s16*)(mngSt + 0x74), (s32)*(s16*)(mngSt + 0x76),
-            (s32)frameParam->m_initWOrk, (s32)frameParam->m_graphId, &position);
+        mngStIndex = ((s32)(mngSt - (PartMng + 0x2A18))) / 0x158;
+        Game.game.ParticleFrameCallback(mngStIndex, (s32)*(s16*)(mngSt + 0x74),
+                                        (s32)*(s16*)(mngSt + 0x76),
+                                        (s32)frameParam->m_initWOrk, (s32)frameParam->m_graphId,
+                                        &position);
     }
 }


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmCallBack` to call `Game.game.ParticleFrameCallback(...)` directly.
- Switched this translation unit's `PartMng` declaration to a raw symbol base (`extern u8 PartMng[]`) and used `PartMng + 0x2A18` for index math.
- Kept runtime behavior the same while improving codegen alignment around particle manager index calculation.

## Functions improved
- Unit: `main/pppYmCallBack`
- Function: `pppFrameYmCallBack` (192 bytes)

## Match evidence
- `pppFrameYmCallBack` fuzzy match: **78.583336% -> 87.229164%**
- Unit `main/pppYmCallBack` fuzzy match: **79.44% -> 87.74%**
- Verified by rebuilding with `ninja` and reading `build/GCCP01/report.json`.

## Plausibility rationale
- The update follows existing project style: member callback call through `Game.game` and explicit manager-base offset arithmetic.
- No artificial control-flow reshaping or dead temporary coercion was added.
- The resulting code remains readable and source-plausible for this decomp stage.

## Technical details
- Prior codegen in this unit used SDA21-style `PartMng` addressing.
- Using a raw symbol base for `PartMng` produced absolute base relocation patterns and significantly improved instruction alignment for this function.
- Some residual mismatch remains around `Game` base materialization order, but this change is a substantial concrete improvement.
