### PR TITLE
maphit: improve CalcHitPosition control flow match

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -524,13 +524,10 @@ void CMapHit::CalcHitSlide(Vec* out, float y)
 void CMapHit::CalcHitPosition(Vec* position)
 {
     float len = PSVECMag(&g_hit_cyl_min.m_direction);
-    float push = (s_hit_edge_index == -1) ? s_push : s_epsilon;
-    if (len > s_epsilon) {
-        PSVECScale(&g_hit_cyl_min.m_direction, position, s_hit_t_min - (push / len));
+    if (s_hit_edge_index == -1) {
+        PSVECScale(&g_hit_cyl_min.m_direction, position, s_hit_t_min - (s_push / len));
     } else {
-        position->x = 0.0f;
-        position->y = 0.0f;
-        position->z = 0.0f;
+        PSVECScale(&g_hit_cyl_min.m_direction, position, s_hit_t_min - (s_epsilon / len));
     }
     PSVECAdd(&g_hit_cyl_min.m_bottom, position, position);
 }


### PR DESCRIPTION
## Summary
This PR refines `CMapHit::CalcHitPosition` in `src/maphit.cpp` to better match the original PAL control flow.

Changes made:
- Removed the extra zero-length fallback branch.
- Split the scale expression into two explicit branches based on `s_hit_edge_index`.
- Kept vector scaling/addition flow equivalent while aligning branch structure with decomp evidence.

## Functions improved
- Unit: `main/maphit`
- Symbol: `CalcHitPosition__7CMapHitFP3Vec`
  - Before: `36.2%`
  - After: `58.9%`
  - Delta: `+22.7%`

## Match evidence
Objdiff (symbol-level):
- `build/tools/objdiff-cli diff -p . -u main/maphit -o - CalcHitPosition__7CMapHitFP3Vec`
- Result improved from `36.2%` to `58.9%`.

Unit-level `.text` match also improved:
- Before: `27.312666%`
- After: `27.744389%`

## Plausibility rationale
This update removes a defensive branch that is not indicated in the PAL decomp flow and uses straightforward branch-local arithmetic based on edge-vs-face hit state. The resulting code is simpler and matches the style of direct movement/slide computation used in nearby collision helpers.

## Technical details
- The previous version combined push selection with an additional `len > s_epsilon` guard and a zero-vector fallback.
- The updated version computes magnitude once and uses two direct `PSVECScale` calls keyed by `s_hit_edge_index`, then applies `PSVECAdd`.
- This specifically improves instruction/control-flow alignment without introducing contrived temporaries or non-idiomatic constructs.