### PR TITLE
texanim: use ctor wrapper in CTexAnimSet::Duplicate

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -738,7 +738,7 @@ CTexAnimSet* CTexAnimSet::Duplicate(CMemory::CStage* stage)
     if (dup != 0) {
         __ct__4CRefFv(dup);
         dup->vtable = __vt__11CTexAnimSet;
-        new (&dup->texAnims) CPtrArray<CTexAnim*>();
+        __ct__21CPtrArray_P8CTexAnim_Fv(&dup->texAnims);
         dup->unk24 = FLOAT_8032fb38;
     }
 


### PR DESCRIPTION
Summary:
- replace the placement-new call for `dup->texAnims` with the explicit `CPtrArray<CTexAnim*>` constructor wrapper already used elsewhere in `texanim.cpp`
- keep the duplicated set initialization aligned with the constructor symbol pattern emitted for this unit

Units/functions improved:
- `main/texanim`
- `Duplicate__11CTexAnimSetFPQ27CMemory6CStage`

Progress evidence:
- objdiff for `Duplicate__11CTexAnimSetFPQ27CMemory6CStage`: `93.85227%` -> `97.27273%`
- function size remains `352` bytes
- no intentional regressions in code, data, or linkage were introduced; `ninja` still passes

Plausibility rationale:
- this keeps the code in line with the rest of the file, which already uses the explicit Metrowerks-generated constructor wrappers for `CPtrArray` specializations
- using the same wrapper for the duplicate path is more plausible original source reconstruction than mixing placement-new in one spot with wrapper calls everywhere else

Technical details:
- the change is isolated to `CTexAnimSet::Duplicate` in `src/texanim.cpp`
- objdiff improvement comes from matching the `CPtrArray<CTexAnim*>` construction sequence more closely during duplicate-set setup

Verification:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/texanim -o - Duplicate__11CTexAnimSetFPQ27CMemory6CStage`