### PR TITLE
Refine CWind free-slot scans

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -109,47 +109,40 @@ int CWind::AddSphere(const Vec* pos, float radius, float speed, int life)
 
 	do {
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
 		if (active == 0) {
 			goto found;
@@ -206,47 +199,40 @@ int CWind::AddDiffuse(const Vec* pos, float radius, float dir, float speed)
 
 	for (int blocks = 4; blocks != 0; blocks--) {
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
 		if (active == 0) {
 			goto found;
@@ -310,47 +296,40 @@ int CWind::AddAmbient(float dir, float speed)
 
 	for (int blocks = 4; blocks != 0; blocks--) {
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
-		if (active != 0) {
-			obj++;
-		} else {
+		if (active == 0) {
 			goto found;
 		}
+		obj++;
 		active = GetWindActiveFlag(obj);
 		if (active == 0) {
 			goto found;


### PR DESCRIPTION
## Summary
- rewrite the free-slot scans in CWind::AddSphere, CWind::AddDiffuse, and CWind::AddAmbient to use early exit on inactive slots
- keep the object initialization logic intact while making the scan flow closer to the original control structure

## Evidence
- `ninja`
- game data progress improved from `925325` to `925373` bytes matched (`+48`)
- `build/tools/objdiff-cli diff -p . -u main/wind -o -`

## Plausibility
- this removes compiler-unfriendly branch pairs around each slot probe and expresses the search in the straightforward early-exit form the object code suggests, without introducing hacks or fake linkage
