### PR TITLE
cflat_r2system: define missing SetFromScript and Vec assignment symbols

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1400,6 +1400,20 @@ extern "C" float sinf__3stdFf(float x)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9C1C
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void SetFromScript__10CCameraPcsFv(CCameraPcs* camera)
+{
+    *(int*)((char*)camera + 0x438) = 1;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800B9C28
  * PAL Size: 28b
  * EN Address: TODO
@@ -1428,6 +1442,25 @@ void CCameraPcs::SetRefPosition(Vec* position)
     *(float*)((char*)this + 0xD4) = *(float*)((char*)position + 0x0);
     *(float*)((char*)this + 0xD8) = *(float*)((char*)position + 0x4);
     *(float*)((char*)this + 0xDC) = *(float*)((char*)position + 0x8);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9C60
+ * PAL Size: 28b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __as__3VecFRC3Vec(Vec* self, const Vec* other)
+{
+    float x = other->x;
+    float y = other->y;
+    self->x = x;
+    float z = other->z;
+    self->y = y;
+    self->z = z;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added explicit symbol-correct implementations in `src/cflat_r2system.cpp` for:
  - `SetFromScript__10CCameraPcsFv`
  - `__as__3VecFRC3Vec`
- Used direct field writes and copy sequencing consistent with surrounding decomp style and existing vector helper patterns.

## Functions improved
- Unit: `main/cflat_r2system`
- `SetFromScript__10CCameraPcsFv`
- `__as__3VecFRC3Vec`

## Match evidence
- Unit `.text` match improved from `9.0535145` to `9.180002`.
- `SetFromScript__10CCameraPcsFv`: previously missing on build side (effectively 0% in target selection), now `100.0%`.
- `__as__3VecFRC3Vec`: previously missing on build side (effectively 0% in target selection), now `98.28571%`.
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - --format json ...`

## Plausibility rationale
- Changes represent plausible original source helpers:
  - `SetFromScript__10CCameraPcsFv` is a straightforward member-flag setter (`0x438 = 1`) matching expected camera state behavior.
  - `__as__3VecFRC3Vec` is a normal `Vec` field copy implementation (`x/y/z`) with idiomatic temporary usage seen elsewhere in this file.
- No contrived control-flow tricks, offset arithmetic hacks, or debug/comment artifacts were introduced.

## Technical details
- The two symbols existed in the reference object but were absent from the decomp build symbol map for this unit.
- Introducing explicit symbol definitions restored symbol correspondence and materially improved unit match.
- `__as__3VecFRC3Vec` is now instruction-close with only a small load-order difference remaining.
