### PR TITLE
RedExecute: implement SetReverb__FiiPi

### DIFF
--- a/include/ffcc/RedSound/RedExecute.h
+++ b/include/ffcc/RedSound/RedExecute.h
@@ -20,7 +20,7 @@ void ReverbAreaFree(void*);
 void InitReverb();
 void _SetReverbData(RedReverbDATA*, int*);
 void _ClearReverb(int);
-void SetReverb(int, int, int*);
+int* SetReverb(int, int, int*);
 
 void EntryVoiceSearch(RedTrackDATA*);
 void _VoiceEnvelopeCheck();


### PR DESCRIPTION
## Summary
- Implemented `SetReverb__FiiPi` in `src/RedSound/RedExecute.cpp` with full effect-kind handling (clear, std, hi, delay, chorus, hi dpl2).
- Updated the function declaration in `include/ffcc/RedSound/RedExecute.h` to return `int*`, matching the observed function behavior of returning the global status/result buffer pointer.
- Added PAL metadata block for `SetReverb` (`0x801c3718`, `1324b`).

## Functions improved
- Unit: `main/RedSound/RedExecute`
- Symbol: `SetReverb__FiiPi`

## Match evidence
- Before (selector output): `0.3%` match
- After (`objdiff-cli`): `37.293053%` match
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedExecute -o - SetReverb__FiiPi`

## Plausibility rationale
- The implementation uses source-plausible logic for effect configuration and aux callback registration rather than compiler-only coercion.
- It relies on existing project abstractions (`RedNew`, `_ClearReverb`, `_SetReverbData`, `AXFX*` APIs) and consistent field semantics already used in nearby reverb code.
- Control flow reflects expected runtime behavior: reusing existing effect instances when `kind` matches, reallocating/reinitializing otherwise.

## Technical details
- Added explicit initialization paths for each reverb kind with typed `AXFX_*` contexts and callback assignment.
- Preserved parameter scaling behavior (`/100.0f`, `/10000.0f`) consistent with existing `_SetReverbData` behavior.
- Registered aux callback on the selected bank only after successful init, otherwise reset status buffer.
- Verified build success with `ninja`.
