### PR TITLE
Improve pppYmBreath particle typing

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -105,7 +105,7 @@ struct YmBreathParams {
 struct YmBreathParticleGroup {
     int active;
     signed char* particleIndices;
-    unsigned char* particleStates;
+    signed char* particleStates;
     Vec position;
     Vec direction;
     float speed;
@@ -551,13 +551,15 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
                 groupTable[1] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                     (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12),
                     pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x260);
-                memset((void*)groupTable[1], 0xFF,
+                void* particleIndices = (void*)groupTable[1];
+                memset(particleIndices, -1,
                        (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12));
 
                 groupTable[2] = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
                     (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12),
                     pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmBreath_cpp_801DA9B0), 0x263);
-                memset((void*)groupTable[2], 0xFF,
+                void* particleStates = (void*)groupTable[2];
+                memset(particleStates, -1,
                        (unsigned long)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12));
                 groupTable[0] = 0;
                 groupTable += 0x17;
@@ -721,7 +723,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                         groupData = &groupTable[(int)foundGroup];
                         for (slot = 0; slot < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
                              slot++) {
-                            groupData->particleStates[slot] = 0xFF;
+                            groupData->particleStates[slot] = -1;
                             groupData->position.x = zero;
                             groupData->position.y = zero;
                             groupData->position.z = zero;
@@ -744,7 +746,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                     for (j = 0; j < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x14); j++) {
                         for (k = 0; k < (int)(unsigned short)*(unsigned short*)((unsigned char*)pYmBreath + 0x12);
                              k++) {
-                            if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == 0xFF)) {
+                            if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == -1)) {
                                 groupData->particleIndices[k] = (signed char)i;
                                 found = false;
                                 groupData->particleStates[k] = 1;
@@ -831,7 +833,7 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* 
         particleColor->m_colorFrameDeltas[1] += params->m_colorFrameAccel1;
         particleColor->m_colorFrameDeltas[2] += params->m_colorFrameAccel2;
         particleColor->m_colorFrameDeltas[3] += params->m_colorFrameAccel3;
-        alpha = (unsigned int)vColor->m_alpha + (int)particleColor->m_color[3];
+        alpha = (int)vColor->m_alpha + (int)particleColor->m_color[3];
         if (alpha > 0xFF) {
             alpha = 0xFF;
         }
@@ -864,14 +866,17 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* 
 
     particle->m_scale += params->m_scaleAccel;
     if (params->m_disableScaleClamp == 0) {
-        float start = params->m_scaleClampStart;
         float zero = 0.0f;
-        if ((zero < start) && (params->m_scaleAccel < zero)) {
-            if (particle->m_scale < zero) {
+        if (zero < params->m_scaleClampStart) {
+            if (params->m_scaleAccel < zero) {
+                if (particle->m_scale < zero) {
+                    particle->m_scale = zero;
+                }
+            }
+        } else if (params->m_scaleClampStart < zero) {
+            if ((zero < params->m_scaleAccel) && (zero < particle->m_scale)) {
                 particle->m_scale = zero;
             }
-        } else if ((start < zero) && (zero < params->m_scaleAccel) && (zero < particle->m_scale)) {
-            particle->m_scale = zero;
         }
     }
 
@@ -908,12 +913,10 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
 {
     unsigned char* breath = (unsigned char*)pYmBreath;
     Vec* particle = reinterpret_cast<Vec*>(particleData);
-    int angle[3];
+    int angle[4];
     pppFMATRIX rotMtx;
     Vec baseDir;
-    float normX;
-    float normY;
-    float normZ;
+    Vec directionNorm;
     float spread;
     float range;
     unsigned char flags;
@@ -936,6 +939,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     angle[0] = (int)((float)((int)(range * Math.RandF() - spread) << 15) / FLOAT_80330C98);
     angle[1] = (int)((float)((int)(range * Math.RandF() - spread) << 15) / FLOAT_80330C98);
     angle[2] = (int)((float)((int)(range * Math.RandF() - spread) << 15) / FLOAT_80330C98);
+    angle[3] = 0;
 
     pppGetRotMatrixXYZ__FR10pppFMATRIXP11pppIVECTOR4(&rotMtx, &angle);
     PSMTXMultVecSR(rotMtx.value, &baseDir, &particle[1]);
@@ -944,10 +948,8 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     particle[1].y *= *(float*)(breath + 0xB4);
     particle[1].z *= *(float*)(breath + 0xB8);
 
-    normX = particle[1].x;
-    normY = particle[1].y;
-    normZ = particle[1].z;
-    pppNormalize__FR3Vec3Vec(reinterpret_cast<float*>(&particle[1]), reinterpret_cast<Vec*>(&normX));
+    directionNorm = particle[1];
+    pppNormalize__FR3Vec3Vec(reinterpret_cast<float*>(&particle[1]), &directionNorm);
 
     if (*(float*)(breath + 0xAC) != 0.0f) {
         PSVECScale(&particle[1], &particle[0], *(float*)(breath + 0xAC));


### PR DESCRIPTION
## Summary
- tighten `YmBreathParticleGroup::particleStates` to signed storage so the code matches the `-1` sentinel usage
- initialize group particle index/state buffers through named temporaries in `pppFrameYmBreath`
- reshape `UpdateParticle` scale clamp and alpha accumulation, and give `BirthParticle` the 4-word angle scratch + vector temp layout expected by the original code

## Evidence
- `ninja` succeeds
- `main/pppYmBreath` `.text` match: `91.92636%` -> `91.990715%`
- `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`: `90.30597%` -> `91.1306%`
- `pppFrameYmBreath`: `92.00949%` -> `92.01582%`
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: `86.47089%` -> `86.17215%`

## Why this is plausible
- the changes line up the code with existing signed sentinel semantics already used throughout the unit
- the stack/temp reshaping in `BirthParticle` and clamp branching in `UpdateParticle` make the source more compiler-faithful without introducing hacks or fake linkage
- despite the small `BirthParticle` regression, the unit shows a real net code-match improvement in objdiff