### PR TITLE
mapobj: implement map-hit draw stubs

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -683,32 +683,53 @@ void CMapObj::SetDrawFlag()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80028F70
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapObj::DrawHit()
 {
-	// TODO
+    if ((U8At(this, 0x1D) == 2) && (PtrAt(this, 0xC) != 0)) {
+        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        reinterpret_cast<CMapHit*>(PtrAt(this, 0xC))->Draw();
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80028F08
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapObj::DrawHitWire()
 {
-	// TODO
+    if ((U8At(this, 0x1D) == 2) && (PtrAt(this, 0xC) != 0)) {
+        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        reinterpret_cast<CMapHit*>(PtrAt(this, 0xC))->DrawWire();
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80028EA0
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMapObj::DrawHitNormal()
 {
-	// TODO
+    if ((U8At(this, 0x1D) == 2) && (PtrAt(this, 0xC) != 0)) {
+        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        reinterpret_cast<CMapHit*>(PtrAt(this, 0xC))->DrawNormal();
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three previously-stubbed `CMapObj` map-hit rendering helpers in `src/mapobj.cpp` and filled PAL metadata headers:
- `DrawHit__7CMapObjFv`
- `DrawHitWire__7CMapObjFv`
- `DrawHitNormal__7CMapObjFv`

Each now performs the expected runtime guard (`type == 2` and hit pointer non-null), sets object matrix through `MaterialMan`, and dispatches to the corresponding `CMapHit` draw routine.

## Functions Improved
Unit: `main/mapobj`
- `DrawHit__7CMapObjFv`: `3.8461537% -> 85.19231%`
- `DrawHitWire__7CMapObjFv`: `3.8461537% -> 85.19231%`
- `DrawHitNormal__7CMapObjFv`: `3.8461537% -> 85.19231%`

## Match Evidence
Measured with `objdiff-cli` oneshot JSON mode (`diff -p . -u main/mapobj ... <symbol>`) against baseline `main` build and this branch build.

All three functions moved from minimal stub output to near-match bodies with matching control-flow shape and call graph:
1. conditional type/null checks
2. `CMaterialMan::SetObjMatrix`
3. matching `CMapHit` draw call (`Draw`, `DrawWire`, `DrawNormal`)

## Plausibility Rationale
These changes replace placeholder TODO stubs with straightforward engine-idiomatic code that matches the expected responsibilities of the functions and existing `mapobj` rendering patterns (matrix setup + delegated draw call). The resulting code is readable and source-plausible rather than compiler-coaxed.

## Technical Details
- Added PAL address/size metadata blocks for all three functions from the Ghidra export.
- Verified project still builds with `ninja`.
- Verified match improvements with per-symbol objdiff JSON extraction.
