### PR TITLE
pppVertexAttend: improve match by restructuring data load order

### DIFF
--- a/src/pppVertexAttend.cpp
+++ b/src/pppVertexAttend.cpp
@@ -48,21 +48,22 @@ void pppVertexAttend(void* r3, void* r4, void* r5)
     }
 
     VertexAttendStream* stream = *(VertexAttendStream**)((u8*)r5 + 0xC);
-    MtxPtr matrix = (MtxPtr)((u8*)*(void**)((u8*)r3 + 4) + 0x10);
-    Vec transformed;
-    u8* output = (u8*)r3 + stream->destOffset + 0x80;
+    VertexAttendEnv* env = lbl_8032ED54;
+    VertexSetEntry* setEntry = &env->vertexSetTable[entryIndex];
     u16 sourceIndex = *(u16*)((u8*)r3 + stream->sourceOffset + 0x80);
-    VertexSetEntry* setEntry = &lbl_8032ED54->vertexSetTable[entryIndex];
-    u16 vertexIndex = setEntry->vertexRemap[sourceIndex];
+    u8* output = (u8*)r3 + stream->destOffset + 0x80;
     s16 modelIndex = setEntry->modelIndex;
-    Vec* sourceVertex =
-        (Vec*)((u8*)lbl_8032ED54->modelTable[modelIndex]->vertexData + (vertexIndex * sizeof(Vec)));
+    u16 vertexIndex = setEntry->vertexRemap[sourceIndex];
+    VertexAttendModel* model = env->modelTable[modelIndex];
+    Vec* sourceVertex = (Vec*)((u8*)model->vertexData + (vertexIndex * sizeof(Vec)));
+    void* matrixObject = *(void**)((u8*)r3 + 4);
+    Vec transformed;
 
     transformed.x = sourceVertex->x;
     transformed.y = sourceVertex->y;
     transformed.z = sourceVertex->z;
 
-    PSMTXMultVec(matrix, &transformed, &transformed);
+    PSMTXMultVec((MtxPtr)((u8*)matrixObject + 0x10), &transformed, &transformed);
 
     *(f32*)(output + 0) = transformed.x;
     *(f32*)(output + 4) = transformed.y;


### PR DESCRIPTION
## Summary
- Reworked local variable ordering and access sequencing in `pppVertexAttend` without changing behavior.
- Kept the same data flow while aligning load timing for stream/env/model/matrix pointers.

## Functions improved
- Unit: `main/pppVertexAttend`
- Symbol: `pppVertexAttend`
- Before: `80.96%`
- After: `87.50%`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/pppVertexAttend -o - --format json-pretty pppVertexAttend`
- `.text` size remains `200` bytes; instruction alignment improved with fewer argument/register-order mismatches.

## Plausibility rationale
- The change is source-plausible and idiomatic: no artificial temporaries, no magic constants, and no control-flow tricks.
- Adjustments reflect natural ordering of game data lookups (`stream`/`vertex set`/`model`) and matrix application before output writeback.

## Technical details
- Introduced explicit `env`, `model`, and `matrixObject` temporaries and reordered existing computations to better match original instruction scheduling.
- Preserved the existing function contract and struct field usage.
