### PR TITLE
mesmenu: decompile CMesMenu::CalcHeart

### DIFF
--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/mesmenu.h"
+#include "ffcc/p_game.h"
 
 extern "C" {
 void Set__4CMesFPci(void* mes, char* script, int flags);
@@ -74,12 +75,89 @@ void CMesMenu::onDraw()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009bcec
+ * PAL Size: 496b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMesMenu::CalcHeart()
 {
-	// TODO
+    unsigned int scriptFood = Game.game.m_scriptFoodBase[*(int*)((char*)this + 0x18)];
+    if (scriptFood == 0) {
+        return;
+    }
+
+    unsigned int foodCount = (unsigned int)*(unsigned short*)(scriptFood + 0x1C);
+    int targetValue = (int)(foodCount * 6);
+    if (*(int*)((char*)this + 0x3DAC) < targetValue) {
+        *(int*)((char*)this + 0x3DAC) = targetValue;
+    } else if (targetValue < *(int*)((char*)this + 0x3DAC)) {
+        *(unsigned int*)((char*)this + 0x3DAC) = foodCount * 6;
+    }
+
+    int currentValue = *(int*)((char*)this + 0x3DA8);
+    if (currentValue < *(int*)((char*)this + 0x3DAC)) {
+        int index = currentValue / 0xC + (currentValue >> 0x1F);
+        int base = (int)this + (index - (index >> 0x1F)) * 4;
+        if (*(int*)(base + 0x3DB0) == 0) {
+            *(int*)(base + 0x3DB0) = 0x10;
+        }
+
+        int nextValue = currentValue + 2;
+        int maxValue = *(int*)((char*)this + 0x3DAC);
+        if (nextValue < maxValue) {
+            maxValue = nextValue;
+        }
+        *(int*)((char*)this + 0x3DA8) = maxValue;
+    } else if (*(int*)((char*)this + 0x3DAC) < currentValue) {
+        *(unsigned int*)((char*)this + 0x3DA8) = (currentValue - 2U) & ~((int)(currentValue - 2U) >> 0x1F);
+
+        int decValue = *(int*)((char*)this + 0x3DA8);
+        int index = decValue / 0xC + (decValue >> 0x1F);
+        int base = (int)this + (index - (index >> 0x1F)) * 4;
+        if (*(int*)(base + 0x3DD0) == 0) {
+            *(int*)(base + 0x3DD0) = 0x10;
+        }
+        if (*(int*)((char*)this + 0x3DF0) == 0) {
+            *(int*)((char*)this + 0x3DF0) = 0x10;
+        }
+    }
+
+    int i = 2;
+    int base = (int)this;
+    do {
+        unsigned int value = *(int*)(base + 0x3DB0) - 1;
+        *(unsigned int*)(base + 0x3DB0) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DD0) - 1;
+        *(unsigned int*)(base + 0x3DD0) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DB4) - 1;
+        *(unsigned int*)(base + 0x3DB4) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DD4) - 1;
+        *(unsigned int*)(base + 0x3DD4) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DB8) - 1;
+        *(unsigned int*)(base + 0x3DB8) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DD8) - 1;
+        *(unsigned int*)(base + 0x3DD8) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DBC) - 1;
+        *(unsigned int*)(base + 0x3DBC) = value & ~((int)value >> 0x1F);
+
+        value = *(int*)(base + 0x3DDC) - 1;
+        *(unsigned int*)(base + 0x3DDC) = value & ~((int)value >> 0x1F);
+
+        base += 0x10;
+        i--;
+    } while (i != 0);
+
+    unsigned int value = *(int*)((char*)this + 0x3DF0) - 1;
+    *(unsigned int*)((char*)this + 0x3DF0) = value & ~((int)value >> 0x1F);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Decompiled `CMesMenu::CalcHeart()` in `src/mesmenu.cpp` using the PAL Ghidra reference and existing codebase style (raw offset-based field access used throughout this file).
- Added PAL metadata block for the function:
  - PAL Address: `0x8009bcec`
  - PAL Size: `496b`
- Added `#include "ffcc/p_game.h"` so the implementation can use `Game.game.m_scriptFoodBase` directly.

## Functions Improved
- Unit: `main/mesmenu`
- Function: `CalcHeart__8CMesMenuFv`

## Match Evidence
- `build/tools/objdiff-cli diff -p . -u main/mesmenu -o - CalcHeart__8CMesMenuFv`
  - Function match: **83.048386%**
  - Target size: `496`
  - Current size: `512`
- `build/GCCP01/report.json`
  - `CalcHeart__8CMesMenuFv` fuzzy match: **83.25**

## Plausibility Rationale
- The implementation mirrors clear gameplay-state logic (food-count driven heart animation counters and bounded decrement timers), not synthetic control-flow tricks.
- Uses consistent field offsets and integer clamping idioms already present in this decomp codebase.
- No artificial temporaries/comments were added purely to influence codegen.

## Technical Notes
- Preserved branch structure and arithmetic patterns from reference decomp where practical (counter growth/shrink path, per-slot decay loop, final global decay).
- This is a first-pass reconstruction and leaves room for further register/allocation tuning to reduce the remaining size delta (`512` vs `496`).
