### PR TITLE
Improve prgobj target rotation helpers

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -429,15 +429,13 @@ void CGPrgObj::putParticleBindTrace(int no, int dataNo, CGObject* obj, float sca
  */
 float CGPrgObj::getTargetRot(CGPrgObj* target)
 {
-	float targetRot;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(m_worldPosition);
 	CVector deltaPos;
+	float targetRot = FLOAT_80331BD4;
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
-	if (deltaPos.x == FLOAT_80331BD4 || deltaPos.z == FLOAT_80331BD4) {
-		targetRot = 0.0f;
-	} else {
+	if (deltaPos.x != FLOAT_80331BD4 && deltaPos.z != FLOAT_80331BD4) {
 		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 	}
 
@@ -455,26 +453,17 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
  */
 void CGPrgObj::rotTarget(CGPrgObj* target)
 {
-	CGPrgObj* self = this;
 	CVector targetPos(target->m_worldPosition);
-	CVector basePos(self->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
-	float targetRot;
-	float deltaX;
-	float zero;
-	float deltaZ;
+	float targetRot = FLOAT_80331BD4;
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos),
 	              reinterpret_cast<Vec*>(&deltaPos));
-	deltaX = deltaPos.x;
-	zero = FLOAT_80331BD4;
-	deltaZ = deltaPos.z;
-	if (deltaX == zero || deltaZ == zero) {
-		targetRot = FLOAT_80331BD4;
-	} else {
-		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
+	if (deltaPos.x != FLOAT_80331BD4 && deltaPos.z != FLOAT_80331BD4) {
+		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 	}
-	self->m_rotTargetY = targetRot;
+	m_rotTargetY = targetRot;
 }
 
 /*
@@ -488,27 +477,18 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
  */
 void CGPrgObj::dstTargetRot(CGPrgObj* target)
 {
-	CGPrgObj* self = this;
-	float targetRot;
 	CVector targetPos(target->m_worldPosition);
-	CVector basePos(self->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
-	float deltaX;
-	float zero;
-	float deltaZ;
+	float targetRot = FLOAT_80331BD4;
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos),
 	              reinterpret_cast<Vec*>(&deltaPos));
-	deltaX = deltaPos.x;
-	zero = FLOAT_80331BD4;
-	deltaZ = deltaPos.z;
-	if (deltaX == zero || deltaZ == zero) {
-		targetRot = FLOAT_80331BD4;
-	} else {
-		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
+	if (deltaPos.x != FLOAT_80331BD4 && deltaPos.z != FLOAT_80331BD4) {
+		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 	}
 
-	Math.DstRot(self->m_rotBaseY, FLOAT_80331BD8 + targetRot);
+	Math.DstRot(m_rotBaseY, FLOAT_80331BD8 + targetRot);
 }
 
 /*


### PR DESCRIPTION
Summary:
Simplify the three `CGPrgObj` target-rotation helpers so they compute the rotation directly from the subtracted world-position delta without the extra self aliases and intermediate float temporaries.

Units/functions improved:
- `main/prgobj`
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: 57.583332 -> 85.055560
- `rotTarget__8CGPrgObjFP8CGPrgObj`: 64.589745 -> 83.282050
- `dstTargetRot__8CGPrgObjFP8CGPrgObj`: 68.613640 -> 86.204544

Progress evidence:
- `ninja` succeeds after the change.
- `objdiff` oneshot diffs for all three functions show substantial code-match gains with no data/linkage regressions in the touched unit.
- Accepted regressions: none.

Plausibility rationale:
The new code is closer to what the original authors likely wrote: initialize the return/target angle to the shared zero constant, compute the delta vector once, and only call `atan2` when both relevant axes are non-zero. This removes compiler-coaxing style temporaries and redundant aliases while preserving straightforward gameplay logic.

Technical details:
- Replaced the `== zero || == zero`/`else` pattern with a direct guarded `atan2` assignment from `deltaPos`.
- Removed unnecessary `self`, `deltaX`, `deltaZ`, and `zero` locals so the compiler can keep the vector math path closer to the original register usage.
- Kept the existing CVector construction and member access patterns, so the result remains source-plausible within the surrounding codebase.
