### PR TITLE
Match InitMetroTRK success branch

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -101,7 +101,6 @@ asm void InitMetroTRK()
 	blr
 initCommTableSuccess:
 	b TRK_main //Jump to TRK_main
-	blr
 #endif // clang-format on
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable `blr` after the success-path branch to `TRK_main` in `InitMetroTRK`
- keep the asm stub aligned with the original control flow for the TRK startup handoff

## Evidence
- `InitMetroTRK` objdiff improved from `97.297295%` to `100.0%`
- `main/TRK_MINNOW_DOLPHIN/dolphin_trk` `.text` is `100.0%` matched
- `ninja` rebuilt through `main.dol`; the final SHA-1 check still fails as expected for an incompletely matched decomp

## Why This Is Plausible
- the deleted instruction was unreachable after an unconditional branch
- removing dead control flow makes the startup stub more consistent with the original source and the recovered control-flow shape