### PR TITLE
Recover pppChangeTex model layouts

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -33,7 +33,9 @@ struct ChangeTexDisplayList {
 };
 
 struct ChangeTexMeshData {
-	u8 _pad0[0x20];
+	u8 _pad0[0x14];
+	u32 m_vertexCount;
+	u8 _pad18[0x8];
 	void* m_normals;
 	u8 _pad1[0x28];
 	s32 m_displayListCount;
@@ -43,7 +45,35 @@ struct ChangeTexMeshData {
 struct ChangeTexMeshRef {
 	u8 _pad0[0x8];
 	ChangeTexMeshData* m_data;
-	u8 _padC[0x14 - 0xC];
+	s16* m_points;
+	u8 _pad10[0x14 - 0x10];
+};
+
+struct ChangeTexWork;
+
+struct ChangeTexModelData {
+	u8 _pad0[0xC];
+	u32 m_meshCount;
+	u8 _pad10[0x14];
+	CMaterialSet* m_materialSet;
+	u8 _pad28[0xC];
+	s32 m_frameShift;
+};
+
+struct ChangeTexModelRaw {
+	u8 _pad0[0x68];
+	Mtx m_matrix;
+	u8 _pad98[0xC];
+	ChangeTexModelData* m_data;
+	u8 _padA8[0x4];
+	ChangeTexMeshRef* m_meshes;
+	u8 _padB0[0x34];
+	ChangeTexWork* m_work;
+	pppChangeTexUnkB* m_step;
+	u8 _padEC[0x10];
+	void (*m_drawMeshDlCallback)(CChara::CModel*, void*, void*, int, int, float (*)[4]);
+	u8 _pad100[0x4];
+	void (*m_afterDrawMeshCallback)(CChara::CModel*, void*, void*, int, float (*)[4]);
 };
 
 struct ChangeTexWork {
@@ -69,6 +99,21 @@ extern const float FLOAT_80332028 = 255.0f;
 extern const double DOUBLE_80332030 = 4503601774854144.0;
 extern const double DOUBLE_80332038 = 4503599627370496.0;
 static const char s_pppChangeTex_cpp_801dd660[] = "pppChangeTex.cpp";
+
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_data) == 0xA4);
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_meshes) == 0xAC);
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_work) == 0xE4);
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_step) == 0xE8);
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_drawMeshDlCallback) == 0xFC);
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_afterDrawMeshCallback) == 0x104);
+STATIC_ASSERT(offsetof(ChangeTexMeshData, m_vertexCount) == 0x14);
+STATIC_ASSERT(offsetof(ChangeTexMeshData, m_normals) == 0x20);
+STATIC_ASSERT(offsetof(ChangeTexMeshData, m_displayListCount) == 0x4C);
+STATIC_ASSERT(offsetof(ChangeTexMeshData, m_displayLists) == 0x50);
+STATIC_ASSERT(offsetof(ChangeTexMeshRef, m_points) == 0xC);
+STATIC_ASSERT(offsetof(ChangeTexModelData, m_meshCount) == 0xC);
+STATIC_ASSERT(offsetof(ChangeTexModelData, m_materialSet) == 0x24);
+STATIC_ASSERT(offsetof(ChangeTexModelData, m_frameShift) == 0x34);
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 
@@ -137,6 +182,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	u8* colorData = base + serializedDataOffsets[1] + 0x80;
 	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_charaObj, 0);
 	CChara::CModel* model0 = GetCharaModelPtr(handle0);
+	ChangeTexModelRaw* model0Raw = (ChangeTexModelRaw*)model0;
 
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
 	    &changeTex->field0_0x0, step->m_graphId, work->m_value0, work->m_value1, work->m_value2, step->m_initWOrk,
@@ -144,10 +190,10 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 
 	work->m_charaObj = (CGObject*)pppMngStPtr->m_charaObj;
 	work->m_context = pppEnvStPtr;
