### PR TITLE
pppBreathModel: fix signed particle state slots

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -52,7 +52,7 @@ struct pppBreathModel {
 struct BreathParticleGroup {
     int active;
     signed char* particleIndices;
-    unsigned char* particleStates;
+    signed char* particleStates;
     Vec position;
     Vec direction;
     float speed;
@@ -725,7 +725,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
                     if (found) {
                         groupData = &groupTable[(int)foundGroup];
                         for (slot = 0; slot < (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10); slot++) {
-                            groupData->particleStates[slot] = 0xFF;
+                            groupData->particleStates[slot] = -1;
                             groupData->position.x = zero;
                             groupData->position.y = zero;
                             groupData->position.z = zero;
@@ -748,7 +748,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
                     groupData = groupTable;
                     for (j = 0; j < (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x12); j++) {
                         for (k = 0; k < (int)(unsigned short)*(unsigned short*)((unsigned char*)pBreathModel + 0x10); k++) {
-                            if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == 0xFF)) {
+                            if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == -1)) {
                                 groupData->particleIndices[k] = (signed char)i;
                                 found = false;
                                 groupData->particleStates[k] = 1;
@@ -1125,7 +1125,7 @@ void IsDeadGroupBreath(PBreathModel* pBreathModel, VBreathModel* vBreathModel, s
 
     if (isDead) {
         for (i = 0; i < *(unsigned short*)((unsigned char*)pBreathModel + 0x10); i++) {
-            groupData->particleStates[i] = 0xFF;
+            groupData->particleStates[i] = -1;
             groupData->position.x = zero;
             groupData->position.y = zero;
             groupData->position.z = zero;


### PR DESCRIPTION
## Summary
- change `BreathParticleGroup::particleStates` to `signed char*`
- normalize the per-slot empty-state sentinel from `0xFF` to `-1`
- keep the existing `-1/1` slot-state semantics consistent across `pppFrameBreathModel`, `UpdateAllParticle`, and related cleanup paths

## Evidence
- initial target selection on April 27, 2026 listed `main/pppBreathModel` as a top code opportunity with:
  - `BirthParticle...` at 81.5%
  - `pppFrameBreathModel` at 90.3%
  - `UpdateAllParticle...` at 91.6%
- after this change, the generated report shows:
  - `BirthParticle...` at 81.494896%
  - `pppFrameBreathModel` at 90.275314%
  - `UpdateAllParticle...` at 92.424126%
- after the rebuild, `python3 tools/agent_select_target.py` no longer surfaces `main/pppBreathModel` in the top code-opportunity bucket

## Why This Is Plausible
- the group state array is used throughout the unit as a signed byte state machine with `-1` meaning empty and `1` meaning active
- aligning the type and sentinel literals to that behavior removes an ABI-level mismatch instead of adding compiler-coaxing hacks

## Validation
- `ninja`