### PR TITLE
Improve CSystem scenegraph execution match

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -23,10 +23,6 @@
 #include "ffcc/p_minigame.h"
 #include <string.h>
 
-extern "C" {
-#include "PowerPC_EABI_Support/Runtime/ptmf.h"
-}
-
 CSystem System;
 
 class CScenegraphProcessProxy {
@@ -450,6 +446,7 @@ void CSystem::ExecScenegraph()
         }
 
         float totalTime = 0.0f;
+        unsigned int perfEnabled = perfTrigger & 1;
         CStopWatch watch((char*)"no name");
 
         int index = 0;
@@ -502,19 +499,19 @@ void CSystem::ExecScenegraph()
                 {
                     Graphic.SetDrawDoneDebugData(-1);
                 }
-                __ptmf_scall(order->m_owner);
+                (order->m_owner->*order->m_entry->m_callback)();
                 watch.Stop();
                 order->m_lastTime = watch.Get();
 
                 watch.Start();
-                if ((perfTrigger & 1) != 0)
+                if (perfEnabled != 0)
                 {
                     Graphic._WaitDrawDone(const_cast<char*>(s_system_cpp), 0x2CA);
                     GXReadGP0Metric();
                     GXReadGP1Metric();
                 }
                 watch.Stop();
-                if ((perfTrigger & 1) != 0)
+                if (perfEnabled != 0)
                 {
                     order->m_lastTime = watch.Get();
                 }


### PR DESCRIPTION
## Summary
- Invoke scenegraph callbacks through the real CProcess member-pointer entry instead of a raw __ptmf_scall shim.
- Cache the perf trigger bit once before timing each scenegraph order.
- Drop the now-unused PTMF runtime include from system.cpp.

## Objdiff evidence
- Unit: main/system
- Symbol: ExecScenegraph__7CSystemFv
- Before: 89.87027% match, current size 1448b
- After: 90.87297% match, current size 1452b
- Unit .text: 96.011024% -> 96.38277%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/system -o - ExecScenegraph__7CSystemFv