### PR TITLE
Improve maptexanim frame clamp

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -201,12 +201,11 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
         static_cast<unsigned long>(m_textureSlot), TextureAt(textureSet, textureIndex));
 
     m_currentFrame = m_currentFrame + m_frameStep;
-    const float endFrame = static_cast<float>(m_endFrame);
-    if (m_currentFrame >= endFrame) {
+    if (m_currentFrame >= static_cast<float>(m_endFrame)) {
         if (m_wrapMode != 0) {
             m_currentFrame = m_currentFrame - static_cast<float>(m_endFrame - m_startFrame);
         } else {
-            m_currentFrame = endFrame;
+            m_currentFrame = static_cast<float>(m_endFrame);
         }
     }
 


### PR DESCRIPTION
## Summary
- Recompute the map texture animation end-frame float at the clamp assignment instead of keeping and reusing a local value.
- This matches the target non-looping clamp sequence more closely in CMapTexAnim::Calc.

## Evidence
- ninja passes.
- objdiff command: build/tools/objdiff-cli diff -p . -u main/maptexanim -o - Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet
- Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet: 91.411766% -> 92.14439%
- main/maptexanim .text: 95.39056% -> 95.78255%

## Plausibility
- The change is a natural source expression: the comparison and clamp assignment each convert m_endFrame where used.
- No manual symbols, forced sections, address hacks, or generated ctor/dtor/vtable code were added.