### PR TITLE
main/pppYmMegaBirthShpTail2: fix PYmMegaBirthShpTail2 type identity

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail2.h
+++ b/include/ffcc/pppYmMegaBirthShpTail2.h
@@ -3,7 +3,9 @@
 
 #include "ffcc/partMng.h"
 
-typedef _PARTICLE_DATA PYmMegaBirthShpTail2; // Size 0x140
+struct PYmMegaBirthShpTail2 : _PARTICLE_DATA
+{
+};
 
 struct pppYmMegaBirthShpTail2
 {


### PR DESCRIPTION
## Summary
- changed `PYmMegaBirthShpTail2` from a typedef alias of `_PARTICLE_DATA` to a distinct struct type inheriting `_PARTICLE_DATA`
- this preserves data layout semantics while restoring distinct C++ type identity for mangled symbols in this unit

## Functions improved
- `birth__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR`

## Match evidence
- `birth...` now maps to the expected symbol and reports `0.10799136%` fuzzy match (previously unresolved/mis-mangled for the target signature)
- unit `main/pppYmMegaBirthShpTail2` fuzzy match improved from `7.2917757%` to `7.352017%`

## Plausibility rationale
- using a dedicated `PYmMegaBirthShpTail2` type is source-plausible and consistent with shipped symbol naming
- this avoids compiler-coaxing and aligns with ABI/type information expectations from the map/decomp data

## Technical details
- `ninja` build passes after change
- `nm` now emits:
  - `birth__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR`
  - `calc_particle__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P6VColor`
