### PR TITLE
Improve CFlatRuntime2::onSystemVal match

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1753,10 +1753,9 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         int valueIndex = -0x1000 - systemValue;
         int valueGroup = valueIndex / 0x600;
         int rowIndex = 0x5FF - (valueIndex - valueGroup * 0x600);
-        u8* row = *reinterpret_cast<u8**>(game + 0xC5A8) + rowIndex * 0x48;
-
+        u16* row = reinterpret_cast<u16*>(*reinterpret_cast<u8**>(game + 0xC5A8) + rowIndex * 0x48);
         if ((unsigned int)valueGroup <= 0x23) {
-            result = reinterpret_cast<u16*>(row)[valueGroup];
+            result = row[valueGroup];
         }
     } else if (systemValue < -499) {
         unsigned int bitIndex = static_cast<unsigned int>(systemValue + 0x9F3);
@@ -1870,6 +1869,9 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
             break;
         case -0x42:
             result = *reinterpret_cast<u32*>(gameWork + 0x10B8 + (systemValue + 0x6B) * 4);
+            break;
+        case -0x41:
+            result = *reinterpret_cast<u32*>(gameWork + 0x10BC);
             break;
         }
     }


### PR DESCRIPTION
## Summary
- Updated `CFlatRuntime2::onSystemVal` in `src/cflat_r2system.cpp` to better align value access and system switch coverage.
- Switched the `< -0xFFF` row access path to a direct `u16*` row pointer before indexing.
- Added missing `case -0x41` in the system value switch to read `m_timerA` (`gameWork + 0x10BC`).

## Functions improved
- Unit: `main/cflat_r2system`
- Function: `onSystemVal__13CFlatRuntime2FPQ212CFlatRuntime7CObjecti`

## Match evidence
- Before: `12.1%` (target selector baseline)
- After: `21.425438%` (`objdiff-cli v3.6.1`, JSON oneshot)
- Command used:
  - `/Users/zcanann/Documents/projects/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - onSystemVal__13CFlatRuntime2FPQ212CFlatRuntime7CObjecti`

## Plausibility rationale
- The change does not introduce contrived control flow or compiler-coaxing artifacts.
- The new `-0x41` case is consistent with existing `onSetSystemVal` handling for timer fields and keeps source behavior semantically coherent.
- Pointer typing cleanup (`u16*` row access) reflects the underlying data layout already implied by existing code and decomp context.

## Technical notes
- This is a focused first-pass improvement on a low-match unit while preserving readability and existing source style.
- `ninja` build passes after changes.
