### PR TITLE
p_camera: decompile SetStdProjectionMatrix and createFullShadow

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1,8 +1,10 @@
 #include "ffcc/p_camera.h"
 
 #include "ffcc/materialman.h"
+#include "ffcc/memory.h"
 
 #include <dolphin/mtx.h>
+#include <dolphin/os/OSCache.h>
 
 extern Mtx ppvCameraMatrix0;
 extern float FLOAT_8032fa30;
@@ -11,10 +13,18 @@ extern float FLOAT_8032fa38;
 extern float FLOAT_8032fa5c;
 extern float FLOAT_8032fa58;
 extern float FLOAT_8032fa8c;
+extern float FLOAT_8032fa3c;
+extern float FLOAT_8032fac8;
+extern float FLOAT_8032faa4;
+extern float FLOAT_8032faa8;
 extern float FLOAT_8032fab0;
 extern float FLOAT_8032fab4;
 extern float FLOAT_8032fab8;
 extern CMaterialMan MaterialMan;
+extern char DAT_801d7928[];
+extern unsigned char MapMng[];
+extern "C" void Printf__7CSystemFPce(CSystem* system, char* format, ...);
+extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long size, CMemory::CStage* stage, char* file, int line);
 
 extern "C" {
 void pppEditGetViewPos__FP3Vec(Vec*);
@@ -144,12 +154,27 @@ void CCameraPcs::calc()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80039450
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCameraPcs::SetStdProjectionMatrix()
 {
-	// TODO
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+    float fov = *reinterpret_cast<float*>(self + 0xFC);
+
+    if (fov < FLOAT_8032fac8 && System.m_execParam != 0) {
+        Printf__7CSystemFPce(&System, DAT_801d7928);
+        fov = FLOAT_8032fab4;
+    }
+
+    C_MTXPerspective(reinterpret_cast<Mtx44Ptr>(self + 0x94), fov, FLOAT_8032fa3c,
+                     *reinterpret_cast<float*>(self + 0x100),
+                     *reinterpret_cast<float*>(self + 0x104));
+    GXSetProjection(reinterpret_cast<Mtx44Ptr>(self + 0x94), GX_PERSPECTIVE);
 }
 
 /*
@@ -283,12 +308,66 @@ void CCameraPcs::createRampTex8()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80038358
+ * PAL Size: 624b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CCameraPcs::createFullShadow()
 {
-	// TODO
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+    unsigned int rampTexSize;
+    unsigned int i;
+    unsigned char* rampTex;
+    CMemory::CStage* stage = *reinterpret_cast<CMemory::CStage**>(MapMng);
+
+    *reinterpret_cast<void**>(self + 0x31C) = 0;
+    rampTexSize = GXGetTexBufferSize(0x1E0, 0x1E0, GX_TF_I8, GX_FALSE, 0);
+    *reinterpret_cast<void**>(self + 0x31C) =
+        __nwa__FUlPQ27CMemory6CStagePci(rampTexSize, stage, const_cast<char*>("p_camera.cpp"), 0x3A5);
+
+    rampTexSize = GXGetTexBufferSize(0x10, 0x10, GX_TF_I8, GX_FALSE, 0);
+    rampTex = static_cast<unsigned char*>(
+        __nwa__FUlPQ27CMemory6CStagePci(rampTexSize, stage, const_cast<char*>("p_camera.cpp"), 0x361));
+    *reinterpret_cast<unsigned char**>(self + 0x320) = rampTex;
+
+    for (i = 0; i < 0x100; i += 8) {
+        unsigned int i1 = i + 1;
+        unsigned int i2 = i + 2;
+        unsigned int i3 = i + 3;
+        unsigned int i4 = i + 4;
+        unsigned int i5 = i + 5;
+        unsigned int i6 = i + 6;
+        unsigned int i7 = i + 7;
+
+        rampTex[(i & 0xC) * 0x10 + ((i >> 2) & 0x20) + ((i >> 4) & 7)] = static_cast<unsigned char>(i);
+        rampTex[((i1 * 8) & 0x18) + ((i1 * 0x10) & 0xC0) + ((i1 >> 2) & 0x20) + ((i1 >> 4) & 7)] =
+            static_cast<unsigned char>(i1);
+        rampTex[((i2 * 8) & 0x18) + ((i2 * 0x10) & 0xC0) + ((i2 >> 2) & 0x20) + ((i2 >> 4) & 7)] =
+            static_cast<unsigned char>(i2);
+        rampTex[((i3 * 8) & 0x18) + ((i3 * 0x10) & 0xC0) + ((i3 >> 2) & 0x20) + ((i3 >> 4) & 7)] =
+            static_cast<unsigned char>(i3);
+        rampTex[((i4 * 0x10) & 0xC0) + ((i4 >> 2) & 0x20) + ((i4 >> 4) & 7)] = static_cast<unsigned char>(i4);
+        rampTex[((i5 * 8) & 0x18) + ((i5 * 0x10) & 0xC0) + ((i5 >> 2) & 0x20) + ((i5 >> 4) & 7)] =
+            static_cast<unsigned char>(i5);
+        rampTex[((i6 * 8) & 0x18) + ((i6 * 0x10) & 0xC0) + ((i6 >> 2) & 0x20) + ((i6 >> 4) & 7)] =
+            static_cast<unsigned char>(i6);
+        rampTex[((i7 * 8) & 0x18) + ((i7 * 0x10) & 0xC0) + ((i7 >> 2) & 0x20) + ((i7 >> 4) & 7)] =
+            static_cast<unsigned char>(i7);
+    }
+
+    GXInitTexObj(reinterpret_cast<GXTexObj*>(self + 0x344), rampTex, 0x10, 0x10, GX_TF_I8,
+                 GX_CLAMP, GX_REPEAT, GX_FALSE);
+    GXInitTexObjLOD(reinterpret_cast<GXTexObj*>(self + 0x344), GX_NEAR, GX_NEAR, 0.0f, 0.0f, 0.0f,
+                    GX_FALSE, GX_FALSE, GX_ANISO_1);
+    DCFlushRange(rampTex, rampTexSize);
+
+    self[0x404] = 1;
+    *reinterpret_cast<float*>(self + 0x364) = FLOAT_8032faa4;
+    *reinterpret_cast<float*>(self + 0x368) = FLOAT_8032fa34;
+    *reinterpret_cast<float*>(self + 0x370) = FLOAT_8032faa8;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Decompiled `CCameraPcs::SetStdProjectionMatrix()` in `src/p_camera.cpp` using existing offset-based camera state access.
- Decompiled `CCameraPcs::createFullShadow()` including texture allocation, swizzled ramp generation, GX texture-object init, cache flush, and full-shadow state setup.
- Added PAL address/size metadata blocks for both updated functions.

## Functions improved
- `SetStdProjectionMatrix__10CCameraPcsFv` (main/p_camera, 128b)
  - Before: `3.125%` fuzzy match
  - After: `87.8125%` fuzzy match
- `createFullShadow__10CCameraPcsFv` (main/p_camera, 624b)
  - Before: `0.64102566%` fuzzy match
  - After: `55.929485%` fuzzy match

## Match evidence
- `ninja` rebuild succeeds and updates `build/GCCP01/report.json` with the above improvements.
- `objdiff-cli diff -p . -u main/p_camera SetStdProjectionMatrix__10CCameraPcsFv` reports ~`87.19%` in the live diff view.
- `objdiff-cli diff -p . -u main/p_camera createFullShadow__10CCameraPcsFv` reports ~`55.19%` in the live diff view.

## Plausibility rationale
- Changes are direct first-pass decompilation of game logic (projection setup and full-shadow resource setup), not compiler-coaxing transformations.
- Implementation follows established file style in `p_camera.cpp` (raw offset field access with existing engine APIs).
- No debug artifacts or commented-out code were introduced.

## Technical details
- `SetStdProjectionMatrix` now performs:
  - FOV floor guard using `System.m_execParam` gated debug print path.
  - Perspective matrix creation via `C_MTXPerspective`.
  - Projection upload via `GXSetProjection`.
- `createFullShadow` now performs:
  - Stage-allocator usage via `__nwa__FUlPQ27CMemory6CStagePci`.
  - 16x16 ramp texture swizzle write pattern for all 0x100 entries.
  - `GXInitTexObj`, `GXInitTexObjLOD`, and `DCFlushRange` setup.
  - Activation and default float parameter writes for full-screen shadow state.
