### PR TITLE
Decompile and map os/__ppc_eabi_init

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -609,7 +609,7 @@ config.libs = [
         "os",
         [
             Object(NonMatching, "os/__start.c"),
-            Object(NonMatching, "os/__ppc_eabi_init.cpp"),
+            Object(NonMatching, "os/__ppc_eabi_init.c"),
             Object(NonMatching, "os/OS.c"),
             Object(NonMatching, "os/OSAddress.c"),
             Object(NonMatching, "os/OSAlarm.c"),

--- a/src/os/__ppc_eabi_init.c
+++ b/src/os/__ppc_eabi_init.c
@@ -1,125 +1,52 @@
-#include <stdlib.h>
-#include <dolphin.h>
-#include <dolphin/os.h>
-#include <string.h>
+#include "dolphin/base/PPCArch.h"
 
-#include "dolphin/os/__os.h"
+typedef void (*voidfunctionptr)(void);
 
-__declspec(section ".ctors") extern void (* _ctors[])();
-__declspec(section ".dtors") extern void (* _dtors[])();
+extern voidfunctionptr _ctors[];
 
-// External symbols for initialization
-extern char _rom_copy_info[];
-extern char _bss_init_info[];
+void __init_cpp(void);
 
-// Structure for ROM copy info
-typedef struct {
-    void* dst;
-    void* src; 
-    unsigned int size;
-} RomCopyInfo;
-
-// Structure for BSS init info  
-typedef struct {
-    void* dst;
-    unsigned int size;
-} BssInitInfo;
-
-static void __init_cpp(void);
-static void __fini_cpp(void);
-
-__declspec(section ".init") void __init_data_80003340(void)
-{
-    RomCopyInfo* romInfo = (RomCopyInfo*)_rom_copy_info;
-    
-    // Process ROM copy entries
-    while (romInfo->size != 0) {
-        if (romInfo->dst != romInfo->src) {
-            memcpy(romInfo->dst, romInfo->src, romInfo->size);
-            __flush_cache(romInfo->dst, romInfo->size);
-        }
-        romInfo++;
-    }
-    
-    BssInitInfo* bssInfo = (BssInitInfo*)_bss_init_info;
-    
-    // Process BSS initialization entries  
-    while (bssInfo->size != 0) {
-        memset(bssInfo->dst, 0, bssInfo->size);
-        bssInfo++;
-    }
-}
-
-__declspec(section ".init") asm void __init_hardware(void)
-{ // clang-format off
-    nofralloc
-    mfmsr r0
-    ori  r0,r0,MSR_FP
-    mtmsr r0
-    mflr    r31
-    bl      __OSPSInit
-    bl      __OSFPRInit
-    bl      __OSCacheInit
-    mtlr    r31
-    blr
-}
-
-__declspec(section ".init") asm void __flush_cache(void *address, unsigned int size)
-{ // clang-format off
-    nofralloc
-    lis     r5, 0xffff
-    ori     r5, r5, 0xfff1
-    and     r5, r5, r3
-    subf    r3, r5, r3
-    add     r4, r4, r3
-rept:
-    dcbst   0,r5
-    sync
-    icbi    0,r5
-    addic   r5,r5,0x8
-    subic.  r4,r4,0x8
-    bge     rept
-    isync
-    blr
-}
-
+/*
+ * --INFO--
+ * PAL Address: 0x8018201C
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void __init_user(void) {
     __init_cpp();
 }
 
-static void __init_cpp(void) {
-	void (* * constructor)();
+/*
+ * --INFO--
+ * PAL Address: 0x8018203C
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+#pragma peephole off
+void __init_cpp(void) {
+    voidfunctionptr* constructor;
 
-	/*
-	 *	call static initializers
-	 */
-	for (constructor = _ctors; *constructor; constructor++) {
-		(*constructor)();
-	}
-}
-
-static void __fini_cpp(void) {
-    void (* * destructor)();
-
-	/*
-	 *	call destructors
-	 */
-    for (destructor = _dtors; *destructor; destructor++) {
-        (*destructor)();
+    for (constructor = _ctors; *constructor != 0; constructor++) {
+        (*constructor)();
     }
 }
+#pragma peephole reset
 
-__declspec(weak)
-void abort(void) {
-    _ExitProcess();
-}
-
-__declspec(weak)
-void exit(int status) {
-    __fini_cpp();
-    _ExitProcess();
-}
-
+/*
+ * --INFO--
+ * PAL Address: 0x80182090
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 void _ExitProcess(void) {
     PPCHalt();
 }


### PR DESCRIPTION
## Summary
- Fixed object mapping in `configure.py` so the SDK OS unit uses `os/__ppc_eabi_init.c`.
- Replaced `src/os/__ppc_eabi_init.c` with a minimal, split-accurate implementation for:
  - `__init_user`
  - `__init_cpp`
  - `_ExitProcess`
- Added PAL address/size info blocks for the three functions.

## Functions improved
- Unit: `main/os/__ppc_eabi_init`
- `__init_user`: 0.0% -> 100.0% (32b)
- `__init_cpp`: 0.0% -> 100.0% (84b)
- `_ExitProcess`: 0.0% -> 100.0% (32b)

## Match evidence
- `objdiff report generate` now reports:
  - `main/os/__ppc_eabi_init`: `fuzzy_match_percent=100.0`
  - `matched_code=148/148`
  - `matched_functions=3/3`
- Project progress after build increased from:
  - `Code: 212592 / 1855300 bytes` to `212740 / 1855300 bytes`
  - `Functions: 1685 / 4733` to `1688 / 4733`

## Plausibility rationale
- Implementation is standard Metrowerks/EABI startup behavior: iterate `_ctors` until null and call `PPCHalt()` in `_ExitProcess`.
- No contrived temporaries or unnatural control-flow coercion; code is short, idiomatic SDK-style source.

## Technical notes
- `#pragma peephole off/reset` is retained around `__init_cpp` to preserve expected codegen.
- `objdiff diff` for this unit shows 100% symbol/section matches.
