### PR TITLE
Fix menu_lst state flag signedness

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -21,9 +21,9 @@ namespace {
 
 struct MenuLstState {
 	unsigned char pad_0000[0xB];
-	unsigned char initialized;
-	unsigned char pad_000C;
-	unsigned char closeRequested;
+	char initialized;
+	char pad_000C;
+	char closeRequested;
 	unsigned char pad_000E[2];
 	short mode;
 	unsigned char pad_0012[0x10];


### PR DESCRIPTION
Summary:
Model the menu list state flag bytes as signed `char` instead of `unsigned char` in `src/menu_lst.cpp`. This keeps the state layout intact while matching the signed byte access pattern used by the original code for the initialized/close-request fields.

Units/functions improved:
- `main/menu_lst`
- `MLstOpen__8CMenuPcsFv`: 72.38333% -> 72.71667% (`build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstOpen__8CMenuPcsFv`)
- `MLstCtrl__8CMenuPcsFv`: 56.07175% -> 56.076233% (`build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstCtrl__8CMenuPcsFv`)
- Current unit fuzzy match in `build/GCCP01/report.json`: 59.695053%

Progress evidence:
- `ninja` builds cleanly and updates `build/GCCP01/report.json` without regressions in code/data/linkage progress.
- The signedness fix improves code generation in the same unit without introducing extern hacks, section tricks, or layout changes.
- `MLstClose__8CMenuPcsFv` remains stable at 62.0%, so the change is isolated to the flag accesses that actually benefit.

Plausibility rationale:
The affected fields are state bytes, not arithmetic values. Treating them as signed `char` is a plausible original-source choice for menu state flags, and it matches the compiler behavior seen in the target where the initialized flag is sign-extended before the zero check.

Technical details:
- Updated `MenuLstState::initialized` at offset `0x0B` and `MenuLstState::closeRequested` at offset `0x0D` to `char`.
- This removes one obvious signed-byte mismatch in `MLstOpen` and slightly improves nearby state handling in `MLstCtrl` while preserving the existing struct layout and control flow.

Verification:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstOpen__8CMenuPcsFv`
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstCtrl__8CMenuPcsFv`