### PR TITLE
chara_anim: improve CAnim ctor match via init store ordering

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -145,8 +145,8 @@ CChara::CAnim::CAnim()
 	*(void**)(p + 0x18) = 0;
 	*(void**)(p + 0x28) = 0;
 	*(int*)(p + 0x1C) = 0;
-	*(int*)(p + 0x24) = 0;
 	*(void**)(p + 0x2C) = 0;
+	*(int*)(p + 0x24) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adjusted the final zero-initialization store order in `CChara::CAnim::CAnim()` to better match original codegen.
- No semantic changes: all same fields remain initialized to zero.

## Functions improved
- Unit: `main/chara_anim`
- Function: `__ct__Q26CChara5CAnimFv`
  - Before: `85.76316%`
  - After: `85.81579%`
  - Delta: `+0.05263`

## Match evidence
- `build/GCCP01/report.json` shows:
  - `main/chara_anim` unit fuzzy: `58.12547%` -> `58.129215%`
  - `__ct__Q26CChara5CAnimFv`: `85.76316%` -> `85.81579%`
- Full rebuild completed successfully (`build/GCCP01/main.dol: OK` earlier in this run; final incremental `ninja` passes).

## Plausibility rationale
- Reordering adjacent initialization stores in a constructor is plausible original source behavior.
- The change avoids contrived temporaries or unnatural control flow and keeps the constructor readable and idiomatic.

## Technical notes
- The tweak was selected after objdiff-guided iteration in `chara_anim` and retained only when it produced a positive fuzzy-match delta.
