### PR TITLE
cflat_data: improve dtor_800980B4 loop-bound matching

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -77,7 +77,7 @@ extern "C" CFlatData* dtor_800980B4(CFlatData* flatData, short shouldDelete)
 	if (flatData != nullptr)
 	{
 		pCVar1 = (FlatDataLayout*)flatData;
-		for (iVar2 = 0; iVar2 < pCVar1->m_dataCount; iVar2++)
+		for (iVar2 = 0; iVar2 < ((FlatDataLayout*)flatData)->m_dataCount; iVar2++)
 		{
 			if (pCVar1->m_data[0].m_data != nullptr)
 			{


### PR DESCRIPTION
## Summary
- Adjusted `dtor_800980B4` first cleanup loop condition to read the loop bound from `flatData` directly instead of the advancing cursor pointer.
- Kept behavior unchanged; this only affects codegen shape for the deleting-destructor wrapper.

## Functions improved
- Unit: `main/cflat_data`
- Symbol: `dtor_800980B4` (`CFlatData* dtor_800980B4(CFlatData*, short)`)

## Match evidence
- `dtor_800980B4`: **94.178085% -> 94.246574%** (`build/tools/objdiff-cli diff -p . -u main/cflat_data -o - dtor_800980B4`)
- Diff-kind counts for this symbol:
  - `DIFF_ARG_MISMATCH`: **18 -> 17**
  - `DIFF_INSERT`: 2 -> 2
  - `DIFF_REPLACE`: 2 -> 2
- `Create__9CFlatDataFPv` was checked for regression and remained unchanged at **57.459282%**.

## Plausibility rationale
- This is source-plausible cleanup-loop logic: the loop counter naturally compares against the owning object's stable count field (`flatData->m_dataCount`) rather than a cursor pointer that is intentionally advanced through entry storage.
- No contrived temporaries or compiler-only tricks were introduced.

## Technical details
- The function uses a cursor-like `FlatDataLayout*` to walk entry slots by fixed stride.
- Reading the bound from `flatData` stabilizes loop-bound codegen and removed one argument-level instruction mismatch in objdiff while preserving function size and control flow.
