### PR TITLE
Improve YmBreath particle lifetime match

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -908,6 +908,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     unsigned char* breath = (unsigned char*)pYmBreath;
     Vec* particle = reinterpret_cast<Vec*>(particleData);
     int angle[4];
+    short life;
     pppFMATRIX rotMtx;
     Vec baseDir;
     Vec directionNorm;
@@ -1037,10 +1038,11 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         particle[6].z += (spread + spread) * Math.RandF() - spread;
     }
 
-    if (*(short*)(breath + 0x24) == 0) {
+    life = *(short*)(breath + 0x24);
+    if (life == 0) {
         *(short*)&particle[2].z = -1;
     } else {
-        *(short*)&particle[2].z = *(short*)(breath + 0x24);
+        *(short*)&particle[2].z = life;
     }
     *(unsigned char*)&particle[7].x = 0;
 


### PR DESCRIPTION
## Summary
- route `BirthParticle`'s lifetime load through a signed short local in `src/pppYmBreath.cpp`
- keep the rest of the function unchanged so the diff only captures the matching improvement

## Evidence
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: `86.17215%` -> `86.18228%`
- full `ninja` build passes after the change

## Plausibility
- this is a source-plausible type clarification for the particle lifetime field, not compiler coaxing or a linkage hack