### PR TITLE
p_light: implement CLightPcs::MakeLightMap first pass

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/p_light.h"
 
+#include "ffcc/graphic.h"
+
 #include <dolphin/mtx.h>
 #include <dolphin/gx/GXVert.h>
 #include <math.h>
@@ -29,6 +31,9 @@ extern float FLOAT_8032fc18;
 extern float FLOAT_8032fc1c;
 extern float FLOAT_8032fc20;
 extern float FLOAT_8032fc24;
+extern float FLOAT_8032fc28;
+extern float FLOAT_8032fc2c;
+extern float FLOAT_8032fc30;
 extern float FLOAT_8032fc34;
 extern float FLOAT_8032fc38;
 extern float FLOAT_8032fc3c;
@@ -38,6 +43,7 @@ extern float FLOAT_8032fc60;
 extern float FLOAT_8032fc70;
 extern float FLOAT_8032fc74;
 extern float FLOAT_8032fc78;
+extern float FLOAT_8032fc80;
 extern float FLOAT_8032fc84;
 extern float FLOAT_8032fc94;
 extern double DOUBLE_8032fc48;
@@ -45,7 +51,11 @@ extern double DOUBLE_8032fc50;
 extern double DOUBLE_8032fc58;
 extern double DOUBLE_8032fc68;
 extern double DAT_8032ec20;
+extern void* DAT_80238030;
 extern float DAT_801ea430;
+extern void* GraphicsPcs;
+
+extern "C" void setViewport__11CGraphicPcsFv(void*);
 
 extern class CCameraPcs {
 public:
@@ -976,7 +986,55 @@ void CLightPcs::CBumpLight::MakeLightMap()
  */
 void CLightPcs::MakeLightMap()
 {
-	// TODO
+    Mtx44 projection;
+
+    GXSetCullMode(GX_CULL_BACK);
+    GXSetZCompLoc(GX_TRUE);
+    GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
+    GXSetBlendMode(GX_BM_NONE, GX_BL_ZERO, GX_BL_ZERO, GX_LO_SET);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_AND, GX_ALWAYS, 0xFF);
+    GXSetColorUpdate(GX_TRUE);
+    GXSetPixelFmt(GX_PF_RGB8_Z24, GX_ZC_LINEAR);
+    GXSetViewport(FLOAT_8032fc14, FLOAT_8032fc14, FLOAT_8032fc28, FLOAT_8032fc28, FLOAT_8032fc14, FLOAT_8032fc1c);
+    GXSetScissor(0, 0, 0x40, 0x40);
+    C_MTXOrtho(projection, FLOAT_8032fc2c, FLOAT_8032fc1c, FLOAT_8032fc2c, FLOAT_8032fc1c, FLOAT_8032fc1c,
+               FLOAT_8032fc30);
+    GXSetProjection(projection, GX_ORTHOGRAPHIC);
+    GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT0, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetChanCtrl(GX_COLOR1A1, GX_TRUE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT0, GX_DF_NONE, GX_AF_SPEC);
+    GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);
+    GXSetTevDirect(GX_TEVSTAGE0);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
+    GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+    GXSetNumIndStages(0);
+    GXSetNumTevStages(1);
+    GXSetNumTexGens(0);
+    GXSetNumChans(1);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_NRM, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_NRM, GX_NRM_XYZ, GX_F32, 0);
+    GXSetAlphaUpdate(GX_TRUE);
+
+    char* lightTarget = (char*)this;
+    for (u32 target = 0; target < 4; target++, lightTarget += 0x9c0) {
+        char* bump = lightTarget;
+        for (u32 i = 0; i < 8; i++, bump += 0x138) {
+            if (*(u8*)(bump + 0x1cec) != 0) {
+                ((CLightPcs::CBumpLight*)(bump + 0x1c3c))->MakeLightMap();
+            }
+        }
+    }
+
+    Graphic.SetStdPixelFmt();
+    setViewport__11CGraphicPcsFv(GraphicsPcs);
+    GXSetCullMode(GX_CULL_FRONT);
+    GXSetAlphaUpdate(GX_FALSE);
+    GXSetTexCopySrc(0, 0, 0x40, 0x40);
+    GXSetTexCopyDst((u16)0x40, (u16)0x40, GX_TF_I8, GX_FALSE);
+    GXCopyTex(DAT_80238030, GX_TRUE);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::MakeLightMap()` in `src/p_light.cpp` (previously TODO stub).
- Added the GX render-state setup, 64x64 orthographic lightmap pass, and per-target/per-bump dispatch to `CBumpLight::MakeLightMap()`.
- Restored standard pixel/viewport state and copied the generated texture back to `DAT_80238030` at the end of the pass.

## Functions improved
- Unit: `main/p_light`
- Function: `MakeLightMap__9CLightPcsFv` (712b)

## Match evidence
- Before: `0.6%` (selector output for `MakeLightMap__9CLightPcsFv`)
- After: `90.39%` (`objdiff-cli diff -p . -u main/p_light -o - MakeLightMap__9CLightPcsFv`)
- Current report also shows `90.75843%` fuzzy for this function in `build/GCCP01/report.json`.

## Plausibility rationale
- The implementation follows the expected high-level game rendering flow for an offscreen lightmap pass: setup GX state, render bump-light maps, restore global draw state.
- Changes avoid contrived compiler-only rewrites and use code patterns already present in this codebase (direct GX API setup + existing process/global calls).

## Technical details
- Introduced extern declarations required by the function (`DAT_80238030`, `GraphicsPcs`, viewport bridge symbol, and constants used by projection/viewport setup).
- Used the existing memory layout assumptions already present in `p_light.cpp` for bump-target iteration (`0x9c0` target stride, `0x138` bump stride).
- Verified build with `ninja` and validated symbol-level assembly proximity with objdiff.
