### PR TITLE
p_gba: improve CGbaPcs::create match via rodata-backed literals

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -9,6 +9,8 @@ CGbaPcs GbaPcs;
 extern char __vt__8CManager[];
 extern char lbl_801E8668[];
 extern char lbl_8020F4A4[];
+extern char lbl_80330870[];
+extern char lbl_801D9DE0[];
 extern "C" unsigned int lbl_8020F2F8[];
 extern "C" unsigned int lbl_8020F304[];
 extern "C" unsigned int lbl_8020F310[];
@@ -107,11 +109,11 @@ void* CGbaPcs::GetTable(unsigned long tableIndex)
  */
 void CGbaPcs::create()
 {
-	m_stage = Memory.CreateStage(0x56000, "CGbaPcs", 0);
+	m_stage = Memory.CreateStage(0x56000, lbl_80330870, 0);
 	Joybus.CreateInit();
 	int result = Joybus.LoadBin();
-	if (result != 0 && (unsigned int)System.m_execParam >= 2u) {
-		System.Printf("JoyBus::LoadBin() error");
+	if ((result != 0) && (1 < (unsigned int)System.m_execParam)) {
+		System.Printf(lbl_801D9DE0);
 	}
 	Joybus.ThreadInit();
 }


### PR DESCRIPTION
## Summary
- Updated `CGbaPcs::create` in `src/p_gba.cpp` to use existing rodata symbols (`lbl_80330870`, `lbl_801D9DE0`) instead of inline string literals.
- Matched the condition form to the original-style comparison: `(result != 0) && (1 < (unsigned int)System.m_execParam)`.
- Kept behavior identical while making emitted code closer to original.

## Functions improved
- Unit: `main/p_gba`
- Function: `create__7CGbaPcsFv`
- Match: `89.46154%` -> `96.07692%` (+`6.61538`)

## Match evidence
- Command used:
  - `tools/objdiff-cli diff -p . -u main/p_gba -o - create__7CGbaPcsFv`
- Before change: `89.46154%`
- After change: `96.07692%`
- Sanity checks (no regressions from this edit):
  - `destroy__7CGbaPcsFv`: `90.588234%` -> `90.588234%`
  - `__sinit_p_gba_cpp`: `66.528305%` -> `66.528305%`

## Plausibility rationale
- Using named rodata symbols for fixed message/class strings is consistent with original source style in this codebase.
- The comparison rewrite is a normal C/C++ expression-level equivalent likely to reflect the original author intent, rather than contrived compiler coaxing.
- No artificial temporaries or unreadable control-flow tricks were introduced.
