### PR TITLE
p_tina: implement IsLoadPartCompleted busy-flag scan

### DIFF
--- a/include/ffcc/p_tina.h
+++ b/include/ffcc/p_tina.h
@@ -61,7 +61,7 @@ public:
     void SetParColIdx(int, pppFVECTOR4&);
     void GetParColIdx(int, pppFVECTOR4&);
 
-    void IsLoadPartCompleted();
+    unsigned int IsLoadPartCompleted();
 
     void LoadFieldPdt(int, int, void*, unsigned long, unsigned char);
     void LoadMonsterPdt(int, int, void*, int, void*, int);

--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -900,12 +900,31 @@ void CPartPcs::drawAfterViewer()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80052660
+ * PAL Size: 260b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CPartPcs::IsLoadPartCompleted()
+unsigned int CPartPcs::IsLoadPartCompleted()
 {
-	// TODO
+    unsigned char* partMng = reinterpret_cast<unsigned char*>(&PartMng);
+    unsigned char* busy = partMng + 0x236F4;
+    int i = 2;
+
+    while (true) {
+        if (busy[0] != 0 || busy[1] != 0 || busy[2] != 0 || busy[3] != 0 || busy[4] != 0 ||
+            busy[5] != 0 || busy[6] != 0 || busy[7] != 0) {
+            return 0;
+        }
+
+        busy += 8;
+        i--;
+        if (i == 0) {
+            return 1;
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement `CPartPcs::IsLoadPartCompleted` in `p_tina` and align the method return type to the way this symbol is consumed (returns completion state). The implementation now scans the 16 async busy flags in `PartMng` (two 8-byte blocks) and returns `0` while any load is in progress, otherwise `1`.

## Functions improved
- Unit: `main/p_tina`
- Symbol: `IsLoadPartCompleted__8CPartPcsFv`

## Match evidence
- Before: **1.5%** (from `tools/agent_select_target.py` target report)
- After: **39.2%** (`build/tools/objdiff-cli diff -p . -u main/p_tina -o - IsLoadPartCompleted__8CPartPcsFv`)
- Build: `ninja` passes.

## Plausibility rationale
This change reflects likely original source behavior: returning whether asynchronous part loading is complete by checking the load-busy flags, with straightforward early-out control flow. No contrived temporaries or compiler-only tricks were introduced.

## Technical details
- Updated declaration/definition return type: `void` -> `unsigned int` (mangled symbol unchanged).
- Added PAL metadata block for the function (`0x80052660`, `260b`).
- Used existing raw-offset style in this file (`PartMng + 0x236F4`) to avoid speculative struct rewrites.
