### PR TITLE
materialman: implement CMaterialMan Init/Quit

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 
 extern "C" unsigned long UnkMaterialSetGetter(void*);
+static const char s_materialStageName[] = "material";
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)
@@ -66,7 +67,8 @@ CMaterialMan::CMaterialMan()
  */
 void CMaterialMan::Init()
 {
-	// TODO
+	*reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x218)) = Memory.CreateStage(0x20000, const_cast<char*>(s_materialStageName), 0);
+	*Ptr(this, 0x204) = 0x30;
 }
 
 /*
@@ -76,7 +78,7 @@ void CMaterialMan::Init()
  */
 void CMaterialMan::Quit()
 {
-	// TODO
+	Memory.DestroyStage(*reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x218)));
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement `CMaterialMan::Init` and `CMaterialMan::Quit` in `src/materialman.cpp` using the PAL Ghidra references:
- `Init` now allocates the material manager stage (`0x20000`, name `"material"`) and initializes the byte at offset `0x204` to `0x30`.
- `Quit` now destroys the stage stored at offset `0x218`.

## Functions improved
Unit: `main/materialman`
- `Init__12CMaterialManFv` (`80b`)
- `Quit__12CMaterialManFv` (`48b`)

## Match evidence
From `build/GCCP01/report.json`:
- `Init__12CMaterialManFv`: **5.0% -> 89.0%**
- `Quit__12CMaterialManFv`: **8.333333% -> 40.833332%**

(Overall unit score remains low due to many remaining TODO bodies in `materialman.cpp`, but these two symbols improved substantially.)

## Plausibility rationale
These changes are source-plausible game code behavior:
- Stage lifecycle management (create in `Init`, destroy in `Quit`) is standard ownership logic.
- The implementation uses existing engine APIs (`CMemory::CreateStage`, `CMemory::DestroyStage`) rather than contrived compiler-only transformations.
- The `0x30` write in `Init` matches the observed decomp initialization behavior for material manager state.

## Technical notes
- Added a local stage-name constant (`"material"`) and preserved the existing pointer-offset style used throughout the file.
- No debug artifacts or assembly comments were added.
