### PR TITLE
materialman: fix CMaterialSet embedded array lifetime

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -3152,7 +3152,6 @@ CMaterialSet::~CMaterialSet()
         }
     }
 
-    materials->RemoveAll();
     materials->~CPtrArray<CMaterial*>();
     __dt__4CRefFv(this, 0);
 }
@@ -3168,16 +3167,17 @@ CMaterialSet::~CMaterialSet()
  */
 CMaterialSet::CMaterialSet()
 {
+    CPtrArray<CMaterial*>* const materials = reinterpret_cast<CPtrArray<CMaterial*>*>(Ptr(this, 8));
+
     __ct__4CRefFv(this);
     *reinterpret_cast<void**>(this) = __vt__12CMaterialSet;
-
-    *reinterpret_cast<unsigned long*>(Ptr(this, 0x0C)) = 0;
-    *reinterpret_cast<unsigned long*>(Ptr(this, 0x10)) = 0;
-    *reinterpret_cast<unsigned long*>(Ptr(this, 0x14)) = 0x10;
-    *reinterpret_cast<void**>(Ptr(this, 0x18)) = 0;
-    *reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x1C)) =
-        MaterialMan.GetMemoryStage();
-    *reinterpret_cast<int*>(Ptr(this, 0x20)) = 1;
+    materials->m_vtable = PTR_PTR_s_CPtrArray_P9CMaterial_801e9bfc;
+    materials->m_size = 0;
+    materials->m_numItems = 0;
+    materials->m_defaultSize = 0x10;
+    materials->m_items = 0;
+    materials->m_stage = MaterialMan.GetMemoryStage();
+    materials->m_growCapacity = 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
Fix `CMaterialSet`'s embedded `CPtrArray<CMaterial*>` lifetime handling in `src/materialman.cpp`.

- remove the redundant `RemoveAll()` call before `CPtrArray<CMaterial*>::~CPtrArray()` in `CMaterialSet::~CMaterialSet()`
- initialize the embedded pointer-array state explicitly in `CMaterialSet::CMaterialSet()`, including its vtable and memory stage

## Units/functions improved
Unit: `main/materialman`

Primary symbol movement:
- `__dt__12CMaterialSetFv`: `45.592594%` -> `62.25926%`
- `__ct__12CMaterialSetFv`: `40.545456%` -> `24.136364%`

Unit-level code movement:
- `.text`: `46.3039%` -> `46.37218%`

## Progress evidence
`ninja` passes after the change.

`objdiff` shows a net text improvement for `main/materialman`, with the destructor gain outweighing the constructor regression:
- accepted regression: `CMaterialSet::CMaterialSet()` regressed while switching the recovered source toward a coherent embedded-array initialization
- net gain: `CMaterialSet::~CMaterialSet()` improved substantially and the unit's `.text` match increased overall

No extab-focused changes were made.

## Plausibility rationale
This change makes the recovered source more plausible as original game code:
- `CMaterialSet` owns an embedded `CPtrArray<CMaterial*>`, so destroying it twice is not credible source
- the constructor now initializes that embedded array as a real object, including its vtable and stage, instead of partially poking fields while leaving array object state incomplete
- the change improves object lifetime semantics without introducing hardcoded hacks, fake extern linkage, or section tricks

## Technical details
The recovered constructor/destructor pair was treating the embedded `CPtrArray` inconsistently:
- constructor: initialized several array fields manually but skipped the embedded array vtable entirely
- destructor: called `RemoveAll()` and then immediately called the array destructor, which already performs `RemoveAll()`

Aligning those two functions around a single embedded-array lifetime model produced the measured net code improvement.
