### PR TITLE
gx: improve __GXDefaultTexRegionCallback match in GXInit

### DIFF
--- a/src/gx/GXInit.c
+++ b/src/gx/GXInit.c
@@ -110,32 +110,23 @@ static void DisableWriteGatherPipe(void) {
  * JP Size: TODO
  */
 static GXTexRegion* __GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapID id) {
-    u8* gx;
-    u32* regionCount;
     u32 count;
-    u32 offset;
+    u8* gx = (u8*)__GXData;
 
     (void)id;
-    gx = (u8*)__GXData;
 
     switch (GXGetTexObjFmt(t_obj)) {
     case GX_TF_C4:
     case GX_TF_C8:
     case GX_TF_C14X2:
-        regionCount = (u32*)(gx + 0x2CC);
-        count = *regionCount;
-        *regionCount = count + 1;
-        offset = ((count & 3) << 4) + 0x288;
-        break;
+        count = *(u32*)(gx + 0x2CC);
+        *(u32*)(gx + 0x2CC) = count + 1;
+        return (GXTexRegion*)(gx + (((count & 3) << 4) + 0x288));
     default:
-        regionCount = (u32*)(gx + 0x2C8);
-        count = *regionCount;
-        *regionCount = count + 1;
-        offset = ((count & 7) << 4) + 0x208;
-        break;
+        count = *(u32*)(gx + 0x2C8);
+        *(u32*)(gx + 0x2C8) = count + 1;
+        return (GXTexRegion*)(gx + (((count & 7) << 4) + 0x208));
     }
-
-    return (GXTexRegion*)(gx + offset);
 }
 
 static GXTlutRegion* __GXDefaultTlutRegionCallback(u32 idx) {


### PR DESCRIPTION
## Summary
Refactored `__GXDefaultTexRegionCallback` in `src/gx/GXInit.c` to remove intermediate pointer/offset temporaries and return directly from each texture-format path.

## Functions improved
- Unit: `main/gx/GXInit`
- Function: `__GXDefaultTexRegionCallback` (PAL size 124b)

## Match evidence
- `__GXDefaultTexRegionCallback`: `58.70968%` -> `62.870968%` (`+4.161288`)
- Other symbols in `main/gx/GXInit` remained stable in this change (`GXInit`, `__GXInitGX`, `__GXShutdown`, `__GXDefaultTlutRegionCallback` unchanged).
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXInit -o - __GXDefaultTexRegionCallback`

## Plausibility rationale
This rewrite is source-plausible: it keeps behavior intact while expressing the callback as straightforward load/increment/return logic per format branch, which is idiomatic SDK-style C and avoids artificial temporaries.

## Technical details
- Preserved the existing format split (`GX_TF_C4/C8/C14X2` vs default).
- Preserved region-count addresses (`0x2CC` and `0x2C8`) and region base offsets (`0x288` and `0x208`).
- Reduced local state (`regionCount`, `offset`) and branch tail join, improving code shape alignment.
