### PR TITLE
pppYmMegaBirthShpTail3: improve pppFrame accumulator updates

### DIFF
--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -268,6 +268,30 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
         return;
     }
 
+    *(s16*)work[1].m_emitterMatrix.value[1] += *(s16*)(work[1].m_emitterMatrix.value[1] + 2);
+    *(s16*)work[1].m_emitterMatrix.value[0] += *(s16*)work[1].m_emitterMatrix.value[1];
+
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[1] + 2) += *(s16*)((u8*)work[1].m_emitterMatrix.value[1] + 0xa);
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[0] + 2) += *(s16*)((u8*)work[1].m_emitterMatrix.value[1] + 2);
+
+    *(s16*)(work[1].m_emitterMatrix.value[1] + 1) += *(s16*)(work[1].m_emitterMatrix.value[1] + 3);
+    *(s16*)(work[1].m_emitterMatrix.value[0] + 1) += *(s16*)(work[1].m_emitterMatrix.value[1] + 1);
+
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[1] + 6) += *(s16*)((u8*)work[1].m_emitterMatrix.value[1] + 0xe);
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[0] + 6) += *(s16*)((u8*)work[1].m_emitterMatrix.value[1] + 6);
+
+    *(s16*)work[1].m_emitterMatrix.value[2] += *(s16*)(work[1].m_emitterMatrix.value[2] + 2);
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[0] + 8) += *(s16*)work[1].m_emitterMatrix.value[2];
+
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[2] + 2) += *(s16*)((u8*)work[1].m_emitterMatrix.value[2] + 0xa);
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[0] + 0xa) += *(s16*)((u8*)work[1].m_emitterMatrix.value[2] + 2);
+
+    *(s16*)(work[1].m_emitterMatrix.value[2] + 1) += *(s16*)(work[1].m_emitterMatrix.value[2] + 3);
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[0] + 0xc) += *(s16*)(work[1].m_emitterMatrix.value[2] + 1);
+
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[2] + 6) += *(s16*)((u8*)work[1].m_emitterMatrix.value[2] + 0xe);
+    *(s16*)((u8*)work[1].m_emitterMatrix.value[0] + 0xe) += *(s16*)((u8*)work[1].m_emitterMatrix.value[2] + 6);
+
     switch (*(paramPayload + 0x12)) {
     default:
         PSMTXCopy(pppMngStPtr->m_matrix.value, work->m_emitterMatrix.value);


### PR DESCRIPTION
## Summary
- restored the per-frame `s16` accumulator chain in `pppFrameYmMegaBirthShpTail3`
- added the missing updates that integrate angular/phase values before emitter-matrix mode selection
- kept the change localized to source-plausible math/state updates (no compiler-coax temporaries)

## Functions improved
- Unit: `main/pppYmMegaBirthShpTail3`
- Symbol: `pppFrameYmMegaBirthShpTail3`

## Match evidence
- Controlled local baseline (same branch, file reset to `origin/main`): `18.407408%`
- After this change: `33.503704%`
- Delta: `+15.096296` percentage points

### Repro commands
```sh
# baseline (origin/main file in same worktree)
tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o - pppFrameYmMegaBirthShpTail3

# after applying this commit
tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o - pppFrameYmMegaBirthShpTail3
```

## Plausibility rationale
- The restored code is the kind of fixed-step state integration expected for this particle emitter path.
- It uses existing in-struct storage and arithmetic patterns already present in neighboring particle units.
- No artificial no-op control flow or unnatural reordering was introduced; this is a direct behavioral reconstruction step.

## Technical details
- Inserted 24 lines of `s16` accumulation updates in `pppFrameYmMegaBirthShpTail3` immediately after allocation checks.
- These updates match the missing accumulator progression seen in decomp references and feed the existing mode switch / spawn logic.
