### PR TITLE
main/chara: implement CModel matrix/skin/frame stubs

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -1,7 +1,14 @@
 #include "ffcc/chara.h"
 #include "ffcc/cflat_runtime.h"
 
+#include <math.h>
+
 extern "C" void CalcBind__Q26CChara5CNodeFPQ26CChara6CModel(void*, void*);
+extern "C" void gqrInit__6CCharaFUlUlUl(void*, unsigned long, unsigned long, unsigned long);
+extern "C" void Calc__Q26CChara5CMeshFPQ26CChara6CModel(void*, void*);
+
+struct CharaGlobal;
+extern CharaGlobal Chara;
 
 /*
  * --INFO--
@@ -203,22 +210,66 @@ void CChara::CModel::calcBindMatrix()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800723a4
+ * PAL Size: 276b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CChara::CModel::CalcMatrix()
 {
-	// TODO
+	float(*localMtx)[4] = (float(*)[4])((u8*)this + 0x14);
+	float(*worldBaseMtx)[4] = (float(*)[4])((u8*)this + 0x44);
+	float(*drawMtx)[4] = (float(*)[4])((u8*)this + 0x74);
+
+	worldBaseMtx[0][0] = localMtx[0][0];
+	worldBaseMtx[1][0] = localMtx[1][0];
+	worldBaseMtx[2][0] = localMtx[2][0];
+	worldBaseMtx[0][1] = localMtx[0][1];
+	worldBaseMtx[1][1] = localMtx[1][1];
+	worldBaseMtx[2][1] = localMtx[2][1];
+	worldBaseMtx[0][2] = localMtx[0][2];
+	worldBaseMtx[1][2] = localMtx[1][2];
+	worldBaseMtx[2][2] = localMtx[2][2];
+	worldBaseMtx[0][3] = 0.0f;
+	worldBaseMtx[1][3] = 0.0f;
+	worldBaseMtx[2][3] = 0.0f;
+
+	PSMTXIdentity(drawMtx);
+	drawMtx[0][3] = localMtx[0][3];
+	drawMtx[1][3] = localMtx[1][3];
+	drawMtx[2][3] = localMtx[2][3];
+
+	calcMatrix();
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800722f4
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CChara::CModel::CalcSkin()
 {
-	// TODO
+	void* refData = *(void**)((u8*)this + 0xA4);
+	void* mesh = *(void**)((u8*)this + 0xAC);
+	u32 posQuant = *(u32*)((u8*)refData + 0x28);
+	u32 normQuant = *(u32*)((u8*)refData + 0x2C);
+	u16 meshCount = *(u16*)((u8*)refData + 0xA);
+	u32 i = 0;
+
+	gqrInit__6CCharaFUlUlUl(&Chara, (posQuant << 24) | 0x70000 | (posQuant << 8) | 7,
+	                        (normQuant << 24) | 0x70000 | (normQuant << 8) | 7, 0x0C070C07);
+
+	while (i < meshCount) {
+		Calc__Q26CChara5CMeshFPQ26CChara6CModel(mesh, this);
+		mesh = (u8*)mesh + 0x14;
+		i++;
+	}
 }
 
 /*
@@ -228,7 +279,31 @@ void CChara::CModel::CalcSkin()
  */
 void CChara::CModel::calcNowFrame()
 {
-	// TODO
+	if (m_anim == 0) {
+		m_curFrame = 0.0f;
+		return;
+	}
+
+	float total = 1.0f + (m_animEnd - m_animStart);
+	if ((((u8*)m_anim)[8] & 0x40) == 0) {
+		if (m_time >= 0.0f) {
+			m_curFrame = m_animStart + static_cast<float>(fmod(m_time, total));
+		} else {
+			m_curFrame = ((m_animStart + total) - 1.0f) - static_cast<float>(fmod(-m_time, total));
+		}
+	} else if (m_time >= 0.0f) {
+		float clamped = total - 1.0f;
+		if (m_time < clamped) {
+			clamped = m_time;
+		}
+		m_curFrame = m_animStart + clamped;
+	} else {
+		float clamped = total - 1.0f;
+		if (-m_time < clamped) {
+			clamped = -m_time;
+		}
+		m_curFrame = ((m_animStart + total) - 1.0f) - clamped;
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented first-pass bodies for `CChara::CModel::CalcMatrix`, `CChara::CModel::CalcSkin`, and `CChara::CModel::calcNowFrame` in `src/chara.cpp`.
- Added PAL metadata blocks for `CalcMatrix` and `CalcSkin` from the Ghidra export headers.
- Used existing offset-based style in this unit to keep code plausible with current incomplete class layouts.

## Functions Improved
- `CalcMatrix__Q26CChara6CModelFv`
- `CalcSkin__Q26CChara6CModelFv`
- (supporting logic) `calcNowFrame__Q26CChara6CModelFv`

## Match Evidence
- `objdiff` current symbol scores in `main/chara`:
  - `CalcMatrix__Q26CChara6CModelFv`: **48.550724%**
  - `CalcSkin__Q26CChara6CModelFv`: **71.59091%**
- Unit-level report after rebuild (`build/GCCP01/report.json`):
  - `main/chara` fuzzy match: **5.3405004%**
  - selector run before edits reported `main/chara` current: **4.1%**

## Plausibility Rationale
- The new code follows expected runtime behavior from surrounding decomp and Ghidra function structure:
  - `CalcMatrix` seeds world/draw matrices from local transforms and invokes `calcMatrix()`.
  - `CalcSkin` initializes GQR quantization and iterates mesh skin calc.
  - `calcNowFrame` advances/clamps frame based on looping/ping-pong anim mode bit.
- These are source-plausible engine behaviors rather than compiler-only coercions.

## Technical Details
- Build verified with `ninja`.
- Symbol checks done via:
  - `build/tools/objdiff-cli diff -p . -u main/chara -o - <symbol>`
- This PR intentionally avoids large 0.2% functions (`calcMatrix`/`dynamics`/`CMesh::Create`) and instead lands a clean incremental pass on adjacent TODO stubs to increase unit progress with low risk.
