### PR TITLE
map: relocate CMapTexAnimSet dtor/ctor to map unit

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -15,12 +15,14 @@ extern "C" unsigned long UnkMaterialSetGetter(void*);
 extern "C" void __dl__FPv(void*);
 extern "C" void __dla__FPv(void*);
 extern "C" void __destroy_arr(void*, void*, unsigned long, unsigned long);
+extern "C" void __dt__4CRefFv(void*, int);
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void __dt__8COctTreeFv(void*, int);
 extern "C" void __dt__7CMapHitFv(void*, int);
 extern "C" void __dt__7CMapObjFv(void*, int);
 extern "C" void __dt__8CMapMeshFv(void*, int);
+extern "C" void* PTR_PTR_s_CMapTexAnimSet_801e896c;
 extern "C" float Spline1D__5CMathFifPfPfPf(CMath*, int, float, float*, float*, float*);
 extern "C" float Line1D__5CMathFifPfPf(CMath*, int, float, float*, float*);
 extern "C" void MakeSpline1Dtable__5CMathFiPfPfPf(CMath*, int, float*, float*, float*);
@@ -78,6 +80,47 @@ CMapKeyFrame::CMapKeyFrame()
     *reinterpret_cast<int*>(Ptr(this, 0x1C)) = 0;
     *reinterpret_cast<int*>(Ptr(this, 0x20)) = 0;
     *reinterpret_cast<int*>(Ptr(this, 0x24)) = 0;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+CMapTexAnimSet::CMapTexAnimSet()
+{
+	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800335d0
+ * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CMapTexAnimSet::~CMapTexAnimSet()
+{
+    unsigned char* const p = reinterpret_cast<unsigned char*>(this);
+    const short count = *reinterpret_cast<short*>(p + 8);
+
+    *reinterpret_cast<void**>(p) = &PTR_PTR_s_CMapTexAnimSet_801e896c;
+
+    for (int i = 0; i < count; i++) {
+        int* entry = *reinterpret_cast<int**>(p + 0xC + (i * 4));
+        if (entry != 0) {
+            const int refCount = entry[1];
+            entry[1] = refCount - 1;
+            if ((refCount - 1) == 0 && entry != 0) {
+                (*reinterpret_cast<void (**)(int*, int)>(*entry + 8))(entry, 1);
+            }
+            *reinterpret_cast<int**>(p + 0xC + (i * 4)) = 0;
+        }
+    }
+
+    __dt__4CRefFv(this, 0);
 }
 
 /*

--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -15,7 +15,6 @@ extern "C" void __dt__4CRefFv(void*, int);
 extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void __dl__FPv(void*);
-extern "C" void* PTR_PTR_s_CMapTexAnimSet_801e896c;
 extern "C" void* PTR_PTR_s_CMapTexAnim_801ea9a4;
 extern "C" char s_maptexanim_cpp_801d7ec4[];
 extern "C" int IsRun__12CMapKeyFrameFv(CMapKeyFrame*);
@@ -97,47 +96,6 @@ static inline void SetMaterialTextureSlot(void* material, unsigned long slotInde
         numTexture = static_cast<unsigned short>(slotIndex + 1);
     }
 }
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-CMapTexAnimSet::CMapTexAnimSet()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800335d0
- * PAL Size: 188b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CMapTexAnimSet::~CMapTexAnimSet()
-{
-    unsigned char* const p = reinterpret_cast<unsigned char*>(this);
-    const short count = *reinterpret_cast<short*>(p + 8);
-
-    *reinterpret_cast<void**>(p) = &PTR_PTR_s_CMapTexAnimSet_801e896c;
-
-    for (int i = 0; i < count; i++) {
-        int* entry = *reinterpret_cast<int**>(p + 0xC + (i * 4));
-        if (entry != 0) {
-            const int refCount = entry[1];
-            entry[1] = refCount - 1;
-            if ((refCount - 1) == 0 && entry != 0) {
-                (*reinterpret_cast<void (**)(int*, int)>(*entry + 8))(entry, 1);
-            }
-            *reinterpret_cast<int**>(p + 0xC + (i * 4)) = 0;
-        }
-    }
-
-    __dt__4CRefFv(this, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Moved `CMapTexAnimSet::CMapTexAnimSet()` and `CMapTexAnimSet::~CMapTexAnimSet()` from `src/maptexanim.cpp` into `src/map.cpp`.
- Kept destructor logic unchanged while relocating symbol ownership to the expected compilation unit.
- Added required externs in `src/map.cpp` and removed now-unused `PTR_PTR_s_CMapTexAnimSet_801e896c` extern from `src/maptexanim.cpp`.

## Functions improved
- Unit: `main/map`
- Symbol: `__dt__14CMapTexAnimSetFv` (`CMapTexAnimSet::~CMapTexAnimSet()`)
- Size: 188 bytes
- Match: **0.0% -> 79.680855%**

## Match evidence
- Before: selector/report tracked `__dt__14CMapTexAnimSetFv` under `main/map` with no matched output (0% target in selector).
- After: `build/GCCP01/report.json` now reports `main/map::__dt__14CMapTexAnimSetFv` at `79.680855` fuzzy match.
- Verification build: `ninja` completed successfully after relocation.

## Plausibility rationale
- This is a source-organization correction, not compiler coaxing: the original binary/report expects `__dt__14CMapTexAnimSetFv` in `map.o` (`main/map`), but the decomp had it implemented in `maptexanim.cpp`.
- Relocating ctor/dtor into `map.cpp` aligns symbol ownership with object-unit expectations while preserving readable, idiomatic C++ destructor logic.
- No contrived temporaries or unnatural control-flow tricks were introduced solely to chase score.

## Technical notes
- `main/maptexanim` function set remains unchanged for its tracked symbols; this patch specifically addresses cross-unit placement of `CMapTexAnimSet` ctor/dtor.
- The result is a concrete per-function improvement in the intended unit with clean build output.
