### PR TITLE
util: implement display list parsing helpers

### DIFF
--- a/include/ffcc/util.h
+++ b/include/ffcc/util.h
@@ -40,7 +40,7 @@ public:
     void IsHasDrawFmtDL(unsigned char);
     void ReWriteDisplayList(void*, unsigned long, unsigned long);
     void CalcBoundaryBoxQuantized(Vec*, Vec*, S16Vec*, unsigned long, unsigned long);
-    void GetNumPolygonFromDL(void*, unsigned long);
+    int GetNumPolygonFromDL(void*, unsigned long);
     void GetDirectVector(Vec*, Vec*, Vec);
     void InitConstantRegister();
     void SSepa(char*);


### PR DESCRIPTION
## Summary
- Implemented three previously stubbed `CUtil` display-list helpers in `src/util.cpp` using decomp-guided control flow and data handling.
- Added PAL address/size metadata blocks for each implemented function.
- Corrected `GetNumPolygonFromDL` declaration to return `int` in `include/ffcc/util.h`.

## Functions Improved
- `GetNumPolygonFromDL__5CUtilFPvUl` (`main/util`)
- `ReWriteDisplayList__5CUtilFPvUlUl` (`main/util`)
- `CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl` (`main/util`)

## Match Evidence
- `GetNumPolygonFromDL__5CUtilFPvUl`: **1.2345679% -> 50.419754%**
- `ReWriteDisplayList__5CUtilFPvUlUl`: **1.369863% -> 78.095894%**
- `CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`: **0.729927% -> 48.270073%**

Measured via:
- `build/tools/objdiff-cli diff -p . -u main/util -o - <symbol>`

## Plausibility Rationale
- Changes are type/control-flow corrections that match expected gameplay/SDK-era source style for GX display-list parsing and quantized AABB conversion.
- Logic uses straightforward primitive decoding, vertex stride handling, and min/max accumulation rather than compiler-only coercion.
- No assembly comments, no debug scaffolding, no intentionally contrived temporaries.

## Technical Details
- Rewrote primitive-command recognition around masked opcode groups (`cmd & 0xF8`) and format-specific per-vertex strides.
- Implemented display-list in-place rewrite path with `copyFlags`-gated attribute duplication and final `DCFlushRange`.
- Implemented quantized boundary-box pass with signed 16-bit extrema and fixed-point-to-float conversion via `1 << shift` scaling.
