### PR TITLE
Improve pppFrameLocationTitle2 model handle setup

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -231,6 +231,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     if (work->m_particles == 0) {
         LocationTitle2Particle* particles;
         CGObject* owner;
+        CCharaPcs::CHandle* handle;
         CChara::CModel* model;
         LocationTitle2ModelRaw* modelRaw;
         int nodeIndex;
@@ -244,9 +245,13 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         particles = (LocationTitle2Particle*)work->m_particles;
 
         owner = (CGObject*)pppMngStPtr->m_owner;
-        model = 0;
+        handle = 0;
         if (owner->m_charaModelHandle != 0) {
-            model = owner->m_charaModelHandle->m_model;
+            handle = owner->m_charaModelHandle;
+        }
+        model = 0;
+        if (handle != 0) {
+            model = handle->m_model;
         }
 
         modelRaw = (LocationTitle2ModelRaw*)model;


### PR DESCRIPTION
## Summary
- split the LocationTitle2 owner/model bootstrap into an explicit handle step before reading the model pointer
- keep the control flow aligned with the original null-check chain in the particle initialization path

## Evidence
- `pppFrameLocationTitle2`: `87.10526%` -> `87.17105%`
- `main/LocationTitle2` `.text`: `92.66483%` -> `92.70146%`
- `ninja` rebuild succeeds

## Why this is plausible source
- the change removes a cleaned-up direct dereference and restores a more conservative handle-to-model setup without introducing compiler-coaxing hacks
- behavior is unchanged; this is purely a source-shape correction in the target dependency chain