### PR TITLE
cflat_runtime: fix low-match hook signatures

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -123,15 +123,15 @@ public:
 	void reqFinished(int, CFlatRuntime::CObject*);
 	void onDeleteObject(CFlatRuntime::CObject*);
 	void onNewObject(CFlatRuntime::CObject*);
-	void getFreeObject(int);
-	void intToClass(int);
+	CFlatRuntime::CObject* getFreeObject(int);
+	CFlatRuntime::CClass* intToClass(int);
 
-	void onSystemVal(CFlatRuntime::CObject*, int);
-	void onClassSystemVal(CFlatRuntime::CObject*, int);
+	CFlatRuntime::CVal* onSystemVal(CFlatRuntime::CObject*, int);
+	CFlatRuntime::CVal* onClassSystemVal(CFlatRuntime::CObject*, int);
 	void onSetSystemVal(int, CFlatRuntime::CStack*, int);
 	void onSetClassSystemVal(int, CFlatRuntime::CObject*, CFlatRuntime::CStack*, int);
-	void onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&);
-	void onSystemFunc(CFlatRuntime::CObject*, int, int, int&);
+	int onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&);
+	int onSystemFunc(CFlatRuntime::CObject*, int, int, int&);
 };
 
 #endif // _FFCC_CFLAT_RUNTIME_H_

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -501,9 +501,9 @@ void CFlatRuntime::onNewObject(CFlatRuntime::CObject*)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime::getFreeObject(int)
+CFlatRuntime::CObject* CFlatRuntime::getFreeObject(int)
 {
-	// TODO
+	return 0;
 }
 
 /*
@@ -511,9 +511,9 @@ void CFlatRuntime::getFreeObject(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime::intToClass(int)
+CFlatRuntime::CClass* CFlatRuntime::intToClass(int)
 {
-	// TODO
+	return 0;
 }
 
 /*
@@ -521,9 +521,9 @@ void CFlatRuntime::intToClass(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime::onSystemVal(CFlatRuntime::CObject*, int)
+CFlatRuntime::CVal* CFlatRuntime::onSystemVal(CFlatRuntime::CObject* object, int)
 {
-	// TODO
+	return reinterpret_cast<CVal*>(reinterpret_cast<u8*>(object) + 0x96C);
 }
 
 /*
@@ -531,9 +531,9 @@ void CFlatRuntime::onSystemVal(CFlatRuntime::CObject*, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime::onClassSystemVal(CFlatRuntime::CObject*, int)
+CFlatRuntime::CVal* CFlatRuntime::onClassSystemVal(CFlatRuntime::CObject* object, int)
 {
-	// TODO
+	return reinterpret_cast<CVal*>(reinterpret_cast<u8*>(object) + 0x96C);
 }
 
 /*
@@ -561,9 +561,9 @@ void CFlatRuntime::onSetClassSystemVal(int, CFlatRuntime::CObject*, CFlatRuntime
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime::onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&)
+int CFlatRuntime::onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&)
 {
-	// TODO
+	return 0;
 }
 
 /*
@@ -571,7 +571,7 @@ void CFlatRuntime::onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime::onSystemFunc(CFlatRuntime::CObject*, int, int, int&)
+int CFlatRuntime::onSystemFunc(CFlatRuntime::CObject*, int, int, int&)
 {
-	// TODO
+	return 0;
 }


### PR DESCRIPTION
## Summary
- Corrected six CFlatRuntime stub hook signatures that were previously typed as `void` but clearly return values in target codegen.
- Implemented minimal plausible bodies for those hooks (`return 0` / return object-relative `CVal*`) to match observed ABI behavior.

## Functions Improved
- `onSystemFunc__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiRi`
- `onClassSystemFunc__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiRi`
- `getFreeObject__12CFlatRuntimeFi`
- `intToClass__12CFlatRuntimeFi`
- `onSystemVal__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti`
- `onClassSystemVal__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti`

## Match Evidence
- Unit `main/cflat_runtime`:
  - Before: `fuzzy_match_percent 3.2796292`, `matched_code 132`, `matched_functions 8/32`
  - After: `fuzzy_match_percent 3.4274619`, `matched_code 164`, `matched_functions 12/32`
- Function-level improvements:
  - `onSystemFunc`: `0.22727273 -> 100.0`
  - `onClassSystemFunc`: `0.22727273 -> 100.0`
  - `getFreeObject`: `50.0 -> 100.0`
  - `intToClass`: `50.0 -> 100.0`
  - `onSystemVal`: `50.0 -> 97.5`
  - `onClassSystemVal`: `50.0 -> 97.5`

## Plausibility Rationale
- Returning null pointers / zero status from base runtime hook defaults is consistent with engine extension-point patterns and is more plausible than `void` stubs that erase required return-register semantics.
- Returning `object + 0x96C` for system-value accessors aligns with current object-layout-based runtime access already used elsewhere in this decomp stage.

## Technical Notes
- `objdiff` confirmed missing `li r3, 0` and base+offset return sequences were the primary deltas for these hooks.
- Two accessors remain at `97.5%` due a minor register-operand mismatch (`addi` source register choice), but the semantic/assembly alignment is substantially improved and non-contrived.
