### PR TITLE
Improve map tex anim calc match

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -159,8 +159,12 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
 
             if (reachedFrame != 0) {
                 const unsigned short textureIndex = m_frameTable[keyFrameIndex];
-                void* texture = TextureAt(textureSet, textureIndex);
-                SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
+                void* texture =
+                    (*reinterpret_cast<CPtrArray<CTexture*>*>(reinterpret_cast<unsigned char*>(textureSet) + 8))
+                        [textureIndex];
+                SetMaterialTextureSlot(
+                    (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))
+                        [static_cast<unsigned long>(m_materialIndex)],
                     static_cast<unsigned long>(m_textureSlot), texture);
 
                 if (m_usesBlendTexture != 0) {
@@ -174,8 +178,12 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
                 }
             } else {
                 const unsigned short textureIndex = m_frameTable[keyFrameIndex];
-                void* texture = TextureAt(textureSet, textureIndex);
-                SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
+                void* texture =
+                    (*reinterpret_cast<CPtrArray<CTexture*>*>(reinterpret_cast<unsigned char*>(textureSet) + 8))
+                        [textureIndex];
+                SetMaterialTextureSlot(
+                    (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))
+                        [static_cast<unsigned long>(m_materialIndex)],
                     static_cast<unsigned long>(m_textureSlot), texture);
 
                 if (m_usesBlendTexture != 0) {
@@ -197,8 +205,11 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
     frame = m_currentFrame;
     const int frameIndex = static_cast<int>(frame);
     const unsigned short textureIndex = m_frameTable[frameIndex & 0xFFFF];
-    SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
-        static_cast<unsigned long>(m_textureSlot), TextureAt(textureSet, textureIndex));
+    SetMaterialTextureSlot(
+        (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(materialSet) + 8))
+            [static_cast<unsigned long>(m_materialIndex)],
+        static_cast<unsigned long>(m_textureSlot),
+        (*reinterpret_cast<CPtrArray<CTexture*>*>(reinterpret_cast<unsigned char*>(textureSet) + 8))[textureIndex]);
 
     m_currentFrame = m_currentFrame + m_frameStep;
     if (m_currentFrame >= static_cast<float>(m_endFrame)) {


### PR DESCRIPTION
## Summary
- Use direct CPtrArray access for the primary material/texture swaps in CMapTexAnim::Calc.
- Avoid the helper wrapper form at the sites where it causes MWCC to keep extra array-base temporaries live.

## Evidence
- ninja: passes
- Objdiff main/maptexanim Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet:
  - before: 1520b, 92.14439% match
  - after: 1508b, 93.649734% match
- Unit .text is now 2808b against target 2796b.

## Plausibility
- The changed sites still use the real CPtrArray operator[] on the material and texture arrays at offset 8.
- This matches the decompiled function shape more closely at the primary texture swap calls without adding fake symbols or manual linkage hacks.