### PR TITLE
GXTransform: improve GXSetScissorBoxOffset codegen match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -625,13 +625,19 @@ void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht) {
  */
 void GXSetScissorBoxOffset(s32 x_off, s32 y_off) {
     u32 reg;
+    u32 x;
+    u32 y;
 
     CHECK_GXBEGIN(1119, "GXSetScissorBoxOffset");
 
     ASSERTMSGLINE(1122, (u32)(x_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid X offset");
     ASSERTMSGLINE(1124, (u32)(y_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid Y offset");
 
-    reg = ((((u32)(x_off + 0x156) >> 1) & 0x7FF003FF) | (((u32)(y_off + 0x156) << 9) & 0xFFFFFC00)) & 0x00FFFFFF;
+    x = (u32)(x_off + 0x156);
+    y = (u32)(y_off + 0x156);
+    reg = (x >> 1) & 0xFFF003FF;
+    reg |= (y << 9) & 0x003FFC00;
+    reg &= 0x00FFFFFF;
     reg |= 0x59000000;
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;


### PR DESCRIPTION
## Summary
- Refactored `GXSetScissorBoxOffset` bitfield construction into explicit `x`/`y` intermediates.
- Replaced one large combined mask expression with stepwise mask/or operations.
- Kept behavior unchanged while steering MWCC toward target instruction selection.

## Functions improved
- Unit: `main/gx/GXTransform`
- Function: `GXSetScissorBoxOffset`

## Match evidence
- `GXSetScissorBoxOffset`: **82.5% -> 86.5625%** (`build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetScissorBoxOffset`)
- Diff entries in symbol instruction stream reduced from **6 -> 5**.
- Notable improvement: expression lowering now includes `rlwinm` pattern aligning with target, replacing a broader constant-mask sequence.

## Plausibility rationale
- The change preserves the original API and semantics (same offset adjustment, field packing, and register write).
- Using explicit temporaries and staged packing is plausible for SDK-era low-level bitfield code and improves readability versus one dense expression.

## Technical details
- Previous code shape encouraged `lis/addi/and` materialization of a mask.
- New structure (`x`, `y`, then staged combine) improves alignment with target codegen around x-offset packing and bitfield assembly.
- Remaining mismatch appears to be register/symbol allocation (`gx` vs `__GXData`) and one nearby argument allocation difference.
