### PR TITLE
graphic: improve __sinit_graphic_cpp init sequencing

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -13,7 +13,7 @@
 #include "dolphin/vi.h"
 #include "dolphin/vi/vifuncs.h"
 
-extern void* lbl_801E8408;
+extern "C" char lbl_801E8408[];
 extern GXRenderModeObj lbl_801E83C0;
 extern u8 DAT_801E83F2[7];
 extern char DAT_80238030[];
@@ -22,6 +22,7 @@ extern "C" u8 DAT_8032ec48;
 extern "C" u8 DAT_8032ec4c;
 extern "C" u8 DAT_8032ec50;
 extern "C" u8 DAT_8032ec54;
+extern "C" char __vt__8CManager[];
 extern "C" _GXColor DAT_8032e3e8;
 extern "C" char DAT_801d637c[];
 extern "C" char DAT_801d63c0[];
@@ -103,7 +104,9 @@ void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
  */
 extern "C" void __sinit_graphic_cpp(void)
 {
-	*(void**)&Graphic = &lbl_801E8408;
+    void* vtbl = __vt__8CManager;
+    *reinterpret_cast<void**>(&Graphic) = vtbl;
+    *reinterpret_cast<void**>(&Graphic) = lbl_801E8408;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Updated `__sinit_graphic_cpp` in `src/graphic.cpp` to follow the original init sequence more closely.
- Switched `lbl_801E8408` declaration to `char[]` and added `__vt__8CManager` symbol usage.
- Function now performs an explicit manager-vtable initialization assignment before the final `Graphic` vtable assignment.

## Functions Improved
- Unit: `main/graphic`
- Symbol: `__sinit_graphic_cpp`

## Match Evidence
- Before: `22.5%`
- After: `70.0%`
- Tool: `tools/objdiff-cli diff -p . -u main/graphic -o - __sinit_graphic_cpp`
- Assembly alignment improved by matching the expected setup of both `__vt__8CManager` and `lbl_801E8408` symbol references; remaining mismatch is in store form/register usage (`stwu` sequence).

## Plausibility Rationale
- The change models a common Metrowerks C++ static-init pattern: write base manager vtable first, then overwrite with the final concrete-class vtable.
- Uses symbol-accurate declarations rather than artificial control-flow or temporary hacks.

## Technical Details
- `__sinit_graphic_cpp` now mirrors the same source-level initialization style used in similar static init functions in this repo.
- No debug artifacts/comments were added.
- Build verified with `ninja`.
