### PR TITLE
materialman: decompile SetMaterialCharaShadow

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1136,12 +1136,64 @@ void CMaterialMan::SetMaterial(CMaterialSet*, int, int, _GXTevScale)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003fb4c
+ * PAL Size: 676b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMaterialMan::SetMaterialCharaShadow(CMaterial*)
+void CMaterialMan::SetMaterialCharaShadow(CMaterial* material)
 {
-	// TODO
+    unsigned int tevBit = *reinterpret_cast<unsigned int*>(Ptr(material, 0x24));
+    int bumpLight = *reinterpret_cast<int*>(Ptr(material, 0x28));
+    unsigned char materialType = *reinterpret_cast<unsigned char*>(Ptr(material, 0xA2));
+
+    if ((bumpLight != 0) && (materialType != 3) && (materialType != 2)) {
+        if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 1) {
+            GXClearVtxDesc();
+            GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+            GXSetVtxDesc(GX_VA_NBT, GX_INDEX8);
+            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
+            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+            *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 1;
+        }
+        GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 0x12);
+    } else {
+        if ((tevBit & 0x20002) == 0) {
+            if ((bumpLight != 0) || ((tevBit & 1) == 0)) {
+                if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) {
+                    GXClearVtxDesc();
+                    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                    *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
+                }
+                GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 6);
+            } else {
+                if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 3) {
+                    GXClearVtxDesc();
+                    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
+                    *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 3;
+                }
+                GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 6);
+            }
+        } else {
+            if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 2) {
+                GXClearVtxDesc();
+                GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_TEX1, GX_INDEX8);
+                *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 2;
+            }
+            GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 6);
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMaterialMan::SetMaterialCharaShadow(CMaterial*)` in `src/materialman.cpp` using existing project idioms (`Ptr(...)` offset access + GX API calls).
- Added version metadata block for the function:
  - PAL Address: `0x8003fb4c`
  - PAL Size: `676b`

## Functions Improved
- Unit: `main/materialman`
- Function: `SetMaterialCharaShadow__12CMaterialManFP9CMaterial`
  - Before: `0.591716%`
  - After: `37.75148%`
  - Size: `676b`

## Match Evidence
- `main/materialman` unit fuzzy match:
  - Before: `37.069168%`
  - After: `37.864708%`
- Improvement came from replacing a TODO stub with real TEV-bit/material-type dependent vertex descriptor and normal-array setup logic.

## Plausibility Rationale
- The implementation follows behavior already implied by nearby material setup code (`SetMaterialPart`) and uses standard GX setup patterns seen across this codebase.
- No synthetic compiler-coaxing patterns were introduced; the code is direct control flow around material flags and bump/light state, consistent with expected original game-engine source style.

## Technical Details
- Preserved low-level field access style used in this file (`Ptr(this, offset)` / `Ptr(material, offset)`) to minimize ABI and layout risk.
- Matched branch structure around:
  - `material + 0x28` (bump/light presence)
  - `material + 0xA2` (material mode)
  - `material + 0x24` TEV bitmask tests (`0x20002`, `0x1`)
- Configured GX vertex descriptors for three material paths:
  - standard normal+tex0 (`state 0`)
  - compact path (`state 3`)
  - dual-tex path (`state 2`)
  - NBT path (`state 1`, stride `0x12`)
