### PR TITLE
mapanim: improve CMapAnimRun::Calc match

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -634,22 +634,18 @@ void CMapAnim::Calc(long frame)
 void CMapAnimRun::Calc(long frame)
 {
     int* run = reinterpret_cast<int*>(this);
-    CMapAnim* mapAnim;
-
-    if (run[0] < 0 && run[3] != frame) {
-        return;
-    }
-
     if (run[0] < 0) {
+        if (run[3] != frame) {
+            return;
+        }
         run[0] = run[1];
     }
 
-    mapAnim = __vc__21CPtrArray_P8CMapAnim_FUl(MapMng + 0x2140C, reinterpret_cast<unsigned short*>(this)[9]);
+    CMapAnim* mapAnim = __vc__21CPtrArray_P8CMapAnim_FUl(MapMng + 0x2140C, reinterpret_cast<unsigned short*>(this)[9]);
     mapAnim->Calc(run[0]);
-    int nextFrame = run[0] + 1;
-    run[0] = nextFrame;
+    run[0] = run[0] + 1;
 
-    if (nextFrame > run[2]) {
+    if (run[2] < run[0]) {
         if (reinterpret_cast<unsigned char*>(this)[0x10] != 0) {
             run[0] = 0;
         } else {


### PR DESCRIPTION
## Summary
- Refactored `CMapAnimRun::Calc(long)` in `src/mapanim.cpp` to match original branch structure and comparison direction more closely.
- Replaced the short-circuit early return (`run[0] < 0 && run[3] != frame`) with nested control flow that mirrors the expected assembly shape.
- Kept behavior intact while simplifying temporary usage around frame increment/check.

## Functions improved
- Unit: `main/mapanim`
- Symbol: `Calc__11CMapAnimRunFl`

## Match evidence
- `Calc__11CMapAnimRunFl`: **65.57143% -> 67.71429%** (`+2.14286`)
- Verification command:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/mapanim -o - Calc__11CMapAnimRunFl`

## Plausibility rationale
- The updated code is a natural source-level expression of the same runtime logic:
  - explicit negative-frame gate, then conditional reset to start frame
  - post-calc increment followed by an upper-bound check
- No compiler-coaxing constructs were introduced; this is straightforward gameplay/menu animation run-state logic.

## Technical details
- Primary improvement came from matching control-flow shape (nested branch vs short-circuit branch).
- Secondary alignment came from using direct in-place increment and boundary comparison (`run[2] < run[0]`) to better match compare/branch ordering.
