### PR TITLE
RedMemory: improve RedDelete* match via signed division cleanup

### DIFF
--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -137,7 +137,7 @@ void RedDelete(int address)
 		while (blockPtr[1] != 0 && blockPtr < DAT_8032f4a0 + 0x800) {
 			if (blockPtr[0] == address) {
 				unsigned int moveCount = (int)DAT_8032f4a0 + (0x2000 - (int)(blockPtr + 2));
-				int entryCount = ((int)moveCount >> 3) + ((int)moveCount < 0 && (moveCount & 7) != 0);
+				int entryCount = (int)moveCount / 8;
 				if (entryCount > 0) {
 					memcpy(blockPtr, blockPtr + 2, entryCount * 8);
 					memset(DAT_8032f4a0 + 0x7FE, 0, 8);
@@ -279,7 +279,7 @@ void RedDeleteA(int address)
 		while (blockPtr[1] != 0 && blockPtr < DAT_8032f4a4 + 0x800) {
 			if (blockPtr[0] == address) {
 				unsigned int moveCount = (int)DAT_8032f4a4 + (0x2000 - (int)(blockPtr + 2));
-				int entryCount = ((int)moveCount >> 3) + ((int)moveCount < 0 && (moveCount & 7) != 0);
+				int entryCount = (int)moveCount / 8;
 				if (entryCount > 0) {
 					memcpy(blockPtr, blockPtr + 2, entryCount * 8);
 					memset(DAT_8032f4a4 + 0x7FE, 0, 8);


### PR DESCRIPTION
## Summary
- Updated `src/RedSound/RedMemory.cpp` in `RedDelete(int)` and `RedDeleteA(int)`.
- Replaced a decompiler-style signed rounding expression used to compute shifted entry counts with direct signed division by 8.
- Kept behavior and structure intact; only the `entryCount` expression changed in both functions.

## Functions improved
- `RedDelete__Fi`
  - Before: `65.77778%`
  - After: `73.81481%`
- `RedDeleteA__Fi`
  - Before: `65.77778%`
  - After: `73.81481%`

## Match evidence
- Unit `main/RedSound/RedMemory`
  - Before: `57.411087%`
  - After: `59.415703%`
- `objdiff-cli diff` for `RedDelete__Fi` improved symbol match from `65.59259%` to `73.62963%`.
- The improved diff region is centered on the entry-count arithmetic and subsequent memmove/memset block layout.

## Plausibility rationale
- The previous expression is a reverse-engineered arithmetic expansion for signed divide semantics.
- Using plain `(int)moveCount / 8` is more likely original authored source and lets the compiler emit the expected division pattern.
- This is a readability and intent improvement, not a contrived temporary/reordering change.

## Technical details
- Changed lines:
  - `src/RedSound/RedMemory.cpp` (`RedDelete`): `entryCount` computation
  - `src/RedSound/RedMemory.cpp` (`RedDeleteA`): `entryCount` computation
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedMemory -o - RedDelete__Fi`
  - `build/GCCP01/report.json` before/after comparisons
