### PR TITLE
Match p_tina viewer stopwatch calls

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -22,7 +22,7 @@ extern "C" const char s_no_name_8032fdcc[];
 extern "C" {
 const char s_no_name_8032fdcc[] = "no_name";
 }
-static char s_tinaSourceName[] = "p_tina.cpp";
+static char s_p_tina_cpp_801d8008[] = "p_tina.cpp";
 static char s_tinaPrioTimeFmt[] = "prioTime:%d prio:%d pdtID:%2d fp:%08x\n";
 static char s_tinaTitleFmt[] = "Tina :%c\n";
 static char s_tinaCalcFmt[] = "clc :%f / max :%f\n";
@@ -55,6 +55,9 @@ extern "C" void SetDrawDoneDebugData__8CGraphicFSc(void*, signed char);
 extern "C" void SetFog__8CGraphicFii(void*, int, int);
 extern "C" void pppSetRendMatrix__8CPartMngFv(CPartMng*);
 extern "C" void pppDraw__8CPartMngFv(CPartMng*);
+extern "C" void _WaitDrawDone__8CGraphicFPci(CGraphic*, const char*, int);
+extern "C" void Start__10CStopWatchFv(void*);
+extern "C" void Stop__10CStopWatchFv(void*);
 extern "C" void Init__13CAmemCacheSetFPcPQ27CMemory6CStagePQ27CMemory6CStageiPFUl_UcUlPFUl_UcUlPFUl_UcUl(
     void*,
     char*,
@@ -807,15 +810,15 @@ void CPartPcs::draw()
  */
 void CPartPcs::drawShadowViewer()
 {
-    Graphic._WaitDrawDone(s_tinaSourceName, 0x308);
-    OSStartStopwatch(&g_par_draw_prof);
-    OSStartStopwatch(&g_par_calc_prof);
+    _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_tina_cpp_801d8008, 0x308);
+    Start__10CStopWatchFv(&g_par_draw_prof);
+    Start__10CStopWatchFv(&g_par_calc_prof);
     pppSetProjection();
     pppInitDrawEnv(0);
     PartMng.pppEditDrawShadow();
-    OSStopStopwatch(&g_par_calc_prof);
-    Graphic._WaitDrawDone(s_tinaSourceName, 0x30f);
-    OSStopStopwatch(&g_par_draw_prof);
+    Stop__10CStopWatchFv(&g_par_calc_prof);
+    _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_tina_cpp_801d8008, 0x30f);
+    Stop__10CStopWatchFv(&g_par_draw_prof);
     pppClearDrawEnv();
 }
 
@@ -830,15 +833,15 @@ void CPartPcs::drawShadowViewer()
  */
 void CPartPcs::drawViewer()
 {
-    Graphic._WaitDrawDone(s_tinaSourceName, 0x31a);
-    OSStartStopwatch(&g_par_draw_prof);
-    OSStartStopwatch(&g_par_calc_prof);
+    _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_tina_cpp_801d8008, 0x31a);
+    Start__10CStopWatchFv(&g_par_draw_prof);
+    Start__10CStopWatchFv(&g_par_calc_prof);
     pppSetProjection();
     pppInitDrawEnv(0);
     PartMng.pppEditDraw();
-    OSStopStopwatch(&g_par_calc_prof);
-    Graphic._WaitDrawDone(s_tinaSourceName, 0x322);
-    OSStopStopwatch(&g_par_draw_prof);
+    Stop__10CStopWatchFv(&g_par_calc_prof);
+    _WaitDrawDone__8CGraphicFPci(&Graphic, s_p_tina_cpp_801d8008, 0x322);
+    Stop__10CStopWatchFv(&g_par_draw_prof);
     pppClearDrawEnv();
 }
 
@@ -1056,14 +1059,14 @@ void CPartPcs::drawAfterViewer()
 {
 	int frameSign;
 
-	Graphic._WaitDrawDone(s_tinaSourceName, 0x3f1);
+	Graphic._WaitDrawDone(s_p_tina_cpp_801d8008, 0x3f1);
 	OSStartStopwatch(&g_par_draw_prof);
 	OSStartStopwatch(&g_par_calc_prof);
 	Graphic.SetFog(1, 0);
 	pppInitDrawEnv(0);
 	PartMng.pppEditPartDrawAfter();
 	OSStopStopwatch(&g_par_calc_prof);
-	Graphic._WaitDrawDone(s_tinaSourceName, 0x3fb);
+	Graphic._WaitDrawDone(s_p_tina_cpp_801d8008, 0x3fb);
 	OSStopStopwatch(&g_par_draw_prof);
 	PartMng.pppGet2Dpos();
 	pppClearDrawEnv();


### PR DESCRIPTION
## Summary
Route the  viewer draw paths through the same stopwatch wrapper calls and source-file string symbol used by the original object.

## Units/functions improved
- 
- : 
- : 

## Progress evidence
- Unit : 
- No code/data/linkage regressions were introduced in the touched unit; this is a straight code-match improvement.
- [1/1] PROGRESS
Progress:
  All: 23.51% matched, 8.23% linked (228 / 529 files)
    Code: 436108 / 1855300 bytes (2834 / 4733 functions)
    Data: 219915 / 1489807 bytes (14.76%)
  Game Code: 8.40% matched, 1.45% linked (86 / 272 files)
    Code: 129896 / 1545468 bytes (1596 / 3487 functions)
    Data: 67024 / 139392 bytes (48.08%)
  SDK Code: 98.91% matched, 42.06% linked (142 / 201 files)
    Code: 306212 / 309576 bytes (1238 / 1243 functions)
    Data: 152891 / 154707 bytes (98.83%) completes successfully after the change.

## Plausibility rationale
This keeps the underlying behavior unchanged and aligns the source with symbols already present in .
The viewer paths now call the existing , , and  entry points directly, which is consistent with how this codebase often preserves original linkage for near-match cleanup.

## Technical details
- Replaced method-style  calls in the viewer draw paths with the matching external wrapper.
- Swapped raw  /  calls for the existing stopwatch wrapper symbols used by the target object.
- Reused the existing  rodata symbol name from  so the viewer wait-draw sites bind to the original string symbol.
- Left  behavior unchanged aside from the same source-file symbol reuse, since its remaining mismatch is larger and unrelated to the viewer stopwatch cleanup addressed here.