### PR TITLE
Fix CFlatRuntime constructor state layout

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -31,8 +31,8 @@ public:
 	class CObject
 	{
 	public:
-		CObject();
-		~CObject();
+		CObject() {}
+		~CObject() {}
 		void onNewFinished();
 
 		unsigned int m_id;         // 0x0

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -50,14 +50,15 @@ struct CFlatRuntimeLifecycleProxy
 CFlatRuntime::CFlatRuntime()
 {
 	unsigned char* const self = reinterpret_cast<unsigned char*>(this);
+	const u32 clearBit = 0;
 
 	*reinterpret_cast<void***>(self) = __vt__12CFlatRuntime;
-	*reinterpret_cast<void***>(self + 0x1204) = __vt__Q212CFlatRuntime7CObject;
-	self[0x123C] &= 0xEF;
-	*reinterpret_cast<void***>(self + 0x124C) = __vt__Q212CFlatRuntime7CObject;
-	self[0x1284] &= 0xEF;
-	self[0x1294] = 0;
-	self[0x1298] = 1;
+	*reinterpret_cast<void***>(self + 0x914) = __vt__Q212CFlatRuntime7CObject;
+	self[0x904] = static_cast<u8>((self[0x904] & 0xEF) | (clearBit << 4));
+	*reinterpret_cast<void***>(self + 0x960) = __vt__Q212CFlatRuntime7CObject;
+	self[0x950] = static_cast<u8>((self[0x950] & 0xEF) | (clearBit << 4));
+	*reinterpret_cast<u32*>(self + 0x970) = clearBit;
+	*reinterpret_cast<u32*>(self + 0x1298) = 1;
 
 	clear();
 }
@@ -465,7 +466,7 @@ void CFlatRuntime::Create(void* filePtr)
 	}
 
 	createObject(-1);
-	self[0x1294] = 1;
+	*reinterpret_cast<u32*>(self + 0x970) = 1;
 	*reinterpret_cast<u8*>(self + 0x974) = 1;
 }
 
@@ -844,7 +845,7 @@ CFlatRuntime::CObject* CFlatRuntime::createObject(int classIndex)
 
 	u32 allowKeep = 1;
 	if (classIndex == -1) {
-		allowKeep = static_cast<u32>(__cntlzw(*reinterpret_cast<u32*>(self + 0x1294))) >> 5 & 0xFF;
+		allowKeep = static_cast<u32>(__cntlzw(*reinterpret_cast<u32*>(self + 0x970))) >> 5 & 0xFF;
 	}
 
 	u8* defs = 0;


### PR DESCRIPTION
## Summary
- inline `CFlatRuntime::CObject`'s empty ctor/dtor so `CFlatRuntime` stops emitting a spurious member-construction call
- fix `CFlatRuntime` constructor setup to write the runtime object/vtable state at the observed PAL offsets
- move `m_isCreated` handling onto the 0x970 word used by `Create` and `createObject`

## Evidence
- full rebuild succeeds with `ninja`
- overall progress improved from `491964` to `492068` matched code bytes and from `3099` to `3100` matched functions
- game code improved from `156784` to `156888` matched code bytes and from `1577` to `1578` matched functions
- `__ct__12CFlatRuntimeFv` improved from about `45.24%` to `94.48%` in objdiff

## Plausibility
These changes remove a non-original member ctor call and align the runtime's created-state storage and constructor writes with the PAL decomp/layout rather than preserving the previous offset drift.