### PR TITLE
Clean up CPtrArray header macros and align Add/setSize signatures

### DIFF
--- a/include/ffcc/ptrarray.h
+++ b/include/ffcc/ptrarray.h
@@ -6,40 +6,25 @@
 #include "ffcc/system.h"
 #include <string.h>
 
-#ifndef FFCC_PTRARRAY_DECL_ONLY
-static char s_CPtrArrayGrowError[] = "CPtrArray grow error";
-static char s_CPtrArrayFile[] = "collection/ptrarray.h";
-#endif
-
 template <class T>
 class CPtrArray
 {
 public:
     CPtrArray();
     virtual ~CPtrArray();
-    
+
     int GetSize();
-#ifdef FFCC_PTRARRAY_INT_RETURN
     int Add(T item);
-#else
-    bool Add(T item);
-#endif
     void RemoveAll();
-#ifdef FFCC_PTRARRAY_RELEASE_AND_REMOVE_ALL
     void ReleaseAndRemoveAll();
-#endif
     T GetAt(unsigned long index);
     T operator[](unsigned long index);
     void SetStage(CMemory::CStage* stage);
     void SetDefaultSize(unsigned long defaultSize);
     void SetGrow(int growCapacity);
-    
+
 private:
-#ifdef FFCC_PTRARRAY_INT_RETURN
     int setSize(unsigned long newSize);
-#else
-    bool setSize(unsigned long newSize);
-#endif
 
     unsigned long m_numItems;
     unsigned long m_size;
@@ -48,8 +33,6 @@ private:
     CMemory::CStage* m_stage;
     int m_growCapacity;
 };
-
-#ifndef FFCC_PTRARRAY_DECL_ONLY
 
 template <class T>
 CPtrArray<T>::CPtrArray()
@@ -105,14 +88,15 @@ void CPtrArray<T>::SetGrow(int growCapacity)
 }
 
 template <class T>
-bool CPtrArray<T>::Add(T item)
+int CPtrArray<T>::Add(T item)
 {
-    bool success = setSize(m_numItems + 1);
-    if (success) {
-        m_items[m_numItems] = item;
-        m_numItems = m_numItems + 1;
+    if (setSize(m_numItems + 1) == 0) {
+        return 0;
     }
-    return success;
+
+    m_items[m_numItems] = item;
+    m_numItems = m_numItems + 1;
+    return 1;
 }
 
 template <class T>
@@ -127,40 +111,57 @@ void CPtrArray<T>::RemoveAll()
 }
 
 template <class T>
-bool CPtrArray<T>::setSize(unsigned long newSize)
+void CPtrArray<T>::ReleaseAndRemoveAll()
+{
+    int offset = 0;
+    for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
+        int* item = *(int**)((int)m_items + offset);
+        if (item != 0) {
+            int refCount = item[1];
+            item[1] = refCount - 1;
+            if (refCount - 1 == 0 && item != 0) {
+                (*(void (**)(int*, int))(*item + 8))(item, 1);
+            }
+            *(unsigned int*)((int)m_items + offset) = 0;
+        }
+        offset += 4;
+    }
+    RemoveAll();
+}
+
+template <class T>
+int CPtrArray<T>::setSize(unsigned long newSize)
 {
     T* newItems;
-    
+
     if (m_size < newSize) {
         if (m_size == 0) {
             m_size = m_defaultSize;
         } else {
             if (m_growCapacity == 0) {
-                System.Printf(s_CPtrArrayGrowError);
+                System.Printf("CPtrArray grow error");
             }
             m_size = m_size << 1;
         }
-        
-        newItems = static_cast<T*>(Memory._Alloc(m_size * sizeof(T), m_stage, s_CPtrArrayFile, 0xfa, 0));
+
+        newItems = static_cast<T*>(Memory._Alloc(m_size * sizeof(T), m_stage, "collection_ptrarray.h", 0xfa, 0));
         if (newItems == 0) {
-            return false;
+            return 0;
         }
-        
+
         if (m_items != 0) {
             memcpy(newItems, m_items, m_numItems * sizeof(T));
         }
-        
+
         if (m_items != 0) {
             delete[] m_items;
             m_items = 0;
         }
-        
+
         m_items = newItems;
     }
 
-    return true;
+    return 1;
 }
-
-#endif // FFCC_PTRARRAY_DECL_ONLY
 
 #endif // _FFCC_PTRARRAY_H_

