### PR TITLE
map: implement CMapMng::DrawBefore

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -33,6 +33,8 @@ extern "C" float lbl_8032F99C;
 extern "C" int CheckHitCylinder__8COctTreeFP12CMapCylinderP3VecUl(void*, CMapCylinder*, Vec*, unsigned long);
 extern "C" int CheckHitCylinderNear__8COctTreeFP12CMapCylinderP3VecUl(void*, CMapCylinder*, Vec*, unsigned long);
 extern "C" void SetDrawFlag__8COctTreeFv(void*);
+extern "C" void Draw__8COctTreeFUc(void*, unsigned char);
+extern "C" void Draw__7CMapObjFUc(void*, unsigned char);
 extern "C" void Calc__11CMapAnimRunFl(CMapAnimRun*, long);
 extern "C" void* lbl_801E89A8[];
 extern "C" void* lbl_801E899C[];
@@ -42,6 +44,7 @@ extern "C" void* lbl_801E8978[];
 extern int DAT_8032ec78;
 extern float FLOAT_8032ec80;
 extern unsigned char DAT_8032ec88;
+extern unsigned char DAT_8032ecb8;
 extern float FLOAT_8032f9a0;
 extern float FLOAT_8032f9a4;
 extern float FLOAT_8032f9a8;
@@ -1693,7 +1696,27 @@ void setDbgLight(int, Vec&, _GXColor&)
  */
 void CMapMng::DrawBefore()
 {
-	// TODO
+    if ((*reinterpret_cast<short*>(Ptr(this, 0xC)) != 0) && (*reinterpret_cast<unsigned char*>(Ptr(this, 0x2298B)) != 0)) {
+        GXSetColorUpdate(1);
+        GXSetAlphaUpdate(0);
+        GXSetCullMode(GX_CULL_BACK);
+        GXSetZMode(1, GX_LEQUAL, 1);
+        LightPcs.SetNumDiffuse(0);
+
+        if ((DAT_8032ecb8 & 8) == 0) {
+            unsigned char* mapObj = Ptr(&MapMng, 0x954);
+            for (int i = 0; i < *reinterpret_cast<short*>(Ptr(this, 0xC)); i++) {
+                Draw__7CMapObjFUc(mapObj, 0xFE);
+                mapObj += 0xF0;
+            }
+
+            unsigned char* octTree = Ptr(this, 0x14);
+            for (int i = 0; i < *reinterpret_cast<short*>(Ptr(this, 0x8)); i++) {
+                Draw__8COctTreeFUc(octTree, 0xFF);
+                octTree += 0x38;
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implements `CMapMng::DrawBefore()` in `src/map.cpp` using the existing offset-based style in this translation unit.

Changes:
- Added missing extern declarations for `Draw__8COctTreeFUc`, `Draw__7CMapObjFUc`, and `DAT_8032ecb8`
- Replaced TODO body of `CMapMng::DrawBefore()` with a concrete implementation that:
  - Validates map draw enable/object count state
  - Sets GX draw state and diffuse light count
  - Draws map objects with flag `0xFE`
  - Draws octree nodes with flag `0xFF`

## Functions improved
Unit: `main/map`
- `DrawBefore__7CMapMngFv` (size 244b): **1.6393442% -> 85.18033%**

## Match evidence
- Unit `main/map` fuzzy match: **27.870115% -> 28.817282%**
- Unit `main/map` matched code: **5.770489% -> 5.852137%**
- Verified by:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/map -o - DrawBefore__7CMapMngFv`

## Plausibility rationale
This change is source-plausible and aligns with existing project patterns:
- Uses established map object/octetree memory layout offsets already used throughout `src/map.cpp`
- Uses existing game-engine draw flow and GX state setup conventions
- Avoids compiler-coaxing constructs; implementation directly represents expected engine behavior

## Technical notes
- The new loop structure and draw-flag constants align closely with the target function behavior from objdiff/Ghidra guidance.
- Kept scope intentionally narrow (single function) to isolate and verify real assembly improvement.
