### PR TITLE
Match p_MaterialEditor data split

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -38,9 +38,8 @@ unsigned int m_table_desc3__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpre
 unsigned int m_table__18CMaterialEditorPcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CMaterialEditorPcs_VIEWER_801D7D18)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x20, 0, 0, 0, 0, 0x41, 1
 };
-unsigned int lbl_801EA624[4] = {
-    reinterpret_cast<unsigned int>(lbl_8032E648), 0, 0, reinterpret_cast<unsigned int>(lbl_8032E648)
-};
+unsigned int lbl_801EA624[3] = {reinterpret_cast<unsigned int>(lbl_8032E648), 0, 0};
+unsigned int lbl_801EA630 = reinterpret_cast<unsigned int>(lbl_8032E648);
 CMaterialEditorPcs MaterialEditorPcs;
 
 struct MaterialEditorTableInit {


### PR DESCRIPTION
## Summary
- split the hand-written `p_MaterialEditor` data initializer at `lbl_801EA624` so the trailing pointer is emitted as its own 4-byte symbol (`lbl_801EA630`)
- keep the source-side representation aligned with the object layout already implied by the built data sections

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o -`
- primary `.data` section improved from `98.19695%` to `99.02913%`
- `lbl_801EA624` now matches at `100%`

## Plausibility
- this is a data-layout correction rather than compiler coaxing
- the change reflects the existing object split in the unit instead of relying on a merged four-word array initializer
