### PR TITLE
Fix GbaQueue GetUseItemFlg layout

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -3515,11 +3515,13 @@ int GbaQueue::GetArtifactData(int, unsigned char*)
  */
 int GbaQueue::GetUseItemFlg(int channel)
 {
-	char* obj = reinterpret_cast<char*>(this);
+	char* compatibilityStr = reinterpret_cast<char*>(this) + 0x458;
+	int result;
 	OSWaitSemaphore(accessSemaphores + channel);
-	char value = obj[channel * 0xDC + 0x44F];
+	char value = compatibilityStr[channel * 0xDC + 0x1F];
+	result = static_cast<int>(value);
 	OSSignalSemaphore(accessSemaphores + channel);
-	return static_cast<int>(value);
+	return result;
 }
 
 /*


### PR DESCRIPTION
Summary:
- Correct GbaQueue::GetUseItemFlg to read from the compatibility data block at `0x458 + channel * 0xDC + 0x1F` instead of the stale hardcoded `0x44F` offset.
- Keep the semaphore access pattern intact while storing the signed result before releasing the semaphore, matching the original codegen.

Units/functions improved:
- Unit: `main/gbaque`
- Function: `GetUseItemFlg__8GbaQueueFi`

Progress evidence:
- `GetUseItemFlg__8GbaQueueFi`: 80.53846% -> 100.0% match (104 bytes)
- Overall game code matched bytes: 130232 -> 130336 (+104)
- Overall matched game functions: 1599 -> 1600 (+1)
- No data/linkage regressions observed in the build report for this change.

Plausibility rationale:
- Neighboring getters already treat this region as the per-channel compatibility/status block starting at `0x458`, and Ghidra places this field at offset `0x1F` inside that block.
- This change removes an incoherent raw offset and replaces it with a layout-consistent access pattern that matches surrounding source conventions.

Technical details:
- Verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/gbaque -o - GetUseItemFlg__8GbaQueueFi`.
- The remaining codegen mismatch disappeared after materializing the signed return value before `OSSignalSemaphore`, which preserved the intended semantics while matching the original instruction ordering.