### PR TITLE
Improve pppVertexAp match by aligning child spawn locals

### DIFF
--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -137,16 +137,16 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 
                 if ((data->childId + 0x10000) != 0xFFFF) {
                     s32 childId = data->childId;
-                    _pppPObject* child;
                     _pppPDataVal* childData =
                         (_pppPDataVal*)((u8*)*(u32*)((u8*)pppMngStPtr + 0xD4) + (childId << 4));
                     Vec pos;
-                    Vec* dst;
+                    Vec* outPos;
+                    _pppPObject* child;
 
                     if (childData == 0) {
                         child = 0;
                     } else {
-                        child = pppCreatePObject(pppMngStPtr, childData);
+                        child = pppCreatePObject((_pppMngSt*)pppMngStPtr, childData);
                         *(void**)((u8*)child + 0x4) = parent;
                     }
 
@@ -154,14 +154,14 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     pos.y = y;
                     pos.z = z;
                     PSMTXMultVec(parentObj->localMatrix, &pos, &pos);
-                    dst = (Vec*)((u8*)child + data->childPosOffset + 0x80);
+                    outPos = (Vec*)((u8*)child + data->childPosOffset + 0x80);
 
                     if (data->useWorldMtx == 0) {
-                        dst->x = pos.x;
-                        dst->y = pos.y;
-                        dst->z = pos.z;
+                        outPos->x = pos.x;
+                        outPos->y = pos.y;
+                        outPos->z = pos.z;
                     } else {
-                        PSMTXMultVec(pppMngStPtr->m_matrix.value, &pos, dst);
+                        PSMTXMultVec(pppMngStPtr->m_matrix.value, &pos, outPos);
                     }
                 }
             }
@@ -180,16 +180,16 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 
                 if ((data->childId + 0x10000) != 0xFFFF) {
                     s32 childId = data->childId;
-                    _pppPObject* child;
                     _pppPDataVal* childData =
                         (_pppPDataVal*)((u8*)*(u32*)((u8*)pppMngStPtr + 0xD4) + (childId << 4));
                     Vec pos;
-                    Vec* dst;
+                    Vec* outPos;
+                    _pppPObject* child;
 
                     if (childData == 0) {
                         child = 0;
                     } else {
-                        child = pppCreatePObject(pppMngStPtr, childData);
+                        child = pppCreatePObject((_pppMngSt*)pppMngStPtr, childData);
                         *(void**)((u8*)child + 0x4) = parent;
                     }
 
@@ -197,14 +197,14 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     pos.y = y;
                     pos.z = z;
                     PSMTXMultVec(parentObj->localMatrix, &pos, &pos);
-                    dst = (Vec*)((u8*)child + data->childPosOffset + 0x80);
+                    outPos = (Vec*)((u8*)child + data->childPosOffset + 0x80);
 
                     if (data->useWorldMtx == 0) {
-                        dst->x = pos.x;
-                        dst->y = pos.y;
-                        dst->z = pos.z;
+                        outPos->x = pos.x;
+                        outPos->y = pos.y;
+                        outPos->z = pos.z;
                     } else {
-                        PSMTXMultVec(pppMngStPtr->m_matrix.value, &pos, dst);
+                        PSMTXMultVec(pppMngStPtr->m_matrix.value, &pos, outPos);
                     }
                 }
             }


### PR DESCRIPTION
Summary:
- Reordered the child spawn locals in `pppVertexAp` to match the existing `pppVertexApMtx`/`pppVertexApLc` source patterns.
- Switched the child creation call to the same `_pppMngSt*` cast form already used by sibling particle functions.
- Kept behavior unchanged: the function still transforms the chosen vertex into local or world space and writes it to the spawned child position buffer.

Units/functions improved:
- Unit: `main/pppVertexAp`
- Function: `pppVertexAp`

Progress evidence:
- `pppVertexAp` match percent: `94.97423%` -> `98.453606%` (`+3.479376`)
- Unit `.text` match percent: `95.17326%` -> `98.514854%`
- No data/linkage regressions were introduced.
- `ninja` rebuild passes after the change.

Plausibility rationale:
- This change makes `pppVertexAp` follow the same local-variable ordering and call pattern already present in the sibling vertex-ap particle implementations, instead of introducing contrived temporaries or hardcoded offsets.
- The resulting source reads more like coherent original engine code, with the child spawn path structured consistently across related particle behaviors.

Technical details:
- The remaining diff was concentrated in the two child-spawn branches. Matching the sibling layout moved the switch/branch shape and stack/register allocation much closer to the target without changing control flow semantics.
- Objdiff shows the key gain in the main symbol body rather than in formatting-only noise, which is why this is a net-positive step worth landing.