### PR TITLE
Improve CFlatRuntime construction layout

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -31,8 +31,8 @@ public:
 	class CObject
 	{
 	public:
-		CObject();
-		~CObject();
+		CObject() {}
+		~CObject() {}
 		void onNewFinished();
 
 		unsigned int m_id;         // 0x0

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -52,12 +52,12 @@ CFlatRuntime::CFlatRuntime()
 	unsigned char* const self = reinterpret_cast<unsigned char*>(this);
 
 	*reinterpret_cast<void***>(self) = __vt__12CFlatRuntime;
-	*reinterpret_cast<void***>(self + 0x1204) = __vt__Q212CFlatRuntime7CObject;
-	self[0x123C] &= 0xEF;
-	*reinterpret_cast<void***>(self + 0x124C) = __vt__Q212CFlatRuntime7CObject;
-	self[0x1284] &= 0xEF;
-	self[0x1294] = 0;
-	self[0x1298] = 1;
+	*reinterpret_cast<void***>(self + 0x914) = __vt__Q212CFlatRuntime7CObject;
+	self[0x904] &= 0xEF;
+	*reinterpret_cast<void***>(self + 0x960) = __vt__Q212CFlatRuntime7CObject;
+	self[0x950] &= 0xEF;
+	*reinterpret_cast<int*>(self + 0x970) = 0;
+	*reinterpret_cast<int*>(self + 0x1298) = 1;
 
 	clear();
 }


### PR DESCRIPTION
## Summary
- Make `CFlatRuntime::CObject` construction/destruction inline empty, matching the absence of standalone ctor/dtor symbols in PAL.
- Correct the two embedded `CObject` setup offsets in `CFlatRuntime::CFlatRuntime()`, including the flags and created-state word fields.

## Objdiff evidence
- `__ct__12CFlatRuntimeFv`: 45.24138% -> 94.48276%
- `__dt__12CFlatRuntimeFv`: 88.46154% -> 100.0%
- `main/cflat_runtime` `.text`: 46.943874% -> 47.376846%
- Small extab/extabindex movement remains from removing the nonexistent member ctor/dtor calls.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o - __ct__12CFlatRuntimeFv`
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o - __dt__12CFlatRuntimeFv`