### PR TITLE
Improve astar realtime portal matching

### DIFF
--- a/include/ffcc/charaobj.h
+++ b/include/ffcc/charaobj.h
@@ -112,13 +112,14 @@ public:
 	unsigned char m_unk66C[0x18];
 	int m_damageParticle;
 	int m_unk688;
+	int m_unk68C;
 	float m_pushScale;
 	float m_alpha;
 	int m_stateResetCounter;
 	int m_stateResetLimit;
 	int m_stateTick;
-	short m_lastBgGroupCopy;
 	short m_aStarGroupId;
+	short m_unk6A6;
 	int m_castTimeTick;
 	unsigned char m_unk6AC[0xC];
 };

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -698,11 +698,6 @@ void CAStar::addRealTime(CGPartyObj* gPartyObj)
 		}
 	}
 
-	if (portalIndex >= 64)
-	{
-		return;
-	}
-
 	CAPos& portal = m_portals[portalIndex];
 
 	portal.m_position.x = m_lastGroupPos.x;

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -711,7 +711,6 @@ void CGCharaObj::onFramePreCalc()
 		m_aStarGroupId = static_cast<unsigned short>(
 			calcSpecialPolygonGroup__6CAStarFP3Vec(reinterpret_cast<unsigned char*>(&DbgMenuPcs) + 0x2A5C, &m_worldPosition));
 	}
-	m_lastBgGroupCopy = m_lastBgGroup;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Correct the tail layout of CGCharaObj around the A* group/cast-time fields.
- Remove an unmatched cached background-group store from CGCharaObj::onFramePreCalc.
- Remove the extra full-table guard in CAStar::addRealTime so the control flow better matches the original.

## Evidence
- ninja: passes.
- main/astar .text: 78.813286% -> 79.07102%.
- addRealTime__6CAStarFP10CGPartyObj: 70.523636% -> 72.16%.
- main/charaobj .text: 34.822147% -> 34.861683%.
- onFramePreCalc__10CGCharaObjFv: 64.95149% -> 66.05224%.
- onCreate__10CGCharaObjFv: 81.710144% -> 81.78261%.
- claim_doctor src/astar.cpp: no diagnoses found.

## Plausibility
The Ghidra output and target instructions place CGCharaObj::m_aStarGroupId at 0x6a4 and m_castTimeTick at 0x6a8. The header was missing a word before m_pushScale and still modeled a cached last-bg-group halfword that the target onFramePreCalc does not store. The addRealTime guard also was not present in the target control flow.