### PR TITLE
Improve ChangeTex after-draw TEV setup match

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -180,6 +180,7 @@ extern "C" void ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2(C
 				drawTevBits = 0xACE0F;
 				fullTevBits = 0xADE0F;
 				allOnes = -1;
+				u8 fullByte = 0xFF;
 				tevScale = 0x1e;
 				displayListIdx = meshData->m_displayListCount - 1;
 				dlOffset = displayListIdx * 4;
@@ -190,12 +191,12 @@ extern "C" void ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2(C
 					*(int*)(MaterialManRaw() + 0x12c) = tevScale;
 					*(int*)(MaterialManRaw() + 0x130) = 0;
 					*(int*)(MaterialManRaw() + 0x44) = allOnes;
-					*(char*)(MaterialManRaw() + 0x4c) = allOnes;
+					*(u8*)(MaterialManRaw() + 0x4c) = fullByte;
 					*(int*)(MaterialManRaw() + 0x11c) = 0;
 					*(int*)(MaterialManRaw() + 0x120) = tevScale;
 					*(int*)(MaterialManRaw() + 0x124) = 0;
-					*(char*)(MaterialManRaw() + 0x205) = allOnes;
-					*(char*)(MaterialManRaw() + 0x206) = allOnes;
+					*(u8*)(MaterialManRaw() + 0x205) = fullByte;
+					*(u8*)(MaterialManRaw() + 0x206) = fullByte;
 					*(int*)(MaterialManRaw() + 0x58) = 0;
 					*(int*)(MaterialManRaw() + 0x5c) = 0;
 					*(char*)(MaterialManRaw() + 0x208) = 0;


### PR DESCRIPTION
## Summary
- tighten `ChangeTex_AfterDrawMeshCallback` TEV byte writes to use explicit `u8` values for the MaterialMan byte fields
- leave `ChangeTex_DrawMeshDLCallback` unchanged after verifying the width tweak only helped the after-draw path

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o - ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2`
- `ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2`: `92.209305% -> 95.639534%`
- `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2`: unchanged at `86.78689%`
- unit `.text` match for `main/pppChangeTex`: `94.69313% -> 95.14351%`

## Plausibility
- the change keeps the same logic and only makes the written field widths explicit where the callback programs byte-sized MaterialMan state
- this matches the original code pattern more closely without introducing compiler-coaxing or fake linkage hacks