### PR TITLE
pppLocationTitle: match pppDestructLocationTitle

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -72,12 +72,17 @@ void pppConstructLocationTitle(pppLocationTitle* pppLocationTitle, UnkC* param_2
  */
 void pppDestructLocationTitle(pppLocationTitle* pppLocationTitle, UnkC* param_2)
 {
-    s32* serializedOffsets = *(s32**)((u8*)param_2 + 0xC);
-    s32 fieldOffset = *serializedOffsets + 0x80;
+    int serializedOffset;
+    CMemory::CStage** stagePtr;
+    s32* serializedOffsets;
 
-    if (*(CMemory::CStage**)((u8*)pppLocationTitle + fieldOffset) != NULL) {
-        pppHeapUseRate(*(CMemory::CStage**)((u8*)pppLocationTitle + fieldOffset));
-        *(u32*)((u8*)pppLocationTitle + fieldOffset) = 0;
+    serializedOffsets = *(s32**)((u8*)param_2 + 0xC);
+    serializedOffset = *serializedOffsets;
+    stagePtr = (CMemory::CStage**)((u8*)pppLocationTitle + serializedOffset + 0x80);
+
+    if (*stagePtr != NULL) {
+        pppHeapUseRate(*stagePtr);
+        *stagePtr = 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- Refactored `pppDestructLocationTitle` to use a typed `CMemory::CStage**` work pointer instead of repeated raw offset casts.
- Kept behavior identical: conditionally call `pppHeapUseRate` and clear the heap pointer.

## Functions improved
- Unit: `main/pppLocationTitle`
- Symbol: `pppDestructLocationTitle`
- Match: **76.33% -> 100.00%** (`objdiff-cli diff -p . -u main/pppLocationTitle pppDestructLocationTitle`)

## Match evidence
- Before: `pppDestructLocationTitle` showed instruction mismatches in pointer-addressing form (`lwz/stw` with fixed displacement vs indexed form).
- After: symbol reaches **100.00%** in objdiff, with full instruction alignment.
- Global progress impact from `ninja` report: matched functions increased **1681 -> 1682**.

## Plausibility rationale
- The update is source-plausible and idiomatic for this codebase: compute serialized offset once, derive a typed stage pointer, then read/use/clear through that pointer.
- No compiler-coaxing artifacts were introduced; this is a readability-neutral cleanup that also matches the target assembly.

## Technical details
- Preserved the original serialized-offset load shape (`*(s32**)((u8*)param_2 + 0xC)`) to keep ABI/codegen alignment.
- Switched heap slot access to `*stagePtr`, which produced the target indexed load/store pattern (`lwzx/stwx`) and resolved remaining mismatches.
