### PR TITLE
Reference shared CManager RTTI in usb

### DIFF
--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/system.h"
 
 extern "C" void* __vt__8CManager[];
+extern "C" void* __RTTI__8CManager[];
 
 CUSB USB;
 


### PR DESCRIPTION
## Summary
- Declare the shared CManager RTTI symbol in usb.cpp so CUSB RTTI references the existing owner instead of emitting a duplicate CManager RTTI object.
- Keeps usb.cpp code fully matched while improving its data layout.

## Evidence
- ninja passes.
- main/usb objdiff remains 100% for .text and all functions.
- [.data-0] improves from 38.78788% to 74.89879%.
- __vt__4CUSB improves to 100%.

## Plausibility
- system.cpp already owns CManager RTTI/vtable data; usb.cpp already references the shared CManager vtable, so referencing the shared CManager RTTI is consistent with the intended linkage instead of compiler-emitting a duplicate local copy.