### PR TITLE
Improve pppVertexAp control flow match

### DIFF
--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -119,8 +119,12 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
 
         count = data->spawnCount;
 
-        switch (data->mode) {
-        case 0:
+        if (data->mode != 1) {
+            if (data->mode != 0) {
+                state->countdown = data->spawnDelay;
+                state->countdown--;
+                return;
+            }
             while (count-- != 0) {
                 if (state->index >= entry->maxValue) {
                     state->index = 0;
@@ -165,8 +169,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     }
                 }
             }
-            break;
-        case 1:
+        } else {
             while (count-- != 0) {
                 f32 randValue = Math.RandF();
                 f32 maxValue = (f32)entry->maxValue;
@@ -208,7 +211,6 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
                     }
                 }
             }
-            break;
         }
 
         state->countdown = data->spawnDelay;


### PR DESCRIPTION
## Summary
- simplify the `pppVertexAp` mode dispatch into explicit `mode != 1` / `mode != 0` checks
- keep the spawn-delay update in the non-spawning path so countdown behavior remains unchanged
- preserve the existing vertex spawn logic while removing extra switch-driven control-flow noise

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppVertexAp -o - pppVertexAp`
- `pppVertexAp` match improved from `84.58763%` to `95.3866%`
- mismatch profile improved from `17 deletes / 12 inserts / 1 replace / 3 op mismatches` to `3 deletes / 4 inserts / 3 replaces / 1 op mismatch`

## Plausibility
This change stays source-level and behavior-preserving: it only reshapes the mode-selection control flow and keeps the existing spawn, transform, and countdown logic intact, which makes it a plausible original-source cleanup rather than compiler coaxing.
