### PR TITLE
fontman: improve CFont::GetWidth(char*) match

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -701,10 +701,9 @@ float CFont::GetWidth(char* text)
 		unsigned int drawWidth;
 		if ((renderFlags & 0x10) != 0) {
 			drawWidth = m_glyphWidth;
-		} else if ((renderFlags & 0x80) != 0) {
-			drawWidth = *(reinterpret_cast<unsigned char*>(glyph) + 6);
 		} else {
-			drawWidth = *(reinterpret_cast<unsigned char*>(glyph) + 4);
+			drawWidth = *(reinterpret_cast<unsigned char*>(glyph) + 4 +
+			             ((static_cast<signed char>(renderFlags) >> 7) & 2));
 		}
 
 		float charWidth = scaleX * (margin + static_cast<float>(drawWidth));


### PR DESCRIPTION
## Summary
- Updated CFont::GetWidth(char*) in src/fontman.cpp to use a compact glyph-width selection expression based on enderFlags sign bit.
- Kept behavior identical while aligning control/data flow with the existing unsigned short overload and expected MWCC codegen shape.

## Functions improved
- Unit: main/fontman
- Symbol improved: GetWidth__5CFontFPc (CFont::GetWidth(char*))

## Match evidence
- GetWidth__5CFontFPc: 34.940594% -> 37.267326% (+2.326732)
- GetWidth__5CFontFUs: 26.302631% -> 26.302631% (unchanged)
- Verified with:
  - uild/tools/objdiff-cli.exe diff -p . -u main/fontman -o - GetWidth__5CFontFPc
  - uild/tools/objdiff-cli.exe diff -p . -u main/fontman -o - GetWidth__5CFontFUs

## Plausibility rationale
- This change is source-plausible: it simplifies equivalent branch logic into an idiomatic indexed-byte selection tied directly to flag bits, without adding contrived temporaries or non-idiomatic ordering.
- It matches patterns already used in this file for glyph metric extraction and preserves readability.

## Technical details
- Replaced:
  - separate (renderFlags & 0x80) branch reading +6 vs +4
- With:
  - *(reinterpret_cast<unsigned char*>(glyph) + 4 + ((static_cast<signed char>(renderFlags) >> 7) & 2))
- This improves compiler codegen alignment for this symbol while keeping all other tested font width behavior unchanged.