### PR TITLE
mapanim: fix CMapAnimRun::Calc map anim array base offset

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -638,7 +638,7 @@ void CMapAnimRun::Calc(long frame)
         run[0] = run[1];
     }
 
-    CMapAnim* mapAnim = __vc__21CPtrArray_P8CMapAnim_FUl(MapMng + 0x2140C, reinterpret_cast<unsigned short*>(this)[9]);
+    CMapAnim* mapAnim = __vc__21CPtrArray_P8CMapAnim_FUl(MapMng + 0x213FC, reinterpret_cast<unsigned short*>(this)[9]);
     mapAnim->Calc(run[0]);
     run[0] = run[0] + 1;
 


### PR DESCRIPTION
## Summary
- Corrected the map animation array base passed in `CMapAnimRun::Calc(long)` from `MapMng + 0x2140C` to `MapMng + 0x213FC`.
- This aligns the code with `CMapMng::Create()`/`DestroyAnimation()` layout usage of the same `CPtrArray<CMapAnim*>` region.

## Functions improved
- Unit: `main/mapanim`
- Symbol: `Calc__11CMapAnimRunFl`

## Match evidence
- `Calc__11CMapAnimRunFl`: **67.71429% -> 96.54762%** (`tools/objdiff-cli diff -p . -u main/mapanim -o ... Calc__11CMapAnimRunFl`)
- Function size unchanged: 168 bytes

## Plausibility rationale
- This is a semantic struct-offset correction, not artificial compiler coaxing.
- The new offset is consistent with nearby map manager animation container accesses in the same module family.

## Technical details
- The previous offset produced relocation/argument mismatches around the `__vc__21CPtrArray<P8CMapAnim>FUl` call path.
- After correcting the base pointer, objdiff shows substantially improved instruction alignment for the lookup-and-calc sequence in `CMapAnimRun::Calc`.