### PR TITLE
Improve CrossCheckSphereVector matching

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -38,15 +38,51 @@ extern inline float sqrtf(float x)
 {
     static const double _half = .5;
     static const double _three = 3.0;
-    volatile float y;
+    union {
+        float f;
+        unsigned long bits;
+    } bits;
+    int fpclass;
+
     if (x > 0.0f) {
         double guess = __frsqrte((double)x); // returns an approximation to
         guess = _half * guess * (_three - guess * guess * x); // now have 12 sig bits
         guess = _half * guess * (_three - guess * guess * x); // now have 24 sig bits
         guess = _half * guess * (_three - guess * guess * x); // now have 32 sig bits
-        y = (float)(x * guess);
-        return y;
+        x = (float)(x * guess);
+        return x;
     }
+
+    if ((double)x < 0.0) {
+        x = NAN;
+        return x;
+    }
+
+    bits.f = x;
+    switch (bits.bits & 0x7f800000) {
+    case 0x7f800000:
+        if ((bits.bits & 0x7fffff) != 0) {
+            fpclass = 1;
+        } else {
+            fpclass = 2;
+        }
+        break;
+    case 0:
+        if ((bits.bits & 0x7fffff) != 0) {
+            fpclass = 5;
+        } else {
+            fpclass = 3;
+        }
+        break;
+    default:
+        fpclass = 4;
+        break;
+    }
+
+    if (fpclass == 1) {
+        x = NAN;
+    }
+
     return x;
 }
 #else

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -732,15 +732,17 @@ extern "C" int CrossCheckSphereVector__5CMathFP3VecPfP3VecP3VecP3Vecf(
             if (dVar8 < 0.0f) {
                 hit = false;
             } else {
-                dVar8 = -dVar6 - sqrtf(fVar1);
+                dVar8 = sqrtf(dVar8);
+                dVar8 = -dVar6 - dVar8;
                 if ((dVar8 <= 0.0f) || (dVar7 < dVar8)) {
                     hit = false;
                 } else {
+                    dVar8 = dVar8 / dVar7;
                     if (outT != NULL) {
-                        *outT = dVar8 / dVar7;
+                        *outT = dVar8;
                     }
                     if (outPos != NULL) {
-                        PSVECScale(&local_6c, &local_84, dVar8 / dVar7);
+                        PSVECScale(&local_6c, &local_84, dVar8);
                         PSVECAdd(&local_60, &local_84, outPos);
                     }
                     hit = true;


### PR DESCRIPTION
## Summary
- expands the inline `sqrtf` non-positive/NaN handling used by `math.cpp`
- reuses the discriminant sqrt result and normalized hit time in `CrossCheckSphereVector`

## Objdiff evidence
- `CrossCheckSphereVector__5CMathFP3VecPfP3VecP3VecP3Vecf`: 81.64249% -> 98.663216%
- compiled size: 652b -> 776b, closer to the 772b target
- nearby selected math symbols unchanged: `CheckFrustum0__6CBoundFR6CBound` 95.01845%, `CheckFrustum0__6CBoundFf` 97.54777%, `DstRot__5CMathFff` 95.932205%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/math -o /tmp/math_final_diff.json CrossCheckSphereVector__5CMathFP3VecPfP3VecP3VecP3Vecf`