### PR TITLE
Improve pppConstrainCameraDir2 match

### DIFF
--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -72,8 +72,8 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
                 resultPos.z = cameraDir.z * *value + resultPos.z;
             }
 
-            float localX = param_1->m_object.m_localMatrix.value[0][3];
             float localY = param_1->m_object.m_localMatrix.value[1][3];
+            float localX = param_1->m_object.m_localMatrix.value[0][3];
 
             Vec direct0;
             Vec direct1;


### PR DESCRIPTION
What changed
- reorder the two local matrix translation loads in `pppFrameConstrainCameraDir2`
- keep the function logic and data flow otherwise unchanged

Improved unit/symbols
- `main/pppConstrainCameraDir2`
- `pppFrameConstrainCameraDir2`

Before/after evidence
- `pppFrameConstrainCameraDir2` match: `99.65116%` -> `99.726746%`
- instruction diffs: `12` -> `9`
- removed mismatches in the first local-offset multiply group, leaving only the constant-load and second local-offset register mismatches
- `ninja` passes after the change

Why this is plausible source
- this is a minimal source-level local declaration ordering change in a tight math block
- it does not introduce fake symbols, address tricks, or compiler-only scaffolding
- it improves register allocation in the existing camera-local offset math without changing behavior