### PR TITLE
main/pppVertexAp: improve pppVertexAp match to 78.35%

### DIFF
--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -97,7 +97,9 @@ void pppVertexApCon(_pppPObject* pobj, PVertexAp* vtxAp)
 void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 {
     VertexApData* data = (VertexApData*)dataRaw;
-    VertexApState* state = (VertexApState*)((u8*)parent + **(s32**)((u8*)ctrlRaw + 0xC) + 0x80);
+    VertexApCtrl* ctrl = (VertexApCtrl*)ctrlRaw;
+    s32 stateOffset = *ctrl->stateOffset;
+    VertexApState* state = (VertexApState*)((u8*)parent + stateOffset + 0x80);
 
     if (lbl_8032ED70 != 0) {
         return;
@@ -119,7 +121,8 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 
         u8 count = data->spawnCount;
 
-        if (data->mode == 0) {
+        switch (data->mode) {
+        case 0:
             do {
                 if (state->index >= (u16)entry->maxValue) {
                     state->index = 0;
@@ -132,9 +135,10 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                 f32 y = vertex->y;
                 f32 z = vertex->z;
 
-                if ((data->childId + 0x10000) != 0xFFFF) {
+                s32 childId = data->childId;
+                if ((u16)childId != 0xFFFF) {
                     _pppPObject* child;
-                    _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
+                    _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
                     Vec pos;
                     Vec worldPos;
                     Vec* outPos;
@@ -160,7 +164,8 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     }
                 }
             } while (count-- != 0);
-        } else if (data->mode == 1) {
+            break;
+        case 1:
             do {
                 u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
                 Vec* vertex = &points[vertexIndex];
@@ -168,9 +173,10 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                 f32 y = vertex->y;
                 f32 z = vertex->z;
 
-                if ((data->childId + 0x10000) != 0xFFFF) {
+                s32 childId = data->childId;
+                if ((u16)childId != 0xFFFF) {
                     _pppPObject* child;
-                    _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
+                    _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
                     Vec pos;
                     Vec worldPos;
                     Vec* outPos;
@@ -196,6 +202,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     }
                 }
             } while (count-- != 0);
+            break;
         }
 
         state->countdown = data->spawnDelay;


### PR DESCRIPTION
## Summary
Aligned `pppVertexAp` source shape with nearby vertex-ap units while preserving behavior:
- used typed `VertexApCtrl` access and explicit `stateOffset`
- changed mode dispatch to `switch (data->mode)` with `case 0/1`
- normalized child sentinel handling to `s32 childId` + `(u16)childId != 0xFFFF`

## Functions Improved
- Unit: `main/pppVertexAp`
- Symbol: `pppVertexAp`
- Target size: 776 bytes (unchanged)

## Match Evidence
`objdiff` command used:
```sh
build/tools/objdiff-cli diff -p . -u main/pppVertexAp -o - pppVertexAp
```
Before:
- `pppVertexAp`: **76.04124%**

After:
- `pppVertexAp`: **78.35052%**

Net improvement:
- **+2.30928%** for `pppVertexAp`

Build verification:
- `ninja` passes after the change.

## Plausibility Rationale
Changes are source-plausible and consistent with neighboring implementations (`pppVertexApLc` / `pppVertexApAt`):
- control/state access uses named control struct fields rather than opaque pointer math
- mode flow uses straightforward case dispatch
- child id sentinel check uses explicit 16-bit semantic comparison common in this codepath

No contrived temporaries or non-idiomatic compiler coaxing were introduced.
