### PR TITLE
maptexanim: improve Calc__11CMapTexAnim matching

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -314,16 +314,14 @@ void CMapTexAnim::SetMapTexAnim(int, int, int)
  */
 void CMapTexAnimSet::Calc()
 {
-    int param_1;
     int iVar1;
     int iVar2;
 
-    param_1 = (int)this;
-    iVar2 = param_1;
-    for (iVar1 = 0; iVar1 < *(short*)(param_1 + 8); iVar1 = iVar1 + 1) {
+    iVar2 = (int)this;
+    for (iVar1 = 0; iVar1 < *(short*)((int)this + 8); iVar1 = iVar1 + 1) {
         Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet(
-            *(CMapTexAnim**)(iVar2 + 0xC), *(CMaterialSet**)(param_1 + 0x10C),
-            *(CTextureSet**)(param_1 + 0x110));
+            *(CMapTexAnim**)(iVar2 + 0xC), *(CMaterialSet**)((int)this + 0x10C),
+            *(CTextureSet**)((int)this + 0x110));
         iVar2 = iVar2 + 4;
     }
 }


### PR DESCRIPTION
## Summary
- Adjusted `CMapTexAnimSet::Calc()` to use `this` directly for fixed-offset material/texture set loads while keeping the iterating pointer only for anim entry traversal.
- Reduced an unnecessary temporary base variable/lifetime in the loop.

## Functions improved
- Unit: `main/maptexanim`
- Symbol: `Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet`

## Match evidence
- `Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet`: `0.0% -> 6.3983955%`
- Other symbols in `main/maptexanim` remained unchanged:
  - `Calc__14CMapTexAnimSetFv`: `90.76923% -> 90.76923%`
  - `Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet`: `48.205715% -> 48.205715%`
  - `SetMapTexAnim__14CMapTexAnimSetFiiii`: `77.46377% -> 77.46377%`
  - `__dt__11CMapTexAnimFv`: `82.09091% -> 82.09091%`

## Plausibility rationale
- The change is source-plausible: it simplifies loop bookkeeping and uses direct object-base access for fixed fields (`+0x10C`, `+0x110`) while still advancing the per-entry pointer for `+0xC` entries.
- No contrived temporaries, no artificial instruction-level coercion, and no behavior changes.

## Technical details
- Built with `ninja` successfully.
- Verified with `build/tools/objdiff-cli diff -p . -u main/maptexanim -o -` before/after JSON comparisons.
- Improvement is localized to the intended symbol without collateral regressions in the same unit.
