### PR TITLE
goout: improve CalcGoOut state-machine matching

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -610,9 +610,36 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
  */
 void CGoOutMenu::CalcGoOut()
 {
+    CMenuPcsGoOutLayout& menuPcsLayout = *reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs);
     McCtrl& mcCtrl = *reinterpret_cast<McCtrl*>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0x20);
     unsigned short input;
     unsigned char next;
+
+    if (field_0x1c != 0 && field_0x30 > 0x13 && (field_0x30 & 0xF) == 0) {
+        const int cardStatus = ((field_0x30 & 0x10) == 0) ? mcCtrl.ChkConnect(1) : mcCtrl.ChkConnect(0);
+        if (cardStatus != 1) {
+            field_0x1c = 0;
+            field_0x19 = -1;
+            field_0x18 = 0;
+            WriteMenuShort(menuPcsLayout.field_2120, 0xA, 3);
+            WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+            field_0x36 = -1;
+            field_0x40 = 0;
+            field_0x44 = 1;
+            SetMenuStr(0, 5,
+                       "A Memory Card has been removed.",
+                       "Cancelling character transfer.",
+                       "",
+                       "Please do not remove either Memory Card",
+                       "until the character transfer is complete.");
+            return;
+        }
+    }
+
+    if (field_0x1d != 0) {
+        const unsigned char selInit = static_cast<unsigned char>(__cntlzw(0xF - static_cast<int>(field_0x18)) >> 5 & 0xFF);
+        CalcGoOutSelChar__8CMenuPcsFUcUc(&MenuPcs, selInit, 1);
+    }
 
     switch (field_0x18) {
     case 0:


### PR DESCRIPTION
## Summary
- Added missing pre-switch logic in `CGoOutMenu::CalcGoOut` to better match original control flow.
- Implemented periodic memory-card transfer disconnect handling (`field_0x1c`/`field_0x30` path), including menu state resets and transfer-cancel messaging.
- Added the `CalcGoOutSelChar__8CMenuPcsFUcUc` precompute call gated by `field_0x1d`, with `__cntlzw`-based selector init matching existing style used elsewhere in this unit.

## Functions improved
- Unit: `main/goout`
- Symbol: `CalcGoOut__10CGoOutMenuFv`

## Match evidence
- `CalcGoOut__10CGoOutMenuFv`: **19.163893% -> 20.93406%** (`+1.770167`)
- `main/goout` `.text` section match: **28.240868% -> 28.83498%** (`+0.594112`)
- Verification commands:
  - `tools/objdiff-cli diff -p . -u main/goout -o - CalcGoOut__10CGoOutMenuFv`
  - `ninja`

## Plausibility rationale
- The new logic reflects expected game/menu behavior for interrupted character transfer (card removed mid-process) and uses existing project conventions (`SetMenuStr`, `WriteMenuShort`, mode fields).
- The change corrects missing state-machine behavior rather than introducing compiler-coaxing temporaries or unnatural control flow.

## Technical details
- Added `menuPcsLayout` local to write 16-bit UI state values at the same menu offsets already used in nearby goout code.
- The disconnect path now sets:
  - `field_0x1c = 0`, `field_0x19 = -1`, `field_0x18 = 0`
  - menu window state at `field_2120 + 0xA` and `field_2092 + 0x22`
  - `field_0x36 = -1`, `field_0x40 = 0`, `field_0x44 = 1`
  - then returns after pushing transfer-cancel messaging.
