### PR TITLE
Improve MLstDraw cursor placement

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -150,8 +150,7 @@ void CMenuPcs::MLstDraw()
 	DrawInit__8CMenuPcsFv(this);
 	if (menuMode == 1) {
 		MenuLstEntry* curItem = &list->entries[state->cursor];
-		float cursorYOffset =
-			(float)(((double)(float)(curItem->height - 0x20) * DOUBLE_803333E8) + (double)(float)curItem->height);
+		float cursorYOffset = (float)((double)(float)(curItem->height - 0x20) * DOUBLE_803333E8);
 		int cursorY = (int)((float)curItem->y + cursorYOffset);
 		int cursorX = (int)((float)curItem->x - 56.0f + (float)(System.m_frameCounter & 7));
 		DrawCursor__8CMenuPcsFiif(this, cursorX, cursorY, FLOAT_803333F0);


### PR DESCRIPTION
## Summary
- simplify `MLstDraw()` cursor Y placement to use the centered row offset directly
- keep the change isolated to the selected `main/menu_lst` target

## Evidence
- `MLstDraw__8CMenuPcsFv` before: `65.300835%`, size `1352`
- `MLstDraw__8CMenuPcsFv` after: `67.47354%`, size `1332`
- verification command: `build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstDraw__8CMenuPcsFv > diff_result.json`
- full rebuild: `ninja`

## Plausibility
The old expression added the full item height after already computing the centered cursor offset from `(height - 0x20) * 0.5`, which produced a cursor position below the row and inflated the generated code. Using only the centered offset is a cleaner, more plausible source form for a row-aligned list cursor.