### PR TITLE
graphic: match IsFifoOver local stack layout

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -552,11 +552,11 @@ void CGraphic::Thread()
  */
 u8 CGraphic::IsFifoOver()
 {
-	GXBool fifoWrap;
-	GXBool gpRead;
-	GXBool cpuWrite;
-	GXBool underflow;
 	GXBool overhi;
+	GXBool underflow;
+	GXBool cpuWrite;
+	GXBool gpRead;
+	GXBool fifoWrap;
 	u32 fifoCount;
 
 	GXGetFifoStatus(GXGetCPUFifo(), &overhi, &underflow, &fifoCount, &cpuWrite, &gpRead, &fifoWrap);


### PR DESCRIPTION
## Summary
- Reordered local `GXBool` declarations in `CGraphic::IsFifoOver()` to match the original stack slot layout used for `GXGetFifoStatus` out-params.
- No behavior changes; this only adjusts local variable layout/codegen.

## Functions improved
- Unit: `main/graphic`
- Symbol: `IsFifoOver__8CGraphicFv`

## Match evidence
- `IsFifoOver__8CGraphicFv`: **99.6875% -> 100.0%**
- `ninja` build passes and project progress increased by one matched function (`1775 -> 1776`).

## Plausibility rationale
- The change is source-plausible and idiomatic: same variables, same API call, same return value.
- It only reorders local declarations to reflect likely original source ordering and ABI stack layout.

## Technical details
- Objdiff showed only argument stack-slot mismatches (`addi r4/r5/r8/r9`) and return-load slot mismatch (`lbz r3, ...`) in this function.
- Reordering locals aligned stack offsets with the base object, eliminating those residual instruction diffs.
