### PR TITLE
Remove unused IV rand helpers

### DIFF
--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
-}

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- remove unused trailing randint helpers from pppRandDownIV and pppRandUpIV
- eliminates the extra emitted randint__Fif symbol from both objects
- brings extab and extabindex section sizes/matches in line with the target objects

## Evidence
- ninja succeeds
- main/pppRandDownIV before: extab 16b at 66.67%, extabindex 24b at 57.14%, extra randint__Fif 56b symbol present
- main/pppRandDownIV after: extab 8b at 100%, extabindex 12b at 100%, no randint__Fif symbol
- main/pppRandUpIV before: extab 16b at 66.67%, extabindex 24b at 57.14%, extra randint__Fif 56b symbol present
- main/pppRandUpIV after: extab 8b at 100%, extabindex 12b at 100%, no randint__Fif symbol

The remaining pppRandUpIV/pppRandDownIV text mismatch is unchanged at 99.60396% and appears to be only FPR allocation in the int-vector update conversions.