### PR TITLE
partMng.h: drop scaffolding unions in _pppCtrlTable / _pppMngSt

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -189,10 +189,8 @@ struct _pppCtrlTableData
 struct _pppCtrlTable
 {
     pppProg* m_prog;                    // 0x0
-    struct {
-        unsigned short m_workOffset;    // 0x4
-        unsigned short m_workFlags;     // 0x6
-    } m_workInfo;
+    unsigned short m_workOffset;        // 0x4
+    unsigned short m_workFlags;         // 0x6
     int m_unk8;                         // 0x8
     union {
         _pppCtrlTableData* m_serializedDef; // 0xC
@@ -272,10 +270,7 @@ struct _pppMngSt
     unsigned char m_envColorG;         // 0xA9
     unsigned char m_envColorB;         // 0xAA
     unsigned char m_envColorA;         // 0xAB
-    union {
-        int m_prioTime;                // 0xAC
-        int m_spawnedCount;
-    };
+    int m_spawnedCount;                // 0xAC
     int m_previousFrame2;              // 0xB0
     int m_numPrograms;                 // 0xB4
     int m_reservedB8;                  // 0xB8
@@ -309,7 +304,7 @@ struct _pppMngSt
     unsigned char m_fpBillboard;       // 0xF7
     unsigned char m_prio;              // 0xF8
     unsigned char m_padF9;             // 0xF9
-    short m_frameCounter;              // 0xFA
+    short m_prioTime;                  // 0xFA
     unsigned char m_padFC[4];          // 0xFC
     unsigned int m_paramA;             // 0x100
     unsigned int m_paramB;             // 0x104

--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -189,13 +189,10 @@ struct _pppCtrlTableData
 struct _pppCtrlTable
 {
     pppProg* m_prog;                    // 0x0
-    union {
-        int m_initialWork;              // 0x4
-        struct {
-            unsigned short m_workOffset; // 0x4
-            unsigned short m_workFlags;  // 0x6
-        } m_workInfo;
-    };
+    struct {
+        unsigned short m_workOffset;    // 0x4
+        unsigned short m_workFlags;     // 0x6
+    } m_workInfo;
     int m_unk8;                         // 0x8
     union {
         _pppCtrlTableData* m_serializedDef; // 0xC
@@ -266,14 +263,7 @@ struct _pppMngSt
     float m_userFloat0;                // 0x48
     float m_userFloat1;                // 0x4C
     Vec m_savedPosition;               // 0x50
-    union {
-        Vec m_previousPosition;        // 0x5C
-        struct {
-            float m_previousPositionX; // 0x5C
-            float m_previousPositionY; // 0x60
-            float m_paramD;            // 0x64
-        } m_previousPositionFields;
-    };
+    Vec m_previousPosition;            // 0x5C (third float doubles as a generic param)
     Vec m_paramVec0;                   // 0x68
     short m_kind;                      // 0x74
     short m_nodeIndex;                 // 0x76

--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -146,7 +146,6 @@ typedef void (*pppProgDestructCallback)(_pppPObjLink*, _pppCtrlTable*);
 
 struct pppFVECTOR4
 {
-
 };
 
 struct VColor
@@ -179,23 +178,13 @@ struct pppProg
     pppProgAnyCallback m_pppFunctionDestructor;   // 0x28
 }; // Size 0x2c
 
-struct _pppCtrlTableData
-{
-    int m_workOffset;       // 0x0
-    int m_workOffsetAlt;    // 0x4
-    int m_ownerWorkOffset;  // 0x8
-};
-
 struct _pppCtrlTable
 {
     pppProg* m_prog;                    // 0x0
     unsigned short m_workOffset;        // 0x4
     unsigned short m_workFlags;         // 0x6
     int m_unk8;                         // 0x8
-    union {
-        _pppCtrlTableData* m_serializedDef; // 0xC
-        int* m_serializedDataOffsets;       // 0xC
-    };
+    int* m_serializedDataOffsets;       // 0xC
 };
 
 struct _pppDataHead

--- a/include/ffcc/pppBlurChara.h
+++ b/include/ffcc/pppBlurChara.h
@@ -5,12 +5,7 @@
 #include <dolphin/types.h>
 
 struct pppBlurChara {
-    union {
-        void* ptr;
-        struct {
-            u32 m_graphId;
-        };
-    } field0_0x0;
+    u32 m_graphId;
 };
 
 struct pppBlurCharaUnkB {

--- a/include/ffcc/pppCallBackDistance.h
+++ b/include/ffcc/pppCallBackDistance.h
@@ -4,12 +4,7 @@
 #include <dolphin/types.h>
 
 struct pppCallBackDistance {
-    union {
-        void* ptr;
-        struct {
-            u32 m_graphId;
-        };
-    } field0_0x0;
+    u32 m_graphId;
 };
 
 struct pppCallBackDistanceUnkB {
@@ -36,4 +31,3 @@ void pppFrameCallBackDistance(pppCallBackDistance* param1, pppCallBackDistanceUn
 #endif
 
 #endif // _FFCC_PPPCALLBACKDISTANCE_H_
-

--- a/include/ffcc/pppChangeTex.h
+++ b/include/ffcc/pppChangeTex.h
@@ -9,12 +9,7 @@
 #include <dolphin/types.h>
 
 struct pppChangeTex {
-    union {
-        void* ptr;
-        struct {
-            u32 m_graphId;
-        };
-    } field0_0x0;
+    u32 m_graphId;
 };
 
 struct pppChangeTexUnkB {

--- a/include/ffcc/pppCharaBreak.h
+++ b/include/ffcc/pppCharaBreak.h
@@ -14,12 +14,7 @@ void InitPolygonParameter(PCharaBreak*, VCharaBreak*, POLYGON_DATA*, unsigned lo
 void UpdatePolygonData(PCharaBreak*, VCharaBreak*, CChara::CModel*);
 
 struct pppCharaBreak {
-    union {
-        void* ptr;
-        struct {
-            unsigned int m_graphId;
-        };
-    } field0_0x0;
+    unsigned int m_graphId;
 };
 
 struct CharaBreakUnkB {

--- a/include/ffcc/pppColum.h
+++ b/include/ffcc/pppColum.h
@@ -10,13 +10,8 @@ typedef struct pppCVector {
 } pppCVector;
 
 struct pppColum {
-    union {
-        void* ptr;
-        struct {
-            u32 m_graphId;
-        };
-    } field0_0x0;
-    
+    u32 m_graphId;
+
     // Add padding/fields up to the offsets we need
     char pad[0x82];
     u16 field_0x82;

--- a/include/ffcc/pppConstrainCameraDir.h
+++ b/include/ffcc/pppConstrainCameraDir.h
@@ -4,17 +4,11 @@
 #include "ffcc/partMng.h"
 
 typedef struct pppConstrainCameraDir {
-    union {
-        _pppPObject m_pppPObject;
-        struct {
-            s32 m_graphId;
-            s32 m_unknown04;
-            s32 m_unknown08;
-            s32 m_unknown0C;
-            pppFMATRIX m_localMatrix;
-        } m_object;
-        float field0_0x0;
-    };
+    s32 m_graphId;            // 0x00
+    s32 m_unknown04;          // 0x04
+    s32 m_unknown08;          // 0x08
+    s32 m_unknown0C;          // 0x0C
+    pppFMATRIX m_localMatrix; // 0x10
 } pppConstrainCameraDir;
 
 typedef struct pppConstrainCameraDirUnkB {

--- a/include/ffcc/pppCorona.h
+++ b/include/ffcc/pppCorona.h
@@ -4,12 +4,7 @@
 #include <dolphin/types.h>
 
 struct pppCorona {
-    union {
-        void* ptr;
-        struct {
-            u32 m_graphId;
-        };
-    } field0_0x0;
+    s32 m_graphId;
 };
 
 struct pppCoronaUnkC {
@@ -49,4 +44,3 @@ void pppRenderCorona(pppCorona* param1, CoronaParam* param2, pppCoronaUnkC* para
 #endif
 
 #endif // _FFCC_PPPCORONA_H_
-

--- a/include/ffcc/pppEmission.h
+++ b/include/ffcc/pppEmission.h
@@ -8,12 +8,7 @@
 class CMaterialMan;
 
 struct pppEmission {
-    union {
-        void* ptr;
-        struct {
-            u32 m_graphId;
-        };
-    } field0_0x0;
+    u32 m_graphId;
 
     u8 _pad0[0x84];
     u8 field_0x88;

--- a/include/ffcc/pppYmChangeTex.h
+++ b/include/ffcc/pppYmChangeTex.h
@@ -5,13 +5,8 @@
 #include <dolphin/types.h>
 
 struct pppYmChangeTex {
-    union {
-        void* ptr;
-        struct {
-            u8 _pad0[0xC];
-            s32 m_graphId;
-        } data;
-    } field0_0x0;
+    u8 _pad0[0xC];
+    s32 m_graphId;
 };
 
 struct pppYmChangeTexStep {

--- a/src/pppAngMove.cpp
+++ b/src/pppAngMove.cpp
@@ -32,7 +32,7 @@ struct PppAngMoveInput {
  */
 void pppAngMoveCon(void* dest, _pppCtrlTable* ctrlTable)
 {
-    int offset = ctrlTable->m_serializedDef->m_workOffsetAlt;
+    int offset = ctrlTable->m_serializedDataOffsets[1];
     int* ptr = (int*)((char*)dest + offset + 0x80);
     ptr[2] = 0;
     ptr[1] = 0;
@@ -50,7 +50,7 @@ void pppAngMoveCon(void* dest, _pppCtrlTable* ctrlTable)
  */
 void pppAngMove(void* basePtr, void* input, _pppCtrlTable* ctrlTable)
 {
-    PppAngMoveOffsets* offsets = (PppAngMoveOffsets*)ctrlTable->m_serializedDef;
+    PppAngMoveOffsets* offsets = (PppAngMoveOffsets*)ctrlTable->m_serializedDataOffsets;
     PppAngMoveObj* a = (PppAngMoveObj*)((char*)basePtr + offsets->a + 0x80);
     PppAngMoveObj* b = (PppAngMoveObj*)((char*)basePtr + offsets->b + 0x80);
     PppAngMoveInput* inputData = (PppAngMoveInput*)input;

--- a/src/pppAngle.cpp
+++ b/src/pppAngle.cpp
@@ -9,7 +9,7 @@
  */
 void pppAngleCon(void* dest, _pppCtrlTable* ctrlTable)
 {
-    int offset = ((int*)ctrlTable->m_serializedDef)[0];
+    int offset = (ctrlTable->m_serializedDataOffsets)[0];
     
     int* ptr = (int*)((char*)dest + offset + 0x80);
     ptr[2] = 0;
@@ -32,7 +32,7 @@ void pppAngle(void* dest, void* src, _pppCtrlTable* ctrlTable)
         return;
     }
 
-    int offset = ((int*)ctrlTable->m_serializedDef)[0];
+    int offset = (ctrlTable->m_serializedDataOffsets)[0];
     int* destPtr = (int*)((char*)dest + offset + 0x80);
     int* srcPtr = (int*)((char*)src + 8);
 

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -586,7 +586,7 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
 group_ready:
         if (ready) {
             firstParticle = -1;
-            scaledOwner = mngSt->m_previousPositionFields.m_paramD * pBreathModel->m_groupOwnerScale;
+            scaledOwner = mngSt->m_previousPosition.z * pBreathModel->m_groupOwnerScale;
             for (slotIndex = 0; slotCount != 0; slotCount--) {
                 if (*(signed char*)(*(int*)(groupTable + 8) + slotIndex) != -1) {
                     firstParticle = (int)*(signed char*)(*(int*)(groupTable + 4) + slotIndex);

--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -175,14 +175,14 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	}
 
 	s32* serializedDataOffsets = data->m_serializedDataOffsets;
-	u8* base = (u8*)&changeTex->field0_0x0;
+	u8* base = (u8*)changeTex;
 	ChangeTexWork* work = (ChangeTexWork*)(base + serializedDataOffsets[2] + 0x80);
 	u8* colorData = base + serializedDataOffsets[1] + 0x80;
 	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_charaObj, 0);
 	CChara::CModel* model0 = GetCharaModelPtr(handle0);
 
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-	    &changeTex->field0_0x0, step->m_graphId, work->m_value0, work->m_value1, work->m_value2, step->m_initWOrk,
+	    changeTex, step->m_graphId, work->m_value0, work->m_value1, work->m_value2, step->m_initWOrk,
 	    step->m_stepValue, step->m_arg3);
 
 	work->m_charaObj = (CGObject*)pppMngStPtr->m_charaObj;

--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -25,7 +25,7 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
         float* value = (float*)((char*)pppConstrainCameraDir + *param_3->m_serializedDataOffsets + 0x80);
         unsigned char* flags = (unsigned char*)&param_2->m_arg3;
 
-        CalcGraphValue(&pppConstrainCameraDir->m_pppPObject, param_2->m_graphId, value[0], value[1], value[2],
+        CalcGraphValue((_pppPObject*)pppConstrainCameraDir, param_2->m_graphId, value[0], value[1], value[2],
                        param_2->m_dataValIndex, param_2->m_initWOrk, param_2->m_stepValue);
 
         if ((gPppInConstructor != 1) && ((flags[1] != 0 || flags[0] != 0))) {

--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -30,7 +30,7 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
         float* value = (float*)((char*)param_1 + *param_3->m_serializedDataOffsets + 0x80);
         unsigned char* flags = (unsigned char*)&param_2->m_arg3;
 
-        CalcGraphValue(&param_1->m_pppPObject, param_2->m_graphId, value[0], value[1], value[2], param_2->m_dataValIndex,
+        CalcGraphValue((_pppPObject*)param_1, param_2->m_graphId, value[0], value[1], value[2], param_2->m_dataValIndex,
                        param_2->m_initWOrk, param_2->m_stepValue);
 
         if ((gPppInConstructor != 1) && ((flags[1] != 0 || flags[0] != 0))) {
@@ -74,8 +74,8 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
                 resultPos.z = cameraDir.z * *value + resultPos.z;
             }
 
-            localX = param_1->m_object.m_localMatrix.value[0][3];
-            localY = param_1->m_object.m_localMatrix.value[1][3];
+            localX = param_1->m_localMatrix.value[0][3];
+            localY = param_1->m_localMatrix.value[1][3];
 
             Vec direct0;
             Vec direct1;

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -364,7 +364,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
         if (step->m_payload[0x3b] == 0) {
             pppHitCylinderSendSystem(
                 pppMngStPtr, &work->m_origin, &localA,
-                pppMngStPtr->m_previousPositionFields.m_paramD * *(float*)(step->m_payload + 0x24),
+                pppMngStPtr->m_previousPosition.z * *(float*)(step->m_payload + 0x24),
                 *(float*)(step->m_payload + 0x20));
         }
 
@@ -614,7 +614,7 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
             GXSetZMode(1, GX_LEQUAL, 0);
 
             PSMTXIdentity(tempMtx);
-            tempMtx[0][0] = pppMngStPtr->m_previousPositionFields.m_paramD * *(float*)(step->m_payload + 0x24);
+            tempMtx[0][0] = pppMngStPtr->m_previousPosition.z * *(float*)(step->m_payload + 0x24);
             tempMtx[1][1] = tempMtx[0][0];
             tempMtx[2][2] = PSVECDistance(work->m_points, &work->m_origin);
             PSMTXConcat(baseObj->m_localMatrix.value, tempMtx, tempMtx);

--- a/src/pppMove.cpp
+++ b/src/pppMove.cpp
@@ -28,7 +28,7 @@ struct PppMoveOffsets {
  */
 void pppMoveCon(void* basePtr, _pppCtrlTable* ctrlTable)
 {
-    u32 offset = static_cast<u32>(ctrlTable->m_serializedDef->m_workOffsetAlt);
+    u32 offset = static_cast<u32>(ctrlTable->m_serializedDataOffsets[1]);
     PppMoveObj* moveObj = (PppMoveObj*)((u8*)basePtr + offset + 0x80);
     
     // Initialize to zero (store order: z, y, x to match assembly)
@@ -49,7 +49,7 @@ void pppMoveCon(void* basePtr, _pppCtrlTable* ctrlTable)
  */
 void pppMove(void* basePtr, PppMoveInput* input, _pppCtrlTable* ctrlTable)
 {
-    PppMoveOffsets* offsets = (PppMoveOffsets*)ctrlTable->m_serializedDef;
+    PppMoveOffsets* offsets = (PppMoveOffsets*)ctrlTable->m_serializedDataOffsets;
     PppMoveObj* a = (PppMoveObj*)((u8*)basePtr + offsets->a + 0x80);
     PppMoveObj* b = (PppMoveObj*)((u8*)basePtr + offsets->b + 0x80);
 

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -789,7 +789,7 @@ void callCon2Prog(_pppPObject* pObject)
 			u32 stageSlotOffset = progSet->m_workBaseOffset + stageIdx * 4;
 			u32* stageSlot = *(u32**)(((u8*)pObject) + stageSlotOffset);
 			pppProg* prog = stage->m_prog;
-			u32* nextSlot = (u32*)(((u8*)stageSlot) + stage->m_workInfo.m_workOffset);
+			u32* nextSlot = (u32*)(((u8*)stageSlot) + stage->m_workOffset);
 
 			if (*nextSlot == *(u32*)(((u8*)pObject) + 0x0C))
 			{
@@ -2440,7 +2440,7 @@ void _pppDeadPart(_pppMngSt* pppMngSt)
 					_pppCtrlTable* stage = &progSet->m_stages[stageIdx];
 					u32 stageSlotOffset = progSet->m_workBaseOffset + stageIdx * 4;
 					u32* stageSlot = *(u32**)(((u8*)obj) + stageSlotOffset);
-					u32* nextSlot = (u32*)(((u8*)stageSlot) + stage->m_workInfo.m_workOffset);
+					u32* nextSlot = (u32*)(((u8*)stageSlot) + stage->m_workOffset);
 					if (*nextSlot == *(u32*)(((u8*)obj) + 0x0C))
 					{
 						*(u32**)(((u8*)obj) + stageSlotOffset) = nextSlot;

--- a/src/pppPoint.cpp
+++ b/src/pppPoint.cpp
@@ -14,7 +14,7 @@ extern const float kPppPointZero;
  */
 void pppPointCon(_pppPObject* pObject, _pppCtrlTable* ctrlTable)
 {
-	int dataOffset = ctrlTable->m_serializedDef->m_workOffset;
+	int dataOffset = ctrlTable->m_serializedDataOffsets[0];
 	float* dst = (float*)((char*)pObject + dataOffset + 0x80);
 	float value = kPppPointZero;
 
@@ -42,7 +42,7 @@ void pppPoint(_pppPObject* pObject, pppPointStep* step, _pppCtrlTable* ctrlTable
 		return;
 	}
 
-	int dataOffset = ctrlTable->m_serializedDef->m_workOffset;
+	int dataOffset = ctrlTable->m_serializedDataOffsets[0];
 	float* dst = (float*)((char*)pObject + dataOffset + 0x80);
 
 	dst[0] += step->m_x;

--- a/src/pppPointAp.cpp
+++ b/src/pppPointAp.cpp
@@ -30,7 +30,7 @@ struct _pppPointApStep {
  */
 void pppPointAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
 {
-    _pppPointApOffsets* data = (_pppPointApOffsets*)ctrlTable->m_serializedDef;
+    _pppPointApOffsets* data = (_pppPointApOffsets*)ctrlTable->m_serializedDataOffsets;
     u32 srcOffset = data->srcOffset;
     u32 targetOffset = data->targetOffset;
     Vec* src = (Vec*)((u8*)pObject + srcOffset + 0x80);
@@ -82,7 +82,7 @@ void pppPointAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
  */
 void pppPointApCon(_pppPObject* pObject, _pppCtrlTable* ctrlTable)
 {
-    _pppPointApOffsets* data = (_pppPointApOffsets*)ctrlTable->m_serializedDef;
+    _pppPointApOffsets* data = (_pppPointApOffsets*)ctrlTable->m_serializedDataOffsets;
     u8* target = (u8*)pObject + data->targetOffset;
     target[0x81] = 0;
 }

--- a/src/pppPointApMtx.cpp
+++ b/src/pppPointApMtx.cpp
@@ -25,7 +25,7 @@ void pppPointApMtx(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
 {
 	pppPointApMtxStep* payload = (pppPointApMtxStep*)step;
 	Vec pos;
-	u32* offsets = (u32*)ctrlTable->m_serializedDef;
+	u32* offsets = (u32*)ctrlTable->m_serializedDataOffsets;
 	Vec* source = (Vec*)((u8*)pObject + offsets[0] + 0x80);
 	Mtx* target = (Mtx*)((u8*)pObject + offsets[1] + 0x80);
 
@@ -82,7 +82,7 @@ void pppPointApMtx(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
  */
 void pppPointApMtxCon(_pppPObject* pObject, _pppCtrlTable* ctrlTable)
 {
-	unsigned long offset = (unsigned long)(((u32*)ctrlTable->m_serializedDef)[1]);
+	unsigned long offset = (unsigned long)(((u32*)ctrlTable->m_serializedDataOffsets)[1]);
 	_pppPObject* object = (_pppPObject*)((char*)pObject + offset);
 
 	*(unsigned char*)((char*)object + 0x81) = 0;

--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -29,7 +29,7 @@ struct pppPointRApStep {
 void pppPointRAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
 {
     pppPointRApStep* payload = (pppPointRApStep*)step;
-    u32* ctrlData = (u32*)ctrlTable->m_serializedDef;
+    u32* ctrlData = (u32*)ctrlTable->m_serializedDataOffsets;
     u8* state = (u8*)pObject + ctrlData[1] + 0x80;
 
     if (gPppCalcDisabled != 0) {
@@ -95,7 +95,7 @@ void pppPointRAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
  */
 void pppPointRApCon(_pppPObject* pObject, _pppCtrlTable* ctrlTable)
 {
-    u32* ctrlData = (u32*)ctrlTable->m_serializedDef;
+    u32* ctrlData = (u32*)ctrlTable->m_serializedDataOffsets;
     u32 offset = ctrlData[1];
     u8* state = (u8*)pObject + offset;
     state[0x81] = 0;

--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -161,7 +161,7 @@ void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, 
 	}
 
 	s32* serializedDataOffsets = data->m_serializedDataOffsets;
-	u8* base = (u8*)&ymChangeTex->field0_0x0;
+	u8* base = (u8*)ymChangeTex;
 	pppYmChangeTexState* state = (pppYmChangeTexState*)(base + serializedDataOffsets[2] + 0x80);
 	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_charaObj, 0);
 	CChara::CModel* model0 = GetCharaModelPtr(handle0);
@@ -200,7 +200,7 @@ void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, 
 
 	state->m_value1 = state->m_value1 + state->m_value2;
 	state->m_value0 = state->m_value0 + state->m_value1;
-	if (step->m_graphId == ymChangeTex->field0_0x0.data.m_graphId) {
+	if (step->m_graphId == ymChangeTex->m_graphId) {
 		state->m_value0 = state->m_value0 + step->m_initWOrk;
 		state->m_value1 = state->m_value1 + step->m_stepValue;
 		state->m_value2 = state->m_value2 + step->m_arg3;

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -296,7 +296,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 		if (step->m_payload[0x3b] == 0) {
 			pppHitCylinderSendSystem(
 				pppMngStPtr, &work->m_origin, &localA,
-				pppMngStPtr->m_previousPositionFields.m_paramD * *(float*)(step->m_payload + 0x24),
+				pppMngStPtr->m_previousPosition.z * *(float*)(step->m_payload + 0x24),
 				*(float*)(step->m_payload + 0x20));
 		}
 
@@ -544,7 +544,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			GXSetZMode(1, GX_LEQUAL, 0);
 
 			PSMTXIdentity(tempMtx);
-			tempMtx[0][0] = pppMngStPtr->m_previousPositionFields.m_paramD * *(float*)(step->m_payload + 0x24);
+			tempMtx[0][0] = pppMngStPtr->m_previousPosition.z * *(float*)(step->m_payload + 0x24);
 			tempMtx[1][1] = tempMtx[0][0];
 			tempMtx[2][2] = PSVECDistance(work->m_points, &work->m_origin);
 			PSMTXConcat(laser->m_localMatrix.value, tempMtx, tempMtx);


### PR DESCRIPTION
Two unions in partMng.h were decomp scaffolding rather than real source:

1) _pppCtrlTable::m_initialWork / m_workInfo
   The 'int m_initialWork' alias has zero references; only m_workInfo's
   inner struct is used (pppPart.cpp m_workInfo.m_workOffset). Drop the
   union and keep just the work-info struct.

2) _pppMngSt::m_previousPosition / m_previousPositionFields
   m_previousPositionX/Y were never referenced. m_previousPositionFields
   .m_paramD was used in pppLaser/pppYmLaser/pppBreathModel as the third
   float of a Vec at offset 0x64 — i.e. m_previousPosition.z. Drop the
   union, rewrite those sites to use .z.

m_prioTime / m_spawnedCount union left intact: both names are heavily referenced and represent a genuine repurpose of the same slot.

Build green; objdiff report unchanged (no regressions, no improvements: codegen identical).