### PR TITLE
pppColum: fix pppFrameColum shape data pointer

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -195,8 +195,9 @@ void pppFrameColum(pppColum *column, UnkB *param_2, UnkC *param_3)
         }
 
         if (param_2->m_dataValIndex != 0xffff) {
+            long* animData = **(long***)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4);
             pppCalcFrameShape__FPlRsRsRss(
-                *(long**)(*(int*)&pppEnvStPtr->m_particleColors[0] + param_2->m_dataValIndex * 4),
+                animData,
                 *(short*)(work + 0), *(short*)(work + 2), *(short*)(work + 4), param_2->m_initWOrk);
         }
     }


### PR DESCRIPTION
## Summary
- Adjust `pppFrameColum` to pass the shape animation-data pointer into `pppCalcFrameShape`.
- Keep behavior/source style aligned with existing code by only changing the callsite data source and leaving surrounding control flow intact.

## Functions improved
- Unit: `main/pppColum`
- Symbol improved: `pppFrameColum`
- Related symbol checked: `pppRenderColum` (no regression)

## Match evidence
- `pppFrameColum`: **80.61729% -> 81.85185%**
- `pppRenderColum`: **60.54799% -> 60.54799%** (unchanged)
- Objdiff delta signal: `pppFrameColum` diff kinds changed from `33 arg_mismatch / 5 delete / 5 insert / 6 replace` to `33 arg_mismatch / 4 delete / 5 insert / 6 replace`.

## Plausibility rationale
- The updated call now passes what `pppCalcFrameShape` logically consumes for shape progression (animation data), rather than the owning shape wrapper pointer.
- This is consistent with neighboring code paths that obtain animation data from the same shape entry before shape/frame operations.
- Change is minimal and source-plausible (type/data correctness), not register-coaxing or control-flow distortion.

## Technical details
- Before: `pppCalcFrameShape` first argument came from a single dereference of the shape table entry.
- After: first argument is the underlying anim-data pointer (`**tableEntry`), matching Ghidra’s dataflow for `pppFrameColum`.
