### PR TITLE
vec.c: use extern constants for PSVECNormalize inverse sqrt

### DIFF
--- a/src/mtx/vec.c
+++ b/src/mtx/vec.c
@@ -84,8 +84,8 @@ asm void PSVECScale(register const Vec *src, register Vec *dst, register f32 sca
 void PSVECNormalize(const register Vec *vec1, register Vec *ret)
 {
 #ifdef __MWERKS__ // clang-format off
-	register f32 half  = 0.5f;
-	register f32 three = 3.0f;
+	register f32 half  = kVecInvSqrtHalfConst;
+	register f32 three = kVecInvSqrtThreeConst;
 	register f32 xx_zz, xx_yy;
 	register f32 square_sum;
 	register f32 ret_sqrt;


### PR DESCRIPTION
Replace inline 0.5f/3.0f literals with kVecInvSqrtHalfConst and kVecInvSqrtThreeConst extern references in PSVECNormalize, matching the target object's sdata2 layout.

Result: sdata2 reduced from 12 to 4 bytes, instruction diffs from 3 to 1. Remaining 1 diff is C_VECReflect cross-TU sdata2 reference (unfixable without breaking register allocation).