### PR TITLE
sound: add __sinit_sound_cpp static initializer

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -2,6 +2,8 @@
 
 #include "ffcc/RedSound/RedSound.h"
 #include "ffcc/system.h"
+#include "PowerPC_EABI_Support/Runtime/MWCPlusLib.h"
+#include <Runtime.PPCEABI.H/NMWException.h>
 #include "dolphin/gx.h"
 #include "dolphin/mtx.h"
 #include <math.h>
@@ -16,6 +18,10 @@ extern double DOUBLE_80330d18;
 extern double DOUBLE_80330d20;
 extern double DOUBLE_80330d28;
 extern float DAT_8032ec20;
+extern "C" void* PTR_PTR_s_CSound_8021056c;
+extern "C" void __ct__9CRedSoundFv(void*);
+extern "C" void __dt__6CSoundFv(void*);
+extern void* ARRAY_802f26c8;
 
 struct CLineSegment {
     Vec delta;
@@ -215,6 +221,24 @@ extern "C" void CalcBound__9CLine2(CLine* line)
             }
         }
     }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800c8998
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_sound_cpp(void)
+{
+    *reinterpret_cast<void**>(&Sound) = &PTR_PTR_s_CSound_8021056c;
+    __ct__9CRedSoundFv(&Sound);
+    __construct_array(reinterpret_cast<unsigned char*>(&Sound) + 0x142c, (ConstructorDestructor)__ct__9CLine, 0, 0x1cc,
+                      8);
+    __register_global_object(&Sound, __dt__6CSoundFv, &ARRAY_802f26c8);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added `__sinit_sound_cpp` in `src/sound.cpp` with PAL metadata (`0x800c8998`, `132b`).
- Wired explicit static init steps for `Sound`: vtable pointer store, `CRedSound` base construction, `CLine[8]` array construction, and global destructor-chain registration.
- Added required runtime symbol declarations and runtime headers used by this initializer.

## Functions improved
- Unit: `main/sound`
- Symbol: `__sinit_sound_cpp`

## Match evidence
- Before: `0.0%` (from `tools/agent_select_target.py` output for this symbol)
- After: `48.909092%` via:
  - `build/tools/objdiff-cli diff -p . -u main/sound -o - __sinit_sound_cpp`
- Current symbol size: `132` bytes (target-sized)

## Plausibility rationale
- This follows standard Metrowerks static-initializer patterns already used in the repo:
  - construct static/global storage,
  - call runtime array construction helper,
  - register destructor with `__register_global_object`.
- The changes are source-plausible and idiomatic for the codebase, not compiler-coaxing reordering.

## Technical details
- `__construct_array` is applied at the inferred `Sound + 0x142c` region using `__ct__9CLine` with stride `0x1cc` and count `8`, aligning with the Ghidra reference.
- `__register_global_object(&Sound, __dt__6CSoundFv, &ARRAY_802f26c8)` hooks `CSound` teardown into the runtime global destructor chain.
- Build verification: `ninja` passes after the change.
