### PR TITLE
pppEmission: improve Emission_DrawMeshDLCallback pointer access matching

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -82,14 +82,16 @@ void SetTexGenMode(pppEmission*) {
 void Emission_DrawMeshDLCallback(CChara::CModel* model, void*, void*, int meshIndex, int displayListIndex, float (*)[4]) {
     Graphic.SetDrawDoneDebugData(0x64);
 
-    char* meshData = *(char**)((char*)model + 0xAC + (meshIndex * 0x14) + 8);
+    char* meshList = *(char**)((char*)model + 0xAC);
+    char* meshData = *(char**)(meshList + (meshIndex * 0x14) + 8);
     char* displayList = *(char**)(meshData + 0x50) + (displayListIndex * 0xC);
 
     if (strcmp(meshData, DAT_803311fc) == 0) {
-        *(u8*)(meshData + 0x18) = 0;
-        *(u8*)(meshData + 0x19) = 0;
-        *(u8*)(meshData + 0x1A) = 0;
-        *(u8*)(meshData + 0x1B) = 0;
+        u8* color = *(u8**)(meshData + 0x28);
+        color[0] = 0;
+        color[1] = 0;
+        color[2] = 0;
+        color[3] = 0;
     } else {
         void* modelData = *(void**)((char*)model + 0xA4);
         void* materialSet = *(void**)((char*)modelData + 0x24);


### PR DESCRIPTION
## Summary
- Adjusted Emission_DrawMeshDLCallback mesh access to treat model + 0xAC as a mesh-list pointer.
- Updated color write path to use the color buffer pointer at meshData + 0x28 instead of writing directly to meshData + 0x18..0x1B.
- Kept behavior the same: zeroing 4 color bytes for the matching mesh name branch.

## Functions Improved
- Unit: main/pppEmission
- Symbol: Emission_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f
- Before: 82.22807%
- After: 82.666664%

## Match Evidence
- uild/tools/objdiff-cli diff -p . -u main/pppEmission -o - Emission_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f
- Improvement was instruction-level in pointer-chasing/color-store sequence, not a formatting-only change.
- pppFrameEmission remained stable (67.84615% before/after), indicating localized impact.

## Plausibility Rationale
- The change aligns with likely original data layout semantics:
  - mesh list pointer at model + 0xAC
  - mesh color pointer at meshData + 0x28
- This is a natural source-level correction (struct/field access interpretation), not compiler-coaxing.

## Technical Notes
- This resolves objdiff mismatches around repeated loads/stores where expected code dereferences an intermediate color pointer before writing RGBA bytes.