### PR TITLE
graphic: implement progressive/copy-clear helper stubs

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -17,7 +17,7 @@ class CFile;
 class CUtil;
 class CCameraPcs;
 
-void checkThread(void*);
+int checkThread(void*);
 void wakeup(OSAlarm*, OSContext*);
 void sleep();
 void std_sinf(float);
@@ -30,7 +30,7 @@ public:
 
     void Init();
     void Quit();
-    void GetProgressive();
+    int GetProgressive();
     void ChangeProgressive(int);
     void SetCopyClear(_GXColor, int);
     void SetStdDispCopySrc();

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -6,8 +6,12 @@
 #include "ffcc/pppfunctbl.h"
 #include "ffcc/system.h"
 #include "ffcc/util.h"
+#include "dolphin/vi.h"
+#include "dolphin/vi/vifuncs.h"
 
 extern void* lbl_801E8408;
+extern GXRenderModeObj lbl_801E83C0;
+extern u8 DAT_801E83F2[7];
 extern char DAT_80238030[];
 extern CUtil DAT_8032ec70;
 
@@ -68,9 +72,10 @@ extern "C" void __sinit_graphic_cpp(void)
  * Address:	TODO
  * Size:	TODO
  */
-void checkThread(void*)
+int checkThread(void*)
 {
-	// TODO
+	Graphic.Thread();
+	return 0;
 }
 
 /*
@@ -108,9 +113,12 @@ void CGraphic::Quit()
  * Address:	TODO
  * Size:	TODO
  */
-void CGraphic::GetProgressive()
+int CGraphic::GetProgressive()
 {
-	// TODO
+    if (VIGetDTVStatus() == 0) {
+        return 0;
+    }
+    return OSGetProgressiveMode() == 0 ? 1 : 2;
 }
 
 /*
@@ -118,9 +126,19 @@ void CGraphic::GetProgressive()
  * Address:	TODO
  * Size:	TODO
  */
-void CGraphic::ChangeProgressive(int)
+void CGraphic::ChangeProgressive(int mode)
 {
-	// TODO
+    GXRenderModeObj** renderMode = reinterpret_cast<GXRenderModeObj**>(reinterpret_cast<u8*>(this) + 0x71E0);
+    if (*renderMode != &lbl_801E83C0) {
+        *renderMode = &lbl_801E83C0;
+        GXAdjustForOverscan(*renderMode, *renderMode, 0, 0x10);
+        VIConfigure(*renderMode);
+        GXSetCopyFilter((*renderMode)->aa, (*renderMode)->sample_pattern, GX_TRUE, DAT_801E83F2);
+        VIFlush();
+        VIWaitForRetrace();
+        VIWaitForRetrace();
+    }
+    OSSetProgressiveMode(mode);
 }
 
 /*
@@ -128,9 +146,11 @@ void CGraphic::ChangeProgressive(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CGraphic::SetCopyClear(_GXColor, int)
+void CGraphic::SetCopyClear(_GXColor color, int)
 {
-	// TODO
+    _GXColor* clearColor = reinterpret_cast<_GXColor*>(reinterpret_cast<u8*>(this) + 0x735F);
+    *clearColor = color;
+    GXSetCopyClear(*clearColor, 0xFFFFFF);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented four previously stubbed `CGraphic` helpers in `src/graphic.cpp` and aligned declarations in `include/ffcc/graphic.h`:
- `checkThread`
- `CGraphic::GetProgressive`
- `CGraphic::ChangeProgressive`
- `CGraphic::SetCopyClear`

The new code uses existing SDK APIs and existing class/object state access already used in this file.

## Functions improved
Unit: `main/graphic`

- `SetCopyClear__8CGraphicF8_GXColori`: **4.7619% -> 86.8095%**
- `ChangeProgressive__8CGraphicFi`: **2.5641% -> 92.5641%**
- `GetProgressive__8CGraphicFv`: **5.8824% -> 65.0000%**
- `checkThread__FPv`: **9.0909% -> 85.4545%**

Unit fuzzy match:
- `main/graphic`: **23.5612% -> 25.4189%**

## Match evidence
Validated with a full rebuild (`ninja`) and regenerated `build/GCCP01/report.json`.
Before/after percentages above are from report snapshots taken immediately before and after this change.

## Plausibility rationale
These changes replace empty stubs with straightforward source-plausible game/SDK logic:
- Thread entry forwards directly to `Graphic.Thread()` and returns a status code.
- Progressive mode query/change use VI/OS APIs (`VIGetDTVStatus`, `OSGetProgressiveMode`, `OSSetProgressiveMode`) and VI reconfiguration flow.
- Copy clear updates the object's stored clear color bytes and calls `GXSetCopyClear` with the expected depth constant.

No contrived compiler coaxing, no synthetic temporaries beyond what is needed for class field access.

## Technical details
- Added required VI headers for referenced APIs.
- Added extern declarations for mode/filter data used by `ChangeProgressive`.
- Updated header signatures to reflect implemented behavior (`checkThread` returns `int`; `GetProgressive` returns `int`).