### PR TITLE
Improve CTexAnim::CRefData destructor match

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -45,6 +45,7 @@ extern "C" void* __vt__11CTexAnimSeq[];
 extern "C" void* __vt__Q28CTexAnim8CRefData[];
 extern "C" void __ct__21CPtrArray_P8CTexAnim_Fv(void*);
 extern "C" void __ct__25CPtrArray_P11CTexAnimSeq_Fv(void*);
+extern "C" void __dt__25CPtrArray_P11CTexAnimSeq_Fv(void*, int);
 extern "C" {
 char s_texanim_cpp_801d7adc[] = "texanim.cpp";
 }
@@ -1144,7 +1145,7 @@ CTexAnim::CRefData::~CRefData()
         refData->material = 0;
     }
     refData->texAnimSeqs.ReleaseAndRemoveAll();
-    refData->texAnimSeqs.~CPtrArray<CTexAnimSeq*>();
+    __dt__25CPtrArray_P11CTexAnimSeq_Fv(&refData->texAnimSeqs, -1);
 
     __dt__4CRefFv(this, 0);
 }


### PR DESCRIPTION
Summary:
- call the specialized `CPtrArray<CTexAnimSeq*>` destructor symbol directly in `CTexAnim::CRefData::~CRefData()`
- add the matching extern declaration in `src/texanim.cpp`

Units/functions improved:
- `main/texanim`: `__dt__Q28CTexAnim8CRefDataFv`

Progress evidence:
- `__dt__Q28CTexAnim8CRefDataFv`: `91.95652%` -> `99.67391%` (`184` bytes)
- `main/texanim` `.text` match: `81.40562%` -> `81.682526%`
- `ninja` passes after the change

Plausibility rationale:
- this destructor already performs the expected manual cleanup steps for the embedded `CPtrArray<CTexAnimSeq*>`
- switching from an object-expression destructor call to the explicit specialized destructor symbol is consistent with the codebase's existing manual Metrowerks runtime interop and removes a codegen mismatch without adding hacks or changing behavior

Technical details:
- objdiff showed the remaining mismatch in `__dt__Q28CTexAnim8CRefDataFv` was the `CPtrArray<CTexAnimSeq*>` destructor call sequence
- calling `__dt__25CPtrArray_P11CTexAnimSeq_Fv(&refData->texAnimSeqs, -1)` eliminates the extra virtual-dispatch pattern and brings the function to a near match