### PR TITLE
Remove spurious pppMiasma data emission

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/render_buffers.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/partMng.h"
 #include "ffcc/util.h"


### PR DESCRIPTION
## Summary
- Replace the broad p_game.h include in pppMiasma with game.h, since the unit only uses the CGame global fields.
- This avoids emitting the inline CGamePcs constructor descriptor statics into pppMiasma.o.

## Evidence
- Before: objdiff for main/pppMiasma showed an extra source .data section, size 108, match 0.0%.
- After: objdiff for main/pppMiasma no longer shows a source .data section; .sdata2 remains 40 bytes and 100.0%.
- pppRenderMiasma code score is unchanged at 91.06638%, so this is isolated data/linkage cleanup.
- ninja passes.

## Plausibility
- pppMiasma does not need CGamePcs declarations or constructor side effects from p_game.h. Using game.h keeps the CGame declaration while removing unrelated descriptor data from the unit.