### PR TITLE
Improve CFlatData::Create message pointer walk

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -232,6 +232,7 @@ void CFlatData::Create(void* filePtr)
 				}
 				case 0x4D455320: // 'MES '
 				{
+					char** mesPtr;
 					int iVar7;
 					int iVar8;
 
@@ -240,13 +241,13 @@ void CFlatData::Create(void* filePtr)
 					memcpy(m_mesBuffer, chunkFile.GetAddress(), chunk.m_size);
 
 					iVar10 = (int)chunkFile.GetAddress();
-					flatData = (FlatDataLayout*)this;
+					mesPtr = m_mesPtr;
 					for (iVar7 = 0; iVar7 < m_mesCount; iVar7++)
 					{
 						iVar8 = (int)chunkFile.GetAddress();
-						flatData->m_mesPtr[0] = m_mesBuffer + iVar8 - iVar10;
+						*mesPtr = m_mesBuffer + (iVar8 - iVar10);
 						chunkFile.GetString();
-						flatData = (FlatDataLayout*)flatData->m_data;
+						mesPtr++;
 					}
 					break;
 				}


### PR DESCRIPTION
## Summary
- replace the `MES ` chunk writeback in `CFlatData::Create` with a direct `m_mesPtr` walk
- keep the existing control flow and allocation behavior intact while removing one synthetic whole-object pointer cast in that block

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/cflat_data -o - Create__9CFlatDataFPv`
- `Create__9CFlatDataFPv`: `98.09446%` -> `98.41694%`
- `main/cflat_data` `.text`: `98.72271%` -> `98.938866%`

## Plausibility
- this uses the real `m_mesPtr` member as a linear pointer table instead of reinterpreting the whole object and stepping it through unrelated fields
- behavior is unchanged: each message pointer still targets the copied `m_mesBuffer` contents using the chunk-string address delta