### PR TITLE
Remove unused pppRandDownIV helper

### DIFF
--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
-}


### PR DESCRIPTION
## Summary
- Removed the unused static `randint` helper from `src/pppRandDownIV.cpp`.
- This drops the extra generated exception metadata for the unit while leaving `pppRandDownIV` code output unchanged.

## Evidence
- `ninja`: passes, `build/GCCP01/main.dol: OK` from the baseline full rebuild and incremental rebuilds completed after the edit.
- Before: `build/tools/objdiff-cli diff -p . -u main/pppRandDownIV -o -` showed extab 66.66667% and extabindex 57.14286%, with right-side extab/extabindex sizes 16/24.
- After: the same objdiff shows extab 100%, extabindex 100%, and .sdata2 100%; right-side extab/extabindex sizes now match 8/12.
- After report for `main/pppRandDownIV`: total_data 36, matched_data 36, matched_data_percent 100.0.

## Plausibility
- The removed helper was unreferenced, marked `PAL Address: UNUSED`, and generated metadata that does not exist in the original unit. Removing it makes the unit layout cleaner without introducing a source-level workaround.