### PR TITLE
p_camera: implement shadow helper methods

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/p_camera.h"
 
+#include "ffcc/materialman.h"
+
 #include <dolphin/mtx.h>
 
 extern Mtx ppvCameraMatrix0;
@@ -7,10 +9,12 @@ extern float FLOAT_8032fa30;
 extern float FLOAT_8032fa34;
 extern float FLOAT_8032fa38;
 extern float FLOAT_8032fa5c;
+extern float FLOAT_8032fa58;
 extern float FLOAT_8032fa8c;
 extern float FLOAT_8032fab0;
 extern float FLOAT_8032fab4;
 extern float FLOAT_8032fab8;
+extern CMaterialMan MaterialMan;
 
 extern "C" {
 void pppEditGetViewPos__FP3Vec(Vec*);
@@ -329,22 +333,43 @@ void CCameraPcs::drawShadowEnd()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80036c7c
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCameraPcs::drawShadowChrBegin()
 {
-	// TODO
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+
+    if (self[0x404] != 0) {
+        *reinterpret_cast<float*>(self + 0x3E0) *= FLOAT_8032fa58;
+        *reinterpret_cast<float*>(self + 0x3F0) *= FLOAT_8032fa58;
+        PSMTXConcat(reinterpret_cast<MtxPtr>(self + 0x3D4),
+                    reinterpret_cast<MtxPtr>(self + 0x214),
+                    reinterpret_cast<MtxPtr>(self + 0x3A4));
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80036c38
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CCameraPcs::SetFullScreenShadow(float (*) [4], long)
+void CCameraPcs::SetFullScreenShadow(float (*matrix)[4], long flags)
 {
-	// TODO
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+
+    if (self[0x404] != 0) {
+        MaterialMan.SetFullScreenShadow(*reinterpret_cast<CFullScreenShadow*>(self + 0x31C),
+                                        matrix, flags);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two `CCameraPcs` shadow helper stubs in `src/p_camera.cpp` using the existing raw-offset style already used in this unit:
- `SetFullScreenShadow__10CCameraPcsFPA4_fl`
- `drawShadowChrBegin__10CCameraPcsFv`

Also added PAL metadata blocks for both functions and required declarations (`CMaterialMan MaterialMan`, `FLOAT_8032fa58`).

## Functions improved
Unit: `main/p_camera`
- `SetFullScreenShadow__10CCameraPcsFPA4_fl` (68b)
- `drawShadowChrBegin__10CCameraPcsFv` (88b)

## Match evidence
`build/GCCP01/report.json` function fuzzy match percent:
- `SetFullScreenShadow__10CCameraPcsFPA4_fl`: **5.882353% -> 83.52941%**
- `drawShadowChrBegin__10CCameraPcsFv`: **4.5454545% -> 93.86364%**

Rebuild status:
- `ninja` passes in the PR branch.

## Plausibility rationale
These edits are direct, idiomatic implementations of camera shadow helper behavior:
- gate behavior on the camera shadow enable byte (`+0x404`)
- forward full-screen shadow setup to `CMaterialMan::SetFullScreenShadow`
- apply shadow matrix scale and concatenate matrices for character shadow draw begin

No contrived control-flow shaping or artificial temporaries were introduced; the changes are compact and consistent with nearby decomp style in `p_camera.cpp`.

## Technical notes
- Used Ghidra only as structure guidance and validated with project report metrics.
- Kept implementation scoped to these two methods to avoid touching unrelated TODO-heavy camera routines in this pass.
