### PR TITLE
Fix _pppEnvSt map mesh pointer typing

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -215,7 +215,7 @@ struct _pppEnvSt
 {
     CMemory::CStage* m_stagePtr;    // 0x0
     CMaterialSet* m_materialSetPtr; // 0x4
-    CMapMesh* m_mapMeshPtr;         // 0x8
+    CMapMesh** m_mapMeshPtr;        // 0x8
     _pppColor m_particleColors[10];  // 0xc
     unsigned int m_mngStCount;      // 0x34
     unsigned int m_debugCounter;    // 0x38

--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -424,7 +424,7 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
     colorData = (u8*)pppYmTracer + 0x80 + colorOffset;
     poly = work->entries;
     dataValIndex = param_2->m_dataValIndex;
-    mapMesh = ((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[dataValIndex];
+    mapMesh = pppEnvStPtr->m_mapMeshPtr[dataValIndex];
 
     if (dataValIndex != 0xFFFF) {
         pppSetBlendMode(param_2->m_payload[10]);

--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -371,7 +371,7 @@ void pppRenderYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, p
     colorData = (u8*)pppYmTracer2 + 0x80 + colorOffset;
     poly = work->entries;
     dataValIndex = param_2->m_dataValIndex;
-    mapMesh = ((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[dataValIndex];
+    mapMesh = pppEnvStPtr->m_mapMeshPtr[dataValIndex];
 
     if (dataValIndex != 0xFFFF) {
         pppSetBlendMode(param_2->m_payload[10]);


### PR DESCRIPTION
## Summary
- correct `_pppEnvSt::m_mapMeshPtr` from `CMapMesh*` to `CMapMesh**`
- remove the redundant casts in `pppRenderYmTracer` and `pppRenderYmTracer2`
- keep the env layout coherent with how these particle renderers already access the map-mesh table

## Evidence
- `pppRenderYmTracer`: `93.94782% -> 94.46957%`
- `main/pppYmTracer` `.text`: `82.16755% -> 82.32586%`
- full build still passes with `ninja`

## Why this is plausible source
- `_pppEnvSt::m_mapMeshPtr` is used as an indexed table of `CMapMesh*` throughout the particle code
- the previous `CMapMesh*` declaration forced call sites to cast around an ABI-relevant type mismatch
- this change restores the coherent shared declaration instead of preserving a broken header and compensating locally