### PR TITLE
Improve pppKeShpTail3X match via explicit mode-based position path

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -59,11 +59,11 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct UnkB* param_2, struct Unk
     if ((obj->pppPObject.m_graphId == 0) && (obj->field_0x7d != 0)) {
         ((u8*)work)[0x1c3] = 1;
 
-        pos.x = obj->pppPObject.m_localMatrix.value[0][3];
-        pos.y = obj->pppPObject.m_localMatrix.value[1][3];
-        pos.z = obj->pppPObject.m_localMatrix.value[2][3];
-
-        if (step->m_payload[0x3f] == 1) {
+        if (step->m_payload[0x3f] == 0) {
+            pos.x = obj->pppPObject.m_localMatrix.value[0][3];
+            pos.y = obj->pppPObject.m_localMatrix.value[1][3];
+            pos.z = obj->pppPObject.m_localMatrix.value[2][3];
+        } else if (step->m_payload[0x3f] == 1) {
             pppFMATRIX ownerMatrix;
             pppFMATRIX partMatrix;
             pppFMATRIX outMatrix;
@@ -88,11 +88,11 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct UnkB* param_2, struct Unk
     }
     ((u8*)work)[0x1c2]--;
 
-    pos.x = obj->pppPObject.m_localMatrix.value[0][3];
-    pos.y = obj->pppPObject.m_localMatrix.value[1][3];
-    pos.z = obj->pppPObject.m_localMatrix.value[2][3];
-
-    if (step->m_payload[0x3f] == 1) {
+    if (step->m_payload[0x3f] == 0) {
+        pos.x = obj->pppPObject.m_localMatrix.value[0][3];
+        pos.y = obj->pppPObject.m_localMatrix.value[1][3];
+        pos.z = obj->pppPObject.m_localMatrix.value[2][3];
+    } else if (step->m_payload[0x3f] == 1) {
         pppFMATRIX ownerMatrix;
         pppFMATRIX partMatrix;
         pppFMATRIX outMatrix;


### PR DESCRIPTION
## Summary
- Updated `pppKeShpTail3X` position selection to use explicit `mode == 0` / `mode == 1` branches in both initialization and per-frame update paths.
- Removed implicit defaulting to local-matrix translation before the mode check.

## Functions improved
- Unit: `main/pppKeShpTail3X`
- Symbol: `pppKeShpTail3X`
  - Before: `79.414246%`
  - After: `81.28232%`
  - Delta: `+1.868074`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o -`
- Observed symbol match values:
  - `pppKeShpTail3X`: `79.414246%` -> `81.28232%`
  - `pppKeShpTail3XDraw`: `16.483232%` (unchanged)
  - `pppKeShpTail3XCon`: `99.52631%` (unchanged)

## Plausibility rationale
- This change aligns control flow with the decompilation pattern of mode-gated transform selection, which is a natural gameplay code structure.
- No contrived temporaries, hardcoded offsets, or readability regressions were introduced.
- Behavior remains straightforward and source-plausible while improving generated assembly alignment.

## Technical details
- The rewrite was limited to branch structure around translation source selection.
- Build verified with `ninja` after edits.
