### PR TITLE
Implement LoadFurTexBuffer in chara_fur

### DIFF
--- a/src/chara_fur.cpp
+++ b/src/chara_fur.cpp
@@ -176,6 +176,21 @@ extern "C" void SaveFurTexBuffer__6CCharaFPUs(CChara*, unsigned short* outTexels
 
 /*
  * --INFO--
+ * PAL Address: 0x800e12a0
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void LoadFurTexBuffer__6CCharaFPUs(CChara* chara, unsigned short* inTexels)
+{
+	memcpy(Chara + 4, inTexels, 0x2000);
+	CalcMogScore__6CCharaFv(chara);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added `LoadFurTexBuffer__6CCharaFPUs` in `src/chara_fur.cpp`.
- Implemented PAL-expected behavior: copy 0x2000 bytes from save buffer into the fur texture buffer (`Chara + 4`) and recalculate fur score via `CalcMogScore__6CCharaFv`.
- Added PAL metadata block for address/size.

## Functions improved
- Unit: `main/chara_fur`
- Function: `LoadFurTexBuffer__6CCharaFPUs` (PAL `0x800e12a0`, size `68b`)

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` output)
- After: `99.70588%` (`tools/objdiff-cli diff -p . -u main/chara_fur -o - --format json LoadFurTexBuffer__6CCharaFPUs`)
- Project progress after rebuild (`ninja`):
  - matched functions: `1532 -> 1533`
  - matched code bytes: `203232 -> 203300`
- Unit-level report now shows `3/14` matched functions for `main/chara_fur`.

## Plausibility rationale
- The implementation matches the expected save/load pairing already present in this file (`SaveFurTexBuffer__6CCharaFPUs`).
- Copy direction and follow-up score recomputation are consistent with natural game save-load behavior and with the Ghidra reference function.
- No compiler-coaxing constructs were introduced; this is straightforward source-level functionality.
