### PR TITLE
exi: improve SetExiInterruptMask match shape

### DIFF
--- a/src/exi/EXIBios.c
+++ b/src/exi/EXIBios.c
@@ -39,7 +39,8 @@ static int __EXIProbe(s32 chan);
 
 static void SetExiInterruptMask(s32 chan, EXIControl* exi) {
     EXIControl* exi2;
-    exi2 = &Ecb[2];
+    exi2 = Ecb;
+    exi2 += 2;
 
     switch (chan) {
     case 0:


### PR DESCRIPTION
## Summary
- Updated `SetExiInterruptMask` in `src/exi/EXIBios.c` to use a two-step pointer expression (`exi2 = Ecb; exi2 += 2;`) instead of direct indexing.
- This keeps behavior identical while changing codegen shape in a way that better matches the original binary.

## Functions Improved
- Unit: `main/exi/EXIBios`
- Function: `SetExiInterruptMask`
  - Before: `89.91803%`
  - After: `90.72131%`
  - Delta: `+0.80328%`

## Match Evidence
- Objdiff command: `build/tools/objdiff-cli diff -p . -u main/exi/EXIBios -o -`
- `.text` section match for `EXIBios.o`:
  - Before: `68.60846%`
  - After: `68.63807%`
  - Delta: `+0.02961%`
- Symbol-level comparison shows only `SetExiInterruptMask` changed, with a positive delta.

## Plausibility Rationale
- The change is source-plausible C pointer arithmetic and does not introduce contrived temporaries, magic offsets, or non-idiomatic sequencing.
- Runtime behavior is unchanged; this is a code-shape refinement for closer compiler output alignment.

## Technical Details
- The previous direct `&Ecb[2]` form compiled to a slightly different address calculation pattern.
- Splitting the expression into base-pointer initialization plus increment produced a closer instruction sequence in `SetExiInterruptMask` according to objdiff.
