### PR TITLE
Correct CUSBPcs base class

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,10 +2,10 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/system.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/usb.h"
 
-class CUSBPcs : public CProcess
+class CUSBPcs : public CSamplePcs
 {
 public:
     CUSBPcs();


### PR DESCRIPTION
## Summary
- Change `CUSBPcs` to derive from `CSamplePcs`, matching the target constructor path that initializes through the `CSamplePcs` vtable.
- This lets the compiler emit a more plausible class hierarchy and improves matched data for `main/p_usb`.

## Evidence
- `ninja` passes, including `build/GCCP01/main.dol: OK`.
- Full report matched data: `1095177 -> 1095285` (+108 bytes).
- `main/p_usb` matched data: `324 -> 432` bytes (`35.84071% -> 47.78761%`).
- Matched code bytes/functions are unchanged. `__sinit_p_usb_cpp` fuzzy score dips slightly because the current visible base constructor is emitted as a call, but the hierarchy now matches the target `CSamplePcs` base initialization.