### PR TITLE
RedSound: improve DMAEntry wrapper match

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -269,6 +269,7 @@ int CRedSound::ReportStandby(int id)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma optimization_level 0
 void CRedSound::DMAEntry(int type, int src, int dst, int length, int flags, void (*callback)(void*), void* userData)
 {
 	int localType = type;
@@ -281,6 +282,7 @@ void CRedSound::DMAEntry(int type, int src, int dst, int length, int flags, void
 
 	RedDmaEntry(localType, localSrc, localDst, localLength, localFlags, localCallback, localUserData);
 }
+#pragma optimization_level 4
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
This updates CRedSound::DMAEntry in src/RedSound/RedSound.cpp to use a function-local optimization level (#pragma optimization_level 0) for the wrapper, then restores #pragma optimization_level 4 immediately after.

## Functions improved
- Unit: main/RedSound/RedSound
- Symbol: DMAEntry__9CRedSoundFiiiiiPFPv_vPv

## Match evidence
- Before: 35.954544%
- After: 57.81818%
- Size: 88b (unchanged)

## Plausibility rationale
DMAEntry is a thin forwarding wrapper. Lowering optimization only for this small wrapper is source-plausible in this codebase (which already uses per-function #pragma optimization_level), and avoids unnatural volatile/type-coaxing changes.

## Technical details
Objdiff showed the prior mismatch came from argument shuffle/spill shape before RedDmaEntry. With function-local O0, the generated stack-store/load pattern aligns significantly better with the target while preserving behavior.
