### PR TITLE
TRK: align write_aram DMA scratch buffer

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -251,7 +251,7 @@ void TRK__write_aram(register u32 param_1, register u32 param_2, u32* param_3)
 	u32 iVar5;
 	u32 uVar6;
 	u32 uVar7;
-	u8 auStack_60[60];
+	u8 auStack_60[0x20] __attribute__((aligned(32)));
 
 	if (param_2 < 0x4000) {
 		return;


### PR DESCRIPTION
## Summary
- Updated `TRK__write_aram` in `src/TRK_MINNOW_DOLPHIN/dolphin_trk.c` to use a 32-byte aligned DMA scratch buffer.
- Kept behavior unchanged: same staging logic and DMA sizes, only buffer declaration/layout was adjusted.

## Functions improved
- Unit: `main/TRK_MINNOW_DOLPHIN/dolphin_trk`
- Symbol: `TRK__write_aram`
  - Before: `67.138214%`
  - After: `71.61789%`

## Match evidence
- `objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - TRK__write_aram`
  - Improved by `+4.479676` points.
- Unit `.text` match (same objdiff run):
  - Before: `83.25628%`
  - After: `84.6407%`

## Plausibility rationale
- AR DMA and dcache block operations are 32-byte granularity; a 32-byte aligned staging buffer is expected and idiomatic for this code path.
- This is a source-plausible type/layout correction, not contrived control-flow coercion.

## Technical details
- Changed:
  - `u8 auStack_60[60];`
  - to `u8 auStack_60[0x20] __attribute__((aligned(32)));`
- Resulting codegen moved measurably closer to target in `TRK__write_aram` while preserving surrounding logic.
