### PR TITLE
Improve LocationTitle frame matching

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -208,6 +208,29 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     s32* serializedOffsets;
     LocationTitle2Work* work;
     LocationTitle2ColorBlock* colorData;
+    LocationTitle2Particle* particles;
+    CChara::CModel* model;
+    LocationTitle2ModelRaw* modelRaw;
+    int nodeIndex;
+    u8* node;
+    float zOffset;
+    CCharaPcs::CHandle* handle;
+    CCharaPcs::CHandle* ownerHandle;
+    CGObject* owner;
+    CChara::CModel* handleModel;
+    Mtx nodeMtx;
+    int nextCount;
+    Vec stepDir;
+    Vec interp[21];
+    int startIndex;
+    int inserted;
+    float stepScale;
+    Vec* startPos;
+    Vec* interpRead;
+    Vec* interpWrite;
+    Vec scaled;
+    float t;
+    LocationTitle2Particle* dst;
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -234,13 +257,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     }
 
     if (work->m_particles == 0) {
-        LocationTitle2Particle* particles;
-        CChara::CModel* model;
-        LocationTitle2ModelRaw* modelRaw;
-        int nodeIndex;
-        u8* node;
-        float zOffset;
-
         work->m_particles = pppMemAlloc__FUlPQ27CMemory6CStagePci(
             unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp,
             0x70);
@@ -249,10 +265,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
 
         model = 0;
         {
-            CCharaPcs::CHandle* handle;
-            CCharaPcs::CHandle* ownerHandle;
-            CGObject* owner;
-
             owner = ((pppMngStLocationTitle2Raw*)pppMngStPtr)->m_charaObj;
             handle = 0;
             ownerHandle = owner->m_charaModelHandle;
@@ -261,8 +273,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
             }
 
             {
-                CChara::CModel* handleModel;
-
                 handleModel = handle->m_model;
                 if (handleModel != 0) {
                     model = handleModel;
@@ -276,8 +286,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         zOffset = 1.0f;
 
         for (int frameIndex = 0; frameIndex < modelRaw->m_anim->m_frameCount; frameIndex++) {
-            Mtx nodeMtx;
-
             CalcBind__Q26CChara5CNodeFPQ26CChara6CModel(node, model);
             SetFrame__Q26CChara6CModelFf((float)frameIndex, model);
             CalcMatrix__Q26CChara6CModelFv(model);
@@ -298,7 +306,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
             work->m_count++;
 
             {
-                int nextCount = (int)work->m_count + 1;
+                nextCount = (int)work->m_count + 1;
 
                 if (nextCount >= unkB->m_maxCount) {
                     return;
@@ -306,15 +314,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
             }
 
             if (work->m_count > 1) {
-                Vec stepDir;
-                Vec interp[21];
-                int startIndex;
-                int inserted;
-                float stepScale;
-                Vec* startPos;
-                Vec* interpRead;
-                Vec* interpWrite;
-
                 startIndex = (int)work->m_count - 2;
                 inserted = 0;
                 startPos = &particles[startIndex].m_pos;
@@ -324,9 +323,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                 interpWrite = interpRead;
 
                 for (int i = 0; i < unkB->m_stepCount; i++) {
-                    Vec scaled;
-                    float t;
-
                     t = stepScale * (float)(i + 1);
                     PSVECScale(&stepDir, &scaled, t);
                     PSVECAdd(startPos, &scaled, interpWrite);
@@ -334,7 +330,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                     work->m_count++;
 
                     {
-                        int nextCount = (int)work->m_count + 1;
+                        nextCount = (int)work->m_count + 1;
 
                         if (nextCount >= unkB->m_maxCount) {
                             break;
@@ -348,8 +344,6 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                               particles[startIndex + 1].m_pos);
 
                 for (int i = 0; i < inserted; i++) {
-                    LocationTitle2Particle* dst;
-
                     dst = &particles[startIndex + (i + 1)];
                     interpRead->z += zOffset;
                     pppCopyVector(dst->m_pos, *interpRead);

--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -135,6 +135,24 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
     int graphFrame;
     long* shapeTable;
     LocationTitleParticle* particles;
+    LocationTitleParticle* particle;
+    float zero;
+    int randomValue;
+    s16 shapeCount;
+    s16 shape;
+    pppFMATRIX resultMatrix;
+    Vec subVec;
+    Vec interp[50];
+    int startIndex;
+    int inserted;
+    float stepScale;
+    Vec* startPos;
+    Vec* interpRead;
+    Vec* interpWrite;
+    Vec scaled;
+    float t;
+    int nextCount;
+    LocationTitleParticle* dst;
 
     if (gPppCalcDisabled != 0) {
         return;
@@ -162,9 +180,6 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
     }
 
     if (work->m_particles == NULL) {
-        LocationTitleParticle* particle;
-        float zero;
-
         work->m_particles = pppMemAlloc__FUlPQ27CMemory6CStagePci(
             param_2->m_maxCount * sizeof(LocationTitleParticle), pppEnvStPtr->m_stagePtr,
             const_cast<char*>(s_pppLocationTitle_cpp_801DB510), 0x6d);
@@ -172,10 +187,6 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
         particle = (LocationTitleParticle*)work->m_particles;
 
         for (int i = 0; i < param_2->m_maxCount; i++) {
-            int randomValue;
-            s16 shapeCount;
-            s16 shape;
-
             particle->m_pos.x = zero;
             particle->m_pos.y = zero;
             particle->m_pos.z = zero;
@@ -197,8 +208,6 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
     if (work->m_count + 1 < param_2->m_maxCount) {
         graphFrame = pppLocationTitle->m_graphId / 0x1000;
         if (graphFrame >= (int)param_2->m_spawnFrame) {
-            pppFMATRIX resultMatrix;
-
             pppMulMatrix(resultMatrix, pppMngStPtr->m_matrix, pppLocationTitle->m_localMatrix);
 
             particles[work->m_count].m_pos.x = resultMatrix.value[0][3];
@@ -216,15 +225,6 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
             work->m_count++;
 
             if (work->m_count > 1) {
-                Vec subVec;
-                Vec interp[50];
-                int startIndex;
-                int inserted;
-                float stepScale;
-                Vec* startPos;
-                Vec* interpRead;
-                Vec* interpWrite;
-
                 startIndex = (int)work->m_count - 2;
                 inserted = 0;
                 startPos = &particles[startIndex].m_pos;
@@ -234,9 +234,6 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
                 interpWrite = interpRead;
 
                 for (int i = 0; i < param_2->m_stepCount; i++) {
-                    Vec scaled;
-                    float t;
-
                     t = stepScale * (float)(i + 1);
                     PSVECScale(&subVec, &scaled, t);
                     PSVECAdd(startPos, &scaled, interpWrite);
@@ -244,7 +241,7 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
                     work->m_count++;
 
                     {
-                        int nextCount = work->m_count + 1;
+                        nextCount = work->m_count + 1;
 
                         if (nextCount >= param_2->m_maxCount) {
                             break;
@@ -258,8 +255,6 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
                               particles[startIndex + 1].m_pos);
 
                 for (int i = 0; i < inserted; i++) {
-                    LocationTitleParticle* dst;
-
                     dst = &particles[startIndex + (i + 1)];
 
                     pppCopyVector(dst->m_pos, *interpRead);


### PR DESCRIPTION
## Summary
- Hoisted working locals in pppFrameLocationTitle and pppFrameLocationTitle2 to better match the original Metrowerks local lifetime/register allocation shape.
- Keeps generated function sizes unchanged while reducing instruction argument mismatches in both LocationTitle frame functions.

## Objdiff evidence
- main/pppLocationTitle pppFrameLocationTitle: 98.27361% -> 98.35505%, size 1228b unchanged, mismatches 87 -> 83.
- main/LocationTitle2 pppFrameLocationTitle2: 94.66776% -> 94.79934%, size 1216b unchanged, mismatches 143 -> 136.

## Verification
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o /tmp/final_pppLocationTitle.json pppFrameLocationTitle
- build/tools/objdiff-cli diff -p . -u main/LocationTitle2 -o /tmp/final_LocationTitle2.json pppFrameLocationTitle2

## Plausibility
- This keeps the existing control flow and data accesses intact, but uses a top-local declaration style consistent with decompiled Metrowerks-era C/C++ and the Ghidra local layout for these functions.