### PR TITLE
materialman: decompile CMaterialMan::InitVtxFmt

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1732,12 +1732,55 @@ void CMaterialMan::SetShadowBound(CMapShadow::TARGET target, CBound* bound, floa
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8003ddc4
+ * PAL Size: 660b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMaterialMan::InitVtxFmt(int, _GXCompType, int, _GXCompType, int, _GXCompType, int)
+void CMaterialMan::InitVtxFmt(
+    int formatFlags, _GXCompType positionType, int positionFrac, _GXCompType colorType, int colorFrac,
+    _GXCompType texCoordType, int texCoordFrac)
 {
-	// TODO
+    if ((formatFlags & 1) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)0, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)0, (_GXAttr)10, (_GXCompCnt)0, colorType, colorFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)0, (_GXAttr)11, (_GXCompCnt)1, (_GXCompType)5, 0);
+        GXSetVtxAttrFmt((_GXVtxFmt)0, (_GXAttr)13, (_GXCompCnt)1, texCoordType, texCoordFrac);
+    }
+    if ((formatFlags & 2) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)1, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)1, (_GXAttr)0x19, (_GXCompCnt)1, colorType, colorFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)1, (_GXAttr)11, (_GXCompCnt)1, (_GXCompType)5, 0);
+        GXSetVtxAttrFmt((_GXVtxFmt)1, (_GXAttr)13, (_GXCompCnt)1, texCoordType, texCoordFrac);
+    }
+    if ((formatFlags & 4) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)2, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)2, (_GXAttr)10, (_GXCompCnt)0, colorType, colorFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)2, (_GXAttr)11, (_GXCompCnt)1, (_GXCompType)5, 0);
+        GXSetVtxAttrFmt((_GXVtxFmt)2, (_GXAttr)13, (_GXCompCnt)1, texCoordType, texCoordFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)2, (_GXAttr)14, (_GXCompCnt)1, texCoordType, texCoordFrac);
+    }
+    if ((formatFlags & 8) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)3, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)3, (_GXAttr)10, (_GXCompCnt)0, colorType, colorFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)3, (_GXAttr)11, (_GXCompCnt)1, (_GXCompType)5, 0);
+    }
+    if ((formatFlags & 0x10) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)4, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)4, (_GXAttr)11, (_GXCompCnt)1, (_GXCompType)5, 0);
+        GXSetVtxAttrFmt((_GXVtxFmt)4, (_GXAttr)13, (_GXCompCnt)1, texCoordType, texCoordFrac);
+    }
+    if ((formatFlags & 0x20) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)5, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+    }
+    if ((formatFlags & 0x40) != 0) {
+        GXSetVtxAttrFmt((_GXVtxFmt)6, (_GXAttr)9, (_GXCompCnt)1, positionType, positionFrac);
+        GXSetVtxAttrFmt((_GXVtxFmt)6, (_GXAttr)11, (_GXCompCnt)1, (_GXCompType)5, 0);
+    }
+
+    *reinterpret_cast<unsigned int*>(Ptr(this, 0x44)) = 0xFFFFFFFF;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Decompiles `CMaterialMan::InitVtxFmt` in `src/materialman.cpp` from a TODO stub into a full implementation.
- Adds PAL metadata header for the function:
  - PAL Address: `0x8003ddc4`
  - PAL Size: `660b`
- Implements the per-format `GXSetVtxAttrFmt` setup flow and updates the runtime state word at `this + 0x44` to `0xFFFFFFFF`.

## Functions improved
- Unit: `main/materialman`
- Symbol: `InitVtxFmt__12CMaterialManFi11_GXCompTypei11_GXCompTypei11_GXCompTypei`

## Match evidence
- `build/tools/objdiff-cli diff -p . -u main/materialman -o - InitVtxFmt__12CMaterialManFi11_GXCompTypei11_GXCompTypei11_GXCompTypei`
- Before: `0.6060606%`
- After: `97.21212%`
- Diff profile changed from a near-total mismatch (`164 DIFF_DELETE`) to a small residual mismatch (`3 DIFF_INSERT`, `1 DIFF_DELETE`, `1 DIFF_REPLACE`).

## Plausibility rationale
- The implementation is a direct, idiomatic GX vertex-format setup routine for this engine style:
  - uses `formatFlags` bit tests to configure each `GXVtxFmt`
  - configures position/color/normal/texcoord attributes in the expected order
  - updates manager state at the end
- No contrived temporaries, artificial reordering, or opaque coercions were introduced beyond enum casts already common in this codebase.

## Technical details
- Used the PAL Ghidra function reference (`resources/ghidra-decomp-1-31-2026/8003ddc4_InitVtxFmt__12CMaterialManFi11_GXCompTypei11_GXCompTypei11_GXCompTypei.c`) as structural guidance.
- Verified compile/build success with `ninja`.
- Verified symbol-level improvement with objdiff JSON output (`-o -`) and parsed match metrics.
