### PR TITLE
Rewrite CMapHit::CheckHitCylinderNear face loop

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -692,11 +692,15 @@ int CMapHit::CheckHitCylinderNear(CMapCylinder* mapCylinder, Vec* position, unsi
 {
     g_hit_cyl = *mapCylinder;
     g_hit_mvec = *position;
-    g_hit_t_min = s_large_pos;
-    gMapHitFace = 0;
-    g_hit_edge_idx_min = -1;
 
-    return CheckHitFaceCylinder(mask);
+    int faceOffset = 0;
+    for (int i = 0; i < static_cast<int>(m_faceCount); i++) {
+        gMapHitFace = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
+        CheckHitFaceCylinder(mask);
+        faceOffset += 0x50;
+    }
+
+    return 0;
 }
 
 /*


### PR DESCRIPTION
Summary:
- rewrite `CMapHit::CheckHitCylinderNear` to iterate across every face entry instead of treating the near-check as a single `CheckHitFaceCylinder` call
- keep the helper aligned with the existing `CheckHitCylinder` pattern and the Ghidra reference by advancing through `m_faces` in 0x50-byte steps

Units/functions improved:
- `main/maphit`
- `CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUl`

Progress evidence:
- function match improved from `24.616438%` to `26.767124%` in objdiff oneshot for `CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUl`
- build still passes with `build/GCCP01/main.dol: OK`
- overall report percentages are unchanged at project scale, which is expected for a 292-byte helper, but the per-function assembly match improved with no additional regressions in this branch

Plausibility rationale:
- the new loop matches the existing source style already used by `CMapHit::CheckHitCylinder`, which also walks `m_faces` in 0x50-byte strides and dispatches face checks one at a time
- this avoids the previous one-shot wrapper behavior and instead reflects the recovered per-face traversal shown in the decomp reference

Technical details:
- `g_hit_cyl` and `g_hit_mvec` are still initialized from the incoming cylinder and position
- each iteration now points `gMapHitFace` at the current face before calling `CheckHitFaceCylinder(mask)`, then advances the face offset by `0x50`
- the helper returns `0` after the scan, matching the reference structure for this near-check variant
