### PR TITLE
Improve CFunnyShapePcs::drawViewer static state matching

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -48,6 +48,7 @@ extern "C" void* __vt__8CManager;
 extern "C" void* gVtable_CPtrArray_OSFSTexture[];
 extern "C" void* gVtable_CPtrArray_GXTexObj[];
 extern "C" void* __vt__14CFunnyShapePcs[];
+extern "C" char lbl_8032FD1C[];
 
 CFunnyShapePcs FunnyShapePcs;
 u8 ARRAY_8026D728[0xC];
@@ -76,7 +77,7 @@ void CopyFunnyShapePcsTable()
 extern "C" CPtrArray<OSFS_TEXTURE_ST*>* dtor_8004EAD0(CPtrArray<OSFS_TEXTURE_ST*>* ptrArray, short shouldDelete);
 extern "C" CUSBStreamData* __dt__14CUSBStreamDataFv(CUSBStreamData* self, short shouldDelete);
 static const char s_CFunnyShapePcs[] = "CFunnyShapePcs";
-static int frameCount;
+static const char s_funnyShapeFmt[] = "FunnyShape %c";
 
 namespace {
 static inline u8* Ptr(CFunnyShapePcs* self, u32 offset)
@@ -365,8 +366,8 @@ void CFunnyShapePcs::drawViewer()
     Vec eye = {0.0f, 0.0f, 0.0f};
     Vec at = {0.0f, 0.0f, 0.0f};
     Vec up = {0.0f, 1.0f, 0.0f};
-    static const char s_funnyShapeFmt[] = "FunnyShape %c";
-    static const char s_spinner[] = "|/-\\";
+    static char* s_spinner = lbl_8032FD1C;
+    static int frameCount = 0;
 
     C_MTXOrtho(ortho, kFunnyShapeNdcMax, kFunnyShapeNdcMin, kFunnyShapeNdcMin, kFunnyShapeNdcMax, kFunnyShapeNdcMax, kFunnyShapeOrthoFarZ);
     GXSetProjection(ortho, GX_ORTHOGRAPHIC);


### PR DESCRIPTION
Summary:
- move the FunnyShape viewer format string to file scope
- switch the viewer spinner to a function-local static pointer backed by the existing small-data string symbol
- make the viewer frame counter function-local static instead of file-scope state

Units/functions improved:
- unit: `main/p_FunnyShape`
- function: `drawViewer__14CFunnyShapePcsFv`

Progress evidence:
- `objdiff` for `drawViewer__14CFunnyShapePcsFv` improved from `85.992424%` to `86.458336%`
- `__sinit_p_FunnyShape_cpp` remained at the same near-match bucket (`86.8%`-range); no new regressions were introduced in the edited source
- `ninja` still completes successfully and project-wide progress does not regress

Plausibility rationale:
- the Ghidra reference shows the viewer using guarded static state for the spinner pointer and frame counter inside `drawViewer()`
- this change moves the source toward that original storage pattern without adding hacks, fake linkage, or layout-forcing tricks
- reusing the existing `lbl_8032FD1C` string symbol is more plausible than materializing a separate local array for the same spinner text

Technical details:
- declared the existing small-data spinner string symbol and used it for the function-local static pointer
- kept behavior identical: the spinner selection and viewport/print path are unchanged, only the static storage shape changed
- verified by rebuilding with `ninja` and checking `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - drawViewer__14CFunnyShapePcsFv`