### PR TITLE
Gecko_ExceptionPPC: Fix compiler version, data matching, and bad_exce…

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -928,7 +928,7 @@ config.libs = [
             Object(
                 NonMatching,
                 "Runtime.PPCEABI.H/Gecko_ExceptionPPC.cp",
-                mw_version="GC/2.6",
+                mw_version="GC/2.7",
                 extra_cflags=["-inline auto,deferred", "-char signed", "-RTTI on"],
             ),
             Object(

--- a/src/Runtime.PPCEABI.H/Gecko_ExceptionPPC.cp
+++ b/src/Runtime.PPCEABI.H/Gecko_ExceptionPPC.cp
@@ -1,8 +1,42 @@
+#define _EXCEPTION  // Block exception.h — local class definitions needed for inline dtor inlining
+
 #include "PowerPC_EABI_Support/Runtime/MWCPlusLib.h"
 #include "PowerPC_EABI_Support/Runtime/Gecko_ExceptionPPC.h"
 #include "PowerPC_EABI_Support/Runtime/NMWException.h"
 #include "PowerPC_EABI_Support/Runtime/__ppc_eabi_linker.h"
-#include "PowerPC_EABI_Support/Runtime/exception.h"
+
+namespace std {
+
+class exception {
+public:
+	virtual ~exception() {}
+	virtual const char* what() const;
+};
+
+class bad_exception : public exception {
+public:
+	virtual ~bad_exception();
+	virtual const char* what() const;
+};
+
+typedef void (*unexpected_handler)();
+unexpected_handler set_unexpected(unexpected_handler handler);
+void unexpected();
+
+typedef void (*terminate_handler)();
+terminate_handler set_terminate(terminate_handler handler);
+void terminate();
+
+} // namespace std
+
+using std::bad_exception;
+using std::exception;
+using std::terminate;
+using std::terminate_handler;
+using std::set_terminate;
+using std::unexpected;
+using std::unexpected_handler;
+using std::set_unexpected;
 
 #pragma force_active on
 
@@ -649,8 +683,7 @@ extern "C" const char s_bad_exception[];
 
 using std::bad_exception;
 
-extern "C" const char s_bad_exception[] = "bad_exception";
-static const char s_exception[]        = "exception";
+extern "C" const char s_bad_exception[] = "bad_exception\0\0\0exception\0\0\0\0\0\0";
 
 namespace std {
 


### PR DESCRIPTION
…ption dtor

- Change mw_version from GC/2.6 to GC/2.7 (matches target .comment metadata: Version 11, Compiler 2.4.7.1)
- Pack s_bad_exception string to match target layout ("bad_exception\0\0\0exception\0\0\0\0\0\0")
- Define exception class locally with inline dtor to allow bad_exception dtor to inline base class vtable assignment (matching target exactly)
- Block exception.h via _EXCEPTION guard to avoid conflict with NMWException.h transitive include

Improvements:
  s_bad_exception: 60.87% -> 100% __dt__Q23std13bad_exceptionFv: 65% -> 100% __unexpected: 94.17% -> 94.27% SDK matched code: +92 bytes (304812 -> 304904)

Regressions (from weak __dt__Q23std9exceptionFv emission):
  extab: 96.55% -> 94.17%
  extabindex: 98.57% -> 76.67%
  Note: weak symbol stripped at link time, no impact on final binary