### PR TITLE
pppLaser: improve pppRenderLaser matrix composition match

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -375,9 +375,6 @@ void pppRenderLaser(struct pppLaser *pppLaser, struct UnkB *param_2, struct UnkC
     float u0;
     float u1;
     float uvStep;
-    pppFMATRIX localMtx;
-    pppFMATRIX worldMtx;
-    pppFMATRIX viewMtx;
     pppFMATRIX modelView;
     pppFMATRIX mtxOut;
     pppFMATRIX shapeMtx;
@@ -416,11 +413,8 @@ void pppRenderLaser(struct pppLaser *pppLaser, struct UnkB *param_2, struct UnkC
     halfWidth = work[4];
     length = work[0];
 
-    localMtx = baseObj->m_localMatrix;
-    worldMtx = pppMngStPtr->m_matrix;
-    pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &worldMtx, &localMtx);
-    viewMtx = *(pppFMATRIX*)&ppvCameraMatrix0;
-    pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&mtxOut, &viewMtx, &modelView);
+    pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &pppMngStPtr->m_matrix, &baseObj->m_localMatrix);
+    pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&mtxOut, (pppFMATRIX*)&ppvCameraMatrix0, &modelView);
     GXLoadPosMtxImm(mtxOut.value, 0);
 
     GXBegin(GX_QUADS, GX_VTXFMT7, 4);


### PR DESCRIPTION
## Summary
- Simplified matrix composition in `pppRenderLaser` by removing temporary matrix copies (`localMtx`, `worldMtx`, `viewMtx`).
- Kept behavior identical while composing model/view matrices directly from `baseObj`, `pppMngStPtr`, and `ppvCameraMatrix0`.

## Functions improved
- `main/pppLaser` -> `pppRenderLaser` (PAL size 3008b)

## Match evidence
- `pppRenderLaser`: 24.50133% -> 34.20213%
- Unit `.text` (`main/pppLaser`): 37.281677% -> 43.16949%
- Objdiff instruction alignment improved with fewer inserts in this symbol:
  - `DIFF_INSERT`: 290 -> 217

## Plausibility rationale
- This change removes unnecessary local copies and uses straightforward matrix multiplication on existing object/world/view matrices.
- The resulting code is simpler and idiomatic for game rendering setup, without hardcoded offsets or contrived compiler-only constructs.

## Technical details
- Replaced:
  - `localMtx = baseObj->m_localMatrix`
  - `worldMtx = pppMngStPtr->m_matrix`
  - `viewMtx = *(pppFMATRIX*)&ppvCameraMatrix0`
- With direct calls:
  - `pppMulMatrix(&modelView, &pppMngStPtr->m_matrix, &baseObj->m_localMatrix)`
  - `pppMulMatrix(&mtxOut, (pppFMATRIX*)&ppvCameraMatrix0, &modelView)`