-	*(ChangeTexWork**)((char*)model0 + 0xE4) = work;
-	*(pppChangeTexUnkB**)((char*)model0 + 0xE8) = step;
-	*(void**)((char*)model0 + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
-	*(void**)((char*)model0 + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
+	model0Raw->m_work = work;
+	model0Raw->m_step = step;
+	model0Raw->m_drawMeshDlCallback = ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
+	model0Raw->m_afterDrawMeshCallback = ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
 
 	work->m_texture = GetTextureFromRSD__FiP9_pppEnvSt(step->m_dataValIndex, pppEnvStPtr);
 
@@ -156,17 +202,19 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 
 	CChara::CModel* model;
 	if ((handle1 != 0) && ((model = GetCharaModelPtr(handle1)), model != 0)) {
-		*(ChangeTexWork**)((char*)model + 0xE4) = work;
-		*(pppChangeTexUnkB**)((char*)model + 0xE8) = step;
-		*(void**)((char*)model + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
-		*(void**)((char*)model + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
+		ChangeTexModelRaw* modelRaw = (ChangeTexModelRaw*)model;
+		modelRaw->m_work = work;
+		modelRaw->m_step = step;
+		modelRaw->m_drawMeshDlCallback = ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
+		modelRaw->m_afterDrawMeshCallback = ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
 	}
 
 	if ((handle2 != 0) && ((model = GetCharaModelPtr(handle2)), model != 0)) {
-		*(ChangeTexWork**)((char*)model + 0xE4) = work;
-		*(pppChangeTexUnkB**)((char*)model + 0xE8) = step;
-		*(void**)((char*)model + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
-		*(void**)((char*)model + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
+		ChangeTexModelRaw* modelRaw = (ChangeTexModelRaw*)model;
+		modelRaw->m_work = work;
+		modelRaw->m_step = step;
+		modelRaw->m_drawMeshDlCallback = ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
+		modelRaw->m_afterDrawMeshCallback = ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
 	}
 
 	if (step->m_payload[0] == 0) {
@@ -179,32 +227,33 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	}
 	work->m_texture = texObj;
 
-	int meshList = *(int*)((char*)model0 + 0xAC);
+	ChangeTexMeshRef* meshList = model0Raw->m_meshes;
 	if ((work->m_meshColorArrays == 0) && (work->m_displayListArrays == 0)) {
 		work->m_cachedValue = FLOAT_80332020;
 		work->m_meshColorArrays = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-		    *(int*)(*(int*)((char*)model0 + 0xA4) + 0xC) << 2, pppEnvStPtr->m_stagePtr,
+		    model0Raw->m_data->m_meshCount << 2, pppEnvStPtr->m_stagePtr,
 		    const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x163);
 		work->m_displayListArrays = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-		    *(int*)(*(int*)((char*)model0 + 0xA4) + 0xC) << 2, pppEnvStPtr->m_stagePtr,
+		    model0Raw->m_data->m_meshCount << 2, pppEnvStPtr->m_stagePtr,
 		    const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x166);
 
 		int* meshColorArrays = (int*)work->m_meshColorArrays;
 		int arrayOffset = 0;
-		for (unsigned int meshIdx = 0; meshIdx < *(unsigned int*)(*(int*)((char*)model0 + 0xA4) + 0xC); meshIdx++) {
-			int meshHdr = *(int*)(meshList + 8);
-			if (strcmp((char*)meshHdr, DAT_80332024) == 0) {
+		for (unsigned int meshIdx = 0; meshIdx < model0Raw->m_data->m_meshCount; meshIdx++) {
+			ChangeTexMeshData* meshData = meshList->m_data;
+			char* meshHdr = (char*)meshData;
+			if (strcmp(meshHdr, DAT_80332024) == 0) {
 				CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl(
-				    &gUtil, &work->m_bboxMin, &work->m_bboxMax, *(void**)(meshList + 0xC), *(unsigned long*)(meshHdr + 0x14),
-				    *(unsigned long*)(*(int*)((char*)model0 + 0xA4) + 0x34));
+				    &gUtil, &work->m_bboxMin, &work->m_bboxMax, meshList->m_points, meshData->m_vertexCount,
+				    model0Raw->m_data->m_frameShift);
 			}
 
 			*(int*)((u8*)work->m_displayListArrays + arrayOffset) = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-			    *(int*)(*(int*)(meshList + 8) + 0x4C) << 2, pppEnvStPtr->m_stagePtr,
+			    meshData->m_displayListCount << 2, pppEnvStPtr->m_stagePtr,
 			    const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x181);
 
-			int dlIdx = *(int*)(*(int*)(meshList + 8) + 0x4C) - 1;
-			int* dlInfo = (int*)(*(int*)(*(int*)(meshList + 8) + 0x50));
+			int dlIdx = meshData->m_displayListCount - 1;
+			int* dlInfo = (int*)meshData->m_displayLists;
 			int* dlEntry = (int*)(*(int*)((u8*)work->m_displayListArrays + arrayOffset) + dlIdx * 4);
 			for (; dlIdx >= 0; dlIdx = dlIdx - 1, dlInfo = dlInfo + 3) {
 				int dlPair = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
@@ -219,13 +268,13 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 			}
 
 			*meshColorArrays = (int)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-			    *(int*)(*(int*)(meshList + 8) + 0x14) << 2, pppEnvStPtr->m_stagePtr,
+			    meshData->m_vertexCount << 2, pppEnvStPtr->m_stagePtr,
 			    const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x196);
-			memset((void*)*meshColorArrays, 0, *(int*)(*(int*)(meshList + 8) + 0x14) << 2);
+			memset((void*)*meshColorArrays, 0, meshData->m_vertexCount << 2);
 
 			arrayOffset += 4;
 			meshColorArrays = meshColorArrays + 1;
-			meshList += 0x14;
+			meshList = (ChangeTexMeshRef*)((char*)meshList + sizeof(ChangeTexMeshRef));
 		}
 	}
 
@@ -240,7 +289,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	float currentValue = work->m_value0 * (work->m_bboxMax.y - work->m_bboxMin.y) + work->m_bboxMin.y;
 
 	scale.u[0] = 0x43300000;
-	scale.u[1] = (1 << *(int*)(*(int*)((char*)model0 + 0xA4) + 0x34)) ^ 0x80000000;
+	scale.u[1] = (1 << model0Raw->m_data->m_frameShift) ^ 0x80000000;
 	short splitY = (short)(int)(currentValue * (float)(scale.d - DOUBLE_80332030));
 	if (work->m_cachedValue == currentValue) {
 		return;
@@ -253,21 +302,22 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	double alphaBase = (double)(FLOAT_80332028 * ((float)(scale.d - DOUBLE_80332038) / FLOAT_80332028));
 
 	int arrayOffset = 0;
-	meshList = *(int*)((char*)model0 + 0xAC);
-	for (unsigned int meshIdx = 0; meshIdx < *(unsigned int*)(*(int*)((char*)model0 + 0xA4) + 0xC); meshIdx++) {
+	meshList = model0Raw->m_meshes;
+	for (unsigned int meshIdx = 0; meshIdx < model0Raw->m_data->m_meshCount; meshIdx++) {
 		int pointOffset = 0;
 		int colorBase = *(int*)((u8*)work->m_meshColorArrays + arrayOffset);
 		int colorPtr = colorBase;
 		unsigned int vertCount;
-		for (unsigned int v = 0; (vertCount = *(unsigned int*)(*(int*)(meshList + 8) + 0x14), v < vertCount); v++) {
+		ChangeTexMeshData* meshData = meshList->m_data;
+		for (unsigned int v = 0; (vertCount = meshData->m_vertexCount, v < vertCount); v++) {
 			if (step->m_payload[0] == 1) {
-				if (*(short*)(*(int*)(meshList + 0xC) + pointOffset + 2) < splitY) {
+				if (*(short*)((char*)meshList->m_points + pointOffset + 2) < splitY) {
 					*(char*)(colorPtr + 3) = (char)(int)alphaBase;
 				} else {
 					*(char*)(colorPtr + 3) = 0;
 				}
 			} else if (step->m_payload[0] == 2) {
-				if (*(short*)(*(int*)(meshList + 0xC) + pointOffset + 2) > splitY) {
+				if (*(short*)((char*)meshList->m_points + pointOffset + 2) > splitY) {
 					*(char*)(colorPtr + 3) = (char)(int)alphaBase;
 				} else {
 					*(char*)(colorPtr + 3) = 0;
@@ -280,7 +330,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 
 		DCFlushRange((void*)colorBase, vertCount << 2);
 		arrayOffset += 4;
-		meshList += 0x14;
+		meshList = (ChangeTexMeshRef*)((char*)meshList + sizeof(ChangeTexMeshRef));
 	}
 }
 
@@ -426,7 +476,8 @@ void pppConstructChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
  */
 extern "C" void ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2(CChara::CModel* model, void* param_2, void* param_3, int meshIdx, float (*) [4])
 {
-	ChangeTexMeshRef* meshes = *(ChangeTexMeshRef**)((char*)model + 0xAC);
+	ChangeTexModelRaw* modelRaw = (ChangeTexModelRaw*)model;
+	ChangeTexMeshRef* meshes = modelRaw->m_meshes;
 	int displayListIdx;
 	int* displayListPtr;
 	int dlArrayBase;
@@ -481,7 +532,7 @@ extern "C" void ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2(C
 					*(int*)(MaterialManRaw() + 0x130) = 0;
 					*(int*)(MaterialManRaw() + 0x40) = fullTevBits;
 					SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
-					    &MaterialMan, *(void**)(*(int*)((char*)model + 0xA4) + 0x24), displayList->m_material, 0, 0);
+					    &MaterialMan, modelRaw->m_data->m_materialSet, displayList->m_material, 0, 0);
 					displayListPtr = *(int**)(dlArrayBase + dlOffset);
 					GXCallDisplayList((void*)displayListPtr[0], (unsigned int)displayListPtr[1]);
 					dlOffset -= 4;
@@ -504,7 +555,8 @@ extern "C" void ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2(C
  */
 extern "C" void ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2(CChara::CModel* model, void* param_2, void* param_3, int param_4, int param_5, float (*param_6) [4])
 {
-	ChangeTexMeshRef* meshes = *(ChangeTexMeshRef**)((char*)model + 0xAC);
+	ChangeTexModelRaw* modelRaw = (ChangeTexModelRaw*)model;
+	ChangeTexMeshRef* meshes = modelRaw->m_meshes;
 	ChangeTexMeshData* meshData = meshes[param_4].m_data;
 	ChangeTexDisplayList* displayList = meshData->m_displayLists + param_5;
 	int textureInfo = *(int*)((char*)param_2 + 0x1C);
@@ -541,6 +593,6 @@ extern "C" void ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2(CCh
 	}
 
 	SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(
-	    &MaterialMan, *(void**)(*(int*)((char*)model + 0xA4) + 0x24), displayList->m_material, 0, 0);
+	    &MaterialMan, modelRaw->m_data->m_materialSet, displayList->m_material, 0, 0);
 	GXCallDisplayList(displayList->m_data, displayList->m_size);
 }


### PR DESCRIPTION
## Summary
- recover the typed model, mesh, and material-set layouts used by `pppChangeTex`
- replace high-value raw offset accesses in `pppFrameChangeTex` and the draw callbacks with recovered member access
- keep the existing behavior while aligning this unit with the already-recovered `pppYmChangeTex` object model

## Evidence
- `main/pppChangeTex` fuzzy match: `82.42596%` -> `94.21374%`
- `pppFrameChangeTex`: `71.37771%` -> `92.17647%`
- `ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2`: `86.593025%` -> `95.639534%`
- `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2`: `89.16393%` -> `90.88525%`
- `pppDestructChangeTex`: `96.651855%` -> `97.54074%`

## Why this is plausible
- the new layouts are backed by the same field offsets already recovered in `pppYmChangeTex.cpp`
- member access replaces ad hoc pointer arithmetic without introducing hardcoded fake symbols or section hacks
- the change preserves normal compiler-generated callback wiring and material-set access patterns

## Validation
- `ninja`
- `build/tools/objdiff-cli report generate -p . -o build/GCCP01/report.json`