### PR TITLE
Improve CSystem::ExecScenegraph pause toggle match

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -328,17 +328,17 @@ void CSystem::ExecScenegraph()
 
                 if (((trigger | held) & 0x1000) != 0)
                 {
-                    if (m_scenegraphStepMode == 2)
+                    if (System.m_scenegraphStepMode == 2)
                     {
                         Sound.PauseAllSe(0);
-                        m_scenegraphStepMode = 0;
+                        System.m_scenegraphStepMode = 0;
                         GbaQue.ClrShopMode();
                         GbaQue.SetPauseMode(0);
                     }
                     else if ((*(unsigned int*)(CFlat + 0x12A0) & 0x10) != 0)
                     {
                         Sound.PauseAllSe(1);
-                        m_scenegraphStepMode = 2;
+                        System.m_scenegraphStepMode = 2;
                         GbaQue.SetPauseMode(1);
                     }
                 }


### PR DESCRIPTION
## Summary
- switch the scenegraph pause-toggle path in `CSystem::ExecScenegraph` to reference the global `System` object
- keep the change limited to the pause/unpause handling block used by the debug step-mode toggle
- preserve behavior while aligning the generated code more closely with the original source shape

## Improved symbols
- `main/system`
- `ExecScenegraph__7CSystemFv`

## Evidence
- `ExecScenegraph__7CSystemFv`: `77.14054%` -> `78.35676%` by `build/tools/objdiff-cli diff -p . -u main/system -o - ExecScenegraph__7CSystemFv`
- `main/system` `.text` fuzzy match improved from `90.74605%` to `91.21047%`
- `ninja` builds cleanly after the change

## Plausibility
- Ghidra already points to the pause-toggle block reading and writing `System.m_scenegraphStepMode`, so this change restores a more coherent original-source access pattern instead of adding compiler-specific hacks.
