### PR TITLE
Claim pppKeShpTail3X sdata2 conversion constant

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -859,7 +859,7 @@ pppKeShpTail3X.cpp:
 	extab       start:0x80007A38 end:0x80007A50
 	extabindex  start:0x8000DCA8 end:0x8000DCCC
 	.text       start:0x8008922C end:0x8008A38C
-	.sdata2     start:0x80330520 end:0x80330540
+	.sdata2     start:0x80330520 end:0x80330548
 
 pppYmDrawMdlTexAnm.cpp:
 	extab       start:0x80007A50 end:0x80007A70


### PR DESCRIPTION
## Summary
- Extend the pppKeShpTail3X .sdata2 split through 0x80330548 so the unsigned conversion double at 0x80330540 is owned by the unit.
- This matches the existing symbol for DOUBLE_80330540 and the Ghidra references from pppKeShpTail3XDraw.

## Evidence
- ninja: passes, build/GCCP01/main.dol OK
- objdiff main/pppKeShpTail3X before: .sdata2 32 bytes, 88.88889%; pppKeShpTail3XDraw 52.63262%
- objdiff main/pppKeShpTail3X after: .sdata2 40 bytes, 100.0%; pppKeShpTail3XDraw 52.640244%

## Plausibility
- The additional 8 bytes are the compiler-generated unsigned conversion double referenced by the draw function, not a source coercion or manual data blob.
- The split now agrees with the existing symbol table entry for DOUBLE_80330540.