### PR TITLE
Improve RedDmaEntry queue flow matching

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -950,39 +950,28 @@ void _DmaCallback(unsigned long)
 int RedDmaEntry(int param_1, int param_2, int param_3, int param_4, int param_5, void (*param_6)(void*), void* param_7)
 {
     unsigned int interrupt;
-    void* baseAddr;
-    void** queuePtr;
+    int* queueBase;
+    int** queuePtr;
     unsigned int entryID;
     unsigned int size;
     unsigned int chunkSize;
     int* queueEntry;
+    int* queueEnd;
     int* nextEntry;
 
     interrupt = OSDisableInterrupts();
-    if ((param_1 & 0xffff7fff) == 0) {
-        baseAddr = RedDriverStreamDmaQueue();
-        queuePtr = &DAT_8032f3e0[1];
+    if ((param_1 & 0xffff7fff) != 0) {
+        queuePtr = (int**)&DAT_8032f3e0[0];
+        queueBase = RedDriverMainDmaQueue();
     } else {
-        queuePtr = &DAT_8032f3e0[0];
-        baseAddr = RedDriverMainDmaQueue();
+        queueBase = RedDriverStreamDmaQueue();
+        queuePtr = (int**)&DAT_8032f3e0[1];
     }
-    queueEntry = (int*)*queuePtr;
+    queueEntry = *queuePtr;
     entryID = GetMyEntryID();
     size = (unsigned int)(param_5 + 0x1f) & 0xffffffe0;
-    if ((DAT_8032f43c == 0) && ((param_1 & 0x8000) == 0)) {
-        queueEntry[0] = entryID;
-        queueEntry[1] = param_2;
-        queueEntry[2] = param_3;
-        queueEntry[3] = param_4;
-        queueEntry[4] = size;
-        queueEntry[5] = (int)param_6;
-        queueEntry[6] = (int)param_7;
-        nextEntry = queueEntry + 7;
-        if ((int*)baseAddr + 0x380 <= nextEntry) {
-            nextEntry = (int*)baseAddr;
-        }
-        *queuePtr = nextEntry;
-    } else {
+    if ((DAT_8032f43c != 0) || ((param_1 & 0x8000) != 0)) {
+        queueEnd = queueBase + 0x380;
         do {
             chunkSize = size;
             if ((int)size > 0x40000) {
@@ -1003,11 +992,25 @@ int RedDmaEntry(int param_1, int param_2, int param_3, int param_4, int param_5,
                 queueEntry[5] = 0;
             }
             queueEntry += 7;
-            if ((int*)baseAddr + 0x380 <= queueEntry) {
-                queueEntry = (int*)baseAddr;
+            if (queueEnd <= queueEntry) {
+                queueEntry = queueBase;
             }
         } while ((int)size > 0);
         *queuePtr = queueEntry;
+    } else {
+        nextEntry = queueEntry + 7;
+        queueEnd = queueBase + 0x380;
+        queueEntry[0] = entryID;
+        queueEntry[1] = param_2;
+        queueEntry[2] = param_3;
+        queueEntry[3] = param_4;
+        queueEntry[4] = size;
+        queueEntry[5] = (int)param_6;
+        queueEntry[6] = (int)param_7;
+        if (queueEnd <= nextEntry) {
+            nextEntry = queueBase;
+        }
+        *queuePtr = nextEntry;
     }
     OSSignalSemaphore(&DAT_8032ddd8);
     OSRestoreInterrupts(interrupt);


### PR DESCRIPTION
Summary:
- retime `RedDmaEntry` around typed DMA queue pointers and a shared queue-end pointer
- invert the branch structure so the single-entry and chunked paths follow the target control flow more directly
- keep the queue write logic unchanged while making the source shape closer to plausible original code

Units/functions improved:
- `main/RedSound/RedDriver`
- `RedDmaEntry__FiiiiiPFPv_vPv` (356 bytes)

Progress evidence:
- `RedDmaEntry__FiiiiiPFPv_vPv`: 49.47191% -> 77.786514% fuzzy match (`build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - RedDmaEntry__FiiiiiPFPv_vPv`)
- `main/RedSound/RedDriver` selector baseline was 78.9% code; current `build/GCCP01/report.json` reports 79.787476% `.text` fuzzy match
- no data or linkage regressions observed in `ninja` output

Plausibility rationale:
- the change replaces generic `void*` queue state with concrete `int*` DMA queue pointers, which matches how the function indexes queue entries
- the rewritten branching mirrors the two natural behaviors in the routine: a direct single queue write vs. chunked 0x40000-byte splits
- this keeps the code readable and source-plausible rather than introducing compiler-only temporaries or offset hacks

Technical details:
- precomputes `queueEnd` once per path and reuses it for wraparound checks
- moves the chunked transfer path into the positive branch that the target assembly already prefers
- keeps callback and buffer fields in the same queue slots while improving instruction ordering around queue pointer updates