### PR TITLE
pppVertexApLc: improve signed loop/index matching

### DIFF
--- a/src/pppVertexApLc.cpp
+++ b/src/pppVertexApLc.cpp
@@ -112,7 +112,7 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
             points = src->points;
         }
 
-        u8 count = data->spawnCount;
+        s32 count = data->spawnCount;
 
         switch (data->mode) {
         case 0:
@@ -121,7 +121,7 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
                     state->index = 0;
                 }
 
-                u16 vertexIndex = entry->vertexIndices[state->index];
+                s32 vertexIndex = entry->vertexIndices[state->index];
                 state->index++;
                 Vec* vertex = &points[vertexIndex];
                 f32 x = vertex->x;
@@ -149,7 +149,7 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
             break;
         case 1:
             do {
-                u16 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
+                s32 vertexIndex = entry->vertexIndices[(s32)(RandF__5CMathFv(&math) * (f32)entry->maxValue)];
                 Vec* vertex = &points[vertexIndex];
                 f32 x = vertex->x;
                 f32 y = vertex->y;


### PR DESCRIPTION
## Summary
- Adjusted local types in `pppVertexApLc` to better match signed arithmetic in the original codegen.
- Changed spawn loop counter from `u8` to `s32`.
- Changed temporary `vertexIndex` locals from `u16` to `s32` in both mode branches.

## Functions Improved
- Unit: `main/pppVertexApLc`
- Symbol: `pppVertexApLc`
- Match: **86.68627% -> 88.95425%** (`+2.26798`)

## Match Evidence
- Baseline: `tools/objdiff-cli diff -p . -u main/pppVertexApLc -o - --format json pppVertexApLc`
- After change: same command
- Instruction-level diff summary improved from:
  - `MATCH=92, DIFF_DELETE=6, DIFF_INSERT=5`
  to:
  - `MATCH=94, DIFF_DELETE=4, DIFF_INSERT=3`

## Plausibility Rationale
- The changes reflect plausible original source intent: loop counters and temporary index math are naturally signed in this style of game code and align with expected compare/arithmetic instruction patterns.
- No control-flow restructuring, artificial temporaries, or non-idiomatic compiler coaxing was introduced.

## Technical Details
- The key improvement came from signedness correction in short-lived locals used in loop/index calculations.
- A separate experiment hoisting `&math` into a local pointer regressed matching and was intentionally excluded from this PR.
