### PR TITLE
menu_cmd: implement CmdOpen0 and CmdClose0

### DIFF
--- a/include/ffcc/menu_cmd.h
+++ b/include/ffcc/menu_cmd.h
@@ -15,8 +15,8 @@ public:
     int CmdClose();
     void CmdDraw();
     void CmdCtrlCur();
-    void CmdOpen0();
-    void CmdClose0();
+    unsigned int CmdOpen0();
+    unsigned int CmdClose0();
     void GetCmdItem();
     void ChkCmdActive(int);
     void ChkUnite(int, int (*)[2]);

--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -250,22 +250,119 @@ void CMenuPcs::CmdCtrlCur()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014d0c4
+ * PAL Size: 432b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::CmdOpen0()
+unsigned int CMenuPcs::CmdOpen0()
 {
-	// TODO
+	u8* self = reinterpret_cast<u8*>(this);
+	u8* menuState = *reinterpret_cast<u8**>(self + 0x82c);
+
+	*reinterpret_cast<s16*>(menuState + 0x22) = static_cast<s16>(*reinterpret_cast<s16*>(menuState + 0x22) + 1);
+	s32 time = static_cast<s32>(*reinterpret_cast<s16*>(menuState + 0x22));
+	s32 selectedOffset = static_cast<s32>(*reinterpret_cast<s16*>(menuState + 0x26)) * 0x40 + 8;
+
+	if (time < 5) {
+		*reinterpret_cast<s16*>(*reinterpret_cast<u8**>(self + 0x850) + selectedOffset) =
+		    static_cast<s16>(*reinterpret_cast<s16*>(*reinterpret_cast<u8**>(self + 0x850) + selectedOffset) - 0x13);
+	}
+
+	s16* base = *reinterpret_cast<s16**>(self + 0x850);
+	s32 doneCount = 0;
+	s32 entryCount = static_cast<s32>(base[1]) - static_cast<s32>(base[0]);
+	s16* entry = base + base[0] * 0x20 + 4;
+
+	for (s32 i = 0; i < entryCount; i++) {
+		if (*reinterpret_cast<s32*>(entry + 0x12) <= time) {
+			if (time < (*reinterpret_cast<s32*>(entry + 0x12) + *reinterpret_cast<s32*>(entry + 0x14))) {
+				*reinterpret_cast<s32*>(entry + 0x10) = *reinterpret_cast<s32*>(entry + 0x10) + 1;
+				const f64 denom = static_cast<f64>(*reinterpret_cast<s32*>(entry + 0x14));
+				const f64 numer = static_cast<f64>(*reinterpret_cast<s32*>(entry + 0x10));
+
+				*reinterpret_cast<f32*>(entry + 8) = static_cast<f32>(numer / denom);
+				if ((*reinterpret_cast<u32*>(entry + 0x16) & 2) == 0) {
+					const f32 t = static_cast<f32>(numer / denom);
+					*reinterpret_cast<f32*>(entry + 0x18) =
+					    (*reinterpret_cast<f32*>(entry + 0x1c) - static_cast<f32>(entry[0])) * t;
+					*reinterpret_cast<f32*>(entry + 0x1a) =
+					    (*reinterpret_cast<f32*>(entry + 0x1e) - static_cast<f32>(entry[1])) * t;
+				}
+			} else {
+				doneCount++;
+				*reinterpret_cast<f32*>(entry + 8) = 1.0f;
+				*reinterpret_cast<f32*>(entry + 0x18) = 0.0f;
+				*reinterpret_cast<f32*>(entry + 0x1a) = 0.0f;
+			}
+		}
+		entry += 0x20;
+	}
+
+	return static_cast<unsigned int>(entryCount == doneCount);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014cef8
+ * PAL Size: 460b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::CmdClose0()
+unsigned int CMenuPcs::CmdClose0()
 {
-	// TODO
+	u8* self = reinterpret_cast<u8*>(this);
+	u8* menuState = *reinterpret_cast<u8**>(self + 0x82c);
+
+	*reinterpret_cast<s16*>(menuState + 0x22) = static_cast<s16>(*reinterpret_cast<s16*>(menuState + 0x22) + 1);
+	s32 time = static_cast<s32>(*reinterpret_cast<s16*>(menuState + 0x22));
+	s32 selectedOffset = static_cast<s32>(*reinterpret_cast<s16*>(menuState + 0x26)) * 0x40 + 8;
+
+	if (time > 7) {
+		*reinterpret_cast<s16*>(*reinterpret_cast<u8**>(self + 0x850) + selectedOffset) =
+		    static_cast<s16>(*reinterpret_cast<s16*>(*reinterpret_cast<u8**>(self + 0x850) + selectedOffset) + 0x13);
+	}
+
+	s16* base = *reinterpret_cast<s16**>(self + 0x850);
+	s32 doneCount = 0;
+	s32 entryCount = static_cast<s32>(base[1]) - static_cast<s32>(base[0]);
+	s16* entry = base + base[0] * 0x20 + 4;
+
+	for (s32 i = 0; i < entryCount; i++) {
+		if (*reinterpret_cast<s32*>(entry + 0x12) <= time) {
+			if (time < (*reinterpret_cast<s32*>(entry + 0x12) + *reinterpret_cast<s32*>(entry + 0x14))) {
+				*reinterpret_cast<s32*>(entry + 0x10) = *reinterpret_cast<s32*>(entry + 0x10) + 1;
+				const f64 denom = static_cast<f64>(*reinterpret_cast<s32*>(entry + 0x14));
+				const f64 numer = static_cast<f64>(*reinterpret_cast<s32*>(entry + 0x10));
+
+				*reinterpret_cast<f32*>(entry + 8) = static_cast<f32>(1.0 - (numer / denom));
+				if ((*reinterpret_cast<u32*>(entry + 0x16) & 2) == 0) {
+					const f32 t = static_cast<f32>(1.0 - (numer / denom));
+					*reinterpret_cast<f32*>(entry + 0x18) =
+					    (*reinterpret_cast<f32*>(entry + 0x1c) - static_cast<f32>(entry[0])) * t;
+					*reinterpret_cast<f32*>(entry + 0x1a) =
+					    (*reinterpret_cast<f32*>(entry + 0x1e) - static_cast<f32>(entry[1])) * t;
+				}
+			} else {
+				doneCount++;
+				*reinterpret_cast<f32*>(entry + 8) = 0.0f;
+				*reinterpret_cast<f32*>(entry + 0x18) = 0.0f;
+				*reinterpret_cast<f32*>(entry + 0x1a) = 0.0f;
+			}
+		}
+		entry += 0x20;
+	}
+
+	if (entryCount == doneCount) {
+		*reinterpret_cast<s16*>(*reinterpret_cast<u8**>(self + 0x850) + selectedOffset) =
+		    *reinterpret_cast<s16*>(*reinterpret_cast<u8**>(self + 0x850) + 8);
+	}
+
+	return static_cast<unsigned int>(entryCount == doneCount);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented first-pass decompilation for `CMenuPcs::CmdOpen0` and `CMenuPcs::CmdClose0` in `src/menu_cmd.cpp`.
- Updated method declarations in `include/ffcc/menu_cmd.h` to return `unsigned int`, matching control-flow usage in `CmdCtrl` decomp references.
- Added PAL address/size metadata blocks for both functions.

## Functions Improved
- `CmdOpen0__8CMenuPcsFv` (`main/menu_cmd`)
- `CmdClose0__8CMenuPcsFv` (`main/menu_cmd`)

## Match Evidence
- Unit `.text` (`main/menu_cmd`): **1.4259579% -> 2.3888505%**
- `CmdClose0__8CMenuPcsFv` (460b): **0.8695652% -> 46.93913%**
- `CmdOpen0__8CMenuPcsFv` (432b): **0.9259259% -> 3.5277777%**

Measured with:
- `build/tools/objdiff-cli diff -p . -u main/menu_cmd -o - CmdClose2__8CMenuPcsFv`

## Plausibility Rationale
- Uses the existing codebase pattern in menu modules: direct field-offset access through menu state blocks and per-entry animation update loops.
- No compiler-coaxing transformations were introduced; logic follows expected menu open/close interpolation behavior and state-reset semantics.
- Changes are localized and source-plausible for original game code style.

## Technical Notes
- `CmdClose0` now performs close interpolation and restores selected entry Y position when close animation completes.
- `CmdOpen0` now performs open interpolation and per-entry position deltas with non-flagged entries.
- Both functions now return completion state (`0/1`), enabling future `CmdCtrl` integration.
