### PR TITLE
util: improve ConvI2FVector match via scale conversion cast

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -242,8 +242,8 @@ void CUtil::GetSplinePos(Vec& out, Vec p0, Vec p1, Vec p2, Vec p3, float t, floa
  */
 void CUtil::ConvI2FVector(Vec& out, S16Vec in, long shift)
 {
-    unsigned int scale = 1u << shift;
-    float fScale = (float)scale;
+    unsigned int scale = 1U << shift;
+    float fScale = (float)(double)scale;
 
     out.x = (float)in.x / fScale;
     out.y = (float)in.y / fScale;


### PR DESCRIPTION
## Summary
- Updated `CUtil::ConvI2FVector` in `src/util.cpp` to adjust scale conversion typing.
- Changed:
  - `1u` -> `1U`
  - `float fScale = (float)scale;` -> `float fScale = (float)(double)scale;`

## Functions improved
- Unit: `main/util`
- Symbol: `ConvI2FVector__5CUtilFR3Vec6S16Vecl`
- Size: `176b`

## Match evidence
- Before: `35.386364%`
- After: `54.340908%`
- Delta: `+18.954544%`
- Command used:
  - `tools/objdiff-cli diff -p . -u main/util -o - --format json ConvI2FVector__5CUtilFR3Vec6S16Vecl`

## Plausibility rationale
- The change is type-focused and source-plausible: it refines numeric conversion semantics without introducing contrived control flow or artificial temporaries.
- Behavior remains equivalent for valid shift ranges while improving compiler codegen alignment.

## Technical notes
- Rebuild verified with `ninja`.
- Improvement is localized to `ConvI2FVector` and does not include cleanup/debug artifacts.
