### PR TITLE
main/pppBreathModel: implement frame/render first-pass decomp

### DIFF
--- a/include/ffcc/pppBreathModel.h
+++ b/include/ffcc/pppBreathModel.h
@@ -25,8 +25,8 @@ void IsExistGroupParticle(PBreathModel*, VBreathModel*, short);
 extern "C" {
 #endif
 
-void pppFrameBreathModel(void);
-void pppRenderBreathModel(void);
+void pppFrameBreathModel(pppBreathModel*, PBreathModel*, UnkC*);
+void pppRenderBreathModel(pppBreathModel*, PBreathModel*, UnkC*);
 void pppConstructBreathModel(pppBreathModel*, UnkC*);
 void pppDestructBreathModel(pppBreathModel*, UnkC*);
 

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -1,12 +1,36 @@
 #include "ffcc/pppBreathModel.h"
 #include "dolphin/mtx.h"
+#include "dolphin/gx.h"
 #include "ffcc/math.h"
 #include <string.h>
 
 extern CMath math;
-extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
 extern float lbl_80330F70;
+extern float FLOAT_80330F80;
 extern int DAT_8032ed70;
+extern u32 CFlatFlags;
+extern unsigned char* pppEnvStPtr;
+extern unsigned char* pppMngStPtr;
+extern Mtx ppvCameraMatrix0;
+
+struct pppFMATRIX {
+    Mtx value;
+};
+
+struct pppModelSt;
+
+extern "C" {
+void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
+void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
+void pppHitCylinderSendSystem__FP9_pppMngStP3VecP3Vecff(void*, Vec*, Vec*, float, float);
+void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(void*, void*, float, u8, u8, u8, u8, u8, u8, u8);
+void pppSetBlendMode__FUc(u8);
+void pppDrawMesh__FP10pppModelStP3Veci(pppModelSt*, Vec*, int);
+void pppInitBlendMode__Fv(void);
+void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+}
+
+static char s_pppBreathModel_cpp[] = "pppBreathModel.cpp";
 
 struct UnkC {
     unsigned char _pad[0xC];
@@ -371,10 +395,157 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
  * PAL Address: 0x800db6e0
  * PAL Size: 1264b
  */
-extern "C" void pppFrameBreathModel(void)
+extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* pBreathModel, UnkC* offsets)
 {
-	// Basic particle system frame processing
-	// TODO: Complete implementation
+    int i;
+    int j;
+    int firstParticle;
+    int slotCount;
+    int groupCount;
+    int* dataOffsets;
+    unsigned char* base;
+    unsigned char* work;
+    unsigned char* groupPtr;
+    unsigned char* particleWMat;
+    bool ready;
+    float scaleValue;
+    Mtx scaleMtx;
+    Mtx worldMtx;
+    pppFMATRIX rotMtx;
+    Vec origin;
+    Vec dir;
+    Vec dirNorm;
+    Vec target;
+    Vec hitVector;
+
+    if (DAT_8032ed70 != 0) {
+        return;
+    }
+
+    dataOffsets = offsets->m_serializedDataOffsets;
+    base = (unsigned char*)breathModel + 8;
+    work = base + dataOffsets[0];
+
+    if (*(void**)(work + 0x30) == NULL) {
+        int maxParticleCount = (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x1A);
+        int particleGroups = (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x12);
+        int particlePerGroup = (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10);
+        int* groupTable;
+
+        *(int*)(work + 0x40) = maxParticleCount;
+        *(short*)(work + 0x54) = *(short*)((unsigned char*)pBreathModel + 0x10);
+        *(short*)(work + 0x56) = *(short*)((unsigned char*)pBreathModel + 0x12);
+
+        *(void**)(work + 0x30) =
+            pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(maxParticleCount * 0x98), *(void**)pppEnvStPtr,
+                                                  s_pppBreathModel_cpp, 0x257);
+        if (*(void**)(work + 0x30) != NULL) {
+            memset(*(void**)(work + 0x30), 0, (unsigned long)(maxParticleCount * 0x98));
+        }
+
+        *(void**)(work + 0x34) =
+            pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(maxParticleCount * 0x30), *(void**)pppEnvStPtr,
+                                                  s_pppBreathModel_cpp, 0x25d);
+        if (*(void**)(work + 0x34) != NULL) {
+            memset(*(void**)(work + 0x34), 0, (unsigned long)(maxParticleCount * 0x30));
+        }
+
+        *(void**)(work + 0x38) =
+            pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(maxParticleCount * 0x20), *(void**)pppEnvStPtr,
+                                                  s_pppBreathModel_cpp, 0x263);
+        if (*(void**)(work + 0x38) != NULL) {
+            memset(*(void**)(work + 0x38), 0, (unsigned long)(maxParticleCount * 0x20));
+        }
+
+        *(void**)(work + 0x3C) =
+            pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(particleGroups * 0x5C), *(void**)pppEnvStPtr,
+                                                  s_pppBreathModel_cpp, 0x269);
+        if (*(void**)(work + 0x3C) != NULL) {
+            memset(*(void**)(work + 0x3C), 0, (unsigned long)(particleGroups * 0x5C));
+
+            groupTable = (int*)*(void**)(work + 0x3C);
+            for (i = 0; i < particleGroups; i++) {
+                groupTable[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                    (unsigned long)particlePerGroup, *(void**)pppEnvStPtr, s_pppBreathModel_cpp, 0x274);
+                memset((void*)groupTable[1], 0xFF, (unsigned long)particlePerGroup);
+
+                groupTable[2] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                    (unsigned long)particlePerGroup, *(void**)pppEnvStPtr, s_pppBreathModel_cpp, 0x277);
+                memset((void*)groupTable[2], 0xFF, (unsigned long)particlePerGroup);
+                groupTable[0] = 0;
+                groupTable += 0x17;
+            }
+        }
+
+        *(float*)(work + 0x48) = lbl_80330F70;
+        *(float*)(work + 0x4C) = lbl_80330F70;
+        *(float*)(work + 0x50) = FLOAT_80330F80;
+        PSVECNormalize((Vec*)(work + 0x48), (Vec*)(work + 0x48));
+    }
+
+    PSMTXCopy(*(Mtx*)pppMngStPtr, *(Mtx*)work);
+    UpdateAllParticle((_pppPObject*)breathModel, (VBreathModel*)work, pBreathModel, (VColor*)(base + dataOffsets[1]));
+
+    groupCount = (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x12);
+    slotCount = (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10);
+    particleWMat = *(unsigned char**)(work + 0x34);
+    groupPtr = *(unsigned char**)(work + 0x3C);
+    scaleValue = *(float*)((unsigned char*)pBreathModel + 8);
+
+    for (i = 0; i < groupCount; i++) {
+        ready = true;
+        for (j = 0; j < slotCount; j++) {
+            if ((*(signed char*)(*(int*)(groupPtr + 4) + j) == -1) || (*(signed char*)(*(int*)(groupPtr + 8) + j) != 1)) {
+                ready = false;
+                break;
+            }
+        }
+
+        if (ready) {
+            firstParticle = -1;
+            for (j = 0; j < slotCount; j++) {
+                if (*(signed char*)(*(int*)(groupPtr + 8) + j) != -1) {
+                    firstParticle = (int)*(signed char*)(*(int*)(groupPtr + 4) + j);
+                    break;
+                }
+            }
+
+            if (firstParticle >= 0) {
+                Mtx* particleMtx = (Mtx*)(particleWMat + firstParticle * 0x30);
+
+                PSMTXIdentity(scaleMtx);
+                scaleMtx[0][0] = scaleValue;
+                scaleMtx[1][1] = scaleValue;
+                scaleMtx[2][2] = scaleValue;
+
+                PSMTXConcat(*particleMtx, *(Mtx*)((unsigned char*)breathModel + 4), worldMtx);
+                PSMTXMultVec(worldMtx, (Vec*)(groupPtr + 0xC), &origin);
+
+                PSMTXCopy(*particleMtx, rotMtx.value);
+                rotMtx.value[0][3] = lbl_80330F70;
+                rotMtx.value[1][3] = lbl_80330F70;
+                rotMtx.value[2][3] = lbl_80330F70;
+
+                dir = *(Vec*)(groupPtr + 0x18);
+                PSMTXMultVec(rotMtx.value, &dir, &dir);
+                if ((dir.x != 0.0f) || (dir.y != 0.0f) || (dir.z != 0.0f)) {
+                    PSVECNormalize(&dir, &dirNorm);
+                } else {
+                    dirNorm.x = 0.0f;
+                    dirNorm.y = 0.0f;
+                    dirNorm.z = 0.0f;
+                }
+                PSVECScale(&dirNorm, &target, *(float*)(groupPtr + 0x24));
+                PSVECAdd(&origin, &target, &target);
+                PSVECSubtract(&target, &origin, &hitVector);
+
+                pppHitCylinderSendSystem__FP9_pppMngStP3VecP3Vecff(pppMngStPtr, &origin, &hitVector, scaleValue,
+                                                                    *(float*)((unsigned char*)pBreathModel + 4));
+            }
+        }
+
+        groupPtr += 0x5C;
+    }
 }
 
 /*
@@ -382,10 +553,105 @@ extern "C" void pppFrameBreathModel(void)
  * PAL Address: 0x800db204
  * PAL Size: 1244b
  */
