### PR TITLE
gx/GXTev: improve GXSetTevColor register packing

### DIFF
--- a/src/gx/GXTev.c
+++ b/src/gx/GXTev.c
@@ -208,15 +208,23 @@ void GXSetTevAlphaOp(GXTevStageID stage, GXTevOp op, GXTevBias bias, GXTevScale 
 
 void GXSetTevColor(GXTevRegID id, GXColor color) {
     u8* c;
+    u8 a;
+    u8 r;
+    u8 g;
+    u8 b;
     u32 id2;
     u32 regRA;
     u32 regBG;
 
     CHECK_GXBEGIN(740, "GXSetTevColor");
     c = (u8*)&color;
+    a = c[3];
+    r = c[0];
+    b = c[2];
+    g = c[1];
     id2 = id * 2;
-    regRA = (c[3] << 12) | c[0] | ((id2 + 0xE0) << 24);
-    regBG = (c[1] << 12) | c[2] | ((id2 + 0xE1) << 24);
+    regRA = (a << 12) | r | ((id2 + 0xE0) << 24);
+    regBG = (g << 12) | b | ((id2 + 0xE1) << 24);
 
     GX_WRITE_RAS_REG(regRA);
     GX_WRITE_RAS_REG(regBG);


### PR DESCRIPTION
## Summary
- Reworked GXSetTevColor byte extraction into explicit locals before BP register packing.
- Kept behavior and API unchanged; only expression shape/order changed.

## Functions improved
- Unit: main/gx/GXTev
- Symbol: GXSetTevColor

## Match evidence
- Targeted objdiff command: build/tools/objdiff-cli diff -p . -u main/gx/GXTev -o - GXSetTevColor
- Before: 39.96552% (target symbol id 6)
- After: 67.0% (target symbol id 6)
- Symbol diff count: 26 -> 21

## Plausibility rationale
- Change is source-plausible: explicit channel-byte temporaries are common in low-level GX packing code.
- No contrived control flow or hardcoded offset tricks; semantic behavior is unchanged.

## Technical details
- The new local load order (a/r/b/g) improved codegen alignment with the original BP command packing sequence while preserving existing checks and writes.
