### PR TITLE
Improve RedStream StreamPlay match

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -293,122 +293,126 @@ void StreamStop(int param_1)
  */
 int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5)
 {
-	int* streamData = (int*)_SearchEmptyStreamData();
-	if (streamData != (int*)0) {
-		memcpy(streamData + 4, param_2, 0x20);
-		*streamData = SearchSeEmptyTrack__Fiii(*(short*)((int)streamData + 0x2a), 0xff, 0);
-		streamData[3] = RedNew(0x4000);
+	int amemSize;
+	int arOffset;
+	int pitch;
+	int iVar2;
+	int* streamData;
+	int* voice;
 
-		int amemSize = *(short*)((int)streamData + 0x2a) << 0xd;
-        int arOffset = DAT_8032f468.GetABufferSize() < 0x800000 ? 0 : 0x300000;
+	streamData = (int*)_SearchEmptyStreamData();
+	if (streamData == (int*)0) {
+		return param_1;
+	}
+
+	memcpy(streamData + 4, param_2, 0x20);
+	*streamData = SearchSeEmptyTrack__Fiii(*(short*)((int)streamData + 0x2a), 0xff, 0);
+	streamData[3] = RedNew(0x4000);
+	amemSize = *(short*)((int)streamData + 0x2a) << 0xd;
+	if (DAT_8032f468.GetABufferSize() < 0x800000) {
+		arOffset = 0;
+	} else {
+		arOffset = 0x300000;
+	}
+	streamData[0x4b] = RedNewA(amemSize, 0, arOffset);
+	if (streamData[0x4b] == 0) {
+		DAT_8032e154.WaveOldClear(0, arOffset);
 		streamData[0x4b] = RedNewA(amemSize, 0, arOffset);
-		if (streamData[0x4b] == 0) {
-			DAT_8032e154.WaveOldClear(0, arOffset);
-			streamData[0x4b] = RedNewA(amemSize, 0, arOffset);
+	}
+
+	if ((*streamData == 0) || (streamData[3] == 0) || (streamData[0x4b] == 0)) {
+		if (streamData[3] != 0) {
+			RedDelete__FPv((void*)streamData[3]);
 		}
-
-		if ((*streamData == 0) || (streamData[3] == 0) || (streamData[0x4b] == 0)) {
-			if (streamData[3] != 0) {
-				RedDelete__FPv((void*)streamData[3]);
-			}
-			if (streamData[0x4b] != 0) {
-				RedDeleteA(streamData[0x4b]);
-			}
-			if (gRedMemoryDebugEnabled != 0) {
-				fflush(&DAT_8021d1a8);
-			}
-			return param_1;
+		if (streamData[0x4b] != 0) {
+			RedDeleteA(streamData[0x4b]);
 		}
+		if (gRedMemoryDebugEnabled != 0) {
+			fflush(&DAT_8021d1a8);
+		}
+		return param_1;
+	}
 
-		*(short*)((int)param_2 + 0x42) = (short)*(char*)((int)param_2 + 0x1000);
-		*(unsigned short*)((int)param_2 + 0x46) = 0;
-		*(unsigned short*)((int)param_2 + 0x44) = 0;
+	*(short*)((int)param_2 + 0x42) = (short)*(char*)((int)param_2 + 0x1000);
+	*(unsigned short*)((int)param_2 + 0x46) = 0;
+	*(unsigned short*)((int)param_2 + 0x44) = 0;
+	if (*(short*)((int)streamData + 0x2a) == 2) {
+		if (streamData[8] < 0) {
+			iVar2 = 0x2000;
+		} else {
+			iVar2 = 0x1008;
+		}
+		*(short*)((int)param_2 + 0x70) = (short)*(char*)((int)param_2 + iVar2);
+		*(unsigned short*)((int)param_2 + 0x74) = 0;
+		*(unsigned short*)((int)param_2 + 0x72) = 0;
+	}
 
+	streamData[0x43] = param_1;
+	streamData[0x47] = 0;
+	streamData[0x48] = 0x1000;
+	streamData[0x49] = 0;
+	streamData[1] = (int)DAT_8032f444 + *(char*)(*streamData + 0x14e) * 0xc0;
+	streamData[2] = (int)param_2;
+	streamData[0x46] = param_3;
+	if (param_5 != 0) {
+		param_5 = ((param_5 + 1) * 0x100 - 1) * 0x1000;
+	}
+	streamData[0x3c] = param_5;
+	streamData[0x3e] = 0;
+	pitch = PitchCompute__Fiiii(0x3c00000, 0, streamData[9], 0);
+	iVar2 = 0;
+	do {
+		voice = (int*)(streamData[1] + iVar2 * 0xc0);
+		*voice = *streamData + iVar2 * 0x154;
+		*(unsigned char*)(*voice + 0x26) |= 2;
+		*(unsigned char*)((int)voice + 0x1a) |= 2;
+		voice[0x25] = 0xc01;
+		if (*(short*)(streamData + 0xb) != 0) {
+			voice[0x25] |= 0x3000;
+		}
+		*(int*)(*voice + 0xfc) = 1;
+		voice[0x2c] = 0x8000;
+		voice[1] = (int)(streamData + iVar2 * 0x18 + 0xc);
+		voice[0x27] = pitch;
+		*(int*)(*voice + 0x68) = *(int*)((int)DAT_8032f474 + 0xc);
+		*(int*)(*voice + 0x70) = 0;
 		if (*(short*)((int)streamData + 0x2a) == 2) {
-			int iVar2;
-			if (streamData[8] < 0) {
-				iVar2 = 0x2000;
+			if (iVar2 == 0) {
+				streamData[0x40] = 0;
+				streamData[0x42] = 0;
 			} else {
-				iVar2 = 0x1008;
-			}
-			*(short*)((int)param_2 + 0x70) = (short)*(char*)((int)param_2 + iVar2);
-			*(unsigned short*)((int)param_2 + 0x74) = 0;
-			*(unsigned short*)((int)param_2 + 0x72) = 0;
-		}
-
-		streamData[0x43] = param_1;
-		streamData[0x47] = 0;
-		streamData[0x48] = 0x1000;
-		streamData[0x49] = 0;
-		streamData[1] = (int)DAT_8032f444 + *(char*)(*streamData + 0x14e) * 0xc0;
-		streamData[2] = (int)param_2;
-		streamData[0x46] = param_3;
-
-		if (param_5 != 0) {
-			param_5 = ((param_5 + 1) * 0x100 - 1) * 0x1000;
-		}
-		streamData[0x3c] = param_5;
-		streamData[0x3e] = 0;
-
-		int pitch = PitchCompute__Fiiii(0x3c00000, 0, streamData[9], 0);
-		int iVar2 = 0;
-		do {
-			int* voice = (int*)(streamData[1] + iVar2 * 0xc0);
-			*voice = *streamData + iVar2 * 0x154;
-			*(unsigned char*)(*voice + 0x26) |= 2;
-			*(unsigned char*)((int)voice + 0x1a) |= 2;
-			voice[0x25] = 0xc01;
-			if (*(short*)(streamData + 0xb) != 0) {
-				voice[0x25] |= 0x3000;
-			}
-			*(int*)(*voice + 0xfc) = 1;
-			voice[0x2c] = 0x8000;
-			voice[1] = (int)(streamData + iVar2 * 0x18 + 0xc);
-			voice[0x27] = pitch;
-			*(int*)(*voice + 0x68) = *(int*)((int)DAT_8032f474 + 0xc);
-			*(int*)(*voice + 0x70) = 0;
-
-			if (*(short*)((int)streamData + 0x2a) == 2) {
-				if (iVar2 == 0) {
-					streamData[0x40] = 0;
-					streamData[0x42] = 0;
-				} else {
-					streamData[0x40] = 0x7f000;
-					streamData[0x42] = 0;
-				}
-			} else {
-				streamData[0x40] = param_4 << 0xc;
+				streamData[0x40] = 0x7f000;
 				streamData[0x42] = 0;
 			}
-
-			SetVoiceVolumeMix((RedVoiceDATA*)(streamData[1] + iVar2 * 0xc0), streamData[0x40] >> 0xc,
-				streamData[0x3c] >> 0xc);
-			*(int*)(*streamData + iVar2 * 0x154 + 0x11c) = streamData[0x4b] + iVar2 * 0x2000;
-			memset(streamData + iVar2 * 0x18 + 0xc, 0, 0x60);
-			memcpy((void*)((int)streamData + iVar2 * 0x60 + 0x52), (void*)((int)param_2 + 0x20 + iVar2 * 0x2e), 0x2e);
-			*(unsigned char*)((int)voice + 0x5a) = 0;
-			*(unsigned char*)((int)voice + 0x59) = 0;
-			*(unsigned char*)(voice + 0x16) = 0;
-			*(unsigned char*)((int)voice + 0x5b) = 0x7f;
-			*(unsigned short*)(voice + 0x15) = 0;
-			*(unsigned short*)((int)voice + 0x52) = 0;
-			*(unsigned short*)(voice + 0x14) = 0;
-			*(unsigned short*)((int)voice + 0x56) = 10;
-			streamData[iVar2 * 0x18 + 0xd] = 0;
-			streamData[iVar2 * 0x18 + 0xf] = 0x3fff;
-			streamData[iVar2 * 0x18 + 0xe] = 2;
-			iVar2 += 1;
-		} while (iVar2 < *(short*)((int)streamData + 0x2a));
-
-		if (streamData[8] < 0) {
-			streamData[0x45] = _ArrangeStreamDataNoLoop((RedStreamDATA*)streamData, 0, 0x2000);
 		} else {
-			streamData[0x45] = _ArrangeStreamDataLoop((RedStreamDATA*)streamData, 0, 0x2000);
+			streamData[0x40] = param_4 << 0xc;
+			streamData[0x42] = 0;
 		}
+		SetVoiceVolumeMix((RedVoiceDATA*)(streamData[1] + iVar2 * 0xc0), streamData[0x40] >> 0xc, streamData[0x3c] >> 0xc);
+		*(int*)(*streamData + iVar2 * 0x154 + 0x11c) = streamData[0x4b] + iVar2 * 0x2000;
+		memset(streamData + iVar2 * 0x18 + 0xc, 0, 0x60);
+		memcpy((void*)((int)streamData + iVar2 * 0x60 + 0x52), (void*)((int)param_2 + 0x20 + iVar2 * 0x2e), 0x2e);
+		*(unsigned char*)((int)voice + 0x5a) = 0;
+		*(unsigned char*)((int)voice + 0x59) = 0;
+		*(unsigned char*)(voice + 0x16) = 0;
+		*(unsigned char*)((int)voice + 0x5b) = 0x7f;
+		*(unsigned short*)(voice + 0x15) = 0;
+		*(unsigned short*)((int)voice + 0x52) = 0;
+		*(unsigned short*)(voice + 0x14) = 0;
+		*(unsigned short*)((int)voice + 0x56) = 10;
+		streamData[iVar2 * 0x18 + 0xd] = 0;
+		streamData[iVar2 * 0x18 + 0xf] = 0x3fff;
+		streamData[iVar2 * 0x18 + 0xe] = 2;
+		iVar2 += 1;
+	} while (iVar2 < *(short*)((int)streamData + 0x2a));
 
-		streamData[0x4a] = 0x1000;
-		streamData[0x44] = 3;
+	if (streamData[8] < 0) {
+		streamData[0x45] = _ArrangeStreamDataNoLoop((RedStreamDATA*)streamData, 0, 0x2000);
+	} else {
+		streamData[0x45] = _ArrangeStreamDataLoop((RedStreamDATA*)streamData, 0, 0x2000);
 	}
+	streamData[0x4a] = 0x1000;
+	streamData[0x44] = 3;
 	return param_1;
 }
 


### PR DESCRIPTION
## Summary
- rewrite `StreamPlay__FiPviii` in `src/RedSound/RedStream.cpp` into a flatter C-style shape with explicit top-level locals and an early null return
- keep the existing raw layout accesses intact while reducing scoped declarations and nested lifetime differences
- preserve behavior while making the source closer to the original compiler's expected control-flow shape

## Improved Symbols
- `main/RedSound/RedStream`
- `StreamPlay__FiPviii`

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream -o - StreamPlay__FiPviii`
- exact match percent improved from `59.05625` to `59.409374` at the same `1280` byte size

## Why This Is Plausible Source
- the function still uses the same data layout and side effects; this change only reshapes declarations and control flow
- replacing block-scoped temporaries with up-front locals and an early return is consistent with source written for the original MWCC-era compiler
- no fake symbols, hardcoded addresses, or section-forcing tricks were introduced
