### PR TITLE
gobjwork: implement CCaravanWork::FindItem

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -90,7 +90,7 @@ public:
     void FGAddItemIdx(int, int);
     void ChkNumItem(char*, int);
     void CanAddTmpArtifact(int);
-    void FindItem(int);
+    int FindItem(int);
     void DeleteItemIdx(int, int);
     void DeleteItem(int, int);
     void AddTmpArtifact(int, int*);

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -573,12 +573,52 @@ void CCaravanWork::CanAddTmpArtifact(int)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800a1d70
+ * PAL Size: 284b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CCaravanWork::FindItem(int)
+int CCaravanWork::FindItem(int itemId)
 {
-	// TODO
+	int baseIdx = 0;
+	int rowCount = 8;
+	CCaravanWork* cur = this;
+
+	while (true) {
+		if ((short)cur->m_inventoryItems[0] != -1 && (short)cur->m_inventoryItems[0] == itemId) {
+			return baseIdx;
+		}
+		if ((short)cur->m_inventoryItems[1] != -1 && (short)cur->m_inventoryItems[1] == itemId) {
+			return baseIdx + 1;
+		}
+		if ((short)cur->m_inventoryItems[2] != -1 && (short)cur->m_inventoryItems[2] == itemId) {
+			return baseIdx + 2;
+		}
+		if ((short)cur->m_inventoryItems[3] != -1 && (short)cur->m_inventoryItems[3] == itemId) {
+			return baseIdx + 3;
+		}
+		if ((short)cur->m_inventoryItems[4] != -1 && (short)cur->m_inventoryItems[4] == itemId) {
+			return baseIdx + 4;
+		}
+		if ((short)cur->m_inventoryItems[5] != -1 && (short)cur->m_inventoryItems[5] == itemId) {
+			return baseIdx + 5;
+		}
+		if ((short)cur->m_inventoryItems[6] != -1 && (short)cur->m_inventoryItems[6] == itemId) {
+			return baseIdx + 6;
+		}
+		if ((short)cur->m_inventoryItems[7] != -1 && (short)cur->m_inventoryItems[7] == itemId) {
+			return baseIdx + 7;
+		}
+
+		cur = (CCaravanWork*)&cur->m_baseDataIndex;
+		baseIdx += 8;
+		rowCount--;
+		if (rowCount == 0) {
+			return -1;
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `CCaravanWork::FindItem(int)` in `src/gobjwork.cpp` instead of a TODO stub.
- Corrected the class declaration in `include/ffcc/gobjwork.h` from `void FindItem(int)` to `int FindItem(int)`.
- Added version info block for the function using PAL address/size metadata.

## Functions Improved
- Unit: `main/gobjwork`
- Symbol: `FindItem__12CCaravanWorkFi`

## Match Evidence
- `FindItem__12CCaravanWorkFi`: **1.4084507% -> 78.830986%** (size 284b)
- Verified with:
  - `tools/objdiff-cli diff -p . -u main/gobjwork --format json -o /tmp/finditem_before.json FindItem__12CCaravanWorkFi`
  - `tools/objdiff-cli diff -p . -u main/gobjwork --format json -o /tmp/finditem_after.json FindItem__12CCaravanWorkFi`
- `ninja` build passes in PAL configuration and regenerates report successfully.

## Plausibility Rationale
- The previous function was an unimplemented placeholder and mismatched declaration, which is implausible for original shipped source.
- The new implementation uses straightforward inventory scanning logic across 64 entries in 8-entry chunks, matching expected game-side coding style.
- No contrived compiler-coaxing constructs were introduced.

## Technical Details
- The function now returns an inventory slot index for the requested item, skipping empty entries (`0xFFFF`) and returning `-1` if not found.
- Control flow is structured to align with the recovered unrolled 8-item check pattern and chunk iteration behavior.
