### PR TITLE
Match CTexture teardown and mip LOD setup

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -585,7 +585,10 @@ CTexture::CTexture()
  */
 CTexture::~CTexture()
 {
-    if (m_usesExternalAddress == 0) {
+    if (m_usesExternalAddress != 0) {
+        m_imageData = 0;
+        m_tlutData = 0;
+    } else {
         if (m_imageData != 0) {
             __dla__FPv(m_imageData);
             m_imageData = 0;
@@ -594,9 +597,6 @@ CTexture::~CTexture()
             __dla__FPv(m_tlutData);
             m_tlutData = 0;
         }
-    } else {
-        m_imageData = 0;
-        m_tlutData = 0;
     }
 }
 
@@ -837,8 +837,8 @@ void CTexture::Create(CChunkFile& chunkFile, CMemory::CStage* stage, CAmemCacheS
                      static_cast<GXTexWrapMode>(*reinterpret_cast<unsigned int*>(texture + 0x6C)), 1 - (texture[0x74] >> 31));
     }
 
-    if (texture[0x74] >= 2) {
-        GXInitTexObjLOD(reinterpret_cast<GXTexObj*>(texture + 0x28), GX_LINEAR, GX_LINEAR, 0.0f,
+    if (1 < texture[0x74]) {
+        GXInitTexObjLOD(reinterpret_cast<GXTexObj*>(texture + 0x28), GX_LIN_MIP_LIN, GX_LINEAR, 0.0f,
                         static_cast<float>(texture[0x74] - 1), 0.0f, GX_FALSE, GX_FALSE, GX_ANISO_1);
     }
 }
@@ -1047,10 +1047,8 @@ void CTexture::SetTlutColor(int index, _GXColor color)
 {
     int offset;
     u16* tlut = reinterpret_cast<u16*>(m_tlutData);
-    union {
-        _GXColor color;
-        u32 value;
-    } packedColor;
+    unsigned char* packedColor = reinterpret_cast<unsigned char*>(&color);
+    u16 lowColor = packedColor[0] | (packedColor[1] << 8);
 
     if (m_format == 9) {
         offset = 0x100;
@@ -1060,9 +1058,8 @@ void CTexture::SetTlutColor(int index, _GXColor color)
         offset = 0;
     }
 
-    packedColor.color = color;
-    tlut[index + offset] = static_cast<u16>(packedColor.value >> 16);
-    tlut[index] = static_cast<u16>(packedColor.value);
+    tlut[index + offset] = packedColor[2] | (packedColor[3] << 8);
+    tlut[index] = lowColor;
 }
 
 /*


### PR DESCRIPTION
## Summary
- rewrite `CTexture::~CTexture()` to follow the original external-address branch shape
- use the original mipmapped min filter in `CTexture::Create(...)`
- keep the source plausible and localized to the `textureman` dependency cluster

## Objdiff evidence
- `__dt__8CTextureFv`: `81.59091%` -> `100.0%`
- `Create__8CTextureFR10CChunkFilePQ27CMemory6CStageP13CAmemCacheSetii`: `58.955555%` -> `58.97778%`

## Why this is plausible source
- the destructor now matches the expected ownership split between external-backed textures and internally allocated buffers
- mipmapped textures now initialize LOD filtering consistently with `InitTexObj()` and `CacheLoadTexture()` instead of forcing plain linear minification

## Verification
- `ninja`