### PR TITLE
Improve pppFrameColum control-flow matching

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -171,45 +171,38 @@ void pppRenderColum(pppColum *column, UnkB *param_2, UnkC *param_3)
 void pppFrameColum(pppColum *column, UnkB *param_2, UnkC *param_3)
 {
     int i;
-    int* serializedDataOffsets;
     unsigned char* work;
+    float* values;
+    unsigned char count;
 
-    if (lbl_8032ED70 != 0) {
-        return;
-    }
-
-    serializedDataOffsets = GetColumSerializedDataOffsets(param_3);
-    work = (unsigned char*)((char*)column + 0x80 + serializedDataOffsets[3]);
-
-    if (*(void**)(work + 8) == 0) {
-        unsigned char count = *((unsigned char*)&param_2->m_arg3 + 1);
-        float* values = (float*)pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(count * 0xc),
-                                                                       pppEnvStPtr->m_stagePtr,
-                                                                       (char*)"pppColum.cpp", 0x7d);
-
-        *(void**)(work + 8) = values;
-        for (i = 0; i < (int)count; i++) {
-            values[0] = RandF__5CMathFf(*(float*)(param_2->m_payload + 4), &Math);
-            values[0] += *(float*)param_2->m_payload;
-            values[1] = RandF__5CMathFf(*(float*)(param_2->m_payload + 0xc), &Math);
-            values[1] += *(float*)(param_2->m_payload + 8);
-            ((unsigned char*)values)[8] =
-                GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x16]);
-            ((unsigned char*)values)[9] =
-                GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x17]);
-            ((unsigned char*)values)[10] =
-                GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x18]);
-            values += 3;
+    if (lbl_8032ED70 == 0) {
+        work = (unsigned char*)((char*)column + 0x80 + param_3->m_serializedDataOffsets[3]);
+        if (*(void**)(work + 8) == 0) {
+            count = *((unsigned char*)&param_2->m_arg3 + 1);
+            *(void**)(work + 8) = pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)count * 0xc,
+                                                                         pppEnvStPtr->m_stagePtr,
+                                                                         (char*)"pppColum.cpp", 0x7d);
+            values = *(float**)(work + 8);
+            for (i = 0; i < (int)count; i++) {
+                values[0] = RandF__5CMathFf(*(float*)(param_2->m_payload + 4), &Math);
+                values[0] = values[0] + *(float*)param_2->m_payload;
+                values[1] = RandF__5CMathFf(*(float*)(param_2->m_payload + 0xc), &Math);
+                values[1] = values[1] + *(float*)(param_2->m_payload + 8);
+                *(unsigned char*)(values + 2) =
+                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x16]);
+                *(unsigned char*)((char*)values + 9) =
+                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x17]);
+                *(unsigned char*)((char*)values + 10) =
+                    GetNoise__5CUtilFUc(&DAT_8032ec70, (unsigned char)param_2->m_payload[0x18]);
+                values = values + 3;
+            }
         }
-    }
 
-    if (param_2->m_dataValIndex != 0xffff) {
-        long* shapeTable = *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4);
-        short& shapeA = *(short*)(work + 0);
-        short& shapeB = *(short*)(work + 2);
-        short& shapeC = *(short*)(work + 4);
-
-        pppCalcFrameShape__FPlRsRsRss(shapeTable, shapeA, shapeB, shapeC, (short)param_2->m_initWOrk);
+        if (param_2->m_dataValIndex != 0xffff) {
+            pppCalcFrameShape__FPlRsRsRss(
+                *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4),
+                *(short*)(work + 0), *(short*)(work + 2), *(short*)(work + 4), (short)param_2->m_initWOrk);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Reworked `pppFrameColum` in `src/pppColum.cpp` to use a direct work-pointer flow and a single enclosing `if (lbl_8032ED70 == 0)` block.
- Inlined the work buffer initialization and shape-frame call path in a way that more closely follows the observed original control flow.
- Removed C++ reference temporaries in the shape update call and used direct short lvalue accesses at the work-buffer offsets.

## Functions improved
- Unit: `main/pppColum`
- Function: `pppFrameColum` (324b)

## Match evidence
- `pppFrameColum` fuzzy match: **71.012344% -> 72.296295%** (`build/GCCP01/report.json`)
- Unit `main/pppColum` fuzzy match: **65.321014% -> 65.5612%** (`build/GCCP01/report.json`)
- One-shot objdiff symbol match (`tools/objdiff-cli diff -p . -u main/pppColum ... pppFrameColum`):
  - `match_percent`: **70.580246 -> 71.8642**

## Plausibility rationale
- The change favors source-level cleanup that mirrors likely original author intent: straightforward pointer-based work-buffer setup, looped parameter generation, and direct shape-frame updates.
- No contrived compiler-coaxing temporaries or artificial instruction-order hacks were introduced.

## Technical details
- Key alignment changes came from restructuring branching and variable lifetimes so allocation/init work and shape-frame application occur in the same top-level guard path.
- The updated loop keeps per-iteration noise/random field writes adjacent to each generated entry, matching expected data initialization sequencing.
