### PR TITLE
Improve pppKeShpTail3X matrix and history updates

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -67,8 +67,7 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
     KeShpTail3XStep* step;
     KeShpTail3XWork* work;
     Vec pos;
-    Vec temp;
-    Vec historyPos;
+    Vec historyPos ATTRIBUTE_ALIGN(8);
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -85,13 +84,9 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
             pos.y = obj->pppPObject.m_localMatrix.value[1][3];
             pos.z = obj->pppPObject.m_localMatrix.value[2][3];
         } else if (step->m_worldSpaceMode == 1) {
-            pppFMATRIX ownerMatrix;
-            pppFMATRIX partMatrix;
             pppFMATRIX outMatrix;
 
-            partMatrix = obj->pppPObject.m_localMatrix;
-            ownerMatrix = pppMngStPtr->m_matrix;
-            pppMulMatrix(outMatrix, ownerMatrix, partMatrix);
+            pppMulMatrix(outMatrix, pppMngStPtr->m_matrix, obj->pppPObject.m_localMatrix);
             pos.x = outMatrix.value[0][3];
             pos.y = outMatrix.value[1][3];
             pos.z = outMatrix.value[2][3];
@@ -101,8 +96,7 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
         Vec* history = work->m_posHistory;
         s32 i = 0x1c;
         do {
-            temp = historyPos;
-            pppCopyVector(*history, temp);
+            pppCopyVector(*history, historyPos);
             history++;
             i--;
         } while (i > 0);
@@ -118,20 +112,15 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
         pos.y = obj->pppPObject.m_localMatrix.value[1][3];
         pos.z = obj->pppPObject.m_localMatrix.value[2][3];
     } else if (step->m_worldSpaceMode == 1) {
-        pppFMATRIX ownerMatrix;
-        pppFMATRIX partMatrix;
         pppFMATRIX outMatrix;
 
-        partMatrix = obj->pppPObject.m_localMatrix;
-        ownerMatrix = pppMngStPtr->m_matrix;
-        pppMulMatrix(outMatrix, ownerMatrix, partMatrix);
+        pppMulMatrix(outMatrix, pppMngStPtr->m_matrix, obj->pppPObject.m_localMatrix);
         pos.x = outMatrix.value[0][3];
         pos.y = outMatrix.value[1][3];
         pos.z = outMatrix.value[2][3];
     }
 
-    temp = pos;
-    pppCopyVector(work->m_posHistory[work->m_head], temp);
+    pppCopyVector(work->m_posHistory[work->m_head], pos);
 
     work->m_values[8] += work->m_values[0xc];
     work->m_values[0] += work->m_values[8];


### PR DESCRIPTION
## Summary
- align the temporary history vector used by `pppKeShpTail3X`
- simplify the world-space position path to call `pppMulMatrix` directly with the owner and local matrices
- remove unnecessary temporary vector and matrix copies when seeding and updating the tail history

## Units/functions improved
- Unit: `main/pppKeShpTail3X`
- Function: `pppKeShpTail3X`

## Progress evidence
- `ninja` builds successfully after the change
- `tools/agent_select_target.py` reported `pppKeShpTail3X` at `61.2%` match when selected
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o /tmp/ks_tail_diff.json pppKeShpTail3X` now reports `99.79156%` for `pppKeShpTail3X`
- No intentional regressions were introduced in code, data, or linkage

## Plausibility rationale
- the new code is closer to the already-matching `pppKeShpTail2X` implementation in the same subsystem
- using a directly aligned history vector and writing history entries without extra temporaries is a normal source-level cleanup, not compiler coaxing
- the world-space path now expresses the obvious original operation: multiply the manager matrix by the local matrix, then read the translated position

## Technical details
- the previous version kept extra `Vec` and `pppFMATRIX` temporaries alive across both world-space branches
- tightening those branches reduced stack noise and brought the history update path much closer to the target object code
