### PR TITLE
Improve game argument parsing match

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,23 +61,25 @@ void main(int argc, char** argv)
  */
 void game(int argc, char** argv)
 {
-    int i;
-    int copyScriptName;
-    int parseLanguage;
+    char c;
+    bool copyScriptName;
+    bool parseLanguage;
+    int cmp;
     char** argument;
+    int i;
 
     Game.Init();
     strcpy(Game.m_startScriptName, kDefaultScriptName);
 
     if (argc != 0) {
-        copyScriptName = 0;
-        parseLanguage = 0;
+        copyScriptName = false;
+        parseLanguage = false;
         for (i = 1, argument = argv + 1; i < argc; i++, argument++) {
             if (copyScriptName) {
                 strcpy(Game.m_startScriptName, *argument);
-                copyScriptName = 0;
+                copyScriptName = false;
             } else if (parseLanguage) {
-                int cmp = strcmp(*argument, kLanguageArgUs);
+                cmp = strcmp(*argument, kLanguageArgUs);
                 if (cmp == 0) {
                     Game.m_gameWork.m_languageId = 1;
                 } else {
@@ -108,17 +110,17 @@ void game(int argc, char** argv)
                         }
                     }
                 }
-                parseLanguage = 0;
+                parseLanguage = false;
             } else {
-                char c = (*argument)[0];
+                c = (*argument)[0];
                 if ((c == '-') || (c == '/')) {
                     c = (*argument)[1];
                     switch (c) {
                     case 'f':
-                        copyScriptName = 1;
+                        copyScriptName = true;
                         break;
                     case 'l':
-                        parseLanguage = 1;
+                        parseLanguage = true;
                         break;
                     }
                 }


### PR DESCRIPTION
Summary:
- tighten `game` local variable types and lifetimes to better match the original argument parsing routine
- keep the existing control flow intact while hoisting the temporary character and compare result into the surrounding scope
- use boolean state flags for the script-name and language parsing states

Units/functions improved:
- `main/main`: `.text` match improved from `98.617645%` to `99.458824%`
- `game(int, char**)`: match improved from `98.02521%` to `99.22689%`

Progress evidence:
- before: `build/tools/objdiff-cli diff -p . -u main/main -o - game` reported `98.02521%` for `game(int, char**)` and `98.617645%` for the unit `.text`
- after: the same diff reports `99.22689%` for `game(int, char**)` and `99.458824%` for the unit `.text`
- `ninja` rebuilds cleanly after the change

Plausibility rationale:
- this change moves the function toward plausible original source by matching the decomp's local-variable layout and state handling rather than introducing compiler-coaxing control-flow changes
- the command-line parsing logic is unchanged; only the storage class and lifetime of the existing temporaries were adjusted

Technical details:
- hoisting `c` and `cmp` and converting the state flags to `bool` reduced register/layout mismatches throughout the parsing loop
- the remaining objdiff differences are register-allocation mismatches around the argv walker, not structural control-flow differences