### PR TITLE
Match p_map drawAfter debug color

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -880,8 +880,7 @@ void CMapPcs::drawAfter()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }


### PR DESCRIPTION
Summary
- Inline the debug color temporary in CMapPcs::drawAfter.
- Keep the debug bound draw path behavior the same while matching the original construction shape more closely.

Evidence
- objdiff for drawAfter__7CMapPcsFv: 99.933334% -> 100.0%
- Global matched code: 491964 -> 492504 bytes
- Global matched functions: 3099 -> 3100

Plausibility
- This removes a throwaway local and passes the temporary color directly at the call site.
- The resulting source is simpler and fits the surrounding debug-only draw path without compiler-coaxing hacks.