### PR TITLE
Improve RedMidiCtrl rate direct handlers

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1823,16 +1823,12 @@ void __MidiCtrl_VibrateDepthChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA
 void __MidiCtrl_VibrateRateDirect(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
 	int* trackData = (int*)track;
-	int rate;
-	int rateDivisor;
+	u32 rate = 0x100;
 
-	if (*(u8*)trackData[0] == 0) {
-		rate = 0x100;
-	} else {
+	if (*(u8*)trackData[0] != 0) {
 		rate = *(u8*)trackData[0];
 	}
-	rateDivisor = rate;
-	trackData[0x1e] = 0x100000 / rateDivisor;
+	trackData[0x1e] = 0x100000 / rate;
 	*(short*)(trackData + 0x23) = 0;
 	trackData[0] += 1;
 }
@@ -2022,16 +2018,12 @@ void __MidiCtrl_TremoloDepthChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA
 void __MidiCtrl_TremoloRateDirect(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
 	int* trackData = (int*)track;
-	int rate;
-	int rateDivisor;
+	u32 rate = 0x100;
 
-	if (*(u8*)trackData[0] == 0) {
-		rate = 0x100;
-	} else {
+	if (*(u8*)trackData[0] != 0) {
 		rate = *(u8*)trackData[0];
 	}
-	rateDivisor = rate;
-	trackData[0x26] = 0x100000 / rateDivisor;
+	trackData[0x26] = 0x100000 / rate;
 	*(short*)(trackData + 0x2b) = 0;
 	trackData[0] += 1;
 }
@@ -2192,17 +2184,12 @@ void __MidiCtrl_ShakeDepthChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* 
 void __MidiCtrl_ShakeRateDirect(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
 	int* trackData = (int*)track;
-	int rate;
-	int rateDivisor;
+	u32 rate = 0x100;
 
-	if (*(u8*)trackData[0] == 0) {
-		rate = 0x100;
-	} else {
+	if (*(u8*)trackData[0] != 0) {
 		rate = *(u8*)trackData[0];
 	}
-
-	rateDivisor = rate;
-	trackData[0x2e] = 0x100000 / rateDivisor;
+	trackData[0x2e] = 0x100000 / rate;
 	*(short*)(trackData + 0x34) = 0;
 	trackData[0] += 1;
 }


### PR DESCRIPTION
## Summary
- simplify the three 96-byte `*RateDirect` RedMidiCtrl handlers to use a single defaulted rate value
- remove the redundant `rateDivisor` temporary in favor of the actual divisor used by the command
- keep the source behavior unchanged while tightening the generated code around the rate selection path

## Improved symbols
- `__MidiCtrl_VibrateRateDirect__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_TremoloRateDirect__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- `__MidiCtrl_ShakeRateDirect__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Evidence
- `ninja` builds cleanly for `GCCP01`
- objdiff improved each target from `44.583332%` to `45.0%`

## Plausibility
This is a source cleanup rather than output forcing: the handlers now express the direct-rate command as a single defaulted rate value, which matches the surrounding command-handler style better than carrying a duplicated divisor temporary.