### PR TITLE
RedMidiCtrl: implement ADSR AR/DR/SR envelope handlers

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1134,12 +1134,31 @@ void __MidiCtrl_ADSR_AL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8BF4
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ADSR_AR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ADSR_AR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    int trackData;
+    int* voice;
+    int delta;
+
+    trackData = (int)track;
+    delta = DeltaTimeSumup((unsigned char**)trackData);
+    *(unsigned short*)(trackData + 0xD4) = delta;
+
+    voice = (int*)DAT_8032f444;
+    do {
+        if (*voice == trackData) {
+            *(unsigned short*)(voice + 0x14) = delta;
+            voice[0x24] |= 0x3C0;
+        }
+        voice += 0x30;
+    } while (voice < (int*)(DAT_8032f444 + 0xC00));
 }
 
 /*
@@ -1154,12 +1173,31 @@ void __MidiCtrl_ADSR_DL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8CD8
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ADSR_DR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ADSR_DR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    int trackData;
+    int* voice;
+    int delta;
+
+    trackData = (int)track;
+    delta = DeltaTimeSumup((unsigned char**)trackData);
+    *(unsigned short*)(trackData + 0xD6) = delta;
+
+    voice = (int*)DAT_8032f444;
+    do {
+        if (*voice == trackData) {
+            *(unsigned short*)((int)voice + 0x52) = delta;
+            voice[0x24] |= 0x3C0;
+        }
+        voice += 0x30;
+    } while (voice < (int*)(DAT_8032f444 + 0xC00));
 }
 
 /*
@@ -1174,12 +1212,31 @@ void __MidiCtrl_ADSR_SL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8DBC
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ADSR_SR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ADSR_SR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    int trackData;
+    int* voice;
+    int delta;
+
+    trackData = (int)track;
+    delta = DeltaTimeSumup((unsigned char**)trackData);
+    *(unsigned short*)(trackData + 0xD8) = delta;
+
+    voice = (int*)DAT_8032f444;
+    do {
+        if (*voice == trackData) {
+            *(unsigned short*)(voice + 0x15) = delta;
+            voice[0x24] |= 0x3C0;
+        }
+        voice += 0x30;
+    } while (voice < (int*)(DAT_8032f444 + 0xC00));
 }
 
 /*


### PR DESCRIPTION
## Summary
Implement three previously stubbed ADSR controller handlers in `src/RedSound/RedMidiCtrl.cpp`:
- `__MidiCtrl_ADSR_AR`
- `__MidiCtrl_ADSR_DR`
- `__MidiCtrl_ADSR_SR`

Each handler now:
- computes delta time via `DeltaTimeSumup`
- writes the corresponding envelope field on `RedTrackDATA`
- propagates the value into active voice entries in `DAT_8032f444`
- marks voice state with `|= 0x3C0`

Also added PAL address/size metadata blocks for these three functions.

## Functions Improved
Unit: `main/RedSound/RedMidiCtrl`

- `__MidiCtrl_ADSR_AR__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - before: `3.2258065%`
  - after: `79.0%`
- `__MidiCtrl_ADSR_DR__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - before: `3.2258065%`
  - after: `79.0%`
- `__MidiCtrl_ADSR_SR__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
  - before: `3.2258065%`
  - after: `79.0%`

## Match Evidence
Used:
```sh
tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o - '__MidiCtrl_ADSR_AR__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA'
```

Key result: each of the three ADSR handlers moved from near-empty/stub-level matching (~3.2%) to substantial instruction alignment (79.0%).

## Plausibility Rationale
These changes are source-plausible original logic, not compiler coercion:
- behavior follows expected ADSR semantics (attack/decay/sustain rate update path)
- implementation updates both track-local envelope state and per-voice runtime state
- memory layout access patterns align with nearby existing RedMidiCtrl code style
- no contrived temp variables or artificial control-flow tricks were introduced

## Build Verification
`ninja` succeeds after changes.
