### PR TITLE
Define chara_anim sdata2 constants

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -23,6 +23,12 @@ extern unsigned char Chara[];
 extern CCharaPcs CharaPcs;
 extern const float kCharaSharedZeroF;
 extern const float kCharaSharedOneF;
+extern const double DOUBLE_80330C78 = 4503599627370496.0;
+extern const float FLOAT_80330c80 = 0.0f;
+extern const float FLOAT_80330c84 = 0.01745329238474369f;
+extern const double DOUBLE_80330c88 = 4503601774854144.0;
+extern const float FLOAT_80330C90 = -1.0f;
+extern const float FLOAT_80330C94 = 360.0f;
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)


### PR DESCRIPTION
## Summary
- Define the six shared .sdata2 constants owned by chara_anim in MAP/order: DOUBLE_80330C78, FLOAT_80330c80, FLOAT_80330c84, DOUBLE_80330c88, FLOAT_80330C90, FLOAT_80330C94.
- This replaces anonymous/missing local constant ownership with real named definitions in src/chara_anim.cpp.

## Objdiff evidence
- Unit: main/chara_anim
- Before: .text 98.503746%, .data 80.0%, .sdata2 62.5%, Create__Q26CChara5CAnimFPvPQ27CMemory6CStage 97.354164%
- After: .text 98.503746%, .data 80.0%, .sdata2 100.0%, Create__Q26CChara5CAnimFPvPQ27CMemory6CStage 97.354164%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara_anim -o - Create__Q26CChara5CAnimFPvPQ27CMemory6CStage

## Plausibility
- The constants match config/GCCP01/symbols.txt ownership and target order for chara_anim .sdata2.
- No code-shape changes were kept; attempted source rewrites that regressed code were reverted.