### PR TITLE
singmenu: first-pass decomp for drawSingleMenu

### DIFF
--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/singmenu.h"
+#include "ffcc/p_game.h"
+#include "ffcc/util.h"
 #include <dolphin/gx.h>
 
 typedef signed short s16;
@@ -7,11 +9,26 @@ typedef unsigned char u8;
 extern "C" void SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(CMenuPcs*, int);
 extern "C" void SetTexture__8CMenuPcsFQ28CMenuPcs3TEX(CMenuPcs*, int);
 extern "C" void DrawRect__8CMenuPcsFUlfffffffff(CMenuPcs*, unsigned long, float, float, float, float, float, float, float, float, float);
+extern "C" void DrawInit__8CMenuPcsFv(CMenuPcs*);
+extern "C" void DrawFilter__8CMenuPcsFUcUcUcUc(CMenuPcs*, u8, u8, u8, u8);
+extern "C" void Draw__9CShopMenuFv(void*);
+extern "C" void SingleDrawCtrl__8CMenuPcsFv(CMenuPcs*);
 
 extern float FLOAT_8033292c;
+extern float FLOAT_80332928;
 extern float FLOAT_80332934;
+extern float FLOAT_80332940;
+extern float FLOAT_80332948;
 extern float FLOAT_8033294c;
 extern float FLOAT_80332970;
+extern float FLOAT_803329a4;
+extern float FLOAT_803329a8;
+extern float FLOAT_803329ac;
+extern float FLOAT_803329b0;
+extern float FLOAT_803329b4;
+extern float FLOAT_803329bc;
+extern CUtil DAT_8032ec70;
+extern double DOUBLE_80332938;
 extern double DOUBLE_80332968;
 extern double DOUBLE_80332978;
 extern double DOUBLE_80332980;
