### PR TITLE
memorycard: improve EncodeData/DecodeData matching

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1717,51 +1717,62 @@ inline int rotrwi(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800C1FF0
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemoryCardMan::EncodeData()
 {
-    const u8  key = m_saveBuffer[0x11];
-    const u32 rotAmount = key & 0x1F;
-
+    const u32 rotAmount = m_saveBuffer[0x11] & 0x1F;
     u32* ptr = reinterpret_cast<u32*>(m_saveBuffer + 0x18);
+    int count = 0x5B6;
 
-    for (int i = 0; i < 0x5B6; i++)
+    do
     {
-        for (int w = 0; w < 7; w++)
-        {
-            u32 v = ptr[w];
-            v = (v << rotAmount) | (v >> (32 - rotAmount));
-            ptr[w] = v;
-        }
-
+        ptr[0] = (ptr[0] << rotAmount) | (ptr[0] >> (0x20 - rotAmount));
+        ptr[1] = (ptr[1] << rotAmount) | (ptr[1] >> (0x20 - rotAmount));
+        ptr[2] = (ptr[2] << rotAmount) | (ptr[2] >> (0x20 - rotAmount));
+        ptr[3] = (ptr[3] << rotAmount) | (ptr[3] >> (0x20 - rotAmount));
+        ptr[4] = (ptr[4] << rotAmount) | (ptr[4] >> (0x20 - rotAmount));
+        ptr[5] = (ptr[5] << rotAmount) | (ptr[5] >> (0x20 - rotAmount));
+        ptr[6] = (ptr[6] << rotAmount) | (ptr[6] >> (0x20 - rotAmount));
         ptr += 7;
+        count--;
     }
+    while (count != 0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800C1F20
+ * PAL Size: 208b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemoryCardMan::DecodeData()
 {
-    u32 shift = (m_saveBuffer[0x11] & 0x1F);
-    u32 rshift = (32 - shift) & 31; 
+    const u32 rotAmount = 0x20 - (m_saveBuffer[0x11] & 0x1F);
     u32* ptr = reinterpret_cast<u32*>(m_saveBuffer + 0x18);
+    int count = 0x5B6;
 
-    for (int i = 0; i < 0x5B6; i++)
+    do
     {
-        for (int w = 0; w < 7; w++)
-        {
-            u32 v = ptr[w];
-            v = (v >> shift) | (v << rshift);
-            ptr[w] = v;
-        }
-
+        ptr[0] = (ptr[0] << (rotAmount & 0x1F)) | (ptr[0] >> (0x20 - (rotAmount & 0x1F)));
+        ptr[1] = (ptr[1] << (rotAmount & 0x1F)) | (ptr[1] >> (0x20 - (rotAmount & 0x1F)));
+        ptr[2] = (ptr[2] << (rotAmount & 0x1F)) | (ptr[2] >> (0x20 - (rotAmount & 0x1F)));
+        ptr[3] = (ptr[3] << (rotAmount & 0x1F)) | (ptr[3] >> (0x20 - (rotAmount & 0x1F)));
+        ptr[4] = (ptr[4] << (rotAmount & 0x1F)) | (ptr[4] >> (0x20 - (rotAmount & 0x1F)));
+        ptr[5] = (ptr[5] << (rotAmount & 0x1F)) | (ptr[5] >> (0x20 - (rotAmount & 0x1F)));
+        ptr[6] = (ptr[6] << (rotAmount & 0x1F)) | (ptr[6] >> (0x20 - (rotAmount & 0x1F)));
         ptr += 7;
+        count--;
     }
+    while (count != 0);
 }
 
 void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)


### PR DESCRIPTION
## Summary
- rewrote `CMemoryCardMan::EncodeData` and `CMemoryCardMan::DecodeData` to use fixed 7-word block processing with a countdown loop
- kept behavior source-plausible (same rotation-based transform), while aligning control flow and expression shape to expected Metrowerks codegen
- added PAL function metadata comments for both edited functions

## Functions improved
- Unit: `main/memorycard`
- `EncodeData__14CMemoryCardManFv`
- `DecodeData__14CMemoryCardManFv`

## Match evidence (objdiff)
- `EncodeData__14CMemoryCardManFv`: **51.862743% -> 53.431374%** (+1.568631)
- `DecodeData__14CMemoryCardManFv`: **47.192307% -> 57.019230%** (+9.826923)

Command used:
```sh
build/tools/objdiff-cli diff -p . -u main/memorycard -o - DecodeData__14CMemoryCardManFv
```

## Plausibility rationale
- The revised code uses straightforward blockwise word transforms and a simple decrementing loop, which is plausible original game code style.
- No compiler-coaxing artifacts (no contrived temporaries, no magic-offset hacks, no debug/comment junk) were introduced.
- Improvement comes from closer instruction/control-flow alignment rather than symbol or formatting-only changes.

## Technical details
- switched from nested index loop (`i` x `w`) to explicit 7-word operations per block
- used direct rotation expressions over each word and pointer bump by 7 words per iteration
- mirrored this structure in both encode/decode paths to keep transforms consistent
