### PR TITLE
Decompile pppRyjMegaBirthModel frame entrypoint

### DIFF
--- a/include/ffcc/pppRyjMegaBirthModel.h
+++ b/include/ffcc/pppRyjMegaBirthModel.h
@@ -29,7 +29,7 @@ void set_matrix(_pppPObject*, pppFMATRIX, pppFMATRIX, PRyjMegaBirthModel*, _PART
 extern "C" {
 #endif
 
-void pppRyjMegaBirthModel(void);
+void pppRyjMegaBirthModel(_pppPObject*, PRyjMegaBirthModel*, PRyjMegaBirthModelOffsets*);
 void pppRyjDrawMegaBirthModel(void);
 void pppRyjMegaBirthModelCon(_pppPObject*, PRyjMegaBirthModelOffsets*);
 void pppRyjMegaBirthModelDes(_pppPObject*, PRyjMegaBirthModelOffsets*);

--- a/src/pppRyjMegaBirthModel.cpp
+++ b/src/pppRyjMegaBirthModel.cpp
@@ -1,9 +1,12 @@
 #include "ffcc/pppRyjMegaBirthModel.h"
 #include <string.h>
 
+extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 extern float FLOAT_80330498;
 extern float FLOAT_8033049c;
+
+static char s_pppRyjMegaBirthModel_cpp_801d9c18[] = "pppRyjMegaBirthModel.cpp";
 
 /*
  * --INFO--
@@ -37,12 +40,70 @@ void alloc_check(VRyjMegaBirthModel*, PRyjMegaBirthModel*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80087ce8
+ * PAL Size: 520b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppRyjMegaBirthModel(void)
+void pppRyjMegaBirthModel(_pppPObject* pObject, PRyjMegaBirthModel* params, PRyjMegaBirthModelOffsets* offsets)
 {
-	// TODO
+    bool hasRequiredMemory;
+    s32 colorOffset = offsets->m_serializedDataOffsets[1];
+    u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+    u8* payload = (u8*)params;
+
+    if (*(void**)(work + 0xC) == 0) {
+        *(u32*)(work + 0x18) = *(u16*)(payload + 0x20);
+        *(void**)(work + 0xC) = pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            *(u32*)(work + 0x18) * 0xA0, pppEnvStPtr->m_stagePtr, s_pppRyjMegaBirthModel_cpp_801d9c18, 0x8D);
+        if (*(void**)(work + 0xC) != 0) {
+            memset(*(void**)(work + 0xC), 0, *(u32*)(work + 0x18) * 0xA0);
+        }
+
+        if (*(u8*)(payload + 0x136) != 0) {
+            *(void**)(work + 0x10) = pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                *(u32*)(work + 0x18) * 0x30, pppEnvStPtr->m_stagePtr, s_pppRyjMegaBirthModel_cpp_801d9c18, 0x97);
+            if (*(void**)(work + 0x10) != 0) {
+                memset(*(void**)(work + 0x10), 0, *(u32*)(work + 0x18) * 0x30);
+            }
+        }
+
+        if (*(u8*)(payload + 0x131) != 0) {
+            *(void**)(work + 0x14) = pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                *(u32*)(work + 0x18) << 5, pppEnvStPtr->m_stagePtr, s_pppRyjMegaBirthModel_cpp_801d9c18, 0xA2);
+            if (*(void**)(work + 0x14) != 0) {
+                memset(*(void**)(work + 0x14), 0, *(u32*)(work + 0x18) << 5);
+            }
+        }
+
+        *(float*)(work + 0x0) = *(float*)(payload + 0xF8);
+        *(float*)(work + 0x4) = *(float*)(payload + 0xFC);
+        *(float*)(work + 0x8) = *(float*)(payload + 0x100);
+        PSVECNormalize((Vec*)(work + 0x0), (Vec*)(work + 0x0));
+
+        *(float*)(work + 0x20) = pObject->m_localMatrix.value[0][3];
+        *(float*)(work + 0x24) = pObject->m_localMatrix.value[1][3];
+        *(float*)(work + 0x28) = pObject->m_localMatrix.value[2][3];
+        *(float*)(work + 0x2C) = pObject->m_localMatrix.value[0][3];
+        *(float*)(work + 0x30) = pObject->m_localMatrix.value[1][3];
+        *(float*)(work + 0x34) = pObject->m_localMatrix.value[2][3];
+    }
+
+    if (*(void**)(work + 0xC) == 0) {
+        hasRequiredMemory = false;
+    } else if ((*(u8*)(payload + 0x136) != 0) && (*(void**)(work + 0x10) == 0)) {
+        hasRequiredMemory = false;
+    } else if ((*(u8*)(payload + 0x131) == 0) || (*(void**)(work + 0x14) != 0)) {
+        hasRequiredMemory = true;
+    } else {
+        hasRequiredMemory = false;
+    }
+
+    if (hasRequiredMemory) {
+        calc_particle(pObject, (VRyjMegaBirthModel*)work, params, (VColor*)((u8*)pObject + 0x80 + colorOffset));
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `pppRyjMegaBirthModel` with its recovered 3-argument signature and frame-time setup flow.
- Added the missing PAL metadata block for the function.
- Added local file-label string and allocator extern used by the function's allocation path.

## Functions improved
- Unit: `main/pppRyjMegaBirthModel`
- Function: `pppRyjMegaBirthModel` (`src/pppRyjMegaBirthModel.cpp`)

## Match evidence
- Before: `0.7692308%` (`report.json` fuzzy match for `pppRyjMegaBirthModel`)
- After: `90.7%` (`report.json` fuzzy match for `pppRyjMegaBirthModel`)
- Objdiff oneshot validation: `90.238464%` for `pppRyjMegaBirthModel`

## Technical details
- Matched recovered object layout usage at `work = pObject + 0x80 + serializedOffset[2]`.
- Recreated allocation/memory-zero paths and guard checks with recovered field offsets:
  - particle count at `params + 0x20`
  - world-matrix flag at `params + 0x136`
  - color block flag at `params + 0x131`
  - normalized direction vector source at `params + 0xF8/0xFC/0x100`
- Reconnected `calc_particle(...)` dispatch with color payload at `pObject + 0x80 + serializedOffset[1]`.

## Plausibility rationale
- The implementation follows existing FFCC particle code patterns used in adjacent units (allocator callsite style, staged optional block allocation, and per-frame guard dispatch), rather than introducing artificial compiler-coaxing constructs.
- Control flow and data movement were reconstructed to mirror the original instruction sequence directly, including condition ordering and block initialization behavior.
