### PR TITLE
Improve pppColum alpha fade matching

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -201,10 +201,11 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
                 {
                     float dist = PSVECMag(&offset);
                     float fadeAmount = dist / *(float*)(param_2->m_payload + 0x10);
+                    u32 baseAlpha = positionWork->m_alpha;
 
-                    alpha = positionWork->m_alpha;
+                    alpha = (u8)baseAlpha;
                     if (dist < *(float*)(param_2->m_payload + 0x10) && fadeAmount > FLOAT_80331084) {
-                        alpha = (u8)((float)alpha * fadeAmount);
+                        alpha = (u8)((float)baseAlpha * fadeAmount);
                     }
                 }
                 color.rgba[0] = *((u8*)&param_2->m_stepValue + 0) + values->m_colorR;


### PR DESCRIPTION
## Summary
- Keep the rain-column alpha source byte in a widened temporary before fade scaling.
- This matches the target register flow for the alpha fade path and improves the pppColum render diff without adding hacks or manual data.

## Evidence
- `ninja` passes.
- `pppRenderColum`: 97.75542% -> 98.09598%.
- `main/pppColum .text`: 98.32564% -> 98.57967%.
- `extabindex`: 97.22222% -> 100.0%.
- Overall data matched bytes: 1095159 -> 1095195.

## Plausibility
The change preserves the original u8 stored alpha while using a u32 temporary for the fade calculation, matching Ghidra widened-alpha shape and the target register flow.