### PR TITLE
Fix CMapPcs instance size

### DIFF
--- a/include/ffcc/p_map.h
+++ b/include/ffcc/p_map.h
@@ -48,6 +48,7 @@ private:
     s32 m_drawEnabled;                   // 0x180
     u8 m_useStoredViewMtx;               // 0x184
     u8 m_pad185[3];                      // 0x185
+    u8 m_pad188[0x28];                   // 0x188
 };
 
 extern CMapPcs MapPcs;


### PR DESCRIPTION
## Summary
- Add the missing trailing storage to CMapPcs so the global MapPcs instance has the target size.
- Keeps existing known member offsets unchanged and only fills the unknown tail from 0x188 to 0x1B0.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/p_map -o - MapPcs reports MapPcs at 100.0% match.
- Before this change MapPcs was size-mismatched at 50.0%; after this change it is size 0x1B0 / 432 bytes and 100.0% matched.
- Overall data progress improved from 1082339 to 1082771 matched bytes.