### PR TITLE
Improve p_chara_viewer grid color setup

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -207,11 +207,7 @@ extern "C" void drawViewer__9CCharaPcsFv(void* param_1)
         GXLoadPosMtxImm(cameraMtx, 0);
 
         for (int i = -10; i < 11; i++) {
-            GXColor color;
-            color.r = 0x80;
-            color.g = 0x80;
-            color.b = 0x80;
-            color.a = (i == 0) ? 0x60 : 0x20;
+            GXColor color = {0x80, 0x80, 0x80, static_cast<u8>((i == 0) ? 0x60 : 0x20)};
             GXSetChanMatColor(GX_COLOR0A0, color);
             float x = (float)i * kCharaViewerGridSpacing;
             GXBegin((GXPrimitive)0xA8, GX_VTXFMT0, 4);


### PR DESCRIPTION
## Summary
- tighten the grid color setup in `CCharaPcs::drawViewer()` to use a single `GXColor` aggregate initialization
- keep behavior unchanged while producing cleaner codegen for the grid draw loop

## Evidence
- `drawViewer__9CCharaPcsFv`: `78.5%` -> `78.78095%`
- `createViewer__9CCharaPcsFv`: unchanged at `67.46479%`
- verification: `ninja`
- objdiff: `build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o - drawViewer__9CCharaPcsFv`

## Plausibility
This replaces four scalar byte assignments with the equivalent `GXColor` aggregate literal already implied by the surrounding GX API usage, so the source stays straightforward and consistent with the original rendering code style.