### PR TITLE
Improve SetMainMode control-flow alignment

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -385,44 +385,37 @@ void CGoOutMenu::CalcLoadMenu()
 void CGoOutMenu::SetMainMode(unsigned char mode)
 {
     CMenuPcsGoOutLayout& menuPcsLayout = *reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs);
+    char prevMainMode;
+    int i;
 
     WriteMenuU8(2185, 0);
     WriteMenuU8(2186, 0);
-    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&MenuPcs) + 2188) = 0;
-
-    if (field_0x2c == 2) {
+    WriteMenuS32(2188, 0);
+    if (field_0x2c == '\x02') {
         MemoryCardMan.McEnd();
     }
-
-    const signed char previousMode = field_0x2c;
+    prevMainMode = field_0x2c;
     field_0x2c = mode;
     field_0x30 = 0;
-
-    if (mode == 2) {
+    if (mode == '\x02') {
         if (Game.game.m_gameWork.m_mcHasSerial != 1) {
-            SetMenuStr(0, 4,
-                       "This game has not been saved.",
-                       "",
-                       "You must save your game before",
+            SetMenuStr(0, 4, "This game has not been saved.", "", "You must save your game before",
                        "you can import a character.");
-            field_0x19 = -1;
+            field_0x19 = (char)0xff;
             field_0x18 = 0;
         }
-
-        for (int i = 0; i < 8; i++) {
+        i = 0;
+        do {
             if (Game.game.m_caravanWorkArr[i].m_objType != 0 &&
                 Game.game.m_caravanWorkArr[i].m_caravanLocalFlags != 1) {
-                SetMenuStr(0, 5,
-                           "This game contains character data",
-                           "that has not yet been saved.",
-                           "",
+                SetMenuStr(0, 5, "This game contains character data", "that has not yet been saved.", "",
                            "You must save your game before",
                            "you can import a character.");
-                field_0x19 = -1;
+                field_0x19 = (char)0xff;
                 field_0x18 = 0;
             }
-        }
-
+            i++;
+        } while (i < 8);
         field_0x1 = 0;
         reinterpret_cast<unsigned char*>(this)[0] = 0;
         field_0x2 = 0;
@@ -430,31 +423,28 @@ void CGoOutMenu::SetMainMode(unsigned char mode)
         field_0x4 = -1;
         field_0x8 = 0;
         SetGoOutMode(7);
-    } else if (mode < 2) {
-        if (mode != 0) {
+    } else if (mode < '\x02') {
+        if (mode != '\0') {
             field_0x46 = 1;
-            if (previousMode != 3) {
+            if (prevMainMode != '\x03') {
                 field_0x46 = 0;
             }
-
             MenuPcs.ChgAllModel();
-
             if (field_0x36 >= 0) {
-                WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
-                WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+                *reinterpret_cast<short*>(menuPcsLayout.field_2120 + 10) = 2;
+                *reinterpret_cast<short*>(menuPcsLayout.field_2092 + 0x22) = 0;
             }
-
             field_0x45 = 0;
             field_0x34 = 0x1e;
             field_0x48 = 0;
             field_0x3c = 0;
             field_0x14 = 0;
         }
-    } else if (mode < 4) {
+    } else if (mode < '\x04') {
         MenuPcs.ChgAllModel();
         WriteMenuU8(2184, 2);
         field_0x14 = 0;
-        reinterpret_cast<signed char&>(field_0x24[2]) = 0;
+        field_0x24[2] = 0;
         SetDelMode(2);
     }
 }


### PR DESCRIPTION
## Summary
- Reworked `CGoOutMenu::SetMainMode(unsigned char)` in `src/goout.cpp` to better mirror original C-style control flow and state writes.
- Kept behavior identical while removing several high-level constructs that were likely producing different codegen.
- Maintained existing message text behavior (no content changes), but aligned branch structure, mode checks, and loop form.

## Functions improved
- Unit: `main/goout`
- Function: `SetMainMode__10CGoOutMenuFUc` (PAL 0x8016c1a4, 616b)

## Match evidence
- `SetMainMode__10CGoOutMenuFUc`: **4.6168833% -> 5.2077923%** (+0.5909)
- `main/goout` unit fuzzy: **30.830038 -> 30.849592** (+0.019554)
- Build: `ninja` passes after change.

## Plausibility rationale
- The change moves the function toward the project’s existing low-level decomp style for this module: explicit byte/word state transitions, direct mode comparisons, and do/while style iteration used by Metrowerks-era codegen.
- No artificial compiler-coaxing temporaries were introduced; this is a source-plausible control-flow normalization pass.

## Technical notes
- The largest structural alignment in this pass is around:
  - mode transition bookkeeping (`field_0x2c`, `field_0x30`, `field_0x46`, `field_0x34`)
  - branch partitioning for `mode == 2`, `mode < 2`, and `mode < 4`
  - caravan iteration converted to explicit loop form matching decomp shape
- Follow-up work can focus on language-table-backed message selection for additional gains in this function and neighboring goout states.
