### PR TITLE
Remove stray randchar from pppRandUpCV

### DIFF
--- a/include/ffcc/pppRandUpCV.h
+++ b/include/ffcc/pppRandUpCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDUPCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -79,17 +79,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- remove the unused `randchar` declaration from `include/ffcc/pppRandUpCV.h`
- remove the stray local `randchar` helper emitted by `src/pppRandUpCV.cpp`
- keep `pppRandUpCV` behavior unchanged while fixing the object's data/linkage shape

## Evidence
- `ninja` succeeds
- `python3 tools/agent_select_target.py` reported `main/pppRandUpCV` at `data 44.44%` before this change
- `build/GCCP01/report.json` now reports `main/pppRandUpCV` with `matched_data_percent: 100.0`
- `build/tools/objdiff-cli diff -p . -u main/pppRandUpCV -o - pppRandUpCV` now shows `extab` and `extabindex` at `100.0%`; `.text` remains `99.57627%`

## Plausibility
The helper was not referenced by `pppRandUpCV`, and keeping it in this translation unit only introduced extra exception metadata and an extra symbol. Removing it makes the object layout more coherent without adding compiler-coaxing logic.