### PR TITLE
Improve YmTracer spline step math

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -323,7 +323,7 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
             Vec splineFrom[4];
             Vec splineTo[4];
             s16 splineCount = 0;
-            f64 stepScale = FLOAT_803306ec / (f32)(u32)(param_2->m_payload[9] + 1);
+            f32 stepScale = FLOAT_803306ec / (f32)(param_2->m_payload[9] + 1);
 
             for (i = 0; i < (s32)(u32)param_2->m_payload[9]; i++) {
                 f32 t = stepScale * (f32)(i + 1);


### PR DESCRIPTION
## Summary
- Use float step math for YmTracer spline interpolation instead of forcing an unsigned/double intermediate.
- This matches the target float multiply/divide pattern more closely and removes several instruction mismatches in `pppFrameYmTracer`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer -o - pppFrameYmTracer`
- `pppFrameYmTracer`: 94.07407% -> 95.47325% match, diffs 239 -> 232.
- `main/pppYmTracer` `.text`: 95.758575% -> 96.65567%.
- `.sdata2` remains 100% matched.

## Plausibility
- The target assembly performs the spline step as float arithmetic; the previous source forced an unsigned cast and double-typed temporary. The new expression is simpler and fits plausible original particle interpolation code.