### PR TITLE
Move CProcess default handlers out of header

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -16,10 +16,10 @@ class CProcess : public CManager
 public:
     CProcess() {}
     virtual int GetTable(unsigned long) = 0;
-    virtual void onScriptChanging(char*) {}
-    virtual void onScriptChanged(char*, int) {}
-    virtual void onMapChanging(int, int) {}
-    virtual void onMapChanged(int, int, int) {}
+    virtual void onScriptChanging(char*);
+    virtual void onScriptChanged(char*, int);
+    virtual void onMapChanging(int, int);
+    virtual void onMapChanged(int, int, int);
 
     void ScriptChanging(char* script) { onScriptChanging(script); }
     void ScriptChanged(char* script, int param) { onScriptChanged(script, param); }

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -28,6 +28,58 @@ CSamplePcs SamplePcs;
 
 /*
  * --INFO--
+ * PAL Address: 0x8001FE74
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CProcess::onScriptChanging(char*)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FE78
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CProcess::onScriptChanged(char*, int)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FE7C
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CProcess::onMapChanging(int, int)
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8001FE80
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CProcess::onMapChanged(int, int, int)
+{
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x8001FE84
  * PAL Size: 4b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- declare CProcess default script/map handlers in system.h instead of defining them inline
- define the four empty CProcess handlers in p_sample.cpp at their PAL symbol addresses
- prevents unrelated process units from emitting local weak handler copies and improves p_mc data layout

## Evidence
- ninja: passes, main.dol OK
- main/p_sample: onScriptChanging/onScriptChanged/onMapChanging/onMapChanged all 100% matched
- main/p_mc: calc__6CMcPcsFv remains 100%, __sinit_p_mc_cpp remains 100%
- main/p_mc [.data-0]: 84.53453% -> 90.99886%

## Plausibility
The PAL symbol map places the CProcess default handlers next to CSamplePcs in the p_sample cluster. Keeping only declarations in the shared header and defining the handlers once there matches that ownership better than inline header bodies emitted into unrelated process units.