### PR TITLE
p_usb: improve IsBigAlloc match via lbl_8032F810 symbol typing

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -18,7 +18,7 @@ extern u32 lbl_801E8690[];
 extern u32 lbl_801E869C[];
 extern u32 lbl_801E86A8[];
 extern u32 lbl_801E86B4[];
-extern char lbl_8032F810[];
+extern char lbl_8032F810;
 extern CUSBPcs USBPcs;
 
 
@@ -38,7 +38,7 @@ CUSBPcs::CUSBPcs()
  */
 void CUSBPcs::Init()
 { 
-	m_smallStage = Memory.CreateStage(0x2000, lbl_8032F810, 0);
+	m_smallStage = Memory.CreateStage(0x2000, &lbl_8032F810, 0);
 	m_bigStage = (CMemory::CStage*)nullptr;
 
 	strcpy(m_rootPath, "plot/kmitsuru/");
@@ -82,7 +82,7 @@ void* CUSBPcs::GetTable(unsigned long param)
 void CUSBPcs::IsBigAlloc(int param_2)
 {
     if ((param_2 != 0) && (m_bigStage == (CMemory::CStage*)nullptr)) {
-        m_bigStage = Memory.CreateStage(0x100000, lbl_8032F810, 0);
+        m_bigStage = Memory.CreateStage(0x100000, &lbl_8032F810, 0);
     } else if ((param_2 == 0) && (m_bigStage != (CMemory::CStage*)nullptr)) {
         Memory.DestroyStage(m_bigStage);
         m_bigStage = (CMemory::CStage*)nullptr;


### PR DESCRIPTION
## Summary
- Updated `lbl_8032F810` declaration in `src/p_usb.cpp` from array-form to symbol-form (`extern char lbl_8032F810`) and passed it explicitly as an address at call sites.
- Adjusted stage creation call arguments in `CUSBPcs::Init` and `CUSBPcs::IsBigAlloc` to use `&lbl_8032F810`.

## Functions Improved
- Unit: `main/p_usb`
- Primary improvement:
  - `IsBigAlloc__7CUSBPcsFi`
- Secondary impact:
  - `Init__7CUSBPcsFv` (regressed slightly)

## Match Evidence
- Unit fuzzy match (`main/p_usb`):
  - Before: `88.55151`
  - After:  `88.718185`
  - Delta:  `+0.166675`
- `IsBigAlloc__7CUSBPcsFi`:
  - Before: `85.30303%`
  - After:  `88.181816%`
  - Delta:  `+2.878786%`
- `Init__7CUSBPcsFv`:
  - Before: `88.62069%`
  - After:  `87.24138%`
  - Delta:  `-1.37931%`

## Plausibility Rationale
- Treating `lbl_8032F810` as a symbol address instead of array syntax is source-plausible for this codebase’s linker-label style globals.
- The change is type/layout-neutral at runtime for pointer use (address of first byte), but materially affects relocation/codegen shape in `IsBigAlloc`, producing better alignment with target assembly.

## Technical Details
- Objdiff indicated relocation/form differences around stage-label argument materialization in `IsBigAlloc`.
- This update shifts argument formation toward target behavior and improves the key target function’s match score.
- Full build still passes with `ninja`.
