### PR TITLE
GXTransform: improve GXSetScissorBoxOffset match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -630,7 +630,7 @@ void GXSetScissorBoxOffset(s32 x_off, s32 y_off) {
     ASSERTMSGLINE(1124, (u32)(y_off + 342) < 2048, "GXSetScissorBoxOffset: Invalid Y offset");
 
     reg = ((u32)(x_off + 0x156U) >> 1) | ((u32)(y_off + 0x156) << 9);
-    reg &= 0xFFFFFF;
+    reg = (reg << 8) >> 8;
     reg |= 0x59000000;
     GX_WRITE_RAS_REG(reg);
     __GXData->bpSentNot = 0;


### PR DESCRIPTION
## Summary
Adjust GXSetScissorBoxOffset mask shaping in src/gx/GXTransform.c to encourage original bit-truncation codegen.

## Functions Improved
- Unit: main/gx/GXTransform
- Symbol: GXSetScissorBoxOffset

## Match Evidence
- GXSetScissorBoxOffset: 89.0625% -> 89.6875% (+0.6250)
- Objdiff now shows a tighter sequence around register packing/truncation (DIFF_ARG_MISMATCH, DIFF_REPLACE, and one DIFF_DELETE remain).

## Plausibility Rationale
The change is behavior-preserving and source-plausible: it keeps the same 24-bit truncation semantics while expressing the mask as an explicit post-pack truncate step ((reg << 8) >> 8), which is a normal low-level style in this codebase.

## Technical Details
- Previous form: eg &= 0xFFFFFF
- New form: eg = (reg << 8) >> 8
- Both are equivalent for u32, but the new form generated closer instruction selection for this symbol.