### PR TITLE
pppEmission: improve pppFrameEmission conversion codegen

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -348,7 +348,7 @@ void pppFrameEmission(pppEmission* pppEmission_, UnkB* param_2, UnkC* param_3) {
     *((u8*)state + 10) = *((u8*)pppEmission_ + 0x8A + dataSet);
     *((u8*)state + 11) = baseAlpha;
 
-    double alphaScale = (double)((float)baseAlpha / FLOAT_803311e0);
+    double alphaScale = (double)baseAlpha / FLOAT_803311e0;
 
     CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
         param_2->m_stepValue, pppEmission_, param_2->m_graphId,
@@ -418,7 +418,7 @@ void pppFrameEmission(pppEmission* pppEmission_, UnkB* param_2, UnkC* param_3) {
             }
 
             *(s16*)((u8*)particle + 10) = *(s16*)((u8*)particle + 10) - 1;
-            int alpha = (int)((double)(float)*(s16*)(particle + 1) * alphaScale);
+            int alpha = (int)((double)*(s16*)(particle + 1) * alphaScale);
 
             if (*(s16*)((u8*)particle + 10) < 1) {
                 s16 jitter = 0;


### PR DESCRIPTION
## Summary
- Adjusted numeric conversions in `pppFrameEmission` to remove an unnecessary float round-trip before double arithmetic.
- Updated:
  - `alphaScale` calculation from `(double)((float)baseAlpha / FLOAT_803311e0)` to `(double)baseAlpha / FLOAT_803311e0`
  - per-particle alpha calculation from `(double)(float)*(s16*)(particle + 1) * alphaScale` to `(double)*(s16*)(particle + 1) * alphaScale`

## Functions improved
- Unit: `main/pppEmission`
- Symbol: `pppFrameEmission`

## Match evidence
- `pppFrameEmission`: **67.84615% -> 68.81923%** (`+0.97308`)
- Measured with:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppEmission -o /tmp/pppEmission_before.json --format json-pretty pppFrameEmission`
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/pppEmission -o /tmp/pppEmission_after1.json --format json-pretty pppFrameEmission`

## Plausibility rationale
- The change reflects natural source-level intent: convert byte/short values directly to double when participating in double-domain math, instead of introducing an intermediate float cast.
- No control-flow restructuring or contrived temporaries were introduced.

## Technical details
- This aligns the compiler toward PPC conversion sequences seen in decomp/asm patterns for mixed integer+floating math in this function.
- Full build remains green (`ninja`), and the diff impact is isolated to `src/pppEmission.cpp`.
