### PR TITLE
Improve pppBlurChara projection setup

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -279,9 +279,9 @@ void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppB
     GXSetCurrentMtx(0);
 
     PSMTX44Identity(projection);
+    projection[2][2] = FLOAT_8033103c;
     projection[0][0] = FLOAT_80331034;
     projection[1][1] = FLOAT_80331038;
-    projection[2][2] = FLOAT_8033103c;
     projection[0][3] = FLOAT_80331040;
     projection[1][3] = FLOAT_8033103c;
     projection[2][3] = FLOAT_80331030;


### PR DESCRIPTION
## Summary
- Reordered the orthographic projection matrix setup in pppRenderBlurChara to match the expected store/load pattern more closely.

## Evidence
- ninja passes.
- objdiff main/pppBlurChara: pppRenderBlurChara improved from 99.161644% to 99.19452%.
- Other pppBlurChara functions remain unchanged at their previous match levels.

## Plausibility
- This keeps the same matrix values and only adjusts source assignment order, matching the surrounding decomp style without introducing hacks or artificial symbols.