### PR TITLE
Improve pppRenderYmTracer texture index local

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -416,7 +416,7 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
     f32 uTop;
     f32 uBottom;
     f32 uvStep;
-    int textureIndex[2];
+    int textureIndex;
 
     dataOffset = *param_3->m_serializedDataOffsets;
     colorOffset = param_3->m_serializedDataOffsets[1];
@@ -433,9 +433,8 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
             param_2->m_payload[0xC], param_2->m_payload[0xB], param_2->m_payload[10], 0, 1, 1, 0);
         SetVtxFmt_POS_CLR_TEX__5CUtilFv(&gUtil);
 
-        textureIndex[0] = 0;
-        texture = (CTexture*)GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr,
-                                                                     textureIndex[0]);
+        textureIndex = 0;
+        texture = (CTexture*)GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
         if (texture != 0) {
             GXLoadTexObj(&texture->m_texObj, GX_TEXMAP0);
             GXSetNumChans(1);


### PR DESCRIPTION
Summary:
- Replace the temporary `textureIndex` buffer in `pppRenderYmTracer` with a single `int` local.
- Keep the `GetTexture__8CMapMeshFP12CMaterialSetRi` call site semantically identical while matching the expected stack/local layout more closely.

Units/functions improved:
- Unit: `main/pppYmTracer`
- Function: `pppRenderYmTracer`

Progress evidence:
- `pppRenderYmTracer` match improved from `86.78261%` to `94.43913%`.
- `main/pppYmTracer` `.text` match improved from `79.9934%` to `82.31662%`.
- No intended data or linkage changes.
- `ninja` passes after the change.

Plausibility rationale:
- `GetTexture__8CMapMeshFP12CMaterialSetRi` takes an `int&`; using a single `int` local is the natural original-source representation.
- The prior two-element array was an unnecessary temporary shape that only existed to satisfy the call expression, not because the logic needed an array.
- This improves the source toward a cleaner and more plausible local variable layout without resorting to extern hacks or section tricks.

Technical details:
- The improvement comes from correcting the local stack shape around the `GetTexture` call in `pppRenderYmTracer`.
- I tested a few broader render rewrites first and rejected them because objdiff regressed; this PR keeps only the isolated local-type fix that produced a real gain.
