### PR TITLE
Improve CAmemCacheSet CalcPrio matching

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2163,8 +2163,8 @@ void CAmemCacheSet::CacheClear()
 void CAmemCacheSet::CalcPrio()
 {
     unsigned char* bytes = reinterpret_cast<unsigned char*>(this);
-    int i = 0;
     int offset = 0;
+    int i = 0;
 
     while (i < *reinterpret_cast<int*>(bytes + 0x3C)) {
         int* entry = reinterpret_cast<int*>(*reinterpret_cast<int*>(bytes + 0x58) + offset);


### PR DESCRIPTION
## Summary
- Reordered the local declarations in CAmemCacheSet::CalcPrio so MWCC keeps the byte offset in the target register.
- This keeps the function size unchanged and improves the local instruction match without changing behavior.

## Evidence
- ninja passes for GCCP01.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_calcprio_final.json CalcPrio__13CAmemCacheSetFv
- CalcPrio__13CAmemCacheSetFv: 97.2% -> 97.8%, size remains 100 bytes.

## Plausibility
- The change is source-level local ordering only; it does not introduce hardcoded addresses, fake symbols, or section forcing.
- The resulting register allocation better matches the original while preserving the existing cache-priority logic.