### PR TITLE
os/OS: emit asm entry symbols for FPR/DB routines

### DIFF
--- a/src/os/OS.c
+++ b/src/os/OS.c
@@ -85,10 +85,10 @@ u32 __OSIsDebuggerPresent(void) {
 }
 
 /* clang-format off */
-#ifdef __GEKKO__
 asm void __OSFPRInit(void) {
     // clang-format off
     nofralloc
+entry __OSFPRInit
 
     mfmsr r3
     ori r3, r3, 0x2000
@@ -171,7 +171,6 @@ skip_ps_init:
     blr
     // clang-format on
 }
-#endif
 
 static void DisableWriteGatherPipe(void) {
     u32 hid2;
@@ -470,9 +469,9 @@ static void OSExceptionInit(void) {
     DBPrintf("Exceptions initialized...\n");
 }
 
-#ifdef __GEKKO__
-static asm void __OSDBIntegrator(void) {
+asm void __OSDBIntegrator(void) {
     nofralloc
+entry __OSDBIntegrator
 entry __OSDBINTSTART
     li      r5, OS_DBINTERFACE_ADDR
     mflr    r3
@@ -485,16 +484,14 @@ entry __OSDBINTSTART
     blr
 entry __OSDBINTEND
 }
-#endif
 
-#ifdef __GEKKO__
-static asm void __OSDBJump(void) {
+asm void __OSDBJump(void) {
     nofralloc
+entry __OSDBJump
 entry __OSDBJUMPSTART
     bla     OS_DBJUMPPOINT_ADDR
 entry __OSDBJUMPEND
 }
-#endif
 
 __OSExceptionHandler __OSSetExceptionHandler(__OSException exception, __OSExceptionHandler handler) {
     __OSExceptionHandler oldHandler;


### PR DESCRIPTION
## Summary
- Fixed missing asm symbol emission in `src/os/OS.c` for OS exception/debug entry routines by:
  - removing inactive `#ifdef __GEKKO__` guards around these specific asm functions in this build context,
  - making `__OSDBIntegrator` / `__OSDBJump` non-static asm definitions,
  - adding explicit `entry` labels for `__OSFPRInit`, `__OSDBIntegrator`, and `__OSDBJump`.
- This changes symbol visibility/emission only for the three target routines and preserves existing instruction bodies.

## Functions improved
Unit: `main/os/OS`
- `__OSFPRInit` (296b): `null` (unmatched) -> `99.797295%` (`objdiff-cli`)
- `__OSDBIntegrator` (36b): `null` (unmatched) -> `100.0%`
- `__OSDBJump` (4b): `null` (unmatched) -> `100.0%`

## Match evidence
- Pre-change `ninja` progress:
  - All code: `199496 / 1855300` bytes, `1482 / 4733` functions
  - SDK code: `164748 / 266980` bytes, `828 / 1139` functions
- Post-change `ninja` progress:
  - All code: `200000 / 1855300` bytes, `1490 / 4733` functions
  - SDK code: `165252 / 266980` bytes, `836 / 1139` functions
- Post-change `objdiff-cli` one-shot (`tools/objdiff-cli v3.6.1`) confirms direct function-level mapping/match percentages listed above.

## Plausibility rationale
- These routines were already authored as handwritten asm in `OS.c`; the issue was symbol emission/mapping, not behavior.
- Adding explicit `entry` labels and ensuring the asm definitions are emitted is consistent with Metrowerks-style asm conventions and original-source intent.
- No contrived control-flow/type hacks were introduced; instruction sequences for the routines remain unchanged.

## Technical details
- Before this patch, `nm` for `build/GCCP01/src/os/OS.o` showed unresolved `__OSDBINT*`/`__OSDBJUMP*` labels and no exported `__OSFPRInit`/`__OSDB*` function symbols, causing `report.json`/objdiff to treat these as unmatched (`null`).
- After the patch, `nm` shows emitted text symbols:
  - `__OSFPRInit`
  - `__OSDBIntegrator` + `__OSDBINTSTART`
  - `__OSDBJump` + `__OSDBJUMPSTART`
- This restores expected symbol pairing in objdiff and converts prior unmapped functions into high/complete matches.
