### PR TITLE
Improve CMapPcs::calc codegen

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -529,11 +529,11 @@ void CMapPcs::calc()
                     *reinterpret_cast<COctNode**>(reinterpret_cast<char*>(&MapMng) + 0x18);
                 if (rootNode != 0) {
                     cameraPos.x =
-                        (rootNode->m_boundMinX + rootNode->m_boundMaxX) * kMapBoundsCenterScale;
+                        kMapBoundsCenterScale * (rootNode->m_boundMinX + rootNode->m_boundMaxX);
                     cameraPos.y =
-                        (rootNode->m_boundMinY + rootNode->m_boundMaxY) * kMapBoundsCenterScale;
+                        kMapBoundsCenterScale * (rootNode->m_boundMinY + rootNode->m_boundMaxY);
                     cameraPos.z =
-                        (rootNode->m_boundMinZ + rootNode->m_boundMaxZ) * kMapBoundsCenterScale;
+                        kMapBoundsCenterScale * (rootNode->m_boundMinZ + rootNode->m_boundMaxZ);
                 } else {
                     float* mapCenter =
                         reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0xAA8);
@@ -549,23 +549,20 @@ void CMapPcs::calc()
         }
 
         if (static_cast<unsigned int>(System.m_execParam) >= 3U) {
-            CMemory::CStage* mapStage = *reinterpret_cast<CMemory::CStage**>(&MapMng);
-            int heapUnuse = mapStage->GetHeapUnuse();
-
             Printf__7CSystemFPce(
                 &System,
                 s_map_load_ok_fmt,
                 m_mapName,
                 *reinterpret_cast<short*>(reinterpret_cast<char*>(&MapMng) + 0xC),
                 *reinterpret_cast<short*>(reinterpret_cast<char*>(&MapMng) + 0x8),
-                heapUnuse / 1024);
+                (*reinterpret_cast<CMemory::CStage**>(&MapMng))->GetHeapUnuse() / 1024);
         }
 
-        CPtrArray<CMapLightHolder*>* mapLightHolderArr =
-            reinterpret_cast<CPtrArray<CMapLightHolder*>*>(reinterpret_cast<char*>(&MapMng) + 0x21450);
-        if (static_cast<unsigned int>(mapLightHolderArr[1].GetSize()) > 0U) {
-            mapLightHolderArr[1][0]->GetLightHolder(reinterpret_cast<_GXColor*>(reinterpret_cast<char*>(&MapMng) + 0x2298C),
-                                                    static_cast<Vec*>(0));
+        CPtrArray<CMapLightHolder*>& mapLightHolderArr =
+            reinterpret_cast<CPtrArray<CMapLightHolder*>*>(reinterpret_cast<char*>(&MapMng) + 0x21450)[1];
+        if (mapLightHolderArr.GetSize() > 0) {
+            mapLightHolderArr[0]->GetLightHolder(reinterpret_cast<_GXColor*>(reinterpret_cast<char*>(&MapMng) + 0x2298C),
+                                                 static_cast<Vec*>(0));
         }
 
         m_forceMapReload = 0;


### PR DESCRIPTION
## Summary
- tighten `CMapPcs::calc` around viewer-centering, heap debug logging, and map-light-holder access
- keep behavior intact while steering MWCC toward the original codegen in `src/p_map.cpp`

## Evidence
- `calc__7CMapPcsFv`: `94.81407%` -> `99.447235%`
- `main/p_map` `.text`: `90.2347%` -> `90.810234%`
- full project rebuild still passes with `ninja`

## Why this is plausible source
- uses the same existing fields and control flow, without adding hacks or fake linkage
- simplifies the light-holder access into the concrete second `CPtrArray` slot used by the original code
- preserves the original map-center calculation while adjusting expression shape for closer compiler output