### PR TITLE
main: improve arg replay-flag parsing match

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,8 +107,6 @@ void game(int argc, char** argv)
 void main(int argc, char** argv)
 {
     if (argc != 0) {
-        int* padFlags = reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&Pad) + 0x1B4);
-
         for (int i = 1; i < argc; i++) {
             const char* argument = argv[i];
 
@@ -116,13 +114,10 @@ void main(int argc, char** argv)
                 continue;
             }
 
-            if (argument[1] == 'w') {
-                padFlags[1] = 1;
-                continue;
-            }
-
             if (argument[1] == 'r') {
-                padFlags[0] = 1;
+                Pad._1b4_4_ = 1;
+            } else if (argument[1] == 'w') {
+                Pad._1b8_4_ = 1;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaced pointer arithmetic-based pad flag writes with direct `Pad` member access in `main(int argc, char** argv)`.
- Simplified the option branch to a direct `'r'` / `'w'` check with an `else if`, preserving behavior.

## Functions improved
- Unit: `main/main`
- Symbol: `main`

## Match evidence
- `main`: **90.47059% -> 90.54902%** (size 204 bytes)
- `game__FiPPc`: unchanged at **82.579834%** in unit diff
- Build verification: `ninja` succeeds after the change.

## Plausibility rationale
- The change removes artificial offset math and uses existing typed fields (`Pad._1b4_4_`, `Pad._1b8_4_`), which is more plausible as original authored C++.
- Control flow remains straightforward command-line option parsing with identical semantics.

## Technical details
- The old code cast `&Pad` plus constant offset `0x1B4` to an `int*` and then indexed `[0]`/`[1]`.
- The new code emits direct field stores and tighter branching, improving generated instruction alignment for `main` in objdiff.
