### PR TITLE
Remove extra pppYmDeformationScreen stub

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -377,13 +377,3 @@ void pppConstructYmDeformationScreen(pppYmDeformationScreen* obj, void* param2)
 	*(float*)(basePtr + 0x18) = zero;
 	*(float*)(basePtr + 0x14) = zero;
 }
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void SetUpIndWarp(VYmDeformationScreen*)
-{
-	// TODO
-}


### PR DESCRIPTION
## Summary
- Removed the fake TODO definition of SetUpIndWarp(VYmDeformationScreen*) from src/pppYmDeformationScreen.cpp.
- The symbol is not present in the target object and is not referenced by the repo, so leaving only the declaration avoids emitting an extra blr function.

## Evidence
- Before: compiled main/pppYmDeformationScreen right .text size was 2240 bytes and included SetUpIndWarp__FP20VYmDeformationScreen as an extra 4-byte symbol.
- After: compiled right .text size is 2236 bytes, matching the target left .text size of 2236 bytes; no SetUpIndWarp symbol is emitted.
- pppRenderYmDeformationScreen remains 94.745636% and 1604 bytes, so the change is isolated to linkage/section size cleanup.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationScreen -o - pppRenderYmDeformationScreen