### PR TITLE
Improve pppBreathModel particle clamp matching

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -783,14 +783,13 @@ extern "C" void UpdateParticle__FP12VBreathModelP12PBreathModelP13PARTICLE_DATAP
     unsigned char clampScale = *(unsigned char*)(breath + 0xC8);
     if (clampScale == 0) {
         float zero = kPppBreathModelZero;
-        float start = *(float*)(breath + 0xA0);
-        if (zero < start) {
+        if (zero < *(float*)(breath + 0xA0)) {
             if (*(float*)(breath + 0xA4) < zero) {
                 if (particle[11].z < zero) {
                     particle[11].z = zero;
                 }
             }
-        } else if (start < zero) {
+        } else if (*(float*)(breath + 0xA0) < zero) {
             if ((zero < *(float*)(breath + 0xA4)) && (zero < particle[11].z)) {
                 particle[11].z = zero;
             }


### PR DESCRIPTION
## Summary
- Reshape the `UpdateParticle` scale-clamp branch to compare against the start scale directly instead of keeping a separate local.
- This matches the target branch shape more closely without changing behavior.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o /tmp/breath_pr_evidence.json --format json`
- `UpdateParticle__FP12VBreathModelP12PBreathModelP13PARTICLE_DATAP6VColorP14PARTICLE_COLOR`: 98.680855% -> 99.14893%.
- No other `pppBreathModel` symbol regressions in the unit diff.