### PR TITLE
materialman: decompile CPad::GetButtonDown and CPtrArray<CMaterial> ctor

### DIFF
--- a/include/ffcc/pad.h
+++ b/include/ffcc/pad.h
@@ -17,6 +17,7 @@ public:
     void Quit();
     void Frame();
     void SaveReplayData();
+    unsigned short GetButtonDown(long);
 
     void* _0_4_;
     short _4_2_;


### PR DESCRIPTION
## Summary
- Added `CPad::GetButtonDown(long)` declaration in `include/ffcc/pad.h` and implemented it in `src/materialman.cpp`.
- Added explicit `CPtrArray<CMaterial*>::CPtrArray()` construction logic in `src/materialman.cpp` with the expected layout initialization.
- Updated local raw ptr-array helper layout to include `defaultSize`, matching the reconstructed constructor/object layout.

## Functions Improved
- Unit: `main/materialman`
- `GetButtonDown__4CPadFl` (100b): `null` -> `72.2%`
- `__ct__22CPtrArray<P9CMaterial>Fv` (52b): `null` -> `98.69231%`

## Match Evidence
- `build/GCCP01/report.json` before/after:
  - Unit `main/materialman` fuzzy match: `11.063212%` -> `11.454395%`
  - Symbol matches moved from unmatched (`null`) to non-zero fuzzy matches for both functions above.
- Rebuilt with `ninja` and verified with `build/tools/objdiff-cli diff -p . -u main/materialman ...` for both symbols.

## Plausibility Rationale
- These are direct class/API-level fixes that restore likely original source structure:
  - `CPad::GetButtonDown(long)` is a natural member API used by menu/material code.
  - `CPtrArray<CMaterial*>::CPtrArray()` initialization uses expected fields (`size`, `numItems`, `defaultSize`, `items`, `stage`, `growCapacity`) and the class vtable slot.
- No contrived compiler-coaxing temporaries or unnatural control-flow tricks were introduced.

## Technical Details
- `GetButtonDown` now follows the original guard+index clamp pattern and reads the per-pad button state from the expected stride.
- `CPtrArray<CMaterial*>::CPtrArray()` now materializes as an out-of-line symbol with constructor-style initialization, enabling symbol-level matching instead of remaining unmatched.
