### PR TITLE
Inline default CProcess hooks

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -16,10 +16,10 @@ class CProcess : public CManager
 public:
     CProcess() {}
     virtual int GetTable(unsigned long) = 0;
-    virtual void onScriptChanging(char*);
-    virtual void onScriptChanged(char*, int);
-    virtual void onMapChanging(int, int);
-    virtual void onMapChanged(int, int, int);
+    virtual void onScriptChanging(char*) {}
+    virtual void onScriptChanged(char*, int) {}
+    virtual void onMapChanging(int, int) {}
+    virtual void onMapChanged(int, int, int) {}
 
     void ScriptChanging(char* script) { onScriptChanging(script); }
     void ScriptChanged(char* script, int param) { onScriptChanged(script, param); }

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -28,62 +28,6 @@ CSamplePcs SamplePcs;
 
 /*
  * --INFO--
- * PAL Address: 0x8001fe74
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CProcess::onScriptChanging(char*)
-{
-	return;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8001fe78
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CProcess::onScriptChanged(char*, int)
-{
-	return;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8001fe7c
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CProcess::onMapChanging(int, int)
-{
-	return;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8001fe80
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CProcess::onMapChanged(int, int, int)
-{
-	return;
-}
-
-/*
- * --INFO--
  * PAL Address: 0x8001FE84
  * PAL Size: 4b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- move the default empty `CProcess` hook implementations into `include/ffcc/system.h`
- remove the duplicate out-of-line no-op definitions from `src/p_sample.cpp`
- keep the behavior identical while shifting virtual metadata emission to match the binary more closely across process-derived units

## Evidence
- full rebuild succeeded with `ninja`
- repo progress moved from `26.01%` to `26.07%` matched
- matched code bytes increased from `482568` to `483608`
- matched data bytes increased from `1094343` to `1094487`
- game code matched bytes increased from `153968` to `155008`
- game data matched bytes increased from `917241` to `917385`

## Why this is plausible source
- the removed functions were all trivial no-op defaults for `CProcess`
- placing those defaults on the class declaration is a normal source-level way to express the same behavior
- this avoids carrying separate empty definitions in `p_sample.cpp` and better reflects shared base-class behavior instead of making one arbitrary TU own it