### PR TITLE
main/monobj: first-pass decomp for moveAStar

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/gobjwork.h"
 #include "ffcc/fontman.h"
 #include "ffcc/math.h"
+#include "ffcc/astar.h"
 #include "ffcc/p_game.h"
 #include "ffcc/sound.h"
 #include "ffcc/vector.h"
@@ -1507,12 +1508,82 @@ void CGMonObj::statMove()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8011367C
+ * PAL Size: 740b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGMonObj::moveAStar(int, int, Vec&)
+void CGMonObj::moveAStar(int startGroup, int forbiddenGroup, Vec& targetPos)
 {
-	// TODO
+	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
+	CGObject* object = reinterpret_cast<CGObject*>(this);
+
+	unsigned int moveFlags = *reinterpret_cast<unsigned int*>(mon + 0x70C);
+	short& routeFrom = *reinterpret_cast<short*>(mon + 0x73C);
+	short& routePrev = *reinterpret_cast<short*>(mon + 0x73E);
+
+	if (((moveFlags & 0x30000) == 0) || (*reinterpret_cast<unsigned int*>(ARRAY_8030918c) == 0)) {
+		return;
+	}
+
+	if (routeFrom == 0) {
+		routeFrom = static_cast<short>(startGroup);
+	}
+
+	if (((moveFlags & 0x10000) == 0) || ((moveFlags & 0x40) != 0)) {
+		if ((routeFrom == 0) || (forbiddenGroup == 0)) {
+			return;
+		}
+
+		CAStar::CAPos* escapePos = AStar.getEscapePos(object->m_worldPosition, targetPos, routeFrom, routePrev);
+		if (escapePos == nullptr) {
+			return;
+		}
+
+		unsigned int nextGroup = escapePos->m_groupA;
+		if (static_cast<short>(nextGroup) == routeFrom) {
+			nextGroup = escapePos->m_groupB;
+		}
+
+		unsigned char* routeStep = AStar.m_routeTable[routeFrom - 1][nextGroup + 0x36];
+		float portalDist = PSVECDistance(&object->m_worldPosition, &escapePos->m_position);
+		if ((portalDist < object->m_capsuleHalfHeight) || (startGroup == routeStep[0])) {
+			routePrev = routeFrom;
+			routeFrom = routeStep[0];
+			escapePos = reinterpret_cast<CAStar::CAPos*>(ARRAY_8030918c) +
+				AStar.m_routeTable[routeStep[0] - 1][forbiddenGroup + 0x36][1];
+		}
+
+		float targetDist = PSVECDistance(&targetPos, &object->m_worldPosition);
+		Vec dirRaw;
+		PSVECSubtract(&object->m_worldPosition, &escapePos->m_position, &dirRaw);
+		CVector dir(dirRaw);
+		dir.Normalize();
+		targetPos.x = object->m_worldPosition.x + dir.x * targetDist;
+		targetPos.y = object->m_worldPosition.y + dir.y * targetDist;
+		targetPos.z = object->m_worldPosition.z + dir.z * targetDist;
+		return;
+	}
+
+	short currentRoute = routeFrom;
+	if ((currentRoute == 0) || (forbiddenGroup == 0) || (currentRoute == forbiddenGroup)) {
+		return;
+	}
+
+	unsigned char* routeStep = AStar.m_routeTable[currentRoute - 1][forbiddenGroup + 0x36];
+	CAStar::CAPos* portalPos = reinterpret_cast<CAStar::CAPos*>(ARRAY_8030918c) + routeStep[1];
+	float portalDist = PSVECDistance(&object->m_worldPosition, &portalPos->m_position);
+	if ((portalDist < object->m_capsuleHalfHeight) || (startGroup == routeStep[0])) {
+		routeFrom = routeStep[0];
+		portalPos = reinterpret_cast<CAStar::CAPos*>(ARRAY_8030918c) +
+			AStar.m_routeTable[routeStep[0] - 1][forbiddenGroup + 0x36][1];
+	}
+
+	targetPos.x = portalPos->m_position.x;
+	targetPos.y = portalPos->m_position.y;
+	targetPos.z = portalPos->m_position.z;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGMonObj::moveAStar(int, int, Vec&)` in `src/monobj.cpp` from the PAL Ghidra reference (`8011367c_moveAStar__8CGMonObjFiiR3Vec.c`) as a first-pass source reconstruction.
- Added `ffcc/astar.h` include and replaced the prior empty stub with route-table, escape-position, and target-adjustment logic.
- Updated the function info block with PAL address/size metadata.

## Functions Improved
- Unit: `main/monobj`
- Symbol: `moveAStar__8CGMonObjFiiR3Vec`
- Size: `740b`

## Match Evidence
- `moveAStar__8CGMonObjFiiR3Vec`: `0.5405405%` -> `27.081081%`
- Measurement command:
  - `tools/objdiff-cli diff -p . -u main/monobj -o - moveAStar__8CGMonObjFiiR3Vec`

## Plausibility Rationale
- The implementation uses existing project types and APIs (`CAStar`, `CAStar::CAPos`, `m_routeTable`, `getEscapePos`, `PSVEC*`, `CVector`) rather than compiler-only coaxing.
- Control flow and data access align with existing `monobj` movement code style (explicit offset-backed state + `CGObject` fields).
- This is a large low-match target first pass; code is intended as source-plausible structure recovery, not final polish.

## Technical Notes
- The path update splits on movement mode flags (`0x10000`, `0x40`) and updates route tracking fields (`0x73C`, `0x73E`).
- Target vector is either redirected to a portal node or projected relative to world position using normalized direction and original target distance.
