### PR TITLE
Improve pppFrameYmDrawMdlTexAnm control flow match

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -211,11 +211,11 @@ void pppFrameYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step, 
     perU = work->m_perU;
     perV = work->m_perV;
     if ((perU == FLOAT_8033054c) || (perV == FLOAT_8033054c)) {
-        if (mapMesh == NULL) {
+        if (mapMesh != NULL) {
+            SetUpPerUV((pppModelSt*)mapMesh, work->m_perU, work->m_perV);
+        } else {
             return;
         }
-
-        SetUpPerUV((pppModelSt*)mapMesh, work->m_perU, work->m_perV);
     }
 
     uvLayout = (CMapMeshUVLayout*)mapMesh;


### PR DESCRIPTION
## Summary
- rewrite the sentinel-path `mapMesh` null check in `pppFrameYmDrawMdlTexAnm` to use an explicit `mapMesh != NULL` branch with an `else return`
- keep the surrounding work/state updates unchanged so the emitted control flow stays plausible to original source

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppYmDrawMdlTexAnm -o - pppFrameYmDrawMdlTexAnm`
- before: `98.37379%` match, size `824`
- after: `99.34466%` match, size `824`

## Why this looks plausible
- this is a local control-flow cleanup in the target function rather than compiler coaxing
- it preserves the existing data flow and only changes the null-check shape around `SetUpPerUV`