### PR TITLE
main/RedSound: implement Start, End, and SetSeBlockData

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -10,6 +10,7 @@
 #include "dolphin/ai.h"
 #include "dolphin/ar.h"
 #include "dolphin/ax.h"
+#include "dolphin/axart.h"
 
 // Global variables (external declarations)
 extern CRedDriver CRedDriver_8032f4c0;
@@ -19,8 +20,12 @@ extern int DAT_8032f408; // Debug flag
 extern unsigned int DAT_8032f4c4; // Auto ID counter
 extern char DAT_8032e17c[]; // Buffer for memset
 extern void* DAT_8032e170; // Registration memory
+extern void* DAT_8032f4c8; // Internal sound state buffer
 extern FILE DAT_8021d1a8; // File handle for fflush
-extern "C" void __dl__FPv(void*);
+extern "C" {
+	void __dl__FPv(void*);
+	void* RedNew__Fi(int);
+}
 
 /*
  * --INFO--
@@ -153,22 +158,33 @@ void CRedSound::Init(void* param_2, int param_3, int param_4, int param_5)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccd0c
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CRedSound::Start()
 {
-	// TODO
+	DAT_8032f4c8 = RedNew__Fi(0x100);
+	memset(DAT_8032f4c8, 0, 0x100);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccd44
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CRedSound::End()
 {
-	// TODO
+	CRedDriver_8032f4c0.End();
+	AXARTQuit();
+	AXQuit();
 }
 
 /*
@@ -406,12 +422,16 @@ void CRedSound::SetMusicPhraseStop(int id)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd174
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetSeBlockData(int, void*)
+void CRedSound::SetSeBlockData(int bank, void* blockData)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetSeBlockData(bank, blockData);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement three `CRedSound` methods in `src/RedSound/RedSound.cpp` using source-plausible wrapper logic that aligns with PAL Ghidra references:
- `Start__9CRedSoundFv`
- `End__9CRedSoundFv`
- `SetSeBlockData__9CRedSoundFiPv`

Also added the needed declarations/includes used by those wrappers (`DAT_8032f4c8`, `RedNew__Fi`, and `dolphin/axart.h`) and filled in PAL address/size metadata blocks.

## Functions Improved
Unit: `main/RedSound/RedSound`

- `Start__9CRedSoundFv`: **7.1% -> 92.85714%**
- `End__9CRedSoundFv`: **9.1% -> 100.0%**
- `SetSeBlockData__9CRedSoundFiPv`: **7.7% -> 68.76923%**

## Match Evidence
- Selector baseline for unit (`tools/agent_select_target.py`): **50.9%** (`main/RedSound/RedSound`)
- Current build report (`build/GCCP01/report.json`): **54.117584%**
- Build verification: `build/GCCP01/main.dol: OK`

## Plausibility Rationale
These changes replace TODO stubs with direct, idiomatic engine calls consistent with neighboring wrappers in the same file and class:
- `Start` allocates and clears the internal red sound buffer.
- `End` tears down driver/AXART/AX in expected order.
- `SetSeBlockData` forwards directly to `CRedDriver`.

No contrived control-flow or compiler-coaxing patterns were introduced; the implementation style matches existing wrapper methods in this unit.

## Technical Notes
- Local `objdiff-cli` version in this environment is `3.4.1` (no JSON one-shot `-o` mode), so score verification used `build/GCCP01/report.json` generated by `ninja`.
- Changes are isolated to one file: `src/RedSound/RedSound.cpp`.
