### PR TITLE
Improve mapmesh vertex chunk setup

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -409,18 +409,18 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
             m_meshData = __nwa__FUlPQ27CMemory6CStagePci(workSize, DAT_8032EC98, s_mapmesh_cpp_801D70B0, 0x13A);
 
             minInit = FLOAT_8032F930;
-            offset = 0;
             cursor = reinterpret_cast<unsigned char*>(Align32(reinterpret_cast<unsigned int>(m_meshData)));
             m_vertexCount = static_cast<unsigned short>(chunk.m_size / 0xC);
             m_vertices = cursor;
+            offset = 0;
             maxInit = FLOAT_8032F934;
+            cursor += chunk.m_size;
             m_bboxMinZ = minInit;
             m_bboxMinY = minInit;
             m_bboxMinX = minInit;
             m_bboxMaxZ = maxInit;
             m_bboxMaxY = maxInit;
             m_bboxMaxX = maxInit;
-            cursor += chunk.m_size;
 
             for (int i = 0; i < static_cast<int>(m_vertexCount); i++) {
                 float value = reader.GetF4();


### PR DESCRIPTION
## Summary
- Move the vertex chunk cursor advance in `CMapMesh::ReadOtmMesh` before bbox initialization.
- Keeps behavior the same while matching the target instruction order more closely.

## Evidence
- `main/mapmesh` `.text`: 99.12225% -> 99.16905%
- `ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`: 98.396164% -> 98.481674%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/mapmesh -o - ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`