### PR TITLE
Match pppBreathModel source filename string

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -27,7 +27,7 @@ void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 void DrawSphere__8CGraphicFPA4_f8_GXColor(void*, Mtx, _GXColor);
 }
 
-static char s_pppBreathModel_cpp[] = "pppBreathModel.cpp";
+static char s_pppBreathModel_cpp[] = "pppBreathModel.c";
 
 struct pppBreathModelUnkC {
     unsigned char _pad[0xC];


### PR DESCRIPTION
## Summary
- change `s_pppBreathModel_cpp` to `"pppBreathModel.c"` in `src/pppBreathModel.cpp`
- keep the change narrowly scoped to the selected `main/pppBreathModel` unit

## Evidence
- `ninja` succeeds
- before this change, `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o - pppFrameBreathModel` reported a standalone `s_pppBreathModel_cpp` / `.[data]-0` mismatch
- after this change, that unit diff no longer reports `s_pppBreathModel_cpp` or `.[data]-0`; only the existing `extab` / `extabindex` data diffs remain

## Plausibility
- this only updates the allocation filename string embedded in the object, which is consistent with matching original source metadata rather than compiler coaxing