### PR TITLE
textureman: implement CTexture destructor thunk

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -38,6 +38,7 @@ public:
 extern "C" void __dl__FPv(void*);
 extern "C" void __dla__FPv(void*);
 extern "C" void __ct__4CRefFv(void*);
+extern "C" void __dt__4CRefFv(void*, int);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void* lbl_801E9BA0[];
 extern "C" void* PTR_PTR_s_CTextureSet_801e9b34;
@@ -541,12 +542,36 @@ CTexture::CTexture()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003B8D8
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-CTexture::~CTexture()
+extern "C" CTexture* __dt__8CTextureFv(CTexture* texture, short shouldDelete)
 {
-	// TODO
+    if (texture != 0) {
+        *reinterpret_cast<void**>(texture) = &PTR_PTR_s_CTexture_801e9b78;
+        if (U8At(texture, 0x75) == 0) {
+            if (PtrAt(texture, 0x78) != 0) {
+                __dla__FPv(PtrAt(texture, 0x78));
+                PtrAt(texture, 0x78) = 0;
+            }
+            if (PtrAt(texture, 0x7C) != 0) {
+                __dla__FPv(PtrAt(texture, 0x7C));
+                PtrAt(texture, 0x7C) = 0;
+            }
+        } else {
+            PtrAt(texture, 0x78) = 0;
+            PtrAt(texture, 0x7C) = 0;
+        }
+        __dt__4CRefFv(texture, 0);
+        if (shouldDelete > 0) {
+            __dl__FPv(texture);
+        }
+    }
+    return texture;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__dt__8CTextureFv` in `src/textureman.cpp` using the PAL decompilation structure.
- Replaced the TODO destructor stub with explicit cleanup of owned image/tlut buffers, vtable restore, `CRef` base teardown, and `shouldDelete` handling.
- Added the missing `__dt__4CRefFv` extern declaration required by the destructor path.
- Updated the function info block with PAL address/size metadata.

## Functions Improved
- Unit: `main/textureman`
- Function: `__dt__8CTextureFv` (`CTexture` destructor thunk)

## Match Evidence
- `__dt__8CTextureFv`: **33.386364% -> 77.954544%** (`build/GCCP01/report.json` fuzzy match)
- `objdiff-cli diff` (unit/symbol) reports function match around **77.84%** after change.
- Unit-level match signal in `objdiff` output improved from about **50.61% -> 51.71%**.

## Plausibility Rationale
- The new code follows the expected Metrowerks deleting-destructor pattern used elsewhere in the repo:
  - null check on `this`
  - vtable reset
  - conditional owned-resource cleanup
  - explicit base destructor call (`CRef`)
  - delete-on-positive-flag behavior
- This aligns with decomp-derived behavior and common original-source idioms in this codebase, rather than compiler-coaxing changes.

## Technical Notes
- Cleanup logic distinguishes between internally-owned texture/tlut data (`field 0x75 == 0`) and externally-provided pointers.
- For owned data, both allocations are released with `__dla__FPv`; otherwise pointers are just cleared.
- The symbol is now a concrete implementation instead of an empty TODO body.
