### PR TITLE
gx/GXAttr: improve __GXXfVtxSpecs match

### DIFF
--- a/src/gx/GXAttr.c
+++ b/src/gx/GXAttr.c
@@ -25,12 +25,34 @@
  * JP Size: TODO
  */
 static void __GXXfVtxSpecs(void) {
-    u32 nCols;
+    u32 nCol0;
+    u32 nCol1;
     s32 nNrm;
-    u32 nTex;
+    u32 nTex0;
+    u32 nTex1;
+    u32 nTex2;
+    u32 nTex3;
+    u32 nTex4;
+    u32 nTex5;
+    u32 nTex6;
+    u32 nTex7;
     u32 reg;
     u32 vcdHi;
     u32 vcdLo;
+
+    vcdLo = __GXData->vcdLo;
+
+    if (((vcdLo >> 13) & 3) != 0) {
+        nCol0 = 1;
+    } else {
+        nCol0 = 0;
+    }
+
+    if (((vcdLo >> 15) & 3) != 0) {
+        nCol1 = 1;
+    } else {
+        nCol1 = 0;
+    }
 
     if (__GXData->hasBiNrms != 0) {
         nNrm = 2;
@@ -41,43 +63,57 @@ static void __GXXfVtxSpecs(void) {
     }
 
     vcdHi = __GXData->vcdHi;
-    vcdLo = __GXData->vcdLo;
 
-    nTex = 0;
     if ((vcdHi & 3) != 0) {
-        nTex++;
+        nTex0 = 1;
+    } else {
+        nTex0 = 0;
     }
+
     if (((vcdHi >> 2) & 3) != 0) {
-        nTex++;
+        nTex1 = 1;
+    } else {
+        nTex1 = 0;
     }
+
     if (((vcdHi >> 4) & 3) != 0) {
-        nTex++;
+        nTex2 = 1;
+    } else {
+        nTex2 = 0;
     }
+
     if (((vcdHi >> 6) & 3) != 0) {
-        nTex++;
+        nTex3 = 1;
+    } else {
+        nTex3 = 0;
     }
+
     if (((vcdHi >> 8) & 3) != 0) {
-        nTex++;
+        nTex4 = 1;
+    } else {
+        nTex4 = 0;
     }
+
     if (((vcdHi >> 10) & 3) != 0) {
-        nTex++;
+        nTex5 = 1;
+    } else {
+        nTex5 = 0;
     }
+
     if (((vcdHi >> 12) & 3) != 0) {
-        nTex++;
+        nTex6 = 1;
+    } else {
+        nTex6 = 0;
     }
+
     if (((vcdHi >> 14) & 3) != 0) {
-        nTex++;
+        nTex7 = 1;
+    } else {
+        nTex7 = 0;
     }
 
-    nCols = 0;
-    if (((vcdLo >> 13) & 3) != 0) {
-        nCols++;
-    }
-    if (((vcdLo >> 15) & 3) != 0) {
-        nCols++;
-    }
-
-    reg = (nTex << 4) | nCols | (nNrm << 2);
+    reg = (nCol0 + nCol1) | (nNrm << 2);
+    reg |= (nTex0 + nTex1 + nTex2 + nTex3 + nTex4 + nTex5 + nTex6 + nTex7) << 4;
     GX_WRITE_XF_REG(8, reg);
     __GXData->bpSentNot = 1;
 }


### PR DESCRIPTION
## Summary
- Reworked `__GXXfVtxSpecs` in `src/gx/GXAttr.c` to use explicit per-field boolean temporaries and reordered evaluation to better match expected register-counting flow.
- Preserved behavior: still computes color count, normal mode bits, and texture count bits into XF reg `0x1008`.

## Functions Improved
- Unit: `main/gx/GXAttr`
- Function: `__GXXfVtxSpecs` (PAL `0x801A0B10`, size `344b`)

## Match Evidence
- `__GXXfVtxSpecs`: **50.081394% -> 66.023254%** (`+15.94186`)
- Unit `.text` match: **85.83423% -> 87.06272%**
- No other code symbols in `main/gx/GXAttr` changed match score.

## Plausibility Rationale
- Changes are source-plausible SDK-style logic refinements: explicit boolean extraction of VCD fields and straightforward accumulation, without artificial no-op patterns or ABI hacks.
- Control flow remains readable and semantically identical to the original intent of counting enabled attributes.

## Technical Notes
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli.exe diff -p . -u main/gx/GXAttr -o - __GXXfVtxSpecs`
- Analysis compared before/after symbol-level match percents and unit-level `.text` match percent.