### PR TITLE
Refine lens flare alpha clamp

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -180,10 +180,10 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 			int scaledAlpha = (u8)work->m_alpha * (0xFF / sampleCount);
 
 			work->m_alpha = (u8)scaledAlpha;
-			if ((int)(u8)scaledAlpha <= 0xFF) {
-				work->m_alpha = (u8)scaledAlpha;
-			} else {
+			if (0xFF < (int)(u8)scaledAlpha) {
 				work->m_alpha = 0xff;
+			} else {
+				work->m_alpha = (u8)scaledAlpha;
 			}
 		}
 


### PR DESCRIPTION
## Summary
- rewrite the `pppFrameLensFlare` alpha clamp in `src/pppLensFlare.cpp`
- keep behavior unchanged while matching the original branch direction more closely

## Objdiff evidence
- unit: `main/pppLensFlare`
- symbol: `pppFrameLensFlare`
- before: one opcode mismatch remained in the alpha clamp tail at `0x1100` (`ble` vs `bgt`), plus register-allocation mismatches
- after: the opcode mismatch at `0x1100` is gone; the remaining differences in that tail are register-allocation only
- build: `ninja` succeeds

## Plausibility
- this keeps the same clamp logic and only rewrites the comparison into the opposite-but-equivalent form
- the result is source-plausible C++ rather than compiler-forcing hacks
