### PR TITLE
main/cflat_r2system: fix IsHitDrawMode symbol binding

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -39,7 +39,7 @@ extern "C" {
 int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned long);
 void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
 int GetWait__4CMesFv(void*);
-unsigned char DAT_8032ecb8;
+unsigned char lbl_8032ECB8;
 }
 extern "C" double fmod(double, double);
 extern "C" double atan2(double, double);
@@ -1048,7 +1048,7 @@ extern "C" void GetWorldMapMatrix__10CCameraPcsFPA4_f(void* camera, Mtx matrix)
  */
 extern "C" void IsHitDrawMode__7CMapPcsFc(CMapPcs*, unsigned char drawMode)
 {
-    DAT_8032ecb8 = drawMode;
+    lbl_8032ECB8 = drawMode;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Renamed the external BSS byte used by `IsHitDrawMode__7CMapPcsFc` in `src/cflat_r2system.cpp` from `DAT_8032ecb8` to `lbl_8032ECB8`.
- Kept behavior identical (`drawMode` byte is written to the same storage), only symbol binding/name changed.

## Functions improved
- Unit: `main/cflat_r2system`
- Symbol: `IsHitDrawMode__7CMapPcsFc`
  - Before: `97.5%`
  - After: `100.0%`
  - Size: `8b`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - IsHitDrawMode__7CMapPcsFc`
  - Remaining mismatch (`DIFF_ARG_MISMATCH` on `stb`) is eliminated after the symbol rename.
- Unit `.text` match:
  - Before: `9.180002`
  - After: `9.180643`

## Plausibility rationale
- `DAT_...` was a placeholder decomp name. Using the concrete linker symbol `lbl_8032ECB8` is more plausible to original source/link output and avoids synthetic naming noise.
- Code semantics are unchanged; this is a symbol-resolution correction, not compiler coaxing or control-flow distortion.

## Technical details
- `IsHitDrawMode__7CMapPcsFc` writes one byte to a global. Objdiff showed instruction opcode parity with only argument mismatch in the relocation target.
- Updating the extern declaration and single write site to the expected label resolves the mismatch fully.
