### PR TITLE
Recover map object attr constructors

### DIFF
--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -26,7 +26,11 @@ class CMapObjAtr
 public:
     enum TYPE
     {
-        TODO,
+        SPOT_LIGHT = 0,
+        POINT_LIGHT = 1,
+        MIME = 2,
+        MESH_NAME = 3,
+        PLAY_STA = 4,
     };
     
     CMapObjAtr();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1746,7 +1746,7 @@ void CMapMng::AttachMapHit(CMapHit* mapHit, char* mapHitName)
 
         if (mapObj < mapObjEnd) {
             do {
-                if (mapObj->attr != 0 && mapObj->attr->type == 3) {
+                if (mapObj->attr != 0 && mapObj->attr->type == CMapObjAtr::MESH_NAME) {
                     goto found;
                 }
                 mapObj++;
@@ -1793,7 +1793,7 @@ int CMapMng::GetDebugPlaySta(int playStaNo, Vec* vec)
 
     while (mapObj < mapObjEnd) {
         unsigned char* mapObjAtr = *reinterpret_cast<unsigned char**>(mapObj + 0xEC);
-        if (mapObjAtr != 0 && *reinterpret_cast<int*>(mapObjAtr + 4) == 4 &&
+        if (mapObjAtr != 0 && *reinterpret_cast<int*>(mapObjAtr + 4) == CMapObjAtr::PLAY_STA &&
             *(mapObjAtr + 8) == static_cast<unsigned char>(playStaNo)) {
             vec->x = *reinterpret_cast<float*>(mapObj + 0xC4);
             vec->y = *reinterpret_cast<float*>(mapObj + 0xD4);
@@ -1830,7 +1830,7 @@ void CMapMng::SetLightSource()
         if (atr != 0) {
             const int type = *reinterpret_cast<int*>(atr + 4);
 
-            if (type == 1) {
+            if (type == CMapObjAtr::POINT_LIGHT) {
                 if (*reinterpret_cast<int*>(atr + 0x34) == 0) {
                     CLightPcs::CLight light;
                     light.m_type = 1;
@@ -1895,7 +1895,7 @@ void CMapMng::SetLightSource()
                     PSVECNormalize(reinterpret_cast<Vec*>(&light->m_direction), reinterpret_cast<Vec*>(&light->m_direction));
                 }
                 mapLightIndex += 1;
-            } else if (type == 0) {
+            } else if (type == CMapObjAtr::SPOT_LIGHT) {
                 CLightPcs::CLight light;
                 light.m_type = 0;
                 light.m_position.x = *reinterpret_cast<float*>(mapObj + 0xC4);
@@ -2452,7 +2452,7 @@ void CMapMng::ReadOtm(char* mapName)
         if (atr == 0) {
             continue;
         }
-        if (*reinterpret_cast<int*>(atr + 4) != 1 || *reinterpret_cast<int*>(atr + 0x34) == 0) {
+        if (*reinterpret_cast<int*>(atr + 4) != CMapObjAtr::POINT_LIGHT || *reinterpret_cast<int*>(atr + 0x34) == 0) {
             continue;
         }
 
@@ -3490,7 +3490,7 @@ found:
     unsigned char* mapObj = reinterpret_cast<unsigned char*>(this) + (objIndex * 0xF0) + 0x954;
     unsigned char* mapObjLight = *reinterpret_cast<unsigned char**>(mapObj + 0xEC);
 
-    if (*reinterpret_cast<int*>(mapObjLight + 4) == 1) {
+    if (*reinterpret_cast<int*>(mapObjLight + 4) == CMapObjAtr::POINT_LIGHT) {
         const unsigned char* colorBytes = reinterpret_cast<const unsigned char*>(&packedColor);
         *reinterpret_cast<unsigned char*>(mapObjLight + 8) = colorBytes[0];
         *reinterpret_cast<unsigned char*>(mapObjLight + 9) = colorBytes[1];

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -21,6 +21,7 @@ extern const float kMapObjInitNegOne;
 extern const float kMapObjDegToRad;
 extern const float kMapObjInitValue50;
 unsigned int DAT_8032e498 = 0xFFFFFFFF;
+extern "C" void __ct__12CMapKeyFrameFv(CMapKeyFrame*);
 extern "C" int IsRun__12CMapKeyFrameFv(CMapKeyFrame*);
 extern "C" int Get__12CMapKeyFrameFRiRiRf(CMapKeyFrame*, int*, int*, float*);
 extern "C" void Calc__12CMapKeyFrameFv(CMapKeyFrame*);
@@ -34,6 +35,43 @@ static inline unsigned char* Ptr(CMapObj* self, unsigned int offset)
 {
     return reinterpret_cast<unsigned char*>(self) + offset;
 }
+
+struct MapObjAttrBaseLayout
+{
+    void* vtable;
+    int type;
+};
+
+struct MapObjAttrPlayStaLayout
+{
+    void* vtable;
+    int type;
+    unsigned char playStaNo;
+    unsigned char pad09[3];
+};
+
+struct MapObjAttrMimeLayout
+{
+    void* vtable;
+    int type;
+    unsigned char vertexListCount;
+    unsigned char pad09[3];
+    void* vertexLists;
+    int vertexCount;
+    CMapKeyFrame keyFrame;
+};
+
+struct MapObjAttrMeshNameLayout
+{
+    void* vtable;
+    int type;
+    char name[0x20];
+};
+
+STATIC_ASSERT(sizeof(MapObjAttrBaseLayout) == 0x8);
+STATIC_ASSERT(sizeof(MapObjAttrPlayStaLayout) == 0xC);
+STATIC_ASSERT(sizeof(MapObjAttrMimeLayout) == 0x3C);
+STATIC_ASSERT(sizeof(MapObjAttrMeshNameLayout) == 0x28);
 
 static inline void*& PtrAt(CMapObj* self, unsigned int offset)
 {
@@ -422,7 +460,7 @@ void CMapObj::ReadOtmObj(CChunkFile& chunkFile)
 
             if (mime != 0) {
                 reinterpret_cast<CMapObjAtrMime*>(mime)->CMapObjAtrMime::CMapObjAtrMime();
-                *reinterpret_cast<int*>(mime + 0x4) = 2;
+                *reinterpret_cast<int*>(mime + 0x4) = CMapObjAtr::MIME;
                 *reinterpret_cast<void**>(mime + 0xC) = 0;
                 *reinterpret_cast<int*>(mime + 0x10) = 0;
                 *reinterpret_cast<int*>(mime + 0x14) = 0;
@@ -926,7 +964,7 @@ void CMapObj::Calc()
     int attr = S32At(this, 0xEC);
     if (attr != 0) {
         int attrType = *reinterpret_cast<int*>(attr + 4);
-        if (attrType == 1) {
+        if (attrType == CMapObjAtr::POINT_LIGHT) {
             _GXColor& colorCurrent = *reinterpret_cast<_GXColor*>(attr + 8);
             _GXColor* colorTable = reinterpret_cast<_GXColor*>(attr + 0x40);
 
@@ -936,8 +974,7 @@ void CMapObj::Calc()
             }
 
             calcColorKeyFrame(reinterpret_cast<CMapKeyFrame*>(attr + 0xE8), colorCurrent, colorTable);
-        } else if (attrType < 1) {
-            if (attrType >= 0) {
+        } else if (attrType == CMapObjAtr::SPOT_LIGHT) {
                 _GXColor& colorCurrent = *reinterpret_cast<_GXColor*>(attr + 8);
                 _GXColor* colorTable = reinterpret_cast<_GXColor*>(attr + 0x24);
 
@@ -947,8 +984,8 @@ void CMapObj::Calc()
                 }
 
                 calcColorKeyFrame(reinterpret_cast<CMapKeyFrame*>(attr + 0xCC), colorCurrent, colorTable);
-            }
-        } else if ((attrType < 3) && (IsRun__12CMapKeyFrameFv(reinterpret_cast<CMapKeyFrame*>(attr + 0x14)) != 0)) {
+        } else if ((attrType == CMapObjAtr::MIME) &&
+                   (IsRun__12CMapKeyFrameFv(reinterpret_cast<CMapKeyFrame*>(attr + 0x14)) != 0)) {
             int key0 = 0;
             int key1 = 0;
             float blend = 0.0f;
@@ -1537,7 +1574,10 @@ static inline void FreeAndClear(void* base, unsigned int offset)
  */
 CMapObjAtrPlaySta::CMapObjAtrPlaySta()
 {
-	// TODO
+    MapObjAttrPlayStaLayout* self = reinterpret_cast<MapObjAttrPlayStaLayout*>(this);
+
+    self->type = CMapObjAtr::PLAY_STA;
+    self->playStaNo = 0;
 }
 
 /*
@@ -1547,7 +1587,7 @@ CMapObjAtrPlaySta::CMapObjAtrPlaySta()
  */
 CMapObjAtr::CMapObjAtr()
 {
-	// TODO
+    reinterpret_cast<MapObjAttrBaseLayout*>(this)->type = -1;
 }
 
 /*
@@ -1557,7 +1597,13 @@ CMapObjAtr::CMapObjAtr()
  */
 CMapObjAtrMime::CMapObjAtrMime()
 {
-	// TODO
+    MapObjAttrMimeLayout* self = reinterpret_cast<MapObjAttrMimeLayout*>(this);
+
+    self->type = CMapObjAtr::MIME;
+    self->vertexListCount = 0;
+    self->vertexLists = 0;
+    self->vertexCount = 0;
+    __ct__12CMapKeyFrameFv(reinterpret_cast<CMapKeyFrame*>(reinterpret_cast<unsigned char*>(this) + 0x14));
 }
 
 /*
@@ -1577,7 +1623,10 @@ void CMapObj::SetCalcMtx()
  */
 CMapObjAtrMeshName::CMapObjAtrMeshName()
 {
-	// TODO
+    MapObjAttrMeshNameLayout* self = reinterpret_cast<MapObjAttrMeshNameLayout*>(this);
+
+    self->type = CMapObjAtr::MESH_NAME;
+    memset(self->name, 0, sizeof(self->name));
 }
 
 /*


### PR DESCRIPTION
## Summary
- recover `CMapObjAtr`, `CMapObjAtrPlaySta`, `CMapObjAtrMime`, and `CMapObjAtrMeshName` constructor initialization in `mapobj.cpp`
- add recovered `CMapObjAtr::TYPE` values and replace raw attr-type literals in `map.cpp`/`mapobj.cpp`
- initialize MIME attr storage coherently, including embedded `CMapKeyFrame` construction and mesh-name buffer clearing

## Evidence
- `ninja build/GCCP01/src/map.o build/GCCP01/src/mapobj.o build/GCCP01/report.json`
- current report: `main/mapobj` fuzzy `45.582447`, `main/map` fuzzy `56.068977`
- baseline `origin/main` constructor assembly for `__ct__17CMapObjAtrPlayStaFv`, `__ct__14CMapObjAtrMimeFv`, and `__ct__18CMapObjAtrMeshNameFv` was just vtable setup; the rebuilt object now also writes recovered attr type fields, zeros play-sta / mesh-name state, and constructs the embedded MIME `CMapKeyFrame`

## Plausibility
These changes replace stub constructors with coherent class initialization that matches existing callsites which already read attr type fields and depend on MIME / mesh-name storage being initialized.