### PR TITLE
Improve pppFrameYmTraceMove register/layout match

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -56,6 +56,7 @@ void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
  */
 void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* param_3)
 {
+	u8* pppMngSt;
 	u8* owner;
 	Vec* dest;
 	Vec local_128;
@@ -85,8 +86,9 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 		return;
 	}
 
+	pppMngSt = (u8*)pppMngStPtr;
 	dest = (Vec*)((u8*)pppYmTraceMove + 0x80 + *param_3->m_serializedDataOffsets);
-	owner = *(u8**)((u8*)pppMngStPtr + 0xdc);
+	owner = *(u8**)(pppMngSt + 0xdc);
 
 	dest[2].z = dest[2].z + dest[3].x;
 	dest[2].y = dest[2].y + dest[2].z;
@@ -112,9 +114,9 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 		local_74.y = *(f32*)(owner + 0x160);
 		local_74.z = *(f32*)(owner + 0x164);
 
-		local_68.x = *(f32*)((u8*)pppMngStPtr + 0x8);
-		local_68.y = *(f32*)((u8*)pppMngStPtr + 0xc);
-		local_68.z = *(f32*)((u8*)pppMngStPtr + 0x10);
+		local_68.x = *(f32*)(pppMngSt + 0x8);
+		local_68.y = *(f32*)(pppMngSt + 0xc);
+		local_68.z = *(f32*)(pppMngSt + 0x10);
 		pppSubVector__FR3Vec3Vec3Vec(&local_20, &local_74, &local_68);
 
 		local_20.y = local_20.y + param_2->m_payload;
@@ -128,12 +130,12 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 		local_50.z = local_20.z;
 		pppCopyVector__FR3Vec3Vec(dest, &local_50);
 
-		local_44.x = *(f32*)((u8*)pppMngStPtr + 0x48);
-		local_44.y = *(f32*)((u8*)pppMngStPtr + 0x4c);
-		local_44.z = *(f32*)((u8*)pppMngStPtr + 0x50);
-		local_38.x = *(f32*)((u8*)pppMngStPtr + 0x8);
-		local_38.y = *(f32*)((u8*)pppMngStPtr + 0xc);
-		local_38.z = *(f32*)((u8*)pppMngStPtr + 0x10);
+		local_44.x = *(f32*)(pppMngSt + 0x48);
+		local_44.y = *(f32*)(pppMngSt + 0x4c);
+		local_44.z = *(f32*)(pppMngSt + 0x50);
+		local_38.x = *(f32*)(pppMngSt + 0x8);
+		local_38.y = *(f32*)(pppMngSt + 0xc);
+		local_38.z = *(f32*)(pppMngSt + 0x10);
 		pppSubVector__FR3Vec3Vec3Vec(&local_2c, &local_38, &local_44);
 
 		if ((local_2c.x == 0.0f) && (local_2c.y == 0.0f) && (local_2c.z == 0.0f)) {
@@ -163,27 +165,27 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkB* param_2, UnkC* pa
 	local_8c.x = local_9c.x;
 	local_8c.y = local_9c.y;
 	local_8c.z = local_9c.z;
-	PSVECScale(&local_8c, &local_8c, dest[2].y * *(f32*)((u8*)pppMngStPtr + 0x24));
+	PSVECScale(&local_8c, &local_8c, dest[2].y * *(f32*)(pppMngSt + 0x24));
 
-	local_110.x = *(f32*)((u8*)pppMngStPtr + 0x8);
-	local_110.y = *(f32*)((u8*)pppMngStPtr + 0xc);
-	local_110.z = *(f32*)((u8*)pppMngStPtr + 0x10);
+	local_110.x = *(f32*)(pppMngSt + 0x8);
+	local_110.y = *(f32*)(pppMngSt + 0xc);
+	local_110.z = *(f32*)(pppMngSt + 0x10);
 	local_104.x = local_8c.x;
 	local_104.y = local_8c.y;
 	local_104.z = local_8c.z;
 	pppAddVector__FR3Vec3Vec3Vec(&local_ec, &local_104, &local_110);
 
-	local_11c.x = *(f32*)((u8*)pppMngStPtr + 0x8);
-	local_11c.y = *(f32*)((u8*)pppMngStPtr + 0xc);
-	local_11c.z = *(f32*)((u8*)pppMngStPtr + 0x10);
-	pppCopyVector__FR3Vec3Vec((Vec*)((u8*)pppMngStPtr + 0x48), &local_11c);
+	local_11c.x = *(f32*)(pppMngSt + 0x8);
+	local_11c.y = *(f32*)(pppMngSt + 0xc);
+	local_11c.z = *(f32*)(pppMngSt + 0x10);
+	pppCopyVector__FR3Vec3Vec((Vec*)(pppMngSt + 0x48), &local_11c);
 
 	local_128.x = local_ec.x;
 	local_128.y = local_ec.y;
 	local_128.z = local_ec.z;
-	pppCopyVector__FR3Vec3Vec((Vec*)((u8*)pppMngStPtr + 0x8), &local_128);
+	pppCopyVector__FR3Vec3Vec((Vec*)(pppMngSt + 0x8), &local_128);
 
-	pppMngStPtr->m_matrix.value[0][3] = local_ec.x;
-	pppMngStPtr->m_matrix.value[1][3] = local_ec.y;
-	pppMngStPtr->m_matrix.value[2][3] = local_ec.z;
+	((_pppMngSt*)pppMngSt)->m_matrix.value[0][3] = local_ec.x;
+	((_pppMngSt*)pppMngSt)->m_matrix.value[1][3] = local_ec.y;
+	((_pppMngSt*)pppMngSt)->m_matrix.value[2][3] = local_ec.z;
 }


### PR DESCRIPTION
## Summary
- Refactored `pppFrameYmTraceMove` to cache `pppMngStPtr` as a single local base pointer.
- Replaced repeated `(u8*)pppMngStPtr + <offset>` expressions with accesses through the cached pointer.
- Kept behavior unchanged; this is a data-access/layout refactor aimed at codegen alignment.

## Functions improved
- Unit: `main/pppYmTraceMove`
- Symbol: `pppFrameYmTraceMove`

## Match evidence
- `pppFrameYmTraceMove`: **66.36752% -> 68.82051%** (+2.45299)
- `pppConstructYmTraceMove`: 64.48837% (unchanged)
- Diff profile for `pppFrameYmTraceMove` improved:
  - `MATCH`: 34 -> 62
  - `DIFF_ARG_MISMATCH`: 110 -> 81
  - `DIFF_INSERT`: 14 -> 9

## Plausibility rationale
- Caching a frequently used manager pointer at function scope is a natural source-level pattern in this codebase.
- The change improves locality/readability of repeated field access without introducing contrived control flow or artificial temporaries.
- No debug artifacts or non-source-plausible compiler coaxing were introduced.

## Technical details
- Build verified with `ninja`.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmTraceMove -o - pppFrameYmTraceMove`
