### PR TITLE
prgobj: improve GetClassControl match

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -552,11 +552,11 @@ int CGPrgObj::GetClassControl(int classControl)
 		return reinterpret_cast<CGPartyObj*>(this)->isRideTarget();
 	}
 
-	if (classControl < 9) {
-		if (classControl > 7) {
-			return reinterpret_cast<CGPartyObj*>(this)->isDispTarget();
-		}
-	} else if (classControl < 11) {
+	if (classControl == 8) {
+		return reinterpret_cast<CGPartyObj*>(this)->isDispTarget();
+	}
+
+	if (classControl == 10) {
 		return *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x560);
 	}
 


### PR DESCRIPTION
## Summary
- Reworked `CGPrgObj::GetClassControl(int)` in `src/prgobj.cpp` to use direct equality checks for class-control selectors (`8`, `9`, `10`) rather than range/nested comparisons.
- Kept behavior unchanged:
  - `9` -> `isRideTarget()`
  - `8` -> `isDispTarget()`
  - `10` -> read value at `this + 0x560`
  - otherwise `0`

## Functions Improved
- Unit: `main/prgobj`
- Symbol: `GetClassControl__8CGPrgObjFi`

## Match Evidence
- `GetClassControl__8CGPrgObjFi`: **63.869564% -> 71.695656%**
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/prgobj -o - GetClassControl__8CGPrgObjFi`
- Neighbor checks:
  - `reqAnim__8CGPrgObjFiii` unchanged at `62.142857%`
  - `onFrame__8CGPrgObjFv` unchanged at `50.024%`

## Plausibility Rationale
- The new source is a straightforward selector dispatch pattern that a game codebase would naturally use for discrete control IDs.
- This avoids contrived temporaries/reordering and preserves readability while improving codegen alignment.

## Technical Details
- Objdiff showed the previous nested/range branch shape was not matching the original compare/branch layout.
- Constraining the logic to explicit case-like checks reduced branch-shape divergence and improved instruction alignment for this symbol.
