### PR TITLE
Improve pppYmMana mesh and prgobj rotation matching

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1139,7 +1139,6 @@ static int CreateWaterMesh(Vec* positionsInOut, Vec* normalsOut, Vec2d* uvOut, u
     float zero;
     float normalY;
     float radius;
-    float step;
     float uvStep;
     float x;
     float z;
@@ -1158,19 +1157,17 @@ static int CreateWaterMesh(Vec* positionsInOut, Vec* normalsOut, Vec2d* uvOut, u
     zero = FLOAT_80330e4c;
     rowCount = 0;
     uvStep = FLOAT_80330e6c;
-    step = size * uvStep;
     radius = size * FLOAT_80330e5c;
-    for (z = radius; -radius <= z; z -= step) {
+    for (z = radius; -radius <= z; z -= size * uvStep) {
         colCount = 0;
         rowUv = static_cast<float>(rowCount) * uvStep;
         positions = reinterpret_cast<float*>(positionsInOut);
         normals = reinterpret_cast<float*>(normalsOut);
         uvs = reinterpret_cast<float*>(uvOut);
-        for (x = -radius; x <= radius; x += step) {
+        for (x = -radius; x <= radius; x += size * uvStep) {
             *positions = x;
             positionsInOut = reinterpret_cast<Vec*>(positions + 3);
             positions[1] = zero;
-            colCount = colCount + 1;
             normalsOut = reinterpret_cast<Vec*>(normals + 3);
             uvOut = reinterpret_cast<Vec2d*>(uvs + 2);
             positions[2] = z;
@@ -1179,9 +1176,10 @@ static int CreateWaterMesh(Vec* positionsInOut, Vec* normalsOut, Vec2d* uvOut, u
             normals[1] = normalY;
             normals[2] = zero;
             normals = normals + 3;
-            *uvs = static_cast<float>(colCount - 1) * uvStep;
+            *uvs = static_cast<float>(colCount) * uvStep;
             uvs[1] = rowUv;
             uvs = uvs + 2;
+            colCount = colCount + 1;
         }
         rowCount = rowCount + 1;
     }

--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -210,14 +210,14 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	float targetRot;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(self->m_worldPosition);
-	CVector deltaPos;
+	Vec deltaPos;
 	float deltaX;
 	float zero;
 	float deltaZ;
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	deltaX = deltaPos.x;
-	zero = 0.0f;
+	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
 	if (zero == deltaX || zero == deltaZ) {
 		targetRot = zero;
@@ -280,7 +280,7 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
 	deltaX = deltaPos.x;
-	zero = 0.0f;
+	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
 	if (zero == deltaX || zero == deltaZ) {
 		targetRot = zero;


### PR DESCRIPTION
## Summary
- Reshape pppYmMana water mesh generation to match the target loop expression/order more closely.
- Use a plain Vec output and shared zero constant in CGPrgObj target-rotation helpers.

## Objdiff evidence
- main/pppYmMana .text: 78.64177 -> 78.645775
- CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf: 58.643566 -> 58.792080
- main/prgobj .text: 97.502075 -> 97.51729
- dstTargetRot__8CGPrgObjFP8CGPrgObj: 87.681816 -> 87.931816
- rotTarget__8CGPrgObjFP8CGPrgObj and getTargetRot__8CGPrgObjFP8CGPrgObj remain unchanged

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmMana -o /tmp/pppYmMana_final.json
- build/tools/objdiff-cli diff -p . -u main/prgobj -o /tmp/prgobj_final.json