### PR TITLE
Improve RedDriver SetWaveData match

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -2168,8 +2168,12 @@ void CRedDriver::SetWaveData(int slot, int waveID, void* waveData, int waveSize)
         RedSleep(0);
     }
 
-    DAT_8032daac.waveSize = waveSize;
     waveHeader = (char*)waveData;
+    DAT_8032daac.slot = slot;
+    DAT_8032daac.waveID = waveID;
+    DAT_8032daac.waveData = waveData;
+    DAT_8032daac.waveSize = waveSize;
+
     if (waveSize == -1) {
         if ((waveHeader[0] == 'W') && (waveHeader[1] == 'D')) {
             DAT_8032daac.waveSize = *(int*)(waveHeader + 4) +
@@ -2180,10 +2184,6 @@ void CRedDriver::SetWaveData(int slot, int waveID, void* waveData, int waveSize)
             DAT_8032daac.waveSize = 0;
         }
     }
-
-    DAT_8032daac.slot = slot;
-    DAT_8032daac.waveID = waveID;
-    DAT_8032daac.waveData = waveData;
     OSSignalSemaphore(&DAT_8032daa0);
 }
 


### PR DESCRIPTION
Summary:
Reordered the shared wave-setting state writes in `CRedDriver::SetWaveData` so `slot`, `waveID`, and `waveData` are stored before the `waveSize == -1` branch, matching the target write order more closely.

Units/functions improved:
- `main/RedSound/RedDriver`
- `SetWaveData__10CRedDriverFiiPvi`

Progress evidence:
- `SetWaveData__10CRedDriverFiiPvi`: `58.463768% -> 68.304344%` match at the same `276` byte symbol size
- `main/RedSound/RedDriver` `.text` fuzzy match: `84.529854% -> 84.75016%`
- No data or linkage regressions were introduced by this change
- `ninja` rebuild completed successfully after the edit

Plausibility rationale:
The new source preserves the existing logic and only changes the ordering of assignments into the wave-setting struct. That is a plausible original-source cleanup because the function naturally stages the request payload before conditionally recomputing `waveSize` from the wave header.

Technical details:
- Objdiff showed the target storing `slot`, `waveID`, and `waveData` into `DAT_8032daac` before branching on `waveSize == -1`
- Moving those assignments earlier reduced control-flow and store-order mismatches without resorting to symbol hacks, section tricks, or extern-based linkage shortcuts
- Verified with `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - SetWaveData__10CRedDriverFiiPvi` and a clean `ninja` rebuild