### PR TITLE
Improve THPSimplePreLoad ring index match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -550,7 +550,7 @@ s32 THPSimplePreLoad(s32 loop)
         SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid = 1;
         SimpleControl.readBuffer[SimpleControl.readIndex].mFrameNumber = SimpleControl.curAudioTrack;
         SimpleControl.curAudioTrack++;
-        SimpleControl.readIndex = (SimpleControl.readIndex + 1) & 7;
+        SimpleControl.readIndex = (SimpleControl.readIndex + 1) % 8;
 
         if (((SimpleControl.header.mNumFrames - 1) < static_cast<u32>(SimpleControl.curAudioTrack)) &&
             (SimpleControl.isLooping == 1)) {


### PR DESCRIPTION
## Summary
- change `THPSimplePreLoad` to advance the read buffer index with `% 8` instead of `& 7`
- keep the logic plausible as original source for a ring buffer whose size is already expressed as `8` elsewhere in the function
- limit the patch to a single compiler-shape change in `src/THPSimple.cpp`

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPSimplePreLoad`
- verified baseline by rebuilding the reverted version: `82.33088%`
- current branch result after rebuild: `85.125%`

## Why This Is Plausible Source
- using `% 8` for ring-buffer wraparound is straightforward original-source code for this preload queue
- the change removes a compiler shape mismatch without introducing target-specific hacks or ABI workarounds
