### PR TITLE
p_light: implement CLightPcs::InsertOctTree

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/p_light.h"
 
 #include "ffcc/graphic.h"
+#include "ffcc/mapocttree.h"
 
 #include <dolphin/mtx.h>
 #include <dolphin/gx/GXVert.h>
@@ -865,12 +866,25 @@ void CLightPcs::SetPart(CLightPcs::TARGET target, void* part, unsigned char mode
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80048cbc
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CLightPcs::InsertOctTree(CLightPcs::TARGET, COctTree&)
+void CLightPcs::InsertOctTree(CLightPcs::TARGET target, COctTree& octTree)
 {
-	// TODO
+    char* light = (char*)this + 0x63c;
+    u32 i;
+
+    octTree.ClearLight();
+    for (i = 0; i < *(u32*)((char*)this + 0xb8); i++) {
+        if (*(char*)(light + 0x60 + (int)target) != '\0') {
+            octTree.InsertLight(i, *(Vec*)(light + 4), *(float*)(light + 0x24), *(u32*)(light + 0x34));
+        }
+        light += 0xb0;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CLightPcs::InsertOctTree(CLightPcs::TARGET, COctTree&)` in `src/p_light.cpp`.
- Replaced the TODO stub with a loop that clears octree light state, iterates active light slots, filters by target enable flag, and inserts each matching light using position/radius/mask fields.
- Added PAL metadata for the function (`0x80048cbc`, `128b`) and included `ffcc/mapocttree.h` for method declarations.

## Functions improved
- Unit: `main/p_light`
- Symbol: `InsertOctTree__9CLightPcsFQ29CLightPcs6TARGETR8COctTree`

## Match evidence
- Before: `3.125%`
- After: `71.34375%`
- Measurement command:
  - `build/tools/objdiff-cli diff -p . -u main/p_light -o - InsertOctTree__9CLightPcsFQ29CLightPcs6TARGETR8COctTree`

## Plausibility rationale
- The implementation follows existing source patterns in this repo (`char*` base + known offsets) and expresses straightforward original-engine logic: clear octree light entries, iterate light array, and insert enabled lights.
- No contrived temporaries or unnatural reorder-only transformations were added.

## Technical details
- Current remaining delta is primarily register/argument allocation differences (`DIFF_ARG_MISMATCH`) and a few structural instruction differences, indicating semantic alignment with compiler-output gaps remaining.
- This is a first-pass conversion of a previously empty function body, yielding substantial real assembly alignment improvement.
