### PR TITLE
Improve CGraphic::SetViewport match

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -368,12 +368,8 @@ void CGraphic::SetStdPixelFmt()
  */
 void CGraphic::SetViewport()
 {
-    register void* renderMode = PtrAt(this, 0x71E0);
-    register u16 width = U16At(renderMode, 4);
-    register u16 height = U16At(renderMode, 6);
-
-    GXSetViewport(kGraphicZeroF, kGraphicZeroF, (f32)width, (f32)height, kGraphicZeroF, kGraphicOneF);
-    GXSetScissor(0, 0, width, height);
+    GXSetViewport(0.0f, 0.0f, (f32)U16At(PtrAt(this, 0x71E0), 4), (f32)U16At(PtrAt(this, 0x71E0), 6), 0.0f, 1.0f);
+    GXSetScissor(0, 0, U16At(PtrAt(this, 0x71E0), 4), U16At(PtrAt(this, 0x71E0), 6));
 }
 
 /*


### PR DESCRIPTION
## Summary
- simplify `CGraphic::SetViewport` to read EFB dimensions directly at each GX call site
- remove local caching/register hints that were producing worse codegen in `graphic.o`

## Improved symbols
- `SetViewport__8CGraphicFv`
- unit: `main/graphic`

## Evidence
- `SetViewport__8CGraphicFv`: 55.441177% -> 84.382355%
- `SetViewport__8CGraphicFv` diff count: 23 -> 16
- `main/graphic` `.text` match: 75.0% -> 75.02467%

## Why this is plausible source
- the change keeps the function behavior identical and only removes unnecessary temporaries
- directly reading the render mode dimensions at the call sites is straightforward engine code and avoids compiler-coaxing artifacts