### PR TITLE
Improve pppVertexAp loop control-flow matching

### DIFF
--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -123,7 +123,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 
         switch (data->mode) {
         case 0:
-            do {
+            while (count-- != 0) {
                 if (state->index >= (u16)entry->maxValue) {
                     state->index = 0;
                 }
@@ -163,10 +163,10 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                         *outPos = worldPos;
                     }
                 }
-            } while (count-- != 0);
+            }
             break;
         case 1:
-            do {
+            while (count-- != 0) {
                 u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
                 Vec* vertex = &points[vertexIndex];
                 f32 x = vertex->x;
@@ -201,7 +201,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                         *outPos = worldPos;
                     }
                 }
-            } while (count-- != 0);
+            }
             break;
         }
 


### PR DESCRIPTION
## Summary
- Updated `pppVertexAp` loop control flow in `src/pppVertexAp.cpp`.
- Replaced `do { ... } while (count-- != 0)` with guarded `while (count-- != 0) { ... }` in both mode branches.
- No behavior-specific helper temporaries or compiler-only patterns were introduced.

## Functions improved
- Unit: `main/pppVertexAp`
- Symbol: `pppVertexAp`

## Match evidence
- Before: `78.35052%` (`/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppVertexAp -o /tmp/diff_pppVertexAp_before.json --format json-pretty pppVertexAp`)
- After: `78.99484%` (`/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppVertexAp -o /tmp/diff_pppVertexAp_after1.json --format json-pretty pppVertexAp`)
- Build verification: `ninja` passes.

## Plausibility rationale
- Guarded loop execution is a natural source-level form for spawn-count-driven emission.
- This removes forced one-iteration semantics from `do-while` and better reflects expected gameplay/authored logic when `spawnCount == 0`.
- Change is localized and readable, without synthetic temporaries or offset-only compiler coaxing.

## Technical details
- The objdiff delta showed improvement in `pppVertexAp` instruction matching and moved the compared side to the expected function size alignment for one side of the diff.
- No signature changes or ABI-impacting type/layout edits were made.
