### PR TITLE
Improve pppKeShpTail3X zero trail handling

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -236,7 +236,7 @@ void pppKeShpTail3XDraw(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* p
     trailStep = step->m_stepDistance * pppMngStPtr->m_scale.x;
     trailStepDelta = trailStep * (shapeScaleStep / shapeScale);
     if (trailStep == zero) {
-        return;
+        count = 0;
     }
 
     currentIndex = work->m_head;


### PR DESCRIPTION
## Summary
- Match pppKeShpTail3XDraw's zero trail-step handling more closely to target control flow by zeroing the draw count instead of returning immediately.
- Keeps the no-draw behavior while allowing the surrounding setup/control flow to match more closely.

## Evidence
- ninja
- ninja build/GCCP01/main.dol
- objdiff main/pppKeShpTail3X .text: 77.00449% -> 77.04497%
- objdiff pppKeShpTail3XDraw: 61.019817% -> 61.088413%