### PR TITLE
Improve CMemory allocation defaults

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -41,7 +41,7 @@ public:
     void SetGroup(void*, int);
     CStage* CreateStage(unsigned long, char*, int);
     void DestroyStage(CMemory::CStage*);
-    void _Alloc(unsigned long, CMemory::CStage*, char*, int, int);
+    void* _Alloc(unsigned long, CMemory::CStage*, char*, int, int);
     void Free(void*);
     void IncHeapWalkerLevel();
     void DecHeapWalkerLevel();

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -43,7 +43,7 @@ extern char DAT_801d669c[];
 extern char DAT_801d67d8[];
 extern char DAT_801d6bdc[];
 extern char DAT_801d6bec[];
-extern char DAT_8032f7d4[];
+extern char DAT_8032f7d4[4];
 extern char DAT_8032f7e8[];
 extern char DAT_8032f808[];
 extern float FLOAT_8032f7d8;
@@ -162,10 +162,13 @@ static void stageDestroyInternal(CMemory::CStage* stage)
  */
 void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int line)
 {
+    char* source;
     if (file == (char*)nullptr) {
-        file = const_cast<char*>(s_memory_cpp);
+        source = DAT_8032f7d4;
+    } else {
+        source = file;
     }
-    return stage->alloc(size, file, line, 0);
+    return stage->alloc(size, source, line, 0);
 }
 
 /*
@@ -179,10 +182,13 @@ void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int l
  */
 void* operator new[](unsigned long size, CMemory::CStage* stage, char* file, int line)
 {
+    char* source;
     if (file == (char*)nullptr) {
-        file = const_cast<char*>(s_memory_cpp);
+        source = DAT_8032f7d4;
+    } else {
+        source = file;
     }
-    return stage->alloc(size, file, line, 0);
+    return stage->alloc(size, source, line, 0);
 }
 
 /*
@@ -801,12 +807,15 @@ void CMemory::DestroyStage(CMemory::CStage* stage)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMemory::_Alloc(unsigned long size, CMemory::CStage* stage, char* source, int line, int noError)
+void* CMemory::_Alloc(unsigned long size, CMemory::CStage* stage, char* source, int line, int noError)
 {
+    char* allocSource;
     if (source == (char*)nullptr) {
-        source = DAT_8032f7d4;
+        allocSource = DAT_8032f7d4;
+    } else {
+        allocSource = source;
     }
-    stage->alloc(size, source, line, noError);
+    return stage->alloc(size, allocSource, line, noError);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Type `DAT_8032f7d4` as the known 4-byte `.sdata2` default source object.
- Use that default source in placement `operator new` / `operator new[]` when no file is supplied, matching the PAL small-data load shape.
- Update `CMemory::_Alloc` to return the allocation pointer, matching external declarations and caller expectations.

## Objdiff evidence
Before -> after:
- `main/memory` fuzzy: `64.715675` -> `64.97375`
- `alloc__Q27CMemory6CStageFUlPcUli`: `76.12977` -> `77.92367`
- `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii`: `65.625` -> `68.125`
- `__nwa__FUlPQ27CMemory6CStagePci`: `66.875` -> `68.125`
- `__nw__FUlPQ27CMemory6CStagePci`: `66.875` -> `68.125`

## Verification
- `ninja`
- targeted `objdiff-cli diff` for `_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii` and `__nw__FUlPQ27CMemory6CStagePci`