### PR TITLE
Match CPtrArray<CTexture*> constructor init order

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -144,8 +144,8 @@ static inline CTexture* AllocTexture()
 template <>
 CPtrArray<CTexture*>::CPtrArray()
 {
-    m_numItems = 0;
     m_size = 0;
+    m_numItems = 0;
     m_defaultSize = 0x10;
     m_items = 0;
     m_stage = 0;


### PR DESCRIPTION
## Summary
- reorder the first two zero-initializations in `CPtrArray<CTexture*>::CPtrArray()`
- preserve the existing field values while matching the constructor's original store order

## Evidence
- `ninja` succeeds
- `main/textureman` improved from 19/38 matched functions to 20/38 matched functions
- `main/textureman` matched code improved by 52 bytes: 1160 -> 1212
- `__ct__21CPtrArray<P8CTexture>Fv` now reports 100% in `build/GCCP01/report.json`

## Plausibility
- this is a source-plausible constructor ordering fix, not a compiler-coaxing hack
- it only changes the order of two equivalent zero assignments and leaves the resulting object state unchanged
