### PR TITLE
Improve pppPointRAp codegen

### DIFF
--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -57,25 +57,23 @@ void pppPointRAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
         float* trig = gPppTrigTable;
         s32 angleA = (s32)(gPppPointRApRandomAngleRange * Math.RandF() - gPppPointRApRandomAngleBias);
         float scaleA = payload->m_radius;
-        float planarOff = scaleA * *(float*)((u8*)trig + ((angleA + 0x4000) & 0xFFFC));
         float yOff = scaleA * *(float*)((u8*)trig + (angleA & 0xFFFC));
+        float planarOff = scaleA * *(float*)((u8*)trig + ((angleA + 0x4000) & 0xFFFC));
         float spinRand = Math.RandF();
         float spinAngle = gPppPointRApRandomAngleRange * spinRand;
         s32 angleB = (s32)(gPppPointRApSpinScale * spinAngle);
-        float xOff = *(float*)((u8*)trig + (angleB & 0xFFFC));
-        float zOff = *(float*)((u8*)trig + ((angleB + 0x4000) & 0xFFFC));
-        xOff = planarOff * xOff;
-        zOff = planarOff * zOff;
+        float xOff = planarOff * *(float*)((u8*)trig + (angleB & 0xFFFC));
+        planarOff = planarOff * *(float*)((u8*)trig + ((angleB + 0x4000) & 0xFFFC));
         Vec* dstPos = (Vec*)((u8*)obj + payload->m_childPosOffset + 0x80);
         Vec* dstVel = (Vec*)((u8*)obj + payload->m_childVelocityOffset + 0x80);
 
         dstPos->x = srcPos->x + xOff;
         dstPos->y = srcPos->y + yOff;
-        dstPos->z = srcPos->z + zOff;
+        dstPos->z = srcPos->z + planarOff;
 
         dstVel->x = xOff * payload->m_speedScale;
         dstVel->y = yOff * payload->m_speedScale;
-        dstVel->z = zOff * payload->m_speedScale;
+        dstVel->z = planarOff * payload->m_speedScale;
 
         state[1] = payload->m_cooldown;
     }


### PR DESCRIPTION
Summary:
- Reworked the spin offset math in `pppPointRAp` to reuse the planar offset value instead of introducing a separate `zOff` temporary.
- This keeps the source plausible while aligning the compiler's float register allocation more closely with the original object.

Evidence:
- `ninja -j1` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/pppPointRAp -o - pppPointRAp` improved from `99.557526%` to `99.60177%` match for `pppPointRAp`.
- `pppPointRApCon` remains `100%` matched.

Why this is plausible source:
- The function still expresses the same particle spawn math, but now reuses the planar radial term directly when producing the child Z offset and velocity, which is a reasonable original-source formulation rather than compiler coaxing.
