### PR TITLE
Improve CGObject onCreate initialization

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -110,6 +110,8 @@ public:
     unsigned char m_ownerSlot;        // 0x53
     unsigned char m_moveMode;         // 0x54
     unsigned char m_moveModePrevious; // 0x55
+    unsigned char m_field_0x56;       // 0x56
+    unsigned char m_field_0x57;       // 0x57
     void** m_scriptHandle;            // 0x58
     unsigned int m_objectFlags;       // 0x5C
     unsigned int m_displayFlags;      // 0x60

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -336,7 +336,7 @@ void CGObject::onCreate()
 
     unk_0x184 = 0.0f;
     unk_0x188 = 0.0f;
-    m_moveVec.x = NAN;
+    m_moveVec.x = -NAN;
     m_turnSpeed = 0.0f;
     m_pushParamA = 0;
     m_pushParamB = 0;
@@ -395,6 +395,7 @@ void CGObject::onCreate()
     m_groundSlide = 0.0f;
     m_worldParam = 0.0f;
     m_worldParamA = 0;
+    m_field_0x56 = 0x7D;
     *reinterpret_cast<float*>(m_worldMode) = 0.0f;
 
     m_lookAtTargetNodeIndex = -1;


### PR DESCRIPTION
## Summary
- Add explicit CGObject layout bytes at offsets 0x56 and 0x57.
- Initialize offset 0x56 to the value shown by the target onCreate decompilation.
- Use the target negative NaN value for m_moveVec.x initialization.

## Evidence
- ninja passes.
- main/gobject .text objdiff improves from 64.26785% to 64.34347%.
- onCreate__8CGObjectFv improves from 41.77551% to 43.7551%.

## Plausibility
- Offset 0x56 was previously implicit padding but the target writes 0x7D there during CGObject::onCreate.
- Ghidra shows m_moveVec.x initialized as -NAN, and this source form emits the target value more closely.