### PR TITLE
Refine pppFrameLensFlare alpha conversion matching

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -99,10 +99,12 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 				double d;
 				u32 u[2];
 			} alphaScaleBits;
+			float alphaValue;
 
 			alphaScaleBits.u[0] = 0x43300000;
 			alphaScaleBits.u[1] = sourceAlpha;
-			alphaScale = (float)((float)(alphaScaleBits.d - kPppLensFlareUnusedDouble) * kPppLensFlareAlphaScale);
+			alphaValue = (float)(alphaScaleBits.d - kPppLensFlareUnusedDouble);
+			alphaScale = alphaValue * kPppLensFlareAlphaScale;
 		}
 
 		GXGetViewportv(viewport);
@@ -160,10 +162,10 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 		if ((u8)work->m_alpha == sampleCount) {
 			work->m_alpha = 0xff;
 		} else {
-			u32 scaledAlpha = (u8)work->m_alpha * (0xFF / sampleCount);
+			int scaledAlpha = (u8)work->m_alpha * (0xFF / sampleCount);
 
 			work->m_alpha = (u8)scaledAlpha;
-			if ((u8)scaledAlpha <= 0xFF) {
+			if ((int)(u8)scaledAlpha <= 0xFF) {
 				work->m_alpha = (u8)scaledAlpha;
 			} else {
 				work->m_alpha = 0xff;
@@ -175,11 +177,12 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 				double d;
 				u32 u[2];
 			} finalAlphaBits;
+			float finalAlpha;
 
 			finalAlphaBits.u[0] = 0x43300000;
 			finalAlphaBits.u[1] = (u8)work->m_alpha;
-			work->m_alpha =
-				(u8)(int)((float)(finalAlphaBits.d - kPppLensFlareUnusedDouble) * alphaScale);
+			finalAlpha = (float)(finalAlphaBits.d - kPppLensFlareUnusedDouble);
+			work->m_alpha = (u8)(int)(finalAlpha * alphaScale);
 		}
 		if (unkB->m_dataValIndex != 0xffff) {
 			long** shapeTable = *(long***)(*(int*)&pppEnvStPtr->m_particleColors[0] + unkB->m_dataValIndex * 4);


### PR DESCRIPTION
Summary:
- split the alpha byte-to-float conversions in `pppFrameLensFlare` through explicit float temporaries
- use a signed intermediate for the sampled alpha clamp so the generated compare shape is closer to the target
- keep the logic identical while steering MWCC toward the original float pipeline

Units/functions improved:
- `main/pppLensFlare`
- `pppFrameLensFlare`: objdiff `match_percent` 96.56398 -> 96.84834
- `pppFrameLensFlare`: report `fuzzy_match_percent` 96.56398-ish selector baseline / 96.6 bucket -> 96.91943 after rebuild

Progress evidence:
- symbol diff reduced from 3 `DIFF_REPLACE` + 2 `DIFF_INSERT` + 1 `DIFF_OP_MISMATCH` to 2 `DIFF_REPLACE` + 2 `DIFF_INSERT` + 1 `DIFF_OP_MISMATCH`
- build remains clean with `ninja`
- no data or linkage regressions were introduced in this unit

Plausibility rationale:
- the new source expresses the byte-to-float conversion in straightforward game code terms: convert once to float, then scale
- using an `int` for the temporary alpha scale is also a normal source-level choice for clamping a byte-derived sample count
- this avoids offset hacks, symbol hacks, and any linkage shortcuts

Technical details:
- the target assembly wants the alpha conversion to stay in single-precision around the subtraction/multiply sequence
- factoring the expressions into float temporaries removes one instruction replacement in objdiff and improves the symbol score without changing behavior