### PR TITLE
Improve GetFoodRank loop shape

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1042,21 +1042,14 @@ int CCaravanWork::GetFoodRank(int playerIdx)
 	int baseIdx = 0;
 
 	for (int i = 0; i < 2; i++) {
-		if ((playerIdx != baseIdx) && (cur->m_letterMeta[0] > m_letterMeta[playerIdx])) {
-			rank++;
-		}
-		if ((playerIdx != (baseIdx + 1)) && (cur->m_letterMeta[1] > m_letterMeta[playerIdx])) {
-			rank++;
-		}
-		if ((playerIdx != (baseIdx + 2)) && (cur->m_letterMeta[2] > m_letterMeta[playerIdx])) {
-			rank++;
-		}
-		if ((playerIdx != (baseIdx + 3)) && (cur->m_letterMeta[3] > m_letterMeta[playerIdx])) {
-			rank++;
+		for (int j = 0; j < 4; j++) {
+			if ((playerIdx != baseIdx) && (cur->m_letterMeta[j] > m_letterMeta[playerIdx])) {
+				rank++;
+			}
+			baseIdx++;
 		}
 
 		cur = (CCaravanWork*)&cur->m_saveSlot;
-		baseIdx += 4;
 	}
 
 	return rank;


### PR DESCRIPTION
## Summary
- Rework CCaravanWork::GetFoodRank to use a small inner loop over each save slot's four food metadata entries.
- This matches the target's per-entry base index increment pattern more closely and removes repeated manual checks.

## Evidence
- ninja
- objdiff: main/gobjwork GetFoodRank__12CCaravanWorkFi improves from 97.83721% to 98.325584% (172b)

## Plausibility
- The nested loop is cleaner source than four repeated manually offset comparisons and matches the target incrementing the global player index after each entry check.