### PR TITLE
Improve YmMiasma particle init vector copy

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -560,9 +560,7 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     trigCos = trigSin * (vYmMiasma->m_radius + radiusJitter);
     particleData->m_matrix[0][2] = trigCos;
     particleData->m_matrix[1][2] = trigCos;
-    normalizedPos.x = particleData->m_matrix[1][0];
-    normalizedPos.y = particleData->m_matrix[1][1];
-    normalizedPos.z = particleData->m_matrix[1][2];
+    pppCopyVector(normalizedPos, *(Vec*)particleData->m_matrix[1]);
     pppNormalize__FR3Vec3Vec(particleData->m_matrix[1], &normalizedPos);
     if ((s32)Game.m_currentSceneId != 7) {
         basePos.x = pppMngStPtr->m_matrix.value[0][3];


### PR DESCRIPTION
## Summary
- Use the existing particle vector copy helper when preparing the normalized position in InitParticleData.
- Keeps the change localized to src/pppYmMiasma.cpp.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o /tmp/pppYmMiasma_diff_final.json
- InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP14_PARTICLE_DATA: 88.288994% -> 88.357796%.

## Plausibility
- The file already uses pppCopyVector for YmMiasma render vector movement.
- This replaces three field-wise vector assignments with the same project-local vector-copy idiom.