### PR TITLE
Improve pppYmLaser frame matching

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -94,13 +94,6 @@ struct pppYmLaserColorData {
 	pppCVECTOR m_color;
 };
 
-struct pppYmLaserBaseObject {
-	s32 m_graphId;
-	u8 m_pad4[0x0C];
-	pppFMATRIX m_localMatrix;
-	pppFMATRIX m_drawMatrix;
-};
-
 union pppYmLaserDoubleBits {
 	double d;
 	u32 u[2];
@@ -198,7 +191,6 @@ extern "C" void pppDestructYmLaser(pppYmLaser* laser, _pppCtrlTable* ctrlTable)
  */
 extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtrlTable* data)
 {
-	pppYmLaserBaseObject* baseObj = (pppYmLaserBaseObject*)laser;
 	pppYmLaserWork* work;
 	Vec localA;
 	Vec localB;
@@ -219,11 +211,11 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 	}
 
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-		(_pppPObject*)baseObj, step->m_graphId, work->m_halfWidth, work->m_graphValue2, work->m_graphValue3,
+		(_pppPObject*)laser, step->m_graphId, work->m_halfWidth, work->m_graphValue2, work->m_graphValue3,
 		*(float*)(step->m_payload + 0x10),
 		*(float*)(step->m_payload + 0x14), *(float*)(step->m_payload + 0x18));
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-		(_pppPObject*)baseObj, step->m_graphId, work->m_lengthStep, work->m_graphValue0, work->m_graphValue1,
+		(_pppPObject*)laser, step->m_graphId, work->m_lengthStep, work->m_graphValue0, work->m_graphValue1,
 		*(float*)(step->m_payload + 4),
 		*(float*)(step->m_payload + 8), *(float*)(step->m_payload + 0xc));
 
@@ -231,7 +223,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 		**(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)step->m_stepValue * 4), work->m_shapeArg1,
 		work->m_shapeArg2, work->m_shapeArg0, *(short*)(step->m_payload + 0x2c));
 
-	for (u32 i = 0; i < (u32)step->m_payload[0x3a] + 1; i++) {
+	for (int i = 0; i < (int)(step->m_payload[0x3a] + 1); i++) {
 		int max = (int)step->m_payload[0x1e] - 2;
 
 		for (int j = max; (int)i <= j; j--) {
@@ -243,7 +235,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 		localB.z = work->m_length;
 
 		if (i == 0) {
-			PSMTXConcat(pppMngStPtr->m_matrix.value, baseObj->m_localMatrix.value, tempMtx);
+			PSMTXConcat(pppMngStPtr->m_matrix.value, laser->m_localMatrix.value, tempMtx);
 			work->m_origin.x = tempMtx[0][3];
 			work->m_origin.y = tempMtx[1][3];
 			work->m_origin.z = tempMtx[2][3];
@@ -257,17 +249,18 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 			pppYmLaserDoubleBits indexDouble;
 
 			countDouble.u[0] = 0x43300000;
-			countDouble.u[1] = (u32)(int)(step->m_payload[0x3a] + 1) ^ 0x80000000;
+			countDouble.u[1] = (u32)(step->m_payload[0x3a] + 1) ^ 0x80000000;
 			indexDouble.u[0] = 0x43300000;
-			indexDouble.u[1] = (u32)(int)i ^ 0x80000000;
+			indexDouble.u[1] = (u32)i ^ 0x80000000;
 
-			double t = (FLOAT_80330de0 / (float)(countDouble.d - DOUBLE_80330dd8)) *
-				(float)(indexDouble.d - DOUBLE_80330dd8);
-			if (GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(pppMngStPtr, (float)t, charaMtx) == 0) {
+			float count = (float)(countDouble.d - DOUBLE_80330dd8);
+			float index = (float)(indexDouble.d - DOUBLE_80330dd8);
+			float t = (FLOAT_80330de0 / count) * index;
+			if (GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f(pppMngStPtr, t, charaMtx) == 0) {
 				emptyHistory = 1;
 				continue;
 			} else {
-				PSMTXConcat(charaMtx, baseObj->m_localMatrix.value, charaMtx);
+				PSMTXConcat(charaMtx, laser->m_localMatrix.value, charaMtx);
 				PSMTXMultVec(charaMtx, &localB, &work->m_points[i]);
 			}
 		}
@@ -331,7 +324,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 					created = 0;
 				} else {
 					created = pppCreatePObject(pppMngStPtr, dataVal);
-					*(_pppPObject**)((u8*)created + 4) = (_pppPObject*)baseObj;
+					*(_pppPObject**)((u8*)created + 4) = (_pppPObject*)laser;
 				}
 
 				Vec* createdPos = (Vec*)((u8*)created + *(int*)step->m_payload + 0x80);
@@ -361,7 +354,6 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
  */
 extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtrlTable* data)
 {
-	pppYmLaserBaseObject* baseObj = (pppYmLaserBaseObject*)laser;
 	int colorOffset = data->m_serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	pppYmLaserWork* work = (pppYmLaserWork*)((u8*)laser + 0x80 + data->m_serializedDataOffsets[2]);
@@ -398,7 +390,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	pppSetBlendMode(step->m_payload[0x1c]);
 	_GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(1, 0, 0);
 	pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
-		&colorData->m_color, &baseObj->m_localMatrix, kPppYmLaserOne, step->m_payload[0x39],
+		&colorData->m_color, &laser->m_localMatrix, kPppYmLaserOne, step->m_payload[0x39],
 		step->m_payload[0x38], step->m_payload[0x1c], 0, 1, 1, 0);
 	GXSetNumTevStages(1);
 	GXSetNumTexGens(1);
@@ -420,7 +412,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	halfWidth = work->m_halfWidth;
 	length = work->m_length;
 
-	pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &pppMngStPtr->m_matrix, &baseObj->m_localMatrix);
+	pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&modelView, &pppMngStPtr->m_matrix, &laser->m_localMatrix);
 	pppMulMatrix__FR10pppFMATRIX10pppFMATRIX10pppFMATRIX(&mtxOut, (pppFMATRIX*)&ppvCameraMatrix0, &modelView);
 	GXLoadPosMtxImm(mtxOut.value, 0);
 
