### PR TITLE
Improve p_FunnyShape static init match

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -44,7 +44,7 @@ extern "C" void CreateBuffer__14CUSBStreamDataFv(CUSBStreamData*);
 extern "C" void DeleteBuffer__14CUSBStreamDataFv(CUSBStreamData*);
 extern "C" CFunnyShape* __dt__11CFunnyShapeFv(CFunnyShape*, short);
 extern "C" void __dt__14CFunnyShapePcsFv(void*);
-extern "C" void* __vt__8CManager;
+extern "C" void* __vt__8CManager[];
 extern "C" void* gVtable_CPtrArray_OSFSTexture[];
 extern "C" void* gVtable_CPtrArray_GXTexObj[];
 extern "C" void* __vt__14CFunnyShapePcs[];
@@ -107,16 +107,17 @@ static inline CFunnyShape* FunnyShape(CFunnyShapePcs* self)
 extern "C" void __sinit_p_FunnyShape_cpp(void)
 {
     u8* self = reinterpret_cast<u8*>(&FunnyShapePcs);
+    volatile void** base = reinterpret_cast<volatile void**>(self);
 
-    *reinterpret_cast<void**>(self) = &__vt__8CManager;
-    *reinterpret_cast<void**>(self) = &__vt__8CProcess;
-    *reinterpret_cast<void**>(self) = __vt__14CFunnyShapePcs;
+    *base = __vt__8CManager;
+    *base = &__vt__8CProcess;
+    *base = __vt__14CFunnyShapePcs;
 
     __ct__14CUSBStreamDataFv(self + 0x3C);
     __ct__11CFunnyShapeFv(self + 0x50);
     __ct__29CPtrArray_P15OSFS_TEXTURE_ST_Fv(self + 0x61BC);
     __ct__22CPtrArray_P9_GXTexObj_Fv(self + 0x61D8);
-    __register_global_object(&FunnyShapePcs, reinterpret_cast<void*>(__dt__14CFunnyShapePcsFv), ARRAY_8026D728);
+    __register_global_object(&FunnyShapePcs, __dt__14CFunnyShapePcsFv, ARRAY_8026D728);
 
     CopyFunnyShapePcsTable();
 }


### PR DESCRIPTION
Summary:
- normalize the `p_FunnyShape` static initializer to use the project's existing compiler-style vtable setup pattern
- switch `__vt__8CManager` to an array declaration and write through a volatile base pointer in `__sinit_p_FunnyShape_cpp`
- keep object construction/linkage behavior unchanged while removing mismatched initialization codegen

Units/functions improved:
- `main/p_FunnyShape`
- `__sinit_p_FunnyShape_cpp`

Progress evidence:
- unit `.text` match: `95.22166%` -> `95.36548%`
- `__sinit_p_FunnyShape_cpp`: `86.458336%` -> `87.638885%`
- build still passes with `ninja`
- no accepted regressions in code/data/linkage for this unit

Plausibility rationale:
- the change makes `p_FunnyShape` follow the same explicit static-init style already used in nearby units such as `p_menu` and `p_map`
- this is a declaration/linkage cleanup around vtable writes and global-object registration, not a hardcoded offset hack or temporary extern trick
- runtime behavior is unchanged: the same object, constructors, and registration path are preserved

Technical details:
- objdiff showed the remaining mismatch concentrated at the front of `__sinit_p_FunnyShape_cpp`, around vtable materialization and registration setup
- changing the manager vtable declaration to an array and writing through a `volatile void**` base produced closer compiler codegen for the initializer without touching unrelated logic
- verification was done with `ninja` and `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o -`