### PR TITLE
RedDriver: implement _EntryExecCommand queue writer

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -606,12 +606,41 @@ void _StreamPause(int* param_1)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bdb10
+ * PAL Size: 192b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _EntryExecCommand(void (*) (int*), int, int, int, int, int, int, int)
+void _EntryExecCommand(void (*command)(int*), int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6)
 {
-	// TODO
+    unsigned int interrupt;
+    int* entry;
+    int* nextEntry;
+    int* begin;
+
+    interrupt = OSDisableInterrupts();
+
+    entry = (int*)DAT_8032f3d8;
+    entry[0] = (int)command;
+    entry[1] = arg0;
+    entry[2] = arg1;
+    entry[3] = arg2;
+    entry[4] = arg3;
+    entry[5] = arg4;
+    entry[6] = arg5;
+    entry[7] = arg6;
+
+    begin = (int*)DAT_8032f3d4;
+    nextEntry = entry + 8;
+    if (nextEntry == begin + 0x800) {
+        nextEntry = begin;
+    }
+
+    DAT_8032f3d8 = nextEntry;
+
+    OSRestoreInterrupts(interrupt);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `_EntryExecCommand__FPFPi_viiiiiii` in `src/RedSound/RedDriver.cpp`
- Added PAL metadata comment (`0x801bdb10`, `192b`)
- Implemented interrupt-guarded command queue write and ring-wrap update for `DAT_8032f3d8`

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `_EntryExecCommand__FPFPi_viiiiiii` (PAL size: `192b`)

## Match evidence
- Before: `2.0833333%`
- After: `36.541668%`
- Delta: `+34.4583347%`
- Verification command:
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - _EntryExecCommand__FPFPi_viiiiiii`

## Plausibility rationale
- The new function body matches an idiomatic producer-side ring-buffer enqueue used elsewhere in this module.
- It uses `OSDisableInterrupts`/`OSRestoreInterrupts` around shared queue state updates, which is a natural original-source synchronization pattern for this codebase.
- Control flow and data movement are straightforward and source-plausible (no contrived temporaries or artificial reorderings).

## Technical details
- Writes callback pointer + 7 integer arguments into an 8-word command slot.
- Advances write cursor by 8 words.
- Wraps to queue base when reaching `base + 0x800` entries.
- Stores the new cursor back into `DAT_8032f3d8`.
