### PR TITLE
memorycard: restore Init/Quit stage lifecycle in CMemoryCardMan

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/memorycard.h"
 #include "ffcc/file.h"
 #include "ffcc/math.h"
+#include "ffcc/memory.h"
 #include "ffcc/sound.h"
 #include "ffcc/system.h"
 
@@ -70,8 +71,12 @@ CMemoryCardMan::CMemoryCardMan()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c4d24
+ * PAL Size: 148b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemoryCardMan::Init()
 {
@@ -82,17 +87,20 @@ void CMemoryCardMan::Init()
     m_currentSlot = -1;
     m_state = 0;
     m_saveBuffer = (char*)nullptr;
-
-    // m_stage = Memory.CreateStage(0x16000, s_CMemoryCardMan_801dae0c, 0);
-    // m_mountWorkArea = __nwa__(0xA000,  mStage, s_memorycard_cpp_801daea8, 0x88);
+    m_stage = reinterpret_cast<CStage*>(Memory.CreateStage(0x16000, (char*)"CMemoryCardMan", 0));
+    m_mountWorkArea = new (reinterpret_cast<CMemory::CStage*>(m_stage), (char*)"memorycard.cpp", 0x88) char[0xA000];
 
     m_currentSlot = -1;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800c4ccc
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemoryCardMan::Quit()
 { 
@@ -104,7 +112,7 @@ void CMemoryCardMan::Quit()
     m_mountWorkArea = (void*)nullptr;
   }
   
-  // DestroyStage__7CMemoryFPQ27CMemory6CStage(&Memory,mStage);
+  Memory.DestroyStage(reinterpret_cast<CMemory::CStage*>(m_stage));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Restored `CMemoryCardMan::Init()` stage setup instead of leaving it stubbed/commented.
- Restored `CMemoryCardMan::Quit()` stage teardown.
- Switched the touched function headers to the project `--INFO--` PAL/EN/JP format with PAL address/size filled.

## Functions improved
- Unit: `main/memorycard`
- `Init__14CMemoryCardManFv`: **49.2973% -> 87.5676%**
- `Quit__14CMemoryCardManFv`: **81.8182% -> 92.7273%**

## Match evidence
`objdiff-cli` (`tools/objdiff-cli diff -p . -u main/memorycard -o - <symbol>`) reports significantly higher symbol match for both functions after this change.

## Plausibility rationale
- The new code follows normal game-side memory stage lifecycle patterns already used throughout this codebase (`CreateStage` on init, `DestroyStage` on quit).
- Work-area allocation now uses stage-scoped `new[]` with file/line metadata, which is consistent with existing FFCC allocation style.
- No contrived control-flow tricks were introduced; this is straightforward source-level behavior restoration.

## Technical details
- `Init()` now:
  - creates the `CMemoryCardMan` stage (`0x16000` bytes),
  - allocates the mount work area (`0xA000`) from that stage,
  - keeps the original slot/state initialization.
- `Quit()` now destroys the stage after releasing `m_mountWorkArea`.
- Build verified with `ninja` on `GCCP01`.
