### PR TITLE
Improve pppYmChangeTex frame conversion

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -254,7 +254,7 @@ void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, 
 	Mtx modelMtx;
 
 	ChangeTexMeshRef* curMesh = model0Raw->m_meshes;
-	int frame = (int)((double)state->m_value0 * (double)(1 << model0Raw->m_data->m_frameShift));
+	int frame = (int)(state->m_value0 * (float)(1 << model0Raw->m_data->m_frameShift));
 	short frameShort = (short)frame;
 	PSMTXCopy(model0Raw->m_matrix, modelMtx);
 


### PR DESCRIPTION
## Summary
- Keep the pppFrameYmChangeTex frame-scale calculation in single precision instead of promoting through double.
- This matches the PAL codegen around the frame conversion more closely while preserving the existing control flow and data layout.

## Evidence
- ninja passes for GCCP01.
- objdiff pppFrameYmChangeTex: 97.29747% -> 97.677216%, size remains 1264 bytes.

## Plausibility
- The target uses single-precision fsubs/fmuls in this path; using a float scale for the shifted frame factor is more consistent with nearby particle code and avoids an unnecessary double promotion.