### PR TITLE
main/cflat_r2system: restore SetNextScript/GetDbgFlag symbols

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -7,6 +7,7 @@
 #include "ffcc/maphit.h"
 #include "ffcc/mes.h"
 #include "ffcc/p_camera.h"
+#include "ffcc/p_dbgmenu.h"
 #include "ffcc/p_map.h"
 #include "ffcc/p_menu.h"
 #include "ffcc/p_minigame.h"
@@ -1315,6 +1316,44 @@ extern "C" void SetFov__10CCameraPcsFf(CCameraPcs* camera, float fov)
 void CCameraPcs::SetZRotate(float zRotate)
 {
     *(float*)((char*)this + 0x108) = zRotate;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9928
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGame::SetNextScript(CGame::CNextScript* nextScript)
+{
+    unsigned int* dst = (unsigned int*)&m_nextScript;
+    unsigned int* src = (unsigned int*)nextScript;
+    int count = 0x20;
+
+    do {
+        *dst++ = *src++;
+        *dst++ = *src++;
+        count--;
+    } while (count != 0);
+
+    m_newGameFlag = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9BB0
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CDbgMenuPcs::GetDbgFlag()
+{
+    return *(int*)((char*)this + 0x4);
 }
 
 /*

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1536,21 +1536,6 @@ const char* CGame::GetLangString()
 
 /*
  * --INFO--
- * PAL Address: 0x800b9928
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGame::SetNextScript(CGame::CNextScript* nextScript)
-{ 
-    memcpy(&m_nextScript, nextScript, sizeof(CNextScript));
-    m_newGameFlag = 1;
-}
-
-/*
- * --INFO--
  * PAL Address: 0x800b91a4
  * PAL Size: 72b
  * EN Address: TODO


### PR DESCRIPTION
﻿## Summary
- Moved `CGame::SetNextScript(CGame::CNextScript*)` out of `src/game.cpp` and into `src/cflat_r2system.cpp` to match symbol ownership for the `main/cflat_r2system` unit.
- Rewrote `SetNextScript` as a direct 32-bit copy loop (32 iterations, 2 words each) plus `m_newGameFlag = 1` to better align generated assembly.
- Added `CDbgMenuPcs::GetDbgFlag()` in `src/cflat_r2system.cpp`.
- Added PAL `--INFO--` headers for both functions and included `ffcc/p_dbgmenu.h` where needed.

## Functions Improved
- `SetNextScript__5CGameFPQ25CGame11CNextScript` (main/cflat_r2system): from unmatched (`None`/0%) to **53.07143%**.
- `GetDbgFlag__11CDbgMenuPcsFv` (main/cflat_r2system): from unmatched (`None`) to **100.0%**.

## Match Evidence
- Global progress (`ninja`):
  - Code matched: **211076 -> 211084** bytes (+8)
  - Matched functions: **1658 -> 1659** (+1)
- Unit fuzzy score (`main/cflat_r2system`):
  - **8.932787 -> 9.074638**
- Per-symbol objdiff:
  - `SetNextScript__5CGameFPQ25CGame11CNextScript`: 0.0 / unmatched -> 53.07143
  - `GetDbgFlag__11CDbgMenuPcsFv`: unmatched -> 100.0

## Plausibility Rationale
- These are class member functions with known PAL symbols and addresses that belong in this runtime glue unit.
- The `SetNextScript` behavior remains source-plausible: copy next-script payload then set new-game flag; only expression form changed to better match compiler output.
- `GetDbgFlag` is a simple accessor consistent with existing object-layout based accessors in this file.

## Technical Notes
- The `SetNextScript` match improvement came from switching away from `memcpy` to a fixed-count word-copy loop, which better reproduces original loop structure and register flow in objdiff.
- `__ct__14PPPCREATEPARAMFv` remains unmatched in this change and was left untouched to keep scope focused on verified gains.
