### PR TITLE
monobj: match CGMonObj::GetCID

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -702,10 +702,14 @@ void CGMonObj::CMoveWork::Clear()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80112d54
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 int CGMonObj::GetCID()
 {
-	return 0;
+	return 0xAD;
 }


### PR DESCRIPTION
## Summary
- Updated `CGMonObj::GetCID()` in `src/monobj.cpp` to return the class ID constant `0xAD`.
- Replaced the old placeholder info block with PAL address/size metadata in project format.

## Functions improved
- Unit: `main/monobj`
- Symbol: `GetCID__8CGMonObjFv` (`CGMonObj::GetCID()`)

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` target listing for `main/monobj`)
- After: `100.0%` (from `tools/objdiff-cli diff -p . -u main/monobj -o - GetCID__8CGMonObjFv`)
- Assembly now matches expected 8-byte form:
  - `li r3, 0xad`
  - `blr`
- `ninja` progress also increased by one matched function (`1482 -> 1483`).

## Plausibility rationale
- This change replaces a temporary `return 0;` stub with the object class ID constant expected for `CGMonObj`.
- Returning a fixed class ID from `GetCID()` is consistent with the existing class hierarchy and the style used in other object `GetCID` implementations.
- The resulting source is straightforward and plausible as original game code, not compiler coaxing.

## Technical details
- Confirmed target constant from Ghidra reference (`resources/ghidra-decomp-1-31-2026/80112d54_GetCID__8CGMonObjFv.c`), which returns `0xad`.
- Built with `ninja` and verified symbol-level match via objdiff CLI v3.6.1 oneshot JSON output.
