### PR TITLE
materialman: implement addtev_bump_jimen

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -18,6 +18,15 @@ extern "C" void __dt__10CTexScrollFv(void*, int);
 extern "C" void __construct_array(void*, void (*)(void*), void (*)(void*, int), unsigned long, unsigned long);
 extern "C" void __destroy_arr(void*, void*, unsigned long, unsigned long);
 extern "C" int CheckName__8CTextureFPc(CTexture*, char*);
+extern "C" void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+extern "C" void _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(
+    int, int, int, int, int);
+extern "C" void _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(
+    int, int, int, int, int);
+extern "C" void _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int,
+                                                                                                        int, int, int);
+extern "C" void _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(int, int, int,
+                                                                                                        int, int, int);
 class CMapKeyFrame;
 extern "C" float Get__12CMapKeyFrameFv(CMapKeyFrame*);
 extern "C" void Calc__12CMapKeyFrameFv(CMapKeyFrame*);
@@ -396,12 +405,34 @@ void CMaterialMan::addtev_bump_spec_col_water(_GXTevScale)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80042b58
+ * PAL Size: 264b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMaterialMan::addtev_bump_jimen(_GXTevScale)
 {
-	// TODO
+    int tevStage = *reinterpret_cast<int*>(Ptr(this, 0x60));
+
+    GXSetIndTexMtx((GXIndTexMtxID)1, reinterpret_cast<const float(*)[3]>(0x8026901c), 0);
+    GXSetNumIndStages(1);
+    GXSetIndTexOrder((GXIndTexStageID)0,
+                     *reinterpret_cast<GXTexCoordID*>(Ptr(this, 0x1E8)),
+                     *reinterpret_cast<GXTexMapID*>(Ptr(this, 0x1C4)));
+    GXSetIndTexCoordScale((GXIndTexStageID)0, (GXIndTexScale)0, (GXIndTexScale)0);
+    GXSetTevIndBumpXYZ((GXTevStageID)tevStage, (GXIndTexStageID)0, (GXIndTexMtxID)1);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(
+        tevStage, *reinterpret_cast<int*>(Ptr(this, 0x1F8)), *reinterpret_cast<int*>(Ptr(this, 0x1C8)), 0xFF);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(
+        tevStage, 0xF, 4, 9, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(
+        tevStage, 7, 7, 7, 0);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(tevStage, 0, 0, 0, 1, 0);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(tevStage, 0, 0, 0, 1, 0);
+    *reinterpret_cast<unsigned int*>(Ptr(this, 0x60)) =
+        (((*reinterpret_cast<unsigned int*>(Ptr(this, 0x60))) & 0xFF) + 1) & 0xFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMaterialMan::addtev_bump_jimen(_GXTevScale)` in `src/materialman.cpp` from the current PAL decomp reference instead of a TODO stub.
- Added the required `_GXSetTev*` helper extern declarations used by this function.
- Updated the function header to include PAL address/size metadata:
  - PAL Address: `0x80042b58`
  - PAL Size: `264b`

## Functions Improved
- Unit: `main/materialman`
- Function: `addtev_bump_jimen__12CMaterialManF11_GXTevScale`
  - Before: `1.5151515%` (size `264b`)
  - After: `74.43939%` (size `264b`)

## Match Evidence
- `ninja` rebuild succeeded and regenerated `build/GCCP01/report.json`.
- `main/materialman` unit fuzzy match:
  - Before: `13.471498%`
  - After: `14.081201%`
- `objdiff-cli` for `addtev_bump_jimen__12CMaterialManF11_GXTevScale` now shows substantially more aligned instructions (90 matched instructions), with remaining diffs mostly argument/opcode-level around constants/register allocation.

## Plausibility Rationale
- The change replaces a placeholder TODO with a straightforward TEV/indirect-texture setup routine that matches the surrounding material pipeline style used across this codebase.
- Field accesses use existing `Ptr(this, offset)` conventions already present in `materialman.cpp`, avoiding contrived control flow or compiler-coaxing patterns.
- The implementation keeps semantic behavior clear and idiomatic for the original rendering setup sequence: configure indirection, configure TEV stage inputs/ops, then increment current TEV stage index.

## Technical Details
- Sequence implemented from decomp reference:
  1. Configure indirect matrix/stage/order/scale.
  2. Configure TEV indirect bump and TEV stage order/color/alpha ops.
  3. Advance the current stage index at offset `0x60` using an 8-bit masked increment.
- Calls used:
  - `GXSetIndTexMtx`, `GXSetNumIndStages`, `GXSetIndTexOrder`, `GXSetIndTexCoordScale`, `GXSetTevIndBumpXYZ`
  - `_GXSetTevOrder__...`, `_GXSetTevColorIn__...`, `_GXSetTevAlphaIn__...`, `_GXSetTevColorOp__...`, `_GXSetTevAlphaOp__...`
