### PR TITLE
Static-initialize CMapPcs scenegraph tables

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -69,15 +69,51 @@ const char s_CMapPcs_VIEWER_801D76F0[] = "CMapPcs_VIEWER";
 const char s_CMapPcs_PART_801D7700[] = "CMapPcs_PART";
 
 unsigned int m_table__7CMapPcs[3][0x414 / 3 / sizeof(unsigned int)] = {
-    {reinterpret_cast<unsigned int>(const_cast<char*>(s_CMapPcs_GAME_801D76E0)), 0, 0, 0, 0, 0, 0, 0, 0, 0,
-     0x14, 0, 0, 0, 0, 0x1E, 0, 0, 0, 0, 0x2F, 1, 0, 0, 0, 0x35, 1, 0, 0, 0, 0x37, 1, 0, 0, 0,
-     0x3F, 1},
-    {reinterpret_cast<unsigned int>(const_cast<char*>(s_CMapPcs_VIEWER_801D76F0)), 0, 0, 0, 0, 0, 0, 0, 0, 0,
-     0x14, 0, 0, 0, 0, 0x1E, 0, 0, 0, 0, 0x2F, 1, 0, 0, 0, 0x35, 1, 0, 0, 0, 0x37, 1, 0, 0, 0,
-     0x3F, 1},
-    {reinterpret_cast<unsigned int>(const_cast<char*>(s_CMapPcs_PART_801D7700)), 0, 0, 0, 0, 0, 0, 0, 0, 0,
-     0x14, 0, 0, 0, 0, 0x1E, 0, 0, 0, 0, 0x2F, 1, 0, 0, 0, 0x35, 1, 0, 0, 0, 0x37, 1, 0, 0, 0,
-     0x3F, 1},
+    {
+        reinterpret_cast<unsigned int>(const_cast<char*>(s_CMapPcs_GAME_801D76E0)),
+        m_table_desc0__7CMapPcs[0],  m_table_desc0__7CMapPcs[1],  m_table_desc0__7CMapPcs[2],
+        m_table_desc1__7CMapPcs[0],  m_table_desc1__7CMapPcs[1],  m_table_desc1__7CMapPcs[2],
+        m_table_desc2__7CMapPcs[0],  m_table_desc2__7CMapPcs[1],  m_table_desc2__7CMapPcs[2],
+        0x14,                        0,                           m_table_desc3__7CMapPcs[0],
+        m_table_desc3__7CMapPcs[1],  m_table_desc3__7CMapPcs[2],  0x1E,
+        0,                           m_table_desc4__7CMapPcs[0],  m_table_desc4__7CMapPcs[1],
+        m_table_desc4__7CMapPcs[2],  0x2F,                        1,
+        m_table_desc5__7CMapPcs[0],  m_table_desc5__7CMapPcs[1],  m_table_desc5__7CMapPcs[2],
+        0x35,                        1,                           m_table_desc6__7CMapPcs[0],
+        m_table_desc6__7CMapPcs[1],  m_table_desc6__7CMapPcs[2],  0x37,
+        1,                           m_table_desc7__7CMapPcs[0],  m_table_desc7__7CMapPcs[1],
+        m_table_desc7__7CMapPcs[2],  0x3F,                        1,
+    },
+    {
+        reinterpret_cast<unsigned int>(const_cast<char*>(s_CMapPcs_VIEWER_801D76F0)),
+        m_table_desc8__7CMapPcs[0],  m_table_desc8__7CMapPcs[1],  m_table_desc8__7CMapPcs[2],
+        m_table_desc9__7CMapPcs[0],  m_table_desc9__7CMapPcs[1],  m_table_desc9__7CMapPcs[2],
+        m_table_desc10__7CMapPcs[0], m_table_desc10__7CMapPcs[1], m_table_desc10__7CMapPcs[2],
+        0x14,                        0,                           m_table_desc11__7CMapPcs[0],
+        m_table_desc11__7CMapPcs[1], m_table_desc11__7CMapPcs[2], 0x1E,
+        0,                           m_table_desc12__7CMapPcs[0], m_table_desc12__7CMapPcs[1],
+        m_table_desc12__7CMapPcs[2], 0x2F,                        1,
+        m_table_desc13__7CMapPcs[0], m_table_desc13__7CMapPcs[1], m_table_desc13__7CMapPcs[2],
+        0x35,                        1,                           m_table_desc14__7CMapPcs[0],
+        m_table_desc14__7CMapPcs[1], m_table_desc14__7CMapPcs[2], 0x37,
+        1,                           m_table_desc15__7CMapPcs[0], m_table_desc15__7CMapPcs[1],
+        m_table_desc15__7CMapPcs[2], 0x3F,                        1,
+    },
+    {
+        reinterpret_cast<unsigned int>(const_cast<char*>(s_CMapPcs_PART_801D7700)),
+        m_table_desc16__7CMapPcs[0], m_table_desc16__7CMapPcs[1], m_table_desc16__7CMapPcs[2],
+        m_table_desc17__7CMapPcs[0], m_table_desc17__7CMapPcs[1], m_table_desc17__7CMapPcs[2],
+        m_table_desc18__7CMapPcs[0], m_table_desc18__7CMapPcs[1], m_table_desc18__7CMapPcs[2],
+        0x14,                        0,                           m_table_desc19__7CMapPcs[0],
+        m_table_desc19__7CMapPcs[1], m_table_desc19__7CMapPcs[2], 0x1E,
+        0,                           m_table_desc20__7CMapPcs[0], m_table_desc20__7CMapPcs[1],
+        m_table_desc20__7CMapPcs[2], 0x2F,                        1,
+        m_table_desc21__7CMapPcs[0], m_table_desc21__7CMapPcs[1], m_table_desc21__7CMapPcs[2],
+        0x35,                        1,                           m_table_desc22__7CMapPcs[0],
+        m_table_desc22__7CMapPcs[1], m_table_desc22__7CMapPcs[2], 0x37,
+        1,                           m_table_desc23__7CMapPcs[0], m_table_desc23__7CMapPcs[1],
+        m_table_desc23__7CMapPcs[2], 0x3F,                        1,
+    },
 };
 
 CRelProfile g_hit_prof;
