### PR TITLE
p_map: restore camera recentering in calc

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -321,6 +321,7 @@ void CMapPcs::calcInit()
  */
 void CMapPcs::calc()
 {
+    Vec cameraPos;
     Mtx cameraMtx;
     Mtx44 screenMtx;
 
@@ -362,6 +363,10 @@ void CMapPcs::calc()
         if ((*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x17C) != 0) &&
             (strcmp(lbl_801E8EEC, reinterpret_cast<char*>(this) + 0x74) != 0)) {
             strcpy(lbl_801E8EEC, reinterpret_cast<char*>(this) + 0x74);
+            MapMng.GetDebugPlaySta(0, &cameraPos);
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0) = cameraPos.x;
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE4) = cameraPos.y + lbl_8032FA10;
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE8) = cameraPos.z;
         }
         *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x174) = 0;
         *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x178) = 1;


### PR DESCRIPTION
## Summary
- Updated `CMapPcs::calc()` to restore debug-play camera recentering after reloading map data in the reload path.
- Added a local `Vec` and assigned camera X/Y/Z from `MapMng.GetDebugPlaySta`, with Y offset by `lbl_8032FA10`.
- Kept the change focused to one control-flow point where the current decomp was missing behavior seen in the reference.

## Functions improved
- Unit: `main/p_map`
- Function: `calc__7CMapPcsFv` (796b)

## Match evidence
- `calc__7CMapPcsFv`: **35.05025% -> 36.492462%** (`+1.442212`)
- `main/p_map` unit fuzzy: **59.66729% -> 59.846443%** (`+0.179153`)
- Build verification: `ninja` completed successfully.

## Plausibility rationale
- This change restores a natural source-level behavior for map reload: recenter camera from map debug start data instead of only preserving prior values.
- The implementation uses existing engine APIs (`GetDebugPlaySta`) and existing camera fields, without contrived temporaries or synthetic compiler-only constructs.

## Technical details
- Modified block in `CMapPcs::calc()` reload branch (path change case under viewer/debug flow).
- No signature changes, no build-system flag changes, and no unrelated code movement.
