### PR TITLE
Improve command list item sentinel comparisons

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2036,7 +2036,7 @@ extern "C" int GetCmdListItemName__12CCaravanWorkFi(CCaravanWork* caravanWork, i
 			int topIdx = cmdListIdx;
 			if (cmdListIdx >= 0) {
 				do {
-					if (slotRef[0] != 0xFFFF) {
+					if (slotRef[0] != -1) {
 						break;
 					}
 					slotRef--;
@@ -2050,7 +2050,7 @@ extern "C" int GetCmdListItemName__12CCaravanWorkFi(CCaravanWork* caravanWork, i
 			slotRef = caravanWork->m_commandListInventorySlotRef + topIdx + 1;
 			if ((topIdx + 1) < caravanWork->m_numCmdListSlots) {
 				do {
-					if (slotRef[0] != 0xFFFF) {
+					if (slotRef[0] != -1) {
 						break;
 					}
 					groupedCount++;
@@ -2066,7 +2066,7 @@ extern "C" int GetCmdListItemName__12CCaravanWorkFi(CCaravanWork* caravanWork, i
 		short* slotRef = caravanWork->m_commandListInventorySlotRef + cmdListIdx;
 		if (cmdListIdx >= 0) {
 			do {
-				if (slotRef[0] != 0xFFFF) {
+				if (slotRef[0] != -1) {
 					break;
 				}
 				slotRef--;


### PR DESCRIPTION
## Summary
- Treat command-list inventory slot sentinels as signed `-1` values in `GetCmdListItemName__12CCaravanWorkFi`.
- This matches the slot type and the target compare pattern instead of comparing signed shorts against `0xFFFF`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o - GetCmdListItemName__12CCaravanWorkFi`
- `GetCmdListItemName__12CCaravanWorkFi`: 66.431816% -> 74.72727%.
- `main/gobjwork` `.text`: 74.45328% -> 74.6032%.

## Plausibility
- Command-list slots use `short` storage and `-1` is the natural signed sentinel for empty/grouped entries.
- The change removes unsigned-compare codegen around the sentinel checks without changing control flow or data layout.