### PR TITLE
chara: match gqrInit register writes

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -83,7 +83,11 @@ void CChara::FlipDBuffer()
  */
 void CChara::gqrInit(unsigned long, unsigned long, unsigned long)
 {
-	// TODO
+	asm {
+		mtspr GQR5, r4
+		mtspr GQR6, r5
+		mtspr GQR7, r6
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CChara::gqrInit(unsigned long, unsigned long, unsigned long)` with direct GQR SPR writes.
- Replaced TODO stub with Metrowerks inline assembly writing `GQR5`, `GQR6`, and `GQR7` from argument registers.

## Functions improved
- Unit: `main/chara`
- Symbol: `gqrInit__6CCharaFUlUlUl`

## Match evidence
- Before: `25.0%` (objdiff snapshot prior to edit)
- After: `100.0%`
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/chara -o - gqrInit__6CCharaFUlUlUl`
  - Resulting instruction sequence: `mtspr GQR5, r4; mtspr GQR6, r5; mtspr GQR7, r6; blr`
- Build still passes with `ninja`.

## Plausibility rationale
- This is source-plausible engine code: `gqrInit` is explicitly responsible for setting quantization registers, and direct `mtspr` writes are the idiomatic/expected implementation on GC/Wii PPC.
- The change removes a placeholder and restores concrete hardware setup behavior rather than introducing compiler-coaxing constructs.

## Technical details
- Assembly shape now matches the expected four-instruction function body exactly.
- No unrelated refactors or control-flow manipulation were introduced; change scope is limited to one function in `src/chara.cpp`.
