### PR TITLE
textureman: improve CTexture::Create CI TLUT setup match

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -712,13 +712,23 @@ void CTexture::Create(CChunkFile& chunkFile, CMemory::CStage* stage, CAmemCacheS
                        static_cast<GXCITexFmt>(format), static_cast<GXTexWrapMode>(U8At(this, 0x6C)),
                        static_cast<GXTexWrapMode>(U8At(this, 0x6C)), 0, 0);
 
+        int tlutBase = reinterpret_cast<int>(PtrAt(this, 0x7C));
         unsigned int numEntries = 0x10;
         if (U8At(this, 0x60) == 9) {
             numEntries = 0x100;
         }
+        GXInitTlutObj(reinterpret_cast<GXTlutObj*>(Ptr(this, 0x48)), reinterpret_cast<void*>(tlutBase), GX_TL_IA8,
+                      static_cast<u16>(numEntries));
 
-        GXInitTlutObj(reinterpret_cast<GXTlutObj*>(Ptr(this, 0x48)), PtrAt(this, 0x7C), GX_TL_IA8, static_cast<u16>(numEntries));
-        GXInitTlutObj(reinterpret_cast<GXTlutObj*>(Ptr(this, 0x54)), Ptr(PtrAt(this, 0x7C), numEntries * 2), GX_TL_IA8,
+        numEntries = 0x10;
+        if (U8At(this, 0x60) == 9) {
+            numEntries = 0x100;
+        }
+        int offset = 0x10;
+        if (U8At(this, 0x60) == 9) {
+            offset = 0x100;
+        }
+        GXInitTlutObj(reinterpret_cast<GXTlutObj*>(Ptr(this, 0x54)), reinterpret_cast<void*>(tlutBase + offset * 2), GX_TL_IA8,
                       static_cast<u16>(numEntries));
     } else {
         GXInitTexObj(reinterpret_cast<GXTexObj*>(Ptr(this, 0x28)), PtrAt(this, 0x78), U16At(this, 0x64), U16At(this, 0x68),


### PR DESCRIPTION
## Summary
- Updated `CTexture::Create` CI texture TLUT initialization to use explicit `tlutBase`, recomputed `numEntries`, and explicit `offset` before second `GXInitTlutObj`.
- Kept behavior equivalent while making control/data flow closer to original-style code generation.

## Functions improved
- Unit: `main/textureman`
- Symbol: `Create__8CTextureFR10CChunkFilePQ27CMemory6CStageP13CAmemCacheSetii`

## Match evidence
- Before: `3.6571429%`
- After: `5.5555553%`
- Delta: `+1.8984124%`
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/textureman -o - Create__8CTextureFR10CChunkFilePQ27CMemory6CStageP13CAmemCacheSetii`

## Plausibility rationale
- The revised block mirrors common FFCC source patterns already present in nearby texture code (`CacheLoadTexture` / `SetExternalTlut`) where palette entry counts and second-TLUT offset are calculated explicitly.
- This avoids contrived compiler coaxing and keeps the code readable and source-plausible.

## Technical details
- The change is localized to CI-format TLUT setup in `CTexture::Create`.
- The update affects register/value materialization around `GXInitTlutObj` calls, producing measurable objdiff improvement in the target symbol.