### PR TITLE
Improve pppSRandUpFV code match

### DIFF
--- a/src/pppSRandUpFV.cpp
+++ b/src/pppSRandUpFV.cpp
@@ -32,6 +32,7 @@ struct PppSRandUpFVParam3 {
  */
 void pppSRandUpFV(void* param1, void* param2, void* param3)
 {
+    f32* randVec;
     u8* self = (u8*)param2;
     PppSRandUpFVParam2* cfg = (PppSRandUpFVParam2*)param1;
     PppSRandUpFVParam3* info = (PppSRandUpFVParam3*)param3;
@@ -40,7 +41,6 @@ void pppSRandUpFV(void* param1, void* param2, void* param3)
         return;
     }
 
-    f32* randVec;
     s32 currentIndex = *(s32*)(self + 0xC);
     if (currentIndex == 0) {
         randVec = (f32*)(self + *info->fieldC + 0x80);


### PR DESCRIPTION
## Summary
Moves the persistent `randVec` local in `pppSRandUpFV` ahead of the parameter-derived locals.
This is a source-plausible local ordering cleanup that changes register allocation without changing behavior.

## Units/functions improved
- Unit: `main/pppSRandUpFV`
- Function: `pppSRandUpFV`

## Progress evidence
- `objdiff` code match for `pppSRandUpFV`: `98.78505%` -> `99.15888%`
- Data match: unchanged at `100%`
- Linkage: unchanged
- Accepted regressions: none
- `ninja`: passes cleanly

## Plausibility rationale
`randVec` is a long-lived local used across both the randomization path and the final accumulation path. Hoisting its declaration is a plausible original-source layout choice and avoids introducing any hacks, fake linkage, or hardcoded offsets.

## Technical details
The previous local ordering kept the compiler's saved-register assignment slightly off from the original object. Declaring `randVec` earlier moves the generated register allocation closer to the target and yields a real text-match improvement with no behavioral change.
