### PR TITLE
main/cflat_r2system: add ReqScreenCapture and IsUse wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/map.h"
 #include "ffcc/maphit.h"
+#include "ffcc/mes.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/p_map.h"
 #include "ffcc/p_menu.h"
@@ -28,6 +29,12 @@ struct CMapCylinderRaw
     Vec m_direction2;
     float m_radius2;
     float m_height2;
+};
+
+struct CSystemErrorLevelSlot
+{
+    char m_pad[0x3CDC];
+    int m_value;
 };
 
 extern "C" {
@@ -597,6 +604,56 @@ extern "C" void SyncCompleted__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 extern "C" void Read__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 {
     File.Read(fileHandle);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9478
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void ReqScreenCapture__11CGraphicPcsFv(void* graphicPcs)
+{
+    *(int*)((char*)graphicPcs + 0xBC) = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9484
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsUse__8CMesMenuFv(void* mesMenu)
+{
+    unsigned char result = 0;
+
+    if ((*(int*)((char*)mesMenu + 0x8) != 0) && (*(int*)((char*)mesMenu + 0xC) <= 1)) {
+        if (((CMes*)((char*)mesMenu + 0x1C))->GetWait() != 4) {
+            result = 1;
+        }
+    }
+
+    return (int)result;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B94DC
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int GetErrorLevel__7CSystemFv(void* system, int index)
+{
+    return ((CSystemErrorLevelSlot*)((char*)system + (index << 2)))->m_value;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added three PAL-addressed wrapper functions in `src/cflat_r2system.cpp` at `0x800B9478`, `0x800B9484`, and `0x800B94DC`
- Implemented `ReqScreenCapture__11CGraphicPcsFv` and `IsUse__8CMesMenuFv` with offset-accurate field access and existing `CMes::GetWait()` usage
- Added a first-pass implementation for `GetErrorLevel__7CSystemFv` with matching symbol/linkage and stable semantics

## Functions improved
- Unit: `main/cflat_r2system`
- `ReqScreenCapture__11CGraphicPcsFv`: 0.0% -> 100.0%
- `IsUse__8CMesMenuFv`: 0.0% -> 100.0%
- `GetErrorLevel__7CSystemFv`: 0.0% -> 68.75% (partial)

## Match evidence
- `python3 tools/agent_select_target.py` baseline showed `main/cflat_r2system` with `20/84` matched functions and listed these targets at 0.0%
- After change, `ninja` report for `main/cflat_r2system` shows `22/84` matched functions (`build/GCCP01/report.json`)
- `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o -` per-symbol results:
  - `ReqScreenCapture__11CGraphicPcsFv`: 100.0
  - `IsUse__8CMesMenuFv`: 100.0
  - `GetErrorLevel__7CSystemFv`: 68.75

## Plausibility rationale
- The changes are small ABI/field-access wrappers consistent with existing style already used throughout `cflat_r2system.cpp`
- No contrived control flow or compiler-coaxing temporaries were introduced; behavior maps directly to symbol intent and existing class memory layout usage in this unit

## Technical details
- Preserved exact mangled symbol names via `extern "C"` wrappers to ensure objdiff symbol pairing in this unit
- `IsUse__8CMesMenuFv` returns an integer boolean from message-menu state checks and `CMes::GetWait()`
- `GetErrorLevel__7CSystemFv` now links and partially matches; remaining gap appears to be instruction-shape/signature-level and should be addressed in a follow-up
