### PR TITLE
Avoid transitive ptrarray includes

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -7,7 +7,6 @@
 #include "ffcc/gobjwork.h"
 #include "ffcc/manager.h"
 #include "ffcc/memory.h"
-#include "ffcc/ptrarray.h"
 
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>

--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -1,8 +1,6 @@
 #ifndef _FFCC_MAPOBJ_H_
 #define _FFCC_MAPOBJ_H_
 
-#include "ffcc/ptrarray.h"
-
 class CChunkFile;
 class CMapKeyFrame;
 class CMapCylinder;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,5 +1,6 @@
 #include "ffcc/game.h"
 
+#include "ffcc/ptrarray.h"
 #include "ffcc/partyobj.h"
 #include "ffcc/system.h"
 #include "ffcc/vector.h"

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/mapobj.h"
+#include "ffcc/ptrarray.h"
 #include "ffcc/map.h"
 #include "ffcc/chunkfile.h"
 #include "ffcc/maphit.h"

--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -1,5 +1,6 @@
 #define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/maptexanim.h"
+#include "ffcc/ptrarray.h"
 #include "ffcc/chunkfile.h"
 #include "ffcc/map.h"
 #include "ffcc/memory.h"


### PR DESCRIPTION
## Summary
- Remove unused `ptrarray.h` includes from `game.h` and `mapobj.h` so unrelated translation units do not emit CPtrArray support data.
- Add explicit `ptrarray.h` includes to `game.cpp`, `mapobj.cpp`, and `maptexanim.cpp`, which are the files that actually use `CPtrArray` after this cleanup.

## Evidence
- `ninja` passes and `build/GCCP01/main.dol: OK`.
- `main/pppYmMiasma` objdiff keeps the same code/section matches: `.text` 95.5474%, extab 100%, extabindex 98.333336%, rodata 100%.
- `main/pppYmMiasma` generated sections no longer include the unrelated `.data` section with `CPtrArray grow error` / `collection/ptrarray.h`; direct symbol check for `CPtrArray|ptrarray` is empty.

## Plausibility
- `game.h` and `mapobj.h` do not declare or store `CPtrArray` members, so depending on `ptrarray.h` there was unnecessary header coupling.
- Files that instantiate or access `CPtrArray` now include the header directly, matching their real dependency.
