### PR TITLE
texanim: improve SetTexGen decomp match

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -892,16 +892,26 @@ void CTexAnimSet::SetTexGen()
 
     for (unsigned int i = 0; i < static_cast<unsigned int>(texAnims->GetSize()); i++) {
         CTexAnim* texAnim = (*texAnims)[i];
+        const float fVar2 = FLOAT_8032fb38;
         void* refData = *reinterpret_cast<void**>(Ptr(texAnim, 8));
         int* material = reinterpret_cast<int*>(*reinterpret_cast<void**>(Ptr(refData, 0x108)));
         if (material != 0) {
+            const unsigned int uVar1 = U32At(texAnim, 0x1C);
             int* texSrt = material + (S32At(refData, 0x10C) * 5);
             U32At(texSrt, 0x50) = U32At(texAnim, 0x18);
-            U32At(texSrt, 0x54) = U32At(texAnim, 0x1C);
-            F32At(texSrt, 0x58) = FLOAT_8032fb38;
-            F32At(texSrt, 0x5C) = FLOAT_8032fb38;
-            U8At(texSrt, 0x4C) = (F32At(texSrt, 0x58) != FLOAT_8032fb38);
-            U8At(texSrt, 0x4D) = (F32At(texSrt, 0x5C) != FLOAT_8032fb38);
+            U32At(texSrt, 0x54) = uVar1;
+            F32At(texSrt, 0x58) = fVar2;
+            F32At(texSrt, 0x5C) = fVar2;
+            if (fVar2 == F32At(texSrt, 0x58)) {
+                U8At(texSrt, 0x4C) = 0;
+            } else {
+                U8At(texSrt, 0x4C) = 1;
+            }
+            if (FLOAT_8032fb38 == F32At(texSrt, 0x5C)) {
+                U8At(texSrt, 0x4D) = 0;
+            } else {
+                U8At(texSrt, 0x4D) = 1;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Refined `CTexAnimSet::SetTexGen()` in `src/texanim.cpp` to better match original codegen by:
- introducing explicit temporaries (`fVar2`, cached `uVar1`) to align load/store ordering
- replacing boolean-expression byte writes with explicit branch-based `0/1` stores
- preserving behavior while improving compiler output alignment

## Functions improved
- Unit: `main/texanim`
- Function: `SetTexGen__11CTexAnimSetFv`

## Match evidence
- `SetTexGen__11CTexAnimSetFv`: **34.18868% -> 56.037735%** (`build/GCCP01/report.json`)
- `main/texanim` unit fuzzy: **56.122463% -> 57.26833%** (`build/GCCP01/report.json`)
- Build verification: `ninja` passes.

## Plausibility rationale
Changes are source-plausible and idiomatic: they keep the same material/texSrt semantics, but express flag writes in explicit branch form that is common in original-era C/C++ code and better reflects the observed assembly structure.

## Technical details
The main gain came from controlling expression lowering:
- forcing an explicit float temporary reused across writes/comparisons
- avoiding compiler-generated boolean canonicalization for byte fields
- matching decomp-like store and compare ordering around `texSrt + 0x4C/0x4D` flag bytes
