### PR TITLE
p_menu: decompile GetTable and correct signature

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -58,7 +58,7 @@ public:
 
     void Init();
     void Quit();
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void create();
     void destroy();

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -4,6 +4,7 @@
 #include <dolphin/mtx.h>
 
 extern CTextureMan TextureMan;
+extern unsigned char lbl_8020ee40[];
 
 /*
  * --INFO--
@@ -47,12 +48,18 @@ void CMenuPcs::Quit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80097490
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetTable(unsigned long)
+int CMenuPcs::GetTable(unsigned long index)
 {
-	// TODO
+    unsigned char* table = lbl_8020ee40;
+    unsigned long offset = index * 0x15c;
+    return (int)(table + offset);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::GetTable(unsigned long)` in `src/p_menu.cpp` using the project-standard table-offset pattern.
- Corrected the declaration in `include/ffcc/p_menu.h` from `void` to `int` to match actual usage/ABI behavior.
- Added PAL function metadata block for the updated function.

## Functions improved
- Unit: `main/p_menu`
- Symbol: `GetTable__8CMenuPcsFUl`

## Match evidence
- `GetTable__8CMenuPcsFUl`: **20.0% -> 97.0%** (objdiff-cli oneshot JSON)
- Unit-level progress moved from selector baseline **2/30** matched functions (13.9% fuzzy) to **3/30** matched functions (`build/GCCP01/report.json` now shows 14.008715% fuzzy).

## Plausibility rationale
- The new implementation follows the same idiom used in other process classes (`CGraphicPcs`, `CSystemPcs`, `CGamePcs`): return base table pointer + `index * 0x15c`.
- The return-type correction is consistent with this pattern and replaces a placeholder TODO implementation with plausible source-level behavior.

## Technical details
- Uses external table symbol `lbl_8020ee40` and computes offset via a local `unsigned long offset = index * 0x15c;`.
- Keeps the implementation minimal and readable while aligning generated code closely with original output.
