### PR TITLE
menu_equip: first-pass decomp for EquipCtrlCur/Open0/Close0

### DIFF
--- a/include/ffcc/menu_equip.h
+++ b/include/ffcc/menu_equip.h
@@ -11,9 +11,9 @@ public:
     void EquipCtrl();
     void EquipClose();
     void EquipDraw();
-    void EquipCtrlCur();
-    void EquipOpen0();
-    void EquipClose0();
+    int EquipCtrlCur();
+    int EquipOpen0();
+    int EquipClose0();
     void GetEquipItem();
     void ChkEquipActive(int);
 };


### PR DESCRIPTION
## Summary
- Implemented first-pass C++ bodies for `EquipCtrlCur__8CMenuPcsFv`, `EquipOpen0__8CMenuPcsFv`, and `EquipClose0__8CMenuPcsFv` in `src/menu_equip.cpp`.
- Updated `include/ffcc/menu_equip.h` signatures for these three methods to return `int`, matching actual callsites and behavior.
- Added PAL address/size metadata blocks for the three implemented functions.
- Included required menu input/audio dependencies (`pad.h`, `sound.h`) and missing external symbol declarations used by equip control flow.

## Functions Improved
Unit: `main/menu_equip`
- `EquipCtrlCur__8CMenuPcsFv` (1592b): **0.3% -> 44.53%**
- `EquipClose0__8CMenuPcsFv` (516b): **0.8% -> 12.07%**
- `EquipOpen0__8CMenuPcsFv` (432b): now at **43.16%** (was previously an unimplemented stub in this source)
- Unit fuzzy match moved from selector-reported ~8.3% to **17.97%** after this pass.

## Match Evidence
- Build: `ninja` succeeds.
- Objdiff (oneshot JSON):
  - `EquipCtrlCur__8CMenuPcsFv`: `44.53015`
  - `EquipOpen0__8CMenuPcsFv`: `43.157406`
  - `EquipClose0__8CMenuPcsFv`: `12.069767`
- These are structural improvements (substantial instruction-level alignment in previously near-0% functions), not formatting-only edits.

## Plausibility Rationale
- The implementation follows existing `CMenuPcs` menu-control patterns already present in nearby units (`menu_arti`, `menu_favo`, `menu_lst`):
  - same pad gating pattern (`Pad._452_4_` / `Pad._448_4_`),
  - same state-machine fields in menu work buffers,
  - same cursor/list animation progression model,
  - same sound effect usage and command transitions.
- Changes prioritize source-plausible control/data flow rather than contrived compiler coaxing.

## Technical Notes
- `EquipCtrlCur` now includes the equip selection validity path (possible/equip-type checks, equip swap, caravan status recalc, transition to command phase).
- `EquipOpen0` and `EquipClose0` now implement per-item timed alpha/offset interpolation and completion checks, plus selected-entry X reset behavior on close complete.
- `EquipDraw` and `EquipClose` remain TODO and can be targeted in follow-up passes.
