### PR TITLE
cflat_data: improve Create__9CFlatDataFPv match

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -143,139 +143,124 @@ extern "C" CFlatData* dtor_800980B4(CFlatData* flatData, short shouldDelete)
  */
 void CFlatData::Create(void* filePtr)
 {
-	CFlatData* self = this;
-	for (int i = 0; i < m_dataCount; i++)
-	{
-		if (self->m_data[0].m_data != nullptr)
-		{
-			operator delete(self->m_data[0].m_data);
-			self->m_data[0].m_data = nullptr;
-		}
-		if (self->m_data[0].m_strings != nullptr)
-		{
-			operator delete(self->m_data[0].m_strings);
-			self->m_data[0].m_strings = (char**)nullptr;
-		}
-		if (self->m_data[0].m_stringBuf != nullptr)
-		{
-			operator delete(self->m_data[0].m_stringBuf);
-			self->m_data[0].m_stringBuf = (char*)nullptr;
-		}
-		self = (CFlatData*)&self->m_data[0].m_stringBuf;
-	}
-	m_dataCount = 0;
+    CFlatData* self = this;
+    int i;
 
-	self = this;
-	for (int i = 0; i < m_tableCount; i++)
-	{
-		if (self->m_tabl[0].m_strings != nullptr)
-		{
-			operator delete(self->m_tabl[0].m_strings);
-			self->m_tabl[0].m_strings = (char**)nullptr;
-		}
-		if (self->m_tabl[0].m_stringBuf != nullptr)
-		{
-			operator delete(self->m_tabl[0].m_stringBuf);
-			self->m_tabl[0].m_stringBuf = (char*)nullptr;
-		}
-		self = (CFlatData*)&self->m_data[0].m_numStrings;
-	}
-	m_tableCount = 0;
+    for (i = 0; i < m_dataCount; i++) {
+        if (self->m_data[0].m_data != nullptr) {
+            operator delete(self->m_data[0].m_data);
+            self->m_data[0].m_data = nullptr;
+        }
+        if (self->m_data[0].m_strings != nullptr) {
+            operator delete(self->m_data[0].m_strings);
+            self->m_data[0].m_strings = (char**)nullptr;
+        }
+        if (self->m_data[0].m_stringBuf != nullptr) {
+            operator delete(self->m_data[0].m_stringBuf);
+            self->m_data[0].m_stringBuf = (char*)nullptr;
+        }
+        self = (CFlatData*)&self->m_data[0].m_stringBuf;
+    }
+    m_dataCount = 0;
 
-	if (m_mesBuffer != nullptr)
-	{
-		operator delete(m_mesBuffer);
-		m_mesBuffer = (char*)nullptr;
-	}
-	m_mesCount = 0;
+    self = this;
+    for (i = 0; i < m_tableCount; i++) {
+        if (self->m_tabl[0].m_strings != nullptr) {
+            operator delete(self->m_tabl[0].m_strings);
+            self->m_tabl[0].m_strings = (char**)nullptr;
+        }
+        if (self->m_tabl[0].m_stringBuf != nullptr) {
+            operator delete(self->m_tabl[0].m_stringBuf);
+            self->m_tabl[0].m_stringBuf = (char*)nullptr;
+        }
+        self = (CFlatData*)&self->m_data[0].m_numStrings;
+    }
+    m_tableCount = 0;
 
-	CChunkFile chunkFile(filePtr);
-	CChunkFile::CChunk chunk;
+    if (m_mesBuffer != nullptr) {
+        operator delete(m_mesBuffer);
+        m_mesBuffer = (char*)nullptr;
+    }
+    m_mesCount = 0;
 
-	while (chunkFile.GetNextChunk(chunk))
-	{
-		if (chunk.m_id != 0x43464C44) // 'CFLD'
-		{
-			continue;
-		}
+    CChunkFile chunkFile(filePtr);
+    CChunkFile::CChunk chunk;
+    while (chunkFile.GetNextChunk(chunk)) {
+        if (chunk.m_id == 0x43464C44) { // 'CFLD'
+            chunkFile.PushChunk();
+            while (chunkFile.GetNextChunk(chunk)) {
+                if (chunk.m_id == 0x4D455320) { // 'MES '
+                    m_mesCount = chunk.m_arg0;
+                    m_mesBuffer = new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x76) char[chunk.m_size];
+                    memcpy(m_mesBuffer, chunkFile.GetAddress(), chunk.m_size);
 
-		chunkFile.PushChunk();
-		while (chunkFile.GetNextChunk(chunk))
-		{
-			if (chunk.m_id == 0x4D455320) // 'MES '
-			{
-				m_mesCount = chunk.m_arg0;
-				m_mesBuffer = new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x76) char[chunk.m_size];
-				memcpy(m_mesBuffer, chunkFile.GetAddress(), chunk.m_size);
+                    int baseAddress = (int)chunkFile.GetAddress();
+                    self = this;
+                    for (i = 0; i < m_mesCount; i++) {
+                        int curAddress = (int)chunkFile.GetAddress();
+                        self->m_mesPtr[0] = m_mesBuffer + (curAddress - baseAddress);
+                        chunkFile.GetString();
+                        self = (CFlatData*)self->m_data;
+                    }
+                } else if ((int)chunk.m_id < 0x4D455320) {
+                    if (chunk.m_id == 0x44415441) { // 'DATA'
+                        m_data[m_dataCount].m_size = chunk.m_arg0;
+                        m_data[m_dataCount].m_data =
+                            new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x45) unsigned char[chunk.m_arg0];
+                        chunkFile.Get(m_data[m_dataCount].m_data, chunk.m_arg0);
 
-				unsigned char* base = chunkFile.GetAddress();
-				self = this;
-				for (int i = 0; i < m_mesCount; i++)
-				{
-					self->m_mesPtr[0] = m_mesBuffer + (chunkFile.GetAddress() - base);
-					chunkFile.GetString();
-					self = (CFlatData*)self->m_data;
-				}
-				continue;
-			}
+                        if (chunk.m_version == 0) {
+                            m_data[m_dataCount].m_numStrings = 0;
+                            m_data[m_dataCount].m_stringBuf = (char*)nullptr;
+                            m_data[m_dataCount].m_strings = (char**)nullptr;
+                        } else {
+                            int stringCount = chunkFile.Get4();
+                            int offset = 0;
 
-			if (chunk.m_id < 0x4D455320)
-			{
-				if (chunk.m_id == 0x44415441) // 'DATA'
-				{
-					m_data[m_dataCount].m_size = chunk.m_arg0;
-					m_data[m_dataCount].m_data =
-						new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x45) unsigned char[chunk.m_arg0];
-					chunkFile.Get(m_data[m_dataCount].m_data, chunk.m_arg0);
+                            m_data[m_dataCount].m_numStrings = stringCount;
+                            m_data[m_dataCount].m_strings =
+                                (char**)new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x4C)
+                                    unsigned char[stringCount << 2];
+                            m_data[m_dataCount].m_stringBuf =
+                                new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x4D) char[stringCount];
+                            memcpy(m_data[m_dataCount].m_stringBuf, chunkFile.GetAddress(), stringCount);
 
-					if (chunk.m_version == 0)
-					{
-						m_data[m_dataCount].m_numStrings = 0;
-						m_data[m_dataCount].m_stringBuf = (char*)nullptr;
-						m_data[m_dataCount].m_strings = (char**)nullptr;
-					}
-					else
-					{
-						m_data[m_dataCount].m_numStrings = chunkFile.Get4();
-						m_data[m_dataCount].m_strings = (char**)new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x4C)
-							unsigned char[m_data[m_dataCount].m_numStrings * sizeof(char*)];
-						m_data[m_dataCount].m_stringBuf =
-							new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x4D) char[m_data[m_dataCount].m_numStrings];
-						memcpy(m_data[m_dataCount].m_stringBuf, chunkFile.GetAddress(), m_data[m_dataCount].m_numStrings);
+                            int baseAddress = (int)chunkFile.GetAddress();
+                            for (i = 0; i < m_data[m_dataCount].m_numStrings; i++) {
+                                int curAddress = (int)chunkFile.GetAddress();
+                                *(char**)((int)m_data[m_dataCount].m_strings + offset) =
+                                    m_data[m_dataCount].m_stringBuf + (curAddress - baseAddress);
+                                chunkFile.GetString();
+                                offset += 4;
+                            }
+                        }
 
-						unsigned char* base = chunkFile.GetAddress();
-						for (int i = 0; i < m_data[m_dataCount].m_numStrings; i++)
-						{
-							m_data[m_dataCount].m_strings[i] =
-								m_data[m_dataCount].m_stringBuf + (chunkFile.GetAddress() - base);
-							chunkFile.GetString();
-						}
-					}
+                        m_dataCount++;
+                    }
+                } else if (chunk.m_id == 0x5441424C) { // 'TABL'
+                    int offset = 0;
+                    m_tabl[m_tableCount].m_numEntries = chunk.m_arg0;
+                    m_tabl[m_tableCount].m_strings = (char**)new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x65)
+                        unsigned char[chunk.m_arg0 << 2];
+                    m_tabl[m_tableCount].m_stringBuf =
+                        new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x66) char[chunk.m_size];
+                    memcpy(m_tabl[m_tableCount].m_stringBuf, chunkFile.GetAddress(), chunk.m_size);
 
