### PR TITLE
Improve menu list pad selection

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -307,8 +307,8 @@ void CMenuPcs::MLstCtrl()
 {
 	bool blocked;
 	float one;
-	short press;
-	short hold;
+	unsigned short press;
+	unsigned short hold;
 	unsigned int itemCount;
 	unsigned int chunkCount;
 	int i;
@@ -324,8 +324,9 @@ void CMenuPcs::MLstCtrl()
 	if (blocked) {
 		press = 0;
 	} else {
-		__cntlzw((unsigned int)Pad._448_4_);
-		press = Pad._8_2_;
+		int padIndex = 0;
+		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
+		press = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + padIndex * 0x54 + 0x8);
 	}
 
 	blocked = false;
@@ -335,8 +336,9 @@ void CMenuPcs::MLstCtrl()
 	if (blocked) {
 		hold = 0;
 	} else {
-		__cntlzw((unsigned int)Pad._448_4_);
-		hold = Pad._20_2_;
+		int padIndex = 0;
+		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
+		hold = *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(&Pad) + padIndex * 0x54 + 0x14);
 	}
 
 	if (hold == 0) {


### PR DESCRIPTION
## Summary
- restore MLstCtrl pad-slot selection from the debug-pad mask instead of discarding the `__cntlzw` result
- read press/hold from the selected pad input block rather than always using pad 0 fields
- keep the change localized to `src/menu_lst.cpp`

## Evidence
- `MLstCtrl__8CMenuPcsFv` direct objdiff: `68.327354%` -> `74.739914%`
- `MLstCtrl__8CMenuPcsFv` report fuzzy match: `68.3%` target-listing baseline -> `76.17489%`
- `main/menu_lst` report fuzzy match: `72.4%` target-listing baseline -> `74.36249%`
- full `ninja -j4` build passes

## Plausibility
- the new code matches the existing menu-controller pattern of selecting the active pad through `Pad._448_4_`
- this removes a dead `__cntlzw` call and uses its result to choose the actual input block, which is more coherent source than reading fixed fields after computing the mask