### PR TITLE
cflat_runtime2: implement SetParticleWorkPos

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -51,6 +51,41 @@ static inline float& ParticleWorkTargetZ(CFlatRuntime2* runtime)
 	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x176C);
 }
 
+static inline float*& ParticleWorkPosPtr(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float**>(reinterpret_cast<u8*>(runtime) + 0x16CC);
+}
+
+static inline float*& ParticleWorkPosVecPtr(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float**>(reinterpret_cast<u8*>(runtime) + 0x16D0);
+}
+
+static inline float& ParticleWorkPosX(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1740);
+}
+
+static inline float& ParticleWorkPosY(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1744);
+}
+
+static inline float& ParticleWorkPosZ(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1748);
+}
+
+static inline float& ParticleWorkPosAngle(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x1750);
+}
+
+static inline float& ParticleWorkPosVecBase(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<float*>(reinterpret_cast<u8*>(runtime) + 0x174C);
+}
+
 static inline CFlatRuntime::CObject*& ParticleWorkBind(CFlatRuntime2* runtime)
 {
 	return *reinterpret_cast<CFlatRuntime::CObject**>(reinterpret_cast<u8*>(runtime) + 0x16E0);
@@ -471,12 +506,21 @@ void CFlatRuntime2::SetParticleWorkNo(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A2FC
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::SetParticleWorkPos(Vec&, float)
+void CFlatRuntime2::SetParticleWorkPos(Vec& vec, float angle)
 {
-	// TODO
+	ParticleWorkPosX(this) = vec.x;
+	ParticleWorkPosY(this) = vec.y;
+	ParticleWorkPosZ(this) = vec.z;
+	ParticleWorkPosAngle(this) = 180.0f * angle / 3.1415927f;
+	ParticleWorkPosPtr(this) = &ParticleWorkPosX(this);
+	ParticleWorkPosVecPtr(this) = &ParticleWorkPosVecBase(this);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFlatRuntime2::SetParticleWorkPos(Vec&, float)` in `src/cflat_runtime2.cpp`.
- Added explicit particle-work field accessors for the position fields/pointers used by this function.
- Updated the function INFO block with PAL address/size (`0x8006A2FC`, `64b`).

## Functions improved
- Unit: `main/cflat_runtime2`
- Symbol: `SetParticleWorkPos__13CFlatRuntime2FR3Vecf`

## Match evidence
- Before: `6.25%` (unit diff snapshot taken before implementation)
- After: `100.0%` in `build/GCCP01/report.json` for this symbol
- Objdiff symbol diff now reports `99.375%` with only argument-label diffs on two `lfs ...@sda21` constant loads
- Overall progress delta from build output after change:
  - Matched code: `199540 -> 199604` (`+64` bytes)
  - Matched functions: `1483 -> 1484` (`+1` function)

## Plausibility rationale
- The implementation follows the same source style as neighboring particle-work setters (typed field writes through fixed offsets).
- Logic is straightforward and domain-plausible: copy input position, convert angle units (`180.0f * angle / 3.1415927f`), set working pointers.
- No contrived control flow or compiler-coaxing constructs were introduced.

## Technical details
- Implemented writes to offsets `0x1740`, `0x1744`, `0x1748`, `0x1750`, and pointer slots `0x16CC`/`0x16D0` via local inline accessors.
- Verified by rebuilding with `ninja` and diffing with:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - SetParticleWorkPos__13CFlatRuntime2FR3Vecf`
