### PR TITLE
Improve pppBlurChara render color staging

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -241,7 +241,7 @@ void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppB
         1, 0, 0, 0, 0);
     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 1, 5, 7);
 
-    GXSetChanMatColor(GX_COLOR0A0, *reinterpret_cast<_GXColor*>(&colorData->m_color));
+    GXSetChanMatColor(GX_COLOR0A0, drawColor);
     GXSetChanCtrl(GX_COLOR0A0, GX_DISABLE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
     drawColor.r = colorData->m_color.rgba[0];
     drawColor.g = colorData->m_color.rgba[1];


### PR DESCRIPTION
## Summary
- update pppRenderBlurChara to pass the local draw color into GXSetChanMatColor, matching the stack-color staging shown by the decompiled reference

## Evidence
- build: ninja
- objdiff pppRenderBlurChara: 99.19452% -> 99.21096%
- main/pppBlurChara unit .text: 98.8067% -> 98.81443%
- BlurChara_AfterDrawModelCallback remains 97.6679%

## Notes
- MWCC reports drawColor as uninitialized at this call site; this matches the current target/Ghidra ordering where the local color is staged after GXSetChanMatColor.