### PR TITLE
p_light: implement CLightPcs::SetPosition

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -23,6 +23,7 @@ extern unsigned int lbl_801EA2C8[];
 extern unsigned int lbl_801EA2D4[];
 
 extern unsigned int DAT_8032fc0c;
+extern unsigned int DAT_8032fc08;
 extern float FLOAT_8032fc14;
 extern float FLOAT_8032fc18;
 extern float FLOAT_8032fc1c;
@@ -474,12 +475,70 @@ void CLightPcs::SetDiffuse(unsigned long, _GXColor, Vec*, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80048fe0
+ * PAL Size: 536b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CLightPcs::SetPosition(CLightPcs::TARGET, Vec*, unsigned long)
+void CLightPcs::SetPosition(CLightPcs::TARGET target, Vec* pos, unsigned long mask)
 {
-	// TODO
+    char* lightPcs = (char*)this;
+    *(u32*)(lightPcs + 0xb0) = *(u32*)(lightPcs + 0xac);
+    *(u32*)(lightPcs + 0xb4) = 0;
+
+    if (mask == 0) {
+        unsigned long chanMask = *(u32*)(lightPcs + 0xb4);
+        GXSetNumChans((u8)1);
+        if ((int)target != 1) {
+            GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, chanMask, (GXDiffuseFn)2, (GXAttnFn)1);
+            GXSetChanCtrl((GXChannelID)2, (u8)1, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
+
+            _GXColor chanMat;
+            *(u32*)&chanMat = DAT_8032fc08;
+            GXSetChanMatColor((GXChannelID)4, chanMat);
+        }
+        return;
+    }
+
+    char* lightSlot = lightPcs + 0xbc;
+    *(u32*)(lightPcs + 0xb4) = (1 << *(u32*)(lightPcs + 0xb0)) - 1;
+
+    for (u32 i = 0; i < *(u32*)(lightPcs + 0xac); i++) {
+        GXLoadLightObjImm((GXLightObj*)(lightSlot + 0x6c), (GXLightID)(1 << i));
+        lightSlot += 0xb0;
+    }
+
+    if (pos != nullptr) {
+        char* bumpSlot = lightPcs + 0x63c;
+        for (u32 i = 0; i < *(u32*)(lightPcs + 0xb8); i++) {
+            if ((*(char*)(bumpSlot + 0x60 + (int)target) != '\0') && ((*(u32*)(bumpSlot + 0x34) & mask) != 0) &&
+                ((double)PSVECSquareDistance(pos, (Vec*)(bumpSlot + 4)) < (double)*(float*)(bumpSlot + 0xac))) {
+                _GXColor lightColor;
+                *(u32*)&lightColor = *(u32*)(bumpSlot + 0x50 + ((int)target * 4));
+                GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c), lightColor);
+                GXLoadLightObjImm((GXLightObj*)(bumpSlot + 0x6c), (GXLightID)(1 << *(u32*)(lightPcs + 0xb0)));
+                *(u32*)(lightPcs + 0xb4) |= 1 << *(u32*)(lightPcs + 0xb0);
+                *(u32*)(lightPcs + 0xb0) += 1;
+                if (*(u32*)(lightPcs + 0xb0) > 7) {
+                    break;
+                }
+            }
+            bumpSlot += 0xb0;
+        }
+    }
+
+    unsigned long chanMask = *(u32*)(lightPcs + 0xb4);
+    GXSetNumChans((u8)1);
+    if ((int)target != 1) {
+        GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, chanMask, (GXDiffuseFn)2, (GXAttnFn)1);
+        GXSetChanCtrl((GXChannelID)2, (u8)1, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
+
+        _GXColor chanMat;
+        *(u32*)&chanMat = DAT_8032fc08;
+        GXSetChanMatColor((GXChannelID)4, chanMat);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::SetPosition(CLightPcs::TARGET, Vec*, unsigned long)` in `src/p_light.cpp` using source-plausible light setup/control flow.
- Added PAL address metadata block for the function (`0x80048fe0`, `536b`).
- Added missing `DAT_8032fc08` declaration used for channel material color.

## Functions improved
- Unit: `main/p_light`
- Symbol: `SetPosition__9CLightPcsFQ29CLightPcs6TARGETP3VecUl`

## Match evidence
- Selector baseline before edits: `0.7%` match for `SetPosition__9CLightPcsFQ29CLightPcs6TARGETP3VecUl`.
- After edit/build, report fuzzy match: `87.208954%` for the same function (`build/GCCP01/report.json`).
- Objdiff (v3.6.1) symbol diff reports `87.13433%` match for the target symbol.
- This is assembly-alignment progress from a TODO stub to a near-match implementation, not a formatting-only change.

## Plausibility rationale
- The implementation follows expected engine behavior: initialize active light mask, load base light objects, conditionally inject bump lights by target/mask/distance, then set GX channel controls.
- Uses existing per-light memory layout and GX APIs already used in adjacent p_light code.
- Avoids synthetic compiler-only tricks; logic reflects natural original game-engine source structure.

## Technical details
- Preserved original-style pointer/offset access already used in `p_light.cpp`.
- Added early branch for `mask == 0` and matched channel setup paths for `target != 1`.
- Capped dynamic light appending at 8 entries (`> 7` break) consistent with hardware light slot limits and decomp behavior.
