### PR TITLE
main/mapanim: improve ReadOtmAnim decomp match

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -518,27 +518,12 @@ CMapAnim::~CMapAnim()
  */
 void CMapAnim::ReadOtmAnim(CChunkFile& chunkFile)
 {
-    struct CMapAnimNodeData
-    {
-        unsigned char* target;
-        CMapAnim* mapAnim;
-        CMapAnimKeyDt* keyData;
-    };
-
-    struct CMapAnimKeyDtData
-    {
-        unsigned int positionCount;
-        CMapAnimNodeTrackKey* position;
-        unsigned int rotationCount;
-        CMapAnimNodeTrackKey* rotation;
-        unsigned int scaleCount;
-        CMapAnimNodeTrackKey* scale;
-    };
-
     CChunkFile::CChunk chunk;
+    int* item;
+    int keyData;
+    int nodeIdx;
     CPtrArray<CMapAnimNode*>* mapAnimNodes = reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this);
     CPtrArray<CMapAnimKeyDt*>* keyDtArray = reinterpret_cast<CPtrArray<CMapAnimKeyDt*>*>(MapMng + 0x21418);
-    CMemory::CStage* stage = *reinterpret_cast<CMemory::CStage**>(MapMng);
 
     chunkFile.PushChunk();
     while (chunkFile.GetNextChunk(chunk)) {
@@ -552,47 +537,50 @@ void CMapAnim::ReadOtmAnim(CChunkFile& chunkFile)
             continue;
         }
 
-        CMapAnimNodeData* node = static_cast<CMapAnimNodeData*>(__nw__FUlPQ27CMemory6CStagePci(0xC, stage, s_mapanim_cpp, 0xC2));
-        if (node != 0) {
-            node->keyData = 0;
+        item = static_cast<int*>(
+            __nw__FUlPQ27CMemory6CStagePci(0xC, *reinterpret_cast<CMemory::CStage**>(MapMng), s_mapanim_cpp, 0xC2));
+        if (item != 0) {
+            item[2] = 0;
         }
-        node->mapAnim = this;
+        item[1] = reinterpret_cast<int>(this);
 
         chunkFile.PushChunk();
         while (chunkFile.GetNextChunk(chunk)) {
             if (chunk.m_id == 0x4E494458) {
-                node->target = MapMng + (static_cast<int>(chunkFile.Get4()) * 0xF0);
+                nodeIdx = static_cast<int>(chunkFile.Get4());
+                item[0] = reinterpret_cast<int>(MapMng + (nodeIdx * 0xF0));
             } else if (chunk.m_id == 0x5452414E) {
-                CMapAnimKeyDtData* keyData =
-                    static_cast<CMapAnimKeyDtData*>(__nw__FUlPQ27CMemory6CStagePci(0x18, stage, s_mapanim_cpp, 0x4C));
+                keyData = reinterpret_cast<int>(
+                    __nw__FUlPQ27CMemory6CStagePci(0x18, *reinterpret_cast<CMemory::CStage**>(MapMng), s_mapanim_cpp, 0x4C));
                 if (keyData != 0) {
-                    keyData->position = 0;
-                    keyData->rotation = 0;
-                    keyData->scale = 0;
+                    *reinterpret_cast<int*>(keyData + 0x4) = 0;
+                    *reinterpret_cast<int*>(keyData + 0xC) = 0;
+                    *reinterpret_cast<int*>(keyData + 0x14) = 0;
                 }
 
-                node->keyData = reinterpret_cast<CMapAnimKeyDt*>(keyData);
-                keyDtArray->Add(node->keyData);
-                keyData->positionCount = chunk.m_size >> 4;
-                keyData->position = static_cast<CMapAnimNodeTrackKey*>(
-                    __nwa__FUlPQ27CMemory6CStagePci(keyData->positionCount << 4, stage, s_mapanim_cpp, 0x4F));
-                memcpy(keyData->position, chunkFile.GetAddress(), chunk.m_size);
+                item[2] = keyData;
+                keyDtArray->Add(reinterpret_cast<CMapAnimKeyDt*>(item[2]));
+                *reinterpret_cast<unsigned int*>(item[2]) = chunk.m_size >> 4;
+                *reinterpret_cast<int*>(item[2] + 0x4) = reinterpret_cast<int>(
+                    __nwa__FUlPQ27CMemory6CStagePci(
+                        *reinterpret_cast<int*>(item[2]) << 4, *reinterpret_cast<CMemory::CStage**>(MapMng), s_mapanim_cpp, 0x4F));
+                memcpy(reinterpret_cast<void*>(*reinterpret_cast<int*>(item[2] + 0x4)), chunkFile.GetAddress(), chunk.m_size);
             } else if (chunk.m_id == 0x524F5420) {
-                CMapAnimKeyDtData* keyData = reinterpret_cast<CMapAnimKeyDtData*>(node->keyData);
-                keyData->rotationCount = chunk.m_size >> 4;
-                keyData->rotation = static_cast<CMapAnimNodeTrackKey*>(
-                    __nwa__FUlPQ27CMemory6CStagePci(keyData->rotationCount << 4, stage, s_mapanim_cpp, 0x55));
-                memcpy(keyData->rotation, chunkFile.GetAddress(), chunk.m_size);
+                *reinterpret_cast<unsigned int*>(item[2] + 0x8) = chunk.m_size >> 4;
+                *reinterpret_cast<int*>(item[2] + 0xC) = reinterpret_cast<int>(
+                    __nwa__FUlPQ27CMemory6CStagePci(
+                        *reinterpret_cast<int*>(item[2] + 0x8) << 4, *reinterpret_cast<CMemory::CStage**>(MapMng), s_mapanim_cpp, 0x55));
+                memcpy(reinterpret_cast<void*>(*reinterpret_cast<int*>(item[2] + 0xC)), chunkFile.GetAddress(), chunk.m_size);
             } else if (chunk.m_id == 0x5343414C) {
-                CMapAnimKeyDtData* keyData = reinterpret_cast<CMapAnimKeyDtData*>(node->keyData);
-                keyData->scaleCount = chunk.m_size >> 4;
-                keyData->scale = static_cast<CMapAnimNodeTrackKey*>(
-                    __nwa__FUlPQ27CMemory6CStagePci(keyData->scaleCount << 4, stage, s_mapanim_cpp, 0x5B));
-                memcpy(keyData->scale, chunkFile.GetAddress(), chunk.m_size);
+                *reinterpret_cast<unsigned int*>(item[2] + 0x10) = chunk.m_size >> 4;
+                *reinterpret_cast<int*>(item[2] + 0x14) = reinterpret_cast<int>(
+                    __nwa__FUlPQ27CMemory6CStagePci(
+                        *reinterpret_cast<int*>(item[2] + 0x10) << 4, *reinterpret_cast<CMemory::CStage**>(MapMng), s_mapanim_cpp, 0x5B));
+                memcpy(reinterpret_cast<void*>(*reinterpret_cast<int*>(item[2] + 0x14)), chunkFile.GetAddress(), chunk.m_size);
             }
         }
         chunkFile.PopChunk();
-        mapAnimNodes->Add(reinterpret_cast<CMapAnimNode*>(node));
+        mapAnimNodes->Add(reinterpret_cast<CMapAnimNode*>(item));
     }
     chunkFile.PopChunk();
 }


