### PR TITLE
TRK: link set-option serial strings via rodata symbol

### DIFF
--- a/src/TRK_MINNOW_DOLPHIN/msghndlr.c
+++ b/src/TRK_MINNOW_DOLPHIN/msghndlr.c
@@ -4,6 +4,8 @@
 #include "PowerPC_EABI_Support/MetroTRK/trk.h"
 #include <string.h>
 
+const char lbl_801E6868[] = "\nMetroTRK Option : SerialIO - \0Enable\n\0Disable\n";
+
 /* 8044F288-8044F290 07BFA8 0004+04 4/4 0/0 0/0 .bss             IsTRKConnected */
 BOOL IsTRKConnected;
 
@@ -517,13 +519,14 @@ DSError TRKDoStop(TRKBuffer* b) {
 /* 8036DD14-8036DDBC 368654 00A8+00 0/0 1/1 0/0 .text            TRKDoSetOption */
 DSError TRKDoSetOption(TRKBuffer* message) {
     u8 enable = message->data[0xc];
+    const char* optionText = lbl_801E6868;
 
     if (message->data[0x8] == '\1') {
-        usr_puts_serial("\nMetroTRK Option : SerialIO - ");
+        usr_puts_serial(optionText);
         if (enable) {
-            usr_puts_serial("Enable\n");
+            usr_puts_serial(optionText + 0x20);
         } else {
-            usr_puts_serial("Disable\n");
+            usr_puts_serial(optionText + 0x28);
         }
         SetUseSerialIO(enable);
     }


### PR DESCRIPTION
## Summary
- give `TRKDoSetOption` a named shared rodata object for the serial option strings
- switch the function to index into `lbl_801E6868` instead of emitting anonymous local string references
- keep the strings in `msghndlr.c` so the symbol is defined and linkable in the current tree

## Evidence
- before this change, `build/binutils/powerpc-eabi-objdump -r build/GCCP01/src/TRK_MINNOW_DOLPHIN/msghndlr.o` showed the `TRKDoSetOption` text relocations at offsets `0x0000000a` and `0x00000016` targeting `...rodata.0`
- after this change, those same relocations target `lbl_801E6868`
- `build/binutils/powerpc-eabi-nm -n build/GCCP01/obj/TRK_MINNOW_DOLPHIN/msghndlr.o` now shows `00000000 R lbl_801E6868`, confirming the named rodata symbol is defined in the rebuilt object

## Validation
- rebuilt `build/GCCP01/src/TRK_MINNOW_DOLPHIN/msghndlr.o`
- ran full `ninja`; compile and link completed through `main.dol`, and the final `build.sha1` check failed as expected because the binary changed