### PR TITLE
main/pppLocationTitle: improve pppFrameLocationTitle match via matrix call form

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -18,6 +18,7 @@ extern void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(void*, voi
                                                                        unsigned char);
 extern void pppSetBlendMode__FUc(unsigned char);
 extern void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, unsigned char);
+extern "C" void pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(pppFMATRIX*, pppFMATRIX*, pppFMATRIX*);
 extern int DAT_8032ed70;
 extern "C" int rand(void);
 extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
@@ -168,7 +169,7 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, UnkB* param_2, Un
 
         localMatrix = *(pppFMATRIX*)((u8*)pppLocationTitle + 4);
         managerMatrix = pppMngStPtr->m_matrix;
-        pppMulMatrix(resultMatrix, managerMatrix, localMatrix);
+        pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&resultMatrix, &managerMatrix, &localMatrix);
 
         particles[count].m_pos.x = resultMatrix.value[0][3];
         particles[count].m_pos.y = resultMatrix.value[1][3];


### PR DESCRIPTION
## Summary
- Updated `pppFrameLocationTitle` to call the explicit matrix multiply symbol `pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX` with pointer arguments.
- Added the matching extern declaration in `src/pppLocationTitle.cpp`.
- Kept behavior/source intent unchanged; this is a call-form alignment change.

## Functions Improved
- Unit: `main/pppLocationTitle`
- Symbol: `pppFrameLocationTitle`

## Match Evidence
- Command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o - pppFrameLocationTitle`
- `pppFrameLocationTitle`: **44.811073% -> 65.62866%**
- `.text` section (unit diff run): **53.797726% -> 68.32273%**
- Control check: `pppRenderLocationTitle` remained **66.19%**

## Plausibility Rationale
- The code now uses the same explicit matrix multiply symbol call pattern already used across other PPP units.
- This aligns with likely original source linkage/call form rather than introducing unnatural control-flow or temporary-variable coercion.

## Technical Notes
- This change targets call ABI/symbol resolution shape, which materially affects generated code for this function without changing functional behavior.
- `ninja` build passes after the change.