@@ -156,80 +192,6 @@ CRelProfile::~CRelProfile()
  */
 CMapPcs::CMapPcs()
 {
-    unsigned int* dst = &m_table__7CMapPcs[0][0];
-
-    dst[0x004 / 4] = m_table_desc0__7CMapPcs[0];
-    dst[0x008 / 4] = m_table_desc0__7CMapPcs[1];
-    dst[0x00C / 4] = m_table_desc0__7CMapPcs[2];
-    dst[0x010 / 4] = m_table_desc1__7CMapPcs[0];
-    dst[0x014 / 4] = m_table_desc1__7CMapPcs[1];
-    dst[0x018 / 4] = m_table_desc1__7CMapPcs[2];
-    dst[0x01C / 4] = m_table_desc2__7CMapPcs[0];
-    dst[0x020 / 4] = m_table_desc2__7CMapPcs[1];
-    dst[0x024 / 4] = m_table_desc2__7CMapPcs[2];
-    dst[0x030 / 4] = m_table_desc3__7CMapPcs[0];
-    dst[0x034 / 4] = m_table_desc3__7CMapPcs[1];
-    dst[0x038 / 4] = m_table_desc3__7CMapPcs[2];
-    dst[0x044 / 4] = m_table_desc4__7CMapPcs[0];
-    dst[0x048 / 4] = m_table_desc4__7CMapPcs[1];
-    dst[0x04C / 4] = m_table_desc4__7CMapPcs[2];
-    dst[0x058 / 4] = m_table_desc5__7CMapPcs[0];
-    dst[0x05C / 4] = m_table_desc5__7CMapPcs[1];
-    dst[0x060 / 4] = m_table_desc5__7CMapPcs[2];
-    dst[0x06C / 4] = m_table_desc6__7CMapPcs[0];
-    dst[0x070 / 4] = m_table_desc6__7CMapPcs[1];
-    dst[0x074 / 4] = m_table_desc6__7CMapPcs[2];
-    dst[0x080 / 4] = m_table_desc7__7CMapPcs[0];
-    dst[0x084 / 4] = m_table_desc7__7CMapPcs[1];
-    dst[0x088 / 4] = m_table_desc7__7CMapPcs[2];
-    dst[0x160 / 4] = m_table_desc8__7CMapPcs[0];
-    dst[0x164 / 4] = m_table_desc8__7CMapPcs[1];
-    dst[0x168 / 4] = m_table_desc8__7CMapPcs[2];
-    dst[0x16C / 4] = m_table_desc9__7CMapPcs[0];
-    dst[0x170 / 4] = m_table_desc9__7CMapPcs[1];
-    dst[0x174 / 4] = m_table_desc9__7CMapPcs[2];
-    dst[0x178 / 4] = m_table_desc10__7CMapPcs[0];
-    dst[0x17C / 4] = m_table_desc10__7CMapPcs[1];
-    dst[0x180 / 4] = m_table_desc10__7CMapPcs[2];
-    dst[0x18C / 4] = m_table_desc11__7CMapPcs[0];
-    dst[0x190 / 4] = m_table_desc11__7CMapPcs[1];
-    dst[0x194 / 4] = m_table_desc11__7CMapPcs[2];
-    dst[0x1A0 / 4] = m_table_desc12__7CMapPcs[0];
-    dst[0x1A4 / 4] = m_table_desc12__7CMapPcs[1];
-    dst[0x1A8 / 4] = m_table_desc12__7CMapPcs[2];
-    dst[0x1B4 / 4] = m_table_desc13__7CMapPcs[0];
-    dst[0x1B8 / 4] = m_table_desc13__7CMapPcs[1];
-    dst[0x1BC / 4] = m_table_desc13__7CMapPcs[2];
-    dst[0x1C8 / 4] = m_table_desc14__7CMapPcs[0];
-    dst[0x1CC / 4] = m_table_desc14__7CMapPcs[1];
-    dst[0x1D0 / 4] = m_table_desc14__7CMapPcs[2];
-    dst[0x1DC / 4] = m_table_desc15__7CMapPcs[0];
-    dst[0x1E0 / 4] = m_table_desc15__7CMapPcs[1];
-    dst[0x1E4 / 4] = m_table_desc15__7CMapPcs[2];
-    dst[0x2BC / 4] = m_table_desc16__7CMapPcs[0];
-    dst[0x2C0 / 4] = m_table_desc16__7CMapPcs[1];
-    dst[0x2C4 / 4] = m_table_desc16__7CMapPcs[2];
-    dst[0x2C8 / 4] = m_table_desc17__7CMapPcs[0];
-    dst[0x2CC / 4] = m_table_desc17__7CMapPcs[1];
-    dst[0x2D0 / 4] = m_table_desc17__7CMapPcs[2];
-    dst[0x2D4 / 4] = m_table_desc18__7CMapPcs[0];
-    dst[0x2D8 / 4] = m_table_desc18__7CMapPcs[1];
-    dst[0x2DC / 4] = m_table_desc18__7CMapPcs[2];
-    dst[0x2E8 / 4] = m_table_desc19__7CMapPcs[0];
-    dst[0x2EC / 4] = m_table_desc19__7CMapPcs[1];
-    dst[0x2F0 / 4] = m_table_desc19__7CMapPcs[2];
-    dst[0x2FC / 4] = m_table_desc20__7CMapPcs[0];
-    dst[0x300 / 4] = m_table_desc20__7CMapPcs[1];
-    dst[0x304 / 4] = m_table_desc20__7CMapPcs[2];
-    dst[0x310 / 4] = m_table_desc21__7CMapPcs[0];
-    dst[0x314 / 4] = m_table_desc21__7CMapPcs[1];
-    dst[0x318 / 4] = m_table_desc21__7CMapPcs[2];
-    dst[0x324 / 4] = m_table_desc22__7CMapPcs[0];
-    dst[0x328 / 4] = m_table_desc22__7CMapPcs[1];
-    dst[0x32C / 4] = m_table_desc22__7CMapPcs[2];
-    dst[0x338 / 4] = m_table_desc23__7CMapPcs[0];
-    dst[0x33C / 4] = m_table_desc23__7CMapPcs[1];
-    dst[0x340 / 4] = m_table_desc23__7CMapPcs[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
- move the `CMapPcs` scenegraph table contents out of the constructor and into the static `m_table__7CMapPcs` data
- leave the constructor empty so `__sinit_p_map_cpp` no longer spends most of its work patching descriptor entries at runtime
- keep the existing descriptor arrays and table layout intact, just expressed as plausible original static source

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_map -o diff_result.json __sinit_p_map_cpp`

Before:
- `main/p_map::__sinit_p_map_cpp`: 9.4% match in target selection
- `main/p_map` `.text`: 80.38327% match

After:
- `main/p_map::__sinit_p_map_cpp`: 51.557377% symbol diff match, 60.188526% in `build/GCCP01/report.json`
- `main/p_map` `.text`: 86.93196% match

## Why this is plausible source
- the table contents already existed conceptually in source as fixed descriptors; writing them in the constructor was a decomp artifact
- expressing them directly in `.data` is consistent with how other process table units in the repo are represented
- this reduces dynamic initialization noise instead of adding compiler-forcing hacks
