### PR TITLE
Improve pppKeZCrctShpDraw match via vector lifetime cleanup

### DIFF
--- a/src/pppKeZCrctShp.cpp
+++ b/src/pppKeZCrctShp.cpp
@@ -27,9 +27,12 @@ void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
     pppFMATRIX managerMatrix;
     pppFMATRIX worldMatrixA;
     pppFMATRIX worldMatrixB;
+    float scaledPosX;
+    float scaledPosY;
+    float scaledPosZ;
+    u8 mode;
 
     pppGetRowVector(pObject->m_localMatrix, rowX, rowY, rowZ, rowPos);
-
     pppScaleVector(scaledX, rowX, pppMngStPtr->m_scale.x);
     pppScaleVector(scaledY, rowY, pppMngStPtr->m_scale.y);
     pppScaleVector(scaledZ, rowZ, pppMngStPtr->m_scale.z);
@@ -38,14 +41,11 @@ void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
     zeroVec.y = 0.0f;
     zeroVec.z = 0.0f;
     pppSetRowVector(transformMatrix, scaledX, scaledY, scaledZ, zeroVec);
-
     pppCopyVector(transformedPos, rowPos);
-
-    float scaledPosX = transformedPos.x * *(float*)(param2 + 0x18);
-    float scaledPosY = transformedPos.y * *(float*)(param2 + 0x1c);
-    float scaledPosZ = transformedPos.z * *(float*)(param2 + 0x20);
-
-    u8 mode = *(u8*)(param2 + 0x28);
+    scaledPosX = transformedPos.x * *(float*)(param2 + 0x18);
+    scaledPosY = transformedPos.y * *(float*)(param2 + 0x1c);
+    scaledPosZ = transformedPos.z * *(float*)(param2 + 0x20);
+    mode = *(u8*)(param2 + 0x28);
     transformedPos.x = scaledPosX;
     transformedPos.y = scaledPosY;
     transformedPos.z = scaledPosZ;
@@ -59,22 +59,37 @@ void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
         modePos.z = scaledPosZ;
         pppApplyMatrix(zeroVec, worldMatrixA, modePos);
     } else if (mode == 0) {
-        float offsetPosX = scaledPosX + *(float*)(param2 + 8);
-        float offsetPosY = scaledPosY + *(float*)(param2 + 0xc);
-        float offsetPosZ = scaledPosZ + *(float*)(param2 + 0x10);
+        float offsetPosX;
+        float offsetPosY;
+        float offsetPosZ;
+        Vec offsetPos;
+
+        offsetPosX = scaledPosX + *(float*)(param2 + 8);
+        offsetPosY = scaledPosY + *(float*)(param2 + 0xc);
+        offsetPosZ = scaledPosZ + *(float*)(param2 + 0x10);
 
         worldMatrixB = *(pppFMATRIX*)&ppvWorldMatrix;
         transformedPos.x = offsetPosX;
         transformedPos.y = offsetPosY;
         transformedPos.z = offsetPosZ;
-        pppApplyMatrix(transformedPos, worldMatrixB, transformedPos);
+        offsetPos.x = offsetPosX;
+        offsetPos.y = offsetPosY;
+        offsetPos.z = offsetPosZ;
+        pppApplyMatrix(transformedPos, worldMatrixB, offsetPos);
     } else if (mode < 3) {
-        managerMatrix = pppMngStPtr->m_matrix;
-        pppApplyMatrix(zeroVec, managerMatrix, transformedPos);
+        Vec modePos;
+        float cameraPosX;
+        float cameraPosY;
+        float cameraPosZ;
 
-        float cameraPosX = *(float*)(param2 + 8) * pppMngStPtr->m_scale.x + zeroVec.x;
-        float cameraPosY = *(float*)(param2 + 0xc) * pppMngStPtr->m_scale.y + zeroVec.y;
-        float cameraPosZ = *(float*)(param2 + 0x10) * pppMngStPtr->m_scale.z + zeroVec.z;
+        managerMatrix = pppMngStPtr->m_matrix;
+        modePos.x = scaledPosX;
+        modePos.y = scaledPosY;
+        modePos.z = scaledPosZ;
+        pppApplyMatrix(zeroVec, managerMatrix, modePos);
+        cameraPosX = *(float*)(param2 + 8) * pppMngStPtr->m_scale.x + zeroVec.x;
+        cameraPosY = *(float*)(param2 + 0xc) * pppMngStPtr->m_scale.y + zeroVec.y;
+        cameraPosZ = *(float*)(param2 + 0x10) * pppMngStPtr->m_scale.z + zeroVec.z;
 
         cameraMatrix = *(pppFMATRIX*)&ppvCameraMatrix0;
         zeroVec.x = cameraPosX;


### PR DESCRIPTION
## Summary
Adjusted `pppKeZCrctShpDraw` to better match original codegen by aligning temporary lifetimes and data-flow in the mode branches.

## Functions improved
- Unit: `main/pppKeZCrctShp`
- Symbol: `pppKeZCrctShpDraw`

## Match evidence
- `pppKeZCrctShpDraw`: **31.522648% -> 35.55052%** (`+4.027872`)
- Size remained `1148b`
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/pppKeZCrctShp -o - pppKeZCrctShpDraw`

## Plausibility rationale
Changes keep the same behavior and use source-plausible structures (explicit temporaries and branch-local vectors) rather than artificial compiler coaxing. The update reflects more natural parameter staging around `pppApplyMatrix` calls and matrix/vector transforms.

## Technical details
- Hoisted branch-shared scaled-position scalars and `mode` into stable locals.
- In `mode == 0`, introduced explicit offset vector source when applying world matrix.
- In `mode < 3`, staged scaled position into a branch-local vector before manager-matrix application, then computed camera-space vector in branch-local floats.
- No build-system or flag changes; source-only change in `src/pppKeZCrctShp.cpp`.
