### PR TITLE
pppYmMiasma: improve pppConstructYmMiasma match

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -16,7 +16,7 @@ extern float FLOAT_8033065c;
 extern float FLOAT_80330660;
 extern float FLOAT_80330664;
 extern float FLOAT_80330668;
-extern u32 DAT_80330658;
+extern float FLOAT_80330658;
 extern int DAT_8032ed70;
 extern double DOUBLE_80330648;
 extern double RandF__5CMathFf(double, void*);
@@ -278,23 +278,22 @@ void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA
  */
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, UnkC* param_2)
 {
-    u32 value;
+    u8* workBytes = (u8*)pppYmMiasma_ + 8 + param_2->m_serializedDataOffsets[2];
     float fVar1 = FLOAT_80330644;
-    u32* work = (u32*)((u8*)pppYmMiasma_ + 8 + param_2->m_serializedDataOffsets[2]);
+    float* work = (float*)workBytes;
 
-    value = DAT_80330658;
-    work[0] = 0;
-    ((float*)work)[7] = fVar1;
-    ((float*)work)[8] = fVar1;
-    ((float*)work)[9] = fVar1;
-    *((u8*)(work + 2)) = 0;
-    work[4] = value;
-    ((float*)work)[5] = fVar1;
-    ((float*)work)[6] = fVar1;
-    ((float*)work)[0xc] = fVar1;
-    ((float*)work)[0xb] = fVar1;
-    ((float*)work)[10] = fVar1;
-    *((u8*)(work + 0xd)) = 0;
+    *(u32*)workBytes = 0;
+    work[7] = fVar1;
+    work[8] = fVar1;
+    work[9] = fVar1;
+    workBytes[8] = 0;
+    work[4] = FLOAT_80330658;
+    work[5] = fVar1;
+    work[6] = fVar1;
+    work[0xc] = fVar1;
+    work[0xb] = fVar1;
+    work[10] = fVar1;
+    workBytes[0x34] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- refactored `pppConstructYmMiasma` initialization stores to use a byte base pointer plus float view, matching how the object blob is laid out
- switched the 0x80330658 constant binding from raw `u32` bits to `float` semantics for the write at offset `+0x10`
- kept behavior unchanged while aligning store forms and offset usage

## Functions improved
- Unit: `main/pppYmMiasma`
- `pppConstructYmMiasma`: **91.45% -> 99.45%**

## Match evidence
- objdiff before: `pppConstructYmMiasma` at 91.45%
- objdiff after: `pppConstructYmMiasma` at 99.45%
- remaining differences reduced to 3 argument mismatches in the function prologue/constant addressing

## Plausibility rationale
- the new code uses direct field-style initialization through typed views over the serialized work area, which is consistent with surrounding ppp object init patterns
- no control-flow tricks or compiler-coaxing temporaries were introduced; this is a straightforward representation of the same initialization logic

## Technical details
- initialization now writes zero to the object pointer slot with `*(u32*)workBytes = 0`
- float slots are set through `float* work` (`work[4..12]` relevant slots)
- byte flags at offsets `+0x08` and `+0x34` remain explicit to preserve structure overlay semantics
