### PR TITLE
alloc: align soft_allocate_from_var_pools null-path control flow

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -502,6 +502,15 @@ static void* allocate_from_var_pools(__mem_pool_obj* pool_obj, unsigned long siz
     return 0;
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801b2640
+ * PAL Size: 216b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 static void* soft_allocate_from_var_pools(__mem_pool_obj* pool_obj, unsigned long size, unsigned long* available_size) {
     unsigned long aligned_size;
     Block* current_block;
@@ -514,24 +523,26 @@ static void* soft_allocate_from_var_pools(__mem_pool_obj* pool_obj, unsigned lon
     
     *available_size = 0;
     current_block = pool_obj->start_;
-    
-    if (current_block != 0) {
-        do {
-            if ((aligned_size <= current_block->max_size) &&
-                ((result = Block_subBlock(current_block, aligned_size)) != 0)) {
-                pool_obj->start_ = current_block;
-                return (char*)result + 8;
-            }
 
-            if ((8 < current_block->max_size) &&
-                (*available_size < current_block->max_size - 8)) {
-                *available_size = current_block->max_size - 8;
-            }
-
-            current_block = current_block->next;
-        } while (current_block != pool_obj->start_);
+    if (current_block == 0) {
+        return 0;
     }
-    
+
+    do {
+        if ((aligned_size <= current_block->max_size) &&
+            ((result = Block_subBlock(current_block, aligned_size)) != 0)) {
+            pool_obj->start_ = current_block;
+            return (char*)result + 8;
+        }
+
+        if ((8 < current_block->max_size) &&
+            (*available_size < current_block->max_size - 8)) {
+            *available_size = current_block->max_size - 8;
+        }
+
+        current_block = current_block->next;
+    } while (current_block != pool_obj->start_);
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Reworked `soft_allocate_from_var_pools` null-start handling to use an early return (`if (current_block == 0) return 0;`) before the allocation scan loop.
- Kept the loop body and allocation behavior unchanged.
- Added the required `--INFO--` metadata block for this function.

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/alloc`
- Symbol: `soft_allocate_from_var_pools`

## Match evidence
- `soft_allocate_from_var_pools`: **76.55556% -> 80.44444%** (`+3.88888`)
  - Command: `build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/alloc -o - soft_allocate_from_var_pools`
- Additional context from the same build:
  - `Block_subBlock`: 57.867767% -> 57.867767% (no change)
  - `allocate_from_fixed_pools`: 50.7% -> 49.555557% (minor regression)

## Plausibility rationale
- The change is source-plausible: it expresses the same behavior with an idiomatic early null guard and preserves the loop/body semantics.
- No compiler-coaxing constructs, magic offsets, or readability regressions were introduced.

## Technical details
- Objdiff on `soft_allocate_from_var_pools` shows branch/control-flow alignment improvement around the null-start path, including removal of a prior branch opcode mismatch in that region.
- The function remains a straightforward scan over variable-size blocks with unchanged allocation checks and `available_size` tracking.
