### PR TITLE
Improve pppRandHCV match via delta-based HCV interpolation

### DIFF
--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -53,6 +53,7 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
     u8* base = (u8*)p1;
     RandHCVParams* params = (RandHCVParams*)p2;
     RandHCVCtx* ctx = (RandHCVCtx*)p3;
+    int outputOffset;
     float* randomValue;
 
     if (lbl_8032ED70 != 0) {
@@ -67,13 +68,15 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
             value *= lbl_8032FF98;
         }
 
-        randomValue = (float*)(base + *ctx->outputOffset + 0x80);
+        outputOffset = *ctx->outputOffset;
+        randomValue = (float*)(base + outputOffset + 0x80);
         *randomValue = value;
     } else if (params->index != *(int*)(base + 0xC)) {
         return;
     }
 
-    randomValue = (float*)(base + *ctx->outputOffset + 0x80);
+    outputOffset = *ctx->outputOffset;
+    randomValue = (float*)(base + outputOffset + 0x80);
 
     s16* target;
     if (params->colorOffset == -1) {
@@ -85,27 +88,27 @@ void pppRandHCV(void* p1, void* p2, void* p3) {
     float scale = *randomValue;
 
     {
+        s16 delta = params->delta[0];
         s16 current = target[0];
-        s16 base = params->delta[0];
-        target[0] = (s16)(current + (int)((float)base * scale - (float)current));
+        target[0] = (s16)(current + (int)((float)delta * scale - (float)delta));
     }
 
     {
+        s16 delta = params->delta[1];
         s16 current = target[1];
-        s16 base = params->delta[1];
-        target[1] = (s16)(current + (int)((float)base * scale - (float)current));
+        target[1] = (s16)(current + (int)((float)delta * scale - (float)delta));
     }
 
     {
+        s16 delta = params->delta[2];
         s16 current = target[2];
-        s16 base = params->delta[2];
-        target[2] = (s16)(current + (int)((float)base * scale - (float)current));
+        target[2] = (s16)(current + (int)((float)delta * scale - (float)delta));
     }
 
     {
+        s16 delta = params->delta[3];
         s16 current = target[3];
-        s16 base = params->delta[3];
-        target[3] = (s16)(current + (int)((float)base * scale - (float)current));
+        target[3] = (s16)(current + (int)((float)delta * scale - (float)delta));
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated `src/pppRandHCV.cpp` to better match original codegen by staging the output offset in a local and reordering per-channel interpolation inputs.
- Adjusted per-channel update math to use the delta term on both sides of the interpolation expression (`delta * scale - delta`), matching the established sibling pattern.

## Functions improved
- Unit: `main/pppRandHCV`
- Symbol: `pppRandHCV`
- `.text` match: **85.541985% -> 93.99236%** (+8.450375)

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/pppRandHCV -o - pppRandHCV`
- Instruction diff counts improved from:
  - `DIFF_ARG_MISMATCH`: 47 -> 29
  - `DIFF_DELETE`: 4 -> 3
  - `DIFF_INSERT`: 7 -> 2
  - `DIFF_REPLACE`: 8 -> 2

## Plausibility rationale
- This change aligns `pppRandHCV` with the same source-level behavior/style already used in adjacent particle randomization code (`pppSRandHCV`): apply a shared random scalar and add per-channel delta adjustments.
- The resulting code is straightforward gameplay/FX logic, not compiler-specific coercion.

## Technical details
- Kept control flow structure intact (`index` gate, early return, callback work path).
- Reduced pointer-expression volatility by introducing `outputOffset` local and reusing a concrete `randomValue` pointer.
- Reordered channel update locals to better align load/use order with target assembly while preserving readable C/C++ source.
