### PR TITLE
Improve match for pppConstructYmMoveParabola

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -31,9 +31,9 @@ void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
  */
 extern "C" void pppConstructYmMoveParabola(struct pppYmMoveParabola* basePtr, struct UnkC* dataPtr)
 {
-    _pppMngSt* pppMngSt;
-    f32 fVar2;
-    f32* pfVar;
+    _pppMngSt* pppMngSt = pppMngStPtr;
+    f32 fVar2 = FLOAT_80330e1c;
+    f32* pfVar = (f32*)((u8*)&basePtr->field0_0x0 + 8 + *dataPtr->m_serializedDataOffsets);
     Vec local_48;
     Vec local_24;
     f32 local_3c;
@@ -46,9 +46,6 @@ extern "C" void pppConstructYmMoveParabola(struct pppYmMoveParabola* basePtr, st
     f32 local_14;
     f32 local_10;
 
-    fVar2 = FLOAT_80330e1c;
-    pppMngSt = pppMngStPtr;
-    pfVar = (f32*)((u8*)&basePtr->field0_0x0 + 8 + *dataPtr->m_serializedDataOffsets);
     pfVar[2] = FLOAT_80330e1c;
     pfVar[1] = fVar2;
     *pfVar = fVar2;


### PR DESCRIPTION
## Summary
- Refined local variable initialization/lifetime in `pppConstructYmMoveParabola` to better align with compiler-emitted register allocation and stack usage.
- Kept runtime logic unchanged; this is a source-shape adjustment only.

## Functions improved
- `pppConstructYmMoveParabola`
  - Before: `58.164383%` (left size `292`, target size `240`)
  - After: `62.410957%` (left size `292`, target size `240`)
- `pppFrameYmMoveParabola`
  - Unchanged at `55.233696%`

## Match evidence
- Unit `main/pppYmMoveParabola`
  - Selector baseline: `56.7%`
  - After change (`ninja` report): `57.972763%`
- Objdiff symbol check command used:
  - `tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o - pppConstructYmMoveParabola`

## Plausibility rationale
- The change is a normal C/C++ cleanup (declaration placement and initialization consolidation), not artificial control-flow coercion.
- No contrived temporaries, offset tricks, or behavior changes were introduced.

## Technical details
- Shifted three locals in `pppConstructYmMoveParabola` from deferred assignment to declaration-time initialization.
- This affects lifetime/scheduling while preserving all existing operations and call ordering.
