### PR TITLE
Fix CMapHit deleting destructor wrapper

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -212,6 +212,39 @@ CMapHit::~CMapHit()
 
 /*
  * --INFO--
+ * PAL Address: 0x80026d5c
+ * PAL Size: 144b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" CMapHit* dtor_80026D5C(CMapHit* mapHit, short shouldDelete)
+{
+    if (mapHit != 0) {
+        if (mapHit->m_vertices != 0) {
+            operator delete(mapHit->m_vertices);
+            mapHit->m_vertices = 0;
+        }
+
+        if (mapHit->m_faces != 0) {
+            delete[] mapHit->m_faces;
+            mapHit->m_faces = 0;
+        }
+
+        mapHit->m_vertexCount = 0;
+        mapHit->m_faceCount = 0;
+
+        if (shouldDelete > 0) {
+            operator delete(mapHit);
+        }
+    }
+
+    return mapHit;
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x800266f0
  * PAL Size: 1608b
  * EN Address: TODO


### PR DESCRIPTION
Summary:
- add the missing PAL deleting-destructor wrapper for `CMapHit` at `0x80026D5C`
- mirror the existing destructor cleanup path for vertices, faces, and count fields before conditionally freeing `this`

Units/functions improved:
- `main/maphit`
- `__dt__7CMapHitFv` / deleting-destructor wrapper `dtor_80026D5C`

Progress evidence:
- before: the deleting-destructor wrapper was not present in source, so the wrapper path in `maphit` was not recovered
- after: `build/tools/objdiff-cli diff -p . -u main/maphit -o - __dt__7CMapHitFv` reports `99.861115%` for `__dt__7CMapHitFv`
- accepted regressions: none
- verification: `ninja` passes after the change

Plausibility rationale:
- the wrapper follows the standard Metrowerks deleting-destructor pattern: run the object cleanup logic, then free `this` only when the destructor flag is positive
- cleanup uses the same member teardown already present in `CMapHit::~CMapHit()`, so this recovers source structure rather than introducing compiler-only shaping

Technical details:
- implemented the wrapper as `extern "C" CMapHit* dtor_80026D5C(CMapHit* mapHit, short shouldDelete)` in `src/maphit.cpp`
- kept the object cleanup explicit and reset members after freeing owned allocations to match the existing destructor semantics