### PR TITLE
gobject: implement CalcSafePos and PutDropItem

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -72,7 +72,7 @@ public:
     void ResetAnimPoint(int);
     void AddAnimPoint(int, int, int);
     void SetAnimSlot(int, int);
-    void CalcSafePos(int, CGObject*, Vec*);
+    float CalcSafePos(int, CGObject*, Vec*);
     void PutDropItem();
     bool IsDispRader();
     void onHit(int, CGObject*, int, Vec*);

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -26,10 +26,14 @@ extern "C" int CalcHitSlide__7CMapObjFP3Vecf(void*, Vec*);
 extern "C" void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
 extern "C" void GetHitFaceNormal__7CMapObjFP3Vec(void*, Vec*);
 extern "C" int PlaySe3D__6CSoundFiP3Vecffi(CSound*, int, Vec*, float, float, int);
+extern "C" void* CreateFromScript__9CGItemObjFiiiP8CGObjectfPQ29CGItemObj4CCFS(
+    int, int, int, CGObject*, float, void*);
 extern unsigned char DAT_8032ec90[];
 extern float FLOAT_8033033c;
 extern float FLOAT_80330340;
+extern float FLOAT_80330344;
 extern float FLOAT_80330360;
+extern double DOUBLE_80330348;
 extern double DOUBLE_80330400;
 extern float FLOAT_80330410;
 extern float FLOAT_8033041c;
