### PR TITLE
Fix sdata2 ownership for map texture and screen break

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -27,6 +27,8 @@ char s_SetMapTexAnim_MaterialIdNotFound[];
 extern "C" float FLOAT_8032fd38;
 extern "C" float FLOAT_8032fd48;
 extern "C" float FLOAT_8032fd4c;
+extern "C" const double DOUBLE_8032FCD0 = 4503601774854144.0;
+extern "C" const float FLOAT_8032FCD8 = 0.0f;
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)

--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -45,20 +45,20 @@ static const char lbl_80331C3C[] = "MUTEKI";
 static const char lbl_80331C44[] = "FOLLOW";
 static const char s_DISPPRINT_801DD434[] = "DISPPRINT";
 static const char lbl_80331C4C[] = "COMBO";
-static const char lbl_80331C54[] = "PAUSE";
-static const char lbl_80331C5C[] = "BATTLE";
-static const char lbl_80331C64[] = "ANALOG";
+extern const char lbl_80331C54[];
+extern const char lbl_80331C5C[];
+extern const char lbl_80331C64[];
 static const char s_COLCHECK_801DD440[] = "COLCHECK";
-static const char lbl_80331C6C[] = "A*";
+extern const char lbl_80331C6C[];
 static const char s_PARTICLE_801DD44C[] = "PARTICLE";
-static const char lbl_80331C70[] = "PRINTF";
+extern const char lbl_80331C70[];
 static const char s_SOUND_INFO_801DD458[] = "SOUND INFO";
-static const char lbl_80331C78[] = "SHADOW";
+extern const char lbl_80331C78[];
 static const char s_PART_HEAP_801DD464[] = "PART HEAP";
 static const char s_CHARA_INFO_801DD470[] = "CHARA INFO";
 static const char s_ITEM_WEAPON_801DD47C[] = "ITEM WEAPON";
 static const char s_SMITH_MASTER_801DD488[] = "SMITH MASTER";
-static const char lbl_80331C80[] = "CHARA";
+extern const char lbl_80331C80[];
 
 u32 m_table_desc0__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__11CDbgMenuPcsFv)};
 u32 m_table_desc1__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__11CDbgMenuPcsFv)};
@@ -68,7 +68,7 @@ u32 m_table__11CDbgMenuPcs[0x15C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CDbgMenuPcs_801DD428)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x11, 0, 0, 0, 0, 0x4A, 1
 };
 
