### PR TITLE
Improve CGCharaObj onCancelStat control flow

### DIFF
--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -509,27 +509,30 @@ void CGCharaObj::onChangeStat(int state)
 void CGCharaObj::onCancelStat(int)
 {
 	int state = m_lastStateId;
-	int* slots = m_particleSlots;
 
-	if (state == 6) {
+	if (state != 6) {
+		if (state < 6) {
+			if (state == 2) {
+				for (int i = 0; i < 0x16; i++) {
+					if (((1U << i) & 0x18U) != 0) {
+						EndParticleSlot__13CFlatRuntime2Fii(CFlat, m_particleSlots[i], 1);
+					}
+				}
+			}
+		} else if (state == 0x12) {
+			for (int i = 0; i < 0x16; i++) {
+				if (((1U << i) & 1U) != 0) {
+					EndParticleSlot__13CFlatRuntime2Fii(CFlat, m_particleSlots[i], 1);
+				}
+			}
+		}
+	} else {
 		for (int i = 0; i < 0x16; i++) {
 			if (((1U << i) & 0x138U) != 0) {
-				EndParticleSlot__13CFlatRuntime2Fii(CFlat, slots[i], 1);
+				EndParticleSlot__13CFlatRuntime2Fii(CFlat, m_particleSlots[i], 1);
 			}
 		}
 		m_damageParticle = -1;
-	} else if (state == 2) {
-		for (int i = 0; i < 0x16; i++) {
-			if (((1U << i) & 0x18U) != 0) {
-				EndParticleSlot__13CFlatRuntime2Fii(CFlat, slots[i], 1);
-			}
-		}
-	} else if (state == 0x12) {
-		for (int i = 0; i < 0x16; i++) {
-			if (((1U << i) & 1U) != 0) {
-				EndParticleSlot__13CFlatRuntime2Fii(CFlat, slots[i], 1);
-			}
-		}
 	}
 
 	m_comboFrame = 0;


### PR DESCRIPTION
## Summary
- Reworked CGCharaObj::onCancelStat to follow the original state comparison structure for state 6, state 2, and state 0x12 handling.
- Removed the temporary particle-slot pointer so loop bodies use direct member access for particle slots.

## Evidence
- Built with `ninja` successfully.
- `build/tools/objdiff-cli diff -p . -u main/charaobj -o - onCancelStat__10CGCharaObjFi`:
  - Before: `.text` 34.831078%
  - After: `.text` 35.76212%

## Plausibility
- The control flow now matches the decompiled original branch shape more closely without introducing address hacks or fake symbols.
- Particle slot access is expressed through the class member rather than a detached pointer.