### PR TITLE
Fix CMapPcs base class

### DIFF
--- a/include/ffcc/p_map.h
+++ b/include/ffcc/p_map.h
@@ -4,7 +4,7 @@
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 
-#include "ffcc/system.h"
+#include "ffcc/p_sample.h"
 
 struct Vec;
 
@@ -12,7 +12,7 @@ void mapInitDrawEnv();
 extern const float kMapBoundsCenterScale;
 extern const float kMapCameraCenterYOffset;
 
-class CMapPcs : public CProcess
+class CMapPcs : public CSamplePcs
 {
 public:
     CMapPcs();


### PR DESCRIPTION
## Summary
- Make CMapPcs inherit from CSamplePcs instead of CProcess, matching the static initializer's base vtable path used by other process classes.
- This keeps the object layout unchanged while improving p_map static initialization output.

## Evidence
- Build: ninja
- Objdiff: __sinit_p_map_cpp improves from 52.795% to 57.213%.
- Unit .text improves from 91.134% to 91.806%.
- LoadMap__7CMapPcsFiiPvUlUc remains unchanged at 87.545%.