### PR TITLE
Recover AXCL trailing sbss slot

### DIFF
--- a/src/ax/AXCL.c
+++ b/src/ax/AXCL.c
@@ -10,6 +10,7 @@ static u16* __AXClWrite;
 static u32 __AXCommandListCycles;
 static u32 __AXCompressor;
 u32 __AXClMode;
+u32 gap_04_8032F23C_sbss;
 
 u32 __AXGetCommandListCycles(void) {
     return __AXCommandListCycles;


### PR DESCRIPTION
Summary:
- add the missing trailing 4-byte AXCL `.sbss` object so the unit layout matches the target
- keep the change scoped to `src/ax/AXCL.c` with no codegen changes

Units/functions improved:
- `main/ax/AXCL`
- functions were already 100%; this change fixes the remaining data/layout mismatch

Progress evidence:
- before: `.text` 100.0%, `.bss` 100.0%, `.sbss` 90.9091%
- after: `.text` 100.0%, `.bss` 100.0%, `.sbss` 100.0%
- `ninja` succeeds and `build/GCCP01/main.dol: OK`

Plausibility rationale:
- the missing storage already exists in `config/GCCP01/symbols.txt` as a 4-byte `.sbss` object at `0x8032F23C`
- this PR restores that object directly instead of using any code-shaping hacks or extern-based score inflation

Technical details:
- `build/GCCP01/asm/ax/AXCL.s` shows a trailing `.sbss` entry after `__AXClMode`
- adding the 4-byte object in AXCL restores the original small-data layout and clears the last unit mismatch