### PR TITLE
pppKeShpTail2X: implement core trail/frame update path

### DIFF
--- a/include/ffcc/pppKeShpTail2X.h
+++ b/include/ffcc/pppKeShpTail2X.h
@@ -2,13 +2,16 @@
 #define _PPP_KESHPTAIL2X_H_
 
 struct pppFVECTOR4;
+struct _pppPObject;
+struct UnkB;
+struct UnkC;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppKeShpTail2X(void);
-void pppKeShpTail2XDraw(void);
+void pppKeShpTail2X(struct _pppPObject*, struct UnkB*, struct UnkC*);
+void pppKeShpTail2XDraw(struct _pppPObject*, struct UnkB*, struct UnkC*);
 void pppKeShpTail2XCon(void*, void*);
 void pppKeShpTail2XDes(void*, void*);
 void U8ToF32(pppFVECTOR4*, unsigned char*);

--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -1,6 +1,39 @@
 #include "ffcc/pppKeShpTail2X.h"
+#include "ffcc/partMng.h"
+#include "ffcc/pppPart.h"
 #include <dolphin/types.h>
 #include <string.h>
+
+extern int lbl_8032ED70;
+extern _pppMngSt* pppMngStPtr;
+extern _pppEnvSt* pppEnvStPtr;
+
+extern "C" {
+void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
+void pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(pppFMATRIX*, pppFMATRIX*, pppFMATRIX*);
+}
+
+struct KeShpTail2XStep {
+    u8 _pad0[4];
+    s32 m_dataValIndex;
+    s32 m_frameStep;
+    u8 _padC[0x1A];
+    u8 m_worldSpaceMode;
+};
+
+struct KeShpTail2XOffsets {
+    u8 _pad0[0xc];
+    s32* m_serializedDataOffsets;
+};
+
+struct KeShpTail2XWork {
+    u8 m_count;
+    u8 m_head;
+    u16 m_frameAcc;
+    u16 m_shapeFrame;
+    u16 m_shapePrevFrame;
+    Vec m_posHistory[31];
+};
 
 /*
  * --INFO--
@@ -11,9 +44,90 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail2X(void)
+void pppKeShpTail2X(_pppPObject* obj, UnkB* param_2, UnkC* param_3)
 {
-	// TODO
+    KeShpTail2XStep* step;
+    KeShpTail2XWork* work;
+    Vec pos;
+
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
+
+    step = (KeShpTail2XStep*)param_2;
+    work = (KeShpTail2XWork*)((u8*)obj + 0x80 + ((KeShpTail2XOffsets*)param_3)->m_serializedDataOffsets[0]);
+
+    if (obj->m_graphId == 0) {
+        if (step->m_worldSpaceMode == 0) {
+            pos.x = obj->m_localMatrix.value[0][3];
+            pos.y = obj->m_localMatrix.value[1][3];
+            pos.z = obj->m_localMatrix.value[2][3];
+        } else if (step->m_worldSpaceMode == 1) {
+            pppFMATRIX local;
+            pppFMATRIX world;
+            pppFMATRIX out;
+
+            local = obj->m_localMatrix;
+            world = pppMngStPtr->m_matrix;
+            pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&out, &world, &local);
+            pos.x = out.value[0][3];
+            pos.y = out.value[1][3];
+            pos.z = out.value[2][3];
+        }
+
+        for (u8 i = 0; i < work->m_count; i++) {
+            pppCopyVector__FR3Vec3Vec(&work->m_posHistory[i], &pos);
+        }
+    }
+
+    if (work->m_head == 0) {
+        work->m_head = work->m_count;
+    }
+    work->m_head--;
+
+    if (step->m_worldSpaceMode == 0) {
+        pos.x = obj->m_localMatrix.value[0][3];
+        pos.y = obj->m_localMatrix.value[1][3];
+        pos.z = obj->m_localMatrix.value[2][3];
+    } else if (step->m_worldSpaceMode == 1) {
+        pppFMATRIX local;
+        pppFMATRIX world;
+        pppFMATRIX out;
+
+        local = obj->m_localMatrix;
+        world = pppMngStPtr->m_matrix;
+        pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&out, &world, &local);
+        pos.x = out.value[0][3];
+        pos.y = out.value[1][3];
+        pos.z = out.value[2][3];
+    }
+
+    pppCopyVector__FR3Vec3Vec(&work->m_posHistory[work->m_head], &pos);
+
+    {
+        long* shape = *(long**)(*(u32*)&pppEnvStPtr->m_particleColors[0] + step->m_dataValIndex * 4);
+        u8* frameEntry;
+        s16 frameDuration;
+
+        work->m_shapePrevFrame = work->m_shapeFrame;
+        frameEntry = (u8*)shape + ((u32)work->m_shapeFrame << 3) + 0x10;
+
+        work->m_frameAcc = (u16)(work->m_frameAcc + (u16)step->m_frameStep);
+        frameDuration = *(s16*)(frameEntry + 2);
+        if (work->m_frameAcc >= (u16)frameDuration) {
+            work->m_frameAcc = (u16)(work->m_frameAcc - (u16)frameDuration);
+            work->m_shapeFrame++;
+            if (work->m_shapeFrame >= (u16)*(s16*)((u8*)shape + 6)) {
+                if ((frameEntry[4] & 0x80) != 0) {
+                    work->m_shapeFrame = 0;
+                    work->m_frameAcc = 0;
+                } else {
+                    work->m_frameAcc = 0;
+                    work->m_shapeFrame--;
+                }
+            }
+        }
+    }
 }
 
 /*
@@ -25,7 +139,7 @@ void pppKeShpTail2X(void)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail2XDraw(void)
+void pppKeShpTail2XDraw(_pppPObject*, UnkB*, UnkC*)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Implemented pppKeShpTail2X in src/pppKeShpTail2X.cpp from current target assembly behavior instead of leaving it as a TODO stub.
- Added local work/step/offset structs for serialized tail state access and frame progression.
- Updated declarations in include/ffcc/pppKeShpTail2X.h so pppKeShpTail2X/pppKeShpTail2XDraw use object/step/offset arguments.

## Functions Improved
- Unit: main/pppKeShpTail2X
- Symbol: pppKeShpTail2X

## Match Evidence
- pppKeShpTail2X: 0.4032258% -> 75.44355% (build/tools/objdiff-cli diff -p . -u main/pppKeShpTail2X -o - pppKeShpTail2X)
- pppKeShpTail2XDraw: unchanged at 0.22271715%
- Build check: ninja succeeds after the change.

## Plausibility Rationale
- The implementation follows existing ppp patterns already used across this repo:
  - object local-vs-world matrix position selection
  - history buffer updates via pppCopyVector
  - shape table frame advance with per-frame duration and loop-flag handling
- No artificial coercion patterns were introduced (no contrived volatile/temp tricks, no hardcoded asm comments).

## Technical Details
- Reconstructed key behaviors from target instruction flow:
  - lbl_8032ED70 early-out guard
  - serialized work lookup through serializedDataOffsets[0]
  - initial history fill when graph id is zero
  - ring-style head decrement and current-position write
  - frame accumulator and shape-frame stepping against shape-table duration/loop flags
