### PR TITLE
Remove unused random helper emissions

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -85,17 +85,3 @@ void pppRandCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -84,17 +84,3 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
         target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
-}

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -73,17 +73,3 @@ void pppRandHCV(void* p1, void* p2, void* p3)
 }
 
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static short randshort(short value, float scale)
-{
-    return (short)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -77,17 +77,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- Remove unused local rand helper functions from pppRand IV/CV/HCV units.
- Eliminates extra emitted helper symbols and their EH records from these objects.

## Objdiff evidence
- main/pppRandUpIV: extab/extabindex now 100% (main function remains 99.60396%).
- main/pppRandDownIV: extab/extabindex now 100% (main function remains 99.60396%).
- main/pppRandUpCV: extab/extabindex now 100% (main function remains 99.57627%).
- main/pppRandDownCV: extab/extabindex now 100% (main function remains 99.57627%).
- main/pppRandHCV: extab/extabindex now 100% (main function remains 99.46565%).
- main/pppRandCV: extab now 100%; extabindex improved to 95.0% (main function remains 98.703705%).

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRandUpIV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandDownIV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandUpCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandDownCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandHCV -o -