### PR TITLE
gx/GXLight: improve GXSetChanMatColor match

### DIFF
--- a/src/gx/GXLight.c
+++ b/src/gx/GXLight.c
@@ -472,7 +472,6 @@ void GXSetChanAmbColor(GXChannelID chan, GXColor amb_color) {
 
 void GXSetChanMatColor(GXChannelID chan, GXColor mat_color) {
     u32 reg;
-    u32 rgb;
     u32 colIdx;
 
     CHECK_GXBEGIN(762, "GXSetChanMatColor");
@@ -480,14 +479,12 @@ void GXSetChanMatColor(GXChannelID chan, GXColor mat_color) {
     switch (chan) {
     case GX_COLOR0:
         reg = __GXData->matColor[GX_COLOR0];
-        rgb = GXCOLOR_AS_U32(mat_color) >> 8;
-        SET_REG_FIELD(776, reg, 24, 8, rgb);
+        reg = (reg & 0xFF) | (GXCOLOR_AS_U32(mat_color) & 0xFFFFFF00);
         colIdx = 0;
         break;
     case GX_COLOR1:
         reg = __GXData->matColor[GX_COLOR1];
-        rgb = GXCOLOR_AS_U32(mat_color) >> 8;
-        SET_REG_FIELD(791, reg, 24, 8, rgb);
+        reg = (reg & 0xFF) | (GXCOLOR_AS_U32(mat_color) & 0xFFFFFF00);
         colIdx = 1;
         break;
     case GX_ALPHA0:


### PR DESCRIPTION
## Summary
- Refactored `GXSetChanMatColor` color-channel packing to use direct masked merge for RGB bytes.
- Removed an intermediate `rgb` temporary and shifted-field assignment in the `GX_COLOR0`/`GX_COLOR1` paths.
- Kept alpha-only paths and channel selection behavior unchanged.

## Functions improved
- Unit: `main/gx/GXLight`
- Function: `GXSetChanMatColor`

## Match evidence
- `GXSetChanMatColor`: **89.91803% -> 92.70492%** (`+2.78689`)
- `main/gx/GXLight` `.text` match: **88.41627% -> 88.82297%** (`+0.40670`)
- Instruction diff profile for `GXSetChanMatColor` improved:
  - `DIFF_ARG_MISMATCH`: `14 -> 12`
  - `DIFF_DELETE`: `4 -> 2`

## Plausibility rationale
- The new code expresses the same channel write semantics more directly: preserve alpha byte, replace RGB bytes.
- This is idiomatic low-level GX register packing and avoids contrived compiler-only rearrangements.

## Technical details
- Before: `GXCOLOR_AS_U32(mat_color) >> 8` + `SET_REG_FIELD(..., 24, 8, rgb)` in color cases.
- After: `(reg & 0xFF) | (GXCOLOR_AS_U32(mat_color) & 0xFFFFFF00)` in color cases.
- Build remains clean with `ninja`, and objdiff confirms a real assembly-level improvement for the target symbol.
