### PR TITLE
Improve textureman TLUT flush matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -966,7 +966,7 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
         numEntries = 0x100;
     }
 
-    GXInitTlutObj(&m_tlutObj0, reinterpret_cast<void*>(tlutBase), GX_TL_IA8, static_cast<u16>(numEntries));
+    GXInitTlutObj(&m_tlutObj0, reinterpret_cast<void*>(tlutBase), GX_TL_IA8, numEntries);
 
     numEntries = 0x10;
     if (m_format == 9) {
@@ -976,7 +976,7 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
     if (m_format == 9) {
         offset = 0x100;
     }
-    GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(tlutBase + offset * 2), GX_TL_IA8, static_cast<u16>(numEntries));
+    GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(tlutBase + offset * 2), GX_TL_IA8, numEntries);
 
     if (loadToGX != 0) {
         GXLoadTlut(&m_tlutObj0, GX_TLUT0);
@@ -1091,13 +1091,16 @@ void CTexture::SetExternalTlutColor(void* tlutData, int tlutOffset, int index, _
  */
 void CTexture::FlushTlut()
 {
-    int numEntries = 0;
+    int numEntries;
+
     if (m_format == 9) {
         numEntries = 0x100;
     } else if (m_format == 8) {
         numEntries = 0x10;
+    } else {
+        numEntries = 0;
     }
-    DCFlushRange(m_tlutData, static_cast<unsigned int>(numEntries << 2));
+    DCFlushRange(m_tlutData, numEntries << 2);
 }
 
 /*
@@ -1111,13 +1114,16 @@ void CTexture::FlushTlut()
  */
 void CTexture::FlushExternalTlut(void* tlutData)
 {
-    int numEntries = 0;
+    int numEntries;
+
     if (m_format == 9) {
         numEntries = 0x100;
     } else if (m_format == 8) {
         numEntries = 0x10;
+    } else {
+        numEntries = 0;
     }
-    DCFlushRange(tlutData, static_cast<unsigned int>(numEntries << 2));
+    DCFlushRange(tlutData, numEntries << 2);
 }
 
 /*


### PR DESCRIPTION
## Summary
- tighten `CTexture::FlushTlut` and `CTexture::FlushExternalTlut` in `textureman.cpp`
- remove unnecessary casts and make the TLUT entry count/flush-size logic follow the original compiler shape more closely
- keep adjacent `CTexture` TLUT helpers behaviorally unchanged

## Objdiff evidence
- `main/textureman` fuzzy match: `83.46817 -> 83.82986`
- `FlushTlut__8CTextureFv`: `77.95 -> 94.0`
- `FlushExternalTlut__8CTextureFPv`: `77.95 -> 94.0`
- `SetExternalTlut__8CTextureFPvi`: unchanged at `77.01961`
- `CacheLoadTexture__8CTextureFP13CAmemCacheSet`: unchanged at `76.54128`

## Why this is plausible source
- the change is a small cleanup in existing TLUT helper code rather than compiler coaxing through fake symbols or section tricks
- it preserves the original logic and only narrows local types/casts so the generated code better matches the original build
