### PR TITLE
Recover CUSBPcs table descriptors

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -5,10 +5,28 @@
 #include "ffcc/usb.h"
 #include "ffcc/system.h"
 
+extern u32 m_table_desc0__7CUSBPcs[];
+extern u32 m_table_desc1__7CUSBPcs[];
+extern u32 m_table_desc2__7CUSBPcs[];
+extern u32 m_table__7CUSBPcs[];
+
 class CUSBPcs : public CProcess
 {
 public:
-    CUSBPcs();
+    CUSBPcs()
+    {
+        u32* table = m_table__7CUSBPcs;
+
+        table[1] = m_table_desc0__7CUSBPcs[0];
+        table[2] = m_table_desc0__7CUSBPcs[1];
+        table[3] = m_table_desc0__7CUSBPcs[2];
+        table[4] = m_table_desc1__7CUSBPcs[0];
+        table[5] = m_table_desc1__7CUSBPcs[1];
+        table[6] = m_table_desc1__7CUSBPcs[2];
+        table[7] = m_table_desc2__7CUSBPcs[0];
+        table[8] = m_table_desc2__7CUSBPcs[1];
+        table[9] = m_table_desc2__7CUSBPcs[2];
+    }
 
     void Init();
     void Quit();
@@ -30,7 +48,6 @@ public:
 };
 
 extern CUSBPcs USBPcs;
-extern u32 m_table__7CUSBPcs[];
 extern int s_usbReadPollFrameCounter;
 extern char s_usbReadPollInitialized;
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -13,35 +13,15 @@ extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 const char s_CUSBPcs_8032f810[] = "CUSBPcs";
+u32 m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__7CUSBPcsFv)};
+u32 m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__7CUSBPcsFv)};
+u32 m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(func__7CUSBPcsFv)};
 u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-inline CUSBPcs::CUSBPcs()
-{
-    u32* table = reinterpret_cast<u32*>(m_table__7CUSBPcs);
-    static u32 desc0[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__7CUSBPcsFv)};
-    static u32 desc1[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__7CUSBPcsFv)};
-    static u32 desc2[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(func__7CUSBPcsFv)};
-
-    table[1] = desc0[0];
-    table[2] = desc0[1];
-    table[3] = desc0[2];
-    table[4] = desc1[0];
-    table[5] = desc1[1];
-    table[6] = desc1[2];
-    table[7] = desc2[0];
-    table[8] = desc2[1];
-    table[9] = desc2[2];
-}
 
 static inline unsigned int Align32(unsigned int x)
 {


### PR DESCRIPTION
## Summary
- Promote the three CUSBPcs process-table descriptors to named .data objects matching symbols.txt.
- Move the CUSBPcs constructor table-copy logic into the header, matching the pattern used by other process classes with descriptor tables.

## Evidence
- ninja: passes, build/GCCP01/main.dol OK.
- p_usb objdiff now has exact descriptor symbols:
  - m_table_desc0__7CUSBPcs: 100%
  - m_table_desc1__7CUSBPcs: 100%
  - m_table_desc2__7CUSBPcs: 100%
  - m_table__7CUSBPcs: 100%
- p_usb .data improves to 87.6933% with descriptors placed before m_table as listed in config/GCCP01/symbols.txt.

## Notes
- SendDataCode remains 98.74436%.
- __sinit_p_usb_cpp still differs because the compiler emits section-base relocation setup for the contiguous data block; this PR keeps the source structure and data ownership closer to the shipped symbol layout rather than hiding the descriptors as constructor-local statics.