### PR TITLE
targimpl: inline TRK step entry flow for closer matching

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/targimpl.c
+++ b/src/TRK_MINNOW_DOLPHIN/targimpl.c
@@ -1017,34 +1017,47 @@ static BOOL TRKTargetCheckStep()
 
 DSError TRKTargetSingleStep(u32 count, BOOL stepOver)
 {
-    DSError error = DS_NoError;
-
     if (stepOver) {
-        error = DS_UnsupportedError;
-    } else {
-        gTRKStepStatus.type  = DSSTEP_IntoCount;
-        gTRKStepStatus.count = count;
-        error                = TRKTargetDoStep();
+        return DS_UnsupportedError;
     }
 
-    return error;
+    gTRKStepStatus.type   = DSSTEP_IntoCount;
+    gTRKStepStatus.active = TRUE;
+    gTRKStepStatus.count  = count;
+
+    MWTRACE(1, "TargetDoStep:\n");
+    TRKTargetEnableTrace(TRUE);
+
+    if (gTRKStepStatus.type == DSSTEP_IntoCount
+        || gTRKStepStatus.type == DSSTEP_OverCount) {
+        gTRKStepStatus.count--;
+    }
+
+    TRKTargetSetStopped(FALSE);
+    return DS_NoError;
 }
 
 DSError TRKTargetStepOutOfRange(u32 rangeStart, u32 rangeEnd, BOOL stepOver)
 {
-    DSError error = DS_NoError;
-
     if (stepOver) {
-        // Stepping over isn't supported for PowerPC
-        error = DS_UnsupportedError;
-    } else {
-        gTRKStepStatus.type = DSSTEP_IntoRange;
-        gTRKStepStatus.rangeStart = rangeStart;
-        gTRKStepStatus.rangeEnd   = rangeEnd;
-        error                     = TRKTargetDoStep();
+        return DS_UnsupportedError;
     }
 
-    return error;
+    gTRKStepStatus.type       = DSSTEP_IntoRange;
+    gTRKStepStatus.active     = TRUE;
+    gTRKStepStatus.rangeStart = rangeStart;
+    gTRKStepStatus.rangeEnd   = rangeEnd;
+
+    MWTRACE(1, "TargetDoStep:\n");
+    TRKTargetEnableTrace(TRUE);
+
+    if (gTRKStepStatus.type == DSSTEP_IntoCount
+        || gTRKStepStatus.type == DSSTEP_OverCount) {
+        gTRKStepStatus.count--;
+    }
+
+    TRKTargetSetStopped(FALSE);
+    return DS_NoError;
 }
 
 u32 TRKTargetGetPC() { return gTRKCPUState.Default.PC; }


### PR DESCRIPTION
## Summary
- Reworked `TRKTargetSingleStep` and `TRKTargetStepOutOfRange` to inline the step-start sequence instead of delegating to `TRKTargetDoStep`.
- Restored the explicit state writes and trace setup order (`active/type/count|range`, `MWTRACE`, trace enable, conditional decrement, stopped flag clear).

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/targimpl`
- `TRKTargetSingleStep`: **49.953487% -> 96.51163%**
- `TRKTargetStepOutOfRange`: **44.086956% -> 96.304344%**

## Match evidence
- `objdiff` for both symbols now shows near-complete alignment in control flow and call placement.
- The prior helper call boundary (`TRKTargetDoStep`) was introducing prologue/call/return and register-allocation differences; inlining removed that mismatch source.

## Plausibility rationale
- This aligns with the Ghidra-reconstructed PAL flow where each step entrypoint contains the same explicit step bootstrap sequence.
- The resulting C remains natural and maintainable (direct state transitions in each public step API), rather than compiler-coaxing patterns.

## Technical details
- Added `MWTRACE(1, "TargetDoStep:\n")` at step start, matching the traced step bootstrap pattern in related TRK routines.
- Preserved existing semantics for unsupported step-over requests (`DS_UnsupportedError`).
- Verified build with `ninja` and re-ran symbol-level `objdiff` checks after the edit.
