### PR TITLE
Correct CUSBPcs base class

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,10 +2,10 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/system.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/usb.h"
 
-class CUSBPcs : public CProcess
+class CUSBPcs : public CSamplePcs
 {
 public:
     CUSBPcs();


### PR DESCRIPTION
## Summary
- Change CUSBPcs to derive from CSamplePcs instead of CProcess.
- This matches the static initializer evidence, which installs the CSamplePcs vtable before the CUSBPcs vtable.

## Evidence
- ninja passes.
- main/p_usb data match improves from 35.84% (selector baseline) to 47.79%.
- Existing matched p_usb functions remain matched; 9/11 functions matched after the change.
- __sinit_p_usb_cpp size is now 176 bytes, matching the target size.

## Plausibility
- CUSBPcs uses the same scene/process table pattern as CSamplePcs-derived process classes.
- The change removes an incorrect direct CProcess inheritance assumption without adding manual vtable or section hacks.