### PR TITLE
main/map: add missing deleting destructors for pointer arrays

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -34,6 +34,9 @@ extern "C" void SetDrawFlag__8COctTreeFv(void*);
 extern "C" void Calc__11CMapAnimRunFl(CMapAnimRun*, long);
 extern "C" void* lbl_801E89A8[];
 extern "C" void* lbl_801E899C[];
+extern "C" void* lbl_801E8990[];
+extern "C" void* lbl_801E8984[];
+extern "C" void* lbl_801E8978[];
 extern int DAT_8032ec78;
 extern float FLOAT_8032ec80;
 extern unsigned char DAT_8032ec88;
@@ -691,7 +694,44 @@ CPtrArray<CMapAnim*>::CPtrArray()
 template <>
 CPtrArray<CMapAnim*>::~CPtrArray()
 {
-    RemoveAll();
+    if (m_items != 0) {
+        __dla__FPv(m_items);
+        m_items = 0;
+    }
+
+    m_size = 0;
+    m_numItems = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80034574
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CPtrArray<CMapAnim*>* dtor_80034574(CPtrArray<CMapAnim*>* ptrArray, short param_2)
+{
+    if (ptrArray != 0) {
+        *reinterpret_cast<void***>(Ptr(ptrArray, 0)) = lbl_801E8990;
+
+        void*& items = *reinterpret_cast<void**>(Ptr(ptrArray, 0x10));
+        if (items != 0) {
+            __dla__FPv(items);
+            items = 0;
+        }
+
+        *reinterpret_cast<int*>(Ptr(ptrArray, 8)) = 0;
+        *reinterpret_cast<int*>(Ptr(ptrArray, 4)) = 0;
+
+        if (0 < param_2) {
+            __dl__FPv(ptrArray);
+        }
+    }
+
+    return ptrArray;
 }
 
 /*
@@ -731,6 +771,37 @@ CPtrArray<CMapAnimKeyDt*>::~CPtrArray()
 
 /*
  * --INFO--
+ * PAL Address: 0x80034624
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CPtrArray<CMapAnimKeyDt*>* dtor_80034624(CPtrArray<CMapAnimKeyDt*>* ptrArray, short param_2)
+{
+    if (ptrArray != 0) {
+        *reinterpret_cast<void***>(Ptr(ptrArray, 0)) = lbl_801E8984;
+
+        void*& items = *reinterpret_cast<void**>(Ptr(ptrArray, 0x10));
+        if (items != 0) {
+            __dla__FPv(items);
+            items = 0;
+        }
+
+        *reinterpret_cast<int*>(Ptr(ptrArray, 8)) = 0;
+        *reinterpret_cast<int*>(Ptr(ptrArray, 4)) = 0;
+
+        if (0 < param_2) {
+            __dl__FPv(ptrArray);
+        }
+    }
+
+    return ptrArray;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800346a0
  * PAL Size: 52b
  * EN Address: TODO
@@ -762,6 +833,37 @@ template <>
 CPtrArray<CMapShadow*>::~CPtrArray()
 {
     RemoveAll();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800346d4
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CPtrArray<CMapShadow*>* dtor_800346D4(CPtrArray<CMapShadow*>* ptrArray, short param_2)
+{
+    if (ptrArray != 0) {
+        *reinterpret_cast<void***>(Ptr(ptrArray, 0)) = lbl_801E8978;
+
+        void*& items = *reinterpret_cast<void**>(Ptr(ptrArray, 0x10));
+        if (items != 0) {
+            __dla__FPv(items);
+            items = 0;
+        }
+
+        *reinterpret_cast<int*>(Ptr(ptrArray, 8)) = 0;
+        *reinterpret_cast<int*>(Ptr(ptrArray, 4)) = 0;
+
+        if (0 < param_2) {
+            __dl__FPv(ptrArray);
+        }
+    }
+
+    return ptrArray;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added missing deleting-destructor wrappers in `src/map.cpp` for pointer-array specializations that already exist nearby in the same file.
- Declared the required vtable label symbols (`lbl_801E8990`, `lbl_801E8984`, `lbl_801E8978`) and used them in wrappers.
- Updated `CPtrArray<CMapAnim*>::~CPtrArray()` to explicit in-place cleanup (`m_items` free + size reset) to match expected destructor behavior.

## Functions improved
- `dtor_80034574` (`0x80034574`, 124b): now `100.0%`
- `dtor_80034624` (`0x80034624`, 124b): now `100.0%`
- `dtor_800346D4` (`0x800346D4`, 124b): now `100.0%`

## Match evidence
- `main/map` unit fuzzy match: `24.350395%` -> `26.056503%`
- `main/map` matched functions: `23/94` -> `26/94`
- `main/map` matched code bytes: `812` -> `1184`
- Global progress from `ninja` increased matched code/functions: `211128 bytes, 1660 funcs` -> `211500 bytes, 1663 funcs`.

## Plausibility rationale
- This follows the same source pattern already used in `src/map.cpp` for adjacent pointer-array deleting destructors (`dtor_80034414`, `dtor_800344C4`).
- The wrappers perform standard Metrowerks deleting-dtor semantics: set class vtable, free owned array storage, clear counters, and conditionally `delete this`.
- No contrived control flow or compiler-coaxing constructs were introduced; changes are direct ownership/lifetime logic consistent with surrounding code style.

## Technical notes
- Validation done with `ninja` (successful build) and `build/GCCP01/report.json` function/unit metrics.
- Spot-checked with `build/tools/objdiff-cli diff -p . -u main/map -o - dtor_80034574` and unit-level match data.
