### PR TITLE
Align pppYmDeformationMdl UnkC layout with serialized offset ABI

### DIFF
--- a/include/ffcc/pppYmDeformationMdl.h
+++ b/include/ffcc/pppYmDeformationMdl.h
@@ -7,6 +7,7 @@
 struct VYmDeformationMdl;
 
 struct UnkC {
+    u8 m_pad_0x0[0xc];
     s32* m_serializedDataOffsets;
 };
 


### PR DESCRIPTION
## Summary
- Updated `UnkC` in `include/ffcc/pppYmDeformationMdl.h` to include the missing `0x0C` pad before `m_serializedDataOffsets`.
- This aligns the type layout with neighboring `ppp*` modules that already use the same offset-data pattern.

## Functions improved
- Unit: `main/pppYmDeformationMdl`
- Symbol: `pppConstruct2YmDeformationMdl`
- Symbol: `pppFrameYmDeformationMdl`

## Match evidence
- `pppConstruct2YmDeformationMdl`: `86.916664%` -> `87.0%`
- `pppConstruct2YmDeformationMdl` instruction diff count: `11` -> `10`
- `pppFrameYmDeformationMdl`: `90.07792%` -> `90.09091%`
- Project progress (`ninja`): code matched bytes `204072` -> `204136`, matched functions `1551` -> `1552`

## Plausibility rationale
- This is an ABI/layout correction, not compiler coaxing: the decomp uses serialized offset tables read from a pointer located after metadata fields.
- Multiple existing `ppp*` headers already model `UnkC` with a leading `0x0C` pad and then `m_serializedDataOffsets`; this change makes this module consistent with that established source pattern.

## Technical details
- Before change, generated code for `pppConstruct2YmDeformationMdl` showed an extra mismatch around offset-table addressing.
- After introducing `m_pad_0x0[0xc]`, address computation and store sequence moved closer to target codegen (one fewer instruction-level mismatch in objdiff).
