### PR TITLE
pppYmTraceMove: improve null-owner frame path matching

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -79,7 +79,6 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 	Vec local_50;
 	Vec local_44;
 	Vec local_38;
-	Vec local_8c;
 	Vec local_2c;
 	Vec local_20;
 	f32 fVar1;
@@ -100,15 +99,8 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 	}
 
 	if (owner == nullptr) {
-		local_8c.x = dest->x;
-		local_8c.y = dest->y;
-		local_8c.z = dest->z;
-		pppCopyVector__FR3Vec3Vec(&local_20, &local_8c);
-
-		local_8c.x = dest[1].y;
-		local_8c.y = dest[1].z;
-		local_8c.z = dest[2].x;
-		pppCopyVector__FR3Vec3Vec(&local_2c, &local_8c);
+		pppCopyVector__FR3Vec3Vec(&local_20, dest);
+		pppCopyVector__FR3Vec3Vec(&local_2c, (Vec*)&dest[1].y);
 	} else {
 		local_b0.x = *(f32*)(owner + 0x15c);
 		local_b0.y = *(f32*)(owner + 0x160);


### PR DESCRIPTION
## Summary
- Simplified the `owner == nullptr` path in `pppFrameYmTraceMove` by removing an unnecessary temporary `Vec` staging variable.
- Replaced manual component copies with direct `pppCopyVector__FR3Vec3Vec` calls:
  - `pppCopyVector__FR3Vec3Vec(&local_20, dest)`
  - `pppCopyVector__FR3Vec3Vec(&local_2c, (Vec*)&dest[1].y)`
- Kept constructor logic unchanged from baseline to avoid regressions.

## Functions Improved
- Unit: `main/pppYmTraceMove`
- Symbol: `pppFrameYmTraceMove` (size 936b)
  - Before: `63.320515%`
  - After: `64.61966%`
  - Delta: `+1.299145` points

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmTraceMove -o - pppFrameYmTraceMove`
- `pppConstructYmTraceMove` verified unchanged from baseline:
  - Before: `59.069767%`
  - After: `59.069767%`
- Build verification:
  - `ninja` completed successfully.

## Plausibility Rationale
- The new code removes redundant temporary data movement and uses direct vector-copy operations on existing contiguous data.
- This is a natural source-level simplification a game developer would reasonably write, not contrived compiler-only coaxing.
- Behavior is preserved while aligning emitted code closer to target assembly.

## Technical Details
- The previous null-owner branch copied `dest` and `dest[1].y/z + dest[2].x` through a temporary `local_8c` before copying again.
- The updated path performs equivalent copies directly from source memory, reducing intermediate stack traffic and improving instruction alignment in objdiff.
