### PR TITLE
pppYmMoveCircle: simplify quadrant branch in constructor

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -54,8 +54,8 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
     double angle = acos((double)PSVECDotProduct(&temp2, &temp1));
     work->m_angle = lbl_80330D90 * (f32)angle;
 
-    if (!((temp1.x <= lbl_80330D7C && temp1.z >= lbl_80330D7C) ||
-          (temp1.x > lbl_80330D7C && temp1.z < lbl_80330D7C))) {
+    if ((temp1.x <= lbl_80330D7C && temp1.z < lbl_80330D7C) ||
+        (temp1.x > lbl_80330D7C && temp1.z >= lbl_80330D7C)) {
         work->m_angle = lbl_80330D78 - work->m_angle;
     }
 


### PR DESCRIPTION
## Summary
- Rewrote the quadrant/sign test in `pppConstructYmMoveCircle` to an equivalent positive-form condition.
- Kept behavior identical (`angle = 360 - angle` only in opposite quadrants), while changing control-flow shape used by the compiler.

## Functions improved
- Unit: `main/pppYmMoveCircle`
- Function: `pppConstructYmMoveCircle` improved from **72.72%** to **72.78667%** fuzzy match.
- `pppFrameYmMoveCircle` unchanged at **78.671425%**.

## Match evidence
- Unit fuzzy match moved from **76.59535%** to **76.61861%**.
- Build report source: `build/GCCP01/report.json` after rebuilding `pppYmMoveCircle` and running `ninja`.

## Plausibility rationale
- This is a readability-positive rewrite of the same boolean logic (eliminates negated compound condition).
- No magic constants, no compiler-only temporaries, and no behavior changes.

## Technical details
- Changed:
  - From: `!((x <= 0 && z >= 0) || (x > 0 && z < 0))`
  - To: `(x <= 0 && z < 0) || (x > 0 && z >= 0)`
- The resulting branch/control-flow aligns slightly better with target codegen for this function.
