### PR TITLE
cflat_r2system: match __ct__14PPPCREATEPARAMFv

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -952,17 +952,15 @@ extern "C" char* GetNumSysMes__5CGameFv(void* game, int index)
 /*
  * --INFO--
  * PAL Address: 0x800B9538
- * PAL Size: 116b
+ * PAL Size: 16b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void __ct__14PPPCREATEPARAMFv2(PPPCREATEPARAM* pppCreateParam);
-
-extern "C" void __ct__14PPPCREATEPARAMFv(PPPCREATEPARAM* pppCreateParam)
+extern "C" char* __ct__14PPPCREATEPARAMFv(void* game, int index)
 {
-    __ct__14PPPCREATEPARAMFv2(pppCreateParam);
+    return ((char**)((char*)game + 0x10C))[index];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `__ct__14PPPCREATEPARAMFv` in `src/cflat_r2system.cpp` to match its actual 16-byte code shape in the target object.
- Replaced the previous wrapper/call-through form with a direct table access at `+0x10C`.
- Updated the function info block size from `116b` to `16b`.

## Functions improved
- Unit: `main/cflat_r2system`
- Symbol: `__ct__14PPPCREATEPARAMFv`
- Match: **0.0% -> 100.0%**
- Size alignment: **32b -> 16b** (now matches base symbol size)

## Match evidence
- Baseline:
  - `tools/objdiff-cli diff -p . -u main/cflat_r2system -o - --format json-pretty __ct__14PPPCREATEPARAMFv`
  - target symbol size/match: `32`, `0.0%`
- After patch:
  - same command
  - target symbol size/match: `16`, `100.0%`
- Project progress (`ninja`): function count improved from `1707/4733` to `1708/4733`.

## Plausibility rationale
- The changed function now follows the same idiomatic raw-offset accessor pattern already used by neighboring `GetSysMes__5CGameFi` and `GetNumSysMes__5CGameFv` helpers in this file.
- This avoids artificial compiler coaxing and instead corrects a symbol/body mismatch so emitted code matches the original object layout.

## Technical details
- Removed the prior wrapper implementation that generated call/epilogue scaffolding.
- Emitted direct indexed load sequence (`slwi/add/lwz/blr`) for this symbol, which aligns with the base object instruction shape and size.
