### PR TITLE
Match pppMiasma bounds constants

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -598,3 +598,6 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, pppMias
     Graphic.SetViewport();
     gUtil.InitConstantRegister();
 }
+
+extern const float kQuadObjMaxBounds = 10000000.0f;
+extern const float kQuadObjMinBounds = -10000000.0f;


### PR DESCRIPTION
## Summary
- Define the missing pppMiasma quad bounds constants in src/pppMiasma.cpp
- This restores the unit-owned .sdata2 tail symbols without changing pppRenderMiasma codegen

## Evidence
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppMiasma -o -
- pppRenderMiasma: 86.86082% -> 86.86082%
- [.sdata2-0]: 88.88889% -> 100.0%
- kQuadObjMaxBounds: unmatched -> 100.0%
- kQuadObjMinBounds: unmatched -> 100.0%