### PR TITLE
Match ExpressionDirect MIDI control

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1159,10 +1159,9 @@ void __MidiCtrl_VolumeChange(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* trac
  */
 void __MidiCtrl_ExpressionDirect(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* track)
 {
-    unsigned char* command = (unsigned char*)*(int*)track;
+    int value = ((int)(char)*(*(unsigned char**)track)++) << 0xc;
 
-    *(int*)track = (int)(command + 1);
-    ((int*)track)[0xd] = ((int)(char)*command) << 0xc;
+    ((int*)track)[0xd] = value;
     ((int*)track)[0xe] = 0;
     ((int*)track)[0xf] = 0;
     m_ChangeStatus |= 2;


### PR DESCRIPTION
## Summary
- Rework __MidiCtrl_ExpressionDirect to name the shifted expression value directly
- Matches the target command-byte post-increment and store sequence

## Evidence
- Before: __MidiCtrl_ExpressionDirect__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA was 98.68421% (76 bytes)
- After: 100.0% match (76 bytes)
- ninja passes; report increased RedSound matched code from 19024 to 19100 bytes and matched RedSound functions from 243 to 244

## Plausibility
- The source now keeps the signed command byte conversion and left shift as the named value that is stored to track[0xd], matching the generated code without casts to addresses or other output-only hacks.