### PR TITLE
wm_menu: add missing SetMenuCharaAnim helper symbol

### DIFF
--- a/src/wm_menu.cpp
+++ b/src/wm_menu.cpp
@@ -275,6 +275,24 @@ void CMenuPcs::SetMenuCharaAnim(int charaIndex, int animIndex)
 
 /*
  * --INFO--
+ * PAL Address: 0x800fc220
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetMenuCharaAnim__8CMenuPcsFii2(CMenuPcs* menuPcs)
+{
+	unsigned char* const bytes = reinterpret_cast<unsigned char*>(menuPcs);
+	unsigned char* const data = *reinterpret_cast<unsigned char**>(bytes + 0x828);
+
+	data[0xA] = 0;
+	data[0xE] = 0;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800fc1f4
  * PAL Size: 24b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added the missing `SetMenuCharaAnim__8CMenuPcsFii2` symbol implementation in `src/wm_menu.cpp` at PAL address `0x800fc220` (20 bytes).
- The function writes `0` to two menu animation state bytes at offsets `0x0A` and `0x0E` from the object at `this + 0x828`.

## Functions Improved
- Unit: `main/wm_menu`
- Symbol: `SetMenuCharaAnim__8CMenuPcsFii2`

## Match Evidence
- `SetMenuCharaAnim__8CMenuPcsFii2`: unmatched/0% -> **100.0%** (`20b`)
- Verified with: `build/tools/objdiff-cli diff -p . -u main/wm_menu -o - SetMenuCharaAnim__8CMenuPcsFii2`

## Plausibility Rationale
- The implementation directly matches the observed behavior in decomp/reference assembly for this symbol (single pointer load, two zero-byte stores).
- The code uses existing source conventions for unknown menu internals (byte-offset access patterns already used in `wm_menu.cpp`).

## Technical Notes
- The unit already had `SetMenuCharaAnim__8CMenuPcsFii` partially matched (`75%`).
- This change addresses the separate duplicate symbol entry (`...Fii2`) that was previously unmatched.
