### PR TITLE
p_usb: widen USB root path buffer

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -17,7 +17,7 @@ u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
-static const char s_usbRootPath[] = "plot/kmitsuru/";
+static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
 /*


### PR DESCRIPTION
## Summary
- declare `s_usbRootPath` as a 16-byte buffer instead of an unsized string literal array
- keep `SendDataCode` and the surrounding p_usb logic unchanged

## Evidence
- baseline target selection before the change showed `main/p_usb` at `code 99.5%, data 52.65%`
- current `build/GCCP01/report.json` shows `main/p_usb` at `fuzzy_match_percent 99.49394` with `matched_data_percent 55.752213`
- `ninja` passes on the prepared repo after the change
- `main/p_usb` no longer appears in the top opportunities from `tools/agent_select_target.py`

## Why this is plausible
- the string contents were already correct; the remaining issue was storage width and adjacent rodata layout
- making the root path a fixed 16-byte array matches the object layout directly without introducing coercive codegen tricks or fake symbols

## Notes
- I tried to get an exact clean-main rebuild in a temporary worktree for a byte-for-byte before/after report, but that checkout did not have the extracted `orig/GCCP01/sys/main.dol`; the baseline above comes from the pre-change target selector output in the prepared workspace.