### PR TITLE
Inline p_dbgmenu local helpers

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -158,7 +158,7 @@ void CDbgMenuPcs::destroy()
 	return;
 }
 
-CDbgMenuPcs::CDbgMenuPcs()
+inline CDbgMenuPcs::CDbgMenuPcs()
 {
     m_table__11CDbgMenuPcs[1] = m_table_desc0__11CDbgMenuPcs[0];
     m_table__11CDbgMenuPcs[2] = m_table_desc0__11CDbgMenuPcs[1];
@@ -179,7 +179,7 @@ CDbgMenuPcs::CDbgMenuPcs()
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::selectNext()
+inline void CDbgMenuPcs::selectNext()
 {
 	if (m_currentMenu == 0) {
 		return;
@@ -201,7 +201,7 @@ void CDbgMenuPcs::selectNext()
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::selectPrev()
+inline void CDbgMenuPcs::selectPrev()
 {
 	if (m_currentMenu == 0) {
 		return;
@@ -700,7 +700,7 @@ void CDbgMenuPcs::drawFont(int flags, int x, int y, char* text)
  * Address:	TODO
  * Size:	TODO
  */
-CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
+inline CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
 {
 	for (int i = 0; i < 0x80; i++) {
 		if ((m_menuPool[i].m_status & 0x80) == 0) {
@@ -922,7 +922,7 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::Delete(int id)
+inline void CDbgMenuPcs::Delete(int id)
 {
 	CDM* menu = reinterpret_cast<CDM*>(searchID(id, m_rootMenuNode));
 	if (menu == 0) {


### PR DESCRIPTION
## Summary
- Marked `CDbgMenuPcs` local helper definitions inline so MWCC stops emitting standalone helper/outer-constructor bodies that are not present in the target object.
- Keeps the helper source in the unit while moving the compiled object closer to the PAL layout.

## Evidence
- `ninja` passes, including `build/GCCP01/main.dol: OK` on the final build.
- `build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o ...` section-size comparison:
  - before: compiled `.text` 8060, `extab` 120, `extabindex` 180
  - after: compiled `.text` 7412, `extab` 104, `extabindex` 156
  - target: `.text` 7404, `extab` 104, `extabindex` 156

## Plausibility
- These are local helper routines and a local constructor body used within `p_dbgmenu.cpp`; making them inline matches the target's lack of standalone symbols without manually defining vtables, constructors, destructors, or static init code.
