### PR TITLE
Improve LoadFieldPdt0 match in p_tina

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -1129,15 +1129,13 @@ unsigned int CPartPcs::IsLoadPartCompleted()
  */
 void LoadFieldPdt0(int mapId, int floorId)
 {
-    CPartMngState* loadState = GetPartMngState();
-    PppPdtSlotRaw* pdtSlots = GetPartMngPdtSlots();
     int pdtSlot;
     char path[1024];
 
     DAT_8032ed3c = 0;
     DAT_8032ed38 = 0;
 
-    if (loadState->m_partLoadMode != 3) {
+    if (GetPartMngState()->m_partLoadMode != 3) {
         pppReleasePdt__8CPartMngFi(&PartMng, 0);
         pppReleasePdt__8CPartMngFi(&PartMng, 6);
         pppReleasePdt__8CPartMngFi(&PartMng, 7);
@@ -1151,17 +1149,18 @@ void LoadFieldPdt0(int mapId, int floorId)
     pdtSlot = pppLoadPtx__8CPartMngFPCciiPvi(&PartMng, path, 0, 1, 0, 0);
     if (pdtSlot != 0) {
         pdtSlot = pppLoadPdt__8CPartMngFPCciiPvi(&PartMng, path, 0, 1, 0, 0);
-        if ((pdtSlot != 0) && (loadState->m_partLoadMode != 2) && (loadState->m_partLoadMode != 3)) {
+        if ((pdtSlot != 0) && (GetPartMngState()->m_partLoadMode != 2) && (GetPartMngState()->m_partLoadMode != 3)) {
             _pppDataHead* pppDataHead;
             PPPCREATEPARAM* createParam;
             int checkOff;
             int i;
 
-            pppDataHead = pdtSlots[0].m_pppDataHead;
+            pppDataHead = GetPartMngPdtSlots()[0].m_pppDataHead;
             createParam = PartMng.pppGetDefaultCreateParam();
             checkOff = 0;
             for (i = 0; i < static_cast<int>((unsigned int)pppDataHead->m_partCount); i++) {
-                if (*reinterpret_cast<int*>(&pdtSlots[0].m_pppDataHead[2].m_shapeGroupCount + checkOff) != -0x1000) {
+                if (*reinterpret_cast<int*>(&GetPartMngPdtSlots()[0].m_pppDataHead[2].m_shapeGroupCount + checkOff) !=
+                    -0x1000) {
                     pppCreate__8CPartMngFiiP14PPPCREATEPARAMi(&PartMng, 0, i, createParam, 0);
                 }
                 checkOff += 0x60;


### PR DESCRIPTION
## Summary
- remove long-lived `loadState` and `pdtSlots` locals from `LoadFieldPdt0`
- read the load-mode and PDT slot state through the existing helpers at the use sites instead
- keep the control flow and data accesses otherwise unchanged

## Units/functions improved
- Unit: `main/p_tina`
- Function: `LoadFieldPdt0__Fii` (400 bytes)

## Progress evidence
- `LoadFieldPdt0__Fii` objdiff match improved from `88.49%` to `93.94%`
- Remaining instruction mismatches dropped to `8`
- `main/p_tina` selector baseline was `85.7%` code / `0.60%` data; after rebuild the generated report shows `85.99528%` fuzzy match for the unit
- Full PAL build passes with `ninja`

## Plausibility rationale
- This change does not introduce compiler coaxing or new hacks; it shortens the lifetime of cached `PartMng`-derived pointers so the source more closely reflects direct state access the original code likely used
- The behavior is unchanged: the same load-mode checks, PDT slot reads, and create loop remain in place

## Technical details
- The previous version kept `GetPartMngState()` and `GetPartMngPdtSlots()` results alive across the whole function, which produced extra register pressure and a less accurate register/allocation shape
- Replacing those long-lived locals with direct use-site accesses moved the function substantially closer to the target without affecting surrounding logic
