### PR TITLE
pppLaser: fix pppDestructLaser call linkage for full match

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -7,7 +7,6 @@
 
 #include <string.h>
 
-extern void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 extern struct _pppMngSt* pppMngStPtr;
 extern CMath math;
 extern f32 FLOAT_80333428;
@@ -29,6 +28,7 @@ extern Mtx ppvCameraMatrix0;
 extern CGraphic Graphic;
 
 extern "C" {
+void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 f32 RandF__5CMathFf(f32, CMath*);
 int GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(CGame*, PPPIFPARAM*, int*, int*);
 void GetTargetCursor__5CGameFiR3VecR3Vec(CGame*, int, Vec*, Vec*);


### PR DESCRIPTION
## Summary
- Adjusted `pppHeapUseRate__FPQ27CMemory6CStage` declaration in `src/pppLaser.cpp` to use `extern "C"` linkage.
- Kept behavior unchanged; this is a symbol/linkage correction only.

## Functions Improved
- Unit: `main/pppLaser`
- Function: `pppDestructLaser`

## Match Evidence
- `pppDestructLaser`: `99.73684%` -> `100.0%`
- `main/pppLaser` `.text` match: `36.983856%` -> `36.987892%`
- `pppConstructLaser`: unchanged at `70.63095%` (no incidental regression)

## Plausibility Rationale
- The called symbol name is already in Metrowerks-mangled form, so C linkage is the plausible original declaration form in this codebase.
- This avoids re-mangling at compile time and aligns the relocation target without introducing control-flow or algorithmic changes.

## Technical Details
- Before change, objdiff showed a single remaining mismatch in `pppDestructLaser`:
  - `DIFF_ARG_MISMATCH` at the `bl pppHeapUseRate__FPQ27CMemory6CStage` call.
- After change, objdiff reports no instruction diffs for `pppDestructLaser`.
- Verified with `ninja` build and symbol diff via:
  - `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppDestructLaser`
