### PR TITLE
GXInit: improve __GXDefaultTexRegionCallback match

### DIFF
--- a/src/gx/GXInit.c
+++ b/src/gx/GXInit.c
@@ -111,22 +111,23 @@ static void DisableWriteGatherPipe(void) {
  */
 static GXTexRegion* __GXDefaultTexRegionCallback(const GXTexObj* t_obj, GXTexMapID id) {
     u32 count;
-    u8* gx = (u8*)__GXData;
+    s32 offset;
+    u32 base = (u32)__GXData;
+    GXTexFmt format = GXGetTexObjFmt(t_obj);
 
     (void)id;
 
-    switch (GXGetTexObjFmt(t_obj)) {
-    case GX_TF_C4:
-    case GX_TF_C8:
-    case GX_TF_C14X2:
-        count = *(u32*)(gx + 0x2CC);
-        *(u32*)(gx + 0x2CC) = count + 1;
-        return (GXTexRegion*)(gx + (((count & 3) << 4) + 0x288));
-    default:
-        count = *(u32*)(gx + 0x2C8);
-        *(u32*)(gx + 0x2C8) = count + 1;
-        return (GXTexRegion*)(gx + (((count & 7) << 4) + 0x208));
+    if ((format >= GX_TF_C4) && (format <= GX_TF_C14X2)) {
+        count = *(u32*)(base + 0x2CC);
+        *(u32*)(base + 0x2CC) = count + 1;
+        offset = ((count & 3) << 4) + 0x288;
+    } else {
+        count = *(u32*)(base + 0x2C8);
+        *(u32*)(base + 0x2C8) = count + 1;
+        offset = ((count & 7) << 4) + 0x208;
     }
+
+    return (GXTexRegion*)(base + offset);
 }
 
 static GXTlutRegion* __GXDefaultTlutRegionCallback(u32 idx) {


### PR DESCRIPTION
## Summary
Refactored `__GXDefaultTexRegionCallback` in `src/gx/GXInit.c` to use a single base-address + offset path with explicit format capture and range-based branch selection.

## Functions improved
- Unit: `main/gx/GXInit`
- Symbol: `__GXDefaultTexRegionCallback`
  - Before: `62.870968%`
  - After: `64.22581%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/gx/GXInit -o - __GXDefaultTexRegionCallback`
- Unit `.text` match moved from `69.86389%` to `69.897514%`.
- Diff profile improved in callback body:
  - `DIFF_ARG_MISMATCH`: 17 -> 16
  - `DIFF_DELETE`: 5 -> 4

## Plausibility rationale
The rewrite keeps the same behavior but expresses the callback in a source-plausible SDK style: compute texture format once, select one of two counter/update paths, and return `base + offset`. This avoids coercive/noisy constructs and stays close to likely original C control flow.

## Technical details
- Replaced a switch over three explicit cases with one range test for CI formats (`GX_TF_C4..GX_TF_C14X2`).
- Consolidated duplicated return/address arithmetic into a shared `offset` + final return.
- Preserved all existing constants and memory offsets used by the original callback logic.
