### PR TITLE
RedCommand: implement _EraseAttribute and SeStopID

### DIFF
--- a/include/ffcc/RedSound/RedCommand.h
+++ b/include/ffcc/RedSound/RedCommand.h
@@ -8,7 +8,7 @@ struct RedWaveHeadWD;
 void _EraseAttribute(int, int);
 int _EraseTime(int);
 void SearchSeEmptyTrack(int, int, int);
-void SeStopID(int);
+int SeStopID(int);
 void SeStopMG(int, int, int, int);
 void _SePlayStart(RedSeINFO*, int, int, int, int);
 void SeBlockPlay(int, int, int, int, int);

--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -9,12 +9,45 @@ extern unsigned int* DAT_8032f444;
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ca038
+ * PAL Size: 364b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _EraseAttribute(int, int)
+void _EraseAttribute(int eraseTrack, int attrMask)
 {
-	// TODO
+	int* trackBasePtr = (int*)((char*)DAT_8032f3f0 + 0xdbc);
+	int* track = (int*)*trackBasePtr;
+
+	do {
+		if ((*track != 0) && ((int)*(unsigned char*)((char*)track + 0x14f) <= eraseTrack) &&
+		    ((((unsigned int)*(unsigned char*)(track + 0x54)) & (unsigned int)attrMask) != 0)) {
+			unsigned char trackNo;
+			unsigned int* seTrack;
+
+			KeyOnReserveClear((RedKeyOnDATA*)DAT_8032f3fc, (RedTrackDATA*)track);
+			track[0x3e] = 0;
+			track[0x41] = 0;
+			*track = 0;
+			track[0x16] = 0;
+
+			trackNo = *(unsigned char*)((char*)track + 0x14e);
+			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= (unsigned char)0xfa;
+			seTrack = (unsigned int*)((unsigned char*)DAT_8032f444 + trackNo * 0xc0);
+			seTrack[0x25] &= 0xfffffff7;
+			seTrack[0x24] &= 0xfffffffe;
+			seTrack[0x24] |= 2;
+			seTrack[0x23] = 0;
+
+			DAT_8032e154.SeSepHistoryManager(0, track[0x3d]);
+			if (track[6] != 0) {
+				DAT_8032e154.WaveHistoryManager(0, *(short*)(track[6] + 2));
+			}
+		}
+		track += 0x55;
+	} while (track < (int*)(*trackBasePtr + 0x2a80));
 }
 
 /*
@@ -108,12 +141,49 @@ void SearchSeEmptyTrack(int, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ca4b8
+ * PAL Size: 384b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SeStopID(int)
+int SeStopID(int seId)
 {
-	// TODO
+	int* trackBasePtr = (int*)((char*)DAT_8032f3f0 + 0xdbc);
+	int* track;
+
+	*(unsigned int*)((char*)DAT_8032f3f0 + 0x1244) = 0;
+	track = (int*)*trackBasePtr;
+	do {
+		if ((*track != 0) && ((seId == -1) || (track[0x3e] == seId))) {
+			unsigned char trackNo;
+			unsigned int* seTrack;
+
+			KeyOnReserveClear((RedKeyOnDATA*)DAT_8032f3fc, (RedTrackDATA*)track);
+			track[0x3e] = 0;
+			track[0x41] = 0;
+			*track = 0;
+			track[0x16] = 0;
+
+			trackNo = *(unsigned char*)((char*)track + 0x14e);
+			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= (unsigned char)0xfa;
+			seTrack = (unsigned int*)((unsigned char*)DAT_8032f444 + trackNo * 0xc0);
+			seTrack[0x25] &= 0xfffffff7;
+			seTrack[0x24] &= 0xfffffffe;
+			seTrack[0x24] |= 2;
+			seTrack[0] = 0;
+			seTrack[0x23] = 0;
+
+			if (track[6] != 0) {
+				DAT_8032e154.WaveHistoryManager(0, *(short*)(track[6] + 2));
+			}
+			DAT_8032e154.SeSepHistoryManager(0, track[0x3d]);
+		}
+		track += 0x55;
+	} while (track < (int*)(*trackBasePtr + 0x2a80));
+
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `_EraseAttribute(int, int)` in `src/RedSound/RedCommand.cpp` using existing RedSound track-management patterns already present in `_EraseTime`.
- Implemented `SeStopID(int)` in `src/RedSound/RedCommand.cpp` and updated declaration in `include/ffcc/RedSound/RedCommand.h` to `int SeStopID(int)` to match observed return behavior.
- Added function info metadata blocks for both implemented functions with PAL address/size:
  - `_EraseAttribute`: `0x801ca038`, `364b`
  - `SeStopID`: `0x801ca4b8`, `384b`

## Functions Improved
- Unit: `main/RedSound/RedCommand`
- Symbols with substantial gains after this change:
  - `_EraseAttribute__Fii`: now `53.043957%`
  - `SeStopID__Fi`: now `58.791668%`

## Match Evidence
- Baseline (from `tools/agent_select_target.py` before edits):
  - `main/RedSound/RedCommand` fuzzy match: `6.1%`
- After edits (`build/GCCP01/report.json`):
  - `main/RedSound/RedCommand` fuzzy match: `12.51218%`
- Build verification:
  - `build/GCCP01/main.dol: OK`

## Plausibility Rationale
- The new code follows the same idioms already used in the surrounding RedSound code:
  - fixed-size track table iteration
  - key-on reserve clearing
  - track state teardown fields
  - SE track flag/mask updates
  - wave/separation history manager callbacks
- This is not compiler-coaxing; it replaces TODO stubs with straightforward control flow and data handling consistent with neighboring source.

## Technical Details
- Implementations were adapted from decomp reference and normalized into existing project style.
- The stop-path state writes were kept explicit (track state + SE table flags) to preserve behavior and improve generated assembly alignment.
- `SeStopID` returns `0` explicitly, consistent with current decomp behavior and symbol-level matching trajectory.
