### PR TITLE
Remove unused randchar helpers from CV particle units

### DIFF
--- a/include/ffcc/pppRandCV.h
+++ b/include/ffcc/pppRandCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppRandDownCV.h
+++ b/include/ffcc/pppRandDownCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDDOWNCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppRandUpCV.h
+++ b/include/ffcc/pppRandUpCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDUPCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -85,17 +85,3 @@ void pppRandCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -84,17 +84,3 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
         target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -79,17 +79,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- remove unused `randchar` declarations from the `pppRandCV`, `pppRandDownCV`, and `pppRandUpCV` headers
- remove the matching dead helper definitions from the three CV particle unit sources
- keep the live particle functions unchanged while eliminating extra metadata/symbol noise from unused helpers

## Evidence
- `main/pppRandDownCV` data match improved from `44.44%` to `100.0%`
- `main/pppRandDownCV` extab and extabindex now both diff at `100.0%`
- project report matched data increased from `1069819` to `1069867` bytes (`+48`)

## Why This Is Plausible Source
- the removed helpers were marked `UNUSED` and had no call sites in the repo
- deleting dead exported helpers is cleaner and more faithful than keeping unreferenced code that only emits extra metadata
- the live CV particle routines and their constant pools were left intact
