### PR TITLE
pppScreenBreak: implement pppRenderScreenBreak

### DIFF
--- a/include/ffcc/pppScreenBreak.h
+++ b/include/ffcc/pppScreenBreak.h
@@ -22,7 +22,7 @@ void pppConScreenBreak(PScreenBreak*, UnkC*);
 void pppCon2ScreenBreak(PScreenBreak*, UnkC*);
 void pppDesScreenBreak(PScreenBreak*, UnkC*);
 void pppFrameScreenBreak(PScreenBreak*, UnkB*, UnkC*);
-void pppRenderScreenBreak(void);
+void pppRenderScreenBreak(PScreenBreak*, UnkB*, UnkC*);
 
 #ifdef __cplusplus
 }

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -37,6 +37,7 @@ struct UnkC {
 
 extern int DAT_8032ed70;
 extern int DAT_802381a0;
+extern void* DAT_80238034;
 extern float FLOAT_80331cc0;
 extern float FLOAT_80331cc4;
 extern float FLOAT_80331cd0;
@@ -44,6 +45,7 @@ extern float FLOAT_80331ce8;
 extern float FLOAT_80331cec;
 extern float FLOAT_80331cf0;
 extern char MaterialMan[];
+extern char s_f999_root_801dd4c8[];
 extern char s_pppScreenBreak_cpp_801dd4d4[];
 extern CGraphic GraphicsPcs;
 extern _pppMngSt* pppMngStPtr;
@@ -70,6 +72,7 @@ int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void*);
 void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
 void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 void pppHeapUseRate__FPQ27CMemory6CStage(void*);
+void SearchNode__Q26CChara6CModelFPc(CChara::CModel*, char*);
 }
 
 /*
@@ -401,10 +404,22 @@ void pppFrameScreenBreak(PScreenBreak* pppScreenBreak, UnkB* param_2, UnkC* para
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d458
+ * PAL Size: 168b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppRenderScreenBreak(void)
+void pppRenderScreenBreak(PScreenBreak* pppScreenBreak, UnkB*, UnkC* param_3)
 {
-	// TODO
+    s32 dataOffset = param_3->m_serializedDataOffsets[2];
+    void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((u8*)pppMngStPtr + 0xD8), 0);
+    CChara::CModel* model = (CChara::CModel*)GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+    SearchNode__Q26CChara6CModelFPc(model, s_f999_root_801dd4c8);
+    if (*(u8*)((u8*)pppScreenBreak + 0xA4 + dataOffset) == 0) {
+        Graphic.GetBackBufferRect2(DAT_80238034, (_GXTexObj*)((u8*)pppScreenBreak + 0x90 + dataOffset), 0, 0, 0x280,
+                                   0x1C0, 0, GX_LINEAR, GX_TF_RGBA8, 0);
+        *(u8*)((u8*)pppScreenBreak + 0xA4 + dataOffset) = 1;
+    }
 }


### PR DESCRIPTION
## Summary
- Updated `pppRenderScreenBreak` to a concrete callback implementation instead of TODO.
- Corrected the callback prototype to `pppRenderScreenBreak(PScreenBreak*, UnkB*, UnkC*)` in both header and source.
- Added required extern references and the model node search call used by this effect path.

## Functions improved
- Unit: `main/pppScreenBreak`
- Function: `pppRenderScreenBreak` (PAL 0x8012d458, 168b)

## Match evidence
- `pppRenderScreenBreak` fuzzy match: **2.3809524% -> 57.52381%**
- Verified with `build/tools/objdiff-cli report generate -p . -f json` (v3.4.1 in-tree CLI).
- Other functions in `main/pppScreenBreak` remained unchanged in reported fuzzy match.

## Plausibility rationale
- The new function follows existing effect callback patterns in the codebase:
  - resolve current character model via `pppMngStPtr`
  - perform the expected node lookup (`f999_root`)
  - perform one-time backbuffer capture into effect state storage
  - set an initialization flag to avoid redundant capture
- This is straightforward gameplay/rendering logic, not compiler-coaxing transformations.

## Technical details
- Added PAL metadata block for `pppRenderScreenBreak`.
- Used existing engine APIs (`GetCharaHandlePtr`, `GetCharaModelPtr`, `SearchNode`, `CGraphic::GetBackBufferRect2`) and the existing state layout offsets in `pppScreenBreak` work data.
- Build validation: `ninja` succeeds on this branch.
