### PR TITLE
Improve pppLight default target selection

### DIFF
--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -248,13 +248,11 @@ void pppLight(void* param1, void* param2, void* param3)
 				Add__9CLightPcsFPQ29CLightPcs6CLight(&LightPcs, &light);
 			} else {
 				u32 targetIndex;
-				unsigned char* obj;
+				unsigned char* obj = gPppDefaultValueBuffer;
 
 				light.m_type = 1;
 				targetIndex = step->targetIndex;
-				if (targetIndex == 0xFFFFFFFF) {
-					obj = gPppDefaultValueBuffer;
-				} else {
+				if (targetIndex != 0xFFFFFFFF) {
 					pppLightTarget* targetTable =
 						(pppLightTarget*)((PppLightMngProgramInfo*)pppMngStPtr)->programInfoTable;
 					obj = targetTable[targetIndex].obj;


### PR DESCRIPTION
## Summary
- initialize the local target object pointer to `gPppDefaultValueBuffer` before branching
- only overwrite that pointer when `step->targetIndex` resolves to a real light target
- keep the emitted source plausible while removing redundant fallback assignment logic

## Units/functions improved
- `main/pppLight`
- `pppLight`

## Progress evidence
- Before: selector reported `main/pppLight` at `code 99.7%, data 40.00%`
- After: `build/GCCP01/report.json` reports `main/pppLight` at `matched_data_percent: 100.0` with `pppLightCon3` and `pppLightCon` still exact matches
- Project rebuild stayed clean and improved overall matched data from `219843` to `219855` bytes
- Remaining text mismatch in `pppLight` is unchanged; this PR is strictly a net data/linkage improvement with no build regression

## Plausibility rationale
- Defaulting to the global fallback buffer and only replacing it for valid target indices is a straightforward source-level expression of the existing runtime behavior
- The change removes redundant assignment rather than introducing compiler-coaxing temporaries, hardcoded addresses, or linkage hacks

## Technical details
- objdiff still shows a single mismatch in the fallback-target path of `pppLight`; this change resolves the unit's remaining data mismatch while preserving the current text shape elsewhere
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/pppLight -o - pppLight`