### PR TITLE
RedExecute: implement _VoiceEnvelopeCheck first-pass

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -438,12 +438,22 @@ RedVoiceDATA* EntryVoiceSearch(RedTrackDATA* track)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801c3db4
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void _VoiceEnvelopeCheck()
 {
-	// TODO
+    u32* voiceData = DAT_8032f444;
+    do {
+        if ((((u8*)voiceData)[0x1A] & 7) != 0) {
+            voiceData[0x2C] = 0x8000;
+        }
+        voiceData += 0x30;
+    } while (voiceData < DAT_8032f444 + 0xC00);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `_VoiceEnvelopeCheck` in `src/RedSound/RedExecute.cpp` (previously a TODO stub).
- Added PAL metadata comment block for the implemented function.
- Kept implementation in the existing pointer/offset style used across `RedExecute.cpp` for source plausibility and consistency.

## Functions improved
- Unit: `main/RedSound/RedExecute`
- `_VoiceEnvelopeCheck__Fv` (68b): `5.882353% -> 59.117645%`

## Match evidence
- Baseline and after were measured via `ninja build/GCCP01/src/RedSound/RedExecute.o build/GCCP01/report.json` and `build/GCCP01/report.json` function entries.
- Unit fuzzy moved from `47.581078%` to `47.680237%` on this pass.
- Side effect observed in same unit during this isolated change: `_KeyOnControl__Fv` moved from `26.435583%` to `24.996933%`, but net weighted delta for the unit remained positive in this experiment.

## Plausibility rationale
- The new implementation follows the surrounding codebase idiom (raw voice slot iteration with fixed-stride layout, flag-bit tests, and direct state writes).
- Behavior aligns with the function role and Ghidra control-flow shape for PAL address `0x801c3db4` while remaining readable, production-style C/C++.

## Technical notes
- Loop walks `DAT_8032f444` voice entries in `0xC0` byte strides (`0x30` words) and applies envelope reset (`0x8000`) when voice status bits indicate activity.
- Full build verification passed (`ninja`, `build/GCCP01/main.dol: OK` in the worktree build prior to incremental passes).