### PR TITLE
chara: implement gqrInit and recover GetDispIndex return path

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -109,7 +109,7 @@ class CChara
 		void SetFrame(float);
 		void CalcFurColor();
 		void InitMogFurTex();
-		void GetDispIndex(CChara::CNode*);
+		int GetDispIndex(CChara::CNode*);
         void GetMatrix();
         void GetMatrix(float(*)[4]);
 

--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -83,7 +83,11 @@ void CChara::FlipDBuffer()
  */
 void CChara::gqrInit(unsigned long, unsigned long, unsigned long)
 {
-	// TODO
+	asm {
+		mtspr GQR5, r4
+		mtspr GQR6, r5
+		mtspr GQR7, r6
+	}
 }
 
 /*
@@ -381,9 +385,10 @@ void CChara::CModel::CalcFurColor()
  * Address:	TODO
  * Size:	TODO
  */
-void CChara::CModel::GetDispIndex(CChara::CNode*)
+int CChara::CModel::GetDispIndex(CChara::CNode* node)
 {
-	// TODO
+	u8 displayIndex = *(u8*)(*(u8**)node + 0x8D);
+	return (s8)displayIndex;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CChara::gqrInit` using direct `mtspr` writes to `GQR5-7`.
- Corrected `CChara::CModel::GetDispIndex` to return an index value instead of a TODO stub.
- Updated `CChara::CModel::GetDispIndex` declaration in `include/ffcc/chara.h` from `void` to `int`.

## Functions improved
- Unit: `main/chara`
- `gqrInit__6CCharaFUlUlUl`: **25.0% -> 100.0%**
- `GetDispIndex__Q26CChara6CModelFPQ26CChara5CNode`: **25.0% -> 97.5%**

## Match evidence
- `main/chara` `.text` match: **3.4171228% -> 3.5318608%** (objdiff oneshot JSON)
- Global progress (`ninja`): function count increased from **1696 -> 1697** matched functions.
- `gqrInit` instruction diffs dropped from 3 mismatches to 0.

## Plausibility rationale
- `gqrInit`’s purpose is register setup, and explicit GQR writes are the most plausible original implementation.
- `GetDispIndex` now performs the expected signed byte extraction flow from node/refdata, matching the recovered decomp intent (`(char)displayIndex`) rather than compiler-coaxing temporaries.

## Technical details
- Used `tools/objdiff-cli` v3.6.1 JSON oneshot for before/after per-symbol comparison.
- `GetDispIndex` still has minor arg/register mismatches at 97.5%, but opcode/control-flow alignment is recovered (`lwz`/`lbz`/`extsb`/`blr`).
