### PR TITLE
Remove stray p_game include from pppYmLaser

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -2,7 +2,6 @@
 #include "ffcc/graphic.h"
 #include "ffcc/math.h"
 #include "ffcc/map.h"
-#include "ffcc/p_game.h"
 #include "ffcc/linkage.h"
 extern "C" {
 extern const f32 kPppYmLaserOne;


### PR DESCRIPTION
## Summary
- Remove the unused ffcc/p_game.h include from src/pppYmLaser.cpp.
- Keep ffcc/linkage.h as the source for CFlatFlags, which is the only game-process-related symbol this unit uses.
- Prevent unrelated CGamePcs constructor-local descriptor data from being emitted into pppYmLaser.o.

## Evidence
- ninja succeeds and build/GCCP01/main.dol reports OK.
- Before: main/pppYmLaser current object had an extra .data section of 108 bytes and 9 desc*localstatic*__ct__8CGamePcsFv symbols.
- After: that extra .data section is gone and the descriptor symbol count in pppYmLaser.o is 0.
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - still reports the same target code scores while removing unrelated current-side data.

## Plausibility
pppYmLaser.cpp does not use CGamePcs or GamePcs. It only needs CFlatFlags, already declared by ffcc/linkage.h, so removing the heavyweight process header is cleaner source and avoids accidental local static data ownership in this particle unit.