### PR TITLE
RedCommand: implement SeSepPlay and fix signature

### DIFF
--- a/include/ffcc/RedSound/RedCommand.h
+++ b/include/ffcc/RedSound/RedCommand.h
@@ -12,7 +12,7 @@ int SeStopID(int);
 int SeStopMG(int, int, int, int);
 int _SePlayStart(RedSeINFO*, int, int, int, int);
 int SeBlockPlay(int, int, int, int, int);
-void SeSepPlay(int, int, int, int);
+int SeSepPlay(int, int, int, int);
 void SetSeVolume(int, int, int, int);
 void SetSePan(int, int, int);
 void SetSePitch(int, int, int);

--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -35,6 +35,8 @@ extern "C" {
 int fflush(void*);
 int SearchMusicBank__9CRedEntryFi(CRedEntry*, int);
 int SearchWaveBase__9CRedEntryFi(void*, int);
+int SearchSeSepBank__9CRedEntryFi(CRedEntry*, int);
+void SeSepHistoryManager__9CRedEntryFii(CRedEntry*, int, int);
 void WaveHistoryManager__9CRedEntryFii(void*, int, int);
 }
 int* SetReverb(int, int, int*);
@@ -499,12 +501,30 @@ int SeBlockPlay(int seId, int bank, int no, int pan, int volume)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801cacb8
+ * PAL Size: 192b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SeSepPlay(int, int, int, int)
+int SeSepPlay(int seId, int sepId, int pan, int volume)
 {
-	// TODO
+	int sepBank;
+	unsigned char* sepInfo;
+
+	sepBank = SearchSeSepBank__9CRedEntryFi(&DAT_8032e154, sepId);
+	if (sepBank != 0) {
+		sepInfo = (unsigned char*)(*(int*)(sepBank + 8) + 0x10);
+		if ((*(unsigned int*)(*(int*)(sepBank + 8) + 0xc) & 0x80000000) != 0) {
+			*sepInfo |= 0x80;
+		}
+		if (_SePlayStart((RedSeINFO*)sepInfo, seId, sepId, pan, volume) != 0) {
+			SeSepHistoryManager__9CRedEntryFii(&DAT_8032e154, 1, sepId);
+			return sepId;
+		}
+	}
+	return -1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `SeSepPlay__Fiiii` in `src/RedSound/RedCommand.cpp` using the existing RedEntry/RedCommand flow (bank lookup -> sequence header resolution -> `_SePlayStart` -> history update).
- Updated the function declaration in `include/ffcc/RedSound/RedCommand.h` from `void` to `int` to match observed call/return behavior and symbol usage.
- Added PAL metadata header block for `SeSepPlay` (address/size) per project doc format.
- Added C-linkage declarations in `RedCommand.cpp` for `SearchSeSepBank__9CRedEntryFi` and `SeSepHistoryManager__9CRedEntryFii` so this function can call the expected symbols directly without relying on currently incomplete class stubs.

## Functions Improved
- Unit: `main/RedSound/RedCommand`
- Function: `SeSepPlay__Fiiii`
  - Before: `2.0833333%` fuzzy match
  - After: `69.75%` fuzzy match

## Match Evidence
- Unit `main/RedSound/RedCommand` fuzzy match:
  - Before: `47.0025%`
  - After: `49.03123%`
- Improvement is concentrated on `SeSepPlay__Fiiii`; function now has full control flow and return semantics instead of a TODO stub.

## Plausibility Rationale
- The new implementation follows expected source-level behavior for an SE sequence play entry point:
  1. Resolve SE sequence bank by SEP id.
  2. Derive sequence header pointer and preserve high-bit loop flag.
  3. Start playback via `_SePlayStart`.
  4. Record SEP history on success and return SEP id, otherwise return `-1`.
- This is straightforward game-audio runtime logic rather than compiler-coaxing patterns.

## Technical Details
- Because `CRedEntry` method signatures are currently incomplete in source stubs, this function uses explicit mangled C-linkage entry points already consistent with usage patterns in this file (`SearchMusicBank__9CRedEntryFi`, `SearchWaveBase__9CRedEntryFi`, etc.).
- Build verification: redsound object build completes with updated code (`RedCommand.o`, dependent `RedDriver.o`/`RedStream.o` up to date).
