### PR TITLE
pppBreathModel: improve UpdateParticle color handling match

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -283,21 +283,20 @@ extern "C" void UpdateParticle__FP12VBreathModelP12PBreathModelP14_PARTICLE_DATA
 {
     unsigned char* breath = (unsigned char*)pBreathModel;
     unsigned char* particle = (unsigned char*)particleData;
-    unsigned char* color = (unsigned char*)particleColor;
     unsigned int alpha = vColor->m_alpha;
     char frameCount;
     Vec step;
 
-    if (color != NULL) {
-        *(float*)(color + 0x00) += *(float*)(color + 0x10);
-        *(float*)(color + 0x04) += *(float*)(color + 0x14);
-        *(float*)(color + 0x08) += *(float*)(color + 0x18);
-        *(float*)(color + 0x0C) += *(float*)(color + 0x1C);
-        *(float*)(color + 0x10) += *(float*)(breath + 0x38);
-        *(float*)(color + 0x14) += *(float*)(breath + 0x3C);
-        *(float*)(color + 0x18) += *(float*)(breath + 0x40);
-        *(float*)(color + 0x1C) += *(float*)(breath + 0x44);
-        alpha += (unsigned int)(int)*(float*)(color + 0x0C);
+    if (particleColor != NULL) {
+        particleColor->m_color[0] += particleColor->m_colorFrameDeltas[0];
+        particleColor->m_color[1] += particleColor->m_colorFrameDeltas[1];
+        particleColor->m_color[2] += particleColor->m_colorFrameDeltas[2];
+        particleColor->m_color[3] += particleColor->m_colorFrameDeltas[3];
+        particleColor->m_colorFrameDeltas[0] += *(float*)(breath + 0x38);
+        particleColor->m_colorFrameDeltas[1] += *(float*)(breath + 0x3C);
+        particleColor->m_colorFrameDeltas[2] += *(float*)(breath + 0x40);
+        particleColor->m_colorFrameDeltas[3] += *(float*)(breath + 0x44);
+        alpha = (unsigned int)vColor->m_alpha + (int)particleColor->m_color[3];
         if (alpha > 0xFF) {
             alpha = 0xFF;
         }


### PR DESCRIPTION
## Summary
- switch `UpdateParticle` in `pppBreathModel.cpp` from raw byte-offset color access to the existing `_PARTICLE_COLOR` field layout
- keep the same behavior while aligning the update pattern with the sibling particle code in `pppYmBreath.cpp`

## Evidence
- `ninja`: passes
- `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o - UpdateParticle__FP12VBreathModelP12PBreathModelP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`
- before: `86.353195%`
- after: `86.8%`
- size: unchanged at `940`

## Why This Is Plausible Source
- the code now uses the project's shared `_PARTICLE_COLOR` definition instead of manual byte indexing
- the color accumulation logic now matches the style already used by the closely related `pppYmBreath` particle updater
- this improves codegen without introducing coercive hacks or fake linkage changes