### PR TITLE
os/OSAlarm: match OSInitAlarm by removing reset registration

### DIFF
--- a/src/os/OSAlarm.c
+++ b/src/os/OSAlarm.c
@@ -52,7 +52,6 @@ void OSInitAlarm(void) {
     if (__OSGetExceptionHandler(8) != DecrementerExceptionHandler) {
         AlarmQueue.head = AlarmQueue.tail = NULL;
         __OSSetExceptionHandler(8, DecrementerExceptionHandler);
-        OSRegisterResetFunction(&ResetFunctionInfo);
     }
 }
 


### PR DESCRIPTION
## Summary
- Removed the `OSRegisterResetFunction(&ResetFunctionInfo);` call from `OSInitAlarm` in `src/os/OSAlarm.c`.
- Kept initialization logic otherwise unchanged (`AlarmQueue` reset + decrementer handler install).

## Functions Improved
- Unit: `main/os/OSAlarm`
- Function: `OSInitAlarm` (`76b`)

## Match Evidence
- `OSInitAlarm`: `84.210526%` -> `100.0%`
- `main/os/OSAlarm` unit fuzzy match: `94.25105%` -> `94.883965%`
- Overall progress after rebuild: `+76` matched code bytes, `+1` matched function.

## Plausibility Rationale
- The original binary for this unit does not include a reset-function registration call in `OSInitAlarm`.
- Removing that call makes the function align with the expected minimal initialization sequence and yields a full function match without introducing contrived control flow or compiler coaxing.

## Technical Details
- Verified with `ninja` (build + report generation).
- Compared unit-level match metrics via `build/GCCP01/report.json` before/after.
- Instruction-level objdiff mismatch in `OSInitAlarm` previously showed extra call setup (`lis/addi/bl OSRegisterResetFunction`) that is now gone.
