### PR TITLE
Improve caravan and YmMegaBirthShpTail2 matching

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail2.h
+++ b/include/ffcc/pppYmMegaBirthShpTail2.h
@@ -27,7 +27,8 @@ struct VYmMegaBirthShpTail2
     _PARTICLE_WMAT* m_wmats;            // 0x40
     _PARTICLE_COLOR* m_colors;          // 0x44
     unsigned int m_maxParticles;        // 0x48
-    unsigned int m_lifeLimit;           // 0x4c
+    unsigned short m_lifeLimit;         // 0x4c
+    unsigned short m_lifeLimitPadding;  // 0x4e
 };
 
 struct pppYmMegaBirthShpTail2UnkB;
@@ -37,7 +38,7 @@ struct pppYmMegaBirthShpTail2UnkC {
 };
 
 void birth(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
-void calc(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_COLOR*);
+void calc(_pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1015,15 +1015,13 @@ int CCaravanWork::AddGil(int gilToAdd)
 
 	m_gil = m_gil + gilToAdd;
 	totalGil = m_gil;
-	if (totalGil <= 99999999) {
-		if (totalGil < 0) {
-			gilToAdd = gilToAdd - totalGil;
-			m_gil = 0;
-		}
-	} else {
+	if (totalGil > 99999999) {
 		int overflow = totalGil - 99999999;
 		m_gil = totalGil - overflow;
 		gilToAdd = gilToAdd - overflow;
+	} else if (totalGil < 0) {
+		gilToAdd = gilToAdd - totalGil;
+		m_gil = 0;
 	}
 	return gilToAdd;
 }
@@ -1039,29 +1037,27 @@ int CCaravanWork::AddGil(int gilToAdd)
  */
 int CCaravanWork::GetFoodRank(int playerIdx)
 {
+	CCaravanWork* cur = this;
 	int rank = 0;
 	int baseIdx = 0;
-	int loops = 2;
-	CCaravanWork* cur = this;
 
-	do {
-		if ((playerIdx != baseIdx) && (m_letterMeta[playerIdx] < cur->m_letterMeta[0])) {
+	for (int i = 0; i < 2; i++) {
+		if ((playerIdx != baseIdx) && (cur->m_letterMeta[0] > m_letterMeta[playerIdx])) {
 			rank++;
 		}
-		if ((playerIdx != (baseIdx + 1)) && (m_letterMeta[playerIdx] < cur->m_letterMeta[1])) {
+		if ((playerIdx != (baseIdx + 1)) && (cur->m_letterMeta[1] > m_letterMeta[playerIdx])) {
 			rank++;
 		}
-		if ((playerIdx != (baseIdx + 2)) && (m_letterMeta[playerIdx] < cur->m_letterMeta[2])) {
+		if ((playerIdx != (baseIdx + 2)) && (cur->m_letterMeta[2] > m_letterMeta[playerIdx])) {
 			rank++;
 		}
-		if ((playerIdx != (baseIdx + 3)) && (m_letterMeta[playerIdx] < cur->m_letterMeta[3])) {
+		if ((playerIdx != (baseIdx + 3)) && (cur->m_letterMeta[3] > m_letterMeta[playerIdx])) {
 			rank++;
 		}
 
 		cur = (CCaravanWork*)&cur->m_saveSlot;
 		baseIdx += 4;
-		loops--;
-	} while (loops != 0);
+	}
 
 	return rank;
 }

--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -21,7 +21,7 @@ extern "C" void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
 extern "C" void pppSetBlendMode(unsigned char);
 extern "C" void pppDrawShp__FP13tagOAN3_SHAPEP12CMaterialSetUc(void*, void*, unsigned char);
 extern "C" void calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
-    _pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, VColor*, _PARTICLE_COLOR*);
+    _pppPObject*, VYmMegaBirthShpTail2*, PYmMegaBirthShpTail2*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
 pppFMATRIX g_matUnit2;
 
 static const char s_pppYmMegaBirthShpTail2_cpp_801d9c68[] = "pppYmMegaBirthShpTail2.cpp";
@@ -229,14 +229,14 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
     _PARTICLE_WMAT* worldMat;
     _PARTICLE_COLOR* particleColor;
     VYmMegaBirthShpTail2* work;
+    VColor* colorWork;
 
     colorOffset = offsets->m_serializedDataOffsets[1];
     work = (VYmMegaBirthShpTail2*)((u8*)object + 0x80 + offsets->m_serializedDataOffsets[2]);
+    colorWork = (VColor*)((u8*)object + 0x80 + colorOffset);
     paramPayload = (u8*)param;
 
     if (work->m_particles == 0) {
-        Vec tailScale;
-
         work->m_maxParticles = *(u16*)((u8*)&param->m_matrix + 0xe);
         work->m_particles = (_PARTICLE_DATA*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
             work->m_maxParticles * 0x1b8, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail2_cpp_801d9c68), 0x30e);
@@ -259,8 +259,7 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
         }
 
         work->m_tailScaleDirection = param->m_directionTail;
-        tailScale = work->m_tailScaleDirection;
-        pppNormalize(work->m_tailScaleDirection, tailScale);
+        pppNormalize(work->m_tailScaleDirection, work->m_tailScaleDirection);
     }
 
     if (work->m_particles == 0) {
@@ -278,9 +277,6 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
     }
 
     switch (paramPayload[0x18]) {
-    default:
-        pppCopyMatrix(work->m_emitterMatrix, pppMngStPtr->m_matrix);
-        break;
     case 1:
     case 3:
     case 5:
@@ -321,33 +317,36 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
         work->m_emitterMatrix.value[2][3] = pppMngStPtr->m_position.z;
         break;
     }
-    }
-
-    if ((gPppCalcDisabled != 0) || (paramPayload[0x18] == 0)) {
-        return;
+    default:
+        pppCopyMatrix(work->m_emitterMatrix, pppMngStPtr->m_matrix);
+        break;
     }
 
     worldMat = work->m_wmats;
     particleColor = work->m_colors;
     particleData = (u8*)work->m_particles;
+
+    if ((gPppCalcDisabled != 0) || (*(u32*)((u8*)&param->m_matrix + 4) == 0xFFFF)) {
+        return;
+    }
+
     work->m_lifeLimit = work->m_lifeLimit + 1;
 
     for (i = 0; i < work->m_maxParticles; i++) {
-        if (*(s16*)(particleData + 0x22) == 0) {
+        if (*(u16*)(particleData + 0x22) != 0) {
+            calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
+                &object->field0_0x0, work, param, (_PARTICLE_DATA*)particleData, colorWork, particleColor);
+        } else {
             if ((*(u16*)((u8*)&param->m_matrix + 0x12) <= work->m_lifeLimit) &&
                 (spawnCount < *(u16*)((u8*)&param->m_matrix + 0x10))) {
-                birth(&object->field0_0x0, work, param, (VColor*)((u8*)object + 0x80 + colorOffset),
-                    (_PARTICLE_DATA*)particleData, worldMat, particleColor);
+                birth(&object->field0_0x0, work, param, colorWork, (_PARTICLE_DATA*)particleData, worldMat,
+                    particleColor);
                 spawnCount = spawnCount + 1;
             }
-        } else {
-            calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
-                &object->field0_0x0, work, param, (VColor*)particleData,
-                (_PARTICLE_COLOR*)((u8*)object + 0x80 + colorOffset));
         }
 
         if (worldMat != 0) {
-            worldMat = worldMat + 1;
+            worldMat = (_PARTICLE_WMAT*)((u8*)worldMat + 0x30);
         }
         if (particleColor != 0) {
             particleColor = particleColor + 1;
@@ -371,9 +370,10 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
  */
 extern "C" void calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
     _pppPObject* pppPObject, VYmMegaBirthShpTail2* vYmMegaBirthShpTail2,
-    PYmMegaBirthShpTail2* pYmMegaBirthShpTail2, VColor* vColor, _PARTICLE_COLOR* particleColor)
+    PYmMegaBirthShpTail2* pYmMegaBirthShpTail2, _PARTICLE_DATA* particleData, VColor* vColor,
+    _PARTICLE_COLOR* particleColor)
 {
-    u8* color = (u8*)vColor;
+    u8* color = (u8*)particleData;
     u32 alpha = ((u8*)particleColor)[0xb];
     float* blend = (float*)(color + 0x30);
     float* velocityScale = (float*)(color + 0x28);


### PR DESCRIPTION
## Summary
- Matched `CCaravanWork::AddGil` by restoring the original overflow-first clamp shape.
- Improved `CCaravanWork::GetFoodRank` by using the original fixed-count loop and comparison direction.
- Improved `pppFrameYmMegaBirthShpTail2` by correcting `VYmMegaBirthShpTail2` halfword layout, calc signature, color-work pointer lifetime, switch layout, active test, and `_PARTICLE_WMAT` stride.

## Objdiff evidence
- `AddGil__12CCaravanWorkFi`: 67.85714% -> 100.0% (84 bytes)
- `GetFoodRank__12CCaravanWorkFi`: 67.441864% -> 97.83721% (172 bytes)
- `pppFrameYmMegaBirthShpTail2`: 63.46642% / 1092 bytes -> 96.76119% / 1072 bytes (target size 1072)

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o - AddGil__12CCaravanWorkFi`
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o - GetFoodRank__12CCaravanWorkFi`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail2 -o - pppFrameYmMegaBirthShpTail2`
