### PR TITLE
cflat_r2system: add missing screen/menu/system wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -33,6 +33,7 @@ struct CMapCylinderRaw
 extern "C" {
 int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned long);
 void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
+int GetWait__4CMesFv(void*);
 }
 
 /*
@@ -597,6 +598,54 @@ extern "C" void SyncCompleted__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 extern "C" void Read__Q25CFile7CHandleFv(CFile::CHandle* fileHandle)
 {
     File.Read(fileHandle);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9478
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void ReqScreenCapture__11CGraphicPcsFv(void* graphicPcs)
+{
+    *(int*)((char*)graphicPcs + 0xBC) = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9484
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsUse__8CMesMenuFv(void* mesMenu)
+{
+    if (*(int*)((char*)mesMenu + 8) == 0) {
+        return 0;
+    }
+    if (*(int*)((char*)mesMenu + 0xC) >= 2) {
+        return 0;
+    }
+    return GetWait__4CMesFv((char*)mesMenu + 0x1C) != 4;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B94DC
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int GetErrorLevel__7CSystemFv(CSystem* system)
+{
+    return system->m_execParam;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added three missing wrappers in `src/cflat_r2system.cpp` for symbols that existed in `config/GCCP01/symbols.txt` but were not emitted in `build/GCCP01/src/cflat_r2system.o`.
- Implemented:
  - `ReqScreenCapture__11CGraphicPcsFv`
  - `IsUse__8CMesMenuFv`
  - `GetErrorLevel__7CSystemFv`
- Used existing codebase style for accessor/wrapper helpers (typed `char*` offset access plus explicit mangled symbol exports).

## Functions improved
- Unit: `main/cflat_r2system`
- Symbols:
  - `ReqScreenCapture__11CGraphicPcsFv`
  - `IsUse__8CMesMenuFv`
  - `GetErrorLevel__7CSystemFv`

## Match evidence
- `ReqScreenCapture__11CGraphicPcsFv`: **0.0% -> 100.0%**
- `IsUse__8CMesMenuFv`: **0.0% -> 48.545456%**
- `GetErrorLevel__7CSystemFv`: **0.0% -> 49.75%**
- Overall `.text` for `main/cflat_r2system`: now `3.13609%` (`objdiff-cli diff -p . -u main/cflat_r2system --format json`)
- Global progress increased by one matched function in `ninja` progress output.

## Plausibility rationale
- These are small API-style wrappers/getters in a file already composed of offset-based wrapper glue.
- `ReqScreenCapture` and `IsUse` follow the exact control/data flow shown in Ghidra reference for their PAL addresses/sizes.
- `GetErrorLevel` is implemented as a direct `CSystem` field accessor (`m_execParam`), consistent with current field usage and wrapper conventions in this unit.

## Technical details
- Added a local `extern "C"` declaration for `GetWait__4CMesFv` and reused it in `IsUse__8CMesMenuFv`.
- Added full PAL `--INFO--` blocks for each new function using current PAL symbol addresses/sizes.
- Verified resulting symbol emission with `nm -C build/GCCP01/src/cflat_r2system.o`.
