### PR TITLE
main/mapshadow: improve Init__10CMapShadowFv match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -6,7 +6,6 @@
 #include <dolphin/mtx.h>
 
 // External constants referenced in decompilation
-extern double DOUBLE_8032fcf8;
 extern double DOUBLE_8032fce8;
 extern float FLOAT_8032fcf0;
 extern float FLOAT_8032fce0;
@@ -73,13 +72,6 @@ void CMapShadow::Init()
 	u32 materialWidth;
 	u32 materialHeight;
 	u32 materialMode;
-	union {
-		double d;
-		struct {
-			u32 hi;
-			u32 lo;
-		} parts;
-	} cvt;
 
 	materialArray = *(int*)((char*)&MapMng + 0x213d4);
 	material = (int)(((CPtrArray<CMaterial>*)(materialArray + 8))->operator[](*(u16*)((char*)this + 4)));
@@ -88,11 +80,8 @@ void CMapShadow::Init()
 	materialHeight = *(u32*)(material + 0x68);
 	materialMode = *(u32*)(material + 0x6c);
 	*((u8*)this + 7) = materialMode;
-	cvt.parts.hi = 0x43300000;
-	cvt.parts.lo = materialWidth;
-	width = (float)(cvt.d - DOUBLE_8032fcf8);
-	cvt.parts.lo = materialHeight;
-	height = (float)(cvt.d - DOUBLE_8032fcf8);
+	width = (float)materialWidth;
+	height = (float)materialHeight;
 	scale = *(float*)((char*)this + 0xa8);
 	if (*(s8*)((char*)this + 6) != 0) {
 		C_MTXLightFrustum((MtxPtr)((char*)this + 0x48), -height, height, -width, width, *(float*)((char*)this + 0xac),


### PR DESCRIPTION
## Summary
- Reworked `CMapShadow::Init()` width/height conversion from manual union bit-twiddling to direct `u32`->`float` casts.
- Kept control flow and matrix setup logic unchanged.

## Functions improved
- Unit: `main/mapshadow`
- Symbol: `Init__10CMapShadowFv`

## Match evidence
- `Init__10CMapShadowFv`: **66.13559% -> 79.745766%**
- `main/mapshadow` `.text`: **79.550804% -> 83.84492%**
- Neighbor symbols remained stable:
  - `CMapShadowInsertOctTree__FQ210CMapShadow6TARGETR8COctTree`: 78.13559% (unchanged)
  - `Draw__10CMapShadowFv`: 91.541664% (unchanged)

## Plausibility rationale
- The original source likely used straightforward integer dimension values converted to floating-point for projection setup, not explicit union-based bit reinterpretation.
- The new code is simpler, idiomatic, and preserves behavior while improving codegen alignment.

## Technical details
- The previous conversion forced an explicit high/low-word `double` construction path.
- Direct casts aligned generated float conversion sequences better for this unit and significantly reduced instruction diffs in `Init__10CMapShadowFv`.
