### PR TITLE
cflat_r2system: decompile VECLerp and GetViewMatrix

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -864,6 +864,39 @@ void CCameraPcs::SetFullScreenShadowEnable(unsigned char enable)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B965C
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void GetViewMatrix__10CCameraPcsFPA4_f(void* camera, Mtx matrix)
+{
+    PSMTXCopy((MtxPtr)((char*)camera + 4), matrix);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9680
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void VECLerp(Vec* a, Vec* b, Vec* out, float t)
+{
+    Vec scaledA;
+    Vec scaledB;
+
+    PSVECScale(a, &scaledA, 1.0f - t);
+    PSVECScale(b, &scaledB, t);
+    PSVECAdd(&scaledA, &scaledB, out);
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800B9920
  * PAL Size: 8b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added a decompilation for `GetViewMatrix__10CCameraPcsFPA4_f` in `src/cflat_r2system.cpp` using the existing camera matrix storage convention in this unit (`(char*)camera + 4`).
- Added a decompilation for `VECLerp__FP3VecP3VecP3Vecf` using SDK vector ops (`PSVECScale` + `PSVECAdd`) and straightforward interpolation flow.
- Included PAL address/size info blocks for both functions.

## Functions improved
- `main/cflat_r2system`:
  - `GetViewMatrix__10CCameraPcsFPA4_f`: **0.0% -> 100.0%**
  - `VECLerp__FP3VecP3VecP3Vecf`: **0.0% -> 99.833336%**

## Match evidence
- Build: `ninja` passes.
- Objdiff commands used:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - GetViewMatrix__10CCameraPcsFPA4_f`
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - VECLerp__FP3VecP3VecP3Vecf`
- Results:
  - `GetViewMatrix__10CCameraPcsFPA4_f match=100.0`
  - `VECLerp__FP3VecP3VecP3Vecf match=99.833336`

## Plausibility rationale
- Both functions are small math/matrix helpers and follow existing conventions already used in this source file:
  - camera matrix access through pointer offsets in this partially decompiled unit
  - SDK vector helper calls for interpolation instead of contrived control flow
- No compiler-coaxing patterns were introduced (no artificial temporaries beyond natural stack vectors for `PSVECScale` outputs).

## Technical details
- `VECLerp` computes `(1.0f - t) * a + t * b` via two `PSVECScale` calls and one `PSVECAdd`.
- `GetViewMatrix` copies the camera view matrix from offset `+0x4` into the destination matrix with `PSMTXCopy`.
