### PR TITLE
Improve astar polygon group matching

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -909,8 +909,8 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 {
 	unsigned int mask = m_hitAttributeMask;
-	CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 	CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
+	CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 	CMapCylinderRaw cyl;
 
 	cyl.m_top.x = kPolyGroupAabbMax;
@@ -949,8 +949,8 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 {
 	if ((AStar.m_flags & 1) == 0)
 	{
-		CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
+		CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CMapCylinderRaw cyl;
 
 		cyl.m_top.x = kPolyGroupAabbMax;
@@ -975,8 +975,8 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 	}
 	else
 	{
-		CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CVector top(pos->x, pos->y + kPolyGroupTopOffsetY, pos->z);
+		CVector base(kPolyGroupBaseX, kPolyGroupBaseY, kPolyGroupBaseZ);
 		CMapCylinderRaw cyl;
 
 		cyl.m_top.x = kPolyGroupAabbMax;


### PR DESCRIPTION
## Summary
- reorder the `CVector` temporaries in `CAStar::calcSpecialPolygonGroup` and both `CAStar::calcPolygonGroup` branches
- keep behavior unchanged while nudging stack layout and register allocation toward the original object code

## Units/functions improved
- Unit: `main/astar`
- `calcSpecialPolygonGroup__6CAStarFP3Vec`: `55.698414% -> 61.619050%` (`+5.920636`)
- `calcPolygonGroup__6CAStarFP3Veci`: `54.829060% -> 55.247864%` (`+0.418804`)

## Progress evidence
- `ninja` rebuild passes cleanly after the change
- No data/linkage regressions were introduced
- No accepted regressions in code match; both touched functions improved in objdiff

## Plausibility rationale
- This change only reorders local temporary declarations used to build the collision probe vectors
- The resulting C++ remains natural and source-plausible, with no hardcoded offsets, no extern hacks, and no compiler-coaxing control-flow changes

## Technical details
- The target assembly for these helpers is sensitive to temporary construction order
- Moving `top` ahead of `base` causes MWCC to lay out and materialize the `CVector` temporaries in a way that better matches the original stack/copy sequence used before `CheckHitCylinderNear`
