### PR TITLE
Improve CMath::DstRot clamp matching

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -10,6 +10,7 @@ extern "C" float kNegOneF;
 extern "C" double DOUBLE_8032F778;
 extern "C" float FLOAT_8032F780;
 extern "C" float FLOAT_8032F788;
+extern "C" float FLOAT_8032F748;
 extern "C" float FLOAT_8032F758;
 extern "C" float FLOAT_8032F75C;
 extern "C" float kRandSignedScaleF;
@@ -1119,10 +1120,12 @@ float CMath::DstRot(float from, float to)
     float clamped;
     if (dot < -1.0f) {
         clamped = -1.0f;
-    } else if (dot > 1.0f) {
-        clamped = 1.0f;
     } else {
-        clamped = dot;
+        if (FLOAT_8032F748 < dot) {
+            clamped = FLOAT_8032F748;
+        } else {
+            clamped = dot;
+        }
     }
 
     float angle = (float)acos((double)clamped);


### PR DESCRIPTION
Summary:
- declare `FLOAT_8032F748` in `src/math.cpp` and use it for the upper clamp in `CMath::DstRot`
- reshape the clamp path so the generated branch structure is closer to the target while preserving the existing trigonometric flow

Units/functions improved:
- `main/math`: `DstRot__5CMathFff` (`CMath::DstRot(float, float)`)

Progress evidence:
- objdiff for `DstRot__5CMathFff`: `95.08475% -> 95.169495%`
- mismatch count in the instruction stream: `17 -> 16`
- full `ninja` build still passes; coarse global progress counters are unchanged because this is a sub-byte local improvement inside an unmatched function

Plausibility rationale:
- the function is computing a clamped dot product before `acos`, so using the real `+1.0f` sdata symbol (`FLOAT_8032F748`) is plausible original source and not a compiler-coaxing hack
- the rewritten nested clamp keeps the code readable and reflects the target compare/branch order more directly

Technical details:
- the previous implementation used a literal `1.0f` upper bound in the `else if` branch
- switching to the known sdata constant and explicit nested clamp reduced one remaining mismatch in the clamp section without introducing regressions elsewhere