### PR TITLE
main/util: implement GetNoise, CalcUV, and IsHasDrawFmtDL

### DIFF
--- a/include/ffcc/util.h
+++ b/include/ffcc/util.h
@@ -20,7 +20,7 @@ public:
     void SetVtxFmt_POS_TEX0_TEX1();
     void SetVtxFmt_POS_CLR_TEX0_TEX1();
     void SetOrthoEnv();
-    void GetNoise(unsigned char);
+    int GetNoise(unsigned char);
     void GetSplinePos(Vec&, Vec, Vec, Vec, Vec, float, float);
     void ConvI2FVector(Vec&, S16Vec, long);
     void ConvF2IVector(S16Vec&, Vec, long);
@@ -37,7 +37,7 @@ public:
     void RenderTextureQuad(float, float, float, float, CTexture*, Vec2d*, Vec2d*, _GXColor*, _GXBlendFactor, _GXBlendFactor);
     void SetPaletteEnv(CTexture*);
     void CalcUV(float&, float&, unsigned long, unsigned long, unsigned long, unsigned long);
-    void IsHasDrawFmtDL(unsigned char);
+    int IsHasDrawFmtDL(unsigned char);
     void ReWriteDisplayList(void*, unsigned long, unsigned long);
     void CalcBoundaryBoxQuantized(Vec*, Vec*, S16Vec*, unsigned long, unsigned long);
     int GetNumPolygonFromDL(void*, unsigned long);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,6 +6,7 @@ extern float lbl_8032f88c;
 extern float lbl_8032f8a0;
 extern float lbl_8032f8a4;
 extern float lbl_8032f8a8;
+extern CMath Math;
 
 extern struct {
     float _212_4_;
@@ -114,12 +115,18 @@ void CUtil::SetOrthoEnv()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024b38
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::GetNoise(unsigned char)
+int CUtil::GetNoise(unsigned char noise)
 {
-	// TODO
+    float maxNoise = (float)(noise * 2);
+    float minNoise = (float)(noise >> 1);
+    return (int)(maxNoise * Math.RandF() - minNoise);
 }
 
 /*
@@ -839,22 +846,42 @@ void CUtil::SetPaletteEnv(CTexture* texture)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80022d0c
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::CalcUV(float&, float&, unsigned long, unsigned long, unsigned long, unsigned long)
+void CUtil::CalcUV(float& u, float& v, unsigned long x, unsigned long y, unsigned long width, unsigned long height)
 {
-	// TODO
+    u = (float)x / (float)width;
+    v = (float)y / (float)height;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80022ca4
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CUtil::IsHasDrawFmtDL(unsigned char)
+int CUtil::IsHasDrawFmtDL(unsigned char cmd)
 {
-	// TODO
+    switch (cmd & 0xF8) {
+    case 0x80:
+    case 0x90:
+    case 0x98:
+    case 0xA0:
+    case 0xA8:
+    case 0xB0:
+    case 0xB8:
+        return 1;
+    default:
+        return 0;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three previously stubbed `CUtil` functions in `src/util.cpp` and corrected their declarations in `include/ffcc/util.h`.

- Changed return types to match actual behavior:
  - `GetNoise(unsigned char)`: `void -> int`
  - `IsHasDrawFmtDL(unsigned char)`: `void -> int`
- Implemented plausible source logic for:
  - `GetNoise__5CUtilFUc`
  - `CalcUV__5CUtilFRfRfUlUlUlUl`
  - `IsHasDrawFmtDL__5CUtilFUc`
- Added PAL address/size metadata blocks for these functions.

## Functions improved
Unit: `main/util`

- `GetNoise__5CUtilFUc`: `3.2258065% -> 88.03226%`
- `CalcUV__5CUtilFRfRfUlUlUlUl`: `4.0% -> 99.8%`
- `IsHasDrawFmtDL__5CUtilFUc`: `3.8461537% -> 100.0%`

## Match evidence
Measured with:

```sh
build/tools/objdiff-cli diff -p . -u main/util -o - <symbol>
```

Symbol-level diffs show major assembly convergence for all three functions, including one full match and one near-full match.

## Plausibility rationale
These changes are source-plausible and align with function naming/usage semantics rather than compiler-coaxing:

- `GetNoise` now returns an integer noise value derived from random float scaling and byte-range parameters.
- `CalcUV` performs expected normalized UV computation from pixel coordinates and texture dimensions.
- `IsHasDrawFmtDL` uses an idiomatic primitive opcode mask/switch that mirrors GX draw command families.

No contrived temporaries, magic-offset hacks, or unnatural control-flow shaping were introduced.

## Validation
- `ninja` build passes.
- objdiff measurements collected before/after for each targeted symbol.
