### PR TITLE
menu_lst: correct MLstClose signature for improved match

### DIFF
--- a/include/ffcc/menu_lst.h
+++ b/include/ffcc/menu_lst.h
@@ -8,7 +8,7 @@ public:
     void MLstInit1();
     void MLstOpen();
     void MLstCtrl();
-    int MLstClose();
+    void MLstClose();
     void MLstDraw();
     void MLstCtrlCur();
 };

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -299,7 +299,7 @@ void CMenuPcs::MLstCtrl()
  * JP Address: TODO  
  * JP Size: TODO
  */
-int CMenuPcs::MLstClose()
+void CMenuPcs::MLstClose()
 {
 	int completedItems;
 	int currentFrame;
@@ -386,7 +386,7 @@ int CMenuPcs::MLstClose()
 
 				itemCount = itemCount & 7;
 				if (itemCount == 0) {
-					return 1;
+					return;
 				}
 			}
 
@@ -401,10 +401,8 @@ int CMenuPcs::MLstClose()
 			} while (itemCount != 0);
 		}
 
-		return 1;
+		return;
 	}
-
-	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Changed `CMenuPcs::MLstClose` declaration/definition from `int` to `void` to match the PAL symbol (`MLstClose__8CMenuPcsFv`).
- Removed synthetic return values introduced by decompiler-style reconstruction (`return 1` / `return 0`) and kept equivalent early-exit control flow.

## Functions improved
- Unit: `main/menu_lst`
- Symbol: `MLstClose__8CMenuPcsFv`

## Match evidence
- Before: **37.64%** (`build/tools/objdiff-cli diff -p . -u main/menu_lst MLstClose__8CMenuPcsFv`)
- After: **40.53%** (same command after this change)
- Net: **+2.89%**

## Plausibility rationale
- The symbol name encodes a `void` return type (`Fv`), so changing the C++ signature to `void` is ABI- and source-plausible.
- Removing fabricated integer return values aligns with what original game/source authors likely wrote for a close-animation updater that mutates state in-place.

## Technical details
- Updated both declaration and definition to keep type consistency (`include/ffcc/menu_lst.h`, `src/menu_lst.cpp`).
- Preserved existing animation behavior and exit points; only return-type semantics were corrected.
- Verified successful build with `ninja`.
