### PR TITLE
Improve pppFrameLocationTitle interpolation match

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -189,24 +189,25 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, Un
         LocationTitleParticle* particles = (LocationTitleParticle*)work->m_particles;
         Vec subVec;
         Vec interp[50];
-        u16 count = work->m_count;
+        LocationTitleParticle* startParticle;
         u8 stepCount = *(u8*)&param_2->m_stepValue;
-        int startIndex = count - 2;
+        int startIndex = (int)work->m_count - 2;
         int inserted = 0;
-        float inv = 1.0f / (float)(stepCount + 1);
+        double stepScale = (double)(1.0f / (float)(stepCount + 1));
 
-        PSVECSubtract(&particles[count - 1].m_pos, &particles[startIndex].m_pos, &subVec);
+        startParticle = &particles[startIndex];
+        PSVECSubtract(&particles[work->m_count - 1].m_pos, &startParticle->m_pos, &subVec);
 
-        for (u8 i = 0; i < stepCount; i++) {
-            float t = (float)(i + 1) * inv;
+        for (int i = 0; i < stepCount; i++) {
             Vec scaled;
+            float t = (float)(stepScale * (double)(i + 1));
 
             PSVECScale(&subVec, &scaled, t);
-            PSVECAdd(&particles[startIndex].m_pos, &scaled, &interp[i]);
+            PSVECAdd(&startParticle->m_pos, &scaled, &interp[i]);
             inserted++;
             work->m_count++;
 
-            if (maxCount <= work->m_count + 1) {
+            if (maxCount <= (u16)(work->m_count + 1)) {
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- Refined `pppFrameLocationTitle` interpolation block to follow existing particle interpolation patterns used elsewhere in the codebase.
- Switched interpolation scale to a `double`-based computation and used `int` loop indexing for step interpolation.
- Reused a `startParticle` pointer and aligned capacity check casting in the insertion loop.

## Functions improved
- Unit: `main/pppLocationTitle`
- Function: `pppFrameLocationTitle`

## Match evidence
- `pppFrameLocationTitle`: **41.368076% -> 44.957653%** (+3.589577)
- `main/pppLocationTitle` unit fuzzy match: **51.554543% -> 54.059086%** (+2.504543)
- Build verification: `ninja` completed and regenerated report successfully.

## Plausibility rationale
- The changes keep behavior intact and mirror established coding patterns already present in `LocationTitle2` interpolation logic.
- No artificial temporaries or non-idiomatic sequencing were introduced; this remains plausible original-source style rather than compiler-only coaxing.

## Technical details
- Interpolation now computes `t` via `double stepScale * (i + 1)` before conversion to `float`, which better aligns generated math code.
- Loop index changed from `u8` to `int`, matching common Metrowerks-emitted iteration patterns in similar routines.
- Capacity guard now uses explicit `(u16)` cast on `(work->m_count + 1)` in the interpolation insertion loop.
