### PR TITLE
Improve pppFrameYmMelt loop matching

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -319,9 +319,11 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
         rot = FLOAT_80330b0c * (f32)phaseWork;
         vertex = vertexBase;
 
-        for (z = -halfWidth; z <= halfWidth; z += step) {
+        const float start = -halfWidth;
+
+        for (z = start; z <= halfWidth; z += step) {
             rowVertex = vertex;
-            for (x = -halfWidth; x <= halfWidth; x += step) {
+            for (x = start; x <= halfWidth; x += step) {
                 rowVertex->m_position.x = x;
                 rowVertex->m_position.y = kPppYmMeltZero;
                 rowVertex->m_position.z = z;


### PR DESCRIPTION
## Summary
- make the ym melt vertex-generation loop reuse a block-local start value for both axes
- keep the source behavior unchanged while nudging MWCC closer to the original FP register/lifetime shape

## Evidence
- `ninja` succeeds
- `pppFrameYmMelt` objdiff improved from `99.35294%` to `99.73529%`
- remaining diffs in `pppFrameYmMelt` dropped to 6 instruction mismatches

## Why this is plausible source
- the change only names the repeated `-halfWidth` bound explicitly
- no compiler-specific hacks, fake linkage, or ABI-forcing tricks were added
- the loop logic remains the same, but the source reads more directly as a symmetric grid build