### PR TITLE
Improve pppFrameCrystal2 NaN handling

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -61,10 +61,23 @@ struct pppCrystal2ColorBlock {
     pppCVECTOR m_color;
 };
 
+union Crystal2FloatBits {
+    float value;
+    unsigned long bits;
+};
+
 static const Crystal2IndTexMtx s_crystal2IndTexMtxBase = {{{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}}};
 
 static const Crystal2TexMtx s_crystal2TexMtxBase = {
     {{0.5f, 0.0f, 0.0f, 0.5f}, {0.0f, -0.5f, 0.0f, 0.5f}, {0.0f, 0.0f, 0.0f, 1.0f}}};
+
+static inline bool Crystal2IsNaN(float value)
+{
+    Crystal2FloatBits bits;
+
+    bits.value = value;
+    return (bits.bits & 0x7F800000) == 0x7F800000 && (bits.bits & 0x007FFFFF) != 0;
+}
 
 /*
  * --INFO--
@@ -185,7 +198,7 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCry
 
                     if (magnitude > 1.0f) {
                         magnitude = sqrtf(magnitude);
-                    } else if (!(magnitude >= 0.0f)) {
+                    } else if (Crystal2IsNaN(magnitude)) {
                         magnitude = NAN;
                     }
 


### PR DESCRIPTION
## Summary
- add a small local float-bit helper in `pppCrystal2.cpp` to classify NaN values during refraction-map generation
- replace the generic `!(magnitude >= 0.0f)` fallback in `pppFrameCrystal2` with the explicit NaN path
- keep the refraction map logic and output behavior otherwise unchanged

## Improved Symbols
- `main/pppCrystal2`
- `pppFrameCrystal2`

## Evidence
- `build/GCCP01/report.json`: `pppFrameCrystal2` improved from `83.11688%` to `85.03896%`
- `build/tools/objdiff-cli diff -p . -u main/pppCrystal2 -o - pppFrameCrystal2`: symbol match now `84.82251%`
- `ninja -j4`: passes

## Why This Is Plausible Source
- the change makes the NaN handling explicit instead of relying on a comparison side effect
- it matches the target's float-classification behavior around the `sqrtf` path without introducing address hacks, fake symbols, or section forcing