### PR TITLE
singmenu: implement language table accessors and item icon lookup

### DIFF
--- a/include/ffcc/singmenu.h
+++ b/include/ffcc/singmenu.h
@@ -63,12 +63,12 @@ public:
     void DrawSingLife();
     void SingLifeInit(int);
     void SingLifeResetWait();
-    void GetTribeStr(int);
-    void GetJobStr(int);
-    void GetHairStr(int);
-    void GetMenuStr(int);
-    void GetAttrStr(int);
-    void GetItemIcon(int);
+    char* GetTribeStr(int);
+    char* GetJobStr(int);
+    char* GetHairStr(int);
+    char* GetMenuStr(int);
+    char* GetAttrStr(int);
+    unsigned char GetItemIcon(int);
 };
 
 #endif // _FFCC_PPP_SINGMENU_H_

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -73,6 +73,27 @@ extern "C" char* PTR_s_Masculin_802144c4[];
 extern "C" char* PTR_DAT_80214224[];
 extern "C" char DAT_80332958[];
 extern "C" char DAT_8033295c[];
+extern "C" u8 lbl_801DE6AC[];
+extern "C" char* lbl_80214140[];
+extern "C" char* lbl_80214160[];
+extern "C" char* lbl_80214180[];
+extern "C" char* lbl_802141A0[];
+extern "C" char* lbl_802141C0[];
+extern "C" char* lbl_802141E0[];
+extern "C" char* lbl_802142C0[];
+extern "C" char* lbl_802143A0[];
+extern "C" char* lbl_80214480[];
+extern "C" char* lbl_80214560[];
+extern "C" char* lbl_80214640[];
+extern "C" char* lbl_802146C0[];
+extern "C" char* lbl_80214740[];
+extern "C" char* lbl_802147C0[];
+extern "C" char* lbl_80214840[];
+extern "C" char* lbl_802148C0[];
+extern "C" char* lbl_80214910[];
+extern "C" char* lbl_80214960[];
+extern "C" char* lbl_802149B0[];
+extern "C" char* lbl_80214A00[];
 
 extern "C" unsigned int CmdOpen__8CMenuPcsFv(CMenuPcs*);
 extern "C" unsigned int CmdCtrl__8CMenuPcsFv(CMenuPcs*);
@@ -1506,62 +1527,109 @@ void CMenuPcs::SingLifeResetWait()
 	// TODO
 }
 
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CMenuPcs::GetTribeStr(int)
+static inline char* GetLanguageTableString(int index, char** englishTable, char** germanTable, char** italianTable,
+                                           char** frenchTable, char** spanishTable)
 {
-	// TODO
+    u8 languageId = Game.game.m_gameWork.m_languageId;
+    if (languageId == 3) {
+        return italianTable[index];
+    }
+    if (languageId < 3) {
+        if ((languageId != 1) && (languageId != 0)) {
+            return germanTable[index];
+        }
+    } else {
+        if (languageId == 5) {
+            return spanishTable[index];
+        }
+        if (languageId < 5) {
+            return frenchTable[index];
+        }
+    }
+    return englishTable[index];
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80145674
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetJobStr(int)
+char* CMenuPcs::GetTribeStr(int index)
 {
-	// TODO
+    return GetLanguageTableString(index, PTR_s_Clavat_802140f0, PTR_s_Clavat_80214100, PTR_s_Clavat_80214110,
+                                  PTR_s_Clavat_80214120, PTR_s_Clavate_80214130);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801455d8
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetHairStr(int)
+char* CMenuPcs::GetJobStr(int index)
 {
-	// TODO
+    return GetLanguageTableString(index, lbl_80214140, lbl_80214160, lbl_80214180, lbl_802141A0, lbl_802141C0);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014553c
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetMenuStr(int)
+char* CMenuPcs::GetHairStr(int index)
 {
-	// TODO
+    return GetLanguageTableString(index, lbl_80214640, lbl_802146C0, lbl_80214740, lbl_802147C0, lbl_80214840);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801454a0
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetAttrStr(int)
+char* CMenuPcs::GetMenuStr(int index)
 {
-	// TODO
+    return GetLanguageTableString(index, lbl_802141E0, lbl_802142C0, lbl_802143A0, lbl_80214480, lbl_80214560);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80145404
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetItemIcon(int)
+char* CMenuPcs::GetAttrStr(int index)
 {
-	// TODO
+    return GetLanguageTableString(index, lbl_802148C0, lbl_80214910, lbl_80214960, lbl_802149B0, lbl_80214A00);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x801453f4
+ * PAL Size: 16b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+u8 CMenuPcs::GetItemIcon(int index)
+{
+    return lbl_801DE6AC[index];
 }


### PR DESCRIPTION
## Summary
Implemented the trailing `singmenu` string/icon accessors that were still TODO stubs, and corrected their return types in `CMenuPcs` declarations to match actual usage.

- Implemented:
  - `GetTribeStr__8CMenuPcsFi`
  - `GetJobStr__8CMenuPcsFi`
  - `GetHairStr__8CMenuPcsFi`
  - `GetMenuStr__8CMenuPcsFi`
  - `GetAttrStr__8CMenuPcsFi`
  - `GetItemIcon__8CMenuPcsFi`
- Added PAL address/size INFO blocks for those functions.
- Added shared language-table selection helper in `singmenu.cpp` to keep logic consistent across these accessors.

## Functions improved
Unit: `main/singmenu`

Current per-function fuzzy scores in report:
- `GetItemIcon__8CMenuPcsFi`: `100.0%`
- `GetAttrStr__8CMenuPcsFi`: `54.589745%`
- `GetMenuStr__8CMenuPcsFi`: `54.589745%`
- `GetHairStr__8CMenuPcsFi`: `54.589745%`
- `GetJobStr__8CMenuPcsFi`: `54.589745%`
- `GetTribeStr__8CMenuPcsFi`: `54.589745%`

## Match evidence
- Selector baseline before changes: `main/singmenu` was `26.4%` with `0/44` matched functions.
- After changes (`ninja` report):
  - `fuzzy_match_percent`: `28.283752`
  - `matched_functions`: `1/44`
  - `matched_code`: `16/21836`
- Global progress moved from `1776/4733` to `1777/4733` matched functions.

## Plausibility rationale
These functions are straightforward language-dependent table lookups and an icon-table index read, which is plausible original game source behavior (data-driven menu text/icon selection), rather than compiler-coaxing.

## Technical details
- Language dispatch follows the same branch structure seen across the menu codebase (`languageId` checks for EN/DE/IT/FR/ES table sets).
- Used existing symbol tables at known PAL addresses (via linked data labels) to map strings/icons by index.
- Build verified with `ninja` and symbol-level diffing via `objdiff-cli`.
