### PR TITLE
RedDriver: prevent _EntryExecCommand inlining in stream wrappers

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -613,6 +613,7 @@ void _StreamPause(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 void _EntryExecCommand(void (*command)(int*), int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6)
 {
     unsigned int interrupt;
@@ -642,6 +643,7 @@ void _EntryExecCommand(void (*command)(int*), int arg0, int arg1, int arg2, int 
 
     OSRestoreInterrupts(interrupt);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added `#pragma dont_inline on/reset` around `_EntryExecCommand` in `src/RedSound/RedDriver.cpp`.
- This preserves wrapper-style call codegen instead of inlining queue-write logic into small driver methods.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- `StreamStop__10CRedDriverFi`: **0.0% -> 88.55556%** (72b)
- `StreamPlay__10CRedDriverFiPviii`: **0.0% -> 66.208336%** (96b)

## Match evidence
Used:
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - StreamStop__10CRedDriverFi`
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - StreamPlay__10CRedDriverFiPviii`

Before this change both wrappers were at 0% because `_EntryExecCommand` was inlined into callsites. After this change both wrappers now emit direct calls and align substantially better.

## Plausibility rationale
- The wrapper methods in this file are intended to enqueue command packets through `_EntryExecCommand`.
- For these short wrappers, preventing inlining is source-plausible and keeps code style consistent with explicit command-dispatch wrappers used throughout the unit.
- The change avoids contrived control-flow or temporary-variable coaxing and only constrains inlining behavior.

## Technical details
- The main assembly improvement is replacement of inlined queue-write sequences with a single call to `_EntryExecCommand`.
- This significantly reduces mismatched instruction blocks in the stream wrapper methods while keeping function semantics unchanged.
