### PR TITLE
partMng: implement __sinit_partMng_cpp

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -7,6 +7,10 @@
 extern "C" void __dl__FPv(void* ptr);
 extern "C" void pppPartInit__8CPartMngFv2(CPartMng* partMng);
 extern "C" unsigned int CheckSum__FPvi(void*, int);
+extern "C" void __ct__9_pppMngStFv(_pppMngSt* pppMngSt);
+extern "C" void __construct_array(void*, void (*)(void*), void (*)(void*, int), unsigned long, unsigned long);
+extern CPartMng PartMng;
+extern PPPCREATEPARAM g_dcp;
 static char s_partMng_cpp_801d8230[] = "partMng.cpp";
 
 struct CPtrArrayBare {
@@ -1061,6 +1065,45 @@ void CPartMng::pppDeleteAll()
 void CPartMng::pppDestroyAll()
 {
 	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8005f624
+ * PAL Size: 184b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_partMng_cpp(void)
+{
+    __construct_array(reinterpret_cast<unsigned char*>(&PartMng) + 0x2A18, (void (*)(void*))__ct__9_pppMngStFv, 0,
+                      sizeof(_pppMngSt), 0x180);
+
+    g_dcp.m_soundEffectParams.m_soundEffectHandle = -1;
+    g_dcp.m_soundEffectParams.m_soundEffectSlot = -1;
+    g_dcp.m_soundEffectParams.m_soundEffectStopFlag = 0;
+    g_dcp.m_soundEffectParams.m_soundEffectKind = 1;
+    g_dcp.m_soundEffectParams.m_soundEffectStartFrame = 0;
+    g_dcp.m_soundEffectParams.m_soundEffectStartedOnce = 0;
+    g_dcp.m_soundEffectParams.m_soundEffectFadeFrames = 30;
+    g_dcp.m_hitParamA = 0;
+    g_dcp.m_hitParamB = 0;
+    g_dcp.m_hitObjectCount = 0;
+    g_dcp.m_hitFlags = 0;
+    g_dcp.m_positionOffsetPtr = 0;
+    g_dcp.m_rotationPtr = 0;
+    g_dcp.m_scalePtr = 0;
+    g_dcp.m_extraPositionPtr = 0;
+    g_dcp.m_paramA = 0;
+    g_dcp.m_paramB = 0;
+    g_dcp.m_lookTargetPtr = 0;
+    g_dcp.m_objectHitMask = 0;
+    g_dcp.m_cylinderAttribute = 0;
+    g_dcp.m_paramC = 1.0f;
+    g_dcp.m_paramD = 1.0f;
+    g_dcp.m_owner = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added `__sinit_partMng_cpp` in `src/partMng.cpp` using the PAL decomp initialization sequence.
- Added the required runtime/global declarations used by the initializer (`__construct_array`, `PartMng`, `g_dcp`, `__ct__9_pppMngStFv`).
- Initialized the `_pppMngSt` array storage under `PartMng` and defaulted `g_dcp` fields (sound params, hit params, pointers, scalar defaults).

## Functions improved
- Unit: `main/partMng`
- Symbol: `__sinit_partMng_cpp`
  - Before: not mapped in current object (`target_symbol=null`, effectively 0% function match)
  - After: `89.54348%` match

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/partMng -o - __sinit_partMng_cpp`
- `main/partMng` `.text` match moved from `3.3717227%` to `3.8763783%`.
- The symbol transitioned from missing/unpaired to a paired code symbol with substantial instruction alignment.

## Plausibility rationale
- This change reconstructs expected static-initialization behavior for `partMng.o` (array constructor + default create-parameter setup), which is a normal source-level pattern for this codebase and toolchain.
- No compiler-coaxing temporaries or artificial control-flow shaping were introduced.

## Technical details
- Used `__construct_array` over `PartMng`'s `_pppMngSt` storage (`+0x2A18`, count `0x180`, element size `sizeof(_pppMngSt)`), matching known layout usage in existing code.
- Mirrored the constructor defaults from decomp for sound/hit/create parameter fields to bring emitted init code close to target.
