### PR TITLE
Improve pppRenderYmDeformationScreen codegen

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -246,9 +246,6 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 	YmDeformationScreenStep* step = (YmDeformationScreenStep*)param2;
 	float* work = (float*)((char*)param1 + 0x80 + ((YmDeformationScreenData*)param3)->m_serializedDataOffsets[2]);
 	int textureIndex = 0;
-	GXTexObj backTexObj;
-	Mtx rot;
-	float indMtx[2][3];
 	float depth;
 	float texU;
 	float texV;
@@ -265,10 +262,7 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 	_GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 1, 5, 1);
 	GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
 	GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_TEX1, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
-	color.rgba[0] = 0x40;
-	color.rgba[1] = 0x40;
-	color.rgba[2] = 0x40;
-	color.rgba[3] = 0x40;
+	*(u32*)color.rgba = 0x40404040;
 	pppSetBlendMode(0);
 	pppSetDrawEnv(&color, (pppFMATRIX*)0, 0.0f, (u8)0, (u8)0, (u8)0, (u8)0, (u8)1, (u8)1, (u8)0);
 	_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
@@ -320,59 +314,68 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 		*(short*)(work + 1) = 1;
 	}
 
-	PSMTXRotRad(rot, 'z', FLOAT_80330684 * (float)(*(short*)(work + 1)));
-	indMtx[0][0] = rot[0][0] * work[2];
-	indMtx[0][1] = rot[0][1] * work[2];
-	indMtx[0][2] = 0.0f;
-	indMtx[1][0] = rot[1][0] * work[2];
-	indMtx[1][1] = rot[1][1] * work[2];
-	indMtx[1][2] = 0.0f;
-	GXSetIndTexMtx(GX_ITM_0, indMtx, 1);
+	{
+		Mtx rot;
+		float indMtx[2][3];
+
+		PSMTXRotRad(rot, 'z', FLOAT_80330684 * (float)(*(short*)(work + 1)));
+		indMtx[0][0] = rot[0][0] * work[2];
+		indMtx[0][1] = rot[0][1] * work[2];
+		indMtx[0][2] = 0.0f;
+		indMtx[1][0] = rot[1][0] * work[2];
+		indMtx[1][1] = rot[1][1] * work[2];
+		indMtx[1][2] = 0.0f;
+		GXSetIndTexMtx(GX_ITM_0, indMtx, 1);
+	}
 
 	texU = (float)(0x280 / *(unsigned int*)(textureBase + 100));
 	texV = (float)(0x1C0 / *(unsigned int*)(textureBase + 0x68));
 
