### PR TITLE
gobject: match CGObject::GetCID class id return value

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1436,5 +1436,5 @@ void CGObject::onDrawDebug(CFont*, float, float&, float)
  */
 int CGObject::GetCID()
 {
-	return 0;
+	return 5;
 }


### PR DESCRIPTION
## Summary
- Updated `CGObject::GetCID()` in `src/gobject.cpp` to return the class id constant used by the original binary (`5` instead of `0`).
- No control-flow restructuring or compiler-coaxing changes; this is a direct semantic correction for the class-id accessor.

## Functions Improved
- Unit: `main/gobject`
- Function: `GetCID__8CGObjectFv` (PAL size: `8b`)
- Match change: `99.5%` -> `100.0%`

## Match Evidence
- Before (`objdiff-cli v3.6.1`): `GetCID__8CGObjectFv` showed one argument mismatch in `li r3, imm`.
- After: function is fully matched (`100.0%`) with `li r3, 0x5; blr` on both sides.
- Project progress impact from `ninja`:
  - Code bytes matched: `218760` -> `218768`
  - Matched functions: `1788` -> `1789`

## Plausibility Rationale
- `GetCID()` is a virtual class-id accessor; returning a fixed id constant is expected for this pattern.
- Returning `5` aligns with target code generation and is more plausible as original source intent than returning a generic `0`.

## Technical Details
- Verified with one-shot objdiff JSON on `main/gobject` and symbol `GetCID__8CGObjectFv` before/after the change.
- Rebuilt and regenerated project report with `ninja`; no additional source files were modified.
