### PR TITLE
Use texture fields in texture manager

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -450,21 +450,21 @@ int CTextureMan::SetTexture(_GXTexMapID texMapId, CTexture* texture)
     bool usePalette;
 
     usePalette = false;
-    if ((U8At(texture, 0x60) == 9) || (U8At(texture, 0x60) == 8)) {
+    if ((texture->m_format == 9) || (texture->m_format == 8)) {
         usePalette = true;
     }
 
     if (usePalette) {
-        GXInitTexObjTlut(reinterpret_cast<GXTexObj*>(Ptr(texture, 0x28)), GX_TLUT0);
+        GXInitTexObjTlut(&texture->m_texObj, GX_TLUT0);
     }
 
-    GXLoadTexObj(reinterpret_cast<GXTexObj*>(Ptr(texture, 0x28)), texMapId);
+    GXLoadTexObj(&texture->m_texObj, texMapId);
 
     if (usePalette) {
-        GXInitTexObjTlut(reinterpret_cast<GXTexObj*>(Ptr(texture, 0x28)), GX_TLUT1);
-        GXLoadTexObj(reinterpret_cast<GXTexObj*>(Ptr(texture, 0x28)), static_cast<_GXTexMapID>(texMapId + 1));
-        GXLoadTlut(reinterpret_cast<GXTlutObj*>(Ptr(texture, 0x48)), GX_TLUT0);
-        GXLoadTlut(reinterpret_cast<GXTlutObj*>(Ptr(texture, 0x54)), GX_TLUT1);
+        GXInitTexObjTlut(&texture->m_texObj, GX_TLUT1);
+        GXLoadTexObj(&texture->m_texObj, static_cast<_GXTexMapID>(texMapId + 1));
+        GXLoadTlut(&texture->m_tlutObj0, GX_TLUT0);
+        GXLoadTlut(&texture->m_tlutObj1, GX_TLUT1);
     }
 
     return 0;
@@ -491,7 +491,7 @@ int CTextureMan::SetTextureTev(CTexture* texture)
         return 1;
     }
 
-    usePalette = *(u8*)((u8*)texture + 0x60) == 9 || *(u8*)((u8*)texture + 0x60) == 8;
+    usePalette = texture->m_format == 9 || texture->m_format == 8;
     if (usePalette) {
         GXColor tevColor1 = {0xFF, 0, 0, 0xFF};
         GXSetTevColor((GXTevRegID)1, tevColor1);


### PR DESCRIPTION
## Summary
- Use CTexture::m_format instead of raw byte reads when checking paletted texture formats.
- Use CTexture members for texture object and TLUT object loads in CTextureMan::SetTexture.
- Apply the same m_format field access in CTextureMan::SetTextureTev.

## Objdiff Evidence
- main/textureman .text: 84.270424% -> 84.713806%
- SetTexture__11CTextureManF11_GXTexMapIDP8CTexture: 77.28889% -> 93.44444%
- SetTextureTev__11CTextureManFP8CTexture: 94.12936% -> 94.427864%

## Plausibility
- m_format is declared as a 32-bit field in CTexture; the target code uses word loads for these comparisons.
- Texture/TLUT loads now use the existing class members instead of raw offsets, which matches the known layout more directly.

## Verification
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/textureman -o - SetTexture__11CTextureManF11_GXTexMapIDP8CTexture
- build/tools/objdiff-cli diff -p . -u main/textureman -o - SetTextureTev__11CTextureManFP8CTexture
