### PR TITLE
Fix menu_arti animation layout

### DIFF
--- a/include/ffcc/menu_arti.h
+++ b/include/ffcc/menu_arti.h
@@ -8,7 +8,7 @@ public:
     void ArtiInit1();
     unsigned int ArtiOpen();
     int ArtiCtrl();
-    unsigned int ArtiClose();
+    bool ArtiClose();
     void ArtiDraw();
     int ArtiCtrlCur();
 };

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -114,7 +114,6 @@ struct ArtiOpenAnim {
 	float v;
 	float alpha;
 	float scale;
-	int stepMax;
 	int tex;
 	int step;
 	int startFrame;
@@ -465,22 +464,24 @@ int CMenuPcs::ArtiCtrl()
  * JP Address: TODO
  * JP Size: TODO
  */
-unsigned int CMenuPcs::ArtiClose()
+bool CMenuPcs::ArtiClose()
 {
-	s16* artiState = GetArtiState(this);
-	s16* artiList = GetArtiList(this);
 	int finished = 0;
-	int count = artiList[0];
-	ArtiOpenAnim* anim = (ArtiOpenAnim*)((u8*)artiList + 8);
-	int frame;
+	GetArtiState(this)[0x11]++;
 
-	artiState[0x11]++;
-	frame = artiState[0x11];
+	int count = GetArtiList(this)[0];
+	ArtiOpenAnim* anim = (ArtiOpenAnim*)((u8*)GetArtiList(this) + 8);
+	int frame = GetArtiState(this)[0x11];
 
 	for (int i = 0; i < count; i++, anim++) {
 		float zeroF = FLOAT_80332fa8;
 		if (anim->startFrame <= frame) {
-			if (frame < anim->startFrame + anim->duration) {
+			if (!(frame < anim->startFrame + anim->duration)) {
+				finished++;
+				anim->alpha = FLOAT_80332fa8;
+				anim->dx = zeroF;
+				anim->dy = zeroF;
+			} else {
 				anim->step++;
 				double oneD = DOUBLE_80332fb0;
 				anim->alpha = (float)-((DOUBLE_80332fb0 / (double)anim->duration) * (double)anim->step - DOUBLE_80332fb0);
@@ -489,16 +490,11 @@ unsigned int CMenuPcs::ArtiClose()
 					anim->dx = (anim->targetX - (float)anim->x) * ratio;
 					anim->dy = (anim->targetY - (float)anim->y) * ratio;
 				}
-			} else {
-				finished++;
-				anim->alpha = FLOAT_80332fa8;
-				anim->dx = zeroF;
-				anim->dy = zeroF;
 			}
 		}
 	}
 
-	return (unsigned int)(count == finished);
+	return count == finished;
 }
 
 /*


### PR DESCRIPTION
## Summary
- correct the `ArtiOpenAnim` layout in `menu_arti` by removing the extra `stepMax` field that shifted the animation state fields by 4 bytes
- update `CMenuPcs::ArtiClose()` to use the corrected layout directly and return a boolean completion state

## Units/functions improved
- Unit: `main/menu_arti`
- `ArtiClose__8CMenuPcsFv`: `49.042107% -> 74.315790%` (`+25.273683`)
- `ArtiOpen__8CMenuPcsFv`: `58.546295% -> 64.870370%` (`+6.324075`)

## Progress evidence
- `ArtiCtrlCur__8CMenuPcsFv`: `71.325130% -> 71.315270%` (`-0.009860`)
- `ArtiDraw__8CMenuPcsFv`: `57.830154% -> 57.691510%` (`-0.138644`)
- `ArtiClose__8CMenuPcsFv`: `49.042107% -> 74.315790%` (`+25.273683`)
- `ArtiCtrl__8CMenuPcsFv`: `100.000000% -> 100.000000%` (`+0.000000`)
- `ArtiOpen__8CMenuPcsFv`: `58.546295% -> 64.870370%` (`+6.324075`)
- `ArtiInit1__8CMenuPcsFv`: `45.271523% -> 45.158940%` (`-0.112583`)
- `ArtiInit__8CMenuPcsFv`: `61.747060% -> 61.658825%` (`-0.088235`)
- accepted the tiny regressions above because they are outweighed by the large gains in the two functions that actively consume the animation state layout

## Plausibility rationale
- the previous source declared an extra `stepMax` field that does not exist in the observed object layout
- removing that field aligns `tex`, `step`, `startFrame`, `duration`, `flags`, `dx`, and `dy` with the offsets used by the original code
- the updated `ArtiClose()` flow follows the corrected field semantics and remains straightforward game UI code rather than compiler coaxing

## Technical details
- verified with `ninja`
- measured with `build/tools/objdiff-cli diff -p . -u main/menu_arti -o ...`
- the layout fix materially improved both close/open menu animation handling, which is strong evidence that the field offsets were the real issue rather than local control-flow noise
