### PR TITLE
RedCommand: improve SearchSeEmptyTrack by preventing _EraseAttribute inlining

### DIFF
--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -50,6 +50,7 @@ int* SetReverb(int, int, int*);
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 void _EraseAttribute(int eraseTrack, int attrMask)
 {
 	int* trackBasePtr = (int*)((char*)DAT_8032f3f0 + 0xdbc);
@@ -83,6 +84,7 @@ void _EraseAttribute(int eraseTrack, int attrMask)
 		track += 0x55;
 	} while (track < (int*)(*trackBasePtr + 0x2a80));
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Added `#pragma dont_inline on/reset` around `_EraseAttribute` in `src/RedSound/RedCommand.cpp`.
- This keeps `SearchSeEmptyTrack__Fiii` in call-form instead of inlining `_EraseAttribute`, improving control-flow and call shape.

## Functions Improved
- Unit: `main/RedSound/RedCommand`
- Symbol: `SearchSeEmptyTrack__Fiii`

## Match Evidence
- `SearchSeEmptyTrack__Fiii`: **0.00% -> 43.22%** (objdiff oneshot JSON).
- Local object symbol size moved from **0x1AC -> 0xF4** bytes (`build/GCCP01/src/RedSound/RedCommand.o`), much closer to original **0xFC** (`build/GCCP01/obj/RedSound/RedCommand.o`).
- Build verification still passes: `build/GCCP01/main.dol: OK`.

## Plausibility Rationale
- `dont_inline` pragmas are already used in this codebase (including RedSound files).
- The change expresses a plausible original compiler-control intent for a large helper and does not introduce contrived logic or readability regressions.

## Technical Details
- Before change, `SearchSeEmptyTrack__Fiii` absorbed `_EraseAttribute` logic, creating major prologue/control-flow divergence.
- After change, it emits a direct call to `_EraseAttribute`, reducing divergence and restoring the expected high-level structure for this function.
