### PR TITLE
gx/GXFrameBuf: improve GXSetCopyClear match via register packing

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -356,21 +356,15 @@ void GXSetCopyClear(GXColor clear_clr, u32 clear_z) {
     CHECK_GXBEGIN(1596, "GXSetCopyClear");
     ASSERTMSGLINE(1598, clear_z <= 0xFFFFFF, "GXSetCopyClear: Z clear value is out of range");
 
-    regA = clear_clr.a;
-    regA = (regA << 8) | clear_clr.r;
-    regA = (regA & 0xFFFF) | 0x4F000000;
-    GX_WRITE_U8(0x61);
-    GX_WRITE_U32(regA);
+    regA = clear_clr.r;
+    regA = (regA & ~0xFF00) | ((u32)clear_clr.a << 8);
+    GX_WRITE_RAS_REG(regA | 0x4F000000);
 
-    regGB = clear_clr.g;
-    regGB = (regGB << 8) | clear_clr.b;
-    regGB = (regGB & 0xFFFF) | 0x50000000;
-    GX_WRITE_U8(0x61);
-    GX_WRITE_U32(regGB);
+    regGB = clear_clr.b;
+    regGB = (regGB & ~0xFF00) | ((u32)clear_clr.g << 8);
+    GX_WRITE_RAS_REG(regGB | 0x50000000);
 
-    regA = (clear_z & 0xFFFFFF) | 0x51000000;
-    GX_WRITE_U8(0x61);
-    GX_WRITE_U32(regA);
+    GX_WRITE_RAS_REG((clear_z & 0xFFFFFF) | 0x51000000);
 
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
## Summary
- Reworked `GXSetCopyClear` register packing to use `GX_WRITE_RAS_REG` consistently and pack channel bytes in a form closer to the original MWCC output.
- Kept behavior identical: same BP writes (`0x4F`, `0x50`, `0x51`) and same Z-range assertion.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Function: `GXSetCopyClear`

## Match evidence
- `GXSetCopyClear`: **62.807693% -> 86.34615%** (+23.538457)
- Unit `.text` (`main/gx/GXFrameBuf`): **81.183556% -> 81.912994%** (+0.729438)
- Validation command used:
  - `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o -`

## Plausibility rationale
- The new code remains idiomatic SDK-style source: explicit channel packing into BP register values and direct use of `GX_WRITE_RAS_REG` helper macro already used throughout GX code.
- No contrived temporaries, offset tricks, or readability regressions were introduced; the change is a straightforward expression of likely original intent.
