### PR TITLE
cflat_r2system: add missing CPad wrapper functions for script runtime

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -470,6 +470,222 @@ done_check:
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9960
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" double GetRightStickY__4CPadFl(void* pad, long padIndex)
+{
+    bool isInvalidPad = false;
+
+    if (*(int*)((char*)pad + 0x1C4) == 0) {
+        if (padIndex != 0) {
+            goto done_check;
+        }
+        if (*(int*)((char*)pad + 0x1C0) == -1) {
+            goto done_check;
+        }
+    }
+    isInvalidPad = true;
+
+done_check:
+    if (isInvalidPad) {
+        return (double)0.0f;
+    }
+
+    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
+                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
+                                          31)) *
+                                               0x54 +
+                             0x30);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B99C0
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" double GetRightStickX__4CPadFl(void* pad, long padIndex)
+{
+    bool isInvalidPad = false;
+
+    if (*(int*)((char*)pad + 0x1C4) == 0) {
+        if (padIndex != 0) {
+            goto done_check;
+        }
+        if (*(int*)((char*)pad + 0x1C0) == -1) {
+            goto done_check;
+        }
+    }
+    isInvalidPad = true;
+
+done_check:
+    if (isInvalidPad) {
+        return (double)0.0f;
+    }
+
+    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
+                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
+                                          31)) *
+                                               0x54 +
+                             0x2C);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9A20
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" double GetLeftStickY__4CPadFl(void* pad, long padIndex)
+{
+    bool isInvalidPad = false;
+
+    if (*(int*)((char*)pad + 0x1C4) == 0) {
+        if (padIndex != 0) {
+            goto done_check;
+        }
+        if (*(int*)((char*)pad + 0x1C0) == -1) {
+            goto done_check;
+        }
+    }
+    isInvalidPad = true;
+
+done_check:
+    if (isInvalidPad) {
+        return (double)0.0f;
+    }
+
+    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
+                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
+                                          31)) *
+                                               0x54 +
+                             0x28);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9A80
+ * PAL Size: 96b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" double GetLeftStickX__4CPadFl(void* pad, long padIndex)
+{
+    bool isInvalidPad = false;
+
+    if (*(int*)((char*)pad + 0x1C4) == 0) {
+        if (padIndex != 0) {
+            goto done_check;
+        }
+        if (*(int*)((char*)pad + 0x1C0) == -1) {
+            goto done_check;
+        }
+    }
+    isInvalidPad = true;
+
+done_check:
+    if (isInvalidPad) {
+        return (double)0.0f;
+    }
+
+    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
+                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
+                                          31)) *
+                                               0x54 +
+                             0x24);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9AE0
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" unsigned short GetButtonRepeat__4CPadFl(void* pad, long padIndex)
+{
+    bool isInvalidPad = false;
+    unsigned int result;
+
+    if (*(int*)((char*)pad + 0x1C4) == 0) {
+        if (padIndex != 0) {
+            goto done_check;
+        }
+        if (*(int*)((char*)pad + 0x1C0) == -1) {
+            goto done_check;
+        }
+    }
+    isInvalidPad = true;
+
+done_check:
+    if (isInvalidPad) {
+        result = 0;
+    } else {
+        result = *(unsigned short*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
+                                                               padIndex - *(int*)((char*)pad + 0x1C0)) >>
+                                                 31)) *
+                                                  0x54 +
+                                    0x14);
+    }
+
+    return (unsigned short)result;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9BB8
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" unsigned short GetButton__4CPadFl(void* pad, long padIndex)
+{
+    bool isInvalidPad = false;
+    unsigned int result;
+
+    if (*(int*)((char*)pad + 0x1C4) == 0) {
+        if (padIndex != 0) {
+            goto done_check;
+        }
+        if (*(int*)((char*)pad + 0x1C0) == -1) {
+            goto done_check;
+        }
+    }
+    isInvalidPad = true;
+
+done_check:
+    if (isInvalidPad) {
+        result = 0;
+    } else {
+        result = *(unsigned short*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
+                                                               padIndex - *(int*)((char*)pad + 0x1C0)) >>
+                                                 31)) *
+                                                  0x54 +
+                                    4);
+    }
+
+    return (unsigned short)result;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800B9394
  * PAL Size: 44b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added six missing `extern C` `CPad` wrappers in `src/cflat_r2system.cpp` used by system-script runtime paths:
  - `GetRightStickY__4CPadFl`
  - `GetRightStickX__4CPadFl`
  - `GetLeftStickY__4CPadFl`
  - `GetLeftStickX__4CPadFl`
  - `GetButtonRepeat__4CPadFl`
  - `GetButton__4CPadFl`
- Each function includes PAL address/size metadata and follows the same invalid-pad guard + clamped slot-index access pattern already used by nearby `GetGbaButtonDown__4CPadFl`.

## Functions Improved
Unit: `main/cflat_r2system`
- `GetRightStickY__4CPadFl`: unresolved -> 87.916664%
- `GetRightStickX__4CPadFl`: unresolved -> 87.916664%
- `GetLeftStickY__4CPadFl`: unresolved -> 87.916664%
- `GetLeftStickX__4CPadFl`: unresolved -> 87.916664%
- `GetButtonRepeat__4CPadFl`: unresolved -> 90.8%
- `GetButton__4CPadFl`: unresolved -> 90.8%

## Match Evidence
- Objdiff unit `.text` match for `main/cflat_r2system` improved from `6.9253616%` to `8.587121%`.
- Before this change, those six symbols were present but unresolved in objdiff output (`target_symbol: None`), so they could not contribute to code alignment.
- After this change, each symbol has concrete code-level match with non-zero percentages above.

## Plausibility Rationale
- These wrappers are source-plausible because they mirror existing local style and ABI usage in this file:
  - `extern C` symbol-stable wrappers used by script glue.
  - direct field-offset access into `CPad` state used throughout this unit’s low-level bridge functions.
  - straightforward guard/return behavior (invalid pad returns `0` / `0.0f`) matching neighboring input access routines.
- No contrived control-flow tricks or non-idiomatic temporaries were introduced.

## Technical Notes
- Used Ghidra function entries/sizes only for target identification and function metadata.
- Validation path:
  1. `ninja`
  2. `build/tools/objdiff-cli diff -p . -u main/cflat_r2system --format json`
  3. Symbol-level extraction of match percentages for the six added functions.