### PR TITLE
p_sound: simplify static table initialization

### DIFF
--- a/include/ffcc/p_sound.h
+++ b/include/ffcc/p_sound.h
@@ -3,36 +3,12 @@
 
 #include "ffcc/system.h"
 
-extern unsigned int m_table_desc0__9CSoundPcs[];
-extern unsigned int m_table_desc1__9CSoundPcs[];
-extern unsigned int m_table_desc2__9CSoundPcs[];
-extern unsigned int m_table_desc3__9CSoundPcs[];
 extern unsigned int m_table__9CSoundPcs[];
 
 class CSoundPcs : public CProcess
 {
 public:
-    CSoundPcs()
-    {
-        unsigned int* table = &m_table__9CSoundPcs[1];
-        const unsigned int* desc0 = m_table_desc0__9CSoundPcs;
-        const unsigned int* desc1 = m_table_desc1__9CSoundPcs;
-        const unsigned int* desc2 = m_table_desc2__9CSoundPcs;
-        const unsigned int* desc3 = m_table_desc3__9CSoundPcs;
-
-        table[0] = desc0[0];
-        table[1] = desc0[1];
-        table[2] = desc0[2];
-        table[3] = desc1[0];
-        table[4] = desc1[1];
-        table[5] = desc1[2];
-        table[6] = desc2[0];
-        table[7] = desc2[1];
-        table[8] = desc2[2];
-        table[11] = desc3[0];
-        table[12] = desc3[1];
-        table[13] = desc3[2];
-    }
+    CSoundPcs() {}
 
     void draw();
     void calc();

--- a/src/p_sound.cpp
+++ b/src/p_sound.cpp
@@ -8,15 +8,39 @@ extern "C" void calc__9CSoundPcsFv(CSoundPcs*);
 extern "C" void draw__9CSoundPcsFv(CSoundPcs*);
 
 const char s_CSoundPcs_801DB4E8[] = "CSoundPcs";
-unsigned int m_table_desc0__9CSoundPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__9CSoundPcsFv)};
-unsigned int m_table_desc1__9CSoundPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__9CSoundPcsFv)};
-unsigned int m_table_desc2__9CSoundPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__9CSoundPcsFv)};
-unsigned int m_table_desc3__9CSoundPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__9CSoundPcsFv)};
 unsigned int m_table__9CSoundPcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CSoundPcs_801DB4E8)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x25, 0, 0, 0, 0, 0x44, 1
 };
+static const unsigned int sSoundTableInitData[] = {
+    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__9CSoundPcsFv),
+    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__9CSoundPcsFv),
+    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__9CSoundPcsFv),
+    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__9CSoundPcsFv),
+};
 
 CSoundPcs SoundPcs;
+
+struct SoundTableInit {
+    SoundTableInit()
+    {
+        unsigned int* table = &m_table__9CSoundPcs[1];
+
+        table[0] = sSoundTableInitData[0];
+        table[1] = sSoundTableInitData[1];
+        table[2] = sSoundTableInitData[2];
+        table[3] = sSoundTableInitData[3];
+        table[4] = sSoundTableInitData[4];
+        table[5] = sSoundTableInitData[5];
+        table[6] = sSoundTableInitData[6];
+        table[7] = sSoundTableInitData[7];
+        table[8] = sSoundTableInitData[8];
+        table[11] = sSoundTableInitData[9];
+        table[12] = sSoundTableInitData[10];
+        table[13] = sSoundTableInitData[11];
+    }
+};
+
+static SoundTableInit sSoundTableInit;
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- move `CSoundPcs` table population out of the inline constructor
- replace the exported descriptor arrays with one packed TU-local init blob used only by `p_sound`
- keep the runtime behavior the same while producing a closer `__sinit_p_sound_cpp`

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/p_sound -o - __sinit_p_sound_cpp`
- before: `59.276596%`
- after: `74.19149%`
- matched game data bytes increased by 40 in the build progress report (`912009` -> `912049`)

## Plausibility
- the new source keeps `CSoundPcs` construction simple and makes the table-copy logic explicit in one TU-local initializer
- descriptor data no longer leaks into headers when it is only needed to seed static init in this translation unit

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_sound -o - __sinit_p_sound_cpp`