### PR TITLE
Use shared double-bias symbol in pppVertexApMtx

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -61,7 +61,7 @@ struct _pppPDataVal;
 
 _pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
 
-extern "C" const f64 DOUBLE_80330DD0 = 4503599627370496.0;
+extern const double kPppYmSharedDoubleBias;
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- replace the local double-bias definition in `pppVertexApMtx` with the existing shared `kPppYmSharedDoubleBias` symbol
- keep the function logic unchanged while improving the unit's constant/linkage shape

## Evidence
- `ninja` builds cleanly
- `build/tools/objdiff-cli diff -p . -u main/pppVertexApMtx -o -`
- before: `.sdata2` 66.67%
- after: `.sdata2` 87.5%
- after: `.text` 98.66228%

## Why this is plausible source
- other PPP/YM code already uses the shared double-bias symbol instead of redeclaring a local copy
- this change removes a redundant TU-local constant and matches the existing cross-unit linkage pattern