### PR TITLE
Improve sound 3D SE matching

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1754,61 +1754,59 @@ int CSound::PlaySe3D(int soundId, Vec* pos, float nearDistance, float farDistanc
     u8* se;
     int loopCount;
     int slot;
-    int pan;
     int volume;
+    int pan;
 
     if (soundId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-    } else {
-        CSoundLayout& sound = SoundData(this);
-        se = sound.m_seWork;
+        return -1;
+    }
 
-        for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
-            if ((*se & 0x80) != 0) {
-                continue;
-            }
+    CSoundLayout& sound = SoundData(this);
+    se = sound.m_seWork;
 
-            *se = (*se & 0x7F) | 0x80;
-            *se &= 0xBF;
-            *reinterpret_cast<int*>(se + 0xC) = soundId;
-            slot = sound.m_seCount;
-            sound.m_seCount = slot + 1;
-            *reinterpret_cast<int*>(se + 4) = slot;
-
-            *reinterpret_cast<float*>(se + 0x10) = nearDistance;
-            *reinterpret_cast<float*>(se + 0x14) = farDistance;
-            *reinterpret_cast<Vec*>(se + 0x18) = *pos;
-            se[3] = 0xFF;
-
-            calcVolumePan(reinterpret_cast<CSe3D*>(se), volume, pan);
-            se[1] = static_cast<u8>(volume);
-            se[2] = static_cast<u8>(pan);
-            se[0x24] = 0xFF;
-            se[0x25] = 0xFF;
-            se[0x26] = 0xFF;
-            se[0x27] = 0xFF;
-
-            if (soundId < 0) {
-                Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-                slot = -1;
-            } else if (soundId < 4000) {
-                int bank = soundId / 1000;
-                slot = SePlay__9CRedSoundFiiiii(RedSound(this), bank, soundId - bank * 1000, pan,
-                                                volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
-                if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
-                }
-            } else {
-                slot = SePlay__9CRedSoundFiiiii(RedSound(this), -1, soundId, pan,
-                                                volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
-                if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
-                }
-            }
-
-            *reinterpret_cast<int*>(se + 8) = slot;
-            return *reinterpret_cast<int*>(se + 4);
+    for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
+        if ((*se & 0x80) != 0) {
+            continue;
         }
+
+        *se = (*se & 0x7F) | 0x80;
+        *se &= 0xBF;
+        *reinterpret_cast<int*>(se + 0xC) = soundId;
+        slot = sound.m_seCount;
+        sound.m_seCount = slot + 1;
+        *reinterpret_cast<int*>(se + 4) = slot;
+
+        *reinterpret_cast<float*>(se + 0x10) = nearDistance;
+        *reinterpret_cast<float*>(se + 0x14) = farDistance;
+        *reinterpret_cast<Vec*>(se + 0x18) = *pos;
+        se[3] = 0xFF;
+
+        calcVolumePan(reinterpret_cast<CSe3D*>(se), volume, pan);
+        se[1] = static_cast<u8>(volume);
+        se[2] = static_cast<u8>(pan);
+        *reinterpret_cast<int*>(se + 0x24) = -1;
+
+        if (soundId < 0) {
+            Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
+            slot = -1;
+        } else if (soundId < 4000) {
+            int bank = soundId / 1000;
+            slot = SePlay__9CRedSoundFiiiii(RedSound(this), bank, soundId - bank * 1000, pan,
+                                            volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
+            if (fadeFrames != 0) {
+                SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
+            }
+        } else {
+            slot = SePlay__9CRedSoundFiiiii(RedSound(this), -1, soundId, pan,
+                                            volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
+            if (fadeFrames != 0) {
+                SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
+            }
+        }
+
+        *reinterpret_cast<int*>(se + 8) = slot;
+        return *reinterpret_cast<int*>(se + 4);
     }
 
     return -1;
@@ -1828,60 +1826,58 @@ int CSound::PlaySe3DLine(int soundId, int lineIndex, float nearDistance, float f
     u8* se;
     int loopCount;
     int slot;
-    int pan;
     int volume;
+    int pan;
 
     if (soundId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-    } else {
-        CSoundLayout& sound = SoundData(this);
-        se = sound.m_seWork;
+        return -1;
+    }
 
-        for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
-            if ((*se & 0x80) != 0) {
-                continue;
-            }
+    CSoundLayout& sound = SoundData(this);
+    se = sound.m_seWork;
 
-            *se = (*se & 0x7F) | 0x80;
-            *se &= 0xBF;
-            *reinterpret_cast<int*>(se + 0xC) = soundId;
-            slot = sound.m_seCount;
-            sound.m_seCount = slot + 1;
-            *reinterpret_cast<int*>(se + 4) = slot;
-
-            *reinterpret_cast<float*>(se + 0x10) = nearDistance;
-            *reinterpret_cast<float*>(se + 0x14) = farDistance;
-            se[3] = static_cast<u8>(lineIndex);
-
-            calcVolumePan(reinterpret_cast<CSe3D*>(se), volume, pan);
-            se[1] = static_cast<u8>(volume);
-            se[2] = static_cast<u8>(pan);
-            se[0x24] = 0xFF;
-            se[0x25] = 0xFF;
-            se[0x26] = 0xFF;
-            se[0x27] = 0xFF;
-
-            if (soundId < 0) {
-                Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-                slot = -1;
-            } else if (soundId < 4000) {
-                int bank = soundId / 1000;
-                slot = SePlay__9CRedSoundFiiiii(RedSound(this), bank, soundId - bank * 1000, pan,
-                                               volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
-                if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
-                }
-            } else {
-                slot = SePlay__9CRedSoundFiiiii(RedSound(this), -1, soundId, pan,
-                                               volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
-                if (fadeFrames != 0) {
-                    SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
-                }
-            }
-
-            *reinterpret_cast<int*>(se + 8) = slot;
-            return *reinterpret_cast<int*>(se + 4);
+    for (loopCount = 0x80; loopCount != 0; loopCount--, se += 0x28) {
+        if ((*se & 0x80) != 0) {
+            continue;
         }
+
+        *se = (*se & 0x7F) | 0x80;
+        *se &= 0xBF;
+        *reinterpret_cast<int*>(se + 0xC) = soundId;
+        slot = sound.m_seCount;
+        sound.m_seCount = slot + 1;
+        *reinterpret_cast<int*>(se + 4) = slot;
+
+        *reinterpret_cast<float*>(se + 0x10) = nearDistance;
+        *reinterpret_cast<float*>(se + 0x14) = farDistance;
+        se[3] = static_cast<u8>(lineIndex);
+
+        calcVolumePan(reinterpret_cast<CSe3D*>(se), volume, pan);
+        se[1] = static_cast<u8>(volume);
+        se[2] = static_cast<u8>(pan);
+        *reinterpret_cast<int*>(se + 0x24) = -1;
+
+        if (soundId < 0) {
+            Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
+            slot = -1;
+        } else if (soundId < 4000) {
+            int bank = soundId / 1000;
+            slot = SePlay__9CRedSoundFiiiii(RedSound(this), bank, soundId - bank * 1000, pan,
+                                            volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
+            if (fadeFrames != 0) {
+                SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
+            }
+        } else {
+            slot = SePlay__9CRedSoundFiiiii(RedSound(this), -1, soundId, pan,
+                                            volume & ~((int)(-fadeFrames | fadeFrames) >> 0x1F), 0);
+            if (fadeFrames != 0) {
+                SeVolume__9CRedSoundFiii(RedSound(this), slot, volume, fadeFrames);
+            }
+        }
+
+        *reinterpret_cast<int*>(se + 8) = slot;
+        return *reinterpret_cast<int*>(se + 4);
     }
 
     return -1;
@@ -2290,7 +2286,7 @@ void CSound::LoadStream(int streamID)
  */
 void CSound::PlayStreamASync()
 {
-    char streamPath[268];
+    char streamPath[252];
     CSoundLayout& sound = SoundData(this);
     sprintf(streamPath, s_soundStreamPathFmt, sound.m_streamWaveID);
 


### PR DESCRIPTION
## Summary
- Reshape negative sound-id handling in `CSound::PlaySe3D` and `CSound::PlaySe3DLine` so the early error return matches target control flow more closely.
- Store the 3D SE group sentinel as a word, matching the underlying `CSe3D` layout.
- Adjust the `PlayStreamASync` local stream path buffer to recover the target stack frame size.

## Evidence
- `ninja` passes.
- `main/sound` `.text`: 78.938515% after changes.
- `PlaySe3D__6CSoundFiP3Vecffi`: 61.741936% -> 63.26613%.
- `PlayStreamASync__6CSoundFv`: 61.819443% -> 61.90278%.
- `PlaySe3DLine__6CSoundFiiffi`: 63.59829% after the same source-shape cleanup.

## Plausibility
- The early returns preserve the existing behavior while matching the target non-fallthrough error path.
- The sentinel write corresponds to the `CSe3D` word at offset `0x24` rather than four unrelated byte stores.
- The stream path buffer size is grounded in the target stack frame for `PlayStreamASync`.