### PR TITLE
mapobj: implement CMapObj cylinder collision checks

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/mapobj.h"
 #include "ffcc/map.h"
+#include "ffcc/maphit.h"
 #include "ffcc/mapmesh.h"
 #include "ffcc/materialman.h"
 #include "ffcc/math.h"
@@ -9,6 +10,7 @@
 
 extern float lbl_8032F938;
 extern float lbl_8032F93C;
+extern float lbl_8032F940;
 extern float lbl_8032F944;
 extern float lbl_8032F948;
 extern float lbl_8032F950;
@@ -659,22 +661,124 @@ void CMapObj::DrawHitNormal()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80028BC0
+ * PAL Size: 736b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-int CMapObj::CheckHitCylinder(CMapCylinder*, Vec*, unsigned long)
+int CMapObj::CheckHitCylinder(CMapCylinder* cylinder, Vec* move, unsigned long mask)
 {
-	// TODO
+    if ((U8At(this, 0x1D) != 2) || (PtrAt(this, 0xC) == 0) || (U8At(this, 0x1F) != 0xFF)) {
+        return 0;
+    }
+
+    Mtx inverseMtx;
+    CMapCylinder localCylinder;
+    Vec localMove;
+    CMapHit* mapHit = reinterpret_cast<CMapHit*>(PtrAt(this, 0xC));
+
+    PSMTXInverse(MtxAt(this, 0xB8), inverseMtx);
+    PSMTXMultVec(inverseMtx, &cylinder->m_bottom, &localCylinder.m_bottom);
+    PSMTXMultVec(inverseMtx, &cylinder->m_direction, &localCylinder.m_direction);
+    PSMTXMultVecSR(inverseMtx, reinterpret_cast<Vec*>(&cylinder->m_radius), reinterpret_cast<Vec*>(&localCylinder.m_radius));
+    PSMTXMultVecSR(inverseMtx, move, &localMove);
+
+    localCylinder.m_top.y = cylinder->m_top.y;
+    float margin = lbl_8032F940 + localCylinder.m_top.y;
+
+    float minValue = localCylinder.m_direction.x;
+    float maxValue = localCylinder.m_bottom.x;
+    if (maxValue < minValue) {
+        minValue = localCylinder.m_bottom.x;
+        maxValue = localCylinder.m_direction.x;
+    }
+    localCylinder.m_direction2.z = maxValue + margin;
+    localCylinder.m_top.z = minValue - margin;
+
+    minValue = localCylinder.m_direction.y;
+    maxValue = localCylinder.m_bottom.y;
+    if (maxValue < minValue) {
+        minValue = localCylinder.m_bottom.y;
+        maxValue = localCylinder.m_direction.y;
+    }
+    localCylinder.m_radius2 = maxValue + margin;
+    localCylinder.m_direction2.x = minValue - margin;
+
+    minValue = localCylinder.m_direction.z;
+    maxValue = localCylinder.m_bottom.z;
+    if (maxValue < minValue) {
+        minValue = localCylinder.m_bottom.z;
+        maxValue = localCylinder.m_direction.z;
+    }
+    localCylinder.m_height2 = maxValue + margin;
+    localCylinder.m_direction2.y = minValue - margin;
+
+    if (mapHit->CheckHitCylinder(&localCylinder, &localMove, mask) != 0) {
+        return 1;
+    }
+    return 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800288F4
+ * PAL Size: 716b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-int CMapObj::CheckHitCylinderNear(CMapCylinder*, Vec*, unsigned long)
+int CMapObj::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned long mask)
 {
-	// TODO
+    if ((U8At(this, 0x1D) != 2) || (PtrAt(this, 0xC) == 0) || (U8At(this, 0x1F) != 0xFF)) {
+        return 0;
+    }
+
+    Mtx inverseMtx;
+    CMapCylinder localCylinder;
+    Vec localMove;
+    CMapHit* mapHit = reinterpret_cast<CMapHit*>(PtrAt(this, 0xC));
+
+    PSMTXInverse(MtxAt(this, 0xB8), inverseMtx);
+    PSMTXMultVec(inverseMtx, &cylinder->m_bottom, &localCylinder.m_bottom);
+    PSMTXMultVec(inverseMtx, &cylinder->m_direction, &localCylinder.m_direction);
+    PSMTXMultVecSR(inverseMtx, reinterpret_cast<Vec*>(&cylinder->m_radius), reinterpret_cast<Vec*>(&localCylinder.m_radius));
+    PSMTXMultVecSR(inverseMtx, move, &localMove);
+
+    localCylinder.m_top.y = cylinder->m_top.y;
+    float margin = lbl_8032F940 + localCylinder.m_top.y;
+
+    float minValue = localCylinder.m_direction.x;
+    float maxValue = localCylinder.m_bottom.x;
+    if (maxValue < minValue) {
+        minValue = localCylinder.m_bottom.x;
+        maxValue = localCylinder.m_direction.x;
+    }
+    localCylinder.m_direction2.z = maxValue + margin;
+    localCylinder.m_top.z = minValue - margin;
+
+    minValue = localCylinder.m_direction.y;
+    maxValue = localCylinder.m_bottom.y;
+    if (maxValue < minValue) {
+        minValue = localCylinder.m_bottom.y;
+        maxValue = localCylinder.m_direction.y;
+    }
+    localCylinder.m_radius2 = maxValue + margin;
+    localCylinder.m_direction2.x = minValue - margin;
+
+    minValue = localCylinder.m_direction.z;
+    maxValue = localCylinder.m_bottom.z;
+    if (maxValue < minValue) {
+        minValue = localCylinder.m_bottom.z;
+        maxValue = localCylinder.m_direction.z;
+    }
+    localCylinder.m_height2 = maxValue + margin;
+    localCylinder.m_direction2.y = minValue - margin;
+
+    mapHit->CheckHitCylinderNear(&localCylinder, &localMove, mask);
+    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented CMapObj::CheckHitCylinder and CMapObj::CheckHitCylinderNear in src/mapobj.cpp.
- Added the missing fcc/maphit.h include and lbl_8032F940 extern used by the collision margin path.
- Replaced TODO stubs with transformed-cylinder collision flow that matches existing project patterns (notably mapocttree.cpp), including matrix-space transforms, expanded local AABB bounds, and delegation to CMapHit.

## Functions Improved
- Unit: main/mapobj
- CheckHitCylinder__7CMapObjFP12CMapCylinderP3VecUl
  - Before: 