### PR TITLE
cmake: implement calcVillageMenu state flow

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -5,8 +5,18 @@
 extern "C" void __dl__FPv(void*);
 extern "C" void freeTexture__8CMenuPcsFiiii(CMenuPcs*, int, int, int, int);
 extern "C" void CmakeVillageDraw__8CMenuPcsFv(CMenuPcs*);
+extern "C" unsigned short CmakeVillageCtrl__8CMenuPcsFv(CMenuPcs*);
 extern "C" void CallWorldParam__8CMenuPcsFiii(CMenuPcs*, int, int, int);
 extern "C" void ChgModel__8CMenuPcsFiiii(CMenuPcs*, int, int, int, int);
+extern "C" char* GetLangString__5CGameFv(void*);
+extern "C" int sprintf(char*, const char*, ...);
+extern "C" void loadFont__8CMenuPcsFiPcii(CMenuPcs*, int, char*, int, int);
+extern "C" void loadTexture__8CMenuPcsFPPciiPQ28CMenuPcs4CTmpiii(CMenuPcs*, char**, int, int, void*, int, int, int);
+extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
+extern "C" char s_dvd__smenu_subfont_fnt_801e3020[];
+extern "C" char* PTR_s_world2_802159a4[];
+extern "C" int DAT_802159c8;
+extern "C" char s_cmake_cpp_801e3038[];
 
 static inline short& MenuS16(CMenuPcs* menu, int offset)
 {
@@ -680,12 +690,77 @@ void CMenuPcs::destroyVillageMenu()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8016cf58
+ * PAL Size: 580b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CMenuPcs::calcVillageMenu()
 {
-	// TODO
+    if (MenuU8(this, 0x16) != 0 && MenuS16(this, 0x86C) == 0) {
+        if (Game.game.m_gameWork.m_menuStageMode == 0) {
+            char path[128];
+            char* language = GetLangString__5CGameFv(&Game.game);
+            sprintf(path, s_dvd__smenu_subfont_fnt_801e3020, language);
+            loadFont__8CMenuPcsFiPcii(this, 2, path, 4, -1);
+        }
+
+        loadTexture__8CMenuPcsFPPciiPQ28CMenuPcs4CTmpiii(
+            this, PTR_s_world2_802159a4, 8, 1, &DAT_802159c8, 0x60, 9, 3);
+
+        void* stage = *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(this) + 0xEC);
+        int& villageWork = MenuS32(this, 0x830);
+        villageWork = reinterpret_cast<int>(__nw__FUlPQ27CMemory6CStagePci(0x48, stage, s_cmake_cpp_801e3038, 0xCB3));
+        memset(reinterpret_cast<void*>(villageWork), 0, 0x48);
+        MenuS16(this, 0x86C) = 1;
+    }
+
+    short active = MenuS16(this, 0x86C);
+    if (active == 0) {
+        return;
+    }
+
+    if (MenuU8(this, 0x16) == 0) {
+        if (Game.game.m_gameWork.m_menuStageMode == 0) {
+            void*& font = *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(this) + 0x108);
+            ReleaseRefObject(font);
+            font = nullptr;
+        }
+
+        freeTexture__8CMenuPcsFiiii(this, 8, 1, 0x60, 9);
+        int& villageWork = MenuS32(this, 0x830);
+        if (villageWork != 0) {
+            __dl__FPv(reinterpret_cast<void*>(villageWork));
+            villageWork = 0;
+        }
+        MenuS16(this, 0x86C) = 0;
+        return;
+    }
+
+    int villageWork = MenuS32(this, 0x830);
+    unsigned short result = 0;
+    short& mode = *reinterpret_cast<short*>(villageWork + 0x10);
+    short& frame = *reinterpret_cast<short*>(villageWork + 0x22);
+
+    if (mode == 0) {
+        if (frame < 10) {
+            frame = frame + 1;
+            result = 0;
+        } else {
+            result = 1;
+        }
+    } else if (mode == 1) {
+        result = CmakeVillageCtrl__8CMenuPcsFv(this);
+    } else if (frame < 10) {
+        frame = frame + 1;
+        result = 0;
+    } else {
+        result = 1;
+    }
+
+    *reinterpret_cast<unsigned short*>(villageWork + 0x2E) = result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::calcVillageMenu()` in `src/cmake.cpp` from the PAL decomp flow.
- Added required extern declarations for runtime calls used by the function (`loadFont`, `loadTexture`, stage allocator, and village ctrl thunk).
- Preserved existing menu object offset-style access already used in this file for consistency.

## Functions improved
- Unit: `main/cmake`
- Function: `calcVillageMenu__8CMenuPcsFv` (580b)

## Match evidence
- `calcVillageMenu__8CMenuPcsFv`: **0.6896552% -> 75.655174%** (`build/GCCP01/report.json`)
- Unit `main/cmake` fuzzy match: **3.1% -> 4.4440603%**
- Verification steps:
  - `ninja` (build and report regeneration passed)
  - `build/tools/objdiff-cli diff -p . -u main/cmake -o - calcVillageMenu__8CMenuPcsFv`

## Plausibility rationale
- This change restores expected menu lifecycle behavior (open/load resources, active-state control, and teardown) using existing project conventions.
- The implementation uses ABI-consistent signed/unsigned widths and direct field offsets already established in `cmake.cpp`, rather than contrived reordering or compiler-coaxing temporaries.

## Technical details
- `CmakeVillageCtrl` is called via its mangled symbol returning `unsigned short`, matching decomp call semantics where the return value is stored at village state offset `+0x2e`.
- Resource teardown path mirrors existing `destroyVillageMenu()` behavior, including refcount release and texture free sequencing.
