### PR TITLE
pppYmTraceMove: improve constructor match with Vec temporaries

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -22,36 +22,23 @@ extern "C" {
  */
 void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
 {
-	union {
-		Vec vec;
-		u32 words[3];
-	} local_20;
-
-	Vec local_38;
 	Vec* dest;
+	Vec local_20;
 	f32 zero;
-	u32 local_24;
-	u32 local_28;
-	u32 local_2c;
-	u32 local_18;
-	u32 local_1c;
-
-	local_2c = *(u32*)((u8*)pppMngStPtr + 0x58);
-	local_28 = *(u32*)((u8*)pppMngStPtr + 0x5c);
+	Vec local_38;
+	Vec local_2c;
 	dest = (Vec*)((u8*)pppYmTraceMove + 0x80 + *param_2->m_serializedDataOffsets);
-	local_24 = *(u32*)((u8*)pppMngStPtr + 0x60);
-	local_20.words[0] = *(u32*)((u8*)pppMngStPtr + 0x68);
-	local_1c = *(u32*)((u8*)pppMngStPtr + 0x6c);
-	local_18 = *(u32*)((u8*)pppMngStPtr + 0x70);
-	local_20.words[1] = local_1c;
-	local_20.words[2] = local_18;
-	pppSubVector__FR3Vec3Vec3Vec((Vec*)&dest[1].y, &local_20.vec, (Vec*)&local_2c);
-
+	local_2c.x = *(f32*)((u8*)pppMngStPtr + 0x58);
+	local_2c.y = *(f32*)((u8*)pppMngStPtr + 0x5c);
+	local_2c.z = *(f32*)((u8*)pppMngStPtr + 0x60);
+	local_20.x = *(f32*)((u8*)pppMngStPtr + 0x68);
+	local_20.y = *(f32*)((u8*)pppMngStPtr + 0x6c);
+	local_20.z = *(f32*)((u8*)pppMngStPtr + 0x70);
+	pppSubVector__FR3Vec3Vec3Vec((Vec*)&dest[1].y, &local_20, &local_2c);
 	local_38.x = dest[1].y;
 	local_38.y = dest[1].z;
 	local_38.z = dest[2].x;
 	pppCopyVector__FR3Vec3Vec(dest, &local_38);
-
 	zero = 0.0f;
 	dest[3].x = 0.0f;
 	dest[2].z = zero;


### PR DESCRIPTION
## Summary
- Reworked `pppConstructYmTraceMove` to use `Vec`-typed temporaries for saved/param vectors instead of `u32` staging + union packing.
- Kept runtime behavior identical (same loads, subtraction, copy-back, and zero initialization), but adjusted local layout and typed accesses.

## Functions Improved
- Unit: `main/pppYmTraceMove`
- Function: `pppConstructYmTraceMove` (`PAL 0x800d4bd0`, 172b)
  - Before: `59.069767%`
  - After: `64.48837%`
  - Delta: `+5.418603` points
- Function: `pppFrameYmTraceMove` unchanged at `66.36752%`

## Match Evidence
- Unit `.text` match (`main/pppYmTraceMove`, 1108b):
  - Before: `65.23466%`
  - After: `66.07581%`
  - Net delta: `+0.84115` points
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmTraceMove -o - pppFrameYmTraceMove`

## Plausibility Rationale
- The updated constructor uses straightforward typed `Vec` temporaries for particle manager position/parameter vectors, which is a natural source-level representation.
- Removed coercive `u32` aliasing/packing patterns that were less source-plausible while preserving operation order and data flow.

## Technical Details
- Declaration/order of locals was adjusted to improve stack/register layout in constructor codegen.
- Vector component loads are now explicit `f32` accesses prior to `pppSubVector__FR3Vec3Vec3Vec`, followed by unchanged copy/zero-out sequence.
- Full build validated with `ninja`.
