### PR TITLE
Fix CGObject onHit return type

### DIFF
--- a/include/ffcc/charaobj.h
+++ b/include/ffcc/charaobj.h
@@ -50,7 +50,7 @@ public:
 	void resetIgnoreHit();
 	void decIgnoreHit();
 	void damageDelete();
-	void onHit(int, CGObject*, int, Vec*);
+	int onHit(int, CGObject*, int, Vec*);
 	void onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*);
 	int getReplaceStat(int);
 	void putHitParticleFromItem(CGPrgObj*, int);
@@ -104,8 +104,8 @@ public:
 	int m_castFrameStart;
 	int m_castFrameEnd;
 	int m_castFrameCurrent;
+	int m_unk63C;
 	IgnoreHitSlot m_ignoreHit[4];
-	unsigned char m_unk65C[4];
 	int m_comboFrame;
 	int m_comboFramePrev;
 	int m_comboState;

--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -78,7 +78,7 @@ public:
     float CalcSafePos(int, CGObject*, Vec*);
     void PutDropItem();
     virtual bool IsDispRader();
-    virtual void onHit(int, CGObject*, int, Vec*);
+    virtual int onHit(int, CGObject*, int, Vec*);
     virtual void onAnimPoint(int, int);
     virtual float onAlphaUpdate();
     virtual void onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*);

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -1058,13 +1058,13 @@ void CGCharaObj::damageDelete()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGCharaObj::onHit(int hitArg, CGObject* sourceObj, int hitType, Vec* hitPos)
+int CGCharaObj::onHit(int hitArg, CGObject* sourceObj, int hitType, Vec* hitPos)
 {
 	typedef unsigned int (*VCall0C)(void*);
-	typedef void (*VCall80)(void*, void*, int, int, int, Vec*);
+	typedef int (*VCall80)(void*, void*, int, int, int, Vec*);
 
 	if (sourceObj == 0) {
-		return;
+		return 0;
 	}
 
 	VCall0C cidFn = *reinterpret_cast<VCall0C*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(sourceObj) + 0x48) + 0x0C);
@@ -1072,7 +1072,7 @@ void CGCharaObj::onHit(int hitArg, CGObject* sourceObj, int hitType, Vec* hitPos
 	if ((sourceCid & 0x6D) == 0x6D && Game.m_gameWork.m_menuStageMode != 0 && Game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
 		sourceCid = cidFn(sourceObj);
 		if ((sourceCid & 0x6D) == 0x6D && sourceObj->m_scriptHandle != 0 && sourceObj->m_scriptHandle[0xED] != 0) {
-			return;
+			return 0;
 		}
 	}
 
@@ -1092,12 +1092,12 @@ void CGCharaObj::onHit(int hitArg, CGObject* sourceObj, int hitType, Vec* hitPos
 			break;
 		}
 		if (slotData.m_source == sourceObj) {
-			return;
+			return 2;
 		}
 	}
 
 	if (slot < 0) {
-		return;
+		return 2;
 	}
 
 	if ((sourceObj->m_objectFlags & 0x100) != 0) {
@@ -1109,6 +1109,8 @@ void CGCharaObj::onHit(int hitArg, CGObject* sourceObj, int hitType, Vec* hitPos
 		VCall80 onHitVCall = *reinterpret_cast<VCall80*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(sourceObj) + 0x48) + 0x80);
 		onHitVCall(sourceObj, this, m_itemId, hitArg, hitType, hitPos);
 	}
+
+	return 1;
 }
 
 /*

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3491,12 +3491,16 @@ bool CGObject::IsDispRader()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8007BE54
+ * PAL Size: 8b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void CGObject::onHit(int, CGObject*, int, Vec*)
+int CGObject::onHit(int, CGObject*, int, Vec*)
 {
-	return;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Change CGObject::onHit and CGCharaObj::onHit to return status codes instead of void.
- Return the status values shown by the decompilation: 0 for ignored hits, 2 for duplicate/full ignore slots, and 1 after successful handling.
- Move the CGCharaObj ignore-hit padding so m_ignoreHit starts at 0x640 while m_comboFrame remains at 0x660.

## Evidence
- ninja passes.
- Progress report improves matched code from 471116 to 471124 bytes and matched functions from 2974 to 2975.
- objdiff: onHit__8CGObjectFiP8CGObjectiP3Vec is now 100% matched, size 8.
- objdiff: onHit__10CGCharaObjFiP8CGObjectiP3Vec moves to the correct return-status ABI and keeps size closer to target (464b current vs 480b target).