### PR TITLE
Match pppCalcFrameShape in pppShape

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -325,15 +325,13 @@ void pppCalcFrameShape(long* animData, short& currentFrame, short& drawFrame, sh
                        short deltaTime)
 {
     char* frameData = (char*)animData + (currentFrame << 3) + 0x10;
-    short duration;
 
     drawFrame = currentFrame;
     frameTime += deltaTime;
-    duration = *(short*)(frameData + 2);
-    if (frameTime < duration) {
+    if (frameTime < *(short*)(frameData + 2)) {
         return;
     }
-    frameTime -= duration;
+    frameTime -= *(short*)(frameData + 2);
     currentFrame += 1;
     if (currentFrame < *(short*)((int)animData + 6)) {
         return;


### PR DESCRIPTION
Summary:
- Simplified `pppCalcFrameShape` in `src/pppShape.cpp` by removing the temporary `duration` local and reading the frame duration directly at the compare/subtract sites.
- Kept behavior unchanged while aligning the generated instruction order with the original object.

Units/functions improved:
- Unit: `main/pppShape`
- Function: `pppCalcFrameShape__FPlRsRsRss`

Progress evidence:
- `pppCalcFrameShape__FPlRsRsRss`: 99.12% -> 100.0%
- `main/pppShape` code match: 98.84887% -> 98.90428%
- No data or linkage hacks were introduced; `extern` usage and section tricks were unchanged.
- `ninja` rebuild passed after the change.

Plausibility rationale:
- The updated source is simpler and more natural than carrying a one-use temporary.
- Reading the frame duration directly in the compare/subtract is plausible original source and matches the existing control flow without introducing coaxing-only temporaries or reordered logic.

Technical details:
- Objdiff previously showed the only mismatch in `pppCalcFrameShape` as the load order of `frameTime` versus the frame duration before the compare.
- Expressing the condition and subtraction directly removed that mismatch and produced a full code match for the function.
