### PR TITLE
Improve pppFrameYmDrawMdlTexAnm match with payload-based control flow

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -132,9 +132,7 @@ void pppFrameYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep*
     CMapMeshUVLayout* uvLayout;
     s16* uvPairs;
     s32* payload;
-    u32 frameU;
-    u32 frameMod;
-    u32 i;
+    s32 i;
 
     work = (pppYmDrawMdlTexAnmWork*)((u8*)param1 + 0x80 + param3->m_serializedDataOffsets[2]);
     if (DAT_8032ed70 != 0) {
@@ -158,14 +156,12 @@ void pppFrameYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep*
 
         uvLayout = (CMapMeshUVLayout*)mapMesh;
         uvPairs = uvLayout->m_uvPairs;
-        for (i = 0; i < (u32)uvLayout->m_uvCount; i++) {
-            const f32 u = (f32)uvPairs[0];
-            const f32 v = (f32)uvPairs[1];
-            if (work->m_perU < u) {
-                work->m_perU = u;
+        for (i = 0; i < (s32)(u32)uvLayout->m_uvCount; i++) {
+            if (work->m_perU < (f32)uvPairs[0]) {
+                work->m_perU = (f32)uvPairs[0];
             }
-            if (work->m_perV < v) {
-                work->m_perV = v;
+            if (work->m_perV < (f32)uvPairs[1]) {
+                work->m_perV = (f32)uvPairs[1];
             }
             uvPairs += 2;
         }
@@ -178,26 +174,21 @@ void pppFrameYmDrawMdlTexAnm(pppYmDrawMdlTexAnm* param1, pppYmDrawMdlTexAnmStep*
     work->m_frame += 1;
     work->m_wait = 0x200;
 
-    for (i = 0; i < (u32)uvLayout->m_uvCount; i++) {
+    for (i = 0; i < (s32)(u32)uvLayout->m_uvCount; i++) {
         uvPairs[0] = (s16)((f32)uvPairs[0] + work->m_perU);
-
-        frameMod = work->m_frame / work->m_tilesU;
-        if (work->m_frame == frameMod * work->m_tilesU) {
-            uvPairs[0] = (s16)(-((work->m_perU * (f32)work->m_tilesU) - (f32)uvPairs[0]));
+        if (work->m_frame == (work->m_frame / (u32)payload[1]) * (u32)payload[1]) {
+            uvPairs[0] = (s16)(-((work->m_perU * (f32)(u32)payload[1]) - (f32)uvPairs[0]));
             uvPairs[1] = (s16)((f32)uvPairs[1] + work->m_perV);
         }
-
-        if ((work->m_tilesU * work->m_tilesV) <= work->m_frame) {
-            frameU = work->m_tilesV;
-            uvPairs[1] = (s16)(-((work->m_perV * (f32)frameU) - (f32)uvPairs[1]));
+        if ((u32)(payload[1] * payload[2]) <= work->m_frame) {
+            uvPairs[1] = (s16)(-((work->m_perV * (f32)(u32)payload[2]) - (f32)uvPairs[1]));
         }
-
         uvPairs += 2;
     }
 
     DCFlushRange(uvLayout->m_uvPairs, (u32)uvLayout->m_uvCount << 2);
 
-    if ((work->m_tilesU * work->m_tilesV) <= work->m_frame) {
+    if ((u32)(payload[1] * payload[2]) <= work->m_frame) {
         work->m_frame = 0;
     }
 }


### PR DESCRIPTION
## Summary
- Refined `pppFrameYmDrawMdlTexAnm` in `src/pppYmDrawMdlTexAnm.cpp` to better match original control/data flow while keeping behavior intact.
- Removed unnecessary temporaries in UV max scan and frame loop (`frameU`, `frameMod`, float locals).
- Switched wrap/reset checks to use payload-derived tile counts directly in expressions where the original appears to reload payload terms.

## Functions improved
- Unit: `main/pppYmDrawMdlTexAnm`
- Function: `pppFrameYmDrawMdlTexAnm`
  - Before: `64.25728%`
  - After: `73.51942%`
  - Delta: `+9.26214`

## Match evidence
- Baseline: `build/tools/objdiff-cli diff -p . -u main/pppYmDrawMdlTexAnm -o - pppFrameYmDrawMdlTexAnm`
- Post-change: same command after rebuild
- Symbol-level comparison shows only `pppFrameYmDrawMdlTexAnm` changed, with the delta above.

## Plausibility rationale
- Changes are source-plausible and idiomatic: simplified loop variables and equivalent arithmetic/control-flow forms rather than artificial compiler coaxing patterns.
- No hardcoded offsets or unnatural sequencing were introduced; logic still reflects per-frame UV stepping and tiling wrap behavior from the original effect system.

## Technical details
- UV max scan now compares directly against `uvPairs[0]` and `uvPairs[1]` without extra temporaries, matching a tighter generated form.
- Divisibility and frame-end wrap conditions now operate on payload tile values in-place in the branch expressions, improving instruction shape/alignment with target assembly.
- Verified with `ninja` build and objdiff JSON output.
