### PR TITLE
Fix pppYmMiasma vector length call

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -22,7 +22,6 @@ extern float FLOAT_80330658;
 extern double DOUBLE_80330648;
 extern void pppNormalize__FR3Vec3Vec(float*, Vec*);
 extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
-extern float pppVectorLength__F3Vec(Vec*);
 extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
     void*, void*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char,
@@ -331,7 +330,7 @@ void UpdateParticleData(_pppPObject* pppPObject, _pppCtrlTable* pppCtrlTable, PY
     }
 
     pppSubVector(delta, worldPos, basePos);
-    if (pppVectorLength__F3Vec(&delta) < (vData->m_radius - pYmMiasma->m_minDistance)) {
+    if (pppVectorLength(delta) < (vData->m_radius - pYmMiasma->m_minDistance)) {
         state->m_speedDecay = state->m_speedDecay + pYmMiasma->m_gravity;
         state->m_hasImpulse = 1;
     }


### PR DESCRIPTION
## Summary
- remove the local `pppVectorLength` redeclaration in `src/pppYmMiasma.cpp`
- call the proper `pppVectorLength(Vec)` helper from `UpdateParticleData`
- keep the rest of the unit unchanged so the improvement stays localized to the real signature/linkage issue

## Evidence
- `main/pppYmMiasma` fuzzy match: `85.459366%` -> `86.15801%`
- `UpdateParticleData__FP11_pppPObjectP13_pppCtrlTableP9PYmMiasmaP14_PARTICLE_DATA`: `91.779526%` -> `94.21654%`
- `InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP14_PARTICLE_DATA` remains at `74.30275%`
- `ninja` builds cleanly

## Plausibility
This replaces a bad local C++ declaration with the existing engine helper signature from `pppPart.h`, so the object now references the same `pppVectorLength__F3Vec` symbol as the original object instead of the incorrect pointer-mangled variant. That is a real linkage/type correction rather than compiler coaxing.