### PR TITLE
Improve THPSimplePreLoad match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -518,6 +518,9 @@ void __THPSimpleDVDCallback(long result, DVDFileInfo*)
 s32 THPSimplePreLoad(s32 loop)
 {
     s32 status;
+    THPReadBuffer* readBuffer;
+    s32 readOffset;
+    s32 readSize;
     u32 i;
     u32 readCount;
 
@@ -531,8 +534,11 @@ s32 THPSimplePreLoad(s32 loop)
     }
 
     for (i = 0; i < readCount; i++) {
-        while ((status = DVDReadAsyncPrio(&SimpleControl.fileInfo, SimpleControl.readBuffer[SimpleControl.readIndex].mPtr,
-                                          SimpleControl.readSize, SimpleControl.readOffset,
+        readBuffer = &SimpleControl.readBuffer[SimpleControl.readIndex];
+        readOffset = SimpleControl.readOffset;
+        readSize = SimpleControl.readSize;
+
+        while ((status = DVDReadAsyncPrio(&SimpleControl.fileInfo, readBuffer->mPtr, readSize, readOffset,
                                           static_cast<DVDCallback>(0), 2)) == 0) {
             status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
             if ((status == 0xB) || ((status - 4U) < 3) || (status == -1)) {
@@ -547,10 +553,10 @@ s32 THPSimplePreLoad(s32 loop)
             }
         }
 
-        SimpleControl.readOffset += SimpleControl.readSize;
-        SimpleControl.readSize = *reinterpret_cast<s32*>(SimpleControl.readBuffer[SimpleControl.readIndex].mPtr);
-        SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid = 1;
-        SimpleControl.readBuffer[SimpleControl.readIndex].mFrameNumber = SimpleControl.curAudioTrack;
+        SimpleControl.readOffset = readOffset + readSize;
+        SimpleControl.readSize = *reinterpret_cast<s32*>(readBuffer->mPtr);
+        readBuffer->mIsValid = 1;
+        readBuffer->mFrameNumber = SimpleControl.curAudioTrack;
         SimpleControl.curAudioTrack++;
         SimpleControl.readIndex = (SimpleControl.readIndex + 1) & 7;
 


### PR DESCRIPTION
Summary:
- Refactor `THPSimplePreLoad` to snapshot the active read buffer, read offset, and read size into loop-local variables before each preload iteration.
- Keep the existing control flow and error handling intact while making the per-iteration state updates explicit.

Units/functions improved:
- `main/THPSimple`: `THPSimplePreLoad`

Progress evidence:
- `THPSimplePreLoad` objdiff match improved from `75.31618%` to `78.31618%` (+3.0 percentage points) at the same 544-byte function size.
- `ninja` still completes successfully after the change.
- No data or linkage hacks were introduced; this is a source-only improvement in `src/THPSimple.cpp`.

Plausibility rationale:
- The new locals model the natural per-iteration state an original implementation would likely keep on hand while issuing each DVD read and advancing the ring buffer.
- This avoids artificial symbol tricks or offset hacks and makes the buffer/offset/size relationship more explicit without changing behavior.

Technical details:
- The previous version repeatedly re-read `SimpleControl.readBuffer[SimpleControl.readIndex]`, `readOffset`, and `readSize` directly from global state inside the loop.
- Hoisting those values into locals improved register lifetimes and moved the generated code closer to the original assembly according to objdiff.

Build verification:
- `ninja`
