### PR TITLE
pppYmTracer2: improve pppFrameYmTracer2 control-flow match

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -307,13 +307,10 @@ void pppFrameYmTracer2(pppYmTracer2* pppYmTracer2, UnkB* param_2, UnkC* param_3)
 
     visibleCount = 0;
     for (iVar4 = 0; iVar4 < (s32)(u32)*(u16*)(step->m_payload + 4); iVar4++) {
-        bool dead;
-
         alpha = (u16)step->m_payload[8] - (s16)iVar4 * *(s16*)(work + 0x30);
-        dead = *(char*)&source[2].z == '\0';
-        if (alpha < 0 || dead) {
+        if ((alpha < 0) || ((useFallback = *(char*)&source[2].z == '\0'), useFallback)) {
             *(u8*)((u8*)&source[2].y + 3) = 0;
-        } else if (!dead) {
+        } else if (!useFallback) {
             *(u8*)((u8*)&source[2].y + 3) = (u8)alpha;
             visibleCount++;
         }


### PR DESCRIPTION
## Summary
- Updated the final alpha/visibility branch in `pppFrameYmTracer2` to better match the original control-flow shape.
- Removed a temporary `dead` boolean and used the inline flag check pattern in-condition.

## Functions improved
- Unit: `main/pppYmTracer2`
- Primary target: `pppFrameYmTracer2`

## Match evidence
- `main/pppYmTracer2` fuzzy match: **62.641476% -> 62.82601%** (`+0.184534`)
- Verified with `ninja` + `build/GCCP01/report.json` before/after this change.

## Plausibility rationale
- This is a source-plausible cleanup of branch structure rather than compiler coercion.
- It preserves behavior and follows the Ghidra-observed flow for the final visibility update loop.

## Technical details
- Changed:
  - `if (alpha < 0 || dead) ... else if (!dead) ...`
- To:
  - `if ((alpha < 0) || ((useFallback = *(char*)&source[2].z == '\0'), useFallback)) ... else if (!useFallback) ...`
- No functional changes outside that loop.
