### PR TITLE
Improve pppLaser frame history handling

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -246,12 +246,11 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     LaserWork* work;
     Vec localA;
     Vec localB;
-    Vec localPos;
     CMapCylinderRaw cyl;
     Mtx charaMtx;
     Mtx tempMtx;
 
-    bool emptyHistory;
+    int emptyHistory;
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -265,12 +264,12 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
         return;
     }
 
-    emptyHistory = false;
+    emptyHistory = 0;
     if (work->m_points == 0) {
         work->m_points = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
             (u32)step->m_payload[0x1e] * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppLaser_cpp), 0x7d);
         memset(work->m_points, 0, (u32)step->m_payload[0x1e] * 0xc);
-        emptyHistory = true;
+        emptyHistory = 1;
     }
 
     CalcGraphValue((_pppPObject*)baseObj, step->m_graphId, work->m_halfWidth, work->m_graphValue2, work->m_graphValue3,
@@ -314,7 +313,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
             double t = (FLOAT_80333448 / (float)(countDouble.d - DOUBLE_80333440)) *
                 (float)(indexDouble.d - DOUBLE_80333440);
             if (GetCharaNodeFrameMatrix(pppMngStPtr, (float)t, charaMtx) == 0) {
-                emptyHistory = true;
+                emptyHistory = 1;
                 continue;
             } else {
                 PSMTXConcat(charaMtx, baseObj->m_localMatrix.value, charaMtx);
@@ -322,8 +321,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
             }
         }
 
-        localPos = work->m_origin;
-        pppSubVector(localA, work->m_points[i], localPos);
+        pppSubVector(localA, work->m_points[i], work->m_origin);
         PSVECScale(&localA, &localA, FLOAT_8033344c);
 
         cyl.m_bottom = work->m_origin;
@@ -404,9 +402,8 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     }
 
     if (emptyHistory) {
-        Vec* points = work->m_points;
         for (int i = 0; i < (int)(u32)step->m_payload[0x1e]; i++) {
-            pppCopyVector(points[i], points[0]);
+            pppCopyVector(work->m_points[i], work->m_points[0]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- simplify `pppFrameLaser` history state tracking to use integer control flow instead of bool temporaries
- remove redundant local aliasing around the beam origin and history copyback path
- keep render logic unchanged after verifying the frame-side cleanup alone gives the best net result

## Improved symbols
- `pppFrameLaser`: 83.6267% -> 87.44959%
- `main/pppLaser` `.text`: 74.190475% -> 75.32284%
- `pppRenderLaser`: unchanged at 65.46676%

## Evidence
- before: `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser` reported 83.6267%
- after: `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser` reports 87.44959%
- unit after: `build/tools/objdiff-cli diff -p . -u main/pppLaser -o -` reports 75.32284% code match for `.text`

## Why this is plausible source
- the changes reduce temporary aliasing and use straightforward integer state in a hot control-flow path
- no linkage hacks, fake symbols, manual section forcing, or ABI workarounds were introduced
- behavior stays the same while the generated control flow moves closer to the original binary