### PR TITLE
pppLaser: resolve final const-symbol mismatch in pppConstruct2Laser

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -10,6 +10,7 @@
 extern struct _pppMngSt* pppMngStPtr;
 extern CMath math[];
 extern const f32 FLOAT_80333428;
+extern const f32 lbl_80333428;
 extern const f32 FLOAT_80333448;
 extern const f32 FLOAT_8033344c;
 extern const f32 FLOAT_80333450;
@@ -165,10 +166,10 @@ void pppConstructLaser(struct pppLaser *pppLaser, struct UnkC *param_2)
  */
 void pppConstruct2Laser(struct pppLaser *pppLaser, struct UnkC *param_2)
 {
-    f32 fVar1 = FLOAT_80333428;
+    f32 fVar1 = lbl_80333428;
     u8* work = (u8*)pppLaser + param_2->offsets->m_serializedDataOffsets[2] + 0x80;
 
-    *(f32*)(work + 0x18) = FLOAT_80333428;
+    *(f32*)(work + 0x18) = lbl_80333428;
     *(f32*)(work + 0x14) = fVar1;
     *(f32*)(work + 0x10) = fVar1;
     *(f32*)(work + 0x0C) = fVar1;


### PR DESCRIPTION
## Summary
- Updated pppConstruct2Laser in src/pppLaser.cpp to load the zero constant via lbl_80333428 instead of FLOAT_80333428 for this function.
- Kept behavior identical; this only changes which SDA symbol relocation the compiler emits.

## Functions improved
- Unit: main/pppLaser
- Symbol: pppConstruct2Laser

## Match evidence
- pppConstruct2Laser: 99.70588% -> 100.0% (size 68b)
- Objdiff mismatch before: single DIFF_ARG_MISMATCH on constant load symbol (lbl_80333428 vs FLOAT_80333428).
- Objdiff after: no instruction diffs for the symbol.

## Plausibility rationale
- The change is source-plausible and minimal: the function initializes work memory to 0.0f and still does exactly that.
- No control-flow or arithmetic changes; only the referenced global constant symbol changed to match original object output.

## Technical details
- Added extern const f32 lbl_80333428; and used it only in pppConstruct2Laser.
- Build verification: ninja passes (build/GCCP01/main.dol: OK).
