### PR TITLE
main/THPSimple: improve THPSimpleCalcNeedMemory match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -301,20 +301,21 @@ s32 THPSimpleClose(void)
  */
 s32 THPSimpleCalcNeedMemory(void)
 {
-    if (SimpleControl.isOpen == 0) {
-        return 0;
+    if (SimpleControl.isOpen != 0) {
+        u32 framePixels = static_cast<u32>(SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize);
+        s32 need = ((SimpleControl.header.mBufferSize + 0x1F) * 8) & ~0xFF;
+        need += (framePixels + 0x1F) & ~0x1F;
+        need += ((framePixels >> 2) + 0x1F) & ~0x1F;
+        need += ((framePixels >> 2) + 0x1F) & ~0x1F;
+
+        if (SimpleControl.hasAudio != 0) {
+            need += ((SimpleControl.header.mAudioMaxSamples * 4 + 0x1F) & ~0x1F) * 3;
+        }
+
+        return need + 0x1000;
     }
 
-    s32 need = ((SimpleControl.header.mBufferSize + 0x1F) * 8) & ~0xFF;
-    need += (SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize + 0x1F) & ~0x1F;
-    need += (((SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize) >> 2) + 0x1F) & ~0x1F;
-    need += (((SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize) >> 2) + 0x1F) & ~0x1F;
-
-    if (SimpleControl.hasAudio != 0) {
-        need += ((SimpleControl.header.mAudioMaxSamples * 4 + 0x1F) & ~0x1F) * 3;
-    }
-
-    return need + 0x1000;
+    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `THPSimpleCalcNeedMemory` arithmetic to use an explicit unsigned frame-pixel intermediate and local accumulation within the open-state branch.
- Preserved behavior while changing expression structure to better match the original compiler output.

## Functions improved
- Unit: `main/THPSimple`
- Symbol: `THPSimpleCalcNeedMemory`

## Match evidence
- `THPSimpleCalcNeedMemory`: **84.0625% -> 94.375%**
- Unit `.text` match (`main/THPSimple`): **71.5098% -> 71.71854%**
- Build check: `ninja` passes after change.

## Plausibility rationale
- The change is source-plausible: it clarifies `framePixels` as a shared intermediate and uses natural unsigned shifting for chroma plane sizing.
- Control flow remains idiomatic and straightforward (`isOpen` gate, conditional audio buffer addition, final aligned total).
- No contrived temporaries or artificial sequencing were introduced.

## Technical details
- Introduced `u32 framePixels` for repeated `mXSize * mYSize` usage.
- Reused that intermediate for luma and two chroma alignment computations.
- Structured the function as `if (isOpen != 0) { ... return total; } return 0;` which aligned branch/codegen better in objdiff.
