### PR TITLE
RedMidiCtrl: implement __MidiCtrl_FuzzyOff

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1833,10 +1833,39 @@ void __MidiCtrl_FuzzyOn(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C9FA0
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_FuzzyOff(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_FuzzyOff(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+	unsigned char* data = *(unsigned char**)track;
+	unsigned int* trackWords = (unsigned int*)track;
+	*(unsigned char**)track = data + 1;
+	unsigned char mode = *data;
+
+	if (mode == 3) {
+		trackWords[0x3F] &= 0xFFFDFFFF;
+		return;
+	}
+
+	if (mode < 3) {
+		if (mode == 1) {
+			trackWords[0x3F] &= 0xFFFF7FFF;
+			return;
+		}
+
+		if (mode != 0) {
+			trackWords[0x3F] &= 0xFFFEFFFF;
+			return;
+		}
+	} else if (mode < 5) {
+		trackWords[0x3F] &= 0xFFFBFFFF;
+		return;
+	}
+
+	trackWords[0x3F] &= 0xFFFFBFFF;
 }


### PR DESCRIPTION
## Summary
- Implemented `__MidiCtrl_FuzzyOff` in `src/RedSound/RedMidiCtrl.cpp` from TODO stub to real control-handler logic.
- Added versioned function metadata in the required `--INFO--` format with PAL address/size from Ghidra reference.
- Kept implementation source-plausible: consumes one command byte from track stream and clears one of several fuzzy flags on the track bitfield.

## Functions improved
- Unit: `main/RedSound/RedMidiCtrl`
- Symbol: `__MidiCtrl_FuzzyOff__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Match evidence
- Before: `2.6%` (from `tools/agent_select_target.py` output for this symbol)
- After: `78.86842%` (`objdiff-cli v3.6.1`)
- Objdiff command:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o diff_fuzzyoff.json --format json-pretty __MidiCtrl_FuzzyOff__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Plausibility rationale
- The resulting code follows standard MIDI-control handler style for this module: parse event byte, mutate track state flags, and advance stream pointer.
- No compiler-coaxing artifacts were introduced (no contrived temporaries, no unnatural control-flow rearrangement beyond direct decomp transcription).

## Technical details
- Reads one control byte from `track` event data and updates `trackWords[0x3F]` bitfield with mask-specific clears for each fuzzy mode.
- Uses early-return branching to mirror original logic structure and preserve codegen behavior as closely as possible.

## Validation
- `ninja` passes in the branch worktree.
