### PR TITLE
RedExecute: implement PitchCompute first pass

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -31,6 +31,8 @@ extern int DAT_8032f400;
 extern s16 DAT_8021ddce[];
 extern s16 DAT_8021dfce[];
 extern s16 DAT_8021de4e;
+extern u32 DAT_8021d7f0[];
+extern int DAT_8021d820[];
 extern int lbl_8021EA10[];
 
 struct RedReverbDATA {
@@ -60,13 +62,38 @@ u8 GetRandomData()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801C2FFC
+ * PAL Size: 256b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-int PitchCompute(int, int, int, int)
+int PitchCompute(int param_1, int param_2, int param_3, int param_4)
 {
-	// TODO
-	return 0;
+    u32 value;
+    u32 param4;
+    int result;
+    u32 pitch;
+
+    result = 0;
+    for (pitch = (param_1 >> 12) + param_2 + (param_3 >> 16); (int)pitch < 0; pitch += 0xC00) {
+        result--;
+    }
+
+    value = (pitch >> 8) & 0x7F;
+    result = (int)((DAT_8021d7f0[value % 12] >> (10 - (result + (int)(value / 12)))) * DAT_8021d820[pitch & 0xFF]) >> 12;
+
+    param4 = (u32)param_4;
+    if (param4 != 0) {
+        if ((int)param4 < 1) {
+            result = (int)(result * (param4 & 0xFF)) >> 8;
+        } else {
+            result = result + ((int)(result * (param4 + 1)) >> 7);
+        }
+    }
+
+    return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Implemented `PitchCompute__Fiiii` in `src/RedSound/RedExecute.cpp` (previously TODO stub returning 0)
- Added PAL function metadata block for this function (`0x801C2FFC`, `256b`)
- Added missing extern table declarations used by the fixed-point pitch path (`DAT_8021d7f0`, `DAT_8021d820`)

## Functions improved
- Unit: `main/RedSound/RedExecute`
- Symbol: `PitchCompute__Fiiii`

## Match evidence
- Before: `2.2%` (selector output for this symbol)
- After: `15.890625%` (`objdiff-cli v3.6.1`, one-shot JSON diff on `PitchCompute__Fiiii`)

## Plausibility rationale
- This replaces a non-original placeholder with a concrete fixed-point implementation using lookup tables and interpolation, which is consistent with production-era audio pitch computation patterns in this codebase.
- The change avoids compiler-coaxing patterns and keeps behavior-oriented structure (normalization loop, table lookup, optional modulation scaling).

## Technical details
- Implemented normalization of semitone/fraction input into a non-negative pitch accumulator (`+0xC00` loop).
- Implemented octave/semitone factor application via table lookup and shift.
- Implemented optional modulation adjustment branch matching the Ghidra-decompiled control flow shape.
- Verified build with `ninja` and measured function delta with objdiff oneshot JSON mode.
