### PR TITLE
materialman: decompile addtev_lightmap first pass

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -502,12 +502,80 @@ void CMaterialMan::addtev_bump_jimen(_GXTevScale)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80042814
+ * PAL Size: 836b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMaterialMan::addtev_lightmap(long)
+void CMaterialMan::addtev_lightmap(long index)
 {
-	// TODO
+    unsigned int stage = *reinterpret_cast<unsigned int*>(Ptr(this, 0x60));
+    unsigned char indexByte = static_cast<unsigned char>(index);
+    int stageOffset = static_cast<int>(index) * 4;
+
+    if (((*Ptr(this, 0x208)) & (1 << indexByte)) == 0) {
+        GXSetTevDirect(static_cast<GXTevStageID>(stage));
+        _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(
+            stage, *reinterpret_cast<int*>(Ptr(this, stageOffset + 0x180)),
+            *reinterpret_cast<int*>(Ptr(this, stageOffset + 0x158)), 0xFF);
+        _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(stage,
+                                                                                                              0xF, 8,
+                                                                                                              9, 0);
+        _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+        _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(stage, 7,
+                                                                                                              7, 7,
+                                                                                                              0);
+        _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(stage, 0, 0);
+        IncNumTevStage();
+        return;
+    }
+
+    GXColor kcolor;
+    *reinterpret_cast<unsigned int*>(&kcolor) = static_cast<unsigned int>(indexByte);
+    GXSetTevKColor(static_cast<GXTevKColorID>(index), kcolor);
+
+    GXSetTevDirect(static_cast<GXTevStageID>(stage));
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(
+        stage, *reinterpret_cast<int*>(Ptr(this, stageOffset + 0x180)),
+        *reinterpret_cast<int*>(Ptr(this, stageOffset + 0x158)), 0xFF);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(stage, 0xF,
+                                                                                                          8, 9, 0);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 2);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(stage, 7, 7,
+                                                                                                          7, 0);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(stage, 0, 0);
+    IncNumTevStage();
+
+    stage = *reinterpret_cast<unsigned int*>(Ptr(this, 0x60));
+    GXSetTevDirect(static_cast<GXTevStageID>(stage));
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(
+        stage, *reinterpret_cast<int*>(Ptr(this, stageOffset + 0x180)),
+        *reinterpret_cast<int*>(Ptr(this, stageOffset + 0x158)) + 1, 0xFF);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(stage, 0xF,
+                                                                                                          8, 9, 0);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(stage, 7, 7,
+                                                                                                          7, 0);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(stage, 0, 0);
+    IncNumTevStage();
+
+    stage = *reinterpret_cast<unsigned int*>(Ptr(this, 0x60));
+    GXSetTevDirect(static_cast<GXTevStageID>(stage));
+    GXSetTevKColorSel(static_cast<GXTevStageID>(stage), static_cast<GXTevKColorSel>(index + 0x1C));
+    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(stage, 0xFF, 0xFF, 0xFF);
+    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(stage, 4, 0,
+                                                                                                          0xE, 0xF);
+    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(stage, 7, 7,
+                                                                                                          7, 0);
+    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(stage, 0, 0, 0, 1, 0);
+    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(stage, 0, 0);
+    IncNumTevStage();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMaterialMan::addtev_lightmap(long)` in `src/materialman.cpp` from the PAL Ghidra reference as a first-pass decomp.
- Replaced the TODO stub with TEV/indirect stage setup logic, including K color path and stage count updates.
- Added PAL function metadata comment (`0x80042814`, `836b`).

## Functions improved
- Unit: `main/materialman`
- Symbol: `addtev_lightmap__12CMaterialManFl`

## Match evidence
Direct object diff (`tools/objdiff-cli diff -1 build/GCCP01/src/materialman.o -2 build/GCCP01/obj/materialman.o`):
- Before: left size `4`, match `0.0%`
- After: left size `768`, match `58.541668%`
- Target size (right): `836`

This is a substantial assembly alignment improvement from a stub toward the original implementation.

## Plausibility rationale
- The implementation follows the existing `materialman.cpp` style (pointer-offset field access, GX helper usage, stage increment flow).
- Logic mirrors expected engine behavior for lightmap TEV composition, including the alternate K-color blending path.
- No compiler-coaxing artifacts or unnatural control-flow were introduced.

## Technical details
- Preserved the project’s established helper usage (`Ptr(...)`, `_GXSetTev*` wrappers).
- Used `IncNumTevStage()` to match the file’s existing state-update idiom for TEV stage progression.
- Kept behavior split on `field_0x208` bitmask and per-index stage offsets (`0x180`, `0x158`) as indicated by decomp and object diff behavior.
