### PR TITLE
pppBlurChara: match pppFrameBlurChara via mng layout-correct access

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -27,6 +27,11 @@ struct pppBlurCharaWork {
     float m_savedModelField;
 };
 
+struct pppMngStBlurCharaRaw {
+    char _padding0[0xD8];
+    void* m_charaObj;
+};
+
 extern int DAT_8032ed70;
 extern void* DAT_80238030;
 extern CUtil DAT_8032ec70;
@@ -277,13 +282,13 @@ void pppFrameBlurChara(pppBlurChara* blurChara, UnkB* param_2, UnkC* param_3)
     }
 
     work = GetBlurWork(blurChara, param_3);
-    handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((char*)pppMngStPtr + 0xD8), 0);
+    handle = GetCharaHandlePtr__FP8CGObjectl(((pppMngStBlurCharaRaw*)pppMngStPtr)->m_charaObj, 0);
     model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
 
     *(pppBlurCharaWork**)(model + 0xE4) = work;
     *(UnkB**)(model + 0xE8) = param_2;
 
-    if (work->m_captureBuffer == 0) {
+    if ((unsigned int)work->m_captureBuffer == 0) {
         unsigned int texBufferSize = GXGetTexBufferSize(0x140, 0xE0, GX_TF_I8, GX_FALSE, GX_FALSE);
 
         work->m_captureBuffer = pppMemAlloc__FUlPQ27CMemory6CStagePci(texBufferSize, pppEnvStPtr->m_stagePtr,


### PR DESCRIPTION
## Summary
- Updated `pppFrameBlurChara` in `src/pppBlurChara.cpp` to use a small raw manager-layout view (`pppMngStBlurCharaRaw`) for the owner chara object at offset `0xD8`.
- Switched the `m_captureBuffer` null check to an unsigned comparison to match the expected unsigned zero-test codegen (`cmplwi`).

## Functions improved
- Unit: `main/pppBlurChara`
- Function: `pppFrameBlurChara`
  - Before: `98.94827%`
  - After: `100.0%`

## Match evidence
- Rebuilt with `ninja` and verified updated report values in `build/GCCP01/report.json`.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppBlurChara -o /tmp/frame_diff_after2.json pppFrameBlurChara`
- The function now reaches full fuzzy match in report output.

## Plausibility rationale
- The change models existing reality in this codebase: raw-layout structs are already used in PPP code where official struct layout is still WIP.
- Using a layout-accurate member access at `0xD8` is more plausible than ad-hoc pointer arithmetic and aligns with surrounding manager/object semantics.
- The unsigned null test reflects pointer-like storage semantics for the capture buffer and produces ABI-consistent codegen.
