### PR TITLE
Improve singmenu and THPSimple matches

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -856,12 +856,13 @@ s32 THPSimpleOpen(const char* path)
         }
     }
     memcpy(&SimpleControl.header, sReadBuffer, sizeof(THPHeader));
-    compInfoOffset = SimpleControl.header.mCompInfoDataOffsets;
 
     if (strcmp(SimpleControl.header.mMagic, lbl_80331868) != 0) {
         DVDClose(&SimpleControl.fileInfo);
         return 0;
     }
+
+    compInfoOffset = SimpleControl.header.mCompInfoDataOffsets;
 
     if (SimpleControl.header.mVersion != 0x11000) {
         DVDClose(&SimpleControl.fileInfo);

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/singmenu.h"
 #include "ffcc/chara.h"
+#include "ffcc/color.h"
 #include "ffcc/file.h"
 #include "ffcc/fontman.h"
 #include "ffcc/graphic.h"
@@ -2535,8 +2536,8 @@ void CMenuPcs::DrawSingWinMess(int messageNo, int activeMask, int useDynamic)
     font->SetScale(FLOAT_8032ea78);
     font->DrawInit();
 
-    _GXColor color = {0xFF, 0xFF, 0xFF, 0xFF};
-    font->SetColor(color);
+    CColor color(0xFF, 0xFF, 0xFF, 0xFF);
+    font->SetColor(color.color);
 
     int lineCount = gSingDynamicWinMessInfo[0];
     const SingMenuStaticMessageInfo& staticMessage = DAT_80214a50[messageNo];


### PR DESCRIPTION
## Summary
- Use the normal `CColor` construction path for `CMenuPcs::DrawSingWinMess` before setting the font color.
- Move the `THPSimpleOpen` component-info offset load after the THP magic check, matching the observed source order/codegen more closely.

## Objdiff evidence
- `main/singmenu` `DrawSingWinMess__8CMenuPcsFiii`: 44.11905% -> 46.718254%
- `main/singmenu` `.text`: 55.247665% -> 55.36765%
- `main/THPSimple` `THPSimpleOpen`: 87.59773% -> 88.320114%
- `main/THPSimple` `.text`: 93.3% -> 93.37002%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/singmenu -o /tmp/sing_final.json DrawSingWinMess__8CMenuPcsFiii`
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o /tmp/thp_final.json THPSimpleOpen`

Both changes are source-plausible and avoid manual symbol, section, ctor/dtor, or address hacks.