### PR TITLE
cflat_runtime2: match SetParticleWorkTrace offset store

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -91,6 +91,11 @@ static inline CFlatRuntime::CObject*& ParticleWorkBind(CFlatRuntime2* runtime)
 	return *reinterpret_cast<CFlatRuntime::CObject**>(reinterpret_cast<u8*>(runtime) + 0x16E0);
 }
 
+static inline CFlatRuntime::CObject*& ParticleWorkTrace(CFlatRuntime2* runtime)
+{
+	return *reinterpret_cast<CFlatRuntime::CObject**>(reinterpret_cast<u8*>(runtime) + 0x16E4);
+}
+
 static inline int& ParticleWorkColor0(CFlatRuntime2* runtime)
 {
 	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(runtime) + 0x16E8);
@@ -588,9 +593,9 @@ void CFlatRuntime2::SetParticleWorkCol(int color0, int color1, float lerp)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime2::SetParticleWorkTrace(CFlatRuntime::CObject*)
+void CFlatRuntime2::SetParticleWorkTrace(CFlatRuntime::CObject* object)
 {
-	// TODO
+	ParticleWorkTrace(this) = object;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement `CFlatRuntime2::SetParticleWorkTrace` by storing the incoming `CFlatRuntime::CObject*` into the particle trace slot at offset `0x16E4`, using a dedicated accessor.

## Functions improved
- Unit: `main/cflat_runtime2`
- Symbol: `SetParticleWorkTrace__13CFlatRuntime2FPQ212CFlatRuntime7CObject`

## Match evidence
- `SetParticleWorkTrace`: **50.0% -> 100.0%** (`objdiff` oneshot)
- Instruction diffs for this symbol: **non-zero -> 0**
- Project progress moved from **1510 -> 1511 matched functions** in the latest `ninja` report.

## Plausibility rationale
This change reflects plausible original source behavior: the function is a trivial setter, and the decomp reference indicates a direct store of the object pointer into the trace field. The implementation uses an explicit typed field accessor rather than contrived control-flow/temporary tricks.

## Technical details
- Added `ParticleWorkTrace(CFlatRuntime2*)` helper at offset `0x16E4`.
- Replaced TODO body with a single assignment in `SetParticleWorkTrace`.