### PR TITLE
gx/GXLight: improve GXInitSpecularDir match

### DIFF
--- a/src/gx/GXLight.c
+++ b/src/gx/GXLight.c
@@ -225,6 +225,7 @@ void GXGetLightDir(const GXLightObj* lt_obj, f32* nx, f32* ny, f32* nz) {
 
 void GXInitSpecularDir(GXLightObj* lt_obj, f32 nx, f32 ny, f32 nz) {
     f32 mag;
+    f32 tmp;
     f32 vx;
     f32 vy;
     f32 vz;
@@ -236,9 +237,13 @@ void GXInitSpecularDir(GXLightObj* lt_obj, f32 nx, f32 ny, f32 nz) {
 
     vx = -nx;
     vy = -ny;
-    vz = -nz + 1.0f;
+    vz = 1.0f - nz;
 
-    mag = (vx * vx) + (vy * vy) + (vz * vz);
+    mag = vx * vx;
+    tmp = vy * vy;
+    mag += tmp;
+    tmp = vz * vz;
+    mag += tmp;
     if (mag != 0.0f) {
         mag = 1.0f / sqrtf(mag);
     }


### PR DESCRIPTION
## Summary
Refactored `GXInitSpecularDir` in `src/gx/GXLight.c` to compute the direction-vector magnitude using explicit intermediate steps (`tmp`) and stable operation ordering.

This keeps behavior identical while guiding MWCC toward a closer instruction sequence for the dot-product portion of the function.

## Functions improved
- Unit: `main/gx/GXLight`
- Symbol: `GXInitSpecularDir`
- Size: 228 bytes

## Match evidence
- `GXInitSpecularDir` fuzzy match: **79.91228% -> 83.333336%**
- Nearby tracked functions remained unchanged:
  - `GXSetChanCtrl`: 65.196075%
  - `GXSetChanMatColor`: 93.11475%
  - `GXInitLightSpot`: 93.0%

Objdiff spot-check (`build/tools/objdiff-cli diff -p . -u main/gx/GXLight GXInitSpecularDir`) shows improved alignment in the pre-normalization arithmetic sequence (dot-product setup), with remaining differences primarily in register allocation/stack layout.

## Plausibility rationale
The change is source-plausible and idiomatic C:
- no contrived control-flow or unsafe casts
- straightforward explicit temporaries for vector magnitude accumulation
- no hardcoded offsets or readability regressions

This looks like a realistic original-source variant rather than compiler-only coaxing.
