### PR TITLE
Improve pppYmBreath particle matching

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -45,6 +45,63 @@ struct YmBreathRenderStep {
     unsigned char m_payload[1];
 };
 
+struct YmBreathParams {
+    unsigned char _pad00[0x04];
+    float m_groupRadius;
+    float m_groupOwnerScale;
+    int m_shapeStepValue;
+    short m_shapeFrameArg;
+    unsigned short m_slotCount;
+    unsigned short m_groupCount;
+    float m_groupSpeed;
+    unsigned char _pad1C[0x02];
+    unsigned short m_particleCount;
+    unsigned short m_emitCount;
+    unsigned short m_emitInterval;
+    short m_particleLifetime;
+    unsigned char m_fadeOutFrames;
+    unsigned char m_fadeInFrames;
+    unsigned char m_spread;
+    unsigned char _pad29[0x03];
+    float m_colorFrameDelta0;
+    float m_colorFrameDelta1;
+    float m_colorFrameDelta2;
+    float m_colorFrameDelta3;
+    float m_colorFrameAccel0;
+    float m_colorFrameAccel1;
+    float m_colorFrameAccel2;
+    float m_colorFrameAccel3;
+    unsigned char _pad48[0x08];
+    float m_rotationStartX;
+    float m_rotationStartY;
+    unsigned char _pad58[0x08];
+    float m_rotationVelocityX;
+    float m_rotationVelocityY;
+    unsigned char _pad68[0x08];
+    float m_rotationAccelX;
+    float m_rotationAccelY;
+    unsigned char _pad78[0x08];
+    float m_rotationRandomX;
+    float m_rotationRandomY;
+    unsigned char _pad88[0x08];
+    float m_angleStart;
+    float m_angleStep;
+    float m_angleAccel;
+    float m_angleRandomRange;
+    float m_scaleClampStart;
+    float m_scaleAccel;
+    float m_scaleRandomRange;
+    float m_spawnOffset;
+    float m_directionScaleX;
+    float m_directionScaleY;
+    float m_directionScaleZ;
+    unsigned char _padBC[0x05];
+    unsigned char m_rotationFlags;
+    unsigned char m_angleFlags;
+    unsigned char _padC3[0x05];
+    unsigned char m_disableScaleClamp;
+};
+
 struct YmBreathParticleGroup {
     int active;
     signed char* particleIndices;
@@ -70,6 +127,30 @@ struct VYmBreath {
     short m_slotCount;
     unsigned char m_flags;
     unsigned char _pad59[3];
+};
+
+struct YmBreathParticleData {
+    Vec m_position;
+    Vec m_direction;
+    unsigned char _pad18[0x08];
+    short m_life;
+    unsigned char _pad22[0x02];
+    unsigned char m_fadeOutFrames;
+    unsigned char m_fadeInFrames;
+    unsigned char _pad26[0x02];
+    float m_angle;
+    float m_angleVelocity;
+    float m_angleRandom;
+    float m_rotationX;
+    float m_rotationY;
+    float m_rotationVelocityX;
+    float m_rotationVelocityY;
+    float m_rotationAccelX;
+    float m_rotationAccelY;
+    float m_alpha;
+    float m_scale;
+    unsigned char m_age;
+    unsigned char _pad55[0x0B];
 };
 
 extern "C" const char s_pppYmBreath_cpp_801DA9B0[] = "pppYmBreath.cpp";
@@ -732,9 +813,9 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
 void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* particleData, VColor* vColor,
                     _PARTICLE_COLOR* particleColor)
 {
-    unsigned char* breath = (unsigned char*)pYmBreath;
+    YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
     int alpha = vColor->m_alpha;
-    Vec* particle = reinterpret_cast<Vec*>(particleData);
+    YmBreathParticleData* particle = reinterpret_cast<YmBreathParticleData*>(particleData);
     char frameCount;
     Vec step;
     float angleRange;
@@ -746,70 +827,70 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* 
         particleColor->m_color[1] += particleColor->m_colorFrameDeltas[1];
         particleColor->m_color[2] += particleColor->m_colorFrameDeltas[2];
         particleColor->m_color[3] += particleColor->m_colorFrameDeltas[3];
-        particleColor->m_colorFrameDeltas[0] += *(float*)(breath + 0x3C);
-        particleColor->m_colorFrameDeltas[1] += *(float*)(breath + 0x40);
-        particleColor->m_colorFrameDeltas[2] += *(float*)(breath + 0x44);
-        particleColor->m_colorFrameDeltas[3] += *(float*)(breath + 0x48);
+        particleColor->m_colorFrameDeltas[0] += params->m_colorFrameAccel0;
+        particleColor->m_colorFrameDeltas[1] += params->m_colorFrameAccel1;
+        particleColor->m_colorFrameDeltas[2] += params->m_colorFrameAccel2;
+        particleColor->m_colorFrameDeltas[3] += params->m_colorFrameAccel3;
         alpha = (unsigned int)vColor->m_alpha + (int)particleColor->m_color[3];
         if (alpha > 0xFF) {
             alpha = 0xFF;
         }
     }
 
