### PR TITLE
main/RedSound/RedDriver: improve ReportSeLoop match

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1879,18 +1879,18 @@ int CRedDriver::GetSeVolume(int param_1, int param_2)
 int CRedDriver::ReportSeLoop(int param_1)
 {
     int* seInfo;
-    int* end;
 
     seInfo = *(int**)((int)DAT_8032f3f0 + 0xdbc);
-    end = (int*)(*(int*)((int)DAT_8032f3f0 + 0xdbc) + 0x2a80);
-    while (seInfo < end) {
+    while (1) {
         if ((*seInfo != 0) &&
-            ((param_1 == -1 || (param_1 == seInfo[0x3e])) && ((seInfo[0x40] & 1) != 0))) {
+            (((param_1 == -1) || (param_1 == seInfo[0x3e])) && ((seInfo[0x40] & 1) != 0))) {
             return 1;
         }
         seInfo += 0x55;
+        if ((int*)(*(int*)((int)DAT_8032f3f0 + 0xdbc) + 0x2a80) <= seInfo) {
+            return 0;
+        }
     }
-    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CRedDriver::ReportSeLoop(int)` loop structure in `src/RedSound/RedDriver.cpp` to match the in-object control-flow pattern used by nearby sound-query functions.
- Removed the cached `end` pointer local and switched to an in-loop termination check after stride advance (`seInfo += 0x55`).
- Preserved behavior: still returns `1` on first matching active looped SE entry, otherwise `0` after scanning the full table.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `ReportSeLoop__10CRedDriverFi`
- Size: `108` bytes (unchanged)
- Match: `32.555557%` -> `72.59259%`

## Match evidence
- `tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o /tmp/ReportSeLoop_before.json --format json ReportSeLoop__10CRedDriverFi`
- `tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o /tmp/ReportSeLoop_after.json --format json ReportSeLoop__10CRedDriverFi`
- Observed a strong symbol-local increase with no size change, indicating real instruction/control-flow alignment rather than naming or formatting-only effects.

## Plausibility rationale
- The new form mirrors idiomatic source already present in this same file (`GetSeVolume`), making it a plausible original-author coding pattern rather than artificial compiler coaxing.
- The change is minimal and semantically direct: same predicates, same stride (`0x55` words), same data source and bounds.

## Technical details
- The previous version used `while (seInfo < end)` with a hoisted end pointer; the new version uses `while (1)` with a post-increment bound check.
- This altered branch layout and compare timing to better match the target assembly for this symbol.
