### PR TITLE
p_chara: match IsModelLoaded unsigned model-field check

### DIFF
--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -809,7 +809,7 @@ bool CCharaPcs::CHandle::IsModelLoaded(int checkModelField)
 	if ((m_asyncState == 0 || m_asyncState == 7)
 		&& m_model != nullptr
 		// TODO: Pending CModel decomp
-		&& (checkModelField == 0 || *reinterpret_cast<int*>(reinterpret_cast<char*>(m_model) + 0xB0) != 0))
+		&& (checkModelField == 0 || *reinterpret_cast<unsigned int*>(reinterpret_cast<char*>(m_model) + 0xB0) != 0))
 	{
 			return true;
 	}


### PR DESCRIPTION
## Summary
- Adjust `CCharaPcs::CHandle::IsModelLoaded(int)` in `src/p_chara.cpp`
- Switched the pending-model field probe at `m_model + 0xB0` from `int*` to `unsigned int*`
- This preserves behavior (`!= 0`) while matching the original compare instruction form

## Functions improved
- Unit: `main/p_chara`
- Symbol: `IsModelLoaded__Q29CCharaPcs7CHandleFi`

## Match evidence
- `objdiff` before: **96.47%**
- `objdiff` after: **100.00%**
- Assembly delta removed: signed compare (`cmpwi`) at the model field check now matches unsigned compare (`cmplwi`)

## Plausibility rationale
- The source change is a type correction at a raw model flag/field probe, which is a normal decompilation refinement for ABI/instruction parity.
- No control-flow restructuring or compiler-coaxing temporaries were introduced.

## Technical details
- Full build still succeeds (`ninja`; prior full build in this worktree reported `build/GCCP01/main.dol: OK`).
- Progress report advanced by one matched function in this run (`1785 -> 1786` matched functions in project progress output).
