### PR TITLE
Improve calc_particle match in pppRyjMegaBirth

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -283,15 +283,7 @@ void calc_particle(_pppPObject* pObject, VRyjMegaBirth* work, PRyjMegaBirth* par
 
 		for (i = 0; i < maxParticles; i = i + 1)
 		{
-			if (*(s16*)((u8*)particle + 0x22) == 0)
-			{
-				if ((emitRate <= work->m_emitTimer) && (emitCount < (s32)emitPerFrame))
-				{
-					birth(pObject, work, param, color, particle, (_PARTICLE_WMAT*)worldMats, colorData);
-					emitCount = emitCount + 1;
-				}
-			}
-			else
+			if (*(s16*)((u8*)particle + 0x22) != 0)
 			{
 				calc(work, param, particle, color, colorData);
 
@@ -324,6 +316,11 @@ void calc_particle(_pppPObject* pObject, VRyjMegaBirth* work, PRyjMegaBirth* par
 						}
 					}
 				}
+			}
+			else if ((emitRate <= work->m_emitTimer) && (emitCount < (s32)emitPerFrame))
+			{
+				birth(pObject, work, param, color, particle, (_PARTICLE_WMAT*)worldMats, colorData);
+				emitCount = emitCount + 1;
 			}
 
 			if (worldMats != 0)


### PR DESCRIPTION
## Summary
- Reworked `calc_particle` loop control flow in `src/pppRyjMegaBirth.cpp` to process active particles first and gate spawning in an `else if` branch.
- No behavioral logic changes were introduced; this is a control-flow/layout alignment change.

## Functions Improved
- Unit: `main/pppRyjMegaBirth`
- Symbol: `calc_particle__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColor`
- Match: **48.109093% -> 73.88182%**

## Match Evidence
- Baseline objdiff command:
  - `tools/objdiff-cli diff -p . -u main/pppRyjMegaBirth -o - calc_particle__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColor`
- After-change objdiff command:
  - same as above
- Assembly diff characteristics:
  - `DIFF_DELETE`: 24 -> 9
  - `DIFF_INSERT`: 25 -> 10
  - matched instruction entries (`null` diff kind): 30 -> 36

## Plausibility Rationale
- The edit keeps the same high-level particle update behavior (active-particle update path vs spawn path) while expressing branch structure in a more direct, source-plausible way.
- This is consistent with nearby particle-system code patterns that branch on active state before spawning.

## Technical Details
- Modified only `calc_particle` in `src/pppRyjMegaBirth.cpp`.
- Reordered loop branching from:
  - `if (inactive) { maybe spawn } else { update active particle }`
  to:
  - `if (active) { update active particle } else if (can spawn) { spawn }`
- Build verification: `ninja` completed successfully after the change.
