### PR TITLE
Improve THPSimplePreLoad control flow

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -553,11 +553,7 @@ s32 THPSimplePreLoad(s32 loop)
     u32 readCount;
     u8* readPtr;
 
-    if (SimpleControl.isOpen == 0) {
-        return 0;
-    }
-
-    if (SimpleControl.isPreLoaded == 0) {
+    if ((SimpleControl.isOpen != 0) && (SimpleControl.isPreLoaded == 0)) {
         readCount = 8;
         if ((loop == 0) && (SimpleControl.header.mNumFrames < 8)) {
             readCount = SimpleControl.header.mNumFrames;


### PR DESCRIPTION
## Summary
- Restructure THPSimplePreLoad's initial guard into the target's single guarded body shape.
- Preserve behavior while reducing the mismatch in the THPSimple unit.

## Evidence
- ninja: passes
- main/THPSimple .text: 93.816574% -> 93.85389%
- THPSimplePreLoad: 91.27941% -> 91.713234%
- Nearby checked symbols unchanged:
  - __THPSimpleDVDCallback__FlP11DVDFileInfo: 90.8%
  - THPSimpleSetBuffer: 95.72642%
  - THPSimpleCalcNeedMemory: 96.25%
  - THPSimpleOpen: 90.320114%

## Plausibility
- The change removes an early return and expresses the function as a single open/preload guard followed by the existing preload body and bottom failure return, matching the decompiled target control-flow shape without adding hacks, fake symbols, or address-dependent behavior.