### PR TITLE
Improve PlaySe3DLine error string matching

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1821,7 +1821,7 @@ int CSound::PlaySe3D(int soundId, Vec* pos, float nearDistance, float farDistanc
 int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float farDistance, int fadeFrames)
 {
     if (soundId < 0) {
-        Printf__7CSystemFPce(&System, s_soundErrorFmt);
+        Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
         CSoundLayout& sound = SoundData(this);
         u8* se = sound.m_seWork;
@@ -1853,7 +1853,7 @@ int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float f
 
                 int sePlayId;
                 if (soundId < 0) {
-                    Printf__7CSystemFPce(&System, s_soundErrorFmt);
+                    Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
                     sePlayId = -1;
                 } else if (soundId < 4000) {
                     int bank = soundId / 1000 + (soundId >> 31);
@@ -1869,7 +1869,8 @@ int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float f
                 } else {
                     const u32 fade = static_cast<u32>(fadeFrames);
                     const int firstVolume = volume & ~((int)((-fade) | fade) >> 0x1F);
-                    sePlayId = SePlay__9CRedSoundFiiiii(reinterpret_cast<CRedSound*>(this), -1, soundId, pan, firstVolume, 0);
+                    sePlayId = SePlay__9CRedSoundFiiiii(reinterpret_cast<CRedSound*>(this), -1, soundId, pan,
+                                                        firstVolume, 0);
                     if (fade != 0) {
                         SeVolume__9CRedSoundFiii(reinterpret_cast<CRedSound*>(this), sePlayId, volume, fade);
                     }


### PR DESCRIPTION
Summary:
- Switch `CSound::PlaySe3DLine` to use the `"Sound: -1\n"` format string on its negative `soundId` error paths.
- Leave the rest of the control flow and data layout untouched so the change stays narrowly focused on codegen that is already evidenced by objdiff.

Units/functions improved:
- Unit: `main/sound`
- Function: `PlaySe3DLine__6CSoundFiiffi`

Progress evidence:
- `PlaySe3DLine__6CSoundFiiffi`: `58.247864%` -> `61.324787%` match (`+3.076923` points).
- `ninja` still completes successfully after the change.
- No data/linkage hacks were introduced; this is a pure source correction inside `src/sound.cpp`.

Plausibility rationale:
- Other nearby 3D sound paths already use `s_soundMinusOneFmt` for invalid `-1`-style handles/IDs, so aligning `PlaySe3DLine` with that convention is consistent with the surrounding original-source patterns.
- The change improves codegen without introducing contrived temporaries, hardcoded offsets beyond the existing function, or extern-based shortcuts.

Technical details:
- The target object uses full-address relocations for `s_soundMinusOneFmt` on both negative `soundId` print sites. Updating those two calls moves the generated prologue/error path closer to the target assembly while keeping the rest of the function stable.
- Verified with `build/tools/objdiff-cli diff -p . -u main/sound -o - PlaySe3DLine__6CSoundFiiffi` and a full `ninja` rebuild.