### PR TITLE
pppYmMoveParabola: improve frame match via explicit unsigned index conversion

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -18,6 +18,7 @@ void pppCopyVector__FR3Vec3Vec(Vec*, const Vec*);
 void pppAddVector__FR3Vec3Vec3Vec(Vec*, const Vec*, const Vec*);
 void pppNormalize__FR3Vec3Vec(float*, Vec*);
 void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
+unsigned int __cvt_fp2unsigned(double);
 }
 
 /*
@@ -116,7 +117,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
         pppNormalize__FR3Vec3Vec((float*)&direction, &tempDir);
         
         // Trigonometric parabolic motion calculations
-        u32 sinIndex = (u32)((FLOAT_80330e20 * (f32)stepData->m_dataValIndex) / FLOAT_80330e24);
+        u32 sinIndex = __cvt_fp2unsigned((double)((FLOAT_80330e20 * (f32)stepData->m_dataValIndex) / FLOAT_80330e24));
         
         f32 baseValue = *pfVar;
         f32 horizontalScale = (f32)(frameCount * (double)(baseValue * *(f32*)((int)ppvSinTbl + ((sinIndex + 0x4000) & 0xfffc))));


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmMoveParabola` in `src/pppYmMoveParabola.cpp` to use the runtime float-to-unsigned conversion helper for sine table indexing.
- Added the extern declaration for `__cvt_fp2unsigned(double)` and replaced the direct C cast with `__cvt_fp2unsigned(...)`.

## Functions Improved
- Unit: `main/pppYmMoveParabola`
- Symbol: `pppFrameYmMoveParabola`
- Related symbol in same unit: `pppConstructYmMoveParabola`

## Match Evidence
Objdiff command used:
- `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o - <symbol>`

Before:
- `pppFrameYmMoveParabola`: **46.326088%**
- `pppConstructYmMoveParabola`: **58.164383%**

After:
- `pppFrameYmMoveParabola`: **55.233696%**
- `pppConstructYmMoveParabola`: **62.410957%**

## Plausibility Rationale
- The change is source-plausible and idiomatic for this codebase: several existing files already call `__cvt_fp2unsigned` when converting floating-point expressions to unsigned indices.
- It avoids contrived control-flow or temporary-variable coercion and directly models an explicit numeric-conversion intent likely present in original Metrowerks-era source.

## Technical Notes
- Objdiff for `pppFrameYmMoveParabola` showed target-side use of conversion-helper-style codegen around the sine index path.
- Switching just that conversion path improved instruction alignment meaningfully without broad restructuring of function logic.
