### PR TITLE
Restore unsigned pppVertexApMtx entry count

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -8,7 +8,7 @@
 struct VertexApMtxEntry
 {
 	s16 vertexSetIndex;
-	s16 maxValue;
+	u16 maxValue;
 	u16* vertexIndices;
 };
 


### PR DESCRIPTION
## Summary
- restore `VertexApMtxEntry::maxValue` to `u16` in `pppVertexApMtx`
- recover the unsigned bound/indexing codegen used by both the sequential and random vertex-selection paths
- keep the change limited to the ABI-relevant field type that drives the object diff

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o - pppVertexApMtx`

Before:
- `pppVertexApMtx`: `88.204544%`
- `.text`: `88.61842%`
- `.sdata2`: `0.0%`

After:
- `pppVertexApMtx`: `98.61364%`
- `.text`: `98.66228%`
- `.sdata2`: `87.5%`

## Plausibility
`maxValue` is used as an entry count / upper bound for vertex table indexing, and restoring the unsigned field type produces the expected unsigned compare and indexing behavior in the matched code paths instead of compiler-coaxed source changes.