### PR TITLE
map: match CMapShadow CPtrArray GetSize/RemoveAll

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -575,6 +575,41 @@ CMapAnimRun* CPtrArray<CMapAnimRun*>::GetAt(unsigned long index)
 
 /*
  * --INFO--
+ * PAL Address: 0x800341d4
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+int CPtrArray<CMapShadow*>::GetSize()
+{
+    return m_numItems;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800341dc
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+void CPtrArray<CMapShadow*>::RemoveAll()
+{
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added explicit `CPtrArray<CMapShadow*>` specializations in `src/map.cpp` for:
  - `GetSize__24CPtrArray<P10CMapShadow>Fv`
  - `RemoveAll__24CPtrArray<P10CMapShadow>Fv`
- Kept implementations consistent with existing `CPtrArray` patterns used for other map-related pointer arrays.
- Added PAL metadata blocks for both functions using Ghidra reference addresses/sizes.

## Functions Improved
- Unit: `main/map`
- `GetSize__24CPtrArray<P10CMapShadow>Fv`
  - Before: effectively unresolved on source side (0% target in selector)
  - After: `100.0%` match (`size=8`)
- `RemoveAll__24CPtrArray<P10CMapShadow>Fv`
  - Before: effectively unresolved on source side (0% target in selector)
  - After: `99.8421%` match (`size=76`)

## Match Evidence
- `main/map` `.text` match percent:
  - Before: `13.720052`
  - After: `14.104752`
- Build progress delta observed in `ninja` output:
  - Code matched bytes: `204020 -> 204028`
  - Matched functions: `1548 -> 1549`

## Plausibility Rationale
- These are straightforward container specializations already present for sibling types (`CMapAnim*`, `CMapAnimRun*`, etc.) in the same translation unit.
- Logic is idiomatic and minimal for this codebase (return `m_numItems`; free `m_items` then reset size/count).
- No coercive or non-source-like compiler tricks were introduced.

## Technical Details
- Verified via `objdiff-cli` oneshot JSON mode on `main/map`.
- Added only two concrete template specializations, minimizing collateral codegen changes while enabling symbol pairing and high instruction alignment.
