### PR TITLE
Align pppVertexApMtx entry count type

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -8,7 +8,7 @@
 struct VertexApMtxEntry
 {
 	s16 vertexSetIndex;
-	u16 maxValue;
+	s16 maxValue;
 	u16* vertexIndices;
 };
 


### PR DESCRIPTION
## Summary
- change `VertexApMtxEntry::maxValue` from `u16` to `s16` in `pppVertexApMtx`
- align the Mtx entry layout with the sibling vertex applier units, which already model the count field as a signed halfword

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o - pppVertexApMtx`
- before: `97.17273%`
- after: `98.61364%`

## Why This Is Plausible Source
- `pppVertexAp.cpp` and `pppVertexApLc.cpp` both define the analogous `maxValue` field as `s16`
- the remaining objdiff mismatch previously clustered around signed halfword loads/conversion in the random spawn path, which is consistent with this layout correction