### PR TITLE
Match FunnyShape viewer spinner format

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -404,7 +404,7 @@ void CFunnyShapePcs::drawViewer()
     Vec eye = {0.0f, 0.0f, 0.0f};
     Vec at = {0.0f, 0.0f, 0.0f};
     Vec up = {0.0f, 1.0f, 0.0f};
-    static const char s_funnyShapeFmt[] = "FunnyShape %c";
+    static const char s_funnyShapeFmt[] = "FunnyShape [%c]";
 
     C_MTXOrtho(ortho, kFunnyShapeNdcMax, kFunnyShapeNdcMin, kFunnyShapeNdcMin, kFunnyShapeNdcMax, kFunnyShapeNdcMax, kFunnyShapeOrthoFarZ);
     GXSetProjection(ortho, GX_ORTHOGRAPHIC);


### PR DESCRIPTION
## Summary
- Correct the FunnyShape viewer spinner format string from `FunnyShape %c` to `FunnyShape [%c]`.
- This matches the original rodata string used by `drawViewer__14CFunnyShapePcsFv`.

## Evidence
- `ninja` completes successfully.
- `main/p_FunnyShape` rodata improved from a mismatched `[.rodata-0]` entry at 98.4127% to no remaining rodata mismatch in objdiff.
- Current remaining mismatches are in generated/static-init or code areas: `.text` 98.177666%, extab/extabindex, and a secondary data/vtable block.

## Plausibility
- The corrected text matches the shipped rodata spelling `FunnyShape [%c]` and is a normal UI/debug display string, not compiler coaxing.