### PR TITLE
pppScreenBreak: implement constructor/destructor routines

### DIFF
--- a/include/ffcc/pppScreenBreak.h
+++ b/include/ffcc/pppScreenBreak.h
@@ -18,9 +18,9 @@ void SB_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int);
 extern "C" {
 #endif
 
-void pppConScreenBreak(void);
-void pppCon2ScreenBreak(void);
-void pppDesScreenBreak(void);
+void pppConScreenBreak(PScreenBreak*, UnkC*);
+void pppCon2ScreenBreak(PScreenBreak*, UnkC*);
+void pppDesScreenBreak(PScreenBreak*, UnkC*);
 void pppFrameScreenBreak(PScreenBreak*, UnkB*, UnkC*);
 void pppRenderScreenBreak(void);
 

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -69,6 +69,7 @@ void* GetCharaHandlePtr__FP8CGObjectl(void*, long);
 int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void*);
 void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
 void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 }
 
 /*
@@ -218,32 +219,85 @@ void SB_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d930
+ * PAL Size: 208b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppConScreenBreak(void)
+void pppConScreenBreak(PScreenBreak* pppScreenBreak, UnkC* param_2)
 {
-	// TODO
+    float* value = (float*)((u8*)&pppScreenBreak->field0_0x0 + 8 + param_2->m_serializedDataOffsets[2]);
+    void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((u8*)pppMngStPtr + 0xD8), 0);
+    int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+    *(u32*)((u8*)*(void**)((u8*)pppMngStPtr + 0xD8) + 0x60) |= 0x40;
+    *(void**)(model + 0xF0) = (void*)SB_BeforeDrawCallback;
+    *(void**)(model + 0xFC) = (void*)SB_DrawMeshDLCallback;
+    *(void**)(model + 0xF4) = (void*)SB_BeforeMeshLockEnvCallback;
+    *(void**)(model + 0xEC) = (void*)SB_BeforeCalcMatrixCallback;
+    value[3] = 0.0f;
+    value[4] = 0.0f;
+    value[8] = FLOAT_80331cc4;
+    value[7] = FLOAT_80331cc4;
+    value[6] = FLOAT_80331cc4;
+    value[2] = FLOAT_80331cc4;
+    value[1] = FLOAT_80331cc4;
+    value[0] = FLOAT_80331cc4;
+    ((u8*)value)[0x24] = 0;
+    ((u8*)value)[0x28] = 0xFF;
+    ((u8*)value)[0x29] = 0xFF;
+    ((u8*)value)[0x2A] = 0xFF;
+    ((u8*)value)[0x2B] = 0xFF;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d90c
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppCon2ScreenBreak(void)
+void pppCon2ScreenBreak(PScreenBreak* pppScreenBreak, UnkC* param_2)
 {
-	// TODO
+    float* value = (float*)((u8*)&pppScreenBreak->field0_0x0 + 8 + param_2->m_serializedDataOffsets[2]);
+    value[2] = FLOAT_80331cc4;
+    value[1] = FLOAT_80331cc4;
+    value[0] = FLOAT_80331cc4;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d870
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDesScreenBreak(void)
+void pppDesScreenBreak(PScreenBreak* pppScreenBreak, UnkC* param_2)
 {
-	// TODO
+    s32 dataOffset = param_2->m_serializedDataOffsets[2];
+    void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((u8*)pppMngStPtr + 0xD8), 0);
+    int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+    if (model != 0) {
+        *(void**)(model + 0xF0) = NULL;
+        *(void**)(model + 0xFC) = NULL;
+        *(void**)(model + 0xF4) = NULL;
+        *(void**)(model + 0xE4) = NULL;
+        *(void**)(model + 0xE8) = NULL;
+        *(void**)(model + 0xEC) = NULL;
+    }
+    if (*(void**)((u8*)pppScreenBreak + 0x8C + dataOffset) != NULL) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*(void**)((u8*)pppScreenBreak + 0x8C + dataOffset));
+        *(void**)((u8*)pppScreenBreak + 0x8C + dataOffset) = NULL;
+    }
+    if (*(void**)((u8*)pppScreenBreak + 0x90 + dataOffset) != NULL) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*(void**)((u8*)pppScreenBreak + 0x90 + dataOffset));
+        *(void**)((u8*)pppScreenBreak + 0x90 + dataOffset) = NULL;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppConScreenBreak`, `pppCon2ScreenBreak`, and `pppDesScreenBreak` in `src/pppScreenBreak.cpp` from the PAL decomp reference instead of TODO stubs.
- Corrected C-linkage prototypes in `include/ffcc/pppScreenBreak.h` to accept `PScreenBreak*` and `UnkC*`, matching how these routines consume serialized offsets/work buffers.
- Added PAL address/size info blocks for the three implemented functions.

## Functions improved
- Unit: `main/pppScreenBreak`
- `pppConScreenBreak` (PAL size 208b)
- `pppCon2ScreenBreak` (PAL size 36b)
- `pppDesScreenBreak` (PAL size 156b)

## Match evidence
Objdiff (`tools/objdiff-cli v3.6.1`, unit `main/pppScreenBreak`):
- `pppConScreenBreak`: **1.9% -> 42.08%**
  - Baseline 1.9% came from `tools/agent_select_target.py` output before the patch.
- `pppCon2ScreenBreak`: **77.00% current**
- `pppDesScreenBreak`: **30.64% current**

Build validation:
- `ninja` passes and regenerates `build/GCCP01/report.json` successfully.

## Plausibility rationale
- Changes restore expected constructor/destructor behavior for the ScreenBreak effect: model callback wiring, state initialization/reset, and heap-backed work buffer cleanup.
- Implementations follow existing project conventions (offset-based data access and callback slot writes used in nearby particle routines), rather than introducing artificial compiler-coaxing control flow.

## Technical details
- Constructor now sets display bit `0x40`, installs draw/calc/mesh callbacks, and initializes runtime value/color bytes from serialized data.
- Secondary constructor now resets the first three runtime floats to the zero constant used by this module.
- Destructor now nulls all relevant model callback/work pointers and releases both stage allocations at `0x8C + offset` and `0x90 + offset` using `pppHeapUseRate__FPQ27CMemory6CStage`.
