### PR TITLE
Improve menu list fade calculations

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -199,8 +199,8 @@ int CMenuPcs::MLstClose()
 			if (entry->startFrame <= currentFrame) {
 				if (currentFrame < entry->startFrame + entry->duration) {
 					entry->timer = entry->timer + 1;
-					entry->alpha =
-						(float)(DOUBLE_80333410 - (DOUBLE_80333410 / (double)entry->duration) * (double)entry->timer);
+					double ratio = DOUBLE_80333410 / (double)entry->duration;
+					entry->alpha = (float)(DOUBLE_80333410 - ratio * (double)entry->timer);
 					if ((double)entry->alpha < DOUBLE_80333418) {
 						entry->alpha = FLOAT_803333D0;
 					}
@@ -481,7 +481,8 @@ int CMenuPcs::MLstOpen()
 			if (entry->startFrame <= currentFrame) {
 				if (currentFrame < entry->startFrame + entry->duration) {
 					entry->timer = entry->timer + 1;
-					entry->alpha = (float)((DOUBLE_80333410 / (double)entry->duration) * (double)entry->timer);
+					double ratio = DOUBLE_80333410 / (double)entry->duration;
+					entry->alpha = (float)(ratio * (double)entry->timer);
 				} else {
 					completedItems++;
 					entry->alpha = FLOAT_803333F0;


### PR DESCRIPTION
## Summary
- Split the menu-list open/close fade calculations into an explicit ratio temporary.
- This keeps behavior equivalent while improving the compiler floating-point operation ordering for MLstOpen and MLstClose.

## Objdiff evidence
- main/menu_lst unit fuzzy match: 68.133484% -> 68.20023%.
- MLstClose__8CMenuPcsFv: 63.093456% -> 63.233646% in report; one-shot objdiff 63.04673% -> 63.186916%.
- MLstOpen__8CMenuPcsFv: 67.755554% -> 67.994446% in report; one-shot objdiff 67.7% -> 67.93889%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst_close_after.json MLstClose__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst_open_after.json MLstOpen__8CMenuPcsFv