### PR TITLE
graphic: match IsFrameRateOver return-load implementation

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -44,7 +44,7 @@ public:
     void _WaitDrawDone(char*, int);
     void Thread();
     u8 IsFifoOver();
-    void IsFrameRateOver();
+    u32 IsFrameRateOver();
     void Flip();
 
     void Printf(char*, ...);

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -284,9 +284,9 @@ u8 CGraphic::IsFifoOver()
  * Address:	TODO
  * Size:	TODO
  */
-void CGraphic::IsFrameRateOver()
+u32 CGraphic::IsFrameRateOver()
 {
-	// TODO
+	return *reinterpret_cast<u32*>(reinterpret_cast<u8*>(this) + 0x7350);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Changed `CGraphic::IsFrameRateOver` signature from `void` to `u32` in `include/ffcc/graphic.h`.
- Implemented `CGraphic::IsFrameRateOver` in `src/graphic.cpp` as a direct 32-bit load from offset `0x7350`.

## Functions improved
- Unit: `main/graphic`
- Symbol: `IsFrameRateOver__8CGraphicFv` (8 bytes)

## Match evidence
- `IsFrameRateOver__8CGraphicFv`: **50.0% -> 100.0%** (`build/tools/objdiff-cli diff -p . -u main/graphic -o - IsFrameRateOver__8CGraphicFv`)
- Build progress delta from `ninja`:
  - Matched code bytes: **210784 -> 210792** (+8)
  - Matched functions: **1652 -> 1653** (+1)

## Plausibility rationale
- This change aligns the function with its observed machine-level behavior: the routine is a trivial getter returning a 32-bit field from `CGraphic`.
- Using a `u32` return type and direct field load is natural source-level code for this pattern, not compiler-coaxing.

## Technical details
- Objdiff before showed only `blr` matching and a missing load (`lwz r3, 0x7350(r3)`).
- After the change, objdiff reports a full symbol match for `IsFrameRateOver__8CGraphicFv`.