@@ -556,7 +548,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			tempMtx[0][0] = pppMngStPtr->m_previousPositionFields.m_paramD * *(float*)(step->m_payload + 0x24);
 			tempMtx[1][1] = tempMtx[0][0];
 			tempMtx[2][2] = PSVECDistance(work->m_points, &work->m_origin);
-			PSMTXConcat(baseObj->m_localMatrix.value, tempMtx, tempMtx);
+			PSMTXConcat(laser->m_localMatrix.value, tempMtx, tempMtx);
 			PSMTXConcat(pppMngStPtr->m_matrix.value, tempMtx, tempMtx);
 			PSMTXConcat(ppvCameraMatrix0, tempMtx, tempMtx);
 			shapePos.x = kPppYmLaserOne;
@@ -572,7 +564,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			debugColor.a = 0xFF;
 			Graphic.DrawSphere(tempMtx, debugColor);
 
-			GXLoadPosMtxImm(baseObj->m_drawMatrix.value, GX_PNMTX0);
+			GXLoadPosMtxImm(laser->m_drawMatrix.value, GX_PNMTX0);
 			for (i = 0; (int)i < (int)(u32)step->m_payload[0x1e]; i++) {
 				if ((points[i].x == kPppYmLaserOne) && (points[i].y == kPppYmLaserOne) &&
 					(points[i].z == kPppYmLaserOne)) {


### PR DESCRIPTION
## Summary
- Remove the redundant local pppYmLaserBaseObject alias and use the existing pppYmLaser matrix fields directly.
- Use signed history indexing in pppFrameYmLaser to match the target loop compares.
- Split the frame interpolation math into float temporaries so the conversion/rounding shape is closer to the target.

## Objdiff Evidence
- main/pppYmLaser .text: 76.05204% -> 76.73808%
- pppFrameYmLaser: 94.73089% -> 96.97859%
- pppRenderYmLaser: unchanged at 65.64761%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppFrameYmLaser
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppRenderYmLaser

## Plausibility
The changes remove a duplicate struct alias in favor of the real object layout already declared in the header, preserve normal member access, and make the interpolation expression explicitly use the float values consumed by GetCharaNodeFrameMatrix. No addresses, manual sections, generated ctor/dtor code, or fake symbols were introduced.