### PR TITLE
exi: improve SetExiInterruptMask match

### DIFF
--- a/src/exi/EXIBios.c
+++ b/src/exi/EXIBios.c
@@ -39,7 +39,8 @@ static int __EXIProbe(s32 chan);
 
 static void SetExiInterruptMask(s32 chan, EXIControl* exi) {
     EXIControl* exi2;
-    exi2 = &Ecb[2];
+    exi2 = Ecb;
+    exi2 += 2;
 
     switch (chan) {
     case 0:


### PR DESCRIPTION
## Summary
Adjust `SetExiInterruptMask` local initialization to use base-pointer plus increment form for `Ecb[2]`.

- Changed:
  - `exi2 = &Ecb[2];`
  - to:
    - `exi2 = Ecb;`
    - `exi2 += 2;`

This preserves behavior and keeps source style plausible while changing codegen shape.

## Functions improved
- Unit: `main/exi/EXIBios`
- Function: `SetExiInterruptMask`
  - Before: `89.91803%`
  - After:  `90.72131%`

## Match evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/exi/EXIBios -o - SetExiInterruptMask`
- Unit `.text` match moved:
  - Before: `68.60846%`
  - After:  `68.63807%`

## Assembly analysis
Objdiff indicates improved alignment around `Ecb[2]` address computation and subsequent load path in `SetExiInterruptMask`, reducing addressing/relocation mismatches while preserving branch structure and call behavior.

## Plausibility rationale
The update is source-plausible C (equivalent pointer arithmetic) and avoids contrived compiler-only tricks. It reflects a reasonable original coding style variation with identical runtime semantics.
