### PR TITLE
sound: fix FadeOutSe3D debug format string

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -2040,7 +2040,7 @@ found_entry:
 _pppMngSt* CSound::FadeOutSe3D(int se3dHandle, int fadeFrames)
 {
     if (se3dHandle < 0) {
-        Printf__7CSystemFPce(&System, s_soundErrorFmt);
+        Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
         return 0;
     }
 
@@ -2065,7 +2065,7 @@ found_entry:
     if (found != 0) {
         const int playId = *reinterpret_cast<int*>(found + 8);
         if (playId < 0) {
-            Printf__7CSystemFPce(&System, s_soundErrorFmt, fadeFrames, ret);
+            Printf__7CSystemFPce(&System, s_soundMinusOneFmt, fadeFrames, ret);
         } else {
             SeFadeOut__9CRedSoundFii(reinterpret_cast<CRedSound*>(this), playId, fadeFrames);
         }


### PR DESCRIPTION
Summary:
- Update `CSound::FadeOutSe3D` to use `s_soundMinusOneFmt` for its invalid-handle and invalid-play-id diagnostics.
- Keep the surrounding control flow and slot search logic unchanged.

Units/functions improved:
- `main/sound`: `FadeOutSe3D__6CSoundFii`

Progress evidence:
- `FadeOutSe3D__6CSoundFii` improved from 58.47% to 63.40% match in objdiff (`tools/objdiff-cli diff -p . -u main/sound -o - FadeOutSe3D__6CSoundFii`).
- Function size stayed at 288 bytes.
- `ninja` still completes successfully after the change.

Plausibility rationale:
- The function already carries a dedicated `s_soundMinusOneFmt` string, and objdiff showed both diagnostic callsites relocating against that symbol rather than the generic `s_soundErrorFmt`.
- This is a semantic fix to a debug print selection, not a compiler-coaxing rewrite.

Technical details:
- The only source change is swapping the two `Printf__7CSystemFPce` callsites in `CSound::FadeOutSe3D`.
- Objdiff for the function now resolves both format-string relocations to `s_soundMinusOneFmt`, which removes a real mismatch without introducing broader regressions.