### PR TITLE
pppMana2: improve pppConstructMana2 offset access

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -32,9 +32,11 @@ void pppConstructMana2(pppMana2* pppMana2, UnkC* param_2)
     void* handle;
     u32 model;
     u32* work;
+    s32 workOffset;
 
-    gObject = *(CGObject**)((char*)pppMngStPtr + 0x8);
-    work = (u32*)((char*)pppMana2 + 2 + param_2->m_serializedDataOffsets[2]);
+    gObject = *(CGObject**)((char*)pppMngStPtr + 0xDC);
+    workOffset = *(s32*)((char*)param_2 + 0xC);
+    work = (u32*)((char*)pppMana2 + 0x80 + workOffset);
     gObject->m_stepSlopeLimit = FLOAT_803318fc;
 
     handle = GetCharaHandlePtr__FP8CGObjectl(gObject, 0);


### PR DESCRIPTION
## Summary
- Updated `pppConstructMana2` in `src/pppMana2.cpp` to use manager/object access and work-buffer offset math that better matches target assembly.
- Replaced owner-object fetch at `pppMngStPtr + 0x8` with `pppMngStPtr + 0xDC`.
- Replaced prior work pointer math (`+2 + m_serializedDataOffsets[2]`) with explicit offset extraction from `param_2 + 0xC` and base `+0x80`.

## Functions Improved
- Unit: `main/pppMana2`
- Function: `pppConstructMana2`

## Match Evidence
- `pppConstructMana2`: **76.14474% -> 77.47369%**
- Unit `main/pppMana2`: **3.9366515% -> 3.9692955%**
- Validation: rebuilt with `ninja` and checked updated metrics in `build/GCCP01/report.json`.

## Plausibility Rationale
- The change is a type/offset correction rather than compiler coaxing.
- It aligns with surrounding PPP code patterns that use explicit manager-runtime field offsets and serialized-data offset lookups for per-effect work blocks.
- No behavior-only no-op reordering was introduced.

## Technical Details
- Used `objdiff-cli diff` (TTY mode) to inspect first-block instruction mismatches for `pppConstructMana2`.
- Improvement comes from correcting early load/addi sequences so register/dataflow better aligns with target assembly.
