### PR TITLE
Improve CPad accessor matching

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -664,12 +664,13 @@ extern "C" unsigned short GetGbaButtonDown__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
     unsigned int result;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -679,11 +680,9 @@ done_check:
     if (isInvalidPad) {
         result = 0;
     } else {
-        int activePad = *(int*)((char*)pad + 0x1C0);
-        int validMask = ~((activePad - padIndex) | (padIndex - activePad));
-        int slot = padIndex & ~(validMask >> 31);
-        unsigned int offset = static_cast<unsigned int>(slot) * 0x54 + 0xA;
-        result = *(unsigned short*)((char*)pad + offset);
+        int activePad = self->_448_4_;
+        int slot = padIndex & ~((int)~(activePad - padIndex | padIndex - activePad) >> 31);
+        result = self->GetPadInputs()[slot].buttonDown[1];
     }
 
     return (unsigned short)result;
@@ -698,15 +697,16 @@ done_check:
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" double GetRightStickY__4CPadFl(void* pad, long padIndex)
+extern "C" float GetRightStickY__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -714,14 +714,11 @@ extern "C" double GetRightStickY__4CPadFl(void* pad, long padIndex)
 
 done_check:
     if (isInvalidPad) {
-        return (double)0.0f;
+        return 0.0f;
     }
 
