### PR TITLE
Improve pppFrameYmMelt vertex init matching

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -235,7 +235,6 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
 
     YmMeltWork* work = (YmMeltWork*)((u8*)ymMelt + *offsets->m_serializedDataOffsets + 0x80);
     colorOffset = offsets->m_serializedDataOffsets[1];
-    YmMeltColorWork* colorWork = (YmMeltColorWork*)((u8*)ymMelt + colorOffset + 0x80);
     gridCount = *(u16*)((u8*)&ctrl->m_initWOrk + 2) + 1;
     int vertexCount = gridCount * gridCount;
     float matrixY = pppMngStPtr->m_matrix.value[1][3];
@@ -253,27 +252,27 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
         s16 phaseOffset = work->m_phaseOffset;
         float step = ctrl->m_stepValue / (f32)*(u16*)((u8*)&ctrl->m_initWOrk + 2);
         float rot = FLOAT_80330b0c * (f32)phaseOffset;
-        YmMeltVertex* vertex = vertexBase;
+        Vec* vertex = &vertexBase->m_position;
         Mtx rotMtx;
 
         for (float z = -halfWidth; z <= halfWidth; z += step) {
-            YmMeltVertex* rowVertex = vertex;
+            Vec* rowVertex = vertex;
             for (float x = -halfWidth; x <= halfWidth; x += step) {
-                rowVertex->m_position.x = x;
-                rowVertex->m_position.y = kPppYmMeltZero;
-                rowVertex->m_position.z = z;
+                rowVertex->x = x;
+                rowVertex->y = kPppYmMeltZero;
+                rowVertex->z = z;
 
                 if (phaseOffset != 0) {
                     PSMTXRotRad(rotMtx, 'y', rot);
-                    PSMTXMultVec(rotMtx, &rowVertex->m_position, &rowVertex->m_position);
+                    PSMTXMultVec(rotMtx, rowVertex, rowVertex);
                 }
 
-                rowVertex++;
-                vertex++;
+                rowVertex = (Vec*)((u8*)rowVertex + sizeof(YmMeltVertex));
+                vertex = (Vec*)((u8*)vertex + sizeof(YmMeltVertex));
             }
         }
 
-        CalcPolygonHeight((VERTEX_DATA*)ctrl, vertexBase, (_GXColor*)&colorWork->m_color, matrixY);
+        CalcPolygonHeight((VERTEX_DATA*)ctrl, vertexBase, (_GXColor*)((u8*)ymMelt + colorOffset + 0x88), matrixY);
     }
 
     work->m_phaseVelocity = work->m_phaseVelocity + work->m_phaseAccel;


### PR DESCRIPTION
Summary
- Reworked the `pppFrameYmMelt` vertex initialization loop to iterate over the position payload directly and delayed the color pointer materialization until the `CalcPolygonHeight` call.
- This keeps the generated code closer to the target object without changing behavior or introducing linkage hacks.

Units/functions improved
- `main/pppYmMelt`
- `pppFrameYmMelt`: `95.05882%` -> `98.76471%`

Progress evidence
- Unit `.text`: `71.7398%` -> `72.543365%`
- `pppRenderYmMelt`: unchanged at `63.689976%`
- `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf`: unchanged at `63.21154%`
- `ninja` still succeeds; no data or linkage regressions were introduced in this change.

Plausibility rationale
- The function only initializes vertex positions before collision height adjustment, so iterating over the packed position fields directly is a plausible original implementation detail.
- Removing the extra local color-work temporary is a source-plausible cleanup, not compiler coaxing or an extern-based shortcut.

Technical details
- Verified against the clean `main` version of `src/pppYmMelt.cpp` by rebuilding the baseline file, recording objdiff metrics, then restoring the patch and rebuilding again.
- The measurable gain comes from `pppFrameYmMelt`; the other major symbols in the unit remained flat.
