### PR TITLE
main/game: implement CGame Draw/Calc wrapper calls

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -70,6 +70,13 @@ void ScriptChanging__7CSystemFPc(CSystem*, char*);
 void ScriptChanged__7CSystemFPci(CSystem*, char*, int);
 void MapChanging__7CSystemFii(CSystem*, int, int);
 void MapChanged__7CSystemFiii(CSystem*, int, int, int);
+void Draw__13CFlatRuntime2Fv(void*);
+void Frame__13CFlatRuntime2Fii(void*, int, int);
+void AfterFrame__12CFlatRuntimeFi(void*, int);
+void SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+    void*, int, int, int, int, void*, void*);
+void Draw__5CWindFv(void*);
+void CheckMenu__10CGPartyObjFv();
 void LoadMap__7CMapPcsFiiPvUlUc(void*, int, int, void*, unsigned long, unsigned char);
 void LoadFieldPdt__8CPartPcsFiiPvUlUc(void*, int, int, void*, unsigned long, unsigned char);
 unsigned char CFlat[];
@@ -766,53 +773,77 @@ void CGame::Calc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80014964
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Calc2()
 {
-	// CFlat.Frame(0, 1);
+	Frame__13CFlatRuntime2Fii(CFlat, 0, 1);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80014934
+ * PAL Size: 48b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Calc3()
 { 
-	// CheckMenu__10CGPartyObjFv();
-	// AfterFrame__12CFlatRuntimeFi(&CFlat,0);
+	CheckMenu__10CGPartyObjFv();
+	AfterFrame__12CFlatRuntimeFi(CFlat, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800148f4
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Draw()
 {
-	// TODO
+	SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+	    CFlat, 0, 1, 6, 0, 0, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800148c0
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Draw2()
 {
-	// TODO
+	Draw__13CFlatRuntime2Fv(CFlat);
+	Draw__5CWindFv(Wind);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001486c
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGame::Draw3()
 {
-	// TODO
+	Frame__13CFlatRuntime2Fii(CFlat, 0, 2);
+	SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+	    CFlat, 0, 1, 5, 0, 0, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented five small `CGame` wrapper functions in `src/game.cpp` by replacing TODO stubs with runtime calls to existing engine entry points:
- `Calc2__5CGameFv`
- `Calc3__5CGameFv`
- `Draw__5CGameFv`
- `Draw2__5CGameFv`
- `Draw3__5CGameFv`

Also added missing `extern "C"` declarations for those runtime functions and updated per-function PAL address/size info comments.

## Functions Improved
Unit: `main/game`

Per-function objdiff results:
- `Calc2__5CGameFv`: **8.3333% -> 100.0%**
- `Calc3__5CGameFv`: **8.3333% -> 100.0%**
- `Draw__5CGameFv`: **6.25% -> 100.0%**
- `Draw2__5CGameFv`: **7.6923% -> 100.0%**
- `Draw3__5CGameFv`: **4.7619% -> 100.0%**

Unit fuzzy match:
- `main/game`: **42.613976% -> 45.48419%**

Overall progress (`ninja`):
- Matched code: **204216 -> 204512 bytes**
- Matched functions: **1554 -> 1559**

## Match Evidence
Verified with:
- `build/tools/objdiff-cli diff -p . -u main/game -o /tmp/game_wrappers_before.json Draw2__5CGameFv`
- `build/tools/objdiff-cli diff -p . -u main/game -o /tmp/game_wrappers_after.json Draw2__5CGameFv`

The generated diff JSON shows all five symbols now at 100% match.

## Plausibility Rationale
These are thin wrapper functions that dispatch to existing runtime systems (`CFlat`, `Wind`, and system-call helpers). The changes are direct behavioral restorations from obvious TODO stubs to idiomatic call-through wrappers already used throughout this codebase, with no contrived temporaries or compiler-coaxing control flow.

## Technical Notes
- `Draw`/`Draw3` now invoke the flat-runtime system call with command IDs `6` and `5` respectively.
- `Draw2` now issues the expected flat-runtime draw + wind draw sequence.
- `Calc2`/`Calc3` now call flat-runtime frame/after-frame and party menu check paths matching the decomp intent.