-extern "C" void pppRenderBreathModel(void)
+extern "C" void pppRenderBreathModel(pppBreathModel* breathModel, PBreathModel* pBreathModel, UnkC* offsets)
 {
-	// Basic particle system rendering
-	// TODO: Complete implementation  
+    int i;
+    int dataOffset;
+    int colorOffset;
+    int maxParticleCount;
+    int graphId;
+    unsigned char* base;
+    unsigned char* work;
+    unsigned char* particleData;
+    unsigned char* particleWMat;
+    float* particleColor;
+    pppModelSt* model;
+    GXColor color;
+    Mtx scaledMtx;
+    Mtx drawMtx;
+    Mtx worldMtx;
+    Vec pos;
+
+    dataOffset = offsets->m_serializedDataOffsets[0];
+    colorOffset = offsets->m_serializedDataOffsets[1];
+    base = (unsigned char*)breathModel + 8;
+    work = base + dataOffset;
+    particleData = *(unsigned char**)(work + 0x30);
+    particleWMat = *(unsigned char**)(work + 0x34);
+    particleColor = *(float**)(work + 0x38);
+    maxParticleCount = *(int*)(work + 0x40);
+    graphId = *(int*)((unsigned char*)pBreathModel + 0x00);
+
+    if (graphId == -1) {
+        return;
+    }
+
+    model = (pppModelSt*)(*(void***)(pppEnvStPtr + 8))[graphId];
+    pppInitBlendMode__Fv();
+    pppSetBlendMode__FUc(*(unsigned char*)((unsigned char*)pBreathModel + 4));
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(base + colorOffset, NULL, 0.0f, 0xFF, 0xFF,
+                                                               *(unsigned char*)((unsigned char*)pBreathModel + 4), 0xFF, 0xFF,
+                                                               1, 0xFF);
+
+    color.r = *(unsigned char*)(base + colorOffset + 0);
+    color.g = *(unsigned char*)(base + colorOffset + 1);
+    color.b = *(unsigned char*)(base + colorOffset + 2);
+    color.a = *(unsigned char*)(base + colorOffset + 3);
+
+    for (i = 0; i < maxParticleCount; i++) {
+        if (*(short*)(particleData + 0x50) > 0) {
+            PSMTXScale(scaledMtx,
+                       *(float*)(pppMngStPtr + 0x28) * *(float*)(particleData + 0x64),
+                       *(float*)(pppMngStPtr + 0x2C) * *(float*)(particleData + 0x68),
+                       *(float*)(pppMngStPtr + 0x30) * *(float*)(particleData + 0x6C));
+            PSMTXConcat(*(Mtx*)particleData, scaledMtx, drawMtx);
+            PSMTXConcat(ppvCameraMatrix0, drawMtx, drawMtx);
+            PSMTXConcat(ppvCameraMatrix0, *(Mtx*)particleData, worldMtx);
+            PSMTXMultVec(worldMtx, (Vec*)(particleData + 0x30), &pos);
+            drawMtx[0][3] = pos.x;
+            drawMtx[1][3] = pos.y;
+            drawMtx[2][3] = pos.z;
+
+            if (particleColor != NULL) {
+                int r = (int)color.r + (int)particleColor[0];
+                int g = (int)color.g + (int)particleColor[1];
+                int b = (int)color.b + (int)particleColor[2];
+                int a = (int)color.a + (int)particleColor[3];
+
+                if (r < 0) r = 0;
+                if (r > 255) r = 255;
+                if (g < 0) g = 0;
+                if (g > 255) g = 255;
+                if (b < 0) b = 0;
+                if (b > 255) b = 255;
+                if (a < 0) a = 0;
+                if (a > 127) a = 127;
+
+                color.r = (u8)r;
+                color.g = (u8)g;
+                color.b = (u8)b;
+                color.a = (u8)a;
+            }
+
+            GXLoadPosMtxImm(drawMtx, 0);
+            GXSetChanAmbColor(GX_COLOR0A0, color);
+            pppDrawMesh__FP10pppModelStP3Veci(model, *(Vec**)((unsigned char*)breathModel + 0x70), 1);
+        }
+
+        if (particleWMat != NULL) {
+            particleWMat += 0x30;
+        }
+        if (particleColor != NULL) {
+            particleColor += 8;
+        }
+        particleData += 0x98;
+    }
+
+    if ((CFlatFlags & 0x200000) != 0) {
+        pppInitBlendMode__Fv();
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `pppFrameBreathModel` / `pppRenderBreathModel` from stubs to concrete first-pass decomp implementations.
- Added callback parameter prototypes in `pppBreathModel.h` to match actual runtime callback arguments.
- Implemented particle work allocation/init path, per-frame particle update integration, group collision dispatch, and render loop setup in source-plausible C/C++.

## Functions improved
- Unit: `main/pppBreathModel`
- `pppFrameBreathModel`
- `pppRenderBreathModel`

## Match evidence
- Prior selector baseline (before edits):
  - `pppFrameBreathModel`: **0.3%**
  - `pppRenderBreathModel`: **0.3%**
- Current objdiff (after edits):
  - `pppFrameBreathModel`: **48.92%**
  - `pppRenderBreathModel`: **38.47%**
- `ninja` build passes and regenerates report successfully.

## Plausibility rationale
- Changes restore expected engine-style control flow (lazy work allocation, array/block initialization, per-particle iteration, GX setup) rather than introducing synthetic compiler-only tricks.
- Data access patterns align with established ppp* modules in this codebase (raw offset work blocks, stage allocator usage, camera/matrix concatenation, blend/env setup).
- This is a large-function first pass; readability and structure were kept coherent while preserving decomp-style pointer/offset semantics.

## Technical details
- Added local extern hooks for allocator/draw/hit-system APIs used by the decomp path.
- Mirrored Ghidra-observed block layout for work state (`+0x30/+0x34/+0x38/+0x3C/+0x40`) and group bookkeeping (`0x5C` stride, per-slot tables).
- Added frame-side collision vector build + `pppHitCylinderSendSystem` dispatch loop.
- Added render-side matrix construction, color accumulation/clamp, and mesh draw dispatch per active particle.
