### PR TITLE
Improve p_menu matching

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -81,7 +81,6 @@ public:
     CMenuPcs()
     {
         unsigned int* mcCtrl = reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(this) + 0x20);
-        unsigned int* table = m_table__8CMenuPcs;
 
         mcCtrl[0] = 0;
         mcCtrl[1] = 0;
@@ -91,25 +90,6 @@ public:
         mcCtrl[5] = 0;
         mcCtrl[6] = 0;
         mcCtrl[7] = 0;
-
-        table[1] = m_table_desc0__8CMenuPcs[0];
-        table[2] = m_table_desc0__8CMenuPcs[1];
-        table[3] = m_table_desc0__8CMenuPcs[2];
-        table[4] = m_table_desc1__8CMenuPcs[0];
-        table[5] = m_table_desc1__8CMenuPcs[1];
-        table[6] = m_table_desc1__8CMenuPcs[2];
-        table[7] = m_table_desc2__8CMenuPcs[0];
-        table[8] = m_table_desc2__8CMenuPcs[1];
-        table[9] = m_table_desc2__8CMenuPcs[2];
-        table[12] = m_table_desc3__8CMenuPcs[0];
-        table[13] = m_table_desc3__8CMenuPcs[1];
-        table[14] = m_table_desc3__8CMenuPcs[2];
-        table[17] = m_table_desc4__8CMenuPcs[0];
-        table[18] = m_table_desc4__8CMenuPcs[1];
-        table[19] = m_table_desc4__8CMenuPcs[2];
-        table[22] = m_table_desc5__8CMenuPcs[0];
-        table[23] = m_table_desc5__8CMenuPcs[1];
-        table[24] = m_table_desc5__8CMenuPcs[2];
     }
     ~CMenuPcs();
 

--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -434,7 +434,9 @@ public:
     }; // Size 0x38
 
     PppPdtSlot m_pdtSlots[0x18];          // 0x22E18
