### PR TITLE
p_game: normalize CGame wrapper calls in CGamePcs methods

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -110,7 +110,8 @@ int CGamePcs::GetTable(unsigned long param)
  */
 void CGamePcs::create()
 {
-    game.Create();
+    CGame& game = Game.game;
+    game.CGame::Create();
 }
 
 /*
@@ -124,7 +125,8 @@ void CGamePcs::create()
  */
 void CGamePcs::destroy()
 {
-    game.Destroy();
+    CGame& game = Game.game;
+    game.CGame::Destroy();
 }
 
 /*
@@ -134,7 +136,8 @@ void CGamePcs::destroy()
  */
 void CGamePcs::calcInit()
 {
-	game.CheckScriptChange();
+    CGame& game = Game.game;
+    game.CGame::CheckScriptChange();
 }
 
 /*
@@ -148,7 +151,8 @@ void CGamePcs::calcInit()
  */
 void CGamePcs::calc0()
 {
-    game.Calc();
+    CGame& game = Game.game;
+    game.CGame::Calc();
 }
 
 /*
@@ -162,7 +166,8 @@ void CGamePcs::calc0()
  */
 void CGamePcs::calc1()
 {
-    game.Calc2();
+    CGame& game = Game.game;
+    game.CGame::Calc2();
 }
 
 /*
@@ -176,7 +181,8 @@ void CGamePcs::calc1()
  */
 void CGamePcs::calc2()
 {
-    game.Calc3();
+    CGame& game = Game.game;
+    game.CGame::Calc3();
 }
 
 /*
@@ -190,7 +196,8 @@ void CGamePcs::calc2()
  */
 void CGamePcs::draw0()
 {
-    game.Draw();
+    CGame& game = Game.game;
+    game.CGame::Draw();
 }
 
 /*
@@ -204,7 +211,8 @@ void CGamePcs::draw0()
  */
 void CGamePcs::draw1()
 {
-    game.Draw2();
+    CGame& game = Game.game;
+    game.CGame::Draw2();
 }
 
 /*
@@ -218,7 +226,8 @@ void CGamePcs::draw1()
  */
 void CGamePcs::draw2()
 {
-    game.Draw3();
+    CGame& game = Game.game;
+    game.CGame::Draw3();
 }
 
 /*


### PR DESCRIPTION
## Summary
Adjusted nine thin `CGamePcs` wrapper methods in `src/p_game.cpp` to use a local `CGame& game = Game.game` and explicit base-qualified calls (`game.CGame::...`).

## Functions improved
Unit: `main/p_game`

Updated methods:
- `create__8CGamePcsFv`
- `destroy__8CGamePcsFv`
- `calcInit__8CGamePcsFv`
- `calc0__8CGamePcsFv`
- `calc1__8CGamePcsFv`
- `calc2__8CGamePcsFv`
- `draw0__8CGamePcsFv`
- `draw1__8CGamePcsFv`
- `draw2__8CGamePcsFv`

## Match evidence
From `build/GCCP01/report.json` after `ninja`:
- Unit `main/p_game` fuzzy match: **83.77625 -> 86.03653** (+2.26028)
- Each updated wrapper: **84.0 -> 89.5** fuzzy match

No change expected in larger initializer here:
- `__sinit_p_game_cpp`: 79.35366 (unchanged)

## Plausibility rationale
These are straightforward forwarding methods, and this call style is already used in nearby `CGamePcs` wrappers (for example map/script change handlers in the same file). The change improves matching while remaining idiomatic and source-plausible, without introducing contrived temporaries or control-flow tricks.

## Technical notes
- Build verified with `ninja`.
- Improvement is localized to wrapper call codegen; behavior remains equivalent.
