### PR TITLE
Fix signed vertex count in pppVertexApMtx

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -8,7 +8,7 @@
 struct VertexApMtxEntry
 {
 	s16 vertexSetIndex;
-	u16 maxValue;
+	s16 maxValue;
 	u16* vertexIndices;
 };
 
@@ -156,7 +156,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 		case 1:
 			while (count-- != 0) {
 				f32 randValue = Math.RandF();
-				f32 maxValue = (f32)(u16)entry->maxValue;
+				f32 maxValue = (f32)entry->maxValue;
 				int outValue = (int)(randValue * maxValue);
 				u16* vertexIndices = entry->vertexIndices;
 				u16 vertexIndex = vertexIndices[outValue];


### PR DESCRIPTION
## Summary
- treat `VertexApMtxEntry::maxValue` as a signed halfword in `src/pppVertexApMtx.cpp`
- keep the runtime state layout unchanged and update the random-path float conversion to use the corrected signed value

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o - pppVertexApMtx`
- `pppVertexApMtx`: `97.17273%` -> `98.61364%`
- `main/pppVertexApMtx` unit fuzzy match in `build/GCCP01/report.json`: `98.68421%`

## Plausibility
The diff was caused by ABI-relevant signedness on a serialized halfword field. Using `s16` for `maxValue` matches the observed halfword loads and the float conversion pattern without introducing coercion hacks.