### PR TITLE
Implement RedDriver music command stubs

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1441,9 +1441,9 @@ void CRedDriver::ReentryMusicData(int musicID)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedDriver::MusicStop(int)
+void CRedDriver::MusicStop(int musicID)
 {
-	// TODO
+    _EntryExecCommand(_MusicStop, musicID, 0, 0, 0, 0, 0, 0);
 }
 
 /*
@@ -1496,9 +1496,9 @@ int CRedDriver::MusicNextPlay(int musicID, int volume, int mode)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedDriver::MusicMasterVolume(int)
+void CRedDriver::MusicMasterVolume(int volume)
 {
-	// TODO
+    _EntryExecCommand(_MusicMasterVolume, volume, 0, 0, 0, 0, 0, 0);
 }
 
 /*
@@ -1534,9 +1534,9 @@ void CRedDriver::MusicVolume(int param_1, int param_2, int param_3)
  * Address:	TODO
  * Size:	TODO
  */
-void CRedDriver::SetMusicPhraseStop(int)
+void CRedDriver::SetMusicPhraseStop(int stop)
 {
-	// TODO
+    _EntryExecCommand(_SetMusicPhraseStop, stop, 0, 0, 0, 0, 0, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented three previously stubbed `CRedDriver` music control methods by wiring them into the existing command queue entry path:
- `MusicStop__10CRedDriverFi`
- `MusicMasterVolume__10CRedDriverFi`
- `SetMusicPhraseStop__10CRedDriverFi`

Each now forwards its input parameter into `_EntryExecCommand(...)` with the corresponding command handler.

## Functions improved
Unit: `main/RedSound/RedDriver`

- `MusicStop__10CRedDriverFi`: **5.5555553% -> 88.55556%** (72b)
- `MusicMasterVolume__10CRedDriverFi`: **5.5555553% -> 88.55556%** (72b)
- `SetMusicPhraseStop__10CRedDriverFi`: **5.5555553% -> 88.55556%** (72b)

## Match evidence
- Rebuilt with `ninja` and regenerated `build/GCCP01/report.json`.
- Verified function-level fuzzy match changes in report output.
- Confirmed symbol-level objdiff JSON now reports `88.55556` `match_percent` entries for the updated symbols.

## Plausibility rationale
These methods sit alongside many existing `CRedDriver` methods that are thin wrappers around `_EntryExecCommand`. The new implementations match that established source pattern and directly correspond to existing command handlers (`_MusicStop`, `_MusicMasterVolume`, `_SetMusicPhraseStop`) already used by the command execution path.

## Technical details
- Added parameter names and forwarded the parameter as command arg0.
- Kept argument layout consistent with neighboring wrappers (`arg0` payload + zero-fill remaining slots).
- No control-flow tricks or compiler-coaxing constructs were introduced.
