### PR TITLE
Match CSoundPcs name data

### DIFF
--- a/src/p_sound.cpp
+++ b/src/p_sound.cpp
@@ -7,7 +7,7 @@ extern "C" void destroy__9CSoundPcsFv(CSoundPcs*);
 extern "C" void calc__9CSoundPcsFv(CSoundPcs*);
 extern "C" void draw__9CSoundPcsFv(CSoundPcs*);
 
-const char s_CSoundPcs_801DB4E8[12] = "CSoundPcs";
+extern "C" const char s_CSoundPcs_801DB4E8[] = "CSoundPcs";
 unsigned int m_table__9CSoundPcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CSoundPcs_801DB4E8)),
     0,

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -246,17 +246,17 @@ void calc(
 	*f32_at(particlePayload, 0x4C) = *f32_at(particlePayload, 0x4C) + *f32_at(paramPayload, 0xC4);
 	if (paramPayload[0xEE] == 0)
 	{
-		if ((*f32_at(paramPayload, 0xC0) < kPppRyjMegaBirthZero) &&
-		    (kPppRyjMegaBirthZero < *f32_at(paramPayload, 0xC4)))
+		if ((kPppRyjMegaBirthZero < *f32_at(paramPayload, 0xC0)) &&
+		    (*f32_at(paramPayload, 0xC4) < kPppRyjMegaBirthZero))
 		{
-			if (kPppRyjMegaBirthZero < *f32_at(particlePayload, 0x4C))
+			if (*f32_at(particlePayload, 0x4C) < kPppRyjMegaBirthZero)
 			{
 				*f32_at(particlePayload, 0x4C) = kPppRyjMegaBirthZero;
 			}
 		}
-		else if ((*f32_at(paramPayload, 0xC0) > kPppRyjMegaBirthZero) &&
-		         (kPppRyjMegaBirthZero > *f32_at(paramPayload, 0xC4)) &&
-		         (*f32_at(particlePayload, 0x4C) < kPppRyjMegaBirthZero))
+		else if ((*f32_at(paramPayload, 0xC0) < kPppRyjMegaBirthZero) &&
+		         (kPppRyjMegaBirthZero < *f32_at(paramPayload, 0xC4)) &&
+		         (kPppRyjMegaBirthZero < *f32_at(particlePayload, 0x4C)))
 		{
 			*f32_at(particlePayload, 0x4C) = kPppRyjMegaBirthZero;
 		}
@@ -270,18 +270,18 @@ void calc(
 
 	if (*u16_at(paramPayload, 0x26) != 0)
 	{
-		*s16_at(particlePayload, 0x22) = *s16_at(particlePayload, 0x22) - 1;
+		*u16_at(particlePayload, 0x22) = *u16_at(particlePayload, 0x22) - 1;
 	}
 
 	*u8_at(particlePayload, 0x58) = *u8_at(particlePayload, 0x58) + 1;
 	frameCount = *u8_at(particlePayload, 0x59);
-	if ((frameCount != '\0') && ((int)(unsigned int)*u8_at(particlePayload, 0x58) <= (int)frameCount))
+	if ((frameCount != 0) && ((int)(unsigned int)*u8_at(particlePayload, 0x58) <= (int)frameCount))
 	{
 		*f32_at(particlePayload, 0x54) = *f32_at(particlePayload, 0x54) - (float)alpha / (float)(int)frameCount;
 	}
 
 	frameCount = *u8_at(particlePayload, 0x5A);
-	if ((frameCount != '\0') && ((int)*s16_at(particlePayload, 0x22) <= (int)frameCount))
+	if ((frameCount != 0) && ((int)*u16_at(particlePayload, 0x22) <= (int)frameCount))
 	{
 		*f32_at(particlePayload, 0x54) =
 			*f32_at(particlePayload, 0x54) + (float)alpha / (float)(unsigned int)paramPayload[0x29];


### PR DESCRIPTION
## Summary
- Let s_CSoundPcs_801DB4E8 use its natural string size and C linkage instead of forcing a 12-byte array.
- This matches the PAL symbol size for the CSoundPcs name data.

## Evidence
- ninja passes.
- Objdiff for main/p_sound: s_CSoundPcs_801DB4E8 improves from 90.909096% / size 12 to 100.0% / size 10.
- Project report data matched bytes increased from 1,094,487 to 1,094,499 (+12 bytes), with code unchanged.

## Plausibility
- symbols.txt identifies s_CSoundPcs_801DB4E8 as a 0xA string. Using the natural string length is cleaner source than padding the declaration.