### PR TITLE
Improve pppLight default target selection matching

### DIFF
--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -248,13 +248,11 @@ void pppLight(void* param1, void* param2, void* param3)
 				Add__9CLightPcsFPQ29CLightPcs6CLight(&LightPcs, &light);
 			} else {
 				u32 targetIndex;
-				unsigned char* obj;
+				unsigned char* obj = gPppDefaultValueBuffer;
 
 				light.m_type = 1;
 				targetIndex = step->targetIndex;
-				if (targetIndex == 0xFFFFFFFF) {
-					obj = gPppDefaultValueBuffer;
-				} else {
+				if (targetIndex != 0xFFFFFFFF) {
 					pppLightTarget* targetTable =
 						(pppLightTarget*)((PppLightMngProgramInfo*)pppMngStPtr)->programInfoTable;
 					obj = targetTable[targetIndex].obj;


### PR DESCRIPTION
## Summary
Refactor the non-zero `pppLight` target-selection path to default `obj` to `gPppDefaultValueBuffer` and only override it when `targetIndex != 0xFFFFFFFF`.

## Units/functions improved
- Unit: `main/pppLight`
- Function: `pppLight`

## Progress evidence
- Selector baseline before the change: `main/pppLight` was `code 99.7%, data 40.00%`.
- After the change and rebuild, `build/GCCP01/report.json` reports `main/pppLight` with `matched_data: 20 / 20 (100.0%)` while keeping the unit stable otherwise.
- Overall game data progress increased from `67024 / 139392` to `67036 / 139392` in the `ninja` progress report.
- `ninja` passes cleanly.

## Plausibility rationale
This is a source-plausible cleanup rather than compiler coaxing: the code now expresses the obvious default-target behavior directly, with `gPppDefaultValueBuffer` as the default object and a single override for real target-table entries.

## Technical details
The previous `if/else` shape around `targetIndex == 0xFFFFFFFF` was functionally equivalent, but the default-initialized `obj` form produces a better data layout/match outcome for `pppLight` without introducing hacks, dummy temporaries, or address-based naming.
