### PR TITLE
texanim: implement CTexAnimSet create/duplicate/attach

### DIFF
--- a/include/ffcc/texanim.h
+++ b/include/ffcc/texanim.h
@@ -20,7 +20,7 @@ public:
     ~CTexAnimSet();
 
     void Create(CChunkFile&, CMemory::CStage*);
-    void Duplicate(CMemory::CStage*);
+    CTexAnimSet* Duplicate(CMemory::CStage*);
     void AttachMaterialSet(CMaterialSet*);
     void AddFrame();
     void Change(char*, float, ANIM_TYPE);


### PR DESCRIPTION
## Summary
- Implemented `CTexAnimSet::Create`, `CTexAnimSet::Duplicate`, and `CTexAnimSet::AttachMaterialSet` in `src/texanim.cpp` from Ghidra-guided PAL behavior.
- Added PAL address/size metadata for these functions.
- Added missing declarations/includes needed for chunk parsing, material lookup, object allocation, and reference management.
- Updated `CTexAnimSet::Duplicate` declaration in `include/ffcc/texanim.h` to return `CTexAnimSet*` (matching reconstructed behavior).

## Functions improved
- Unit: `main/texanim`
- `AttachMaterialSet__11CTexAnimSetFP12CMaterialSet`: `1.5625%` -> `60.71875%` (+59.15625)
- `Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage`: `0.44444445%` -> `0.0%`
- `Duplicate__11CTexAnimSetFPQ27CMemory6CStage`: `1.1363636%` -> `0.0%`

## Match evidence
- `main/texanim` `.text` match: `47.45242%` -> `50.24961%` (+2.79719)
- Sizes for target symbols remain exact (`AttachMaterialSet` 256b, `Duplicate` 352b, `Create` 900b).
- Build verification: `ninja` succeeds and regenerates report cleanly.

## Plausibility rationale
- Changes model plausible original source patterns for this codebase: explicit refcount release/retain, chunk-tag driven parsing (`TANM`/`SEQ `/`INFO`/`KEY `/`NAME`), and stage-based allocations using project allocators.
- `AttachMaterialSet` now follows expected material binding semantics (release old material ref, lookup by name, retain new material).
- Implementations avoid synthetic compiler-coaxing constructs and align with existing pointer-offset style used in nearby decomp code.

## Technical details
- `Create` now initializes `CTexAnim`, `CTexAnim::CRefData`, and `CTexAnimSeq` layouts and populates sequence/keyframe buffers from chunk data.
- `Duplicate` now performs deep element copy for the `CTexAnim` array while retaining shared ref-data handles.
- `AttachMaterialSet` now resolves material indices via `CMaterialSet::Find` and binds materials from the internal array with proper refcount updates.
