### PR TITLE
Improve CGQuadObj::onDraw match

### DIFF
--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -43,12 +43,12 @@ void CGQuadObj::onDraw()
         GXLoadPosMtxImm(*reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(&CameraPcs) + 0x4), GX_PNMTX0);
         GXBegin(GX_LINES, GX_VTXFMT0, ((u32)m_vertexCount << 1) + ((u32)m_vertexCount << 2));
 
-        CGQuadObj* self = this;
         int i = 0;
+        CGQuadObj* self = this;
 
         while (i < (int)(u32)m_vertexCount) {
-            int next = i + 1;
             QuadVertex* vertex = self->m_vertices;
+            int next = i + 1;
 
             i++;
 
@@ -59,7 +59,6 @@ void CGQuadObj::onDraw()
             next = next - (next / (int)(u32)m_vertexCount) * (u32)m_vertexCount;
             GXPosition3f32(m_vertices[next].x, m_yBase + m_yHeight, m_vertices[next].z);
             GXPosition3f32(vertex->x, m_yBase, vertex->z);
-
             self = reinterpret_cast<CGQuadObj*>(reinterpret_cast<unsigned char*>(self) + sizeof(QuadVertex));
             GXPosition3f32(vertex->x, m_yBase + m_yHeight, vertex->z);
         }


### PR DESCRIPTION
Summary:
Reordered the local declarations in `CGQuadObj::onDraw` so the loop state is initialized in the order that produces a closer register allocation for the existing debug line-draw logic. This keeps the same control flow and member access while tightening the generated code shape.

Units/functions improved:
- `main/quadobj`
- `onDraw__9CGQuadObjFv`

Progress evidence:
- `onDraw__9CGQuadObjFv`: 95.66038% -> 97.35849% match
- `main/quadobj` `.text`: now 98.82845%
- `ninja` build passes after the change

Plausibility rationale:
This change only adjusts local declaration order in a small draw loop. It does not introduce hacks, raw-address tricks, or control-flow distortions; it is a natural source-level variation that matches the existing implementation style and improves register assignment.

Technical details:
Objdiff showed `CGQuadObj::onDraw` was already logic-equivalent and primarily missing on register allocation in the loop setup. Declaring the loop index before the walker pointer moves the generated code closer to the expected register layout without affecting behavior.