### PR TITLE
Define pppBlurChara sdata2 constant

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -61,6 +61,7 @@ extern float FLOAT_80331048;
 extern float FLOAT_8033104c;
 extern float FLOAT_80331050;
 extern float FLOAT_80331054;
+extern const double DOUBLE_80330FE8 = 3.0;
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 


### PR DESCRIPTION
## Summary
- Defines the missing pppBlurChara sdata2 double constant at DOUBLE_80330FE8.
- Matches the unit's .sdata2 section without changing generated text.

## Evidence
- Before: main/pppBlurChara .sdata2 was 62.5% matched.
- After: main/pppBlurChara .sdata2 is 100.0% matched.
- Text remains 98.79124% for the unit; pppRenderBlurChara remains 99.161644%, and BlurChara_AfterDrawModelCallback remains 97.6679%.
- Full ninja passes: build/GCCP01/main.dol OK.

## Plausibility
- DOUBLE_80330FE8 is the target-owned 3.0 double in this unit's .sdata2. Defining it in source restores the expected data layout instead of relying on an anonymous compiler-emitted constant.