### PR TITLE
Fix joybus placement for CSystem::GetCounter

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -111,6 +111,20 @@ static inline unsigned int MakeJoyCmd16(unsigned short opcode, unsigned char arg
 
 /*
  * --INFO--
+ * PAL Address: 0x800b138c
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+unsigned int CSystem::GetCounter()
+{
+	return m_frameCounter;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -638,20 +638,6 @@ CSystem::COrder* CSystem::GetOrder(int index)
 
 /*
  * --INFO--
- * PAL Address: 0x800b138c
- * PAL Size: 8b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-unsigned int CSystem::GetCounter()
-{
-	return m_frameCounter;
-}
-
-/*
- * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Moved the `CSystem::GetCounter()` definition from `src/system.cpp` to `src/joybus.cpp`.
- Kept implementation unchanged (`return m_frameCounter;`) and preserved PAL metadata comment.
- This aligns translation-unit placement with the target object layout for `main/joybus`.

## Functions improved
- Unit: `main/joybus`
- Symbol: `GetCounter__7CSystemFv`
- Match: `0.0% -> 100.0%` (8-byte function)

## Match evidence
- `build/GCCP01/report.json` now reports:
  - `GetCounter__7CSystemFv` with `fuzzy_match_percent: 100.0`
  - `main/joybus` matched functions: `16/91 -> 17/91`
  - Global matched code bytes: `203168 -> 203176`
- `objdiff-cli` JSON diff for `main/joybus:GetCounter__7CSystemFv` now includes the symbol on both sides (previously missing on the right/decomp side).

## Plausibility rationale
- The change is source-plausible and minimal: no behavioral edits, only TU placement correction.
- It resolves a symbol placement mismatch where this method was emitted in `system.o` while the target expects it in `joybus.o`.
- This is consistent with decomp workflows where function ownership between translation units is still being reconstructed.

## Technical details
- Removed function definition block from `src/system.cpp`.
- Added identical function definition block in `src/joybus.cpp`.
- Rebuilt with `ninja` and verified updated match/progress metrics in report output.
