### PR TITLE
gx: improve GXCopyDisp match in GXFrameBuf

### DIFF
--- a/src/gx/GXFrameBuf.c
+++ b/src/gx/GXFrameBuf.c
@@ -482,9 +482,8 @@ static void __GXVerifCopy(void* dest, u8 clear) {
  */
 void GXCopyDisp(void* dest, GXBool clear) {
     u32 reg;
-    u32 tempPeCtrl;
-    GXBool changePeCtrl;
-    GXData* gx;
+    u32 oldPeCtrl;
+    GXBool disablePeCtrl;
 
     CHECK_GXBEGIN(1833, "GXCopyDisp");
 
@@ -492,46 +491,45 @@ void GXCopyDisp(void* dest, GXBool clear) {
     __GXVerifCopy(dest, clear);
 #endif
 
-    gx = __GXData;
     if (clear) {
-        reg = gx->zmode;
+        reg = __GXData->zmode;
         reg = (reg & 0xFFFFFFF0) | 0xF;
         GX_WRITE_RAS_REG(reg);
 
-        reg = gx->cmode0;
+        reg = __GXData->cmode0;
         reg &= 0xFFFFFFFC;
         GX_WRITE_RAS_REG(reg);
     }
 
-    changePeCtrl = FALSE;
-    tempPeCtrl = gx->peCtrl;
-    if ((clear || ((tempPeCtrl & 7) == 3)) && (((tempPeCtrl >> 6) & 1) == 1)) {
-        changePeCtrl = TRUE;
-        GX_WRITE_RAS_REG(tempPeCtrl & 0xFFFFFFBF);
+    disablePeCtrl = FALSE;
+    oldPeCtrl = __GXData->peCtrl;
+    if ((clear || ((oldPeCtrl & 7) == 3)) && (((oldPeCtrl >> 6) & 1) == 1)) {
+        disablePeCtrl = TRUE;
+        GX_WRITE_RAS_REG(oldPeCtrl & 0xFFFFFFBF);
     }
 
-    GX_WRITE_RAS_REG(gx->cpDispSrc);
-    GX_WRITE_RAS_REG(gx->cpDispSize);
-    GX_WRITE_RAS_REG(gx->cpDispStride);
+    GX_WRITE_RAS_REG(__GXData->cpDispSrc);
+    GX_WRITE_RAS_REG(__GXData->cpDispSize);
+    GX_WRITE_RAS_REG(__GXData->cpDispStride);
 
     reg = (((u32)dest >> 5) & 0xFFFFFF) | 0x4B000000;
     GX_WRITE_RAS_REG(reg);
 
-    gx->cpDisp = (gx->cpDisp & 0xFFFFF7FF) | ((u32)clear << 11);
-    gx->cpDisp = (gx->cpDisp & 0xFFFFBFFF) | 0x4000;
-    gx->cpDisp = (gx->cpDisp & 0x00FFFFFF) | 0x52000000;
-    GX_WRITE_RAS_REG(gx->cpDisp);
+    __GXData->cpDisp = (__GXData->cpDisp & 0xFFFFF7FF) | ((u32)clear << 11);
+    __GXData->cpDisp = (__GXData->cpDisp & 0xFFFFBFFF) | 0x4000;
+    __GXData->cpDisp = (__GXData->cpDisp & 0x00FFFFFF) | 0x52000000;
+    GX_WRITE_RAS_REG(__GXData->cpDisp);
 
     if (clear) {
-        GX_WRITE_RAS_REG(gx->zmode);
-        GX_WRITE_RAS_REG(gx->cmode0);
+        GX_WRITE_RAS_REG(__GXData->zmode);
+        GX_WRITE_RAS_REG(__GXData->cmode0);
     }
 
-    if (changePeCtrl) {
-        GX_WRITE_RAS_REG(gx->peCtrl);
+    if (disablePeCtrl) {
+        GX_WRITE_RAS_REG(__GXData->peCtrl);
     }
 
-    gx->bpSentNot = 0;
+    __GXData->bpSentNot = 0;
 }
 
 void GXCopyTex(void* dest, GXBool clear) {


### PR DESCRIPTION
## Summary
- Refactored `GXCopyDisp` in `src/gx/GXFrameBuf.c` to use direct `__GXData` access instead of a local alias pointer.
- Kept behavior unchanged while tightening variable usage and control-flow around PE control disable/restore handling.

## Functions improved
- Unit: `main/gx/GXFrameBuf`
- Function: `GXCopyDisp`

## Match evidence
- `GXCopyDisp` match improved from **81.195404%** to **87.91954%** (objdiff, same unit/symbol).
- Function size stayed at **348 bytes**, indicating instruction-level alignment improvement rather than bulk structural changes.

## Plausibility rationale
- The change keeps code idiomatic for Dolphin GX sources: direct global GX state access, straightforward BP register writes, and explicit temporary state control.
- No compiler-coaxing constructs were introduced; this is a readability-preserving cleanup that still aligns better with target codegen.

## Technical details
- Replaced `GXData* gx` alias + `tempPeCtrl/changePeCtrl` locals with direct `__GXData` reads/writes and `oldPeCtrl/disablePeCtrl` flow.
- This adjusted register allocation and branching around the clear path and PE control mask write (`0xFFFFFFBF`), improving assembly correspondence.
- Build verified with `ninja` in PAL (`GCCP01`) after the change.
