### PR TITLE
Match game script/map control flow

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -844,13 +844,21 @@ void CGame::ChangeMap(int mapId, int mapVariant, int param4, int param5)
 {
     u32 hasParamMask;
 
-    if (param5 != 0) {
+    if (param5 == 0) {
+        hasParamMask = (u32)((-param4 | param4) >> 31);
+        MapPcs.LoadMap(
+            mapId, mapVariant, (void*)(hasParamMask & 0x800000), hasParamMask & 0x580000, param4 & 0xFF);
+
+        hasParamMask = (u32)((-param4 | param4) >> 31);
+        PartPcs.LoadFieldPdt(
+            mapId, mapVariant, (void*)(hasParamMask & 0xD80000), hasParamMask & 0x80000, (u8)param4);
+    } else {
         Graphic._WaitDrawDone(const_cast<char*>(s_game_cpp_801d6190), 0x24E);
         System.MapChanging(mapId, mapVariant);
 
         m_currentMapId = mapId;
-        m_currentMapVariantId = mapVariant;
         hasParamMask = (u32)((-param4 | param4) >> 31);
+        m_currentMapVariantId = mapVariant;
 
         MapPcs.LoadMap(
             mapId, mapVariant, (void*)(hasParamMask & 0x800000), hasParamMask & 0x580000, 0);
@@ -860,14 +868,6 @@ void CGame::ChangeMap(int mapId, int mapVariant, int param4, int param5)
             mapId, mapVariant, (void*)(hasParamMask & 0xD80000), hasParamMask & 0x80000, 0);
 
         System.MapChanged(mapId, mapVariant, 1);
-    } else {
-        hasParamMask = (u32)((-param4 | param4) >> 31);
-        MapPcs.LoadMap(
-            mapId, mapVariant, (void*)(hasParamMask & 0x800000), hasParamMask & 0x580000, param4 & 0xFF);
-
-        hasParamMask = (u32)((-param4 | param4) >> 31);
-        PartPcs.LoadFieldPdt(
-            mapId, mapVariant, (void*)(hasParamMask & 0xD80000), hasParamMask & 0x80000, (u8)param4);
     }
 }
 
@@ -1241,7 +1241,11 @@ void CGame::SaveScript(char* scriptData)
     int entryOffset = 0;
     int i = 0;
 
-    while (i < *(int*)(CFlat + 4)) {
+    while (true) {
+        if (i >= *(int*)(CFlat + 4)) {
+            break;
+        }
+
         if ((*(u8*)(*(int*)(CFlat + 8) + entryOffset + 1) & 0x20) != 0) {
             *(u32*)(scriptData + scriptOffset) = *(u32*)(*(int*)(CFlat + 12) + entryOffset);
             scriptOffset += 4;
@@ -1265,12 +1269,20 @@ void CGame::LoadScript(char* scriptData)
 {
     int scriptOffset = 0;
     int entryOffset = 0;
+    int i = 0;
 
-    for (int i = 0; i < *(int*)(CFlat + 4); i++, entryOffset += 4) {
+    while (true) {
+        if (i >= *(int*)(CFlat + 4)) {
+            break;
+        }
+
         if ((*(u8*)(*(int*)(CFlat + 8) + entryOffset + 1) & 0x20) != 0) {
             *(u32*)(*(int*)(CFlat + 12) + entryOffset) = *(u32*)(scriptData + scriptOffset);
             scriptOffset += 4;
         }
+
+        entryOffset += 4;
+        i++;
     }
 }
 


### PR DESCRIPTION
## Summary
- rewrite `CGame::ChangeMap` to match the original branch order and assignment ordering
- rewrite `CGame::SaveScript` and `CGame::LoadScript` to use the original counted `while` loop shape
- keep behavior unchanged while improving compiler output in `main/game`

## Evidence
- before this change, `python3 tools/agent_select_target.py` listed `main/game` with these top remaining code targets:
  - `ChangeMap__5CGameFiiii` at 68.0%
  - `LoadScript__5CGameFPc` at 78.5%
  - `SaveScript__5CGameFPc` at 88.5%
- after rebuilding with this patch, `main/game` no longer appears in the target buckets from `tools/agent_select_target.py`
- rebuilt successfully with `ninja`

## Plausibility
- these edits remove source-side control-flow differences instead of adding hacks
- the resulting code follows the original function structure more closely without changing interfaces or data layout
