### PR TITLE
cflat_r2system: add missing CCameraPcs setter methods

### DIFF
--- a/include/ffcc/p_camera.h
+++ b/include/ffcc/p_camera.h
@@ -67,6 +67,9 @@ public:
     void drawShadowChrBegin();
     void SetFullScreenShadow(float (*)[4], long);
     void SetFullScreenShadowCamLen(float);
+    void SetFullScreenShadowRot(float, float);
+    void SetFullScreenShadowPos(Vec*, float);
+    void SetFullScreenShadowEnable(unsigned char);
     void drawShadowEndAll();
 
     // Material editor
@@ -86,6 +89,9 @@ public:
 
     // Misc
     void SetOffsetZBuff(float);
+    void SetZRotate(float);
+    void SetPosition(Vec*);
+    void SetRefPosition(Vec*);
     void addWorldMap();
     void SetIsAbsolute(int);
     void SetWorldMapMatrix(float (*)[4]);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -818,6 +818,98 @@ extern "C" void IsHitDrawMode__7CMapPcsFc(CMapPcs*, unsigned char drawMode)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9628
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetFullScreenShadowRot(float rotX, float rotY)
+{
+    *(float*)((char*)this + 0x364) = rotX;
+    *(float*)((char*)this + 0x368) = rotY;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9634
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetFullScreenShadowPos(Vec* position, float len)
+{
+    *(float*)((char*)this + 0x408) = *(float*)((char*)position + 0x0);
+    *(float*)((char*)this + 0x40C) = *(float*)((char*)position + 0x4);
+    *(float*)((char*)this + 0x410) = *(float*)((char*)position + 0x8);
+    *(float*)((char*)this + 0x370) = len;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9654
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetFullScreenShadowEnable(unsigned char enable)
+{
+    *(unsigned char*)((char*)this + 0x404) = enable;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9920
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetZRotate(float zRotate)
+{
+    *(float*)((char*)this + 0x108) = zRotate;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9C28
+ * PAL Size: 28b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetPosition(Vec* position)
+{
+    *(float*)((char*)this + 0xE0) = *(float*)((char*)position + 0x0);
+    *(float*)((char*)this + 0xE4) = *(float*)((char*)position + 0x4);
+    *(float*)((char*)this + 0xE8) = *(float*)((char*)position + 0x8);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9C44
+ * PAL Size: 28b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::SetRefPosition(Vec* position)
+{
+    *(float*)((char*)this + 0xD4) = *(float*)((char*)position + 0x0);
+    *(float*)((char*)this + 0xD8) = *(float*)((char*)position + 0x4);
+    *(float*)((char*)this + 0xDC) = *(float*)((char*)position + 0x8);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
Adds missing `CCameraPcs` setter method declarations and implementations in `main/cflat_r2system`:
- `SetFullScreenShadowRot(float, float)`
- `SetFullScreenShadowPos(Vec*, float)`
- `SetFullScreenShadowEnable(unsigned char)`
- `SetZRotate(float)`
- `SetPosition(Vec*)`
- `SetRefPosition(Vec*)`

All implementations are straightforward field setters using existing style (offset-based member writes) and include PAL address/size info blocks.

## Functions improved
Unit: `main/cflat_r2system`

Symbols moved from unmatched/missing mapping to matched:
- `SetFullScreenShadowRot__10CCameraPcsFff`: `-1` (unmatched) -> `100.0%`
- `SetFullScreenShadowPos__10CCameraPcsFP3Vecf`: `-1` (unmatched) -> `100.0%`
- `SetFullScreenShadowEnable__10CCameraPcsFUc`: `-1` (unmatched) -> `100.0%`
- `SetZRotate__10CCameraPcsFf`: `-1` (unmatched) -> `100.0%`
- `SetPosition__10CCameraPcsFP3Vec`: `-1` (unmatched) -> `100.0%`
- `SetRefPosition__10CCameraPcsFP3Vec`: `-1` (unmatched) -> `100.0%`

## Match evidence
`objdiff` unit `.text` match improved:
- Before: `4.2204585%`
- After: `4.5917296%`

Build verification:
- `ninja` passes and updates report successfully.

## Plausibility rationale
These are minimal, idiomatic setter functions that map directly to expected camera state fields and are invoked by system runtime paths. No artificial temporaries, unnatural control flow, or score-only coercions were introduced.

## Technical details
- Added method declarations to `include/ffcc/p_camera.h` to align class interface with emitted symbols.
- Implemented methods in `src/cflat_r2system.cpp` near surrounding camera/map helper functions in address order, using direct load/store patterns that match target instruction shape.
- Left `__ct__14PPPCREATEPARAMFv` untouched in this PR; it still requires separate symbol/signature investigation.
