### PR TITLE
alloc: improve Block_subBlock match in MSL alloc

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -372,12 +372,21 @@ static void Block_construct(Block* block, unsigned long size) {
     Block_link(block, sb);
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x801B28A8
+ * PAL Size: 484b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 static SubBlock* Block_subBlock(Block* block, unsigned long requested_size) {
     unsigned long current_size;
-    unsigned long max_size;
+    int start_offset;
     unsigned long* start;
     unsigned long* current;
-    int start_offset;
+    unsigned long max_size;
 
     start_offset = (block->size & 0xFFFFFFF8UL) - 4;
     start = *(unsigned long**)((char*)block + start_offset);
@@ -392,45 +401,46 @@ static SubBlock* Block_subBlock(Block* block, unsigned long requested_size) {
     do {
         if (requested_size <= current_size) {
             if (0x4F < current_size - requested_size) {
-                unsigned long* remainder;
-                unsigned long old_header;
-                unsigned long block_link;
-                unsigned long is_alloc_clz;
-                unsigned long has_alloc_neighbor_clz;
+                unsigned long* split_block;
+                unsigned long old_size_flags;
+                unsigned long block_flags;
+                unsigned long prev_used_clz;
+                unsigned long prev_used_is_zero_clz;
 
-                remainder = (unsigned long*)((char*)current + requested_size);
-                old_header = *current;
-                block_link = current[1] & 0xFFFFFFFEUL | 1;
-                current[1] = block_link;
-                is_alloc_clz = __cntlzw(old_header & 2);
+                split_block = (unsigned long*)((char*)current + requested_size);
+                old_size_flags = *current;
+                block_flags = current[1] & 0xFFFFFFFEUL | 1;
+                current[1] = block_flags;
+                prev_used_clz = __cntlzw(old_size_flags & 2);
                 *current = requested_size;
-                has_alloc_neighbor_clz = __cntlzw(is_alloc_clz >> 5);
-                if (old_header & 4) {
+                prev_used_is_zero_clz = __cntlzw(prev_used_clz >> 5);
+                if ((old_size_flags & 4) != 0) {
                     *current |= 4;
                 }
-                if ((has_alloc_neighbor_clz >> 5) == 0) {
-                    remainder[-1] = requested_size;
+                if ((prev_used_is_zero_clz >> 5) == 0) {
+                    split_block[-1] = requested_size;
                 } else {
                     *current |= 2;
-                    *remainder |= 4;
+                    *split_block |= 4;
                 }
-                remainder[1] = block_link;
-                requested_size = (old_header & 0xFFFFFFF8UL) - requested_size;
-                *remainder = requested_size;
-                if ((has_alloc_neighbor_clz >> 5) == 0) {
-                    *(unsigned long*)((char*)remainder + (requested_size - 4)) = requested_size;
+                split_block[1] = block_flags;
+                requested_size = (old_size_flags & 0xFFFFFFF8UL) - requested_size;
+                *split_block = requested_size;
+                if ((prev_used_is_zero_clz >> 5) == 0) {
+                    *(unsigned long*)((char*)split_block + requested_size - 4) = requested_size;
                 } else {
-                    *remainder |= 4;
-                    *remainder |= 2;
-                    *(unsigned long*)((char*)remainder + requested_size) |= 4;
+                    *split_block |= 4;
+                    *split_block |= 2;
+                    *(unsigned long*)((char*)split_block + requested_size) |= 4;
                 }
-                if (is_alloc_clz >> 5) {
-                    remainder[3] = current[3];
-                    *(unsigned long*)(remainder[3] + 8) = (unsigned long)remainder;
-                    remainder[2] = (unsigned long)current;
-                    current[3] = (unsigned long)remainder;
+                if ((prev_used_clz >> 5) != 0) {
+                    split_block[3] = current[3];
+                    *(unsigned long*)(split_block[3] + 8) = (unsigned long)split_block;
+                    split_block[2] = (unsigned long)current;
+                    current[3] = (unsigned long)split_block;
                 }
             }
+
             *(unsigned long**)((char*)block + ((block->size & 0xFFFFFFF8UL) - 4)) = (unsigned long*)current[3];
             current_size = *current & 0xFFFFFFF8UL;
             *current |= 2;
@@ -448,6 +458,7 @@ static SubBlock* Block_subBlock(Block* block, unsigned long requested_size) {
             }
             return (SubBlock*)current;
         }
+
         current = (unsigned long*)current[3];
         current_size = *current & 0xFFFFFFF8UL;
         if (max_size < current_size) {


### PR DESCRIPTION
## Summary
- Reworked `Block_subBlock` in `src/MSL_C/PPCEABI/bare/H/alloc.c` to follow the original low-level control-flow more literally.
- Preserved behavior while adjusting variable flow and split-block handling structure to better align generated assembly.
- Added the standard function metadata block for `Block_subBlock` (`PAL Address: 0x801B28A8`, `PAL Size: 484b`).

## Functions improved
- Unit: `main/MSL_C/PPCEABI/bare/H/alloc`
- Function: `Block_subBlock`
- Match: **57.867767% -> 58.07438%**
- Function size alignment: **468b -> 484b** (target size 484b)

## Match evidence
- Built with `ninja` successfully after the change.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/MSL_C/PPCEABI/bare/H/alloc -o /tmp/out_after2.json Block_subBlock`
- Result from `/tmp/out_after2.json`:
  - `Block_subBlock.match_percent = 58.07438`
  - `Block_subBlock.size = 484`

## Plausibility rationale
- This function is allocator internals and naturally low-level/bitwise; keeping explicit header/flag manipulation and linked-list pointer operations is consistent with plausible original MSL-style source.
- The update avoids artificial compiler-coaxing patterns and instead moves the source closer to a direct, semantically faithful implementation.

## Technical details
- Aligned split-block path with expected ordering of header writes and flag propagation.
- Kept explicit `cntlzw`-based flag checks (`__cntlzw`) to maintain target-like branch shaping.
- Retained existing API and data layout; no struct/interface changes.
