### PR TITLE
Fix CharaBreak mesh ref layout

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -165,10 +165,10 @@ struct CharaBreakMeshData {
 };
 
 struct CharaBreakMeshRef {
+    u8 _pad0[8];
     CharaBreakMeshData* m_data;
     S16Vec* m_workPositions;
     S16Vec* m_workNormals;
-    u8 _padC[8];
 };
 
 struct CharaBreakModelData {
@@ -188,9 +188,9 @@ struct CharaBreakModelView {
     CharaBreakMeshRef* m_meshes;
 };
 
-STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_data) == 0x0);
-STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_workPositions) == 0x4);
-STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_workNormals) == 0x8);
+STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_data) == 0x8);
+STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_workPositions) == 0xC);
+STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_workNormals) == 0x10);
 STATIC_ASSERT(offsetof(CharaBreakModelView, m_data) == 0xA4);
 STATIC_ASSERT(offsetof(CharaBreakModelView, m_nodes) == 0xA8);
 STATIC_ASSERT(offsetof(CharaBreakModelView, m_meshes) == 0xAC);
@@ -389,6 +389,7 @@ void CreatePolygon(POLYGON_DATA* polygonData, void* displayList, unsigned long, 
     while (keepReading != 0) {
         u8 drawCmd = *(u8*)stream;
         u16 drawCount = *(u16*)((u8*)stream + 1);
+        u8 drawMode = drawCmd & 7;
         u8 primitive = drawCmd & 0xF8;
         s16 triCount;
         s32 outVertex;
@@ -414,7 +415,7 @@ void CreatePolygon(POLYGON_DATA* polygonData, void* displayList, unsigned long, 
                 u16 texIndex = stream[3];
 
                 stripRestart = stream + 4;
-                if ((drawCmd & 7) == 2) {
+                if (drawMode == 2) {
                     stripRestart = stream + 5;
                 }
                 stream = stripRestart;


### PR DESCRIPTION
## Summary
- Correct the local CharaBreak mesh ref layout so typed accesses match the mesh data/work position offsets used by the PAL code.
- Keep the display-list draw mode in a named local before polygon decoding, matching the original CreatePolygon control-flow shape more closely.

## Evidence
- Built with ninja.
- main/pppCharaBreak report fuzzy score: 80.94513.
- CreatePolygon__FP12POLYGON_DATAPvUlPQ26CChara6CModelPQ26CChara5CMesh: 79.547295% -> 81.14865%.
- pppFrameCharaBreak: 82.87369% -> 82.87719%.
- InitPolygonParameter__FP11PCharaBreakP11VCharaBreakP12POLYGON_DATAUlPQ26CChara6CModelPQ26CChara5CMesh: 81.85714% -> 81.86207%.

## Plausibility
The mesh struct now reflects the offsets already used elsewhere in this unit: mesh + 0x8 for mesh data and mesh + 0xC for work positions. This replaces an incorrect local layout rather than adding output-only coercion.