### PR TITLE
Improve pppFrameCrystal texture lookup

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -252,19 +252,19 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 		CrystalWork* work = (CrystalWork*)((u8*)pppCrystal + param_3->m_serializedDataOffsets[2] + 0x80);
 
 		if (param_2->m_dataValIndex != 0xFFFF) {
-			CMapMesh** mapMeshTable = (CMapMesh**)pppEnvStPtr->m_mapMeshPtr;
+			CMapMesh** mapMeshTable = pppEnvStPtr->m_mapMeshPtr;
+			CMapMesh* mapMesh = mapMeshTable[param_2->m_dataValIndex];
 			int textureIndex = 0;
 
-			GetTexture__8CMapMeshFP12CMaterialSetRi(
-				mapMeshTable[param_2->m_dataValIndex], pppEnvStPtr->m_materialSetPtr, textureIndex);
+			GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
 
 			if (param_2->m_payload[0] == 0) {
 				if (param_2->m_initWOrk == 0xFFFF) {
 					return;
 				}
 
-				GetTexture__8CMapMeshFP12CMaterialSetRi(
-					mapMeshTable[param_2->m_initWOrk], pppEnvStPtr->m_materialSetPtr, textureIndex);
+				mapMesh = mapMeshTable[param_2->m_initWOrk];
+				GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
 			}
 
 			if ((param_2->m_payload[0] == 1) && (work->m_refractionMap == 0)) {


### PR DESCRIPTION
## Summary
- Materialize the selected map mesh before each `GetTexture` call in `pppFrameCrystal`.
- Removes an unnecessary cast on the map mesh table now that the environment field has the correct type.

## Objdiff evidence
- `main/pppCrystal` `pppFrameCrystal`: 93.62592% -> 95.53704%
- `pppRenderCrystal` remained 99.9169%

## Plausibility
This keeps the existing control flow and data layout intact while making the texture lookup source more explicit: the code now selects a `CMapMesh*` from `pppEnvStPtr->m_mapMeshPtr` before passing it to `GetTexture`, matching the recovered dependency shape more closely without hardcoded addresses, fake symbols, or ABI hacks.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppCrystal -o - pppFrameCrystal`
- `build/tools/objdiff-cli diff -p . -u main/pppCrystal -o - pppRenderCrystal`
