### PR TITLE
Fix CMenuPcs::EquipClose return type

### DIFF
--- a/include/ffcc/menu_equip.h
+++ b/include/ffcc/menu_equip.h
@@ -9,7 +9,7 @@ public:
     void EquipInit1();
     int EquipOpen();
     void EquipCtrl();
-    void EquipClose();
+    int EquipClose();
     void EquipDraw();
     int EquipCtrlCur();
     bool EquipOpen0();

--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -565,7 +565,7 @@ void CMenuPcs::EquipCtrl()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMenuPcs::EquipClose()
+int CMenuPcs::EquipClose()
 {
 	int menuState = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c);
 	s16* menuData = *reinterpret_cast<s16**>(reinterpret_cast<char*>(this) + 0x850);
@@ -605,7 +605,9 @@ void CMenuPcs::EquipClose()
 			*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
 			item += 0x20;
 		}
+		return 1;
 	}
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- fix the `CMenuPcs::EquipClose` declaration/definition to return a value instead of `void`
- return `1` when the close animation fully completes and `0` otherwise, matching the existing call pattern in `singmenu.cpp`
- keep the existing close-state reset loop unchanged apart from the explicit return path

## Evidence
- `ninja` succeeds after the change
- `EquipClose__8CMenuPcsFv` remains a 428-byte function in objdiff for `main/menu_equip`
- the target cluster now has a coherent ABI: `singmenu.cpp` already treats `EquipClose__8CMenuPcsFv` as value-returning, and Ghidra shows the original function returning `undefined4`

## Plausibility
This is source-coherence and linkage progress rather than compiler coaxing. The previous `void` member signature conflicted with both the callsite behavior and the recovered function shape; restoring an explicit return value is the more plausible original source.
