### PR TITLE
RedEntry: implement music history/search helpers and fix return signatures

### DIFF
--- a/include/ffcc/RedSound/RedEntry.h
+++ b/include/ffcc/RedSound/RedEntry.h
@@ -35,7 +35,7 @@ public:
 	void SeSepHistoryAdd();
 	void SeSepHistoryDelete(int);
 	void SeSepHistoryChoice(RedHistoryBANK*);
-	void SearchSeSepSequence(int);
+	int SearchSeSepSequence(int);
 	void SeSepMemoryFree(RedHistoryBANK*);
 	void SeSepOldDelete();
 	void SeSepHeadAdd(RedSeSepHEAD*);
@@ -50,11 +50,11 @@ public:
 	void MusicHistoryAdd();
 	void MusicHistoryDelete(int);
 	void MusicHistoryChoice(RedHistoryBANK*);
-	void SearchMusicSequence(int);
+	int SearchMusicSequence(int);
 	void MusicMemoryFree(RedHistoryBANK*);
 	void MusicOldClear();
 	void MusicOldChoice();
-	void SearchMusicBank(int);
+	int* SearchMusicBank(int);
 	void ReentryMusicData(int);
 	void MusicHistoryManager(int, int);
 	void MusicHeadAdd(RedMusicHEAD*);

--- a/src/RedSound/RedEntry.cpp
+++ b/src/RedSound/RedEntry.cpp
@@ -759,12 +759,37 @@ void CRedEntry::SeSepHistoryChoice(RedHistoryBANK*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c1b84
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedEntry::SearchSeSepSequence(int)
+int CRedEntry::SearchSeSepSequence(int seNo)
 {
-	// TODO
+	int* const base = reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<int>(this) + 4));
+	int* seSepBank = base;
+
+	if (seNo == -1) {
+		do {
+			if (seSepBank[3] != 0) {
+				int offset = reinterpret_cast<int>(seSepBank) - reinterpret_cast<int>(base);
+				return (offset >> 4) + ((offset < 0) && ((offset & 0xF) != 0));
+			}
+			seSepBank += 4;
+		} while ((unsigned int)seSepBank < (unsigned int)base + 0x1000);
+	} else {
+		do {
+			if ((seSepBank[3] != 0) && (seSepBank[0] == seNo)) {
+				int offset = reinterpret_cast<int>(seSepBank) - reinterpret_cast<int>(base);
+				return (offset >> 4) + ((offset < 0) && ((offset & 0xF) != 0));
+			}
+			seSepBank += 4;
+		} while ((unsigned int)seSepBank < (unsigned int)base + 0x1000);
+	}
+
+	return -1;
 }
 
 /*
@@ -955,12 +980,27 @@ void CRedEntry::MusicHistoryChoice(RedHistoryBANK*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c2610
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedEntry::SearchMusicSequence(int)
+int CRedEntry::SearchMusicSequence(int musicNo)
 {
-	// TODO
+	int* const base = reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<int>(this) + 8));
+	int* musicBank = base;
+
+	while ((musicBank[3] == 0) || (musicBank[0] != musicNo)) {
+		musicBank += 4;
+		if (musicBank >= reinterpret_cast<int*>(reinterpret_cast<int>(base) + 0x40)) {
+			return -1;
+		}
+	}
+
+	int offset = reinterpret_cast<int>(musicBank) - reinterpret_cast<int>(base);
+	return (offset >> 4) + ((offset < 0) && ((offset & 0xF) != 0));
 }
 
 /*
@@ -995,12 +1035,24 @@ void CRedEntry::MusicOldChoice()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c27d8
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedEntry::SearchMusicBank(int)
+int* CRedEntry::SearchMusicBank(int musicNo)
 {
-	// TODO
+	int* musicBank = reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<int>(this) + 8));
+	do {
+		if (musicBank[0] == musicNo) {
+			return musicBank;
+		}
+		musicBank += 4;
+	} while (musicBank < reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<int>(this) + 8) + 0x40));
+
+	return 0;
 }
 
 /*
@@ -1015,12 +1067,44 @@ void CRedEntry::ReentryMusicData(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c2874
+ * PAL Size: 324b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CRedEntry::MusicHistoryManager(int, int)
+void CRedEntry::MusicHistoryManager(int mode, int musicNo)
 {
-	// TODO
+	if (mode == 0) {
+		bool inUse = false;
+		if ((*reinterpret_cast<short*>((int)DAT_8032f3f0 + 0x48E) != 0)
+		    && (*reinterpret_cast<int*>((int)DAT_8032f3f0 + 0x470) == musicNo)) {
+			inUse = true;
+		}
+		if ((*reinterpret_cast<short*>((int)DAT_8032f3f0 + 0x922) != 0)
+		    && (*reinterpret_cast<int*>((int)DAT_8032f3f0 + 0x904) == musicNo)) {
+			inUse = true;
+		}
+
+		int musicSeq = SearchMusicSequence(musicNo);
+		if ((!inUse) && (musicSeq >= 0)) {
+			int* const musicBank = reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<int>(this) + 8));
+			if (musicBank[musicSeq * 4 + 1] == 0) {
+				MusicHistoryAdd();
+				musicBank[musicSeq * 4 + 1] = 1;
+			}
+		}
+	} else {
+		int musicSeq = SearchMusicSequence(musicNo);
+		if (musicSeq >= 0) {
+			int* const musicBank = reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<int>(this) + 8));
+			if (musicBank[musicSeq * 4 + 1] != 0) {
+				MusicHistoryDelete(musicBank[musicSeq * 4 + 1]);
+				musicBank[musicSeq * 4 + 1] = 0;
+			}
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Corrected `CRedEntry` method signatures to match call/usage behavior in PAL decomp:
  - `SearchSeSepSequence(int)` now returns `int`
  - `SearchMusicSequence(int)` now returns `int`
  - `SearchMusicBank(int)` now returns `int*`
- Implemented `SearchSeSepSequence`, `SearchMusicSequence`, and `SearchMusicBank` with pointer-walk logic matching RedEntry bank layouts.
- Implemented `MusicHistoryManager(int mode, int musicNo)` with active-use checks and history add/delete updates.
- Left `SeSepHistoryManager` unchanged from baseline stub after testing a pass that regressed matching.

## Functions improved
Unit: `main/RedSound/RedEntry`

- `MusicHistoryManager__9CRedEntryFii` (324b): **1.2345679% -> 6.814815%**
- `SearchSeSepSequence__9CRedEntryFi` (156b): **2.5641026% -> 34.179485%**
- `SearchMusicSequence__9CRedEntryFi` (92b): **4.347826% -> 5.3913045%**
- `SearchMusicBank__9CRedEntryFi` (68b): **5.882353% -> 71.17647%**

Reference check (no regression target kept flat):
- `SeSepHistoryManager__9CRedEntryFii` (320b): **1.25% -> 1.25%**

## Match evidence
- Built with `ninja` (PAL / `GCCP01`) successfully.
- Compared baseline (`origin/main`) vs this branch using `tools/objdiff-cli v3.6.1` JSON one-shot diffs on the symbols above.
- Improvements are from real control-flow/data-access changes (not renames/formatting only):
  - bank traversal now emits sequence-index calculations instead of stub returns
  - history manager now emits active-track checks and conditional history updates

## Plausibility rationale
- Changes are source-plausible for the existing RedSound architecture: they use existing bank layouts, established pointer arithmetic style in this file, and existing helper calls (`MusicHistoryAdd`, `MusicHistoryDelete`).
- No contrived compiler coaxing patterns were introduced; control flow matches decomp behavior while staying idiomatic with current code style.
