### PR TITLE
p_light: implement CLightPcs::SetBit32

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -626,22 +626,46 @@ void CLightPcs::SetPosition(CLightPcs::TARGET target, Vec* pos, unsigned long ma
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80048ef8
+ * PAL Size: 232b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void setchanctrl(CLightPcs::TARGET, unsigned long)
+void CLightPcs::SetBit32(CLightPcs::TARGET target, unsigned long* bits)
 {
-	// TODO
-}
+    char* lightPcs = (char*)this;
+    char* bumpSlot = lightPcs + 0x63c;
+    u32 i;
+    _GXColor lightColor;
 
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CLightPcs::SetBit32(CLightPcs::TARGET, unsigned long*)
-{
-	// TODO
+    *(u32*)(lightPcs + 0xb0) = 0;
+    *(u32*)(lightPcs + 0xb4) = 0;
+    i = 0;
+
+    do {
+        if (*(u32*)(lightPcs + 0xb8) <= i) {
+            return;
+        }
+
+        if ((*(char*)((int)target + (int)bumpSlot + 0x60) != '\0') &&
+            (((1 << (i & 0x1f)) & *(u32*)((char*)bits + ((i >> 3) & 0x1ffffffc))) != 0))
+        {
+            *(u32*)&lightColor = *(u32*)(bumpSlot + 0x50 + ((int)target * 4));
+            GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c), lightColor);
+            GXLoadLightObjImm((GXLightObj*)(bumpSlot + 0x6c), (GXLightID)(1 << *(u32*)(lightPcs + 0xb0)));
+            *(u32*)(lightPcs + 0xb4) |= 1 << *(u32*)(lightPcs + 0xb0);
+            *(u32*)(lightPcs + 0xb0) += 1;
+
+            if (*(u32*)(lightPcs + 0xb0) > 7) {
+                return;
+            }
+        }
+
+        i += 1;
+        bumpSlot += 0xb0;
+    } while (true);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::SetBit32(CLightPcs::TARGET, unsigned long*)` in `src/p_light.cpp` (previously TODO/stub).
- Added PAL metadata block for the implemented function:
  - PAL Address: `0x80048ef8`
  - PAL Size: `232b`
- Removed the local `setchanctrl` stub definition from this translation unit so symbol ordering no longer includes a non-target helper function at this location.

## Functions Improved
- Unit: `main/p_light`
- Function: `SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl`

## Match Evidence
- Before: `1.7%` (from `tools/agent_select_target.py` output for this symbol on this unit)
- After: `81.68965%` (`objdiff-cli` JSON for direct target-vs-source object comparison on a symbol-isolated diff)

Commands used for after-metric:
```sh
build/binutils/powerpc-eabi-objcopy --strip-unneeded --keep-symbol=SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl build/GCCP01/obj/p_light.o /tmp/p_light_target_setbit32.o
build/binutils/powerpc-eabi-objcopy --strip-unneeded --keep-symbol=SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl build/GCCP01/src/p_light.o /tmp/p_light_src_setbit32.o
tools/objdiff-cli diff -1 /tmp/p_light_target_setbit32.o -2 /tmp/p_light_src_setbit32.o -o - SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl
```

## Plausibility Rationale
- The implementation is source-plausible and consistent with nearby `p_light.cpp` style:
  - Iterates bump-light slots (`0xb0` stride) and checks per-target enable byte.
  - Tests packed bitset membership for each slot.
  - Loads light color and GX light object per matched slot.
  - Updates manager bitmasks/count (`+0xb0`, `+0xb4`) with the expected 8-light cap behavior.
- No contrived compiler-only temporaries were added; logic matches expected game-engine author intent.

## Technical Notes
- Unit-level auto symbol pairing in this file can drift because of surrounding incomplete functions. To avoid false pairings, measurement was taken with a symbol-isolated object diff focused on `SetBit32`.
- Full project build still succeeds with `ninja` after the change.
