### PR TITLE
main/pppYmDrawMdlTexAnm: improve destruct UV offset restore

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -102,8 +102,8 @@ void pppDestructYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmOf
         uvPairs = uvLayout->m_uvPairs;
         for (i = 0; i < (u32)uvLayout->m_uvCount; i++) {
             u32 frameU = frameIndex / work->m_tilesU;
-            uvPairs[0] = (s16)(-((f32)(frameIndex - frameU * work->m_tilesU) * work->m_perU) - (f32)uvPairs[0]);
-            uvPairs[1] = (s16)(-((f32)frameU * work->m_perV) - (f32)uvPairs[1]);
+            uvPairs[0] = (s16)((f32)uvPairs[0] - ((f32)(frameIndex - frameU * work->m_tilesU) * work->m_perU));
+            uvPairs[1] = (s16)((f32)uvPairs[1] - ((f32)frameU * work->m_perV));
             uvPairs += 2;
         }
 


### PR DESCRIPTION
## Summary
- Updated `pppDestructYmDrawMdlTexAnm` UV restoration expressions to subtract frame offsets from the current UV pair values.
- Kept control flow, data accesses, and flushing behavior unchanged.

## Functions improved
- Unit: `main/pppYmDrawMdlTexAnm`
- Symbol: `pppDestructYmDrawMdlTexAnm` (PAL size 328b)

## Match evidence
- `pppDestructYmDrawMdlTexAnm`: **62.0488% -> 71.9878%** (`build/tools/objdiff-cli diff -p . -u main/pppYmDrawMdlTexAnm -o - pppDestructYmDrawMdlTexAnm`)
- `pppConstructYmDrawMdlTexAnm`: unchanged at **79.6076%**

## Plausibility rationale
- The revised arithmetic matches expected source intent for destructor rollback of animated UV offsets: restore by subtracting accumulated frame displacement from current UV coordinates.
- This is straightforward source logic, not compiler-coaxing (no artificial temporaries/reordering).

## Technical details
- Replaced:
  - `-offset - current`
- With:
  - `current - offset`
- This reduced instruction-level divergence in the destructor while preserving function size and surrounding behavior.
