### PR TITLE
pppLaser: initialize laser work[7] via float store

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -114,7 +114,7 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
     pfVar3[3] = FLOAT_80333428;
     pfVar3[2] = FLOAT_80333428;
     pfVar3[1] = FLOAT_80333428;
-    *(u32*)((u8*)pfVar3 + 0x1c) = 0;
+    pfVar3[7] = FLOAT_80333428;
     pfVar3[10] = FLOAT_80333428;
     pfVar3[9] = FLOAT_80333428;
     pfVar3[8] = FLOAT_80333428;


### PR DESCRIPTION
## Summary
- Changed one initialization in `pppConstructLaser` from an integer byte-offset store to a typed float-array store:
  - `*(u32*)((u8*)pfVar3 + 0x1c) = 0;`
  - -> `pfVar3[7] = FLOAT_80333428;`
- This keeps behavior equivalent (zeroing the same 4-byte slot) while matching the surrounding source style and improving generated code alignment.

## Functions improved
- Unit: `main/pppLaser`
- Function: `pppConstructLaser` (PAL 0x801766ec, 336b)

## Match evidence
- `pppConstructLaser`: **71.63095% -> 71.67857%** (+0.04762)
- `main/pppLaser` unit fuzzy match: **37.57708% -> 37.580307%** (+0.003227)
- Build verification: `ninja` succeeded and regenerated `build/GCCP01/report.json`.

## Plausibility rationale
- The change is source-plausible and idiomatic: we initialize a float work slot using the existing float work buffer, rather than a raw integer cast/store.
- No control-flow changes, no artificial temporaries, and no contrived ordering were introduced.

## Technical details
- The edited slot corresponds to `work[7]` in the same contiguous float workspace that already initializes neighboring entries (`work[0..6]`, `work[8..10]`).
- This narrows type ambiguity for the compiler and slightly improves assembly match without reducing readability.
