### PR TITLE
Improve CMapTexAnim::Calc frame index handling

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -255,7 +255,7 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
     }
 
     const float frameFloat = F32At(this, 0x1C);
-    const unsigned int frameIndex = static_cast<unsigned int>(frameFloat);
+    const int frameIndex = static_cast<int>(frameFloat);
     const unsigned short textureIndex = U16At(*reinterpret_cast<void**>(Ptr(this, 0x20)), (frameIndex & 0xFFFF) * 2);
     void* material = MaterialAt(materialSet, static_cast<unsigned long>(U16At(this, 8)));
     SetMaterialTextureSlot(material, static_cast<unsigned long>(U16At(this, 0xA)), TextureAt(textureSet, textureIndex));
@@ -271,7 +271,7 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
     }
 
     if (U8At(this, 0x14) != 0) {
-        unsigned int nextFrame = (frameIndex + 1) & 0xFFFF;
+        int nextFrame = (frameIndex + 1) & 0xFFFF;
         if (static_cast<float>(U16At(this, 0xC)) <= static_cast<float>(frameIndex + 1)) {
             nextFrame = 0;
         }


### PR DESCRIPTION
## Summary
- change the non-keyframe path in `CMapTexAnim::Calc` to use signed frame indices
- keep the generated masking logic the same while avoiding the unsigned float-conversion path

## Objdiff Evidence
- `main/maptexanim` fuzzy match improved from 75.7% to 76.06867%
- `Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet` improved from 70.4% to 71.09091%
- `SetMapTexAnim__14CMapTexAnimSetFiiii` remains at 94.710144%
- `Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet` remains at 68.28%

## Why This Is Plausible Source
- the original object converts the current frame float through a signed integer path in the non-keyframe case
- using `int` for `frameIndex` and `nextFrame` matches that behavior without introducing compiler-coaxing or fake structure changes

## Validation
- `ninja` passes
- objdiff report regenerated from `build/GCCP01/report.json`