### PR TITLE
pppPart: implement pppCacheLoadShape

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -1529,12 +1529,24 @@ void pppCacheLoadModel(short*, _pppDataHead*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80055868
+ * PAL Size: 108b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppCacheLoadShape(short*, _pppDataHead*)
+void pppCacheLoadShape(short* shapeList, _pppDataHead* pppDataHead)
 {
-	// TODO
+	short shapeCount = shapeList[0];
+	short* shapeIndices = shapeList + 1;
+
+	for (short i = 0; i < shapeCount; i++) {
+		short shapeIndex = *shapeIndices;
+		shapeIndices++;
+		pppShapeSt* shape = *(pppShapeSt**)(pppDataHead->m_shapeNames + (shapeIndex * sizeof(pppShapeSt*)));
+		pppCacheLoadShapeTexture(shape, pppEnvStPtr->m_materialSetPtr);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented pppCacheLoadShape(short*, _pppDataHead*) in src/pppPart.cpp (previously a TODO stub).
- Added complete function info header with PAL address/size from decomp reference.
- Implemented shape-list iteration and shape texture cache loading using existing project types and data layout (_pppDataHead::m_shapeNames, pppShapeSt, pppCacheLoadShapeTexture).

## Functions improved
- Unit: main/pppPart
- Symbol: pppCacheLoadShape__FPsP12_pppDataHead
- Size: 108b (unchanged, target size preserved)

## Match evidence
- Before: 3.7037036%
- After: 36.666668%
- Improvement: +32.9629644%
- Validation command:
  - uild/tools/objdiff-cli diff -p . -u main/pppPart -o - pppCacheLoadShape__FPsP12_pppDataHead

## Plausibility rationale
- The new implementation follows natural source-level behavior for this routine: read a short index list, map each index to a shape pointer table, and call the existing shape-texture cache routine.
- Uses existing declared structures/functions instead of contrived temporaries or artificial reordering.
- Keeps code consistent with surrounding pppPart.cpp style and current project abstractions.

## Technical notes
- Loop shape and pointer arithmetic were aligned to the decomp-guided control flow (count + index list traversal).
- Material-set access is routed through established part-system environment data used throughout this file.