### PR TITLE
main/pppYmMelt: fix YmMeltCtrl field widths for better matching

### DIFF
--- a/include/ffcc/pppYmMelt.h
+++ b/include/ffcc/pppYmMelt.h
@@ -28,10 +28,10 @@ struct PYmMeltDataOffsets {
 
 struct YmMeltCtrl {
     s32 m_graphId;
-    u16 m_dataValIndex;
-    u16 m_initWOrk;
+    s32 m_dataValIndex;
+    s32 m_initWOrk;
     f32 m_stepValue;
-    f32 m_arg3;
+    s32 m_arg3;
     u8 m_payload[0x20];
 };
 


### PR DESCRIPTION
## Summary
- Adjusted YmMeltCtrl field widths in include/ffcc/pppYmMelt.h to better match observed access patterns in pppFrameYmMelt/pppRenderYmMelt.
- Changed:
  - m_dataValIndex: u16 -> s32
  - m_initWOrk: u16 -> s32
  - m_arg3: f32 -> s32

## Functions Improved
- Unit: main/pppYmMelt
- pppFrameYmMelt: 65.382355 -> 66.55294
- pppRenderYmMelt: 43.484848 -> 43.53613

## Match Evidence
- Build passes with ninja.
- Objdiff commands used:
  - build/tools/objdiff-cli diff -p . -u main/pppYmMelt -o - pppFrameYmMelt
  - build/tools/objdiff-cli diff -p . -u main/pppYmMelt -o -
- pppFrameYmMelt diff characteristics moved toward target (fewer replace/delete ops, higher score).

## Plausibility Rationale
- This is a type/layout correction rather than compiler coaxing.
- The new widths align with mixed packed/word control data usage patterns in nearby particle control code.
- Improvement appears in multiple functions in the same unit with no readability degradation.

## Technical Details
- Main issue was field width mismatch causing offset/register divergence in generated code.
- Correcting control struct layout reduced divergence while keeping code source-plausible.
