### PR TITLE
pppYmTraceMove: align work/param layouts with object ABI

### DIFF
--- a/include/ffcc/pppYmTraceMove.h
+++ b/include/ffcc/pppYmTraceMove.h
@@ -4,23 +4,21 @@
 #include <dolphin/types.h>
 
 struct pppYmTraceMove {
-    union {
-        void* ptr;
-        s32 m_graphId;
-    } field0_0x0;
+    char pad[0x0c];
+    s32 m_graphId;
 };
 
 struct UnkB {
     s32 m_graphId;
     f32 m_dataValIndex;
-    s16 m_initWOrk;
+    f32 m_initWOrk;
     f32 m_stepValue;
-    s16 m_arg3;
-    u16 pad;
-    f32* m_payload;
+    f32 m_arg3;
+    f32 m_payload;
 };
 
 struct UnkC {
+    char pad[0x0c];
     s32* m_serializedDataOffsets;
 };
 

--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -23,14 +23,13 @@ extern "C" {
 void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
 {
 	Vec* dest;
-	Vec local_38;
-	Vec local_2c;
 	Vec local_20;
-	f32 fVar1;
+	Vec local_2c;
+	Vec local_38;
 
 	local_2c.x = *(f32*)((u8*)pppMngStPtr + 0x58);
 	local_2c.y = *(f32*)((u8*)pppMngStPtr + 0x5c);
-	dest = (Vec*)((u8*)(&pppYmTraceMove->field0_0x0 + 2) + *param_2->m_serializedDataOffsets);
+	dest = (Vec*)((u8*)pppYmTraceMove + 0x80 + *param_2->m_serializedDataOffsets);
 	local_2c.z = *(f32*)((u8*)pppMngStPtr + 0x60);
 	local_20.x = *(f32*)((u8*)pppMngStPtr + 0x68);
 	local_20.y = *(f32*)((u8*)pppMngStPtr + 0x6c);
@@ -40,10 +39,9 @@ void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
 	local_38.y = dest[1].z;
 	local_38.z = dest[2].x;
 	pppCopyVector__FR3Vec3Vec(dest, &local_38);
-	fVar1 = 0.0f;
 	dest[3].x = 0.0f;
-	dest[2].z = fVar1;
-	dest[2].y = fVar1;
+	dest[2].z = 0.0f;
+	dest[2].y = 0.0f;
 }
 
 /*
@@ -79,14 +77,14 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 	}
 
 	owner = *(u8**)((u8*)pppMngStPtr + 0xdc);
-	dest = (Vec*)((u8*)(&pppYmTraceMove->field0_0x0 + 2) + *param_3->m_serializedDataOffsets);
+	dest = (Vec*)((u8*)pppYmTraceMove + 0x80 + *param_3->m_serializedDataOffsets);
 	dest[2].z = dest[2].z + dest[3].x;
 	dest[2].y = dest[2].y + dest[2].z;
 
-	if (param_2->m_graphId == pppYmTraceMove->field0_0x0.m_graphId) {
-		dest[2].y = dest[2].y + (f32)param_2->m_initWOrk;
+	if (param_2->m_graphId == pppYmTraceMove->m_graphId) {
+		dest[2].y = dest[2].y + param_2->m_initWOrk;
 		dest[2].z = dest[2].z + param_2->m_stepValue;
-		dest[3].x = dest[3].x + (f32)param_2->m_arg3;
+		dest[3].x = dest[3].x + param_2->m_arg3;
 	}
 
 	if (owner == nullptr) {
@@ -108,7 +106,7 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 		local_a4.z = *(f32*)((u8*)pppMngStPtr + 0x10);
 		pppSubVector__FR3Vec3Vec3Vec(&local_20, &local_b0, &local_a4);
 
-		local_20.y = local_20.y + *(f32*)param_2->m_payload;
+		local_20.y = local_20.y + param_2->m_payload;
 		local_5c.x = local_20.x;
 		local_5c.y = local_20.y;
 		local_5c.z = local_20.z;


### PR DESCRIPTION
## Summary
- Aligned `pppYmTraceMove` object and parameter layouts with observed object ABI/codegen patterns.
- Switched work-data addressing to `obj + 0x80 + serializedOffset` for construct/frame paths.
- Updated `UnkC` to read serialized offsets from `+0x0C`.
- Updated `UnkB` fields used by `pppFrameYmTraceMove` to float slots matching load behavior at offsets `+0x08/+0x0C/+0x10/+0x14`.
- Updated graph-id access to `pppYmTraceMove->m_graphId` at `+0x0C`.

## Functions improved
- Unit: `main/pppYmTraceMove`
- `pppFrameYmTraceMove`: **55.67094% -> 63.44872%**

## Match evidence
- Unit fuzzy score: **55.9% -> 61.194946%**
- `pppConstructYmTraceMove`: **57.0% -> 48.930233%** (regressed)
- Net unit score still improved due large gain in `pppFrameYmTraceMove` (936b target).

## Plausibility rationale
- The changes move this unit toward the same object/work-layout conventions used throughout PPP code:
  - serialized work accessed from `+0x80` object region,
  - offset-table pointer at `UnkC + 0x0C`,
  - direct float parameter loads for frame step values.
- This is a source-plausible ABI/layout correction rather than compiler-only coaxing.

## Technical details
- Disassembly-driven adjustments were made where generated code showed consistent offset/type mismatch:
  - prior code was sign-extending `s16` fields and dereferencing payload pointer in frame path,
  - target object behavior showed direct `lfs` usage from param slots and `+0x80` base work addressing.
