### PR TITLE
Improve MLstCtrl branch ordering

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -326,20 +326,18 @@ void CMenuPcs::MLstCtrl()
 	if (hold == 0) {
 		blocked = false;
 	} else {
-		if ((hold & 0x48) == 0) {
-			if ((hold & 0x24) != 0) {
-				if (state->cursor < 8) {
-					state->cursor = state->cursor + 1;
-				} else {
-					state->cursor = 0;
-				}
-				Sound.PlaySe(1, 0x40, 0x7f, 0);
-			}
-		} else {
+		if ((hold & 0x48) != 0) {
 			if (state->cursor == 0) {
 				state->cursor = 8;
 			} else {
 				state->cursor = state->cursor - 1;
+			}
+			Sound.PlaySe(1, 0x40, 0x7f, 0);
+		} else if ((hold & 0x24) != 0) {
+			if (state->cursor < 8) {
+				state->cursor = state->cursor + 1;
+			} else {
+				state->cursor = 0;
 			}
 			Sound.PlaySe(1, 0x40, 0x7f, 0);
 		}


### PR DESCRIPTION
## Summary
Reorder the held-input branch handling in `CMenuPcs::MLstCtrl` to match the original control-flow shape more closely.

## What Changed
- check the `0x48` held-input mask before the `0x24` mask
- keep the existing behavior and data access intact
- avoid adding new linkage hacks or offset-only rewrites

## Evidence
- rebuilt with `ninja`
- objdiff symbol checked with `build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstCtrl__8CMenuPcsFv`
- `MLstCtrl__8CMenuPcsFv` improved from 56.1% match in the target picker output to 57.81166%

## Why This Is Plausible Source
The change is a small control-flow reorder that lines the source up with the target branch order visible in the generated assembly, without changing the surrounding menu state model or introducing compiler-coaxing artifacts.