### PR TITLE
menu_letter: first-pass implementation of LetterCtrlCur

### DIFF
--- a/include/ffcc/menu_letter.h
+++ b/include/ffcc/menu_letter.h
@@ -28,7 +28,7 @@ public:
     void LetterDraw();
     void LetterListDraw();
     void LetterMessDraw();
-    void LetterCtrlCur();
+    int LetterCtrlCur();
     void LetterLstBaseDraw(float);
     void LetterDrawPageMark(int);
     void LetterSetAttachItem(unsigned int, int);

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -1,10 +1,13 @@
 #include "ffcc/menu_letter.h"
+#include "ffcc/pad.h"
 #include "ffcc/p_game.h"
+#include "ffcc/sound.h"
 
 #include <string.h>
 
 typedef signed short s16;
 typedef unsigned char u8;
+typedef unsigned short u16;
 
 extern "C" int SingGetLetterAttachflg__8CMenuPcsFv(CMenuPcs*);
 extern "C" void LetterInit1__8CMenuPcsFv(CMenuPcs*);
@@ -17,6 +20,14 @@ extern "C" const char* GetMenuStr__8CMenuPcsFi(CMenuPcs*, int);
 extern "C" void SetSingDynamicWinMessInfo__8CMenuPcsFiPcPcPcPcPcPcPcPc(CMenuPcs*, int, char*, char*, char*, char*, char*, char*, char*, char*);
 extern "C" void GetSingWinSize__8CMenuPcsFiPsPsi(CMenuPcs*, int, s16*, s16*, int);
 extern "C" void SetMcWinInfo__8CMenuPcsFii(CMenuPcs*, int, int);
+extern "C" void PlaySe__6CSoundFiiii(void*, int, int, int, int);
+extern "C" void AddItem__12CCaravanWorkFiPi(void*, int, int*);
+extern "C" void AddGil__12CCaravanWorkFi(void*, int);
+extern "C" int CanAddGil__12CCaravanWorkFi(void*, int);
+extern "C" void FGLetterReply__12CCaravanWorkFiiii(void*, int, int, int, int);
+extern "C" void DeleteItemIdx__12CCaravanWorkFii(void*, int, int);
+extern "C" int m_tempVar__4CMes[];
+extern u8 CFlat[];
 
 extern float FLOAT_803330bc;
 extern float FLOAT_803330f8;
@@ -33,6 +44,7 @@ int DAT_8032eef4 = 0;
 int DAT_8032eef8 = 0;
 int DAT_8032eefc = 0;
 int DAT_8032ef00 = 0;
