### PR TITLE
Improve RedMidiCtrl MIDI handler matches

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -10,7 +10,9 @@ extern int DAT_8032f3f8;
 extern void* DAT_8032f3f0;
 extern int* DAT_8032f420;
 extern int DAT_8032f424;
+extern int DAT_8032f414;
 extern CRedEntry DAT_8032e154;
+extern int DAT_8021dc20[];
 extern int lbl_8021EA10[];
 extern int PTR_SineSwing__Fi_8021e9d0[];
 
@@ -637,12 +639,32 @@ void __MidiCtrl_TimeSignature(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C824C
+ * PAL Size: 140b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_KeySignature(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_KeySignature(RedSoundCONTROL* control, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    unsigned char* command = (unsigned char*)((int*)track)[0];
+    int* controlData = (int*)control;
+    int scale;
+    unsigned int voice;
+
+    ((int*)track)[0] = (int)(command + 1);
+    scale = command[0] & 0x1f;
+    controlData[0x120] = scale;
+    controlData[2] = DAT_8021dc20[scale] + (int)DAT_8021dc20;
+
+    if (DAT_8032f414 != 0) {
+        voice = (unsigned int)controlData[0];
+        do {
+            *(int*)(voice + 0x20) = controlData[2];
+            voice += 0x154;
+        } while (voice < (unsigned int)(controlData[0] + (unsigned int)*(unsigned char*)((char*)control + 0x491) * 0x154));
+    }
 }
 
 /*
@@ -872,12 +894,28 @@ void __MidiCtrl_ExpressionDirect(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8800
+ * PAL Size: 132b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ExpressionChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ExpressionChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    int delta[4];
+    char* command;
+    int* trackData = (int*)track;
+
+    delta[0] = DeltaTimeSumup((unsigned char**)trackData);
+    if (delta[0] == 0) {
+        delta[0] = 1;
+    }
+
+    command = (char*)trackData[0];
+    trackData[0] = (int)(command + 1);
+    trackData[0xe] = DataAddCompute(trackData + 0xd, *command, delta);
+    trackData[0xf] = delta[0];
 }
 
 /*
@@ -1841,22 +1879,71 @@ void __MidiCtrl_ReverbMix(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C9DBC
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_StepRelative(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_StepRelative(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    char value;
+    short step;
+    char* command;
+    int* trackData = (int*)track;
+
+    command = (char*)trackData[0];
+    trackData[0] = (int)(command + 1);
+    value = *command;
+    if (value == 0) {
+        step = 0;
+    } else {
+        step = *(short*)(trackData + 0x4e) + (short)value;
+    }
+    *(short*)(trackData + 0x4e) = step;
+    *(short*)((char*)trackData + 0x13a) = 0;
+
+    if (*(short*)(trackData + 0x4e) < -9999) {
+        *(short*)(trackData + 0x4e) = -9999;
+    } else if (*(short*)(trackData + 0x4e) > 9999) {
+        *(short*)(trackData + 0x4e) = 9999;
+    }
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C9E3C
+ * PAL Size: 128b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_StepRelative2(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_StepRelative2(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    unsigned char value;
+    short step;
+    unsigned char* command;
+    int* trackData = (int*)track;
+
+    command = (unsigned char*)trackData[0];
+    trackData[0] = (int)(command + 1);
+    value = *command;
+    *(short*)(trackData + 0x4e) = 0;
+
+    if (value == 0) {
+        step = 0;
+    } else {
+        step = *(short*)((char*)trackData + 0x13a) + (unsigned short)value;
+    }
+    *(short*)((char*)trackData + 0x13a) = step;
+
+    if (*(short*)((char*)trackData + 0x13a) < -9999) {
+        *(short*)((char*)trackData + 0x13a) = -9999;
+    } else if (*(short*)((char*)trackData + 0x13a) > 9999) {
+        *(short*)((char*)trackData + 0x13a) = 9999;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented four previously TODO MIDI control handlers in `src/RedSound/RedMidiCtrl.cpp` using existing RedSound pointer/offset style:
  - `__MidiCtrl_KeySignature`
  - `__MidiCtrl_ExpressionChange`
  - `__MidiCtrl_StepRelative`
  - `__MidiCtrl_StepRelative2`
- Added missing extern declarations required by these handlers (`DAT_8032f414`, `DAT_8021dc20`).
- Updated each implemented function header with PAL address/size metadata.

## Functions Improved
Unit: `main/RedSound/RedMidiCtrl`

- `__MidiCtrl_KeySignature__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - 2.857143% -> 65.28571%
- `__MidiCtrl_ExpressionChange__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - 3.030303% -> 41.636364%
- `__MidiCtrl_StepRelative__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - 3.125% -> 57.1875%
- `__MidiCtrl_StepRelative2__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - 3.125% -> 50.9375%

Unit fuzzy match:
- `main/RedSound/RedMidiCtrl`: 38.905% -> 41.30464%

## Match Evidence
- Verified with exact before/after rebuilds against `build/GCCP01/report.json` on this branch.
- Full build passes (`ninja`, `build/GCCP01/main.dol: OK`).

## Plausibility Rationale
- Implementations follow existing project conventions for RedSound code (raw command stream consumption, integer fixed-point deltas, short clamping behavior, and track/control array slot semantics).
- No artificial control-flow tricks or compiler-coaxing temporaries were introduced; logic is direct and consistent with adjacent implemented MIDI control handlers.
