### PR TITLE
Fix CGame hook declarations

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -99,10 +99,10 @@ public:
     void clearWorkScript();
     void CheckScriptChange();
     void ChangeMap(int, int, int, int);
-    virtual void ScriptChanging(char*);
-    virtual void ScriptChanged(char*, int);
-    virtual void MapChanging(int, int);
-    virtual void MapChanged(int, int, int);
+    void ScriptChanging(char*);
+    void ScriptChanged(char*, int);
+    void MapChanging(int, int);
+    void MapChanged(int, int, int);
     void loadCfd();
     void Calc();
     void Calc2();


### PR DESCRIPTION
## Summary
- remove the stray `virtual` qualifiers from `CGame::ScriptChanging`, `ScriptChanged`, `MapChanging`, and `MapChanged`
- keep `CGame`'s ABI aligned with the actual non-polymorphic usage of those hooks

## Evidence
- `ninja` builds cleanly after the header change
- `build/tools/objdiff-cli diff -p . -u main/game -o -` now reports `__vt__5CGame` at `85.71429%`
- before this change, `__vt__5CGame` was `42.424248%`
- `__sinit_game_cpp` remains high at `99.4359%`, so the vtable improvement did not destabilize the nearby static init path

## Why this is plausible
- nothing derives from `CGame`
- these four methods are only called directly through the global `Game` instance or forwarded from `CGamePcs`
- leaving them `virtual` inflated `CGame`'s vtable beyond what the original object layout appears to use
