### PR TITLE
Refine pppKeShpTail2X frame duration access

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -145,18 +145,15 @@ void pppKeShpTail2X(_pppPObject* obj, pppKeShpTail2XUnkB* param_2, pppKeShpTail2
         long** shapeTable = *(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + step->m_dataValIndex * 4);
         u8* shape = (u8*)*shapeTable;
         KeShpTail2XShapeFrame* frameEntry;
-        s16 frameDuration;
         u16 shapeFrame;
 
         shapeFrame = work->m_shapeFrame;
         work->m_shapePrevFrame = shapeFrame;
 
         work->m_frameAcc += step->m_frameStep;
-        frameEntry =
-            reinterpret_cast<KeShpTail2XShapeFrame*>(shape + ((u32)shapeFrame << 3) + 0x10);
-        frameDuration = frameEntry->m_duration;
-        if (work->m_frameAcc >= frameDuration) {
-            work->m_frameAcc -= frameDuration;
+        frameEntry = reinterpret_cast<KeShpTail2XShapeFrame*>(shape + ((u32)shapeFrame << 3) + 0x10);
+        if (work->m_frameAcc >= frameEntry->m_duration) {
+            work->m_frameAcc -= frameEntry->m_duration;
             work->m_shapeFrame++;
             if (work->m_shapeFrame >= *(s16*)(shape + 6)) {
                 if ((frameEntry->m_flags & 0x80) != 0) {


### PR DESCRIPTION
## Summary
- simplify the `pppKeShpTail2X` shape-frame duration block to compare and subtract directly from `frameEntry->m_duration`
- keep the existing logic and data flow intact while removing a temporary that was changing instruction ordering in the frame-advance path

## Units/functions improved
- Unit: `main/pppKeShpTail2X`
- Function: `pppKeShpTail2X`

## Progress evidence
- `pppKeShpTail2X`: `98.73387%` -> `99.520164%`
- `main/pppKeShpTail2X` `.text`: `65.97841%` -> `66.24156%`
- Data/linkage progress for the unit is unchanged by this patch
- `ninja -j1` passes after the change

## Plausibility rationale
- This is a source-plausible cleanup of the frame-advance logic rather than compiler coaxing: the code now uses the frame entry directly where the duration is consumed
- No hardcoded offsets, extern hacks, section tricks, or non-idiomatic reordering were introduced

## Technical details
- The previous temporary caused the compiler to emit the `lha`/`lhz` pair in the wrong order around the `m_frameAcc` vs frame-duration comparison
- Comparing against `frameEntry->m_duration` directly moves that block closer to the target assembly while preserving the same behavior and surrounding control flow
