### PR TITLE
math: model CMath as CManager-derived for better static-init match

### DIFF
--- a/include/ffcc/math.h
+++ b/include/ffcc/math.h
@@ -1,6 +1,8 @@
 #ifndef _FFCC_CMATH_H_
 #define _FFCC_CMATH_H_
 
+#include "ffcc/manager.h"
+
 struct Vec;
 struct Vec4d;
 struct SRT;
@@ -24,7 +26,7 @@ public:
     void Identity();
 };
 
-class CMath
+class CMath : public CManager
 {
 public:
     CMath();

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -21,25 +21,6 @@ struct Vec4d {
     float w;
 };
 
-extern void* __vt__8CManager[];
-extern void* __vt__5CMath[];
-
-/*
- * --INFO--
- * PAL Address: 0x8001c2d0
- * PAL Size: 32b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-extern "C" void __sinit_math_cpp()
-{
-    volatile void** base = (volatile void**)&math;
-    *base = __vt__8CManager;
-    *base = __vt__5CMath;
-}
-
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## Summary
- Corrected `CMath` class hierarchy to inherit from `CManager` in the header.
- Removed the hand-written `__sinit_math_cpp` + manual vtable externs from `math.cpp` so static init is compiler-driven.
- This aligns `math` static initialization with expected C++ object model behavior instead of forcing ad-hoc vtable stores.

## Functions improved
- Unit: `main/math`
- Symbol: `__sinit_math_cpp`
- Match: **12.50% -> 41.88%** (objdiff symbol diff)

## Match evidence
- Before: objdiff for `main/math::__sinit_math_cpp` showed only **12.50%**, with current side effectively selecting a no-op init path.
- After hierarchy fix: objdiff for `main/math::__sinit_math_cpp` shows **41.88%**, and generated code now writes `CMath` vtable into `math` instead of `blr`-only.
- Rebuild still succeeds with `ninja`.

## Plausibility rationale
- Existing target data already implied `CMath`/`CManager` vtable relationship (`__vt__8CManager`, `__vt__5CMath`).
- Modeling `CMath` as a `CManager` subclass is source-plausible and consistent with normal C++ class design, rather than compiler-coaxing instruction hacks.
- Letting the compiler synthesize static init from accurate class metadata is closer to expected original source structure.

## Technical notes
- This change intentionally improves initializer structure first; there is still remaining delta in `__sinit_math_cpp` (target also stages `CManager` vtable store before `CMath`).
- Follow-up work can tune constructor/init interactions once class layout is now represented correctly.
