### PR TITLE
Match game empty separator data

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -201,7 +201,7 @@ static const char* s_localLangDirs[] = {
 static const char s_numNameFmt[] = "%d %s";
 static const char s_nameJoinFmt[] = "%s%s%s";
 static const char s_nameSep[] = " ";
-static const char s_nameNoSep[] = "";
+static const char s_nameNoSep[4] = "";
 
 struct CFlatDataTableEntryView
 {


### PR DESCRIPTION
## Summary
- Explicitly size the empty game name separator to 4 bytes so it matches the target data symbol layout.

## Evidence
- ninja succeeds.
- git diff --check is clean.
- objdiff for main/game now reports s_nameNoSep as size=4 match=100.0.
- Before this change, s_nameNoSep was emitted as a one-byte empty string and matched 40.0%.

## Plausibility
- The value remains an empty C string for all call sites.
- The explicit bound only restores the target object padded data layout; it does not add control-flow or address hacks.