### PR TITLE
p_map: hand-match static init flow

### DIFF
--- a/include/ffcc/p_map.h
+++ b/include/ffcc/p_map.h
@@ -15,8 +15,6 @@ extern const float kMapCameraCenterYOffset;
 class CMapPcs : public CProcess
 {
 public:
-    CMapPcs();
-	
     void Init();
     void Quit();
     int GetTable(unsigned long);

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -17,7 +17,8 @@
 #include <string.h>
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdio.h>
 CMapPcs MapPcs;
-extern void* __vt__8CManager;
+extern "C" void* __vt__8CManager[];
+extern "C" void* __vt__8CProcess[];
 extern "C" void* __vt__7CMapPcs[];
 extern "C" void create__7CMapPcsFv(CMapPcs*);
 extern "C" void destroy__7CMapPcsFv(CMapPcs*);
@@ -102,6 +103,8 @@ static const char s_dvd_map_stage_map_fmt[] = "dvd/map/stg%03d/map%03d";
 extern "C" void Destroy__7CMapMngFv(CMapMng*);
 extern "C" void MapFileRead__7CMapMngFPcRUl(CMapMng*);
 extern "C" void Printf__7CSystemFPce(CSystem* system, const char* format, ...);
+extern "C" void* __register_global_object(void* object, void* destructor, void* regmem);
+extern "C" CRelProfile* __dt__11CRelProfileFv(CRelProfile*, short);
 
 extern "C" void __dl__FPv(void*);
 extern "C" void DrawBound__8CGraphicFR6CBound8_GXColor(CGraphic*, void*, _GXColor);
@@ -136,6 +139,10 @@ struct CMapMngAsyncLoadState {
     CFile::CHandle* m_asyncHandles[16];
 };
 
+u8 g_hit_prof_desc[0xC];
+u8 g_map_calc_prof_desc[0xC];
+u8 g_map_draw_prof_desc[0xC];
+
 /*
  * --INFO--
  * PAL Address: 0x80036254
@@ -151,13 +158,20 @@ CRelProfile::~CRelProfile()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80035e84
+ * PAL Size: 976b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-CMapPcs::CMapPcs()
+extern "C" void __sinit_p_map_cpp(void)
 {
     unsigned int* dst = &m_table__7CMapPcs[0][0];
 
+    *reinterpret_cast<void**>(&MapPcs) = __vt__8CManager;
+    *reinterpret_cast<void**>(&MapPcs) = __vt__8CProcess;
+    *reinterpret_cast<void**>(&MapPcs) = __vt__7CMapPcs;
     dst[0x004 / 4] = m_table_desc0__7CMapPcs[0];
     dst[0x008 / 4] = m_table_desc0__7CMapPcs[1];
     dst[0x00C / 4] = m_table_desc0__7CMapPcs[2];
@@ -230,6 +244,10 @@ CMapPcs::CMapPcs()
     dst[0x338 / 4] = m_table_desc23__7CMapPcs[0];
     dst[0x33C / 4] = m_table_desc23__7CMapPcs[1];
     dst[0x340 / 4] = m_table_desc23__7CMapPcs[2];
+
+    __register_global_object(&g_hit_prof, __dt__11CRelProfileFv, g_hit_prof_desc);
+    __register_global_object(&g_map_calc_prof, __dt__11CRelProfileFv, g_map_calc_prof_desc);
+    __register_global_object(&g_map_draw_prof, __dt__11CRelProfileFv, g_map_draw_prof_desc);
 }
 
 /*


### PR DESCRIPTION
## Summary
- replace the ad hoc `CMapPcs` constructor path with an explicit `__sinit_p_map_cpp` flow in `p_map.cpp`
- initialize `MapPcs` vtables and scenegraph descriptor slots directly in `__sinit_p_map_cpp`
- register the three `CRelProfile` globals there and drop the stale `CMapPcs()` declaration from the header

## Evidence
- `python3 tools/agent_select_target.py` reported `__sinit_p_map_cpp` at 9.4% and `LoadMap__7CMapPcsFiiPvUlUc` at 70.9% before the change
- `build/tools/objdiff-cli diff -p . -u main/p_map -o - __sinit_p_map_cpp` now reports `51.72131%`
- the same diff shows `main/p_map` `.text` at `85.450066%`, with `.data` still `97.93976%` and `.bss` `100%`
- `ninja` completes successfully after the change

## Plausibility
- this matches the existing project pattern used by other process units that hand-shape `__sinit_*` when compiler-generated init owns the wrong layout
- the change removes a non-matching constructor artifact instead of adding compiler-coaxing hacks or fake runtime data