### PR TITLE
monobj_table: fix __sinit symbol linkage for matching

### DIFF
--- a/src/monobj_table.cpp
+++ b/src/monobj_table.cpp
@@ -2,10 +2,14 @@
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801434a8
+ * PAL Size: 8012b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void __sinit_monobj_table_cpp(void)
+extern "C" void __sinit_monobj_table_cpp(void)
 {
 	// TODO
 }


### PR DESCRIPTION
## Summary
- Updated `__sinit_monobj_table_cpp` in `src/monobj_table.cpp` to use C linkage (`extern "C"`) so the produced symbol name matches the expected DOL symbol.
- Replaced the function info block with PAL address/size metadata from the Ghidra export (`0x801434a8`, `8012b`).

## Functions improved
- Unit: `main/monobj_table`
- Symbol: `__sinit_monobj_table_cpp` (PAL size 8012b)

## Match evidence
- Before this change, the compiled symbol name was `__sinit_monobj_table_cpp__Fv` and objdiff could not pair it with target `__sinit_monobj_table_cpp` (no valid symbol-level comparison).
- After this change, objdiff pairs the correct symbol and reports non-zero instruction matching:
  - `__sinit_monobj_table_cpp`: `0.04992511%` match

## Plausibility rationale
- `__sinit_*` functions in this codebase are linker-facing startup symbols and frequently require exact linkage naming.
- Using C linkage here is a source-plausible fix for symbol ABI/name alignment, not compiler-coaxing; it restores the intended symbol identity for decomp matching.

## Technical details
- Verified with:
  - `ninja`
  - `/Users/zcanann/Documents/FFCC-Decomp/tools/objdiff-cli diff -p . -u main/monobj_table -o - __sinit_monobj_table_cpp`
- Post-change objdiff output shows a valid `target_symbol` mapping for `__sinit_monobj_table_cpp` and non-zero match percent.
