### PR TITLE
pppYmLaser: improve pppRenderYmLaser match by aligning control flow

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -456,43 +456,41 @@ extern "C" void pppRenderYmLaser(void* pppYmLaser, void* param_2, void* param_3)
 			shape, *(s16*)(work + 0xd), pppEnvStPtr->m_materialSetPtr, step->m_payload[0x1c]);
 
 		count = (u32)step->m_payload[0x1e];
-		if (count > 1) {
-			uvStep = FLOAT_80330de0 / ((float)(double)count - (float)DOUBLE_80330dd8);
-			if (step->m_initWOrk == 0xFFFF) {
-				_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
-				_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);
-			} else {
-				tex = GetTextureFromRSD__FiP9_pppEnvSt(step->m_initWOrk, pppEnvStPtr);
-				_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 0);
-				GXLoadTexObj((GXTexObj*)(tex + 0x28), GX_TEXMAP0);
-			}
+		uvStep = FLOAT_80330de0 / ((float)(double)count - (float)DOUBLE_80330dd8);
+		if (step->m_initWOrk == 0xFFFF) {
+			_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
+			_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);
+		} else {
+			tex = GetTextureFromRSD__FiP9_pppEnvSt(step->m_initWOrk, pppEnvStPtr);
+			_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 0);
+			GXLoadTexObj((GXTexObj*)(tex + 0x28), GX_TEXMAP0);
+		}
 
-			GXLoadPosMtxImm(ppvCameraMatrix0, GX_PNMTX0);
-			alphaMax = step->m_payload[0x2b];
-			alphaStep = (u8)((u32)alphaMax / count);
-			colorBase = *(u32*)(step->m_payload + 0x28) & 0xFFFFFF00;
-			points = (Vec*)(u32)work[7];
+		GXLoadPosMtxImm(ppvCameraMatrix0, GX_PNMTX0);
+		alphaMax = step->m_payload[0x2b];
+		alphaStep = (u8)((u32)alphaMax / count);
+		colorBase = *(u32*)(step->m_payload + 0x28) & 0xFFFFFF00;
+		points = (Vec*)(u32)work[7];
 
-			GXBegin(GX_TRIANGLES, GX_VTXFMT7, (u16)((count - 1) * 3));
-			for (i = 0; i < count - 1; i++) {
-				alpha0 = (u8)(alphaMax - (u8)(alphaStep * i));
-				color0 = colorBase | alpha0;
-				color1 = colorBase | (u8)(alphaMax - (u8)(alphaStep * (i + 1)));
-				u0 = (float)i * uvStep;
-				u1 = (float)(i + 1) * uvStep;
+		GXBegin(GX_TRIANGLES, GX_VTXFMT7, (u16)((count - 1) * 3));
+		for (i = 0; i < count - 1; i++) {
+			alpha0 = (u8)(alphaMax - (u8)(alphaStep * i));
+			color0 = colorBase | alpha0;
+			color1 = colorBase | (u8)(alphaMax - (u8)(alphaStep * (i + 1)));
+			u0 = (float)i * uvStep;
+			u1 = (float)(i + 1) * uvStep;
 
-				GXPosition3f32(work[8], work[9], work[10]);
-				GXColor1u32(color0);
-				GXTexCoord2f32(u0, FLOAT_80330de0);
+			GXPosition3f32(work[8], work[9], work[10]);
+			GXColor1u32(color0);
+			GXTexCoord2f32(u0, FLOAT_80330de0);
 
-				GXPosition3f32(points[i].x, points[i].y, points[i].z);
-				GXColor1u32(color0);
-				GXTexCoord2f32(u0, FLOAT_80330dc0);
+			GXPosition3f32(points[i].x, points[i].y, points[i].z);
+			GXColor1u32(color0);
+			GXTexCoord2f32(u0, FLOAT_80330dc0);
 
-				GXPosition3f32(points[i + 1].x, points[i + 1].y, points[i + 1].z);
-				GXColor1u32(color1);
-				GXTexCoord2f32(u1, FLOAT_80330dc0);
-			}
+			GXPosition3f32(points[i + 1].x, points[i + 1].y, points[i + 1].z);
+			GXColor1u32(color1);
+			GXTexCoord2f32(u1, FLOAT_80330dc0);
 		}
 
 		if ((CFlatFlags & 0x200000) != 0) {


### PR DESCRIPTION
## Summary
- Updated `pppRenderYmLaser` control flow in `src/pppYmLaser.cpp` to better match original behavior.
- Removed an extra `if (count > 1)` wrapper that incorrectly gated the trail rendering setup.
- Kept trail draw loop semantics unchanged (`for (i = 0; i < count - 1; i++)`) while allowing the debug-render block to run under the same conditions as the original control flow.

## Functions Improved
- Unit: `main/pppYmLaser`
- Function: `pppRenderYmLaser`
  - Before: `24.541224%`
  - After: `24.800531%`
  - Size: `3008b`

## Match Evidence
- objdiff command:
  - `tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppRenderYmLaser`
- Unit `.text` match changed:
  - Before: `30.93235%`
  - After: `31.101475%`

## Plausibility Rationale
- This change removes a non-essential guard and restores a more natural render-path structure where debug drawing depends on the runtime debug flag and step state, not an additional trail-count condition.
- The updated flow remains readable and source-plausible, with no synthetic temporaries or coercive compiler tricks.

## Technical Details
- `count`, `points`, alpha setup, and GX path setup are now initialized consistently before the trail draw loop.
- The debug block remains under `m_stepValue != 0` and no longer inherits the extra `count > 1` gate.
