### PR TITLE
Promote PPP filename string symbols

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -38,7 +38,7 @@ void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 void DrawSphere__8CGraphicFPA4_f8_GXColor(void*, Mtx, _GXColor);
 }
 
-static const char s_pppBreathModel_cpp[] = "pppBreathModel.cpp";
+extern "C" const char s_pppBreathModel_cpp_801DB5A0[] = "pppBreathModel.cpp";
 
 struct pppBreathModelUnkC {
     unsigned char _pad[0xC];
@@ -441,21 +441,21 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
 
         *(void**)(work + 0x30) =
             pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(*(int*)(work + 0x40) * 0x98), pppEnvStPtr->m_stagePtr,
-                                                  const_cast<char*>(s_pppBreathModel_cpp), 0x257);
+                                                  const_cast<char*>(s_pppBreathModel_cpp_801DB5A0), 0x257);
         if (*(void**)(work + 0x30) != NULL) {
             memset(*(void**)(work + 0x30), 0, (unsigned long)(*(int*)(work + 0x40) * 0x98));
         }
 
         *(void**)(work + 0x34) =
             pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(*(int*)(work + 0x40) * 0x30), pppEnvStPtr->m_stagePtr,
-                                                  const_cast<char*>(s_pppBreathModel_cpp), 0x25d);
+                                                  const_cast<char*>(s_pppBreathModel_cpp_801DB5A0), 0x25d);
         if (*(void**)(work + 0x34) != NULL) {
             memset(*(void**)(work + 0x34), 0, (unsigned long)(*(int*)(work + 0x40) * 0x30));
         }
 
         *(void**)(work + 0x38) =
             pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(*(int*)(work + 0x40) << 5), pppEnvStPtr->m_stagePtr,
-                                                  const_cast<char*>(s_pppBreathModel_cpp), 0x263);
+                                                  const_cast<char*>(s_pppBreathModel_cpp_801DB5A0), 0x263);
         if (*(void**)(work + 0x38) != NULL) {
             memset(*(void**)(work + 0x38), 0, (unsigned long)(*(int*)(work + 0x40) << 5));
         }
@@ -463,7 +463,7 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
         *(void**)(work + 0x3C) =
             pppMemAlloc__FUlPQ27CMemory6CStagePci(
                 (unsigned long)((int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x12) * 0x5C),
-                pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppBreathModel_cpp), 0x269);
+                pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppBreathModel_cpp_801DB5A0), 0x269);
         if (*(void**)(work + 0x3C) != NULL) {
             memset(*(void**)(work + 0x3C), 0,
                    (unsigned long)((int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x12) * 0x5C));
@@ -472,14 +472,14 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
             for (i = 0; i < (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x12); i++) {
                 groupTable[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                     (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10),
-                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppBreathModel_cpp), 0x274);
+                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppBreathModel_cpp_801DB5A0), 0x274);
                 void* particleIndices = (void*)groupTable[1];
                 memset(particleIndices, -1,
                        (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10));
 
                 groupTable[2] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                     (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10),
-                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppBreathModel_cpp), 0x277);
+                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppBreathModel_cpp_801DB5A0), 0x277);
                 void* particleStates = (void*)groupTable[2];
                 memset(particleStates, -1,
                        (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10));

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -62,7 +62,7 @@ void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, u8);
 
 }
 
-static const char s_pppLaser_cpp[] = "pppLaser.cpp";
+extern "C" const char s_pppLaser_cpp_801E3048[] = "pppLaser.cpp";
 
 struct LaserStep {
     s32 m_graphId;
@@ -267,7 +267,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     emptyHistory = 0;
     if (work->m_points == 0) {
         work->m_points = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            (u32)step->m_payload[0x1e] * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppLaser_cpp), 0x7d);
+            (u32)step->m_payload[0x1e] * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppLaser_cpp_801E3048), 0x7d);
         memset(work->m_points, 0, (u32)step->m_payload[0x1e] * 0xc);
         emptyHistory = 1;
     }

--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -19,7 +19,7 @@ struct Vec2d {
     float y;
 };
 
-static const char s_pppMana2_cpp[] = "pppMana2.cpp";
+extern "C" const char s_pppMana2_cpp_801DC4E0[] = "pppMana2.cpp";
 
 extern char s_Render_Mana2___801dc4d0[];
 extern float FLOAT_803318fc;
