### PR TITLE
Improve pppBreathModel debug color branch

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -402,39 +402,37 @@ extern "C" void pppRenderBreathModel(pppBreathModel* breathModel, PBreathModel* 
                 Mtx tempMtx;
                 Vec pos;
 
-                if (i != 2) {
-                    if (i >= 2) {
-                        if (i >= 4) {
-                            debugColor.r = 0x00;
-                            debugColor.g = 0x60;
-                            debugColor.b = 0x80;
-                            debugColor.a = 0xFF;
-                        } else {
-                            debugColor.r = 0x80;
-                            debugColor.g = 0x80;
-                            debugColor.b = 0x80;
-                            debugColor.a = 0xFF;
-                        }
-                    } else if (i == 0) {
+                if (i == 2) {
+                    debugColor.r = 0x80;
+                    debugColor.g = 0x00;
+                    debugColor.b = 0x00;
+                    debugColor.a = 0xFF;
+                } else if (i < 2) {
+                    if (i == 0) {
                         debugColor.r = 0x80;
                         debugColor.g = 0x00;
                         debugColor.b = 0x00;
                         debugColor.a = 0xFF;
-                    } else if (i >= 0) {
-                        debugColor.r = 0x80;
-                        debugColor.g = 0x80;
-                        debugColor.b = 0xFF;
-                        debugColor.a = 0xFF;
-                    } else {
+                    } else if (i < 0) {
                         debugColor.r = 0x00;
                         debugColor.g = 0x60;
                         debugColor.b = 0x80;
                         debugColor.a = 0xFF;
+                    } else {
+                        debugColor.r = 0x80;
+                        debugColor.g = 0x80;
+                        debugColor.b = 0xFF;
+                        debugColor.a = 0xFF;
                     }
-                } else {
+                } else if (i < 4) {
                     debugColor.r = 0x80;
-                    debugColor.g = 0x00;
-                    debugColor.b = 0x00;
+                    debugColor.g = 0x80;
+                    debugColor.b = 0x80;
+                    debugColor.a = 0xFF;
+                } else {
+                    debugColor.r = 0x00;
+                    debugColor.g = 0x60;
+                    debugColor.b = 0x80;
                     debugColor.a = 0xFF;
                 }
 


### PR DESCRIPTION
## Summary
- Reorders the debug sphere color branch in pppRenderBreathModel to match the PAL branch shape more closely.
- Keeps the same color assignments while reducing control-flow diff noise around debug group color selection.

## Objdiff Evidence
- pppRenderBreathModel: 92.31511% -> 93.0418%
- Diff counts: deletes 6 -> 4, inserts 12 -> 10, op mismatches 3 -> 2; arg/replacement mismatches unchanged.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o - pppRenderBreathModel
