### PR TITLE
menu_cmd: implement CmdClose1 close-state logic

### DIFF
--- a/include/ffcc/menu_cmd.h
+++ b/include/ffcc/menu_cmd.h
@@ -26,7 +26,7 @@ public:
     void UniteOpenAnim(int);
     int UniteCloseAnim(int);
     void CmdOpen1();
-    void CmdClose1();
+    unsigned int CmdClose1();
     void CmdOpen2();
     void CmdClose2();
     const char* GetSkillStr(int);


### PR DESCRIPTION
## Summary
- Implemented `CmdClose1__8CMenuPcsFv` in `src/menu_cmd.cpp` using the existing offset/field access style already used by nearby `CmdCtrl`, `CmdOpen0`, and `CmdClose0` code.
- Updated declaration/signature to return `unsigned int` so the symbol matches call sites that treat this as a state-machine completion return.
- Added PAL info block metadata for the implemented function.

## Functions improved
- Unit: `main/menu_cmd`
- Symbol: `CmdClose1__8CMenuPcsFv`

## Match evidence
- Before: `0.33222592%`
- After: `32.372093%`
- Measurement command:
  - `build/tools/objdiff-cli diff -p . -u main/menu_cmd -o - CmdClose1__8CMenuPcsFv`

## Plausibility rationale
- The function now behaves as a menu command-close state machine with explicit state transitions (`0..4`), animation timing, and command-list updates, which is consistent with adjacent menu command functions in this unit.
- The implementation favors type/signature corrections, control-flow restoration, and data-structure field usage over compiler-only tricks.

## Technical details
- Restored timer-driven close animation progression and completion checks.
- Restored branch handling for unite close/open flow, including calls to `ChkUnite`, `UniteCloseAnim`, `UniteOpenAnim__8CMenuPcsFi`, `UniteComList__12CCaravanWorkFiii`, and `UnuniteComList__12CCaravanWorkFii`.
- Verified project build passes with `ninja` after changes.
