### PR TITLE
Improve THPSimple DVD callback match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -623,39 +623,35 @@ void __THPSimpleDVDCallback(long result, DVDFileInfo*)
 
     if (result == -1) {
         SimpleControl.readError = 1;
-        return;
-    }
-    if (result == -3) {
-        return;
-    }
+    } else if (result != -3) {
+        SimpleControl.isReadFrameAsync = 0;
+        SimpleControl.readBuffer[SimpleControl.readIndex].mFrameNumber = SimpleControl.curAudioTrack;
+        SimpleControl.curAudioTrack++;
+        SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid = 1;
+        SimpleControl.readOffset += SimpleControl.readSize;
 
-    SimpleControl.isReadFrameAsync = 0;
-    SimpleControl.readBuffer[SimpleControl.readIndex].mFrameNumber = SimpleControl.curAudioTrack;
-    SimpleControl.curAudioTrack++;
-    SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid = 1;
-    SimpleControl.readOffset += SimpleControl.readSize;
+        oldReadIndex = SimpleControl.readIndex;
+        SimpleControl.readIndex = (SimpleControl.readIndex + 1) & 7;
+        SimpleControl.readSize = *reinterpret_cast<s32*>(SimpleControl.readBuffer[oldReadIndex].mPtr);
 
-    oldReadIndex = SimpleControl.readIndex;
-    SimpleControl.readIndex = (SimpleControl.readIndex + 1) & 7;
-    SimpleControl.readSize = *reinterpret_cast<s32*>(SimpleControl.readBuffer[oldReadIndex].mPtr);
-
-    if ((SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid == 0) && (SimpleControl.readError == 0) &&
-        (SimpleControl.isPreLoaded == 1)) {
-        if ((SimpleControl.header.mNumFrames - 1) < static_cast<u32>(SimpleControl.curAudioTrack)) {
-            if (SimpleControl.isLooping != 1) {
-                return;
+        if ((SimpleControl.readBuffer[SimpleControl.readIndex].mIsValid == 0) && (SimpleControl.readError == 0) &&
+            (SimpleControl.isPreLoaded == 1)) {
+            if ((SimpleControl.header.mNumFrames - 1) < static_cast<u32>(SimpleControl.curAudioTrack)) {
+                if (SimpleControl.isLooping != 1) {
+                    return;
+                }
+                SimpleControl.curAudioTrack = 0;
+                SimpleControl.readOffset = static_cast<s32>(SimpleControl.header.mMovieDataOffsets);
+                SimpleControl.readSize = static_cast<s32>(SimpleControl.header.mFirstFrameSize);
             }
-            SimpleControl.curAudioTrack = 0;
-            SimpleControl.readOffset = static_cast<s32>(SimpleControl.header.mMovieDataOffsets);
-            SimpleControl.readSize = static_cast<s32>(SimpleControl.header.mFirstFrameSize);
-        }
 
-        SimpleControl.isReadFrameAsync = 1;
-        if (!DVDReadAsyncPrio(&SimpleControl.fileInfo, SimpleControl.readBuffer[SimpleControl.readIndex].mPtr,
-                              SimpleControl.readSize, SimpleControl.readOffset,
-                              static_cast<DVDCallback>(__THPSimpleDVDCallback), 2)) {
-            SimpleControl.isReadFrameAsync = 0;
-            SimpleControl.readError = 1;
+            SimpleControl.isReadFrameAsync = 1;
+            if (DVDReadAsyncPrio(&SimpleControl.fileInfo, SimpleControl.readBuffer[SimpleControl.readIndex].mPtr,
+                                 SimpleControl.readSize, SimpleControl.readOffset,
+                                 static_cast<DVDCallback>(__THPSimpleDVDCallback), 2) != 1) {
+                SimpleControl.isReadFrameAsync = 0;
+                SimpleControl.readError = 1;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- reshape `__THPSimpleDVDCallback` to follow the original branch layout more closely
- keep the callback logic identical while using an explicit `DVDReadAsyncPrio(...) != 1` failure check
- preserve a clean full rebuild on PAL (`GCCP01`)

## Evidence
- `__THPSimpleDVDCallback__FlP11DVDFileInfo` improved from `90.73684%` to `90.8%` in objdiff
- rebuilt successfully with `ninja`

## Why this is plausible source
- the change removes source-shape differences in control flow rather than adding compiler-coaxing hacks
- the callback still reads naturally as original game code and keeps the same THP read scheduling behavior