--- a/include/ffcc/texanim.h
+++ b/include/ffcc/texanim.h
@@ -3,12 +3,7 @@
 
 #include "ffcc/memory.h"
 #include "ffcc/ref.h"
-
-#define FFCC_PTRARRAY_RELEASE_AND_REMOVE_ALL
-#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/ptrarray.h"
-#undef FFCC_PTRARRAY_DECL_ONLY
-#undef FFCC_PTRARRAY_RELEASE_AND_REMOVE_ALL
 
 class CMaterialSet;
 class CMaterial;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -404,7 +404,7 @@ extern "C" CPtrArray<CMapLightHolder*>* dtor_80034414(CPtrArray<CMapLightHolder*
 }
 
 template <>
-bool CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize);
+int CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize);
 
 /*
  * --INFO--
@@ -416,14 +416,14 @@ bool CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize);
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CMapLightHolder*>::Add(CMapLightHolder* item)
+int CPtrArray<CMapLightHolder*>::Add(CMapLightHolder* item)
 {
-    bool success = setSize(m_numItems + 1);
-    if (success) {
-        m_items[m_numItems] = item;
-        m_numItems++;
+    if (setSize(m_numItems + 1) == 0) {
+        return 0;
     }
-    return success;
+    m_items[m_numItems] = item;
+    m_numItems++;
+    return 1;
 }
 
 /*
@@ -467,7 +467,7 @@ void CPtrArray<CMapLightHolder*>::SetStage(CMemory::CStage* stage)
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize)
+int CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize)
 {
     CMapLightHolder** newItems;
 
@@ -484,7 +484,7 @@ bool CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize)
         newItems = (CMapLightHolder**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
             &Memory, m_size << 2, m_stage, const_cast<char*>(s_map_collection_ptrarray_h), 0xFA, 0);
         if (newItems == 0) {
-            return false;
+            return 0;
         }
 
         if (m_items != 0) {
@@ -498,11 +498,11 @@ bool CPtrArray<CMapLightHolder*>::setSize(unsigned long newSize)
         m_items = newItems;
     }
 
-    return true;
+    return 1;
 }
 
 template <>
-bool CPtrArray<CMapAnim*>::setSize(unsigned long newSize);
+int CPtrArray<CMapAnim*>::setSize(unsigned long newSize);
 
 /*
  * --INFO--
@@ -514,14 +514,14 @@ bool CPtrArray<CMapAnim*>::setSize(unsigned long newSize);
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CMapAnim*>::Add(CMapAnim* item)
+int CPtrArray<CMapAnim*>::Add(CMapAnim* item)
 {
-    bool success = setSize(m_numItems + 1);
-    if (success) {
-        m_items[m_numItems] = item;
-        m_numItems++;
+    if (setSize(m_numItems + 1) == 0) {
+        return 0;
     }
-    return success;
+    m_items[m_numItems] = item;
+    m_numItems++;
+    return 1;
 }
 
 /*
@@ -726,7 +726,7 @@ void CPtrArray<CMapAnim*>::SetStage(CMemory::CStage* stage)
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CMapAnim*>::setSize(unsigned long newSize)
+int CPtrArray<CMapAnim*>::setSize(unsigned long newSize)
 {
     CMapAnim** newItems;
 
@@ -743,7 +743,7 @@ bool CPtrArray<CMapAnim*>::setSize(unsigned long newSize)
         newItems = (CMapAnim**)_Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
             &Memory, m_size << 2, m_stage, const_cast<char*>(s_map_collection_ptrarray_h), 0xFA, 0);
         if (newItems == 0) {
-            return false;
+            return 0;
         }
 
         if (m_items != 0) {
@@ -757,7 +757,7 @@ bool CPtrArray<CMapAnim*>::setSize(unsigned long newSize)
         m_items = newItems;
     }
 
-    return true;
+    return 1;
 }
 
 /*

--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -1,8 +1,4 @@
-#define FFCC_PTRARRAY_DECL_ONLY
-#define FFCC_PTRARRAY_INT_RETURN
 #include "ffcc/mapanim.h"
-#undef FFCC_PTRARRAY_INT_RETURN
-#undef FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/chunkfile.h"
 #include "ffcc/linkage.h"
 #include "ffcc/memory.h"

--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -1,4 +1,3 @@
-#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/maptexanim.h"
 #include "ffcc/ptrarray.h"
 #include "ffcc/chunkfile.h"

--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -2,9 +2,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/render_buffers.h"
-#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/game.h"
-#undef FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/pppPart.h"
 #include "ffcc/partMng.h"
 #include "ffcc/util.h"

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -3,9 +3,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/materialman.h"
 #include "ffcc/math.h"
-#define FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/ptrarray.h"
-#undef FFCC_PTRARRAY_DECL_ONLY
 #include "ffcc/partMng.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/linkage.h"

--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -209,14 +209,14 @@ CPtrArray<CTexAnimSeq*>::~CPtrArray()
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CTexAnimSeq*>::Add(CTexAnimSeq* item)
+int CPtrArray<CTexAnimSeq*>::Add(CTexAnimSeq* item)
 {
     if (setSize(m_numItems + 1) == 0) {
-        return false;
+        return 0;
     }
     m_items[m_numItems] = item;
     m_numItems = m_numItems + 1;
-    return true;
+    return 1;
 }
 
 /*
@@ -332,7 +332,7 @@ void CPtrArray<CTexAnimSeq*>::SetStage(CMemory::CStage* stage)
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CTexAnimSeq*>::setSize(unsigned long newSize)
+int CPtrArray<CTexAnimSeq*>::setSize(unsigned long newSize)
 {
     CTexAnimSeq** newItems;
 
@@ -426,14 +426,14 @@ CPtrArray<CTexAnim*>::~CPtrArray()
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CTexAnim*>::Add(CTexAnim* item)
+int CPtrArray<CTexAnim*>::Add(CTexAnim* item)
 {
     if (setSize(m_numItems + 1) == 0) {
-        return false;
+        return 0;
     }
     m_items[m_numItems] = item;
     m_numItems = m_numItems + 1;
-    return true;
+    return 1;
 }
 
 /*
@@ -549,7 +549,7 @@ void CPtrArray<CTexAnim*>::SetStage(CMemory::CStage* stage)
  * JP Size: TODO
  */
 template <>
