### PR TITLE
p_light: implement EnableLight and improve symbol match

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -580,12 +580,29 @@ void CLightPcs::SetDiffuseColor(unsigned long, _GXColor)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8004934c
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CLightPcs::EnableLight(int, int)
+void CLightPcs::EnableLight(int param_1, int param_2)
 {
-	// TODO
+    unsigned int light_mask;
+
+    if (param_1 == 0) {
+        light_mask = 0;
+    } else {
+        light_mask = *(unsigned int*)((char*)this + 0xb4);
+    }
+
+    GXSetChanCtrl((GXChannelID)0, (u8)(((unsigned int)(-param_1 | param_1)) >> 0x1f), (GXColorSrc)0,
+                  (GXColorSrc)(__cntlzw((unsigned int)param_2) >> 5), light_mask, (GXDiffuseFn)2,
+                  (GXAttnFn)1);
+    GXSetChanCtrl((GXChannelID)2, (u8)(((unsigned int)(-param_1 | param_1)) >> 0x1f), (GXColorSrc)0,
+                  (GXColorSrc)(__cntlzw((unsigned int)param_2) >> 5), 0, (GXDiffuseFn)0,
+                  (GXAttnFn)2);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::EnableLight(int, int)` in `src/p_light.cpp` with control flow and flag computation aligned to PAL behavior.
- Added PAL address/size metadata comment for the function header.

## Functions improved
- Unit: `main/p_light`
- Symbol: `EnableLight__9CLightPcsFii`
- Size: `152b`

## Match evidence
- Before: `2.631579%`
- After: `68.92105%`
- Method: `build/tools/objdiff-cli diff -p . -u main/p_light -o - EnableLight__9CLightPcsFii`

## Assembly analysis
- Replaced a TODO stub with two explicit `GXSetChanCtrl` calls and the same bit/zero-test style used in the target (`(-x | x) >> 31` and `__cntlzw(...) >> 5`).
- Current diff profile for the symbol is now mostly instruction-aligned (`18` matched instruction slots), with remaining differences concentrated in register allocation / argument placement (`DIFF_ARG_MISMATCH`) and a few control-flow opcode/layout mismatches.

## Plausibility rationale
- The implementation is source-plausible for original game code: it computes channel enable/material source flags from input parameters and dispatches the two expected GX channel-control calls without introducing contrived temporaries or unnatural sequencing.
