### PR TITLE
Improve CTexture GX init matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -621,41 +621,43 @@ CTextureSet::~CTextureSet()
  */
 void CTexture::InitTexObj()
 {
-    const int format = m_format;
+    int format;
+    int tlutBase;
+    unsigned int numEntries;
+    int offset;
+
+    format = m_format;
     if ((format == 9) || (format == 8)) {
-        GXInitTexObjCI(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height), static_cast<GXCITexFmt>(format),
-                       static_cast<GXTexWrapMode>(m_wrapMode), static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
+        GXInitTexObjCI(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
+                       static_cast<GXCITexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
+                       static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
 
-        void* tlutData = m_tlutData;
-        int numEntries0 = 0x10;
+        tlutBase = reinterpret_cast<int>(m_tlutData);
+        numEntries = 0x10;
         if (m_format == 9) {
-            numEntries0 = 0x100;
+            numEntries = 0x100;
+        }
+        GXInitTlutObj(&m_tlutObj0, reinterpret_cast<void*>(tlutBase), GX_TL_IA8, static_cast<u16>(numEntries));
+
+        numEntries = 0x10;
+        if (m_format == 9) {
+            numEntries = 0x100;
         }
 
-        GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, static_cast<u16>(numEntries0));
-
-        int numEntries1 = 0x10;
+        offset = 0x10;
         if (m_format == 9) {
-            numEntries1 = 0x100;
+            offset = 0x100;
         }
-
-        int offsetEntries = 0x10;
-        if (m_format == 9) {
-            offsetEntries = 0x100;
-        }
-
-        GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(reinterpret_cast<unsigned int>(tlutData) + offsetEntries * 2),
-                      GX_TL_IA8, static_cast<u16>(numEntries1));
+        GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(tlutBase + offset * 2), GX_TL_IA8, static_cast<u16>(numEntries));
     } else {
-        GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height), static_cast<GXTexFmt>(format),
-                     static_cast<GXTexWrapMode>(m_wrapMode), static_cast<GXTexWrapMode>(m_wrapMode),
-                     (1 - static_cast<int>(m_maxLod)) >> 31);
+        GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
+                     static_cast<GXTexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
+                     static_cast<GXTexWrapMode>(m_wrapMode), (1 - m_maxLod) >> 31);
     }
 
-    const unsigned char maxLod = m_maxLod;
-    if (1 < maxLod) {
-        GXInitTexObjLOD(&m_texObj, GX_LIN_MIP_LIN, GX_LINEAR, 0.0f, static_cast<float>(maxLod) - 1.0f, 0.0f, GX_FALSE, GX_FALSE,
-                        GX_ANISO_1);
+    if (1 < m_maxLod) {
+        GXInitTexObjLOD(&m_texObj, GX_LIN_MIP_LIN, GX_LINEAR, 0.0f, static_cast<float>(m_maxLod) - 1.0f, 0.0f, GX_FALSE,
+                        GX_FALSE, GX_ANISO_1);
     }
 }
 
@@ -849,16 +851,20 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
 {
     if (m_cacheId != -1) {
         if (IsEnable__13CAmemCacheSetFs(amemCacheSet, m_cacheId) == 0) {
+            int format;
+            unsigned int numEntries;
+            int offset;
+
             m_imageData = reinterpret_cast<void*>(
                 GetData__13CAmemCacheSetFsPci(amemCacheSet, m_cacheId, const_cast<char*>(s_textureman_cpp), 0x1DD));
 
-            const int format = m_format;
+            format = m_format;
             if ((format == 9) || (format == 8)) {
                 GXInitTexObjCI(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                                static_cast<GXCITexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
                                static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
 
-                unsigned int numEntries = 0x10;
+                numEntries = 0x10;
                 if (m_format == 9) {
                     numEntries = 0x100;
                 }
@@ -868,7 +874,7 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
                 if (m_format == 9) {
                     numEntries = 0x100;
                 }
-                int offset = 0x10;
+                offset = 0x10;
                 if (m_format == 9) {
                     offset = 0x100;
                 }
@@ -877,12 +883,11 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
             } else {
                 GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                              static_cast<GXTexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
-                             static_cast<GXTexWrapMode>(m_wrapMode), (1 - static_cast<int>(m_maxLod)) >> 31);
+                             static_cast<GXTexWrapMode>(m_wrapMode), (1 - m_maxLod) >> 31);
             }
 
-            const unsigned char maxLod = m_maxLod;
-            if (maxLod >= 2) {
-                GXInitTexObjLOD(&m_texObj, GX_LINEAR, GX_LINEAR, 0.0f, static_cast<float>(maxLod - 1), 0.0f, GX_FALSE,
+            if (1 < m_maxLod) {
+                GXInitTexObjLOD(&m_texObj, GX_LINEAR, GX_LINEAR, 0.0f, static_cast<float>(m_maxLod - 1), 0.0f, GX_FALSE,
                                 GX_FALSE, GX_ANISO_1);
             }
         }


### PR DESCRIPTION
## Summary
- rewrite the GX texture-object initialization flow in `CTexture::InitTexObj`
- align `CTexture::CacheLoadTexture` with the same original palette/Lod setup sequence
- keep behavior the same while matching the original register and compare flow more closely

## Evidence
- `InitTexObj__8CTextureFv`: `72.02247%` -> `82.93259%`
- `CacheLoadTexture__8CTextureFP13CAmemCacheSet`: `74.642204%` -> `76.357796%`
- `main/textureman` `.text`: `82.65521%` -> `83.3076%`

## Why this is plausible source
- the change removes reconstruction-driven temporaries and uses the same repeated field reads/sign-sensitive comparisons the original codegen expects
- palette and LOD setup still follow the existing engine logic; this is a codegen-focused cleanup, not compiler coaxing or behavioral hacking

## Verification
- `ninja`