### PR TITLE
sound: fix FadeOutSe3D RedSound base pointer

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -2067,7 +2067,7 @@ found_entry:
         if (playId < 0) {
             Printf__7CSystemFPce(&System, s_soundErrorFmt, fadeFrames, ret);
         } else {
-            SeFadeOut__9CRedSoundFii(reinterpret_cast<CRedSound*>(this), playId, fadeFrames);
+            SeFadeOut__9CRedSoundFii(RedSound(this), playId, fadeFrames);
         }
         *found &= 0x7F;
     }


### PR DESCRIPTION
Summary
Use `RedSound(this)` instead of `reinterpret_cast<CRedSound*>(this)` in `CSound::FadeOutSe3D`, so the fade-out call targets the embedded `CRedSound` subobject instead of the `CSound` object base.

Units/functions improved
- `main/sound`
- `FadeOutSe3D__6CSoundFii`: `58.47222%` -> `59.930557%`

Progress evidence
- `build/tools/objdiff-cli diff -p . -u main/sound -o - FadeOutSe3D__6CSoundFii` shows a +`1.458337` point improvement in the target symbol.
- `PlaySe3DLine__6CSoundFiiffi` was rechecked after isolating this change and remained at its baseline `58.247864%`, so this PR avoids the regression from the earlier broader attempt.
- `ninja` still completes successfully after the change.

Plausibility rationale
`CSound` stores a `CRedSound` instance as a subobject. Neighboring functions in this file already use `RedSound(this)` when calling into the RedSound API, so using the same subobject base in `FadeOutSe3D` is the more plausible original source than passing the `CSound` object base directly.

Technical details
The change only updates the receiver passed to `SeFadeOut__9CRedSoundFii`. This is a real codegen fix rather than a rename or formatting-only change, and it improves the objdiff for the targeted sound helper without introducing extra linkage or extern hacks.