### PR TITLE
main/p_graphic: match CGraphicPcs::GetTable

### DIFF
--- a/include/ffcc/p_graphic.h
+++ b/include/ffcc/p_graphic.h
@@ -10,7 +10,7 @@ class CGraphicPcs : public CProcess
 public:
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void create();
     void destroy();

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -124,12 +124,16 @@ void CGraphicPcs::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004776c
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGraphicPcs::GetTable(unsigned long)
+int CGraphicPcs::GetTable(unsigned long index)
 {
-	// TODO
+    return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(lbl_801E9D08) + index * 0x15C);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `CGraphicPcs::GetTable` signature from `void` to `int` in `include/ffcc/p_graphic.h`.
- Implemented `CGraphicPcs::GetTable(unsigned long index)` in `src/p_graphic.cpp` to return the table base plus `index * 0x15C`.
- Added PAL metadata header for the function (`0x8004776c`, `20b`).

## Functions improved
- Unit: `main/p_graphic`
- Symbol: `GetTable__11CGraphicPcsFUl`

## Match evidence
- Before: `20.0%` (from `agent_select_target.py` target listing in this branch session)
- After: `100.0%` (`tools/objdiff-cli diff -p . -u main/p_graphic -o - GetTable__11CGraphicPcsFUl`)
- Build progress also increased by one matched function (`1665 -> 1666`) and code matched bytes (`211776 -> 211796`).

## Plausibility rationale
- This aligns with established process-table patterns used in nearby units (`p_system`, `p_sample`), where `GetTable` returns a row pointer computed as `base + index * entry_size`.
- The previous `void` TODO body was inconsistent with both symbol behavior and codebase conventions.

## Technical details
- Implemented as:
  - `return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(lbl_801E9D08) + index * 0x15C);`
- Uses existing table symbol and entry stride reflected by the decomp and neighboring process classes.