@@ -69,12 +86,98 @@ void CMenuPcs::calcSingleMenu()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80149534
+ * PAL Size: 2344b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::drawSingleMenu()
 {
-	// TODO
+    u8* self = reinterpret_cast<u8*>(this);
+
+    if ((Game.game.m_gameWork.m_menuStageMode != 0) &&
+        (Game.game.m_gameWork.m_singleShopOrSmithMenuActiveFlag != 0)) {
+        DrawInit__8CMenuPcsFv(this);
+        DrawFilter__8CMenuPcsFUcUcUcUc(this, 0, 0, 0, 0xFF);
+        DAT_8032ec70.ClearZBufferRect(FLOAT_8033294c, FLOAT_8033294c, FLOAT_803329a4, FLOAT_803329a4);
+        DrawInit__8CMenuPcsFv(this);
+
+        unsigned int scriptFoodBase = Game.game.m_scriptFoodBase[0];
+        if (scriptFoodBase != 0) {
+            u8 menuType = *reinterpret_cast<u8*>(scriptFoodBase + 0xBE0);
+            void* shopMenu = *reinterpret_cast<void**>(self + 0x868);
+            if (((menuType == 1) || (menuType == 2)) && (shopMenu != 0)) {
+                Draw__9CShopMenuFv(shopMenu);
+            }
+        }
+
+        s16 mode = *reinterpret_cast<s16*>(self + 0x866);
+        if (mode == 1) {
+            SingleDrawCtrl__8CMenuPcsFv(this);
+            return;
+        }
+
+        if ((mode == 0) || (mode == 2)) {
+            s16* menuData = *reinterpret_cast<s16**>(self + 0x850);
+            if (menuData == 0) {
+                return;
+            }
+
+            s16 count = menuData[0];
+            s16* entry = menuData + 4;
+
+            for (s16 i = 0; i < count; i++) {
+                if ((i == 0) || (*reinterpret_cast<s16*>(self + 0x864) != 8)) {
+                    float alpha = *reinterpret_cast<float*>(entry + 8);
+
+                    if (i == 0) {
+                        DrawInit__8CMenuPcsFv(this);
+                        GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_SET);
+                        SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(this, 0);
+                        u8 a = static_cast<u8>(FLOAT_80332940 * alpha);
+                        _GXColor color = {0xFF, 0xFF, 0xFF, a};
+                        GXSetChanMatColor(GX_COLOR0A0, color);
+
+                        SetTexture__8CMenuPcsFQ28CMenuPcs3TEX(this, 0x20);
+                        DrawRect__8CMenuPcsFUlfffffffff(this, 0, FLOAT_8033294c, FLOAT_8033294c, FLOAT_803329a4, FLOAT_80332928,
+                                                         FLOAT_8033294c, FLOAT_8033294c, FLOAT_80332934, FLOAT_80332934, 0.0f);
+                        DrawRect__8CMenuPcsFUlfffffffff(this, 4, FLOAT_8033294c, FLOAT_803329a8, FLOAT_803329a4, FLOAT_80332928,
+                                                         FLOAT_8033294c, FLOAT_8033294c, FLOAT_80332934, FLOAT_80332934, 0.0f);
+
+                        SetTexture__8CMenuPcsFQ28CMenuPcs3TEX(this, 0x28);
+                        unsigned int step = 0x20;
+                        for (unsigned int y = 0x40; y < 0x180; y += step) {
+                            if ((0x180 - y) < step) {
+                                step = 0x180 - y;
+                            }
+                            DrawRect__8CMenuPcsFUlfffffffff(this, 0, FLOAT_8033294c, static_cast<float>(y), FLOAT_803329a4,
+                                                             static_cast<float>(step), FLOAT_8033294c, FLOAT_8033294c,
+                                                             FLOAT_80332934, FLOAT_80332934, 0.0f);
+                        }
+                    } else if (i == 1) {
+                        DrawInit__8CMenuPcsFv(this);
+                        GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_SET);
+                        SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(this, 0);
+                        _GXColor white = {0xFF, 0xFF, 0xFF, 0xFF};
+                        GXSetChanMatColor(GX_COLOR0A0, white);
+                        SetTexture__8CMenuPcsFQ28CMenuPcs3TEX(this, 0x21);
+                        DrawRect__8CMenuPcsFUlfffffffff(this, 0, -(FLOAT_803329ac * alpha - FLOAT_803329bc), FLOAT_80332948,
+                                                         FLOAT_803329ac, FLOAT_803329b0, FLOAT_8033294c, FLOAT_8033294c,
+                                                         alpha, FLOAT_80332934, 0.0f);
+                        DrawRect__8CMenuPcsFUlfffffffff(this, 8, FLOAT_803329b4, FLOAT_80332948, FLOAT_803329ac, FLOAT_803329b0,
+                                                         FLOAT_8033294c, FLOAT_8033294c, alpha, FLOAT_80332934, 0.0f);
+                    } else if (i == 2) {
+                        DrawSingleStat(alpha);
+                    } else {
+                        DrawSingleHelpWim(alpha);
+                    }
+                }
+                entry += 0x20;
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced the `drawSingleMenu__8CMenuPcsFv` TODO stub in `src/singmenu.cpp` with a first-pass decomp based on the PAL Ghidra reference.
- Added PAL/EN/JP info header block for this function.
- Implemented the main menu-stage guard, draw setup/filter pass, shop menu draw dispatch, and per-entry draw loop using existing offset-based `CMenuPcs` state access used elsewhere in menu decomp files.
- Implemented the major rendering branches for entries 0/1/2/3+ (background strips, side panels, stat/help draws), preserving existing project conventions (`reinterpret_cast` offset access, explicit extern symbols, existing helper calls).

## Functions Improved
- Unit: `main/singmenu`
- Function: `drawSingleMenu__8CMenuPcsFv` (PAL `0x80149534`, size `2344b`)

## Match Evidence
- `drawSingleMenu__8CMenuPcsFv`: **0.2% -> 30.32594%** fuzzy match
  - Before: from `tools/agent_select_target.py` baseline output.
  - After: from `build/GCCP01/report.json` (`main/singmenu` function entry).
- Unit `main/singmenu` fuzzy match: **4.4% -> 7.6845574%**.

## Plausibility Rationale
- The implementation follows existing menu code patterns already used in this repo: raw offset field access on `CMenuPcs`, explicit draw-state setup, texture/rect draw sequencing, and incremental per-entry rendering logic.
- Changes avoid synthetic compiler-coax constructs; they represent a straightforward first-pass reconstruction of the original control flow and rendering behavior.
- Given the function size and prior near-empty state, this is an intentionally conservative but source-plausible baseline to enable subsequent matching passes.

## Technical Details
- Used project-known globals (`Game`, `DAT_8032ec70`) and existing menu draw helpers (`DrawInit`, `DrawFilter`, `SetAttrFmt`, `SetTexture`, `DrawRect`, `DrawSingleStat`, `DrawSingleHelpWim`, `SingleDrawCtrl`).
- Ported key branching structure from decomp reference while keeping the implementation compatible with current type information and existing code style.
- Build verification: `ninja` passes and regenerates report successfully.
