### PR TITLE
GXPixel: improve GXSetFogRangeAdj match

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -147,19 +147,29 @@ void GXSetFogRangeAdj(GXBool enable, u16 center, const GXFogAdjTable *table) {
     if (enable) {
         ASSERTMSGLINE(334, table != NULL, "GXSetFogRangeAdj: table pointer is null");
 
-        range_adj = (table->r[0] & 0xfff) | ((table->r[1] & 0xfff) << 12) | 0xe9000000;
+        range_adj = ((u32)table->r[1] << 12);
+        range_adj = (range_adj & 0x00fff000) | (table->r[0] & 0xfff);
+        range_adj |= 0xe9000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[2] & 0xfff) | ((table->r[3] & 0xfff) << 12) | 0xea000000;
+        range_adj = ((u32)table->r[3] << 12);
+        range_adj = (range_adj & 0x00fff000) | (table->r[2] & 0xfff);
+        range_adj |= 0xea000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[4] & 0xfff) | ((table->r[5] & 0xfff) << 12) | 0xeb000000;
+        range_adj = ((u32)table->r[5] << 12);
+        range_adj = (range_adj & 0x00fff000) | (table->r[4] & 0xfff);
+        range_adj |= 0xeb000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[6] & 0xfff) | ((table->r[7] & 0xfff) << 12) | 0xec000000;
+        range_adj = ((u32)table->r[7] << 12);
+        range_adj = (range_adj & 0x00fff000) | (table->r[6] & 0xfff);
+        range_adj |= 0xec000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[8] & 0xfff) | ((table->r[9] & 0xfff) << 12) | 0xed000000;
+        range_adj = ((u32)table->r[9] << 12);
+        range_adj = (range_adj & 0x00fff000) | (table->r[8] & 0xfff);
+        range_adj |= 0xed000000;
         GX_WRITE_RAS_REG(range_adj);
     }
 


### PR DESCRIPTION
## Summary
- Reworked `GXSetFogRangeAdj` register packing expressions in `src/gx/GXPixel.c` to use explicit staged packing (`shift -> mask/merge -> opcode OR`) for each fog adjustment register write.
- Kept behavior unchanged while steering codegen closer to expected PPC instruction forms.

## Functions improved
- Unit: `main/gx/GXPixel`
- Symbol: `GXSetFogRangeAdj`

## Match evidence
- `GXSetFogRangeAdj`: **59.8125% -> 61.96875%** (`+2.15625`)
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXPixel -o - GXSetFogRangeAdj`

## Plausibility rationale
- The rewrite is source-plausible SDK-style bitfield packing, not artificial control-flow manipulation.
- It preserves clear intent: pack two 12-bit table entries and then apply the register opcode field.

## Technical details
- Moved from a single composite expression per write to a staged form:
  - cast/shift upper 12-bit value
  - masked merge of lower 12-bit value
  - high opcode insertion via `|= 0xEx000000`
- This reduced opcode-level mismatches in objdiff for the range-adjust register writes.
