### PR TITLE
Fix RedSound standby ID array size

### DIFF
--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -20,7 +20,7 @@ extern "C" {
 
 // RedSound global linkage that is shared across Red* units.
 CRedDriver gRedDriver;
-int DAT_8032e17c[0x40];
+int DAT_8032e17c[0x41];
 u8 DAT_8032f4a8;
 int DAT_8032f4ac;
 u32* DAT_8032f4b0;


### PR DESCRIPTION
Summary:
- Correct `DAT_8032e17c` in `src/RedSound/RedSound.cpp` from 64 ints to 65 ints to match the shipped PAL symbol size (`0x104`).
- Keep the standby ID logic unchanged; the code still uses the first 64 entries, but the backing object now matches the original data layout.

Units/functions improved:
- Unit: `main/RedSound/RedSound`
- Functions: no behavioral code changes; all 58 functions remain matched.

Progress evidence:
- Selector baseline for `main/RedSound/RedSound`: code `100.0%`, data `0.27%`.
- After this change (`build/GCCP01/report.json`): code `100.0%`, data `18.85%` (`276 / 1464` bytes).
- Objdiff section result for `main/RedSound/RedSound`: `.bss` improved from `50.0%` to `100.0%`.
- Overall build progress improved by `+272` matched data bytes (`220743 -> 221015`).
- No code-match regressions were introduced; `ninja` still passes.

Plausibility rationale:
- This is a data-layout correction, not compiler coaxing.
- The existing source declared `DAT_8032e17c` as `0x40` ints, but the symbol table records a `0x104`-byte object. Declaring the real object size is the plausible original-source fix and brings the backing storage in line with the shipped binary layout.

Technical details:
- `config/GCCP01/symbols.txt` records `DAT_8032e17c = .bss:0x8032E17C; // size:0x104`.
- The previous declaration only allocated `0x100` bytes, which left the unit's `.bss` layout short by 4 bytes.
- Expanding the array to `0x41` ints restores the expected object size and resolves the `.bss` mismatch cleanly.
