### PR TITLE
Improve chara_anim Create node flag packing

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -301,37 +301,42 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 						while (chunkFile.GetNextChunk(nodeChunk)) {
 							if (nodeChunk.m_id == 0x4E414D45) {
 								strcpy(node.m_name, chunkFile.GetString());
-							} else if (((int)nodeChunk.m_id < 0x4E414D45) && (nodeChunk.m_id == 0x44415441)) {
-								int i = 0;
-								int shift = 0;
-								do {
-									int type = (int)chunkFile.Get4();
-									int mode;
+							} else if ((int)nodeChunk.m_id < 0x4E414D45) {
+								if (nodeChunk.m_id == 0x44415441) {
+									int i = 0;
+									int shift = 0;
+									do {
+										int type = (int)chunkFile.Get4();
+										int mode;
 
-									if (type == 0) {
-										mode = 0;
-									} else if (type == 1) {
-										mode = 1;
-									} else {
-										mode = 2;
-									}
+										if (type == 0) {
+											mode = 0;
+										} else if (type == 1) {
+											mode = 1;
+										} else {
+											mode = 2;
+										}
 
-									unsigned int dataOffset = chunkFile.Get4();
-									if (i == 0) {
-										node.m_dataOffset = dataOffset;
-									}
+										unsigned int dataOffset = chunkFile.Get4();
+										if (i == 0) {
+											node.m_dataOffset = dataOffset;
+										}
 
-									node.m_flags = (((node.m_flags >> 0xD) & 0x3FFFF) | ((mode << shift) & 0x3FFFFU)) << 0xD |
-									               (node.m_flags & 0x80001FFF);
+										unsigned int nodeFlags = node.m_flags;
+										node.m_flags =
+										    (((nodeFlags >> 0xD) & 0x3FFFF) | ((mode << shift) & 0x3FFFFU)) << 0xD |
+										    (nodeFlags & 0x80001FFF);
 
-									if ((5 < i) && (type != 0)) {
-										*reinterpret_cast<unsigned char*>(&node.m_flags) =
-										    (*reinterpret_cast<unsigned char*>(&node.m_flags) & 0x7F) | 0x80;
-									}
+										if ((5 < i) && (type != 0)) {
+											unsigned char flags = *reinterpret_cast<unsigned char*>(&node.m_flags);
+											*reinterpret_cast<unsigned char*>(&node.m_flags) =
+											    static_cast<unsigned char>(__rlwimi(flags, 1, 7, 24, 24));
+										}
 
-									i++;
-									shift += 2;
-								} while (i < 9);
+										i++;
+										shift += 2;
+									} while (i < 9);
+								}
 							}
 						}
 						chunkFile.PopChunk();


### PR DESCRIPTION
## Summary
- reshape the `NODE` chunk parser in `CChara::CAnim::Create` so the `NAME`/`DATA` handling follows the original nested branch structure more closely
- cache `node.m_flags` before repacking the 2-bit mode fields
- use `__rlwimi` when setting the high flag bit for scale channels instead of ad hoc byte masking

## Units/functions improved
- Unit: `main/chara_anim`
- Function: `Create__Q26CChara5CAnimFPvPQ27CMemory6CStage`

## Progress evidence
- `Create__Q26CChara5CAnimFPvPQ27CMemory6CStage`: `46.358334%` -> `46.4625%` match (`960b`)
- `main/chara_anim` `.text`: `75.25655%` -> `75.30337%`
- `Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf` held at `98.1697%`
- `ninja` still passes after the change

## Plausibility rationale
- this keeps the existing parser behavior intact while expressing the node-data handling in a form that better matches the original control flow and bitfield updates
- using `__rlwimi` for the packed flag byte is consistent with the rest of this file and with how Metrowerks-authored bitfield code is typically represented in the repo

## Technical details
- the useful movement came from the `NODE` -> `DATA` path, especially the mode packing and the late high-bit set for non-zero scale tracks
- no extern hacks, section tricks, or linkage shortcuts were introduced