### PR TITLE
Match p_usb USB root path data size

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -20,7 +20,7 @@ u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
-static const char s_usbRootPath[] = "plot/kmitsuru/";
+static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
 /*


### PR DESCRIPTION
## Summary
- size `s_usbRootPath` in `src/p_usb.cpp` as a 16-byte array to match the original object layout
- keep `SendDataCode__7CUSBPcsFiPvii` and the rest of `p_usb` unchanged

## Evidence
- `main/p_usb` `.rodata`: `98.18182%` -> `100.0%`
- `s_usbRootPath`: `96.77419%` -> `100.0%`
- full `ninja` report improved overall matched data from `1083459` to `1083487` bytes and game matched data from `925841` to `925869` bytes

## Plausibility
- this is a data-layout correction, not compiler coaxing
- the path is used as a C string and the original object expects 16 bytes of storage for it