### PR TITLE
Avoid ptrarray data in declaration-only includes

### DIFF
--- a/include/ffcc/ptrarray.h
+++ b/include/ffcc/ptrarray.h
@@ -6,8 +6,10 @@
 #include "ffcc/system.h"
 #include <string.h>
 
+#ifndef FFCC_PTRARRAY_DECL_ONLY
 static char s_CPtrArrayGrowError[] = "CPtrArray grow error";
 static char s_CPtrArrayFile[] = "collection/ptrarray.h";
+#endif
 
 template <class T>
 class CPtrArray


### PR DESCRIPTION
## Summary
- Gate the generic `CPtrArray` support strings behind `!FFCC_PTRARRAY_DECL_ONLY`.
- This keeps declaration-only users from emitting unused `CPtrArray grow error` / `collection/ptrarray.h` data while still allowing units with full template definitions to own those strings.
- `mapanim.o` now only owns the local mapanim ptrarray strings plus the `CPtrArray<CMapAnimNode*>` vtable in `.data`.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/mapanim -o /tmp/mapanim_final.json`
- `main/mapanim` `.data` payload symbol `[.data-0]` improved from 16.666668% to 80.0%.
- Final mapanim sections: `.text` 99.721565%, `.rodata` 100.0%, `.data` 80.0%.

## Plausibility
`FFCC_PTRARRAY_DECL_ONLY` is already used to include only declarations before explicit local specializations. Suppressing the generic support data in that mode matches the target object layout without manually defining vtables, forcing sections, or introducing address-based hacks.