### PR TITLE
Improve CLightPcs::Add match in p_light

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -436,7 +436,7 @@ void CLightPcs::Add(CLightPcs::CLight* light)
     float intensity = *(float*)((char*)light + 0x28);
     unsigned int colorMask = 0x01010101;
 
-    if (maxDist >= FLOAT_8032fc14) {
+    if (maxDist >= FLOAT_8032fc10) {
         maxDist = radius;
     }
 
@@ -460,9 +460,53 @@ void CLightPcs::Add(CLightPcs::CLight* light)
 
     unsigned int* dst = (unsigned int*)((char*)this + 0x63c + index * 0xb0);
     unsigned int* src = (unsigned int*)light;
-    for (int i = 0; i < 0x2c; i++) {
-        dst[i] = src[i];
-    }
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    dst[4] = src[4];
+    dst[5] = src[5];
+    dst[6] = src[6];
+    dst[7] = src[7];
+    dst[8] = src[8];
+    dst[9] = src[9];
+    dst[10] = src[10];
+    dst[11] = src[11];
+    dst[12] = src[12];
+    dst[13] = src[13];
+    dst[14] = src[14];
+    dst[15] = src[15];
+    dst[16] = src[16];
+    dst[17] = src[17];
+    dst[18] = src[18];
+    *(u8*)(dst + 19) = *(u8*)(src + 19);
+    *(u8*)((char*)dst + 0x4d) = *(u8*)((char*)src + 0x4d);
+    *(u8*)((char*)dst + 0x4e) = *(u8*)((char*)src + 0x4e);
+    *(u8*)((char*)dst + 0x4f) = *(u8*)((char*)src + 0x4f);
+    dst[20] = src[20];
+    dst[21] = src[21];
+    dst[22] = src[22];
+    dst[23] = src[23];
+    dst[24] = src[24];
+    dst[25] = src[25];
+    dst[26] = src[26];
+    dst[27] = src[27];
+    dst[28] = src[28];
+    dst[29] = src[29];
+    dst[30] = src[30];
+    dst[31] = src[31];
+    dst[32] = src[32];
+    dst[33] = src[33];
+    dst[34] = src[34];
+    dst[35] = src[35];
+    dst[36] = src[36];
+    dst[37] = src[37];
+    dst[38] = src[38];
+    dst[39] = src[39];
+    dst[40] = src[40];
+    dst[41] = src[41];
+    dst[42] = src[42];
+    dst[43] = src[43];
 
     float atten = absRadius * FLOAT_8032fc18 * intensity;
     float radiusSq = radius * radius;


### PR DESCRIPTION
## Summary
- Updated `CLightPcs::Add` in `src/p_light.cpp` to better reflect original field-wise copy behavior.
- Replaced the generic 0x2c-word copy loop with explicit field-order stores (including byte fields at 0x4d..0x4f), then applied the function-specific overrides (`maxDist`, attenuation, channel mask, radius squared).
- Corrected the `maxDist` clamp comparison constant to `FLOAT_8032fc10` to align with decomp reference behavior.

## Functions improved
- Unit: `main/p_light`
- Symbol: `Add__9CLightPcsFPQ29CLightPcs6CLight`

## Match evidence
- `Add__9CLightPcsFPQ29CLightPcs6CLight`: **22.6% -> 32.36434%**
  - Before: selector baseline (`tools/agent_select_target.py`) reported 22.6%.
  - After: `build/GCCP01/report.json` reports 32.36434%.
- Unit `main/p_light` fuzzy score increased from selector baseline **53.4%** to **54.370552%**.

## Plausibility rationale
- The change is source-plausible and reflects expected original author intent:
  - `Add` ingests a light template and populates an internal light table entry with a mostly direct copy, then patches computed fields.
  - Explicit stores by field/offset are consistent with existing low-level style in this unit and avoid contrived compiler-coax temporaries.
  - The constant fix in the clamp path matches observed reference logic rather than introducing artificial reordering.

## Technical details
- Validation flow:
  - `ninja` rebuild succeeded.
  - `objdiff-cli` TUI diff for `Add__9CLightPcsFPQ29CLightPcs6CLight` reflected improved alignment.
  - `build/GCCP01/report.json` confirms post-change fuzzy scores for both the symbol and the unit.
