### PR TITLE
Improve CGPrgObj getTargetRot stack layout

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -249,7 +249,7 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	deltaX = deltaPos.x;
-	zero = 0.0f;
+	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
 	if (zero == deltaX || zero == deltaZ) {
 		targetRot = zero;
@@ -273,12 +273,12 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float targetRot;
 	CVector targetPos(target->m_worldPosition);
 	CVector basePos(m_worldPosition);
-	CVector deltaPos;
+	Vec deltaPos;
 	float deltaX;
 	float zero;
 	float deltaZ;
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), &deltaPos);
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;


### PR DESCRIPTION
## Summary
- switch `CGPrgObj::getTargetRot` to use a plain stack `Vec` for the subtraction result
- keep the zero constant usage consistent in the adjacent rotation helper
- rebuild and verify the `main/prgobj` diff after the stack-layout change

## Evidence
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: `91.02778%` -> `91.27778%`
- `main/prgobj` `.text`: `97.51729%` -> `97.52974%`
- `rotTarget__8CGPrgObjFP8CGPrgObj` and `dstTargetRot__8CGPrgObjFP8CGPrgObj` stayed at `86.51282%` and `87.931816%`
- `ninja` passes on this branch

## Why this is plausible source
- Ghidra shows the delta buffer in `getTargetRot` as a plain stack `Vec`, not a `CVector`
- the change removes an unnecessary typed wrapper around `PSVECSubtract` instead of adding compiler-coaxing logic
