### PR TITLE
THPSimple: improve MixAudio volume-update control flow matching

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -775,7 +775,6 @@ s32 THPSimpleDrawCurrentFrame(GXRenderModeObj* obj, int x, int y, int polyWidth,
 void MixAudio(short* output, short* input, unsigned long samples)
 {
     u16 volume;
-    f32 nextVolume;
     s32 mixedSample;
     s16* audioPtr;
     u32 availableSamples;
@@ -799,12 +798,12 @@ void MixAudio(short* output, short* input, unsigned long samples)
 
                 audioPtr = SimpleControl.audioBuffer[playIndex].mCurPtr;
                 for (i = availableSamples; i != 0; i--) {
-                    nextVolume = SimpleControl.unk_C8;
                     if (SimpleControl.unk_D0 != 0) {
                         SimpleControl.unk_D0 -= 1;
-                        nextVolume = SimpleControl.unk_C4 + SimpleControl.unk_CC;
+                        SimpleControl.unk_C4 = SimpleControl.unk_C4 + SimpleControl.unk_CC;
+                    } else {
+                        SimpleControl.unk_C4 = SimpleControl.unk_C8;
                     }
-                    SimpleControl.unk_C4 = nextVolume;
                     volume = lbl_802111E8[static_cast<s32>(SimpleControl.unk_C4)];
 
                     mixedSample = static_cast<s32>((static_cast<u32>(volume) * static_cast<s32>(*audioPtr)) >> 15);
@@ -856,12 +855,12 @@ void MixAudio(short* output, short* input, unsigned long samples)
 
             audioPtr = SimpleControl.audioBuffer[playIndex].mCurPtr;
             for (i = availableSamples; i != 0; i--) {
-                nextVolume = SimpleControl.unk_C8;
                 if (SimpleControl.unk_D0 != 0) {
                     SimpleControl.unk_D0 -= 1;
-                    nextVolume = SimpleControl.unk_C4 + SimpleControl.unk_CC;
+                    SimpleControl.unk_C4 = SimpleControl.unk_C4 + SimpleControl.unk_CC;
+                } else {
+                    SimpleControl.unk_C4 = SimpleControl.unk_C8;
                 }
-                SimpleControl.unk_C4 = nextVolume;
                 volume = lbl_802111E8[static_cast<s32>(SimpleControl.unk_C4)];
 
                 mixedSample = static_cast<s32>(*input) +


### PR DESCRIPTION
## Summary
- Refactored `MixAudio` volume fade updates to write `SimpleControl.unk_C4` directly in each branch.
- Removed the temporary `nextVolume` variable and used explicit `if/else` assignment flow in both mixing loops.
- Kept behavior intact and avoided contrived compiler-coaxing constructs.

## Functions Improved
- Unit: `main/THPSimple`
- Symbol: `MixAudio__FPsPsUl`

## Match Evidence
- `MixAudio__FPsPsUl`: **50.957745% -> 55.323944%** (size unchanged at 852 bytes)
- `MixAudio__FPsPsUl` instruction diff count: **214 -> 208**
- Unit `.text` match (`main/THPSimple`): **68.686905% -> 69.27514%** (size unchanged at 6324 bytes)

## Plausibility Rationale
- The updated code follows a natural source-level pattern for fade stepping:
  - decrement step counter when active,
  - apply incremental fade to current volume,
  - otherwise clamp to target/base volume.
- This is consistent with readable game-audio mixing code and not an artificial ordering trick.

## Technical Details
- The main mismatch cluster in objdiff was around volume-update branch sequencing and redundant temporary handling.
- Converting to direct `unk_C4` updates improved instruction alignment while preserving semantics in both input-null and input-mixing paths.
