### PR TITLE
Match pppRenderYmDrawMdlTexAnm

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -110,17 +110,20 @@ void pppRenderYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step,
 {
     pppYmDrawMdlTexAnmObject* ymDrawMdlTexAnm;
     pppModelSt* model;
-    pppYmDrawMdlTexAnmColorBlock* colorBlock;
+    u8* colorBase;
     pppFMATRIX matrix;
     u8* initBytes;
     u8* stepBytes;
+    s32 colorOffset;
+
     ymDrawMdlTexAnm = (pppYmDrawMdlTexAnmObject*)object;
     model = (pppModelSt*)GetMapMeshTable()[step->m_dataValIndex];
     if (model == NULL) {
         return;
     }
 
-    colorBlock = GetYmDrawMdlTexAnmColorBlock(ymDrawMdlTexAnm, ctrl);
+    colorOffset = ctrl->m_serializedDataOffsets[0];
+    colorBase = (u8*)ymDrawMdlTexAnm + 0x80 + colorOffset;
 
     pppUnitMatrix(matrix);
     matrix.value[2][2] *= FLOAT_80330548;
@@ -130,7 +133,7 @@ void pppRenderYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step,
 
     initBytes = (u8*)&step->m_initWOrk;
     stepBytes = (u8*)&step->m_stepValue;
-    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(&colorBlock->m_color, &ymDrawMdlTexAnm->m_modelViewMatrix,
+    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc((pppCVECTOR*)(colorBase + 8), &ymDrawMdlTexAnm->m_modelViewMatrix,
                                                                step->m_arg3, step->m_payload[0xC], initBytes[2], initBytes[1],
                                                                initBytes[3], stepBytes[0], stepBytes[1], stepBytes[2]);
 


### PR DESCRIPTION
## Summary
- rewrite the serialized color-block setup in `pppRenderYmDrawMdlTexAnm` to use the raw byte base plus serialized offset directly
- keep the existing object layout and call flow intact while matching the original address-formation pattern for the draw env color pointer

## Evidence
- `ninja` succeeds
- `pppRenderYmDrawMdlTexAnm` now reaches `100.0%` in objdiff
- `main/pppYmDrawMdlTexAnm` improved from `1/4` matched functions and `99.3%` code in target selection to `2/4` matched functions and `.text` `99.39047%`
- overall progress increased by one matched function and `632` matched code bytes in the generated progress report

## Plausibility
- this is not compiler coaxing through fake symbols or section tricks; it makes the serialized color-block access explicit in the same object-relative form already used elsewhere in the unit
- the change preserves the original control flow and data layout while removing an extra typed helper indirection that was obscuring the codegen shape