### PR TITLE
Improve pppVertexApMtx match

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -156,7 +156,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 		case 1:
 			while (count-- != 0) {
 				f32 randValue = Math.RandF();
-				f32 maxValue = (f32)(u16)entry->maxValue;
+				f32 maxValue = (f32)entry->maxValue;
 				int outValue = (int)(randValue * maxValue);
 				u16* vertexIndices = entry->vertexIndices;
 				u16 vertexIndex = vertexIndices[outValue];
@@ -201,11 +201,9 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 				}
 			}
 			break;
-		default:
-			break;
 		}
 		state->countdown = data->spawnDelay;
-	}
+		}
 
 	state->countdown--;
 }


### PR DESCRIPTION
## Summary
- adjust the random vertex-selection path in `pppVertexApMtx` to use the signed `entry->maxValue` conversion the sibling vertex-applier units already use
- drop the unnecessary `default` switch arm so the tail codegen stays closer to the original layout

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o - pppVertexApMtx`
- before: `.text` 98.399124%, `pppVertexApMtx` 98.34091%
- after: `.text` 98.66228%, `pppVertexApMtx` 98.61364%

## Plausibility
- this keeps the logic aligned with the already-matched `pppVertexApLc` implementation instead of adding compiler-only tricks
- the change is limited to signedness/control-flow cleanup in the existing source path