### PR TITLE
p_FunnyShape: improve __sinit_p_FunnyShape_cpp layout

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -109,16 +109,14 @@ static inline CFunnyShape* FunnyShape(CFunnyShapePcs* self)
  */
 extern "C" void __sinit_p_FunnyShape_cpp(void)
 {
-    CPtrArray<OSFS_TEXTURE_ST*>* texData =
-        reinterpret_cast<CPtrArray<OSFS_TEXTURE_ST*>*>(FunnyShapePcs + 0x61BC);
-    CPtrArray<_GXTexObj*>* gxTex = reinterpret_cast<CPtrArray<_GXTexObj*>*>(FunnyShapePcs + 0x61D8);
-
+    *reinterpret_cast<void**>(FunnyShapePcs) = &__vt__8CManager;
+    *reinterpret_cast<void**>(FunnyShapePcs) = &lbl_801E8668;
     *reinterpret_cast<void**>(FunnyShapePcs) = &lbl_801EA924;
 
-    __ct__14CUSBStreamDataFv(reinterpret_cast<CUSBStreamData*>(FunnyShapePcs + 0x8));
-    __ct__11CFunnyShapeFv(reinterpret_cast<CFunnyShape*>(FunnyShapePcs + 0x1C));
-    texData->CPtrArray<OSFS_TEXTURE_ST*>::CPtrArray();
-    gxTex->CPtrArray<_GXTexObj*>::CPtrArray();
+    __ct__14CUSBStreamDataFv(reinterpret_cast<CUSBStreamData*>(FunnyShapePcs + 0x3C));
+    __ct__11CFunnyShapeFv(reinterpret_cast<CFunnyShape*>(FunnyShapePcs + 0x50));
+    reinterpret_cast<CPtrArray<OSFS_TEXTURE_ST*>*>(FunnyShapePcs + 0x61BC)->CPtrArray<OSFS_TEXTURE_ST*>::CPtrArray();
+    reinterpret_cast<CPtrArray<_GXTexObj*>*>(FunnyShapePcs + 0x61D8)->CPtrArray<_GXTexObj*>::CPtrArray();
 
     __register_global_object(FunnyShapePcs, reinterpret_cast<void*>(__dt__14CFunnyShapePcsFv), ARRAY_8026D728);
 


### PR DESCRIPTION
## Summary
- Adjusted `__sinit_p_FunnyShape_cpp` initialization layout in `src/p_FunnyShape.cpp` to better match expected constructor/object memory layout.
- Added explicit staged vtable assignments for `FunnyShapePcs` base/derived init sequence.
- Corrected constructor offsets used during static init:
  - `CUSBStreamData` from `+0x08` -> `+0x3C`
  - `CFunnyShape` from `+0x1C` -> `+0x50`
- Inlined `CPtrArray` constructor calls at the existing `+0x61BC` and `+0x61D8` regions without temporary locals.

## Functions Improved
- Unit: `main/p_FunnyShape`
- Symbol: `__sinit_p_FunnyShape_cpp`
- Match: `44.34722% -> 45.38889%` (objdiff oneshot)

## Match Evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - __sinit_p_FunnyShape_cpp`
- Result shows measurable instruction alignment improvement in static init prologue and constructor setup sequence.

## Plausibility Rationale
- Changes reflect plausible original source behavior for static object setup:
  - class/base vtable establishment followed by member subobject constructors,
  - corrected member offsets for embedded `CUSBStreamData`/`CFunnyShape`,
  - preserved existing data table copy logic and overall initialization semantics.
- No compiler-coaxing temporaries or non-idiomatic control flow were introduced.