### PR TITLE
Inline ppp rand conversion helpers

### DIFF
--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -22,6 +22,11 @@ struct PppRandDownCVParam3 {
     s32* fieldC;
 };
 
+inline char randchar(char value, float scale)
+{
+    return (char)((f32)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 80061384
@@ -65,23 +70,19 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
     f32 scale = *valuePtr;
     {
         s8 baseValue = in->field8;
-        f32 scaledValue = (f32)baseValue;
-        target[0] = (u8)(target[0] + (s32)(scaledValue * scale));
+        target[0] = (u8)(target[0] + randchar(baseValue, scale));
     }
     {
         s8 baseValue = in->field9;
-        f32 scaledValue = (f32)baseValue;
-        target[1] = (u8)(target[1] + (s32)(scaledValue * scale));
+        target[1] = (u8)(target[1] + randchar(baseValue, scale));
     }
     {
         s8 baseValue = in->fieldA;
-        f32 scaledValue = (f32)baseValue;
-        target[2] = (u8)(target[2] + (s32)(scaledValue * scale));
+        target[2] = (u8)(target[2] + randchar(baseValue, scale));
     }
     {
         s8 baseValue = in->fieldB;
-        f32 scaledValue = (f32)baseValue;
-        target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
+        target[3] = (u8)(target[3] + randchar(baseValue, scale));
     }
 }
 
@@ -94,7 +95,3 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -21,6 +21,11 @@ struct PppRandDownIVParam3 {
     s32* fieldC;
 };
 
+inline int randint(int value, float scale)
+{
+    return (int)((float)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80061a88
@@ -62,9 +67,9 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
     f32 scale = *valuePtr;
 
-    target[0] += (s32)((f32)in->field8 * scale);
-    target[1] += (s32)((f32)in->fieldC * scale);
-    target[2] += (s32)((f32)in->field10 * scale);
+    target[0] += randint(in->field8, scale);
+    target[1] += randint(in->fieldC, scale);
+    target[2] += randint(in->field10, scale);
 }
 
 /*
@@ -76,7 +81,3 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
-}

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -17,6 +17,11 @@ struct RandUpCVCtx {
     s32* outputOffset;
 };
 
+inline char randchar(char value, float scale)
+{
+    return (char)((f32)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80062708
@@ -61,19 +66,19 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         f32 scale = *valuePtr;
         {
             s8 baseValue = in->delta[0];
-            target[0] = (u8)(target[0] + (s32)((f32)baseValue * scale));
+            target[0] = (u8)(target[0] + randchar(baseValue, scale));
         }
         {
             s8 baseValue = in->delta[1];
-            target[1] = (u8)(target[1] + (s32)((f32)baseValue * scale));
+            target[1] = (u8)(target[1] + randchar(baseValue, scale));
         }
         {
             s8 baseValue = in->delta[2];
-            target[2] = (u8)(target[2] + (s32)((f32)baseValue * scale));
+            target[2] = (u8)(target[2] + randchar(baseValue, scale));
         }
         {
             s8 baseValue = in->delta[3];
-            target[3] = (u8)(target[3] + (s32)((f32)baseValue * scale));
+            target[3] = (u8)(target[3] + randchar(baseValue, scale));
         }
     }
 }
@@ -87,7 +92,3 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
-}

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -21,6 +21,11 @@ struct PppRandUpIVParam3 {
     s32* fieldC;
 };
 
+inline int randint(int value, float scale)
+{
+    return (int)((f32)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80062e0c
@@ -62,9 +67,9 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
     f32 scale = *valuePtr;
 
-    target[0] += (s32)((f32)in->field8 * scale);
-    target[1] += (s32)((f32)in->fieldC * scale);
-    target[2] += (s32)((f32)in->field10 * scale);
+    target[0] += randint(in->field8, scale);
+    target[1] += randint(in->fieldC, scale);
+    target[2] += randint(in->field10, scale);
 }
 
 /*
@@ -76,7 +81,3 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
  * JP Address: TODO
  * JP Size: TODO
  */
-static int randint(int value, float scale)
-{
-    return (int)((f32)value * scale);
-}


### PR DESCRIPTION
## Summary
- Move the small rand conversion helpers in the Up/Down IV and CV particle callbacks into inline helpers used by the callback bodies.
- Removes the unused out-of-line helper functions that were producing mismatched exception table data.

## Objdiff evidence
- main/pppRandUpIV: extab 66.67% -> 100%, extabindex 57.14% -> 100%, .sdata2 100% retained.
- main/pppRandDownIV: extab 66.67% -> 100%, extabindex 57.14% -> 100%, .sdata2 100% retained.
- main/pppRandUpCV: extab 66.67% -> 100%, extabindex 57.14% -> 100%, .sdata2 100% retained.
- main/pppRandDownCV: extab 66.67% -> 100%, extabindex 57.14% -> 100%, .sdata2 100% retained.
- Overall matched data increased by 80 bytes: 1091391 -> 1091471.

## Plausibility
These helpers already existed in the source as the intended conversion operations. Defining them inline at the use sites matches plausible original source and avoids carrying unused out-of-line functions solely as decomp artifacts.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRandUpIV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandDownIV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandUpCV -o -
- build/tools/objdiff-cli diff -p . -u main/pppRandDownCV -o -