### PR TITLE
cflat_runtime2: implement CLine<64> ctor/draw

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -2,6 +2,72 @@
 #include "ffcc/baseobj.h"
 #include "ffcc/p_game.h"
 
+template <int count>
+class CLine;
+
+template <>
+class CLine<64>
+{
+public:
+	CLine();
+	void Draw();
+
+private:
+	u8 m_0x00[0x18];
+	u32 m_numPoints;
+	u8 m_0x1C[0x14];
+	Vec m_points[64];
+};
+
+CLine<64>::CLine()
+{
+	m_numPoints = 0;
+}
+
+void CLine<64>::Draw()
+{
+	if (m_numPoints == 0) {
+		return;
+	}
+
+	GXBegin((GXPrimitive)0xB0, GX_VTXFMT0, (u16)(m_numPoints & 0xFFFF));
+	u32 i = 0;
+	u8* it = reinterpret_cast<u8*>(this);
+	while (i < m_numPoints) {
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x30);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x34);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x38);
+		it += 0xC;
+		i++;
+	}
+
+	const float yOffset = 1.0f;
+	GXBegin((GXPrimitive)0xB0, GX_VTXFMT0, (u16)(m_numPoints & 0xFFFF));
+	i = 0;
+	it = reinterpret_cast<u8*>(this);
+	while (i < m_numPoints) {
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x30);
+		GXWGFifo.f32 = yOffset + *reinterpret_cast<float*>(it + 0x34);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x38);
+		it += 0xC;
+		i++;
+	}
+
+	GXBegin((GXPrimitive)0xA8, GX_VTXFMT0, (u16)((m_numPoints & 0x7FFF) << 1));
+	i = 0;
+	it = reinterpret_cast<u8*>(this);
+	while (i < m_numPoints) {
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x30);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x34);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x38);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x30);
+		GXWGFifo.f32 = yOffset + *reinterpret_cast<float*>(it + 0x34);
+		GXWGFifo.f32 = *reinterpret_cast<float*>(it + 0x38);
+		it += 0xC;
+		i++;
+	}
+}
+
 namespace {
 
 typedef unsigned char u8;


### PR DESCRIPTION
## Summary
- Added a local `CLine<64>` helper reconstruction in `src/cflat_runtime2.cpp`.
- Implemented `CLine<64>::CLine()` and `CLine<64>::Draw()` using GX FIFO writes, matching expected symbol behavior.
- Kept changes scoped to one file with no build-system or unrelated source edits.

## Functions Improved
- Unit: `main/cflat_runtime2`
- `__ct__9CLine<64>Fv`: missing -> **100.0%** match
- `Draw__9CLine<64>Fv`: missing -> **71.9125%** match

## Match Evidence
- objdiff unit `.text` match: **2.2449696% -> 3.4274273%**
- Project progress (ninja report): code matched bytes **203220 -> 203232** (+12)
- Project progress (ninja report): matched functions **1531 -> 1532**

## Plausibility Rationale
- The implementation follows the existing codebase style used in similar line-draw helpers (`src/sound.cpp`) with direct `GXWGFifo` emission.
- Structure access uses stable offsets and straightforward loops, avoiding contrived control-flow hacks.
- This is a first-pass reconstruction for a large low-match unit and intentionally keeps semantics readable and source-plausible.

## Technical Notes
- Baseline/after analysis used `tools/objdiff-cli` v3.6.1 in JSON oneshot mode.
- The change restores concrete emitted symbols for the selected low-match target while leaving unrelated TODO stubs untouched.
