### PR TITLE
Move pppLocationTitle filename string to rodata

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -47,7 +47,7 @@ struct LocationTitleColorBlock {
     u32 m_color;
 };
 
-char s_pppLocationTitle_cpp_801DB510[] = "pppLocationTitle.cpp";
+static const char s_pppLocationTitle_cpp_801DB510[] = "pppLocationTitle.cpp";
 
 /*
  * --INFO--
@@ -147,7 +147,8 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
         float zero;
 
         work->m_particles = pppMemAlloc(param_2->m_maxCount * sizeof(LocationTitleParticle),
-                                        pppEnvStPtr->m_stagePtr, s_pppLocationTitle_cpp_801DB510, 0x6d);
+                                        pppEnvStPtr->m_stagePtr,
+                                        const_cast<char*>(s_pppLocationTitle_cpp_801DB510), 0x6d);
         particle = (LocationTitleParticle*)work->m_particles;
         zero = FLOAT_80330ee0;
 


### PR DESCRIPTION
## Summary
- make `s_pppLocationTitle_cpp_801DB510` a `static const` string so the object emits it in read-only storage
- keep the existing `pppMemAlloc` call working by passing `const_cast<char*>(...)`, without changing runtime behavior

## Units/functions improved
- Unit: `main/pppLocationTitle`
- Data symbol: `s_pppLocationTitle_cpp_801DB510`
- Functions checked for regressions: `pppConstructLocationTitle`, `pppDestructLocationTitle`, `pppFrameLocationTitle`, `pppRenderLocationTitle`

## Progress evidence
- `ninja` still builds cleanly with no overall progress regression
- `objdiff` for `main/pppLocationTitle` keeps `.text` at `90.74773%`
- `objdiff` keeps `pppConstructLocationTitle` and `pppDestructLocationTitle` at `100%`, `pppRenderLocationTitle` at `99.0%`, and `pppFrameLocationTitle` at `87.06515%`
- `nm -m build/GCCP01/src/pppLocationTitle.o` now reports `s_pppLocationTitle_cpp_801DB510` as `r` instead of writable `D`, matching `config/GCCP01/symbols.txt`, which places it in `.rodata`

## Plausibility rationale
- this is a straightforward source-level const-correctness fix for a file name string literal
- `LocationTitle2.cpp` already uses the same pattern (`static const char ...`), so this aligns `pppLocationTitle.cpp` with an adjacent recovered source style rather than compiler coaxing

## Technical details
- the map labels `s_pppLocationTitle_cpp_801DB510` as `.rodata:0x801DB510`
- the previous declaration forced the symbol into writable data; the new declaration restores read-only placement while preserving the existing allocation-call ABI
