### PR TITLE
p_light: implement CLightPcs::SetBit32 first pass

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -636,12 +636,46 @@ void setchanctrl(CLightPcs::TARGET, unsigned long)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80048ef8
+ * PAL Size: 232b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CLightPcs::SetBit32(CLightPcs::TARGET, unsigned long*)
+void CLightPcs::SetBit32(CLightPcs::TARGET target, unsigned long* bitPattern)
 {
-	// TODO
+    char* lightPcs = (char*)this;
+    char* bumpSlot = lightPcs + 0x63c;
+    char* enable = bumpSlot + (int)target + 0x60;
+    u32 i = 0;
+    u32 colorTemp[4];
+
+    *(u32*)(lightPcs + 0xb0) = 0;
+    *(u32*)(lightPcs + 0xb4) = 0;
+
+    do {
+        if (*(u32*)(lightPcs + 0xb8) <= i) {
+            return;
+        }
+
+        if ((*enable != '\0') && (((1 << (i & 0x1f)) & bitPattern[i >> 5]) != 0)) {
+            colorTemp[0] = *(u32*)(bumpSlot + 0x50 + ((int)target * 4));
+            GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c), *(_GXColor*)&colorTemp[0]);
+            GXLoadLightObjImm((GXLightObj*)(bumpSlot + 0x6c), (GXLightID)(1 << *(u32*)(lightPcs + 0xb0)));
+
+            *(u32*)(lightPcs + 0xb4) |= 1 << *(u32*)(lightPcs + 0xb0);
+            *(u32*)(lightPcs + 0xb0) += 1;
+
+            if (*(u32*)(lightPcs + 0xb0) > 7) {
+                return;
+            }
+        }
+
+        i++;
+        bumpSlot += 0xb0;
+        enable += 0xb0;
+    } while (true);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::SetBit32(CLightPcs::TARGET, unsigned long*)` in `src/p_light.cpp` from decomp/symbol context.
- Added the PAL function metadata header for the updated function.
- Kept the existing source style used by nearby `p_light` functions (offset-based member access, GX light object setup).

## Functions Improved
- Unit: `main/p_light`
- Function: `SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl`

## Match Evidence
- `SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl`: **1.7241379% -> 72.12069%**
- `main/p_light` unit fuzzy match: **32.63592% -> 34.28762%**
- Size parity for function body remains unresolved (`left: 232`, `right: 248`), but instruction-level alignment improved substantially.

## Plausibility Rationale
- The implementation follows expected original behavior: iterate active light slots, test bitmask membership, initialize/load GX lights, and accumulate active light bits with the same cutoff behavior (`> 7`).
- Changes are type/control-flow corrections and completion of a TODO body, not compiler-only coercion.

## Technical Notes
- Refined loop/addressing to match observed assembly patterns: per-slot pointer walk, signed enabled-byte check, bitfield test by index, and early returns at slot bound/light-count limit.
- Build verified via `ninja` after change.
