### PR TITLE
main/util: implement CUtil GX format stubs and RenderQuadNoTex

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -64,42 +64,82 @@ void CUtil::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024de0
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::SetVtxFmt_POS_CLR()
 {
-	// TODO
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024d54
+ * PAL Size: 140b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::SetVtxFmt_POS_CLR_TEX()
 {
-	// TODO
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_TEX0, GX_TEX_ST, GX_F32, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024cc8
+ * PAL Size: 140b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::SetVtxFmt_POS_TEX0_TEX1()
 {
-	// TODO
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX1, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_TEX0, GX_TEX_ST, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_TEX1, GX_TEX_ST, GX_F32, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024c18
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::SetVtxFmt_POS_CLR_TEX0_TEX1()
 {
-	// TODO
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_TEX1, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_TEX0, GX_TEX_ST, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT7, GX_VA_TEX1, GX_TEX_ST, GX_F32, 0);
 }
 
 /*
@@ -214,12 +254,28 @@ void CUtil::ConvF2IVector2d(S16Vec2d& out, Vec2d in, long shift)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024748
+ * PAL Size: 172b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::RenderQuadNoTex(Vec, Vec, _GXColor)
+void CUtil::RenderQuadNoTex(Vec pos1, Vec pos2, _GXColor color)
 {
-	// TODO
+    GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT7, 4);
+
+    GXPosition3f32(pos1.x, pos1.y, pos1.z);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+
+    GXPosition3f32(pos2.x, pos1.y, pos1.z);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+
+    GXPosition3f32(pos2.x, pos2.y, pos1.z);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
+
+    GXPosition3f32(pos1.x, pos2.y, pos1.z);
+    GXColor1u32(*reinterpret_cast<u32*>(&color));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented five TODO stubs in `src/util.cpp` using the PAL decomp/GX API behavior:
  - `CUtil::SetVtxFmt_POS_CLR`
  - `CUtil::SetVtxFmt_POS_CLR_TEX`
  - `CUtil::SetVtxFmt_POS_TEX0_TEX1`
  - `CUtil::SetVtxFmt_POS_CLR_TEX0_TEX1`
  - `CUtil::RenderQuadNoTex`
- Added PAL address/size metadata blocks to these functions.

## Functions Improved
- Unit: `main/util`
- Symbols:
  - `SetVtxFmt_POS_CLR__5CUtilFv`
  - `SetVtxFmt_POS_CLR_TEX__5CUtilFv`
  - `SetVtxFmt_POS_TEX0_TEX1__5CUtilFv`
  - `SetVtxFmt_POS_CLR_TEX0_TEX1__5CUtilFv`
  - `RenderQuadNoTex__5CUtilF3Vec3Vec8_GXColor`

## Match Evidence
`objdiff-cli` before -> after:
- `SetVtxFmt_POS_CLR__5CUtilFv`: `3.8461537%` -> `100.0%` (104b)
- `SetVtxFmt_POS_CLR_TEX__5CUtilFv`: `2.857143%` -> `100.0%` (140b)
- `SetVtxFmt_POS_TEX0_TEX1__5CUtilFv`: `2.857143%` -> `100.0%` (140b)
- `SetVtxFmt_POS_CLR_TEX0_TEX1__5CUtilFv`: `2.2727273%` -> `100.0%` (176b)
- `RenderQuadNoTex__5CUtilF3Vec3Vec8_GXColor`: `2.3255813%` -> `64.558136%` (172b)

Build verification:
- `ninja` passes.

## Plausibility Rationale
- Changes are direct, idiomatic GX setup/render calls that match existing nearby `CUtil` code style and usage patterns.
- No coercive compiler tricks or contrived temporaries were added; these are straightforward source-level implementations expected in original rendering utility code.

## Technical Details
- Vertex-format functions now configure the expected direct attributes and formats (`POS`, `CLR0`, `TEX0`, `TEX1`) in `GX_VTXFMT7`.
- `RenderQuadNoTex` now emits a 4-vertex triangle strip with XYZ positions and packed color, matching the expected quad-without-texture path.
