### PR TITLE
system: improve __sinit_system_cpp initialization match

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -39,8 +39,6 @@ CSystem System;
  */
 CSystem::CSystem()
 {
-    volatile void** base = (volatile void**)this;
-    *base = __vt__7CSystem;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Simplified `CSystem::CSystem()` by removing the manual volatile vtable write.
- Let Metrowerks emit the normal C++ ctor vtable path for global `System` initialization.

## Functions Improved
- Unit: `main/system`
- Function: `__sinit_system_cpp`
  - Before: `21.25%` (`build/GCCP01/report.json` before change)
  - After: `100.0%` in report / `98.75%` symbol-level objdiff

## Match Evidence
- Unit fuzzy match improved:
  - Before: `72.558304%`
  - After: `73.18083%`
- Symbol diff (`build/tools/objdiff-cli diff -p . -u main/system -o - __sinit_system_cpp`):
  - Size now matches at `32` bytes.
  - Remaining delta is limited to relocation-symbol arg mismatches (`lbl_801E8884@ha/@l`), with no structural control-flow mismatch.

## Plausibility Rationale
- Removing a forced volatile vtable store is more plausible original source than manually coercing vptr writes.
- The new code relies on standard C++ ctor semantics for base/derived vtable setup, which aligns with typical Metrowerks-generated initialization for global objects.

## Technical Details
- Only source edit: `src/system.cpp` constructor body.
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/system -o - __sinit_system_cpp`
