### PR TITLE
Improve pppVertexAttend match via local/load ordering

### DIFF
--- a/src/pppVertexAttend.cpp
+++ b/src/pppVertexAttend.cpp
@@ -42,28 +42,41 @@ extern VertexAttendEnv* lbl_8032ED54;
 void pppVertexAttend(void* r3, void* r4, void* r5)
 {
     s16 entryIndex = *(s16*)((u8*)r4 + 0xC);
+    VertexAttendStream* stream;
+    VertexAttendEnv* env;
+    VertexSetEntry* setEntry;
+    VertexAttendModel** modelTable;
+    u16 sourceIndex;
+    s32 modelIndex;
+    u16 vertexIndex;
+    u8* output;
+    VertexAttendModel* model;
+    Vec* sourceVertex;
+    void* matrixObject;
+    Vec transformed;
+    Vec* transformedPtr = &transformed;
 
     if (entryIndex < 0) {
         return;
     }
 
-    VertexAttendStream* stream = *(VertexAttendStream**)((u8*)r5 + 0xC);
-    VertexAttendEnv* env = lbl_8032ED54;
-    VertexSetEntry* setEntry = &env->vertexSetTable[entryIndex];
-    u16 sourceIndex = *(u16*)((u8*)r3 + stream->sourceOffset + 0x80);
-    u8* output = (u8*)r3 + stream->destOffset + 0x80;
-    s16 modelIndex = setEntry->modelIndex;
-    u16 vertexIndex = setEntry->vertexRemap[sourceIndex];
-    VertexAttendModel* model = env->modelTable[modelIndex];
-    Vec* sourceVertex = (Vec*)((u8*)model->vertexData + (vertexIndex * sizeof(Vec)));
-    void* matrixObject = *(void**)((u8*)r3 + 4);
-    Vec transformed;
+    stream = *(VertexAttendStream**)((u8*)r5 + 0xC);
+    env = lbl_8032ED54;
+    setEntry = (VertexSetEntry*)((u8*)env->vertexSetTable + (entryIndex * sizeof(VertexSetEntry)));
+    sourceIndex = *(u16*)((u8*)r3 + stream->sourceOffset + 0x80);
+    output = (u8*)r3 + stream->destOffset + 0x80;
+    modelIndex = setEntry->modelIndex;
+    vertexIndex = setEntry->vertexRemap[sourceIndex];
+    modelTable = env->modelTable;
+    model = modelTable[modelIndex];
+    sourceVertex = (Vec*)((u8*)model->vertexData + (vertexIndex * sizeof(Vec)));
+    matrixObject = *(void**)((u8*)r3 + 4);
 
     transformed.x = sourceVertex->x;
     transformed.y = sourceVertex->y;
     transformed.z = sourceVertex->z;
 
-    PSMTXMultVec((MtxPtr)((u8*)matrixObject + 0x10), &transformed, &transformed);
+    PSMTXMultVec((MtxPtr)((u8*)matrixObject + 0x10), transformedPtr, transformedPtr);
 
     *(f32*)(output + 0) = transformed.x;
     *(f32*)(output + 4) = transformed.y;


### PR DESCRIPTION
## Summary
- Refactored `pppVertexAttend` local declarations and load order to better match original codegen.
- Kept behavior unchanged: same index lookup, vertex remap, matrix transform, and output writes.
- Introduced an explicit local pointer for the stack `Vec` used by `PSMTXMultVec` to improve register usage/order.

## Functions improved
- Unit: `main/pppVertexAttend`
- Function: `pppVertexAttend` (`200b`)
- Fuzzy match: `87.50%` -> `91.48%`

## Match evidence
- `ninja` regenerated `build/GCCP01/report.json` with the updated function score above.
- Objdiff now shows the majority of instructions aligned (`43 OK`), with remaining diffs clustered in early register/load scheduling.

## Plausibility rationale
- Changes are source-plausible and maintain readable C/C++ structure:
  - explicit intermediate locals for stream/env/table/model flow,
  - straightforward pointer arithmetic,
  - unchanged algorithm and data flow.
- No compiler-coaxing-only artifacts (no inline asm, no magic volatile tricks, no behavior changes).

## Technical details
- Main improvement came from moving model-table and remap computations into a sequence that better matches expected instruction ordering around:
  - stream/env loads,
  - model index load timing,
  - stack `Vec` address usage for `PSMTXMultVec`.
- Remaining mismatch is small and appears limited to early register assignment/instruction scheduling.
