### PR TITLE
materialman: decompile CMaterial ctor/dtor

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -664,6 +664,60 @@ CTexScroll::CTexScroll()
 
 /*
  * --INFO--
+ * PAL Address: 0x8003dc38
+ * PAL Size: 220b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CMaterial::~CMaterial()
+{
+    *reinterpret_cast<void**>(this) = __vt__9CMaterial;
+
+    int numTexture = static_cast<int>(*reinterpret_cast<unsigned short*>(Ptr(this, 0x18)));
+    for (int i = 0; i < numTexture; i++) {
+        unsigned char* textureRef = Ptr(this, 0x3C + (i << 2));
+        ReleaseRef(*reinterpret_cast<void**>(textureRef));
+        *reinterpret_cast<void**>(textureRef) = 0;
+    }
+
+    __destroy_arr(Ptr(this, 0x4C), (void*)__dt__10CTexScrollFv, 0x14, 4);
+    __dt__4CRefFv(this, 0);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8003dd14
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CMaterial::CMaterial()
+{
+    __ct__4CRefFv(this);
+    *reinterpret_cast<void**>(this) = __vt__9CMaterial;
+    __construct_array(Ptr(this, 0x4C), __ct__10CTexScrollFv, __dt__10CTexScrollFv, 0x14, 4);
+    memset(Ptr(this, 0x8C), 0, 0x10);
+    *reinterpret_cast<int*>(Ptr(this, 0x9C)) = -1;
+    *Ptr(this, 0xA0) = 4;
+    *Ptr(this, 0xA1) = 1;
+    *Ptr(this, 0xA2) = 0;
+    *Ptr(this, 0xA4) = 0;
+    *reinterpret_cast<void**>(Ptr(this, 0x3C)) = 0;
+    *reinterpret_cast<void**>(Ptr(this, 0x40)) = 0;
+    *reinterpret_cast<void**>(Ptr(this, 0x44)) = 0;
+    *reinterpret_cast<void**>(Ptr(this, 0x48)) = 0;
+    *Ptr(this, 0x34) = 0;
+    *Ptr(this, 0x35) = 0;
+    *Ptr(this, 0x36) = 0;
+    *Ptr(this, 0xA5) = 0;
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Implemented `CMaterial::CMaterial()` and `CMaterial::~CMaterial()` in `src/materialman.cpp` using existing file conventions (`Ptr(...)` raw offsets, refcount release path, and runtime array ctor/dtor helpers).
- Added `--INFO--` PAL metadata blocks for both functions.
- Kept behavior source-plausible by mirroring neighboring material setup/release patterns already used in `CMaterialSet` paths.

## Functions Improved
- Unit: `main/materialman`
- `__ct__9CMaterialFv` (176b): `null%` -> `99.97727%`
- `__dt__9CMaterialFv` (220b): `null%` -> `76.145454%`

## Match Evidence
- Build: `ninja` passes.
- `build/GCCP01/report.json` now reports concrete fuzzy matches for both symbols (previously `null%`, effectively unmatched).
- Unit-level fuzzy moved from selector baseline `10.0%` to `11.063212%`.

## Plausibility Rationale
- Constructor initializes material state exactly where the rest of the file expects it (texture refs, flags, texture scroll array, vtable, base class construction).
- Destructor releases texture references with the same refcount/vtable destructor convention already used throughout this file and destroys the `CTexScroll` array before base-class teardown.
- No contrived coercions or synthetic control flow were introduced; this is straightforward gameplay/source-style object lifecycle code.

## Technical Notes
- The constructor uses `__construct_array` for the 4-element `CTexScroll` block and applies default field values consistent with `SetPartFromTextureSet` object initialization.
- The destructor uses the existing `ReleaseRef` helper and clears texture slots after release, then calls `__destroy_arr` and `__dt__4CRefFv`.
