### PR TITLE
itemobj: match CanCreateFromScript implementation

### DIFF
--- a/include/ffcc/itemobj.h
+++ b/include/ffcc/itemobj.h
@@ -26,7 +26,7 @@ public:
 	void onFrame();
 	void onFrameStat();
 	void DeleteOld(int, int, CFlatRuntime::CObject*, CFlatRuntime::CObject*);
-	void CanCreateFromScript();
+	unsigned int CanCreateFromScript();
 	void CreateFromScript(int, int, int, CGObject*, float, CGItemObj::CCFS*);
 	void safeDetach(int, float);
 	void carry(CGPartyObj*, int, int);

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -26,6 +26,7 @@ extern "C" void PlayAnim__8CGObjectFiiiiiPSc(void*, int, int, int, int, int, sig
 extern "C" void DispCharaParts__8CGObjectFi(void*, int);
 extern "C" void putParticle__8CGPrgObjFiiP8CGObjectfi(void*, int, int, void*, float, int);
 extern "C" float RandF__5CMathFf(float, CMath*);
+extern "C" unsigned int getNumFreeObject__13CFlatRuntime2Fi(void*, int);
 
 extern unsigned char CFlat[];
 extern CMath Math;
@@ -200,12 +201,18 @@ void CGItemObj::DeleteOld(int, int, CFlatRuntime::CObject*, CFlatRuntime::CObjec
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80125E74
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGItemObj::CanCreateFromScript()
+unsigned int CGItemObj::CanCreateFromScript()
 {
-	// TODO
+	unsigned int numFreeObjects = getNumFreeObject__13CFlatRuntime2Fi(CFlat, 5);
+
+	return (-numFreeObjects & ~numFreeObjects) >> 31;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGItemObj::CanCreateFromScript()` from the PAL decomp reference.
- Corrected the method return type from `void` to `unsigned int` in `include/ffcc/itemobj.h` and `src/itemobj.cpp`.
- Added PAL function metadata block to the implementation (`0x80125E74`, `56b`).

## Functions improved
- Unit: `main/itemobj`
- Function: `CanCreateFromScript__9CGItemObjFv`

## Match evidence
- `CanCreateFromScript__9CGItemObjFv`: **7.142857% -> 100.0%** (`size: 56`)
- `main/itemobj` fuzzy match: **15.745299 -> 16.300856**
- `main/itemobj` matched code bytes: **16 -> 72**
- `main/itemobj` matched functions: **3 -> 4**

## Plausibility rationale
- The new body is a direct, minimal expression of existing engine behavior: call `CFlatRuntime2::getNumFreeObject(5)` and return a boolean-like integer indicating availability.
- No contrived temporaries, offset tricks, or non-idiomatic control flow were introduced.
- Signature correction aligns the API with actual behavior (returns availability state).

## Technical details
- Used `objdiff-cli report generate` before and after to validate function-level and unit-level movement.
- This change is intentionally scoped to a small low-match TODO function to produce verified, plausible progress before tackling larger TODOs (`onFrameStat`, `CreateFromScript`).
