### PR TITLE
Fix CPtrArray<CMaterial*> ctor init order in materialman

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -103,8 +103,8 @@ private:
 template <>
 CPtrArray<CMaterial*>::CPtrArray()
 {
-    m_numItems = 0;
     m_size = 0;
+    m_numItems = 0;
     m_defaultSize = 0x10;
     m_items = 0;
     m_stage = 0;


### PR DESCRIPTION
## Summary
- reorder the local `CPtrArray<CMaterial*>` constructor stores in `materialman.cpp` to match the pattern used by other `CPtrArray` specializations
- keep the change scoped to the material manager specialization so the branch only carries the verified improvement

## Evidence
- `ninja -j4` now reports `Code: 448728 / 1855304 bytes (2893 / 4733 functions)`
- before this change, the same build reported `Code: 448676 / 1855304 bytes (2892 / 4733 functions)`
- `build/GCCP01/report.json` now records `__ct__22CPtrArray<P9CMaterial>Fv` at `100.0` fuzzy match within `main/materialman`

## Plausibility
- this aligns `materialman.cpp` with the existing initialization order already used by matched `CPtrArray` specializations in nearby units such as `textureman.cpp` and `map.cpp`
- the change is source-level cleanup rather than compiler coaxing or section forcing