### PR TITLE
Improve pppPointRAp register allocation

### DIFF
--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -62,9 +62,10 @@ void pppPointRAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
         float spinRand = Math.RandF();
         float spinAngle = gPppPointRApRandomAngleRange * spinRand;
         s32 angleB = (s32)(gPppPointRApSpinScale * spinAngle);
-        float xOff = *(float*)((u8*)trig + (angleB & 0xFFFC));
-        float zOff = *(float*)((u8*)trig + ((angleB + 0x4000) & 0xFFFC));
-        xOff = planarOff * xOff;
+        float xOff;
+        float zOff;
+        xOff = planarOff * *(float*)((u8*)trig + (angleB & 0xFFFC));
+        zOff = *(float*)((u8*)trig + ((angleB + 0x4000) & 0xFFFC));
         zOff = planarOff * zOff;
         Vec* dstPos = (Vec*)((u8*)obj + payload->m_childPosOffset + 0x80);
         Vec* dstVel = (Vec*)((u8*)obj + payload->m_childVelocityOffset + 0x80);


### PR DESCRIPTION
## Summary
- reshape the `pppPointRAp` X/Z offset temporaries so MWCC keeps the second trig path closer to the original register flow
- preserve existing behavior and keep the source plausible, with no section hacks or fake symbols

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppPointRAp -o - pppPointRAp`
- before: `99.557526%` match, `8` instruction diffs
- after: `99.867256%` match, `3` instruction diffs

## Why this is plausible source
- the change only adjusts temporary initialization order in normal C++ source
- it improves register allocation naturally rather than coercing the compiler with non-source-like tricks
