### PR TITLE
p_menu: use shared kMenuInitOne

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -25,7 +25,6 @@
 
 CMenuPcs MenuPcs;
 u8 gMenuProcessTable[0x15C];
-extern const f32 kMenuInitOne = 1.0f;
 static const char kMenuPcsStageName[] = "CMenuPcs";
 static const char kPMenuSourceFile[] = "p_menu.cpp";
 


### PR DESCRIPTION
Summary
- Remove the redundant `kMenuInitOne` definition from `src/p_menu.cpp` so the unit uses the shared menu constant declared in `symbols_shared.h`.

Units/functions improved
- `main/p_menu`: `DrawInit__8CMenuPcsFv` improved from `99.95727%` to `100.0%`.

Progress evidence
- Before: objdiff reported a single remaining diff in `DrawInit__8CMenuPcsFv`, an `lfs f1` SDA21 relocation targeting the local `kMenuInitOne` definition.
- After: objdiff reports `DrawInit__8CMenuPcsFv` at `100.0%`.
- Accepted regressions: none.
- Verification: `ninja build/GCCP01/src/p_menu.o` and `ninja` both pass; the unit is still unlinked, so this is a pure decomp/code-match improvement.

Plausibility rationale
- `kMenuInitOne` is already declared as a shared symbol in `include/ffcc/symbols_shared.h` and mapped in `config/GCCP01/symbols.txt`, alongside the other orthographic constants used by `DrawInit`. Removing the duplicate TU-local definition is the more plausible original source and fixes the final relocation mismatch without adding any compiler-coaxing code.

Technical details
- `DrawInit` already loaded `kMenuOrthoBottom`, `kMenuOrthoRight`, and `kMenuOrthoFar` from the shared symbol pool. `kMenuInitOne` was the outlier because `src/p_menu.cpp` redefined it locally. Dropping that definition lets the compiler emit the same SDA21 reference the original object uses, which resolves the last diff in the function.