### PR TITLE
menu_arti: improve ArtiClose match with interpolation shape

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -439,25 +439,35 @@ unsigned int CMenuPcs::ArtiClose()
 	int count = artiList[0];
 	ArtiOpenAnim* anim = (ArtiOpenAnim*)((u8*)artiList + 8);
 	int frame;
+	float zeroF;
+	double biasD;
+	double oneD;
 
 	artiState[0x11]++;
 	frame = artiState[0x11];
 
 	for (int i = 0; i < count; i++, anim++) {
+		biasD = DOUBLE_80332fe0;
+		zeroF = FLOAT_80332fa8;
 		if (anim->startFrame <= frame) {
 			if (frame < anim->startFrame + anim->duration) {
 				anim->step++;
-				anim->alpha = 1.0f - ((float)anim->step / (float)anim->duration);
+				oneD = DOUBLE_80332fb0;
+				anim->alpha = (float)-(((DOUBLE_80332fb0 / ((double)(unsigned int)anim->duration - biasD)) *
+				                        ((double)(unsigned int)anim->step - biasD)) -
+				                       DOUBLE_80332fb0);
 				if ((anim->flags & 2) == 0) {
-					float t = 1.0f - ((float)anim->step / (float)anim->duration);
-					anim->dx = (anim->targetX - (float)anim->x) * t;
-					anim->dy = (anim->targetY - (float)anim->y) * t;
+					float ratio = (float)-(((oneD / ((double)(unsigned int)anim->duration - biasD)) *
+					                        ((double)(unsigned int)anim->step - biasD)) -
+					                       oneD);
+					anim->dx = (anim->targetX - (float)anim->x) * ratio;
+					anim->dy = (anim->targetY - (float)anim->y) * ratio;
 				}
 			} else {
 				finished++;
-				anim->alpha = 0.0f;
-				anim->dx = 0.0f;
-				anim->dy = 0.0f;
+				anim->alpha = FLOAT_80332fa8;
+				anim->dx = zeroF;
+				anim->dy = zeroF;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Updated `CMenuPcs::ArtiClose()` in `src/menu_arti.cpp` to better match original arithmetic/codegen shape.
- Kept behavior equivalent while reworking interpolation math to use the decomp-observed double intermediate form and shared zero constant writes.
- Left `ArtiOpen` unchanged after testing, because that path regressed fuzzy match.

## Functions improved
- Unit: `main/menu_arti`
- Symbol improved: `ArtiClose__8CMenuPcsFv`

## Match evidence
- `ArtiClose__8CMenuPcsFv`: **44.421050% -> 46.589474%** (+2.168424)
- `ArtiOpen__8CMenuPcsFv`: **45.324074% -> 45.324074%** (no regression)
- `main/menu_arti` unit fuzzy: **54.847057% -> 55.000000%** (+0.152943)
- Verified with rebuild (`ninja`) and updated `build/GCCP01/report.json`.

## Plausibility rationale
- The change aligns with plausible original source for menu open/close tweening: same state machine, same step progression, same output fields (`alpha`, `dx`, `dy`), and same terminal values.
- Adjustment is focused on numeric expression shape (conversion/interpolation form), not contrived control-flow tricks or non-semantic hacks.

## Technical details
- `ArtiClose` now computes fade/interpolation with explicit double intermediates matching the decomp pattern, including the `1.0 - ratio` equivalent represented in the original-generated form.
- Terminal reset path now uses the file’s shared float zero symbol for `alpha/dx/dy`, consistent with surrounding decomp style.
