### PR TITLE
Align sample and USB process data ownership

### DIFF
--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -1,6 +1,6 @@
 #include "ffcc/p_sample.h"
 
-static const char s_CSamplePcs_801D6CC8[] = "CSamplePcs";
+extern const char s_CSamplePcs_801D6CC8[];
 
 CSamplePcsTable m_table__10CSamplePcs = {
     const_cast<char*>(s_CSamplePcs_801D6CC8),

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -13,16 +13,15 @@ extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 const char s_CUSBPcs_8032f810[] = "CUSBPcs";
+unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
-
-unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
-unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
-unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- reference the existing CSamplePcs name string from its owning object instead of defining duplicate rodata in p_sample
- move CUSBPcs process table descriptors before m_table to match the target object layout

## Evidence
- ninja passes for GCCP01
- main/p_usb fuzzy code improves from 95.93636% to 95.93939%
- __sinit_p_usb_cpp is 67.681816% after the descriptor ownership/order change

## Plausibility
These changes adjust data ownership and declaration order to match the target object/symbol split. They avoid manual vtable/RTTI definitions and keep normal C++ data definitions.