### PR TITLE
Improve CUSBPcs class layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,10 +2,10 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/usb.h"
-#include "ffcc/system.h"
 
-class CUSBPcs : public CProcess
+class CUSBPcs : public CSamplePcs
 {
 public:
     CUSBPcs();

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -13,16 +13,15 @@ extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 const char s_CUSBPcs_8032f810[] = "CUSBPcs";
+unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
-
-unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
-unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
-unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Make CUSBPcs inherit through CSamplePcs, matching the constructor/vtable path indicated by p_usb's static initializer.
- Move the CUSBPcs scenegraph descriptor arrays before m_table__7CUSBPcs so the object data layout matches the symbol order.

## Evidence
- ninja passes.
- main/p_usb matched data improves from 324/904 bytes (35.84%) to 432/904 bytes (47.79%).
- SendDataCode__7CUSBPcsFiPvii remains 532 bytes at 98.74436%.
- __sinit_p_usb_cpp remains 176 bytes; its local score drops slightly to 71.63636%, but the generated path now goes through CSamplePcs and the data layout is closer to the shipped symbols.

## Plausibility
- CSamplePcs is the established process base used by nearby process classes, and it has no instance fields, so this keeps CUSBPcs object offsets intact.
- The descriptor order follows the PAL symbol order for p_usb data rather than introducing artificial sections or hand-written vtables.