### PR TITLE
gobject: implement CGObject::CancelAnim

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -710,12 +710,35 @@ void CGObject::IsAnimFinished(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8007c7b8
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGObject::CancelAnim(int)
+void CGObject::CancelAnim(int keepFacing)
 {
-	// TODO
+	m_currentAnimSlot = -1;
+
+	u8 flags = *((u8*)&m_shieldNodeFlags);
+	flags &= 0xbf;
+	*((u8*)&m_shieldNodeFlags) = flags;
+
+	m_turnSpeed = sZeroFloat;
+
+	if (keepFacing != 0)
+	{
+		m_rotTargetY = m_rotBaseY;
+	}
+
+	flags = *((u8*)&m_shieldNodeFlags);
+	flags &= 0xf7;
+	*((u8*)&m_shieldNodeFlags) = flags;
+
+	flags = *((u8*)&m_shieldNodeFlags);
+	flags &= 0x7f;
+	*((u8*)&m_shieldNodeFlags) = flags;
 }
 
 /*


### PR DESCRIPTION
## Summary
Implements `CGObject::CancelAnim(int)` in `src/gobject.cpp` using the PAL-addressed behavior at `0x8007C7B8`.

Changes made:
- Added function info block with PAL address/size metadata.
- Implemented animation cancellation state updates:
- reset current anim slot
- clear relevant `m_shieldNodeFlags` bits
- reset turn speed
- optionally copy `m_rotBaseY` to `m_rotTargetY`

## Functions improved
- Unit: `main/gobject`
- Symbol: `CancelAnim__8CGObjectFi`
- Size: 80 bytes
- Match: **5.0% -> 61.0%**

## Match evidence
- `ninja` rebuild passes.
- `tools/objdiff-cli diff -p . -u main/gobject -o - CancelAnim__8CGObjectFi` now reports:
- `match_percent: 61.0`
- `size: 80`
- Improvement is instruction-level alignment (state writes/bit-flag updates), not rename-only noise.

## Plausibility rationale
The implementation is source-plausible engine code: straightforward state reset + flag masking + optional facing preservation. It avoids compiler-coaxing patterns and matches how nearby animation state functions in this unit are structured.

## Technical details
- The implementation follows the control/data updates shown by the PAL decomp reference for this function.
- Remaining mismatch appears in exact bit-op instruction selection/order, but the routine now has the correct object-field side effects and function shape.
