### PR TITLE
gbaque: implement GbaQueue::GetMoney

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -75,7 +75,7 @@ public:
     int GetFavorite(int, char*);
     void GetMoneyFlg(int);
     void ClrMoneyFlg(int);
-    void GetMoney(int);
+    int GetMoney(int);
     void ClrScrInitEnd();
     void InitCmakeInfo(int, int);
     void ClrCmakeInfo(int);

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -952,12 +952,22 @@ void GbaQueue::ClrMoneyFlg(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800ccaf4
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::GetMoney(int)
+int GbaQueue::GetMoney(int channel)
 {
-	// TODO
+	char* compatibilityStr = reinterpret_cast<char*>(accessSemaphores) + 0x28;
+
+	OSWaitSemaphore(accessSemaphores + channel);
+	int value = *reinterpret_cast<int*>(compatibilityStr + channel * 0xDC + 0x20);
+	OSSignalSemaphore(accessSemaphores + channel);
+
+	return value;
 }
 
 /*


### PR DESCRIPTION
## Summary
- implement `GbaQueue::GetMoney(int)` in `src/gbaque.cpp` instead of a stub
- update declaration in `include/ffcc/gbaque.h` to return `int`
- use the existing gbaque semaphore pattern (`OSWaitSemaphore`/`OSSignalSemaphore`) and read from the channel-scoped compatibility block

## Functions improved
- Unit: `main/gbaque`
- Symbol: `GetMoney__8GbaQueueFi`

## Match evidence
- Prior state in-tree was a TODO/stub body (report showed the symbol at ~4.0% fuzzy)
- `objdiff` interactive diff for `GetMoney__8GbaQueueFi` now reports **87.76%**
- Remaining differences are small address/offset details around semaphore/data base computation, not control-flow mismatches

## Plausibility rationale
- The new code follows the same source style already used in this file for neighboring getters (`GetMemorys`, `GetCmdNum`, etc.)
- Synchronization and per-channel memory access pattern match established project idioms and the decomp reference behavior
- This is a straightforward restoration of missing game logic, not compiler-coaxing

## Technical details
- Added PAL metadata block for the function (`0x800ccaf4`, `100b`)
- Return value is loaded from `compatibilityStr + channel * 0xDC + 0x20` under semaphore protection
- Signature corrected to return `int` while preserving symbol identity (`GetMoney__8GbaQueueFi`)
