### PR TITLE
map: decompile CMapMng::SetViewMtx

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -14,6 +14,10 @@ extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned lo
 extern "C" float Spline1D__5CMathFifPfPfPf(CMath*, int, float, float*, float*, float*);
 extern "C" float Line1D__5CMathFifPfPf(CMath*, int, float, float*, float*);
 extern "C" void MakeSpline1Dtable__5CMathFiPfPfPf(CMath*, int, float*, float*, float*);
+extern "C" float lbl_8032F990;
+extern "C" float lbl_8032F994;
+extern "C" float lbl_8032F998;
+extern "C" float lbl_8032F99C;
 extern CMath Math;
 
 static char s_map_cpp[] = "map.cpp";
@@ -1149,12 +1153,25 @@ void CMapMng::GetAnimRunID(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002fdb0
+ * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::SetViewMtx(float (*) [4], float (*) [4])
+void CMapMng::SetViewMtx(float (*viewMtx)[4], float (*projMtx)[4])
 {
-	// TODO
+    float* proj = reinterpret_cast<float*>(projMtx);
+    float scaleY = lbl_8032F994 * proj[5];
+    float scaleX = proj[0];
+    Mtx* viewCopy = reinterpret_cast<Mtx*>(Ptr(this, 0x228F8));
+
+    PSMTXCopy(viewMtx, *viewCopy);
+    PSMTXScaleApply(
+        *viewCopy, *reinterpret_cast<Mtx*>(Ptr(this, 0x22928)), lbl_8032F990 * scaleX, scaleY, lbl_8032F998);
+    PSMTXScaleApply(
+        *viewCopy, *reinterpret_cast<Mtx*>(Ptr(this, 0x22958)), lbl_8032F99C * scaleX, scaleY, lbl_8032F998);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMapMng::SetViewMtx` in `src/map.cpp` based on PAL decomp structure.

Changes:
- Added PAL metadata block for the function (`0x8002fdb0`, `188b`).
- Replaced TODO body with matrix copy/scale logic using `PSMTXCopy` and two `PSMTXScaleApply` calls.
- Added extern declarations for SDA2 float literals used by the original sequence (`lbl_8032F990`, `lbl_8032F994`, `lbl_8032F998`, `lbl_8032F99C`).

## Functions improved
- Unit: `main/map`
- Symbol: `SetViewMtx__7CMapMngFPA4_fPA4_f`

## Match evidence
objdiff command:
`build/tools/objdiff-cli diff -p . -u main/map -o - SetViewMtx__7CMapMngFPA4_fPA4_f`

Before:
- Match: `2.1276596%`

After:
- Match: `59.446808%`
- Target size: `188b`
- Current size: `180b`

## Plausibility rationale
The new implementation is source-plausible for original game code:
- Uses Dolphin matrix APIs directly (`PSMTXCopy`, `PSMTXScaleApply`) rather than compiler-coaxing constructs.
- Uses projected matrix terms (`proj[0]`, `proj[5]`) and shared scale factors exactly as expected for view-dependent map transforms.
- Keeps straightforward control/data flow with explicit matrix destinations at fixed `CMapMng` offsets.

## Technical details
- The resulting assembly now aligns on the major call structure and floating-point setup seen in target (`PSMTXCopy` followed by two scale-apply calls with shared factors).
- Remaining mismatch appears to be register/instruction ordering and small stack/register allocation differences, not algorithmic divergence.
