### PR TITLE
Match BreathModel constructor zero load

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -170,10 +170,8 @@ extern "C" void pppDestructBreathModel(pppBreathModel* pppBreathModel, pppBreath
 extern "C" void pppConstructBreathModel(pppBreathModel* pppBreathModel, pppBreathModelUnkC* param_2)
 {
     VBreathModel* state = (VBreathModel*)((unsigned char*)pppBreathModel + 0x80 + *param_2->m_serializedDataOffsets);
-    float zero;
-
     PSMTXIdentity(state->m_matrix);
-    zero = 0.0f;
+    const float& zero = kPppBreathModelZero;
 
     state->m_direction.z = zero;
     state->m_direction.y = zero;


### PR DESCRIPTION
## Summary
- Update pppConstructBreathModel to reuse the shared BreathModel zero constant.
- This makes the constructor emit the target load from kPppBreathModelZero instead of an anonymous pooled zero.

## Evidence
- Before: pppConstructBreathModel was 99.833336% matched, size 120.
- After: pppConstructBreathModel is 100.0% matched, size 120.
- Verified with: ninja
- Verified with: build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o /tmp/breath_pr_evidence.json pppConstructBreathModel

## Plausibility
- The unit already owns kPppBreathModelZero in .sdata2; using it for the constructor zero keeps the source tied to the unit's existing constant layout rather than introducing a new literal.