### PR TITLE
itemobj: improve ItemJump__9CGItemObjFif match

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1037,42 +1037,64 @@ void CGItemObj::DrawOmoideName(CFont* font)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80124cb8
+ * PAL Size: 332b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::ItemJump(int state, float jump)
 {
-	unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat);
-
-	while (itemObj != 0) {
-		if ((*(unsigned int*)(itemObj + 0x60) & 0x10) == 0) {
-			float local_78 = FLOAT_80331b20;
-			float local_74 = FLOAT_80331b24;
-			float local_70 = FLOAT_80331b20;
-			float local_6c = *(float*)(itemObj + 0x68);
-			float local_68 = *(float*)(itemObj + 0x6c) + FLOAT_80331b1c;
-			float local_64 = *(float*)(itemObj + 0x70);
-			float local_60 = local_6c;
-			float local_5c = local_68;
-			float local_58 = local_64;
-			float local_48 = FLOAT_80331b20;
-			float local_44 = FLOAT_80331b24;
-			float local_40 = FLOAT_80331b20;
-			float local_3c = FLOAT_80331b20;
-			float local_38 = FLOAT_80331b28;
-			float local_34 = FLOAT_80331b28;
-			float local_30 = FLOAT_80331b28;
-			float local_2c = FLOAT_80331b2c;
-			float local_28 = FLOAT_80331b2c;
-			float local_24 = FLOAT_80331b2c;
-
-			if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &local_60, &local_78, *(unsigned int*)(itemObj + 0x1c4)) != 0 &&
-			    DAT_8032ec90[0x47] == (unsigned char)state) {
-				*(float*)(itemObj + 0x108) = *(float*)(itemObj + 0x108) + jump;
-			}
+	for (unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat); itemObj != 0;
+	     itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
+		if ((*(unsigned int*)(itemObj + 0x60) & 0x10) != 0) {
+			continue;
 		}
 
-		itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj);
+		float local_78;
+		float local_74;
+		float local_70;
+		float local_6c;
+		float local_68;
+		float local_64;
+		float local_60;
+		float local_5c;
+		float local_58;
+		float local_48;
+		float local_44;
+		float local_40;
+		float local_3c;
+		float local_38;
+		float local_34;
+		float local_30;
+		float local_2c;
+		float local_28;
+		float local_24;
+
+		local_6c = *(float*)(itemObj + 0x68);
+		local_64 = *(float*)(itemObj + 0x70);
+		local_68 = *(float*)(itemObj + 0x6c) + FLOAT_80331b1c;
+		local_78 = FLOAT_80331b20;
+		local_70 = FLOAT_80331b20;
+		local_74 = FLOAT_80331b24;
+		local_30 = FLOAT_80331b28;
+		local_34 = FLOAT_80331b28;
+		local_38 = FLOAT_80331b28;
+		local_24 = FLOAT_80331b2c;
+		local_28 = FLOAT_80331b2c;
+		local_2c = FLOAT_80331b2c;
+		local_48 = FLOAT_80331b20;
+		local_44 = FLOAT_80331b24;
+		local_40 = FLOAT_80331b20;
+		local_3c = FLOAT_80331b20;
+		local_60 = local_6c;
+		local_5c = local_68;
+		local_58 = local_64;
+		if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &local_60, &local_78, *(unsigned int*)(itemObj + 0x1c4)) != 0 &&
+		    DAT_8032ec90[0x47] == state) {
+			*(float*)(itemObj + 0x108) = *(float*)(itemObj + 0x108) + jump;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Updated `CGItemObj::ItemJump(int state, float jump)` in `src/itemobj.cpp` to better align with the original stack/local layout and control-flow shape.
- Reordered local float declarations/assignments to match the expected compiled layout more closely.
- Switched the iteration to a `for` form with early-continue for the object-flag gate.
- Filled in function metadata block with PAL address/size.

## Functions improved
- Unit: `main/itemobj`
- Function: `ItemJump__9CGItemObjFif`
  - Before: `51.481926%`
  - After: `53.349396%`
  - Delta: `+1.867470%`

## Match evidence
- Build passes (`ninja`).
- Objdiff command used:
  - `build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_diff_final.json ItemJump__9CGItemObjFif`
- Improvement is function-specific and persisted after rebuilding.

## Plausibility rationale
- Changes keep behavior intact and follow existing codebase style (pointer-offset field access, same APIs, same constants).
- The rewrite targets source-plausible structure (local ordering and loop/control-flow shape), rather than non-idiomatic compiler coaxing.

## Technical notes
- The post-change assembly diff for `ItemJump__9CGItemObjFif` shows fewer structural instruction replacements/inserts in the hot path while preserving core call/branch behavior.
