### PR TITLE
game: first-pass decomp for CGame::Create

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7,6 +7,7 @@
 #include "ffcc/p_minigame.h"
 #include "ffcc/map.h"
 #include "ffcc/sound.h"
+#include "ffcc/graphic.h"
 
 #include <string.h>
 
@@ -61,6 +62,11 @@ void ClearAll__5CWindFv(void*);
 void* CreateStage__7CMemoryFUlPci(void*, unsigned long, const char*, int);
 void Init__12CFlatRuntimeFv(void*);
 void Printf__7CSystemFPce(CSystem* system, const char* format, ...);
+void _WaitDrawDone__8CGraphicFPci(CGraphic*, const char*, int);
+void MapChanging__7CSystemFii(CSystem*, int, int);
+void MapChanged__7CSystemFiii(CSystem*, int, int, int);
+void LoadMap__7CMapPcsFiiPvUlUc(void*, int, int, void*, unsigned long, unsigned char);
+void LoadFieldPdt__8CPartPcsFiiPvUlUc(void*, int, int, void*, unsigned long, unsigned char);
 unsigned char CFlat[];
 unsigned char PartMng[];
 unsigned char McPcs[];
@@ -80,6 +86,7 @@ unsigned char DAT_8032ed00[];
 unsigned char DAT_8032ed08[];
 unsigned char Wind[];
 extern const char DAT_801d61dc[];
+extern const char s_game_cpp_801d6190[];
 }
 
 static const float FLOAT_8032f688 = 1.0E+10;
@@ -341,14 +348,63 @@ void CGame::Exec()
 	RemoveScenegraph__7CSystemFP8CProcessi(&System, DAT_8032ed08, 0);
 }
 
+static const char s_defaultTownName[] = "Tipa";
+static const char s_italianTownName[] = "TipaItalia";
+
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80015610
+ * PAL Size: 408b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Create()
 {
-	// TODO
+    int mapVariant;
+    int mapId;
+
+    m_nextScript.m_flags = 1;
+    clearWork();
+
+    memset(&m_gameWork.m_gameDataStartMarker, 0, 0x13E1);
+    memset(m_gameWork.m_wmBackupParams, 0xFF, sizeof(m_gameWork.m_wmBackupParams));
+
+    m_gameWork.m_scriptSysVal0 = 0;
+    m_gameWork.m_scriptSysVal1 = 0;
+    m_gameWork.m_scriptSysVal2 = 0;
+    m_gameWork.m_scriptSysVal3 = 1;
+    m_gameWork.m_chaliceElement = 1;
+
+    if (m_gameWork.m_languageId == 3) {
+        strcpy(m_gameWork.m_townName, s_italianTownName);
+    } else {
+        strcpy(m_gameWork.m_townName, s_defaultTownName);
+    }
+
+    m_gameWork.m_gameInitFlag = 1;
+
+    if (strlen(m_startScriptName) != 0) {
+        strcpy(m_nextScript.m_name, m_startScriptName);
+        m_newGameFlag = 1;
+    }
+
+    if (m_newGameFlag == 0) {
+        mapVariant = m_currentMapVariantId;
+        mapId = m_currentMapId;
+
+        _WaitDrawDone__8CGraphicFPci(&Graphic, s_game_cpp_801d6190, 0x24E);
+        MapChanging__7CSystemFii(&System, mapId, mapVariant);
+
+        m_currentMapId = mapId;
+        m_currentMapVariantId = mapVariant;
+
+        LoadMap__7CMapPcsFiiPvUlUc(MapPcs, mapId, mapVariant, 0, 0, 0);
+        LoadFieldPdt__8CPartPcsFiiPvUlUc(&PartPcs, mapId, mapVariant, 0, 0, 0);
+
+        MapChanged__7CSystemFiii(&System, mapId, mapVariant, 1);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a first-pass decompilation of `CGame::Create()` in `src/game.cpp` using the PAL Ghidra reference and existing codebase calling conventions.

Key updates:
- Added PAL metadata block for `Create` (`0x80015610`, `408b`).
- Replaced TODO body with full initialization/control-flow logic:
  - next-script flag setup
  - `clearWork()` + `m_gameWork` zero/init paths
  - script sys value/chalice defaults
  - town-name selection based on language
  - start-script transfer into `m_nextScript`
  - non-new-game map-change/load sequence (`_WaitDrawDone`, `MapChanging`, `LoadMap`, `LoadFieldPdt`, `MapChanged`)
- Added missing extern declarations needed by this function path.

## Functions Improved
- Unit: `main/game`
- Function: `Create__5CGameFv`

## Match Evidence
Objdiff command used:
```sh
tools/objdiff-cli diff -p . -u main/game -o -
```
Measured with forced `game.o` rebuild before each sample:
- Before: `Create__5CGameFv` = `0.98039216%` (size `408`)
- After: `Create__5CGameFv` = `73.93137%` (size `408`)

## Plausibility Rationale
The new implementation follows expected original source structure instead of compiler-coaxing:
- Uses existing class fields semantically (`m_gameWork`, `m_nextScript`, map IDs/variants).
- Uses established engine entry points and call ordering already seen elsewhere in this unit.
- Keeps the logic readable and idiomatic for the project style (straightforward conditionals + clear initialization sequence).

## Technical Notes
- Symbol-level diffing for `Create__5CGameFv` only was misleading in this unit; full-unit diff (`-u main/game`) gave stable/usable function metrics.
- This is intentionally a first pass; remaining gap appears to be in stack/layout details and constant/data selection that can be iterated in follow-ups.
