### PR TITLE
textureman: improve cache unload and allocator wrapper matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -803,9 +803,11 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
  * Address:	TODO
  * Size:	TODO
  */
-void CTexture::CacheUnLoadTexture(CAmemCacheSet*)
+void CTexture::CacheUnLoadTexture(CAmemCacheSet* amemCacheSet)
 {
-	// TODO
+    if (S16At(this, 0x72) != -1) {
+        amemCacheSet->Release(S16At(this, 0x72));
+    }
 }
 
 /*
@@ -1271,7 +1273,7 @@ void CTexture::GetNumTlut()
  */
 void* CTexture::operator new(unsigned long size, CMemory::CStage*, char* file, int line)
 {
-	return ::operator new(size, TextureMan.m_memoryStage, file, line);
+    return _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(&Memory, size, TextureMan.m_memoryStage, file, line, 0);
 }
 
 /*
@@ -1285,5 +1287,5 @@ void* CTexture::operator new(unsigned long size, CMemory::CStage*, char* file, i
  */
 void* CTextureSet::operator new(unsigned long size, CMemory::CStage*, char* file, int line)
 {
-	return ::operator new(size, TextureMan.m_memoryStage, file, line);
+    return _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(&Memory, size, TextureMan.m_memoryStage, file, line, 0);
 }


### PR DESCRIPTION
## Summary
- Implemented `CTexture::CacheUnLoadTexture(CAmemCacheSet*)` to release cached texture handles when present.
- Reworked `CTexture::operator new(...)` and `CTextureSet::operator new(...)` to call `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii` directly with `TextureMan.m_memoryStage`.

## Functions improved
- `main/textureman`:
  - `CacheUnLoadTexture__8CTextureFP13CAmemCacheSet` (52b)
  - `__nw__8CTextureFUlPQ27CMemory6CStagePci` (68b)
  - `__nw__11CTextureSetFUlPQ27CMemory6CStagePci` (68b)

## Match evidence
Measured with:
`build/tools/objdiff-cli diff -p . -u main/textureman -o - <symbol>`

- `CacheUnLoadTexture__8CTextureFP13CAmemCacheSet`: **7.6923% -> 100.0%**
- `__nw__8CTextureFUlPQ27CMemory6CStagePci`: **57.6471% -> 73.4706%**
- `__nw__11CTextureSetFUlPQ27CMemory6CStagePci`: **57.6471% -> 73.4706%**
- Guard check (no target regression):
  - `Create__11CTextureSetFR10CChunkFilePQ27CMemory6CStageiP13CAmemCacheSetii` remained at **3.1286%**

Build still verifies:
- `ninja` succeeds and reports `build/GCCP01/main.dol: OK`.

## Plausibility rationale
- Cache unload behavior now matches expected memory-cache semantics: release only when cache index is valid (`!= -1`).
- The allocator wrappers now explicitly route through project allocator entrypoint with stage/file/line metadata, which is idiomatic for this codebase and aligns with neighboring low-level memory calls.
- No contrived control-flow tricks or opaque coercions were introduced.

## Technical notes
- The changes are small and isolated to `src/textureman.cpp`.
- The `operator new` changes reduce wrapper indirection and improve call-site codegen alignment while preserving behavior.