### PR TITLE
Improve pppRenderLaser matching

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -107,11 +107,6 @@ struct LaserWork {
     u8 m_spawnEnabled;
 };
 
-struct LaserColorData {
-    u8 m_pad0[8];
-    pppCVECTOR m_color;
-};
-
 /*
  * --INFO--
  * PAL Address: 801766ec
@@ -390,11 +385,9 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
 extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *param_2, _pppCtrlTable *param_3)
 {
     LaserStep* step = (LaserStep*)param_2;
-    _pppPObject* baseObj = (_pppPObject*)pppLaser;
-    Vec* points;
     int colorOffset = param_3->m_serializedDataOffsets[1];
-    LaserColorData* colorData = (LaserColorData*)((u8*)pppLaser + 0x80 + colorOffset);
     LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_3->m_serializedDataOffsets[2]);
+    Vec* points;
     u32 count;
     u32 i;
     u32 colorBase;
@@ -427,14 +420,14 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     pppSetBlendMode(step->m_payload[0x1c]);
     _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 0);
     pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
-        &colorData->m_color, &baseObj->m_localMatrix, kPppLaserZero, step->m_payload[0x39], step->m_payload[0x38],
+        (u8*)pppLaser + 0x88 + colorOffset, &pppLaser->m_localMatrix, kPppLaserZero, step->m_payload[0x39], step->m_payload[0x38],
         step->m_payload[0x1c], 0, 1, 1, 0);
     GXSetNumTevStages(1);
     GXSetNumTexGens(1);
     GXSetNumChans(1);
     GXSetCullMode(GX_CULL_NONE);
     _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(7, 0, 1, 7, 0);
-    color = *(_GXColor*)&colorData->m_color;
+    color = *(_GXColor*)((u8*)pppLaser + 0x88 + colorOffset);
     _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
     GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);
     _GXSetTevColorIn__F13_GXTevStageID14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg14_GXTevColorArg(
@@ -449,7 +442,7 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     halfWidth = work->m_halfWidth;
     length = work->m_length;
 
-    pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &pppMngStPtr->m_matrix, &baseObj->m_localMatrix);
+    pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &pppMngStPtr->m_matrix, &pppLaser->m_localMatrix);
     pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&mtxOut, (pppFMATRIX*)&ppvCameraMatrix0, &modelView);
     GXLoadPosMtxImm(mtxOut.value, 0);
 
@@ -550,8 +543,8 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
             GXSetChanAmbColor(GX_COLOR0A0, debugColor);
             GXSetPointSize(0x28, GX_TO_ZERO);
             GXBegin(GX_POINTS, GX_VTXFMT7, (u16)(count - 1));
-            for (i = 0; i < count - 1; i++) {
-                GXPosition3f32(points[i].x, points[i].y, points[i].z);
+            for (int j = 0; j < (int)(step->m_payload[0x1e] - 1); j++) {
+                GXPosition3f32(points[j].x, points[j].y, points[j].z);
                 GXColor1u32(*(u32*)&debugColor);
             }
 
@@ -562,12 +555,12 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
             GXSetChanAmbColor(GX_COLOR0A0, debugColor);
             GXSetLineWidth(0x14, GX_TO_ZERO);
             GXBegin(GX_LINES, GX_VTXFMT7, (u16)((count - 1) * 4));
-            for (i = 0; i < count - 1; i++) {
-                GXPosition3f32(points[i].x, points[i].y, points[i].z);
+            for (int j = 0; j < (int)(step->m_payload[0x1e] - 1); j++) {
+                GXPosition3f32(points[j].x, points[j].y, points[j].z);
                 GXColor1u32(*(u32*)&debugColor);
-                GXPosition3f32(points[i + 1].x, points[i + 1].y, points[i + 1].z);
+                GXPosition3f32(points[j + 1].x, points[j + 1].y, points[j + 1].z);
                 GXColor1u32(*(u32*)&debugColor);
-                GXPosition3f32(points[i].x, points[i].y, points[i].z);
+                GXPosition3f32(points[j].x, points[j].y, points[j].z);
                 GXColor1u32(*(u32*)&debugColor);
                 GXPosition3f32(work->m_origin.x, work->m_origin.y, work->m_origin.z);
                 GXColor1u32(*(u32*)&debugColor);
@@ -580,8 +573,8 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
             PSMTXIdentity(tempMtx);
             tempMtx[0][0] = *(float*)((u8*)pppMngStPtr + 0x64) * *(float*)(step->m_payload + 0x24);
             tempMtx[1][1] = tempMtx[0][0];
-	            tempMtx[2][2] = PSVECDistance(work->m_points, &work->m_origin);
-            PSMTXConcat(baseObj->m_localMatrix.value, tempMtx, tempMtx);
+            tempMtx[2][2] = PSVECDistance(work->m_points, &work->m_origin);
+            PSMTXConcat(pppLaser->m_localMatrix.value, tempMtx, tempMtx);
             PSMTXConcat(pppMngStPtr->m_matrix.value, tempMtx, tempMtx);
             PSMTXConcat(ppvCameraMatrix0, tempMtx, tempMtx);
             shapePos.x = kPppLaserZero;


### PR DESCRIPTION
## Summary
- simplify `pppRenderLaser` to access the serialized laser color block directly instead of routing through a local wrapper struct
- align local ordering and debug draw loops with the existing `pppYmLaser` sibling so the generated code is closer to the original source
- drop the now-unused `LaserColorData` helper

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppRenderLaser`
  - before: `43.81649%`
  - after: `60.855053%`
- `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppLaser | jq ".left.sections[] | select(.name==".text") | .match_percent"`
  - before: `56.67151%`
  - after: `67.01292%`
- `ninja`
  - passes

## Plausibility
These changes remove decomp-only scaffolding and use the same direct field access pattern already present in `pppYmLaser`, which is a closer fit for plausible original source than the previous wrapper-based version.