### PR TITLE
Fix CLightPcs inheritance

### DIFF
--- a/include/ffcc/p_light.h
+++ b/include/ffcc/p_light.h
@@ -2,7 +2,7 @@
 #define _FFCC_P_LIGHT_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/system.h"
+#include "ffcc/p_sample.h"
 
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
@@ -10,7 +10,7 @@
 class COctTree;
 struct Vec;
 
-class CLightPcs : public CProcess
+class CLightPcs : public CSamplePcs
 {
 public:
     struct Vec3f


### PR DESCRIPTION
## Summary
- change `CLightPcs` to inherit from `CSamplePcs` instead of directly from `CProcess`
- keep the light process hierarchy aligned with the constructor/static-init path already used by the binary

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/p_light -o - __sinit_p_light_cpp`
- before: `47.720932%`
- after: `52.23256%`
- the `p_light` unit also dropped out of the current top code-opportunity list from `tools/agent_select_target.py`

## Why this is plausible source
- the generated `__sinit_p_light_cpp` sequence references the `CSamplePcs` vtable path, which is inconsistent with the previous direct `CProcess` inheritance
- `CSamplePcs` is a behavior-only intermediate base here, so this corrects the class hierarchy without introducing risky data layout changes
