### PR TITLE
Fix skipped history path in pppFrameYmLaser

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -240,6 +240,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 				(float)((double)(int)i - DOUBLE_80330dd8);
 			if (GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(pppMngStPtr, (float)t, charaMtx) == 0) {
 				emptyHistory = true;
+				continue;
 			} else {
 				PSMTXConcat(charaMtx, laser->m_localMatrix.value, charaMtx);
 				PSMTXMultVec(charaMtx, &localB, &points[i]);


### PR DESCRIPTION
## Summary
- add the missing `continue;` in `pppFrameYmLaser` when `GetCharaNodeFrameMatrix(...)` fails
- keep the failed-history path aligned with the existing sibling laser implementation and the Ghidra control flow

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppFrameYmLaser`
  - before: `74.62997%`
  - after: `77.01835%`
- `build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppRenderYmLaser`
  - unchanged: `64.26994%`

## Why this is plausible source
- on a failed node-frame lookup, the old code fell through and kept using the current loop body; the new code marks history as empty and skips that iteration instead
- this matches the sibling `pppFrameLaser` behavior and produces cleaner, more coherent control flow rather than compiler coaxing