### PR TITLE
Improve CMapPcs::IsLoadMapCompleted polling shape

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -283,44 +283,43 @@ unsigned long long CMapPcs::IsLoadMapCompleted()
 {
     char* mapMng = reinterpret_cast<char*>(&MapMng);
     unsigned int value = 0;
+    int count = 2;
 
-    for (int count = 2; count != 0; count--) {
+    while (true) {
         if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A30) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A34) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A38) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A3C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A40) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A44) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
-            return (unsigned long long)value;
+        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A48) != 0) {
+            break;
         }
-        mapMng += 4;
+
+        mapMng += 0x20;
         value += 7;
+        count--;
+        if (count == 0) {
+            return ((unsigned long long)1 << 32) | value;
+        }
     }
 
-    return ((unsigned long long)1 << 32) | value;
+    return (unsigned long long)value;
 }
 
 /*


### PR DESCRIPTION
## Summary
- reshape `CMapPcs::IsLoadMapCompleted()` to match the original early-return polling flow more closely
- replace the indexed/stride-by-4 loop shape with direct checks for the eight async map handles and a single 0x20 block advance
- keep the existing ABI and return-value contract while making the source more plausible

## Evidence
- symbol `IsLoadMapCompleted__7CMapPcsFv` objdiff match improved from `1.7692307%` to `65.03077%`
- symbol diff count dropped from `77` to `32`
- `ninja` completes successfully after the change

## Why This Is Plausible Source
- the new control flow matches the Ghidra-observed structure: fixed-order handle checks, early exits on any in-flight load, one block advance, and the final completed return value
- this removes decompiler-shaped pointer bumping after every check and replaces it with a more coherent polling routine centered on the actual handle block layout