### PR TITLE
Improve pppFrameYmMoveCircle constant matching

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -118,14 +118,15 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
     }
 
     {
-        f32 tableAngle = (32768.0f * (0.017453292f * work->m_angle)) / 3.1415927f;
+        f32 tableAngle =
+            (gPppYmMoveCircleAngleToTableScale * (gPppYmMoveCircleAngleScale * work->m_angle)) / gPppYmMoveCircleTableDivisor;
         tableIndex = (s32)tableAngle;
     }
     sinAngle = *(f32*)((u8*)gPppTrigTable + (tableIndex & 0xFFFC));
     cosAngle = *(f32*)((u8*)gPppTrigTable + ((tableIndex + 0x4000) & 0xFFFC));
     radiusX = work->m_radius * cosAngle;
     radiusZ = work->m_radius * -sinAngle;
-    nextPos.y = 0.0f;
+    nextPos.y = gPppYmMoveCircleZero;
     nextPos.x = radiusX;
     nextPos.z = radiusZ;
     nextPos.x += work->m_center.x;


### PR DESCRIPTION
Summary:
- replace the angle-to-trig-table conversion literals in `pppFrameYmMoveCircle` with the unit's named `gPppYmMoveCircle*` constants
- use `gPppYmMoveCircleZero` for the transient Y initialization so the function reuses the same constant materialization path

Units/functions improved:
- `main/pppYmMoveCircle`
- `pppFrameYmMoveCircle`

Progress evidence:
- `build/GCCP01/report.json` unit fuzzy match: `97.102325%` -> `98.288376%`
- `build/GCCP01/report.json` function fuzzy match: `95.55%` -> `97.37143%`
- `objdiff-cli` `.text` match for `pppFrameYmMoveCircle`: `98.0093%` -> `98.032555%`
- `objdiff-cli` symbol match for `pppFrameYmMoveCircle`: `97.15714%` -> `97.192856%`
- no data/linkage regressions introduced; extab remains unchanged and was not targeted

Plausibility rationale:
- these constants already exist as named globals for this exact particle routine, so using them is more plausible original source than restating the same values as ad hoc literals
- the change improves the compiler's constant selection without adding control-flow tricks, hardcoded addresses, or extern/linkage hacks

Technical details:
- the previous implementation mixed raw literals with the `pppYmMoveCircle` constant set, which produced slightly worse materialization around the trig-table angle conversion
- routing both the conversion expression and zero initialization through the existing globals tightened the generated code while keeping the logic unchanged