@@ -531,28 +531,28 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
     work[0x1F] = (u32)GetTextureFromRSD__FiP9_pppEnvSt(*(s32*)((char*)param_2 + 0x2C), pppEnvStPtr);
 
     if (work[0x1D] == 0) {
-        work[0x1D] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x1D7);
+        work[0x1D] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x1D7);
     }
     if (work[10] == 0) {
-        work[10] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x1DD);
+        work[10] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x1DD);
     }
     if (work[11] == 0) {
-        work[11] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x1E1);
+        work[11] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x1E1);
     }
 
     texBufferSize = GXGetTexBufferSize(0x80, 0x80, GX_TF_RGBA8, GX_FALSE, 0);
     if (work[12] == 0) {
-        work[12] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x1E9);
+        work[12] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x1E9);
     }
     if (work[13] == 0) {
-        work[13] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x1EB);
+        work[13] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x1EB);
     }
 
     GXInitTexObj((GXTexObj*)work[10], (void*)work[12], 0x80, 0x80, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
     GXInitTexObj((GXTexObj*)work[11], (void*)work[13], 0x80, 0x80, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (work[8] == 0) {
-        work[8] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x1F6);
+        work[8] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x1F6);
     }
     dstBuffer = (void*)work[8];
     texList = &work[2];
@@ -568,7 +568,7 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
     InitTexObj__8CTextureFv((void*)work[0x1F]);
 
     if (work[9] == 0) {
-        work[9] = (u32)pppMemAlloc(0xA5E8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x211);
+        work[9] = (u32)pppMemAlloc(0xA5E8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x211);
         genParaboloidMap__FPvPUlUs9_GXVtxFmt((void*)work[9], &work[0x39], 0x1E, GX_VTXFMT7);
     }
 
@@ -584,7 +584,7 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
                 if (work[0x19] == 0) {
                     work[0x19] =
                         (u32)pppMemAlloc(*(s32*)(meshShape + 0x14) * 0xC, pppEnvStPtr->m_stagePtr,
-                                         const_cast<char*>(s_pppMana2_cpp), 0x232);
+                                         const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x232);
                     Vec* reflectionVec = (Vec*)work[0x19];
                     float zero = FLOAT_80331898;
                     for (vertexIndex = 0; vertexIndex < *(u32*)(meshShape + 0x14); vertexIndex++) {
@@ -598,7 +598,7 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
                 if (work[0x1A] == 0) {
                     work[0x1A] =
                         (u32)pppMemAlloc(*(s32*)(meshShape + 0x14) << 2, pppEnvStPtr->m_stagePtr,
-                                         const_cast<char*>(s_pppMana2_cpp), 0x23B);
+                                         const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x23B);
                     u8* color = (u8*)work[0x1A];
                     for (vertexIndex = 0; vertexIndex < *(u32*)(meshShape + 0x14); vertexIndex++) {
                         color[0] = 0xFF;
@@ -612,7 +612,7 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
                 if (work[0x1B] == 0) {
                     work[0x1B] =
                         (u32)pppMemAlloc(*(s32*)(meshShape + 0x14) * 6, pppEnvStPtr->m_stagePtr,
-                                         const_cast<char*>(s_pppMana2_cpp), 0x244);
+                                         const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x244);
                     u16* texCoord = (u16*)work[0x1B];
                     for (vertexIndex = 0; vertexIndex < *(u32*)(meshShape + 0x14); vertexIndex++) {
                         texCoord[1] = 0;
@@ -622,12 +622,12 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
                 }
 
                 work[0x18] = (u32)pppMemAlloc(*(s32*)(meshShape + 0x4C) << 2, pppEnvStPtr->m_stagePtr,
-                                              const_cast<char*>(s_pppMana2_cpp), 0x24B);
+                                              const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x24B);
                 u32* dlInfo = *(u32**)(meshShape + 0x50);
                 dlOffset = (*(s32*)(meshShape + 0x4C) - 1) * 4;
                 for (s32 dlIndex = *(s32*)(meshShape + 0x4C) - 1; dlIndex >= 0; dlIndex--) {
                     *(u32*)(work[0x18] + dlOffset) =
-                        (u32)pppMemAlloc(dlInfo[0], pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x255);
+                        (u32)pppMemAlloc(dlInfo[0], pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x255);
                     *(u32*)(work[0x18] + dlOffset) = (*(u32*)(work[0x18] + dlOffset) + 0x1F) & 0xFFFFFFE0;
                     work[0x3A] = dlInfo[0];
                     memcpy((void*)*(u32*)(work[0x18] + dlOffset), (void*)dlInfo[1], dlInfo[0]);
@@ -640,15 +640,15 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
 
             if (((type == 1) && strcmp((char*)meshShape, DAT_803318ec) == 0) ||
                 ((type == 2) && strcmp((char*)meshShape, DAT_803318f4) == 0)) {
-                work[0xF] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x26A);
-                work[0x10] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x26B);
-                work[0x17] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x26C);
-                work[0x15] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x26D);
-                work[0x16] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x26E);
-                work[0x12] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x26F);
-                work[0x13] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x270);
-                work[0x14] = (u32)pppMemAlloc(0xC00, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x271);
-                work[0x11] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp), 0x272);
+                work[0xF] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x26A);
+                work[0x10] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x26B);
+                work[0x17] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x26C);
+                work[0x15] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x26D);
+                work[0x16] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x26E);
+                work[0x12] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x26F);
+                work[0x13] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x270);
+                work[0x14] = (u32)pppMemAlloc(0xC00, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x271);
+                work[0x11] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppMana2_cpp_801DC4E0), 0x272);
 
                 float* waterHeightA = (float*)work[0x12];
                 float* waterHeightB = (float*)work[0x13];

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -16,7 +16,7 @@ extern float FLOAT_80330460;
 
 static Mtx g_matUnit;
 
