### PR TITLE
os/OSRtc: improve UnlockSram match by removing extra gbs branch

### DIFF
--- a/src/os/OSRtc.c
+++ b/src/os/OSRtc.c
@@ -186,13 +186,6 @@ static int UnlockSram(int commit, u32 offset) {
             Scb.offset = offset;
         }
 
-        if (Scb.offset <= 0x14) {
-            OSSramEx* sram = (OSSramEx*)(Scb.sram + sizeof(OSSram));
-            if (((u32)sram->gbs & 0x7c00) == 0x5000 || ((u32)sram->gbs & 0xc0) == 0xc0) {
-                sram->gbs = 0;
-            }
-        }
-
         Scb.sync = WriteSram(&Scb.sram[Scb.offset], Scb.offset, SRAM_SIZE - Scb.offset);
         if (Scb.sync != 0) {
             Scb.offset = SRAM_SIZE;


### PR DESCRIPTION
## Summary
- Removed an extra `Scb.offset <= 0x14` branch in `UnlockSram` that sanitized `OSSramEx::gbs` before `WriteSram`.
- Kept all existing checksum/update and SRAM write flow intact.

## Functions improved
- Unit: `main/os/OSRtc`
- Symbol: `UnlockSram`
  - Before: `91.28866%`
  - After: `98.015465%`

## Match evidence
- `objdiff` (`build/tools/objdiff-cli diff -p . -u main/os/OSRtc -o -`)
  - Unit `.text` match: `88.451324%` -> `90.37611%`
  - `UnlockSram`: `91.28866%` -> `98.015465%`
- Assembly alignment detail:
  - Removed a 13-instruction `DIFF_INSERT` block around the `Scb.offset` path.
  - Post-change `UnlockSram` has only `MATCH` + `DIFF_ARG_MISMATCH` entries (no insertions), indicating tighter control-flow alignment.

## Plausibility rationale
- The removed block was an isolated guard/mutation on `gbs` that did not match target control flow.
- The resulting code remains straightforward and idiomatic for this module (lock/update/write/unlock) without introducing compiler-coaxing patterns.

## Technical notes
- Sound/progressive mode functions remain low-match due a known symbol/signature mismatch pattern in this unit; this PR focuses only on the concrete `UnlockSram` control-flow mismatch.
