### PR TITLE
Improve pppPObjPoint signed index handling

### DIFF
--- a/include/ffcc/pppPObjPoint.h
+++ b/include/ffcc/pppPObjPoint.h
@@ -5,7 +5,7 @@
 
 struct PppObjData {
     int id;          // 0x0
-    unsigned int field_4;     // 0x4
+    int field_4;     // 0x4
     void* data;      // 0x8
     unsigned int objId;       // 0xc
 };

--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -31,15 +31,18 @@ void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* co
     PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + objOffset + 0x80);
 
     if (objData->id == pointData->id) {
+        u32 vecIndex = objData->field_4;
         u8* vecPtr;
+        u8* data;
+        PObjPointEntry* table;
 
-        if ((objData->field_4 + 0x10000) == 0xFFFF) {
-            vecPtr = (u8*)gPppDefaultValueBuffer;
+        if (vecIndex == -1) {
+            vecPtr = gPppDefaultValueBuffer;
         } else {
-            PObjPointEntry* table = *(PObjPointEntry**)((u8*)pppMngStPtr + 0xD4);
-            u8* data = (u8*)objData->data;
-            u32 vecOffset = table[objData->field_4].vecOffset;
-            vecPtr = data + 0x80;
+            table = *(PObjPointEntry**)((u8*)pppMngStPtr + 0xD4);
+            data = (u8*)objData->data + 0x80;
+            u32 vecOffset = table[vecIndex].vecOffset;
+            vecPtr = data;
             vecPtr += vecOffset;
         }
 


### PR DESCRIPTION
## Summary
- treat `PppObjData::field_4` as a signed index/sentinel in `pppPObjPoint`
- hoist the resolved point-vector index/data temporaries to better reflect the original control flow
- keep the logic source-plausible without introducing linkage hacks or compiler-only tricks

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o - pppPObjPoint`
- before: `pppPObjPoint` matched `84.46%` on a clean `main` rebuild
- after: `pppPObjPoint` matches `89.73%`

## Why this is plausible
- nearby PPP code already treats these object/source offsets as signed values with `-1` as the default-buffer sentinel
- the change replaces an ad hoc unsigned wraparound check with the signed sentinel semantics the engine uses elsewhere