### PR TITLE
Fix signed THP audio mixing

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -877,7 +877,7 @@ void MixAudio(short* output, short* input, unsigned long samples)
                 volume = gTHPSimpleVolumeTable[static_cast<s32>(SimpleControl.unk_C4)];
 
                 mixedSample = static_cast<s32>(*input) +
-                              static_cast<s32>((static_cast<u32>(volume) * static_cast<s32>(*audioPtr)) >> 15);
+                              ((static_cast<s32>(volume) * static_cast<s32>(*audioPtr)) >> 15);
                 if (mixedSample < -0x8000) {
                     mixedSample = -0x8000;
                 }
@@ -887,7 +887,7 @@ void MixAudio(short* output, short* input, unsigned long samples)
                 *output = static_cast<s16>(mixedSample);
 
                 mixedSample = static_cast<s32>(input[1]) +
-                              static_cast<s32>((static_cast<u32>(volume) * static_cast<s32>(audioPtr[1])) >> 15);
+                              ((static_cast<s32>(volume) * static_cast<s32>(audioPtr[1])) >> 15);
                 if (mixedSample < -0x8000) {
                     mixedSample = -0x8000;
                 }
@@ -935,7 +935,7 @@ void MixAudio(short* output, short* input, unsigned long samples)
                 }
                 volume = gTHPSimpleVolumeTable[static_cast<s32>(SimpleControl.unk_C4)];
 
-                mixedSample = static_cast<s32>((static_cast<u32>(volume) * static_cast<s32>(*audioPtr)) >> 15);
+                mixedSample = (static_cast<s32>(volume) * static_cast<s32>(*audioPtr)) >> 15;
                 if (mixedSample < -0x8000) {
                     mixedSample = -0x8000;
                 }
@@ -944,7 +944,7 @@ void MixAudio(short* output, short* input, unsigned long samples)
                 }
                 *output = static_cast<s16>(mixedSample);
 
-                mixedSample = static_cast<s32>((static_cast<u32>(volume) * static_cast<s32>(audioPtr[1])) >> 15);
+                mixedSample = (static_cast<s32>(volume) * static_cast<s32>(audioPtr[1])) >> 15;
                 if (mixedSample < -0x8000) {
                     mixedSample = -0x8000;
                 }


### PR DESCRIPTION
What changed
- Fix `MixAudio__FPsPsUl` to multiply THP samples with signed arithmetic before the `>> 15` scale step.
- This replaces the current unsigned promotion, which produced the wrong shift for negative decoded samples and diverged from the target assembly.

Evidence
- `ninja` succeeds.
- `MixAudio__FPsPsUl`: `81.14554%` -> `82.15493%` match.
- `main/THPSimple` `.text`: `89.577484%` -> `89.71347%` match.

Why this is plausible source
- Signed PCM mixing is the natural implementation here: the PAL object uses `srawi` after `mullw`, and the old code path was both less accurate and behaviorally wrong for negative samples.
