### PR TITLE
RedMemory: add missing fflush on A-bank full path

### DIFF
--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -177,6 +177,7 @@ int RedNewA(int size, int offset, int maxSize)
 	if (DAT_8032f4a4[0x7FF] >= 1) {
 		if (DAT_8032f408) {
 			OSReport(s__s_sA_Memory_Bank_Full____s_801e78b5, &DAT_801e78a3, &DAT_80333d20, &DAT_80333d28);
+			fflush(&DAT_8021d1a8);
 		}
 		return 0;
 	}


### PR DESCRIPTION
## Summary
- Updated `RedNewA__Fiii` in `src/RedSound/RedMemory.cpp` to flush the debug stream after reporting A-memory bank exhaustion.
- This aligns the error-report side effects with the Ghidra reference behavior for the PAL function.

## Functions improved
- Unit: `main/RedSound/RedMemory`
- Symbol: `RedNewA__Fiii`

## Match evidence
- `RedNewA__Fiii`: **56.458332% -> 56.520832%** (+0.0625)
- `RedNew__Fi`: 34.6% (unchanged)
- `RedDelete__Fi`: 65.59259% (unchanged)

Measured with:
- `tools/objdiff-cli diff -p . -u main/RedSound/RedMemory -o -`

## Plausibility rationale
- `RedNewA` already reports `A Memory Bank Full`; flushing the output stream immediately after `OSReport` is a plausible original behavior and matches the neighboring memory-bank-full handling style.
- Change is minimal and behaviorally coherent (debug/reporting path only), avoiding compiler-coaxing structure changes.

## Technical details
- Added one call: `fflush(&DAT_8021d1a8);` directly after the existing `OSReport(...)` in the `DAT_8032f4a4[0x7FF] >= 1` branch.
- Rebuilt and verified with `ninja` and symbol-level `objdiff` diffing.
