### PR TITLE
main/wind: improve AddAmbient match by tightening free-slot scan flow

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -338,58 +338,30 @@ void CWind::getObj(int)
 int CWind::AddAmbient(float dir, float speed)
 {
 	u8* freeObj;
-	u8* scan = (u8*)this;
-	int group = 4;
+	u8* scan;
+	int group;
 
+	scan = (u8*)this;
+	group = 4;
 	do {
 		freeObj = scan;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 100;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 200;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 300;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 400;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 500;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 600;
-		if ((s8)freeObj[0] >= 0) {
-			break;
-		}
-
-		freeObj = scan + 700;
-		if ((s8)freeObj[0] >= 0) {
-			break;
+		if (((s8)scan[0] >= 0) ||
+		    ((freeObj = scan + 100), (s8)freeObj[0] >= 0) ||
+		    ((freeObj = scan + 200), (s8)freeObj[0] >= 0) ||
+		    ((freeObj = scan + 300), (s8)freeObj[0] >= 0) ||
+		    ((freeObj = scan + 400), (s8)freeObj[0] >= 0) ||
+		    ((freeObj = scan + 500), (s8)freeObj[0] >= 0) ||
+		    ((freeObj = scan + 600), (s8)freeObj[0] >= 0) ||
+		    ((freeObj = scan + 700), (s8)freeObj[0] >= 0)) {
+			goto found;
 		}
 
 		scan += 800;
 		group--;
 	} while (group != 0);
 
-	if (group == 0) {
-		freeObj = 0;
-	}
-
+	freeObj = 0;
+found:
 	if (freeObj == 0) {
 		System.Printf(DAT_801db568);
 		return -1;


### PR DESCRIPTION
## Summary
- Reworked `CWind::AddAmbient(float dir, float speed)` free-slot search to use a chained short-circuit scan pattern per 8-object group.
- Preserved behavior while aligning branch/control-flow shape more closely to original codegen.
- Kept object initialization semantics unchanged (active flag, id allocation, dir/speed field setup).

## Functions Improved
- Unit: `main/wind`
- Symbol: `AddAmbient__5CWindFff`

## Match Evidence
- `AddAmbient__5CWindFff`: **59.933334% -> 62.266666%** (`+2.333332%`)
- Validation command:
  - `tools/objdiff-cli diff -p . -u main/wind -o - AddAmbient__5CWindFff`
- Build verification:
  - `ninja` succeeds and regenerates report/progress.

## Plausibility Rationale
- Change is source-plausible and idiomatic for this codebase: a compact grouped scan over fixed-size wind slots with early exit on first free entry.
- No contrived temporaries or non-semantic hacks were introduced; this is a control-flow and expression-shape refinement aimed at matching likely original author intent.

## Technical Notes
- The key improvement came from expressing the 8-slot probe as a single short-circuit chain with explicit candidate pointer updates, which better matches expected branch layout in the target object.
