### PR TITLE
main/gx/GXTransform: improve GXSetProjection decomp match

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -79,33 +79,31 @@ void __GXSetProjection(void) {
 }
 
 void GXSetProjection(const Mtx44 mtx, GXProjectionType type) {
-    GXData* gx = __GXData;
-
     CHECK_GXBEGIN(295, "GXSetProjection");
 
-    gx->projType = type;
-    gx->projMtx[0] = mtx[0][0];
-    gx->projMtx[2] = mtx[1][1];
-    gx->projMtx[4] = mtx[2][2];
-    gx->projMtx[5] = mtx[2][3];
+    __GXData->projType = type;
+    __GXData->projMtx[0] = mtx[0][0];
+    __GXData->projMtx[2] = mtx[1][1];
+    __GXData->projMtx[4] = mtx[2][2];
+    __GXData->projMtx[5] = mtx[2][3];
     if (type == GX_ORTHOGRAPHIC) {
-        gx->projMtx[1] = mtx[0][3];
-        gx->projMtx[3] = mtx[1][3];
+        __GXData->projMtx[1] = mtx[0][3];
+        __GXData->projMtx[3] = mtx[1][3];
     } else {
-        gx->projMtx[1] = mtx[0][2];
-        gx->projMtx[3] = mtx[1][2];
+        __GXData->projMtx[1] = mtx[0][2];
+        __GXData->projMtx[3] = mtx[1][2];
     }
 
     GX_WRITE_U8(0x10);
     GX_WRITE_U32(0x00061020);
-    GX_WRITE_F32(gx->projMtx[0]);
-    GX_WRITE_F32(gx->projMtx[1]);
-    GX_WRITE_F32(gx->projMtx[2]);
-    GX_WRITE_F32(gx->projMtx[3]);
-    GX_WRITE_F32(gx->projMtx[4]);
-    GX_WRITE_F32(gx->projMtx[5]);
-    GX_WRITE_U32(gx->projType);
-    gx->bpSentNot = 1;
+    GX_WRITE_F32(__GXData->projMtx[0]);
+    GX_WRITE_F32(__GXData->projMtx[1]);
+    GX_WRITE_F32(__GXData->projMtx[2]);
+    GX_WRITE_F32(__GXData->projMtx[3]);
+    GX_WRITE_F32(__GXData->projMtx[4]);
+    GX_WRITE_F32(__GXData->projMtx[5]);
+    GX_WRITE_U32(__GXData->projType);
+    __GXData->bpSentNot = 1;
 }
 
 void GXSetProjectionv(const f32* ptr) {


### PR DESCRIPTION
## Summary
- Reworked `GXSetProjection` in `src/gx/GXTransform.c` to use direct `__GXData` accesses instead of a local `GXData*` alias.
- Kept behavior unchanged while adjusting expression/access shape to better match PAL codegen.

## Functions Improved
- Unit: `main/gx/GXTransform`
- Symbol: `GXSetProjection` (`180b`)

## Match Evidence
Controlled A/B on the same branch using `build/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o -`:
- `GXSetProjection`: **95.31111% -> 99.422226%**
- Diff-bearing instructions in symbol: **29 -> 18**
- Unit `.text` match: **88.74187% -> 89.11789%**

No regressions in sampled neighboring symbols during the same controlled run:
- `GXProject`: 60.80645% (unchanged)
- `GXSetViewportJitter`: 77.83077% (unchanged)
- `GXSetScissorBoxOffset`: 89.6875% (unchanged)

## Plausibility Rationale
- The change is source-plausible and idiomatic for this codebase: direct global state writes through `__GXData` are already used across GX SDK wrappers.
- No contrived temporaries, control-flow distortions, or readability regressions were introduced.

## Technical Details
- Remaining differences are `DIFF_ARG_MISMATCH` on load/store operands for `gx`-backed fields; no structural insert/delete mismatches remain in this function.