### PR TITLE
menu_lst: improve MLstClose match via literal interpolation cleanup

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -368,8 +368,6 @@ void CMenuPcs::MLstClose()
 	unsigned int itemCount;
 	unsigned int remaining;
 	short* item;
-	double zero;
-	double one;
 	float alphaZero;
 
 	completedItems = 0;
@@ -378,16 +376,14 @@ void CMenuPcs::MLstClose()
 	item = *(short**)((char*)this + 0x850) + 4;
 	currentFrame = (int)*(short*)(*(int*)((char*)this + 0x82c) + 0x22);
 	remaining = itemCount;
-	zero = 0.0;
-	one = 1.0;
 
 	if (0 < (int)itemCount) {
 		do {
 			if (*(int*)(item + 0x12) <= currentFrame) {
 				if (currentFrame < *(int*)(item + 0x12) + *(int*)(item + 0x14)) {
 					*(int*)(item + 0x10) = *(int*)(item + 0x10) + 1;
-					*(float*)(item + 8) = (float)-((one / (double)*(int*)(item + 0x14)) * (double)*(int*)(item + 0x10) - one);
-					if ((double)*(float*)(item + 8) < zero) {
+					*(float*)(item + 8) = (float)-((1.0 / (double)*(int*)(item + 0x14)) * (double)*(int*)(item + 0x10) - 1.0);
+					if ((double)*(float*)(item + 8) < 0.0) {
 						*(float*)(item + 8) = 0.0f;
 					}
 				} else {


### PR DESCRIPTION
## Summary
- Simplified CMenuPcs::MLstClose() alpha interpolation by removing local double temporaries (zero, one) and using direct floating-point literals.
- Kept control flow and data layout unchanged; only expression/constant handling was adjusted.

## Functions improved
- Unit: main/menu_lst
- Symbol: MLstClose__8CMenuPcsFv

## Match evidence
- MLstClose__8CMenuPcsFv: **44.757008% -> 45.794390%** (+1.037382)
- main/menu_lst .text match: **51.127730% -> 51.255466%** (+0.127736)
- Verified no regression on nearby symbols:
  - MLstOpen__8CMenuPcsFv: unchanged at 52.461113%
  - MLstDraw__8CMenuPcsFv: unchanged at 51.197773%

## Plausibility rationale
- This change reflects natural source cleanup an original developer could reasonably write: direct literal math without redundant temporary variables.
- It does not add compiler-coaxing patterns, artificial temporaries, or hardcoded structural hacks.

## Technical details
- The adjustment targets floating-point constant materialization and arithmetic expression form in the close-animation alpha path.
- This improved alignment in generated PPC code for MLstClose while preserving behavior.