### PR TITLE
Improve util boundary box matching

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -182,8 +182,6 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
 {
     S16Vec min;
     S16Vec max;
-    int scale = 1 << shift;
-
     min.z = 0x7FFF;
     min.y = 0x7FFF;
     min.x = 0x7FFF;
@@ -200,12 +198,16 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
         max.z = max.z < vecs->z ? vecs->z : max.z;
     }
 
-    minOut->x = (float)min.x / (float)scale;
-    minOut->y = (float)min.y / (float)scale;
-    minOut->z = (float)min.z / (float)scale;
-    maxOut->x = (float)max.x / (float)scale;
-    maxOut->y = (float)max.y / (float)scale;
-    maxOut->z = (float)max.z / (float)scale;
+    S16Vec minResult = min;
+    S16Vec maxResult = max;
+    int scale = 1 << shift;
+
+    minOut->x = (float)minResult.x / (float)scale;
+    minOut->y = (float)minResult.y / (float)scale;
+    minOut->z = (float)minResult.z / (float)scale;
+    maxOut->x = (float)maxResult.x / (float)scale;
+    maxOut->y = (float)maxResult.y / (float)scale;
+    maxOut->z = (float)maxResult.z / (float)scale;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rework `CUtil::CalcBoundaryBoxQuantized` to keep final quantized bounds in local `S16Vec` copies before float conversion.
- Moves scale calculation to the conversion phase, matching the target size and final conversion layout more closely.

## Objdiff Evidence
- `CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`: 63.072994% -> 96.642334%
- Source size: 528b -> 548b, matching target size 548b

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/util -o - CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl`
