### PR TITLE
Improve p_sample data layout

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -474,7 +474,7 @@ config.libs = [
             Object(NonMatching, "p_mc.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_menu.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_minigame.cpp", extra_cflags=["-RTTI on"]),
-            Object(NonMatching, "p_sample.cpp", extra_cflags=["-RTTI on"]),
+            Object(NonMatching, "p_sample.cpp"),
             Object(NonMatching, "p_sound.cpp"),
             Object(NonMatching, "p_system.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_tina.cpp", extra_cflags=["-RTTI on"]),


### PR DESCRIPTION
## Summary
- Remove the per-file RTTI override from p_sample.cpp so it uses the game default flags.
- This drops the extra generated RTTI small-data from p_sample.o and aligns the vtable block with the target object.

## Evidence
- ninja passes.
- p_sample .data: 91.25202% -> 92.22882%.
- [.data-0]: 75.08448% -> 87.30159%.
- __vt__8CManager: 80.0% -> 100.0%.
- Overall report data matched bytes: 1082671 -> 1082695 (+24).

## Plausibility
- Other process units still opt into RTTI when needed, but p_sample's target object does not contain the extra local RTTI data emitted by that override.
- The change is a build-flag correction, not source-level compiler coaxing.