### PR TITLE
math: improve DstRot match by using float intermediates

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -1117,28 +1117,26 @@ unsigned int CMath::Hsb2Rgb(int hue, int saturation, int brightness)
  */
 float CMath::DstRot(float from, float to)
 {
-    const double s0 = (double)(float)sin((double)from);
-    const double c0 = (double)(float)cos((double)from);
-    const double s1 = (double)(float)sin((double)to);
-    const double c1 = (double)(float)cos((double)to);
-
-    const double dot = (double)(float)(s0 * s1 + (double)(float)(c0 * c1));
-    double angle = 0.0;
+    const float s0 = (float)sin((double)from);
+    const float c0 = (float)cos((double)from);
+    const float s1 = (float)sin((double)to);
+    const float c1 = (float)cos((double)to);
+    const float dot = s0 * s1 + c0 * c1;
+    float angle = 0.0f;
 
     if (angle != dot) {
-        angle = -1.0;
+        angle = -1.0f;
         if (angle <= dot) {
             angle = dot;
-            if (1.0 < dot) {
-                angle = 1.0;
+            if (1.0f < dot) {
+                angle = 1.0f;
             }
         }
-
-        angle = (double)(float)acos(angle);
-        if ((float)(s0 * c1 - (double)(float)(s1 * c0)) < 0.0f) {
+        angle = (float)acos((double)angle);
+        if (s0 * c1 - s1 * c0 < 0.0f) {
             angle = -angle;
         }
     }
 
-    return (float)angle;
+    return angle;
 }


### PR DESCRIPTION
## Summary
- Refined `CMath::DstRot(float from, float to)` in `src/math.cpp` to use float temporaries for sine/cosine outputs and intermediate dot/cross calculations.
- Kept function behavior and control flow intact (clamp to `[-1, 1]`, `acos`, and sign correction), while removing unnecessary float<->double roundtrips in local arithmetic.

## Functions Improved
- Unit: `main/math`
- Symbol: `DstRot__5CMathFff`

## Match Evidence
- Before: `76.61017%`
- After: `89.830505%`
- Delta: `+13.220335` points
- Verification command:
  - `tools/objdiff-cli diff -p . -u main/math -o - DstRot__5CMathFff`

## Plausibility Rationale
- This change reflects plausible original source cleanup: float-domain math for rotation delta while still using libm double-argument calls (`sin`, `cos`, `acos`) as in the original ABI environment.
- The updated code is more idiomatic for game math code (float intermediates for vector-angle terms) and avoids contrived compiler-coaxing constructs.

## Technical Details
- The previous implementation forced repeated explicit float->double->float conversions on local intermediates.
- Converting temporaries (`s0`, `c0`, `s1`, `c1`, `dot`, `angle`) to `float` improved instruction selection in the scalar/floating sequence around dot product, clamp, and sign test.
- Objdiff indicates materially improved instruction alignment for this symbol without changing external interfaces.
