### PR TITLE
Match InitMetroTRK symbol size

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
+++ b/src/TRK_MINNOW_DOLPHIN/dolphin_trk.c
@@ -101,7 +101,6 @@ asm void InitMetroTRK()
 	blr
 initCommTableSuccess:
 	b TRK_main //Jump to TRK_main
-	blr
 #endif // clang-format on
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable trailing `blr` after the unconditional `b TRK_main` in `InitMetroTRK`
- keep the behavior and surrounding handwritten assembly intact while fixing the symbol extent

## Evidence
- before: `build/tools/objdiff-cli diff -p . -u main/TRK_MINNOW_DOLPHIN/dolphin_trk -o - InitMetroTRK` reported `97.297295%` for `InitMetroTRK`
- before: the unit `.text` match was `99.74874%`
- after: `InitMetroTRK` reports `100.0%`
- after: `dolphin_trk.o` `.text` reports `100.0%`

## Why this is plausible source
- the removed instruction was dead code immediately following an unconditional branch to `TRK_main`
- deleting it fixes symbol size and layout without introducing compiler coaxing or changing the live control flow

## Build
- `ninja build/GCCP01/src/TRK_MINNOW_DOLPHIN/dolphin_trk.o` succeeded
- `ninja` linked successfully and then failed only at the final SHA1 verification step for `build/GCCP01/main.dol`, which is expected in a nonmatching decomp workspace