-static const char s_pppRyjMegaBirth_cpp[] = "pppRyjMegaBirth.cpp";
+extern "C" const char s_pppRyjMegaBirth_cpp_801D9C00[] = "pppRyjMegaBirth.cpp";
 
 static inline float* f32_at(void* base, s32 off)
 {
@@ -414,7 +414,7 @@ void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMega
 	{
 		work->m_numParticles = *(u16*)(particleDataBytes + 0x20);
 		work->m_particleBlock = (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-			work->m_numParticles * 0x60, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp), 0x262);
+			work->m_numParticles * 0x60, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x262);
 		if (work->m_particleBlock != NULL)
 		{
 			memset(work->m_particleBlock, 0, work->m_numParticles * 0x60);
@@ -423,7 +423,7 @@ void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMega
 		if ((particleDataBytes[0xEC] == 1) || (particleDataBytes[0xEC] == 2))
 		{
 			work->m_worldMatrixBlock = (PARTICLE_WMAT*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-				work->m_numParticles * 0x30, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp), 0x269);
+				work->m_numParticles * 0x30, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x269);
 			if (work->m_worldMatrixBlock != NULL)
 			{
 				memset(work->m_worldMatrixBlock, 0, work->m_numParticles * 0x30);
@@ -433,7 +433,7 @@ void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMega
 		if (particleDataBytes[0xE9] != 0)
 		{
 			work->m_colorBlock = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-				work->m_numParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp), 0x271);
+				work->m_numParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x271);
 			if (work->m_colorBlock != NULL)
 			{
 				memset(work->m_colorBlock, 0, work->m_numParticles << 5);

--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -40,7 +40,7 @@ struct VtMimeEnv
     void** sourceTable;
 };
 
-static const char s_pppVtMime_cpp[] = "pppVtMime.cpp";
+extern "C" const char s_pppVtMime_cpp[] = "pppVtMime.cpp";
 
 extern "C" {
 void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long size, void* stage, const char* file, int line);

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -70,7 +70,7 @@ struct VYmBreath {
     unsigned char _pad59[3];
 };
 
