### PR TITLE
map: add CPtrArray<CMapAnimNode*> specializations

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -259,6 +259,51 @@ CMapAnim* CPtrArray<CMapAnim*>::operator[](unsigned long index)
 
 /*
  * --INFO--
+ * PAL Address: 0x80034130
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimNode*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034138
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimNode* CPtrArray<CMapAnimNode*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034270
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimNode* CPtrArray<CMapAnimNode*>::GetAt(unsigned long index)
+{
+    return m_items[index];
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x80034038
  * PAL Size: 8b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
Add explicit `CPtrArray<CMapAnimNode*>` template specializations in `src/map.cpp` for:
- `GetSize()`
- `operator[]`
- `GetAt()`

These were missing in the `main/map` unit and were showing as unresolved 0% targets.

## Functions Improved
Unit: `main/map`
- `GetSize__26CPtrArray<P12CMapAnimNode>Fv` (`8b`): **0.0% -> 100.0%**
- `__vc__26CPtrArray<P12CMapAnimNode>FUl` (`32b`): **0.0% -> 100.0%**
- `GetAt__26CPtrArray<P12CMapAnimNode>FUl` (`16b`): **0.0% -> 99.75%**

## Match Evidence
After rebuild (`ninja`):
- `main/map` matched functions: **14/94 -> 16/94**
- `main/map` matched code: **+40 bytes** (now `432 / 21804`)
- Added two full matches and one near-exact tiny accessor match.

## Plausibility Rationale
This change restores straightforward pointer-array accessors that are consistent with existing `CPtrArray` specializations already present in this file (`CMapAnim*`, `CMapLightHolder*`).
The code is idiomatic original-source style (simple template specializations), not compiler-coaxing.

## Technical Notes
- Implementations mirror the canonical `CPtrArray` behavior used elsewhere in the codebase:
  - `GetSize` returns `m_numItems`
  - `operator[]` forwards to `GetAt`
  - `GetAt` returns `m_items[index]`
- No control-flow tricks, no ABI-altering changes, no behavior changes outside these missing symbols.
