### PR TITLE
Improve pppShape texture cache loops

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -75,10 +75,10 @@ void pppCalcFrameShape(long* animData, short& currentFrame, short& drawFrame, sh
  */
 void pppGetShapeUV(long* animData, short frameIndex, Vec2d& minUv, Vec2d& maxUv, int shapeIndex)
 {
-    int shapeBase = *(short*)((int)animData + frameIndex * 8 + 0x10);
-    int shapeEntry = *(int*)((int)animData + shapeBase + 0xc + shapeIndex * 8);
-    float* minUvF = (float*)&minUv;
-    float* maxUvF = (float*)&maxUv;
+    float* minUvF = reinterpret_cast<float*>(&minUv);
+    float* maxUvF = reinterpret_cast<float*>(&maxUv);
+    int shapeEntry =
+        *(int*)((int)animData + *(short*)((int)animData + frameIndex * 8 + 0x10) + 0xc + shapeIndex * 8);
     const float uvScale = FLOAT_80330108;
 
     minUvF[0] = (float)*(short*)(shapeEntry + 0x13) * uvScale;
@@ -117,33 +117,27 @@ void pppGetShapePos(long* animData, short frameIndex, Vec& minPos, Vec& maxPos, 
  */
 void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
 {
-    short shapeOffset;
-    char* currentFrame;
-    int frameIndex;
     char* animData;
+    char* currentFrame;
+    unsigned char textureUsed[0x100];
     unsigned char* texturePtr;
     unsigned int textureIndex;
-    unsigned char textureUsed[0x100];
+    int frameIndex;
 
     animData = (char*)shapeSt->m_animData;
     memset(textureUsed, 0, sizeof(textureUsed));
 
     currentFrame = animData;
-    for (frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex = frameIndex + 1) {
-        unsigned char* shapeEntry;
-        char* shapeBase;
-        int shapeStep;
+    for (frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex++) {
+        short shapeOffset = *(short*)((int)currentFrame + 0x10);
+        int shapeEntryOffset = 0;
         int shapeIndex;
 
-        shapeOffset = *(short*)((int)currentFrame + 0x10);
-        shapeBase = animData + shapeOffset;
-        shapeIndex = 0;
-        shapeStep = 0;
-        while (shapeIndex < *(short*)(shapeBase + 2)) {
-            shapeEntry = (unsigned char*)(shapeBase + 8 + shapeStep);
-            shapeIndex += 1;
-            shapeStep += 8;
-            textureUsed[shapeEntry[2]] = 1;
+        for (shapeIndex = 0; shapeIndex < *(short*)((int)animData + shapeOffset + 2); shapeIndex++) {
+            int shapeEntry = shapeEntryOffset + shapeOffset;
+
+            shapeEntryOffset += 8;
+            textureUsed[(unsigned char)*(char*)((int)animData + shapeEntry + 10)] = 1;
         }
         currentFrame += 8;
     }
@@ -170,33 +164,27 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
  */
 void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
 {
-    short shapeOffset;
-    char* currentFrame;
-    int frameIndex;
     char* animData;
+    char* currentFrame;
+    unsigned char textureUsed[0x100];
     unsigned char* texturePtr;
     unsigned int textureIndex;
-    unsigned char textureUsed[0x100];
+    int frameIndex;
 
     animData = (char*)shapeSt->m_animData;
     memset(textureUsed, 0, sizeof(textureUsed));
 
     currentFrame = animData;
-    for (frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex = frameIndex + 1) {
-        unsigned char* shapeEntry;
-        char* shapeBase;
-        int shapeStep;
+    for (frameIndex = 0; frameIndex < *(short*)((int)animData + 6); frameIndex++) {
+        short shapeOffset = *(short*)((int)currentFrame + 0x10);
+        int shapeEntryOffset = 0;
         int shapeIndex;
 
-        shapeOffset = *(short*)((int)currentFrame + 0x10);
-        shapeBase = animData + shapeOffset;
-        shapeIndex = 0;
-        shapeStep = 0;
-        while (shapeIndex < *(short*)(shapeBase + 2)) {
-            shapeEntry = (unsigned char*)(shapeBase + 8 + shapeStep);
-            shapeIndex += 1;
-            shapeStep += 8;
-            textureUsed[shapeEntry[2]] = 1;
+        for (shapeIndex = 0; shapeIndex < *(short*)((int)animData + shapeOffset + 2); shapeIndex++) {
+            int shapeEntry = shapeEntryOffset + shapeOffset;
+
+            shapeEntryOffset += 8;
+            textureUsed[(unsigned char)*(char*)((int)animData + shapeEntry + 10)] = 1;
         }
         currentFrame += 8;
     }


### PR DESCRIPTION
## Summary
- rewrite `pppCacheDumpShapeTexture` and `pppCacheLoadShapeTexture` to use the anim-data offset loop structure indicated by the PAL decomp
- keep the logic centered on real shape entry offsets instead of the previous pointer-walk variant
- preserve buildability with no linkage hacks or section forcing

## Evidence
- `pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet`: `85.9%` -> `91.98333%`
- `pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`: `85.9%` -> `91.98333%`
- unit `.text` match for `main/pppShape`: `95.61209%` -> `97.45088%`
- `ninja` succeeds

## Why this is plausible source
- the new loops follow the underlying animation data layout directly: frame table -> shape offset -> 8-byte shape entries -> texture index byte
- this improves code generation by fixing the surrounding data access pattern rather than introducing compiler-specific tricks
- no fake symbols, forced sections, or manual ctor/dtor/vtable work were introduced