### PR TITLE
Improve pppRandIV matching

### DIFF
--- a/src/pppRandIV.cpp
+++ b/src/pppRandIV.cpp
@@ -35,7 +35,7 @@ void pppRandIV(void* param1, void* param2, void* param3)
     u8* base = (u8*)param1;
     PppRandIVParam2* in = (PppRandIVParam2*)param2;
     PppRandIVParam3* out = (PppRandIVParam3*)param3;
-    s32* target;
+    f32 value;
     f32* valuePtr;
 
     if (gPppCalcDisabled != 0) {
@@ -43,7 +43,7 @@ void pppRandIV(void* param1, void* param2, void* param3)
     }
 
     if (in->field0 == *(s32*)(base + 0xC)) {
-        f32 value = Math.RandF();
+        value = Math.RandF();
         if (in->field18 != 0) {
             value += Math.RandF();
         } else {
@@ -52,15 +52,17 @@ void pppRandIV(void* param1, void* param2, void* param3)
 
         valuePtr = (f32*)(base + *out->fieldC + 0x80);
         *valuePtr = value;
-    } else if (in->field0 != *(s32*)(base + 0xC)) {
-        return;
     } else {
+        if (in->field0 != *(s32*)(base + 0xC)) {
+            return;
+        }
         valuePtr = (f32*)(base + *out->fieldC + 0x80);
     }
-    
-    target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
 
-    target[0] += (s32)((f32)in->field8 * *valuePtr - (f32)in->field8);
-    target[1] += (s32)((f32)in->fieldC * *valuePtr - (f32)in->fieldC);
-    target[2] += (s32)((f32)in->field10 * *valuePtr - (f32)in->field10);
+    s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
+    f32 scale = *valuePtr;
+
+    target[0] += (s32)((f32)in->field8 * scale - (f32)in->field8);
+    target[1] += (s32)((f32)in->fieldC * scale - (f32)in->fieldC);
+    target[2] += (s32)((f32)in->field10 * scale - (f32)in->field10);
 }


### PR DESCRIPTION
## Summary
- rewrite `pppRandIV` to follow the control-flow and temporary usage pattern used by the neighboring `Rand*IV` implementations
- keep the random-value generation and target updates behavior-identical while making the integer-vector update sequence compile closer to the original

## Improved symbols
- `pppRandIV`
- unit: `main/pppRandIV`

## Evidence
- `pppRandIV` symbol match improved from `96.57895%` to `99.51755%`
- unit `.text` match is now `99.51755%`
- unit data sections in the diff (`extab`, `extabindex`, `.sdata2`) are all `100%`
- `ninja` builds cleanly after the change

## Why this is plausible source
- the final code now matches the style already used in `pppRandDownIV` and `pppRandUpIV`: one local `value`, a reused `valuePtr`, and a local `scale` used for the 3-axis integer updates
- this is a cleanup of control flow and temporary lifetimes, not an artificial source hack or section-forcing change