### PR TITLE
Improve pppEmission and mapanim matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -488,7 +488,7 @@ config.libs = [
             Object(NonMatching, "main.cpp"),
             Object(Matching, "manager.cpp"),
             Object(NonMatching, "map.cpp"),
-            Object(NonMatching, "mapanim.cpp", extra_cflags=["-RTTI on"]),
+            Object(NonMatching, "mapanim.cpp"),
             Object(NonMatching, "maphit.cpp"),
             Object(Matching, "maplight.cpp"),
             Object(NonMatching, "mapmesh.cpp"),

--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -360,13 +360,13 @@ void pppConstructEmission(pppEmission* pppEmission_, pppEmissionUnkC* param_2) {
 void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* param_3, int meshIndex, float (*param_5)[4]) {
     SetDrawDoneDebugData__8CGraphicFSc(&Graphic, 0x66);
 
+    EmissionModelView* modelView = (EmissionModelView*)model;
     EmissionState* state = (EmissionState*)param_2;
     pppEmissionUnkB* step = (pppEmissionUnkB*)param_3;
-    EmissionMeshData* meshData = ((EmissionModelView*)model)->m_meshes[meshIndex].m_data;
+    EmissionMeshData* meshData = modelView->m_meshes[meshIndex].m_data;
     if ((strcmp((const char*)meshData, &DAT_803311fc) == 0) && (state->m_colorA != 0)) {
         int texture = state->m_texture;
-        int drawTevBits = 0xACE0F;
-        int fullTevBits = drawTevBits | 0x40000;
+        u32 drawTevBits = 0xACE0F;
 
         pppInitBlendMode();
         pppSetBlendMode(step->m_payload[8]);
@@ -405,13 +405,13 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     *(int*)(MaterialManRaw() + 0x58) = 0;
                     *(int*)(MaterialManRaw() + 0x5C) = 0;
                     *(u8*)(MaterialManRaw() + 0x208) = 0;
-                    *(int*)(MaterialManRaw() + 0x48) = fullTevBits;
+                    *(u32*)(MaterialManRaw() + 0x48) |= 0x40000;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
                     *(int*)(MaterialManRaw() + 0x130) = 0;
-                    *(int*)(MaterialManRaw() + 0x40) = fullTevBits;
+                    *(u32*)(MaterialManRaw() + 0x40) = *(u32*)(MaterialManRaw() + 0x48);
                     SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
-                        &MaterialMan, ((EmissionModelView*)model)->m_data->m_materialSet, displayList->m_material, 0, 0);
+                        &MaterialMan, modelView->m_data->m_materialSet, displayList->m_material, 0, 0);
 
                     if (step->m_payload[10] == 0) {
                         GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);
@@ -459,13 +459,13 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                     *(int*)(MaterialManRaw() + 0x58) = 0;
                     *(int*)(MaterialManRaw() + 0x5C) = 0;
                     *(u8*)(MaterialManRaw() + 0x208) = 0;
-                    *(int*)(MaterialManRaw() + 0x48) = fullTevBits;
+                    *(u32*)(MaterialManRaw() + 0x48) |= 0x40000;
                     *(int*)(MaterialManRaw() + 0x128) = 0;
                     *(int*)(MaterialManRaw() + 0x12C) = 0x1E;
                     *(int*)(MaterialManRaw() + 0x130) = 0;
-                    *(int*)(MaterialManRaw() + 0x40) = fullTevBits;
+                    *(u32*)(MaterialManRaw() + 0x40) = *(u32*)(MaterialManRaw() + 0x48);
                     SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
-                        &MaterialMan, ((EmissionModelView*)model)->m_data->m_materialSet, displayList->m_material, 0, 0);
+                        &MaterialMan, modelView->m_data->m_materialSet, displayList->m_material, 0, 0);
 
                     if (step->m_payload[10] == 0) {
                         GXSetTexCoordGen2((GXTexCoordID)0, (GXTexGenType)1, (GXTexGenSrc)4, 0x3C, GX_FALSE, 0x7D);


### PR DESCRIPTION
## Summary
- Express pppEmission material TEV flags as an in-place bit update, matching the target codegen for Emission_AfterDrawMeshCallback.
- Remove the mapanim RTTI override so the compiled object no longer emits extra RTTI .data/.sdata alongside the CPtrArray vtable.

## Evidence
- main/pppEmission objdiff .text: 97.639275% -> 98.89972%; compiled .text size: 2880 -> 2872; extabindex: 98.61111% -> 100%.
- main/mapanim compiled data layout: .data size 40 -> 12 and extra .sdata size 8 removed; target .data is 12.
- Final [1/1] PROGRESS
Progress:
  All: 25.58% matched, 18.44% linked (306 / 631 files)
    Code: 474516 / 1855224 bytes (2984 / 4732 functions)
    Data: 1086135 / 1489579 bytes (72.92%)
  Game Code: 10.40% matched, 2.21% linked (104 / 265 files)
    Code: 153720 / 1477652 bytes (1566 / 3111 functions)
    Data: 914417 / 1103477 bytes (82.87%)
  RedSound: 16.59% matched, 0.00% linked (0 / 8 files)
    Code: 11296 / 68072 bytes (176 / 379 functions)
    Data: 14100 / 21268 bytes (66.30%)
  SDK Code: 100.00% matched, 100.00% linked (202 / 202 files)
    Code: 309500 / 309500 bytes (1242 / 1242 functions)
    Data: 157618 / 158254 bytes (99.60%) passes.

## Plausibility
- The pppEmission change uses the same kind of material bitfield update already seen elsewhere in the codebase instead of precomputing an unrelated constant.
- The mapanim flag change matches the target object's lack of emitted RTTI data and avoids manual vtable/RTTI definitions.