### PR TITLE
math: improve Hsb2Rgb match in main/math

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -1034,49 +1034,55 @@ unsigned int CMath::Hsb2Rgb(int hue, int saturation, int brightness)
     sat -= sat >> 31;
     val -= val >> 31;
 
-    unsigned char v = (unsigned char)val;
-    unsigned int rgba;
+    unsigned char rgba[4];
     if ((float)sat == 0.0f) {
-        rgba = ((unsigned int)v << 24) | ((unsigned int)v << 16) | ((unsigned int)v << 8);
-    }
-    else {
-        int m = ((0xFF - sat) * val) / 0xFF;
-        int sector = hue / 60;
-        int fraction = (hue - (sector * 60)) * (val - m);
-        int x = fraction / 60;
+        rgba[0] = (unsigned char)val;
+        rgba[1] = (unsigned char)val;
+        rgba[2] = (unsigned char)val;
+    } else {
+        int tmp = (0xFF - sat) * val;
+        int lo = tmp / 0xFF + (tmp >> 31);
+        lo -= lo >> 31;
+        tmp = hue / 60 + (hue >> 31);
+        tmp = (hue + (tmp - (tmp >> 31)) * -60) * (val - lo);
+        tmp = tmp / 60 + (tmp >> 31);
 
-        unsigned char lo = (unsigned char)m;
-        unsigned char hi = (unsigned char)val;
-        unsigned char q = (unsigned char)(val - x);
-        unsigned char t = (unsigned char)(m + x);
-
+        unsigned char x = (unsigned char)(tmp - (tmp >> 31));
+        unsigned char cLo = (unsigned char)lo;
+        unsigned char cHi = (unsigned char)val;
         if (hue < 60) {
-            rgba = ((unsigned int)hi << 24) | ((unsigned int)t << 16) | ((unsigned int)lo << 8);
-        }
-        else if (hue < 120) {
-            rgba = ((unsigned int)q << 24) | ((unsigned int)hi << 16) | ((unsigned int)lo << 8);
-        }
-        else if (hue < 180) {
-            rgba = ((unsigned int)lo << 16) | ((unsigned int)hi << 8) | (unsigned int)t;
-            rgba <<= 8;
-        }
-        else if (hue < 240) {
-            rgba = ((unsigned int)lo << 16) | ((unsigned int)q << 8) | (unsigned int)hi;
-            rgba <<= 8;
-        }
-        else if (hue < 300) {
-            rgba = ((unsigned int)t << 16) | ((unsigned int)lo << 8) | (unsigned int)hi;
-            rgba <<= 8;
-        }
-        else if (hue < 360) {
-            rgba = ((unsigned int)hi << 24) | ((unsigned int)lo << 16) | ((unsigned int)q << 8);
-        }
-        else {
-            rgba = 0;
+            rgba[0] = cHi;
+            rgba[1] = cLo + x;
+            rgba[2] = cLo;
+        } else if (hue < 120) {
+            rgba[0] = cHi - x;
+            rgba[1] = cHi;
+            rgba[2] = cLo;
+        } else if (hue < 180) {
+            rgba[0] = cLo;
+            rgba[1] = cHi;
+            rgba[2] = cLo + x;
+        } else if (hue < 240) {
+            rgba[0] = cLo;
+            rgba[1] = cHi - x;
+            rgba[2] = cHi;
+        } else if (hue < 300) {
+            rgba[0] = cLo + x;
+            rgba[1] = cLo;
+            rgba[2] = cHi;
+        } else if (hue < 360) {
+            rgba[0] = cHi;
+            rgba[1] = cLo;
+            rgba[2] = cHi - x;
+        } else {
+            rgba[0] = 0;
+            rgba[1] = 0;
+            rgba[2] = 0;
         }
     }
 
-    return rgba | 0xFF;
+    rgba[3] = 0xFF;
+    return *(unsigned int*)rgba;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CMath::Hsb2Rgb(int hue, int saturation, int brightness)` in `src/math.cpp`.
- Kept behavior intact while restructuring signed integer normalization and color packing to better match original codegen.
- Switched to explicit byte-channel assembly (`rgba[0..3]`) with alpha appended last.

## Functions improved
- Unit: `main/math`
- Symbol: `Hsb2Rgb__5CMathFiii`

## Match evidence
- Before: `52.475727%`
- After: `64.572815%`
- Net: `+12.097088` points

Objdiff command used:
```sh
/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/math -o - Hsb2Rgb__5CMathFiii
```

## Plausibility rationale
- The update favors source-level integer math patterns that are common in this codebase (signed divide normalization and explicit byte channels), rather than artificial instruction-coaxing.
- Control-flow remains straightforward HSV sector branching and is consistent with expected original gameplay utility code.

## Technical details
- Added explicit signed normalization around division results in intermediate steps.
- Replaced packed-shift composition with per-channel byte writes, which aligned emitted stores/branch layout more closely with target assembly.
