### PR TITLE
pppYmTraceMove: improve construct matching

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -22,34 +22,38 @@ extern "C" {
  */
 void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
 {
-	Vec* dest;
-	f32 fVar1;
-	Vec local_20;
-	f32 local_24;
-	f32 local_28;
-	f32 local_2c;
-	Vec local_38;
-	f32 local_18;
-	f32 local_1c;
+	union {
+		Vec vec;
+		u32 words[3];
+	} local_20;
 
-	local_2c = *(f32*)((u8*)pppMngStPtr + 0x58);
-	local_28 = *(f32*)((u8*)pppMngStPtr + 0x5c);
+	Vec* dest;
+	f32 zero;
+	u32 local_24;
+	u32 local_28;
+	u32 local_2c;
+	Vec local_38;
+	u32 local_18;
+	u32 local_1c;
+
+	local_2c = *(u32*)((u8*)pppMngStPtr + 0x58);
+	local_28 = *(u32*)((u8*)pppMngStPtr + 0x5c);
 	dest = (Vec*)((u8*)pppYmTraceMove + 0x80 + *param_2->m_serializedDataOffsets);
-	local_24 = *(f32*)((u8*)pppMngStPtr + 0x60);
-	local_20.x = *(f32*)((u8*)pppMngStPtr + 0x68);
-	local_1c = *(f32*)((u8*)pppMngStPtr + 0x6c);
-	local_18 = *(f32*)((u8*)pppMngStPtr + 0x70);
-	local_20.y = local_1c;
-	local_20.z = local_18;
-	pppSubVector__FR3Vec3Vec3Vec((Vec*)&dest[1].y, &local_20, (Vec*)&local_2c);
+	local_24 = *(u32*)((u8*)pppMngStPtr + 0x60);
+	local_20.words[0] = *(u32*)((u8*)pppMngStPtr + 0x68);
+	local_1c = *(u32*)((u8*)pppMngStPtr + 0x6c);
+	local_18 = *(u32*)((u8*)pppMngStPtr + 0x70);
+	local_20.words[1] = local_1c;
+	local_20.words[2] = local_18;
+	pppSubVector__FR3Vec3Vec3Vec((Vec*)&dest[1].y, &local_20.vec, (Vec*)&local_2c);
 	local_38.x = dest[1].y;
 	local_38.y = dest[1].z;
 	local_38.z = dest[2].x;
 	pppCopyVector__FR3Vec3Vec(dest, &local_38);
-	fVar1 = 0.0f;
+	zero = 0.0f;
 	dest[3].x = 0.0f;
-	dest[2].z = fVar1;
-	dest[2].y = fVar1;
+	dest[2].z = zero;
+	dest[2].y = zero;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppConstructYmTraceMove` local data handling to better match original codegen.
- Switched saved-position/param vector temporaries to raw `u32` words and staged vector data via a `Vec/u32[3]` union before `pppSubVector`.
- Kept behavior unchanged (same vector math and zeroing logic), but changed load/store shape to align better with target assembly.

## Functions improved
- Unit: `main/pppYmTraceMove`
  - `pppConstructYmTraceMove`

## Match evidence
- `pppConstructYmTraceMove` (`main/pppYmTraceMove`):
  - Before: **50.26%** (objdiff-cli diff)
  - After: **59.07%** (objdiff-cli diff)
- Unit `main/pppYmTraceMove` fuzzy match:
  - Before: **61.4%** (target selector report)
  - After: **62.787%** (`build/GCCP01/report.json`)
- `pppFrameYmTraceMove` remained stable around **63.3%**.

## Plausibility rationale
- The function reads serialized/packed manager fields and feeds them into vector ops; treating these fields as word-level temporaries is plausible for original low-level engine code and improves ABI/codegen alignment without introducing contrived control flow.

## Technical details
- Main assembly-impacting change is conversion from float-typed temporaries to word-typed temporaries for stack staging before `pppSubVector`.
- This shifted instruction selection toward integer load/store patterns (`lwz`/`stw`) in the setup sequence, reducing mismatch in the function prologue/body initialization path.
