### PR TITLE
Improve CUtil vector conversion casts

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -239,12 +239,10 @@ void CUtil::ConvF2IVector(S16Vec& out, Vec in, long shift)
     int scaleInt = 1 << shift;
     float y = in.y;
     float z = in.z;
-    double scaleY = (double)scaleInt;
-    double scaleZ = (double)scaleInt;
 
-    out.x = (short)(int)(in.x * (float)((double)scaleInt));
-    out.y = (short)(int)(y * (float)scaleY);
-    out.z = (short)(int)(z * (float)scaleZ);
+    out.x = (short)(int)(in.x * (float)scaleInt);
+    out.y = (short)(int)(y * (float)scaleInt);
+    out.z = (short)(int)(z * (float)scaleInt);
 }
 
 /*
@@ -260,10 +258,9 @@ void CUtil::ConvF2IVector2d(S16Vec2d& out, Vec2d in, long shift)
 {
     int scaleInt = 1 << shift;
     float y = in.y;
-    double scaleY = (double)scaleInt;
 
-    out.x = (short)(int)(in.x * (float)((double)scaleInt));
-    out.y = (short)(int)(y * (float)scaleY);
+    out.x = (short)(int)(in.x * (float)scaleInt);
+    out.y = (short)(int)(y * (float)scaleInt);
 }
 
 /*


### PR DESCRIPTION
## Summary
- simplify CUtil::ConvF2IVector and ConvF2IVector2d scale casts to use direct float conversions from the integer scale
- removes forced double temporaries that caused extra rounding instructions and larger output

## Objdiff evidence
- main/util .text fuzzy: 85.11071% -> 85.44923%
- CUtil::ConvF2IVector: 82.76316% -> 97.10526%
- CUtil::ConvF2IVector2d: 86.78571% -> 97.67857%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/util -o - ConvF2IVector__5CUtilFR6S16Vec3Vecl
- build/tools/objdiff-cli diff -p . -u main/util -o - ConvF2IVector2d__5CUtilFR8S16Vec2d5Vec2dl