### PR TITLE
pppCrystal2: align work-area base offsets

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -99,7 +99,7 @@ void MakeRefractionMap(HSD_ImageBuffer*)
 void pppConstructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
 {
     s32 iVar1 = param_2->m_serializedDataOffsets[2];
-    u32* data = (u32*)((char*)pppCrystal2 + iVar1 + 8);
+    u32* data = (u32*)((char*)pppCrystal2 + iVar1 + 0x80);
 
     data[0] = 0;
     data[1] = 0;
@@ -149,7 +149,7 @@ void pppDestructCrystal2(pppCrystal2* pppCrystal2, UnkC* param_2)
 void pppFrameCrystal2(pppCrystal2* pppCrystal2, UnkB* param_2, UnkC* param_3)
 {
     if ((DAT_8032ed70 == 0) && (param_2->m_payload[0] != 0)) {
-        int* refractionData = (int*)((char*)pppCrystal2 + param_3->m_serializedDataOffsets[2] + 8);
+        int* refractionData = (int*)((char*)pppCrystal2 + param_3->m_serializedDataOffsets[2] + 0x80);
         if (refractionData[0] == 0) {
             u32 y;
             u32 x;


### PR DESCRIPTION
## Summary
- Aligned `pppConstructCrystal2` work-data base from `+8` to `+0x80`.
- Aligned `pppFrameCrystal2` refraction work pointer setup to the same `+0x80` base.
- Kept changes minimal and source-plausible (consistent with nearby ppp work-area usage patterns).

## Functions Improved
- Unit: `main/pppCrystal2`
- `pppConstructCrystal2`: **99.875% -> 100.0%**
- `pppFrameCrystal2`: **69.92641% -> 69.93073%** (report fuzzy)

## Match Evidence
- Unit fuzzy match: **56.088543% -> 56.092014%** (`main/pppCrystal2`).
- Global progress delta after rebuild:
  - Matched code bytes: **212532 -> 212564**
  - Matched functions: **1683 -> 1684**
- Objdiff (`main/pppCrystal2`, `pppConstructCrystal2`): now **100.0%** with matched instruction stream.

## Plausibility Rationale
- ppp effect code commonly stores runtime work blocks off a fixed object-local work area base (`0x80` region), then applies serialized offsets.
- The new offsets are consistent with that pattern and remove an isolated base-offset discrepancy, improving alignment without introducing contrived control flow.

## Technical Details
- Edited only `src/pppCrystal2.cpp`.
- No behavioral refactors; pointer-base correction only.
- Build verified with `ninja` and per-symbol verification via objdiff CLI (`v3.6.1`).
