### PR TITLE
pppBreathModel: improve UpdateAllParticle group state codegen

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -364,15 +364,16 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
     for (groupIndex = 0; groupIndex < (int)groupTableCount; groupIndex++) {
         int* group = groupTable + groupIndex * 0x17;
         if ((group[0] != 1) && (*(signed char*)group[1] != -1) && (*(signed char*)group[2] == 1)) {
-            float* position = (float*)(group + 3);
-            float* velocity = (float*)(group + 6);
+            Vec unitVelocity;
+            unitVelocity.x = lbl_80330F70;
+            unitVelocity.y = lbl_80330F70;
+            unitVelocity.z = 1.0f;
             group[9] = *(int*)((unsigned char*)pBreathModel + 0x14);
-            position[0] = lbl_80330F70;
-            position[1] = lbl_80330F70;
-            position[2] = lbl_80330F70;
-            velocity[0] = lbl_80330F70;
-            velocity[1] = lbl_80330F70;
-            velocity[2] = 1.0f;
+            *(float*)(group + 3) = lbl_80330F70;
+            *((float*)(group + 3) + 1) = lbl_80330F70;
+            *((float*)(group + 3) + 2) = lbl_80330F70;
+            *(Vec*)(group + 6) = unitVelocity;
+            PSMTXCopy(*(Mtx*)pppMngStPtr, *(Mtx*)(group + 0xB));
             group[0] = 1;
         }
     }
@@ -380,12 +381,9 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
     for (groupIndex = 0; groupIndex < (int)groupTableCount; groupIndex++) {
         int* group = groupTable + groupIndex * 0x17;
         if (group[0] != 0) {
-            float* position = (float*)(group + 3);
-            float* velocity = (float*)(group + 6);
-            float step = (float)group[9];
-            position[0] += velocity[0] * step;
-            position[1] += velocity[1] * step;
-            position[2] += velocity[2] * step;
+            Vec stepVelocity;
+            PSVECScale((Vec*)(group + 6), &stepVelocity, (float)group[9]);
+            PSVECAdd(&stepVelocity, (Vec*)(group + 3), (Vec*)(group + 3));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reworked the group activation/update tail of `UpdateAllParticle` in `src/pppBreathModel.cpp` to better reflect recovered source structure.
- Replaced scalar per-component position integration with `PSVECScale` + `PSVECAdd` vector ops.
- Initialized group velocity as an explicit `Vec` unit direction and added the missing `PSMTXCopy` of the manager matrix into group work state.

## Functions improved
- Unit: `main/pppBreathModel`
- Function: `UpdateAllParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColor`
  - Before: `29.140078%`
  - After: `35.766537%`
  - Delta: `+6.626459%`

## Match evidence
- Unit `.text` match (`main/pppBreathModel`):
  - Before: `49.29445%`
  - After: `50.35683%`
  - Delta: `+1.06238%`
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o -`

## Plausibility rationale
- The new form uses project-idiomatic vector/matrix helpers already used throughout particle/effect code.
- Added operations align with the expected data model for group state (position/velocity vectors + transform matrix), instead of ad-hoc scalar math.
- Changes are localized to state update logic and avoid contrived control-flow reshaping purely for score coaxing.

## Technical notes
- This patch intentionally targets a high-gap function and improves instruction-level alignment without introducing non-local behavior changes.
- `ninja` build passes after changes.
