### PR TITLE
Match p_game object layout

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -4,186 +4,16 @@ CGamePcs GamePcs;
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGamePcs::Init()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGamePcs::Quit()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047b38
- * PAL Size: 20b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-int CGamePcs::GetTable(unsigned long param)
-{
-    return (int)m_table__8CGamePcs + (int)param * 0x15C;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047b10
+ * PAL Address: 80047930
  * PAL Size: 40b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGamePcs::create()
+void CGamePcs::onMapChanged(int a, int b, int c)
 {
-    Game.Create();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047ae8
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::destroy()
-{
-    Game.Destroy();
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGamePcs::calcInit()
-{
-    Game.CheckScriptChange();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047a98
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::calc0()
-{
-    Game.Calc();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047a70
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::calc1()
-{
-    Game.Calc2();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047a48
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::calc2()
-{
-    Game.Calc3();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80047a20
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::draw0()
-{
-    Game.Draw();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800479f8
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::draw1()
-{
-    Game.Draw2();
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800479d0
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::draw2()
-{
-    Game.Draw3();
-}
-
-/*
- * --INFO--
- * PAL Address: 800479a8
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::onScriptChanging(char* script)
-{
-    Game.ScriptChanging(script);
-}
-
-/*
- * --INFO--
- * PAL Address: 80047980
- * PAL Size: 40b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CGamePcs::onScriptChanged(char* script, int param)
-{
-    Game.ScriptChanged(script, param);
+    Game.MapChanged(a, b, c);
 }
 
 /*
@@ -202,14 +32,184 @@ void CGamePcs::onMapChanging(int a, int b)
 
 /*
  * --INFO--
- * PAL Address: 80047930
+ * PAL Address: 80047980
  * PAL Size: 40b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGamePcs::onMapChanged(int a, int b, int c)
+void CGamePcs::onScriptChanged(char* script, int param)
 {
-    Game.MapChanged(a, b, c);
+    Game.ScriptChanged(script, param);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 800479a8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::onScriptChanging(char* script)
+{
+    Game.ScriptChanging(script);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800479d0
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::draw2()
+{
+    Game.Draw3();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800479f8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::draw1()
+{
+    Game.Draw2();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047a20
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::draw0()
+{
+    Game.Draw();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047a48
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::calc2()
+{
+    Game.Calc3();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047a70
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::calc1()
+{
+    Game.Calc2();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047a98
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::calc0()
+{
+    Game.Calc();
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CGamePcs::calcInit()
+{
+    Game.CheckScriptChange();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047ae8
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::destroy()
+{
+    Game.Destroy();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047b10
+ * PAL Size: 40b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CGamePcs::create()
+{
+    Game.Create();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80047b38
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CGamePcs::GetTable(unsigned long param)
+{
+    return (int)m_table__8CGamePcs + (int)param * 0x15C;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CGamePcs::Quit()
+{
+	// TODO
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CGamePcs::Init()
+{
+	// TODO
 }


### PR DESCRIPTION
## Summary
- reorder `CGamePcs` method definitions in `src/p_game.cpp` to match the original object layout
- preserve the existing implementations while aligning emitted `.text` / exception index ordering

## Evidence
- before: `main/p_game` reported `code 100.0%`, `data 40.85%`
- after: `main/p_game` now reports `matched_code_percent: 100.0`, `matched_data_percent: 100.0`, `matched_functions: 17/17`
- `ninja` succeeds

## Plausibility
- this change does not add compiler-coaxing logic or fake symbols
- it restores original function layout/order for a thin process wrapper unit, which is a plausible source-level property
