### PR TITLE
Improve UpdateAllParticle control flow in pppBreathModel

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -375,7 +375,10 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
         *(short*)((unsigned char*)vBreathModel + 0x44) = *(short*)((unsigned char*)vBreathModel + 0x44) + 1;
 
         for (i = 0; i < maxParticleCount; i++) {
-            if (*(short*)(particleData + 0x50) < 1) {
+            if (*(short*)(particleData + 0x50) >= 1) {
+                UpdateParticle__FP12VBreathModelP12PBreathModelP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
+                    vBreathModel, pBreathModel, (_PARTICLE_DATA*)particleData, vColor, (_PARTICLE_COLOR*)particleColor);
+            } else {
                 float zero = kPppBreathModelZero;
 
                 groupTableWork = *(int*)((unsigned char*)vBreathModel + 0x3C);
@@ -461,9 +464,6 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
                         }
                     }
                 }
-            } else {
-                UpdateParticle__FP12VBreathModelP12PBreathModelP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
-                    vBreathModel, pBreathModel, (_PARTICLE_DATA*)particleData, vColor, (_PARTICLE_COLOR*)particleColor);
             }
 
             if (particleWmat != NULL) {


### PR DESCRIPTION
## Summary
Reordered the per-particle branch in `UpdateAllParticle` so the live-particle update path is taken first and the spawn/reset logic remains in the `else` path.

## Units/functions improved
- `main/pppBreathModel`
- `UpdateAllParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColor`

## Progress evidence
- `UpdateAllParticle`: `71.66537%` -> `76.84436%` (`1028b`)
- Unit fuzzy match: selector reported `78.5%`; current `build/GCCP01/report.json` reports `79.31503%`
- Checked neighboring selector targets after the change:
  - `BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: unchanged at `73.27551%`
  - `pppFrameBreathModel`: unchanged at `77.49683%`
- `ninja` build passes after the change
- Accepted regressions: none observed

## Plausibility rationale
This mirrors the control-flow shape already used by the sibling breath implementation in `pppYmBreath.cpp`: active particles take the update path directly, while expired slots fall through into the group cleanup and respawn logic. That is a source-plausible organization change rather than compiler coaxing.

## Technical details
- Kept the data flow and slot/group bookkeeping unchanged
- Only reordered the top-level lifetime branch inside the particle loop
- Objdiff improvement was isolated to `UpdateAllParticle`, with the other tracked `pppBreathModel` targets staying flat