### PR TITLE
Improve pppYmBreath group state signedness

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -105,7 +105,7 @@ struct YmBreathParams {
 struct YmBreathParticleGroup {
     int active;
     signed char* particleIndices;
-    unsigned char* particleStates;
+    signed char* particleStates;
     Vec position;
     Vec direction;
     float speed;
@@ -718,7 +718,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                     if (found) {
                         groupData = &groupTable[(int)foundGroup];
                         for (slot = 0; slot < (int)params->m_slotCount; slot++) {
-                            groupData->particleStates[slot] = 0xFF;
+                            groupData->particleStates[slot] = -1;
                             groupData->position.x = zero;
                             groupData->position.y = zero;
                             groupData->position.z = zero;
@@ -739,7 +739,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                     groupData = groupTable;
                     for (j = 0; j < (int)params->m_groupCount; j++) {
                         for (k = 0; k < (int)params->m_slotCount; k++) {
-                            if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == 0xFF)) {
+                            if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == -1)) {
                                 groupData->particleIndices[k] = (signed char)i;
                                 found = false;
                                 groupData->particleStates[k] = 1;


### PR DESCRIPTION
## Summary
- switch `YmBreathParticleGroup::particleStates` to signed storage
- use `-1` consistently for cleared group-state slots in `pppYmBreath`
- keep the change limited to ABI-relevant state handling in the existing breath particle path

## Evidence
- `ninja` succeeds for `GCCP01`
- `build/tools/objdiff-cli diff -p . -u main/pppYmBreath`
- `pppFrameYmBreath`: `92.00949%` -> `93.76582%`
- `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`: `90.30597%` -> `91.16791%`
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: `86.47089%` -> `86.59494%`

## Plausibility
The breath group code already treats empty state slots as signed `-1` sentinels in loads and comparisons. Making the backing storage signed and writing `-1` directly removes unsigned/signed churn without introducing compiler-coaxing hacks.