### PR TITLE
p_map: implement drawBeforeViewer first pass

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -236,12 +236,58 @@ void CMapPcs::draw()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80034fd4
+ * PAL Size: 532b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapPcs::drawBeforeViewer()
 {
-	// TODO
+    if ((*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x180) != 0) &&
+        (*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x178) == 0)) {
+        Mtx cameraMtx;
+        Mtx44 screenMtx;
+
+        if (Game.game.m_currentSceneId == 3) {
+            _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_map_cpp_801d7728, 0x298);
+        }
+
+        MaterialMan.InitVtxFmt(-1, GX_F32, 0, GX_RGBA4, 0xE, GX_RGBA6, 0xA);
+
+        *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228DC) =
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0);
+        *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228E0) =
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE4);
+        *reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0x228E4) =
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE8);
+
+        PSMTXCopy(*reinterpret_cast<Mtx*>(reinterpret_cast<char*>(&CameraPcs) + 0x4), cameraMtx);
+        PSMTX44Copy(*reinterpret_cast<Mtx44*>(reinterpret_cast<char*>(&CameraPcs) + 0x48), screenMtx);
+        MapMng.SetViewMtx(cameraMtx, screenMtx);
+        Graphic.SetFog(*reinterpret_cast<unsigned char*>(reinterpret_cast<char*>(&MapMng) + 0x22978), 0);
+
+        GXSetColorUpdate(GX_TRUE);
+        GXSetAlphaUpdate(GX_FALSE);
+        GXSetCullMode(GX_CULL_BACK);
+        GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
+
+        _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapModeTable(GX_TEV_SWAP1, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapModeTable(GX_TEV_SWAP2, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapModeTable(GX_TEV_SWAP3, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+        _GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        _GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        _GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        _GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+        MapMng.DrawBefore();
+
+        if (Game.game.m_currentSceneId == 3) {
+            _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_map_cpp_801d7728, 0x2B2);
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapPcs::drawBeforeViewer()` in `src/p_map.cpp` using the existing codebase style used by `drawViewer()`.
- Added PAL metadata block for the function:
  - PAL Address: `0x80034fd4`
  - PAL Size: `532b`
- Function now performs map pre-viewer draw setup (view/fog/GX state), invokes `MapMng.DrawBefore()`, and keeps scene-3 draw waits.

## Functions improved
- Unit: `main/p_map`
- Symbol: `drawBeforeViewer__7CMapPcsFv`

## Match evidence
- Before: `0.7518797%` (`532b`)
- After: `72.65414%` (`532b`)
- Delta: `+71.9022603%`

Objdiff command used:
```sh
tools/objdiff-cli diff -p . -u main/p_map -o - drawBeforeViewer__7CMapPcsFv
```

## Plausibility rationale
- The implementation follows established `p_map.cpp` patterns already present in nearby `drawViewer()`:
  - same matrix/fog/GX setup sequence,
  - same scene-gated draw waits,
  - same low-level field access conventions used throughout this file.
- The main behavior distinction is a plausible original split of map passes (`DrawBefore` vs `Draw`) rather than compiler-coaxing changes.

## Technical details
- Replaced TODO stub with a full first-pass implementation.
- Kept call shapes and constants consistent with adjacent decomp style to preserve ABI and codegen behavior.
