### PR TITLE
util: improve GetDirectVector match by using Vec constant load

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1219,21 +1219,16 @@ INVALID:
  */
 void CUtil::GetDirectVector(Vec* param_2, Vec* param_3, Vec param_4)
 {
-	Vec local_vec;
-	
-	// Use up vector constant
-	extern float lbl_801d7070;  // x component
-	extern float lbl_801d7074;  // y component  
-	extern float lbl_801d7078;  // z component
-	
-	local_vec.x = lbl_801d7070;
-	local_vec.y = lbl_801d7074;
-	local_vec.z = lbl_801d7078;
-	
-	PSVECCrossProduct(&param_4, &local_vec, param_2);
-	PSVECNormalize(param_2, param_2);
-	PSVECCrossProduct(param_2, &param_4, param_3);
-	PSVECNormalize(param_3, param_3);
+    Vec local_vec;
+
+    extern Vec lbl_801d7070;
+
+    local_vec = lbl_801d7070;
+
+    PSVECCrossProduct(&param_4, &local_vec, param_2);
+    PSVECNormalize(param_2, param_2);
+    PSVECCrossProduct(param_2, &param_4, param_3);
+    PSVECNormalize(param_3, param_3);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refactored `CUtil::GetDirectVector` in `src/util.cpp` to read the up-vector constant as a single `Vec` symbol (`extern Vec lbl_801d7070`) instead of three separate float symbols.
- Replaced per-component assignments with a direct struct copy (`local_vec = lbl_801d7070`).

## Functions improved
- Unit: `main/util`
- Symbol: `GetDirectVector__5CUtilFP3VecP3Vec3Vec`

## Match evidence
- Before: `70.52631%`
- After: `75.23684%`
- Size: `152b` (unchanged)
- Build status: `ninja` passes.

## Plausibility rationale
- Loading a canonical up-vector as a single vector object is more source-plausible than manually reading three neighboring float symbols.
- This aligns with expected game-code style for vector constants and keeps behavior identical.

## Technical details
- Objdiff previously showed an early constant-load mismatch pattern around `lbl_801D7070` setup in `GetDirectVector`.
- Switching to a single `Vec` symbol improved alignment in that region and increased overall symbol match percentage.