### PR TITLE
quadobj: improve onDraw loop matching

### DIFF
--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -43,15 +43,17 @@ void CGQuadObj::onDraw()
         GXLoadPosMtxImm(*reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(&CameraPcs) + 0x4), GX_PNMTX0);
         GXBegin(GX_LINES, GX_VTXFMT0, ((u32)m_vertexCount << 1) + ((u32)m_vertexCount << 2));
 
-        CGQuadObj* self = this;
+        CGQuadObj* current = this;
         int i = 0;
 
         while (i < (int)(u32)m_vertexCount) {
             int next = i + 1;
-            QuadVertex* vertex = self->m_vertices;
+            QuadVertex* vertex;
+            QuadVertex* vertex2;
 
             i++;
 
+            vertex = current->m_vertices;
             GXPosition3f32(vertex->x, m_yBase, vertex->z);
             next = next - (next / (int)(u32)m_vertexCount) * (u32)m_vertexCount;
             GXPosition3f32(m_vertices[next].x, m_yBase, m_vertices[next].z);
@@ -60,8 +62,10 @@ void CGQuadObj::onDraw()
             GXPosition3f32(m_vertices[next].x, m_yBase + m_yHeight, m_vertices[next].z);
             GXPosition3f32(vertex->x, m_yBase, vertex->z);
 
-            self = reinterpret_cast<CGQuadObj*>(reinterpret_cast<unsigned char*>(self) + sizeof(QuadVertex));
-            GXPosition3f32(vertex->x, m_yBase + m_yHeight, vertex->z);
+            vertex2 = current->m_vertices;
+            vertex = current->m_vertices;
+            current = reinterpret_cast<CGQuadObj*>(reinterpret_cast<unsigned char*>(current) + sizeof(QuadVertex));
+            GXPosition3f32(vertex->x, m_yBase + m_yHeight, vertex2->z);
         }
     }
 }


### PR DESCRIPTION
## Summary
- rewrite `CGQuadObj::onDraw()` to mirror the original moving-vertex loop shape more closely
- keep the existing behavior while shortening local lifetimes and recomputing `next` in the same places as the original

## Evidence
- `onDraw__9CGQuadObjFv`: `73.179245%` -> `98.113205%`
- `main/quadobj` `.text` fuzzy match: `88.08368%` -> `99.16318%`
- `ninja` builds cleanly after the change

## Plausibility
- the result uses normal member access and the same control flow the original assembly shows
- no fake symbols, forced sections, or hardcoded FIFO writes were introduced