### PR TITLE
Implement CGame script save/load helpers

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -837,22 +837,60 @@ void CGame::ParticleFrameCallback(int, int, int, int, int, Vec*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001462c
+ * PAL Size: 136b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGame::SaveScript(char*)
+void CGame::SaveScript(char* scriptData)
 {
-	// TODO
+    memset(scriptData, 0, 0x800);
+
+    int scriptOffset = 0;
+    int entryOffset = 0;
+    int i = 0;
+    int count = *(int*)(CFlat + 4);
+    u8* table = *(u8**)(CFlat + 8);
+    u32* values = *(u32**)(CFlat + 12);
+
+    while (i < count) {
+        if ((table[entryOffset + 1] & 0x20) != 0) {
+            *(u32*)(scriptData + scriptOffset) = values[i];
+            scriptOffset += 4;
+        }
+        entryOffset += 4;
+        ++i;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800145d8
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGame::LoadScript(char*)
+void CGame::LoadScript(char* scriptData)
 {
-	// TODO
+    int scriptOffset = 0;
+    int entryOffset = 0;
+    int i = 0;
+    int count = *(int*)(CFlat + 4);
+    u8* table = *(u8**)(CFlat + 8);
+    u32* values = *(u32**)(CFlat + 12);
+
+    while (i < count) {
+        if ((table[entryOffset + 1] & 0x20) != 0) {
+            values[i] = *(u32*)(scriptData + scriptOffset);
+            scriptOffset += 4;
+        }
+        entryOffset += 4;
+        ++i;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two previously stubbed script serialization helpers in `src/game.cpp`:
- `CGame::SaveScript(char*)`
- `CGame::LoadScript(char*)`

Both now follow the existing `CFlat` runtime table/flag layout and copy only entries marked with script-save flag bit `0x20`, matching the decompilation behavior.

## Functions improved
- `SaveScript__5CGameFPc` (PAL 0x8001462c, 136b)
- `LoadScript__5CGameFPc` (PAL 0x800145d8, 84b)

## Match evidence
From `build/GCCP01/report.json` function fuzzy match values:
- `SaveScript__5CGameFPc`: **2.9411764% -> 63.14706%**
- `LoadScript__5CGameFPc`: **4.7619047% -> 24.380953%**

Additional `objdiff-cli diff` symbol-level `match_percent` after this change:
- `SaveScript__5CGameFPc`: **61.411766%**
- `LoadScript__5CGameFPc`: **21.809525%**

Build validation:
- `ninja` passes and regenerates report/progress successfully.

## Plausibility rationale
This change replaces `// TODO` bodies with straightforward serialization logic that is source-plausible for the original codebase:
- uses `memset` to clear save buffer (`0x800`) before writing
- iterates runtime entries with simple counters/offsets
- gates copy behavior on the per-entry flag byte (`+1`, mask `0x20`)
- keeps behavior symmetric between save and load paths

No contrived temporaries, no artificial control-flow shaping, and no debug artifacts were added.
