### PR TITLE
Clean up file.cpp game include ownership

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -189,4 +189,6 @@ public:
 STATIC_ASSERT(sizeof(CGame::CGameWork) == 0x13E8);
 STATIC_ASSERT(sizeof(CGame) == 0x11F88);
 
+extern CGame Game;
+
 #endif // _FFCC_GAME_H_

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -2,10 +2,9 @@
 
 #include "ffcc/color.h"
 #include "ffcc/fontman.h"
-#include "ffcc/goout.h"
+#include "ffcc/game.h"
 #include "ffcc/graphic.h"
 #include "ffcc/memory.h"
-#include "ffcc/p_game.h"
 #include "ffcc/p_menu.h"
 #include "ffcc/sound.h"
 #include "ffcc/system.h"


### PR DESCRIPTION
## Summary
- Declare the global Game instance from ffcc/game.h, the owning game header.
- Stop src/file.cpp from including ffcc/p_game.h and unused ffcc/goout.h just to access Game.
- This prevents file.o from emitting unrelated CGamePcs constructor local static descriptors.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- Objdiff target percentages for main/file DrawError are unchanged, but rebuilt .data size moves from 0x1e0 to 0x174 against the original 0x180.
- objdump -t build/GCCP01/src/file.o no longer lists the desc0 through desc8 CGamePcs localstatic symbols in file.o.

## Plausibility
file.cpp only needs CGame/Game state, not the process-piece CGamePcs header or go-out menu declarations. Keeping the extern on the owning game header is cleaner source ownership and removes unrelated data from the file unit.