### PR TITLE
Improve FunnyShape render loop matching

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -448,19 +448,20 @@ void CFunnyShape::Render()
         count = 1;
     }
 
-    const f32 baseX = FLOAT_8032fd9c;
-    CFunnyShapeAnmWork* work = AnmWork(this);
-    const f32 baseY = FLOAT_8032fda0;
+    const double baseX = FLOAT_8032fd9c;
+    const double baseY = FLOAT_8032fda0;
+    CFunnyShape* work = this;
 
     for (s32 i = 0; i < count; i++) {
         Vec2d pos;
-        pos.x = baseX + work->x;
-        pos.y = baseY + work->y;
+        pos.x = static_cast<float>(baseX + static_cast<double>(*reinterpret_cast<float*>(Ptr(work, 8))));
+        pos.y = static_cast<float>(baseY + static_cast<double>(*reinterpret_cast<float*>(Ptr(work, 0xC))));
 
         u8* animData = reinterpret_cast<u8*>(AnimData(this));
-        const s16 shapeOffset = *reinterpret_cast<s16*>(animData + (work->frame * 8) + 0x10);
-        RenderShape(reinterpret_cast<FS_tagOAN3_SHAPE*>(animData + shapeOffset), pos, work->angle);
-        work++;
+        const s16 frame = *reinterpret_cast<s16*>(Ptr(work, 0x14));
+        const s16 shapeOffset = *reinterpret_cast<s16*>(animData + 0x10 + frame * 8);
+        RenderShape(reinterpret_cast<FS_tagOAN3_SHAPE*>(animData + shapeOffset), pos, *reinterpret_cast<float*>(Ptr(work, 0x28)));
+        work = reinterpret_cast<CFunnyShape*>(Ptr(work, 0x30));
     }
 }
 


### PR DESCRIPTION
What changed
- rewrote the `CFunnyShape::Render` work-item loop to walk the animation work buffer with the original raw 0x30-byte stride
- used the decomp-shaped float/double conversions and direct frame/angle field loads when building the `RenderShape` call

Units / symbols improved
- `main/FunnyShape`
- `Render__11CFunnyShapeFv`

Before / after evidence
- `build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - Render__11CFunnyShapeFv`
- before: `92.07254%`
- after: `96.6114%`
- verification: `ninja`

Why this is plausible source
- the change removes an inferred helper-struct walk in favor of the raw fixed-stride work-buffer traversal shown by the recovered function shape
- field accesses now line up with the surrounding `FunnyShape` code, which already uses direct offset-based storage for this animation work area
