### PR TITLE
Improve createViewer match in p_chara_viewer

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -383,18 +383,13 @@ extern "C" void createViewer__9CCharaPcsFv(void* param_1)
     p[0xE9] = 0x3F;
     p[0xEA] = 0x3F;
     p[0xEB] = 0xFF;
-    p[0xF0] = 0x3F;
-    p[0xF1] = 0x3F;
-    p[0xF2] = 0x3F;
-    p[0xF3] = 0xFF;
-    p[0xF4] = 0;
-    p[0xF5] = 0;
-    p[0xF6] = 0;
-    p[0xF7] = 0xFF;
-    p[0xF8] = 0;
-    p[0xF9] = 0;
-    p[0xFA] = 0;
-    p[0xFB] = 0xFF;
+    for (i = 0; i < 3; i++) {
+        unsigned char c = (unsigned char)(-((__cntlzw(i) >> 5) & 1) & 0x3F);
+        p[0xF0 + i * 4 + 0] = c;
+        p[0xF0 + i * 4 + 1] = c;
+        p[0xF0 + i * 4 + 2] = c;
+        p[0xF0 + i * 4 + 3] = 0xFF;
+    }
     *(float*)(p + 0x108) = lbl_80330BE8;
     *(float*)(p + 0x10C) = lbl_80330BE8;
     *(float*)(p + 0x110) = lbl_80330C28;
@@ -443,7 +438,9 @@ extern "C" void createViewer__9CCharaPcsFv(void* param_1)
     *(int*)(p + 0x1A4) = 0;
     *(int*)(p + 0x1A8) = 0;
     *(int*)(p + 0x1AC) = 0;
-    memset(p + 0x1B0, 0, 0x100);
+    for (i = 0; i < 0x40; i++) {
+        *(int*)(p + 0x1B0 + i * 4) = 0;
+    }
 
     strcpy((char*)(p + 0x2C0), lbl_801DA7E8 + 0x11C);
     *(int*)(p + 0x2BC) = 1;


### PR DESCRIPTION
## Summary
- Reworked diffuse-light color initialization in `createViewer__9CCharaPcsFv` to use the original-style `__cntlzw`-derived expression instead of hardcoded per-light constants.
- Replaced `memset(p + 0x1B0, 0, 0x100)` with an explicit pointer-slot zeroing loop over the 0x40 animation entries.
- Kept behavior unchanged while making code generation closer to the original object layout/flow.

## Functions improved
- Unit: `main/p_chara_viewer`
- Function: `createViewer__9CCharaPcsFv`
  - Before: `44.205635%`
  - After: `57.58028%`

## Match evidence
- `objdiff-cli diff -p . -u main/p_chara_viewer ...`
- Unit `.text` fuzzy match:
  - Before: `42.827747%`
  - After: `45.313614%`
- Neighboring major functions remained stable:
  - `drawViewer__9CCharaPcsFv`: `41.1%` (unchanged)
  - `calcViewer__9CCharaPcsFv`: `36.10202%` (unchanged)

## Plausibility rationale
- The `__cntlzw` bit-expression aligns with existing bit-manipulation style in this codebase and with the decompilation pattern for this routine, rather than relying on hand-picked constants.
- Explicitly clearing the animation pointer table by slot is a plausible original-source approach for a fixed-size pointer array and better matches observed object code shape than a generic `memset` call.

## Technical details
- The previous version encouraged a different lowering path for both constant materialization and zero-initialization.
- Constraining both regions to fixed-width integer/pointer operations improved instruction selection and scheduling alignment in `createViewer__9CCharaPcsFv` without introducing contrived control flow.
