### PR TITLE
gx: improve __GXXfVtxSpecs match in GXAttr

### DIFF
--- a/src/gx/GXAttr.c
+++ b/src/gx/GXAttr.c
@@ -15,22 +15,29 @@
 #define CHECK_LISTPTR(line, list)    ASSERTMSGLINE(line, (list) != NULL, "GXSetVtxAttrFmt: list pointer is NULL")
 #define CHECK_MTXIDX(line, attr, type)    ASSERTMSGLINE(line, (attr) > GX_VA_TEX7MTXIDX || (type) <= GX_VA_TEX0MTXIDX, "GXSetVtxDesc: GX_VA_*MTXIDX accepts GX_NONE or GX_DIRECT only")
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A0B10
+ * PAL Size: 344b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 static void __GXXfVtxSpecs(void) {
     u32 nCols;
-    u32 nNrm;
+    s32 nNrm;
     u32 nTex;
     u32 reg;
     u32 vcdHi;
     u32 vcdLo;
 
-    if (__GXData->hasBiNrms == 0) {
-        if (__GXData->hasNrms == 0) {
-            nNrm = 0;
-        } else {
-            nNrm = 1;
-        }
-    } else {
+    if (__GXData->hasBiNrms != 0) {
         nNrm = 2;
+    } else if (__GXData->hasNrms != 0) {
+        nNrm = 1;
+    } else {
+        nNrm = 0;
     }
 
     vcdHi = __GXData->vcdHi;


### PR DESCRIPTION
## Summary
- Updated `__GXXfVtxSpecs` in `src/gx/GXAttr.c` to better match original control-flow/codegen by:
  - switching `nNrm` to signed (`s32`)
  - rewriting nested zero-comparison branches into an ordered `if / else if / else` chain on `hasBiNrms` and `hasNrms`
- Added the required function info block with PAL address/size metadata.

## Functions Improved
- Unit: `main/gx/GXAttr`
- Symbol: `__GXXfVtxSpecs`

## Match Evidence
- `__GXXfVtxSpecs`: **46.744186% -> 50.081394%** (`+3.337208`)
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXAttr -o - __GXXfVtxSpecs`
- Neighbor checks (unchanged):
  - `GXSetVtxDesc`: `62.877357%`
  - `GXSetVtxAttrFmtv`: `58.833332%`

## Plausibility Rationale
- The change is source-plausible and idiomatic C for SDK-style state selection (`bi-normal > normal > none`).
- No compiler-coaxing temporaries, hardcoded offsets, or unnatural sequencing were introduced.
- Runtime behavior is preserved while improving generated assembly alignment.

## Technical Notes
- Build passes with `ninja` (`build/GCCP01/main.dol: OK` path remains in normal verified build flow).
- Improvement is localized to control-flow shape in one function.
