### PR TITLE
cflat_r2system: add IsAbsolute__10CCameraPcsFv

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1465,6 +1465,20 @@ extern "C" void __as__3VecFRC3Vec(Vec* self, const Vec* other)
 
 /*
  * --INFO--
+ * PAL Address: 0x800B9C7C
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" int IsAbsolute__10CCameraPcsFv(void* camera)
+{
+    return *(int*)((char*)camera + 0x444);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- add missing `IsAbsolute__10CCameraPcsFv` in `src/cflat_r2system.cpp`
- implement as a direct camera flag accessor at offset `0x444`
- include standard `--INFO--` metadata block with PAL address/size

## Functions Improved
- Unit: `main/cflat_r2system`
- Symbol: `IsAbsolute__10CCameraPcsFv`
- Before: `0.0%` (from `tools/agent_select_target.py` target list)
- After: `100.0%` (`objdiff-cli diff` symbol match)
- Size: `8b`

## Match Evidence
- Build: `ninja` succeeds
- `objdiff` command:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - IsAbsolute__10CCameraPcsFv`
- Extracted result:
  - `name: IsAbsolute__10CCameraPcsFv`
  - `match_percent: 100.0`
  - `size: 8`

## Plausibility Rationale
- This is a minimal getter mirroring existing offset-based camera accessors already present in this unit.
- The implementation is straightforward, readable source that matches expected engine coding style, not compiler-coaxing.

## Technical Details
- Added:
  - `extern "C" int IsAbsolute__10CCameraPcsFv(void* camera) { return *(int*)((char*)camera + 0x444); }`
- Placed near adjacent camera helper wrappers in the PAL 0x800B9Cxx region.