### PR TITLE
Improve CreateBoundaryBox match in p_MaterialEditor

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -554,43 +554,38 @@ void CMaterialEditorPcs::drawViewer()
  */
 void CMaterialEditorPcs::CreateBoundaryBox(Vec& minPos, Vec& maxPos, long count, const Vec* points)
 {
-    float* minVals = reinterpret_cast<float*>(&minPos);
-    float* maxVals = reinterpret_cast<float*>(&maxPos);
-    const float* src = reinterpret_cast<const float*>(points);
+    minPos.x = lbl_8032FCAC;
+    minPos.y = lbl_8032FCAC;
+    minPos.z = lbl_8032FCAC;
+    maxPos.x = lbl_8032FCB0;
+    maxPos.y = lbl_8032FCB0;
+    maxPos.z = lbl_8032FCB0;
 
-    minVals[0] = lbl_8032FCAC;
-    minVals[1] = lbl_8032FCAC;
-    minVals[2] = lbl_8032FCAC;
-
-    maxVals[0] = lbl_8032FCB0;
-    maxVals[1] = lbl_8032FCB0;
-    maxVals[2] = lbl_8032FCB0;
-
-    if (count < 1) {
+    if (count <= 0) {
         return;
     }
 
     do {
-        if (src[0] < minVals[0]) {
-            minVals[0] = src[0];
+        if (minPos.x > points->x) {
+            minPos.x = points->x;
         }
-        if (src[1] < minVals[1]) {
-            minVals[1] = src[1];
+        if (minPos.y > points->y) {
+            minPos.y = points->y;
         }
-        if (src[2] < minVals[2]) {
-            minVals[2] = src[2];
+        if (minPos.z > points->z) {
+            minPos.z = points->z;
         }
-        if (maxVals[0] < src[0]) {
-            maxVals[0] = src[0];
+        if (maxPos.x < points->x) {
+            maxPos.x = points->x;
         }
-        if (maxVals[1] < src[1]) {
-            maxVals[1] = src[1];
+        if (maxPos.y < points->y) {
+            maxPos.y = points->y;
         }
-        if (maxVals[2] < src[2]) {
-            maxVals[2] = src[2];
+        if (maxPos.z < points->z) {
+            maxPos.z = points->z;
         }
 
-        src += 3;
+        points += 1;
         count -= 1;
     } while (count != 0);
 }


### PR DESCRIPTION
## Summary
Refactored `CMaterialEditorPcs::CreateBoundaryBox(Vec&, Vec&, long, const Vec*)` in `src/p_MaterialEditor.cpp` to use direct `Vec` field access and comparison flow closer to the original compiler output.

## Functions improved
- Unit: `main/p_MaterialEditor`
- Symbol: `CreateBoundaryBox__18CMaterialEditorPcsFR3VecR3VeclPC3Vec`

## Match evidence
- Before: **51.795456%**
- After: **54.31818%**
- Delta: **+2.522724%**

Measured with:
- `build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - CreateBoundaryBox__18CMaterialEditorPcsFR3VecR3VeclPC3Vec`

Also verified `drawViewer__18CMaterialEditorPcsFv` remained unchanged at **19.062582%** after reverting an exploratory tweak.

## Plausibility rationale
The updated code is a straightforward, idiomatic bounding-box implementation over `Vec` coordinates (`x/y/z`) and avoids artificial compiler-coaxing patterns. It improves codegen alignment while keeping behavior and readability consistent with likely original source intent.

## Technical details
- Removed float-array reinterpretation and replaced with explicit `Vec` component assignments.
- Used direct min/max comparisons on `x/y/z` fields with pointer iteration over input points.
- Kept control flow simple (`count <= 0` early return, do-while traversal) while improving generated instruction ordering against target.
