### PR TITLE
Refine CGObject::Attach weapon flag write

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1819,10 +1819,8 @@ void CGObject::Attach(CGObject* owner, char* nodeName, Vec* attachLocal)
         int nodeIndex = SearchNode__Q26CChara6CModelFPc(handle->m_model, nodeName);
         if (nodeIndex >= 0) {
             int weaponFlags = *reinterpret_cast<u8*>(&m_weaponNodeFlags);
-            int setFlag = 1;
-            weaponFlags = __rlwimi(weaponFlags, setFlag, 0, 31, 31);
+            weaponFlags = weaponFlags | 1;
             *reinterpret_cast<u8*>(&m_weaponNodeFlags) = static_cast<u8>(weaponFlags);
-
             m_attachOwner = owner;
             m_attachNode = nodeIndex;
             m_attachLocal.x = attachLocal->x;


### PR DESCRIPTION
Summary:
- simplify the low-byte `m_weaponNodeFlags` update in `CGObject::Attach` to a direct byte OR instead of the manual `__rlwimi` helper sequence
- keep the rest of the attach path unchanged

Units/functions improved:
- `main/gobject`: `Attach__8CGObjectFP8CGObjectPcP3Vec`

Progress evidence:
- `build/tools/objdiff-cli diff -p . -u main/gobject -o - Attach__8CGObjectFP8CGObjectPcP3Vec`
- before: 4 instruction diffs remained in the flag-set sequence (`lbz`, `li`, `rlwimi`, `stb`)
- after: 2 instruction diffs remain, narrowed to the immediate materialization/bit-set pair (`li r4, 0x1` and the old rotate-insert pattern is gone)
- aggregate `ninja` progress is unchanged, but the symbol-level assembly is materially closer and the noisy helper sequence has been removed

Plausibility rationale:
- the new code expresses the original intent directly: read the attach flag byte, set bit 0, write it back
- this is cleaner and more source-plausible than forcing the bit update through `__rlwimi` in gameplay code

Technical details:
- build verified with `ninja`
- current objdiff for the symbol shows only two remaining mismatches at addresses `0x178c/0x1790` in the flag-set block