### PR TITLE
memory: implement CMemory::HeapWalker

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -20,11 +20,17 @@ extern char DAT_801d6bb0[];
 extern char DAT_801d6c58[];
 extern char DAT_801d6c88[];
 extern char DAT_801d6c98[];
+extern char s____Heap_Walker_801d6bfc[];
+extern char s_Use____5dKB__s_801d6c0c[];
+extern char s_Unuse___5dKB_801d6c20[];
+extern char s_Total___5dKB_Use___5dKB_Unuse____801d6c30[];
 extern char DAT_801d669c[];
 extern char DAT_801d67d8[];
 extern char DAT_801d6bdc[];
 extern char DAT_801d6bec[];
 extern char DAT_8032f7d4[];
+extern char DAT_8032f7e8[];
+extern char DAT_8032f808[];
 extern float FLOAT_8032f7d8;
 extern float FLOAT_8032f7dc;
 extern float FLOAT_8032f7fc;
@@ -500,12 +506,62 @@ void CMemory::Frame()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001EF90
+ * PAL Size: 392b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMemory::HeapWalker()
 {
-	// TODO
+    Printf__7CSystemFPce(&System, DAT_8032f7e8);
+    Printf__7CSystemFPce(&System, DAT_8032f808);
+    Printf__7CSystemFPce(&System, s____Heap_Walker_801d6bfc);
+    Printf__7CSystemFPce(&System, DAT_8032f808);
+
+    unsigned char* listHead = reinterpret_cast<unsigned char*>(this) + 4;
+    for (int mode = 0; mode < 3; mode++) {
+        if ((mode != 1) || (OSGetConsoleSimulatedMemSize() == 0x3000000)) {
+            CStage* head = reinterpret_cast<CStage*>(listHead);
+            CStage* stage = *reinterpret_cast<CStage**>(listHead + 4);
+            while (stage != head) {
+                stage->heapWalker(-1, nullptr, static_cast<unsigned long>(-1));
+                stage = *reinterpret_cast<CStage**>(reinterpret_cast<unsigned char*>(stage) + 4);
+            }
+
+            Printf__7CSystemFPce(&System, DAT_8032f7e8);
+            stage = *reinterpret_cast<CStage**>(listHead + 4);
+
+            int useTotalKB = 0;
+            int unuseTotalKB = 0;
+            while (stage != head) {
+                unsigned int useKB = static_cast<unsigned int>(
+                    (*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 0xC) -
+                     *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 8)) >>
+                    10);
+                Printf__7CSystemFPce(
+                    &System, s_Use____5dKB__s_801d6c0c, useKB,
+                    reinterpret_cast<char*>(reinterpret_cast<unsigned char*>(stage) + 0x10));
+                useTotalKB += static_cast<int>(useKB);
+
+                unsigned int unuseKB = static_cast<unsigned int>(
+                    (*reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 4) + 8) -
+                     *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 0xC)) >>
+                    10);
+                Printf__7CSystemFPce(&System, s_Unuse___5dKB_801d6c20, unuseKB);
+                unuseTotalKB += static_cast<int>(unuseKB);
+
+                stage = *reinterpret_cast<CStage**>(reinterpret_cast<unsigned char*>(stage) + 4);
+            }
+
+            Printf__7CSystemFPce(
+                &System, s_Total___5dKB_Use___5dKB_Unuse____801d6c30, useTotalKB + unuseTotalKB,
+                useTotalKB, unuseTotalKB);
+        }
+
+        listHead += 0x27D8;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMemory::HeapWalker()` in `src/memory.cpp` from the PAL decomp reference.
- Added missing string/format extern declarations used by the function.
- Updated the function info header with PAL address/size metadata.

## Functions improved
- Unit: `main/memory`
- Symbol: `HeapWalker__7CMemoryFv` (`CMemory::HeapWalker()`)

## Match evidence
- Before: `1.0%` (from `tools/agent_select_target.py` output for `main/memory`)
- After: `63.52041%` (`build/tools/objdiff-cli diff -p . -u main/memory -o - HeapWalker__7CMemoryFv`)
- Function size: `392b`

## Plausibility rationale
- The implementation follows normal engine-style stage-list traversal and per-mode reporting logic, with no contrived temporaries or compiler-only coercions.
- It reuses existing object layout conventions already used across `memory.cpp` (field offsets and list linkage) and delegates detailed per-stage output to existing `CStage::heapWalker()`.

## Technical details
- Prints the same report preamble and per-mode separators as the reference.
- Preserves the PAL mode-1 memory-size gate (`OSGetConsoleSimulatedMemSize() == 0x3000000`).
- Computes and prints per-stage `Use/Unuse` totals in KB, then aggregated totals per mode.
