### PR TITLE
Improve CPartPcs::LoadMenuPdt match

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -1274,18 +1274,17 @@ int CPartPcs::LoadMonsterPdt(int monsterId, int variant, void* pdtData, int pdtC
  */
 int CPartPcs::LoadMenuPdt(char* fileName)
 {
-    char* language;
     int pdtSlotIndex;
     int loaded;
     CMemory::CStage* stage;
-    char path[256];
+    char path[0x108];
 
-    language = GetLangString__5CGameFv(&Game);
-    sprintf(path, s_dvd__smenu__s_801d7fb0, language, fileName);
+    sprintf(path, s_dvd__smenu__s_801d7fb0, GetLangString__5CGameFv(&Game), fileName);
 
-    stage = reinterpret_cast<CMemory::CStage*>(*reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xEC));
     if (Game.m_gameWork.m_menuStageMode != 0) {
         stage = reinterpret_cast<CMemory::CStage*>(*reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xF4));
+    } else {
+        stage = reinterpret_cast<CMemory::CStage*>(*reinterpret_cast<void**>(reinterpret_cast<unsigned char*>(&MenuPcs) + 0xEC));
     }
 
     m_usbStreamData.m_stageLoad = stage;


### PR DESCRIPTION
Summary:
- tighten `CPartPcs::LoadMenuPdt` to better match the original stack and control-flow shape
- inline the language fetch into `sprintf`, grow the local path buffer to `0x108`, and use an explicit menu-stage `if/else`

Units/functions improved:
- `main/p_tina`: `LoadMenuPdt__8CPartPcsFPc`

Progress evidence:
- `LoadMenuPdt__8CPartPcsFPc`: `88.255104%` -> `95.37755%` code match by `objdiff`
- no data or linkage regressions in this unit
- full `ninja` build passes after the change

Plausibility rationale:
- the new source removes an unnecessary temporary, uses the full local buffer size implied by the stack frame, and expresses the menu-stage selection as normal `if/else` logic rather than compiler-coaxing
- the change keeps the existing semantics while moving the function closer to a plausible original implementation

Technical details:
- the remaining mismatch had been clustered around the prologue, `sprintf` setup, and menu-stage selection
- matching the path buffer size to the observed frame and reshaping the branch reduced those setup diffs substantially
- verified with `build/tools/objdiff-cli diff -p . -u main/p_tina -o - LoadMenuPdt__8CPartPcsFPc` and a full rebuild