### PR TITLE
pppAlignmentScale: improve pppFrameAlignmentScale codegen match

### DIFF
--- a/src/pppAlignmentScale.cpp
+++ b/src/pppAlignmentScale.cpp
@@ -53,8 +53,8 @@ struct pppAlignmentScale* pppFrameAlignmentScale(struct pppAlignmentScale* align
     Vec objPos;
     Mtx scaleMtx;
 
-    pppMngSt = pppMngStPtr;
     if (DAT_8032ed70 == 0) {
+        pppMngSt = pppMngStPtr;
         cameraPos.x = CameraPcs._224_4_;
         cameraPos.y = CameraPcs._228_4_;
         cameraPos.z = CameraPcs._232_4_;


### PR DESCRIPTION
## Summary
- Moved the `pppMngStPtr` load into the `DAT_8032ed70 == 0` branch in `pppFrameAlignmentScale`.
- No behavior change; this only narrows pointer initialization lifetime to the path that uses it.

## Functions improved
- Unit: `main/pppAlignmentScale`
- Symbol: `pppFrameAlignmentScale`

## Match evidence
- Project report (`build/GCCP01/report.json`) fuzzy match:
  - Before: `86.19718%`
  - After: `95.07042%`
- Objdiff oneshot (`tools/objdiff-cli diff -p . -u main/pppAlignmentScale -o - pppFrameAlignmentScale`) symbol match:
  - Before: `85.478874%`
  - After: `94.29578%`
- Instruction diff quality (same objdiff JSON):
  - `DIFF_INSERT`: `4 -> 1`
  - `DIFF_DELETE`: `5 -> 2`
  - `MATCH` instructions: `37 -> 42`

## Plausibility rationale
- Deferring acquisition of `pppMngStPtr` until after the early-exit guard is ordinary source-level control flow and avoids unnecessary work on the return path.
- This is source-plausible cleanup rather than artificial temporary/reordering tricks.

## Technical details
- Objdiff highlighted a pre-guard load mismatch in the function prologue.
- Aligning that load with the guarded path reduced prologue/control-flow divergence and improved overall instruction alignment for the symbol.
