### PR TITLE
Improve gbaque letter and radar stat matching

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -58,7 +58,7 @@ public:
     int GetItemAll(int, unsigned char*);
     unsigned int GetScrFlg();
     int GetPlayerHP(int, unsigned char*);
-    void MakeLetterList(int, char*);
+    int MakeLetterList(int, char*);
     int MakeLetterData(int, char*, int);
     unsigned int GetLetterLstFlg(int);
     void ClrLetterLstFlg(int);

--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -77,7 +77,7 @@ public:
     void SetAnimSlot(int, int);
     float CalcSafePos(int, CGObject*, Vec*);
     void PutDropItem();
-    virtual bool IsDispRader();
+    virtual unsigned int IsDispRader();
     virtual int onHit(int, CGObject*, int, Vec*);
     virtual void onAnimPoint(int, int);
     virtual float onAlphaUpdate();

--- a/include/ffcc/monobj.h
+++ b/include/ffcc/monobj.h
@@ -77,7 +77,7 @@ public:
     void setIceJEffect(int);
     void setFlyEffect(int, int);
     void setUndeadEffect(int, int);
-    bool IsDispRader();
+    unsigned int IsDispRader();
     void setRepop(int);
     void statMove();
     void moveAStar(int, int, Vec&);

--- a/include/ffcc/partyobj.h
+++ b/include/ffcc/partyobj.h
@@ -99,7 +99,7 @@ public:
     static void SetBonusCondition(int, int, int, int, int);
 
     void InitFinished();
-    bool IsDispRader();
+    unsigned int IsDispRader();
 
     void ChangeCommandMode(int);
     void checkAndSetWeapon();

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1540,8 +1540,7 @@ void GbaQueue::LoadEnemyStat()
 				CMonWork* enemyWork = reinterpret_cast<CMonWork*>(enemyWorkPtrs[i]);
 				const int enemyDataBase = Game.unkCFlatData0[1] + enemyWork->m_baseDataIndex * 0x1D0;
 				const short enemyKind = *reinterpret_cast<short*>(enemyDataBase + 0x10C);
-				typedef int (*IsDispRadarFn)(CGObject*);
-				const int isDispRadar = reinterpret_cast<IsDispRadarFn>((*reinterpret_cast<void***>(enemyObj))[0xB])(enemyObj);
+				const int isDispRadar = enemyObj->IsDispRader();
 
 				if (enemyKind == 10) {
 					enemyEntry[1] = 1;
@@ -1627,8 +1626,7 @@ void GbaQueue::LoadMapItemStat()
 					mapItemEntry[1] = (itemStage < bossStageLimit) ? 4 : 5;
 				}
 
-				typedef int (*IsDispRadarFn)(CGObject*);
-				int isDispRader = reinterpret_cast<IsDispRadarFn>((*reinterpret_cast<void***>(object))[0xB])(object);
+				int isDispRader = object->IsDispRader();
 				numMapItems++;
 				mapItemEntry[2] = static_cast<unsigned char>((-isDispRader | isDispRader) >> 31);
 				*reinterpret_cast<short*>(mapItemEntry + 8) = static_cast<short>(object->m_worldPosition.x / 100.0f);
