### PR TITLE
Improve pppCharaBreak constructor codegen matching

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -614,15 +614,16 @@ void UpdatePolygonData(PCharaBreak* step, VCharaBreak* work, CChara::CModel* mod
  */
 void pppConstructCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkC* data)
 {
+    float fVar1 = FLOAT_80332048;
     int dataOffset = data->m_serializedDataOffsets[2];
 
     *(u32*)((u8*)charaBreak + 0x9C + dataOffset) = 0;
-    *(float*)((u8*)charaBreak + 0x8C + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x88 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x84 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x98 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x94 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x90 + dataOffset) = FLOAT_80332048;
+    *(float*)((u8*)charaBreak + 0x8C + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x88 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x84 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x98 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x94 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x90 + dataOffset) = fVar1;
     *(u32*)((u8*)charaBreak + 0xC4 + dataOffset) = 1;
 }
 
@@ -637,14 +638,15 @@ void pppConstructCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkC* data)
  */
 void pppConstruct2CharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkC* data)
 {
+    float fVar1 = FLOAT_80332048;
     int dataOffset = data->m_serializedDataOffsets[2];
 
-    *(float*)((u8*)charaBreak + 0x8C + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x88 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x84 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x98 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x94 + dataOffset) = FLOAT_80332048;
-    *(float*)((u8*)charaBreak + 0x90 + dataOffset) = FLOAT_80332048;
+    *(float*)((u8*)charaBreak + 0x8C + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x88 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x84 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x98 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x94 + dataOffset) = fVar1;
+    *(float*)((u8*)charaBreak + 0x90 + dataOffset) = fVar1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated pppConstructCharaBreak and pppConstruct2CharaBreak in src/pppCharaBreak.cpp to use a single local loat constant (Var1) for repeated initialization stores.
- Kept behavior unchanged; only expression shape/codegen was adjusted.

## Functions improved
- Unit: main/pppCharaBreak
- pppConstructCharaBreak
- pppConstruct2CharaBreak

## Match evidence
- pppConstructCharaBreak: **44.8125% -> 88.25%**
- pppConstruct2CharaBreak: **45.333332% -> 87.0%**
- Measurement command used:
  - 	ools/objdiff-cli diff -p . -u main/pppCharaBreak -o - <symbol>

## Plausibility rationale
- Reusing one loaded constant for a burst of field initialization is a natural source pattern in constructor-style setup code.
- This avoids contrived sequencing and keeps the code readable and idiomatic while producing materially better assembly alignment.

## Technical details
- Prior form repeatedly referenced FLOAT_80332048 at each store site.
- New form introduces one local Var1 and writes that value into each target field, matching the decomp pattern more closely and reducing register/constant reload divergence.