### PR TITLE
Improve PlaySe3DLine sound slot setup

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1828,65 +1828,64 @@ int CSound::PlaySe3D(int soundId, Vec* pos, float nearDistance, float farDistanc
  */
 int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float farDistance, int fadeFrames)
 {
+    u8* se;
+    int loopCount;
+    int slot;
+    int pan;
+    int volume;
+    CRedSound* redSound;
+
     if (soundId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
         CSoundLayout& sound = SoundData(this);
-        u8* se = sound.m_seWork;
-        for (int i = 0; i < 0x80; i++, se += 0x28) {
-            if (static_cast<s8>(*se) >= 0) {
-                int volume;
-                int pan;
+        redSound = RedSound(this);
+        se = sound.m_seWork;
 
-                *se = (*se & 0x7F) | 0x80;
-                *se &= 0xBF;
-                *reinterpret_cast<int*>(se + 0xC) = soundId;
-
-                int& seCount = sound.m_seCount;
-                const int seIndex = seCount;
-                seCount = seIndex + 1;
-                *reinterpret_cast<int*>(se + 4) = seIndex;
-
-                *reinterpret_cast<float*>(se + 0x10) = nearDistance;
-                *reinterpret_cast<float*>(se + 0x14) = farDistance;
-                se[3] = static_cast<u8>(lineIndex);
-
-                calcVolumePan(reinterpret_cast<CSe3D*>(se), volume, pan);
-                se[1] = static_cast<u8>(volume);
-                se[2] = static_cast<u8>(pan);
-                se[0x24] = 0xFF;
-                se[0x25] = 0xFF;
-                se[0x26] = 0xFF;
-                se[0x27] = 0xFF;
-
-                int sePlayId;
-                if (soundId < 0) {
-                    Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-                    sePlayId = -1;
-                } else if (soundId < 4000) {
-                    int bank = soundId / 1000 + (soundId >> 31);
-                    bank -= (bank >> 31);
-
-                    const u32 fade = static_cast<u32>(fadeFrames);
-                    const int firstVolume = volume & ~((int)((-fade) | fade) >> 0x1F);
-                    sePlayId = SePlay__9CRedSoundFiiiii(reinterpret_cast<CRedSound*>(this), bank,
-                                                        soundId + bank * -1000, pan, firstVolume, 0);
-                    if (fade != 0) {
-                        SeVolume__9CRedSoundFiii(reinterpret_cast<CRedSound*>(this), sePlayId, volume, fade);
-                    }
-                } else {
-                    const u32 fade = static_cast<u32>(fadeFrames);
-                    const int firstVolume = volume & ~((int)((-fade) | fade) >> 0x1F);
-                    sePlayId = SePlay__9CRedSoundFiiiii(reinterpret_cast<CRedSound*>(this), -1, soundId, pan,
-                                                        firstVolume, 0);
-                    if (fade != 0) {
-                        SeVolume__9CRedSoundFiii(reinterpret_cast<CRedSound*>(this), sePlayId, volume, fade);
-                    }
-                }
-
-                *reinterpret_cast<int*>(se + 8) = sePlayId;
-                return *reinterpret_cast<int*>(se + 4);
+        for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
+            if (static_cast<s8>(*se) < 0) {
+                continue;
             }
+
+            *se = (*se & 0x7F) | 0x80;
+            *se &= 0xBF;
+            *reinterpret_cast<int*>(se + 0xC) = soundId;
+            slot = sound.m_seCount;
+            sound.m_seCount = slot + 1;
+            *reinterpret_cast<int*>(se + 4) = slot;
+
+            *reinterpret_cast<float*>(se + 0x10) = nearDistance;
+            *reinterpret_cast<float*>(se + 0x14) = farDistance;
+            se[3] = static_cast<u8>(lineIndex);
+
+            calcVolumePan(reinterpret_cast<CSe3D*>(se), volume, pan);
+            se[1] = static_cast<u8>(volume);
+            se[2] = static_cast<u8>(pan);
+            se[0x24] = 0xFF;
+            se[0x25] = 0xFF;
+            se[0x26] = 0xFF;
+            se[0x27] = 0xFF;
+
+            if (soundId < 0) {
+                Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
+                slot = -1;
+            } else if (soundId < 4000) {
+                int bank = soundId / 1000;
+                slot = SePlay__9CRedSoundFiiiii(redSound, bank, soundId - bank * 1000, pan,
+                                               volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
+                if (fadeFrames != 0) {
+                    SeVolume__9CRedSoundFiii(redSound, slot, volume, fadeFrames);
+                }
+            } else {
+                slot = SePlay__9CRedSoundFiiiii(redSound, -1, soundId, pan,
+                                               volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
+                if (fadeFrames != 0) {
+                    SeVolume__9CRedSoundFiii(redSound, slot, volume, fadeFrames);
+                }
+            }
+
+            *reinterpret_cast<int*>(se + 8) = slot;
+            return *reinterpret_cast<int*>(se + 4);
         }
     }
 


### PR DESCRIPTION
## Summary
- rewrite `CSound::PlaySe3DLine` into the same low-level slot setup style used by `PlaySe3D`
- keep the line variant's state writes and playback path closer to plausible original source

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/sound -o - PlaySe3DLine__6CSoundFiiffi`
- before: `61.324787%`
- after: `62.444443%`

## Why this is plausible
- the new code follows the adjacent `PlaySe3D` implementation pattern instead of relying on extra references and temporary abstractions
- slot initialization and SE playback setup remain straightforward game-side source, not compiler coaxing

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/sound -o - PlaySe3DLine__6CSoundFiiffi`
