### PR TITLE
Adjust emission alpha scaling types

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -398,7 +398,7 @@ void pppFrameEmission(pppEmission* pppEmission_, pppEmissionUnkB* param_2, pppEm
     *(u32*)(model + 0x104) = (u32)Emission_AfterDrawMeshCallback;
 
     u8 baseAlpha = dataSet[0xB];
-    float alphaScale = (float)baseAlpha / FLOAT_803311e0;
+    double alphaScale = (double)((float)baseAlpha / FLOAT_803311e0);
     state->m_colorR = dataSet[8];
     state->m_colorG = dataSet[9];
     state->m_colorB = dataSet[0xA];
@@ -466,7 +466,7 @@ void pppFrameEmission(pppEmission* pppEmission_, pppEmissionUnkB* param_2, pppEm
             }
 
             particle->m_fieldA = particle->m_fieldA - 1;
-            int alpha = (int)((float)particle->m_alpha * alphaScale);
+            int alpha = (int)((double)particle->m_alpha * alphaScale);
 
             if (particle->m_fieldA < 1) {
                 s16 jitter = 0;


### PR DESCRIPTION
## Summary
- change `pppFrameEmission` to keep the emission alpha scale in a `double` intermediate
- use the same `double` intermediate when converting per-particle alpha back to an integer

## Evidence
- `ninja -j4` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppEmission -o - pppFrameEmission` improved from `85.45385%` on clean `main` to `85.61539%` with this branch

## Why this is plausible source
- Ghidra shows the alpha-scale path flowing through a `double` temporary before the final integer conversion
- the change is limited to type semantics in the existing particle-alpha math; it does not add compiler-coaxing helpers or change control flow