### PR TITLE
Improve texanim material set array access

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -824,10 +824,9 @@ void CTexAnimSet::AttachMaterialSet(CMaterialSet* materialSet)
     unsigned int texAnimCount;
 
     for (texAnimIndex = 0;
-         ((texAnimCount = static_cast<unsigned int>(GetSize__21CPtrArray_P8CTexAnim_Fv(&self->texAnims))), texAnimIndex < texAnimCount);
+         ((texAnimCount = static_cast<unsigned int>(self->texAnims.GetSize())), texAnimIndex < texAnimCount);
          texAnimIndex = texAnimIndex + 1) {
-        CTexAnimStorage* texAnim =
-            reinterpret_cast<CTexAnimStorage*>(__vc__21CPtrArray_P8CTexAnim_FUl(&self->texAnims, texAnimIndex));
+        CTexAnimStorage* texAnim = reinterpret_cast<CTexAnimStorage*>(self->texAnims[texAnimIndex]);
         int* material = reinterpret_cast<int*>(*reinterpret_cast<void**>((int)texAnim->refData + 0x108));
         int materialIndex;
 


### PR DESCRIPTION
## Summary
- Use the real CPtrArray<CTexAnim*> member calls in CTexAnimSet::AttachMaterialSet instead of the temporary extern-style accessor shims.
- Keeps the same behavior while making the source closer to the surrounding C++ template usage.

## Evidence
- ninja: passes
- main/texanim .text: 83.06006% -> 83.06786%
- CTexAnimSet::AttachMaterialSet: 79.828125% -> 79.984375%
- CTexAnimSet::Create: unchanged at 38.18667%
- CTexAnimSet::AddFrame: unchanged at 77.26761%

## Plausibility
- The original source would naturally call the CPtrArray member functions/operators on the texAnim array; this removes a local fake-call pattern without changing layout or control flow.