### PR TITLE
map: match CMapIdGrp constructor initialization

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -82,6 +82,36 @@ CMapKeyFrame::CMapKeyFrame()
 
 /*
  * --INFO--
+ * PAL Address: 0x8003492c
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CMapIdGrp::CMapIdGrp()
+{
+    *reinterpret_cast<int*>(Ptr(this, 0)) = -1;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 4)) = 0x80;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 6)) = 0;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 5)) = 0;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 7)) = 0x80;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 8)) = 0;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 9)) = 0;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 10)) = 0x80;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 11)) = 0x80;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 12)) = 0xff;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 13)) = 0x40;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 14)) = 0x40;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 15)) = 0x80;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 16)) = 0x40;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 17)) = 0x40;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 18)) = 0;
+    *reinterpret_cast<unsigned char*>(Ptr(this, 19)) = 0x80;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added an explicit `CMapIdGrp::CMapIdGrp()` implementation in `src/map.cpp`.
- Initialized the 0x14-byte `CMapIdGrp` record in the same field order/values as the target constructor.
- Added PAL metadata block for the function (`0x8003492c`, `92b`) following repository format.

## Functions improved
- Unit: `main/map`
- Symbol: `__ct__9CMapIdGrpFv` (`CMapIdGrp::CMapIdGrp()`)

## Match evidence
- `__ct__9CMapIdGrpFv`: **0.0% -> 100.0%** (`build/tools/objdiff-cli diff -p . -u main/map -o - __ct__9CMapIdGrpFv`)
- Unit `main/map` matched functions: **26/94 (~27.7%) -> 27/94 (28.72%)**
- Build/verification: `ninja` completed successfully.

## Plausibility rationale
- This constructor is straightforward default initialization of an ID-group state blob used by `CMapMng`.
- Values and sequencing are natural source-level initialization (sentinel `-1`, channel defaults, and mask bytes), not compiler-coaxing artifacts.

## Technical details
- Used the Ghidra export only for address/size and rough layout (`resources/ghidra-decomp-1-31-2026/8003492c___ct__9CMapIdGrpFv.c`).
- Confirmed exact generated instruction stream and final 100% symbol match through objdiff JSON output.
