### PR TITLE
map: refine AttachMapHit traversal

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -104,6 +104,21 @@ static inline unsigned char* Ptr(void* p, unsigned int offset)
 {
     return reinterpret_cast<unsigned char*>(p) + offset;
 }
+
+struct MapObjAttachAttr
+{
+    void* vtable;
+    int type;
+    char name[1];
+};
+
+struct MapObjAttachObj
+{
+    char pad_00[0x0C];
+    CMapHit* mapHit;
+    char pad_10[0xDC];
+    MapObjAttachAttr* attr;
+};
 }
 
 /*
@@ -1708,35 +1723,43 @@ void CMapMng::SearchAtribMapObj(CMapObj*, CMapObjAtr::TYPE)
  */
 void CMapMng::AttachMapHit(CMapHit* mapHit, char* mapHitName)
 {
-    int mapObjCount = *reinterpret_cast<short*>(Ptr(this, 0xC));
-    unsigned char* mapObj = Ptr(this, 0x954);
-    unsigned char* mapObjEnd = mapObj + (mapObjCount * 0xF0);
+    MapObjAttachObj* mapObj = reinterpret_cast<MapObjAttachObj*>(Ptr(this, 0x954));
 
     while (true) {
-        while (mapObj < mapObjEnd) {
-            unsigned char* mapObjAtr = *reinterpret_cast<unsigned char**>(mapObj + 0xEC);
-            if (mapObjAtr != 0 && *reinterpret_cast<int*>(mapObjAtr + 4) == 3) {
-                break;
-            }
-            mapObj += 0xF0;
+        unsigned int remaining = static_cast<unsigned int>(
+            (reinterpret_cast<MapObjAttachObj*>(Ptr(this, 0x954 + *reinterpret_cast<short*>(Ptr(this, 0xC)) * 0xF0)) -
+                mapObj));
+
+        if (mapObj < reinterpret_cast<MapObjAttachObj*>(Ptr(this, 0x954 + *reinterpret_cast<short*>(Ptr(this, 0xC)) * 0xF0))) {
+            do {
+                if (mapObj->attr != 0 && mapObj->attr->type == 3) {
+                    goto found;
+                }
+                mapObj++;
+                remaining--;
+            } while (remaining != 0);
         }
 
-        if (mapObj >= mapObjEnd) {
+        mapObj = 0;
+found:
+        if (mapObj == 0) {
             return;
         }
 
-        unsigned char* mapObjAtr = *reinterpret_cast<unsigned char**>(mapObj + 0xEC);
-        if (strcmp(mapHitName, reinterpret_cast<char*>(mapObjAtr + 8)) == 0) {
-            *reinterpret_cast<CMapHit**>(mapObj + 0xC) = mapHit;
+        if (strcmp(mapHitName, mapObj->attr->name) == 0) {
+            mapObj->mapHit = mapHit;
 
+            MapObjAttachAttr* mapObjAtr = mapObj->attr;
             if (mapObjAtr != 0) {
-                void (**vtable)(void*, int) = reinterpret_cast<void (**)(void*, int)>(*reinterpret_cast<void**>(mapObjAtr));
-                vtable[2](mapObjAtr, 1);
-                *reinterpret_cast<unsigned char**>(mapObj + 0xEC) = 0;
+                if (mapObjAtr != 0) {
+                    typedef void (*MapObjAtrDtor)(MapObjAttachAttr*, int);
+                    reinterpret_cast<MapObjAtrDtor*>(*reinterpret_cast<void***>(mapObjAtr))[2](mapObjAtr, 1);
+                }
+                mapObj->attr = 0;
             }
         }
 
-        mapObj += 0xF0;
+        mapObj++;
     }
 }
 


### PR DESCRIPTION
Summary:
- replace raw byte-walking in `CMapMng::AttachMapHit` with temporary typed views for the map object and attached attribute payload
- preserve the existing behavior while expressing the search and detach logic through named members instead of repeated `0x0C`/`0xEC` offsets
- keep the destructor dispatch and attr clear in the same control-flow path after a successful name match

Units/functions improved:
- `main/map`
- `AttachMapHit__7CMapMngFP7CMapHitPc`: 16.142857% -> 20.444445% (`build/tools/objdiff-cli diff -p . -u main/map -o - AttachMapHit__7CMapMngFP7CMapHitPc`)

Progress evidence:
- symbol size unchanged at 252 bytes
- function match improved by 4.301588 percentage points
- `ninja` still completes successfully after the change
- overall unit progress in the report does not move enough to change the rounded project summary, but objdiff shows a real instruction-level improvement in the targeted symbol

Plausibility rationale:
- this moves the function toward plausible original source by modeling the specific map object and attribute fields that `AttachMapHit` actually uses, instead of relying on opaque byte pointers
- the rewritten loop still follows the original search pattern: scan for attribute type 3, compare the embedded name, attach the `CMapHit`, destroy the consumed attribute object, and clear the pointer
- no extern hacks, section hacks, or compiler-only coercion were introduced

Technical details:
- introduced local typed views for the `0x0C` hit pointer and `0xEC` attr pointer in map objects, plus the attr header at offsets `0x0`/`0x4`/`0x8`
- rewrote the traversal around typed pointer increments so the compiler emits a closer object-array walk than the previous raw `unsigned char*` arithmetic
- kept the virtual destructor call through slot 2 and nulling of the attr pointer after destruction