-const char s_Debug_80331c90[] = "Debug";
+extern const char s_Debug_80331c90[];
 
 DbgMenuDef PTR_DAT_80212524[] = {
     { lbl_80331C18, 100, 2, 1 },      { lbl_80331C20, 101, 2, 1 },      { lbl_80331C28, 102, 2, 1 },

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -89,20 +89,28 @@ struct pppScreenBreakUnkC {
 
 extern float FLOAT_80331cc0;
 extern float FLOAT_80331cc4;
+extern float FLOAT_80331cc8;
+extern float FLOAT_80331ccc;
 extern float FLOAT_80331cd0;
+extern float FLOAT_80331cd4;
+extern float FLOAT_80331cd8;
 extern float FLOAT_80331ce8;
 extern float FLOAT_80331cec;
 extern float FLOAT_80331cf0;
-static const float kPppScreenBreakDoubleScale = 2.0f;
-static const float kPppScreenBreakZero = 0.0f;
-static const float kPppScreenBreakRandRange = 0.3f;
-static const float kPppScreenBreakVelocityScale = -0.5f;
-static const float kPppScreenBreakOne = 1.0f;
-static const float kPppScreenBreakNegOne = -1.0f;
-static const float kPppScreenBreakDegreesToRadians = 0.017453292f;
-static const float kPppScreenBreakCameraOffset = 30.0f;
-static const float kPppScreenBreakLightAttn = 4.0f;
-static const float kPppScreenBreakLightBias = -3.0f;
+
+extern const char lbl_80331C54[] = "PAUSE";
+extern const char lbl_80331C5C[] = "BATTLE";
+extern const char lbl_80331C64[] = "ANALOG";
+extern const char lbl_80331C6C[] = "A*";
+extern const char lbl_80331C70[] = "PRINTF";
+extern const char lbl_80331C78[] = "SHADOW";
+extern const char lbl_80331C80[] = "CHARA";
+extern const u32 DAT_80331C88 = 0x00000080;
+extern const u32 DAT_80331C8C = 0xFFFFFFFF;
+extern const char s_Debug_80331c90[] = "Debug";
+extern const float FLOAT_80331C98 = 0.0f;
+extern const double DOUBLE_80331CA0 = 4503601774854144.0;
+
 static const Vec DAT_801dd4b0 = { 0.0f, 1.0f, 0.0f };
 static const char s_f999_root_801dd4c8[] = "f999_root";
 static const char s_pppScreenBreak_cpp_801dd4d4[] = "pppScreenBreak.cpp";
@@ -412,13 +420,13 @@ void InitPieceData(CChara::CModel* model, PScreenBreak* step, VScreenBreak* work
     Vec* inVec;
     s32 iVar16;
     float dVar17;
-    const float dVar18 = -kPppScreenBreakRandRange;
-    const float dVar19 = kPppScreenBreakRandRange;
-    const float dVar20 = kPppScreenBreakOne;
-    const float dVar21 = kPppScreenBreakNegOne;
-    const float dVar22 = kPppScreenBreakZero;
-    const float dVar24 = kPppScreenBreakDoubleScale;
-    const float dVar25 = kPppScreenBreakDegreesToRadians;
+    const float dVar18 = -FLOAT_80331cc8;
+    const float dVar19 = FLOAT_80331cc8;
+    const float dVar20 = FLOAT_80331cd0;
+    const float dVar21 = FLOAT_80331cd4;
+    const float dVar22 = FLOAT_80331cc4;
+    const float dVar24 = FLOAT_80331cc0;
+    const float dVar25 = FLOAT_80331cd8;
     S16Vec local_e8;
     S16Vec local_e0;
     S16Vec local_d8;
@@ -519,14 +527,14 @@ void InitPieceData(CChara::CModel* model, PScreenBreak* step, VScreenBreak* work
         local_e0.y = local_d8.y;
         local_d8.z = local_e0.z;
         ConvI2FVector__5CUtilFR3Vec6S16Vecl(&gUtil, inVec + 3, local_e0, *(u32*)(modelData + 0x34));
-        PSVECScale(inVec + 3, inVec + 3, kPppScreenBreakVelocityScale);
+        PSVECScale(inVec + 3, inVec + 3, FLOAT_80331ccc);
 
         dVar17 = inVec[3].x;
         if (dVar19 < dVar17) {
-            dVar17 = Math.RandF(kPppScreenBreakRandRange);
+            dVar17 = Math.RandF(FLOAT_80331cc8);
         }
         if (inVec[3].x < dVar18) {
-            dVar17 = -Math.RandF(kPppScreenBreakRandRange);
+            dVar17 = -Math.RandF(FLOAT_80331cc8);
         }
 
         inVec->x = dVar17;


### PR DESCRIPTION
## Summary
- Move the p_dbgmenu tail strings and constants to the pppScreenBreak split owner, leaving p_dbgmenu with external references.
- Define the maptexanim-owned DOUBLE_8032FCD0 and FLOAT_8032FCD8 constants so the target .sdata2 symbols match.

## Evidence
- ninja passes.
- Overall matched data increased from 1095169 to 1095265 bytes (+96); Game Code data increased from 917461 to 917557 bytes (+96).
- pppScreenBreak .sdata2 target size 84 now reports 100% match; moved symbols lbl_80331C54..lbl_80331C80, DAT_80331C88, DAT_80331C8C, s_Debug_80331c90, FLOAT_80331C98, and DOUBLE_80331CA0 all report 100%.
- maptexanim .sdata2 target size 12 now reports 100%; DOUBLE_8032FCD0 and FLOAT_8032FCD8 both report 100%.

## Plausibility
- Changes follow config/GCCP01/splits.txt ownership for .sdata2 data.
- No generated ctor/dtor/vtable code was hand-written; this only corrects constant definitions and cross-unit declarations.