### PR TITLE
main: improve game() option-flag branch matching

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,10 +79,13 @@ void game(int argc, char** argv)
                 c = (*argument)[0];
                 if ((c == '-') || (c == '/')) {
                     c = (*argument)[1];
-                    if (c == 'l') {
+                    switch (c) {
+                    case 'l':
                         parseLanguage = 1;
-                    } else if ((c < 'l') && (c == 'f')) {
+                        break;
+                    case 'f':
                         copyScriptName = 1;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Reworked the `game()` command-option branch in `src/main.cpp` from a coupled `if/else if` expression to a `switch` on `argument[1]`.
- Kept behavior unchanged for supported options (`-l`/`/l` and `-f`/`/f`).
- Left all other parsing logic intact.

## Functions improved
- Unit: `main/main`
- Symbol: `game__FiPPc`
- Size: `476b` (unchanged)

## Match evidence
- `game__FiPPc`: **83.336136% -> 87.579834%**
- objdiff oneshot command used:
  - `build/tools/objdiff-cli diff -p . -u main/main -o - game__FiPPc`
- Instruction diff signal improved in the option-parse block (removed opcode mismatches and reduced insert/delete noise):
  - Before: `53 ARG_MISMATCH, 6 DELETE, 7 INSERT, 2 OP_MISMATCH, 5 REPLACE`
  - After: `56 ARG_MISMATCH, 3 DELETE, 5 INSERT, 0 OP_MISMATCH, 5 REPLACE`

## Plausibility rationale
- A `switch` on a single-character option is a straightforward, idiomatic source form for command-line parsing in this codebase.
- The change does not introduce compiler-coaxing artifacts or readability regressions; it simplifies intent while preserving behavior.

## Technical details
- The previous condition used an odd coupled branch (`(c < 'l') && (c == 'f')`) that emitted less-aligned control flow in this region.
- Replacing it with explicit `case 'l'` and `case 'f'` improved branch structure alignment in objdiff while keeping all side effects unchanged.
