### PR TITLE
Improve Mana2 normal clearing order

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1421,9 +1421,9 @@ static void CalculateNormal(VMana2* mana2)
     indices = *(u16**)((u8*)mana2 + 0x50);
 
     for (s32 i = 0; i < 0x121; i++) {
-        normals[i].x = 0.0f;
-        normals[i].y = 0.0f;
         normals[i].z = 0.0f;
+        normals[i].y = 0.0f;
+        normals[i].x = 0.0f;
     }
 
     for (s32 i = 0; i < 0x200; i++) {


### PR DESCRIPTION
## Summary
- Reorder CalculateNormal normal zeroing to write z/y/x, matching the decompiled original store order.
- Keeps the function size unchanged while improving objdiff for the main/pppMana2 unit.

## Evidence
- ninja passes.
- Objdiff for CalculateNormal__FP6VMana2:
  - before: 94.13908%
  - after: 94.364235%
  - size: 604 bytes unchanged

## Plausibility
- The change only adjusts member assignment order during a zero-initialization loop.
- Ghidra shows the original clearing each normal in z, then y, then x order; this source now reflects that order without adding hacks or changing behavior.