### PR TITLE
gx/GXTransform: improve GXSetScissorBoxOffset match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -625,19 +625,13 @@ void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht) {
  */
 void GXSetScissorBoxOffset(s32 x_off, s32 y_off) {
     u32 reg;
-    u32 x;
-    u32 y;
 
     CHECK_GXBEGIN(1119, "GXSetScissorBoxOffset");
 
     ASSERTMSGLINE(1122, (u32)(x_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid X offset");
     ASSERTMSGLINE(1124, (u32)(y_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid Y offset");
 
-    x = (u32)(x_off + 0x156);
-    y = (u32)(y_off + 0x156);
-    reg = (x >> 1) & 0xFFF003FF;
-    reg |= (y << 9) & 0x003FFC00;
-    reg &= 0x00FFFFFF;
+    reg = (((x_off + 0x156U >> 1) & 0x7FF003FF) | ((y_off + 0x156) * 0x200 & 0xFFFFFC00U)) & 0xFFFFFF;
     reg |= 0x59000000;
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;


### PR DESCRIPTION
## Summary
Reworked `GXSetScissorBoxOffset` register packing to use a single packed bit-expression and removed intermediate temporaries (`x`, `y`) while preserving behavior.

## Functions improved
- Unit: `main/gx/GXTransform`
- Function: `GXSetScissorBoxOffset` (64 bytes)

## Match evidence
- `GXSetScissorBoxOffset`: **81.5625% -> 83.125%** (`build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetScissorBoxOffset`)

## Plausibility rationale
The change keeps original API usage and assertions intact, and only tightens bitfield packing into an idiomatic direct register-composition expression used widely in low-level GX code.

## Technical details
- Replaced staged operations:
  - compute shifted/masked `x` and `y`
  - merge into `reg`
- With direct composition:
  - `(((x_off + 0x156U >> 1) & 0x7FF003FF) | ((y_off + 0x156) * 0x200 & 0xFFFFFC00U)) & 0xFFFFFF`
  - then OR with `0x59000000`
- Build verified with `ninja`.