-static const char s_pppYmBreath_cpp[] = "pppYmBreath.cpp";
+extern "C" const char s_pppYmBreath_cpp_801DA9B0[] = "pppYmBreath.cpp";
 
 /*
  * --INFO--
@@ -427,7 +427,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
         work->m_particleData =
             (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(work->m_particleCount * 0x60),
                                                                   pppEnvStPtr->m_stagePtr,
-                                                                  const_cast<char*>(s_pppYmBreath_cpp), 0x243);
+                                                                  const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x243);
         if (work->m_particleData != NULL) {
             memset(work->m_particleData, 0, (unsigned long)(work->m_particleCount * 0x60));
         }
@@ -435,7 +435,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
         work->m_particleWmats =
             (Mtx*)pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(work->m_particleCount * 0x30),
                                                        pppEnvStPtr->m_stagePtr,
-                                                       const_cast<char*>(s_pppYmBreath_cpp), 0x249);
+                                                       const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x249);
         if (work->m_particleWmats != NULL) {
             memset(work->m_particleWmats, 0, (unsigned long)(work->m_particleCount * 0x30));
         }
@@ -443,7 +443,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
         work->m_particleColors =
             (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(work->m_particleCount << 5),
                                                                    pppEnvStPtr->m_stagePtr,
-                                                                   const_cast<char*>(s_pppYmBreath_cpp), 0x24F);
+                                                                   const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x24F);
         if (work->m_particleColors != NULL) {
             memset(work->m_particleColors, 0, (unsigned long)(work->m_particleCount << 5));
         }
@@ -452,7 +452,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
             (YmBreathParticleGroup*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                 (unsigned long)((int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14) * 0x5C),
                 pppEnvStPtr->m_stagePtr,
-                const_cast<char*>(s_pppYmBreath_cpp), 0x255);
+                const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x255);
         if (work->m_groups != NULL) {
             memset(work->m_groups, 0,
                    (unsigned long)((int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14) * 0x5C));
@@ -461,13 +461,13 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
             for (i = 0; i < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14); i++) {
                 groupTable[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                     (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12),
-                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp), 0x260);
+                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x260);
                 memset((void*)groupTable[1], 0xFF,
                        (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12));
 
                 groupTable[2] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                     (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12),
-                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp), 0x263);
+                    pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x263);
                 memset((void*)groupTable[2], 0xFF,
                        (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12));
                 groupTable[0] = 0;

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -58,7 +58,7 @@ void pppUnitMatrix__FR10pppFMATRIX(pppFMATRIX*);
 void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, u8);
 }
 
-static const char s_pppYmLaser_cpp[] = "pppYmLaser.cpp";
+extern "C" const char s_pppYmLaser_cpp_801DB4B0[] = "pppYmLaser.cpp";
 
 struct CMapCylinderRaw {
 	Vec m_bottom;
@@ -214,7 +214,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 
 	if (work->m_points == 0) {
 		work->m_points = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-			(u32)step->m_payload[0x1e] * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmLaser_cpp), 0x5d);
+			(u32)step->m_payload[0x1e] * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmLaser_cpp_801DB4B0), 0x5d);
 		memset(work->m_points, 0, (u32)step->m_payload[0x1e] * 0xc);
 		emptyHistory = 1;
 	}

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -68,7 +68,7 @@ struct Vec2d {
     float y;
 };
 
-static const char s_pppYmMana_cpp[] = "pppYmMana.cpp";
+extern "C" const char s_pppYmMana_cpp_801DB4D8[] = "pppYmMana.cpp";
 
 struct pppYmManaOffsetsRaw {
     u8 _pad0[0xc];
@@ -531,7 +531,7 @@ void pppDestructYmMana(PYmMana* ymMana, pppYmManaUnkC* param_2)
     *(u32*)(model + 0xE8) = 0;
     *(u32*)(model + 0xF0) = 0;
     *(u32*)(model + 0xFC) = 0;
-    _WaitDrawDone__8CGraphicFPci(&Graphic, const_cast<char*>(s_pppYmMana_cpp), 0x2CE);
+    _WaitDrawDone__8CGraphicFPci(&Graphic, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x2CE);
     *(u32*)(MaterialManRaw() + 0x208) = 0;
     *(u32*)(MaterialManRaw() + 0x220) = 0;
 
@@ -742,28 +742,28 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
     InitTexObj__8CTextureFv((void*)work[0x20]);
 
     if (work[0x1E] == 0) {
-        work[0x1E] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x38F);
+        work[0x1E] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x38F);
     }
     if (work[10] == 0) {
-        work[10] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x395);
+        work[10] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x395);
     }
     if (work[11] == 0) {
-        work[11] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x399);
+        work[11] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x399);
     }
 
     texBufferSize = GXGetTexBufferSize(0x80, 0x80, GX_TF_RGBA8, GX_FALSE, 0);
     if (work[12] == 0) {
-        work[12] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x3A1);
+        work[12] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3A1);
     }
     if (work[13] == 0) {
-        work[13] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x3A3);
+        work[13] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3A3);
     }
 
     GXInitTexObj((GXTexObj*)work[10], (void*)work[12], 0x80, 0x80, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
     GXInitTexObj((GXTexObj*)work[11], (void*)work[13], 0x80, 0x80, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (work[8] == 0) {
-        work[8] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x3B0);
+        work[8] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3B0);
     }
     dstBuffer = (void*)work[8];
     texList = &work[2];
@@ -776,7 +776,7 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
     }
 
     if (work[9] == 0) {
-        work[9] = (u32)pppMemAlloc(0xA5E8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x3CB);
+        work[9] = (u32)pppMemAlloc(0xA5E8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3CB);
         genParaboloidMap__FPvPUlUs9_GXVtxFmt((void*)work[9], &work[0x3B], 0x1E, GX_VTXFMT7);
     }
 
@@ -792,30 +792,30 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
                 if (work[0x19] == 0) {
                     work[0x19] =
                         (u32)pppMemAlloc(*(s32*)(meshShape + 0x14) * 0xC, pppEnvStPtr->m_stagePtr,
-                                         const_cast<char*>(s_pppYmMana_cpp), 1000);
+                                         const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 1000);
                     memset((void*)work[0x19], 0, *(s32*)(meshShape + 0x14) * 0xC);
                 }
                 if (work[0x1A] == 0) {
                     work[0x1A] =
                         (u32)pppMemAlloc(*(s32*)(meshShape + 0x14) << 2, pppEnvStPtr->m_stagePtr,
-                                         const_cast<char*>(s_pppYmMana_cpp), 0x3F1);
+                                         const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3F1);
                     memset((void*)work[0x1A], 0xFF, *(s32*)(meshShape + 0x14) << 2);
                 }
                 if (work[0x1B] == 0) {
                     s32 texCoordSize = *(s32*)(meshShape + 0x14) * 6;
-                    work[0x1B] = (u32)pppMemAlloc(texCoordSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x3FA);
-                    work[0x1C] = (u32)pppMemAlloc(texCoordSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x3FB);
+                    work[0x1B] = (u32)pppMemAlloc(texCoordSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3FA);
+                    work[0x1C] = (u32)pppMemAlloc(texCoordSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3FB);
                     memset((void*)work[0x1B], 0, texCoordSize);
                     memset((void*)work[0x1C], 0, texCoordSize);
                 }
 
                 work[0x18] = (u32)pppMemAlloc(*(s32*)(meshShape + 0x4C) << 2, pppEnvStPtr->m_stagePtr,
-                                              const_cast<char*>(s_pppYmMana_cpp), 0x407);
+                                              const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x407);
                 u32* dlInfo = *(u32**)(meshShape + 0x50);
                 s32 dlOffset = (*(s32*)(meshShape + 0x4C) - 1) * 4;
                 for (s32 dlIndex = *(s32*)(meshShape + 0x4C) - 1; dlIndex >= 0; dlIndex--) {
                     *(u32*)(work[0x18] + dlOffset) =
-                        (u32)pppMemAlloc(dlInfo[0], pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x411);
+                        (u32)pppMemAlloc(dlInfo[0], pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x411);
                     *(u32*)(work[0x18] + dlOffset) = (*(u32*)(work[0x18] + dlOffset) + 0x1F) & 0xFFFFFFE0;
                     work[0x3C] = dlInfo[0];
                     memcpy((void*)*(u32*)(work[0x18] + dlOffset), (void*)dlInfo[1], dlInfo[0]);
@@ -828,15 +828,15 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
 
             if (((type == 1) && strcmp((char*)meshShape, DAT_80330ea0) == 0) ||
                 ((type == 2) && strcmp((char*)meshShape, DAT_80330ea8) == 0)) {
-                work[0xF] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x427);
-                work[0x10] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x428);
-                work[0x17] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x429);
-                work[0x15] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x42A);
-                work[0x16] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x42B);
-                work[0x12] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x42C);
-                work[0x13] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x42D);
-                work[0x14] = (u32)pppMemAlloc(0xC00, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x42E);
-                work[0x11] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp), 0x42F);
+                work[0xF] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x427);
+                work[0x10] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x428);
+                work[0x17] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x429);
+                work[0x15] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x42A);
+                work[0x16] = (u32)pppMemAlloc(0x908, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x42B);
+                work[0x12] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x42C);
+                work[0x13] = (u32)pppMemAlloc(0x484, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x42D);
+                work[0x14] = (u32)pppMemAlloc(0xC00, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x42E);
+                work[0x11] = (u32)pppMemAlloc(0xD8C, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x42F);
                 memset((void*)work[0x12], 0, 0x484);
                 memset((void*)work[0x13], 0, 0x484);
                 CreateWaterMesh((Vec*)work[0xF], (Vec*)work[0x10], (Vec2d*)work[0x15], (unsigned short*)work[0x14],


### PR DESCRIPTION
## Summary
- Promotes eight PPP filename strings from local statics to their mapped PAL symbol names.
- Updates allocation/debug callsites to reference the recovered symbols directly.

## Evidence
- `ninja` passes and rebuilds `main.dol` with SHA OK.
- Objdiff now resolves these strings as 100% matched target symbols:
  - `s_pppBreathModel_cpp_801DB5A0`
  - `s_pppMana2_cpp_801DC4E0`
  - `s_pppVtMime_cpp`
  - `s_pppRyjMegaBirth_cpp_801D9C00`
  - `s_pppYmMana_cpp_801DB4D8`
  - `s_pppYmBreath_cpp_801DA9B0`
  - `s_pppLaser_cpp_801E3048`
  - `s_pppYmLaser_cpp_801DB4B0`

## Plausibility
These are existing filename literals passed to allocator/debug helpers; using the map-backed symbol names recovers linkage without changing control flow or generated code.
