### PR TITLE
Fix drawViewer GPU timing print order

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -242,7 +242,7 @@ extern "C" void drawViewer__9CCharaPcsFv(void* param_1)
                 if (i == 0) {
                     float totalTime = watch.Get();
                     float gpuTime = totalTime - cpuTime;
-                    Printf__8CGraphicFPce(&Graphic, s_gpu_profile_fmt, cpuTime, gpuTime, totalTime);
+                    Printf__8CGraphicFPce(&Graphic, s_gpu_profile_fmt, totalTime, cpuTime, gpuTime);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix `drawViewer__9CCharaPcsFv` to pass timing values to `Printf__8CGraphicFPce` in the original total/CPU/GPU order
- keep the change narrowly scoped to the verified match improvement in `src/p_chara_viewer.cpp`

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o - drawViewer__9CCharaPcsFv`
- before: `drawViewer__9CCharaPcsFv` 81.35%, unit `.text` 65.27487%
- after: `drawViewer__9CCharaPcsFv` 81.71905%, unit `.text` 65.35602%

## Plausibility
- the format string is `"GPU = %f.5%%(C = %.5f%% G = %.5f%%)"`, so passing total, CPU, then GPU is the coherent source-level argument order
- the recovered Ghidra shape for the call also lines up with total time being produced after the second `Get()` and used as the first floating-point argument