### PR TITLE
chara: implement CModel::calcBindMatrix first pass

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -1,6 +1,8 @@
 #include "ffcc/chara.h"
 #include "ffcc/cflat_runtime.h"
 
+extern "C" void CalcBind__Q26CChara5CNodeFPQ26CChara6CModel(void*, void*);
+
 /*
  * --INFO--
  * Address:	TODO
@@ -187,7 +189,16 @@ void CChara::CModel::Duplicate(CMemory::CStage*)
  */
 void CChara::CModel::calcBindMatrix()
 {
-	// TODO
+	CNode* node = *(CNode**)((u8*)this + 0xA8);
+	u32 i = 0;
+
+	while (i < *(u32*)((u8*)*(void**)((u8*)this + 0xA4) + 8)) {
+		if (*(s16*)((u8*)*(void**)node + 0x68) < 0) {
+			CalcBind__Q26CChara5CNodeFPQ26CChara6CModel(node, this);
+		}
+		i++;
+		node = (CNode*)((u8*)node + 0xC0);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implement `CChara::CModel::calcBindMatrix()` in `src/chara.cpp`.
- Added the node traversal loop, parent-index gate, and call into `CalcBind` for root nodes.
- Kept this as a focused first-pass implementation using currently known object-layout offsets from objdiff/ghidra.

## Functions Improved
- Unit: `main/chara`
- Symbol: `calcBindMatrix__Q26CChara6CModelFv`

## Match Evidence
- `objdiff` before: `3.3333333%` (`size: 120`)
- `objdiff` after: `92.0%` (`size: 120`)
- Command used:
  - `tools/objdiff-cli diff -p . -u main/chara -o - --format json calcBindMatrix__Q26CChara6CModelFv`

## Plausibility Rationale
- The resulting control flow matches the expected source behavior: iterate model nodes and only bind nodes with negative parent index (root nodes).
- Call structure and loop shape align with target assembly while preserving readable first-pass decomp intent.
- The remaining mismatch appears to be register allocation/local ordering, not behavioral divergence.

## Technical Notes
- Key recovered layout in this function path:
  - `this + 0xA8`: node array base
  - `this + 0xA4`: model data pointer (`+8` node count)
  - `node + 0x0`: refdata pointer (`+0x68` parent index)
  - node stride: `0xC0`
- Full build verification passes with `ninja` after this change.
