### PR TITLE
Use secondary camera matrix for Ym particle renders

### DIFF
--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -132,7 +132,7 @@ void pppRenderYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, pppYmMegaBirth
                             managerPos.y = pppMngStPtr->m_matrix.value[1][3];
                             managerPos.z = pppMngStPtr->m_matrix.value[2][3];
                             PSVECAdd(&trailPos, &managerPos, &trailPos);
-                            PSMTXMultVec(ppvCameraMatrix0, &trailPos, &cameraPos);
+                            PSMTXMultVec(ppvCameraMatrix02, &trailPos, &cameraPos);
                         } else {
                             cameraPos = trailPos;
                         }

--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -131,7 +131,7 @@ void pppRenderYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, pppYmMegaBirth
                             managerPos.y = pppMngStPtr->m_matrix.value[1][3];
                             managerPos.z = pppMngStPtr->m_matrix.value[2][3];
                             PSVECAdd(&trailPos, &managerPos, &trailPos);
-                            PSMTXMultVec(ppvCameraMatrix0, &trailPos, &cameraPos);
+                            PSMTXMultVec(ppvCameraMatrix02, &trailPos, &cameraPos);
                         } else {
                             cameraPos = trailPos;
                         }

--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -186,7 +186,7 @@ void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkB* param_2, pppY
             if ((s32)Game.m_currentSceneId == 7) {
                 PSMTXMultVec(ppvWorldMatrix, &worldPos, &worldPos);
             } else {
-                PSMTXMultVec(ppvCameraMatrix0, &worldPos, &worldPos);
+                PSMTXMultVec(ppvCameraMatrix02, &worldPos, &worldPos);
             }
 
             model.value[0][3] = worldPos.x;


### PR DESCRIPTION
## Summary
- Switched Ym Miasma and MegaBirthShpTail2/3 render transforms from ppvCameraMatrix0 to ppvCameraMatrix02 where objdiff showed the target references ppvCameraMatrix02.
- Keeps the existing control flow and data layout intact; only the camera matrix symbol used for these render-space transforms changes.

## Objdiff evidence
- main/pppYmMiasma: pppRenderYmMiasma 97.195656% -> 97.25%; unit .text 95.5474% -> 95.55869%.
- main/pppYmMegaBirthShpTail3: pppRenderYmMegaBirthShpTail3 6.1813474% -> 6.1986184%; unit .text 39.34573% -> 39.350323%.
- main/pppYmMegaBirthShpTail2: pppRenderYmMegaBirthShpTail2 24.613043% -> 24.634783%; unit .text 43.48088% -> 43.48612%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o -
- build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o -
- build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail2 -o -