### PR TITLE
Remove stray CLight Set stub

### DIFF
--- a/include/ffcc/p_light.h
+++ b/include/ffcc/p_light.h
@@ -25,8 +25,6 @@ public:
     public:
         CLight();
 
-        void Set(CLightPcs::CLight*);
-
         u32 m_type;               // 0x00
         Vec3f m_position;         // 0x04
         Vec3f m_targetPosition;   // 0x10

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1418,13 +1418,3 @@ void CLightPcs::CBumpLight::SetTexture(_GXTexMapID texMapID, int textureIdx)
 {
     GXLoadTexObj(&m_textures[textureIdx], texMapID);
 }
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CLightPcs::CLight::Set(CLightPcs::CLight*)
-{
-	// TODO
-}


### PR DESCRIPTION
## Summary
- Remove the unused CLightPcs::CLight::Set declaration and empty TODO definition.
- Prevent p_light.o from emitting the non-PAL Set__Q29CLightPcs6CLightFPQ29CLightPcs6CLight symbol.

## Evidence
- ninja completes and build/GCCP01/main.dol verifies OK.
- rg finds no references to CLightPcs::CLight::Set or Set__Q29CLightPcs6CLight in config/GCCP01/symbols.txt, include, or src.
- objdump -t build/GCCP01/src/p_light.o no longer lists Set__Q29CLightPcs6CLightFPQ29CLightPcs6CLight.

## Plausibility
- The removed function was an empty analysis stub with no PAL symbol entry and no callers, so deleting it makes the declared source surface closer to the shipped object rather than adding compiler coaxing.