### PR TITLE
game: specialize CPtrArray<CMapLightHolder*>::operator[]

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -165,6 +165,21 @@ static bool BOOL_8032ec44;
 
 /*
  * --INFO--
+ * PAL Address: 0x800161f0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapLightHolder* CPtrArray<CMapLightHolder*>::operator[](unsigned long index)
+{
+    return GetAt(index);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added an explicit specialization for `CPtrArray<CMapLightHolder*>::operator[]` in `src/game.cpp`.
- Implemented it as a simple wrapper returning `GetAt(index)`, matching the existing pattern used by other `CPtrArray` specializations in the codebase.
- Added PAL metadata for the function (`0x800161f0`, `32b`) based on the Ghidra export.

## Functions Improved
- Unit: `main/game`
- Symbol: `__vc__29CPtrArray<P15CMapLightHolder>FUl`

## Match Evidence
- `__vc__29CPtrArray<P15CMapLightHolder>FUl`: **33.625% -> 100.0%**
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/game -o - --format json`

## Plausibility Rationale
- This change is source-plausible and idiomatic for this repository: multiple object files already define explicit `CPtrArray<...>::operator[]` wrappers that delegate to `GetAt`.
- The specialization avoids compiler inlining differences from the generic template path and aligns with likely original out-of-line code generation.

## Technical Notes
- The generic template path emitted a different instruction pattern for this specialization.
- Making the specialization explicit in `src/game.cpp` forces the expected wrapper body and restores instruction-level alignment for this symbol.
