### PR TITLE
Improve match for pppFrameYmDeformationShp

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -202,34 +202,45 @@ void pppDestructYmDeformationShp(void)
  */
 void pppFrameYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, UnkB* param_2, UnkC* param_3)
 {
-	s16* angle;
+	struct FrameState {
+		s16 m_angle;
+		u8 m_direction;
+		u8 m_pad;
+		float m_values[6];
+	};
+
+	FrameState* state;
 
 	if (DAT_8032ed70 != 0) {
 		return;
 	}
 
-	angle = (s16*)((u8*)pppYmDeformationShp_ + 0x8c + param_3->m_serializedDataOffsets[2]);
+	state = (FrameState*)((u8*)pppYmDeformationShp_ + 0x8c + param_3->m_serializedDataOffsets[2]);
 
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-		param_2->m_payload[0], pppYmDeformationShp_, param_2->m_graphId, (float*)(angle + 2), (float*)(angle + 4),
-		(float*)(angle + 6), &param_2->m_payload[1], &param_2->m_payload[2]);
+		param_2->m_payload[0], pppYmDeformationShp_, param_2->m_graphId, &state->m_values[0], &state->m_values[1],
+		&state->m_values[2], &param_2->m_payload[1], &param_2->m_payload[2]);
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-		param_2->m_payload[3], pppYmDeformationShp_, param_2->m_graphId, (float*)(angle + 8), (float*)(angle + 10),
-		(float*)(angle + 12), &param_2->m_payload[4], &param_2->m_payload[5]);
+		param_2->m_payload[3], pppYmDeformationShp_, param_2->m_graphId, &state->m_values[3], &state->m_values[4],
+		&state->m_values[5], &param_2->m_payload[4], &param_2->m_payload[5]);
 
 	if (DAT_8032ed78 != 0) {
 		return;
 	}
 
-	if (*(u8*)(angle + 1) == 0) {
-		*angle = *angle - (s16)(int)*(float*)(angle + 8);
-		if ((int)*angle < -(int)param_2->m_payload3) {
-			*(u8*)(angle + 1) = 1;
+	if (state->m_direction != 0) {
+		s16 step = (s16)(int)state->m_values[3];
+
+		state->m_angle = state->m_angle + step;
+		if (param_2->m_payload3 < state->m_angle) {
+			state->m_direction = 0;
 		}
 	} else {
-		*angle = *angle + (s16)(int)*(float*)(angle + 8);
-		if (param_2->m_payload3 < *angle) {
-			*(u8*)(angle + 1) = 0;
+		s16 step = (s16)(int)state->m_values[3];
+
+		state->m_angle = state->m_angle - step;
+		if ((int)state->m_angle < -(int)param_2->m_payload3) {
+			state->m_direction = 1;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked `pppFrameYmDeformationShp` state access to use an explicit local frame-state layout (`angle`, `direction`, and six float graph values).
- Kept behavior equivalent while reshaping control flow and typed arithmetic around the direction/angle update.
- Preserved existing function documentation and PAL metadata.

## Functions improved
- Unit: `main/pppYmDeformationShp`
- Symbol: `pppFrameYmDeformationShp`
- Size: `292b` (unchanged)

## Match evidence
- `pppFrameYmDeformationShp`: `52.90411%` -> `93.16438%`
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp -o - pppFrameYmDeformationShp`
- Improvement reflects instruction-level alignment in the frame update path (not a rename-only change).

## Plausibility rationale
- The update uses source-plausible structure/typing for serialized per-instance state rather than compiler-coaxing patterns.
- Direction flag and angle integration are expressed in straightforward gameplay-style logic.
- Float-to-s16 step conversion is explicit and consistent with existing codebase style.

## Technical details
- The previous implementation relied on `s16*` plus manual casts (`(float*)(angle + N)`), which produced weaker codegen alignment.
- Introducing a local typed state view improved register use and branch shaping around both `CalcGraphValue` calls and angle/direction transitions.
- One branch/compare mismatch remains, but the function now matches at a high percentage without introducing unnatural source constructs.
