### PR TITLE
maphit: improve CheckHitCylinder face-range iteration

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -556,32 +556,33 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
  */
 int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned short startFace, unsigned short faceCount, unsigned long mask)
 {
-    (void)position;
-
-    const unsigned int start = static_cast<unsigned int>(startFace);
-    const unsigned int end = start + static_cast<unsigned int>(faceCount);
-    if (start >= static_cast<unsigned int>(m_faceCount)) {
-        return 0;
-    }
-
     g_hit_cyl = *mapCylinder;
-    s_hit_t_min = s_large_pos;
-    s_hit_face_min = 0;
-    s_hit_edge_index = -1;
+    g_hit_mvec = *position;
 
+    unsigned int faceIndex = static_cast<unsigned short>(startFace);
+    unsigned int endFace = static_cast<unsigned short>(startFace + faceCount);
+    int faceOffset = static_cast<int>(faceIndex) * 0x50;
     CMapHitFace* savedFaces = m_faces;
     const unsigned short savedFaceCount = m_faceCount;
-    m_faces = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, start * 0x98));
-    if (end >= static_cast<unsigned int>(savedFaceCount)) {
-        m_faceCount = static_cast<unsigned short>(savedFaceCount - start);
-    } else {
-        m_faceCount = static_cast<unsigned short>(faceCount);
+
+    while (faceIndex < endFace) {
+        m_faces = reinterpret_cast<CMapHitFace*>(Ptr(savedFaces, faceOffset));
+        s_hit_t_min = s_large_pos;
+        m_faceCount = 1;
+
+        if (CheckHitFaceCylinder(mask) != 0) {
+            m_faces = savedFaces;
+            m_faceCount = savedFaceCount;
+            return 1;
+        }
+
+        faceOffset += 0x50;
+        faceIndex++;
     }
 
-    const int hit = CheckHitFaceCylinder(mask);
     m_faces = savedFaces;
     m_faceCount = savedFaceCount;
-    return hit;
+    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
Reworked `CMapHit::CheckHitCylinder(CMapCylinder*, Vec*, unsigned short, unsigned short, unsigned long)` to follow the face-by-face range iteration pattern seen in target code.

## Functions improved
- `main/maphit`
  - `CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUsUsUl`

## Match evidence
- Before: **9.51282%** (`build/GCCP01/report.json` prior run)
- After: **25.705128%** (`objdiff report generate` after change)
- Symbol diff (`build/tools/objdiff-cli diff -p . -u main/maphit -o - CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUsUsUl`): `match_percent=24.884615`

## Technical details
- Removed the single-range slice + one-call path.
- Now copies `g_hit_mvec`, iterates from `startFace` to `startFace + faceCount` with `0x50`-byte face stepping, resets `s_hit_t_min` per face, and early-returns on first hit.
- Preserves and restores `m_faces`/`m_faceCount` around temporary per-face checks.

## Plausibility rationale
This changes collision traversal behavior in source-plausible ways (face iteration order and per-face collision test setup) rather than synthetic compiler coaxing, and aligns the function with existing nearby collision helper patterns.
