### PR TITLE
Match SRTToMatrix temporaries in math.cpp

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -94,6 +94,9 @@ void CMath::SRTToMatrix(float (*out)[4], SRT* srt)
     float cz;
     float sxsy;
     float cxsy;
+    float zRotX;
+    float zRotY;
+    float zRotZ;
 
     PSMTXScale(out, s[6], s[7], s[8]);
     sx = (float)sin((double)s[3]);
@@ -111,9 +114,12 @@ void CMath::SRTToMatrix(float (*out)[4], SRT* srt)
     rot[0][1] = cz * sxsy - (cx * sz);
     rot[1][1] = sz * sxsy + (cx * cz);
     rot[2][1] = sx * cy;
-    rot[2][2] = cx * cy;
-    rot[0][2] = cz * cxsy + (sx * sz);
-    rot[1][2] = sz * cxsy - (sx * cz);
+    zRotZ = cx * cy;
+    zRotX = cz * cxsy + (sx * sz);
+    zRotY = sz * cxsy - (sx * cz);
+    rot[0][2] = zRotX;
+    rot[1][2] = zRotY;
+    rot[2][2] = zRotZ;
     rot[0][3] = s[0];
     rot[1][3] = s[1];
     rot[2][3] = s[2];


### PR DESCRIPTION
## Summary
- add explicit temporaries for the final Z-axis rotation terms in `CMath::SRTToMatrix`
- preserve the same arithmetic while matching the compiler's register flow for the last three stores

## Evidence
- `SRTToMatrix__5CMathFPA4_fP3SRT`: `99.44444%` -> `100.0%`
- `main/math` `.text`: `97.00645%` -> `96.90983%` by current objdiff report? No, unit-level report after the exact function match is `96.90983%`
- repo progress after rebuild: game code matched functions `1736 -> 1737`, code bytes `162148 -> 162508`

## Why this is plausible source
- the change only names the three final computed rotation terms before storing them
- no compiler coercion, linkage hacks, or ABI changes were introduced
- the emitted arithmetic sequence is unchanged in meaning and now matches the original object exactly for this function