### PR TITLE
Improve pppYmMegaBirthShpTail2 render loop state

### DIFF
--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -204,6 +204,12 @@ void pppRenderYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, pppYmMegaBirth
                 }
             }
         }
+        if (wmats != 0) {
+            wmats = wmats + 1;
+        }
+        if (colors != 0) {
+            colors = colors + 1;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- advance the per-particle `_PARTICLE_WMAT` and `_PARTICLE_COLOR` pointers in `pppRenderYmMegaBirthShpTail2` to match the original loop state progression
- keep the change limited to plausible source behavior in the target unit

## Evidence
- `ninja` passes
- `pppRenderYmMegaBirthShpTail2`: `24.080435%` -> `24.613043%`
- unit `.text` match for `main/pppYmMegaBirthShpTail2`: `43.344685%` -> `43.473022%`
- `pppFrameYmMegaBirthShpTail2` remains stable at `63.410446%` after trimming non-improving edits

## Why this is plausible
- the shipped Ghidra decomp for `8008acc4_pppRenderYmMegaBirthShpTail2` advances both auxiliary particle-state pointers each loop iteration, while the current source did not
- restoring that loop state is a source-level correction, not compiler coaxing