### PR TITLE
math: improve Hsb2Rgb signed normalization matching

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -1060,19 +1060,14 @@ float CMath::Line1D(int lastIndex, float x, float* x_arr, float* y_arr)
  */
 unsigned int CMath::Hsb2Rgb(int hue, int saturation, int brightness)
 {
-    int sat = (saturation * 0xFF) / 100;
-    int val = (brightness * 0xFF) / 100;
-
-    if (sat < 0) {
-        sat = -sat;
-    }
-    if (val < 0) {
-        val = -val;
-    }
+    int sat = (saturation * 0xFF) / 100 + ((saturation * 0xFF) >> 31);
+    int val = (brightness * 0xFF) / 100 + ((brightness * 0xFF) >> 31);
+    sat -= sat >> 31;
+    val -= val >> 31;
 
     unsigned char v = (unsigned char)val;
     unsigned int rgba;
-    if (sat == 0) {
+    if ((float)sat == 0.0f) {
         rgba = ((unsigned int)v << 24) | ((unsigned int)v << 16) | ((unsigned int)v << 8);
     }
     else {


### PR DESCRIPTION
## Summary
- Refined `CMath::Hsb2Rgb(int,int,int)` signed normalization to better match Metrowerks codegen.
- Replaced branch-based absolute value handling with shift-based signed normalization for saturation/value scaling.
- Adjusted the zero-saturation guard to use float-style comparison shape (`(float)sat == 0.0f`) matching observed target arithmetic flow.

## Functions Improved
- Unit: `main/math`
- Symbol: `Hsb2Rgb__5CMathFiii`

## Match Evidence
- `Hsb2Rgb__5CMathFiii`: **47.08738% -> 51.213593%** (`+4.126213`)
- Size remained `412` bytes.
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/math -o - Hsb2Rgb__5CMathFiii`

## Plausibility Rationale
- The change keeps behavior source-plausible: it is still straightforward HSB-to-RGB conversion logic.
- Edits focus on signed integer normalization and condition style, which are common source-level differences that materially affect PPC codegen without introducing contrived control flow.

## Technical Notes
- Iterated against `objdiff` and kept only the variant that improved symbol alignment.
- Full rebuild passes with `ninja`.
