### PR TITLE
RedDriver: implement GetProgramTime

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -57,7 +57,7 @@ public:
 
 	void Init();
 	void End();
-	void GetProgramTime();
+	int GetProgramTime();
 	void SetSoundMode(int);
 	void GetSoundMode();
 	void SetMusicData(void*);

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1239,12 +1239,25 @@ void CRedDriver::End()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bec04
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedDriver::GetProgramTime()
+int CRedDriver::GetProgramTime()
 {
-	// TODO
+	int total;
+	int* timePtr;
+
+	total = 0;
+	timePtr = (int*)DAT_8032f3cc;
+	do {
+		total += *timePtr;
+		timePtr++;
+	} while (timePtr < (int*)DAT_8032f3cc + 100);
+	return total;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CRedDriver::GetProgramTime()` using a 100-entry accumulation loop over the driver timing buffer.
- Updated `CRedDriver` declaration to return `int`, matching the recovered function behavior.
- Added PAL metadata header block for `GetProgramTime__10CRedDriverFv`.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Function: `GetProgramTime__10CRedDriverFv` (68b)

## Match evidence
- `GetProgramTime__10CRedDriverFv`: **5.882353% -> 20.235294%** fuzzy match
- Unit `main/RedSound/RedDriver`: **42.69468% -> 42.77385%** fuzzy match
- `objdiff-cli diff -p . -u main/RedSound/RedDriver GetProgramTime__10CRedDriverFv` now shows ~**19.94%** instruction match and aligned loop structure.

## Plausibility rationale
- The change reflects natural source behavior for a "program time" query: summing a fixed-length timing history buffer.
- This replaces a TODO stub with straightforward logic rather than compiler-coaxing patterns.
- Control flow and data access are consistent with the surrounding RedSound driver code.

## Technical details
- Reads `DAT_8032f3cc` as an `int*` timing array.
- Iterates exactly 100 elements (`+ 100`) and accumulates to `total`.
- Returns the accumulated value for callers that need aggregate timing information.
