### PR TITLE
Type DAT_8032e12c as a RedSound pointer table

### DIFF
--- a/include/ffcc/RedSound/RedGlobals.h
+++ b/include/ffcc/RedSound/RedGlobals.h
@@ -22,7 +22,7 @@ extern int DAT_8021e1d0[];
 extern int DAT_8021ec10[];
 extern CRedEntry DAT_8032e154;
 extern OSSemaphore DAT_8032e120;
-extern int DAT_8032e12c[];
+extern void* DAT_8032e12c[];
 extern int DAT_8032e17c[];
 extern unsigned int DAT_8032ec30;
 extern int DAT_8032f3c0;

--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -484,7 +484,7 @@ int SeBlockPlay(int seId, int bank, int no, int pan, int volume)
 	int playSeId = seId;
 
 	if (DAT_8032e12c[bankIndex] != 0) {
-		int bankData = DAT_8032e12c[bankIndex];
+		int bankData = (int)DAT_8032e12c[bankIndex];
 		int playNo = seNo + (bankIndex << 9);
 		short count = *(short*)(bankData + 10);
 

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -128,7 +128,7 @@ OSSemaphore DAT_8032ddd8;
 ARQRequest DAT_8032dde4;
 OSThread DAT_8032de08;
 OSSemaphore DAT_8032e120;
-int DAT_8032e12c[4];
+void* DAT_8032e12c[4];
 CRedMemory DAT_8032f480;
 CRedEntry DAT_8032e154;
 
@@ -423,25 +423,24 @@ void _SetMusicPhraseStop(int* param_1)
  */
 void _SetSeBlockData(int* param_1)
 {
-    u32 index;
+    u32 index = (u32)*param_1 & 3;
     u8* seBlockData;
 
-    index = (u32)*param_1 & 3;
-    if (((void**)DAT_8032e12c)[*param_1 & 3] != 0) {
-        RedDelete__FPv(((void**)DAT_8032e12c)[index]);
-        ((void**)DAT_8032e12c)[index] = 0;
+    if (DAT_8032e12c[*param_1 & 3] != 0) {
+        RedDelete__FPv(DAT_8032e12c[index]);
+        DAT_8032e12c[index] = 0;
     }
 
     if (param_1[1] != 0) {
         seBlockData = (u8*)param_1[1];
-        seBlockData[0] = 0x53;
+        *seBlockData = 0x53;
         seBlockData[1] = 0x65;
         seBlockData[2] = 0x42;
         seBlockData[3] = 0x6c;
         seBlockData[4] = 0x6f;
-        seBlockData[5] = 0x63;
+        seBlockData[5] = 99;
         seBlockData[6] = 0x6b;
-        ((u8**)DAT_8032e12c)[index] = seBlockData;
+        DAT_8032e12c[index] = seBlockData;
     }
 }
 

--- a/src/RedSound/RedEntry.cpp
+++ b/src/RedSound/RedEntry.cpp
@@ -1594,7 +1594,7 @@ void CRedEntry::DisplayMMemoryInfo()
 	memoryBank = DAT_8032f480.GetMainBankAddress();
 	bufferTop = nextAddress + DAT_8032f480.GetMainBufferSize();
 	bankEntry = memoryBank;
-	seBlockBase = DAT_8032e12c;
+	seBlockBase = (int*)DAT_8032e12c;
 
 	do {
 		if (bankEntry[1] != 0) {


### PR DESCRIPTION
## Summary
- type DAT_8032e12c as a pointer table instead of an int array in the shared RedSound globals
- update the RedDriver, RedCommand, and RedEntry use sites to reflect pointer semantics directly
- keep _SetSeBlockData on the cleaner pointer-based access path without changing behavior

## Evidence
- ninja passes after the type cleanup
- objdiff on the examined RedDriver targets (_SetMusicData__FPi and _SetSeBlockData__FPi) is unchanged, so this is a declaration/linkage cleanup rather than a codegen win

## Why this is plausible source
DAT_8032e12c is used as a bank-pointer table throughout the RedSound cluster. Typing it as void*[] matches the actual storage and removes repeated cast noise from the callers, which is a more coherent reconstruction of the original source than keeping a fake int[] declaration.
