### PR TITLE
Correct CUSBPcs inheritance

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -1,11 +1,11 @@
 #ifndef _FFCC_P_USB_H_
 #define _FFCC_P_USB_H_
 
+#include "ffcc/p_sample.h"
 #include "ffcc/memory.h"
 #include "ffcc/usb.h"
-#include "ffcc/system.h"
 
-class CUSBPcs : public CProcess
+class CUSBPcs : public CSamplePcs
 {
 public:
     CUSBPcs();


### PR DESCRIPTION
## Summary
- Make CUSBPcs inherit from CSamplePcs instead of directly from CProcess.
- This matches the p_usb static initializer's vtable path through CSamplePcs and removes p_usb from the selector's data-opportunity bucket.

## Evidence
- ninja passes for GCCP01.
- Global report data match improved from 1,091,391 / 1,489,575 bytes to 1,091,499 / 1,489,575 bytes (+108 matched data bytes).
- p_usb extabindex section improved from 99.07407% to 100.0%; [extabindex-0] improved from 99.44444% to 100.0%.
- After the change, tools/agent_select_target.py no longer lists main/p_usb as a data opportunity.

## Plausibility
- CUSBPcs uses the same process-table pattern as CSample-derived process classes, and objdiff shows its static init passing through CSamplePcs before installing the CUSBPcs vtable.
- The object layout stays compatible because CSamplePcs adds no data members over CProcess.