### PR TITLE
menu_item: correct item entry layout used by ItemOpen/ItemClose

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -71,10 +71,13 @@ struct MenuItemOpenAnim {
     s16 h;
     float alpha;
     float scale;
+    float progress;
+    float uvScale;
+    int tex;
     int frame;
+    int unk24;
     int duration;
     unsigned int flags;
-    float progress;
     float dx;
     float dy;
     float targetX;


### PR DESCRIPTION
## Summary
- Corrected MenuItemOpenAnim field layout in src/menu_item.cpp to match the unit's 0x40-byte item entry stride used throughout menu item code.
- Added missing in-record fields between scale and frame (progress, uvScale, tex) and preserved the trailing animation fields.
- This removes an implausible 44-byte struct interpretation and aligns source layout with existing pointer arithmetic (+0x20 shorts per entry).

## Functions improved
- main/menu_item :: ItemOpen__8CMenuPcsFv
- main/menu_item :: ItemClose__8CMenuPcsFv

## Match evidence
Objdiff (build/tools/objdiff-cli diff -p . -u main/menu_item -o - <symbol>):
- ItemOpen__8CMenuPcsFv: 41.08108% -> 41.09910%
- ItemClose__8CMenuPcsFv: 41.83158% -> 41.85263%

## Plausibility rationale
- The file already manipulates these records as fixed 0x40-byte entries (for example, s16* stepping by 0x20), so a 44-byte C struct is structurally inconsistent with surrounding source.
- Restoring a consistent record layout is a source-level correction, not compiler-coaxing.

## Technical notes
- During verification, an alternate arithmetic rewrite for interpolation regressed match and was discarded.
- Final PR keeps only the layout correction and rebuilds cleanly with ninja.
