### PR TITLE
Match CMath::MakeSpline1Dtable

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -876,7 +876,10 @@ void CMath::MakeSpline1Dtable(int count, float* x, float* y, float* outSecondDer
     outSecondDerivatives[0] = firstDerivative;
     outSecondDerivatives[count] = firstDerivative;
     for (i = 1; i < count; ++i) {
-        outSecondDerivatives[i] = -(firstDerivative * s_wSpline[i] - outSecondDerivatives[i]) / s_dSpline[i];
+        float w = s_wSpline[i];
+        float value = outSecondDerivatives[i];
+        float d = s_dSpline[i];
+        outSecondDerivatives[i] = -(firstDerivative * w - value) / d;
     }
 }
 


### PR DESCRIPTION
## Summary
- Matched `CMath::MakeSpline1Dtable` by preserving the final loop inputs as locals before the recurrence assignment.
- Keeps the spline algorithm source-shaped while matching the compiler's register scheduling for the final loop.

## Evidence
- `ninja` passes for `GCCP01`.
- `main/math` matched functions: `19/24 -> 20/24`.
- `main/math` matched code: `3028/8384 -> 5356/8384` bytes.
- `MakeSpline1Dtable__5CMathFiPfPfPf`: `99.96564% -> 100.0%` and byte-identical (`2328` bytes).
