### PR TITLE
Improve RedMidiCtrl handler matching

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -687,6 +687,7 @@ void __MidiCtrl_LoopRepeat(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma optimization_level 4
 void __MidiCtrl_TempoDirect(RedSoundCONTROL* control, RedKeyOnDATA*, RedTrackDATA* track)
 {
     u8* command = (u8*)*(u32*)track;
@@ -696,6 +697,7 @@ void __MidiCtrl_TempoDirect(RedSoundCONTROL* control, RedKeyOnDATA*, RedTrackDAT
     *(u32*)((u8*)control + 0x44C) = 0;
     *(u32*)((u8*)control + 0x450) = 0;
 }
+#pragma optimization_level 0
 
 /*
  * --INFO--
@@ -1143,17 +1145,18 @@ void __MidiCtrl_VolumeChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* trac
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma optimization_level 0
 void __MidiCtrl_ExpressionDirect(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-    unsigned char* command = (unsigned char*)*(int*)track;
-    int* trackData = (int*)track;
+    char* command = (char*)*(int*)track;
 
-    *trackData = (int)(command + 1);
-    trackData[0xd] = ((int)(char)*command) << 0xc;
-    trackData[0xe] = 0;
-    trackData[0xf] = 0;
+    *(int*)track = (int)(command + 1);
+    ((int*)track)[0xd] = ((int)*command) << 0xc;
+    ((int*)track)[0xe] = 0;
+    ((int*)track)[0xf] = 0;
     m_AChangeStatus |= 2;
 }
+#pragma optimization_level 4
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Scope optimization pragmas around __MidiCtrl_TempoDirect so it compiles closer to the original short handler.
- Compile __MidiCtrl_ExpressionDirect with the saved-register shape seen in the target and simplify its direct track writes.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o -
  - Before: .text 77.17036%, .data 100.0%
  - After: .text 77.54536%, .data 100.0%

## Plausibility
- The changes are limited to existing RedMidiCtrl pragma/source-shape patterns.
- The handlers still express the same command-byte reads and track/control field updates without fake symbols or address tricks.