### PR TITLE
RedMidiCtrl: implement KeyOn note/velocity command handlers

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -749,33 +749,68 @@ void __MidiCtrl_KeyOnSame(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8328
+ * PAL Size: 104b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_KeyOnNoteVelocity(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+#pragma dont_inline on
+void __MidiCtrl_KeyOnNoteVelocity(RedSoundCONTROL*, RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 {
-	// TODO
+    int* trackData = reinterpret_cast<int*>(track);
+    unsigned char* command = reinterpret_cast<unsigned char*>(trackData[0]);
+
+    trackData[0] = reinterpret_cast<int>(command + 1);
+    *reinterpret_cast<unsigned char*>(trackData + 9) = *command;
+    command = reinterpret_cast<unsigned char*>(trackData[0]);
+    trackData[0] = reinterpret_cast<int>(command + 1);
+    *reinterpret_cast<unsigned char*>(reinterpret_cast<int>(trackData) + 0x25) = *command;
+
+    KeyOnReserve(keyOnData, track);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8390
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_KeyOnNote(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_KeyOnNote(RedSoundCONTROL*, RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 {
-	// TODO
+    int* trackData = reinterpret_cast<int*>(track);
+    unsigned char* command = reinterpret_cast<unsigned char*>(trackData[0]);
+
+    trackData[0] = reinterpret_cast<int>(command + 1);
+    *reinterpret_cast<unsigned char*>(trackData + 9) = *command;
+
+    KeyOnReserve(keyOnData, track);
 }
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C83E0
+ * PAL Size: 80b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_KeyOnVelocity(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_KeyOnVelocity(RedSoundCONTROL*, RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 {
-	// TODO
+    int* trackData = reinterpret_cast<int*>(track);
+    unsigned char* command = reinterpret_cast<unsigned char*>(trackData[0]);
+
+    trackData[0] = reinterpret_cast<int>(command + 1);
+    *reinterpret_cast<unsigned char*>(reinterpret_cast<int>(trackData) + 0x25) = *command;
+
+    KeyOnReserve(keyOnData, track);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
Implemented three previously stubbed MIDI KeyOn command handlers in `src/RedSound/RedMidiCtrl.cpp` and populated their PAL metadata blocks:
- `__MidiCtrl_KeyOnNoteVelocity`
- `__MidiCtrl_KeyOnNote`
- `__MidiCtrl_KeyOnVelocity`

Each function now reads command bytes from the track stream, advances the command pointer, writes note/velocity state bytes on `RedTrackDATA`, and queues the event via `KeyOnReserve`.

## Functions Improved
Unit: `main/RedSound/RedMidiCtrl`
- `__MidiCtrl_KeyOnNoteVelocity__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_KeyOnNote__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_KeyOnVelocity__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Match Evidence
`objdiff-cli` before (from selector snapshot):
- KeyOnNoteVelocity: **3.8%**
- KeyOnNote: **5.0%**
- KeyOnVelocity: **5.0%**

`objdiff-cli` after this change:
- KeyOnNoteVelocity: **57.884617%**
- KeyOnNote: **52.25%**
- KeyOnVelocity: **52.25%**

Build check: `ninja` passes.

## Plausibility Rationale
This change replaces TODO stubs with straightforward command-decoding behavior consistent with neighboring `KeyOff*` handlers and RedSound command processing style. The implementation is readable and idiomatic for this codebase (pointer-based command stream decode + helper call), not contrived compiler coaxing.

## Technical Details
- Adopted the same low-level access style already used in this TU (`int*` track view + `unsigned char*` command stream).
- Added `#pragma dont_inline` around the three KeyOn handlers to preserve call boundaries and avoid aggressive expansion that hurt symbol-level matching.
- Filled PAL address/size comments from Ghidra reference exports for the three implemented symbols.
