### PR TITLE
memory: implement sync A-memory DMA copy routines

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -868,22 +868,56 @@ void CMemory::CopyFromAMemory(void*, void*, unsigned long)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001E620
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMemory::CopyToAMemorySync(void*, void*, unsigned long)
+void CMemory::CopyToAMemorySync(void* source, void* dest, unsigned long size)
 {
-	// TODO
+    int dmaId = DMAEntry__9CRedSoundFiiiiiPFPv_vPv(&Sound, 0, 0, reinterpret_cast<int>(source),
+                                                   reinterpret_cast<int>(dest), static_cast<int>(size), 0, 0);
+    CStopWatch watch((char*)-1);
+    System.DumpMapFile(&watch);
+    watch.Start();
+    while (DMACheck__9CRedSoundFi(&Sound, dmaId) != 0) {
+        watch.Stop();
+        watch.Get();
+        watch.Start();
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001E4F8
+ * PAL Size: 296b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMemory::CopyFromAMemorySync(void*, void*, unsigned long)
+void CMemory::CopyFromAMemorySync(void* source, void* dest, unsigned long size)
 {
-	// TODO
+    int dmaId = DMAEntry__9CRedSoundFiiiiiPFPv_vPv(&Sound, 0, 1, reinterpret_cast<int>(source),
+                                                   reinterpret_cast<int>(dest), static_cast<int>(size), 0, 0);
+    CStopWatch watch((char*)-1);
+    System.DumpMapFile(&watch);
+    watch.Start();
+    while (DMACheck__9CRedSoundFi(&Sound, dmaId) != 0) {
+        watch.Stop();
+        if (watch.Get() < FLOAT_8032f7d8) {
+            watch.Start();
+        } else {
+            if (System.m_execParam != 0) {
+                Printf__7CSystemFPce(&System, DAT_801d669c);
+            }
+            Sound.CheckDriver(1);
+            watch.Reset();
+            watch.Start();
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMemory::CopyToAMemorySync` and `CMemory::CopyFromAMemorySync` in `src/memory.cpp`.
- Added PAL metadata blocks for both functions:
  - `CopyToAMemorySync` @ `0x8001E620` (176b)
  - `CopyFromAMemorySync` @ `0x8001E4F8` (296b)
- Implementation uses existing project patterns: `DMAEntry`/`DMACheck`, `CStopWatch`, `System.DumpMapFile`, and timeout handling via `Sound.CheckDriver(1)`.

## Functions Improved
- Unit: `main/memory`
- `CopyFromAMemorySync__7CMemoryFPvPvUl`: **1.3513514% -> 41.68919%**
- `CopyToAMemorySync__7CMemoryFPvPvUl`: **2.2727273% -> 22.613636%**

## Match Evidence
Objdiff command used:
```sh
tools/objdiff-cli diff -p . -u main/memory -o - CopyFromAMemorySync__7CMemoryFPvPvUl
```
Before:
- `CopyFromAMemorySync__7CMemoryFPvPvUl` = `1.3513514%`
- `CopyToAMemorySync__7CMemoryFPvPvUl` = `2.2727273%`

After:
- `CopyFromAMemorySync__7CMemoryFPvPvUl` = `41.68919%`
- `CopyToAMemorySync__7CMemoryFPvPvUl` = `22.613636%`

## Plausibility Rationale
- Code follows the same style and call sequencing already used in nearby `memory.cpp` routines (`CAmemCacheSet::GetData`, `SetData`) for synchronous DMA polling.
- Timeout recovery path in `CopyFromAMemorySync` matches established source behavior (debug print + `Sound.CheckDriver(1)` + stopwatch reset), which is source-plausible and not compiler-coaxing.

## Build
- `ninja` passes in this branch.
