### PR TITLE
Improve CMapMesh ReadOtmMesh normal loop matching

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -447,14 +447,12 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
             m_normals = cursor;
             cursor += chunk.m_size;
 
-            offset = 0;
-            for (int i = 0; i < static_cast<int>(m_normalCount); i++) {
+            for (int i = 0, offset = 0; i < static_cast<int>(m_normalCount); i++, offset += 6) {
                 *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned int>(m_normals) + offset) = reader.Get2();
                 *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned int>(m_normals) + offset + 2) =
                     reader.Get2();
                 *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned int>(m_normals) + offset + 4) =
                     reader.Get2();
-                offset += 6;
             }
             break;
         case 0x434F4C52:


### PR DESCRIPTION
## Summary
- Move the normal-read byte offset increment into the `for` increment clause in `CMapMesh::ReadOtmMesh`
- Preserves the same source behavior while matching the original loop counter/update ordering more closely

## Objdiff evidence
- Unit: `main/mapmesh`
- Symbol: `ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`
- Before: `98.481674%`
- After: `98.53752%`
- `.text` before: `99.16905%`
- `.text` after: `99.199615%`

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/mapmesh -o - ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`
