### PR TITLE
memory: implement CAmemCacheSet::DestroyCache

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -791,12 +791,40 @@ void CAmemCacheSet::Destroy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001D468
+ * PAL Size: 576b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CAmemCacheSet::DestroyCache(int)
+void CAmemCacheSet::DestroyCache(int index)
 {
-	// TODO
+    unsigned char* bytes = reinterpret_cast<unsigned char*>(this);
+    unsigned char* entry =
+        reinterpret_cast<unsigned char*>(*reinterpret_cast<int*>(bytes + 0x58) + index * 0x1C);
+    int cacheData = *reinterpret_cast<int*>(entry + 0x00);
+    int workData = *reinterpret_cast<int*>(entry + 0x04);
+
+    if (entry[0x1A] == 0) {
+        if (workData != 0) {
+            operator delete(reinterpret_cast<void*>(workData));
+        }
+        *reinterpret_cast<int*>(entry + 0x00) = 0;
+        *reinterpret_cast<int*>(entry + 0x04) = 0;
+    } else {
+        if (cacheData != 0) {
+            operator delete(reinterpret_cast<void*>(cacheData));
+            *reinterpret_cast<int*>(entry + 0x00) = 0;
+        }
+        if (workData != 0) {
+            *reinterpret_cast<int*>(entry + 0x04) = 0;
+        }
+    }
+
+    *reinterpret_cast<unsigned short*>(entry + 0x18) = 0;
+    *reinterpret_cast<unsigned short*>(entry + 0x0C) = 0;
+    entry[0x0E] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CAmemCacheSet::DestroyCache(int)` in `src/memory.cpp` (previously a TODO stub).
- Added PAL metadata block for the function (`0x8001D468`, `576b`) using the project function documentation format.
- Implemented cache-entry cleanup for both paths (`entry[0x1A] == 0` and DMA-backed path), including freeing the correct buffer and resetting state fields.

## Functions improved
- Unit: `main/memory`
- Symbol: `DestroyCache__13CAmemCacheSetFi`

## Match evidence
- Before: `0.7%` (from `tools/agent_select_target.py` output for `main/memory` target list)
- After: `66.083336%` (from `build/GCCP01/report.json`, `fuzzy_match_percent` for `DestroyCache__13CAmemCacheSetFi`)
- Build status: `ninja` passes.

## Plausibility rationale
- The implementation follows the existing memory manager semantics already used in this unit (`operator delete` path with block-header validation/merge behavior).
- Field updates match expected cache-entry lifecycle behavior: clear active data pointers, reset ref/checksum fields, and clear enable flag.
- No coercive compiler tricks were introduced; code remains readable and consistent with current source style.

## Technical details
- Addressed both storage modes indicated by entry flag at offset `0x1A`:
  - CPU-allocated data path frees `workData` (`+0x04`) and clears both data pointers.
  - Alternate path frees `cacheData` (`+0x00`) and clears pointer slots.
- Final state reset mirrors expected teardown fields (`+0x18`, `+0x0C`, `+0x0E`).
- Used objdiff unit diff generation during validation (`build/tools/objdiff-cli diff -p . -u main/memory -o - DestroyCache__13CAmemCacheSetFi`).
