### PR TITLE
partMng: implement pppSetRendMatrix

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -30,6 +30,7 @@ extern "C" unsigned char DAT_8032ed68;
 extern "C" int DAT_8032ed6c;
 extern "C" unsigned char DAT_8032ed90;
 extern "C" unsigned char DAT_8032ed91;
+extern unsigned char CameraPcs[];
 extern "C" void __ct__9_pppMngStFv(_pppMngSt* pppMngSt);
 extern "C" void __construct_array(void*, void (*)(void*), void (*)(void*, int), unsigned long, unsigned long);
 extern "C" void pppSetBlendMode__FUc(unsigned char);
@@ -1083,12 +1084,20 @@ void pppSetProjection()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8005a8c0
+ * PAL Size: 108b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CPartMng::pppSetRendMatrix()
 {
-	// TODO
+    PSMTX44Copy(*reinterpret_cast<Mtx44*>(CameraPcs + 0x48), ppvScreenMatrix);
+    PSMTXCopy(*reinterpret_cast<Mtx*>(CameraPcs + 4), ppvCameraMatrix0);
+    FLOAT_8032ed58 = ppvScreenMatrix[2][0];
+    FLOAT_8032ed5c = ppvScreenMatrix[2][1];
+    FLOAT_8032ed60 = ppvScreenMatrix[2][3];
 }
 
 /*


### PR DESCRIPTION
## Summary
Implements `CPartMng::pppSetRendMatrix()` in `src/partMng.cpp` using the PAL decomp reference behavior:
- copy `CameraPcs` projection matrix into `ppvScreenMatrix`
- copy `CameraPcs` view matrix into `ppvCameraMatrix0`
- cache projection terms into `FLOAT_8032ed58`, `FLOAT_8032ed5c`, `FLOAT_8032ed60`

Also adds PAL function metadata block for this function.

## Functions improved
- Unit: `main/partMng`
- Symbol: `pppSetRendMatrix__8CPartMngFv` (108 bytes)

## Match evidence
- Objdiff symbol match: **3.7037036% -> 98.85185%**
- Report fuzzy match for symbol: **3.7037036 -> 99.96296**
- Build status: `ninja` passes and `build/GCCP01/main.dol: OK`

## Plausibility rationale
This change is source-plausible and aligns with surrounding engine patterns:
- other modules read camera matrices from `CameraPcs` offsets (`+0x4` view, `+0x48` projection)
- matrix copy and cached projection-term writes are standard rendering setup steps
- no contrived temporaries or compiler-coaxing-only constructs were introduced

## Technical details
Implemented with existing matrix APIs used throughout the codebase (`PSMTX44Copy`, `PSMTXCopy`) and existing globals already used by part rendering paths (`ppvScreenMatrix`, `ppvCameraMatrix0`, `FLOAT_8032ed58/5c/60`).
