### PR TITLE
Improve CTexAnimSet Change loop locals

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -950,16 +950,15 @@ void CTexAnimSet::AddFrame()
 void CTexAnimSet::Change(char* name, float frame, CTexAnimSet::ANIM_TYPE mode)
 {
     CTexAnimSetStorage* self = reinterpret_cast<CTexAnimSetStorage*>(this);
-    for (unsigned int texAnimIndex = 0; texAnimIndex < static_cast<unsigned int>(GetSize__21CPtrArray_P8CTexAnim_Fv(&self->texAnims));
+    unsigned int seqIndex;
+    unsigned int texAnimIndex;
+
+    for (texAnimIndex = 0; texAnimIndex < static_cast<unsigned int>(GetSize__21CPtrArray_P8CTexAnim_Fv(&self->texAnims));
          texAnimIndex = texAnimIndex + 1) {
         CTexAnimStorage* texAnim =
             reinterpret_cast<CTexAnimStorage*>(__vc__21CPtrArray_P8CTexAnim_FUl(&self->texAnims, texAnimIndex));
-        unsigned int seqIndex;
-        unsigned int seqCount;
-
         for (seqIndex = 0;
-             ((seqCount = static_cast<unsigned int>(GetSize__25CPtrArray_P11CTexAnimSeq_Fv(Ptr(texAnim->refData, 0x110)))),
-              seqIndex < seqCount);
+             seqIndex < static_cast<unsigned int>(GetSize__25CPtrArray_P11CTexAnimSeq_Fv(Ptr(texAnim->refData, 0x110)));
              seqIndex = seqIndex + 1) {
             CTexAnimSeqStorage* seq =
                 reinterpret_cast<CTexAnimSeqStorage*>(__vc__25CPtrArray_P11CTexAnimSeq_FUl(Ptr(texAnim->refData, 0x110), seqIndex));


### PR DESCRIPTION
Summary:\n- Hoists the CTexAnimSet::Change loop indices into explicit locals.\n- Removes the extra seqCount temporary so the inner loop source more closely follows the PAL/Ghidra shape.\n\nEvidence:\n- build/tools/objdiff-cli diff -p . -u main/texanim -o /tmp/texanim_change_diff.json Change__11CTexAnimSetFPcfQ211CTexAnimSet9ANIM_TYPE\n- CTexAnimSet::Change improved from 92.5% to 93.65385% match.\n- ninja passes and build/GCCP01/main.dol remains OK.\n\nPlausibility:\n- The change preserves behavior and only adjusts local variable lifetime/order around the nested search loops.\n- The resulting source matches the decompiled PAL loop shape more closely without hard-coded addresses or artificial symbols.