### PR TITLE
game: match Draw/Calc wrappers in CGame

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -72,6 +72,13 @@ void MapChanging__7CSystemFii(CSystem*, int, int);
 void MapChanged__7CSystemFiii(CSystem*, int, int, int);
 void LoadMap__7CMapPcsFiiPvUlUc(void*, int, int, void*, unsigned long, unsigned char);
 void LoadFieldPdt__8CPartPcsFiiPvUlUc(void*, int, int, void*, unsigned long, unsigned char);
+void Draw__13CFlatRuntime2Fv(void*);
+void Draw__5CWindFv(void*);
+void Frame__13CFlatRuntime2Fii(void*, int, int);
+void CheckMenu__10CGPartyObjFv(void);
+void AfterFrame__12CFlatRuntimeFi(void*, int);
+void SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+    void*, int, int, int, int, void*, void*);
 unsigned char CFlat[];
 unsigned char PartMng[];
 unsigned char McPcs[];
@@ -766,43 +773,61 @@ void CGame::Calc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80014964
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Calc2()
 {
-	// CFlat.Frame(0, 1);
+	Frame__13CFlatRuntime2Fii(CFlat, 0, 1);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80014934
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Calc3()
 { 
-	// CheckMenu__10CGPartyObjFv();
-	// AfterFrame__12CFlatRuntimeFi(&CFlat,0);
+	CheckMenu__10CGPartyObjFv();
+	AfterFrame__12CFlatRuntimeFi(CFlat, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800148f4
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Draw()
 {
-	// TODO
+	SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+	    CFlat, 0, 1, 6, 0, 0, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800148c0
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Draw2()
 {
-	// TODO
+	Draw__13CFlatRuntime2Fv(CFlat);
+	Draw__5CWindFv(Wind);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented four small `CGame` methods in `src/game.cpp` from decomp reference behavior and filled in PAL metadata blocks:
- `CGame::Calc2()`
- `CGame::Calc3()`
- `CGame::Draw()`
- `CGame::Draw2()`

Also added the required `extern "C"` declarations for the called runtime/wind helpers.

## Functions Improved
Unit: `main/game`

- `Draw2__5CGameFv`: `7.6923075% -> 100.0%`
- `Draw__5CGameFv`: `6.25% -> 100.0%`
- `Calc3__5CGameFv`: `8.333333% -> 100.0%`
- `Calc2__5CGameFv`: `8.333333% -> 100.0%`

## Match Evidence
- Build/progress delta:
  - Matched code: `204216 -> 204428` bytes (`+212`)
  - Matched functions: `1554 -> 1558` (`+4`)
- Symbol diff check (`objdiff-cli diff -p . -u main/game Draw2__5CGameFv`):
  - `match_percent: 100.0`

## Plausibility Rationale
These are straightforward dispatcher/wrapper methods that call existing engine runtime entry points (`Frame`, `AfterFrame`, `SystemCall`, `Draw`, `Wind::Draw`) in the same order shown by decomp output. The changes remove TODO stubs and replace them with direct, idiomatic production calls rather than compiler-specific coercions.

## Technical Notes
- `Draw()` uses the flat runtime `SystemCall(..., 0, 1, 6, 0, 0, 0)` signature directly.
- `Draw2()` calls flat runtime draw, then wind draw.
- `Calc2()` and `Calc3()` now invoke the expected runtime step and post-frame hooks.
