### PR TITLE
gx/GXTev: improve GXSetTevColor register packing match

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -207,20 +207,16 @@ void GXSetTevAlphaOp(GXTevStageID stage, GXTevOp op, GXTevBias bias, GXTevScale 
 }
 
 void GXSetTevColor(GXTevRegID id, GXColor color) {
-    u32 rgba;
+    u8* c;
+    u32 id2;
     u32 regRA;
     u32 regBG;
 
     CHECK_GXBEGIN(740, "GXSetTevColor");
-    rgba = *(u32*)&color;
-
-    regRA = (0xE0 + id * 2) << 24;
-    SET_REG_FIELD(745, regRA, 8, 0, rgba >> 24);
-    SET_REG_FIELD(746, regRA, 8, 12, rgba & 0xFF);
-
-    regBG = (0xE1 + id * 2) << 24;
-    SET_REG_FIELD(749, regBG, 8, 0, (rgba >> 8) & 0xFF);
-    SET_REG_FIELD(750, regBG, 8, 12, (rgba >> 16) & 0xFF);
+    c = (u8*)&color;
+    id2 = id * 2;
+    regRA = (c[3] << 12) | c[0] | ((id2 + 0xE0) << 24);
+    regBG = (c[1] << 12) | c[2] | ((id2 + 0xE1) << 24);
 
     GX_WRITE_RAS_REG(regRA);
     GX_WRITE_RAS_REG(regBG);


### PR DESCRIPTION
## Summary
- Reworked `GXSetTevColor` register packing in `src/gx/GXTev.c` to use direct byte extraction and packed register expressions.
- Removed intermediate `u32` reinterpretation and `SET_REG_FIELD` choreography for this function.

## Functions improved
- Unit: `main/gx/GXTev`
- Symbol: `GXSetTevColor`
  - Before: `62.068966%`
  - After: `67.0%`
  - Size: `116b`

## Match evidence
- Baseline command:
  - `tools/objdiff-cli diff -p . -u main/gx/GXTev -o /tmp/gxtev_color_before.json GXSetTevColor`
- After-change command:
  - `tools/objdiff-cli diff -p . -u main/gx/GXTev -o /tmp/gxtev_color_after.json GXSetTevColor`
- Improvement is from assembly alignment in the color-byte load/pack sequence used to emit BP register writes.

## Plausibility rationale
- The updated source is a straightforward SDK-style implementation: read RGBA bytes and compose two TEV BP words.
- It is simpler and more idiomatic than the previous macro-heavy bitfield update path while preserving behavior.

## Technical details
- New implementation computes:
  - `regRA = (a << 12) | r | ((0xE0 + id*2) << 24)`
  - `regBG = (g << 12) | b | ((0xE1 + id*2) << 24)`
- This better matches the expected instruction pattern (`lbz`-based color extraction and packed writes).
