### PR TITLE
Improve LocationTitle2 frame matching

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -267,7 +267,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         node = modelRaw->m_nodes + nodeIndex * 0xC0;
         zOffset = 1.0f;
 
-        for (u32 frameIndex = 0; frameIndex < modelRaw->m_anim->m_frameCount; frameIndex++) {
+        for (int frameIndex = 0; (u32)frameIndex < modelRaw->m_anim->m_frameCount; frameIndex++) {
             Mtx nodeMtx;
 
             CalcBind__Q26CChara5CNodeFPQ26CChara6CModel(node, model);
@@ -283,18 +283,14 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
             particles[work->m_count].m_pad0 = 0;
             particles[work->m_count].m_shape = 0;
             particles[work->m_count].m_pad1 = 0;
-            particles[work->m_count].m_frame = (s16)frameIndex;
+            particles[work->m_count].m_frame = frameIndex;
             particles[work->m_count].m_scaleX = locationTitle->m_localMatrix.value[0][0];
             particles[work->m_count].m_scaleY = locationTitle->m_localMatrix.value[1][1];
             particles[work->m_count].m_scaleZ = locationTitle->m_localMatrix.value[2][2];
             work->m_count++;
 
-            {
-                u32 nextCount = (u32)work->m_count + 1;
-
-                if ((u32)unkB->m_maxCount <= nextCount) {
-                    return;
-                }
+            if ((int)work->m_count + 1 >= (int)unkB->m_maxCount) {
+                return;
             }
 
             if (work->m_count > 1) {
@@ -325,12 +321,8 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                     inserted++;
                     work->m_count++;
 
-                    {
-                        u32 nextCount = (u32)work->m_count + 1;
-
-                        if ((u32)unkB->m_maxCount <= nextCount) {
-                            break;
-                        }
+                    if ((int)work->m_count + 1 >= (int)unkB->m_maxCount) {
+                        break;
                     }
 
                     interpWrite++;
@@ -352,7 +344,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                     dst->m_scaleX = locationTitle->m_localMatrix.value[0][0];
                     dst->m_scaleY = locationTitle->m_localMatrix.value[1][1];
                     dst->m_scaleZ = locationTitle->m_localMatrix.value[2][2];
-                    dst->m_frame = (s16)frameIndex;
+                    dst->m_frame = frameIndex;
                     interpRead++;
                 }
             }


### PR DESCRIPTION
## Summary
- use a signed frame loop index while keeping the serialized animation frame bound unsigned
- remove redundant frame-index casts and use signed count-limit comparisons in pppFrameLocationTitle2

## Objdiff evidence
Command: `build/tools/objdiff-cli diff -p . -u main/LocationTitle2 -o - pppFrameLocationTitle2`

Before:
- pppFrameLocationTitle2: 92.5296%
- .text: 95.77656%
- .sdata2: 85.71429%

After:
- pppFrameLocationTitle2: 93.94079%
- .text: 96.56227%
- .sdata2: 100.0%

Unchanged:
- pppRenderLocationTitle2: 99.832535%
- pppDestructLocationTitle2: 100.0%
- pppConstructLocationTitle2: 100.0%

## Plausibility
The changes keep the existing control flow and data layout, but use source-level signedness that matches the compiler output more closely. The frame field is already s16, so assigning the loop index directly lets the store perform the truncation instead of forcing an extra cast.