### PR TITLE
Decompile pppRyjMegaBirth calc_particle and fix VRyjMegaBirth layout

### DIFF
--- a/include/ffcc/pppRyjMegaBirth.h
+++ b/include/ffcc/pppRyjMegaBirth.h
@@ -10,11 +10,13 @@ struct PRyjMegaBirth : _PARTICLE_DATA
 struct VRyjMegaBirth
 {
     Mtx m_worldMatrix;
-    Vec *m_particleBlock;
-    u32 m_numParticles;
-    PARTICLE_WMAT *m_worldMatrixBlock;
-    _PARTICLE_COLOR *m_colorBlock;
     Vec m_accelerationAxis;
+    Vec* m_particleBlock;
+    PARTICLE_WMAT* m_worldMatrixBlock;
+    _PARTICLE_COLOR* m_colorBlock;
+    void* m_meshData;
+    u16 m_numParticles;
+    u16 m_emitTimer;
 };
 
 struct PRyjMegaBirthOffsets


### PR DESCRIPTION
## Summary
- aligned `VRyjMegaBirth` member layout with constructor/destructor offset usage (`m_accelerationAxis` at `+0x30`, particle/color pointers at `+0x3C/+0x40/+0x44`, timer fields at `+0x4C/+0x4E`)
- replaced the `calc_particle__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColor` TODO with a first-pass implementation from the PAL Ghidra reference (`0x80082b10`, `440b`)
- preserved existing decomp style by using explicit byte-offset accesses where owning structs are still incomplete

## Functions improved
- Unit: `main/pppRyjMegaBirth`
- `calc_particle__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColor`
  - before: `0.90909094%`
  - after: `40.69091%`
- side effect in same unit from corrected work-struct layout:
  - `pppRyjMegaBirth`: `84.26415%` -> `88.528305%`

## Match evidence
- Unit `main/pppRyjMegaBirth` fuzzy match:
  - before: `9.943312%`
  - after: `12.45649%`
- `ninja` build passes after the change.
- `objdiff-cli diff -p . -u main/pppRyjMegaBirth calc_particle__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColor` reports current-symbol diff at ~`40.60%`.

## Plausibility rationale
- the layout correction follows concrete constructor/destructor stores in `pppRyjMegaBirthCon`/`pppRyjMegaBirthDes`, rather than compiler-only coaxing.
- the new `calc_particle` logic maps to expected particle-system behavior already used across nearby units: emit gate by timer/count, per-particle advance, color-table frame stepping, and optional per-particle matrix/color block stepping.
- code remains readable and intentionally avoids artificial temporaries for score-only tuning.

## Technical details
- added PAL metadata block for the newly implemented function.
- imported `DAT_8032ed70` gate used by many PPP frame functions.
- retained `_PARTICLE_DATA` stepping at `0x60` bytes and frame-index timing math from reference assembly shape.
