### PR TITLE
Implement RedSound driver wrapper TODOs

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -322,22 +322,30 @@ void CRedSound::SetReverbDepth(int bank, int sep, int depth)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccf74
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetMusicData(void*)
+void CRedSound::SetMusicData(void* musicData)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetMusicData(musicData);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ccfa0
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::ReentryMusicData(int)
+void CRedSound::ReentryMusicData(int bank)
 {
-	// TODO
+	CRedDriver_8032f4c0.ReentryMusicData(bank);
 }
 
 /*
@@ -436,12 +444,16 @@ void CRedSound::SetSeBlockData(int bank, void* blockData)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cd1a8
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedSound::SetSeSepData(void*)
+void CRedSound::SetSeSepData(void* seSepData)
 {
-	// TODO
+	CRedDriver_8032f4c0.SetSeSepData(seSepData);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three previously TODO `CRedSound` wrapper methods in `src/RedSound/RedSound.cpp`.
- Added versioned function info headers (PAL address/size + EN/JP TODO) for each implemented function.
- Each implementation now forwards directly to `CRedDriver_8032f4c0`, matching the expected driver delegation pattern in this module.

## Functions Improved
Unit: `main/RedSound/RedSound`
- `SetMusicData__9CRedSoundFPv` (44b): **9.09% -> 81.27%**
- `ReentryMusicData__9CRedSoundFi` (44b): **9.09% -> 81.27%**
- `SetSeSepData__9CRedSoundFPv` (44b): **9.09% -> 81.27%**

## Match Evidence
- Baseline function values from target selection/report: 9.09% for all three symbols.
- Post-change values from `build/GCCP01/report.json`: 81.27273% for all three symbols.
- Unit fuzzy match moved from selector baseline `54.1%` to `56.64089%` in the post-build report.
- One-symbol objdiff TUI check (`SetMusicData__9CRedSoundFPv`) reports ~80.82%, consistent with report-based improvement.

## Plausibility Rationale
- These are natural wrapper functions in `CRedSound` that delegate to the driver singleton; this is consistent with surrounding already-matching code in the same file (e.g., `SetReverb`, `SetReverbDepth`, `MusicStop`, etc.).
- No contrived temporaries, offset tricks, or control-flow distortion were introduced.
- Changes improve decomp accuracy while preserving readable, plausible original-source structure.

## Technical Details
- Implemented methods:
  - `CRedSound::SetMusicData(void*)`
  - `CRedSound::ReentryMusicData(int)`
  - `CRedSound::SetSeSepData(void*)`
- Build verification: `ninja` passes and regenerates `build/GCCP01/report.json`.
