### PR TITLE
Improve pppScreenBreak matrix callback match

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -162,17 +162,15 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
     Quaternion resultQuat;
     Quaternion axisQuat;
     Quaternion meshQuat;
-    float axisX;
-    float axisY;
-    float axisZ;
+    Vec axis;
     Vec gravityAdd;
     Vec basis = { DAT_801dd4b0, DAT_801dd4b4, DAT_801dd4b8 };
-    Vec cameraPos;
-    Vec cameraOffset;
-    Vec cameraForward;
     Vec screenOffset;
     Vec4d clipOutput;
     Vec4d clipInput;
+    Vec cameraPos;
+    Vec cameraOffset;
+    Vec cameraForward;
     Mtx invTransMtx;
     Mtx transMtx;
     Mtx quatMtx;
@@ -235,10 +233,10 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
             transMtx[2][3] = pieceData[11];
             PSMTXInverse(transMtx, invTransMtx);
 
-            axisX = pieceData[6];
-            axisY = pieceData[7];
-            axisZ = pieceData[8];
-            C_QUATRotAxisRad(&axisQuat, (Vec*)&axisX, pieceData[0xD]);
+            axis.x = pieceData[6];
+            axis.y = pieceData[7];
+            axis.z = pieceData[8];
+            C_QUATRotAxisRad(&axisQuat, &axis, pieceData[0xD]);
             PSMTXQuat(quatMtx, &axisQuat);
             C_QUATMtx(&meshQuat, meshMtx);
             PSQUATMultiply(&axisQuat, &meshQuat, &resultQuat);


### PR DESCRIPTION
## Summary
- refactor `SB_BeforeCalcMatrixCallback` to use a real contiguous `Vec axis` for quaternion rotation instead of three standalone float temporaries
- reorder the callback locals to better match the original stack/register layout while keeping the source plausible and readable
- keep the change scoped to `src/pppScreenBreak.cpp`; no linkage hacks, section directives, or `extern` tricks were introduced

## Units/functions improved
- `main/pppScreenBreak`
- `SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`

## Progress evidence
- `SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`: `92.95111%` -> `94.657776%`
- `main/pppScreenBreak` `.text`: `89.9438%` -> `90.286354%`
- `ninja -j1` builds cleanly after the change
- no data/linkage regressions were introduced by this patch

## Plausibility rationale
- the original code is already treating the rotation axis as a 3-component vector; expressing it as `Vec axis` is more plausible source than storing the components in unrelated scalar locals and casting their address
- local reordering here is in service of recovering the original function layout, not introducing contrived compiler-coaxing statements or hard-coded offsets
- node/matrix/member access remains expressed through the existing typed structures and callbacks

## Technical details
- the biggest movement came from changing the quaternion setup path so `C_QUATRotAxisRad` receives a real vector local with contiguous storage
- I also grouped the callback temporaries to better align with the original stack frame seen in the target object, which improved emitted code without changing behavior