### PR TITLE
menu_equip: improve EquipClose0 codegen via offset hoist

### DIFF
--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -938,12 +938,13 @@ int CMenuPcs::EquipClose0()
 	int remaining;
 	s16* item;
 	int itemCount;
+	int selectedOffset;
 
 	*(s16*)(*(int*)((char*)this + 0x82c) + 0x22) = *(s16*)(*(int*)((char*)this + 0x82c) + 0x22) + 1;
 	timer = (int)*(s16*)(*(int*)((char*)this + 0x82c) + 0x22);
+	selectedOffset = *(s16*)(*(int*)((char*)this + 0x82c) + 0x26) * 0x40 + 8;
 	if (7 < timer) {
-		*(s16*)(*(int*)((char*)this + 0x850) + *(s16*)(*(int*)((char*)this + 0x82c) + 0x26) * 0x40 + 8) =
-		    *(s16*)(*(int*)((char*)this + 0x850) + *(s16*)(*(int*)((char*)this + 0x82c) + 0x26) * 0x40 + 8) + 0x13;
+		*(s16*)(*(int*)((char*)this + 0x850) + selectedOffset) = *(s16*)(*(int*)((char*)this + 0x850) + selectedOffset) + 0x13;
 	}
 
 	item = *(s16**)((char*)this + 0x850);
@@ -991,7 +992,7 @@ int CMenuPcs::EquipClose0()
 	}
 
 	if (itemCount == doneCount) {
-		selected = (s16*)(*(int*)((char*)this + 0x850) + *(s16*)(*(int*)((char*)this + 0x82c) + 0x26) * 0x40 + 8);
+		selected = (s16*)(*(int*)((char*)this + 0x850) + selectedOffset);
 		*selected = (s16)(int)-(((double)(((unsigned int)(short)selected[2] ^ 0x80000000U) | 0x4330000000000000ULL) - DOUBLE_80332ed8) *
 		                        DOUBLE_80332ed0 -
 		                        DOUBLE_80332ec8);


### PR DESCRIPTION
## Summary
Hoist the selected equipment entry offset in `CMenuPcs::EquipClose0` and reuse it for both write sites.

## Functions improved
- Unit: `main/menu_equip`
- Function: `EquipClose0__8CMenuPcsFv`

## Match evidence
- `EquipClose0__8CMenuPcsFv`: `16.511627%` -> `16.612404%`
- Unit `.text` match (objdiff): `32.89624%` -> `32.901554%`

Measured with:
- `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/menu_equip -o diff_menu_equip_baseline.json --format json-pretty`
- `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/menu_equip -o diff_menu_equip_final.json --format json-pretty`

## Plausibility rationale
The change removes duplicated pointer/offset recomputation and uses one local offset value, which is a normal source-level cleanup the original code could plausibly have used.

## Technical details
- Introduced `selectedOffset` in `EquipClose0`.
- Reused this value in the `timer > 7` update and final completion writeback path.
- No behavior changes; control flow and calculations are unchanged.
