### PR TITLE
Define pppEmission double bias constant

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -30,6 +30,7 @@ extern const char DAT_803311fc;
 extern const float FLOAT_803311e0;
 extern const float FLOAT_803311e4;
 extern const float FLOAT_803311f8;
+extern const double DOUBLE_803311e8 = 4503599627370496.0;
 static const char s_pppEmission_cpp_801db7e8[] = "pppEmission.cpp";
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }


### PR DESCRIPTION
## Summary
- Define the pppEmission unsigned double-bias constant used by compiler-generated byte-to-float conversion data.
- Leaves pppEmission code generation unchanged while improving the unit's .sdata2 match.

## Evidence
- Built with `ninja`.
- `build/tools/objdiff-cli diff -p . -u main/pppEmission -o /tmp/pppEmission_final.json Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`
- Before: `.sdata2` 55.0%, `.text` 98.927574%, `pppFrameEmission` 99.94231%, `Emission_AfterDrawMeshCallback` 97.51645%.
- After: `.sdata2` 62.5%, `.text` 98.927574%, `pppFrameEmission` 99.94231%, `Emission_AfterDrawMeshCallback` 97.51645%.

## Plausibility
- The value is the standard unsigned integer-to-double bias constant (4503599627370496.0) already referenced by the PAL pppEmission code path.
- This is data ownership cleanup, not a control-flow or register-allocation hack.