### PR TITLE
pppMiasma: improve pppRenderMiasma slice/render pass matching

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -166,7 +166,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, void* param_2, pppMiasmaCtrl* param_3
     drawColor.b = drawColor.r;
     drawColor.a = 0xFF;
 
-    for (slice = 0; slice < 4; slice++) {
+    for (slice = 0; slice < 2; slice++) {
         yOffset = (int)((float)slice * FLOAT_8033192c);
 
         Graphic.GetBackBufferRect2(DAT_80238030, &backI4Tex, 0, yOffset, texWidth, texHeight, 0, GX_LINEAR, GX_TF_I4, 0);
@@ -247,6 +247,12 @@ void pppRenderMiasma(pppMiasma* pppMiasma, void* param_2, pppMiasmaCtrl* param_3
             Graphic.GetBackBufferRect2(DAT_80238030, &backRgba8Tex2, 0, yOffset, texWidth, texHeight, i4TexSize + rgba8TexSize,
                                        GX_LINEAR, GX_TF_RGBA8, 0);
         }
+
+        Graphic.SetViewport();
+        DAT_8032ec70.RenderTextureQuad(FLOAT_8033193c, (float)yOffset, FLOAT_80331928, FLOAT_8033192c, &backI4Tex, 0, 0,
+                                       0, (GXBlendFactor)4, (GXBlendFactor)5);
+        DAT_8032ec70.BeginQuadEnv();
+        DAT_8032ec70.SetVtxFmt_POS_CLR_TEX0_TEX1();
     }
 
     Graphic.SetViewport();


### PR DESCRIPTION
## Summary
- adjusted `pppRenderMiasma` slice processing from 4 passes to 2 passes to match observed render loop shape
- added the immediate backbuffer texture-quad pass setup inside each slice (`SetViewport`, `RenderTextureQuad`, `BeginQuadEnv`, `SetVtxFmt_POS_CLR_TEX0_TEX1`)
- kept changes localized and source-plausible (render pipeline ordering), without introducing compiler-coaxing patterns

## Functions improved
- Unit: `main/pppMiasma`
- Function: `pppRenderMiasma`
  - before: `24.31977%`
  - after: `25.477516%`
  - delta: `+1.157746%`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/pppMiasma -o - pppRenderMiasma`
  - before fuzzy match: `24.31977%`
  - after fuzzy match: `25.477516%`
- unit fuzzy score (`tools/objdiff-cli report generate -p .`):
  - `main/pppMiasma` before: `31.718264`
  - `main/pppMiasma` after: `32.792747`

## Plausibility rationale
- the revised loop count and pass ordering align with a typical two-slice postprocess path seen in similar FFCC render code and the available decomp reference
- the added backbuffer quad pass is a natural rendering step (capture + composite), not artificial control-flow shaping
- no readability regressions or non-idiomatic temporary coercions were introduced

## Technical notes
- validated by full `ninja` rebuild (`build/GCCP01/main.dol: OK`)
- change is intentionally incremental; deeper TEV/state reconstruction for this function remains open for follow-up passes
