### PR TITLE
Improve pppLocationTitle render and font glyph layout

### DIFF
--- a/include/ffcc/fontman.h
+++ b/include/ffcc/fontman.h
@@ -79,8 +79,8 @@ public:
 	_GXColor m_color;
 	CTexture* texturePtr;
 	void* m_glyphData;
-	unsigned short* m_glyphBuckets[64];
-	unsigned char m_pad13c[0x304];
+	unsigned short* m_glyphBuckets[256];
+	unsigned char m_pad43c[4];
 	unsigned char m_tlutData[0x1000];
 };
 

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -643,15 +643,15 @@ void CFont::Create(void* filePtr, CMemory::CStage* stage)
                     m_glyphHeight = static_cast<unsigned short>(chunkFile.Get4());
                     m_glyphColumns = static_cast<unsigned short>(chunkFile.Get4());
                 } else if (chunk.m_id == 0x44415441) {
-                    if (m_usesEmbeddedData == 0) {
-                        m_glyphData = ::operator new(chunk.m_size, stage, const_cast<char*>(s_fontman_cpp), 0xCF);
-                        chunkFile.Get(m_glyphData, chunk.m_size);
-                    } else {
+                    if (m_usesEmbeddedData != 0) {
                         m_glyphData = chunkFile.GetAddress();
+                    } else {
+                        m_glyphData = new (stage, const_cast<char*>(s_fontman_cpp), 0xCF) unsigned char[chunk.m_size];
+                        chunkFile.Get(m_glyphData, chunk.m_size);
                     }
 
                     unsigned short* bucket = static_cast<unsigned short*>(m_glyphData);
-                    for (int i = 0; i < 64; i++) {
+                    for (int i = 0; i < 256; i++) {
                         m_glyphBuckets[i] = bucket;
                         bucket = reinterpret_cast<unsigned short*>(
                             reinterpret_cast<unsigned char*>(bucket) + static_cast<unsigned int>(*bucket) * 8 + 2);

--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -58,10 +58,10 @@ void pppRenderLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitle
     int serializedOffset;
     LocationTitleWork* work;
     int graphFrame;
-    int fadeDivisor;
     LocationTitleParticle* particle;
     LocationTitleParticle* particles;
     long** shapeTable;
+    int fadeDivisor;
 
     dataValIndex = param_2->m_dataValIndex;
     serializedOffset = *param_3->m_serializedDataOffsets;


### PR DESCRIPTION
## Summary
- Match `pppRenderLocationTitle` by aligning the fade divisor and shape table local ordering.
- Correct `CFont` glyph bucket layout to expose all 256 buckets while preserving the TLUT offset.
- Update `CFont::Create` to use the array allocator for glyph data and initialize all 256 buckets, with the embedded-data branch ordered like the target.

## Evidence
- `ninja` succeeds for GCCP01.
- `pppRenderLocationTitle`: 99.7% -> 100.0% match.
- `Create__5CFontFPvPQ27CMemory6CStage`: 61.962963% -> 67.0% match.
- Build report after changes: 482928 / 1855224 code bytes matched, 3048 / 4732 functions matched.

## Plausibility
- The font data is indexed by byte-sized character values, so the bucket table should contain 256 entries; the explicit 4-byte pad preserves the existing `m_tlutData` offset.
- Glyph data allocation now uses the same array-new path as the target code instead of scalar `operator new`.