### PR TITLE
pppYmLaser: align created trail position stores in frame

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -315,8 +315,10 @@ extern "C" void pppFrameYmLaser(void* pppYmLaser, void* param_2, void* param_3)
 				}
 
 				if (created != 0) {
-					*(Vec*)(created + *(int*)step->m_payload + 0x80) = points[i];
-					*(float*)(created + *(int*)step->m_payload + 0x84) += *(float*)(step->m_payload + 0x34);
+					Vec* createdPos = (Vec*)(created + *(int*)step->m_payload + 0x80);
+					createdPos->x = points[i].x;
+					createdPos->y = points[i].y + *(float*)(step->m_payload + 0x34);
+					createdPos->z = points[i].z;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Updated `pppFrameYmLaser` in `src/pppYmLaser.cpp` to write spawned child position components explicitly (`x`, `y + offset`, `z`) instead of a full `Vec` copy followed by a separate `y` increment.
- This keeps behavior equivalent while producing a store sequence closer to the expected original codegen.

## Functions Improved
- Unit: `main/pppYmLaser`
- Function: `pppFrameYmLaser`
  - Before: `32.186543%`
  - After: `33.593273%`
  - Delta: `+1.406730%`
- Function checked for regression: `pppRenderYmLaser`
  - Before: `24.969416%`
  - After: `24.969416%` (unchanged)

## Match Evidence
- Rebuilt with `ninja` and compared per-function fuzzy match in `build/GCCP01/report.json`.
- Improvement is localized to the frame path where created particle/object position is emitted.

## Plausibility Rationale
- The new form is straightforward gameplay logic: spawn position is copied from trail point and Y is offset by payload height.
- This is more explicit and source-plausible than compiler-coaxing patterns, while preserving semantics.

## Technical Details
- Replaced:
  - `*(Vec*)(...) = points[i];`
  - `*(float*)(... + 0x84) += payloadY;`
- With direct component stores:
  - `x = points[i].x`
  - `y = points[i].y + payloadY`
  - `z = points[i].z`
- This reduces intermediate aliasing around the destination pointer and better matches expected store ordering in the target function.
