### PR TITLE
Improve pppRyjMegaBirth draw matching

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -582,16 +582,16 @@ void calc(
 	}
 
 	{
-		float angleWrap = FLOAT_80330458;
 		float angleMax = FLOAT_8033045c;
+		float angleWrap = FLOAT_80330458;
 		while (angleMax <= *f32_at(particlePayload, 0x28))
 		{
 			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) - angleWrap;
 		}
 	}
 	{
-		float angleWrap = FLOAT_80330458;
 		float angleMin = FLOAT_80330460;
+		float angleWrap = FLOAT_80330458;
 		while (*f32_at(particlePayload, 0x28) < angleMin)
 		{
 			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + angleWrap;

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/math.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/pppShape.h"
+#include <dolphin/gx.h>
 extern "C" {
 extern const float kPppRyjMegaBirthZero;
 extern int gPppCalcDisabled;
@@ -14,6 +15,7 @@ extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void*);
 extern float FLOAT_80330458;
 extern float FLOAT_8033045c;
 extern float FLOAT_80330460;
+extern float FLOAT_8033044C;
 extern float FLOAT_80330470;
 extern float FLOAT_80330474;
 extern float FLOAT_80330478;
@@ -94,6 +96,568 @@ static inline void apply_signed_randomization_2(u8* particle, s32 offset, u8 fla
 	} else if ((flags & 2) != 0) {
 		*f32_at(particle, offset) = *f32_at(particle, offset) * FLOAT_80330490;
 		*f32_at(particle, offset + 4) = *f32_at(particle, offset + 4) * FLOAT_80330490;
+	}
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80082278
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppRyjMegaBirthDes(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
+{
+	u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
+
+	if (*(void**)(work + 0x3C) != 0)
+	{
+		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x3C));
+		*(void**)(work + 0x3C) = 0;
+	}
+
+	if (*(void**)(work + 0x40) != 0)
+	{
+		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x40));
+		*(void**)(work + 0x40) = 0;
+	}
+
+	if (*(void**)(work + 0x44) != 0)
+	{
+		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x44));
+		*(void**)(work + 0x44) = 0;
+	}
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800822f4
+ * PAL Size: 124b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppRyjMegaBirthCon(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
+{
+	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2]);
+	float zero;
+
+	PSMTXIdentity(work->m_worldMatrix);
+	zero = kPppRyjMegaBirthZero;
+	work->m_accelerationAxis.z = kPppRyjMegaBirthZero;
+	work->m_accelerationAxis.y = zero;
+	work->m_accelerationAxis.x = zero;
+	work->m_particleBlock = 0;
+	work->m_worldMatrixBlock = 0;
+	work->m_colorBlock = 0;
+	work->m_numParticles = 0;
+	work->m_emitTimer = 0;
+	work->m_meshEmitIndex = 0;
+	work->m_emitTimer = 10000;
+
+	PSMTXIdentity(g_matUnit);
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void pppRyjDrawMegaBirth(_pppPObject* obj, void* stepData, _pppCtrlTable* ctrlTable)
+{
+	PRyjMegaBirth* params = (PRyjMegaBirth*)stepData;
+	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)obj + 0x80 + ctrlTable->m_serializedDataOffsets[2]);
+	VColor* color = (VColor*)((u8*)obj + 0x80 + ctrlTable->m_serializedDataOffsets[1]);
+	u8* payload = (u8*)params;
+	int dataValIndex = *(int*)(payload + 4);
+	_PARTICLE_DATA* particle = work->m_particleBlock;
+	_PARTICLE_WMAT* particleWorldMat = (_PARTICLE_WMAT*)work->m_worldMatrixBlock;
+	_PARTICLE_COLOR* colorData = work->m_colorBlock;
+	s32 numParticles = work->m_numParticles;
+	s8 hasRequiredMemory;
+
+	if (particle == 0) {
+		hasRequiredMemory = 0;
+	} else if (((payload[0xEC] == 1) || (payload[0xEC] == 2)) && (particleWorldMat == 0)) {
+		hasRequiredMemory = 0;
+	} else if ((payload[0xE9] != 0) && (colorData == 0)) {
+		hasRequiredMemory = 0;
+	} else {
+		hasRequiredMemory = 1;
+	}
+
+	if (!hasRequiredMemory) {
+		return;
+	}
+
+	if (dataValIndex == 0xFFFF) {
+		return;
+	}
+
+	tagOAN3_SHAPE** shapeTable = *(tagOAN3_SHAPE***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + dataValIndex * 4);
+
+	pppFMATRIX worldViewMatrix;
+	if (payload[0xEC] == 0) {
+		PSMTXConcat(work->m_worldMatrix, obj->m_localMatrix.value, worldViewMatrix.value);
+		PSMTXConcat(ppvCameraMatrix02, worldViewMatrix.value, worldViewMatrix.value);
+	}
+
+	pppSetDrawEnv(
+		0, 0, payload[0x0E] != 0 ? *f32_at(payload, 0x18) : kPppRyjMegaBirthZero, payload[0xF3], payload[0x0C],
+		payload[0xF2], 0, payload[0xED] == 0, 1, 0);
+
+	tagOAN3_SHAPE* shapeData = *shapeTable;
+	u8 baseRed = color->m_red;
+	u8 baseGreen = color->m_green;
+	u8 baseBlue = color->m_blue;
+	u8 baseAlpha = color->m_alpha;
+
+	for (int i = 0; i < numParticles; i++) {
+		if (*u16_at(particle, 0x22) == 0) {
+			goto next_particle;
+		}
+
+		pppFMATRIX drawMatrix;
+		PSMTXIdentity(drawMatrix.value);
+		drawMatrix.value[0][0] = *f32_at(particle, 0x34) * pppMngStPtr->m_scale.x;
+		drawMatrix.value[1][1] = *f32_at(particle, 0x38) * pppMngStPtr->m_scale.y;
+		drawMatrix.value[2][2] = drawMatrix.value[0][0];
+
+		if (*f32_at(particle, 0x28) != kPppRyjMegaBirthZero) {
+			Mtx rotMatrix;
+
+			PSMTXRotRad(rotMatrix, 'Z', FLOAT_8033044C * *f32_at(particle, 0x28));
+			PSMTXConcat(drawMatrix.value, rotMatrix, drawMatrix.value);
+		}
+
+		Vec position;
+		Vec particlePosition = *(Vec*)particle;
+		position.x = drawMatrix.value[0][3];
+		position.y = drawMatrix.value[1][3];
+		position.z = drawMatrix.value[2][3];
+		PSVECAdd(&position, &particlePosition, &position);
+		drawMatrix.value[0][3] = position.x;
+		drawMatrix.value[1][3] = position.y;
+		drawMatrix.value[2][3] = position.z;
+
+		switch (payload[0xEC]) {
+		case 0:
+			PSMTXMultVec(worldViewMatrix.value, &position, &position);
+			drawMatrix.value[0][3] = position.x;
+			drawMatrix.value[1][3] = position.y;
+			drawMatrix.value[2][3] = position.z;
+			break;
+		case 1: {
+			pppFMATRIX particleViewMatrix;
+			PSMTXConcat(*(Mtx*)particleWorldMat, obj->m_localMatrix.value, particleViewMatrix.value);
+			PSMTXConcat(ppvCameraMatrix02, particleViewMatrix.value, particleViewMatrix.value);
+			PSMTXMultVec(particleViewMatrix.value, &position, &position);
+			drawMatrix.value[0][3] = position.x;
+			drawMatrix.value[1][3] = position.y;
+			drawMatrix.value[2][3] = position.z;
+			break;
+		}
+		case 2: {
+			pppFMATRIX particleViewMatrix;
+			PSMTXConcat(work->m_worldMatrix, *(Mtx*)particleWorldMat, particleViewMatrix.value);
+			PSMTXConcat(ppvCameraMatrix02, particleViewMatrix.value, particleViewMatrix.value);
+			PSMTXMultVec(particleViewMatrix.value, &position, &position);
+			drawMatrix.value[0][3] = position.x;
+			drawMatrix.value[1][3] = position.y;
+			drawMatrix.value[2][3] = position.z;
+			break;
+		}
+		default:
+			break;
+		}
+
+		GXLoadPosMtxImm(drawMatrix.value, GX_PNMTX0);
+
+		int red = baseRed + (s8)*u8_at(particle, 0x24);
+		int green = baseGreen + (s8)*u8_at(particle, 0x25);
+		int blue = baseBlue + (s8)*u8_at(particle, 0x26);
+		int alpha = (int)((float)baseAlpha + (float)(s8)*u8_at(particle, 0x27) - *f32_at(particle, 0x54));
+
+		if (colorData != 0) {
+			red += (int)colorData->m_color[0];
+			green += (int)colorData->m_color[1];
+			blue += (int)colorData->m_color[2];
+			alpha += (int)colorData->m_color[3];
+		}
+
+		if (red < 0) {
+			red = 0;
+		} else if (red > 0xFF) {
+			red = 0xFF;
+		}
+		if (green < 0) {
+			green = 0;
+		} else if (green > 0xFF) {
+			green = 0xFF;
+		}
+		if (blue < 0) {
+			blue = 0;
+		} else if (blue > 0xFF) {
+			blue = 0xFF;
+		}
+		if (alpha < 0) {
+			alpha = 0;
+		} else if (alpha > 0x7F) {
+			alpha = 0x7F;
+		}
+
+		pppCVECTOR drawColor = {{(u8)red, (u8)green, (u8)blue, (u8)alpha}};
+		GXSetChanAmbColor(GX_COLOR0A0, *(GXColor*)drawColor.rgba);
+		pppSetBlendMode(payload[0xF2]);
+
+		u8* shape = (u8*)shapeData;
+		s16 shapeOffset = *(s16*)(shape + (u32)*u16_at(particle, 0x20) * 8 + 0x10);
+		pppDrawShp((tagOAN3_SHAPE*)(shape + shapeOffset), pppEnvStPtr->m_materialSetPtr, payload[0xF2]);
+
+	next_particle:
+		if (particleWorldMat != 0) {
+			particleWorldMat = (_PARTICLE_WMAT*)((u8*)particleWorldMat + 0x30);
+		}
+		if (colorData != 0) {
+			colorData = colorData + 1;
+		}
+		particle = (_PARTICLE_DATA*)((u8*)particle + 0x60);
+	}
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80082894
+ * PAL Size: 636b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMegaBirthOffsets* offsets)
+{
+	s8 hasRequiredMemory;
+	u8* particleDataBytes;
+	s32* serializedDataOffsets;
+	s32 workOffset;
+	s32 colorOffset;
+	VRyjMegaBirth* work;
+	VColor* color;
+
+	particleDataBytes = (u8*)particleData;
+	serializedDataOffsets = offsets->m_serializedDataOffsets;
+	workOffset = serializedDataOffsets[2];
+	colorOffset = serializedDataOffsets[1];
+	work = (VRyjMegaBirth*)((u8*)pObject + 0x80 + workOffset);
+	color = (VColor*)((u8*)pObject + 0x80 + colorOffset);
+
+	if (work->m_particleBlock == NULL)
+	{
+		work->m_numParticles = *(u16*)(particleDataBytes + 0x20);
+		work->m_particleBlock = (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+			work->m_numParticles * 0x60, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x262);
+		if (work->m_particleBlock != NULL)
+		{
+			memset(work->m_particleBlock, 0, work->m_numParticles * 0x60);
+		}
+
+		if ((particleDataBytes[0xEC] == 1) || (particleDataBytes[0xEC] == 2))
+		{
+			work->m_worldMatrixBlock = (PARTICLE_WMAT*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+				work->m_numParticles * 0x30, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x269);
+			if (work->m_worldMatrixBlock != NULL)
+			{
+				memset(work->m_worldMatrixBlock, 0, work->m_numParticles * 0x30);
+			}
+		}
+
+		if (particleDataBytes[0xE9] != 0)
+		{
+			work->m_colorBlock = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+				work->m_numParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x271);
+			if (work->m_colorBlock != NULL)
+			{
+				memset(work->m_colorBlock, 0, work->m_numParticles << 5);
+			}
+		}
+
+		work->m_accelerationAxis.x = *(float*)(particleDataBytes + 0xB0);
+		work->m_accelerationAxis.y = *(float*)(particleDataBytes + 0xB4);
+		work->m_accelerationAxis.z = *(float*)(particleDataBytes + 0xB8);
+		PSVECNormalize(&work->m_accelerationAxis, &work->m_accelerationAxis);
+	}
+
+	if (work->m_particleBlock == NULL)
+	{
+		hasRequiredMemory = 0;
+	}
+	else if (((particleDataBytes[0xEC] == 1) || (particleDataBytes[0xEC] == 2)) &&
+	         (work->m_worldMatrixBlock == NULL))
+	{
+		hasRequiredMemory = 0;
+	}
+	else if ((particleDataBytes[0xE9] != 0) && (work->m_colorBlock == NULL))
+	{
+		hasRequiredMemory = 0;
+	}
+	else
+	{
+		hasRequiredMemory = 1;
+	}
+
+	if (hasRequiredMemory)
+	{
+		switch (particleDataBytes[0x2A])
+		{
+		case 1:
+		case 3:
+		case 5:
+		case 7:
+		case 9:
+			PSMTXIdentity(work->m_worldMatrix);
+			work->m_worldMatrix[0][0] = pppMngStPtr->m_scale.x;
+			work->m_worldMatrix[1][1] = pppMngStPtr->m_scale.y;
+			work->m_worldMatrix[2][2] = pppMngStPtr->m_scale.z;
+			work->m_worldMatrix[0][3] = pppMngStPtr->m_position.x;
+			work->m_worldMatrix[1][3] = pppMngStPtr->m_position.y;
+			work->m_worldMatrix[2][3] = pppMngStPtr->m_position.z;
+			break;
+		default:
+			PSMTXCopy(pppMngStPtr->m_matrix.value, work->m_worldMatrix);
+			break;
+		}
+
+		calc_particle(pObject, work, particleData, color);
+	}
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80082b10
+ * PAL Size: 440b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void calc_particle(_pppPObject* pObject, VRyjMegaBirth* work, PRyjMegaBirth* param, VColor* color)
+{
+	s16 duration;
+	u16 frame;
+	s32 colorSet;
+	s32 frameData;
+	_PARTICLE_DATA* particle;
+	PARTICLE_WMAT* worldMats;
+	_PARTICLE_COLOR* colorData;
+	s32 maxParticles;
+	s32 emitCount;
+	s32 i;
+	u8* paramPayload;
+
+	emitCount = 0;
+	particle = (_PARTICLE_DATA*)work->m_particleBlock;
+	worldMats = work->m_worldMatrixBlock;
+	colorData = work->m_colorBlock;
+	maxParticles = work->m_numParticles;
+	paramPayload = (u8*)param;
+
+	if ((gPppCalcDisabled == 0) && (*(s32*)(paramPayload + 4) != 0xFFFF))
+	{
+		work->m_emitTimer = work->m_emitTimer + 1;
+
+		for (i = 0; i < maxParticles; i = i + 1)
+		{
+			if (*(u16*)((u8*)particle + 0x22) != 0)
+			{
+				calc(work, param, particle, color, colorData);
+
+				frame = *(u16*)((u8*)particle + 0x1E);
+				colorSet = (s32)**(s32***)(*(s32*)&pppEnvStPtr->m_particleColors[0] + *(s32*)(paramPayload + 4) * 4);
+				*(u16*)((u8*)particle + 0x20) = frame;
+				frameData = colorSet + (u32)frame * 8 + 0x10;
+
+				*(u16*)((u8*)particle + 0x1C) = *(u16*)((u8*)particle + 0x1C) + *(u32*)(paramPayload + 0x08);
+				frame = *(u16*)((u8*)particle + 0x1C);
+				duration = *(s16*)(frameData + 2);
+
+				if ((s32)frame >= (s32)duration)
+				{
+					*(u16*)((u8*)particle + 0x1C) = frame - duration;
+					*(u16*)((u8*)particle + 0x1E) = *(u16*)((u8*)particle + 0x1E) + 1;
+
+					if ((s32)*(u16*)((u8*)particle + 0x1E) >= (s32)*(s16*)(colorSet + 6))
+					{
+						if ((*(u8*)(frameData + 4) & 0x80) != 0)
+						{
+							*(u16*)((u8*)particle + 0x1E) = 0;
+							*(u16*)((u8*)particle + 0x1C) = 0;
+						}
+						else
+						{
+							*(u16*)((u8*)particle + 0x1C) = 0;
+							*(u16*)((u8*)particle + 0x1E) = *(u16*)((u8*)particle + 0x1E) - 1;
+						}
+					}
+				}
+			}
+			else if ((*(u16*)(paramPayload + 0x24) <= work->m_emitTimer) &&
+			         (emitCount < (s32)*(u16*)(paramPayload + 0x22)))
+			{
+				birth(pObject, work, param, color, particle, (_PARTICLE_WMAT*)worldMats, colorData);
+				emitCount = emitCount + 1;
+			}
+
+			if (worldMats != 0)
+			{
+				worldMats = worldMats + 1;
+			}
+
+			if (colorData != 0)
+			{
+				colorData = colorData + 1;
+			}
+
+			particle = (_PARTICLE_DATA*)((u8*)particle + 0x60);
+		}
+
+		if (emitCount > 0)
+		{
+			work->m_emitTimer = 0;
+		}
+	}
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x80082cc8
+ * PAL Size: 936b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void calc(
+	VRyjMegaBirth* work, PRyjMegaBirth* param, _PARTICLE_DATA* particle, VColor* vColor,
+	_PARTICLE_COLOR* colorData)
+{
+	int alpha;
+	u8* paramPayload;
+	u8* particlePayload;
+	u32 frameCount;
+	Vec step;
+
+	alpha = vColor->m_alpha;
+	paramPayload = (u8*)param;
+	particlePayload = (u8*)particle;
+
+	if (colorData != NULL)
+	{
+		colorData->m_color[0] = colorData->m_color[0] + colorData->m_colorFrameDeltas[0];
+		colorData->m_color[1] = colorData->m_color[1] + colorData->m_colorFrameDeltas[1];
+		colorData->m_color[2] = colorData->m_color[2] + colorData->m_colorFrameDeltas[2];
+		colorData->m_color[3] = colorData->m_color[3] + colorData->m_colorFrameDeltas[3];
+		colorData->m_colorFrameDeltas[0] = colorData->m_colorFrameDeltas[0] + *f32_at(paramPayload, 0x3C);
+		colorData->m_colorFrameDeltas[1] = colorData->m_colorFrameDeltas[1] + *f32_at(paramPayload, 0x40);
+		colorData->m_colorFrameDeltas[2] = colorData->m_colorFrameDeltas[2] + *f32_at(paramPayload, 0x44);
+		colorData->m_colorFrameDeltas[3] = colorData->m_colorFrameDeltas[3] + *f32_at(paramPayload, 0x48);
+		alpha = (int)vColor->m_alpha + (int)colorData->m_color[3];
+		if (alpha > 0xFF)
+		{
+			alpha = 0xFF;
+		}
+	}
+
+	*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + *f32_at(particlePayload, 0x2C);
+	if ((paramPayload[0xEB] & 0x10) != 0)
+	{
+		*f32_at(particlePayload, 0x2C) =
+			*f32_at(particlePayload, 0x2C) + (*f32_at(paramPayload, 0x98) + *f32_at(particlePayload, 0x30));
+	}
+	else
+	{
+		*f32_at(particlePayload, 0x2C) = *f32_at(particlePayload, 0x2C) + *f32_at(paramPayload, 0x98);
+	}
+
+	{
+		float angleWrap = FLOAT_80330458;
+		float angleMax = FLOAT_8033045c;
+		while (angleMax <= *f32_at(particlePayload, 0x28))
+		{
+			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) - angleWrap;
+		}
+	}
+	{
+		float angleWrap = FLOAT_80330458;
+		float angleMin = FLOAT_80330460;
+		while (*f32_at(particlePayload, 0x28) < angleMin)
+		{
+			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + angleWrap;
+		}
+	}
+
+	*f32_at(particlePayload, 0x34) = *f32_at(particlePayload, 0x34) + *f32_at(particlePayload, 0x3C);
+	*f32_at(particlePayload, 0x38) = *f32_at(particlePayload, 0x38) + *f32_at(particlePayload, 0x40);
+	if ((paramPayload[0xEA] & 0x10) != 0)
+	{
+		*f32_at(particlePayload, 0x3C) =
+			*f32_at(particlePayload, 0x3C) + (*f32_at(paramPayload, 0x70) + *f32_at(particlePayload, 0x44));
+		*f32_at(particlePayload, 0x40) =
+			*f32_at(particlePayload, 0x40) + (*f32_at(paramPayload, 0x74) + *f32_at(particlePayload, 0x48));
+	}
+	else
+	{
+		*f32_at(particlePayload, 0x3C) = *f32_at(particlePayload, 0x3C) + *f32_at(paramPayload, 0x70);
+		*f32_at(particlePayload, 0x40) = *f32_at(particlePayload, 0x40) + *f32_at(paramPayload, 0x74);
+	}
+
+	*f32_at(particlePayload, 0x4C) = *f32_at(particlePayload, 0x4C) + *f32_at(paramPayload, 0xC4);
+	if (paramPayload[0xEE] == 0)
+	{
+		if ((kPppRyjMegaBirthZero < *f32_at(paramPayload, 0xC0)) &&
+		    (*f32_at(paramPayload, 0xC4) < kPppRyjMegaBirthZero))
+		{
+			if (*f32_at(particlePayload, 0x4C) < kPppRyjMegaBirthZero)
+			{
+				*f32_at(particlePayload, 0x4C) = kPppRyjMegaBirthZero;
+			}
+		}
+		else
+		{
+			float zero = kPppRyjMegaBirthZero;
+			if ((*f32_at(paramPayload, 0xC0) < zero) && (zero < *f32_at(paramPayload, 0xC4)) &&
+			    (zero < *f32_at(particlePayload, 0x4C)))
+			{
+				*f32_at(particlePayload, 0x4C) = zero;
+			}
+		}
+	}
+
+	*f32_at(particlePayload, 0x50) = *f32_at(particlePayload, 0x50) + *f32_at(paramPayload, 0xD0);
+	PSVECScale((Vec*)(particlePayload + 0x10), &step, *f32_at(particlePayload, 0x4C));
+	PSVECAdd(&step, (Vec*)particlePayload, (Vec*)particlePayload);
+	PSVECScale(&work->m_accelerationAxis, &step, *f32_at(particlePayload, 0x50));
+	PSVECAdd((Vec*)particlePayload, &step, (Vec*)particlePayload);
+
+	if (*u16_at(paramPayload, 0x26) != 0)
+	{
+		*u16_at(particlePayload, 0x22) = *u16_at(particlePayload, 0x22) - 1;
+	}
+
+	*u8_at(particlePayload, 0x58) = *u8_at(particlePayload, 0x58) + 1;
+	frameCount = *u8_at(particlePayload, 0x59);
+	if ((frameCount != 0) && ((u32)*u8_at(particlePayload, 0x58) <= frameCount))
+	{
+		*f32_at(particlePayload, 0x54) = *f32_at(particlePayload, 0x54) - (float)alpha / (float)frameCount;
+	}
+
+	frameCount = *u8_at(particlePayload, 0x5A);
+	if ((frameCount != 0) && ((int)*u16_at(particlePayload, 0x22) <= (int)frameCount))
+	{
+		*f32_at(particlePayload, 0x54) =
+			*f32_at(particlePayload, 0x54) + (float)alpha / (float)(unsigned int)paramPayload[0x29];
 	}
 }
 
