### PR TITLE
pppYmLookOn: improve pppFrameYmLookOn match via stack/local alignment

### DIFF
--- a/src/pppYmLookOn.cpp
+++ b/src/pppYmLookOn.cpp
@@ -44,14 +44,14 @@ void pppFrameYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkB* param_2, str
     Vec local_40;
     Vec local_34;
     Vec local_28;
-    Vec local_1c[2];
+    Vec local_1c;
 
-    pppMngSt = pppMngStPtr;
     if (DAT_8032ed70 != 0) {
         return;
     }
 
-    owner = *(u8**)((u8*)pppMngStPtr + 0xdc);
+    pppMngSt = pppMngStPtr;
+    owner = *(u8**)((u8*)pppMngSt + 0xdc);
     dataOffset = *param_3->m_serializedDataOffsets;
     if ((owner != nullptr) || (*(int*)((u8*)pppYmLookOn + dataOffset + 0x80) != 0)) {
         *(u8**)((u8*)pppYmLookOn + dataOffset + 0x80) = owner;
@@ -62,14 +62,14 @@ void pppFrameYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkB* param_2, str
         local_4c.x = *(f32*)(owner + 0x15c);
         local_4c.y = *(f32*)(owner + 0x160) + (f32)param_2->m_dataValIndex;
         local_4c.z = *(f32*)(owner + 0x164);
-        local_58.x = *(f32*)((u8*)pppMngStPtr + 0x84);
-        local_58.y = *(f32*)((u8*)pppMngStPtr + 0x94);
-        local_58.z = *(f32*)((u8*)pppMngStPtr + 0xa4);
-        PSVECSubtract(&local_58, &local_4c, local_1c);
+        local_58.x = *(f32*)((u8*)pppMngSt + 0x84);
+        local_58.y = *(f32*)((u8*)pppMngSt + 0x94);
+        local_58.z = *(f32*)((u8*)pppMngSt + 0xa4);
+        PSVECSubtract(&local_58, &local_4c, &local_1c);
 
-        if (((FLOAT_80330ec8 != local_1c[0].x) || (FLOAT_80330ec8 != local_1c[0].y)) ||
-            (FLOAT_80330ec8 != local_1c[0].z)) {
-            PSVECNormalize(local_1c, &local_40);
+        if (((FLOAT_80330ec8 != local_1c.x) || (FLOAT_80330ec8 != local_1c.y)) ||
+            (FLOAT_80330ec8 != local_1c.z)) {
+            PSVECNormalize(&local_1c, &local_40);
             local_28.z = -local_40.x;
             local_28.x = local_40.z;
             local_28.y = FLOAT_80330ec8;


### PR DESCRIPTION
## Summary
Adjusted `pppFrameYmLookOn` in `src/pppYmLookOn.cpp` to better align with original compiler output while preserving behavior:
- switched temporary subtraction vector from `Vec local_1c[2]` to `Vec local_1c`
- moved `pppMngStPtr` load after the early return guard
- reused `pppMngSt` local for owner/position reads
- updated vector helper calls and zero-vector checks to use `local_1c` directly

## Functions Improved
- Unit: `main/pppYmLookOn`
- Symbol: `pppFrameYmLookOn`
- Match: **86.2% -> 88.69%**

## Match Evidence
- Built with `ninja` successfully.
- Verified in objdiff TUI for `main/pppYmLookOn::pppFrameYmLookOn`.
- Improvement comes from closer stack frame/local variable placement and earlier control-flow/register alignment near function entry.

## Plausibility Rationale
This change is source-plausible and idiomatic:
- removes an unnecessary vector array where only a single temporary vector is used
- avoids redundant global pointer reads by using an existing local
- keeps gameplay logic/math unchanged while improving generated code structure

## Technical Details
The biggest assembly alignment improvements came from:
- matching expected stack size/local layout (`stwu r1, -0x60(r1)`)
- matching load/use order around `DAT_8032ed70`, `pppMngStPtr`, and owner pointer checks
- preserving existing math/control flow and external call sequence (`PSVEC*`, `pppSetFpMatrix`)
