### PR TITLE
Improve packed CAnim node flag decoding in chara_anim

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -316,12 +316,13 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 									node->m_dataOffset = dataOffset;
 								}
 
-								node->m_flags = static_cast<unsigned int>(
-								    __rlwimi(static_cast<int>(node->m_flags), (node->m_flags >> 0xD) | (mode << shift), 13, 1, 18));
+								node->m_flags =
+								    ((((node->m_flags >> 0xD) & 0x3FFFF) | ((static_cast<unsigned int>(mode) << shift) & 0x3FFFF))
+								      << 0xD) |
+								    (node->m_flags & 0x80001FFF);
 
 								if ((5 < i) && (type != 0)) {
-									*reinterpret_cast<unsigned char*>(&node->m_flags) =
-									    static_cast<unsigned char>(__rlwimi(*reinterpret_cast<unsigned char*>(&node->m_flags), 1, 7, 24, 24));
+									*reinterpret_cast<unsigned char*>(&node->m_flags) |= 0x80;
 								}
 
 								i++;
@@ -371,12 +372,10 @@ void CChara::CAnim::InitQuantize()
  */
 CChara::CAnimNode::CAnimNode()
 {
-	int zero = 0;
 	CAnimNodeFields& node = AnimNode(this);
 
-	*reinterpret_cast<unsigned char*>(&node.m_flags) =
-	    static_cast<unsigned char>(__rlwimi(*reinterpret_cast<unsigned char*>(&node.m_flags), zero, 7, 24, 24));
-	node.m_flags = static_cast<unsigned int>(__rlwimi(static_cast<int>(node.m_flags), zero, 13, 1, 18));
+	*reinterpret_cast<unsigned char*>(&node.m_flags) &= 0x7F;
+	node.m_flags &= 0x80001FFF;
 }
 
 /*


### PR DESCRIPTION
What changed:
- Replaced `__rlwimi`-style packed flag updates in `CChara::CAnim::Create` with equivalent mask-and-insert logic.
- Rewrote `CChara::CAnimNode::CAnimNode` initialization to explicit flag masks, matching the same packed layout semantics.

Improvement:
- `Create__Q26CChara5CAnimFPvPQ27CMemory6CStage`: 54.8% -> 55.68% match.
- `main/chara_anim` .text: 78.96% -> 79.09% match.
- `Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf` stayed at 98.35%, so the gain is net positive.

Why plausible:
- The change removes compiler-coaxing bitfield intrinsics in favor of straightforward mask operations that match the packed node flag format shown by decompilation.
- No fake symbols, hardcoded addresses, or section tricks were introduced.
