### PR TITLE
Fix YmTracer2 frame matrix call order

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -11,7 +11,6 @@
 #include <dolphin/mtx.h>
 
 extern "C" void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
-extern "C" int GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(float, _pppMngSt*, Mtx);
 extern "C" void pppSetBlendMode(unsigned char);
 extern "C" void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
     void*, void*, float, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char, unsigned char,
@@ -296,7 +295,7 @@ void pppFrameYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, pp
             PSMTXMultVec(MStack_78, &entries[0].targetPos, &entries[0].targetPos);
         } else if (!useFallback) {
             frameT = (FLOAT_80331860 / (f32)((s32)param_2->m_payload[9] + 1)) * (f32)(s32)i;
-            if (GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(frameT, pppMngStPtr, MStack_78) == 0) {
+            if (GetCharaNodeFrameMatrix(pppMngStPtr, frameT, MStack_78) == 0) {
                 useFallback = true;
             } else {
                 PSMTXConcat(MStack_78, ((_pppPObject*)pppYmTracer2)->m_localMatrix.value, MStack_78);


### PR DESCRIPTION
## Summary
- remove the local reversed `GetCharaNodeFrameMatrix` declaration from `pppYmTracer2.cpp`
- call the shared `GetCharaNodeFrameMatrix(pppMngStPtr, frameT, MStack_78)` declaration from `pppYmEnv.h`
- keep the frame path aligned with the real ABI instead of carrying a file-local signature mismatch

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppFrameYmTracer2`
- before: `pppFrameYmTracer2` was reported by `tools/agent_select_target.py` at 82.7% match
- after: `pppFrameYmTracer2` is 86.66907% match

## Why this is plausible source
- `GetCharaNodeFrameMatrix` is already declared in `include/ffcc/pppYmEnv.h` with `_pppMngSt*, float, Mtx`
- nearby code in `src/pppYmLaser.cpp` uses the same argument order
- this change removes a decomp artifact rather than adding compiler-coaxing logic
