### PR TITLE
materialman: implement CMaterialSet::Find

### DIFF
--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -112,7 +112,7 @@ public:
     void CacheUnLoadTexture(int, CAmemCacheSet*);
     void CacheRefCnt0UpTexture(int, CAmemCacheSet*);
     void CacheDumpTexture(int, CAmemCacheSet*);
-    void Find(char*);
+    unsigned long Find(char*);
     void SetPartFromTextureSet(CTextureSet*, int);
     void ReleaseTag(CTextureSet*, int, CAmemCacheSet*);
     void AddMaterial(CMaterial*, int);

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1,6 +1,8 @@
 #include "ffcc/materialman.h"
 #include "ffcc/textureman.h"
 
+#include <string.h>
+
 extern "C" unsigned long UnkMaterialSetGetter(void*);
 
 namespace {
@@ -539,6 +541,35 @@ void CMaterialSet::ReleaseTag(CTextureSet* textureSet, int pdtSlotIndex, CAmemCa
 void CMaterialSet::AddMaterial(CMaterial*, int)
 {
 	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003c690
+ * PAL Size: 140b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+unsigned long CMaterialSet::Find(char* name)
+{
+    void* materials = Ptr(this, 8);
+    unsigned long index = 0;
+
+    while (index < UnkMaterialSetGetter(materials)) {
+        CMaterial** materialItems = *reinterpret_cast<CMaterial***>(Ptr(materials, 0xC));
+        if (materialItems != 0) {
+            CMaterial* material = materialItems[index];
+            if ((material != 0) && (strcmp(reinterpret_cast<char*>(Ptr(material, 8)), name) == 0)) {
+                return index;
+            }
+        }
+
+        index++;
+    }
+
+    return 0xFFFFFFFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMaterialSet::Find(char*)` in `src/materialman.cpp` using the same material-array access pattern already used in `ReleaseTag`.
- Added `<string.h>` include for `strcmp`.
- Corrected the declaration in `include/ffcc/materialman.h` so `Find` returns an index value.

## Functions improved
- `main/materialman`
- `Find__12CMaterialSetFPc` (size: 140b)

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` target listing in this run)
- After: `64.08572%` fuzzy match (`build/GCCP01/report.json` for `Find__12CMaterialSetFPc`)

## Plausibility rationale
- The implementation follows expected original-source behavior for a material-set lookup: iterate active material slots, skip null entries, compare material name strings, return index or `-1`.
- It uses the same object/array layout conventions already present in this file (`Ptr(this, 8)` plus pointer-array storage), avoiding contrived compiler-only rewrites.

## Technical details
- Iterates up to `_UnkMaterialSetGetter(materials)`.
- Reads `CMaterial**` storage from array object offset `+0xC`, consistent with existing code in this translation unit.
- Compares the candidate material name at material offset `+0x8` using `strcmp`.
- Returns `0xFFFFFFFF` when no match is found.
