### PR TITLE
Use math bounds constants in frustum clipping

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -305,8 +305,8 @@ int CBound::CheckFrustum0(CBound& outBound)
     Vec vertex;
     Vec transformed;
 
-    maxInit = 3.40282347e38f;
-    minInit = -3.40282347e38f;
+    maxInit = FLOAT_8032F784;
+    minInit = FLOAT_8032F788;
     clipBound[2] = maxInit;
     clipBound[1] = maxInit;
     clipBound[0] = maxInit;


### PR DESCRIPTION
## Summary
- Use the existing math unit bound sentinel constants when initializing the output clip bound in CBound::CheckFrustum0(CBound&).
- This matches the Ghidra decompile for 0x8001b99c, which initializes with FLOAT_8032F784/FLOAT_8032F788 instead of IEEE max/min literals.

## Evidence
- ninja: passes, main.dol OK.
- objdiff main/math CheckFrustum0__6CBoundFR6CBound remains 96.56827%.
- Neighbor targets unchanged in the same diff run: CheckFrustum0__6CBoundFf 98.88535%, CrossCheckEllipseCapsule 97.16912%.

## Plausibility
- The source now reuses constants already owned by math.cpp, avoiding hard-coded float extrema where the target uses the unit's bound sentinel values.