### PR TITLE
main/gbaque: implement GbaQueue flag/query helper methods

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -145,16 +145,16 @@ public:
     void GetSPModeFlg(int);
     void ClrSPModeFlg(int);
     unsigned int GetSPMode(int);
-    void GetMemorysFlg(int);
+    unsigned int GetMemorysFlg(int);
     void ClrMemorysFlg(int);
     unsigned char GetMemorys(int);
-    void GetCmdNumFlg(int);
+    unsigned int GetCmdNumFlg(int);
     void ClrCmdNumFlg(int);
     unsigned char GetCmdNum(int);
-    void GetPlayModeFlg(int);
+    unsigned int GetPlayModeFlg(int);
     void ClrPlayModeFlg(int);
     void SetStartBonusFlg();
-    void GetStartBonusFlg(int);
+    unsigned int GetStartBonusFlg(int);
     void ClrStartBonusFlg(int);
 
 private:

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1366,112 +1366,208 @@ unsigned int GbaQueue::GetSPMode(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8ecc
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::GetMemorysFlg(int)
+unsigned int GbaQueue::GetMemorysFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	char value = obj[0x2C8B];
+	OSSignalSemaphore(accessSemaphores + channel);
+	unsigned int mask = static_cast<unsigned int>(value) & (1U << channel);
+	return (-mask | mask) >> 31;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8e64
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::ClrMemorysFlg(int)
+void GbaQueue::ClrMemorysFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	obj[0x2C8B] = obj[0x2C8B] & ~(1 << channel);
+	OSSignalSemaphore(accessSemaphores + channel);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8e00
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-unsigned char GbaQueue::GetMemorys(int)
+unsigned char GbaQueue::GetMemorys(int channel)
 {
-	return 0;
+	char* compatibilityStr = reinterpret_cast<char*>(accessSemaphores) + 0x28;
+	OSWaitSemaphore(accessSemaphores + channel);
+	unsigned short value = *reinterpret_cast<unsigned short*>(compatibilityStr + channel * 0xDC + 0x10);
+	OSSignalSemaphore(accessSemaphores + channel);
+	return static_cast<unsigned char>(value);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8d98
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::GetCmdNumFlg(int)
+unsigned int GbaQueue::GetCmdNumFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	char value = obj[0x2C8A];
+	OSSignalSemaphore(accessSemaphores + channel);
+	return (static_cast<unsigned int>(value) >> ((channel & 0x1F) << 1)) & 3;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8d2c
+ * PAL Size: 108b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::ClrCmdNumFlg(int)
+void GbaQueue::ClrCmdNumFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	obj[0x2C8A] = obj[0x2C8A] & ~(3 << (channel << 1));
+	OSSignalSemaphore(accessSemaphores + channel);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8cc4
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-unsigned char GbaQueue::GetCmdNum(int)
+unsigned char GbaQueue::GetCmdNum(int channel)
 {
-	return 0;
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	char value = obj[channel * 0xDC + 0x527];
+	OSSignalSemaphore(accessSemaphores + channel);
+	return static_cast<unsigned char>(value);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8c50
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::GetPlayModeFlg(int)
+unsigned int GbaQueue::GetPlayModeFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	char value = obj[0x2C88];
+	OSSignalSemaphore(accessSemaphores + channel);
+	unsigned int mask = static_cast<unsigned int>(value) & (1U << channel);
+	return (-mask | mask) >> 31;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8be8
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::ClrPlayModeFlg(int)
+void GbaQueue::ClrPlayModeFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	obj[0x2C88] = obj[0x2C88] & ~(1 << channel);
+	OSSignalSemaphore(accessSemaphores + channel);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8b68
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void GbaQueue::SetStartBonusFlg()
 {
-	// TODO
+	GbaQueue* semaphoreIter = this;
+	for (int i = 0; i < 4; i++) {
+		OSWaitSemaphore(semaphoreIter->accessSemaphores);
+		semaphoreIter = reinterpret_cast<GbaQueue*>(semaphoreIter->accessSemaphores + 1);
+	}
+
+	char* obj = reinterpret_cast<char*>(this);
+	obj[0x2D14] = 0xF;
+
+	semaphoreIter = this;
+	for (int i = 0; i < 4; i++) {
+		OSSignalSemaphore(semaphoreIter->accessSemaphores);
+		semaphoreIter = reinterpret_cast<GbaQueue*>(semaphoreIter->accessSemaphores + 1);
+	}
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8af4
+ * PAL Size: 116b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::GetStartBonusFlg(int)
+unsigned int GbaQueue::GetStartBonusFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	char value = obj[0x2D14];
+	OSSignalSemaphore(accessSemaphores + channel);
+	unsigned int mask = static_cast<unsigned int>(value) & (1U << channel);
+	return (-mask | mask) >> 31;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c8a8c
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::ClrStartBonusFlg(int)
+void GbaQueue::ClrStartBonusFlg(int channel)
 {
-	// TODO
+	char* obj = reinterpret_cast<char*>(this);
+	OSWaitSemaphore(accessSemaphores + channel);
+	obj[0x2D14] = obj[0x2D14] & ~(1 << channel);
+	OSSignalSemaphore(accessSemaphores + channel);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a first-pass decomp for 11 GbaQueue flag/query methods in gbaque.o, replacing TODO stubs with semaphore-protected bitfield/data access based on PAL Ghidra references.

## Functions improved
- GetMemorysFlg__8GbaQueueFi: 3.4483% -> 82.0345%
- ClrMemorysFlg__8GbaQueueFi: 3.8462% -> 85.6923%
- GetMemorys__8GbaQueueFi: 5.6000% -> 85.3600%
- GetCmdNumFlg__8GbaQueueFi: 3.8462% -> 69.4615%
- ClrCmdNumFlg__8GbaQueueFi: 3.7037% -> 86.2222%
- GetCmdNum__8GbaQueueFi: 5.3846% -> 84.4231%
- GetPlayModeFlg__8GbaQueueFi: 3.4483% -> 82.0345%
- ClrPlayModeFlg__8GbaQueueFi: 3.8462% -> 85.6923%
- SetStartBonusFlg__8GbaQueueFv: 3.1250% -> 96.1563%
- GetStartBonusFlg__8GbaQueueFi: 3.4483% -> 82.0345%
- ClrStartBonusFlg__8GbaQueueFi: 3.8462% -> 85.6923%

## Match evidence
- Rebuilt with 
inja (build passes).
- Used project report/objdiff flow on main/gbaque and measured per-function fuzzy match deltas above.
- Changes are functional assembly improvements (from stubbed placeholder code to semaphore + bitfield logic), not formatting-only edits.

## Plausibility rationale
- Code follows existing GbaQueue style already present in this unit: direct offset-based access, semaphore-guarded per-channel reads/writes, and bitmask logic.
- No contrived temporaries or compiler-coaxing patterns were added; this is a straightforward semantic implementation of small queue-state helpers.

## Technical details
- Updated signatures in include/ffcc/gbaque.h for Get*Flg methods to return unsigned int (matching decompiled semantics).
- Added PAL address/size metadata blocks for each implemented function.
- Implemented channel-masked flag clear/get behavior and SetStartBonusFlg 4-semaphore lock/unlock loop.