### PR TITLE
Refine pppYmChangeTex material setup

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -470,27 +470,37 @@ void ChangeTex_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void*
 void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void* param_3, int meshIdx, int displayListIdx, float (*) [4])
 {
 	ChangeTexMeshRef* meshes = *(ChangeTexMeshRef**)((char*)model + 0xAC);
-	ChangeTexDisplayList* displayList = meshes[meshIdx].m_data->m_displayLists + displayListIdx;
-	int textureInfo = *(int*)((char*)param_2 + 0x1C);
+	ChangeTexMeshData* meshData = meshes[meshIdx].m_data;
+	ChangeTexDisplayList* displayList = meshData->m_displayLists + displayListIdx;
 
 	if (*(u8*)((char*)param_3 + 0x14) == 0) {
-		*(int*)(MaterialManRaw() + 0xd0) = (int)param_2 + 0x1c + 0x28;
-		*(int*)(MaterialManRaw() + 0x44) = 0xFFFFFFFF;
-		*(char*)(MaterialManRaw() + 0x4c) = 0xFF;
-		*(int*)(MaterialManRaw() + 0x11c) = 0;
+		int drawTevBits = 0xACE0F;
+		int fullWord = -1;
+		u8 fullByte = 0xFF;
+		int zero = 0;
+		int fullTevBits;
+
+		*(int*)(MaterialManRaw() + 0x128) = zero;
+		fullTevBits = drawTevBits | 0x1000;
+		*(int*)(MaterialManRaw() + 0x48) = drawTevBits;
+		*(int*)(MaterialManRaw() + 0x12c) = 0x1E;
+		*(int*)(MaterialManRaw() + 0x130) = zero;
+		*(int*)(MaterialManRaw() + 0x44) = fullWord;
+		*(char*)(MaterialManRaw() + 0x4c) = fullByte;
+		*(int*)(MaterialManRaw() + 0x11c) = zero;
 		*(int*)(MaterialManRaw() + 0x120) = 0x1E;
-		*(int*)(MaterialManRaw() + 0x124) = 0;
-		*(char*)(MaterialManRaw() + 0x205) = 0xFF;
-		*(char*)(MaterialManRaw() + 0x206) = 0xFF;
-		*(int*)(MaterialManRaw() + 0x58) = 0;
-		*(int*)(MaterialManRaw() + 0x5c) = 0;
-		*(char*)(MaterialManRaw() + 0x208) = 0;
-		*(int*)(MaterialManRaw() + 0x48) = 0xADE0F;
-		*(int*)(MaterialManRaw() + 0xD0) = textureInfo + 0x28;
-		*(int*)(MaterialManRaw() + 0x128) = 0;
-		*(int*)(MaterialManRaw() + 0x12c) = 0x1e;
-		*(int*)(MaterialManRaw() + 0x130) = 0;
-		*(int*)(MaterialManRaw() + 0x40) = 0xADE0F;
+		*(int*)(MaterialManRaw() + 0x124) = zero;
+		*(char*)(MaterialManRaw() + 0x205) = fullByte;
+		*(char*)(MaterialManRaw() + 0x206) = fullByte;
+		*(int*)(MaterialManRaw() + 0x58) = zero;
+		*(int*)(MaterialManRaw() + 0x5c) = zero;
+		*(char*)(MaterialManRaw() + 0x208) = zero;
+		*(int*)(MaterialManRaw() + 0x48) = fullTevBits;
+		*(int*)(MaterialManRaw() + 0xD0) = *(int*)((char*)param_2 + 0x1C) + 0x28;
+		*(int*)(MaterialManRaw() + 0x128) = zero;
+		*(int*)(MaterialManRaw() + 0x12c) = 0x1E;
+		*(int*)(MaterialManRaw() + 0x130) = zero;
+		*(int*)(MaterialManRaw() + 0x40) = fullTevBits;
 	}
 
 	SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(


### PR DESCRIPTION
## Summary
- reshape the material setup block in `ChangeTex_DrawMeshDLCallback` to use explicit locals for TEV state and zero/full-byte values
- keep behavior unchanged while making the emitted code for `main/pppYmChangeTex` closer to the target

## Evidence
- `main/pppYmChangeTex` `.text`: `92.90139% -> 92.99538%`
- `pppFrameYmChangeTex`: `91.93038% -> 92.12342%`
- `ninja`: passes

## Plausibility
- the change replaces repeated immediate stores with named locals and staged TEV setup, matching the style already used by the sibling `pppChangeTex` implementation
- no fake symbols, address hacks, or section forcing were introduced
