### PR TITLE
Fix CMcPcs name string ownership

### DIFF
--- a/src/p_mc.cpp
+++ b/src/p_mc.cpp
@@ -5,7 +5,7 @@
 extern const float FLOAT_80331b18 = 1.0f;
 extern const float FLOAT_80331b1c = 10.0f;
 
-const char s_CMcPcs_80331B10[] = "CMcPcs";
+extern const char s_CMcPcs_80331B10[];
 
 unsigned int m_table__6CMcPcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CMcPcs_80331B10)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1B


### PR DESCRIPTION
## Summary
- Treat s_CMcPcs_80331B10 as an external string owned outside p_mc.
- Keep p_mc focused on the table, singleton, and matched code it actually owns.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/p_mc -o - keeps calc__6CMcPcsFv at 100.0%.
- Compiled p_mc no longer emits s_CMcPcs_80331B10; its .sdata2 output is now 8 bytes instead of the previous 15 bytes.
- Reference assembly shows p_mc only references s_CMcPcs_80331B10, while the string itself is emitted from partyobj.s.