### PR TITLE
pppScreenBreak: raise pppCon2ScreenBreak match to 99.33%

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -553,9 +553,10 @@ void pppCon2ScreenBreak(PScreenBreak* pppScreenBreak, UnkC* param_2)
 {
     s32 dataOffset = param_2->m_serializedDataOffsets[2];
     float* value = (float*)((u8*)pppScreenBreak + dataOffset + 0x80);
+    float f = FLOAT_80331cc4;
     value[2] = FLOAT_80331cc4;
-    value[1] = FLOAT_80331cc4;
-    value[0] = FLOAT_80331cc4;
+    value[1] = f;
+    *value = f;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adjusted `pppCon2ScreenBreak` initialization sequencing to better match original MWCC codegen.
- Introduced a local float temporary and used `*value` for the last store while preserving behavior.

## Functions improved
- Unit: `main/pppScreenBreak`
- Symbol: `pppCon2ScreenBreak`

## Match evidence
- Before: `77.111115%` match, query size `44b`
- After: `99.333336%` match, query size `36b` (target size-aligned)
- Objdiff deltas: removed two inserted `lfs` instructions in the store sequence; remaining mismatches are two argument-level differences at function start.

## Plausibility rationale
- This is source-plausible cleanup: all three values are still initialized to the same constant (`FLOAT_80331cc4`) with no behavioral change.
- The rewrite reflects a natural coding style (single temporary reused across related assignments), rather than contrived compiler-only constructs.

## Technical details
- Change localized to `src/pppScreenBreak.cpp` in `pppCon2ScreenBreak`.
- Build verified with `ninja` after edit.
- Validation command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - pppCon2ScreenBreak`
