### PR TITLE
RedDriver: implement _DMACheckProcess

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/RedSound/RedStream.h"
 #include "ffcc/RedSound/RedCommand.h"
 #include "ffcc/RedSound/RedExecute.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/file_io.h"
 #include "dolphin/ar.h"
 #include "dolphin/ax.h"
 #include "dolphin/os.h"
@@ -48,6 +49,7 @@ extern int DAT_8032f404;
 extern int DAT_8032f410;
 extern int DAT_8032f40c;
 extern int DAT_8032f468;
+extern int DAT_8032f484;
 extern int DAT_8032f434;
 extern int DAT_8032f430;
 extern int DAT_8032f488;
@@ -98,6 +100,7 @@ extern OSThread DAT_8032d788;
 extern OSThread DAT_8032de08;
 extern OSThread DAT_8032d460;
 extern ARQRequest DAT_8032dde4;
+extern FILE DAT_8021d1a8;
 
 extern void ReverbAreaAlloc(unsigned long);
 extern void ReverbAreaFree(void*);
@@ -657,12 +660,37 @@ void _WaveSettingThread(void*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bdfac
+ * PAL Size: 280b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void _DMACheckProcess()
 {
-	// TODO
+    int semCount;
+    int* dmaInfo;
+
+    if (DAT_8032f408 != 0) {
+        OSReport("[%s]------DMA_CHECK_PROCESS------\n", "RedDriver");
+        fflush(&DAT_8021d1a8);
+
+        semCount = OSGetSemaphoreCount(&DAT_8032ddd8);
+        OSReport("[%s]Status = %d Semaphore = %d Entry = %d/%d\n", "RedDriver", DAT_8032f468, semCount, DAT_8032f484, DAT_8032f488);
+        fflush(&DAT_8021d1a8);
+    }
+
+    dmaInfo = (int*)&DAT_8032b860;
+    do {
+        if ((*dmaInfo != 0) && (DAT_8032f408 != 0)) {
+            OSReport("[%s]ID = %d MMem = %8.8X AMem = %8.8X Size = %d %d\n", "RedDriver", dmaInfo[0], dmaInfo[2], dmaInfo[3], dmaInfo[4], dmaInfo[5]);
+            fflush(&DAT_8021d1a8);
+        }
+        dmaInfo += 7;
+    } while (dmaInfo < (int*)&DAT_8032d460);
+
+    fflush(&DAT_8021d1a8);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `_DMACheckProcess()` in `src/RedSound/RedDriver.cpp` using the PAL-addressed Ghidra reference as a guide.

Changes made:
- replaced TODO stub with DMA status/semaphore diagnostics and queue iteration
- added PAL metadata block for the function (`0x801bdfac`, `280b`)
- added required extern declarations (`DAT_8032f484`, `DAT_8021d1a8`) and `file_io.h` include for `fflush`

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `_DMACheckProcess__Fv`

## Match evidence
- Selector baseline before edit: `_DMACheckProcess__Fv` reported at `1.4%` match
- After edit (`build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - _DMACheckProcess__Fv`): `_DMACheckProcess__Fv` is `67.314285%` match (size `280`)

## Plausibility rationale
The implementation follows expected original source behavior for a debug DMA checker:
- conditional debug output gated on the global debug flag
- semaphore count read via `OSGetSemaphoreCount`
- linear iteration through DMA entry slots with fixed record stride
- reporting only active entries and flushing output between reports

This is source-plausible game/engine debugging code, not compiler coaxing.

## Technical details
- loop stride is `7` integers per DMA entry, matching surrounding DMA queue layout
- loop bound uses the next global block start (`&DAT_8032d460`) exactly as reflected in decomp context
- report fields map to active entry id and memory/size fields (`[0], [2], [3], [4], [5]`)
