### PR TITLE
sound: export CalcBound with CLine2 symbol name

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -171,7 +171,7 @@ extern "C" void Draw__9CLine(CLine* line)
     }
 }
 
-extern "C" void CalcBound__9CLine(CLine* line)
+extern "C" void CalcBound__9CLine2(CLine* line)
 {
     line->min.x = FLOAT_80330d10;
     line->min.y = FLOAT_80330d10;


### PR DESCRIPTION
## Summary
- Renamed the exported helper symbol in `src/sound.cpp` from `CalcBound__9CLine` to `CalcBound__9CLine2`.
- This aligns the compiled symbol with the `main/sound` target symbol table entry.
- No logic changes were made to bound calculation; this is a symbol/linkage correction only.

## Functions improved
- Unit: `main/sound`
- Function: `CalcBound__9CLine2` (352b)

## Match evidence
- Before: selector reported `CalcBound__9CLine2` at `0.0%` (unmatched symbol in this unit).
- After: `objdiff` reports `67.75%` for `CalcBound__9CLine2`.
- Unit progress moved from `9.6%` (selector baseline) to `11.212403%` in current `build/GCCP01/report.json`.

## Plausibility rationale
- `config/GCCP01/symbols.txt` expects `CalcBound__9CLine2` for the `sound` object while a separate `CalcBound__9CLine` exists in another object.
- Exporting the correct symbol name is consistent with original multi-object symbol layout and avoids artificial control-flow changes.

## Technical details
- Verified object symbol emission via `powerpc-eabi-nm`:
  - Current object exports `CalcBound__9CLine2`.
- Verified improvement with `objdiff` on `main/sound` and symbol `CalcBound__9CLine2`.