-    unsigned char m_unk23358[0x39C];      // 0x23358
+    unsigned char m_unk23358[0x1C4];      // 0x23358
+    _pppEnvSt m_pppEnvSt;                 // 0x2351C
+    unsigned char m_unk235A8[0x14C];      // 0x235A8
     unsigned int m_partAMemBase;          // 0x236F4
     unsigned int m_partAMemCursor;        // 0x236F8
     unsigned int m_partLoadCacheParam;    // 0x236FC

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -683,7 +683,7 @@ extern "C" CPtrArray<CCharaPcs::CLoadModel*>* dtor_8007BB14(CPtrArray<CCharaPcs:
 CMemory::CStage* GET_CHARA_ALLOC_STAGE_S(int stageIndex, CMemory::CStage* stage)
 {
     if (stageIndex == 3) {
-        return *reinterpret_cast<CMemory::CStage**>(reinterpret_cast<unsigned char*>(&PartMng) + 0x2351c);
+        return PartMng.m_pppEnvSt.m_stagePtr;
     }
 
     if (stageIndex < 3) {

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -537,6 +537,14 @@ void CMenuPcs::loadFont(int type, char* path, int slot, int tlutMode)
         MenuFontTlutPalette* palette = &sMenuFontTlutPaletteTable[tlutMode * 0x1C];
 
         for (int colorIndex = 0; colorIndex < 0x10; colorIndex++) {
+            float blend = 0.0f;
+            float blendInv = 0.0f;
+
+            if (colorIndex >= 8) {
+                blend = 1.0f - static_cast<float>(colorIndex - 8) * 0.125f;
+                blendInv = 1.0f - blend;
+            }
+
             for (int tlutIndex = 0; tlutIndex < 0x1C; tlutIndex++) {
                 _GXColor color = {
                     static_cast<u8>(0xFF - sMenuFontShadeTable[colorIndex]),
@@ -550,9 +558,6 @@ void CMenuPcs::loadFont(int type, char* path, int slot, int tlutMode)
                     color.g = palette[tlutIndex].highlight.g;
                     color.b = palette[tlutIndex].highlight.b;
                 } else {
-                    float blend = 1.0f - static_cast<float>(colorIndex - 8) * 0.125f;
-                    float blendInv = 1.0f - blend;
-
                     color.r = static_cast<u8>(static_cast<float>(palette[tlutIndex].shadow.r) * blendInv +
                                               static_cast<float>(palette[tlutIndex].highlight.r) * blend);
                     color.g = static_cast<u8>(static_cast<float>(palette[tlutIndex].shadow.g) * blendInv +

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -123,8 +123,17 @@ unsigned int m_table_desc4__8CMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsi
 unsigned int m_table_desc5__8CMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawSingleMenu__8CMenuPcsFv)};
 
 unsigned int m_table__8CMenuPcs[0x57] = {
-    reinterpret_cast<unsigned int>(const_cast<char*>(kMenuPcsStageName)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1A, 0, 0, 0, 0,
-    0x49, 0x1, 0, 0, 0, 0x1A, 0x10, 0, 0, 0, 0x49, 0x11
+    reinterpret_cast<unsigned int>(const_cast<char*>(kMenuPcsStageName)),
+    m_table_desc0__8CMenuPcs[0], m_table_desc0__8CMenuPcs[1], m_table_desc0__8CMenuPcs[2],
+    m_table_desc1__8CMenuPcs[0], m_table_desc1__8CMenuPcs[1], m_table_desc1__8CMenuPcs[2],
+    m_table_desc2__8CMenuPcs[0], m_table_desc2__8CMenuPcs[1], m_table_desc2__8CMenuPcs[2],
+    0x1A, 0,
+    m_table_desc3__8CMenuPcs[0], m_table_desc3__8CMenuPcs[1], m_table_desc3__8CMenuPcs[2],
+    0x49, 0x1,
+    m_table_desc4__8CMenuPcs[0], m_table_desc4__8CMenuPcs[1], m_table_desc4__8CMenuPcs[2],
+    0x1A, 0x10,
+    m_table_desc5__8CMenuPcs[0], m_table_desc5__8CMenuPcs[1], m_table_desc5__8CMenuPcs[2],
+    0x49, 0x11
 };
 
 int DAT_8020ef9c[] = {

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1772,9 +1772,18 @@ void CMenuPcs::drawBattle()
             fade = 0.0f;
         }
 
+        Mtx cameraMtx;
+        Mtx44 viewMtx;
         Mtx44 screenMtx;
         Vec4d projected;
-        PSMTX44Copy(*reinterpret_cast<Mtx44*>(reinterpret_cast<u8*>(&CameraPcs) + 0x48), screenMtx);
+        PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
+        PSMTXCopy(cameraMtx, reinterpret_cast<MtxPtr>(viewMtx));
+        viewMtx[3][0] = 0.0f;
+        viewMtx[3][1] = 0.0f;
+        viewMtx[3][2] = 0.0f;
+        viewMtx[3][3] = 1.0f;
+        PSMTX44Copy(CameraPcs.m_screenMatrix, screenMtx);
+        PSMTX44Concat(screenMtx, viewMtx, screenMtx);
         Math.MTX44MultVec4(screenMtx, reinterpret_cast<Vec*>(m_battleHud.m_worldPos), &projected);
 
         if (projected.w > 0.0f) {
@@ -1806,12 +1815,12 @@ void CMenuPcs::drawBattle()
             const float left = screenX - static_cast<float>(halfWidth);
             const float bodyLeft = left + 8.0f;
             const float alphaF = 80.0f * fade;
-            const u8 alpha = static_cast<u8>(alphaF < 0.0f ? 0.0f : (alphaF > 255.0f ? 255.0f : alphaF));
+            const u8 alpha = static_cast<u8>(alphaF);
             const CColor frameColor(0xFF, 0xFF, 0xFF, alpha);
             GXSetChanMatColor(GX_COLOR0A0, frameColor.color);
 
             if (totalWidth > 0) {
-                CTexture* tex = m_textures[0xDD];
+                CTexture* tex = MenuPcs.m_textures[0xDD];
                 TextureMan.SetTexture(GX_TEXMAP0, tex);
                 if (tex != 0) {
                     Mtx texMtx;
@@ -1823,9 +1832,9 @@ void CMenuPcs::drawBattle()
                     GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);
                 }
                 TextureMan.SetTextureTev(tex);
-                DrawRect(0, left, screenY, 8.0f, 8.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+                MenuPcs.DrawRect(0, left, screenY, 8.0f, 8.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
-                tex = m_textures[0xDE];
+                tex = MenuPcs.m_textures[0xDE];
                 TextureMan.SetTexture(GX_TEXMAP0, tex);
                 if (tex != 0) {
                     Mtx texMtx;
@@ -1837,9 +1846,9 @@ void CMenuPcs::drawBattle()
                     GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);
                 }
                 TextureMan.SetTextureTev(tex);
-                DrawRect(0, bodyLeft, screenY, static_cast<float>(totalWidth - 16), 8.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+                MenuPcs.DrawRect(0, bodyLeft, screenY, static_cast<float>(totalWidth - 16), 8.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
-                tex = m_textures[0xDF];
+                tex = MenuPcs.m_textures[0xDF];
                 TextureMan.SetTexture(GX_TEXMAP0, tex);
                 if (tex != 0) {
                     Mtx texMtx;
@@ -1851,7 +1860,7 @@ void CMenuPcs::drawBattle()
                     GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);
                 }
                 TextureMan.SetTextureTev(tex);
-                DrawRect(0, (left + static_cast<float>(totalWidth)) - 8.0f, screenY, 8.0f, 8.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+                MenuPcs.DrawRect(0, (left + static_cast<float>(totalWidth)) - 8.0f, screenY, 8.0f, 8.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
             }
 
             const u8 gauge = static_cast<u8>((m_battleHud.m_gaugeCounter * 0xFF) >> 4);

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -516,7 +516,7 @@ void CMenuPcs::loadFont(int type, char* path, int slot, int tlutMode)
             stage = m_menuStage;
         }
     } else if (type < 3) {
-        stage = pppEnvStPtr->m_stagePtr;
+        stage = PartMng.m_pppEnvSt.m_stagePtr;
     }
 
     if ((slot == 0) && (FontMan.m_font != 0)) {
@@ -1868,22 +1868,13 @@ void CMenuPcs::drawBattle()
     }
 
     for (int i = 0; i < 4; i++) {
-        CMenu* menu = m_battleRingMenus[i];
-        if (menu != 0) {
-            menu->Draw();
-        }
+        m_battleRingMenus[i]->Draw();
     }
     for (int i = 0; i < 12; i++) {
-        CMenu* menu = reinterpret_cast<CMenu*>(m_battleMesMenus[i]);
-        if (menu != 0) {
-            menu->Draw();
-        }
+        reinterpret_cast<CMenu*>(m_battleMesMenus[i])->Draw();
     }
     for (int i = 0; i < 4; i++) {
-        CRingMenu* menu = m_battleRingMenus[i];
-        if (menu != 0) {
-            menu->DrawIcon();
-        }
+        m_battleRingMenus[i]->DrawIcon();
     }
 }
 


### PR DESCRIPTION
## Summary
- Move CMenuPcs table descriptor population into the table definition so static init order matches the target more closely.
- Hoist menu font palette blend setup and model the embedded CPartMng particle environment member.
- Align battle HUD projection/drawing with the target, including camera-screen matrix concatenation and singleton frame texture draws.

## Objdiff evidence
Before -> after for main/p_menu:
- __sinit_p_menu_cpp: 38.841465% -> 83.69512%
- loadFont__8CMenuPcsFiPcii: 53.228573% -> 61.77619%
- drawBattle__8CMenuPcsFv: 60.892704% -> 71.79185%
- createBattle__8CMenuPcsFv: unchanged at 79.35909%

## Validation
- ninja (build/GCCP01/main.dol: OK)
