### PR TITLE
Improve pppScreenBreak constructor match

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -352,9 +352,9 @@ void pppConScreenBreak(PScreenBreak* pppScreenBreak, pppScreenBreakUnkC* param_2
     void* gObject = *(void**)((u8*)pppMngStPtr + 0xD8);
     void* handle = GetCharaHandlePtr__FP8CGObjectl(gObject, 0);
     int model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
-    float f = FLOAT_80331cc4;
     *(u32*)((u8*)gObject + 0x60) |= 0x40;
     *(void**)(model + 0xF0) = (void*)SB_BeforeDrawCallback;
+    float f = FLOAT_80331cc4;
     *(void**)(model + 0xFC) = (void*)SB_DrawMeshDLCallback;
     *(void**)(model + 0xF4) = (void*)SB_BeforeMeshLockEnvCallback;
     *(void**)(model + 0xEC) = (void*)SB_BeforeCalcMatrixCallback;


### PR DESCRIPTION
## Summary
- Move the default float load in pppConScreenBreak after the first callback assignment to match the original instruction scheduling more closely.
- Keeps the constructor source shape aligned with Ghidra's rough ordering without adding hacks or changing behavior.

## Objdiff Evidence
Before:
- main/pppScreenBreak .text: 90.75379%
- pppConScreenBreak: 90.57692%

After:
- main/pppScreenBreak .text: 90.994644%
- pppConScreenBreak: 95.76923%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - pppConScreenBreak