### PR TITLE
Rename GBA status word table symbols

### DIFF
--- a/include/ffcc/p_gba.h
+++ b/include/ffcc/p_gba.h
@@ -35,10 +35,10 @@ struct CGbaPcsTable
 };
 
 extern CGbaPcs GbaPcs;
-extern unsigned int m_table_desc0__7CGbaPcs[];
-extern unsigned int m_table_desc1__7CGbaPcs[];
-extern unsigned int m_table_desc2__7CGbaPcs[];
-extern unsigned int m_table_desc3__7CGbaPcs[];
-extern CGbaPcsTable m_table__7CGbaPcs;
+extern unsigned int gGbaStatusWordTriplet0[];
+extern unsigned int gGbaStatusWordTriplet1[];
+extern unsigned int gGbaStatusWordTriplet2[];
+extern unsigned int gGbaStatusWordTriplet3[];
+extern CGbaPcsTable gGbaStatusWordTable;
 
 #endif // _FFCC_P_GBA_H_

--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -15,7 +15,7 @@ extern const char s_JoyBus__LoadBin___error_801d9de0[];
 const char s_CGbaPcs_80330870[] = "CGbaPcs";
 const char s_JoyBus__LoadBin___error_801d9de0[] = "JoyBus::LoadBin() error\n";
 
-CGbaPcsTable m_table__7CGbaPcs = {
+CGbaPcsTable gGbaStatusWordTable = {
     const_cast<char*>(s_CGbaPcs_80330870),
     {
         0x00000000,
@@ -168,7 +168,7 @@ int CGbaPcs::GetTable(unsigned long tableIndex)
 {
 	unsigned long offset = tableIndex;
 	offset *= 0x15c;
-	return (int)(reinterpret_cast<unsigned char*>(&m_table__7CGbaPcs) + offset);
+	return (int)(reinterpret_cast<unsigned char*>(&gGbaStatusWordTable) + offset);
 }
 
 /*
@@ -207,11 +207,11 @@ void CGbaPcs::Init()
  */
 inline CGbaPcs::CGbaPcs()
 {
-	unsigned int* table = reinterpret_cast<unsigned int*>(&m_table__7CGbaPcs);
-	const unsigned int* desc0 = m_table_desc0__7CGbaPcs;
-	const unsigned int* desc1 = m_table_desc1__7CGbaPcs;
-	const unsigned int* desc2 = m_table_desc2__7CGbaPcs;
-	const unsigned int* desc3 = m_table_desc3__7CGbaPcs;
+	unsigned int* table = reinterpret_cast<unsigned int*>(&gGbaStatusWordTable);
+	const unsigned int* desc0 = gGbaStatusWordTriplet0;
+	const unsigned int* desc1 = gGbaStatusWordTriplet1;
+	const unsigned int* desc2 = gGbaStatusWordTriplet2;
+	const unsigned int* desc3 = gGbaStatusWordTriplet3;
 
 	table[1] = desc0[0];
 	table[2] = desc0[1];


### PR DESCRIPTION
## Summary
Rename the `p_gba` status-word globals to the PAL symbol names already present in `config/GCCP01/symbols.txt`.

This keeps the data layout unchanged, but aligns the source-level symbol ownership with the target object so relocations land on the correct globals.

## What Changed
- renamed `m_table__7CGbaPcs` to `gGbaStatusWordTable`
- renamed the four descriptor triplets to `gGbaStatusWordTriplet0` through `gGbaStatusWordTriplet3`
- updated `CGbaPcs::GetTable` and the inline `CGbaPcs` constructor to use the renamed globals

## Evidence
- `GetTable__7CGbaPcsFUl`: `97.0% -> 100.0%`
- `__sinit_p_gba_cpp`: `96.886795% -> 99.81132%`
- full build still passes with `ninja`
- project data progress increased by 16 bytes in the generated report

## Why This Is Plausible
The remaining mismatch was driven by relocations targeting configured PAL data symbols (`gGbaStatusWordTable` / triplets) while the source used placeholder process-table names. Renaming the globals fixes symbol ownership without changing the underlying structure or behavior.