### PR TITLE
Fix menu_arti animation entry layout

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -114,6 +114,7 @@ struct ArtiOpenAnim {
 	float v;
 	float alpha;
 	float scale;
+	int unk;
 	int tex;
 	int step;
 	int startFrame;


### PR DESCRIPTION
Summary:
- add the missing 32-bit slot after `ArtiOpenAnim::scale` in `src/menu_arti.cpp`
- this realigns `tex`, `step`, `startFrame`, `duration`, `flags`, and the motion fields with the offsets used by the menu artifact code

Units/functions improved:
- Unit: `main/menu_arti`
- `ArtiInit1__8CMenuPcsFv`: 45.15894% -> 45.271523%
- `ArtiClose__8CMenuPcsFv`: 74.31579% -> 74.46316%
- `ArtiOpen__8CMenuPcsFv`: unchanged at 64.87037%

Progress evidence:
- real code improvement in two functions from correcting field layout, with no code regressions in the checked neighboring animation path
- build still passes with `ninja`
- no extern hacks, section hacks, or flag tuning used

Plausibility rationale:
- the prior struct packed `tex` immediately after `scale`, but the surrounding raw offset code in `menu_arti.cpp` uses an additional 32-bit word before `tex`
- matching that layout is a source-plausible recovery step because it fixes the animation record shape rather than coercing control flow

Technical details:
- the artifact animation entries are 0x40 bytes each and the code treats the field after `scale` as a separate 32-bit slot before `tex`
- correcting the struct layout improves generated accesses in both initialization and close handling while leaving the open path stable