### PR TITLE
pppMana2: implement UpdateWaterMesh

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -665,12 +665,82 @@ extern "C" int CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf2(
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80106c54
+ * PAL Size: 968b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void UpdateWaterMesh(VMana2*)
+void UpdateWaterMesh(VMana2* mana2)
 {
-	// TODO
+    u8* work;
+    float* waterHeightA;
+    float* waterHeightB;
+    Vec* positions;
+    Vec origin;
+
+    work = (u8*)mana2;
+    waterHeightA = *(float**)(work + 0x48);
+    positions = *(Vec**)(work + 0x3C);
+    waterHeightB = *(float**)(work + 0x4C);
+    if (waterHeightA == NULL) {
+        return;
+    }
+
+    for (int row = 1; row < 0x10; row++) {
+        int rowBase = row * 0x11;
+        for (int colBlock = 0; colBlock < 3; colBlock++) {
+            int col = colBlock * 5 + 1;
+            int idx = rowBase + col;
+
+            waterHeightB[idx + 0] =
+                FLOAT_80331898 * waterHeightA[idx + 0] +
+                FLOAT_803318a4 *
+                    (waterHeightA[idx + 1] + waterHeightA[idx - 1] + waterHeightA[idx - 0x11] + waterHeightA[idx + 0x11]) -
+                waterHeightB[idx + 0];
+
+            waterHeightB[idx + 1] =
+                FLOAT_80331898 * waterHeightA[idx + 1] +
+                FLOAT_803318a4 *
+                    (waterHeightA[idx + 2] + waterHeightA[idx + 0] + waterHeightA[idx - 0x10] + waterHeightA[idx + 0x12]) -
+                waterHeightB[idx + 1];
+
+            waterHeightB[idx + 2] =
+                FLOAT_80331898 * waterHeightA[idx + 2] +
+                FLOAT_803318a4 *
+                    (waterHeightA[idx + 3] + waterHeightA[idx + 1] + waterHeightA[idx - 0x0F] + waterHeightA[idx + 0x13]) -
+                waterHeightB[idx + 2];
+
+            waterHeightB[idx + 3] =
+                FLOAT_80331898 * waterHeightA[idx + 3] +
+                FLOAT_803318a4 *
+                    (waterHeightA[idx + 4] + waterHeightA[idx + 2] + waterHeightA[idx - 0x0E] + waterHeightA[idx + 0x14]) -
+                waterHeightB[idx + 3];
+
+            waterHeightB[idx + 4] =
+                FLOAT_80331898 * waterHeightA[idx + 4] +
+                FLOAT_803318a4 *
+                    (waterHeightA[idx + 5] + waterHeightA[idx + 3] + waterHeightA[idx - 0x0D] + waterHeightA[idx + 0x15]) -
+                waterHeightB[idx + 4];
+        }
+    }
+
+    for (int i = 0; i < 0x121; i++) {
+        float tmp = waterHeightA[i];
+        waterHeightA[i] = waterHeightB[i];
+        waterHeightB[i] = tmp;
+        positions[i].y = waterHeightA[i];
+    }
+
+    DCFlushRange(positions, 0xD8C);
+    CalculateNormal(mana2);
+
+    origin.x = *(float*)(work + 0x8C);
+    origin.y = *(float*)(work + 0x9C);
+    origin.z = *(float*)(work + 0xAC);
+    CalcWaterReflectionVector(*(Vec**)(work + 0x44), *(Vec**)(work + 0x3C), *(Vec**)(work + 0x40), 0x121, &origin,
+                              (float(*)[4])(work + 0x80), *(_GXColor**)(work + 0x5C), *(Vec2d**)(work + 0x58));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `UpdateWaterMesh(VMana2*)` in `src/pppMana2.cpp`.
- Replaced TODO stub with full water height propagation/update loop, buffer swap, vertex Y writeback, cache flush, normal recomputation, and reflection-vector update.
- Added PAL metadata block for the function (`0x80106c54`, `968b`).

## Functions Improved
- Unit: `main/pppMana2`
- Symbol: `UpdateWaterMesh__FP6VMana2`
- Before: `0.4%` (selector baseline)
- After: `63.98347%` (`objdiff-cli` JSON oneshot)

## Match Evidence
- Build: `ninja` succeeds.
- Diff command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppMana2 -o - UpdateWaterMesh__FP6VMana2`
- Parsed result:
  - `.left.symbols[] | select(.name=="UpdateWaterMesh__FP6VMana2") | .match_percent`
  - `63.98347`

## Plausibility Rationale
- The implementation follows existing project style for low-level engine code in this module:
  - offset-based access for partially-reversed work structs,
  - explicit fixed-size loops for 17x17 water grid updates,
  - direct `DCFlushRange` and GX/normal pipeline integration.
- Logic is consistent with surrounding functions (`CalculateNormal`, `CalcWaterReflectionVector`) and preserves expected dataflow (height update -> positions -> normals -> reflection data), rather than introducing synthetic compiler-coaxing constructs.

## Technical Notes
- The update step uses adjacent-neighbor accumulation with `FLOAT_80331898`/`FLOAT_803318a4` constants and ping-pong buffers at offsets `0x48/0x4C`.
- Vertex Y values are written into position buffer at `0x3C`, followed by `DCFlushRange(..., 0xD8C)` and `CalculateNormal(mana2)`.
- Reflection setup uses origin components from `0x8C/0x9C/0xAC`, matrix at `0x80`, color buffer at `0x5C`, and UV buffer at `0x58`.
