### PR TITLE
cflat_runtime: implement deleteObject

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -170,12 +170,28 @@ void CFlatRuntime::AfterFrame(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006879c
+ * PAL Size: 136b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime::deleteObject(CFlatRuntime::CObject*)
+void CFlatRuntime::deleteObject(CFlatRuntime::CObject* object)
 {
-	// TODO
+	object->m_previous->m_next = object->m_next;
+	object->m_next->m_previous = object->m_previous;
+
+	*(void**)((char*)*object->m_freeListNode + 4) = object->m_freeListNode[1];
+	*(void**)object->m_freeListNode[1] = *object->m_freeListNode;
+
+	object->m_freeListNode[1] = *(void***)((char*)this + 0x98C);
+	*(void***)((char*)this + 0x98C) = object->m_freeListNode;
+
+	object->m_flags &= 0xEF;
+
+	typedef void (*OnDeleteFn)(CFlatRuntime*);
+	reinterpret_cast<OnDeleteFn>((*reinterpret_cast<void***>(this))[7])(this);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CFlatRuntime::deleteObject(CFlatRuntime::CObject*)` in `src/cflat_runtime.cpp` using the existing object/list layout and runtime callback path, and replaced the TODO metadata with PAL address/size info.

## Functions Improved
- Unit: `main/cflat_runtime`
- Symbol: `deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject`
- Size: `136b`

## Match Evidence
- `deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject`: **2.9411764% -> 92.64706%**
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o - deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject`
- Build check: `ninja` passes.

## Plausibility Rationale
This change is a straightforward source-level implementation of expected runtime behavior:
- unlink object from active doubly-linked list
- relink object’s free-list node into runtime free list
- clear live flag bit (`0x10`)
- call runtime deletion callback via vtable

No compiler-coaxing temporaries or artificial control flow were added.

## Technical Notes
- Runtime free-list head access uses offset `0x98C`, matching the target instruction stream for this symbol.
- Callback dispatch uses vtable slot index `7` (offset `0x1C`), consistent with target callsite.