### PR TITLE
chara: improve __sinit_chara_cpp matching

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -612,8 +612,8 @@ struct CharaGlobal {
 	} field0_0x0;
 } Chara;
 
-// External vtable reference
-extern "C" void* PTR_PTR_s_CChara_801fcd24;
+extern "C" void* __vt__8CManager;
+extern "C" void* lbl_801FCD24;
 
 /*
  * --INFO--
@@ -622,5 +622,7 @@ extern "C" void* PTR_PTR_s_CChara_801fcd24;
  */
 extern "C" void __sinit_chara_cpp(void)
 {
-	Chara.field0_0x0.object.base_object.object.m_id = (u32)&PTR_PTR_s_CChara_801fcd24;
+	u32* charaBase = (u32*)&Chara;
+	*charaBase = (u32)&__vt__8CManager;
+	*charaBase = (u32)&lbl_801FCD24;
 }


### PR DESCRIPTION
## Summary
- Reworked `__sinit_chara_cpp` in `src/chara.cpp` to initialize `Chara` through the symbol sequence used by the original binary.
- Replaced the previous single assignment via `PTR_PTR_s_CChara_801fcd24` with explicit symbol writes using `__vt__8CManager` and `lbl_801FCD24`.

## Functions Improved
- Unit: `main/chara`
- Symbol: `__sinit_chara_cpp`

## Match Evidence
- `__sinit_chara_cpp` improved from **41.125%** to **58.125%** (`tools/objdiff-cli diff -p . -u main/chara __sinit_chara_cpp`).
- Build passes with `ninja` and report regeneration.

## Plausibility Rationale
- This is a source-plausible static initializer adjustment: it aligns symbol-level initialization behavior with the object setup pattern already implied by the class/global layout.
- The change avoids contrived compiler coaxing and focuses on correcting symbol usage/order in a small initializer.

## Technical Notes
- Introduced explicit external symbols:
  - `__vt__8CManager`
  - `lbl_801FCD24`
- Updated the init body to write through a base pointer to `Chara`, matching the expected two-store setup pattern more closely.
