### PR TITLE
main/chara_anim: improve CAnim ctor match by correcting flag-byte offset

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -136,8 +136,8 @@ CChara::CAnim::CAnim()
 	*(unsigned short*)(p + 0xE) = 0;
 	*(int*)(p + 0x14) = 0;
 	*(void**)(p + 0x20) = 0;
-	p[9] = (unsigned char)((p[9] & 0x7F) | 0x80);
-	p[9] = (unsigned char)(p[9] & 0xBF);
+	p[8] = (unsigned char)((p[8] & 0x7F) | 0x80);
+	p[8] = (unsigned char)(p[8] & 0xBF);
 	p[0xA] = 5;
 	p[0xB] = 0xB;
 	p[0xC] = 10;


### PR DESCRIPTION
## Summary
- Adjusted `CChara::CAnim::CAnim()` flag-bit initialization to operate on byte offset `0x8` instead of `0x9`.
- Kept the rest of constructor initialization order and behavior unchanged.

## Functions improved
- Unit: `main/chara_anim`
- Symbol: `__ct__Q26CChara5CAnimFv` (`CChara::CAnim::CAnim()`)

## Match evidence
- `objdiff` before: **85.6579%**
- `objdiff` after: **85.76316%**
- Net: **+0.10526%** for this symbol

Additional signal from diff kinds in this symbol:
- `DIFF_ARG_MISMATCH`: 16 -> 12

## Plausibility rationale
- `CAnim` derives from `CRef`, so the first derived-class byte field starts at offset `0x8`.
- Applying the flag mask at `0x8` is consistent with that layout and with nearby constructor field initialization, so this is a source-plausible fix rather than compiler coaxing.

## Technical details
- Change is limited to two lines in `src/chara_anim.cpp` in `CChara::CAnim::CAnim()`.
- Verified with full `ninja` build and symbol-level `objdiff` (`build/tools/objdiff-cli diff -p . -u main/chara_anim -o - __ct__Q26CChara5CAnimFv`).
