### PR TITLE
Improve pppEmission loop lowering

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -373,9 +373,8 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
         *(int*)(MaterialManRaw() + 0xD0) = texture + 0x28;
 
         if (step->m_payload[9] == 0) {
-            for (int i = 0; i < step->m_initWOrk; i++) {
-                float scale = FLOAT_803311e4;
-                scale += (float)i * state->m_scale0;
+            for (u32 i = 0; (int)i < (int)step->m_initWOrk; i++) {
+                float scale = (float)i * state->m_scale0 + FLOAT_803311e4;
                 Mtx viewMtx;
                 Mtx objMtx;
                 PSMTXScale(objMtx, scale, scale, scale);
@@ -383,9 +382,9 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 PSMTXCopy(CameraMatrix(), viewMtx);
                 SetObjMatrix__12CMaterialManFPA4_fPA4_f(&MaterialMan, viewMtx, objMtx);
 
-                int remaining = meshData->m_displayListCount - 1;
+                u32 remaining = meshData->m_displayListCount;
                 EmissionDisplayList* displayList = meshData->m_displayLists;
-                while (remaining >= 0) {
+                while ((remaining = remaining - 1), -1 < (int)remaining) {
                     *(int*)(MaterialManRaw() + 0x48) = drawTevBits;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
@@ -424,7 +423,6 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     GXSetArray((GXAttr)0xB, &state->m_colorR, 4);
                     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
                     GXCallDisplayList(displayList->m_data, displayList->m_size);
-                    remaining--;
                     displayList++;
                 }
             }
@@ -440,9 +438,9 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 PSMTXConcat(viewMtx, objMtx, objMtx);
                 GXLoadPosMtxImm(objMtx, 0);
 
-                int remaining = meshData->m_displayListCount - 1;
+                u32 remaining = meshData->m_displayListCount;
                 EmissionDisplayList* displayList = meshData->m_displayLists;
-                while (remaining >= 0) {
+                while ((remaining = remaining - 1), -1 < (int)remaining) {
                     *(int*)(MaterialManRaw() + 0x48) = drawTevBits;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
@@ -481,7 +479,6 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     GXSetArray((GXAttr)0xB, &particle->m_colorR, 4);
                     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
                     GXCallDisplayList(displayList->m_data, displayList->m_size);
-                    remaining--;
                     displayList++;
                 }
                 particle++;


### PR DESCRIPTION
## Summary
- adjust the emission after-draw loops to use the compiler's original unsigned counter and decrement-in-condition lowering
- keep the source plausible while aligning the shared loop shape that feeds the unit's code and data layout

## Evidence
- `build/GCCP01/report.json` now reports `main/pppEmission` at `1656 / 2872` matched code bytes and `pppFrameEmission` at `100.0` fuzzy match
- the same report now shows `.sdata2` for `main/pppEmission` at `100.0` fuzzy match
- baseline before this patch had `pppFrameEmission` at `99.86539` and the unit `.sdata2` section at `55.0` from `objdiff-cli diff`

## Notes
- `Emission_AfterDrawMeshCallback` regressed locally while this change fixed the frame path and section layout, but the unit made real net progress in objdiff terms rather than only stylistic changes
- verified with `ninja` on `GCCP01`