### PR TITLE
pad: improve CPad::Init match quality

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -64,7 +64,7 @@ void CPad::Init()
 {
 	FILE* fp;
 	int frames;
-	unsigned int size;
+	int size;
 
 	PADInit();
 	memset(reinterpret_cast<char*>(this) + 4, 0, 0x1A4);
@@ -81,13 +81,7 @@ void CPad::Init()
 		if (_1ac_4_ != 0)
 		{
 			_1b0_4_ = new (reinterpret_cast<CMemory::CStage*>(_1ac_4_), (char*)"pad.cpp", 0x54) unsigned char[0x69780C];
-			if ((_1b4_4_ == 0) || ((fp = fopen("replay.dat", "rb")) == 0))
-			{
-				*reinterpret_cast<unsigned int*>(_1b0_4_) = 0xC;
-				*reinterpret_cast<unsigned int*>(_1b0_4_ + 8) = 0;
-				*reinterpret_cast<unsigned int*>(_1b0_4_ + 4) = 1;
-			}
-			else
+			if ((_1b4_4_ != 0) && ((fp = fopen("replay.dat", "rb")) != 0))
 			{
 				fseek(fp, 0, 2);
 				size = ftell(fp);
@@ -98,6 +92,12 @@ void CPad::Init()
 				frames = *reinterpret_cast<int*>(_1b0_4_ + 8);
 				frames = frames / 0x1E + (frames >> 0x1F);
 				System.Printf((char*)"replay frames=%d\n", frames - (frames >> 0x1F));
+			}
+			else
+			{
+				*reinterpret_cast<unsigned int*>(_1b0_4_) = 0xC;
+				*reinterpret_cast<unsigned int*>(_1b0_4_ + 8) = 0;
+				*reinterpret_cast<unsigned int*>(_1b0_4_ + 4) = 1;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Reworked `CPad::Init()` replay-load control flow in `src/pad.cpp` to better match original code generation while preserving behavior:
- Inverted the replay branch to load from file only when `_1b4_4_ != 0` and `fopen` succeeds.
- Moved default replay header initialization (`0xC`, frame count `0`, mode `1`) into the `else` path.
- Changed `size` local type from `unsigned int` to `int` to align with `ftell` usage/codegen.

## Functions improved
- Unit: `main/pad`
- Symbol: `Init__4CPadFv`
  - Before: `73.30769%`
  - After: `92.68269%`
  - Delta: `+19.375` points

## Match evidence
Measured with:
`tools/objdiff-cli diff -p . -u main/pad -o - Init__4CPadFv`

Relevant unchanged controls (sanity check):
- `Quit__4CPadFv`: `92.72727%` -> `92.72727%`
- `Frame__4CPadFv`: `17.483826%` -> `17.483826%`

## Plausibility rationale
This update is source-plausible and not compiler-coaxing:
- The replay-path rewrite reflects natural game logic: use replay data only when enabled and readable; otherwise initialize replay buffer header defaults.
- Type adjustment (`ftell` result stored in signed integer) is a conventional C/C++ pattern in this codebase and aligns with observed target behavior.
- No contrived temporaries, no unnatural instruction-forcing patterns, and no debug artifacts/comments were introduced.

## Technical notes
Instruction-level diff showed improved alignment around replay open/load/default branching and replay metadata writes in `Init__4CPadFv`, which drove the significant score increase.
