### PR TITLE
Improve GbaQueue GetScrFlg match

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -2038,7 +2038,7 @@ unsigned int GbaQueue::GetScrFlg()
 	unsigned int flag;
 
 	i = 0;
-	semaphoreIter = reinterpret_cast<OSSemaphore*>(this);
+	semaphoreIter = accessSemaphores;
 	do {
 		OSWaitSemaphore(semaphoreIter);
 		i++;
@@ -2046,16 +2046,17 @@ unsigned int GbaQueue::GetScrFlg()
 	} while (i < 4);
 
 	flag = *reinterpret_cast<unsigned int*>(reinterpret_cast<char*>(this) + 0x2AF8);
+	flag = (-flag | flag) >> 31;
 
 	i = 0;
-	semaphoreIter = reinterpret_cast<OSSemaphore*>(this);
+	semaphoreIter = accessSemaphores;
 	do {
 		OSSignalSemaphore(semaphoreIter);
 		i++;
 		semaphoreIter++;
 	} while (i < 4);
 
-	return (-flag | flag) >> 31;
+	return flag;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Update GetScrFlg to reduce the script-init flag before releasing semaphores, matching the original control/data lifetime more closely.
- Use the real accessSemaphores member instead of casting this for semaphore iteration.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/gbaque -o - GetScrFlg__8GbaQueueFv
- GetScrFlg__8GbaQueueFv: 38.85294% -> 89.411766%.
- main/gbaque .text: 71.27867% -> 71.471214%.
- main/gbaque .bss remains 100.0%.

## Plausibility
- The change keeps the existing semaphore pattern and only moves the boolean normalization to where the original codegen expects it, without adding fake labels, hardcoded symbols, or layout changes.