### PR TITLE
p_game: improve singleton wrapper matching for script/map callbacks

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -232,7 +232,8 @@ void CGamePcs::draw2()
  */
 void CGamePcs::onScriptChanging(char* script)
 {
-	game.CGame::ScriptChanging(script);
+    CGame& game = Game.game;
+    game.CGame::ScriptChanging(script);
 }
 
 /*
@@ -246,7 +247,8 @@ void CGamePcs::onScriptChanging(char* script)
  */
 void CGamePcs::onScriptChanged(char* script, int param)
 {
-	game.CGame::ScriptChanged(script, param);
+    CGame& game = Game.game;
+    game.CGame::ScriptChanged(script, param);
 }
 
 /*
@@ -260,7 +262,8 @@ void CGamePcs::onScriptChanged(char* script, int param)
  */
 void CGamePcs::onMapChanging(int a, int b)
 {
-	game.CGame::MapChanging(a, b);
+    CGame& game = Game.game;
+    game.CGame::MapChanging(a, b);
 }
 
 /*
@@ -274,5 +277,6 @@ void CGamePcs::onMapChanging(int a, int b)
  */
 void CGamePcs::onMapChanged(int a, int b, int c)
 {
-	game.CGame::MapChanged(a, b, c);
+    CGame& game = Game.game;
+    game.CGame::MapChanged(a, b, c);
 }


### PR DESCRIPTION
## Summary
- Updated four `CGamePcs` callback wrappers in `src/p_game.cpp` to route through the global singleton storage (`Game.game`) via a local `CGame&` binding.
- Kept behavior identical (each wrapper still directly forwards to the corresponding `CGame` method).

## Functions improved
- `onScriptChanging__8CGamePcsFPc`
- `onScriptChanged__8CGamePcsFPci`
- `onMapChanging__8CGamePcsFii`
- `onMapChanged__8CGamePcsFiii`

## Match evidence
`objdiff-cli report generate -p .`:
- Unit `main/p_game` fuzzy match: **82.77169% -> 83.77625%**
- Each wrapper above: **84.0% -> 89.5%**

## Assembly analysis notes
- Prior code path generated addressing from the implicit `this` object (`this + 0x10`) for `game`.
- New code path generates global-address based setup for `Game`/`Game.game`, which aligns better with target wrapper codegen and improves call-site instruction similarity.

## Plausibility rationale
- The project already treats `Game` as a global singleton across many units.
- Using `Game.game` directly in these top-level callbacks is idiomatic and source-plausible, and avoids contrived control-flow or temporary-only compiler coaxing.
