### PR TITLE
main/map: add missing CMapAnimKeyDt CPtrArray specializations

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -375,6 +375,36 @@ int CPtrArray<CMapAnimKeyDt*>::GetSize()
 
 /*
  * --INFO--
+ * PAL Address: 0x800341ac
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapAnimKeyDt* CPtrArray<CMapAnimKeyDt*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800341cc
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapAnimKeyDt*>::SetStage(CMemory::CStage* stage)
+{
+    m_stage = stage;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x80034160
  * PAL Size: 76b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray<CMapAnimKeyDt*>` specializations in `src/map.cpp` for:
  - `operator[](unsigned long)`
  - `SetStage(CMemory::CStage*)`
- Added PAL metadata blocks for both functions using the exported addresses/sizes.

## Functions improved
- Unit: `main/map`
- `__vc__27CPtrArray<P13CMapAnimKeyDt>FUl`
- `SetStage__27CPtrArray<P13CMapAnimKeyDt>FPQ27CMemory6CStage`

## Match evidence
- Selector baseline (before):
  - `__vc__27CPtrArray<P13CMapAnimKeyDt>FUl`: `0.0%`
  - `SetStage__27CPtrArray<P13CMapAnimKeyDt>FPQ27CMemory6CStage`: `0.0%`
- Objdiff after change:
  - `__vc__27CPtrArray<P13CMapAnimKeyDt>FUl`: `100.0%`
  - `SetStage__27CPtrArray<P13CMapAnimKeyDt>FPQ27CMemory6CStage`: `99.5%`

## Plausibility rationale
- These are standard `CPtrArray` member specializations already used consistently in this codebase for other pointer element types.
- Implementations are idiomatic and minimal (`operator[]` forwarding to `GetAt`, `SetStage` assigning `m_stage`), which is consistent with neighboring matched specializations.

## Technical details
- Ghidra reference for `__vc__` indicates a direct call to `GetAt` in a 32-byte wrapper, matching the specialization pattern used elsewhere.
- Ghidra reference for `SetStage` indicates a direct stage pointer assignment in an 8-byte body.
- Build verified with `ninja` and targeted symbol checks via `build/tools/objdiff-cli diff -p . -u main/map -o - <symbol>`.
