### PR TITLE
Improve pppKeShpTail3X random scale expression

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -270,7 +270,7 @@ draw_loop:
         if (step->m_useRandomShape != 0) {
             u32 lcg = (u32)rng * 0x80du + 7u;
             rng = (u16)lcg;
-            drawScale *= kPppKeShpTail3XOne - (((float)rng / kPppKeShpTail3XRandomMax) * step->m_randomScale);
+            drawScale *= -(((float)rng / kPppKeShpTail3XRandomMax) * step->m_randomScale - kPppKeShpTail3XOne);
             {
                 u32 shapeIdx = (u32)(life + rng) / shapeSetCount;
                 shapeEntry = (long*)(shapeData + *(s16*)(shapeData + (shapeIdx % (u32)shapeCount) * 8 + 0x10));


### PR DESCRIPTION
## Summary
- Rewrite the random tail scale expression in `pppKeShpTail3XDraw` as the equivalent negated difference form used by the target code shape.
- This restores the target ordering of the `65535.0f` and `1.0f` constants in `pppKeShpTail3X` `.sdata2`.

## Evidence
- `ninja` passes.
- `main/pppKeShpTail3X` `.sdata2` improves from `77.77778%` to `88.88889%` in objdiff report.
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o /tmp/pppKeShpTail3X.final.json` reports `.sdata2 32 88.88889`.

## Plausibility
- The expression is algebraically equivalent to the prior source: `1.0f - x` becomes `-(x - 1.0f)`.
- The rewritten form matches the target constant layout without adding fake symbols, manual sections, or address-based hacks.
