### PR TITLE
Improve p_chara reset and CPtrArray matching

### DIFF
--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -151,6 +151,8 @@ public:
     void RemoveAll();
 };
 
+#pragma dont_inline on
+
 template <class T>
 CPtrArray<T>::CPtrArray()
 {
@@ -306,6 +308,8 @@ template class CPtrArray<CCharaPcs::CLoadPdt*>;
 template class CPtrArray<CCharaPcs::CLoadTexture*>;
 template class CPtrArray<CCharaPcs::CLoadAnim*>;
 template class CPtrArray<CCharaPcs::CLoadModel*>;
+
+#pragma dont_inline reset
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -999,9 +999,8 @@ void CCharaPcs::Reset(CCharaPcs::RESET mode)
 
             for (int i = LoadAnimArray(this)->GetSize() - 1; i >= 0; i--) {
                 int* loadAnim = reinterpret_cast<int*>((*LoadAnimArray(this))[static_cast<unsigned long>(i)]);
-                const bool releaseByKind = loadAnim[4] < 0 && loadAnim[1] == 1;
-                const bool releaseByMask = loadAnim[4] >= 0 && ((releaseMask & static_cast<unsigned int>(loadAnim[5])) != 0);
-                if (!releaseByKind && !releaseByMask) {
+                if (!(((loadAnim[4] < 0) && (loadAnim[1] == 1)) ||
+                      ((loadAnim[4] >= 0) && ((releaseMask & static_cast<unsigned int>(loadAnim[5])) != 0)))) {
                     continue;
                 }
 

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -98,6 +98,11 @@ static const char s_charaMergePathFmt[] = "dvd/mrg/m%04d_%02d.mrg";
 static const char s_charaMergeDupFmt[] = "CCharaPcs duplicate merge %d\n";
 static const char s_charaMergeOpenFmt[] = "CCharaPcs missing merge %d\n";
 static const char s_charaMergeDoneFmt[] = "CCharaPcs LoadMergeFile %d 0x%x\n";
+static const char s_charaFreeMergeFmt[] = "CCharaPcs.FreeMergeFile: 0x%08x\n";
+static const char s_charaAmemCompactFailed[] =
+    "\x83\x4b\x83\x78\x81\x5b\x83\x57\x83\x52\x83\x8c\x83\x4e\x83\x56\x83\x87"
+    "\x83\x93\x82\xc9\x8e\xb8\x94\x73\x82\xb5\x82\xbd\x82\xcc\x82\xc5\x81\x41"
+    "\x91\x53\x82\xc4\x8f\xc1\x8b\x8e\x82\xb5\x82\xdc\x82\xb7\x81\x42\n";
 static const char s_charaBasePathFmt[] = "dvd/char/k%02d/chara%03d/chara%03d";
 static const char s_charaAnimPathFmt[] = "dvd/char/k%02d/chara%03d/%s.cha";
 static const char s_charaModelSuffix[] = ".mdl";
@@ -987,7 +992,6 @@ void CCharaPcs::Reset(CCharaPcs::RESET mode)
         }
     }
 
-    int charaAmemSize = static_cast<int>(CharaAmemSize());
     if (resetMode != 1) {
         if (resetMode == 0) {
             const unsigned int releaseMask = ~(FreeMergeMask(this) | 0x10000000U);
@@ -1008,24 +1012,27 @@ void CCharaPcs::Reset(CCharaPcs::RESET mode)
                 LoadAnimArray(this)->RemoveAt(static_cast<unsigned long>(i));
             }
 
+            Printf__7CSystemFPce(&System, s_charaFreeMergeFmt, releaseMask);
             LoadPdtArray(this)->ReleaseAndRemoveAll();
-            charaAmemSize = correctLoadAnimAmem();
-        } else {
-            LoadModelArray(this)->ReleaseAndRemoveAll();
-            LoadAnimArray(this)->ReleaseAndRemoveAll();
-            LoadTextureArray(this)->ReleaseAndRemoveAll();
-            LoadPdtArray(this)->ReleaseAndRemoveAll();
-            charaAmemSize = 0;
+            int charaAmemSize = correctLoadAnimAmem();
+            if (charaAmemSize >= 0) {
+                CharaAmemSize() = static_cast<unsigned int>(charaAmemSize);
+                gCharaPartWorkPtr[0x6B] = 0xFF;
+                FreeMergeMask(this) = 0;
+                return;
+            }
+
+            if (System.m_execParam > 1) {
+                Printf__7CSystemFPce(&System, s_charaAmemCompactFailed);
+            }
         }
-    } else {
-        LoadModelArray(this)->ReleaseAndRemoveAll();
-        LoadAnimArray(this)->ReleaseAndRemoveAll();
-        LoadTextureArray(this)->ReleaseAndRemoveAll();
-        LoadPdtArray(this)->ReleaseAndRemoveAll();
-        charaAmemSize = 0;
     }
 
