### PR TITLE
game: improve ScriptChanged loop structure for better match

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -845,7 +845,6 @@ void CGame::ScriptChanged(char*, int)
 {
     int i;
     int j;
-    int k;
 
     for (i = 0; i < 4; i++) {
         m_partyObjArr[i] = 0;
@@ -855,10 +854,11 @@ void CGame::ScriptChanged(char*, int)
     unk_flat3_0xc7d0 = 0;
 
     for (i = 0; i < 4; i++) {
-        for (j = 0; j < 16; j++) {
-            for (k = 0; k < 2; k++) {
-                m_scriptWork[i][j][k] = 0;
-            }
+        for (j = 0; j < 8; j++) {
+            m_scriptWork[i][j][0] = 0;
+            m_scriptWork[i][j + 8][0] = 0;
+            m_scriptWork[i][j][1] = 0;
+            m_scriptWork[i][j + 8][1] = 0;
         }
     }
 


### PR DESCRIPTION
## Summary
- Reworked `CGame::ScriptChanged(char*, int)` reset loop shape in `src/game.cpp`.
- Replaced a generic triple-nested `i/j/k` clear loop with the split `j` + `j+8` zeroing pattern already used in `CGame::clearWork()`.
- Kept behavior unchanged: all `m_scriptWork[4][16][2]` entries are still cleared, just with a code structure closer to expected original output.

## Functions improved
- Unit: `main/game`
- Function: `ScriptChanged__5CGameFPci`
  - Before: **40.6125%**
  - After: **76.0875%**

## Match evidence
- `tools/objdiff-cli diff -p . -u main/game -o - --format json`
- Key nearby checks after change:
  - `ScriptChanged__5CGameFPci`: 40.6125% -> 76.0875%
  - `clearWork__5CGameFv`: unchanged at 47.21557%
  - `GetBossArtifact__5CGameFii`: unchanged at 41.012985%

## Plausibility rationale
- The new loop structure is source-plausible and idiomatic for this codebase (it matches an existing pattern in `clearWork`).
- No contrived temporaries, no hardcoded object offsets, and no readability regressions were introduced.
- Change is narrowly scoped to control-flow/layout tuning in a single function, with no behavioral side effects expected.

## Technical details
- The previous triple loop generated a materially different store pattern.
- Splitting the inner iteration into paired `j`/`j+8` writes moved emitted stores and loop control closer to the target assembly pattern and significantly improved symbol alignment.
