### PR TITLE
main/astar: improve polygon-group helper matches

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -21,6 +21,18 @@ static const float kPolyGroupAabbMin = -1.0e10f; // FLOAT_80332098
 static const float kInfiniteCost = 10000000.0f;  // FLOAT_8033209c
 static const float kDrawAStarSphereRadius = 5.0f;
 
+struct CMapCylinderRaw
+{
+	Vec m_bottom;
+	Vec m_direction;
+	float m_radius;
+	float m_height;
+	Vec m_top;
+	Vec m_direction2;
+	float m_radius2;
+	float m_height2;
+};
+
 extern Mtx gFlatPosMtx;
 extern int DAT_8032ed70;
 extern unsigned char lbl_8032EC90[];
@@ -892,17 +904,12 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 {
 	unsigned long mask = m_hitAttributeMask;
-
-	CVector bottom(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
+	CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 	CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
-	CMapCylinder cyl;
+	CMapCylinderRaw cyl;
 
-	cyl.m_bottom.x = top.x;
-	cyl.m_bottom.y = top.y;
-	cyl.m_bottom.z = top.z;
-	cyl.m_direction.x = bottom.x;
-	cyl.m_direction.y = bottom.y;
-	cyl.m_direction.z = bottom.z;
+	cyl.m_bottom = *reinterpret_cast<Vec*>(&top);
+	cyl.m_direction = *reinterpret_cast<Vec*>(&base);
 	cyl.m_radius = kPolyGroupBaseZ;
 	cyl.m_height = kPolyGroupAabbMax;
 	cyl.m_top.x = kPolyGroupAabbMax;
@@ -912,9 +919,13 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 	cyl.m_direction2.y = kPolyGroupAabbMin;
 	cyl.m_direction2.z = kPolyGroupAabbMin;
 
-	return (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), mask) != 0)
-	           ? lbl_8032EC90[0x47]
-	           : 0;
+	if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl),
+	                                reinterpret_cast<Vec*>(&base), mask) != 0)
+	{
+		return lbl_8032EC90[0x47];
+	}
+
+	return 0;
 }
 
 /*
@@ -930,16 +941,12 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 {
 	if ((DAT_8032ed70 & 1) == 0)
 	{
-		CVector bottom(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
+		CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
-		CMapCylinder cyl;
+		CMapCylinderRaw cyl;
 
-		cyl.m_bottom.x = top.x;
-		cyl.m_bottom.y = top.y;
-		cyl.m_bottom.z = top.z;
-		cyl.m_direction.x = bottom.x;
-		cyl.m_direction.y = bottom.y;
-		cyl.m_direction.z = bottom.z;
+		cyl.m_bottom = *reinterpret_cast<Vec*>(&top);
+		cyl.m_direction = *reinterpret_cast<Vec*>(&base);
 		cyl.m_radius = kPolyGroupBaseZ;
 		cyl.m_height = kPolyGroupAabbMax;
 		cyl.m_top.x = kPolyGroupAabbMax;
@@ -949,23 +956,20 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		cyl.m_direction2.y = kPolyGroupAabbMin;
 		cyl.m_direction2.z = kPolyGroupAabbMin;
 
-		if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), hitAttributeMask) != 0)
+		if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl),
+		                                reinterpret_cast<Vec*>(&base), hitAttributeMask) != 0)
 		{
 			return lbl_8032EC90[0x47];
 		}
 	}
 	else
 	{
-		CVector bottom(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
+		CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
-		CMapCylinder cyl;
+		CMapCylinderRaw cyl;
 
-		cyl.m_bottom.x = top.x;
-		cyl.m_bottom.y = top.y;
-		cyl.m_bottom.z = top.z;
-		cyl.m_direction.x = bottom.x;
-		cyl.m_direction.y = bottom.y;
-		cyl.m_direction.z = bottom.z;
+		cyl.m_bottom = *reinterpret_cast<Vec*>(&top);
+		cyl.m_direction = *reinterpret_cast<Vec*>(&base);
 		cyl.m_radius = kPolyGroupBaseZ;
 		cyl.m_height = kPolyGroupAabbMax;
 		cyl.m_top.x = kPolyGroupAabbMax;
@@ -975,7 +979,8 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		cyl.m_direction2.y = kPolyGroupAabbMin;
 		cyl.m_direction2.z = kPolyGroupAabbMin;
 
-		if (MapMng.CheckHitCylinderNear(&cyl, reinterpret_cast<Vec*>(&bottom), m_hitAttributeMask) != 0)
+		if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl),
+		                                reinterpret_cast<Vec*>(&base), m_hitAttributeMask) != 0)
 		{
 			return lbl_8032EC90[0x47];
 		}


### PR DESCRIPTION
## Summary
- Reworked `CAStar::calcPolygonGroup` and `CAStar::calcSpecialPolygonGroup` in `src/astar.cpp` to use explicit `CMapCylinderRaw` stack layout.
- Switched per-field vector writes to full `Vec` copies for cylinder `m_bottom`/`m_direction` and kept scalar initialization order aligned with target codegen.
- Preserved existing behavior and branch logic, including debug-flag mask selection.

## Functions improved
- Unit: `main/astar`
- `calcPolygonGroup__6CAStarFP3Veci`: **42.7094% -> 48.666668%**
- `calcSpecialPolygonGroup__6CAStarFP3Vec`: **51.57143% -> 54.47619%**

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/astar -o - calcPolygonGroup__6CAStarFP3Veci`
  - `build/tools/objdiff-cli diff -p . -u main/astar -o - calcSpecialPolygonGroup__6CAStarFP3Vec`
- `ninja` build passes after changes.

## Plausibility rationale
- The updates reflect plausible original source for game collision checks: filling a raw cylinder struct and passing it to map collision helpers.
- Changes are type/layout-focused and avoid contrived control flow or compiler-specific hacks.

## Technical notes
- Main gain came from matching stack object shape and copy patterns for `Vec` members in the temporary collision cylinder.
- Using branch-local temporary vectors retained existing logic while improving instruction alignment.
