### PR TITLE
Improve GBAGetProcessStatus control-flow match

### DIFF
--- a/src/gba/GBAGetProcessStatus.c
+++ b/src/gba/GBAGetProcessStatus.c
@@ -1,5 +1,14 @@
 #include "dolphin/gba/GBAPriv.h"
 
+/*
+ * --INFO--
+ * PAL Address: 0x801A76FC
+ * PAL Size: 372b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
 s32 GBAGetProcessStatus(s32 chan, u8* percentp) {
     GBAControl* gba = &__GBA[chan];
     GBABootInfo* bootInfo = &gba->bootInfo;
@@ -26,10 +35,10 @@ s32 GBAGetProcessStatus(s32 chan, u8* percentp) {
             *percentp = percent;
         }
     } else {
-        if (gba->callback == NULL) {
-            ret = GBA_READY;
-        } else {
+        if (gba->callback != NULL) {
             ret = GBA_BUSY;
+        } else {
+            ret = GBA_READY;
         }
     }
 


### PR DESCRIPTION
## Summary
- Added function metadata block for `GBAGetProcessStatus` with PAL address/size.
- Rewrote the final callback status check to equivalent but more compiler-aligned control flow:
  - from `if (gba->callback == NULL) ret = GBA_READY; else ret = GBA_BUSY;`
  - to `if (gba->callback != NULL) ret = GBA_BUSY; else ret = GBA_READY;`

## Functions improved
- Unit: `main/gba/GBAGetProcessStatus`
- Symbol: `GBAGetProcessStatus`

## Match evidence
- `objdiff-cli` symbol match improved from **99.27957%** to **99.354836%**.
- `ninja` progress increased function count from **1776/4733** to **1777/4733**.
- The previous `DIFF_OP_MISMATCH` at the final callback branch was eliminated, leaving only relocation/symbol-name-level differences.

## Plausibility rationale
- The change preserves behavior and keeps idiomatic C control flow.
- It removes a compiler-ordering mismatch without introducing contrived temporaries, unnatural ordering, or readability regressions.

## Technical details
- The only code-generation delta targeted was the terminal callback check in the non-boot path.
- This branch-shape alignment improves instruction-level correspondence while maintaining original semantics.
