### PR TITLE
memory: implement SetGroup and heap walker level helpers

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -156,12 +156,17 @@ void CMemory::Draw()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001EC80
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMemory::SetGroup(void*, int)
+void CMemory::SetGroup(void* ptr, int group)
 {
-	// TODO
+    unsigned char* header = reinterpret_cast<unsigned char*>(ptr) - 0x3e;
+    *header = (*header & 0x0F) | (static_cast<unsigned char>(group) << 4);
 }
 
 /*
@@ -206,22 +211,30 @@ void CMemory::Free(void*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001E6E0
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemory::IncHeapWalkerLevel()
 {
-	// TODO
+    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x7794) += 1;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001E6D0
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemory::DecHeapWalkerLevel()
 {
-	// TODO
+    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x7794) -= 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three `CMemory` methods in `src/memory.cpp` using decomp-guided behavior and existing class layout conventions:
  - `CMemory::IncHeapWalkerLevel`
  - `CMemory::DecHeapWalkerLevel`
  - `CMemory::SetGroup`
- Updated each touched function comment to the project `--INFO--` format with PAL address/size and TODO placeholders for EN/JP.

## Functions improved
- Unit: `main/memory` (`memory.o`)
- `IncHeapWalkerLevel__7CMemoryFv`: **25.0% -> 100.0%**
- `DecHeapWalkerLevel__7CMemoryFv`: **25.0% -> 100.0%**
- `SetGroup__7CMemoryFPvi`: **20.0% -> 88.0%**

## Match evidence
- `main/memory` `.text` match: **2.2089787% -> 2.4557626%**
- Project progress (ninja): code matched bytes **199496 -> 199528** (`+32` bytes)

## Plausibility rationale
- Changes model straightforward original-source intent rather than contrived ordering:
  - heap walker level helpers now perform direct increment/decrement on the backing counter.
  - `SetGroup` updates only the upper nibble of the allocation header group byte while preserving low nibble flags.
- Offset-based access is consistent with this unit's current incomplete class field recovery and existing decomp state.

## Technical details
- Verified with `objdiff-cli` JSON diff (`v3.6.1`) on unit `main/memory` and symbol-specific checks.
- `SetGroup` still has a single instruction-form mismatch (`slwi` vs `clrlslwi`) but materially improves from 20% to 88% while preserving plausible source form.
