### PR TITLE
Improve RedMidiCtrl loop-end match

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -638,25 +638,25 @@ void __MidiCtrl_LoopStart(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 void __MidiCtrl_LoopEnd(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
     unsigned char* command;
-    int* trackData = (int*)track;
-    unsigned int loopCount;
     int loopIndexOffset;
+    unsigned short loopCount;
 
-    command = (unsigned char*)trackData[0];
-    trackData[0] = (int)(command + 1);
+    command = *(unsigned char**)track;
+    *(unsigned char**)track = command + 1;
     loopCount = command[0];
     if (loopCount == 0) {
         loopCount = 0x100;
     }
 
-    loopIndexOffset = *(short*)(trackData + 0x4f) * 2 + 0x128;
-    *(short*)((char*)trackData + loopIndexOffset) = *(short*)((char*)trackData + loopIndexOffset) + 1;
-    if (*(unsigned short*)((char*)trackData + *(short*)(trackData + 0x4f) * 2 + 0x128) == loopCount) {
-        *(short*)(trackData + 0x4f) = *(short*)(trackData + 0x4f) - 1;
-        *(unsigned short*)(trackData + 0x4f) &= 3;
+    loopIndexOffset = *(short*)((char*)track + 0x13C) * 2 + 0x128;
+    *(short*)((char*)track + loopIndexOffset) = *(short*)((char*)track + loopIndexOffset) + 1;
+    if (*(unsigned short*)((char*)track + *(short*)((char*)track + 0x13C) * 2 + 0x128) == loopCount) {
+        *(short*)((char*)track + 0x13C) = *(short*)((char*)track + 0x13C) - 1;
+        *(unsigned short*)((char*)track + 0x13C) &= 3;
     } else {
-        trackData[0] = trackData[*(short*)(trackData + 0x4f) + 2];
-        *(short*)(trackData + 0x51) = *(short*)((char*)trackData + *(short*)(trackData + 0x4f) * 2 + 0x130);
+        *(int*)track = ((int*)track)[*(short*)((char*)track + 0x13C) + 2];
+        *(unsigned short*)((char*)track + 0x144) =
+            *(unsigned short*)((char*)track + *(short*)((char*)track + 0x13C) * 2 + 0x130);
     }
 }
 


### PR DESCRIPTION
## Summary
- rewrite `__MidiCtrl_LoopEnd` in `src/RedSound/RedMidiCtrl.cpp` to use direct track pointer access instead of the broader `int* trackData` aliasing
- preserve the existing behavior while moving the control flow and type usage closer to the original source shape

## Improved symbols
- `__MidiCtrl_LoopEnd__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o - __MidiCtrl_LoopEnd__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`
- before: `50.658535%`
- after: `56.146343%`

## Plausibility
- this change removes an overly broad integer alias and uses the same byte/halfword access pattern suggested by the PAL decomp for the loop counter stack and loop target restore logic
- the result is cleaner source and improves match quality without adding compiler-coaxing hacks or fake symbols
