### PR TITLE
menu_compa: restore CompaOpen completion return behavior

### DIFF
--- a/include/ffcc/menu_compa.h
+++ b/include/ffcc/menu_compa.h
@@ -6,7 +6,7 @@ class CMenuPcs
 public:
     void CompaInit();
     void CompaInit0();
-    void CompaOpen();
+    bool CompaOpen();
     void CompaCtrl();
     void CompaClose();
     void CompaDraw();

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -123,7 +123,7 @@ void CMenuPcs::CompaInit0()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMenuPcs::CompaOpen()
+bool CMenuPcs::CompaOpen()
 {
 	int menuState = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c);
 	if (*reinterpret_cast<char*>(menuState + 0xb) == 0) {
@@ -135,6 +135,7 @@ void CMenuPcs::CompaOpen()
 
 	int entryCount = static_cast<int>(**reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850));
 	short* entry = *reinterpret_cast<short**>(reinterpret_cast<char*>(this) + 0x850) + 4;
+	int completeCount = 0;
 	for (int i = 0; i < entryCount; ++i) {
 		if (*reinterpret_cast<int*>(entry + 0x12) <= time) {
 			int duration = *reinterpret_cast<int*>(entry + 0x14);
@@ -150,6 +151,7 @@ void CMenuPcs::CompaOpen()
 						(*reinterpret_cast<float*>(entry + 0x1e) - static_cast<float>(entry[1])) * t;
 				}
 			} else {
+				completeCount = completeCount + 1;
 				*reinterpret_cast<float*>(entry + 8) = 1.0f;
 				*reinterpret_cast<float*>(entry + 0x18) = 0.0f;
 				*reinterpret_cast<float*>(entry + 0x1a) = 0.0f;
@@ -158,6 +160,7 @@ void CMenuPcs::CompaOpen()
 
 		entry += 0x20;
 	}
+	return entryCount == completeCount;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CMenuPcs::CompaOpen` to return a completion-state `bool` instead of `void`.
- Added explicit completion counting for fully finished entries and returned `entryCount == completeCount`.
- Kept existing animation/update logic intact; only signature + completion return flow changed.

## Functions improved
- Unit: `main/menu_compa`
- Symbol: `CompaOpen__8CMenuPcsFv`

## Match evidence
- `objdiff` (`tools/objdiff-cli diff -p . -u main/menu_compa -o - CompaOpen__8CMenuPcsFv`):
  - Before: `41.49074%`
  - After: `45.666668%`
  - Delta: `+4.175928%`
- Unit fuzzy match (`build/GCCP01/report.json`): now `16.13709%` for `main/menu_compa`.

## Plausibility rationale
- Returning completion status for menu open transitions is source-plausible game UI behavior and aligns with the decompilation reference control flow.
- Change avoids contrived compiler-only transformations; it restores a coherent, natural API contract for transition completion.

## Technical details
- Header updated in `include/ffcc/menu_compa.h`:
  - `void CompaOpen();` -> `bool CompaOpen();`
- Implementation updated in `src/menu_compa.cpp`:
  - Added `completeCount` increment in the terminal branch of each entry.
  - Added final return `entryCount == completeCount`.
