### PR TITLE
RedDriver: implement _SetSoundMode and improve match

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -133,12 +133,31 @@ extern "C" void __sinit_RedDriver_cpp(void)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801bcf0c
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void _SetSoundMode(int*)
+void _SetSoundMode(int* param_1)
 {
-	// TODO
+    int soundMode;
+
+    soundMode = *param_1;
+    DAT_8032f3c8 = soundMode;
+    if (soundMode == 1) {
+        OSSetSoundMode(0);
+    } else {
+        OSSetSoundMode(1);
+    }
+    soundMode = DAT_8032f3c8;
+    DAT_8032f400 = soundMode;
+    if (soundMode == 2) {
+        AXSetMode(2);
+    } else {
+        AXSetMode(0);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
Implements `_SetSoundMode(int*)` in `src/RedSound/RedDriver.cpp` using source-plausible control flow and existing SDK APIs.

Changes made:
- Replaced TODO stub with real logic that:
  - stores requested mode to `DAT_8032f3c8`
  - routes to `OSSetSoundMode(0/1)` based on mode
  - mirrors mode into `DAT_8032f400`
  - sets AX output mode via `AXSetMode(2/0)`
- Updated the function info block with PAL address/size metadata.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `_SetSoundMode__FPi`

## Match evidence
- `objdiff-cli` (symbol diff, one-shot JSON):
  - Before: `3.2258065%`
  - After: `66.741936%`
- `build/GCCP01/report.json` fuzzy match:
  - `_SetSoundMode__FPi`: `67.22581%`

## Technical details
- Used `tools/objdiff-cli v3.6.1` for one-shot JSON diff on `main/RedSound/RedDriver`.
- Improvement came from aligning the function’s branch and call structure with target assembly (sound-mode branch followed by AX-mode branch), not from formatting/renaming changes.

## Plausibility rationale
This implementation is consistent with expected original game-source behavior:
- Uses named SDK entry points (`OSSetSoundMode`, `AXSetMode`) rather than compiler-coaxing tricks.
- Keeps straightforward state synchronization between driver globals and hardware mode setup.
- Maintains readable, idiomatic control flow for a small state-application routine.
