### PR TITLE
Improve pppLight default target selection

### DIFF
--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -248,13 +248,11 @@ void pppLight(void* param1, void* param2, void* param3)
 				Add__9CLightPcsFPQ29CLightPcs6CLight(&LightPcs, &light);
 			} else {
 				u32 targetIndex;
-				unsigned char* obj;
+				unsigned char* obj = gPppDefaultValueBuffer;
 
 				light.m_type = 1;
 				targetIndex = step->targetIndex;
-				if (targetIndex == 0xFFFFFFFF) {
-					obj = gPppDefaultValueBuffer;
-				} else {
+				if (targetIndex != 0xFFFFFFFF) {
 					pppLightTarget* targetTable =
 						(pppLightTarget*)((PppLightMngProgramInfo*)pppMngStPtr)->programInfoTable;
 					obj = targetTable[targetIndex].obj;


### PR DESCRIPTION
Summary:
- initialize the spotlight target pointer with `gPppDefaultValueBuffer` and only overwrite it for explicit target entries
- keep the fallback path source-plausible while tightening the generated relocation/register sequence in `pppLight`

Units/functions improved:
- `main/pppLight`
- `pppLight`

Progress evidence:
- selector baseline for `main/pppLight`: code `99.7%`, data `40.00%`
- after this change, `build/GCCP01/report.json` shows `main/pppLight` data at `20 / 20` bytes matched (`100.00%`)
- `tools/objdiff-cli diff -p . -u main/pppLight -o - '*'` now reports `[extabindex-0]` at `100.0%`\n- overall rebuild progress moved game data from `67240 / 139392` to `67252 / 139392` bytes\n- `pppLight` remains a near-match; no code/linkage regressions were introduced in the unit\n\nPlausibility rationale:\n- this is a natural source cleanup of the default-target path, not compiler coaxing: the object pointer now starts at the default buffer and only switches when a real target index exists\n- the logic matches the intended runtime behavior and removes an unnecessary special-case assignment\n\nTechnical details:\n- the only source edit is in the `step->targetIndex == 0xFFFFFFFF` fallback path inside `pppLight`\n- verified with `ninja` and objdiff after isolating the branch to this single-file change