### PR TITLE
Match menu money control

### DIFF
--- a/include/ffcc/menu_money.h
+++ b/include/ffcc/menu_money.h
@@ -61,7 +61,7 @@ class CMenuPcs
 public:
     void MoneyInit();
     bool MoneyOpen();
-    void MoneyCtrl();
+    int MoneyCtrl();
     bool MoneyClose();
     void MoneyDraw();
     int MoneyCtrlCur();

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -339,11 +339,11 @@ bool CMenuPcs::MoneyOpen()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMenuPcs::MoneyCtrl()
+int CMenuPcs::MoneyCtrl()
 {
 	int iVar2;
 	int iVar3;
-	s16 sVar1;
+	int sVar1;
 
 	iVar2 = 0;
 	*(s16*)((int)this->moneyState + 0x32) = *(s16*)((int)this->moneyState + 0x30);
@@ -365,12 +365,14 @@ void CMenuPcs::MoneyCtrl()
 	}
 
 	if (iVar2 != 0) {
-		iVar2 = (int)this->moneyPanel;
-		*(float*)(iVar2 + 0x18) = FLOAT_80332f70;
-		*(int*)(iVar2 + 0x2C) = 0;
-		*(int*)(iVar2 + 0x30) = 10;
-		*(int*)(iVar2 + 0x28) = 0;
+		MoneyMenuAnim* anim = this->moneyPanel->anims;
+		anim->progress = FLOAT_80332f70;
+		anim->startFrame = 0;
+		anim->duration = 10;
+		anim->frame = 0;
 	}
+
+	return iVar2;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Correct `CMenuPcs::MoneyCtrl` to return the control result used by sing menu dispatch.
- Widen the local mode value to `int` to avoid extra sign-extension and use typed `MoneyMenuAnim` fields for the reset block.

## Evidence
- Before: `MoneyCtrl__8CMenuPcsFv` 96.875% match.
- After: `MoneyCtrl__8CMenuPcsFv` 100.0% match.
- `ninja` passes.

## Plausibility
- `singmenu.cpp` already declares `MoneyCtrl__8CMenuPcsFv` as returning `unsigned int`, and the target preserves the result in `r3`.
- The reset block now uses existing menu-money structures instead of raw offsets.