### PR TITLE
Align pppKeShpTail2X draw vectors

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -151,10 +151,10 @@ void pppKeShpTail2XDraw(_pppPObject* obj, pppKeShpTail2XUnkB* param_2, pppKeShpT
     float invCountMinusOne;
     pppFMATRIX localBase;
     pppFMATRIX drawMtx;
-    Vec zeroVec;
-    Vec pos;
-    Vec nextPos;
-    Vec seg;
+    Vec zeroVec ATTRIBUTE_ALIGN(8);
+    Vec pos ATTRIBUTE_ALIGN(8);
+    Vec nextPos ATTRIBUTE_ALIGN(8);
+    Vec seg ATTRIBUTE_ALIGN(8);
     float trailLen;
     float segLen;
     float segCursor;


### PR DESCRIPTION
## Summary
- align the local Vec temporaries in pppKeShpTail2XDraw to 8 bytes
- matches the alignment style used by nearby particle vector math and nudges the generated stack layout closer to the target

## Evidence
- ninja succeeds
- pppKeShpTail2XDraw remains size-matched at 1796 bytes
- objdiff improves pppKeShpTail2XDraw from 61.572384% to 61.57461%
- generated frame moves from stwu r1, -0x260(r1) to stwu r1, -0x270(r1), closer to target stwu r1, -0x2d0(r1)