### PR TITLE
Fix process table string linkage

### DIFF
--- a/src/p_mc.cpp
+++ b/src/p_mc.cpp
@@ -5,10 +5,10 @@
 extern const float FLOAT_80331b18 = 1.0f;
 extern const float FLOAT_80331b1c = 10.0f;
 
-extern const char s_CMcPcs_80331B10[];
+extern const char lbl_80331B10[];
 
 unsigned int m_table__6CMcPcs[0x15C / sizeof(unsigned int)] = {
-    reinterpret_cast<unsigned int>(const_cast<char*>(s_CMcPcs_80331B10)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1B
+    reinterpret_cast<unsigned int>(const_cast<char*>(lbl_80331B10)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1B
 };
 
 CMcPcs McPcs;

--- a/src/p_system.cpp
+++ b/src/p_system.cpp
@@ -5,7 +5,7 @@
 extern "C" void create__10CSystemPcsFv(CSystemPcs*);
 extern "C" void destroy__10CSystemPcsFv(CSystemPcs*);
 extern "C" void calc__10CSystemPcsFv(CSystemPcs*);
-static const char s_CSystemPcs_801D7C48[] = "CSystemPcs";
+extern const char s_CSystemPcs_801D7C48[];
 
 CSystemPcs SystemPcs;
 unsigned int m_table__10CSystemPcs[0x15C / sizeof(unsigned int)] = {


### PR DESCRIPTION
## Summary
- Treat `s_CSystemPcs_801D7C48` as an external symbol in `p_system`, matching the split original object instead of emitting local rodata in this unit.
- Rename the `p_mc` process table string reference to the symbol used by the split object and `config/GCCP01/symbols.txt` (`lbl_80331B10`).

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- Overall data matched increased from `1085967 / 1489579` to `1086063 / 1489579` bytes.
- `build/GCCP01/src/p_system.o` no longer emits a local `.rodata` section for `CSystemPcs`; `m_table__10CSystemPcs` remains 100% matched in objdiff.
- `m_table__6CMcPcs` remains 100% matched while using the MAP/split-object symbol name.

## Plausibility
- The split target objects show these table string pointers as undefined externals, so this moves the source toward the original object ownership rather than adding codegen coercion.
