### PR TITLE
MenuUtil: decompile DrawFont and CalcCenteringPos2

### DIFF
--- a/include/ffcc/MenuUtil.h
+++ b/include/ffcc/MenuUtil.h
@@ -10,7 +10,7 @@ class CMenuPcs
 public:
     void CalcHelpLine(int, int&, int&);
     void GetLongHelpString(CFont*, int, int);
-    void CalcCenteringPos2(char*, float, float);
+    float CalcCenteringPos2(char*, float, float);
     float CalcCenteringPos(char*, CFont*);
     void DrawFont(int, int, _GXColor, int, char*, float, float);
     void GetFontWidth(char*, float, float);

--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -1,8 +1,20 @@
 #include "ffcc/MenuUtil.h"
 
 extern "C" float GetWidth__5CFontFPc(CFont*, const char*);
+extern "C" void SetMargin__5CFontFf(float, CFont*);
+extern "C" void SetShadow__5CFontFi(CFont*, int);
+extern "C" void SetScaleX__5CFontFf(float, CFont*);
+extern "C" void SetScaleY__5CFontFf(float, CFont*);
+extern "C" void SetScale__5CFontFf(float, CFont*);
+extern "C" void DrawInit__5CFontFv(CFont*);
+extern "C" void SetTlut__5CFontFi(CFont*, int);
+extern "C" void SetColor__5CFontF8_GXColor(CFont*, _GXColor*);
+extern "C" void SetPosX__5CFontFf(float, CFont*);
+extern "C" void SetPosY__5CFontFf(float, CFont*);
+extern "C" void Draw__5CFontFPc(CFont*, const char*);
 
 extern float lbl_80333558;
+extern float lbl_8033356C;
 extern float lbl_8033358C;
 
 /*
@@ -30,9 +42,15 @@ void CMenuPcs::GetLongHelpString(CFont*, int, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::CalcCenteringPos2(char*, float, float)
+float CMenuPcs::CalcCenteringPos2(char* text, float margin, float scale)
 {
-	// TODO
+	CFont* font = *(CFont**)((unsigned char*)this + 0xF8);
+
+	SetShadow__5CFontFi(font, 1);
+	SetMargin__5CFontFf(margin, font);
+	SetScaleX__5CFontFf(scale, font);
+	SetScaleY__5CFontFf(lbl_8033356C, font);
+	return -(GetWidth__5CFontFPc(font, text) * lbl_80333558 - lbl_8033358C);
 }
 
 /*
@@ -51,9 +69,19 @@ float CMenuPcs::CalcCenteringPos(char* text, CFont* font)
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::DrawFont(int, int, _GXColor, int, char*, float, float)
+void CMenuPcs::DrawFont(int posX, int posY, _GXColor color, int tlut, char* text, float margin, float scale)
 {
-	// TODO
+	CFont* font = *(CFont**)((unsigned char*)this + 0xF8);
+
+	SetMargin__5CFontFf(margin, font);
+	SetShadow__5CFontFi(font, 1);
+	SetScale__5CFontFf(scale, font);
+	DrawInit__5CFontFv(font);
+	SetTlut__5CFontFi(font, tlut);
+	SetColor__5CFontF8_GXColor(font, &color);
+	SetPosX__5CFontFf((float)posX, font);
+	SetPosY__5CFontFf((float)posY, font);
+	Draw__5CFontFPc(font, text);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::DrawFont` in `src/MenuUtil.cpp` using existing `CFont` runtime calls (`SetMargin`, `SetShadow`, `SetScale`, `DrawInit`, `SetTlut`, `SetColor`, `SetPosX`, `SetPosY`, `Draw`).
- Implemented `CMenuPcs::CalcCenteringPos2` using menu font pointer access at `this + 0xF8`, with margin/scale setup and centered width calculation.
- Corrected `CalcCenteringPos2` return type from `void` to `float` in `include/ffcc/MenuUtil.h` to match codegen behavior.

## Functions improved
- Unit: `main/MenuUtil`
- `DrawFont__8CMenuPcsFii8_GXColoriPcff`
- `CalcCenteringPos2__8CMenuPcsFPcff`

## Match evidence
From `build/GCCP01/report.json` fuzzy function percentages:
- `DrawFont__8CMenuPcsFii8_GXColoriPcff`: **1.6666666% -> 88.35%**
- `CalcCenteringPos2__8CMenuPcsFPcff`: **2.4390244% -> 99.51219%**

Build verification:
- `ninja` passes after the change.

## Plausibility rationale
- The new implementations follow existing menu/font usage patterns already present across the codebase (same external `CFont` entry points and call ordering).
- Changes are semantic/type corrections and missing logic restoration rather than compiler-specific coercion tricks.

## Technical details
- Used the Ghidra PAL decomp references for the two symbols as a structural guide, then adapted to project style and existing extern prototypes.
- Kept member access/source behavior plausible by using the same menu font field offset and centering constants (`lbl_80333558`, `lbl_8033356C`, `lbl_8033358C`) seen in adjacent logic.
