### PR TITLE
Improve CGraphic::makeSphere trig calls

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1081,14 +1081,14 @@ void CGraphic::makeSphere()
 
     for (int ring = 0; ring < 5; ring++) {
         float pitch = (3.1415927f * (float)(ring + 1)) / 6.0f;
-        float x = cosf(pitch);
-        float radius = sinf(pitch);
+        float x = cos(pitch);
+        float radius = sin(pitch);
 
         for (int seg = 0; seg < 8; seg++) {
             float yaw = (6.2831855f * (float)seg) / 8.0f;
             vertices[vertexCount * 3 + 0] = x;
-            vertices[vertexCount * 3 + 1] = radius * sinf(yaw);
-            vertices[vertexCount * 3 + 2] = radius * cosf(yaw);
+            vertices[vertexCount * 3 + 1] = radius * sin(yaw);
+            vertices[vertexCount * 3 + 2] = radius * cos(yaw);
             vertexCount++;
         }
     }


### PR DESCRIPTION
## Summary
- Use double-precision sin/cos calls in CGraphic::makeSphere, matching the shape shown in the Ghidra decompilation more closely than the prior sinf/cosf calls.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/graphic -o -
  - makeSphere__8CGraphicFv: 62.911034% -> 63.323845%
  - main/graphic .text: 79.22677% -> 79.25722%
  - Checked neighboring selected targets: RenderBlur__8CGraphicFiUcUcUcUcs and CreateSmallBackTexture__8CGraphicFPvP9_GXTexObjll12_GXTexFilter9_GXTexFmtUl unchanged.

## Plausibility
- The PAL Ghidra decompilation for makeSphere__8CGraphicFv shows sin/cos style double-returning calls in the sphere vertex generation loops, so this is a source-level correction rather than a layout hack.
