### PR TITLE
Clean up unused pppRand helpers

### DIFF
--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -59,7 +59,7 @@ void pppRandCV(void* param1, void* param2, void* param3)
     u8* targetColor;
     s32 colorOffset = params->colorOffset;
     if (colorOffset == -1) {
-        targetColor = gPppDefaultValueBuffer;
+        targetColor = &gPppDefaultValueBuffer[0];
     } else {
         targetColor = base + colorOffset + 0x80;
     }
@@ -84,18 +84,4 @@ void pppRandCV(void* param1, void* param2, void* param3)
             targetColor[3] = color + (s8)((f32)params->delta[3] * scale - (f32)params->delta[3]);
         }
     }
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
 }

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -22,6 +22,11 @@ struct PppRandDownCVParam3 {
     s32* fieldC;
 };
 
+static inline char randchar_inline(char value, float scale)
+{
+    return (char)((f32)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 80061384
@@ -65,36 +70,18 @@ extern "C" void pppRandDownCV(void* param1, void* param2, void* param3)
     f32 scale = *valuePtr;
     {
         s8 baseValue = in->field8;
-        f32 scaledValue = (f32)baseValue;
-        target[0] = (u8)(target[0] + (s32)(scaledValue * scale));
+        target[0] = (u8)(target[0] + randchar_inline(baseValue, scale));
     }
     {
         s8 baseValue = in->field9;
-        f32 scaledValue = (f32)baseValue;
-        target[1] = (u8)(target[1] + (s32)(scaledValue * scale));
+        target[1] = (u8)(target[1] + randchar_inline(baseValue, scale));
     }
     {
         s8 baseValue = in->fieldA;
-        f32 scaledValue = (f32)baseValue;
-        target[2] = (u8)(target[2] + (s32)(scaledValue * scale));
+        target[2] = (u8)(target[2] + randchar_inline(baseValue, scale));
     }
     {
         s8 baseValue = in->fieldB;
-        f32 scaledValue = (f32)baseValue;
-        target[3] = (u8)(target[3] + (s32)(scaledValue * scale));
+        target[3] = (u8)(target[3] + randchar_inline(baseValue, scale));
     }
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
 }

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -21,6 +21,11 @@ struct PppRandDownIVParam3 {
     s32* fieldC;
 };
 
+static inline int randint(int value, float scale)
+{
+    return (int)((float)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80061a88
@@ -62,21 +67,7 @@ extern "C" void pppRandDownIV(void* param1, void* param2, void* param3)
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
     f32 scale = *valuePtr;
 
-    target[0] += (s32)((f32)in->field8 * scale);
-    target[1] += (s32)((f32)in->fieldC * scale);
-    target[2] += (s32)((f32)in->field10 * scale);
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((float)value * scale);
+    target[0] += randint(in->field8, scale);
+    target[1] += randint(in->fieldC, scale);
+    target[2] += randint(in->field10, scale);
 }

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -21,6 +21,11 @@ typedef struct RandHCVCtx {
     s32* fieldC;
 } RandHCVCtx;
 
+static inline short randshort(short value, float scale)
+{
+    return (short)(((f32)value * scale) - (f32)value);
+}
+
 /*
  * --INFO--
  * PAL Address: 80061f88
@@ -65,25 +70,11 @@ void pppRandHCV(void* p1, void* p2, void* p3)
 
     {
         f32 scale = *randomValue;
-        target[0] += (s16)((f32)params->field8 * scale - (f32)params->field8);
-        target[1] += (s16)((f32)params->fieldA * scale - (f32)params->fieldA);
-        target[2] += (s16)((f32)params->fieldC * scale - (f32)params->fieldC);
-        target[3] += (s16)((f32)params->fieldE * scale - (f32)params->fieldE);
+        target[0] += randshort(params->field8, scale);
+        target[1] += randshort(params->fieldA, scale);
+        target[2] += randshort(params->fieldC, scale);
+        target[3] += randshort(params->fieldE, scale);
     }
 }
 
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static short randshort(short value, float scale)
-{
-    return (short)(((f32)value * scale) - (f32)value);
 }

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -17,6 +17,11 @@ struct RandUpCVCtx {
     s32* outputOffset;
 };
 
+static inline char randchar_inline(char value, float scale)
+{
+    return (char)((f32)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80062708
@@ -61,33 +66,19 @@ void pppRandUpCV(void* param1, void* param2, void* param3)
         f32 scale = *valuePtr;
         {
             s8 baseValue = in->delta[0];
-            target[0] = (u8)(target[0] + (s32)((f32)baseValue * scale));
+            target[0] = (u8)(target[0] + randchar_inline(baseValue, scale));
         }
         {
             s8 baseValue = in->delta[1];
-            target[1] = (u8)(target[1] + (s32)((f32)baseValue * scale));
+            target[1] = (u8)(target[1] + randchar_inline(baseValue, scale));
         }
         {
             s8 baseValue = in->delta[2];
-            target[2] = (u8)(target[2] + (s32)((f32)baseValue * scale));
+            target[2] = (u8)(target[2] + randchar_inline(baseValue, scale));
         }
         {
             s8 baseValue = in->delta[3];
-            target[3] = (u8)(target[3] + (s32)((f32)baseValue * scale));
+            target[3] = (u8)(target[3] + randchar_inline(baseValue, scale));
         }
     }
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)((f32)value * scale);
 }

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -21,6 +21,11 @@ struct PppRandUpIVParam3 {
     s32* fieldC;
 };
 
+static inline int randint(int value, float scale)
+{
+    return (int)((f32)value * scale);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80062e0c
@@ -62,21 +67,7 @@ extern "C" void pppRandUpIV(void* param1, void* param2, void* param3)
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);
     f32 scale = *valuePtr;
 
-    target[0] += (s32)((f32)in->field8 * scale);
-    target[1] += (s32)((f32)in->fieldC * scale);
-    target[2] += (s32)((f32)in->field10 * scale);
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 56b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static int randint(int value, float scale)
-{
-    return (int)((f32)value * scale);
+    target[0] += randint(in->field8, scale);
+    target[1] += randint(in->fieldC, scale);
+    target[2] += randint(in->field10, scale);
 }


### PR DESCRIPTION
## Summary
- Remove out-of-line unused rand helper functions from pppRand CV/HCV/IV variants.
- Keep the helper logic inline where it preserves the existing main-function code shape.
- Eliminates extra emitted helper code/extab noise in the rebuilt objects.

## Objdiff evidence
- Overall matched data: 1091391 -> 1091499 (+108 bytes).
- main/pppRandUpIV data: 16/36 -> 36/36.
- main/pppRandDownIV data: 16/36 -> 36/36.
- main/pppRandUpCV data: 16/36 -> 36/36.
- main/pppRandDownCV data: 16/36 -> 36/36.
- main/pppRandHCV data: 16/36 -> 36/36.
- main/pppRandCV data: 16/36 -> 24/36.

Code fuzzy scores for these functions remain unchanged; the improvement is cleaner linkage/data layout from removing helpers that are not present in the target objects.

## Verification
- ninja
- objdiff-cli diff for main/pppRandCV, main/pppRandHCV, main/pppRandUpCV, main/pppRandDownCV, main/pppRandUpIV, main/pppRandDownIV