### PR TITLE
ringmenu: decompile SetBattleButton and SetBattleCommand

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -122,22 +122,67 @@ void CRingMenu::SetFade(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a33dc
+ * PAL Size: 28b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRingMenu::SetBattleButton(int, int)
+void CRingMenu::SetBattleButton(int buttonIndex, int newValue)
 {
-	// TODO
+	int* battleButtons = reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x18);
+
+	if (battleButtons[buttonIndex] == newValue) {
+		return;
+	}
+
+	battleButtons[buttonIndex] = newValue;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a3340
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRingMenu::SetBattleCommand(int, int, int)
+void CRingMenu::SetBattleCommand(int buttonGroupIndex, int newCommandId, int newRotation)
 {
-	// TODO
+	int slot8 = buttonGroupIndex * 8;
+	int slot12 = buttonGroupIndex * 12;
+	char* self = reinterpret_cast<char*>(this);
+	int* commandCurrent = reinterpret_cast<int*>(self + slot8 + 0x20);
+	int currentCommand = *commandCurrent;
+
+	if (newCommandId == 0) {
+		newCommandId = -1;
+	}
+
+	if (currentCommand == newCommandId) {
+		return;
+	}
+
+	if (((currentCommand >= 0) && (newCommandId < 0)) || ((currentCommand < 0) && (newCommandId >= 0))) {
+		int* timer2 = reinterpret_cast<int*>(self + slot12 + 0x40);
+		*timer2 = 8 - *timer2;
+	}
+
+	*reinterpret_cast<int*>(self + slot8 + 0x24) = currentCommand;
+	*commandCurrent = newCommandId;
+
+	int* timer0 = reinterpret_cast<int*>(self + slot12 + 0x38);
+	*reinterpret_cast<int*>(self + slot12 + 0x3c) = 8 - *timer0;
+	*timer0 = 8 - *timer0;
+
+	if (buttonGroupIndex != 2) {
+		return;
+	}
+
+	*reinterpret_cast<int*>(self + 0x60) = *reinterpret_cast<int*>(self + 0x5c);
+	*reinterpret_cast<int*>(self + 0x5c) = newRotation;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRingMenu::SetBattleButton(int, int)` and `CRingMenu::SetBattleCommand(int, int, int)` in `src/ringmenu.cpp` from the PAL decomp flow.
- Updated both functions to the project's versioned info header format with PAL address/size.
- Kept behavior source-plausible: button/command update logic, timer flips, and group-2 rotation state handoff.

## Functions improved
- Unit: `main/ringmenu`
- `SetBattleButton__9CRingMenuFii`
- `SetBattleCommand__9CRingMenuFiii`

## Match evidence
`build/tools/objdiff-cli diff -p . -u main/ringmenu -o - SetBattleCommand__9CRingMenuFiii`

Before:
- `SetBattleButton__9CRingMenuFii`: `14.285714%`
- `SetBattleCommand__9CRingMenuFiii`: `2.5641026%`

After:
- `SetBattleButton__9CRingMenuFii`: `98.57143%`
- `SetBattleCommand__9CRingMenuFiii`: `61.23077%`

Assembly alignment notes:
- `SetBattleButton` now aligns almost fully; remaining diff is a small argument-level mismatch in one compare.
- `SetBattleCommand` now matches major control-flow and store/update structure (normalize command, sign-transition timer flip, previous/current command rollover, timer mirroring, group-2 rotation update), with remaining register/ordering diffs.

## Plausibility rationale
- This is a first-pass restoration of two core battle-button update routines in a currently stubbed `ringmenu.cpp` unit.
- The implementation reflects coherent game-side logic rather than no-op stubs, and improves assembly agreement materially without introducing debug artifacts or commented-out code.
