### PR TITLE
Improve CTexture external TLUT setup

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -958,8 +958,8 @@ int CTexture::CheckName(char* name)
  */
 void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
 {
-    int tlutBase = reinterpret_cast<int>(tlutData);
     int load = loadToGX;
+    int tlutBase = reinterpret_cast<int>(tlutData);
     unsigned int numEntries;
     int offset;
 
@@ -967,22 +967,19 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
         tlutBase = reinterpret_cast<int>(m_tlutData);
     }
 
-    numEntries = 0x10;
-    if (static_cast<unsigned int>(m_format) == 9) {
-        numEntries = 0x100;
-    }
-
-    GXInitTlutObj(&m_tlutObj0, reinterpret_cast<void*>(tlutBase), GX_TL_IA8, numEntries);
+    GXInitTlutObj(&m_tlutObj0, reinterpret_cast<void*>(tlutBase), GX_TL_IA8,
+                  static_cast<u16>((static_cast<unsigned int>(m_format) == 9) ? 0x100 : 0x10));
 
     numEntries = 0x10;
     if (static_cast<unsigned int>(m_format) == 9) {
         numEntries = 0x100;
     }
+    GXTlutObj* tlutObj = &m_tlutObj1;
     offset = 0x10;
     if (static_cast<unsigned int>(m_format) == 9) {
         offset = 0x100;
     }
-    GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(tlutBase + offset * 2), GX_TL_IA8, numEntries);
+    GXInitTlutObj(tlutObj, reinterpret_cast<void*>(tlutBase + offset * 2), GX_TL_IA8, numEntries);
 
     if (load != 0) {
         GXLoadTlut(&m_tlutObj0, GX_TLUT0);


### PR DESCRIPTION
## Summary
- Reshape CTexture::SetExternalTlut so the first TLUT init uses the direct entry-count expression and the second TLUT init keeps the object pointer and entry count in source locals that better match the original codegen.
- Keeps the behavior unchanged while improving the textureman object diff.

## Evidence
- ninja: passes
- objdiff main/textureman SetExternalTlut__8CTextureFPvi: 82.039215% -> 98.92157%
- objdiff main/textureman .text: 86.97859% -> 87.46366%
- Neighbor checks unchanged: Create__8CTextureFR10CChunkFilePQ27CMemory6CStageP13CAmemCacheSetii remains 58.955555%, __dt__8CTextureFv remains 81.59091%

## Plausibility
- The change uses normal source-level locals and call expressions around TLUT setup, not hard-coded addresses or section forcing.
- The source still follows the Ghidra-observed control flow: fallback to m_tlutData, choose 0x10/0x100 entries for format 9, initialize both TLUT objects, then optionally load them to GX.