### PR TITLE
Improve pppRenderYmDeformationScreen projection restore

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -376,7 +376,12 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 
 	gUtil.EndQuadEnv();
 	DisableIndWarp(GX_TEVSTAGE1, GX_INDTEXSTAGE0);
-	GXSetProjection(ppvScreenMatrix, GX_PERSPECTIVE);
+	{
+		Mtx44 projectionMtx;
+
+		PSMTX44Copy(ppvScreenMatrix, projectionMtx);
+		GXSetProjection(projectionMtx, GX_PERSPECTIVE);
+	}
 	pppInitBlendMode();
 }
 


### PR DESCRIPTION
## Summary
- restore the perspective projection through a local `Mtx44` copy in `pppRenderYmDeformationScreen`
- keep the render-path source closer to the original stack-based projection handoff instead of passing `ppvScreenMatrix` directly

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationScreen -o - pppRenderYmDeformationScreen`
- before: `87.37656%`
- after: `94.05237%`

## Why this is plausible source
- the game already uses `PSMTX44Copy` to move projection matrices through locals in adjacent render code
- restoring the projection from a temporary matrix is a normal GX-era source pattern and improves the generated register/stack shape without adding compiler-coaxing hacks
