### PR TITLE
Runtime: restore local exception class declarations

### DIFF
--- a/include/PowerPC_EABI_Support/Runtime/exception.h
+++ b/include/PowerPC_EABI_Support/Runtime/exception.h
@@ -5,18 +5,6 @@
 
 namespace std {
 
-class exception {
-public:
-	virtual ~exception();
-	virtual const char* what() const;
-};
-
-class bad_exception : public exception {
-public:
-	virtual ~bad_exception();
-	virtual const char* what() const;
-};
-
 typedef void (*unexpected_handler)();
 unexpected_handler set_unexpected(unexpected_handler handler);
 void unexpected();
@@ -27,8 +15,6 @@ void terminate();
 
 } // namespace std
 
-using std::bad_exception;
-using std::exception;
 using std::terminate;
 using std::terminate_handler;
 using std::set_terminate;

--- a/src/Runtime.PPCEABI.H/Gecko_ExceptionPPC.cp
+++ b/src/Runtime.PPCEABI.H/Gecko_ExceptionPPC.cp
@@ -2,7 +2,6 @@
 #include "PowerPC_EABI_Support/Runtime/Gecko_ExceptionPPC.h"
 #include "PowerPC_EABI_Support/Runtime/NMWException.h"
 #include "PowerPC_EABI_Support/Runtime/__ppc_eabi_linker.h"
-#include "PowerPC_EABI_Support/Runtime/exception.h"
 
 #pragma force_active on
 
@@ -75,6 +74,22 @@ typedef struct ActionIterator {
 static ProcessInfo fragmentinfo[MAXFRAGMENTS];
 
 typedef void (*DeleteFunc)(void*);
+
+namespace std {
+
+class exception {
+public:
+	virtual ~exception() {}
+	virtual const char* what() const;
+};
+
+class bad_exception : public exception {
+public:
+	virtual ~bad_exception();
+	virtual const char* what() const;
+};
+
+} // namespace std
 
 /**
  * @note Address: 0x800C2374

--- a/src/Runtime.PPCEABI.H/New.cp
+++ b/src/Runtime.PPCEABI.H/New.cp
@@ -1,6 +1,5 @@
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/alloc.h"
 #include "PowerPC_EABI_Support/Runtime/New.h"
-#include "PowerPC_EABI_Support/Runtime/exception.h"
 
 inline void operator delete(void* arg0) throw() {
     if (arg0 != 0) {
@@ -9,6 +8,12 @@ inline void operator delete(void* arg0) throw() {
 }
 
 namespace std {
+
+class exception {
+public:
+    virtual ~exception();
+    virtual const char* what() const;
+};
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- restore `std::exception` / `std::bad_exception` class declarations to the runtime translation units that implement them
- keep `include/PowerPC_EABI_Support/Runtime/exception.h` focused on the handler API declarations used across the runtime
- preserve the current named `bad_exception` string setup while restoring the inline empty base destructor visibility needed by `Gecko_ExceptionPPC`

## Units/functions improved
- `main/Runtime.PPCEABI.H/Gecko_ExceptionPPC`
- `__dt__Q23std13bad_exceptionFv`: 65.21739% -> 100.0%

## Progress evidence
- `main/Runtime.PPCEABI.H/Gecko_ExceptionPPC` matched code: 4648 / 5176 bytes (89.79907%) -> 4740 / 5176 bytes (91.57651%)
- `main/Runtime.PPCEABI.H/Gecko_ExceptionPPC` matched functions: 11 / 13 (84.61539%) -> 12 / 13 (92.30769%)
- overall project matched code: 433768 -> 433860 bytes
- overall project matched functions: 2827 -> 2828
- accepted regression: unit `extab` fuzzy match moved from 96.55172% -> 94.166664%; this is acceptable because extab is not the current priority and the change promotes a real code match improvement by fully matching one remaining runtime function

## Plausibility rationale
- this restores a source-plausible SDK layout where the runtime TUs that define `std::exception` behavior also carry the class declarations they need for codegen
- the improvement comes from normal class/declaration placement and inline empty destructor visibility, not from symbol hacks, forced sections, or fake linkage
- `main/Runtime.PPCEABI.H/New` remains 100% matched after the declaration split, so the change improves `Gecko_ExceptionPPC` without destabilizing already matched runtime code

## Technical details
- `Gecko_ExceptionPPC` needed the base `std::exception` destructor visible as an inline empty body in that TU to generate the correct deleting destructor sequence for `std::bad_exception`
- after moving the class declarations into the shared header, that TU lost the codegen shape and `__dt__Q23std13bad_exceptionFv` stalled at 65.2%
- restoring TU-local class declarations while leaving handler APIs in `exception.h` recovers the target destructor body and keeps the rest of the runtime build coherent
- verified with `ninja` (`build/GCCP01/main.dol: OK`) and `objdiff-cli`