### PR TITLE
Improve pppRain loop codegen

### DIFF
--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -134,10 +134,6 @@ void pppFrameRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_DA
     RainWork* work;
     RainDrop* drop;
     RainParam* rain;
-    float unitA;
-    float unitB;
-    float lengthDelta;
-    s16 lifeJitter;
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -157,6 +153,10 @@ void pppFrameRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_DA
             float maxX;
             float minZ;
             float maxZ;
+            float unitA;
+            float unitB;
+            float lengthDelta;
+            s16 lifeJitter;
 
             randA = rand();
             randB = rand();
@@ -210,6 +210,10 @@ void pppFrameRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_DA
             float maxX;
             float minZ;
             float maxZ;
+            float unitA;
+            float unitB;
+            float lengthDelta;
+            s16 lifeJitter;
 
             randA = rand();
             randB = rand();
@@ -322,28 +326,28 @@ void pppRenderRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_D
     GXBegin((GXPrimitive)0xA8, GX_VTXFMT7, (u16)((param_2->m_dataValIndex & 0x7fff) << 1));
     tex0 = kPppRainTexCoordBase;
     tex1 = FLOAT_8033101c;
-    {
-        RainDrop* currentDrop = drop;
-        for (i = 0; i < (int)(u32)param_2->m_dataValIndex; i++, currentDrop++) {
-            float x = baseX + currentDrop->posX;
-            float y = baseY + currentDrop->posY;
-            float z = baseZ + currentDrop->posZ;
+    i = 0;
+    while (i < (int)(u32)param_2->m_dataValIndex) {
+        float x = baseX + drop->posX;
+        float y = baseY + drop->posY;
+        float z = baseZ + drop->posZ;
 
-            PSVECScale((Vec*)&currentDrop->dirX, &segment, currentDrop->length);
-            GXWGFifo.f32 = x;
-            GXWGFifo.f32 = y;
-            GXWGFifo.f32 = z;
-            GXWGFifo.u32 = *(u32*)(colorBase + 8);
-            GXWGFifo.f32 = tex0;
-            GXWGFifo.f32 = tex0;
+        PSVECScale((Vec*)&drop->dirX, &segment, drop->length);
+        GXWGFifo.f32 = x;
+        drop++;
+        i++;
+        GXWGFifo.f32 = y;
+        GXWGFifo.f32 = z;
+        GXWGFifo.u32 = *(u32*)(colorBase + 8);
+        GXWGFifo.f32 = tex0;
+        GXWGFifo.f32 = tex0;
 
-            GXWGFifo.f32 = x + segment.x;
-            GXWGFifo.f32 = y + segment.y;
-            GXWGFifo.f32 = z + segment.z;
-            GXWGFifo.u32 = *(u32*)(colorBase + 8);
-            GXWGFifo.f32 = tex1;
-            GXWGFifo.f32 = tex1;
-        }
+        GXWGFifo.f32 = x + segment.x;
+        GXWGFifo.f32 = y + segment.y;
+        GXWGFifo.f32 = z + segment.z;
+        GXWGFifo.u32 = *(u32*)(colorBase + 8);
+        GXWGFifo.f32 = tex1;
+        GXWGFifo.f32 = tex1;
     }
     GXSetLineWidth(8, GX_TO_ZERO);
 }


### PR DESCRIPTION
Summary:
- narrow the temporary scopes in `pppFrameRain`
- reshape the `pppRenderRain` emission loop to advance a single drop pointer in lockstep with FIFO writes
- keep behavior unchanged while moving the compiler toward the original instruction order

Units/functions improved:
- Unit `main/pppRain`
- `pppFrameRain`: 89.23881% -> 89.27612% match, 110 -> 109 instruction diffs
- Unit `.text` match for `main/pppRain`: 93.27002% -> 93.29291%
- `pppRenderRain` held at 99.58394%

Progress evidence:
- `ninja` passes
- objdiff shows a real `pppFrameRain` improvement with no regression in `pppRenderRain`
- overall project progress output is unchanged at the top level, which is expected for a small per-symbol improvement

Plausibility rationale:
- the render loop now uses a single advancing particle pointer instead of an extra iterator variable, which is a normal handwritten pattern for streaming vertex emission
- the frame function keeps the same logic but limits randomization temporaries to the blocks where they are used, which is also a natural source cleanup
- no extern hacks, section tricks, or address-based coercion were introduced

Technical details:
- the useful change was in loop shape rather than gameplay logic
- `pppFrameRain` gained one fewer objdiff instruction mismatch after the source reshaping
- all edits stay within `src/pppRain.cpp` and preserve the existing data model