### PR TITLE
Remove unused ppp random helper stubs

### DIFF
--- a/include/ffcc/pppRandCV.h
+++ b/include/ffcc/pppRandCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppRandDownCV.h
+++ b/include/ffcc/pppRandDownCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDDOWNCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppRandUpCV.h
+++ b/include/ffcc/pppRandUpCV.h
@@ -2,8 +2,6 @@
 #define _PPP_RANDUPCV_H_
 
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/include/ffcc/pppSRandDownCV.h
+++ b/include/ffcc/pppSRandDownCV.h
@@ -5,8 +5,6 @@
 extern "C" {
 #endif
 
-void randchar(char, float);
-void randf(unsigned char);
 void pppSRandDownCV(void* param1, void* param2, void* param3);
 
 #ifdef __cplusplus

--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -85,17 +85,3 @@ void pppRandCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -84,17 +84,3 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
         target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
-}

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -73,17 +73,3 @@ void pppRandHCV(void* p1, void* p2, void* p3)
 }
 
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static short randshort(short value, float scale)
-{
-    return (short)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -77,17 +77,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -66,17 +66,3 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
     target[1] += (s32)((f32)in->fieldC * scale);
     target[2] += (s32)((f32)in->field10 * scale);
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((f32)value * scale);
-}

--- a/src/pppSRandDownCV.cpp
+++ b/src/pppSRandDownCV.cpp
@@ -113,23 +113,3 @@ void pppSRandDownCV(void* param1, void* param2, void* param3)
         target_colors[3] = (u8)(target_colors[3] + delta);
     }
 }
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void randchar(char, float)
-{
-    // TODO
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void randf(unsigned char)
-{
-    // TODO
-}


### PR DESCRIPTION
## Summary
- Remove emitted unused randchar/randint/randshort helper stubs from ppp random units where the PAL object only contains the exported particle function.
- Drop matching unused header declarations for the removed helpers.

## Objdiff evidence
- main/pppRandDownIV: compiled .text 460 -> 404 bytes; PAL .text is 404 bytes; pppRandDownIV remains 99.60396%.
- main/pppRandUpIV: compiled .text 460 -> 404 bytes; PAL .text is 404 bytes; pppRandUpIV remains 99.60396%.
- main/pppRandCV: compiled .text 620 -> 544 bytes; removed extra randchar__Fcf symbol; pppRandCV remains 98.703705%.
- main/pppRandDownCV: compiled .text 532 -> 472 bytes; PAL .text is 472 bytes; pppRandDownCV remains 99.57627%.
- main/pppRandHCV: compiled .text 600 -> 524 bytes; PAL .text is 524 bytes; pppRandHCV remains 99.46565%.
- main/pppRandUpCV: compiled .text 532 -> 472 bytes; PAL .text is 472 bytes; pppRandUpCV remains 99.57627%.
- main/pppSRandDownCV: compiled .text 664 -> 656 bytes; PAL .text is 656 bytes; pppSRandDownCV remains 100%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/<unit> -o - for each changed unit

## Plausibility
These helpers were marked UNUSED/TODO and were not referenced by the exported particle functions. Removing them eliminates extra compiler-emitted symbols and brings the units closer to the PAL object layout without manual section or vtable forcing.