### PR TITLE
Match CUSBPcs table descriptor globals

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -30,6 +30,9 @@ public:
 };
 
 extern CUSBPcs USBPcs;
+extern unsigned int m_table_desc0__7CUSBPcs[];
+extern unsigned int m_table_desc1__7CUSBPcs[];
+extern unsigned int m_table_desc2__7CUSBPcs[];
 extern u32 m_table__7CUSBPcs[];
 extern int s_usbReadPollFrameCounter;
 extern char s_usbReadPollInitialized;

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -20,6 +20,10 @@ static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
+unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
+
 /*
  * --INFO--
  * Address:	TODO
@@ -27,10 +31,10 @@ extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stag
  */
 inline CUSBPcs::CUSBPcs()
 {
-    u32* table = reinterpret_cast<u32*>(m_table__7CUSBPcs);
-    static u32 desc0[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__7CUSBPcsFv)};
-    static u32 desc1[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__7CUSBPcsFv)};
-    static u32 desc2[] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(func__7CUSBPcsFv)};
+    unsigned int* table = reinterpret_cast<unsigned int*>(m_table__7CUSBPcs);
+    const unsigned int* desc0 = m_table_desc0__7CUSBPcs;
+    const unsigned int* desc1 = m_table_desc1__7CUSBPcs;
+    const unsigned int* desc2 = m_table_desc2__7CUSBPcs;
 
     table[1] = desc0[0];
     table[2] = desc0[1];


### PR DESCRIPTION
## Summary
- define real `CUSBPcs` table descriptor globals instead of constructor-local static arrays
- update `CUSBPcs::CUSBPcs()` to load those globals before copying them into `m_table__7CUSBPcs`
- expose the descriptor symbols in `p_usb.h` so the linkage model matches the object layout

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o -`
- `main/p_usb` `.data` match improved from `78.41495%` to `87.6933%`
- `m_table_desc0__7CUSBPcs`, `m_table_desc1__7CUSBPcs`, `m_table_desc2__7CUSBPcs`, and `m_table__7CUSBPcs` now all match `100%`
- `SendDataCode__7CUSBPcsFiPvii` remains at `98.74436%`

## Why this is plausible
- the target assembly already uses global `m_table_desc*__7CUSBPcs` objects in `.data`
- moving the descriptors out of constructor-local statics removes a decomp convenience and restores the original linkage/data layout