### PR TITLE
Fix p_map rel profile small data layout

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -37,6 +37,9 @@ class CRelProfile
 {
 public:
     ~CRelProfile();
+
+private:
+    unsigned int m_data;
 };
 
 unsigned int m_table_desc0__7CMapPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CMapPcsFv)};
@@ -116,11 +119,11 @@ unsigned int m_table__7CMapPcs[3][0x414 / 3 / sizeof(unsigned int)] = {
     },
 };
 
-CRelProfile g_hit_prof;
-CRelProfile g_map_calc_prof;
-CRelProfile g_map_draw_prof;
 unsigned int s_loadedStageNo__7CMapPcs;
 unsigned int s_loadedMapNo__7CMapPcs;
+CRelProfile s_mapRelProfile0__7CMapPcs;
+CRelProfile s_mapRelProfile1__7CMapPcs;
+CRelProfile s_mapRelProfile2__7CMapPcs;
 extern const float DrawRangeDefault;
 extern const float kPMapBoundMinInit;
 extern const float kPMapBoundMaxInit;


### PR DESCRIPTION
## Summary
- Give CRelProfile its MAP-backed word-sized payload.
- Move and rename the p_map rel profile globals after s_loadedStageNo__7CMapPcs and s_loadedMapNo__7CMapPcs to match the shipped small-data layout symbols.

## Evidence
- ninja succeeds.
- main/p_map __sinit_p_map_cpp improves from 52.07377% to 52.114754%.
- main/p_map .text improves from 90.84457% to 90.850815%.
- LoadMap__7CMapPcsFiiPvUlUc stays at 86.24171% and m_table__7CMapPcs stays 100%.

## Plausibility
- This is backed by config/GCCP01/symbols.txt: s_loadedStageNo__7CMapPcs and s_loadedMapNo__7CMapPcs precede s_mapRelProfile0/1/2 in small data, with the profile entries word-sized.