### PR TITLE
Improve CMath::Spline1D matching

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -942,14 +942,16 @@ float CMath::Spline1D(int lastIndex, float t, float* x, float* y, float* secondD
         low--;
     }
 
+    float x0 = x[low];
     float sd0 = secondDerivatives[low];
-    float dt = t - x[low];
-    float dx = x[low + 1] - x[low];
+    float sd1 = secondDerivatives[low + 1];
+    float dt = t - x0;
+    float y0 = y[low];
+    float dx = x[low + 1] - x0;
+    float cubic = FLOAT_8032F758 * sd0 + (dt * (sd1 - sd0)) / dx;
+    float linear = dx * (FLOAT_8032F75C * sd0 + sd1) - (y[low + 1] - y0) / dx;
 
-    return dt * (dt * (FLOAT_8032F758 * sd0 + (dt * (secondDerivatives[low + 1] - sd0)) / dx) +
-                 -(dx * (FLOAT_8032F75C * sd0 + secondDerivatives[low + 1]) -
-                   (y[low + 1] - y[low]) / dx)) +
-           y[low];
+    return ((dt * cubic) - linear) * dt + y0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- reshape `CMath::Spline1D` temporaries and final expression in `src/math.cpp`
- keep the same spline math while steering MWCC toward a closer register and arithmetic sequence
- avoid ABI, signature, or linkage changes

## Evidence
- `Spline1D__5CMathFifPfPfPf`: 96.72727% -> 97.09091%
- symbol diff instructions: 12 -> 10
- `main/math` `.text`: 98.58206% -> 98.591606%
- `ninja`: passes

## Plausibility
- this is a source-shape cleanup of an existing decomp, not compiler coaxing with hacks
- the function now names the intermediate spline terms explicitly and mirrors the observed arithmetic flow more closely