### PR TITLE
Recover more of CGItemObj::onFrameStat

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/maphit.h"
 #include "ffcc/math.h"
 #include "ffcc/partMng.h"
+#include "ffcc/partyobj.h"
 #include "ffcc/prgobj.h"
 #include "ffcc/p_game.h"
 #include "ffcc/vector.h"
@@ -438,27 +439,10 @@ void CGItemObj::onFrameStat()
 			bool useBossAttachName = false;
 
 			if (Game.m_gameWork.m_menuStageMode != 0) {
-				bool condA = false;
-				bool condB = false;
-				bool condC = false;
-
-				if (Game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
-					condC = true;
-				}
-				if (condC) {
-					CGPartyObj* carryObj = *(CGPartyObj**)(self + 0x550);
-					typedef unsigned int (*PartyVFunc)(CGPartyObj*);
-					PartyVFunc getCid = reinterpret_cast<PartyVFunc>((*reinterpret_cast<void***>(carryObj))[3]);
-					unsigned int cid = getCid(carryObj);
-					unsigned int stageCarry = (unsigned int)__cntlzw(0x6D - (cid & 0x6D));
-					if (((stageCarry >> 5) & 0xFF) != 0) {
-						condB = true;
-					}
-				}
-				if (condB && *(int*)(*(unsigned char**)(*(unsigned char**)(self + 0x550) + 0x58) + 0x3B4) != 0) {
-					condA = true;
-				}
-				if (condA) {
+				CGPartyObj* carryObj = *(CGPartyObj**)(self + 0x550);
+				if (Game.m_gameWork.m_bossArtifactStageIndex < 0xF &&
+				    (static_cast<unsigned int>(carryObj->GetCID()) & 0x6D) == 0x6D &&
+				    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(carryObj->m_scriptHandle) + 0x3B4) != 0) {
 					useBossAttachName = true;
 				}
 			}
@@ -478,6 +462,34 @@ void CGItemObj::onFrameStat()
 		if (*(int*)(self + 0x528) == *(int*)(self + 0x554)) {
 			CGPartyObj* carryObj = *(CGPartyObj**)(self + 0x550);
 			Vec safePos;
+			float launchSpeed = FLOAT_80331b40;
+
+			if (*(int*)(self + 0x520) == 0xC) {
+				bool useMenuLaunchSpeed = false;
+
+				if (Game.m_gameWork.m_menuStageMode != 0 && Game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
+					unsigned int carryCid = static_cast<unsigned int>(carryObj->GetCID());
+					if ((carryCid & 0x6D) == 0x6D &&
+					    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(carryObj->m_scriptHandle) + 0x3B4) != 0) {
+						useMenuLaunchSpeed = true;
+					}
+				}
+
+				if (useMenuLaunchSpeed) {
+					launchSpeed = FLOAT_80331b18;
+				} else if (*(int*)(CFlat + 0x4780) == 1) {
+					unsigned int carryCid = static_cast<unsigned int>(carryObj->GetCID());
+					if ((carryCid & 0x6D) == 0x6D &&
+					    1 < *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(carryObj->m_scriptHandle) + 0x3E0)) {
+						launchSpeed = FLOAT_80331b18;
+					} else {
+						launchSpeed = FLOAT_80331ba8;
+					}
+				} else {
+					launchSpeed = FLOAT_80331b90;
+				}
+			}
+
 			float safeDist = CalcSafePos__8CGObjectFiP8CGObjectP3Vec(this, 0x41, carryObj, &safePos);
 
 			if (FLOAT_80331b20 < safeDist) {
@@ -488,11 +500,6 @@ void CGItemObj::onFrameStat()
 
 			Detach__8CGObjectFv(this);
 			*(Vec*)(self + 0x15C) = safePos;
-
-			float launchSpeed = FLOAT_80331b90;
-			if (*(int*)(self + 0x520) != 0xC) {
-				launchSpeed = FLOAT_80331b40;
-			}
 
 			float ownerRotY = *(float*)((unsigned char*)carryObj + 0x1B4);
 			CVector moveVec((float)sin((double)ownerRotY), FLOAT_80331b54, (float)cos((double)ownerRotY));
@@ -512,6 +519,37 @@ void CGItemObj::onFrameStat()
 			} else if (isActive) {
 				changeStat__8CGPrgObjFiii(this, 0, 0, 0);
 			}
+		}
+		break;
+	case 0xE:
+		if (*(int*)(self + 0x528) == 0) {
+			prgObj->m_bgColMask = 0;
+			prgObj->m_weaponNodeFlags &= 0xFFEF;
+			prgObj->m_groundHitOffset.z = zero;
+			prgObj->m_groundHitOffset.y = zero;
+			prgObj->m_groundHitOffset.x = zero;
+		} else if (*(int*)(self + 0x528) == 4) {
+			prgObj->m_bgDownDist = FLOAT_80331b68;
+			prgObj->m_stepSlopeLimit = zero;
+			EndParticle__13CFlatRuntime2FPQ29CCharaPcs7CHandle(CFlat, prgObj->m_charaModelHandle);
+		} else if (*(int*)(self + 0x528) == 0xC) {
+			self[0x54D] = (self[0x54D] & 0x7F) | 0x80;
+		}
+
+		if (7 < *(int*)(self + 0x528)) {
+			CGObject* carryObj = *(CGObject**)(self + 0x550);
+
+			prgObj->m_rotTargetY = prgObj->m_rotTargetY + FLOAT_80331b54;
+			prgObj->m_worldPosition.x =
+			    FLOAT_80331b54 * (carryObj->m_worldPosition.x - prgObj->m_worldPosition.x) + prgObj->m_worldPosition.x;
+			prgObj->m_worldPosition.y =
+			    FLOAT_80331b54 * (FLOAT_80331b3c * carryObj->unk_0x188 + carryObj->m_worldPosition.y - prgObj->m_worldPosition.y) +
+			    prgObj->m_worldPosition.y;
+			prgObj->m_worldPosition.z =
+			    FLOAT_80331b54 * (carryObj->m_worldPosition.z - prgObj->m_worldPosition.z) + prgObj->m_worldPosition.z;
+			prgObj->m_rotationX = prgObj->m_rotationX * FLOAT_80331bac;
+			prgObj->m_rotationY = prgObj->m_rotationY * FLOAT_80331bac;
+			prgObj->m_rotationZ = prgObj->m_rotationZ * FLOAT_80331bac;
 		}
 		break;
 	case 0x1b:


### PR DESCRIPTION
## Summary
- restore more original `CGItemObj::onFrameStat` state handling in `src/itemobj.cpp`
- recover the missing launch-speed selection for the `0xC/0xD` carry throw path
- simplify the `0xB` attach-name selection to the direct CID/script checks shown by the decomp
- add the recovered `0xE` state branch to keep the state machine coherent with adjacent item carry/drop logic

## Evidence
- `onFrameStat__9CGItemObjFv`: `45.99883%` -> `52.254097%`
- `main/itemobj` `.text`: `67.2%` -> `68.75897%`
- `ninja`: passes

## Why this is plausible source
- the new logic follows the existing item/party object state machine instead of compiler-coaxing patterns
- checks now use real object state (`GetCID()`, script data, menu-stage state) that already drives nearby item carry behavior elsewhere in the repo
- the recovered `0xE` path restores missing gameplay state transitions rather than introducing output-only hacks