### PR TITLE
textureman: improve SetExternalTlutColor match

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -1032,9 +1032,8 @@ void CTexture::SetTlutColor(int index, _GXColor color)
 void CTexture::SetExternalTlutColor(void* tlutData, int tlutOffset, int index, _GXColor& color)
 {
     unsigned short color0 = static_cast<unsigned short>(color.r | (color.g << 8));
-    unsigned short color1 = static_cast<unsigned short>(color.b | (color.a << 8));
-    U16At(tlutData, index * 2) = color0;
-    U16At(tlutData, (index + tlutOffset) * 2) = color1;
+    *reinterpret_cast<unsigned short*>(Ptr(tlutData, (index + tlutOffset) * 2)) = static_cast<unsigned short>(color.b | (color.a << 8));
+    *reinterpret_cast<unsigned short*>(Ptr(tlutData, index * 2)) = color0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Adjusted `CTexture::SetExternalTlutColor` in `src/textureman.cpp` to write TLUT halfwords in the same order as the decomp reference.
- Replaced one intermediate local with a direct halfword store expression while keeping behavior unchanged.

## Functions improved
- Unit: `main/textureman`
- Symbol: `SetExternalTlutColor__8CTextureFPviiR8_GXColor`

## Match evidence
- Before: `27.88889%`
- After: `28.444445%`
- Delta: `+0.555555%`
- Verified with:
  - `build/tools/objdiff-cli diff -p . -u main/textureman -o - SetExternalTlutColor__8CTextureFPviiR8_GXColor`

## Plausibility rationale
- The change is source-plausible and idiomatic: it keeps the same color packing semantics (`RG` and `BA` 16-bit pairs) while using straightforward memory stores.
- No contrived temporaries or non-idiomatic control-flow tricks were introduced.

## Technical details
- The function still packs `color.r|color.g<<8` and `color.b|color.a<<8`, but writes the `(index + tlutOffset)` entry first, then `index`, which aligns better with target codegen ordering.
- Build verified with `ninja` after the edit.