-					m_dataCount++;
-				}
-			}
-			else if (chunk.m_id == 0x5441424C) // 'TABL'
-			{
-				m_tabl[m_tableCount].m_numEntries = chunk.m_arg0;
-				m_tabl[m_tableCount].m_strings = (char**)new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x65)
-					unsigned char[chunk.m_arg0 * sizeof(char*)];
-				m_tabl[m_tableCount].m_stringBuf =
-					new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x66) char[chunk.m_size];
-				memcpy(m_tabl[m_tableCount].m_stringBuf, chunkFile.GetAddress(), chunk.m_size);
+                    int baseAddress = (int)chunkFile.GetAddress();
+                    for (i = 0; i < m_tabl[m_tableCount].m_numEntries; i++) {
+                        int curAddress = (int)chunkFile.GetAddress();
+                        *(char**)((int)m_tabl[m_tableCount].m_strings + offset) =
+                            m_tabl[m_tableCount].m_stringBuf + (curAddress - baseAddress);
+                        chunkFile.GetString();
+                        offset += 4;
+                    }
 
-				unsigned char* base = chunkFile.GetAddress();
-				for (int i = 0; i < m_tabl[m_tableCount].m_numEntries; i++)
-				{
-					m_tabl[m_tableCount].m_strings[i] = m_tabl[m_tableCount].m_stringBuf + (chunkFile.GetAddress() - base);
-					chunkFile.GetString();
-				}
-
-				m_tableCount++;
-			}
-		}
-		chunkFile.PopChunk();
-	}
+                    m_tableCount++;
+                }
+            }
+            chunkFile.PopChunk();
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CFlatData::Create(void*)` control flow to follow the recovered PAL structure more closely.
- Kept behavior intact while adjusting temporary usage and branch layout for chunk parsing (`'MES '`, `'DATA'`, `'TABL'`).
- Switched string table/index pointer writes to explicit offset-based address math in the DATA/TABL parsing paths.

## Functions Improved
- Unit: `main/cflat_data`
- Symbol: `Create__9CFlatDataFPv`

## Match Evidence
- `Create__9CFlatDataFPv` match: **56.211727% -> 57.14658%** (**+0.934853**)
- Measured with:
  - `tools/objdiff-cli diff -p . -u main/cflat_data -o - Create__9CFlatDataFPv`

## Plausibility Rationale
- The update removes decomp-convenience structure and aligns to the likely original low-level implementation style for chunk iteration and index pointer emission.
- Changes are semantically neutral and preserve idioms already present in this translation unit (manual pointer stepping, explicit chunk ID dispatch).

## Technical Notes
- The biggest alignment gain comes from mirroring address-delta calculations around `GetAddress()` and using explicit `offset += 4` index writes, which better matches the observed register/loop shape in objdiff.
- Build verified with `ninja` after the change.