-    particle[3].y += particle[3].z;
-    if ((*(unsigned char*)(breath + 0xC2) & 0x10) != 0) {
-        particle[3].z += *(float*)(breath + 0x98) + particle[4].x;
+    particle->m_angle += particle->m_angleVelocity;
+    if (params->m_angleFlags & 0x10) {
+        particle->m_angleVelocity = params->m_angleAccel + particle->m_angleRandom + particle->m_angleVelocity;
     } else {
-        particle[3].z += *(float*)(breath + 0x98);
+        particle->m_angleVelocity += params->m_angleAccel;
     }
 
     angleRange = 6.2831855f;
-    while (angleRange <= particle[3].y) {
-        particle[3].y -= angleRange;
+    while (angleRange <= particle->m_angle) {
+        particle->m_angle -= angleRange;
     }
-    while (particle[3].y < 0.0f) {
-        particle[3].y += angleRange;
+    while (particle->m_angle < 0.0f) {
+        particle->m_angle += angleRange;
     }
 
-    particle[4].y += particle[5].x;
-    particle[4].z += particle[5].y;
-    if ((*(unsigned char*)(breath + 0xC1) & 0x10) != 0) {
-        particle[5].x += *(float*)(breath + 0x70) + particle[5].z;
-        particle[5].y += *(float*)(breath + 0x74) + particle[6].x;
+    particle->m_rotationX += particle->m_rotationVelocityX;
+    particle->m_rotationY += particle->m_rotationVelocityY;
+    if (params->m_rotationFlags & 0x10) {
+        particle->m_rotationVelocityX = params->m_rotationAccelX + particle->m_rotationAccelX + particle->m_rotationVelocityX;
+        particle->m_rotationVelocityY = params->m_rotationAccelY + particle->m_rotationAccelY + particle->m_rotationVelocityY;
     } else {
-        particle[5].x += *(float*)(breath + 0x70);
-        particle[5].y += *(float*)(breath + 0x74);
+        particle->m_rotationVelocityX += params->m_rotationAccelX;
+        particle->m_rotationVelocityY += params->m_rotationAccelY;
     }
 
-    particle[6].z += *(float*)(breath + 0xA4);
-    if (*(unsigned char*)(breath + 0xC8) == 0) {
-        float start = *(float*)(breath + 0xA0);
+    particle->m_scale += params->m_scaleAccel;
+    if (params->m_disableScaleClamp == 0) {
+        float start = params->m_scaleClampStart;
         float zero = 0.0f;
-        if ((zero < start) && (*(float*)(breath + 0xA4) < zero)) {
-            if (particle[6].z < zero) {
-                particle[6].z = zero;
+        if ((zero < start) && (params->m_scaleAccel < zero)) {
+            if (particle->m_scale < zero) {
+                particle->m_scale = zero;
             }
-        } else if ((start < zero) && (zero < *(float*)(breath + 0xA4)) && (zero < particle[6].z)) {
-            particle[6].z = zero;
+        } else if ((start < zero) && (zero < params->m_scaleAccel) && (zero < particle->m_scale)) {
+            particle->m_scale = zero;
         }
     }
 
-    PSVECScale(&particle[1], &step, particle[6].z);
-    PSVECAdd(&step, &particle[0], &particle[0]);
+    PSVECScale(&particle->m_direction, &step, particle->m_scale);
+    PSVECAdd(&step, &particle->m_position, &particle->m_position);
 
-    if (*(unsigned short*)(breath + 0x24) != 0) {
-        *(short*)&particle[2].z = *(short*)&particle[2].z - 1;
+    if (params->m_particleLifetime != 0) {
+        particle->m_life = particle->m_life - 1;
     }
-    *(char*)&particle[7].x = *(char*)&particle[7].x + 1;
+    particle->m_age = particle->m_age + 1;
 
-    frameCount = *(char*)&particle[3].x;
-    if ((frameCount != '\0') && ((int)(unsigned int)*(unsigned char*)&particle[7].x <= (int)frameCount)) {
-        *(float*)&particle[6].y -= (float)alpha / (float)(int)frameCount;
+    frameCount = particle->m_fadeOutFrames;
+    if ((frameCount != '\0') && ((int)(unsigned int)particle->m_age <= (int)frameCount)) {
+        particle->m_alpha -= (float)alpha / (float)(int)frameCount;
     }
 
-    frameCount = *(char*)((unsigned char*)&particle[3].x + 1);
-    if ((frameCount != '\0') && ((int)*(short*)&particle[2].z <= (int)frameCount)) {
-        *(float*)&particle[6].y += (float)alpha / (float)(unsigned int)*(unsigned char*)(breath + 0x27);
+    frameCount = particle->m_fadeInFrames;
+    if ((frameCount != '\0') && ((int)particle->m_life <= (int)frameCount)) {
+        particle->m_alpha += (float)alpha / (float)(unsigned int)params->m_fadeInFrames;
     }
 }
 

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -45,63 +45,6 @@ struct YmBreathRenderStep {
     unsigned char m_payload[1];
 };
 
-struct YmBreathParams {
-    unsigned char _pad00[0x04];
-    float m_groupRadius;
-    float m_groupOwnerScale;
-    int m_shapeStepValue;
-    short m_shapeFrameArg;
-    unsigned short m_slotCount;
-    unsigned short m_groupCount;
-    float m_groupSpeed;
-    unsigned char _pad1C[0x02];
-    unsigned short m_particleCount;
-    unsigned short m_emitCount;
-    unsigned short m_emitInterval;
-    short m_particleLifetime;
-    unsigned char m_fadeOutFrames;
-    unsigned char m_fadeInFrames;
-    unsigned char m_spread;
-    unsigned char _pad29[0x03];
-    float m_colorFrameDelta0;
-    float m_colorFrameDelta1;
-    float m_colorFrameDelta2;
-    float m_colorFrameDelta3;
-    float m_colorFrameAccel0;
-    float m_colorFrameAccel1;
-    float m_colorFrameAccel2;
-    float m_colorFrameAccel3;
-    unsigned char _pad48[0x08];
-    float m_rotationStartX;
-    float m_rotationStartY;
-    unsigned char _pad58[0x08];
-    float m_rotationVelocityX;
-    float m_rotationVelocityY;
-    unsigned char _pad68[0x08];
-    float m_rotationAccelX;
-    float m_rotationAccelY;
-    unsigned char _pad78[0x08];
-    float m_rotationRandomX;
-    float m_rotationRandomY;
-    unsigned char _pad88[0x08];
-    float m_angleStart;
-    float m_angleStep;
-    float m_angleAccel;
-    float m_angleRandomRange;
-    float m_scaleClampStart;
-    float m_scaleAccel;
-    float m_scaleRandomRange;
-    float m_spawnOffset;
-    float m_directionScaleX;
-    float m_directionScaleY;
-    float m_directionScaleZ;
-    unsigned char _padBC[0x05];
-    unsigned char m_rotationFlags;
-    unsigned char m_angleFlags;
-    unsigned char _padC3[0x05];
-    unsigned char m_disableScaleClamp;
-};
-
 struct YmBreathParticleGroup {
     int active;
     signed char* particleIndices;
@@ -127,30 +70,6 @@ struct VYmBreath {
     short m_slotCount;
     unsigned char m_flags;
     unsigned char _pad59[3];
-};
-
-struct YmBreathParticleData {
-    Vec m_position;
-    Vec m_direction;
-    unsigned char _pad18[0x08];
-    short m_life;
-    unsigned char _pad22[0x02];
-    unsigned char m_fadeOutFrames;
-    unsigned char m_fadeInFrames;
-    unsigned char _pad26[0x02];
-    float m_angle;
-    float m_angleVelocity;
-    float m_angleRandom;
-    float m_rotationX;
-    float m_rotationY;
-    float m_rotationVelocityX;
-    float m_rotationVelocityY;
-    float m_rotationAccelX;
-    float m_rotationAccelY;
-    float m_alpha;
-    float m_scale;
-    unsigned char m_age;
-    unsigned char _pad55[0x0B];
 };
 
 extern "C" const char s_pppYmBreath_cpp_801DA9B0[] = "pppYmBreath.cpp";
@@ -471,7 +390,6 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
  */
 extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pppYmBreathUnkC* offsets)
 {
-    YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
     int colorOffset;
     int* dataOffsets;
     _pppMngSt* mngSt;
@@ -510,9 +428,9 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     if (work->m_particleData == NULL) {
         int* groupTable;
 
-        work->m_particleCount = (int)params->m_particleCount;
-        work->m_slotCount = params->m_slotCount;
-        work->m_groupCount = params->m_groupCount;
+        work->m_particleCount = (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x1E);
+        work->m_slotCount = *(unsigned short*)((unsigned char*)pYmBreath + 0x12);
+        work->m_groupCount = *(unsigned short*)((unsigned char*)pYmBreath + 0x14);
 
         work->m_particleData =
             (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci((unsigned long)(work->m_particleCount * 0x60),
@@ -540,26 +458,26 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
 
         work->m_groups =
             (YmBreathParticleGroup*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-                (unsigned long)((int)params->m_groupCount * 0x5C),
+                (unsigned long)((int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14) * 0x5C),
                 pppEnvStPtr->m_stagePtr,
                 const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x255);
         if (work->m_groups != NULL) {
             memset(work->m_groups, 0,
-                   (unsigned long)((int)params->m_groupCount * 0x5C));
+                   (unsigned long)((int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14) * 0x5C));
 
             groupTable = (int*)work->m_groups;
-            for (i = 0; i < (int)params->m_groupCount; i++) {
+            for (i = 0; i < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14); i++) {
                 groupTable[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-                    (unsigned long)params->m_slotCount,
+                    (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12),
                     pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x260);
                 memset((void*)groupTable[1], 0xFF,
-                       (unsigned long)params->m_slotCount);
+                       (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12));
 
                 groupTable[2] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-                    (unsigned long)params->m_slotCount,
+                    (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12),
                     pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x263);
                 memset((void*)groupTable[2], 0xFF,
-                       (unsigned long)params->m_slotCount);
+                       (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12));
                 groupTable[0] = 0;
                 groupTable += 0x17;
             }
@@ -576,8 +494,9 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
 
     particleWMat = work->m_particleWmats;
     groupData = (int*)work->m_groups;
-    for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
-        slotCount = params->m_slotCount;
+    for (groupIndex = 0; groupIndex < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14);
+         groupIndex++) {
+        slotCount = (unsigned int)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
         groupTable = (int)groupData;
         for (slotIndex = 0; slotIndex < (int)slotCount; slotIndex++) {
             if ((*(signed char*)(*(int*)(groupTable + 4) + slotIndex) == -1) ||
@@ -590,7 +509,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
 group_ready:
         if (ready) {
             firstParticle = -1;
-            scaledOwner = mngSt->m_ownerScale * params->m_groupOwnerScale;
+            scaledOwner = mngSt->m_ownerScale * *(float*)((unsigned char*)pYmBreath + 8);
             for (slotIndex = 0; slotCount != 0; slotCount--) {
                 if (*(signed char*)(*(int*)(groupTable + 8) + slotIndex) != -1) {
                     firstParticle = (int)*(signed char*)(*(int*)(groupTable + 4) + slotIndex);
@@ -618,7 +537,8 @@ group_ready:
             PSVECScale(&dir, &target, *(float*)(groupTable + 0x24));
             pppAddVector(target, origin, target);
             pppSubVector(hitVector, target, origin);
-            pppHitCylinderSendSystem(mngSt, &origin, &hitVector, scaledOwner, params->m_groupRadius);
+            pppHitCylinderSendSystem(mngSt, &origin, &hitVector, scaledOwner,
+                                                                *(float*)((unsigned char*)pYmBreath + 4));
         }
 
         groupData += 0x17;
@@ -636,7 +556,6 @@ group_ready:
  */
 void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VColor* vColor)
 {
-    YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
     bool found;
     int spawnCount;
     int i;
@@ -654,7 +573,6 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
     short foundGroup;
     Vec stepVelocity;
     Vec unitVelocity;
-    unsigned short* emitFrameCounter;
 
     spawnCount = 0;
     particleData = (unsigned char*)vYmBreath->m_particleData;
@@ -662,24 +580,27 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
     particleColor = (unsigned char*)vYmBreath->m_particleColors;
     groupTable = vYmBreath->m_groups;
     maxParticleCount = vYmBreath->m_particleCount;
-    emitFrameCounter = &vYmBreath->m_emitFrameCounter;
 
-    if ((gPppCalcDisabled == 0) && (params->m_shapeStepValue != 0xFFFF)) {
-        *emitFrameCounter = *emitFrameCounter + 1;
+    if ((gPppCalcDisabled == 0) && (*(int*)((unsigned char*)pYmBreath + 0xC) != 0xFFFF)) {
+        vYmBreath->m_emitFrameCounter = vYmBreath->m_emitFrameCounter + 1;
 
         for (i = 0; i < maxParticleCount; i++) {
             if (*(short*)(particleData + 0x50) >= 1) {
                 UpdateParticle(vYmBreath, pYmBreath, (_PARTICLE_DATA*)particleData, vColor,
                                (_PARTICLE_COLOR*)particleColor);
-                pppCalcFrameShape(*(long**)(*(int*)(pppEnvStPtr + 0xC) + params->m_shapeStepValue * 4),
+                pppCalcFrameShape(*(long**)(*(int*)(pppEnvStPtr + 0xC) + *(int*)((unsigned char*)pYmBreath + 0xC) * 4),
                                   *(short*)(particleData + 0x58), *(short*)(particleData + 0x5A),
-                                  *(short*)(particleData + 0x56), params->m_shapeFrameArg);
+                                  *(short*)(particleData + 0x56), *(short*)((unsigned char*)pYmBreath + 0x10));
             } else {
                 float zero = FLOAT_80330c80;
 
                 groupTableWork = (int)vYmBreath->m_groups;
-                for (foundGroup = 0; foundGroup < (int)params->m_groupCount; foundGroup++) {
-                    for (foundSlot = 0; foundSlot < (int)params->m_slotCount; foundSlot++) {
+                for (foundGroup = 0;
+                     foundGroup < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14);
+                     foundGroup++) {
+                    for (foundSlot = 0;
+                         foundSlot < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
+                         foundSlot++) {
                         if ((int)(short)i == (int)*(signed char*)(*(int*)(groupTableWork + 4) + (int)foundSlot)) {
                             found = true;
                             goto found_index;
@@ -702,7 +623,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
 
                     slot = 0;
                     group = (int)vYmBreath->m_groups + (int)foundGroup * 0x5C;
-                    slotCount = params->m_slotCount;
+                    slotCount = *(unsigned short*)((unsigned char*)pYmBreath + 0x12);
                     while (slotCount != 0) {
                         if ((*(signed char*)(*(int*)(group + 4) + slot) != -1) ||
                             (*(signed char*)(*(int*)(group + 8) + slot) != 1)) {
@@ -717,7 +638,8 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                 group_checked:
                     if (found) {
                         groupData = &groupTable[(int)foundGroup];
-                        for (slot = 0; slot < (int)params->m_slotCount; slot++) {
+                        for (slot = 0; slot < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
+                             slot++) {
                             groupData->particleStates[slot] = 0xFF;
                             groupData->position.x = zero;
                             groupData->position.y = zero;
@@ -731,14 +653,16 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                     }
                 }
 
-                if ((params->m_emitInterval <= *emitFrameCounter) && (spawnCount < (int)params->m_emitCount)) {
+                if ((*(unsigned short*)((unsigned char*)pYmBreath + 0x22) <= vYmBreath->m_emitFrameCounter) &&
+                    (spawnCount < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x20))) {
                     BirthParticle(pppObject, vYmBreath, pYmBreath, vColor, (_PARTICLE_DATA*)particleData,
                                   (Mtx*)particleWmat, (_PARTICLE_COLOR*)particleColor);
                     found = true;
                     spawnCount += 1;
                     groupData = groupTable;
-                    for (j = 0; j < (int)params->m_groupCount; j++) {
-                        for (k = 0; k < (int)params->m_slotCount; k++) {
+                    for (j = 0; j < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14); j++) {
+                        for (k = 0; k < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
+                             k++) {
                             if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == 0xFF)) {
                                 groupData->particleIndices[k] = (signed char)i;
                                 found = false;
@@ -766,16 +690,16 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
         }
 
         if (spawnCount > 0) {
-            *emitFrameCounter = 0;
+            vYmBreath->m_emitFrameCounter = 0;
         }
 
         groupData = groupTable;
-        for (i = 0; i < (int)params->m_groupCount; i++) {
+        for (i = 0; i < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14); i++) {
             if ((groupData->active != 1) && (*groupData->particleIndices != -1) && (*groupData->particleStates == 1)) {
                 unitVelocity.x = FLOAT_80330c80;
                 unitVelocity.y = FLOAT_80330c80;
                 unitVelocity.z = FLOAT_80330C90;
-                groupData->speed = params->m_groupSpeed;
+                groupData->speed = *(float*)((unsigned char*)pYmBreath + 0x18);
                 pppCopyVector(groupData->direction, unitVelocity);
                 groupData->position.x = 0.0f;
                 groupData->position.y = 0.0f;
@@ -786,7 +710,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
             groupData += 1;
         }
 
-        for (i = 0; i < (int)params->m_groupCount; i++) {
+        for (i = 0; i < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14); i++) {
             if (groupTable->active != 0) {
                 PSVECScale(&groupTable->direction, &stepVelocity, groupTable->speed);
                 PSVECAdd(&stepVelocity, &groupTable->position, &groupTable->position);
@@ -808,9 +732,9 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
 void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* particleData, VColor* vColor,
                     _PARTICLE_COLOR* particleColor)
 {
-    YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
-    YmBreathParticleData* particle = reinterpret_cast<YmBreathParticleData*>(particleData);
+    unsigned char* breath = (unsigned char*)pYmBreath;
     int alpha = vColor->m_alpha;
+    Vec* particle = reinterpret_cast<Vec*>(particleData);
     char frameCount;
     Vec step;
     float angleRange;
@@ -822,70 +746,70 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* 
         particleColor->m_color[1] += particleColor->m_colorFrameDeltas[1];
         particleColor->m_color[2] += particleColor->m_colorFrameDeltas[2];
         particleColor->m_color[3] += particleColor->m_colorFrameDeltas[3];
-        particleColor->m_colorFrameDeltas[0] += params->m_colorFrameAccel0;
-        particleColor->m_colorFrameDeltas[1] += params->m_colorFrameAccel1;
-        particleColor->m_colorFrameDeltas[2] += params->m_colorFrameAccel2;
-        particleColor->m_colorFrameDeltas[3] += params->m_colorFrameAccel3;
+        particleColor->m_colorFrameDeltas[0] += *(float*)(breath + 0x3C);
+        particleColor->m_colorFrameDeltas[1] += *(float*)(breath + 0x40);
+        particleColor->m_colorFrameDeltas[2] += *(float*)(breath + 0x44);
+        particleColor->m_colorFrameDeltas[3] += *(float*)(breath + 0x48);
         alpha = (unsigned int)vColor->m_alpha + (int)particleColor->m_color[3];
         if (alpha > 0xFF) {
             alpha = 0xFF;
         }
     }
 
-    particle->m_angle += particle->m_angleVelocity;
-    if (params->m_angleFlags & 0x10) {
-        particle->m_angleVelocity = params->m_angleAccel + particle->m_angleRandom + particle->m_angleVelocity;
+    particle[3].y += particle[3].z;
+    if ((*(unsigned char*)(breath + 0xC2) & 0x10) != 0) {
+        particle[3].z += *(float*)(breath + 0x98) + particle[4].x;
     } else {
-        particle->m_angleVelocity += params->m_angleAccel;
+        particle[3].z += *(float*)(breath + 0x98);
     }
 
     angleRange = 6.2831855f;
-    while (angleRange <= particle->m_angle) {
-        particle->m_angle -= angleRange;
+    while (angleRange <= particle[3].y) {
+        particle[3].y -= angleRange;
     }
-    while (particle->m_angle < 0.0f) {
-        particle->m_angle += angleRange;
+    while (particle[3].y < 0.0f) {
+        particle[3].y += angleRange;
     }
 
-    particle->m_rotationX += particle->m_rotationVelocityX;
-    particle->m_rotationY += particle->m_rotationVelocityY;
-    if (params->m_rotationFlags & 0x10) {
-        particle->m_rotationVelocityX = params->m_rotationAccelX + particle->m_rotationAccelX + particle->m_rotationVelocityX;
-        particle->m_rotationVelocityY = params->m_rotationAccelY + particle->m_rotationAccelY + particle->m_rotationVelocityY;
+    particle[4].y += particle[5].x;
+    particle[4].z += particle[5].y;
+    if ((*(unsigned char*)(breath + 0xC1) & 0x10) != 0) {
+        particle[5].x += *(float*)(breath + 0x70) + particle[5].z;
+        particle[5].y += *(float*)(breath + 0x74) + particle[6].x;
     } else {
-        particle->m_rotationVelocityX += params->m_rotationAccelX;
-        particle->m_rotationVelocityY += params->m_rotationAccelY;
+        particle[5].x += *(float*)(breath + 0x70);
+        particle[5].y += *(float*)(breath + 0x74);
     }
 
-    particle->m_scale += params->m_scaleAccel;
-    if (params->m_disableScaleClamp == 0) {
-        float start = params->m_scaleClampStart;
+    particle[6].z += *(float*)(breath + 0xA4);
+    if (*(unsigned char*)(breath + 0xC8) == 0) {
+        float start = *(float*)(breath + 0xA0);
         float zero = 0.0f;
-        if ((zero < start) && (params->m_scaleAccel < zero)) {
-            if (particle->m_scale < zero) {
-                particle->m_scale = zero;
+        if ((zero < start) && (*(float*)(breath + 0xA4) < zero)) {
+            if (particle[6].z < zero) {
+                particle[6].z = zero;
             }
-        } else if ((start < zero) && (zero < params->m_scaleAccel) && (zero < particle->m_scale)) {
-            particle->m_scale = zero;
+        } else if ((start < zero) && (zero < *(float*)(breath + 0xA4)) && (zero < particle[6].z)) {
+            particle[6].z = zero;
         }
     }
 
-    PSVECScale(&particle->m_direction, &step, particle->m_scale);
-    PSVECAdd(&step, &particle->m_position, &particle->m_position);
+    PSVECScale(&particle[1], &step, particle[6].z);
+    PSVECAdd(&step, &particle[0], &particle[0]);
 
-    if (params->m_particleLifetime != 0) {
-        particle->m_life = particle->m_life - 1;
+    if (*(unsigned short*)(breath + 0x24) != 0) {
+        *(short*)&particle[2].z = *(short*)&particle[2].z - 1;
     }
-    particle->m_age = particle->m_age + 1;
+    *(char*)&particle[7].x = *(char*)&particle[7].x + 1;
 
-    frameCount = particle->m_fadeOutFrames;
-    if ((frameCount != '\0') && ((int)(unsigned int)particle->m_age <= (int)frameCount)) {
-        particle->m_alpha -= (float)alpha / (float)(int)frameCount;
+    frameCount = *(char*)&particle[3].x;
+    if ((frameCount != '\0') && ((int)(unsigned int)*(unsigned char*)&particle[7].x <= (int)frameCount)) {
+        *(float*)&particle[6].y -= (float)alpha / (float)(int)frameCount;
     }
 
-    frameCount = particle->m_fadeInFrames;
-    if ((frameCount != '\0') && ((int)particle->m_life <= (int)frameCount)) {
-        particle->m_alpha += (float)alpha / (float)(unsigned int)params->m_fadeInFrames;
+    frameCount = *(char*)((unsigned char*)&particle[3].x + 1);
+    if ((frameCount != '\0') && ((int)*(short*)&particle[2].z <= (int)frameCount)) {
+        *(float*)&particle[6].y += (float)alpha / (float)(unsigned int)*(unsigned char*)(breath + 0x27);
     }
 }
 
@@ -901,8 +825,8 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* 
 void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VColor* vColor, _PARTICLE_DATA* particleData,
                    Mtx* particleWmat, _PARTICLE_COLOR* particleColor)
 {
-    YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
-    YmBreathParticleData* particle = reinterpret_cast<YmBreathParticleData*>(particleData);
+    unsigned char* breath = (unsigned char*)pYmBreath;
+    Vec* particle = reinterpret_cast<Vec*>(particleData);
     int angle[3];
     pppFMATRIX rotMtx;
     Vec baseDir;
@@ -913,7 +837,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     float range;
     unsigned char flags;
 
-    spread = (float)(unsigned int)params->m_spread;
+    spread = (float)(unsigned int)*(unsigned char*)(breath + 0x28);
     range = FLOAT_80330CA8 * spread;
 
     memset(particleData, 0, 0x60);
@@ -933,122 +857,122 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     angle[2] = (int)((float)((int)(range * Math.RandF() - spread) << 15) / FLOAT_80330C98);
 
     pppGetRotMatrixXYZ__FR10pppFMATRIXP11pppIVECTOR4(&rotMtx, &angle);
-    PSMTXMultVecSR(rotMtx.value, &baseDir, &particle->m_direction);
+    PSMTXMultVecSR(rotMtx.value, &baseDir, &particle[1]);
 
-    particle->m_direction.x *= params->m_directionScaleX;
-    particle->m_direction.y *= params->m_directionScaleY;
-    particle->m_direction.z *= params->m_directionScaleZ;
+    particle[1].x *= *(float*)(breath + 0xB0);
+    particle[1].y *= *(float*)(breath + 0xB4);
+    particle[1].z *= *(float*)(breath + 0xB8);
 
-    normX = particle->m_direction.x;
-    normY = particle->m_direction.y;
-    normZ = particle->m_direction.z;
-    pppNormalize__FR3Vec3Vec(reinterpret_cast<float*>(&particle->m_direction), reinterpret_cast<Vec*>(&normX));
+    normX = particle[1].x;
+    normY = particle[1].y;
+    normZ = particle[1].z;
+    pppNormalize__FR3Vec3Vec(reinterpret_cast<float*>(&particle[1]), reinterpret_cast<Vec*>(&normX));
 
-    if (params->m_spawnOffset != 0.0f) {
-        PSVECScale(&particle->m_direction, &particle->m_position, params->m_spawnOffset);
+    if (*(float*)(breath + 0xAC) != 0.0f) {
+        PSVECScale(&particle[1], &particle[0], *(float*)(breath + 0xAC));
     }
 
-    if (params->m_fadeOutFrames != '\0') {
-        particle->m_alpha = (float)(unsigned int)vColor->m_alpha;
-        particle->m_fadeOutFrames = params->m_fadeOutFrames;
+    if (*(char*)(breath + 0x26) != '\0') {
+        particle[6].y = (float)(unsigned int)vColor->m_alpha;
+        *(char*)&particle[3].x = *(char*)(breath + 0x26);
     }
-    if (params->m_fadeInFrames != '\0') {
-        particle->m_fadeInFrames = params->m_fadeInFrames;
+    if (*(char*)(breath + 0x27) != '\0') {
+        *(char*)((unsigned char*)&particle[3].x + 1) = *(char*)(breath + 0x27);
     }
 
-    particle->m_angle = params->m_angleStart;
-    particle->m_angleVelocity = params->m_angleStep;
+    particle[3].y = *(float*)(breath + 0x90);
+    particle[3].z = *(float*)(breath + 0x94);
 
-    if (params->m_angleFlags != 0) {
-        particle->m_angleRandom = params->m_angleRandomRange * Math.RandF();
-        flags = params->m_angleFlags;
+    if (*(char*)(breath + 0xC2) != '\0') {
+        particle[4].x = *(float*)(breath + 0x9C) * Math.RandF();
+        flags = *(unsigned char*)(breath + 0xC2);
         if (((flags & 1) != 0) && ((flags & 2) != 0)) {
             if (Math.RandF() > 0.5f) {
-                particle->m_angleRandom *= -1.0f;
+                particle[4].x *= -1.0f;
             }
         } else if ((flags & 2) != 0) {
-            particle->m_angleRandom *= -1.0f;
+            particle[4].x *= -1.0f;
         }
     }
 
-    if ((params->m_angleFlags & 4) != 0) {
-        particle->m_angle += particle->m_angleRandom;
+    if ((*(unsigned char*)(breath + 0xC2) & 4) != 0) {
+        particle[3].y += particle[4].x;
     }
-    if ((params->m_angleFlags & 8) != 0) {
-        particle->m_angleVelocity += particle->m_angleRandom;
-    }
-
-    while (particle->m_angle >= 6.2831855f) {
-        particle->m_angle -= 6.2831855f;
-    }
-    while (particle->m_angle < 0.0f) {
-        particle->m_angle += 6.2831855f;
+    if ((*(unsigned char*)(breath + 0xC2) & 8) != 0) {
+        particle[3].z += particle[4].x;
     }
 
-    particle->m_rotationX = params->m_rotationStartX;
-    particle->m_rotationY = params->m_rotationStartY;
-    particle->m_rotationVelocityX = params->m_rotationVelocityX;
-    particle->m_rotationVelocityY = params->m_rotationVelocityY;
+    while (particle[3].y >= 6.2831855f) {
+        particle[3].y -= 6.2831855f;
+    }
+    while (particle[3].y < 0.0f) {
+        particle[3].y += 6.2831855f;
+    }
 
-    if (params->m_rotationFlags != 0) {
-        flags = params->m_rotationFlags;
+    particle[4].y = *(float*)(breath + 0x50);
+    particle[4].z = *(float*)(breath + 0x54);
+    particle[5].x = *(float*)(breath + 0x60);
+    particle[5].y = *(float*)(breath + 0x64);
+
+    if (*(unsigned char*)(breath + 0xC1) != 0) {
+        flags = *(unsigned char*)(breath + 0xC1);
         if ((flags & 0x20) == 0) {
-            particle->m_rotationAccelX = params->m_rotationRandomX * Math.RandF();
-            particle->m_rotationAccelY = params->m_rotationRandomY * Math.RandF();
+            particle[5].z = *(float*)(breath + 0x80) * Math.RandF();
+            particle[6].x = *(float*)(breath + 0x84) * Math.RandF();
             if (((flags & 1) != 0) && ((flags & 2) != 0)) {
                 if (Math.RandF() > 0.5f) {
-                    particle->m_rotationAccelX *= -1.0f;
+                    particle[5].z *= -1.0f;
                 }
                 if (Math.RandF() > 0.5f) {
-                    particle->m_rotationAccelY *= -1.0f;
+                    particle[6].x *= -1.0f;
                 }
             } else if ((flags & 2) != 0) {
-                particle->m_rotationAccelX *= -1.0f;
-                particle->m_rotationAccelY *= -1.0f;
+                particle[5].z *= -1.0f;
+                particle[6].x *= -1.0f;
             }
         } else {
-            particle->m_rotationAccelX = params->m_rotationRandomX * Math.RandF();
-            particle->m_rotationAccelY = particle->m_rotationAccelX;
+            particle[5].z = *(float*)(breath + 0x80) * Math.RandF();
+            particle[6].x = particle[5].z;
             if (((flags & 1) != 0) && ((flags & 2) != 0)) {
                 if (Math.RandF() > 0.5f) {
-                    particle->m_rotationAccelX *= -1.0f;
-                    particle->m_rotationAccelY *= -1.0f;
+                    particle[5].z *= -1.0f;
+                    particle[6].x *= -1.0f;
                 }
             } else if ((flags & 2) != 0) {
-                particle->m_rotationAccelX *= -1.0f;
-                particle->m_rotationAccelY *= -1.0f;
+                particle[5].z *= -1.0f;
+                particle[6].x *= -1.0f;
             }
         }
     }
 
-    if ((params->m_rotationFlags & 4) != 0) {
-        particle->m_rotationX += particle->m_rotationAccelX;
-        particle->m_rotationY += particle->m_rotationAccelY;
+    if ((*(unsigned char*)(breath + 0xC1) & 4) != 0) {
+        particle[4].y += particle[5].z;
+        particle[4].z += particle[6].x;
     }
-    if ((params->m_rotationFlags & 8) != 0) {
-        particle->m_rotationVelocityX += particle->m_rotationAccelX;
-        particle->m_rotationVelocityY += particle->m_rotationAccelY;
-    }
-
-    particle->m_scale = params->m_groupSpeed;
-    if (params->m_scaleRandomRange != 0.0f) {
-        spread = params->m_scaleRandomRange;
-        particle->m_scale += (spread + spread) * Math.RandF() - spread;
+    if ((*(unsigned char*)(breath + 0xC1) & 8) != 0) {
+        particle[5].x += particle[5].z;
+        particle[5].y += particle[6].x;
     }
 
-    if (params->m_particleLifetime == 0) {
-        particle->m_life = -1;
+    particle[6].z = *(float*)(breath + 0x18);
+    if (*(float*)(breath + 0xA8) != 0.0f) {
+        spread = *(float*)(breath + 0xA8);
+        particle[6].z += (spread + spread) * Math.RandF() - spread;
+    }
+
+    if (*(short*)(breath + 0x24) == 0) {
+        *(short*)&particle[2].z = -1;
     } else {
-        particle->m_life = params->m_particleLifetime;
+        *(short*)&particle[2].z = *(short*)(breath + 0x24);
     }
-    particle->m_age = 0;
+    *(unsigned char*)&particle[7].x = 0;
 
     PSMTXCopy(*(Mtx*)vYmBreath, *(Mtx*)particleWmat);
     if (particleColor != NULL) {
-        particleColor->m_colorFrameDeltas[0] = params->m_colorFrameDelta0;
-        particleColor->m_colorFrameDeltas[1] = params->m_colorFrameDelta1;
-        particleColor->m_colorFrameDeltas[2] = params->m_colorFrameDelta2;
-        particleColor->m_colorFrameDeltas[3] = params->m_colorFrameDelta3;
+        particleColor->m_colorFrameDeltas[0] = *(float*)(breath + 0x2C);
+        particleColor->m_colorFrameDeltas[1] = *(float*)(breath + 0x30);
+        particleColor->m_colorFrameDeltas[2] = *(float*)(breath + 0x34);
+        particleColor->m_colorFrameDeltas[3] = *(float*)(breath + 0x38);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace speculative local `pppYmBreath` parameter access in the frame/update path with raw offset reads where they better match the original PAL decomp shape
- keep `UpdateParticle` on explicit typed structs, which substantially improves its codegen while preserving the adjacent raw-offset wins
- limit the change to `src/pppYmBreath.cpp`

## Evidence
Objdiff against `main/pppYmBreath` after `ninja`:
- unit `.text`: `92.0031%` -> `92.14728%`
- `UpdateParticle__FP9VYmBreathP9PYmBreathP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`: `94.78281%` -> `98.61991%`
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: `86.15443%` -> `86.47089%`
- `pppFrameYmBreath`: unchanged at `93.76582%`
- `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`: `91.16418%` -> `90.30597%`

## Why this is plausible
- the improved functions now follow the raw memory-access style shown by the PAL decomp for nearby particle code instead of relying on broader speculative layout reconstruction in the hot path
- the remaining local `UpdateAllParticle` regression is smaller than the gains in `UpdateParticle` and `BirthParticle`, and the unit-level `.text` score improved with data totals unchanged from baseline
