### PR TITLE
main/memory: implement CAmemCacheSet::GetData

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -86,7 +86,7 @@ public:
     void AmemAlloc(int);
     void AmemPrev();
     void GetFree();
-    void GetData(short, char*, int);
+    int GetData(short, char*, int);
     int SetData(void*, int, CAmemCache::TYPE, int);
     unsigned int IsEnable(short);
     void AddRef(short);


### PR DESCRIPTION
## Summary
- Change `CAmemCacheSet::GetData(short, char*, int)` declaration to return `int` in `include/ffcc/memory.h`.
- Replace the TODO stub in `src/memory.cpp` with a concrete implementation matching the PAL function shape.
- Implement cache-entry resolution loop with low-priority eviction fallback, ARAM alloc path, DMA transfer, and timeout-driven sound driver recovery.

## Functions improved
- Unit: `main/memory`
- Symbol: `GetData__13CAmemCacheSetFsPci`

## Match evidence
- Before: `0.877193%` (`tools/objdiff-cli diff -p . -u main/memory -o - --format json-pretty GetData__13CAmemCacheSetFsPci`)
- After: `24.263159%` (same command after change)
- Absolute gain: `+23.385966` percentage points

## Plausibility rationale
- The implementation follows existing project patterns already used in `SetData` and other cache-management code paths: raw field-offset access, retry-until-allocated behavior, and DMA completion polling with `CStopWatch`.
- The logic is behavior-driven (resolve resident pointer, allocate if needed, transfer, recover on timeout) rather than compiler-coaxing transformations.

## Technical details
- Added PAL metadata block for `GetData` (`0x8001D278`, `456b`).
- Preserved low-level control flow structure from the recovered implementation while expressing it in maintainable C++.
- Kept diagnostics gated by `System.m_execParam`, and reused `Sound.CheckDriver(1)` timeout handling inside DMA poll loop.
