### PR TITLE
system: improve CSystem::Printf match by using USB logger

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -12,6 +12,7 @@
 #include "ffcc/stopwatch.h"
 #include "ffcc/gbaque.h"
 #include "ffcc/textureman.h"
+#include "ffcc/usb.h"
 
 #include "dolphin/gx/GXPerf.h"
 #include "dolphin/os.h"
@@ -204,8 +205,7 @@ void CSystem::Printf(char* fmt, ...)
     va_start(args, fmt);
     vsprintf(buffer, fmt, args);
     va_end(args);
-    OSReport(buffer);
-    // USB.Printf(buffer);
+    USB.Printf(buffer);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CSystem::Printf` to send formatted output through `USB.Printf`.
- Added the missing `#include "ffcc/usb.h"` required for the global `USB` logger symbol.

## Functions improved
- Unit: `main/system`
- Symbol: `Printf__7CSystemFPce`

## Match evidence
- `Printf__7CSystemFPce`: **72.695656% -> 77.26087%** (`+4.565214`)
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/system -o - Printf__7CSystemFPce`
  - Full rebuild via `ninja` completed successfully.

## Plausibility rationale
- A system-level variadic printf path routing to the USB debug channel is plausible original game-dev code for runtime debugging on hardware.
- This change aligns the function with the project’s existing USB logging infrastructure (`CUSB::Printf`).

## Technical details
- The change is intentionally minimal (single function + include) to isolate codegen effects to `Printf__7CSystemFPce`.
- No control-flow restructuring or compiler-coaxing patterns were introduced.
