### PR TITLE
RedMemory: improve RedNewA match with full-bank flush

### DIFF
--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -177,6 +177,7 @@ int RedNewA(int size, int offset, int maxSize)
 	if (DAT_8032f4a4[0x7FF] >= 1) {
 		if (DAT_8032f408) {
 			OSReport(s__s_sA_Memory_Bank_Full____s_801e78b5, &DAT_801e78a3, &DAT_80333d20, &DAT_80333d28);
+			fflush(&DAT_8021d1a8);
 		}
 		return 0;
 	}


### PR DESCRIPTION
## Summary
- Added the missing `fflush` call in `RedNewA`'s A-memory-bank-full debug reporting path.
- Kept all other logic and structure unchanged to preserve source plausibility.

## Functions improved
- Unit: `main/RedSound/RedMemory`
- Symbol: `RedNewA__Fiii`

## Match evidence
- `RedNewA__Fiii`: **56.458332% -> 56.520832%** (`build/tools/objdiff-cli diff -p . -u main/RedSound/RedMemory -o - RedNewA__Fiii`)
- No regressions kept; attempted broader rewrites were discarded when they reduced score.

## Plausibility rationale
- `fflush` after `OSReport` in a memory-bank-full error path is consistent with existing behavior in `RedNew` and is a natural original-source pattern, not compiler coaxing.

## Technical details
- Change location: `src/RedSound/RedMemory.cpp` in `RedNewA(int size, int offset, int maxSize)`.
- Added exactly one statement in the existing error-report branch:
  - `fflush(&DAT_8021d1a8);`
