### PR TITLE
Improve pppFrameYmCheckBGHeight branch-shape match

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -88,7 +88,7 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(struct pppYmCheckBGHeight* pp
 
         if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, (CMapCylinder*)&cyl, &direction, 0xffffffff) != 0) {
             CalcHitPosition__7CMapObjFP3Vec(*(void**)((u8*)&MapMng + 0x22A78), &hitPos);
-            if (currentY - ((float*)param_2)[3] <= hitPos.y) {
+            if (!(currentY - ((float*)param_2)[3] > hitPos.y)) {
                 currentY = hitPos.y + param_2->m_unk0x8;
             }
         }


### PR DESCRIPTION
## Summary
- Adjusted the hit-height comparison in pppFrameYmCheckBGHeight to an equivalent negated-> form.
- Kept behavior identical while steering PPC branch generation closer to target.

## Functions Improved
- Unit: main/pppYmCheckBGHeight
- Function: pppFrameYmCheckBGHeight

## Match Evidence
- eport.json function fuzzy match: **82.666664% -> 83.81609%** (+1.149426)
- eport.json unit fuzzy match: **82.86364% -> 84.0%** (+1.13636)
- objdiff symbol match: **80.77012% -> 81.91954%** (+1.14942)

## Plausibility Rationale
- The source change is a standard equivalent comparison rewrite ( <= b vs !(a > b)) that an original author could plausibly write.
- No contrived temporaries, reordered side effects, or non-idiomatic hacks were introduced.

## Technical Details
- This change influences floating-point compare/branch lowering (cmpo condition handling path), improving alignment of control-flow shape in the hit-position update block.
- Build verification passed with 
inja after the change.