### PR TITLE
system: improve CSystem::Printf match by restoring OSReport

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -191,6 +191,7 @@ void CSystem::Printf(char* fmt, ...)
     va_start(args, fmt);
     vsprintf(buffer, fmt, args);
     va_end(args);
+    OSReport(buffer);
     USB.Printf(buffer);
 }
 


### PR DESCRIPTION
## Summary
- Updated `CSystem::Printf` in `src/system.cpp` to call `OSReport(buffer)` after `vsprintf` and before `USB.Printf`.
- Kept control flow and varargs handling otherwise unchanged.

## Functions improved
- Unit: `main/system`
- Function: `Printf__7CSystemFPce`

## Match evidence
- `objdiff` (`build/tools/objdiff-cli diff -p . -u main/system -o - Printf__7CSystemFPce`):
  - Before: `77.26087%`
  - After: `83.891304%`
  - Delta: `+6.630434` points
- Unit fuzzy (`build/GCCP01/report.json`):
  - Before: `73.78656%`
  - After: `74.083%`

## Plausibility rationale
- Ghidra decomp for PAL `0x80021efc` shows `OSReport` in this function’s debug print path.
- Calling both `OSReport` and `USB.Printf` is consistent with expected debug-output behavior for this path.
- The change is minimal and source-plausible (no compiler-coaxing constructs).

## Technical details
- The inserted `OSReport` call improves call-sequence alignment in the function body while preserving existing buffer/vararg flow.
- No new helper code, type changes, or control-flow rewrites were introduced.
