### PR TITLE
main/gbaque: decompile GetMapObj

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -818,12 +818,66 @@ void GbaQueue::LoadMapObj()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800CCE38
+ * PAL Size: 368b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-int GbaQueue::GetMapObj(unsigned char*)
+int GbaQueue::GetMapObj(unsigned char* outData)
 {
-	return 0;
+	unsigned char mapObjWork[0x188];
+	unsigned char* workEntry;
+	unsigned char* writePtr;
+	GbaQueue* semaphoreIter;
+	int i;
+	int outSize;
+
+	i = 0;
+	semaphoreIter = this;
+	do {
+		OSWaitSemaphore(semaphoreIter->accessSemaphores);
+		i++;
+		semaphoreIter = reinterpret_cast<GbaQueue*>(semaphoreIter->accessSemaphores + 1);
+	} while (i < 4);
+
+	memcpy(mapObjWork, reinterpret_cast<char*>(this) + 0x2B00, sizeof(mapObjWork));
+
+	i = 0;
+	semaphoreIter = this;
+	do {
+		OSSignalSemaphore(semaphoreIter->accessSemaphores);
+		i++;
+		semaphoreIter = reinterpret_cast<GbaQueue*>(semaphoreIter->accessSemaphores + 1);
+	} while (i < 4);
+
+	workEntry = mapObjWork;
+	outData[0] = mapObjWork[0];
+	outData[1] = mapObjWork[4];
+	outData[2] = mapObjWork[5];
+	outData[3] = mapObjWork[6];
+	outData[4] = mapObjWork[7];
+
+	writePtr = outData + 5;
+	for (i = 0; i < mapObjWork[0]; i++) {
+		writePtr[0] = workEntry[8];
+		writePtr[1] = workEntry[0xC];
+		writePtr[2] = workEntry[0xD];
+		writePtr[3] = workEntry[0xE];
+		writePtr[4] = workEntry[0xF];
+		writePtr[5] = workEntry[0x10];
+		writePtr[6] = workEntry[0x11];
+		writePtr[7] = workEntry[0x12];
+		writePtr[8] = workEntry[0x13];
+
+		workEntry += 0xC;
+		writePtr += 9;
+	}
+
+	reinterpret_cast<char*>(this)[0x2C88] = 1;
+	outSize = static_cast<int>(writePtr - outData);
+	return outSize;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `GbaQueue::GetMapObj(unsigned char*)` in `src/gbaque.cpp` using the PAL 0x800CCE38 decompilation as guidance.
- Added PAL metadata block for the function.
- Preserved existing source style (raw buffer packing + semaphore-guarded copy) and avoided non-source-plausible compiler coaxing.

## Functions Improved
- Unit: `main/gbaque`
- Symbol: `GetMapObj__8GbaQueueFPUc`

## Match Evidence
- `GetMapObj__8GbaQueueFPUc`: **1.5217391% -> 59.79348%** (`tools/objdiff-cli v3.6.1`, one-shot JSON diff)
- Function size remained `368` bytes in objdiff metadata.

## Plausibility Rationale
- The implementation follows expected game-side behavior: lock all four GBA semaphores, snapshot map object data, unlock, serialize to outbound link payload format, then set the draw/update flag.
- Data layout and loop structure map directly to existing queue buffer organization already used elsewhere in `gbaque.cpp`/`joybus.cpp`.

## Technical Details
- Implemented packed output header bytes `[0..4]` and per-entry 9-byte records from the 0x2B00 backing store.
- Returned the serialized payload length (`5 + count * 9`), which matches downstream usage in `JoyBus::HandleGetMapObj`.
