### PR TITLE
cflat_runtime2: implement object pool lookup TODOs

### DIFF
--- a/include/ffcc/cflat_runtime2.h
+++ b/include/ffcc/cflat_runtime2.h
@@ -31,9 +31,9 @@ class CFlatRuntime2
 	void onNewObject(CFlatRuntime::CObject*);
 	void onDeleteObject(CFlatRuntime::CObject*);
 
-	void getNumFreeObject(int);
-	void getFreeObject(int);
-	void intToClass(int);
+	unsigned int getNumFreeObject(int);
+	CGObject* getFreeObject(int);
+	void* intToClass(int);
 
 	void Frame(int, int);
 	void Load(char*);

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -556,32 +556,161 @@ void CFlatRuntime2::onDeleteObject(CFlatRuntime::CObject* object)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006DA68
+ * PAL Size: 1452b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::getNumFreeObject(int)
+unsigned int CFlatRuntime2::getNumFreeObject(int classType)
 {
-	// TODO
+	unsigned int count = 0;
+	unsigned char* objects;
+	int stride;
+	int objectCount;
+
+	if (classType == 3) {
+		objects = m_objParty;
+		stride = 0x6F8;
+		objectCount = 4;
+	} else if (classType < 3) {
+		if (classType == 1) {
+			objects = CFlat + 0x110C0;
+			stride = 0xAC;
+			objectCount = 0x18;
+		} else if (classType < 1) {
+			if (classType < 0) {
+				return 0;
+			}
+			objects = CFlat + 0x10440;
+			stride = 0x50;
+			objectCount = 0x28;
+		} else {
+			objects = CFlat + 0x120E0;
+			stride = 0x518;
+			objectCount = 0x38;
+		}
+	} else if (classType == 5) {
+		objects = m_objItem;
+		stride = 0x57C;
+		objectCount = 0x20;
+	} else if (classType < 5) {
+		objects = m_objMon;
+		stride = 0x740;
+		objectCount = 0x40;
+	} else {
+		return 0;
+	}
+
+	for (int i = 0; i < objectCount; i++) {
+		if (*reinterpret_cast<signed char*>(objects + 0x4C) >= 0) {
+			count++;
+		}
+		objects += stride;
+	}
+
+	return count;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006D868
+ * PAL Size: 512b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::getFreeObject(int)
+CGObject* CFlatRuntime2::getFreeObject(int classType)
 {
-	// TODO
+	unsigned char* objects;
+	int stride;
+	int objectCount;
+
+	if (classType == 3) {
+		objects = m_objParty;
+		stride = 0x6F8;
+		objectCount = 4;
+	} else if (classType < 3) {
+		if (classType == 1) {
+			objects = CFlat + 0x110C0;
+			stride = 0xAC;
+			objectCount = 0x18;
+		} else if (classType < 1) {
+			if (classType < 0) {
+				return 0;
+			}
+			objects = CFlat + 0x10440;
+			stride = 0x50;
+			objectCount = 0x28;
+		} else {
+			objects = CFlat + 0x120E0;
+			stride = 0x518;
+			objectCount = 0x38;
+		}
+	} else if (classType == 5) {
+		objects = m_objItem;
+		stride = 0x57C;
+		objectCount = 0x20;
+	} else if (classType < 5) {
+		objects = m_objMon;
+		stride = 0x740;
+		objectCount = 0x40;
+	} else {
+		return 0;
+	}
+
+	for (int i = 0; i < objectCount; i++) {
+		if (*reinterpret_cast<signed char*>(objects + 0x4C) >= 0) {
+			return reinterpret_cast<CGObject*>(objects);
+		}
+		objects += stride;
+	}
+
+	return 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006D79C
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::intToClass(int)
+void* CFlatRuntime2::intToClass(int classId)
 {
-	// TODO
+	const int classType = classId >> 8;
+	const unsigned int objectIndex = static_cast<unsigned int>(classId) & 0xFF;
+	const int slot = static_cast<int>(objectIndex) - 1;
+
+	if (classType == 3) {
+		return m_objParty + slot * 0x6F8;
+	}
+
+	if (classType > 2) {
+		if (classType == 5) {
+			return m_objItem + slot * 0x57C;
+		}
+		if (classType > 4) {
+			return this;
+		}
+		return m_objMon + slot * 0x740;
+	}
+
+	if (classType == 1) {
+		return CFlat + 0x110C0 + slot * 0xAC;
+	}
+	if (classType < 1) {
+		if (classType < 0) {
+			return this;
+		}
+		return CFlat + 0x10440 + slot * 0x50;
+	}
+
+	return CFlat + 0x120E0 + slot * 0x518;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three `CFlatRuntime2` TODO methods using the existing runtime object-pool layout and corrected their declaration return types:
- `getNumFreeObject(int)`
- `getFreeObject(int)`
- `intToClass(int)`

Also added PAL address/size metadata blocks for these functions.

## Functions improved
Unit: `main/cflat_runtime2`
- `intToClass__13CFlatRuntime2Fi`
- `getFreeObject__13CFlatRuntime2Fi`
- `getNumFreeObject__13CFlatRuntime2Fi`

## Match evidence (objdiff)
- `intToClass__13CFlatRuntime2Fi`: **1.9607843% -> 26.588236%**
- `getFreeObject__13CFlatRuntime2Fi`: **0.78125% -> 32.78125%**
- `getNumFreeObject__13CFlatRuntime2Fi`: **0.2754821% -> 11.071626%**

Measured with:
`build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - <symbol>`

## Plausibility rationale
These changes model the runtime object pools exactly as initialized in `CFlatRuntime2` construction (`__construct_array` sizes/strides already present in this module), and perform straightforward active-slot scans / class-id-to-pool mapping. The implementation avoids compiler-coaxing patterns and matches expected engine behavior for selecting active/free objects by class.

## Technical details
- Mapped class IDs using high-byte class type and low-byte slot index (`classId >> 8`, `classId & 0xFF`).
- Used existing pool locations/strides from this translation unit:
  - base objects: `CFlat + 0x10440`, stride `0x50`
  - quad objects: `CFlat + 0x110C0`, stride `0xAC`
  - objects: `CFlat + 0x120E0`, stride `0x518`
  - party: `m_objParty`, stride `0x6F8`
  - item: `m_objItem`, stride `0x57C`
  - mon: `m_objMon`, stride `0x740`
- Active-state checks use the object flag byte at offset `0x4C` as in surrounding decomp patterns.
