### PR TITLE
Refine CCaravanWork::GetMagicCharge control flow

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1887,10 +1887,13 @@ void CCaravanWork::GetMagicCharge(int cmdListIdx, int& groupedCount, int& isSele
 		return;
 	}
 
-	groupedCount = 1;
-	if (Game.m_gameWork.m_menuStageMode != 0) {
+	if (Game.m_gameWork.m_menuStageMode == 0) {
+		groupedCount = 1;
+	} else {
 		short* slotRef = m_commandListExtra + cmdListIdx;
-		if (slotRef[0] != 0) {
+		if (slotRef[0] == 0) {
+			groupedCount = 1;
+		} else {
 			int scanCount = cmdListIdx + 1;
 			int topIdx = cmdListIdx;
 			if (cmdListIdx >= 0) {
@@ -1905,9 +1908,9 @@ void CCaravanWork::GetMagicCharge(int cmdListIdx, int& groupedCount, int& isSele
 			}
 
 			groupedCount = 1;
-			scanCount = m_numCmdListSlots - (topIdx + 1);
+			scanCount = static_cast<short>(m_numCmdListSlots) - (topIdx + 1);
 			slotRef = m_commandListExtra + topIdx + 1;
-			if ((topIdx + 1) < m_numCmdListSlots) {
+			if ((topIdx + 1) < static_cast<short>(m_numCmdListSlots)) {
 				do {
 					if (slotRef[0] != -1) {
 						break;
@@ -1921,7 +1924,7 @@ void CCaravanWork::GetMagicCharge(int cmdListIdx, int& groupedCount, int& isSele
 	}
 
 	if (groupedCount == 1) {
-		isSelected = (((unsigned int)__cntlzw(cmdListIdx - m_currentCmdListIndex)) >> 5) & 0xFF;
+		isSelected = (((unsigned int)__cntlzw(cmdListIdx - static_cast<short>(m_currentCmdListIndex))) >> 5) & 0xFF;
 		return;
 	}
 
@@ -1939,8 +1942,8 @@ void CCaravanWork::GetMagicCharge(int cmdListIdx, int& groupedCount, int& isSele
 	}
 
 	unsigned int selected = 0;
-	if ((cmdListIdx <= m_currentCmdListIndex) &&
-		(m_currentCmdListIndex <= (cmdListIdx + groupedCount - 1))) {
+	if ((cmdListIdx <= static_cast<short>(m_currentCmdListIndex)) &&
+		(static_cast<short>(m_currentCmdListIndex) <= (cmdListIdx + groupedCount - 1))) {
 		selected = 1;
 	}
 	isSelected = selected;


### PR DESCRIPTION
Summary:
- Rewrite `CCaravanWork::GetMagicCharge` to follow the decomp's branch structure more closely.
- Keep the command-group scan centered on `m_commandListExtra`, but make the menu-stage and empty-slot cases explicit.
- Add short casts where the backing fields are stored as `short`, so the generated comparisons track the real object layout.

Units/functions improved:
- Unit: `main/gobjwork`
- Function: `GetMagicCharge__12CCaravanWorkFiRiRi`

Progress evidence:
- `GetMagicCharge__12CCaravanWorkFiRiRi`: `53.18072%` -> `55.831326%` match in objdiff.
- No intended data/linkage hacks were introduced.
- `ninja` still completes successfully after the change.

Plausibility rationale:
- The new flow is a cleaner source representation of the command-list grouping logic already present in neighboring functions.
- The change removes compiler-coaxing style fallthroughs and uses the real `short` field widths from `CCaravanWork`, which is more plausible as original source.
- The function still operates on actual members rather than hard-coded offsets or extern tricks.

Technical details:
- Reworked the `m_menuStageMode` path into explicit `if/else` cases so the grouped-count initialization matches the target's fallthrough structure.
- Preserved the backward and forward scans over grouped command slots while tightening comparisons against `m_numCmdListSlots` and `m_currentCmdListIndex` to the class field types.
- Verified by rebuilding with `ninja` and re-running objdiff on `main/gobjwork` for `GetMagicCharge__12CCaravanWorkFiRiRi`.
