### PR TITLE
gbaque: implement first-pass MakeSellData

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -23,6 +23,7 @@ extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*
 extern "C" void __dla__FPv(void*);
 extern "C" void Printf__7CSystemFPce(CSystem*, char*, ...);
 extern "C" int memcmp(const void*, const void*, unsigned long);
+extern "C" void MakeAgbString__4CMesFPcPcii(char*, char*, int, int);
 extern "C" int IsOutOfShouki__12CCaravanWorkFv(void*);
 extern "C" int CanPlayerUseItem__12CCaravanWorkFv(void*);
 extern "C" int CanPlayerPutItem__12CCaravanWorkFv(void*);
@@ -1860,12 +1861,111 @@ void GbaQueue::MakeBuyData(int, char*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800cb0d0
+ * PAL Size: 972b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::MakeSellData(int, char*)
+void GbaQueue::MakeSellData(int channel, char* outData)
 {
-	// TODO
+	char* itemNameScratch = static_cast<char*>(__nwa__FUlPQ27CMemory6CStagePci(
+		0x400, Game.game.m_mainStage, s_gbaque_cpp, 0xDD5));
+	if (itemNameScratch == 0) {
+		if (System.m_execParam != 0) {
+			Printf__7CSystemFPce(&System, s_mem_alloc_error, s_gbaque_cpp, 0xDD7);
+		}
+		return;
+	}
+	memset(itemNameScratch, 0, 0x400);
+
+	char* agbStringScratch = static_cast<char*>(__nwa__FUlPQ27CMemory6CStagePci(
+		0x400, Game.game.m_mainStage, s_gbaque_cpp, 0xDDE));
+	if (agbStringScratch == 0) {
+		if (System.m_execParam != 0) {
+			Printf__7CSystemFPce(&System, s_mem_alloc_error, s_gbaque_cpp, 0xDE0);
+		}
+		__dla__FPv(itemNameScratch);
+		return;
+	}
+	memset(agbStringScratch, 0, 0x400);
+
+	const unsigned int scriptFood = Game.game.m_scriptFoodBase[channel];
+	const unsigned int flatBase = Game.game.unkCFlatData0[2];
+	int totalSize = 0;
+
+	for (int i = 0; i < 0x40; i++) {
+		const int itemId = *reinterpret_cast<short*>(scriptFood + i * 2 + 0xB6);
+		unsigned int sellInfo[2];
+		if ((itemId < 1) || (itemId > 0x9E)) {
+			sellInfo[0] = 0;
+			sellInfo[1] = 0;
+		} else {
+			const int itemBase = flatBase + itemId * 0x48;
+			sellInfo[0] = static_cast<unsigned short>(*reinterpret_cast<unsigned short*>(itemBase + 4));
+			sellInfo[1] = static_cast<unsigned short>(*reinterpret_cast<unsigned short*>(itemBase + 6)) |
+				(static_cast<unsigned int>(static_cast<unsigned short>(*reinterpret_cast<unsigned short*>(itemBase + 8))) << 16);
+		}
+		memcpy(outData, sellInfo, 8);
+		outData += 8;
+		totalSize += 8;
+	}
+
+	const double userRate = static_cast<double>(static_cast<float>(
+		static_cast<float>(*reinterpret_cast<short*>(scriptFood + 0xBE2)) / 100.0f * 0.3f));
+	for (int i = 0; i < 0x40; i++) {
+		const int itemId = *reinterpret_cast<short*>(scriptFood + i * 2 + 0xB6);
+		unsigned int packedPrice = 0;
+		if (itemId > 0) {
+			unsigned int itemPrice = static_cast<unsigned short>(
+				*reinterpret_cast<unsigned short*>(flatBase + itemId * 0x48 + 0x20));
+			itemPrice = static_cast<unsigned int>(static_cast<double>(static_cast<float>(itemPrice)) * userRate);
+			if (static_cast<int>(itemPrice) < 1) {
+				itemPrice = 1;
+			}
+			packedPrice =
+				(itemPrice << 24) |
+				((itemPrice >> 8) & 0xFF) << 16 |
+				((itemPrice >> 16) & 0xFF) << 8 |
+				(itemPrice >> 24);
+		}
+
+		memcpy(outData, &packedPrice, 4);
+		outData += 4;
+		totalSize += 4;
+	}
+
+	GbaFlatDataView* flatData = reinterpret_cast<GbaFlatDataView*>(&Game.game.m_cFlatDataArr[1]);
+	for (int i = 0; i < 0x40; i++) {
+		memset(itemNameScratch, 0, 0x400);
+		memset(agbStringScratch, 0, 0x400);
+
+		const int itemId = *reinterpret_cast<short*>(scriptFood + i * 2 + 0xB6);
+		if (itemId < 1) {
+			outData[0] = 0;
+			outData += 1;
+			totalSize += 1;
+			continue;
+		}
+
+		strcpy(itemNameScratch, flatData->m_tabl[6].m_strings[itemId]);
+		MakeAgbString__4CMesFPcPcii(agbStringScratch, itemNameScratch, 0, 0);
+		const int strSize = static_cast<int>(strlen(agbStringScratch) + 1);
+		memcpy(outData, agbStringScratch, strSize);
+		outData += strSize;
+		totalSize += strSize;
+	}
+
+	__dla__FPv(agbStringScratch);
+	__dla__FPv(itemNameScratch);
+
+	OSWaitSemaphore(accessSemaphores + channel);
+	reinterpret_cast<unsigned char*>(this)[0x2C98] =
+		static_cast<unsigned char>(reinterpret_cast<unsigned char*>(this)[0x2C98] | (1 << channel));
+	OSSignalSemaphore(accessSemaphores + channel);
+
+	Joybus.SetLetterSize(channel, totalSize);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented a first-pass decomp of `GbaQueue::MakeSellData(int, char*)` in `src/gbaque.cpp`.
- Replaced the previous TODO stub with real sell-packet construction logic:
  - item stat packing for up to 0x40 inventory slots
  - per-item sell price packing with endianness conversion
  - AGB-safe item-name string generation and packed output writing
  - sell flag/semaphore update and JoyBus letter size reporting
- Added PAL metadata block for the function (`0x800cb0d0`, `972b`).

## Functions Improved
- Unit: `main/gbaque`
- Symbol: `MakeSellData__8GbaQueueFiPc`

## Match Evidence
- Before: selector output showed `MakeSellData__8GbaQueueFiPc` at about `0.4%`.
- After: `build/GCCP01/report.json` now reports:
  - `MakeSellData__8GbaQueueFiPc`: `64.09054%` fuzzy match (size `972`)

## Plausibility Rationale
- The implementation follows existing `gbaque.cpp` style already used in adjacent functions (`MakeLetterList`, semaphore-gated flag updates, table/string handling).
- Data flow aligns with game semantics (inventory -> sell metadata -> names -> JoyBus payload), rather than artificial temporary-only coercions.
- Memory allocation/error handling mirrors established project patterns using the same allocator and error format string.

## Technical Details
- Uses `Game.game.m_scriptFoodBase[channel]` and `Game.game.unkCFlatData0[2]` for item and flat-data lookups.
- Converts packed values to transfer byte order using explicit shifts/masks before `memcpy` into output payload.
- Uses `MakeAgbString__4CMesFPcPcii` to produce AGB-safe item names from flat-data table 6.
- Sets sell-ready bit at queue offset `0x2C98` under per-channel semaphore and updates outgoing payload size via `Joybus.SetLetterSize(channel, totalSize)`.

## Verification
- `python3 configure.py --version GCCP01`
- `ninja`
- Build result: `build/GCCP01/main.dol: OK`
