### PR TITLE
mapocttree: improve __sinit_mapocttree_cpp static init match

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1922,12 +1922,14 @@ COctNode::COctNode()
  */
 extern "C" void __sinit_mapocttree_cpp()
 {
-	((float*)&s_bound)[0] = lbl_8032F96C;
-	((float*)&s_bound)[1] = lbl_8032F96C;
-	((float*)&s_bound)[2] = lbl_8032F96C;
-	((float*)&s_bound)[3] = lbl_8032F970;
-	((float*)&s_bound)[4] = lbl_8032F970;
-	((float*)&s_bound)[5] = lbl_8032F970;
+	float* bound = reinterpret_cast<float*>(Ptr(&s_bound, 0x0));
+
+	bound[2] = lbl_8032F96C;
+	bound[1] = lbl_8032F96C;
+	bound[0] = lbl_8032F96C;
+	bound[5] = lbl_8032F970;
+	bound[4] = lbl_8032F970;
+	bound[3] = lbl_8032F970;
 
 	s_cyl.m_direction2.y = lbl_8032F96C;
 	s_cyl.m_direction2.x = lbl_8032F96C;


### PR DESCRIPTION
## Summary
Reworked `__sinit_mapocttree_cpp` in `src/mapocttree.cpp` to use pointer-based bound initialization with store ordering aligned to target codegen.

## Functions improved
- Unit: `main/mapocttree`
- Symbol: `__sinit_mapocttree_cpp`

## Match evidence
- `__sinit_mapocttree_cpp`: **53.94737% -> 54.736843%**
- Function size stayed at 76 bytes.
- Objdiff diff profile improved by eliminating prior argument-register mismatches in this function; remaining differences are instruction-order/replace deltas around prologue init sequencing.

## Plausibility rationale
The change keeps source-plausible behavior:
- still initializes `s_bound` and `s_cyl` to the same min/max constants,
- only adjusts expression structure and write order,
- avoids compiler-coaxing artifacts like synthetic control-flow or magic constants.

## Technical details
- Switched bound writes to a local pointer (`Ptr(&s_bound, 0x0)`) and ordered writes as `[2,1,0,5,4,3]`.
- Kept all semantic values identical (`lbl_8032F96C` for mins, `lbl_8032F970` for maxes).
- Verified by rebuilding with `ninja` and running:
  - `tools/objdiff-cli diff -p . -u main/mapocttree -o - __sinit_mapocttree_cpp`
