### PR TITLE
pppLocationTitle: improve pppFrameLocationTitle shape init match

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -136,14 +136,9 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, Un
             memcpy(&particle->m_color, (u8*)pppLocationTitle + 0x88 + colorOffset, 4);
             particle->m_frame = work->m_cur;
 
-            if (*(s16*)((u8*)shapeTable + 6) != 0) {
-                s16 shape = (s16)(rand() % *(s16*)((u8*)shapeTable + 6));
-                particle->m_shapeA = shape;
-                particle->m_shapeB = shape;
-            } else {
-                particle->m_shapeA = 0;
-                particle->m_shapeB = 0;
-            }
+            s16 shape = (s16)(rand() % *(s16*)((u8*)shapeTable + 6));
+            particle->m_shapeA = shape;
+            particle->m_shapeB = shape;
 
             particle++;
         }


### PR DESCRIPTION
## Summary
- Simplified particle shape initialization in `pppFrameLocationTitle` by removing the zero-guard branch and always deriving both shape indices from the same randomized modulo result.
- Kept behavior aligned with existing data model (`m_shapeA`/`m_shapeB` paired) and with the low-level decomp pattern for this function.

## Functions improved
- Unit: `main/pppLocationTitle`
- Symbol: `pppFrameLocationTitle`

## Match evidence
- `objdiff` (before): `37.690556%`
- `objdiff` (after): `41.221497%`
- Net improvement: `+3.530941%`

Commands used:
- `build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o - pppFrameLocationTitle`
- `ninja`

## Plausibility rationale
- This removes defensive branching and uses direct randomized index assignment, which is a simpler, more natural game-code initialization pattern.
- The resulting C is cleaner and closer to how original code likely handled fixed-format shape tables, rather than introducing control-flow solely to influence codegen.

## Technical details
- Updated `src/pppLocationTitle.cpp` in the particle init loop:
  - Replaced conditional shape assignment with unconditional modulo-derived `s16 shape`.
  - Assigned both `m_shapeA` and `m_shapeB` from the same value.
