### PR TITLE
Improve CAmemCacheSet CalcPrio comparisons

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2170,8 +2170,8 @@ void CAmemCacheSet::CalcPrio()
         int* entry = reinterpret_cast<int*>(*reinterpret_cast<int*>(bytes + 0x58) + offset);
         unsigned char* entryBytes = reinterpret_cast<unsigned char*>(entry);
 
-        if ((entryBytes[0x0E] != 0) && (*reinterpret_cast<short*>(entryBytes + 0x0C) == 0) && (*entry != 0) &&
-            (entry[4] != 0)) {
+        if ((entryBytes[0x0E] != 0) && (*reinterpret_cast<unsigned short*>(entryBytes + 0x0C) == 0) &&
+            (*reinterpret_cast<unsigned int*>(entry) != 0) && (static_cast<unsigned int>(entry[4]) != 0)) {
             entry[4]--;
         }
 


### PR DESCRIPTION
## Summary
- Use unsigned zero checks in CAmemCacheSet::CalcPrio for the cache entry halfword and word fields.
- This matches the target's lhz/cmplwi sequence instead of signed lha/cmpwi comparisons.

## Evidence
- ninja passes for GCCP01.
- objdiff main/memory CalcPrio__13CAmemCacheSetFv: 87.8% -> 97.2% match, size unchanged at 100 bytes.

## Plausibility
- The fields are tested only for zero/non-zero state, so unsigned loads are a cleaner fit for flag/counter-style cache metadata and align with the generated target code.