### PR TITLE
gx/GXPixel: improve GXSetFogRangeAdj bitfield packing

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -172,7 +172,7 @@ void GXSetFogRangeAdj(GXBool enable, u16 center, const GXFogAdjTable *table) {
         GX_WRITE_RAS_REG(range_adj);
     }
 
-    range_adj = (center + 342) | ((u32)(u8)enable << 10) | 0xE8000000;
+    range_adj = ((center + 342) & 0x00FFFBFF) | ((u32)(u8)enable << 10) | 0xE8000000;
     GX_WRITE_RAS_REG(range_adj);
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
## Summary
- Adjusted GXSetFogRangeAdj center register packing in src/gx/GXPixel.c to clear bit 10 before OR-ing the enable flag.
- Change: ange_adj = ((center + 342) & 0x00FFFBFF) | ((u32)(u8)enable << 10) | 0xE8000000;

## Functions Improved
- Unit: main/gx/GXPixel
- Symbol: GXSetFogRangeAdj
  - Before: 62.546875%
  - After: 63.0%

## Match Evidence
- objdiff command used:
  - uild/tools/objdiff-cli diff -p . -u main/gx/GXPixel -o - GXSetFogRangeAdj
- Unit .text match percent also increased:
  - Before: 82.56281%
  - After: 82.63568%

## Plausibility Rationale
- This change is source-plausible: it is a straightforward register bitfield hygiene fix ensuring the incoming center value does not leak into the enable bit position before that bit is explicitly set from enable.
- It keeps existing control flow and data layout intact while better matching expected low-level register composition.

## Technical Notes
- No control-flow restructuring or compiler-coaxing temporaries were introduced.
- Build verified with 
inja.