### PR TITLE
Improve matching for pppRenderYmTracer

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -351,10 +351,6 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, UnkB* param_2, UnkC* param_3)
     work = (f32*)((u8*)pppYmTracer + 0x10 + *param_3->m_serializedDataOffsets);
     polygons = (TRACE_POLYGON*)(u32)work[10];
     count = *(u16*)(work + 0xB);
-    if (polygons == nullptr || count < 2) {
-        return;
-    }
-
     mapMesh = ((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[param_2->m_dataValIndex];
     pppSetBlendMode__FUc(param_2->m_payload[10]);
     pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
@@ -386,48 +382,47 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, UnkB* param_2, UnkC* param_3)
     GXSetCullMode(GX_CULL_NONE);
 
     for (u16 i = 0; i < (u16)(count - 1); i++) {
-        TRACE_POLYGON* current = &polygons[i];
-        TRACE_POLYGON* next = &polygons[i + 1];
+        f32* poly = (f32*)(polygons + i);
         f32 u0;
         f32 u1;
         u32 color0;
         u32 color1;
 
-        if (current->life <= 0) {
+        if (*(s16*)(poly + 8) <= 0) {
             continue;
         }
-        if (current->to.x == FLOAT_803306e8 || current->to.y == FLOAT_803306e8 || current->to.z == FLOAT_803306e8) {
+        if (poly[4] == FLOAT_803306e8 || poly[5] == FLOAT_803306e8 || poly[6] == FLOAT_803306e8) {
             continue;
         }
-        if (current->from.x == FLOAT_803306e8 || current->from.y == FLOAT_803306e8 || current->from.z == FLOAT_803306e8) {
+        if (poly[0] == FLOAT_803306e8 || poly[1] == FLOAT_803306e8 || poly[2] == FLOAT_803306e8) {
             continue;
         }
-        if (next->to.x == FLOAT_803306e8 || next->to.y == FLOAT_803306e8 || next->to.z == FLOAT_803306e8) {
+        if (poly[14] == FLOAT_803306e8 || poly[15] == FLOAT_803306e8 || poly[16] == FLOAT_803306e8) {
             continue;
         }
-        if (next->from.x == FLOAT_803306e8 || next->from.y == FLOAT_803306e8 || next->from.z == FLOAT_803306e8) {
+        if (poly[10] == FLOAT_803306e8 || poly[11] == FLOAT_803306e8 || poly[12] == FLOAT_803306e8) {
             continue;
         }
 
         u0 = (f32)i * uvStep;
         u1 = (f32)(i + 1) * uvStep;
-        color0 = (DAT_803306e0 & 0xFFFFFF00) | current->alpha;
-        color1 = (DAT_803306e4 & 0xFFFFFF00) | next->alpha;
+        color0 = (DAT_803306e0 & 0xFFFFFF00) | *(u8*)((u8*)poly + 0x1F);
+        color1 = (DAT_803306e4 & 0xFFFFFF00) | *(u8*)((u8*)poly + 0x47);
 
         GXBegin((GXPrimitive)0x98, GX_VTXFMT7, 4);
-        GXPosition3f32(current->to.x, current->to.y, current->to.z);
+        GXPosition3f32(poly[4], poly[5], poly[6]);
         GXColor1u32(color0);
         GXTexCoord2f32(u0, FLOAT_803306ec);
 
-        GXPosition3f32(current->from.x, current->from.y, current->from.z);
+        GXPosition3f32(poly[0], poly[1], poly[2]);
         GXColor1u32(color0);
         GXTexCoord2f32(u0, FLOAT_803306e8);
 
-        GXPosition3f32(next->to.x, next->to.y, next->to.z);
+        GXPosition3f32(poly[14], poly[15], poly[16]);
         GXColor1u32(color1);
         GXTexCoord2f32(u1, FLOAT_803306ec);
 
-        GXPosition3f32(next->from.x, next->from.y, next->from.z);
+        GXPosition3f32(poly[10], poly[11], poly[12]);
         GXColor1u32(color1);
         GXTexCoord2f32(u1, FLOAT_803306e8);
     }


### PR DESCRIPTION
## Summary
- Refactored `pppRenderYmTracer` to iterate polygon data via contiguous float layout/offsets instead of per-field struct accesses.
- Removed an early null/count guard in render flow to better match the original control-flow shape.
- Kept behavior-focused checks and draw setup unchanged.

## Functions Improved
- Unit: `main/pppYmTracer`
- Symbol: `pppRenderYmTracer`

## Match Evidence
- `pppRenderYmTracer`: **67.839134% -> 69.582610%** (+1.743476)
- Unit `.text`: **43.560684% -> 44.089710%** (+0.529026)
- `pppFrameYmTracer`: unchanged at **27.203703%**

Measured with:
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer -o - pppFrameYmTracer`

## Plausibility Rationale
- The revised implementation follows the object-memory traversal style seen across other particle/deformation modules.
- Changes are type/layout corrections and control-flow alignment, not artificial temporary-variable coaxing.

## Technical Details
- Uses direct offsets for life/alpha and neighboring segment coordinates (`+0x1F`, `+0x47`, and packed float slots) to align emitted loads/stores with target layout.
- Retains existing GX command sequence and blend/TEV setup while improving instruction-level data access alignment.
