### PR TITLE
Remove stray ppp random helpers

### DIFF
--- a/include/ffcc/pppRandCV.h
+++ b/include/ffcc/pppRandCV.h
@@ -5,8 +5,6 @@
 struct _pppCtrlTable;
 struct RandCVParams;
 #ifdef __cplusplus
-char randchar(char, float);
-
 extern "C" {
 #endif
 

--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -79,17 +79,3 @@ void pppRandCV(void* basePtr, RandCVParams* in, _pppCtrlTable* ctrl)
         }
     }
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-char randchar(char value, float scale)
-{
-    return (char)(((f32)value * scale) - (f32)value);
-}

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -67,17 +67,3 @@ void pppRandHCV(void* basePtr, RandHCVParams* in, _pppCtrlTable* ctrl)
 }
 
 }
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-static short randshort(short value, float scale)
-{
-    return (short)(((f32)value * scale) - (f32)value);
-}


### PR DESCRIPTION
## Summary
- Removed stray non-target helper emission from `pppRandCV` and `pppRandHCV`.
- Dropped the now-invalid `randchar` declaration from `pppRandCV.h`.

## Evidence
- `ninja` passes for PAL (`GCCP01`).
- Overall matched data improved from 1,095,321 bytes to 1,095,349 bytes (+28).
- `main/pppRandCV`: `extab` improved to 100%; `extabindex` improved from 61.11% to 91.67%.
- `main/pppRandHCV`: `extab` and `extabindex` improved to 100%; unit data is now 100% matched.

## Plausibility
- The removed helpers were labeled UNUSED and were not referenced by the unit or other sources.
- Keeping them caused extra emitted text/extab that the target object does not contain, so removing them aligns source ownership with the compiled object.