### PR TITLE
Match InitMetroTRK symbol boundary

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -101,7 +101,6 @@ asm void InitMetroTRK()
 	blr
 initCommTableSuccess:
 	b TRK_main //Jump to TRK_main
-	blr
 #endif // clang-format on
 }
 


### PR DESCRIPTION
What changed
- Remove the unreachable trailing `blr` after the `b TRK_main` branch in `InitMetroTRK`
- Leave `InitMetroTRK_BBA` unchanged, since it already matched

What improved
- `InitMetroTRK`: 97.297295% -> 100.0% match
- `main/TRK_MINNOW_DOLPHIN/dolphin_trk` `.text`: 99.74874% -> 100.0% match

Evidence
- Before: `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - InitMetroTRK` reported a trailing `DIFF_INSERT`
- After: the same diff reports `InitMetroTRK` at 100.0%, and the unit text section is fully matched

Why this is plausible source
- The deleted instruction was unreachable after an unconditional branch to `TRK_main`
- The change only adjusts the symbol boundary of the hand-written asm and does not alter runtime behavior