### PR TITLE
memory: improve SetData match in CAmemCacheSet

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -78,26 +78,6 @@ extern "C" void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 extern "C" void __ct__10CAmemCacheFv(void*, int);
 extern "C" void __dt__10CAmemCacheFv(void*, int);
 
-static int calcCacheChecksum(const unsigned char* data, unsigned int size)
-{
-    int checksum = 0x12345678;
-    unsigned int blockCount = size >> 3;
-    while (blockCount != 0) {
-        checksum += data[0] + data[1] + data[2] + data[3] + data[4] + data[5] + data[6] + data[7];
-        data += 8;
-        blockCount--;
-    }
-
-    unsigned int remain = size & 7;
-    while (remain != 0) {
-        checksum += *data;
-        data++;
-        remain--;
-    }
-
-    return checksum;
-}
-
 static int stageGetAllocationMode(CMemory::CStage* stage)
 {
     return *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(stage) + 0x10C);
@@ -1837,9 +1817,26 @@ int CAmemCacheSet::SetData(void* src, int size, CAmemCache::TYPE type, int dmaCo
 
     *reinterpret_cast<int*>(entry + 0x00) = 0;
     *reinterpret_cast<unsigned int*>(entry + 0x08) = allocSize;
-    *reinterpret_cast<int*>(entry + 0x14) = calcCacheChecksum(reinterpret_cast<unsigned char*>(src), allocSize);
+    {
+        const unsigned char* data = reinterpret_cast<unsigned char*>(src);
+        int checksum = 0x12345678;
+        unsigned int blockCount = allocSize >> 3;
+        while (blockCount != 0) {
+            checksum += data[0] + data[1] + data[2] + data[3] + data[4] + data[5] + data[6] + data[7];
+            data += 8;
+            blockCount--;
+        }
 
-    if (entry[0x1A] == 0) {
+        unsigned int remain = allocSize & 7;
+        while (remain != 0) {
+            checksum += *data;
+            data++;
+            remain--;
+        }
+        *reinterpret_cast<int*>(entry + 0x14) = checksum;
+    }
+
+    if (dmaCopy == 0) {
         memcpy(reinterpret_cast<void*>(*reinterpret_cast<int*>(entry + 0x04)), src, *reinterpret_cast<int*>(entry + 0x08));
         DCFlushRange(reinterpret_cast<void*>(*reinterpret_cast<int*>(entry + 0x04)), allocSize);
     } else {


### PR DESCRIPTION
## Summary
- Refactored `CAmemCacheSet::SetData` in `src/memory.cpp` to better match original codegen.
- Inlined the cache checksum loop inside `SetData` instead of routing through a helper.
- Switched the copy/flush branch condition to `dmaCopy` directly in `SetData`.
- Removed now-unused local helper `calcCacheChecksum`.

## Functions improved
- Unit: `main/memory`
- Symbol: `SetData__13CAmemCacheSetFPviQ210CAmemCache4TYPEi`
  - Before: `34.48718%`
  - After: `35.37607%`

## Match evidence
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memorydiff_reset.json`
  - `build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memorydiff_final.json`
- Result: `SetData__13CAmemCacheSetFPviQ210CAmemCache4TYPEi` improved by `+0.88889` percentage points.
- Spot-checks remained stable:
  - `drawHeapTitle__Q27CMemory6CStageFi`: `7.5454545%` (no change)
  - `drawHeapBar__Q27CMemory6CStageFi`: `16.018383%` (no change)

## Plausibility rationale
- The checksum logic is straightforward byte-accumulation and is plausible as in-function code in performance-sensitive memory/cache code.
- Branching on `dmaCopy` directly is natural source-level logic and avoids unnecessary state re-read from entry metadata.
- No contrived temporaries, hardcoded offset tricks, or readability regressions were introduced.

## Technical details
- The primary assembly alignment gain came from matching the structure of `SetData`'s checksum and branch flow more closely.
- This was validated through iterative `objdiff` checks after each small change and reverting regressive attempts.
