### PR TITLE
RedMidiCtrl: implement KeyOffSet with isolated inlining behavior

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -85,13 +85,42 @@ void KeyOnReserve(RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C75F4
+ * PAL Size: 220b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void KeyOffSet(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+#pragma dont_inline on
+void KeyOffSet(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 {
-	// TODO
+    char key;
+    int* slot;
+
+    if (((void*)control == (void*)((int)DAT_8032f3f0 + 0x928)) || ((((unsigned int*)track)[0x41] & 0x80000) == 0)) {
+        ((int*)track)[0x44] = 0;
+        key = ((char*)track)[0x24];
+        slot = (int*)keyOnData;
+        do {
+            if ((*slot == (int)track) && (*(char*)(slot + 1) == key)) {
+                *slot = 0;
+            }
+            slot += 2;
+        } while (slot < (int*)((int)keyOnData + 0x600));
+
+        key = ((char*)track)[0x24];
+        slot = (int*)DAT_8032f444;
+        do {
+            if ((*slot == (int)track && (*(char*)(slot + 6) == key))) {
+                slot[0x24] &= 0xfffffffe;
+                slot[0x24] |= 2;
+            }
+            slot += 0x30;
+        } while (slot < (int*)(DAT_8032f444 + 0xc00));
+    }
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Implemented `KeyOffSet__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA` in `src/RedSound/RedMidiCtrl.cpp` from a decomp-guided first pass.
- Added PAL function metadata block for this function (`0x801C75F4`, `220b`).
- Wrapped `KeyOffSet` with `#pragma dont_inline on/reset` to prevent inlining side effects into callers in this TU.

## Functions improved
- Unit: `main/RedSound/RedMidiCtrl`
- Symbol: `KeyOffSet__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - Before: `1.8181819%`
  - After: `63.436363%`
  - Delta: `+61.6181811`

## Match evidence
Measured by rebuilding `RedMidiCtrl.o` before/after and comparing `build/GCCP01/report.json`:
- `KeyOffSet__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`: `1.8181819% -> 63.436363%`
- `__MidiCtrl_Stop__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`: `80.76316% -> 81.64035%`
- Unit `main/RedSound/RedMidiCtrl` fuzzy match: `13.008572 -> 14.2546425`

## Plausibility rationale
- The implementation uses existing codebase conventions (raw pointer arithmetic on track/key-on/voice buffers, flag masking, and in-place slot clearing).
- The logic matches expected runtime behavior for key-off cleanup in both key reserve and live voice tables.
- `#pragma dont_inline` keeps the function boundary stable for matching while preserving straightforward, readable source.

## Technical details
- Initial implementation improved `KeyOffSet` but caused a regression in `__MidiCtrl_Stop` due optimizer inlining.
- After isolating `KeyOffSet` with `#pragma dont_inline`, the caller regression was eliminated and both symbol-level and unit-level fuzzy scores improved.
