### PR TITLE
Fix pppFrameLaser step sentinel

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -232,7 +232,7 @@ void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *param_2, _ppp
     Mtx charaMtx;
     Mtx tempMtx;
 
-    if ((gPppCalcDisabled != 0) || (step->m_stepValue == 1)) {
+    if ((gPppCalcDisabled != 0) || (step->m_stepValue == 0xFFFF)) {
         return;
     }
 


### PR DESCRIPTION
## Summary
Fix the early-return sentinel in `pppFrameLaser` so the frame path skips only the disabled `0xFFFF` shape step instead of incorrectly treating `1` as the stop value.

## Units/functions improved
- Unit: `main/pppLaser`
- Function: `pppFrameLaser`

## Progress evidence
- `pppFrameLaser`: `61.046320%` -> `61.495914%`
- Unit `.text`: `42.518158%` -> `42.598870%`
- Build: `ninja` passes and project progress remains stable at `23.49% matched, 8.23% linked`
- Note: `pppRenderLaser` shows a small objdiff drift (`24.303192%` -> `24.216755%`) despite no surviving render-source change. This appears to be layout churn from recompiling the unit after the frame-side control-flow fix, and it is outweighed by the larger targeted gain in `pppFrameLaser` plus the net unit `.text` improvement.

## Plausibility rationale
The sibling laser unit and the decomp both indicate this field uses a disabled-step sentinel rather than a literal `1`. Changing the guard to `0xFFFF` is a direct control-flow correction that matches the surrounding data conventions and is more plausible original source than special-casing step index `1`.

## Technical details
- Updated the top-level `pppFrameLaser` guard from `step->m_stepValue == 1` to `step->m_stepValue == 0xFFFF`
- Kept the patch intentionally minimal after testing render-side hypotheses that did not produce a clean net gain
- Verified the result with `ninja` and `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser`
