### PR TITLE
RedExecute: implement SetVoiceAccess/SetVoiceSwitch

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -968,22 +968,42 @@ RedVoiceDATA* _VoiceDataSelect(RedTrackDATA* track, RedNoteDATA* note, int* voic
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c4d08
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SetVoiceAccess(RedTrackDATA*, int)
+void SetVoiceAccess(RedTrackDATA* track, int mask)
 {
-	// TODO
+    int* voiceData = (int*)DAT_8032f444;
+    do {
+        if ((voiceData[0] != 0) && (voiceData[0] == (int)track)) {
+            voiceData[0x24] |= mask;
+        }
+        voiceData += 0x30;
+    } while (voiceData < (int*)DAT_8032f444 + 0xC00);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c4d58
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void SetVoiceSwitch(RedTrackDATA*, int)
+void SetVoiceSwitch(RedTrackDATA* track, int voiceSwitch)
 {
-	// TODO
+    int* voiceData = (int*)DAT_8032f444;
+    do {
+        if ((voiceData[0] != 0) && (voiceData[0] == (int)track)) {
+            voiceData[0x25] = voiceSwitch;
+        }
+        voiceData += 0x30;
+    } while (voiceData < (int*)DAT_8032f444 + 0xC00);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented two TODO helpers in `src/RedSound/RedExecute.cpp`:
- `SetVoiceAccess(RedTrackDATA*, int)`
- `SetVoiceSwitch(RedTrackDATA*, int)`

Both now iterate the active voice table (`DAT_8032f444`) and update per-voice state for entries owned by the input track, matching the observed object layout and access pattern.

## Functions improved
Unit: `main/RedSound/RedExecute`
- `SetVoiceAccess__FP12RedTrackDATAi`: `5.000000% -> 67.250000%` (+62.250000)
- `SetVoiceSwitch__FP12RedTrackDATAi`: `5.555555% -> 63.888890%` (+58.333335)

## Match evidence
`objdiff-cli report generate` before/after for the unit:
- `main/RedSound/RedExecute` fuzzy match: `46.855583% -> 47.377530%` (+0.521947)

No regressions were introduced in this final patch scope.

## Plausibility rationale
The new code is straightforward engine-style source:
- linear scan over fixed-size voice slots
- track-owner equality check before mutation
- direct bitmask/set operations on existing voice state fields

This is behaviorally plausible original source for a voice manager and avoids compiler-coaxing artifacts.

## Technical details
- Added PAL metadata blocks for both functions from Ghidra (`0x801c4d08`, `0x801c4d58`), leaving EN/JP fields as TODO.
- Verified with a full `ninja` build and post-build `objdiff-cli` report comparison.
