### PR TITLE
sound: fix SetStereo this-adjustment for CRedSound

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -327,7 +327,7 @@ void CSound::Quit()
  */
 void CSound::SetStereo(int stereo)
 {
-    reinterpret_cast<CRedSound*>(this)->SetSoundMode((u32)__cntlzw(stereo) >> 5);
+    reinterpret_cast<CRedSound*>(reinterpret_cast<u8*>(this) + 8)->SetSoundMode((u32)__cntlzw(stereo) >> 5);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CSound::SetStereo(int)` to call `SetSoundMode` on the embedded `CRedSound` object (`this + 0x8`) instead of using the unadjusted `this` pointer.
- Kept behavior and readability intact; this is an ABI/this-pointer adjustment only.

## Functions improved
- Unit: `main/sound`
- Symbol: `SetStereo__6CSoundFi` (44b)

## Match evidence
- `SetStereo__6CSoundFi`: **90.90909% -> 100.0%** (`+9.09091`)
- Whole-unit `main/sound` diff check showed exactly one changed symbol, with no regressions in other functions.

## Plausibility rationale
- The change aligns with object layout expectations where `CSound` contains a `CRedSound` subobject at offset `0x8`.
- This is a natural source-level fix (correct subobject call target), not compiler coaxing.

## Technical details
- Verified with `tools/objdiff-cli diff -p . -u main/sound -o /tmp/sound_after_final.json` and compared against pre-change baseline.
- Full build passes with `ninja` after the change.
