### PR TITLE
Improve RedStream StreamPause matching

### DIFF
--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -477,6 +477,8 @@ void StreamPause(int param_1, int param_2)
 	unsigned int streamData;
 	int voiceData;
 	int pitch;
+	int volume;
+	int pan;
 
 	if (redSoundDebugEnabled != 0) {
 		if (param_2 == 1) {
@@ -501,12 +503,14 @@ void StreamPause(int param_1, int param_2)
 				}
 			} else if (*(void**)(voiceData + 0x14) != 0) {
 				pitch = PitchCompute__Fiiii(0x3c00000, 0, *(int*)(streamData + 0x24), 0);
+				volume = *(int*)(streamData + 0xf0) >> 0xc;
 				if (*(short*)(streamData + 0x2a) == 2) {
 					*(int*)(voiceData + 0x9c) = pitch;
 					*(unsigned int*)(voiceData + 0x90) |= 0x10;
 					*(int*)(voiceData + 0x15c) = pitch;
 					*(unsigned int*)(voiceData + 0x150) |= 0x10;
 				} else {
+					pan = *(int*)(streamData + 0x100) >> 0xc;
 					*(int*)(voiceData + 0x9c) = pitch;
 					*(unsigned int*)(voiceData + 0x90) |= 0x10;
 				}


### PR DESCRIPTION
## Summary
- Add the retained volume and pan local calculations in `StreamPause`
- Brings the compiled `StreamPause__Fii` body back to the target size

## Objdiff evidence
- `StreamPause__Fii`: 93.46939% -> 99.65306%
- `StreamPause__Fii` compiled size: 368b -> 392b target size
- `main/RedSound/RedStream` `.text`: 86.03407% -> 86.59208%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/RedSound/RedStream -o - StreamPause__Fii`