### PR TITLE
Improve pppRyjMegaBirthCon match in pppRyjMegaBirth

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -492,19 +492,21 @@ void pppRyjDrawMegaBirth(void)
  */
 void pppRyjMegaBirthCon(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
 {
-	u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2]);
+	Vec axis;
 
-	PSMTXIdentity(*(Mtx*)work);
-	*(f32*)(work + 0x30) = 0.0f;
-	*(f32*)(work + 0x34) = 0.0f;
-	*(f32*)(work + 0x38) = 0.0f;
-	*(void**)(work + 0x3C) = 0;
-	*(void**)(work + 0x40) = 0;
-	*(void**)(work + 0x44) = 0;
-	*(void**)(work + 0x48) = 0;
-	*(u16*)(work + 0x4C) = 0;
-	*(u16*)(work + 0x4E) = 0;
-	*(u16*)(work + 0x4C) = 10000;
+	PSMTXIdentity(work->m_worldMatrix);
+	axis.x = 0.0f;
+	axis.y = 0.0f;
+	axis.z = 0.0f;
+	work->m_accelerationAxis = axis;
+	work->m_particleBlock = 0;
+	work->m_worldMatrixBlock = 0;
+	work->m_colorBlock = 0;
+	work->m_meshData = 0;
+	work->m_numParticles = 0;
+	work->m_emitTimer = 0;
+	work->m_numParticles = 10000;
 
 	PSMTXIdentity(g_matUnit);
 }


### PR DESCRIPTION
## Summary
- Reworked `pppRyjMegaBirthCon` initialization to use the concrete `VRyjMegaBirth` layout instead of repeated byte-offset stores.
- Initialized the acceleration axis through a local `Vec` aggregate and assigned it to `m_accelerationAxis`.
- Kept behavior and field values identical (identity matrix, zeroed pointers/counters, `m_numParticles = 10000`, identity `g_matUnit`).

## Functions improved
- Unit: `main/pppRyjMegaBirth`
- Symbol: `pppRyjMegaBirthCon`

## Match evidence
- `pppRyjMegaBirthCon`: **99.77419% -> 99.83871%**
- Objdiff mismatch kinds reduced from:
  - Before: `DIFF_ARG_MISMATCH, DIFF_ARG_MISMATCH, DIFF_ARG_MISMATCH`
  - After: `DIFF_ARG_MISMATCH`
- Build check: `ninja` passes after the change.

## Plausibility rationale
- The new code expresses the initialization through typed fields (`VRyjMegaBirth`) rather than ad-hoc byte offsets, which is consistent with plausible original source structure.
- No contrived temporaries or artificial control-flow changes were introduced; this is a straightforward representation change that preserves semantics.

## Technical details
- The key improvement came from changing scalar axis writes to aggregate assignment (`Vec` local -> `m_accelerationAxis`), which tightened store argument alignment in generated code.
- Remaining mismatch is a single argument-level difference in objdiff for this symbol.
