### PR TITLE
pppConstrainCameraDir2: improve pppFrameConstrainCameraDir2 match with Vec temporaries

### DIFF
--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -43,12 +43,8 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, UnkB* param_2, 
 	float local_100;
 	Vec local_fc;
 	Vec local_f0;
-	float local_e4;
-	float local_e0;
-	float local_dc;
-	float local_d8;
-	float local_d4;
-	float local_d0;
+	Vec local_e4;
+	Vec local_d8;
 	float local_cc;
 	float local_c8;
 	float local_c4;
@@ -111,14 +107,14 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, UnkB* param_2, 
 			local_104 = local_c8;
 			local_100 = local_c4;
 			
-			GetDirectVector__5CUtilFP3VecP3Vec3Vec((void*)&DAT_8032ec70, (Vec*)&local_d8, (Vec*)&local_e4, (Vec*)&local_108);
+			GetDirectVector__5CUtilFP3VecP3Vec3Vec((void*)&DAT_8032ec70, &local_d8, &local_e4, (Vec*)&local_108);
 			
-			local_f0.x = fVar2 * local_d8;
-			local_f0.y = fVar2 * local_d4;
-			local_f0.z = fVar2 * local_d0;
-			local_fc.x = fVar3 * local_e4;
-			local_fc.y = fVar3 * local_e0;
-			local_fc.z = fVar3 * local_dc;
+			local_f0.x = fVar2 * local_d8.x;
+			local_f0.y = fVar2 * local_d8.y;
+			local_f0.z = fVar2 * local_d8.z;
+			local_fc.x = fVar3 * local_e4.x;
+			local_fc.y = fVar3 * local_e4.y;
+			local_fc.z = fVar3 * local_e4.z;
 			
 			PSVECAdd(&local_c0, &local_f0, &local_c0);
 			PSVECAdd(&local_c0, &local_fc, &local_c0);


### PR DESCRIPTION
## Summary
- Refactored local direction-vector temporaries in `pppFrameConstrainCameraDir2` from scalar triplets to `Vec` values.
- Removed pointer-cast usage for `GetDirectVector__5CUtilFP3VecP3Vec3Vec` outputs and used direct `Vec` arguments/field access.
- Kept behavior and data flow the same (no algorithmic changes), only tightened type expression around vector math.

## Functions improved
- Unit: `main/pppConstrainCameraDir2`
- Symbol: `pppFrameConstrainCameraDir2`

## Match evidence
- `pppFrameConstrainCameraDir2`: **71.81396% -> 80.209305%** (`+8.395345`)
- Verified via:
  - `tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir2 -o - --format json-pretty pppFrameConstrainCameraDir2`

## Plausibility rationale
- Using `Vec` temporaries for vector outputs is more natural/source-plausible than storing 3-float groups and casting to `Vec*`.
- The updated code aligns with neighboring particle/camera code patterns that pass and manipulate explicit `Vec` objects.
- This is a readability and type-correctness improvement that also yields real assembly alignment progress, rather than contrived reordering.

## Technical details
- Main assembly impact is localized around the `GetDirectVector` callsite and subsequent multiply/add vector composition.
- Replacing scalar aliasing with typed vector field access reduced mismatch in the .text diff for this symbol.
