### PR TITLE
Claim pppChangeTex sdata2 constants

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -1528,6 +1528,7 @@ pppChangeTex.cpp:
 	extabindex  start:0x80010D80 end:0x80010DBC
 	.text       start:0x8013EF94 end:0x8013F9D0
 	.rodata     start:0x801DD660 end:0x801DD678
+	.sdata2     start:0x80332020 end:0x80332040
 
 pppCharaBreak.cpp:
 	extab       start:0x80009B4C end:0x80009B84


### PR DESCRIPTION
## Summary
- Claim the `pppChangeTex.cpp` `.sdata2` constant range `0x80332020..0x80332040` in the PAL split config.
- This assigns the named constants `FLOAT_80332020`, `DAT_80332024`, `FLOAT_80332028`, `DOUBLE_80332030`, and `DOUBLE_80332038` to the unit instead of leaving them unowned.

## Evidence
- `ninja` passes and reports `build/GCCP01/main.dol: OK`.
- Before: `main/pppChangeTex` data was `64 / 124` bytes matched (`51.61%`), with no claimed `.sdata2` section.
- After: `main/pppChangeTex` data is `96 / 156` bytes matched (`61.54%`).
- Objdiff now reports `main/pppChangeTex` `.sdata2` as `32` bytes at `100.0%` match.

## Plausibility
- The claimed range is contiguous with the symbol addresses in `config/GCCP01/symbols.txt` and matches the constants referenced by the existing `pppChangeTex` source/Ghidra output.
- No source coercion or manual section forcing was added; this is split ownership cleanup only.