### PR TITLE
RedDriver: implement _ExecuteCommand and DeltaTimeSumup

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -34,7 +34,7 @@ void _StreamVolume(int*);
 void _StreamPause(int*);
 void _EntryExecCommand(void (*)(int*), int, int, int, int, int, int, int);
 void _ExecuteCommand();
-void DeltaTimeSumup(unsigned char**);
+unsigned int DeltaTimeSumup(unsigned char**);
 void GetMyEntryID();
 void _MyAlarmHandler(OSAlarm*, OSContext*);
 void RedSleep(int);

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -557,22 +557,54 @@ void _EntryExecCommand(void (*) (int*), int, int, int, int, int, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bdbd0
+ * PAL Size: 120b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void _ExecuteCommand()
 {
-	// TODO
+	int* executePos = (int*)DAT_8032f3d8;
+	int* readPos = (int*)DAT_8032f3dc;
+
+	while (executePos != readPos) {
+		if (*readPos != 0) {
+			((void (*)(int*))(*readPos))(readPos + 1);
+		}
+		readPos += 8;
+		if (readPos == (int*)DAT_8032f3d4 + 0x800) {
+			readPos = (int*)DAT_8032f3d4;
+		}
+	}
+
+	DAT_8032f3dc = readPos;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bdc48
+ * PAL Size: 112b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void DeltaTimeSumup(unsigned char **)
+unsigned int DeltaTimeSumup(unsigned char** buffer)
 {
-	// TODO
+	unsigned int deltaTime = 0;
+
+	if (buffer != 0) {
+		deltaTime = **buffer & 0x7f;
+		while ((**buffer & 0x80) != 0) {
+			*buffer += 1;
+			deltaTime = (deltaTime << 7) | (**buffer & 0x7f);
+		}
+		*buffer += 1;
+	}
+
+	return deltaTime;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `_ExecuteCommand()` command-ring processing in `src/RedSound/RedDriver.cpp`.
- Implement `DeltaTimeSumup(unsigned char**)` variable-length delta-time decode in `src/RedSound/RedDriver.cpp`.
- Update declaration in `include/ffcc/RedSound/RedDriver.h` to return `unsigned int` to match the decoded value semantics.
- Add PAL address/size metadata blocks for both functions.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- `_ExecuteCommand__Fv` (120b)
- `DeltaTimeSumup__FPPUc` (112b)

## Match evidence
From full `ninja` `report.json` before/after on the same branch:
- `_ExecuteCommand__Fv`: `3.3333333%` -> `90.833336%`
- `DeltaTimeSumup__FPPUc`: `3.5714285%` -> `71.96429%`

From unit-level objdiff (`tools/objdiff-cli diff -p . -u main/RedSound/RedDriver`):
- `_ExecuteCommand__Fv`: `3.3333333%` -> `90.166664%`
- `DeltaTimeSumup__FPPUc`: `3.5714285%` -> `71.96429%`

## Plausibility rationale
- `_ExecuteCommand` now follows a natural producer/consumer ring-buffer walk: execute queued callback entries, advance by fixed slot width, wrap at the buffer end, and commit the read pointer.
- `DeltaTimeSumup` now decodes standard 7-bit continuation bytes (MIDI-style VLQ), which matches the surrounding RedSound command/data flow and expected game-audio source style.
- Changes are behavioral implementations rather than compiler-only coaxing.

## Technical details
- `_ExecuteCommand` reads from `DAT_8032f3dc`, stops at `DAT_8032f3d8`, dispatches `void (*)(int*)` callbacks at slot head, and wraps against `DAT_8032f3d4 + 0x2000`.
- `DeltaTimeSumup` accumulates `(**buffer & 0x7F)` and shifts by 7 while continuation bit `0x80` is set, incrementing the source pointer each byte.
- Build verification: `ninja` completed successfully after the change.
