### PR TITLE
Improve p_usb static constructor table setup

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -12,9 +12,6 @@ extern "C" void create__7CUSBPcsFv(CUSBPcs*);
 extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
-u32 m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__7CUSBPcsFv)};
-u32 m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__7CUSBPcsFv)};
-u32 m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(func__7CUSBPcsFv)};
 const char s_CUSBPcs_8032f810[] = "CUSBPcs";
 u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
@@ -30,10 +27,10 @@ extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stag
  */
 inline CUSBPcs::CUSBPcs()
 {
-    u32* table = m_table__7CUSBPcs;
-    const u32* desc0 = m_table_desc0__7CUSBPcs;
-    const u32* desc1 = m_table_desc1__7CUSBPcs;
-    const u32* desc2 = m_table_desc2__7CUSBPcs;
+    u32* table = reinterpret_cast<u32*>(m_table__7CUSBPcs);
+    static u32 desc0[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__7CUSBPcsFv)};
+    static u32 desc1[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__7CUSBPcsFv)};
+    static u32 desc2[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(func__7CUSBPcsFv)};
 
     table[1] = desc0[0];
     table[2] = desc0[1];


### PR DESCRIPTION
## Summary
- move the `CUSBPcs` scenegraph descriptor triples into the constructor as local static arrays
- keep the constructor copying the same descriptor contents into `m_table__7CUSBPcs`, but in the pattern already used by other process classes
- remove the now-unused global descriptor arrays from `src/p_usb.cpp`

## Evidence
- `ninja` succeeds
- `__sinit_p_usb_cpp` improved from `73.454544%` to `97.84091%` in `build/tools/objdiff-cli diff -p . -u main/p_usb -o - __sinit_p_usb_cpp`
- project progress moved from `473424` to `473600` matched code bytes and from `1085883` to `1086063` matched data bytes

## Why this is plausible source
- other process classes in the repo already build their scenegraph descriptor tables from constructor-local static descriptor triples
- this change removes bespoke global descriptor storage and makes `CUSBPcs` follow that established source pattern rather than adding compiler-specific coaxing