### PR TITLE
RedDriver: improve GetSoundMode match

### DIFF
--- a/include/ffcc/RedSound/RedDriver.h
+++ b/include/ffcc/RedSound/RedDriver.h
@@ -59,7 +59,7 @@ public:
 	void End();
 	int GetProgramTime();
 	void SetSoundMode(int);
-	void GetSoundMode();
+	int GetSoundMode();
 	void SetMusicData(void*);
 	void ReentryMusicData(int);
 	void MusicStop(int);

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1275,9 +1275,14 @@ void CRedDriver::SetSoundMode(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedDriver::GetSoundMode()
+int CRedDriver::GetSoundMode()
 {
-	// TODO
+    if (OSGetSoundMode() == 0) {
+        DAT_8032f400 = 1;
+    } else {
+        DAT_8032f400 = DAT_8032f3c8;
+    }
+    return DAT_8032f400;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `CRedDriver::GetSoundMode` in `src/RedSound/RedDriver.cpp` from a TODO stub to concrete logic matching the PAL decomp structure.
- Aligned method signature in `include/ffcc/RedSound/RedDriver.h` to return `int` (matching usage/target symbol behavior).
- Left other nearby RedDriver methods unchanged after validating they did not improve fuzz metrics.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Function: `GetSoundMode__10CRedDriverFv`

## Match evidence
- `GetSoundMode__10CRedDriverFv`: **5.5555553% -> 56.333332%** fuzzy match (from `build/GCCP01/report.json` before/after rebuild comparison).
- Control check (unchanged):
  - `End__10CRedDriverFv`: 2.857143% -> 2.857143%
  - `SetSoundMode__10CRedDriverFi`: 5.5555553% -> 5.5555553%

## Plausibility rationale
- The change replaces an empty placeholder with straightforward console sound-mode retrieval and cached mode update logic.
- Implementation remains idiomatic and readable for this codebase (no artificial temporaries, no layout tricks, no coercive compiler-only rewrites).

## Technical details
- Implemented:
  - `if (OSGetSoundMode() == 0) DAT_8032f400 = 1; else DAT_8032f400 = DAT_8032f3c8; return DAT_8032f400;`
- This mirrors the observed branching/data-flow in the PAL Ghidra reference while keeping source-level style consistent with existing RedDriver code.
