### PR TITLE
Restore texture preview setup in p_chara_viewer drawViewer

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -7,8 +7,10 @@
 #include "ffcc/pad.h"
 #include "ffcc/p_light.h"
 #include "ffcc/p_usb.h"
+#include "ffcc/ptrarray.h"
 #include "ffcc/system.h"
 #include "ffcc/symbols_shared.h"
+#include "ffcc/textureman.h"
 #include <dolphin/gx.h>
 #include "dolphin/mtx.h"
 #include <string.h>
@@ -52,6 +54,10 @@ extern "C" void* __ct__6CColorFUcUcUcUc(void*, unsigned char, unsigned char, uns
 extern "C" void __ct__6CColorFv(void*);
 extern "C" void __ct__6CColorFR6CColor(void*, void*);
 extern "C" char s_no_texture____801da7e8[];
+extern "C" float FLOAT_80330BEC;
+extern "C" float FLOAT_80330BF0;
+extern "C" float FLOAT_80330BF4;
+extern "C" float FLOAT_80330BF8;
 extern "C" double fmod(double, double);
 
 static void releaseRef(unsigned char* p, int offset)
@@ -97,9 +103,55 @@ static inline Mtx44Ptr GetScreenMatrix()
 extern "C" void drawViewer__9CCharaPcsFv(void* param_1)
 {
     unsigned char* p = (unsigned char*)param_1;
+    CTextureSet* textureSet = *reinterpret_cast<CTextureSet**>(p + 0x2B8);
     Mtx cameraMtx;
     Mtx scratchMtx;
     Mtx44 projMtx;
+    Mtx texMtx;
+
+    if (textureSet != 0) {
+        CPtrArray<CTexture*>* textureArray = reinterpret_cast<CPtrArray<CTexture*>*>(reinterpret_cast<unsigned char*>(textureSet) + 8);
+
+        if (textureArray->GetSize() != 0) {
+            CTexture* texture = (*textureArray)[0];
+
+            C_MTXOrtho(projMtx, kCharaViewerZero, FLOAT_80330BEC, kCharaViewerZero, FLOAT_80330BF0, kCharaViewerZero,
+                       FLOAT_80330BF4);
+            GXSetProjection(projMtx, GX_ORTHOGRAPHIC);
+            PSMTXIdentity(cameraMtx);
+            GXLoadPosMtxImm(cameraMtx, 0);
+            GXSetCurrentMtx(0);
+            _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 1, 0, 0);
+            GXSetZMode(GX_FALSE, GX_ALWAYS, GX_FALSE);
+            GXSetNumChans(0);
+            GXSetNumTevStages(1);
+            _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 3);
+            _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 0xFF);
+            PSMTXIdentity(cameraMtx);
+            GXLoadPosMtxImm(cameraMtx, 0);
+            GXSetCullMode(GX_CULL_NONE);
+            TextureMan.SetTexture(GX_TEXMAP0, texture);
+            PSMTXScale(texMtx, FLOAT_80330BF8 / static_cast<float>(texture->m_width),
+                       FLOAT_80330BF8 / static_cast<float>(texture->m_height), FLOAT_80330BF8);
+            GXLoadTexMtxImm(texMtx, GX_TEXMTX0, GX_MTX2x4);
+            GXSetNumTexGens(1);
+            GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);
+            GXClearVtxDesc();
+            GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+            GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+            GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_S16, 0);
+            GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_S16, 1);
+            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
+            GXPosition3s16(0, 0, 0);
+            GXTexCoord2s16(0, 0);
+            GXPosition3s16(static_cast<short>(texture->m_width), 0, 0);
+            GXTexCoord2s16(static_cast<short>(texture->m_width * 2), 0);
+            GXPosition3s16(static_cast<short>(texture->m_width), static_cast<short>(texture->m_height), 0);
+            GXTexCoord2s16(static_cast<short>(texture->m_width * 2), static_cast<short>(texture->m_height * 2));
+            GXPosition3s16(0, static_cast<short>(texture->m_height), 0);
+            GXTexCoord2s16(0, static_cast<short>(texture->m_height * 2));
+        }
+    }
 
     PSMTXCopy(GetCameraMatrix(), cameraMtx);
     PSMTX44Copy(GetScreenMatrix(), projMtx);


### PR DESCRIPTION
Summary:
Restore the missing texture preview setup at the top of `drawViewer__9CCharaPcsFv` in `src/p_chara_viewer.cpp`.
The function now pulls the first texture from the viewer texture set, sets up the orthographic projection/tex matrix state, and emits the preview quad before switching back to the normal viewer camera path.

Units/functions improved:
- `main/p_chara_viewer`
- `drawViewer__9CCharaPcsFv`

Progress evidence:
- `drawViewer__9CCharaPcsFv` objdiff match: `44.59762% -> 70.27143%`.
- `main/p_chara_viewer` unit fuzzy match: `53.4% -> 58.95602%`.
- No data/linkage regressions were introduced in this change.
- `ninja` passes after the update.

Plausibility rationale:
The current source was missing a coherent front half of `drawViewer()` that renders the texture preview overlay when a texture set is present. Reintroducing that path is a source-plausible recovery of intended game behavior, not compiler coaxing: it uses existing engine types (`CTextureSet`, `CPtrArray<CTexture*>`, `TextureMan`) and normal GX setup calls rather than temporary hacks.

Technical details:
- Added the texture preview path before the camera/projection restore in `drawViewer()`.
- Used the existing Chara Viewer constants/symbolized float constants for the ortho and texture matrix setup.
- Drew the preview quad with the texture dimensions pulled from `CTexture` so the emitted GX state more closely follows the original function shape.
