### PR TITLE
pppLaser: improve pppConstruct2Laser codegen match

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -160,18 +160,18 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
 void pppConstruct2Laser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
     f32 fVar1 = FLOAT_80333428;
-    int iVar2 = 0x80 + param_2->offsets->m_serializedDataOffsets[2];
+    u8* work = (u8*)pppLaser + param_2->offsets->m_serializedDataOffsets[2] + 0x80;
 
-    *(f32*)((u8*)pppLaser + iVar2 + 0x18) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x14) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x10) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0xc) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x8) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x4) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x28) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x24) = fVar1;
-    *(f32*)((u8*)pppLaser + iVar2 + 0x20) = fVar1;
-    *((u8*)pppLaser + iVar2 + 0x2c) = 0;
+    *(f32*)(work + 0x18) = FLOAT_80333428;
+    *(f32*)(work + 0x14) = fVar1;
+    *(f32*)(work + 0x10) = fVar1;
+    *(f32*)(work + 0x0C) = fVar1;
+    *(f32*)(work + 0x08) = fVar1;
+    *(f32*)(work + 0x04) = fVar1;
+    *(f32*)(work + 0x28) = fVar1;
+    *(f32*)(work + 0x24) = fVar1;
+    *(f32*)(work + 0x20) = fVar1;
+    *(work + 0x2C) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refactored `pppConstruct2Laser` pointer math in `src/pppLaser.cpp` to use a computed work-base pointer.
- Kept behavior identical while shaping codegen toward target register/addressing form (`add r4, r3, r4` and `stfs/stb` off `r4`).

## Functions Improved
- Unit: `main/pppLaser`
- Function: `pppConstruct2Laser`
  - Before: `96.47059%`
  - After: `99.70588%`

## Match Evidence
- Unit fuzzy match:
  - Before: `37.371265`
  - After: `37.415657`
- Instruction diff is now fully aligned except a single `DIFF_ARG_MISMATCH` on the SDA21 float symbol label for `FLOAT_80333428` load.

## Plausibility Rationale
- The change is source-plausible and idiomatic for this codebase: compute a working base pointer once and write contiguous fields through it.
- No contrived temporaries or artificial control-flow changes were introduced.
- This is a direct improvement in code generation alignment, not formatting-only churn.

## Technical Notes
- Previous form used repeated `(u8*)pppLaser + iVar2 + ...` addressing and compiled with stores off `r3`.
- New form stores through `work` and compiles to the target-style addressing sequence.
