### PR TITLE
RedDriver: implement _SetReverbDepth and _WaveSettingThread

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -39,7 +39,7 @@ unsigned int GetMyEntryID();
 void _MyAlarmHandler(OSAlarm*, OSContext*);
 void RedSleep(int);
 int _MainThread(void*);
-void _WaveSettingThread(void*);
+int _WaveSettingThread(void*);
 void _DMACheckProcess();
 void _DmaCallback(unsigned long);
 int RedDmaEntry(int, int, int, int, int, void (*)(void*), void*);
@@ -80,7 +80,7 @@ public:
 	int SePlayState(int);
 	void SeStop(int);
 	void SeStopMG(int, int, int, int);
-	void SePlay(int, int, int, int, int, int);
+	int SePlay(int, int, int, int, int, int);
 	void SeMasterVolume(int);
 	void SeFadeOut(int, int);
 	void SeVolume(int, int, int);


### PR DESCRIPTION
## Summary
- Implemented `_SetReverbDepth(int*)` using the PAL decomp flow and existing RedDriver state layout.
- Implemented `_WaveSettingThread(void*)` semaphore loop, wave-data dispatch, and thread state flag handling.
- Corrected `CRedDriver::SePlay` to return `autoID` (and updated header prototype) to align with observed codegen expectations.

## Functions improved
- `main/RedSound/RedDriver::_SetReverbDepth__FPi` (192b)
- `main/RedSound/RedDriver::_WaveSettingThread__FPv` (196b)
- `main/RedSound/RedDriver::SePlay__10CRedDriverFiiiiii` (196b, minor improvement)

## Match evidence (objdiff-cli v3.6.1)
- `_SetReverbDepth__FPi`: **2.0833333% -> 69.479164%**
- `_WaveSettingThread__FPv`: **2.0408163% -> 65.591835%**
- `SePlay__10CRedDriverFiiiiii`: **2.0408163% -> 3.877551%**

## Plausibility rationale
- Replaced TODO stubs with straightforward control flow and arithmetic that matches the game/audio domain behavior (reverb-depth ramping, voice update iteration, and worker thread semaphore draining) rather than compiler-only coercion.
- Kept existing global/state access patterns already used throughout `RedDriver.cpp`.
- Added PAL address/size metadata in the project’s required function doc format.

## Technical details
- `_SetReverbDepth` now computes the packed depth value, writes per-reverb-slot state, and updates active voice fade-step fields (`+0x6C`/`+0x70` via int-indexed layout) over the `0x2A80`-byte voice table.
- `_WaveSettingThread` now toggles the worker-active bit in `DAT_8032f3c4`, processes queued wave-setting commands from the thread argument block, clears completion flags, drains extra semaphore posts, and exits cleanly.
- `SePlay` keeps existing command dispatch branches and now returns `autoID` for call/ABI consistency.
