### PR TITLE
os/OS: enable __GEKKO__ path for exception vector and PS init

### DIFF
--- a/src/os/OS.c
+++ b/src/os/OS.c
@@ -8,6 +8,10 @@
 
 #define NOP 0x60000000
 
+#ifndef __GEKKO__
+#define __GEKKO__
+#endif
+
 // external functions
 extern void EnableMetroTRKInterrupts(void);
 extern void __OSInitMemoryProtection(void);


### PR DESCRIPTION
## Summary
- Define `__GEKKO__` in `src/os/OS.c` when it is not already defined.
- This aligns the file’s conditional assembly blocks with current build flags (`-DGEKKO`), allowing the intended exception-vector and paired-single init code paths to compile in this unit.

## Functions improved
- Unit: `main/os/OS`
- `OSExceptionVector`: 0.0% -> 100.0% (156b)
- `OSDefaultExceptionHandler`: 0.0% -> 100.0% (88b)
- `__OSPSInit`: 0.0% -> 100.0% (84b)

## Match evidence
- Before (selector output): `main/os/OS` reported 9/15 matched functions (60.0%) and these three symbols at 0.0%.
- After (`ninja` report + objdiff): `main/os/OS` is now 12/15 matched functions (80.0%), and objdiff shows all three above at 100.0%.

## Plausibility rationale
- This is not compiler coaxing; it restores the intended SDK-gated code path for Gekko-specific assembly in this translation unit.
- The change is minimal, readable, and consistent with existing project style (same fallback define pattern already used in `src/os/OSCache.c`).

## Technical details
- Build currently defines `GEKKO` but not `__GEKKO__`.
- `src/os/OS.c` used `#ifdef __GEKKO__` around key asm functions, so they were omitted previously and stayed unmatched.
- The fallback define enables those symbols to compile with correct names/sizes and full instruction matches.
