### PR TITLE
Improve pppRyjMegaBirth calc layout

### DIFF
--- a/include/ffcc/pppRyjMegaBirth.h
+++ b/include/ffcc/pppRyjMegaBirth.h
@@ -25,13 +25,9 @@ struct PRyjMegaBirthOffsets
     s32* m_serializedDataOffsets;
 };
 
-void get_rand(void);
-void get_noise(unsigned char);
 void birth(_pppPObject*, VRyjMegaBirth*, PRyjMegaBirth*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
 void calc(VRyjMegaBirth*, PRyjMegaBirth*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
 void calc_particle(_pppPObject*, VRyjMegaBirth*, PRyjMegaBirth*, VColor*);
-void init_matrix(_pppPObject*, pppFMATRIX&, PRyjMegaBirth*, VRyjMegaBirth*);
-void set_matrix(_pppPObject*, pppFMATRIX&, PRyjMegaBirth*, VRyjMegaBirth*, _PARTICLE_DATA*, _PARTICLE_WMAT*);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -52,29 +52,6 @@ static inline unsigned char clamp_u8(float value)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void get_rand()
-{
-	(void)Math.RandF();
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void get_noise(unsigned char count)
-{
-	while (count != 0) {
-		(void)Math.RandF();
-		count--;
-	}
-}
-
-/*
- * --INFO--
  * PAL Address: 0x80083070
  * PAL Size: 4468b
  * EN Address: TODO
@@ -216,16 +193,21 @@ void calc(
 		*f32_at(particlePayload, 0x2C) = *f32_at(particlePayload, 0x2C) + *f32_at(paramPayload, 0x98);
 	}
 
-	float angleWrap = FLOAT_80330458;
-	float angleMax = FLOAT_8033045c;
-	while (angleMax <= *f32_at(particlePayload, 0x28))
 	{
-		*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) - angleWrap;
+		float angleWrap = FLOAT_80330458;
+		float angleMax = FLOAT_8033045c;
+		while (angleMax <= *f32_at(particlePayload, 0x28))
+		{
+			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) - angleWrap;
+		}
 	}
-	float angleMin = FLOAT_80330460;
-	while (*f32_at(particlePayload, 0x28) < angleMin)
 	{
-		*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + angleWrap;
+		float angleWrap = FLOAT_80330458;
+		float angleMin = FLOAT_80330460;
+		while (*f32_at(particlePayload, 0x28) < angleMin)
+		{
+			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + angleWrap;
+		}
 	}
 
 	*f32_at(particlePayload, 0x34) = *f32_at(particlePayload, 0x34) + *f32_at(particlePayload, 0x3C);
@@ -254,11 +236,14 @@ void calc(
 				*f32_at(particlePayload, 0x4C) = kPppRyjMegaBirthZero;
 			}
 		}
-		else if ((*f32_at(paramPayload, 0xC0) < kPppRyjMegaBirthZero) &&
-		         (kPppRyjMegaBirthZero < *f32_at(paramPayload, 0xC4)) &&
-		         (kPppRyjMegaBirthZero < *f32_at(particlePayload, 0x4C)))
+		else
 		{
-			*f32_at(particlePayload, 0x4C) = kPppRyjMegaBirthZero;
+			float zero = kPppRyjMegaBirthZero;
+			if ((*f32_at(paramPayload, 0xC0) < zero) && (zero < *f32_at(paramPayload, 0xC4)) &&
+			    (zero < *f32_at(particlePayload, 0x4C)))
+			{
+				*f32_at(particlePayload, 0x4C) = zero;
+			}
 		}
 	}
 
@@ -495,7 +480,7 @@ void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMega
  * Address:	TODO
  * Size:	TODO
  */
-void init_matrix(_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirth* params, VRyjMegaBirth* work)
+static inline void init_matrix(_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirth* params, VRyjMegaBirth* work)
 {
 	u8* payload = (u8*)params;
 
@@ -528,7 +513,7 @@ void init_matrix(_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirth* params, V
  * Address:	TODO
  * Size:	TODO
  */
-void set_matrix(
+static inline void set_matrix(
 	_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirth* params, VRyjMegaBirth* work, _PARTICLE_DATA* particle,
 	_PARTICLE_WMAT* particleWorldMat)
 {


### PR DESCRIPTION
## Summary
- Tighten the local constant lifetimes in `pppRyjMegaBirth::calc` so the generated angle-wrap/clamp code moves closer to the target.
- Remove unused `get_rand` / `get_noise` declarations and definitions from `pppRyjMegaBirth`.
- Make the draw-only matrix helpers internal inline helpers instead of exported declarations absent from the target object.

## Evidence
- `ninja` passes.
- `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR` improved from 97.649574% to 98.05556%; current size is 924 bytes vs 936-byte target.
- Full unit check now reports `.data` at 66.66667% for `main/pppRyjMegaBirth`.

## Plausibility
- The source changes preserve the existing behavior and offsets while avoiding unused exported helpers that are not present in the target symbol set.
- The calc change reflects normal compiler-visible scoping of local float constants rather than fake labels, addresses, or manual section control.
