### PR TITLE
pppBlurChara: improve pppRenderBlurChara color setup

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -9,8 +9,6 @@
 #include "ffcc/util.h"
 #include "ffcc/math.h"
 
-#include <string.h>
-
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 
@@ -443,9 +441,12 @@ void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppB
         1, 0, 0, 0, 0);
     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 1, 5, 7);
 
-    memcpy(&drawColor, &colorData->m_color, sizeof(drawColor));
-    GXSetChanMatColor(GX_COLOR0A0, drawColor);
+    GXSetChanMatColor(GX_COLOR0A0, *reinterpret_cast<_GXColor*>(&colorData->m_color));
     GXSetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
+    drawColor.r = colorData->m_color.rgba[0];
+    drawColor.g = colorData->m_color.rgba[1];
+    drawColor.b = colorData->m_color.rgba[2];
+    drawColor.a = colorData->m_color.rgba[3];
 
     _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
     _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 1);


### PR DESCRIPTION
Summary:
- Split the channel-color setup in `pppRenderBlurChara` so GX gets the packed source color directly while the local `drawColor` is still populated explicitly for the later quad render.
- Removed the temporary `memcpy` path and the now-unused `<string.h>` include.

Units/functions improved:
- `main/pppBlurChara`
- `pppRenderBlurChara`

Progress evidence:
- `pppRenderBlurChara`: 93.50411% -> 97.08493% (`build/tools/objdiff-cli diff -p . -u main/pppBlurChara ...`)
- `main/pppBlurChara` `.text`: 94.301544% -> 95.985825%
- `BlurChara_AfterDrawModelCallback__FPQ26CChara6CModelPvPv`: unchanged at 92.43173%
- No code/data/linkage regressions were introduced in this change; extab remains incomplete and was not targeted.

Plausibility rationale:
- This keeps the code aligned with likely original intent: the GX material color setup uses the packed serialized color directly, while the separate `drawColor` local remains the struct passed later into `gUtil.RenderQuad`.
- The change removes an unnatural helper copy (`memcpy`) in favor of two uses that correspond to the two actual call sites, which is more plausible original source than forcing both through a shared temporary.

Technical details:
- Replaced `memcpy(&drawColor, &colorData->m_color, sizeof(drawColor))` with a direct packed `_GXColor` load for `GXSetChanMatColor`.
- Moved the explicit per-channel `drawColor` population to immediately after `GXSetChanCtrl`, which brings the remaining code shape much closer to the target object.
- Verified with `ninja` and `objdiff-cli`.
