### PR TITLE
memorycard: preserve script/fur blocks in MakeSaveData

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -13,6 +13,11 @@ extern unsigned char Game[];
 extern CMath Math;
 CMemoryCardMan MemoryCardMan;
 
+extern "C" void SaveScript__5CGameFPc(void* game, char* scriptData);
+class CChara;
+extern CChara Chara;
+extern "C" void SaveFurTexBuffer__6CCharaFPUs(CChara* chara, unsigned short* outTexels);
+
 // CRC32 lookup table
 static const unsigned int crcTable[256] = {
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
@@ -872,6 +877,9 @@ void CMemoryCardMan::MakeSaveData()
         *reinterpret_cast<int*>(dst + 0x1DA0) = *reinterpret_cast<int*>(cv + 0xC24);
         *reinterpret_cast<int*>(dst + 0x1DA4) = *reinterpret_cast<int*>(cv + 0x10);
     }
+
+    SaveScript__5CGameFPc(Game, reinterpret_cast<char*>(save + 0x62D0));
+    SaveFurTexBuffer__6CCharaFPUs(&Chara, reinterpret_cast<unsigned short*>(save + 0x6AD0));
 }
 
 /*
@@ -1026,6 +1034,7 @@ void CMemoryCardMan::SetLoadData()
             *reinterpret_cast<int*>(gameWork + 0x18 + i * 4) = -1;
         }
     }
+
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added missing save-data writes for script state and fur texture buffers in `CMemoryCardMan::MakeSaveData`.
- Kept the change minimal and source-plausible by using existing engine entry points and existing save-buffer layout offsets.

## Functions improved
- Unit: `main/memorycard`
- `MakeSaveData__14CMemoryCardManFv` (PAL 0x800c369c, 2576b)

## Match evidence
Measured with:
`tools/objdiff-cli diff -p . -u main/memorycard -o - MakeSaveData__14CMemoryCardManFv`

- `MakeSaveData__14CMemoryCardManFv`: **29.972050% -> 34.071430%** (+4.099380)
- `SetLoadData__14CMemoryCardManFv`: **19.700705% -> 19.700705%** (no regression)

## Plausibility rationale
- The save routine is expected to serialize all runtime state that load consumes.
- PAL decomp reference for `MakeSaveData` includes these two calls after per-character packing, matching the existing save buffer regions (`0x62D0`, `0x6AD0`).
- The change avoids artificial control-flow coercion and keeps behavior aligned with project conventions.

## Technical details
- Added `SaveScript__5CGameFPc(Game, save+0x62D0)`.
- Added `SaveFurTexBuffer__6CCharaFPUs(&Chara, (u16*)(save+0x6AD0))`.
- No struct-layout edits, no changes to load flow, and build remains clean with `ninja`.
