### PR TITLE
Name PPP sdata2 constants

### DIFF
--- a/src/pppCorona.cpp
+++ b/src/pppCorona.cpp
@@ -9,10 +9,11 @@ extern int gPppCalcDisabled;
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 
-static const float kPppCoronaScreenWidth = 640.0f;
-static const float kPppCoronaScreenHeight = 448.0f;
-static const float kPppCoronaScreenCenterX = 320.0f;
-static const float kPppCoronaScreenCenterY = 224.0f;
+extern const float FLOAT_80331048 = 640.0f;
+extern const float FLOAT_8033104c = 448.0f;
+extern const float FLOAT_80331050 = 320.0f;
+extern const float FLOAT_80331054 = 224.0f;
+extern const double DOUBLE_80331058 = 4503601774854144.0;
 
 struct CoronaWork {
     s16 m_shapeX;
@@ -70,16 +71,16 @@ void pppRenderCorona(pppCorona* param1, CoronaParam* param2, pppCoronaUnkC* para
 
     PSMTXIdentity(mtx.value);
 
-    viewDir.x = kPppCoronaScreenWidth;
-    viewDir.y = kPppCoronaScreenHeight;
-    viewDir.z = kPppCoronaScreenCenterX;
+    viewDir.x = FLOAT_80331048;
+    viewDir.y = FLOAT_8033104c;
+    viewDir.z = FLOAT_80331050;
     PSVECSubtract(&vecWork->m_cameraOffset, &viewDir, &fromOrigin);
 
     mag = PSVECMag(&fromOrigin);
     scale = param2->m_distMin;
     if (mag < param2->m_distRange) {
         distScale = param2->m_distMax - param2->m_distMin;
-        distScale *= kPppCoronaScreenCenterY - (mag / param2->m_distRange);
+        distScale *= FLOAT_80331054 - (mag / param2->m_distRange);
         scale = param2->m_distMin + distScale;
     }
 
@@ -99,7 +100,7 @@ void pppRenderCorona(pppCorona* param1, CoronaParam* param2, pppCoronaUnkC* para
     color.rgba[2] = param2->m_colorB;
     color.rgba[3] = alpha;
 
-    pppSetDrawEnv(&color, (pppFMATRIX*)0, kPppCoronaScreenCenterX, param2->m_drawA, param2->m_drawB, param2->m_blendMode, 0, 1,
+    pppSetDrawEnv(&color, (pppFMATRIX*)0, FLOAT_80331050, param2->m_drawA, param2->m_drawB, param2->m_blendMode, 0, 1,
                   1, 0);
     pppSetBlendMode(param2->m_blendMode);
     pppDrawShp(*shape, work->m_shapeY, pppEnvStPtr->m_materialSetPtr, param2->m_blendMode);
@@ -167,7 +168,7 @@ void pppDestructCorona(pppCorona*, pppCoronaUnkC*)
  */
 void pppConstructCorona(pppCorona* param1, pppCoronaUnkC* param2)
 {
-    float fVar1 = kPppCoronaScreenCenterX;
+    float fVar1 = FLOAT_80331050;
     u16* puVar2 = (u16*)((u8*)param1 + 0x80 + param2->m_serializedDataOffsets[3]);
     puVar2[2] = 0;
     puVar2[1] = 0;

--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -336,4 +336,5 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, str
     *(float*)(puVar2 + 8) = fVar1;
 }
 
+extern const double DOUBLE_80330DB0 = 4503601774854144.0;
 extern const double kPppYmSharedDoubleBias = 4503601774854144.0;

--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -16,8 +16,8 @@ extern const f32 FLOAT_803306e8;
 extern const f32 FLOAT_803306ec;
 extern u32 DAT_803306e0;
 extern u32 DAT_803306e4;
-static const f64 DOUBLE_803306F0 = 4503601774854144.0;
-static const f64 DOUBLE_803306f8 = 4503599627370496.0;
+extern const f64 DOUBLE_80330578 = 4503601774854144.0;
+extern const f64 DOUBLE_80330580 = 4503599627370496.0;
 
 extern "C" {
 void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);


### PR DESCRIPTION
## Summary
- define the MAP-owned double bias for pppYmDeformationMdl
- name pppYmTracer's owned double constants at 0x80330578/0x80330580
- name pppCorona's owned sdata2 constants at 0x80331048..0x80331058

## Evidence
- ninja passes
- Progress data bytes: 1095177 -> 1095237 (+60)
- objdiff: pppYmDeformationMdl .sdata2 20 bytes at 100.0%
- objdiff: pppYmTracer .sdata2 16 bytes at 100.0%, .rodata 16 bytes at 100.0%
- objdiff: pppCorona .sdata2 24 bytes at 100.0%, code remains 100.0%

## Plausibility
These changes replace anonymous/local constants with the PAL MAP-owned symbols for their compilation units. No control-flow or manual section hacks were introduced.