### PR TITLE
p_map: add octree-center fallback for debug spawn camera

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -6,6 +6,7 @@
 #include "ffcc/p_camera.h"
 #include "ffcc/p_game.h"
 #include "ffcc/p_light.h"
+#include "ffcc/mapocttree.h"
 
 #include <dolphin/mtx.h>
 extern void* __vt__8CManager;
@@ -46,6 +47,7 @@ extern unsigned int lbl_8032ECD0;
 extern unsigned int lbl_8032ECC0;
 extern unsigned int lbl_8032ECC4;
 extern float DrawRangeDefault;
+extern float lbl_8032FA0C;
 extern float lbl_8032FA10;
 extern "C" char lbl_801E8EEC[];
 extern "C" const char lbl_801D7844[];
@@ -219,8 +221,19 @@ void CMapPcs::LoadMap(int stageNo, int mapNo, void* mapPtr, unsigned long mapSiz
         if ((*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x17C) != 0) &&
             (strcmp(lbl_801E8EEC, mapPath) != 0)) {
             strcpy(lbl_801E8EEC, mapPath);
-            MapMng.GetDebugPlaySta(0, &unusedVec);
-            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0) += lbl_8032FA10;
+            if (MapMng.GetDebugPlaySta(0, &unusedVec) == 0) {
+                COctNode* rootNode =
+                    *reinterpret_cast<COctNode**>(reinterpret_cast<char*>(&MapMng) + 0x18);
+                if (rootNode != 0) {
+                    float* bounds = reinterpret_cast<float*>(rootNode);
+                    unusedVec.x = (bounds[0] + bounds[3]) * lbl_8032FA0C;
+                    unusedVec.y = (bounds[1] + bounds[4]) * lbl_8032FA0C;
+                    unusedVec.z = (bounds[2] + bounds[5]) * lbl_8032FA0C;
+                }
+            }
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE4) = unusedVec.y + lbl_8032FA10;
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0) = unusedVec.x;
+            *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE8) = unusedVec.z;
         }
     }
 
@@ -363,7 +376,16 @@ void CMapPcs::calc()
         if ((*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x17C) != 0) &&
             (strcmp(lbl_801E8EEC, reinterpret_cast<char*>(this) + 0x74) != 0)) {
             strcpy(lbl_801E8EEC, reinterpret_cast<char*>(this) + 0x74);
-            MapMng.GetDebugPlaySta(0, &cameraPos);
+            if (MapMng.GetDebugPlaySta(0, &cameraPos) == 0) {
+                COctNode* rootNode =
+                    *reinterpret_cast<COctNode**>(reinterpret_cast<char*>(&MapMng) + 0x18);
+                if (rootNode != 0) {
+                    float* bounds = reinterpret_cast<float*>(rootNode);
+                    cameraPos.x = (bounds[0] + bounds[3]) * lbl_8032FA0C;
+                    cameraPos.y = (bounds[1] + bounds[4]) * lbl_8032FA0C;
+                    cameraPos.z = (bounds[2] + bounds[5]) * lbl_8032FA0C;
+                }
+            }
             *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE0) = cameraPos.x;
             *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE4) = cameraPos.y + lbl_8032FA10;
             *reinterpret_cast<float*>(reinterpret_cast<char*>(&CameraPcs) + 0xE8) = cameraPos.z;


### PR DESCRIPTION
## Summary
- Updated `CMapPcs::LoadMap` and `CMapPcs::calc` to mirror original fallback behavior after `MapMng.GetDebugPlaySta`.
- When debug-play start lookup fails, both functions now derive the camera position from the root octree node bounds center.
- Camera assignment now writes full XYZ from the resolved debug position in `LoadMap` as part of the same flow.

## Functions improved
- `LoadMap__7CMapPcsFiiPvUlUc` (size 844)
  - `report.json` fuzzy match: **33.85308% -> 41.976303%**
  - objdiff `match_percent`: **39.19905%** (post-change)
- `calc__7CMapPcsFv` (size 796)
  - `report.json` fuzzy match: **36.492462% -> 47.984924%**
  - objdiff `match_percent`: **43.34171%** (post-change)
- Unit: `main/p_map`
  - `report.json` unit fuzzy match: **59.846443% -> 62.343945%**

## Match evidence
- Rebuilt with `ninja` (build + report succeeded).
- Verified updated symbol scores in `build/GCCP01/report.json`.
- Verified symbol-level objdiff output via:
  - `build/tools/objdiff-cli diff -p . -u main/p_map -o - LoadMap__7CMapPcsFiiPvUlUc`
  - `build/tools/objdiff-cli diff -p . -u main/p_map -o - calc__7CMapPcsFv`

## Plausibility rationale
- The change restores source-plausible map-camera fallback logic that naturally fits existing engine behavior: if debug start lookup cannot provide a valid position, center the camera using map octree bounds.
- This is not compiler coaxing; it is behaviorally meaningful and aligns with the nearby original control flow (same functions and data paths, no contrived temporaries or synthetic reorderings).

## Technical details
- Added `COctNode`-based bounds center calculation using the map manager octree root pointer.
- Reused existing global constants (`lbl_8032FA0C`, `lbl_8032FA10`) and existing camera/map manager pathways.
- No build-system or flag modifications were required.
