### PR TITLE
p_dbgmenu: reconstruct small CDbgMenuPcs methods

### DIFF
--- a/include/ffcc/p_dbgmenu.h
+++ b/include/ffcc/p_dbgmenu.h
@@ -26,7 +26,7 @@ public:
 	
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
     void create();
     void destroy();
     void selectNext();

--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -59,52 +59,77 @@ CDbgMenuPcs::CDbgMenuPcs()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d260
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CDbgMenuPcs::Init()
 {
-	// TODO
+	*(u32*)((char*)this + 0x40) = 0;
+	*(u32*)((char*)this + 0x20) = 0x280;
+	*(u32*)((char*)this + 0x24) = 0x1C0;
+	*(u32*)((char*)this + 4) = 0x8940;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d25c
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CDbgMenuPcs::Quit()
 {
-	// TODO
+	return;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d248
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CDbgMenuPcs::GetTable(unsigned long)
+int CDbgMenuPcs::GetTable(unsigned long index)
 {
-	// TODO
+	return index * 0x15C + -0x7FDEDC38;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d204
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CDbgMenuPcs::create()
 {
-	// TODO
+	memset((char*)this + 0x5C, 0, 0x2A00);
+	*(u32*)((char*)this + 0x2A60) = 0;
+	*(u32*)((char*)this + 0x2A64) = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d200
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CDbgMenuPcs::destroy()
 {
-	// TODO
+	return;
 }
 
 /*
@@ -300,12 +325,23 @@ void CDbgMenuPcs::calc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012cd10
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CDbgMenuPcs::draw()
 {
-	// TODO
+	*(s32*)((char*)this + 0x2A68) = -1;
+	Graphic.InitDebugString();
+	_GXSetBlendMode((_GXBlendMode)1, (_GXBlendFactor)4, (_GXBlendFactor)5, (_GXLogicOp)1);
+	GXSetNumChans(1);
+	if (*(CDM**)((char*)this + 0x58) != 0) {
+		drawMenu(*(CDM**)((char*)this + 0x58));
+	}
+	Graphic.SetViewport();
 }
 
 /*
@@ -956,12 +992,17 @@ void CDbgMenuPcs::CDMParam::Clear()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012d3b4
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CDbgMenuPcs::CDM::CDM()
 {
-	// TODO
+	memset(this, 0, 0x34);
+	memset((char*)this + 0x34, 0, 0x20);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reconstructed several small `CDbgMenuPcs` methods in `src/p_dbgmenu.cpp` from the PAL Ghidra references.
- Added PAL `--INFO--` address/size blocks for the methods touched.
- Corrected `CDbgMenuPcs::GetTable` return type in `include/ffcc/p_dbgmenu.h` from `void` to `int` to match emitted behavior.

## Functions improved
Unit: `main/p_dbgmenu`

- `draw__11CDbgMenuPcsFv`: `3.3333% -> 84.5%`
- `create__11CDbgMenuPcsFv`: `5.8823% -> 100%`
- `destroy__11CDbgMenuPcsFv`: `100% -> 100%` (kept exact no-op)
- `GetTable__11CDbgMenuPcsFUl`: `20.0% -> 65.0%`
- `Quit__11CDbgMenuPcsFv`: `100% -> 100%` (kept exact no-op)
- `Init__11CDbgMenuPcsFv`: `10.0% -> 100%`
- `__ct__Q211CDbgMenuPcs3CDMFv`: `5.5555% -> 100%`

Unit fuzzy match:
- `main/p_dbgmenu`: `52.9973% -> 56.7034%`

## Match evidence
- `ninja` succeeded and regenerated `build/GCCP01/report.json`.
- Overall project code matched bytes increased (`203276 -> 203456`) with this pass.
- Improvements are concentrated in the edited `p_dbgmenu` methods rather than broad noise.

## Plausibility rationale
- Changes are direct source-plausible reconstructions of small lifecycle/draw helpers (initialization, table access, and no-op stubs).
- No compiler-coaxing temporaries or artificial control-flow tricks were introduced.
- Field/offset usage is consistent with existing surrounding `p_dbgmenu` code style and ABI conventions used in this repository.
