### PR TITLE
RedMemory: improve Init__10CRedMemoryFiiii match

### DIFF
--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -317,12 +317,14 @@ void RedDeleteA(void* param_1)
  */
 void CRedMemory::Init(int param1, int param2, int param3, int param4)
 {
-	DAT_8032f498 = param2 + -0x4000;
-	DAT_8032f4a4 = (int*)(param1 + 0x2000);
+	int* bankA = (int*)(param1 + 0x2000);
+
+	DAT_8032f498 = param2 - 0x4000;
+	DAT_8032f4a4 = bankA;
 	DAT_8032f490 = param1 + 0x4000;
 	DAT_8032f4a0 = (int*)param1;
 	memset((void*)param1, 0, 0x2000);
-	memset(DAT_8032f4a4, 0, 0x2000);
+	memset(bankA, 0, 0x2000);
 	DAT_8032f494 = param3;
 	DAT_8032f49c = param4;
 }


### PR DESCRIPTION
## Summary
- Refined `CRedMemory::Init(int, int, int, int)` in `src/RedSound/RedMemory.cpp` to use an explicit local bank pointer (`bankA`) for the A-bank region.
- Kept logic and ordering plausible/original-source friendly while improving compiler codegen shape.

## Functions Improved
- Unit: `main/RedSound/RedMemory`
- Function: `Init__10CRedMemoryFiiii`

## Match Evidence
- Before: `48.0%` match
- After: `50.625%` match
- Delta: `+2.625%`
- Objdiff instruction-level deltas for this symbol decreased from `36` to `34` differing instructions.

## Plausibility Rationale
- The update is a natural source-level refactor (introducing a local alias for a computed bank pointer) that a game codebase would reasonably contain.
- No contrived control-flow tricks, artificial temporaries, or readability regressions were introduced.

## Technical Details
- Main change: route both assignment and second `memset` through the same computed pointer local.
- This adjusts register/liveness behavior in `Init__10CRedMemoryFiiii` and reduces objdiff divergence while preserving behavior.
