### PR TITLE
pppBlurChara: inline blur depth constant

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -200,9 +200,8 @@ void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppB
     }
 
     pppInitBlendMode();
-    const float drawDepth = FLOAT_80331030;
     _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
-    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(&colorData->m_color, (pppFMATRIX*)0, drawDepth,
+    pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(&colorData->m_color, (pppFMATRIX*)0, FLOAT_80331030,
                                                                param_2->m_alpha, 0, 0, 0, 1, 1, 0);
     objPosBase = texData->m_objPosBase;
 


### PR DESCRIPTION
## Summary
- inline the blur render depth constant directly in `pppRenderBlurChara`
- remove the temporary local that was only feeding `pppSetDrawEnv`
- keep the change limited to plausible source cleanup in the selected dependency cluster

## Evidence
- project data progress improved from `1095249 / 1489517` bytes to `1095321 / 1489517` bytes after this change
- `main/pppBlurChara` extabindex now reports `100%` match in objdiff
- build remains green with `ninja`

## Why this is plausible
- this replaces an unnecessary local temporary with the linked constant already used elsewhere in the function
- the result is simpler source rather than compiler coaxing or section-forcing hacks

## Tradeoff
- `pppRenderBlurChara` code shape moved slightly while the unit made real data/linkage progress; this PR keeps the net improvement and documents that tradeoff explicitly