### PR TITLE
p_map: correct s_mapRelProfile2 storage size

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -48,7 +48,7 @@ unsigned int PTR_s_CMapPcs_GAME__801e8ad8[0x414 / sizeof(unsigned int)];
 
 unsigned int s_mapRelProfile0__7CMapPcs;
 unsigned int s_mapRelProfile1__7CMapPcs;
-unsigned int s_mapRelProfile2__7CMapPcs;
+unsigned int s_mapRelProfile2__7CMapPcs[2];
 unsigned int s_loadedStageNo__7CMapPcs;
 unsigned int s_loadedMapNo__7CMapPcs;
 extern const float DrawRangeDefault;


### PR DESCRIPTION
Summary:
- correct `s_mapRelProfile2__7CMapPcs` from a single word to two-word storage in `src/p_map.cpp`
- keep the declaration aligned with the PAL symbol map, which records this symbol as an 0x8-byte `.sbss` object

Units/functions improved:
- `main/p_map`: `fuzzy_match_percent` 80.58552 -> 80.63670
- `__sinit_p_map_cpp`: `fuzzy_match_percent` 60.04918 -> 60.38525

Progress evidence:
- before: `main/p_map` report fuzzy 80.58552, `__sinit_p_map_cpp` fuzzy 60.04918
- after: `main/p_map` report fuzzy 80.63670, `__sinit_p_map_cpp` fuzzy 60.38525
- build still passes with `ninja`; global project progress remains stable outside this unit
- matched data bytes do not move yet, but the source declaration is now closer to the shipped symbol layout and improves the generated init path for the unit

Plausibility rationale:
- this is a source-plausible storage correction rather than compiler coaxing
- the PAL symbol map lists `s_mapRelProfile2__7CMapPcs` as size `0x8`; the previous single-`unsigned int` declaration under-modeled that object
- adjusting the local storage shape is consistent with the project rule to prefer defining things correctly over forcing temporary symbols or hacks

Technical details:
- verified the current object symbol layout with `nm -S build/GCCP01/src/p_map.o`
- rebuilt with `ninja -j2` and compared the updated unit/function metrics from `build/GCCP01/report.json`
- no unrelated files were changed