### PR TITLE
p_FunnyShape: improve calcViewer match with explicit layout guards

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -328,14 +328,20 @@ void CFunnyShapePcs::destroyViewer()
  */
 void CFunnyShapePcs::calcViewer()
 {
-    if (UsbStream(this)->IsUSBStreamDataDone()) {
+    if (reinterpret_cast<CUSBStreamData*>(reinterpret_cast<u8*>(this) + 0x3C)->IsUSBStreamDataDone() != 0) {
         SetUSBData();
-        UsbStream(this)->SetUSBStreamDataDone();
+        reinterpret_cast<CUSBStreamData*>(reinterpret_cast<u8*>(this) + 0x3C)->SetUSBStreamDataDone();
     }
 
-    if ((Ptr(this, 0x6124)[0] != 0) && (*reinterpret_cast<int*>(Ptr(this, 0x6134)) != 0)) {
-        FunnyShape(this)->Update();
+    if (static_cast<s8>(reinterpret_cast<u8*>(this)[0x6124]) == 0) {
+        return;
     }
+
+    if (*reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + 0x6134) == 0) {
+        return;
+    }
+
+    reinterpret_cast<CFunnyShape*>(reinterpret_cast<u8*>(this) + 0x50)->Update();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refactored `CFunnyShapePcs::calcViewer()` in `src/p_FunnyShape.cpp` to use explicit class-layout offsets for USB stream and FunnyShape members.
- Reworked the update guard into early-return checks:
  - signed byte check at `this + 0x6124`
  - pointer/int check at `this + 0x6134`
- Kept behavior equivalent while aligning control flow and memory access shape with the target object.

## Functions improved
- Unit: `main/p_FunnyShape`
- Symbol: `calcViewer__14CFunnyShapePcsFv`

## Match evidence
- `calcViewer__14CFunnyShapePcsFv`: **62.148148% -> 76.85185%** (`+14.703702`)
- Function size remained `116` bytes.
- Instruction diff markers reduced (`17 -> 14` in objdiff JSON instruction stream).

## Plausibility rationale
- The change reflects plausible original source for this codebase:
  - explicit offset-based member access is already common in nearby decomped manager/viewer code,
  - guard conditions are expressed as straightforward early exits,
  - no contrived temporaries or artificial instruction coaxing were added.

## Technical details
- Validation command:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - calcViewer__14CFunnyShapePcsFv`
- Build verification:
  - `ninja` completes and verifies `build/GCCP01/main.dol: OK`.
