### PR TITLE
Match CGQuadObj::Reset bounds constants

### DIFF
--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -6,6 +6,9 @@
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 
+extern const float kQuadObjMaxBounds;
+extern const float kQuadObjMinBounds;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -125,10 +128,10 @@ void CGQuadObj::Reset(float base, float height)
 	m_vertexCount = 0;
 	m_yBase = base;
 	m_yHeight = height;
-	m_bboxMinZ = 20.0f;
-	m_bboxMinX = 20.0f;
-	m_bboxMaxZ = 1.0f;
-	m_bboxMaxX = 1.0f;
+	m_bboxMinZ = kQuadObjMaxBounds;
+	m_bboxMinX = kQuadObjMaxBounds;
+	m_bboxMaxZ = kQuadObjMinBounds;
+	m_bboxMaxX = kQuadObjMinBounds;
 }
 
 /*


### PR DESCRIPTION
## Summary
- replace `CGQuadObj::Reset`'s raw `20.0f` / `1.0f` literals with the existing `kQuadObjMaxBounds` / `kQuadObjMinBounds` symbols
- preserve the current source shape while matching the original `.sdata2` linkage for the reset bounds constants

## Improved symbols
- `Reset__9CGQuadObjFff`

## Evidence
- before: `Reset__9CGQuadObjFff` was a near-match (`99.09091%`) with `.sdata2`/SDA relocation mismatches
- after: `build/tools/objdiff-cli diff -p . -u main/quadobj -o - Reset__9CGQuadObjFff` reports `100.0`
- rebuilt successfully with `ninja`

## Plausibility
- this uses the existing named bound constants from the symbol map instead of compiler-generated local float literals
- the resulting source is cleaner and more consistent with how adjacent linked constants are represented elsewhere in the project
