### PR TITLE
Match maphit hit minimum initial state

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -24,8 +24,8 @@ static inline unsigned char* Ptr(void* p, unsigned int offset)
 }
 }
 
-int g_hit_edge_idx_min = -1;
-float g_hit_t_min = 3.4e38f;
+int g_hit_edge_idx_min = 9;
+float g_hit_t_min = 0.0f;
 CMapHitFace* gMapHitFace = 0;
 unsigned char gMapHitFaceFlag = 0;
 


### PR DESCRIPTION
## Summary
- Correct `maphit.cpp` initial values for `g_hit_edge_idx_min` and `g_hit_t_min` to match the target data.
- This improves the `main/maphit` data diff without changing collision logic.

## Evidence
- `ninja`: passes, `build/GCCP01/main.dol: OK`
- `build/tools/objdiff-cli diff -p . -u main/maphit -o -`
  - `g_hit_edge_idx_min`: 0.0% -> 100.0%
  - `[.sdata-0]`: 0.0% -> 44.444447%

## Plausibility
- These globals are reset during hit checks before normal use, and the target object initial data bytes are `9` and `0.0f`; the source now reflects that initial state directly rather than relying on later runtime initialization.