### PR TITLE
RedCommand: improve SeStopMG match via signed track offset math

### DIFF
--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -278,9 +278,9 @@ int SeStopMG(int bank, int sep, int group, int kind)
 		if ((*track != 0) && ((track[0x3d] & 0x80000000U) == 0)) {
 			int id = track[0x3d] / 1000 + (track[0x3d] >> 0x1f);
 			id = id - (id >> 0x1f);
-			if ((bank != id) && (sep != id) && (group != id) && (kind != id)) {
-				unsigned char trackNo;
-				unsigned int* seTrack;
+				if ((bank != id) && (sep != id) && (group != id) && (kind != id)) {
+					int trackNo;
+					int seTrackOffset;
 
 				KeyOnReserveClear((RedKeyOnDATA*)DAT_8032f3fc, (RedTrackDATA*)track);
 				track[0x3e] = 0;
@@ -288,14 +288,14 @@ int SeStopMG(int bank, int sep, int group, int kind)
 				*track = 0;
 				track[0x16] = 0;
 
-				trackNo = *(unsigned char*)((char*)track + 0x14e);
-				((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= (unsigned char)0xfa;
-				seTrack = (unsigned int*)((unsigned char*)DAT_8032f444 + trackNo * 0xc0);
-				seTrack[0x25] &= 0xfffffff7;
-				seTrack[0x24] &= 0xfffffffe;
-				seTrack[0x24] |= 2;
-				seTrack[0] = 0;
-				seTrack[0x23] = 0;
+					trackNo = *(char*)((char*)track + 0x14e);
+					seTrackOffset = trackNo * 0xc0;
+					((unsigned char*)DAT_8032f444)[seTrackOffset + 0x1a] &= (unsigned char)0xfa;
+					*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x94) &= 0xfffffff7;
+					*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x90) &= 0xfffffffe;
+					*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x90) |= 2;
+					*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset) = 0;
+					*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x8c) = 0;
 
 				if (track[6] != 0) {
 					DAT_8032e154.WaveHistoryManager(0, *(short*)(track[6] + 2));


### PR DESCRIPTION
## Summary
- Updated `SeStopMG` in `src/RedSound/RedCommand.cpp` to use signed `char`-derived track index arithmetic and direct SE-track offset writes.
- Kept behavior unchanged while aligning generated code with expected RedSound track-table access patterns.

## Functions Improved
- Unit: `main/RedSound/RedCommand`
- Function: `SeStopMG__Fiiii` (`PAL 0x801ca638`, 464b)

## Match Evidence
- `SeStopMG__Fiiii`: **47.146553% -> 53.396553%** (`+6.25` points)
- Measured with:
  - `tools/objdiff-cli diff -p . -u main/RedSound/RedCommand -o - SeStopMG__Fiiii`

## Plausibility Rationale
- The changes are type/representation corrections (`char` sign extension + offset arithmetic), which are source-plausible for original game code and common in this codebase.
- No contrived control-flow or artificial compiler coaxing was introduced.

## Technical Details
- Replaced `unsigned char trackNo` + pointer-indexed `seTrack[...]` accesses with signed `trackNo` and explicit byte-offset writes against `DAT_8032f444`.
- This better matches the expected sign-extension and repeated offset materialization pattern in the target assembly.
