### PR TITLE
pppYmTracer2: match pppConstruct2YmTracer2 store order

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -81,7 +81,7 @@ void copyPolygonData(TRACE_POLYGON*, TRACE_POLYGON*)
  */
 void pppConstructYmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
 {
-	float fVar1 = 1.0f; // FLOAT_80331840 placeholder
+	float fVar1 = FLOAT_80331844;
 	unsigned char* puVar2 = (unsigned char*)pppYmTracer2 + 0x80 + *param_2->m_serializedDataOffsets;
 	
 	*(u32*)(puVar2 + 0x28) = 0;
@@ -116,8 +116,8 @@ void pppConstruct2YmTracer2(pppYmTracer2* pppYmTracer2, UnkC* param_2)
 {
 	unsigned char* iVar1 = (unsigned char*)pppYmTracer2 + 0x80 + *param_2->m_serializedDataOffsets;
 	
-	*(short*)(iVar1 + 0x2c) = 0;
 	*(short*)(iVar1 + 0x2e) = 0;
+	*(short*)(iVar1 + 0x2c) = 0;
 	*(short*)(iVar1 + 0x32) = 0;
 }
 


### PR DESCRIPTION
## Summary
- Updated `pppConstruct2YmTracer2` initialization store order in `src/pppYmTracer2.cpp`.
- Replaced a placeholder float literal in `pppConstructYmTracer2` with the named constant `FLOAT_80331844` (no match impact).

## Functions improved
- Unit: `main/pppYmTracer2`
- Symbol improved: `pppConstruct2YmTracer2`

## Match evidence
- `pppConstruct2YmTracer2`: **99.77778% -> 100.0%**
- Non-matching instructions for this symbol: **2 -> 0**
- Verification command used:
  - `tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppConstruct2YmTracer2`

## Plausibility rationale
- The change is a minimal reorder of adjacent zero-initialization stores to packed work data fields.
- This is consistent with plausible original source structure and avoids contrived compiler-coaxing patterns.

## Technical details
- Build validated with `ninja` after the edit.
- Sanity-checked nearby symbols in the same unit to confirm no regressions:
  - `pppDestructYmTracer2`: 100.0% (unchanged)
  - `pppFrameYmTracer2`: 14.6690645% (unchanged)
  - `pppRenderYmTracer2`: 57.247967% (unchanged)
