### PR TITLE
Refine pppColum to use shared particle/util declarations

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -34,22 +34,14 @@ struct pppColumPositionWork {
     u8 m_alpha;
 };
 
-enum {
-    ColumFloatQNaN = 1,
-    ColumFloatInfinite = 2,
-    ColumFloatZero = 3,
-    ColumFloatNormal = 4,
-    ColumFloatSubnormal = 5
-};
-
 union ColumFloatBits {
     float value;
-    unsigned long bits;
+    u32 bits;
 };
 
 static const char s_pppColum_cpp_801DB638[] = "pppColum.cpp";
 
-extern int __float_nan[];
+extern unsigned long __float_nan[];
 extern float FLOAT_80331078;
 extern float FLOAT_8033107C;
 extern float FLOAT_80331080;
@@ -64,20 +56,30 @@ extern double DOUBLE_803310B0;
 extern double DOUBLE_803310B8;
 
 extern "C" {
-void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
-unsigned char GetNoise__5CUtilFUc(void*, unsigned int);
-
-void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(void*, void*, float, unsigned char,
-                                                                unsigned char, unsigned char, unsigned char,
-                                                                unsigned char, unsigned char, unsigned char);
-void BeginQuadEnv__5CUtilFv(void*);
-void EndQuadEnv__5CUtilFv(void*);
-void SetVtxFmt_POS_CLR_TEX__5CUtilFv(void*);
 void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
 void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
-void pppGetShapePos__FPlsR3VecR3Veci(long*, short, Vec&, Vec&, int);
-void pppGetShapeUV__FPlsR5Vec2dR5Vec2di(long*, short, Vec2d&, Vec2d&, int);
-void RenderQuad__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d(void*, Vec, Vec, GXColor, Vec2d*, Vec2d*);
+}
+
+static inline int ColumFpClassify(float value)
+{
+    ColumFloatBits bits;
+
+    bits.value = value;
+    switch (bits.bits & 0x7F800000) {
+    case 0x7F800000:
+        if ((bits.bits & 0x007FFFFF) != 0) {
+            return 1;
+        }
+        return 2;
+
+    case 0:
+        if ((bits.bits & 0x007FFFFF) != 0) {
+            return 5;
+        }
+        return 3;
+    }
+
+    return 4;
 }
 
 static inline float ColumSqrtPositive(float value)
@@ -107,7 +109,7 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
     pppColumFrameWork* frameWork = (pppColumFrameWork*)(objBytes + serializedDataOffsets[3] + 0x80);
     pppColumPositionWork* positionWork =
         (pppColumPositionWork*)(objBytes + serializedDataOffsets[2] + 0x80);
-    pppCVector color;
+    pppCVECTOR color;
     int textureIndex = 0;
 
     if (param_2->m_dataValIndex != 0xFFFF) {
@@ -142,38 +144,10 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             lengthXY = cameraDelta.x * cameraDelta.x + cameraDelta.y * cameraDelta.y;
             if (lengthXY > FLOAT_80331084) {
                 lengthXY = ColumSqrtPositive(lengthXY);
-            } else {
-                if ((double)lengthXY < DOUBLE_80331098) {
-                    lengthXY = *(float*)__float_nan;
-                } else {
-                    ColumFloatBits bits;
-                    int floatClass;
-
-                    bits.value = lengthXY;
-                    switch (bits.bits & 0x7F800000) {
-                    case 0x7F800000:
-                        if ((bits.bits & 0x007FFFFF) != 0) {
-                            floatClass = ColumFloatQNaN;
-                        } else {
-                            floatClass = ColumFloatInfinite;
-                        }
-                        break;
-                    case 0:
-                        if ((bits.bits & 0x007FFFFF) != 0) {
-                            floatClass = ColumFloatSubnormal;
-                        } else {
-                            floatClass = ColumFloatZero;
-                        }
-                        break;
-                    default:
-                        floatClass = ColumFloatNormal;
-                        break;
-                    }
-
-                    if (floatClass == ColumFloatQNaN) {
-                        lengthXY = *(float*)__float_nan;
-                    }
-                }
+            } else if ((double)lengthXY < DOUBLE_80331098) {
+                lengthXY = *(float*)__float_nan;
+            } else if (ColumFpClassify(lengthXY) == 1) {
+                lengthXY = *(float*)__float_nan;
             }
             if (FLOAT_803310A0 < lengthXY) {
                 PSVECScale(&cameraDelta, &cameraDelta, FLOAT_803310A4 / lengthXY);
@@ -203,17 +177,18 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
                         alpha = (u8)((float)alpha * fadeAmount);
                     }
                 }
-                color.m_rgba[0] = *((u8*)&param_2->m_stepValue + 0) + values->m_colorR;
-                color.m_rgba[1] = *((u8*)&param_2->m_stepValue + 1) + values->m_colorG;
-                color.m_rgba[2] = *((u8*)&param_2->m_stepValue + 2) + values->m_colorB;
-                color.m_rgba[3] = alpha;
+                color.rgba[0] = *((u8*)&param_2->m_stepValue + 0) + values->m_colorR;
+                color.rgba[1] = *((u8*)&param_2->m_stepValue + 1) + values->m_colorG;
+                color.rgba[2] = *((u8*)&param_2->m_stepValue + 2) + values->m_colorB;
+                color.rgba[3] = alpha;
 
