### PR TITLE
main/game: place CGBaseObj::GetCID in correct unit

### DIFF
--- a/src/baseobj.cpp
+++ b/src/baseobj.cpp
@@ -20,20 +20,6 @@ void CGBaseObj::onFrame()
 
 /*
  * --INFO--
- * PAL Address: 8001439c
- * PAL Size: 8b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-int CGBaseObj::GetCID()
-{
-	return 1;
-}
-
-/*
- * --INFO--
  * Address:	TODO
  * Size:	TODO
  */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -177,6 +177,20 @@ static bool BOOL_8032ec44;
 
 /*
  * --INFO--
+ * PAL Address: 0x8001439c
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CGBaseObj::GetCID()
+{
+    return 1;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x80016220
  * PAL Size: 312b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Moved `CGBaseObj::GetCID()` definition from `src/baseobj.cpp` to `src/game.cpp`.
- Kept function body unchanged (`return 1;`) and preserved PAL info header on the moved definition.

## Functions Improved
- Unit: `main/game`
- Symbol: `GetCID__9CGBaseObjFv` (`CGBaseObj::GetCID()`)

## Match Evidence
- Before: selector reported `GetCID__9CGBaseObjFv` at `0.0%` in `main/game`, and symbol-level diff for `main/game` did not contain a matched right-side symbol for `GetCID__9CGBaseObjFv`.
- After: `objdiff` for `main/game` shows `GetCID__9CGBaseObjFv` at `100.0%` (size `8`).
- Build progress increased matched functions from `1672` to `1673`.

## Plausibility Rationale
- This change is source-plausible because it corrects translation-unit placement rather than introducing compiler-coaxing control-flow tricks.
- The target data indicates `CGBaseObj::GetCID()` belongs to the `main/game` unit, while our decomp had it emitted from `baseobj`.
- The implementation logic is unchanged; only location was corrected to match original unit structure.

## Technical Details
- Validation command: `build/tools/objdiff-cli diff -p . -u main/game -o -`
- Verified in the resulting JSON that:
  - left symbol exists: `GetCID__9CGBaseObjFv` size `8`
  - right symbol now exists and matches: `100.0%`, size `8`
