### PR TITLE
monobj: implement onAttacked and enableDamageCol

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -2,6 +2,7 @@
 #include "ffcc/charaobj.h"
 #include "ffcc/math.h"
 #include "ffcc/vector.h"
+#include "PowerPC_EABI_Support/Runtime/ptmf.h"
 
 #include <math.h>
 #include <string.h>
@@ -277,12 +278,29 @@ void CGMonObj::enableAttackCol(int, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80117B08
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGMonObj::enableDamageCol(int)
+void CGMonObj::enableDamageCol(int enabled)
 {
-	// TODO
+	CGObject* object = reinterpret_cast<CGObject*>(this);
+
+	unsigned int& damageCol1X =
+		*reinterpret_cast<unsigned int*>(&object->m_damageColliders[1].m_localPosition.x);
+	unsigned int& damageCol2X =
+		*reinterpret_cast<unsigned int*>(&object->m_damageColliders[2].m_localPosition.x);
+
+	if (enabled != 0) {
+		damageCol1X = 1;
+		damageCol2X = 1;
+	} else {
+		damageCol1X = 0;
+		damageCol2X = 0;
+	}
 }
 
 /*
@@ -327,12 +345,21 @@ void CGMonObj::onDrawDebug(CFont*, float, float&, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801173B4
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGMonObj::onAttacked(CGPrgObj*)
 {
-	// TODO
+	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
+	mon[0x6C0] = 1;
+
+	if (__ptmf_test(reinterpret_cast<__ptmf*>(mon + 0x780)) != 0) {
+		__ptmf_scall(this, mon + 0x708);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two CGMonObj methods in src/monobj.cpp with plausible gameplay-object behavior from the Ghidra reference:
- CGMonObj::enableDamageCol(int) now toggles damage collider activation flags.
- CGMonObj::onAttacked(CGPrgObj*) now sets the attacked flag and conditionally invokes the configured PTMF callback.

Also added PAL address/size metadata blocks for both functions.

## Functions improved
- Unit: main/monobj
- enableDamageCol__8CGMonObjFi: 10.0% -> 100.0% (40b)
- onAttacked__8CGMonObjFP8CGPrgObj: 4.5454545% -> 85.59091% (88b)
- Unit fuzzy match: 5.3651147% -> 5.7141%

## Match evidence
- ninja progress increased matched code by 40 bytes and matched functions by +1.
- tools/objdiff-cli JSON diff for enableDamageCol__8CGMonObjFi reports match_percent: 100.0 with fully matching instruction rows.
- tools/objdiff-cli JSON diff for onAttacked__8CGMonObjFP8CGPrgObj reports ~85.36% with 16 matching instructions and only a few remaining arg/delete diffs.

## Plausibility rationale
These edits are source-plausible and align with expected engine behavior:
- Collider enable/disable state is represented via per-collider flag writes.
- Attack reaction sets state and dispatches an existing callback only when the PTMF entry is valid.

No contrived control-flow reshaping or synthetic temporaries were added.

## Technical details
- Added #include "PowerPC_EABI_Support/Runtime/ptmf.h" to use project-native __ptmf / __ptmf_test declarations.
- Preserved existing object-layout access style used across monobj.cpp (offset-based reinterpretation) to avoid ABI/layout drift while improving codegen match.
