### PR TITLE
menu_item: improve ItemOpen decomp match

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -368,9 +368,9 @@ bool CMenuPcs::ItemOpen()
     s16* itemList = *(s16**)((u8*)this + 0x850);
     int finished;
     int count;
+    s16* anim;
     int step;
     int remaining;
-    MenuItemOpenAnim* anim;
 
     if (*(u8*)(itemState + 5) == 0) {
         SingLifeInit(-1);
@@ -380,7 +380,7 @@ bool CMenuPcs::ItemOpen()
     finished = 0;
     itemState[0x11] = itemState[0x11] + 1;
     count = (int)*itemList;
-    anim = (MenuItemOpenAnim*)((u8*)itemList + 8);
+    anim = itemList + 4;
     step = (int)itemState[0x11];
     remaining = count;
 
@@ -388,24 +388,25 @@ bool CMenuPcs::ItemOpen()
         do {
             double dVar3 = DOUBLE_80332ea0;
             float zero = FLOAT_80332e60;
-            if (anim->startFrame <= step) {
-                if (step < anim->startFrame + anim->duration) {
+            if (*(int*)(anim + 0x12) <= step) {
+                if (step < *(int*)(anim + 0x12) + *(int*)(anim + 0x14)) {
                     double dVar2 = DOUBLE_80332e68;
-                    anim->frame = anim->frame + 1;
-                    anim->progress = (float)((DOUBLE_80332e68 / (double)anim->duration) * (double)anim->frame);
-                    if ((anim->flags & 2) == 0) {
-                        float t = (float)((dVar2 / (double)anim->duration) * (double)anim->frame);
-                        anim->dx = (anim->targetX - (float)anim->x) * t;
-                        anim->dy = (anim->targetY - (float)anim->y) * t;
+                    *(int*)(anim + 0x10) = *(int*)(anim + 0x10) + 1;
+                    *(float*)(anim + 8) =
+                        (float)((DOUBLE_80332e68 / (double)*(int*)(anim + 0x14)) * (double)*(int*)(anim + 0x10));
+                    if ((*(unsigned int*)(anim + 0x16) & 2) == 0) {
+                        float t = (float)((dVar2 / (double)*(int*)(anim + 0x14)) * (double)*(int*)(anim + 0x10));
+                        *(float*)(anim + 0x18) = (*(float*)(anim + 0x1C) - (float)anim[0]) * t;
+                        *(float*)(anim + 0x1A) = (*(float*)(anim + 0x1E) - (float)anim[1]) * t;
                     }
                 } else {
                     finished = finished + 1;
-                    anim->progress = FLOAT_80332e64;
-                    anim->dx = zero;
-                    anim->dy = zero;
+                    *(float*)(anim + 8) = FLOAT_80332e64;
+                    *(float*)(anim + 0x18) = zero;
+                    *(float*)(anim + 0x1A) = zero;
                 }
             }
-            anim = anim + 1;
+            anim = anim + 0x20;
             remaining = remaining - 1;
         } while (remaining != 0);
     }


### PR DESCRIPTION
## Summary
- Reworked `CMenuPcs::ItemOpen()` in `src/menu_item.cpp` to use the menu-entry pointer layout (`s16*` + fixed offsets) instead of struct-field access for animation state.
- Kept behavior unchanged (same open sequencing, progress interpolation, and delta update math), while nudging generated code closer to the original MWCC output.

## Functions Improved
- Unit: `main/menu_item`
- Symbol: `ItemOpen__8CMenuPcsFv`

## Match Evidence
- `ItemOpen__8CMenuPcsFv`: **47.297300% -> 47.558560%** (`+0.261260`)
- Size stayed constant: `444b`
- Validation command used:
  - `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/menu_item -o - ItemOpen__8CMenuPcsFv`

## Plausibility Rationale
- The change uses direct field offsets over a packed menu-item entry block, which is consistent with adjacent menu code patterns in this file and with the decomp style expected from original code in this area.
- No contrived temporary variables or artificial control flow were introduced; logic remains straightforward menu animation progression.

## Technical Details
- Updated entry traversal from `MenuItemOpenAnim*` to `s16*` (`itemList + 4` / `+0x20` stride).
- Replaced member expressions (`startFrame`, `duration`, `frame`, `progress`, `dx`, `dy`, etc.) with explicit offset loads/stores to better match original integer/float conversion codegen behavior.
- Verified clean rebuild with `ninja`.
