### PR TITLE
Implement CMemory::CStage::heapInfo

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2089,12 +2089,60 @@ void CAmemCacheSet::DumpCache()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8001C2F0
+ * PAL Size: 280b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMemory::CStage::heapInfo(unsigned long&, unsigned long&, unsigned long&)
+void CMemory::CStage::heapInfo(unsigned long& heapTotal, unsigned long& heapUse, unsigned long& heapUnuse)
 {
-	// TODO
+    int mode = stageGetAllocationMode(this);
+    int node = stageGetHeapHead(this);
+    if (mode != 2) {
+        node = *reinterpret_cast<int*>(node + 8);
+    }
+
+    heapTotal = 0;
+    heapUse = 0;
+    heapUnuse = 0;
+
+    if (mode == 2) {
+        int top = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 8);
+        int tail = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 12);
+        int count = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x120);
+
+        for (int i = 0; i <= count; i++) {
+            int blockTail = (i == count) ? tail : *reinterpret_cast<int*>(node + 4);
+            int freeSize = blockTail - top;
+            if (freeSize != 0) {
+                heapUnuse += freeSize;
+                heapTotal += freeSize;
+            }
+
+            if (i < count) {
+                int usedSize = *reinterpret_cast<int*>(node + 8) - *reinterpret_cast<int*>(node + 4);
+                heapUse += usedSize;
+                top = blockTail + usedSize;
+                heapTotal += usedSize;
+            }
+
+            node += 0x40;
+        }
+        return;
+    }
+
+    while ((*reinterpret_cast<unsigned char*>(node + 2) & 2) == 0) {
+        if ((*reinterpret_cast<unsigned char*>(node + 2) & 4) == 0) {
+            heapUnuse += *reinterpret_cast<int*>(node + 0x10);
+        } else {
+            heapUse += *reinterpret_cast<int*>(node + 0x10);
+        }
+
+        heapTotal += *reinterpret_cast<int*>(node + 8) - node;
+        node = *reinterpret_cast<int*>(node + 8);
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMemory::CStage::heapInfo(unsigned long&, unsigned long&, unsigned long&)` in `src/memory.cpp` using existing stage/heap metadata layout and mode-specific traversal.
- Added PAL metadata block for the function (`0x8001C2F0`, `280b`).
- Kept implementation style consistent with surrounding `memory.cpp` (raw offset reads and mode checks).

## Functions improved
- Unit: `main/memory`
- Symbol: `heapInfo__Q27CMemory6CStageFRUlRUlRUl`

## Match evidence
- Before: `1.4%` (target selector baseline for `main/memory`)
- After: `74.57746%` (`tools/objdiff-cli diff -p . -u main/memory heapInfo__Q27CMemory6CStageFRUlRUlRUl`)
- Build: `ninja` completed successfully.

## Plausibility rationale
- The code follows the same original-style memory-node walking used by adjacent stage utilities (`heapWalker`, `GetHeapUnuse`) rather than artificial compiler coaxing.
- Mode `2` and non-mode `2` paths use natural heap accounting semantics: total bytes, used bytes, and unused bytes.

## Technical notes
- Mode `2` path iterates per node span (`0x40`) and accounts free gaps plus used segments.
- Other modes walk linked heap nodes until terminator flag (`bit 1`) and accumulate from block header size/next pointers.
