### PR TITLE
Improve menu animation loop matches

### DIFF
--- a/include/ffcc/menu_equip.h
+++ b/include/ffcc/menu_equip.h
@@ -9,7 +9,7 @@ public:
     void EquipInit1();
     int EquipOpen();
     void EquipCtrl();
-    void EquipClose();
+    int EquipClose();
     void EquipDraw();
     int EquipCtrlCur();
     bool EquipOpen0();

--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -471,25 +471,23 @@ int CMenuPcs::EquipOpen()
 	uVar8 = (u32)*GetEquipList(this);
 	psVar7 = GetEquipList(this) + 4;
 	iVar11 = (int)*(s16*)(GetEquipStateBase(this) + 0x22);
-	uVar12 = uVar8;
 	if (0 < (int)uVar8) {
-		do {
+		for (int i = 0; i < (int)uVar8; i++) {
 			dVar2 = DOUBLE_80332ed8;
 			if (*(int*)(psVar7 + 0x12) <= iVar11) {
-				if (iVar11 < *(int*)(psVar7 + 0x12) + *(int*)(psVar7 + 0x14)) {
+				if (iVar11 >= *(int*)(psVar7 + 0x12) + *(int*)(psVar7 + 0x14)) {
+					iVar6++;
+					*(float*)(psVar7 + 8) = FLOAT_80332ee0;
+				} else {
 					*(int*)(psVar7 + 0x10) = *(int*)(psVar7 + 0x10) + 1;
 					dVar20 = (double)(((u64)((u32)*(u32*)(psVar7 + 0x14) ^ 0x80000000U)) | 0x4330000000000000ULL);
 					*(float*)(psVar7 + 8) =
 					    (float)((DOUBLE_80332ec0 / (dVar20 - dVar2)) *
 					            ((double)(((u64)((u32)*(u32*)(psVar7 + 0x10) ^ 0x80000000U)) | 0x4330000000000000ULL) - dVar2));
-				} else {
-					iVar6++;
-					*(float*)(psVar7 + 8) = FLOAT_80332ee0;
 				}
 			}
 			psVar7 += 0x20;
-			uVar12--;
-		} while (uVar12 != 0);
+		}
 	}
 
 	fVar5 = FLOAT_80332ee0;
@@ -631,7 +629,7 @@ void CMenuPcs::EquipCtrl()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMenuPcs::EquipClose()
+int CMenuPcs::EquipClose()
 {
 	int menuState = *reinterpret_cast<int*>(reinterpret_cast<char*>(this) + 0x82c);
 	s16* menuData = *reinterpret_cast<s16**>(reinterpret_cast<char*>(this) + 0x850);
@@ -644,7 +642,10 @@ void CMenuPcs::EquipClose()
 
 	for (int i = 0; i < itemCount; i++) {
 		if (*reinterpret_cast<int*>(item + 0x12) <= timer) {
-			if (timer < (*reinterpret_cast<int*>(item + 0x12) + *reinterpret_cast<int*>(item + 0x14))) {
+			if (timer >= (*reinterpret_cast<int*>(item + 0x12) + *reinterpret_cast<int*>(item + 0x14))) {
+				doneCount++;
+				*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
+			} else {
 				*reinterpret_cast<int*>(item + 0x10) = *reinterpret_cast<int*>(item + 0x10) + 1;
 				float ratio = FLOAT_80332ee0 -
 				              (static_cast<float>(*reinterpret_cast<int*>(item + 0x10)) /
@@ -653,9 +654,6 @@ void CMenuPcs::EquipClose()
 				if (*reinterpret_cast<float*>(item + 8) < FLOAT_80332eb8) {
 					*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
 				}
-			} else {
-				doneCount++;
-				*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
 			}
 		}
 		item += 0x20;
@@ -671,7 +669,9 @@ void CMenuPcs::EquipClose()
 			*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
 			item += 0x20;
 		}
+		return 1;
 	}
+	return 0;
 }
 
 /*

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -223,25 +223,23 @@ int CMenuPcs::MLstClose()
 	itemCount = (unsigned int)this->lstData->count;
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
-	count = itemCount;
 	if ((int)itemCount > 0) {
-		do {
+		for (int i = 0; i < (int)itemCount; i++) {
 			if (entry->startFrame <= currentFrame) {
-				if (entry->startFrame + entry->duration > currentFrame) {
+				if (entry->startFrame + entry->duration <= currentFrame) {
+					completedItems++;
+					entry->alpha = FLOAT_803333D0;
+				} else {
 					entry->timer = entry->timer + 1;
 					double ratio = DOUBLE_80333410 / (double)entry->duration;
 					entry->alpha = (float)(DOUBLE_80333410 - ratio * (double)entry->timer);
 					if ((double)entry->alpha < DOUBLE_80333418) {
 						entry->alpha = FLOAT_803333D0;
 					}
-				} else {
-					completedItems++;
-					entry->alpha = FLOAT_803333D0;
 				}
 			}
 			entry++;
-			count--;
-		} while (count != 0);
+		}
 	}
 	zero = FLOAT_803333D0;
 	if (this->lstData->count == completedItems) {
@@ -505,22 +503,20 @@ int CMenuPcs::MLstOpen()
 	itemCount = (unsigned int)this->lstData->count;
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
-	count = itemCount;
 	if ((int)itemCount > 0) {
-		do {
+		for (int i = 0; i < (int)itemCount; i++) {
 			if (entry->startFrame <= currentFrame) {
-				if (entry->startFrame + entry->duration > currentFrame) {
+				if (entry->startFrame + entry->duration <= currentFrame) {
+					completedItems++;
+					entry->alpha = FLOAT_803333F0;
+				} else {
 					entry->timer = entry->timer + 1;
 					double ratio = DOUBLE_80333410 / (double)entry->duration;
 					entry->alpha = (float)(ratio * (double)entry->timer);
-				} else {
-					completedItems++;
-					entry->alpha = FLOAT_803333F0;
 				}
 			}
 			entry++;
-			count--;
-		} while (count != 0);
+		}
 	}
 
 	one = FLOAT_803333F0;


### PR DESCRIPTION
## Summary
- Reworked MLstClose/MLstOpen animation loops so completed-item handling matches the target branch shape and counted-loop form.
- Updated EquipOpen/EquipClose animation state handling similarly, and corrected EquipClose to return completion status like the target.

## Evidence
- ninja passes.
- main/menu_lst .text fuzzy: 68.6% picker baseline -> 70.56% report.
- MLstClose__8CMenuPcsFv: 63.28% -> 71.00% objdiff.
- MLstOpen__8CMenuPcsFv: 67.99% -> 72.83% objdiff.
- main/menu_equip .text fuzzy: 38.4% picker baseline -> 38.82% report.
- EquipClose__8CMenuPcsFv: 43.93% -> 47.25% objdiff.
- EquipOpen__8CMenuPcsFv: 43.97% -> 46.65% objdiff.

## Plausibility
- The changes preserve existing behavior while expressing the animation completion path in the branch order shown by Ghidra and reflected by objdiff.
- EquipClose now has the same completion-return contract as the target and as nearby menu close/open helpers.