### PR TITLE
menu_cmd: decompile GetCmdItem for major match gain

### DIFF
--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -1,5 +1,10 @@
 #include "ffcc/menu_cmd.h"
+#include "ffcc/joybus.h"
+#include "ffcc/p_game.h"
 #include "dolphin/types.h"
+
+extern "C" int GetItemType__8CMenuPcsFii(CMenuPcs*, int, int);
+extern "C" int GetItemIcon__8CMenuPcsFi(CMenuPcs*, int);
 
 /*
  * --INFO--
@@ -367,12 +372,71 @@ unsigned int CMenuPcs::CmdClose0()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014cce0
+ * PAL Size: 536b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::GetCmdItem()
 {
-	// TODO
+	u32 scriptFood = Game.game.m_scriptFoodBase[0];
+	s16* list = reinterpret_cast<s16*>(Joybus.GetLetterBuffer(0));
+	s16* write = list;
+	s32 count = 0;
+	u32 itemIndexPtr = scriptFood + 0xb6;
+
+	for (s32 i = 0; i < 0x40; i++) {
+		s32 itemType = GetItemType__8CMenuPcsFii(this, i, 0);
+		if ((itemType != 0) && (itemType != 5) && (itemType != 6) && (itemType != 8) && (itemType != 9)) {
+			if ((itemType != 1) ||
+			    (static_cast<u32>(GetItemIcon__8CMenuPcsFi(this, *reinterpret_cast<s16*>(itemIndexPtr))) ==
+			     (*reinterpret_cast<u16*>(scriptFood + 0x3e0) & 3))) {
+				write++;
+				*write = static_cast<s16>(i);
+				count++;
+			}
+		}
+		itemIndexPtr += 2;
+	}
+
+	s16* write2 = list + count;
+	u32 artifactPtr = scriptFood;
+	for (s32 i = 0; i < 0x49; i++) {
+		s32 arti = i + 0x9f;
+		if (*reinterpret_cast<s16*>(artifactPtr + 0x136) == arti) {
+			if ((arti > 0xde) && (arti < 0xe4)) {
+				count++;
+				write2++;
+				*write2 = static_cast<s16>(i + 0x40);
+			}
+		}
+		artifactPtr += 2;
+	}
+
+	s16* write3 = list + count;
+	if ((*reinterpret_cast<s16*>(scriptFood + 0x1f6) > 0xde) && (*reinterpret_cast<s16*>(scriptFood + 0x1f6) < 0xe4)) {
+		count++;
+		write3++;
+		*write3 = 0xa0;
+	}
+	if ((*reinterpret_cast<s16*>(scriptFood + 0x1f8) > 0xde) && (*reinterpret_cast<s16*>(scriptFood + 0x1f8) < 0xe4)) {
+		count++;
+		write3++;
+		*write3 = 0xa1;
+	}
+	if ((*reinterpret_cast<s16*>(scriptFood + 0x1fa) > 0xde) && (*reinterpret_cast<s16*>(scriptFood + 0x1fa) < 0xe4)) {
+		count++;
+		write3++;
+		*write3 = 0xa2;
+	}
+	if ((*reinterpret_cast<s16*>(scriptFood + 0x1fc) > 0xde) && (*reinterpret_cast<s16*>(scriptFood + 0x1fc) < 0xe4)) {
+		count++;
+		write3[1] = 0xa3;
+	}
+
+	*reinterpret_cast<s16*>(Joybus.GetLetterBuffer(0)) = static_cast<s16>(count + 2);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced the `GetCmdItem` TODO stub in `src/menu_cmd.cpp` with a decompilation-based implementation using existing game state and JoyBus letter buffer flow.
- Added PAL metadata for `GetCmdItem` in the required comment format.
- Added minimal symbol prototypes required by this TU (`GetItemType__8CMenuPcsFii`, `GetItemIcon__8CMenuPcsFi`) and included `joybus`/`p_game` headers for real data access.

## Functions improved
- `main/menu_cmd` / `GetCmdItem__8CMenuPcsFv`

## Match evidence
- `GetCmdItem__8CMenuPcsFv`: **0.74626863% -> 62.58209%** (`build/tools/objdiff-cli diff -p . -u main/menu_cmd -o - GetCmdItem__8CMenuPcsFv`)
- Unit `main/menu_cmd` fuzzy match: **2.3940282% -> 3.8241284%** (`build/GCCP01/report.json`)

## Plausibility rationale
- The implementation mirrors expected menu command list construction behavior (item-type filtering, icon-specific gating, and artifact append rules) instead of compiler-coaxing tricks.
- Logic and memory access patterns are consistent with nearby decompiled menu code in this repository (raw-offset access to script-food/JoyBus structures).

## Technical details
- Recreated the two-pass list build:
  1. collect command-eligible inventory entries
  2. append special artifact candidates and fixed IDs for equipped slots
- Preserved the original buffer semantics where the count header is written at index 0 and entries begin at index 1.
- Verified with `ninja` and symbol-level objdiff after build.
