### PR TITLE
RedMidiCtrl: implement ReverbMix and FuzzyOn

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1,8 +1,10 @@
 #include "ffcc/RedSound/RedMidiCtrl.h"
 #include "ffcc/RedSound/RedEntry.h"
+#include "ffcc/RedSound/RedExecute.h"
 #include "ffcc/RedSound/RedMemory.h"
 
 extern unsigned int* DAT_8032f444;
+extern unsigned int DAT_8032f4b4;
 extern int DAT_8032f3f8;
 extern void* DAT_8032f3f0;
 extern int DAT_8032f424;
@@ -1174,12 +1176,37 @@ void __MidiCtrl_ReverbOff(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C9CD4
+ * PAL Size: 232b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ReverbMix(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ReverbMix(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    unsigned char* command = (unsigned char*)((int*)track)[0];
+    int* trackData = (int*)track;
+
+    trackData[0x3f] &= 0xFFFFC3FF;
+
+    if (command[0] == 1 || command[0] == 2) {
+        trackData[0x3f] |= 0x1000;
+    }
+    if (command[0] == 0 || command[0] >= 2) {
+        trackData[0x3f] |= 0x400;
+    }
+
+    if (command[1] == 1 || command[1] == 2) {
+        trackData[0x3f] |= 0x2000;
+    }
+    if (command[1] == 0 || command[1] >= 2) {
+        trackData[0x3f] |= 0x800;
+    }
+
+    trackData[0] += 2;
+    SetVoiceSwitch(track, trackData[0x3f]);
+    DAT_8032f4b4 |= 2;
 }
 
 /*
@@ -1204,12 +1231,41 @@ void __MidiCtrl_StepRelative2(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C9EBC
+ * PAL Size: 228b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_FuzzyOn(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_FuzzyOn(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    unsigned char* command = (unsigned char*)((int*)track)[0];
+    int* trackData = (int*)track;
+    int value;
+
+    trackData[0] = (int)(command + 2);
+    value = command[1] + 1;
+    if (command[1] == 0) {
+        value = 0x100;
+    }
+
+    if (command[0] == 1) {
+        trackData[0x39] = value;
+        trackData[0x3f] |= 0x8000;
+    } else if (command[0] == 2) {
+        trackData[0x3a] = value;
+        trackData[0x3f] |= 0x10000;
+    } else if (command[0] == 3) {
+        trackData[0x3b] = value;
+        trackData[0x3f] |= 0x20000;
+    } else if (command[0] == 4) {
+        trackData[0x3c] = value;
+        trackData[0x3f] |= 0x40000;
+    } else {
+        trackData[0x38] = value;
+        trackData[0x3f] |= 0x4000;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__MidiCtrl_ReverbMix` and `__MidiCtrl_FuzzyOn` in `src/RedSound/RedMidiCtrl.cpp` from decomp-guided control-byte behavior.
- Replaced TODO stubs with real flag/parameter updates on `RedTrackDATA` and command stream pointer advancement.
- Added PAL address/size metadata blocks for both functions.

## Functions improved
- Unit: `main/RedSound/RedMidiCtrl`
- `__MidiCtrl_ReverbMix__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_FuzzyOn__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Match evidence
- `__MidiCtrl_ReverbMix`: `1.7241379%` -> `48.068966%` (+46.3448281)
- `__MidiCtrl_FuzzyOn`: `1.754386%` -> `41.7193%` (+39.964914)
- Measured via:
  - `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o ... <symbol>`

## Plausibility rationale
- Behavior now matches expected command-decoding structure used elsewhere in RedSound: read command bytes, update per-track runtime fields/flags, and advance the stream pointer.
- Changes are straightforward control-flow and bitfield updates, without contrived compiler-coaxing temporaries.

## Technical details
- `__MidiCtrl_ReverbMix` now decodes two bytes into voice switch flags, updates track switch state via `SetVoiceSwitch`, and sets the global voice-update flag.
- `__MidiCtrl_FuzzyOn` now decodes target slot/value from command bytes and updates the corresponding fuzzy parameter + dirty flag.
