### PR TITLE
RedDriver: implement _DmaCallback state clear

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -895,12 +895,16 @@ void _DMACheckProcess()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801be0c4
+ * PAL Size: 12b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void _DmaCallback(unsigned long)
 {
-	// TODO
+    DAT_8032f468 = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `_DmaCallback(unsigned long)` in `src/RedSound/RedDriver.cpp` by clearing `DAT_8032f468`.
- Updated function metadata comment to include PAL address/size from the decomp reference.

## Functions Improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `_DmaCallback__FUl`

## Match Evidence
- `_DmaCallback__FUl`: **33.333332% -> 98.333336%** (`tools/objdiff-cli diff -p . -u main/RedSound/RedDriver _DmaCallback__FUl`)
- Full build passes with `ninja`.

## Plausibility Rationale
- This callback is used as a DMA completion handler; clearing the driver DMA busy/status flag (`DAT_8032f468`) is expected original behavior.
- Change is minimal and source-plausible (no compiler-coaxing transformations or artificial control flow).

## Technical Details
- The previous stub body (`// TODO`) produced mostly non-matching output for the symbol.
- Implementing the single state-clear write aligns the callback body with expected assembly shape for this 12-byte function.
