### PR TITLE
Reorder YmMegaBirthShpTail2 functions

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail2.h
+++ b/include/ffcc/pppYmMegaBirthShpTail2.h
@@ -36,12 +36,8 @@ struct pppYmMegaBirthShpTail2UnkC {
     s32* m_serializedDataOffsets;
 };
 
-void get_rand(void);
-void U8ToF32(pppFVECTOR4*, unsigned char*);
-void alloc_check(VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*);
 void birth(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
 void calc(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_COLOR*);
-void calc_particle(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -20,500 +20,11 @@ extern "C" void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
     unsigned char);
 extern "C" void pppSetBlendMode(unsigned char);
 extern "C" void pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(void*, void*, unsigned char);
+extern "C" void calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
+    _pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_COLOR*);
 pppFMATRIX g_matUnit2;
 
 static const char s_pppYmMegaBirthShpTail2_cpp_801d9c68[] = "pppYmMegaBirthShpTail2.cpp";
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void get_rand()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void U8ToF32(pppFVECTOR4*, unsigned char*)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void alloc_check(VYmMegaBirthShpTail2* vdata, PYmMegaBirthShpTail2* param)
-{
-	vdata->m_maxParticles = *(unsigned short*)((char*)&param->m_matrix + 0xe);
-	// TODO: Proper memory allocation
-	vdata->m_particles = (_PARTICLE_DATA*)0;
-	vdata->m_wmats = (_PARTICLE_WMAT*)0;
-	vdata->m_colors = (_PARTICLE_COLOR*)0;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8008ca1c
- * PAL Size: 124b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppConstructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* param1, pppYmMegaBirthShpTail2UnkC* param2)
-{
-    pppFMATRIX* work = (pppFMATRIX*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2]);
-    float initVal;
-
-    pppUnitMatrix(*work);
-    initVal = kPppYmMegaBirthShpTail2Zero;
-
-    work[1].value[0][2] = initVal;
-    work[1].value[0][1] = initVal;
-    work[1].value[0][0] = initVal;
-    *reinterpret_cast<u32*>(&work[1].value[0][3]) = 0;
-    *reinterpret_cast<u32*>(&work[1].value[1][0]) = 0;
-    *reinterpret_cast<u32*>(&work[1].value[1][1]) = 0;
-    *reinterpret_cast<u32*>(&work[1].value[1][2]) = 0;
-    *(u16*)(work[1].value[1] + 3) = 0;
-    *(u16*)((u8*)work[1].value[1] + 0xe) = 0;
-    *(u16*)(work[1].value[1] + 3) = 10000;
-    pppUnitMatrix(g_matUnit2);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8008c9a0
- * PAL Size: 124b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppDestructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* param1, pppYmMegaBirthShpTail2UnkC* param2)
-{
-    u8* work = (u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2];
-    void** ptrBc = (void**)(work + 0x3c);
-    void** ptrC0 = (void**)(work + 0x40);
-    void** ptrC4 = (void**)(work + 0x44);
-
-    if (*ptrBc != 0) {
-        pppHeapUseRate__FPQ27CMemory6CStage(*ptrBc);
-        *ptrBc = 0;
-    }
-    if (*ptrC0 != 0) {
-        pppHeapUseRate__FPQ27CMemory6CStage(*ptrC0);
-        *ptrC0 = 0;
-    }
-    if (*ptrC4 != 0) {
-        pppHeapUseRate__FPQ27CMemory6CStage(*ptrC4);
-        *ptrC4 = 0;
-    }
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8008bb28
- * PAL Size: 3704b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail2* work, PYmMegaBirthShpTail2* param, VColor* vColor,
-           _PARTICLE_DATA* particleData, _PARTICLE_WMAT* particleWMat, _PARTICLE_COLOR* particleColor)
-{
-    u8* paramBytes = (u8*)param;
-    u8* particleBytes = (u8*)particleData;
-    u8 mode = paramBytes[0x12];
-    float speedRandRange = *(float*)(paramBytes + 0x5c);
-    float speedRandHalf = FLOAT_80330568 * speedRandRange;
-
-    memset(particleData, 0, 0x1b8);
-    if (particleWMat != 0) {
-        memset(particleWMat, 0, 0x30);
-    }
-    if (particleColor != 0) {
-        memset(particleColor, 0, 0x20);
-    }
-
-    if (mode < 8) {
-        Vec baseDir = *(Vec*)(paramBytes + 0x20);
-        pppIVECTOR4 angles;
-        pppFMATRIX rot;
-        Vec tempVec;
-        float spread = (float)paramBytes[0x19];
-        float spreadRange = spread * 2.0f;
-
-        angles.x = (s16)(spreadRange * Math.RandF() - spread);
-        angles.y = (s16)(spreadRange * Math.RandF() - spread);
-        angles.z = (s16)(spreadRange * Math.RandF() - spread);
-        angles.w = 0;
-        if ((mode == 2) || (mode == 3)) {
-            angles.x = 0;
-            angles.y = 0;
-            angles.z = 0;
-            angles.w = 0;
-        }
-
-        pppGetRotMatrixXYZ(rot, &angles);
-        PSMTXMultVecSR(rot.value, &baseDir, &particleData->m_velocity);
-        particleData->m_velocity.x *= *(float*)(paramBytes + 0x58);
-        particleData->m_velocity.y *= param->m_velocity.x;
-        particleData->m_velocity.z *= param->m_velocity.y;
-        tempVec = particleData->m_velocity;
-        pppNormalize(particleData->m_velocity, tempVec);
-    }
-
-    if ((mode < 6) && (speedRandRange != 0.0f)) {
-        u8 randType = paramBytes[0x6a];
-
-        if (randType <= 1) {
-            if (randType == 1) {
-                Math.RandF();
-            }
-            particleData->m_matrix[0][0] = speedRandRange * Math.RandF() - speedRandHalf;
-            particleData->m_matrix[0][1] = speedRandRange * Math.RandF() - speedRandHalf;
-            particleData->m_matrix[0][2] = speedRandRange * Math.RandF() - speedRandHalf;
-        } else if (randType == 3) {
-            particleData->m_matrix[0][0] = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange) - speedRandHalf;
-            particleData->m_matrix[0][1] = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange) - speedRandHalf;
-            particleData->m_matrix[0][2] = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange) - speedRandHalf;
-        } else if (randType == 5) {
-            particleData->m_matrix[0][0] =
-                -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange) - speedRandHalf;
-            particleData->m_matrix[0][1] =
-                -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange) - speedRandHalf;
-            particleData->m_matrix[0][2] =
-                -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange) - speedRandHalf;
-        } else {
-            particleData->m_matrix[0][0] = Math.RandF() * (speedRandRange * Math.RandF()) - speedRandHalf;
-            particleData->m_matrix[0][1] = Math.RandF() * (speedRandRange * Math.RandF()) - speedRandHalf;
-            particleData->m_matrix[0][2] = Math.RandF() * (speedRandRange * Math.RandF()) - speedRandHalf;
-        }
-
-        particleData->m_matrix[0][0] *= *(float*)(paramBytes + 0x58);
-        particleData->m_matrix[0][1] *= param->m_velocity.x;
-        particleData->m_matrix[0][2] *= param->m_velocity.y;
-    } else if ((mode >= 10) && (speedRandRange != 0.0f)) {
-        u8 randType = paramBytes[0x6a];
-        float scale = speedRandRange;
-
-        if (randType == 3) {
-            scale = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange);
-        } else if (randType == 1) {
-            Math.RandF();
-            scale = speedRandRange * Math.RandF();
-        } else if (randType == 2) {
-            scale = Math.RandF() * (speedRandRange * Math.RandF());
-        } else if (randType == 4) {
-            scale = Math.RandF() * (Math.RandF() * (speedRandRange * Math.RandF()));
-        } else if (randType == 5) {
-            scale = -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange);
-        }
-
-        Vec velocity = particleData->m_velocity;
-        pppScaleVectorXYZ(particleData->m_velocity, velocity, scale);
-    }
-
-    if (paramBytes[0x16] != 0) {
-        particleData->m_directionTail.x = (float)vColor->m_alpha;
-        *(((u8*)&particleData->m_directionTail.y) + 1) = paramBytes[0x16];
-    }
-    if (paramBytes[0x17] != 0) {
-        *(((u8*)&particleData->m_directionTail.y) + 2) = paramBytes[0x17];
-    }
-
-    particleData->m_matrix[2][2] = param->m_colorDeltaAdd[1];
-    particleData->m_matrix[2][3] = param->m_sizeStart;
-    if (param->m_colorDeltaAdd[3] != 0.0f) {
-        particleData->m_matrix[2][2] += (2.0f * param->m_colorDeltaAdd[3]) * Math.RandF() - param->m_colorDeltaAdd[3];
-    }
-
-    if (*(s16*)(paramBytes + 0x11) == 0) {
-        *(u16*)(particleBytes + 0x22) = 0xFFFF;
-    } else {
-        *(s16*)(particleBytes + 0x22) = *(s16*)(paramBytes + 0x11);
-    }
-    *((u8*)&particleData->m_directionTail.y) = 0;
-
-    if (particleWMat != 0) {
-        memcpy(particleWMat, &work->m_emitterMatrix, 0x30);
-    }
-
-    particleData->m_colorDeltaAdd[0] = 0.0f;
-    particleData->m_colorDeltaAdd[1] = 0.0f;
-    particleData->m_colorDeltaAdd[2] = 0.0f;
-    particleData->m_colorDeltaAdd[3] = 0.0f;
-    *(((u8*)&particleData->m_directionTail.z) + 2) = 0;
-    *((u8*)&particleData->m_directionTail.z) = 0;
-    *(((u8*)&particleData->m_directionTail.y) + 3) = 0x1f;
-    *((u8*)&particleData->m_directionTail.z) = *(((u8*)&particleData->m_directionTail.y) + 3) - 1;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8008b824
- * PAL Size: 772b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-extern "C" void calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
-    _pppPObject* pppPObject, VYmMegaBirthShpTail2* vYmMegaBirthShpTail2,
-    PYmMegaBirthShpTail2* pYmMegaBirthShpTail2, VColor* vColor, _PARTICLE_COLOR* particleColor)
-{
-    u8* color = (u8*)vColor;
-    u32 alpha = ((u8*)particleColor)[0xb];
-    float* blend = (float*)(color + 0x30);
-    float* velocityScale = (float*)(color + 0x28);
-    float* tailScale = (float*)(color + 0x2c);
-    u8* frameState = color + 0x30;
-    u8 frameWindow;
-    u8 fadeInFrames;
-    u8 historyIndex;
-    u16 frameIndex;
-    int colorTable;
-    int frameEntry;
-    s16 frameDuration;
-    Vec local;
-    Vec scaled;
-
-    *velocityScale = *velocityScale + pYmMegaBirthShpTail2->m_colorDeltaAdd[2];
-    *tailScale = *tailScale + pYmMegaBirthShpTail2->m_sizeVal;
-
-    local.x = *(float*)(color + 0x10);
-    local.y = *(float*)(color + 0x14);
-    local.z = *(float*)(color + 0x18);
-    pppScaleVectorXYZ(scaled, local, *velocityScale);
-    pppAddVector(*(Vec*)(color + 0x0), *(Vec*)(color + 0x0), scaled);
-
-    local = vYmMegaBirthShpTail2->m_tailScaleDirection;
-    pppScaleVectorXYZ(scaled, local, *tailScale);
-    pppAddVector(*(Vec*)(color + 0x0), *(Vec*)(color + 0x0), scaled);
-
-    if (*(s16*)((u8*)&pYmMegaBirthShpTail2->m_matrix[1] + 0x4) != 0) {
-        *(s16*)(color + 0x22) = *(s16*)(color + 0x22) - 1;
-    }
-
-    frameState[4] = frameState[4] + 1;
-    frameWindow = frameState[5];
-    if ((frameWindow != 0) && (frameState[4] <= frameWindow)) {
-        *blend = *blend - ((float)alpha / (float)frameWindow);
-        if (*blend < kPppYmMegaBirthShpTail2Zero) {
-            *blend = kPppYmMegaBirthShpTail2Zero;
-        }
-    }
-
-    if ((frameState[6] != 0) && (*(u16*)(color + 0x22) <= frameState[6])) {
-        fadeInFrames = *((u8*)&pYmMegaBirthShpTail2->m_matrix[1] + 7);
-        if (fadeInFrames != 0) {
-            *blend = *blend + ((float)alpha / (float)fadeInFrames);
-            if (*blend > 1.0f) {
-                *blend = 1.0f;
-            }
-        }
-    }
-
-    if (frameState[8] == 0) {
-        frameState[8] = frameState[7];
-    }
-    frameState[8] = frameState[8] - 1;
-    historyIndex = frameState[8];
-
-    PSMTXMultVec(pppPObject->m_localMatrix.value, (Vec*)(color + 0x0),
-                 (Vec*)(color + ((historyIndex + 5) * sizeof(VColor)) + 0x4));
-
-    frameIndex = *(u16*)(color + 0x1e);
-    colorTable = **(int**)(*(int*)&pppEnvStPtr->m_particleColors[0] +
-                           (int)pYmMegaBirthShpTail2->m_matrix[0][1] * 4);
-    *(u16*)(color + 0x20) = frameIndex;
-
-    frameEntry = colorTable + (u32)frameIndex * 8 + 0x10;
-    *(s16*)(color + 0x1c) = *(s16*)(color + 0x1c) + *(s16*)((u8*)pYmMegaBirthShpTail2->m_matrix[0] + 8);
-    frameDuration = *(s16*)(frameEntry + 2);
-    if ((int)frameDuration <= *(u16*)(color + 0x1c)) {
-        *(u16*)(color + 0x1c) = *(u16*)(color + 0x1c) - frameDuration;
-        *(s16*)(color + 0x1e) = *(s16*)(color + 0x1e) + 1;
-        if ((int)*(s16*)(colorTable + 6) <= *(u16*)(color + 0x1e)) {
-            if ((*(u8*)(frameEntry + 4) & 0x80) == 0) {
-                color[0x1c] = 0;
-                color[0x1d] = 0;
-                *(s16*)(color + 0x1e) = *(s16*)(color + 0x1e) - 1;
-            } else {
-                color[0x1e] = 0;
-                color[0x1f] = 0;
-                color[0x1c] = 0;
-                color[0x1d] = 0;
-            }
-        }
-    }
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void calc_particle(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8008b3f4
- * PAL Size: 1072b
- */
-void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShpTail2* param, pppYmMegaBirthShpTail2UnkC* offsets)
-{
-    bool hasRequiredMemory;
-    int spawnCount = 0;
-    u8* paramPayload;
-    u8* particleData;
-    int colorOffset;
-    u32 i;
-    _PARTICLE_WMAT* worldMat;
-    _PARTICLE_COLOR* particleColor;
-    VYmMegaBirthShpTail2* work;
-
-    colorOffset = offsets->m_serializedDataOffsets[1];
-    work = (VYmMegaBirthShpTail2*)((u8*)object + 0x80 + offsets->m_serializedDataOffsets[2]);
-    paramPayload = (u8*)param;
-
-    if (work->m_particles == 0) {
-        Vec tailScale;
-
-        work->m_maxParticles = *(u16*)((u8*)&param->m_matrix + 0xe);
-        work->m_particles = (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            work->m_maxParticles * 0x1b8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x30e);
-        if (work->m_particles != 0) {
-            memset(work->m_particles, 0, work->m_maxParticles * 0x1b8);
-        }
-
-        work->m_wmats = (_PARTICLE_WMAT*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            work->m_maxParticles * 0x30, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x316);
-        if (work->m_wmats != 0) {
-            memset(work->m_wmats, 0, work->m_maxParticles * 0x30);
-        }
-
-        if (paramPayload[0x69] != 0) {
-            work->m_colors = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-                work->m_maxParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x31e);
-            if (work->m_colors != 0) {
-                memset(work->m_colors, 0, work->m_maxParticles << 5);
-            }
-        }
-
-        work->m_tailScaleDirection = param->m_directionTail;
-        tailScale = work->m_tailScaleDirection;
-        pppNormalize(work->m_tailScaleDirection, tailScale);
-    }
-
-    if (work->m_particles == 0) {
-        hasRequiredMemory = false;
-    } else if (work->m_wmats == 0) {
-        hasRequiredMemory = false;
-    } else if ((paramPayload[0x69] == 0) || (work->m_colors != 0)) {
-        hasRequiredMemory = true;
-    } else {
-        hasRequiredMemory = false;
-    }
-
-    if (!hasRequiredMemory) {
-        return;
-    }
-
-    switch (paramPayload[0x18]) {
-    default:
-        pppCopyMatrix(work->m_emitterMatrix, pppMngStPtr->m_matrix);
-        break;
-    case 1:
-    case 3:
-    case 5:
-    case 7:
-    case 9:
-    {
-        Vec firstCol;
-        Vec secondCol;
-        Vec thirdCol;
-
-        PSMTXIdentity(work->m_emitterMatrix.value);
-        firstCol.x = work->m_emitterMatrix.value[0][0];
-        firstCol.y = work->m_emitterMatrix.value[1][0];
-        firstCol.z = work->m_emitterMatrix.value[2][0];
-        PSVECScale(&firstCol, &firstCol, pppMngStPtr->m_scale.x);
-        work->m_emitterMatrix.value[0][0] = firstCol.x;
-        work->m_emitterMatrix.value[1][0] = firstCol.y;
-        work->m_emitterMatrix.value[2][0] = firstCol.z;
-
-        secondCol.x = work->m_emitterMatrix.value[0][1];
-        secondCol.y = work->m_emitterMatrix.value[1][1];
-        secondCol.z = work->m_emitterMatrix.value[2][1];
-        PSVECScale(&secondCol, &secondCol, pppMngStPtr->m_scale.x);
-        work->m_emitterMatrix.value[0][1] = secondCol.x;
-        work->m_emitterMatrix.value[1][1] = secondCol.y;
-        work->m_emitterMatrix.value[2][1] = secondCol.z;
-
-        thirdCol.x = work->m_emitterMatrix.value[0][2];
-        thirdCol.y = work->m_emitterMatrix.value[1][2];
-        thirdCol.z = work->m_emitterMatrix.value[2][2];
-        PSVECScale(&thirdCol, &thirdCol, pppMngStPtr->m_scale.x);
-        work->m_emitterMatrix.value[0][2] = thirdCol.x;
-        work->m_emitterMatrix.value[1][2] = thirdCol.y;
-        work->m_emitterMatrix.value[2][2] = thirdCol.z;
-
-        work->m_emitterMatrix.value[0][3] = pppMngStPtr->m_position.x;
-        work->m_emitterMatrix.value[1][3] = pppMngStPtr->m_position.y;
-        work->m_emitterMatrix.value[2][3] = pppMngStPtr->m_position.z;
-        break;
-    }
-    }
-
-    if ((gPppCalcDisabled != 0) || (paramPayload[0x18] == 0)) {
-        return;
-    }
-
-    worldMat = work->m_wmats;
-    particleColor = work->m_colors;
-    particleData = (u8*)work->m_particles;
-    work->m_lifeLimit = work->m_lifeLimit + 1;
-
-    for (i = 0; i < work->m_maxParticles; i++) {
-        if (*(s16*)(particleData + 0x22) == 0) {
-            if ((*(u16*)((u8*)&param->m_matrix + 0x12) <= work->m_lifeLimit) &&
-                (spawnCount < *(u16*)((u8*)&param->m_matrix + 0x10))) {
-                birth(&object->field0_0x0, work, param, (VColor*)((u8*)object + 0x80 + colorOffset),
-                    (_PARTICLE_DATA*)particleData, worldMat, particleColor);
-                spawnCount = spawnCount + 1;
-            }
-        } else {
-            calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
-                &object->field0_0x0, work, param, (VColor*)particleData,
-                (_PARTICLE_COLOR*)((u8*)object + 0x80 + colorOffset));
-        }
-
-        if (worldMat != 0) {
-            worldMat = worldMat + 1;
-        }
-        if (particleColor != 0) {
-            particleColor = particleColor + 1;
-        }
-        particleData = particleData + 0x1b8;
-    }
-
-    if (spawnCount > 0) {
-        work->m_lifeLimit = 0;
-    }
-}
 
 /*
  * --INFO--
@@ -694,4 +205,451 @@ void pppRenderYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, pppYmMegaBirth
             }
         }
     }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8008b3f4
+ * PAL Size: 1072b
+ */
+void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShpTail2* param, pppYmMegaBirthShpTail2UnkC* offsets)
+{
+    bool hasRequiredMemory;
+    int spawnCount = 0;
+    u8* paramPayload;
+    u8* particleData;
+    int colorOffset;
+    u32 i;
+    _PARTICLE_WMAT* worldMat;
+    _PARTICLE_COLOR* particleColor;
+    VYmMegaBirthShpTail2* work;
+
+    colorOffset = offsets->m_serializedDataOffsets[1];
+    work = (VYmMegaBirthShpTail2*)((u8*)object + 0x80 + offsets->m_serializedDataOffsets[2]);
+    paramPayload = (u8*)param;
+
+    if (work->m_particles == 0) {
+        Vec tailScale;
+
+        work->m_maxParticles = *(u16*)((u8*)&param->m_matrix + 0xe);
+        work->m_particles = (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            work->m_maxParticles * 0x1b8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x30e);
+        if (work->m_particles != 0) {
+            memset(work->m_particles, 0, work->m_maxParticles * 0x1b8);
+        }
+
+        work->m_wmats = (_PARTICLE_WMAT*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            work->m_maxParticles * 0x30, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x316);
+        if (work->m_wmats != 0) {
+            memset(work->m_wmats, 0, work->m_maxParticles * 0x30);
+        }
+
+        if (paramPayload[0x69] != 0) {
+            work->m_colors = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                work->m_maxParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x31e);
+            if (work->m_colors != 0) {
+                memset(work->m_colors, 0, work->m_maxParticles << 5);
+            }
+        }
+
+        work->m_tailScaleDirection = param->m_directionTail;
+        tailScale = work->m_tailScaleDirection;
+        pppNormalize(work->m_tailScaleDirection, tailScale);
+    }
+
+    if (work->m_particles == 0) {
+        hasRequiredMemory = false;
+    } else if (work->m_wmats == 0) {
+        hasRequiredMemory = false;
+    } else if ((paramPayload[0x69] == 0) || (work->m_colors != 0)) {
+        hasRequiredMemory = true;
+    } else {
+        hasRequiredMemory = false;
+    }
+
+    if (!hasRequiredMemory) {
+        return;
+    }
+
+    switch (paramPayload[0x18]) {
+    default:
+        pppCopyMatrix(work->m_emitterMatrix, pppMngStPtr->m_matrix);
+        break;
+    case 1:
+    case 3:
+    case 5:
+    case 7:
+    case 9:
+    {
+        Vec firstCol;
+        Vec secondCol;
+        Vec thirdCol;
+
+        PSMTXIdentity(work->m_emitterMatrix.value);
+        firstCol.x = work->m_emitterMatrix.value[0][0];
+        firstCol.y = work->m_emitterMatrix.value[1][0];
+        firstCol.z = work->m_emitterMatrix.value[2][0];
+        PSVECScale(&firstCol, &firstCol, pppMngStPtr->m_scale.x);
+        work->m_emitterMatrix.value[0][0] = firstCol.x;
+        work->m_emitterMatrix.value[1][0] = firstCol.y;
+        work->m_emitterMatrix.value[2][0] = firstCol.z;
+
+        secondCol.x = work->m_emitterMatrix.value[0][1];
+        secondCol.y = work->m_emitterMatrix.value[1][1];
+        secondCol.z = work->m_emitterMatrix.value[2][1];
+        PSVECScale(&secondCol, &secondCol, pppMngStPtr->m_scale.x);
+        work->m_emitterMatrix.value[0][1] = secondCol.x;
+        work->m_emitterMatrix.value[1][1] = secondCol.y;
+        work->m_emitterMatrix.value[2][1] = secondCol.z;
+
+        thirdCol.x = work->m_emitterMatrix.value[0][2];
+        thirdCol.y = work->m_emitterMatrix.value[1][2];
+        thirdCol.z = work->m_emitterMatrix.value[2][2];
+        PSVECScale(&thirdCol, &thirdCol, pppMngStPtr->m_scale.x);
+        work->m_emitterMatrix.value[0][2] = thirdCol.x;
+        work->m_emitterMatrix.value[1][2] = thirdCol.y;
+        work->m_emitterMatrix.value[2][2] = thirdCol.z;
+
+        work->m_emitterMatrix.value[0][3] = pppMngStPtr->m_position.x;
+        work->m_emitterMatrix.value[1][3] = pppMngStPtr->m_position.y;
+        work->m_emitterMatrix.value[2][3] = pppMngStPtr->m_position.z;
+        break;
+    }
+    }
+
+    if ((gPppCalcDisabled != 0) || (paramPayload[0x18] == 0)) {
+        return;
+    }
+
+    worldMat = work->m_wmats;
+    particleColor = work->m_colors;
+    particleData = (u8*)work->m_particles;
+    work->m_lifeLimit = work->m_lifeLimit + 1;
+
+    for (i = 0; i < work->m_maxParticles; i++) {
+        if (*(s16*)(particleData + 0x22) == 0) {
+            if ((*(u16*)((u8*)&param->m_matrix + 0x12) <= work->m_lifeLimit) &&
+                (spawnCount < *(u16*)((u8*)&param->m_matrix + 0x10))) {
+                birth(&object->field0_0x0, work, param, (VColor*)((u8*)object + 0x80 + colorOffset),
+                    (_PARTICLE_DATA*)particleData, worldMat, particleColor);
+                spawnCount = spawnCount + 1;
+            }
+        } else {
+            calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
+                &object->field0_0x0, work, param, (VColor*)particleData,
+                (_PARTICLE_COLOR*)((u8*)object + 0x80 + colorOffset));
+        }
+
+        if (worldMat != 0) {
+            worldMat = worldMat + 1;
+        }
+        if (particleColor != 0) {
+            particleColor = particleColor + 1;
+        }
+        particleData = particleData + 0x1b8;
+    }
+
+    if (spawnCount > 0) {
+        work->m_lifeLimit = 0;
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8008b824
+ * PAL Size: 772b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
+    _pppPObject* pppPObject, VYmMegaBirthShpTail2* vYmMegaBirthShpTail2,
+    PYmMegaBirthShpTail2* pYmMegaBirthShpTail2, VColor* vColor, _PARTICLE_COLOR* particleColor)
+{
+    u8* color = (u8*)vColor;
+    u32 alpha = ((u8*)particleColor)[0xb];
+    float* blend = (float*)(color + 0x30);
+    float* velocityScale = (float*)(color + 0x28);
+    float* tailScale = (float*)(color + 0x2c);
+    u8* frameState = color + 0x30;
+    u8 frameWindow;
+    u8 fadeInFrames;
+    u8 historyIndex;
+    u16 frameIndex;
+    int colorTable;
+    int frameEntry;
+    s16 frameDuration;
+    Vec local;
+    Vec scaled;
+
+    *velocityScale = *velocityScale + pYmMegaBirthShpTail2->m_colorDeltaAdd[2];
+    *tailScale = *tailScale + pYmMegaBirthShpTail2->m_sizeVal;
+
+    local.x = *(float*)(color + 0x10);
+    local.y = *(float*)(color + 0x14);
+    local.z = *(float*)(color + 0x18);
+    pppScaleVectorXYZ(scaled, local, *velocityScale);
+    pppAddVector(*(Vec*)(color + 0x0), *(Vec*)(color + 0x0), scaled);
+
+    local = vYmMegaBirthShpTail2->m_tailScaleDirection;
+    pppScaleVectorXYZ(scaled, local, *tailScale);
+    pppAddVector(*(Vec*)(color + 0x0), *(Vec*)(color + 0x0), scaled);
+
+    if (*(s16*)((u8*)&pYmMegaBirthShpTail2->m_matrix[1] + 0x4) != 0) {
+        *(s16*)(color + 0x22) = *(s16*)(color + 0x22) - 1;
+    }
+
+    frameState[4] = frameState[4] + 1;
+    frameWindow = frameState[5];
+    if ((frameWindow != 0) && (frameState[4] <= frameWindow)) {
+        *blend = *blend - ((float)alpha / (float)frameWindow);
+        if (*blend < kPppYmMegaBirthShpTail2Zero) {
+            *blend = kPppYmMegaBirthShpTail2Zero;
+        }
+    }
+
+    if ((frameState[6] != 0) && (*(u16*)(color + 0x22) <= frameState[6])) {
+        fadeInFrames = *((u8*)&pYmMegaBirthShpTail2->m_matrix[1] + 7);
+        if (fadeInFrames != 0) {
+            *blend = *blend + ((float)alpha / (float)fadeInFrames);
+            if (*blend > 1.0f) {
+                *blend = 1.0f;
+            }
+        }
+    }
+
+    if (frameState[8] == 0) {
+        frameState[8] = frameState[7];
+    }
+    frameState[8] = frameState[8] - 1;
+    historyIndex = frameState[8];
+
+    PSMTXMultVec(pppPObject->m_localMatrix.value, (Vec*)(color + 0x0),
+                 (Vec*)(color + ((historyIndex + 5) * sizeof(VColor)) + 0x4));
+
+    frameIndex = *(u16*)(color + 0x1e);
+    colorTable = **(int**)(*(int*)&pppEnvStPtr->m_particleColors[0] +
+                           (int)pYmMegaBirthShpTail2->m_matrix[0][1] * 4);
+    *(u16*)(color + 0x20) = frameIndex;
+
+    frameEntry = colorTable + (u32)frameIndex * 8 + 0x10;
+    *(s16*)(color + 0x1c) = *(s16*)(color + 0x1c) + *(s16*)((u8*)pYmMegaBirthShpTail2->m_matrix[0] + 8);
+    frameDuration = *(s16*)(frameEntry + 2);
+    if ((int)frameDuration <= *(u16*)(color + 0x1c)) {
+        *(u16*)(color + 0x1c) = *(u16*)(color + 0x1c) - frameDuration;
+        *(s16*)(color + 0x1e) = *(s16*)(color + 0x1e) + 1;
+        if ((int)*(s16*)(colorTable + 6) <= *(u16*)(color + 0x1e)) {
+            if ((*(u8*)(frameEntry + 4) & 0x80) == 0) {
+                color[0x1c] = 0;
+                color[0x1d] = 0;
+                *(s16*)(color + 0x1e) = *(s16*)(color + 0x1e) - 1;
+            } else {
+                color[0x1e] = 0;
+                color[0x1f] = 0;
+                color[0x1c] = 0;
+                color[0x1d] = 0;
+            }
+        }
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8008bb28
+ * PAL Size: 3704b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail2* work, PYmMegaBirthShpTail2* param, VColor* vColor,
+           _PARTICLE_DATA* particleData, _PARTICLE_WMAT* particleWMat, _PARTICLE_COLOR* particleColor)
+{
+    u8* paramBytes = (u8*)param;
+    u8* particleBytes = (u8*)particleData;
+    u8 mode = paramBytes[0x12];
+    float speedRandRange = *(float*)(paramBytes + 0x5c);
+    float speedRandHalf = FLOAT_80330568 * speedRandRange;
+
+    memset(particleData, 0, 0x1b8);
+    if (particleWMat != 0) {
+        memset(particleWMat, 0, 0x30);
+    }
+    if (particleColor != 0) {
+        memset(particleColor, 0, 0x20);
+    }
+
+    if (mode < 8) {
+        Vec baseDir = *(Vec*)(paramBytes + 0x20);
+        pppIVECTOR4 angles;
+        pppFMATRIX rot;
+        Vec tempVec;
+        float spread = (float)paramBytes[0x19];
+        float spreadRange = spread * 2.0f;
+
+        angles.x = (s16)(spreadRange * Math.RandF() - spread);
+        angles.y = (s16)(spreadRange * Math.RandF() - spread);
+        angles.z = (s16)(spreadRange * Math.RandF() - spread);
+        angles.w = 0;
+        if ((mode == 2) || (mode == 3)) {
+            angles.x = 0;
+            angles.y = 0;
+            angles.z = 0;
+            angles.w = 0;
+        }
+
+        pppGetRotMatrixXYZ(rot, &angles);
+        PSMTXMultVecSR(rot.value, &baseDir, &particleData->m_velocity);
+        particleData->m_velocity.x *= *(float*)(paramBytes + 0x58);
+        particleData->m_velocity.y *= param->m_velocity.x;
+        particleData->m_velocity.z *= param->m_velocity.y;
+        tempVec = particleData->m_velocity;
+        pppNormalize(particleData->m_velocity, tempVec);
+    }
+
+    if ((mode < 6) && (speedRandRange != 0.0f)) {
+        u8 randType = paramBytes[0x6a];
+
+        if (randType <= 1) {
+            if (randType == 1) {
+                Math.RandF();
+            }
+            particleData->m_matrix[0][0] = speedRandRange * Math.RandF() - speedRandHalf;
+            particleData->m_matrix[0][1] = speedRandRange * Math.RandF() - speedRandHalf;
+            particleData->m_matrix[0][2] = speedRandRange * Math.RandF() - speedRandHalf;
+        } else if (randType == 3) {
+            particleData->m_matrix[0][0] = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange) - speedRandHalf;
+            particleData->m_matrix[0][1] = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange) - speedRandHalf;
+            particleData->m_matrix[0][2] = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange) - speedRandHalf;
+        } else if (randType == 5) {
+            particleData->m_matrix[0][0] =
+                -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange) - speedRandHalf;
+            particleData->m_matrix[0][1] =
+                -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange) - speedRandHalf;
+            particleData->m_matrix[0][2] =
+                -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange) - speedRandHalf;
+        } else {
+            particleData->m_matrix[0][0] = Math.RandF() * (speedRandRange * Math.RandF()) - speedRandHalf;
+            particleData->m_matrix[0][1] = Math.RandF() * (speedRandRange * Math.RandF()) - speedRandHalf;
+            particleData->m_matrix[0][2] = Math.RandF() * (speedRandRange * Math.RandF()) - speedRandHalf;
+        }
+
+        particleData->m_matrix[0][0] *= *(float*)(paramBytes + 0x58);
+        particleData->m_matrix[0][1] *= param->m_velocity.x;
+        particleData->m_matrix[0][2] *= param->m_velocity.y;
+    } else if ((mode >= 10) && (speedRandRange != 0.0f)) {
+        u8 randType = paramBytes[0x6a];
+        float scale = speedRandRange;
+
+        if (randType == 3) {
+            scale = -(2.0f * (speedRandRange * Math.RandF() * Math.RandF()) - speedRandRange);
+        } else if (randType == 1) {
+            Math.RandF();
+            scale = speedRandRange * Math.RandF();
+        } else if (randType == 2) {
+            scale = Math.RandF() * (speedRandRange * Math.RandF());
+        } else if (randType == 4) {
+            scale = Math.RandF() * (Math.RandF() * (speedRandRange * Math.RandF()));
+        } else if (randType == 5) {
+            scale = -(FLOAT_80330568 * (Math.RandF() * (speedRandRange * Math.RandF() * Math.RandF())) - speedRandRange);
+        }
+
+        Vec velocity = particleData->m_velocity;
+        pppScaleVectorXYZ(particleData->m_velocity, velocity, scale);
+    }
+
+    if (paramBytes[0x16] != 0) {
+        particleData->m_directionTail.x = (float)vColor->m_alpha;
+        *(((u8*)&particleData->m_directionTail.y) + 1) = paramBytes[0x16];
+    }
+    if (paramBytes[0x17] != 0) {
+        *(((u8*)&particleData->m_directionTail.y) + 2) = paramBytes[0x17];
+    }
+
+    particleData->m_matrix[2][2] = param->m_colorDeltaAdd[1];
+    particleData->m_matrix[2][3] = param->m_sizeStart;
+    if (param->m_colorDeltaAdd[3] != 0.0f) {
+        particleData->m_matrix[2][2] += (2.0f * param->m_colorDeltaAdd[3]) * Math.RandF() - param->m_colorDeltaAdd[3];
+    }
+
+    if (*(s16*)(paramBytes + 0x11) == 0) {
+        *(u16*)(particleBytes + 0x22) = 0xFFFF;
+    } else {
+        *(s16*)(particleBytes + 0x22) = *(s16*)(paramBytes + 0x11);
+    }
+    *((u8*)&particleData->m_directionTail.y) = 0;
+
+    if (particleWMat != 0) {
+        memcpy(particleWMat, &work->m_emitterMatrix, 0x30);
+    }
+
+    particleData->m_colorDeltaAdd[0] = 0.0f;
+    particleData->m_colorDeltaAdd[1] = 0.0f;
+    particleData->m_colorDeltaAdd[2] = 0.0f;
+    particleData->m_colorDeltaAdd[3] = 0.0f;
+    *(((u8*)&particleData->m_directionTail.z) + 2) = 0;
+    *((u8*)&particleData->m_directionTail.z) = 0;
+    *(((u8*)&particleData->m_directionTail.y) + 3) = 0x1f;
+    *((u8*)&particleData->m_directionTail.z) = *(((u8*)&particleData->m_directionTail.y) + 3) - 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8008c9a0
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppDestructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* param1, pppYmMegaBirthShpTail2UnkC* param2)
+{
+    u8* work = (u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2];
+    void** ptrBc = (void**)(work + 0x3c);
+    void** ptrC0 = (void**)(work + 0x40);
+    void** ptrC4 = (void**)(work + 0x44);
+
+    if (*ptrBc != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*ptrBc);
+        *ptrBc = 0;
+    }
+    if (*ptrC0 != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*ptrC0);
+        *ptrC0 = 0;
+    }
+    if (*ptrC4 != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(*ptrC4);
+        *ptrC4 = 0;
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8008ca1c
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppConstructYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* param1, pppYmMegaBirthShpTail2UnkC* param2)
+{
+    pppFMATRIX* work = (pppFMATRIX*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[2]);
+    float initVal;
+
+    pppUnitMatrix(*work);
+    initVal = kPppYmMegaBirthShpTail2Zero;
+
+    work[1].value[0][2] = initVal;
+    work[1].value[0][1] = initVal;
+    work[1].value[0][0] = initVal;
+    *reinterpret_cast<u32*>(&work[1].value[0][3]) = 0;
+    *reinterpret_cast<u32*>(&work[1].value[1][0]) = 0;
+    *reinterpret_cast<u32*>(&work[1].value[1][1]) = 0;
+    *reinterpret_cast<u32*>(&work[1].value[1][2]) = 0;
+    *(u16*)(work[1].value[1] + 3) = 0;
+    *(u16*)((u8*)work[1].value[1] + 0xe) = 0;
+    *(u16*)(work[1].value[1] + 3) = 10000;
+    pppUnitMatrix(g_matUnit2);
 }


### PR DESCRIPTION
## Summary
- Reorders pppYmMegaBirthShpTail2 function definitions to match the PAL MAP order: render, frame, calc, birth, destruct, construct.
- Removes placeholder helper declarations/definitions that do not appear in the PAL symbols for this unit.
- Adds a forward declaration for the mangled calc symbol needed after the reorder.

## Evidence
- ninja passes.
- objdiff main/pppYmMegaBirthShpTail2:
  - extab: 43.75% -> 93.75%
  - extabindex: 0.00% -> 93.06%
  - named function match percentages unchanged.

## Plausibility
- The function order now follows config/GCCP01/symbols.txt / PAL MAP layout rather than source-local placeholder order.
- Removed TODO functions were not PAL symbols and were emitted only by the reconstruction, so dropping them makes the rebuilt unit layout more coherent.