### PR TITLE
Improve match for pppKeShpTail2X

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -6,6 +6,7 @@
 
 extern int lbl_8032ED70;
 extern _pppMngSt* pppMngStPtr;
+extern _pppEnvSt* lbl_8032ED54;
 extern _pppEnvSt* pppEnvStPtr;
 
 extern "C" {
@@ -75,8 +76,10 @@ void pppKeShpTail2X(_pppPObject* obj, UnkB* param_2, UnkC* param_3)
             pos.z = out.value[2][3];
         }
 
-        for (u8 i = 0; i < work->m_count; i++) {
-            pppCopyVector__FR3Vec3Vec(&work->m_posHistory[i], &pos);
+        Vec* history = work->m_posHistory;
+        for (s32 i = 0; i < work->m_count; i++) {
+            pppCopyVector__FR3Vec3Vec(history, &pos);
+            history++;
         }
     }
 
@@ -105,17 +108,17 @@ void pppKeShpTail2X(_pppPObject* obj, UnkB* param_2, UnkC* param_3)
     pppCopyVector__FR3Vec3Vec(&work->m_posHistory[work->m_head], &pos);
 
     {
-        long* shape = *(long**)(*(u32*)&pppEnvStPtr->m_particleColors[0] + step->m_dataValIndex * 4);
+        long* shape = *(long**)(*(u32*)&lbl_8032ED54->m_particleColors[0] + step->m_dataValIndex * 4);
         u8* frameEntry;
         s16 frameDuration;
 
         work->m_shapePrevFrame = work->m_shapeFrame;
         frameEntry = (u8*)shape + ((u32)work->m_shapeFrame << 3) + 0x10;
 
-        work->m_frameAcc = (u16)(work->m_frameAcc + (u16)step->m_frameStep);
+        work->m_frameAcc += step->m_frameStep;
         frameDuration = *(s16*)(frameEntry + 2);
-        if (work->m_frameAcc >= (u16)frameDuration) {
-            work->m_frameAcc = (u16)(work->m_frameAcc - (u16)frameDuration);
+        if (work->m_frameAcc >= frameDuration) {
+            work->m_frameAcc -= frameDuration;
             work->m_shapeFrame++;
             if (work->m_shapeFrame >= (u16)*(s16*)((u8*)shape + 6)) {
                 if ((frameEntry[4] & 0x80) != 0) {


### PR DESCRIPTION
## Summary
- Updated `pppKeShpTail2X` in `main/pppKeShpTail2X` with small source-plausible changes focused on codegen alignment.
- Switched history initialization to pointer-style iteration.
- Adjusted shape-table access to use `lbl_8032ED54` (environment symbol used by related particle units).
- Simplified frame accumulator math to native halfword arithmetic (`+=` / `-=` with `s16` compare).

## Functions Improved
- `pppKeShpTail2X` (`src/pppKeShpTail2X.cpp`)

## Match Evidence
- `objdiff` oneshot command:
  - `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail2X -o - pppKeShpTail2X`
- Before: `75.44355%` (size `992`)
- After: `79.19355%` (size `992`)
- Delta: `+3.75%`

## Plausibility Rationale
- Changes reflect typical original source style in this codebase:
  - pointer walking for contiguous `Vec` history buffers,
  - direct halfword accumulation without contrived casts,
  - consistent use of shared env-global symbol for shape-table lookup.
- No artificial reordering, no hardcoded offsets added, and no readability regressions.

## Technical Details
- Diff reduction includes fewer structural mismatches in `pppKeShpTail2X` (`DIFF_INSERT` and `DIFF_REPLACE` counts drop, with improved overall instruction alignment).
- Build remains clean with `ninja`.