### PR TITLE
Improve mapocttree read and chara shadow matching

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -61,7 +61,7 @@ class COctTree
 public:
 	COctTree();
 	~COctTree();
-	void ReadOtmOctTree(CChunkFile&);
+	int ReadOtmOctTree(CChunkFile&);
 	void DrawTypeMeshFlag_r(COctNode*);
 	void DrawCharaShadowTypeMeshFlag_r(COctNode*);
 	void DrawTypeMeshFrustumIn_r(COctNode*);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -91,7 +91,7 @@ extern "C" unsigned char Vec_80245758[];
 extern "C" void __ct__Q29CLightPcs6CLightFv(void*);
 extern "C" void DestroyBumpLightAll__9CLightPcsFQ29CLightPcs6TARGET(void*, int);
 extern "C" void SetLink__7CMapObjFv();
-extern "C" void ReadOtmOctTree__8COctTreeFR10CChunkFile(void*, CChunkFile&);
+extern "C" int ReadOtmOctTree__8COctTreeFR10CChunkFile(void*, CChunkFile&);
 extern "C" CPtrArray<CMapLightHolder*>* dtor_80034414(CPtrArray<CMapLightHolder*>*, short);
 
 static const char s_map_cpp[] = "map.cpp";

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -180,7 +180,7 @@ COctTree::~COctTree()
  * JP Address: TODO
  * JP Size: TODO
  */
-void COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
+int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
 {
     CChunkFile::CChunk chunk;
 
@@ -250,35 +250,31 @@ void COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
                         }
 
                         case 'BOND':
-                            if (node != 0) {
-                                node->m_boundMinX = chunkFile.GetF4();
-                                node->m_boundMinY = chunkFile.GetF4();
-                                node->m_boundMinZ = chunkFile.GetF4();
-                                node->m_boundMaxX = chunkFile.GetF4();
-                                node->m_boundMaxY = chunkFile.GetF4();
-                                node->m_boundMaxZ = chunkFile.GetF4();
-                            }
+                            node->m_boundMinX = chunkFile.GetF4();
+                            node->m_boundMinY = chunkFile.GetF4();
+                            node->m_boundMinZ = chunkFile.GetF4();
+                            node->m_boundMaxX = chunkFile.GetF4();
+                            node->m_boundMaxY = chunkFile.GetF4();
+                            node->m_boundMaxZ = chunkFile.GetF4();
                             break;
 
                         case 'CHLD':
-                            if (node != 0) {
-                                int childCount = 0;
-                                COctNode** childNode = node->m_children;
+                            int childCount = 0;
+                            COctNode** childNode = node->m_children;
 
-                                for (int i = 0; i < 8; i++) {
-                                    unsigned short childIndex = chunkFile.Get2();
+                            for (int i = 0; i < 8; i++) {
+                                unsigned short childIndex = chunkFile.Get2();
 
-                                    if (childIndex != 0xFFFF) {
-                                        *childNode = m_nodePool + childIndex;
-                                        childNode++;
-                                        childCount++;
-                                    }
-                                }
-
-                                for (int i = childCount; i < 8; i++) {
-                                    *childNode = 0;
+                                if (childIndex != 0xFFFF) {
+                                    *childNode = m_nodePool + childIndex;
                                     childNode++;
+                                    childCount++;
                                 }
+                            }
+
+                            for (int i = childCount; i < 8; i++) {
+                                *childNode = 0;
+                                childNode++;
                             }
                             break;
                         }
@@ -292,6 +288,7 @@ void COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
     }
 
     chunkFile.PopChunk();
+    return 1;
 }
 
 /*
@@ -863,29 +860,22 @@ void COctTree::Draw(unsigned char drawType)
  */
 void COctTree::DrawCharaShadow(unsigned char drawType)
 {
-	unsigned char* thisBytes = reinterpret_cast<unsigned char*>(this);
-	unsigned char* mapObj;
+	void* mapObj;
 
-	if (*thisBytes != 0) {
-		return;
-	}
+	if ((m_type == 0) && (mapObj = m_mapObject, *reinterpret_cast<unsigned char*>(Ptr(mapObj, 0x15)) == drawType)) {
+		LightPcs.SetBumpTexMatirx(reinterpret_cast<float(*)[4]>(Ptr(mapObj, 0xB8)), 0, reinterpret_cast<Vec*>(Ptr(mapObj, 0x58)),
+		                          *reinterpret_cast<unsigned char*>(Ptr(mapObj, 0x1A)));
 
-	mapObj = *reinterpret_cast<unsigned char**>(thisBytes + 8);
-	if (mapObj[0x15] != drawType) {
-		return;
-	}
+		if (kMapOctTreeDefaultOffsetZ != *reinterpret_cast<float*>(Ptr(m_mapObject, 0x40))) {
+			CameraPcs.SetOffsetZBuff(*reinterpret_cast<float*>(Ptr(m_mapObject, 0x40)));
+		}
 
-	LightPcs.SetBumpTexMatirx(reinterpret_cast<float(*)[4]>(mapObj + 0xB8), 0, reinterpret_cast<Vec*>(mapObj + 0x58), mapObj[0x1A]);
+		reinterpret_cast<CMapMesh*>(*reinterpret_cast<void**>(Ptr(m_mapObject, 0xC)))->SetRenderArray();
+		DrawCharaShadowTypeMeshFlag_r(m_nodePool);
 
-	if (kMapOctTreeDefaultOffsetZ != *reinterpret_cast<float*>(mapObj + 0x40)) {
-		CameraPcs.SetOffsetZBuff(*reinterpret_cast<float*>(mapObj + 0x40));
-	}
-
-	reinterpret_cast<CMapMesh*>(*reinterpret_cast<void**>(mapObj + 0xC))->SetRenderArray();
-	DrawCharaShadowTypeMeshFlag_r(*reinterpret_cast<COctNode**>(thisBytes + 4));
-
-	if (kMapOctTreeDefaultOffsetZ != *reinterpret_cast<float*>(mapObj + 0x40)) {
-		CameraPcs.SetOffsetZBuff(*reinterpret_cast<float*>(mapObj + 0x40));
+		if (kMapOctTreeDefaultOffsetZ != *reinterpret_cast<float*>(Ptr(m_mapObject, 0x40))) {
+			CameraPcs.SetOffsetZBuff(*reinterpret_cast<float*>(Ptr(m_mapObject, 0x40)));
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make `COctTree::ReadOtmOctTree` return the success value shown by the target and update the local declaration/caller shim.
- Remove defensive `BOND`/`CHLD` node guards to match the ordered OTM node chunk flow from the target.
- Reshape `COctTree::DrawCharaShadow` to use the same guarded block form as the target and nearby draw code.

## Objdiff evidence
`build/tools/objdiff-cli diff -p . -u main/mapocttree -o /tmp/objdiff_final_mapocttree.json ReadOtmOctTree__8COctTreeFR10CChunkFile`

- `.text`: 90.80703% -> 91.14817%
- `ReadOtmOctTree__8COctTreeFR10CChunkFile`: 84.34034% / 944b -> 86.18908% / 932b
- `DrawCharaShadow__8COctTreeFUc`: 87.65958% / 184b -> 99.36170% / 188b
- `InsertShadow__8COctTreeFlR3VecR6CBound`: unchanged at 78.40741% / 212b

## Verification
- `ninja`
- `python3 tools/agent_select_target.py` no longer selects `main/mapocttree` as a top target.