### PR TITLE
cflat_runtime2: implement PutParticle and ResetParticleWork first pass

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1021,12 +1021,65 @@ void CFlatRuntime2::drawLayer(int, char*, int, int, int, int, int, int, float, f
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A53C
+ * PAL Size: 552b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::PutParticle(int, Vec&, float)
+void CFlatRuntime2::PutParticle(int workNo, Vec& pos, float scale)
 {
-	// TODO
+	u8* runtime = reinterpret_cast<u8*>(this);
+
+	ParticleWorkPosPtr(this) = 0;
+	ParticleWorkPosVecPtr(this) = 0;
+	ParticleWorkScalePtr(this) = 0;
+	ParticleWorkTargetPtr(this) = 0;
+	*reinterpret_cast<int*>(runtime + 0x16DC) = 0;
+	ParticleWorkBind(this) = 0;
+	ParticleWorkTrace(this) = 0;
+	ParticleWorkColor0(this) = 0;
+	ParticleWorkColor1(this) = 0;
+	ParticleWorkSpeed(this) = 1.0f;
+	ParticleWorkColorLerp(this) = 1.0f;
+	runtime[0x16F8] = 0;
+	memset(runtime + 0x16F9, 0, 3);
+
+	ParticleWorkSeNo(this) = -1;
+	runtime[0x1700] = 0;
+	ParticleWorkSeKind(this) = 1;
+	runtime[0x1702] = 0;
+	runtime[0x1703] = 0;
+	ParticleWorkSeParam(this) = 0;
+	*reinterpret_cast<int*>(runtime + 0x1708) = 0x1E;
+	*reinterpret_cast<int*>(runtime + 0x170C) = -1;
+	ParticleWorkParamNo(this) = 0;
+	ParticleWorkParamId(this) = 0;
+	runtime[0x1716] = 0;
+	runtime[0x1717] = 0;
+	memset(runtime + 0x1718, 0, 0x20);
+
+	runtime[0x16F8] = 1;
+	ParticleWorkNoHi(this) = workNo >> 8;
+	*reinterpret_cast<int*>(runtime + 0x16DC) = 0;
+	ParticleWorkNoLo(this) = static_cast<unsigned int>(workNo) & 0xFF;
+
+	ParticleWorkPosX(this) = pos.x;
+	ParticleWorkPosY(this) = pos.y;
+	ParticleWorkPosZ(this) = pos.z;
+	ParticleWorkPosAngle(this) = 0.0f;
+	ParticleWorkPosPtr(this) = &ParticleWorkPosX(this);
+	ParticleWorkPosVecPtr(this) = &ParticleWorkPosVecBase(this);
+
+	ParticleWorkScaleX(this) = scale;
+	ParticleWorkScaleY(this) = scale;
+	ParticleWorkScaleZ(this) = scale;
+	ParticleWorkScalePtr(this) = &ParticleWorkScaleX(this);
+
+	pppCreate__8CPartMngFiiP14PPPCREATEPARAMi(
+		&PartMng, ParticleWorkNoHi(this), ParticleWorkNoLo(this),
+		reinterpret_cast<PPPCREATEPARAM*>(reinterpret_cast<u8*>(this) + 0x16CC), 1);
 }
 
 /*
@@ -1047,12 +1100,49 @@ void CFlatRuntime2::PutParticleWork()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006A350
+ * PAL Size: 432b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::ResetParticleWork(int, int)
+void CFlatRuntime2::ResetParticleWork(int workNo, int arg)
 {
-	// TODO
+	u8* runtime = reinterpret_cast<u8*>(this);
+
+	ParticleWorkPosPtr(this) = 0;
+	ParticleWorkPosVecPtr(this) = 0;
+	ParticleWorkScalePtr(this) = 0;
+	ParticleWorkTargetPtr(this) = 0;
+	*reinterpret_cast<int*>(runtime + 0x16DC) = 0;
+	ParticleWorkBind(this) = 0;
+	ParticleWorkTrace(this) = 0;
+	ParticleWorkColor0(this) = 0;
+	ParticleWorkColor1(this) = 0;
+	ParticleWorkSpeed(this) = 1.0f;
+	ParticleWorkColorLerp(this) = 1.0f;
+	runtime[0x16F8] = 0;
+	memset(runtime + 0x16F9, 0, 3);
+
+	ParticleWorkSeNo(this) = -1;
+	runtime[0x1700] = 0;
+	ParticleWorkSeKind(this) = 1;
+	runtime[0x1702] = 0;
+	runtime[0x1703] = 0;
+	ParticleWorkSeParam(this) = 0;
+	*reinterpret_cast<int*>(runtime + 0x1708) = 0x1E;
+	*reinterpret_cast<int*>(runtime + 0x170C) = -1;
+	ParticleWorkParamNo(this) = 0;
+	ParticleWorkParamId(this) = 0;
+	runtime[0x1716] = 0;
+	runtime[0x1717] = 0;
+	memset(runtime + 0x1718, 0, 0x20);
+
+	runtime[0x16F8] = 1;
+	ParticleWorkNoHi(this) = workNo >> 8;
+	*reinterpret_cast<int*>(runtime + 0x16DC) = arg;
+	ParticleWorkNoLo(this) = static_cast<unsigned int>(workNo) & 0xFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFlatRuntime2::PutParticle(int, Vec&, float)` and `CFlatRuntime2::ResetParticleWork(int, int)` in `src/cflat_runtime2.cpp`.
- Replaced TODO stubs with concrete particle-work initialization/reset logic based on the existing field layout used throughout this translation unit.
- Added PAL `--INFO--` metadata blocks for both functions.

## Functions improved
- Unit: `main/cflat_runtime2`
- `PutParticle__13CFlatRuntime2FiR3Vecf` (552b)
- `ResetParticleWork__13CFlatRuntime2Fii` (432b)

## Match evidence
`objdiff` command used:
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o -`

Before -> After:
- `PutParticle__13CFlatRuntime2FiR3Vecf`: `0.7246377%` -> `20.347826%`
- `ResetParticleWork__13CFlatRuntime2Fii`: `0.9259259%` -> `12.194445%`

Additional confirmation:
- Right-side symbol sizes moved from tiny stubs to substantial bodies:
  - `PutParticle`: `4` -> `372`
  - `ResetParticleWork`: `4` -> `244`

## Plausibility rationale
- The new code follows the existing source style in this file:
  - uses established particle-work field access patterns and existing helper accessors;
  - keeps initialization semantics consistent with constructor and nearby setter behavior;
  - emits particles through the existing `pppCreate__8CPartMng...` path used by `PutParticleWork`.
- This is a first-pass decomp step for low-match, previously stubbed functions, aiming to restore likely original behavior while improving assembly alignment.

## Technical details
- Reset flow now initializes pointer/handle/color/sound fields and control bytes in the particle-work region (`0x16CC` onward), then sets work number hi/lo split.
- Emit flow now performs the same reset pattern, sets position/scale fields, configures pointers to in-struct vectors/scales, and calls the particle manager create function with the assembled parameter block.
- Build verification: `ninja` succeeds after the change.
