### PR TITLE
OdemuExi2: improve DebuggerDriver mailbox/status read matching

### DIFF
--- a/src/OdemuExi2/DebuggerDriver.c
+++ b/src/OdemuExi2/DebuggerDriver.c
@@ -154,21 +154,28 @@ static BOOL DBGWriteMailbox(u32 p1) {
 
 #pragma dont_inline on
 static BOOL DBGReadMailbox(u32* p1) {
-    BOOL total = FALSE;
-    u32 v;
+    u32 busyFlag;
+    u32 regs;
+    u32 result;
+    u32 cmd;
 
-    DBGEXISelect(4);
+    regs = __EXIRegs[10];
+    __EXIRegs[10] = (regs & 0x405) | 0xc0;
 
-    v = 0x60000000;
-    total |= IS_FALSE(DBGEXIImm(&v, 2, 1));
-    total |= IS_FALSE(DBGEXISync());
+    cmd = 0x60000000;
+    result = ((u32)__cntlzw(DBGEXIImm(&cmd, 2, TRUE))) >> 5;
+    do {
+        busyFlag = __EXIRegs[13];
+    } while (busyFlag & 1);
 
-    total |= IS_FALSE(DBGEXIImm(p1, 4, 0));
-    total |= IS_FALSE(DBGEXISync());
+    result |= ((u32)__cntlzw(DBGEXIImm(p1, 4, FALSE))) >> 5;
+    do {
+        busyFlag = __EXIRegs[13];
+    } while (busyFlag & 1);
 
-    total |= IS_FALSE(DBGEXIDeselect());
-
-    return IS_FALSE(total);
+    regs = __EXIRegs[10];
+    __EXIRegs[10] = regs & 0x405;
+    return ((u32)__cntlzw(result)) >> 5;
 }
 #pragma dont_inline reset
 
@@ -249,21 +256,28 @@ static BOOL DBGWrite(u32 count, u32* buffer, s32 param3) {
 }
 
 inline static BOOL _DBGReadStatus(u32* p1) {
-    BOOL total = FALSE;
-    u32 v;
+    u32 busyFlag;
+    u32 regs;
+    u32 result;
+    u32 cmd;
 
-    DBGEXISelect(4);
+    regs = __EXIRegs[10];
+    __EXIRegs[10] = (regs & 0x405) | 0xc0;
 
-    v = 1 << 30;
-    total |= IS_FALSE(DBGEXIImm(&v, 2, 1));
-    total |= IS_FALSE(DBGEXISync());
+    cmd = 0x40000000;
+    result = ((u32)__cntlzw(DBGEXIImm(&cmd, 2, TRUE))) >> 5;
+    do {
+        busyFlag = __EXIRegs[13];
+    } while (busyFlag & 1);
 
-    total |= IS_FALSE(DBGEXIImm(p1, 4, 0));
-    total |= IS_FALSE(DBGEXISync());
+    result |= ((u32)__cntlzw(DBGEXIImm(p1, 4, FALSE))) >> 5;
+    do {
+        busyFlag = __EXIRegs[13];
+    } while (busyFlag & 1);
 
-    total |= IS_FALSE(DBGEXIDeselect());
-
-    return IS_FALSE(total);
+    regs = __EXIRegs[10];
+    __EXIRegs[10] = regs & 0x405;
+    return ((u32)__cntlzw(result)) >> 5;
 }
 #pragma dont_inline on
 static BOOL DBGReadStatus(u32* p1) {


### PR DESCRIPTION
## Summary
- Reworked `DBGReadMailbox` and `_DBGReadStatus` in `src/OdemuExi2/DebuggerDriver.c` to use the same EXI transaction pattern already used by `DBGRead`/`DBGWrite`.
- Replaced helper-based flow (`DBGEXISelect`/`DBGEXISync`/`DBGEXIDeselect`) with direct EXI register programming and `__cntlzw`-based success aggregation.
- Kept behavior and control intent equivalent while aligning code generation shape with the target object.

## Functions Improved
- Unit: `main/OdemuExi2/DebuggerDriver`
- `DBGReadMailbox`: **50.09302% -> 50.186047%** fuzzy match
- `DBGReadStatus`: **50.09302% -> 50.186047%** fuzzy match

## Match Evidence
- Unit fuzzy match: **52.38393% -> 53.096725%** (`main/OdemuExi2/DebuggerDriver`)
- Build verified with `ninja` after changes.
- `objdiff` one-shot checks show both mailbox/status helpers now align with the same low-level transaction structure as adjacent matched helpers in the same TU.

## Plausibility Rationale
- The change removes an outlier helper-call style in two functions and makes them consistent with neighboring production-style code (`DBGRead`/`DBGWrite`) in the same source file.
- This is a source-plausible normalization of register-level EXI I/O flow, not artificial reordering solely for score coaxing.

## Technical Details
- Added explicit local `regs`, `busyFlag`, `result`, and command words (`0x60000000` / `0x40000000`) to mirror hardware transaction sequencing.
- Used the existing `__cntlzw(... ) >> 5` status fold used elsewhere in this module.
- Preserved return contract and byte sizes for the touched functions while improving instruction-level similarity.
