### PR TITLE
Improve CSound 3D sound error-path matching

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1757,13 +1757,11 @@ int CSound::PlaySe3D(int soundId, Vec* pos, float nearDistance, float farDistanc
     int slot;
     int pan;
     int volume;
-    CRedSound* redSound;
 
     if (soundId < 0) {
-        Printf__7CSystemFPce(&System, s_soundErrorFmt);
+        Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
         CSoundLayout& sound = SoundData(this);
-        redSound = RedSound(this);
         se = sound.m_seWork;
 
         for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
@@ -1792,20 +1790,20 @@ int CSound::PlaySe3D(int soundId, Vec* pos, float nearDistance, float farDistanc
             se[0x27] = 0xFF;
 
             if (soundId < 0) {
-                Printf__7CSystemFPce(&System, s_soundErrorFmt);
+                Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
                 slot = -1;
             } else if (soundId < 4000) {
                 int bank = soundId / 1000;
-                slot = SePlay__9CRedSoundFiiiii(redSound, bank, soundId - bank * 1000, pan,
+                slot = SePlay__9CRedSoundFiiiii(RedSound(this), bank, soundId - bank * 1000, pan,
                                                 volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
                 if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(redSound, slot, volume, fadeFrames);
+                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
                 }
             } else {
-                slot = SePlay__9CRedSoundFiiiii(redSound, -1, soundId, pan,
+                slot = SePlay__9CRedSoundFiiiii(RedSound(this), -1, soundId, pan,
                                                 volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
                 if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(redSound, slot, volume, fadeFrames);
+                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
                 }
             }
 
@@ -1833,13 +1831,11 @@ int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float f
     int slot;
     int pan;
     int volume;
-    CRedSound* redSound;
 
     if (soundId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
         CSoundLayout& sound = SoundData(this);
-        redSound = RedSound(this);
         se = sound.m_seWork;
 
         for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
@@ -1871,16 +1867,16 @@ int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float f
                 slot = -1;
             } else if (soundId < 4000) {
                 int bank = soundId / 1000;
-                slot = SePlay__9CRedSoundFiiiii(redSound, bank, soundId - bank * 1000, pan,
+                slot = SePlay__9CRedSoundFiiiii(RedSound(this), bank, soundId - bank * 1000, pan,
                                                volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
                 if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(redSound, slot, volume, fadeFrames);
+                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
                 }
             } else {
-                slot = SePlay__9CRedSoundFiiiii(redSound, -1, soundId, pan,
+                slot = SePlay__9CRedSoundFiiiii(RedSound(this), -1, soundId, pan,
                                                volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
                 if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(redSound, slot, volume, fadeFrames);
+                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
                 }
             }
 
@@ -2009,7 +2005,7 @@ found_se:
 void CSound::StopSe3D(int se3dHandle)
 {
     if (se3dHandle < 0) {
-        Printf__7CSystemFPce(&System, s_soundErrorFmt);
+        Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
         u8* se = reinterpret_cast<u8*>(this) + 0x2C;
         u8* found;
@@ -2032,9 +2028,9 @@ found_entry:
         if (found != 0) {
             const int playId = *reinterpret_cast<int*>(found + 8);
             if (playId < 0) {
-                Printf__7CSystemFPce(&System, s_soundErrorFmt, idx);
+                Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
             } else {
-                SeStop__9CRedSoundFi(reinterpret_cast<CRedSound*>(this), playId);
+                SeStop__9CRedSoundFi(RedSound(this), playId);
             }
             *found &= 0x7F;
         }


### PR DESCRIPTION
## Summary
- align `CSound::PlaySe3D` and `CSound::StopSe3D` with the expected `-1` warning path
- route the 3D SE stop/play volume calls through `RedSound(this)` consistently in this block
- keep the changes localized to `src/sound.cpp`

## Evidence
- `ninja` succeeds
- `PlaySe3D__6CSoundFiP3Vecffi`: `60.564518%` -> `62.94355%`
- `StopSe3D__6CSoundFi`: `61.319443%` -> `64.94444%`
- `PlaySe3DLine__6CSoundFiiffi`: unchanged at `62.444443%`

## Why this is plausible
- the target decomp in `resources/ghidra-decomp-1-31-2026/800c5e2c_PlaySe3D__6CSoundFiP3Vecffi.c` and the adjacent stop helper both use the `-1` diagnostic string rather than the generic sound error string
- these are ABI-neutral source corrections inside the same 3D sound cluster, not compiler-coaxing hacks
