### PR TITLE
main/p_map: implement CMapPcs::drawViewer

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/map.h"
 #include "ffcc/materialman.h"
 #include "ffcc/p_camera.h"
+#include "ffcc/p_game.h"
 
 #include <dolphin/mtx.h>
 
@@ -44,6 +45,8 @@ extern unsigned int lbl_8032ECCC;
 extern unsigned int lbl_8032ECD0;
 extern unsigned int CFlatFlags;
 extern CMaterialMan MaterialMan;
+extern "C" void _WaitDrawDone__8CGraphicFPci(CGraphic*, const char*, int);
+extern "C" const char s_p_map_cpp_801d7728[];
 
 extern "C" void __dl__FPv(void*);
 extern "C" void* __register_global_object(void* object, void* destructor, void* regmem);
@@ -243,12 +246,58 @@ void CMapPcs::drawBeforeViewer()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80034dc0
+ * PAL Size: 532b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapPcs::drawViewer()
 {
-	// TODO
+    if ((*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x180) != 0) &&
+        (*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x178) == 0)) {
+        Mtx cameraMtx;
+        Mtx44 screenMtx;
+
+        if (Game.game.m_currentSceneId == 3) {
+            _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_map_cpp_801d7728, 0x2C4);
+        }
+
+        MaterialMan.InitVtxFmt(-1, GX_F32, 0, GX_RGBA4, 0xE, GX_RGBA6, 0xA);
+
+        *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228DC) =
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0);
+        *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228E0) =
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE4);
+        *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228E4) =
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE8);
+
+        PSMTXCopy(*reinterpret_cast<Mtx*>(reinterpret_cast<char*>(&CameraPcs) + 0x4), cameraMtx);
+        PSMTX44Copy(*reinterpret_cast<Mtx44*>(reinterpret_cast<char*>(&CameraPcs) + 0x48), screenMtx);
+        MapMng.SetViewMtx(cameraMtx, screenMtx);
+        Graphic.SetFog(*reinterpret_cast<unsigned char*>(reinterpret_cast<char*>(&MapMng) + 0x22978), 0);
+
+        GXSetColorUpdate(GX_TRUE);
+        GXSetAlphaUpdate(GX_FALSE);
+        GXSetCullMode(GX_CULL_BACK);
+        GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
+
+        _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapModeTable(GX_TEV_SWAP1, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapModeTable(GX_TEV_SWAP2, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapModeTable(GX_TEV_SWAP3, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        _GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        _GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        _GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+        MapMng.Draw();
+
+        if (Game.game.m_currentSceneId == 3) {
+            _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_map_cpp_801d7728, 0x2E0);
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMapPcs::drawViewer()` in `src/p_map.cpp` using the PAL Ghidra reference structure and existing project conventions for unresolved class layouts.

Changes include:
- Added the full draw path gate checks (`this+0x180` loaded, `this+0x178` not busy)
- Added viewer debug waits in scene 3 via `_WaitDrawDone__8CGraphicFPci`
- Restored map/camera sync writes into `MapMng` camera-related fields
- Restored camera/screen matrix copies and `MapMng.SetViewMtx(...)`
- Restored fog setup, GX state setup, TEV swap setup, and `MapMng.Draw()` call
- Added PAL metadata block for this function

## Functions Improved
- Unit: `main/p_map`
- Symbol: `drawViewer__7CMapPcsFv`

## Match Evidence
- Before: `0.8%` (from `tools/agent_select_target.py` output for `main/p_map` on this branch start)
- After: `72.65414%` (`build/tools/objdiff-cli diff -p . -u main/p_map -o - drawViewer__7CMapPcsFv`)
- Function metadata: PAL address `0x80034dc0`, PAL size `532b`

This is a substantial assembly alignment gain on a previously stubbed function.

## Plausibility Rationale
This change is source-plausible for original game code because it reconstructs an expected render pass sequence (view matrix setup -> fog/state setup -> draw call) using existing engine APIs (`MapMng`, `Graphic`, GX wrappers) and established access patterns already used in this file for unknown fields.

No contrived compiler-coax patterns were introduced; the function follows the same procedural rendering style as neighboring map draw methods.

## Technical Details
- Included `ffcc/p_game.h` to access `Game.game.m_currentSceneId` for viewer wait gates
- Used existing offsets already implied by neighboring decomp in this file for camera transfer into `MapMng`
- Used external debug filename symbol `s_p_map_cpp_801d7728` instead of introducing ad-hoc string data
- Verified compile with `ninja`
