### PR TITLE
Match math Spline1D polynomial shape

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -945,13 +945,13 @@ float CMath::Spline1D(int lastIndex, float t, float* x, float* y, float* secondD
     float x0 = x[low];
     float sd0 = secondDerivatives[low];
     float sd1 = secondDerivatives[low + 1];
-    float dt = t - x0;
     float y0 = y[low];
+    float dt = t - x0;
     float dx = x[low + 1] - x0;
-    float cubic = FLOAT_8032F758 * sd0 + (dt * (sd1 - sd0)) / dx;
-    float linear = dx * (FLOAT_8032F75C * sd0 + sd1) - (y[low + 1] - y0) / dx;
+    float cubic = 3.0f * sd0 + (dt * (sd1 - sd0)) / dx;
+    float linear = (y[low + 1] - y0) / dx - dx * (2.0f * sd0 + sd1);
 
-    return ((dt * cubic) - linear) * dt + y0;
+    return (dt * cubic + linear) * dt + y0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked `CMath::Spline1D`'s final cubic polynomial expression into the source shape used by the target.
- Keeps behavior equivalent while aligning the generated fused multiply/add sequence and local register allocation.

## Evidence
- `ninja` passes.
- Overall progress after change: code matched `483700 / 1855224` bytes, `3054 / 4732` functions.
- Baseline before this branch was `483480 / 1855224` bytes, `3053 / 4732` functions, so this adds one matched function and 220 matched code bytes.
- `build/tools/objdiff-cli diff -p . -u main/math -o - Spline1D__5CMathFifPfPfPf` reports size `220` and `99.818184%`; the instruction stream is aligned, with the remaining difference attributable to constant relocation identity.

## Plausibility
- The expression is algebraically equivalent to the previous code.
- The new shape matches the Ghidra decompilation's polynomial form more closely and looks like normal original source, not a forced asm or linkage hack.
