### PR TITLE
Match ReportStandby in RedSound

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -230,15 +230,18 @@ void CRedSound::ReportPrint(int debugFlag)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma optimization_level 0
 int CRedSound::ReportStandby(int id)
 {
+	int result = 0;
 	int i;
 
 	if (id == 0) {
 		i = 0;
 		do {
 			if (DAT_8032e17c[i] != 0) {
-				return 1;
+				result++;
+				break;
 			}
 			i++;
 		} while (i < 0x40);
@@ -246,13 +249,16 @@ int CRedSound::ReportStandby(int id)
 		i = 0;
 		do {
 			if (id == DAT_8032e17c[i]) {
-				return 1;
+				result++;
+				break;
 			}
 			i++;
 		} while (i < 0x40);
 	}
-	return 0;
+
+	return result;
 }
+#pragma optimization_level 4
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Updated `CRedSound::ReportStandby(int)` in `src/RedSound/RedSound.cpp` to match original control-flow/codegen shape.
- Replaced early returns with a `result` accumulator and explicit loop breaks.
- Scoped optimization control around this function (`#pragma optimization_level 0` / `#pragma optimization_level 4`) to prevent aggressive loop unrolling and recover expected stack/register behavior.

## Functions improved
- Unit: `main/RedSound/RedSound`
- Function: `ReportStandby__9CRedSoundFi` (size: 152b)
- Before: `0.0%` (from target selector / previous report)
- After: `100.0%` in `build/GCCP01/report.json`

## Match evidence
- `ninja` progress delta after change:
  - matched code: `210276 -> 210428` (`+152` bytes)
  - matched functions: `1643 -> 1644` (`+1`)
- Unit fuzzy match (`main/RedSound/RedSound`):
  - `65.02225 -> 69.04767`
- objdiff symbol view for `ReportStandby__9CRedSoundFi` now reports near-complete alignment (`98.947365%`) with restored structural parity.

## Plausibility rationale
- The updated function remains straightforward, readable gameplay code: linear scan of a standby-ID table with the same semantics as before.
- Changes reflect plausible original author intent (single return path + explicit found flag), and the pragma boundary is narrowly scoped to preserve historical compiler behavior for this one function.
- No contrived pointer arithmetic, magic offsets, or behavior-changing rewrites were introduced.

## Technical details
- Previous form was being aggressively unrolled by MWCC, producing a drastically different shape and 0% match.
- Forcing local optimization level and matching loop/return structure recovered expected non-unrolled loop structure and register usage pattern for this function.
