### PR TITLE
Match InitMetroTRK tail flow

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -101,7 +101,6 @@ asm void InitMetroTRK()
 	blr
 initCommTableSuccess:
 	b TRK_main //Jump to TRK_main
-	blr
 #endif // clang-format on
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable trailing `blr` after the tail branch to `TRK_main` in `InitMetroTRK`
- leave `InitMetroTRK_BBA` unchanged, since its tail already matched

## Evidence
- before: `InitMetroTRK` matched at 97.3% with a single inserted trailing `blr`
- after: `InitMetroTRK` matches at 100.0%
- unit status after change: `.init` 100.0%, `.text` 100.0%, `.data` 100.0%, `.bss` 100.0%

## Plausibility
- this removes unreachable tail code from the non-BBA startup path
- the change aligns the function tail with the linked binary without introducing new declarations, fake symbols, or compiler-forcing hacks

## Build
- `ninja -j1` rebuilds successfully through link; the final SHA1 check still fails as expected for a non-fully-matching build tree