### PR TITLE
Name pppCrystal sdata2 constants

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -21,6 +21,16 @@ extern const float FLOAT_80331008;
 extern const float FLOAT_8033100C;
 extern const float FLOAT_80331010;
 
+extern const float FLOAT_80330fa8 = 32.0f;
+extern const float FLOAT_80330fac = -0.5f;
+extern const float FLOAT_80330fb0 = 640.0f;
+extern const float FLOAT_80330fb4 = 448.0f;
+extern const float FLOAT_80330fb8 = 33.3f;
+extern const float FLOAT_80330fbc = 1.3333334f;
+extern const float FLOAT_80330fc0 = 0.5f;
+extern const double DOUBLE_80330FC8 = 4503599627370496.0;
+extern const float FLOAT_80330FD0 = 2.0f;
+
 #define CRYSTAL_REFRACTION_SIZE 32.0f
 #define CRYSTAL_HALF_NEGATIVE -0.5f
 #define CRYSTAL_SCREEN_WIDTH 640.0f


### PR DESCRIPTION
## Summary
- Define the PAL sdata2 constants used by `pppCrystal.o` with their recovered symbol names.
- Keep the existing literal-shaped source expressions intact while giving the object real symbols for the constants at `FLOAT_80330fa8` through `FLOAT_80330FD0`.

## Evidence
- `ninja` passes and reports `build/GCCP01/main.dol: OK`.
- `build/GCCP01/report.json` keeps `main/pppCrystal` at code fuzzy `98.62556`, data matched `100.0`.
- `build/binutils/powerpc-eabi-nm -n build/GCCP01/src/pppCrystal.o` now shows `FLOAT_80330fa8`, `FLOAT_80330fac`, `FLOAT_80330fb0`, `FLOAT_80330fb4`, `FLOAT_80330fb8`, `FLOAT_80330fbc`, `FLOAT_80330fc0`, `DOUBLE_80330FC8`, and `FLOAT_80330FD0` as owned data symbols.

## Plausibility
- Values and names match `config/GCCP01/symbols.txt`.
- No address hardcoding or manual section forcing.
