### PR TITLE
mapanim: improve CMapAnim destructor matching

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -512,20 +512,17 @@ CMapAnim::CMapAnim()
 CMapAnim::~CMapAnim()
 {
     CPtrArray<CMapAnimNode*>* nodeArray = reinterpret_cast<CPtrArray<CMapAnimNode*>*>(this);
-    unsigned int i = 0;
+    unsigned int i;
 
-    while (i < static_cast<unsigned int>(nodeArray->m_numItems)) {
+    for (i = 0; i < static_cast<unsigned int>(nodeArray->GetSize()); i++) {
         CMapAnimNode* node = __vc__26CPtrArray_P12CMapAnimNode_FUl(this, i);
         if (node != 0 && (node = __vc__26CPtrArray_P12CMapAnimNode_FUl(this, i), node != 0)) {
             reinterpret_cast<int*>(node)[1] = 0;
             __dl__FPv(node);
         }
-        i++;
     }
 
-    nodeArray->RemoveAll();
-    nodeArray->m_vtable = lbl_801EA488;
-    nodeArray->RemoveAll();
+    nodeArray->~CPtrArray<CMapAnimNode*>();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CMapAnim::~CMapAnim()` to more closely follow original source structure.
- Switched the node cleanup loop to use `GetSize()` in the loop condition.
- Replaced manual `RemoveAll`/vtable reset sequence with a direct `CPtrArray<CMapAnimNode*>` destructor call.

## Functions improved
- Unit: `main/mapanim`
- Function: `__dt__8CMapAnimFv` (PAL 0x8004a8b0, 192b)

## Match evidence
- `__dt__8CMapAnimFv`: **57.6875% -> 77.270836%** (`build/GCCP01/report.json` fuzzy match)
- Unit `main/mapanim`: **82.125595% -> 83.239334%**
- `ninja` completed successfully and regenerated report.

## Plausibility rationale
- Calling the array destructor directly is a natural C++ source-level pattern and aligns with expected class ownership semantics.
- Using `GetSize()` for loop bounds matches idiomatic usage of the container API and the decompilation flow.
- No contrived temporaries or compiler-coaxing constructs were introduced.

## Technical details
- The updated destructor shape aligns better with the target flow that cleans child nodes, then destructs the `CPtrArray` member.
- This removes a manual vtable reset/removal pattern that was likely diverging from original source and codegen.
