### PR TITLE
RedDriver: improve GetProgramTime decomp match

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1350,18 +1350,18 @@ void CRedDriver::End()
  */
 int CRedDriver::GetProgramTime()
 {
-    int iVar1;
-    int iVar2;
-    int* piVar3;
+    register int total;
+    register int* current;
+    int* start;
 
-    iVar2 = 0;
-    piVar3 = DAT_8032f3cc;
+    total = 0;
+    current = DAT_8032f3cc;
+    start = DAT_8032f3cc;
     do {
-        iVar1 = *piVar3;
-        piVar3 = piVar3 + 1;
-        iVar2 = iVar2 + iVar1;
-    } while (piVar3 < DAT_8032f3cc + 100);
-    return iVar2;
+        total += *current;
+        current += 1;
+    } while (current < start + 100);
+    return total;
 }
 
 /*


### PR DESCRIPTION
## Summary
Restructured `CRedDriver::GetProgramTime()` in `src/RedSound/RedDriver.cpp` to use a stable pointer-start loop form and clearer local variable roles.

## Functions improved
- Unit: `main/RedSound/RedDriver`
- Symbol: `GetProgramTime__10CRedDriverFv`

## Match evidence
- Before: `20.82353%`
- After: `36.705883%`
- Build verification: `ninja` passes after the edit.
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - GetProgramTime__10CRedDriverFv`

## Plausibility rationale
The change keeps behavior identical while moving from generic decompiler-style temporaries (`iVar*`) to a straightforward accumulation loop over the fixed 100-entry timing buffer. This is source-plausible and aligns with normal game-side C++ style for this codebase.

## Technical details
- Replaced anonymous temporary variables with semantically stable locals (`total`, `current`, `start`).
- Kept a `do/while` loop with explicit pointer increment and bounds check (`start + 100`) to improve emitted loop shape alignment.
- No debug artifacts, no commented-out code, and no unrelated file changes.
