### PR TITLE
Improve maptexanim SetMapTexAnim matching

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -296,14 +296,14 @@ void CMapTexAnimSet::Calc()
 void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd, int wrapMode)
 {
     int found = 0;
-    int i = 0;
     int setPtr = reinterpret_cast<int>(this);
+    short targetMaterialId = static_cast<short>(materialId);
 
-    while (i < m_count) {
+    for (int i = 0; i < m_count; i++) {
         void* animPtr = reinterpret_cast<void*>(*reinterpret_cast<int*>(setPtr + 0xC));
-        if (static_cast<short>(materialId) == S16At(animPtr, 0x12)) {
-            int end = frameEnd;
+        if (S16At(animPtr, 0x12) == targetMaterialId) {
             if (U8At(animPtr, 0x15) != 0) {
+                int end = frameEnd;
                 S32At(animPtr, 0x30) = frameStart;
                 S32At(animPtr, 0x2C) = frameStart;
                 if (frameEnd > S32At(animPtr, 0x38)) {
@@ -313,6 +313,7 @@ void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd,
                 U8At(animPtr, 0x27) = static_cast<unsigned char>(wrapMode);
                 U8At(animPtr, 0x28) = 1;
             } else {
+                int end = frameEnd;
                 S16At(animPtr, 0xE) = static_cast<short>(frameStart);
                 F32At(animPtr, 0x1C) = static_cast<float>(static_cast<short>(frameStart));
                 if (frameEnd > S16At(animPtr, 0xC)) {
@@ -324,7 +325,6 @@ void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd,
             found = 1;
         }
         setPtr += 4;
-        i += 1;
     }
 
     if ((found == 0) && (static_cast<unsigned int>(System.m_execParam) >= 1)) {


### PR DESCRIPTION
## Summary
- reshape `CMapTexAnimSet::SetMapTexAnim` in `src/maptexanim.cpp` without changing behavior
- keep the same recovered raw field accesses, but narrow the `end` temporary to each branch and iterate with a source shape that compiles closer to the original

## Evidence
- `SetMapTexAnim__14CMapTexAnimSetFiiii`: `91.695656%` -> `93.18841%`
- `main/maptexanim` `.text`: `90.04578%` -> `90.19313%`
- verified with `ninja` and `build/tools/objdiff-cli diff -p . -u main/maptexanim -o - SetMapTexAnim__14CMapTexAnimSetFiiii`

## Plausibility
This keeps the existing recovered logic intact and only adjusts local variable lifetimes / loop structure to better reflect plausible original source, rather than adding compiler-forcing hacks.