### PR TITLE
Improve reverb_hi_4ch DPL2 damping normalization

### DIFF
--- a/src/axfx/reverb_hi_4ch.c
+++ b/src/axfx/reverb_hi_4ch.c
@@ -230,9 +230,8 @@ static int ReverbHICreateDpl2(AXFX_REVHI_WORK_DPL2* rv, f32 coloration, f32 time
         rv->damping = 0.05f;
     }
     {
-        f32 dampMul = 0.8f;
+        f32 dampMul = 0.8f * rv->damping;
         f32 dampBias = 0.05f;
-        dampMul *= rv->damping;
         dampBias += dampMul;
         rv->damping = 1.0f - dampBias;
     }
@@ -291,9 +290,8 @@ static int ReverbHIModifyDpl2(AXFX_REVHI_WORK_DPL2* rv, f32 coloration, f32 time
         rv->damping = 0.05f;
     }
     {
-        f32 dampMul = 0.8f;
+        f32 dampMul = 0.8f * rv->damping;
         f32 dampBias = 0.05f;
-        dampMul *= rv->damping;
         dampBias += dampMul;
         rv->damping = 1.0f - dampBias;
     }


### PR DESCRIPTION
## Summary
- rewrite the DPL2 damping normalization in `reverb_hi_4ch.c` so the multiply result is formed directly before being accumulated into the bias term
- keep the logic identical while tightening the temporary lifetime around the shared Create/Modify damping block

## Improved Symbols
- `ReverbHICreateDpl2`: `99.902916%` -> `99.92233%`
- `ReverbHIModifyDpl2`: `99.7541%` -> `99.84426%`

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/axfx/reverb_hi_4ch -o - ReverbHICreateDpl2`
- the remaining mismatch stays confined to prologue/epilogue stack layout and a small nearby register-allocation seam; the shared damping block itself moves closer to target scheduling

## Plausibility
- the new source is a straight algebraic restatement of the same normalization
- it removes no-op temporary setup rather than adding compiler-coaxing artifacts, so it remains plausible original Dolphin-era source
