### PR TITLE
cflat_r2system: add GetWorldMapMatrix and IsHitDrawMode wrappers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -36,6 +36,7 @@ extern "C" {
 int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned long);
 void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
 int GetWait__4CMesFv(void*);
+unsigned char DAT_8032ecb8;
 }
 
 /*
@@ -785,6 +786,34 @@ extern "C" void SetWorldMapMatrix__10CCameraPcsFPA4_f(void* camera, Mtx matrix)
 {
     PSMTXCopy(matrix, (MtxPtr)((char*)camera + 0x34));
     PSMTXInverse(matrix, (MtxPtr)((char*)camera + 0x64));
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B95FC
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void GetWorldMapMatrix__10CCameraPcsFPA4_f(void* camera, Mtx matrix)
+{
+    PSMTXCopy((MtxPtr)((char*)camera + 0x34), matrix);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9620
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void IsHitDrawMode__7CMapPcsFc(CMapPcs*, unsigned char drawMode)
+{
+    DAT_8032ecb8 = drawMode;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added missing PAL wrapper `GetWorldMapMatrix__10CCameraPcsFPA4_f` in `src/cflat_r2system.cpp`.
- Added missing PAL wrapper `IsHitDrawMode__7CMapPcsFc` and declared `DAT_8032ecb8` with C linkage.
- Kept implementation style consistent with existing low-level wrapper functions in this unit.

## Functions Improved
- Unit: `main/cflat_r2system`
- `GetWorldMapMatrix__10CCameraPcsFPA4_f` (36b)
  - Before: 0.0% (target selector baseline)
  - After: 100.0% (`build/GCCP01/report.json`)
- `IsHitDrawMode__7CMapPcsFc` (8b)
  - Before: 0.0% (target selector baseline)
  - After: 100.0% (`build/GCCP01/report.json`)

## Match Evidence
- `ninja` build succeeds.
- `build/GCCP01/report.json` now lists both symbols as full fuzzy matches in `main/cflat_r2system`.
- Unit text fuzzy match now reports `4.2409425%` for `main/cflat_r2system` after this change.

## Plausibility Rationale
- These are straightforward engine wrappers consistent with neighboring code in the same source file:
  - matrix getter mirrors existing matrix setter pattern.
  - draw-mode write is a direct global state assignment, matching the decomp reference behavior.
- No contrived control flow or artificial temporaries were introduced.

## Technical Details
- Reference functions used from `resources/ghidra-decomp-1-31-2026/`:
  - `800b95fc_GetWorldMapMatrix__10CCameraPcsFPA4_f.c`
  - `800b9620_IsHitDrawMode__7CMapPcsFc.c`
- Added PAL info headers with addresses/sizes for both wrappers.