@@ -2128,10 +2126,14 @@ int GbaQueue::GetPlayerHP(int channel, unsigned char* outData)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x800cd850
+ * PAL Size: 1436b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
-void GbaQueue::MakeLetterList(int channel, char* outData)
+int GbaQueue::MakeLetterList(int channel, char* outData)
 {
 	unsigned char* self = reinterpret_cast<unsigned char*>(this);
 	const unsigned int scriptFood = Game.m_scriptFoodBase[channel];
@@ -2141,7 +2143,7 @@ void GbaQueue::MakeLetterList(int channel, char* outData)
 		self[0x2C8A] = static_cast<unsigned char>(self[0x2C8A] | channelMask);
 		Joybus.SetLetterSize(channel, 0);
 		self[0x2C89] = static_cast<unsigned char>(self[0x2C89] & ~channelMask);
-		return;
+		return 0;
 	}
 
 char* npcNameBuf = static_cast<char*>(__nwa__FUlPQ27CMemory6CStagePci(
@@ -2150,7 +2152,7 @@ char* npcNameBuf = static_cast<char*>(__nwa__FUlPQ27CMemory6CStagePci(
 		if (System.m_execParam != 0) {
 Printf__7CSystemFPce(&System, const_cast<char*>(s_pcts_pctd_Error_memory_allocation_error_801DB37C), const_cast<char*>(s_gbaque_cpp_801DB370), 0x7A9);
 		}
-		return;
+		return -1;
 	}
 	memset(npcNameBuf, 0, 0x800);
 
@@ -2160,8 +2162,7 @@ char* subjectNameBuf = static_cast<char*>(__nwa__FUlPQ27CMemory6CStagePci(
 		if (System.m_execParam != 0) {
 Printf__7CSystemFPce(&System, const_cast<char*>(s_pcts_pctd_Error_memory_allocation_error_801DB37C), const_cast<char*>(s_gbaque_cpp_801DB370), 0x7B3);
 		}
-		__dla__FPv(npcNameBuf);
-		return;
+		return -1;
 	}
 	memset(subjectNameBuf, 0, 0x1800);
 
@@ -2171,9 +2172,7 @@ unsigned int* letterEntryBuf = static_cast<unsigned int*>(__nwa__FUlPQ27CMemory6
 		if (System.m_execParam != 0) {
 Printf__7CSystemFPce(&System, const_cast<char*>(s_pcts_pctd_Error_memory_allocation_error_801DB37C), const_cast<char*>(s_gbaque_cpp_801DB370), 0x7BD);
 		}
-		__dla__FPv(subjectNameBuf);
-		__dla__FPv(npcNameBuf);
-		return;
+		return -1;
 	}
 	memset(letterEntryBuf, 0, 0x800);
 
@@ -2306,6 +2305,7 @@ Printf__7CSystemFPce(&System, const_cast<char*>(s_letter_data_error), const_cast
 	self[0x2C8A] = static_cast<unsigned char>(self[0x2C8A] | channelMask);
 	Joybus.SetLetterSize(channel, totalSize);
 	self[0x2C89] = static_cast<unsigned char>(self[0x2C89] & ~channelMask);
+	return totalSize;
 }
 
 /*

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3490,7 +3490,7 @@ void CGObject::PutDropItem()
  * Address:	TODO
  * Size:	TODO
  */
-bool CGObject::IsDispRader()
+unsigned int CGObject::IsDispRader()
 { 
 	return m_displayFlags & 1;
 }

--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -2155,11 +2155,11 @@ void CGMonObj::setUndeadEffect(int, int)
  * JP Address: TODO
  * JP Size: TODO
  */
-bool CGMonObj::IsDispRader()
+unsigned int CGMonObj::IsDispRader()
 {
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	if (object->IsDispRader() == 0) {
-		return false;
+		return 0;
 	}
 	return static_cast<int>(static_cast<unsigned int>(object->m_weaponNodeFlags) << 24) < 0;
 }

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -2885,15 +2885,15 @@ void CGPartyObj::InitFinished()
  * JP Address: TODO
  * JP Size: TODO
  */
-bool CGPartyObj::IsDispRader()
+unsigned int CGPartyObj::IsDispRader()
 {
 	if (CGObject::IsDispRader()) {
 		if (((int)((unsigned int)(unsigned char)m_weaponNodeFlags << 24) < 0) &&
 		    ((int)((unsigned int)(unsigned char)(m_weaponNodeFlags >> 8) << 24) < 0)) {
-			return true;
+			return 1;
 		}
 	}
-	return false;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Correct GbaQueue::MakeLetterList to return its generated size/error code and fill in the PAL info block.
- Use the real CGObject::IsDispRader() virtual call from gbaque stat loaders instead of manual vtable indexing.
- Change IsDispRader declarations/definitions from bool to full-word unsigned int, matching the Ghidra decompilation return shape.

## Objdiff evidence
- MakeLetterList__8GbaQueueFiPc: 47.504177% -> 52.29248%
- LoadMapItemStat__8GbaQueueFv: 75.76147% -> 78.926605%
- IsDispRader__8CGObjectFv: remains 100.0%
- IsDispRader__8CGMonObjFv: remains 19.695652%
- IsDispRader__10CGPartyObjFv: remains 61.892857%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/gbaque -o /tmp/final_makeletter.json MakeLetterList__8GbaQueueFiPc
- build/tools/objdiff-cli diff -p . -u main/gbaque -o /tmp/final_mapitem.json LoadMapItemStat__8GbaQueueFv
- build/tools/objdiff-cli diff -p . -u main/gobject -o /tmp/final_gobject_rader.json IsDispRader__8CGObjectFv
- build/tools/objdiff-cli diff -p . -u main/monobj -o /tmp/final_monobj_rader.json IsDispRader__8CGMonObjFv
- build/tools/objdiff-cli diff -p . -u main/partyobj -o /tmp/final_partyobj_rader.json IsDispRader__10CGPartyObjFv