### PR TITLE
p_gba: align CGbaPcs::create execParam compare codegen

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -112,7 +112,7 @@ void CGbaPcs::create()
 	m_stage = Memory.CreateStage(0x56000, lbl_80330870, 0);
 	Joybus.CreateInit();
 	int result = Joybus.LoadBin();
-	if ((result != 0) && (1 < (unsigned int)System.m_execParam)) {
+	if ((result != 0) && (2 <= (unsigned int)System.m_execParam)) {
 		System.Printf(lbl_801D9DE0);
 	}
 	Joybus.ThreadInit();


### PR DESCRIPTION
## Summary
- Updated the `CGbaPcs::create()` threshold check in `src/p_gba.cpp` from `1 < (unsigned int)System.m_execParam` to `2 <= (unsigned int)System.m_execParam`.
- This keeps behavior identical while steering codegen toward the target compare/branch form.

## Functions improved
- Unit: `main/p_gba`
- Symbol: `create__7CGbaPcsFv`
- Match: **96.07692% -> 96.23077%**

## Match evidence
- Baseline: `build/tools/objdiff-cli diff -p . -u main/p_gba -o - create__7CGbaPcsFv`
- After change: same command
- Notable alignment improvement: compare sequence now emits `cmplwi r0, 0x2` + `blt`, which is closer to target than prior `cmplwi r0, 0x1` + `ble`.

## Plausibility rationale
- `2 <= execParam` is idiomatic and equivalent to the original condition.
- No compiler-coaxing temporaries, no unsafe casts, and no readability regression.

## Technical details
- The update narrows one remaining conditional codegen discrepancy in `create__7CGbaPcsFv` while preserving existing control flow and side effects.
- No other source files were modified.
