### PR TITLE
main/pppCrystal2: improve pppRenderCrystal2 match

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -230,113 +230,112 @@ void pppRenderCrystal2(pppCrystal2* pppCrystal2, UnkB* param_2, UnkC* param_3)
 {
     int workOffset = param_3->m_serializedDataOffsets[2];
     int colorOffset = param_3->m_serializedDataOffsets[1];
-    int textureIndex = 0;
     int sourceTex = 0;
     pppModelSt* model;
     _GXTexObj backTexObj;
     float slope;
-    float range;
     float indMtx[2][3];
     float texMtx[3][4];
     Mtx lightMtx;
     Mtx drawMtx;
-    Mtx cameraMtx;
     Mtx tmpMtx;
+    Mtx cameraMtx;
     Mtx normalMtx;
+    int textureIndex = 0;
 
-    if (param_2->m_dataValIndex == 0xFFFF) {
-        return;
-    }
-
-    model = (pppModelSt*)((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[param_2->m_dataValIndex];
-    GetTexture__8CMapMeshFP12CMaterialSetRi((CMapMesh*)model, pppEnvStPtr->m_materialSetPtr, textureIndex);
-    if (param_2->m_payload[0] == 0) {
-        if (param_2->m_initWOrk == 0xFFFF) {
-            return;
+    if (param_2->m_dataValIndex != 0xFFFF) {
+        model = (pppModelSt*)((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[param_2->m_dataValIndex];
+        GetTexture__8CMapMeshFP12CMaterialSetRi((CMapMesh*)model, pppEnvStPtr->m_materialSetPtr, textureIndex);
+        if (param_2->m_payload[0] == 0) {
+            if (param_2->m_initWOrk == 0xFFFF) {
+                return;
+            }
+            sourceTex = GetTexture__8CMapMeshFP12CMaterialSetRi(
+                ((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[param_2->m_initWOrk], pppEnvStPtr->m_materialSetPtr,
+                textureIndex);
         }
-        sourceTex = GetTexture__8CMapMeshFP12CMaterialSetRi(
-            ((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[param_2->m_initWOrk], pppEnvStPtr->m_materialSetPtr, textureIndex);
+
+        pppSetBlendMode__FUc(0);
+        Graphic.GetBackBufferRect2(DAT_80238030, &backTexObj, 0, 0, 0x280, 0x1C0, 0, GX_LINEAR, GX_TF_RGBA8, 0);
+        pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+            (u8*)pppCrystal2 + 0x88 + colorOffset, (u8*)pppCrystal2 + 0x40, (float)param_2->m_arg3,
+            param_2->m_payload[5], param_2->m_payload[4], param_2->m_payload[1], param_2->m_payload[2], 1, 1,
+            param_2->m_payload[3]);
+        GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
+
+        slope = FLOAT_80331fd0 * param_2->m_stepValue;
+        indMtx[0][0] = slope;
+        indMtx[0][1] = DAT_801dd60c;
+        indMtx[0][2] = DAT_801dd610;
+        indMtx[1][0] = DAT_801dd614;
+        indMtx[1][1] = slope;
+        indMtx[1][2] = DAT_801dd61c;
+
+        texMtx[0][0] = DAT_801dd620;
+        texMtx[0][1] = DAT_801dd624;
+        texMtx[0][2] = DAT_801dd628;
+        texMtx[0][3] = DAT_801dd62c;
+        texMtx[1][0] = DAT_801dd630;
+        texMtx[1][1] = DAT_801dd634;
+        texMtx[1][2] = DAT_801dd638;
+        texMtx[1][3] = DAT_801dd63c;
+        texMtx[2][0] = DAT_801dd640;
+        texMtx[2][1] = DAT_801dd644;
+        texMtx[2][2] = DAT_801dd648;
+        texMtx[2][3] = DAT_801dd64c;
+
+        PSMTXIdentity(drawMtx);
+        PSMTXConcat(pppMngStPtr->m_matrix.value, ((_pppPObject*)pppCrystal2)->m_localMatrix.value, cameraMtx);
+        if (Game.game.m_currentSceneId == 7) {
+            C_MTXLightPerspective(lightMtx, FLOAT_80331fd4, FLOAT_80331fd8, *(float*)(param_2->m_payload + 8),
+                                  -*(float*)(param_2->m_payload + 8), FLOAT_80331fdc, FLOAT_80331fdc);
+            PSMTXConcat(ppvCameraMatrix0, cameraMtx, tmpMtx);
+        } else {
+            C_MTXLightPerspective(lightMtx, CameraPcs._252_4_, FLOAT_80331fd8, *(float*)(param_2->m_payload + 8),
+                                  -*(float*)(param_2->m_payload + 8), FLOAT_80331fdc, FLOAT_80331fdc);
+            PSMTXConcat(CameraPcs.m_cameraMatrix, cameraMtx, tmpMtx);
+        }
+        PSMTXConcat(lightMtx, tmpMtx, drawMtx);
+        PSMTXInverse(tmpMtx, normalMtx);
+        PSMTXTranspose(normalMtx, normalMtx);
+
+        if (param_2->m_payload[0] == 0) {
+            GXLoadTexObj((_GXTexObj*)(sourceTex + 0x28), GX_TEXMAP1);
+        } else {
+            GXLoadTexObj((_GXTexObj*)(*(u32*)((u8*)pppCrystal2 + 0x84 + workOffset)), GX_TEXMAP1);
+        }
+
+        GXSetNumIndStages(1);
+        GXSetIndTexOrder((GXIndTexStageID)0, GX_TEXCOORD0, GX_TEXMAP1);
+        GXSetIndTexCoordScale((GXIndTexStageID)0, GX_ITS_1, GX_ITS_1);
+        GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
+        GXSetTevIndirect((GXTevStageID)0, (GXIndTexStageID)0, GX_ITF_8, GX_ITB_NONE, GX_ITM_1, GX_ITW_0, GX_ITW_0,
+                         GX_FALSE, GX_FALSE, GX_ITBA_OFF);
+
+        GXLoadTexMtxImm(texMtx, 0x40, GX_MTX3x4);
+        GXLoadTexMtxImm(normalMtx, 0x21, GX_MTX3x4);
+        GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_NRM, 0x21, GX_TRUE, 0x40);
+        GXLoadTexObj(&backTexObj, GX_TEXMAP0);
+        GXLoadTexMtxImm(drawMtx, 0x1E, GX_MTX3x4);
+        GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_POS, 0x1E, GX_FALSE, GX_IDENTITY);
+        _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 1, 0, 4);
+        _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
+        _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(
+            0, 0xF, 8, 0xC, 0xA);
+        _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+        _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 7, 7,
+                                                                                                               7, 6);
+        _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
+        GXSetNumTevStages(1);
+        GXSetNumTexGens(2);
+        GXClearVtxDesc();
+        GXSetVtxDesc((GXAttr)9, GX_DIRECT);
+        GXSetVtxDesc((GXAttr)10, GX_DIRECT);
+        GXSetVtxDesc((GXAttr)0xB, GX_DIRECT);
+        GXSetVtxDesc((GXAttr)0xD, GX_DIRECT);
+        pppDrawMesh__FP10pppModelStP3Veci(model, 0, 0);
+        DAT_8032ec70.DisableIndMtx();
     }
-
-    slope = FLOAT_80331fd0 * param_2->m_stepValue;
-    range = *(float*)(param_2->m_payload + 8);
-
-    pppSetBlendMode__FUc(0);
-    Graphic.GetBackBufferRect2(DAT_80238030, &backTexObj, 0, 0, 0x280, 0x1C0, 0, GX_LINEAR, GX_TF_RGBA8, 0);
-    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
-        (u8*)pppCrystal2 + 0x88 + colorOffset, (u8*)pppCrystal2 + 0x40, (float)param_2->m_arg3, param_2->m_payload[5],
-        param_2->m_payload[4], param_2->m_payload[1], param_2->m_payload[2], 1, 1, param_2->m_payload[3]);
-
-    GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
-
-    indMtx[0][0] = slope;
-    indMtx[0][1] = DAT_801dd60c;
-    indMtx[0][2] = DAT_801dd610;
-    indMtx[1][0] = DAT_801dd614;
-    indMtx[1][1] = slope;
-    indMtx[1][2] = DAT_801dd61c;
-
-    texMtx[0][0] = DAT_801dd620;
-    texMtx[0][1] = DAT_801dd624;
-    texMtx[0][2] = DAT_801dd628;
-    texMtx[0][3] = DAT_801dd62c;
-    texMtx[1][0] = DAT_801dd630;
-    texMtx[1][1] = DAT_801dd634;
-    texMtx[1][2] = DAT_801dd638;
-    texMtx[1][3] = DAT_801dd63c;
-    texMtx[2][0] = DAT_801dd640;
-    texMtx[2][1] = DAT_801dd644;
-    texMtx[2][2] = DAT_801dd648;
-    texMtx[2][3] = DAT_801dd64c;
-
-    PSMTXIdentity(drawMtx);
-    PSMTXConcat(pppMngStPtr->m_matrix.value, ((_pppPObject*)pppCrystal2)->m_localMatrix.value, cameraMtx);
-    if (Game.game.m_currentSceneId == 7) {
-        C_MTXLightPerspective(lightMtx, FLOAT_80331fd4, FLOAT_80331fd8, range, -range, FLOAT_80331fdc, FLOAT_80331fdc);
-        PSMTXConcat(ppvCameraMatrix0, cameraMtx, tmpMtx);
-    } else {
-        C_MTXLightPerspective(lightMtx, CameraPcs._252_4_, FLOAT_80331fd8, range, -range, FLOAT_80331fdc, FLOAT_80331fdc);
-        PSMTXConcat(CameraPcs.m_cameraMatrix, cameraMtx, tmpMtx);
-    }
-    PSMTXConcat(lightMtx, tmpMtx, drawMtx);
-    PSMTXInverse(tmpMtx, normalMtx);
-    PSMTXTranspose(normalMtx, normalMtx);
-
-    if (param_2->m_payload[0] == 0) {
-        GXLoadTexObj((_GXTexObj*)(sourceTex + 0x28), GX_TEXMAP1);
-    } else {
-        GXLoadTexObj((_GXTexObj*)(*(u32*)((u8*)pppCrystal2 + 0x84 + workOffset)), GX_TEXMAP1);
-    }
-
-    GXSetNumIndStages(1);
-    GXSetIndTexOrder((GXIndTexStageID)0, GX_TEXCOORD0, GX_TEXMAP1);
-    GXSetIndTexCoordScale((GXIndTexStageID)0, GX_ITS_1, GX_ITS_1);
-    GXSetIndTexMtx(GX_ITM_1, indMtx, 1);
-    GXSetTevIndirect((GXTevStageID)0, (GXIndTexStageID)0, GX_ITF_8, GX_ITB_NONE, GX_ITM_1, GX_ITW_0, GX_ITW_0,
-                     GX_FALSE, GX_FALSE, GX_ITBA_OFF);
-
-    GXLoadTexMtxImm(texMtx, 0x40, GX_MTX3x4);
-    GXLoadTexMtxImm(normalMtx, 0x21, GX_MTX3x4);
-    GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_NRM, 0x21, GX_TRUE, 0x40);
-    GXLoadTexObj(&backTexObj, GX_TEXMAP0);
-    GXLoadTexMtxImm(drawMtx, 0x1E, GX_MTX3x4);
-    GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_POS, 0x1E, GX_FALSE, GX_IDENTITY);
-    _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 1, 0, 4);
-    _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
-    _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(0, 0xF, 8, 0xC,
-                                                                                                           0xA);
-    _GXSetTevColorOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
-    _GXSetTevAlphaIn__F13_GXTevStageID14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg14_GXTevAlphaArg(0, 7, 7, 7, 6);
-    _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
-    GXSetNumTevStages(1);
-    GXSetNumTexGens(2);
-    GXClearVtxDesc();
-    GXSetVtxDesc((GXAttr)9, GX_DIRECT);
-    GXSetVtxDesc((GXAttr)10, GX_DIRECT);
-    GXSetVtxDesc((GXAttr)0xB, GX_DIRECT);
-    GXSetVtxDesc((GXAttr)0xD, GX_DIRECT);
-    pppDrawMesh__FP10pppModelStP3Veci(model, 0, 0);
-    DAT_8032ec70.DisableIndMtx();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `pppRenderCrystal2` control flow to match the original branch shape (`m_dataValIndex` guarded block).
- Adjusted local variable lifetime/order and moved scalar setup (`slope`, range loads) to align with observed codegen patterns.
- Kept behavior unchanged while preserving source plausibility (no contrived temporaries or hardcoded offset tricks beyond existing layout usage).

## Functions improved
- Unit: `main/pppCrystal2`
- Function: `pppRenderCrystal2` (size 1212b)

## Match evidence
- `pppRenderCrystal2`: **40.755775% -> 57.848186%** (+17.092411)
- `main/pppCrystal2` unit: **56.776043% -> 65.767365%** (+8.991322)
- Generated with:
  - `build/tools/objdiff-cli report generate -p . -f json-pretty -o /tmp/objdiff_report_before.json`
  - `build/tools/objdiff-cli report generate -p . -f json-pretty -o /tmp/objdiff_report_after.json`
  - `build/tools/objdiff-cli report changes --format json-pretty /tmp/objdiff_report_before.json /tmp/objdiff_report_after.json -o /tmp/objdiff_changes.json`

## Plausibility rationale
- The edits favor idiomatic game-engine render code structure: early symbol validity guard, straightforward texture-source branching, and grouped GX setup.
- No readability regression or purely synthetic compiler coercion patterns were introduced.

## Technical details
- Preserved matrix operations and GX call sequence while changing stack/local arrangement and control-flow shape to reduce codegen divergence.
- Build verification: `ninja` completed successfully (`build/GCCP01/main.dol: OK`).