### PR TITLE
Improve CFunnyShape constructor match

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -49,6 +49,11 @@ static inline u32& U32At(CFunnyShape* self, u32 offset)
     return *reinterpret_cast<u32*>(Ptr(self, offset));
 }
 
+static inline u8& U8At(CFunnyShape* self, u32 offset)
+{
+    return *reinterpret_cast<u8*>(Ptr(self, offset));
+}
+
 static inline s16 S16At(const u8* p, u32 offset)
 {
     return *reinterpret_cast<const s16*>(p + offset);
@@ -140,8 +145,7 @@ CFunnyShape::CFunnyShape()
     memset(Ptr(this, 0x6014), 0, 0x40);
 
     CFunnyShape* p = this;
-    s32 i = 2;
-    do {
+    for (s32 i = 2; i != 0; i--) {
         PtrAt(p, 0x6094) = 0;
         PtrAt(p, 0x6014) = 0;
         PtrAt(p, 0x6054) = 0;
@@ -167,10 +171,9 @@ CFunnyShape::CFunnyShape()
         PtrAt(p, 0x6030) = 0;
         PtrAt(p, 0x6070) = 0;
         p = reinterpret_cast<CFunnyShape*>(Ptr(p, 0x20));
-        i--;
-    } while (i != 0);
+    }
 
-    U32At(this, 0x60D4) = 0;
+    U8At(this, 0x60D4) = 0;
 }
 
 /*


### PR DESCRIPTION
Summary:
- tighten `CFunnyShape::CFunnyShape()` around the trailing clear loop and final flag store
- add a byte-sized helper for the 0x60D4 field so the constructor writes the flag with the correct width

Units/functions improved:
- `main/FunnyShape`
- `__ct__11CFunnyShapeFv` (`CFunnyShape::CFunnyShape()`)

Progress evidence:
- constructor fuzzy match improved from `91.98305%` to `99.94915%` (`236` bytes)
- remaining constructor diff is down to three address-selection mismatches in the memset setup
- full build still passes with `ninja`
- unit-level fuzzy match is now `64.371635%`; the selector reported `64.1%` before this pass

Plausibility rationale:
- the loop still expresses the same two-iteration bulk field clear, but in a form that better matches the original compiler output
- the `0x60D4` field is now written as a byte instead of a word, which is a more plausible representation for a trailing flag byte in this object layout
- no hardcoded addresses, section tricks, or extern/linkage hacks were introduced

Technical details:
- changing the tail store from `U32At(..., 0x60D4)` to `U8At(..., 0x60D4)` fixed the final store width
- expressing the clear as `for (s32 i = 2; i != 0; i--)` moved the loop much closer to the original `bdnz` form
- current residual mismatch is limited to the three memset base-address setup instructions at the top of the constructor