### PR TITLE
Improve pppFrameEmission alpha scheduling

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -218,10 +218,13 @@ void pppFrameEmission(pppEmission* pppEmission_, pppEmissionUnkB* param_2, pppEm
                 }
             }
 
-            int alpha = (int)((float)particle->m_alpha * alphaScale);
-            particle->m_fieldA = particle->m_fieldA - 1;
+            s16 particleAlpha = particle->m_alpha;
+            float scaledAlpha = (float)particleAlpha * alphaScale;
+            int alpha = (int)scaledAlpha;
+            s16 remaining = particle->m_fieldA - 1;
+            particle->m_fieldA = remaining;
 
-            if (particle->m_fieldA <= 0) {
+            if (remaining <= 0) {
                 int jitter = 0;
                 if (payload[0xD] != 0) {
                     jitter = rand() % payload[0xD];


### PR DESCRIPTION
## Summary
- split the per-particle alpha conversion in `pppFrameEmission` into explicit `particleAlpha`, `scaledAlpha`, and `remaining` temporaries
- keep the `m_fieldA` decrement/check tied to the same temporary so the generated schedule stays closer to the original particle update loop

## Evidence
- `ninja`: passes for `GCCP01`
- `build/tools/objdiff-cli diff -p . -u main/pppEmission -o - pppFrameEmission`
  - before: `98.30385%`
  - after: `98.71154%`

## Why this is plausible source
- the rewrite preserves the original logic exactly while making the intermediate particle state explicit
- these temporaries reflect natural game code for a particle update loop rather than compiler-forcing tricks