### PR TITLE
Improve pppFrameCrystal map mesh access

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -252,8 +252,7 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 		CrystalWork* work = (CrystalWork*)((u8*)pppCrystal + param_3->m_serializedDataOffsets[2] + 0x80);
 
 		if (param_2->m_dataValIndex != 0xFFFF) {
-			CMapMesh** mapMeshTable = pppEnvStPtr->m_mapMeshPtr;
-			CMapMesh* mapMesh = mapMeshTable[param_2->m_dataValIndex];
+			CMapMesh* mapMesh = pppEnvStPtr->m_mapMeshPtr[param_2->m_dataValIndex];
 			int textureIndex = 0;
 
 			GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
@@ -263,7 +262,7 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 					return;
 				}
 
-				mapMesh = mapMeshTable[param_2->m_initWOrk];
+				mapMesh = pppEnvStPtr->m_mapMeshPtr[param_2->m_initWOrk];
 				GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr, textureIndex);
 			}
 


### PR DESCRIPTION
## Summary
- reload `pppEnvStPtr->m_mapMeshPtr` at each `GetTexture` use in `pppFrameCrystal` instead of keeping a cached local table
- matches the target access pattern more closely and reduces register pressure in the function

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/pppCrystal -o - pppFrameCrystal`
- `pppFrameCrystal`: 95.53704% -> 96.68519%
- `main/pppCrystal` `.text`: 98.16493% -> 98.62556%

## Plausibility
The change removes an unnecessary cached pointer and uses direct member access for the two map mesh lookups, which matches the decompiled target flow and is plausible original source.