### PR TITLE
main/util: implement SetOrthoEnv, DisableIndMtx, InitConstantRegister

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/util.h"
 #include "ffcc/gxfunc.h"
+#include <string.h>
 
 extern float lbl_8032f888;
 extern float lbl_8032f88c;
@@ -145,12 +146,24 @@ void CUtil::SetVtxFmt_POS_CLR_TEX0_TEX1()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024bb4
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::SetOrthoEnv()
 {
-	// TODO
+    Mtx modelMtx;
+    Mtx44 orthoMtx;
+
+    PSMTXIdentity(modelMtx);
+    GXLoadPosMtxImm(modelMtx, 0);
+    GXSetCurrentMtx(0);
+    C_MTXOrtho(orthoMtx, lbl_8032f888, lbl_8032f8a0, lbl_8032f888, lbl_8032f8a4, lbl_8032f888,
+               lbl_8032f88c);
+    GXSetProjection(orthoMtx, GX_ORTHOGRAPHIC);
 }
 
 /*
@@ -395,12 +408,22 @@ void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80024444
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::DisableIndMtx()
 {
-	// TODO
+    float indMtx[2][3];
+
+    GXSetNumIndStages(0);
+    memset(indMtx, 0, sizeof(indMtx));
+    GXSetIndTexMtx(GX_ITM_0, indMtx, 1);
+    GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
+    GXSetIndTexMtx(GX_ITM_2, indMtx, 1);
 }
 
 /*
@@ -1161,12 +1184,23 @@ void CUtil::GetDirectVector(Vec* param_2, Vec* param_3, Vec param_4)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80022724
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::InitConstantRegister()
 {
-	// TODO
+    int i = 0;
+
+    do {
+        GXSetTevKColorSel((GXTevStageID)i, (GXTevKColorSel)6);
+        GXSetTevKAlphaSel((GXTevStageID)i, (GXTevKAlphaSel)0);
+        _GXSetTevSwapMode((GXTevStageID)i, (_GXTevSwapSel)0, (_GXTevSwapSel)0);
+        i++;
+    } while (i < 0x10);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three `CUtil` TODO functions in `src/util.cpp` using source-plausible GX setup logic:
  - `SetOrthoEnv__5CUtilFv`
  - `DisableIndMtx__5CUtilFv`
  - `InitConstantRegister__5CUtilFv`
- Added PAL address/size metadata blocks for each updated function.
- Kept implementation style aligned with surrounding util rendering/setup helpers.

## Functions improved
- Unit: `main/util`
- Symbols:
  - `SetOrthoEnv__5CUtilFv`: **4.0% -> 99.2%** (100b)
  - `DisableIndMtx__5CUtilFv`: **4.0% -> 99.8%** (100b)
  - `InitConstantRegister__5CUtilFv`: **4.347826% -> 100.0%** (92b)

## Match evidence
- Built with `ninja` after each iteration.
- Verified using:
  - `build/tools/objdiff-cli diff -p . -u main/util -o - <symbol>`
- Assembly alignment improved from near-zero placeholders to near/exact matches.
- Overall progress output increased from `1520` matched functions to `1523` matched functions.

## Plausibility rationale
- Changes are not compiler-coaxing; they are direct, idiomatic GX setup operations that match existing code patterns in `util.cpp` and related rendering utilities.
- `SetOrthoEnv` and `DisableIndMtx` mirror the project's established matrix/projection and indirect-matrix reset flow.
- `InitConstantRegister` uses a straightforward stage loop consistent with GX initialization behavior.

## Technical details
- `SetOrthoEnv` now builds model/projection matrices and sets orthographic projection.
- `DisableIndMtx` now explicitly zeroes a 2x3 indirect matrix and uploads it for ITM0-ITM2 after disabling indirect stages.
- `InitConstantRegister` now loops across 16 TEV stages, configuring KColor/KAlpha and swap mode defaults.
