### PR TITLE
Improve CUSBPcs data layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,10 +2,10 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/usb.h"
-#include "ffcc/system.h"
 
-class CUSBPcs : public CProcess
+class CUSBPcs : public CSamplePcs
 {
 public:
     CUSBPcs();

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -13,16 +13,15 @@ extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 const char s_CUSBPcs_8032f810[] = "CUSBPcs";
+unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
 };
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
-
-unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
-unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
-unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Make `CUSBPcs` inherit from `CSamplePcs`, matching the process hierarchy indicated by the generated vtable/static init path.
- Move the `CUSBPcs` table descriptor definitions before `m_table__7CUSBPcs`, matching the PAL symbol/data ordering around `m_table_desc*__7CUSBPcs` and `m_table__7CUSBPcs`.

## Evidence
- `ninja` passes.
- `main/p_usb` data improved from 324/904 bytes (35.84%) to 432/904 bytes (47.79%).
- Overall matched data improved from 1,091,391 to 1,091,499 bytes.
- Matched code bytes stayed at 612 for `main/p_usb`; the remaining text drift is in the generated static initializer/register scheduling, not a loss of matched functions.

## Plausibility
- `CUSBPcs` follows the same process-family structure as nearby process classes that build on `CSamplePcs`.
- The descriptor/table order matches the PAL data symbol order rather than relying on externs or section forcing.