### PR TITLE
Improve menu list layout and controls

### DIFF
--- a/include/ffcc/menu_lst.h
+++ b/include/ffcc/menu_lst.h
@@ -55,7 +55,9 @@ public:
     void MLstDraw();
     void MLstCtrlCur();
 
-    char pad_00[0x108];
+    char pad_00[0xF8];
+    CFont* helpFont;
+    char pad_fc[0x0C];
     CFont* listFont;
     char pad_10c[0x720];
     MenuLstState* lstState;

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -68,13 +68,9 @@ static const unsigned char gap_80333669[] = {0, 0, 0};
 extern "C" const char DAT_8033366c[] = " ";
 static const unsigned char gap_8033366e[] = {0, 0};
 extern "C" const char DAT_80333670[] = " %d";
-extern "C" const char lbl_80333674[] = " %+d";
-extern "C" const char lbl_8033367C[] = " %s";
-extern "C" const char lbl_80333680[] = "Empty.";
-extern "C" const char lbl_80333688[] = "Vuoto.";
-extern "C" const char lbl_80333690[] = "Vide";
 
 STATIC_ASSERT(offsetof(CMenuPcs, listFont) == 0x108);
+STATIC_ASSERT(offsetof(CMenuPcs, helpFont) == 0xF8);
 STATIC_ASSERT(offsetof(CMenuPcs, lstState) == 0x82C);
 STATIC_ASSERT(offsetof(CMenuPcs, lstData) == 0x850);
 STATIC_ASSERT(offsetof(MenuLstEntry, tex) == 0x1C);
@@ -197,7 +193,7 @@ void CMenuPcs::MLstDraw()
 	DrawHelpMessage__8CMenuPcsFiP5CFontii8_GXColoriff(
 		this,
 		state->cursor + 0x25c,
-		font,
+		this->helpFont,
 		0,
 		-(int)FLOAT_80333400,
 		helpColor.color,
@@ -313,16 +309,18 @@ void CMenuPcs::MLstCtrl()
 {
 	bool blocked;
 	float one;
-	unsigned short press;
-	unsigned short hold;
+	short press;
+	short hold;
 	unsigned int itemCount;
 	unsigned int chunkCount;
 	int i;
 	int startFrame;
 	int duration;
+	int padLock;
 
 	blocked = false;
-	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+	padLock = Pad._452_4_;
+	if ((padLock != 0) || (Pad._448_4_ != -1)) {
 		blocked = true;
 	}
 	if (blocked) {
@@ -334,7 +332,7 @@ void CMenuPcs::MLstCtrl()
 	}
 
 	blocked = false;
-	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+	if ((padLock != 0) || (Pad._448_4_ != -1)) {
 		blocked = true;
 	}
 	if (blocked) {


### PR DESCRIPTION
## Summary
- model the `CMenuPcs` help font at offset `0xF8` and pass it to `MLstDraw` help text rendering
- treat `MLstCtrl` pad masks as signed halfwords and reuse the first pad gate read
- remove `menu_lst.cpp` definitions for sdata2 strings owned by the following split range

## Evidence
- `ninja` passes
- `main/menu_lst` code: 73.30495% -> 73.90794%
- `MLstDraw__8CMenuPcsFv`: 69.02507% -> 69.704735%
- `MLstCtrl__8CMenuPcsFv`: 73.50673% -> 74.76233%
- `tools/map/claim_doctor.py src/menu_lst.cpp`: no diagnoses

## Plausibility
- `0xF8` matches the established menu help-font slot used by neighboring menu units
- pad input values are consumed as signed halfwords in the target assembly
- removed string definitions are outside the `menu_lst.cpp` split range (`0x80333614..0x80333674`)
