### PR TITLE
Improve RenderDeformationShape projection setup

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -363,18 +363,19 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
  */
 int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* vertices, Vec2d* uvs)
 {
-	const Mtx& objMtx = ((pppYmDeformationShpLayout*)obj)->m_modelMatrix.value;
+	pppYmDeformationShpLayout* layout = (pppYmDeformationShpLayout*)obj;
 	Vec4d projected[4];
-	Vec worldPos;
+	Vec localVertex;
 	Vec4d clipPos;
+	Vec worldPos;
 	float maxX;
 	float maxY;
 	float minX;
 	float minY;
-	int left;
-	int top;
-	int width;
-	int height;
+	int left = 0;
+	int top = 0;
+	int width = 0;
+	int height = 0;
 	Mtx texMtx;
 	Mtx tempMtx;
 	Vec origin;
@@ -386,20 +387,26 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 	float texScaleY;
 	float offsetX;
 	float offsetY;
+	float one = FLOAT_803305f8;
+	float screenCenterX = FLOAT_80330610;
+	float screenScaleX = FLOAT_80330614;
+	float screenCenterY = FLOAT_80330618;
+	float screenScaleY = FLOAT_8033061c;
 	int i;
 
 	for (i = 0; i < 4; i++) {
-		PSMTXMultVec(objMtx, &vertices[i], &worldPos);
+		localVertex = vertices[i];
+		PSMTXMultVec(layout->m_modelMatrix.value, &localVertex, &worldPos);
 		clipPos.x = worldPos.x;
 		clipPos.y = worldPos.y;
 		clipPos.z = worldPos.z;
-		clipPos.w = FLOAT_803305f8;
+		clipPos.w = one;
 		MTX44MultVec4__5CMathFPA4_fP5Vec4dP5Vec4d(&Math, ppvScreenMatrix, &clipPos, &projected[i]);
 		projected[i].x = projected[i].x / projected[i].w;
 		projected[i].y = projected[i].y / projected[i].w;
 		projected[i].z = projected[i].z / projected[i].w;
-		projected[i].x = FLOAT_80330610 + projected[i].x / FLOAT_80330614;
-		projected[i].y = FLOAT_80330618 - projected[i].y / FLOAT_8033061c;
+		projected[i].x = screenCenterX + projected[i].x / screenScaleX;
+		projected[i].y = screenCenterY - projected[i].y / screenScaleY;
 	}
 
 	maxX = FLOAT_80330624;
@@ -456,7 +463,7 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 	texMtx[1][2] = FLOAT_80330628;
 	texMtx[2][2] = FLOAT_8033062c;
 
-	PSMTXConcat(texMtx, objMtx, tempMtx);
+	PSMTXConcat(texMtx, layout->m_modelMatrix.value, tempMtx);
 	origin.x = kPppYmDeformationShpZero;
 	origin.y = kPppYmDeformationShpZero;
 	origin.z = kPppYmDeformationShpZero;
@@ -465,7 +472,7 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 	cameraPos.y = cameraPos.y / cameraPos.z;
 	texMtx[0][2] = FLOAT_8033062c + cameraPos.x;
 	texMtx[1][2] = FLOAT_8033062c + cameraPos.y;
-	PSMTXConcat(texMtx, objMtx, tempMtx);
+	PSMTXConcat(texMtx, layout->m_modelMatrix.value, tempMtx);
 
 	for (i = 0; i < 4; i++) {
 		PSMTXMultVec(tempMtx, &vertices[i], &projectedObj[i]);
@@ -484,8 +491,8 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 		}
 	}
 
-	texScaleX = FLOAT_803305f8 / (float)width;
-	texScaleY = FLOAT_803305f8 / (float)height;
+	texScaleX = one / (float)width;
+	texScaleY = one / (float)height;
 	offsetX = projectedObj[maxXIndex].x - texScaleX * (projected[maxXIndex].x - (float)left);
 	offsetY = projectedObj[maxYIndex].y - texScaleY * (projected[maxYIndex].y - (float)top);
 
@@ -523,7 +530,7 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 		texMtx[1][2] = texMtx[1][2] + offsetY;
 	}
 
-	PSMTXConcat(texMtx, objMtx, texMtx);
+	PSMTXConcat(texMtx, layout->m_modelMatrix.value, texMtx);
 	GXLoadTexMtxImm(texMtx, 0x1e, GX_MTX2x4);
 	GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_POS, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);
 	GXSetTexCoordGen2(GX_TEXCOORD1, GX_TG_MTX2x4, GX_TG_TEX1, GX_TEXMTX1, GX_FALSE, GX_PTIDENTITY);


### PR DESCRIPTION
## Summary
- reshape `RenderDeformationShape` around a typed object layout pointer and explicit local vertex copies
- cache the screen-space constants in locals so the projection math matches the original source shape more closely
- keep the surrounding render path unchanged aside from feeding the same matrix through the new local layout access

## Objdiff evidence
- `main/pppYmDeformationShp` `.text`: `86.2065%` -> `89.29384%`
- `RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d`: `74.63777%` -> `81.87306%`
- `pppRenderYmDeformationShp`: remains at `94.50551%`

## Why this is plausible source
- the changes replace repeated cast-heavy matrix access with a coherent local layout pointer
- the projection loop now uses an explicit local vertex/work vector flow that matches the surrounding decompilation patterns without introducing hacks or fake linkage
- no symbols, sections, or generated functions were forced; this is strictly source-shape cleanup inside the target dependency cluster
