### PR TITLE
mapanim: improve CMapAnim constructor match

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -493,10 +493,8 @@ void CMapAnimNode::interp(Vec*, CMapAnimKey*, int, int)
  */
 CMapAnim::CMapAnim()
 {
-    typedef CPtrArray<CMapAnimNode*>* (*CtorFn)(CPtrArray<CMapAnimNode*>*);
-    CtorFn ctorFn = __ct__26CPtrArray_P12CMapAnimNode_Fv;
-    CPtrArray<CMapAnimNode*>* mapAnimNodes = ctorFn(reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this));
-    mapAnimNodes->SetStage(*reinterpret_cast<CMemory::CStage**>(MapMng));
+    __ct__26CPtrArray_P12CMapAnimNode_Fv(reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this));
+    reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this)->SetStage(*reinterpret_cast<CMemory::CStage**>(MapMng));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Simplified `CMapAnim::CMapAnim()` in `src/mapanim.cpp` by removing an unnecessary local function-pointer indirection.
- Kept constructor semantics identical: initialize `CPtrArray<CMapAnimNode*>` and set its stage from `MapMng`.

## Functions improved
- Unit: `main/mapanim`
- Symbol: `__ct__8CMapAnimFv` (`CMapAnim::CMapAnim`, 68 bytes)

## Match evidence
- `__ct__8CMapAnimFv`: **60.588234% -> 80.588234%**
- Unit `.text` match: **62.14929% -> 62.55213%**
- Validation command used:
  - `build/tools/objdiff-cli diff -p . -u main/mapanim -o - __ct__8CMapAnimFv`
  - `build/tools/objdiff-cli diff -p . -u main/mapanim -o -` (queried `.text` `match_percent`)

## Plausibility rationale
- The new code is more natural C++ than the previous indirection pattern and better reflects likely original author intent: direct construction followed by stage assignment.
- No compiler-coaxing constructs were introduced.

## Technical details
- Removed `CtorFn` typedef and temporary `ctorFn` variable.
- Performed direct call to `__ct__26CPtrArray_P12CMapAnimNode_Fv(...)` and direct `SetStage(...)` on the casted array object.
- Build verification: `ninja` passes after the change.
