### PR TITLE
gx: improve GXSetFogRangeAdj match by aligning BP register packing

### DIFF
--- a/src/gx/GXPixel.c
+++ b/src/gx/GXPixel.c
@@ -150,29 +150,38 @@ void GXInitFogAdjTable(GXFogAdjTable *table, u16 width, const f32 projmtx[4][4])
  */
 void GXSetFogRangeAdj(GXBool enable, u16 center, const GXFogAdjTable *table) {
     u32 range_adj;
+    const u16 *r;
 
     CHECK_GXBEGIN(331, "GXSetFogRangeAdj");
 
     if (enable) {
         ASSERTMSGLINE(334, table != NULL, "GXSetFogRangeAdj: table pointer is null");
+        r = table->r;
 
-        range_adj = (table->r[0] & 0xFFF) | ((u32)table->r[1] << 12) | 0xE9000000;
+        range_adj = (r[0] & 0xFFF) | ((u32)r[1] << 12);
+        range_adj = (range_adj & 0x00FFFFFF) | 0xE9000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[2] & 0xFFF) | ((u32)table->r[3] << 12) | 0xEA000000;
+        range_adj = (r[2] & 0xFFF) | ((u32)r[3] << 12);
+        range_adj = (range_adj & 0x00FFFFFF) | 0xEA000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[4] & 0xFFF) | ((u32)table->r[5] << 12) | 0xEB000000;
+        range_adj = (r[4] & 0xFFF) | ((u32)r[5] << 12);
+        range_adj = (range_adj & 0x00FFFFFF) | 0xEB000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[6] & 0xFFF) | ((u32)table->r[7] << 12) | 0xEC000000;
+        range_adj = (r[6] & 0xFFF) | ((u32)r[7] << 12);
+        range_adj = (range_adj & 0x00FFFFFF) | 0xEC000000;
         GX_WRITE_RAS_REG(range_adj);
 
-        range_adj = (table->r[8] & 0xFFF) | ((u32)table->r[9] << 12) | 0xED000000;
+        range_adj = (r[8] & 0xFFF) | ((u32)r[9] << 12);
+        range_adj = (range_adj & 0x00FFFFFF) | 0xED000000;
         GX_WRITE_RAS_REG(range_adj);
     }
 
-    range_adj = ((center + 342) & 0x00FFFBFF) | ((u32)(u8)enable << 10) | 0xE8000000;
+    range_adj = (center + 342) & 0x00FFFBFF;
+    range_adj |= (u32)(u8)enable << 10;
+    range_adj = (range_adj & 0x00FFFFFF) | 0xE8000000;
     GX_WRITE_RAS_REG(range_adj);
     __GXData->bpSentNot = 0;
 }


### PR DESCRIPTION
## Summary
- Reworked `GXSetFogRangeAdj` register-value construction to better match original BP write codegen.
- Switched repeated table access to a local `const u16*` and split low-24-bit packing from register-ID insertion.
- Kept behavior identical while improving instruction selection/order around `GX_WRITE_RAS_REG` values.

## Functions improved
- Unit: `main/gx/GXPixel`
- Function: `GXSetFogRangeAdj`

## Match evidence
- `GXSetFogRangeAdj`: **63.078125% -> 65.265625%** (+2.1875)
- Unit `main/gx/GXPixel`: **83.0% -> 83.35176%** (+0.35176)
- `ninja` report regenerated successfully after the change.

## Plausibility rationale
- The change is source-plausible and idiomatic for GX BP packing code:
  - explicit 12-bit field packing from fog table entries
  - explicit insertion of BP register high byte (`0xE9..0xED`, `0xE8`)
  - no contrived control-flow or artificial temporaries beyond straightforward register construction.

## Technical details
- Replaced one-shot OR constants with two-stage build (`pack fields` then `insert register byte`) to influence rlwimi/oris-style output.
- Rewrote final center/enable register construction into separate steps to better match mask/or sequencing.
- No API/signature changes; only `src/gx/GXPixel.c` updated.
