### PR TITLE
RedSound: improve GetAutoID match via explicit volatile counter updates

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -17,7 +17,7 @@ extern CRedDriver CRedDriver_8032f4c0;
 extern CRedMemory DAT_8032f480;
 extern CRedEntry DAT_8032e154;
 extern int DAT_8032f408; // Debug flag
-extern unsigned int DAT_8032f4c4; // Auto ID counter
+extern volatile unsigned int DAT_8032f4c4; // Auto ID counter
 extern int DAT_8032e17c[0x40]; // Standby ID table
 extern void* DAT_8032e170; // Registration memory
 extern void* DAT_8032f4c8; // Internal sound state buffer
@@ -76,7 +76,8 @@ extern "C" CRedSound* dtor_801CCA38(CRedSound* redSound, short param_2)
 unsigned int CRedSound::GetAutoID()
 {
 	do {
-		DAT_8032f4c4 = (DAT_8032f4c4 + 1) & 0x7FFFFFFF;
+		DAT_8032f4c4 = DAT_8032f4c4 + 1;
+		DAT_8032f4c4 = DAT_8032f4c4 & 0x7FFFFFFF;
 	} while (DAT_8032f4c4 == 0);
 
 	return DAT_8032f4c4;


### PR DESCRIPTION
## Summary
- mark `DAT_8032f4c4` as `volatile` in `src/RedSound/RedSound.cpp`
- split `GetAutoID__9CRedSoundFv` counter update into two explicit steps (`+1`, then `& 0x7FFFFFFF`)
- keep function logic unchanged (still loops until non-zero ID)

## Functions Improved
- Unit: `main/RedSound/RedSound`
- Symbol: `GetAutoID__9CRedSoundFv`

## Match Evidence
- `GetAutoID__9CRedSoundFv`: **46.363636% -> 91.818184%**
- Decompiled size alignment: **24b -> 44b** (target symbol size is 44b)
- Instruction diff count (objdiff): **10 -> 7**

## Plausibility Rationale
- This counter behaves like shared mutable state used by multiple audio paths.
- Marking it `volatile` and performing explicit stepwise updates is plausible original source for preserving observable memory access ordering.
- The change does not alter high-level behavior (ID increments, high bit masked, zero skipped), only representation that better matches original codegen.

## Technical Notes
- Verified with:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedSound -o - GetAutoID__9CRedSoundFv`
- No unrelated files changed.
