### PR TITLE
prgobj: improve reqAnim bitflag codegen match

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -247,8 +247,8 @@ void CGPrgObj::reqAnim(int animId, int loop, int direct)
 {
 	m_animFlags = (m_animFlags & 0x7f) | 0x80;
 	m_reqAnimId = animId;
-	m_animFlags = ((loop << 6) & 0x40) | (m_animFlags & 0xbf);
-	m_animFlags = ((direct << 5) & 0x20) | (m_animFlags & 0xdf);
+	m_animFlags = ((u8)loop << 6) | (m_animFlags & 0xbf);
+	m_animFlags = ((u8)direct << 5) | (m_animFlags & 0xdf);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CGPrgObj::reqAnim(int animId, int loop, int direct)` to treat `loop` and `direct` as byte-valued flag sources when packing animation control bits.
- Kept behavior unchanged while reducing sign-extension-related instruction drift in this function.

## Functions improved
- Unit: `main/prgobj`
- Symbol: `reqAnim__8CGPrgObjFiii`

## Match evidence
- `objdiff` before: `47.857143%`
- `objdiff` after: `62.142857%`
- Instruction diffs in symbol: `15 -> 8`
- Validation command:
  - `build/tools/objdiff-cli diff -p . -u main/prgobj -o - reqAnim__8CGPrgObjFiii`

## Plausibility rationale
- `m_animFlags` is an 8-bit field. Packing control bits from byte semantics is source-plausible and consistent with this codebase's flag handling style.
- This avoids compiler-generated signed-byte extension patterns that do not reflect likely original intent for bitflags.

## Technical details
- Changed:
  - `m_animFlags = ((loop << 6) & 0x40) | (m_animFlags & 0xbf);`
  - `m_animFlags = ((direct << 5) & 0x20) | (m_animFlags & 0xdf);`
- To:
  - `m_animFlags = ((u8)loop << 6) | (m_animFlags & 0xbf);`
  - `m_animFlags = ((u8)direct << 5) | (m_animFlags & 0xdf);`
- Result: better alignment against target object in the affected symbol with no other functional changes.
