### PR TITLE
Improve pppKeZCrctShpDraw matching

### DIFF
--- a/src/pppKeZCrctShp.cpp
+++ b/src/pppKeZCrctShp.cpp
@@ -18,6 +18,12 @@ struct pppKeZCrctShpObject {
  */
 void pppKeZCrctShpDraw(_pppPObject* object, pppKeZCrctShpStep* stepData, _pppCtrlTable* ctrlTable)
 {
+    float scaledPosX;
+    float scaledPosY;
+    float scaledPosZ;
+    float offsetPosX;
+    float offsetPosY;
+    float offsetPosZ;
     Vec rowX;
     Vec rowY;
     Vec rowZ;
@@ -37,30 +43,39 @@ void pppKeZCrctShpDraw(_pppPObject* object, pppKeZCrctShpStep* stepData, _pppCtr
     pppScaleVector(scaledY, rowY, pppMngStPtr->m_scale.y);
     pppScaleVector(scaledZ, rowZ, pppMngStPtr->m_scale.z);
 
-    zeroVec.x = 0.0f;
-    zeroVec.y = 0.0f;
     zeroVec.z = 0.0f;
+    zeroVec.y = 0.0f;
+    zeroVec.x = 0.0f;
     pppSetRowVector(transformMatrix, scaledX, scaledY, scaledZ, zeroVec);
 
     pppCopyVector(transformedPos, rowPos);
-    transformedPos.x *= stepData->m_positionScale.x;
-    transformedPos.y *= stepData->m_positionScale.y;
-    transformedPos.z *= stepData->m_positionScale.z;
+    scaledPosX = transformedPos.x * stepData->m_positionScale.x;
+    scaledPosY = transformedPos.y * stepData->m_positionScale.y;
+    scaledPosZ = transformedPos.z * stepData->m_positionScale.z;
 
     mode = stepData->m_mode;
+    transformedPos.x = scaledPosX;
+    transformedPos.y = scaledPosY;
+    transformedPos.z = scaledPosZ;
 
     if (mode == 0) {
-        transformedPos.x += stepData->m_offset.x;
-        transformedPos.y += stepData->m_offset.y;
-        transformedPos.z += stepData->m_offset.z;
+        offsetPosX = scaledPosX + stepData->m_offset.x;
+        offsetPosY = scaledPosY + stepData->m_offset.y;
+        offsetPosZ = scaledPosZ + stepData->m_offset.z;
+        transformedPos.x = offsetPosX;
+        transformedPos.y = offsetPosY;
+        transformedPos.z = offsetPosZ;
         pppApplyMatrix(transformedPos, *(pppFMATRIX*)&ppvWorldMatrix, transformedPos);
     } else if (mode == 1) {
         pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvWorldMatrix, transformedPos);
-    } else if (mode == 2) {
+    } else if (mode < 3) {
         pppApplyMatrix(zeroVec, pppMngStPtr->m_matrix, transformedPos);
-        zeroVec.x += stepData->m_offset.x * pppMngStPtr->m_scale.x;
-        zeroVec.y += stepData->m_offset.y * pppMngStPtr->m_scale.y;
-        zeroVec.z += stepData->m_offset.z * pppMngStPtr->m_scale.z;
-        pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvCameraMatrix02, zeroVec);
+        offsetPosX = stepData->m_offset.x * pppMngStPtr->m_scale.x + zeroVec.x;
+        offsetPosY = stepData->m_offset.y * pppMngStPtr->m_scale.y + zeroVec.y;
+        offsetPosZ = stepData->m_offset.z * pppMngStPtr->m_scale.z + zeroVec.z;
+        zeroVec.x = offsetPosX;
+        zeroVec.y = offsetPosY;
+        zeroVec.z = offsetPosZ;
+        pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvCameraMatrix0, zeroVec);
     }
 }


### PR DESCRIPTION
## Summary
Reworked `pppKeZCrctShpDraw` to better match the original temporary flow in the position-scaling and offset paths.
The mode-2 path now applies the final transform through `ppvCameraMatrix0`, and the scaled/offset position math is expressed through explicit float temporaries that better reflect the original compiler output.

## Units/functions improved
- Unit: `main/pppKeZCrctShp`
- Function: `pppKeZCrctShpDraw`

## Progress evidence
- `ninja` passes.
- `main/pppKeZCrctShp` fuzzy match improved from `85.60627%` to `85.63066%`.
- No data/linkage regressions were introduced in this unit.

## Plausibility rationale
This change moves the source toward plausible original code rather than adding match-only hacks:
- it keeps the existing object and step-data layout intact,
- it replaces the camera transform in mode 2 with the camera matrix used by the decomp reference,
- it expresses the scaled and offset position values with normal temporaries instead of artificial casts or address-based tricks.

## Technical details
The remaining mismatch in this function is dominated by temporary layout. Making the scaled position and offset values explicit improved the compiler's stack/register usage slightly without resorting to extern hacks or section tricks.
