### PR TITLE
Refine menu_item animation loops

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -245,7 +245,7 @@ void CMenuPcs::ItemInit1()
 {
     float progress;
     int listBase;
-    MenuItemOpenAnim* anim;
+    short* entry;
     unsigned int count;
     unsigned int blocks;
 
@@ -307,30 +307,29 @@ void CMenuPcs::ItemInit1()
     *(int*)(listBase + 0x2E4) = 0x37;
     *(int*)(listBase + 0x2EC) = 0;
     *(int*)(listBase + 0x2F0) = 5;
-
     count = (unsigned int)this->itemList->count;
-    anim = this->itemList->anims;
+    entry = (short*)this->itemList + 4;
     if (0 < (int)count) {
         blocks = count >> 3;
         if (blocks != 0) {
             do {
-                anim[0].frame = 0;
-                anim[0].progress = progress;
-                anim[1].frame = 0;
-                anim[1].progress = progress;
-                anim[2].frame = 0;
-                anim[2].progress = progress;
-                anim[3].frame = 0;
-                anim[3].progress = progress;
-                anim[4].frame = 0;
-                anim[4].progress = progress;
-                anim[5].frame = 0;
-                anim[5].progress = progress;
-                anim[6].frame = 0;
-                anim[6].progress = progress;
-                anim[7].frame = 0;
-                anim[7].progress = progress;
-                anim += 8;
+                *(int*)(entry + 0x10) = 0;
+                *(float*)(entry + 8) = progress;
+                *(int*)(entry + 0x30) = 0;
+                *(float*)(entry + 0x28) = progress;
+                *(int*)(entry + 0x50) = 0;
+                *(float*)(entry + 0x48) = progress;
+                *(int*)(entry + 0x70) = 0;
+                *(float*)(entry + 0x68) = progress;
+                *(int*)(entry + 0x90) = 0;
+                *(float*)(entry + 0x88) = progress;
+                *(int*)(entry + 0xB0) = 0;
+                *(float*)(entry + 0xA8) = progress;
+                *(int*)(entry + 0xD0) = 0;
+                *(float*)(entry + 200) = progress;
+                *(int*)(entry + 0xF0) = 0;
+                *(float*)(entry + 0xE8) = progress;
+                entry = entry + 0x100;
                 blocks--;
             } while (blocks != 0);
             count &= 7;
@@ -339,9 +338,9 @@ void CMenuPcs::ItemInit1()
             }
         }
         do {
-            anim->frame = 0;
-            anim->progress = progress;
-            anim++;
+            *(int*)(entry + 0x10) = 0;
+            *(float*)(entry + 8) = progress;
+            entry = entry + 0x20;
             count--;
         } while (count != 0);
     }
