### PR TITLE
Refine p_MaterialEditor static initialization

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -24,8 +24,8 @@ extern "C" void destroyViewer__18CMaterialEditorPcsFv(CMaterialEditorPcs*);
 extern "C" void calcViewer__18CMaterialEditorPcsFv(CMaterialEditorPcs*);
 extern "C" void drawViewer__18CMaterialEditorPcsFv(CMaterialEditorPcs*);
 extern "C" void __dt__18CMaterialEditorPcsFv(void* self);
-extern "C" char __vt__8CManager[];
-extern "C" char __vt_CProcess[];
+extern "C" void* __vt__8CManager[];
+extern "C" void* __vt__8CProcess[];
 extern "C" char lbl_8032E648[];
 extern "C" const char s_CMaterialEditorPcs_VIEWER_801D7D18[];
 extern "C" const char s_CMaterialEditorPcs_801D7D34[];
@@ -47,26 +47,48 @@ unsigned int m_table__18CMaterialEditorPcs[0x15C / sizeof(unsigned int)] = {
 unsigned int lbl_801EA624[3] = {reinterpret_cast<unsigned int>(lbl_8032E648), 0, 0};
 unsigned int lbl_801EA630 = reinterpret_cast<unsigned int>(lbl_8032E648);
 CMaterialEditorPcs MaterialEditorPcs;
+u8 lbl_8026D338[0xC];
 
-struct MaterialEditorTableInit {
-    MaterialEditorTableInit()
-    {
-        m_table__18CMaterialEditorPcs[1] = m_table_desc0__18CMaterialEditorPcs[0];
-        m_table__18CMaterialEditorPcs[2] = m_table_desc0__18CMaterialEditorPcs[1];
-        m_table__18CMaterialEditorPcs[3] = m_table_desc0__18CMaterialEditorPcs[2];
-        m_table__18CMaterialEditorPcs[4] = m_table_desc1__18CMaterialEditorPcs[0];
-        m_table__18CMaterialEditorPcs[5] = m_table_desc1__18CMaterialEditorPcs[1];
-        m_table__18CMaterialEditorPcs[6] = m_table_desc1__18CMaterialEditorPcs[2];
-        m_table__18CMaterialEditorPcs[7] = m_table_desc2__18CMaterialEditorPcs[0];
-        m_table__18CMaterialEditorPcs[8] = m_table_desc2__18CMaterialEditorPcs[1];
-        m_table__18CMaterialEditorPcs[9] = m_table_desc2__18CMaterialEditorPcs[2];
-        m_table__18CMaterialEditorPcs[12] = m_table_desc3__18CMaterialEditorPcs[0];
-        m_table__18CMaterialEditorPcs[13] = m_table_desc3__18CMaterialEditorPcs[1];
-        m_table__18CMaterialEditorPcs[14] = m_table_desc3__18CMaterialEditorPcs[2];
-    }
-};
+/*
+ * --INFO--
+ * PAL Address: 0x8004c588
+ * PAL Size: 280b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_MaterialEditor_cpp(void)
+{
+    u8* self = reinterpret_cast<u8*>(&MaterialEditorPcs);
+    unsigned int* dst = m_table__18CMaterialEditorPcs;
+    unsigned int* desc0 = m_table_desc0__18CMaterialEditorPcs;
+    unsigned int* desc1 = m_table_desc1__18CMaterialEditorPcs;
+    unsigned int* desc2 = m_table_desc2__18CMaterialEditorPcs;
+    unsigned int* desc3 = m_table_desc3__18CMaterialEditorPcs;
 
-static MaterialEditorTableInit sMaterialEditorTableInit;
+    *reinterpret_cast<void**>(self) = __vt__8CManager;
+    *reinterpret_cast<void**>(self) = __vt__8CProcess;
+    *reinterpret_cast<void**>(self) = __vt__18CMaterialEditorPcs;
+
+    __ct__14CUSBStreamDataFv(self + 0x84);
+    __ct__5ZLISTFv(self + 0xC8);
+    __ct__5ZLISTFv(self + 0xD8);
+    __register_global_object(self, __dt__18CMaterialEditorPcsFv, lbl_8026D338);
+
+    dst[1] = desc0[0];
+    dst[2] = desc0[1];
+    dst[3] = desc0[2];
+    dst[4] = desc1[0];
+    dst[5] = desc1[1];
+    dst[6] = desc1[2];
+    dst[7] = desc2[0];
+    dst[8] = desc2[1];
+    dst[9] = desc2[2];
+    dst[12] = desc3[0];
+    dst[13] = desc3[1];
+    dst[14] = desc3[2];
+}
 
 extern "C" void Printf__8CGraphicFPce(void*, const char*, ...);
 extern "C" void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);


### PR DESCRIPTION
## Summary
- replace the helper-object startup path in `p_MaterialEditor.cpp` with an explicit `__sinit_p_MaterialEditor_cpp`
- initialize `MaterialEditorPcs` the same way as neighboring process units, including the USB/ZLIST constructors and table descriptor copies
- give the destructor registration block real storage via `lbl_8026D338`

## Evidence
- `__sinit_p_MaterialEditor_cpp`: 73.314285% -> 75.22857%
- `main/p_MaterialEditor` `.text`: 77.18899% -> 77.28869%
- `ninja` succeeds after the change

## Why this is plausible
- the new startup path matches the established explicit `__sinit` pattern already used by adjacent process units like `p_FunnyShape`
- this removes a C++ helper object used only to coax table writes and replaces it with the unit's real static initialization sequence
