### PR TITLE
Improve pppVertexApMtx childId handling

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -118,8 +118,9 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 				f32 z = vertex->z;
 
 				if ((data->childId + 0x10000) != 0xFFFF) {
+					s32 childId = data->childId;
 					_pppPDataVal* childData =
-						(_pppPDataVal*)((u8*)*(u32*)((u8*)pppMngStPtr + 0xD4) + (data->childId << 4));
+						(_pppPDataVal*)((u8*)*(u32*)((u8*)pppMngStPtr + 0xD4) + (childId << 4));
 					Vec worldPos;
 					Vec pos;
 					Mtx* outMtx;
@@ -165,8 +166,9 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 				f32 z = vertex->z;
 
 				if ((data->childId + 0x10000) != 0xFFFF) {
+					s32 childId = data->childId;
 					_pppPDataVal* childData =
-						(_pppPDataVal*)((u8*)*(u32*)((u8*)pppMngStPtr + 0xD4) + (data->childId << 4));
+						(_pppPDataVal*)((u8*)*(u32*)((u8*)pppMngStPtr + 0xD4) + (childId << 4));
 					Vec worldPos;
 					Vec pos;
 					Mtx* outMtx;


### PR DESCRIPTION
## Summary
- Extract `data->childId` into a signed local `childId` in both spawn paths inside `pppVertexApMtx`.
- Use that local for the child data table lookup instead of repeating the raw field shift.

## Units/functions improved
- Unit: `main/pppVertexApMtx`
- Function: `pppVertexApMtx`

## Progress evidence
- `pppVertexApMtx` fuzzy match: `95.59091%` -> `98.63636%`
- `main/pppVertexApMtx` fuzzy match: `95.74561%` -> `98.68421%`
- `pppVertexApMtxCon` remains `100%`
- `ninja` still passes and project progress/regression output is unchanged outside this unit

## Plausibility rationale
- Other related particle helpers in this area already materialize `childId` as a local before indexing the child definition table.
- A signed local is a natural way to express the lookup and avoids repeated raw field access without introducing match-only hacks.
- The change preserves the existing control flow and member access patterns.

## Technical details
- The remaining diff was concentrated in the child object lookup/register allocation path.
- Hoisting `data->childId` into a local in both mode branches changes code generation in the expected spot and improves the objdiff score without affecting data/linkage behavior.
