### PR TITLE
goout: implement CGoOutMenu::SetMenuStr

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/goout.h"
 #include "ffcc/wm_menu.h"
+#include <stdarg.h>
 #include <string.h>
 
 extern CGoOutMenu g_GoOutMenu;
@@ -7,6 +8,8 @@ extern CGoOutMenu* g_pGoOutMenu;
 extern "C" int GetYesNoXPos__8CMenuPcsFi(CMenuPcs*, int);
 extern "C" int CalcGoOutSelChar__8CMenuPcsFUcUc(CMenuPcs*, unsigned char, unsigned char);
 extern "C" void Calc__10CGoOutMenuFv(CGoOutMenu*);
+extern "C" const char* GetWinMess__8CMenuPcsFi(CMenuPcs*, int);
+extern "C" const char* const* GetMcWinMessBuff__8CMenuPcsFi(CMenuPcs*, int);
 
 struct CMenuPcsGoOutLayout
 {
@@ -287,9 +290,31 @@ void CGoOutMenu::SetMenu(short, long)
  * Address:	TODO
  * Size:	TODO
  */
-void CGoOutMenu::SetMenuStr(long, int, ...)
+void CGoOutMenu::SetMenuStr(long timer, int lineCount, ...)
 {
-	// TODO
+    CMenuPcsGoOutLayout& menuPcsLayout = *reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs);
+    va_list args;
+
+    field_0x38 ^= 1;
+    *reinterpret_cast<int*>(const_cast<char*>(GetWinMess__8CMenuPcsFi(&MenuPcs, field_0x38 + 0x22))) = lineCount;
+
+    va_start(args, lineCount);
+    const unsigned int indexBase = (~-((static_cast<unsigned int>(__cntlzw(field_0x38)) >> 5) & 1) & 10);
+    const char* const* msgTable = GetMcWinMessBuff__8CMenuPcsFi(&MenuPcs, 2);
+    for (int i = 0; i < lineCount; i++) {
+        const_cast<const char**>(msgTable)[indexBase + i] = va_arg(args, const char*);
+    }
+    va_end(args);
+
+    if (field_0x36 >= 0) {
+        WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
+        WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+    }
+
+    field_0x45 = 0;
+    field_0x34 = field_0x38 + 0x22;
+    field_0x48 = 0;
+    field_0x3c = timer;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGoOutMenu::SetMenuStr(long timer, int lineCount, ...)` in `src/goout.cpp`.
- Added varargs message-buffer writes to `MenuPcs` win-message storage, matching the observed toggle-and-fill behavior.
- Applied the same state updates used by surrounding goout menu flow (`field_0x34`, `field_0x45`, `field_0x48`, `field_0x3c`) and menu window reset writes when `field_0x36 >= 0`.

## Functions Improved
- `main/goout` / `SetMenuStr__10CGoOutMenuFlie`
  - Before: **22.61628%**
  - After: **66.093025%**
  - Delta: **+43.476745**

## Match Evidence
- Objdiff command:
  - `tools/objdiff-cli diff -p . -u main/goout -o -`
- Symbol delta (`SetMenuStr__10CGoOutMenuFlie`): **22.61628% -> 66.093025%**.
- Unit `.text` match also improved:
  - Before: **24.711432%**
  - After: **25.514826%**

## Plausibility Rationale
- The implementation follows expected original menu code patterns already used in this codebase:
  - toggled double-buffer message selection,
  - direct writes into menu message arrays,
  - varargs iteration for line assignment,
  - immediate menu state field updates.
- No contrived compiler-only temporaries were introduced; behavior aligns with adjacent `CGoOutMenu` state-machine code.

## Technical Details
- Added explicit references to existing `CMenuPcs` accessors (`GetWinMess`, `GetMcWinMessBuff`) via the known mangled entry points.
- Used the existing `__cntlzw`-based index calculation pattern to select the message buffer half.
- Kept changes scoped to one function (`SetMenuStr`) to isolate effect and avoid unrelated code motion.
