### PR TITLE
Improve LoadMenuPdt type usage

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -1278,19 +1278,20 @@ int CPartPcs::LoadMenuPdt(char* fileName)
     int pdtSlotIndex;
     char* language;
     int loaded;
-    void* stage;
+    CUSBStreamData* usbStream = &m_usbStreamData;
+    CMemory::CStage* stage;
     char path[256];
 
     language = GetLangString__5CGameFv(&Game);
     sprintf(path, s_dvd__smenu__s_801d7fb0, language, fileName);
 
     if (Game.m_gameWork.m_menuStageMode != 0) {
-        stage = *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xF4);
+        stage = *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xF4);
     } else {
-        stage = *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xEC);
+        stage = *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xEC);
     }
 
-    reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageLoad = stage;
+    usbStream->m_stageLoad = stage;
     SetRStage__13CAmemCacheSetFPQ27CMemory6CStage(&ppvAmemCacheSet, stage);
 
     *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(&PartMng) + 0x236F4) = 0;
@@ -1317,11 +1318,10 @@ int CPartPcs::LoadMenuPdt(char* fileName)
         }
     }
 
-    reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageLoad =
-        reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageDefault;
+    usbStream->m_stageLoad = usbStream->m_stageDefault;
     SetRStage__13CAmemCacheSetFPQ27CMemory6CStage(
         &ppvAmemCacheSet,
-        reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageDefault);
+        usbStream->m_stageDefault);
 
     return pdtSlotIndex;
 }


### PR DESCRIPTION
Summary:
- rewrite `CPartPcs::LoadMenuPdt` around the real `m_usbStreamData` member instead of repeated raw `this + 4` casts
- keep the menu-stage selection typed as `CMemory::CStage*` while preserving the existing control flow and load/release behavior

Units/functions improved:
- `main/p_tina`
- `LoadMenuPdt__8CPartPcsFPc`

Progress evidence:
- `LoadMenuPdt__8CPartPcsFPc` objdiff improved from `87.15306%` to `91.0102%`
- full project build remains clean; `ninja` completed successfully after the change
- no unrelated files changed

Plausibility rationale:
- this moves the function toward plausible original source by using the already-declared `CPartPcs::m_usbStreamData` member and a typed stage pointer, instead of anonymous pointer arithmetic
- the change does not introduce coercive temporaries, fake linkage, section hacks, or address-based symbol workarounds

Technical details:
- caching `&m_usbStreamData` changes the generated frame/register usage in a favorable way and reduces repeated raw casts
- using `CMemory::CStage*` for the selected menu stage better reflects how the rest of `p_tina` handles load/default stages
