### PR TITLE
Improve menu_equip EquipCtrl matching

### DIFF
--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -509,54 +509,49 @@ int CMenuPcs::EquipOpen()
 void CMenuPcs::EquipCtrl()
 {
 	int state = 0;
-	u8* self = reinterpret_cast<u8*>(this);
-	u8* equipState = *reinterpret_cast<u8**>(self + 0x82c);
+	int menuState;
+	int item;
+	int index;
+	int offset;
+	u32 equipCount;
 	s16 mode;
 
-	*reinterpret_cast<s16*>(equipState + 0x32) = *reinterpret_cast<s16*>(equipState + 0x30);
-	mode = *reinterpret_cast<s16*>(equipState + 0x30);
-
-	if ((mode == 0) || ((mode != 0) && (*reinterpret_cast<s16*>(equipState + 0x12) == 1))) {
-		state = EquipCtrlCur__8CMenuPcsFv(this);
-	} else if ((mode == 1) && (*reinterpret_cast<s16*>(equipState + 0x12) == 0)) {
-		state = EquipOpen0__8CMenuPcsFv(this);
+	*reinterpret_cast<s16*>(GetEquipStateBase(this) + 0x32) = *reinterpret_cast<s16*>(GetEquipStateBase(this) + 0x30);
+	menuState = GetEquipStateBase(this);
+	mode = *reinterpret_cast<s16*>(menuState + 0x30);
+	if ((mode == 0) || ((mode != 0) && (*reinterpret_cast<s16*>(menuState + 0x12) == 1))) {
+		state = EquipCtrlCur();
+	} else if ((mode == 1) && (*reinterpret_cast<s16*>(menuState + 0x12) == 0)) {
+		state = EquipOpen0();
 		if (state != 0) {
 			state = 0;
-			*reinterpret_cast<s16*>(equipState + 0x12) = *reinterpret_cast<s16*>(equipState + 0x12) + 1;
+			*reinterpret_cast<s16*>(menuState + 0x12) = *reinterpret_cast<s16*>(menuState + 0x12) + 1;
 		}
-	} else if ((mode == 1) && (*reinterpret_cast<s16*>(equipState + 0x12) == 2) && (EquipClose0__8CMenuPcsFv(this) != 0)) {
-		*reinterpret_cast<s16*>(equipState + 0x12) = 0;
-		*reinterpret_cast<s16*>(equipState + 0x30) = 0;
-		*reinterpret_cast<s16*>(equipState + 0x22) = 0;
+	} else if (((mode == 1) && (*reinterpret_cast<s16*>(menuState + 0x12) == 2)) && EquipClose0()) {
+		*reinterpret_cast<s16*>(menuState + 0x12) = 0;
+		*reinterpret_cast<s16*>(GetEquipStateBase(this) + 0x30) = 0;
+		*reinterpret_cast<s16*>(GetEquipStateBase(this) + 0x22) = 0;
 		CmdInit1__8CMenuPcsFv(this);
 		state = 0;
 	}
-
 	if (state != 0) {
-		float fVar = FLOAT_80332ee0;
-		int menuData = *reinterpret_cast<int*>(self + 0x850);
-		s16 count = **reinterpret_cast<s16**>(self + 0x850);
-		int item = menuData + 8;
-
-		for (int i = 0; i < count; i++) {
-			*reinterpret_cast<float*>(item + 0x10) = fVar;
-			*reinterpret_cast<float*>(item + 0x14) = fVar;
+		item = GetEquipListBase(this) + 8;
+		for (index = 0; index < *GetEquipList(this); index++) {
+			*reinterpret_cast<float*>(item + 0x10) = FLOAT_80332ee0;
+			*reinterpret_cast<float*>(item + 0x14) = FLOAT_80332ee0;
 			item += 0x40;
 		}
-
-		u32 caravanWork = Game.m_scriptFoodBase[0];
-		u32 equipCount = static_cast<u32>(*reinterpret_cast<s16*>(caravanWork + 0xbaa));
-		int index = 0;
-		int offset = static_cast<int>(equipCount - 1) * 0x40;
-
-		if (static_cast<int>(equipCount - 1) >= 0) {
-			for (u32 i = 0; i < equipCount; i++) {
-				int slot = menuData + offset + 8;
-				*reinterpret_cast<int*>(slot + 0x24) = index;
-				*reinterpret_cast<int*>(slot + 0x28) = 3;
-				index++;
-				offset -= 0x40;
-			}
+		equipCount = (u32)*(s16*)(Game.m_scriptFoodBase[0] + 0xbaa);
+		index = 0;
+		offset = (equipCount - 1) * 0x40;
+		if (-1 < (int)(equipCount - 1)) {
+			do {
+				item = GetEquipListBase(this) + offset + 8;
+				*reinterpret_cast<int*>(item + 0x24) = index;
+				index = index + 1;
+				*reinterpret_cast<int*>(item + 0x28) = 3;
+				offset = offset + -0x40;
+			} while (index < (int)equipCount);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- rewrite `CMenuPcs::EquipCtrl()` in `src/menu_equip.cpp` to follow the existing menu control-flow style more closely
- use the existing equip state/list helpers instead of the rough local pointer-casting version
- preserve behavior while tightening the generated loop/control structure for the selected objdiff target

## Evidence
- `ninja` builds cleanly
- `EquipCtrl__8CMenuPcsFv` improved from the selector's `29.0%` match to `51.255035%` after the change
- unit `main/menu_equip` moved from `37.0%` in the selector output to `38.36397%` code match in `build/GCCP01/report.json`

## Plausibility
- this change removes ad hoc local byte-pointer access and aligns `EquipCtrl()` with the surrounding menu control functions
- no fake symbols, section forcing, or compiler-coaxing hacks were introduced