### PR TITLE
main/game: match GetLangString__5CGameFv

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1588,23 +1588,14 @@ char* CGame::MakeNumMonName(char* out, int monIndex, int count)
  */
 const char* CGame::GetLangString()
 {
-    static const char* const sLangDirs[] =
-    {
-        "jp/",
-        "uk/",
-        "gr/",
-        "it/",
-        "fr/",
-        "sp/"
-    };
     const char* localLangDirs[6];
 
-    localLangDirs[0] = sLangDirs[0];
-    localLangDirs[1] = sLangDirs[1];
-    localLangDirs[2] = sLangDirs[2];
-    localLangDirs[3] = sLangDirs[3];
-    localLangDirs[4] = sLangDirs[4];
-    localLangDirs[5] = sLangDirs[5];
+    localLangDirs[0] = lbl_801D60B0[0];
+    localLangDirs[1] = lbl_801D60B0[1];
+    localLangDirs[2] = lbl_801D60B0[2];
+    localLangDirs[3] = lbl_801D60B0[3];
+    localLangDirs[4] = lbl_801D60B0[4];
+    localLangDirs[5] = lbl_801D60B0[5];
 
     return localLangDirs[m_gameWork.m_languageId];
 }


### PR DESCRIPTION
## Summary
- Updated `CGame::GetLangString()` in `src/game.cpp` to use the existing global language directory table (`lbl_801D60B0`) instead of a function-local static table.
- Kept the local stack copy pattern (`localLangDirs[6]`) so generated code remains source-plausible and aligns with expected codegen.

## Functions improved
- Unit: `main/game`
- Function: `GetLangString__5CGameFv`

## Match evidence
- `GetLangString__5CGameFv`: **78.3% -> 100.0%** (80b)
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/game -o /tmp/game_getlang_new.json GetLangString__5CGameFv`

## Plausibility rationale
- Reusing a pre-existing global table of language directory strings is a normal and maintainable source pattern.
- The resulting function is simpler and more consistent with other symbolized globals in this translation unit.
- No contrived control-flow or compiler-coaxing constructs were introduced.

## Technical details
- Prior code emitted a different table symbol (`sLangDirs$...`) and instruction ordering.
- Switching to `lbl_801D60B0` aligned relocation/symbol usage and produced a full assembly match for this function.

## Build/validation
- `ninja` succeeds after the change.
