### PR TITLE
Fix OS.c link hang: remove redundant entry directives

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -694,7 +694,7 @@ config.libs = [
                 source="os/__ppc_eabi_init.cpp",
                 cflags=replace_flag_prefix(cflags_base, "-inline ", "-inline auto,deferred"),
             ),
-            Object(NonMatching, "os/OS.c"),
+            Object(Matching, "os/OS.c"),
             Object(Matching, "os/OSAddress.c"),
             Object(Matching, "os/OSAlarm.c"),
             Object(Matching, "os/OSAlloc.c"),

--- a/src/os/OS.c
+++ b/src/os/OS.c
@@ -89,7 +89,6 @@ void __OSDBJUMPEND(void);
 asm void __OSFPRInit(void) {
     // clang-format off
     nofralloc
-entry __OSFPRInit
 
     mfmsr r3
     ori r3, r3, 0x2000
@@ -476,7 +475,6 @@ entry __OSDBINTSTART
 
 asm void __OSDBJump(void) {
     nofralloc
-entry __OSDBJump
 entry __OSDBJUMPSTART
     bla     OS_DBJUMPPOINT_ADDR
 entry __OSDBJUMPEND


### PR DESCRIPTION
The 'entry __OSFPRInit' and 'entry __OSDBJump' inside their own asm functions prevented the compiler from exporting these symbols. Other TUs (e.g. __ppc_eabi_init.cpp) reference __OSFPRInit, so the linker looped trying to resolve it. Removing the redundant entry keywords (keeping the asm function declarations) fixes the export and unblocks linking.

SDK linked: 194/202 -> 195/202 (88.25% -> 89.16%)