### PR TITLE
Align pppConstrainCameraDir UnkC serialized offset

### DIFF
--- a/include/ffcc/pppConstrainCameraDir.h
+++ b/include/ffcc/pppConstrainCameraDir.h
@@ -15,6 +15,9 @@ typedef struct UnkB {
 } UnkB;
 
 typedef struct UnkC {
+    int pad0;
+    int pad4;
+    int pad8;
     int* m_serializedDataOffsets;
 } UnkC;
 

--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -16,7 +16,7 @@ void pppConstructConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir
     
     float uVar1 = DAT_803320c4;
     float* puVar2 = (float*)((char*)pppConstrainCameraDir + *param_2->m_serializedDataOffsets + 0x80);
-    puVar2[2] = DAT_803320c4;
+    puVar2[2] = uVar1;
     puVar2[1] = uVar1;
     puVar2[0] = uVar1;
 }
@@ -36,7 +36,7 @@ void pppConstruct2ConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDi
     
     float uVar1 = DAT_803320c4;
     float* puVar2 = (float*)((char*)pppConstrainCameraDir + *param_2->m_serializedDataOffsets + 0x80);
-    puVar2[2] = DAT_803320c4;
+    puVar2[2] = uVar1;
     puVar2[1] = uVar1;
     puVar2[0] = uVar1;
 }


### PR DESCRIPTION
## Summary
- Updated `UnkC` layout in `include/ffcc/pppConstrainCameraDir.h` so `m_serializedDataOffsets` is at offset `0xC` (added three 32-bit padding fields).
- Kept constructor assignments in `src/pppConstrainCameraDir.cpp` using the existing temporary/assignment order.

## Functions improved
- `main/pppConstrainCameraDir::pppConstructConstrainCameraDir`
- `main/pppConstrainCameraDir::pppConstruct2ConstrainCameraDir`
- `main/pppConstrainCameraDir2::pppFrameConstrainCameraDir2`

## Match evidence
- `pppConstructConstrainCameraDir`: `99.333336% -> 99.44444%`
- `pppConstruct2ConstrainCameraDir`: `99.333336% -> 99.44444%`
- `pppFrameConstrainCameraDir2`: `71.808136% -> 71.81396%`

Diff-count reduction from objdiff instruction streams:
- `pppConstructConstrainCameraDir`: `4 -> 2` mismatching instructions
- `pppConstruct2ConstrainCameraDir`: `4 -> 2` mismatching instructions
- `pppFrameConstrainCameraDir2`: `158 -> 157` mismatching instructions

## Plausibility rationale
- This change is a type/layout correction, not control-flow coercion.
- Existing generated code was consistently loading the serialized-data pointer from `+0xC`, indicating the prior struct definition was offset-wrong for this unit pair.
- Correcting the struct to match observed access patterns is consistent with original-source intent and improves codegen naturally.

## Technical details
- Before: constructors emitted `lwz r4, 0xc(r4)` while `UnkC` declared the pointer at offset `0x0`, producing argument/address mismatches.
- After: header layout matches observed object access and reduces mismatch noise in both constructor helpers plus the frame function that uses the same offset data.
