### PR TITLE
Define CUSBPcs RTTI data

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -19,6 +19,14 @@ const char s_CUSBPcs_8032f810[] = "CUSBPcs";
 u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
+extern "C" void* CUSBPcs_RTTI_base__7CUSBPcs[3] = {0, 0, 0};
+extern "C" void* CUSBPcs_RTTI__7CUSBPcs[5] = {
+    (void*)s_CUSBPcs_8032f810,
+    CUSBPcs_RTTI_base__7CUSBPcs,
+    0,
+    0,
+    0,
+};
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[0x10] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);


### PR DESCRIPTION
## Summary
- Define the CUSBPcs RTTI base and RTTI data objects in p_usb.cpp.
- Places the RTTI data between m_table__7CUSBPcs and __vt__7CUSBPcs, matching the target-owned data layout more closely.

## Evidence
- ninja succeeds for GCCP01.
- objdiff main/p_usb after change: .text 95.954544%, .data 94.467964%, .sdata 0.0%.
- CUSBPcs_RTTI_base__7CUSBPcs now reports 100.0% match.
- Baseline .data before this local data definition was 87.6933%, so this is real data-layout progress.

## Plausibility
- The symbols already exist in config/GCCP01/symbols.txt as p_usb-owned data.
- The definitions use the real CUSBPcs RTTI symbol names and the existing CUSBPcs class name object instead of address constants or fake labels.