### PR TITLE
RedCommand: implement SetSePan and SetSePitch

### DIFF
--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -345,22 +345,64 @@ void SetSeVolume(int seId, int volume, int frameCount, int mode)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cae20
+ * PAL Size: 164b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SetSePan(int, int, int)
+void SetSePan(int seId, int pan, int frameCount)
 {
-	// TODO
+	int* track;
+	int step;
+
+	if (frameCount < 1) {
+		frameCount = 1;
+	}
+
+	track = *(int**)((char*)DAT_8032f3f0 + 0xdbc);
+	step = (frameCount * 0x60) / 0x3c + ((frameCount * 0x60) >> 0x1f);
+	step = step - (step >> 0x1f);
+
+	do {
+		if ((*track != 0) && ((seId < 0) || (track[0x3e] == seId))) {
+			track[0x11] = (((pan << 0xc) | 0x800) - track[0x10]) / step;
+			track[0x12] = step;
+		}
+		track += 0x55;
+	} while (track < (int*)(*(int*)((char*)DAT_8032f3f0 + 0xdbc) + 0x2a80));
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801caec4
+ * PAL Size: 164b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SetSePitch(int, int, int)
+void SetSePitch(int seId, int pitch, int frameCount)
 {
-	// TODO
+	int* track;
+	int step;
+
+	if (frameCount < 1) {
+		frameCount = 1;
+	}
+
+	track = *(int**)((char*)DAT_8032f3f0 + 0xdbc);
+	step = (frameCount * 0x60) / 0x3c + ((frameCount * 0x60) >> 0x1f);
+	step = step - (step >> 0x1f);
+
+	do {
+		if ((*track != 0) && ((seId < 0) || (track[0x3e] == seId))) {
+			track[0x18] = (((pitch << 0xc) | 0x800) - track[0x17]) / step;
+			track[0x19] = step;
+		}
+		track += 0x55;
+	} while (track < (int*)(*(int*)((char*)DAT_8032f3f0 + 0xdbc) + 0x2a80));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `SetSePan__Fiii` and `SetSePitch__Fiii` in `src/RedSound/RedCommand.cpp` from the PAL decomp shape.
- Added PAL address/size metadata blocks for both functions.
- Kept logic aligned with nearby RedSound code style (shared step calculation, same track iteration and gating predicates).

## Functions Improved
- Unit: `main/RedSound/RedCommand`
- `SetSePan__Fiii` (164b)
- `SetSePitch__Fiii` (164b)

## Match Evidence
Using `objdiff-cli report generate` on the same branch, with a temporary baseline checkout of `origin/main` for the same file:
- `SetSePan__Fiii`: **2.4390244% -> 60.365852%**
- `SetSePitch__Fiii`: **2.4390244% -> 60.609756%**

Build verification:
- `ninja` passes
- `build/GCCP01/main.dol: OK` remained valid during this run

## Plausibility Rationale
- The update is a direct, idiomatic translation of known PAL behavior: frame-clamped interpolation step, per-track filter by `seId`, and fixed-point delta/step writes to the expected track fields.
- No contrived temporaries, no layout hacks, and no compiler-coaxing control-flow tricks were introduced.

## Technical Notes
- Early two-step assignment forms for the delta fields produced materially lower fuzzy match.
- Collapsing to single-expression divide assignments (matching expected expression shape) significantly improved both symbols.
