### PR TITLE
pppScreenBreak: implement SB_BeforeCalcMatrixCallback

### DIFF
--- a/include/ffcc/pppScreenBreak.h
+++ b/include/ffcc/pppScreenBreak.h
@@ -8,7 +8,7 @@ class VScreenBreak;
 struct UnkB;
 struct UnkC;
 
-void SB_BeforeCalcMatrixCallback(CChara::CModel*, void*, void*);
+int SB_BeforeCalcMatrixCallback(CChara::CModel*, void*, void*);
 void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*)[4], int);
 void SB_DrawMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*)[4]);
 void InitPieceData(CChara::CModel*, PScreenBreak*, VScreenBreak*);


### PR DESCRIPTION
## Summary
- Implement `SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv` in `pppScreenBreak` using the existing project math/quaternion/matrix path.
- Correct callback prototype return type from `void` to `int` to match callback semantics and symbol behavior.
- Add PAL metadata block for the function and wire required extern constants/types used by the implementation.

## Functions improved
- Unit: `main/pppScreenBreak`
- Symbol: `SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`

## Match evidence
- Symbol match: **0.44444445% -> 79.99111%** (`objdiff-cli diff -p . -u main/pppScreenBreak -o - SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`)
- Unit `.text` match: **54.132915% -> 70.115074%** (same objdiff run for `main/pppScreenBreak`)

## Plausibility rationale
- The update replaces a TODO stub with behavior consistent with the surrounding particle/screen-break pipeline: camera-space projection setup, per-piece quaternion rotation, translation accumulation, and matrix concatenation on model nodes.
- Changes are type/signature corrections and direct gameplay/math logic implementation, not coercive compiler-only rewrites.

## Technical details
- Uses existing engine helpers already present in this module (`PSMTX*`, `PSVEC*`, `C_QUAT*`, `PSQUAT*`, `MTX44MultVec4`).
- Keeps existing offset-based model/node access pattern used across nearby decomped code while preserving callback hook usage at model offset `0xEC`.
- Build validated with `ninja` after changes.
