### PR TITLE
Match CMapPcs drawAfter debug color temporary

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -880,8 +880,7 @@ void CMapPcs::drawAfter()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }
@@ -934,8 +933,7 @@ void CMapPcs::drawAfterViewer()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Pass the map debug bound color as a temporary `CColor`, matching the constructor-return copy pattern used by the target.
- Applies the same source cleanup to `drawAfter` and `drawAfterViewer`.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/p_map -o - drawAfter__7CMapPcsFv`: 100.0% match, 540b.
- `build/tools/objdiff-cli diff -p . -u main/p_map -o - drawAfterViewer__7CMapPcsFv`: improved to 99.977776%, 540b.
- Build report improved matched code by 540 bytes and matched functions by 1.

## Plausibility
- This uses ordinary C++ temporary construction for the `CColor` argument and removes an unnecessary named local. No address, section, vtable, or linkage hacks.