### PR TITLE
Match pppKeShpTail3X stack layout

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -402,8 +402,10 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
 {
     KeShpTail3XStep* step;
     KeShpTail3XWork* work;
-    Vec pos;
+    pppFMATRIX outMatrix;
     Vec historyPos ATTRIBUTE_ALIGN(8);
+    Vec initPos ATTRIBUTE_ALIGN(8);
+    Vec pos ATTRIBUTE_ALIGN(8);
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -416,19 +418,17 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
         work->m_initialized = 1;
 
         if (step->m_worldSpaceMode == 0) {
-            pos.x = obj->pppPObject.m_localMatrix.value[0][3];
-            pos.y = obj->pppPObject.m_localMatrix.value[1][3];
-            pos.z = obj->pppPObject.m_localMatrix.value[2][3];
+            initPos.x = obj->pppPObject.m_localMatrix.value[0][3];
+            initPos.y = obj->pppPObject.m_localMatrix.value[1][3];
+            initPos.z = obj->pppPObject.m_localMatrix.value[2][3];
         } else if (step->m_worldSpaceMode == 1) {
-            pppFMATRIX outMatrix;
-
             pppMulMatrix(outMatrix, pppMngStPtr->m_matrix, obj->pppPObject.m_localMatrix);
-            pos.x = outMatrix.value[0][3];
-            pos.y = outMatrix.value[1][3];
-            pos.z = outMatrix.value[2][3];
+            initPos.x = outMatrix.value[0][3];
+            initPos.y = outMatrix.value[1][3];
+            initPos.z = outMatrix.value[2][3];
         }
 
-        pppCopyVector(historyPos, pos);
+        pppCopyVector(historyPos, initPos);
         Vec* history = work->m_posHistory;
         s32 i = 0x1c;
         do {
@@ -448,8 +448,6 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
         pos.y = obj->pppPObject.m_localMatrix.value[1][3];
         pos.z = obj->pppPObject.m_localMatrix.value[2][3];
     } else if (step->m_worldSpaceMode == 1) {
-        pppFMATRIX outMatrix;
-
         pppMulMatrix(outMatrix, pppMngStPtr->m_matrix, obj->pppPObject.m_localMatrix);
         pos.x = outMatrix.value[0][3];
         pos.y = outMatrix.value[1][3];


### PR DESCRIPTION
## Summary
- reshape `pppKeShpTail3X` locals so the initialization path and world-space path share the same stack layout
- keep the existing behavior while reusing the matrix/temp vectors in the same way the target object does

## Evidence
- `ninja` builds cleanly
- build progress moved from `471648 / 1855224` matched code bytes and `2978 / 4732` matched functions to `473164 / 1855224` and `2979 / 4732`
- `build/GCCP01/report.json` now reports `main/pppKeShpTail3X` at `3 / 4` matched functions, and `pppKeShpTail3X` itself at `100.0%`

## Plausibility
- this only changes local variable lifetimes, alignment, and reuse in a way that matches the existing tail-history logic
- no fake linkage, manual RTTI, or compiler-forcing hacks were introduced