### PR TITLE
Implement RedMidiCtrl ADSR_AL and ADSR_DL command handlers

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1124,12 +1124,32 @@ void __MidiCtrl_ADSR_Default(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* trac
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8B8C
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ADSR_AL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ADSR_AL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    u8* sequencePos;
+    u8 value;
+    int* voice;
+
+    sequencePos = *(u8**)track;
+    *(u8**)track = sequencePos + 1;
+    value = *sequencePos;
+    *((u8*)track + 0xDC) = value;
+
+    voice = (int*)DAT_8032f444;
+    do {
+        if ((RedTrackDATA*)*voice == track) {
+            *((u8*)voice + 0x58) = value;
+            voice[0x24] |= 0x3C0;
+        }
+        voice += 0x30;
+    } while (voice < (int*)(DAT_8032f444 + 0xC00));
 }
 
 /*
@@ -1163,12 +1183,32 @@ void __MidiCtrl_ADSR_AR(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8C70
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_ADSR_DL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_ADSR_DL(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-	// TODO
+    u8* sequencePos;
+    u8 value;
+    int* voice;
+
+    sequencePos = *(u8**)track;
+    *(u8**)track = sequencePos + 1;
+    value = *sequencePos;
+    *((u8*)track + 0xDD) = value;
+
+    voice = (int*)DAT_8032f444;
+    do {
+        if ((RedTrackDATA*)*voice == track) {
+            *((u8*)voice + 0x59) = value;
+            voice[0x24] |= 0x3C0;
+        }
+        voice += 0x30;
+    } while (voice < (int*)(DAT_8032f444 + 0xC00));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__MidiCtrl_ADSR_AL` and `__MidiCtrl_ADSR_DL` in `src/RedSound/RedMidiCtrl.cpp` (both were TODO stubs).
- Added PAL metadata headers for both functions using Ghidra entry/size data.
- Kept implementation style consistent with surrounding RedMidiCtrl code: bytewise track command read, track state write, and active voice propagation via `DAT_8032f444`.

## Functions improved
- `__MidiCtrl_ADSR_AL__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_ADSR_DL__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Match evidence
- Baseline (selector report / TODO-stub state): ~`3.8%` for each symbol.
- After this change (`tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl ...`):
  - `__MidiCtrl_ADSR_AL...`: `70.57692%`
  - `__MidiCtrl_ADSR_DL...`: `70.57692%`
- `ninja` passes after changes.

## Plausibility rationale
- Logic matches expected MIDI command semantics and existing function patterns in this unit:
  - consume one command byte from the track stream,
  - store it into the track ADSR byte field,
  - propagate the same value into matching live voice slots,
  - mark voice update flags (`0x3C0`).
- The result is readable, source-plausible engine code rather than compiler-only coaxing.
