### PR TITLE
Improve p_usb and pppShape matching

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -1,12 +1,11 @@
 #ifndef _FFCC_P_USB_H_
 #define _FFCC_P_USB_H_
 
-#include "ffcc/p_sample.h"
 #include "ffcc/memory.h"
-#include "ffcc/p_sample.h"
+#include "ffcc/system.h"
 #include "ffcc/usb.h"
 
-class CUSBPcs : public CSamplePcs
+class CUSBPcs : public CProcess
 {
 public:
     CUSBPcs();

--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -130,10 +130,10 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
 
     currentFrame = animData;
     for (frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex = frameIndex + 1) {
-        int shapeIndex;
-        int shapeStep;
-        char* shapeBase;
         unsigned char* shapeEntry;
+        char* shapeBase;
+        int shapeStep;
+        int shapeIndex;
 
         shapeOffset = *(short*)((int)currentFrame + 0x10);
         shapeBase = animData + shapeOffset;
@@ -183,10 +183,10 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
 
     currentFrame = animData;
     for (frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex = frameIndex + 1) {
-        int shapeIndex;
-        int shapeStep;
-        char* shapeBase;
         unsigned char* shapeEntry;
+        char* shapeBase;
+        int shapeStep;
+        int shapeIndex;
 
         shapeOffset = *(short*)((int)currentFrame + 0x10);
         shapeBase = animData + shapeOffset;


### PR DESCRIPTION
## Summary
- make CUSBPcs derive directly from CProcess, matching its process table/vtable shape more closely
- reorder pppShape texture-cache loop locals to improve generated code for both cache load and dump paths

## Objdiff evidence
- main/p_usb: .text 95.07576 -> 95.184845
- main/p_usb: __sinit_p_usb_cpp 66.86364 -> 67.681816
- main/p_usb: [.data-0] 88.43947 -> 90.39505
- main/p_usb: extabindex 100.0 -> 99.07407, accepted as a small metadata regression for the more plausible CUSBPcs base type
- main/pppShape: .text 98.91688 -> 98.94206
- main/pppShape: pppCacheDumpShapeTexture 96.833336 -> 96.916664
- main/pppShape: pppCacheLoadShapeTexture 96.833336 -> 96.916664

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_usb -o -
- build/tools/objdiff-cli diff -p . -u main/pppShape -o -