### PR TITLE
Improve CalcReflectionVector2 matching in pppMana2

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -804,13 +804,12 @@ void CalcReflectionVector2(
     Vec cameraVector;
     Vec objSpacePos;
     Vec objSpaceNormal;
-    Vec reflectOut;
     Vec2d uv;
     Mtx nodeMtx;
     Mtx nodeRotMtx;
     Mtx cameraMtx;
-    u8* dl = (u8*)displayList;
-    u8* dlEnd;
+    u16* dl = (u16*)displayList;
+    u16* dlEnd;
     const double half = (double)FLOAT_803318a4;
 
     cameraPos.x = CameraWorldX();
@@ -840,28 +839,29 @@ void CalcReflectionVector2(
     PSMTXCopy(ppvCameraMatrix0, cameraMtx);
     PSMTXConcat(cameraMtx, matrix, cameraMtx);
 
-    dlEnd = dl + displayListSize;
+    dlEnd = (u16*)((u8*)displayList + displayListSize);
     while (dl < dlEnd) {
-        u8 drawFmt = dl[0];
-        u16 itemCount = *(u16*)(dl + 1);
+        u8 drawFmt = *(u8*)dl;
+        u16 itemCount = *(u16*)((u8*)dl + 1);
         int i;
 
         if (gUtil.IsHasDrawFmtDL(drawFmt) == 0) {
             break;
         }
 
-        dl += 3;
+        dl = (u16*)((u8*)dl + 3);
         for (i = 0; i < itemCount; i++) {
-            u16 posIndex = *(u16*)(dl + 0);
-            u16 normalIndex = *(u16*)(dl + 2);
-            u8* next = dl + 8;
+            u16 posIndex = dl[0];
+            u16 normalIndex = dl[1];
+            u16* next = dl + 4;
             int axis = 0;
             float maxAxis;
             float invAxis;
+            Vec* outVec;
             u8* clr;
 
             if ((drawFmt & 7) == 2) {
-                next = dl + 10;
+                next = dl + 5;
             }
 
             gUtil.ConvI2FVector(objSpacePos, positions[posIndex], posScale);
@@ -871,14 +871,15 @@ void CalcReflectionVector2(
 
             PSVECSubtract(&objSpacePos, &cameraPos, &cameraVector);
             PSVECNormalize(&cameraVector, &cameraVector);
-            C_VECReflect(&cameraVector, &objSpaceNormal, &reflectOut);
+            outVec = &reflectionVec[posIndex];
+            C_VECReflect(&cameraVector, &objSpaceNormal, outVec);
 
-            maxAxis = fabsf(reflectOut.x);
-            if (maxAxis < fabsf(reflectOut.y)) {
+            maxAxis = fabsf(outVec->x);
+            if (maxAxis < fabsf(outVec->y)) {
                 axis = 1;
-                maxAxis = fabsf(reflectOut.y);
+                maxAxis = fabsf(outVec->y);
             }
-            if (maxAxis < fabsf(reflectOut.z)) {
+            if (maxAxis < fabsf(outVec->z)) {
                 axis = 2;
             }
 
@@ -892,43 +893,43 @@ void CalcReflectionVector2(
             uv.y = (float)half;
 
             if (axis == 1) {
-                invAxis = FLOAT_803318b8 * reflectOut.y;
-                if (reflectOut.y < FLOAT_80331898) {
+                invAxis = FLOAT_803318b8 * outVec->y;
+                if (outVec->y < FLOAT_80331898) {
                     clr[1] = (u8)(clr[1] - 0x7F);
-                    uv.x = (float)((half - (double)(reflectOut.x / invAxis)) * (double)FLOAT_803318bc +
+                    uv.x = (float)((half - (double)(outVec->x / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318bc);
-                    uv.y = (float)((double)((float)(half + (double)(reflectOut.z / invAxis)) * FLOAT_803318bc) + half);
+                    uv.y = (float)((double)((float)(half + (double)(outVec->z / invAxis)) * FLOAT_803318bc) + half);
                 } else {
                     clr[1] = (u8)(clr[1] + 0x7F);
-                    uv.y = (float)((half + (double)(reflectOut.z / invAxis)) * (double)FLOAT_803318bc);
-                    uv.x = (float)((double)((float)(half + (double)(reflectOut.x / invAxis)) * FLOAT_803318bc) + half);
+                    uv.y = (float)((half + (double)(outVec->z / invAxis)) * (double)FLOAT_803318bc);
+                    uv.x = (float)((double)((float)(half + (double)(outVec->x / invAxis)) * FLOAT_803318bc) + half);
                 }
             } else if (axis == 0) {
-                invAxis = FLOAT_803318b8 * reflectOut.x;
-                if (reflectOut.x < FLOAT_80331898) {
+                invAxis = FLOAT_803318b8 * outVec->x;
+                if (outVec->x < FLOAT_80331898) {
                     clr[0] = (u8)(clr[0] - 0x7F);
-                    uv.x = (float)((half - (double)(reflectOut.z / invAxis)) * (double)FLOAT_803318bc +
+                    uv.x = (float)((half - (double)(outVec->z / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318c0);
-                    uv.y = (float)((half + (double)(reflectOut.y / invAxis)) * (double)FLOAT_803318bc +
+                    uv.y = (float)((half + (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318bc);
                 } else {
                     clr[0] = (u8)(clr[0] + 0x7F);
-                    uv.x = (float)((half - (double)(reflectOut.z / invAxis)) * (double)FLOAT_803318bc +
+                    uv.x = (float)((half - (double)(outVec->z / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318bc);
-                    uv.y = (float)((half - (double)(reflectOut.y / invAxis)) * (double)FLOAT_803318bc +
+                    uv.y = (float)((half - (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318bc);
                 }
             } else {
-                invAxis = FLOAT_803318b8 * reflectOut.z;
-                if (reflectOut.z < FLOAT_80331898) {
+                invAxis = FLOAT_803318b8 * outVec->z;
+                if (outVec->z < FLOAT_80331898) {
                     clr[2] = (u8)(clr[2] - 0x7F);
-                    uv.x = (float)((double)((float)(half + (double)(reflectOut.x / invAxis)) * FLOAT_803318bc) + half);
-                    uv.y = (float)((half + (double)(reflectOut.y / invAxis)) * (double)FLOAT_803318bc +
+                    uv.x = (float)((double)((float)(half + (double)(outVec->x / invAxis)) * FLOAT_803318bc) + half);
+                    uv.y = (float)((half + (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318bc);
                 } else {
                     clr[2] = (u8)(clr[2] + 0x7F);
-                    uv.x = (float)((half + (double)(reflectOut.x / invAxis)) * (double)FLOAT_803318bc);
-                    uv.y = (float)((half - (double)(reflectOut.y / invAxis)) * (double)FLOAT_803318bc +
+                    uv.x = (float)((half + (double)(outVec->x / invAxis)) * (double)FLOAT_803318bc);
+                    uv.y = (float)((half - (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
                                    (double)FLOAT_803318bc);
                 }
             }


### PR DESCRIPTION
Summary
- Reworked `CalcReflectionVector2` in `src/pppMana2.cpp` to use the reflected output buffer directly instead of a transient local vector.
- Adjusted display-list traversal to operate on 16-bit entries with byte-based header stepping, matching the function's actual packed DL layout more closely.
- Kept the existing control flow and math behavior intact while shifting expression shape toward plausible original source.

Units/functions improved
- Unit: `main/pppMana2`
- Function: `CalcReflectionVector2__FP3VecP6S16VecP6S16VeclUlUlPA4_fPvUlP8_GXColorP8S16Vec2dPQ26CChara5CNode`

Progress evidence
- `CalcReflectionVector2`: `63.778713%` -> `66.420166%` (`+2.641453`)
- `main/pppMana2` `.text`: `66.808340%` -> `67.113120%` (`+0.304780`)
- `ninja` still passes after the change.
- No intentional code/data/linkage regressions were introduced in this patch.

Plausibility rationale
- Writing the reflected vector directly into `reflectionVec[posIndex]` is the more plausible original implementation because the function flushes that output buffer at the end and uses the per-vertex reflected vector immediately afterward.
- Treating the display list as packed 16-bit indices with a 3-byte header matches the observed data layout without resorting to hardcoded hacks or artificial temporaries.
- The patch improves compiler shape by making the data flow explicit rather than coaxing codegen with non-source-like constructs.

Technical details
- Replaced the temporary `reflectOut` local with an `outVec` pointer to the output array element.
- Switched DL iteration from raw 8-byte pointer math to `u16*` index access plus byte-based header advance.
- Reused the output vector consistently for axis selection and UV/color generation, which reduced objdiff distance for the PAL target.