### PR TITLE
Improve pppFrameYmMoveCircle helper-call matching

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -27,6 +27,8 @@ extern f32 lbl_80330D84;
 extern f32 lbl_80330D88;
 extern f32 lbl_80330D8C;
 extern f32 lbl_80330D90;
+extern "C" void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
+extern "C" void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
 extern "C" double acos(double);
 
 /*
@@ -65,7 +67,7 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
     work->m_radius = lbl_80330D7C;
     work->m_radiusStep = lbl_80330D7C;
     work->m_radiusStepStep = lbl_80330D7C;
-    pppCopyVector(work->m_center, *(Vec*)(pppMngSt + 0x58));
+    pppCopyVector__FR3Vec3Vec(&work->m_center, (Vec*)(pppMngSt + 0x58));
     work->m_hasInit = 0;
 }
 
@@ -81,6 +83,7 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
 extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleStep* stepData, pppYmMoveCircleOffsets* offsetData)
 {
     pppYmMoveCircleWork* work;
+    u8* pppMngSt;
     Vec nextPos;
     s32 tableIndex;
 
@@ -88,6 +91,7 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
         return;
     }
 
+    pppMngSt = lbl_8032ED50;
     work = (pppYmMoveCircleWork*)((u8*)basePtr + *offsetData->m_serializedDataOffsets + 0x80);
 
     work->m_radiusStep += work->m_radiusStepStep;
@@ -111,16 +115,16 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
         work->m_angle += lbl_80330D78;
     }
 
-    tableIndex = (s32)((lbl_80330D80 * (lbl_80330D84 * work->m_angle)) / lbl_80330D88);
+    tableIndex = (s32)((lbl_80330D80 * (work->m_angle * lbl_80330D84)) / lbl_80330D88);
     nextPos.x = (work->m_radius * *(f32*)((u8*)lbl_801EC9F0 + ((tableIndex + 0x4000) & 0xFFFC))) + work->m_center.x;
-    nextPos.y = *(f32*)((u8*)lbl_8032ED50 + 0xC);
+    nextPos.y = *(f32*)(pppMngSt + 0xC);
     nextPos.z = (work->m_radius * -(*(f32*)((u8*)lbl_801EC9F0 + (tableIndex & 0xFFFC)))) + work->m_center.z;
 
-    pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x48), *(Vec*)((u8*)lbl_8032ED50 + 0x8));
-    pppCopyVector(*(Vec*)((u8*)lbl_8032ED50 + 0x8), nextPos);
+    pppCopyVector__FR3Vec3Vec((Vec*)(pppMngSt + 0x48), (Vec*)(pppMngSt + 0x8));
+    pppCopyVector__FR3Vec3Vec((Vec*)(pppMngSt + 0x8), &nextPos);
 
-    *(f32*)((u8*)lbl_8032ED50 + 0x84) = nextPos.x;
-    *(f32*)((u8*)lbl_8032ED50 + 0x94) = nextPos.y;
-    *(f32*)((u8*)lbl_8032ED50 + 0xA4) = nextPos.z;
-    pppSetFpMatrix((_pppMngSt*)lbl_8032ED50);
+    *(f32*)(pppMngSt + 0x84) = nextPos.x;
+    *(f32*)(pppMngSt + 0x94) = nextPos.y;
+    *(f32*)(pppMngSt + 0xA4) = nextPos.z;
+    pppSetFpMatrix__FP9_pppMngSt((_pppMngSt*)pppMngSt);
 }


### PR DESCRIPTION
## Summary
- Updated `src/pppYmMoveCircle.cpp` to use explicit helper entry points `pppCopyVector__FR3Vec3Vec` and `pppSetFpMatrix__FP9_pppMngSt` that better match existing ppp module calling conventions.
- Kept the behavior/source intent unchanged while tightening pointer flow through a local `pppMngSt` pointer in `pppFrameYmMoveCircle`.

## Functions improved
- Unit: `main/pppYmMoveCircle`
- `pppFrameYmMoveCircle`: **78.63571% -> 81.74286%**
- `pppConstructYmMoveCircle`: 72.653336% -> 72.653336% (no change)

## Match evidence
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmMoveCircle -o - pppFrameYmMoveCircle`
- Unit `.text` match: **76.548836% -> 78.57209%**
- Improvement is from instruction-level alignment in the frame function, not renaming/format-only edits.

## Plausibility rationale
- The change aligns this file with established patterns already used in other `ppp*` translation units that call the same mangled helper symbols directly.
- The resulting code remains straightforward gameplay/update logic and avoids contrived compiler-coaxing constructs.

## Technical details
- Added explicit declarations:
  - `pppCopyVector__FR3Vec3Vec(Vec*, const Vec*)`
  - `pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*)`
- Switched call sites in construct/frame paths to those helpers.
- Preserved all existing control-flow and data semantics.
