### PR TITLE
Remove stray randchar from pppRandUpCV

### DIFF
--- a/include/ffcc/pppRandUpCV.h
+++ b/include/ffcc/pppRandUpCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDUPCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -79,17 +79,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- remove the stray `randchar` declaration and definition from the `pppRandUpCV` unit
- leave `main/pppRandUpCV` with only the intended `pppRandUpCV` function and its data

## Evidence
- `ninja` succeeds on GCCP01 after the change
- objdiff for `main/pppRandUpCV` reports one code symbol (`pppRandUpCV`, 99.57627%) and 100% matched data/extab sections
- the deleted helper was marked `PAL Address: UNUSED`, so removing it reduces non-original source from the unit rather than adding compiler coaxing

## Plausibility
This looks like cleanup toward original source shape: the extra helper was not part of the shipped unit, and the remaining code is the actual target function.