### PR TITLE
Fix YmDeformationMdl zero constant linkage

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -52,7 +52,7 @@ extern float FLOAT_80330D9C;
 extern float FLOAT_80330DA0;
 extern float FLOAT_80330DA4;
 extern float FLOAT_80330DA8;
-extern const float FLOAT_80330dac = 0.0f;
+extern float FLOAT_80330dac = 0.0f;
 
 static inline Mtx& CameraMatrix()
 {


### PR DESCRIPTION
## Summary
- Change FLOAT_80330dac in pppYmDeformationMdl from a const definition to a normal external float definition.
- This prevents MWCC from folding reads to a private local zero literal where the target uses the named sdata2 symbol.

## Objdiff evidence
Unit: main/pppYmDeformationMdl

Before:
- pppRenderYmDeformationMdl: 99.537575%
- pppConstruct2YmDeformationMdl: 99.583336%
- pppConstructYmDeformationMdl: 99.6875%

After:
- pppRenderYmDeformationMdl: 99.580925%
- pppConstruct2YmDeformationMdl: 100.0%
- pppConstructYmDeformationMdl: 100.0%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o -