### PR TITLE
Improve pppFrameYmMoveParabola match

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -49,9 +49,10 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
     Vec direction;
     if ((s32)Game.m_currentSceneId == 7) {
         f32 zero = gPppYmMoveParabolaZero;
+        f32 yOffset = gPppYmMoveParabolaYOffsetStep;
 
-        direction.x = gPppYmMoveParabolaYOffsetStep;
         direction.y = zero;
+        direction.x = yOffset;
         direction.z = zero;
     } else {
         PSVECSubtract(&pppMngSt->m_paramVec0, (Vec*)((u8*)pppMngSt + 0x58), &direction);
@@ -62,16 +63,12 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
 
     s32 sinIndex = (s32)((gPppYmMoveParabolaAngleScale * stepData->m_dataValIndex) / gPppYmMoveParabolaAngleDivisor);
     f32 distance = work->m_distance;
-    f32 directionX = direction.x;
-    f32 directionZ = direction.z;
-    f32 gravity = gPppYmMoveParabolaGravityScale;
-    f32 trigSin = *(f32*)((u8*)gPppTrigTable + (sinIndex & 0xFFFC));
-    f32 trigCos = *(f32*)((u8*)gPppTrigTable + ((sinIndex + 0x4000) & 0xFFFC));
-    f32 distanceSin = distance * trigSin;
-    f32 parabolaScale = frameCount * (distance * trigCos);
-    newPosition.x = directionX * parabolaScale;
-    newPosition.z = directionZ * parabolaScale;
-    newPosition.y = (frameCount * distanceSin) - (frameCount * (gravity * stepData->m_initWOrk * frameCount));
+    f32 parabolaScale =
+        frameCount * (distance * *(f32*)((u8*)gPppTrigTable + ((sinIndex + 0x4000) & 0xFFFC)));
+    newPosition.x = direction.x * parabolaScale;
+    newPosition.z = direction.z * parabolaScale;
+    newPosition.y = (frameCount * (distance * *(f32*)((u8*)gPppTrigTable + (sinIndex & 0xFFFC)))) -
+                    (frameCount * ((gPppYmMoveParabolaGravityScale * stepData->m_initWOrk) * frameCount));
     if ((s32)Game.m_currentSceneId == 7) {
         Vec basePosition = work->m_basePosition;
         pppAddVector(newPosition, newPosition, basePosition);


### PR DESCRIPTION
Summary
- reorder the scene-7 direction setup so the zero/y-offset values are materialized in the same source order as the target build
- collapse the parabola/trig temporaries into the final evaluation order used for the X/Z scale and Y parabola height
- keep the logic source-plausible: the change is limited to expression ordering and local temporary structure, with no hacks or linkage shortcuts

Units/functions improved
- `main/pppYmMoveParabola`
- `pppFrameYmMoveParabola`

Progress evidence
- `pppFrameYmMoveParabola`: `96.03261%` -> `96.41304%` by objdiff oneshot
- build still passes with `ninja`
- no data or linkage regressions in the unit; `.data` remains fully matched and `pppConstructYmMoveParabola` stays `100%`

Plausibility rationale
- this is still normal gameplay/math code: the patch just expresses the same vector setup and parabola calculation in an order that better matches how the original source appears to have been written
- the update uses named locals and existing game constants instead of compiler-coaxing tricks

Technical details
- moved the scene-7 Y-offset into a dedicated local so the direction vector is assembled in the target load/store order
- rewrote the trig/parabola block so cosine scaling is computed once, X/Z consume that shared scale directly, and Y is formed from the explicit sine/gravity expression ordering suggested by objdiff
- validated with `build/tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o - pppFrameYmMoveParabola` and a full `ninja` rebuild