@@ -287,521 +851,5 @@ void birth(
 		colorData->m_colorFrameDeltas[1] = *(float*)(payload + 0x30);
 		colorData->m_colorFrameDeltas[2] = *(float*)(payload + 0x34);
 		colorData->m_colorFrameDeltas[3] = *(float*)(payload + 0x38);
-	}
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80082cc8
- * PAL Size: 936b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void calc(
-	VRyjMegaBirth* work, PRyjMegaBirth* param, _PARTICLE_DATA* particle, VColor* vColor,
-	_PARTICLE_COLOR* colorData)
-{
-	int alpha;
-	u8* paramPayload;
-	u8* particlePayload;
-	u32 frameCount;
-	Vec step;
-
-	alpha = vColor->m_alpha;
-	paramPayload = (u8*)param;
-	particlePayload = (u8*)particle;
-
-	if (colorData != NULL)
-	{
-		colorData->m_color[0] = colorData->m_color[0] + colorData->m_colorFrameDeltas[0];
-		colorData->m_color[1] = colorData->m_color[1] + colorData->m_colorFrameDeltas[1];
-		colorData->m_color[2] = colorData->m_color[2] + colorData->m_colorFrameDeltas[2];
-		colorData->m_color[3] = colorData->m_color[3] + colorData->m_colorFrameDeltas[3];
-		colorData->m_colorFrameDeltas[0] = colorData->m_colorFrameDeltas[0] + *f32_at(paramPayload, 0x3C);
-		colorData->m_colorFrameDeltas[1] = colorData->m_colorFrameDeltas[1] + *f32_at(paramPayload, 0x40);
-		colorData->m_colorFrameDeltas[2] = colorData->m_colorFrameDeltas[2] + *f32_at(paramPayload, 0x44);
-		colorData->m_colorFrameDeltas[3] = colorData->m_colorFrameDeltas[3] + *f32_at(paramPayload, 0x48);
-		alpha = (int)vColor->m_alpha + (int)colorData->m_color[3];
-		if (alpha > 0xFF)
-		{
-			alpha = 0xFF;
-		}
-	}
-
-	*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + *f32_at(particlePayload, 0x2C);
-	if ((paramPayload[0xEB] & 0x10) != 0)
-	{
-		*f32_at(particlePayload, 0x2C) =
-			*f32_at(particlePayload, 0x2C) + (*f32_at(paramPayload, 0x98) + *f32_at(particlePayload, 0x30));
-	}
-	else
-	{
-		*f32_at(particlePayload, 0x2C) = *f32_at(particlePayload, 0x2C) + *f32_at(paramPayload, 0x98);
-	}
-
-	{
-		float angleWrap = FLOAT_80330458;
-		float angleMax = FLOAT_8033045c;
-		while (angleMax <= *f32_at(particlePayload, 0x28))
-		{
-			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) - angleWrap;
-		}
-	}
-	{
-		float angleWrap = FLOAT_80330458;
-		float angleMin = FLOAT_80330460;
-		while (*f32_at(particlePayload, 0x28) < angleMin)
-		{
-			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + angleWrap;
-		}
-	}
-
-	*f32_at(particlePayload, 0x34) = *f32_at(particlePayload, 0x34) + *f32_at(particlePayload, 0x3C);
-	*f32_at(particlePayload, 0x38) = *f32_at(particlePayload, 0x38) + *f32_at(particlePayload, 0x40);
-	if ((paramPayload[0xEA] & 0x10) != 0)
-	{
-		*f32_at(particlePayload, 0x3C) =
-			*f32_at(particlePayload, 0x3C) + (*f32_at(paramPayload, 0x70) + *f32_at(particlePayload, 0x44));
-		*f32_at(particlePayload, 0x40) =
-			*f32_at(particlePayload, 0x40) + (*f32_at(paramPayload, 0x74) + *f32_at(particlePayload, 0x48));
-	}
-	else
-	{
-		*f32_at(particlePayload, 0x3C) = *f32_at(particlePayload, 0x3C) + *f32_at(paramPayload, 0x70);
-		*f32_at(particlePayload, 0x40) = *f32_at(particlePayload, 0x40) + *f32_at(paramPayload, 0x74);
-	}
-
-	*f32_at(particlePayload, 0x4C) = *f32_at(particlePayload, 0x4C) + *f32_at(paramPayload, 0xC4);
-	if (paramPayload[0xEE] == 0)
-	{
-		if ((kPppRyjMegaBirthZero < *f32_at(paramPayload, 0xC0)) &&
-		    (*f32_at(paramPayload, 0xC4) < kPppRyjMegaBirthZero))
-		{
-			if (*f32_at(particlePayload, 0x4C) < kPppRyjMegaBirthZero)
-			{
-				*f32_at(particlePayload, 0x4C) = kPppRyjMegaBirthZero;
-			}
-		}
-		else
-		{
-			float zero = kPppRyjMegaBirthZero;
-			if ((*f32_at(paramPayload, 0xC0) < zero) && (zero < *f32_at(paramPayload, 0xC4)) &&
-			    (zero < *f32_at(particlePayload, 0x4C)))
-			{
-				*f32_at(particlePayload, 0x4C) = zero;
-			}
-		}
-	}
-
-	*f32_at(particlePayload, 0x50) = *f32_at(particlePayload, 0x50) + *f32_at(paramPayload, 0xD0);
-	PSVECScale((Vec*)(particlePayload + 0x10), &step, *f32_at(particlePayload, 0x4C));
-	PSVECAdd(&step, (Vec*)particlePayload, (Vec*)particlePayload);
-	PSVECScale(&work->m_accelerationAxis, &step, *f32_at(particlePayload, 0x50));
-	PSVECAdd((Vec*)particlePayload, &step, (Vec*)particlePayload);
-
-	if (*u16_at(paramPayload, 0x26) != 0)
-	{
-		*u16_at(particlePayload, 0x22) = *u16_at(particlePayload, 0x22) - 1;
-	}
-
-	*u8_at(particlePayload, 0x58) = *u8_at(particlePayload, 0x58) + 1;
-	frameCount = *u8_at(particlePayload, 0x59);
-	if ((frameCount != 0) && ((u32)*u8_at(particlePayload, 0x58) <= frameCount))
-	{
-		*f32_at(particlePayload, 0x54) = *f32_at(particlePayload, 0x54) - (float)alpha / (float)frameCount;
-	}
-
-	frameCount = *u8_at(particlePayload, 0x5A);
-	if ((frameCount != 0) && ((int)*u16_at(particlePayload, 0x22) <= (int)frameCount))
-	{
-		*f32_at(particlePayload, 0x54) =
-			*f32_at(particlePayload, 0x54) + (float)alpha / (float)(unsigned int)paramPayload[0x29];
-	}
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80082b10
- * PAL Size: 440b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void calc_particle(_pppPObject* pObject, VRyjMegaBirth* work, PRyjMegaBirth* param, VColor* color)
-{
-	s16 duration;
-	u16 frame;
-	s32 colorSet;
-	s32 frameData;
-	_PARTICLE_DATA* particle;
-	PARTICLE_WMAT* worldMats;
-	_PARTICLE_COLOR* colorData;
-	s32 maxParticles;
-	s32 emitCount;
-	s32 i;
-	u8* paramPayload;
-
-	emitCount = 0;
-	particle = (_PARTICLE_DATA*)work->m_particleBlock;
-	worldMats = work->m_worldMatrixBlock;
-	colorData = work->m_colorBlock;
-	maxParticles = work->m_numParticles;
-	paramPayload = (u8*)param;
-
-	if ((gPppCalcDisabled == 0) && (*(s32*)(paramPayload + 4) != 0xFFFF))
-	{
-		work->m_emitTimer = work->m_emitTimer + 1;
-
-		for (i = 0; i < maxParticles; i = i + 1)
-		{
-			if (*(u16*)((u8*)particle + 0x22) != 0)
-			{
-				calc(work, param, particle, color, colorData);
-
-				frame = *(u16*)((u8*)particle + 0x1E);
-				colorSet = (s32)**(s32***)(*(s32*)&pppEnvStPtr->m_particleColors[0] + *(s32*)(paramPayload + 4) * 4);
-				*(u16*)((u8*)particle + 0x20) = frame;
-				frameData = colorSet + (u32)frame * 8 + 0x10;
-
-				*(u16*)((u8*)particle + 0x1C) = *(u16*)((u8*)particle + 0x1C) + *(u32*)(paramPayload + 0x08);
-				frame = *(u16*)((u8*)particle + 0x1C);
-				duration = *(s16*)(frameData + 2);
-
-				if ((s32)frame >= (s32)duration)
-				{
-					*(u16*)((u8*)particle + 0x1C) = frame - duration;
-					*(u16*)((u8*)particle + 0x1E) = *(u16*)((u8*)particle + 0x1E) + 1;
-
-					if ((s32)*(u16*)((u8*)particle + 0x1E) >= (s32)*(s16*)(colorSet + 6))
-					{
-						if ((*(u8*)(frameData + 4) & 0x80) != 0)
-						{
-							*(u16*)((u8*)particle + 0x1E) = 0;
-							*(u16*)((u8*)particle + 0x1C) = 0;
-						}
-						else
-						{
-							*(u16*)((u8*)particle + 0x1C) = 0;
-							*(u16*)((u8*)particle + 0x1E) = *(u16*)((u8*)particle + 0x1E) - 1;
-						}
-					}
-				}
-			}
-			else if ((*(u16*)(paramPayload + 0x24) <= work->m_emitTimer) &&
-			         (emitCount < (s32)*(u16*)(paramPayload + 0x22)))
-			{
-				birth(pObject, work, param, color, particle, (_PARTICLE_WMAT*)worldMats, colorData);
-				emitCount = emitCount + 1;
-			}
-
-			if (worldMats != 0)
-			{
-				worldMats = worldMats + 1;
-			}
-
-			if (colorData != 0)
-			{
-				colorData = colorData + 1;
-			}
-
-			particle = (_PARTICLE_DATA*)((u8*)particle + 0x60);
-		}
-
-		if (emitCount > 0)
-		{
-			work->m_emitTimer = 0;
-		}
-	}
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80082894
- * PAL Size: 636b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppRyjMegaBirth(_pppPObject* pObject, PRyjMegaBirth* particleData, PRyjMegaBirthOffsets* offsets)
-{
-	s8 hasRequiredMemory;
-	u8* particleDataBytes;
-	s32* serializedDataOffsets;
-	s32 workOffset;
-	s32 colorOffset;
-	VRyjMegaBirth* work;
-	VColor* color;
-
-	particleDataBytes = (u8*)particleData;
-	serializedDataOffsets = offsets->m_serializedDataOffsets;
-	workOffset = serializedDataOffsets[2];
-	colorOffset = serializedDataOffsets[1];
-	work = (VRyjMegaBirth*)((u8*)pObject + 0x80 + workOffset);
-	color = (VColor*)((u8*)pObject + 0x80 + colorOffset);
-
-	if (work->m_particleBlock == NULL)
-	{
-		work->m_numParticles = *(u16*)(particleDataBytes + 0x20);
-		work->m_particleBlock = (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-			work->m_numParticles * 0x60, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x262);
-		if (work->m_particleBlock != NULL)
-		{
-			memset(work->m_particleBlock, 0, work->m_numParticles * 0x60);
-		}
-
-		if ((particleDataBytes[0xEC] == 1) || (particleDataBytes[0xEC] == 2))
-		{
-			work->m_worldMatrixBlock = (PARTICLE_WMAT*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-				work->m_numParticles * 0x30, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x269);
-			if (work->m_worldMatrixBlock != NULL)
-			{
-				memset(work->m_worldMatrixBlock, 0, work->m_numParticles * 0x30);
-			}
-		}
-
-		if (particleDataBytes[0xE9] != 0)
-		{
-			work->m_colorBlock = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-				work->m_numParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppRyjMegaBirth_cpp_801D9C00), 0x271);
-			if (work->m_colorBlock != NULL)
-			{
-				memset(work->m_colorBlock, 0, work->m_numParticles << 5);
-			}
-		}
-
-		work->m_accelerationAxis.x = *(float*)(particleDataBytes + 0xB0);
-		work->m_accelerationAxis.y = *(float*)(particleDataBytes + 0xB4);
-		work->m_accelerationAxis.z = *(float*)(particleDataBytes + 0xB8);
-		PSVECNormalize(&work->m_accelerationAxis, &work->m_accelerationAxis);
-	}
-
-	if (work->m_particleBlock == NULL)
-	{
-		hasRequiredMemory = 0;
-	}
-	else if (((particleDataBytes[0xEC] == 1) || (particleDataBytes[0xEC] == 2)) &&
-	         (work->m_worldMatrixBlock == NULL))
-	{
-		hasRequiredMemory = 0;
-	}
-	else if ((particleDataBytes[0xE9] != 0) && (work->m_colorBlock == NULL))
-	{
-		hasRequiredMemory = 0;
-	}
-	else
-	{
-		hasRequiredMemory = 1;
-	}
-
-	if (hasRequiredMemory)
-	{
-		switch (particleDataBytes[0x2A])
-		{
-		case 1:
-		case 3:
-		case 5:
-		case 7:
-		case 9:
-			PSMTXIdentity(work->m_worldMatrix);
-			work->m_worldMatrix[0][0] = pppMngStPtr->m_scale.x;
-			work->m_worldMatrix[1][1] = pppMngStPtr->m_scale.y;
-			work->m_worldMatrix[2][2] = pppMngStPtr->m_scale.z;
-			work->m_worldMatrix[0][3] = pppMngStPtr->m_position.x;
-			work->m_worldMatrix[1][3] = pppMngStPtr->m_position.y;
-			work->m_worldMatrix[2][3] = pppMngStPtr->m_position.z;
-			break;
-		default:
-			PSMTXCopy(pppMngStPtr->m_matrix.value, work->m_worldMatrix);
-			break;
-		}
-
-		calc_particle(pObject, work, particleData, color);
-	}
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-static inline void init_matrix(_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirth* params, VRyjMegaBirth* work)
-{
-	u8* payload = (u8*)params;
-	u8 mode = payload[0x2A];
-
-	if ((mode == 1) || (mode == 3) || (mode == 5) || (mode == 7) || (mode == 9)) {
-		PSMTXIdentity(out.value);
-		out.value[0][0] = pppMngStPtr->m_scale.x;
-		out.value[1][1] = pppMngStPtr->m_scale.y;
-		out.value[2][2] = pppMngStPtr->m_scale.z;
-		out.value[0][3] = pppMngStPtr->m_position.x;
-		out.value[1][3] = pppMngStPtr->m_position.y;
-		out.value[2][3] = pppMngStPtr->m_position.z;
-	} else {
-		PSMTXCopy(pppMngStPtr->m_matrix.value, out.value);
-	}
-
-	if (work != NULL) {
-		PSMTXCopy(out.value, work->m_worldMatrix);
-	}
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-static inline void set_matrix(
-	_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirth* params, VRyjMegaBirth* work, _PARTICLE_DATA* particle,
-	_PARTICLE_WMAT* particleWorldMat)
-{
-	pppFMATRIX local;
-	pppFMATRIX world;
-	Mtx scale;
-
-	pppUnitMatrix(local);
-	local.value[0][3] = *f32_at(particle, 0x0);
-	local.value[1][3] = *f32_at(particle, 0x4);
-	local.value[2][3] = *f32_at(particle, 0x8);
-
-	PSMTXScale(scale, particle->m_sizeStart, particle->m_sizeEnd, particle->m_sizeVal);
-	PSMTXConcat(local.value, scale, local.value);
-
-	if (particleWorldMat != NULL) {
-		PSMTXCopy(*(Mtx*)particleWorldMat, world.value);
-	} else {
-		init_matrix(pObject, world, params, work);
-	}
-
-	PSMTXConcat(world.value, local.value, world.value);
-	PSMTXConcat(ppvCameraMatrix0, world.value, out.value);
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void pppRyjDrawMegaBirth(_pppPObject* obj, void* stepData, _pppCtrlTable* ctrlTable)
-{
-	PRyjMegaBirth* params = (PRyjMegaBirth*)stepData;
-	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)obj + 0x80 + ctrlTable->m_serializedDataOffsets[2]);
-	u8* payload = (u8*)params;
-	int dataValIndex = *(int*)(payload + 4);
-
-	if ((dataValIndex == 0xFFFF) || (work->m_particleBlock == 0)) {
-		return;
-	}
-
-	if (((payload[0xEC] == 1) || (payload[0xEC] == 2)) && (work->m_worldMatrixBlock == 0)) {
-		return;
-	}
-
-	if ((payload[0xE9] != 0) && (work->m_colorBlock == 0)) {
-		return;
-	}
-
-	long* animData = **(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + dataValIndex * 4);
-	if (animData == 0) {
-		return;
-	}
-
-	pppInitBlendMode();
-	pppSetBlendMode(0);
-
-	for (int i = 0; i < work->m_numParticles; i++) {
-		_PARTICLE_DATA* particle = (_PARTICLE_DATA*)((u8*)work->m_particleBlock + i * 0x60);
-		_PARTICLE_WMAT* particleWorldMat = 0;
-		_PARTICLE_COLOR* colorData = 0;
-
-		if (*s16_at(particle, 0x22) == 0) {
-			continue;
-		}
-
-		if (work->m_worldMatrixBlock != 0) {
-			particleWorldMat = (_PARTICLE_WMAT*)(work->m_worldMatrixBlock + i);
-		}
-		if (work->m_colorBlock != 0) {
-			colorData = work->m_colorBlock + i;
-		}
-
-		pppFMATRIX drawMatrix;
-		pppCVECTOR drawColor = {{0xFF, 0xFF, 0xFF, clamp_u8(*f32_at(particle, 0x54))}};
-
-		if (colorData != 0) {
-			drawColor.rgba[0] = clamp_u8(colorData->m_color[0]);
-			drawColor.rgba[1] = clamp_u8(colorData->m_color[1]);
-			drawColor.rgba[2] = clamp_u8(colorData->m_color[2]);
-		}
-
-		set_matrix(obj, drawMatrix, params, work, particle, particleWorldMat);
-		pppSetDrawEnv(&drawColor, &drawMatrix, 0.0f, 0, 0, 0, 0, 1, 1, 0);
-		pppDrawShp(animData, *s16_at(particle, 0x20), pppEnvStPtr->m_materialSetPtr, 0);
-	}
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800822f4
- * PAL Size: 124b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppRyjMegaBirthCon(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
-{
-	VRyjMegaBirth* work = (VRyjMegaBirth*)((u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2]);
-	float zero;
-
-	PSMTXIdentity(work->m_worldMatrix);
-	zero = kPppRyjMegaBirthZero;
-	work->m_accelerationAxis.z = kPppRyjMegaBirthZero;
-	work->m_accelerationAxis.y = zero;
-	work->m_accelerationAxis.x = zero;
-	work->m_particleBlock = 0;
-	work->m_worldMatrixBlock = 0;
-	work->m_colorBlock = 0;
-	work->m_numParticles = 0;
-	work->m_emitTimer = 0;
-	work->m_meshEmitIndex = 0;
-	work->m_emitTimer = 10000;
-
-	PSMTXIdentity(g_matUnit);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x80082278
- * PAL Size: 124b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppRyjMegaBirthDes(_pppPObject* pObject, PRyjMegaBirthOffsets* offsets)
-{
-	u8* work = (u8*)pObject + 0x80 + offsets->m_serializedDataOffsets[2];
-
-	if (*(void**)(work + 0x3C) != 0)
-	{
-		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x3C));
-		*(void**)(work + 0x3C) = 0;
-	}
-
-	if (*(void**)(work + 0x40) != 0)
-	{
-		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x40));
-		*(void**)(work + 0x40) = 0;
-	}
-
-	if (*(void**)(work + 0x44) != 0)
-	{
-		pppHeapUseRate__FPQ27CMemory6CStage(*(void**)(work + 0x44));
-		*(void**)(work + 0x44) = 0;
 	}
 }


### PR DESCRIPTION
## Summary
- Reorder pppRyjMegaBirth function definitions to match the original unit layout, improving extab/extabindex ordering.
- Recover more of pppRyjDrawMegaBirth's original shape draw path: shared draw env setup, GX matrix load, signed color deltas, shape-frame resolution, and running particle/world/color pointers.
- Tune calc angle-wrap locals for a small near-match improvement.

## Objdiff evidence
Baseline from target selection / initial report:
- main/pppRyjMegaBirth text fuzzy: 62.820984%
- pppRyjDrawMegaBirth: 20.398176%
- calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR: 98.14103%
- extab: 64.28571%
- extabindex: 0.0%

After:
- main/pppRyjMegaBirth text fuzzy: 70.26753%
- pppRyjDrawMegaBirth: 65.8997%
- calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR: 98.16239%
- extab: 96.42857%
- extabindex: 94.047615%

## Verification
- ninja