### PR TITLE
RedDriver: implement SetSeBlockData first pass

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -71,7 +71,7 @@ public:
 	void MusicVolume(int, int, int);
 	void SetMusicPhraseStop(int);
 
-	void SetSeBlockData(int, void*);
+	void* SetSeBlockData(int, void*);
 	void SetSeSepData(void*);
 	void ClearSeSepData(int);
 	void ClearSeSepDataMG(int, int, int, int);

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1348,12 +1348,30 @@ void CRedDriver::SetMusicPhraseStop(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bf0c4
+ * PAL Size: 168b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::SetSeBlockData(int, void*)
+void* CRedDriver::SetSeBlockData(int param_1, void* param_2)
 {
-	// TODO
+    int iVar1;
+    void* pvVar2;
+
+    pvVar2 = 0;
+    if (param_2 != 0) {
+        iVar1 = *(int*)((int)param_2 + 0xc);
+        if (0 < iVar1) {
+            pvVar2 = RedNew__Fi(iVar1);
+            if (pvVar2 != 0) {
+                memcpy(pvVar2, param_2, iVar1);
+            }
+        }
+    }
+    _EntryExecCommand(_SetSeBlockData, param_1, (int)pvVar2, 0, 0, 0, 0, 0);
+    return pvVar2;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CRedDriver::SetSeBlockData(int, void*)` in `src/RedSound/RedDriver.cpp` from TODO into a concrete first-pass decomp that:
- validates the incoming block pointer
- reads block size from header offset `+0xC`
- allocates a copy via `RedNew__Fi`
- copies block data with `memcpy`
- enqueues `_SetSeBlockData` with `_EntryExecCommand`

Also aligned signature semantics by changing declaration/definition to return `void*` (matching the function behavior observed in decomp output), and added PAL info block metadata.

## Functions Improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `SetSeBlockData__10CRedDriverFiPv`
- Size: `168b`

## Match Evidence
Objdiff command used:
```sh
/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o <file>.json SetSeBlockData__10CRedDriverFiPv --format json-pretty
```

Before:
- `SetSeBlockData__10CRedDriverFiPv`: `2.3809524%`

After:
- `SetSeBlockData__10CRedDriverFiPv`: `57.97619%`

Net improvement:
- `+55.5952376` percentage points

## Plausibility Rationale
This change is source-plausible for original game code because it models expected runtime behavior directly (copy incoming sound bank blob, queue command) rather than synthetic compiler coaxing. The control flow and API usage match existing `RedDriver` patterns (`RedNew__Fi`, `memcpy`, `_EntryExecCommand`) and does not rely on contrived temporaries or artificial instruction shaping.

## Technical Details
- The low baseline was caused by a TODO stub body.
- Updating return type to `void*` improved tail behavior consistency for the function by preserving the allocated pointer as a return value.
- Remaining mismatch likely comes from fine-grained register/stack allocation differences and can be iterated in follow-up passes.
