### PR TITLE
RedStream: improve StreamControl match by preventing _StreamStop inlining

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -55,6 +55,7 @@ done:
  * Address:	TODO
  * Size:	TODO
  */
+#pragma dont_inline on
 void _StreamStop(RedStreamDATA* streamData)
 {
 	fflush(&DAT_8021d1a8);
@@ -81,6 +82,7 @@ void _StreamStop(RedStreamDATA* streamData)
 		}
 	}
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added `#pragma dont_inline on/reset` around `_StreamStop` in `src/RedSound/RedStream.cpp`.
- This prevents `_StreamStop` from being inlined into `StreamControl`, bringing the generated control-flow and call structure much closer to target.

## Functions Improved
- Unit: `main/RedSound/RedStream`
- Primary symbol improved: `StreamControl__Fv`

## Match Evidence
- `StreamControl__Fv`: **22.43% -> 78.30%** (`build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream StreamControl__Fv`)
- `_StreamStop__FP13RedStreamDATA` remains separately emitted (expected with `dont_inline`) and is still high-match in local diff view.

## Plausibility Rationale
- This change is compiler-behavior alignment, not logic change.
- The codebase already uses `#pragma dont_inline` in multiple translation units, including RedSound modules, so this is a plausible original-source style choice.
- Runtime behavior is unchanged; only inlining decisions are constrained.

## Technical Notes
- Before this change, objdiff showed `fflush`/stop-path instructions merged into `StreamControl`, indicating `_StreamStop` was inlined.
- After applying `dont_inline`, `StreamControl` emits explicit calls to `_StreamStop`, which aligns substantially better with target layout.
