### PR TITLE
Improve PPP data layout

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -3,7 +3,7 @@
 #include "ffcc/render_buffers.h"
 #include "ffcc/mapmesh.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/pppYmEnv.h"

--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -137,3 +137,5 @@ extern "C" void pppConstructYmMoveCircle(pppYmMoveCircle* basePtr, pppYmMoveCirc
     pppCopyVector(work->m_center, *(Vec*)((u8*)pppMngSt + 0x58));
     work->m_hasInit = 0;
 }
+
+extern const float FLOAT_80330D94 = 0.0f;


### PR DESCRIPTION
## Summary
- Replace the heavy p_game include in pppYmDeformationScreen with game.h so this object no longer emits unrelated CGamePcs constructor descriptor data.
- Restore the mapped FLOAT_80330D94 zero constant in pppYmMoveCircle so its sdata2 layout matches the target.

## Evidence
- Built with ninja successfully.
- main/pppYmDeformationScreen: pppRenderYmDeformationScreen text unchanged at 99.33167%; extra current .data section removed (before: right .data size 108, match 0.0; after: no right .data section).
- main/pppYmMoveCircle: .sdata2 improved from 93.333336% to 100.0%; pppFrameYmMoveCircle text unchanged at 97.37143%.

## Plausibility
- pppYmDeformationScreen only needs the global Game declaration, not CGamePcs construction machinery from p_game.h.
- FLOAT_80330D94 is a MAP-backed sdata2 constant owned by pppYmMoveCircle and restores the target data layout without changing codegen.