### PR TITLE
Link pppYmMelt to shared sdata2 constants

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -8,12 +8,12 @@
 #include "ffcc/symbols_shared.h"
 #include "dolphin/mtx.h"
 
-const float FLOAT_80330af4 = 1.0f;
-const float FLOAT_80330b08 = 0.5f;
-const float FLOAT_80330b0c = 0.017453292f;
-const float FLOAT_80330b10 = -2000.0f;
-const float FLOAT_80330b14 = 10000000000.0f;
-const float FLOAT_80330b18 = -10000000000.0f;
+extern const float FLOAT_80330af4;
+extern const float FLOAT_80330b08;
+extern const float FLOAT_80330b0c;
+extern const float FLOAT_80330b10;
+extern const float FLOAT_80330b14;
+extern const float FLOAT_80330b18;
 
 extern "C" {
 int rand(void);


### PR DESCRIPTION
Summary:
- Replace the local `FLOAT_80330af4` through `FLOAT_80330b18` definitions in `src/pppYmMelt.cpp` with `extern` declarations so the unit links against the shared `sdata2` symbols already declared in `config/GCCP01/symbols.txt`.
- Keep the existing control flow and data access intact; this is a linkage cleanup, not compiler coaxing.

Units/functions improved:
- Unit: `main/pppYmMelt`
- Function: `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf`

Progress evidence:
- `ninja` still passes, including report generation.
- `objdiff` for `CalcPolygonHeight__FP7PYmMeltP11VERTEX_DATAP8_GXColorf` improved in `.text` from `72.543365%` to `72.60077%` (+0.057405).
- `extab` stayed at `62.5%` and `extabindex` stayed unchanged, so this is a code/linkage win rather than an extab tradeoff.
- The target object imports these float symbols; after this change the source object also imports `FLOAT_80330af4`, `FLOAT_80330b08`, `FLOAT_80330b0c`, `FLOAT_80330b10`, `FLOAT_80330b14`, and `FLOAT_80330b18` instead of defining duplicate locals.

Plausibility rationale:
- These values already exist as named shared symbols in `config/GCCP01/symbols.txt`, so importing them is more plausible original source than re-defining per-file copies.
- The change improves linkage fidelity without introducing hardcoded offsets, contrived temporaries, or source-unfriendly reshaping.

Technical details:
- I first tested a raw `CMapCylinder` layout rewrite in `CalcPolygonHeight`, but objdiff showed it regressed the unit, so that was discarded.
- The retained change is the isolated net-positive fix: align `pppYmMelt.cpp` with the shared constant linkage used by the target object.