### PR TITLE
Fix wmm_str .sdata2 split ownership

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -1697,7 +1697,7 @@ wmm_str.cpp:
 	.text       start:0x8017AF14 end:0x8017B494
 	.data       start:0x80215BD8 end:0x8021645C
 	.data       start:0x8021645C end:0x80216758
-	.sdata2     start:0x803336A0 end:0x803336AC
+	.sdata2     start:0x803336D8 end:0x803336E0
 
 base/PPCArch.c:
 	.text       start:0x8017B494 end:0x8017B5A8


### PR DESCRIPTION
## Summary
- reassign `wmm_str.cpp` to the local signed-bias `.sdata2` constant it actually emits
- stop claiming the unrelated `0x803336A0-0x803336AC` string range for this unit

## Evidence
- `main/wmm_str` `.sdata2`: `50.0%` -> `100.0%`
- `main/wmm_str` `.text`: `99.80114%` -> `99.829544%`
- `GetSlotABXPos__8CMenuPcsFi`: `99.94949%` -> `100.0%`

## Why this is plausible
- the source object already contained a local `DOUBLE_803336D8` and referenced it from both menu-position helpers
- the previous split claim pulled in unrelated small-data strings instead, so this change fixes section ownership rather than coercing source code