### PR TITLE
Improve pppPObjPoint codegen

### DIFF
--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -27,18 +27,18 @@ void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* co
         return;
     }
 
-    s32 objOffset = *(s32*)container->ptrData;
-    PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + objOffset + 0x80);
+    PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + *(s32*)container->ptrData + 0x80);
 
     if (objData->id == pointData->id) {
         u8* vecPtr;
+        u32 dataValIndex = objData->field_4;
 
-        if ((objData->field_4 + 0x10000) == 0xFFFF) {
+        if ((dataValIndex + 0x10000) == 0xFFFF) {
             vecPtr = (u8*)gPppDefaultValueBuffer;
         } else {
             PObjPointEntry* table = *(PObjPointEntry**)((u8*)pppMngStPtr + 0xD4);
             u8* data = (u8*)objData->data;
-            u32 vecOffset = table[objData->field_4].vecOffset;
+            u32 vecOffset = table[dataValIndex].vecOffset;
             vecPtr = data + 0x80;
             vecPtr += vecOffset;
         }


### PR DESCRIPTION
## Summary
- inline the point object offset load into the `objPtr` expression in `pppPObjPoint`
- cache `objData->field_4` in a local so MWCC keeps the improved register allocation around the lookup path
- preserve the existing control flow and data access pattern while producing closer codegen

## Units/functions improved
- Unit: `main/pppPObjPoint`
- Function: `pppPObjPoint`
- Code match: `93.91892% -> 95.27027%`
- Text size: unchanged at `152` bytes in the decomp object vs target `148` bytes

## Progress evidence
- Baseline was measured by temporarily restoring `origin/main` for `src/pppPObjPoint.cpp`, rebuilding with `ninja`, and running `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o - pppPObjPoint`
- The branch rebuild keeps overall project progress stable and improves this unit's objdiff score without data or linkage regressions
- `ninja` succeeds on the branch

## Plausibility rationale
- Inlining the object offset is a normal source simplification, not a compiler-specific hack
- Caching the data index matches the function's semantics and avoids repeated member loads without changing behavior
- The resulting code still uses named fields and linked data instead of hardcoded offsets or extern-based score inflation

## Technical details
- The improvement comes from better register allocation for the `objPtr` setup and the lookup index used in the `vecPtr` selection path
- The remaining mismatch is still in the default-buffer / table-lookup branch, but the new shape moves the function materially closer to the target assembly
