### PR TITLE
Improve pppMiasma render local layout

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -150,10 +150,14 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, pppMias
     s16* work;
     u8* colorData;
     u8* radiusScaleData;
+    pppCVECTOR drawColor;
     PackedMiasmaColor packedWork;
+    int textureIndex;
     PackedMiasmaColor packedColor;
-    Vec managerPos;
+    Vec quadA;
+    Vec quadB;
     Vec cameraPos;
+    Vec managerPos;
     float radius;
     float maxRadius;
     int texWidth;
@@ -162,7 +166,6 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, pppMias
     u32 scissorHeight;
     int i4TexSize;
     int rgba8TexSize;
-    int textureIndex;
     int yOffset;
     float yPos;
     u16 i;
@@ -176,10 +179,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, pppMias
     Mtx scaleMtx;
     Mtx localMtx;
     Mtx44 screenMtx;
-    pppCVECTOR drawColor;
     GXColor stepColor;
-    Vec quadA;
-    Vec quadB;
 
     Graphic.SetDrawDoneDebugData(0x31);
 


### PR DESCRIPTION
## Summary
- Reordered local declarations in pppRenderMiasma so packed color, texture index, and vector temporaries lay out closer to the target object.
- Keeps the source behavior unchanged while improving stack/local correspondence in main/pppMiasma.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppMiasma -o - pppRenderMiasma
- Before: 92.05211%, size 5604
- After: 92.10064%, size 5604

## Plausibility
- This is normal C++ local declaration ordering, not a linkage hack or manual section/vtable change.
- The change matches the observed target local layout for the packed color work, texture index reference, and render quad/camera/manager vector temporaries.