### PR TITLE
cflat_r2system: add missing ReqScreenCapture/IsUse symbols

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -33,6 +33,7 @@ struct CMapCylinderRaw
 extern "C" {
 int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned long);
 void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
+int GetWait__4CMesFv(void*);
 }
 
 /*
@@ -597,6 +598,42 @@ extern "C" void SyncCompleted__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 extern "C" void Read__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 {
     File.Read(fileHandle);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9478
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void ReqScreenCapture__11CGraphicPcsFv(void* graphicPcs)
+{
+    *(int*)((char*)graphicPcs + 0xBC) = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9484
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsUse__8CMesMenuFv(void* mesMenu)
+{
+    int result = 0;
+    int wait;
+
+    if ((*(int*)((char*)mesMenu + 0x8) != 0) && (*(int*)((char*)mesMenu + 0xC) < 2) &&
+        ((wait = GetWait__4CMesFv((char*)mesMenu + 0x1C)), wait != 4)) {
+        result = 1;
+    }
+
+    return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added missing `cflat_r2system` wrapper symbols `ReqScreenCapture__11CGraphicPcsFv` and `IsUse__8CMesMenuFv`.
- Kept implementations source-plausible and consistent with existing thunk style in `src/cflat_r2system.cpp`.
- Added the required PAL metadata comment blocks for both functions.

## Functions improved
- Unit: `main/cflat_r2system`
- `ReqScreenCapture__11CGraphicPcsFv`: `0.0% -> 100.0%` (12b)
- `IsUse__8CMesMenuFv`: `0.0% -> 97.0%` (88b in current config)

## Match evidence
- `tools/agent_select_target.py` baseline listed both symbols as `0.0%` in this unit.
- After change, `build/GCCP01/report.json` reports:
  - `ReqScreenCapture__11CGraphicPcsFv`: `100.0`
  - `IsUse__8CMesMenuFv`: `97.0`
- Global progress moved from `199496` to `199508` matched code bytes and from `1482` to `1483` matched functions.

## Plausibility rationale
- Both additions are straightforward class-thunk style accessors/helpers already common in this TU.
- `ReqScreenCapture` is a direct flag set at the expected object offset.
- `IsUse` follows the expected gate checks (`active`, mode threshold, mes wait state) without contrived compiler-only transformations.

## Technical details
- Added external declaration for `GetWait__4CMesFv` and used it from `IsUse`.
- Iterated control-flow shape to improve codegen alignment while preserving readable/idiomatic source.
- Verified build with `ninja` and symbol-level diffs with `objdiff-cli` JSON one-shot mode.
