### PR TITLE
Improve pppSRandUpFV register allocation

### DIFF
--- a/src/pppSRandUpFV.cpp
+++ b/src/pppSRandUpFV.cpp
@@ -32,8 +32,8 @@ struct PppSRandUpFVParam3 {
  */
 void pppSRandUpFV(void* param1, void* param2, void* param3)
 {
-    PppSRandUpFVParam2* cfg = (PppSRandUpFVParam2*)param1;
     u8* self = (u8*)param2;
+    PppSRandUpFVParam2* cfg = (PppSRandUpFVParam2*)param1;
     PppSRandUpFVParam3* info = (PppSRandUpFVParam3*)param3;
 
     if (gPppCalcDisabled != 0) {


### PR DESCRIPTION
## Summary
- reorder the local declarations in `pppSRandUpFV` so MWCC chooses the callee-saved register assignment closer to the original build
- keep behavior unchanged while tightening the generated code for the PAL target

## Evidence
- unit: `main/pppSRandUpFV`
- symbol: `pppSRandUpFV`
- objdiff before: `98.78505%`
- objdiff after: `99.15888%`

## Plausibility
- this is a source-level declaration-order adjustment rather than compiler coaxing through hacks
- the resulting code remains straightforward and consistent with plausible original local variable ordering