### PR TITLE
Improve pppRenderColum match

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -154,6 +154,7 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             float deltaX2;
             float deltaY2;
 
+            zero = FLOAT_80331084;
             PSMTXIdentity(identityMtx);
             baseX = positionWork->m_position.x;
             baseY = positionWork->m_position.y;
@@ -183,7 +184,6 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
             values = frameWork->m_values;
             segmentStep =
                 (FLOAT_803310A8 * lengthXY) / (float)param_2->m_count;
-            zero = FLOAT_80331084;
 
             for (int i = 0; i < param_2->m_count; i++) {
                 float positionScale = segmentStep * values->m_positionScale;


### PR DESCRIPTION
## Summary
- Move the shared zero initialization in `pppRenderColum` earlier so MWCC keeps the zero value live across setup in a way that better matches the original codegen.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppColum -o - pppRenderColum`
  - `pppRenderColum`: 98.09598% -> 98.71517%
  - `main/pppColum` .text: 98.57967% -> 99.04157%

## Plausibility
- This is a source-order-only change: the zero value is initialized before matrix setup instead of immediately before the segment loop, with no manual vtable/section/address forcing or fake symbols.