### PR TITLE
Improve Runtime.PPCEABI.H/New exception emission

### DIFF
--- a/src/Runtime.PPCEABI.H/New.cp
+++ b/src/Runtime.PPCEABI.H/New.cp
@@ -2,11 +2,20 @@
 #include "PowerPC_EABI_Support/Runtime/New.h"
 
 namespace std {
+
 class exception {
 public:
-	virtual ~exception();
-	virtual const char* what() const;
+    virtual ~exception();
+    virtual const char* what() const;
 };
+
+exception::~exception() {}
+
+const char* exception::what() const
+{
+    return "exception";
+}
+
 } // namespace std
 
 __declspec(weak) void operator delete(void* arg0) throw()
@@ -15,8 +24,3 @@ __declspec(weak) void operator delete(void* arg0) throw()
         free(arg0);
     }
 }
-
-namespace std {
-exception::~exception() {}
-const char* exception::what() const { return "exception"; }
-} // namespace std


### PR DESCRIPTION
## Summary
- move `std::exception` method definitions next to the class declaration in `New.cp`
- keep `operator delete(void*)` weak so the runtime still links against the existing allocator definition in `memory.o`
- preserve the same runtime behavior while changing how the compiler emits the exception support object data

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/Runtime.PPCEABI.H/New`
- weighted non-code section match for `extab`, `extabindex`, and `.rodata`: `79.37% -> 85.79%`
- `extab`: `66.67% -> 81.82%`
- `extabindex`: `66.67% -> 61.11%` (small local regression)
- `.rodata`: `100.00% -> 100.00%`

## Plausibility
- this keeps the original weak-linkage requirement for `operator delete(void*)`
- the change is limited to declaration/definition placement for `std::exception`, which is a realistic source-level reason for different exception table emission without introducing compiler coaxing or fake symbols