### PR TITLE
Use shared zero constant in deformation model init

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -134,7 +134,7 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, str
 {
     u8 direction = 1;
     u16* puVar2 = (u16*)((u8*)pppYmDeformationMdl_ + 0x80 + param_2->m_serializedDataOffsets[2]);
-    float fVar1 = 0.0f;
+    float fVar1 = FLOAT_80330dac;
 
     *puVar2 = 0;
     *(u8*)(puVar2 + 1) = direction;


### PR DESCRIPTION
## Summary
- change `pppConstructYmDeformationMdl` to initialize with the shared `FLOAT_80330dac` constant instead of a local `0.0f` literal
- keep the initialization pattern aligned with the PAL assembly for the deformation model state block

## Evidence
- clean rebuild with `ninja`
- net progress from this run: total matched game code increased from `137240` bytes to `137368` bytes (`+128`)
- total matched code increased from `446820` bytes to `446948` bytes (`+128`)

## Plausibility
- this replaces a decompiler-style float literal with the shared SDA constant the game already uses at the PAL callsite
- no control-flow or layout tricks were introduced; the change only improves source fidelity