### PR TITLE
pppPart: improve _pppStartPart allocator/init match

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -1669,19 +1669,25 @@ void _pppStartPart(_pppMngSt* pppMngSt, long* pdt, int runControlPrograms)
 
 	pppPDataValRaw* pDataVals = 0;
 	if (programCount > 0) {
-		pDataVals = (pppPDataValRaw*)new (pppEnvStPtr->m_stagePtr, (char*)"pppPart.cpp", 0x585) unsigned char[programCount * 0x10];
+		pDataVals = (pppPDataValRaw*)pppMemAlloc(programCount * 0x10, pppEnvStPtr->m_stagePtr, (char*)"pppPart.cpp", 0x585);
 	}
 	*(void**)(mngBytes + 0xC8) = pDataVals;
+	*(_pppPObjLink**)(mngBytes + 0xC4) = 0;
 
-	pppProgramSetDefRaw* programSet = (pppProgramSetDefRaw*)(pdt + 6);
-	for (int i = 0; i < programCount && programSet != 0 && pDataVals != 0; i++) {
-		pDataVals[i].m_programSetDef = programSet;
-		pDataVals[i].m_nextSpawnTime = programSet->m_startFrame;
-		pDataVals[i].m_objHead = 0;
-		pDataVals[i].m_activeCount = 0;
-		pDataVals[i].m_index = (unsigned char)i;
-		pDataVals[i].m_pad = 0;
-		programSet = programSet->m_next;
+	if (pDataVals != 0) {
+		pppProgramSetDefRaw* programSet = (pppProgramSetDefRaw*)(pdt + 6);
+		unsigned char index = 0;
+		while (programSet != 0) {
+			pDataVals->m_programSetDef = programSet;
+			pDataVals->m_nextSpawnTime = programSet->m_startFrame;
+			pDataVals->m_objHead = 0;
+			pDataVals->m_activeCount = 0;
+			pDataVals->m_index = index;
+			pDataVals->m_pad = 0;
+			programSet = programSet->m_next;
+			index++;
+			pDataVals++;
+		}
 	}
 
 	if (runControlPrograms != 0) {


### PR DESCRIPTION
## Summary
- Updated `_pppStartPart` in `src/pppPart.cpp` to use `pppMemAlloc(...)` for the program data table allocation path.
- Aligned initialization flow with existing particle manager patterns by clearing the object list head and initializing program data entries via linked-list traversal.
- Kept changes source-plausible (allocator selection + init sequencing), without adding contrived compiler-only constructs.

## Functions improved
- Unit: `main/pppPart`
- Symbol: `_pppStartPart__FP9_pppMngStPli`

## Match evidence
- `_pppStartPart__FP9_pppMngStPli`: **19.4506% -> 21.0058%** (`build/tools/objdiff-cli diff -p . -u main/pppPart -o - _pppStartPart__FP9_pppMngStPli`)
- Build verification: `ninja` passes.

## Plausibility rationale
- `pppMemAlloc` is the established allocator path in this unit for particle object lifecycle and pressure handling; using it in startup data allocation is consistent with existing code patterns.
- The linked-list based program-set walk mirrors the data model (`m_next` chain) and avoids brittle index assumptions.

## Technical details
- Replaced `new[]` allocation with:
  - `pppMemAlloc(programCount * 0x10, pppEnvStPtr->m_stagePtr, "pppPart.cpp", 0x585)`
- Added head initialization:
  - `*(_pppPObjLink**)(mngBytes + 0xC4) = 0`
- Changed program metadata initialization from indexed `for` loop to pointer walk over `pppProgramSetDefRaw::m_next`, incrementing stored index bytes.
