### PR TITLE
Improve wind sphere setup ordering

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -211,9 +211,9 @@ found:
 		return -1;
 	}
 
-	float centerX = pos->x;
 	obj->type = 2;
 	float centerZ = pos->z;
+	float centerX = pos->x;
 	obj->flags = static_cast<u8>(__rlwimi(obj->flags, 1, 7, 24, 24));
 
 	int id = m_nextId;


### PR DESCRIPTION
## Summary
- Move the AddSphere__5CWindFPC3Vecffi type initialization before the cached center position loads.
- This better matches the target setup order for sphere wind objects while preserving the same field values and normal member access.

## Objdiff evidence
- AddSphere__5CWindFPC3Vecffi: 85.2421% -> 87.6316% match, diff count 32 -> 25.
- main/wind .text: 91.1640% match after the change.
- main/wind .bss: 100.0% match.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/wind -o - AddSphere__5CWindFPC3Vecffi
- build/tools/objdiff-cli diff -p . -u main/wind -o -