### PR TITLE
Improve pppRenderYmDrawMdlTexAnm matrix matching

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -261,10 +261,7 @@ void pppRenderYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step,
     pppYmDrawMdlTexAnmColorBlock* colorBlock;
     pppModelSt* model;
     pppFMATRIX matrix0;
-    pppFMATRIX matrix1;
     pppFMATRIX matrix2;
-    pppFMATRIX matrix3;
-    pppFMATRIX matrix4;
     u8* initBytes;
     u8* stepBytes;
     ymDrawMdlTexAnm = (pppYmDrawMdlTexAnmObject*)object;
@@ -275,15 +272,11 @@ void pppRenderYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step,
 
     colorBlock = GetYmDrawMdlTexAnmColorBlock(ymDrawMdlTexAnm, ctrl);
 
-    pppUnitMatrix(matrix4);
-    matrix2 = matrix4;
+    pppUnitMatrix(matrix2);
     matrix2.value[2][2] *= FLOAT_80330548;
 
-    matrix1 = ymDrawMdlTexAnm->m_localMatrix;
-    pppMulMatrix(matrix0, matrix1, matrix2);
-
-    matrix3 = *(pppFMATRIX*)&ppvCameraMatrix02;
-    pppMulMatrix(ymDrawMdlTexAnm->m_modelViewMatrix, matrix3, matrix0);
+    pppMulMatrix(matrix0, ymDrawMdlTexAnm->m_localMatrix, matrix2);
+    pppMulMatrix(ymDrawMdlTexAnm->m_modelViewMatrix, *(pppFMATRIX*)&ppvCameraMatrix0, matrix0);
 
     initBytes = (u8*)&step->m_initWOrk;
     stepBytes = (u8*)&step->m_stepValue;


### PR DESCRIPTION
Summary:
- simplify pppRenderYmDrawMdlTexAnm matrix setup by removing extra temporaries
- switch the final model-view multiply to use ppvCameraMatrix0, matching nearby particle render code patterns
- keep the existing object layout and serialized color-block linkage intact

Units/functions improved:
- Unit: main/pppYmDrawMdlTexAnm
- Function: pppRenderYmDrawMdlTexAnm

Progress evidence:
- pppRenderYmDrawMdlTexAnm code match: 39.873417% -> 99.1076%
- main/pppYmDrawMdlTexAnm .text match: 79.02857% -> 96.85524%
- No data regression in the unit; rodata and sdata2 remain 100% matched
- ninja passes after the change

Plausibility rationale:
- this replaces ad hoc temporary matrix copies with the same direct pppUnitMatrix/pppMulMatrix flow already used by comparable particle renderers
- using ppvCameraMatrix0 for the final view transform is consistent with other matched model-view render paths in the particle code
- the result is simpler and more source-plausible than preserving redundant temporaries for codegen alone

Technical details:
- removed three render-only temporaries that were inflating stack layout and copy traffic
- kept the scale-on-Z step in the identity matrix before multiplying with the object local matrix
- rebuilt with ninja and verified improvement via objdiff-cli on main/pppYmDrawMdlTexAnm