### PR TITLE
Match ansi_fp.c (MSL_C): add __dec2num, fix .sdata2 split

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -2071,6 +2071,7 @@ MSL_C/PPCEABI/bare/H/ansi_fp.c:
 	.text       start:0x801B2FD4 end:0x801B4F28
 	.rodata     start:0x801E6FD8 end:0x801E70B5
 	.data       start:0x8021D298 end:0x8021D3BC
+	.sdata2     start:0x80333930 end:0x80333938
 
 MSL_C/PPCEABI/bare/H/buffer_io.c:
 	.text       start:0x801B4F28 end:0x801B5294

--- a/configure.py
+++ b/configure.py
@@ -978,7 +978,7 @@ config.libs = [
             ),
             Object(Matching, "MSL_C/PPCEABI/bare/H/errno.c"),
             Object(Matching, "MSL_C/PPCEABI/bare/H/ansi_files.c", mw_version="GC/2.7"),
-            Object(NonMatching, "MSL_C/PPCEABI/bare/H/ansi_fp.c", mw_version="GC/2.7"),
+            Object(Matching, "MSL_C/PPCEABI/bare/H/ansi_fp.c", mw_version="GC/2.7"),
             Object(Matching, "MSL_C/PPCEABI/bare/H/buffer_io.c"),
             Object(Matching, "MSL_C/PPCEABI/bare/H/gamecube.c", mw_version="GC/2.6"),
             Object(Matching, "MSL_C/PPCEABI/bare/H/ctype.c"),

--- a/include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/float.h
+++ b/include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/float.h
@@ -29,6 +29,12 @@ extern unsigned long __float_nan[];
 extern unsigned long __float_huge[];
 extern unsigned long __float_max[];
 extern unsigned long __float_epsilon[];
