### PR TITLE
RedDriver: implement RedDmaEntry and GetMyEntryID

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -35,7 +35,7 @@ void _StreamPause(int*);
 void _EntryExecCommand(void (*)(int*), int, int, int, int, int, int, int);
 void _ExecuteCommand();
 unsigned int DeltaTimeSumup(unsigned char**);
-void GetMyEntryID();
+unsigned int GetMyEntryID();
 void _MyAlarmHandler(OSAlarm*, OSContext*);
 void RedSleep(int);
 int _MainThread(void*);


### PR DESCRIPTION
## Summary
- Implemented `RedDmaEntry__FiiiiiPFPv_vPv` in `src/RedSound/RedDriver.cpp` using the DMA ring-buffer enqueue flow already used by this unit.
- Implemented `GetMyEntryID__Fv` as a monotonic 31-bit wrapped ID generator and updated its header signature to return `unsigned int`.
- Added the missing `DAT_8032f3bc` extern and updated function info block for `RedDmaEntry` with PAL address/size metadata.

## Functions Improved
- `RedDmaEntry__FiiiiiPFPv_vPv` (`main/RedSound/RedDriver`, 356b)
- `GetMyEntryID__Fv` (`main/RedSound/RedDriver`, 56b)

## Match Evidence
- `RedDmaEntry__FiiiiiPFPv_vPv`: **1.573% -> 33.427%** (`build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - RedDmaEntry__FiiiiiPFPv_vPv`)
- Unit `.text` currently reports `37.324%` match in objdiff output for `main/RedSound/RedDriver`.

## Plausibility Rationale
- The implementation uses straightforward ring-buffer entry writes, chunk splitting for large DMA transfers, and callback placement on final chunk only, which is consistent with typical production DMA queue code.
- The `GetMyEntryID` change restores an ID allocator pattern (increment, mask, skip zero) rather than introducing compiler-coaxing constructs.
- No hardcoded object offsets or contrived temporaries were introduced beyond queue entry field assignment needed by existing data layout.

## Technical Details
- Preserved interrupt critical section boundaries: `OSDisableInterrupts` around queue writes, `OSSignalSemaphore` before `OSRestoreInterrupts`.
- Implemented both enqueue modes:
  - Single-entry enqueue when chunking is not required.
  - Multi-entry enqueue with `0x40000` max chunk size and callback only on last chunk.
- Ring pointer wrap logic uses existing buffer bounds (`base + 0x380` entries) for both DMA queues.
