### PR TITLE
Improve system map-load data matching

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -77,6 +77,11 @@ CSystem::CSystem()
 void CSystem::Init()
 {
     CFile::CHandle* fileHandle;
+    CFile* file;
+    char* emptyString;
+    char* mapName;
+    char* stageName;
+    char* sourceName;
     int mapSize;
     int offset;
     int chunkSize;
@@ -115,6 +120,11 @@ void CSystem::Init()
     m_mapStage = (CStage*)0;
     m_mapBuffer = (void*)0;
     m_mapSize = 0;
+    stageName = const_cast<char*>(s_cSystem);
+    sourceName = const_cast<char*>(s_system_cpp);
+    mapName = const_cast<char*>(s_gamePalM_map);
+    emptyString = const_cast<char*>("");
+    file = &File;
 
     OSSetErrorHandler(0, (OSErrorHandler)errorHandler);
     OSSetErrorHandler(1, (OSErrorHandler)errorHandler);
@@ -128,13 +138,13 @@ void CSystem::Init()
 
     if (OSGetConsoleSimulatedMemSize() == 0x3000000)
     {
-        m_mapStage = (CStage*)Memory.CreateStage(0x400000, const_cast<char*>(s_cSystem), 1);
-        fileHandle = File.Open(const_cast<char*>(s_gamePalM_map), 0, CFile::PRI_LOW);
+        m_mapStage = (CStage*)Memory.CreateStage(0x400000, stageName, 1);
+        fileHandle = file->Open(mapName, 0, CFile::PRI_LOW);
         if (fileHandle != (CFile::CHandle*)0)
         {
-            mapSize = File.GetLength(fileHandle);
+            mapSize = file->GetLength(fileHandle);
             m_mapSize = mapSize;
-            m_mapBuffer = new ((CMemory::CStage*)m_mapStage, const_cast<char*>(s_system_cpp), 0x123) unsigned char[mapSize];
+            m_mapBuffer = new ((CMemory::CStage*)m_mapStage, sourceName, 0x123) unsigned char[mapSize];
             offset = 0;
             for (; mapSize != 0; mapSize -= chunkSize)
             {
@@ -146,14 +156,14 @@ void CSystem::Init()
 
                 fileHandle->m_chunkSize = chunkSize;
                 fileHandle->m_currentOffset = offset;
-                File.Read(fileHandle);
-                File.SyncCompleted(fileHandle);
-                memcpy((unsigned char*)m_mapBuffer + offset, File.m_readBuffer, chunkSize);
+                file->Read(fileHandle);
+                file->SyncCompleted(fileHandle);
+                memcpy((unsigned char*)m_mapBuffer + offset, file->m_readBuffer, chunkSize);
 
                 offset += chunkSize;
             }
-            File.Close(fileHandle);
-            Printf(const_cast<char*>(""));
+            file->Close(fileHandle);
+            Printf(emptyString);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reworked the `CSystem::Init` map-loading path to hoist the pooled string pointers and the `CFile` singleton into locals before the PAL map load block.
- Kept behavior unchanged while making the source shape closer to the original initialization flow for the map-stage setup and chunked read loop.

## Units/functions improved
- Unit: `main/system`
- Function touched: `Init__7CSystemFv`
- Source: `src/system.cpp`

## Progress evidence
- `ninja` still passes after the change.
- Overall matched data improved from `220975 / 1489807` to `221015 / 1489807` (`+40` bytes).
- Game matched data improved from `67484 / 139392` to `67524 / 139392` (`+40` bytes).
- `Init__7CSystemFv` text match stayed at `95.76168%`; this PR is a data-match improvement, not a code-match improvement.

## Plausibility rationale
- The change removes repeated singleton/string materialization inside the map-load block and replaces it with straightforward local aliases.
- That is plausible original source for a hand-written init routine and avoids match-only tricks such as fake externs, address-based names, or layout hacks.

## Technical details
- The map-load block now uses local `char*` aliases for `"CSystem"`, `"system.cpp"`, `"gamePalM.map"`, and the empty format string.
- The same block now uses a local `CFile*` alias for `File` when opening, sizing, reading, syncing, and closing the map file.
- Build verification: `ninja` completed successfully after the edit.
