### PR TITLE
Improve pppFrameYmMoveCircle match quality

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -110,15 +110,15 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
     }
     work->m_angle += work->m_angleStep;
 
-    if (work->m_angle > 360.0f) {
-        work->m_angle -= 360.0f;
+    if (work->m_angle > gPppYmMoveCircleTurnSpan) {
+        work->m_angle -= gPppYmMoveCircleTurnSpan;
     }
-    if (work->m_angle < 0.0f) {
-        work->m_angle += 360.0f;
+    if (work->m_angle < gPppYmMoveCircleZero) {
+        work->m_angle += gPppYmMoveCircleTurnSpan;
     }
 
     {
-        f32 tableAngle = (32768.0f * (0.017453292f * work->m_angle)) / 3.1415927f;
+        f32 tableAngle = (32768.0f * (0.017453292f * work->m_angle)) / gPppYmMoveCircleTableDivisor;
         tableIndex = (s32)tableAngle;
     }
     sinAngle = *(f32*)((u8*)gPppTrigTable + (tableIndex & 0xFFFC));


### PR DESCRIPTION
Summary:
- update `pppFrameYmMoveCircle` to use the unit's existing named wrap/divisor constants for angle normalization and table-angle conversion
- keep the rest of the movement math and linkage unchanged so the source remains plausible and localized

Units/functions improved:
- `main/pppYmMoveCircle`
- `pppFrameYmMoveCircle` (560b)

Progress evidence:
- objdiff oneshot for `pppFrameYmMoveCircle`: 95.51428% -> 97.15714%
- section `.text` for the diffed unit now reports 98.0093% in objdiff
- accepted regressions: none
- build result: `ninja` completed successfully after the change

Plausibility rationale:
- the change replaces hardcoded wrap/divisor literals with existing move-circle constants already defined for this unit
- that matches the surrounding codebase style of using named particle constants without introducing extern hacks, hardcoded addresses, or control-flow distortion

Technical details:
- the live objdiff mismatch cluster showed the angle wrap and divisor loads wanted the named `gPppYmMoveCircleTurnSpan`, `gPppYmMoveCircleZero`, and `gPppYmMoveCircleTableDivisor` symbols
- using only those existing constants improved codegen while avoiding the broader constant rewrite that regressed match quality
