### PR TITLE
cflat_r2system: improve GetErrorLevel/GetMes to full match

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -647,8 +647,7 @@ extern "C" int IsUse__8CMesMenuFv(void* mesMenu)
  */
 extern "C" int GetErrorLevel__7CSystemFv(void* system, int index)
 {
-    char* indexed = (char*)system + index * 4;
-    return *(int*)(indexed + 0x3CDC);
+    return ((int*)((char*)system + 0x3CDC))[index];
 }
 
 /*
@@ -662,8 +661,7 @@ extern "C" int GetErrorLevel__7CSystemFv(void* system, int index)
  */
 extern "C" void GetMes__9CFlatDataFi(void* flatData, int index, int value)
 {
-    char* indexed = (char*)flatData + index * 4;
-    *(int*)(indexed + 0x3CDC) = value;
+    ((int*)((char*)flatData + 0x3CDC))[index] = value;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rewrote offset-index access in `src/cflat_r2system.cpp` for two tiny accessors to use direct array-at-offset form.
- Removed intermediate pointer temporaries that were producing non-matching PPC register allocation.

## Functions improved
- `GetErrorLevel__7CSystemFv` (unit: `main/cflat_r2system`)
- `GetMes__9CFlatDataFi` (unit: `main/cflat_r2system`)

## Match evidence
- `GetErrorLevel__7CSystemFv`: **68.75% -> 100.0%**
- `GetMes__9CFlatDataFi`: **68.75% -> 100.0%**
- `GetNumMes__9CFlatDataFv`: remained **100.0%** (control check)

Verification command used:
- `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o -`

## Plausibility rationale
- The new form is a natural source-level representation of indexed table access at a fixed object offset.
- No contrived temporaries or unnatural sequencing were introduced.
- Behavior is unchanged; this is a code-shape correction consistent with likely original C/C++ author intent.

## Technical details
- For both symbols, objdiff previously showed low-level diffs centered on index scaling/address materialization.
- Switching to `((int*)((char*)obj + 0x3CDC))[index]` aligned emitted code generation and closed the remaining mismatch.
