### PR TITLE
p_minigame: match GetTable and align lifecycle stubs

### DIFF
--- a/include/ffcc/p_minigame.h
+++ b/include/ffcc/p_minigame.h
@@ -27,7 +27,7 @@ class CMiniGamePcs : public CProcess
 public:
     CMiniGamePcs();
 
-    void GetTable(unsigned long);
+    int GetTable(unsigned long);
 
     void Init();
     void Quit();

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -10,7 +10,7 @@ extern unsigned char PartPcs[];
 extern unsigned int lbl_802121A8[];
 extern unsigned int lbl_802121B4[];
 extern unsigned int lbl_802121C0[];
-extern unsigned int lbl_802121CC[];
+extern unsigned char lbl_802121CC[];
 extern unsigned int lbl_80212348[];
 extern int DAT_800000f8;
 extern char DAT_80331bf0[];
@@ -29,7 +29,7 @@ extern "C" void __dl__FPv(void*);
  */
 extern "C" void __sinit_p_minigame_cpp(void)
 {
-    unsigned int* table = lbl_802121CC;
+    unsigned int* table = reinterpret_cast<unsigned int*>(lbl_802121CC);
     unsigned int* desc0 = lbl_802121A8;
     unsigned int* desc1 = lbl_802121B4;
     unsigned int* desc2 = lbl_802121C0;
@@ -185,32 +185,44 @@ CMiniGamePcs::CMiniGamePcs()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012b188
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMiniGamePcs::GetTable(unsigned long)
+int CMiniGamePcs::GetTable(unsigned long index)
 {
-	// TODO
+    return (int)(lbl_802121CC + (int)index * 0x15C);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012b184
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMiniGamePcs::Init()
 {
-	// TODO
+    return;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012b180
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMiniGamePcs::Quit()
 {
-	// TODO
+    return;
 }
 
 /*
@@ -258,12 +270,16 @@ void CMiniGamePcs::create()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012b0d0
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMiniGamePcs::destroy()
 {
-	// TODO
+    return;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMiniGamePcs::GetTable(unsigned long)` with the unit's table-stride addressing pattern.
- Updated `CMiniGamePcs::GetTable` declaration in `include/ffcc/p_minigame.h` from `void` to `int` to match emitted code behavior.
- Added PAL metadata blocks and explicit empty implementations for `Init`, `Quit`, and `destroy` in `src/p_minigame.cpp`.
- Corrected `lbl_802121CC` storage typing to byte-addressed data (`unsigned char[]`) and casted in `__sinit_p_minigame_cpp` where it is treated as a function table.

## Functions Improved
- Unit: `main/p_minigame`
- Symbol: `GetTable__12CMiniGamePcsFUl`
  - Objdiff (oneshot JSON): **100.0% match**
- Also touched for source consistency / metadata:
  - `Init__12CMiniGamePcsFv`
  - `Quit__12CMiniGamePcsFv`
  - `destroy__12CMiniGamePcsFv`

## Match Evidence
- `ninja` progress before this change-set in the clean worktree: `Code: 213980 / 1855300 bytes (1707 / 4733 functions)`
- `ninja` progress after: `Code: 214000 / 1855300 bytes (1708 / 4733 functions)`
- Unit signal from selector/report context improved by one matched function in `main/p_minigame` (from 3/17 to 4/17), consistent with matching `GetTable`.
- Objdiff detail: final remaining mismatch was resolved by using byte-addressed table storage for `lbl_802121CC`, which fixes stride scaling in emitted `mulli`.

## Plausibility Rationale
- `GetTable` now follows the same idiom used across other process units in this codebase: return base table address plus `index * stride`.
- The `lbl_802121CC` type adjustment is source-plausible and aligns with existing usage: byte-addressed table for offset arithmetic, cast to `unsigned int*` only where descriptor words are written in `__sinit`.
- No contrived control-flow or compiler-coaxing temporaries were introduced; this is a direct type/ABI cleanup consistent with surrounding code style.

## Technical Notes
- Verification command used:
  - `../../tools/objdiff-cli diff -p . -u main/p_minigame -o - GetTable__12CMiniGamePcsFUl`
- Extracted match result from JSON output confirms `GetTable__12CMiniGamePcsFUl` at `100.0`.
