### PR TITLE
Improve CMcPcs initializer table copy

### DIFF
--- a/src/p_mc.cpp
+++ b/src/p_mc.cpp
@@ -181,28 +181,16 @@ namespace {
 struct CMcPcsInitializer {
     CMcPcsInitializer()
     {
-        static unsigned int initData[] = {
-            0,
-            0xFFFFFFFF,
-            reinterpret_cast<unsigned int>(create__6CMcPcsFv),
-            0,
-            0xFFFFFFFF,
-            reinterpret_cast<unsigned int>(destroy__6CMcPcsFv),
-            0,
-            0xFFFFFFFF,
-            reinterpret_cast<unsigned int>(calc__6CMcPcsFv),
-        };
-
         gMcPcsSingletonPtr = sMcPcsSingletonData;
-        m_table__6CMcPcs[1] = initData[0];
-        m_table__6CMcPcs[2] = initData[1];
-        m_table__6CMcPcs[3] = initData[2];
-        m_table__6CMcPcs[4] = initData[3];
-        m_table__6CMcPcs[5] = initData[4];
-        m_table__6CMcPcs[6] = initData[5];
-        m_table__6CMcPcs[7] = initData[6];
-        m_table__6CMcPcs[8] = initData[7];
-        m_table__6CMcPcs[9] = initData[8];
+        m_table__6CMcPcs[1] = m_table_desc0__6CMcPcs[0];
+        m_table__6CMcPcs[2] = m_table_desc0__6CMcPcs[1];
+        m_table__6CMcPcs[3] = m_table_desc0__6CMcPcs[2];
+        m_table__6CMcPcs[4] = m_table_desc1__6CMcPcs[0];
+        m_table__6CMcPcs[5] = m_table_desc1__6CMcPcs[1];
+        m_table__6CMcPcs[6] = m_table_desc1__6CMcPcs[2];
+        m_table__6CMcPcs[7] = m_table_desc2__6CMcPcs[0];
+        m_table__6CMcPcs[8] = m_table_desc2__6CMcPcs[1];
+        m_table__6CMcPcs[9] = m_table_desc2__6CMcPcs[2];
     }
 };
 


### PR DESCRIPTION
## Summary
- replace the local `initData` blob in `CMcPcsInitializer` with copies from the existing `m_table_desc0__6CMcPcs`, `m_table_desc1__6CMcPcs`, and `m_table_desc2__6CMcPcs` arrays
- keep the initializer behavior the same while removing duplicate descriptor materialization from the source

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_mc -o - __sinit_p_mc_cpp`
- `__sinit_p_mc_cpp` improved from `56.67%` to `63.39%` match in objdiff after the change

## Why this is plausible source
- the descriptor arrays already exist as named globals and represent the same three table entries being copied into `m_table__6CMcPcs`
- copying from those real definitions is more coherent than rebuilding an equivalent anonymous static array inside the initializer
