### PR TITLE
Improve pppPointRAp codegen

### DIFF
--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -79,12 +79,10 @@ void pppPointRAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
         float spinRand = Math.RandF();
         float spinAngle = gPppPointRApRandomAngleRange * spinRand;
         s32 angleB = (s32)(gPppPointRApSpinScale * spinAngle);
-        float spinSin = *(float*)((u8*)trig + (angleB & 0xFFFC));
-        float spinCos = *(float*)((u8*)trig + ((angleB + 0x4000) & 0xFFFC));
-        float xOff = planarOff * spinSin;
-        float zOff = planarOff * spinCos;
         Vec* dstPos = (Vec*)((u8*)obj + payload->m_childPosOffset + 0x80);
         Vec* dstVel = (Vec*)((u8*)obj + payload->m_childVelocityOffset + 0x80);
+        float xOff = planarOff * *(float*)((u8*)trig + (angleB & 0xFFFC));
+        float zOff = *(float*)((u8*)trig + ((angleB + 0x4000) & 0xFFFC)) * planarOff;
 
         dstPos->x = srcPos->x + xOff;
         dstPos->y = srcPos->y + yOff;


### PR DESCRIPTION
## Summary
- fold the spin trig lookups directly into the `xOff`/`zOff` temporaries in `pppPointRAp`
- move the child position and velocity pointer setup ahead of those multiplies to better match the original temporary lifetimes
- keep behavior unchanged while producing cleaner codegen for the PAL target

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppPointRAp -o - pppPointRAp`
- before: `98.36283%`
- after: `99.38053%`

## Plausibility
This keeps the source straightforward: the particle still computes child pointers, then derives `xOff`/`zOff` from the spin angle without extra helper locals. The change removes intermediate trig temporaries instead of adding compiler-only shaping.