### PR TITLE
main/monobj: improve onFrameAlways match with script-flag flow alignment

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -640,66 +640,64 @@ void CGMonObj::onFrameAlways()
 	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
 	void** scriptHandle = object->m_scriptHandle;
 
-	if (scriptHandle == nullptr) {
-		return;
-	}
-
-	if ((*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(scriptHandle[9]) + 0xFE) & 4) != 0) {
-		unsigned char hasNearParty = 0;
-		if (mon[0x6B9] == 0) {
-			for (int i = 0; i < 4; i++) {
-				CGPartyObj* party = Game.game.m_partyObjArr[i];
-				if (party != nullptr && *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(party) + 0x668) != 0) {
-					float dist = PSVECDistance(
-						reinterpret_cast<Vec*>(reinterpret_cast<unsigned char*>(party) + 0x66C),
-						&object->m_worldPosition
-					);
-					if (dist < 60.0f + object->m_bodyEllipsoidRadius) {
-						hasNearParty = 1;
-						break;
+	if (scriptHandle != nullptr) {
+		if ((*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(scriptHandle[9]) + 0xFE) & 4) != 0) {
+			char hasNearParty = 0;
+			if (mon[0x6B9] == 0) {
+				for (int i = 0; i < 4; i++) {
+					CGPartyObj* party = Game.game.m_partyObjArr[i];
+					if (party != nullptr && *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(party) + 0x668) != 0) {
+						float dist = PSVECDistance(
+							reinterpret_cast<Vec*>(reinterpret_cast<unsigned char*>(party) + 0x66C),
+							&object->m_worldPosition
+						);
+						if (dist < 60.0f + object->m_bodyEllipsoidRadius) {
+							hasNearParty = 1;
+							break;
+						}
 					}
 				}
 			}
-		}
 
-		if (hasNearParty != mon[0x6C3]) {
-			reinterpret_cast<CGCharaObj*>(this)->endPSlotBit(0x200000);
-			if (hasNearParty != 0) {
-				reinterpret_cast<CGPrgObj*>(this)->putParticleBindTrace(
-					0x146,
-					*reinterpret_cast<int*>(mon + 0x5B8),
-					object,
-					1.0f,
-					0
-				);
+			if (hasNearParty != mon[0x6C3]) {
+				if ((*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(object->m_scriptHandle[9]) + 0xFE) & 4) != 0) {
+					reinterpret_cast<CGCharaObj*>(this)->endPSlotBit(0x200000);
+					if (hasNearParty != 0) {
+						reinterpret_cast<CGPrgObj*>(this)->putParticleBindTrace(
+							0x146,
+							*reinterpret_cast<int*>(mon + 0x5B8),
+							object,
+							1.0f,
+							0
+						);
+					}
+				}
+				mon[0x6C3] = hasNearParty;
 			}
-			mon[0x6C3] = hasNearParty;
 		}
-	}
 
-	reinterpret_cast<CMonWork*>(object->m_scriptHandle)->CalcStatus();
-	__ptmf_scall(this, mon + 0x708);
+		reinterpret_cast<CMonWork*>(object->m_scriptHandle)->CalcStatus();
+		__ptmf_scall(this, mon + 0x708);
 
-	unsigned short stepSeRaw = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(object->m_scriptHandle[9]) + 0x1BE);
-	int stepSeId = 0;
-	if (stepSeRaw != 0xFFFF) {
-		stepSeId = (stepSeRaw & 0xFF) + ((stepSeRaw >> 8) * 1000);
-	}
-
-	if (stepSeId == 0) {
-		return;
-	}
-
-	int& stepSeHandle = *reinterpret_cast<int*>(mon + 0x704);
-	if (object->m_currentAnimSlot == static_cast<char>(object->m_animStartFrame)) {
-		if (stepSeHandle == 0) {
-			stepSeHandle = reinterpret_cast<CGPrgObj*>(this)->playSe3D(stepSeId, 0x32, 0x96, 0, (Vec*)0);
-		} else {
-			Sound.ChangeSe3DPos(stepSeHandle, &object->m_worldPosition);
+		unsigned short stepSeRaw = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(object->m_scriptHandle[9]) + 0x1BE);
+		int stepSeId = 0;
+		if (stepSeRaw != 0xFFFF) {
+			stepSeId = (stepSeRaw & 0xFF) + ((stepSeRaw >> 8) * 1000);
 		}
-	} else if (stepSeHandle != 0) {
-		Sound.FadeOutSe3D(stepSeHandle, 0x32);
-		stepSeHandle = 0;
+
+		if (stepSeId != 0) {
+			int& stepSeHandle = *reinterpret_cast<int*>(mon + 0x704);
+			if (object->m_currentAnimSlot == static_cast<char>(object->m_animStartFrame)) {
+				if (stepSeHandle == 0) {
+					stepSeHandle = reinterpret_cast<CGPrgObj*>(this)->playSe3D(stepSeId, 0x32, 0x96, 0, (Vec*)0);
+				} else {
+					Sound.ChangeSe3DPos(stepSeHandle, &object->m_worldPosition);
+				}
+			} else if (stepSeHandle != 0) {
+				Sound.FadeOutSe3D(stepSeHandle, 0x32);
+				stepSeHandle = 0;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Refined `CGMonObj::onFrameAlways()` control flow in `src/monobj.cpp` to better mirror original branching around script flag checks and step-SE handling.
- Kept behavior/source style plausible by preserving existing data access patterns and object method usage.

## Functions improved
- Unit: `main/monobj`
- Symbol: `onFrameAlways__8CGMonObjFv`

## Match evidence
- Before: `80.00781%`
- After: `84.38281%`
- Delta: `+4.375%`
- Measurement command:
  - `build/tools/objdiff-cli diff -p . -u main/monobj -o /tmp/monobj_after.json --format json-pretty fn_80114B74`
- Comparison check showed only this symbol changed in match percent within `monobj.o`.

## Plausibility rationale
- The change removes decomp short-circuit structure that likely diverged from original compilation and restores nested branch ordering visible in reference decomp output.
- No contrived temporaries or hardcoded compiler tricks were introduced; code remains consistent with surrounding project style.

## Technical details
- Added the repeated script-enable guard before P-slot/particle operations.
- Reworked `scriptHandle` null check into the enclosing branch structure used by the original flow.
- Kept the step sound path gated inside the same outer branch and preserved existing method calls/arguments.