### PR TITLE
cflat_r2system: add IsAbsolute__10CCameraPcsFv

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1414,6 +1414,20 @@ extern "C" void SetFromScript__10CCameraPcsFv(CCameraPcs* camera)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9C7C
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsAbsolute__10CCameraPcsFv(CCameraPcs* camera)
+{
+    return *(int*)((char*)camera + 0x444);
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800B9C28
  * PAL Size: 28b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Added the missing `IsAbsolute__10CCameraPcsFv` wrapper in `src/cflat_r2system.cpp`.
- Implemented it as a direct camera state read at offset `0x444`, matching the PAL 8-byte behavior.
- Added the standard `--INFO--` block with PAL address/size metadata.

## Functions Improved
- Unit: `main/cflat_r2system`
- Function: `IsAbsolute__10CCameraPcsFv`
- Before: `0.0%` (from target selector output)
- After: `100.0%` (`build/GCCP01/report.json`, function-level fuzzy match)

## Match Evidence
- Unit progress moved from `50/84` matched functions to `51/84` matched functions.
- Unit fuzzy match increased from `9.180643` to `9.226731`.
- Global progress increased by `+8` matched code bytes and `+1` matched function after rebuild.
- Symbol-level objdiff now shows exact 8-byte body (`lwz r3, 0x444(r3)` then `blr`).

## Plausibility Rationale
- This is a straightforward camera getter and matches established source style in this unit (small C-linkage wrappers around camera fields).
- No compiler-coaxing constructs were introduced; behavior is idiomatic and directly corresponds to the documented PAL symbol.

## Technical Details
- `ninja` build succeeds.
- `objdiff-cli` verification command:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o /tmp/cflat_isabsolute.json --format json-pretty IsAbsolute__10CCameraPcsFv`
- Report verification command:
  - `jq '.units[] | select(.name=="main/cflat_r2system")' build/GCCP01/report.json`
