### PR TITLE
Improve pppRenderColum comparison order

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -149,7 +149,7 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             } else if (ColumFpClassify(lengthXY) == 1) {
                 lengthXY = *(float*)__float_nan;
             }
-            if (FLOAT_803310A0 < lengthXY) {
+            if (lengthXY > FLOAT_803310A0) {
                 PSVECScale(&cameraDelta, &cameraDelta, FLOAT_803310A4 / lengthXY);
             }
 


### PR DESCRIPTION
## Summary
- Reorder the pppRenderColum distance clamp comparison to match the target branch shape.

## Evidence
- Before: `pppRenderColum` objdiff match 88.58205%
- After: `pppRenderColum` objdiff match 88.62849%
- `ninja`: OK

## Plausibility
- This is a source-equivalent comparison rewrite (`lengthXY > threshold`) that produces the target compare/branch ordering without changing behavior.