### PR TITLE
Improve pppRandIV match

### DIFF
--- a/src/pppRandIV.cpp
+++ b/src/pppRandIV.cpp
@@ -60,10 +60,11 @@ void pppRandIV(void* param1, void* param2, void* param3)
     
     target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
 
-    {
-        f32 randValue = *valuePtr;
-        target[0] += (s32)((f32)in->field8 * randValue - (f32)in->field8);
-        target[1] += (s32)((f32)in->fieldC * randValue - (f32)in->fieldC);
-        target[2] += (s32)((f32)in->field10 * randValue - (f32)in->field10);
-    }
+    f32 value = *valuePtr;
+    f32 axis = (f32)in->field8;
+    target[0] += (s32)(axis * value - axis);
+    axis = (f32)in->fieldC;
+    target[1] += (s32)(axis * value - axis);
+    axis = (f32)in->field10;
+    target[2] += (s32)(axis * value - axis);
 }


### PR DESCRIPTION
## Summary
- rewrite the final integer delta update in `pppRandIV` to use stable local float temporaries
- keep the existing control flow and linkage intact while improving generated code shape

## Units / symbols improved
- `main/pppRandIV`
- `pppRandIV`

## Evidence
- objdiff before: `pppRandIV` 88.41228% match
- objdiff after: `pppRandIV` 99.51755% match
- rebuilt successfully with `ninja`

## Why this is plausible source
- the change only names the reused floating-point intermediates explicitly
- it matches the style already used in nearby `pppRand*` implementations rather than adding compiler-specific hacks