### PR TITLE
Improve pppFrameYmMelt register allocation

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -236,14 +236,14 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
     int angleSeed;
     YmMeltWork* work;
     YmMeltColorWork* colorWork;
-    YmMeltVertex* vertexBase;
-    YmMeltVertex* vertex;
     YmMeltVertex* rowVertex;
-    float matrixY;
-    float halfWidth;
+    YmMeltVertex* vertex;
+    YmMeltVertex* vertexBase;
     float step;
-    float rot;
+    float halfWidth;
+    float matrixY;
     float x;
+    float rot;
     float z;
     Mtx rotMtx;
 


### PR DESCRIPTION
## Summary
- reorder `pppFrameYmMelt` local declarations to better match MWCC register allocation
- keep behavior identical while improving the reconstructed source shape around the vertex initialization loop

## Evidence
- `pppFrameYmMelt`: 99.20588% -> 99.73529%
- `main/pppYmMelt` `.text`: 82.605865% -> 82.65051%
- verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/pppYmMelt -o - pppFrameYmMelt`

## Plausibility
- the change is limited to local variable declaration order in a single function
- no compiler coaxing, fake symbols, or ABI hacks were introduced
- the result reflects a plausible original-source layout for MWCC register allocation