### PR TITLE
system: remove stray ExecScenegraph stopwatch literal

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -440,7 +440,7 @@ void CSystem::ExecScenegraph()
 
         float totalTime = 0.0f;
         perfTrigger &= 1;
-        CStopWatch watch((char*)"no name");
+        CStopWatch watch(reinterpret_cast<char*>(-1));
 
         int index = 0;
         for (COrder* order = m_orderSentinel.m_next;


### PR DESCRIPTION
## Summary
- switch `CSystem::ExecScenegraph()` to construct its local `CStopWatch` with `reinterpret_cast<char*>(-1)`
- remove the stray `"no name"` stopwatch-name literal from `system.o`
- keep the existing `ExecScenegraph__7CSystemFv` code shape intact while improving the unit's data output

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/system -o - ExecScenegraph__7CSystemFv`

Before this change, the diff for `main/system` emitted an extra stopwatch-name symbol in `system.o`:
- `@434` containing `"no name"`
- `[.sdata-0]` containing `"no name"` alongside `"CSystem"`

After this change, those stray `.sdata` diff entries are gone; the current diff only retains the expected `s_cSystem` storage in `(.sdata2-0)`.

The target function remains at the same code match level (`ExecScenegraph__7CSystemFv`: 91.75135%), so this is a real data/layout cleanup without compiler-coaxing churn in the control flow.

## Plausibility
Passing `-1` as the stopwatch name already appears in nearby matched codepaths (`memory.cpp`, `p_chara_viewer.cpp`, `cflat_runtime*.cpp`). Using the same constructor form in `ExecScenegraph()` is more coherent with the surrounding codebase and removes a mismatch artifact rather than introducing a workaround.
