### PR TITLE
Recover menu_lst shared constants and strings

### DIFF
--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -36,8 +36,8 @@ extern char DAT_80333660[];
 extern char DAT_80333664[];
 extern char DAT_8033366c[];
 extern char DAT_80333670[];
-extern char DAT_80333674[];
-extern char DAT_8033367c[];
+extern char lbl_80333674[];
+extern char lbl_8033367C[];
 extern char* PTR_s_Strength__80215a48[];
 extern char* PTR_s_Defence__80215a4c[];
 
@@ -404,7 +404,7 @@ void CMenuPcs::DrawHelpMessageUS(int msgNo, CFont* font, int, int, _GXColor colo
 				} else {
 					font->SetTlut(9);
 				}
-				sprintf(scratch, DAT_80333674, delta);
+				sprintf(scratch, lbl_80333674, delta);
 				if (delta != 0) {
 					font->Draw(scratch);
 				}
@@ -421,7 +421,7 @@ void CMenuPcs::DrawHelpMessageUS(int msgNo, CFont* font, int, int, _GXColor colo
 			font->Draw(scratch);
 			font->SetTlut(9);
 			if ((attr != 0) && (attr < 9)) {
-				sprintf(scratch, DAT_8033367c, DAT_80333660);
+				sprintf(scratch, lbl_8033367C, DAT_80333660);
 				font->Draw(scratch);
 			}
 		}

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -27,20 +27,21 @@ extern "C" void Draw__5CFontFPc(CFont*, const char*);
 
 extern "C" const char* GetMenuStr__8CMenuPcsFi(CMenuPcs*, int);
 
-extern double DOUBLE_803333E8;
-extern double DOUBLE_803333D8;
-extern float FLOAT_803333D0;
-extern float FLOAT_803333D4;
-extern float FLOAT_803333E0;
-extern float FLOAT_803333F4;
-extern float FLOAT_803333F8;
-extern float FLOAT_803333FC;
-extern float FLOAT_80333400;
-extern double DOUBLE_80333408;
-extern double DOUBLE_80333410;
-extern double DOUBLE_80333418;
-extern double DOUBLE_80333420;
-extern float FLOAT_803333F0;
+static const float FLOAT_803333D0 = 0.0f;
+static const float FLOAT_803333D4 = 255.0f;
+static const double DOUBLE_803333D8 = 20.0;
+static const float FLOAT_803333E0 = 40.0f;
+static const double DOUBLE_803333E8 = 0.5;
+static const float FLOAT_803333F0 = 1.0f;
+static const float FLOAT_803333F4 = 4.0f;
+static const float FLOAT_803333F8 = 320.0f;
+static const float FLOAT_803333FC = 0.5f;
+static const float FLOAT_80333400 = 352.0f;
+static const float FLOAT_80333404 = 3.0f;
+static const double DOUBLE_80333408 = 4503601774854144.0;
+static const double DOUBLE_80333410 = 1.0;
+static const double DOUBLE_80333418 = 0.0;
+static const double DOUBLE_80333420 = 216.0;
 
 extern "C" const float FLOAT_80333614 = 196.0f;
 extern "C" const float FLOAT_80333618 = 168.0f;
@@ -67,6 +68,11 @@ static const unsigned char gap_80333669[] = {0, 0, 0};
 extern "C" const char DAT_8033366c[] = " ";
 static const unsigned char gap_8033366e[] = {0, 0};
 extern "C" const char DAT_80333670[] = " %d";
+extern "C" const char lbl_80333674[] = " %+d";
+extern "C" const char lbl_8033367C[] = " %s";
+extern "C" const char lbl_80333680[] = "Empty.";
+extern "C" const char lbl_80333688[] = "Vuoto.";
+extern "C" const char lbl_80333690[] = "Vide";
 
 STATIC_ASSERT(offsetof(CMenuPcs, listFont) == 0x108);
 STATIC_ASSERT(offsetof(CMenuPcs, lstState) == 0x82C);
@@ -165,7 +171,7 @@ void CMenuPcs::MLstDraw()
 		font->GetWidth(text);
 
 		float textX = (float)(item->x + 0x28);
-		float textY = (float)(item->y + 3) - FLOAT_803333F4;
+		float textY = ((float)item->y + FLOAT_80333404) - FLOAT_803333F4;
 		if ((menuMode == 1) && (i == state->cursor)) {
 			textX = (float)(textX + DOUBLE_803333D8);
 		}


### PR DESCRIPTION
## Summary
- recover the missing `menu_lst` shared strings that live after `DAT_80333670` in PAL `.sdata2`
- switch `MenuUtil` to reference the recovered symbol names directly
- replace `menu_lst`'s bogus external scalar declarations with concrete local constants from the PAL DOL, including the local `3.0f` text offset used in `MLstDraw`

## Objdiff evidence
`main/menu_lst` improved on the key functions touched by the shared constant/string pool:
- `MLstDraw__8CMenuPcsFv`: 68.395546% -> 68.785515%
- `MLstClose__8CMenuPcsFv`: 73.149536% -> 77.80374%
- `MLstCtrl__8CMenuPcsFv`: 71.73543% -> 73.48431%
- `MLstOpen__8CMenuPcsFv`: 74.02778% -> 78.55556%

## Why this is plausible source
- the new strings come directly from the PAL `main.dol` at `0x80333674` through `0x80333690`
- `MenuUtil` was already referencing these symbols by address; this change restores real definitions instead of leaning on unresolved linker-era placeholders
- the local scalar constants in `menu_lst.cpp` now reflect the original PAL values rather than opaque extern hacks

## Verification
- `ninja -j4`
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstDraw__8CMenuPcsFv`
