### PR TITLE
Implement SearchChildMapObj and map object SetLink reconstruction

### DIFF
--- a/include/ffcc/map.h
+++ b/include/ffcc/map.h
@@ -65,7 +65,7 @@ public:
     void MapFileRead(char*, unsigned long&);
     void MapCheckFileRead(char*);
     void LoadMapNoSyncCalc();
-    void SearchChildMapObj(CMapObj*, CMapObj*);
+    CMapObj* SearchChildMapObj(CMapObj*, CMapObj*);
     void SearchAtribMapObj(CMapObj*, CMapObjAtr::TYPE);
     void AttachMapHit(CMapHit*, char*);
     void GetDebugPlaySta(int, Vec*);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1219,12 +1219,25 @@ void CMapMng::LoadMapNoSyncCalc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800330CC
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::SearchChildMapObj(CMapObj*, CMapObj*)
+CMapObj* CMapMng::SearchChildMapObj(CMapObj* searchStart, CMapObj* parentObj)
 {
-	// TODO
+    const int objCount = *reinterpret_cast<short*>(Ptr(this, 0xC));
+    CMapObj* mapObjEnd = reinterpret_cast<CMapObj*>(Ptr(this, 0x954 + (objCount * 0xF0)));
+
+    for (CMapObj* obj = searchStart; obj < mapObjEnd; obj = reinterpret_cast<CMapObj*>(Ptr(obj, 0xF0))) {
+        if (*reinterpret_cast<CMapObj**>(Ptr(obj, 0x0)) == parentObj) {
+            return obj;
+        }
+    }
+
+    return 0;
 }
 
 /*

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -59,6 +59,36 @@ static inline Mtx& MtxAt(CMapObj* self, unsigned int offset)
 {
     return *reinterpret_cast<Mtx*>(Ptr(self, offset));
 }
+
+static inline CMapObj* NextSlot(CMapObj* obj)
+{
+    return reinterpret_cast<CMapObj*>(Ptr(obj, 0xF0));
+}
+
+static inline CMapObj* MapObjArrayStart()
+{
+    return reinterpret_cast<CMapObj*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x954);
+}
+
+static void SetLinkRecursive(CMapObj* parent)
+{
+    CMapObj* childHead = 0;
+    CMapObj* searchStart = MapObjArrayStart();
+
+    while (true) {
+        CMapObj* child = MapMng.SearchChildMapObj(searchStart, parent);
+        if (child == 0) {
+            break;
+        }
+
+        ObjAt(child, 0x8) = childHead;
+        SetLinkRecursive(child);
+        childHead = child;
+        searchStart = NextSlot(child);
+    }
+
+    ObjAt(parent, 0x4) = childHead;
+}
 }
 
 extern "C" void __dl__FPv(void*);
@@ -431,12 +461,16 @@ void CMapObj::SetShow(int show)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80029D18
+ * PAL Size: 672b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapObj::SetLink()
 {
-	// TODO
+    SetLinkRecursive(this);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented CMapMng::SearchChildMapObj in src/map.cpp and corrected its declaration in include/ffcc/map.h to return CMapObj*.
- Implemented CMapObj::SetLink in src/mapobj.cpp using recursive child-link reconstruction over the map object array.
- Added PAL address/size metadata blocks for both implemented functions.

## Functions improved
- SearchChildMapObj__7CMapMngFP7CMapObjP7CMapObj (main/map)
  - New objdiff match: **89.45%** (80b)
- SetLink__7CMapObjFv (main/mapobj)
  - Selector baseline before changes: **0.6%**
  - New objdiff match: **4.678571%** (672b)

## Match evidence
- Build verified with 
inja.
- Objdiff commands used:
  - uild/tools/objdiff-cli diff -p . -u main/map -o - SearchChildMapObj__7CMapMngFP7CMapObjP7CMapObj
  - uild/tools/objdiff-cli diff -p . -u main/mapobj -o - SetLink__7CMapObjFv
- The new output is no longer placeholder/stub code and introduces expected traversal/link operations visible in assembly.

## Plausibility rationale
- The implementation follows existing codebase conventions (pointer/offset access style, iterative object-array traversal).
- SearchChildMapObj now performs an explicit parent-pointer scan over the fixed-size CMapObj array, which matches the known layout and decomp behavior.
- SetLink now rebuilds child/sibling links with real object hierarchy logic rather than compiler-coaxing patterns.

## Technical details
- SearchChildMapObj scans from a caller-provided start object through the map object array end (