### PR TITLE
pppVertexAp: align child-id sentinel check pattern

### DIFF
--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -135,10 +135,10 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                 f32 y = vertex->y;
                 f32 z = vertex->z;
 
-                s32 childId = data->childId;
-                if ((u16)childId != 0xFFFF) {
+                if ((data->childId + 0x10000) != 0xFFFF) {
                     _pppPObject* child;
-                    _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
+                    _pppPDataVal* childData =
+                        (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
                     Vec pos;
                     Vec worldPos;
                     Vec* outPos;
@@ -173,10 +173,10 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                 f32 y = vertex->y;
                 f32 z = vertex->z;
 
-                s32 childId = data->childId;
-                if ((u16)childId != 0xFFFF) {
+                if ((data->childId + 0x10000) != 0xFFFF) {
                     _pppPObject* child;
-                    _pppPDataVal* childData = (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (childId << 4));
+                    _pppPDataVal* childData =
+                        (_pppPDataVal*)((u8*)*(u32*)((u8*)lbl_8032ED50 + 0xD4) + (data->childId << 4));
                     Vec pos;
                     Vec worldPos;
                     Vec* outPos;


### PR DESCRIPTION
## Summary
Adjusted `pppVertexAp` child creation guard logic to use the same sentinel-check form already used in related `pppVertex*` routines.

- Replaced `(u16)childId != 0xFFFF` with `(data->childId + 0x10000) != 0xFFFF`
- Kept control flow and behavior otherwise unchanged
- Reused `data->childId` directly for child table lookup offset

## Functions improved
- Unit: `main/pppVertexAp`
- Function: `pppVertexAp`

## Match evidence
From `build/GCCP01/report.json` after `ninja`:
- `pppVertexAp`: **79.07217% -> 79.38145%** (`+0.30928`)
- `main/pppVertexAp` unit: **79.90099% -> 80.19802%** (`+0.29703`)

## Plausibility rationale
This is a source-plausible alignment, not compiler coaxing:
- The sentinel check form matches existing idioms already present in nearby `pppVertex*` implementations.
- No artificial temporaries or unnatural reorderings were introduced.
- The resulting code remains readable and consistent with local style.

## Technical details
- Baseline and updated scores were validated via `ninja` report generation (`build/GCCP01/report.json`).
- Interactive `objdiff-cli diff -p . -u main/pppVertexAp pppVertexAp` reflects the expected incremental improvement for the target symbol.
