### PR TITLE
game: implement particle callback handlers

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9,6 +9,7 @@
 #include "ffcc/sound.h"
 #include "ffcc/graphic.h"
 #include "ffcc/file.h"
+#include "ffcc/partMng.h"
 
 #include <string.h>
 
@@ -44,6 +45,8 @@ void createLoad__9CCharaPcsFv(void*);
 void createLoad__8CPartPcsFv(void*);
 void pppDeleteAll__8CPartMngFv(void*);
 void pppDestroyAll__8CPartMngFv(void*);
+int pppGetIfDt__8CPartMngFs(void*, short);
+void pppEndPart__8CPartMngFi(void*, int);
 void Init__10CCameraPcsFv(void*);
 void Init__11CGraphicPcsFv(void*);
 void Init__6CCharaFv(void*);
@@ -107,6 +110,9 @@ unsigned char DAT_8032ed00[];
 unsigned char DAT_8032ed08[];
 unsigned char Wind[];
 extern const char DAT_801d61dc[];
+extern const char DAT_801d60d4[];
+extern const char DAT_801d6114[];
+extern const char DAT_801d6154[];
 extern const char s_game_cpp_801d6190[];
 extern const char DAT_801d619c[];
 extern const char DAT_801d61b8[];
@@ -928,22 +934,60 @@ void CGame::Draw3()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800147f8
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGame::HitParticleBG(int, int, int, Vec*, PPPIFPARAM*)
+void CGame::HitParticleBG(int effectIndex, int kind, int nodeIndex, Vec* pos, PPPIFPARAM* hitParam)
 {
-	// TODO
+	CFlatRuntime::CStack stack[8];
+	stack[0].m_word = (u32)effectIndex;
+	stack[1].m_word = (u32)kind;
+	stack[2].m_word = (u32)nodeIndex;
+	*(float*)&stack[3].m_word = pos->x;
+	*(float*)&stack[4].m_word = pos->y;
+	*(float*)&stack[5].m_word = pos->z;
+	stack[6].m_word = (u32)hitParam->m_particleIndex;
+	stack[7].m_word = (u32)hitParam->m_classId;
+	SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+	    &CFlat, 0, 1, 1, 8, stack, 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800146b4
+ * PAL Size: 324b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGame::ParticleFrameCallback(int, int, int, int, int, Vec*)
+void CGame::ParticleFrameCallback(int effectIndex, int scriptLine, int scriptStep, int, int callbackType, Vec* pos)
 {
-	// TODO
+	int ifData = pppGetIfDt__8CPartMngFs(&PartMng, (short)effectIndex);
+	*(u8*)(ifData + 7) |= 1 << callbackType;
+
+	if (callbackType == 0) {
+		if (System.m_execParam > 2) {
+			Printf__7CSystemFPce(&System, DAT_801d60d4, scriptLine, scriptStep, effectIndex, pos);
+		}
+	} else if (callbackType == 1) {
+		*(u8*)(ifData + 7) &= ~2;
+		pppEndPart__8CPartMngFi(&PartMng, effectIndex);
+
+		if (System.m_execParam > 2) {
+			Printf__7CSystemFPce(&System, DAT_801d6114, scriptLine, scriptStep, effectIndex, pos);
+		}
+	} else if (callbackType == 3) {
+		pppEndPart__8CPartMngFi(&PartMng, effectIndex);
+
+		if (System.m_execParam > 2) {
+			Printf__7CSystemFPce(&System, DAT_801d6154, scriptLine, scriptStep, effectIndex, pos);
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two previously stubbed CGame particle callbacks in src/game.cpp using project-consistent runtime call patterns and existing mangled engine entry points.

- Implemented CGame::ParticleFrameCallback(...) callback-state and teardown behavior.
- Implemented CGame::HitParticleBG(...) stack marshalling into CFlatRuntime::SystemCall.
- Added missing extern declarations for pppGetIfDt__8CPartMngFs, pppEndPart__8CPartMngFi, and related debug format strings.
- Filled PAL address/size metadata blocks for both updated functions.

## Functions Improved
Unit: main/game

- ParticleFrameCallback__5CGameFiiiiiP3Vec
  - Before: 1.2345679%
  - After: 75.97531%
  - Size: 324b
- HitParticleBG__5CGameFiiiP3VecP10PPPIFPARAM
  - Before: 3.4482758%
  - After: 100.0%
  - Size: 116b

## Match Evidence
Measured from build/GCCP01/report.json after baseline rebuild vs patched rebuild.

- ParticleFrameCallback: 1.2345679% -> 75.97531%
- HitParticleBG: 3.4482758% -> 100.0%

Additional symbol-level diff checks were run with:

```sh
build/tools/objdiff-cli diff -p . -u main/game -o - ParticleFrameCallback__5CGameFiiiiiP3Vec
build/tools/objdiff-cli diff -p . -u main/game -o - HitParticleBG__5CGameFiiiP3VecP10PPPIFPARAM
```

## Plausibility Rationale
The changes are direct gameplay/runtime logic, not compiler coaxing:

- Uses existing engine APIs (pppGetIfDt, pppEndPart, SystemCall) with natural parameter flow.
- Uses idiomatic stack marshaling pattern already used by nearby runtime calls.
- Keeps control flow straightforward (callbackType branches 0/1/3) and readable.

## Technical Details
- HitParticleBG now packs 8 stack entries (effect/kind/node, 3D position, particle index/class id) and dispatches runtime opcode (0,1,1) with argument count 8.
- ParticleFrameCallback now:
  - Sets callback bit in particle interface state (ifData + 7).
  - Handles callback 1 and 3 termination via pppEndPart.
  - Preserves debug print gates on System.m_execParam > 2 for each callback branch.

## Validation
- ninja passes after the patch.
