### PR TITLE
MenuUtil: match CalcCenteringPos

### DIFF
--- a/include/ffcc/MenuUtil.h
+++ b/include/ffcc/MenuUtil.h
@@ -11,7 +11,7 @@ public:
     void CalcHelpLine(int, int&, int&);
     void GetLongHelpString(CFont*, int, int);
     void CalcCenteringPos2(char*, float, float);
-    void CalcCenteringPos(char*, CFont*);
+    float CalcCenteringPos(char*, CFont*);
     void DrawFont(int, int, _GXColor, int, char*, float, float);
     void GetFontWidth(char*, float, float);
     void DrawFont2(int, int, _GXColor, int, char*, float, float, float);

--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -1,5 +1,10 @@
 #include "ffcc/MenuUtil.h"
 
+extern "C" float GetWidth__5CFontFPc(CFont*, const char*);
+
+extern float lbl_80333558;
+extern float lbl_8033358C;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -35,9 +40,10 @@ void CMenuPcs::CalcCenteringPos2(char*, float, float)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::CalcCenteringPos(char*, CFont*)
+float CMenuPcs::CalcCenteringPos(char* text, CFont* font)
 {
-	// TODO
+    float width = GetWidth__5CFontFPc(font, text);
+    return -(width * lbl_80333558 - lbl_8033358C);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `CMenuPcs::CalcCenteringPos` return type from `void` to `float` in `include/ffcc/MenuUtil.h`.
- Implemented `CalcCenteringPos__8CMenuPcsFPcP5CFont` in `src/MenuUtil.cpp` using the external font width symbol and sdata2 constants.
- Kept the implementation source-plausible and minimal (no contrived temporaries beyond one width local used to match instruction ordering).

## Functions improved
- Unit: `main/MenuUtil`
- Function: `CalcCenteringPos__8CMenuPcsFPcP5CFont` (48 bytes)

## Match evidence
- `CalcCenteringPos__8CMenuPcsFPcP5CFont`: **8.333333% -> 100.0%** (`objdiff-cli diff -p . -u main/MenuUtil ...`).
- Unit fuzzy match (`main/MenuUtil`): **0.26466697% -> 0.5072783%** (`objdiff-cli report generate`).
- Build/progress also increased matched function count by 1 (`1701 -> 1702`).

## Plausibility rationale
- The change restores a natural function contract (`float` centered offset result) instead of a placeholder `void` stub.
- Logic directly reflects expected menu/font behavior: width lookup followed by centered-position computation.
- Uses existing symbolized constants from `.sdata2`, consistent with surrounding decomp style and compiler output requirements.

## Technical details
- Introduced external symbol declarations used by generated code:
  - `GetWidth__5CFontFPc(CFont*, const char*)`
  - `lbl_80333558`, `lbl_8033358C`
- Final expression form was tuned once to align `fnmsubs` operand ordering and reach 100%.
