### PR TITLE
Improve Mana2 water mesh step calculation

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1110,7 +1110,6 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
     float zero;
     float normalY;
     float radius;
-    float step;
     float uvStep;
     float x;
     float z;
@@ -1129,15 +1128,14 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
     zero = FLOAT_80331898;
     rowCount = 0;
     uvStep = FLOAT_803318A8;
-    step = param_5 * uvStep;
     radius = param_5 * FLOAT_803318a4;
-    for (z = radius; -radius <= z; z -= step) {
+    for (z = radius; -radius <= z; z -= param_5 * uvStep) {
         colCount = 0;
         rowUv = static_cast<float>(rowCount) * uvStep;
         positions = reinterpret_cast<float*>(param_1);
         normals = reinterpret_cast<float*>(param_2);
         uvs = reinterpret_cast<float*>(param_3);
-        for (x = -radius; x <= radius; x += step) {
+        for (x = -radius; x <= radius; x += param_5 * uvStep) {
             *positions = x;
             param_1 = reinterpret_cast<Vec*>(positions + 3);
             positions[1] = zero;


### PR DESCRIPTION
## Summary
- Recompute the Mana2 water mesh step expression in the loop clauses instead of keeping a separate local temporary.
- This better matches the target code shape for `CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppMana2 -o build/agent/pppMana2_final_create.json CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf`
- Before: `CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf` 58.643566% match, size 380
- After: `CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf` 58.79208% match, size 380

## Plausibility
- The change removes a hoisted temporary and expresses the loop step where it is used, matching the target's repeated step calculation without introducing hardcoded addresses or artificial control flow.
