### PR TITLE
ringmenu: improve GetDispCounter and Destroy matches

### DIFF
--- a/include/ffcc/ringmenu.h
+++ b/include/ffcc/ringmenu.h
@@ -18,7 +18,7 @@ public:
 
     void Create();
     void Destroy();
-    void GetDispCounter();
+    double GetDispCounter();
     void onCalc();
     void onDraw();
     void drawGBA();

--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -32,22 +32,31 @@ void CRingMenu::Create()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a51e4
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CRingMenu::Destroy()
 {
-	// TODO
+	CMenu::Destroy();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a51ac
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRingMenu::GetDispCounter()
+double CRingMenu::GetDispCounter()
 {
-	// TODO
+	const int displayCounter = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x500);
+	return -(static_cast<double>(static_cast<float>(displayCounter) * 0.0625f - 1.0f));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CRingMenu::GetDispCounter` signature to return `double` in `include/ffcc/ringmenu.h`.
- Implemented `CRingMenu::GetDispCounter` in `src/ringmenu.cpp` using the observed `displayCounter` field at offset `0x500`.
- Implemented `CRingMenu::Destroy` to call `CMenu::Destroy()`.
- Added PAL address/size metadata blocks for the two implemented functions.

## Functions improved
- `GetDispCounter__9CRingMenuFv`
  - Before: `7.142857%`
  - After: `85.35714%`
- `Destroy__9CRingMenuFv`
  - Before: `12.5%`
  - After: `100.0%`

## Match evidence
- Unit: `main/ringmenu`
- `.text` match percent
  - Before: `2.8786247%`
  - After: `3.6222038%`
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/ringmenu -o - <symbol>`

## Plausibility rationale
- `Destroy` delegating to base `CMenu::Destroy()` is idiomatic source-level behavior for this class hierarchy and matches the observed target assembly pattern.
- `GetDispCounter` now expresses the expected ring menu fade/transition scalar computation and uses the class state value from the decompiled layout, rather than a placeholder stub.
- Changes avoid contrived compiler-coaxing patterns and follow existing source style in this unit.

## Technical details
- Per-symbol objdiff was used to validate real instruction-level improvement.
- A first-pass `Create` implementation was tested and then reverted because it regressed match score; final PR keeps only net-positive changes.
