### PR TITLE
Improve DeleteItemIdx source shape

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -865,16 +865,11 @@ int CCaravanWork::FindItem(int itemId)
  */
 void CCaravanWork::DeleteItemIdx(int itemSlot, int updateJoybus)
 {
-	unsigned short* itemPtr = &m_inventoryItems[itemSlot];
-	unsigned short item = *itemPtr;
-	short itemCount = m_inventoryItemCount;
-
-	if (item != static_cast<unsigned short>(-1)) {
-		unsigned short emptyItem = static_cast<unsigned short>(-1);
-		*itemPtr = emptyItem;
-		m_inventoryItemCount = itemCount - 1;
+	if (m_inventoryItems[itemSlot] != 0xFFFF) {
+		m_inventoryItems[itemSlot] = 0xFFFF;
+		m_inventoryItemCount = m_inventoryItemCount - 1;
 		if (updateJoybus != 0) {
-			DelItem__6JoyBusFiUc(&Joybus, m_joybusCaravanId, static_cast<unsigned char>(static_cast<signed char>(itemSlot)));
+			DelItem__6JoyBusFiUc(&Joybus, m_joybusCaravanId, (char)itemSlot);
 		}
 	}
 }


### PR DESCRIPTION
Summary
- simplify CCaravanWork::DeleteItemIdx to direct field access
- remove temporary locals and use the original (char)itemSlot Joybus argument shape

Evidence
- ninja succeeds
- DeleteItemIdx__12CCaravanWorkFii improved from 29.4% to 73.2% in objdiff

Plausibility
- the new source matches the obvious original control flow: check slot, clear item, decrement count, optionally notify Joybus
- this removes decomp-introduced temporaries instead of adding compiler-coaxing hacks