### PR TITLE
Improve pppFrameYmMoveCircle match via step-layout alignment

### DIFF
--- a/include/ffcc/pppYmMoveCircle.h
+++ b/include/ffcc/pppYmMoveCircle.h
@@ -8,9 +8,9 @@ struct pppYmMoveCircle {
 
 struct pppYmMoveCircleStep {
     int m_graphId;
-    float m_angle;
     float m_angleStep;
     float m_angleStepStep;
+    float m_angleStepStepStep;
     float m_radius;
     float m_radiusStep;
     float m_radiusStepStep;

--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -51,8 +51,8 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
     PSVECSubtract((Vec*)(pppMngSt + 0x68), (Vec*)(pppMngSt + 0x58), &temp1);
     PSVECNormalize(&temp1, &temp1);
 
-    f32 angle = acosf(PSVECDotProduct(&temp2, &temp1));
-    work->m_angle = lbl_80330D90 * angle;
+    f64 angle = acos((f64)PSVECDotProduct(&temp2, &temp1));
+    work->m_angle = lbl_80330D90 * (f32)angle;
 
     if ((temp1.x <= lbl_80330D7C && temp1.z >= lbl_80330D7C) ||
         (temp1.x >= lbl_80330D7C && temp1.z >= lbl_80330D7C)) {
@@ -97,17 +97,18 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
 
     work->m_radiusStep += work->m_radiusStepStep;
     work->m_radius += work->m_radiusStep;
+    work->m_angleStepStep += work->m_angleStepStepStep;
     work->m_angleStep += work->m_angleStepStep;
-    work->m_angle += work->m_angleStep;
 
     if (stepData->m_graphId == basePtr->m_graphId) {
         work->m_radius += stepData->m_radius;
         work->m_radiusStep += stepData->m_radiusStep;
         work->m_radiusStepStep += stepData->m_radiusStepStep;
-        work->m_angle += stepData->m_angle;
         work->m_angleStep += stepData->m_angleStep;
         work->m_angleStepStep += stepData->m_angleStepStep;
+        work->m_angleStepStepStep += stepData->m_angleStepStepStep;
     }
+    work->m_angle += work->m_angleStep;
 
     if (work->m_angle > lbl_80330D78) {
         work->m_angle -= lbl_80330D78;


### PR DESCRIPTION
## Summary
- Corrected `pppYmMoveCircleStep` layout to include `m_angleStepStepStep` at the serialized offset used by `pppFrameYmMoveCircle`.
- Updated `pppFrameYmMoveCircle` accumulation order to match observed object behavior (`angleStepStep += angleStepStepStep`, then `angleStep += angleStepStep`, then apply to angle after conditional step injection).
- Switched `pppConstructYmMoveCircle` angle computation to use `acos` on `f64` input and cast back to `f32`.

## Functions Improved
- Unit: `main/pppYmMoveCircle`
- `pppFrameYmMoveCircle` (`560b`): **82.564285% -> 84.292854%**
- `pppConstructYmMoveCircle` (`300b`): 83.386665% (unchanged)

## Match Evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/pppYmMoveCircle -o /tmp/pppYmMoveCircle_after2.json`
- `pppFrameYmMoveCircle` gained ~1.73 percentage points with instruction alignment improvements around step accumulation and downstream angle use.

## Plausibility Rationale
- Changes align field semantics with observed contiguous step-accumulator data instead of compiler-coaxing temporaries.
- Updated frame logic reflects a plausible authored integration order for higher-order angular deltas feeding lower-order deltas each frame.
- Constructor change uses a standard double-precision `acos` path with explicit cast back to stored float angle.

## Technical Notes
- Build passes with `ninja`.
- Improvement is isolated to source-plausible data/flow corrections in `pppYmMoveCircle` without analysis artifacts.
