### PR TITLE
p_tina: implement first-pass __sinit_p_tina_cpp

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -3,8 +3,16 @@
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/stopwatch.h"
+#include "ffcc/USBStreamData.h"
+
+extern "C" void* __register_global_object(void* object, void* destructor, void* regmem);
+extern "C" CUSBStreamData* __ct__14CUSBStreamDataFv(CUSBStreamData*);
+extern "C" CProfile* __ct__8CProfileFPc(CProfile*, char*);
+extern "C" CPartPcs* __dt__8CPartPcsFv(CPartPcs*, short);
+extern "C" CProfile* __dt__8CProfileFv(CProfile*, short);
 
 extern CPartMng PartMng;
+extern unsigned char PartPcs[];
 
 extern char DAT_801ead4c[];
 extern char s_prioTime__d_prio__d_pdtID__2d_fp_801d81a0[];
@@ -24,6 +32,125 @@ extern float lbl_8032FDB8;
 extern double lbl_8032FDC0;
 extern CProfile g_par_calc_prof;
 extern CProfile g_par_draw_prof;
+extern char s_no_name_8032fdcc[];
+extern unsigned char ARRAY_80273928[];
+extern unsigned char ARRAY_80273968[];
+extern unsigned char ARRAY_802739e8[];
+extern void* PTR_PTR_s_CPartPcs_801eada4;
+extern unsigned int DAT_801ea9b0;
+extern unsigned int DAT_801ea9b4;
+extern unsigned int PTR_create__8CPartPcsFv_801ea9b8;
+extern unsigned int DAT_801ea9bc;
+extern unsigned int DAT_801ea9c0;
+extern unsigned int PTR_destroy__8CPartPcsFv_801ea9c4;
+extern unsigned int DAT_801ea9c8;
+extern unsigned int DAT_801ea9cc;
+extern unsigned int PTR_calcInit__8CPartPcsFv_801ea9d0;
+extern unsigned int DAT_801ea9d4;
+extern unsigned int DAT_801ea9d8;
+extern unsigned int PTR_calc__8CPartPcsFv_801ea9dc;
+extern unsigned int DAT_801ea9e0;
+extern unsigned int DAT_801ea9e4;
+extern unsigned int PTR_calcDead__8CPartPcsFv_801ea9e8;
+extern unsigned int DAT_801ea9ec;
+extern unsigned int DAT_801ea9f0;
+extern unsigned int PTR_ClearOt__8CPartPcsFv_801ea9f4;
+extern unsigned int DAT_801ea9f8;
+extern unsigned int DAT_801ea9fc;
+extern unsigned int PTR_drawShadow__8CPartPcsFv_801eaa00;
+extern unsigned int DAT_801eaa04;
+extern unsigned int DAT_801eaa08;
+extern unsigned int DAT_801eaa10;
+extern unsigned int DAT_801eaa14;
+extern unsigned int PTR_drawCharaBefore__8CPartPcsFv_801eaa0c;
+extern unsigned int PTR_draw__8CPartPcsFv_801eaa18;
+extern unsigned int DAT_801eaa1c;
+extern unsigned int DAT_801eaa20;
+extern unsigned int PTR_drawAfter__8CPartPcsFv_801eaa24;
+extern unsigned int DAT_801eaa28;
+extern unsigned int DAT_801eaa2c;
+extern unsigned int PTR_createViewer__8CPartPcsFv_801eaa30;
+extern unsigned int DAT_801eaa34;
+extern unsigned int DAT_801eaa38;
+extern unsigned int PTR_destroy__8CPartPcsFv_801eaa3c;
+extern unsigned int DAT_801eaa40;
+extern unsigned int DAT_801eaa44;
+extern unsigned int PTR_calcInit__8CPartPcsFv_801eaa48;
+extern unsigned int DAT_801eaa4c;
+extern unsigned int DAT_801eaa50;
+extern unsigned int PTR_calcViewer__8CPartPcsFv_801eaa54;
+extern unsigned int DAT_801eaa58;
+extern unsigned int DAT_801eaa5c;
+extern unsigned int PTR_calcDead__8CPartPcsFv_801eaa60;
+extern unsigned int DAT_801eaa64;
+extern unsigned int DAT_801eaa68;
+extern unsigned int PTR_ClearOt__8CPartPcsFv_801eaa6c;
+extern unsigned int DAT_801eaa70;
+extern unsigned int DAT_801eaa74;
+extern unsigned int PTR_drawShadowViewer__8CPartPcsFv_801eaa78;
+extern unsigned int DAT_801eaa7c;
+extern unsigned int DAT_801eaa80;
+extern unsigned int PTR_drawViewer__8CPartPcsFv_801eaa84;
+extern unsigned int DAT_801eaa88;
+extern unsigned int DAT_801eaa8c;
+extern unsigned int PTR_drawAfterViewer__8CPartPcsFv_801eaa90;
+extern unsigned int DAT_801eaa98;
+extern unsigned int DAT_801eaa9c;
+extern unsigned int DAT_801eaaa0;
+extern unsigned int DAT_801eaaa4;
+extern unsigned int DAT_801eaaa8;
+extern unsigned int DAT_801eaaac;
+extern unsigned int DAT_801eaab0;
+extern unsigned int DAT_801eaab4;
+extern unsigned int DAT_801eaab8;
+extern unsigned int DAT_801eaac4;
+extern unsigned int DAT_801eaac8;
+extern unsigned int DAT_801eaacc;
+extern unsigned int DAT_801eaad8;
+extern unsigned int DAT_801eaadc;
+extern unsigned int DAT_801eaae0;
+extern unsigned int DAT_801eaaec;
+extern unsigned int DAT_801eaaf0;
+extern unsigned int DAT_801eaaf4;
+extern unsigned int DAT_801eab00;
+extern unsigned int DAT_801eab04;
+extern unsigned int DAT_801eab08;
+extern unsigned int DAT_801eab14;
+extern unsigned int DAT_801eab18;
+extern unsigned int DAT_801eab1c;
+extern unsigned int DAT_801eab28;
+extern unsigned int DAT_801eab2c;
+extern unsigned int DAT_801eab30;
+extern unsigned int DAT_801eab3c;
+extern unsigned int DAT_801eab40;
+extern unsigned int DAT_801eab44;
+extern unsigned int DAT_801eabf4;
+extern unsigned int DAT_801eabf8;
+extern unsigned int DAT_801eabfc;
+extern unsigned int DAT_801eac00;
+extern unsigned int DAT_801eac04;
+extern unsigned int DAT_801eac08;
+extern unsigned int DAT_801eac0c;
+extern unsigned int DAT_801eac10;
+extern unsigned int DAT_801eac14;
+extern unsigned int DAT_801eac20;
+extern unsigned int DAT_801eac24;
+extern unsigned int DAT_801eac28;
+extern unsigned int DAT_801eac34;
+extern unsigned int DAT_801eac38;
+extern unsigned int DAT_801eac3c;
+extern unsigned int DAT_801eac48;
+extern unsigned int DAT_801eac4c;
+extern unsigned int DAT_801eac50;
+extern unsigned int DAT_801eac5c;
+extern unsigned int DAT_801eac60;
+extern unsigned int DAT_801eac64;
+extern unsigned int DAT_801eac70;
+extern unsigned int DAT_801eac74;
+extern unsigned int DAT_801eac78;
+extern unsigned int DAT_801eac84;
+extern unsigned int DAT_801eac88;
+extern unsigned int DAT_801eac8c;
 
 static int GetMngStBaseTime(const _pppMngSt* pppMngSt)
 {
@@ -48,6 +175,87 @@ static unsigned char GetMngStPrio(const _pppMngSt* pppMngSt)
 static unsigned char GetMngStPrioTime(const _pppMngSt* pppMngSt)
 {
 	return *(const unsigned char*)((const char*)pppMngSt + 0xf9);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80053960
+ * PAL Size: 832b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_tina_cpp(void)
+{
+    void* object;
+
+    *reinterpret_cast<void**>(PartPcs) = &PTR_PTR_s_CPartPcs_801eada4;
+    __ct__14CUSBStreamDataFv(reinterpret_cast<CUSBStreamData*>(PartPcs + 0x8));
+    __register_global_object(PartPcs, reinterpret_cast<void*>(__dt__8CPartPcsFv), ARRAY_80273928);
+
+    DAT_801eab18 = DAT_801eaa08;
+    DAT_801eab28 = DAT_801eaa10;
+    DAT_801eab2c = DAT_801eaa14;
+    DAT_801eaa98 = DAT_801ea9b0;
+    DAT_801eaa9c = DAT_801ea9b4;
+    DAT_801eaaa0 = PTR_create__8CPartPcsFv_801ea9b8;
+    DAT_801eaaa4 = DAT_801ea9bc;
+    DAT_801eaaa8 = DAT_801ea9c0;
+    DAT_801eaaac = PTR_destroy__8CPartPcsFv_801ea9c4;
+    DAT_801eaab0 = DAT_801ea9c8;
+    DAT_801eaab4 = DAT_801ea9cc;
+    DAT_801eaab8 = PTR_calcInit__8CPartPcsFv_801ea9d0;
+    DAT_801eaac4 = DAT_801ea9d4;
+    DAT_801eaac8 = DAT_801ea9d8;
+    DAT_801eaacc = PTR_calc__8CPartPcsFv_801ea9dc;
+    DAT_801eaad8 = DAT_801ea9e0;
+    DAT_801eaadc = DAT_801ea9e4;
+    DAT_801eaae0 = PTR_calcDead__8CPartPcsFv_801ea9e8;
+    DAT_801eaaec = DAT_801ea9ec;
+    DAT_801eaaf0 = DAT_801ea9f0;
+    DAT_801eaaf4 = PTR_ClearOt__8CPartPcsFv_801ea9f4;
+    DAT_801eab00 = DAT_801ea9f8;
+    DAT_801eab04 = DAT_801ea9fc;
+    DAT_801eab08 = PTR_drawShadow__8CPartPcsFv_801eaa00;
+    DAT_801eab14 = DAT_801eaa04;
+    DAT_801eab1c = PTR_drawCharaBefore__8CPartPcsFv_801eaa0c;
+    DAT_801eab30 = PTR_draw__8CPartPcsFv_801eaa18;
+    DAT_801eab3c = DAT_801eaa1c;
+    DAT_801eab40 = DAT_801eaa20;
+    DAT_801eab44 = PTR_drawAfter__8CPartPcsFv_801eaa24;
+    DAT_801eac70 = DAT_801eaa7c;
+    DAT_801eac74 = DAT_801eaa80;
+    DAT_801eabf4 = DAT_801eaa28;
+    DAT_801eabf8 = DAT_801eaa2c;
+    DAT_801eabfc = PTR_createViewer__8CPartPcsFv_801eaa30;
+    DAT_801eac00 = DAT_801eaa34;
+    DAT_801eac04 = DAT_801eaa38;
+    DAT_801eac08 = PTR_destroy__8CPartPcsFv_801eaa3c;
+    DAT_801eac0c = DAT_801eaa40;
+    DAT_801eac10 = DAT_801eaa44;
+    DAT_801eac14 = PTR_calcInit__8CPartPcsFv_801eaa48;
+    DAT_801eac20 = DAT_801eaa4c;
+    DAT_801eac24 = DAT_801eaa50;
+    DAT_801eac28 = PTR_calcViewer__8CPartPcsFv_801eaa54;
+    DAT_801eac34 = DAT_801eaa58;
+    DAT_801eac38 = DAT_801eaa5c;
+    DAT_801eac3c = PTR_calcDead__8CPartPcsFv_801eaa60;
+    DAT_801eac48 = DAT_801eaa64;
+    DAT_801eac4c = DAT_801eaa68;
+    DAT_801eac50 = PTR_ClearOt__8CPartPcsFv_801eaa6c;
+    DAT_801eac5c = DAT_801eaa70;
+    DAT_801eac60 = DAT_801eaa74;
+    DAT_801eac64 = PTR_drawShadowViewer__8CPartPcsFv_801eaa78;
+    DAT_801eac78 = PTR_drawViewer__8CPartPcsFv_801eaa84;
+    DAT_801eac84 = DAT_801eaa88;
+    DAT_801eac88 = DAT_801eaa8c;
+    DAT_801eac8c = PTR_drawAfterViewer__8CPartPcsFv_801eaa90;
+
+    object = __ct__8CProfileFPc(&g_par_calc_prof, s_no_name_8032fdcc);
+    __register_global_object(object, reinterpret_cast<void*>(__dt__8CProfileFv), ARRAY_80273968);
+    object = __ct__8CProfileFPc(&g_par_draw_prof, s_no_name_8032fdcc);
+    __register_global_object(object, reinterpret_cast<void*>(__dt__8CProfileFv), ARRAY_802739e8);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__sinit_p_tina_cpp` in `src/p_tina.cpp` as a first-pass decompilation.
- Added explicit static initialization flow for `PartPcs` startup objects:
  - `CUSBStreamData` construction on `PartPcs`
  - global destructor registration for `PartPcs`
  - profile object construction/registration for `g_par_calc_prof` and `g_par_draw_prof`
- Reconstructed the startup table assignment block by copying function/data descriptor entries into the target runtime table symbols.

## Functions Improved
- Unit: `main/p_tina`
- Symbol: `__sinit_p_tina_cpp`
  - Previous (selector baseline): `0.0%` match (size `832b`)
  - Current (`objdiff-cli`): `5.855769%` match
  - Current (`report.json` fuzzy): `11.822115%`

## Match Evidence
- Build: `ninja` succeeded after the change.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/p_tina -o - __sinit_p_tina_cpp`
- The function is no longer a stub/TODO path and now emits substantive code and relocations aligned with target startup behavior.

## Plausibility Rationale
- The implementation follows established project patterns used in other `__sinit_*` functions:
  - explicit vtable/object setup for process globals
  - constructor calls for embedded runtime objects
  - registration through `__register_global_object`
  - explicit startup table descriptor wiring
- This is a plausible source-level reconstruction of static initialization logic rather than pure compiler coaxing.

## Technical Details
- Added PAL metadata block to the implemented function:
  - PAL Address: `0x80053960`
  - PAL Size: `832b`
- Reused existing symbol naming conventions already present in the codebase for data/function-pointer tables.
- Kept this as a first-pass implementation to establish non-zero matching and an auditable base for further refinement.