### PR TITLE
MenuUtil: implement CMenuPcs::DrawFont2

### DIFF
--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -124,12 +124,27 @@ void CMenuPcs::GetFontWidth(char*, float, float)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8017ac40
+ * PAL Size: 272b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CMenuPcs::DrawFont2(int, int, _GXColor, int, char*, float, float, float)
+void CMenuPcs::DrawFont2(int posX, int posY, _GXColor color, int tlut, char* text, float margin, float scaleX, float scaleY)
 {
-	// TODO
+	CFont* font = *(CFont**)((unsigned char*)this + 0xF8);
+
+	SetMargin__5CFontFf(margin, font);
+	SetShadow__5CFontFi(font, 1);
+	SetScaleX__5CFontFf(scaleX, font);
+	SetScaleY__5CFontFf(scaleY, font);
+	DrawInit__5CFontFv(font);
+	SetTlut__5CFontFi(font, tlut);
+	SetColor__5CFontF8_GXColor(font, &color);
+	SetPosX__5CFontFf((float)posX, font);
+	SetPosY__5CFontFf((float)posY, font);
+	Draw__5CFontFPc(font, text);
 }
 
 /*


### PR DESCRIPTION
## Summary
Implemented `CMenuPcs::DrawFont2(int, int, _GXColor, int, char*, float, float, float)` in `src/MenuUtil.cpp` using existing `CFont` call patterns already used across menu code.

Changes include:
- Added PAL metadata header for the function (`0x8017ac40`, `272b`)
- Hooked up font setup/render sequence: margin, shadow, scale X/Y, draw init, tlut/color, XY position, draw call
- Used typed parameters (`posX`, `posY`, `color`, `tlut`, `text`, `margin`, `scaleX`, `scaleY`) and existing helper calls for source-plausible style

## Functions improved
- Unit: `main/MenuUtil`
- Symbol: `DrawFont2__8CMenuPcsFii8_GXColoriPcfff`

## Match evidence
- `DrawFont2__8CMenuPcsFii8_GXColoriPcfff`: **1.4705882% -> 89.588234%** (from `build/GCCP01/report.json` before/after)
- `main/MenuUtil` unit fuzzy match: **13.435597% -> 14.757168%**
- `tools/objdiff-cli` v3.6.1 one-shot diff reports the function at ~**89.44%** with aligned structure and call flow.

## Plausibility rationale
This implementation mirrors established in-repo style for `CFont` draw helpers (`DrawFont`, message/menu code) and uses idiomatic field access (`this + 0xF8` font pointer) and function ordering consistent with surrounding source. It targets plausible original source reconstruction rather than compiler-coaxing.

## Technical details
- Reused the same extern helper API and call order already present in `MenuUtil.cpp` and other menu modules.
- Matched the decomp-guided behavior for independent X/Y scale handling, the key difference from `DrawFont`.
- Build/verification: `python3 configure.py --version GCCP01` then `ninja` (pass, `build/GCCP01/main.dol: OK`).
