### PR TITLE
Use CGObject world position in p_graphic screen fade

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/materialman.h"
 #include "ffcc/render_buffers.h"
 #include "ffcc/gxfunc.h"
+#include "ffcc/gobject.h"
 #include "ffcc/joybus.h"
 #include "ffcc/math.h"
 #include "ffcc/memory.h"
@@ -748,13 +749,6 @@ unsigned int CGraphicPcs::GetScreenFadeExecutingBit()
  */
 void CGraphicPcs::drawScreenFade()
 {
-    struct ScreenFadeObjPos {
-        char _padding0[0x15C];
-        float x;
-        float y;
-        float z;
-    };
-
     Mtx44 orthoMtx;
     Mtx cameraMtx;
     Mtx screenMtx;
@@ -889,12 +883,10 @@ void CGraphicPcs::drawScreenFade()
         if (slot == 2) {
             const int mode = slotData->m_mode;
             if (mode == 1) {
-                ScreenFadeObjPos* obj = (ScreenFadeObjPos*)slotData->m_targetObj;
+                CGObject* obj = static_cast<CGObject*>(slotData->m_targetObj);
                 if (obj != NULL) {
-                    Vec pos;
-                    pos.x = obj->x;
-                    pos.y = obj->y + slotData->m_targetYOffs;
-                    pos.z = obj->z;
+                    Vec pos = obj->m_worldPosition;
+                    pos.y += slotData->m_targetYOffs;
                     PSMTX44MultVec(worldScreenMtx, &pos, &pos);
 
                     float sx = pos.x * 320.0f + 320.0f;
@@ -940,9 +932,9 @@ void CGraphicPcs::drawScreenFade()
                 _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
                 _GXSetTevOp(GX_TEVSTAGE0, GX_MODULATE);
 
-                const float phase = m_screenFade[0].m_phase;
-                const float stretch = m_screenFade[0].m_stretch;
-                const float amp = m_screenFade[0].m_amplitude * (1.0f - t);
+                const float phase = slotData->m_phase;
+                const float stretch = slotData->m_stretch;
+                const float amp = slotData->m_amplitude * (1.0f - t);
                 const float size = amp + 1.0f;
                 const float offX = stretch * (320.0f * amp) * (float)sin((double)phase);
                 const float offY = stretch * (240.0f * amp) * (float)cos((double)phase);


### PR DESCRIPTION
## Summary
- replace the local padded screen-fade target-object hack with the real `CGObject` type
- read the fade center directly from `CGObject::m_worldPosition` and keep the slot-local fade parameters together
- keep the logic plausible to original source by removing hard-coded offset access in `drawScreenFade`

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_graphic -o /tmp/p_graphic_unit_after.json`
- `main/p_graphic` `.text`: `52.64162%` -> `52.879623%`
- `drawScreenFade__11CGraphicPcsFv`: `35.419174%` -> `35.98778%`

## Plausibility
This replaces a synthetic local struct used only to reach the world-position fields at `0x15C` with the existing engine type that already defines that layout. The fade code now expresses the same behavior through real member access instead of offset reconstruction.