### PR TITLE
Fix CMenuPcs texture layout

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -41,6 +41,7 @@ public:
         int m_width;
         int m_gaugeMax;
         int m_gaugeValue;
+        int m_unk1c;
     };
 
     struct CTmp

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -19,6 +19,7 @@ extern const f32 kMenuInitOne;
 extern const f32 kMenuOrthoBottom;
 extern const f32 kMenuOrthoRight;
 extern const f32 kMenuOrthoFar;
+extern const f32 FLOAT_80330808;
 }
 #include "ffcc/textureman.h"
 #include "ffcc/fontman.h"
@@ -1162,7 +1163,7 @@ void CMenuPcs::SetTexture(CMenuPcs::TEX tex)
 
         width = *(u32*)((u8*)texture + 0x64);
         height = *(u32*)((u8*)texture + 0x68);
-        PSMTXScale(texMtx, 1.0f / (f32)width, 1.0f / (f32)height, 1.0f);
+        PSMTXScale(texMtx, FLOAT_80330808 / (f32)width, FLOAT_80330808 / (f32)height, FLOAT_80330808);
         GXLoadTexMtxImm(texMtx, GX_TEXMTX0, GX_MTX2x4);
         GXSetNumTexGens(1);
         GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);


### PR DESCRIPTION
## Summary
- add the missing word in CMenuPcs::BattleHudState so later members, including m_textures, land at the target offsets
- use the named FLOAT_80330808 constant in CMenuPcs::SetTexture for the texture matrix scale

## Evidence
- ninja builds successfully
- progress improves from 474220 to 474824 matched code bytes, and from 2983 to 2985 matched functions
- CPartPcs::LoadMenuPdt now reports 100.0% in objdiff
- CMenuPcs::SetTexture improves after m_textures moves from the current 0x188 access to the target 0x18c access

## Plausibility
- this is a source layout fix, not a manual address or section workaround
- the new field accounts for a real object-layout gap before the texture arrays and improves downstream code that indexes MenuPcs textures