### PR TITLE
gobjwork: implement CCaravanWork::AddGil

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -95,7 +95,7 @@ public:
     void DeleteItem(int, int);
     void AddTmpArtifact(int, int*);
     int CanAddGil(int);
-    void AddGil(int);
+    int AddGil(int);
     void GetFoodRank(int);
     void SearchRomLetterWork(CRomLetterWork**, int);
     void ShopRequest(int, int, int, int, int, int, int);

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -493,12 +493,29 @@ int CCaravanWork::CanAddGil(int gilAmount)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a1b5c
+ * PAL Size: 84b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CCaravanWork::AddGil(int)
+int CCaravanWork::AddGil(int gilToAdd)
 {
-	// TODO
+	int totalGil;
+
+	m_gil = m_gil + gilToAdd;
+	totalGil = m_gil;
+	if (totalGil < 100000000) {
+		if (totalGil < 0) {
+			gilToAdd = gilToAdd - totalGil;
+			m_gil = 0;
+		}
+	} else {
+		m_gil = totalGil - (totalGil + -99999999);
+		gilToAdd = gilToAdd - (totalGil + -99999999);
+	}
+	return gilToAdd;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CCaravanWork::AddGil(int)` in `src/gobjwork.cpp` using the expected gil clamp behavior.
- Corrected declaration in `include/ffcc/gobjwork.h` from `void AddGil(int)` to `int AddGil(int)`.
- Added PAL function metadata block for `AddGil`.

## Functions Improved
- Unit: `main/gobjwork`
- Function: `AddGil__12CCaravanWorkFi`

## Match Evidence
- `AddGil__12CCaravanWorkFi`: **4.7619047% -> 58.04762%** (`objdiff-cli` symbol diff)
- `main/gobjwork` unit fuzzy: **18.187513 -> 18.417334** (`build/GCCP01/report.json`)

## Plausibility Rationale
- The change restores natural game logic: add gil, clamp to `0..99,999,999`, and return the effectively applied delta.
- This behavior is source-plausible for gameplay/accounting and avoids contrived compiler-only rewrites.

## Technical Notes
- The final arithmetic form in the upper-bound clamp was adjusted to improve MWCC codegen alignment for this symbol.
- Build verification: `ninja` passes after the change.
