### PR TITLE
THPSimple: improve Open/PreLoad matching via loop/type shaping

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -169,6 +169,7 @@ s32 THPSimpleOpen(const char* path)
 {
     u32 componentIdx;
     s32 componentOffset;
+    u8* frameComp;
 
     if ((lbl_8032EE48 == 0) || (SimpleControl.isOpen != 0)) {
         return 0;
@@ -211,8 +212,9 @@ s32 THPSimpleOpen(const char* path)
     SimpleControl.hasAudio = 0;
     componentOffset = static_cast<s32>(SimpleControl.header.mCompInfoDataOffsets + sizeof(THPFrameCompInfo));
 
+    frameComp = SimpleControl.compInfo.mFrameComp;
     for (componentIdx = 0; componentIdx < SimpleControl.compInfo.mNumComponents; componentIdx++) {
-        if (SimpleControl.compInfo.mFrameComp[componentIdx] == 1) {
+        if (*frameComp == 1) {
             while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, sReadBuffer, 0x20, componentOffset, (DVDCallback)0, 2)) {
                 checkError();
             }
@@ -223,7 +225,7 @@ s32 THPSimpleOpen(const char* path)
             memcpy(&SimpleControl.audioInfo, sReadBuffer, sizeof(THPAudioInfo));
             componentOffset += sizeof(THPAudioInfo);
             SimpleControl.hasAudio = 1;
-        } else if (SimpleControl.compInfo.mFrameComp[componentIdx] == 0) {
+        } else if (*frameComp == 0) {
             while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, sReadBuffer, 0x20, componentOffset, (DVDCallback)0, 2)) {
                 checkError();
             }
@@ -236,6 +238,7 @@ s32 THPSimpleOpen(const char* path)
         } else {
             return 0;
         }
+        frameComp++;
     }
 
     SimpleControl.readOffset = static_cast<s32>(SimpleControl.header.mMovieDataOffsets);
@@ -461,21 +464,23 @@ void __THPSimpleDVDCallback(long result, DVDFileInfo*)
  */
 s32 THPSimplePreLoad(s32 loop)
 {
-    s32 i;
     s32 status;
-    u32 readCount = 8;
+    u32 i;
+    u32 readCount;
 
     if ((SimpleControl.isOpen == 0) || (SimpleControl.isPreLoaded != 0)) {
         return 0;
     }
 
+    readCount = 8;
     if ((loop == 0) && (SimpleControl.header.mNumFrames < 8)) {
         readCount = SimpleControl.header.mNumFrames;
     }
 
-    for (i = 0; i < static_cast<s32>(readCount); i++) {
-        while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, SimpleControl.readBuffer[SimpleControl.readIndex].mPtr,
-                                 SimpleControl.readSize, SimpleControl.readOffset, static_cast<DVDCallback>(0), 2)) {
+    for (i = 0; i < readCount; i++) {
+        while ((status = DVDReadAsyncPrio(&SimpleControl.fileInfo, SimpleControl.readBuffer[SimpleControl.readIndex].mPtr,
+                                          SimpleControl.readSize, SimpleControl.readOffset,
+                                          static_cast<DVDCallback>(0), 2)) == 0) {
             status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
             if ((status == 0xB) || ((status - 4U) < 3) || (status == -1)) {
                 File.DrawError(SimpleControl.fileInfo, status);


### PR DESCRIPTION
## Summary
- Refined `THPSimpleOpen` component parsing to iterate with a component-byte pointer (`frameComp`) instead of repeated indexed reads.
- Refined `THPSimplePreLoad` loop/control-flow typing to use unsigned iteration and status-assignment in the async-read loop condition.
- Kept behavior unchanged while moving generated control flow/register usage closer to target assembly.

## Functions improved
- Unit: `main/THPSimple`
- `THPSimpleOpen`: **60.3% -> 61.1%** fuzzy match (`1412b`)
- `THPSimplePreLoad`: **68.7% -> 70.5%** fuzzy match (`544b`)
- Unit fuzzy match: **72.1% -> 72.4%**

## Match evidence
- Rebuilt with `ninja` and regenerated `build/GCCP01/report.json`.
- `objdiff-cli diff -p . -u main/THPSimple THPSimplePreLoad` showed improved instruction alignment in the function prologue/control-flow region after the loop/type changes.
- `objdiff-cli diff -p . -u main/THPSimple THPSimpleOpen` showed improved alignment around component dispatch and branch structure after pointer-based iteration.

## Plausibility rationale
- Pointer walking over a component byte array and unsigned loop bounds are natural source-level choices for this parsing code.
- No compiler-coaxing artifacts, no magic offsets added, and no readability regressions.

## Technical details
- `THPSimpleOpen`: introduced `u8* frameComp`, switched comparisons to `*frameComp`, incremented once per component.
- `THPSimplePreLoad`: changed loop index to `u32`, removed signed cast in loop bound, and assigned DVD async call result into `status` inside loop condition to better match original control-flow shape.
