### PR TITLE
Match CMapPcs load completion check

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -432,42 +432,42 @@ void CMapPcs::LoadMap(int stageNo, int mapNo, void* mapPtr, unsigned long mapSiz
  */
 unsigned long long CMapPcs::IsLoadMapCompleted()
 {
-    char* mapMng = reinterpret_cast<char*>(&MapMng);
+    CMapMng* mapMng = &MapMng;
     unsigned int value = 0;
 
     for (int count = 2; count != 0; count--) {
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
-        if (*reinterpret_cast<CFile::CHandle**>(mapMng + 0x22A2C) != 0) {
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
+        if (*reinterpret_cast<CFile::CHandle**>(reinterpret_cast<char*>(mapMng) + 0x22A2C) != 0) {
             return (unsigned long long)value;
         }
-        mapMng += 4;
+        mapMng = reinterpret_cast<CMapMng*>(reinterpret_cast<char*>(mapMng) + 4);
         value += 7;
     }
 


### PR DESCRIPTION
## Summary
- Match `IsLoadMapCompleted__7CMapPcsFv` in `main/p_map` by keeping the async handle cursor as a `CMapMng*` while walking the handle slots.
- Leaves `LoadMap__7CMapPcsFiiPvUlUc` unchanged.

## Evidence
- `ninja`: +1 matched function and +260 matched code bytes (`469104 -> 469364`).
- `build/tools/objdiff-cli diff -p . -u main/p_map -o - IsLoadMapCompleted__7CMapPcsFv`: `100.0%` match, size `260`.
- Before this change, `IsLoadMapCompleted__7CMapPcsFv` was `70.36923%`.

## Plausibility
- The function still walks the async map-load handle slots in order and returns the same completion value.
- The typed `CMapMng*` cursor matches the target codegen's advancing base pointer without adding fake symbols or section forcing.
