### PR TITLE
map: implement CMapMng::Destroy

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1348,12 +1348,17 @@ void CMapMng::DestroyMap()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80033218
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapMng::Destroy()
 {
-	// TODO
+    DestroyMap();
+    Memory.DestroyStage(*reinterpret_cast<CMemory::CStage**>(this));
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement `CMapMng::Destroy()` in `src/map.cpp` with the two-call teardown sequence:
- call `DestroyMap()`
- destroy the map memory stage via `Memory.DestroyStage(*reinterpret_cast<CMemory::CStage**>(this))`

Also replaced the placeholder INFO block with PAL metadata for this function.

## Functions improved
- Unit: `main/map`
- Symbol: `Destroy__7CMapMngFv`
- Size: `60b`
- Match: `6.6666665%` -> `64.26667%`

## Match evidence
Objdiff command used:
```sh
build/tools/objdiff-cli diff -p . -u main/map -o - Destroy__7CMapMngFv
```
Observed delta for `Destroy__7CMapMngFv`:
- Instruction slots: `15` -> `15` (size stable)
- Diff ops: `14` -> `9`
- Substantial alignment gain while preserving direct call structure shown in decomp reference.

## Plausibility rationale
This change replaces a TODO stub with straightforward, idiomatic source behavior for a map manager teardown method. The resulting code is minimal and readable, and matches the expected high-level semantics from decompilation (map cleanup followed by stage destruction), without contrived compiler-coaxing constructs.

## Technical details
- Added PAL function annotation:
  - PAL Address: `0x80033218`
  - PAL Size: `60b`
- Build verification: `ninja` completed successfully after the change.
