### PR TITLE
Decompile CLightPcs::AddBump setup flow

### DIFF
--- a/include/ffcc/p_light.h
+++ b/include/ffcc/p_light.h
@@ -45,7 +45,7 @@ public:
     void Clear();
     void Add(CLightPcs::CLight*);
     void GetFreeBumpLight(CLightPcs::TARGET);
-    void AddBump(CLightPcs::CLight*, CLightPcs::TARGET, CMemory::CStage*, int);
+    CLightPcs::CBumpLight* AddBump(CLightPcs::CLight*, CLightPcs::TARGET, CMemory::CStage*, int);
     void SetMapColorAlpha(float (*)[4], _GXColor, _GXColor, unsigned char, float, float, float, unsigned char);
     void SetAmbient(_GXColor);
     void SetAmbientAlpha(float);


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::AddBump` in `src/p_light.cpp` from decomp-guided control flow.
- Added slot search, bump-light data copy/setup, allocation via `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii`, and per-layer `GXInitTexObj` initialization.
- Updated `AddBump` signature in `include/ffcc/p_light.h` to return `CLightPcs::CBumpLight*`, matching how the function is used in assembly flow.
- Added PAL metadata block for the function (`0x8004975c`, `880b`).

## Functions Improved
- Unit: `main/p_light`
- Symbol: `AddBump__9CLightPcsFPQ29CLightPcs6CLightQ29CLightPcs6TARGETPQ27CMemory6CStagei`

## Match Evidence
- Selector baseline before edit: `0.5%` for `AddBump` (from `tools/agent_select_target.py` output).
- After edit (`objdiff-cli v3.6.1`): `31.904545%` match for `AddBump`.
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/p_light -o - AddBump__9CLightPcsFPQ29CLightPcs6CLightQ29CLightPcs6TARGETPQ27CMemory6CStagei`

## Plausibility Rationale
- The change reflects plausible original source behavior for a bump-light registration path:
  - search for a free per-target slot,
  - copy base light params into bump-light storage,
  - normalize/range-adjust key scalar fields,
  - set channel-enable bits from light color presence,
  - allocate packed texture memory and initialize texture objects.
- This avoids synthetic compiler-coaxing patterns and keeps logic aligned with existing pointer/offset style already present in `p_light.cpp`.

## Technical Details
- Introduced local static `s_p_light_cpp` for allocation callsite metadata.
- Used existing globals/constants (`FLOAT_8032fc14`, `FLOAT_8032fc18`, `System`, `Memory`) already used throughout this unit.
- Verified build success with `ninja` after the change.
