### PR TITLE
pppYmMana: implement Chara_DrawShadowMeshDLCallback

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -9,6 +9,7 @@ extern float FLOAT_80330e4c;
 extern float FLOAT_80330e58;
 extern float FLOAT_80330e5c;
 extern float FLOAT_80330e68;
+extern char MaterialMan[];
 
 extern struct {
     float _224_4_;
@@ -32,6 +33,7 @@ void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevA
                                                                                                             int, int);
 void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int, int, int, int);
 void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
+void SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(void*, void*, unsigned int, int, int);
 }
 
 /*
@@ -178,12 +180,30 @@ void Mana_BeforeDrawShadowLockEnvCallback(CChara::CModel*, void*, void*, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800d7ef4
+ * PAL Size: 216b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void Chara_DrawShadowMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*) [4])
+void Chara_DrawShadowMeshDLCallback(CChara::CModel* model, void* work, void* vYmMana, int meshIndex, int dlIndex, float (*) [4])
 {
-	// TODO
+    s32 meshData = *(s32*)((u8*)model + 0xAC);
+    u8 alpha = *(u8*)((u8*)vYmMana + 0x3B);
+
+    *(u8*)((u8*)work + 0xFC) = 0xFF;
+    *(u8*)((u8*)work + 0xFD) = 0xFF;
+    *(u8*)((u8*)work + 0xFE) = 0xFF;
+    *(u8*)((u8*)work + 0xFF) = alpha == 0 ? 0xFF : alpha;
+
+    DCFlushRange((u8*)work + 0xFC, 4);
+    GXSetArray((GXAttr)0xB, (u8*)work + 0xFC, 4);
+
+    u32* dl = (u32*)(*(s32*)(*(s32*)(meshData + meshIndex * 0x14 + 8) + 0x50) + dlIndex * 0xC);
+    SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
+        MaterialMan, *(void**)(*(s32*)((u8*)model + 0xA4) + 0x24), *(u16*)((u8*)dl + 8), 0, 0);
+    GXCallDisplayList((void*)dl[1], dl[0]);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `Chara_DrawShadowMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f` in `src/pppYmMana.cpp` using the existing offset-based style used across particle/chara callback code.

Changes include:
- Added missing extern declarations for `MaterialMan` and `SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale` used by the callback.
- Replaced TODO stub with callback logic to:
  - write shadow color/alpha into work color buffer
  - flush cache + bind GX color array
  - resolve display list/material for mesh + DL index
  - set material and issue display list draw
- Added function info block metadata for PAL address/size.

## Functions improved
- Unit: `main/pppYmMana`
- Function: `Chara_DrawShadowMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`
  - Size: 216b
  - Match: **1.8518518% -> 61.703705%**

## Match evidence
Measured with:
- `build/tools/objdiff-cli diff -p . -u main/pppYmMana -o - Chara_DrawShadowMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`

Method:
1. Built baseline from `main` version of `src/pppYmMana.cpp` and captured objdiff JSON.
2. Restored branch version, rebuilt, and captured objdiff JSON again.
3. Compared symbol `match_percent` in both JSONs.

## Plausibility rationale
This change is a direct callback implementation consistent with nearby original-style code (`pppMana2`, `pppCharaBreak`) and avoids compiler-coaxing patterns. It uses the same data flow expected by the runtime (work color buffer, material setup, and display-list draw path), making it plausible as original source rather than synthetic score tuning.

## Technical details
- Preserved existing ABI/signature used by current unit.
- Used existing pointer-offset conventions already present in this file and related units.
- Kept change scope narrow to one previously stubbed callback to isolate effect and reduce regression risk.
