### PR TITLE
Improve pppYmDeformationMdl render constant reuse

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -46,6 +46,7 @@ struct _pppEnvStYmDeformationMdl {
     CMapMesh** m_mapMeshPtr;
 };
 extern _pppEnvStYmDeformationMdl* pppEnvStPtr;
+static const float kPppYmDeformationMdlZero = 0.0f;
 extern float FLOAT_80330D98;
 extern float FLOAT_80330D9C;
 extern float FLOAT_80330DA0;
@@ -205,10 +206,10 @@ void pppRenderYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, pppYmDe
         PSMTXRotRad(rotMtx, 'z', FLOAT_80330DA8 * (float)state->m_angle);
         indMtx[0][0] = rotMtx[0][0] * state->m_scale;
         indMtx[0][1] = rotMtx[0][1] * state->m_scale;
-        indMtx[0][2] = 0.0f;
+        indMtx[0][2] = kPppYmDeformationMdlZero;
         indMtx[1][0] = rotMtx[1][0] * state->m_scale;
         indMtx[1][1] = rotMtx[1][1] * state->m_scale;
-        indMtx[1][2] = 0.0f;
+        indMtx[1][2] = kPppYmDeformationMdlZero;
         GXSetIndTexMtx(GX_ITM_0, indMtx, 1);
 
         GXLoadTexObj((_GXTexObj*)backTexture, GX_TEXMAP0);
@@ -219,13 +220,13 @@ void pppRenderYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, pppYmDe
         GXSetNumIndStages(0);
         GXSetIndTexCoordScale(GX_INDTEXSTAGE0, GX_ITS_1, GX_ITS_1);
 
-        PSMTXRotRad(resetRotMtx, 'z', 0.0f);
-        resetIndMtx[0][0] = 0.0f;
-        resetIndMtx[0][1] = 0.0f;
-        resetIndMtx[0][2] = 0.0f;
-        resetIndMtx[1][0] = 0.0f;
-        resetIndMtx[1][1] = 0.0f;
-        resetIndMtx[1][2] = 0.0f;
+        PSMTXRotRad(resetRotMtx, 'z', kPppYmDeformationMdlZero);
+        resetIndMtx[0][0] = kPppYmDeformationMdlZero;
+        resetIndMtx[0][1] = kPppYmDeformationMdlZero;
+        resetIndMtx[0][2] = kPppYmDeformationMdlZero;
+        resetIndMtx[1][0] = kPppYmDeformationMdlZero;
+        resetIndMtx[1][1] = kPppYmDeformationMdlZero;
+        resetIndMtx[1][2] = kPppYmDeformationMdlZero;
         GXSetIndTexMtx(GX_ITM_0, resetIndMtx, 1);
 
         _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);


### PR DESCRIPTION
## Summary
- add a shared zero float in `pppYmDeformationMdl.cpp`
- reuse it for the indirect matrix zeroing path in `pppRenderYmDeformationMdl`
- keep the render logic unchanged while improving the PAL fuzzy match

## Evidence
- `ninja` succeeds
- `main/pppYmDeformationMdl` fuzzy match: `99.63496 -> 99.701324`
- `pppRenderYmDeformationMdl` fuzzy match: `99.523125 -> 99.609825`

## Why this is plausible
- the render path repeatedly writes the same `0.0f` value into the indirect matrices
- reusing a TU-local zero constant is coherent source-level cleanup, not section forcing or address chasing
- the change stays inside the target's dependency cluster and preserves behavior