### PR TITLE
p_usb: raise __sinit_p_usb_cpp match to 98.6%

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -11,9 +11,9 @@ int DAT_8032ec68;
 
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
-extern void* __vt__8CManager;
-extern void* lbl_801E8668;
-extern void* lbl_801E8830;
+extern "C" char __vt__8CManager[];
+extern "C" char lbl_801E8668[];
+extern "C" char lbl_801E8830[];
 extern u32 lbl_801E8690[];
 extern u32 lbl_801E869C[];
 extern u32 lbl_801E86A8[];
@@ -147,9 +147,7 @@ void CUSBPcs::mccReadData()
 	if (4 < DAT_8032ec68)
 	{
 		DAT_8032ec68 = 0;
-		if (USB.IsConnected() == 0) {
-			return;
-		}
+		USB.IsConnected();
 	}
 }
 
@@ -247,23 +245,23 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
  */
 extern "C" void __sinit_p_usb_cpp()
 {
-    volatile void** base = (volatile void**)&USBPcs;
-    *base = &__vt__8CManager;
-    *base = &lbl_801E8668;
-    *base = &lbl_801E8830;
+    void* vtbl = __vt__8CManager;
+    *reinterpret_cast<void**>(&USBPcs) = vtbl;
+    *reinterpret_cast<void**>(&USBPcs) = lbl_801E8668;
+    *reinterpret_cast<void**>(&USBPcs) = lbl_801E8830;
 
-    u32* dst = lbl_801E86B4 + 1;
+    u32* dst = lbl_801E86B4;
     u32* src0 = lbl_801E8690;
     u32* src1 = lbl_801E869C;
     u32* src2 = lbl_801E86A8;
 
-    dst[0] = src0[0];
-    dst[1] = src0[1];
-    dst[2] = src0[2];
-    dst[3] = src1[0];
-    dst[4] = src1[1];
-    dst[5] = src1[2];
-    dst[6] = src2[0];
-    dst[7] = src2[1];
-    dst[8] = src2[2];
+    dst[1] = src0[0];
+    dst[2] = src0[1];
+    dst[3] = src0[2];
+    dst[4] = src1[0];
+    dst[5] = src1[1];
+    dst[6] = src1[2];
+    dst[7] = src2[0];
+    dst[8] = src2[1];
+    dst[9] = src2[2];
 }


### PR DESCRIPTION
## Summary
- Updated `src/p_usb.cpp` static initialization and data table copy style in `__sinit_p_usb_cpp` to follow existing project patterns (`pad.cpp`/`p_system.cpp`) and generate cleaner relocation/codegen behavior.
- Removed an extra conditional early-return path in `CUSBPcs::mccReadData()` and kept the connectivity check as a side-effect call, matching the decompilation behavior.
- Adjusted external symbol declarations for vtable/label entries to pointer-compatible array declarations used elsewhere in this codebase.

## Functions improved
- Unit: `main/p_usb`
- `__sinit_p_usb_cpp`: **73.90909% -> 98.63636%** (`+24.72727`)
- `mccReadData__7CUSBPcsFv`: unchanged at `82.03704%`
- `SendDataCode__7CUSBPcsFiPvii`: unchanged at `84.150375%`

## Match evidence
- Objdiff (function-level, one-shot JSON) shows only one function delta in this unit:
  - `__sinit_p_usb_cpp` increased by `+24.72727` points.
- Unit fuzzy match (`build/GCCP01/report.json`):
  - **85.89091% -> 88.55151%**
- Build verification: `ninja` completes successfully after the change.

## Plausibility rationale
- The new `__sinit_p_usb_cpp` structure mirrors established source conventions already present in the repository for static process/dispatch-table initialization.
- The `mccReadData` update removes a branch whose return value handling did not match expected original behavior; leaving a side-effect connectivity probe is a plausible and cleaner source-level form.
- Changes are minimal and semantic-preserving from the game logic perspective, focused on ABI/codegen alignment rather than contrived compiler coaxing.

## Technical details
- Replaced volatile/address-of initializer writes with direct vtable pointer writes (`reinterpret_cast<void**>(&USBPcs)` assignments), matching neighboring translation units.
- Rebased descriptor copy indexing to explicit `[1..9]` slots in the destination table to align with observed static table layout.
- Validated no regressions inside `main/p_usb` by diffing all function-level match percentages before vs after.
