### PR TITLE
memory: implement CStage heap debug helpers

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -26,7 +26,7 @@ public:
         int heapWalker(int, void*, unsigned long);
         void drawHeapBar(int);
         void drawHeapTitle(int);
-        void GetHeapUnuse();
+        int GetHeapUnuse();
         void heapInfo(unsigned long&, unsigned long&, unsigned long&);
         void GetTail();
         void GetTop();


### PR DESCRIPTION
## Summary
- Implemented `CMemory::CStage::drawHeapBar`, `drawHeapTitle`, and `GetHeapUnuse` in `src/memory.cpp` using the PAL Ghidra references as structure guidance.
- Updated `CStage::GetHeapUnuse` declaration in `include/ffcc/memory.h` from `void` to `int` to match symbol behavior.
- Added PAL address/size INFO headers for the three implemented functions.

## Functions improved
Unit: `main/memory`
- `GetHeapUnuse__Q27CMemory6CStageFv` (88b)
  - objdiff match: **81.318184%**
- `drawHeapTitle__Q27CMemory6CStageFi` (396b)
  - objdiff match: **0.83838385%**
- `drawHeapBar__Q27CMemory6CStageFi` (1088b)
  - objdiff match: **0.0%** (still under active decomp convergence)

## Match evidence
Command used:
```sh
build/tools/objdiff-cli diff -p . -u main/memory -o - drawHeapBar__Q27CMemory6CStageFi > diff_drawHeapBar.json
```
Extracted symbol results from `diff_drawHeapBar.json`:
- `GetHeapUnuse__Q27CMemory6CStageFv`: `81.318184`
- `drawHeapTitle__Q27CMemory6CStageFi`: `0.83838385`
- `drawHeapBar__Q27CMemory6CStageFi`: `0.0`

## Plausibility rationale
- Changes favor source-plausible behavior over compiler-only coaxing:
  - corrected `GetHeapUnuse` return type to reflect actual API semantics,
  - kept allocator metadata traversal logic straightforward and consistent with nearby heap code,
  - preserved existing memory-layout access patterns (`reinterpret_cast` + fixed offsets) already used throughout `memory.cpp`.
- No contrived temporaries or artificial control-flow tricks were introduced solely to manipulate codegen.

## Technical details
- `drawHeapBar` now builds a compact occupancy buffer and emits debug quads via GX calls.
- `drawHeapTitle` now computes total/max free block sizes and draws per-stage debug strings.
- `GetHeapUnuse` now iterates heap nodes and accumulates free sizes until sentinel termination.
- Verified with `ninja` (build success).