+char s_ReplyStr[0x80];
 
 struct FlatDataTableView {
 	int m_numEntries;
@@ -636,9 +648,419 @@ void CMenuPcs::LetterMessDraw()
  * Address:	TODO
  * Size:	TODO
  */
-void CMenuPcs::LetterCtrlCur()
+int CMenuPcs::LetterCtrlCur()
 {
-	// TODO
+	bool blocked = false;
+	u16 press;
+	u16 hold;
+	int caravanWork = Game.game.m_scriptFoodBase[0];
+
+	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+		blocked = true;
+	}
+	if (blocked) {
+		press = 0;
+	} else {
+		press = Pad._8_2_;
+	}
+
+	blocked = false;
+	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+		blocked = true;
+	}
+	if (blocked) {
+		hold = 0;
+	} else {
+		hold = *reinterpret_cast<u16*>(reinterpret_cast<u8*>(&Pad) + 0x20);
+	}
+
+	if (hold == 0) {
+		return 0;
+	}
+
+	int state = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82C);
+	s16 menuMode = *reinterpret_cast<s16*>(state + 0x30);
+	if (menuMode != 0) {
+		if (menuMode == 1) {
+			if ((press & 0x100) != 0) {
+				int entry = caravanWork + DAT_8032eee8 * 0xC;
+				if (((*reinterpret_cast<u16*>(entry + 0x3EE) & 0x1FF) != 0) &&
+				    (((*reinterpret_cast<u8*>(entry + 0x3EC) >> 6) & 1) == 0)) {
+					*reinterpret_cast<u8*>(state + 8) = 1;
+					*reinterpret_cast<u8*>(state + 9) = 5;
+					if (((*reinterpret_cast<u8*>(entry + 0x3EC) >> 3) & 1) == 0) {
+						if (*reinterpret_cast<u16*>(caravanWork + 0xB4) + 1 < 0x41) {
+							*reinterpret_cast<u8*>(state + 9) |= 2;
+						}
+					} else {
+						int canAdd = CanAddGil__12CCaravanWorkFi(
+						    reinterpret_cast<void*>(caravanWork),
+						    (*reinterpret_cast<u16*>(entry + 0x3EE) & 0x1FF) * 100);
+						if (canAdd != 0) {
+							*reinterpret_cast<u8*>(state + 9) |= 2;
+						}
+					}
+					*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+					PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+					return 0;
+				}
+
+				if ((*reinterpret_cast<int*>(CFlat + 0x10408) != 0) &&
+				    (((*reinterpret_cast<u8*>(entry + 0x3EC) >> 4) & 1) != 0) &&
+				    (((*reinterpret_cast<u8*>(entry + 0x3EC) >> 5) & 1) == 0)) {
+					*reinterpret_cast<u8*>(state + 8) = 2;
+					*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+					PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+					return 0;
+				}
+				PlaySe__6CSoundFiiii(&Sound, 4, 0x40, 0x7F, 0);
+				return 0;
+			}
+
+			if ((press & 0x200) == 0) {
+				return 0;
+			}
+
+			*reinterpret_cast<u8*>(state + 8) = 0xFF;
+			*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+			int openAnim = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x850);
+			*reinterpret_cast<int*>(openAnim + 0x2C) = 0;
+			*reinterpret_cast<int*>(openAnim + 0x30) = 10;
+			*reinterpret_cast<int*>(openAnim + 0x6C) = 0;
+			*reinterpret_cast<int*>(openAnim + 0x70) = 10;
+
+			float f = FLOAT_803330f8;
+			int panelCount = static_cast<int>(**reinterpret_cast<s16**>(reinterpret_cast<char*>(this) + 0x850));
+			s16* panel = *reinterpret_cast<s16**>(reinterpret_cast<char*>(this) + 0x850) + 4;
+			for (int i = 0; i < panelCount; ++i, panel += 0x20) {
+				panel[0x10] = 0;
+				panel[0x11] = 0;
+				*reinterpret_cast<float*>(panel + 8) = f;
+			}
+
+			*reinterpret_cast<s16*>(state + 0x22) = 0;
+			PlaySe__6CSoundFiiii(&Sound, 3, 0x40, 0x7F, 0);
+			return 0;
+		}
+
+		if (menuMode == 2) {
+			if ((hold & 0xC) != 0) {
+				*reinterpret_cast<u16*>(state + 0x28) ^= 1;
+				PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+				return 0;
+			}
+			if ((press & 0x100) == 0) {
+				if ((press & 0x200) == 0) {
+					return 0;
+				}
+				u8 letterFlags = *reinterpret_cast<u8*>(caravanWork + DAT_8032eee8 * 0xC + 0x3EC);
+				if ((*reinterpret_cast<int*>(CFlat + 0x10408) == 0) || (((letterFlags >> 4) & 1) == 0) ||
+				    (((letterFlags >> 5) & 1) != 0)) {
+					*reinterpret_cast<u8*>(state + 8) = 0xFF;
+				} else {
+					*reinterpret_cast<u8*>(state + 8) = 1;
+				}
+				*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+				*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+				PlaySe__6CSoundFiiii(&Sound, 3, 0x40, 0x7F, 0);
+				return 0;
+			}
+
+			s16 sel = *reinterpret_cast<s16*>(state + 0x28);
+			if ((static_cast<int>(static_cast<signed char>(*reinterpret_cast<char*>(state + 9))) & (1 << (sel + 1))) != 0) {
+				if (sel == 0) {
+					int entry = caravanWork + DAT_8032eee8 * 0xC;
+					unsigned int value = *reinterpret_cast<u16*>(entry + 0x3EE) & 0x1FF;
+					if (((*reinterpret_cast<u8*>(entry + 0x3EC) >> 3) & 1) == 0) {
+						AddItem__12CCaravanWorkFiPi(reinterpret_cast<void*>(caravanWork), static_cast<int>(value), 0);
+					} else {
+						AddGil__12CCaravanWorkFi(reinterpret_cast<void*>(caravanWork), static_cast<int>(value * 100));
+					}
+					*reinterpret_cast<u8*>(entry + 0x3EC) = (*reinterpret_cast<u8*>(entry + 0x3EC) & 0xBF) | 0x40;
+				}
+
+				u8 letterFlags = *reinterpret_cast<u8*>(caravanWork + DAT_8032eee8 * 0xC + 0x3EC);
+				if ((*reinterpret_cast<int*>(CFlat + 0x10408) == 0) || (((letterFlags >> 4) & 1) == 0) ||
+				    (((letterFlags >> 5) & 1) != 0)) {
+					*reinterpret_cast<u8*>(state + 8) = 0xFF;
+				} else {
+					*reinterpret_cast<u8*>(state + 8) = 1;
+				}
+				*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+				*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+				PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+				return 0;
+			}
+
+			PlaySe__6CSoundFiiii(&Sound, 4, 0x40, 0x7F, 0);
+			return 0;
+		}
+
+		if (menuMode == 3) {
+			int maxReply = static_cast<int>(DAT_8032eeeb);
+			if ((hold & 8) == 0) {
+				if ((hold & 4) != 0) {
+					if (static_cast<int>(*reinterpret_cast<s16*>(state + 0x28)) < maxReply - 1) {
+						*reinterpret_cast<s16*>(state + 0x28) = *reinterpret_cast<s16*>(state + 0x28) + 1;
+					} else {
+						*reinterpret_cast<s16*>(state + 0x28) = 0;
+					}
+					PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+				}
+			} else {
+				if (*reinterpret_cast<s16*>(state + 0x28) == 0) {
+					*reinterpret_cast<s16*>(state + 0x28) = DAT_8032eeeb - 1;
+				} else {
+					*reinterpret_cast<s16*>(state + 0x28) = *reinterpret_cast<s16*>(state + 0x28) - 1;
+				}
+				PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+			}
+
+			if ((hold & 0xC) != 0) {
+				return 0;
+			}
+			if ((press & 0x100) == 0) {
+				if ((press & 0x200) == 0) {
+					return 0;
+				}
+				*reinterpret_cast<u8*>(state + 8) = 0xFF;
+				*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+				*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+				PlaySe__6CSoundFiiii(&Sound, 3, 0x40, 0x7F, 0);
+				return 0;
+			}
+
+			s16 curReply = *reinterpret_cast<s16*>(state + 0x28);
+			if (static_cast<int>(curReply) < maxReply - 1) {
+				DAT_8032eeec = static_cast<u8>(curReply);
+				CMemory::CStage* stage = *reinterpret_cast<CMemory::CStage**>(
+				    reinterpret_cast<char*>(this) + (Game.game.m_gameWork.m_menuStageMode == '\0' ? 0xEC : 0xF4));
+				char* srcText = reinterpret_cast<char*>(
+				    __nwa__FUlPQ27CMemory6CStagePci(0x400, stage, const_cast<char*>("menu_letter.cpp"), 0x65E));
+				stage = *reinterpret_cast<CMemory::CStage**>(
+				    reinterpret_cast<char*>(this) + (Game.game.m_gameWork.m_menuStageMode == '\0' ? 0xEC : 0xF4));
+				char* workText = reinterpret_cast<char*>(
+				    __nwa__FUlPQ27CMemory6CStagePci(0x400, stage, const_cast<char*>("menu_letter.cpp"), 0x660));
+				memset(srcText, 0, 0x400);
+				memset(workText, 0, 0x400);
+
+				u16 msgIndex = *reinterpret_cast<u16*>(caravanWork + DAT_8032eee8 * 0xC + 0x3EC);
+				char** mesPtr = reinterpret_cast<char**>(reinterpret_cast<char*>(&Game.game.m_cFlatDataArr[1]) + 0x44);
+				strcpy(srcText, mesPtr[(msgIndex & 0x7FC) >> 1]);
+				MakeAgbString__4CMesFPcPcii(workText, srcText, *reinterpret_cast<u16*>(caravanWork + 0x3E2), 0);
+
+				char* line = workText;
+				for (int i = 0; i < 8; ++i) {
+					char* newline = strchr(line, '\n');
+					if (newline != 0) {
+						*newline = '\0';
+					}
+					if (i == DAT_8032eeec) {
+						strcpy(s_ReplyStr, line);
+					}
+					if (newline == 0) {
+						break;
+					}
+					line = newline + 1;
+				}
+
+				__dla__FPv(srcText);
+				__dla__FPv(workText);
+				*reinterpret_cast<u8*>(state + 8) = 1;
+			} else {
+				*reinterpret_cast<u8*>(state + 8) = 0xFF;
+			}
+
+			*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+			*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+			PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+			return 0;
+		}
+
+		if (menuMode == 4) {
+			if ((hold & 8) == 0) {
+				if ((hold & 4) != 0) {
+					if (*reinterpret_cast<s16*>(state + 0x28) < 3) {
+						*reinterpret_cast<s16*>(state + 0x28) = *reinterpret_cast<s16*>(state + 0x28) + 1;
+					} else {
+						*reinterpret_cast<s16*>(state + 0x28) = 0;
+					}
+					PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+				}
+			} else {
+				if (*reinterpret_cast<s16*>(state + 0x28) == 0) {
+					*reinterpret_cast<s16*>(state + 0x28) = 3;
+				} else {
+					*reinterpret_cast<s16*>(state + 0x28) = *reinterpret_cast<s16*>(state + 0x28) - 1;
+				}
+				PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+			}
+
+			if ((hold & 0xC) != 0) {
+				return 0;
+			}
+			if ((press & 0x100) != 0) {
+				s16 choice = *reinterpret_cast<s16*>(state + 0x28);
+				if (choice < 3) {
+					DAT_8032eeed = static_cast<signed char>(choice);
+					*reinterpret_cast<u8*>(state + 8) = 1;
+				} else {
+					DAT_8032eeed = 2;
+					*reinterpret_cast<u8*>(state + 8) = 0xFF;
+				}
+				*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+				DAT_8032eef4 = 0;
+				DAT_8032eef0 = 0;
+				*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+				PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+				return 0;
+			}
+			if ((press & 0x200) == 0) {
+				return 0;
+			}
+			*reinterpret_cast<u8*>(state + 8) = 0xFF;
+			*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+			*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+			PlaySe__6CSoundFiiii(&Sound, 3, 0x40, 0x7F, 0);
+			return 0;
+		}
+
+		if (menuMode != 5) {
+			return 0;
+		}
+
+		if ((hold & 0xC) != 0) {
+			*reinterpret_cast<u16*>(state + 0x28) ^= 1;
+			PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+			return 0;
+		}
+		if ((press & 0x100) != 0) {
+			if (*reinterpret_cast<s16*>(state + 0x28) == 0) {
+				int itemValue = DAT_8032eef0;
+				int gilValue = 0;
+				if (DAT_8032eeed != 0) {
+					itemValue = 0;
+					if (DAT_8032eeed == 1) {
+						gilValue = DAT_8032eef0;
+					}
+				}
+				FGLetterReply__12CCaravanWorkFiiii(
+				    reinterpret_cast<void*>(caravanWork),
+				    static_cast<int>(DAT_8032eee8),
+				    static_cast<int>(DAT_8032eeec),
+				    itemValue,
+				    gilValue);
+				if (DAT_8032eeed == 0) {
+					DeleteItemIdx__12CCaravanWorkFii(
+					    reinterpret_cast<void*>(caravanWork), static_cast<int>(DAT_8032eeee), 0);
+				} else {
+					AddGil__12CCaravanWorkFi(reinterpret_cast<void*>(caravanWork), -gilValue);
+				}
+				*reinterpret_cast<u8*>(state + 8) = 1;
+			} else {
+				*reinterpret_cast<u8*>(state + 8) = 0xFF;
+			}
+
+			*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+			*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+			PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+			return 0;
+		}
+		if ((press & 0x200) == 0) {
+			return 0;
+		}
+		*reinterpret_cast<u8*>(state + 8) = 0xFF;
+		*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+		*reinterpret_cast<s16*>(*reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x848) + 0xA) = 2;
+		PlaySe__6CSoundFiiii(&Sound, 3, 0x40, 0x7F, 0);
+		return 0;
+	}
+
+	int letterCount = *reinterpret_cast<int*>(caravanWork + 1000);
+	if ((letterCount == 0) && ((hold & 0xC) != 0)) {
+		PlaySe__6CSoundFiiii(&Sound, 4, 0x40, 0x7F, 0);
+		return 0;
+	}
+
+	if ((hold & 8) == 0) {
+		if ((hold & 4) != 0) {
+			int cursor = static_cast<int>(*reinterpret_cast<s16*>(state + 0x26));
+			if ((cursor < 8) && (cursor < letterCount - 1)) {
+				*reinterpret_cast<s16*>(state + 0x26) = *reinterpret_cast<s16*>(state + 0x26) + 1;
+				PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+			} else if (*reinterpret_cast<s16*>(state + 0x34) + cursor < letterCount - 1) {
+				*reinterpret_cast<s16*>(state + 0x34) = *reinterpret_cast<s16*>(state + 0x34) + 1;
+				PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+			} else {
+				PlaySe__6CSoundFiiii(&Sound, 4, 0x40, 0x7F, 0);
+			}
+		}
+	} else if (*reinterpret_cast<s16*>(state + 0x26) == 0) {
+		if (*reinterpret_cast<s16*>(state + 0x34) == 0) {
+			PlaySe__6CSoundFiiii(&Sound, 4, 0x40, 0x7F, 0);
+		} else {
+			*reinterpret_cast<s16*>(state + 0x34) = *reinterpret_cast<s16*>(state + 0x34) - 1;
+			PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+		}
+	} else {
+		*reinterpret_cast<s16*>(state + 0x26) = *reinterpret_cast<s16*>(state + 0x26) - 1;
+		PlaySe__6CSoundFiiii(&Sound, 1, 0x40, 0x7F, 0);
+	}
+
+	if ((hold & 0xC) != 0) {
+		return 0;
+	}
+	if ((press & 0x20) != 0) {
+		*reinterpret_cast<s16*>(state + 0x1E) = 1;
+		PlaySe__6CSoundFiiii(&Sound, 0x5A, 0x40, 0x7F, 0);
+		return 1;
+	}
+	if ((press & 0x40) != 0) {
+		*reinterpret_cast<s16*>(state + 0x1E) = -1;
+		PlaySe__6CSoundFiiii(&Sound, 0x5A, 0x40, 0x7F, 0);
+		return 1;
+	}
+	if ((press & 0x100) == 0) {
+		if ((press & 0x200) == 0) {
+			return 0;
+		}
+		*reinterpret_cast<u8*>(state + 0xD) = 1;
+		PlaySe__6CSoundFiiii(&Sound, 3, 0x40, 0x7F, 0);
+		return 1;
+	}
+
+	if (letterCount == 0) {
+		PlaySe__6CSoundFiiii(&Sound, 4, 0x40, 0x7F, 0);
+		return 0;
+	}
+
+	*reinterpret_cast<s16*>(state + 0x12) = *reinterpret_cast<s16*>(state + 0x12) + 1;
+	DAT_8032eee8 = *reinterpret_cast<s16*>(state + 0x34) + *reinterpret_cast<s16*>(state + 0x26);
+	int entry = caravanWork + DAT_8032eee8 * 0xC;
+	m_tempVar__4CMes[0] = *reinterpret_cast<u16*>(entry + 0x3F0);
+	m_tempVar__4CMes[1] = *reinterpret_cast<u16*>(entry + 0x3F2);
+	m_tempVar__4CMes[2] = *reinterpret_cast<u16*>(entry + 0x3F4);
+	m_tempVar__4CMes[3] = *reinterpret_cast<u16*>(entry + 0x3F6);
+
+	int openAnim = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x850);
+	*reinterpret_cast<int*>(openAnim + 0x24) = 0;
+	*reinterpret_cast<int*>(openAnim + 0x2C) = 10;
+	*reinterpret_cast<int*>(openAnim + 0x30) = 10;
+	*reinterpret_cast<int*>(openAnim + 0x64) = 0;
+	*reinterpret_cast<int*>(openAnim + 0x6C) = 0;
+	*reinterpret_cast<int*>(openAnim + 0x70) = 10;
+
+	int panelCount = static_cast<int>(**reinterpret_cast<s16**>(reinterpret_cast<char*>(this) + 0x850));
+	s16* panel = *reinterpret_cast<s16**>(reinterpret_cast<char*>(this) + 0x850) + 4;
+	for (int i = 0; i < panelCount; ++i, panel += 0x20) {
+		panel[0x10] = 0;
+		panel[0x11] = 0;
+		*reinterpret_cast<float*>(panel + 8) = FLOAT_803330f8;
+	}
+
+	*reinterpret_cast<s16*>(state + 0x22) = 0;
+	PlaySe__6CSoundFiiii(&Sound, 2, 0x40, 0x7F, 0);
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `CMenuPcs::LetterCtrlCur` from the current `TODO` stub as a first-pass decompilation using the Ghidra control flow as guidance.
- Add the missing pad/sound includes and external function declarations used by the control logic.
- Update the declaration/definition of `LetterCtrlCur` to return `int`, matching the recovered control-path behavior (`0/1` return paths).

