### PR TITLE
Improve pppScreenBreak matrix callback match

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -160,19 +160,19 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
     ScreenBreakModelView* modelView = (ScreenBreakModelView*)model;
     float* pieceData = *(float**)((u8*)param_2 + 0xC);
     float zero = FLOAT_80331cc4;
-    Vec translation;
+    Quaternion meshQuat;
     Quaternion resultQuat;
     Quaternion axisQuat;
-    Quaternion meshQuat;
     Vec axis;
     Vec gravityAdd;
     Vec basis = { DAT_801dd4b0, DAT_801dd4b4, DAT_801dd4b8 };
+    Vec cameraOffset;
     Vec screenOffset;
     Vec4d clipOutput;
     Vec4d clipInput;
     Vec cameraPos;
-    Vec cameraOffset;
     Vec cameraForward;
+    Vec translation;
     Mtx invTransMtx;
     Mtx transMtx;
     Mtx quatMtx;
@@ -221,12 +221,11 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
 
     for (u32 i = 0; i < modelView->m_data->m_meshCount; i++) {
         if (*((char*)pieceData + 0x38) != '\0') {
-            u8* node = modelView->m_nodes + (mesh->m_data->m_nodeIndex * 0xC0);
-            u8* nodeMtx = node + 0xC;
+            u8* nodeMtx = modelView->m_nodes + (mesh->m_data->m_nodeIndex * 0xC0) + 0x14;
 
-            *(float*)(node + 0x18) = zero;
-            *(float*)(node + 0x28) = zero;
-            *(float*)(node + 0x38) = zero;
+            *(float*)(nodeMtx + 0xC) = zero;
+            *(float*)(nodeMtx + 0x1C) = zero;
+            *(float*)(nodeMtx + 0x2C) = zero;
 
             PSMTXCopy((float(*)[4])nodeMtx, meshMtx);
             PSMTXIdentity(transMtx);


### PR DESCRIPTION
## Summary
- mirror the original local ordering in `SB_BeforeCalcMatrixCallback` to better match the callback stack layout
- access the model node matrix through the original `+0x14` matrix base and zero the translation columns relative to that base
- keep the change confined to `main/pppScreenBreak` without introducing linkage hacks

## Evidence
- `SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv`: `95.3%` -> `95.96%`
- `main/pppScreenBreak` `.text`: `90.36664%` -> `90.54772%`
- `ninja` succeeds after the change

## Plausibility
This change makes the source reflect the original callback’s matrix access pattern and stack organization more closely, rather than forcing codegen with non-source-like tricks.