### PR TITLE
math: improve __sinit_math_cpp vtable initialization

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -18,8 +18,8 @@ struct Vec4d {
     float w;
 };
 
-extern void* __vt__8CManager;
-extern void* __vt__5CMath;
+extern void* __vt__8CManager[];
+extern void* __vt__5CMath[];
 
 /*
  * --INFO--
@@ -32,9 +32,9 @@ extern void* __vt__5CMath;
  */
 extern "C" void __sinit_math_cpp()
 {
-    char* const base = reinterpret_cast<char*>(&math);
-    *reinterpret_cast<void**>(base) = &__vt__8CManager;
-    *reinterpret_cast<void**>(base) = &__vt__5CMath;
+    volatile void** base = (volatile void**)&math;
+    *base = __vt__8CManager;
+    *base = __vt__5CMath;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adjusted `__sinit_math_cpp` in `src/math.cpp` to initialize `math`'s vtable using direct array-decayed vtable symbols.
- Kept behavior identical (two consecutive writes ending on `__vt__5CMath`) while changing codegen shape.

## Functions improved
- Unit: `main/math`
- Symbol: `__sinit_math_cpp`
- Size: 32 bytes

## Match evidence
- `__sinit_math_cpp` match improved from **32.5%** to **70.0%** using:
  - `tools/objdiff-cli diff -p . -u main/math -o - --format json __sinit_math_cpp`
- Improvement is instruction-level (not formatting-only): fewer relocation/form differences and better alignment in the emitted init sequence.

## Plausibility rationale
- This is source-plausible original code: vtable symbols are represented as arrays and assigned through normal pointer decay, a common Metrowerks-era pattern.
- No contrived temporaries or behavior changes were introduced.

## Technical details
- Changed declarations:
  - `extern void* __vt__8CManager[];`
  - `extern void* __vt__5CMath[];`
- Changed init writes to use `*base = __vt__...` instead of taking explicit addresses of non-array symbols.
- Full build remains green with `ninja`.
