### PR TITLE
Decompile CPartPcs::LoadFieldPdt first pass

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -939,12 +939,37 @@ void LoadFieldPdt0(int, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800523f8
+ * PAL Size: 216b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CPartPcs::LoadFieldPdt(int, int, void*, unsigned long, unsigned char)
+void CPartPcs::LoadFieldPdt(int mapId, int floorId, void* amemBase, unsigned long loadCacheParam, unsigned char mode)
 {
-	// TODO
+    unsigned char* partMng = reinterpret_cast<unsigned char*>(&PartMng);
+
+    *reinterpret_cast<unsigned int*>(partMng + 0x236F4) = 0;
+    *reinterpret_cast<unsigned int*>(partMng + 0x23700) = 0;
+
+    if (loadCacheParam == 0) {
+        *reinterpret_cast<int*>(partMng + 0x236FC) = 0;
+    } else if (mode == 1) {
+        *reinterpret_cast<int*>(partMng + 0x236FC) = 2;
+    } else if (mode == 2) {
+        *reinterpret_cast<int*>(partMng + 0x236FC) = 3;
+        for (int i = 0; i < 0x10; i++) {
+            *reinterpret_cast<int*>(partMng + 0x2370C + (i * 4)) = 0;
+        }
+    } else {
+        *reinterpret_cast<int*>(partMng + 0x236FC) = 1;
+    }
+
+    *reinterpret_cast<void**>(partMng + 0x236E8) = amemBase;
+    *reinterpret_cast<void**>(partMng + 0x236EC) = amemBase;
+    *reinterpret_cast<unsigned long*>(partMng + 0x23704) = loadCacheParam;
+    LoadFieldPdt0(mapId, floorId);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented a first-pass decompilation of `CPartPcs::LoadFieldPdt` in `src/p_tina.cpp` using existing `PartMng` raw-offset conventions already present in this unit.

Changes include:
- setting part loading state/counters before load dispatch
- selecting load mode from `(loadCacheParam, mode)` as in the original control flow
- clearing async busy slots for mode `2`
- setting AMEM base/cursor and cache parameter
- dispatching to `LoadFieldPdt0(mapId, floorId)`
- adding PAL address/size metadata to the function comment block

## Functions improved
- Unit: `main/p_tina`
- Symbol: `LoadFieldPdt__8CPartPcsFiiPvUlUc`

## Match evidence
Objdiff symbol score improved from **1.8518518%** to **36.01852%** for `LoadFieldPdt__8CPartPcsFiiPvUlUc` (216 bytes).

Command used:
- `../tools/objdiff-cli diff -p . -u main/p_tina -o - LoadFieldPdt__8CPartPcsFiiPvUlUc`

## Plausibility rationale
This change follows existing source style in `p_tina.cpp` and nearby `PartMng` code:
- uses the same raw-offset access pattern already used for PartMng fields in this file
- preserves straightforward game-logic control flow (no contrived temporaries/reordering)
- performs initialization and mode handling in a way consistent with asynchronous part-load bookkeeping used elsewhere in the codebase

## Technical notes
- The implementation was derived from the Ghidra reference (`800523f8_LoadFieldPdt__8CPartPcsFiiPvUlUc.c`) but adapted to current decomp conventions and existing typed/untyped field access in this unit.
- Build verification: `ninja` passes after the change (`build/GCCP01/report.json` regenerated successfully).
