### PR TITLE
Improve CFunnyShapePcs::drawViewer match

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -362,7 +362,6 @@ void CFunnyShapePcs::drawViewer()
 {
     Mtx44 ortho;
     Mtx view;
-    CFunnyShape* funnyShape = FunnyShape(this);
     Vec eye = {0.0f, 0.0f, 0.0f};
     Vec at = {0.0f, 0.0f, 0.0f};
     Vec up = {0.0f, 1.0f, 0.0f};
@@ -380,14 +379,14 @@ void CFunnyShapePcs::drawViewer()
     GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_CLR0, GX_CLR_RGBA, GX_RGBA8, 0);
     GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_F32, 0);
 
-    if ((Ptr(this, 0x6178)[0] & 1) != 0) {
-        funnyShape->RenderTexture();
+    if ((*reinterpret_cast<u32*>(Ptr(this, 0x6178)) & 1) != 0) {
+        FunnyShape(this)->RenderTexture();
     }
-    if ((Ptr(this, 0x6178)[0] & 4) != 0) {
-        funnyShape->RenderShape();
+    if ((*reinterpret_cast<u32*>(Ptr(this, 0x6178)) & 4) != 0) {
+        FunnyShape(this)->RenderShape();
     }
-    if ((Ptr(this, 0x6178)[0] & 8) != 0) {
-        funnyShape->Render();
+    if ((*reinterpret_cast<u32*>(Ptr(this, 0x6178)) & 8) != 0) {
+        FunnyShape(this)->Render();
     }
 
     frameCount++;


### PR DESCRIPTION
## Summary
- remove the cached `CFunnyShape*` in `CFunnyShapePcs::drawViewer()` and call the embedded object directly at each render site
- read the viewer render flags as a 32-bit value before each bit test instead of masking the first byte

## Units/functions improved
- `main/p_FunnyShape`
- `drawViewer__14CFunnyShapePcsFv`

## Progress evidence
- `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - drawViewer__14CFunnyShapePcsFv`
- before: `76.44697%`
- after: `83.44697%`
- build report now shows `drawViewer__14CFunnyShapePcsFv` at `84.05303%` fuzzy match and `main/p_FunnyShape` at `94.830795%` fuzzy match
- no accepted regressions in code, data, or linkage on this branch

## Plausibility rationale
- this change removes a decomp-introduced temporary rather than adding compiler-coaxing structure
- calling the embedded `CFunnyShape` directly at each render branch is a more natural fit for the generated code and still reads like plausible original source
- the 32-bit flag checks line up with the surrounding codebase usage for this viewer state without introducing new hacks or fake linkage

## Technical details
- objdiff showed the target rebuilding the embedded `CFunnyShape` address at each `RenderTexture` / `RenderShape` / `Render` call site instead of keeping a persistent local pointer
- switching the branch predicates from byte loads to 32-bit flag loads also moved the conditionals closer to the target instruction shape
- `ninja` passes after the change
