### PR TITLE
graphic: implement standard copy/pixel setup methods

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -135,32 +135,51 @@ void CGraphic::SetCopyClear(_GXColor, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001992c
+ * PAL Size: 52b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphic::SetStdDispCopySrc()
 {
-	// TODO
+    void* renderMode = PtrAt(this, 0x71E0);
+    GXSetDispCopySrc(0, 0, U16At(renderMode, 4), U16At(renderMode, 6));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80019900
+ * PAL Size: 44b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphic::SetStdDispCopyDst()
 {
-	// TODO
+    void* renderMode = PtrAt(this, 0x71E0);
+    GXSetDispCopyDst(U16At(renderMode, 4), U16At(renderMode, 6));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800198b8
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphic::SetStdPixelFmt()
 {
-	// TODO
+    void* renderMode = PtrAt(this, 0x71E0);
+    if (*reinterpret_cast<u8*>(reinterpret_cast<u8*>(renderMode) + 0x19) == 0) {
+        GXSetPixelFmt(GX_PF_RGB8_Z24, GX_ZC_LINEAR);
+    } else {
+        GXSetPixelFmt(GX_PF_RGBA6_Z24, GX_ZC_LINEAR);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three previously stubbed `CGraphic` methods in `src/graphic.cpp` using the PAL Ghidra references and existing class offset helpers.
- Added proper function `--INFO--` headers with PAL address/size metadata for the updated functions.
- Kept implementation source-plausible: direct GX API configuration from render mode fields, without compiler-coaxing constructs.

## Functions Improved
- Unit: `main/graphic`
- `SetStdDispCopyDst__8CGraphicFv` (44b): **9.0909% -> 100.0%**
- `SetStdDispCopySrc__8CGraphicFv` (52b): **7.6923% -> 100.0%**
- `SetStdPixelFmt__8CGraphicFv` (72b): **5.5556% -> 99.6111%**

## Match Evidence
- Rebuilt with `ninja` successfully (completed `REPORT` and `PROGRESS` with no errors).
- Updated `build/GCCP01/report.json` shows the above before/after function percentages for `main/graphic`.
- `main/graphic` unit fuzzy is now `18.303675` after this change.

## Plausibility Rationale
- These routines are standard GX setup wrappers expected in an original engine graphics class.
- Logic follows natural source semantics:
  - copy destination/source dimensions from the render mode object
  - choose pixel format based on a render-mode flag
- No artificial temporaries, reordered side effects, or unnatural code patterns were introduced.

## Technical Details
- Used existing local helpers (`PtrAt`, `U16At`) to preserve current codebase idioms for member-offset access while keeping generated code tight.
- `SetStdPixelFmt` maps the flag branch to expected GX formats:
  - false -> `GX_PF_RGB8_Z24`
  - true -> `GX_PF_RGBA6_Z24`
- All changes are isolated to `src/graphic.cpp` for low-risk review and bisectability.
