### PR TITLE
pppYmMegaBirthShpTail3: implement frame path and correct particle layouts

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail3.h
+++ b/include/ffcc/pppYmMegaBirthShpTail3.h
@@ -17,16 +17,18 @@ struct pppYmMegaBirthShpTail3
 
 struct VYmMegaBirthShpTail3
 {
-    _PARTICLE_DATA m_baseData;  // 0x0 - 0x140
-    Vec m_tailScaleDirection;   // 0x140 - 0x14c
-}; // Size 0x14c+
+    pppFMATRIX m_emitterMatrix;   // 0x0
+    _PARTICLE_DATA* m_particles;  // 0x30
+    _PARTICLE_WMAT* m_wmats;      // 0x34
+    _PARTICLE_COLOR* m_colors;    // 0x38
+    unsigned int m_maxParticles;  // 0x3c
+    unsigned int m_lifeLimit;     // 0x40
+    Vec m_tailScaleDirection;     // 0x44
+};
 
-struct PYmMegaBirthShpTail3
+struct PYmMegaBirthShpTail3 : _PARTICLE_DATA
 {
-    pppFMATRIX m_matrix;        // 0x0 - 0x30
-    float m_colorDeltaAdd[4];   // 0x30 - 0x40
-    float m_sizeVal;            // 0x40 - 0x44
-}; // Size 0x44+
+};
 
 struct UnkB;
 struct UnkC


### PR DESCRIPTION
## Summary
- Reworked `VYmMegaBirthShpTail3` and `PYmMegaBirthShpTail3` layouts in `include/ffcc/pppYmMegaBirthShpTail3.h` to match the same particle-work model used by adjacent `Tail2` code and Ghidra references.
- Implemented `pppFrameYmMegaBirthShpTail3` allocation/spawn/update loop in `src/pppYmMegaBirthShpTail3.cpp` (particle/wmat allocation, emitter matrix selection, life-limit spawn gate, `birth`/`calc` dispatch).
- Kept changes scoped to one unit and preserved successful `ninja` build.

## Functions Improved
- Unit: `main/pppYmMegaBirthShpTail3`
- Function: `pppFrameYmMegaBirthShpTail3`

## Match Evidence (objdiff)
- `pppFrameYmMegaBirthShpTail3`: **0.24691358% -> 18.407408%**
- Other symbols in the unit remained at prior levels in this pass (`birth`, `calc`, `render` unchanged).

## Plausibility Rationale
- The new frame function follows the same source style and control flow already present in `pppYmMegaBirthShpTail2` (same subsystem, neighboring effect implementation), rather than introducing compiler-coaxing-only constructs.
- The struct updates reflect practical field usage observed in this unit (emitter matrix + particle buffers + limits), aligning with how frame logic and allocator calls are actually consumed.

## Technical Notes
- Allocation sizes/gates were matched to the PAL decomp intent for this effect path (`0x1f8` particle stride, `0x30` wmat stride).
- Emitter transform mode switch was implemented with the same matrix source split (manager matrix copy vs scale+position identity path) used by sibling code paths.
