### PR TITLE
partMng: decompile pppGetIfDt and pppShowIdx

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -481,7 +481,7 @@ public:
     void pppDeletePart(int);
     void pppEndPart(int);
 
-    void pppGetIfDt(short);
+    PPPIFPARAM* pppGetIfDt(short);
     void pppShowIdx(short, unsigned char);
     void pppFieldShowFpNo(short, unsigned char);
     void pppFieldEndFpNo(short);

--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -851,22 +851,30 @@ void CPartMng::pppEndPart(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80057e40
+ * PAL Size: 24b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CPartMng::pppGetIfDt(short)
+PPPIFPARAM* CPartMng::pppGetIfDt(short index)
 {
-	// TODO
+	return reinterpret_cast<PPPIFPARAM*>(reinterpret_cast<char*>(this) + (index * 0x158) + 0x130);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80057e2c
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CPartMng::pppShowIdx(short, unsigned char)
+void CPartMng::pppShowIdx(short index, unsigned char visible)
 {
-	// TODO
+	reinterpret_cast<unsigned char*>(this)[(index * 0x158) + 0xe9] = visible;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CPartMng::pppGetIfDt(short)` and `CPartMng::pppShowIdx(short, unsigned char)` in `src/partMng.cpp` using `_pppMngSt` slot-stride offset logic (`0x158` bytes per slot).
- Updated `pppGetIfDt` declaration in `include/ffcc/partMng.h` to return `PPPIFPARAM*`.
- Added PAL metadata blocks for both implemented functions.

## Functions Improved
- Unit: `main/partMng`
- `pppShowIdx__8CPartMngFsUc` (20b): **20.0% -> 99.8%**
- `pppGetIfDt__8CPartMngFs` (24b): **16.666666% -> 99.833336%**

## Match Evidence
- Unit fuzzy match (`main/partMng`): **1.8893653 -> 1.9993874**
- Verified by `objdiff-cli report changes /tmp/objdiff_report.json build/GCCP01/report.json`
- Build passes with `ninja`.

## Plausibility Rationale
- Both implementations are direct field accessors over per-slot particle manager state and match existing code patterns in this unit, which already uses raw offset-based access due incomplete class typing.
- Changes improve decompilation fidelity without introducing compiler-coaxing constructs or non-idiomatic control flow.

## Technical Details
- `pppGetIfDt` now returns pointer to `PPPIFPARAM` at slot offset `0x130`.
- `pppShowIdx` now writes visibility byte at slot offset `0xE9`.
