### PR TITLE
pppYmBreath: improve UpdateAllParticle match by restoring group matrix init

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -379,15 +379,16 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
     for (groupIndex = 0; groupIndex < (int)groupTableCount; groupIndex++) {
         int* group = groupTable + groupIndex * 0x17;
         if ((group[0] != 1) && (*(signed char*)group[1] != -1) && (*(signed char*)group[2] == 1)) {
-            float* position = (float*)(group + 3);
-            float* velocity = (float*)(group + 6);
+            Vec unitVelocity;
+            unitVelocity.x = 0.0f;
+            unitVelocity.y = 0.0f;
+            unitVelocity.z = 1.0f;
             group[9] = *(int*)((unsigned char*)pYmBreath + 0x14);
-            position[0] = 0.0f;
-            position[1] = 0.0f;
-            position[2] = 0.0f;
-            velocity[0] = 0.0f;
-            velocity[1] = 0.0f;
-            velocity[2] = 1.0f;
+            *(float*)(group + 3) = 0.0f;
+            *((float*)(group + 3) + 1) = 0.0f;
+            *((float*)(group + 3) + 2) = 0.0f;
+            *(Vec*)(group + 6) = unitVelocity;
+            PSMTXCopy(*(Mtx*)pppMngStPtr, *(Mtx*)(group + 0xB));
             group[0] = 1;
         }
     }


### PR DESCRIPTION
## Summary
- Updated `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor` in `src/pppYmBreath.cpp`.
- In the group activation path, replaced scalar position/velocity initialization with the code pattern used by sibling particle units and added missing world matrix capture for newly active groups:
  - initialize unit direction vector `(0,0,1)` as a `Vec`
  - write origin to `group + 3`
  - write direction to `group + 6`
  - `PSMTXCopy(*(Mtx*)pppMngStPtr, *(Mtx*)(group + 0xB))`

## Functions Improved
- Unit: `main/pppYmBreath`
- Symbol: `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`

## Match Evidence
- `objdiff-cli` before: **30.25%**
- `objdiff-cli` after: **31.50%**
- Net: **+1.25%** on the target function (1072b)

## Plausibility Rationale
- This aligns `pppYmBreath` with existing source style in related particle modules (`pppBreathModel`), where group activation records a matrix snapshot and uses explicit vector semantics for initial direction/state.
- The change represents behavior and data initialization consistency rather than artificial compiler coaxing.

## Technical Notes
- Build verified with `ninja`.
- Improvement verified using:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`