### PR TITLE
main/wind: improve ChangePower__5CWindFif match

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -557,39 +557,45 @@ found:
  */
 void CWind::ChangePower(int id, float power)
 {
-	u8* found = 0;
+	u8* found;
 	u8* scan = (u8*)this;
 	int group = 8;
 
 	do {
 		found = scan;
-		if ((s8)found[0] < 0 && id == *(s32*)(found + 0x20)) {
-			break;
+		if (((s8)found[0] >= 0) || (id != *(s32*)(found + 0x20))) {
+			;
+		} else {
+			goto found_label;
 		}
 
 		found = scan + 100;
-		if ((s8)found[0] < 0 && id == *(s32*)(found + 0x20)) {
-			break;
+		if (((s8)found[0] >= 0) || (id != *(s32*)(found + 0x20))) {
+			;
+		} else {
+			goto found_label;
 		}
 
 		found = scan + 200;
-		if ((s8)found[0] < 0 && id == *(s32*)(found + 0x20)) {
-			break;
+		if (((s8)found[0] >= 0) || (id != *(s32*)(found + 0x20))) {
+			;
+		} else {
+			goto found_label;
 		}
 
 		found = scan + 300;
-		if ((s8)found[0] < 0 && id == *(s32*)(found + 0x20)) {
-			break;
+		if (((s8)found[0] >= 0) || (id != *(s32*)(found + 0x20))) {
+			;
+		} else {
+			goto found_label;
 		}
 
 		scan += 400;
 		group--;
 	} while (group != 0);
+	found = 0;
 
-	if (group == 0) {
-		found = 0;
-	}
-
+found_label:
 	if (found != 0) {
 		*(float*)(found + 0x54) = power;
 		*(float*)(found + 0x4C) = power;


### PR DESCRIPTION
## Summary
Adjusted `CWind::ChangePower(int, float)` control flow in `src/wind.cpp` to better match expected branch structure while preserving behavior.

## Functions improved
- Unit: `main/wind`
- Symbol: `ChangePower__5CWindFif`

## Match evidence
- `ChangePower__5CWindFif`: `62.375%` -> `66.541664%` (objdiff, sequential build then diff)
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/wind -o - ChangePower__5CWindFif`

## Plausibility rationale
The change keeps original semantics (search active wind entries by id, then update two power fields) and only restructures conditionals/exit flow to a pattern consistent with nearby decompiled wind object scans.

## Technical details
- Replaced direct `break`-style early exit with explicit branch-to-found flow.
- Used equivalent inverted conditions (`>= 0` / `!=`) to align compare/branch ordering seen in objdiff.
- Kept data layout and field writes unchanged (`+0x54` and `+0x4C`).
