### PR TITLE
Improve pppFrameLocationTitle control flow match

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -186,12 +186,12 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
             particles[work->m_count].m_pos.y = resultMatrix.value[1][3];
             particles[work->m_count].m_pos.z = resultMatrix.value[2][3];
 
-            if (work->m_count < 1) {
-                particles[work->m_count].m_frame = work->m_cur;
-                memcpy(&particles[work->m_count].m_color, &colorData->m_color, 4);
-            } else {
+            if (work->m_count >= 1) {
                 particles[work->m_count - 1].m_frame = work->m_cur;
                 memcpy(&particles[work->m_count - 1].m_color, &colorData->m_color, 4);
+            } else {
+                particles[work->m_count].m_frame = work->m_cur;
+                memcpy(&particles[work->m_count].m_color, &colorData->m_color, 4);
             }
 
             work->m_count++;


### PR DESCRIPTION
Summary:
- invert the `work->m_count` branch in `pppFrameLocationTitle` so the >=1 path updates the previous particle first
- keep behavior unchanged while aligning the generated control flow with the original

Units/functions improved:
- `main/pppLocationTitle`
- `pppFrameLocationTitle`

Progress evidence:
- objdiff symbol match for `pppFrameLocationTitle`: `87.06515%` -> `87.361565%`
- build passes with `ninja`
- overall progress counters are unchanged; this PR is a symbol-level codegen improvement inside the existing partial match

Plausibility rationale:
- this is a source-plausible cleanup of an unsigned count check, not a compiler-coaxing hack
- the branch structure now better reflects the natural “existing particle vs first particle” split in the routine

Technical details:
- the previous `work->m_count < 1` form generated less favorable control flow around the frame/color update block
- rewriting it as `work->m_count >= 1` with the same two bodies improves the local branch shape without introducing new temporaries, hacks, or linkage shortcuts