### PR TITLE
Match p_usb read poll sbss order

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -6,8 +6,8 @@
 #include "string.h"
 #include "types.h"
 
-char s_usbReadPollInitialized;
 int s_usbReadPollFrameCounter;
+char s_usbReadPollInitialized;
 extern "C" void create__7CUSBPcsFv(CUSBPcs*);
 extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);


### PR DESCRIPTION
## Summary
- Reordered the p_usb read-poll .sbss definitions so s_usbReadPollFrameCounter precedes s_usbReadPollInitialized.
- This matches the PAL symbol order in config/GCCP01/symbols.txt and the existing declaration order in include/ffcc/p_usb.h.

## Evidence
- ninja completes successfully.
- build/tools/objdiff-cli diff -p . -u main/p_usb -o - shows the compiled current symbols now match target order:
  - target: s_usbReadPollFrameCounter at .sbss+0, size 4
  - target: s_usbReadPollInitialized at .sbss+4, size 1
  - current: s_usbReadPollFrameCounter at .sbss+0, size 4
  - current: s_usbReadPollInitialized at .sbss+4, size 1

## Notes
- Section percentages are unchanged because these are zero-filled .sbss objects, but the source definition order now matches the PAL layout instead of relying on identical zero bytes hiding the symbol-order mismatch.
- I also checked nearby p_usb vtable/static-initializer differences; those need a real C++ RTTI/vtable ownership fix and were left untouched.