### PR TITLE
pppEmission: improve pppFrameEmission state float access

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -402,7 +402,7 @@ void pppFrameEmission(pppEmission* pppEmission_, UnkB* param_2, UnkC* param_3) {
         float* particle = (float*)state[0];
         for (int i = 0; i < particleCount; i++) {
             float randOffset = RandF__5CMathFf(*(float*)(payload + 4), &Math);
-            particle[0] = particle[0] + (float)state[3] + randOffset;
+            particle[0] = particle[0] + *(float*)(state + 3) + randOffset;
 
             if (*(s16*)(particle + 3) < 1) {
                 if (*(s16*)((u8*)particle + 10) < (s16)(u16)payload[0xC]) {


### PR DESCRIPTION
## Summary
- Corrected a float/int type access in `pppFrameEmission` (`src/pppEmission.cpp`) so particle motion uses the graph-computed float value from state, not an integer reinterpret cast.

## Functions improved
- Unit: `main/pppEmission`
- Symbol: `pppFrameEmission`

## Match evidence
- `pppFrameEmission` before: `65.973076%`
- `pppFrameEmission` after: `67.846150%`
- Net: `+1.873074%`
- Build: `ninja` passes.

## Plausibility rationale
- The state block stores graph outputs as floats (`CalcGraphValue` writes to `state + 3..5` as float refs).
- Reading this field as `(float)state[3]` is type-incoherent and not plausible original source.
- Using `*(float*)(state + 3)` aligns with the surrounding data layout and intent.

## Technical details
- Changed one expression in particle update loop:
  - from `particle[0] = particle[0] + (float)state[3] + randOffset;`
  - to   `particle[0] = particle[0] + *(float*)(state + 3) + randOffset;`
- This reduced instruction insertions in objdiff and improved symbol match.