### PR TITLE
prgobj: restore virtual state dispatch for state transitions

### DIFF
--- a/include/ffcc/charaobj.h
+++ b/include/ffcc/charaobj.h
@@ -41,7 +41,7 @@ public:
 	void damageDelete();
 	void onHit(int, CGObject*, int, Vec*);
 	void onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*);
-	void getReplaceStat(int);
+	int getReplaceStat(int);
 	void putHitParticleFromItem(CGPrgObj*, int);
 	void setSta(int, int);
 	void effective(int, int, CGPrgObj*, int&);

--- a/include/ffcc/partyobj.h
+++ b/include/ffcc/partyobj.h
@@ -45,7 +45,7 @@ public:
     void enableAttackCol(int, int, int);
     void enableDamageCol(int);
 
-    void getReplaceStat(int);
+    int getReplaceStat(int);
 
     void statCharge();
     void statAttackSel();

--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -17,12 +17,12 @@ public:
     void onFrameAlwaysAfter();
     void onDamaged(CGPrgObj*);
     void onAttacked(CGPrgObj*);
-    void onCancelStat(int);
-    void onChangeStat(int);
-    void onFramePreCalc();
-    void onFramePostCalc();
-    void onFrameStat();
-    void onChangePrg(int);
+    virtual void onCancelStat(int);
+    virtual void onChangeStat(int);
+    virtual void onFramePreCalc();
+    virtual void onFramePostCalc();
+    virtual void onFrameStat();
+    virtual void onChangePrg(int);
     void changeStat(int, int, int);
     void changeSubStat(int subState);
     void addSubStat();
@@ -35,7 +35,7 @@ public:
     void putParticle(int, int, CGObject*, float, int);
     void putParticleTrace(int, int, CGObject*, float, int);
     void putParticleBindTrace(int, int, CGObject*, float, int);
-    int getReplaceStat(int);
+    virtual int getReplaceStat(int);
     float getTargetRot(CGPrgObj*);
     void rotTarget(CGPrgObj*);
     void dstTargetRot(CGPrgObj*);

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -250,9 +250,10 @@ void CGCharaObj::onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*)
  * Address:	TODO
  * Size:	TODO
  */
-void CGCharaObj::getReplaceStat(int)
+int CGCharaObj::getReplaceStat(int state)
 {
 	// TODO
+	return state;
 }
 
 /*

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -175,9 +175,10 @@ void CGPartyObj::enableDamageCol(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CGPartyObj::getReplaceStat(int)
+int CGPartyObj::getReplaceStat(int state)
 {
 	// TODO
+	return state;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Restored polymorphic state-transition hooks in `CGPrgObj` by marking state-related hook methods as virtual.
- Corrected `getReplaceStat` declarations/definitions in derived classes to return `int` and return passthrough `state` in current TODO stubs.
- This aligns `CGPrgObj::changeStat` call sites with virtual dispatch behavior seen in target assembly.

## Functions improved
Unit: `main/prgobj`
- `changeStat__8CGPrgObjFiii`: **37.02439% -> 85.04878%**
- `onFrame__8CGPrgObjFv`: **41.008% -> 50.024%**
- `ClassControl__8CGPrgObjFii`: **58.896553% -> 89.954025%**

## Match evidence
Measured via:
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - changeStat__8CGPrgObjFiii`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - onFrame__8CGPrgObjFv`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - ClassControl__8CGPrgObjFii`

Observed assembly alignment changes:
- `changeStat` moved from direct/non-polymorphic style toward vtable-mediated calls and now tracks target flow much more closely.
- Related call-heavy functions (`onFrame`, `ClassControl`) also improved due to consistent method dispatch/signature behavior.

## Plausibility rationale
- These are source-level type and dispatch corrections, not instruction-level coaxing.
- Making state hooks virtual in a gameplay object hierarchy is consistent with expected original design.
- Returning `int` from derived `getReplaceStat` matches base-class API and intended state remap semantics.

## Build validation
- `ninja` passes after changes.
