### PR TITLE
shopmenu: implement CShopMenu::SetMode first pass

### DIFF
--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -6,6 +6,7 @@ void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
 void _WaitDrawDone__8CGraphicFPci(void*, char*, int);
 void SetMode__9CShopMenuFi(void*, int);
 int LoadMenuPdt__8CPartPcsFPc(void*, char*);
+int GetItemType__8CMenuPcsFii(void*, int, int);
 }
 
 extern char s_shopmenu_cpp_801ded8c[];
@@ -109,12 +110,103 @@ void bButtonNoRepeat(unsigned short)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801593f8
+ * PAL Size: 604b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CShopMenu::SetMode(int)
+void CShopMenu::SetMode(int mode)
 {
-	// TODO
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+
+    *reinterpret_cast<int*>(self + 0x0) = mode;
+    *reinterpret_cast<int*>(self + 0xC) = 0;
+
+    switch (*reinterpret_cast<int*>(self + 0x0)) {
+    case 0:
+        *reinterpret_cast<float*>(self + 0x1C) = 0.0f;
+        *reinterpret_cast<unsigned char*>(self + 0x48) = 0xFF;
+        break;
+    case 1:
+        *reinterpret_cast<unsigned char*>(self + 0x48) = 0;
+        break;
+    case 3:
+        *reinterpret_cast<int*>(self + 0x14) = 0;
+        *reinterpret_cast<int*>(self + 0x10) = 0;
+        *reinterpret_cast<int*>(self + 0x28) = -1;
+        *reinterpret_cast<int*>(self + 0x24) = 0;
+        *reinterpret_cast<int*>(self + 0x2C) = 8;
+        *reinterpret_cast<int*>(self + 0x34) = 0;
+        *reinterpret_cast<int*>(self + 0x30) = 0;
+        *reinterpret_cast<int*>(self + 0x40) = 0;
+        *reinterpret_cast<int*>(self + 0x44) = 1;
+        *reinterpret_cast<int*>(self + 0x38) = 0;
+        *reinterpret_cast<int*>(self + 0x3C) = 0;
+        break;
+    case 6:
+        *reinterpret_cast<int*>(self + 0x14) = 1;
+        *reinterpret_cast<int*>(self + 0x10) = 0;
+        *reinterpret_cast<int*>(self + 0x28) = -1;
+        *reinterpret_cast<int*>(self + 0x24) = 0;
+        *reinterpret_cast<int*>(self + 0x2C) = 8;
+        *reinterpret_cast<int*>(self + 0x34) = 0;
+        *reinterpret_cast<int*>(self + 0x30) = 0;
+        *reinterpret_cast<int*>(self + 0x40) = 0;
+        *reinterpret_cast<int*>(self + 0x44) = 1;
+        *reinterpret_cast<int*>(self + 0x38) = 0;
+        *reinterpret_cast<int*>(self + 0x3C) = 0;
+        break;
+    case 4:
+    case 7:
+        *reinterpret_cast<int*>(self + 0x28) = 0;
+        *reinterpret_cast<int*>(self + 0x24) = 0;
+        *reinterpret_cast<int*>(self + 0x38) = 0;
+        break;
+    case 9: {
+        *reinterpret_cast<float*>(self + 0x1C) = 0.0f;
+        *reinterpret_cast<unsigned char*>(self + 0x48) = 0xFF;
+        *reinterpret_cast<int*>(self + 0x14) = 2;
+        *reinterpret_cast<int*>(self + 0x10) = 0;
+        *reinterpret_cast<int*>(self + 0x28) = 0;
+        *reinterpret_cast<int*>(self + 0x24) = 0;
+        *reinterpret_cast<int*>(self + 0x2C) = 8;
+        *reinterpret_cast<int*>(self + 0x34) = 0;
+        *reinterpret_cast<int*>(self + 0x30) = 0;
+        *reinterpret_cast<int*>(self + 0x40) = 0;
+        *reinterpret_cast<int*>(self + 0x44) = 1;
+        *reinterpret_cast<int*>(self + 0x38) = 0;
+        *reinterpret_cast<int*>(self + 0x3C) = 0;
+        *reinterpret_cast<int*>(self + 0x154) = -1;
+        *reinterpret_cast<int*>(self + 0x4C) = 0;
+
+        for (int i = 0; i < 0x40; i++) {
+            if (GetItemType__8CMenuPcsFii(MenuPcs, i, 0) == 9) {
+                int count = *reinterpret_cast<int*>(self + 0x4C);
+                *reinterpret_cast<int*>(self + 0x4C) = count + 1;
+                *reinterpret_cast<int*>(self + 0x50 + count * 4) = i;
+            }
+        }
+
+        if (*reinterpret_cast<int*>(self + 0x4C) == 0) {
+            *reinterpret_cast<int*>(self + 0x4C) = 1;
+            *reinterpret_cast<int*>(self + 0x50) = -1;
+            for (int i = 0; i < 7; i++) {
+                int count = *reinterpret_cast<int*>(self + 0x4C);
+                *reinterpret_cast<int*>(self + 0x4C) = count + 1;
+                *reinterpret_cast<int*>(self + 0x50 + count * 4) = -1;
+            }
+        }
+        break;
+    }
+    case 10:
+        *reinterpret_cast<unsigned char*>(self + 0x48) = 0;
+        break;
+    case 12:
+        *reinterpret_cast<int*>(self + 0x3C) = 0;
+        break;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CShopMenu::SetMode(int)` in `src/shopmenu.cpp` from the PAL decomp reference as a first-pass source reconstruction.
- Replaced the prior TODO stub with concrete mode transition/state setup logic for mode cases 0/1/3/4/6/7/9/10/12.
- Added the PAL function metadata block for this function:
  - PAL Address: `0x801593f8`
  - PAL Size: `604b`

## Functions improved
- Unit: `main/shopmenu`
- Symbol: `SetMode__9CShopMenuFi`

## Match evidence
- `objdiff` symbol match for `SetMode__9CShopMenuFi`: **79.15232%**
- Left (decomp) symbol size: **604b**
- Right (target) symbol size: **640b**
- Unit fuzzy match (`build/GCCP01/report.json`): **2.280094%**
  - Selector baseline before this change: **1.0%** for `main/shopmenu`

## Plausibility rationale
- The implementation follows normal game-menu state-machine initialization patterns used elsewhere in the codebase (mode switch, field resets, inventory-derived setup).
- Changes are semantic source reconstruction, not compiler-coaxing patterns: no artificial temporaries or opaque reordering solely for codegen tricks.

## Technical details
- Implemented the mode dispatch and field initialization exactly at existing `CShopMenu` offsets used throughout this file.
- Implemented smith-mode item filtering via `GetItemType__8CMenuPcsFii(..., itemIdx, 0)` and fallback sentinel fill when no items are found.
- Rebuilt with `ninja` and validated with:
  - `build/tools/objdiff-cli diff -p . -u main/shopmenu -o - SetMode__9CShopMenuFi`
