### PR TITLE
Improve THPSimpleOpen matching

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -845,7 +845,11 @@ s32 THPSimpleOpen(const char* path)
             File.DrawError(SimpleControl.fileInfo, status);
         }
     }
-    while ((status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb)) != DVD_STATE_END) {
+    for (;;) {
+        status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+        if (status == DVD_STATE_END) {
+            break;
+        }
         status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
         if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
             File.DrawError(SimpleControl.fileInfo, status);
@@ -858,12 +862,12 @@ s32 THPSimpleOpen(const char* path)
         return 0;
     }
 
-    compInfoOffset = SimpleControl.header.mCompInfoDataOffsets;
-
     if (SimpleControl.header.mVersion != 0x11000) {
         DVDClose(&SimpleControl.fileInfo);
         return 0;
     }
+
+    compInfoOffset = SimpleControl.header.mCompInfoDataOffsets;
 
     while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, sReadBuffer, 0x20, compInfoOffset, (DVDCallback)0, 2)) {
         status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
@@ -871,7 +875,11 @@ s32 THPSimpleOpen(const char* path)
             File.DrawError(SimpleControl.fileInfo, status);
         }
     }
-    while ((status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb)) != DVD_STATE_END) {
+    for (;;) {
+        status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+        if (status == DVD_STATE_END) {
+            break;
+        }
         status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
         if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
             File.DrawError(SimpleControl.fileInfo, status);
@@ -884,6 +892,27 @@ s32 THPSimpleOpen(const char* path)
 
     for (componentIdx = 0; componentIdx < SimpleControl.compInfo.mNumComponents; componentIdx++) {
         switch (SimpleControl.compInfo.mFrameComp[componentIdx]) {
+        case 0:
+            while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, sReadBuffer, 0x20, componentOffset, (DVDCallback)0, 2)) {
+                status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+                if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
+                    File.DrawError(SimpleControl.fileInfo, status);
+                }
+            }
+            for (;;) {
+                status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+                if (status == DVD_STATE_END) {
+                    break;
+                }
+                status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+                if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
+                    File.DrawError(SimpleControl.fileInfo, status);
+                }
+            }
+
+            memcpy(&SimpleControl.videoInfo, sReadBuffer, sizeof(THPVideoInfo));
+            componentOffset += sizeof(THPVideoInfo);
+            break;
         case 1:
             while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, sReadBuffer, 0x20, componentOffset, (DVDCallback)0, 2)) {
                 status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
@@ -891,7 +920,11 @@ s32 THPSimpleOpen(const char* path)
                     File.DrawError(SimpleControl.fileInfo, status);
                 }
             }
-            while ((status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb)) != DVD_STATE_END) {
+            for (;;) {
+                status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
+                if (status == DVD_STATE_END) {
+                    break;
+                }
                 status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
                 if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
                     File.DrawError(SimpleControl.fileInfo, status);
@@ -901,23 +934,6 @@ s32 THPSimpleOpen(const char* path)
             memcpy(&SimpleControl.audioInfo, sReadBuffer, sizeof(THPAudioInfo));
             componentOffset += sizeof(THPAudioInfo);
             SimpleControl.hasAudio = 1;
-            break;
-        case 0:
-            while (!DVDReadAsyncPrio(&SimpleControl.fileInfo, sReadBuffer, 0x20, componentOffset, (DVDCallback)0, 2)) {
-                status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
-                if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
-                    File.DrawError(SimpleControl.fileInfo, status);
-                }
-            }
-            while ((status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb)) != DVD_STATE_END) {
-                status = DVDGetCommandBlockStatus(&SimpleControl.fileInfo.cb);
-                if ((status == 0xB) || ((status - 4U) <= 2) || (status == -1)) {
-                    File.DrawError(SimpleControl.fileInfo, status);
-                }
-            }
-
-            memcpy(&SimpleControl.videoInfo, sReadBuffer, sizeof(THPVideoInfo));
-            componentOffset += sizeof(THPVideoInfo);
             break;
         default:
             return 0;


### PR DESCRIPTION
## Summary
- align `THPSimpleOpen`'s DVD status polling with the original control-flow shape
- reorder THP component parsing so component type `0` loads `videoInfo` and type `1` loads `audioInfo`
- preserve the recovered logic while tightening the source to the compiler pattern the original object expects

## Evidence
- `THPSimpleOpen`: `90.320114%` -> `99.546745%`
- `main/THPSimple` `.text`: `93.85389%` -> `95.91398%`

## Why this is plausible source
- the change removes decompiler-flavored `while ((status = ... ) != DVD_STATE_END)` loops in favor of the repeated polling form used elsewhere in the file
- the component switch now matches the actual THP component type handling instead of relying on inverted branches
- no hacks, fake symbols, or section forcing were introduced

## Verification
- `ninja -j4`
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPSimpleOpen`
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o -`
