### PR TITLE
materialman: implement CMaterialSet::operator new

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -831,6 +831,26 @@ void CMaterialSet::AddMaterial(CMaterial*, int)
 
 /*
  * --INFO--
+ * PAL Address: 0x8003d878
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void* CMaterialSet::operator new(unsigned long size, CMemory::CStage*, char* file, int line)
+{
+    return _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+        &Memory,
+        size,
+        *reinterpret_cast<CMemory::CStage**>(MaterialMan + 0x218),
+        file,
+        line,
+        0);
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x8003c71c
  * PAL Size: 132b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Implemented `CMaterialSet::operator new(unsigned long, CMemory::CStage*, char*, int)` in `src/materialman.cpp`.
- Added the runbook-required `--INFO--` metadata block with PAL address/size (`0x8003d878`, `72b`).
- Allocation now routes through `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii` using the global material manager stage (`MaterialMan + 0x218`), matching existing code patterns in this unit.

## Functions improved
- Unit: `main/materialman`
- Function: `__nw__12CMaterialSetFUlPQ27CMemory6CStagePci`
  - Before: `0.0%` (selector output)
  - After: `67.22222%` fuzzy match (`build/GCCP01/report.json`)

## Match evidence
- `ninja` rebuild succeeds.
- `build/tools/objdiff-cli diff -p . -u main/materialman -o - __nw__12CMaterialSetFUlPQ27CMemory6CStagePci`
  reports this symbol as a matched target with non-zero instruction alignment (`~67.17%` in symbol diff JSON).
- Unit `main/materialman` fuzzy match also rises from selector baseline (`5.9%`) to `6.029516%`.

## Plausibility rationale
- This implementation is source-plausible for original game code: class-local allocator wrapper delegating to the engine memory allocator with file/line forwarding.
- It follows existing allocator conventions in the codebase and avoids contrived control-flow/temporary tricks.

## Technical notes
- Current mismatch is mostly register/argument setup around the allocator call; this should be a good base for a follow-up refinement pass.
