### PR TITLE
memory: implement CAmemCacheSet Release/AssertCache/RefCnt0Compare

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1780,12 +1780,50 @@ void CAmemCacheSet::AddRef(short index)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001CBF4
+ * PAL Size: 340b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CAmemCacheSet::Release(short)
+void CAmemCacheSet::Release(short index)
 {
-	// TODO
+    unsigned char* bytes = reinterpret_cast<unsigned char*>(this);
+    int tableBase = *reinterpret_cast<int*>(bytes + 0x58);
+    int entryOffset = static_cast<int>(index) * 0x1C;
+    int entry = tableBase + entryOffset;
+
+    *reinterpret_cast<short*>(entry + 0x0C) -= 1;
+    if (*reinterpret_cast<short*>(entry + 0x0C) == -1) {
+        if (System.m_execParam > 2) {
+            Printf__7CSystemFPce(&System, "--------------------------------\n");
+        }
+
+        int count = *reinterpret_cast<int*>(bytes + 0x3C);
+        int offset = 0;
+        for (int i = 0; i < count; i++) {
+            unsigned char* current = reinterpret_cast<unsigned char*>(tableBase + offset);
+            int data = *reinterpret_cast<int*>(current + 0x00);
+            if ((current[0x0E] != 0 || data != 0) && System.m_execParam > 2) {
+                const char* useType = (current[0x0E] == 0) ? "FREE" : "USE";
+                Printf__7CSystemFPce(
+                    &System, "%3d %s type:%d RefCnt:%d prio:%d data:%08x\n", i, useType,
+                    static_cast<int>(current[0x0F]), *reinterpret_cast<short*>(current + 0x0C),
+                    *reinterpret_cast<int*>(current + 0x10), data);
+            }
+            offset += 0x1C;
+        }
+
+        if (System.m_execParam > 2) {
+            Printf__7CSystemFPce(&System, "--------------------------------\n");
+        }
+
+        void (*underflowHook)(int) = *reinterpret_cast<void (**)(int)>(bytes + 0x50);
+        if (underflowHook != 0) {
+            underflowHook(static_cast<int>(index));
+        }
+    }
 }
 
 /*
@@ -1970,22 +2008,75 @@ void CAmemCacheSet::RefCnt0Clear()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001C52C
+ * PAL Size: 260b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CAmemCacheSet::RefCnt0Compare()
 {
-	// TODO
+    unsigned char* bytes = reinterpret_cast<unsigned char*>(this);
+
+    if (System.m_execParam > 2) {
+        Printf__7CSystemFPce(&System, "---------- RefCnt0 Compare ----------\n");
+    }
+
+    int count = *reinterpret_cast<int*>(bytes + 0x3C);
+    int offset = 0;
+    for (int i = 0; i < count; i++) {
+        unsigned char* entry = reinterpret_cast<unsigned char*>(*reinterpret_cast<int*>(bytes + 0x58) + offset);
+        if ((entry[0x0E] != 0 && *reinterpret_cast<short*>(entry + 0x0C) != 0) && System.m_execParam > 2) {
+            const char* useType = (entry[0x0E] == 0) ? "FREE" : "USE";
+            Printf__7CSystemFPce(
+                &System, "%3d %s type:%d RefCnt:%d prio:%d data:%08x\n", i, useType, static_cast<int>(entry[0x0F]),
+                *reinterpret_cast<short*>(entry + 0x0C), *reinterpret_cast<int*>(entry + 0x10),
+                *reinterpret_cast<int*>(entry + 0x00));
+        }
+        offset += 0x1C;
+    }
+
+    if (System.m_execParam > 2) {
+        Printf__7CSystemFPce(&System, "--------------------------------\n");
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001C40C
+ * PAL Size: 288b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CAmemCacheSet::AssertCache()
 {
-	// TODO
+    unsigned char* bytes = reinterpret_cast<unsigned char*>(this);
+
+    if (System.m_execParam > 2) {
+        Printf__7CSystemFPce(&System, "--------------------------------\n");
+    }
+
+    int count = *reinterpret_cast<int*>(bytes + 0x3C);
+    int offset = 0;
+    for (int i = 0; i < count; i++) {
+        unsigned char* entry = reinterpret_cast<unsigned char*>(*reinterpret_cast<int*>(bytes + 0x58) + offset);
+        int data = *reinterpret_cast<int*>(entry + 0x00);
+        if ((entry[0x0E] != 0 || data != 0) && System.m_execParam > 2) {
+            const char* useType = (entry[0x0E] == 0) ? "FREE" : "USE";
+            Printf__7CSystemFPce(
+                &System, "%3d %s type:%d RefCnt:%d prio:%d data:%08x\n", i, useType,
+                static_cast<int>(entry[0x0F]), *reinterpret_cast<short*>(entry + 0x0C),
+                *reinterpret_cast<int*>(entry + 0x10), data);
+        }
+        offset += 0x1C;
+    }
+
+    if (System.m_execParam > 2) {
+        Printf__7CSystemFPce(&System, "--------------------------------\n");
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CAmemCacheSet::Release(short)` from decomp context, including refcount underflow handling, debug dump, and callback dispatch.
- Implemented `CAmemCacheSet::AssertCache()` and `CAmemCacheSet::RefCnt0Compare()` debug scan paths using existing cache table field semantics.
- Added PAL address/size headers for the three functions.

## Functions improved
- Unit: `main/memory`
- `Release__13CAmemCacheSetFs`: **1.1764706% -> 60.17647%**
- `AssertCache__13CAmemCacheSetFv`: **1.3888888% -> 60.583332%**
- `RefCnt0Compare__13CAmemCacheSetFv`: **1.5384616% -> 47.49231%**

## Match evidence
- Built with `ninja` after edits (successful).
- Compared `main/memory` with `tools/objdiff-cli` before/after; each targeted symbol moved from ~1% (TODO stubs) to substantial non-trivial matches.
- Improvements are from generated code changes in these function bodies, not formatting or symbol-only churn.

## Plausibility rationale
- Changes follow existing `memory.cpp` patterns already used in nearby methods (`AddRef`, `CacheClear`, pointer-offset field access).
- Logic aligns with expected cache lifecycle behavior: decrement refcount, underflow diagnostics, and cache-state debug dumps.
- No compiler-coaxing patterns or artificial reordering were introduced; implementation remains readable and consistent with surrounding source style.

## Technical details
- Reused existing debug print format used by cache diagnostics (`%3d %s type:%d RefCnt:%d prio:%d data:%08x\n`).
- Preserved callback hook behavior via function pointer at offset `0x50` for underflow notification.
- Kept field interactions at established offsets (`0x3C`, `0x58`, entry stride `0x1C`) to match current object layout assumptions.
