### PR TITLE
RedDriver: implement _RedAXCallback

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1144,7 +1144,9 @@ int _MusicSkipThread(void*)
  */
 void _RedAXCallback()
 {
-	// TODO
+    DAT_8032f3b8 = DAT_8032f3b8 + 1;
+    EnvelopeKeyExecute();
+    OSSignalSemaphore(&DAT_8032d778);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `_RedAXCallback` in `src/RedSound/RedDriver.cpp` using the existing RedSound runtime flow.
- The callback now increments the AX tick counter, runs envelope key processing, and signals the audio semaphore.

## Functions Improved
- Unit: `main/RedSound/RedDriver`
- Function: `_RedAXCallback__Fv` (56 bytes)

## Match Evidence
- `_RedAXCallback__Fv`: **7.142857% -> 100.0%**
- Unit `main/RedSound/RedDriver`: matched functions **2 -> 3**, matched code **+56 bytes**
- Overall build progress increased matched code by **56 bytes** (from 218,768 to 218,824)

## Plausibility Rationale
- The implementation is a straightforward runtime callback path that matches existing surrounding code responsibilities:
  - update global callback tick counter (`DAT_8032f3b8`)
  - execute envelope processing (`EnvelopeKeyExecute`)
  - wake waiting audio work (`OSSignalSemaphore` on `DAT_8032d778`)
- No contrived temporaries or control-flow tricks were introduced.

## Technical Details
- Used the PAL-addressed Ghidra reference for `_RedAXCallback__Fv` (0x801be5d0, 56b) as structure guidance.
- Verified by rebuilding (`ninja`) and checking updated match report in `build/GCCP01/report.json`.
