### PR TITLE
Match RedDriver command queue reads

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -695,16 +695,16 @@ void _EntryExecCommand(void (*param_1)(int*), int param_2, int param_3, int para
 #pragma dont_inline on
 void _ExecuteCommand()
 {
-	int* executePos = (int*)DAT_8032f3d8;
-	int* readPos = (int*)DAT_8032f3dc;
+	unsigned int* executePos = (unsigned int*)DAT_8032f3d8;
+	unsigned int* readPos = (unsigned int*)DAT_8032f3dc;
 
 	while (executePos != readPos) {
 		if (*readPos != 0) {
-			((void (*)(int*))(*readPos))(readPos + 1);
+			((void (*)(int*))(*readPos))((int*)(readPos + 1));
 		}
 		readPos += 8;
-		if (readPos == (int*)DAT_8032f3d4 + 0x800) {
-			readPos = (int*)DAT_8032f3d4;
+		if (readPos == (unsigned int*)DAT_8032f3d4 + 0x800) {
+			readPos = (unsigned int*)DAT_8032f3d4;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- type the RedDriver command ring pointers as `unsigned int*` inside `_ExecuteCommand`
- keep the callback invocation and wraparound logic the same while matching the queue word semantics

## Units/functions improved
- `main/RedSound/RedDriver`
- `_ExecuteCommand__Fv`: `98.0% -> 100.0%` (`120b`, removed the final compare mismatch)

## Progress evidence
- Overall game code matched bytes: `133172 -> 133292` (`+120`)
- Overall matched functions: `1621 -> 1622` (`+1`)
- `main/RedSound/RedDriver` matched code: `4116 -> 4236` (`+120`)
- `main/RedSound/RedDriver` matched functions: `58 -> 59`
- Full rebuild passes with `ninja`

## Plausibility rationale
- `_ExecuteCommand` walks a command buffer whose entries are raw queue words: a callback pointer followed by integer arguments.
- Treating the ring contents as `unsigned int*` is a natural source representation for that storage and explains the original unsigned zero-check without adding hacks or linkage shortcuts.
- The callback ABI and queue wrap logic are unchanged.

## Technical details
- The remaining mismatch was a signed-vs-unsigned compare on the queue entry word.
- Re-typing the queue cursor variables to `unsigned int*` made the compiler emit the expected unsigned compare while preserving the surrounding control flow.