### PR TITLE
system: include game.h in system.cpp

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -19,7 +19,7 @@
 #include "dolphin/gx/GXPerf.h"
 #include "dolphin/os.h"
 #include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/printf.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/p_minigame.h"
 #include <string.h>
 


### PR DESCRIPTION
What changed
- Replaced `#include "ffcc/p_game.h"` with `#include "ffcc/game.h"` in `src/system.cpp`.
- `system.cpp` only needs the `CGame` definition for `Game.m_gameWork`; it does not use `CGamePcs`.

Why this is plausible source
- Pulling in `p_game.h` instantiated `CGamePcs` constructor-local static descriptor arrays inside `system.o` via the inline constructor in the header.
- Including `game.h` directly removes that unrelated ownership and keeps `system.cpp` dependent on the type it actually uses.

Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/system -o -`
- `system.o` data symbol `[.data-0]`: `33.39%` -> `43.54%`
- `objdump -x build/GCCP01/src/system.o` no longer shows the stray `desc0$localstatic3$__ct__8CGamePcsFv` ... `desc8$localstatic11$__ct__8CGamePcsFv` symbols in `.data`

Notes
- This is a linkage/data-ownership cleanup only; no runtime behavior changed.
