### PR TITLE
RedDriver: implement _MusicPlaySequence

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -177,12 +177,39 @@ void _MusicStop(int* param_1)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bd0f4
+ * PAL Size: 264b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _MusicPlaySequence(int*)
+void _MusicPlaySequence(int* param_1)
 {
-	// TODO
+    int iVar1;
+    int srcBuffer;
+
+    srcBuffer = (int)DAT_8032f3f0;
+    if ((((*param_1 != *(int*)(srcBuffer + 0x470)) &&
+          (*param_1 != *(int*)(srcBuffer + 0x904))) &&
+         (*param_1 != *(int*)(srcBuffer + 0xd98))) &&
+        ((iVar1 = SearchMusicSequence__9CRedEntryFi(&DAT_8032e154, *param_1)), -1 < iVar1)) {
+        iVar1 = param_1[2];
+        if (*(int*)(srcBuffer + 0x470) != -1) {
+            if (*(int*)(srcBuffer + 0x904) != -1) {
+                MusicStop__Fi(*(int*)(srcBuffer + 0x904));
+            }
+            if (iVar1 == 0) {
+                iVar1 = *(int*)((int)DAT_8032f418 + *param_1 * 4);
+                *(int*)((int)DAT_8032f418 + *param_1 * 4) = 0;
+            }
+            if (iVar1 == 0) {
+                memcpy((void*)(srcBuffer + 0x494), (void*)srcBuffer, 0x494);
+                *(int*)(srcBuffer + 0x470) = -1;
+            }
+        }
+        MusicPlay__Fiii(*param_1, param_1[1], iVar1);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `_MusicPlaySequence__FPi` in `src/RedSound/RedDriver.cpp` using the current PAL decompilation structure already used by neighboring RedDriver command handlers.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `_MusicPlaySequence__FPi`
- Size: 264 bytes (PAL reference)

## Match evidence
- Before: `1.52%` (`objdiff-cli diff -p . -u main/RedSound/RedDriver _MusicPlaySequence__FPi`)
- After: `80.12%` (same command after patch)
- Improvement is instruction-level and not cosmetic: the function now emits the expected control flow for sequence checks, fallback flag fetch/reset, buffer copy, and final `MusicPlay__Fiii` call.

## Plausibility rationale
The resulting code matches the surrounding file's style and semantics:
- Uses existing global buffers/entry APIs already used throughout `RedDriver.cpp`
- Preserves readable game-logic flow (reject current/queued tracks, validate sequence, resolve fallback state, then play)
- Avoids compiler-coaxing constructs and keeps straightforward C-style logic consistent with this compilation unit

## Technical details
- Added full `--INFO--` metadata block for the function:
  - PAL Address: `0x801bd0f4`
  - PAL Size: `264b`
- Replaced a TODO stub with concrete logic that aligns with the decomp-guided branch and memory-update ordering.
