### PR TITLE
joybus: decompile ThreadAlarmHandler callback

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -965,12 +965,16 @@ void JoyBus::WriteInitialCode(ThreadParam* threadParam)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800ae228
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void ThreadAlarmHandler(OSAlarm*, OSContext*)
+void ThreadAlarmHandler(OSAlarm* alarm, OSContext*)
 {
-	// TODO
+    OSResumeThread((OSThread*)alarm->start);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `ThreadAlarmHandler__FP7OSAlarmP9OSContext` in `src/joybus.cpp` and updated its function metadata block with PAL address/size.

## Functions Improved
- Unit: `main/joybus`
- Function: `ThreadAlarmHandler__FP7OSAlarmP9OSContext`
- Size: `36b`

## Match Evidence
- Before: `11.1%` (selector baseline for this symbol)
- After: `99.888885%` (`build/tools/objdiff-cli diff -p . -u main/joybus -o - ThreadAlarmHandler__FP7OSAlarmP9OSContext`)
- Objdiff analysis: single remaining `DIFF_ARG_MISMATCH`, all other instructions aligned.

## Plausibility Rationale
The new implementation follows the expected Dolphin alarm callback behavior for this code path: resume the suspended thread stored in the alarm payload field. This is straightforward source-level logic, not compiler coaxing.

## Technical Details
- Added:
  - `OSResumeThread((OSThread*)alarm->start);`
- No control-flow tricks, no artificial temporaries, no layout hacks.
- Build verified with `ninja`.
