### PR TITLE
Match CFunnyShape constructor memset ranges

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -140,9 +140,9 @@ CFunnyShape::CFunnyShape()
 {
     PtrAt(this, 0x6010) = 0;
     memset(this, 0, 0x6000);
-    memset(Ptr(this, 0x6000), 0, 0x10);
     memset(Ptr(this, 0x60D8), 0, 0x10);
-    memset(Ptr(this, 0x6014), 0, 0x40);
+    memset(Ptr(this, 0x6000), 0, 0x10);
+    memset(Ptr(this, 0x60E8), 0, 0x40);
 
     CFunnyShape* p = this;
     for (s32 i = 2; i != 0; i--) {


### PR DESCRIPTION
Summary:
- reorder the constructor's post-clear memset calls to match the original object layout setup
- clear the trailing 0x40-byte FunnyShape state block from 0x60E8 instead of 0x6014

Units/functions improved:
- `main/FunnyShape`
- `__ct__11CFunnyShapeFv`: 99.94915% -> 100.0%

Progress evidence:
- objdiff for `__ct__11CFunnyShapeFv` is now a full 100% match
- project matched code increased from 439036 to 439272 bytes (+236)
- matched functions increased from 2857 to 2858 (+1)
- game matched code increased from 132824 to 133060 bytes (+236)
- game matched functions increased from 1619 to 1620 (+1)

Plausibility rationale:
- this change corrects constructor initialization ranges rather than introducing match-only scaffolding
- the updated memset order and destination align with the existing member layout around the FunnyShape work/state region and produce cleaner original-source-style initialization

Technical details:
- the remaining constructor diff was three immediate offsets in the memset setup sequence
- adjusting those clears to `0x60D8`, `0x6000`, and `0x60E8` resolved the final mismatch without affecting other code paths
