### PR TITLE
p_menu: first-pass decomp of DrawWindow

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -285,9 +285,70 @@ void CMenuPcs::DrawBar(float, float, float, CMenuPcs::TEX, float)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::DrawWindow(float, float, float, float, CMenuPcs::TEX, float)
+void CMenuPcs::DrawWindow(float x, float y, float width, float height, CMenuPcs::TEX texBase, float corner)
 {
-	// TODO
+	if (width <= 0.0f || height <= 0.0f) {
+		return;
+	}
+
+	const float twoCorner = corner * 2.0f;
+	float midW = width - twoCorner;
+	float midH = height - twoCorner;
+	float overW = twoCorner - width;
+	float overH = twoCorner - height;
+	float uOff = 0.0f;
+	float vOff = 0.0f;
+	const int tex = static_cast<int>(texBase);
+	const float xL = x;
+	const float yT = y;
+	const float xM = x + corner;
+	const float yM = y + corner;
+	const float xR = (x + width) - corner;
+	const float yB = (y + height) - corner;
+
+	if (midW < 0.0f) {
+		midW = 0.0f;
+	}
+	if (midH < 0.0f) {
+		midH = 0.0f;
+	}
+	if (overW < 0.0f) {
+		overW = 0.0f;
+	}
+	if (overH < 0.0f) {
+		overH = 0.0f;
+	}
+	if (corner > 0.0f) {
+		uOff = overW / twoCorner;
+		vOff = overH / twoCorner;
+	}
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex));
+	DrawRect(0, xL, yT, corner, corner, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 1));
+	DrawRect(0, xM, yT, midW, corner, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 2));
+	DrawRect(0, xR, yT, corner, corner, uOff, 0.0f, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 3));
+	DrawRect(0, xL, yM, corner, midH, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 4));
+	DrawRect(0, xM, yM, midW, midH, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 5));
+	DrawRect(0, xR, yM, corner, midH, uOff, 0.0f, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 6));
+	DrawRect(0, xL, yB, corner, corner, 0.0f, vOff, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 7));
+	DrawRect(0, xM, yB, midW, corner, 0.0f, vOff, 1.0f, 1.0f, 0.0f);
+
+	SetTexture(static_cast<CMenuPcs::TEX>(tex + 8));
+	DrawRect(0, xR, yB, corner, corner, uOff, vOff, 1.0f, 1.0f, 0.0f);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced the `CMenuPcs::DrawWindow` stub in `src/p_menu.cpp` with a first-pass 9-slice window renderer.
- The implementation now:
  - computes inner extents and UV offsets for small window sizes,
  - selects the 9 texture slots derived from the base `TEX` enum,
  - draws all 9 segments via existing `DrawRect` and `SetTexture` helpers.

## Functions Improved
- Unit: `main/p_menu`
- Function: `DrawWindow__8CMenuPcsFffffQ28CMenuPcs3TEXf` (size: 2544b)

## Match Evidence
- Before: `0.1572327%` (from `build/GCCP01/report.json` prior to this change)
- After: `65.636795%` (current `build/GCCP01/report.json`)
- Symbol-level objdiff (`build/tools/objdiff-cli diff -p . -u main/p_menu -o - DrawWindow__8CMenuPcsFffffQ28CMenuPcs3TEXf`):
  - `match_percent`: `65.43553`

## Plausibility Rationale
- This change replaces an empty stub with straightforward UI rendering behavior consistent with how menu windows are typically authored in this codebase (texture selection + rectangle draws).
- It uses existing class APIs (`SetTexture`, `DrawRect`) and preserves readable, maintainable source structure rather than compiler-coaxing patterns.

## Technical Notes
- This is a first-pass decomp implementation aimed at large immediate assembly alignment gain.
- Further refinement can tune constants/flow toward closer byte-level matching if needed.
