### PR TITLE
THPDraw: improve THPGXYuv2RgbSetup match with aggregate color init

### DIFF
--- a/src/THPDraw.cpp
+++ b/src/THPDraw.cpp
@@ -47,10 +47,10 @@ void THPGXYuv2RgbDraw(u32* yImage, u32* uImage, u32* vImage, s16 x, s16 y, s16 t
 void THPGXYuv2RgbSetup(GXRenderModeObj* rmode) {
     Mtx modelMtx;
     Mtx44 projMtx;
-    GXColorS10 tevColor;
-    GXColor kColor0;
-    GXColor kColor1;
-    GXColor kColor2;
+    GXColorS10 tevColor = {-90, 0, -114, 135};
+    GXColor kColor0 = {0, 0, 226, 88};
+    GXColor kColor1 = {179, 0, 0, 182};
+    GXColor kColor2 = {0, 135, 0, 0};
     u16 fbWidth;
     u16 efbHeight;
 
@@ -120,28 +120,12 @@ void THPGXYuv2RgbSetup(GXRenderModeObj* rmode) {
     _GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
     GXSetTevKColorSel(GX_TEVSTAGE3, GX_TEV_KCSEL_K2);
 
-    tevColor.r = -90;
-    tevColor.g = 0;
-    tevColor.b = -114;
-    tevColor.a = 135;
     GXSetTevColorS10(GX_TEVREG0, tevColor);
 
-    kColor0.r = 0;
-    kColor0.g = 0;
-    kColor0.b = 226;
-    kColor0.a = 88;
     GXSetTevKColor(GX_KCOLOR0, kColor0);
 
-    kColor1.r = 179;
-    kColor1.g = 0;
-    kColor1.b = 0;
-    kColor1.a = 182;
     GXSetTevKColor(GX_KCOLOR1, kColor1);
 
-    kColor2.r = 0;
-    kColor2.g = 135;
-    kColor2.b = 0;
-    kColor2.a = 0;
     GXSetTevKColor(GX_KCOLOR2, kColor2);
 
     _GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE, GX_CH_ALPHA);


### PR DESCRIPTION
## Summary
- Reworked `THPGXYuv2RgbSetup` color setup in `src/THPDraw.cpp` to use aggregate initializers for `GXColorS10`/`GXColor` locals.
- Removed per-channel assignment blocks that were producing less-matching codegen for TEV color constants.

## Functions improved
- Unit: `main/THPDraw`
- Symbol: `THPGXYuv2RgbSetup`
  - Before: **81.51104%**
  - After: **90.84543%**

## Match evidence
- `objdiff-cli` oneshot (`v3.6.1`) on `main/THPDraw`:
  - `THPGXYuv2RgbSetup`: 81.51104% -> 90.84543%
  - `THPGXYuv2RgbDraw`: unchanged at 88.193275%
  - `THPGXRestore`: unchanged at 100%
- Instruction-level diff trend for `THPGXYuv2RgbSetup`:
  - `DIFF_INSERT`: 39 -> 15
  - `DIFF_DELETE`: 15 -> 9
  - `DIFF_ARG_MISMATCH`: 37 -> 33

## Plausibility rationale
- Aggregate struct initialization is idiomatic and plausible original source in this codebase.
- The change preserves behavior while better matching constant materialization/order expected by target assembly.
- No contrived temporaries or control-flow distortion were introduced.

## Technical details
- Build verified with `ninja` after change.
- Objdiff command used:
  - `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/THPDraw -o -`
  - `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/THPDraw -o - THPGXYuv2RgbSetup`
