### PR TITLE
pppYmMoveParabola: improve construct offset codegen

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -33,7 +33,7 @@ extern "C" void pppConstructYmMoveParabola(struct pppYmMoveParabola* basePtr, st
 {
     _pppMngSt* pppMngSt = pppMngStPtr;
     f32 fVar2 = FLOAT_80330e1c;
-    f32* pfVar = (f32*)((u8*)&basePtr->field0_0x0 + 8 + *dataPtr->m_serializedDataOffsets);
+    f32* pfVar = (f32*)((u8*)(&basePtr->field0_0x0 + 2) + *dataPtr->m_serializedDataOffsets);
     Vec local_48;
     Vec local_24;
     f32 local_3c;


### PR DESCRIPTION
## Summary
- Adjusted the serialized work-data base pointer expression in `pppConstructYmMoveParabola` to use typed pointer arithmetic on `field0_0x0` (`&field0_0x0 + 2`) instead of byte arithmetic with `+ 8`.
- Kept behavior unchanged; this is a codegen-focused cleanup that still reflects plausible original source.

## Functions Improved
- Unit: `main/pppYmMoveParabola`
- Function improved: `pppConstructYmMoveParabola`

## Match Evidence
Before:
- `main/pppYmMoveParabola`: `57.972763%`
- `pppFrameYmMoveParabola`: `56.02174%`
- `pppConstructYmMoveParabola`: `62.89041%`

After:
- `main/pppYmMoveParabola`: `58.089493%`
- `pppFrameYmMoveParabola`: `56.02174%` (unchanged)
- `pppConstructYmMoveParabola`: `63.30137%` (+0.41096)

## Plausibility Rationale
- The new expression is semantically equivalent and source-plausible C/C++ for stepping past two 32-bit fields before applying the serialized offset.
- No contrived temporaries or artificial control-flow manipulation were introduced.

## Technical Details
- Verified with `ninja` and `objdiff-cli report generate` in the PAL (`GCCP01`) configuration.
- Improvement is isolated to constructor codegen; frame function remained stable.
