### PR TITLE
menu_arti: improve ArtiOpen match by normalizing f64 conversion path

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -341,8 +341,6 @@ void CMenuPcs::ArtiInit1()
 unsigned int CMenuPcs::ArtiOpen()
 {
 	float fVar1;
-	double dVar2;
-	double dVar3;
 	short* psVar4;
 	int iVar5;
 	int iVar6;
@@ -360,28 +358,22 @@ unsigned int CMenuPcs::ArtiOpen()
 	iVar7 = (int)*(short*)(*(int*)((char*)this + 0x82c) + 0x22);
 	if (0 < iVar6) {
 		for (iVar8 = iVar6; iVar8 != 0; iVar8 = iVar8 - 1) {
-			dVar3 = DOUBLE_80332fe0;
 			fVar1 = FLOAT_80332fa8;
 			if (*(int*)(psVar4 + 0x12) <= iVar7) {
 				if (iVar7 < *(int*)(psVar4 + 0x12) + *(int*)(psVar4 + 0x14)) {
-					*(int*)(psVar4 + 0x10) = *(int*)(psVar4 + 0x10) + 1;
-					dVar2 = DOUBLE_80332fb0;
-					*(float*)(psVar4 + 8) =
-					    (float)((DOUBLE_80332fb0 /
-					             ((double)(((unsigned int)*(unsigned int*)(psVar4 + 0x14) ^ 0x80000000U) | 0x4330000000000000ULL) - dVar3)) *
-					            ((double)(((unsigned int)*(unsigned int*)(psVar4 + 0x10) ^ 0x80000000U) | 0x4330000000000000ULL) - dVar3));
+					unsigned int uVar9 = (unsigned int)(*(int*)(psVar4 + 0x10) + 1);
+					unsigned int uVar10 = (unsigned int)*(int*)(psVar4 + 0x14);
+					double dVar11 = IntToF64(uVar9);
+					double dVar12 = IntToF64(uVar10);
+
+					*(int*)(psVar4 + 0x10) = (int)uVar9;
+					fVar1 = (float)((DOUBLE_80332fb0 / dVar12) * dVar11);
+					*(float*)(psVar4 + 8) = fVar1;
 					if ((*(unsigned int*)(psVar4 + 0x16) & 2) == 0) {
-						fVar1 = (float)((dVar2 /
-						                 ((double)(((unsigned int)*(unsigned int*)(psVar4 + 0x14) ^ 0x80000000U) | 0x4330000000000000ULL) - dVar3)) *
-						                ((double)(((unsigned int)*(unsigned int*)(psVar4 + 0x10) ^ 0x80000000U) | 0x4330000000000000ULL) - dVar3));
-						*(float*)(psVar4 + 0x18) =
-						    (*(float*)(psVar4 + 0x1c) -
-						     (float)((double)(((unsigned int)(int)*psVar4 ^ 0x80000000U) | 0x4330000000000000ULL) - dVar3)) *
-						    fVar1;
-						*(float*)(psVar4 + 0x1a) =
-						    (*(float*)(psVar4 + 0x1e) -
-						     (float)((double)(((unsigned int)(int)psVar4[1] ^ 0x80000000U) | 0x4330000000000000ULL) - dVar3)) *
-						    fVar1;
+						float fVar2 = (float)IntToF64((unsigned int)((int)*psVar4));
+						*(float*)(psVar4 + 0x18) = (*(float*)(psVar4 + 0x1c) - fVar2) * fVar1;
+						fVar2 = (float)IntToF64((unsigned int)((int)psVar4[1]));
+						*(float*)(psVar4 + 0x1a) = (*(float*)(psVar4 + 0x1e) - fVar2) * fVar1;
 					}
 				} else {
 					iVar5 = iVar5 + 1;


### PR DESCRIPTION
## Summary
Refactors `CMenuPcs::ArtiOpen()` in `src/menu_arti.cpp` to use the same integer->double conversion path already used by `ArtiClose()` via `IntToF64()`.

This removes manual bit-pattern conversion expressions and keeps the same control flow/constants while producing assembly that aligns better with target output.

## Functions improved
- Unit: `main/menu_arti`
- Symbol: `ArtiOpen__8CMenuPcsFv`
  - Before: `13.638889%`
  - After: `27.38889%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/menu_arti -o - ArtiOpen__8CMenuPcsFv`
  - Function match increased by `+13.75` points.
- Unit `.text` match (same objdiff output)
  - Before: `49.65811%`
  - After: `50.77887%`

## Plausibility rationale
- Uses existing helper (`IntToF64`) already present in this unit and already used in neighboring artifact animation logic (`ArtiClose`).
- Keeps behavior/source intent intact: same activation window checks, alpha progression, and per-entry offset interpolation.
- Change is source-plausible cleanup (type/conversion normalization), not synthetic control-flow coercion.

## Technical details
- Replaced repeated inline `0x4330000000000000ULL` conversion sequences with local `u32` step/total temporaries and `IntToF64` calls.
- Preserved frame counter update order and per-axis interpolation calculations to avoid semantic drift.
- Verified build with `ninja` and rechecked symbol diff with objdiff.