### PR TITLE
RedStream: improve _SearchEmptyStreamData control flow

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -30,15 +30,19 @@ int SearchSeEmptyTrack__Fiii(int, int, int);
  */
 unsigned int _SearchEmptyStreamData()
 {
-	register volatile unsigned int streamData;
+	register RedStreamDATA* streamData;
 
-	streamData = (unsigned int)DAT_8032f438;
+	streamData = (RedStreamDATA*)DAT_8032f438;
 	do {
-		if (*(int*)(streamData + 0x10c) == 0) {
-			return streamData;
+		if (*(int*)((int)streamData + 0x10c) == 0) {
+			break;
 		}
-		streamData += 0x130;
-	} while (streamData < (unsigned int)DAT_8032f438 + 0x4c0);
+		streamData = (RedStreamDATA*)((int)streamData + 0x130);
+	} while ((unsigned int)streamData < (unsigned int)DAT_8032f438 + 0x4c0);
+
+	if ((unsigned int)streamData < (unsigned int)DAT_8032f438 + 0x4c0) {
+		return (unsigned int)streamData;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
- rewrite `_SearchEmptyStreamData` to iterate with a typed `RedStreamDATA*` instead of a volatile integer slot
- use a loop break plus post-loop return check to keep the search result in the same control-flow path
- leave the rest of `RedStream.cpp` unchanged

## Units/functions improved
- Unit: `main/RedSound/RedStream`
- Function: `_SearchEmptyStreamData__Fv`

## Progress evidence
- `_SearchEmptyStreamData__Fv`: `42.0%` -> `46.117645%` match in objdiff oneshot mode
- Build: `ninja` passes and `build/GCCP01/report.json` regenerates successfully
- No code/data/linkage regressions were introduced elsewhere in this unit in the final branch state

## Plausibility rationale
- The new code models the stream slot scan as pointer iteration over `RedStreamDATA` entries rather than treating the pool head as a volatile integer address
- Breaking from the scan and returning after the bounds check is still straightforward source a game programmer could plausibly have written for a fixed-size slot search
- The change improves compiler shape without introducing hacks like hardcoded symbol names, manual sections, or artificial externs

## Technical details
- Verified with `build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream -o - _SearchEmptyStreamData__Fv`
- The improvement comes from changing how the loop-carried search state is represented, which alters register allocation and branch structure in a favorable direction
- Final rebuild command: `ninja`
