### PR TITLE
mapobj: match collision wrapper functions and slide return ABI

### DIFF
--- a/include/ffcc/maphit.h
+++ b/include/ffcc/maphit.h
@@ -48,7 +48,7 @@ public:
     void ReadOtmHit(CChunkFile&);
     int CheckHitFaceCylinder(unsigned long);
     void GetHitFaceNormal(Vec*);
-    void CalcHitSlide(Vec*, float);
+    int CalcHitSlide(Vec*, float);
     void CalcHitPosition(Vec*);
     int CheckHitCylinder(CMapCylinder*, Vec*, unsigned long);
     int CheckHitCylinder(CMapCylinder*, Vec*, unsigned short, unsigned short, unsigned long);

--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -90,7 +90,7 @@ public:
     int CheckHitCylinder(CMapCylinder*, Vec*, unsigned long);
     int CheckHitCylinderNear(CMapCylinder*, Vec*, unsigned long);
     void GetHitFaceNormal(Vec*);
-    void CalcHitSlide(Vec*, float);
+    int CalcHitSlide(Vec*, float);
     void CalcHitPosition(Vec*);
     void SetMime(int, int, int);
     void SetCalcMtx();

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -495,7 +495,7 @@ void CMapHit::GetHitFaceNormal(Vec* out)
  * Address:	TODO
  * Size:	TODO
  */
-void CMapHit::CalcHitSlide(Vec* out, float y)
+int CMapHit::CalcHitSlide(Vec* out, float y)
 {
     if (s_hit_edge_index == -1) {
         if (s_hit_face_min != 0 && y <= s_hit_face_min->m_boundsMin.y) {
@@ -507,13 +507,14 @@ void CMapHit::CalcHitSlide(Vec* out, float y)
                 out->y = 0.0f;
                 out->z = 0.0f;
             }
-            return;
+            return 0;
         }
     }
 
     out->x = 0.0f;
     out->y = 0.0f;
     out->z = 0.0f;
+    return 1;
 }
 
 /*

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -856,32 +856,51 @@ int CMapObj::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned lo
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800288a8
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapObj::GetHitFaceNormal(Vec*)
+void CMapObj::GetHitFaceNormal(Vec* out)
 {
-	// TODO
+    CMapHit* mapHit = reinterpret_cast<CMapHit*>(PtrAt(this, 0xC));
+    mapHit->GetHitFaceNormal(out);
+    PSMTXMultVecSR(MtxAt(this, 0xB8), out, out);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8002884c
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapObj::CalcHitSlide(Vec*, float)
+int CMapObj::CalcHitSlide(Vec* out, float y)
 {
-	// TODO
+    CMapHit* mapHit = reinterpret_cast<CMapHit*>(PtrAt(this, 0xC));
+    int hit = mapHit->CalcHitSlide(out, y);
+    PSMTXMultVecSR(MtxAt(this, 0xB8), out, out);
+    return hit;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80028800
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMapObj::CalcHitPosition(Vec*)
+void CMapObj::CalcHitPosition(Vec* out)
 {
-	// TODO
+    CMapHit* mapHit = reinterpret_cast<CMapHit*>(PtrAt(this, 0xC));
+    mapHit->CalcHitPosition(out);
+    PSMTXMultVec(MtxAt(this, 0xB8), out, out);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented three previously stubbed `CMapObj` collision wrapper methods using `CMapHit` calls plus correct world-space transform calls.
- Added full PAL metadata blocks for the implemented mapobj functions.
- Corrected `CalcHitSlide` return type in `CMapObj`/`CMapHit` declarations and definitions to match observed ABI usage (returning hit-state from `CMapHit::CalcHitSlide`).

## Functions improved
- `CalcHitPosition__7CMapObjFP3Vec` (`main/mapobj`)
- `GetHitFaceNormal__7CMapObjFP3Vec` (`main/mapobj`)
- `CalcHitSlide__7CMapObjFP3Vecf` (`main/mapobj`)

## Match evidence
Objdiff before/after for target symbols:
- `CalcHitPosition__7CMapObjFP3Vec`: `5.263158% -> 100.0%`
- `GetHitFaceNormal__7CMapObjFP3Vec`: `5.263158% -> 100.0%`
- `CalcHitSlide__7CMapObjFP3Vecf`: `4.347826% -> 100.0%`

Build/progress delta observed from `ninja`:
- Matched functions: `1689 -> 1692`
- Matched code bytes: `212760 -> 213004`

## Plausibility rationale
- These wrappers are straightforward object-space/world-space bridge functions and the resulting source is idiomatic for this codebase: invoke `CMapHit` in local hit space, then transform vectors by object matrix (`PSMTXMultVec`/`PSMTXMultVecSR`).
- Return type correction for `CalcHitSlide` is source-plausible and ABI-consistent with the generated wrapper assembly shape (forwarding and returning the callee result).
