### PR TITLE
cflat_runtime2: implement object/particle helper stubs

### DIFF
--- a/include/ffcc/cflat_runtime2.h
+++ b/include/ffcc/cflat_runtime2.h
@@ -61,7 +61,7 @@ class CFlatRuntime2
 	void CcClass2D(int, int, Vec*, float, float, int, CGObject **);
 
 	void loadLayer(int, char*);
-	void isLoadLayerASyncCompleted(int);
+	unsigned int isLoadLayerASyncCompleted(int);
 	void loadLayerASync(int, char*);
 	void drawLayer(int, char*, int, int, int, int, int, int, float, float, _GXColor*, int);
 


### PR DESCRIPTION
## Summary
Implemented a focused set of `CFlatRuntime2` helper stubs in `src/cflat_runtime2.cpp` and one matching signature correction in `include/ffcc/cflat_runtime2.h`.

Key changes:
- Implemented object lifecycle helpers:
  - `onNewObject__13CFlatRuntime2FPQ212CFlatRuntime7CObject`
  - `onDeleteObject__13CFlatRuntime2FPQ212CFlatRuntime7CObject`
- Implemented particle helper functions using existing `CPartMng` APIs:
  - `SetParticleWorkNo__13CFlatRuntime2Fi`
  - `GetFreeParticleSlot__13CFlatRuntime2Fv`
  - `EndParticleSlot__13CFlatRuntime2Fii`
  - `EndParticle__13CFlatRuntime2FPQ29CCharaPcs7CHandle`
  - `DeleteParticleSlot__13CFlatRuntime2Fii`
  - `IgnoreParticle__13CFlatRuntime2FiPQ212CFlatRuntime7CObject`
  - `initAllFinished__13CFlatRuntime2Fv`
- Corrected async-check return type to match decomp behavior:
  - `isLoadLayerASyncCompleted__13CFlatRuntime2Fi` from `void` to `unsigned int`

## Functions improved (objdiff)
Before/after symbol match percentages:

- `SetParticleWorkNo__13CFlatRuntime2Fi`: `20.0%` -> `100.0%`
- `initAllFinished__13CFlatRuntime2Fv`: `8.33%` -> `98.75%`
- `onDeleteObject__13CFlatRuntime2FPQ212CFlatRuntime7CObject`: `6.25%` -> `90.0%`
- `onNewObject__13CFlatRuntime2FPQ212CFlatRuntime7CObject`: `7.69%` -> `86.15%`
- `DeleteParticleSlot__13CFlatRuntime2Fii`: `8.33%` -> `86.67%`
- `EndParticleSlot__13CFlatRuntime2Fii`: `8.33%` -> `86.67%`
- `EndParticle__13CFlatRuntime2FPQ29CCharaPcs7CHandle`: `8.33%` -> `86.67%`
- `GetFreeParticleSlot__13CFlatRuntime2Fv`: `10.0%` -> `84.0%`
- `isLoadLayerASyncCompleted__13CFlatRuntime2Fi`: `16.67%` -> `79.17%`
- `IgnoreParticle__13CFlatRuntime2FiPQ212CFlatRuntime7CObject`: `4.35%` -> `71.52%`

Unit-level `.text` match moved from `4.8110957%` to `6.632741%`.

## Match evidence
Used:
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o -`
- compared pre/post JSON symbol match percentages and section match.

## Plausibility rationale
These changes are source-plausible and follow existing project style:
- direct wrappers around existing `CPartMng` methods
- field writes through known runtime/object offsets already used in this codebase
- no contrived control flow or artificial temporaries
- no asm artifacts/debug comments introduced
