### PR TITLE
graphic: add __sinit_graphic_cpp static initializer

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -3,6 +3,22 @@
 #include "ffcc/pppfunctbl.h"
 #include "ffcc/system.h"
 
+extern void* lbl_801E8408;
+
+/*
+ * --INFO--
+ * PAL Address: 0x80019f68
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_graphic_cpp(void)
+{
+	*(void**)&Graphic = &lbl_801E8408;
+}
+
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- add explicit `__sinit_graphic_cpp` in `src/graphic.cpp`
- initialize global `Graphic` vtable slot to `lbl_801E8408`
- add full PAL metadata block for the function (`0x80019f68`, `32b`)

## Functions improved
- Unit: `main/graphic`
- Symbol: `__sinit_graphic_cpp`

## Match evidence
- `__sinit_graphic_cpp`: selector baseline `0.0%` -> objdiff now `22.5%`
- Unit `.text` match (`main/graphic`): `3.7761154%` -> `3.8233595%`
- Verification command: `build/tools/objdiff-cli diff -p . -u main/graphic -o - __sinit_graphic_cpp`

## Plausibility rationale
- this is a standard Metrowerks static initializer pattern for C++ globals in this codebase
- behavior is source-plausible: the initializer writes the runtime class table/vtable pointer for `Graphic` during static init
- no contrived control-flow or compiler coaxing was introduced

## Technical details
- the new function matches the recovered PAL behavior shape from the ghidra export (`resources/ghidra-decomp-1-31-2026/80019f68___sinit_graphic_cpp.c`)
- change is isolated to one symbol and one source file
