### PR TITLE
bonus_menu: implement ClrBattleItem first-pass decomp

### DIFF
--- a/src/bonus_menu.cpp
+++ b/src/bonus_menu.cpp
@@ -1,4 +1,6 @@
 #include "ffcc/bonus_menu.h"
+#include "ffcc/gobjwork.h"
+#include "ffcc/p_game.h"
 
 /*
  * --INFO--
@@ -237,10 +239,20 @@ void CMenuPcs::GetAllPadOn()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80133108
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::ClrBattleItem()
 {
-	// TODO
+	for (int i = 0; i < 4; i++) {
+		CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(Game.game.m_scriptFoodBase[i]);
+		if (caravanWork != 0) {
+			caravanWork->SafeDeleteTempItem();
+			caravanWork->SortBeforeReturnWorldMap();
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::ClrBattleItem()` in `src/bonus_menu.cpp`.
- Added correct PAL metadata block for the function.
- Wired required includes for `CCaravanWork` and `Game` process state access.

## Functions improved
- `main/bonus_menu` / `ClrBattleItem__8CMenuPcsFv` (104b)

## Match evidence
- Function fuzzy match: **3.846154% -> 81.576920%**
- Unit fuzzy match (`main/bonus_menu`): **0.167209% -> 0.345067%**
- `objdiff-cli` side-by-side diff for `ClrBattleItem__8CMenuPcsFv` reports ~**80.62%** and shows correct call alignment to:
  - `CCaravanWork::SafeDeleteTempItem`
  - `CCaravanWork::SortBeforeReturnWorldMap`

## Plausibility rationale
- The implementation is direct game-logic source: iterate the 4 caravan slots, guard null pointers, then call two existing `CCaravanWork` methods.
- No contrived temporaries, artificial reordering, or compiler-coaxing patterns were introduced.

## Technical details
- Used `Game.game.m_scriptFoodBase[i]` as the 4-entry source of caravan work pointers.
- Maintained clean C++ control flow and existing project conventions.
- Full PAL build verification passed (`build/GCCP01/main.dol: OK`).
