### PR TITLE
Improve MakeSpline1Dtable matching

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -895,7 +895,9 @@ void CMath::MakeSpline1Dtable(int count, float* x, float* y, float* outSecondDer
     outSecondDerivatives[0] = firstDerivative;
     outSecondDerivatives[count] = firstDerivative;
     for (i = 1; i < count; ++i) {
-        outSecondDerivatives[i] = -(firstDerivative * s_wSpline[i] - outSecondDerivatives[i]) / s_dSpline[i];
+        float w = s_wSpline[i];
+        float value = outSecondDerivatives[i];
+        outSecondDerivatives[i] = -(firstDerivative * w - value) / s_dSpline[i];
     }
 }
 


### PR DESCRIPTION
## Summary
- Split the final MakeSpline1Dtable back-substitution expression into explicit local loads for the spline weight and current output value.
- This keeps the source formula unchanged while producing better register/pointer setup in the generated code.

## Evidence
- Built with `ninja`.
- `build/tools/objdiff-cli diff -p . -u main/math -o - MakeSpline1Dtable__5CMathFiPfPfPf`
  - Before: 99.793816% match, 2328 bytes
  - After: 99.84193% match, 2328 bytes

## Plausibility
- The change is ordinary C++ source shaping: naming intermediate values in the final spline solve loop, not hardcoded addresses, fake symbols, or section forcing.