### PR TITLE
Fix acos linkage in pppYmMoveCircle

### DIFF
--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -5,7 +5,7 @@
 #include "types.h"
 #include "dolphin/mtx.h"
 
-double acos(double);
+extern "C" double acos(double);
 
 struct pppYmMoveCircleWork {
     f32 m_angle;


### PR DESCRIPTION
## Summary
- change the local `acos` declaration in `src/pppYmMoveCircle.cpp` to `extern "C"`
- make `pppConstructYmMoveCircle` call the C `acos` symbol instead of the mangled C++ form
- keep the source shape otherwise unchanged

## Evidence
- `pppConstructYmMoveCircle`: `99.933334%` -> `100.0%`
- `main/pppYmMoveCircle` `.text`: `98.265114%` -> `98.288376%`
- `ninja` succeeds after the change

## Why this is plausible source
- this is a linkage correction, not compiler coaxing or logic rewriting
- the file already calls the standard math routine directly; matching the original C linkage is the coherent ABI fix
