### PR TITLE
mapocttree: improve COctNode ctor match ordering

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1820,13 +1820,14 @@ COctNode::COctNode()
 {
 	float min = lbl_8032F96C;
 	float max = lbl_8032F970;
+	float* bounds = (float*)this;
 
-	*(float*)((unsigned char*)this + 0x0) = min;
-	*(float*)((unsigned char*)this + 0x4) = min;
-	*(float*)((unsigned char*)this + 0x8) = min;
-	*(float*)((unsigned char*)this + 0xC) = max;
-	*(float*)((unsigned char*)this + 0x10) = max;
-	*(float*)((unsigned char*)this + 0x14) = max;
+	bounds[2] = min;
+	bounds[1] = min;
+	bounds[0] = min;
+	bounds[5] = max;
+	bounds[4] = max;
+	bounds[3] = max;
 	*(void**)((unsigned char*)this + 0x44) = 0;
 	*(void**)((unsigned char*)this + 0x48) = 0;
 }


### PR DESCRIPTION
## Summary
- Reworked `COctNode::COctNode()` initialization in `src/mapocttree.cpp` to use a typed float buffer and explicit `z/y/x` then `z/y/x` bound store ordering.
- Preserved semantics (same constants, same fields, same null pointer initialization) while improving emitted instruction argument alignment.

## Functions improved
- `__ct__8COctNodeFv` (`COctNode::COctNode()`)

## Match evidence
- Symbol (`objdiff diff -p . -u main/mapocttree -o -`):
  - `__ct__8COctNodeFv`: **96.333336% -> 96.666664%**
- Unit text section (`main/mapocttree`):
  - `.text` match: **58.48897% -> 58.490353%**
- Build status:
  - `ninja` passes

## Plausibility rationale
- The change is source-plausible: it only adjusts initialization expression structure and store order for existing fields, without introducing contrived temporaries, magic constants, or non-idiomatic control flow.
- It aligns with Ghidra-indicated write ordering for the constructor while keeping clean maintainable C++.

## Technical details
- Replaced repeated raw byte-offset float stores with a `float* bounds` view and ordered writes:
  - `bounds[2], bounds[1], bounds[0]` set to min
  - `bounds[5], bounds[4], bounds[3]` set to max
- Kept trailing zero-initialization of `0x44` and `0x48` unchanged.
