### PR TITLE
pppYmMegaBirthShpTail3: first-pass render implementation

### DIFF
--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -7,9 +7,15 @@
 class CMath;
 extern CMath Math;
 extern "C" float RandF__5CMathFv(CMath*);
+extern "C" int __cntlzw(unsigned int);
 extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 extern "C" void pppUnitMatrix__FR10pppFMATRIX(pppFMATRIX*);
 extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+extern "C" void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+    void*, void*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char,
+    unsigned char);
+extern "C" void pppSetBlendMode__FUc(unsigned char);
+extern "C" void pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(void*, void*, unsigned char);
 extern int rand();
 extern float FLOAT_803305a4;
 extern pppFMATRIX MatUnit3;
@@ -514,10 +520,195 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 8008ca98
+ * PAL Size: 2316b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void pppRenderYmMegaBirthShpTail3(pppYmMegaBirthShpTail3*, UnkB*, UnkC*)
+void pppRenderYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, UnkB* stepData, UnkC* offsets)
 {
-	// TODO
+    u8* step = (u8*)stepData;
+    u8* payload = step + 0x14;
+    const u16 dataValIndex = *(u16*)step;
+    const s32 particleDataOffset = offsets->m_serializedDataOffsets[2];
+    _PARTICLE_DATA* particles = *(_PARTICLE_DATA**)((u8*)&object->field_0xbc + particleDataOffset);
+    _PARTICLE_WMAT* wmats = *(_PARTICLE_WMAT**)((u8*)&object->field_0xc0 + particleDataOffset);
+    _PARTICLE_COLOR* colors = *(_PARTICLE_COLOR**)((u8*)&object->field_0xc4 + particleDataOffset);
+    const u32 maxParticles = *(u32*)((u8*)&object->field_0xc8 + particleDataOffset);
+    bool hasRequiredMemory = false;
+
+    if (particles != 0 && wmats != 0) {
+        hasRequiredMemory = (payload[0x55] == 0) || (colors != 0);
+    }
+    if (!hasRequiredMemory || dataValIndex == 0xFFFF) {
+        return;
+    }
+
+    int shapeTable = **(int**)(*(int*)&pppEnvStPtr->m_particleColors[0] + dataValIndex * 4);
+    const u8 zEnable = (u8)(((u32)__cntlzw((u32)payload[0x55])) >> 5);
+    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+        (void*)(payload + 0xA0), &object->field_0x40, *(float*)(payload + 0xA4), step[0x10], payload[0x58],
+        payload[0x58], 0, zEnable, 1, 0);
+    pppSetBlendMode__FUc(payload[0x58]);
+
+    for (u32 i = 0; i < maxParticles; i++) {
+        u8* particle = (u8*)particles + i * 0x1F8;
+        if (*(s16*)(particle + 0x22) != 0) {
+            const u16 frameCountRaw = *(u16*)(payload + 0x9C);
+            if (frameCountRaw != 0) {
+                pppFMATRIX drawMtx;
+                Vec drawPos;
+                Vec cameraPos;
+                Vec managerPos;
+                Vec zeroVec;
+                GXColor amb;
+                const s16 shapeOffset = *(s16*)(shapeTable + (u16)*(u16*)(particle + 0x1C) * 8 + 0x10);
+                const u8 trailReadIndex = *(u8*)(particle + 0x38);
+                const u8 trailMaxIndex = (u8)(*(u8*)(particle + 0x37) - 1);
+                u8 trailNextIndex = (u8)(trailReadIndex + 1);
+                float drawScale = *(float*)(payload + 0x5C);
+                const float drawScaleStep =
+                    (drawScale - *(float*)(payload + 0x60)) / ((frameCountRaw > 1) ? (float)(frameCountRaw - 1) : 1.0f);
+                float fadeR = (float)*(s16*)((u8*)&object->m_data[4] + particleDataOffset) / 128.0f;
+                float fadeG = (float)*(s16*)((u8*)&object->m_data[6] + particleDataOffset) / 128.0f;
+                float fadeB = (float)*(s16*)((u8*)&object->m_data[8] + particleDataOffset) / 128.0f;
+                float fadeA = (float)*(s16*)((u8*)&object->m_data[10] + particleDataOffset) / 128.0f;
+                const float fadeRStep =
+                    (fadeR - (float)*(s16*)((u8*)&object->m_data[16] + particleDataOffset) / 128.0f) /
+                    ((frameCountRaw > 1) ? (float)(frameCountRaw - 1) : 1.0f);
+                const float fadeGStep =
+                    (fadeG - (float)*(s16*)((u8*)&object->m_data[18] + particleDataOffset) / 128.0f) /
+                    ((frameCountRaw > 1) ? (float)(frameCountRaw - 1) : 1.0f);
+                const float fadeBStep =
+                    (fadeB - (float)*(s16*)((u8*)&object->m_data[20] + particleDataOffset) / 128.0f) /
+                    ((frameCountRaw > 1) ? (float)(frameCountRaw - 1) : 1.0f);
+                const float fadeAStep =
+                    (fadeA - (float)*(s16*)((u8*)&object->m_data[22] + particleDataOffset) / 128.0f) /
+                    ((frameCountRaw > 1) ? (float)(frameCountRaw - 1) : 1.0f);
+                const float spacing = *(float*)(payload + 0x98);
+                Vec* history = (Vec*)(particle + 0x80);
+                Vec segVec;
+                float segLen;
+                float segProgress = 0.0f;
+                u16 frameCount = frameCountRaw;
+
+                if (trailReadIndex == trailMaxIndex) {
+                    trailNextIndex = 0;
+                }
+
+                drawPos = history[trailReadIndex];
+                cameraPos = history[trailNextIndex];
+                segVec.x = cameraPos.x - drawPos.x;
+                segVec.y = cameraPos.y - drawPos.y;
+                segVec.z = cameraPos.z - drawPos.z;
+                zeroVec.x = 0.0f;
+                zeroVec.y = 0.0f;
+                zeroVec.z = 0.0f;
+                segLen = PSVECDistance(&zeroVec, &segVec);
+
+                if (payload[0x9E] == 0) {
+                    continue;
+                }
+
+                while (frameCount != 0) {
+                    Vec trailPos = drawPos;
+                    bool canDraw = (trailPos.x != 0.0f) || (trailPos.y != 0.0f) || (trailPos.z != 0.0f);
+                    if (canDraw) {
+                        pppUnitMatrix__FR10pppFMATRIX(&drawMtx);
+                        drawMtx.value[0][0] = drawScale * pppMngStPtr->m_scale.x;
+                        drawMtx.value[1][1] = drawScale * pppMngStPtr->m_scale.y;
+                        drawMtx.value[2][2] = drawScale * pppMngStPtr->m_scale.z;
+
+                        if (payload[0xA5] == 0) {
+                            PSMTXMultVec(ppvWorldMatrix, &trailPos, &cameraPos);
+                        } else if (payload[0xA5] == 1) {
+                            managerPos.x = pppMngStPtr->m_matrix.value[0][3];
+                            managerPos.y = pppMngStPtr->m_matrix.value[1][3];
+                            managerPos.z = pppMngStPtr->m_matrix.value[2][3];
+                            PSVECAdd(&trailPos, &managerPos, &trailPos);
+                            PSMTXMultVec(ppvCameraMatrix0, &trailPos, &cameraPos);
+                        } else {
+                            cameraPos = trailPos;
+                        }
+
+                        drawMtx.value[0][3] = cameraPos.x;
+                        drawMtx.value[1][3] = cameraPos.y;
+                        drawMtx.value[2][3] = cameraPos.z;
+                        GXLoadPosMtxImm(drawMtx.value, 0);
+
+                        amb.r = (u8)fadeR;
+                        amb.g = (u8)fadeG;
+                        amb.b = (u8)fadeB;
+                        amb.a = (u8)(fadeA * (1.0f - *(float*)(particle + 0x30)));
+                        if (amb.a > 0x7F) {
+                            amb.a = 0x7F;
+                        }
+                        GXSetChanAmbColor(GX_COLOR0A0, amb);
+                        pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(
+                            (void*)(shapeTable + shapeOffset), pppEnvStPtr->m_materialSetPtr, payload[0x58]);
+                    }
+
+                    frameCount--;
+                    if (frameCount == 0 || spacing <= 0.0f) {
+                        break;
+                    }
+
+                    drawScale -= drawScaleStep;
+                    fadeR -= fadeRStep;
+                    fadeG -= fadeGStep;
+                    fadeB -= fadeBStep;
+                    fadeA -= fadeAStep;
+                    if (drawScale <= 0.0f) {
+                        break;
+                    }
+
+                    segProgress += spacing;
+                    while (segLen > 0.0f && segProgress > segLen) {
+                        const float overflow = segProgress - segLen;
+                        trailNextIndex++;
+                        if (trailNextIndex > trailMaxIndex) {
+                            trailNextIndex = 0;
+                        }
+                        if (trailNextIndex == trailReadIndex) {
+                            frameCount = 0;
+                            break;
+                        }
+
+                        drawPos = history[trailNextIndex];
+                        {
+                            u8 nextTrail = (u8)(trailNextIndex + 1);
+                            if (trailNextIndex == trailMaxIndex) {
+                                nextTrail = 0;
+                            }
+                            cameraPos = history[nextTrail];
+                        }
+                        segVec.x = cameraPos.x - drawPos.x;
+                        segVec.y = cameraPos.y - drawPos.y;
+                        segVec.z = cameraPos.z - drawPos.z;
+                        segLen = PSVECDistance(&zeroVec, &segVec);
+                        segProgress = overflow;
+                    }
+                    if (frameCount == 0 || segLen <= 0.0f) {
+                        break;
+                    }
+
+                    {
+                        const float t = segProgress / segLen;
+                        drawPos.x = history[trailNextIndex].x + segVec.x * t;
+                        drawPos.y = history[trailNextIndex].y + segVec.y * t;
+                        drawPos.z = history[trailNextIndex].z + segVec.z * t;
+                    }
+                }
+            }
+        }
+
+        if (wmats != 0) {
+            wmats = wmats + 1;
+        }
+        if (colors != 0) {
+            colors = colors + 1;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Implemented a first-pass `pppRenderYmMegaBirthShpTail3` in `src/pppYmMegaBirthShpTail3.cpp` and replaced the previous TODO stub.

- Added missing render-side extern declarations used by this unit (`__cntlzw`, draw-env/blend/draw-shape helpers)
- Added PAL function metadata block for `pppRenderYmMegaBirthShpTail3` (`8008ca98`, `2316b`)
- Implemented particle-trail rendering flow for Tail3:
  - work pointer/data guards
  - render setup (`pppSetDrawEnv`, blend mode)
  - per-particle trail stepping and interpolation
  - world/camera transform path selection
  - ambient color setup and shape draw calls

## Functions Improved
Unit: `main/pppYmMegaBirthShpTail3`

- `pppRenderYmMegaBirthShpTail3`
  - Before: `0.2%` (selector baseline)
  - After: `12.61658%` (`objdiff-cli` oneshot)

## Match Evidence
Command used:

```sh
../../tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o - pppRenderYmMegaBirthShpTail3 \
  | jq '.left.symbols[] | select(.name=="pppRenderYmMegaBirthShpTail3") | .match_percent'
```

Result after this change:

- `12.61658`

Build verification:

- `ninja` passes in PAL config and regenerates report successfully.

## Plausibility Rationale
This is implemented as a source-plausible first pass, based on:

- existing `pppYmMegaBirthShpTail2` renderer structure/style already used in-tree
- Tail3-specific offsets/fields from the existing Ghidra reference
- idiomatic engine helper usage (`pppSetDrawEnv`, `pppSetBlendMode`, `GXLoadPosMtxImm`, `pppDrawShp`)

The implementation favors natural game-source control flow over isolated compiler-coaxing tricks, while establishing a substantial initial match improvement for this previously near-empty function.
