### PR TITLE
Improve pppEmission mesh callback match

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -361,15 +361,18 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
     pppEmissionUnkB* step = (pppEmissionUnkB*)param_3;
     EmissionMeshData* meshData = ((EmissionModelView*)model)->m_meshes[meshIndex].m_data;
     if ((strcmp((const char*)meshData, &DAT_803311fc) == 0) && (state->m_colorA != 0)) {
+        int texture = state->m_texture;
         pppInitBlendMode();
         pppSetBlendMode(step->m_payload[8]);
-        *(int*)(MaterialManRaw() + 0xD0) = state->m_texture + 0x28;
+        *(int*)(MaterialManRaw() + 0xD0) = texture + 0x28;
 
         if (step->m_payload[9] == 0) {
+            int drawTevBits = 0xACE0F;
+            int fullTevBits = drawTevBits | 0x40000;
             for (int i = 0; i < step->m_initWOrk; i++) {
                 float scale = ((float)i * state->m_scale0) + FLOAT_803311e4;
-                Mtx objMtx;
                 Mtx viewMtx;
+                Mtx objMtx;
                 PSMTXScale(objMtx, scale, scale, scale);
                 PSMTXConcat(param_5, objMtx, objMtx);
                 PSMTXCopy(CameraMatrix(), viewMtx);
@@ -378,7 +381,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 int remaining = meshData->m_displayListCount - 1;
                 EmissionDisplayList* displayList = meshData->m_displayLists;
                 while (remaining >= 0) {
-                    *(int*)(MaterialManRaw() + 0x48) = 0xACE0F;
+                    *(int*)(MaterialManRaw() + 0x48) = drawTevBits;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
                     *(int*)(MaterialManRaw() + 0x130) = 0;
@@ -392,11 +395,11 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     *(int*)(MaterialManRaw() + 0x58) = 0;
                     *(int*)(MaterialManRaw() + 0x5C) = 0;
                     *(u8*)(MaterialManRaw() + 0x208) = 0;
-                    *(int*)(MaterialManRaw() + 0x48) = 0xECE0F;
+                    *(int*)(MaterialManRaw() + 0x48) = fullTevBits;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
                     *(int*)(MaterialManRaw() + 0x130) = 0;
-                    *(int*)(MaterialManRaw() + 0x40) = 0xECE0F;
+                    *(int*)(MaterialManRaw() + 0x40) = fullTevBits;
                     SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
                         &MaterialMan, ((EmissionModelView*)model)->m_data->m_materialSet, displayList->m_material, 0, 0);
 
@@ -421,6 +424,8 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 }
             }
         } else if (step->m_payload[9] == 1) {
+            int drawTevBits = 0xACE0F;
+            int fullTevBits = drawTevBits | 0x40000;
             EmissionParticle* particle = (EmissionParticle*)state->m_particles;
             for (int i = 0; i < step->m_initWOrk; i++) {
                 float scale = particle->m_scale;
@@ -435,7 +440,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 int remaining = meshData->m_displayListCount - 1;
                 EmissionDisplayList* displayList = meshData->m_displayLists;
                 while (remaining >= 0) {
-                    *(int*)(MaterialManRaw() + 0x48) = 0xACE0F;
+                    *(int*)(MaterialManRaw() + 0x48) = drawTevBits;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
                     *(int*)(MaterialManRaw() + 0x130) = 0;
@@ -449,11 +454,11 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     *(int*)(MaterialManRaw() + 0x58) = 0;
                     *(int*)(MaterialManRaw() + 0x5C) = 0;
                     *(u8*)(MaterialManRaw() + 0x208) = 0;
-                    *(int*)(MaterialManRaw() + 0x48) = 0xECE0F;
+                    *(int*)(MaterialManRaw() + 0x48) = fullTevBits;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
                     *(int*)(MaterialManRaw() + 0x130) = 0;
-                    *(int*)(MaterialManRaw() + 0x40) = 0xECE0F;
+                    *(int*)(MaterialManRaw() + 0x40) = fullTevBits;
                     SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
                         &MaterialMan, ((EmissionModelView*)model)->m_data->m_materialSet, displayList->m_material, 0, 0);
 


### PR DESCRIPTION
What changed
- Reworked `Emission_AfterDrawMeshCallback` in `src/pppEmission.cpp` to preserve the resolved texture handle across blend setup and to express the TEV setup values through locals that better match the original codegen.
- Reordered one local matrix declaration in the non-particle emission path to line up stack slot usage with the target assembly.

What improved
- Unit: `main/pppEmission`
- Symbol: `Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`
- Before: `93.38816%`
- After: `94.115135%`
- Size: unchanged at `1216b`
- Unit `.text` match: improved to `95.96379%`

Verification
- `ninja -j4`
- `build/tools/objdiff-cli diff -p . -u main/pppEmission -o /tmp/pppEmission_after.json Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`

Why this is plausible source
- The change keeps the existing control flow and data access intact.
- It replaces immediate-heavy setup with locals that reflect how the callback appears to stage texture and TEV state before rendering, improving codegen without introducing hacks or fake linkage.
