### PR TITLE
Match map shadow octree insertion

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -30,7 +30,7 @@ void CMapShadowInsertOctTree(CMapShadow::TARGET mapShadow, COctTree& octTree)
 	CPtrArray<CMapShadow*>* mapShadowArray;
 	CMapShadow* shadow;
 	u32 boundOffset;
-	u32 i;
+	int i;
 	u32 octTreeMask;
 	Vec pos;
 	CBound* bound;
@@ -39,22 +39,18 @@ void CMapShadowInsertOctTree(CMapShadow::TARGET mapShadow, COctTree& octTree)
 	if (*(u32*)(*(u32*)((char*)&octTree + 0x8) + 0x3c) != 0) {
 		mapShadowArray = reinterpret_cast<CPtrArray<CMapShadow*>*>((char*)&MapMng + 0x21434);
 		boundOffset = (u32)mapShadow * sizeof(CBound);
-		for (i = 0; i < mapShadowArray->GetSize(); i++) {
+		for (i = 0; i < (u32)mapShadowArray->GetSize(); i++) {
 			octTreeMask = *(u32*)(*(u32*)((char*)&octTree + 0x8) + 0x3c);
-			if ((octTreeMask & (1U << i)) == 0) {
-				continue;
-			}
-			shadow = (*mapShadowArray)[i];
-			if ((shadow->m_targetEnabled[(int)mapShadow] == 0) || (shadow->m_materialMode != 0)) {
-				continue;
-			}
+			if (((octTreeMask & (1U << i)) != 0) &&
+			    ((shadow = (*mapShadowArray)[i])->m_targetEnabled[(int)mapShadow] != 0) &&
+			    (shadow->m_materialMode == 0)) {
+				pos.x = *(float*)((int)shadow->m_modelA + 0xc4);
+				pos.y = *(float*)((int)shadow->m_modelA + 0xd4);
+				pos.z = *(float*)((int)shadow->m_modelA + 0xe4);
 
-			pos.x = *(float*)((int)shadow->m_modelA + 0xc4);
-			pos.y = *(float*)((int)shadow->m_modelA + 0xd4);
-			pos.z = *(float*)((int)shadow->m_modelA + 0xe4);
-
-			bound = reinterpret_cast<CBound*>(shadow->m_targetBounds + boundOffset);
-			octTree.InsertShadow(i, pos, *bound);
+				bound = reinterpret_cast<CBound*>(shadow->m_targetBounds + boundOffset);
+				octTree.InsertShadow(i, pos, *bound);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Matched `CMapShadowInsertOctTree(CMapShadow::TARGET, COctTree&)` in `main/mapshadow`
- Reshaped the loop to use the signed counter / unsigned bound comparison and combined predicate form that matches the original codegen

## Evidence
- `ninja`: OK
- `build/tools/objdiff-cli diff -p . -u main/mapshadow -o - CMapShadowInsertOctTree__FQ210CMapShadow6TARGETR8COctTree`
  - before: 96.61017% match, 236b
  - after: 100.0% match, 236b
- Overall progress after build: code matched 498148 / 1855224 bytes, 3120 / 4732 functions

## Plausibility
- No manual section forcing, fake symbols, or address hacks
- Keeps the existing function and data layout intact while making the loop source shape closer to the target control flow