### PR TITLE
monobj: implement onChangeStat and setActionParam

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -226,22 +226,61 @@ void CGMonObj::getNearParty(int, int, float, float, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80119528
+ * PAL Size: 324b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGMonObj::onChangeStat(int)
+void CGMonObj::onChangeStat(int state)
 {
-	// TODO
+	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
+	__ptmf_scall(this, mon + 0x708);
+
+	if (state <= -6 && state >= -14) {
+		setActionParam(state);
+	}
+
+	reinterpret_cast<CGCharaObj*>(this)->onChangeStat(state);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80119428
+ * PAL Size: 252b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGMonObj::setActionParam(int)
+void CGMonObj::setActionParam(int state)
 {
-	// TODO
+	CGObject* object = reinterpret_cast<CGObject*>(this);
+	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
+	unsigned char* script = reinterpret_cast<unsigned char*>(object->m_scriptHandle);
+
+	int scriptOffset = (state + 0xE) * 2;
+	unsigned int action = *reinterpret_cast<unsigned short*>(script + scriptOffset + 0xD0);
+	*reinterpret_cast<unsigned int*>(mon + 0x560) = action;
+
+	unsigned int motion = *reinterpret_cast<unsigned short*>(script + scriptOffset + 0xF0);
+	*reinterpret_cast<unsigned int*>(mon + 0x550) = motion;
+	*reinterpret_cast<int*>(mon + 0x554) = static_cast<int>(motion) + 1;
+	*reinterpret_cast<int*>(mon + 0x558) = *reinterpret_cast<int*>(mon + 0x554) + 1;
+	*reinterpret_cast<int*>(mon + 0x55C) = *reinterpret_cast<int*>(mon + 0x558) + 1;
+
+	int actionOffset = static_cast<int>(action) * 0x48;
+	unsigned short actionType = *reinterpret_cast<unsigned short*>(Game.game.unkCFlatData0[2] + actionOffset + 0xE);
+	if (actionType <= 3) {
+		if (actionType < 2 || actionType == 3) {
+			*reinterpret_cast<unsigned int*>(mon + 0x630) = *reinterpret_cast<unsigned short*>(Game.game.unkCFlatData0[2] + actionOffset + 0x20);
+			*reinterpret_cast<unsigned int*>(mon + 0x634) = *reinterpret_cast<unsigned short*>(Game.game.unkCFlatData0[2] + actionOffset + 0x22);
+			*reinterpret_cast<unsigned int*>(mon + 0x638) = *reinterpret_cast<unsigned short*>(Game.game.unkCFlatData0[2] + actionOffset + 0x22);
+		} else if (actionType == 2) {
+			reinterpret_cast<CGCharaObj*>(this)->calcCastTime(static_cast<int>(action));
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced TODO stubs for `CGMonObj::onChangeStat(int)` and `CGMonObj::setActionParam(int)` in `src/monobj.cpp` with first-pass decomp implementations.
- Added PAL metadata blocks for both functions:
  - `onChangeStat__8CGMonObjFi` at `0x80119528` (324b)
  - `setActionParam__8CGMonObjFi` at `0x80119428` (252b)
- Implemented script-driven action/motion parameter setup and forwarded to base class stat handling.

## Functions improved
- Unit: `main/monobj`
- `onChangeStat__8CGMonObjFi`
- `setActionParam__8CGMonObjFi`

## Match evidence
Measured with `build/tools/objdiff-cli diff -p . -u main/monobj <symbol>` (v3.4.1 interactive mode):
- `onChangeStat__8CGMonObjFi`: **1.20% -> 21.08%** (+19.88)
- `setActionParam__8CGMonObjFi`: **1.56% -> 48.25%** (+46.69)

Build status:
- `ninja` passes in this branch (project report/progress generated successfully)
- Prior full build in this worktree produced `build/GCCP01/main.dol: OK`

## Plausibility rationale
- Changes follow existing source style in `monobj.cpp` (offset-based field access and script-handle table reads).
- Logic mirrors expected game behavior rather than compiler-only coercion:
  - state range gate for action-param states
  - script table reads for action/motion ids
  - action-type branch for cast-time vs. direct timing fields
  - base class `CGCharaObj::onChangeStat` call preserved

## Technical details
- `onChangeStat` now performs the function-pointer callback via `__ptmf_scall`, applies `setActionParam` for states `[-14, -6]`, then delegates to `CGCharaObj::onChangeStat`.
- `setActionParam` now fills internal action/motion slots (`0x550-0x560`, `0x630-0x638`) from script and action tables, and invokes `calcCastTime` for type `2` actions.
