### PR TITLE
main/pppScreenBreak: implement SB_BeforeMeshLockEnvCallback

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -212,12 +212,16 @@ void InitPieceData(CChara::CModel*, PScreenBreak*, VScreenBreak*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012da00
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void SB_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int)
 {
-	// TODO
+    GXSetZMode(GX_TRUE, (GXCompare)7, GX_TRUE);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implements `SB_BeforeMeshLockEnvCallback(CChara::CModel*, void*, void*, int)` in `src/pppScreenBreak.cpp` using the observed PAL behavior from the Ghidra reference.

## Functions improved
- `SB_BeforeMeshLockEnvCallback__FPQ26CChara6CModelPvPvi`

## Match evidence
- Symbol match: **9.090909% -> 100.0%** (`objdiff-cli diff -p . -u main/pppScreenBreak ...`)
- Unit `.text` fuzzy match in objdiff snapshot: **43.023193% -> 43.915253%**

## Plausibility rationale
The implementation is a direct, minimal callback body (`GXSetZMode(GX_TRUE, (GXCompare)7, GX_TRUE);`) consistent with the function size (44 bytes) and with how this callback is used in screen-break rendering setup.

## Technical details
- Updated function metadata comment with PAL address/size (`0x8012da00`, `44b`).
- Replaced TODO stub with the single GX state call expected by decomp output.
- Verified project still builds with `ninja` and report generation succeeds.
