### PR TITLE
p_light: implement CLightPcs::GetTable

### DIFF
--- a/include/ffcc/p_light.h
+++ b/include/ffcc/p_light.h
@@ -36,7 +36,7 @@ public:
 
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
     void create();
     void destroy();
     void DestroyBumpLightAll(CLightPcs::TARGET);

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -159,12 +159,16 @@ void CLightPcs::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004a27c
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CLightPcs::GetTable(unsigned long)
+int CLightPcs::GetTable(unsigned long index)
 {
-	// TODO
+    return (int)lbl_801EA2D4 + (index * 0x15c);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `CLightPcs::GetTable` in `src/p_light.cpp` using the decomp-indicated table address calculation.
- Correct the declaration in `include/ffcc/p_light.h` from `void GetTable(unsigned long)` to `int GetTable(unsigned long)` so the ABI/signature matches generated symbol expectations.
- Add PAL address/size metadata block for the function.

## Functions Improved
- Unit: `main/p_light`
- Symbol: `GetTable__9CLightPcsFUl` (20 bytes)

## Match Evidence
- Before: `GetTable__9CLightPcsFUl` fuzzy match `20.0%`
- After: `GetTable__9CLightPcsFUl` fuzzy match `100.0%`
- `objdiff` symbol diff for `GetTable__9CLightPcsFUl` reports `0` differing instructions.
- Global progress also increased by one matched function (`1663 -> 1664` matched functions in ninja progress output).

## Plausibility Rationale
- This change removes a TODO stub and restores a small table accessor consistent with existing `GetTable` patterns in other process classes.
- The return type/signature fix is an ABI-correctness change, not compiler coercion: the implementation now reflects a straightforward indexed table lookup expected from original source.

## Technical Details
- Implemented as `return (int)lbl_801EA2D4 + (index * 0x15c);` from the function’s address/size/decomp guidance.
- Kept edits minimal to avoid unrelated codegen movement in the rest of `p_light`.
