### PR TITLE
cflat_r2system: add IsAbsolute and IsInner implementations

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1465,6 +1465,55 @@ extern "C" void __as__3VecFRC3Vec(Vec* self, const Vec* other)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9C7C
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsAbsolute__10CCameraPcsFv(CCameraPcs* camera)
+{
+    return *(int*)((char*)camera + 0x444);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B9C84
+ * PAL Size: 160b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <int count>
+class CLine;
+
+template <>
+class CLine<64>
+{
+public:
+    int IsInner(Vec* position, float margin);
+};
+
+int CLine<64>::IsInner(Vec* position, float margin)
+{
+    float* values = (float*)this;
+    if (values[6] == 0.0f) {
+        return 0;
+    }
+
+    if ((values[0] - margin) <= position->x && (values[1] - margin) <= position->y &&
+        (values[2] - margin) <= position->z && position->x <= (values[3] + margin) &&
+        position->y <= (values[4] + margin) && position->z <= (values[5] + margin)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added `IsAbsolute__10CCameraPcsFv` in `src/cflat_r2system.cpp` as a direct camera flag accessor (`+0x444`).
- Added `IsInner__9CLine<64>FP3Vecf` in `src/cflat_r2system.cpp` with bounds checks against the line extents and margin.
- Kept existing `PPPCREATEPARAM` constructor thunk/body split unchanged to avoid compiler-generated thunk regressions.

## Functions Improved
- Unit: `main/cflat_r2system`
- `IsAbsolute__10CCameraPcsFv`: now `100.0%`
- `IsInner__9CLine<64>FP3Vecf`: now `88.125%`

## Match Evidence
- Overall matched code bytes: `211776 -> 211784` (`+8`)
- Overall matched functions: `1665 -> 1666` (`+1`)
- Unit `main/cflat_r2system` matched functions: `50/84 -> 51/84`
- Unit `main/cflat_r2system` fuzzy match: `9.2% -> 9.678%`

## Plausibility Rationale
- Both additions are straightforward source-level helpers consistent with surrounding offset-based accessor style in this file.
- `IsInner` uses idiomatic axis-aligned min/max checks with a margin, matching expected behavior for a line/bounds containment test.
- No contrived temporaries or compiler-coaxing patterns were introduced.

## Validation
- Rebuilt with `ninja` successfully.
- Confirmed progress via `build/GCCP01/report.json` deltas after rebuild.
