### PR TITLE
Improve util boundary box matching

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -182,7 +182,6 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
 {
     S16Vec min;
     S16Vec max;
-    int scale = 1 << shift;
 
     min.z = 0x7FFF;
     min.y = 0x7FFF;
@@ -200,12 +199,16 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
         max.z = max.z < vecs->z ? vecs->z : max.z;
     }
 
-    minOut->x = (float)min.x / (float)scale;
-    minOut->y = (float)min.y / (float)scale;
-    minOut->z = (float)min.z / (float)scale;
-    maxOut->x = (float)max.x / (float)scale;
-    maxOut->y = (float)max.y / (float)scale;
-    maxOut->z = (float)max.z / (float)scale;
+    S16Vec finalMin = min;
+    S16Vec finalMax = max;
+    int scale = 1 << shift;
+
+    minOut->x = (float)finalMin.x / (float)scale;
+    minOut->y = (float)finalMin.y / (float)scale;
+    minOut->z = (float)finalMin.z / (float)scale;
+    maxOut->x = (float)finalMax.x / (float)scale;
+    maxOut->y = (float)finalMax.y / (float)scale;
+    maxOut->z = (float)finalMax.z / (float)scale;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Move `CalcBoundaryBoxQuantized` scale calculation after the bounds scan to match the target flow.
- Add explicit final min/max `S16Vec` copies before float conversion, recovering the stack layout and target function size.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/util -o - CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`
- `CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`: 63.07% -> 96.64%.
- Compiled size now matches target: 548 bytes -> 548 bytes.

## Plausibility
- The change keeps normal C++ locals and member access; no address hacks, fake labels, manual section placement, or generated ctor/dtor code.
- The extra local copies correspond to the target stack layout before converting the quantized bounds to floats.