### PR TITLE
main/pad: improve CPad::Init replay frame math match

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -98,8 +98,7 @@ void CPad::Init()
 				fclose(fp);
 				*reinterpret_cast<unsigned int*>(_1b0_4_ + 4) = 0;
 				frames = *reinterpret_cast<int*>(_1b0_4_ + 8);
-				frames = frames / 0x1E + (frames >> 0x1F);
-				System.Printf((char*)"replay frames=%d\n", frames - (frames >> 0x1F));
+				System.Printf((char*)"replay frames=%d\n", frames / 30);
 			}
 			else
 			{


### PR DESCRIPTION
## Summary
- Updated `CPad::Init` replay logging math in `src/pad.cpp` to use direct signed division (`frames / 30`) instead of manual sign-correction arithmetic.
- Kept behavior equivalent for signed frame counts while producing codegen closer to the target object.

## Functions improved
- Unit: `main/pad`
- Symbol: `Init__4CPadFv`

## Match evidence
- `Init__4CPadFv`: **92.68269% -> 97.50000%**
- Instruction diffs: **26 -> 11**
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pad -o - Init__4CPadFv`

## Plausibility rationale
- Direct `/ 30` frame-to-seconds style logging is simpler and more natural source than manually reconstructed sign-bit adjustment.
- The change removes compiler-coaxing style arithmetic and aligns with likely original intent while improving assembly match.

## Technical notes
- The improved sequence now matches expected signed-division lowering (magic multiply/shift) in this build configuration.
- `ninja` build passes after the change.
