### PR TITLE
Improve math frustum vertex selection

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -325,18 +325,10 @@ int CBound::CheckFrustum0(CBound& outBound)
             }
             yIndex = 0;
             do {
-                if (yIndex == 0) {
-                    vertex.y = inBound[1];
-                } else {
-                    vertex.y = inBound[4];
-                }
+                vertex.y = (yIndex == 0) ? inBound[1] : inBound[4];
                 zIndex = 0;
                 do {
-                    if (zIndex == 0) {
-                        vertex.z = inBound[2];
-                    } else {
-                        vertex.z = inBound[5];
-                    }
+                    vertex.z = (zIndex == 0) ? inBound[2] : inBound[5];
                     PSMTXMultVec(s_f_lvmtx, &vertex, &transformed);
 
                     clipBound[0] = clipBound[0] < transformed.x ? clipBound[0] : transformed.x;
@@ -366,18 +358,10 @@ int CBound::CheckFrustum0(CBound& outBound)
         }
         yIndex = 0;
         do {
-            if (yIndex == 0) {
-                vertex.y = inBound[1];
-            } else {
-                vertex.y = inBound[4];
-            }
+            vertex.y = (yIndex == 0) ? inBound[1] : inBound[4];
             zIndex = 0;
             do {
-                if (zIndex == 0) {
-                    vertex.z = inBound[2];
-                } else {
-                    vertex.z = inBound[5];
-                }
+                vertex.z = (zIndex == 0) ? inBound[2] : inBound[5];
                 PSMTXMultVec(s_f_lvmtx, &vertex, &transformed);
 
                 clipBound[0] = clipBound[0] < transformed.x ? clipBound[0] : transformed.x;
@@ -473,18 +457,10 @@ int CBound::CheckFrustum0(float farPlane)
         }
         yIndex = 0;
         do {
-            if (yIndex == 0) {
-                vertex.y = inBound[1];
-            } else {
-                vertex.y = inBound[4];
-            }
+            vertex.y = (yIndex == 0) ? inBound[1] : inBound[4];
             zIndex = 0;
             do {
-                if (zIndex == 0) {
-                    vertex.z = inBound[2];
-                } else {
-                    vertex.z = inBound[5];
-                }
+                vertex.z = (zIndex == 0) ? inBound[2] : inBound[5];
                 PSMTXMultVec(s_f_lvmtx, &vertex, &transformed);
                 if (farthestZ < transformed.z) {
                     farthestZ = transformed.z;


### PR DESCRIPTION
## Summary
- Use conditional expressions for CBound::CheckFrustum0 y/z vertex component selection.
- Improves generated code for both frustum-check overloads while keeping the source equivalent and readable.

## Objdiff evidence
Command: build/tools/objdiff-cli diff -p . -u main/math -o - CheckFrustum0__6CBoundFR6CBound

Before:
- CheckFrustum0__6CBoundFf: 97.54777%
- CheckFrustum0__6CBoundFR6CBound: 95.01845%
- .text: 98.66317%

After:
- CheckFrustum0__6CBoundFf: 98.88535%
- CheckFrustum0__6CBoundFR6CBound: 96.56827%
- .text: 98.96374%

Unchanged nearby target:
- CrossCheckEllipseCapsule__5CMathFP3VecPfP3VecP3VecfP3Vecff: 96.36029%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/math -o - CheckFrustum0__6CBoundFR6CBound