### PR TITLE
Fix YmTracer spline endpoints

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -328,10 +328,10 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
             for (i = 0; i < (s32)(u32)param_2->m_payload[9]; i++) {
                 f32 t = stepScale * (f32)(i + 1);
 
-                gUtil.GetSplinePos(splineFrom[(param_2->m_payload[9] - 1) - i], entries[3].to, entries[2].to,
-                                          entries[1].to, entries[0].from, t, FLOAT_803306ec);
-                gUtil.GetSplinePos(splineTo[(param_2->m_payload[9] - 1) - i], entries[4].from, entries[3].from,
-                                          entries[2].from, entries[0].to, t, FLOAT_803306ec);
+                gUtil.GetSplinePos(splineFrom[(param_2->m_payload[9] - 1) - i], entries[3].from, entries[2].from,
+                                          entries[1].from, entries[0].from, t, FLOAT_803306ec);
+                gUtil.GetSplinePos(splineTo[(param_2->m_payload[9] - 1) - i], entries[3].to, entries[2].to,
+                                          entries[1].to, entries[0].to, t, FLOAT_803306ec);
 
                 splineCount++;
                 work->count++;


### PR DESCRIPTION
## Summary
- Correct pppFrameYmTracer spline interpolation to use from history for the from endpoint and to history for the to endpoint.
- This matches the Ghidra offset pattern and keeps the trail endpoints coherent instead of mixing opposite sides of the tracer strip.

## Evidence
- ninja passes for GCCP01.
- pppFrameYmTracer objdiff improved from 94.68107% to 94.71811%.
- pppRenderYmTracer remained unchanged at 98.54348% during validation.

## Plausibility
The change follows the data layout already modeled in TRACE_POLYGON: each spline is built from one endpoint history, which is what the original decomp offsets indicate. No section forcing, fake labels, or address hacks were added.