### PR TITLE
Improve pppColum render loop match

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -187,15 +187,14 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
 
             for (int i = 0; i < param_2->m_count; i++) {
                 float positionScale = segmentStep * values->m_positionScale;
-                float index = (float)(i + 1);
                 float offsetX;
                 float offsetY;
                 u8 alpha;
 
                 center.z = zero;
-                offsetX = cameraDelta.x * index;
+                offsetX = cameraDelta.x * (float)(i + 1);
                 center.x = baseX + positionScale * offsetX;
-                offsetY = cameraDelta.y * index;
+                offsetY = cameraDelta.y * (float)(i + 1);
                 center.y = baseY + positionScale * offsetY;
 
                 PSVECSubtract(&center, &positionWork->m_position, &offset);


### PR DESCRIPTION
## Summary
- Updates pppRenderColum to cast the loop index at each X/Y use site instead of sharing a cached float index temporary.
- This matches the target source shape more closely: the original code repeats the int-to-float conversion for the two coordinate calculations.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppColum -o - pppRenderColum
- pppRenderColum: 94.287926% -> 97.16718%
- unit .text: 95.73903% -> 97.88683%

## Plausibility
- The change preserves behavior and removes an unnecessary cached temporary.
- The resulting code is ordinary source-level expression spelling and avoids hardcoded addresses, fake symbols, or section forcing.
