### PR TITLE
Improve pppSRandFV register allocation

### DIFF
--- a/src/pppSRandFV.cpp
+++ b/src/pppSRandFV.cpp
@@ -35,10 +35,10 @@ struct PppSRandFVParam3 {
 
 void pppSRandFV(void* param1, void* param2, void* param3)
 {
-    f32* randVec;
     PppSRandFVParam2* cfg = (PppSRandFVParam2*)param1;
     u8* self = (u8*)param2;
     PppSRandFVParam3* info = (PppSRandFVParam3*)param3;
+    f32* randVec;
 
     if (gPppCalcDisabled != 0) {
         return;


### PR DESCRIPTION
## Summary
- reorder the local declarations in `pppSRandFV` to better match the original Metrowerks register allocation
- keep the existing parameter usage and runtime behavior unchanged

## Evidence
- unit: `main/pppSRandFV`
- symbol: `pppSRandFV`
- objdiff before: `98.818184%`
- objdiff after: `99.181816%`

## Why this is plausible source
- this is a minimal source-level cleanup in a small particle helper
- the change only affects local variable lifetime / register pressure rather than introducing compiler-coaxing constructs or fake linkage hacks

## Validation
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppSRandFV -o - pppSRandFV`