### PR TITLE
menu_arti: improve ArtiOpen/ArtiClose animation matching

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -66,12 +66,16 @@ struct ArtiOpenAnim {
 	s16 y;
 	s16 w;
 	s16 h;
+	float u;
+	float v;
 	float alpha;
 	float scale;
-	int frame;
+	int stepMax;
+	int tex;
+	int step;
+	int startFrame;
 	int duration;
 	unsigned int flags;
-	float progress;
 	float dx;
 	float dy;
 	float targetX;
@@ -365,26 +369,28 @@ unsigned int CMenuPcs::ArtiOpen()
 	int finished = 0;
 	int count = artiList[0];
 	ArtiOpenAnim* anim = (ArtiOpenAnim*)((u8*)artiList + 8);
+	int frame = artiState[0x11];
 
 	if (*(u8*)(artiState + 5) == 0) {
 		ArtiInit();
 	}
 
 	artiState[0x11]++;
+	frame = artiState[0x11];
 
 	for (int i = 0; i < count; i++, anim++) {
-		if (anim->frame <= artiState[0x11]) {
-			if (artiState[0x11] < anim->frame + anim->duration) {
-				anim->frame++;
-				anim->progress = (float)anim->frame / (float)anim->duration;
+		if (anim->startFrame <= frame) {
+			if (frame < anim->startFrame + anim->duration) {
+				anim->step++;
+				anim->alpha = (float)anim->step / (float)anim->duration;
 				if ((anim->flags & 2) == 0) {
-					float t = (float)anim->frame / (float)anim->duration;
+					float t = (float)anim->step / (float)anim->duration;
 					anim->dx = (anim->targetX - (float)anim->x) * t;
 					anim->dy = (anim->targetY - (float)anim->y) * t;
 				}
 			} else {
 				finished++;
-				anim->progress = 1.0f;
+				anim->alpha = 1.0f;
 				anim->dx = 0.0f;
 				anim->dy = 0.0f;
 			}
@@ -432,22 +438,24 @@ unsigned int CMenuPcs::ArtiClose()
 	int finished = 0;
 	int count = artiList[0];
 	ArtiOpenAnim* anim = (ArtiOpenAnim*)((u8*)artiList + 8);
+	int frame;
 
 	artiState[0x11]++;
+	frame = artiState[0x11];
 
 	for (int i = 0; i < count; i++, anim++) {
-		if (anim->frame <= artiState[0x11]) {
-			if (artiState[0x11] < anim->frame + anim->duration) {
-				anim->frame++;
-				anim->progress = 1.0f - ((float)anim->frame / (float)anim->duration);
+		if (anim->startFrame <= frame) {
+			if (frame < anim->startFrame + anim->duration) {
+				anim->step++;
+				anim->alpha = 1.0f - ((float)anim->step / (float)anim->duration);
 				if ((anim->flags & 2) == 0) {
-					float t = 1.0f - ((float)anim->frame / (float)anim->duration);
+					float t = 1.0f - ((float)anim->step / (float)anim->duration);
 					anim->dx = (anim->targetX - (float)anim->x) * t;
 					anim->dy = (anim->targetY - (float)anim->y) * t;
 				}
 			} else {
 				finished++;
-				anim->progress = 0.0f;
+				anim->alpha = 0.0f;
 				anim->dx = 0.0f;
 				anim->dy = 0.0f;
 			}


### PR DESCRIPTION
## Summary
- Updated `ArtiOpenAnim` field layout in `src/menu_arti.cpp` to align with observed menu artifact entry offsets used by `ArtiOpen`/`ArtiClose`.
- Reworked `ArtiOpen__8CMenuPcsFv` and `ArtiClose__8CMenuPcsFv` to advance and compare the correct animation timing fields (`step`, `startFrame`, `duration`) and write fade results to `alpha`.
- Kept control flow and behavior equivalent while removing incorrect field usage that produced mismatched codegen.

## Functions Improved
- `ArtiOpen__8CMenuPcsFv` (`main/menu_arti`)
  - Before: `39.25926%`
  - After: `44.712963%`
  - Delta: `+5.453703`
- `ArtiClose__8CMenuPcsFv` (`main/menu_arti`)
  - Before: `41.831577%`
  - After: `44.36842%`
  - Delta: `+2.536843`

## Match Evidence
- Rebuilt with `ninja` (successful).
- Compared via:
  - `build/tools/objdiff-cli diff -p . -u main/menu_arti -o - ArtiOpen__8CMenuPcsFv`
  - Extracted symbol percentages with `jq` for both `ArtiOpen__8CMenuPcsFv` and `ArtiClose__8CMenuPcsFv`.

## Plausibility Rationale
- The change corrects structural typing and field semantics rather than introducing compiler-only tricks.
- Animation open/close logic now uses a source-plausible representation: start frame gating, per-entry step increment, duration-based interpolation, and alpha ramping with optional positional interpolation.
