### PR TITLE
Improve pppChangeTex draw callback

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -417,8 +417,8 @@ void pppConstructChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
 
 /*
  * --INFO--
- * PAL Address: 0x800d3fd8
- * PAL Size: 396b
+ * PAL Address: 0x8013f784
+ * PAL Size: 344b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
@@ -495,8 +495,8 @@ extern "C" void ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2(C
 
 /*
  * --INFO--
- * PAL Address: 0x800d4164
- * PAL Size: 276b
+ * PAL Address: 0x8013f8dc
+ * PAL Size: 244b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
@@ -511,6 +511,7 @@ extern "C" void ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2(CCh
 
 	if (*(u8*)((char*)param_3 + 0x14) == 0) {
 		int drawTevBits = 0xACE0F;
+		int fullTevBits = drawTevBits;
 		int zero = 0;
 		int allOnes = -1;
 		int tevScale = 0x1E;
@@ -518,7 +519,7 @@ extern "C" void ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2(CCh
 
 		*(int*)(MaterialManRaw() + 0x48) = drawTevBits;
 		*(int*)(MaterialManRaw() + 0x128) = zero;
-		drawTevBits |= 0x1000;
+		fullTevBits |= 0x1000;
 		*(int*)(MaterialManRaw() + 0x12c) = tevScale;
 		*(int*)(MaterialManRaw() + 0x130) = zero;
 		*(int*)(MaterialManRaw() + 0x44) = allOnes;
@@ -531,12 +532,12 @@ extern "C" void ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2(CCh
 		*(int*)(MaterialManRaw() + 0x58) = zero;
 		*(int*)(MaterialManRaw() + 0x5c) = zero;
 		*(char*)(MaterialManRaw() + 0x208) = zero;
-		*(int*)(MaterialManRaw() + 0x48) = drawTevBits;
-		*(int*)(MaterialManRaw() + 0x128) = zero;
+		*(int*)(MaterialManRaw() + 0x48) = fullTevBits;
 		*(int*)(MaterialManRaw() + 0xd0) = textureInfo + 0x28;
+		*(int*)(MaterialManRaw() + 0x128) = zero;
 		*(int*)(MaterialManRaw() + 0x12c) = tevScale;
 		*(int*)(MaterialManRaw() + 0x130) = zero;
-		*(int*)(MaterialManRaw() + 0x40) = drawTevBits;
+		*(int*)(MaterialManRaw() + 0x40) = fullTevBits;
 	}
 
 	SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(


### PR DESCRIPTION
## Summary
- Keep base and full TEV flag values separate in the pppChangeTex draw callback.
- Move the texture offset write before the final 0x128 material write, matching the original callback ordering more closely.
- Correct the PAL address/size metadata for the pppChangeTex callback blocks.

## Evidence
- ninja
- objdiff: main/pppChangeTex ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2 improved from 90.60656% to 90.88525%, size remains 244 bytes.

## Plausibility
- This keeps the source-level distinction between the base TEV bitset (0xACE0F) and the full bitset with 0x1000 set, instead of mutating the base value and reusing it for both roles.