### PR TITLE
graphic: implement SetViewport and EndFrame

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -223,12 +223,21 @@ void CGraphic::SetStdPixelFmt()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80019830
+ * PAL Size: 136b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphic::SetViewport()
 {
-	// TODO
+    void* renderMode = PtrAt(this, 0x71E0);
+    u16 width = U16At(renderMode, 4);
+    u16 height = U16At(renderMode, 6);
+
+    GXSetViewport(0.0f, 0.0f, (f32)width, (f32)height, 0.0f, 1.0f);
+    GXSetScissor(0, 0, width, height);
 }
 
 /*
@@ -243,12 +252,16 @@ void CGraphic::BeginFrame()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80019718
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGraphic::EndFrame()
 {
-	// TODO
+    S32At(this, 0x14) = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGraphic::SetViewport()` and `CGraphic::EndFrame()` in `src/graphic.cpp`.
- Updated both edited functions' `--INFO--` headers with PAL address/size metadata.
- Kept implementation style consistent with existing offset-based helpers (`PtrAt`, `U16At`, `S32At`) already used throughout this file.

## Functions Improved
- Unit: `main/graphic`
- `EndFrame__8CGraphicFv`: 33.333332% -> 100.0%
- `SetViewport__8CGraphicFv`: 2.9411764% -> 55.441177%

## Match Evidence
- `main/graphic` fuzzy match: 34.8042% -> 35.325195%
- `main/graphic` matched code: 328 -> 340 bytes
- `main/graphic` matched functions: 7/46 -> 8/46
- Global code matched (from `ninja` progress): 214064 -> 214076 bytes

## Plausibility Rationale
- `SetViewport()` now performs expected render-mode-driven viewport/scissor setup using width/height from the active render mode object.
- `EndFrame()` now clears the frame-in-progress state at offset `0x14`, matching surrounding frame lifecycle behavior.
- No contrived temporaries, artificial reordering, or non-idiomatic hacks were introduced.

## Technical Details
- `SetViewport()` now reads dimensions from `this+0x71E0` render mode, then calls:
  - `GXSetViewport(0.0f, 0.0f, (f32)width, (f32)height, 0.0f, 1.0f)`
  - `GXSetScissor(0, 0, width, height)`
- `EndFrame()` now performs `S32At(this, 0x14) = 0`.
- Verified by full rebuild (`ninja`) and report comparison via `objdiff-cli report generate` before/after.
