### PR TITLE
main/menu_item: decompile ItemInit1 first pass

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -32,12 +32,126 @@ void CMenuPcs::ItemInit()
 
 /*
  * --INFO--
- * Address:\tTODO
- * Size:\tTODO
+ * PAL Address: 0x8015ac54
+ * PAL Size: 604b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::ItemInit1()
 {
-    // TODO
+    s16* itemList = *(s16**)((u8*)this + 0x850);
+    u8* itemListBytes = (u8*)itemList;
+
+    *(int*)(itemListBytes + 0x24) = 0x2E;
+    *(int*)(itemListBytes + 0x2C) = 2;
+    *(int*)(itemListBytes + 0x30) = 5;
+
+    *(int*)(itemListBytes + 0x64) = 0x47;
+    *(int*)(itemListBytes + 0x6C) = 7;
+    *(int*)(itemListBytes + 0x70) = 5;
+
+    *(int*)(itemListBytes + 0xA4) = 0x47;
+    *(int*)(itemListBytes + 0xAC) = 7;
+    *(int*)(itemListBytes + 0xB0) = 5;
+
+    *(int*)(itemListBytes + 0xF4) = 2;
+    *(int*)(itemListBytes + 0xE4) = 0x2E;
+    *(int*)(itemListBytes + 0xEC) = 7;
+    *(int*)(itemListBytes + 0xF0) = 5;
+
+    *(int*)(itemListBytes + 0x134) = 2;
+    *(int*)(itemListBytes + 0x124) = 0x37;
+    *(int*)(itemListBytes + 0x12C) = 0;
+    *(int*)(itemListBytes + 0x130) = 5;
+
+    *(int*)(itemListBytes + 0x174) = 2;
+    *(int*)(itemListBytes + 0x164) = 0x37;
+    *(int*)(itemListBytes + 0x16C) = 0;
+    *(int*)(itemListBytes + 0x170) = 5;
+
+    *(int*)(itemListBytes + 0x1B4) = 2;
+    *(int*)(itemListBytes + 0x1A4) = 0x37;
+    *(int*)(itemListBytes + 0x1AC) = 0;
+    *(int*)(itemListBytes + 0x1B0) = 5;
+
+    *(int*)(itemListBytes + 0x1F4) = 2;
+    *(int*)(itemListBytes + 0x1E4) = 0x37;
+    *(int*)(itemListBytes + 0x1EC) = 0;
+    *(int*)(itemListBytes + 0x1F0) = 5;
+
+    *(int*)(itemListBytes + 0x234) = 2;
+    *(int*)(itemListBytes + 0x224) = 0x37;
+    *(int*)(itemListBytes + 0x22C) = 0;
+    *(int*)(itemListBytes + 0x230) = 5;
+
+    *(int*)(itemListBytes + 0x274) = 2;
+    *(int*)(itemListBytes + 0x264) = 0x37;
+    *(int*)(itemListBytes + 0x26C) = 0;
+    *(int*)(itemListBytes + 0x270) = 5;
+
+    *(int*)(itemListBytes + 0x2B4) = 2;
+    *(int*)(itemListBytes + 0x2A4) = 0x37;
+    *(int*)(itemListBytes + 0x2AC) = 0;
+    *(int*)(itemListBytes + 0x2B0) = 5;
+
+    *(int*)(itemListBytes + 0x2F4) = 2;
+    *(int*)(itemListBytes + 0x2E4) = 0x37;
+    *(int*)(itemListBytes + 0x2EC) = 0;
+    *(int*)(itemListBytes + 0x2F0) = 5;
+
+    unsigned int count = (unsigned int)itemList[0];
+    s16* entry = itemList + 4;
+    if ((int)count <= 0) {
+        return;
+    }
+
+    const float scale = 1.0f;
+    unsigned int blocks = count >> 3;
+    if (blocks != 0) {
+        do {
+            entry[0x10] = 0;
+            entry[0x11] = 0;
+            *(float*)(entry + 8) = scale;
+            entry[0x30] = 0;
+            entry[0x31] = 0;
+            *(float*)(entry + 0x28) = scale;
+            entry[0x50] = 0;
+            entry[0x51] = 0;
+            *(float*)(entry + 0x48) = scale;
+            entry[0x70] = 0;
+            entry[0x71] = 0;
+            *(float*)(entry + 0x68) = scale;
+            entry[0x90] = 0;
+            entry[0x91] = 0;
+            *(float*)(entry + 0x88) = scale;
+            entry[0xB0] = 0;
+            entry[0xB1] = 0;
+            *(float*)(entry + 0xA8) = scale;
+            entry[0xD0] = 0;
+            entry[0xD1] = 0;
+            *(float*)(entry + 0xC8) = scale;
+            entry[0xF0] = 0;
+            entry[0xF1] = 0;
+            *(float*)(entry + 0xE8) = scale;
+            entry += 0x100;
+            blocks--;
+        } while (blocks != 0);
+
+        count &= 7;
+        if (count == 0) {
+            return;
+        }
+    }
+
+    do {
+        entry[0x10] = 0;
+        entry[0x11] = 0;
+        *(float*)(entry + 8) = scale;
+        entry += 0x20;
+        count--;
+    } while (count != 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::ItemInit1()` in `src/menu_item.cpp` based on the PAL Ghidra reference.
- Added the required function info metadata block with PAL address/size.
- Kept this pass scoped to a single function for clean objdiff attribution.

## Functions improved
- Unit: `main/menu_item`
- Symbol: `ItemInit1__8CMenuPcsFv`

## Match evidence
- `ItemInit1__8CMenuPcsFv`: **0.66225165% -> 35.748344%** (`tools/objdiff-cli diff -p . -u main/menu_item -o - ItemInit1__8CMenuPcsFv`)
- Control check (unchanged this pass):
  - `ItemInit__8CMenuPcsFv`: `0.5882353%`
  - `ItemCtrlCur__8CMenuPcsFv`: `0.28688523%`

## Plausibility rationale
- The implementation uses straightforward menu-entry initialization and state reset patterns consistent with existing low-level menu code in this unit.
- Changes are semantic reconstruction (field/state setup, per-entry reset loops), not synthetic compiler-coaxing transformations.

## Technical details
- Recreated the texture/state setup table for the first item entries (IDs, flags, timing fields).
- Recreated the block-by-8 reset loop and tail loop for item entry animation state (`frame`, `duration`, scale/progress fields).
- Verified build succeeds with `ninja` after the edit.
