### PR TITLE
mapshadow: improve Init__10CMapShadowFv match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -75,7 +75,7 @@ void CMapShadow::Init()
 	width = (float)materialWidth;
 	height = (float)materialHeight;
 	scale = *(float*)((char*)this + 0xa8);
-	if (*(s8*)((char*)this + 6) != 0) {
+	if (*(u8*)((char*)this + 6) != 0) {
 		C_MTXLightFrustum((MtxPtr)((char*)this + 0x48), -height, height, -width, width, *(float*)((char*)this + 0xac),
 		                  (float)(DOUBLE_8032fce8 * (double)scale), FLOAT_8032fcf0 * scale, FLOAT_8032fcf0,
 		                  FLOAT_8032fcf0);


### PR DESCRIPTION
## Summary
- Changed the mode flag check in CMapShadow::Init from signed (s8) to unsigned (u8).
- This keeps behavior equivalent for nonzero checks but aligns codegen with the expected unsigned byte compare.

## Functions improved
- Unit: main/mapshadow
- Function: Init__10CMapShadowFv

## Match evidence
- Init__10CMapShadowFv: **79.745766% -> 80.76271%**
- Other symbols in main/mapshadow unchanged (Draw, Calc, CMapShadowInsertOctTree).
- Validation command:
  - uild/tools/objdiff-cli diff -p . -u main/mapshadow -o - Init__10CMapShadowFv

## Plausibility rationale
- The field at offset +0x6 is used as a mode/flag byte; treating it as unsigned is natural and avoids sign-extension-specific codegen.
- The change is minimal, readable, and source-plausible for original game code.

## Technical details
- The previous signed check generated less-aligned branch/compare code in this function.
- Using u8 produced a measurable assembly alignment gain without introducing artificial temporaries or control-flow coercion.