### PR TITLE
main/pppYmCheckBGHeight: improve pppFrameYmCheckBGHeight match

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -62,41 +62,48 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pp
 
     if (DAT_8032ed70 == 0) {
         int hitResult;
-        float currentY;
         CMapCylinderRaw cyl;
         Vec hitPos;
+        float currentY;
 
         cyl.m_direction.x = FLOAT_80330ed0;
         cyl.m_direction.y = FLOAT_80330ed4;
         cyl.m_direction.z = FLOAT_80330ed0;
-        currentY = pppMngSt->m_matrix.value[1][3];
-        cyl.m_bottom.x = pppMngSt->m_matrix.value[0][3];
-        cyl.m_bottom.z = pppMngSt->m_matrix.value[2][3];
+
+        currentY = ((float*)pppMngSt)[0x94 / sizeof(float)];
+        cyl.m_bottom.x = ((float*)pppMngSt)[0x84 / sizeof(float)];
+        cyl.m_bottom.z = ((float*)pppMngSt)[0xA4 / sizeof(float)];
         cyl.m_bottom.y = currentY + param_2->m_unk0x4;
+
         cyl.m_direction2.x = FLOAT_80330ed8;
         cyl.m_direction2.y = FLOAT_80330ed8;
         cyl.m_direction2.z = FLOAT_80330ed8;
         cyl.m_radius2 = FLOAT_80330edc;
         cyl.m_height2 = FLOAT_80330edc;
         cyl.m_radius = FLOAT_80330edc;
+
         cyl.m_top.x = FLOAT_80330ed0;
         cyl.m_top.y = FLOAT_80330ed4;
         cyl.m_top.z = FLOAT_80330ed0;
         cyl.m_height = FLOAT_80330ed0;
+
         hitResult = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, (CMapCylinder*)&cyl, &cyl.m_direction, 0xffffffff);
         if (hitResult != 0) {
-            CalcHitPosition__7CMapObjFP3Vec(*(void**)((char*)&MapMng + 0x22A78), &hitPos);
+            CalcHitPosition__7CMapObjFP3Vec(*(void**)((u8*)&MapMng + 0x22A78), &hitPos);
             if (currentY - param_2->m_serializedDataOffsets <= hitPos.y) {
                 currentY = hitPos.y + param_2->m_unk0x8;
             }
         }
-        pppMngSt->m_position.y = currentY;
-        *((float*)pppMngSt + 0x17) = currentY;
-        *((float*)pppMngSt + 0x1B) = currentY;
-        *((float*)pppMngSt + 0x13) = currentY;
-        pppMngStPtr->m_matrix.value[0][3] = pppMngSt->m_position.x;
-        pppMngStPtr->m_matrix.value[1][3] = pppMngSt->m_position.y;
-        pppMngStPtr->m_matrix.value[2][3] = pppMngSt->m_position.z;
+
+        ((float*)pppMngSt)[0x0C / sizeof(float)] = currentY;
+        ((float*)pppMngSt)[0x5C / sizeof(float)] = currentY;
+        ((float*)pppMngSt)[0x6C / sizeof(float)] = currentY;
+        ((float*)pppMngSt)[0x4C / sizeof(float)] = currentY;
+
+        ((float*)pppMngStPtr)[0x84 / sizeof(float)] = ((float*)pppMngSt)[0x08 / sizeof(float)];
+        ((float*)pppMngStPtr)[0x94 / sizeof(float)] = ((float*)pppMngSt)[0x0C / sizeof(float)];
+        ((float*)pppMngStPtr)[0xA4 / sizeof(float)] = ((float*)pppMngSt)[0x10 / sizeof(float)];
+
         pppYmCheckBGHeight = (struct pppYmCheckBGHeight*)pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
     return pppYmCheckBGHeight;


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmCheckBGHeight` to use offset-based field access that better matches observed object layout for this unit.
- Kept control flow and collision logic intact while reordering and expressing assignments to align closer to target codegen.
- Normalized the map-object pointer cast in `CalcHitPosition` call to `u8*` arithmetic.

## Functions improved
- Unit: `main/pppYmCheckBGHeight`
- Function: `pppFrameYmCheckBGHeight`
  - Before: `78.74712%` fuzzy match
  - After: `78.83908%` fuzzy match

## Match evidence
- Unit fuzzy match moved from `78.98864%` to `79.079544%`.
- Build/report commands used:
  - `ninja`
  - `build/tools/objdiff-cli report generate -p . -o /tmp/report_after2.json`

## Plausibility rationale
- The changes reflect plausible original-source behavior for this codebase: direct offset access is already common in partially reconstructed PPP structures where field layout is still uncertain.
- No behavioral changes were introduced; the function still performs the same collision probe and Y-adjustment logic.

## Technical notes
- Main deltas came from aligning which internal offsets feed collision cylinder construction and which offsets are synchronized back into manager state/matrix fields.
- This reduces structural/codegen mismatch without introducing contrived temporary-only transformations.
