### PR TITLE
texanim: improve CTexAnimSet::Create match with ctor-style refData init

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -56,6 +56,11 @@ extern double DOUBLE_8032fb40;
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
 static char s_ptrarray_grow_error[] = "CPtrArray grow error";
 
+inline void* operator new(unsigned long, void* p)
+{
+    return p;
+}
+
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)
 {
@@ -591,13 +596,7 @@ void CTexAnimSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
             if (refData != 0) {
                 __ct__4CRefFv(refData);
                 *reinterpret_cast<void**>(refData) = &PTR_PTR_s_CTexAnim_CRefData_801e9c3c;
-                CPtrArray<CTexAnimSeq*>* const seqs = reinterpret_cast<CPtrArray<CTexAnimSeq*>*>(Ptr(refData, 0x110));
-                seqs->m_size = 0;
-                seqs->m_numItems = 0;
-                seqs->m_defaultSize = 0x10;
-                seqs->m_items = 0;
-                seqs->m_stage = 0;
-                seqs->m_growCapacity = 1;
+                new (Ptr(refData, 0x110)) CPtrArray<CTexAnimSeq*>();
                 *reinterpret_cast<void**>(Ptr(refData, 0x108)) = 0;
                 S32At(refData, 0x10C) = 0;
             }


### PR DESCRIPTION
## Summary
- Update `CTexAnimSet::Create` in `src/texanim.cpp` to initialize the embedded `CPtrArray<CTexAnimSeq*>` via constructor-style initialization instead of field-by-field assignment.
- Keep behavior identical: the same fields are initialized and subsequent `SetStage`/chunk parsing flow is unchanged.

## Functions improved
- Unit: `main/texanim`
- `Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage`
  - Before: `0.0%`
  - After: `0.43555555%`

## Match evidence
- Built with `ninja` successfully after the change.
- `objdiff` oneshot check:
  - Command: `build/tools/objdiff-cli diff -p . -u main/texanim -o - Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage`
  - Parsed symbol match:
    - `Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage`: `0.0% -> 0.43555555%`
    - `Duplicate__11CTexAnimSetFPQ27CMemory6CStage`: `0.0% -> 0.0%` (unchanged)
    - `__ct__11CTexAnimSetFv`: unchanged at `37.63158%`

## Plausibility rationale
- The change is source-plausible for original game code: constructing an embedded pointer-array object is more idiomatic and consistent with other decomp/Ghidra patterns than manually writing each member field in-place.
- No contrived temporaries, hardcoded object offsets, or behavior changes were introduced.

## Technical details
- Added a local placement-`new` shim used only for constructor-style initialization in this TU.
- Replaced manual initialization block at `refData + 0x110` with:
  - `new (Ptr(refData, 0x110)) CPtrArray<CTexAnimSeq*>();`
- Left surrounding chunk logic and all reference-count operations untouched.
