### PR TITLE
map: implement GetDebugPlaySta and fix return type

### DIFF
--- a/include/ffcc/map.h
+++ b/include/ffcc/map.h
@@ -68,7 +68,7 @@ public:
     CMapObj* SearchChildMapObj(CMapObj*, CMapObj*);
     void SearchAtribMapObj(CMapObj*, CMapObjAtr::TYPE);
     void AttachMapHit(CMapHit*, char*);
-    void GetDebugPlaySta(int, Vec*);
+    int GetDebugPlaySta(int, Vec*);
     void SetLightSource();
     void SetBumpLightSource();
     void InitMapShadow();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1479,12 +1479,34 @@ void CMapMng::AttachMapHit(CMapHit*, char*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80032f1c
+ * PAL Size: 180b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapMng::GetDebugPlaySta(int, Vec*)
+int CMapMng::GetDebugPlaySta(int playStaNo, Vec* vec)
 {
-	// TODO
+    unsigned char* mapObj = Ptr(this, 0x954);
+    unsigned char* mapObjEnd = mapObj + (*reinterpret_cast<short*>(Ptr(this, 0xC)) * 0xF0);
+
+    while (mapObj < mapObjEnd) {
+        unsigned char* mapObjAtr = *reinterpret_cast<unsigned char**>(mapObj + 0xEC);
+        if (mapObjAtr != 0 && *reinterpret_cast<int*>(mapObjAtr + 4) == 4 &&
+            *(mapObjAtr + 8) == static_cast<unsigned char>(playStaNo)) {
+            vec->x = *reinterpret_cast<float*>(mapObj + 0xC4);
+            vec->y = *reinterpret_cast<float*>(mapObj + 0xD4);
+            vec->z = *reinterpret_cast<float*>(mapObj + 0xE4);
+            return 1;
+        }
+        mapObj += 0xF0;
+    }
+
+    vec->x = FLOAT_8032f9a0;
+    vec->y = FLOAT_8032f9a0;
+    vec->z = FLOAT_8032f9a0;
+    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapMng::GetDebugPlaySta` in `src/map.cpp` (previously TODO).
- Updated declaration in `include/ffcc/map.h` from `void` to `int` to match symbol behavior and decomp usage.
- Added PAL metadata block for the implemented function (`0x80032f1c`, `180b`).

## Functions improved
- Unit: `main/map`
- Symbol: `GetDebugPlaySta__7CMapMngFiP3Vec`
- Before: `2.2222223%`
- After: `31.155556%`
- Delta: `+28.9333333%`

## Match evidence
- Objdiff command:
  - `tools/objdiff-cli diff -p . -u main/map -o diff_getdebug_after.json --format json-pretty GetDebugPlaySta__7CMapMngFiP3Vec`
- Unit `.text` match also improved:
  - Before: `27.250597%`
  - After: `27.489452%`
  - Delta: `+0.238855%`

## Plausibility rationale
- The new implementation follows a straightforward gameplay-query pattern: iterate map objects, check object attribute type, return matching play-start position, otherwise return default fallback coordinates.
- This is source-plausible and consistent with existing map/object offset-based logic in this codebase (no contrived temporaries, no artificial sequencing).

## Technical notes
- The old function body was empty (`TODO`), causing near-zero match.
- The updated function aligns to decomp-indicated control/data access points:
  - Map object array at `this + 0x954`
  - Object count from `this + 0xC`
  - Play-start attribute pointer at object `+0xEC`
  - Position reads from `+0xC4/+0xD4/+0xE4`
  - Fallback vector set to `FLOAT_8032f9a0` when no matching play-start is found.
