### PR TITLE
Map and decompile dolphin/os/__ppc_eabi_init

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -610,6 +610,11 @@ config.libs = [
         [
             Object(NonMatching, "os/__start.c"),
             Object(NonMatching, "os/__ppc_eabi_init.c"),
+            Object(
+                NonMatching,
+                "dolphin/os/__ppc_eabi_init.cpp",
+                source="os/__ppc_eabi_init.cpp",
+            ),
             Object(NonMatching, "os/OS.c"),
             Object(NonMatching, "os/OSAddress.c"),
             Object(NonMatching, "os/OSAlarm.c"),

--- a/src/os/__ppc_eabi_init.cpp
+++ b/src/os/__ppc_eabi_init.cpp
@@ -1,52 +1,84 @@
-//
-// __ppc_eabi_init
-//
+#include "__ppc_eabi_linker.h"
+#include "global.h"
+#include <string.h>
 
-#include "dol2asm.h"
-#include "dolphin/PPCArch.h"
-
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-//
-// Forward References:
-//
+SECTION_INIT extern void __flush_cache(void* addr, unsigned int size);
+extern void __OSPSInit(void);
+extern void __OSFPRInit(void);
+extern void __OSCacheInit(void);
 
-void __init_user();
-void __init_cpp();
-void _ExitProcess();
-
-//
-// External References:
-//
-
-typedef void (*voidfunctionptr)(); // pointer to function returning void
-extern voidfunctionptr _ctors[];
-
-/* 80342B78-80342B98 33D4B8 0020+00 0/0 1/1 0/0 .text            __init_user */
-void __init_user(void) {
-    __init_cpp();
-}
-
-/* 80342B98-80342BEC 33D4D8 0054+00 1/1 0/0 0/0 .text            __init_cpp */
-#pragma peephole off
-void __init_cpp(void) {
-    /**
-     *	call static initializers
-     */
-    voidfunctionptr* constructor;
-    for (constructor = _ctors; *constructor; constructor++) {
-        (*constructor)();
+inline static void __copy_rom_section(void* dst, const void* src, unsigned int size)
+{
+    if (size && (dst != src)) {
+        memcpy(dst, src, size);
+        __flush_cache(dst, size);
     }
 }
-#pragma peephole reset
 
-/* 80342BEC-80342C0C 33D52C 0020+00 0/0 2/2 0/0 .text            _ExitProcess */
-void _ExitProcess(void) {
-    PPCHalt();
+inline static void __init_bss_section(void* dst, unsigned int size)
+{
+    if (size) {
+        memset(dst, 0, size);
+    }
 }
 
-#ifdef __cplusplus
+/*
+ * --INFO--
+ * PAL Address: 0x80003340
+ * PAL Size: 192b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+SECTION_INIT void __init_data_80003340(void)
+{
+    __rom_copy_info* dci;
+    __bss_init_info* bii;
+
+    dci = _rom_copy_info;
+    while (1) {
+        if (dci->size == 0)
+            break;
+        __copy_rom_section(dci->addr, dci->rom, dci->size);
+        dci++;
+    }
+
+    bii = _bss_init_info;
+    while (1) {
+        if (bii->size == 0)
+            break;
+        __init_bss_section(bii->addr, bii->size);
+        bii++;
+    }
 }
-#endif
+
+/*
+ * --INFO--
+ * PAL Address: 0x80003400
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+SECTION_INIT asm void __init_hardware(void)
+{
+    // clang-format off
+    nofralloc
+
+    mfmsr r0
+    ori r0, r0, 0x2000
+    mtmsr r0
+    mflr r31
+    bl __OSPSInit
+    bl __OSFPRInit
+    bl __OSCacheInit
+    mtlr r31
+    blr
+    // clang-format on
+}
+
+}


### PR DESCRIPTION
## Summary
- Added missing object mapping for `dolphin/os/__ppc_eabi_init.cpp` in `configure.py`, pointing to `src/os/__ppc_eabi_init.cpp`.
- Replaced `src/os/__ppc_eabi_init.cpp` with decompilation of the two `.init` symbols in this split:
  - `__init_data_80003340`
  - `__init_hardware`
- Added function info headers with PAL address/size metadata.

## Functions Improved
Unit: `main/dolphin/os/__ppc_eabi_init`
- `__init_data_80003340` (192b): **0.0% -> 78.333336% fuzzy**
- `__init_hardware` (36b): **0.0% -> 100.0% fuzzy**

## Match Evidence
Before (selector/report):
- `main/dolphin/os/__ppc_eabi_init` current: **0.0%**

After (`build/GCCP01/report.json`):
- Unit fuzzy match: **81.75439%**
- Matched functions: **1/2**
- Matched code bytes: **36/228**

Objdiff checks used:
- `../tools/objdiff-cli diff -p . -u main/dolphin/os/__ppc_eabi_init -o - __init_data_80003340`
- `../tools/objdiff-cli diff -p . -u main/dolphin/os/__ppc_eabi_init -o - __init_hardware`

## Plausibility Rationale
- The implementation follows expected runtime startup logic for this split: ROM copy loop + BSS zero loop, and hardware init sequence (`__OSPSInit`, `__OSFPRInit`, `__OSCacheInit`).
- The code shape is straightforward and source-plausible for Nintendo SDK startup code, not compiler-coaxed patterning.
- Mapping this split in `configure.py` is required for objdiff to compare generated object code against the existing split target.

## Technical Notes
- This change fixes an unmapped split (`dolphin/os/__ppc_eabi_init.cpp`) that previously produced left-only objdiff output for `main/dolphin/os/__ppc_eabi_init`.
- `__init_hardware` now matches fully; remaining delta is localized to `__init_data_80003340` call/flow details.
