### PR TITLE
partyobj: implement CGPartyObj::onDestroy

### DIFF
--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -23,12 +23,22 @@ void CGPartyObj::onCreate()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80124840
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGPartyObj::onDestroy()
 {
-	// TODO
+	unsigned char* partyFlags = reinterpret_cast<unsigned char*>(this) + 0x6B8;
+	if ((*partyFlags & 0x04) != 0) {
+		addHp(*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(m_scriptHandle) + 0x1A), static_cast<CGPrgObj*>(0));
+		*partyFlags &= ~0x04;
+	}
+
+	CGCharaObj::onDestroy();
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CGPartyObj::onDestroy()` in `src/partyobj.cpp` using the existing class API and field offsets reflected by PAL decomp behavior.

## Functions improved
- Unit: `main/partyobj`
- Function: `onDestroy__10CGPartyObjFv` (100b)

## Match evidence
- `onDestroy__10CGPartyObjFv`: **4.0% -> 83.2%** fuzzy match
- Unit `main/partyobj`: selector baseline was ~**1.2%**, now report shows **1.3968587%**
- `ninja` rebuild succeeds and regenerates report.

## Objdiff/assembly notes
- Control flow now matches expected shape: flag test on `0x6B8`, conditional `addHp(...)`, flag clear, tail call to `CGCharaObj::onDestroy()`.
- Core instruction sequence aligns (`lbz` flag load, conditional branch, `lhz` from `m_scriptHandle + 0x1A`, `bl CGCharaObj::addHp`, bit clear store, `bl CGCharaObj::onDestroy`).

## Plausibility rationale
This change is source-plausible and idiomatic for the codebase:
- uses existing member function calls (`addHp`, `CGCharaObj::onDestroy`)
- uses straightforward flag/cleanup logic consistent with adjacent object lifecycle methods
- avoids contrived temporaries or compiler-coaxing patterns
