### PR TITLE
LocationTitle2: drop stray CGamePcs descriptors

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -1,10 +1,11 @@
 #include "ffcc/LocationTitle2.h"
 #include "ffcc/chara.h"
 #include "ffcc/gobject.h"
+#include "ffcc/linkage.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/pppShape.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>


### PR DESCRIPTION
## Summary
- replace `ffcc/p_game.h` with `ffcc/game.h` plus `ffcc/linkage.h` in `LocationTitle2.cpp`
- stop this translation unit from instantiating `CGamePcs` constructor-local descriptor arrays
- preserve existing `LocationTitle2` codegen while improving object ownership/data layout

## Evidence
- `ninja` succeeds for GCCP01
- before: `main/LocationTitle2` objdiff showed an extra `.data` section in the built object
  - `.data` size `108`, `match_percent` `0.0`
  - relocations pointed at nine `desc*$localstatic*$__ct__8CGamePcsFv` symbols
- after: the built object no longer emits that `.data` section at all
- `pppRenderLocationTitle2` remains `99.832535%`
- `pppFrameLocationTitle2` remains `90.22369%`

## Why this is plausible source
- `LocationTitle2.cpp` only reads `Game.m_currentSceneId`; it does not need `CGamePcs`
- including `p_game.h` pulled in an inline `CGamePcs` constructor with local static descriptor tables, which is an ownership leak rather than real `LocationTitle2` source
- switching to the narrower declarations makes the TU cleaner and closer to the target object's section layout
