### PR TITLE
ringmenu: reconstruct CRingMenu destructor reset path

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -12,12 +12,52 @@ CRingMenu::CRingMenu()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a5204
+ * PAL Size: 216b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CRingMenu::~CRingMenu()
 {
-	// TODO
+	reinterpret_cast<void (*)(CRingMenu*)>(reinterpret_cast<void**>(this)[4])(this);
+	CMenu::Create();
+
+	char* self = reinterpret_cast<char*>(this);
+	*reinterpret_cast<int*>(self + 0x504) = 0;
+	*reinterpret_cast<int*>(self + 0x500) = 0;
+	*reinterpret_cast<int*>(self + 0x0C) = -1;
+	*reinterpret_cast<int*>(self + 0x14) = 0x10;
+	*reinterpret_cast<int*>(self + 0x10) = 1;
+	*reinterpret_cast<int*>(self + 0x18) = 0;
+	*reinterpret_cast<int*>(self + 0x20) = -1;
+	*reinterpret_cast<int*>(self + 0x24) = -1;
+	*reinterpret_cast<int*>(self + 0x38) = 0;
+	*reinterpret_cast<int*>(self + 0x3C) = 0;
+	*reinterpret_cast<int*>(self + 0x40) = 0;
+	*reinterpret_cast<int*>(self + 0x1C) = 0;
+	*reinterpret_cast<int*>(self + 0x28) = -1;
+	*reinterpret_cast<int*>(self + 0x2C) = -1;
+	*reinterpret_cast<int*>(self + 0x44) = 0;
+	*reinterpret_cast<int*>(self + 0x48) = 0;
+	*reinterpret_cast<int*>(self + 0x4C) = 0;
+	*reinterpret_cast<int*>(self + 0x20) = 0;
+	*reinterpret_cast<int*>(self + 0x30) = -1;
+	*reinterpret_cast<int*>(self + 0x34) = -1;
+	*reinterpret_cast<int*>(self + 0x50) = 0;
+	*reinterpret_cast<int*>(self + 0x54) = 0;
+	*reinterpret_cast<int*>(self + 0x58) = 0;
+	*reinterpret_cast<int*>(self + 0x5C) = -1;
+	*reinterpret_cast<int*>(self + 0x60) = -1;
+	*reinterpret_cast<float*>(self + 0x64) = 0.0f;
+	*reinterpret_cast<int*>(self + 0x4EC) = 0;
+	*reinterpret_cast<int*>(self + 0x4F0) = 0;
+	*reinterpret_cast<int*>(self + 0x4F4) = 0;
+	*reinterpret_cast<int*>(self + 0x4F8) = 0;
+	*reinterpret_cast<int*>(self + 0x4FC) = 0;
+	*reinterpret_cast<int*>(self + 0x508) = 0;
+	*reinterpret_cast<float*>(self + 0x50C) = 0.0f;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reconstructed `CRingMenu::~CRingMenu()` using the PAL decomp flow.
- Added the expected virtual teardown call, `CMenu::Create()` call, and explicit offset-based state reinitialization for ring-menu runtime fields.
- Updated the function info block with PAL address/size metadata.

## Functions Improved
- Unit: `main/ringmenu`
- Symbol: `__dt__9CRingMenuFv` (PAL `0x800a5204`, size `216b`)

## Match Evidence
- `__dt__9CRingMenuFv`: `23.722221%` -> `66.37037%`
- Unit `.text` match: `4.009942%` -> `4.96396%`
- Build verification: `ninja` succeeded after changes.

## Plausibility Rationale
- The new code models expected constructor/destructor-style object lifecycle behavior seen elsewhere in the codebase: virtual teardown callback followed by deterministic object field reset.
- Field updates are consistent with existing `ringmenu.cpp` style (explicit offset-backed storage) rather than synthetic compiler-coaxing transforms.

## Technical Details
- Used `objdiff-cli` oneshot on `main/ringmenu` and symbol-specific diffs to identify `__dt__9CRingMenuFv` as high-impact low-risk.
- Implemented all state writes indicated by the decomp/assembly pattern (menu flags, button slots/timers, rotation and counters, float zeroed values) to reduce missing-instruction deltas.