### PR TITLE
p_graphic: implement drawBegin/drawWait/drawFlip wrappers

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -41,6 +41,8 @@ extern "C" float FLOAT_8032fb78;
 extern "C" float FLOAT_8032fbfc;
 extern "C" float FLOAT_8032fc00;
 
+static char s_p_graphic_cpp_801d7c10[] = "p_graphic.cpp";
+
 /*
  * --INFO--
  * PAL Address: 0x80047788
@@ -254,32 +256,45 @@ void CGraphicPcs::calc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047588
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphicPcs::drawBegin()
 {
-	// TODO
+	Graphic.BeginFrame();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047554
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphicPcs::drawWait()
 {
-	// TODO
+	Graphic._WaitDrawDone(s_p_graphic_cpp_801d7c10, 0xDA);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80047528
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphicPcs::drawFlip()
 {
-	// TODO
+	Graphic.Flip();
+	_InitGxFunc();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGraphicPcs::drawBegin`, `CGraphicPcs::drawWait`, and `CGraphicPcs::drawFlip` in `src/p_graphic.cpp` as direct wrappers around existing `CGraphic`/GX entry points.
- Added the PAL address/size INFO blocks for these three functions.
- Added local file-name string symbol used by `_WaitDrawDone` (`"p_graphic.cpp"`).

## Functions improved
- Unit: `main/p_graphic`
- Symbols:
  - `drawBegin__11CGraphicPcsFv` -> 84.0% current
  - `drawWait__11CGraphicPcsFv` -> 85.76923% current (selector baseline: 7.7%)
  - `drawFlip__11CGraphicPcsFv` -> 85.454544% current

## Match evidence
- Unit-level `.text` match now: `20.360739%` (`build/tools/objdiff-cli diff -p . -u main/p_graphic -o - drawWait__11CGraphicPcsFv`)
- Selector baseline for this unit at target selection: `19.7%`.
- `drawWait` moved from TODO-stub state (selector showed 7.7%) to an 85.76923% wrapper match with correct call/line constant.

## Plausibility rationale
- These are straightforward orchestration wrappers in a manager class calling existing lower-level rendering functions.
- The resulting code is idiomatic to nearby code (`Graphic.*` calls + `_InitGxFunc()`/`_WaitDrawDone(...)`) and avoids contrived compiler-coaxing patterns.

## Technical details
- Decompiled references used only as guidance for call targets and PAL metadata:
  - `80047588_drawBegin__11CGraphicPcsFv.c`
  - `80047554_drawWait__11CGraphicPcsFv.c`
  - `80047528_drawFlip__11CGraphicPcsFv.c`
- Validation performed with `ninja` and `build/tools/objdiff-cli diff` on the updated unit/symbols.
