### PR TITLE
RedSound

### DIFF
--- a/src/RedSound/RedCommand.cpp
+++ b/src/RedSound/RedCommand.cpp
@@ -511,12 +511,14 @@ int SeBlockPlay(int seId, int bank, int no, int pan, int volume)
 int SeSepPlay(int seId, int sepId, int pan, int volume)
 {
 	int* sepBank;
+	int sepBase;
 	unsigned char* sepInfo;
 
 	sepBank = c_RedEntry.SearchSeSepBank(sepId);
 	if (sepBank != 0) {
-		sepInfo = (unsigned char*)(sepBank[2] + 0x10);
-		if ((*(unsigned int*)(sepBank[2] + 0xc) & 0x80000000) != 0) {
+		sepBase = sepBank[2];
+		sepInfo = (unsigned char*)(sepBase + 0x10);
+		if ((*(unsigned int*)(sepBase + 0xc) & 0x80000000) != 0) {
 			*sepInfo |= 0x80;
 		}
 		if (_SePlayStart((RedSeINFO*)sepInfo, seId, sepId, pan, volume) != 0) {

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1429,18 +1429,17 @@ int CRedDriver::GetSoundMode()
 int CRedDriver::SetMusicData(void* musicData)
 {
     char localHeader[0x20];
-    char* musicHeader = (char*)musicData;
     void* copiedHeader;
     int headerSize;
     int result;
 
     result = -1;
-    if (((musicHeader[0] == 'B') && (musicHeader[1] == 'G')) && (musicHeader[2] == 'M')) {
-        memcpy(localHeader, musicHeader, sizeof(localHeader));
+    if (((((char*)musicData)[0] == 'B') && (((char*)musicData)[1] == 'G')) && (((char*)musicData)[2] == 'M')) {
+        memcpy(localHeader, musicData, sizeof(localHeader));
         headerSize = *(int*)(localHeader + 0x10);
         copiedHeader = (void*)RedNew(headerSize);
         if (copiedHeader != 0) {
-            memcpy(copiedHeader, musicHeader, headerSize);
+            memcpy(copiedHeader, musicData, headerSize);
             result = *(short*)(localHeader + 4);
             _EntryExecCommand(_SetMusicData, (int)copiedHeader, 0, 0, 0, 0, 0, 0);
         }
@@ -1623,18 +1622,17 @@ void* CRedDriver::SetSeBlockData(int blockIndex, void* seBlockData)
  */
 int CRedDriver::SetSeSepData(void* seSepData)
 {
-    char* seSepHeader = (char*)seSepData;
     void* copiedHeader;
     int headerSize;
     int result;
 
     result = -1;
-    if ((((seSepHeader[0] == 'S') && (seSepHeader[1] == 'e')) && (seSepHeader[2] == 'S')) &&
-        ((seSepHeader[3] == 'e' && (seSepHeader[4] == 'p')))) {
-        headerSize = *(int*)(seSepHeader + 0xc) & 0x7fffffff;
+    if ((((((char*)seSepData)[0] == 'S') && (((char*)seSepData)[1] == 'e')) && (((char*)seSepData)[2] == 'S')) &&
+        ((((char*)seSepData)[3] == 'e' && (((char*)seSepData)[4] == 'p')))) {
+        headerSize = *(int*)((char*)seSepData + 0xc) & 0x7fffffff;
         copiedHeader = (void*)RedNew(headerSize);
         if (copiedHeader != 0) {
-            memcpy(copiedHeader, seSepHeader, headerSize);
+            memcpy(copiedHeader, seSepData, headerSize);
             result = *(int*)((int)copiedHeader + 8);
             _EntryExecCommand(_SetSeSepData, (int)copiedHeader, 0, 0, 0, 0, 0, 0);
         }

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -1463,12 +1463,11 @@ int CRedDriver::SetMusicData(void* musicData)
 int CRedDriver::ReentryMusicData(int musicID)
 {
     unsigned int interrupt;
-    int result;
 
     interrupt = OSDisableInterrupts();
-    result = c_RedEntry.ReentryMusicData(musicID);
+    musicID   = c_RedEntry.ReentryMusicData(musicID);
     OSRestoreInterrupts(interrupt);
-    return result;
+    return musicID;
 }
 
 /*
@@ -1683,12 +1682,11 @@ void CRedDriver::ClearSeSepDataMG(int id1, int id2, int id3, int id4)
 int CRedDriver::ReentrySeSepData(int id)
 {
     unsigned int interrupts;
-    int result;
 
     interrupts = OSDisableInterrupts();
-    result = c_RedEntry.ReentrySeSepData(id);
+    id         = c_RedEntry.ReentrySeSepData(id);
     OSRestoreInterrupts(interrupts);
-    return result;
+    return id;
 }
 
 /*
@@ -2172,12 +2170,11 @@ void CRedDriver::SetWaveData(int slot, int waveID, void* waveData, int waveSize)
 int CRedDriver::ReentryWaveData(int id)
 {
     unsigned int interrupts;
-    int result;
 
     interrupts = OSDisableInterrupts();
-    result = c_RedEntry.ReentryWaveData(id);
+    id         = c_RedEntry.ReentryWaveData(id);
     OSRestoreInterrupts(interrupts);
-    return result;
+    return id;
 }
 
 /*

--- a/src/RedSound/RedDriver.cpp
+++ b/src/RedSound/RedDriver.cpp
@@ -155,10 +155,10 @@ static const char sRedDriverLogReset[] = "\x1B[0m";
  * JP Address: TODO
  * JP Size: TODO
  */
-void _SetSoundMode(int* param_1)
+void _SetSoundMode(int* command)
 {
-    m_SoundMode = *param_1;
-    if (*param_1 == 1) {
+    m_SoundMode = *command;
+    if (*command == 1) {
         OSGetSoundMode(0);
     } else {
         OSGetSoundMode(1);
@@ -183,7 +183,7 @@ void _SetSoundMode(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _SetReverbDepth(int* param_1)
+void _SetReverbDepth(int* command)
 {
     int reverbBank;
     int reverbDepth;
@@ -191,9 +191,9 @@ void _SetReverbDepth(int* param_1)
     int fadeDepth;
     int* seInfo;
 
-    reverbBank = param_1[0] & 1;
-    reverbDepth = param_1[1] & 0x7f;
-    fadeStep = param_1[2];
+    reverbBank = command[0] & 1;
+    reverbDepth = command[1] & 0x7f;
+    fadeStep = command[2];
     if (reverbDepth != 0) {
         reverbDepth += 1;
         reverbDepth <<= 8;
@@ -225,9 +225,9 @@ void _SetReverbDepth(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SetMusicData(int* param_1)
+void _SetMusicData(int* command)
 {
-    c_RedEntry.SetMusicData((RedMusicHEAD*)*param_1);
+    c_RedEntry.SetMusicData((RedMusicHEAD*)*command);
 }
 
 /*
@@ -235,10 +235,10 @@ void _SetMusicData(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _MusicStop(int* param_1)
+void _MusicStop(int* command)
 {
-    MusicStop(*param_1);
-    if ((*param_1 == -1) || (p_MusicNextPlay[0] == *param_1)) {
+    MusicStop(*command);
+    if ((*command == -1) || (p_MusicNextPlay[0] == *command)) {
         p_MusicNextPlay[0] = -1;
     }
     if (p_MusicNextPlay[0] < 0) {
@@ -255,31 +255,31 @@ void _MusicStop(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _MusicPlaySequence(int* param_1)
+void _MusicPlaySequence(int* command)
 {
     int iVar1;
     int srcBuffer;
 
     srcBuffer = (int)p_SoundControlBuffer;
-    if ((((*param_1 != *(int*)(srcBuffer + 0x470)) &&
-          (*param_1 != *(int*)(srcBuffer + 0x904))) &&
-         (*param_1 != *(int*)(srcBuffer + 0xd98))) &&
-        (c_RedEntry.SearchMusicSequence(*param_1) >= 0)) {
-        iVar1 = param_1[2];
+    if ((((*command != *(int*)(srcBuffer + 0x470)) &&
+          (*command != *(int*)(srcBuffer + 0x904))) &&
+         (*command != *(int*)(srcBuffer + 0xd98))) &&
+        (c_RedEntry.SearchMusicSequence(*command) >= 0)) {
+        iVar1 = command[2];
         if (*(int*)(srcBuffer + 0x470) != -1) {
             if (*(int*)(srcBuffer + 0x904) != -1) {
                 MusicStop(*(int*)(srcBuffer + 0x904));
             }
             if (iVar1 == 0) {
-                iVar1 = *(int*)((int)p_MusicReplayPoint + *param_1 * 4);
-                *(int*)((int)p_MusicReplayPoint + *param_1 * 4) = 0;
+                iVar1 = *(int*)((int)p_MusicReplayPoint + *command * 4);
+                *(int*)((int)p_MusicReplayPoint + *command * 4) = 0;
             }
             if (iVar1 == 0) {
                 memcpy((void*)(srcBuffer + 0x494), (void*)srcBuffer, 0x494);
                 *(int*)(srcBuffer + 0x470) = -1;
             }
         }
-        MusicPlay(*param_1, param_1[1], iVar1);
+        MusicPlay(*command, command[1], iVar1);
     }
 }
 
@@ -292,26 +292,26 @@ void _MusicPlaySequence(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _MusicCrossPlaySequence(int* param_1)
+void _MusicCrossPlaySequence(int* command)
 {
     int iVar1;
     void* pvVar2;
     
-    param_1[2] = param_1[2] * 200;
-    param_1[2] = param_1[2] / 0x3c;
-    if (param_1[2] == 0) {
-        param_1[2] = param_1[2] + 1;
+    command[2] = command[2] * 200;
+    command[2] = command[2] / 0x3c;
+    if (command[2] == 0) {
+        command[2] = command[2] + 1;
     }
     pvVar2 = p_SoundControlBuffer;
-    if ((*param_1 != *(int*)((int)p_SoundControlBuffer + 0x470)) &&
-       (*param_1 != *(int*)((int)p_SoundControlBuffer + 0xd98))) {
-        if (*param_1 == *(int*)((int)p_SoundControlBuffer + 0x904)) {
-            *(int*)((int)p_SoundControlBuffer + 0x458) = -*(int*)((int)p_SoundControlBuffer + 0x454) / param_1[2];
-            *(int*)((int)pvVar2 + 0x45c) = param_1[2];
+    if ((*command != *(int*)((int)p_SoundControlBuffer + 0x470)) &&
+       (*command != *(int*)((int)p_SoundControlBuffer + 0xd98))) {
+        if (*command == *(int*)((int)p_SoundControlBuffer + 0x904)) {
+            *(int*)((int)p_SoundControlBuffer + 0x458) = -*(int*)((int)p_SoundControlBuffer + 0x454) / command[2];
+            *(int*)((int)pvVar2 + 0x45c) = command[2];
             pvVar2 = p_SoundControlBuffer;
             *(int*)((int)p_SoundControlBuffer + 0x8ec) =
-                 (0x1ff800 - *(int*)((int)p_SoundControlBuffer + 0x8e8)) / param_1[2];
-            *(int*)((int)pvVar2 + 0x8f0) = param_1[2];
+                 (0x1ff800 - *(int*)((int)p_SoundControlBuffer + 0x8e8)) / command[2];
+            *(int*)((int)pvVar2 + 0x8f0) = command[2];
             pvVar2 = (void*)RedNew(0x494);
             memcpy(pvVar2, (void*)((int)p_SoundControlBuffer + 0x494), 0x494);
             memcpy((void*)((int)p_SoundControlBuffer + 0x494), p_SoundControlBuffer, 0x494);
@@ -319,24 +319,24 @@ void _MusicCrossPlaySequence(int* param_1)
             RedDelete(pvVar2);
         }
         else {
-            iVar1 = c_RedEntry.SearchMusicSequence(*param_1);
+            iVar1 = c_RedEntry.SearchMusicSequence(*command);
             if (iVar1 >= 0) {
-                m_CrossTime = param_1[2];
+                m_CrossTime = command[2];
                 iVar1 = 0;
                 if (*(int*)((int)pvVar2 + 0x470) != -1) {
                     if (*(int*)((int)pvVar2 + 0x904) != -1) {
                         MusicStop(*(int*)((int)pvVar2 + 0x904));
                     }
-                    *(int*)((int)pvVar2 + 0x458) = -*(int*)((int)pvVar2 + 0x454) / param_1[2];
-                    *(int*)((int)pvVar2 + 0x45c) = param_1[2];
-                    iVar1 = *(int*)((char*)p_MusicReplayPoint + *param_1 * 4);
-                    *(int*)((char*)p_MusicReplayPoint + *param_1 * 4) = 0;
+                    *(int*)((int)pvVar2 + 0x458) = -*(int*)((int)pvVar2 + 0x454) / command[2];
+                    *(int*)((int)pvVar2 + 0x45c) = command[2];
+                    iVar1 = *(int*)((char*)p_MusicReplayPoint + *command * 4);
+                    *(int*)((char*)p_MusicReplayPoint + *command * 4) = 0;
                     if (iVar1 == 0) {
                         memcpy((void*)((int)pvVar2 + 0x494), pvVar2, 0x494);
                         *(int*)((int)pvVar2 + 0x470) = 0xffffffff;
                     }
                 }
-                MusicPlay(*param_1, param_1[1], iVar1);
+                MusicPlay(*command, command[1], iVar1);
             }
         }
     }
@@ -347,18 +347,18 @@ void _MusicCrossPlaySequence(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _MusicNextPlaySequence(int* param_1)
+void _MusicNextPlaySequence(int* command)
 {
     int srcBuffer;
 
     srcBuffer = (int)p_SoundControlBuffer;
-    if ((((*param_1 != *(int*)(srcBuffer + 0x470)) &&
-          (*param_1 != *(int*)(srcBuffer + 0x904))) &&
-         (*param_1 != *(int*)(srcBuffer + 0xd98))) &&
-        (c_RedEntry.SearchMusicSequence(*param_1) >= 0)) {
-        p_MusicNextPlay[0] = *param_1;
-        p_MusicNextPlay[1] = param_1[1];
-        p_MusicNextPlay[2] = param_1[2];
+    if ((((*command != *(int*)(srcBuffer + 0x470)) &&
+          (*command != *(int*)(srcBuffer + 0x904))) &&
+         (*command != *(int*)(srcBuffer + 0xd98))) &&
+        (c_RedEntry.SearchMusicSequence(*command) >= 0)) {
+        p_MusicNextPlay[0] = *command;
+        p_MusicNextPlay[1] = command[1];
+        p_MusicNextPlay[2] = command[2];
     }
 }
 
@@ -367,11 +367,11 @@ void _MusicNextPlaySequence(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _MusicMasterVolume(int* param_1)
+void _MusicMasterVolume(int* command)
 {
     unsigned int* puVar1;
 
-    m_MasterMusicVolume = *param_1 & 0x7f;
+    m_MasterMusicVolume = *command & 0x7f;
     if (m_MasterMusicVolume != 0) {
         m_MasterMusicVolume = m_MasterMusicVolume + 1;
         m_MasterMusicVolume = m_MasterMusicVolume * 4;
@@ -389,13 +389,13 @@ void _MusicMasterVolume(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _MusicVolume(int* param_1)
+void _MusicVolume(int* command)
 {
-    if (param_1[3] == 1) {
+    if (command[3] == 1) {
         p_MusicNextPlay[0] = -1;
         m_MusicPhraseStop = 0;
     }
-    SetMusicVolume(param_1[0], param_1[1], param_1[2], param_1[3]);
+    SetMusicVolume(command[0], command[1], command[2], command[3]);
 }
 
 /*
@@ -403,9 +403,9 @@ void _MusicVolume(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SetMusicPhraseStop(int* param_1)
+void _SetMusicPhraseStop(int* command)
 {
-    m_MusicPhraseStop = *param_1;
+    m_MusicPhraseStop = *command;
 }
 
 /*
@@ -413,9 +413,9 @@ void _SetMusicPhraseStop(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SetSeBlockData(int* param_1)
+void _SetSeBlockData(int* command)
 {
-    u32 index = (u32)*param_1 & 3;
+    u32 index = (u32)*command & 3;
     char* seBlockData;
 
     if (p_SeBlockData[index] != 0) {
@@ -423,8 +423,8 @@ void _SetSeBlockData(int* param_1)
         p_SeBlockData[index] = 0;
     }
 
-    if (param_1[1] != 0) {
-        seBlockData = (char*)param_1[1];
+    if (command[1] != 0) {
+        seBlockData = (char*)command[1];
         if ((*seBlockData = 'S') && (seBlockData[1] = 'e') && (seBlockData[2] = 'B') &&
             (seBlockData[3] = 'l') && (seBlockData[4] = 'o') && (seBlockData[5] = 'c') &&
             (seBlockData[6] = 'k')) {
@@ -440,9 +440,9 @@ void _SetSeBlockData(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SetSeSepData(int* param_1)
+void _SetSeSepData(int* command)
 {
-    c_RedEntry.SetSeSepData((RedSeSepHEAD*)*param_1);
+    c_RedEntry.SetSeSepData((RedSeSepHEAD*)*command);
 }
 
 /*
@@ -450,9 +450,9 @@ void _SetSeSepData(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _ClearSeSepData(int* param_1)
+void _ClearSeSepData(int* command)
 {
-    c_RedEntry.ClearSeSepData(*param_1);
+    c_RedEntry.ClearSeSepData(*command);
 }
 
 /*
@@ -460,9 +460,9 @@ void _ClearSeSepData(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _ClearSeSepDataMG(int* param_1)
+void _ClearSeSepDataMG(int* command)
 {
-    c_RedEntry.ClearSeSepDataMG(param_1[0], param_1[1], param_1[2], param_1[3]);
+    c_RedEntry.ClearSeSepDataMG(command[0], command[1], command[2], command[3]);
 }
 
 /*
@@ -470,9 +470,9 @@ void _ClearSeSepDataMG(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeStop(int* param_1)
+void _SeStop(int* command)
 {
-    SeStopID(param_1[0]);
+    SeStopID(command[0]);
 }
 
 /*
@@ -480,9 +480,9 @@ void _SeStop(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeStopMG(int* param_1)
+void _SeStopMG(int* command)
 {
-    SeStopMG(param_1[0], param_1[1], param_1[2], param_1[3]);
+    SeStopMG(command[0], command[1], command[2], command[3]);
 }
 
 /*
@@ -490,10 +490,10 @@ void _SeStopMG(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeBlockPlay(int* param_1)
+void _SeBlockPlay(int* command)
 {
-    m_SeSkipStep = param_1[5];
-    SeBlockPlay(param_1[0], param_1[1], param_1[2], param_1[3], param_1[4]);
+    m_SeSkipStep = command[5];
+    SeBlockPlay(command[0], command[1], command[2], command[3], command[4]);
 }
 
 /*
@@ -501,15 +501,15 @@ void _SeBlockPlay(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeSepPlay(int* param_1)
+void _SeSepPlay(int* command)
 {
     int iVar1;
 
-    iVar1 = c_RedEntry.SetSeSepData((RedSeSepHEAD*)param_1[1]);
+    iVar1 = c_RedEntry.SetSeSepData((RedSeSepHEAD*)command[1]);
     if (iVar1 != 0) {
-        m_SeSkipStep = param_1[4];
-        int seID = param_1[0];
-        SeSepPlay(seID, *(int*)(iVar1 + 8), param_1[2], param_1[3]);
+        m_SeSkipStep = command[4];
+        int seID = command[0];
+        SeSepPlay(seID, *(int*)(iVar1 + 8), command[2], command[3]);
     }
 }
 
@@ -518,11 +518,11 @@ void _SeSepPlay(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeSepPlaySequence(int* param_1)
+void _SeSepPlaySequence(int* command)
 {
-    if (c_RedEntry.SearchSeSepSequence(param_1[1]) >= 0) {
-        m_SeSkipStep = param_1[4];
-        SeSepPlay(param_1[0], param_1[1], param_1[2], param_1[3]);
+    if (c_RedEntry.SearchSeSepSequence(command[1]) >= 0) {
+        m_SeSkipStep = command[4];
+        SeSepPlay(command[0], command[1], command[2], command[3]);
     }
 }
 
@@ -531,11 +531,11 @@ void _SeSepPlaySequence(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeMasterVolume(int* param_1)
+void _SeMasterVolume(int* command)
 {
     unsigned int* puVar1;
 
-    m_MasterSEVolume = *param_1 & 0x7f;
+    m_MasterSEVolume = *command & 0x7f;
     if (m_MasterSEVolume != 0) {
         m_MasterSEVolume = m_MasterSEVolume + 1;
         m_MasterSEVolume = m_MasterSEVolume * 4;
@@ -553,9 +553,9 @@ void _SeMasterVolume(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SeVolume(int* param_1)
+void _SeVolume(int* command)
 {
-    SetSeVolume(param_1[0], param_1[1], param_1[2], param_1[3]);
+    SetSeVolume(command[0], command[1], command[2], command[3]);
 }
 
 /*
@@ -563,9 +563,9 @@ void _SeVolume(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SePan(int* param_1)
+void _SePan(int* command)
 {
-    SetSePan(param_1[0], param_1[1], param_1[2]);
+    SetSePan(command[0], command[1], command[2]);
 }
 
 /*
@@ -573,9 +573,9 @@ void _SePan(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SePitch(int* param_1)
+void _SePitch(int* command)
 {
-    SetSePitch(param_1[0], param_1[1], param_1[2]);
+    SetSePitch(command[0], command[1], command[2]);
 }
 
 /*
@@ -583,9 +583,9 @@ void _SePitch(int* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-void _SePause(int* param_1)
+void _SePause(int* command)
 {
-    SePause(param_1[0], param_1[1]);
+    SePause(command[0], command[1]);
 }
 
 /*
@@ -597,9 +597,9 @@ void _SePause(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _StreamStop(int* param_1)
+void _StreamStop(int* command)
 {
-	StreamStop(*param_1);
+	StreamStop(*command);
 }
 
 /*
@@ -611,9 +611,9 @@ void _StreamStop(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _StreamPlay(int* param_1)
+void _StreamPlay(int* command)
 {
-	StreamPlay(param_1[0], (void*)param_1[1], param_1[2], param_1[3], param_1[4]);
+	StreamPlay(command[0], (void*)command[1], command[2], command[3], command[4]);
 }
 
 /*
@@ -625,9 +625,9 @@ void _StreamPlay(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _StreamVolume(int* param_1)
+void _StreamVolume(int* command)
 {
-	SetStreamVolume(param_1[0], param_1[1], param_1[2]);
+	SetStreamVolume(command[0], command[1], command[2]);
 }
 
 /*
@@ -639,9 +639,9 @@ void _StreamVolume(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _StreamPause(int* param_1)
+void _StreamPause(int* command)
 {
-	StreamPause(param_1[0], param_1[1]);
+	StreamPause(command[0], command[1]);
 }
 
 /*
@@ -653,22 +653,22 @@ void _StreamPause(int* param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-int* _EntryExecCommand(void (*param_1)(int*), int param_2, int param_3, int param_4, int param_5,
-                       int param_6, int param_7, int param_8)
+int* _EntryExecCommand(void (*func)(int*), int arg1, int arg2, int arg3, int arg4,
+                       int arg5, int arg6, int arg7)
 {
     unsigned int interruptLevel;
     int* writePos;
 
     interruptLevel = OSDisableInterrupts();
     writePos = (int*)p_ExecCommandNow;
-    writePos[0] = (int)param_1;
-    writePos[1] = param_2;
-    writePos[2] = param_3;
-    writePos[3] = param_4;
-    writePos[4] = param_5;
-    writePos[5] = param_6;
-    writePos[6] = param_7;
-    writePos[7] = param_8;
+    writePos[0] = (int)func;
+    writePos[1] = arg1;
+    writePos[2] = arg2;
+    writePos[3] = arg3;
+    writePos[4] = arg4;
+    writePos[5] = arg5;
+    writePos[6] = arg6;
+    writePos[7] = arg7;
     writePos += 8;
     if (writePos == (int*)p_ExecCommand + 0x800) {
         writePos = (int*)p_ExecCommand;
@@ -763,9 +763,9 @@ struct RedSleepAlarm {
  * JP Address: TODO
  * JP Size: TODO
  */
-void _MyAlarmHandler(OSAlarm* param_1, OSContext*)
+void _MyAlarmHandler(OSAlarm* alarm, OSContext*)
 {
-    OSResumeThread(((RedSleepAlarm*)param_1)->thread);
+    OSResumeThread(((RedSleepAlarm*)alarm)->thread);
 }
 
 /*
@@ -777,18 +777,18 @@ void _MyAlarmHandler(OSAlarm* param_1, OSContext*)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RedSleep(int param_1)
+void RedSleep(int microseconds)
 {
     unsigned int interruptLevel;
     RedSleepAlarm alarm;
 
-    if (param_1 < 0xfa) {
-        param_1 = 0xfa;
+    if (microseconds < 0xfa) {
+        microseconds = 0xfa;
     }
     interruptLevel = OSDisableInterrupts();
     alarm.thread = OSGetCurrentThread();
     OSCreateAlarm(&alarm.alarm);
-    OSSetAlarm(&alarm.alarm, (param_1 * (OS_TIMER_CLOCK / 125000)) >> 3, _MyAlarmHandler);
+    OSSetAlarm(&alarm.alarm, (microseconds * (OS_TIMER_CLOCK / 125000)) >> 3, _MyAlarmHandler);
     OSSuspendThread(alarm.thread);
     OSRestoreInterrupts(interruptLevel);
 }
@@ -849,14 +849,14 @@ int _MainThread(void*)
  * JP Address: TODO
  * JP Size: TODO
  */
-int _WaveSettingThread(void* param_1)
+int _WaveSettingThread(void* threadArg)
 {
     m_ThreadExecute = m_ThreadExecute | 4;
     m_WaveSettingStatus = 0;
     while (m_ThreadControl != 0) {
         OSWaitSemaphore(&m_WaveSettingSemaphore);
         if (m_ThreadControl != 0) {
-            RedWaveSettingState* waveSetting = (RedWaveSettingState*)param_1;
+            RedWaveSettingState* waveSetting = (RedWaveSettingState*)threadArg;
             m_WaveSettingStatus = m_WaveSettingStatus + 1;
             c_RedEntry.SetWaveData(waveSetting->waveID, waveSetting->waveData, waveSetting->waveSize);
             *(int*)waveSetting->slot = 0;
@@ -1426,10 +1426,10 @@ int CRedDriver::GetSoundMode()
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::SetMusicData(void* param_1)
+int CRedDriver::SetMusicData(void* musicData)
 {
     char localHeader[0x20];
-    char* musicHeader = (char*)param_1;
+    char* musicHeader = (char*)musicData;
     void* copiedHeader;
     int headerSize;
     int result;
@@ -1567,9 +1567,9 @@ void CRedDriver::MusicFadeOut(int musicID, int fadeTime)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::MusicVolume(int param_1, int param_2, int param_3)
+void CRedDriver::MusicVolume(int musicID, int volume, int frameCount)
 {
-    _EntryExecCommand(_MusicVolume, param_1, param_2, param_3, 0, 0, 0, 0);
+    _EntryExecCommand(_MusicVolume, musicID, volume, frameCount, 0, 0, 0, 0);
 }
 
 /*
@@ -1591,17 +1591,17 @@ void CRedDriver::SetMusicPhraseStop(int stop)
  * JP Address: TODO
  * JP Size: TODO
  */
-void* CRedDriver::SetSeBlockData(int param_1, void* param_2)
+void* CRedDriver::SetSeBlockData(int blockIndex, void* seBlockData)
 {
     void* copiedBuffer;
     int copySize;
 
-    if (param_2 != 0) {
-        copySize = *(int*)((char*)param_2 + 0xc);
+    if (seBlockData != 0) {
+        copySize = *(int*)((char*)seBlockData + 0xc);
         if (copySize > 0) {
             copiedBuffer = (void*)RedNew(copySize);
             if (copiedBuffer != 0) {
-                memcpy(copiedBuffer, param_2, copySize);
+                memcpy(copiedBuffer, seBlockData, copySize);
             }
         } else {
             copiedBuffer = 0;
@@ -1609,7 +1609,7 @@ void* CRedDriver::SetSeBlockData(int param_1, void* param_2)
     } else {
         copiedBuffer = 0;
     }
-    _EntryExecCommand(_SetSeBlockData, param_1, (int)copiedBuffer, 0, 0, 0, 0, 0);
+    _EntryExecCommand(_SetSeBlockData, blockIndex, (int)copiedBuffer, 0, 0, 0, 0, 0);
     return copiedBuffer;
 }
 
@@ -1622,9 +1622,9 @@ void* CRedDriver::SetSeBlockData(int param_1, void* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::SetSeSepData(void* param_1)
+int CRedDriver::SetSeSepData(void* seSepData)
 {
-    char* seSepHeader = (char*)param_1;
+    char* seSepHeader = (char*)seSepData;
     void* copiedHeader;
     int headerSize;
     int result;
@@ -1700,7 +1700,7 @@ int CRedDriver::ReentrySeSepData(int id)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::SePlayState(int param_1)
+int CRedDriver::SePlayState(int seID)
 {
     unsigned int uVar1;
     int result;
@@ -1714,7 +1714,7 @@ int CRedDriver::SePlayState(int param_1)
     seInfoBase = (int**)((int)p_SoundControlBuffer + 0xdbc);
     seInfo = *seInfoBase;
     do {
-        if (((u32)*seInfo != 0) && ((param_1 == -1 || (seInfo[0x3e] == param_1)))) {
+        if (((u32)*seInfo != 0) && ((seID == -1 || (seInfo[0x3e] == seID)))) {
             result = (int)seInfo;
             break;
         }
@@ -1728,7 +1728,7 @@ int CRedDriver::SePlayState(int param_1)
                 ((((void (*)(int*))*command == _SeBlockPlay) ||
                   (((void (*)(int*))*command == _SeSepPlay))) ||
                  ((void (*)(int*))*command == _SeSepPlaySequence))) &&
-                ((param_1 == -1 || (param_1 == command[1])))) {
+                ((seID == -1 || (seID == command[1])))) {
                 result = 1;
                 break;
             }
@@ -1828,9 +1828,9 @@ void CRedDriver::SeFadeOut(int seID, int fadeTime)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::SeVolume(int param_1, int param_2, int param_3)
+void CRedDriver::SeVolume(int seID, int volume, int frameCount)
 {
-    _EntryExecCommand(_SeVolume, param_1, param_2, param_3, 0, 0, 0, 0);
+    _EntryExecCommand(_SeVolume, seID, volume, frameCount, 0, 0, 0, 0);
 }
 
 /*
@@ -1842,9 +1842,9 @@ void CRedDriver::SeVolume(int param_1, int param_2, int param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::SePan(int param_1, int param_2, int param_3)
+void CRedDriver::SePan(int seID, int pan, int frameCount)
 {
-    _EntryExecCommand(_SePan, param_1, param_2, param_3, 0, 0, 0, 0);
+    _EntryExecCommand(_SePan, seID, pan, frameCount, 0, 0, 0, 0);
 }
 
 /*
@@ -1856,9 +1856,9 @@ void CRedDriver::SePan(int param_1, int param_2, int param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::SePitch(int param_1, int param_2, int param_3)
+void CRedDriver::SePitch(int seID, int pitch, int frameCount)
 {
-    _EntryExecCommand(_SePitch, param_1, param_2, param_3, 0, 0, 0, 0);
+    _EntryExecCommand(_SePitch, seID, pitch, frameCount, 0, 0, 0, 0);
 }
 
 /*
@@ -1870,9 +1870,9 @@ void CRedDriver::SePitch(int param_1, int param_2, int param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::SePause(int param_1, int param_2)
+void CRedDriver::SePause(int seID, int pause)
 {
-    _EntryExecCommand(_SePause, param_1, param_2, 0, 0, 0, 0, 0);
+    _EntryExecCommand(_SePause, seID, pause, 0, 0, 0, 0, 0);
 }
 
 /*
@@ -1880,15 +1880,15 @@ void CRedDriver::SePause(int param_1, int param_2)
  * Address:	TODO
  * Size:	TODO
  */
-int CRedDriver::GetSeVolume(int param_1, int param_2)
+int CRedDriver::GetSeVolume(int seID, int mode)
 {
     unsigned int* seInfo;
 
     seInfo = *(unsigned int**)((int)p_SoundControlBuffer + 0xdbc);
     while (1) {
-        if ((*seInfo != 0) && ((param_1 == -1) || (param_1 == (int)seInfo[0x3e]))) {
+        if ((*seInfo != 0) && ((seID == -1) || (seID == (int)seInfo[0x3e]))) {
             if (*seInfo != 0) {
-                if (param_2 == 1) {
+                if (mode == 1) {
                     return seInfo[0x15];
                 }
                 return (int)seInfo[0x13] >> 0xc;
@@ -1911,14 +1911,14 @@ int CRedDriver::GetSeVolume(int param_1, int param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::ReportSeLoop(int param_1)
+int CRedDriver::ReportSeLoop(int seID)
 {
     unsigned int* seInfo;
 
     seInfo = *(unsigned int**)((int)p_SoundControlBuffer + 0xdbc);
     while (1) {
         if ((*seInfo != 0) &&
-            (((param_1 == -1) || (param_1 == (int)seInfo[0x3e])) && ((seInfo[0x40] & 1U) != 0))) {
+            (((seID == -1) || (seID == (int)seInfo[0x3e])) && ((seInfo[0x40] & 1U) != 0))) {
             return 1;
         }
         seInfo += 0x55;
@@ -1948,7 +1948,7 @@ void CRedDriver::DisplaySePlayInfo()
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::StreamPlayState(int param_1)
+int CRedDriver::StreamPlayState(int streamID)
 {
 	void* commandNow;
 	unsigned int interrupts;
@@ -1961,7 +1961,7 @@ int CRedDriver::StreamPlayState(int param_1)
 	streamData = (unsigned int)p_Stream;
 	do {
 		if ((*(int*)(streamData + 0x10C) != 0) &&
-		    ((param_1 == -1) || (*(int*)(streamData + 0x10C) == param_1))) {
+		    ((streamID == -1) || (*(int*)(streamData + 0x10C) == streamID))) {
 			result = 1;
 			break;
 		}
@@ -1973,7 +1973,7 @@ int CRedDriver::StreamPlayState(int param_1)
 		command = (unsigned int*)p_ExecCommandOld;
 		while (commandNow != (void*)command) {
 			if ((*command != 0) && ((void (*)(int*))*command == _StreamPlay) &&
-			    ((param_1 == -1) || (param_1 == (int)command[1]))) {
+			    ((streamID == -1) || (streamID == (int)command[1]))) {
 				result = 1;
 				break;
 			}
@@ -1996,26 +1996,26 @@ int CRedDriver::StreamPlayState(int param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::GetStreamPlayPoint(int param_1, int* param_2, int* param_3)
+int CRedDriver::GetStreamPlayPoint(int streamID, int* outPoint1, int* outPoint2)
 {
 	unsigned int streamData;
 	int found;
 
 	found = 0;
-	if (param_2 != 0) {
-		*param_2 = 0;
+	if (outPoint1 != 0) {
+		*outPoint1 = 0;
 	}
-	if (param_3 != 0) {
-		*param_3 = 0;
+	if (outPoint2 != 0) {
+		*outPoint2 = 0;
 	}
 	streamData = (unsigned int)p_Stream;
 	do {
-		if ((*(int*)(streamData + 0x10C) != 0) && (*(int*)(streamData + 0x10C) == param_1)) {
-			if (param_2 != 0) {
-				*param_2 = *(int*)(streamData + 0x11C);
+		if ((*(int*)(streamData + 0x10C) != 0) && (*(int*)(streamData + 0x10C) == streamID)) {
+			if (outPoint1 != 0) {
+				*outPoint1 = *(int*)(streamData + 0x11C);
 			}
-			if (param_3 != 0) {
-				*param_3 = *(int*)(streamData + 0x120);
+			if (outPoint2 != 0) {
+				*outPoint2 = *(int*)(streamData + 0x120);
 			}
 			found = 1;
 			break;
@@ -2034,9 +2034,9 @@ int CRedDriver::GetStreamPlayPoint(int param_1, int* param_2, int* param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::StreamStop(int param_1)
+void CRedDriver::StreamStop(int streamID)
 {
-    _EntryExecCommand(_StreamStop, param_1, 0, 0, 0, 0, 0, 0);
+    _EntryExecCommand(_StreamStop, streamID, 0, 0, 0, 0, 0, 0);
 }
 
 /*
@@ -2048,10 +2048,10 @@ void CRedDriver::StreamStop(int param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedDriver::StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5)
+int CRedDriver::StreamPlay(int streamID, void* streamData, int volume, int pan, int loopMode)
 {
-	_EntryExecCommand(_StreamPlay, param_1, (int)param_2, param_3, param_4, param_5, 0, 0);
-	return param_1;
+	_EntryExecCommand(_StreamPlay, streamID, (int)streamData, volume, pan, loopMode, 0, 0);
+	return streamID;
 }
 
 /*
@@ -2063,9 +2063,9 @@ int CRedDriver::StreamPlay(int param_1, void* param_2, int param_3, int param_4,
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::StreamVolume(int param_1, int param_2, int param_3)
+void CRedDriver::StreamVolume(int streamID, int volume, int frameCount)
 {
-    _EntryExecCommand(_StreamVolume, param_1, param_2, param_3, 0, 0, 0, 0);
+    _EntryExecCommand(_StreamVolume, streamID, volume, frameCount, 0, 0, 0, 0);
 }
 
 /*
@@ -2077,9 +2077,9 @@ void CRedDriver::StreamVolume(int param_1, int param_2, int param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::StreamPause(int param_1, int param_2)
+void CRedDriver::StreamPause(int streamID, int pause)
 {
-    _EntryExecCommand(_StreamPause, param_1, param_2, 0, 0, 0, 0, 0);
+    _EntryExecCommand(_StreamPause, streamID, pause, 0, 0, 0, 0, 0);
 }
 
 /*
@@ -2091,9 +2091,9 @@ void CRedDriver::StreamPause(int param_1, int param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::ClearWaveData(int param_1)
+void CRedDriver::ClearWaveData(int waveID)
 {
-    c_RedEntry.ClearWaveData(param_1);
+    c_RedEntry.ClearWaveData(waveID);
 }
 
 /*
@@ -2119,9 +2119,9 @@ void CRedDriver::ClearWaveDataM(int param_1, int param_2, int param_3, int param
  * JP Address: TODO
  * JP Size: TODO
  */
-void CRedDriver::ClearWaveBank(int param_1)
+void CRedDriver::ClearWaveBank(int waveBank)
 {
-    c_RedEntry.ClearWaveBank(param_1);
+    c_RedEntry.ClearWaveBank(waveBank);
 }
 
 /*

--- a/src/RedSound/RedEntry.cpp
+++ b/src/RedSound/RedEntry.cpp
@@ -1337,8 +1337,7 @@ int CRedEntry::MusicMemoryFree(RedHistoryBANK* bank)
 	WaveHistoryManager(0, (int)*(short*)(reinterpret_cast<int*>(bank)[2] + 6));
 	RedDelete(reinterpret_cast<int*>(bank)[2]);
 	int freedSize = reinterpret_cast<int*>(bank)[3];
-	reinterpret_cast<int*>(bank)[3] = 0;
-	reinterpret_cast<int*>(bank)[2] = 0;
+	reinterpret_cast<int*>(bank)[2] = reinterpret_cast<int*>(bank)[3] = 0;
 	reinterpret_cast<int*>(bank)[1] = 0;
 	reinterpret_cast<int*>(bank)[0] = -1;
 	return freedSize;

--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -231,11 +231,11 @@ int PitchCompute(int param_1, int param_2, int param_3, int param_4)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _ReverbNullCallback(AXFX_BUFFERUPDATE* param_1, void*)
+void _ReverbNullCallback(AXFX_BUFFERUPDATE* update, void*)
 {
-    memset((void*)((u32*)param_1)[0], 0, 0x280);
-    memset((void*)((u32*)param_1)[1], 0, 0x280);
-    memset((void*)((u32*)param_1)[2], 0, 0x280);
+    memset((void*)((u32*)update)[0], 0, 0x280);
+    memset((void*)((u32*)update)[1], 0, 0x280);
+    memset((void*)((u32*)update)[2], 0, 0x280);
 }
 
 /*
@@ -263,9 +263,9 @@ void* ReverbAreaAlloc(unsigned long size)
  * JP Address: TODO
  * JP Size: TODO
  */
-void ReverbAreaFree(void* param_1)
+void ReverbAreaFree(void* area)
 {
-    RedDelete(param_1);
+    RedDelete(area);
 }
 
 /*
@@ -838,10 +838,10 @@ void _VolumeExecute(RedVoiceDATA* voice, int volume)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _PitchExecute(RedVoiceDATA* param_1)
+void _PitchExecute(RedVoiceDATA* voice)
 {
     int pitchDelta = 0;
-    int* voiceData = (int*)param_1;
+    int* voiceData = (int*)voice;
     int* trackData = (int*)voiceData[0];
 
     if ((trackData[0x1D] != 0) && (((s16*)voiceData)[10] == 0)) {
@@ -898,42 +898,42 @@ void _PitchExecute(RedVoiceDATA* param_1)
  * Address:	TODO
  * Size:	TODO
  */
-RedWaveDATA* _WaveSplitSelect(RedWaveDATA* param_1, RedNoteDATA* param_2)
+RedWaveDATA* _WaveSplitSelect(RedWaveDATA* wave, RedNoteDATA* note)
 {
-    if ((param_1 != 0) && ((((u32*)param_1)[0] & 0x30000) != 0)) {
+    if ((wave != 0) && ((((u32*)wave)[0] & 0x30000) != 0)) {
         for (;;) {
-            if ((((u32*)param_1)[0] & 0x200) != 0) {
+            if ((((u32*)wave)[0] & 0x200) != 0) {
                 break;
             }
-            if (*(char*)param_2 <= *(char*)((u32*)param_1 + 6)) {
+            if (*(char*)note <= *(char*)((u32*)wave + 6)) {
                 break;
             }
-            if ((((u32*)param_1)[0] & 1) != 0) {
-                param_1 = (RedWaveDATA*)((u32*)param_1 + 0x18);
+            if ((((u32*)wave)[0] & 1) != 0) {
+                wave = (RedWaveDATA*)((u32*)wave + 0x18);
             }
-            param_1 = (RedWaveDATA*)((u32*)param_1 + 0x18);
+            wave = (RedWaveDATA*)((u32*)wave + 0x18);
         }
 
-        int splitKey = *(char*)((u32*)param_1 + 6);
+        int splitKey = *(char*)((u32*)wave + 6);
         for (;;) {
-            if ((((u32*)param_1)[0] & 0x200) != 0) {
+            if ((((u32*)wave)[0] & 0x200) != 0) {
                 break;
             }
-            if (((char*)param_2)[1] <= *(u8*)((int)param_1 + 0x19)) {
+            if (((char*)note)[1] <= *(u8*)((int)wave + 0x19)) {
                 break;
             }
-            if (splitKey == *(char*)((u32*)param_1 + 6)) {
-                if ((((u32*)param_1)[0] & 1) != 0) {
-                    param_1 = (RedWaveDATA*)((u32*)param_1 + 0x18);
+            if (splitKey == *(char*)((u32*)wave + 6)) {
+                if ((((u32*)wave)[0] & 1) != 0) {
+                    wave = (RedWaveDATA*)((u32*)wave + 0x18);
                 }
-                param_1 = (RedWaveDATA*)((u32*)param_1 + 0x18);
+                wave = (RedWaveDATA*)((u32*)wave + 0x18);
             } else {
-                return param_1;
+                return wave;
             }
         }
     }
 
-    return param_1;
+    return wave;
 }
 
 /*
@@ -1353,13 +1353,13 @@ u32 _AdsrDataExecute(RedVoiceDATA* voice)
  * JP Address: TODO
  * JP Size: TODO
  */
-void _VoiceDropedCallback(void* param_1)
+void _VoiceDropedCallback(void* dropped)
 {
     unsigned int* puVar1;
     
     puVar1 = p_VoiceData;
     do {
-        if ((puVar1[5] != 0) && ((void*)puVar1[5] == param_1)) {
+        if ((puVar1[5] != 0) && ((void*)puVar1[5] == dropped)) {
             puVar1[0x23] = 0;
             *puVar1 = 0;
             puVar1[5] = 0;

--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -1302,7 +1302,8 @@ void _AdsrDataCompute(RedVoiceDATA* voice)
     stage[1] = stepCount;
     if (stepCount != 0) {
         *(int*)((int)voice + 0xac) = prevValue;
-        stage[2] = (int)((level | 0x800) - prevValue) / (int)stepCount;
+        level |= 0x800;
+        stage[2] = (level - prevValue) / stepCount;
     } else {
         *(int*)((int)voice + 0xac) = level;
     }

--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -1258,7 +1258,8 @@ void _AdsrStart(RedVoiceDATA* voice)
             prevLevel <<= 0xc;
         }
         *(int*)((u8*)voice + 0xac) = prevLevel;
-        stage[2] = (int)((nextLevel | 0x800) - prevLevel) / (int)stepFrames;
+        nextLevel |= 0x800;
+        stage[2] = (nextLevel - prevLevel) / stepFrames;
     } else {
         *(int*)((u8*)voice + 0xac) = nextLevel;
     }
@@ -1321,25 +1322,24 @@ void _AdsrDataCompute(RedVoiceDATA* voice)
 u32 _AdsrDataExecute(RedVoiceDATA* voice)
 {
     u32 changed = 0;
-    int* voiceData = (int*)voice;
 
-    if (voiceData[0x17] < 4) {
-        if (((voiceData[0x24] & 4U) != 0) || (voiceData[0x17] < 3)) {
+    if (((int*)voice)[0x17] < 4) {
+        if ((((int*)voice)[0x24] & 4U) != 0 || ((int*)voice)[0x17] < 3) {
             changed += 1;
-            voiceData[0x18] -= 1;
-            voiceData[0x2B] += voiceData[0x19];
-            if ((voiceData[0x18] == 0) && (voiceData[0x17] < 3)) {
-                voiceData[0x17] += 1;
-                _AdsrDataCompute((RedVoiceDATA*)voiceData);
+            ((int*)voice)[0x18] -= 1;
+            ((int*)voice)[0x2B] += ((int*)voice)[0x19];
+            if (((int*)voice)[0x18] == 0 && ((int*)voice)[0x17] < 3) {
+                ((int*)voice)[0x17] += 1;
+                _AdsrDataCompute(voice);
             }
         }
     } else {
-        voiceData[0x2B] = 0;
+        ((int*)voice)[0x2B] = 0;
     }
 
-    if ((voiceData[0x2B] >> 0xC) < 1) {
-        voiceData[0x17] = 4;
-        voiceData[0x2B] = 0;
+    if ((((int*)voice)[0x2B] >> 0xC) < 1) {
+        ((int*)voice)[0x17] = 4;
+        ((int*)voice)[0x2B] = 0;
     }
 
     return changed;
@@ -2024,11 +2024,13 @@ int _MusicMidiNoteExecute(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, int
 {
     frames <<= m_MusicFastSpeed;
     *(int*)((u8*)control + 0x484) = frames;
-    *(int*)((u8*)control + 0x10) += frames;
 
-    while (*(int*)((u8*)control + 0x10) >= *(int*)((u8*)control + 0x14)) {
-        *(int*)((u8*)control + 0x0C) += 1;
-        *(int*)((u8*)control + 0x10) -= *(int*)((u8*)control + 0x14);
+    int* tick = (int*)((u8*)control + 0xc);
+    tick[1] += frames;
+
+    while (tick[1] >= tick[2]) {
+        tick[0] += 1;
+        tick[1] -= tick[2];
     }
 
     if (*(s16*)((u8*)control + 0x48E) != 0) {
@@ -2106,14 +2108,15 @@ void _MusicNoteExecute()
  */
 int _MusicMidiNoteSkipExecute(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData, int frames)
 {
+    int* tick = (int*)((u8*)control + 0xc);
     do {
         *(int*)((u8*)control + 0x474) = frames;
         *(int*)((u8*)control + 0x484) = frames;
-        *(int*)((u8*)control + 0x10) += frames;
+        tick[1] += frames;
 
-        while (*(int*)((u8*)control + 0x10) >= *(int*)((u8*)control + 0x14)) {
-            *(int*)((u8*)control + 0x0C) += 1;
-            *(int*)((u8*)control + 0x10) -= *(int*)((u8*)control + 0x14);
+        while (tick[1] >= tick[2]) {
+            tick[0] += 1;
+            tick[1] -= tick[2];
         }
 
         if (*(s16*)((u8*)control + 0x48E) != 0) {
@@ -2123,7 +2126,7 @@ int _MusicMidiNoteSkipExecute(RedSoundCONTROL* control, RedKeyOnDATA* keyOnData,
         if (m_MusicSkipLine != 0) {
             if ((*(s16*)((u8*)control + 0x48E) != 0) && ((*(int*)((u8*)control + 0x46C) & 2) == 0)) {
                 m_MusicSkipLine--;
-                frames = *(int*)((u8*)control + 0x14);
+                frames = tick[2];
                 RedSleep(1000);
             }
         }

--- a/src/RedSound/RedMemory.cpp
+++ b/src/RedSound/RedMemory.cpp
@@ -49,7 +49,7 @@ CRedMemory::~CRedMemory()
  * JP Address: TODO
  * JP Size: TODO
  */
-int RedNew(int param_1)
+int RedNew(int size)
 {
 	unsigned int interrupts;
 	int alignedSize;
@@ -58,12 +58,12 @@ int RedNew(int param_1)
 	int moveCount;
 	int* slot;
 
-	if (param_1 >= 1) {
+	if (size >= 1) {
 		if (m_MemoryBank != 0) {
 			address = m_DataBuffer;
 			if (address != 0) {
 				interrupts = OSDisableInterrupts();
-				alignedSize = (param_1 + 0x1F) & 0xFFFFFFE0;
+				alignedSize = (size + 0x1F) & 0xFFFFFFE0;
 				slot = m_MemoryBank;
 
 				do {
@@ -153,9 +153,9 @@ void RedDelete(int address)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RedDelete(void* param_1)
+void RedDelete(void* address)
 {
-	RedDelete((int)param_1);
+	RedDelete((int)address);
 }
 
 /*
@@ -297,9 +297,9 @@ void RedDeleteA(int address)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RedDeleteA(void* param_1)
+void RedDeleteA(void* address)
 {
-	RedDeleteA((int)param_1);
+	RedDeleteA((int)address);
 }
 
 /*

--- a/src/RedSound/RedSound.cpp
+++ b/src/RedSound/RedSound.cpp
@@ -105,25 +105,25 @@ int* CRedSound::EntryStandbyID(int id)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedSound::Init(void* param_2, int param_3, int param_4, int param_5)
+int CRedSound::Init(void* mainBuffer, int mainBufferSize, int aramBuffer, int aramBufferSize)
 {
 	memset(m_StandbyStatus, 0, 0x100);
 
-	if (param_3 > 0 && param_5 > 0) {
-		if ((((u32)param_2 & 0x1F) != 0) || (((u32)param_3 & 0x1F) != 0)) {
+	if (mainBufferSize > 0 && aramBufferSize > 0) {
+		if ((((u32)mainBuffer & 0x1F) != 0) || (((u32)mainBufferSize & 0x1F) != 0)) {
 			if (m_ReportPrint != 0) {
-				OSReport(sRedSoundMemorySettingError, sRedSoundLogPrefix, sRedSoundLogErrorColor, (u32)param_2,
-				         param_3, sRedSoundLogReset);
+				OSReport(sRedSoundMemorySettingError, sRedSoundLogPrefix, sRedSoundLogErrorColor, (u32)mainBuffer,
+				         mainBufferSize, sRedSoundLogReset);
 				fflush(__files + 1);
 			}
 			return 0;
 		}
 
-		if ((((u32)param_4 & 0x1F) != 0) || (((u32)param_5 & 0x1F) != 0)) {
+		if ((((u32)aramBuffer & 0x1F) != 0) || (((u32)aramBufferSize & 0x1F) != 0)) {
 			if (m_ReportPrint != 0) {
 				OSReport(sRedSoundAMemorySettingError,
-				         sRedSoundLogPrefix, sRedSoundLogErrorColor, param_4,
-				         param_5, sRedSoundLogReset);
+				         sRedSoundLogPrefix, sRedSoundLogErrorColor, aramBuffer,
+				         aramBufferSize, sRedSoundLogReset);
 				fflush(__files + 1);
 			}
 			return 0;
@@ -143,7 +143,7 @@ int CRedSound::Init(void* param_2, int param_3, int param_4, int param_5)
 		AIInit(0);
 		AXInit();
 		AXARTInit();
-        c_RedMemory.Init((int)param_2, param_3, param_4, param_5);
+        c_RedMemory.Init((int)mainBuffer, mainBufferSize, aramBuffer, aramBufferSize);
 		c_RedEntry.Init();
 		Start();
 		c_Driver.Init();
@@ -154,7 +154,7 @@ int CRedSound::Init(void* param_2, int param_3, int param_4, int param_5)
 			fflush(__files + 1);
 		}
 	} else {
-		param_3 = 0;
+		mainBufferSize = 0;
 
 		if (m_ReportPrint != 0) {
 			OSReport(sRedSoundInitError,
@@ -164,7 +164,7 @@ int CRedSound::Init(void* param_2, int param_3, int param_4, int param_5)
 		}
 	}
 
-	return param_3;
+	return mainBufferSize;
 }
 
 /*
@@ -746,14 +746,14 @@ void CRedSound::StreamStop(int streamID)
  * JP Address: TODO
  * JP Size: TODO
  */
-int CRedSound::StreamPlay(void* data, int param_3, int param_4, int param_5)
+int CRedSound::StreamPlay(void* data, int volume, int pan, int loopMode)
 {
 	int id = 0;
 	char* streamData = (char*)data;
 
 	if (streamData[0] == 'S' && streamData[1] == 'T' && streamData[2] == 'R') {
 		id = GetAutoID();
-		c_Driver.StreamPlay(id, data, param_3, param_4, param_5);
+		c_Driver.StreamPlay(id, data, volume, pan, loopMode);
 	} else if (m_ReportPrint != 0) {
 		OSReport(sRedSoundInvalidStreamData,
 		         sRedSoundLogPrefix, sRedSoundLogErrorColor,

--- a/src/RedSound/RedStream.cpp
+++ b/src/RedSound/RedStream.cpp
@@ -85,49 +85,49 @@ void _StreamStop(RedStreamDATA* streamData)
  * Address:	TODO
  * Size:	TODO
  */
-int _ArrangeStreamDataNoLoop(RedStreamDATA* param_1, int param_2, int param_3)
+int _ArrangeStreamDataNoLoop(RedStreamDATA* stream, int bufferIndex, int byteCount)
 {
 	unsigned char* dstBuffer;
 	int streamStruct;
 	int dmaDstOffset;
 	int dmaID;
 
-	param_2 &= 1;
+	bufferIndex &= 1;
 
 	do {
-		dstBuffer = (unsigned char*)(*(int*)((int)param_1 + 0xc) + param_2 * 0x1000);
-		streamStruct = *(int*)((int)param_1 + 4);
+		dstBuffer = (unsigned char*)(*(int*)((int)stream + 0xc) + bufferIndex * 0x1000);
+		streamStruct = *(int*)((int)stream + 4);
 
-		memcpy(dstBuffer, (void*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120)), 0x1000);
-		*(int*)((int)param_1 + 0x120) += 0x1000;
-		if (*(int*)((int)param_1 + 0x120) >= *(int*)((int)param_1 + 0x118)) {
-			*(int*)((int)param_1 + 0x120) = 0;
+		memcpy(dstBuffer, (void*)(*(int*)((int)stream + 8) + *(int*)((int)stream + 0x120)), 0x1000);
+		*(int*)((int)stream + 0x120) += 0x1000;
+		if (*(int*)((int)stream + 0x120) >= *(int*)((int)stream + 0x118)) {
+			*(int*)((int)stream + 0x120) = 0;
 		}
 
-		if (*(short*)((int)param_1 + 0x2a) == 2) {
-			memcpy(dstBuffer + 0x2000, (void*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120)), 0x1000);
-			*(int*)((int)param_1 + 0x120) += 0x1000;
-			if (*(int*)((int)param_1 + 0x120) >= *(int*)((int)param_1 + 0x118)) {
-				*(int*)((int)param_1 + 0x120) = 0;
+		if (*(short*)((int)stream + 0x2a) == 2) {
+			memcpy(dstBuffer + 0x2000, (void*)(*(int*)((int)stream + 8) + *(int*)((int)stream + 0x120)), 0x1000);
+			*(int*)((int)stream + 0x120) += 0x1000;
+			if (*(int*)((int)stream + 0x120) >= *(int*)((int)stream + 0x118)) {
+				*(int*)((int)stream + 0x120) = 0;
 			}
 		}
 
-		dmaDstOffset = *(int*)((int)param_1 + 0x12c) + param_2 * 0x1000;
+		dmaDstOffset = *(int*)((int)stream + 0x12c) + bufferIndex * 0x1000;
 		dmaID = RedDmaEntry(0x8001, 0, (int)dstBuffer, dmaDstOffset, 0x1000, 0, 0);
 
-		if ((param_2 == 0) && (*(void**)(streamStruct + 0x14) != 0)) {
+		if ((bufferIndex == 0) && (*(void**)(streamStruct + 0x14) != 0)) {
 			*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1ec) = (unsigned short)*dstBuffer;
 			*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1ee) =
 			    *(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1f0) = 0;
 			*(unsigned int*)(*(int*)(streamStruct + 0x14) + 0x1c) |= 0x100000;
 		}
 
-		if (*(short*)((int)param_1 + 0x2a) == 2) {
+		if (*(short*)((int)stream + 0x2a) == 2) {
 			dstBuffer += 0x2000;
 			dmaDstOffset += 0x2000;
 			streamStruct += 0xc0;
 			dmaID = RedDmaEntry(0x8001, 0, (int)dstBuffer, dmaDstOffset, 0x1000, 0, 0);
-			if ((param_2 == 0) && (*(void**)(streamStruct + 0x14) != 0)) {
+			if ((bufferIndex == 0) && (*(void**)(streamStruct + 0x14) != 0)) {
 				*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1ec) = (unsigned short)*dstBuffer;
 				*(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1ee) =
 				    *(unsigned short*)(*(int*)(streamStruct + 0x14) + 0x1f0) = 0;
@@ -135,10 +135,10 @@ int _ArrangeStreamDataNoLoop(RedStreamDATA* param_1, int param_2, int param_3)
 			}
 		}
 
-		param_3 -= 0x1000;
-		param_2 ^= 1;
-		*(int*)((int)param_1 + 0x124) += 0x200;
-	} while (0 < param_3);
+		byteCount -= 0x1000;
+		bufferIndex ^= 1;
+		*(int*)((int)stream + 0x124) += 0x200;
+	} while (0 < byteCount);
 
 	return dmaID;
 }
@@ -148,7 +148,7 @@ int _ArrangeStreamDataNoLoop(RedStreamDATA* param_1, int param_2, int param_3)
  * Address:	801cbc6c
  * Size:	856b
  */
-int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
+int _ArrangeStreamDataLoop(RedStreamDATA* stream, int bufferIndex, int byteCount)
 {
 	unsigned int* puVar3;
 	unsigned char* pbVar4;
@@ -158,13 +158,13 @@ int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
 	int iVar8;
 	int dmaID;
 
-	param_2 = param_2 & 1;
+	bufferIndex = bufferIndex & 1;
 	
-	if (*(short*)((int)param_1 + 0x2a) == 2) {
+	if (*(short*)((int)stream + 0x2a) == 2) {
 		do {
-			pbVar6 = (unsigned char*)(*(int*)((int)param_1 + 0xc) + param_2 * 0x1000);
-			iVar8 = *(int*)((int)param_1 + 4);
-			puVar7 = (unsigned int*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120));
+			pbVar6 = (unsigned char*)(*(int*)((int)stream + 0xc) + bufferIndex * 0x1000);
+			iVar8 = *(int*)((int)stream + 4);
+			puVar7 = (unsigned int*)(*(int*)((int)stream + 8) + *(int*)((int)stream + 0x120));
 			pbVar4 = pbVar6 + 0x2000;
 			puVar3 = puVar7 + 0x400;
 			pbVar5 = pbVar6;
@@ -179,12 +179,12 @@ int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
 				pbVar4 = pbVar4 + 8;
 			} while (puVar7 < puVar3);
 			
-			*(int*)((int)param_1 + 0x120) = *(int*)((int)param_1 + 0x120) + 0x1000;
-			if (*(int*)((int)param_1 + 0x120) >= *(int*)((int)param_1 + 0x118)) {
-				*(int*)((int)param_1 + 0x120) = 0;
+			*(int*)((int)stream + 0x120) = *(int*)((int)stream + 0x120) + 0x1000;
+			if (*(int*)((int)stream + 0x120) >= *(int*)((int)stream + 0x118)) {
+				*(int*)((int)stream + 0x120) = 0;
 			}
 			
-			puVar7 = (unsigned int*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120));
+			puVar7 = (unsigned int*)(*(int*)((int)stream + 8) + *(int*)((int)stream + 0x120));
 			puVar3 = puVar7 + 0x400;
 			
 			do {
@@ -197,15 +197,15 @@ int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
 				pbVar4 = pbVar4 + 8;
 			} while (puVar7 < puVar3);
 			
-			*(int*)((int)param_1 + 0x120) = *(int*)((int)param_1 + 0x120) + 0x1000;
-			if (*(int*)((int)param_1 + 0x120) >= *(int*)((int)param_1 + 0x118)) {
-				*(int*)((int)param_1 + 0x120) = 0;
+			*(int*)((int)stream + 0x120) = *(int*)((int)stream + 0x120) + 0x1000;
+			if (*(int*)((int)stream + 0x120) >= *(int*)((int)stream + 0x118)) {
+				*(int*)((int)stream + 0x120) = 0;
 			}
 			
-			dmaID = RedDmaEntry(0x8001, 0, (int)pbVar6, *(int*)((int)param_1 + 300) + param_2 * 0x1000, 0x1000, 0, 0);
-			dmaID = RedDmaEntry(0x8001, 0, (int)(pbVar6 + 0x2000), *(int*)((int)param_1 + 300) + (param_2 + 2) * 0x1000, 0x1000, 0, 0);
+			dmaID = RedDmaEntry(0x8001, 0, (int)pbVar6, *(int*)((int)stream + 300) + bufferIndex * 0x1000, 0x1000, 0, 0);
+			dmaID = RedDmaEntry(0x8001, 0, (int)(pbVar6 + 0x2000), *(int*)((int)stream + 300) + (bufferIndex + 2) * 0x1000, 0x1000, 0, 0);
 			
-			if ((param_2 == 0) && (*(void**)(iVar8 + 0x14) != 0)) {
+			if ((bufferIndex == 0) && (*(void**)(iVar8 + 0x14) != 0)) {
 				int zero = 0;
 				*(unsigned short*)(*(int*)(iVar8 + 0x14) + 0x1ec) = (unsigned short)*pbVar6;
 				*(unsigned short*)(*(int*)(iVar8 + 0x14) + 0x1f0) = zero;
@@ -217,29 +217,29 @@ int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
 				*(unsigned int*)(*(int*)(iVar8 + 0xd4) + 0x1c) = *(unsigned int*)(*(int*)(iVar8 + 0xd4) + 0x1c) | 0x100000;
 			}
 			
-			param_2 = param_2 ^ 1;
-			param_3 = param_3 + -0x1000;
-			*(int*)((int)param_1 + 0x124) = *(int*)((int)param_1 + 0x124) + 0x200;
+			bufferIndex = bufferIndex ^ 1;
+			byteCount = byteCount + -0x1000;
+			*(int*)((int)stream + 0x124) = *(int*)((int)stream + 0x124) + 0x200;
 			
-			if (*(int*)((int)param_1 + 0x124) >= *(int*)((int)param_1 + 0x1c)) {
-				*(int*)((int)param_1 + 0x124) = *(int*)((int)param_1 + 0x124) - *(int*)((int)param_1 + 0x1c);
-				*(int*)((int)param_1 + 0x124) = *(int*)((int)param_1 + 0x124) + *(int*)((int)param_1 + 0x20);
+			if (*(int*)((int)stream + 0x124) >= *(int*)((int)stream + 0x1c)) {
+				*(int*)((int)stream + 0x124) = *(int*)((int)stream + 0x124) - *(int*)((int)stream + 0x1c);
+				*(int*)((int)stream + 0x124) = *(int*)((int)stream + 0x124) + *(int*)((int)stream + 0x20);
 			}
-		} while (0 < param_3);
+		} while (0 < byteCount);
 	} else {
 		do {
-			pbVar5 = (unsigned char*)(*(int*)((int)param_1 + 0xc) + param_2 * 0x1000);
-			iVar8 = *(int*)((int)param_1 + 4);
-			memcpy(pbVar5, (void*)(*(int*)((int)param_1 + 8) + *(int*)((int)param_1 + 0x120)), 0x1000);
-			*(int*)((int)param_1 + 0x120) = *(int*)((int)param_1 + 0x120) + 0x1000;
+			pbVar5 = (unsigned char*)(*(int*)((int)stream + 0xc) + bufferIndex * 0x1000);
+			iVar8 = *(int*)((int)stream + 4);
+			memcpy(pbVar5, (void*)(*(int*)((int)stream + 8) + *(int*)((int)stream + 0x120)), 0x1000);
+			*(int*)((int)stream + 0x120) = *(int*)((int)stream + 0x120) + 0x1000;
 			
-			if (*(int*)((int)param_1 + 0x120) >= *(int*)((int)param_1 + 0x118)) {
-				*(int*)((int)param_1 + 0x120) = 0;
+			if (*(int*)((int)stream + 0x120) >= *(int*)((int)stream + 0x118)) {
+				*(int*)((int)stream + 0x120) = 0;
 			}
 			
-			dmaID = RedDmaEntry(0x8001, 0, (int)pbVar5, *(int*)((int)param_1 + 300) + param_2 * 0x1000, 0x1000, 0, 0);
+			dmaID = RedDmaEntry(0x8001, 0, (int)pbVar5, *(int*)((int)stream + 300) + bufferIndex * 0x1000, 0x1000, 0, 0);
 			
-			if ((param_2 == 0) && (*(void**)(iVar8 + 0x14) != 0)) {
+			if ((bufferIndex == 0) && (*(void**)(iVar8 + 0x14) != 0)) {
 				int zero = 0;
 				*(unsigned short*)(*(int*)(iVar8 + 0x14) + 0x1ec) = (unsigned short)*pbVar5;
 				*(unsigned short*)(*(int*)(iVar8 + 0x14) + 0x1f0) = zero;
@@ -247,15 +247,15 @@ int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
 				*(unsigned int*)(*(int*)(iVar8 + 0x14) + 0x1c) = *(unsigned int*)(*(int*)(iVar8 + 0x14) + 0x1c) | 0x100000;
 			}
 			
-			param_2 = param_2 ^ 1;
-			param_3 = param_3 + -0x1000;
-			*(int*)((int)param_1 + 0x124) = *(int*)((int)param_1 + 0x124) + 0x200;
+			bufferIndex = bufferIndex ^ 1;
+			byteCount = byteCount + -0x1000;
+			*(int*)((int)stream + 0x124) = *(int*)((int)stream + 0x124) + 0x200;
 			
-			if (*(int*)((int)param_1 + 0x124) >= *(int*)((int)param_1 + 0x1c)) {
-				*(int*)((int)param_1 + 0x124) = *(int*)((int)param_1 + 0x124) - *(int*)((int)param_1 + 0x1c);
-				*(int*)((int)param_1 + 0x124) = *(int*)((int)param_1 + 0x124) + *(int*)((int)param_1 + 0x20);
+			if (*(int*)((int)stream + 0x124) >= *(int*)((int)stream + 0x1c)) {
+				*(int*)((int)stream + 0x124) = *(int*)((int)stream + 0x124) - *(int*)((int)stream + 0x1c);
+				*(int*)((int)stream + 0x124) = *(int*)((int)stream + 0x124) + *(int*)((int)stream + 0x20);
 			}
-		} while (0 < param_3);
+		} while (0 < byteCount);
 	}
 
 	return dmaID;
@@ -270,12 +270,12 @@ int _ArrangeStreamDataLoop(RedStreamDATA* param_1, int param_2, int param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void StreamStop(int param_1)
+void StreamStop(int streamID)
 {
 	volatile RedStreamDATA* streamData = p_Stream;
 
 	do {
-		if ((streamData->m_streamId != 0) && ((param_1 == -1) || (param_1 == streamData->m_streamId))) {
+		if ((streamData->m_streamId != 0) && ((streamID == -1) || (streamID == streamData->m_streamId))) {
 			_StreamStop((RedStreamDATA*)streamData);
 		}
 		streamData++;
@@ -291,7 +291,7 @@ void StreamStop(int param_1)
  * JP Address: TODO
  * JP Size: TODO
  */
-int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5)
+int StreamPlay(int streamID, void* streamHeader, int volume, int pan, int loopMode)
 {
 	int amemSize;
 	int arOffset;
@@ -305,7 +305,7 @@ int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5
 	streamData = (int*)_SearchEmptyStreamData();
 	if (streamData != (int*)0) {
 
-	memcpy(streamData + 4, param_2, 0x20);
+	memcpy(streamData + 4, streamHeader, 0x20);
 	*streamData = (int)SearchSeEmptyTrack(*(short*)((int)streamData + 0x2a), 0xff, 0);
 	streamData[3] = RedNew(0x4000);
 	amemSize = *(short*)((int)streamData + 0x2a) << 0xd;
@@ -322,32 +322,32 @@ int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5
 
 	if ((*streamData != 0) && (streamData[3] != 0) && (streamData[0x4b] != 0)) {
 		sampleOffset = 0x1000;
-		*(short*)((int)param_2 + 0x42) = (short)*(char*)((int)param_2 + sampleOffset);
-		*(unsigned short*)((int)param_2 + 0x46) = 0;
-		*(unsigned short*)((int)param_2 + 0x44) = 0;
-		headerData = (u8*)param_2 + 0x20;
+		*(short*)((int)streamHeader + 0x42) = (short)*(char*)((int)streamHeader + sampleOffset);
+		*(unsigned short*)((int)streamHeader + 0x46) = 0;
+		*(unsigned short*)((int)streamHeader + 0x44) = 0;
+		headerData = (u8*)streamHeader + 0x20;
 		if (*(short*)((int)streamData + 0x2a) == 2) {
 			if (streamData[8] < 0) {
 				sampleOffset += 0x1000;
 			} else {
 				sampleOffset += 8;
 			}
-			*(short*)(headerData + 0x50) = (short)*(char*)((int)param_2 + sampleOffset);
+			*(short*)(headerData + 0x50) = (short)*(char*)((int)streamHeader + sampleOffset);
 			*(unsigned short*)(headerData + 0x54) = 0;
 			*(unsigned short*)(headerData + 0x52) = 0;
 		}
 
-		streamData[0x43] = param_1;
+		streamData[0x43] = streamID;
 		streamData[0x47] = 0;
 		streamData[0x48] = 0x1000;
 		streamData[0x49] = 0;
 		streamData[1] = (int)p_VoiceData + *(char*)(*streamData + 0x14e) * 0xc0;
-		streamData[2] = (int)param_2;
-		streamData[0x46] = param_3;
-		if (param_5 != 0) {
-			param_5 = ((param_5 + 1) * 0x100 - 1) * 0x1000;
+		streamData[2] = (int)streamHeader;
+		streamData[0x46] = volume;
+		if (loopMode != 0) {
+			loopMode = ((loopMode + 1) * 0x100 - 1) * 0x1000;
 		}
-		streamData[0x3c] = param_5;
+		streamData[0x3c] = loopMode;
 		streamData[0x3e] = 0;
 		pitch = PitchCompute(0x3c00000, 0, streamData[9], 0);
 		iVar2 = 0;
@@ -375,7 +375,7 @@ int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5
 					streamData[0x42] = 0;
 				}
 			} else {
-				streamData[0x40] = param_4 << 0xc;
+				streamData[0x40] = pan << 0xc;
 				streamData[0x42] = 0;
 			}
 			SetVoiceVolumeMix((RedVoiceDATA*)(streamData[1] + iVar2 * 0xc0), streamData[0x40] >> 0xc, streamData[0x3c] >> 0xc);
@@ -432,7 +432,7 @@ int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5
 		}
 	}
 	}
-	return param_1;
+	return streamID;
 }
 
 /*
@@ -444,35 +444,35 @@ int StreamPlay(int param_1, void* param_2, int param_3, int param_4, int param_5
  * JP Address: TODO
  * JP Size: TODO
  */
-void SetStreamVolume(int param_1, int param_2, int param_3)
+void SetStreamVolume(int streamID, int volume, int frameCount)
 {
 	volatile RedStreamDATA* streamData;
 
-	if (param_3 < 1) {
-		param_3 = 1;
+	if (frameCount < 1) {
+		frameCount = 1;
 	} else {
-		param_3 *= 200;
-		param_3 /= 60;
+		frameCount *= 200;
+		frameCount /= 60;
 	}
 
-	param_2 &= 0x7f;
-	if (param_2 != 0) {
-		param_2++;
-		param_2 <<= 8;
-		param_2--;
-		param_2 <<= 12;
-		param_2 |= 0x800;
+	volume &= 0x7f;
+	if (volume != 0) {
+		volume++;
+		volume <<= 8;
+		volume--;
+		volume <<= 12;
+		volume |= 0x800;
 	}
 
 	streamData = p_Stream;
 	do {
-		if ((streamData->m_streamId != 0) && ((param_1 == -1) || (param_1 == streamData->m_streamId))) {
-			if (param_3 > 0) {
-				int delta = param_2 - streamData->m_volume;
-				streamData->m_volumeStep = delta / param_3;
-				streamData->m_volumeStepCount = param_3;
+		if ((streamData->m_streamId != 0) && ((streamID == -1) || (streamID == streamData->m_streamId))) {
+			if (frameCount > 0) {
+				int delta = volume - streamData->m_volume;
+				streamData->m_volumeStep = delta / frameCount;
+				streamData->m_volumeStepCount = frameCount;
 			} else {
-				streamData->m_volume = param_2;
+				streamData->m_volume = volume;
 				streamData->m_volumeStepCount = 0;
 			}
 		}
@@ -489,25 +489,25 @@ void SetStreamVolume(int param_1, int param_2, int param_3)
  * JP Address: TODO
  * JP Size: TODO
  */
-void StreamPause(int param_1, int param_2)
+void StreamPause(int streamID, int pause)
 {
 	volatile RedStreamDATA* streamData;
 	int volume;
 	int pan;
 
 	if (m_ReportPrint != 0) {
-		if (param_2 == 1) {
-			OSReport(sRedStreamPauseOnFmt, sRedStreamLogPrefix, param_1);
+		if (pause == 1) {
+			OSReport(sRedStreamPauseOnFmt, sRedStreamLogPrefix, streamID);
 		} else {
-			OSReport(sRedStreamPauseOffFmt, sRedStreamLogPrefix, param_1);
+			OSReport(sRedStreamPauseOffFmt, sRedStreamLogPrefix, streamID);
 		}
 		fflush(__files + 1);
 	}
 	streamData = p_Stream;
 	do {
-		if ((streamData->m_streamId != 0) && ((param_1 == -1) || (param_1 == streamData->m_streamId))) {
+		if ((streamData->m_streamId != 0) && ((streamID == -1) || (streamID == streamData->m_streamId))) {
 			unsigned int voiceData = (unsigned int)streamData->m_voiceData;
-			if (param_2 == 1) {
+			if (pause == 1) {
 				if (*(void**)(voiceData + 0x14) != 0) {
 					*(int*)(voiceData + 0x9c) = 0;
 					*(unsigned int*)(voiceData + 0x90) |= 0x10;


### PR DESCRIPTION
No behavioral or codegen changes. Pure variable-naming pass to make the RedSound module readable. All 7 RedSound units verified at identical matched% / fuzzy% before and after.

Renamed across:
- RedSound.cpp: CRedSound::Init mainBuffer/mainBufferSize/aramBuffer/ aramBufferSize; CRedSound::StreamPlay volume/pan/loopMode.
- RedDriver.cpp: all _XxxCommand dispatcher params from param_1 to command (these unpack a packed int* command buffer); RedSleep microseconds; _MyAlarmHandler alarm; _WaveSettingThread threadArg; CRedDriver public methods (SetMusicData, SetSeSepData, SetSeBlockData, Music/Se/Stream Volume/Pan/Pitch/Pause/PlayState, GetStreamPlayPoint, StreamPlay, ClearWaveData/ClearWaveBank) renamed using the names already established in RedSound.cpp wrappers and RedDriver.h.
- RedExecute.cpp: _ReverbNullCallback update; ReverbAreaFree area; _PitchExecute voice; _WaveSplitSelect wave/note; _VoiceDropedCallback dropped.
- RedStream.cpp: _ArrangeStreamData{NoLoop,Loop} stream/bufferIndex/ byteCount; StreamStop/StreamPlay/SetStreamVolume/StreamPause params matching the public API.
- RedMemory.cpp: RedNew size; RedDelete/RedDeleteA address.

Remaining param_N (~36 instances) are in functions where the parameter meaning is not yet confidently established (RedDmaEntry, PitchCompute, _VoiceDataAsign, ClearWaveDataM) and were left for a follow-up pass.