### PR TITLE
Improve pppColum data constants

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -41,6 +41,20 @@ union ColumFloatBits {
 
 static const char s_pppColum_cpp_801DB638[] = "pppColum.cpp";
 
+extern const float FLOAT_80331008 = 5.0f;
+extern const float FLOAT_8033100C = 128.0f;
+extern const float FLOAT_80331010[] = {127.0f, 0.0f};
+extern const float kPppRainTexCoordBase = 0.0f;
+extern const float FLOAT_8033101c = 1.0f;
+extern const float FLOAT_80331020 = 0.00003051851f;
+extern const double DOUBLE_80331028 = 4503601774854144.0;
+extern const float FLOAT_80331030 = 0.0f;
+extern const float FLOAT_80331034 = 0.003125f;
+extern const float FLOAT_80331038 = -0.004464f;
+extern const float FLOAT_8033103c = 1.0f;
+extern const float FLOAT_80331040 = -1.0f;
+extern const float FLOAT_80331044 = 1.3333334f;
+
 extern unsigned long __float_nan[];
 extern float FLOAT_80331078;
 extern float FLOAT_8033107C;
@@ -131,7 +145,8 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             float baseY;
             float lengthXY;
             float segmentStep;
-            double drawScale;
+            float drawScale;
+            float zero;
             pppColumValue* values;
 
             PSMTXIdentity(identityMtx);
@@ -149,6 +164,7 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             } else if (ColumFpClassify(lengthXY) == 1) {
                 lengthXY = *(float*)__float_nan;
             }
+            drawScale = FLOAT_80331084;
             if (FLOAT_803310A0 < lengthXY) {
                 PSVECScale(&cameraDelta, &cameraDelta, FLOAT_803310A4 / lengthXY);
             }
@@ -157,14 +173,14 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             values = frameWork->m_values;
             segmentStep =
                 (FLOAT_803310A8 * lengthXY) / (float)((double)param_2->m_count - DOUBLE_803310B0);
-            drawScale = DOUBLE_803310B8;
+            zero = FLOAT_80331084;
 
             for (int i = 0; i < param_2->m_count; i++) {
                 float positionScale = segmentStep * values->m_positionScale;
                 float index = (float)(i + 1);
                 u8 alpha = positionWork->m_alpha;
 
-                center.z = FLOAT_80331084;
+                center.z = zero;
                 center.x = baseX + positionScale * (cameraDelta.x * index);
                 center.y = baseY + positionScale * (cameraDelta.y * index);
 
@@ -183,7 +199,7 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
                 color.rgba[3] = alpha;
 
                 pppSetDrawEnv(
-                    &color, (pppFMATRIX*)0, 0.0f, (u8)param_2->m_payload[0x15],
+                    &color, (pppFMATRIX*)0, zero, (u8)param_2->m_payload[0x15],
                     (u8)param_2->m_payload[0x14],
                     param_2->m_arg3, 0, 0, 1, 0);
 


### PR DESCRIPTION
## Summary
- define the small-data constants owned by the pppColum target object
- make pppRenderColum use the shared zero constant and a float draw-scale accumulator

## Evidence
- ninja passes
- objdiff main/pppColum pppRenderColum: .sdata2 50% -> 100%
- objdiff main/pppColum pppRenderColum: extab 95.83333% -> 100%, extabindex 94.44444% -> 97.22222%
- build report main/pppColum data is now 104 / 140 bytes (74.28571%) with .sdata2 at 100%

## Plausibility
- the constants match the target object-owned .sdata2 bytes and replace unresolved extern-only data with real definitions
- the render scale now behaves like a float accumulator initialized from the existing zero constant instead of using the integer-conversion double constant as a scale value