### PR TITLE
Match pppConstructBreathModel zero init

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -170,14 +170,14 @@ extern "C" void pppDestructBreathModel(pppBreathModel* pppBreathModel, pppBreath
 extern "C" void pppConstructBreathModel(pppBreathModel* pppBreathModel, pppBreathModelUnkC* param_2)
 {
     VBreathModel* state = (VBreathModel*)((unsigned char*)pppBreathModel + 0x80 + *param_2->m_serializedDataOffsets);
-    float fVar1;
+    float zero;
 
     PSMTXIdentity(state->m_matrix);
-    fVar1 = kPppBreathModelZero;
+    zero = 0.0f;
 
-    state->m_direction.z = kPppBreathModelZero;
-    state->m_direction.y = fVar1;
-    state->m_direction.x = fVar1;
+    state->m_direction.z = zero;
+    state->m_direction.y = zero;
+    state->m_direction.x = zero;
 
     state->m_particleData = 0;
     state->m_particleWmats = 0;


### PR DESCRIPTION
## Summary
- rewrite the zero initialization in `pppConstructBreathModel` to use a local literal zero
- keep the constructor's state setup identical while matching the target constant load pattern more closely

## Evidence
- `ninja build/GCCP01/src/pppBreathModel.o build/GCCP01/report.json`
- `build/GCCP01/report.json` now reports `pppConstructBreathModel` at `100.0%` fuzzy match in `main/pppBreathModel`
- before this change, direct objdiff on the symbol showed a remaining `lfs f0, kPppBreathModelZero@sda21` mismatch at `99.833336%`

## Plausibility
- this only changes how the constructor sources its zero constant
- the emitted behavior is unchanged: matrix identity, zero direction, null pointers, and counter initialization stay the same
- the source is cleaner and closer to what the original constructor likely looked like than forcing a named global zero constant
