### PR TITLE
pppVtMime: fix constructor zero constant symbol matches

### DIFF
--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -39,6 +39,7 @@ struct VtMimeEnv
 
 extern int lbl_8032ED70;
 extern VtMimeEnv* lbl_8032ED54;
+extern const float lbl_803300F0;
 extern char Graphic[];
 static char lbl_801D8520[] = "pppVtMime.cpp";
 
@@ -147,10 +148,11 @@ void pppDrawVtMime(void* param1, void* param2, void* param3)
 void pppVtMimeCon(void* param1, void* param2, void* param3)
 {
     VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
+    float zero = lbl_803300F0;
 
-    state->accel = 0.0f;
-    state->velocity = 0.0f;
-    state->value = 0.0f;
+    state->accel = zero;
+    state->velocity = zero;
+    state->value = zero;
     state->vertexBuffer = 0;
 }
 
@@ -166,10 +168,11 @@ void pppVtMimeCon(void* param1, void* param2, void* param3)
 void pppVtMimeCon2(void* param1, void* param2, void* param3)
 {
     VtMimeState* state = (VtMimeState*)((char*)param1 + **(int**)((char*)param2 + 0xC) + 0x80);
+    float zero = lbl_803300F0;
 
-    state->accel = 0.0f;
-    state->velocity = 0.0f;
-    state->value = 0.0f;
+    state->accel = zero;
+    state->velocity = zero;
+    state->value = zero;
 }
 
 /*


### PR DESCRIPTION
## Summary
This change updates `src/pppVtMime.cpp` constructor initialization in `pppVtMimeCon` and `pppVtMimeCon2` to source zero from the shared constant symbol `lbl_803300F0` instead of literal `0.0f`.

## Functions improved
- `main/pppVtMime::pppVtMimeCon`: `99.545456% -> 100.0%`
- `main/pppVtMime::pppVtMimeCon2`: `99.44444% -> 100.0%`

## Match evidence
- Baseline (`build/tools/objdiff-cli diff -p . -u main/pppVtMime -o - pppVtMime`):
  - `pppVtMimeCon` had 1 diff: `DIFF_ARG_MISMATCH` on `lfs f0, lbl_803300F0@sda21`
  - `pppVtMimeCon2` had 1 diff: `DIFF_ARG_MISMATCH` on `lfs f0, lbl_803300F0@sda21`
- After change:
  - both functions are exact (`100.0%`), removing the relocation/constant-load mismatch.

## Plausibility rationale
This is a source-plausible change: constructors commonly initialize fields from engine-wide constants, and the behavior is unchanged (all fields still initialize to zero). The update fixes symbol/constant selection without introducing contrived control flow or non-idiomatic code.

## Technical details
- Added `extern const float lbl_803300F0;`
- Introduced a local `zero` loaded from that symbol in both constructors and used it for `value/velocity/accel` initialization.
- Build verification: `ninja` passes.
