### PR TITLE
main/fontman: implement CFont::Draw(char*) loop

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -246,12 +246,19 @@ void CFont::DrawQuit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009255c
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFont::Draw(char*)
+void CFont::Draw(char* text)
 {
-	// TODO
+	unsigned char* cursor = reinterpret_cast<unsigned char*>(text);
+	for (; *cursor != '\0'; cursor++) {
+		Draw(static_cast<unsigned short>(*cursor));
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFont::Draw(char*)` in `src/fontman.cpp` by iterating over each byte and forwarding to `Draw(unsigned short)`.
- Added PAL address/size metadata for the updated function.

## Functions improved
- Unit: `main/fontman`
- Symbol: `Draw__5CFontFPc`

## Match evidence
- `Draw__5CFontFPc`: 3.4482758% -> 58.517242% (`build/GCCP01/report.json`)
- `main/fontman` unit fuzzy match: ~7.1% -> 8.502074%
- Objdiff oneshot (`tools/objdiff-cli` v3.6.1): symbol now aligns at 116 bytes and shows materially improved instruction alignment versus the previous TODO stub output.

## Plausibility rationale
- The change is source-plausible original logic: iterate text bytes until NUL and render each character.
- No compiler-coaxing patterns or unnatural control flow were introduced.

## Technical details
- Build command: `ninja`
- Objdiff command: `tools/objdiff-cli diff -p . -u main/fontman -o - Draw__5CFontFPc`
