### PR TITLE
Use AStar directly in runtime and object callers

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -24,8 +24,6 @@
 
 class CFont;
 
-extern "C" void reset__6CAStarFv(void*);
-extern "C" void drawAStar__6CAStarFv(void*);
 extern "C" void StaticFrame__10CGCharaObjFv();
 extern "C" void CheckGameOver__10CGPartyObjFv();
 extern "C" void DrawDebug__8CGObjectFP5CFont(CGObject*, CFont*);
@@ -1124,7 +1122,7 @@ void CFlatRuntime2::Frame(int arg0, int mode)
 	GXClearVtxDesc();
 	GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
 	GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
-	drawAStar__6CAStarFv(DbgMenuPcsRaw() + 0x2A5C);
+	AStar.drawAStar();
 
 	CFlatRuntime::CObject* const root =
 		reinterpret_cast<CFlatRuntime::CObject*>(reinterpret_cast<u8*>(this) + 0x1204);
@@ -2794,7 +2792,7 @@ void CFlatRuntime2::resetChangeScript()
 	*reinterpret_cast<u32*>(PadRaw() + 0x1C8) = 1;
 	*reinterpret_cast<u32*>(GraphicsPcsRaw() + 0x44) = 0;
 	*reinterpret_cast<u32*>(CameraPcsRaw() + 0x434) = 1;
-	reset__6CAStarFv(DbgMenuPcsRaw() + 0x2A5C);
+	AStar.reset();
 }
 
 /*

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/charaobj.h"
+#include "ffcc/astar.h"
 #include "ffcc/fontman.h"
 #include "ffcc/gobjwork.h"
 #include "ffcc/linkage.h"
@@ -36,7 +37,6 @@ extern "C" void PutParticleWork__13CFlatRuntime2Fv(void*);
 extern "C" int intToClass__13CFlatRuntime2Fi(void*, int);
 extern "C" void IgnoreParticle__13CFlatRuntime2FiPQ212CFlatRuntime7CObject(void*, int, void*);
 extern "C" void pppEndPart__8CPartMngFi(void*, int);
-extern "C" unsigned char calcSpecialPolygonGroup__6CAStarFP3Vec(void*, Vec*);
 extern "C" unsigned char m_boss__8CGMonObj[];
 extern char SoundBuffer[];
 
@@ -711,8 +711,7 @@ void CGCharaObj::onFramePreCalc()
 	if ((DbgMenuPcs.GetDbgFlagsRaw() & 1) == 0) {
 		m_aStarGroupId = static_cast<unsigned short>(static_cast<unsigned char>(m_lastBgGroup));
 	} else {
-		m_aStarGroupId = static_cast<unsigned short>(
-			calcSpecialPolygonGroup__6CAStarFP3Vec(reinterpret_cast<unsigned char*>(&DbgMenuPcs) + 0x2A5C, &m_worldPosition));
+		m_aStarGroupId = static_cast<unsigned short>(AStar.calcSpecialPolygonGroup(&m_worldPosition));
 	}
 }
 

--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -23,7 +23,6 @@ extern "C" char DAT_80331a4c[];
 extern "C" void __ptmf_scall(...);
 extern "C" int calcCastTime__10CGCharaObjFi(CGCharaObj*, int);
 extern "C" void aiAddDuct__8CGMonObjFRi(CGMonObj*, int&);
-extern "C" int calcPolygonGroup__6CAStarFP3Veci(void*, Vec*, int);
 extern "C" CGMonObj* FindGMonObjFirst__13CFlatRuntime2Fv(void*);
 extern "C" CGMonObj* FindGMonObjNext__13CFlatRuntime2FP8CGMonObj(void*, CGMonObj*);
 extern "C" int getNearParty__8CGMonObjFiiffi(CGMonObj*, int, int, float, float, int);
@@ -2502,8 +2501,7 @@ void CGMonObj::moveFrame()
 		in_f29 = PSVECDistance(&local_68, &object->m_worldPosition);
 
 		if (((moveFlags & 0x30000) != 0) && (*reinterpret_cast<unsigned int*>(ARRAY_8030918c) != 0)) {
-			int polygonGroup = calcPolygonGroup__6CAStarFP3Veci(reinterpret_cast<unsigned char*>(&DbgMenuPcs) + 0x2A5C, &local_68,
-			                                                   (int)object->m_moveVec.x);
+			int polygonGroup = AStar.calcPolygonGroup(&local_68, static_cast<int>(object->m_moveVec.x));
 			moveAStar(aStarGroupId, polygonGroup, local_68);
 		}
 	} else if ((moveFlags & 0x2000) != 0) {


### PR DESCRIPTION
## Summary
- replace three fake `CAStar*` call sites that passed `reinterpret_cast<unsigned char*>(&DbgMenuPcs) + 0x2A5C`
- call the real global `AStar` object directly from `cflat_runtime2.cpp`, `charaobj.cpp`, and `monobj.cpp`
- drop now-unneeded raw `extern "C"` declarations for those A* entry points

## Evidence
- `ninja` succeeds before and after this change
- objdiff report metrics for `main/astar`, `main/charaobj`, `main/monobj`, and `main/cflat_runtime2` are unchanged before/after this patch
- this is therefore an assembly-neutral cleanup, but it is still net progress in linkage/source plausibility because the callers now use the real object instead of a `DbgMenuPcs` offset hack

## Why this is plausible source
- `include/ffcc/astar.h` already declares the real `AStar` global and the corresponding member functions
- using `AStar` directly is more coherent than routing CAStar calls through unrelated `CDbgMenuPcs` storage
- this reduces future matching noise around A* call ownership without introducing compiler-coaxing hacks