### PR TITLE
memory: reconstruct CStage::heapWalker

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -23,7 +23,7 @@ public:
         void resDefaultParam();
         void setParam(void*, unsigned long);
         void free(void*);
-        void heapWalker(int, void*, unsigned long);
+        int heapWalker(int, void*, unsigned long);
         void drawHeapBar(int);
         void drawHeapTitle(int);
         void GetHeapUnuse();


### PR DESCRIPTION
## Summary
- Implemented `CMemory::CStage::heapWalker` in `src/memory.cpp` using the recovered heap traversal/control-flow for both allocation modes.
- Updated the method signature in `include/ffcc/memory.h` to return `int`, matching behavior expected by the recovered implementation.
- Added PAL address/size metadata block for the implemented function.

## Functions improved
- Unit: `main/memory`
- Symbol: `heapWalker__Q27CMemory6CStageFiPvUl` (848b)

## Match evidence
- Before: `0.5%` (from `tools/agent_select_target.py` target output)
- After: `74.49056%` (`tools/objdiff-cli diff -p . -u main/memory -o - heapWalker__Q27CMemory6CStageFiPvUl`)

## Plausibility rationale
- The implementation follows expected original allocator-debug behavior: staged heap walk printing, free/used counters, optional group filtering, and mode-specific block iteration.
- Changes are type/flow corrections and functional reconstruction, not artificial compiler coaxing patterns.
- Existing code style in `memory.cpp` already relies on offset-based field access for incomplete class layouts, which this keeps consistent.

## Technical details
- Reconstructed branch structure and loop boundaries from the Ghidra decomp reference at `resources/ghidra-decomp-1-31-2026/8001df88_heapWalker__Q27CMemory6CStageFiPvUl.c`.
- Preserved pointer-walk semantics over block headers (`+0x4/+0x8/+0x10/+0x14/+0x18/+0x1A`) and mode-2 fixed-stride iteration (`+0x40`).
- Verified build with `ninja` and generated symbol diff JSON (`diff_heapWalker.json`) via objdiff v3.6.1.
