### PR TITLE
Improve pppLensFlare frame match

### DIFF
--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -140,8 +140,7 @@ void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTab
 		s16 stepSize;
 		float alphaScale;
 
-		alphaScale = (float)sourceAlpha;
-		alphaScale *= FLOAT_80331064;
+		alphaScale = (float)sourceAlpha * FLOAT_80331064;
 		GXGetViewportv(viewport);
 		GXGetProjectionv(projection);
 		PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);


### PR DESCRIPTION
## Summary
- Fold the lens flare alpha scaling expression so MWCC keeps the multiply in the target register sequence.
- Improves pppFrameLensFlare without changing behavior or data layout.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppLensFlare -o - pppFrameLensFlare
- pppFrameLensFlare: 99.66824% -> 99.71564% match, size remains 844 bytes.
- pppRenderLensFlare and pppConstructLensFlare remain 100% matched.

## Plausibility
- This is source-equivalent arithmetic cleanup: the same alpha scale is computed in one expression instead of assignment plus multiply, matching the compiler original scheduling more closely.