### PR TITLE
Improve Ym deformation shape render flow

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -245,7 +245,7 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
 				vertices[3].x = split;
 				vertices[3].y = split;
 				vertices[3].z = kPppYmDeformationShpZero;
-			} else {
+			} else if (param_2->m_orientation == 1) {
 				vertices[0].x = split;
 				vertices[0].y = kPppYmDeformationShpZero;
 				vertices[0].z = -split;
@@ -348,9 +348,9 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
 				RenderDeformationShape((_pppPObject*)pppYmDeformationShp_, work, vertices, uvs);
 			}
 		}
-	}
 
-	DisableIndWarp__F13_GXTevStageID16_GXIndTexStageID(1, 0);
+		DisableIndWarp__F13_GXTevStageID16_GXIndTexStageID(1, 0);
+	}
 }
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Move the final indirect-warp disable into the active render path for pppRenderYmDeformationShp.
- Tighten one split-shape orientation branch to handle the explicit orientation == 1 case, matching the nearby branch pattern and Ghidra shape.

## Objdiff Evidence
- main/pppYmDeformationShp .text: 89.371025% -> 89.43534%
- pppRenderYmDeformationShp: 94.50551% -> 94.63636%
- RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d: unchanged at 81.87306%

## Plausibility
- Ghidra shows DisableIndWarp(1, 0) under the m_dataValIndex != 0xffff render path rather than after it.
- The split-shape path already uses explicit orientation == 0 / orientation == 1 checks in adjacent blocks; this change makes the remaining broad else follow that same source shape.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp -o - pppRenderYmDeformationShp