### PR TITLE
RedExecute: fix wave split selection return flow

### DIFF
--- a/include/ffcc/RedSound/RedExecute.h
+++ b/include/ffcc/RedSound/RedExecute.h
@@ -27,7 +27,7 @@ void _VoiceEnvelopeCheck();
 void SetVoiceVolumeMix(RedVoiceDATA*, int, int);
 void _VolumeExecute(RedVoiceDATA*, int);
 void _PitchExecute(RedVoiceDATA*);
-void _WaveSplitSelect(RedWaveDATA*, RedNoteDATA*);
+RedWaveDATA* _WaveSplitSelect(RedWaveDATA*, RedNoteDATA*);
 void _VoiceDataAsign(RedTrackDATA*, RedVoiceDATA*, RedNoteDATA*, int*);
 RedVoiceDATA* _VoiceDataSelect(RedTrackDATA*, RedNoteDATA*, int*);
 void SetVoiceAccess(RedTrackDATA*, int);

--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -744,30 +744,57 @@ void _PitchExecute(RedVoiceDATA* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _WaveSplitSelect(RedWaveDATA* param_1, RedNoteDATA* param_2)
+RedWaveDATA* _WaveSplitSelect(RedWaveDATA* param_1, RedNoteDATA* param_2)
 {
     u32* waveData = (u32*)param_1;
     char* noteData = (char*)param_2;
+    u32 flags;
 
-    if ((waveData != nullptr) && ((*waveData & 0x30000) != 0)) {
-        char* splitKeyPtr;
+    if (waveData == nullptr) {
+        return (RedWaveDATA*)waveData;
+    }
 
-        for (; ((*waveData & 0x200) == 0) && (*(char*)(waveData + 6) < *noteData); waveData += 0x18) {
-            if ((*waveData & 1) != 0) {
-                waveData += 0x18;
-            }
+    flags = *waveData;
+    if ((flags & 0x30000) == 0) {
+        return (RedWaveDATA*)waveData;
+    }
+
+    while (true) {
+        if ((flags & 0x200) != 0) {
+            break;
         }
+        if (*(char*)(waveData + 6) >= *noteData) {
+            break;
+        }
+        if ((flags & 1) != 0) {
+            waveData += 0x18;
+        }
+        waveData += 0x18;
+        flags = *waveData;
+    }
 
-        splitKeyPtr = (char*)(waveData + 6);
-        for (; ((*waveData & 0x200) == 0) && ((u8)*((char*)waveData + 0x19) < (u8)noteData[1]); waveData += 0x18) {
-            if (*splitKeyPtr != *(char*)(waveData + 6)) {
-                return;
+    {
+        char* splitKeyPtr = (char*)(waveData + 6);
+
+        while (true) {
+            if ((flags & 0x200) != 0) {
+                return (RedWaveDATA*)waveData;
             }
-            if ((*waveData & 1) != 0) {
+            if ((u8)*((char*)waveData + 0x19) >= (u8)noteData[1]) {
+                return (RedWaveDATA*)waveData;
+            }
+            if (*splitKeyPtr != *(char*)(waveData + 6)) {
+                return (RedWaveDATA*)waveData;
+            }
+            if ((flags & 1) != 0) {
                 waveData += 0x18;
             }
+            waveData += 0x18;
+            flags = *waveData;
         }
     }
+
+    return (RedWaveDATA*)waveData;
 }
 
 /*
@@ -989,8 +1016,8 @@ RedVoiceDATA* _VoiceDataSelect(RedTrackDATA* track, RedNoteDATA* note, int* voic
     }
 
     if (voiceData != 0) {
-        int wave = (int)((RedWaveDATA*(*)(RedWaveDATA*, RedNoteDATA*))_WaveSplitSelect)((RedWaveDATA*)trackData[7], note);
-        voiceData[1] = wave;
+        RedWaveDATA* wave = _WaveSplitSelect((RedWaveDATA*)trackData[7], note);
+        voiceData[1] = (int)wave;
         _VoiceDataAsign(track, (RedVoiceDATA*)voiceData, note, voiceMask);
 
         if (((*(u32*)voiceData[1] & 1) != 0) && ((((u8*)trackData)[0x26] & 5) == 0)) {
@@ -998,7 +1025,7 @@ RedVoiceDATA* _VoiceDataSelect(RedTrackDATA* track, RedNoteDATA* note, int* voic
             voiceData = (int*)EntryVoiceSearch(track);
             if (voiceData != 0) {
                 voiceData[0x25] |= 0x80;
-                voiceData[1] = wave + 0x60;
+                voiceData[1] = (int)((u8*)wave + 0x60);
                 _VoiceDataAsign(track, (RedVoiceDATA*)voiceData, note, voiceMask);
             }
         }


### PR DESCRIPTION
## Summary
- correct `_WaveSplitSelect` to return the selected `RedWaveDATA*` instead of relying on a casted call site
- rewrite the split traversal into explicit early-return loops that keep the active flags/pointer flow closer to the target codegen
- update `_VoiceDataSelect` to call `_WaveSplitSelect` with its real return type and keep the second-wave pointer arithmetic explicit

## Units/functions improved
- Unit: `main/RedSound/RedExecute`
- `_WaveSplitSelect__FP11RedWaveDATAP11RedNoteDATA`: `36.08889%` -> `43.444443%`
- `_VoiceDataSelect__FP12RedTrackDATAP11RedNoteDATAPi`: `26.878378%` -> `76.60811%`
- Unit `.text`: `49.62588%` -> `51.436207%`

## Progress evidence
- `ninja` still passes after the change
- The gain is code-match progress in the `RedExecute` unit; no data/linkage hacks or extern shims were introduced
- Overall repo progress does not move at the printed precision, but the object-level code delta is substantial and concentrated in the affected call chain

## Plausibility rationale
- `_VoiceDataSelect` was already treating `_WaveSplitSelect` as a pointer-returning function via an explicit cast, which is a strong sign the recovered signature was wrong rather than the call site being intentionally odd
- Returning the active `RedWaveDATA*` directly is source-plausible and matches how the selected wave pointer is consumed immediately afterward
- The rewritten traversal uses ordinary wave-table stepping and early exits, not compiler-coaxing tricks or hardcoded addresses

## Technical details
- kept the traversal in `u32*`/byte-pointer form so advancing by `0x60` stays explicit and maps cleanly to the target loop shape
- carried the current flag word through the loops to reduce reload noise and better match the branch structure in objdiff
- kept the duplicate-wave path in `_VoiceDataSelect` as explicit byte-addressed pointer math: `(u8*)wave + 0x60`
