### PR TITLE
textureman: implement CTexture::CheckName

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -26,7 +26,7 @@ public:
     void CacheUnLoadTexture(CAmemCacheSet*);
     void CacheRefCnt0UpTexture(CAmemCacheSet*);
     void CacheDumpTexture(CAmemCacheSet*);
-    void CheckName(char*);
+    int CheckName(char*);
     void SetExternalTlut(void*, int);
     _GXColor GetTlutColor(int);
     void GetExternalTlutColor(void*, int, int);

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -832,12 +832,16 @@ void CTexture::CacheDumpTexture(CAmemCacheSet*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003B030
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CTexture::CheckName(char*)
+int CTexture::CheckName(char* name)
 {
-	// TODO
+    return strcmp(reinterpret_cast<char*>(Ptr(this, 8)), name) == 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CTexture::CheckName` in `src/textureman.cpp` as a direct texture-name comparison against the provided name.
- Updated the declaration in `include/ffcc/textureman.h` to return `int` (comparison result) instead of `void`.
- Added PAL metadata banner for the function (`0x8003B030`, `44b`).

## Functions improved
- Unit: `main/textureman`
- Symbol: `CheckName__8CTextureFPc`

## Match evidence
- `CheckName__8CTextureFPc`: `9.090909%` -> `99.545456%` (`44b`)
- Build progress function count increased by one matched game function (`1659` -> `1660` matched functions in `ninja` progress output).

## Plausibility rationale
- `CheckName` is naturally a name-equality predicate and the implementation uses the same name storage convention already used nearby (`Ptr(texture, 8)` with `strcmp`).
- Change is type/signature correction plus straightforward control flow, not contrived compiler coaxing.

## Technical details
- Baseline and verification were done with:
  - `build/tools/objdiff-cli diff -p . -u main/textureman -o - CheckName__8CTextureFPc`
- Post-change objdiff shows near-complete alignment for the symbol with no broad unrelated code changes.