### PR TITLE
p_tina: use typed USB stream state in LoadMenuPdt

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -1278,19 +1278,20 @@ int CPartPcs::LoadMenuPdt(char* fileName)
     int pdtSlotIndex;
     char* language;
     int loaded;
-    void* stage;
+    CUSBStreamData* usbStream = &m_usbStreamData;
+    CMemory::CStage* stage;
     char path[256];
 
     language = GetLangString__5CGameFv(&Game);
     sprintf(path, s_dvd__smenu__s_801d7fb0, language, fileName);
 
     if (Game.m_gameWork.m_menuStageMode != 0) {
-        stage = *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xF4);
+        stage = *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xF4);
     } else {
-        stage = *reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xEC);
+        stage = *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xEC);
     }
 
-    reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageLoad = stage;
+    usbStream->m_stageLoad = stage;
     SetRStage__13CAmemCacheSetFPQ27CMemory6CStage(&ppvAmemCacheSet, stage);
 
     *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(&PartMng) + 0x236F4) = 0;
@@ -1317,11 +1318,10 @@ int CPartPcs::LoadMenuPdt(char* fileName)
         }
     }
 
-    reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageLoad =
-        reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageDefault;
+    usbStream->m_stageLoad = usbStream->m_stageDefault;
     SetRStage__13CAmemCacheSetFPQ27CMemory6CStage(
         &ppvAmemCacheSet,
-        reinterpret_cast<CUSBStreamDataRaw*>(reinterpret_cast<char*>(this) + 4)->m_stageDefault);
+        usbStream->m_stageDefault);
 
     return pdtSlotIndex;
 }


### PR DESCRIPTION
Summary:
- replace raw `void*` stage handling in `CPartPcs::LoadMenuPdt` with typed `CMemory::CStage*` access
- reuse a typed `CUSBStreamData*` pointer instead of repeated raw `reinterpret_cast` writes to the USB stream state
- preserve the existing control flow while making the stage-load/stage-default updates use real members

Units/functions improved:
- Unit: `main/p_tina`
- Function: `LoadMenuPdt__8CPartPcsFPc`

Progress evidence:
- `LoadMenuPdt__8CPartPcsFPc`: `87.15306%` -> `91.0102%` match (`392` bytes)
- Baseline was measured by recompiling `origin/main`'s `src/p_tina.cpp` with the exact `p_tina.o` compiler invocation, then rebuilding the branch object and re-running objdiff
- `ninja` still completes successfully after the change

Plausibility rationale:
- the change replaces hard-coded offset writes with the typed USB stream state already implied by `CPartPcs`
- using a typed `CMemory::CStage*` for menu-stage selection is a source-plausible cleanup and better reflects the surrounding engine interfaces
- no compiler-coaxing temporaries, symbol hacks, or offset renaming were introduced

Technical details:
- the main codegen gain comes from loading/storing `m_stageLoad` and `m_stageDefault` through a single typed `CUSBStreamData*` base
- the menu stage pointer loads remain at the same offsets, but the typed pointer flow produces better register allocation around the stage handoff and restore path
- verified locally with `ninja` and `build/tools/objdiff-cli diff -p . -u main/p_tina -o - LoadMenuPdt__8CPartPcsFPc`