### PR TITLE
mapanim: improve CMapAnim destructor match in __dt__8CMapAnimFv

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -514,7 +514,7 @@ CMapAnim::~CMapAnim()
     CPtrArray<CMapAnimNode*>* nodeArray = reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this);
     unsigned int i = 0;
 
-    while (i < static_cast<unsigned int>(nodeArray->GetSize())) {
+    while (i < static_cast<unsigned int>(nodeArray->m_numItems)) {
         CMapAnimNode* node = __vc__26CPtrArray_P12CMapAnimNode_FUl(this, i);
         if (node != 0 && (node = __vc__26CPtrArray_P12CMapAnimNode_FUl(this, i), node != 0)) {
             reinterpret_cast<int*>(node)[1] = 0;
@@ -524,7 +524,8 @@ CMapAnim::~CMapAnim()
     }
 
     nodeArray->RemoveAll();
-    dtor_8004AE60(nodeArray, -1);
+    nodeArray->m_vtable = lbl_801EA488;
+    nodeArray->RemoveAll();
 }
 
 /*
@@ -635,10 +636,11 @@ void CMapAnimRun::Calc(long frame)
     int* run = reinterpret_cast<int*>(this);
     CMapAnim* mapAnim;
 
+    if (run[0] < 0 && run[3] != frame) {
+        return;
+    }
+
     if (run[0] < 0) {
-        if (run[3] != frame) {
-            return;
-        }
         run[0] = run[1];
     }
 


### PR DESCRIPTION
## Summary
- Reworked `CMapAnim::~CMapAnim()` cleanup flow in `src/mapanim.cpp` to better match original destructor codegen.
- Switched loop bound to direct `m_numItems` access and inlined the second ptr-array cleanup pass by setting the ptr-array vtable then calling `RemoveAll()` again.
- Kept `CMapAnimRun::Calc(long)` behavior unchanged while rewriting its first condition into a split form (`if (run[0] < 0 && run[3] != frame) return; if (run[0] < 0) run[0] = run[1];`) to preserve its prior match shape.

## Functions Improved
- Unit: `main/mapanim`
- Improved symbol: `__dt__8CMapAnimFv`
  - Before: `53.104168%`
  - After: `57.270832%`
  - Delta: `+4.166664%`
- Checked for regression on `Calc__11CMapAnimRunFl`:
  - Before: `70.57143%`
  - After: `70.57143%` (no change)

## Match Evidence
- Unit `.text` match (`main/mapanim`):
  - Before: `81.5628%`
  - After: `81.79977%`
  - Delta: `+0.23697%`
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/mapanim -o -`

## Plausibility Rationale
- Changes stay within plausible original source structure: direct ptr-array member access and explicit destructor cleanup sequencing are already common patterns in this codebase.
- No contrived temporaries, no artificial reorderings, and no behavior changes were introduced.

## Technical Details
- `__dt__8CMapAnimFv` target assembly indicates explicit repeated ptr-array cleanup logic and vtable reset in destructor path; replacing the helper destructor call with the corresponding inline sequence moved codegen closer to target.
- Splitting the negative-frame guard in `CMapAnimRun::Calc` keeps behavior identical while avoiding unintended match drift in that function during this iteration.
