### PR TITLE
pppYmLaser: fix destruct offset dereference to match PAL access path

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -7,7 +7,7 @@
 
 #include <string.h>
 
-extern CMath Math;
+extern CMath math;
 extern "C" float RandF__5CMathFf(float param, CMath* math);
 extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
 extern struct _pppMngSt* pppMngStPtr;
@@ -137,7 +137,7 @@ extern "C" void pppConstructYmLaser(void* pppYmLaser_, void* param_2_)
 	*((u16*)((u8*)work + 0x30)) = 0;
 	*((u16*)((u8*)work + 0x34)) = 0;
 	*((u16*)((u8*)work + 0x32)) = 0;
-	work[14] = RandF__5CMathFf(FLOAT_80330dc0, &Math);
+	work[14] = RandF__5CMathFf(FLOAT_80330dc0, &math);
 }
 
 /*
@@ -180,8 +180,8 @@ extern "C" void pppConstruct2YmLaser(void* pppYmLaser_, void* param_2_)
 extern "C" void pppDestructYmLaser(void* pppYmLaser_, void* param_2_)
 {
 	pppYmLaser* pppYmLaser = (struct pppYmLaser*)pppYmLaser_;
-	YmLaserOffsets* param_2 = (YmLaserOffsets*)param_2_;
-	f32* work = (f32*)((u8*)pppYmLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
+	YmLaserParam* param_2 = (YmLaserParam*)param_2_;
+	f32* work = (f32*)((u8*)pppYmLaser + 0x80 + param_2->offsets->m_serializedDataOffsets[2]);
 	void* stage = *(void**)(work + 7);
 
 	if (stage != 0) {


### PR DESCRIPTION
## Summary
- Update `pppDestructYmLaser` to treat the second argument as `YmLaserParam*` and dereference `offsets->m_serializedDataOffsets[2]`, matching the access path already used by the construct/frame functions in this unit.
- Keep behavior unchanged: still clears stage usage and nulls the work-stage pointer when present.

## Functions improved
- Unit: `main/pppYmLaser`
- Function: `pppDestructYmLaser`

## Match evidence
- `pppDestructYmLaser`: **94.68421% -> 100.0%**
- No regressions observed in sibling functions in `pppYmLaser.o` during this pass (`pppConstructYmLaser`, `pppConstruct2YmLaser`, `pppFrameYmLaser`, `pppRenderYmLaser` unchanged).
- Verification command used:
  - `tools/objdiff-cli diff -p . -u main/pppYmLaser -o -`

## Plausibility rationale
- The change removes an inconsistent parameter interpretation in destructor code and aligns it with the same serialized offset lookup convention used elsewhere in this object file.
- This is a source-plausible type/access correction, not compiler coaxing.

## Technical details
- Prior mismatch showed one missing dereference load in the destructor offset path.
- After switching to `YmLaserParam*` and reading `param_2->offsets->m_serializedDataOffsets[2]`, instruction shape aligned fully for this function.

## Build
- `ninja` passes in this branch.
