### PR TITLE
Improve CManager RTTI linkage for USB

### DIFF
--- a/include/ffcc/manager.h
+++ b/include/ffcc/manager.h
@@ -3,8 +3,8 @@
 
 class CManager {
 public:
-    virtual void Init() = 0;
-    virtual void Quit() = 0;
+    virtual void Init();
+    virtual void Quit();
 };
 
 #endif // _FFCC_MANAGER_H

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/system.h"
 
 extern "C" void* __vt__8CManager[];
+extern "C" void* __RTTI__8CManager[];
 
 CUSB USB;
 


### PR DESCRIPTION
## Summary
- Treat `CManager` as a concrete virtual base declaration instead of emitting pure-interface metadata in every derived TU.
- Declare the external `__RTTI__8CManager` symbol in `usb.cpp` so `usb.o` references the shared base RTTI instead of carrying local `CManager` RTTI data.

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/usb -o -`:
  - `main/usb` code remains 100% matched.
  - compiled `.data` size improves from 56 bytes before to 28 bytes after, against a 32-byte target.
  - `[.data-0]` improves from 38.78788% to 87.22222%.
  - compiled `.sdata` shrinks from 24 bytes to 16 bytes.

## Plausibility
- The target already has shared `__vt__8CManager` and `__RTTI__8CManager` symbols, so referencing them from `usb.o` is cleaner than letting this unit emit local base-class RTTI/vtable data.
