### PR TITLE
Improve main/game argc handling match

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,18 +61,20 @@ void main(int argc, char** argv)
  */
 void game(int argc, char** argv)
 {
+    int argumentCount;
     int i;
     int copyScriptName;
     int parseLanguage;
     char** argument;
 
+    argumentCount = argc;
     Game.Init();
     strcpy(Game.m_startScriptName, kDefaultScriptName);
 
-    if (argc != 0) {
+    if (argumentCount != 0) {
         copyScriptName = 0;
         parseLanguage = 0;
-        for (i = 1, argument = argv + 1; i < argc; i++, argument++) {
+        for (i = 1, argument = argv + 1; i < argumentCount; i++, argument++) {
             if (copyScriptName) {
                 strcpy(Game.m_startScriptName, *argument);
                 copyScriptName = 0;


### PR DESCRIPTION
## Summary
- introduce a local `argumentCount` copy in `game(int, char**)`
- use the local count for the early `argc != 0` check and loop bound
- keep behavior unchanged while improving the compiler's register allocation around argument parsing

## Evidence
- unit `main/main` `.text` match: `99.28236%` -> `99.458824%`
- symbol `game__FiPPc` match: `98.97479%` -> `99.22689%`
- symbol `game__FiPPc` instruction diffs: `22` -> `17`
- verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/main -o - main`

## Plausibility
This is a source-plausible cleanup rather than compiler coaxing: caching `argc` in a local before parsing arguments is straightforward original-source style, and it improves the emitted register usage without introducing offset tricks, fake symbols, or section hacks.