### PR TITLE
Clean up duplicate pppBlurChara constant emission

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -61,8 +61,6 @@ extern float FLOAT_80331048;
 extern float FLOAT_8033104c;
 extern float FLOAT_80331050;
 extern float FLOAT_80331054;
-extern const double DOUBLE_80330FE8 = 3.0;
-
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 
 static inline float CameraLookAtX()


### PR DESCRIPTION
## Summary
- remove the unused local `DOUBLE_80330FE8` definition from `src/pppBlurChara.cpp`
- stop `pppBlurChara.o` from emitting an extra duplicate constant in `.sdata2`
- keep the source closer to the shared constant ownership already used by other PPP units

## Evidence
- rebuilt with `ninja`
- `build/GCCP01/src/pppBlurChara.o` `.sdata2` shrank from `0x10` bytes to `0x08`
- `objdiff` for `main/pppBlurChara` no longer shows the previous extra 8-byte `.sdata2` payload on `BlurChara_AfterDrawModelCallback__FPQ26CChara6CModelPvPv`

## Plausibility
- the removed definition was unused in this file
- keeping a duplicate file-local definition was adding object data without helping codegen, so removing it is cleaner and more plausible original source