### PR TITLE
Improve pppBreathModel particle layouts

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -100,7 +100,7 @@ struct BreathModelParams {
     u16 m_particleCount;
     u16 m_emitCount;
     u16 m_emitInterval;
-    s16 m_particleLifetime;
+    u16 m_particleLifetime;
     u8 m_fadeOutFrames;
     u8 m_fadeInFrames;
     unsigned char _pad24[0x04];
@@ -128,6 +128,7 @@ struct BreathModelParams {
     float m_rotationRandomX;
     float m_rotationRandomY;
     float m_rotationRandomZ;
+    unsigned char _pad8C[0x04];
     float m_angleStart;
     float m_angleStep;
     float m_angleAccel;
@@ -139,6 +140,7 @@ struct BreathModelParams {
     float m_spawnJitterX;
     float m_spawnJitterY;
     float m_spawnJitterZ;
+    unsigned char _padBC[0x04];
     u8 m_rotationFlags;
     u8 m_angleFlags;
     unsigned char _padC2[0x06];
@@ -149,6 +151,7 @@ struct BreathParticleData {
     Mtx m_modelMtx;
     Vec m_position;
     Vec m_direction;
+    u8 _pad48[0x08];
     s16 m_life;
     u8 _pad52[0x02];
     u8 m_fadeOutFrames;
@@ -919,6 +922,7 @@ extern "C" void BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VC
     BreathModelParams* params = reinterpret_cast<BreathModelParams*>(pBreathModel);
     BreathParticleData* particle = reinterpret_cast<BreathParticleData*>(particleData);
     Mtx workMtx;
+    Mtx cameraMtx;
     Vec jitter;
     Vec pos;
 
@@ -1075,7 +1079,7 @@ extern "C" void BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VC
     (*(Mtx*)particleWmat)[2][3] = pos.z;
 
     PSMTXConcat(*(Mtx*)particleWmat, pppObject->m_localMatrix.value, *(Mtx*)particleData);
-    PSMTXConcat(ppvCameraMatrix02, *(Mtx*)particleData, workMtx);
+    PSMTXConcat(ppvCameraMatrix02, *(Mtx*)particleData, cameraMtx);
 
     particle->m_direction.x = kPppBreathModelZero;
     particle->m_direction.y = kPppBreathModelZero;


### PR DESCRIPTION
Summary:
- Correct BreathModelParams padding around angle, jitter, and flag fields to match Ghidra-observed offsets.
- Correct BreathParticleData padding after direction so lifetime/fade/angle fields line up with target code.
- Treat particle lifetime as unsigned and use a separate camera matrix temp in BirthParticle.

Objdiff evidence (main/pppBreathModel .text):
- Before: 90.26201%
- After: 90.51653%

Symbol improvements:
- UpdateParticle__FP12VBreathModelP12PBreathModelP13PARTICLE_DATAP6VColorP14PARTICLE_COLOR: 97.40000% -> 98.19149%
- BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR: 81.29082% -> 81.85714%

Verification:
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o /tmp/pppBreathModel_verified.json BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR

Plausibility:
- Ghidra for 800dc380/800dbfd4 shows parameter fields at offsets 0x90/0x94/0x98/0x9c, jitter at 0xb0/0xb4/0xb8, flags at 0xc0/0xc1, and particle lifetime/fade/angle data beginning at particle offset 0x50. The changes make the recovered local structs reflect those offsets instead of compensating in expressions.