### PR TITLE
Improve MLstCtrl pad reads

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -296,11 +296,11 @@ void CMenuPcs::MLstCtrl()
 	if (blocked) {
 		press = 0;
 	} else {
-		unsigned char* padPtr = reinterpret_cast<unsigned char*>(&Pad);
 		if ((__cntlzw((unsigned int)Pad._448_4_) & 0x20) == 0) {
-			padPtr += 0x54;
+			press = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + 0x5c);
+		} else {
+			press = Pad._8_2_;
 		}
-		press = *(unsigned short*)(padPtr + 8);
 	}
 
 	blocked = false;
@@ -310,11 +310,11 @@ void CMenuPcs::MLstCtrl()
 	if (blocked) {
 		hold = 0;
 	} else {
-		unsigned char* padPtr = reinterpret_cast<unsigned char*>(&Pad);
 		if ((__cntlzw((unsigned int)Pad._448_4_) & 0x20) == 0) {
-			padPtr += 0x54;
+			hold = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + 0x68);
+		} else {
+			hold = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + 0x14);
 		}
-		hold = *(unsigned short*)(padPtr + 0x14);
 	}
 
 	if (hold == 0) {


### PR DESCRIPTION
## Summary
- Read MLstCtrl press/hold inputs from the explicit active pad slot offsets instead of mutating a shared byte pointer.
- Keeps the behavior equivalent while matching the original input access pattern a bit more closely.

## Evidence
- ninja
- objdiff MLstCtrl__8CMenuPcsFv: 65.53363% -> 65.6861%

## Plausibility
- This keeps the existing debug-pad gate and uses the concrete Pad offsets for the two controller slots, which is clearer source than carrying a temporary pointer and better reflects the two-slot input selection.