### PR TITLE
Name LocationTitle2 rodata symbols

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -68,7 +68,7 @@ struct pppMngStLocationTitle2Raw {
     CGObject* m_charaObj;
 };
 
-static const char s_LocationTitle2_cpp[] = "LocationTitle2.cpp";
+static const char s_LocationTitle2_cpp_801DB588[] = "LocationTitle2.cpp";
 
 /*
  * --INFO--
@@ -190,7 +190,7 @@ extern "C" void pppRenderLocationTitle2(struct pppLocationTitle2* locationTitle,
     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
 }
 
-static const char s_locationNodeName[] = "loc";
+static const char DAT_80330f50[] = "loc";
 
 /*
  * --INFO--
@@ -242,7 +242,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         float zOffset;
 
         work->m_particles = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp,
+            unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp_801DB588,
             0x70);
         memset(work->m_particles, 0, unkB->m_maxCount * sizeof(LocationTitle2Particle));
         particles = (LocationTitle2Particle*)work->m_particles;
@@ -271,7 +271,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         }
 
         modelRaw = (LocationTitle2ModelRaw*)model;
-        nodeIndex = SearchNode__Q26CChara6CModelFPc(model, const_cast<char*>(s_locationNodeName));
+        nodeIndex = SearchNode__Q26CChara6CModelFPc(model, const_cast<char*>(DAT_80330f50));
         node = modelRaw->m_nodes + nodeIndex * 0xC0;
         zOffset = 1.0f;
 


### PR DESCRIPTION
## Summary
- Rename the LocationTitle2 file-name rodata symbol to `s_LocationTitle2_cpp_801DB588` from the PAL symbol map.
- Rename the local node-name rodata symbol to `DAT_80330f50` and update references.

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/LocationTitle2 -o -` keeps section scores unchanged: `.text 96.96703%`, `.rodata 100%`, `.sdata2 100%`.
- Before this change, `s_LocationTitle2_cpp_801DB588` and `DAT_80330f50` appeared without symbol matches; after this change both report `100.0%` symbol matches.
- Function scores remain stable: `pppRenderLocationTitle2 99.832535%`, `pppFrameLocationTitle2 94.66776%`.

## Plausibility
- The names come directly from `config/GCCP01/symbols.txt` for the existing rodata objects.
- This is symbol ownership cleanup only; it does not introduce section forcing, address constants, or generated-function hacks.
