### PR TITLE
goout: improve SetMenuStr varargs/message buffer matching

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -406,25 +406,34 @@ void CGoOutMenu::SetMenuStr(long timer, int lineCount, ...)
 {
     CMenuPcsGoOutLayout& menuPcsLayout = *reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs);
     va_list args;
+    unsigned int leadingZeros;
+    int indexBase;
+    int i;
+    int* winMessage;
+    const char** winMessageBuffer;
+    short messageIndex;
 
     field_0x38 ^= 1;
-    *reinterpret_cast<int*>(const_cast<char*>(GetWinMess__8CMenuPcsFi(&MenuPcs, field_0x38 + 0x22))) = lineCount;
+    winMessage = reinterpret_cast<int*>(const_cast<char*>(GetWinMess__8CMenuPcsFi(&MenuPcs, field_0x38 + 0x22)));
+    *winMessage = lineCount;
 
     va_start(args, lineCount);
-    const unsigned int indexBase = (~-((static_cast<unsigned int>(__cntlzw(field_0x38)) >> 5) & 1) & 10);
-    const char* const* msgTable = GetMcWinMessBuff__8CMenuPcsFi(&MenuPcs, 2);
-    for (int i = 0; i < lineCount; i++) {
-        const_cast<const char**>(msgTable)[indexBase + i] = va_arg(args, const char*);
+    leadingZeros = static_cast<unsigned int>(__cntlzw(static_cast<unsigned int>(field_0x38)));
+    indexBase = static_cast<int>(~-(leadingZeros >> 5 & 1U) & 10U);
+    winMessageBuffer = const_cast<const char**>(GetMcWinMessBuff__8CMenuPcsFi(&MenuPcs, 2));
+    for (i = 0; i < lineCount; i++) {
+        winMessageBuffer[indexBase + i] = va_arg(args, const char*);
     }
     va_end(args);
 
+    messageIndex = field_0x38;
     if (field_0x36 >= 0) {
-        WriteMenuShort(menuPcsLayout.field_2120, 0xA, 2);
-        WriteMenuShort(menuPcsLayout.field_2092, 0x22, 0);
+        *reinterpret_cast<short*>(menuPcsLayout.field_2120 + 0xA) = 2;
+        *reinterpret_cast<short*>(menuPcsLayout.field_2092 + 0x22) = 0;
     }
 
     field_0x45 = 0;
-    field_0x34 = field_0x38 + 0x22;
+    field_0x34 = messageIndex + 0x22;
     field_0x48 = 0;
     field_0x3c = timer;
 }


### PR DESCRIPTION
## Summary
- Refined `CGoOutMenu::SetMenuStr(long, int, ...)` in `src/goout.cpp` to better match original codegen.
- Switched to explicit local temporaries (`winMessage`, `winMessageBuffer`, `messageIndex`) and direct menu-window writes instead of helper abstractions.
- Kept behavior unchanged while aligning varargs message-buffer indexing and state-field assignment flow.

## Functions improved
- Unit: `main/goout`
- Symbol: `SetMenuStr__10CGoOutMenuFlie`
  - Before: `66.093025%`
  - After: `68.30232%`
  - Size: `344b`

## Match evidence
- `objdiff-cli diff -p . -u main/goout -o - SetMenuStr__10CGoOutMenuFlie`
  - Improved symbol match by `+2.209295` points.
- Unit `.text` match also improved:
  - Before: `34.820156%`
  - After: `34.86098%`

## Plausibility rationale
- The update removes extra abstraction-only constructs (`const_cast` + helper indirection in this hot path) and uses straightforward pointer/field operations that match existing low-level menu code style in this file.
- No control-flow or gameplay behavior was changed; this is a codegen-alignment cleanup consistent with plausible original source.

## Technical details
- Preserved varargs handling but restructured locals to better reflect expected register/stack usage.
- Replaced helper-based short writes in this function with direct writes through known menu-layout pointers to match surrounding original-style code paths.
