### PR TITLE
fontman: fix CFont width render flag tests

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -7,8 +7,8 @@ unsigned char g_tFont22[0x10D40] ATTRIBUTE_ALIGN(32) = {
 };
 }
 #include "PowerPC_EABI_Support/Runtime/NMWException.h"
+#include "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/math.h"
 #include <dolphin/mtx.h>
-#include <math.h>
 
 extern "C" void __dt__8CFontManFv(void*);
 extern "C" void __ct__4CRefFv(void*);
@@ -74,7 +74,7 @@ found_fallback:
 	unsigned char flags = renderFlags;
 	unsigned int drawWidth;
 
-	if ((flags & 8) != 0) {
+	if ((flags & 0x10) != 0) {
 		drawWidth = static_cast<unsigned int>(m_glyphWidth);
 	} else {
 		signed char sign = static_cast<signed char>(flags) >> 7;
@@ -84,7 +84,7 @@ found_fallback:
 	}
 
 	double width = static_cast<double>(scaleX * (margin + static_cast<float>(drawWidth)));
-	if ((flags & 0x10) != 0) {
+	if ((flags & 8) != 0) {
 		width = static_cast<double>(static_cast<float>(floor(width)));
 	}
 
@@ -144,7 +144,7 @@ use_glyph:
 		unsigned char flags = renderFlags;
 		unsigned int drawWidth;
 
-		if ((flags & 8) != 0) {
+		if ((flags & 0x10) != 0) {
 			drawWidth = static_cast<unsigned int>(m_glyphWidth);
 		} else {
 			signed char sign = static_cast<signed char>(flags);
@@ -155,7 +155,7 @@ use_glyph:
 		}
 
 		float charWidth = scaleX * (margin + static_cast<float>(drawWidth));
-		if ((flags & 0x10) != 0) {
+		if ((flags & 8) != 0) {
 			charWidth = static_cast<float>(floor(charWidth));
 		}
 


### PR DESCRIPTION
## Summary
- fix the render-flag bit tests used by both `CFont::GetWidth` overloads
- make width code use the same fixed-width and snap-width flags as the target object
- keep the change localized to `src/fontman.cpp`

## Evidence
- `ninja` succeeds
- direct symbol diff against the target object improved after the patch:
  - `GetWidth__5CFontFUs`: `.text` match `77.390045% -> 78.98755%`
  - `GetWidth__5CFontFPc`: `.text` match `77.390045% -> 78.98755%`
- assembly now matches the target flag tests instead of checking the width/snap bits in the opposite order

## Plausibility
- `renderFlags` already models fixed-width as bit `0x10` and position snapping as bit `0x08`
- the old source had those tests swapped in both width functions, so this fixes a real source-level mistake rather than compiler coaxing