### PR TITLE
Improve p_tina part color slot layout

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -996,22 +996,30 @@ void CPartPcs::GetParLocIdx(int index, Vec& location)
  */
 void CPartPcs::SetParColIdx(int index, pppFVECTOR4& color)
 {
-	_pppMngSt* pppMngSt = reinterpret_cast<_pppMngSt*>(&PartMng) + index;
+	struct PartMngColorView {
+		u8 pad[0x2A50];
+		float r;
+		float g;
+		float b;
+		float a;
+	};
+	PartMngColorView* pppMngSt =
+	    reinterpret_cast<PartMngColorView*>(reinterpret_cast<u8*>(&PartMng) + (index * 0x158));
 	float* colorValues = reinterpret_cast<float*>(&color);
 	float one = kPartColorIdentityOne;
 
-	GetMngStUserFloat0(pppMngSt) = colorValues[0];
-	GetMngStUserFloat1(pppMngSt) = colorValues[1];
-	GetMngStScaleFactor(pppMngSt) = colorValues[2];
-	GetMngStOwnerScale(pppMngSt) = colorValues[3];
+	pppMngSt->r = colorValues[0];
+	pppMngSt->g = colorValues[1];
+	pppMngSt->b = colorValues[2];
+	pppMngSt->a = colorValues[3];
 
 	if (one == colorValues[0] && one == colorValues[1] && one == colorValues[2] && one == colorValues[3]) {
-		GetMngStOwnerScaleMode(pppMngSt) = 0;
+		*(reinterpret_cast<u8*>(pppMngSt) + 0xB7) = 0;
 		return;
 	}
 
-	GetMngStOwnerScaleMode(pppMngSt) = 1;
-	GetMngStLockScaleFromOwner(pppMngSt) = 1;
+	*(reinterpret_cast<u8*>(pppMngSt) + 0xB7) = 1;
+	*(reinterpret_cast<u8*>(pppMngSt) + 0xB9) = 1;
 }
 
 /*
@@ -1188,9 +1196,10 @@ void CPartPcs::LoadFieldPdt(int mapId, int floorId, void* amemBase, unsigned lon
     state->m_partLoadCacheParam = loadCacheParam;
     state->m_partChunkIndex = 0;
     state->m_asyncHandleCount = 0;
-    state->m_partLoadMode = 0;
-
-    if (loadCacheParam != 0) {
+    
+    if (loadCacheParam == 0) {
+        state->m_partLoadMode = 0;
+    } else {
         if (mode == 1) {
             state->m_partLoadMode = 2;
         } else if (mode == 2) {


### PR DESCRIPTION
## Summary
- rewrite `CPartPcs::SetParColIdx` to write through a raw per-slot view of `PartMng` instead of treating `PartMng` itself as a contiguous `_pppMngSt` array
- keep the `LoadFieldPdt` default-mode branch in a source-plausible form that preserves the better `p_tina.o` codegen for this TU

## Units/functions improved
- Unit: `main/p_tina`
- Function: `SetParColIdx__8CPartPcsFiR11pppFVECTOR4`

## Progress evidence
- `SetParColIdx__8CPartPcsFiR11pppFVECTOR4`: `87.91428%` -> `89.14286%` match by `build/tools/objdiff-cli diff -p . -u main/p_tina -o - SetParColIdx__8CPartPcsFiR11pppFVECTOR4`
- `build/GCCP01/report.json` now shows `SetParColIdx__8CPartPcsFiR11pppFVECTOR4` at `89.057144%` fuzzy match
- `ninja` still passes and overall project progress is unchanged outside this small local improvement
- `LoadFieldPdt__8CPartPcsFiiPvUlUc` stays flat at `87.68519%`; the control-flow normalization there was retained only because it keeps the improved `SetParColIdx` object code stable in this translation unit

## Plausibility rationale
- the previous code indexed `PartMng` as though `_pppMngSt` entries began at the `PartMng` object base, then used helper accessors that mapped to the wrong in-object offsets for this API
- the new code follows the existing raw-view approach already used nearby in `GetParColIdx`, which is much more plausible for this partially recovered manager layout
- the change writes real slot color/state fields instead of leaning on misleading `_pppMngSt*` arithmetic

## Technical details
- objdiff showed the original function using a `0x158` slot stride plus large fixed offsets for the color block; the old implementation was compiling to a `0x160` stride with small field offsets
- switching `SetParColIdx` to a dedicated raw view corrected the color stores and reduced the remaining mismatch to the final flag-store path/register allocation around the non-identity case
- verification run:
  - `ninja`
  - `build/tools/objdiff-cli diff -p . -u main/p_tina -o - SetParColIdx__8CPartPcsFiR11pppFVECTOR4`
