### PR TITLE
Improve texanim set duplication matching

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -150,12 +150,6 @@ static inline void ReleaseRef(void** slot)
     }
 }
 
-static inline void AddRef(void* ref)
-{
-    if (ref != 0) {
-        reinterpret_cast<RefObject*>(ref)->refCount = reinterpret_cast<RefObject*>(ref)->refCount + 1;
-    }
-}
 }
 
 /*
@@ -635,9 +629,8 @@ CTexAnimSet::~CTexAnimSet()
 void CTexAnimSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
 {
     CChunkFile::CChunk chunk;
-    CPtrArray<CTexAnim*>* texAnims = reinterpret_cast<CPtrArray<CTexAnim*>*>((int)this + 8);
 
-    texAnims->SetStage(stage);
+    reinterpret_cast<CPtrArray<CTexAnim*>*>((int)this + 8)->SetStage(stage);
     chunkFile.PushChunk();
     while ((int)chunkFile.GetNextChunk(chunk) != 0) {
         if (chunk.m_id == 0x54414E4D) {
@@ -721,7 +714,7 @@ void CTexAnimSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
                 }
             }
             chunkFile.PopChunk();
-            texAnims->Add(texAnim);
+            reinterpret_cast<CPtrArray<CTexAnim*>*>((int)this + 8)->Add(texAnim);
         }
     }
     chunkFile.PopChunk();
@@ -749,7 +742,7 @@ CTexAnimSet* CTexAnimSet::Duplicate(CMemory::CStage* stage)
     }
 
     dup->texAnims.SetStage(stage);
-    for (unsigned long i = 0; i < static_cast<unsigned long>(self->texAnims.GetSize()); i++) {
+    for (unsigned int i = 0; i < static_cast<unsigned int>(self->texAnims.GetSize()); i++) {
         CTexAnimStorage* src = reinterpret_cast<CTexAnimStorage*>(self->texAnims[i]);
         CTexAnimStorage* copy = reinterpret_cast<CTexAnimStorage*>(
             __nw__FUlPQ27CMemory6CStagePci(0x24, stage, s_texanim_cpp_801d7adc, 0xF4));
@@ -766,7 +759,7 @@ CTexAnimSet* CTexAnimSet::Duplicate(CMemory::CStage* stage)
         }
 
         copy->refData = src->refData;
-        AddRef(copy->refData);
+        reinterpret_cast<RefObject*>(copy->refData)->refCount = reinterpret_cast<RefObject*>(copy->refData)->refCount + 1;
         copy->unk0C = src->unk0C;
         copy->unk10 = src->unk10;
         copy->unk14 = src->unk14;


### PR DESCRIPTION
Summary:
- remove the extra local ptr-array cache in `CTexAnimSet::Create` and operate on the member directly
- inline the duplicated texanim refcount bump in `CTexAnimSet::Duplicate` and narrow the loop index to `unsigned int`
- drop the now-unused local `AddRef` helper from `texanim.cpp`

Units/functions improved:
- `main/texanim`
- `Duplicate__11CTexAnimSetFPQ27CMemory6CStage`: `88.46591%` -> `93.85227%`
- `Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage`: `35.80000%` -> `35.822224%`

Progress evidence:
- `main/texanim` `.text`: `80.70437%` -> `81.078%`
- nearby checked symbols held steady: `AttachMaterialSet__11CTexAnimSetFP12CMaterialSet` stayed at `72.40625%`, `Change__11CTexAnimSetFPcfQ211CTexAnimSet9ANIM_TYPE` stayed at `80.75%`
- `ninja` still builds cleanly and reports `build/GCCP01/report.json` successfully

Plausibility rationale:
- the refcount increment in `Duplicate` now matches the direct ownership transfer pattern shown by the target object instead of routing through a helper
- the `Create` change removes an unnecessary cached pointer and keeps the code closer to a straightforward member-access implementation a game-side author would plausibly write
- no extern hacks, forced symbol tricks, or section hacks were introduced

Technical details:
- objdiff showed `Duplicate` was sensitive to the refcount/update shape around `copy->refData`; inlining that increment improved register allocation and instruction selection materially
- using `unsigned int` for the duplicate loop also aligns better with the array access patterns in this file
- the `Create` cleanup produced a smaller secondary improvement without destabilizing adjacent texanim methods