### PR TITLE
Match CTexAnimSet destructor helper call

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -45,6 +45,7 @@ extern "C" void* __vt__11CTexAnimSeq[];
 extern "C" void* __vt__Q28CTexAnim8CRefData[];
 extern "C" void __ct__21CPtrArray_P8CTexAnim_Fv(void*);
 extern "C" void __ct__25CPtrArray_P11CTexAnimSeq_Fv(void*);
+extern "C" void __dt__21CPtrArray_P8CTexAnim_Fv(void*, int);
 extern "C" void __dt__25CPtrArray_P11CTexAnimSeq_Fv(void*, int);
 extern "C" {
 char s_texanim_cpp_801d7adc[] = "texanim.cpp";
@@ -613,7 +614,7 @@ CTexAnimSet::~CTexAnimSet()
 
     self->vtable = __vt__11CTexAnimSet;
     self->texAnims.ReleaseAndRemoveAll();
-    self->texAnims.~CPtrArray<CTexAnim*>();
+    __dt__21CPtrArray_P8CTexAnim_Fv(&self->texAnims, -1);
     __dt__4CRefFv(this, 0);
 }
 #pragma dont_inline reset


### PR DESCRIPTION
## Summary
- switch `CTexAnimSet::~CTexAnimSet()` to call the explicit `__dt__21CPtrArray_P8CTexAnim_Fv` helper after `ReleaseAndRemoveAll()`
- keep the destructor flow aligned with the existing `CTexAnim::CRefData` teardown pattern in this unit
- avoid broader `texanim` churn now that this helper-call mismatch is resolved cleanly

## Evidence
- `__dt__11CTexAnimSetFv`: `88.0%` -> `99.833336%`
- `main/texanim` `.text`: `81.9844%` -> `82.343994%`
- `ninja`: passes

## Plausibility
This change replaces a C++ template-destructor syntax call with the concrete helper dtor symbol already used elsewhere in the unit, which is a more coherent representation of the original source and ABI-level teardown path.
