### PR TITLE
Improve pppYmTracer UV step conversion

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -150,7 +150,7 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
                 SetUpPaletteEnv(texture);
             }
 
-            uvStep = FLOAT_803306ec / (f32)(s32)work->count;
+            uvStep = FLOAT_803306ec / (f32)(u32)work->count;
             GXSetCullMode(GX_CULL_NONE);
 
             for (i = 0; i < (s32)(work->count - 1); i++) {


### PR DESCRIPTION
## Summary
- Treat `TracerWork::count` as an unsigned count when computing the tracer UV step.
- This removes the extra signed integer-to-float conversion in `pppRenderYmTracer` and better matches the target codegen.

## Evidence
- `ninja` passes.
- `main/pppYmTracer` fuzzy score improved from 95.63984% to 95.778366%.
- `pppRenderYmTracer` report score improved from 98.13043% to 98.58696%.
- Direct objdiff for `pppRenderYmTracer` improved from 98.08696% to 98.54348%.

## Plausibility
- `work->count` is a `u16` particle/segment count, so converting it as `u32` preserves the original unsigned count semantics and avoids a compiler-generated signed conversion.