### PR TITLE
Improve pppPObjPoint pointer typing

### DIFF
--- a/include/ffcc/pppPObjPoint.h
+++ b/include/ffcc/pppPObjPoint.h
@@ -2,11 +2,12 @@
 #define _PPP_POBJPOINT_H_
 
 #include <stddef.h>
+#include <dolphin/types.h>
 
 struct PppObjData {
     int id;          // 0x0
     unsigned int field_4;     // 0x4
-    void* data;      // 0x8
+    u8* data;      // 0x8
     unsigned int objId;       // 0xc
 };
 
@@ -39,7 +40,7 @@ struct PppPointObj {
     float y;           // 0x4
     float z;           // 0x8
     unsigned char padding[4];   // 0xc
-    void* vecPtr;    // 0x10
+    u8* vecPtr;    // 0x10
 };
 
 #ifdef __cplusplus

--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -27,10 +27,12 @@ void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* co
         u8* vecPtr;
 
         if (objData->field_4 == -1) {
-            vecPtr = (u8*)gPppDefaultValueBuffer;
+            vecPtr = gPppDefaultValueBuffer;
         } else {
-            u8* data = (u8*)objData->data;
-            u32 vecOffset = pppMngStPtr->m_pppPDataVals[objData->field_4].m_nextSpawnTime;
+            u8* data = objData->data;
+            _pppPDataVal* pDataVal = pppMngStPtr->m_pppPDataVals;
+            pDataVal = &pDataVal[objData->field_4];
+            s32 vecOffset = pDataVal->m_nextSpawnTime;
             vecPtr = data + 0x80;
             vecPtr += vecOffset;
         }


### PR DESCRIPTION
## Summary
- Type `pppPObjPoint` object data/vector pointers as byte pointers.
- Split the `_pppPDataVal` lookup into an explicit typed pointer before reading the stored offset.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o - pppPObjPoint`
- `pppPObjPoint` improves from 95.27027% to 96.21622% match.

## Plausibility
- Removes byte-data `void*` casts and uses the existing `_pppPDataVal` layout for the offset lookup.
- No manual sections, fake symbols, address constants, or generated ctor/dtor code.
