### PR TITLE
Match pppKeShpTail3X stack layout

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -402,8 +402,10 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
 {
     KeShpTail3XStep* step;
     KeShpTail3XWork* work;
-    Vec pos;
+    pppFMATRIX outMatrix;
     Vec historyPos ATTRIBUTE_ALIGN(8);
+    Vec initPos ATTRIBUTE_ALIGN(8);
+    Vec pos ATTRIBUTE_ALIGN(8);
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -416,19 +418,17 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
         work->m_initialized = 1;
 
         if (step->m_worldSpaceMode == 0) {
-            pos.x = obj->pppPObject.m_localMatrix.value[0][3];
-            pos.y = obj->pppPObject.m_localMatrix.value[1][3];
-            pos.z = obj->pppPObject.m_localMatrix.value[2][3];
+            initPos.x = obj->pppPObject.m_localMatrix.value[0][3];
+            initPos.y = obj->pppPObject.m_localMatrix.value[1][3];
+            initPos.z = obj->pppPObject.m_localMatrix.value[2][3];
         } else if (step->m_worldSpaceMode == 1) {
-            pppFMATRIX outMatrix;
-
             pppMulMatrix(outMatrix, pppMngStPtr->m_matrix, obj->pppPObject.m_localMatrix);
-            pos.x = outMatrix.value[0][3];
-            pos.y = outMatrix.value[1][3];
-            pos.z = outMatrix.value[2][3];
+            initPos.x = outMatrix.value[0][3];
+            initPos.y = outMatrix.value[1][3];
+            initPos.z = outMatrix.value[2][3];
         }
 
-        pppCopyVector(historyPos, pos);
+        pppCopyVector(historyPos, initPos);
         Vec* history = work->m_posHistory;
         s32 i = 0x1c;
         do {
@@ -448,8 +448,6 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
         pos.y = obj->pppPObject.m_localMatrix.value[1][3];
         pos.z = obj->pppPObject.m_localMatrix.value[2][3];
     } else if (step->m_worldSpaceMode == 1) {
-        pppFMATRIX outMatrix;
-
         pppMulMatrix(outMatrix, pppMngStPtr->m_matrix, obj->pppPObject.m_localMatrix);
         pos.x = outMatrix.value[0][3];
         pos.y = outMatrix.value[1][3];


### PR DESCRIPTION
## Summary
- move `pppKeShpTail3X` onto the original stack/layout shape by hoisting `outMatrix` and separating `initPos` from the per-frame `pos`
- keep the existing behavior while matching the init-history copy path to the original function structure

## Evidence
- `ninja -j6` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o - pppKeShpTail3X` improved from `99.79156%` to `100.0%`
- project progress moved from `2978 / 4732` matched functions to `2979 / 4732`

## Why this is plausible source
- the change mirrors the already-matched `pppKeShpTail2X` initialization/update structure instead of using compiler coaxing
- it uses normal top-level temporaries to match the original stack frame and matrix copy flow rather than introducing hacks or fake linkage