### PR TITLE
Fix CMapAnimNode interpolation weights

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -426,8 +426,8 @@ void CMapAnimNode::Interp(int frame)
                         t = static_cast<float>(frameInLoop - currentFrame) / static_cast<float>(frameRange);
                     }
 
-                    PSVECScale(&current->value, &currentScaled, t);
-                    PSVECScale(&next->value, &nextScaled, 1.0f - t);
+                    PSVECScale(&current->value, &currentScaled, 1.0f - t);
+                    PSVECScale(&next->value, &nextScaled, t);
                     PSVECAdd(&currentScaled, &nextScaled, out);
                     break;
                 }
@@ -476,8 +476,8 @@ void CMapAnimNode::Interp(int frame)
                         t = static_cast<float>(frameInLoop - currentFrame) / static_cast<float>(frameRange);
                     }
 
-                    PSVECScale(&current->value, &currentScaled, t);
-                    PSVECScale(&next->value, &nextScaled, 1.0f - t);
+                    PSVECScale(&current->value, &currentScaled, 1.0f - t);
+                    PSVECScale(&next->value, &nextScaled, t);
                     PSVECAdd(&currentScaled, &nextScaled, out);
                     break;
                 }
@@ -526,8 +526,8 @@ void CMapAnimNode::Interp(int frame)
                         t = static_cast<float>(frameInLoop - currentFrame) / static_cast<float>(frameRange);
                     }
 
-                    PSVECScale(&current->value, &currentScaled, t);
-                    PSVECScale(&next->value, &nextScaled, 1.0f - t);
+                    PSVECScale(&current->value, &currentScaled, 1.0f - t);
+                    PSVECScale(&next->value, &nextScaled, t);
                     PSVECAdd(&currentScaled, &nextScaled, out);
                     break;
                 }


### PR DESCRIPTION
Summary:
Fix the blend weights used by `CMapAnimNode::Interp` when interpolating position, rotation, and scale tracks. The previous code scaled the current key by `t` and the next key by `1.0f - t`; this swaps them to the normal linear interpolation order: current by `1.0f - t`, next by `t`.

Units/functions improved:
- Unit: `main/mapanim`
- Function: `Interp__12CMapAnimNodeFi`

Progress evidence:
- `Interp__12CMapAnimNodeFi`: `16.839357%` -> `97.83132%`
- `main/mapanim` `.text`: `75.28199%` -> `99.17654%`
- No data/linkage regressions introduced in this change.
- Full rebuild passes and verifies: `build/GCCP01/main.dol: OK`

Plausibility rationale:
This is a source-plausible fix rather than compiler coaxing. Linear interpolation of keyed animation values should weight the current key by `1 - t` and the next key by `t`, which matches the surrounding animation code style in the repo and the expected behavior of animation blending. The change only corrects those weights in the three existing interpolation blocks.

Technical details:
- Updated the three `PSVECScale` pairs in `src/mapanim.cpp` so each output vector is built as `current * (1.0f - t) + next * t`.
- Verified the result with `build/tools/objdiff-cli diff -p . -u main/mapanim -o - Interp__12CMapAnimNodeFi`.
