### PR TITLE
Fix KeZCrctShp mode 2 camera matrix

### DIFF
--- a/src/pppKeZCrctShp.cpp
+++ b/src/pppKeZCrctShp.cpp
@@ -69,7 +69,7 @@ void pppKeZCrctShpDraw(_pppPObject* object, pppKeZCrctShpStep* stepData, _pppCtr
         zeroVec.x += stepData->m_offset.x * pppMngStPtr->m_scale.x;
         zeroVec.y += stepData->m_offset.y * pppMngStPtr->m_scale.y;
         zeroVec.z += stepData->m_offset.z * pppMngStPtr->m_scale.z;
-        pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvCameraMatrix02, zeroVec);
+        pppApplyMatrix(zeroVec, *(pppFMATRIX*)&ppvCameraMatrix0, zeroVec);
 
         transformMatrix.value[0][3] = zeroVec.x;
         transformMatrix.value[1][3] = zeroVec.y;


### PR DESCRIPTION
## Summary
- switch `pppKeZCrctShpDraw` mode 2 to use `ppvCameraMatrix0` instead of `ppvCameraMatrix02`
- keep the rest of the function unchanged so the diff reflects the source correction directly

## Improved units and symbols
- `main/pppKeZCrctShp`
- `pppKeZCrctShpDraw`

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppKeZCrctShp -o - pppKeZCrctShpDraw`
- before: `.text` match `81.36585%`
- after: `.text` match `91.70731%`

## Why this is plausible source
- Ghidra’s decomp for mode 2 uses `ppvCameraMatrix0`
- the change is a direct camera-matrix selection fix in particle placement logic, not a codegen-only rewrite