### PR TITLE
main/game: implement first pass of CGame::clearWork

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5,6 +5,8 @@
 #include "ffcc/vector.h"
 #include "ffcc/p_dbgmenu.h"
 #include "ffcc/p_minigame.h"
+#include "ffcc/map.h"
+#include "ffcc/sound.h"
 
 #include <string.h>
 
@@ -19,7 +21,9 @@ unsigned int AddScenegraph__7CSystemFP8CProcessi(CSystem*, void*, int);
 void RemoveScenegraph__7CSystemFP8CProcessi(CSystem*, void*, int);
 void ExecScenegraph__7CSystemFv(CSystem*);
 void Quit__12CFlatRuntimeFv(void*);
+void Destroy__13CFlatRuntime2Fv(void*);
 void DestroyStage__7CMemoryFPQ27CMemory6CStage(void*, void*);
+void DestroyMap__7CMapMngFv(void*);
 void Quit__11CDbgMenuPcsFv(void*);
 void Quit__6CMcPcsFv(void*);
 void Quit__7CGbaPcsFv(void*);
@@ -51,6 +55,9 @@ void Init__8CMenuPcsFv(void*);
 void Init__7CGbaPcsFv(void*);
 void Init__6CMcPcsFv(void*);
 void Init__11CDbgMenuPcsFv(void*);
+void Reset__9CCharaPcsFQ29CCharaPcs5RESET(void*, int);
+void StopAndFreeAllSe__6CSoundFi(void*, int);
+void ClearAll__5CWindFv(void*);
 void* CreateStage__7CMemoryFUlPci(void*, unsigned long, const char*, int);
 void Init__12CFlatRuntimeFv(void*);
 void Printf__7CSystemFPce(CSystem* system, const char* format, ...);
@@ -71,6 +78,7 @@ unsigned char GraphicsPcs[];
 unsigned char CameraPcs[];
 unsigned char DAT_8032ed00[];
 unsigned char DAT_8032ed08[];
+unsigned char Wind[];
 extern const char DAT_801d61dc[];
 }
 
@@ -365,12 +373,47 @@ void CGame::InitNewGame()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80015280
+ * PAL Size: 668b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::clearWork()
 {
-	// TODO
+    int i;
+    int j;
+    int k;
+
+    Destroy__13CFlatRuntime2Fv(CFlat);
+
+    for (i = 0; i < 4; i++) {
+        m_cFlatDataArr[i].Destroy();
+        unkCFlatData0[i] = 0;
+        m_partyObjArr[i] = 0;
+        m_scriptFoodBase[i] = 0;
+    }
+
+    unk_flat3_0xc7d0 = 0;
+
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 16; j++) {
+            for (k = 0; k < 2; k++) {
+                m_scriptWork[i][j][k] = 0;
+            }
+        }
+    }
+
+    m_gameWork.m_soundOptionFlag = 0;
+    m_gameWork.m_gameOverFlag = 0;
+
+    DestroyMap__7CMapMngFv(&MapMng);
+    Reset__9CCharaPcsFQ29CCharaPcs5RESET(&CharaPcs, 0);
+    StopAndFreeAllSe__6CSoundFi(&Sound, 0);
+    ClearAll__5CWindFv(Wind);
+
+    *((u8*)&Sound + 0x8892) = 0x7F;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass decompilation of `CGame::clearWork()` in `src/game.cpp`.
- Replaced TODO body with concrete teardown/reset logic for runtime, flat data, script/party work arrays, map/chara/sound/wind reset calls, and sound state byte reset.
- Added missing PAL-linked extern declarations used by this function.

## Functions improved
- Unit: `main/game`
- Symbol: `clearWork__5CGameFv`
- Size: 668b

## Match evidence
- `clearWork__5CGameFv`: **0.5988024% -> 18.652695%**
- Measurement command:
  - `build/tools/objdiff-cli diff -p . -u main/game -o - clearWork__5CGameFv`

## Plausibility rationale
- The new body follows expected game reset flow already used in this codebase (destroy runtime state, clear work arrays, reset map/chara/sound/wind systems).
- Changes are semantically coherent with existing field naming and manager responsibilities in `CGame`.
- This is an initial large-function pass; one low-level byte write remains as a temporary representation of an unmapped `CSound` field and can be replaced once type layouts are recovered.

## Technical details
- Implemented deterministic loops over `m_cFlatDataArr`, `m_partyObjArr`, `m_scriptFoodBase`, and `m_scriptWork` using existing class members.
- Preserved PAL symbol linkage via explicit extern function declarations for engine-level procedures (`Destroy__13CFlatRuntime2Fv`, `DestroyMap__7CMapMngFv`, `Reset__9CCharaPcs...`, `StopAndFreeAllSe__6CSoundFi`, `ClearAll__5CWindFv`).
- Build verified with `ninja` after the edit.
