### PR TITLE
p_tina: implement first-pass LoadFieldPdt0

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -73,6 +73,7 @@ extern CProfile g_par_draw_prof;
 extern char s_no_name_8032fdcc[];
 extern char s_dvd_tina_stage_03d_mirura_801d7f78[];
 extern char s_dvd_tina_stage_03d_title_801d7f94[];
+extern char s_dvd_tina_stage_03d_fp_03d_801d7fec[];
 extern char s_dvd__smenu__s_801d7fb0[];
 extern char lbl_801D7FC0[];
 extern char lbl_801D7FD4[];
@@ -194,6 +195,8 @@ extern unsigned int DAT_801eac78;
 extern unsigned int DAT_801eac84;
 extern unsigned int DAT_801eac88;
 extern unsigned int DAT_801eac8c;
+extern int DAT_8032ed38;
+extern int DAT_8032ed3c;
 
 static int GetMngStBaseTime(const _pppMngSt* pppMngSt)
 {
@@ -929,12 +932,41 @@ unsigned int CPartPcs::IsLoadPartCompleted()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800524d0
+ * PAL Size: 400b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void LoadFieldPdt0(int, int)
+void LoadFieldPdt0(int mapId, int floorId)
 {
-	// TODO
+    unsigned char* partMng = reinterpret_cast<unsigned char*>(&PartMng);
+    int partLoadMode = *reinterpret_cast<int*>(partMng + 0x236FC);
+    int pdtSlot;
+    char path[1024];
+
+    DAT_8032ed3c = 0;
+    DAT_8032ed38 = 0;
+
+    if (partLoadMode != 3) {
+        pppReleasePdt__8CPartMngFi(&PartMng, 0);
+        pppReleasePdt__8CPartMngFi(&PartMng, 6);
+        pppReleasePdt__8CPartMngFi(&PartMng, 7);
+        reinterpret_cast<CAmemCacheSet*>(CAMemCacheSet)->AmemGetLock();
+        reinterpret_cast<CAmemCacheSet*>(CAMemCacheSet)->RefCnt0Compare();
+    }
+
+    reinterpret_cast<CUSBStreamDataRaw*>(PartPcs + 8)->m_fieldLoadReq = 1;
+
+    sprintf(path, s_dvd_tina_stage_03d_fp_03d_801d7fec, mapId, floorId);
+    pdtSlot = pppLoadPtx__8CPartMngFPCciiPvi(&PartMng, path, 0, 1, 0, 0);
+    if (pdtSlot != 0) {
+        pdtSlot = pppLoadPdt__8CPartMngFPCciiPvi(&PartMng, path, 0, 1, 0, 0);
+        if ((pdtSlot != 0) && (partLoadMode != 2) && (partLoadMode != 3)) {
+            PartMng.pppGetDefaultCreateParam();
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `LoadFieldPdt0` in `src/p_tina.cpp` from the current decompilation context instead of leaving it as a TODO stub.
- Added PAL metadata block for the function (`0x800524d0`, `400b`).
- Wired existing load-state/cache behavior used by the surrounding `p_tina` code path:
  - resets `DAT_8032ed3c` / `DAT_8032ed38`
  - conditional `pppReleasePdt(..., 0/6/7)` and cache lock/refcount pass when load mode is not 3
  - sets `PartPcs` USB stream `m_fieldLoadReq`
  - builds stage path and performs PTX/PDT load calls

## Functions Improved
- Unit: `main/p_tina`
- Symbol: `LoadFieldPdt0__Fii`

## Match Evidence
- `objdiff-cli diff -p . -u main/p_tina`:
  - `LoadFieldPdt0__Fii`: **1.00% -> 49.79%**

## Plausibility Rationale
- The implementation follows the same style already used in `p_tina.cpp` for `PartMng` load-state offsets and existing cache helper usage.
- Changes prioritize real runtime behavior reconstruction (load mode gates, cache lock/refcount, path + PTX/PDT load flow), not compiler-only coercion.
- Remaining create-loop reconstruction is intentionally deferred until `m_pdtSlots` layout is recovered, to avoid speculative field guesses in this PR.

## Technical Notes
- This is an incremental first pass focused on concrete, non-speculative behavior recovered from the decomp reference.
- The resulting function compiles cleanly with `ninja` and materially improves objdiff alignment for the target symbol.
