### PR TITLE
Match pppYmMoveParabola constructor

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -97,7 +97,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
  */
 extern "C" void pppConstructYmMoveParabola(struct pppYmMoveParabola* basePtr, struct pppYmMoveParabolaUnkC* dataPtr)
 {
-    const f32 zero = 0.0f;
+    const f32 zero = gPppYmMoveParabolaZero;
     _pppMngSt* pppMngSt = pppMngStPtr;
     pppYmMoveParabolaWork* work =
         (pppYmMoveParabolaWork*)((u8*)basePtr + *dataPtr->m_serializedDataOffsets + 0x80);


### PR DESCRIPTION
## Summary
- Use the existing MAP-backed `gPppYmMoveParabolaZero` constant when initializing `pppConstructYmMoveParabola` work state.
- This removes the local zero literal mismatch and brings `pppConstructYmMoveParabola` to a full objdiff match.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o /tmp/pppYmMoveParabola.final.json pppConstructYmMoveParabola`: 100.0% match, 0 instruction diffs.
- `pppFrameYmMoveParabola` remains unchanged at 98.858696% with the same 4 diffs.
- `python3 tools/agent_select_target.py` no longer selects `main/pppYmMoveParabola` as a near-complete target after this change.

## Plausibility
The constructor already initializes all scalar fields from a shared zero value. Referencing the unit’s named `.sdata2` zero constant matches the MAP-backed data layout and is cleaner than emitting a TU-local `0.0f` literal.