### PR TITLE
Improve prgobj target rotation scratch type

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -499,17 +499,17 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	float targetRot;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(self->m_worldPosition);
-	Vec deltaPos;
+	CVector deltaPos;
 	float deltaX;
 	float zero;
 	float deltaZ;
 	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), &deltaPos);
+	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
-	if (deltaX == zero || deltaZ == zero) {
+	if (zero == deltaX || zero == deltaZ) {
 		targetRot = FLOAT_80331BD4;
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);


### PR DESCRIPTION
## Summary
- Use a CVector scratch temporary in CGPrgObj::dstTargetRot, matching the constructor-backed temporary shape shown by the decompilation.
- Keep the surrounding rotation math and behavior unchanged.

## Evidence
- ninja passes; build/GCCP01/main.dol OK in the verified build.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/prgobj -o - dstTargetRot__8CGPrgObjFP8CGPrgObj
- dstTargetRot__8CGPrgObjFP8CGPrgObj: 87.47727% -> 87.681816%.
- main/prgobj .text fuzzy in objdiff: 96.12033% -> 96.13278%.

## Plausibility
- Ghidra shows dstTargetRot constructing a default CVector stack object before PSVECSubtract; the source now reflects that instead of using a raw Vec scratch.