### PR TITLE
RedCommand: implement SetMusicVolume decomp

### DIFF
--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -906,10 +906,40 @@ int MusicPlay(int musicId, int volume, int mode)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cb870
+ * PAL Size: 204b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SetMusicVolume(int, int, int, int)
+void SetMusicVolume(int seId, int volume, int duration, int mode)
 {
-	// TODO
+	int step;
+	unsigned int* music = (unsigned int*)DAT_8032f3f0;
+
+	if (volume != 0) {
+		volume = (((volume + 1) * 4) - 1) * 0x1000;
+	}
+
+	if (duration < 1) {
+		step = 1;
+	} else {
+		step = (duration * 200) / 0x3c + (duration * 200 >> 0x1f);
+		step = step - (step >> 0x1f);
+	}
+
+	do {
+		int* musicI = (int*)music;
+		if ((seId == -1) || (seId == (int)music[0x11c]) || ((int)music[0x11c] < 0)) {
+			if (mode == 1) {
+				musicI[0x116] = -musicI[0x115] / step;
+				musicI[0x117] = step;
+			} else {
+				musicI[8] = (((unsigned int)volume | 0x800U) - music[7]) / step;
+				musicI[9] = step;
+			}
+		}
+		music += 0x125;
+	} while (music < (unsigned int*)((char*)DAT_8032f3f0 + 0xdbc));
 }


### PR DESCRIPTION
## Summary
- Implement `SetMusicVolume(int, int, int, int)` in `src/RedSound/RedCommand.cpp` from the decompilation reference instead of the previous TODO stub.
- Add PAL metadata block for the function (`0x801cb870`, `204b`) in standard project format.
- Keep function behavior/source style plausible to original code: volume scaling, duration-to-step conversion, and per-music entry ramp setup for both modes.

## Functions improved
- Unit: `main/RedSound/RedCommand`
- Function: `SetMusicVolume__Fiiii`
  - Before: `2.0%` (selector baseline)
  - After: `75.29%` (`objdiff-cli` one-shot JSON)

## Match evidence
- `objdiff-cli diff -p . -u main/RedSound/RedCommand -o - --format json SetMusicVolume__Fiiii` now reports `match_percent: 75.29412`.
- Unit fuzzy match moved from `44.7%` (selector snapshot) to `47.0025%` (`build/GCCP01/report.json`).

## Plausibility rationale
- The previous TODO stub was clearly incomplete/non-original.
- The new implementation follows natural engine-level logic (validate duration, compute ramp step, apply to each active/target music slot), without contrived compiler-only transformations.
- Types and control flow are consistent with nearby RedSound routines that manipulate music state arrays and fixed-point volume ramps.

## Technical details
- Implemented the same integer math pattern seen in the reference for duration scaling and signed division behavior.
- Preserved contiguous traversal over music slots (`+0x125` stride until `DAT_8032f3f0 + 0xdbc`).
- Build verification passed with `ninja` in this branch.