-    CharaAmemSize() = static_cast<unsigned int>(charaAmemSize < 0 ? 0 : charaAmemSize);
+    LoadModelArray(this)->ReleaseAndRemoveAll();
+    LoadAnimArray(this)->ReleaseAndRemoveAll();
+    LoadTextureArray(this)->ReleaseAndRemoveAll();
+    LoadPdtArray(this)->ReleaseAndRemoveAll();
+    CharaAmemSize() = 0;
     gCharaPartWorkPtr[0x6B] = 0xFF;
     FreeMergeMask(this) = 0;
 }

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -983,13 +983,11 @@ void CCharaPcs::Reset(CCharaPcs::RESET mode)
         }
     }
 
-    if (HandleListHead(this) != 0) {
-        CHandle* handle = HandleListHead(this)->m_next;
-        while (handle != HandleListHead(this)) {
-            CHandle* next = handle->m_next;
-            __dt__Q29CCharaPcs7CHandleFv(handle, 1);
-            handle = next;
-        }
+    CHandle* handle = HandleListHead(this)->m_next;
+    while (handle != HandleListHead(this)) {
+        CHandle* next = handle->m_next;
+        __dt__Q29CCharaPcs7CHandleFv(handle, 1);
+        handle = next;
     }
 
     if (resetMode != 1) {

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -1014,9 +1014,7 @@ void CCharaPcs::Reset(CCharaPcs::RESET mode)
             int charaAmemSize = correctLoadAnimAmem();
             if (charaAmemSize >= 0) {
                 CharaAmemSize() = static_cast<unsigned int>(charaAmemSize);
-                gCharaPartWorkPtr[0x6B] = 0xFF;
-                FreeMergeMask(this) = 0;
-                return;
+                goto complete;
             }
 
             if (System.m_execParam > 1) {
@@ -1030,6 +1028,8 @@ void CCharaPcs::Reset(CCharaPcs::RESET mode)
     LoadTextureArray(this)->ReleaseAndRemoveAll();
     LoadPdtArray(this)->ReleaseAndRemoveAll();
     CharaAmemSize() = 0;
+
+complete:
     gCharaPartWorkPtr[0x6B] = 0xFF;
     FreeMergeMask(this) = 0;
 }


### PR DESCRIPTION
## Summary
- Disable inlining for the local p_chara CPtrArray template instantiations so callers emit the expected template function calls.
- Restore Reset's free-merge logging, AMEM compaction failure fallback, and shared cleanup path.
- Align Reset handle traversal and release-condition control flow with the original decompilation.

## Objdiff evidence
Before this branch:
- Reset__9CCharaPcsFQ29CCharaPcs5RESET: 0.0%
- TryReleaseAnimBank__9CCharaPcsFi: 9.096774%
- correctLoadAnimAmem__9CCharaPcsFv: 37.827816%
- __sinit_p_chara_cpp: 15.371134%

After:
- Reset__9CCharaPcsFQ29CCharaPcs5RESET: 68.80282%
- TryReleaseAnimBank__9CCharaPcsFi: 69.1129%
- correctLoadAnimAmem__9CCharaPcsFv: 42.16556%
- __sinit_p_chara_cpp: 16.268042%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_chara -o - Reset__9CCharaPcsFQ29CCharaPcs5RESET