### PR TITLE
maptexanim: improve SetMapTexAnim compare/branch match

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -382,7 +382,7 @@ void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd,
         setPtr += 4;
     }
 
-    if ((found == 0) && (System.m_execParam != 0)) {
+    if ((found == 0) && (static_cast<unsigned int>(System.m_execParam) >= 1)) {
         System.Printf("SetMapTexAnim: material id (%d) not found\n", materialId);
     }
 }


### PR DESCRIPTION
## Summary
- Updated the final debug-print guard in `CMapTexAnimSet::SetMapTexAnim` to use an unsigned threshold check:
  - from `System.m_execParam != 0`
  - to `static_cast<unsigned int>(System.m_execParam) >= 1`
- No behavior change intended; this preserves the same effective condition while changing compare form.

## Functions improved
- Unit: `main/maptexanim`
- Symbol: `SetMapTexAnim__14CMapTexAnimSetFiiii`

## Match evidence
- Before: **91.37681%**
- After: **92.31884%**
- Size: 276b (unchanged)
- Objdiff delta for this symbol:
  - `DIFF_OP_MISMATCH`: 3 -> 2
  - Other diff-kind counts unchanged

## Plausibility rationale
- The change expresses a common original-source style for execution flag thresholds (`>= 1`) and keeps logic readable.
- This is not compiler-coaxing through unnatural temporaries or reordered side effects; it is a direct conditional form change in existing logic.

## Technical details
- Build: `ninja` passed.
- Targeted diff command used:
  - `build/tools/objdiff-cli diff -p . -u main/maptexanim -o - SetMapTexAnim__14CMapTexAnimSetFiiii`