### PR TITLE
Improve CSound 3D stop matching

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1954,7 +1954,6 @@ void CSound::StopSe3DGroup(int group)
             } else {
                 u8* search = reinterpret_cast<u8*>(this) + 0x2C;
                 int count = 0x20;
-                int idx = 0;
                 u8* found;
                 do {
                     if ((((search[0] & 0x80) != 0 &&
@@ -1967,7 +1966,6 @@ void CSound::StopSe3DGroup(int group)
                           (found = search + 0x78, *reinterpret_cast<int*>(search + 0x7C) == se3dHandle)))) {
                         goto found_se;
                     }
-                    idx += 3;
                     search += 0xA0;
                     count--;
                 } while (count != 0);
@@ -2027,7 +2025,7 @@ found_entry:
         if (found != 0) {
             const int playId = *reinterpret_cast<int*>(found + 8);
             if (playId < 0) {
-                Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
+                Printf__7CSystemFPce(&System, s_soundMinusOneFmt, idx);
             } else {
                 SeStop__9CRedSoundFi(RedSound(this), playId);
             }


### PR DESCRIPTION
## Summary
- Pass the missing search index into the invalid play-id diagnostic in `CSound::StopSe3D`, matching the PAL decompilation shape.
- Remove the unused inner search counter in `CSound::StopSe3DGroup`; the target loop does not carry that counter.

## Evidence
- `ninja`
- `main/sound` `.text`: 77.76497% -> 77.85654%
- `StopSe3D__6CSoundFi`: 67.30556% -> 72.083336%
- `StopSe3DGroup__6CSoundFi`: unchanged at 67.50538%

## Plausibility
- The added diagnostic argument is present in the Ghidra PAL decompilation for `StopSe3D__6CSoundFi`.
- The `StopSe3DGroup` cleanup removes source-only dead bookkeeping from the nested lookup loop without changing generated output.
