### PR TITLE
memory: implement first-pass CMemory::Draw

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -5,6 +5,7 @@
 #include "ffcc/stopwatch.h"
 #include "ffcc/system.h"
 #include <dolphin/gx.h>
+#include <dolphin/mtx.h>
 #include "dolphin/os/OSMemory.h"
 #include <string.h>
 
@@ -18,8 +19,14 @@ extern char DAT_801d6c88[];
 extern char DAT_801d6c98[];
 extern char DAT_801d669c[];
 extern char DAT_801d67d8[];
+extern char DAT_801d6bdc[];
+extern char DAT_801d6bec[];
 extern char DAT_8032f7d4[];
 extern float FLOAT_8032f7d8;
+extern float FLOAT_8032f7dc;
+extern float FLOAT_8032f7fc;
+extern float FLOAT_8032f800;
+extern float FLOAT_8032f804;
 extern char s__4d__4d__4d_801d6800[];
 extern unsigned int DAT_801d64a8;
 extern unsigned int DAT_801d64ac;
@@ -43,6 +50,12 @@ extern "C" int DMAEntry__9CRedSoundFiiiiiPFPv_vPv(
     void*, int, int, int, int, int, void (*)(void*), void*);
 extern "C" int DMACheck__9CRedSoundFi(void*, int);
 extern "C" int __cntlzw(unsigned int);
+extern "C" unsigned char Chara[];
+extern "C" void _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(int, int, int, int);
+extern "C" void _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(int, int, int, int, int);
+extern "C" void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
+extern "C" void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
+extern "C" void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 
 static int calcCacheChecksum(const unsigned char* data, unsigned int size)
 {
@@ -494,12 +507,97 @@ void CMemory::HeapWalker()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001EC94
+ * PAL Size: 764b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemory::Draw()
 {
-	// TODO
+    if (*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x7798) == 0) {
+        return;
+    }
+
+    Mtx orthoMtx;
+    Mtx modelMtx;
+    char line[0x104];
+
+    C_MTXOrtho(orthoMtx, FLOAT_8032f7dc, FLOAT_8032f7fc, FLOAT_8032f7dc, FLOAT_8032f800, FLOAT_8032f7dc,
+               FLOAT_8032f804);
+    GXSetProjection(orthoMtx, GX_ORTHOGRAPHIC);
+    _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 4, 5, 1);
+    GXSetZCompLoc(GX_FALSE);
+    _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(6, 1, 0, 7, 0);
+    GXSetZMode(GX_FALSE, GX_LEQUAL, GX_FALSE);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetNumTevStages(1);
+    GXSetTevDirect(GX_TEVSTAGE0);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
+    GXSetChanCtrl(GX_COLOR1A1, GX_DISABLE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_SPEC);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
+    PSMTXIdentity(modelMtx);
+    GXLoadPosMtxImm(modelMtx, GX_PNMTX0);
+    GXLoadTexMtxImm(modelMtx, GX_IDENTITY, GX_MTX3x4);
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
+    _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);
+
+    for (int pass = 0; pass < 2; pass++) {
+        if (pass == 1) {
+            Graphic.InitDebugString();
+        }
+
+        unsigned char* listHead = reinterpret_cast<unsigned char*>(this) + 4;
+        int y = 0x20;
+        int useTotalKB = 0;
+        int unuseTotalKB = 0;
+
+        for (int mode = 0; mode < 3; mode++) {
+            if (((mode != 1) || (OSGetConsoleSimulatedMemSize() == 0x3000000)) && (mode != 2)) {
+                CMemory::CStage* head = reinterpret_cast<CMemory::CStage*>(listHead);
+                CMemory::CStage* stage = *reinterpret_cast<CMemory::CStage**>(listHead + 4);
+                while (stage != head) {
+                    if (pass == 0) {
+                        stage->drawHeapBar(y);
+                    } else {
+                        stage->drawHeapTitle(y);
+                        if (mode == 0) {
+                            useTotalKB += (*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 0xC) -
+                                           *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 8)) >>
+                                          10;
+                            unuseTotalKB +=
+                                (*reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) +
+                                                                                4) +
+                                                         8) -
+                                 *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 0xC)) >>
+                                10;
+                        }
+                    }
+                    y += 0xC;
+                    stage = *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(stage) + 4);
+                }
+            }
+
+            listHead += 0x27D8;
+        }
+
+        if (pass == 1) {
+            sprintf(line, DAT_801d6bdc, useTotalKB, unuseTotalKB);
+            Graphic.DrawDebugStringDirect(0x10, static_cast<unsigned short>(y), line, 8);
+
+            int amemAnim = *reinterpret_cast<int*>(Chara + 0x2074);
+            int amemAnimKB = (amemAnim >> 10) + ((amemAnim < 0) && ((amemAnim & 0x3FF) != 0));
+            sprintf(line, DAT_801d6bec, amemAnimKB);
+            Graphic.DrawDebugStringDirect(0x10, static_cast<unsigned short>(y + 0xC), line, 8);
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMemory::Draw()` in `src/memory.cpp` as a first-pass decompilation aligned to PAL address `0x8001EC94` (size `764b`).
- Added the required GX wrapper externs/data symbol externs used by the function and filled in the versioned `--INFO--` block.
- Added the necessary `<dolphin/mtx.h>` include for `Mtx`/matrix helpers used by the draw path.

## Functions Improved
- Unit: `main/memory`
- Function: `Draw__7CMemoryFv`
- Prior target selector value: `0.5%` (from `tools/agent_select_target.py` run before edits)
- New score: `87.04712%` (`objdiff-cli diff -p . -u main/memory -o diff_draw.json --format json-pretty Draw__7CMemoryFv`)
- Report fuzzy score for function: `87.256546` (`build/GCCP01/report.json`)

## Match Evidence
- Before: `Draw__7CMemoryFv` was effectively non-matching (`0.5%` selector output).
- After: `objdiff` shows `87.04712%` for `Draw__7CMemoryFv`.
- Unit-level fuzzy for `main/memory` increased from selector baseline `28.6%` to `32.90365%` in the generated report.

## Plausibility Rationale
- The implementation follows the game’s existing rendering/debug style: explicit GX pipeline setup, orthographic projection, stage-list iteration, and debug-string output via `Graphic`.
- Changes are structural decomp work (control flow/types/calls) rather than contrived compiler coaxing.

## Technical Details
- Reconstructed the two-pass draw behavior (heap bar pass + heap title/debug text pass) and the mode-list traversal over stage lists.
- Matched decomp-observed arithmetic for KB rollups and AMEM debug readout (`Chara + 0x2074`) to align output behavior and assembly shape.
- Kept existing field-offset access patterns used throughout `memory.cpp` to stay ABI/layout-consistent with the rest of the file.
