### PR TITLE
Link pppEraseCharaParts

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -517,7 +517,7 @@ config.libs = [
             Object(Matching, "pppDrawShape.cpp"),
             Object(Matching, "pppDrawShape2.cpp"),
             Object(NonMatching, "pppEmission.cpp"),
-            Object(NonMatching, "pppEraseCharaParts.cpp"),
+            Object(Matching, "pppEraseCharaParts.cpp"),
             Object(Matching, "pppFilter.cpp"),
             Object(Matching, "pppFovAdjustMatrix.cpp"),
             Object(NonMatching, "pppGetRotMatrixX.cpp"),


### PR DESCRIPTION
## Summary
- promote `pppEraseCharaParts.cpp` from `NonMatching` to `Matching` in `configure.py`
- preserve the verified PAL build while allowing the exact decomped object to participate in the linked build

## Units/functions improved
- Unit: `main/pppEraseCharaParts`
- Functions: `pppConstructEraseCharaParts`, `pppDestructEraseCharaParts`, `pppFrameEraseCharaParts`, `EraseCharaParts_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`

## Progress evidence
- Objdiff for `main/pppEraseCharaParts` is exact: `.text` 100%, `extab` 100%, `extabindex` 100%
- Linked progress improves from `228 / 529 files (8.23%)` to `229 / 529 files (8.25%)`
- Game linked progress improves from `86 / 272 files (1.45%)` to `87 / 272 files (1.48%)`
- `ninja` still verifies `build/GCCP01/main.dol: OK`

## Plausibility rationale
- This does not introduce compiler coaxing or source hacks; it only acknowledges that the current source for `pppEraseCharaParts.cpp` already matches the original object exactly
- Promoting an exact object to `Matching` is the correct next step toward recovering original source and increasing real linkage coverage

## Technical details
- I tested several exact-object candidates and rejected ones that either changed the final DOL checksum or produced duplicate-symbol link failures
- `pppEraseCharaParts.cpp` was the candidate that linked cleanly and preserved the verified PAL checksum, so it is safe to flip now
