### PR TITLE
Improve CTextureSet::ReleaseTextureIdx match

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -1383,26 +1383,23 @@ int CTextureSet::Find(char* name)
  */
 void CTextureSet::ReleaseTextureIdx(int idx, CAmemCacheSet* amemCacheSet)
 {
-    if (__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx) == 0) {
-        return;
-    }
+    if (__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx) != 0) {
+        if (S16At(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 0x72) != -1) {
+            if (*reinterpret_cast<int*>(Ptr(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 4)) < 2) {
+                amemCacheSet->DestroyCache(S16At(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 0x72));
+                PtrAt(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 0x78) = 0;
+            }
+        }
 
-    if ((S16At(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 0x72) != -1)
-        && (*reinterpret_cast<int*>(Ptr(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 4)) <= 1)) {
-        short cacheId = S16At(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 0x72);
-        amemCacheSet->DestroyCache(cacheId);
-        PtrAt(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx), 0x78) = 0;
-    }
+        int* refObj = reinterpret_cast<int*>(__vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx));
+        int refCount = refObj[1];
+        refObj[1] = refCount - 1;
+        if ((refCount - 1 == 0) && (refObj != 0)) {
+            (*reinterpret_cast<void (**)(int*, int)>(*refObj + 8))(refObj, 1);
+        }
 
-    CTexture* texture = __vc__21CPtrArray_P8CTexture_FUl(Textures(this), idx);
-    int* refObj = reinterpret_cast<int*>(texture);
-    int refCount = refObj[1] - 1;
-    refObj[1] = refCount;
-    if ((refCount == 0) && (refObj != 0)) {
-        (*reinterpret_cast<void (**)(int*, int)>(*refObj + 8))(refObj, 1);
+        SetAt__21CPtrArray_P8CTexture_FUlP8CTexture(Textures(this), idx, 0);
     }
-
-    SetAt__21CPtrArray_P8CTexture_FUlP8CTexture(Textures(this), idx, 0);
 }
 
 /*


### PR DESCRIPTION
## Summary
- reshape `CTextureSet::ReleaseTextureIdx` to follow the original nested control flow instead of the cleaned-up early-return form
- preserve the repeated texture-array lookups and explicit refcount update pattern that MWCC wants in this unit
- keep the change isolated to `src/textureman.cpp`

## Evidence
- `ReleaseTextureIdx__11CTextureSetFiP13CAmemCacheSet`: `77.62295%` -> `78.91803%`
- `main/textureman` `.text`: `85.909294%` -> `85.953804%`
- `ninja -j2` completes successfully

## Plausibility
This is source-shape recovery rather than compiler coaxing: the updated function matches the nested structure shown in the decomp, including the repeated `CPtrArray` accesses and explicit refcount decrement path used elsewhere in the file.