### PR TITLE
RedDriver: implement SePlay command dispatch

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1436,12 +1436,23 @@ void CRedDriver::SeStopMG(int, int, int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bf540
+ * PAL Size: 196b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::SePlay(int, int, int, int, int, int)
+void CRedDriver::SePlay(int bank, int sep, int autoID, int unk, int volume, int pitch)
 {
-	// TODO
+	if (bank == -1) {
+		if (sep > -1) {
+			_EntryExecCommand(_SeSepPlaySequence, autoID, sep, unk, volume, pitch, 0, 0);
+		}
+	} else if ((bank > -1) && (bank < 4) && (sep > -1) && (sep < 0x200)) {
+		_EntryExecCommand(_SeBlockPlay, autoID, bank, sep, unk, volume, pitch, 0);
+	}
+
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedDriver::SePlay(int, int, int, int, int, int)` in `src/RedSound/RedDriver.cpp`.
- Replaced the TODO stub with command-dispatch logic for sep-sequence and block playback paths.
- Added PAL metadata block for this function (`0x801bf540`, `196b`).

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `SePlay__10CRedDriverFiiiiii`

## Match evidence
- Before: `2.0408163%`
- After: `3.877551%`
- Size: `196b` (unchanged)
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - SePlay__10CRedDriverFiiiiii`

## Plausibility rationale
- The new implementation follows expected original source behavior: validate IDs/ranges, then enqueue one of two existing sound commands.
- It uses existing engine command APIs (`_EntryExecCommand`, `_SeSepPlaySequence`, `_SeBlockPlay`) and no compiler-coaxing constructs.

## Technical details
- `bank == -1` path dispatches `_SeSepPlaySequence` when `sep >= 0`.
- bounded block path dispatches `_SeBlockPlay` for `0 <= bank < 4` and `0 <= sep < 0x200`.
- argument ordering mirrors observed command packet layout (`autoID`, then IDs/params).
