### PR TITLE
itemobj: improve DeleteAllFieldItem decomp match

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1091,10 +1091,12 @@ void CGItemObj::DeleteAllFieldItem()
 
 	while (itemObj != 0) {
 		unsigned char stateFlags = itemObj[0x50];
-		int isActive = (int)(((unsigned int)stateFlags << 0x1c) | ((unsigned int)stateFlags >> 4)) < 0;
+		unsigned int rotated = (unsigned int)stateFlags >> 4;
+		rotated |= (unsigned int)stateFlags << 0x1c;
+		int isActive = (int)(rotated >> 0x1f);
 
 		if (*(int*)(itemObj + 0x550) == 0 && isActive != 0) {
-			itemObj[0x54d] = (itemObj[0x54d] & 0x7f) | 0x80;
+			itemObj[0x38] = (itemObj[0x38] & 0x7f) | 0x80;
 		}
 
 		itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj);


### PR DESCRIPTION
## Summary
- Updated `CGItemObj::DeleteAllFieldItem` in `src/itemobj.cpp` to better match original codegen while keeping source-plausible logic.
- Reworked the active-state bit extraction into an explicit rotate-style temporary sequence.
- Corrected the flag byte write from `itemObj[0x54d]` to `itemObj[0x38]`, which aligns with the target object's generated access pattern for this routine.

## Functions improved
- Unit: `main/itemobj`
- Symbol: `DeleteAllFieldItem__9CGItemObjFv`
- Size: `140b`

## Match evidence
- Before: `48.82857%`
- After: `48.857143%`
- Delta: `+0.028573` percentage points

Objdiff command used:
```sh
build/tools/objdiff-cli diff -p . -u main/itemobj -o - DeleteAllFieldItem__9CGItemObjFv
```

Assembly-level changes observed:
- Reduced mismatch count (`DIFF_ARG_MISMATCH`: `3 -> 2`).
- Removed unnecessary constant-register path for setting bit 7 by generating `clrlwi` + `ori` on the flag byte.
- Shifted condition lowering closer to target sequence by using an explicit rotated temporary before the active-bit test.

## Plausibility rationale
- The new code remains straightforward gameplay logic (iterate items, test active state, set a visibility/flag bit).
- Changes are type/control-flow cleanups rather than contrived compiler-only constructs.
- The rewritten bit test and byte-mask update are idiomatic low-level C/C++ patterns that plausibly reflect original source intent.

## Technical details
- Build/test flow:
  - `python3 configure.py --version GCCP01`
  - `ninja`
  - function-level objdiff before/after for `DeleteAllFieldItem__9CGItemObjFv`
- Build remains green after the change.
