### PR TITLE
MenuUtil: implement CalcOptionMenu first-pass decomp

### DIFF
--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -1,4 +1,7 @@
 #include "ffcc/MenuUtil.h"
+#include "ffcc/p_game.h"
+#include "ffcc/pad.h"
+#include "ffcc/sound.h"
 
 extern "C" float GetWidth__5CFontFPc(CFont*, const char*);
 extern "C" void SetMargin__5CFontFf(float, CFont*);
@@ -14,8 +17,26 @@ extern "C" void SetPosY__5CFontFf(float, CFont*);
 extern "C" void Draw__5CFontFPc(CFont*, const char*);
 
 extern float lbl_80333558;
+extern float lbl_8033354C;
 extern float lbl_8033356C;
 extern float lbl_8033358C;
+extern float lbl_80333598;
+extern double lbl_80333640;
+extern float lbl_80333648;
+extern float lbl_8033364C;
+extern float lbl_80333650;
+
+extern "C" int __cntlzw(unsigned int);
+
+static unsigned short GetMenuPress()
+{
+	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+		return 0;
+	}
+
+	__cntlzw(static_cast<unsigned int>(Pad._448_4_));
+	return static_cast<unsigned short>(Pad._8_2_);
+}
 
 /*
  * --INFO--
@@ -176,12 +197,265 @@ void CMenuPcs::InitOptionMenuParam()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80179328
+ * PAL Size: 2560b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::CalcOptionMenu()
 {
-	// TODO
+	unsigned char* const self = reinterpret_cast<unsigned char*>(this);
+	bool optionChanged = false;
+
+	const float minValue = lbl_8033354C;
+	const float maxValue = lbl_8033356C;
+	const float animStep = lbl_80333598;
+	const float animStep2 = lbl_8033364C;
+	const unsigned short press = GetMenuPress();
+
+	signed char& menuState = *reinterpret_cast<signed char*>(self + 0x9C);
+	float& openAnim = *reinterpret_cast<float*>(self + 0x98);
+	float& rowAnim = *reinterpret_cast<float*>(self + 0xA0);
+	float& colAnim = *reinterpret_cast<float*>(self + 0xA8);
+	signed char& animPhase = *reinterpret_cast<signed char*>(self + 0xA4);
+	signed char& animCounter = *reinterpret_cast<signed char*>(self + 0xAC);
+	signed char& optionIndex = *reinterpret_cast<signed char*>(self + 0x8E);
+	signed char& gameInitMode = *reinterpret_cast<signed char*>(self + 0x8F);
+	signed char& stereoMode = *reinterpret_cast<signed char*>(self + 0x90);
+	signed char& bgmVolume = *reinterpret_cast<signed char*>(self + 0x91);
+	signed char& seVolume = *reinterpret_cast<signed char*>(self + 0x92);
+	signed char& leftHintTimer = *reinterpret_cast<signed char*>(self + 0x93);
+	signed char& rightHintTimer = *reinterpret_cast<signed char*>(self + 0x94);
+	int& specialModeEdit = *reinterpret_cast<int*>(self + 0xB0);
+	signed char& specialModeCursor = *reinterpret_cast<signed char*>(self + 0xB4);
+	signed char* const specialModeFlags = reinterpret_cast<signed char*>(self + 0xB5);
+
+	if (menuState == 0) {
+		openAnim += lbl_80333648;
+		if (openAnim < maxValue) {
+			return;
+		}
+
+		menuState = 1;
+		openAnim = maxValue;
+		return;
+	}
+
+	if (menuState == 2) {
+		openAnim -= lbl_80333648;
+		rowAnim -= animStep;
+		colAnim -= animStep2;
+
+		if (rowAnim <= minValue) {
+			rowAnim = minValue;
+		}
+		if (colAnim <= minValue) {
+			colAnim = minValue;
+		}
+		if (static_cast<int>(openAnim / lbl_80333648) == 5) {
+			Sound.PlaySe(0x32, 0x40, 0x7F, 0);
+		}
+		if (openAnim > minValue) {
+			return;
+		}
+
+		*reinterpret_cast<unsigned short*>(*reinterpret_cast<int*>(self + 0x82C) + 0x20) = 1;
+		optionIndex = 0;
+		menuState = 0;
+		openAnim = minValue;
+		rowAnim = minValue;
+		colAnim = minValue;
+		animCounter = 0;
+		animPhase = 0;
+		return;
+	}
+
+	if (menuState == 3) {
+		return;
+	}
+
+	if (animPhase == 0) {
+		rowAnim += animStep;
+		animCounter++;
+		if (rowAnim >= maxValue) {
+			animPhase = 1;
+			rowAnim = maxValue;
+		}
+	} else if (animPhase == 1) {
+		colAnim += animStep2;
+		if (colAnim >= maxValue) {
+			animPhase = 2;
+			colAnim = maxValue;
+		}
+	}
+
+	if (leftHintTimer > 0) {
+		leftHintTimer--;
+	}
+	if (rightHintTimer > 0) {
+		rightHintTimer--;
+	}
+
+	if ((specialModeEdit == 0) && ((press & 8) != 0)) {
+		leftHintTimer = 0;
+		rightHintTimer = 0;
+		optionIndex--;
+		if (optionIndex < 0) {
+			optionIndex = 4;
+		}
+		rowAnim = minValue;
+		colAnim = minValue;
+		animCounter = 0;
+		animPhase = 0;
+		Sound.PlaySe(1, 0x40, 0x7F, 0);
+	} else if ((specialModeEdit == 0) && ((press & 4) != 0)) {
+		leftHintTimer = 0;
+		rightHintTimer = 0;
+		optionIndex++;
+		if (optionIndex > 4) {
+			optionIndex = 0;
+		}
+		rowAnim = minValue;
+		colAnim = minValue;
+		animCounter = 0;
+		animPhase = 0;
+		Sound.PlaySe(1, 0x40, 0x7F, 0);
+	}
+
+	if (specialModeEdit == 0) {
+		const unsigned short press2 = GetMenuPress();
+		if ((press2 & 0x200) != 0) {
+			menuState = 2;
+			Sound.PlaySe(3, 0x40, 0x7F, 0);
+			return;
+		}
+	}
+
+	if ((animPhase == 0) || (animPhase == 1)) {
+		return;
+	}
+
+	if ((press & 1) != 0) {
+		if (optionIndex == 2) {
+			leftHintTimer = 3;
+			rightHintTimer = 0;
+			bgmVolume--;
+			if (bgmVolume < 0) {
+				bgmVolume = 0;
+			}
+		} else if (optionIndex < 2) {
+			if (optionIndex == 0) {
+				gameInitMode--;
+				if (gameInitMode < 0) {
+					gameInitMode = 1;
+				}
+			} else if (optionIndex == 1) {
+				stereoMode--;
+				if (stereoMode < 0) {
+					stereoMode = 1;
+				}
+			}
+		} else if (optionIndex == 4) {
+			if (specialModeEdit != 0) {
+				specialModeFlags[static_cast<signed char>(specialModeCursor)]--;
+				if (specialModeFlags[static_cast<signed char>(specialModeCursor)] < 0) {
+					specialModeFlags[static_cast<signed char>(specialModeCursor)] = 1;
+				}
+			}
+		} else if (optionIndex == 3) {
+			leftHintTimer = 3;
+			rightHintTimer = 0;
+			seVolume--;
+			if (seVolume < 0) {
+				seVolume = 0;
+			}
+		}
+
+		Sound.PlaySe(1, 0x40, 0x7F, 0);
+		optionChanged = true;
+	} else if ((press & 2) != 0) {
+		if (optionIndex == 2) {
+			rightHintTimer = 3;
+			leftHintTimer = 0;
+			bgmVolume++;
+			if (bgmVolume > 0xC) {
+				bgmVolume = 0xC;
+			}
+		} else if (optionIndex < 2) {
+			if (optionIndex == 0) {
+				gameInitMode++;
+				if (gameInitMode > 1) {
+					gameInitMode = 0;
+				}
+			} else if (optionIndex == 1) {
+				stereoMode++;
+				if (stereoMode > 1) {
+					stereoMode = 0;
+				}
+			}
+		} else if (optionIndex == 4) {
+			if (specialModeEdit != 0) {
+				specialModeFlags[static_cast<signed char>(specialModeCursor)]++;
+				if (specialModeFlags[static_cast<signed char>(specialModeCursor)] > 1) {
+					specialModeFlags[static_cast<signed char>(specialModeCursor)] = 0;
+				}
+			}
+		} else if (optionIndex == 3) {
+			rightHintTimer = 3;
+			leftHintTimer = 0;
+			seVolume++;
+			if (seVolume > 0xC) {
+				seVolume = 0xC;
+			}
+		}
+
+		Sound.PlaySe(1, 0x40, 0x7F, 0);
+		optionChanged = true;
+	}
+
+	if (optionIndex == 4) {
+		const unsigned short press3 = GetMenuPress();
+		if ((press3 & 0x100) != 0) {
+			if (specialModeEdit == 0) {
+				specialModeCursor = 0;
+				specialModeEdit = 1;
+				Sound.PlaySe(2, 0x40, 0x7F, 0);
+			}
+		} else if (specialModeEdit != 0) {
+			const unsigned short press4 = GetMenuPress();
+			if ((press4 & 0x200) != 0) {
+				specialModeCursor = 0;
+				specialModeEdit = 0;
+				Sound.PlaySe(3, 0x40, 0x7F, 0);
+
+				Game.game.m_gameWork.m_spModeFlags[0] = static_cast<unsigned char>(specialModeFlags[0]);
+				Game.game.m_gameWork.m_spModeFlags[1] = static_cast<unsigned char>(specialModeFlags[1]);
+				Game.game.m_gameWork.m_spModeFlags[2] = static_cast<unsigned char>(specialModeFlags[2]);
+				Game.game.m_gameWork.m_spModeFlags[3] = static_cast<unsigned char>(specialModeFlags[3]);
+			} else if ((press & 8) != 0) {
+				specialModeCursor--;
+				if (specialModeCursor < 0) {
+					specialModeCursor = 3;
+				}
+				Sound.PlaySe(1, 0x40, 0x7F, 0);
+			} else if ((press & 4) != 0) {
+				specialModeCursor++;
+				if (specialModeCursor > 3) {
+					specialModeCursor = 0;
+				}
+				Sound.PlaySe(1, 0x40, 0x7F, 0);
+			}
+		}
+	}
+
+	if (optionChanged) {
+		Game.game.m_gameWork.m_gameInitFlag = static_cast<unsigned char>(gameInitMode == 0);
+		Sound.SetStereo(stereoMode == 0);
+		Sound.SetSeMasterVolume(static_cast<int>(lbl_80333650 * static_cast<float>(seVolume)));
+		Sound.SetBgmMasterVolume(static_cast<int>(lbl_80333650 * static_cast<float>(bgmVolume)));
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::CalcOptionMenu` in `src/MenuUtil.cpp` as a first-pass decompilation.
- Replaced the stub with full option menu state/input/update flow using existing project style (offset-based member access where class layout is still incomplete).
- Added PAL metadata block for the function (`0x80179328`, `2560b`).

## Functions Improved
- Unit: `main/MenuUtil`
- Symbol: `CalcOptionMenu__8CMenuPcsFv`

## Match Evidence
- Selector baseline: `0.2%` for `CalcOptionMenu__8CMenuPcsFv`
- After this change (`build/tools/objdiff-cli diff -p . -u main/MenuUtil -o - CalcOptionMenu__8CMenuPcsFv`):
  - `match_percent: 65.33281`

## Plausibility Rationale
- The implementation follows the recovered menu state machine and input handling behavior directly from decompilation, rather than using artificial temporary variables solely to force codegen.
- Updates are behavior-driven and map to established FFCC menu patterns already used in nearby menu code (input polling, cursor movement, staged animation progression, option clamping, and sound feedback).
- Pointer-offset field access is consistent with current repo practice for large partially-defined classes and keeps the source coherent while layout reconstruction is still in progress.

## Technical Details
- Added menu open/close animation state handling (`0x98/0x9C/0xA0/0xA4/0xA8/0xAC` fields).
- Added option row navigation and value adjustment logic (`0x8E..0x94` fields).
- Added special mode sub-menu editing and commit-back to `Game.game.m_gameWork.m_spModeFlags` (`0xB0..0xB8` fields).
- Wired sound and runtime option propagation (`Sound.PlaySe`, `Sound.SetStereo`, `Sound.SetSeMasterVolume`, `Sound.SetBgmMasterVolume`).
