### PR TITLE
main/system: improve RemoveScenegraph control-flow match

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -484,27 +484,26 @@ void CSystem::RemoveScenegraph(CProcess* process, int arg)
 {
     typedef void* (*GetScenegraphBlockFn)(CProcess*, int);
     void* descBlock = (*(GetScenegraphBlockFn*)((u8*)*(void**)process + 0x10))(process, arg);
-    COrder* order = m_orderSentinel.m_next;
-    COrder* sentinel = &m_orderSentinel;
+    int test;
+    COrder* next;
+    COrder* current = m_orderSentinel.m_next;
 
     do
     {
-        COrder* next = order->m_next;
-
-        if (order->m_descBlock == descBlock)
+        next = current->m_next;
+        if (current->m_descBlock == descBlock)
         {
-            order->m_previous->m_next = order->m_next;
-            order->m_next->m_previous = order->m_previous;
-            order->m_next = m_freeOrderHead.m_next;
-            m_freeOrderHead.m_next = order;
-
-            m_orderCount--;
+            current->m_previous->m_next = next;
+            current->m_next->m_previous = current->m_previous;
+            current->m_next = m_freeOrderHead.m_next;
+            m_freeOrderHead.m_next = current;
+            m_orderCount = m_orderCount - 1;
         }
+        current = next;
+    } while (next != &m_orderSentinel);
 
-        order = next;
-    } while (order != sentinel);
-
-    if (__ptmf_test((__ptmf*)((u8*)descBlock + 0x10)) != 0)
+    test = __ptmf_test((__ptmf*)((u8*)descBlock + 0x10));
+    if (test != 0)
     {
         __ptmf_scall(process);
     }


### PR DESCRIPTION
## Summary
- Refactored `CSystem::RemoveScenegraph` loop variable lifetimes and update order to better match original control-flow shape.
- Introduced explicit local `test` result handling for `__ptmf_test` before `__ptmf_scall`.
- Preserved behavior while aligning temporary usage (`current`, `next`) with original-style sequencing.

## Functions Improved
- Unit: `main/system`
- Symbol: `RemoveScenegraph__7CSystemFP8CProcessi`

## Match Evidence
- Before: `80.039215%` (size `184`)
- After: `80.23529%` (size `184`)
- Evidence source: `tools/objdiff-cli diff -p . -u main/system --format json-pretty RemoveScenegraph__7CSystemFP8CProcessi`

## Plausibility Rationale
- Changes are source-plausible and maintainable: no synthetic operations, no magic offsets added, no assembly artifacts.
- Edit focuses on natural C/C++ control-flow/lifetime structure that decomp work commonly requires for register-allocation alignment.

## Technical Notes
- Improvement came from re-shaping loop-carried temporaries and making the post-loop PTMF test result explicit.
- This affected generated register pressure/lifetimes and produced measurable objdiff improvement.
