### PR TITLE
Improve allocate_from_fixed_pools setup matching

### DIFF
--- a/src/MSL_C/PPCEABI/bare/H/alloc.c
+++ b/src/MSL_C/PPCEABI/bare/H/alloc.c
@@ -678,13 +678,14 @@ static void* allocate_from_fixed_pools(__mem_pool_obj* pool_obj, unsigned long s
             fs->tail_ = (FixBlock*)block;
         }
 
-        fix_size = pool_sizes[i];
-        sub_size = fix_size + 4;
         b = (FixBlock*)block;
-        head = fs->head_;
-        tail = fs->tail_;
-        num_subblocks = (msize - 0x14) / sub_size;
+        fix_size = pool_sizes[i];
         p = (FixSubBlock*)((char*)b + 0x14);
+        msize -= 0x14;
+        tail = fs->tail_;
+        head = fs->head_;
+        sub_size = fix_size + 4;
+        num_subblocks = msize / sub_size;
         b->prev_ = tail;
         b->next_ = head;
         tail->next_ = b;


### PR DESCRIPTION
What changed
- reordered the fixed-pool block setup in `allocate_from_fixed_pools` so the `FixBlock` base, subblock start pointer, adjusted `msize`, ring links, and subblock-count calculation follow the compiler's expected value flow more closely
- kept behavior unchanged; this is only a source-shape adjustment around the fixed-subblock chain initialization

What improved
- `allocate_from_fixed_pools`: `95.111115%` -> `95.12778%`
- `Block_subBlock`: unchanged at `92.06612%`
- full `ninja` build still passes

Why this looks plausible
- the change stays within the original allocator logic and only tightens local ordering/lifetimes around existing calculations
- no compiler coaxing, fake symbols, or section tricks were introduced