### PR TITLE
p_usb: improve __sinit_p_usb_cpp symbol setup match

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -11,9 +11,9 @@ int DAT_8032ec68;
 
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
-extern void* __vt__8CManager;
-extern void* lbl_801E8668;
-extern void* lbl_801E8830;
+extern void* __vt__8CManager[];
+extern void* lbl_801E8668[];
+extern void* lbl_801E8830[];
 extern u32 lbl_801E8690[];
 extern u32 lbl_801E869C[];
 extern u32 lbl_801E86A8[];
@@ -246,9 +246,9 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 extern "C" void __sinit_p_usb_cpp()
 {
     volatile void** base = (volatile void**)&USBPcs;
-    *base = &__vt__8CManager;
-    *base = &lbl_801E8668;
-    *base = &lbl_801E8830;
+    *base = __vt__8CManager;
+    *base = lbl_801E8668;
+    *base = lbl_801E8830;
 
     u32* dst = lbl_801E86B4 + 1;
     u32* src0 = lbl_801E8690;


### PR DESCRIPTION
## Summary
- Adjusted `src/p_usb.cpp` extern symbol declarations used by `__sinit_p_usb_cpp` from scalar pointer declarations to array-form declarations.
- Updated the three vtable/base assignments in `__sinit_p_usb_cpp` to assign symbol addresses via array decay (`symbol`) instead of explicit address-of (`&symbol`).
- Kept behavior identical; this change only affects emitted relocation/addressing form.

## Functions improved
- Unit: `main/p_usb`
- Function: `__sinit_p_usb_cpp`
  - Before: `73.90909%` (size `160`)
  - After: `75.27273%` (size `176`)

## Match evidence
- Baseline measured from `origin/main` build with `build/tools/objdiff-cli diff -p . -u main/p_usb -o -`.
- Post-change measured with the same command.
- Other tracked functions in this unit remained unchanged in match:
  - `mccReadData__7CUSBPcsFv`: `80.55556%`
  - `SendDataCode__7CUSBPcsFiPvii`: `84.150375%`

## Plausibility rationale
- Array-form extern declarations for linker symbols/vtables are used elsewhere in this codebase and are a plausible original source pattern.
- The init routine still performs the same base/vtable initialization and jump-table copying logic; no gameplay or runtime behavior was modified.

## Technical notes
- The improvement appears to come from producing closer relocation/address materialization in the `__sinit_p_usb_cpp` prologue and symbol stores.