### PR TITLE
Match letter attach item setter

### DIFF
--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -89,19 +89,20 @@ extern double DOUBLE_80333100;
 extern double DOUBLE_80333118;
 extern double DOUBLE_80333120;
 
+static short DAT_8032eee8 = 0;
+static unsigned char DAT_8032eeea = 0;
+static unsigned char DAT_8032eeeb = 0;
+static unsigned char DAT_8032eeec = 0;
+static signed char DAT_8032eeed = 0;
+static unsigned char DAT_8032eeee = 0;
+static int DAT_8032eef0 = 0;
+static int DAT_8032eef4 = 0;
+static int DAT_8032eef8 = 0;
+static int DAT_8032eefc = 0;
+static int DAT_8032ef00 = 0;
+static char s_ReplyStr[0x80];
+
 namespace {
-unsigned char DAT_8032eeea = 0;
-short DAT_8032eee8 = 0;
-unsigned char DAT_8032eeec = 0;
-unsigned char DAT_8032eeeb = 0;
-int DAT_8032eef0 = 0;
-unsigned char DAT_8032eeee = 0;
-signed char DAT_8032eeed = 0;
-int DAT_8032eef4 = 0;
-int DAT_8032eef8 = 0;
-int DAT_8032eefc = 0;
-int DAT_8032ef00 = 0;
-char s_ReplyStr[0x80];
 static const char s_menu_letter_cpp[] = "menu_letter.cpp";
 static const char s_letterItemInfoFmt[] = "%s%d%s%s";
 
@@ -2300,11 +2301,14 @@ void CMenuPcs::LetterDrawPageMark(int pageMark)
  */
 void CMenuPcs::LetterSetAttachItem(unsigned int itemIndex, int flag)
 {
-	DAT_8032eef0 = itemIndex;
+	unsigned int caravanWork = Game.m_scriptFoodBase[0];
+
 	if (DAT_8032eeed == 0) {
 		DAT_8032eeee = static_cast<unsigned char>(itemIndex);
-		DAT_8032eef0 = *reinterpret_cast<short*>(Game.m_scriptFoodBase[0] + itemIndex * 2 + 0xB6);
+		caravanWork += itemIndex * 2;
+		DAT_8032eef0 = *reinterpret_cast<short*>(caravanWork + 0xB6);
+	} else {
+		DAT_8032eef0 = itemIndex;
 	}
 	DAT_8032eef4 = flag;
 }
-


### PR DESCRIPTION
## Summary
- Move menu letter static data to file-scope symbols in target .sbss order.
- Reshape CMenuPcs::LetterSetAttachItem so the script food base load and attach-item branch match the target control flow.

## Evidence
- ninja succeeds.
- LetterSetAttachItem__8CMenuPcsFUii: 48.125% before, 100.0% after.
- LetterCtrl__8CMenuPcsFv: 10.907814% before, 10.912204% after from corrected .sbss relocations.
- Build progress now reports one additional matched game function.

## Plausibility
- The data symbols now match the PAL .sbss layout instead of anonymous-namespace mangled symbols.
- The setter uses straightforward original-source-style branching rather than an unconditional temporary store.