-    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
-                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
-                                          31)) *
-                                               0x54 +
-                             0x30);
+    return self->GetPadInputs()[padIndex & ~((int)~(self->_448_4_ - padIndex | padIndex - self->_448_4_) >> 31)]
+        .substickYF;
 }
 
 /*
@@ -733,15 +730,16 @@ done_check:
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" double GetRightStickX__4CPadFl(void* pad, long padIndex)
+extern "C" float GetRightStickX__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -749,14 +747,11 @@ extern "C" double GetRightStickX__4CPadFl(void* pad, long padIndex)
 
 done_check:
     if (isInvalidPad) {
-        return (double)0.0f;
+        return 0.0f;
     }
 
-    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
-                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
-                                          31)) *
-                                               0x54 +
-                             0x2C);
+    return self->GetPadInputs()[padIndex & ~((int)~(self->_448_4_ - padIndex | padIndex - self->_448_4_) >> 31)]
+        .substickXF;
 }
 
 /*
@@ -768,15 +763,16 @@ done_check:
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" double GetLeftStickY__4CPadFl(void* pad, long padIndex)
+extern "C" float GetLeftStickY__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -784,14 +780,11 @@ extern "C" double GetLeftStickY__4CPadFl(void* pad, long padIndex)
 
 done_check:
     if (isInvalidPad) {
-        return (double)0.0f;
+        return 0.0f;
     }
 
-    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
-                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
-                                          31)) *
-                                               0x54 +
-                             0x28);
+    return self->GetPadInputs()[padIndex & ~((int)~(self->_448_4_ - padIndex | padIndex - self->_448_4_) >> 31)]
+        .stickYF;
 }
 
 /*
@@ -803,15 +796,16 @@ done_check:
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" double GetLeftStickX__4CPadFl(void* pad, long padIndex)
+extern "C" float GetLeftStickX__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -819,14 +813,11 @@ extern "C" double GetLeftStickX__4CPadFl(void* pad, long padIndex)
 
 done_check:
     if (isInvalidPad) {
-        return (double)0.0f;
+        return 0.0f;
     }
 
-    return (double)*(float*)((char*)pad + (padIndex & ~((int)~(*(int*)((char*)pad + 0x1C0) - padIndex |
-                                                        padIndex - *(int*)((char*)pad + 0x1C0)) >>
-                                          31)) *
-                                               0x54 +
-                             0x24);
+    return self->GetPadInputs()[padIndex & ~((int)~(self->_448_4_ - padIndex | padIndex - self->_448_4_) >> 31)]
+        .stickXF;
 }
 
 /*
@@ -842,12 +833,13 @@ extern "C" unsigned short GetButtonRepeat__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
     unsigned int result;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -857,11 +849,9 @@ done_check:
     if (isInvalidPad) {
         result = 0;
     } else {
-        int activePad = *(int*)((char*)pad + 0x1C0);
-        int validMask = ~((activePad - padIndex) | (padIndex - activePad));
-        int slot = padIndex & ~(validMask >> 31);
-        unsigned int offset = static_cast<unsigned int>(slot) * 0x54 + 0x14;
-        result = *(unsigned short*)((char*)pad + offset);
+        int activePad = self->_448_4_;
+        int slot = padIndex & ~((int)~(activePad - padIndex | padIndex - activePad) >> 31);
+        result = self->GetPadInputs()[slot].repeatButton;
     }
 
     return (unsigned short)result;
@@ -880,12 +870,13 @@ extern "C" unsigned short GetButton__4CPadFl(void* pad, long padIndex)
 {
     bool isInvalidPad = false;
     unsigned int result;
+    CPad* self = static_cast<CPad*>(pad);
 
-    if (*(int*)((char*)pad + 0x1C4) == 0) {
+    if (self->_452_4_ == 0) {
         if (padIndex != 0) {
             goto done_check;
         }
-        if (*(int*)((char*)pad + 0x1C0) == -1) {
+        if (self->_448_4_ == -1) {
             goto done_check;
         }
     }
@@ -895,11 +886,9 @@ done_check:
     if (isInvalidPad) {
         result = 0;
     } else {
-        int activePad = *(int*)((char*)pad + 0x1C0);
-        int validMask = ~((activePad - padIndex) | (padIndex - activePad));
-        int slot = padIndex & ~(validMask >> 31);
-        unsigned int offset = static_cast<unsigned int>(slot) * 0x54 + 4;
-        result = *(unsigned short*)((char*)pad + offset);
+        int activePad = self->_448_4_;
+        int slot = padIndex & ~((int)~(activePad - padIndex | padIndex - activePad) >> 31);
+        result = self->GetPadInputs()[slot].button[0];
     }
 
     return (unsigned short)result;

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -387,9 +387,10 @@ CMaterial* CPtrArray<CMaterial*>::GetAt(unsigned long index)
 unsigned short CPad::GetButtonDown(long padIndex)
 {
     bool shouldZero = false;
+    unsigned short result;
 
-    if (_1c4_4_ == 0) {
-        if ((padIndex == 0) && (_1c0_4_ == 0xFFFFFFFF)) {
+    if (_452_4_ == 0) {
+        if ((padIndex == 0) && (_448_4_ == -1)) {
             goto read_slot;
         }
     }
@@ -397,13 +398,17 @@ unsigned short CPad::GetButtonDown(long padIndex)
     shouldZero = true;
 read_slot:
     if (shouldZero) {
-        return 0;
+        result = 0;
+        goto done;
     }
 
-    unsigned int padIndexU = static_cast<unsigned int>(padIndex);
-    unsigned int resolvedIndex =
-        padIndexU & ~((~(_1c0_4_ - padIndexU | padIndexU - _1c0_4_)) >> 31);
-    return GetPadInputs()[resolvedIndex].buttonDown[0];
+    {
+        unsigned int resolvedIndex = padIndex & ~((int)~(_448_4_ - padIndex | padIndex - _448_4_) >> 31);
+        result = GetPadInputs()[resolvedIndex].buttonDown[0];
+    }
+
+done:
+    return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Use typed CPad access in the CFlat pad accessors instead of raw byte offsets.
- Correct the stick accessors to return float values, matching the stored PadInput fields and target load shape.
- Use the signed debug-pad aliases in CPad::GetButtonDown.

## Objdiff evidence
- main/materialman GetButtonDown__4CPadFl: 77.0% -> 88.8% (current size now 100b, target 100b)
- main/cflat_r2system GetRightStickY__4CPadFl: 87.9167% -> 95.4167%
- main/cflat_r2system GetRightStickX__4CPadFl: 87.9167% -> 95.4167%
- main/cflat_r2system GetLeftStickY__4CPadFl: 87.9167% -> 95.4167%
- main/cflat_r2system GetLeftStickX__4CPadFl: 87.9167% -> 95.4167%
- main/cflat_r2system GetGbaButtonDown__4CPadFl: 95.4% -> 95.8%
- main/cflat_r2system GetButtonRepeat__4CPadFl: 95.4% -> 95.8%
- main/cflat_r2system GetButton__4CPadFl: 95.4% -> 95.8%

## Verification
- ninja
- git diff --check

## Plausibility
These changes replace raw offsets with the existing CPad::PadInput layout and use the signed aliases already present for the debug pad sentinel. The stick accessors now return float, which matches the underlying stored fields and the target lfs return path.