### PR TITLE
Refine pppRenderYmMelt quad color emission

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -408,10 +408,7 @@ void pppRenderYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offs
             Vec vtx3;
             float u0 = uvMin.x + (f32)x * uStep;
             float u1 = uvMin.x + (f32)(x + 1) * uStep;
-            float c0 = drawColor;
-            float c1 = drawColor;
-            float c2 = drawColor;
-            float c3 = drawColor;
+            float colorValue;
 
             pppCopyVector(vtx0, p0Data->m_position);
             pppCopyVector(vtx1, p1Data->m_position);
@@ -434,30 +431,36 @@ void pppRenderYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offs
                 vtx3.z = phaseLerp * (worldZ - vtx3.z) + vtx3.z;
             }
 
+            colorValue = drawColor;
             if (p0Data->m_color.m_bytes[3] == 0) {
-                c0 = p0Data->m_color.m_colorValue;
+                colorValue = p0Data->m_color.m_colorValue;
             }
-            if (p1Data->m_color.m_bytes[3] == 0) {
-                c1 = p1Data->m_color.m_colorValue;
-            }
-            if (p2Data->m_color.m_bytes[3] == 0) {
-                c2 = p2Data->m_color.m_colorValue;
-            }
-            if (p3Data->m_color.m_bytes[3] == 0) {
-                c3 = p3Data->m_color.m_colorValue;
-            }
-
             GXPosition3f32(vtx0.x, vtx0.y, vtx0.z);
-            GXColor1u32(*(u32*)&c0);
+            GXColor1u32(*(u32*)&colorValue);
             GXTexCoord2f32(u0, v1);
+
+            colorValue = drawColor;
+            if (p1Data->m_color.m_bytes[3] == 0) {
+                colorValue = p1Data->m_color.m_colorValue;
+            }
             GXPosition3f32(vtx1.x, vtx1.y, vtx1.z);
-            GXColor1u32(*(u32*)&c1);
+            GXColor1u32(*(u32*)&colorValue);
             GXTexCoord2f32(u0, v0);
+
+            colorValue = drawColor;
+            if (p2Data->m_color.m_bytes[3] == 0) {
+                colorValue = p2Data->m_color.m_colorValue;
+            }
             GXPosition3f32(vtx2.x, vtx2.y, vtx2.z);
-            GXColor1u32(*(u32*)&c2);
+            GXColor1u32(*(u32*)&colorValue);
             GXTexCoord2f32(u1, v0);
+
+            colorValue = drawColor;
+            if (p3Data->m_color.m_bytes[3] == 0) {
+                colorValue = p3Data->m_color.m_colorValue;
+            }
             GXPosition3f32(vtx3.x, vtx3.y, vtx3.z);
-            GXColor1u32(*(u32*)&c3);
+            GXColor1u32(*(u32*)&colorValue);
             GXTexCoord2f32(u1, v1);
             x++;
         }


### PR DESCRIPTION
Summary:
- rewrite the per-quad color emission in `pppRenderYmMelt` to reuse a single color temporary and emit each vertex color immediately before its GX write
- keep the existing control flow and data access intact while aligning the ordering of color selection and GX submission more closely with the original routine

Units/functions improved:
- `main/pppYmMelt`
- `pppRenderYmMelt`

Progress evidence:
- unit `.text` match: 72.64541% -> 72.66582%
- `pppRenderYmMelt`: 63.701633% -> 63.738926%
- build still passes with `ninja`
- no data/linkage hacks were introduced; extab was not targeted

Plausibility rationale:
- this change removes four parallel color temporaries in favor of the more natural pattern of choosing a vertex color and immediately submitting it
- the resulting code is simpler and matches the surrounding GX emission style better than the previous batched temporary setup

Technical details:
- objdiff improvement came from tightening the render loop around the per-vertex color path without changing texture lookup, UV stepping, or matrix/phase handling
- verified with `build/tools/objdiff-cli diff -p . -u main/pppYmMelt -o - pppRenderYmMelt` and `ninja`