### PR TITLE
Improve pppFrameLensFlare scan loop match

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -155,14 +155,14 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 		projectedYInt = (int)work->m_projectedY;
 		zAtPixel = 0;
 		u8 flareWidth = unkB->m_arg3;
-		u32 halfWidth = (u32)(flareWidth >> 1);
+		int halfWidth = flareWidth >> 1;
 		u32 z0 = __cvt_fp2unsigned((double)(16777215.0f * work->m_projectedZ));
-		u32 x0 = (u32)(projectedXInt & 0xFFFF);
-		u32 y0 = (u32)(projectedYInt & 0xFFFF);
+		int x0 = (u16)projectedXInt;
+		int y0 = (u16)projectedYInt;
 		s16 stepSize = (s16)((u16)flareWidth / (u16)unkB->m_count);
 
-		for (u32 y = y0 - halfWidth; (int)y <= (int)(y0 + halfWidth); y += stepSize) {
-			for (u32 x = x0 - halfWidth; (int)x <= (int)(x0 + halfWidth); x += stepSize) {
+		for (int y = y0 - halfWidth; y <= (y0 + halfWidth); y += stepSize) {
+			for (int x = x0 - halfWidth; x <= (x0 + halfWidth); x += stepSize) {
 				s16 xShort = (s16)x;
 				s16 yShort = (s16)y;
 
@@ -176,7 +176,7 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 		}
 
 		int alpha = work->m_alpha;
-		int sampleCount = (int)unkB->m_count + 1;
+		int sampleCount = unkB->m_count + 1;
 		sampleCount *= sampleCount;
 		if (alpha == sampleCount) {
 			work->m_alpha = 0xff;


### PR DESCRIPTION
## Summary
- tighten the scan-loop integer typing in `pppFrameLensFlare`
- keep the generated code change local to `src/pppLensFlare.cpp`
- preserve the existing behavior while steering MWCC toward the original register usage

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppLensFlare -o - pppFrameLensFlare`
- before: `main/pppLensFlare` `.text` match `99.4362%`
- after: `main/pppLensFlare` `.text` match `99.46587%`

## Plausibility
- the changes replace unnecessary unsigned widening in the pixel scan with direct signed loop variables
- the resulting source is simpler and more coherent than the previous version, without compiler-coaxing hacks
