### PR TITLE
Match bonus init and party command completion

### DIFF
--- a/src/bonus_menu.cpp
+++ b/src/bonus_menu.cpp
@@ -1089,8 +1089,6 @@ void CMenuPcs::BonusInit()
 {
 	gBonusMenuWork0 = 0;
 	GetBonusMenuMembers(this).m_bonusAnimPtr = 0;
-	s_bonusSummaryData = 0;
-	s_bonusBoardState = 0;
 	gBonusCheckMarkPosBuffer = 0;
 }
 

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -89,8 +89,16 @@ struct GhostPartyWork {
 
 static GhostPartyWork sGhostPartyWork;
 
+struct PartyObjFlags {
+	unsigned char commandActive : 1;
+	unsigned char reserved : 7;
+};
+
 struct PartyObjOverlay {
-	unsigned char partyFlags;
+	union {
+		unsigned char partyFlags;
+		PartyObjFlags flags;
+	};
 	unsigned char _pad6B9[3];
 	int unk6BC;
 	int unk6C0;
@@ -2049,7 +2057,7 @@ void CGPartyObj::onTalk(CGBaseObj* other, int talkType)
  */
 void CGPartyObj::commandFinished()
 {
-	PartyData(this).partyFlags &= 0x7F;
+	PartyData(this).flags.commandActive = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Match `BonusInit__8CMenuPcsFv` by removing two extra static cache pointer clears not present in the target.
- Model the party flag byte with a bitfield overlay and use it in `CGPartyObj::commandFinished()` so the clear emits the target bitfield store sequence.

## Objdiff Evidence
- `main/bonus_menu` `BonusInit__8CMenuPcsFv`: 59.0% -> 100.0%, diff count 0, 20/20 bytes matched.
- `main/partyobj` `commandFinished__10CGPartyObjFv`: 68.0% -> 100.0%, diff count 0, 20/20 bytes matched.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/bonus_menu -o /tmp/bonus_final.json BonusInit__8CMenuPcsFv`
- `build/tools/objdiff-cli diff -p . -u main/partyobj -o /tmp/party_final.json commandFinished__10CGPartyObjFv`

## Plausibility
- `BonusInit` still resets the global menu work pointer, the menu animation pointer, and the check mark buffer; the removed cache clears are handled by the bonus create/destroy path instead.
- The `partyFlags` byte now exposes a named high-bit field for the command-active flag, matching the compiler bitfield-style code generation without hardcoded addresses or manual assembly.