### PR TITLE
Improve MLstCtrl pad mask types

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -280,8 +280,8 @@ void CMenuPcs::MLstCtrl()
 {
 	bool blocked;
 	float one;
-	short press;
-	short hold;
+	unsigned short press;
+	unsigned short hold;
 	unsigned int itemCount;
 	unsigned int chunkCount;
 	int i;


### PR DESCRIPTION
## Summary
- Change MLstCtrl pad press/hold locals to unsigned halfword masks.
- This matches the pad data being read with lhz and improves the generated bit-test shape.

## Evidence
- ninja
- objdiff main/menu_lst: MLstCtrl improves from 71.24215% to 71.73543%.
- Current MLstCtrl object size moves from 828 bytes to 816 bytes.

## Plausibility
- Pad button values are bitmasks loaded as 16-bit unsigned values, so unsigned short is a more coherent source type than signed short.