### PR TITLE
main/pppCallBackDistance: improve pppFrameCallBackDistance callback path

### DIFF
--- a/src/pppCallBackDistance.cpp
+++ b/src/pppCallBackDistance.cpp
@@ -4,9 +4,8 @@
 #include "ffcc/p_game.h"
 #include <dolphin/mtx.h>
 
-extern CPartMng PartMng;
+extern u8 PartMng[];
 extern u8* lbl_8032ED50;
-extern "C" void ParticleFrameCallback__5CGameFiiiiiP3Vec(CGame*, int, int, int, int, int, Vec*);
 
 /*
  * --INFO--
@@ -84,10 +83,10 @@ void pppFrameCallBackDistance(pppCallBackDistance* param1, UnkB* param2, UnkC* p
         local_28.z = *(f32*)(pppMngSt + 0xA4);
         PSMTXMultVec(ppvWorldMatrix, &local_28, &local_28);
 
-        partIndex = ((s32)(pppMngSt - ((u8*)&PartMng + 0x2A18))) / 0x158;
+        partIndex = ((s32)(pppMngSt - (PartMng + 0x2A18))) / 0x158;
         graphFrame = (s32)(*(u32*)((u8*)param1 + 0xC)) / 0x1000;
-        ParticleFrameCallback__5CGameFiiiiiP3Vec(
-            &Game.game, partIndex, (s32)*(s16*)(pppMngSt + 0x74), (s32)*(s16*)(pppMngSt + 0x76),
-            (s32)*(s16*)&param2->m_initWOrk, graphFrame, &local_28);
+        Game.game.ParticleFrameCallback(partIndex, (s32)*(s16*)(pppMngSt + 0x74),
+                                        (s32)*(s16*)(pppMngSt + 0x76),
+                                        (s32)*(s16*)&param2->m_initWOrk, graphFrame, &local_28);
     }
 }


### PR DESCRIPTION
## Summary
- Refactored `pppFrameCallBackDistance` to use the same callback/caller style used by nearby PPP callback code.
- Switched `PartMng` arithmetic in this unit to `extern u8 PartMng[]` + `(PartMng + 0x2A18)` pointer math.
- Replaced manual mangled callback extern call with `Game.game.ParticleFrameCallback(...)` method call.

## Functions improved
- Unit: `main/pppCallBackDistance`
- Function: `pppFrameCallBackDistance`

## Match evidence
- `build/GCCP01/report.json` fuzzy match: **71.79412% -> 77.89706%**
- `objdiff-cli` symbol match: **71.07353% -> 76.45588%**
- Instruction-level diff deltas from objdiff:
  - `MATCH`: 39 -> 42
  - `DIFF_DELETE`: 7 -> 5
  - `DIFF_INSERT`: 8 -> 7
  - `DIFF_REPLACE`: 6 -> 5

## Plausibility rationale
- This change removes decomp-artifact style extern declarations in favor of idiomatic in-project source patterns already used in PPP callback code (`pppYmCallBack.cpp`).
- The resulting code is simpler and more likely to reflect original game source intent: compute particle index, compute graph frame, and dispatch through the `CGame` instance method.

## Technical details
- No control-flow changes were introduced.
- Behavior remains equivalent: same condition gate, same world-space vector transform, same callback argument values.
- Verified with `ninja` (build + report generation) and symbol-level objdiff comparison.
