### PR TITLE
main/pppChangeTex: improve pppDestructChangeTex cleanup sequence

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -269,8 +269,13 @@ void pppDestructChangeTex(pppChangeTex* changeTex, UnkC* data)
 				unsigned int dlCount = *(unsigned int*)(*(int*)(meshList + 8) + 0x4c);
 				void** dlEntries = (void**)*stageArray;
 				for (j = 0; j < dlCount; j++) {
-					if (*dlEntries != 0) {
-						pppHeapUseRate__FPQ27CMemory6CStage(*dlEntries);
+					int* dlPair = (int*)*dlEntries;
+					if (*(void**)dlPair != 0) {
+						pppHeapUseRate__FPQ27CMemory6CStage(*(void**)dlPair);
+						*(void**)dlPair = 0;
+					}
+					if ((void*)dlPair != 0) {
+						pppHeapUseRate__FPQ27CMemory6CStage((void*)dlPair);
 						*dlEntries = 0;
 					}
 					dlEntries++;


### PR DESCRIPTION
## Summary
- Adjust `pppDestructChangeTex` display-list teardown to free both allocations held by each display-list pair entry.
- Keep cleanup control flow aligned with existing unit style and decomp reference (free nested buffer first, then pair container).

## Functions Improved
- Unit: `main/pppChangeTex`
- Symbol: `pppDestructChangeTex`
- Match: `78.333336% -> 79.71111%`

## Match Evidence
- Built successfully with `ninja` after changes.
- Verified with `build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o - pppDestructChangeTex`.
- Improvement is localized to destructor cleanup path; unrelated symbol `pppFrameChangeTex` remained unchanged (`54.91331% -> 54.91331%`).

## Plausibility Rationale
- The revised code matches plausible original source behavior for ownership teardown: each entry appears to store a payload pointer plus entry storage, and both should be released.
- This is a semantic cleanup fix (not compiler-coaxing): it improves memory teardown correctness and preserves readability.

## Technical Details
- In the display-list free loop, treat each element as a pair pointer (`dlPair`).
- Free `*(void**)dlPair` when present, null it, then free `dlPair` itself and clear the array slot.
