### PR TITLE
Improve pppYmTracer2 render setup ordering

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -121,11 +121,11 @@ void pppRenderYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, p
 
     dataValIndex = param_2->m_dataValIndex;
     dataOffset = *param_3->m_serializedDataOffsets;
-    colorOffset = param_3->m_serializedDataOffsets[1];
     work = (TracerWork*)(pppYmTracer2->m_serializedData + dataOffset);
-    colorData = pppYmTracer2->m_serializedData + colorOffset;
+    colorOffset = param_3->m_serializedDataOffsets[1];
     poly = work->entries;
     mapMesh = pppEnvStPtr->m_mapMeshPtr[dataValIndex];
+    colorData = pppYmTracer2->m_serializedData + colorOffset;
 
     if (dataValIndex != 0xFFFF) {
         pppSetBlendMode(param_2->m_payload[10]);


### PR DESCRIPTION
## Summary
- Reordered the initial `pppRenderYmTracer2` setup so the work pointer is established before deriving the color work pointer.
- This matches the target load/use order more closely without changing behavior or adding output-oriented hacks.

## Objdiff Evidence
- `main/pppYmTracer2` unit/text report: 97.899826% -> 97.9877%
- `pppRenderYmTracer2`: 97.80488% -> 98.00813%
- `pppFrameYmTracer2`: unchanged at 97.51798%
- Constructors/destructor remain matched.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppRenderYmTracer2`
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppFrameYmTracer2`

## Plausibility
The change is a straightforward source ordering adjustment in the setup block. It keeps the existing data model, avoids fake symbols or address tricks, and reflects a plausible original ordering where the render work state is loaded before the color data pointer is materialized.
