### PR TITLE
Fix pppYmMelt vertex data redeclaration

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -110,7 +110,6 @@ void pppRenderYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offs
     float phaseLerp;
     u32 drawColor;
     u8* drawColorBytes;
-    YmMeltVertex* vertexData;
     float worldX;
     float worldY;
     float worldZ;


### PR DESCRIPTION
## Summary
- Remove the duplicate local `YmMeltVertex* vertexData` declaration in `pppRenderYmMelt`.
- This restores compilation of `src/pppYmMelt.cpp` after the latest `main` update.

## Evidence
- Before: `ninja` stopped in `src/pppYmMelt.cpp` with `object 'vertexData' redefined`.
- After: `ninja` completes and regenerates `build/GCCP01/report.json`.
- Objdiff check: `main/pppYmMelt` `pppRenderYmMelt__FP7PYmMeltP11YmMeltCtrlP18PYmMeltDataOffsets` remains at 95.74825%.

## Plausibility
- The remaining declaration is the one assigned from `work->m_vertexData` and used throughout the render loop; removing the duplicate is a source-level cleanup rather than compiler coaxing.