### PR TITLE
main/mapobj: implement SetDrawFlag

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -655,12 +655,32 @@ void CMapObj::Draw(unsigned char priority)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80028FD8
+ * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapObj::SetDrawFlag()
 {
-	// TODO
+    U8At(this, 0x18) &= 0xFB;
+
+    if ((U8At(this, 0x1D) == 1) && (PtrAt(this, 0xC) != 0)) {
+        if ((U8At(this, 0x1F) == 0xFF) && ((U8At(this, 0x18) & 1) != 0)) {
+            unsigned char* mapMng = reinterpret_cast<unsigned char*>(&MapMng);
+            Mtx concatMtx;
+            Mtx* viewMtx = reinterpret_cast<Mtx*>(mapMng + 0x22958);
+            CBound* bound = reinterpret_cast<CBound*>(reinterpret_cast<unsigned char*>(PtrAt(this, 0xC)) + 0xC);
+
+            PSMTXConcat(*viewMtx, MtxAt(this, 0xB8), concatMtx);
+            if (bound->CheckFrustum(*reinterpret_cast<Vec*>(mapMng + 0x228EC),
+                                    *viewMtx,
+                                    *reinterpret_cast<float*>(mapMng + 0x22A74)) != 0) {
+                U8At(this, 0x18) |= 4;
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapObj::SetDrawFlag()` in `src/mapobj.cpp` from the current decomp/assembly behavior instead of leaving it as a stub.
- Added required PAL metadata block for the function (`0x80028FD8`, `188b`) with EN/JP placeholders.
- Kept code source-plausible by using existing `MapMng` offset access patterns already used in this unit.

## Functions improved
- Unit: `main/mapobj`
- Symbol: `SetDrawFlag__7CMapObjFv`

## Match evidence
- Before: `2.1%` (from `tools/agent_select_target.py` target listing for `main/mapobj`)
- After: `53.89%` (from `build/tools/objdiff-cli diff -p . -u main/mapobj SetDrawFlag__7CMapObjFv`)
- Assembly alignment improved from a stub body to the expected frustum-check flow (flag clear, condition gates, matrix concat, `CBound::CheckFrustum`, draw-flag set).

## Plausibility rationale
- Logic matches expected original gameplay behavior for map-object visibility gating:
  - clear draw bit,
  - require active type/object state,
  - run frustum test with map view data,
  - set draw bit on positive visibility.
- Uses the same low-level offset style and helper access approach already present in `mapobj.cpp`, avoiding contrived compiler-only transformations.

## Technical details
- Added matrix and frustum argument wiring with map manager offsets used by this object module:
  - view position: `+0x228EC`
  - view matrix: `+0x22958`
  - map-object draw range: `+0x22A74`
- Verified by successful `ninja` build after implementation.
