### PR TITLE
Improve money menu confirm handling

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -675,6 +675,10 @@ int CMenuPcs::MoneyCtrlCur()
 
 		if ((hold & 0xC) == 0) {
 			if ((press & 0x100) != 0) {
+				if (((int)*(u8*)(menuState + 9) & (1 << *(s16*)(optBase + 0x26))) == 0) {
+					Sound.PlaySe(4, 0x40, 0x7F, 0);
+					return 0;
+				}
 				if (*(s16*)(optBase + 0x26) == 0) {
 					FGPutGil__12CCaravanWorkFi((void*)caravanWork, (int)gMenuMoneyTransferAmount);
 					gMenuMoneyTransferAmount = 0;


### PR DESCRIPTION
## Summary
- Add the missing message-mask check before accepting the money confirmation option.
- Play the disabled/error SE and return when the selected option is not enabled, matching the Ghidra control flow for MoneyCtrlCur.

## Evidence
- ninja passes.
- objdiff main/menu_money MoneyCtrlCur improved from 35.078342% to 37.316437%.
- menu_money .text improved from 47.913162% to 48.917297%.

## Plausibility
The guard uses the existing MoneyMenuState messageMask at offset 0x9 and the current option index, matching the surrounding menu option gating pattern instead of adding compiler-only structure.