### PR TITLE
Remove unused ppp rand helper functions

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -85,17 +85,3 @@ void pppRandCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -84,17 +84,3 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
         target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
-}

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -73,17 +73,3 @@ void pppRandHCV(void* p1, void* p2, void* p3)
 }
 
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static short randshort(short value, float scale)
-{
-    return (short)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -77,17 +77,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- Removed unused local rand helper functions from six ppp rand units.
- Eliminates extra unmatched helper symbols and their extab/extabindex entries from the current objects.

## Objdiff evidence
- Overall matched data improved from 1085883 to 1085991 bytes (+108); code score unchanged.
- main/pppRandUpIV: extab 66.67% -> 100%, extabindex 57.14% -> 100%; pppRandUpIV remains 99.60%.
- main/pppRandDownIV: extab/extabindex now 100%; pppRandDownIV remains 99.60%.
- main/pppRandUpCV: extab 66.67% -> 100%, extabindex 57.14% -> 100%; pppRandUpCV remains 99.58%.
- main/pppRandDownCV: extab 66.67% -> 100%, extabindex 57.14% -> 100%; pppRandDownCV remains 99.58%.
- main/pppRandHCV: extab 66.67% -> 100%, extabindex 57.14% -> 100%; pppRandHCV remains 99.47%.
- main/pppRandCV: extab 66.67% -> 100%, extabindex 54.76% -> 95%; pppRandCV remains 98.70%.

## Plausibility
These helpers were not referenced by the live rand routines and produced extra local symbols/exception table entries that are absent from the PAL object. Removing them makes the units closer to the original object layout without changing runtime code.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRandUpIV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandDownIV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandUpCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandDownCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandHCV -o -