### PR TITLE
Improve pppRenderBlurChara register ordering

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -360,11 +360,11 @@ struct BlurCharaTexData {
  */
 void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppBlurCharaUnkC* param_3)
 {
-    int textureBase = 0;
-    int texDataOffset = param_3->m_serializedDataOffsets[2];
     int colorDataOffset = param_3->m_serializedDataOffsets[1];
+    int texDataOffset = param_3->m_serializedDataOffsets[2];
     BlurCharaColorData* colorData = reinterpret_cast<BlurCharaColorData*>((u8*)blurChara + 0x80 + colorDataOffset);
     BlurCharaTexData* texData = reinterpret_cast<BlurCharaTexData*>((u8*)blurChara + 0x80 + texDataOffset);
+    int textureBase = 0;
     int textureIndex;
     int objPosBase;
     _GXTexObj smallBackTex;


### PR DESCRIPTION
## Summary
Reorder the early local declarations in `pppRenderBlurChara` so the compiler loads and preserves the blur color/texture data offsets in the same order as the original.

## Evidence
- `ninja` succeeds
- `pppRenderBlurChara` improved from `97.13425%` to `97.20274%`
- Unit checked with: `build/tools/objdiff-cli diff -p . -u main/pppBlurChara -o - pppRenderBlurChara`

## Plausibility
This is a minimal source-level cleanup in the declaration block only. It keeps the logic identical and improves compiler register allocation without introducing coercive hacks.