### PR TITLE
dolphin_trk: fully match InitMetroTRK_BBA

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -155,6 +155,7 @@ asm void InitMetroTRK_BBA(void)
 	blr
 initCommTableSuccessBBA:
 	b TRK_main
+	blr
 #endif // clang-format on
 }
 


### PR DESCRIPTION
## Summary
- add a terminal `blr` after the unconditional `b TRK_main` path in `InitMetroTRK_BBA` (`src/TRK_MINNOW_DOLPHIN/dolphin_trk.c`)
- keep function structure and calling behavior unchanged; this is a codegen-alignment fix in handwritten TRK asm

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk`
- Symbol: `InitMetroTRK_BBA`
- Match: **97.297295% -> 100.0%**

## Match evidence
- `objdiff` before: one remaining instruction delta (`DIFF_DELETE :: blr`)
- `objdiff` after: no diffs for `InitMetroTRK_BBA`, exact 100% match
- `ninja` progress moved from `Code: 199580 / 1855300 bytes (1484 / 4733 functions)` to `Code: 199728 / 1855300 bytes (1485 / 4733 functions)`

## Plausibility rationale
- this function is handwritten assembly and already contains an explicit early-return `blr` path
- adding the final `blr` on the terminal branch path is consistent with defensive/explicit control-flow style in low-level TRK asm and avoids introducing contrived C-level coercion

## Technical details
- inspected `objdiff` instruction-level diff for `InitMetroTRK_BBA`
- identified the only remaining mismatch as a trailing return instruction
- applied a single-line asm adjustment and revalidated with `ninja` + `objdiff`
