### PR TITLE
main/mes: implement drawTagString first-pass

### DIFF
--- a/include/ffcc/mes.h
+++ b/include/ffcc/mes.h
@@ -30,7 +30,7 @@ public:
     int useFlag(int, int);
     void addFlag(class CFlag&);
     void MakeAgbString(char*, char*, int, int);
-    void drawTagString(CFont*, char*, int, int, int);
+    unsigned long drawTagString(CFont*, char*, int, int, int);
 
 private:
     char* mText;

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1,5 +1,11 @@
 #include "ffcc/mes.h"
+#include "ffcc/fontman.h"
 #include <string.h>
+
+extern "C" void SetPosX__5CFontFf(float, CFont*);
+extern "C" void SetPosY__5CFontFf(float, CFont*);
+extern "C" void Draw__5CFontFUs(CFont*, unsigned short);
+extern "C" float GetWidth__5CFontFUs(CFont*, unsigned short);
 
 /*
  * --INFO--
@@ -432,10 +438,49 @@ void CMes::MakeAgbString(char*, char*, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800981f0
+ * PAL Size: 380b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMes::drawTagString(CFont*, char*, int, int, int)
+unsigned long CMes::drawTagString(CFont* font, char* text, int drawChars, int breakOnLineTag, int lineBaseY)
 {
-	// TODO
+	u8* p = (u8*)text;
+	u32 totalWidth = 0;
+	bool running = true;
+	float startX = font->posX;
+
+	while (running)
+	{
+		u8 ch = *p++;
+		if (ch == 0)
+		{
+			running = false;
+		}
+		else if (ch == 0xFF)
+		{
+			u8 tag = *p++;
+			if (tag == 0xA1)
+			{
+				running = false;
+			}
+			else if ((tag == 0xA0) && (breakOnLineTag != 0))
+			{
+				SetPosX__5CFontFf(startX, font);
+				SetPosY__5CFontFf((float)lineBaseY + font->posY + (float)font->m_glyphWidth * font->scaleY, font);
+			}
+		}
+		else
+		{
+			if (drawChars != 0)
+			{
+				Draw__5CFontFUs(font, ch);
+			}
+			totalWidth += (u32)GetWidth__5CFontFUs(font, ch);
+		}
+	}
+
+	return totalWidth;
 }


### PR DESCRIPTION
## Summary
- Corrected `CMes::drawTagString` return type to return width instead of `void`.
- Replaced the stub in `src/mes.cpp` with a first-pass implementation that parses message tags, draws glyphs, and accumulates width.
- Added PAL address/size metadata for `drawTagString`.

## Functions improved
- Unit: `main/mes`
- Symbol: `drawTagString__4CMesFP5CFontPciii` (380b)

## Match evidence
- `drawTagString__4CMesFP5CFontPciii`: **1.0526316% -> 39.705265%**
- Measured with:
  - `build/tools/objdiff-cli diff -p . -u main/mes -o -`
  - `build/tools/objdiff-cli diff -p . -u main/mes -o - drawTagString__4CMesFP5CFontPciii`

## Plausibility rationale
- The update aligns with observed behavior from Ghidra for this symbol: iterate control bytes, handle `0xFF` tags (`0xA0` newline-like reposition and `0xA1` stop), draw printable glyphs, and return cumulative width.
- This is source-plausible message/font logic rather than compiler coercion; no artificial temporaries or offset tricks were introduced.

## Technical details
- Implemented the same high-level control flow as the decomp reference while keeping code style consistent with existing `mes.cpp` first-pass reconstruction.
- Kept operations in terms of existing `CFont` fields and font helper calls used across the codebase (`SetPosX`, `SetPosY`, `Draw`, `GetWidth`).