### PR TITLE
Improve CGPrgObj::rotTarget match quality

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -455,9 +455,8 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
  */
 void CGPrgObj::rotTarget(CGPrgObj* target)
 {
-	CGPrgObj* self = this;
 	CVector targetPos(target->m_worldPosition);
-	CVector basePos(self->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
 	float targetRot;
 	float deltaX;
@@ -469,12 +468,12 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
-	if (deltaX == zero || deltaZ == zero) {
+	if (zero == deltaX || zero == deltaZ) {
 		targetRot = FLOAT_80331BD4;
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
-	self->m_rotTargetY = targetRot;
+	m_rotTargetY = targetRot;
 }
 
 /*


### PR DESCRIPTION
Summary:
Refines `CGPrgObj::rotTarget` to use direct member access and removes the unnecessary `self` alias. The comparison was also rewritten as `zero == value`, which changes the generated register usage without introducing contrived temporaries or offset hacks.

Units/functions improved:
- `main/prgobj`
- `rotTarget__8CGPrgObjFP8CGPrgObj` (`CGPrgObj::rotTarget`)

Progress evidence:
- `rotTarget__8CGPrgObjFP8CGPrgObj`: `83.28205%` -> `84.17949%` fuzzy match (`156b`)
- `dstTargetRot__8CGPrgObjFP8CGPrgObj`: unchanged at `86.204544%`
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: unchanged at `85.05556%`
- `ninja` still succeeds after the change

Plausibility rationale:
This moves the source toward what the original authors likely wrote: direct `this` member access instead of introducing a redundant self-pointer alias, while keeping the existing local-variable structure intact. The change improves codegen through ordinary C++ expression shape rather than through compiler-coaxing hacks.

Technical details:
Objdiff showed `rotTarget` was close but still carrying an extra saved GPR and redundant moves around `this`. Removing the local self alias and storing through `m_rotTargetY` directly improves that register allocation. Reordering the equality operands to compare the cached zero value first also nudges the compare sequence closer to the target without changing behavior.
