### PR TITLE
Improve CPad frame matching

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -72,19 +72,21 @@ void CPad::Frame()
 	memcpy(g_pad, local_88, 0x30);
 	*reinterpret_cast<u32*>(self + 0x1C4) = 0;
 	uVar17 = 0;
+	CPad::Gba* gba = local_98;
 	puVar18 = reinterpret_cast<u16*>(local_98);
 	do
 	{
 		iVar6 = SIProbe(uVar17);
-		local_98[uVar17].connected = iVar6 == 0x40000;
-		local_98[uVar17].ctrlMode = Joybus.GetCtrlMode(uVar17);
-		local_98[uVar17].noController = local_98[uVar17].connected && (local_98[uVar17].ctrlMode == 0);
-		local_98[uVar17].button = 0;
-		if (local_98[uVar17].connected)
+		gba->connected = iVar6 == 0x40000;
+		gba->ctrlMode = Joybus.GetCtrlMode(uVar17);
+		gba->noController = gba->connected && (gba->ctrlMode == 0);
+		gba->button = 0;
+		if (gba->connected)
 		{
-			local_98[uVar17].button = Joybus.GetPadData(uVar17);
+			gba->button = Joybus.GetPadData(uVar17);
 		}
 		uVar17 = uVar17 + 1;
+		gba++;
 	} while (uVar17 < 4);
 
 	if ((_1b0_4_ != 0) && ((iVar14 = _1bc_4_), iVar14 >= 0))
@@ -181,28 +183,31 @@ void CPad::Frame()
 	{
 		cVar9 = *reinterpret_cast<s8*>(puVar7 + 5);
 		uVar15 = 0x80000000 >> uVar17;
-		if (cVar9 == -1)
+		if (cVar9 != -1)
+		{
+			if (cVar9 >= -1)
+			{
+				if (cVar9 < 1)
+				{
+					_1a8_4_ = _1a8_4_ | uVar15;
+				}
+			}
+			else if (cVar9 == -3)
+			{
+				_1a8_4_ = _1a8_4_ | uVar15;
+			}
+			else if (cVar9 > -4)
+			{
+				_1a8_4_ = _1a8_4_ & ~uVar15;
+			}
+		}
+		else
 		{
 			if (static_cast<u8>(Joybus.GBAReady(uVar17)) == 0)
 			{
 				uVar16 = uVar16 | uVar15;
 			}
 			_1a8_4_ = _1a8_4_ & ~uVar15;
-		}
-		else if (cVar9 < -1)
-		{
-			if (cVar9 == -3)
-			{
-				_1a8_4_ = _1a8_4_ | uVar15;
-			}
-			else if (-4 < cVar9)
-			{
-				_1a8_4_ = _1a8_4_ & ~uVar15;
-			}
-		}
-		else if (cVar9 < 1)
-		{
-			_1a8_4_ = _1a8_4_ | uVar15;
 		}
 		uVar17 = uVar17 + 1;
 		puVar7 = puVar7 + 6;
@@ -268,19 +273,19 @@ void CPad::Frame()
 					*reinterpret_cast<u32*>(iVar6 + 0x40) = 0;
 					if ((*reinterpret_cast<s8*>(iVar6 + 0x44) == 0) || reinterpret_cast<CPad::Gba*>(puVar18)->noController)
 					{
-						if (!reinterpret_cast<CPad::Gba*>(puVar18)->noController)
-						{
-							*puVar12 = *puVar13;
-						}
-						else
+						if (reinterpret_cast<CPad::Gba*>(puVar18)->noController)
 						{
 							*puVar12 = puVar18[1];
 						}
-						if (*reinterpret_cast<u8*>(puVar13 + 3) > 99)
+						else
+						{
+							*puVar12 = *puVar13;
+						}
+						if (*reinterpret_cast<u8*>(puVar13 + 3) >= 100)
 						{
 							*puVar12 = static_cast<u16>(*puVar12 | PAD_TRIGGER_L);
 						}
-						if (*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7) > 99)
+						if (*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7) >= 100)
 						{
 							*puVar12 = static_cast<u16>(*puVar12 | PAD_TRIGGER_R);
 						}


### PR DESCRIPTION
## Summary
- Rework the initial GBA status population loop in CPad::Frame to use the local Gba entry pointer directly.
- Reshape the GBA error-state handling branch and controller button selection to better match the target control flow.
- Express analog trigger thresholds as >= 100, matching the target comparison form.

## Evidence
- Before: Frame__4CPadFv 90.22644% match; main/pad .text 91.80543%.
- After: Frame__4CPadFv 91.09423% match; main/pad .text 92.53302%.
- Final diff command: build/tools/objdiff-cli diff -p . -u main/pad -o /tmp/pad_Frame_diff_result.json --format json Frame__4CPadFv

## Verification
- ninja
- git diff --check

## Plausibility
- The changes preserve the same behavior while making the source read closer to natural original code: pointer iteration over local GBA entries, positive condition checks for no-controller handling, and direct threshold constants.