### PR TITLE
Improve RedDriver SetWaveData matching

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -2162,21 +2162,23 @@ void CRedDriver::ClearWaveBank(int param_1)
  */
 void CRedDriver::SetWaveData(int slot, int waveID, void* waveData, int waveSize)
 {
-    char* waveHeader;
+    while (true) {
+        if (DAT_8032f460 == 0) {
+            break;
+        }
 
-    while (DAT_8032f460 != 0) {
         RedSleep(0);
     }
 
     DAT_8032daac.waveSize = waveSize;
-    waveHeader = (char*)waveData;
     if (waveSize == -1) {
+        char* waveHeader = (char*)waveData;
+
         if ((waveHeader[0] == 'W') && (waveHeader[1] == 'D')) {
             DAT_8032daac.waveSize = *(int*)(waveHeader + 4) +
                                     (((*(int*)(waveHeader + 8) * 4) + 0x3fU) & 0xffffffc0) +
                                     (*(int*)(waveHeader + 0xc) * 0x60) + 0x20;
-        }
-        else {
+        } else {
             DAT_8032daac.waveSize = 0;
         }
     }


### PR DESCRIPTION
## Summary
Tighten `CRedDriver::SetWaveData` to follow the target control-flow and variable lifetime shape more closely.

## Units/functions improved
- Unit: `main/RedSound/RedDriver`
- Function: `SetWaveData__10CRedDriverFiiPvi`

## Progress evidence
- `SetWaveData__10CRedDriverFiiPvi`: `58.46%` -> `68.10%` fuzzy match
- Diff entries in objdiff for the function: `52` -> `45`
- Unit `.text` fuzzy match now reports `85.09%` in `build/GCCP01/report.json`
- No code/data/linkage regressions were introduced elsewhere in the unit; the repo still builds cleanly with `ninja`

## Plausibility rationale
The new source stays source-plausible: it makes the busy-wait explicit and narrows the wave-header pointer to the only path that parses header fields. That aligns with the target's branch structure and register lifetimes without adding hacks, hardcoded offsets, or fake linkage.

## Technical details
- Reworked the wait loop into an explicit break form so the compiler emits the same repeated sleep/check structure seen in objdiff
- Limited `waveHeader` to the `waveSize == -1` parsing path, which reduced unnecessary register pressure and improved the generated instruction sequence
- Verified with `build/tools/objdiff-cli diff -p . -u main/RedSound/RedDriver -o - SetWaveData__10CRedDriverFiiPvi` and a full `ninja` rebuild