+extern unsigned long __double_max[];
+extern unsigned long __double_huge[];
+extern unsigned long __double_min[];
+
+#define DBL_MAX  (*(double*)__double_max)
+#define DBL_MIN  (*(double*)__double_min)
 
 inline int __fpclassifyf(float __value)
 {

--- a/src/MSL_C/PPCEABI/bare/H/ansi_fp.c
+++ b/src/MSL_C/PPCEABI/bare/H/ansi_fp.c
@@ -1,22 +1,10 @@
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/ansi_fp.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/limits.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/float.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/ctype.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/Math/fdlibm.h"
 
-/*
- * TODO: Remove this note block once linkage has been resolved.
- *
- * Current blocker in this unit:
- * - ansi_fp.c reports 100% code/data in objdiff, but promoting it to Matching
- *   on the latest main-based SDK branch still fails the final main.dol checksum
- *
- * Most useful result so far:
- * - a fresh Matching flip on this branch rebuilt cleanly through link and only
- *   failed at the final checksum stage, so the remaining issue is hidden
- *   object/linkage metadata rather than visible function or constant mismatch
- * - promoting `ansi_fp.c` and `e_pow.c` together on the latest main-based SDK
- *   branch still only fails at the final checksum, so `ansi_fp.c` is not just
- *   waiting on the adjacent pow runtime unit to become linkable first
- */
+#define INFINITY (*(float*)__float_huge)
 
 static int __count_trailing_zerol(unsigned long x) {
     int result = 0;
@@ -247,8 +235,6 @@ void __str2dec(decimal* d, const char* s, short exp) {
         __dorounddecup(d, d->sig.length);
     }
 }
-
-static const char* const unused = "179769313486231580793729011405303420";
 
 void __two_exp(decimal* result, long exp) {
     switch (exp) {
@@ -581,5 +567,164 @@ void __num2dec(const decform* form, double x, decimal* d) {
 
     for (i = 0; i < d->sig.length; i++) {
         d->sig.text[i] += '0';
+    }
+}
+
+double __dec2num(const decimal* d)
+{
+    if (d->sig.length <= 0)
+        return copysign(0.0, d->sign == 0 ? 1.0 : -1.0);
+    switch (d->sig.text[0])
+    {
+    case '0':
+        return copysign(0.0, d->sign == 0 ? 1.0 : -1.0);
+    case 'I':
+        return copysign((double)INFINITY, d->sign == 0 ? 1.0 : -1.0);
+    case 'N':
+    {
+        double result;
+        unsigned long long* ll = (unsigned long long*)&result;
+        *ll = 0x7FF0000000000000;
+        if (d->sign)
+            *ll |= 0x8000000000000000;
+        if (d->sig.length == 1)
+            *ll |= 0x0008000000000000;
+        else
+        {
+            unsigned char* p = (unsigned char*)&result + 1;
+            int placed_non_zero = 0;
+            int low = 1;
+            int i;
+            int e = d->sig.length;
+            if (e > 14)
+                e = 14;
+            for (i = 1; i < e; ++i)
+            {
+                unsigned char c = d->sig.text[i];
+                if (isdigit(c))
+                    c -= '0';
+                else
+                    c = (unsigned char)(tolower(c) - 'a' + 10);
+                if (c != 0)
+                    placed_non_zero = 1;
+                if (low)
+                    *p++ |= c;
+                else
+                    *p = (unsigned char)(c << 4);
+                low = !low;
+            }
+            if (!placed_non_zero)
+                *ll |= 0x0008000000000000;
+        }
+        return result;
+    }
+    }
+    {
+        static double pow_10[8] = { 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8 };
+        decimal dec = *d;
+        unsigned char* i = dec.sig.text;
+        unsigned char* e = i + dec.sig.length;
+        double first_guess;
+        int exponent;
+        for (; i < e; ++i)
+            *i -= '0';
+        dec.exp += dec.sig.length - 1;
+        exponent = dec.exp;
+        i = dec.sig.text;
+        first_guess = *i++;
+        while (i < e)
+        {
+            unsigned long ival = 0;
+            int j;
+            double temp1, temp2;
+            int ndig = (e - i) % 8;
+            if (ndig == 0)
+                ndig = 8;
+            for (j = 0; j < ndig; ++j, ++i)
+                ival = ival * 10 + *i;
+            temp1 = first_guess * pow_10[ndig - 1];
+            temp2 = temp1 + ival;
+            if (ival != 0 && temp1 == temp2)
+                break;
+            first_guess = temp2;
+            exponent -= ndig;
+        }
+        if (exponent < 0)
+            first_guess /= pow(5.0, -exponent);
+        else
+            first_guess *= pow(5.0, exponent);
+        first_guess = ldexp(first_guess, exponent);
+        if (isinf(first_guess))
+        {
+            decimal max;
+            __str2dec(&max, "179769313486231580793729011405303420", 308);
+            if (__less_dec(&max, &dec))
+                goto done;
+            first_guess = DBL_MAX;
+        }
+        {
+            decimal feedback1;
+            __num2dec_internal(&feedback1, first_guess);
+            if (__equals_dec(&feedback1, &dec))
+                goto done;
+            if (__less_dec(&feedback1, &dec))
+            {
+                decimal feedback2, difflow, diffhigh;
+                double next_guess = nextafter(first_guess, (double)INFINITY);
+                if (isinf(next_guess))
+                {
+                    first_guess = next_guess;
+                    goto done;
+                }
+                __num2dec_internal(&feedback2, next_guess);
+                while (__less_dec(&feedback2, &dec))
+                {
+                    feedback1 = feedback2;
+                    first_guess = next_guess;
+                    next_guess = nextafter(next_guess, (double)INFINITY);
+                    if (isinf(next_guess))
+                    {
+                        first_guess = next_guess;
+                        goto done;
+                    }
+                    __num2dec_internal(&feedback2, next_guess);
+                }
+                __minus_dec(&difflow, &dec, &feedback1);
+                __minus_dec(&diffhigh, &feedback2, &dec);
+                if (__equals_dec(&difflow, &diffhigh))
+                {
+                    if (*(unsigned long long*)&first_guess & 1)
+                        first_guess = next_guess;
+                }
+                else if (!__less_dec(&difflow, &diffhigh))
+                    first_guess = next_guess;
+            }
+            else
+            {
+                decimal feedback2, difflow, diffhigh;
+                double next_guess = nextafter(first_guess, (double)(-INFINITY));
+                __num2dec_internal(&feedback2, next_guess);
+                while (__less_dec(&dec, &feedback2))
+                {
+                    feedback1 = feedback2;
+                    first_guess = next_guess;
+                    next_guess = nextafter(next_guess, (double)(-INFINITY));
+                    __num2dec_internal(&feedback2, next_guess);
+                }
+                __minus_dec(&difflow, &dec, &feedback2);
+                __minus_dec(&diffhigh, &feedback1, &dec);
+                if (__equals_dec(&difflow, &diffhigh))
+                {
+                    if (*(unsigned long long*)&first_guess & 1)
+                        first_guess = next_guess;
+                }
+                else if (__less_dec(&difflow, &diffhigh))
+                    first_guess = next_guess;
+            }
+        }
+    done:
+        if (dec.sign)
+            first_guess = -first_guess;
+        return first_guess;
     }
 }


### PR DESCRIPTION
- Flip ansi_fp.c from NonMatching to Matching
- Add __dec2num function and all unused function stubs
- Remove incorrect static const unused variable
- Add .sdata2 split (0x80333930-0x80333938) to prevent duplicate .sdata2 entries from auto-generated objects
- Add DBL_MAX/DBL_MIN definitions to float.h

DOL checksum passes. SDK: 99.05% matched.