### PR TITLE
Improve pppFrameYmTraceMove local layout

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -75,10 +75,10 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, pppYmTraceMoveUnkB* par
 	Vec local_2c;
 	Vec local_8c;
 	Vec local_ec;
+	Vec local_e0;
 	Quaternion local_60;
 	Quaternion local_70;
 	Quaternion local_80;
-	Vec local_e0;
 	Vec directionSource;
 	Vec previousDirectionSource;
 


### PR DESCRIPTION
## Summary
Reordered `pppFrameYmTraceMove`'s local declarations so MWCC lays out the post-lerp working vector before the quaternion locals.

## Units/functions improved
- Unit: `main/pppYmTraceMove`
- Function: `pppFrameYmTraceMove`

## Progress evidence
- `pppFrameYmTraceMove`: `95.05556%` -> `95.149574%`
- `main/pppYmTraceMove` `.text`: `95.823105%` -> `95.90253%`
- `extab`: unchanged at `50.0%`
- `extabindex`: unchanged at `0.0%`
- `ninja`: passes after the change

## Plausibility rationale
This change does not alter control flow, data flow, or symbol usage. It only corrects local declaration order so the compiler emits a stack frame layout that is closer to the original source. That is a plausible original-source adjustment, not a coercive matching hack.

## Technical details
Objdiff showed the remaining mismatch cluster was centered around stack offsets for the quaternion block and the scaled output vector. Moving `local_e0` ahead of the quaternion locals shifts those stack slots into a closer arrangement while preserving the existing logic.
