### PR TITLE
Improve pppLaser frame match and file rodata

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -90,6 +90,7 @@ static const char s_fatalErrorEs2[] = {0x64, 0x65, 0x20, 0x4E, 0x69, 0x6E, 0x74,
 
 static const char s_emptyErrorText[] = "";
 
+static const char s_cManager[] = "CManager";
 static const char s_cFile[] = "CFile";
 static const char s_drawErrorFmt[] = "CFile::drawError: %d\n";
 static const char s_fileCpp[] = "file.cpp";

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -345,7 +345,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
                 work->m_length = work->m_maxLength - FLOAT_80333458;
                 ParticleFrameCallback__5CGameFiiiiiP3Vec(
                     &Game, partIndex, (int)pppMngStPtr->m_kind, (int)pppMngStPtr->m_nodeIndex, 3,
-                    baseObj->m_graphId / 0x1000, &work->m_points[i]);
+                    baseObj->m_graphId / 0x1000, work->m_points);
                 work->m_spawnEnabled = 0;
             }
             if (work->m_spawnEnabled != 0) {


### PR DESCRIPTION
## Summary
- Pass the laser point base directly to ParticleFrameCallback in pppFrameLaser when the loop index is known to be zero.
- Recover the missing CManager rodata string in file.cpp so the file unit rodata layout matches.

## Evidence
- main/pppLaser pppFrameLaser: 87.44959% -> 88.9891%.
- main/pppLaser .text: 75.32284% -> 75.778854%.
- main/file .rodata: 99.79123% -> 100.0%.
- main/file .text/.data/.sdata2 unchanged by the rodata recovery.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppLaser -o /tmp/pppFrameLaser_final.json pppFrameLaser
- build/tools/objdiff-cli diff -p . -u main/file -o /tmp/file_after_rodata.json DrawError__5CFileFR11DVDFileInfoi

## Plausibility
- The pppFrameLaser callback is inside the i == 0 branch, so work->m_points is equivalent to &work->m_points[i] and avoids an indexed pointer shape the target does not have.
- The CManager string exists in the target file.o rodata immediately before the file error format strings, and adding it restores the target rodata layout without affecting codegen.