### PR TITLE
cflat_runtime2: improve reqFinished and SetParticleWorkVector matching

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -2,6 +2,7 @@
 #include "ffcc/baseobj.h"
 #include "ffcc/partMng.h"
 #include "ffcc/p_game.h"
+#include <math.h>
 #include <string.h>
 
 extern "C" void reset__6CAStarFv(void*);
@@ -647,9 +648,19 @@ void CFlatRuntime2::SetParticleWorkTarget(Vec& vec)
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime2::SetParticleWorkVector(float, float)
+void CFlatRuntime2::SetParticleWorkVector(float angle1, float angle2)
 {
-	// TODO
+	double cosAngle2 = cos(angle2);
+	double sinAngle1 = sin(angle1);
+	ParticleWorkTargetX(this) = static_cast<float>(sinAngle1 * static_cast<double>(static_cast<float>(cosAngle2))) + ParticleWorkPosX(this);
+
+	double sinAngle2 = sin(angle2);
+	ParticleWorkTargetY(this) = ParticleWorkPosY(this) + static_cast<float>(sinAngle2);
+
+	cosAngle2 = cos(angle2);
+	double cosAngle1 = cos(angle1);
+	ParticleWorkTargetZ(this) = static_cast<float>(cosAngle1 * static_cast<double>(static_cast<float>(cosAngle2))) + ParticleWorkPosZ(this);
+	ParticleWorkTargetPtr(this) = &ParticleWorkTargetX(this);
 }
 
 /*
@@ -834,9 +845,13 @@ void CFlatRuntime2::initAllFinished()
  * Address:	TODO
  * Size:	TODO
  */
-void CFlatRuntime2::reqFinished(int, CFlatRuntime::CObject*)
+void CFlatRuntime2::reqFinished(int reqNo, CFlatRuntime::CObject* object)
 {
-	// TODO
+	if (reqNo == 0xF) {
+		typedef void (*ReqFinishFn)(CFlatRuntime::CObject*);
+		ReqFinishFn fn = *reinterpret_cast<ReqFinishFn*>(*reinterpret_cast<u8**>(object) + 0x10);
+		fn(object);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFlatRuntime2::SetParticleWorkVector(float, float)` using the PAL decompilation math flow (`sin/cos` with target pointer update).
- Implemented `CFlatRuntime2::reqFinished(int, CFlatRuntime::CObject*)` to dispatch the vtable callback for request `0xF`.
- Added `<math.h>` include required for trig calls.

## Functions improved
- Unit: `main/cflat_runtime2`
- `SetParticleWorkVector__13CFlatRuntime2Fff`: **2.00% -> 73.86%**
- `reqFinished__13CFlatRuntime2FiPQ212CFlatRuntime7CObject`: **7.14% -> 85.29%**
- Unit fuzzy score: **6.6747413% -> 7.5952334%**

## Match evidence
- Built with `ninja` successfully.
- Measured with `tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o -` and compared `right.symbols[].match_percent` before/after.
- Improvements are concentrated in the two touched symbols; no formatting-only churn.

## Plausibility rationale
- Changes restore straightforward runtime behavior expected by surrounding code:
  - `SetParticleWorkVector` computes target XYZ from angles relative to current particle-work position, then stores target pointer.
  - `reqFinished` performs the request-type gate (`0xF`) and invokes the object virtual handler.
- This aligns with existing source style in `cflat_runtime2.cpp` (offset-based field access and direct engine callback dispatch), avoiding contrived compiler coaxing.

## Technical details
- Kept existing offset helper accessors (`ParticleWorkTargetX/Y/Z`, `ParticleWorkPosX/Y/Z`, `ParticleWorkTargetPtr`) to preserve ABI/layout assumptions.
- Used explicit casts around trig results to follow the decompilation’s float/double conversion pattern.
