### PR TITLE
mesmenu: first-pass decomp for CMesMenu::Create

### DIFF
--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -2,8 +2,10 @@
 #include "ffcc/p_game.h"
 
 #include <math.h>
+#include <string.h>
 
 extern "C" {
+void Create__5CMenuFv(void* menu);
 void Set__4CMesFPci(void* mes, char* script, int flags);
 void SetPosition__4CMesFff(void* mes, float x, float y);
 void PlaySe__6CSoundFiiii(void* sound, int id, int volume, int pan, int unk);
@@ -64,12 +66,54 @@ CMesMenu::~CMesMenu()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8009dfd0
+ * PAL Size: 300b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMesMenu::Create()
 {
-	// TODO
+    typedef void (*VFunc)(void*);
+
+    ((VFunc)(*(unsigned int*)this + 0x10))(this);
+    Create__5CMenuFv(this);
+
+    *(float*)((char*)this + 0x3D78) = FLOAT_803308d8;
+    *(float*)((char*)this + 0x3D74) = FLOAT_803308d8;
+    *(int*)((char*)this + 8) = 0;
+    *(int*)((char*)this + 0xC) = 4;
+    *(int*)((char*)this + 0x3DF4) = 0;
+    *(int*)((char*)this + 0x3DF8) = 0;
+
+    if (*(int*)((char*)this + 0x18) < 4) {
+        unsigned int x = 0x10;
+        if ((*(int*)((char*)this + 0x18) & 1) != 0) {
+            x = 0x270;
+        }
+        *(float*)((char*)this + 0x3D6C) = (float)x;
+
+        unsigned int y = 0x18;
+        if ((*(int*)((char*)this + 0x18) & 2) != 0) {
+            y = 0x1B0;
+        }
+        *(float*)((char*)this + 0x3D70) = (float)y;
+
+        *(float*)((char*)this + 0x3D7C) = FLOAT_803308d8;
+        *(float*)((char*)this + 0x3D80) = FLOAT_803308d8;
+        *(float*)((char*)this + 0x3D84) = FLOAT_803308d8;
+        *(int*)((char*)this + 0x3D88) = 0;
+        *(int*)((char*)this + 0x3D8C) = 0;
+        *(int*)((char*)this + 0x3DA8) = 0;
+        *(int*)((char*)this + 0x3DAC) = 0;
+        memset((char*)this + 0x3DB0, 0, 0x20);
+        memset((char*)this + 0x3DD0, 0, 0x20);
+        *(int*)((char*)this + 0x3DF0) = 0;
+    }
+
+    *(int*)((char*)this + 0x3D98) = 0;
+    *(int*)((char*)this + 0x3D94) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMesMenu::Create()` in `src/mesmenu.cpp` using the current project style (raw offset fields) and Ghidra as structural guidance.
- Added PAL `--INFO--` metadata for the function (`0x8009dfd0`, `300b`).
- Kept behavior source-plausible: virtual cleanup call, base `CMenu` create path, menu state init, viewport-dependent position init, and timer-array zeroing.

## Functions improved
- Unit: `main/mesmenu`
- Function: `Create__8CMesMenuFv` (`300b`)

## Match evidence
- `Create__8CMesMenuFv`: **1.33% -> 82.12%** fuzzy match (`build/GCCP01/report.json`)
- `main/mesmenu` unit fuzzy: **14.732845 -> 16.84326**

## Plausibility rationale
- Change follows likely original intent for menu init lifecycle rather than compiler-only coaxing.
- Uses existing codebase conventions in this file (explicit memory offsets + external symbol calls) and keeps control flow straightforward.
- No contrived temporaries or artificial sequencing solely for score shaping.

## Technical details
- Reconstructed init sequence from decomp shape:
  - vtable slot call at `+0x10`
  - `Create__5CMenuFv(this)`
  - base state fields (`+0x8`, `+0xC`) and per-open timers
  - per-quadrant start positions derived from `this+0x18` flags
  - reset of heart animation/timer arrays (`memset` on `+0x3DB0` and `+0x3DD0`)
- Verified with full rebuild (`ninja`) and regenerated report metrics.
