### PR TITLE
Correct CMenuPcs base class

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -3,6 +3,7 @@
 
 #include "ffcc/memory.h"
 #include "ffcc/memorycard.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/system.h"
 
 #include <dolphin/gx.h>
@@ -29,7 +30,7 @@ struct McListInfo
     void operator=(const McListInfo&);
 };
 
-class CMenuPcs : public CProcess
+class CMenuPcs : public CSamplePcs
 {
 public:
     struct BattleHudState


### PR DESCRIPTION
## Summary
- Change CMenuPcs to derive from CSamplePcs instead of CProcess.
- This matches the target static initializer's generated base-vtable sequence for MenuPcs more closely.

## Evidence
- ninja: passes, including build/GCCP01/main.dol OK.
- p_menu objdiff .text improved from 78.28295% to 79.15033% for the __sinit_p_menu_cpp target diff.
- Section sizes are unchanged: .text remains 14688 bytes, .data 1280 bytes, .bss 2240 bytes, .sdata2 348 bytes.

## Plausibility
- Target __sinit_p_menu_cpp initializes MenuPcs through the CSamplePcs vtable before installing CMenuPcs, so the class hierarchy was under-specified rather than needing manual ctor/vtable code.