### PR TITLE
Define FLOAT_80330dac in pppYmDeformationMdl

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -52,6 +52,7 @@ extern float FLOAT_80330D9C;
 extern float FLOAT_80330DA0;
 extern float FLOAT_80330DA4;
 extern float FLOAT_80330DA8;
+extern const float FLOAT_80330dac = 0.0f;
 
 static inline Mtx& CameraMatrix()
 {


### PR DESCRIPTION
## Summary
- define the PAL-owned `FLOAT_80330dac` constant in `src/pppYmDeformationMdl.cpp`
- keep the change isolated to the owning translation unit so the object now emits the missing `.sdata2` symbol without touching function bodies

## Evidence
- `ninja` succeeds
- `nm -a build/GCCP01/src/pppYmDeformationMdl.o` now shows `FLOAT_80330dac` in `.sdata2`
- `objdump -h build/GCCP01/src/pppYmDeformationMdl.o` shows `.sdata2` at `0x18` bytes, matching the split range size for `pppYmDeformationMdl.cpp`

## Plausibility
- `config/GCCP01/symbols.txt` assigns `FLOAT_80330dac` to this unit's `.sdata2` range
- this is a source-level definition/linkage fix rather than compiler coaxing or synthetic data placement