### PR TITLE
Clean up CGPrgObj target rotation helpers

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -218,14 +218,13 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	float deltaX;
 	float zero;
 	float deltaZ;
-	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
 	deltaX = deltaPos.x;
-	zero = FLOAT_80331BD4;
+	zero = 0.0f;
 	deltaZ = deltaPos.z;
 	if (zero == deltaX || zero == deltaZ) {
-		targetRot = FLOAT_80331BD4;
+		targetRot = zero;
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
@@ -251,14 +250,13 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 	float deltaX;
 	float zero;
 	float deltaZ;
-	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), &deltaPos);
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	deltaX = deltaPos.x;
-	zero = FLOAT_80331BD4;
+	zero = 0.0f;
 	deltaZ = deltaPos.z;
 	if (zero == deltaX || zero == deltaZ) {
-		targetRot = FLOAT_80331BD4;
+		targetRot = zero;
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
@@ -283,11 +281,10 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float deltaX;
 	float zero;
 	float deltaZ;
-	Vec* basePosVec = reinterpret_cast<Vec*>(&basePos);
 
-	PSVECSubtract(basePosVec, reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
 	deltaX = deltaPos.x;
-	zero = FLOAT_80331BD4;
+	zero = 0.0f;
 	deltaZ = deltaPos.z;
 	if (zero == deltaX || zero == deltaZ) {
 		targetRot = zero;


### PR DESCRIPTION
## Summary
- Removes unnecessary temporary base-position pointer locals in CGPrgObj target rotation helpers.
- Uses local zero values for the target-rotation zero path, keeping the source closer to the target helper shape.

## Evidence
- ninja passes for GCCP01.
- objdiff main/prgobj .text improves from 96.975105% to 96.99032%.
- Affected helper symbol scores remain stable:
  - dstTargetRot__8CGPrgObjFP8CGPrgObj: 87.681816%
  - rotTarget__8CGPrgObjFP8CGPrgObj: 86.51282%
  - getTargetRot__8CGPrgObjFP8CGPrgObj: 91.02778%

## Plausibility
- The change removes redundant pointer temporaries and keeps direct CVector-to-Vec casts at the call site.
- The zero fallback is expressed as a normal literal/local value rather than depending on an unrelated shared symbol.