### PR TITLE
Improve crystal refraction loop matching

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -299,6 +299,7 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 					float xCoord = FLOAT_80330FD4;
 
 					for (x = 0; x < (u32)textureInfo->m_width; x++) {
+						u32 xFine = x & 3;
 						float magnitude = xCoord * xCoord + ySq;
 						if (magnitude > FLOAT_80330FD8) {
 							magnitude = CrystalSqrtPositive(magnitude);
@@ -314,7 +315,6 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 
 						double modulation = fmod(magnitude, DOUBLE_80331000);
 						magnitude = FLOAT_80331008 * (magnitude * (float)modulation);
-						u32 xFine = x & 3;
 						u8 nx = (u8)__cvt_fp2unsigned((double)(xCoord * magnitude * FLOAT_80331010 + FLOAT_8033100C));
 						u8* pixel = textureInfo->m_imageData +
 							yTile * ((textureInfo->m_width & 0x1FFFFFFCU) << 3) +

--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -282,6 +282,7 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCry
             xCoord = FLOAT_80331FE4;
 
             for (x = 0; x < (u32)textureInfo->m_width; x++) {
+                u32 xFine = x & 3;
                 magnitude = xCoord * xCoord + ySq;
 
                 if (magnitude > FLOAT_80331FE8) {
@@ -296,7 +297,6 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCry
                     magnitude = FLOAT_80332008;
                 }
 
-                u32 xFine = x & 3;
                 u8 nx = (u8)__cvt_fp2unsigned((double)(xCoord * magnitude * FLOAT_80332010 + FLOAT_8033200C));
                 u8* pixel = textureInfo->m_imageData +
                     yTile * ((textureInfo->m_width & 0x1FFFFFFCU) << 3) +


### PR DESCRIPTION
Summary:\n- Move the xFine calculation earlier in the refraction texture loops for pppCrystal and pppCrystal2.\n- This matches the target loop instruction order more closely without changing behavior.\n\nObjdiff evidence:\n- pppFrameCrystal: 96.68519% -> 97.64815%\n- main/pppCrystal .text: 98.62556% -> 99.01189%\n- pppFrameCrystal2: 97.25108% -> 98.376625%\n- main/pppCrystal2 .text: 99.296875% after change\n\nVerification:\n- ninja\n- build/tools/objdiff-cli diff -p . -u main/pppCrystal -o /tmp/final_pppCrystal.json pppFrameCrystal\n- build/tools/objdiff-cli diff -p . -u main/pppCrystal2 -o /tmp/final_pppCrystal2.json pppFrameCrystal2