### PR TITLE
gx/GXFrameBuf: improve GXCopyTex match

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -532,7 +532,6 @@ skipPeCtrlWrite:
 void GXCopyTex(void* dest, GXBool clear) {
     u32 reg;
     u32 tempPeCtrl;
-    u32 phyAddr;
     GXBool changePeCtrl;
 
     CHECK_GXBEGIN(1916, "GXCopyTex");
@@ -571,8 +570,7 @@ void GXCopyTex(void* dest, GXBool clear) {
     GX_WRITE_RAS_REG(__GXData->cpTexSize);
     GX_WRITE_RAS_REG(__GXData->cpTexStride);
 
-    phyAddr = (u32)dest & 0x3FFFFFFF;
-    reg = ((phyAddr >> 5) & 0xFFFFFF) | 0x4B000000;
+    reg = (((u32)dest >> 5) & 0xFFFFFF) | 0x4B000000;
     GX_WRITE_RAS_REG(reg);
 
     __GXData->cpTex = (__GXData->cpTex & 0xFFFFF7FF) | ((u32)clear << 11);


### PR DESCRIPTION
## Summary
- Simplified `GXCopyTex` destination BP address packing in `src/gx/GXFrameBuf.c`.
- Removed the intermediate `phyAddr` temporary and packed the register directly from `dest`.
- Kept behavior and surrounding control flow unchanged.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Function: `GXCopyTex`
  - Before: `70.70526%`
  - After: `95.357895%`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/gx/GXFrameBuf -o - GXCopyTex`
  - Before diff profile: `DIFF_ARG_MISMATCH=27`, `DIFF_DELETE=8`, `DIFF_INSERT=12`, `DIFF_REPLACE=11`, `MATCH=49`
  - After diff profile: `DIFF_ARG_MISMATCH=38`, `DIFF_DELETE=2`, `MATCH=55`
- Unit text section (`main/gx/GXFrameBuf`)
  - Before: `81.912994%`
  - After: `88.69368%`

## Plausibility rationale
- Directly shifting and packing `dest` into the BP register is idiomatic for GX register setup and is cleaner than introducing an unnecessary temporary with a separate mask step.
- The resulting source remains straightforward, readable, and consistent with nearby register-write patterns in this file.
- The improvement is due to assembly-level alignment in `GXCopyTex`, not naming/format-only changes.

## Technical details
- Change was restricted to one function and one expression:
  - From: `(u32)dest & 0x3FFFFFFF` into a temp, then shift/pack
  - To: direct `(((u32)dest >> 5) & 0xFFFFFF) | 0x4B000000`
- No changes to ABI, function signature, or side effects.
- Verified build success with `ninja` and verified diff results with `objdiff-cli`.
