### PR TITLE
fontman: improve GetWidth(unsigned short) matching

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -740,16 +740,19 @@ float CFont::GetWidth(unsigned short ch)
 	}
 
 	if (count == 0) {
-		unsigned short* fallback = m_glyphBuckets[63] + 1;
-		unsigned int fallbackCount = static_cast<unsigned int>(m_glyphBuckets[63][0]);
-		for (; fallbackCount != 0; fallbackCount--) {
-			if (*reinterpret_cast<char*>(fallback + 1) == '\0') {
-				glyph = fallback;
+		glyph = 0;
+	}
+
+	if (glyph == 0) {
+		glyphBucket = m_glyphBuckets[63];
+		glyph = glyphBucket + 1;
+		for (count = static_cast<unsigned int>(glyphBucket[0]); count != 0; count--) {
+			if (*reinterpret_cast<char*>(glyph + 1) == '\0') {
 				break;
 			}
-			fallback += 4;
+			glyph += 4;
 		}
-		if (fallbackCount == 0) {
+		if (count == 0) {
 			return 0.0f;
 		}
 	}
@@ -757,10 +760,9 @@ float CFont::GetWidth(unsigned short ch)
 	unsigned int drawWidth;
 	if ((renderFlags & 0x10) != 0) {
 		drawWidth = m_glyphWidth;
-	} else if ((renderFlags & 0x80) != 0) {
-		drawWidth = *(reinterpret_cast<unsigned char*>(glyph) + 6);
 	} else {
-		drawWidth = *(reinterpret_cast<unsigned char*>(glyph) + 4);
+		drawWidth = *(reinterpret_cast<unsigned char*>(glyph) + 4 +
+		             ((static_cast<signed char>(renderFlags) >> 7) & 2));
 	}
 
 	float width = scaleX * (margin + static_cast<float>(drawWidth));


### PR DESCRIPTION
## Summary
- Refined CFont::GetWidth(unsigned short) glyph selection to use a null-sentinel fallback flow.
- Replaced the enderFlags & 0x80 width branch with the same offset-selection expression used by SDK-style codegen (+ 4 + ((signed char)renderFlags >> 7 & 2)).
- Kept CFont::GetWidth(char*) unchanged after validation to avoid regressions.

## Functions improved
- Unit: main/fontman
- Symbol: GetWidth__5CFontFUs
  - Before: 25.631578%
  - After: 26.302631%

## Match evidence
- Verified with:
  - uild/tools/objdiff-cli diff -p . -u main/fontman -o - GetWidth__5CFontFUs
  - uild/tools/objdiff-cli diff -p . -u main/fontman -o - GetWidth__5CFontFPc
- GetWidth__5CFontFPc remained unchanged (34.940594% before/after), ensuring the change is isolated to the target function.

## Plausibility rationale
- The updated control flow and width-byte selection reflect common Dolphin SDK coding patterns for glyph tables and bitflag-based field selection.
- No contrived temporaries or readability regressions were introduced; the function remains straightforward and maintainable.

## Build
- 
inja passes for GCCP01 after the change.