### PR TITLE
Fix duplicated CPartPcs destructor cleanup

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -229,7 +229,6 @@ static PppPdtSlotRaw* GetPartMngPdtSlots()
  */
 CPartPcs::~CPartPcs()
 {
-    reinterpret_cast<CUSBStreamData*>(reinterpret_cast<char*>(this) + 4)->~CUSBStreamData();
 }
 
 /*


### PR DESCRIPTION
## Summary
- remove the manual `CUSBStreamData` destructor call from `CPartPcs::~CPartPcs()`
- let the compiler-generated member destruction handle `m_usbStreamData` once

## Units/functions improved
- `main/p_tina`
- `__dt__8CPartPcsFv`: 88.0% -> 100.0 fuzzy match in `build/GCCP01/report.json`

## Progress evidence
- overall matched code: `436344 -> 436444` bytes (`+100`)
- overall matched functions: `2836 -> 2837`
- game matched code: `130132 -> 130232` bytes (`+100`)
- game matched functions: `1598 -> 1599`
- `main/p_tina` matched functions: `30/43 -> 31/43`

## Plausibility rationale
- the previous source manually destroyed `m_usbStreamData` inside `CPartPcs::~CPartPcs()`, even though the compiler-generated destructor already destroys members
- removing the explicit call makes the destructor behavior plausible original C++ instead of compiler coaxing

## Technical details
- PPC objdump showed `__dt__8CPartPcsFv` calling `__dt__14CUSBStreamDataFv` twice before the change
- after the change, the generated destructor contains a single member-destructor call and the function is reported as fully matched
- verified with `ninja -j1` on PAL (`GCCP01`)