### PR TITLE
Improve p_map drawAfter debug colors

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -933,8 +933,7 @@ void CMapPcs::drawAfterViewer()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -880,8 +880,7 @@ void CMapPcs::drawAfter()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Pass the debug bound color in CMapPcs::drawAfter as a direct CColor temporary.
- Apply the same source shape to CMapPcs::drawAfterViewer.
- This matches drawAfter exactly and improves the sibling viewer callback's constructor-return usage.

## Evidence
- Before: drawAfter__7CMapPcsFv was 99.933334%.
- After: drawAfter__7CMapPcsFv is 100.0%.
- Before: drawAfterViewer__7CMapPcsFv was 99.95556%.
- After: drawAfterViewer__7CMapPcsFv is 99.977776%.
- ninja passes; build/GCCP01/main.dol: OK.