### PR TITLE
Improve process RTTI data layout

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -555,7 +555,7 @@ config.libs = [
             Object(NonMatching, "p_light.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_map.cpp", cflags=[*cflags_game, "-sdata 0", "-sdata2 0"], extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_MaterialEditor.cpp", extra_cflags=["-RTTI on"]),
-            Object(NonMatching, "p_mc.cpp", extra_cflags=["-RTTI on"]),
+            Object(NonMatching, "p_mc.cpp"),
             Object(NonMatching, "p_menu.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_minigame.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_sample.cpp"),

--- a/configure.py
+++ b/configure.py
@@ -560,7 +560,7 @@ config.libs = [
             Object(NonMatching, "p_minigame.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_sample.cpp"),
             Object(NonMatching, "p_sound.cpp"),
-            Object(NonMatching, "p_system.cpp", extra_cflags=["-RTTI on"]),
+            Object(NonMatching, "p_system.cpp"),
             Object(NonMatching, "p_tina.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "p_usb.cpp"),
             Object(NonMatching, "pad.cpp"),


### PR DESCRIPTION
## Summary
- stop forcing RTTI on for p_mc.cpp and p_system.cpp
- keeps generated process vtables/compiler output normal while reducing extra RTTI data emitted into these process units

## Objdiff evidence
- main/p_mc: all 7 functions remain 100% matched; .data extra insertion reduced from 76 bytes to 20 bytes
- main/p_system: all 7 functions remain 100% matched; .data extra insertion reduced from 468 bytes to 400 bytes

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_mc -o -
- build/tools/objdiff-cli diff -p . -u main/p_system -o -