### PR TITLE
RedDriver: implement StreamPlayState

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -92,7 +92,7 @@ public:
 	void DisplaySePlayInfo();
 
 
-	void StreamPlayState(int);
+	int StreamPlayState(int);
 	void GetStreamPlayPoint(int, int*, int*);
 	void StreamStop(int);
 	void StreamPlay(int, void*, int, int, int);

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1547,12 +1547,48 @@ void CRedDriver::DisplaySePlayInfo()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bf8e8
+ * PAL Size: 240b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::StreamPlayState(int)
+int CRedDriver::StreamPlayState(int param_1)
 {
-	// TODO
+	unsigned int interrupts;
+	unsigned int streamData;
+	int result;
+	int* command;
+
+	interrupts = OSDisableInterrupts();
+	result = 0;
+	streamData = (unsigned int)DAT_8032f438;
+	do {
+		if ((*(int*)(streamData + 0x10C) != 0) &&
+		    ((param_1 == -1) || (*(int*)(streamData + 0x10C) == param_1))) {
+			result = 1;
+			break;
+		}
+		streamData += 0x130;
+	} while (streamData < (unsigned int)DAT_8032f438 + 0x4C0);
+
+	command = (int*)DAT_8032f3dc;
+	if (result == 0) {
+		while ((void*)command != DAT_8032f3d8) {
+			if ((*command != 0) && ((void (*)(int*))*command == _StreamPlay) &&
+			    ((param_1 == -1) || (param_1 == command[1]))) {
+				result = 1;
+				break;
+			}
+			command += 8;
+			if (command == (int*)DAT_8032f3d4 + 0x800) {
+				command = (int*)DAT_8032f3d4;
+			}
+		}
+	}
+	OSRestoreInterrupts(interrupts);
+	return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedDriver::StreamPlayState(int)` in `src/RedSound/RedDriver.cpp` from the PAL decomp flow.
- Corrected method signature in `include/ffcc/RedSound/RedDriver.h` from `void` to `int` to match the real symbol/interface.
- Added PAL address/size metadata block for the function.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Function: `StreamPlayState__10CRedDriverFi`

## Match evidence
- Baseline from `tools/agent_select_target.py`: `StreamPlayState__10CRedDriverFi` at **1.7%**.
- After change (`objdiff-cli v3.6.1`): **57.4%**.
- Command used:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - StreamPlayState__10CRedDriverFi`

## Plausibility rationale
- The implementation follows normal engine behavior for this API: check active stream slots first, then scan queued commands for pending `_StreamPlay` requests.
- Uses existing queue/ring-buffer globals and interrupt guards already used throughout `RedDriver`, rather than compiler-coaxing patterns.
- Return semantics (`0/1`) now match expected call-site behavior and symbol prototype.

## Technical details
- Preserved interrupt critical section around both active stream data and command queue scan.
- Preserved ring-buffer wrap behavior (`+8` ints per entry, wrap at `DAT_8032f3d4 + 0x800`).
- Preserved wildcard stream ID behavior (`param == -1`).
