### PR TITLE
gx/GXInit: reset default tex-region counters before callback install

### DIFF
--- a/src/gx/GXInit.c
+++ b/src/gx/GXInit.c
@@ -490,6 +490,8 @@ void __GXInitGX(void) {
     GXSetChanAmbColor(GX_COLOR1A1, black);
     GXSetChanMatColor(GX_COLOR1A1, white);
     GXInvalidateTexAll();
+    *(u32*)((u8*)__GXData + 0x2C8) = 0;
+    *(u32*)((u8*)__GXData + 0x2CC) = 0;
     GXSetTexRegionCallback((GXTexRegionCallback)__GXDefaultTexRegionCallback);
     GXSetTlutRegionCallback(__GXDefaultTlutRegionCallback);
 


### PR DESCRIPTION
## Summary
- Reset GX default texture-region allocation counters at `__GXData + 0x2C8` and `__GXData + 0x2CC` inside `__GXInitGX()` before installing region callbacks.
- Keep implementation minimal: no behavior restructuring, only state initialization that matches the callback usage pattern.

## Functions improved
- Unit: `main/gx/GXInit`
- Primary function impact: `__GXInitGX`

## Match evidence
- `main/gx/GXInit` fuzzy match: **69.39792% -> 70.34988%** (+0.95196)
- `__GXInitGX` fuzzy match: **90.417114% -> 92.536545%** (+2.119431)
- `ninja` build: passes

## Plausibility rationale
- `__GXDefaultTexRegionCallback` uses counters at offsets `0x2C8/0x2CC` to select rotating cache regions.
- Initializing those counters in `__GXInitGX` is consistent with expected SDK-style startup state and avoids stale counter carry-over.
- Change is source-plausible and keeps code quality/readability intact.

## Technical details
- Added two writes in `src/gx/GXInit.c` immediately before `GXSetTexRegionCallback(...)`:
  - `*(u32*)((u8*)__GXData + 0x2C8) = 0;`
  - `*(u32*)((u8*)__GXData + 0x2CC) = 0;`
- Verified through rebuild and report generation (`ninja`).
