### PR TITLE
MenuUtil: implement BindMcObj first-pass decomp

### DIFF
--- a/include/ffcc/MenuUtil.h
+++ b/include/ffcc/MenuUtil.h
@@ -25,6 +25,7 @@ public:
     void CalcOptionMenu();
     void DrawOptionMenu();
     void BindMcObj(int);
+    void BindEffect(int, int, int);
 };
 
 #endif // _FFCC_MENU_UTIL_H_

--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -3,6 +3,8 @@
 #include "ffcc/pad.h"
 #include "ffcc/sound.h"
 
+extern "C" void pppDeletePart__8CPartMngFi(void*, int);
+
 extern "C" float GetWidth__5CFontFPc(CFont*, const char*);
 extern "C" void SetMargin__5CFontFf(float, CFont*);
 extern "C" void SetShadow__5CFontFi(CFont*, int);
@@ -27,6 +29,8 @@ extern float lbl_8033364C;
 extern float lbl_80333650;
 
 extern "C" int __cntlzw(unsigned int);
+
+extern unsigned char PartMng[];
 
 static unsigned short GetMenuPress()
 {
@@ -470,10 +474,73 @@ void CMenuPcs::DrawOptionMenu()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017683c
+ * PAL Size: 336b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::BindMcObj(int)
+void CMenuPcs::BindMcObj(int saveIndex)
 {
-	// TODO
+	unsigned char* const self = reinterpret_cast<unsigned char*>(this);
+	int slot = 0;
+
+	do {
+		if (saveIndex == slot) {
+			int* const effect = reinterpret_cast<int*>(reinterpret_cast<unsigned int*>(self + 0x840)[0] + (slot + 0x11) * 0x524);
+
+			if (-1 < effect[1]) {
+				pppDeletePart__8CPartMngFi(PartMng, effect[1]);
+				effect[1] = -1;
+				effect[2] = -1;
+				effect[0] = -1;
+			}
+			if (-1 < effect[0x525]) {
+				pppDeletePart__8CPartMngFi(PartMng, effect[0x525]);
+				effect[0x525] = -1;
+				effect[0x526] = -1;
+				effect[0x524] = -1;
+			}
+		}
+		slot++;
+	} while (slot < 4);
+
+	slot = 0;
+	int offset = 0;
+
+	do {
+		if (saveIndex == slot) {
+			unsigned int* const saveData = reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned int*>(self + 0x838)[0]);
+			int boundEffect = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(saveData) + offset + 0xC);
+			if (boundEffect != 0) {
+				BindEffect(slot + 0x11, boundEffect + 0x16, -1);
+			}
+
+			unsigned int flags = *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(saveData) + offset + 0x28);
+			int mode;
+			if ((flags & 1) == 0) {
+				if ((flags & 2) == 0) {
+					if ((flags & 4) == 0) {
+						if ((flags & 8) == 0) {
+							if ((flags & 0x10) != 0) {
+								mode = 4;
+							}
+						} else {
+							mode = 3;
+						}
+					} else {
+						mode = 2;
+					}
+				} else {
+					mode = 1;
+				}
+			} else {
+				mode = 0;
+			}
+			BindEffect(slot + 0x11, mode + 0x1A, -1);
+		}
+		slot++;
+		offset += 0x48;
+	} while (slot < 4);
 }


### PR DESCRIPTION
## Summary
- Implemented `CMenuPcs::BindMcObj(int)` in `src/MenuUtil.cpp` from the PAL decomp reference as a first-pass plausible source reconstruction.
- Added the corresponding `BindEffect(int, int, int)` member declaration in `include/ffcc/MenuUtil.h` so the recovered function compiles with existing menu code.
- Added required extern declarations used by the recovered function (`pppDeletePart__8CPartMngFi`, `PartMng`).

## Functions improved
- Unit: `main/MenuUtil`
- Symbol: `BindMcObj__8CMenuPcsFi` (336b)
- Before: `1.2%` (from `tools/agent_select_target.py` target listing)
- After: `73.36905%` (`objdiff-cli diff` / `build/GCCP01/report.json`)

## Match evidence
- Build passes with `ninja`.
- `objdiff-cli` one-shot diff now reports `match_percent: 73.36905` for `BindMcObj__8CMenuPcsFi`.
- Remaining differences are mostly register/branch-layout level (dominant diff kinds are arg mismatches and a small number of control-flow insert/delete/replace entries), indicating substantial structural alignment vs. the prior stub.

## Plausibility rationale
- The function now expresses plausible original gameplay/menu behavior rather than compiler-coaxing:
  - Clears existing particle/effect handles for the selected save slot.
  - Rebinds slot effects based on stored save data and bitflag-driven mode selection.
  - Uses existing menu APIs (`BindEffect`) and part manager deletion flow (`pppDeletePart__8CPartMngFi`) consistent with surrounding code patterns.

## Technical details
- Preserved the project’s existing low-level style in this area (`reinterpret_cast` with known object offsets) to reflect current decomp conventions.
- Added PAL function metadata block for address/size in the required format.
