### PR TITLE
RedDriver: implement GetStreamPlayPoint first pass

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1713,12 +1713,37 @@ int CRedDriver::StreamPlayState(int param_1)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bf9d8
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::GetStreamPlayPoint(int, int*, int*)
+void CRedDriver::GetStreamPlayPoint(int param_1, int* param_2, int* param_3)
 {
-	// TODO
+	unsigned int streamData;
+
+	if (param_2 != 0) {
+		*param_2 = 0;
+	}
+	streamData = (unsigned int)DAT_8032f438;
+	if (param_3 != 0) {
+		*param_3 = 0;
+		streamData = (unsigned int)DAT_8032f438;
+	}
+	while ((*(int*)(streamData + 0x10C) == 0) || (*(int*)(streamData + 0x10C) != param_1)) {
+		streamData += 0x130;
+		if (streamData >= (unsigned int)DAT_8032f438 + 0x4C0) {
+			return;
+		}
+	}
+	if (param_2 != 0) {
+		*param_2 = *(int*)(streamData + 0x11C);
+	}
+	if (param_3 != 0) {
+		*param_3 = *(int*)(streamData + 0x120);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedDriver::GetStreamPlayPoint(int, int*, int*)` in `src/RedSound/RedDriver.cpp`.
- Added PAL metadata block for the function (`0x801bf9d8`, `156b`).
- Implemented stream table scan logic using the existing `DAT_8032f438` layout and offsets used elsewhere in `RedDriver`.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `GetStreamPlayPoint__10CRedDriverFiPiPi`

## Match evidence
- Before: `2.6%` (selector baseline for this symbol in this unit)
- After: `42.410255%` (`objdiff-cli diff -p . -u main/RedSound/RedDriver -o - GetStreamPlayPoint__10CRedDriverFiPiPi`)
- Net: `+39.8` points (first-pass improvement)

## Plausibility rationale
- Behavior is source-plausible and consistent with surrounding `CRedDriver` code:
  - initializes output pointers when non-null,
  - linearly scans the fixed stream slot array (`0x130` stride across `0x4C0` bytes),
  - writes current play-point fields from located slot (`+0x11C`, `+0x120`).
- The implementation follows existing local typing/pointer arithmetic patterns already used in `StreamPlayState` in the same file.

## Technical details
- Used Ghidra output only as structural guidance, then aligned to current source conventions and data access style.
- Left `StreamStop`/`StreamPlay` untouched after testing because they did not improve match in this pass.
- Build and verification steps run:
  - `python3 configure.py --version GCCP01`
  - `ninja`
  - `tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - GetStreamPlayPoint__10CRedDriverFiPiPi`
