### PR TITLE
materialman: implement CMaterialSet::CacheDumpTexture

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -558,6 +558,33 @@ void CMaterialSet::AddMaterial(CMaterial*, int)
 
 /*
  * --INFO--
+ * PAL Address: 0x8003c71c
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CMaterialSet::CacheDumpTexture(int materialIndex, CAmemCacheSet* amemCacheSet)
+{
+    CMaterial* material =
+        (*reinterpret_cast<CMaterial***>(Ptr(this, 0x14)))[materialIndex];
+    if (material == 0) {
+        return;
+    }
+
+    int numTexture = static_cast<int>(*reinterpret_cast<unsigned short*>(Ptr(material, 0x18)));
+    CTexture** texture = reinterpret_cast<CTexture**>(Ptr(material, 0x3C));
+    for (int i = 0; i < numTexture; i++) {
+        if (*texture != 0) {
+            (*texture)->CacheUnLoadTexture(amemCacheSet);
+        }
+        texture++;
+    }
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x8003c690
  * PAL Size: 140b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Implemented `CMaterialSet::CacheDumpTexture(int, CAmemCacheSet*)` in `src/materialman.cpp`.
- Added PAL metadata header for the function and implemented pointer/loop behavior consistent with the existing decomp style used in this unit.

## Functions improved
- Unit: `main/materialman`
- Symbol: `CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet`

## Match evidence
- Before this commit: function body was not implemented in `src/materialman.cpp`.
- After this commit (`objdiff` oneshot on symbol):
  - Target size: `132`
  - Current size: `136`
  - Match: `28.757576%`

## Plausibility rationale
- The implementation reflects the expected original behavior: resolve material by index, iterate material texture slots, and call `CTexture::CacheUnLoadTexture` on each non-null texture reference.
- This avoids contrived compiler-coaxing patterns and follows the existing offset-based style already used in this file.

## Technical details
- Uses `Ptr(...)` helper and existing class method calls to keep ABI-facing behavior consistent.
- Verified build with `ninja` and verified function-level alignment with `build/tools/objdiff-cli diff`.
