### PR TITLE
pppMana2: first-pass decomp for RenderWaterMesh

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -9,6 +9,20 @@ extern float FLOAT_803318fc;
 extern "C" {
 void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
 int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
+void _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(int, int, int, int);
+void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(int, int,
+                                                                                                            int, int,
+                                                                                                            int);
+void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int,
+                                                                                            int);
+void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(int, int,
+                                                                                                            int, int,
+                                                                                                            int);
+void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int,
+                                                                                            int);
+void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 }
 
 /*
@@ -267,12 +281,124 @@ void UpdateWaterMesh(VMana2*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80106694
+ * PAL Size: 1472b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void RenderWaterMesh(VMana2*)
+void RenderWaterMesh(VMana2* mana2)
 {
-	// TODO
+    u8* work = (u8*)mana2;
+    u16* indices = *(u16**)(work + 0x50);
+    void* texObj0 = *(void**)(work + 0x28);
+    void* texObj1 = *(void**)(work + 0x2C);
+    void* texObj2 = (u8*)*(void**)(work + 0x7C) + 0x28;
+    _GXColor modulateColor;
+    _GXColor blendColor = {0x80, 0x80, 0x80, 0x80};
+
+    GXClearVtxDesc();
+    GXSetVtxDesc((GXAttr)9, GX_INDEX16);
+    GXSetVtxDesc((GXAttr)10, GX_INDEX16);
+    GXSetVtxDesc((GXAttr)0xB, GX_INDEX16);
+    GXSetVtxDesc((GXAttr)0xD, GX_INDEX16);
+    GXSetVtxDesc((GXAttr)0xE, GX_INDEX16);
+    GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)9, (GXCompCnt)1, (GXCompType)4, 0);
+    GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)10, (GXCompCnt)0, (GXCompType)4, 0);
+    GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)0xB, (GXCompCnt)1, (GXCompType)5, 0);
+    GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)0xD, (GXCompCnt)1, (GXCompType)4, 0);
+    GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)0xE, (GXCompCnt)1, (GXCompType)4, 0);
+    GXSetNumTexGens(2);
+    GXSetCullMode((GXCullMode)0);
+    _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 4, 5, 0xF);
+    GXSetChanCtrl((GXChannelID)4, GX_DISABLE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_SPOT);
+    GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_DISABLE);
+    GXSetNumChans(1);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 0);
+    GXSetArray((GXAttr)9, *(void**)(work + 0x3C), 0xC);
+    GXSetArray((GXAttr)10, *(void**)(work + 0x40), 0xC);
+    GXSetArray((GXAttr)0xB, *(void**)(work + 0x5C), 4);
+    GXSetArray((GXAttr)0xD, *(void**)(work + 0x54), 8);
+    GXSetArray((GXAttr)0xE, *(void**)(work + 0x58), 8);
+    GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);
+    GXSetTexCoordGen2((GXTexCoordID)1, (GXTexGenType)1, (GXTexGenSrc)5, 0x3C, GX_FALSE, 0x7D);
+    modulateColor.r = *(u8*)(work + 0xE0);
+    modulateColor.g = modulateColor.r;
+    modulateColor.b = modulateColor.r;
+    modulateColor.a = modulateColor.r;
+
+    GXSetTevDirect((GXTevStageID)0);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
+    GXLoadTexObj((GXTexObj*)texObj2, GX_TEXMAP0);
+    GXSetTevKColor((GXTevKColorID)1, modulateColor);
+    GXSetTevKColorSel((GXTevStageID)0, (GXTevKColorSel)0xD);
+    GXSetTevKAlphaSel((GXTevStageID)0, (GXTevKAlphaSel)0x1D);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 0xF, 0xF,
+                                                                                                           0xF, 8);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 7, 6, 4, 7);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+
+    GXSetTevDirect((GXTevStageID)1);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 0);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(1, 1, 1, 4);
+    GXLoadTexObj((GXTexObj*)texObj0, GX_TEXMAP1);
+    GXSetTevKColor((GXTevKColorID)0, blendColor);
+    GXSetTevKColorSel((GXTevStageID)1, (GXTevKColorSel)0xC);
+    GXSetTevKAlphaSel((GXTevStageID)1, (GXTevKAlphaSel)0x1C);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(1, 0xB, 0xE,
+                                                                                                           8, 0xF);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 8, 0, 0, 1, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(1, 7, 7, 7, 0);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(1, 0, 0, 1, 1, 0);
+
+    GXSetTevDirect((GXTevStageID)2);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(2, 0, 0);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(2, 1, 2, 4);
+    GXLoadTexObj((GXTexObj*)texObj1, GX_TEXMAP2);
+    GXSetTevKColor((GXTevKColorID)0, blendColor);
+    GXSetTevKColorSel((GXTevStageID)2, (GXTevKColorSel)0xC);
+    GXSetTevKAlphaSel((GXTevStageID)2, (GXTevKAlphaSel)0x1C);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(2, 0xE, 0xB,
+                                                                                                           8, 0);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(2, 8, 0, 0, 1, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(2, 7, 7, 7, 0);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(2, 0, 0, 0, 1, 0);
+
+    GXSetNumTevStages(3);
+    GXBegin((GXPrimitive)0x90, GX_VTXFMT7, 0x600);
+    for (int i = 0; i < 0x180; i++) {
+        GXPosition1x16(indices[0]);
+        GXNormal1x16(indices[0]);
+        GXColor1x16(indices[0]);
+        GXTexCoord1x16(indices[0]);
+        GXTexCoord1x16(indices[0]);
+        GXPosition1x16(indices[1]);
+        GXNormal1x16(indices[1]);
+        GXColor1x16(indices[1]);
+        GXTexCoord1x16(indices[1]);
+        GXTexCoord1x16(indices[1]);
+        GXPosition1x16(indices[2]);
+        GXNormal1x16(indices[2]);
+        GXColor1x16(indices[2]);
+        GXTexCoord1x16(indices[2]);
+        GXTexCoord1x16(indices[2]);
+        GXPosition1x16(indices[3]);
+        GXNormal1x16(indices[3]);
+        GXColor1x16(indices[3]);
+        GXTexCoord1x16(indices[3]);
+        GXTexCoord1x16(indices[3]);
+        indices += 4;
+    }
+
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0xFF, 4);
+    _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);
+    _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(0, 4, 5, 0xF);
+    GXSetNumTevStages(1);
+    GXLoadTexObj((GXTexObj*)texObj0, GX_TEXMAP0);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `RenderWaterMesh(VMana2*)` in `src/pppMana2.cpp` using the PAL Ghidra reference as guidance.
- Replaced the previous TODO stub with full GX setup + indexed draw path and state restore calls.
- Added PAL metadata for the function block in the required INFO format.
- Added explicit external GX helper declarations used by this function.

## Functions improved
- Unit: `main/pppMana2`
- Symbol: `RenderWaterMesh__FP6VMana2`

## Match evidence
- Selector baseline before edit: `RenderWaterMesh__FP6VMana2` at **0.3%** (from `python3 tools/agent_select_target.py` in this run).
- After edit (`build/tools/objdiff-cli diff -p . -u main/pppMana2 -o - RenderWaterMesh__FP6VMana2`):
  - `left_match=92.358696`
  - target size: `1472`
  - current size: `1428`
- `ninja` build passes after the change.

## Plausibility rationale
- The implementation follows expected source-level GX rendering flow for FFCC effects code (state setup, array binds, TEV stage configuration, indexed vertex emission, and render-state restore).
- It uses existing project interfaces and naming patterns rather than coercion-only compiler tricks.
- Remaining mismatch appears to be local codegen/detail-level differences, not placeholder logic.

## Technical notes
- Vertex emission uses `GXPosition1x16/GXNormal1x16/GXColor1x16/GXTexCoord1x16` in the same indexed pattern as the target assembly layout.
- TEV and blend setup mirrors the reference ordering to reduce control-flow and call-order drift.
