### PR TITLE
system: derive CSystem from CManager for better init match

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -27,7 +27,7 @@ public:
     virtual void MapChanged(int, int, int);
 };
 
-class CSystem
+class CSystem : public CManager
 {
 public:
     struct COrder


### PR DESCRIPTION
## Summary
- Update `CSystem` declaration to inherit from `CManager` in `include/ffcc/system.h`.
- This aligns `CSystem`'s vtable construction pattern with the target static initializer.

## Functions improved
- Unit: `main/system`
- Symbol: `__sinit_system_cpp` (32 bytes)

## Match evidence
- `__sinit_system_cpp`: **58.625% -> 98.75%** (`build/tools/objdiff-cli diff -p . -u main/system -o - __sinit_system_cpp`)
- Overall progress (`ninja`): matched code increased by **+32 bytes** and matched function count increased by **+1** (1663 -> 1664)

## Plausibility rationale
- `CSystem` already implements the same virtual interface family as `CManager` (`ScriptChanging`, `ScriptChanged`, `MapChanging`, `MapChanged`).
- Making this inheritance explicit is a plausible original-source relationship and explains the base-then-derived vtable initialization sequence seen in the target initializer.

## Technical details
- Before: static init emitted a relocation to an anonymous label (`lbl_801E8884`) for the second vtable write.
- After: relocation resolves to `__vt__7CSystem`, aligning the instruction stream and relocation intent with the target.
