### PR TITLE
main/ME_USB_process: improve SetUSBData switch layout match

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -78,6 +78,19 @@ extern "C" void SetUSBData__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialE
     CUSBStreamData* usb = UsbStream(materialEditorPcs);
 
     switch (usb->m_packetCode) {
+    case 0x21:
+        U32At(materialEditorPcs, 0xE8) = 1;
+        ClearTextureData__18CMaterialEditorPcsFv(materialEditorPcs);
+        break;
+    case 0x22:
+        U32At(materialEditorPcs, 0xE8) = 0;
+        break;
+    case 3:
+        U32At(materialEditorPcs, 0x1C) = 1;
+        break;
+    case 4:
+        U32At(materialEditorPcs, 0x1C) = 0;
+        break;
     case 1:
         memcpy(Ptr(materialEditorPcs, 0xEC), usb->m_data, 0x120);
         for (int i = 0; i < 0x20; i++) {
@@ -85,12 +98,6 @@ extern "C" void SetUSBData__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialE
         }
         memcpy(Ptr(materialEditorPcs, 0x16C), Ptr(materialEditorPcs, 0xEC), 0x30);
         DCStoreRange(Ptr(materialEditorPcs, 0xEC), 0x120);
-        break;
-    case 3:
-        U32At(materialEditorPcs, 0x1C) = 1;
-        break;
-    case 4:
-        U32At(materialEditorPcs, 0x1C) = 0;
         break;
     case 0x10: {
         u32** rsdItemRef = reinterpret_cast<u32**>(GetRsdItem__18CMaterialEditorPcsFv(materialEditorPcs));
@@ -162,13 +169,6 @@ extern "C" void SetUSBData__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialE
         DCStoreRange(reinterpret_cast<void*>(rsdItem[5]), dataSize);
         break;
     }
-    case 0x21:
-        U32At(materialEditorPcs, 0xE8) = 1;
-        ClearTextureData__18CMaterialEditorPcsFv(materialEditorPcs);
-        break;
-    case 0x22:
-        U32At(materialEditorPcs, 0xE8) = 0;
-        break;
     case 0x31: {
         u32 size = usb->m_sizeBytes;
         u8* dstBuffer = reinterpret_cast<u8*>(_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(


### PR DESCRIPTION
## Summary
- Reordered early `switch` cases in `SetUSBData__18CMaterialEditorPcsFv` to better match original control-flow block layout.
- No behavioral logic changes were made inside individual case handlers.

## Functions Improved
- Unit: `main/ME_USB_process`
- Symbol: `SetUSBData__18CMaterialEditorPcsFv`

## Match Evidence
- `SetUSBData__18CMaterialEditorPcsFv`: `14.965719%` -> `15.539298%` (`+0.573579`)
- Unit `.text` match: `15.702814%` -> `16.270695%`
- Verified with: `build/tools/objdiff-cli diff -p . -u main/ME_USB_process -o - SetUSBData__18CMaterialEditorPcsFv`

## Plausibility Rationale
- Reordering `switch` cases is source-plausible and common in original game codebases.
- This aligns emitted block ordering with target assembly without adding contrived temporaries, hardcoded control-flow tricks, or readability regressions.

## Technical Details
- Objdiff at function entry showed the target starting with texture-flag/reset handlers while source emitted different early block ordering.
- Moving packet handlers `0x21`, `0x22`, `3`, and `4` ahead of packet `1` reduced early instruction replacements/deletions and improved overall alignment.