### PR TITLE
RedEntry: implement WaveHistoryManager

### DIFF
--- a/src/RedSound/RedEntry.cpp
+++ b/src/RedSound/RedEntry.cpp
@@ -574,12 +574,52 @@ void CRedEntry::ReentryWaveData(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c1594
+ * PAL Size: 408b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedEntry::WaveHistoryManager(int, int)
+void CRedEntry::WaveHistoryManager(int mode, int waveNo)
 {
-	// TODO
+	int* entry = (int*)this;
+
+	if (mode == 0) {
+		bool inUse = false;
+		if ((*(short*)((int)DAT_8032f3f0 + 0x48e) != 0) && (*(int*)((int)DAT_8032f3f0 + 0x47c) == waveNo)) {
+			inUse = true;
+		}
+
+		if ((*(short*)((int)DAT_8032f3f0 + 0x922) != 0) && (*(int*)((int)DAT_8032f3f0 + 0x910) == waveNo)) {
+			inUse = true;
+		}
+
+		if (!inUse) {
+			int* track = (int*)*(int*)((int)DAT_8032f3f0 + 0xdbc);
+			do {
+				if ((*track != 0) && (track[6] != 0) && (*(short*)(track[6] + 2) == waveNo)) {
+					inUse = true;
+					break;
+				}
+				track += 0x55;
+			} while (track < (int*)(*(int*)((int)DAT_8032f3f0 + 0xdbc) + 0x2a80));
+		}
+
+		if (!inUse) {
+			int index = SearchWaveSequence(waveNo);
+			if ((0xf < index) && (*(int*)(entry[0] + index * 0x10 + 4) == 0)) {
+				WaveHistoryAdd(0x14);
+				*(int*)(entry[0] + index * 0x10 + 4) = 0x14;
+			}
+		}
+	} else {
+		int index = SearchWaveSequence(waveNo);
+		if ((0xf < index) && (*(int*)(entry[0] + index * 0x10 + 4) != 0)) {
+			WaveHistoryDelete(*(int*)(entry[0] + index * 0x10 + 4));
+			*(int*)(entry[0] + index * 0x10 + 4) = 0;
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaced the `CRedEntry::WaveHistoryManager(int, int)` TODO stub with a concrete implementation in `src/RedSound/RedEntry.cpp`.
- Added full PAL metadata header for the function:
  - PAL Address: `0x801c1594`
  - PAL Size: `408b`
- Kept the implementation in the same low-level style already used in `RedEntry.cpp` (pointer/offset based memory access) for source plausibility.

## Functions Improved
- Unit: `main/RedSound/RedEntry`
- Symbol: `WaveHistoryManager__9CRedEntryFii`

## Match Evidence
- Baseline at target selection time: `1.0%` for `WaveHistoryManager__9CRedEntryFii` (from `tools/agent_select_target.py` output).
- After change (`tools/objdiff-cli diff -p . -u main/RedSound/RedEntry WaveHistoryManager__9CRedEntryFii`): `7.1764708%`.
- Unit fuzzy match now reports `23.29383%` for `main/RedSound/RedEntry`.

## Plausibility Rationale
- Logic mirrors expected engine behavior for wave history priority tracking:
  - Detect active usage across current BGM/SE slots and live track list.
  - Add history priority when a wave is no longer active.
  - Remove history priority when the wave becomes active again.
- No contrived temporaries or artificial sequencing were introduced; the code remains maintainable and consistent with surrounding decomp style.

## Technical Details
- Implemented the same three-stage checks reflected by reverse-engineering context:
  1. Current active driver slots at fixed offsets from `DAT_8032f3f0`.
  2. Iteration through the live track table (`+0xdbc`, stride `0x55`, range `+0x2a80`).
  3. History table updates in `entry[0]` with 0x10-byte records and threshold gating (`index > 0xF`).
- Verified with full rebuild (`ninja`) and symbol-level objdiff.
