### PR TITLE
main/cflat_runtime2: implement Load__13CFlatRuntime2FPc

### DIFF
--- a/include/ffcc/cflat_runtime2.h
+++ b/include/ffcc/cflat_runtime2.h
@@ -36,7 +36,7 @@ class CFlatRuntime2
 	void* intToClass(int);
 
 	void Frame(int, int);
-	void Load(char*);
+	int Load(char*);
 
 	CGObject* FindGObjFirst();
 	CGObject* FindGObjNext(CGObject*);

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -23,6 +23,8 @@ extern "C" void Destroy__9CGBaseObjFv(CGBaseObj*);
 extern "C" void Frame__9CGBaseObjFv(CGBaseObj*);
 extern "C" void Draw__9CGBaseObjFv(CGBaseObj*);
 extern "C" void Frame__12CFlatRuntimeFii(CFlatRuntime*, int, int);
+extern "C" void Create__12CFlatRuntimeFPv(CFlatRuntime*, void*);
+extern "C" int CreateDebug__12CFlatRuntimeFPvi(CFlatRuntime*, void*, int);
 extern "C" void Destroy__12CFlatRuntimeFv(CFlatRuntime*);
 extern "C" void Destroy__9CFlatDataFv(void*);
 extern "C" void __construct_array(void*, void (*)(void*), void (*)(void*, int), unsigned long, unsigned long);
@@ -48,6 +50,7 @@ extern "C" void* Open__5CFileFPcUlQ25CFile3PRI(void*, char*, unsigned long, int)
 extern "C" void Read__5CFileFPQ25CFile7CHandle(void*, void*);
 extern "C" void SyncCompleted__5CFileFPQ25CFile7CHandle(void*, void*);
 extern "C" void ReadASync__5CFileFPQ25CFile7CHandle(void*, void*);
+extern "C" void Printf__7CSystemFPce(CSystem*, const char*, ...);
 extern "C" void ClrBattleItem__8CMenuPcsFv(void*);
 extern "C" void ChangeMogMode__6CCharaFi(void*, int);
 extern "C" void TimeMogFur__6CCharaFv(void*);
@@ -865,12 +868,61 @@ void CFlatRuntime2::Frame(int arg0, int mode)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8006CB84
+ * PAL Size: 444b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CFlatRuntime2::Load(char*)
+int CFlatRuntime2::Load(char* fileName)
 {
-	// TODO
+	char path[0x100];
+	sprintf(path, "dvd:/%s.cft", fileName);
+
+	void* fileHandle = Open__5CFileFPcUlQ25CFile3PRI(&File, path, 0, 0);
+	if (fileHandle == 0) {
+		return 0;
+	}
+
+	Read__5CFileFPQ25CFile7CHandle(&File, fileHandle);
+	SyncCompleted__5CFileFPQ25CFile7CHandle(&File, fileHandle);
+	Create__12CFlatRuntimeFPv(reinterpret_cast<CFlatRuntime*>(this), File.m_readBuffer);
+	Close__5CFileFPQ25CFile7CHandle(&File, fileHandle);
+
+	typedef int (*NeedDebugDataFn)(CFlatRuntime2*);
+	NeedDebugDataFn needDebugData = reinterpret_cast<NeedDebugDataFn>((*reinterpret_cast<void***>(this))[0x12]);
+
+	if (needDebugData(this) != 0) {
+		int debugChunk = 0;
+		for (int debugIndex = 0;; debugIndex++) {
+			sprintf(path, "dvd:/%s.cft_dbg", fileName);
+			if (debugIndex != 0) {
+				sprintf(path, "%s%d", path, debugIndex);
+			}
+
+			fileHandle = Open__5CFileFPcUlQ25CFile3PRI(&File, path, 0, 0);
+			if (fileHandle == 0) {
+				return 0;
+			}
+
+			Read__5CFileFPQ25CFile7CHandle(&File, fileHandle);
+			SyncCompleted__5CFileFPQ25CFile7CHandle(&File, fileHandle);
+			debugChunk = CreateDebug__12CFlatRuntimeFPvi(
+				reinterpret_cast<CFlatRuntime*>(this), File.m_readBuffer, debugChunk);
+			Close__5CFileFPQ25CFile7CHandle(&File, fileHandle);
+
+			if (debugChunk == -1) {
+				break;
+			}
+		}
+	}
+
+	resetChangeScript();
+	if (System.m_execParam > 2) {
+		Printf__7CSystemFPce(&System, "CFlatRuntime2::Load\n");
+	}
+	return 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CFlatRuntime2::Load` with real CFT load flow: open/read/sync/create/close, optional debug chunk loading loop, and script-change reset.
- Corrected `Load` declaration/definition return type from `void` to `int` to match callsites and symbol behavior.
- Added PAL function metadata block for `Load` (`0x8006CB84`, `444b`).

## Functions Improved
- Unit: `main/cflat_runtime2`
- Function: `Load__13CFlatRuntime2FPc` (size: 444b)

## Match Evidence
- `Load__13CFlatRuntime2FPc`: **0.9009009% -> 80.42342%**
- Measured via: `tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o /tmp/od_load_after3.json --format json Load__13CFlatRuntime2FPc`

## Plausibility Rationale
- The new source follows existing codebase style and expected runtime behavior: file I/O via `CFile`, runtime creation via `CFlatRuntime` entry points, iterative debug data ingest, and post-load script reset.
- Changes avoid contrived compiler coercion and represent natural game-engine loader logic.

## Technical Details
- Implemented debug chunk ingestion as a loop with stop-on-`-1` from `CreateDebug__12CFlatRuntimeFPvi`.
- Preserved release/debug conditional logging path via `System.m_execParam` gate.
