### PR TITLE
main/graphic: implement RenderDOF and fix target mangling

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -77,7 +77,7 @@ public:
     void RenderTexQuadGrouad(Vec, Vec, _GXColor, _GXColor, _GXColor, _GXColor);
     void RenderNoTexQuadGrouad(Vec, Vec, _GXColor, _GXColor, _GXColor, _GXColor);
 
-    void RenderDOF(char, char, float, float, Vec&, int);
+    void RenderDOF(signed char, signed char, float, float, Vec, int);
 
     void CreateSmallBackTexture(void*, _GXTexObj*, long, long, _GXTexFilter, _GXTexFmt, unsigned long);
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -2,8 +2,37 @@
 
 #include "ffcc/pppfunctbl.h"
 #include "ffcc/system.h"
+#include "ffcc/util.h"
 
 extern void* lbl_801E8408;
+extern char DAT_80238030[];
+extern CUtil DAT_8032ec70;
+
+extern struct {
+    float _212_4_;
+    float _216_4_;
+    float _220_4_;
+    float _224_4_;
+    float _228_4_;
+    float _232_4_;
+    Mtx m_cameraMatrix;
+} CameraPcs;
+
+extern "C" {
+void _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(int, int, int, int);
+void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(int, int,
+                                                                                                             int, int,
+                                                                                                             int);
+void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int,
+                                                                                           int);
+void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(int, int,
+                                                                                                             int, int,
+                                                                                                             int);
+void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int,
+                                                                                           int);
+}
 
 /*
  * --INFO--
@@ -503,12 +532,233 @@ void CGraphic::RenderNoTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXCol
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80016fb0
+ * PAL Size: 2112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphic::RenderDOF(char, char, float, float, Vec&, int)
+void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist, float farDist, Vec targetPos, int blurPasses)
 {
-	// TODO
+	_GXTexObj smallBackTex;
+	_GXTexObj backBufferTex;
+	_GXColor dofColor;
+	Vec cameraPos;
+	Vec cameraToTarget;
+	Vec scaledDir;
+	Vec quadMin;
+	Vec quadMax;
+	float gxProjection[7];
+	float gxViewport[6];
+	Mtx cameraMtx;
+	float projX;
+	float projY;
+	float projZ;
+	unsigned int texBufferSize;
+	unsigned int depthAlphaNear;
+	unsigned int depthAlphaFar;
+	unsigned char nearAlpha;
+	unsigned char farAlpha;
+	float xOffset;
+	float yOffset;
+	bool hasNearAlpha;
+	bool hasFarAlpha;
+
+	if (mode >= 4) {
+		return;
+	}
+
+	if (nearDist < 0.0f) {
+		nearDist = 0.0f;
+	}
+	if (nearDist > 1.0f) {
+		nearDist = 1.0f;
+	}
+	if (farDist < nearDist) {
+		farDist = nearDist;
+	}
+	if (blurWidth < 1) {
+		blurWidth = 1;
+	}
+
+	nearAlpha = 0;
+	farAlpha = 0;
+	hasNearAlpha = false;
+	hasFarAlpha = false;
+	texBufferSize = GXGetTexBufferSize(0x140, 0xE0, GX_TF_I8, GX_FALSE, GX_FALSE);
+
+	cameraPos.x = CameraPcs._224_4_;
+	cameraPos.y = 0.0f;
+	cameraPos.z = CameraPcs._232_4_;
+
+	targetPos.y = 0.0f;
+	PSVECSubtract(&targetPos, &cameraPos, &cameraToTarget);
+
+	GXGetProjectionv(gxProjection);
+	GXGetViewportv(gxViewport);
+	PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
+
+	if (mode != 2) {
+		PSVECScale(&cameraToTarget, &scaledDir, nearDist);
+		GXProject(cameraPos.x + scaledDir.x, targetPos.y, cameraPos.z + scaledDir.z, cameraMtx, gxProjection,
+		          gxViewport, &projX, &projY, &projZ);
+
+		depthAlphaNear = (unsigned int)(projZ * 255.0f);
+		if (depthAlphaNear > 0xFF) {
+			depthAlphaNear = 0xFF;
+		}
+		nearAlpha = (unsigned char)depthAlphaNear;
+		hasNearAlpha = true;
+	}
+
+	if (mode != 1) {
+		float targetMag = PSVECMag(&cameraToTarget);
+		if (targetMag > 0.0f) {
+			PSVECScale(&cameraToTarget, &scaledDir, farDist / targetMag);
+		} else {
+			scaledDir.x = 0.0f;
+			scaledDir.y = 0.0f;
+			scaledDir.z = 0.0f;
+		}
+
+		GXProject(targetPos.x + scaledDir.x, targetPos.y, targetPos.z + scaledDir.z, cameraMtx, gxProjection,
+		          gxViewport, &projX, &projY, &projZ);
+
+		depthAlphaFar = (unsigned int)(projZ * 255.0f);
+		if (depthAlphaFar == 0) {
+			depthAlphaFar = 0xFF;
+		}
+		if (depthAlphaFar > 0xFF) {
+			depthAlphaFar = 0xFF;
+		}
+		farAlpha = (unsigned char)depthAlphaFar;
+		hasFarAlpha = true;
+	}
+
+	if (!hasNearAlpha) {
+		nearAlpha = 0;
+	}
+	if (!hasFarAlpha) {
+		farAlpha = 0xFF;
+	}
+
+	DAT_8032ec70.SetVtxFmt_POS_CLR_TEX();
+	CreateSmallBackTexture(DAT_80238030, &smallBackTex, 0x140, 0xE0, GX_NEAR, GX_TF_I8, 0);
+	GetBackBufferRect2(DAT_80238030, &backBufferTex, 0, 0, 0x280, 0x1C0, texBufferSize, GX_NEAR, (_GXTexFmt)0x11, 0);
+	DAT_8032ec70.SetVtxFmt_POS_CLR_TEX0_TEX1();
+	DAT_8032ec70.SetOrthoEnv();
+
+	xOffset = (float)blurWidth;
+	yOffset = xOffset * (224.0f / 640.0f);
+
+	for (int pass = 0; pass < 2; pass++) {
+		int kColorSel = 0x0C;
+		int kAlphaSel = 0x1C;
+		unsigned char passAlpha = nearAlpha;
+
+		if ((pass == 0) && !((mode != 2) && hasNearAlpha && (mode != 1) && hasFarAlpha)) {
+			continue;
+		}
+
+		if (pass != 0) {
+			kColorSel = 0x0D;
+			kAlphaSel = 0x1D;
+			passAlpha = farAlpha;
+		}
+
+		dofColor.r = passAlpha;
+		dofColor.g = passAlpha;
+		dofColor.b = passAlpha;
+		dofColor.a = passAlpha;
+		GXSetTevKColor((GXTevKColorID)pass, dofColor);
+
+		dofColor.a = 0x80;
+		GXSetChanAmbColor(GX_COLOR0A0, dofColor);
+		GXSetChanMatColor(GX_COLOR0A0, dofColor);
+
+		_GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 4, 5, 5);
+
+		GXSetTevDirect(GX_TEVSTAGE0);
+		GXLoadTexObj(&backBufferTex, GX_TEXMAP0);
+		GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, 0x7D);
+		_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
+		_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+		GXSetTevKColorSel(GX_TEVSTAGE0, (GXTevKColorSel)kColorSel);
+		GXSetTevKAlphaSel(GX_TEVSTAGE0, (GXTevKAlphaSel)kAlphaSel);
+
+		if (pass == 0) {
+			_GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0,
+			                                                                                                         0x0E, 8,
+			                                                                                                         0x0C,
+			                                                                                                         0x0F);
+		} else {
+			_GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 8,
+			                                                                                                         0x0E,
+			                                                                                                         0x0C,
+			                                                                                                         0x0F);
+		}
+		_GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 8, 0, 0, 1, 0);
+		_GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 4, 6, 6,
+		                                                                                                       7);
+		_GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 8, 0, 0, 1, 0);
+
+		GXSetTevDirect(GX_TEVSTAGE1);
+		GXLoadTexObj(&smallBackTex, GX_TEXMAP1);
+		GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_TEX1, GX_IDENTITY, GX_FALSE, 0x7D);
+		_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(1, 1, 1, 4);
+		_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 0);
+		_GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(1, 0x0F,
+		                                                                                                       0x0F, 0x0F,
+		                                                                                                       8);
+		_GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 0, 1, 0);
+		_GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(1, 7, 5, 0,
+		                                                                                                       7);
+		_GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 0, 1, 0);
+
+		GXSetNumTevStages(2);
+		GXSetNumTexGens(2);
+
+		quadMin.x = 0.0f;
+		quadMin.y = 0.0f;
+		quadMin.z = 0.0f;
+		quadMax.x = 640.0f;
+		quadMax.y = 224.0f;
+		quadMax.z = 0.0f;
+		DAT_8032ec70.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+
+		quadMin.x = -xOffset;
+		quadMin.y = 0.0f;
+		quadMin.z = 0.0f;
+		quadMax.x = 640.0f - xOffset;
+		quadMax.y = 224.0f;
+		quadMax.z = 0.0f;
+		DAT_8032ec70.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+
+		quadMin.x = xOffset;
+		quadMin.y = 0.0f;
+		quadMin.z = 0.0f;
+		quadMax.x = 640.0f + xOffset;
+		quadMax.y = 224.0f;
+		quadMax.z = 0.0f;
+		DAT_8032ec70.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+
+		quadMin.x = 0.0f;
+		quadMin.y = -yOffset;
+		quadMin.z = 0.0f;
+		quadMax.x = 640.0f;
+		quadMax.y = 224.0f - yOffset;
+		quadMax.z = 0.0f;
+		DAT_8032ec70.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+
+		quadMin.x = 0.0f;
+		quadMin.y = yOffset;
+		quadMin.z = 0.0f;
+		quadMax.x = 640.0f;
+		quadMax.y = 224.0f + yOffset;
+		quadMax.z = 0.0f;
+		DAT_8032ec70.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGraphic::RenderDOF` in `src/graphic.cpp` (previously a TODO stub).
- Added PAL metadata block for the function (`0x80016fb0`, `2112b`).
- Corrected `RenderDOF` signature in `include/ffcc/graphic.h` and `src/graphic.cpp` to align mangling with the target symbol:
  - from `char, char, float, float, Vec&, int`
  - to `signed char, signed char, float, float, Vec, int`

## Functions improved
- Unit: `main/graphic`
- Symbol: `RenderDOF__8CGraphicFScScff3Veci`

## Match evidence
- `RenderDOF__8CGraphicFScScff3Veci`: **0.0% (pre-target selection output) -> 86.74811%**
- `main/graphic` `.text` match (objdiff diff run):
  - before: `3.8233595`
  - after: `15.845144`

## Plausibility rationale
- The update replaces a stub with a concrete GX/DOF rendering routine that uses existing engine patterns (projection sampling, backbuffer capture, TEV setup, quad passes).
- The signature fix is ABI/mangling-correctness work, not compiler coaxing: without it, objdiff cannot map the target symbol (`FScScff3Veci`) to this implementation.

## Technical details
- Uses camera-relative depth projection to derive near/far alpha ramps.
- Captures a reduced backbuffer texture and full backbuffer texture, then composites multiple offset quads across two TEV passes.
- Reuses existing util/global infrastructure (`DAT_8032ec70`, `CameraPcs`, GX helper wrappers) to stay consistent with surrounding code.
