### PR TITLE
Match p_sound rodata padding

### DIFF
--- a/src/p_sound.cpp
+++ b/src/p_sound.cpp
@@ -7,7 +7,7 @@ extern "C" void destroy__9CSoundPcsFv(CSoundPcs*);
 extern "C" void calc__9CSoundPcsFv(CSoundPcs*);
 extern "C" void draw__9CSoundPcsFv(CSoundPcs*);
 
-const char s_CSoundPcs_801DB4E8[] = "CSoundPcs";
+const char s_CSoundPcs_801DB4E8[12] = "CSoundPcs";
 unsigned int m_table__9CSoundPcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CSoundPcs_801DB4E8)),
     0,


### PR DESCRIPTION
## Summary
- Size the CSoundPcs name buffer to include the two trailing rodata padding bytes present in the original p_sound object.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff main/p_sound: [.rodata-0] improved from 90.909096% (10 bytes) to 100.0% (12 bytes)
- p_sound no longer appears in agent_select_target.py data opportunities after the build

## Plausibility
- The source still exposes the same CSoundPcs string content; the fixed array extent accounts for the original object's aligned storage without section attributes or hand-written data.