### PR TITLE
p_gba: improve __sinit_p_gba_cpp init ordering

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -30,15 +30,13 @@ extern "C" void __sinit_p_gba_cpp(void)
 {
 	*reinterpret_cast<void**>(&GbaPcs) = __vt__8CManager;
 	*reinterpret_cast<void**>(&GbaPcs) = lbl_801E8668;
-
-	unsigned int* table = lbl_8020F328;
-	table[4] = lbl_8020F304[0];
-
 	*reinterpret_cast<void**>(&GbaPcs) = lbl_8020F4A4;
 
+	unsigned int* table = lbl_8020F328;
 	table[1] = lbl_8020F2F8[0];
 	table[2] = lbl_8020F2F8[1];
 	table[3] = lbl_8020F2F8[2];
+	table[4] = lbl_8020F304[0];
 	table[5] = lbl_8020F304[1];
 	table[6] = lbl_8020F304[2];
 	table[7] = lbl_8020F310[0];


### PR DESCRIPTION
## Summary
- Simplified `__sinit_p_gba_cpp` table initialization ordering in `src/p_gba.cpp`.
- Kept the existing vtable-store sequence, but moved `table[4]` into the contiguous function-table assignment block.
- Removed the isolated early write to `table[4]` that occurred before the final process vtable assignment.

## Functions improved
- Unit: `main/p_gba`
- Symbol: `__sinit_p_gba_cpp` (212 bytes)

## Match evidence
- Objdiff command used:
  - `tools/objdiff-cli diff -p . -u main/p_gba -o - __sinit_p_gba_cpp`
- Before: `75.13207%`
- After: `98.30189%`
- Improvement: `+23.16982` percentage points

## Plausibility rationale
- This change preserves the same data assignments while expressing them in a straightforward contiguous vtable/function-table init sequence that is idiomatic for static process table setup in this codebase.
- No contrived temporaries or compiler-coaxing constructs were introduced.

## Technical details
- The previous version emitted one function-table slot write (`table[4]`) earlier than the rest.
- Grouping slots `1..9` and `12..14` into a contiguous assignment block aligned generated code much more closely with the target assembly according to objdiff.
