### PR TITLE
Improve SetGoOutMode decomp coverage in goout

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -602,6 +602,145 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         field_0x3c = 0;
         field_0x46 = 1;
         break;
+    case 7:
+        WriteMenuU8(2184, 1);
+        field_0x14 = 0;
+        field_0x18 = 7;
+        field_0x1c = 0;
+        field_0x1d = 0;
+        SetMenuStr(0, 7,
+                   "Please insert a Memory Card with",
+                   "current game's data into Slot A.",
+                   "Insert into Slot B a Memory Card",
+                   "with the character data to be transferred.",
+                   "",
+                   "Please do not remove either Memory Card",
+                   "until the transfer is complete.");
+        break;
+    case 0xC:
+        if (field_0x36 >= 0) {
+            WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
+            WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+        }
+        field_0x45 = 0;
+        field_0x34 = 0x21;
+        field_0x48 = 0;
+        field_0x3c = 0;
+        MenuPcs.GetMcAccessPos(&field_0xc, &field_0x10);
+        field_0xc = 0;
+        mcCtrl.m_cardChannel = field_0xc;
+        field_0x2 = static_cast<char>(mcCtrl.m_cardChannel);
+        field_0x3 = static_cast<char>(field_0x10);
+        field_0x4 = mcCtrl.ChkConnect(static_cast<unsigned char>(field_0x2));
+        if (field_0x4 == 1) {
+            mcCtrl.m_saveIndex = static_cast<unsigned char>(field_0x3);
+            mcCtrl.m_cardChannel = static_cast<unsigned char>(field_0x2);
+            mcCtrl.m_previousState = 0;
+            mcCtrl.m_state = 0;
+            mcCtrl.m_lastResult = 0;
+            mcCtrl.m_iteration = 0;
+            mcCtrl.m_userBuffer = 0;
+            mcCtrl.m_createFlag = 0;
+            field_0x1 = 1;
+        }
+        break;
+    case 0xE:
+        MenuPcs.InitSaveLoadMenu();
+        MenuPcs.SetMenuCharaAnim(0, 0);
+        MenuPcs.CopyNowCaravanDat(*reinterpret_cast<Mc::SaveDat**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 2176));
+        WriteMenuU8(2185, 2);
+        WriteMenuU8(2186, 1);
+        WriteMenuS32(2188, ReadMenuS32(2180));
+        if (field_0x36 >= 0) {
+            WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
+            WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+        }
+        field_0x45 = 0;
+        field_0x34 = -1;
+        field_0x48 = 0;
+        field_0x3c = 0;
+        break;
+    case 0xF:
+        MenuPcs.ChgAllModel2();
+        if (field_0x1d == 0) {
+            MenuPcs.InitSaveLoadMenu();
+        }
+        MenuPcs.SetMenuCharaAnim(0, 0);
+        field_0x1d = 1;
+        if (field_0x36 >= 0) {
+            WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
+            WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+        }
+        field_0x45 = 0;
+        field_0x34 = -1;
+        field_0x48 = 0;
+        field_0x3c = 0;
+        WriteMenuU8(2185, 2);
+        WriteMenuU8(2186, 1);
+        WriteMenuS32(2188, ReadMenuS32(2180));
+        break;
+    case 0x10:
+        if (field_0x1e == 0) {
+            SetMenuStr(0, 5,
+                       "Are you sure you wish to import",
+                       "the selected character into the",
+                       "current game? The character will",
+                       "be unavailable until returned.",
+                       "  Yes   No");
+        } else {
+            SetMenuStr(0, 5,
+                       "Are you sure you wish to return",
+                       "the selected character to the",
+                       "current game? The character's",
+                       "guest data will be deleted.",
+                       "  Yes   No");
+        }
+        field_0x46 = 1;
+        break;
+    case 0x11:
+        if (field_0x36 >= 0) {
+            WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
+            WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+        }
+        field_0x45 = 0;
+        field_0x34 = 0x1F;
+        field_0x48 = 0;
+        field_0x3c = 0;
+        field_0x46 = 1;
+        break;
+    case 0x13:
+        mcCtrl.m_cardChannel = static_cast<unsigned char>(field_0x1a);
+        field_0x2 = field_0x1a;
+        field_0x3 = field_0x1b;
+        field_0x8 = ReadMenuS32(2180);
+        field_0x4 = mcCtrl.ChkConnect(static_cast<unsigned char>(field_0x2));
+        if (field_0x4 == 1) {
+            mcCtrl.m_saveIndex = static_cast<unsigned char>(field_0x3);
+            mcCtrl.m_cardChannel = static_cast<unsigned char>(field_0x2);
+            mcCtrl.m_previousState = 0;
+            mcCtrl.m_state = 0;
+            mcCtrl.m_lastResult = 0;
+            mcCtrl.m_iteration = 0;
+            mcCtrl.m_userBuffer = 0;
+            mcCtrl.m_createFlag = 0;
+            field_0x1 = 2;
+        }
+        SetMenuStr(0, 4,
+                   "Saving data to the Memory",
+                   "Card in Slot B. Please do",
+                   "not touch the Memory Card",
+                   "or the POWER Button.");
+        break;
+    case 0x14:
+        if (field_0x36 >= 0) {
+            WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
+            WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+        }
+        field_0x45 = 0;
+        field_0x34 = 0x20;
+        field_0x48 = 0;
+        field_0x3c = 0;
+        break;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Expanded `CGoOutMenu::SetGoOutMode` with missing mode handlers restored from the current decomp pattern.
- Added concrete logic for modes `7`, `0xC`, `0xE`, `0xF`, `0x10`, `0x11`, `0x13`, and `0x14`.
- Kept existing style and field-level state transitions used throughout `goout.cpp`.

## Functions improved
- Unit: `main/goout`
- Function: `SetGoOutMode__10CGoOutMenuFUc`

## Match evidence
- `SetGoOutMode__10CGoOutMenuFUc`: **20.971632% -> 27.861702%** (`objdiff-cli`)
- Verification command:
  - `tools/objdiff-cli diff -p . -u main/goout -o - SetGoOutMode__10CGoOutMenuFUc`

## Plausibility rationale
- The added paths are menu-mode state handlers with normal game-flow responsibilities (menu text setup, memory card channel setup, save/load transitions, and common window state resets).
- Changes rely on existing class fields and established helper calls (`SetMenuStr`, `GetMcAccessPos`, `InitSaveLoadMenu`, `SetMenuCharaAnim`, `ChgAllModel2`) rather than contrived coercion patterns.

## Technical notes
- The previous implementation only handled a subset of switch cases (`1,3,4,5,6`), leaving large target-body coverage unmatched.
- Restoring additional cases increases control-flow/side-effect alignment and improves symbol-level assembly correspondence.
