### PR TITLE
Fix RedExecute PitchCompute linkage signature

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -41,7 +41,7 @@ u8 GetRandomData()
  * JP Address: TODO
  * JP Size: TODO
  */
-int PitchCompute(int param_1, int param_2, int param_3, u32 param_4)
+int PitchCompute(int param_1, int param_2, int param_3, int param_4)
 {
     u32 pitch;
     int octaveAdjust;


### PR DESCRIPTION
Summary:
- change `PitchCompute()`'s fourth parameter from `u32` to `int` so the definition matches the existing declaration and call sites
- restore the correct Metrowerks mangled symbol for the helper in `main/RedSound/RedExecute`

Units/functions improved:
- Unit: `main/RedSound/RedExecute`
- Function touched: `PitchCompute__Fiiii`

Progress evidence:
- `ninja` passes cleanly
- before this change, `build/GCCP01/src/RedSound/RedExecute.o` defined `PitchCompute__FiiiUl` and left `PitchCompute__Fiiii` unresolved
- after this change, the object defines `PitchCompute__Fiiii`
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedExecute -o - PitchCompute__Fiiii` now reports `23.90625%` for the correct target symbol
- accepted regressions: none

Plausibility rationale:
- the header already declared `PitchCompute(int, int, int, int)`, and the function body performs signed comparisons on the fourth argument, so the unsigned definition was not plausible original source
- this is a real linkage/type correction, not a compiler coaxing change or an extern hack

Technical details:
- the wrong `u32` parameter emitted `PitchCompute__FiiiUl`, which blocked direct matching against the target `PitchCompute__Fiiii`
- fixing the signature aligns the definition, declaration, and call sites on the same ABI surface, allowing objdiff to score the actual function body