### PR TITLE
materialman: implement CMaterial::Set and operator new

### DIFF
--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -93,7 +93,7 @@ public:
     CMaterial();
     ~CMaterial();
     void Create(unsigned long, CMaterialMan::TEV_BIT);
-    void Set(_GXTexMapID);
+    int Set(_GXTexMapID);
     void CacheLoadTexture(CAmemCacheSet*);
     void CacheUnLoadTexture(CAmemCacheSet*);
     void CacheRefCnt0UpTexture(CAmemCacheSet*);


### PR DESCRIPTION
## Summary
- Implemented `CMaterial::operator new(unsigned long, CMemory::CStage*, char*, int)` in `src/materialman.cpp` with PAL metadata block.
- Implemented a first-pass, source-plausible body for `CMaterial::Set(_GXTexMapID)` using texture binding, tex-matrix setup, and tex-coord generation flow from the PAL reference.
- Updated `CMaterial::Set` declaration in `include/ffcc/materialman.h` to return `int` (matching observed call/return behavior in PAL symbol output).

## Functions improved
- Unit: `main/materialman`
- `Set__9CMaterialF11_GXTexMapID`
  - Before: `0.0%` (from `tools/agent_select_target.py` target selection output)
  - After: `69.47458%` (`objdiff-cli`)
- `__nw__9CMaterialFUlPQ27CMemory6CStagePci`
  - Before: `0.0%` (from `tools/agent_select_target.py` target selection output)
  - After: `66.666664%` (`objdiff-cli`)

## Match evidence
- Build verified with `ninja`.
- Diff command used:
  - `build/tools/objdiff-cli diff -p . -u main/materialman -o - Set__9CMaterialF11_GXTexMapID`
- Current symbol matches from JSON output:
  - `Set__9CMaterialF11_GXTexMapID match=69.47458`
  - `__nw__9CMaterialFUlPQ27CMemory6CStagePci match=66.666664`

## Plausibility rationale
- The `Set` implementation follows expected engine behavior for a material setup pass:
  - bind each available `CTexture` to incrementing tex-map slots,
  - apply scroll offsets through a local texture matrix,
  - push tex-matrix / tex-coord state through GX calls,
  - update material manager tracking fields for matrix/coord allocation.
- The code keeps existing project style (typed offsets via `Ptr(...)`, minimal helper logic, no contrived temporary-only reordering).

## Technical details
- Added PAL metadata blocks for new implementations:
  - `CMaterial::operator new` (PAL `0x8003d9f0`, `72b`)
  - `CMaterial::Set` (PAL `0x8003da38`, `472b`)
- Introduced `extern CTextureMan TextureMan;` in `src/materialman.cpp` to resolve texture binding calls.
