### PR TITLE
pppKeZCrctShp: improve pppKeZCrctShpDraw match

### DIFF
--- a/src/pppKeZCrctShp.cpp
+++ b/src/pppKeZCrctShp.cpp
@@ -23,6 +23,7 @@ void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
     Vec zeroVec;
     Vec transformedPos;
     pppFMATRIX transformMatrix;
+    pppFMATRIX modeMatrix;
     float scaledPosX;
     float scaledPosY;
     float scaledPosZ;
@@ -48,15 +49,17 @@ void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
 
     if (mode == 1) {
         Vec modePos;
+        modeMatrix = *(pppFMATRIX*)&ppvWorldMatrix;
         modePos.x = scaledPosX;
         modePos.y = scaledPosY;
         modePos.z = scaledPosZ;
-        pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvWorldMatrix, modePos);
+        pppApplyMatrix(zeroVec, modeMatrix, modePos);
     } else if (mode == 0) {
         float offsetPosX;
         float offsetPosY;
         float offsetPosZ;
         Vec offsetPos;
+        modeMatrix = *(pppFMATRIX*)&ppvWorldMatrix;
 
         offsetPosX = scaledPosX + *(float*)(param2 + 8);
         offsetPosY = scaledPosY + *(float*)(param2 + 0xc);
@@ -68,24 +71,27 @@ void pppKeZCrctShpDraw(_pppPObject *pObject, int param2)
         offsetPos.x = offsetPosX;
         offsetPos.y = offsetPosY;
         offsetPos.z = offsetPosZ;
-        pppApplyMatrix(transformedPos, *(pppFMATRIX*)&ppvWorldMatrix, offsetPos);
+        pppApplyMatrix(transformedPos, modeMatrix, offsetPos);
     } else if (mode < 3) {
         Vec modePos;
         float cameraPosX;
         float cameraPosY;
         float cameraPosZ;
+        pppFMATRIX cameraMatrix;
 
+        modeMatrix = pppMngStPtr->m_matrix;
         modePos.x = scaledPosX;
         modePos.y = scaledPosY;
         modePos.z = scaledPosZ;
-        pppApplyMatrix(zeroVec, pppMngStPtr->m_matrix, modePos);
+        pppApplyMatrix(zeroVec, modeMatrix, modePos);
         cameraPosX = *(float*)(param2 + 8) * pppMngStPtr->m_scale.x + zeroVec.x;
         cameraPosY = *(float*)(param2 + 0xc) * pppMngStPtr->m_scale.y + zeroVec.y;
         cameraPosZ = *(float*)(param2 + 0x10) * pppMngStPtr->m_scale.z + zeroVec.z;
 
+        cameraMatrix = *(pppFMATRIX*)&ppvCameraMatrix0;
         zeroVec.x = cameraPosX;
         zeroVec.y = cameraPosY;
         zeroVec.z = cameraPosZ;
-        pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvCameraMatrix0, zeroVec);
+        pppApplyMatrix(zeroVec, cameraMatrix, zeroVec);
     }
 }


### PR DESCRIPTION
## Summary
- Refactored `pppKeZCrctShpDraw` matrix flow to use explicit local `pppFMATRIX` temporaries in each mode branch.
- Kept behavior identical while aligning generated code with the original function's matrix-by-value calling pattern.

## Functions improved
- Unit: `main/pppKeZCrctShp`
- Symbol: `pppKeZCrctShpDraw`

## Match evidence
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/pppKeZCrctShp -o - pppKeZCrctShpDraw`
- Before: `31.348433%` (right size `1276`)
- After: `55.059235%` (right size `1072`)
- Improvement: `+23.710802` percentage points

## Plausibility rationale
- This change models a realistic original-source style for this codebase: temporary local matrices are created before transform calls instead of repeatedly passing raw global matrices directly.
- No contrived reorderings or magic constants were introduced; control flow and data dependencies remain straightforward and readable.

## Technical details
- Added `modeMatrix` to hold copied `ppvWorldMatrix`/`m_matrix` values before `pppApplyMatrix`.
- Added a local `cameraMatrix` for the mode-2 camera transform path.
- Build and progress report still succeed with `ninja`.
