### PR TITLE
Improve THPSimplePreLoad read buffer access

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -518,8 +518,8 @@ void __THPSimpleDVDCallback(long result, DVDFileInfo*)
 s32 THPSimplePreLoad(s32 loop)
 {
     s32 status;
-    u32 i;
     u32 readCount;
+    u32 i;
 
     if ((SimpleControl.isOpen == 0) || (SimpleControl.isPreLoaded != 0)) {
         return 0;
@@ -531,9 +531,10 @@ s32 THPSimplePreLoad(s32 loop)
     }
 
     for (i = 0; i < readCount; i++) {
-        while ((status = DVDReadAsyncPrio(&SimpleControl.fileInfo, SimpleControl.readBuffer[SimpleControl.readIndex].mPtr,
-                                          SimpleControl.readSize, SimpleControl.readOffset,
-                                          static_cast<DVDCallback>(0), 2)) == 0) {
+        THPReadBuffer* readBuffer = &SimpleControl.readBuffer[SimpleControl.readIndex];
+
+        while ((status = DVDReadAsyncPrio(&SimpleControl.fileInfo, readBuffer->mPtr, SimpleControl.readSize,
+                                          SimpleControl.readOffset, static_cast<DVDCallback>(0), 2)) == 0) {
             status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
             if ((status == 0xB) || ((status - 4U) < 3) || (status == -1)) {
                 File.DrawError(SimpleControl.fileInfo, status);
@@ -548,9 +549,9 @@ s32 THPSimplePreLoad(s32 loop)
         }
 
         SimpleControl.readOffset += SimpleControl.readSize;
-        SimpleControl.readSize = *reinterpret_cast<s32*>(SimpleControl.readBuffer[SimpleControl.readIndex].mPtr);
-        SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid = 1;
-        SimpleControl.readBuffer[SimpleControl.readIndex].mFrameNumber = SimpleControl.curAudioTrack;
+        SimpleControl.readSize = *reinterpret_cast<s32*>(readBuffer->mPtr);
+        readBuffer->mIsValid = 1;
+        readBuffer->mFrameNumber = SimpleControl.curAudioTrack;
         SimpleControl.curAudioTrack++;
         SimpleControl.readIndex = (SimpleControl.readIndex + 1) & 7;
 


### PR DESCRIPTION
## Summary
- reuse the active `THPReadBuffer` pointer within each `THPSimplePreLoad` iteration instead of repeatedly indexing `SimpleControl.readBuffer[SimpleControl.readIndex]`
- keep the existing control flow and linkage intact while making the preload loop closer to the original source shape

## Units/functions improved
- `main/THPSimple`
- `THPSimplePreLoad`

## Progress evidence
- `THPSimplePreLoad`: `75.31618% -> 77.08088%` (`+1.76470`)
- no intentional regressions were introduced in the other inspected near-match targets from this unit
- `ninja` still passes and project progress remains stable after the change

## Plausibility rationale
- this change removes repeated indexed accesses to the same ring-buffer entry inside one loop iteration and replaces them with a single local pointer
- that is a normal, source-plausible cleanup an original author could have written for readability and does not rely on extern hacks, hardcoded offsets, or section tricks

## Technical details
- objdiff on `main/THPSimple` showed the preload loop was close enough that small source-shape changes were worth testing
- reusing `THPReadBuffer* readBuffer = &SimpleControl.readBuffer[SimpleControl.readIndex];` improved code generation around the async read, frame-size load, and validity/frame-number stores without affecting behavior
- verification used `ninja` and `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPSimplePreLoad`
