### PR TITLE
Improve pppFrameLocationTitle2 reconstruction in LocationTitle2

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -193,18 +193,20 @@ void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, struct UnkB
         animFrameCount = *(u16*)(modelAnim + 0x10);
 
         for (u16 frameIndex = 0; frameIndex < animFrameCount; frameIndex++) {
+            Mtx nodeMtx;
             LocationTitle2Particle* particle;
             u16 count;
 
             CalcBind__Q26CChara5CNodeFPQ26CChara6CModel(modelNodes + nodeIndex * 0xC0, model);
             SetFrame__Q26CChara6CModelFf((float)frameIndex, model);
             CalcMatrix__Q26CChara6CModelFv(model);
+            PSMTXCopy((float(*)[4])(modelNodes + nodeIndex * 0xC0 + 0xC), nodeMtx);
 
             count = work->m_count;
             particle = &particles[count];
-            particle->m_pos.x = *(float*)(modelNodes + nodeIndex * 0xC0 + 0x18);
-            particle->m_pos.y = *(float*)(modelNodes + nodeIndex * 0xC0 + 0x28);
-            particle->m_pos.z = *(float*)(modelNodes + nodeIndex * 0xC0 + 0x38) + FLOAT_80330f4c;
+            particle->m_pos.x = nodeMtx[0][3];
+            particle->m_pos.y = nodeMtx[1][3];
+            particle->m_pos.z = nodeMtx[2][3] + FLOAT_80330f4c;
             memcpy(&particle->m_color, (u8*)locationTitle + 0x88 + colorOffset, 4);
             particle->m_pad0 = 0;
             particle->m_shape = 0;
@@ -250,14 +252,15 @@ void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, struct UnkB
                     }
                 }
 
-                particles[startIndex + inserted + 1].m_pos = particles[startIndex + 1].m_pos;
+                pppCopyVector(particles[startIndex + inserted + 1].m_pos,
+                              particles[startIndex + 1].m_pos);
 
                 for (int i = 0; i < inserted; i++) {
                     LocationTitle2Particle* dst;
 
                     dst = &particles[startIndex + i + 1];
                     interp[i].z += FLOAT_80330f4c;
-                    dst->m_pos = interp[i];
+                    pppCopyVector(dst->m_pos, interp[i]);
                     memcpy(&dst->m_color, (u8*)locationTitle + 0x88 + colorOffset, 4);
                     dst->m_pad0 = 0;
                     dst->m_shape = 0;


### PR DESCRIPTION
## Summary
- Updated `pppFrameLocationTitle2` in `src/LocationTitle2.cpp` to follow a more source-plausible node transform extraction flow.
- Replaced direct raw offset reads for node translation with an explicit `PSMTXCopy` + matrix translation read.
- Switched interpolation vector moves from direct struct assignment to `pppCopyVector` usage in two locations, matching common codebase idioms.

## Functions improved
- Unit: `main/LocationTitle2`
- Function: `pppFrameLocationTitle2`

## Match evidence
`tools/objdiff-cli diff -p . -u main/LocationTitle2 -o - --format json pppFrameLocationTitle2`

Before:
- `match_percent`: **51.68092%**
- Diff instruction counts:
  - `DIFF_ARG_MISMATCH`: 146
  - `DIFF_DELETE`: 75
  - `DIFF_INSERT`: 39
  - `DIFF_OP_MISMATCH`: 4
  - `DIFF_REPLACE`: 40

After:
- `match_percent`: **57.12171%**
- Diff instruction counts:
  - `DIFF_ARG_MISMATCH`: 131
  - `DIFF_DELETE`: 63
  - `DIFF_INSERT`: 38
  - `DIFF_OP_MISMATCH`: 3
  - `DIFF_REPLACE`: 34

Net improvement: **+5.44079%** for `pppFrameLocationTitle2`.

## Plausibility rationale
- The new implementation is consistent with how model/node transforms are commonly handled in this codebase: materializing a node matrix, then reading translation components.
- Using `pppCopyVector` in interpolation paths matches nearby particle systems and avoids contrived optimizer-only rewrites.
- Changes are local, readable, and preserve behavior while improving assembly alignment.

## Technical details
- Added a local `Mtx nodeMtx` in the frame-sampling loop.
- Added `PSMTXCopy((float(*)[4])(modelNodes + nodeIndex * 0xC0 + 0xC), nodeMtx)` before position extraction.
- Replaced:
  - direct position reads from `modelNodes + {0x18,0x28,0x38}` with `nodeMtx[0][3..]`.
  - two `Vec` assignment sites in interpolation with `pppCopyVector` calls.
- Verified project still builds with `ninja`.
