### PR TITLE
mapobj: match SetShow branch layout

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -429,10 +429,10 @@ void CMapObj::SetShow_r(int show)
  */
 void CMapObj::SetShow(int show)
 {
-    if (show == 0) {
-        U8At(this, 0x18) &= 0xFE;
-    } else {
+    if (show != 0) {
         U8At(this, 0x18) |= 1;
+    } else {
+        U8At(this, 0x18) &= 0xFE;
     }
 
     if (ObjAt(this, 0x4) != 0) {


### PR DESCRIPTION
## Summary
- Updated `CMapObj::SetShow(int show)` in `src/mapobj.cpp` to use `show != 0` as the first branch case.
- Behavior is unchanged; this only adjusts branch layout to better match original code generation.

## Functions improved
- Unit: `main/mapobj`
- Function: `SetShow__7CMapObjFi`

## Match evidence
- `SetShow__7CMapObjFi`: **59.5% -> 100.0%** fuzzy match (`size: 80b`)
- Neighbor checks:
  - `SetShow_r__7CMapObjFi`: 79.39189% (unchanged)
  - `SetLink__7CMapObjFv`: 26.529762% (unchanged)
- Global progress signal from `ninja` report:
  - Matched functions: **1702 -> 1703**
  - Matched code bytes: **213660 -> 213740**

## Plausibility rationale
- The change is source-plausible and idiomatic (`if (show != 0) ... else ...`).
- No artificial temporaries, offsets, or contrived ordering were introduced.
- This aligns control-flow shape with target assembly while preserving readability.

## Technical details
- The previous version generated an alternate early branch ordering in `SetShow`.
- Reordering the condition to put the non-zero case first aligned the branch pattern and yielded a full function match.
