### PR TITLE
main/cflat_runtime: decompile ResetPerformance and CClass::CClass

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/cflat_runtime.h"
+#include <string.h>
 
 extern "C" {
 void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
@@ -429,12 +430,16 @@ void CFlatRuntime::systemFunc(CFlatRuntime::CObject*, int, int, int&)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80065cf0
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CFlatRuntime::ResetPerformance()
 {
-	// TODO
+	memset((u8*)this + 0x48, 0, 0x804);
 }
 
 /*
@@ -449,12 +454,16 @@ void CFlatRuntime::PrintPerformance()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800695fc
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CFlatRuntime::CClass::CClass()
 {
-	// TODO
+	*(u32*)((u8*)this + 0x228) = 2;
 }
 
 /*


### PR DESCRIPTION
## Summary
- decompiled `CFlatRuntime::ResetPerformance()` using the PAL reference body (`memset(this + 0x48, 0, 0x804)`)
- decompiled `CFlatRuntime::CClass::CClass()` by restoring the class field init at offset `0x228`
- added PAL address/size info blocks for both functions

## Functions improved
- `ResetPerformance__12CFlatRuntimeFv`: `9.090909%` -> `99.545456%`
- `__ct__Q212CFlatRuntime6CClassFv`: `33.333332%` -> `100.0%`
- Unit `main/cflat_runtime` `.text`: `2.9664245%` -> `3.2658482%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o - ResetPerformance__12CFlatRuntimeFv`
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o - __ct__Q212CFlatRuntime6CClassFv`
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o -`

`ResetPerformance` now matches all instructions except one remaining relocation argument mismatch on the `bl memset` call, while `CClass::CClass` is full match.

## Plausibility rationale
- both changes are direct, idiomatic source-level reconstructions of small runtime initializers/resets
- no compiler-coaxing temporaries or unnatural control flow were introduced
- behavior aligns with existing runtime offset-based coding style already present in `cflat_runtime.cpp`
