### PR TITLE
Improve drawParaboloidMap table locals

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -660,15 +660,15 @@ void genParaboloidMap(void* displayListBuffer, unsigned long* outDisplayListSize
 void drawParaboloidMap(_GXTexObj* texObjs, _GXTexObj* targetTexObj, void* displayList, unsigned long displayListSize,
                        _GXTexObj* blendTexObj, unsigned char mode)
 {
-    static const unsigned char s_texObjIndices[] = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4};
-    static const unsigned char s_xAxisRotIndices[] = {0, 0, 0, 1, 1, 0, 0, 0, 1, 1};
-    static const unsigned char s_yAxisRotIndices[] = {0, 1, 0, 0, 1, 0, 1, 0, 0, 1};
-    static const float s_xAxisAngles[] = {0.0f, 90.0f, 180.0f, 270.0f};
-    static const unsigned char s_xAxisIds[] = {'x', 'x', 'x', 'x'};
-    static const float s_yAxisAngles[] = {0.0f, 1.0f};
-    static const Vec s_cameraPos = {0.0f, 0.0f, 0.0f};
-    static const Vec s_cameraUp = {0.0f, 1.0f, 0.0f};
-    static const Vec s_cameraLook = {0.0f, 0.0f, -1.0f};
+    const unsigned char s_texObjIndices[] = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4};
+    const unsigned char s_xAxisRotIndices[] = {0, 0, 0, 1, 1, 0, 0, 0, 1, 1};
+    const unsigned char s_yAxisRotIndices[] = {0, 1, 0, 0, 1, 0, 1, 0, 0, 1};
+    const float s_xAxisAngles[] = {0.0f, 90.0f, 180.0f, 270.0f};
+    const unsigned char s_xAxisIds[] = {'x', 'x', 'x', 'x'};
+    const float s_yAxisAngles[] = {0.0f, 1.0f};
+    const Vec s_cameraPos = {0.0f, 0.0f, 0.0f};
+    const Vec s_cameraUp = {0.0f, 1.0f, 0.0f};
+    const Vec s_cameraLook = {0.0f, 0.0f, -1.0f};
 
     const unsigned short texWidth = GXGetTexObjWidth(targetTexObj);
     const unsigned short texHeight = GXGetTexObjHeight(targetTexObj);


### PR DESCRIPTION
## Summary
- Make the drawParaboloidMap lookup tables ordinary local const arrays instead of static tables.
- This matches the target's function-entry pattern more closely, where these small tables are copied into stack locals before the render loop.

## Evidence
- ninja passes for GCCP01.
- objdiff main/pppYmEnv drawParaboloidMap__FP9_GXTexObjP9_GXTexObjPvUlP9_GXTexObjUc improved from 73.40035% to 75.06879%.
- Compiled drawParaboloidMap size moved from 1992 bytes to 2212 bytes, closer to the 2268-byte target.
- Adjacent selected pppYmEnv targets genParaboloidMap and GetCharaNodeFrameMatrix remained unchanged in objdiff.

## Plausibility
- Function-local lookup tables are plausible source for this renderer and align with Ghidra showing stack-local table copies at entry.
- No address hardcoding or fake symbols were introduced.