### PR TITLE
Move DOUBLE_80330DD0 to pppVertexApMtx

### DIFF
--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -61,6 +61,9 @@ struct _pppPDataVal;
 
 _pppPObject* pppCreatePObject(_pppMngSt*, _pppPDataVal*);
 
+extern const double kPppYmSharedDoubleBias;
+extern "C" const f64 DOUBLE_80330DD0 = 4503599627370496.0;
+
 /*
  * --INFO--
  * PAL Address: 0x800de360

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -23,7 +23,7 @@ extern f32 FLOAT_80330de0;
 extern f32 FLOAT_80330de4;
 extern f32 FLOAT_80330de8;
 extern f32 FLOAT_80330dec;
-extern "C" const f64 DOUBLE_80330DD0 = 4503599627370496.0;
+extern "C" const f64 DOUBLE_80330DD0;
 extern f64 DOUBLE_80330dd8;
 
 void pppInitBlendMode(void);


### PR DESCRIPTION
## Summary
- Move the DOUBLE_80330DD0 definition from pppYmLaser.cpp to pppVertexApMtx.cpp, matching the original object ownership.
- Leave pppYmLaser.cpp with an extern declaration for the shared constant.

## Evidence
- ninja passes.
- Project report improved from 470768 to 471648 matched code bytes and from 2977 to 2978 matched functions.
- main/pppVertexApMtx now reports full unit progress in the project report: 912/912 code bytes, 28/28 data bytes, 2/2 functions.
- Direct objdiff for main/pppVertexApMtx: .sdata2 improved from 87.5% to 100%; DOUBLE_80330DD0 now matches 100%.
- Direct objdiff for main/pppYmLaser: .text fuzzy score improved from 76.0477% to 76.05204%; pppRenderYmLaser improved from 65.56649% to 65.573135%.

## Plausibility
- The original pppVertexApMtx.o owns DOUBLE_80330DD0 in .sdata2, while pppYmLaser.o only needs to reference it.
- This is a linkage/data ownership correction, not a source control-flow coaxing change.