### PR TITLE
main/gx/GXAttr: improve __GXSetVAT match with fixed VAT loop

### DIFF
--- a/src/gx/GXAttr.c
+++ b/src/gx/GXAttr.c
@@ -396,19 +396,15 @@ void GXSetVtxAttrFmtv(GXVtxFmt vtxfmt, const GXVtxAttrFmtList* list) {
 
 void __GXSetVAT(void) {
     s32 i;
-    u32 dirty = __GXData->dirtyVAT;
-    
-    i = 0;
-    do {
-        if (dirty & 1) {
-            GX_WRITE_SOME_REG4(8, i | 0x70, __GXData->vatA[i], i - 12);
-            GX_WRITE_SOME_REG4(8, i | 0x80, __GXData->vatB[i], i - 12);
-            GX_WRITE_SOME_REG4(8, i | 0x90, __GXData->vatC[i], i - 12);
-        }
+    u8 b;
 
-        dirty >>= 1;
-        i++;
-    } while (dirty != 0);
+    for (b = 0, i = 0; b < 8; b++, i++) {
+        if ((__GXData->dirtyVAT & (u8)(1 << b)) != 0) {
+            GX_WRITE_SOME_REG4(8, b | 0x70, __GXData->vatA[i], i - 12);
+            GX_WRITE_SOME_REG4(8, b | 0x80, __GXData->vatB[i], i - 12);
+            GX_WRITE_SOME_REG4(8, b | 0x90, __GXData->vatC[i], i - 12);
+        }
+    }
 
     __GXData->dirtyVAT = 0;
 }


### PR DESCRIPTION
## Summary
- Reworked `__GXSetVAT` in `src/gx/GXAttr.c` to iterate over the 8 VAT slots with explicit bit tests against `dirtyVAT`.
- Removed the shifting `dirty >>= 1` do/while structure and switched to a fixed-width loop that directly checks `(dirtyVAT & (1 << b))`.
- Preserved behavior: write VAT A/B/C registers for dirty entries, then clear `dirtyVAT`.

## Functions improved
- Unit: `main/gx/GXAttr`
- Symbol: `__GXSetVAT`

## Match evidence
- `__GXSetVAT`: **76.10256% -> 94.76923%**
- Unit `.text` (`main/gx/GXAttr`): **64.85215% -> 65.50448%**
- Diff-kind reduction on `__GXSetVAT`:
  - Before: `DIFF_ARG_MISMATCH` 17, `DIFF_DELETE` 6, `DIFF_INSERT` 1, `DIFF_OP_MISMATCH` 1, `DIFF_REPLACE` 2
  - After: `DIFF_ARG_MISMATCH` 18, `DIFF_INSERT` 1 (structural delete/replace/op mismatches removed)

## Plausibility rationale
- A fixed 8-entry VAT loop is consistent with GX vertex format slot count and is a natural original-source implementation.
- The new structure simplifies control flow without introducing contrived temporaries or compiler-coaxing constructs.
- Register write semantics and state mutation remain unchanged.

## Technical details
- Main adjustment was loop shape and dirty-bit test strategy, which better aligns branch structure with target assembly for `__GXSetVAT`.
- Verified with `tools/objdiff-cli` and full `ninja` build (`build/GCCP01/main.dol: OK`).
