### PR TITLE
pppScreenBreak: align pppRenderScreenBreak control flow

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -705,10 +705,13 @@ void pppRenderScreenBreak(PScreenBreak* pppScreenBreak, UnkB*, UnkC* param_3)
 {
     s32 dataOffset = param_3->m_serializedDataOffsets[2];
     u8* value = (u8*)pppScreenBreak + dataOffset + 0x80;
+    void* handle = GetCharaHandlePtr__FP8CGObjectl(*(void**)((u8*)pppMngStPtr + 0xD8), 0);
+    int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
+    SearchNode__Q26CChara6CModelFPc((CChara::CModel*)model, s_f999_root_801dd4c8);
 
     if (value[0x24] == 0) {
-        Graphic.GetBackBufferRect2(*(void**)((u8*)&Graphic + 0x71EC), *(_GXTexObj**)(value + 0x10), 0, 0, 0x280, 0x1C0,
-                                   0, (_GXTexFilter)0, (_GXTexFmt)0, 0);
+        Graphic.GetBackBufferRect2(DAT_80238034, *(_GXTexObj**)(value + 0x10), 0, 0, 0x280, 0x1C0, 0, (_GXTexFilter)1,
+                                   (_GXTexFmt)4, 0);
         value[0x24] = 1;
     }
 }


### PR DESCRIPTION
## Summary
- Updated `pppRenderScreenBreak` in `src/pppScreenBreak.cpp` to restore model lookup/node selection flow before backbuffer capture.
- Switched `GetBackBufferRect2` call to use `DAT_80238034` and the observed texture filter/format constants used by this effect path.

## Functions improved
- Unit: `main/pppScreenBreak`
- Symbol: `pppRenderScreenBreak`
- Match: **69.28571% -> 92.26190%** (`168b`)

## Match evidence
- Baseline: `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o diff_render_before.json --format json-pretty pppRenderScreenBreak`
- After change: `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o diff_render_after.json --format json-pretty pppRenderScreenBreak`
- Objdiff instruction deltas show removal of several deleted callsites and improved alignment around:
  - `GetCharaHandlePtr__FP8CGObjectl`
  - `GetCharaModelPtr__FPQ29CCharaPcs7CHandle`
  - `SearchNode__Q26CChara6CModelFPc`
  - `Graphic.GetBackBufferRect2(...)`

## Plausibility rationale
- The restored code reflects normal game-side setup for effect rendering: resolve current character model, select effect root node, then capture backbuffer once.
- This improves assembly correspondence by reinstating game-logic steps that are semantically expected for screen-break setup, rather than introducing compiler-only coercions.

## Technical details
- Kept the change tightly scoped to one function to reduce noise.
- Verified with `ninja` that build and report generation remain clean after the edit.
