### PR TITLE
Match GbaQueue::GetCaravanName

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1709,26 +1709,15 @@ void GbaQueue::GetPlayerStat(int channel, GbaPInfo* outInfo)
  */
 void GbaQueue::GetCaravanName(char* outName)
 {
-	int i;
-	OSSemaphore* semaphoreIter;
-
-	i = 0;
-	semaphoreIter = (OSSemaphore*)this;
-	do {
-		OSWaitSemaphore(semaphoreIter);
-		i++;
-		semaphoreIter++;
-	} while (i < 4);
+	for (int i = 0; i < 4; i++) {
+		OSWaitSemaphore(accessSemaphores + i);
+	}
 
 	memcpy(outName, reinterpret_cast<char*>(this) + 0x2A74, 0x80);
 
-	i = 0;
-	semaphoreIter = (OSSemaphore*)this;
-	do {
-		OSSignalSemaphore(semaphoreIter);
-		i++;
-		semaphoreIter++;
-	} while (i < 4);
+	for (int i = 0; i < 4; i++) {
+		OSSignalSemaphore(accessSemaphores + i);
+	}
 }
 
 /*


### PR DESCRIPTION
## Summary
Rewrote `GbaQueue::GetCaravanName(char*)` to iterate directly over `accessSemaphores + i` for both the wait and signal passes, removing the extra semaphore iterator state.

## Units/functions improved
- Unit: `main/gbaque`
- Function: `GetCaravanName__8GbaQueueFPc`

## Progress evidence
- `GetCaravanName__8GbaQueueFPc`: `98.91892%` -> `100.0%` in `build/GCCP01/report.json`
- Overall game code: `130232 / 1545468` -> `130380 / 1545468` matched bytes (`+148`)
- Overall matched functions: `1599 / 3487` -> `1600 / 3487` (`+1`)
- `ninja` still passes after the change

## Plausibility rationale
This keeps the original behavior but expresses the semaphore walks as straightforward indexed loops over the class's `accessSemaphores` array. That is simpler and more source-plausible than carrying a casted iterator over `this`, while still matching the original binary output.

## Technical details
The previous version used a local `OSSemaphore*` iterator and manual incrementing for both loops. Replacing that with `for (int i = 0; i < 4; i++)` plus `accessSemaphores + i` produced the exact code shape for the function according to the generated report, without relying on linkage hacks or offset-based coercion.