### PR TITLE
fontman: improve SetShadow match with signed cast

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -380,7 +380,7 @@ void CFont::SetScaleY(float value)
  */
 void CFont::SetShadow(int enabled)
 {
-	renderFlags = (static_cast<unsigned char>(enabled) << 7) | (renderFlags & 0x7F);
+	renderFlags = static_cast<unsigned char>(static_cast<char>(enabled) << 7) | (renderFlags & 0x7F);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adjust `CFont::SetShadow(int)` in `src/fontman.cpp` to use a signed 8-bit cast before the left shift.
- Keep behavior source-plausible while aligning closer to the original codegen pattern for render flag packing.

## Functions Improved
- Unit: `main/fontman`
- Function: `SetShadow__5CFontFi` (`CFont::SetShadow(int)`)
  - Before: `58.6%`
  - After: `67.8%`

## Match Evidence
- `main/fontman` fuzzy match percent:
  - Before: `59.40913%`
  - After: `59.447304%`
- `objdiff-cli report changes` identifies only one function-level delta in this unit:
  - `SetShadow__5CFontFi` improved from `58.6%` to `67.8%`

## Plausibility Rationale
- The change is a small signedness fix consistent with bitfield flag writes on PPC-era codebases.
- It avoids contrived control flow or compiler-coaxing artifacts; it is a natural source-level expression for packing a boolean/shadow flag into bit 7.

## Technical Details
- Changed:
  - From: `(unsigned char(enabled) << 7) | (renderFlags & 0x7F)`
  - To: `unsigned char(char(enabled) << 7) | (renderFlags & 0x7F)`
- Build validated with `ninja`.
- Progress validated with `build/tools/objdiff-cli report generate` and `report changes` JSON comparison.
