### PR TITLE
fontman: implement CFont ctor/dtor and improve match

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -148,22 +148,60 @@ unsigned long CFontMan::GetInternal22Size()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80092e3c
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CFont::CFont()
 {
-	// TODO
+	texturePtr = 0;
+	m_glyphData = 0;
+	margin = 0.0f;
+	posZ = 0.0f;
+	posY = 0.0f;
+	posX = 0.0f;
+	renderFlags &= static_cast<unsigned char>(~0x80);
+	scaleY = 1.0f;
+	scaleX = 1.0f;
+	renderFlags &= static_cast<unsigned char>(~0x08);
+	m_color.r = 0xFF;
+	m_color.g = 0xFF;
+	m_color.b = 0xFF;
+	m_color.a = 0xFF;
+	renderFlags &= static_cast<unsigned char>(~0x40);
+	renderFlags &= static_cast<unsigned char>(~0x20);
+	m_usesEmbeddedData = 0;
+	m_pad0f = 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80092d74
+ * PAL Size: 200b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CFont::~CFont()
 {
-	// TODO
+	if (texturePtr != 0) {
+		int* texture = reinterpret_cast<int*>(texturePtr);
+		int refCount = texture[1];
+		texture[1] = refCount - 1;
+		if ((refCount - 1 == 0) && (texture != 0)) {
+			(*(void (**)(int*, int))(*texture + 8))(texture, 1);
+		}
+		texturePtr = 0;
+	}
+
+	if (m_usesEmbeddedData == 0 && m_glyphData != 0) {
+		::operator delete[](m_glyphData);
+		m_glyphData = 0;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFont::CFont()` and `CFont::~CFont()` in `src/fontman.cpp` using source-plausible initialization and cleanup logic already reflected in the unit's existing low-level setup patterns.
- Added PAL metadata blocks for both functions from the decomp reference:
  - `__ct__5CFontFv` at `0x80092e3c` (176b)
  - `__dt__5CFontFv` at `0x80092d74` (200b)

## Functions Improved
- Unit: `main/fontman`
- `__ct__5CFontFv` (`CFont::CFont()`)
  - Before: `31.0%`
  - After: `86.795456%`
- `__dt__5CFontFv` (`CFont::~CFont()`)
  - Before: `45.28%`
  - After: `96.0%`

## Match Evidence
- Built with `ninja` after changes (successful).
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/fontman -o - __ct__5CFontFv`
  - `build/tools/objdiff-cli diff -p . -u main/fontman -o - __dt__5CFontFv`
- Improvements are in function-level instruction alignment for the constructor/destructor, not formatting-only changes.

## Plausibility Rationale
- Changes model normal constructor/destructor responsibilities for this class:
  - initialize member defaults (positions/scales/flags/colors/pointers)
  - release owned resources with existing project refcount patterns
  - free glyph data only when not using embedded data
- This removes TODO stubs and replaces them with straightforward class lifecycle behavior consistent with surrounding code style.

## Technical Details
- Constructor now performs the same style of object-state setup previously duplicated in `CFontMan::Init()` after raw allocation.
- Destructor now follows the same reference-counted release idiom used elsewhere in this file and resets pointers after release.
