### PR TITLE
TRK: improve TRK__read_aram match with inline dcbi helper

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -217,6 +217,13 @@ static asm void dataCacheBlockInvalidate(register void* param_1)
 #endif // clang-format on
 }
 
+static inline void dataCacheBlockInvalidateInline(register void* param_1)
+{
+#ifdef __MWERKS__
+	asm { dcbi 0, param_1 }
+#endif
+}
+
 static asm void dataCacheBlockFlush(register void* param_1)
 {
 #ifdef __MWERKS__ // clang-format off
@@ -351,14 +358,14 @@ void TRK__read_aram(u32 param_1, u32 param_2, u32* param_3)
 		uVar7 = uVar2;
 		if (uVar6 != 0) {
 			do {
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0x20));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0x40));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0x60));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0x80));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0xA0));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0xC0));
-				dataCacheBlockInvalidate((void*)(param_1 + iVar5 + 0xE0));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0x20));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0x40));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0x60));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0x80));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0xA0));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0xC0));
+				dataCacheBlockInvalidateInline((void*)(param_1 + iVar5 + 0xE0));
 				iVar5 += 0x100;
 				uVar6--;
 			} while (uVar6 != 0);
@@ -369,7 +376,7 @@ void TRK__read_aram(u32 param_1, u32 param_2, u32* param_3)
 			}
 		}
 		do {
-			dataCacheBlockInvalidate((void*)(param_1 + iVar5));
+			dataCacheBlockInvalidateInline((void*)(param_1 + iVar5));
 			iVar5 += 0x20;
 			uVar7--;
 		} while (uVar7 != 0);


### PR DESCRIPTION
## Summary
- Added a read-path-only inline helper `dataCacheBlockInvalidateInline` that emits `dcbi` via inline asm.
- Switched `TRK__read_aram` cache invalidation calls to this helper.
- Kept existing `dataCacheBlockInvalidate` asm function for other call sites unchanged.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk`
- `TRK__read_aram`: **58.57143% -> 65.94805%** (+7.37662)
- `TRK__write_aram`: **67.138214% -> 67.138214%** (unchanged)

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - TRK__read_aram`
  - `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - TRK__write_aram`
- `TRK__read_aram` improved while preserving ARAM status polling and DMA call sequence.

## Plausibility rationale
- Behavior/source intent is unchanged: the ARAM read path still invalidates cache lines before DMA.
- Change is localized to invalidation emission style in the read path, not algorithmic logic.
- Retaining the original helper for non-read paths avoids broad compiler-coaxing side effects.
