### PR TITLE
Match RedSound voice clear masks

### DIFF
--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -68,7 +68,7 @@ void _EraseAttribute(int eraseTrack, int attrMask)
 
 			trackNo = *(char*)((char*)track + 0x14e);
 			seTrackOffset = trackNo * 0xc0;
-			((unsigned char*)DAT_8032f444)[seTrackOffset + 0x1a] &= (unsigned char)0xfa;
+			((unsigned char*)DAT_8032f444)[seTrackOffset + 0x1a] &= -6;
 			*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x94) &= 0xfffffff7;
 			*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x90) &= 0xfffffffe;
 			*(unsigned int*)((unsigned char*)DAT_8032f444 + seTrackOffset + 0x90) |= 2;
@@ -140,8 +140,7 @@ int _EraseTime(int eraseTrack)
 			track[0x16] = 0;
 
 			trackNo = *(unsigned char*)((char*)track + 0x14e);
-			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &=
-			    (unsigned char)0xfa;
+			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= -6;
 			seTrack = (unsigned int*)((unsigned char*)DAT_8032f444 + trackNo * 0xc0);
 			seTrack[0x25] &= 0xfffffff7;
 			seTrack[0x24] &= 0xfffffffe;
@@ -239,7 +238,7 @@ int SeStopID(int seId)
 			track[0x16] = 0;
 
 			trackNo = *(unsigned char*)((char*)track + 0x14e);
-			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= (unsigned char)0xfa;
+			((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= -6;
 			seTrack = (unsigned int*)((unsigned char*)DAT_8032f444 + trackNo * 0xc0);
 			seTrack[0x25] &= 0xfffffff7;
 			seTrack[0x24] &= 0xfffffffe;
@@ -293,7 +292,7 @@ int SeStopMG(int bank, int sep, int group, int kind)
 				trackNo = *(char*)((char*)track + 0x14e);
 				voiceFlagsOffset = trackNo * 0xc0 + 0x94;
 				voiceStateOffset = trackNo * 0xc0 + 0x90;
-				((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= (unsigned char)0xfa;
+				((unsigned char*)DAT_8032f444)[trackNo * 0xc0 + 0x1a] &= -6;
 				*(unsigned int*)((unsigned char*)DAT_8032f444 + voiceFlagsOffset) &= 0xfffffff7;
 				*(unsigned int*)((unsigned char*)DAT_8032f444 + voiceStateOffset) &= 0xfffffffe;
 				*(unsigned int*)((unsigned char*)DAT_8032f444 + voiceStateOffset) |= 2;

--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -449,7 +449,7 @@ void __MidiCtrl_Stop(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, RedTrack
     seTrack = DAT_8032f444;
     do {
         if ((RedTrackDATA*)*seTrack == track) {
-            ((unsigned char*)seTrack)[0x1a] &= (unsigned char)0xfa;
+            ((unsigned char*)seTrack)[0x1a] &= -6;
         }
         seTrack += 0x30;
     } while (seTrack < DAT_8032f444 + 0xc00);


### PR DESCRIPTION
## Summary
- Use the signed `-6` mask form for RedSound voice state byte clears.
- Applies the same pattern in RedCommand stop/erase paths and RedMidiCtrl stop handling.

## Objdiff evidence
- `main/RedSound/RedCommand` `_EraseAttribute__Fii`: 63.31868% -> 64.62637%
- `main/RedSound/RedCommand` `_EraseTime__Fi`: 65.08209% -> 66.18657%
- `main/RedSound/RedCommand` `SeStopID__Fi`: 61.864582% -> 63.416668%
- `main/RedSound/RedCommand` `SeStopMG__Fiiii`: 58.267242% -> 59.50862%
- `main/RedSound/RedMidiCtrl` `__MidiCtrl_Stop__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`: 91.74561% -> 93.23684%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedCommand -o - <symbol>`
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o - __MidiCtrl_Stop__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA`

## Plausibility
The target code materializes the clear mask as signed `-6` before applying it to the voice status byte. This keeps the existing behavior while matching the compiler's codegen for the original source pattern.
