### PR TITLE
materialman: add static init + CPtrArray<CMaterial*> deleting dtor

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -12,6 +12,7 @@ extern "C" unsigned long UnkMaterialSetGetter(void*);
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void __dla__FPv(void*);
 extern "C" void __dl__FPv(void*);
+extern "C" void __ct__6CColorFv(void*);
 extern "C" void __ct__4CRefFv(void*);
 extern "C" void __dt__4CRefFv(void*, int);
 extern "C" void __ct__10CTexScrollFv(void*);
@@ -38,6 +39,7 @@ extern "C" void ReadFrame__12CMapKeyFrameFR10CChunkFilei(CMapKeyFrame*, CChunkFi
 extern "C" void ReadKey__12CMapKeyFrameFR10CChunkFilei(CMapKeyFrame*, CChunkFile*, int);
 extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void* __vt__9CMaterial[];
+extern "C" void* PTR_PTR_s_CMaterialMan_801e9bec;
 extern "C" void* PTR_PTR_s_CMaterialSet_801e9bbc;
 extern CMemory Memory;
 extern CTextureMan TextureMan;
@@ -49,6 +51,21 @@ extern float FLOAT_8032faf4;
 extern float FLOAT_8032faf8;
 extern float FLOAT_8032fafc;
 static const char s_materialStageName[] = "material";
+
+/*
+ * --INFO--
+ * PAL Address: 0x80043ccc
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_materialman_cpp(void)
+{
+    *reinterpret_cast<void**>(MaterialMan) = &PTR_PTR_s_CMaterialMan_801e9bec;
+    __ct__6CColorFv(reinterpret_cast<void*>(0x80268E83));
+}
 
 class CMapKeyFrame
 {
@@ -208,6 +225,27 @@ CPtrArray<CMaterial*>::~CPtrArray()
 {
     m_vtable = reinterpret_cast<void**>(0x801E9BFC);
     RemoveAll();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80043aac
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CPtrArray<CMaterial*>* dtor_80043AAC(CPtrArray<CMaterial*>* ptrArray, short shouldDelete)
+{
+    if (ptrArray != 0) {
+        ptrArray->m_vtable = reinterpret_cast<void**>(0x801E9BFC);
+        ptrArray->RemoveAll();
+        if (shouldDelete > 0) {
+            __dl__FPv(ptrArray);
+        }
+    }
+    return ptrArray;
 }
 
 template <>
@@ -855,7 +893,69 @@ extern "C" void* dtor_8003C49C(void* material, short shouldDelete)
  */
 CTexScroll::~CTexScroll()
 {
-	// TODO
+    if (m_type0 == 2) {
+        void*& keyFrame0 = *reinterpret_cast<void**>(Ptr(this, 0xC));
+        if (keyFrame0 != 0) {
+            void*& table0 = *reinterpret_cast<void**>(Ptr(keyFrame0, 0x18));
+            if (table0 != 0) {
+                __dl__FPv(table0);
+                table0 = 0;
+            }
+
+            void*& table1 = *reinterpret_cast<void**>(Ptr(keyFrame0, 0x1C));
+            if (table1 != 0) {
+                __dl__FPv(table1);
+                table1 = 0;
+            }
+
+            void*& table2 = *reinterpret_cast<void**>(Ptr(keyFrame0, 0x20));
+            if (table2 != 0) {
+                __dl__FPv(table2);
+                table2 = 0;
+            }
+
+            void*& table3 = *reinterpret_cast<void**>(Ptr(keyFrame0, 0x24));
+            if (table3 != 0) {
+                __dl__FPv(table3);
+                table3 = 0;
+            }
+
+            __dl__FPv(keyFrame0);
+            keyFrame0 = 0;
+        }
+    }
+
+    if (m_type1 == 2) {
+        void*& keyFrame1 = *reinterpret_cast<void**>(Ptr(this, 0x10));
+        if (keyFrame1 != 0) {
+            void*& table0 = *reinterpret_cast<void**>(Ptr(keyFrame1, 0x18));
+            if (table0 != 0) {
+                __dl__FPv(table0);
+                table0 = 0;
+            }
+
+            void*& table1 = *reinterpret_cast<void**>(Ptr(keyFrame1, 0x1C));
+            if (table1 != 0) {
+                __dl__FPv(table1);
+                table1 = 0;
+            }
+
+            void*& table2 = *reinterpret_cast<void**>(Ptr(keyFrame1, 0x20));
+            if (table2 != 0) {
+                __dl__FPv(table2);
+                table2 = 0;
+            }
+
+            void*& table3 = *reinterpret_cast<void**>(Ptr(keyFrame1, 0x24));
+            if (table3 != 0) {
+                __dl__FPv(table3);
+                table3 = 0;
+            }
+
+            __dl__FPv(keyFrame1);
+            keyFrame1 = 0;
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Added explicit `__sinit_materialman_cpp` implementation in `src/materialman.cpp` to initialize `MaterialMan` vtable and run the `CColor` ctor used by this TU.
- Added explicit deleting-destructor thunk `dtor_80043AAC` for `CPtrArray<CMaterial*>`, matching existing patterns used in other units.
- Implemented `CTexScroll::~CTexScroll()` using the current TU's raw-offset style to release allocated keyframe tables and keyframe objects.

## Functions improved
Unit: `main/materialman`
- `dtor_80043AAC`: `null` -> `99.347824%` (92b)
- `__sinit_materialman_cpp`: `null` -> `71.17647%` (68b)

## Match evidence
- Unit fuzzy match (`main/materialman`): `14.685457%` -> `15.128199%`
- Verified with `build/tools/objdiff-cli report generate -p . --format json`.

## Plausibility rationale
- The new `dtor_80043AAC` follows the same deleting-destructor thunk style already present across the codebase (set vtable, call cleanup, conditionally `__dl__`).
- The `__sinit_materialman_cpp` behavior is directly aligned with Ghidra/reference output (global vtable bootstrap + color object construction).
- `CTexScroll` destruction now follows expected ownership cleanup for keyframe tables/pointers in type-2 mode and keeps code conventions already used in this file.

## Technical details
- Added required extern symbol declarations for `__ct__6CColorFv` and `PTR_PTR_s_CMaterialMan_801e9bec`.
- Reused existing `Ptr()` helper and raw pointer field access approach in `materialman.cpp` for ABI-consistent codegen behavior.
- Build and report pass with `ninja` after changes.
