### PR TITLE
singmenu: implement DrawSingleBase first-pass decomp

### DIFF
--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -609,12 +609,40 @@ void CMenuPcs::SingCalcChara(float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014935c
+ * PAL Size: 472b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::DrawSingleBase(float)
+void CMenuPcs::DrawSingleBase(float alpha)
 {
-	// TODO
+    DrawInit__8CMenuPcsFv(this);
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_SET);
+    SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(this, 0);
+
+    _GXColor color = {0xFF, 0xFF, 0xFF, static_cast<u8>(FLOAT_80332940 * alpha)};
+    GXSetChanMatColor(GX_COLOR0A0, color);
+
+    SetTexture__8CMenuPcsFQ28CMenuPcs3TEX(this, 0x20);
+    DrawRect__8CMenuPcsFUlfffffffff(this, 0, FLOAT_8033294c, FLOAT_8033294c, FLOAT_803329a4, FLOAT_80332928,
+                                     FLOAT_8033294c, FLOAT_8033294c, FLOAT_80332934, FLOAT_80332934, 0.0f);
+    DrawRect__8CMenuPcsFUlfffffffff(this, 4, FLOAT_8033294c, FLOAT_803329a8, FLOAT_803329a4, FLOAT_80332928,
+                                     FLOAT_8033294c, FLOAT_8033294c, FLOAT_80332934, FLOAT_80332934, 0.0f);
+
+    SetTexture__8CMenuPcsFQ28CMenuPcs3TEX(this, 0x28);
+    float y = 64.0f;
+    float sliceHeight = 32.0f;
+    while (y < 384.0f) {
+        if ((384.0f - y) < sliceHeight) {
+            sliceHeight = 384.0f - y;
+        }
+
+        DrawRect__8CMenuPcsFUlfffffffff(this, 0, FLOAT_8033294c, y, FLOAT_803329a4, sliceHeight, FLOAT_8033294c,
+                                         FLOAT_8033294c, FLOAT_80332934, FLOAT_80332934, 0.0f);
+        y += sliceHeight;
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::DrawSingleBase(float)` in `src/singmenu.cpp` using the PAL Ghidra reference as a first-pass source reconstruction.
- Added the function info header with PAL address/size metadata.
- Kept implementation style consistent with surrounding `DrawSingleStat` rendering setup and texture-rect flow.

## Functions improved
- Unit: `main/singmenu`
- Symbol: `DrawSingleBase__8CMenuPcsFf`

## Match evidence
- Baseline (from `tools/agent_select_target.py` output): **0.8%**
- After patch (`tools/objdiff-cli diff -p . -u main/singmenu -o - DrawSingleBase__8CMenuPcsFf`): **57.372883%**
- Size now matches target symbol size: **472 bytes**

## Plausibility rationale
- The function now follows expected menu rendering flow used across the same translation unit:
  - initialize draw state
  - set blend/vertex format
  - set color alpha from input fade
  - draw base panels with texture 0x20
  - draw repeated middle slices with texture 0x28
- No compiler-coaxing temporaries or artificial control-flow was introduced.

## Technical details
- Implemented the slice loop corresponding to the original repeated vertical strips (`y: 64 -> <384`, clamped 32px slice height).
- Objdiff still reports argument/replacement diffs, but this is a major first-pass jump from near-zero match and brings the symbol to correct overall size.
