### PR TITLE
Improve RedStream empty stream search match

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -30,19 +30,15 @@ int SearchSeEmptyTrack__Fiii(int, int, int);
  */
 unsigned int _SearchEmptyStreamData()
 {
-	register RedStreamDATA* streamData;
+	unsigned int streamData = (unsigned int)DAT_8032f438;
 
-	streamData = (RedStreamDATA*)DAT_8032f438;
-	do {
-		if (*(int*)((int)streamData + 0x10c) == 0) {
-			break;
+	while (streamData < (unsigned int)DAT_8032f438 + 0x4c0) {
+		if (*(int*)(streamData + 0x10c) == 0) {
+			return streamData;
 		}
-		streamData = (RedStreamDATA*)((int)streamData + 0x130);
-	} while ((unsigned int)streamData < (unsigned int)DAT_8032f438 + 0x4c0);
-
-	if ((unsigned int)streamData < (unsigned int)DAT_8032f438 + 0x4c0) {
-		return (unsigned int)streamData;
+		streamData += 0x130;
 	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Summary:
- rewrote `_SearchEmptyStreamData` in `src/RedSound/RedStream.cpp` to scan the stream pool as raw addresses with an early return
- removed the do/while + post-loop range check that was forcing a less plausible code shape for this tiny helper

Units/functions improved:
- `main/RedSound/RedStream`
- `_SearchEmptyStreamData__Fv`

Progress evidence:
- `_SearchEmptyStreamData__Fv` objdiff match improved from `0.0%` on the `main` source shape to `46.117645%` after this rewrite
- current rebuilt symbol size is `48` bytes
- `ninja` still passes after the change
- no data or linkage regressions were introduced; this is an isolated code-only improvement in one helper

Plausibility rationale:
- nearby RedSound code already iterates the same `DAT_8032f438` stream pool as raw `unsigned int` addresses and steps by `0x130` bytes
- expressing the search as a simple bounded scan with an immediate return matches that local coding style better than the prior register-forced `RedStreamDATA*` do/while form
- the new source is simpler and more source-plausible, not a compiler-only hack

Technical details:
- the old form compiled to a `0.0%` helper despite being close in behavior
- switching to a `while` loop over the raw pool address removed the unnecessary post-loop condition and produced a materially closer leaf-function shape in objdiff
- verification was done with `build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream -o - _SearchEmptyStreamData__Fv` and a full `ninja` rebuild