### PR TITLE
Match CMapPcs drawAfter debug color

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -880,8 +880,7 @@ void CMapPcs::drawAfter()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }
@@ -934,8 +933,7 @@ void CMapPcs::drawAfterViewer()
             if ((*reinterpret_cast<u32*>(CFlat + 0x129C) & 0x02000000) != 0) {
                 CBoundHack bound;
                 bound = *reinterpret_cast<CBoundHack*>(reinterpret_cast<char*>(&CameraPcs) + 0x414);
-                CColor debugColor(0xFF, 0xFF, 0x80, 0xFF);
-                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, debugColor.color);
+                DrawBound__8CGraphicFR6CBound8_GXColor(&Graphic, &bound, CColor(0xFF, 0xFF, 0x80, 0xFF).color);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Pass the debug bound color as a temporary CColor in CMapPcs drawAfter paths.
- This matches the constructor-return codegen pattern used by the original for drawAfter and improves drawAfterViewer.

## Objdiff Evidence
- main/p_map drawAfter__7CMapPcsFv: 99.933334% -> 100.0% (540b matched)
- main/p_map drawAfterViewer__7CMapPcsFv: 99.95556% -> 99.977776%
- ninja report: Game Code matched bytes 156784 -> 157324; matched functions 1577 -> 1578

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_map -o /tmp/pmap_final.json