### PR TITLE
monobj: implement onCreate/onDestroy lifecycle init

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -1,23 +1,63 @@
 #include "ffcc/monobj.h"
+#include "ffcc/charaobj.h"
+
+#include <string.h>
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8011A4CC
+ * PAL Size: 168b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGMonObj::onCreate()
 {
-	// TODO
+	CGCharaObj* charaObj = reinterpret_cast<CGCharaObj*>(this);
+	charaObj->onCreate();
+
+	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
+	*reinterpret_cast<unsigned int*>(mon + 0x6C4) = static_cast<unsigned int>(-1);
+	*reinterpret_cast<unsigned short*>(mon + 0x6E4) = 0;
+	*reinterpret_cast<unsigned short*>(mon + 0x6E6) = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x6C8) = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x6CC) = 0;
+	mon[0x6B4] = 0;
+	mon[0x6B8] = 0;
+	mon[0x6B9] = 0;
+	mon[0x6BA] = 0;
+	mon[0x6BC] = 0;
+	mon[0x6BD] = 0;
+	mon[0x6BE] = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x6F0) = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x6F4) = 0;
+	mon[0x6BF] = 0;
+	mon[0x6C0] = 0;
+	mon[0x6C2] = 0;
+	mon[0x6C3] = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x6D8) = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x6DC) = 0;
+	mon[0x6BB] = 0;
+	*reinterpret_cast<unsigned int*>(mon + 0x704) = 0;
+	memset(mon + 0x70C, 0, 0x34);
+	*reinterpret_cast<unsigned int*>(mon + 0x6E0) = 0;
+	mon[0x6C1] = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8011A4AC
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGMonObj::onDestroy()
 {
-	// TODO
+	CGCharaObj* charaObj = reinterpret_cast<CGCharaObj*>(this);
+	charaObj->onDestroy();
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CGMonObj::onCreate` and `CGMonObj::onDestroy` in `src/monobj.cpp` using the PAL Ghidra references for `onCreate__8CGMonObjFv` and `onDestroy__8CGMonObjFv`.

Changes made:
- `onDestroy` now forwards to `CGCharaObj::onDestroy`.
- `onCreate` now forwards to `CGCharaObj::onCreate` and initializes the same member region/flags seen in the PAL reference.
- Added PAL address/size metadata blocks for both functions.

## Functions Improved
- `onCreate__8CGMonObjFv` (size 168)
  - Before: `2.3809524%`
  - After: `86.47619%`
- `onDestroy__8CGMonObjFv` (size 32)
  - Before: `12.5%`
  - After: `36.125%`
- Unit: `main/monobj`
  - Before: `0.54630595%`
  - After: `1.0303069%`

## Match Evidence
- Rebuilt with `ninja` after edits and confirmed `main/monobj` function-level fuzzy match increases in `build/GCCP01/report.json`.
- Improvement is concentrated in the two edited symbols, not just unrelated global noise.

## Plausibility Rationale
These changes reflect plausible original source behavior:
- Derived-object lifecycle forwarding (`CGMonObj` -> `CGCharaObj`) is standard and consistent with the class stack used across this codebase.
- The initialization sequence in `onCreate` is straightforward state zeroing/setup of contiguous object work fields, matching expected game object construction patterns.
- No debug artifacts, dead code, or explanatory junk comments were added.

## Technical Notes
- The class layout for `CGMonObj` is currently incomplete in headers, so this pass uses offset-based writes in `onCreate` to reproduce observed initialization while preserving current project structure.
