### PR TITLE
main/pppYmDeformationMdl: improve pppConstruct2 init match

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -113,17 +113,15 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, str
  */
 void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, UnkC* param_2)
 {
-    float fVar1;
-    int iVar2;
+    float fVar1 = FLOAT_80330dac;
+    u8* state = (u8*)pppYmDeformationMdl_ + param_2->m_serializedDataOffsets[2];
 
-    fVar1 = FLOAT_80330dac;
-    iVar2 = param_2->m_serializedDataOffsets[2];
-    *(float*)((u8*)pppYmDeformationMdl_ + 0x8C + iVar2) = FLOAT_80330dac;
-    *(float*)((u8*)pppYmDeformationMdl_ + 0x88 + iVar2) = fVar1;
-    *(float*)((u8*)pppYmDeformationMdl_ + 0x84 + iVar2) = fVar1;
-    *(float*)((u8*)pppYmDeformationMdl_ + 0x98 + iVar2) = fVar1;
-    *(float*)((u8*)pppYmDeformationMdl_ + 0x94 + iVar2) = fVar1;
-    *(float*)((u8*)pppYmDeformationMdl_ + 0x90 + iVar2) = fVar1;
+    *(float*)(state + 0x8C) = fVar1;
+    *(float*)(state + 0x88) = fVar1;
+    *(float*)(state + 0x84) = fVar1;
+    *(float*)(state + 0x98) = fVar1;
+    *(float*)(state + 0x94) = fVar1;
+    *(float*)(state + 0x90) = fVar1;
 }
 
 /*


### PR DESCRIPTION
## Summary
Refactored `pppConstruct2YmDeformationMdl` state initialization in `src/pppYmDeformationMdl.cpp` to use a single computed base pointer plus fixed field offsets. This keeps behavior unchanged while improving codegen alignment.

## Functions improved
- Unit: `main/pppYmDeformationMdl`
- `pppConstruct2YmDeformationMdl`: `86.916664%` -> `87.0%`
- Unit `.text` match in this objdiff run: `85.29646%` -> `85.30531%`

## Match evidence
Objdiff command used:
```sh
build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o - pppConstruct2YmDeformationMdl
```
Observed instruction-level alignment improvement with one leading instruction now matching and small positive movement in aggregate symbol/unit percentages.

## Plausibility rationale
The new code is source-plausible C/C++: it removes redundant temporaries and repeated pointer arithmetic, replacing them with a direct base-pointer expression and straightforward field writes that a game code author would naturally write.

## Technical details
- Consolidated repeated `param_2->m_serializedDataOffsets[2]` arithmetic into one `state` pointer.
- Initialized all six deformation floats from one local `fVar1` value (`FLOAT_80330dac`) to keep consistent load/store behavior.
- No functional behavior changes; build passes with `ninja`.
