### PR TITLE
cflat_runtime2: improve getNumFreeObject match

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -619,48 +619,186 @@ void CFlatRuntime2::onDeleteObject(CFlatRuntime::CObject* object)
 unsigned int CFlatRuntime2::getNumFreeObject(int classType)
 {
 	unsigned int count = 0;
-	unsigned char* objects;
-	int stride;
-	int objectCount;
-
 	if (classType == 3) {
-		objects = m_objParty;
-		stride = 0x6F8;
-		objectCount = 4;
-	} else if (classType < 3) {
-		if (classType == 1) {
-			objects = CFlat + 0x110C0;
-			stride = 0xAC;
-			objectCount = 0x18;
-		} else if (classType < 1) {
-			if (classType < 0) {
-				return 0;
-			}
-			objects = CFlat + 0x10440;
-			stride = 0x50;
-			objectCount = 0x28;
-		} else {
-			objects = CFlat + 0x120E0;
-			stride = 0x518;
-			objectCount = 0x38;
-		}
-	} else if (classType == 5) {
-		objects = m_objItem;
-		stride = 0x57C;
-		objectCount = 0x20;
-	} else if (classType < 5) {
-		objects = m_objMon;
-		stride = 0x740;
-		objectCount = 0x40;
-	} else {
-		return 0;
-	}
-
-	for (int i = 0; i < objectCount; i++) {
-		if (*reinterpret_cast<signed char*>(objects + 0x4C) >= 0) {
+		signed char* obj = reinterpret_cast<signed char*>(m_objParty);
+		if (obj[0x4C] >= 0) {
 			count++;
 		}
-		objects += stride;
+		if (obj[0x744] >= 0) {
+			count++;
+		}
+		if (obj[0xE3C] >= 0) {
+			count++;
+		}
+		if (obj[0x1534] >= 0) {
+			count++;
+		}
+		return count;
+	}
+
+	if (classType < 3) {
+		if (classType == 1) {
+			signed char* obj = reinterpret_cast<signed char*>(CFlat + 0x110C0);
+			for (int i = 0; i < 3; i++) {
+				if (obj[0x4C] >= 0) {
+					count++;
+				}
+				if (obj[0xF8] >= 0) {
+					count++;
+				}
+				if (obj[0x1A4] >= 0) {
+					count++;
+				}
+				if (obj[0x250] >= 0) {
+					count++;
+				}
+				if (obj[0x2FC] >= 0) {
+					count++;
+				}
+				if (obj[0x3A8] >= 0) {
+					count++;
+				}
+				if (obj[0x454] >= 0) {
+					count++;
+				}
+				if (obj[0x500] >= 0) {
+					count++;
+				}
+				obj += 0x560;
+			}
+			return count;
+		}
+
+		if (classType < 1) {
+			if (classType < 0) {
+				return count;
+			}
+
+			signed char* obj = reinterpret_cast<signed char*>(CFlat + 0x10440);
+			for (int i = 0; i < 5; i++) {
+				if (obj[0x4C] >= 0) {
+					count++;
+				}
+				if (obj[0x9C] >= 0) {
+					count++;
+				}
+				if (obj[0xEC] >= 0) {
+					count++;
+				}
+				if (obj[0x13C] >= 0) {
+					count++;
+				}
+				if (obj[0x18C] >= 0) {
+					count++;
+				}
+				if (obj[0x1DC] >= 0) {
+					count++;
+				}
+				if (obj[0x22C] >= 0) {
+					count++;
+				}
+				if (obj[0x27C] >= 0) {
+					count++;
+				}
+				obj += 0x280;
+			}
+			return count;
+		}
+
+		signed char* obj = reinterpret_cast<signed char*>(CFlat + 0x120E0);
+		for (int i = 0; i < 7; i++) {
+			if (obj[0x4C] >= 0) {
+				count++;
+			}
+			if (obj[0x564] >= 0) {
+				count++;
+			}
+			if (obj[0xA7C] >= 0) {
+				count++;
+			}
+			if (obj[0xF94] >= 0) {
+				count++;
+			}
+			if (obj[0x14AC] >= 0) {
+				count++;
+			}
+			if (obj[0x19C4] >= 0) {
+				count++;
+			}
+			if (obj[0x1EDC] >= 0) {
+				count++;
+			}
+			if (obj[0x23F4] >= 0) {
+				count++;
+			}
+			obj += 0x28C0;
+		}
+		return count;
+	}
+
+	if (classType == 5) {
+		signed char* obj = reinterpret_cast<signed char*>(m_objItem);
+		for (int i = 0; i < 4; i++) {
+			if (obj[0x4C] >= 0) {
+				count++;
+			}
+			if (obj[0x5C8] >= 0) {
+				count++;
+			}
+			if (obj[0xB44] >= 0) {
+				count++;
+			}
+			if (obj[0x10C0] >= 0) {
+				count++;
+			}
+			if (obj[0x163C] >= 0) {
+				count++;
+			}
+			if (obj[0x1BB8] >= 0) {
+				count++;
+			}
+			if (obj[0x2134] >= 0) {
+				count++;
+			}
+			if (obj[0x26B0] >= 0) {
+				count++;
+			}
+			obj += 0x2BE0;
+		}
+		return count;
+	}
+
+	if (classType > 4) {
+		return count;
+	}
+
+	signed char* obj = reinterpret_cast<signed char*>(m_objMon);
+	for (int i = 0; i < 8; i++) {
+		if (obj[0x4C] >= 0) {
+			count++;
+		}
+		if (obj[0x78C] >= 0) {
+			count++;
+		}
+		if (obj[0xECC] >= 0) {
+			count++;
+		}
+		if (obj[0x160C] >= 0) {
+			count++;
+		}
+		if (obj[0x1D4C] >= 0) {
+			count++;
+		}
+		if (obj[0x248C] >= 0) {
+			count++;
+		}
+		if (obj[0x2BCC] >= 0) {
+			count++;
+		}
+		if (obj[0x330C] >= 0) {
+			count++;
+		}
+		obj += 0x3A00;
 	}
 
 	return count;


### PR DESCRIPTION
## Summary
- Reworked `CFlatRuntime2::getNumFreeObject(int)` in `src/cflat_runtime2.cpp` to follow the original class-bucket control flow more closely.
- Replaced the prior generic `objects/stride/objectCount` loop with class-specific counting paths and unrolled 8-at-a-time active-slot checks.
- Kept behavior equivalent: count objects whose active byte (`+0x4C`) is non-negative for each class pool.

## Functions Improved
- Unit: `main/cflat_runtime2`
- Symbol: `getNumFreeObject__13CFlatRuntime2Fi`

## Match Evidence
- Before: `11.8%` (from `tools/agent_select_target.py` output)
- After: `45.39394%` (`tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - getNumFreeObject__13CFlatRuntime2Fi`)
- Improvement: `+33.59394` percentage points

## Plausibility Rationale
- The new implementation uses source patterns that are plausible for original shipped game code: explicit per-class branches and fixed-size pool iteration, rather than decomp-only coercion tricks.
- It mirrors known object-pool layout semantics already used in this file (`CFlat`/`m_obj*` pools and fixed slot strides).

## Technical Details
- Aligns branch ordering (`classType == 3`, `< 3` with nested cases, `== 5`, `< 5`, fallback) to the decompilation structure.
- Uses repeated `signed char` active-flag checks at fixed offsets to better match the compiler's emitted compare/add sequence.
- Preserves interfaces and avoids introducing analysis-only comments or debug artifacts.
