### PR TITLE
Name FS USB process source string

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -13,8 +13,9 @@ extern "C" void* __nw__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 extern "C" void __dla__FPv(void* ptr);
 
+extern "C" const char s_FS_USB_Process_cpp_801D7E80[] = "FS_USB_Process.cpp";
+
 namespace {
-static const char s_FS_USB_Process_cpp_801d7e80[] = "FS_USB_Process.cpp";
 
 struct CUSBStreamDataHeader {
     u8* m_data;
@@ -82,10 +83,10 @@ void CFunnyShapePcs::SetUSBData()
     case 5: {
         char textureIndex;
         u16* tmp = static_cast<u16*>(__nwa__FUlPQ27CMemory6CStagePci(
-            usb->m_sizeBytes, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801d7e80), 0x55));
+            usb->m_sizeBytes, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801D7E80), 0x55));
         textureIndex = m_textureCount;
         m_textureHeaders[textureIndex] = __nw__FUlPQ27CMemory6CStagePci(
-            0x30, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801d7e80), 0x57);
+            0x30, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801D7E80), 0x57);
 
         memcpy(tmp, usb->m_data, usb->m_sizeBytes);
         for (int i = 0; i < 8; i++) {
@@ -98,12 +99,12 @@ void CFunnyShapePcs::SetUSBData()
         memcpy(m_textureHeaders[textureIndex], tmp, 0x30);
 
         m_textureData[textureIndex] = __nwa__FUlPQ27CMemory6CStagePci(
-            usb->m_sizeBytes - 0x30, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801d7e80), 0x6C);
+            usb->m_sizeBytes - 0x30, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801D7E80), 0x6C);
         memcpy(m_textureData[textureIndex], tmp + 0x18, usb->m_sizeBytes - 0x30);
         DCFlushRange(m_textureData[textureIndex], usb->m_sizeBytes - 0x30);
 
         m_texObjData[textureIndex] = __nw__FUlPQ27CMemory6CStagePci(
-            0x20, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801d7e80), 0x73);
+            0x20, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801D7E80), 0x73);
         GXInitTexObj(static_cast<GXTexObj*>(m_texObjData[textureIndex]), m_textureData[textureIndex], tmp[2], tmp[3], GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
         m_textureCount++;
@@ -130,7 +131,7 @@ void CFunnyShapePcs::SetUSBData()
         break;
     case 11: {
         u8* animData = static_cast<u8*>(__nwa__FUlPQ27CMemory6CStagePci(
-            usb->m_sizeBytes, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801d7e80), 0x9C));
+            usb->m_sizeBytes, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801D7E80), 0x9C));
         m_anm.anmData = animData;
 
         memcpy(animData, usb->m_data, usb->m_sizeBytes);
@@ -230,7 +231,7 @@ void CFunnyShapePcs::SetUSBData()
         }
 
         u8* meshData = static_cast<u8*>(__nwa__FUlPQ27CMemory6CStagePci(
-            usb->m_sizeBytes, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801d7e80), 0x106));
+            usb->m_sizeBytes, FunnyShapePcs.m_viewerStage, const_cast<char*>(s_FS_USB_Process_cpp_801D7E80), 0x106));
         memcpy(meshData, usb->m_data, usb->m_sizeBytes);
         *reinterpret_cast<u16*>(meshData + 0x0) = LoadSwap16(*reinterpret_cast<u16*>(meshData + 0x0));
         *reinterpret_cast<u16*>(meshData + 0x2) = LoadSwap16(*reinterpret_cast<u16*>(meshData + 0x2));


### PR DESCRIPTION
## Summary
- Give the FS_USB_Process source-file string the mapped external symbol name `s_FS_USB_Process_cpp_801D7E80`.
- Update allocation call sites to reference that named symbol instead of the anonymous-namespace local.

## Evidence
- `ninja` passes; build report remains clean.
- `build/tools/objdiff-cli diff -p . -u main/FS_USB_Process -o - SetUSBData__14CFunnyShapePcsFv` shows `s_FS_USB_Process_cpp_801D7E80` emitted on both sides with size 19 and 100% data match.
- Section percentages are unchanged (`.text` 60.486946%, `.rodata` 100%, `.data` 0%), so this is linkage/symbol cleanup rather than code-byte progress.

## Plausibility
- The string is already named in the PAL symbol map, and the source now uses that real mapped name directly instead of an anonymous namespace symbol.
