### PR TITLE
Improve GetSkillStr__8CMenuPcsFi match in menu_cmd

### DIFF
--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -2102,18 +2102,20 @@ unsigned int CMenuPcs::CmdClose2()
  */
 const char* CMenuPcs::GetSkillStr(int index)
 {
-	if (Game.game.m_gameWork.m_languageId == '\x03') {
+	const s8 languageId = Game.game.m_gameWork.m_languageId;
+
+	if (languageId == '\x03') {
 		return PTR_s_Colpo_Fire_80214d50[index];
 	}
-	if (Game.game.m_gameWork.m_languageId < 3) {
-		if ((Game.game.m_gameWork.m_languageId != '\x01') && (Game.game.m_gameWork.m_languageId != '\0')) {
+	if (languageId < 3) {
+		if ((languageId != '\x01') && (languageId != '\0')) {
 			return PTR_s_Feuer_Hieb_80214d3c[index];
 		}
 	} else {
-		if (Game.game.m_gameWork.m_languageId == '\x05') {
+		if (languageId == '\x05') {
 			return PTR_s_Efecto_Fuego_80214d78[index];
 		}
-		if (Game.game.m_gameWork.m_languageId < 5) {
+		if (languageId < 5) {
 			return PTR_s_Pyro_Frappe_80214d64[index];
 		}
 	}


### PR DESCRIPTION
## Summary
- Refactored `CMenuPcs::GetSkillStr(int)` in `src/menu_cmd.cpp` to load `m_languageId` once into a local `s8` and reuse it for all branch checks.
- Kept the same language-selection behavior and return paths while aligning code generation with expected branch/compare patterns.

## Functions improved
- Unit: `main/menu_cmd`
- Function: `GetSkillStr__8CMenuPcsFi`

## Match evidence
- `GetSkillStr__8CMenuPcsFi`: **48.692307% -> 54.820515%**
  - Measured with:
    - `tools/objdiff-cli diff -p . -u main/menu_cmd -o /tmp/menu_cmd_getskill_before.json GetSkillStr__8CMenuPcsFi`
    - `tools/objdiff-cli diff -p . -u main/menu_cmd -o /tmp/menu_cmd_getskill_final.json GetSkillStr__8CMenuPcsFi`
- Unit `.text` (`main/menu_cmd`): **28.968416% -> 29.009665%**

## Plausibility rationale
- This is plausible original source style: caching a frequently-read field in a local variable before condition checks is common, readable, and non-contrived.
- No artificial temporaries, hardcoded offsets, or control-flow tricks were introduced.

## Technical details
- The change specifically influences compare/load lowering for language checks (`==`, `<`, `!=`) by using a consistent signed local value.
- Objdiff indicates a real instruction-level improvement for the targeted symbol rather than superficial formatting changes.
