### PR TITLE
Improve util vector conversion matching

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -264,11 +264,9 @@ void CUtil::ConvI2FVector(Vec& out, S16Vec in, long shift)
  */
 void CUtil::ConvF2IVector(S16Vec& out, Vec in, long shift)
 {
-	float scale = (float)(1 << shift);
-
-	out.x = (short)(in.x * scale);
-	out.y = (short)(in.y * scale);
-	out.z = (short)(in.z * scale);
+	out.x = (short)(int)(in.x * (float)(1 << shift));
+	out.y = (short)(int)(in.y * (float)(1 << shift));
+	out.z = (short)(int)(in.z * (float)(1 << shift));
 }
 
 /*
@@ -282,10 +280,8 @@ void CUtil::ConvF2IVector(S16Vec& out, Vec in, long shift)
  */
 void CUtil::ConvF2IVector2d(S16Vec2d& out, Vec2d in, long shift)
 {
-	float scale = (float)(1 << shift);
-
-	out.x = (short)(in.x * scale);
-	out.y = (short)(in.y * scale);
+	out.x = (short)(int)(in.x * (float)(1 << shift));
+	out.y = (short)(int)(in.y * (float)(1 << shift));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Simplified `CUtil::ConvF2IVector` and `CUtil::ConvF2IVector2d` to use direct float-to-int conversion expressions.
- Removed temporary `scale` locals so the generated conversion sequence is closer to the target compiler output while keeping behavior unchanged.

## Functions improved
- `ConvF2IVector__5CUtilFR6S16Vec3Vecl`
  - Before: `28.578947%`
  - After: `55.710526%`
- `ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl`
  - Before: `31.25%`
  - After: `69.82143%`

## Match evidence
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/util -o - ConvF2IVector__5CUtilFR6S16Vec3Vecl`
  - `tools/objdiff-cli diff -p . -u main/util -o - ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl`
- `ninja` completes successfully after the change.

## Plausibility rationale
- This change is source-plausible: it keeps the original semantic operation (scale by `1 << shift`, then truncate to signed 16-bit) and removes an unnecessary local temporary.
- The resulting C++ is more idiomatic and does not introduce compiler-coaxing-only constructs.

## Technical details
- The updated form reduces mismatched conversion scaffolding emitted around the temporary `scale` path.
- Objdiff reports substantially better instruction alignment on both conversion helpers.
