### PR TITLE
main/texanim: decompile CTexAnimSet::AddFrame first pass

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -1,7 +1,10 @@
 #include "ffcc/texanim.h"
 #include "ffcc/system.h"
+#include "ffcc/math.h"
 
 #include <string.h>
+#include <math.h>
+#include "dolphin/mtx.h"
 
 template <class T>
 class CPtrArray
@@ -33,9 +36,14 @@ extern "C" void __ct__4CRefFv(void*);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void* PTR_PTR_s_CTexAnimSet_801e9c6c;
 extern "C" float FLOAT_8032fb38;
+extern "C" int Rand__5CMathFUl(CMath*, unsigned long);
 
 extern CMemory Memory;
 extern CSystem System;
+extern CMath Math;
+extern float FLOAT_8032fb3c;
+extern float FLOAT_8032fb4c;
+extern double DOUBLE_8032fb40;
 
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
 static char s_ptrarray_grow_error[] = "CPtrArray grow error";
@@ -49,6 +57,21 @@ static inline unsigned char* Ptr(void* p, unsigned int offset)
 static inline float& F32At(void* p, unsigned int offset)
 {
     return *reinterpret_cast<float*>(Ptr(p, offset));
+}
+
+static inline int& S32At(void* p, unsigned int offset)
+{
+    return *reinterpret_cast<int*>(Ptr(p, offset));
+}
+
+static inline unsigned int& U32At(void* p, unsigned int offset)
+{
+    return *reinterpret_cast<unsigned int*>(Ptr(p, offset));
+}
+
+static inline unsigned char& U8At(void* p, unsigned int offset)
+{
+    return *reinterpret_cast<unsigned char*>(Ptr(p, offset));
 }
 }
 
@@ -542,12 +565,93 @@ void CTexAnimSet::AttachMaterialSet(CMaterialSet*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800440ec
+ * PAL Size: 852b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CTexAnimSet::AddFrame()
 {
-	// TODO
+    unsigned int i = 0;
+    CPtrArray<CTexAnim*>* texAnims = reinterpret_cast<CPtrArray<CTexAnim*>*>(Ptr(this, 8));
+
+    while (i < (unsigned int)texAnims->GetSize()) {
+        CTexAnim* texAnim = (*texAnims)[i];
+        CPtrArray<CTexAnimSeq*>* seqArray = reinterpret_cast<CPtrArray<CTexAnimSeq*>*>(Ptr(texAnim, 0x110));
+        CTexAnimSeq* seq = (*seqArray)[S32At(texAnim, 0x0C)];
+        unsigned char flags = U8At(seq, 0x110);
+        float frameStep = FLOAT_8032fb3c;
+
+        if ((flags & 0x80) != 0) {
+            frameStep = FLOAT_8032fb4c;
+        }
+
+        if (((flags & 0x40) == 0) || (FLOAT_8032fb3c != F32At(texAnim, 0x10)) || (Rand__5CMathFUl(&Math, 0x1E) == 0)) {
+            float currentFrame = (float)fmod((double)F32At(texAnim, 0x10), (double)(float)U32At(seq, 0x108));
+            int keyCount = S32At(seq, 0x10C);
+            unsigned int* keyData = reinterpret_cast<unsigned int*>(Ptr(seq, 0x114));
+            unsigned int keyIndex = 0;
+            unsigned int lastKeyIndex = keyCount - 1;
+
+            while (keyCount != 0) {
+                float nextFrame = (float)((keyIndex < lastKeyIndex) ? keyData[0xC] : U32At(seq, 0x108));
+                unsigned int* nextKeyData = keyData;
+
+                if (keyIndex < lastKeyIndex) {
+                    nextKeyData = keyData + 0xC;
+                }
+
+                if (((float)keyData[0] <= currentFrame) && (currentFrame < nextFrame)) {
+                    float t = FLOAT_8032fb38;
+                    float frameSpan = nextFrame - (float)keyData[0];
+                    if (frameSpan != FLOAT_8032fb38) {
+                        t = (currentFrame - (float)keyData[0]) / frameSpan;
+                    }
+
+                    Vec v0;
+                    Vec v1;
+                    PSVECScale(reinterpret_cast<Vec*>(keyData + 9), &v0, FLOAT_8032fb3c - t);
+                    PSVECScale(reinterpret_cast<Vec*>(nextKeyData + 9), &v1, t);
+                    PSVECAdd(&v0, &v1, reinterpret_cast<Vec*>(Ptr(texAnim, 0x18)));
+
+                    if ((flags & 0x80) == 0) {
+                        U32At(texAnim, 0x18) = keyData[9];
+                        U32At(texAnim, 0x1C) = keyData[10];
+                    }
+                    break;
+                }
+
+                keyData += 0xC;
+                keyIndex = keyIndex + 1;
+                keyCount = keyCount - 1;
+            }
+
+            if (S32At(texAnim, 0x14) != -3) {
+                F32At(texAnim, 0x10) = F32At(texAnim, 0x10) + frameStep;
+                if ((float)U32At(seq, 0x108) <= F32At(texAnim, 0x10)) {
+                    int mode = S32At(texAnim, 0x14);
+                    if (mode == -1) {
+                        F32At(texAnim, 0x10) = (float)U32At(seq, 0x108);
+                    } else if (mode >= 0) {
+                        S32At(texAnim, 0x0C) = mode;
+                        S32At(texAnim, 0x14) = -2;
+                    }
+                    F32At(texAnim, 0x10) = F32At(texAnim, 0x10) - (float)U32At(seq, 0x108);
+                }
+            }
+        }
+
+        seq = (*seqArray)[S32At(texAnim, 0x0C)];
+        if ((U8At(seq, 0x110) & 0x40) != 0) {
+            F32At(this, 0x24) = F32At(texAnim, 0x20);
+        } else {
+            F32At(this, 0x24) = FLOAT_8032fb38;
+        }
+
+        i = i + 1;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass decompilation of `CTexAnimSet::AddFrame` in `src/texanim.cpp`.
- Replaced the previous TODO stub with runtime logic for sequence selection, keyframe interpolation, frame-step advancement, loop/end behavior, and set-level blend propagation.
- Added PAL function metadata for this function and required extern declarations/constants used by the implementation.

## Functions improved
- Unit: `main/texanim`
- Symbol: `AddFrame__11CTexAnimSetFv`
- Size: 852 bytes

## Match evidence
- Before: `0.47%` (objdiff)
- After: `67.41%` (objdiff)
- Delta: `+66.94` percentage points

Objdiff command used:
- `build/tools/objdiff-cli diff -p . -u main/texanim AddFrame__11CTexAnimSetFv`

## Plausibility rationale
- The implementation follows existing source patterns already used in this file (offset-based field access for partially recovered class layouts).
- Control flow and state transitions map to expected animation runtime behavior (frame wrap, interpolation between keyframes, mode transition handling).
- This is a first-pass decomp for a large low-match function; the code is structurally faithful to decompiled behavior without adding non-functional coercion patterns.

## Technical details
- Uses `CPtrArray<CTexAnim*>` / `CPtrArray<CTexAnimSeq*>` access paths consistent with nearby constructors and template specializations.
- Interpolates vector data using `PSVECScale` + `PSVECAdd` for keyframe blends.
- Preserves per-sequence flag-driven behavior for frame stepping and output assignment.
- Verified project health with `ninja` after the edit.
