### PR TITLE
Use CPad hold-button field in menu controllers

### DIFF
--- a/include/ffcc/pad.h
+++ b/include/ffcc/pad.h
@@ -68,7 +68,9 @@ public:
     short _6_2_;
     short _8_2_;
     short _a_2_;
-    unsigned char _c_1_[0x19c];
+    unsigned char _c_1_[0x14];
+    short _20_2_;
+    unsigned char _22_1_[0x186];
     unsigned int _1a8_4_;
     void* _1ac_4_;
     unsigned char* _1b0_4_;

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -777,7 +777,7 @@ int CMenuPcs::ArtiCtrlCur()
 	if (bVar2) {
 		uVar4 = 0;
 	} else {
-		uVar4 = *(unsigned short*)((char*)&Pad + 0x20);
+		uVar4 = Pad._20_2_;
 	}
 
 	if (uVar4 == 0) {

--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -1361,7 +1361,7 @@ unsigned int CMenuPcs::CmdCtrlCur()
 	if (blocked) {
 		hold = 0;
 	} else {
-		hold = *reinterpret_cast<u16*>(reinterpret_cast<u8*>(&Pad) + 0x20);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -309,7 +309,7 @@ void CMenuPcs::CompaCtrl()
 	if (activeInput) {
 		hold = 0;
 	} else {
-		hold = *reinterpret_cast<short*>(reinterpret_cast<char*>(&Pad) + 0x20);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {
@@ -666,7 +666,7 @@ void CMenuPcs::CompaCtrlCur()
 	if (activeInput) {
 		hold = 0;
 	} else {
-		hold = *reinterpret_cast<short*>(reinterpret_cast<char*>(&Pad) + 0x20);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {

--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -838,7 +838,7 @@ int CMenuPcs::EquipCtrlCur()
 	if (blocked) {
 		hold = 0;
 	} else {
-		hold = *reinterpret_cast<u16*>(reinterpret_cast<char*>(&Pad) + 0x20);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -749,7 +749,7 @@ int CMenuPcs::ItemCtrlCur()
     if (blocked) {
         hold = 0;
     } else {
-        hold = *(u16*)((u8*)&Pad + 0x20);
+        hold = Pad._20_2_;
     }
 
     if (hold == 0) {

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -1714,7 +1714,7 @@ int CMenuPcs::LetterCtrlCur()
 	if (blocked) {
 		hold = 0;
 	} else {
-		hold = *reinterpret_cast<u16*>(reinterpret_cast<u8*>(&Pad) + 0x20);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -328,9 +328,8 @@ void CMenuPcs::MLstCtrl()
 	if (blocked) {
 		press = 0;
 	} else {
-		int padIndex = 0;
-		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
-		press = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + padIndex * 0x54 + 0x8);
+		__cntlzw((unsigned int)Pad._448_4_);
+		press = Pad._8_2_;
 	}
 
 	blocked = false;
@@ -340,9 +339,8 @@ void CMenuPcs::MLstCtrl()
 	if (blocked) {
 		hold = 0;
 	} else {
-		int padIndex = 0;
-		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
-		hold = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + padIndex * 0x54 + 0x14);
+		__cntlzw((unsigned int)Pad._448_4_);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -566,7 +566,7 @@ int CMenuPcs::MoneyCtrlCur()
 		hold = 0;
 	} else {
 		__cntlzw(static_cast<unsigned int>(Pad._448_4_));
-		hold = *(u16*)((u8*)&Pad + 0x20);
+		hold = Pad._20_2_;
 	}
 
 	if (hold == 0) {

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -201,7 +201,7 @@ static unsigned short GetShopMenuListButtons()
             return 0;
         }
         __cntlzw(static_cast<unsigned int>(Pad._448_4_));
-        return *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + 0x20);
+        return Pad._20_2_;
     }
 
     unsigned short buttons;
@@ -646,7 +646,7 @@ unsigned short getButtonRepeat(int, unsigned short noRepeatMask)
             buttons = 0;
         } else {
             __cntlzw(static_cast<unsigned int>(Pad._448_4_));
-            buttons = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + 0x20);
+            buttons = Pad._20_2_;
         }
     } else {
         bool hasInput = (Pad._452_4_ != 0) || (Pad._448_4_ != -1);
@@ -3203,4 +3203,3 @@ void CShopMenu::setFaceAlpha(int, int alpha)
 {
     ShopMenuInt(this, 0x40) = alpha;
 }
-


### PR DESCRIPTION
## Summary
- split `CPad` around the known hold-button field at offset `0x20`
- replace repeated raw `&Pad + 0x20` casts in the menu controller cluster with `Pad._20_2_`
- update `menu_lst` input reads to use direct `CPad` members instead of fabricated pointer math

## Evidence
- `ninja` succeeds after the header/layout change
- touched menu units still report cleanly in `build/GCCP01/report.json`
- `main/menu_lst` remains at `71.90104%` code / `54.545456%` data after the cleanup

## Why This Is Plausible Source
- the menu code was repeatedly reading the same concrete pad slot through anonymous byte offsets
- promoting that slot into `CPad` makes the shared layout explicit and removes per-file reinterpret-cast guesses
- this is a decomp-quality cleanup that should make future menu matching work against a single authoritative declaration instead of duplicated offset folklore