-                pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
-                    &color, NULL, 0.0f, (u8)param_2->m_payload[0x15], (u8)param_2->m_payload[0x14],
+                pppSetDrawEnv(
+                    &color, (pppFMATRIX*)0, 0.0f, (u8)param_2->m_payload[0x15],
+                    (u8)param_2->m_payload[0x14],
                     param_2->m_arg3, 0, 0, 1, 0);
 
-                BeginQuadEnv__5CUtilFv(&gUtil);
-                SetVtxFmt_POS_CLR_TEX__5CUtilFv(&gUtil);
+                gUtil.BeginQuadEnv();
+                gUtil.SetVtxFmt_POS_CLR_TEX();
                 _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0, 0, 4);
                 _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 0);
                 GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
@@ -225,21 +200,19 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
                     (u8*)shapeSt->m_animData +
                     *(short*)((u8*)shapeSt->m_animData + (frameWork->m_shapeB * 8) + 0x10);
                 for (int j = 0; j < *(short*)(frameData + 2); j++) {
-                    pppGetShapePos__FPlsR3VecR3Veci(
-                        (long*)shapeSt->m_animData, frameWork->m_shapeB, shapePosA, shapePosB, j);
-                    pppGetShapeUV__FPlsR5Vec2dR5Vec2di(
-                        (long*)shapeSt->m_animData, frameWork->m_shapeB, uvA, uvB, j);
+                    pppGetShapePos((long*)shapeSt->m_animData, frameWork->m_shapeB, shapePosA,
+                                   shapePosB, j);
+                    pppGetShapeUV((long*)shapeSt->m_animData, frameWork->m_shapeB, uvA, uvB, j);
 
                     PSVECScale(&shapePosA, &shapePosA, drawScale);
                     PSVECScale(&shapePosB, &shapePosB, drawScale);
                     PSVECAdd(&shapePosA, &center, &shapePosA);
                     PSVECAdd(&shapePosB, &center, &shapePosB);
 
-                    RenderQuad__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d(
-                        &gUtil, shapePosA, shapePosB, *(GXColor*)color.m_rgba, &uvA, &uvB);
+                    gUtil.RenderQuad(shapePosA, shapePosB, *(GXColor*)color.rgba, &uvA, &uvB);
                 }
 
-                EndQuadEnv__5CUtilFv(&gUtil);
+                gUtil.EndQuadEnv();
                 pppSetBlendMode(0);
                 values++;
             }
@@ -267,7 +240,7 @@ void pppFrameColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param_
         serializedDataOffsets = param_3->m_serializedDataOffsets;
         work = (pppColumFrameWork*)((char*)column + 0x80 + serializedDataOffsets[3]);
         if (work->m_values == 0) {
-            work->m_values = (pppColumValue*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            work->m_values = (pppColumValue*)pppMemAlloc(
                 (unsigned long)param_2->m_count * 0xc, pppEnvStPtr->m_stagePtr,
                 const_cast<char*>(s_pppColum_cpp_801DB638), 0x7d);
 
@@ -277,12 +250,9 @@ void pppFrameColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param_
                 values->m_scaleStep = values->m_scaleStep + *(float*)(param_2->m_payload + 0);
                 values->m_positionScale = Math.RandF(*(float*)(param_2->m_payload + 0xc));
                 values->m_positionScale = values->m_positionScale + *(float*)(param_2->m_payload + 8);
-                values->m_colorR =
-                    GetNoise__5CUtilFUc(&gUtil, *(unsigned char*)(param_2->m_payload + 0x16));
-                values->m_colorG =
-                    GetNoise__5CUtilFUc(&gUtil, *(unsigned char*)(param_2->m_payload + 0x17));
-                values->m_colorB =
-                    GetNoise__5CUtilFUc(&gUtil, *(unsigned char*)(param_2->m_payload + 0x18));
+                values->m_colorR = gUtil.GetNoise(*(unsigned char*)(param_2->m_payload + 0x16));
+                values->m_colorG = gUtil.GetNoise(*(unsigned char*)(param_2->m_payload + 0x17));
+                values->m_colorB = gUtil.GetNoise(*(unsigned char*)(param_2->m_payload + 0x18));
                 values++;
             }
         }


### PR DESCRIPTION
## Summary
- switch  over to the project-owned particle and util declarations instead of local mangled prototypes
- factor the float classification path into a shared-style inline helper and tighten the NaN handling path in 
- use the existing , , , , and  member calls directly

## Units / symbols improved
- 
- 

## Evidence
- :  -> 
-  :  -> 
- [1/1] PROGRESS
Progress:
  All: 25.16% matched, 18.10% linked (293 / 635 files)
    Code: 466860 / 1855304 bytes (2960 / 4733 functions)
    Data: 1082139 / 1489611 bytes (72.65%)
  Game Code: 10.18% matched, 1.70% linked (91 / 273 files)
    Code: 157280 / 1545724 bytes (1717 / 3490 functions)
    Data: 923885 / 1122157 bytes (82.33%)
  SDK Code: 100.00% matched, 100.00% linked (202 / 202 files)
    Code: 309580 / 309580 bytes (1243 / 1243 functions)
    Data: 158254 / 158254 bytes (100.00%) passes after the change

## Why this is plausible source
These edits remove local ABI workarounds in favor of the declarations already used elsewhere in the particle code, and they make the math/classification flow look like adjacent effect sources rather than compiler-coaxing stubs.