### PR TITLE
Improve RedStream StreamPlay helper call shape

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -29,6 +29,7 @@ int SearchSeEmptyTrack__Fiii(int, int, int);
  * JP Size: TODO
  */
 #pragma optimization_level 0
+#pragma dont_inline on
 RedStreamDATA* _SearchEmptyStreamData()
 {
 	RedStreamDATA* streamData = (RedStreamDATA*)DAT_8032f420;
@@ -43,6 +44,7 @@ RedStreamDATA* _SearchEmptyStreamData()
 
 	return 0;
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Mark _SearchEmptyStreamData as dont_inline so StreamPlay emits the helper call shape seen in the PAL target.
- Keeps the already-matching helper body unchanged.

## Evidence
- ninja passes.
- Ran: build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream -o - StreamPlay__FiPviii
- RedStream unit fuzzy match improved from 82.97% to 84.60%.
- StreamPlay__FiPviii fuzzy match improved from 59.09% to 64.62%.

## Plausibility
- This mirrors the target disassembly, where StreamPlay calls _SearchEmptyStreamData instead of inlining its scan loop.
- The change follows the existing local pattern: _StreamStop in this same file is already explicitly kept out of line.