### PR TITLE
Match CRedDriver StreamPlay

### DIFF
--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -2103,14 +2103,8 @@ void CRedDriver::StreamStop(int param_1)
  */
 int CRedDriver::StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5)
 {
-	int streamID = param_1;
-	int data = (int)param_2;
-	int arg3 = param_3;
-	int arg4 = param_4;
-	int arg5 = param_5;
-
-	_EntryExecCommand(_StreamPlay, streamID, data, arg3, arg4, arg5, 0, 0);
-	return streamID;
+	_EntryExecCommand(_StreamPlay, param_1, (int)param_2, param_3, param_4, param_5, 0, 0);
+	return param_1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Simplify CRedDriver::StreamPlay to enqueue the stream command directly without temporary argument copies.
- Matches the shipped source shape for the command wrapper and removes the extra stack frame/register saves.

## Evidence
- ninja passes.
- objdiff StreamPlay__10CRedDriverFiPviii: 72.708336% -> 100.0%.
- Compiled function size: 104 bytes -> 96 bytes, matching target 96 bytes.
- RedDriver .text match: 87.21058% -> 87.4231%.
- Overall progress from ninja: code bytes 468524 -> 468620, matched functions 2966 -> 2967.

## Plausibility
- The resulting function is a direct wrapper around _EntryExecCommand and returns the stream ID, matching the Ghidra decomp and avoiding artificial local temporaries.