### PR TITLE
Improve CGPrgObj target rotation helpers

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -432,9 +432,10 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float targetRot;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(m_worldPosition);
-	CVector deltaPos;
+	Vec deltaPos;
+	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	if (deltaPos.x == FLOAT_80331BD4 || deltaPos.z == FLOAT_80331BD4) {
 		targetRot = 0.0f;
 	} else {
@@ -457,14 +458,14 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 {
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(m_worldPosition);
-	CVector deltaPos;
+	Vec deltaPos;
 	float targetRot;
 	float deltaX;
 	float zero;
 	float deltaZ;
+	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos),
-	              reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
@@ -491,13 +492,13 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	float targetRot;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(self->m_worldPosition);
-	CVector deltaPos;
+	Vec deltaPos;
 	float deltaX;
 	float zero;
 	float deltaZ;
+	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos),
-	              reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;


### PR DESCRIPTION
Summary:
- switch the three `CGPrgObj` target-rotation helpers to use a plain `Vec` subtraction result and an explicit `Vec*` for the base temporary
- keep the existing control flow and math while tightening the temporary layout around `PSVECSubtract`

Units/functions improved:
- `main/prgobj`
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: `85.05556%` -> `85.30556%`
- `rotTarget__8CGPrgObjFP8CGPrgObj`: `84.17949%` -> `84.46154%`
- `dstTargetRot__8CGPrgObjFP8CGPrgObj`: `86.204544%` -> `86.454544%`

Progress evidence:
- unit `.text` match: `93.88935%` -> `93.93223%`
- `extab` stayed at `81.818184%`
- `ninja` still passes and reports `build/GCCP01/main.dol: OK` via the normal build verification flow

Plausibility rationale:
- these helpers conceptually subtract two world positions into a raw vector and then inspect that raw delta, so storing the subtraction result in `Vec` is a more natural source representation than materializing another `CVector` object
- the change removes unnecessary object semantics without introducing hardcoded offsets, fake linkage, or control-flow reshaping

Technical details:
- objdiff mismatches were concentrated around stack layout and temporary/register use after the `CVector` constructors
- changing only the subtraction output type and the base-pointer handoff improved all three functions at once, which is consistent with correcting the local temporary layout rather than gaming a single symbol