### PR TITLE
os: improve OSRegisterVersion matching in main/os/OS

### DIFF
--- a/src/os/OS.c
+++ b/src/os/OS.c
@@ -632,9 +632,5 @@ u32 __OSGetDIConfig(void) {
 }
 
 void OSRegisterVersion(const char* id) {
-    (void)id;
-    asm {
-        crclr 6
-    }
-    OSReport(__OSVersion);
+    OSReport("%s\n", id);
 }


### PR DESCRIPTION
## Summary
Adjust `OSRegisterVersion` to forward the provided module version string through a format string, instead of ignoring the argument and always reporting `__OSVersion`.

## Functions improved
- Unit: `main/os/OS`
- Symbol: `OSRegisterVersion`

## Match evidence
- `OSRegisterVersion`: **76.36364% -> 99.545456%**
- Unit `.text` (`main/os/OS`): **85.71531% -> 86.08012%**
- Remaining diff is a single relocation-target mismatch on the format string load (`li r3, ...@sda21`).

## Plausibility rationale
This change is source-plausible for Dolphin SDK style: `OSRegisterVersion(const char* id)` should report the caller-provided module version (`id`). The previous form discarded `id` and always printed `__OSVersion`, which is less plausible for a shared SDK helper used by many modules.

## Technical details
- Replaced:
  - `OSReport(__OSVersion);`
- With:
  - `OSReport("%s\\n", id);`
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/os/OS -o - OSRegisterVersion`.
