### PR TITLE
p_menu: decompile CMenuPcs::SetTexture

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1,4 +1,9 @@
 #include "ffcc/p_menu.h"
+#include "ffcc/textureman.h"
+
+#include <dolphin/mtx.h>
+
+extern CTextureMan TextureMan;
 
 /*
  * --INFO--
@@ -212,12 +217,37 @@ void CMenuPcs::onMapChanged(int, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80095bd0
+ * PAL Size: 212b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::SetTexture(CMenuPcs::TEX)
+void CMenuPcs::SetTexture(CMenuPcs::TEX tex)
 {
-	// TODO
+    CTexture* texture;
+    Mtx texMtx;
+
+    if ((int)tex == -1) {
+        texture = 0;
+    } else {
+        CTexture** textures = (CTexture**)((u8*)this + 0x18C);
+        u32 width;
+        u32 height;
+
+        texture = textures[(int)tex];
+        TextureMan.SetTexture(GX_TEXMAP0, texture);
+
+        width = *(u32*)((u8*)texture + 0x64);
+        height = *(u32*)((u8*)texture + 0x68);
+        PSMTXScale(texMtx, 1.0f / (f32)width, 1.0f / (f32)height, 1.0f);
+        GXLoadTexMtxImm(texMtx, GX_TEXMTX0, GX_MTX2x4);
+        GXSetNumTexGens(1);
+        GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);
+    }
+
+    TextureMan.SetTextureTev(texture);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::SetTexture(CMenuPcs::TEX)` in `src/p_menu.cpp` from the PAL decomp reference (`0x80095BD0`, `212b`) as a first-pass plausible source reconstruction.
- Added required dependencies for this function (`ffcc/textureman.h`, `<dolphin/mtx.h>`) and declared `extern CTextureMan TextureMan` used by existing rendering code.
- Updated the function header block to the project `--INFO--` format with PAL address/size and TODOs for EN/JP.

## Functions improved
- Unit: `main/p_menu`
- Symbol: `SetTexture__8CMenuPcsFQ28CMenuPcs3TEX`
- Size: `212b`

## Match evidence
- Objdiff (symbol-level):
  - Before: `1.8867924%`
  - After: `99.81132%`
- Build progress impact (`ninja` report):
  - `main/p_menu` matched functions: `1/30` -> `2/30`
  - `main/p_menu` matched code: `4/14688` -> `216/14688`

## Plausibility rationale
- The implementation follows expected engine-level behavior for menu texture binding:
  - resolves texture pointer from menu texture table,
  - binds texture via `TextureMan.SetTexture`,
  - configures texture matrix scale from texture dimensions,
  - sets one texture generator and standard texcoord matrix,
  - finalizes TEV setup via `TextureMan.SetTextureTev`.
- This is a direct behavior match rather than compiler-coaxing: no artificial temporaries or non-idiomatic control flow were introduced.

## Technical details
- The decomp indicates texture width/height are read from texture object offsets `0x64` and `0x68`; this pass preserves that access pattern with offset-based reads pending a full `CTexture` layout recovery.
- `param == -1` null-texture path is preserved and TEV state update still executes for both branches.
