### PR TITLE
Gate unused PAL pppRand helpers

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -95,7 +95,9 @@ void pppRandCV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 char randchar(char value, float scale)
 {
     return (char)(((f32)value * scale) - (f32)value);
 }
+#endif

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -94,7 +94,9 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 char randchar(char value, float scale)
 {
     return (char)((f32)value * scale);
 }
+#endif

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -76,7 +76,9 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 static int randint(int value, float scale)
 {
     return (int)((float)value * scale);
 }
+#endif

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -83,7 +83,9 @@ void pppRandHCV(void* p1, void* p2, void* p3)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 static short randshort(short value, float scale)
 {
     return (short)(((f32)value * scale) - (f32)value);
 }
+#endif

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -87,7 +87,9 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 char randchar(char value, float scale)
 {
     return (char)((f32)value * scale);
 }
+#endif

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -76,7 +76,9 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 static int randint(int value, float scale)
 {
     return (int)((f32)value * scale);
 }
+#endif


### PR DESCRIPTION
## Summary
- Gate PAL-unused helper functions in the pppRand color/int variation units with `#ifndef VERSION_GCCP01`.
- Removes helpers marked `PAL Address: UNUSED` from the active GCCP01 objects while preserving them for non-PAL builds.

## Objdiff evidence
- Full `ninja` passes: `build/GCCP01/main.dol: OK`.
- Overall matched data improved from `1083459 / 1489607` to `1083567 / 1489607` bytes (+108).
- Affected units now have matching `.sdata2`; all except the remaining small `pppRandCV` extabindex mismatch also have matching extab/extabindex:
  - `main/pppRandDownIV`: extab 100%, extabindex 100%, `.sdata2` 100%
  - `main/pppRandUpIV`: extab 100%, extabindex 100%, `.sdata2` 100%
  - `main/pppRandDownCV`: extab 100%, extabindex 100%, `.sdata2` 100%
  - `main/pppRandUpCV`: extab 100%, extabindex 100%, `.sdata2` 100%
  - `main/pppRandHCV`: extab 100%, extabindex 100%, `.sdata2` 100%
  - `main/pppRandCV`: extab 100%, `.sdata2` 100%, extabindex 95%

## Plausibility
These helpers already carry `PAL Address: UNUSED` headers, and similar unused-version code in the repo is excluded from `VERSION_GCCP01`. The change removes PAL-only emitted helper code/data rather than coaxing instruction selection.
