### PR TITLE
Improve p_gba __sinit_p_gba_cpp match

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -28,24 +28,25 @@ extern "C" unsigned int lbl_8020F328[];
  */
 extern "C" void __sinit_p_gba_cpp(void)
 {
-	volatile void** base = reinterpret_cast<volatile void**>(&GbaPcs);
-	*base = __vt__8CManager;
-	*base = lbl_801E8668;
-	*base = lbl_8020F4A4;
+	*reinterpret_cast<void**>(&GbaPcs) = __vt__8CManager;
+	*reinterpret_cast<void**>(&GbaPcs) = lbl_801E8668;
 
-	unsigned int* dst = lbl_8020F328;
-	dst[0x004 / 4] = lbl_8020F2F8[0];
-	dst[0x008 / 4] = lbl_8020F2F8[1];
-	dst[0x00C / 4] = lbl_8020F2F8[2];
-	dst[0x010 / 4] = lbl_8020F304[0];
-	dst[0x014 / 4] = lbl_8020F304[1];
-	dst[0x018 / 4] = lbl_8020F304[2];
-	dst[0x01C / 4] = lbl_8020F310[0];
-	dst[0x020 / 4] = lbl_8020F310[1];
-	dst[0x024 / 4] = lbl_8020F310[2];
-	dst[0x030 / 4] = lbl_8020F31C[0];
-	dst[0x034 / 4] = lbl_8020F31C[1];
-	dst[0x038 / 4] = lbl_8020F31C[2];
+	unsigned int* table = lbl_8020F328;
+	table[4] = lbl_8020F304[0];
+
+	*reinterpret_cast<void**>(&GbaPcs) = lbl_8020F4A4;
+
+	table[1] = lbl_8020F2F8[0];
+	table[2] = lbl_8020F2F8[1];
+	table[3] = lbl_8020F2F8[2];
+	table[5] = lbl_8020F304[1];
+	table[6] = lbl_8020F304[2];
+	table[7] = lbl_8020F310[0];
+	table[8] = lbl_8020F310[1];
+	table[9] = lbl_8020F310[2];
+	table[12] = lbl_8020F31C[0];
+	table[13] = lbl_8020F31C[1];
+	table[14] = lbl_8020F31C[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked __sinit_p_gba_cpp in src/p_gba.cpp to use direct global writes and explicit table slot assignments in a canonical __sinit style.
- Removed volatile pointer usage and reordered assignments to better reflect compiler-emitted initialization flow.
- Kept behavior unchanged: same three GbaPcs vtable-stage writes and same copied function-table entries.

## Functions improved
- Unit: main/p_gba
- Symbol: __sinit_p_gba_cpp (PAL 0x800979f4, 212b)
- Match: 66.528305% -> 75.13207% (+8.603765)

## Match evidence
- Baseline command: build/tools/objdiff-cli diff -p . -u main/p_gba -o - __sinit_p_gba_cpp
- After change: same command, with improved symbol match percentage above.
- ninja build passes after the edit.

## Plausibility rationale
- The updated source is consistent with existing project patterns for static init routines (for example, table slot writes used in other __sinit_* functions).
- Changes are type/ordering cleanup rather than contrived assembly coaxing: no opaque temporaries, no magic pointer arithmetic beyond existing table indexing semantics.

## Technical notes
- Main impact came from assignment ordering and removal of volatile-driven codegen differences.
- The function still performs the same data movement across lbl_8020F2F8/lbl_8020F304/lbl_8020F310/lbl_8020F31C into lbl_8020F328.
