### PR TITLE
p_graphic: implement setViewport and stdDrawEnvInit

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -445,12 +445,16 @@ void CGraphicPcs::drawCopy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80046594
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphicPcs::setViewport()
 {
-	// TODO
+	Graphic.SetViewport();
 }
 
 /*
@@ -482,12 +486,19 @@ void CGraphicPcs::preDrawEnvInit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004650c
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphicPcs::stdDrawEnvInit()
 {
-	// TODO
+	*(u32*)(MaterialMan + 0x128) = *(u32*)(MaterialMan + 0x11C);
+	*(u32*)(MaterialMan + 0x12C) = *(u32*)(MaterialMan + 0x120);
+	*(u32*)(MaterialMan + 0x130) = *(u32*)(MaterialMan + 0x124);
+	*(u32*)(MaterialMan + 0x58) = *(u32*)(MaterialMan + 0x48);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGraphicPcs::setViewport()` in `src/p_graphic.cpp` as a direct call to `Graphic.SetViewport()`.
- Implemented `CGraphicPcs::stdDrawEnvInit()` in `src/p_graphic.cpp` using `MaterialMan` field copies consistent with the PAL decomp reference.
- Replaced TODO metadata with PAL address/size blocks for both functions.

## Functions improved
- Unit: `main/p_graphic`
- `setViewport__11CGraphicPcsFv`: **10.0% -> 84.0%**
- `stdDrawEnvInit__11CGraphicPcsFv`: **9.090909% -> 99.454544%**

## Match evidence
- Built successfully with `ninja` after changes.
- `objdiff` oneshot used for per-symbol verification:
  - `build/tools/objdiff-cli diff -p . -u main/p_graphic -o - setViewport__11CGraphicPcsFv`
  - `build/tools/objdiff-cli diff -p . -u main/p_graphic -o - stdDrawEnvInit__11CGraphicPcsFv`
- Unit fuzzy match now reads **21.428402%** in `build/GCCP01/report.json` (selector had this unit at 20.7% before edits).

## Plausibility rationale
- Both changes replace placeholder TODOs with minimal, idiomatic behavior that maps directly to existing engine APIs and `MaterialMan` state fields.
- No contrived temporaries/reordering were introduced; the implementations are straightforward, readable, and consistent with adjacent code style in `p_graphic.cpp`.

## Technical details
- `setViewport` decomp indicates only a call-through to `CGraphic::SetViewport`; implemented as `Graphic.SetViewport();`.
- `stdDrawEnvInit` decomp indicates four word copies from previously configured draw-environment fields; implemented with existing `MaterialMan + offset` access pattern already used in this translation unit.