### PR TITLE
p_chara: improve CHandle::Add match and list-head linkage

### DIFF
--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -700,8 +700,12 @@ void* CCharaPcs::CHandle::operator new(unsigned long size, CMemory::CStage* stag
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80077080
+ * PAL Size: 252b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CCharaPcs::CHandle::CHandle()
 {
@@ -733,7 +737,6 @@ CCharaPcs::CHandle::CHandle()
 
 	m_fogBlend = m_sortZ;
 	m_unk0x158 = 0;
-
 	m_drawListFlags &= 0x80;
 }
 
@@ -749,14 +752,19 @@ CCharaPcs::CHandle::~CHandle()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80076cf4
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCharaPcs::CHandle::Add()
 {
     if (m_next == nullptr && m_previous == nullptr)
 	{
-		CCharaPcs::CHandle* head = (this); // *(CCharaPcsCHandle **)(CharaPcs._76_4_ + 0x15c); // gCharaPcsHandleHead;
+		CCharaPcs::CHandle* head = *reinterpret_cast<CCharaPcs::CHandle**>(
+			reinterpret_cast<char*>(&CharaPcs) + 0x4C);
 
 		m_previous = head;
 		m_next = head->m_next;


### PR DESCRIPTION
## Summary
- Updated CCharaPcs::CHandle::Add() in src/p_chara.cpp to insert into the global CharaPcs handle list using the actual list sentinel pointer.
- Removed an incorrect self-head insertion pattern and linked the node between head and head->m_next.
- Added PAL metadata blocks for the updated CHandle::Add and CHandle constructor function docs.

## Functions improved
- Unit: main/p_chara
- Symbol: Add__Q29CCharaPcs7CHandleFv
  - Before: 63.764706%
  - After: 84.411766%

## Match evidence
- Unit main/p_chara fuzzy match:
  - Before: 12.910582%
  - After: 12.953225%
- Build status: 
inja passes after change.

## Plausibility rationale
- The new logic matches the expected doubly-linked-list insertion behavior for a per-manager sentinel list.
- It removes an implausible temporary/self-head usage and uses the manager-owned list head, which is consistent with surrounding handle lifecycle behavior in this module.

## Technical details
- Add() now resolves the CharaPcs handle-list sentinel and performs standard insertion:
  - prev = head
  - 
ext = head->next
  - head->next->prev = this
  - head->next = this
- This aligns control flow/data flow with the original binary enough to produce a measurable symbol-level score increase.