## Functions improved
- Unit: `main/menu_letter`
- Symbol: `LetterCtrlCur__8CMenuPcsFv`

## Match evidence
- `objdiff-cli` command used:
  - `tools/objdiff-cli diff -p . -u main/menu_letter -o - LetterCtrlCur__8CMenuPcsFv`
- Before: `0.10405827%` (`size=3844`)
- After: `16.235172%` (`size=3844`)
- Net gain: `+16.13111373` percentage points on this function.

## Plausibility rationale
- The implementation follows existing menu-controller patterns already present in this codebase (pad input gating, state-machine transitions, sound IDs, menu cursor behavior, and caravan action calls).
- Changes prioritize restoring likely original gameplay/menu behavior rather than synthetic instruction coercion.
- This is intentionally a first-pass large-function recovery; structure remains readable and consistent with nearby decomp style.

## Technical details
- Implemented the major state branches recovered for mode values `0..5` (list navigation, message/reply/confirm flows, accept/cancel paths).
- Restored message extraction path for reply text selection, including temporary text buffer allocation and `MakeAgbString` conversion flow.
- Restored side effects for caravan mutations (`AddItem`, `AddGil`, `FGLetterReply`, `DeleteItemIdx`) and menu state transitions (`0x82C`/`0x848` control fields).