@@ -1351,22 +1355,109 @@ void CGObject::SetAnimSlot(int slot, int anim)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8007bf34
+ * PAL Size: 644b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGObject::CalcSafePos(int, CGObject*, Vec*)
+float CGObject::CalcSafePos(int hitMask, CGObject* other, Vec* outSafePos)
 {
-	// TODO
+    Vec centerPos;
+    Vec hitMove;
+    CMapCylinder hitCylinder;
+    float safeDistance = sZeroFloat;
+    void* hitObject = *reinterpret_cast<void**>(reinterpret_cast<u8*>(&MapMng) + 0x22A88);
+
+    centerPos.x = other->m_worldPosition.x;
+    centerPos.y = m_worldPosition.y;
+    if (centerPos.y < other->m_worldPosition.y) {
+        centerPos.y = other->m_worldPosition.y;
+    }
+    centerPos.y += m_capsuleHalfHeight;
+    centerPos.z = other->m_worldPosition.z;
+
+    PSVECSubtract(&m_worldPosition, &centerPos, &hitMove);
+    hitMove.y = sZeroFloat;
+
+    hitCylinder.m_bottom = centerPos;
+    hitCylinder.m_direction = hitMove;
+    hitCylinder.m_radius = FLOAT_8033033c;
+    hitCylinder.m_height = FLOAT_8033033c;
+    hitCylinder.m_top = hitMove;
+    hitCylinder.m_direction2.x = FLOAT_80330340;
+    hitCylinder.m_direction2.y = FLOAT_80330340;
+    hitCylinder.m_direction2.z = FLOAT_80330340;
+    hitCylinder.m_radius2 = m_capsuleHalfHeight;
+    hitCylinder.m_height2 = sZeroFloat;
+
+    if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &hitCylinder, &hitMove, hitMask) == 0) {
+        *outSafePos = m_worldPosition;
+        hitMove.y = sZeroFloat;
+        hitMove.x = (m_capsuleHalfHeight + other->m_capsuleHalfHeight) * (float)sin((double)other->m_rotBaseY);
+        hitMove.z = (m_capsuleHalfHeight + other->m_capsuleHalfHeight) * (float)cos((double)other->m_rotBaseY);
+
+        hitCylinder.m_bottom = centerPos;
+        hitCylinder.m_direction = hitMove;
+        hitCylinder.m_radius = FLOAT_8033033c;
+        hitCylinder.m_height = FLOAT_8033033c;
+        hitCylinder.m_top = hitMove;
+        hitCylinder.m_direction2.x = FLOAT_80330340;
+        hitCylinder.m_direction2.y = FLOAT_80330340;
+        hitCylinder.m_direction2.z = FLOAT_80330340;
+        hitCylinder.m_radius2 = m_capsuleHalfHeight;
+        hitCylinder.m_height2 = sZeroFloat;
+
+        if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &hitCylinder, &hitMove, hitMask) != 0) {
+            CalcHitPosition__7CMapObjFP3Vec(hitObject, &centerPos);
+            safeDistance = (m_capsuleHalfHeight + other->m_capsuleHalfHeight) -
+                           PSVECDistance(&m_worldPosition, &centerPos);
+        }
+    } else {
+        CalcHitPosition__7CMapObjFP3Vec(hitObject, &centerPos);
+        centerPos.y -= m_capsuleHalfHeight;
+        *outSafePos = centerPos;
+        safeDistance = PSVECDistance(&m_worldPosition, &centerPos);
+    }
+
+    return safeDistance;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8007be74
+ * PAL Size: 192b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGObject::PutDropItem()
 {
-	// TODO
+    u32 dropCount = 0;
+
+    for (int i = 0; i < 4; i++) {
+        u32 dropCode = static_cast<u16>(m_dropItemCodes[i]);
+        if ((short)m_dropItemCodes[i] > 0) {
+            int createMode;
+            if ((dropCode & 0xC000) == 0x4000) {
+                dropCode &= 0x3FFF;
+                createMode = 2;
+            } else {
+                createMode = 0;
+            }
+
+            CreateFromScript__9CGItemObjFiiiP8CGObjectfPQ29CGItemObj4CCFS(
+                createMode,
+                4,
+                dropCode,
+                this,
+                FLOAT_80330344 * (float)dropCount,
+                0);
+            dropCount++;
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CGObject::CalcSafePos` and `CGObject::PutDropItem` in `src/gobject.cpp` from current Ghidra reference as first-pass plausible gameplay logic.
- Corrected the class declaration for `CalcSafePos` to return `float` in `include/ffcc/gobject.h` (it is consumed as a float-returning symbol by existing callers).
- Added required PAL address/size metadata blocks for the two implemented functions.

## Functions Improved
- Unit: `main/gobject`
- `PutDropItem__8CGObjectFv` (192b)
  - Before: `2.0833333%`
  - After: `84.145836%`
- `CalcSafePos__8CGObjectFiP8CGObjectP3Vec` (644b)
  - Before: `0.621118%`
  - After: `50.93789%`

## Match Evidence
- Symbol diffs generated with:
  - `tools/objdiff-cli diff -p . -u main/gobject -o - <symbol>` (after)
  - same command against a clean `origin/main` baseline worktree (before)
- Unit fuzzy match (`main/gobject`) moved from `15.246804%` to `17.130964%`.
- Build passes with `ninja`, including DOL verification (`build/GCCP01/main.dol: OK`).

## Plausibility Rationale
- Changes model expected gameplay behavior directly:
  - `CalcSafePos`: performs map-cylinder collision queries and computes a safe fallback position + separation distance.
  - `PutDropItem`: iterates drop slots, decodes item mode bits, and forwards item spawn requests with deterministic slot-based angle offsets.
- The changes are not compiler-coaxing rewrites; they replace explicit TODO stubs with behavior consistent with surrounding engine usage and existing symbol contracts.

## Technical Details
- `CalcSafePos` now matches existing call-sites that expect float-return semantics (e.g. wrapper calls in `itemobj.cpp`).
- `PutDropItem` now routes through `CreateFromScript__9CGItemObjFiiiP8CGObjectfPQ29CGItemObj4CCFS` and uses the item-code high bits (`0xC000/0x4000`) to select spawn mode and masked script code.
- Collision lookup and hit-position fetch reuse existing map access conventions already present in `gobject.cpp`.