### PR TITLE
Improve p_gba exception table matching

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -6,9 +6,165 @@
 #include "ffcc/system.h"
 #include <dolphin/gba/GBA.h>
 
-CGbaPcs GbaPcs;
 const char s_CGbaPcs_80330870[] = "CGbaPcs";
 char s_JoyBus__LoadBin___error_801d9de0[] = "JoyBus::LoadBin() error.";
+
+/*
+ * --INFO--
+ * PAL Address: 0x800977d8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::SetFirstZone()
+{
+	GbaQue.ClrRadarTypeFlg();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80097800
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::onScriptChanging(char*)
+{
+	GbaQue.ClrScrInitEnd();
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CGbaPcs::onMapChanged(int, int, int)
+{
+	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8009782c
+ * PAL Size: 92b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::onMapChanging(int stageNo1, int stageNo2)
+{
+	if (Joybus.IsThreadRunning()) {
+		GbaQue.SetStageNo(stageNo1, stageNo2);
+	}
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CGbaPcs::draw()
+{
+	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8009788c
+ * PAL Size: 72b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::calc()
+{
+	if (Joybus.IsThreadRunning()) {
+		GbaQue.ExecutQueue();
+		GbaQue.LoadAll();
+	}
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800978d4
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::destroy()
+{
+	Joybus.Destroy();
+	Memory.DestroyStage(m_stage);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80097918
+ * PAL Size: 156b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::create()
+{
+	m_stage = Memory.CreateStage(0x56000, const_cast<char*>(s_CGbaPcs_80330870), 0);
+	Joybus.CreateInit();
+	int result = Joybus.LoadBin();
+	if ((result != 0) && (2 <= (unsigned int)System.m_execParam)) {
+		System.Printf(s_JoyBus__LoadBin___error_801d9de0);
+	}
+	Joybus.ThreadInit();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800979b4
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CGbaPcs::GetTable(unsigned long tableIndex)
+{
+	unsigned long offset = tableIndex;
+	offset *= 0x15c;
+	return (int)(reinterpret_cast<unsigned char*>(gGbaStatusWordTable) + offset);
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CGbaPcs::Quit()
+{
+	// TODO
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800979cc
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGbaPcs::Init()
+{
+	m_stage = (CMemory::CStage*)0;
+	GBAInit();
+}
 
 /*
  * --INFO--
@@ -36,159 +192,4 @@ CGbaPcs::CGbaPcs()
 	table[13] = gGbaStatusWordTriplet3[2];
 }
 
-/*
- * --INFO--
- * PAL Address: 0x800979cc
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::Init()
-{
-	m_stage = (CMemory::CStage*)0;
-	GBAInit();
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGbaPcs::Quit()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800979b4
- * PAL Size: 20b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-int CGbaPcs::GetTable(unsigned long tableIndex)
-{
-	unsigned long offset = tableIndex;
-	offset *= 0x15c;
-	return (int)(reinterpret_cast<unsigned char*>(gGbaStatusWordTable) + offset);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80097918
- * PAL Size: 156b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::create()
-{
-	m_stage = Memory.CreateStage(0x56000, const_cast<char*>(s_CGbaPcs_80330870), 0);
-	Joybus.CreateInit();
-	int result = Joybus.LoadBin();
-	if ((result != 0) && (2 <= (unsigned int)System.m_execParam)) {
-		System.Printf(s_JoyBus__LoadBin___error_801d9de0);
-	}
-	Joybus.ThreadInit();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800978d4
- * PAL Size: 68b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::destroy()
-{
-	Joybus.Destroy();
-	Memory.DestroyStage(m_stage);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8009788c
- * PAL Size: 72b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::calc()
-{
-	if (Joybus.IsThreadRunning()) {
-		GbaQue.ExecutQueue();
-		GbaQue.LoadAll();
-	}
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGbaPcs::draw()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8009782c
- * PAL Size: 92b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::onMapChanging(int stageNo1, int stageNo2)
-{
-	if (Joybus.IsThreadRunning()) {
-		GbaQue.SetStageNo(stageNo1, stageNo2);
-	}
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGbaPcs::onMapChanged(int, int, int)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80097800
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::onScriptChanging(char*)
-{
-	GbaQue.ClrScrInitEnd();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800977d8
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGbaPcs::SetFirstZone()
-{
-	GbaQue.ClrRadarTypeFlg();
-}
+CGbaPcs GbaPcs;


### PR DESCRIPTION
## Summary
- reorder the out-of-line `CGbaPcs` method definitions in `src/p_gba.cpp`
- move the global `GbaPcs` instance below the constructor definition
- keep generated code for the unit at 100% while improving exception-table data matching

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/p_gba -o -`
- Before: `extab 70.588234`, `extabindex 0.0`, `.text 100.0`
- After: `extab 94.117645`, `extabindex 94.117645`, `.text 100.0`

## Plausibility
- this only changes source declaration/definition placement and static object placement
- behavior stays the same while bringing emitted symbol/exception layout closer to the original binary