### PR TITLE
monobj: implement CGMonObj::setAttackAfter

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -171,12 +171,47 @@ void CGMonObj::onStatAttack(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80119930
+ * PAL Size: 308b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGMonObj::setAttackAfter(int)
+void CGMonObj::setAttackAfter(int attackKind)
 {
-	// TODO
+	unsigned int delay = *reinterpret_cast<unsigned short*>(Game.game.unkCFlatData0[2] + attackKind * 0x48 + 0xA);
+	if (delay == 0xFFFF) {
+		delay = 0;
+	}
+
+	int stageRank = 0;
+	if (Game.game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
+		stageRank = Game.game.m_gameWork.m_bossArtifactStageTable[Game.game.m_gameWork.m_bossArtifactStageIndex];
+		if (2 < stageRank) {
+			stageRank = 2;
+		}
+	}
+
+	if (0 < stageRank) {
+		delay -= *reinterpret_cast<unsigned short*>(Game.game.unk_flat3_field_8_0xc7dc + stageRank * 2 + 0x58);
+		delay &= ~((int)delay >> 31);
+	}
+
+	if (delay == 0) {
+		reinterpret_cast<CGPrgObj*>(this)->changeStat(0, 0, 0);
+		return;
+	}
+
+	int range = (int)delay / 5 + ((int)delay >> 31);
+	range -= range >> 31;
+	if (range < 1) {
+		range = 1;
+	}
+
+	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
+	*reinterpret_cast<unsigned int*>(mon + 0x6F0) = delay + Math.Rand(range);
+	reinterpret_cast<CGPrgObj*>(this)->changeStat(0x11, 0, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGMonObj::setAttackAfter(int)` in `src/monobj.cpp`.
- Replaced TODO/stub behavior with gameplay-consistent attack-delay logic using artifact flat-data, stage modifiers, randomization, and state transitions.
- Added PAL metadata block for the function (`0x80119930`, `308b`) and left EN/JP as TODO per project convention.

## Functions improved
- Unit: `main/monobj`
- Symbol: `setAttackAfter__8CGMonObjFi`
- Current objdiff symbol match: `47.896103%` (size `308` bytes)

## Match evidence
- Build succeeded with `ninja` after the change.
- `objdiff` oneshot check:
  - `build/tools/objdiff-cli diff -p . -u main/monobj -o - setAttackAfter__8CGMonObjFi`
  - Result reports `CGMonObj::setAttackAfter(int)` at `47.896103%` match.

## Plausibility rationale
- The implementation follows existing game-code patterns already used in this codebase:
  - Reads timing data from `Game.game.unkCFlatData0[2]` records.
  - Applies boss-artifact stage scaling via `m_bossArtifactStageTable` and `unk_flat3_field_8_0xc7dc`.
  - Uses existing `Math.Rand` and `CGPrgObj::changeStat` transitions rather than artificial compiler-oriented constructs.
- The resulting code reflects expected gameplay logic (attack cooldown scheduling and state updates) rather than output-only coaxing.

## Technical details
- Handles `0xFFFF` delay sentinel as zero delay.
- Clamps stage rank to expected range (`<=2`) before applying flat-data subtraction.
- Uses signed clamp-to-zero after subtraction (`delay &= ~((int)delay >> 31)`) to mirror decomp behavior.
- For positive delay:
  - Computes random range from delay (`delay / 5`, minimum 1).
  - Stores cooldown at object offset `0x6F0`.
  - Transitions to state `0x11`.
- For zero delay:
  - Transitions directly to state `0`.
