### PR TITLE
menu_favo: align FavoCtrl return semantics

### DIFF
--- a/include/ffcc/menu_favo.h
+++ b/include/ffcc/menu_favo.h
@@ -12,7 +12,7 @@ public:
     void FavoInit();
     void FavoInit0();
     bool FavoOpen();
-    void FavoCtrl();
+    unsigned int FavoCtrl();
     bool FavoClose();
     void FavoDraw();
     void FavoCtrlCur();

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -26,6 +26,7 @@ extern "C" void SetPosX__5CFontFf(float, CFont*);
 extern "C" void SetPosY__5CFontFf(float, CFont*);
 extern "C" void Draw__5CFontFPc(CFont*, const char*);
 extern "C" int sprintf(char*, const char*, ...);
+extern "C" int __cntlzw(unsigned int);
 
 struct FavoFlatTableEntry
 {
@@ -454,7 +455,7 @@ bool CMenuPcs::FavoOpen()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMenuPcs::FavoCtrl()
+unsigned int CMenuPcs::FavoCtrl()
 {
 	bool activeInput = false;
 	unsigned short press;
@@ -467,6 +468,7 @@ void CMenuPcs::FavoCtrl()
 	if (activeInput) {
 		press = 0;
 	} else {
+		__cntlzw((unsigned int)Pad._448_4_);
 		press = Pad._8_2_;
 	}
 
@@ -492,6 +494,8 @@ void CMenuPcs::FavoCtrl()
 	if (doReset) {
 		FavoInit0();
 	}
+
+	return doReset;
 }
 
 /*


### PR DESCRIPTION
## Summary
- changed `CMenuPcs::FavoCtrl` to return an `unsigned int` reset flag instead of `void`
- returned `doReset` from the function
- added the no-op `__cntlzw((unsigned int)Pad._448_4_)` in the non-active-input path to mirror established input-read patterns used in nearby menu code

## Functions improved
- Unit: `main/menu_favo`
- Function: `FavoCtrl__8CMenuPcsFv`

## Match evidence
- `FavoCtrl__8CMenuPcsFv`: **73.0100% -> 73.4500%** (`+0.4400`)
- `main/menu_favo` unit fuzzy match: **50.360657% -> 50.392017%** (`+0.031360`)
- Other functions in `main/menu_favo` unchanged in this patch

## Plausibility rationale
- `singmenu.cpp` already treats `FavoCtrl__8CMenuPcsFv` as returning a flag value in the menu state dispatch, so returning a reset flag from `FavoCtrl` is source-plausible and consistent with call-site behavior.
- The added `__cntlzw` call matches a recurring pattern in this codebase for input polling paths and keeps behavior unchanged.

## Technical details
- Build verified with `ninja` (`build/GCCP01/report.json` generated successfully).
- Match deltas were measured with `build/tools/objdiff-cli report generate -p . -f json` before/after and compared at function level.
