### PR TITLE
monobj: first-pass implementation for fn_801162B4

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -1083,6 +1083,21 @@ void CGMonObj::moveChaseAndStat(CGCharaObj*, int, float, int, int)
 
 /*
  * --INFO--
+ * PAL Address: 0x801162B4
+ * PAL Size: 60b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void fn_801162B4(CGMonObj* monObj)
+{
+	*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(monObj) + 0x6C8) = 0;
+	memset(reinterpret_cast<unsigned char*>(monObj) + 0x70C, 0, 0x34);
+}
+
+/*
+ * --INFO--
  * Address:	TODO
  * Size:	TODO
  */


### PR DESCRIPTION
## Summary
- Added a first-pass C implementation for `fn_801162B4` in `src/monobj.cpp`.
- Included the standard PAL/EN/JP function metadata block with PAL address/size from decomp resources.
- Kept behavior focused and source-plausible: reset AI state slot and clear the `0x70C` work buffer.

## Functions improved
- Unit: `main/monobj`
- Symbol: `fn_801162B4` (PAL `0x801162B4`, size `60b`)

## Match evidence
- `objdiff-cli diff -p . -u main/monobj -o - --format json-pretty fn_801162B4`
- Current symbol match reported: `60.6%` (`left size 60`, `right size 52`).
- Prior to this change the function was still an unmatched `fn_*` target with no source implementation in `src/monobj.cpp`.

## Plausibility rationale
- The implementation is a direct, minimal translation of the recovered logic from the Ghidra reference for this address.
- It uses existing monobj field conventions already present in this file (`0x6C8` AI state and `0x70C` work buffer), without introducing coercion-only control-flow tricks.

## Technical details
- Change is isolated to one symbol to avoid collateral regressions while establishing a baseline for the `0x801162B4` helper family (`fn_801162F0`, `fn_80116654`, `fn_80116870`).
- Build and report generation pass with `ninja`.
