### PR TITLE
pppYmLaser: improve pppDestructYmLaser match

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -181,12 +181,12 @@ extern "C" void pppDestructYmLaser(void* pppYmLaser_, void* param_2_)
 {
 	pppYmLaser* pppYmLaser = (struct pppYmLaser*)pppYmLaser_;
 	YmLaserOffsets* param_2 = (YmLaserOffsets*)param_2_;
-	s32 dataOffset = param_2->m_serializedDataOffsets[2];
-	void* stage = *(void**)((u8*)&pppYmLaser->field_0x9c + dataOffset);
+	f32* work = (f32*)((u8*)pppYmLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
+	void* stage = *(void**)(work + 7);
 
 	if (stage != 0) {
 		pppHeapUseRate__FPQ27CMemory6CStage(stage);
-		*(void**)((u8*)&pppYmLaser->field_0x9c + dataOffset) = 0;
+		*(void**)(work + 7) = 0;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reworked `pppDestructYmLaser` to access the per-instance work area through the same base-pointer pattern used in sibling laser code (`work = base + 0x80 + offset`, then `work[7]`).
- Kept behavior identical: read allocated stage pointer, call `pppHeapUseRate__FPQ27CMemory6CStage`, then clear the pointer.

## Functions Improved
- Unit: `main/pppYmLaser`
- Function: `pppDestructYmLaser`
  - Before: `88.789474%`
  - After: `94.684210%`

## Match Evidence
- Unit `main/pppYmLaser` fuzzy match:
  - Before: `30.918474%`
  - After: `31.015612%`
- Other functions in the unit remained unchanged in score (`pppRenderYmLaser`, `pppFrameYmLaser`, `pppConstructYmLaser`, `pppConstruct2YmLaser`).
- Verified with `ninja` and updated `build/GCCP01/report.json`.

## Plausibility Rationale
- The change removes ad-hoc field-offset pointer arithmetic and uses the same work-buffer indexing idiom already present in `pppDestructLaser`, which is more consistent with likely original source style in this particle subsystem.
- No contrived temporaries or behavior changes were introduced; this is a representation-level cleanup that improves code generation alignment.

## Technical Notes
- Edited location: `src/pppYmLaser.cpp` in `pppDestructYmLaser`.
- Key adjustment:
  - from: `*(void**)((u8*)&pppYmLaser->field_0x9c + dataOffset)`
  - to: `f32* work = (f32*)((u8*)pppYmLaser + 0x80 + dataOffset); *(void**)(work + 7)`
