### PR TITLE
partMng: implement pppGetFreeDataMng first pass

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -467,7 +467,7 @@ public:
     void pppLoadPan(const char*);
     void pppLoadPdt(const char*, int, int, void*, int);
 
-    void pppGetFreeDataMng();
+    int pppGetFreeDataMng();
     void pppGetDefaultCreateParam();
 
     int pppCreate0(int, int, PPPCREATEPARAM*, int);

--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -47,6 +47,7 @@ extern unsigned char MapPcs[];
 extern CPartMng PartMng;
 extern PPPCREATEPARAM g_dcp;
 static char s_partMng_cpp_801d8230[] = "partMng.cpp";
+static char s_pppGetFreePppDataMngSt_CAN_NOT_ALLOC[] = "pppGetFreePppDataMngSt CAN NOT ALLOC!!\n";
 static char s_CheckSum_ERROR_code_0x_x____801d82f0[] = "CheckSum ERROR code[0x%x]!!!";
 
 struct CPtrArrayBare {
@@ -1369,9 +1370,23 @@ void CPartMng::pppLoadPdt(const char*, int, int, void*, int)
  * Address:	TODO
  * Size:	TODO
  */
-void CPartMng::pppGetFreeDataMng()
+int CPartMng::pppGetFreeDataMng()
 {
-	// TODO
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+    int index = 8;
+    _pppDataHead** pdtPtr = reinterpret_cast<_pppDataHead**>(self + 0x22E18 + (index * 0x38));
+
+    for (int i = 0; i < 0x18; i++, index++, pdtPtr = reinterpret_cast<_pppDataHead**>(reinterpret_cast<char*>(pdtPtr) + 0x38)) {
+        if (*pdtPtr == 0) {
+            return index;
+        }
+    }
+
+    if (System.m_execParam != 0) {
+        System.Printf(s_pppGetFreePppDataMngSt_CAN_NOT_ALLOC);
+    }
+    OSPanic(s_partMng_cpp_801d8230, 0xD74, "");
+    return -1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CPartMng::pppGetFreeDataMng` with a first-pass decompilation aligned to the PAL target behavior.
- Updated declaration/definition to return `int` and return the selected PDT slot index.
- Added missing allocation-failure debug print + panic path used by this routine.

## Functions Improved
- Unit: `main/partMng`
- Symbol: `pppGetFreeDataMng__8CPartMngFv` (212 bytes)

## Match Evidence
- `pppGetFreeDataMng__8CPartMngFv`: **1.8867924% -> 9.905661%**
- `main/partMng` `.text` section match: **19.470596% -> 19.522667%**

Commands used:
- `build/tools/objdiff-cli diff -p . -u main/partMng -o - pppGetFreeDataMng__8CPartMngFv`
- `build/tools/objdiff-cli diff -p . -u main/partMng -o -`

## Plausibility Rationale
- The change follows existing project style for partially decompiled systems code in this unit (offset-based field access and explicit runtime checks).
- Control flow and constants are grounded in target assembly behavior (`slot start index 8`, `24-slot scan`, `stride 0x38`, panic line `0xD74`).
- No compiler-coaxing-only temporaries or opaque reorder-only edits were introduced.

## Technical Details
- Slot scan starts at `this + 0x22E18 + 8 * 0x38` and iterates 24 entries for a null `_pppDataHead*` slot.
- On success, returns the slot index.
- On exhaustion, emits debug output when `System.m_execParam != 0`, then calls `OSPanic`.
