### PR TITLE
pppScreenBreak: improve pppRenderScreenBreak object match

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -703,12 +703,11 @@ void pppFrameScreenBreak(PScreenBreak* pppScreenBreak, UnkB* param_2, UnkC* para
 void pppRenderScreenBreak(PScreenBreak* pppScreenBreak, UnkB*, UnkC* param_3)
 {
     s32 dataOffset = param_3->m_serializedDataOffsets[2];
-    void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((u8*)pppMngStPtr + 0xD8), 0);
-    CChara::CModel* model = (CChara::CModel*)GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
-    SearchNode__Q26CChara6CModelFPc(model, s_f999_root_801dd4c8);
-    if (*(u8*)((u8*)pppScreenBreak + 0xA4 + dataOffset) == 0) {
-        Graphic.GetBackBufferRect2(DAT_80238034, (_GXTexObj*)((u8*)pppScreenBreak + 0x90 + dataOffset), 0, 0, 0x280,
-                                   0x1C0, 0, GX_LINEAR, GX_TF_RGBA8, 0);
-        *(u8*)((u8*)pppScreenBreak + 0xA4 + dataOffset) = 1;
+    u8* value = (u8*)pppScreenBreak + dataOffset + 0x80;
+
+    if (value[0x24] == 0) {
+        Graphic.GetBackBufferRect2(*(void**)((u8*)&Graphic + 0x71EC), *(_GXTexObj**)(value + 0x10), 0, 0, 0x280, 0x1C0,
+                                   0, (_GXTexFilter)0, (_GXTexFmt)0, 0);
+        value[0x24] = 1;
     }
 }


### PR DESCRIPTION
## Summary
- Simplified `pppRenderScreenBreak` to operate directly on the serialized per-effect data block (`+0x80` base) used by this unit.
- Removed extra character/model node lookup work from this render path.
- Switched `GetBackBufferRect2` inputs to the data-backed texture pointer (`value + 0x10`) and `Graphic` backbuffer source pointer (`Graphic + 0x71EC`) with explicit zeroed filter/format args.
- Kept behavior-local state update via the same one-byte completion flag (`value[0x24] = 1`).

## Functions improved
- Unit: `main/pppScreenBreak`
- Symbol: `pppRenderScreenBreak` (PAL `0x8012d458`, size `168b`)

## Match evidence
Measured with direct objdiff on this unit object:
- Before: `57.38095%`
- After: `69.28571%`
- Command: `tools/objdiff-cli diff -1 build/GCCP01/obj/pppScreenBreak.o -2 build/GCCP01/src/pppScreenBreak.o -o - pppRenderScreenBreak`

No other symbol in `pppScreenBreak.o` regressed in this change set.

## Plausibility rationale
- The updated function uses the same serialized runtime block layout already used throughout neighboring screen-break code (`dataOffset + 0x80`), including the local flag and texture pointer fields.
- The removed model-search path is not required for the actual backbuffer capture operation performed here, and removing it makes this render function tighter and more consistent with the target object shape.
- The resulting C++ remains straightforward, readable game code (data extraction + one guarded capture call), not compiler-coaxing artifacts.

## Technical notes
- Full build passes: `ninja`
- Verification performed against PAL (`GCCP01`).
