### PR TITLE
main/cflat_r2system: improve SetMiniGameParam control-flow match

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -41,6 +41,7 @@ extern "C" {
 int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned long);
 void CalcHitPosition__7CMapObjFP3Vec(void*, Vec*);
 int GetWait__4CMesFv(void*);
+void Printf__7CSystemFPce(CSystem*, const char*, ...);
 unsigned char lbl_8032ECB8;
 }
 extern "C" double fmod(double, double);
@@ -273,18 +274,26 @@ int CMiniGamePcs::GetMiniGameParam(int id)
 void CMiniGamePcs::SetMiniGameParam(int id, int value)
 {
     if ((unsigned int)System.m_execParam > 2U) {
-        System.Printf("SetMiniGameParam no 0x%04x data[%d]\n", id, value);
+        Printf__7CSystemFPce(&System, "SetMiniGameParam no 0x%04x data[%d]\n", id, value);
     }
 
     if (id == 0x1202) {
         *(unsigned char*)((char*)this + 0x134B) |= (unsigned char)(1 << value);
-    } else if (id < 0x1202) {
+        return;
+    }
+
+    if (id < 0x1202) {
         if (id == 0x1102) {
             *(unsigned char*)((char*)this + 0x1348) = 1;
-        } else if (id > 0x1100 && id < 0x1102) {
-            *(signed char*)((char*)this + 0x1350) = (signed char)value;
+            return;
         }
-    } else if (id < 0x1204) {
+        if (id < 0x1102 && 0x1100 < id) {
+            *(char*)((char*)this + 0x1350) = (char)value;
+        }
+        return;
+    }
+
+    if (id < 0x1204) {
         *(unsigned char*)((char*)this + 0x134B) &= (unsigned char)~(1 << value);
     }
 }


### PR DESCRIPTION
## Summary
- Updated `CMiniGamePcs::SetMiniGameParam(int, int)` to use the explicit `Printf__7CSystemFPce(&System, ...)` call form.
- Restructured conditional flow to explicit early-return blocks that more closely mirror the original branch layout.
- Kept behavior equivalent (same param ID handling and bit operations).

## Functions improved
- Unit: `main/cflat_r2system`
- Symbol: `SetMiniGameParam__12CMiniGamePcsFii`

## Match evidence
- `SetMiniGameParam__12CMiniGamePcsFii`: **51.145454% -> 52.963634%** (`220b`)
- Built with `ninja` successfully after changes.
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - SetMiniGameParam__12CMiniGamePcsFii`

## Plausibility rationale
- The final shape is a straightforward source-level refactor (explicit function call + early returns), not contrived compiler coaxing.
- It preserves readability and idiomatic game-code control flow while tightening branch structure.

## Technical details
- Objdiff alignment improved after:
  - replacing method-style `System.Printf(...)` usage with the explicit runtime print symbol call used elsewhere in this codebase.
  - converting nested `else if` chains into branch-local return paths, reducing divergence in compare/branch sequencing.
