### PR TITLE
RedExecute: implement ReverbAreaAlloc

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -91,9 +91,12 @@ void _ReverbNullCallback(AXFX_BUFFERUPDATE* param_1, void*)
  * Address:	TODO
  * Size:	TODO
  */
-void ReverbAreaAlloc(unsigned long)
+void ReverbAreaAlloc(unsigned long size)
 {
-	// TODO
+    DAT_8032f4b0[0] += (u32)size;
+    size = ((u32)size + 0x1F) & ~0x1F;
+    DAT_8032f4b0[1] += (u32)size;
+    RedNew((int)size);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `ReverbAreaAlloc(unsigned long)` in `src/RedSound/RedExecute.cpp`.
- Added aligned allocation accounting and preserved existing allocator call behavior.

## Functions Improved
- Unit: `main/RedSound/RedExecute`
- Function: `ReverbAreaAlloc__FUl` (PAL `0x801c3154`, 88b)

## Match Evidence
- `ReverbAreaAlloc__FUl`: `4.5454545%` -> `45.227272%`
- Unit `main/RedSound/RedExecute` fuzzy: `47.37753%` -> `47.581078%`
- Overall project fuzzy: `45.512535%` -> `45.51447%`

Measured via:
- `tools/objdiff-cli report generate -p . -f json`
- `tools/objdiff-cli report changes /tmp/ffcc_report_before.json /tmp/ffcc_report_after2.json`

## Plausibility Rationale
- The update follows expected original intent for a reverb workspace allocator helper:
  - track raw requested bytes
  - track 0x20-aligned bytes
  - request aligned memory via `RedNew`
- No control-flow tricks or compiler-only coercion were introduced.

## Technical Notes
- The implementation keeps arithmetic explicit in unsigned form and preserves `RedNew` side-effect usage.
- Build and progress verification pass with `ninja`.
