### PR TITLE
Fix THPSimpleOpen volume defaults

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -75,6 +75,8 @@ u16 gTHPSimpleVolumeTable[0x80] = {
 };
 s16 WorkBuffer_32_[0x280] ATTRIBUTE_ALIGN(32);
 
+extern const float FLOAT_8033186C;
+
 /*
  * --INFO--
  * Address:	TODO
@@ -939,8 +941,8 @@ s32 THPSimpleOpen(const char* path)
     SimpleControl.isBufferSet = 0;
     SimpleControl.isLooping = 0;
     SimpleControl.isOpen = 1;
-    SimpleControl.unk_C4 = 0.0f;
-    SimpleControl.unk_C8 = 0.0f;
+    SimpleControl.unk_C4 = FLOAT_8033186C;
+    SimpleControl.unk_C8 = FLOAT_8033186C;
     SimpleControl.unk_D0 = 0;
 
     return 1;


### PR DESCRIPTION
## Summary
- Initialize THPSimple's current and target volume fields from the existing 127.0f small-data constant instead of 0.0f.
- Matches the Ghidra shape for THPSimpleOpen and keeps the change localized to the THP simple player state setup.

## Evidence
- `ninja`: build succeeds, `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPSimpleOpen`: THPSimpleOpen improves from 86.75921% to 86.77337%.
- Unit text match improves from 93.01771% to 93.020874%.

## Plausibility
- The affected fields are used as volume-table indices by MixAudio, and 127.0f is the max/default volume value already present in nearby small data.
