### PR TITLE
Introduce _pppPObject::m_workArea for canonical work-block access

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -113,11 +113,22 @@ struct _PARTICLE_DATA
 };
 typedef _PARTICLE_DATA PARTICLE_DATA;
 
+// The fixed 0x34-byte prefix that wrapper types embed by value when they
+// continue with their own fields after it. The full _pppPObject (used as
+// the callback parameter type) extends this with a per-instance work-area
+// block at offset 0x80.
+struct _pppPObjectHead
+{
+    s32 m_graphId;              // 0x0
+    pppFMATRIX m_localMatrix;   // 0x4 (size 0x30)
+};
+
 struct _pppPObject
 {
     s32 m_graphId;              // 0x0
     pppFMATRIX m_localMatrix;   // 0x4 (size 0x30)
-    // Additional members may exist
+    char m_pad34[0x80 - 0x34];  // 0x34
+    u8 m_workArea[1];           // 0x80 - per-instance work block, indexed by _pppCtrlTable::m_serializedDataOffsets[N]
 };
 
 struct _pppPObjLink;

--- a/include/ffcc/pppColor.h
+++ b/include/ffcc/pppColor.h
@@ -2,6 +2,8 @@
 #define _FFCC_PPPCOLOR_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct _pppColor
 {
@@ -30,8 +32,8 @@ extern const double kPppColorScale;
 extern "C" {
 #endif
 
-void pppColor(void* param1, void* param2, struct _pppCtrlTable* param3);
-void pppColorCon(void* param1, struct _pppCtrlTable* param2);
+void pppColor(struct _pppPObject* param1, void* param2, struct _pppCtrlTable* param3);
+void pppColorCon(struct _pppPObject* param1, struct _pppCtrlTable* param2);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppKeShpTail2X.h
+++ b/include/ffcc/pppKeShpTail2X.h
@@ -6,7 +6,7 @@
 struct pppKeShpTail2X
 {
     u8 _pad0[0xc];
-    _pppPObject pppPObject;
+    _pppPObjectHead pppPObject;
     pppFMATRIX field_0x40;
 };
 

--- a/include/ffcc/pppKeShpTail3X.h
+++ b/include/ffcc/pppKeShpTail3X.h
@@ -6,7 +6,7 @@
 struct pppKeShpTail3X
 {
     u8 _pad0[0xc];
-    _pppPObject pppPObject;
+    _pppPObjectHead pppPObject;
     pppFMATRIX field_0x40;
     u8 field_0x70[0xd];
     u8 field_0x7d;

--- a/include/ffcc/pppLight.h
+++ b/include/ffcc/pppLight.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_LIGHT_H_
 #define _PPP_LIGHT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppLight(void* param1, void* param2, void* param3);
+void pppLight(struct _pppPObject* param1, void* param2, void* param3);
 void pppLightCon(void* param1, void* param2);
 void pppLightCon3(void* param1, void* param2);
 

--- a/include/ffcc/pppRandCV.h
+++ b/include/ffcc/pppRandCV.h
@@ -2,6 +2,8 @@
 #define _PPP_RANDCV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct RandCVParams;
 #ifdef __cplusplus
@@ -10,7 +12,7 @@ char randchar(char, float);
 extern "C" {
 #endif
 
-void pppRandCV(void* basePtr, struct RandCVParams* in, struct _pppCtrlTable* ctrl);
+void pppRandCV(struct _pppPObject* basePtr, struct RandCVParams* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandChar.h
+++ b/include/ffcc/pppRandChar.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDCHAR_H_
 #define _PPP_RANDCHAR_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandChar(void* basePtr, struct RandCharParam* in, struct _pppCtrlTable* ctrl);
+void pppRandChar(struct _pppPObject* basePtr, struct RandCharParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownCV.h
+++ b/include/ffcc/pppRandDownCV.h
@@ -2,6 +2,8 @@
 #define _PPP_RANDDOWNCV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandDownCVParam2;
 #ifdef __cplusplus
@@ -10,7 +12,7 @@ char randchar(char, float);
 extern "C" {
 #endif
 
-void pppRandDownCV(void* basePtr, struct PppRandDownCVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandDownCV(struct _pppPObject* basePtr, struct PppRandDownCVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownChar.h
+++ b/include/ffcc/pppRandDownChar.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDDOWNCHAR_H_
 #define _PPP_RANDDOWNCHAR_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandDownChar(void* basePtr, struct PppRandDownCharParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandDownChar(struct _pppPObject* basePtr, struct PppRandDownCharParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownFV.h
+++ b/include/ffcc/pppRandDownFV.h
@@ -2,6 +2,8 @@
 #define _PPP_RANDDOWNFV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandDownFVParam2;
 #ifdef __cplusplus
@@ -10,7 +12,7 @@ void randf(float, float);
 extern "C" {
 #endif
 
-void pppRandDownFV(void* basePtr, struct PppRandDownFVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandDownFV(struct _pppPObject* basePtr, struct PppRandDownFVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownFloat.h
+++ b/include/ffcc/pppRandDownFloat.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDDOWNFLOAT_H_
 #define _PPP_RANDDOWNFLOAT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandDownFloat(void* basePtr, struct RandDownFloatParam* in, struct _pppCtrlTable* ctrl);
+void pppRandDownFloat(struct _pppPObject* basePtr, struct RandDownFloatParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownHCV.h
+++ b/include/ffcc/pppRandDownHCV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDDOWNHCV_H_
 #define _PPP_RANDDOWNHCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandDownHCV(void* basePtr, struct PppRandDownHCVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandDownHCV(struct _pppPObject* basePtr, struct PppRandDownHCVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownIV.h
+++ b/include/ffcc/pppRandDownIV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDDOWNIV_H_
 #define _PPP_RANDDOWNIV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandDownIV(void* basePtr, struct PppRandDownIVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandDownIV(struct _pppPObject* basePtr, struct PppRandDownIVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownInt.h
+++ b/include/ffcc/pppRandDownInt.h
@@ -2,13 +2,15 @@
 #define _PPP_RANDDOWNINT_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandDownIntParam2;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandDownInt(void* basePtr, struct PppRandDownIntParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandDownInt(struct _pppPObject* basePtr, struct PppRandDownIntParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandDownShort.h
+++ b/include/ffcc/pppRandDownShort.h
@@ -1,13 +1,15 @@
 #ifndef _PPP_RANDDOWNSHORT_H_
 #define _PPP_RANDDOWNSHORT_H_
 
+
+struct _pppPObject;
 #include "types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandDownShort(void* basePtr, struct RandDownShortParam* in, struct _pppCtrlTable* ctrl);
+void pppRandDownShort(struct _pppPObject* basePtr, struct RandDownShortParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandFV.h
+++ b/include/ffcc/pppRandFV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDFV_H_
 #define _PPP_RANDFV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandFV(void* basePtr, struct PppRandFVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandFV(struct _pppPObject* basePtr, struct PppRandFVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandFloat.h
+++ b/include/ffcc/pppRandFloat.h
@@ -1,6 +1,8 @@
 #ifndef _PPP_RANDFLOAT_H_
 #define _PPP_RANDFLOAT_H_
 
+
+struct _pppPObject;
 #include "dolphin/types.h"
 
 struct _pppCtrlTable;
@@ -10,7 +12,7 @@ struct RandFloatParam;
 extern "C" {
 #endif
 
-void pppRandFloat(void* basePtr, struct RandFloatParam* in, struct _pppCtrlTable* ctrl);
+void pppRandFloat(struct _pppPObject* basePtr, struct RandFloatParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandHCV.h
+++ b/include/ffcc/pppRandHCV.h
@@ -2,13 +2,15 @@
 #define _PPP_RANDHCV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct RandHCVParams;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandHCV(void* basePtr, struct RandHCVParams* in, struct _pppCtrlTable* ctrl);
+void pppRandHCV(struct _pppPObject* basePtr, struct RandHCVParams* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandIV.h
+++ b/include/ffcc/pppRandIV.h
@@ -2,13 +2,15 @@
 #define _PPP_RANDIV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandIVParam2;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandIV(void* basePtr, struct PppRandIVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandIV(struct _pppPObject* basePtr, struct PppRandIVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandInt.h
+++ b/include/ffcc/pppRandInt.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDINT_H_
 #define _PPP_RANDINT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandInt(void* basePtr, struct PppRandIntParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandInt(struct _pppPObject* basePtr, struct PppRandIntParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandShort.h
+++ b/include/ffcc/pppRandShort.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDSHORT_H_
 #define _PPP_RANDSHORT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandShort(void* basePtr, struct PppRandShortParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandShort(struct _pppPObject* basePtr, struct PppRandShortParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpCV.h
+++ b/include/ffcc/pppRandUpCV.h
@@ -1,13 +1,15 @@
 #ifndef _PPP_RANDUPCV_H_
 #define _PPP_RANDUPCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 char randchar(char, float);
 
 extern "C" {
 #endif
 
-void pppRandUpCV(void* basePtr, struct RandUpCVParam* in, struct _pppCtrlTable* ctrl);
+void pppRandUpCV(struct _pppPObject* basePtr, struct RandUpCVParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpChar.h
+++ b/include/ffcc/pppRandUpChar.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDUPCHAR_H_
 #define _PPP_RANDUPCHAR_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandUpChar(void* basePtr, struct RandUpCharParam* in, struct _pppCtrlTable* ctrl);
+void pppRandUpChar(struct _pppPObject* basePtr, struct RandUpCharParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpFV.h
+++ b/include/ffcc/pppRandUpFV.h
@@ -1,6 +1,8 @@
 #ifndef _PPP_RANDUPFV_H_
 #define _PPP_RANDUPFV_H_
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandUpFVParam2;
 
@@ -9,7 +11,7 @@ extern "C" {
 #endif
 
 void randf(float, float);
-void pppRandUpFV(void* basePtr, struct PppRandUpFVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandUpFV(struct _pppPObject* basePtr, struct PppRandUpFVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpFloat.h
+++ b/include/ffcc/pppRandUpFloat.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDUPFLOAT_H_
 #define _PPP_RANDUPFLOAT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandUpFloat(void* basePtr, struct RandUpFloatParam* in, struct _pppCtrlTable* ctrl);
+void pppRandUpFloat(struct _pppPObject* basePtr, struct RandUpFloatParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpHCV.h
+++ b/include/ffcc/pppRandUpHCV.h
@@ -2,13 +2,15 @@
 #define _PPP_RANDUPHCV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandUpHCVParam2;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandUpHCV(void* basePtr, struct PppRandUpHCVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandUpHCV(struct _pppPObject* basePtr, struct PppRandUpHCVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpIV.h
+++ b/include/ffcc/pppRandUpIV.h
@@ -2,13 +2,15 @@
 #define _PPP_RANDUPIV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppRandUpIVParam2;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandUpIV(void* basePtr, struct PppRandUpIVParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandUpIV(struct _pppPObject* basePtr, struct PppRandUpIVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpInt.h
+++ b/include/ffcc/pppRandUpInt.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDUPINT_H_
 #define _PPP_RANDUPINT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandUpInt(void* basePtr, struct PppRandUpIntParam2* in, struct _pppCtrlTable* ctrl);
+void pppRandUpInt(struct _pppPObject* basePtr, struct PppRandUpIntParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppRandUpShort.h
+++ b/include/ffcc/pppRandUpShort.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_RANDUPSHORT_H_
 #define _PPP_RANDUPSHORT_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppRandUpShort(void* basePtr, struct RandUpShortParam* in, struct _pppCtrlTable* ctrl);
+void pppRandUpShort(struct _pppPObject* basePtr, struct RandUpShortParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandCV.h
+++ b/include/ffcc/pppSRandCV.h
@@ -1,6 +1,8 @@
 #ifndef _PPP_SRANDCV_H_
 #define _PPP_SRANDCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 void randchar(char, float);
 void randf(unsigned char);
@@ -8,7 +10,7 @@ void randf(unsigned char);
 extern "C" {
 #endif
 
-void pppSRandCV(void* basePtr, struct SRandCVParam* in, struct _pppCtrlTable* ctrl);
+void pppSRandCV(struct _pppPObject* basePtr, struct SRandCVParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandDownFV.h
+++ b/include/ffcc/pppSRandDownFV.h
@@ -1,13 +1,15 @@
 #ifndef _PPP_SRANDDOWNFV_H_
 #define _PPP_SRANDDOWNFV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void randfloat(float, float);
 void randf(unsigned char);
-void pppSRandDownFV(void* basePtr, struct PppSRandDownFVParam2* in, struct _pppCtrlTable* ctrl);
+void pppSRandDownFV(struct _pppPObject* basePtr, struct PppSRandDownFVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandDownHCV.h
+++ b/include/ffcc/pppSRandDownHCV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_SRANDDOWNHCV_H_
 #define _PPP_SRANDDOWNHCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppSRandDownHCV(void* basePtr, struct PppSRandDownHCVParam2* in, struct _pppCtrlTable* ctrl);
+void pppSRandDownHCV(struct _pppPObject* basePtr, struct PppSRandDownHCVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandFV.h
+++ b/include/ffcc/pppSRandFV.h
@@ -2,6 +2,8 @@
 #define _PPP_SRANDFV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppSRandFVParam2;
 #ifdef __cplusplus
@@ -10,7 +12,7 @@ extern "C" {
 
 void randfloat(float, float);
 void randf(unsigned char);
-void pppSRandFV(void* basePtr, struct PppSRandFVParam2* in, struct _pppCtrlTable* ctrl);
+void pppSRandFV(struct _pppPObject* basePtr, struct PppSRandFVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandHCV.h
+++ b/include/ffcc/pppSRandHCV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_SRANDHCV_H_
 #define _PPP_SRANDHCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppSRandHCV(void* basePtr, struct PppSRandHCVParam2* in, struct _pppCtrlTable* ctrl);
+void pppSRandHCV(struct _pppPObject* basePtr, struct PppSRandHCVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandUpCV.h
+++ b/include/ffcc/pppSRandUpCV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_SRANDUPCV_H_
 #define _PPP_SRANDUPCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppSRandUpCV(void* basePtr, struct SRandUpCVParam* in, struct _pppCtrlTable* ctrl);
+void pppSRandUpCV(struct _pppPObject* basePtr, struct SRandUpCVParam* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandUpFV.h
+++ b/include/ffcc/pppSRandUpFV.h
@@ -2,6 +2,8 @@
 #define _PPP_SRANDUPFV_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppSRandUpFVParam2;
 #ifdef __cplusplus
@@ -10,7 +12,7 @@ extern "C" {
 
 void randfloat(float, float);
 void randf(unsigned char);
-void pppSRandUpFV(void* basePtr, struct PppSRandUpFVParam2* in, struct _pppCtrlTable* ctrl);
+void pppSRandUpFV(struct _pppPObject* basePtr, struct PppSRandUpFVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppSRandUpHCV.h
+++ b/include/ffcc/pppSRandUpHCV.h
@@ -1,11 +1,13 @@
 #ifndef _PPP_SRANDUPHCV_H_
 #define _PPP_SRANDUPHCV_H_
 
+
+struct _pppPObject;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppSRandUpHCV(void* basePtr, struct PppSRandUpHCVParam2* in, struct _pppCtrlTable* ctrl);
+void pppSRandUpHCV(struct _pppPObject* basePtr, struct PppSRandUpHCVParam2* in, struct _pppCtrlTable* ctrl);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppScaleLoopAuto.h
+++ b/include/ffcc/pppScaleLoopAuto.h
@@ -2,13 +2,15 @@
 #define _PPP_SCALELOOPAUTO_H_
 
 
+
+struct _pppPObject;
 struct pppScaleLoopAutoContext;
 struct pppScaleLoopAutoStep;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppScaleLoopAuto(void* arg1, struct pppScaleLoopAutoStep* arg2, struct pppScaleLoopAutoContext* arg3);
+void pppScaleLoopAuto(struct _pppPObject* arg1, struct pppScaleLoopAutoStep* arg2, struct pppScaleLoopAutoContext* arg3);
 void pppScaleLoopAutoCon(void* arg1, void* arg2);
 
 #ifdef __cplusplus

--- a/include/ffcc/pppSclAccele.h
+++ b/include/ffcc/pppSclAccele.h
@@ -2,14 +2,16 @@
 #define _PPP_SCLACCELE_H_
 
 
+
+struct _pppPObject;
 struct _pppCtrlTable;
 struct PppSclAcceleStep;
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppSclAccele(void* arg1, struct PppSclAcceleStep* arg2, struct _pppCtrlTable* arg3);
-void pppSclAcceleCon(void* arg1, struct _pppCtrlTable* arg2);
+void pppSclAccele(struct _pppPObject* arg1, struct PppSclAcceleStep* arg2, struct _pppCtrlTable* arg3);
+void pppSclAcceleCon(struct _pppPObject* arg1, struct _pppCtrlTable* arg2);
 
 #ifdef __cplusplus
 }

--- a/src/pppColor.cpp
+++ b/src/pppColor.cpp
@@ -12,8 +12,8 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppColorCon(void* param1, _pppCtrlTable* param2){
-    _pppColorWork* work = (_pppColorWork*)((u8*)param1 + param2->m_serializedDataOffsets[0] + 0x80);
+void pppColorCon(_pppPObject* param1, _pppCtrlTable* param2){
+    _pppColorWork* work = (_pppColorWork*)(param1->m_workArea + param2->m_serializedDataOffsets[0]);
     
     work->a = 0;
     work->b = 0;
@@ -30,8 +30,8 @@ void pppColorCon(void* param1, _pppCtrlTable* param2){
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppColor(void* param1, void* param2, _pppCtrlTable* param3){
-    _pppColorWork* work = (_pppColorWork*)((u8*)param1 + param3->m_serializedDataOffsets[0] + 0x80);
+void pppColor(_pppPObject* param1, void* param2, _pppCtrlTable* param3){
+    _pppColorWork* work = (_pppColorWork*)(param1->m_workArea + param3->m_serializedDataOffsets[0]);
 
     if (gPppCalcDisabled != 0) {
         return;

--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -149,14 +149,14 @@ void pppLightCon(void* param1, void* param2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppLight(void* param1, void* param2, void* param3)
+void pppLight(_pppPObject* param1, void* param2, void* param3)
 {
 	u8* pObject = (u8*)param1;
 	PppLightStep* step = (PppLightStep*)param2;
 	_pppCtrlTable* ctrlTable = (_pppCtrlTable*)param3;
 
 	if (gPppCalcDisabled == 0) {
-		PppLightWork* work = (PppLightWork*)(pObject + ctrlTable->m_serializedDataOffsets[0] + 0x80);
+		PppLightWork* work = (PppLightWork*)(param1->m_workArea + ctrlTable->m_serializedDataOffsets[0]);
 
 		if (gPppCalcDisabled != 0) {
 			goto create_light;

--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -25,7 +25,7 @@ typedef struct RandCVParams {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandCV(void* basePtr, RandCVParams* in, _pppCtrlTable* ctrl)
+void pppRandCV(_pppPObject* basePtr, RandCVParams* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     f32* valuePtr;
@@ -42,12 +42,12 @@ void pppRandCV(void* basePtr, RandCVParams* in, _pppCtrlTable* ctrl)
             value *= kPppRandCVSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else if (in->index != *(s32*)(base + 0xC)) {
         return;
     } else {
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     u8* targetColor;

--- a/src/pppRandChar.cpp
+++ b/src/pppRandChar.cpp
@@ -24,7 +24,7 @@ struct RandCharParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandChar(void* basePtr, RandCharParam* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandChar(_pppPObject* basePtr, RandCharParam* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     u8* target;
@@ -43,13 +43,13 @@ extern "C" void pppRandChar(void* basePtr, RandCharParam* in, _pppCtrlTable* ctr
             value *= kPppRandCharSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != state) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 colorOffset = in->sourceOffset;

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -32,7 +32,7 @@ inline char randchar(char value, float scale)
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandDownCV(void* basePtr, PppRandDownCVParam2* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandDownCV(_pppPObject* basePtr, PppRandDownCVParam2* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     u8* target;
@@ -51,12 +51,12 @@ extern "C" void pppRandDownCV(void* basePtr, PppRandDownCVParam2* in, _pppCtrlTa
             value = blend * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else if (in->field0 != *(s32*)(base + 0xC)) {
         return;
     } else {
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->field4 == -1) ? &gPppDefaultValueBuffer[0] : (u8*)(base + in->field4 + 0x80);

--- a/src/pppRandDownChar.cpp
+++ b/src/pppRandDownChar.cpp
@@ -25,7 +25,7 @@ struct PppRandDownCharParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandDownChar(void* basePtr, PppRandDownCharParam2* in, _pppCtrlTable* ctrl)
+void pppRandDownChar(_pppPObject* basePtr, PppRandDownCharParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -43,13 +43,13 @@ void pppRandDownChar(void* basePtr, PppRandDownCharParam2* in, _pppCtrlTable* ct
             value = mixed * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != baseState) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     u8* target = (in->field4 == -1) ? gPppDefaultValueBuffer : (u8*)(base + in->field4 + 0x80);

--- a/src/pppRandDownFV.cpp
+++ b/src/pppRandDownFV.cpp
@@ -26,7 +26,7 @@ struct PppRandDownFVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandDownFV(void* basePtr, PppRandDownFVParam2* in, _pppCtrlTable* ctrl)
+void pppRandDownFV(_pppPObject* basePtr, PppRandDownFVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -44,14 +44,14 @@ void pppRandDownFV(void* basePtr, PppRandDownFVParam2* in, _pppCtrlTable* ctrl)
             value = randomValue * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != baseState) {
             return;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 sourceOffset = in->field4;

--- a/src/pppRandDownFloat.cpp
+++ b/src/pppRandDownFloat.cpp
@@ -23,7 +23,7 @@ struct RandDownFloatParam {
  * JP Address: TODO  
  * JP Size: TODO
  */
-void pppRandDownFloat(void* basePtr, RandDownFloatParam* in, _pppCtrlTable* ctrl)
+void pppRandDownFloat(_pppPObject* basePtr, RandDownFloatParam* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -41,13 +41,13 @@ void pppRandDownFloat(void* basePtr, RandDownFloatParam* in, _pppCtrlTable* ctrl
             value = randomValue * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != id) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 sourceOffset = in->sourceOffset;

--- a/src/pppRandDownHCV.cpp
+++ b/src/pppRandDownHCV.cpp
@@ -26,7 +26,7 @@ struct PppRandDownHCVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandDownHCV(void* basePtr, PppRandDownHCVParam2* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandDownHCV(_pppPObject* basePtr, PppRandDownHCVParam2* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     s16* target;
@@ -45,12 +45,12 @@ extern "C" void pppRandDownHCV(void* basePtr, PppRandDownHCVParam2* in, _pppCtrl
             value = blend * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else if (in->field0 != *(s32*)(base + 0xC)) {
         return;
     } else {
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->field4 == -1) ? (s16*)gPppDefaultValueBuffer : (s16*)(base + in->field4 + 0x80);

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -31,7 +31,7 @@ inline int randint(int value, float scale)
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandDownIV(void* basePtr, PppRandDownIVParam2* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandDownIV(_pppPObject* basePtr, PppRandDownIVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -49,13 +49,13 @@ extern "C" void pppRandDownIV(void* basePtr, PppRandDownIVParam2* in, _pppCtrlTa
             value = randValue * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != *(s32*)(base + 0xC)) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);

--- a/src/pppRandDownInt.cpp
+++ b/src/pppRandDownInt.cpp
@@ -23,7 +23,7 @@ struct PppRandDownIntParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandDownInt(void* basePtr, PppRandDownIntParam2* in, _pppCtrlTable* ctrl)
+void pppRandDownInt(_pppPObject* basePtr, PppRandDownIntParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -41,13 +41,13 @@ void pppRandDownInt(void* basePtr, PppRandDownIntParam2* in, _pppCtrlTable* ctrl
             value = mixed * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != baseState) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);

--- a/src/pppRandDownShort.cpp
+++ b/src/pppRandDownShort.cpp
@@ -23,7 +23,7 @@ struct RandDownShortParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandDownShort(void* basePtr, RandDownShortParam* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandDownShort(_pppPObject* basePtr, RandDownShortParam* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     s16* target;
@@ -42,14 +42,14 @@ extern "C" void pppRandDownShort(void* basePtr, RandDownShortParam* in, _pppCtrl
             value = mixed * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != state) {
             return;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->sourceOffset == -1) ? (s16*)gPppDefaultValueBuffer : (s16*)(base + in->sourceOffset + 0x80);

--- a/src/pppRandFV.cpp
+++ b/src/pppRandFV.cpp
@@ -26,7 +26,7 @@ struct PppRandFVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandFV(void* basePtr, PppRandFVParam2* in, _pppCtrlTable* ctrl)
+void pppRandFV(_pppPObject* basePtr, PppRandFVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -44,13 +44,13 @@ void pppRandFV(void* basePtr, PppRandFVParam2* in, _pppCtrlTable* ctrl)
             value *= kPppRandFVSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != state) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     f32* target = (in->field4 == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)(base + in->field4 + 0x80);

--- a/src/pppRandFloat.cpp
+++ b/src/pppRandFloat.cpp
@@ -23,7 +23,7 @@ struct RandFloatParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandFloat(void* basePtrIn, RandFloatParam* in, _pppCtrlTable* ctrl)
+void pppRandFloat(_pppPObject* basePtrIn, RandFloatParam* in, _pppCtrlTable* ctrl)
 {
     u8* base;
     f32* valuePtr;
@@ -43,13 +43,13 @@ void pppRandFloat(void* basePtrIn, RandFloatParam* in, _pppCtrlTable* ctrl)
             value *= kPppRandFloatSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtrIn->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != state) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtrIn->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 sourceOffset = in->sourceOffset;

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -29,7 +29,7 @@ typedef struct RandHCVParams {
 
 extern "C" {
 
-void pppRandHCV(void* basePtr, RandHCVParams* in, _pppCtrlTable* ctrl)
+void pppRandHCV(_pppPObject* basePtr, RandHCVParams* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     s16* target;
@@ -47,12 +47,12 @@ void pppRandHCV(void* basePtr, RandHCVParams* in, _pppCtrlTable* ctrl)
             value *= kPppRandHCVSingleSampleScale;
         }
 
-        randomValue = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        randomValue = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *randomValue = value;
     } else if (in->field0 != *(s32*)(base + 0xC)) {
         return;
     } else {
-        randomValue = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        randomValue = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->field4 == -1) ? (s16*)gPppDefaultValueBuffer : (s16*)(base + in->field4 + 0x80);

--- a/src/pppRandIV.cpp
+++ b/src/pppRandIV.cpp
@@ -31,7 +31,7 @@ inline int randint(int value, float scale)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandIV(void* basePtr, PppRandIVParam2* in, _pppCtrlTable* ctrl)
+void pppRandIV(_pppPObject* basePtr, PppRandIVParam2* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     f32 value;
@@ -49,13 +49,13 @@ void pppRandIV(void* basePtr, PppRandIVParam2* in, _pppCtrlTable* ctrl)
             value *= kPppRandIVSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != *(s32*)(base + 0xC)) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);

--- a/src/pppRandInt.cpp
+++ b/src/pppRandInt.cpp
@@ -26,7 +26,7 @@ struct PppRandIntParam2 {
     u8 fieldC;
 };
 
-void pppRandInt(void* basePtr, PppRandIntParam2* in, _pppCtrlTable* ctrl)
+void pppRandInt(_pppPObject* basePtr, PppRandIntParam2* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     f32* valuePtr;
@@ -44,14 +44,14 @@ void pppRandInt(void* basePtr, PppRandIntParam2* in, _pppCtrlTable* ctrl)
             value *= kPppRandIntSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != baseState) {
             return;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);

--- a/src/pppRandShort.cpp
+++ b/src/pppRandShort.cpp
@@ -23,7 +23,7 @@ struct PppRandShortParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandShort(void* basePtr, PppRandShortParam2* in, _pppCtrlTable* ctrl)
+void pppRandShort(_pppPObject* basePtr, PppRandShortParam2* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     f32* valuePtr;
@@ -41,14 +41,14 @@ void pppRandShort(void* basePtr, PppRandShortParam2* in, _pppCtrlTable* ctrl)
             value *= kPppRandShortSingleSampleScale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != baseState) {
             return;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s16* target = (in->field4 == -1) ? (s16*)gPppDefaultValueBuffer : (s16*)(base + in->field4 + 0x80);

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -27,7 +27,7 @@ inline char randchar(char value, float scale)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandUpCV(void* basePtr, RandUpCVParam* in, _pppCtrlTable* ctrl)
+void pppRandUpCV(_pppPObject* basePtr, RandUpCVParam* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     u8* target;
@@ -46,12 +46,12 @@ void pppRandUpCV(void* basePtr, RandUpCVParam* in, _pppCtrlTable* ctrl)
             value = blend * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else if (in->targetId != *(s32*)(base + 0xC)) {
         return;
     } else {
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->sourceOffset == -1) ? &gPppDefaultValueBuffer[0] : (u8*)(base + in->sourceOffset + 0x80);

--- a/src/pppRandUpChar.cpp
+++ b/src/pppRandUpChar.cpp
@@ -24,7 +24,7 @@ struct RandUpCharParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandUpChar(void* basePtr, RandUpCharParam* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandUpChar(_pppPObject* basePtr, RandUpCharParam* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     u8* target;
@@ -43,13 +43,13 @@ extern "C" void pppRandUpChar(void* basePtr, RandUpCharParam* in, _pppCtrlTable*
             value = mixed * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != state) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->sourceOffset == -1) ? gPppDefaultValueBuffer : (u8*)(base + in->sourceOffset + 0x80);

--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -26,7 +26,7 @@ struct PppRandUpFVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandUpFV(void* basePtrIn, PppRandUpFVParam2* in, _pppCtrlTable* ctrl)
+void pppRandUpFV(_pppPObject* basePtrIn, PppRandUpFVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -44,13 +44,13 @@ void pppRandUpFV(void* basePtrIn, PppRandUpFVParam2* in, _pppCtrlTable* ctrl)
             value = randomValue * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtrIn->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != state) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtrIn->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 sourceOffset = in->field4;

--- a/src/pppRandUpFloat.cpp
+++ b/src/pppRandUpFloat.cpp
@@ -23,7 +23,7 @@ struct RandUpFloatParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandUpFloat(void* basePtr, RandUpFloatParam* in, _pppCtrlTable* ctrl) {
+void pppRandUpFloat(_pppPObject* basePtr, RandUpFloatParam* in, _pppCtrlTable* ctrl) {
     if (gPppCalcDisabled != 0) {
         return;
     }
@@ -41,13 +41,13 @@ void pppRandUpFloat(void* basePtr, RandUpFloatParam* in, _pppCtrlTable* ctrl) {
             value = randomValue * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != id) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 sourceOffset = in->sourceOffset;

--- a/src/pppRandUpHCV.cpp
+++ b/src/pppRandUpHCV.cpp
@@ -26,7 +26,7 @@ struct PppRandUpHCVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandUpHCV(void* basePtr, PppRandUpHCVParam2* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandUpHCV(_pppPObject* basePtr, PppRandUpHCVParam2* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     s16* target;
@@ -45,12 +45,12 @@ extern "C" void pppRandUpHCV(void* basePtr, PppRandUpHCVParam2* in, _pppCtrlTabl
             value = blend * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else if (in->field0 != *(s32*)(base + 0xC)) {
         return;
     } else {
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->field4 == -1) ? (s16*)gPppDefaultValueBuffer : (s16*)(base + in->field4 + 0x80);

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -31,7 +31,7 @@ inline int randint(int value, float scale)
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandUpIV(void* basePtr, PppRandUpIVParam2* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandUpIV(_pppPObject* basePtr, PppRandUpIVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -49,13 +49,13 @@ extern "C" void pppRandUpIV(void* basePtr, PppRandUpIVParam2* in, _pppCtrlTable*
             value = randValue * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != *(s32*)(base + 0xC)) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);

--- a/src/pppRandUpInt.cpp
+++ b/src/pppRandUpInt.cpp
@@ -23,7 +23,7 @@ struct PppRandUpIntParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRandUpInt(void* basePtr, PppRandUpIntParam2* in, _pppCtrlTable* ctrl)
+void pppRandUpInt(_pppPObject* basePtr, PppRandUpIntParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -41,13 +41,13 @@ void pppRandUpInt(void* basePtr, PppRandUpIntParam2* in, _pppCtrlTable* ctrl)
             value = mixed * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->field0 != baseState) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32* target = (in->field4 == -1) ? (s32*)gPppDefaultValueBuffer : (s32*)(base + in->field4 + 0x80);

--- a/src/pppRandUpShort.cpp
+++ b/src/pppRandUpShort.cpp
@@ -23,7 +23,7 @@ struct RandUpShortParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-extern "C" void pppRandUpShort(void* basePtr, RandUpShortParam* in, _pppCtrlTable* ctrl)
+extern "C" void pppRandUpShort(_pppPObject* basePtr, RandUpShortParam* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     s16* target;
@@ -42,13 +42,13 @@ extern "C" void pppRandUpShort(void* basePtr, RandUpShortParam* in, _pppCtrlTabl
             value = mixed * scale;
         }
 
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         *valuePtr = value;
     } else {
         if (in->targetId != state) {
             return;
         }
-        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     target = (in->sourceOffset == -1) ? (s16*)gPppDefaultValueBuffer : (s16*)(base + in->sourceOffset + 0x80);

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/pppRyjMegaBirth.h"
+#include "ffcc/partMng.h"
 #include "ffcc/pppGetRotMatrixXYZ.h"
 #include "ffcc/math.h"
 #include "ffcc/pppPart.h"
@@ -689,7 +690,7 @@ static inline void set_matrix(
 void pppRyjDrawMegaBirth(_pppPObject* obj, void* stepData, _pppCtrlTable* ctrlTable)
 {
 	PRyjMegaBirth* params = (PRyjMegaBirth*)stepData;
-	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)obj + 0x80 + ctrlTable->m_serializedDataOffsets[2]);
+	VRyjMegaBirth* work = (VRyjMegaBirth*)(obj->m_workArea + ctrlTable->m_serializedDataOffsets[2]);
 	u8* payload = (u8*)params;
 	int dataValIndex = *(int*)(payload + 4);
 
@@ -755,7 +756,7 @@ void pppRyjDrawMegaBirth(_pppPObject* obj, void* stepData, _pppCtrlTable* ctrlTa
  */
 void pppRyjMegaBirthCon(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
 {
-	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2]);
+	VRyjMegaBirth* work = (VRyjMegaBirth*)(pObject->m_workArea + offsets->m_serializedDataOffsets[2]);
 	float zero;
 
 	PSMTXIdentity(work->m_worldMatrix);
@@ -785,7 +786,7 @@ void pppRyjMegaBirthCon(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
  */
 void pppRyjMegaBirthDes(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
 {
-	u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+	u8* work = pObject->m_workArea + offsets->m_serializedDataOffsets[2];
 
 	if (*(void**)(work + 0x3C) != 0)
 	{

--- a/src/pppRyjMegaBirthModel.cpp
+++ b/src/pppRyjMegaBirthModel.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/pppRyjMegaBirthModel.h"
+#include "ffcc/partMng.h"
 #include "ffcc/math.h"
 #include "ffcc/pppPart.h"
 #include <string.h>
@@ -222,7 +223,7 @@ void pppRyjMegaBirthModel(_pppPObject* pObject, PRyjMegaBirthModel* params, PRyj
     float posZ;
     bool hasRequiredMemory;
     s32 colorOffset = offsets->m_serializedDataOffsets[1];
-    u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+    u8* work = pObject->m_workArea + offsets->m_serializedDataOffsets[2];
     u8* payload = (u8*)params;
 
     if (*(void**)(work + 0xC) == 0) {
@@ -817,7 +818,7 @@ void pppRyjDrawMegaBirthModel(_pppPObject* obj, void* stepData, _pppCtrlTable* c
 {
     PRyjMegaBirthModel* params = (PRyjMegaBirthModel*)stepData;
     VRyjMegaBirthModel* work =
-        (VRyjMegaBirthModel*)((u8*)obj + 0x80 + ctrlTable->m_serializedDataOffsets[2]);
+        (VRyjMegaBirthModel*)(obj->m_workArea + ctrlTable->m_serializedDataOffsets[2]);
     int modelIndex = *(int*)((u8*)params + 4);
 
     if (modelIndex == 0xFFFF || work->m_particleBlock == NULL) {
@@ -1048,7 +1049,7 @@ void set_matrix(_pppPObject* pObject, pppFMATRIX mtxA, pppFMATRIX mtxB, PRyjMega
  */
 void pppRyjMegaBirthModelCon(_pppPObject* pObject, PRyjMegaBirthModelOffsets* offsets)
 {
-    u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+    u8* work = pObject->m_workArea + offsets->m_serializedDataOffsets[2];
     float value1;
     float value0;
 
@@ -1080,7 +1081,7 @@ void pppRyjMegaBirthModelCon(_pppPObject* pObject, PRyjMegaBirthModelOffsets* of
  */
 void pppRyjMegaBirthModelDes(_pppPObject* pObject, PRyjMegaBirthModelOffsets* offsets)
 {
-    u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+    u8* work = pObject->m_workArea + offsets->m_serializedDataOffsets[2];
 
     if (*(void**)(work + 0xC) != 0) {
         pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0xC));

--- a/src/pppSRandCV.cpp
+++ b/src/pppSRandCV.cpp
@@ -25,7 +25,7 @@ struct SRandCVParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandCV(void* basePtr, SRandCVParam* in, _pppCtrlTable* ctrl)
+void pppSRandCV(_pppPObject* basePtr, SRandCVParam* in, _pppCtrlTable* ctrl)
 {
     u8* base = (u8*)basePtr;
     if (gPppCalcDisabled != 0) {
@@ -35,7 +35,7 @@ void pppSRandCV(void* basePtr, SRandCVParam* in, _pppCtrlTable* ctrl)
     float* target;
 
     if (in->targetId == *(s32*)(base + 0xC)) {
-        target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
         {
             u8 flag = in->randomTwice;
@@ -88,7 +88,7 @@ void pppSRandCV(void* basePtr, SRandCVParam* in, _pppCtrlTable* ctrl)
         if (in->targetId != *(s32*)(base + 0xC)) {
             return;
         }
-        target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 color_offset = in->sourceOffset;

--- a/src/pppSRandDownFV.cpp
+++ b/src/pppSRandDownFV.cpp
@@ -26,7 +26,7 @@ struct PppSRandDownFVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandDownFV(void* basePtr, PppSRandDownFVParam2* in, _pppCtrlTable* ctrl)
+void pppSRandDownFV(_pppPObject* basePtr, PppSRandDownFVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -35,7 +35,7 @@ void pppSRandDownFV(void* basePtr, PppSRandDownFVParam2* in, _pppCtrlTable* ctrl
     f32* randVec;
     s32 currentIndex = *(s32*)((u8*)basePtr + 0xC);
     if (currentIndex == 0) {
-        randVec = (f32*)((u8*)basePtr + *ctrl->m_serializedDataOffsets + 0x80);
+        randVec = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
         {
             u8 flag = in->field18;
@@ -76,7 +76,7 @@ void pppSRandDownFV(void* basePtr, PppSRandDownFVParam2* in, _pppCtrlTable* ctrl
         if (in->field0 != currentIndex) {
             return;
         }
-        randVec = (f32*)((u8*)basePtr + *ctrl->m_serializedDataOffsets + 0x80);
+        randVec = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     f32* target = (in->field4 == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)((u8*)basePtr + in->field4 + 0x80);

--- a/src/pppSRandDownHCV.cpp
+++ b/src/pppSRandDownHCV.cpp
@@ -26,7 +26,7 @@ struct PppSRandDownHCVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandDownHCV(void* basePtr, PppSRandDownHCVParam2* in, _pppCtrlTable* ctrl)
+void pppSRandDownHCV(_pppPObject* basePtr, PppSRandDownHCVParam2* in, _pppCtrlTable* ctrl)
 {
 	u8* base = (u8*)basePtr;
 	if (gPppCalcDisabled != 0) {
@@ -36,7 +36,7 @@ void pppSRandDownHCV(void* basePtr, PppSRandDownHCVParam2* in, _pppCtrlTable* ct
 	float* target;
 
 	if (in->field0 == *(s32*)(base + 0xC)) {
-		target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+		target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
 		{
 			u8 flag = in->field10;
@@ -89,7 +89,7 @@ void pppSRandDownHCV(void* basePtr, PppSRandDownHCVParam2* in, _pppCtrlTable* ct
 		if (in->field0 != *(s32*)(base + 0xC)) {
 			return;
 		}
-		target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+		target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 	}
 
 	s32 color_offset = in->field4;

--- a/src/pppSRandFV.cpp
+++ b/src/pppSRandFV.cpp
@@ -29,7 +29,7 @@ struct PppSRandFVParam2 {
     u8 field18;
 };
 
-void pppSRandFV(void* basePtr, PppSRandFVParam2* in, _pppCtrlTable* ctrl)
+void pppSRandFV(_pppPObject* basePtr, PppSRandFVParam2* in, _pppCtrlTable* ctrl)
 {
     f32* randVec;
     if (gPppCalcDisabled != 0) {
@@ -38,7 +38,7 @@ void pppSRandFV(void* basePtr, PppSRandFVParam2* in, _pppCtrlTable* ctrl)
 
     s32 currentIndex = *(s32*)((u8*)basePtr + 0xC);
     if (currentIndex == 0) {
-        randVec = (f32*)((u8*)basePtr + *ctrl->m_serializedDataOffsets + 0x80);
+        randVec = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
         {
             u8 flag = in->field18;
             f32 value = Math.RandF();
@@ -78,7 +78,7 @@ void pppSRandFV(void* basePtr, PppSRandFVParam2* in, _pppCtrlTable* ctrl)
         if (in->field0 != currentIndex) {
             return;
         }
-        randVec = (f32*)((u8*)basePtr + *ctrl->m_serializedDataOffsets + 0x80);
+        randVec = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     f32* target = (in->field4 == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)((u8*)basePtr + in->field4 + 0x80);

--- a/src/pppSRandHCV.cpp
+++ b/src/pppSRandHCV.cpp
@@ -27,7 +27,7 @@ struct PppSRandHCVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandHCV(void* basePtr, PppSRandHCVParam2* in, _pppCtrlTable* ctrl)
+void pppSRandHCV(_pppPObject* basePtr, PppSRandHCVParam2* in, _pppCtrlTable* ctrl)
 {
 	u8* base = (u8*)basePtr;
 	if (gPppCalcDisabled != 0) {
@@ -37,7 +37,7 @@ void pppSRandHCV(void* basePtr, PppSRandHCVParam2* in, _pppCtrlTable* ctrl)
 	float* target;
 
 	if (in->field0 == *(s32*)(base + 0xC)) {
-		target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+		target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
 		{
 			u8 flag = in->field10;
@@ -90,7 +90,7 @@ void pppSRandHCV(void* basePtr, PppSRandHCVParam2* in, _pppCtrlTable* ctrl)
 		if (in->field0 != *(s32*)(base + 0xC)) {
 			return;
 		}
-		target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+		target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 	}
 	s32 color_offset = in->field4;
 	s16* target_colors;

--- a/src/pppSRandUpCV.cpp
+++ b/src/pppSRandUpCV.cpp
@@ -24,7 +24,7 @@ struct SRandUpCVParam {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandUpCV(void* basePtr, SRandUpCVParam* in, _pppCtrlTable* ctrl)
+void pppSRandUpCV(_pppPObject* basePtr, SRandUpCVParam* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -34,7 +34,7 @@ void pppSRandUpCV(void* basePtr, SRandUpCVParam* in, _pppCtrlTable* ctrl)
     f32* target;
 
     if (in->targetId == *(s32*)(base + 0xC)) {
-        target = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        target = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
         {
             u8 flag = in->randomTwice;
@@ -83,7 +83,7 @@ void pppSRandUpCV(void* basePtr, SRandUpCVParam* in, _pppCtrlTable* ctrl)
         if (in->targetId != *(s32*)(base + 0xC)) {
             return;
         }
-        target = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+        target = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     s32 color_offset = in->sourceOffset;

--- a/src/pppSRandUpFV.cpp
+++ b/src/pppSRandUpFV.cpp
@@ -26,7 +26,7 @@ struct PppSRandUpFVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandUpFV(void* basePtr, PppSRandUpFVParam2* in, _pppCtrlTable* ctrl)
+void pppSRandUpFV(_pppPObject* basePtr, PppSRandUpFVParam2* in, _pppCtrlTable* ctrl)
 {
     if (gPppCalcDisabled != 0) {
         return;
@@ -35,7 +35,7 @@ void pppSRandUpFV(void* basePtr, PppSRandUpFVParam2* in, _pppCtrlTable* ctrl)
     s32 currentIndex = *(s32*)((u8*)basePtr + 0xC);
     f32* randVec;
     if (currentIndex == 0) {
-        randVec = (f32*)((u8*)basePtr + *ctrl->m_serializedDataOffsets + 0x80);
+        randVec = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
         {
             u8 flag = in->field18;
@@ -76,7 +76,7 @@ void pppSRandUpFV(void* basePtr, PppSRandUpFVParam2* in, _pppCtrlTable* ctrl)
         if (in->field0 != currentIndex) {
             return;
         }
-        randVec = (f32*)((u8*)basePtr + *ctrl->m_serializedDataOffsets + 0x80);
+        randVec = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
     }
 
     f32* target = (in->field4 == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)((u8*)basePtr + in->field4 + 0x80);

--- a/src/pppSRandUpHCV.cpp
+++ b/src/pppSRandUpHCV.cpp
@@ -26,7 +26,7 @@ struct PppSRandUpHCVParam2 {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSRandUpHCV(void* basePtr, PppSRandUpHCVParam2* in, _pppCtrlTable* ctrl)
+void pppSRandUpHCV(_pppPObject* basePtr, PppSRandUpHCVParam2* in, _pppCtrlTable* ctrl)
 {
 	u8* base = (u8*)basePtr;
 	if (gPppCalcDisabled != 0) {
@@ -36,7 +36,7 @@ void pppSRandUpHCV(void* basePtr, PppSRandUpHCVParam2* in, _pppCtrlTable* ctrl)
 	float* target;
 
 	if (in->field0 == *(s32*)(base + 0xC)) {
-		target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+		target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 
 		{
 			u8 flag = in->field10;
@@ -89,7 +89,7 @@ void pppSRandUpHCV(void* basePtr, PppSRandUpHCVParam2* in, _pppCtrlTable* ctrl)
 		if (in->field0 != *(s32*)(base + 0xC)) {
 			return;
 		}
-		target = (float*)(base + *ctrl->m_serializedDataOffsets + 0x80);
+		target = (float*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
 	}
 
 	s32 color_offset = in->field4;

--- a/src/pppScaleLoopAuto.cpp
+++ b/src/pppScaleLoopAuto.cpp
@@ -1,4 +1,5 @@
 #include "ffcc/pppScaleLoopAuto.h"
+#include "ffcc/partMng.h"
 #include "ffcc/ppp_constants.h"
 #include <dolphin/types.h>
 #include "ffcc/ppp_linkage.h"
@@ -45,12 +46,12 @@ struct pppScaleLoopAutoContext {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppScaleLoopAuto(void* arg1, pppScaleLoopAutoStep* arg2, pppScaleLoopAutoContext* arg3){
+void pppScaleLoopAuto(_pppPObject* arg1, pppScaleLoopAutoStep* arg2, pppScaleLoopAutoContext* arg3){
     if (gPppCalcDisabled != 0) {
         return;
     }
 
-    pppScaleLoopAutoWork* work = (pppScaleLoopAutoWork*)((u8*)arg1 + arg3->m_serializedDataOffsets[0] + 0x80);
+    pppScaleLoopAutoWork* work = (pppScaleLoopAutoWork*)(arg1->m_workArea + arg3->m_serializedDataOffsets[0]);
 
     if (arg2->m_index == *(s32*)((u8*)arg1 + 0xC)) {
         work->m_scale[0] += arg2->m_addScale[0];

--- a/src/pppSclAccele.cpp
+++ b/src/pppSclAccele.cpp
@@ -21,8 +21,8 @@ struct PppSclAcceleStep {
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSclAcceleCon(void* arg1, _pppCtrlTable* arg2){
-    float* accel = (float*)((char*)arg1 + arg2->m_serializedDataOffsets[1] + 0x80);
+void pppSclAcceleCon(_pppPObject* arg1, _pppCtrlTable* arg2){
+    float* accel = (float*)(arg1->m_workArea + arg2->m_serializedDataOffsets[1]);
     float zero = kPppSclAcceleZero;
 
     accel[2] = zero;
@@ -39,9 +39,9 @@ void pppSclAcceleCon(void* arg1, _pppCtrlTable* arg2){
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppSclAccele(void* arg1, PppSclAcceleStep* arg2, _pppCtrlTable* arg3){
-    float* scale = (float*)((char*)arg1 + arg3->m_serializedDataOffsets[0] + 0x80);
-    float* accel = (float*)((char*)arg1 + arg3->m_serializedDataOffsets[1] + 0x80);
+void pppSclAccele(_pppPObject* arg1, PppSclAcceleStep* arg2, _pppCtrlTable* arg3){
+    float* scale = (float*)(arg1->m_workArea + arg3->m_serializedDataOffsets[0]);
+    float* accel = (float*)(arg1->m_workArea + arg3->m_serializedDataOffsets[1]);
 
     if (gPppCalcDisabled != 0) {
         return;

--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -130,7 +130,7 @@ void pppDrawVtMime(_pppPObject* object, void* step, _pppCtrlTable* ctrl)
         return;
     }
 
-    VtMimeState* state = (VtMimeState*)((char*)object + *ctrl->m_serializedDataOffsets + 0x80);
+    VtMimeState* state = (VtMimeState*)(object->m_workArea + *ctrl->m_serializedDataOffsets);
     VtMimeEnv* env = (VtMimeEnv*)pppEnvStPtr;
     void** sourceTable = env->sourceTable;
     int vertIdx2 = data->sourceB;
@@ -172,7 +172,7 @@ void pppDrawVtMime(_pppPObject* object, void* step, _pppCtrlTable* ctrl)
  */
 void pppVtMime(_pppPObject* object, void* step, _pppCtrlTable* ctrl)
 {
-    VtMimeState* state = (VtMimeState*)((char*)object + *ctrl->m_serializedDataOffsets + 0x80);
+    VtMimeState* state = (VtMimeState*)(object->m_workArea + *ctrl->m_serializedDataOffsets);
     VtMimeData* data = (VtMimeData*)step;
 
     if (gPppCalcDisabled != 0) {


### PR DESCRIPTION
The recurring expression `(u8*)pObject + 0x80 + ctrl->m_serializedDataOffsets[N]` in operation/render/construct callbacks is really just indexing a per-instance work-area block embedded in _pppPObject at offset 0x80. Model that explicitly:

    struct _pppPObject {
        s32 m_graphId;             // 0x0
        pppFMATRIX m_localMatrix;  // 0x4
        char m_pad34[0x80 - 0x34]; // 0x34
        u8 m_workArea[1];          // 0x80
    };

so the access becomes `pObject->m_workArea + ctrl->m_serializedDataOffsets[N]`, which is what the original source almost certainly looked like.

Apply this rewrite to every ppp*.cpp call site whose first parameter was `void*` (now retyped to _pppPObject*) and whose body uses the cast-and-add idiom. Codegen is identical (constant offset folded by the compiler); two incidental fuzz improvements (pppYmDeformationShp, pppYmTracer), no regressions, 100% SDK code matched.