### PR TITLE
pppLaser: improve pppConstruct2Laser match via base-pointer offset form

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -160,18 +160,18 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
 void pppConstruct2Laser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
     f32 fVar1 = FLOAT_80333428;
-    int iVar2 = param_2->offsets->m_serializedDataOffsets[2];
+    int iVar2 = 0x80 + param_2->offsets->m_serializedDataOffsets[2];
 
-    *(f32*)((u8*)&pppLaser->field_0x98 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0x94 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0x90 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0x8c + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0x88 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0x84 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0xa8 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0xa4 + iVar2) = fVar1;
-    *(f32*)((u8*)&pppLaser->field_0xa0 + iVar2) = fVar1;
-    *((u8*)&pppLaser->field_0xac + iVar2) = 0;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x18) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x14) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x10) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0xc) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x8) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x4) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x28) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x24) = fVar1;
+    *(f32*)((u8*)pppLaser + iVar2 + 0x20) = fVar1;
+    *((u8*)pppLaser + iVar2 + 0x2c) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppConstruct2Laser` address math to use a single base offset (`0x80 + serializedDataOffsets[2]`) and explicit field-relative writes.
- Kept behavior unchanged (same zero/clear initialization), but aligned generated code with expected object layout access patterns.

## Functions improved
- Unit: `main/pppLaser`
- Function: `pppConstruct2Laser`
- Match: `90.00%` -> `96.47059%`
- Size: `68b`

## Match evidence
- Command used: `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppConstruct2Laser`
- Before: `90.00%`
- After: `96.47059%`
- The primary alignment gain came from matching the `+0x80` base-address construction before the clustered stores.

## Plausibility rationale
- The final code is a straightforward, source-plausible expression of initialization over a serialized per-instance block.
- It improves ABI-consistent pointer arithmetic without introducing contrived temporaries or non-idiomatic ordering aimed only at compiler coercion.

## Technical details
- Converted member-address form (`&field_0x.. + offset`) to object-base form (`(u8*)pppLaser + base + literal`) to better match original access sequencing.
- Verified no regressions in nearby `pppLaser` functions from this edit via the same unit diff pass and a full `ninja` build.
