### PR TITLE
Improve p_map build flags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -553,7 +553,7 @@ config.libs = [
             Object(NonMatching, "p_gba.cpp"),
             Object(NonMatching, "p_graphic.cpp"),
             Object(NonMatching, "p_light.cpp"),
-            Object(NonMatching, "p_map.cpp", cflags=[*cflags_game, "-sdata 0", "-sdata2 0"]),
+            Object(NonMatching, "p_map.cpp"),
             Object(NonMatching, "p_MaterialEditor.cpp"),
             Object(NonMatching, "p_mc.cpp"),
             Object(NonMatching, "p_menu.cpp"),


### PR DESCRIPTION
## Summary
- Compile `p_map.cpp` with the normal game flags instead of forcing `-sdata 0 -sdata2 0`.
- This matches the object profile better for several already-decompiled `CMapPcs` routines.

## Evidence
- `ninja` passes.
- `main/p_map` unit fuzzy match improved from 88.40699% to 91.55868%.
- Function improvements:
  - `LoadMap__7CMapPcsFiiPvUlUc`: 77.189575% -> 86.407585%
  - `calc__7CMapPcsFv`: 89.29146% -> 94.88945%
  - `drawAfter__7CMapPcsFv`: 92.9037% -> 99.933334%
  - `drawAfterViewer__7CMapPcsFv`: 92.91852% -> 99.95556%
- Section diff after change: `.text` 90.20037%, `.data` 34.89628%.

## Plausibility
The removed overrides were unit-specific compiler-profile coercion. The normal game flags produce code that is closer to the target across multiple independent `p_map` functions without source hacks or manual data definitions.
