### PR TITLE
main/cflat_runtime2: implement resetSpawnBit and ResetNewGame

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/cflat_runtime2.h"
 #include "ffcc/baseobj.h"
 #include "ffcc/p_game.h"
+#include <string.h>
 
 template <int count>
 class CLine;
@@ -819,12 +820,26 @@ void CFlatRuntime2::GetSysControl(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006FA68
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::resetSpawnBit(int)
+void CFlatRuntime2::resetSpawnBit(int spawnBit)
 {
-	// TODO
+	if (spawnBit == -1) {
+		memset(reinterpret_cast<u8*>(this) + 0x12F0, 0, 0x48);
+		return;
+	}
+	if (spawnBit < 0 || spawnBit > 8) {
+		return;
+	}
+
+	u8* ptr = reinterpret_cast<u8*>(this) + (spawnBit << 3);
+	*reinterpret_cast<int*>(ptr + 0x12F4) = 0;
+	*reinterpret_cast<int*>(ptr + 0x12F0) = 0;
 }
 
 /*
@@ -839,10 +854,15 @@ void CFlatRuntime2::resetChangeScript()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006F850
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CFlatRuntime2::ResetNewGame()
 {
-	// TODO
+	resetChangeScript();
+	memset(reinterpret_cast<u8*>(this) + 0x12F0, 0, 0x48);
 }


### PR DESCRIPTION
## Summary
- Implemented `CFlatRuntime2::resetSpawnBit(int)` using the expected spawn-bit slot reset behavior:
  - full-table clear for `-1`
  - bounds check for valid slots
  - per-slot pair clear for valid indices
- Implemented `CFlatRuntime2::ResetNewGame()` to call `resetChangeScript()` and clear the spawn-bit table region.
- Updated function metadata blocks with PAL address/size for both implemented functions.

## Functions Improved
Unit: `main/cflat_runtime2` (`src/cflat_runtime2.cpp`)
- `resetSpawnBit__13CFlatRuntime2Fi`
- `ResetNewGame__13CFlatRuntime2Fv`

## Match Evidence
Symbol-level objdiff results:
- `resetSpawnBit__13CFlatRuntime2Fi`: **4.347826% -> 93.91304%**
- `ResetNewGame__13CFlatRuntime2Fv`: **6.6666665% -> 51.266666%**

Notes from current objdiff:
- `resetSpawnBit` now has the correct main control flow and memory-clear pattern; remaining delta is small (current size 96 vs target 92).
- `ResetNewGame` now performs the expected reset call + table clear, but remains partial because `resetChangeScript` is still a TODO stub in this unit, which alters the call/prologue shape.

## Plausibility Rationale
These changes represent straightforward gameplay runtime state-reset code, using normal control flow and table clearing via `memset`/slot writes. The implementation follows the existing coding style in this unit (offset-based runtime work fields) and avoids contrived compiler-coaxing constructs.

## Technical Details
- Derived exact target behavior from symbol-scoped objdiff disassembly for `main/cflat_runtime2`.
- Chose two small, high-gap TODO stubs to get measurable assembly alignment in one iteration.
- Kept edits localized to `src/cflat_runtime2.cpp` and validated with a full `ninja` build.
