### PR TITLE
Improve pppSRandFV match

### DIFF
--- a/src/pppSRandFV.cpp
+++ b/src/pppSRandFV.cpp
@@ -38,12 +38,12 @@ void pppSRandFV(void* param1, void* param2, void* param3)
     u8* self = (u8*)param2;
     PppSRandFVParam2* cfg = (PppSRandFVParam2*)param1;
     PppSRandFVParam3* info = (PppSRandFVParam3*)param3;
-    f32* randVec;
 
     if (gPppCalcDisabled != 0) {
         return;
     }
 
+    f32* randVec;
     s32 currentIndex = *(s32*)(self + 0xC);
     if (currentIndex == 0) {
         randVec = (f32*)(self + *info->fieldC + 0x80);
@@ -51,10 +51,10 @@ void pppSRandFV(void* param1, void* param2, void* param3)
             u8 flag = cfg->field18;
             f32 value = Math.RandF();
             if (flag != 0) {
-                value = value + Math.RandF();
+                f32 random = Math.RandF();
+                value = value + random;
             } else {
-                f32 scale = kPppSRandFVSingleSampleScale;
-                value = value * scale;
+                value = value * kPppSRandFVSingleSampleScale;
             }
             randVec[0] = value;
         }
@@ -63,10 +63,10 @@ void pppSRandFV(void* param1, void* param2, void* param3)
             u8 flag = cfg->field18;
             f32 value = Math.RandF();
             if (flag != 0) {
-                value = value + Math.RandF();
+                f32 random = Math.RandF();
+                value = value + random;
             } else {
-                f32 scale = kPppSRandFVSingleSampleScale;
-                value = value * scale;
+                value = value * kPppSRandFVSingleSampleScale;
             }
             randVec[1] = value;
         }
@@ -75,10 +75,10 @@ void pppSRandFV(void* param1, void* param2, void* param3)
             u8 flag = cfg->field18;
             f32 value = Math.RandF();
             if (flag != 0) {
-                value = value + Math.RandF();
+                f32 random = Math.RandF();
+                value = value + random;
             } else {
-                f32 scale = kPppSRandFVSingleSampleScale;
-                value = value * scale;
+                value = value * kPppSRandFVSingleSampleScale;
             }
             randVec[2] = value;
         }


### PR DESCRIPTION
## Summary
Refines `pppSRandFV`'s random-value generation blocks to better match the original source shape.

The change is limited to:
- moving `randVec` below the early `gPppCalcDisabled` return
- introducing explicit `random` temporaries for the dual-sample path
- folding the single-sample path to multiply directly by `kPppSRandFVSingleSampleScale`

## Units/functions improved
- Unit: `main/pppSRandFV`
- Function: `pppSRandFV`

## Progress evidence
Objdiff (`build/tools/objdiff-cli diff -p . -u main/pppSRandFV -o - pppSRandFV`):
- `.text`: `98.90909%` -> `99.181816%`
- `extab`: `100.0%` -> `100.0%`
- `extabindex`: `100.0%` -> `100.0%`

`ninja` still passes after the change.

## Plausibility rationale
This does not add hacks or fake linkage. It rewrites the repeated random-sampling blocks into a shape that matches the already-decompiled `pppSRandUpFV` / `pppSRandDownFV` family more closely:
- the dual-sample path now materializes the second random draw explicitly before combining it
- the single-sample path uses the constant directly instead of a throwaway local
- local lifetime for `randVec` is narrowed to the active calculation region

That is all plausible original source cleanup and keeps the function readable.

## Technical details
The remaining mismatch is still concentrated around register assignment for the base/state pointers, but this rewrite removes part of the compiler noise in the repeated random blocks and produces a measurable `.text` improvement without regressions elsewhere.