-	Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backTexObj, 0, 0, 640, 224, 0, GX_LINEAR, GX_TF_RGBA8, 0);
-	GXLoadTexObj(&backTexObj, GX_TEXMAP0);
-	GXLoadTexObj((GXTexObj*)(textureBase + 0x28), GX_TEXMAP1);
-	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-	GXPosition3f32(FLOAT_80330670, FLOAT_80330670, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
-	GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
-	GXPosition3f32(FLOAT_80330688, FLOAT_80330670, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_8033067C, FLOAT_80330670);
-	GXTexCoord2f32(texU, FLOAT_80330670);
-	GXPosition3f32(FLOAT_80330688, FLOAT_8033068C, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_8033067C, FLOAT_8033067C);
-	GXTexCoord2f32(texU, texV);
-	GXPosition3f32(FLOAT_80330670, FLOAT_8033068C, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_80330670, FLOAT_8033067C);
-	GXTexCoord2f32(FLOAT_80330670, texV);
+	{
+		GXTexObj backTexObj;
 
-	Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backTexObj, 0, 224, 640, 224, 0, GX_LINEAR, GX_TF_RGBA8, 0);
-	GXLoadTexObj(&backTexObj, GX_TEXMAP0);
-	depth = work[0];
-	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-	GXPosition3f32(FLOAT_80330670, FLOAT_8033068C, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
-	GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
-	GXPosition3f32(FLOAT_80330688, FLOAT_8033068C, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_8033067C, FLOAT_80330670);
-	GXTexCoord2f32(texU, FLOAT_80330670);
-	GXPosition3f32(FLOAT_80330688, FLOAT_80330690, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_8033067C, FLOAT_8033067C);
-	GXTexCoord2f32(texU, texV);
-	GXPosition3f32(FLOAT_80330670, FLOAT_80330690, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(FLOAT_80330670, FLOAT_8033067C);
-	GXTexCoord2f32(FLOAT_80330670, texV);
+		Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backTexObj, 0, 0, 640, 224, 0, GX_LINEAR, GX_TF_RGBA8, 0);
+		GXLoadTexObj(&backTexObj, GX_TEXMAP0);
+		GXLoadTexObj((GXTexObj*)(textureBase + 0x28), GX_TEXMAP1);
+		GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+		GXPosition3f32(FLOAT_80330670, FLOAT_80330670, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
+		GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
+		GXPosition3f32(FLOAT_80330688, FLOAT_80330670, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_8033067C, FLOAT_80330670);
+		GXTexCoord2f32(texU, FLOAT_80330670);
+		GXPosition3f32(FLOAT_80330688, FLOAT_8033068C, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_8033067C, FLOAT_8033067C);
+		GXTexCoord2f32(texU, texV);
+		GXPosition3f32(FLOAT_80330670, FLOAT_8033068C, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_80330670, FLOAT_8033067C);
+		GXTexCoord2f32(FLOAT_80330670, texV);
+
+		Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backTexObj, 0, 224, 640, 224, 0, GX_LINEAR, GX_TF_RGBA8, 0);
+		GXLoadTexObj(&backTexObj, GX_TEXMAP0);
+		depth = work[0];
+		GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+		GXPosition3f32(FLOAT_80330670, FLOAT_8033068C, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
+		GXTexCoord2f32(FLOAT_80330670, FLOAT_80330670);
+		GXPosition3f32(FLOAT_80330688, FLOAT_8033068C, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_8033067C, FLOAT_80330670);
+		GXTexCoord2f32(texU, FLOAT_80330670);
+		GXPosition3f32(FLOAT_80330688, FLOAT_80330690, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_8033067C, FLOAT_8033067C);
+		GXTexCoord2f32(texU, texV);
+		GXPosition3f32(FLOAT_80330670, FLOAT_80330690, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(FLOAT_80330670, FLOAT_8033067C);
+		GXTexCoord2f32(FLOAT_80330670, texV);
+	}
 
 	gUtil.EndQuadEnv();
 	DisableIndWarp(GX_TEVSTAGE1, GX_INDTEXSTAGE0);


### PR DESCRIPTION
## Summary
- Narrowed local lifetimes in `pppRenderYmDeformationScreen` so the rotation/indirect-matrix temporaries and scratch texture object are scoped to their actual use sites.
- Collapsed the constant overlay color initialization to a single 32-bit store, matching the compiler shape that produced the better render path codegen.

## Units/functions improved
- Unit: `main/pppYmDeformationScreen`
- Function: `pppRenderYmDeformationScreen`

## Progress evidence
- `pppRenderYmDeformationScreen`: `94.05237%` -> `94.05985%` match in `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationScreen -o - pppRenderYmDeformationScreen`.
- Unit `.text`: `95.72451%` -> `95.72987%`.
- `ninja` still completes successfully; displayed global progress is unchanged at repo-report precision.
- No code/data/linkage regressions were introduced outside this unit.

## Plausibility rationale
- This keeps the original control flow and rendering behavior intact and only tightens temporary lifetimes around the matrix setup and scratch texture capture.
- The packed color write is plausible original source for a fixed `0x40/0x40/0x40/0x40` overlay constant and, in practice, is what preserved the improved codegen.

## Technical details
- The remaining gap is still mostly stack layout and register allocation, but this patch nudges the compiler closer by letting local storage be reused between the indirect warp setup and back-buffer texture capture blocks.
