### PR TITLE
Improve match for pppVertexApAt in main/pppVertexApAt

### DIFF
--- a/src/pppVertexApAt.cpp
+++ b/src/pppVertexApAt.cpp
@@ -43,7 +43,7 @@ struct VertexApAtState
 
 struct _pppPDataVal;
 
-extern CMath math;
+extern CMath math[];
 extern int lbl_8032ED70;
 extern unsigned char* lbl_8032ED50;
 extern VertexApAtEnv* lbl_8032ED54;
@@ -111,7 +111,7 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
 
         switch (vtxData->mode) {
         case 0:
-            while (count-- != 0) {
+            do {
                 if (state->index >= (u16)entry->maxValue) {
                     state->index = 0;
                 }
@@ -119,8 +119,8 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
                 u16 outValue = state->index;
                 state->index++;
 
-                s32 childId = vtxData->childId;
-                if ((u16)childId != 0xFFFF) {
+                u16 childId = (u16)vtxData->childId;
+                if (childId != 0xFFFF) {
                     _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
                     _pppPObject* child;
 
@@ -133,14 +133,14 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
 
                     *(u16*)((u8*)child + vtxData->childValueOffset + 0x80) = outValue;
                 }
-            }
+            } while (count-- != 0);
             break;
         case 1:
-            while (count-- != 0) {
-                u16 outValue = (u16)(RandF__5CMathFv(&math) * (f32)entry->maxValue);
-                s32 childId = vtxData->childId;
+            do {
+                u16 outValue = (u16)(RandF__5CMathFv(math) * (f32)entry->maxValue);
+                u16 childId = (u16)vtxData->childId;
 
-                if ((u16)childId != 0xFFFF) {
+                if (childId != 0xFFFF) {
                     _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
                     _pppPObject* child;
 
@@ -153,7 +153,7 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
 
                     *(u16*)((u8*)child + vtxData->childValueOffset + 0x80) = outValue;
                 }
-            }
+            } while (count-- != 0);
             break;
         }
 


### PR DESCRIPTION
## Summary
- Adjusted `pppVertexApAt` control flow and typing to better match expected codegen while keeping source-plausible particle-spawn behavior.
- Switched `math` declaration to array form and passed `math` directly to `RandF__5CMathFv`, matching common patterns in related `ppp*` units.
- Updated both spawn branches to `do { ... } while (count-- != 0)` and narrowed child id handling to explicit 16-bit comparison semantics.

## Functions Improved
- Unit: `main/pppVertexApAt`
- Function: `pppVertexApAt`
- Size: `448` bytes (unchanged)

## Match Evidence
- `pppVertexApAt` match: **88.125% -> 89.77679%** (`+1.65179`)
- One-shot objdiff mismatch count (`diff_kind != null`): **49 -> 28**
- Command used:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppVertexApAt -o /tmp/pppVertexApAt_{before,after}.json --format json pppVertexApAt`

## Plausibility Rationale
- The revised loop structure and child-id narrowing are consistent with existing `pppVertexAp`-family source patterns in this repository.
- Changes improve generated assembly without introducing contrived temporaries or non-idiomatic control flow.
- Behavior remains aligned with expected particle spawning logic and data-driven child creation.

## Technical Notes
- Iteration on unrelated float-heavy target (`pppFrameConstrainCameraDir2`) was discarded due regression and not included.
- Final diff is intentionally limited to `src/pppVertexApAt.cpp` for a clean, reviewable improvement.
