### PR TITLE
EXIBios: improve EXTIntrruptHandler match

### DIFF
--- a/src/exi/EXIBios.c
+++ b/src/exi/EXIBios.c
@@ -536,18 +536,23 @@ int EXIDeselect(s32 chan) {
 }
 
 static void EXIIntrruptHandler(__OSInterrupt interrupt, OSContext* context) {
+    EXIControl* exi;
     s32 chan;
-    OSContext exceptionContext;
+    s16 exiInterrupt;
 
-    chan = ((s16)interrupt - 9) / 3;
+    exiInterrupt = interrupt;
+    chan = (exiInterrupt - 9) / 3;
 
     ASSERTLINE(1071, 0 <= chan && chan < MAX_CHAN);
     REG(chan, 0) = (REG(chan, 0) & 0x7F5) | 2;
 
-    if (Ecb[chan].exiCallback) {
+    exi = &Ecb[chan];
+    if (exi->exiCallback) {
+        OSContext exceptionContext;
+
         OSClearContext(&exceptionContext);
         OSSetCurrentContext(&exceptionContext);
-        Ecb[chan].exiCallback(chan, context);
+        exi->exiCallback(chan, context);
         OSClearContext(&exceptionContext);
         OSSetCurrentContext(context);
     }
@@ -582,8 +587,8 @@ static void TCIntrruptHandler(__OSInterrupt interrupt, OSContext* context) {
 
 static void EXTIntrruptHandler(__OSInterrupt interrupt, OSContext* context) {
     s32 chan;
-    EXIControl* exi;
     EXICallback callback;
+    EXIControl* exi;
 
     chan = (interrupt - 11) / 3;
 


### PR DESCRIPTION
## Summary
- Refactored local variable usage in `src/exi/EXIBios.c` interrupt handlers to better match original register allocation and callback access patterns.
- In `EXIIntrruptHandler`, introduced a local `EXIControl*` and narrowed interrupt value through a local `s16` before channel derivation.
- In `EXTIntrruptHandler`, adjusted declaration ordering for callback/control variables.

## Functions improved
- Unit: `main/exi/EXIBios`
- Function: `EXTIntrruptHandler`
  - Before: `42.692307%`
  - After: `43.076923%`
  - Size: `208` bytes

## Match evidence
- `objdiff-cli report changes /tmp/report_before.json build/GCCP01/report.json` shows:
  - `main/exi/EXIBios` fuzzy match percent: `69.05196 -> 69.06405`
  - Only function-level change in this unit: `EXTIntrruptHandler`
- Build verification:
  - `ninja` completed successfully.

## Plausibility rationale
- Changes keep semantics intact and use conventional SDK-style control-pointer locals and straightforward interrupt/channel narrowing.
- No contrived control-flow tricks or readability regressions were introduced; the resulting source remains idiomatic for this file.

## Technical notes
- `EXIIntrruptHandler` remains at the same function score, but the revised source layout improved neighboring `EXTIntrruptHandler` codegen.
- `EXIImm` and other tracked functions in this pass were unchanged.
