### PR TITLE
Improve pppYmBreath control layout matching

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -32,10 +32,10 @@ struct pppYmBreathUnkC {
 struct YmBreathRenderStep {
     int m_graphId;
     int m_dataValIndex;
-    unsigned short m_initWork;
-    unsigned short m_stepValue;
+    int m_initWork;
+    int m_stepValue;
     int m_arg3;
-    unsigned char* m_payload;
+    unsigned char m_payload[1];
 };
 
 struct YmBreathParticleGroup {
@@ -80,6 +80,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     float spread;
     unsigned char flags;
 
+    spread = (float)(unsigned int)*(unsigned char*)(breath + 0x28);
     memset(particle + 0x30, 0, 0x60);
     if (particleWmat != NULL) {
         memset(particleWmat, 0, 0x30);
@@ -88,7 +89,6 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         memset(particleColor, 0, 0x20);
     }
 
-    spread = (float)(unsigned int)*(unsigned char*)(breath + 0x28);
     baseDir.x = 0.0f;
     baseDir.y = 0.0f;
     baseDir.z = -1.0f;
@@ -509,6 +509,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     int colorOffset;
     int* dataOffsets;
     unsigned char* work;
+    VColor* color;
     int* groupData;
     Mtx* particleWMat;
     Mtx* particleMtx;
@@ -536,6 +537,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     dataOffsets = offsets->m_serializedDataOffsets;
     colorOffset = dataOffsets[1];
     work = reinterpret_cast<unsigned char*>(ymBreath) + 0x80 + dataOffsets[0];
+    color = (VColor*)(reinterpret_cast<unsigned char*>(ymBreath) + 0x80 + colorOffset);
 
     if (*(void**)(work + 0x30) == NULL) {
         int maxParticleCount = (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x1E);
@@ -544,8 +546,8 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
         int* groupTable;
 
         *(int*)(work + 0x40) = maxParticleCount;
-        *(short*)(work + 0x54) = *(short*)((unsigned char*)pYmBreath + 0x14);
         *(short*)(work + 0x56) = *(short*)((unsigned char*)pYmBreath + 0x12);
+        *(short*)(work + 0x54) = *(short*)((unsigned char*)pYmBreath + 0x14);
 
         *(void**)(work + 0x30) =
             pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(maxParticleCount * 0x98), pppEnvStPtr->m_stagePtr,
@@ -595,15 +597,14 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     }
 
     PSMTXCopy(pppMngStPtr->m_matrix.value, *(Mtx*)work);
-    UpdateAllParticle(reinterpret_cast<_pppPObject*>(ymBreath), (VYmBreath*)work, pYmBreath,
-                      (VColor*)(reinterpret_cast<unsigned char*>(ymBreath) + 0x80 + colorOffset));
+    UpdateAllParticle(reinterpret_cast<_pppPObject*>(ymBreath), (VYmBreath*)work, pYmBreath, color);
 
     particleWMat = *(Mtx**)(work + 0x34);
     groupData = *(int**)(work + 0x3C);
     for (groupIndex = 0; groupIndex < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14);
          groupIndex++) {
         slotCount = (unsigned int)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
-        groupTable = *(int*)(work + 0x3C) + groupIndex * 0x5C;
+        groupTable = (int)groupData;
         for (slotIndex = 0; slotIndex < (int)slotCount; slotIndex++) {
             if ((*(signed char*)(*(int*)(groupTable + 4) + slotIndex) == -1) ||
                 (*(signed char*)(*(int*)(groupTable + 8) + slotIndex) != 1)) {
@@ -683,7 +684,7 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
     groupData = *(int**)(reinterpret_cast<unsigned char*>(ymBreath) + 8 + workOffset + 0x3C);
     groupCount = *(int*)(reinterpret_cast<unsigned char*>(ymBreath) + 8 + workOffset + 0x40);
 
-    if (step->m_stepValue == 0) {
+    if (step->m_stepValue == 0xFFFF) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- correct `YmBreathRenderStep` to use 32-bit control fields with inline payload bytes instead of a payload pointer
- treat `0xFFFF` as the invalid render-step sentinel in `pppRenderYmBreath`
- align a few `pppYmBreath` local accesses/orderings with the object’s existing register flow

## Units/functions improved
- Unit: `main/pppYmBreath`
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: `68.15949% -> 72.14430%`
- `pppFrameYmBreath`: `77.46519% -> 79.31645%`
- `pppRenderYmBreath`: `82.97214% -> 85.47987%`

## Progress evidence
- `pppYmBreath.o` `.text`: `80.59963% -> 82.43688%`
- `ninja` still passes after the change
- no data/linkage regressions were introduced in this unit; this is a code-match improvement driven by control-layout cleanup

## Plausibility rationale
- nearby effect code uses 32-bit step/control values with `0xFFFF` sentinels, so the old mixed `u16`/pointer layout for `YmBreathRenderStep` was not consistent with surrounding source patterns
- treating the payload as inline bytes matches how the function actually reads the step block and avoids an implausible extra level of indirection
- the remaining local cleanups only remove redundant recomputation and better reflect the existing source style in analogous particle units

## Technical details
- the main gain came from matching the render-step memory layout to the assembly’s access pattern: fixed-width control words followed by inline payload bytes
- after that layout correction, `pppRenderYmBreath`, `pppFrameYmBreath`, and `BirthParticle` all improved within the same object
