### PR TITLE
Improve pppVertexApMtx matching

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -8,7 +8,7 @@
 struct VertexApMtxEntry
 {
 	s16 vertexSetIndex;
-	u16 maxValue;
+	s16 maxValue;
 	u16* vertexIndices;
 };
 
@@ -129,7 +129,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 					if (childData == 0) {
 						child = 0;
 					} else {
-						child = pppCreatePObject(pppMngStPtr, childData);
+						child = pppCreatePObject((_pppMngSt*)pppMngStPtr, childData);
 						*(void**)((u8*)child + 0x4) = parent;
 					}
 
@@ -156,7 +156,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 		case 1:
 			while (count-- != 0) {
 				f32 randValue = Math.RandF();
-				f32 maxValue = (f32)(u16)entry->maxValue;
+				f32 maxValue = (f32)entry->maxValue;
 				int outValue = (int)(randValue * maxValue);
 				u16* vertexIndices = entry->vertexIndices;
 				u16 vertexIndex = vertexIndices[outValue];
@@ -177,7 +177,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 					if (childData == 0) {
 						child = 0;
 					} else {
-						child = pppCreatePObject(pppMngStPtr, childData);
+						child = pppCreatePObject((_pppMngSt*)pppMngStPtr, childData);
 						*(void**)((u8*)child + 0x4) = parent;
 					}
 
@@ -200,8 +200,6 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 					}
 				}
 			}
-			break;
-		default:
 			break;
 		}
 		state->countdown = data->spawnDelay;


### PR DESCRIPTION
## Summary
- change `VertexApMtxEntry::maxValue` to `s16` to match the sibling vertex-ap entry layouts
- use the same `_pppMngSt*` cast form as the matching `pppVertexAp` variants when creating child objects
- drop the unreachable `default` arm in the mode switch to keep the generated control flow closer to the original

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o - pppVertexApMtx`
- before: `97.17273%` match
- after: `98.61364%` match
- remaining instruction diffs: `4`

## Plausibility
These changes make `pppVertexApMtx` consistent with the already decompiled `pppVertexAp` and `pppVertexApLc` implementations instead of adding compiler-coaxing hacks. The signed entry count is especially likely to be original source, since the same field is signed in the related particle vertex spawners.