### PR TITLE
pppYmMelt: improve pppFrameYmMelt match via init math alignment

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -246,26 +246,32 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
         YmMeltVertex* vtx = work->m_vertexData;
         s16 phaseDiv = *(s16*)((u8*)&ctrl->m_arg3 + 2);
         int angleSeed = rand();
-        work->m_phaseOffset = (phaseDiv != 0) ? (s16)(angleSeed - (angleSeed / phaseDiv) * phaseDiv) : 0;
+        work->m_phaseOffset = (s16)angleSeed - (s16)(angleSeed / (int)phaseDiv) * phaseDiv;
 
-        float halfWidth = ctrl->m_stepValue * FLOAT_80330b08;
-        float step = ctrl->m_stepValue / ((float)((u16)((u8*)&ctrl->m_initWOrk)[2]) - (float)DOUBLE_80330af8);
-        float rot = FLOAT_80330b0c * ((float)(work->m_phaseOffset) - (float)DOUBLE_80330b00);
+        double halfWidth = (double)(ctrl->m_stepValue * FLOAT_80330b08);
+        double step =
+            (double)(ctrl->m_stepValue / (float)((double)((u16)((u8*)&ctrl->m_initWOrk)[2]) - DOUBLE_80330af8));
+        double rot = (double)(FLOAT_80330b0c * (float)((double)work->m_phaseOffset - DOUBLE_80330b00));
+        double z = -halfWidth;
+        double x;
 
-        for (float z = -halfWidth; z <= halfWidth; z += step) {
-            for (float x = -halfWidth; x <= halfWidth; x += step) {
-                vtx->m_position.x = x;
+        while (z <= halfWidth) {
+            x = -halfWidth;
+            while (x <= halfWidth) {
+                vtx->m_position.x = (float)x;
                 vtx->m_position.y = FLOAT_80330af0;
-                vtx->m_position.z = z;
+                vtx->m_position.z = (float)z;
 
-                if (work->m_phaseOffset != 0) {
+                if (phaseDiv != 0) {
                     Mtx rotMtx;
-                    PSMTXRotRad(rotMtx, 'y', rot);
+                    PSMTXRotRad(rotMtx, 'y', (float)rot);
                     PSMTXMultVec(rotMtx, &vtx->m_position, &vtx->m_position);
                 }
 
                 vtx++;
+                x = (double)(float)(x + step);
             }
+            z = (double)(float)(z + step);
         }
 
         CalcPolygonHeight(ymMelt, (VERTEX_DATA*)ctrl, (_GXColor*)work->m_vertexData, matrixY);


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmMelt` initialization math in `src/pppYmMelt.cpp` to better match original codegen patterns.
- Replaced guarded modulo path for `m_phaseOffset` with direct quotient/remainder form used by the decompilation.
- Switched grid construction stepping to explicit float-rounded double stepping (`(double)(float)(x + step)`) and equivalent rotation scalar computation.
- Kept behavior/source plausibility intact: this remains normal particle-grid initialization logic, with no artificial compiler-only scaffolding.

## Functions improved
- Unit: `main/pppYmMelt`
- Symbol: `pppFrameYmMelt`
  - Before: `63.3%`
  - After: `65.382355%`

## Match evidence
Command used:
```sh
../tools/objdiff-cli diff -p . -u main/pppYmMelt -o - pppRenderYmMelt
```
Key symbol results from JSON:
- `pppFrameYmMelt`: `63.3 -> 65.382355` (+2.082355)
- `pppRenderYmMelt`: `43.484848 -> 43.484848` (no regression)
- `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf`: `64.90385 -> 64.90385` (no regression)

## Plausibility rationale
- Changes are type/arithmetic fidelity improvements (signedness/casts/stepping precision), not contrived reorderings.
- The rewritten loop and phase math align with existing codebase style and typical Metrowerks float-rounding behavior in particle-grid setup code.

## Technical details
- `m_phaseOffset` now uses explicit quotient/remainder expression on the random seed and divisor.
- Grid coordinate iteration now uses float-rounded accumulation to preserve intermediate precision/rounding side effects observed in decompilation.
- Rotation scalar uses matching float-to-double conversion flow before `PSMTXRotRad`.
