### PR TITLE
main/pppYmLookOn: improve pppFrameYmLookOn match

### DIFF
--- a/src/pppYmLookOn.cpp
+++ b/src/pppYmLookOn.cpp
@@ -37,14 +37,14 @@ void pppConstructYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkC* param_2)
 void pppFrameYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkB* param_2, struct UnkC* param_3)
 {
     struct _pppMngSt* pppMngSt;
-    int dataOffset;
+    int workOffset;
     u8* owner;
-    Vec local_58;
-    Vec local_4c;
-    Vec local_40;
-    Vec local_34;
-    Vec local_28;
     Vec local_1c;
+    Vec local_28;
+    Vec local_34;
+    Vec local_40;
+    Vec local_4c;
+    Vec local_58;
 
     if (DAT_8032ed70 != 0) {
         return;
@@ -52,48 +52,51 @@ void pppFrameYmLookOn(struct pppYmLookOn* pppYmLookOn, struct UnkB* param_2, str
 
     pppMngSt = pppMngStPtr;
     owner = *(u8**)((u8*)pppMngSt + 0xdc);
-    dataOffset = *param_3->m_serializedDataOffsets;
-    if ((owner != nullptr) || (*(int*)((u8*)pppYmLookOn + dataOffset + 0x80) != 0)) {
-        *(u8**)((u8*)pppYmLookOn + dataOffset + 0x80) = owner;
-        if (owner == nullptr) {
-            owner = *(u8**)((u8*)pppYmLookOn + dataOffset + 0x80);
+    workOffset = *param_3->m_serializedDataOffsets;
+    if (owner == nullptr) {
+        if (*(int*)((u8*)pppYmLookOn + workOffset + 0x80) == 0) {
+            return;
         }
+    }
 
-        local_4c.x = *(f32*)(owner + 0x15c);
-        local_4c.y = *(f32*)(owner + 0x160) + (f32)param_2->m_dataValIndex;
-        local_4c.z = *(f32*)(owner + 0x164);
-        local_58.x = *(f32*)((u8*)pppMngSt + 0x84);
-        local_58.y = *(f32*)((u8*)pppMngSt + 0x94);
-        local_58.z = *(f32*)((u8*)pppMngSt + 0xa4);
-        PSVECSubtract(&local_58, &local_4c, &local_1c);
+    *(u8**)((u8*)pppYmLookOn + workOffset + 0x80) = owner;
+    if (owner == nullptr) {
+        owner = *(u8**)((u8*)pppYmLookOn + workOffset + 0x80);
+    }
 
-        if (((FLOAT_80330ec8 != local_1c.x) || (FLOAT_80330ec8 != local_1c.y)) ||
-            (FLOAT_80330ec8 != local_1c.z)) {
-            PSVECNormalize(&local_1c, &local_40);
-            local_28.z = -local_40.x;
-            local_28.x = local_40.z;
-            local_28.y = FLOAT_80330ec8;
-            if ((FLOAT_80330ec8 == local_40.z) && (FLOAT_80330ec8 == local_28.z)) {
-                local_28.x = FLOAT_80330ecc;
-                local_28.z = FLOAT_80330ec8;
-                local_34.x = FLOAT_80330ec8;
-                local_34.y = FLOAT_80330ec8;
-                local_34.z = FLOAT_80330ecc;
-            } else {
-                PSVECNormalize(&local_28, &local_28);
-                PSVECCrossProduct(&local_40, &local_28, &local_34);
-                PSVECNormalize(&local_34, &local_34);
-            }
-            *(f32*)((u8*)pppMngStPtr + 0x78) = local_28.x;
-            *(f32*)((u8*)pppMngStPtr + 0x88) = local_28.y;
-            *(f32*)((u8*)pppMngStPtr + 0x98) = local_28.z;
-            *(f32*)((u8*)pppMngStPtr + 0x7c) = local_34.x;
-            *(f32*)((u8*)pppMngStPtr + 0x8c) = local_34.y;
-            *(f32*)((u8*)pppMngStPtr + 0x9c) = local_34.z;
-            *(f32*)((u8*)pppMngStPtr + 0x80) = local_40.x;
-            *(f32*)((u8*)pppMngStPtr + 0x90) = local_40.y;
-            *(f32*)((u8*)pppMngStPtr + 0xa0) = local_40.z;
-            pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
+    local_4c.x = *(f32*)(owner + 0x15c);
+    local_4c.y = *(f32*)(owner + 0x160) + (f32)param_2->m_dataValIndex;
+    local_4c.z = *(f32*)(owner + 0x164);
+    local_58.x = *(f32*)((u8*)pppMngSt + 0x84);
+    local_58.y = *(f32*)((u8*)pppMngSt + 0x94);
+    local_58.z = *(f32*)((u8*)pppMngSt + 0xa4);
+    PSVECSubtract(&local_58, &local_4c, &local_1c);
+
+    if (((FLOAT_80330ec8 != local_1c.x) || (FLOAT_80330ec8 != local_1c.y)) || (FLOAT_80330ec8 != local_1c.z)) {
+        PSVECNormalize(&local_1c, &local_40);
+        local_28.z = -local_40.x;
+        local_28.x = local_40.z;
+        local_28.y = FLOAT_80330ec8;
+        if ((FLOAT_80330ec8 == local_40.z) && (FLOAT_80330ec8 == local_28.z)) {
+            local_28.x = FLOAT_80330ecc;
+            local_28.z = FLOAT_80330ec8;
+            local_34.x = FLOAT_80330ec8;
+            local_34.y = FLOAT_80330ec8;
+            local_34.z = FLOAT_80330ecc;
+        } else {
+            PSVECNormalize(&local_28, &local_28);
+            PSVECCrossProduct(&local_40, &local_28, &local_34);
+            PSVECNormalize(&local_34, &local_34);
         }
+        *(f32*)((u8*)pppMngStPtr + 0x78) = local_28.x;
+        *(f32*)((u8*)pppMngStPtr + 0x88) = local_28.y;
+        *(f32*)((u8*)pppMngStPtr + 0x98) = local_28.z;
+        *(f32*)((u8*)pppMngStPtr + 0x7c) = local_34.x;
+        *(f32*)((u8*)pppMngStPtr + 0x8c) = local_34.y;
+        *(f32*)((u8*)pppMngStPtr + 0x9c) = local_34.z;
+        *(f32*)((u8*)pppMngStPtr + 0x80) = local_40.x;
+        *(f32*)((u8*)pppMngStPtr + 0x90) = local_40.y;
+        *(f32*)((u8*)pppMngStPtr + 0xa0) = local_40.z;
+        pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
     }
 }


### PR DESCRIPTION
## Summary
Refined `pppFrameYmLookOn` control flow and temporary ordering to better align with PAL codegen while keeping behavior intact.

## Functions improved
- Unit: `main/pppYmLookOn`
- Symbol: `pppFrameYmLookOn`

## Match evidence
- `pppFrameYmLookOn`: `88.68908%` -> `88.91597%`
- Unit `.text` (`main/pppYmLookOn`): `89.232%` -> `89.448%`

Measured via:
`build/tools/objdiff-cli diff -p . -u main/pppYmLookOn -o - pppFrameYmLookOn`

## Plausibility rationale
Changes are source-plausible cleanup of branch structure and local variable ordering (no contrived compiler-only tricks, no behavior changes, no hardcoded object offsets added beyond existing code style in this unit).

## Technical details
- Reworked the owner/work-slot guard into explicit nested null checks, which shifted early branch shape toward the target.
- Reordered local `Vec` declarations to better match target stack slot layout used around vector math calls.
- Preserved existing matrix update and normalization logic; no algorithmic changes introduced.
