### PR TITLE
Use PPP program names in CGraphic::Thread

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -11,6 +11,7 @@
 #include "ffcc/file.h"
 #include "ffcc/pad.h"
 #include "ffcc/p_camera.h"
+#include "ffcc/pppfunctbl.h"
 #include "ffcc/system.h"
 #include "ffcc/util.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/printf.h"
@@ -534,7 +535,8 @@ void CGraphic::Thread()
                     } else if (drawSyncPart == 0x7FFE) {
                         System.Printf(DAT_801d63c0, PtrAt(this, 0x7368), S32At(this, 0x736C));
                     } else {
-                        System.Printf(DAT_801d6400, PtrAt(this, 0x7368), S32At(this, 0x736C), sGraphicUnknownOrderName);
+                        System.Printf(DAT_801d6400, PtrAt(this, 0x7368), S32At(this, 0x736C),
+                                      pppGetSysProgTable()[drawSyncPart].m_pppName);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- update `CGraphic::Thread` to use the PPP system program table for draw-sync debug output instead of the placeholder unknown-order string
- include `ffcc/pppfunctbl.h` so the debug path resolves through the existing `pppGetSysProgTable()` API
- keep the change narrow and source-plausible: it restores a concrete original lookup rather than introducing compiler-forcing logic

## Evidence
- `ninja` succeeds
- `main/graphic` fuzzy match: `74.91811%` -> `74.988976%`
- `Thread__8CGraphicFv` fuzzy match: `54.050632%` -> `55.759495%`
- `DrawBound__8CGraphicFR6CBound8_GXColor` is unchanged at `52.64629%`

## Plausibility
- Ghidra for `Thread__8CGraphicFv` points to PPP program-name lookup on this debug print path
- the change removes a decomp placeholder in favor of an existing game data source already used elsewhere in the codebase
- no fake symbols, hardcoded addresses, section coercion, or ABI workarounds were introduced
