### PR TITLE
main/cflat_data: improve Create__9CFlatDataFPv match

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -229,7 +229,7 @@ void CFlatData::Create(void* filePtr)
 							new (Game.game.m_mainStage, (char*)"cflat_data.cpp", 0x45) unsigned char[chunk.m_arg0];
 						chunkFile.Get(m_data[m_dataCount].m_data, chunk.m_arg0);
 
-						if (chunk.m_version == 0)
+						if (chunk.m_version < 1)
 						{
 							m_data[m_dataCount].m_numStrings = 0;
 							m_data[m_dataCount].m_stringBuf = (char*)nullptr;


### PR DESCRIPTION
## Summary
- Adjusted one condition in `CFlatData::Create(void*)` in `src/cflat_data.cpp`.
- Changed the DATA-chunk string-table gate from `chunk.m_version == 0` to `chunk.m_version < 1`.

## Functions Improved
- Unit: `main/cflat_data`
- Symbol: `Create__9CFlatDataFPv`
- Size: `1228` bytes (unchanged)

## Match Evidence
- Before: `57.459282%`
- After: `58.071663%`
- Delta: `+0.612381%`
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_data -o - Create__9CFlatDataFPv | jq '.left.symbols[] | select(.name=="Create__9CFlatDataFPv") | {match_percent,size}'`

## Plausibility Rationale
- Treating version values as a range check (`< 1`) is source-plausible for chunk format handling and common in legacy game code parsing.
- The change preserves behavior for valid non-negative versions while producing better assembly alignment, without introducing contrived temporaries or unnatural control flow.

## Technical Notes
- Rebuilt with `ninja` after the change.
- `dtor_800980B4` remains unchanged at `94.246574%`.
