### PR TITLE
Improve pppYmEnv paraboloid lookup tables

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -92,8 +92,8 @@ struct CModelRaw {
 void drawParaboloidMap(_GXTexObj* texObjs, _GXTexObj* targetTexObj, void* displayList, unsigned long displayListSize,
                        _GXTexObj* blendTexObj, unsigned char mode)
 {
-    const unsigned char s_texObjIndices[] = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4};
-    const unsigned char s_xAxisRotIndices[] = {0, 0, 0, 1, 1, 0, 0, 0, 1, 1};
+    const unsigned char s_texObjIndices[] = {5, 2, 1, 0, 4, 5, 0, 0, 0, 0};
+    const unsigned char s_xAxisRotIndices[] = {0, 0, 0, 0, 1, 1, 0, 0, 2, 0};
     const unsigned char s_yAxisRotIndices[] = {0, 1, 0, 0, 1, 0, 1, 0, 0, 1};
     const float s_xAxisAngles[] = {0.0f, 90.0f, 180.0f, 270.0f};
     const unsigned char s_xAxisIds[] = {'x', 'x', 'x', 'x'};


### PR DESCRIPTION
## Summary
- Update the first two drawParaboloidMap lookup tables to match the target rodata bytes.
- Leaves the draw function codegen unchanged while improving pppYmEnv data matching.

## Evidence
- ninja: passes
- objdiff main/pppYmEnv drawParaboloidMap:
  - .rodata match: 74.324326% -> 77.7027%
  - .text match: 78.22535% current, unchanged by the table data correction
  - .sdata2 match: 27.659575% current

## Plausibility
- The change is confined to existing lookup-table data used by drawParaboloidMap face/rotation selection.
- No fake symbols, address hardcoding, manual sections, or generated ctor/dtor/vtable work.