### PR TITLE
main/util: implement CUtil::EndQuadEnv

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -472,22 +472,22 @@ void CUtil::BeginQuadEnv()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void GXSetTexCoordGen(void)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002428c
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CUtil::EndQuadEnv()
 {
-	// TODO
+    Mtx cameraMtx;
+    Mtx44 screenMtx;
+
+    PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
+    PSMTX44Copy(CameraPcs.m_screenMatrix, screenMtx);
+    GXLoadPosMtxImm(cameraMtx, 0);
+    GXSetProjection(screenMtx, GX_PERSPECTIVE);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CUtil::EndQuadEnv()` in `src/util.cpp` and replaced its TODO stub with a matrix/projection restore path that matches call patterns already used in nearby utility rendering code.

## Functions improved
- Unit: `main/util`
- Symbol: `EndQuadEnv__5CUtilFv`

## Match evidence
- `EndQuadEnv__5CUtilFv`: **4.347826% -> 99.478264%** (`size: 92`)
- Evidence command:
  - `build/tools/objdiff-cli diff -p . -u main/util -o - EndQuadEnv__5CUtilFv`

## Plausibility rationale
The new implementation is source-plausible and consistent with the existing `BeginQuadEnv()` / render helper flow in `CUtil`:
- restore camera matrix via `PSMTXCopy(CameraPcs.m_cameraMatrix, ...)`
- restore screen projection via `PSMTX44Copy(CameraPcs.m_screenMatrix, ...)`
- apply restored matrices with `GXLoadPosMtxImm` and `GXSetProjection`

This mirrors how nearby utility rendering functions transition to ortho and then back to perspective state.

## Technical details
- Added PAL metadata comment block for the function (`0x8002428c`, `92b`).
- Removed a stray local TODO stub declaration (`GXSetTexCoordGen(void)`) in the same region to avoid unintended codegen interaction with the target symbol layout.