-bool CPtrArray<CTexAnim*>::setSize(unsigned long newSize)
+int CPtrArray<CTexAnim*>::setSize(unsigned long newSize)
 {
     CTexAnim** newItems;
 


### PR DESCRIPTION
The ffcc/ptrarray.h header was wrapped in three speculative macros (FFCC_PTRARRAY_DECL_ONLY, FFCC_PTRARRAY_INT_RETURN, FFCC_PTRARRAY_RELEASE_AND_REMOVE_ALL) plus file-scope static char[] arrays for grow-error / file-name strings. None of this is plausible original source.

The DECL_ONLY guard existed only because the header emitted file-scope static char[] objects into every including TU under fixed names that conflicted with the per-TU literals callers wanted. Inlining the literals directly into setSize() lets MWCC's per-TU literal pooling do the right thing automatically and removes the need for the guard.

The INT_RETURN guard existed because mapanim.cpp's explicit specializations returned int. Objdiff evidence backs int as the original signature: in mapanim, Add tests setSize() and the original emits 'cmpwi r3, 0x0' (int), not 'clrlwi. r0, r3, 24' (bool). Standardizing on int Add / int setSize for the canonical template matches that evidence.

The RELEASE_AND_REMOVE_ALL guard gated whether ReleaseAndRemoveAll was even declared. The function is always declared in the original; MWCC only emits the body in TUs that ODR-use it (matching the weak symbols in the PAL MAP). Defining it unconditionally with the canonical offset-arithmetic body restores that behavior.

Changes:
- Drop all three macros from include/ffcc/ptrarray.h.
- Inline 'CPtrArray grow error' / 'collection_ptrarray.h' into setSize().
- Standardize Add/setSize on int return with the early-return idiom.
- Always declare and define ReleaseAndRemoveAll.
- Remove the macro define/undef dance from src/mapanim.cpp, src/maptexanim.cpp, src/pppMiasma.cpp, src/pppScreenBreak.cpp, include/ffcc/texanim.h.
- Convert bool Add/setSize specializations in src/map.cpp, src/texanim.cpp, src/mapanim.cpp to int to match the new signature.

Net effect:
- main/map         match 14.97% -> 16.00%
- main/mapobj      match  7.79% -> 9.17%
- main/texanim     match 37.60% -> 41.97%
- 6 CPtrArray<T>::Add specializations reach 100% match:
  CMapAnim, CMapLightHolder, CMapShadow, CMapAnimRun,
  CTexAnim, CTexAnimSeq.
- One minor unrelated 1.74% regression in ReadOtmObj (rodata shift).
- +8 matched functions overall (1595 -> 1603).