### PR TITLE
main/pppLocationTitle: improve pppRenderLocationTitle match

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -262,7 +262,7 @@ void pppRenderLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, U
 
             pppSetDrawEnv((pppCVECTOR*)(particle + 1), (pppFMATRIX*)0, 0.0f, 0, 0, 0, 0, 0, 1, 0);
 
-            if (fadeDivisor > 0) {
+            if (fadeDivisor >= 0) {
                 u8* alpha = (u8*)&particle[1].x + 3;
                 *alpha = (u8)(*alpha - (*alpha / fadeDivisor));
             }
@@ -272,9 +272,9 @@ void pppRenderLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, U
             GXSetChanMatColor(GX_COLOR0A0, color);
             GXLoadPosMtxImm(model, 0);
 
-            u8 blendMode = ((u8*)&param_2->m_stepValue)[1];
-            pppSetBlendMode(blendMode);
-            pppDrawShp(shapeTable, *(short*)&particle[2].x, pppEnvStPtr->m_materialSetPtr, blendMode);
+            pppSetBlendMode(((u8*)&param_2->m_stepValue)[1]);
+            pppDrawShp(shapeTable, *(short*)&particle[2].x, pppEnvStPtr->m_materialSetPtr,
+                       ((u8*)&param_2->m_stepValue)[1]);
 
             particle = (Vec*)&particle[2].y;
         }


### PR DESCRIPTION
## Summary
- Adjusted `pppRenderLocationTitle` control-flow and argument loading in `src/pppLocationTitle.cpp`.
- Changed alpha-fade gate from `fadeDivisor > 0` to `fadeDivisor >= 0` to match the observed compare shape.
- Removed the loop-local `blendMode` temporary and passed the same byte expression directly to `pppSetBlendMode` and `pppDrawShp`.

## Functions improved
- Unit: `main/pppLocationTitle`
- Function: `pppRenderLocationTitle` (400b)

## Match evidence
- `objdiff-cli diff` (`-u main/pppLocationTitle`, symbol `pppRenderLocationTitle`):
  - Before: `65.05%`
  - After: `66.19%`
  - Delta: `+1.14%`
- Report (`build/GCCP01/report.json`) for the same function:
  - Before: `65.75%`
  - After: `66.84%`
  - Delta: `+1.09%`
- Unit fuzzy (`main/pppLocationTitle`) increased from `50.177273%` to `50.424995%`.

## Plausibility rationale
- Changes keep behavior within the intended original render flow and avoid contrived reordering.
- Edits are type/control-flow level adjustments that align with decomp structure rather than compiler-coax artifacts.
- No debug artifacts or analysis comments were introduced.

## Technical details
- Used `ninja` after each iteration and validated per-symbol assembly alignment via:
  - `build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o diff_result.json --format json-pretty pppRenderLocationTitle`
- Rejected one intermediate arithmetic-cast tweak because it regressed match percent, then restored the better variant.