### PR TITLE
Improve maptexanim CPtrArray linkage

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -1,3 +1,4 @@
+#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/maptexanim.h"
 #include "ffcc/chunkfile.h"
 #include "ffcc/map.h"


### PR DESCRIPTION
## Summary
- define `FFCC_PTRARRAY_DECL_ONLY` before `maptexanim.h` in `src/maptexanim.cpp`
- keep `CMapTexAnim` logic unchanged while forcing this TU to reuse existing `CPtrArray` implementations
- improve `main/maptexanim` exception table/linkage matching without compiler-coaxing logic changes

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/maptexanim -o -`
- before: `extab` 83.33333%, `extabindex` 81.94444%, `.text` 95.39056%
- after: `extab` 100.0%, `extabindex` 98.333336%, `.text` 95.39056%
- overall build progress increased by 40 matched game data bytes after the change

## Plausibility
- this matches how other translation units consume `CPtrArray` declarations and avoids redundant local template linkage in `maptexanim.o`
- the source behavior of `CMapTexAnim` is unchanged; this is a linkage/layout correction, not output-forcing source distortion