### PR TITLE
mapocttree: improve __sinit_mapocttree_cpp match

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1922,21 +1922,17 @@ COctNode::COctNode()
  */
 extern "C" void __sinit_mapocttree_cpp()
 {
-	float max = lbl_8032F970;
-	float min = lbl_8032F96C;
-	float* bounds = (float*)&s_bound;
+	((float*)&s_bound)[0] = lbl_8032F96C;
+	((float*)&s_bound)[1] = lbl_8032F96C;
+	((float*)&s_bound)[2] = lbl_8032F96C;
+	((float*)&s_bound)[3] = lbl_8032F970;
+	((float*)&s_bound)[4] = lbl_8032F970;
+	((float*)&s_bound)[5] = lbl_8032F970;
 
-	bounds[0] = min;
-	bounds[1] = min;
-	bounds[2] = min;
-	bounds[3] = max;
-	bounds[4] = max;
-	bounds[5] = max;
-
-	s_cyl.m_direction2.y = min;
-	s_cyl.m_direction2.x = min;
-	s_cyl.m_top.z = min;
-	s_cyl.m_height2 = max;
-	s_cyl.m_radius2 = max;
-	s_cyl.m_direction2.z = max;
+	s_cyl.m_direction2.y = lbl_8032F96C;
+	s_cyl.m_direction2.x = lbl_8032F96C;
+	s_cyl.m_top.z = lbl_8032F96C;
+	s_cyl.m_height2 = lbl_8032F970;
+	s_cyl.m_radius2 = lbl_8032F970;
+	s_cyl.m_direction2.z = lbl_8032F970;
 }


### PR DESCRIPTION
## Summary
- Updated `__sinit_mapocttree_cpp` in `src/mapocttree.cpp` to use direct constant-to-storage assignments without temporary locals.
- Kept store order aligned with the PAL decomp pattern for `s_bound` and `s_cyl` static initialization.

## Functions Improved
- Unit: `main/mapocttree`
- Symbol: `__sinit_mapocttree_cpp` (PAL `0x8002f410`, 76b)

## Match Evidence
- Before: `0.0%` (from `tools/agent_select_target.py` output for `main/mapocttree` in this branch before edits)
- After: `53.94737%` from:
  - `tools/objdiff-cli diff -p . -u main/mapocttree -o - __sinit_mapocttree_cpp`
- The resulting diff shows improved instruction/relocation alignment in the function body.

## Plausibility Rationale
- This is a source-plausible cleanup: replacing compiler-influencing temporaries with straightforward static initialization stores.
- No synthetic control flow or non-idiomatic coercion was introduced.

## Technical Details
- Removed local aliases (`min`, `max`, and `bounds`) that altered register and address-materialization behavior.
- Switched to direct stores from `lbl_8032F96C` / `lbl_8032F970` into `s_bound` and `s_cyl` fields in the observed order.
