### PR TITLE
pppVertexApMtx: improve loop counter typing for closer codegen

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -126,7 +126,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 			points = src->points;
 		}
 
-		u8 count = data->spawnCount;
+		s32 count = data->spawnCount;
 		if (data->mode == 0) {
 			do {
 				if (state->index >= (u16)entry->maxValue) {


### PR DESCRIPTION
## Summary
- Updated `pppVertexApMtx` spawn loop counter type from `u8` to `s32`.
- Kept control flow and data flow unchanged; only adjusted the loop counter width/sign to better match likely original compiler behavior.

## Functions improved
- Unit: `main/pppVertexApMtx`
- Function: `pppVertexApMtx`

## Match evidence
- `main/pppVertexApMtx` fuzzy match: **85.0921% -> 86.83772%** (+1.74562)
- `pppVertexApMtx` fuzzy match: **84.55% -> 86.35909%** (+1.80909)
- Build/verification: `ninja` succeeds after the change.

## Plausibility rationale
- The change is source-plausible: loop iteration counts are typically promoted to signed integer temporaries in this codebase and toolchain.
- This avoids introducing synthetic reordering or unnatural temporaries; semantics stay identical while improving generated code alignment.

## Technical details
- File changed: `src/pppVertexApMtx.cpp`
- Diff: `u8 count = data->spawnCount;` -> `s32 count = data->spawnCount;`
- Observed impact is isolated to `pppVertexApMtx` scoring and does not alter external behavior.
