### PR TITLE
Use CMapTexAnim helper in SetMapTexAnim

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -107,35 +107,14 @@ static inline void SetMaterialTextureSlot(void* material, unsigned long slotInde
 void CMapTexAnimSet::SetMapTexAnim(int materialId, int frameStart, int frameEnd, int wrapMode)
 {
     int found = 0;
-    int i = 0;
-    int setPtr = reinterpret_cast<int>(this);
+    CMapTexAnim** anim = m_anims;
 
-    while (i < m_count) {
-        void* animPtr = reinterpret_cast<void*>(*reinterpret_cast<int*>(setPtr + 0xC));
-        if (S16At(animPtr, 0x12) == static_cast<short>(materialId)) {
-            int end = frameEnd;
-            if (U8At(animPtr, 0x15) != 0) {
-                S32At(animPtr, 0x30) = frameStart;
-                S32At(animPtr, 0x2C) = frameStart;
-                if (frameEnd > S32At(animPtr, 0x38)) {
-                    end = S32At(animPtr, 0x38);
-                }
-                S32At(animPtr, 0x34) = end;
-                U8At(animPtr, 0x27) = static_cast<unsigned char>(wrapMode);
-                U8At(animPtr, 0x28) = 1;
-            } else {
-                S16At(animPtr, 0xE) = static_cast<short>(frameStart);
-                F32At(animPtr, 0x1C) = static_cast<float>(static_cast<short>(frameStart));
-                if (frameEnd > S16At(animPtr, 0xC)) {
-                    end = S16At(animPtr, 0xC);
-                }
-                S16At(animPtr, 0x10) = static_cast<short>(end);
-                U8At(animPtr, 0x16) = static_cast<unsigned char>(wrapMode);
-            }
+    for (int i = 0; i < m_count; i++) {
+        if ((*anim)->m_materialId == static_cast<short>(materialId)) {
+            (*anim)->SetMapTexAnim(frameStart, frameEnd, wrapMode);
             found = 1;
         }
-        setPtr += 4;
-        i += 1;
+        anim++;
     }
 
     if ((found == 0) && (static_cast<unsigned int>(System.m_execParam) >= 1)) {


### PR DESCRIPTION
## Summary
- replace the offset-based duplicate logic in `CMapTexAnimSet::SetMapTexAnim` with direct `CMapTexAnim` member access
- call the existing inline `CMapTexAnim::SetMapTexAnim` helper instead of manually reimplementing the same state updates
- keep the existing warning path for missing material IDs unchanged

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/maptexanim -o - SetMapTexAnim__14CMapTexAnimSetFiiii`
- before: `94.63768%`
- after: `95.13043%`

## Plausibility
This is more plausible original source than the previous pointer-offset implementation because the per-animation update logic already exists as an inline method on `CMapTexAnim`, and `CMapTexAnimSet` is declared as a friend specifically so it can use those members directly.