### PR TITLE
cflat_r2system: match SetWorldMapMatrix and CVector op wrapper

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -761,6 +761,34 @@ extern "C" void __ct__14PPPCREATEPARAMFv2(PPPCREATEPARAM* pppCreateParam)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B95AC
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __opR3Vec__7CVectorFv(void)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B95B0
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetWorldMapMatrix__10CCameraPcsFPA4_f(void* camera, Mtx matrix)
+{
+    PSMTXCopy(matrix, (MtxPtr)((char*)camera + 0x34));
+    PSMTXInverse(matrix, (MtxPtr)((char*)camera + 0x64));
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added two missing PAL symbols in `main/cflat_r2system` using existing source style and ABI-compatible wrappers:
  - `__opR3Vec__7CVectorFv`
  - `SetWorldMapMatrix__10CCameraPcsFPA4_f`
- Implemented `SetWorldMapMatrix` with direct matrix copy + inverse at the known camera offsets (`+0x34`, `+0x64`).
- Added version info headers for both functions.

## Functions improved
- `__opR3Vec__7CVectorFv` (PAL `0x800B95AC`, 4b)
- `SetWorldMapMatrix__10CCameraPcsFPA4_f` (PAL `0x800B95B0`, 76b)

## Match evidence
- `objdiff` (`build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - __opR3Vec__7CVectorFv`):
  - `__opR3Vec__7CVectorFv`: `0.0% -> 100.0%`
  - `SetWorldMapMatrix__10CCameraPcsFPA4_f`: `0.0% -> 100.0%`
- Project progress after rebuild (`ninja`):
  - Code bytes matched: `203,908 -> 203,988` (`+80`)
  - Matched functions: `1,545 -> 1,547` (`+2`)

## Plausibility rationale
- Both changes are straightforward low-level wrappers consistent with surrounding `cflat_r2system.cpp` patterns (raw symbol wrappers, offset-based member access).
- The matrix operations (`PSMTXCopy`, `PSMTXInverse`) and offsets are directly aligned with recovered function behavior.
- No contrived control-flow or compiler-coaxing transformations were introduced.

## Technical details
- Kept signatures in explicit symbol form (`extern "C"` + exact symbol names) to ensure correct symbol emission in this unit.
- Verified final assembly match via targeted `objdiff` symbol checks after rebuild.
