### PR TITLE
Improve calc__FP13VRyjMegaBirth particle integration path

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -155,7 +155,9 @@ void calc(
 	u8* paramPayload;
 	u8* particlePayload;
 	u8 fadeOutFrames;
+	u8 fadeInFrames;
 	float particleAngle;
+	Vec velocityStep;
 
 	alpha = (u8)((u8*)vColor)[0xB];
 	paramPayload = (u8*)param;
@@ -234,12 +236,34 @@ void calc(
 		}
 	}
 
+	*(float*)(particlePayload + 0x5C) = *(float*)(particlePayload + 0x5C) + *(float*)(paramPayload + 0xB0);
+	PSVECScale((Vec*)(particlePayload + 0x10), &velocityStep, *(float*)(particlePayload + 0x58));
+	PSVECAdd(&velocityStep, (Vec*)particlePayload, (Vec*)particlePayload);
+	PSVECScale(&work->m_accelerationAxis, &velocityStep, *(float*)(particlePayload + 0x5C));
+	PSVECAdd((Vec*)particlePayload, &velocityStep, (Vec*)particlePayload);
+
+	if (*(s16*)(paramPayload + 0x8E) != 0)
+	{
+		*(s16*)(particlePayload + 0x22) = *(s16*)(particlePayload + 0x22) - 1;
+	}
+
 	fadeOutFrames = *(u8*)(particlePayload + 0x59);
 	*(u8*)(particlePayload + 0x58) = *(u8*)(particlePayload + 0x58) + 1;
 	if ((fadeOutFrames != 0) && (*(u8*)(particlePayload + 0x58) <= fadeOutFrames))
 	{
 		*(float*)(particlePayload + 0x5C) =
 			*(float*)(particlePayload + 0x5C) - ((float)alpha / (float)fadeOutFrames);
+	}
+
+	fadeInFrames = *(u8*)(particlePayload + 0x5A);
+	if ((fadeInFrames != 0) && (*(u16*)(particlePayload + 0x22) <= (u16)fadeInFrames))
+	{
+		u8 blendWindow = paramPayload[0x95];
+		if (blendWindow != 0)
+		{
+			*(float*)(particlePayload + 0x5C) =
+				*(float*)(particlePayload + 0x5C) + ((float)alpha / (float)blendWindow);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Updated `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR` in `src/pppRyjMegaBirth.cpp` to restore missing per-frame particle integration logic.
- Added velocity/acceleration vector integration (`PSVECScale`/`PSVECAdd`) using existing field/offset layout used by this unit.
- Added missing lifetime decrement gate and secondary alpha blend ramp path.

## Functions Improved
- Unit: `main/pppRyjMegaBirth`
- Symbol: `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`
  - Before: `55.786324%`
  - After: `80.67522%`

## Match Evidence
- Unit `.text` match (`main/pppRyjMegaBirth`):
  - Before: `26.79264%`
  - After: `29.688711%`
- This change is from emitted logic changes in `calc__...`, not naming/formatting-only edits.

## Plausibility Rationale
- The added behavior follows normal particle update flow used elsewhere in the project: directional integration, acceleration-axis contribution, lifetime countdown, and staged alpha adjustments.
- Changes keep the existing code style and offset-based access pattern already used in this file, avoiding contrived compiler-coaxing constructs.

## Technical Details
- Reintroduced vector step integration around particle payload offsets (`+0x10`, `+0x58`, `+0x5C`) with `PSVECScale` and `PSVECAdd`.
- Added conditional decrement of particle life (`+0x22`) gated by param control (`+0x8E`).
- Added secondary blend path using fade threshold (`+0x5A`) and blend window (`+0x95`).
