### PR TITLE
Improve material editor drawViewer match

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -7,7 +7,7 @@ extern "C" {
 extern const float kMaterialEditorControlMaxInit;
 extern const float kMaterialEditorControlMinInit;
 extern unsigned int kMaterialEditorDefaultColorRgba;
-extern const char sMaterialEditorSpinnerText[];
+extern const char sMaterialEditorSpinnerText[5];
 }
 #include "ffcc/zlist.h"
 #include <Dolphin/mtx.h>
@@ -530,8 +530,7 @@ void CMaterialEditorPcs::drawViewer()
     }
 
     gDebugSpinnerFrame_addr = gDebugSpinnerFrame_addr + 1;
-    int sign = gDebugSpinnerFrame_addr >> 31;
-    int idx = (sign * 4 | (unsigned int)(((gDebugSpinnerFrame_addr >> 4) * 0x40000000) + sign) >> 30) - sign;
+    int idx = (gDebugSpinnerFrame_addr >> 4) % 4;
     Printf__8CGraphicFPce(&Graphic, s_MaterialEditor_pctc_801D7D60, (int)(char)gDebugSpinnerText_addr[idx]);
 
     if (*reinterpret_cast<int*>(self + 0xE8) != 0) {
@@ -603,8 +602,11 @@ void CMaterialEditorPcs::drawViewer()
                         dstFactor = 5;
                     } else if ((src == 0) && (dst == 2)) {
                         srcFactor = 4;
+                        dstFactor = 1;
                     } else if ((src == 2) && (dst == 0)) {
                         blend = 3;
+                        srcFactor = 1;
+                        dstFactor = 1;
                     }
 
                     GXSetZCompLoc(GX_FALSE);
@@ -612,7 +614,7 @@ void CMaterialEditorPcs::drawViewer()
                     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(blend, srcFactor, dstFactor, 3);
                     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
                     GXSetCullMode(GX_CULL_NONE);
-                } else {
+                } else if (pass == 0) {
                     if ((polygon->flags & 0x400) != 0) {
                         continue;
                     }
@@ -621,7 +623,9 @@ void CMaterialEditorPcs::drawViewer()
                     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(0, 0, 0, 7);
                 }
 
-                if ((polygon->textureMarker == 'H') && (polygon->textureIndex < static_cast<s16>(m_loadedTextureCount))) {
+                switch (polygon->textureMarker) {
+                case 'H':
+                if (polygon->textureIndex < static_cast<s16>(m_loadedTextureCount)) {
                     s16* textureHeader = m_textureHeader[polygon->textureIndex];
                     float scaleU = static_cast<float>(DOUBLE_8032FCC0 / (static_cast<double>(textureHeader[2]) - DOUBLE_8032FCD0));
                     float scaleV = static_cast<float>(DOUBLE_8032FCC0 / (static_cast<double>(textureHeader[3]) - DOUBLE_8032FCD0));
@@ -718,6 +722,7 @@ void CMaterialEditorPcs::drawViewer()
                         GXLoadTlut(m_tlutObj0[polygon->textureIndex], 0);
                         GXLoadTlut(m_tlutObj1[polygon->textureIndex], 1);
                     }
+                }
                 }
 
                 GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);


### PR DESCRIPTION
## Summary
- Tighten CMaterialEditorPcs::drawViewer source shape around the debug spinner, blend-mode handling, and texture marker dispatch.
- Declare sMaterialEditorSpinnerText with its known 5-byte size so MWCC emits the target SDA-relative reference.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - drawViewer__18CMaterialEditorPcsFv
  - Unit .text fuzzy match: 77.18899% -> 78.302086%
  - drawViewer__18CMaterialEditorPcsFv: 65.31551% -> 67.26597%
  - main/p_MaterialEditor unit code fuzzy match: 77.46056% -> 78.57366%

## Plausibility
- Replaces decompiler-style spinner modulus arithmetic with ordinary (frame >> 4) % 4 source.
- Keeps blend defaults explicit in the same cases visible in the target control flow.
- Uses a switch for the texture marker branch, matching the target dispatch shape without adding manual codegen hacks.
