### PR TITLE
Avoid stray ptrarray instantiations in particle units

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -2,7 +2,9 @@
 #include "ffcc/graphic.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/render_buffers.h"
+#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/game.h"
+#undef FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/pppPart.h"
 #include "ffcc/partMng.h"
 #include "ffcc/util.h"

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -3,7 +3,9 @@
 #include "ffcc/graphic.h"
 #include "ffcc/materialman.h"
 #include "ffcc/math.h"
+#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/ptrarray.h"
+#undef FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/partMng.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/linkage.h"


### PR DESCRIPTION
## Summary
- Use declaration-only `ptrarray.h` inclusion in `pppScreenBreak` so `CPtrArray<CMaterial*>` resolves to the existing external specialization instead of emitting local weak helpers and strings.
- Use declaration-only `ptrarray.h` inclusion through `game.h` in `pppMiasma` to avoid unused local ptrarray string data.

## Evidence
- `ninja` succeeds.
- `main/pppScreenBreak`: `.text` match improves `90.98127% -> 90.994644%`; generated `.data` shrinks `76 -> 28` bytes to match target; extab improves `92.10526% -> 97.22222%`; extabindex improves `92.98246% -> 98.14815%`.
- `main/pppMiasma`: generated stray `.data` containing `s_CPtrArrayGrowError`/`s_CPtrArrayFile` is removed (`46 -> 0` bytes) while text score/size remain unchanged.

## Plausibility
- The original objects treat these ptrarray helpers/data as external or absent. This keeps normal C++ linkage and avoids manually defining ABI objects or vtables.
