### PR TITLE
pppConstrainCameraDir2: fix helper linkage declarations

### DIFF
--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -15,9 +15,9 @@ extern float FLOAT_803331e4;
 extern float FLOAT_803331e8;
 extern int DAT_8032ec70;
 
-void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, pppConstrainCameraDir*, int, float*, float*, float*, float*, float*);
-void GetDirectVector__5CUtilFP3VecP3Vec3Vec(void*, Vec*, Vec*, Vec*);
-void pppSetFpMatrix__FP9_pppMngSt(_pppMngSt*);
+extern "C" void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(float, void*, int, float*, float*, float*, float*, float*);
+extern "C" void GetDirectVector__5CUtilFP3VecP3Vec3Vec(void*, Vec*, Vec*, Vec*);
+extern "C" void pppSetFpMatrix__FP9_pppMngSt(void*);
 
 /*
  * --INFO--
@@ -63,7 +63,7 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, UnkB* param_2, 
 		
 		CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
 			param_2->m_dataValIndex,
-			param_1,
+			(void*)param_1,
 			param_2->m_graphId,
 			value,
 			value + 1,
@@ -127,7 +127,7 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, UnkB* param_2, 
 			pppMngStPtr->m_matrix.value[1][3] = local_c0.y;
 			pppMngStPtr->m_matrix.value[2][3] = local_c0.z;
 			
-			pppSetFpMatrix__FP9_pppMngSt(pppMngSt);
+			pppSetFpMatrix__FP9_pppMngSt((void*)pppMngSt);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Updated helper function declarations in `src/pppConstrainCameraDir2.cpp` to explicit C linkage with generic pointer signatures where this unit treats them as external C symbols.
- Kept function logic unchanged; only declaration/call typing/linkage was adjusted for closer original call ABI/codegen.

## Functions Improved
- Unit: `main/pppConstrainCameraDir2`
- Symbol: `pppFrameConstrainCameraDir2`
  - Before: `71.72093%`
  - After: `71.808136%`
  - Delta: `+0.087206`

## Match Evidence
- `objdiff-cli` run:
  - `../tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir2 -o -`
- Verified against saved before/after outputs:
  - `/tmp/dir2_reset.json` (before)
  - `/tmp/dir2_final.json` (after)

## Plausibility Rationale
- The `ppp*` units frequently rely on exact external symbol linkage/mangling behavior; using explicit `extern "C"` declarations with ABI-compatible pointer types is a plausible correction to how original game-side glue code was compiled.
- This is not compiler-coaxing control-flow churn: it is a targeted linkage/type correction consistent with existing project patterns for other `ppp` units.

## Technical Details
- Helper declarations changed to:
  - `CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf`
  - `GetDirectVector__5CUtilFP3VecP3Vec3Vec`
  - `pppSetFpMatrix__FP9_pppMngSt`
- Calls were kept semantically identical; only pointer typing at the call boundary was made explicit.
