### PR TITLE
Improve pppYmMoveParabola constant usage

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -7,8 +7,6 @@
 #include "dolphin/mtx.h"
 
 extern CGame Game;
-extern double DOUBLE_80330E30;
-
 struct pppYmMoveParabolaWork {
     f32 m_distance;
     f32 m_velocity;
@@ -99,7 +97,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
  */
 extern "C" void pppConstructYmMoveParabola(struct pppYmMoveParabola* basePtr, struct pppYmMoveParabolaUnkC* dataPtr)
 {
-    const f32 zero = gPppYmMoveParabolaZero;
+    const f32 zero = 0.0f;
     _pppMngSt* pppMngSt = pppMngStPtr;
     pppYmMoveParabolaWork* work =
         (pppYmMoveParabolaWork*)((u8*)basePtr + *dataPtr->m_serializedDataOffsets + 0x80);


### PR DESCRIPTION
## Summary
- remove the stray external `DOUBLE_80330E30` declaration from `pppYmMoveParabola.cpp`
- use a local `0.0f` literal in `pppConstructYmMoveParabola` instead of routing through `gPppYmMoveParabolaZero`
- keep the source closer to compiler-generated local constants without introducing section or linkage hacks

## Evidence
- `ninja`: passes
- `main/pppYmMoveParabola` section fuzzy match: `99.18288%` -> `99.22179%`
- `pppFrameYmMoveParabola` fuzzy match: `98.858696%` -> `98.91304%`
- `pppConstructYmMoveParabola`: remains `100.0%`

## Plausibility
These changes remove decompiler-style constant plumbing and let the compiler emit the local literals the original object appears to use. The result is cleaner source and a measurable objdiff improvement without resorting to compiler coaxing hacks.