### PR TITLE
mes: improve addString signed nibble tag parsing

### DIFF
--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -71,6 +71,13 @@ static int ReadTagU8(char** text)
 	return value;
 }
 
+static int ReadTagS8(char** text)
+{
+	int value = GetMesNibbleValue(*text);
+	*text += 2;
+	return (int)(signed char)value;
+}
+
 static int ReadTagS16(char** text)
 {
 	int a = (unsigned char)(*text)[0] & 0x0F;
@@ -389,8 +396,7 @@ void CMes::addString(char** text, int branchMode)
 				*(int*)((char*)this + 0x3C74) = 1;
 				return;
 			case 3:
-				*(int*)((char*)this + 0x3C7C) = *(int*)((char*)this + 0x3C7C) + GetMesNibbleValue(*text);
-				*text = *text + 2;
+				*(int*)((char*)this + 0x3C7C) = *(int*)((char*)this + 0x3C7C) + ReadTagS8(text);
 				break;
 			case 4:
 				*(int*)((char*)this + 0x3D2C) = 0;
@@ -435,7 +441,7 @@ void CMes::addString(char** text, int branchMode)
 			}
 			case 0x25:
 			{
-				int value = ReadTagU8(text);
+				int value = ReadTagS8(text);
 				if (*(int*)((char*)this + 0x3D4C) == 0)
 				{
 					if (value == 0x7F)
@@ -450,21 +456,21 @@ void CMes::addString(char** text, int branchMode)
 				break;
 			}
 			case 0x26:
-				*(int*)((char*)this + 0x3CB4) = ReadTagU8(text);
+				*(int*)((char*)this + 0x3CB4) = ReadTagS8(text);
 				break;
 			case 0x27:
-				*(int*)((char*)this + 0x3CB8) = ReadTagU8(text);
+				*(int*)((char*)this + 0x3CB8) = ReadTagS8(text);
 				break;
 			case 0x31:
 				*(int*)((char*)this + 0x3C84) = ReadTagS16(text);
 				*(int*)((char*)this + 0x3C88) = ReadTagS16(text);
 				break;
 			case 0x33:
-				*(int*)((char*)this + 0x3D3C) = ReadTagU8(text);
+				*(int*)((char*)this + 0x3D3C) = ReadTagS8(text);
 				break;
 			case 0x34:
 			{
-				*(int*)((char*)this + 0x3D40) = ReadTagU8(text);
+				*(int*)((char*)this + 0x3D40) = ReadTagS8(text);
 				int nextFontSel = *(int*)((char*)this + 0x3D40);
 				if (nextFontSel == 0)
 				{


### PR DESCRIPTION
## Summary
- Updated `CMes::addString` tag parameter parsing for specific single-byte tags to use signed 8-bit nibble decoding.
- Added `ReadTagS8` helper and applied it to tags that map to signed byte semantics in the reference decomp path (`0x03`, `0x25`, `0x26`, `0x27`, `0x33`, `0x34`).
- Kept changes narrow and source-plausible (type/signedness correction only), with no control-flow coercion.

## Functions improved
- Unit: `main/mes`
- Symbol: `addString__4CMesFPPci`
  - Before: `18.870724%`
  - After: `19.133333%`
  - Delta: `+0.262609%`

## Match evidence
- Build: `ninja` (passes)
- Objdiff command used:
  - `tools/objdiff-cli diff -p . -u main/mes -o - addString__4CMesFPPci`
- JSON extraction confirms increased `match_percent` for `addString__4CMesFPPci`.

## Plausibility rationale
- This change aligns with typical Metrowerks-era signed `char` behavior for nibble-packed single-byte control/tag values.
- The edit reflects likely original source intent (correct signedness), rather than introducing artificial temporaries or non-idiomatic compiler coaxing.

## Technical details
- Introduced `ReadTagS8(char**)` and replaced unsigned nibble reads only where the value is consumed as a signed control/spacing/font-selection parameter.
- Left index-like nibble reads (`ReadTagU8`) unchanged to avoid broad behavioral assumptions.
