### PR TITLE
Improve pppFrameYmTracer2 match

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -264,11 +264,8 @@ void pppFrameYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, pp
 
     for (i = 0; (s32)i < (s32)(param_2->m_payload[9] + 1); i++) {
         iVar8 = *(u16*)(param_2->m_payload + 4) - 2;
-        pfVar6 = (float*)(entries + iVar8);
-
         for (; (s32)i <= iVar8; iVar8--) {
             copyPolygonData(entries + (iVar8 + 1), entries + iVar8);
-            pfVar6 -= 10;
         }
 
         fVar2 = work->initWork[0];


### PR DESCRIPTION
## Summary
- remove an unused `pfVar6` setup and decrement from the `pppFrameYmTracer2` history-shift loop
- keep the existing copy path intact while dropping dead decomp artifacts that were not contributing to generated code

## Evidence
- `pppFrameYmTracer2`: 86.66907% -> 87.01079%
- `main/pppYmTracer2` `.text`: 87.33568% -> 87.50264%
- `ninja` succeeds for GCCP01 after the change

## Plausibility
This is a source cleanup rather than compiler coaxing. The removed `pfVar6` variable was assigned and decremented inside the loop but never read, so deleting it makes the function closer to plausible original source and improves objdiff without changing behavior.