### PR TITLE
pppPart: implement pppDrawMesh

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -2122,12 +2122,40 @@ void _pppDrawPart(_pppMngSt* pppMngSt)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80054588
+ * PAL Size: 236b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppDrawMesh(pppModelSt*, Vec*, int)
+void pppDrawMesh(pppModelSt* model, Vec* positions, int usePartMaterial)
 {
-	// TODO
+	*(u32*)(MaterialMan + 0x128) = *(u32*)(MaterialMan + 0x11C);
+	*(u32*)(MaterialMan + 0x12C) = *(u32*)(MaterialMan + 0x120);
+	*(u32*)(MaterialMan + 0x130) = *(u32*)(MaterialMan + 0x124);
+	*(u32*)(MaterialMan + 0x40) = *(u32*)(MaterialMan + 0x48);
+
+	if (positions == 0)
+	{
+		GXSetArray((GXAttr)9, *(void**)((u8*)&model->m_mapMesh + 0x2C), 0xC);
+	}
+	else
+	{
+		GXSetArray((GXAttr)9, positions, 0xC);
+	}
+
+	GXSetArray((GXAttr)0xB, *(void**)((u8*)&model->m_mapMesh + 0x3C), 4);
+	GXSetArray((GXAttr)0xD, *(void**)((u8*)&model->m_mapMesh + 0x38), 4);
+	GXSetArray((GXAttr)0xE, *(void**)((u8*)&model->m_mapMesh + 0x38), 4);
+	*(void**)(MaterialMan + 4) = *(void**)((u8*)&model->m_mapMesh + 0x30);
+
+	if (usePartMaterial == 0)
+	{
+		GXSetArray((GXAttr)10, *(void**)(MaterialMan + 4), 6);
+	}
+
+	model->m_mapMesh.DrawPart(pppEnvStPtr->m_materialSetPtr, usePartMaterial);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented pppDrawMesh(pppModelSt*, Vec*, int) in src/pppPart.cpp using the existing raw MaterialMan / CMapMesh conventions already used in neighboring particle-render paths.
- Added version metadata for the function header:
  - PAL Address: 80054588
  - PAL Size: 236b
- Replaced TODO body with real render setup:
  - syncs MaterialMan state fields
  - binds vertex/color arrays via GXSetArray
  - conditionally binds normals/tangents for the non-part path
  - calls CMapMesh::DrawPart with pppEnvStPtr->m_materialSetPtr

## Functions improved
- Unit: main/pppPart
- Symbol: pppDrawMesh__FP10pppModelStP3Veci

## Match evidence
- Before: 1.7% (from 	ools/agent_select_target.py output)
- After: 99.91525% (objdiff-cli oneshot)
- Command used:
  - uild/tools/objdiff-cli diff -p . -u main/pppPart -o - pppDrawMesh

## Plausibility rationale
- The implementation follows existing project style in this unit (direct MaterialMan offset writes + explicit GX array setup) rather than introducing synthetic temporaries or compiler-coaxing constructs.
- Control flow is straightforward and idiomatic for this rendering path: set shared render state, choose position source, then dispatch DrawPart.

## Technical details
- Matches Ghidra reference function shape for 80054588_pppDrawMesh__FP10pppModelStP3Veci while preserving local codebase conventions.
- Keeps behavior consistent with CMapMesh::SetRenderArray field usage and DrawPart invocation semantics.