### PR TITLE
Improve pppYmLaser matching

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -231,7 +231,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 		**(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)step->m_stepValue * 4), work->m_shapeArg1,
 		work->m_shapeArg2, work->m_shapeArg0, *(short*)(step->m_payload + 0x2c));
 
-	for (u32 i = 0; i < (u32)step->m_payload[0x3a] + 1; i++) {
+	for (int i = 0; i < (int)(step->m_payload[0x3a] + 1); i++) {
 		int max = (int)step->m_payload[0x1e] - 2;
 
 		for (int j = max; (int)i <= j; j--) {
@@ -259,10 +259,11 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 			countDouble.u[0] = 0x43300000;
 			countDouble.u[1] = (u32)(int)(step->m_payload[0x3a] + 1) ^ 0x80000000;
 			indexDouble.u[0] = 0x43300000;
-			indexDouble.u[1] = (u32)(int)i ^ 0x80000000;
+			indexDouble.u[1] = (u32)i ^ 0x80000000;
 
-			double t = (FLOAT_80330de0 / (float)(countDouble.d - DOUBLE_80330dd8)) *
-				(float)(indexDouble.d - DOUBLE_80330dd8);
+			float count = countDouble.d - DOUBLE_80330dd8;
+			float index = indexDouble.d - DOUBLE_80330dd8;
+			float t = (FLOAT_80330de0 / count) * index;
 			if (GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(pppMngStPtr, (float)t, charaMtx) == 0) {
 				emptyHistory = 1;
 				continue;
@@ -417,11 +418,11 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	SetVtxFmt_POS_CLR_TEX__5CUtilFv(&gUtil);
 	GXLoadTexObj((GXTexObj*)(tex + 0x28), GX_TEXMAP0);
 
-	halfWidth = work->m_halfWidth;
 	length = work->m_length;
+	halfWidth = work->m_halfWidth;
 
 	pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &pppMngStPtr->m_matrix, &baseObj->m_localMatrix);
-	pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&mtxOut, (pppFMATRIX*)&ppvCameraMatrix0, &modelView);
+	pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&mtxOut, (pppFMATRIX*)&ppvCameraMatrix02, &modelView);
 	GXLoadPosMtxImm(mtxOut.value, 0);
 
 	GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT7, 4);
@@ -458,11 +459,11 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 		shapeMtx.value[0][0] = *(float*)(step->m_payload + 0x30) * pppMngStPtr->m_scale.x;
 		shapeMtx.value[1][1] = *(float*)(step->m_payload + 0x30) * pppMngStPtr->m_scale.y;
 		shapeMtx.value[2][2] = shapeMtx.value[0][0];
-		if (work->m_shapeRotation != kPppYmLaserOne) {
+		if (kPppYmLaserOne != work->m_shapeRotation) {
 			PSMTXRotRad(tempMtx, 'z', work->m_shapeRotation);
 			PSMTXConcat(shapeMtx.value, tempMtx, shapeMtx.value);
 		}
-		PSMTXMultVec(ppvCameraMatrix0, work->m_points, &shapePos);
+		PSMTXMultVec(ppvCameraMatrix02, work->m_points, &shapePos);
 		shapeMtx.value[0][3] = shapePos.x;
 		shapeMtx.value[1][3] = shapePos.y;
 		shapeMtx.value[2][3] = shapePos.z;
@@ -484,7 +485,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			GXLoadTexObj((GXTexObj*)(tex + 0x28), GX_TEXMAP0);
 		}
 
-		GXLoadPosMtxImm(ppvCameraMatrix0, GX_PNMTX0);
+		GXLoadPosMtxImm(ppvCameraMatrix02, GX_PNMTX0);
 		alphaMax = step->m_payload[0x2b];
 		alphaStep = (u8)((u32)alphaMax / step->m_payload[0x1e]);
 		colorBase = *(u32*)(step->m_payload + 0x28) & 0xFFFFFF00;
@@ -558,7 +559,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			tempMtx[2][2] = PSVECDistance(work->m_points, &work->m_origin);
 			PSMTXConcat(baseObj->m_localMatrix.value, tempMtx, tempMtx);
 			PSMTXConcat(pppMngStPtr->m_matrix.value, tempMtx, tempMtx);
-			PSMTXConcat(ppvCameraMatrix0, tempMtx, tempMtx);
+			PSMTXConcat(ppvCameraMatrix02, tempMtx, tempMtx);
 			shapePos.x = kPppYmLaserOne;
 			shapePos.y = kPppYmLaserOne;
 			shapePos.z = FLOAT_80330DC4;
@@ -582,14 +583,14 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 				tempMtx[0][3] = points[i].x;
 				tempMtx[1][3] = points[i].y;
 				tempMtx[2][3] = points[i].z;
-				PSMTXConcat(ppvCameraMatrix0, tempMtx, sphereMtx);
+				PSMTXConcat(ppvCameraMatrix02, tempMtx, sphereMtx);
 				Graphic.DrawSphere(sphereMtx, debugColor);
 			}
 
 			tempMtx[0][3] = work->m_origin.x;
 			tempMtx[1][3] = work->m_origin.y;
 			tempMtx[2][3] = work->m_origin.z;
-			PSMTXConcat(ppvCameraMatrix0, tempMtx, sphereMtx);
+			PSMTXConcat(ppvCameraMatrix02, tempMtx, sphereMtx);
 			Graphic.DrawSphere(sphereMtx, debugColor);
 			pppInitBlendMode();
 		}


### PR DESCRIPTION
## Summary
- Use signed frame-history iteration and explicit float temporaries in pppFrameYmLaser's node-frame interpolation path.
- Switch pppRenderYmLaser camera-space work to ppvCameraMatrix02, matching the target assembly references.
- Adjust render source ordering/comparison shape for closer codegen without changing behavior.

## Evidence
- ninja
- pppFrameYmLaser: 94.73089% -> 95.43425% (size remains 1312)
- pppRenderYmLaser: 65.573135% -> 65.65691% (size remains 2424)
- pppConstructYmLaser, pppConstruct2YmLaser, and pppDestructYmLaser remain 100% matched.

## Plausibility
- Changes are source-level control-flow, float-temporary, and camera-matrix corrections backed by the target assembly shape.
- No address hardcoding, section forcing, or generated ctor/dtor/vtable hacks.