### PR TITLE
Improve pppFrameYmMelt loop codegen

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -249,6 +249,7 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
     YmMeltVertex* rowVertex;
     float matrixY;
     float halfWidth;
+    float minCoord;
     float step;
     float rot;
     float x;
@@ -276,14 +277,15 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
         phaseWork = *(s16*)((u8*)&ctrl->m_arg3 + 2);
         work->m_phaseOffset = angleSeed - angleSeed / phaseWork * phaseWork;
         halfWidth = ctrl->m_stepValue * FLOAT_80330b08;
+        minCoord = -halfWidth;
         phaseWork = work->m_phaseOffset;
         step = ctrl->m_stepValue / (f32)*(u16*)((u8*)&ctrl->m_initWOrk + 2);
         rot = FLOAT_80330b0c * (f32)phaseWork;
         vertex = vertexBase;
 
-        for (z = -halfWidth; z <= halfWidth; z += step) {
+        for (z = minCoord; z <= halfWidth; z += step) {
             rowVertex = vertex;
-            for (x = -halfWidth; x <= halfWidth; x += step) {
+            for (x = minCoord; x <= halfWidth; x += step) {
                 rowVertex->m_position.x = x;
                 rowVertex->m_position.y = kPppYmMeltZero;
                 rowVertex->m_position.z = z;


### PR DESCRIPTION
## Summary
- split the shared negative loop bound in `pppFrameYmMelt` into a named local instead of recomputing `-halfWidth` in both loop headers
- keep the control flow and data flow identical while nudging MWCC back toward the original register/loop setup

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMelt -o - | jq -r .left.symbols[] | select(.name=="pppFrameYmMelt") | .match_percent`
- `pppFrameYmMelt`: `82.61176% -> 98.97059%`

## Why this is plausible source
- the change is a normal source-level refactor of a reused loop bound, not compiler coaxing through fake symbols, casts, or section tricks
- behavior stays the same while the generated loop structure aligns much more closely with the original object