### PR TITLE
Align CUSBPcs descriptor ordering in p_usb

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -13,16 +13,16 @@ extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 const char s_CUSBPcs_8032f810[] = "CUSBPcs";
-u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
-    reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
-};
 static const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 static const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
-unsigned int m_table_desc0__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
-unsigned int m_table_desc1__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
-unsigned int m_table_desc2__7CUSBPcs[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
+unsigned int m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
+u32 m_table__7CUSBPcs[0x11C / sizeof(u32)] = {
+    reinterpret_cast<u32>(const_cast<char*>(s_CUSBPcs_8032f810)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x12
+};
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- reorder `CUSBPcs` descriptor table definitions ahead of `m_table__7CUSBPcs` in `src/p_usb.cpp`
- keep the generated constructor/startup path intact while matching the PAL `.data` symbol ordering from `config/GCCP01/symbols.txt`
- preserve the existing runtime behavior and linkage, changing only declaration order and explicit descriptor array sizing

## Evidence
- `ninja` succeeds after the change
- `main/p_usb` `.text` match improved from `95.181816%` to `95.184845%`
- `main/p_usb` synthesized `[.data-0]` match improved from `80.11389%` to `90.39505%`
- `__sinit_p_usb_cpp` improved from `67.65909%` to `67.681816%`

## Why this is plausible
- PAL symbol order already places `m_table_desc0/1/2__7CUSBPcs` before `m_table__7CUSBPcs`
- nearby process units use the same descriptor-then-table layout pattern
- this is a source-layout correction, not a compiler-forcing hack