### PR TITLE
Fix miasma render camera transform

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -186,7 +186,7 @@ void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkB* param_2, pppY
             if ((s32)Game.m_currentSceneId == 7) {
                 PSMTXMultVec(ppvWorldMatrix, &worldPos, &worldPos);
             } else {
-                PSMTXMultVec(ppvCameraMatrix02, &worldPos, &worldPos);
+                PSMTXMultVec(ppvCameraMatrix0, &worldPos, &worldPos);
             }
 
             model.value[0][3] = worldPos.x;


### PR DESCRIPTION
## Summary
- switch `pppRenderYmMiasma` to use `ppvCameraMatrix0` for the non-scene-7 path
- keep the scene-7 world-matrix path unchanged
- align the render transform with the current Ghidra decomp for `pppRenderYmMiasma`

## Evidence
- `ninja` succeeds for `GCCP01`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o -` now reports `.text` match `95.490974` for `main/pppYmMiasma`
- prior target selection showed `main/pppYmMiasma` at `95.2%` code match, so this is a real net improvement in the unit

## Plausibility
- the previous code used `ppvCameraMatrix02` in the normal camera path, but the decomp for `pppRenderYmMiasma` uses `ppvCameraMatrix0`
- this changes source behavior toward the more plausible original camera transform instead of coaxing the compiler
