### PR TITLE
pppChangeTex: match pppConstructChangeTex by fixing manager symbol alias

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -19,6 +19,7 @@ extern char MaterialMan[];
 extern void SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(void*, void*, unsigned int, int, int);
 extern void GXCallDisplayList(void*, unsigned int);
 extern _pppMngStChangeTex* pppMngStPtr;
+extern _pppMngStChangeTex* lbl_8032ED50;
 extern _pppEnvStChangeTex* lbl_8032ED54;
 extern _pppEnvStChangeTex* pppEnvStPtr;
 extern float lbl_80332040;
@@ -163,7 +164,7 @@ void pppConstructChangeTex(pppChangeTex* changeTex, UnkC* data)
 	state[2] = init;
 	state[1] = init;
 	stateInt[6] = 0;
-	stateInt[9] = (int)pppMngStPtr;
+	stateInt[9] = (int)lbl_8032ED50;
 	stateInt[7] = 0;
 	stateInt[3] = 0;
 	stateInt[4] = 0;


### PR DESCRIPTION
## Summary
- Added the `lbl_8032ED50` manager alias declaration in `src/pppChangeTex.cpp`.
- Updated `pppConstructChangeTex` to store `lbl_8032ED50` into the work state instead of `pppMngStPtr`.
- Left behavior unchanged; this is a symbol-level alignment to match original SDA relocation.

## Functions improved
- Unit: `main/pppChangeTex`
- Function: `pppConstructChangeTex`

## Match evidence
- `pppConstructChangeTex`: **99.6875% -> 100.0%** (objdiff one-shot JSON)
- Other unit functions unchanged:
  - `pppFrameChangeTex`: 54.91331%
  - `pppDestructChangeTex`: 79.71111%
  - `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2`: 69.81967%
  - `ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2`: 80.139534%

## Plausibility rationale
- The project already uses `lbl_8032ED50` as the canonical global alias for PPP manager state in many PPP units.
- Using that alias here is consistent with existing source style and resolves a remaining relocation-level mismatch without introducing compiler-coaxing control-flow changes.

## Technical details
- Before this patch, objdiff showed an otherwise fully matching `pppConstructChangeTex` with a single SDA relocation argument mismatch at the manager pointer load/store path.
- Switching to `lbl_8032ED50` produced instruction+relocation alignment for the function (100.0%).
