### PR TITLE
Improve memory heap and emission matching

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1288,6 +1288,8 @@ void CMemory::CStage::drawHeapBar(int y)
                         } else {
                             color = 0x400080;
                         }
+                    } else if (stageGetAllocationMode(this) == 0) {
+                        color = colors[drawColor];
                     } else {
                         color = colors[drawColor];
                     }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1397,18 +1397,10 @@ void CMemory::CStage::drawHeapTitle(int y)
             int srcLen = strlen(sourceName);
             strcpy(line, sourceName + ((srcLen - 12U) & ~((srcLen - 12U) >> 31)));
             Graphic.DrawDebugStringDirect(0x10, static_cast<unsigned short>(y), line, 8);
-            int maxRound = 0;
-            if ((static_cast<int>(maxUnuse) < 0) && ((maxUnuse & 0x3ff) != 0)) {
-                maxRound = 1;
-            }
-            int totalRound = 0;
-            if ((static_cast<int>(totalUnuse) < 0) && ((totalUnuse & 0x3ff) != 0)) {
-                totalRound = 1;
-            }
 
             sprintf(line, s_drawHeapTitleFmt, *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x124),
-                    (static_cast<int>(totalUnuse) >> 10) + totalRound, (static_cast<int>(maxUnuse) >> 10) + maxRound);
-            Graphic.DrawDebugStringDirect(0x208, y, line, 8);
+                    static_cast<int>(totalUnuse) / 1024, static_cast<int>(maxUnuse) / 1024);
+            Graphic.DrawDebugStringDirect(0x208, static_cast<unsigned short>(y), line, 8);
             return;
         }
 

--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -372,16 +372,21 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
         pppSetBlendMode(step->m_payload[8]);
         *(int*)(MaterialManRaw() + 0xD0) = texture + 0x28;
 
+        Mtx viewMtx0;
+        Mtx objMtx0;
+        Mtx viewMtx1;
+        Mtx objMtx1;
+        Mtx texMtx0;
+        Mtx texMtx1;
+
         if (step->m_payload[9] == 0) {
             for (int i = 0; i < step->m_initWOrk; i++) {
                 float scale = FLOAT_803311e4;
                 scale += (float)i * state->m_scale0;
-                Mtx viewMtx;
-                Mtx objMtx;
-                PSMTXScale(objMtx, scale, scale, scale);
-                PSMTXConcat(param_5, objMtx, objMtx);
-                PSMTXCopy(CameraMatrix(), viewMtx);
-                SetObjMatrix__12CMaterialManFPA4_fPA4_f(&MaterialMan, viewMtx, objMtx);
+                PSMTXScale(objMtx0, scale, scale, scale);
+                PSMTXConcat(param_5, objMtx0, objMtx0);
+                PSMTXCopy(CameraMatrix(), viewMtx0);
+                SetObjMatrix__12CMaterialManFPA4_fPA4_f(&MaterialMan, viewMtx0, objMtx0);
 
                 int remaining = meshData->m_displayListCount - 1;
                 EmissionDisplayList* displayList = meshData->m_displayLists;
@@ -411,9 +416,8 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     if (step->m_payload[10] == 0) {
                         GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);
                     } else {
-                        Mtx texMtx;
-                        PSMTXCopy((float(*)[4])(MaterialManRaw() + 0xE8), texMtx);
-                        GXLoadTexMtxImm(texMtx, 0x1E, GX_MTX3x4);
+                        PSMTXCopy((float(*)[4])(MaterialManRaw() + 0xE8), texMtx0);
+                        GXLoadTexMtxImm(texMtx0, 0x1E, GX_MTX3x4);
                         if (step->m_payload[10] == 1) {
                             GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)0, (GXTexGenSrc)0, 0x1E, GX_FALSE, 0x7D);
                         } else if (step->m_payload[10] == 2) {
@@ -432,13 +436,11 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
             EmissionParticle* particle = (EmissionParticle*)state->m_particles;
             for (int i = 0; i < step->m_initWOrk; i++) {
                 float scale = particle->m_scale;
-                Mtx objMtx;
-                Mtx viewMtx;
-                PSMTXScale(objMtx, scale, scale, scale);
-                PSMTXConcat(param_5, objMtx, objMtx);
-                PSMTXCopy(CameraMatrix(), viewMtx);
-                PSMTXConcat(viewMtx, objMtx, objMtx);
-                GXLoadPosMtxImm(objMtx, 0);
+                PSMTXScale(objMtx1, scale, scale, scale);
+                PSMTXConcat(param_5, objMtx1, objMtx1);
+                PSMTXCopy(CameraMatrix(), viewMtx1);
+                PSMTXConcat(viewMtx1, objMtx1, objMtx1);
+                GXLoadPosMtxImm(objMtx1, 0);
 
                 int remaining = meshData->m_displayListCount - 1;
                 EmissionDisplayList* displayList = meshData->m_displayLists;
@@ -468,9 +470,8 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     if (step->m_payload[10] == 0) {
                         GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);
                     } else {
-                        Mtx texMtx;
-                        PSMTXCopy((float(*)[4])(MaterialManRaw() + 0xE8), texMtx);
-                        GXLoadTexMtxImm(texMtx, 0x1E, GX_MTX3x4);
+                        PSMTXCopy((float(*)[4])(MaterialManRaw() + 0xE8), texMtx1);
+                        GXLoadTexMtxImm(texMtx1, 0x1E, GX_MTX3x4);
                         if (step->m_payload[10] == 1) {
                             GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)0, (GXTexGenSrc)0, 0x1E, GX_FALSE, 0x7D);
                         } else if (step->m_payload[10] == 2) {


### PR DESCRIPTION
## Summary
- simplify heap title size formatting back to signed division, improving drawHeapTitle matching
- restore the allocation-mode branch shape for heap bar color selection, improving drawHeapBar matching
- hoist emission callback matrix temporaries to match the target stack layout more closely

## Objdiff evidence
- main/memory drawHeapTitle__Q27CMemory6CStageFi: 13.40404% -> 27.747475%
- main/memory drawHeapBar__Q27CMemory6CStageFi: 17.32353% -> 19.75%
- main/pppEmission Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f: 94.52631% -> 94.539474%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_final.json drawHeapBar__Q27CMemory6CStageFi
- build/tools/objdiff-cli diff -p . -u main/pppEmission -o /tmp/pppEmission_final.json Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f

These changes follow the decompiled control flow and normal C source forms rather than adding address or section hacks.