### PR TITLE
map: implement SetMapObjAnim run lookup

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2760,9 +2760,31 @@ void CMapMng::GetMapObjWMtx(int mapObjIndex, float (*destination)[4])
  * Address:	TODO
  * Size:	TODO
  */
-void CMapMng::SetMapObjAnim(int, int, int, int)
+void CMapMng::SetMapObjAnim(int mapObjIndex, int startFrame, int endFrame, int loop)
 {
-	// TODO
+    CPtrArray<CMapAnimRun*>* mapAnimRunArray = reinterpret_cast<CPtrArray<CMapAnimRun*>*>(Ptr(this, 0x213E0));
+    CPtrArray<CMapAnim*>* mapAnimArray = reinterpret_cast<CPtrArray<CMapAnim*>*>(Ptr(this, 0x213FC));
+    CMapAnimRun* foundMapAnimRun = 0;
+    CMapObj* mapObj = reinterpret_cast<CMapObj*>(reinterpret_cast<unsigned char*>(this) + (mapObjIndex * 0xF0) + 0x954);
+    int mapAnimRunCount = mapAnimRunArray->GetSize();
+
+    for (unsigned int mapAnimRunIndex = 0; mapAnimRunIndex < static_cast<unsigned int>(mapAnimRunCount); mapAnimRunIndex++) {
+        CMapAnimRun* mapAnimRun = (*mapAnimRunArray)[mapAnimRunIndex];
+        unsigned short mapAnimIndex = *reinterpret_cast<unsigned short*>(Ptr(mapAnimRun, 0x12));
+        CPtrArray<CMapAnimNode*>* mapAnimNodeArray = reinterpret_cast<CPtrArray<CMapAnimNode*>*>((*mapAnimArray)[mapAnimIndex]);
+        int mapAnimNodeCount = mapAnimNodeArray->GetSize();
+
+        for (int mapAnimNodeIndex = 0; mapAnimNodeIndex < mapAnimNodeCount; mapAnimNodeIndex++) {
+            CMapAnimNode* mapAnimNode = (*mapAnimNodeArray)[mapAnimNodeIndex];
+            if (reinterpret_cast<CMapObj*>(*reinterpret_cast<int*>(mapAnimNode)) == mapObj) {
+                foundMapAnimRun = mapAnimRun;
+                goto startMapObjAnim;
+            }
+        }
+    }
+
+startMapObjAnim:
+    foundMapAnimRun->Start(startFrame, endFrame, loop);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMapMng::SetMapObjAnim(int, int, int, int)` in `src/map.cpp` by following the PAL decomp control flow:
- iterate `g_CMapAnimRunArray`
- resolve each run's `mapAnimIndex`
- scan that animation's node list for the target map object
- start the matching `CMapAnimRun`

## Functions improved
- Unit: `main/map`
- Symbol: `SetMapObjAnim__7CMapMngFiiii`

## Match evidence
- Before: `1.8181819%`
- After: `43.70909%`
- Tool: `tools/objdiff-cli diff -p . -u main/map -o - SetMapObjAnim__7CMapMngFiiii`

## Plausibility rationale
This change replaces a stub with behavior that is consistent with surrounding map animation code and data layout already used in the file (same array offsets and `CPtrArray` access patterns), rather than introducing compiler-coaxing-only constructs.

## Technical notes
- `mapAnimIndex` is read from `CMapAnimRun` at offset `0x12` (consistent with existing `CMapAnimRun` field layout in `src/mapanim.cpp`)
- node ownership check matches the decomp pattern by comparing the node's map object pointer against `mapObjArr[mapObjIndex]`
