### PR TITLE
Improve SetUSBData display copy matching

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -205,25 +205,8 @@ void CFunnyShapePcs::SetUSBData()
         m_displayPending.unk30 = BSWAP32(m_displayPending.unk30);
         DCStoreRange(&m_displayPending, 0x40);
 
-        GXColor clear = m_displayPending.clear;
-        GXSetCopyClear(clear, 0xFFFFFF);
-
-        m_displayCurrent.flags = m_displayPending.flags;
-        memcpy(&m_displayCurrent.clear, &m_displayPending.clear, sizeof(GXColor));
-        m_displayCurrent.unk08 = m_displayPending.unk08;
-        m_displayCurrent.unk0C = m_displayPending.unk0C;
-        m_displayCurrent.unk10 = m_displayPending.unk10;
-        m_displayCurrent.unk14 = m_displayPending.unk14;
-        m_displayCurrent.unk18 = m_displayPending.unk18;
-        m_displayCurrent.unk1C = m_displayPending.unk1C;
-        m_displayCurrent.unk20 = m_displayPending.unk20;
-        m_displayCurrent.unk24 = m_displayPending.unk24;
-        m_displayCurrent.unk28 = m_displayPending.unk28;
-        m_displayCurrent.unk2A = m_displayPending.unk2A;
-        m_displayCurrent.unk2C = m_displayPending.unk2C;
-        m_displayCurrent.unk30 = m_displayPending.unk30;
-        m_displayCurrent.unk34[0] = m_displayPending.unk34[0];
-        memcpy(&m_displayCurrent.unk34[1], &m_displayPending.unk34[1], 0x0B);
+        GXSetCopyClear(m_displayPending.clear, 0xFFFFFF);
+        memcpy(&m_displayCurrent, &m_displayPending, sizeof(m_displayCurrent));
         break;
     }
     case 15: {


### PR DESCRIPTION
## Summary
- simplify the `SetUSBData__14CFunnyShapePcsFv` case-12 display-status copy path in `src/FS_USB_Process.cpp`
- replace the manual field-by-field `m_displayPending -> m_displayCurrent` copy with a single struct copy after `GXSetCopyClear`
- keep behavior the same while moving the generated code closer to the original source shape

## Evidence
- `ninja`: passes
- `build/tools/objdiff-cli diff -p . -u main/FS_USB_Process -o - SetUSBData__14CFunnyShapePcsFv`
- `.text` match for `main/FS_USB_Process` improved from `18.334846%` to `20.461975%`
- `.rodata` stayed at `100%`
- `.data` remained `0%`

## Plausibility
- the original decomp already shows case 12 as a mostly direct struct-transfer path
- this removes decomp-driven manual member shuffling and lets the compiler emit a more natural bulk-copy sequence
- no fake symbols, forced sections, or compiler-coaxing hacks were introduced
