### PR TITLE
menu_letter: decompile LetterDraw + LetterSetAttachItem

### DIFF
--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -1,4 +1,12 @@
 #include "ffcc/menu_letter.h"
+#include "ffcc/p_game.h"
+
+namespace {
+unsigned int DAT_8032eef0 = 0;
+unsigned char DAT_8032eeee = 0;
+unsigned char DAT_8032eeed = 0;
+int DAT_8032eef4 = 0;
+} // namespace
 
 /*
  * --INFO--
@@ -212,12 +220,20 @@ void CMenuPcs::LetterConfirmClose()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 80165b4c
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::LetterDraw()
 {
-	// TODO
+	if (*reinterpret_cast<short*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82C) + 0x30) == 0) {
+		LetterListDraw();
+	} else {
+		LetterMessDraw();
+	}
 }
 
 /*
@@ -272,10 +288,19 @@ void CMenuPcs::LetterDrawPageMark(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8016394c
+ * PAL Size: 64b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::LetterSetAttachItem(unsigned int, int)
+void CMenuPcs::LetterSetAttachItem(unsigned int itemIndex, int flag)
 {
-	// TODO
+	DAT_8032eef0 = itemIndex;
+	if (DAT_8032eeed == 0) {
+		DAT_8032eeee = static_cast<unsigned char>(itemIndex);
+		DAT_8032eef0 = static_cast<unsigned int>(*reinterpret_cast<short*>(Game.game.m_scriptFoodBase[0] + itemIndex * 2 + 0xB6));
+	}
+	DAT_8032eef4 = flag;
 }


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::LetterDraw()` using the PAL control-flow split between list and message modes.
- Implemented `CMenuPcs::LetterSetAttachItem(unsigned int, int)` with the expected attach-index/flag state updates and caravan lookup path.
- Updated both function doc blocks to the required PAL/EN/JP info format.

## Functions Improved
- Unit: `main/menu_letter`
- `LetterDraw__8CMenuPcsFv` (PAL 80165b4c, 56b): now 100.0% symbol match in objdiff.
- `LetterSetAttachItem__8CMenuPcsFUii` (PAL 8016394c, 64b): now 44.0625% symbol match in objdiff.

## Match Evidence
- Unit-level matched functions improved from selector baseline `0/12` to `1/12` (`8.33%`) after this change.
- Unit matched code is now `56 / 17544` bytes (`0.319%`) from `build/GCCP01/report.json`.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/menu_letter -o - LetterDraw__8CMenuPcsFv`
  - `build/tools/objdiff-cli diff -p . -u main/menu_letter -o - LetterSetAttachItem__8CMenuPcsFUii`

## Plausibility Rationale
- The implementation follows existing decomp style in this repo: direct field-offset access for `CMenuPcs` menu state and explicit global attach-state bookkeeping.
- No compiler-coaxing temporaries/reordering were introduced; logic is the straightforward source-level behavior implied by the PAL decomp and symbol metadata.

## Technical Notes
- `LetterDraw` resolves to a clean mode dispatch (list draw vs message draw) and fully matches target assembly.
- `LetterSetAttachItem` currently improves substantially but is not yet full match; remaining deltas are primarily around addressing/register allocation and global symbol layout.
