### PR TITLE
pppColum: improve pppFrameColum match via local/ref cleanup

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -170,38 +170,46 @@ void pppRenderColum(pppColum *column, UnkB *param_2, UnkC *param_3)
  */
 void pppFrameColum(pppColum *column, UnkB *param_2, UnkC *param_3)
 {
-    if (lbl_8032ED70 == 0) {
-        int* serializedDataOffsets = GetColumSerializedDataOffsets(param_3);
-        unsigned char* work = (unsigned char*)((char*)column + 0x80 + serializedDataOffsets[3]);
+    int i;
+    int* serializedDataOffsets;
+    unsigned char* work;
 
-        if (*(void**)(work + 8) == 0) {
-            float* values = (float*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-                (unsigned long)(*((unsigned char*)&param_2->m_arg3 + 1) * 0xc),
-                pppEnvStPtr->m_stagePtr, (char*)"pppColum.cpp", 0x7d);
-            int i;
-            unsigned char count = *((unsigned char*)&param_2->m_arg3 + 1);
+    if (lbl_8032ED70 != 0) {
+        return;
+    }
 
-            *(void**)(work + 8) = values;
-            for (i = 0; i < count; i++) {
-                values[0] = RandF__5CMathFf(*(float*)(param_2->m_payload + 4), &Math);
-                values[0] += *(float*)param_2->m_payload;
-                values[1] = RandF__5CMathFf(*(float*)(param_2->m_payload + 0xc), &Math);
-                values[1] += *(float*)(param_2->m_payload + 8);
-                ((unsigned char*)values)[8] =
-                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x16]);
-                ((unsigned char*)values)[9] =
-                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x17]);
-                ((unsigned char*)values)[10] =
-                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x18]);
-                values += 3;
-            }
+    serializedDataOffsets = GetColumSerializedDataOffsets(param_3);
+    work = (unsigned char*)((char*)column + 0x80 + serializedDataOffsets[3]);
+
+    if (*(void**)(work + 8) == 0) {
+        unsigned char count = *((unsigned char*)&param_2->m_arg3 + 1);
+        float* values = (float*)pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(count * 0xc),
+                                                                       pppEnvStPtr->m_stagePtr,
+                                                                       (char*)"pppColum.cpp", 0x7d);
+
+        *(void**)(work + 8) = values;
+        for (i = 0; i < (int)count; i++) {
+            values[0] = RandF__5CMathFf(*(float*)(param_2->m_payload + 4), &Math);
+            values[0] += *(float*)param_2->m_payload;
+            values[1] = RandF__5CMathFf(*(float*)(param_2->m_payload + 0xc), &Math);
+            values[1] += *(float*)(param_2->m_payload + 8);
+            ((unsigned char*)values)[8] =
+                GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x16]);
+            ((unsigned char*)values)[9] =
+                GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x17]);
+            ((unsigned char*)values)[10] =
+                GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x18]);
+            values += 3;
         }
+    }
 
-        if (param_2->m_dataValIndex != 0xffff) {
-            long* shapeTable = *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4);
-            pppCalcFrameShape__FPlRsRsRss(shapeTable, *(short*)(work + 0), *(short*)(work + 2),
-                                          *(short*)(work + 4), (short)param_2->m_initWOrk);
-        }
+    if (param_2->m_dataValIndex != 0xffff) {
+        long* shapeTable = *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4);
+        short& shapeA = *(short*)(work + 0);
+        short& shapeB = *(short*)(work + 2);
+        short& shapeC = *(short*)(work + 4);
+
+        pppCalcFrameShape__FPlRsRsRss(shapeTable, shapeA, shapeB, shapeC, (short)param_2->m_initWOrk);
     }
 }
 


### PR DESCRIPTION
## Summary
- Refactored `pppFrameColum` local variable setup and control flow in `src/pppColum.cpp`.
- Switched to early return for `lbl_8032ED70` gate, hoisted shared locals, and normalized count typing in allocation/loop logic.
- Introduced explicit `short&` aliases for the three shape frame work values passed into `pppCalcFrameShape__FPlRsRsRss`.

## Functions improved
- Unit: `main/pppColum`
- Function: `pppFrameColum`

## Match evidence
- `pppFrameColum`: **70.07% -> 70.58%** (`build/tools/objdiff-cli diff -p . -u main/pppColum pppFrameColum`)
- `pppRenderColum`: unchanged at **60.55%**
- Build verification: `ninja` completes successfully and regenerates report.

## Plausibility rationale
- The change preserves behavior while making data flow closer to how this codebase typically handles serialized work buffers (typed locals, direct reference passing for in-place frame updates).
- No contrived compiler-coax constructs were added; adjustments are readable and source-plausible for original game code.

## Technical notes
- The measurable gain comes from argument/local shaping around frame-work state and loop/count handling in `pppFrameColum`, not from cosmetic formatting.
