### PR TITLE
fontman: improve CFont::GetWidth(unsigned short) match

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -727,34 +727,31 @@ float CFont::GetWidth(char* text)
  */
 float CFont::GetWidth(unsigned short ch)
 {
-	unsigned short* glyphBucket = m_glyphBuckets[ch & 0xFF];
-	unsigned short* glyph = glyphBucket + 1;
-	unsigned int count = static_cast<unsigned int>(glyphBucket[0]);
+	unsigned short* glyph = m_glyphBuckets[ch & 0xFF] + 1;
+	unsigned int count = static_cast<unsigned int>(*m_glyphBuckets[ch & 0xFF]);
 
 	for (; count != 0; count--) {
 		if (static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(glyph + 1)) == ((ch >> 8) & 0xFF)) {
-			break;
+			goto found_glyph;
 		}
 		glyph += 4;
 	}
+	glyph = 0;
 
-	if (count == 0) {
-		glyph = 0;
-	}
+found_glyph:
 
 	if (glyph == 0) {
-		glyphBucket = m_glyphBuckets[63];
-		glyph = glyphBucket + 1;
-		for (count = static_cast<unsigned int>(glyphBucket[0]); count != 0; count--) {
+		glyph = m_glyphBuckets[63] + 1;
+		for (count = static_cast<unsigned int>(*m_glyphBuckets[63]); count != 0; count--) {
 			if (*reinterpret_cast<char*>(glyph + 1) == '\0') {
-				break;
+				goto found_fallback;
 			}
 			glyph += 4;
 		}
-		if (count == 0) {
-			return 0.0f;
-		}
+		return 0.0f;
 	}
+
+found_fallback:
 
 	unsigned char flags = renderFlags;
 	unsigned int drawWidth;


### PR DESCRIPTION
## Summary
- Refined `CFont::GetWidth(unsigned short)` in `src/fontman.cpp` to better match original control flow in glyph lookup.
- Simplified bucket access to use direct `m_glyphBuckets[...]` dereferences.
- Adjusted primary/fallback glyph search exits to reduce unnecessary branch noise while preserving behavior.

## Functions improved
- Unit: `main/fontman`
- Function: `GetWidth__5CFontFUs` (`CFont::GetWidth(unsigned short)`)

## Match evidence
- `GetWidth__5CFontFUs`: **30.052631% -> 39.592106%** (`build/GCCP01/report.json`)
- `main/fontman` unit fuzzy match: **58.363487% -> 58.965145%**
- Rebuilt with `ninja build/GCCP01/src/fontman.o` and regenerated report with `ninja`.

## Plausibility rationale
- The change keeps the same algorithm and data usage (primary bucket lookup, fallback bucket 63 lookup, width calculation from flags).
- Improvements come from control-flow shape and data access form, not from artificial constants or semantic hacks.

## Technical details
- Primary search now sets glyph null only on full miss and exits directly on hit.
- Fallback search exits immediately on hit and returns `0.0f` on miss.
- Width computation path and flag-based width selection remain unchanged in behavior.