### PR TITLE
Improve IsBigAlloc control-flow match in p_usb

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -80,16 +80,13 @@ void* CUSBPcs::GetTable(unsigned long param)
  */
 void CUSBPcs::IsBigAlloc(int param_2)
 {
-    if (param_2 != 0) {
-        if (m_bigStage == (CMemory::CStage*)nullptr) {
-            m_bigStage = Memory.CreateStage(0x100000, "CUSBPcs", 0);
+    if ((param_2 == 0) || (m_bigStage != (CMemory::CStage*)nullptr)) {
+        if ((param_2 == 0) && (m_bigStage != (CMemory::CStage*)nullptr)) {
+            Memory.DestroyStage(m_bigStage);
+            m_bigStage = (CMemory::CStage*)nullptr;
         }
-        return;
-    }
-
-    if (m_bigStage != (CMemory::CStage*)nullptr) {
-        Memory.DestroyStage(m_bigStage);
-        m_bigStage = (CMemory::CStage*)nullptr;
+    } else {
+        m_bigStage = Memory.CreateStage(0x100000, "CUSBPcs", 0);
     }
 }
 


### PR DESCRIPTION
## Summary
- Reshaped `CUSBPcs::IsBigAlloc(int)` control flow in `src/p_usb.cpp` to mirror the original nested conditional form while preserving semantics.
- Kept the same API usage and side effects (stage create on enable when absent, stage destroy on disable when present).

## Functions Improved
- Unit: `main/p_usb`
- Symbol: `IsBigAlloc__7CUSBPcsFi`
- Size: `132b`

## Match Evidence
- Before: `48.78788%`
- After: `77.72727%`
- Delta: `+28.93939` percentage points

Measured via:
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o - IsBigAlloc__7CUSBPcsFi`

Additional check across all match-scored symbols in `main/p_usb` showed no regressions in other functions.

## Plausibility Rationale
- The updated form is idiomatic original-source logic for a two-state allocator toggle and matches the shape shown by decompilation.
- No contrived temporaries, hardcoded offsets, or non-idiomatic coercions were introduced.

## Technical Notes
- This improvement comes from control-flow restructuring only; no data layout or ABI-impacting signature changes were made.
