### PR TITLE
Improve p_tina SetParColIdx match

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -1164,34 +1164,22 @@ void CPartPcs::GetParLocIdx(int index, Vec& location)
  */
 void CPartPcs::SetParColIdx(int index, pppFVECTOR4& color)
 {
-	struct PartMngColorWriteView {
-		u8 pad0[0x2A50];
-		float r;
-		float g;
-		float b;
-		float a;
-		u8 pad1[0xA7];
-		u8 ownerScaleMode;
-		u8 pad2[1];
-		u8 lockScaleFromOwner;
-	};
-	PartMngColorWriteView* pppMngSt =
-	    reinterpret_cast<PartMngColorWriteView*>(reinterpret_cast<u8*>(&PartMng) + (index * 0x158));
+	_pppMngSt* pppMngSt = &PartMng.m_pppMng[index];
 	float* colorValues = reinterpret_cast<float*>(&color);
 	float one = kPartColorIdentityOne;
 
-	pppMngSt->r = colorValues[0];
-	pppMngSt->g = colorValues[1];
-	pppMngSt->b = colorValues[2];
-	pppMngSt->a = colorValues[3];
+	pppMngSt->m_userFloat0 = colorValues[0];
+	pppMngSt->m_userFloat1 = colorValues[1];
+	pppMngSt->m_scaleFactor = colorValues[2];
+	pppMngSt->m_ownerScale = colorValues[3];
 
 	if (one == colorValues[0] && one == colorValues[1] && one == colorValues[2] && one == colorValues[3]) {
-		pppMngSt->ownerScaleMode = 0;
+		PartMng.m_pppMng[index].m_useOwnerScaleSign = 0;
 		return;
 	}
 
-	pppMngSt->ownerScaleMode = 1;
-	pppMngSt->lockScaleFromOwner = 1;
+	PartMng.m_pppMng[index].m_useOwnerScaleSign = 1;
+	PartMng.m_pppMng[index].m_nodeScaleInitialized = 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- switch `CPartPcs::SetParColIdx` to the real `_pppMngSt` layout for the user color floats
- write the trailing owner-scale flags through `PartMng.m_pppMng[index]` instead of a custom overlay view
- keep behavior intact while making the source layout more consistent with the surrounding part manager definitions

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_tina -o diff_result.json SetParColIdx__8CPartPcsFiR11pppFVECTOR4`
- `SetParColIdx__8CPartPcsFiR11pppFVECTOR4`: 89.14286% -> 99.65714%
- remaining mismatches: 2 float stores in the early color writes

## Why This Is Plausible
- the function now uses the project’s existing `_pppMngSt` field layout for `m_userFloat0`, `m_userFloat1`, `m_scaleFactor`, and `m_ownerScale`
- the tail flag writes are expressed as direct accesses on `PartMng.m_pppMng[index]`, which matches the real manager ownership model better than a hand-rolled byte overlay
