### PR TITLE
Improve pppRyjMegaBirth calc matching

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -148,12 +148,11 @@ void calc(
 	VRyjMegaBirth* work, PRyjMegaBirth* param, _PARTICLE_DATA* particle, VColor* vColor,
 	_PARTICLE_COLOR* colorData)
 {
-	s32 alpha;
+	u32 alpha;
 	u8* paramPayload;
 	u8* particlePayload;
 	u8 fadeOutFrames;
 	u8 fadeInFrames;
-	float particleAngle;
 	Vec step;
 
 	alpha = vColor->m_alpha;
@@ -188,16 +187,14 @@ void calc(
 				*(float*)(paramPayload + 0x98) + *(float*)(particlePayload + 0x3C);
 	}
 
-	particleAngle = *(float*)(particlePayload + 0x28);
-	while (FLOAT_8033045c <= particleAngle)
+	while (FLOAT_8033045c <= *(float*)(particlePayload + 0x28))
 	{
-		particleAngle = particleAngle - FLOAT_80330458;
+		*(float*)(particlePayload + 0x28) = *(float*)(particlePayload + 0x28) - FLOAT_80330458;
 	}
-	while (particleAngle < FLOAT_80330460)
+	while (*(float*)(particlePayload + 0x28) < FLOAT_80330460)
 	{
-		particleAngle = particleAngle + FLOAT_80330458;
+		*(float*)(particlePayload + 0x28) = *(float*)(particlePayload + 0x28) + FLOAT_80330458;
 	}
-	*(float*)(particlePayload + 0x28) = particleAngle;
 
 	*(float*)(particlePayload + 0x40) = *(float*)(particlePayload + 0x40) + *(float*)(particlePayload + 0x48);
 	*(float*)(particlePayload + 0x44) = *(float*)(particlePayload + 0x44) + *(float*)(particlePayload + 0x4C);
@@ -244,8 +241,8 @@ void calc(
 		*(s16*)(particlePayload + 0x22) = *(s16*)(particlePayload + 0x22) - 1;
 	}
 
-	fadeOutFrames = *(u8*)(particlePayload + 0x59);
 	*(u8*)(particlePayload + 0x58) = *(u8*)(particlePayload + 0x58) + 1;
+	fadeOutFrames = *(u8*)(particlePayload + 0x59);
 	if ((fadeOutFrames != 0) && (*(u8*)(particlePayload + 0x58) <= fadeOutFrames))
 	{
 		*(float*)(particlePayload + 0x5C) =


### PR DESCRIPTION
## Summary
- tighten `calc` in `src/pppRyjMegaBirth.cpp` to use an unsigned alpha accumulator
- update the angle wrap loop to operate directly on the particle angle field
- increment the fade-out frame counter before reading the fade threshold, matching the existing assembly flow more closely

## Units/functions improved
- Unit: `main/pppRyjMegaBirth`
- Function: `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`

## Progress evidence
- `objdiff` for `calc` improved from `82.388885%` to `85.25641%`
- No additional source files changed
- `ninja` still completes successfully after the change

## Plausibility rationale
- `VColor::m_alpha` is an unsigned byte, so keeping the accumulator unsigned is a plausible original-source choice and aligns better with the generated PPC code
- wrapping the angle in place and incrementing the lifetime counter before comparing fade windows are both straightforward source-level expressions of the existing behavior, not compiler-coaxing hacks

## Technical details
- the biggest match movement came from changing the alpha accumulator from `s32` to `u32`
- the remaining edits simplify temporary usage around angle normalization and fade timing so the compiler keeps values in the same places the target object expects
