### PR TITLE
gx/GXMisc: match GXPokeAlphaRead bitmask sequence

### DIFF
--- a/src/gx/GXMisc.c
+++ b/src/gx/GXMisc.c
@@ -205,7 +205,7 @@ void GXPokeAlphaMode(GXCompare func, u8 threshold) {
  * JP Size: TODO
  */
 void GXPokeAlphaRead(GXAlphaReadMode mode) {
-    GX_SET_PE_REG(4, (mode & 0xFFFB) | 4);
+    GX_SET_PE_REG(4, (mode & 0xFFFFFFFB) | 4);
 }
 
 void GXPokeAlphaUpdate(GXBool update_enable) {


### PR DESCRIPTION
## Summary
- Updated `GXPokeAlphaRead` in `src/gx/GXMisc.c` to use a 32-bit mask literal (`0xFFFFFFFB`) before setting bit `0x4`.
- This preserves behavior while matching the original PE register bit-clear/set codegen pattern.

## Functions improved
- `main/gx/GXMisc`
  - `GXPokeAlphaRead`: **88.0% -> 100.0%** (20-byte function)

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXMisc -o - GXPokeAlphaRead`
- After change, generated first instruction is `rlwinm r0, r3, 0, 30, 28` (matching target) instead of `andi.`.

## Plausibility rationale
- The change is source-plausible and idiomatic for GX register programming: explicit full-width bitmasking for a register field before forcing a control bit.
- No contrived temporaries, no reordering tricks, and no readability regression.

## Technical details
- Previous expression used `0xFFFB`, which led MWCC to emit `andi.`.
- Using `0xFFFFFFFB` steers MWCC to emit the target `rlwinm` mask form, aligning with original assembly while keeping identical semantics in this call site.