### PR TITLE
singmenu: implement window/equip helper stubs

### DIFF
--- a/include/ffcc/singmenu.h
+++ b/include/ffcc/singmenu.h
@@ -49,10 +49,10 @@ public:
     void SetSingWinInfo(int, int, int, int);
     void SetSingDynamicWinMessInfo(int, char*, char*, char*, char*, char*, char*, char*, char*);
     void SetSingWinScl(float);
-    void GetSingWinScl();
-    void SingWinMessHeight();
-    void ChkEquipPossible(int);
-    void GetEquipType(int);
+    float GetSingWinScl();
+    int SingWinMessHeight();
+    int ChkEquipPossible(int);
+    int GetEquipType(int);
     void GetSmithItem(int);
     void GetRecipeMaterial(int, MaterialInfo*);
     void GetRaceStr(int, char*);

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -192,6 +192,7 @@ extern float FLOAT_803329f4;
 extern float FLOAT_803329f8;
 extern float FLOAT_80332994;
 extern float FLOAT_803329fc;
+extern float FLOAT_80332960;
 extern float FLOAT_80332a00;
 extern float FLOAT_80332a04;
 extern float FLOAT_80332a08;
@@ -1527,12 +1528,22 @@ void CMenuPcs::GetSingWinSize(int, short*, short*, int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80146490
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::SetSingWinInfo(int, int, int, int)
+void CMenuPcs::SetSingWinInfo(int x, int y, int w, int h)
 {
-	// TODO
+    s16* winInfo = *reinterpret_cast<s16**>(reinterpret_cast<u8*>(this) + 0x848);
+    winInfo[0] = static_cast<s16>(x);
+    winInfo[1] = static_cast<s16>(y);
+    winInfo[2] = static_cast<s16>(w);
+    winInfo[3] = static_cast<s16>(h);
+    winInfo[4] = 0;
+    winInfo[5] = 3;
 }
 
 /*
@@ -1547,52 +1558,112 @@ void CMenuPcs::SetSingDynamicWinMessInfo(int, char*, char*, char*, char*, char*,
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80146364
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::SetSingWinScl(float)
+void CMenuPcs::SetSingWinScl(float scale)
 {
-	// TODO
+    FLOAT_8032ea78 = scale;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: TODO
+ * PAL Size: TODO
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetSingWinScl()
+float CMenuPcs::GetSingWinScl()
 {
-	// TODO
+    return FLOAT_8032ea78;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014630c
+ * PAL Size: 88b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::SingWinMessHeight()
+int CMenuPcs::SingWinMessHeight()
 {
-	// TODO
+    unsigned int lineHeight = static_cast<unsigned int>(FLOAT_80332960 * FLOAT_8032ea78);
+    float scaledHeight = FLOAT_80332960 * FLOAT_8032ea78;
+    double intHeight = static_cast<double>(lineHeight);
+
+    if (FLOAT_8033294c < (scaledHeight - static_cast<float>(intHeight))) {
+        lineHeight += 1;
+    }
+    return static_cast<int>(lineHeight + 3);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8014624c
+ * PAL Size: 192b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::ChkEquipPossible(int)
+int CMenuPcs::ChkEquipPossible(int itemNo)
 {
-	// TODO
+    u16 flags = *reinterpret_cast<u16*>(Game.game.unkCFlatData0[2] + itemNo * 0x48 + 4);
+    unsigned int raceMask = 1 << (*reinterpret_cast<u16*>(Game.game.m_scriptFoodBase[0] + 0x3E0) & 3);
+    unsigned int genderMask = 0x10;
+
+    if (*reinterpret_cast<s16*>(Game.game.m_scriptFoodBase[0] + 0x3E2) != 0) {
+        genderMask = 0x20;
+    }
+
+    bool result;
+    if ((flags & 0xF) != 0) {
+        if ((flags & 0x30) != 0) {
+            result = (((flags & 0xF) & raceMask) != 0) && (((flags & 0x30) & genderMask) != 0);
+            return result ? 1 : 0;
+        }
+        result = ((flags & 0xF) & raceMask) != 0;
+    } else {
+        result = ((flags & 0x30) & genderMask) != 0;
+    }
+
+    return result ? 1 : 0;
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80146190
+ * PAL Size: 188b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::GetEquipType(int)
+int CMenuPcs::GetEquipType(int itemNo)
 {
-	// TODO
+    u16 flags = *reinterpret_cast<u16*>(Game.game.unkCFlatData0[2] + itemNo * 0x48 + 4);
+
+    if ((flags & 0x100) != 0) {
+        return 0;
+    }
+    if ((flags & 0x400) != 0) {
+        return 1;
+    }
+    if ((flags & 0xA00) != 0) {
+        return 2;
+    }
+    if ((flags & 0x3000) != 0) {
+        return 3;
+    }
+    return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented several `singmenu` helper stubs with plausible game-logic equivalents from nearby decomp context.
- Added concrete implementations for window info/sizing scale and equip compatibility/type checks.
- Updated `CMenuPcs` declarations for these helpers to return values where call sites already treat them as value-returning APIs.

## Functions Improved
- `SetSingWinInfo__8CMenuPcsFiiii`
- `SetSingWinScl__8CMenuPcsFf`
- `SingWinMessHeight__8CMenuPcsFv`
- `ChkEquipPossible__8CMenuPcsFi`
- `GetEquipType__8CMenuPcsFi`

## Match Evidence (objdiff)
Baseline was measured on `HEAD~1` with the same unit build, then compared against this branch.

- `SetSingWinInfo__8CMenuPcsFiiii`: **6.67% -> 63.67%**
- `SetSingWinScl__8CMenuPcsFf`: **50.00% -> 97.50%**
- `SingWinMessHeight__8CMenuPcsFv`: **4.55% -> 0.00%**
- `ChkEquipPossible__8CMenuPcsFi`: **2.08% -> 56.60%**
- `GetEquipType__8CMenuPcsFi`: **2.13% -> 45.19%**

Net effect: 4/5 targeted helpers improved substantially from near-stub matches to meaningful partial matches.

## Plausibility Rationale
- Logic follows the expected data-flow of item flag checks and menu state structures rather than compiler-coaxing patterns.
- Field usage is consistent with existing surrounding `singmenu` code (`0x848` window info block, item flag reads from flat data, script base fields for race/gender gates).
- Control flow remains readable and idiomatic for this codebase.

## Technical Details
- `SetSingWinInfo` now writes x/y/w/h and initializes window state fields used by draw/control code.
- `SetSingWinScl`/`GetSingWinScl` operate on `FLOAT_8032ea78` scale state.
- `ChkEquipPossible` now computes race/gender compatibility masks against item flags and party character fields.
- `GetEquipType` now classifies equipment category from item flag groups.
- Added PAL `--INFO--` metadata for implemented functions where addresses/sizes were available from decomp exports.
