### PR TITLE
Improve pppYmMoveCircle state access

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -1,11 +1,11 @@
 #include "ffcc/pppYmMoveCircle.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/partMng.h"
+#include "ffcc/ppp_constants.h"
 #include "types.h"
 #include "dolphin/mtx.h"
 
 double acos(double);
-extern float gPppTrigTable[];
 
 struct pppYmMoveCircleWork {
     f32 m_angle;
@@ -33,12 +33,11 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
 {
     pppYmMoveCircleWork* work;
     int* serializedDataOffsets;
-    u8* pppMngSt;
+    _pppMngSt* pppMngSt;
     Vec nextPos;
     s32 tableIndex;
     f32 sinAngle;
     f32 cosAngle;
-    f32 turnSpan;
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -46,7 +45,7 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
 
     serializedDataOffsets = offsetData->m_serializedDataOffsets;
     work = (pppYmMoveCircleWork*)((u8*)basePtr + serializedDataOffsets[0] + 0x80);
-    pppMngSt = (u8*)pppMngStPtr;
+    pppMngSt = pppMngStPtr;
 
     work->m_radiusStep += work->m_radiusStepStep;
     work->m_radius += work->m_radiusStep;
@@ -61,11 +60,10 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
         work->m_angleStepStep += stepData->m_angleStepStep;
         work->m_angleStepStepStep += stepData->m_angleStepStepStep;
     }
-    turnSpan = 360.0f;
     work->m_angle += work->m_angleStep;
 
-    if (work->m_angle > turnSpan) {
-        work->m_angle -= turnSpan;
+    if (work->m_angle > 360.0f) {
+        work->m_angle -= 360.0f;
     }
     if (work->m_angle < 0.0f) {
         work->m_angle += 360.0f;
@@ -81,13 +79,12 @@ extern "C" void pppFrameYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCircleSt
     cosAngle = *(f32*)((u8*)gPppTrigTable + ((tableIndex + 0x4000) & 0xFFFC));
     nextPos.x = work->m_radius * cosAngle;
     nextPos.z = work->m_radius * -sinAngle;
-    nextPos.y = 0.0f;
     nextPos.x += work->m_center.x;
-    nextPos.y = *(f32*)(pppMngSt + 0xC);
+    nextPos.y = pppMngSt->m_position.y;
     nextPos.z += work->m_center.z;
 
-    pppCopyVector(*(Vec*)(pppMngSt + 0x48), *(Vec*)(pppMngSt + 0x8));
-    pppCopyVector(*(Vec*)(pppMngSt + 0x8), nextPos);
+    pppCopyVector(pppMngSt->m_previousPosition, pppMngSt->m_position);
+    pppCopyVector(pppMngSt->m_position, nextPos);
 
     *(f32*)((u8*)pppMngStPtr + 0x84) = nextPos.x;
     *(f32*)((u8*)pppMngStPtr + 0x94) = nextPos.y;


### PR DESCRIPTION
What changed
- cleaned up `pppFrameYmMoveCircle` to use the existing `_pppMngSt` field definitions instead of raw byte-pointer access for position updates
- removed an unnecessary local `turnSpan` and direct `gPppTrigTable` extern in favor of the shared particle constants declaration
- kept the behavior source-plausible while improving the generated code around angle wrapping and previous/current position copies

Improved unit / symbol
- `main/pppYmMoveCircle`
- `pppFrameYmMoveCircle`

Before / after evidence
- `pppFrameYmMoveCircle`: `86.85%` -> `97.37%`
- unit `.text`: `91.344185%` -> `98.265114%`
- unit `.sdata2`: `87.5%` -> `93.333336%`

Why this is plausible source
- `_pppMngSt` already exposes `m_position` and `m_previousPosition`, so replacing raw offsets with those fields is a real type/layout recovery rather than compiler coaxing
- the angle-wrap cleanup removes a temporary without changing behavior and matches the surrounding style in nearby PPP movement code
