### PR TITLE
p_map: implement CMapPcs::drawAfter first-pass decomp

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -253,12 +253,66 @@ void CMapPcs::drawViewer()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80034ba4
+ * PAL Size: 540b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapPcs::drawAfter()
 {
-	// TODO
+    if (*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x178) == 0) {
+        if (*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x180) != 0) {
+            CBoundHack bound;
+            _GXColor debugColor;
+            Mtx cameraMtx;
+            Mtx44 screenMtx;
+
+            MaterialMan.InitVtxFmt(-1, GX_F32, 0, GX_RGBA4, 0xE, GX_RGBA6, 0xA);
+
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228DC) =
+                *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0);
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228E0) =
+                *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE4);
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228E4) =
+                *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE8);
+
+            PSMTXCopy(*reinterpret_cast<Mtx*>(reinterpret_cast<char*>(&CameraPcs) + 0x4), cameraMtx);
+            PSMTX44Copy(*reinterpret_cast<Mtx44*>(reinterpret_cast<char*>(&CameraPcs) + 0x48), screenMtx);
+
+            GXSetColorUpdate(GX_TRUE);
+            GXSetAlphaUpdate(GX_FALSE);
+            GXSetCullMode(GX_CULL_BACK);
+            GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
+
+            _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+            _GXSetTevSwapModeTable(GX_TEV_SWAP1, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+            _GXSetTevSwapModeTable(GX_TEV_SWAP2, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+            _GXSetTevSwapModeTable(GX_TEV_SWAP3, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+            _GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+            _GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+            _GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP0);
+            _GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+            MapMng.DrawAfter();
+
+            if ((CFlatFlags & 0x02000000) != 0) {
+                debugColor.r = 0xFF;
+                debugColor.g = 0xFF;
+                debugColor.b = 0x80;
+                debugColor.a = 0xFF;
+
+                bound.p0 = *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
+                bound.p1 = *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0x418);
+                bound.p2 = *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0x41C);
+                bound.p3 = *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0x420);
+                bound.p4 = *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0x424);
+                bound.p5 = *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0x428);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor);
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapPcs::drawAfter()` in `src/p_map.cpp` (previously TODO) using a Ghidra-guided first-pass source reconstruction.
- Added version metadata for the function block:
  - PAL Address: `0x80034ba4`
  - PAL Size: `540b`
- Preserved existing codebase style by using explicit offset-based access where class layout is still incomplete.

## Functions improved
- Unit: `main/p_map`
- Symbol: `drawAfter__7CMapPcsFv`

## Match evidence
- Before: `0.7%` (from `tools/agent_select_target.py` target listing for `main/p_map`)
- After: `59.837036%` (`build/tools/objdiff-cli diff -p . -u main/p_map -o - drawAfter__7CMapPcsFv`)
- Function size remained `540` bytes.

## Plausibility rationale
- This change is a direct, structured implementation of the identified render path behavior:
  - map draw-after gate checks (`this+0x178` / `this+0x180`)
  - GX setup and TEV swap configuration
  - `MapMng.DrawAfter()` call
  - debug bound rendering under `CFlatFlags & 0x02000000`
- The implementation uses existing project idioms for partially-known class layouts (typed locals + offset access), avoiding contrived compiler-coaxing constructs.

## Technical details
- Added stack-local matrix copies (`PSMTXCopy` / `PSMTX44Copy`) and retained them as locals to match call/stack behavior.
- Preserved constant values and ordering from decomp evidence (`InitVtxFmt` args, GX state, TEV setup).
- Current objdiff for `drawAfter__7CMapPcsFv` still shows remaining non-match deltas (arg mismatches/inserts/deletes/replaces), but this is a substantial first-pass alignment improvement over the TODO baseline.

## Validation
- `ninja` build succeeds.
- Objdiff command run for target symbol as above.
