### PR TITLE
Improve CGPrgObj target rotation delta

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -435,14 +435,16 @@ void CGPrgObj::putParticleBindTrace(int no, int dataNo, CGObject* obj, float sca
 float CGPrgObj::getTargetRot(CGPrgObj* target)
 {
 	float targetRot;
+	float zero;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(m_worldPosition);
-	Vec deltaPos;
 	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
+	CVector deltaPos;
 
-	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), &deltaPos);
-	if (deltaPos.x == FLOAT_80331BD4 || deltaPos.z == FLOAT_80331BD4) {
-		targetRot = 0.0f;
+	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	zero = FLOAT_80331BD4;
+	if (deltaPos.x == zero || deltaPos.z == zero) {
+		targetRot = zero;
 	} else {
 		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 	}


### PR DESCRIPTION
## Summary
- Use a real CVector delta in CGPrgObj::getTargetRot so the generated code includes the expected CVector default construction.
- Reuse the shared zero constant through a local zero value instead of a raw 0.0f assignment.

## Evidence
- ninja: build/GCCP01/main.dol OK
- main/prgobj .text fuzzy: 96.22407%
- getTargetRot__8CGPrgObjFP8CGPrgObj: size 144, fuzzy 85.19444%

## Plausibility
- Ghidra shows getTargetRot constructing a CVector work vector before PSVECSubtract; this source now models that directly instead of using a raw Vec scratch.
- No manual vtable, ctor/dtor, section, or address hacks.