### PR TITLE
Improve util quantized boundary conversion

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -182,6 +182,7 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
 {
     S16Vec min;
     S16Vec max;
+    int scale = 1 << shift;
 
     min.z = 0x7FFF;
     min.y = 0x7FFF;
@@ -199,8 +200,12 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
         max.z = max.z < vecs->z ? vecs->z : max.z;
     }
 
-    ConvI2FVector(*minOut, min, shift);
-    ConvI2FVector(*maxOut, max, shift);
+    minOut->x = (float)min.x / (float)scale;
+    minOut->y = (float)min.y / (float)scale;
+    minOut->z = (float)min.z / (float)scale;
+    maxOut->x = (float)max.x / (float)scale;
+    maxOut->y = (float)max.y / (float)scale;
+    maxOut->z = (float)max.z / (float)scale;
 }
 
 /*


### PR DESCRIPTION
## Summary
- rewrite `CUtil::CalcBoundaryBoxQuantized` to emit direct quantized-to-float conversion instead of routing the final min/max vectors back through `ConvI2FVector`
- keep the source plausible while moving the generated code closer to the PAL binary's explicit conversion sequence

## Evidence
- `CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`: 35.9% -> 63.07% match according to the target selection snapshot and current objdiff
- `main/util` unit fuzzy match: 82.0% in `tools/agent_select_target.py` snapshot -> 83.463165% after rebuild (`build/GCCP01/report.json`)
- global rebuild progress moved from `473272` matched code bytes / `2981` matched functions to `473424` matched code bytes / `2982` matched functions

## Plausibility
- the function still computes the quantized bounds the same way; the change is limited to how the final `S16Vec` extrema are converted back to floats
- this matches the binary's behavior more closely without introducing hacks, fake symbols, or section tricks

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/util -o - CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`
