### PR TITLE
Fix pppYmBreath constant symbol case

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -20,7 +20,7 @@ extern "C" void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 extern "C" void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, unsigned char);
 extern float FLOAT_80330c80;
 extern float FLOAT_80330c84;
-extern float FLOAT_80330c90;
+extern float FLOAT_80330C90;
 extern double DOUBLE_80330c88;
 extern void pppNormalize__FR3Vec3Vec(float*, Vec*);
 
@@ -689,7 +689,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
             if ((groupData->active != 1) && (*groupData->particleIndices != -1) && (*groupData->particleStates == 1)) {
                 unitVelocity.x = FLOAT_80330c80;
                 unitVelocity.y = FLOAT_80330c80;
-                unitVelocity.z = FLOAT_80330c90;
+                unitVelocity.z = FLOAT_80330C90;
                 groupData->speed = *(float*)((unsigned char*)pYmBreath + 0x18);
                 pppCopyVector(groupData->direction, unitVelocity);
                 groupData->position.x = 0.0f;


### PR DESCRIPTION
## Summary
- Correct the FLOAT_80330C90 reference in pppYmBreath.cpp to match the PAL symbol casing.
- Keeps the code tied to the existing sdata2 symbol instead of an incorrect spelling.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - pppFrameYmBreath improved .text fuzzy match from 87.76299% to 87.76609%.

## Plausibility
- The target assembly and config/GCCP01/symbols.txt both use FLOAT_80330C90, so this is a symbol naming correction rather than compiler coaxing.