### PR TITLE
Match pppYmDeformationMdl constructor zero loads

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -305,10 +305,10 @@ void pppDestructYmDeformationMdl(pppYmDeformationMdl*, pppYmDeformationMdlUnkC*)
  */
 void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, pppYmDeformationMdlUnkC* param_2)
 {
-    float value = FLOAT_80330dac;
+    float value = DeformationMdlZero();
     float* state = (float*)((u8*)pppYmDeformationMdl_ + 0x80 + param_2->m_serializedDataOffsets[2]);
 
-    state[3] = FLOAT_80330dac;
+    state[3] = DeformationMdlZero();
     state[2] = value;
     state[1] = value;
     state[6] = value;
@@ -329,7 +329,7 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, str
 {
     u8 direction = 1;
     u16* puVar2 = (u16*)((u8*)pppYmDeformationMdl_ + 0x80 + param_2->m_serializedDataOffsets[2]);
-    float fVar1 = FLOAT_80330dac;
+    float fVar1 = DeformationMdlZero();
 
     *puVar2 = 0;
     *(u8*)(puVar2 + 1) = direction;


### PR DESCRIPTION
## Summary
- route the constructor zero-initialization through `DeformationMdlZero()` in `pppYmDeformationMdl.cpp`
- make both constructor helpers bind their zero loads to `FLOAT_80330dac`, matching the original object

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o -`
- before: `pppConstruct2YmDeformationMdl` 99.583336%, `pppConstructYmDeformationMdl` 99.6875%, unit `.text` 99.62389%
- after: `pppConstruct2YmDeformationMdl` 100.0%, `pppConstructYmDeformationMdl` 100.0%, unit `.text` 99.64602%

## Why this is plausible source
- the constructors are still just zero-initializing the deformation state
- the change removes a symbol-binding mismatch without introducing compiler coaxing, fake linkage, or ABI changes
