### PR TITLE
RedDriver: implement SetSeBlockData command path

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1348,12 +1348,33 @@ void CRedDriver::SetMusicPhraseStop(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bf0c4
+ * PAL Size: 168b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::SetSeBlockData(int, void*)
+void CRedDriver::SetSeBlockData(int bank, void* blockData)
 {
-	// TODO
+    void* copiedHeader;
+    int headerSize;
+
+    if (blockData == 0) {
+        copiedHeader = 0;
+    } else {
+        headerSize = *(int*)((char*)blockData + 0xc);
+        if (headerSize < 1) {
+            copiedHeader = 0;
+        } else {
+            copiedHeader = RedNew__Fi(headerSize);
+            if (copiedHeader != 0) {
+                memcpy(copiedHeader, blockData, headerSize);
+            }
+        }
+    }
+
+    _EntryExecCommand(_SetSeBlockData, bank, (int)copiedHeader, 0, 0, 0, 0, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
- implemented `CRedDriver::SetSeBlockData(int, void*)` using the RedSound command-queue flow
- added PAL metadata for the function (`0x801bf0c4`, `168b`)
- replaced TODO stub with source-plausible logic:
  - validate incoming header pointer
  - read header size at offset `0xC`
  - allocate copy via `RedNew__Fi`
  - copy with `memcpy`
  - enqueue `_SetSeBlockData` through `_EntryExecCommand`

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `SetSeBlockData__10CRedDriverFiPv` (168 bytes)

## Match evidence
- Before: `2.3809524%`
- After: `51.214287%`
- Improvement: `+48.8333346` percentage points

## Plausibility rationale
- This matches the expected RedDriver pattern used across the file: front-end API methods clone input payloads then dispatch to worker-side command handlers.
- The implementation uses existing engine alloc/copy/queue helpers (`RedNew__Fi`, `memcpy`, `_EntryExecCommand`) and avoids compiler-coaxing constructs.

## Technical notes
- The command payload is passed as integer argument slot 2 in `_EntryExecCommand`, consistent with other command wrappers in `RedDriver.cpp`.
- Null/invalid-size headers are normalized to `0`, still dispatching command for consistent state updates in the worker thread.
