### PR TITLE
gbaque: improve GetCaravanName semaphore iteration matching

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1163,24 +1163,24 @@ void GbaQueue::GetPlayerStat(int, GbaPInfo*)
 void GbaQueue::GetCaravanName(char* outName)
 {
 	int i;
-	GbaQueue* semaphoreIter;
+	OSSemaphore* semaphoreIter;
 
 	i = 0;
-	semaphoreIter = this;
+	semaphoreIter = (OSSemaphore*)this;
 	do {
-		OSWaitSemaphore(semaphoreIter->accessSemaphores);
+		OSWaitSemaphore(semaphoreIter);
 		i++;
-		semaphoreIter = reinterpret_cast<GbaQueue*>(semaphoreIter->accessSemaphores + 1);
+		semaphoreIter++;
 	} while (i < 4);
 
 	memcpy(outName, reinterpret_cast<char*>(this) + 0x2A74, 0x80);
 
 	i = 0;
-	semaphoreIter = this;
+	semaphoreIter = (OSSemaphore*)this;
 	do {
-		OSSignalSemaphore(semaphoreIter->accessSemaphores);
+		OSSignalSemaphore(semaphoreIter);
 		i++;
-		semaphoreIter = reinterpret_cast<GbaQueue*>(semaphoreIter->accessSemaphores + 1);
+		semaphoreIter++;
 	} while (i < 4);
 }
 


### PR DESCRIPTION
## Summary
- Reworked `GbaQueue::GetCaravanName(char*)` semaphore traversal to iterate as contiguous `OSSemaphore*` entries.
- Replaced `GbaQueue*`-based reinterpret stepping with direct semaphore pointer iteration for both wait/release loops.
- Kept function behavior unchanged (`memcpy` payload and lock/unlock count are unchanged).

## Functions improved
- `main/gbaque`
  - `GetCaravanName__8GbaQueueFPc`: **95.75676% -> 98.91892%** (`148b`)

## Match evidence
- Rebuilt with `ninja` after the change.
- `build/GCCP01/report.json` now reports `GetCaravanName__8GbaQueueFPc` at `98.91892%`.
- Assembly alignment improvement:
  - Loop base/stride now matches target (`OSWaitSemaphore` / `OSSignalSemaphore` called on base pointer with `+12` stride per iteration) instead of the prior `+0x80` base and `+0x8C` stride pattern.

## Plausibility rationale
- The change removes artificial object-pointer stepping and expresses the logic as direct semaphore-array iteration, which is more natural source for semaphore handling.
- No compiler-coaxing temporaries or non-idiomatic control-flow were added.

## Technical details
- Source edit is isolated to `src/gbaque.cpp` (`GetCaravanName`).
- Both lock and unlock loops now operate on `OSSemaphore* semaphoreIter` with `semaphoreIter++` for 4 channels.
