### PR TITLE
map: specialize CPtrArray<CMapAnimKeyDt*> accessors

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -360,6 +360,41 @@ CMapAnimNode* CPtrArray<CMapAnimNode*>::GetAt(unsigned long index)
 
 /*
  * --INFO--
+ * PAL Address: 0x80034158
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapAnimKeyDt*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034160
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnimKeyDt*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x80034038
  * PAL Size: 8b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
Added explicit `CPtrArray<CMapAnimKeyDt*>` specializations in `src/map.cpp` for:
- `GetSize__27CPtrArray<P13CMapAnimKeyDt>Fv`
- `RemoveAll__27CPtrArray<P13CMapAnimKeyDt>Fv`

Both follow the same source pattern already used in this file for `CMapAnim*` and `CMapAnimRun*` arrays.

## Functions improved
- Unit: `main/map`
- `GetSize__27CPtrArray<P13CMapAnimKeyDt>Fv`: **0.0% -> 100.0%**
- `RemoveAll__27CPtrArray<P13CMapAnimKeyDt>Fv`: **0.0% -> 99.8421%**

## Match evidence
- Rebuilt with `ninja`.
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/map -o - 'GetSize__27CPtrArray<P13CMapAnimKeyDt>Fv'`
  - `build/tools/objdiff-cli diff -p . -u main/map -o - 'RemoveAll__27CPtrArray<P13CMapAnimKeyDt>Fv'`
- Remaining delta in `RemoveAll` is minimal (`DIFF_ARG_MISMATCH:3`).

## Plausibility rationale
This is not compiler-coaxing: these are straightforward template specializations that align with existing code style in `map.cpp` for similar pointer-array types. `RemoveAll` uses the project's expected deallocation path (`__dla__FPv`) and resets count/capacity exactly like sibling specializations.

## Technical details
- Added PAL metadata blocks for both functions (0x80034158 / 0x80034160).
- Implemented directly in `main/map` unit so objdiff can match the expected symbols for this object.
