### PR TITLE
Improve pppEmission callback TEV constant setup

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -36,8 +36,6 @@ extern const float FLOAT_803311f8;
 static const char s_pppEmission_cpp_801db7e8[] = "pppEmission.cpp";
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
-static inline MtxPtr CameraMatrix() { return reinterpret_cast<MtxPtr>(reinterpret_cast<unsigned char*>(&CameraPcs) + 0x4); }
-
 void pppInitBlendMode(void);
 void pppSetBlendMode(unsigned char);
 
@@ -366,7 +364,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
     if ((strcmp((const char*)meshData, &DAT_803311fc) == 0) && (state->m_colorA != 0)) {
         int texture = state->m_texture;
         int drawTevBits = 0xACE0F;
-        int fullTevBits = drawTevBits | 0x40000;
+        int fullTevBits = 0xECE0F;
 
         pppInitBlendMode();
         pppSetBlendMode(step->m_payload[8]);
@@ -385,7 +383,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 scale += (float)i * state->m_scale0;
                 PSMTXScale(objMtx0, scale, scale, scale);
                 PSMTXConcat(param_5, objMtx0, objMtx0);
-                PSMTXCopy(CameraMatrix(), viewMtx0);
+                PSMTXCopy(CameraPcs.m_cameraMatrix, viewMtx0);
                 SetObjMatrix__12CMaterialManFPA4_fPA4_f(&MaterialMan, viewMtx0, objMtx0);
 
                 int remaining = meshData->m_displayListCount - 1;
@@ -438,7 +436,7 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
                 float scale = particle->m_scale;
                 PSMTXScale(objMtx1, scale, scale, scale);
                 PSMTXConcat(param_5, objMtx1, objMtx1);
-                PSMTXCopy(CameraMatrix(), viewMtx1);
+                PSMTXCopy(CameraPcs.m_cameraMatrix, viewMtx1);
                 PSMTXConcat(viewMtx1, objMtx1, objMtx1);
                 GXLoadPosMtxImm(objMtx1, 0);
 


### PR DESCRIPTION
## Summary
- make `Emission_AfterDrawMeshCallback` materialize the full TEV bit mask directly instead of deriving it with `| 0x40000`
- switch the callback over to `CameraPcs.m_cameraMatrix` directly instead of the local offset helper

## Evidence
- `main/pppEmission` before: `97.462395%` fuzzy match, `25.0%` matched data
- `main/pppEmission` after: `97.87883%` fuzzy match, `55.0%` matched data
- `Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f` remains at `94.990135%` while the unit-level data layout improves

## Why this is plausible
- the callback already programs both TEV bit states explicitly; using the final literal mask matches that intent without adding hacks or fake linkage
- reading the camera matrix through the real `CCameraPcs` member is cleaner and closer to normal source than a local raw-offset helper

## Verification
- `ninja -j4`
- inspected `build/GCCP01/report.json` for `main/pppEmission` progress