### PR TITLE
RedMidiCtrl: implement KeyOffSame and KeyOffVelocity

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -779,12 +779,16 @@ void __MidiCtrl_KeyOnVelocity(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C8430
+ * PAL Size: 56b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_KeyOffSame(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_KeyOffSame(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 {
-	// TODO
+    KeyOffSet(control, keyOnData, track);
 }
 
 /*
@@ -830,12 +834,20 @@ void __MidiCtrl_KeyOffNote(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, Re
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C851C
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __MidiCtrl_KeyOffVelocity(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA*)
+void __MidiCtrl_KeyOffVelocity(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, RedTrackDATA* track)
 {
-	// TODO
+    int* trackData = reinterpret_cast<int*>(track);
+
+    trackData[0] += 1;
+
+    KeyOffSet(control, keyOnData, track);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `__MidiCtrl_KeyOffSame` as a direct `KeyOffSet` dispatch.
- Implemented `__MidiCtrl_KeyOffVelocity` to consume velocity byte (`trackData[0] += 1`) and then call `KeyOffSet`.
- Added PAL address/size `--INFO--` metadata for both functions.

## Functions improved
Unit: `main/RedSound/RedMidiCtrl`
- `__MidiCtrl_KeyOffSame__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_KeyOffVelocity__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Match evidence
Measured with:
`build/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o - <symbol>`

- `__MidiCtrl_KeyOffSame...`: **7.142857% -> 56.5%**
- `__MidiCtrl_KeyOffVelocity...`: **5.5555553% -> 60.055557%**

## Plausibility rationale
- Both implementations match the expected MIDI command-handler pattern already used in adjacent functions (`KeyOffNoteVelocity`, `KeyOffNote`): read/advance track command stream, then dispatch to `KeyOffSet`.
- The edits are minimal and idiomatic, avoiding coercive compiler-only transformations.

## Technical details
- Verified full build success with `ninja` after changes.
- Confirmed no regressions in neighboring `KeyOn*` handlers by restoring baseline and retaining only the two positive-delta implementations.
