### PR TITLE
util: improve __sinit_util_cpp match with explicit initializer

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -32,7 +32,23 @@ struct CTextureLite {
     GXTlutObj m_tlutObj1;
 };
 
+extern void* lbl_801E88C4;
+
 CUtil DAT_8032ec70;
+
+/*
+ * --INFO--
+ * PAL Address: 0x80024e48
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_util_cpp(void)
+{
+    *reinterpret_cast<void**>(&DAT_8032ec70) = &lbl_801E88C4;
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added an explicit `__sinit_util_cpp` implementation in `src/util.cpp`.
- Wired global `DAT_8032ec70` initialization to the known vtable symbol (`lbl_801E88C4`) to better reflect original startup behavior.
- Kept the change narrow to a single initializer path; no functional edits to runtime utility methods.

## Functions Improved
- Unit: `main/util`
- Symbol: `__sinit_util_cpp`

## Match Evidence
- `__sinit_util_cpp`: **25.00% -> 58.75%** (`16b`, 4 instructions)
- Build check: `ninja` succeeds after the change.

## Plausibility Rationale
- This file owns the global `CUtil` instance (`DAT_8032ec70`) and startup initializer symbol.
- Setting the first word of the singleton to the class vtable pointer in `__sinit` is consistent with existing project patterns (other `__sinit_*` functions) and likely original source intent.

## Technical Details
- The previous decomp emitted effectively empty initializer code for `__sinit_util_cpp`.
- Explicitly materializing the vtable store introduces the expected startup-side code shape and improves objdiff alignment for this symbol.
