### PR TITLE
Improve pppFrameYmMoveParabola helper call matching

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -16,6 +16,8 @@ extern int DAT_8032ed70;      // Global flag
 extern "C" {
 void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
 void pppAddVector__FR3Vec3Vec3Vec(Vec*, const Vec*, const Vec*);
+void pppNormalize__FR3Vec3Vec(float*, Vec*);
+void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
 }
 
 /*
@@ -114,7 +116,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
         
         // Normalize the direction vector
         Vec tempDir = direction;
-        pppNormalize(direction, tempDir);
+        pppNormalize__FR3Vec3Vec((float*)&direction, &tempDir);
         
         // Trigonometric parabolic motion calculations
         u32 sinIndex = (u32)((FLOAT_80330e20 * (f32)stepData->m_dataValIndex) / FLOAT_80330e24);
@@ -136,7 +138,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
             offset.x = horizontalX;
             offset.y = verticalY;
             offset.z = horizontalZ;
-            pppAddVector(newPosition, offset, basePos);
+            pppAddVector__FR3Vec3Vec3Vec(&newPosition, &offset, &basePos);
         } else {
             Vec basePos;
             basePos.x = *(f32*)((u8*)pppMngSt + 0x58);
@@ -146,18 +148,18 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
             offset.x = horizontalX;
             offset.y = verticalY;
             offset.z = horizontalZ;
-            pppAddVector(newPosition, offset, basePos);
+            pppAddVector__FR3Vec3Vec3Vec(&newPosition, &offset, &basePos);
         }
 
-        pppCopyVector(*(Vec*)((u8*)pppMngSt + 0x48), *(Vec*)((u8*)pppMngSt + 0x8));
-        pppCopyVector(*(Vec*)((u8*)pppMngSt + 0x8), newPosition);
+        pppCopyVector__FR3Vec3Vec((Vec*)((u8*)pppMngSt + 0x48), (Vec*)((u8*)pppMngSt + 0x8));
+        pppCopyVector__FR3Vec3Vec((Vec*)((u8*)pppMngSt + 0x8), &newPosition);
         
         // Update matrix with new position
         pppMngStPtr->m_matrix.value[0][3] = newPosition.x;
         pppMngStPtr->m_matrix.value[1][3] = newPosition.y;
         pppMngStPtr->m_matrix.value[2][3] = newPosition.z;
         
-        pppSetFpMatrix(pppMngSt);
+        pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
         
         *(u16*)(pfVar + 3) = *(u16*)(pfVar + 3) + 1;
     }


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmMoveParabola` to call the explicit Metrowerks-mangled helper variants used by nearby PPP units.
- Switched vector helper calls to `pppNormalize__FR3Vec3Vec`, `pppAddVector__FR3Vec3Vec3Vec`, and `pppCopyVector__FR3Vec3Vec` with pointer arguments.
- Switched matrix update call to `pppSetFpMatrix__FP9_pppMngSt`.

## Functions Improved
- Unit: `main/pppYmMoveParabola`
- Symbol: `pppFrameYmMoveParabola`
  - Before: `54.054348%`
  - After: `55.233696%`
  - Delta: `+1.179348%`
- Symbol: `pppConstructYmMoveParabola`
  - Before: `58.164383%`
  - After: `58.164383%` (unchanged)

## Match Evidence
- Built with `ninja` after changes (build succeeded).
- Verified with objdiff oneshot:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o - pppFrameYmMoveParabola`
  - `build/tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o - pppConstructYmMoveParabola`

## Plausibility Rationale
- These changes preserve behavior and align with coding patterns already present across existing `pppYm*` sources, where explicit mangled helper entry points are called directly.
- The update avoids contrived control-flow/temporary rewrites; it focuses on ABI/call-shape alignment that is plausible for original source in this codebase.

## Technical Notes
- A larger stack/control-flow rewrite attempt regressed match and was discarded.
- Final patch keeps only the net-positive call-form adjustments.
