### PR TITLE
file: improve CheckQueue status branch shape

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -468,7 +468,7 @@ CFile::CHandle* CFile::CheckQueue()
         {
             int dvdStatus = DVDGetCommandBlockStatus(&handle->m_dvdFileInfo.cb);
 
-            if (dvdStatus == 0x0B || (dvdStatus >= 4 && dvdStatus <= 6) || dvdStatus == -1)
+            if (dvdStatus == 0x0B || ((u32)(dvdStatus - 4) <= 2U) || dvdStatus == -1)
             {
                 DrawError(handle->m_dvdFileInfo, dvdStatus);
             }


### PR DESCRIPTION
## Summary
- Refined the `dvdStatus` error-range condition in `CFile::CheckQueue` to an unsigned range form that better matches Metrowerks branch generation.
- Kept behavior equivalent: the error path still triggers for status `0x0B`, `4..6`, and `-1`.

## Functions improved
- Unit: `main/file`
- Symbol: `CheckQueue__5CFileFv`

## Match evidence
- `CheckQueue__5CFileFv`: **71.19162% -> 76.58084%** (`+5.38922`)
- Target size remained `668b`.
- Objdiff commands used:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/file -o /tmp/diff_checkqueue_before.json --format json-pretty CheckQueue__5CFileFv`
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/file -o /tmp/diff_checkqueue_after.json --format json-pretty CheckQueue__5CFileFv`

## Plausibility rationale
- This is a type/range-expression refinement, not contrived reordering or artificial temporaries.
- The resulting code remains idiomatic and readable while aligning with the compiler's likely unsigned compare lowering.

## Technical details
- Changed:
  - `dvdStatus >= 4 && dvdStatus <= 6`
  - to `((u32)(dvdStatus - 4) <= 2U)`
- This preserves semantics and improved assembly alignment in objdiff for `CheckQueue__5CFileFv`.
