### PR TITLE
Improve pppRandCV data matching

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -57,12 +57,7 @@ void pppRandCV(void* param1, void* param2, void* param3)
     }
 
     s32 colorOffset = params->colorOffset;
-    u8* targetColor;
-    if (colorOffset == -1) {
-        targetColor = gPppDefaultValueBuffer;
-    } else {
-        targetColor = base + colorOffset + 0x80;
-    }
+    u8* targetColor = (colorOffset == -1) ? gPppDefaultValueBuffer : (base + colorOffset + 0x80);
 
     {
         f32 scale = target[0];


### PR DESCRIPTION
Summary:
- rewrite the default color-buffer selection in `pppRandCV` as a single conditional expression
- keep the existing control flow and color math intact while matching the pointer-selection style used by neighboring particle helpers

Units/functions improved:
- `main/pppRandCV`
- `pppRandCV`

Progress evidence:
- unit data match: `66.67%` -> `100.00%` (`24/36` bytes -> `36/36` bytes)
- unit code fuzzy match: `98.70%` -> `98.11%`
- project game data matched bytes: `67024` -> `67036`
- project matched code bytes stayed flat at `128992`, so this change improves data recovery without reducing currently matched code bytes
- accepted regression: the function's fuzzy code score drops slightly, but the result is a real data-match gain for a tiny, source-plausible rewrite rather than an extern or layout hack

Plausibility rationale:
- the new ternary form is a normal C/C++ source pattern and matches how related particle routines in this repo already choose `gPppDefaultValueBuffer` versus a computed buffer pointer
- no hardcoded addresses, section hacks, or symbol-name coercion are involved

Technical details:
- `ninja` succeeds after the change
- `objdiff` for `main/pppRandCV` now reports `.sdata2`, `extab`, and `extabindex` at `100%`, with the unit's data measure fully matched
- the remaining code mismatch is confined to register allocation in `pppRandCV`, not a behavioral change