### PR TITLE
gobjwork: implement four CCaravanWork helper stubs

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/gobjwork.h"
+#include "ffcc/partyobj.h"
 #include "ffcc/p_game.h"
 #include <string.h>
 
@@ -290,12 +291,20 @@ void CCaravanWork::AddItem(int, int*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a1ee8
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CCaravanWork::SetArtifact(int, int)
+void CCaravanWork::SetArtifact(int artifactIndex, int enabled)
 {
-	// TODO
+	unsigned short artifact = 0xFFFF;
+	if (enabled != 0) {
+		artifact = (short)artifactIndex + 0x9F;
+	}
+	m_artifacts[artifactIndex] = artifact;
 }
 
 /*
@@ -475,12 +484,16 @@ void CCaravanWork::CalcStatus()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009fa20
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCaravanWork::CanPlayerUseItem()
 {
-	// TODO
+	((CGPartyObj*)m_ownerObj)->canPlayerUseItem();
 }
 
 /*
@@ -615,12 +628,16 @@ void CCaravanWork::GetNextCmdListIdx(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009f280
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCaravanWork::CanPlayerPutItem()
 {
-	// TODO
+	((CGPartyObj*)m_ownerObj)->canPlayerPutItem();
 }
 
 /*
@@ -635,12 +652,17 @@ void CCaravanWork::GetCurrentWeaponItem(int&, int&)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009f1d8
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CCaravanWork::SetCurrentWeaponIdx(int)
+void CCaravanWork::SetCurrentWeaponIdx(int weaponIdx)
 {
-	// TODO
+	m_weaponIdx = (short)weaponIdx;
+	CheckAndResetCurrentWeaponIdx(weaponIdx);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented four previously stubbed `CCaravanWork` helpers in `src/gobjwork.cpp`.
- Added PAL address/size metadata blocks for each implemented function.
- Added `#include "ffcc/partyobj.h"` so `CCaravanWork` can directly dispatch to `CGPartyObj` item-action methods.

## Functions Improved
Unit: `main/gobjwork`
- `CanPlayerUseItem__12CCaravanWorkFv`: **11.111111% -> 100.0%**
- `CanPlayerPutItem__12CCaravanWorkFv`: **11.111111% -> 100.0%**
- `SetCurrentWeaponIdx__12CCaravanWorkFi`: **11.111111% -> 100.0%**
- `SetArtifact__12CCaravanWorkFii`: **12.5% -> 50.625%**

## Match Evidence
- Verified with `tools/objdiff-cli diff -p . -u main/gobjwork -o - CalcStatus__8CMonWorkFv` and symbol-level JSON extraction.
- Full build/report still passes (`ninja`), and global progress moved from:
  - Code matched: `202964 -> 203072` bytes
  - Matched functions: `1524 -> 1527`

## Plausibility Rationale
- These edits replace TODO stubs with direct, straightforward game-logic behavior that is consistent with class ownership and field semantics:
  - `CanPlayerUseItem`/`CanPlayerPutItem`: delegate to the owning `CGPartyObj`.
  - `SetCurrentWeaponIdx`: store weapon index then run consistency check.
  - `SetArtifact`: assign either `0xFFFF` sentinel or indexed artifact id.
- No compiler-coaxing patterns, unnatural temporaries, or offset obfuscation were introduced.

## Technical Notes
- Function bodies were aligned to the Ghidra snapshots for PAL addresses:
  - `0x8009fa20`, `0x8009f280`, `0x8009f1d8`, `0x800a1ee8`.
- The remaining gap in `SetArtifact` likely reflects type/signature nuances still to refine.
