### PR TITLE
materialman: improve CPtrArray<CMaterial*>::setSize match

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1,6 +1,7 @@
 #include "ffcc/materialman.h"
 #include "ffcc/pad.h"
 #include "ffcc/chunkfile.h"
+#include "ffcc/system.h"
 #include "ffcc/textureman.h"
 #include "ffcc/vector.h"
 
@@ -117,6 +118,7 @@ static void ReleaseRef(void* object)
 
 static char s_materialman_cpp[] = "materialman.cpp";
 static char s_collection_ptrarray_h[] = "collection_ptrarray.h";
+static char s_ptrarray_grow_error[] = "CPtrArray grow error";
 
 struct RawPtrArray {
     void** vtable;
@@ -230,25 +232,31 @@ void CPtrArray<CMaterial*>::SetStage(CMemory::CStage* stage)
 template <>
 int CPtrArray<CMaterial*>::Add(CMaterial* item)
 {
-    int result = setSize(m_numItems + 1);
-    if (result != 0) {
-        m_items[m_numItems] = item;
-        m_numItems = m_numItems + 1;
+    if (setSize(m_numItems + 1) == 0) {
+        return 0;
     }
-    return result != 0;
+
+    m_items[m_numItems] = item;
+    m_numItems = m_numItems + 1;
+    return 1;
 }
 
 template <>
 int CPtrArray<CMaterial*>::setSize(unsigned long size)
 {
+    CMaterial** newItems;
+
     if (m_size < size) {
         if (m_size == 0) {
             m_size = m_defaultSize;
         } else {
+            if (m_growCapacity == 0) {
+                System.Printf(s_ptrarray_grow_error);
+            }
             m_size = m_size << 1;
         }
 
-        void** newItems = reinterpret_cast<void**>(
+        newItems = reinterpret_cast<CMaterial**>(
             _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
                 &Memory,
                 m_size << 2,
@@ -267,7 +275,7 @@ int CPtrArray<CMaterial*>::setSize(unsigned long size)
             __dla__FPv(m_items);
             m_items = 0;
         }
-        m_items = reinterpret_cast<CMaterial**>(newItems);
+        m_items = newItems;
     }
     return 1;
 }


### PR DESCRIPTION
## Summary
- Updated `CPtrArray<CMaterial*>::setSize` in `src/materialman.cpp` to follow the project's existing ptrarray growth pattern.
- Added explicit grow-capacity guard logging (`System.Printf("CPtrArray grow error")`) before doubling size.
- Kept allocation/copy/free flow equivalent but simplified pointer typing to `CMaterial**` through the function.
- Rewrote `CPtrArray<CMaterial*>::Add` return path to explicit `0/1` style.

## Functions Improved
- Unit: `main/materialman`
- Function: `setSize__22CPtrArray<P9CMaterial>FUl`

## Match Evidence
- `setSize__22CPtrArray<P9CMaterial>FUl`: **75.75% -> 92.15%**
- Instruction diff entries reduced: **30 -> 24**
- Build status: `ninja` completes and reports normally.

## Plausibility Rationale
- The change mirrors ptrarray behavior already used in this codebase (`mapanim.cpp`, `p_chara.cpp`), especially the grow-capacity warning path and doubling logic.
- No contrived compiler-only temporaries or non-idiomatic control flow were introduced.
- Resulting code remains readable and consistent with neighboring container implementations.

## Technical Details
- Added `#include "ffcc/system.h"` so the grow warning uses the existing `System.Printf` interface.
- Introduced local `s_ptrarray_grow_error` string constant (`"CPtrArray grow error"`) used by other ptrarray implementations.
- No build-flag or linker-script changes; improvement comes from source-level control-flow/data-flow alignment.
