### PR TITLE
main/cflat_runtime2: improve SetParticleWorkParam match

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -704,10 +704,10 @@ void CFlatRuntime2::SetParticleWorkBind(CFlatRuntime::CObject* object)
 void CFlatRuntime2::SetParticleWorkParam(int paramNo, CFlatRuntime::CObject* object)
 {
 	ParticleWorkParamNo(this) = paramNo;
-	if (object == 0) {
-		ParticleWorkParamId(this) = 0;
-	} else {
+	if (object != 0) {
 		ParticleWorkParamId(this) = *reinterpret_cast<short*>(reinterpret_cast<u8*>(object) + 0x30);
+	} else {
+		ParticleWorkParamId(this) = 0;
 	}
 }
 


### PR DESCRIPTION
## Summary
Adjusted `CFlatRuntime2::SetParticleWorkParam` control flow to test `object != 0` first, preserving behavior while matching expected branch layout more closely.

## Functions Improved
- Unit: `main/cflat_runtime2`
- Symbol: `SetParticleWorkParam__13CFlatRuntime2FiPQ212CFlatRuntime7CObject`
  - Before: `36.25%`
  - After: `80.0%`

## Match Evidence
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - SetParticleWorkParam__13CFlatRuntime2FiPQ212CFlatRuntime7CObject`
  - Branch/opcode alignment improved from mixed delete/insert around null handling to a mostly aligned sequence.
- Unit `.text` match also improved:
  - Before: `3.4274273%`
  - After: `3.4958%`

## Plausibility Rationale
This is a natural source-level form of null handling (`if (object != 0) { ... } else { ... }`) and avoids artificial compiler-coaxing constructs. The change keeps semantics identical while improving assembly alignment.

## Technical Notes
- Build: `ninja` passes.
- The remaining mismatch in this function is now a small branch replacement near the store path, indicating substantially closer control-flow shape.
