### PR TITLE
mapobj: improve deleting dtor wrapper match

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -159,9 +159,11 @@ CMapObj::~CMapObj()
 extern "C" CMapObj* dtor_8002BE7C(CMapObj* mapObj, short param_2)
 {
     if (mapObj != 0) {
-        void* attr = PtrAt(mapObj, 0xEC);
-        if (attr != 0) {
-            (*(void (**)(void*, int))(*reinterpret_cast<unsigned int*>(attr) + 8))(attr, 1);
+        int* piVar1 = reinterpret_cast<int*>(PtrAt(mapObj, 0xEC));
+        if (piVar1 != 0) {
+            if (piVar1 != 0) {
+                (*(void (**)(int*, int))(*piVar1 + 8))(piVar1, 1);
+            }
             PtrAt(mapObj, 0xEC) = 0;
         }
 


### PR DESCRIPTION
## Summary
- Adjusted `dtor_8002BE7C` in `src/mapobj.cpp` to better mirror original destructor-wrapper control flow.
- Switched the attr pointer local to `int*` and added the duplicated null-check branch shape before virtual dtor dispatch.
- Kept behavior unchanged: destroy attr at `+0xEC`, clear pointer, call `Init()`, conditionally `__dl__` when `param_2 > 0`.

## Functions improved
- Unit: `main/mapobj`
- Symbol: `dtor_8002BE7C` (PAL 0x8002BE7C, 128b)
- Match: **96.5625% -> 99.6875%**

## Match evidence
- Baseline command:
  - `tools/objdiff-cli diff -p . -u main/mapobj -o - dtor_8002BE7C`
- After change:
  - same command reports `99.6875%`
- Remaining mismatch reduced to argument-use around the virtual call load path (`lwz r12, 0(r3)` / `lwz r12, 8(r12)`).

## Plausibility rationale
- This change preserves natural C++ deleting-dtor wrapper structure used throughout the codebase.
- The duplicated null-check pattern is compiler-plausible output for this era/toolchain and aligns with the decomp reference shape.
- No contrived temporaries, hardcoded object-layout hacks, or readability regressions were introduced.

## Technical details
- File changed: `src/mapobj.cpp`
- Build status: `ninja` passes (`build/GCCP01/main.dol: OK` already established in this worktree).
- Other key `mapobj` targets checked remained stable during validation (`SetLink`, `ReadOtmObj`).
