### PR TITLE
Refine CRedDriver::GetProgramTime loop

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1402,17 +1402,17 @@ void CRedDriver::End()
 #pragma optimization_level 4
 int CRedDriver::GetProgramTime()
 {
-    int value;
     volatile int sum;
+    int* end;
     int* p;
 
     sum = 0;
+    end = DAT_8032f3cc + 100;
     p = DAT_8032f3cc;
     do {
-        value = *p;
-        p = p + 1;
-        sum = sum + value;
-    } while (p < DAT_8032f3cc + 100);
+        sum += *p;
+        p++;
+    } while (p < end);
     return sum;
 }
 #pragma optimization_level 0


### PR DESCRIPTION
## Summary
- rewrite `CRedDriver::GetProgramTime()` as a compact pointer/end `do-while` loop with a volatile accumulator
- remove the extra temporary load/add pattern from the decomp so MWCC emits the short linear loop instead of the previous inflated form

## Objdiff
- symbol: `GetProgramTime__10CRedDriverFv`
- before: `15.372881%` match, `236` bytes
- after: `44.875%` match, `64` bytes
- target size: `68` bytes

## Plausibility
- the new source is a straightforward rolling sum over the 100-entry buffer at `DAT_8032f3cc`
- this is a cleanup toward plausible original source, not compiler coaxing through fake linkage or hardcoded addresses

## Validation
- `ninja`
- `build/tools/objdiff-cli diff -1 build/GCCP01/src/RedSound/RedDriver.o -2 build/GCCP01/obj/RedSound/RedDriver.o -o - GetProgramTime__10CRedDriverFv`