### PR TITLE
Match InitMetroTRK

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -101,7 +101,6 @@ asm void InitMetroTRK()
 	blr
 initCommTableSuccess:
 	b TRK_main //Jump to TRK_main
-	blr
 #endif // clang-format on
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable trailing `blr` from `InitMetroTRK` in `src/TRK_MINNOW_DOLPHIN/dolphin_trk.c`
- preserve the existing control flow and assembly layout while eliminating the extra emitted instruction

## Improved symbols
- `main/TRK_MINNOW_DOLPHIN/dolphin_trk`: `InitMetroTRK`

## Evidence
- before: `InitMetroTRK` matched at 97.297295%
- after: `InitMetroTRK` matches at 100.0%
- `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - InitMetroTRK` now reports 100% `.text` for the unit

## Plausibility
- the change removes dead code after an unconditional branch to `TRK_main`, which is a straightforward source cleanup rather than compiler coaxing

## Build
- `ninja` reaches link and DOL generation successfully
- the final `config/GCCP01/build.sha1` check still fails because the overall target is not yet fully matched
