### PR TITLE
RedSound: implement missing CRedSound forwarding wrappers

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -461,9 +461,9 @@ void CRedSound::SetSeSepData(void* seSepData)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::ClearSeSepData(int)
+void CRedSound::ClearSeSepData(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.ClearSeSepData(id);
 }
 
 /*
@@ -485,9 +485,9 @@ void CRedSound::ClearSeSepDataMG(int bank, int sep, int group, int kind)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::ReentrySeSepData(int)
+void CRedSound::ReentrySeSepData(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.ReentrySeSepData(id);
 }
 
 /*
@@ -495,9 +495,9 @@ void CRedSound::ReentrySeSepData(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::SePlayState(int)
+void CRedSound::SePlayState(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.SePlayState(id);
 }
 
 /*
@@ -505,9 +505,9 @@ void CRedSound::SePlayState(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::SeStop(int)
+void CRedSound::SeStop(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.SeStop(id);
 }
 
 /*
@@ -783,9 +783,9 @@ unsigned int CRedSound::SetWaveData(int waveID, void* waveData, int waveSize)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::ClearWaveData(int)
+void CRedSound::ClearWaveData(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.ClearWaveData(id);
 }
 
 /*
@@ -807,9 +807,9 @@ void CRedSound::ClearWaveDataM(int bank, int sep, int group, int kind)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::ClearWaveBank(int)
+void CRedSound::ClearWaveBank(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.ClearWaveBank(id);
 }
 
 /*
@@ -817,9 +817,9 @@ void CRedSound::ClearWaveBank(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::ReentryWaveData(int)
+void CRedSound::ReentryWaveData(int id)
 {
-	// TODO
+	CRedDriver_8032f4c0.ReentryWaveData(id);
 }
 
 /*
@@ -829,7 +829,7 @@ void CRedSound::ReentryWaveData(int)
  */
 void CRedSound::DisplayWaveInfo()
 {
-	// TODO
+	CRedDriver_8032f4c0.DisplayWaveInfo();
 }
 
 /*
@@ -837,9 +837,9 @@ void CRedSound::DisplayWaveInfo()
  * Address:	TODO
  * Size:	TODO
  */
-void CRedSound::TestProcess(int)
+void CRedSound::TestProcess(int mode)
 {
-	// TODO
+	CRedDriver_8032f4c0.TestProcess(mode);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement the missing `CRedSound` wrapper methods in `src/RedSound/RedSound.cpp` by forwarding to the corresponding `CRedDriver` methods.

## Functions improved
- `ClearSeSepData__9CRedSoundFi`: `9.090909 -> 81.27273`
- `ReentrySeSepData__9CRedSoundFi`: `9.090909 -> 81.27273`
- `SePlayState__9CRedSoundFi`: `9.090909 -> 81.27273`
- `SeStop__9CRedSoundFi`: `9.090909 -> 81.27273`
- `ClearWaveData__9CRedSoundFi`: `9.090909 -> 81.27273`
- `ClearWaveBank__9CRedSoundFi`: `9.090909 -> 81.27273`
- `ReentryWaveData__9CRedSoundFi`: `9.090909 -> 81.27273`
- `DisplayWaveInfo__9CRedSoundFv`: `11.111111 -> 100.0`
- `TestProcess__9CRedSoundFi`: `9.090909 -> 81.27273`

## Match evidence
Measured from `build/GCCP01/report.json` on this branch vs clean `main`:
- Unit `main/RedSound/RedSound` matched code: `120 -> 156` bytes
- Unit matched functions: `4 -> 5`

## Plausibility rationale
These methods are thin API wrappers in `CRedSound` and naturally delegate to `CRedDriver`; this mirrors nearby already-matched `CRedSound` methods in the same file and aligns with the function names/signatures from symbol data.

## Technical notes
- Build verified with `ninja`.
- Measurements taken by stashing/reapplying the patch around a clean-main baseline in the same workspace.
