### PR TITLE
textureman: match CPtrArray<CTexture>::GetSize

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -159,7 +159,7 @@ void CPtrArray<CTexture*>::SetAt(unsigned long index, CTexture* item)
 template <>
 int CPtrArray<CTexture*>::GetSize()
 {
-    return m_numItems;
+    return m_size;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CPtrArray<CTexture*>::GetSize()` in `src/textureman.cpp` to return `m_size` instead of `m_numItems`.
- This is a one-line, source-plausible field-selection fix in the specialized ptr-array implementation.

## Functions Improved
- Unit: `main/textureman`
- Function: `GetSize__21CPtrArray<P8CTexture>Fv` (size `8b`)
- Match: `99.5%` -> `100.0%`

## Match Evidence
- `build/GCCP01/report.json` now shows:
  - `GetSize__21CPtrArray<P8CTexture>Fv`: `100.0%`
- Overall progress moved:
  - matched code: `199540` -> `199548` (`+8` bytes)
  - matched functions: `1483` -> `1484` (`+1`)
- `objdiff-cli diff` now reports a full function match for `GetSize__21CPtrArray<P8CTexture>Fv`.

## Plausibility Rationale
- The change is a straightforward correction of which tracked size field the accessor returns.
- No artificial temporaries, no control-flow coaxing, and no hardcoded offsets were introduced.
- Resulting code remains clean and idiomatic for this template specialization.

## Technical Details
- Verified with:
  - `ninja`
  - `ninja progress`
  - `build/tools/objdiff-cli diff -p . -u main/textureman -o - 'GetSize__21CPtrArray<P8CTexture>Fv'`
- Post-change `objdiff` for the function is instruction-identical (100% match).
