### PR TITLE
Improve pppFrameConstrainCameraDir2 local scalar ordering

### DIFF
--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -72,8 +72,7 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
                 resultPos.z = cameraDir.z * *value + resultPos.z;
             }
 
-            float localY = param_1->m_object.m_localMatrix.value[1][3];
-            float localX = param_1->m_object.m_localMatrix.value[0][3];
+            float localX = param_1->m_object.m_localMatrix.value[0][3], localY = param_1->m_object.m_localMatrix.value[1][3];
 
             Vec direct0;
             Vec direct1;


### PR DESCRIPTION
## Summary
- combine the local matrix X/Y scalar loads in `pppFrameConstrainCameraDir2`
- preserve behavior while nudging MWCC toward the original float register allocation around the local offset math

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir2 -o - pppFrameConstrainCameraDir2`
- match improved from `99.76744%` to `99.843025%`

## Plausibility
This is a source-plausible cleanup of adjacent scalar declarations rather than compiler coaxing with artificial casts or fake linkage. It keeps the surrounding camera/local-offset logic intact while improving the generated code shape.