### PR TITLE
pppRain: use pooled texcoord literal in pppRenderRain

### DIFF
--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -7,7 +7,6 @@
 #include "ffcc/symbols_shared.h"
 #include "ffcc/util.h"
 #include "dolphin/gx.h"
-const float FLOAT_8033101c = 1.0f;
 const float FLOAT_80331020 = 3.0518509e-05f;
 const double DOUBLE_80331028 = 4503601774854144.0;
 static char s_pppRain_cpp_801DB610[] = "pppRain.cpp";
@@ -321,7 +320,7 @@ void pppRenderRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_D
     tex0 = kPppRainTexCoordBase;
     GXBegin((GXPrimitive)0xA8, GX_VTXFMT7, (u16)((param_2->m_dataValIndex & 0x7fff) << 1));
     tex0 = kPppRainTexCoordBase;
-    tex1 = FLOAT_8033101c;
+    tex1 = 1.0f;
     {
         RainDrop* currentDrop = drop;
         for (i = 0; i < (int)(u32)param_2->m_dataValIndex; i++, currentDrop++) {


### PR DESCRIPTION
Summary:
- replace the TU-local named `1.0f` constant in `pppRenderRain` with a direct `1.0f` literal
- drop the now-unused `FLOAT_8033101c` definition from `src/pppRain.cpp`

Units/functions improved:
- Unit: `main/pppRain`
- `pppRenderRain`: 97.40876% -> 99.58394%
- `pppFrameRain`: 86.41791% -> 89.23881%

Progress evidence:
- codegen improved in both rain functions after rebuilding `build/GCCP01/src/pppRain.o` and diffing with `build/tools/objdiff-cli diff -p . -u main/pppRain -o - <symbol>`
- no data or linkage hacks were introduced
- build passes with `ninja`

Plausibility rationale:
- using a plain `1.0f` literal for the second rain texcoord is more plausible original source than routing that value through a translation-unit-global named constant
- the change lets MWCC pool the float the way the target object expects without adding coercion variables, offset tricks, or other compiler-coaxing changes

Technical details:
- the previous code forced `pppRenderRain` to materialize `FLOAT_8033101c` as a named SDA load
- switching to the literal restores the pooled constant form used by the target object and also improves the neighboring `pppFrameRain` codegen in the same object file