### PR TITLE
pppYmEnv: align small helper ABI/signature behavior

### DIFF
--- a/include/ffcc/pppYmEnv.h
+++ b/include/ffcc/pppYmEnv.h
@@ -16,7 +16,7 @@ struct Vec;
 CChara::CModel* GetModelPtr(CGObject*);
 void GetCharaNodeFrameMatrix(_pppMngSt*, float, float (*)[4]);
 void CalcGraphValue(_pppPObject*, long, float&, float&, float&, float, float&, float&);
-void GetTextureFromRSD(int, _pppEnvSt*);
+int GetTextureFromRSD(int, _pppEnvSt*);
 CChara::CModel* GetCharaModelPtr(CCharaPcs::CHandle*);
 CCharaPcs::CHandle* GetCharaHandlePtr(CGObject*, long);
 void DisableIndWarp(_GXTevStageID, _GXIndTexStageID);

--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -99,17 +99,17 @@ void CalcGraphValue(_pppPObject* object, long graphId, float& value, float& velo
  * JP Address: TODO
  * JP Size: TODO
  */
-void GetTextureFromRSD(int mapMeshIndex, _pppEnvSt* env)
+int GetTextureFromRSD(int mapMeshIndex, _pppEnvSt* env)
 {
     int textureIndex;
 
     if (mapMeshIndex == 0xFFFF) {
-        return;
+        return 0;
     }
 
     textureIndex = 0;
-    GetTexture__8CMapMeshFP12CMaterialSetRi(((_pppEnvStYmEnv*)env)->m_mapMeshPtr[mapMeshIndex],
-                                            ((_pppEnvStYmEnv*)env)->m_materialSetPtr, textureIndex);
+    return GetTexture__8CMapMeshFP12CMaterialSetRi(((_pppEnvStYmEnv*)env)->m_mapMeshPtr[mapMeshIndex],
+                                                   ((_pppEnvStYmEnv*)env)->m_materialSetPtr, textureIndex);
 }
 
 /*
@@ -123,11 +123,11 @@ void GetTextureFromRSD(int mapMeshIndex, _pppEnvSt* env)
  */
 CChara::CModel* GetCharaModelPtr(CCharaPcs::CHandle* handle)
 {
-    if (handle == 0) {
-        return 0;
+    if (handle != 0) {
+        return handle->m_model;
     }
 
-    return handle->m_model;
+    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `GetTextureFromRSD` to return the underlying texture lookup result instead of `void`.
- Kept the early `0xFFFF` path explicit (`return 0`) and returned the call result in the normal path.
- Reordered `GetCharaModelPtr` null-check flow to match target branch structure.

## Functions improved
- `GetCharaModelPtr__FPQ29CCharaPcs7CHandle`: **31.666666% -> 100.0%** (24b)
- `GetTextureFromRSD__FiP9_pppEnvSt`: **62.5% -> 70.25%** (size moved from 72b to expected 80b)

## Match evidence
Objdiff command used:
```sh
build/tools/objdiff-cli diff -p . -u main/pppYmEnv -o - <symbol>
```
Before/after symbols:
- `GetCharaModelPtr__FPQ29CCharaPcs7CHandle`: 31.666666 -> 100.0
- `GetTextureFromRSD__FiP9_pppEnvSt`: 62.5 -> 70.25
- `GetCharaHandlePtr__FP8CGObjectl`: unchanged at 70.92308
- `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf`: unchanged at 99.95652

## Plausibility rationale
- Returning the result of `GetTexture__8CMapMeshFP12CMaterialSetRi` is source-plausible and semantically clearer than discarding it.
- The `GetCharaModelPtr` null-guard is standard idiomatic C++ and matches expected control flow for this tiny accessor.
- No contrived temporaries, hardcoded offsets, or non-idiomatic ordering were introduced.

## Technical details
- Main improvement came from ABI/signature correction in `GetTextureFromRSD` (`void` -> `int`) and direct return of call result.
- `GetCharaModelPtr` reached full match after branch ordering alignment.
- Build passes with `ninja` after changes.
