### PR TITLE
Improve CMapPcs calc size check

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -560,7 +560,7 @@ void CMapPcs::calc()
 
         CPtrArray<CMapLightHolder*>& mapLightHolderArr =
             reinterpret_cast<CPtrArray<CMapLightHolder*>*>(reinterpret_cast<char*>(&MapMng) + 0x21450)[1];
-        if (mapLightHolderArr.GetSize() > 0) {
+        if (static_cast<unsigned int>(mapLightHolderArr.GetSize()) > 0) {
             mapLightHolderArr[0]->GetLightHolder(reinterpret_cast<_GXColor*>(reinterpret_cast<char*>(&MapMng) + 0x2298C),
                                                  static_cast<Vec*>(0));
         }


### PR DESCRIPTION
## Summary
- Treat the `CMapPcs::calc()` map light holder count check as unsigned before comparing against zero.
- This matches the count-like semantics of `GetSize()` more closely and improves the generated branch sequence for the PAL target.

## Objdiff evidence
- `calc__7CMapPcsFv`: 99.49749% -> 99.77387%
- `main/p_map` unit text fuzzy match: 92.13109% -> 92.16542%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_map --format json-pretty -o /tmp/pmap_calc_final.json calc__7CMapPcsFv`
- `build/tools/objdiff-cli report generate -p . --format json-pretty -o /tmp/full_report_final.json`