### PR DESCRIPTION
## Summary
- Reworked `CMapAnim::ReadOtmAnim(CChunkFile&)` in `src/mapanim.cpp` to use pointer/int field access patterns already used in this unit.
- Removed temporary helper structs in favor of direct offset writes for node/key-data setup.
- Kept control flow and API behavior unchanged while aligning allocation/copy sequences more closely to the target.

## Functions improved
- Unit: `main/mapanim`
- Function: `ReadOtmAnim__8CMapAnimFR10CChunkFile`

## Match evidence
- `objdiff` (`tools/objdiff-cli diff -p . -u main/mapanim ReadOtmAnim__8CMapAnimFR10CChunkFile`)
  - Before: **15.4175825%**
  - After: **18.532967%**
- `ninja` report (`build/GCCP01/report.json`) now shows this function at **21.56044% fuzzy match**.
- Build/verification: `ninja` passes and regenerates report successfully.

## Plausibility rationale
- The new version reflects existing source style in this file (manual field offsets and raw pointer writes for partially decompiled classes).
- Changes are semantic-preserving and avoid artificial reorder-only coaxing.
- This is an early-pass cleanup on a low-match function intended to move toward plausible original source while improving codegen alignment.

## Technical details
- Node allocation now stores fields via `item[0..2]` (target/mapAnim/keyData) matching observed object layout usage.
- TRAN/ROT/SCALE chunk parsing now writes counts/pointers at expected key-data offsets (`+0x0/+0x4`, `+0x8/+0xC`, `+0x10/+0x14`) and performs direct `memcpy` from chunk data.
- Stage pointer loads were changed from one cached local to direct `MapMng` dereferences at allocation sites to better match emitted code structure.
