### PR TITLE
memory: improve drawHeapTitle match shape

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -940,7 +940,9 @@ void CMemory::CStage::drawHeapBar(int y)
  */
 void CMemory::CStage::drawHeapTitle(int y)
 {
-    int node = (stageGetAllocationMode(this) == 2) ? stageGetHeapHead(this) : *reinterpret_cast<int*>(stageGetHeapHead(this) + 8);
+    int node = (*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x10C) == 2)
+                   ? *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x110)
+                   : *reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x110) + 8);
     unsigned int totalUnuse = 0;
     unsigned int maxUnuse = 0;
     int prev = *reinterpret_cast<int*>(node + 4);
@@ -949,20 +951,18 @@ void CMemory::CStage::drawHeapTitle(int y)
         unsigned char flags = *reinterpret_cast<unsigned char*>(node + 2);
         if ((flags & 2) != 0) {
             char line[264];
-            int srcLen = strlen(stageGetSourceName(this));
-            int start = srcLen - 12;
-            if (start < 0) {
-                start = 0;
-            }
-            strcpy(line, stageGetSourceName(this) + start);
+            int srcLen = strlen(reinterpret_cast<char*>(reinterpret_cast<unsigned char*>(this) + 0x10));
+            int start = (srcLen - 12U) & ~((srcLen - 12) >> 0x1F);
+            strcpy(line, reinterpret_cast<char*>(reinterpret_cast<unsigned char*>(this) + 0x10) + start);
             Graphic.DrawDebugStringDirect(0x10, static_cast<unsigned short>(y), line, 8);
 
             int totalUnuseKB = (static_cast<int>(totalUnuse) >> 10) +
                 static_cast<int>((static_cast<int>(totalUnuse) < 0) && ((totalUnuse & 0x3FF) != 0));
             int maxUnuseKB = (static_cast<int>(maxUnuse) >> 10) +
                 static_cast<int>((static_cast<int>(maxUnuse) < 0) && ((maxUnuse & 0x3FF) != 0));
-            sprintf(line, s__4d__4d__4d_801d6800, *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x124),
-                    totalUnuseKB, maxUnuseKB);
+            sprintf(line, s__4d__4d__4d_801d6800,
+                    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x124), totalUnuseKB,
+                    maxUnuseKB);
             Graphic.DrawDebugStringDirect(0x208, static_cast<unsigned short>(y), line, 8);
             return;
         }
@@ -975,12 +975,14 @@ void CMemory::CStage::drawHeapTitle(int y)
             }
         }
 
-        if ((*reinterpret_cast<int*>(node + 0x10) != *reinterpret_cast<int*>(node + 8) - (node + 0x40)) ||
-            (*reinterpret_cast<int*>(node + 4) != prev)) {
+        bool validPrev = *reinterpret_cast<int*>(node + 4) == prev;
+        int next = *reinterpret_cast<int*>(node + 8);
+        int current = node;
+        if ((*reinterpret_cast<int*>(node + 0x10) != next - (node + 0x40)) || !validPrev) {
             break;
         }
-        prev = node;
-        node = *reinterpret_cast<int*>(node + 8);
+        prev = current;
+        node = next;
     }
 
     if (System.m_execParam != 0) {


### PR DESCRIPTION
## Summary
- Refined `CMemory::CStage::drawHeapTitle(int)` in `src/memory.cpp` to better align with original control flow and arithmetic patterns.
- Replaced helper-based stage field access with direct stage offset access used by adjacent decompilation style.
- Matched the original source-name slicing behavior with a branchless clamp expression.
- Restructured loop-carried state updates (`prev` / `node`) to mirror the original post-check update order.

## Functions Improved
- Unit: `main/memory`
- Function: `drawHeapTitle__Q27CMemory6CStageFi` (PAL 0x8001D9BC, 396b)
- Before: `1.5353535%`
- After: `2.909091%`
- Delta: `+1.3737375%`

## Match Evidence
- `ninja` rebuild succeeded after the change.
- `build/GCCP01/report.json` confirms `drawHeapTitle__Q27CMemory6CStageFi` increased from `1.5353535` to `2.909091` fuzzy match.
- Unit-level fuzzy measure for `main/memory` improved from `28.554476` to `28.590181`.

## Plausibility Rationale
- The change preserves behavior and keeps idiomatic code for this codebase while matching the observed original execution structure.
- Adjustments are type/control-flow/offset-shape refinements, not contrived compiler coaxing.
- No debug artifacts, assembly comments, or placeholder logic were introduced.

## Technical Details
- Updated source-tail extraction to use the same arithmetic shape as decomp (`(len - 12U) & ~((len - 12) >> 31)`).
- Aligned node traversal bookkeeping with explicit `next/current` temporaries before validation branch exit.
- Kept printed values and memory accounting logic unchanged.
