### PR TITLE
Fix p_tina profile label string

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -21,7 +21,7 @@ extern const float kPartColorIdentityOne;
 
 extern "C" const char s_no_name_8032fdcc[];
 extern "C" {
-const char s_no_name_8032fdcc[] = "no_name";
+const char s_no_name_8032fdcc[] = "no name";
 }
 static const char s_p_tina_cpp_801d8008[] = "p_tina.cpp";
 static const char s_tina_title_fmt_801d8014[] = "Tina [%c]";


### PR DESCRIPTION
## Summary
- change `s_no_name_8032fdcc` in `src/p_tina.cpp` from `"no_name"` to `"no name"`
- keep the change narrowly scoped to the shared profile-label data in `main/p_tina`

## Evidence
- `ninja -j4`
- `build/tools/objdiff-cli diff -p . -u main/p_tina -o - create__8CPartPcsFv`
- before: `s_no_name_8032fdcc` matched `87.5%`, `main/p_tina` `.sdata2` matched `58.33%`
- after: `s_no_name_8032fdcc` matches `100.0%`, `main/p_tina` `.sdata2` matches `66.67%`

## Why This Is Plausible
- the symbol is explicitly the shared profile name string used by `g_par_calc_prof` and `g_par_draw_prof`
- changing the literal to the shipped byte sequence improves the unit's data match without adding any compiler-coaxing or artificial linkage hacks