### PR TITLE
Improve CMapMesh ReadOtmMesh matching

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -366,20 +366,6 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
                 offset += 6;
             }
             break;
-        case 0x4E425420:
-            m_nbtCount = static_cast<unsigned short>(chunk.m_size / 0x12);
-            cursor = reinterpret_cast<unsigned char*>(Align32(reinterpret_cast<unsigned int>(cursor)));
-            m_nbt = cursor;
-            cursor += chunk.m_size;
-
-            offset = 0;
-            for (int i = 0; i < static_cast<int>(m_nbtCount); i++) {
-                for (int j = 0; j < 9; j++) {
-                    *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned int>(m_nbt) + offset) = reader.Get2();
-                    offset += 2;
-                }
-            }
-            break;
         case 0x434F4C52:
             m_colorCount = static_cast<unsigned short>(chunk.m_size >> 2);
             cursor = reinterpret_cast<unsigned char*>(Align32(reinterpret_cast<unsigned int>(cursor)));


### PR DESCRIPTION
## Summary
- Removed the second-pass `NBT ` chunk read from `CMapMesh::ReadOtmMesh`.
- This matches the Ghidra decomp shape: the function accounts for `NBT ` during work-size calculation, but the second pass skips a dedicated NBT population block and only flushes the existing NBT field later.

## Evidence
- `main/mapmesh` fuzzy match: `95.94556%` -> `99.12703%`.
- `ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`: `92.59162%` -> `98.404884%` in `build/GCCP01/report.json`.
- One-shot objdiff after change: `98.396164%` for `ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`.

## Verification
- `ninja`
- `git diff --check`

## Plausibility
- This removes an extra source-level parsing block that is absent from the shipped function shape, rather than adding artificial control flow or manual section/vtable tricks.
- Function size remains `2292` bytes, and adjacent matched functions are not touched.