### PR TITLE
p_FunnyShape: add missing CPtrArray vtable layout

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -24,7 +24,7 @@ public:
     int growCapacity;
 
     CPtrArray();
-    ~CPtrArray();
+    virtual ~CPtrArray();
 
     void RemoveAll();
     void DeleteAndRemoveAll();


### PR DESCRIPTION
## Summary
- Marked `CPtrArray` destructor as `virtual` in `src/p_FunnyShape.cpp`.
- This introduces the missing polymorphic layout/vptr expected by the target object for the template specializations used in `p_FunnyShape`.

## Functions Improved
Unit: `main/p_FunnyShape`
- `__ct__22CPtrArray<P9_GXTexObj>Fv`: **71.61539% -> 99.53846%**
- `__dt__22CPtrArray<P9_GXTexObj>Fv`: **90.22581% -> 99.870964%**
- `__ct__29CPtrArray<P15OSFS_TEXTURE_ST>Fv`: **71.61539% -> 99.53846%**

Unit-level fuzzy match:
- `main/p_FunnyShape`: **73.64636% -> 74.771576%**

## Match Evidence
Generated with objdiff report comparison:
- Before: `/tmp/objdiff_report_restored.json`
- After: `/tmp/objdiff_report_vdtor.json`
- Changes: `/tmp/objdiff_changes.json`

Instruction-level evidence showed the target ctors/dtors use a vptr at offset `0x0`, with other members shifted accordingly (e.g. `items` at `0x10`), which aligns with a polymorphic class layout.

## Plausibility Rationale
This is a source-plausible correction: `CPtrArray` is used with specialized ctor/dtor code patterns consistent with a polymorphic type in the original binary. Adding `virtual` on the destructor expresses that intent directly in C++ rather than using non-idiomatic coercion.

## Technical Details
- Change is minimal: one keyword (`virtual`) on template destructor declaration.
- The resulting assembly now aligns much more closely in the affected template ctor/dtor functions.
- Note: `__dt__14CFunnyShapePcsFv` regressed (**99.94118% -> 89.35294%**), but overall unit fuzzy match and multiple lower-match functions improved significantly, yielding a net positive for this pass.
