### PR TITLE
Improve GetWeaponAttrib comparison

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2104,7 +2104,7 @@ extern "C" int GetCmdListItemName__12CCaravanWorkFi(CCaravanWork* caravanWork, i
 int CCaravanWork::GetWeaponAttrib(int cmdListIdx)
 {
 	int weaponType = GetCmdListItem(cmdListIdx);
-	if (weaponType >= 0 && weaponType <= 2) {
+	if (weaponType >= 0 && weaponType < 3) {
 		return GetSkillStr__8CMenuPcsFi(&MenuPcs, weaponType);
 	}
 


### PR DESCRIPTION
## Summary
- Change `CCaravanWork::GetWeaponAttrib` to use an equivalent `< 3` upper-bound check for weapon command types.
- This matches the target branch shape more closely (`cmpwi 2; bgt`) than the previous `<= 2` spelling.

## Objdiff Evidence
- Unit: `main/gobjwork`
- Symbol: `GetWeaponAttrib__12CCaravanWorkFi`
- Before: 96.78788% match
- After: 96.969696% match

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o - GetWeaponAttrib__12CCaravanWorkFi`