### PR TITLE
pppLaser: compute frame callback part index from manager state

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -26,6 +26,8 @@ extern u32 CFlatFlags;
 extern CMapMng MapMng;
 extern Mtx ppvCameraMatrix0;
 extern CGraphic Graphic;
+extern u8 PartMng[];
+extern u8* lbl_8032ED50;
 
 extern "C" {
 void pppHeapUseRate__FPQ27CMemory6CStage(void*);
@@ -299,9 +301,10 @@ void pppFrameLaser(struct pppLaser *pppLaser, struct UnkB *param_2, struct UnkC 
             work[0] = PSVECDistance(&points[i], (Vec*)(work + 8));
         } else if (i == 0 && *((u8*)work + 0x4c) != 0) {
             if (work[0xf] - FLOAT_80333458 < work[0]) {
+                s32 partIndex = ((s32)(lbl_8032ED50 - (PartMng + 0x2A18))) / 0x158;
                 work[0] = work[0xf] - FLOAT_80333458;
                 ParticleFrameCallback__5CGameFiiiiiP3Vec(
-                    &Game.game, 0, (int)pppMngStPtr->m_kind, (int)pppMngStPtr->m_nodeIndex, 3,
+                    &Game.game, partIndex, (int)pppMngStPtr->m_kind, (int)pppMngStPtr->m_nodeIndex, 3,
                     (int)((u32)baseObj->m_graphId >> 12));
                 *((u8*)work + 0x4c) = 0;
             }


### PR DESCRIPTION
## Summary
- Updated `pppFrameLaser` callback handling in `src/pppLaser.cpp` to compute the particle manager index from manager storage (`lbl_8032ED50` / `PartMng`) instead of hardcoding `0`.
- Added the required extern declarations used by that computation.

## Functions improved
- Unit: `main/pppLaser`
- Symbol: `pppFrameLaser`
  - Before: `49.119892%`
  - After: `51.588554%`
  - Delta: `+2.468662%`
- `pppRenderLaser` remained unchanged at `35.085106%`.

## Match evidence
- Built with `ninja` successfully after the change.
- Verified via objdiff oneshot JSON:
  - `../tools/objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser`

## Plausibility rationale
- The previous code path used a literal `0` for the first `ParticleFrameCallback` argument.
- Nearby callback units (`pppCallBackDistance`, `pppYmCallBack`) compute this argument as the current manager index from `PartMng` + stride `0x158`.
- This change aligns `pppFrameLaser` with that established project pattern and expected runtime semantics, rather than compiler-only coaxing.

## Technical details
- New index expression:
  - `((s32)(lbl_8032ED50 - (PartMng + 0x2A18))) / 0x158`
- The change only affects callback argument formation inside the existing clamp/emit branch; no unrelated control flow or formatting artifacts were introduced.
