### PR TITLE
goout: extend CalcGoOut mode handling for card transfer flow

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -575,6 +575,7 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
  */
 void CGoOutMenu::CalcGoOut()
 {
+    McCtrl& mcCtrl = *reinterpret_cast<McCtrl*>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0x20);
     unsigned short input;
     unsigned char next;
 
@@ -702,6 +703,44 @@ void CGoOutMenu::CalcGoOut()
             Sound.PlaySe(2, 0x40, 0x7f, 0);
             SetGoOutMode(8);
         }
+        break;
+    case 8:
+        if (mcCtrl.ChkConnect(0) == -1) {
+            return;
+        }
+        field_0x30 = 0;
+        SetGoOutMode(9);
+        break;
+    case 9:
+        if (field_0x30 < 0x14) {
+            return;
+        }
+        if (mcCtrl.ChkConnect(0) == -3) {
+            SetMenuStr(0, 2, "No Memory Card found in", "Slot A.");
+            field_0x19 = -1;
+            SetGoOutMode(0);
+            return;
+        }
+        SetGoOutMode(0xC);
+        break;
+    case 10:
+        if (mcCtrl.ChkConnect(1) == -1) {
+            return;
+        }
+        field_0x30 = 0;
+        SetGoOutMode(0xB);
+        break;
+    case 0xB:
+        if (field_0x30 < 0x14) {
+            return;
+        }
+        if (mcCtrl.ChkConnect(1) == -3) {
+            SetMenuStr(0, 2, "No Memory Card found in", "Slot B.");
+            field_0x19 = -1;
+            SetGoOutMode(0);
+            return;
+        }
+        SetGoOutMode(0xE);
         break;
     default:
         break;


### PR DESCRIPTION
## Summary
- Extended `CGoOutMenu::CalcGoOut()` with explicit handling for go-out submodes `8`, `9`, `10`, and `0xB`.
- Added the local `McCtrl` view (via existing `MenuPcs` layout reinterpret pattern already used in this file) so card-slot checks compile in this function.
- Implemented mode transitions for card reconnect wait loops and slot-specific missing-card fallback text/state resets.

## Functions Improved
- Unit: `main/goout`
- Symbol: `CalcGoOut__10CGoOutMenuFv`
  - Before: `16.309858%`
  - After: `19.163893%`

## Match Evidence
- Objdiff command:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/goout -o - CalcGoOut__10CGoOutMenuFv`
- Result:
  - `CalcGoOut__10CGoOutMenuFv 16.309858 -> 19.163893`
- Build verification:
  - `ninja` passes and regenerates report successfully.

## Plausibility Rationale
- These branches correspond to naturally expected menu-state behavior for memory-card polling and timeout/slot validation in a transfer flow.
- The implementation follows existing `goout.cpp` style and existing state-machine conventions (`field_0x30` frame wait, `SetGoOutMode`, early returns for async card checks).
- No compiler-coaxing artifacts were introduced (no contrived temp scaffolding or opaque reorder-only edits).

## Technical Details
- Added mode `8`/`10` connect-check gates that wait for non-`-1` results before advancing.
- Added mode `9`/`0xB` delayed checks (`field_0x30 < 0x14`) and slot-specific no-card fallback messaging before returning to mode `0`.
- Maintained existing convention of `field_0x19 = -1` when returning to base go-out mode after card errors.
