### PR TITLE
Remove unused PPP CV randchar helpers

### DIFF
--- a/include/ffcc/pppRandCV.h
+++ b/include/ffcc/pppRandCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppRandDownCV.h
+++ b/include/ffcc/pppRandDownCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDDOWNCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppRandUpCV.h
+++ b/include/ffcc/pppRandUpCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDUPCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -85,17 +85,3 @@ void pppRandCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -84,17 +84,3 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
         target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -79,17 +79,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- remove the unused `randchar` declarations from the PPP CV headers
- remove the dead `randchar` definitions from `pppRandCV.cpp`, `pppRandDownCV.cpp`, and `pppRandUpCV.cpp`
- keep the object layout focused on the real exported PPP entrypoints

## Evidence
- `ninja`
- `main/pppRandCV`: data match improved from 44.44% to 66.67%
- `main/pppRandDownCV`: now 100.0% data matched
- `main/pppRandUpCV`: now 100.0% data matched
- `build/tools/objdiff-cli diff -p . -u main/pppRandCV -o - pppRandCV` no longer emits the extra `randchar` extab entry that was previously bloating the object

## Plausibility
These helpers were declared but not referenced anywhere in the repo. Removing the dead code is a plausible source cleanup and improves the emitted object layout without introducing compiler-coaxing hacks.
