### PR TITLE
Match YmTracer sdata2 constants

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -150,7 +150,7 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
                 SetUpPaletteEnv(texture);
             }
 
-            uvStep = FLOAT_803306ec / (f32)work->count;
+            uvStep = FLOAT_803306ec / (f32)(s32)work->count;
             GXSetCullMode(GX_CULL_NONE);
 
             for (i = 0; i < (s32)(work->count - 1); i++) {
@@ -323,7 +323,7 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
             Vec splineFrom[4];
             Vec splineTo[4];
             s16 splineCount = 0;
-            f64 stepScale = FLOAT_803306ec / (f32)(param_2->m_payload[9] + 1);
+            f64 stepScale = FLOAT_803306ec / (f32)(u32)(param_2->m_payload[9] + 1);
 
             for (i = 0; i < (s32)(u32)param_2->m_payload[9]; i++) {
                 f32 t = stepScale * (f32)(i + 1);


### PR DESCRIPTION
## Summary
- Adjust `pppYmTracer` float conversion signedness so the compiler emits the two `.sdata2` conversion doubles in the target order.
- This matches the unit `.sdata2` section while keeping source-level behavior equivalent for these bounded counts.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer -o /tmp/pppYmTracer_final.json --format json`
- `[.sdata2-0]`: 50.0% -> 100.0% (16 bytes)
- Overall build report data matched: 1,095,177 -> 1,095,193 bytes (+16)

## Notes
- Local code percentages for `pppRenderYmTracer` / `pppFrameYmTracer` move slightly due to cast codegen, but total matched code bytes in the build report remain unchanged. The change is aimed at the real data-layout mismatch for the conversion constants.