### PR TITLE
RedCommand: implement SearchSeEmptyTrack

### DIFF
--- a/include/ffcc/RedSound/RedCommand.h
+++ b/include/ffcc/RedSound/RedCommand.h
@@ -7,7 +7,7 @@ struct RedWaveHeadWD;
 
 void _EraseAttribute(int, int);
 int _EraseTime(int);
-void SearchSeEmptyTrack(int, int, int);
+int* SearchSeEmptyTrack(int, int, int);
 int SeStopID(int);
 int SeStopMG(int, int, int, int);
 int _SePlayStart(RedSeINFO*, int, int, int, int);

--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -144,12 +144,47 @@ int _EraseTime(int eraseTrack)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801ca3bc
+ * PAL Size: 252b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SearchSeEmptyTrack(int, int, int)
+int* SearchSeEmptyTrack(int trackCount, int eraseTrack, int attrMask)
 {
-	// TODO
+	int* trackBasePtr;
+	int* scan;
+	int* track;
+	int remaining;
+
+	trackBasePtr = (int*)((char*)DAT_8032f3f0 + 0xdbc);
+	if (attrMask != 0) {
+		_EraseAttribute(eraseTrack, attrMask);
+	}
+
+	do {
+		track = (int*)(*trackBasePtr + 0x292c);
+		scan = track;
+		remaining = trackCount;
+		do {
+			while (((track = scan, remaining = remaining - 1, remaining != 0) && (*track == 0)) &&
+			       ((((unsigned char*)track)[0x26] & 2) == 0)) {
+				scan = track - 0x55;
+			}
+			if ((*track != 0) || ((((unsigned char*)track)[0x26] & 2) != 0)) {
+				remaining = 1;
+				scan = track;
+			}
+			scan = scan - 0x55;
+		} while ((remaining != 0) && ((int*)*trackBasePtr <= track));
+	} while ((track < (int*)*trackBasePtr) && (_EraseTime(eraseTrack) != 0));
+
+	if (track < (int*)*trackBasePtr) {
+		track = 0;
+	}
+
+	return track;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `SearchSeEmptyTrack__Fiii` in `src/RedSound/RedCommand.cpp` using the PAL Ghidra reference as a first-pass decomp.
- Updated the declaration in `include/ffcc/RedSound/RedCommand.h` from `void` to `int*` to match the implemented behavior (returns selected track pointer or `NULL`).
- Added full PAL metadata block for the function (`0x801ca3bc`, `252b`).

## Functions improved
- Unit: `main/RedSound/RedCommand`
- Symbol: `SearchSeEmptyTrack__Fiii`

## Match evidence
- Baseline (before implementation): symbol compiled as stub (`size=4`) with low match (`1.5873016%`) from objdiff JSON oneshot.
- After implementation: symbol compiles to full body (`size=428`) and shows substantial structural alignment against the base (`38.785046%`) in direct object diff.

Commands used:
```sh
# baseline
../tools/objdiff-cli diff -p . -u main/RedSound/RedCommand -o - SearchSeEmptyTrack__Fiii > /tmp/redcommand_searchse_before.json

# after
../tools/objdiff-cli diff -1 build/GCCP01/src/RedSound/RedCommand.o -2 build/GCCP01/obj/RedSound/RedCommand.o -o - SearchSeEmptyTrack__Fiii > /tmp/redcommand_direct_after.json
```

## Plausibility rationale
- The implementation follows existing RedSound coding style in this file (raw pointer traversal over track blocks, offset-based field access, erase/retry loop).
- Behavior is source-plausible: optional attribute erase, reverse scan for usable SE track, fallback to `_EraseTime` when full, and `NULL` when no track can be allocated.
- No compiler-coaxing artifacts were introduced (no contrived temporaries or unnatural control flow beyond what the decomp itself requires for first-pass recovery).

## Technical details
- Uses same base data anchors already used in neighboring functions (`DAT_8032f3f0 + 0xdbc` track base).
- Preserves the two-stage retry loop shown by reference behavior:
  1. scan candidate tracks backward with `trackCount` budget,
  2. if exhausted, call `_EraseTime(eraseTrack)` and retry while it can free a track.
- Return path now exposes the located track pointer for use by later play-start logic.
