### PR TITLE
Match CMenuPcs::ItemCtrl

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -417,7 +417,7 @@ bool CMenuPcs::ItemOpen()
  */
 int CMenuPcs::ItemCtrl()
 {
-    short sVar1;
+    int sVar1;
     int iVar2;
     int iVar3;
 


### PR DESCRIPTION
## Summary
- Change the local copy of item menu mode in CMenuPcs::ItemCtrl from short to int.
- This avoids redundant sign-extension around the mode checks and matches the target codegen.

## Evidence
- ninja builds successfully.
- objdiff: ItemCtrl__8CMenuPcsFv improved from 97.53846% to 100.0% and remains 260 bytes.
- main/menu_item .text is now 64.14401% matched.

## Plausibility
- The value is loaded with lha and used as an int for comparisons; keeping the local as int reflects the target codegen without introducing manual layout or linkage hacks.