### PR TITLE
p_camera: improve createFunnyShape/createMaterialEditor match

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1833,20 +1833,22 @@ void CCameraPcs::drawShadowEndAll()
  */
 void CCameraPcs::createMaterialEditor()
 {
-    unsigned char* self = reinterpret_cast<unsigned char*>(this);
-
+    u8* self = reinterpret_cast<u8*>(this);
+    float fVar2 = FLOAT_8032fa34;
     *reinterpret_cast<int*>(self + 0x46C) = 0;
-    *reinterpret_cast<float*>(self + 0x450) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x44C) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x448) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x45C) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x458) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x454) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x468) = FLOAT_8032fa1c;
-    *reinterpret_cast<float*>(self + 0x464) = FLOAT_8032fa1c;
-    *reinterpret_cast<float*>(self + 0x460) = FLOAT_8032fa1c;
-    *reinterpret_cast<float*>(self + 0x44C) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x450) = FLOAT_8032fa50;
+    float fVar1 = FLOAT_8032fa1c;
+    *reinterpret_cast<float*>(self + 0x450) = fVar2;
+    float fVar3 = FLOAT_8032fa50;
+    *reinterpret_cast<float*>(self + 0x44C) = fVar2;
+    *reinterpret_cast<float*>(self + 0x448) = fVar2;
+    *reinterpret_cast<float*>(self + 0x45C) = fVar2;
+    *reinterpret_cast<float*>(self + 0x458) = fVar2;
+    *reinterpret_cast<float*>(self + 0x454) = fVar2;
+    *reinterpret_cast<float*>(self + 0x468) = fVar1;
+    *reinterpret_cast<float*>(self + 0x464) = fVar1;
+    *reinterpret_cast<float*>(self + 0x460) = fVar1;
+    *reinterpret_cast<float*>(self + 0x44C) = fVar2;
+    *reinterpret_cast<float*>(self + 0x450) = fVar3;
 }
 
 /*
@@ -1958,20 +1960,22 @@ void CCameraPcs::calcMaterialEditor()
  */
 void CCameraPcs::createFunnyShape()
 {
-    unsigned char* self = reinterpret_cast<unsigned char*>(this);
-
+    u8* self = reinterpret_cast<u8*>(this);
+    float fVar2 = FLOAT_8032fa34;
     *reinterpret_cast<int*>(self + 0x46C) = 0;
-    *reinterpret_cast<float*>(self + 0x450) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x44C) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x448) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x45C) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x458) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x454) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x468) = FLOAT_8032fa1c;
-    *reinterpret_cast<float*>(self + 0x464) = FLOAT_8032fa1c;
-    *reinterpret_cast<float*>(self + 0x460) = FLOAT_8032fa1c;
-    *reinterpret_cast<float*>(self + 0x44C) = FLOAT_8032fa34;
-    *reinterpret_cast<float*>(self + 0x450) = FLOAT_8032fa50;
+    float fVar1 = FLOAT_8032fa1c;
+    *reinterpret_cast<float*>(self + 0x450) = fVar2;
+    float fVar3 = FLOAT_8032fa50;
+    *reinterpret_cast<float*>(self + 0x44C) = fVar2;
+    *reinterpret_cast<float*>(self + 0x448) = fVar2;
+    *reinterpret_cast<float*>(self + 0x45C) = fVar2;
+    *reinterpret_cast<float*>(self + 0x458) = fVar2;
+    *reinterpret_cast<float*>(self + 0x454) = fVar2;
+    *reinterpret_cast<float*>(self + 0x468) = fVar1;
+    *reinterpret_cast<float*>(self + 0x464) = fVar1;
+    *reinterpret_cast<float*>(self + 0x460) = fVar1;
+    *reinterpret_cast<float*>(self + 0x44C) = fVar2;
+    *reinterpret_cast<float*>(self + 0x450) = fVar3;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CCameraPcs::createFunnyShape` and `CCameraPcs::createMaterialEditor` to use explicit temporary float variables (`fVar1/fVar2/fVar3`) and assignment ordering that better matches original codegen.
- Kept logic and offsets unchanged; this is a codegen-shape improvement only.

## Functions Improved
- `createFunnyShape__10CCameraPcsFv`
- `createMaterialEditor__10CCameraPcsFv`

## Match Evidence
- `createFunnyShape__10CCameraPcsFv`: **37.35294% -> 85.0%**
- `createMaterialEditor__10CCameraPcsFv`: **37.35294% -> 85.0%**
- Measured with:
  - `tools/objdiff-cli diff -p . -u main/p_camera -o - createFunnyShape__10CCameraPcsFv`
  - `tools/objdiff-cli diff -p . -u main/p_camera -o - createMaterialEditor__10CCameraPcsFv`

## Plausibility Rationale
- The changes use straightforward local temporaries for reused constants and preserve idiomatic initialization flow.
- No contrived control-flow tricks or offset hacks were introduced; this remains plausible source-level author code.

## Technical Details
- Prior code inlined repeated constant stores directly.
- Updated versions introduce explicit temporaries and assignment sequencing that aligns better with the original register/load usage pattern in objdiff.
- Verified clean build with `ninja` after changes.
