### PR TITLE
Improve pppConstructYmTraceMove match via packed vector loads

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -23,24 +23,41 @@ extern "C" {
 void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, UnkC* param_2)
 {
 	Vec* dest;
-	Vec local_20;
-	f32 zero;
 	Vec local_38;
-	Vec local_2c;
+	u32 local_2c;
+	u32 local_28;
+	u32 local_24;
+	u32 local_20;
+	u32 local_1c;
+	u32 local_18;
+	f32 zero;
+	u32 savedX;
+	u32 savedY;
+	u32 savedZ;
+	u32 paramX;
+	u32 paramY;
+	u32 paramZ;
+
 	dest = (Vec*)((u8*)pppYmTraceMove + 0x80 + *param_2->m_serializedDataOffsets);
-	local_2c.x = *(f32*)((u8*)pppMngStPtr + 0x58);
-	local_2c.y = *(f32*)((u8*)pppMngStPtr + 0x5c);
-	local_2c.z = *(f32*)((u8*)pppMngStPtr + 0x60);
-	local_20.x = *(f32*)((u8*)pppMngStPtr + 0x68);
-	local_20.y = *(f32*)((u8*)pppMngStPtr + 0x6c);
-	local_20.z = *(f32*)((u8*)pppMngStPtr + 0x70);
-	pppSubVector__FR3Vec3Vec3Vec((Vec*)&dest[1].y, &local_20, &local_2c);
+	savedX = *(u32*)((u8*)pppMngStPtr + 0x58);
+	savedY = *(u32*)((u8*)pppMngStPtr + 0x5c);
+	savedZ = *(u32*)((u8*)pppMngStPtr + 0x60);
+	paramX = *(u32*)((u8*)pppMngStPtr + 0x68);
+	paramY = *(u32*)((u8*)pppMngStPtr + 0x6c);
+	paramZ = *(u32*)((u8*)pppMngStPtr + 0x70);
+	local_2c = savedX;
+	local_28 = savedY;
+	local_24 = savedZ;
+	local_20 = paramX;
+	local_1c = paramY;
+	local_18 = paramZ;
+	pppSubVector__FR3Vec3Vec3Vec((Vec*)&dest[1].y, (Vec*)&local_20, (Vec*)&local_2c);
 	local_38.x = dest[1].y;
 	local_38.y = dest[1].z;
 	local_38.z = dest[2].x;
 	pppCopyVector__FR3Vec3Vec(dest, &local_38);
 	zero = 0.0f;
-	dest[3].x = 0.0f;
+	dest[3].x = zero;
 	dest[2].z = zero;
 	dest[2].y = zero;
 }


### PR DESCRIPTION
## Summary
- Reworked `pppConstructYmTraceMove` to load saved/parameter vectors as packed `u32` words before calling `pppSubVector`.
- Kept behavior unchanged while making the stack/local data flow closer to the target object layout.
- Preserved existing control flow and zero-initialization semantics.

## Functions Improved
- Unit: `main/pppYmTraceMove`
- Function: `pppConstructYmTraceMove` (PAL `0x800d4bd0`, size `172b`)

## Match Evidence
- `pppConstructYmTraceMove`: **64.72093% -> 68.53488%** (`+3.81395`)
  - Before: from `build/GCCP01/report.json` prior to edit
  - After: from regenerated `build/GCCP01/report.json` after `ninja`
- Spot check in objdiff TUI also moved from mid-64% to high-68% for this symbol.

## Plausibility Rationale
- Change is type/layout-centric (word copies of vec components) rather than contrived instruction coaxing.
- The rewritten locals align with common GameCube-era codegen patterns when vectors are passed through stack temporaries.
- No artificial branches or non-idiomatic sequencing were introduced.

## Technical Notes
- Key delta was replacing float field loads/stores (`lfs/stfs` tendency) with packed word loads/stores (`lwz/stw` tendency) for the intermediate vectors.
- This improved alignment of the setup path feeding `pppSubVector` and subsequent copy/zero writes.
