### PR TITLE
maptexanim: improve SetMapTexAnim debug-path matching

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -371,8 +371,8 @@ void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd,
         setPtr += 4;
     }
 
-    if ((!found) && (System.m_execParam >= 1)) {
-        System.Printf("%s: material id (%d) not found\n", "SetMapTexAnim", materialId);
+    if ((!found) && (System.m_execParam != 0)) {
+        System.Printf("SetMapTexAnim: material id (%d) not found\n", materialId);
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated the not-found debug path in `CMapTexAnimSet::SetMapTexAnim` to use a direct non-zero exec-param check and a single format string.
- This removes the extra `%s` argument indirection and better matches the expected call shape.

## Functions Improved
- Unit: `main/maptexanim`
- Symbol: `SetMapTexAnim__14CMapTexAnimSetFiiii`

## Match Evidence
- Before: `77.37681%`
- After: `77.46377%`
- Delta: `+0.08696%`
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/maptexanim -o - SetMapTexAnim__14CMapTexAnimSetFiiii`

## Plausibility Rationale
- The change is source-plausible and not compiler-coaxing:
  - `System.m_execParam != 0` is semantically equivalent to the previous integer threshold check.
  - A single literal format string for the warning is a natural original-source style and avoids unnecessary argument indirection.

## Technical Notes
- `CMapTexAnim::Calc` remains unchanged (`6.3983955%`), so this PR is scoped to one targeted improvement.
- The resulting code is cleaner while producing a measured objdiff improvement for the target symbol.
