### PR TITLE
Improve CFile::DrawError match

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -182,10 +182,10 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
 
         Graphic._WaitDrawDone(const_cast<char*>(s_fileCpp), 0x2CC);
 
-        int compactLayout = 0;
-        if (Graphic.m_scratchTextureBuffer != 0 && !usingFallbackFont)
+        int compactLayout = Graphic.m_scratchTextureBuffer != 0;
+        if (usingFallbackFont)
         {
-            compactLayout = 1;
+            compactLayout = 0;
         }
 
         if (compactLayout)
@@ -218,15 +218,15 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
         int msgIndex = 0;
         switch (errorCode)
         {
-        case 4:
-        case 6:
-            msgIndex = 2;
+        case 0x0B:
+            msgIndex = 0;
             break;
         case 5:
             msgIndex = 1;
             break;
-        case 0x0B:
-            msgIndex = 0;
+        case 4:
+        case 6:
+            msgIndex = 2;
             break;
         case -1:
             msgIndex = 3;
@@ -291,8 +291,13 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
         VIFlush();
 
         int status;
-        while ((status = DVDGetCommandBlockStatus(&info.cb)) == errorCode)
+        while (true)
         {
+            status = DVDGetCommandBlockStatus(&info.cb);
+            if (status != errorCode)
+            {
+                break;
+            }
             VIWaitForRetrace();
         }
 


### PR DESCRIPTION
## Summary
- Adjust compact-layout selection in CFile::DrawError to keep the scratch-buffer test and fallback-font clearing closer to target codegen.
- Reorder the disk-error message switch cases to match the emitted case body order.
- Rewrite the DVD status wait as an explicit read/break loop, matching the target loop shape more closely.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/file -o - DrawError__5CFileFR11DVDFileInfoi
- DrawError__5CFileFR11DVDFileInfoi: 94.58255% -> 95.63444% match.
- Compiled function size: 1684 -> 1688 bytes, target 1696 bytes.

## Plausibility
- Changes preserve behavior and express the same control flow in a source-level shape that better matches the original compiler output.
- No hardcoded addresses, fake symbols, or manual section/vtable work.
