### PR TITLE
Correct FunnyShapePcs base class

### DIFF
--- a/include/ffcc/p_FunnyShape.h
+++ b/include/ffcc/p_FunnyShape.h
@@ -2,6 +2,7 @@
 #define _FFCC_P_FUNNYSHAPE_H_
 
 #include "ffcc/memory.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/system.h"
 #include "ffcc/FS_USB_Process.h"
 
@@ -17,7 +18,7 @@ extern unsigned int m_table_desc2__14CFunnyShapePcs[];
 extern unsigned int m_table_desc3__14CFunnyShapePcs[];
 extern unsigned int m_table__14CFunnyShapePcs[];
 
-class CFunnyShapePcs : public CProcess
+class CFunnyShapePcs : public CSamplePcs
 {
 public:
     CFunnyShapePcs();

--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -56,6 +56,7 @@ extern "C" void drawViewer__14CFunnyShapePcsFv(CFunnyShapePcs*);
 extern "C" CFunnyShape* __dt__11CFunnyShapeFv(CFunnyShape*, short);
 extern "C" void __dt__14CFunnyShapePcsFv(void*);
 extern "C" void* __vt__8CManager[];
+extern "C" void* __vt__10CSamplePcs[];
 extern "C" void* gVtable_CPtrArray_OSFSTexture[];
 extern "C" void* gVtable_CPtrArray_GXTexObj[];
 extern "C" void* __vt__14CFunnyShapePcs[];
@@ -109,7 +110,7 @@ extern "C" void __sinit_p_FunnyShape_cpp(void)
     unsigned int* desc3 = m_table_desc3__14CFunnyShapePcs;
 
     *reinterpret_cast<void**>(self) = __vt__8CManager;
-    *reinterpret_cast<void**>(self) = __vt__8CProcess;
+    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
     *reinterpret_cast<void**>(self) = __vt__14CFunnyShapePcs;
 
     __ct__14CUSBStreamDataFv(self + 0x3C);


### PR DESCRIPTION
## Summary
- Change CFunnyShapePcs to inherit from CSamplePcs, matching sibling PCS classes that use sample process tables.
- Update __sinit_p_FunnyShape_cpp's intermediate base vtable store from __vt__8CProcess to __vt__10CSamplePcs.

## Evidence
- ninja passes for GCCP01.
- objdiff for main/p_FunnyShape __sinit_p_FunnyShape_cpp remains 86.02778%, .text 98.177666%, .data 100.0%.
- Relocation target improves from __vt__8CProcess to __vt__10CSamplePcs; target uses the same base vtable family (__vt__10CSamplePcs+0x14).

## Plausibility
CFunnyShapePcs has the same table-driven PCS shape as CSamplePcs-derived units such as CMapPcs, CMenuPcs, CLightPcs, and CUSBPcs. This makes the class hierarchy and static initializer more coherent without adding synthetic symbols or address hacks.