### PR TITLE
p_usb: improve __sinit_p_usb_cpp addressing match

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -11,9 +11,9 @@ int DAT_8032ec68;
 
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
-extern void* __vt__8CManager;
-extern void* lbl_801E8668;
-extern void* lbl_801E8830;
+extern char __vt__8CManager[];
+extern char lbl_801E8668[];
+extern char lbl_801E8830[];
 extern u32 lbl_801E8690[];
 extern u32 lbl_801E869C[];
 extern u32 lbl_801E86A8[];
@@ -246,9 +246,9 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 extern "C" void __sinit_p_usb_cpp()
 {
     volatile void** base = (volatile void**)&USBPcs;
-    *base = &__vt__8CManager;
-    *base = &lbl_801E8668;
-    *base = &lbl_801E8830;
+    *base = __vt__8CManager;
+    *base = lbl_801E8668;
+    *base = lbl_801E8830;
 
     u32* dst = lbl_801E86B4 + 1;
     u32* src0 = lbl_801E8690;


### PR DESCRIPTION
## Summary
- Adjusted `src/p_usb.cpp` symbol declarations used by `__sinit_p_usb_cpp` from `void*` externs to symbol-address arrays (`char[]`).
- Updated `__sinit_p_usb_cpp` assignments to write symbol addresses directly (`*base = symbol`) instead of taking address-of pointer objects.
- Kept init flow and data copy logic unchanged.

## Functions improved
- Unit: `main/p_usb`
- Symbol: `__sinit_p_usb_cpp`

## Match evidence
- `__sinit_p_usb_cpp`: `73.90909%` -> `75.27273%` (`objdiff-cli`)
- `main/p_usb` `.text` match: `85.01212%` -> `85.19394%`
- Other tracked symbols in this pass (`mccReadData__7CUSBPcsFv`, `SendDataCode__7CUSBPcsFiPvii`) were unchanged.

## Plausibility rationale
- This change is source-plausible: it corrects symbol typing/address usage in static init code rather than introducing control-flow tricks.
- Behavior is unchanged; only address materialization/relocation style in constructor init code shifts closer to expected object output.

## Technical details
- The previous form encouraged less accurate relocation/materialization for vtable-like symbols in this TU.
- Using symbol-address declarations and direct symbol assignment improved codegen alignment for static initialization writes in `__sinit_p_usb_cpp`.
