### PR TITLE
menu_item: implement ItemClose animation step

### DIFF
--- a/include/ffcc/menu_item.h
+++ b/include/ffcc/menu_item.h
@@ -8,7 +8,7 @@ public:
     void ItemInit1();
     bool ItemOpen();
     int ItemCtrl();
-    void ItemClose();
+    bool ItemClose();
     void ItemDraw();
     int ItemCtrlCur();
     void SingLifeInit(int);

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -357,12 +357,43 @@ int CMenuPcs::ItemCtrl()
 
 /*
  * --INFO--
- * Address:\tTODO
- * Size:\tTODO
+ * PAL Address: 0x8015a818
+ * PAL Size: 380b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::ItemClose()
+bool CMenuPcs::ItemClose()
 {
-    // TODO
+    s16* itemState = *(s16**)((u8*)this + 0x82C);
+    s16* itemList = *(s16**)((u8*)this + 0x850);
+    int finished = 0;
+    int count = itemList[0];
+    MenuItemOpenAnim* anim = (MenuItemOpenAnim*)((u8*)itemList + 8);
+
+    itemState[0x11]++;
+
+    for (int i = 0; i < count; i++, anim++) {
+        if (anim->frame <= itemState[0x11]) {
+            if (itemState[0x11] < anim->frame + anim->duration) {
+                anim->frame++;
+                anim->progress = 1.0f - ((float)anim->frame / (float)anim->duration);
+                if ((anim->flags & 2) == 0) {
+                    float t = 1.0f - ((float)anim->frame / (float)anim->duration);
+                    anim->dx = (anim->targetX - (float)anim->x) * t;
+                    anim->dy = (anim->targetY - (float)anim->y) * t;
+                }
+            } else {
+                finished++;
+                anim->progress = 0.0f;
+                anim->dx = 0.0f;
+                anim->dy = 0.0f;
+            }
+        }
+    }
+
+    return count == finished;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::ItemClose()` in `src/menu_item.cpp` using the decompilation-guided close-animation flow.
- Updated `include/ffcc/menu_item.h` signature from `void ItemClose()` to `bool ItemClose()` to match function behavior.
- Added PAL metadata block for the function (`0x8015a818`, `380b`).

## Functions improved
- Unit: `main/menu_item`
- Symbol: `ItemClose__8CMenuPcsFv`

## Match evidence
- Before: `1.1%` (from `tools/agent_select_target.py` target report)
- After: `41.831577%` (`build/tools/objdiff-cli diff -p . -u main/menu_item -o - ItemClose__8CMenuPcsFv`)
- The function body now emits a full close-animation loop with frame progression, lerp-style position updates, and completion counting, replacing a stub.

## Plausibility rationale
- The implementation mirrors the existing `ItemOpen()` data layout and animation state machine already present in this unit.
- It uses straightforward per-entry frame/progress updates and reset behavior that are natural for original UI menu code rather than contrived compiler-shaping logic.

## Technical details
- Iterates over menu entries from the same `itemList` block (`+0x850`) and per-entry animation records (`+8` offset).
- Advances `itemState[0x11]` and updates each entry based on start frame, duration, and `flags & 2` behavior.
- Returns completion state when all entries have finished their close animation window.
