### PR TITLE
Improve CrossCheckEllipseCapsule codegen

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -762,7 +762,7 @@ extern "C" void CrossCheckEllipseCapsule__5CMathFP3VecPfP3VecP3VecfP3Vecff(
     float radiusCubed = radius * radiusSquared;
     Vec4d coeffs;
     coeffs.x = FLOAT_8032F748 + ((FLOAT_8032F75C * radiusCubed) - (FLOAT_8032F758 * radiusSquared));
-    coeffs.y = radius - ((FLOAT_8032F75C * radiusSquared) - radiusCubed);
+    coeffs.y = radius + (radiusCubed - (FLOAT_8032F75C * radiusSquared));
     coeffs.z = (FLOAT_8032F760 * radiusCubed) + (FLOAT_8032F758 * radiusSquared);
     coeffs.w = radiusCubed - radiusSquared;
 


### PR DESCRIPTION
## Summary
- Rewrite the Y coefficient in CrossCheckEllipseCapsule as radius + (radiusCubed - 2 * radiusSquared)
- Keeps the same algebra while matching the PAL instruction selection more closely

## Evidence
- ninja: passes, build/GCCP01/main.dol OK
- objdiff main/math CrossCheckEllipseCapsule__5CMathFP3VecPfP3VecP3VecfP3Vecff: 96.36029% -> 97.16912%
- instruction diff count: 28 -> 27

## Plausibility
- This is an equivalent polynomial expression, not a hardcoded output hack
- The rewritten form matches the target's fnmsubs/fadds sequence for the coefficient