### PR TITLE
main/chunkfile: improve GetNextChunk match via signed align path

### DIFF
--- a/src/chunkfile.cpp
+++ b/src/chunkfile.cpp
@@ -93,13 +93,20 @@ void CChunkFile::PopChunk()
 bool CChunkFile::GetNextChunk(CChunk& outChunk)
 {
     int skip;
-    unsigned int alignedSize;
+    int alignedSize;
+    unsigned int roundUp;
 
     if (m_lastChunkSize < 0) {
         skip = 0;
     } else {
-        alignedSize = static_cast<unsigned int>(m_lastChunkSize + 0xF);
-        skip = (((int)alignedSize >> 4) + ((int)alignedSize < 0 && (alignedSize & 0xF) != 0)) * 0x10 + 0x10;
+        alignedSize = m_lastChunkSize + 0xF;
+        roundUp = 0;
+        if (alignedSize < 0) {
+            if ((alignedSize & 0xF) != 0) {
+                roundUp = 1;
+            }
+        }
+        skip = ((alignedSize >> 4) + static_cast<int>(roundUp)) * 0x10 + 0x10;
     }
 
     m_scopeOffset += skip;


### PR DESCRIPTION
## Summary
- Updated `CChunkFile::GetNextChunk` skip/alignment calculation to use signed arithmetic with explicit round-up control flow.
- Kept behavior unchanged while steering codegen toward the original branch sequence in the chunk-size alignment path.

## Functions improved
- Unit: `main/chunkfile`
- Symbol: `GetNextChunk__10CChunkFileFRQ210CChunkFile6CChunk`

## Match evidence
- Before: `81.458336%`
- After: `84.895836%`
- Net: `+3.4375` percentage points
- Objdiff diff-kind signal (same symbol):
  - `MATCH` instructions: `44 -> 45`
  - `DIFF_INSERT`: `7 -> 6`

## Plausibility rationale
- `Check/round-up` logic is expressed as straightforward signed integer control flow, which is plausible original source style for chunk readers.
- No contrived temporaries or unnatural reordering were introduced beyond what was needed to match the signed alignment behavior.

## Technical details
- Previous code used an unsigned temporary in the alignment expression; target assembly expects signed-path correction.
- The new code computes `alignedSize` as signed and applies explicit conditional `roundUp` before computing `skip`, improving instruction alignment in the first arithmetic block.