### PR TITLE
Name VColor channel fields

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -140,8 +140,11 @@ struct pppFVECTOR4
 
 struct VColor
 {
-    unsigned char m_unknown[11]; // 0x0
-    unsigned char m_alpha;       // 0xb
+    unsigned char m_unknown[8]; // 0x0
+    unsigned char m_red;        // 0x8
+    unsigned char m_green;      // 0x9
+    unsigned char m_blue;       // 0xa
+    unsigned char m_alpha;      // 0xb
 }; // Size 0xC
 
 struct PPPIFPARAM

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -744,7 +744,7 @@ extern "C" void pppRenderBreathModel(pppBreathModel* breathModel, PBreathModel* 
     int workOffset;
     int colorOffset;
     unsigned char* work;
-    unsigned char* color;
+    VColor* color;
     unsigned char colorR;
     unsigned char colorG;
     unsigned char colorB;
@@ -762,7 +762,7 @@ extern "C" void pppRenderBreathModel(pppBreathModel* breathModel, PBreathModel* 
     workOffset = offsets->m_serializedDataOffsets[0];
     colorOffset = offsets->m_serializedDataOffsets[1];
     work = reinterpret_cast<unsigned char*>(breathModel) + 0x80 + workOffset;
-    color = reinterpret_cast<unsigned char*>(breathModel) + 0x80 + colorOffset;
+    color = reinterpret_cast<VColor*>(reinterpret_cast<unsigned char*>(breathModel) + 0x80 + colorOffset);
     particleData = (float*)*(void**)(work + 0x30);
     matrixList = *(Mtx**)(work + 0x34);
     particleColor = (float*)*(void**)(work + 0x38);
@@ -781,10 +781,10 @@ extern "C" void pppRenderBreathModel(pppBreathModel* breathModel, PBreathModel* 
                                                                step->m_payload[0xB5], step->m_payload[4], step->m_payload[0xB7],
                                                                step->m_payload[0xB8], 1, step->m_payload[0xB9]);
 
-    colorR = color[0];
-    colorG = color[1];
-    colorB = color[2];
-    colorA = color[3];
+    colorR = color->m_red;
+    colorG = color->m_green;
+    colorB = color->m_blue;
+    colorA = color->m_alpha;
 
     for (i = 0; i < groupCount; i++) {
         if (0 < *(short*)particleData) {

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -703,7 +703,7 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
     int workOffset;
     int colorOffset;
     VYmBreath* work;
-    unsigned char* color;
+    VColor* color;
     Vec* source;
     Mtx* matrixList;
     float* colorDelta;
@@ -721,7 +721,7 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
     workOffset = offsets->m_serializedDataOffsets[0];
     colorOffset = offsets->m_serializedDataOffsets[1];
     work = reinterpret_cast<VYmBreath*>(reinterpret_cast<unsigned char*>(ymBreath) + 0x80 + workOffset);
-    color = reinterpret_cast<unsigned char*>(ymBreath) + 0x80 + colorOffset;
+    color = reinterpret_cast<VColor*>(reinterpret_cast<unsigned char*>(ymBreath) + 0x80 + colorOffset);
     source = reinterpret_cast<Vec*>(work->m_particleData);
     matrixList = work->m_particleWmats;
     colorDelta = reinterpret_cast<float*>(work->m_particleColors);
@@ -739,10 +739,10 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
         0, 0, *reinterpret_cast<float*>(step->m_payload + 0xB0), step->m_payload[0xB6], step->m_payload[0xB5],
         step->m_payload[8], 0, 1, 1, 0);
 
-    colorR = color[0];
-    colorG = color[1];
-    colorB = color[2];
-    colorA = color[3];
+    colorR = color->m_red;
+    colorG = color->m_green;
+    colorB = color->m_blue;
+    colorA = color->m_alpha;
 
     for (i = 0; i < groupCount; i++) {
         if (*(short*)&source[2].z > 0) {


### PR DESCRIPTION
## Summary
- Name the RGB channel bytes in VColor while preserving its 0xC size and existing alpha offset.
- Use the VColor channel fields in pppBreathModel and pppYmBreath render paths instead of treating the color block as raw bytes from offset 0.

## Objdiff evidence
- pppBreathModel: pppRenderBreathModel improved from 87.7492% to 87.762054%.
- pppYmBreath: pppRenderYmBreath improved from 88.52322% to 88.53561%.

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o -
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -

## Plausibility
- Target assembly for both renderers reads the color data from VColor offsets 0x8-0xb, matching the newly named red, green, blue, and alpha fields.
- This replaces raw pointer indexing with real member access without changing VColor size or existing alpha offset.