### PR TITLE
map: implement DrawMapShadow

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1667,7 +1667,13 @@ void CMapMng::Calc()
  */
 void CMapMng::DrawMapShadow()
 {
-	// TODO
+    if (*reinterpret_cast<short*>(Ptr(this, 0xC)) != 0) {
+        CPtrArray<CMapShadow*>* mapShadowArray = reinterpret_cast<CPtrArray<CMapShadow*>*>(Ptr(this, 0x21434));
+        for (unsigned int i = 0; i < mapShadowArray->GetSize(); i++) {
+            CMapShadow* mapShadow = (*mapShadowArray)[i];
+            mapShadow->Draw();
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMapMng::DrawMapShadow()` in `src/map.cpp`.
- Replaced the placeholder body with a real map-shadow draw loop guarded by map object count.
- Uses existing `CPtrArray<CMapShadow*>` access pattern already present in this unit.

## Functions improved
- Unit: `main/map`
- Symbol: `DrawMapShadow__7CMapMngFv`
- Size: `112b`

## Match evidence
- Before: `3.5714285%` fuzzy match
- After: `63.214287%` fuzzy match
- Measurement method: `build/tools/objdiff-cli report generate -p . -f json`

## Plausibility rationale
- The new implementation is source-plausible: check map-active state, iterate map shadow array, call per-shadow draw.
- This follows the same data layout and array access style used throughout `src/map.cpp` (`Ptr(this, ...)` + `CPtrArray` traversal).
- No compiler-coaxing patterns or artificial temporaries were introduced.

## Technical details
- Reads the same map state fields already used elsewhere in this file:
  - map object count at `0xC`
  - map shadow array at `0x21434`
- Loop form intentionally keeps `GetSize()` in the condition, matching expected object-level control flow for this area.
- Full `ninja` build passes after the change.