@@ -358,56 +357,51 @@ void CMenuPcs::ItemInit1()
  */
 bool CMenuPcs::ItemOpen()
 {
-    float fVar1;
+    float ratio;
     double dVar2;
-    double dVar3;
-    short* psVar4;
-    int iVar5;
-    int iVar6;
-    int iVar7;
-    int iVar8;
+    short* entry;
+    int finished;
+    unsigned int count;
+    int frame;
+    unsigned int remaining;
 
     if (*(char*)((int)this->itemMenuState + 0xB) == '\0') {
         SingLifeInit(-1);
         ItemInit();
     }
 
-    iVar5 = 0;
     *(short*)((int)this->itemMenuState + 0x22) = *(short*)((int)this->itemMenuState + 0x22) + 1;
-    iVar6 = (int)*(short*)this->itemList;
-    psVar4 = (short*)((int)this->itemList + 8);
-    iVar7 = (int)*(short*)((int)this->itemMenuState + 0x22);
-    iVar8 = iVar6;
-    if (0 < iVar6) {
+    finished = 0;
+    count = (unsigned int)this->itemList->count;
+    entry = (short*)this->itemList + 4;
+    frame = (int)*(short*)((int)this->itemMenuState + 0x22);
+    remaining = count;
+    if (0 < (int)count) {
         do {
-            dVar3 = DOUBLE_80332ea0;
-            fVar1 = FLOAT_80332e60;
-            if (iVar7 >= *(int*)(psVar4 + 0x12)) {
-                if (*(int*)(psVar4 + 0x12) + *(int*)(psVar4 + 0x14) > iVar7) {
-                    *(int*)(psVar4 + 0x10) = *(int*)(psVar4 + 0x10) + 1;
+            ratio = FLOAT_80332e60;
+            if (*(int*)(entry + 0x12) <= frame) {
+                if (frame < *(int*)(entry + 0x12) + *(int*)(entry + 0x14)) {
                     dVar2 = DOUBLE_80332e68;
-                    *(float*)(psVar4 + 8) =
-                        (float)((DOUBLE_80332e68 / (double)*(int*)(psVar4 + 0x14)) * (double)*(int*)(psVar4 + 0x10));
-                    if ((*(unsigned int*)(psVar4 + 0x16) & 2) == 0) {
-                        fVar1 =
-                            (float)((dVar2 / (double)*(int*)(psVar4 + 0x14)) * (double)*(int*)(psVar4 + 0x10));
-                        *(float*)(psVar4 + 0x18) =
-                            (*(float*)(psVar4 + 0x1C) - (float)*psVar4) * fVar1;
-                        *(float*)(psVar4 + 0x1A) =
-                            (*(float*)(psVar4 + 0x1E) - (float)psVar4[1]) * fVar1;
+                    *(int*)(entry + 0x10) = *(int*)(entry + 0x10) + 1;
+                    *(float*)(entry + 8) =
+                        (float)((DOUBLE_80332e68 / (double)*(int*)(entry + 0x14)) * (double)*(int*)(entry + 0x10));
+                    if ((*(unsigned int*)(entry + 0x16) & 2) == 0) {
+                        ratio = (float)((dVar2 / (double)*(int*)(entry + 0x14)) * (double)*(int*)(entry + 0x10));
+                        *(float*)(entry + 0x18) = (*(float*)(entry + 0x1C) - (float)*entry) * ratio;
+                        *(float*)(entry + 0x1A) = (*(float*)(entry + 0x1E) - (float)entry[1]) * ratio;
                     }
                 } else {
-                    iVar5 = iVar5 + 1;
-                    *(float*)(psVar4 + 8) = FLOAT_80332e64;
-                    *(float*)(psVar4 + 0x18) = fVar1;
-                    *(float*)(psVar4 + 0x1A) = fVar1;
+                    finished = finished + 1;
+                    *(float*)(entry + 8) = FLOAT_80332e64;
+                    *(float*)(entry + 0x18) = ratio;
+                    *(float*)(entry + 0x1A) = ratio;
                 }
             }
-            psVar4 = psVar4 + 0x20;
-            iVar8 = iVar8 + -1;
-        } while (iVar8 != 0);
+            entry = entry + 0x20;
+            remaining = remaining - 1;
+        } while (remaining != 0);
     }
-    return iVar6 == iVar5;
+    return count == (unsigned int)finished;
 }
 
 /*
@@ -464,45 +458,33 @@ int CMenuPcs::ItemCtrl()
  */
 bool CMenuPcs::ItemClose()
 {
-    int count;
-    int finished;
-    int step;
-    int remaining;
-    MenuItemOpenAnim* anim;
-    ItemMenuState* itemState = this->itemMenuState;
+    int finished = 0;
+    this->itemMenuState->frame++;
 
-    finished = 0;
-    itemState->frame = itemState->frame + 1;
-    count = (int)this->itemList->count;
-    anim = this->itemList->anims;
-    step = (int)itemState->frame;
-    remaining = count;
+    int count = this->itemList->count;
+    MenuItemOpenAnim* anim = (MenuItemOpenAnim*)((u8*)this->itemList + 8);
+    int frame = this->itemMenuState->frame;
 
-    if (0 < count) {
-        do {
-            double dVar3 = DOUBLE_80332ea0;
-            float zero = FLOAT_80332e60;
-            if (step >= anim->startFrame) {
-                if (anim->startFrame + anim->duration > step) {
-                    double dVar2 = DOUBLE_80332e68;
-                    anim->frame = anim->frame + 1;
-                    anim->progress =
-                        (float)-((DOUBLE_80332e68 / (double)anim->duration) * (double)anim->frame - DOUBLE_80332e68);
-                    if ((anim->flags & 2) == 0) {
-                        float t = (float)-((dVar2 / (double)anim->duration) * (double)anim->frame - dVar2);
-                        anim->dx = (anim->targetX - (float)anim->x) * t;
-                        anim->dy = (anim->targetY - (float)anim->y) * t;
-                    }
-                } else {
-                    finished = finished + 1;
-                    anim->progress = FLOAT_80332e60;
-                    anim->dx = zero;
-                    anim->dy = zero;
+    for (int i = 0; i < count; i++, anim++) {
+        float zero = FLOAT_80332e60;
+        if (anim->startFrame <= frame) {
+            if (!(frame < anim->startFrame + anim->duration)) {
+                finished++;
+                anim->progress = FLOAT_80332e60;
+                anim->dx = zero;
+                anim->dy = zero;
+            } else {
+                anim->frame++;
+                double one = DOUBLE_80332e68;
+                anim->progress =
+                    (float)-((DOUBLE_80332e68 / (double)anim->duration) * (double)anim->frame - DOUBLE_80332e68);
+                if ((anim->flags & 2) == 0) {
+                    float ratio = (float)-((one / (double)anim->duration) * (double)anim->frame - one);
+                    anim->dx = (anim->targetX - (float)anim->x) * ratio;
+                    anim->dy = (anim->targetY - (float)anim->y) * ratio;
                 }
             }
-            anim = anim + 1;
-            remaining = remaining - 1;
-        } while (remaining != 0);
+        }
     }
 
     return count == finished;


### PR DESCRIPTION
## Summary
- restate `ItemInit1`, `ItemOpen`, and `ItemClose` in `menu_item.cpp` using the same low-level animation loop shape already used by neighboring menu code
- keep the existing item menu behavior and data layout intact while reducing some mismatch-heavy struct/member access patterns

## Evidence
- `ninja` succeeds
- `ItemClose__8CMenuPcsFv`: 49.7% -> 62.45%
- `main/menu_item` fuzzy code match: 62.8% -> 63.38%
- `main/menu_item` no longer appears in `tools/agent_select_target.py`'s top code opportunities after the rebuild

## Plausibility
- the changes only reshape existing animation setup/open/close logic
- no fake symbols, section forcing, or compiler-coaxing hacks were introduced
