### PR TITLE
texanim: recover DAT_8032fb48 as "e1"

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -54,7 +54,7 @@ extern "C" void* __vc__25CPtrArray_P11CTexAnimSeq_FUl(void*, unsigned long);
 extern "C" {
 char s_texanim_cpp_801d7adc[] = "texanim.cpp";
 }
-static const char DAT_8032fb48[] = "";
+static const char DAT_8032fb48[] = "e1";
 const float FLOAT_8032fb38 = 0.0f;
 const float FLOAT_8032fb3c = 1.0f;
 const float FLOAT_8032fb4c = 1.25f;


### PR DESCRIPTION
## Summary
- correct `DAT_8032fb48` in `src/texanim.cpp` from `""` to `"e1"`
- keep the change scoped to the local constant used by `CTexAnimSet::Create`

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/texanim -o - Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage`
- before: `DAT_8032fb48` matched at 50.0%
- after: `DAT_8032fb48` matches at 100.0%
- aggregate `.sdata2` match in `main/texanim` improved from 38.095238% to 45.238094%

## Plausibility
- the target data for `DAT_8032fb48` is the 3-byte string `"e1\0"`, so reconstructing it as `"e1"` is a direct data recovery rather than compiler coaxing
- this constant is consumed by the existing `strcmp(..., DAT_8032fb48)` path in `CTexAnimSet::Create`, so the change aligns the source with observed target data and existing control flow
