### PR TITLE
THPSimple: improve THPSimpleCalcNeedMemory match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -298,18 +298,14 @@ s32 THPSimpleClose(void)
  */
 s32 THPSimpleCalcNeedMemory(void)
 {
-    s32 need;
-    s32 framePixels;
-
     if (SimpleControl.isOpen == 0) {
         return 0;
     }
 
-    framePixels = static_cast<s32>(SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize);
-    need = ((SimpleControl.header.mBufferSize + 0x1F) * 8) & ~0xFF;
-    need += (framePixels + 0x1F) & ~0x1F;
-    need += (((u32)framePixels >> 2) + 0x1F) & ~0x1F;
-    need += (((u32)framePixels >> 2) + 0x1F) & ~0x1F;
+    s32 need = ((SimpleControl.header.mBufferSize + 0x1F) * 8) & ~0xFF;
+    need += (SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize + 0x1F) & ~0x1F;
+    need += (((SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize) >> 2) + 0x1F) & ~0x1F;
+    need += (((SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize) >> 2) + 0x1F) & ~0x1F;
 
     if (SimpleControl.hasAudio != 0) {
         need += ((SimpleControl.header.mAudioMaxSamples * 4 + 0x1F) & ~0x1F) * 3;


### PR DESCRIPTION
## Summary
- Reworked `THPSimpleCalcNeedMemory` in `src/THPSimple.cpp` to use expression flow closer to the original output.
- Removed the temporary `framePixels` accumulation path and switched to direct repeated `mXSize * mYSize` terms in the size calculation.
- Kept behavior unchanged while improving instruction-level alignment.

## Functions improved
- Unit: `main/THPSimple`
- Symbol: `THPSimpleCalcNeedMemory`
- Size: `128b`

## Match evidence
- `THPSimpleCalcNeedMemory`: **81.5625% -> 84.0625%**
- `ninja` build completed successfully after the change.
- Unit-level check showed no regressions in other `main/THPSimple` symbols.
- Diff detail: `DIFF_ARG_MISMATCH` entries for this function dropped from **11 -> 0** in objdiff output.

## Plausibility rationale
- The new shape is a straightforward memory-size computation and remains idiomatic game/source code.
- This is not compiler-only tricking: the change simplifies control/data flow and matches a plausible original expression style for aggregate size math.

## Technical details
- Baseline and after were measured with:
  - `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPSimpleCalcNeedMemory`
- Final code path computes:
  - buffer size contribution,
  - luma/chroma frame contributions,
  - optional audio contribution,
  - final page alignment addend (`+0x1000`).
