### PR TITLE
p_tina: implement create and LoadMenuPdt

### DIFF
--- a/include/ffcc/p_tina.h
+++ b/include/ffcc/p_tina.h
@@ -65,7 +65,7 @@ public:
 
     void LoadFieldPdt(int, int, void*, unsigned long, unsigned char);
     void LoadMonsterPdt(int, int, void*, int, void*, int);
-    void LoadMenuPdt(char*);
+    int LoadMenuPdt(char*);
     void ReleasePdt(int);
 
     void StartLocationTitle();


### PR DESCRIPTION
## Summary
- Implemented `CPartPcs::create()` in `src/p_tina.cpp` using the current Ghidra reference flow and existing project conventions.
- Implemented `CPartPcs::LoadMenuPdt(char*)` (and corrected declaration to return `int`) with matching stage selection/load/reset behavior.
- Added PAL metadata blocks for both implemented functions.

## Functions Improved
- Unit: `main/p_tina`
- `create__8CPartPcsFv`
- `LoadMenuPdt__8CPartPcsFPc`

## Match Evidence
- `create__8CPartPcsFv`: **1.2195122% -> 55.963413%**
- `LoadMenuPdt__8CPartPcsFPc`: **1.0204082% -> 60.52041%**
- Build verification: `ninja` succeeds after changes.

## Plausibility Rationale
- Both implementations follow the same control flow and side-effect ordering shown in the decomp reference:
  - Stage initialization/selection,
  - part manager reset and load calls,
  - load failure cleanup via `pppReleasePdt`,
  - success flag updates and stage restoration.
- The return type correction for `LoadMenuPdt` aligns with observed behavior (slot index return semantics) and the target symbol.
- No contrived temporary-only rewrites or non-idiomatic control flow were introduced.

## Technical Details
- `create()` now initializes USB stream state, allocates default/amem stages conditionally, initializes `CAMemCacheSet`, zeroes `PartMng`, and calls `PartMng.Create()`.
- `LoadMenuPdt()` now:
  - builds language-specific menu PDT/PTX path,
  - sets `m_stageLoad` and amem cache read stage,
  - resets part-load state fields,
  - acquires a free PDT slot and performs PTX/PDT load with failure fallback,
  - restores default stage and returns slot index.
