### PR TITLE
Improve pppFrameCrystal texture lookup typing

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -252,19 +252,19 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 		CrystalWork* work = (CrystalWork*)((u8*)pppCrystal + param_3->m_serializedDataOffsets[2] + 0x80);
 
 		if (param_2->m_dataValIndex != 0xFFFF) {
-			CMapMesh** mapMeshTable = pppEnvStPtr->m_mapMeshPtr;
-			CMapMesh* mapMesh = mapMeshTable[param_2->m_dataValIndex];
+			CMapMesh** mapMeshTable = (CMapMesh**)pppEnvStPtr->m_mapMeshPtr;
 			int textureIndex = 0;
 
-			GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
+			GetTexture__8CMapMeshFP12CMaterialSetRi(
+				mapMeshTable[param_2->m_dataValIndex], pppEnvStPtr->m_materialSetPtr, textureIndex);
 
 			if (param_2->m_payload[0] == 0) {
 				if (param_2->m_initWOrk == 0xFFFF) {
 					return;
 				}
 
-				mapMesh = mapMeshTable[param_2->m_initWOrk];
-				GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
+				GetTexture__8CMapMeshFP12CMaterialSetRi(
+					mapMeshTable[param_2->m_initWOrk], pppEnvStPtr->m_materialSetPtr, textureIndex);
 			}
 
 			if ((param_2->m_payload[0] == 1) && (work->m_refractionMap == 0)) {


### PR DESCRIPTION
## Summary
- tighten  texture lookup typing in 
- remove the temporary  local and index directly through a correctly typed  table
- keep behavior unchanged while improving codegen for the PAL  unit

## Evidence
-   match improved from  on  to  on this branch
- build is clean with [1/1] PROGRESS
Progress:
  All: 25.94% matched, 18.44% linked (306 / 630 files)
    Code: 481260 / 1855224 bytes (3028 / 4732 functions)
    Data: 1091391 / 1489575 bytes (73.27%)
  Game Code: 10.46% matched, 2.21% linked (104 / 265 files)
    Code: 154556 / 1477652 bytes (1567 / 3111 functions)
    Data: 914289 / 1103477 bytes (82.86%)
  RedSound: 25.27% matched, 0.00% linked (0 / 8 files)
    Code: 17204 / 68072 bytes (219 / 379 functions)
    Data: 19484 / 25844 bytes (75.39%)
  SDK Code: 100.00% matched, 100.00% linked (202 / 202 files)
    Code: 309500 / 309500 bytes (1242 / 1242 functions)
    Data: 157618 / 158254 bytes (99.60%)
- change is plausible original source: it replaces an unnecessary local with direct indexed access through the environment mesh table rather than compiler coaxing or ABI hacks

## Notes
-  remains the same high-level logic; this is a codegen-focused cleanup around typed mesh lookups
- no generated ctors/dtors, section forcing, or address hacks were introduced