### PR TITLE
cflat_r2system: improve GetEvtFlag match via bit-slice indexing

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -413,8 +413,8 @@ extern "C" void SetEvtFlag__12CCaravanWorkFii(CCaravanWork* caravanWork, int evt
 extern "C" int GetEvtFlag__12CCaravanWorkFi(CCaravanWork* caravanWork, int evtFlagIndex)
 {
     unsigned char* evtFlags = reinterpret_cast<unsigned char*>(caravanWork->m_evtWorkArr);
-    int byteIndex = evtFlagIndex / 8;
-    int bitIndex = evtFlagIndex - byteIndex * 8;
+    int byteIndex = evtFlagIndex >> 3;
+    int bitIndex = evtFlagIndex & 7;
     unsigned char mask = (unsigned char)(1u << bitIndex);
 
     return (evtFlags[byteIndex] & mask) != 0;


### PR DESCRIPTION
## Summary
- Updated `GetEvtFlag__12CCaravanWorkFi` in `src/cflat_r2system.cpp` to compute byte/bit positions with direct bit-slice math:
  - `byteIndex = evtFlagIndex >> 3`
  - `bitIndex = evtFlagIndex & 7`
- Preserved existing behavior (`(evtFlags[byteIndex] & mask) != 0`) while generating assembly closer to the target.

## Functions improved
- Unit: `main/cflat_r2system`
- Function: `GetEvtFlag__12CCaravanWorkFi`
  - Before: `48.4375%`
  - After: `62.1875%`
  - Delta: `+13.75%`

## Match evidence
- Built with `ninja` (build succeeds).
- Measured with objdiff CLI oneshot JSON:
  - `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/cflat_r2system -o diff_cflat.json --format json GetEvtFlag__12CCaravanWorkFi`
- Cross-check in same unit:
  - `SetEvtFlag__12CCaravanWorkFii` remained at `15.5%` (no regression retained in final commit).

## Plausibility rationale
- Bitfield access code is idiomatic original-source style for packed flags.
- This change removes an algebraic remainder reconstruction and uses straightforward shift/mask decomposition that developers commonly write for flag arrays.
- The resulting source is simpler and more maintainable without introducing contrived compiler-coaxing patterns.

## Technical details
- The previous code used `/ 8` and `evtFlagIndex - byteIndex * 8`; the updated version uses `>> 3` and `& 7` directly.
- Objdiff indicates improved instruction alignment in the function body and a materially better match score.
