### PR TITLE
Improve pppYmTracer frame entry tracking

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -225,7 +225,8 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
             (u32)*(u16*)(param_2->m_payload + 4) * sizeof(TRACE_POLYGON), pppEnvStPtr->m_stagePtr,
             const_cast<char*>(s_pppYmTracer_cpp_801d9ce0), 0xEB);
         fVar3 = FLOAT_803306e8;
-        entry = work->entries;
+        entries = work->entries;
+        entry = entries;
         for (i = 0; i < (s32)(u32)*(u16*)(param_2->m_payload + 4); i++) {
             entry->life = -1;
             entry->alpha = param_2->m_payload[8];
@@ -260,7 +261,6 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
         work->arg3Work = valuePtr;
     }
 
-    entries = work->entries;
     if (work->count + 1 < *(u16*)(param_2->m_payload + 4)) {
         for (i = *(u16*)(param_2->m_payload + 4) - 2; i >= 0; i--) {
             TRACE_POLYGON* current = &entries[i];


### PR DESCRIPTION
## Summary
- Keep the freshly allocated tracer entry buffer in the existing local `entries` pointer.
- Avoid reloading `work->entries` before the history shift, matching the original source shape more closely.

## Evidence
- `ninja` passes.
- `pppFrameYmTracer`: 94.71811% -> 95.05144%.
- `main/pppYmTracer` `.text`: 96.1715% -> 96.38522%.

## Plausibility
- This is a source-level lifetime cleanup: after allocation, the local entry pointer already represents the buffer used by the following initialization and shift logic.
- No manual vtable/RTTI/section forcing or address hacks.