### PR TITLE
gx/GXTransform: improve GXSetViewportJitter matching

### DIFF
--- a/src/gx/GXTransform.c
+++ b/src/gx/GXTransform.c
@@ -474,12 +474,15 @@ void GXSetViewport(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz) {
  * JP Size: TODO
  */
 void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz, u32 field) {
+    f32 half;
+    f32 origin;
     f32 sx;
     f32 sy;
     f32 sz;
     f32 ox;
     f32 oy;
     f32 zmax;
+    f32 zScale;
 
     CHECK_GXBEGIN(903, "GXSetViewport");  // not the correct function name
 
@@ -487,21 +490,25 @@ void GXSetViewportJitter(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz,
         top -= 0.5f;
     }
 
-    sx = wd * 0.5f;
-    sy = -ht * 0.5f;
-    zmax = __GXData->zScale * farz;
+    half = 0.5f;
+    origin = 342.0f;
+    sx = wd * half;
+    zScale = __GXData->zScale;
+    zmax = zScale * farz;
+
     __GXData->vpLeft = left;
     __GXData->vpTop = top;
     __GXData->vpWd = wd;
+    sy = -ht * half;
     __GXData->vpHt = ht;
-    ox = 342.0f + (left + sx);
+    ox = origin + (left + sx);
     __GXData->vpNearz = nearz;
-    oy = 342.0f + (top + (ht * 0.5f));
-    sz = zmax - (__GXData->zScale * nearz);
+    oy = origin + (top + (ht * half));
+    sz = zmax - (zScale * nearz);
     __GXData->vpFarz = farz;
 
     if (__GXData->zOffset != 0.0f) {
-        __GXSetRange(nearz, __GXData->zScale);
+        __GXSetRange(nearz, zScale);
     }
 
     GX_WRITE_U8(0x10);


### PR DESCRIPTION
## Summary
Refined `GXSetViewportJitter` to better match original code generation by aligning temporary usage and operation ordering:
- hoisted `0.5f` and `342.0f` into locals used throughout the function
- cached `__GXData->zScale` in a local and reused it for `zmax`, `sz`, and `__GXSetRange`
- adjusted assignment ordering so viewport state writes and derived values are computed in the same sequence as the target

## Functions Improved
- Unit: `main/gx/GXTransform`
- Function: `GXSetViewportJitter`
- Match: **77.83077% -> 81.67693%** (`+3.84616`)

## Match Evidence
Measured with:
```sh
/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/gx/GXTransform -o - GXSetViewportJitter
```
`match_percent` now reports `81.676926` for `GXSetViewportJitter`.

## Plausibility Rationale
These changes are source-plausible and reflect common SDK-era style:
- reuse of semantic constants (`half`, `origin`) instead of repeated literals
- caching device state (`zScale`) before dependent calculations
- straightforward sequencing of derived viewport values and state writes

No contrived control flow or artificial compiler-only constructs were introduced.

## Technical Notes
The improvement comes from closer alignment of FPU value lifetimes and arithmetic sequencing (especially around `zScale`, `sx/sy`, and `sz`), reducing argument/order mismatches in objdiff while preserving behavior.
