### PR TITLE
Improve FunnyShape viewer spinner state

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -76,8 +76,11 @@ void CopyFunnyShapePcsTable()
 extern "C" CPtrArray<OSFS_TEXTURE_ST*>* dtor_8004EAD0(CPtrArray<OSFS_TEXTURE_ST*>* ptrArray, short shouldDelete);
 extern "C" CUSBStreamData* __dt__14CUSBStreamDataFv(CUSBStreamData* self, short shouldDelete);
 static const char s_CFunnyShapePcs[] = "CFunnyShapePcs";
-static char* s_spinner = const_cast<char*>("|/-\\");
-static int frameCount;
+static const char s_funnyShapeSpinnerText[] = "|/-\\";
+char* gFunnyShapeSpinnerText = 0;
+unsigned char gFunnyShapeSpinnerTextInitialized = 0;
+int gFunnyShapeSpinnerFrame = 0;
+unsigned char gFunnyShapeSpinnerFrameInitialized = 0;
 
 namespace {
 static inline u8* Ptr(CFunnyShapePcs* self, u32 offset)
@@ -362,6 +365,7 @@ void CFunnyShapePcs::calcViewer()
  */
 void CFunnyShapePcs::drawViewer()
 {
+    int frameSign;
     Mtx44 ortho;
     Mtx view;
     Vec eye = {0.0f, 0.0f, 0.0f};
@@ -390,13 +394,26 @@ void CFunnyShapePcs::drawViewer()
         FunnyShape(this)->Render();
     }
 
-    frameCount++;
-    if (frameCount > 100000) {
-        frameCount = 0;
+    if (gFunnyShapeSpinnerTextInitialized == 0) {
+        gFunnyShapeSpinnerText = const_cast<char*>(s_funnyShapeSpinnerText);
+        gFunnyShapeSpinnerTextInitialized = 1;
+    }
+    if (gFunnyShapeSpinnerFrameInitialized == 0) {
+        gFunnyShapeSpinnerFrame = 0;
+        gFunnyShapeSpinnerFrameInitialized = 1;
     }
 
+    gFunnyShapeSpinnerFrame++;
+    if (gFunnyShapeSpinnerFrame > 100000) {
+        gFunnyShapeSpinnerFrame = 0;
+    }
+
+    frameSign = gFunnyShapeSpinnerFrame >> 31;
     GXSetViewport(kFunnyShapeViewportOrigin, kFunnyShapeViewportOrigin, kFunnyShapeViewportWidth, kFunnyShapeViewportHeight, kFunnyShapeViewportOrigin, kFunnyShapeNdcMax);
-    Graphic.Printf(const_cast<char*>(s_funnyShapeFmt), s_spinner[(frameCount >> 4) % 4]);
+    Graphic.Printf(const_cast<char*>(s_funnyShapeFmt),
+                   gFunnyShapeSpinnerText[(frameSign * 4 |
+                                           static_cast<unsigned int>((gFunnyShapeSpinnerFrame >> 4) * 0x40000000 + frameSign) >> 30) -
+                                          frameSign]);
 }
 
 /*


### PR DESCRIPTION
## Summary
- switch `CFunnyShapePcs::drawViewer()` from directly initialized file-scope spinner state to explicit lazy-initialized globals
- keep the viewer spinner logic in source while matching the PAL build's `@sda21` state pattern more closely
- preserve the rest of the viewer rendering path and full PAL build output

## Improved symbols
- `drawViewer__14CFunnyShapePcsFv`: `88.59849%` -> `90.15151%`

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - drawViewer__14CFunnyShapePcsFv`

## Plausibility
- this keeps the original behavior but expresses the spinner state the way nearby debug/viewer code already does elsewhere in the repo: pointer + init guard + frame counter in small-data globals
- the change is source-clean and removes dependence on static initialization side effects inside the viewer path