### PR TITLE
Improve mapmesh allocation stage linkage

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -8,14 +8,15 @@
 #include <string.h>
 
 class CMaterial;
+class CMapHitFace;
 
 extern "C" void __dl__FPv(void* ptr);
 extern "C" void __dla__FPv(void* ptr);
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long size, CMemory::CStage* stage, char* file, int line);
-extern "C" CMemory::CStage* DAT_8032EC98;
 extern "C" char s_mapmesh_cpp_801D70B0[];
 extern "C" float FLOAT_8032F930;
 extern "C" float FLOAT_8032F934;
+extern CMapHitFace* g_hit_lpface_min;
 
 extern "C" {
 void SetBlendMode__12CMaterialManFP12CMaterialSeti(void* materialMan, CMaterialSet* materialSet, unsigned int materialIdx);
@@ -96,6 +97,11 @@ static inline CMaterialSet* DefaultMaterialSet()
 static inline unsigned int Align32(unsigned int value)
 {
     return (value + 0x1F) & ~0x1FU;
+}
+
+static inline CMemory::CStage*& MapMeshAllocStage()
+{
+    return reinterpret_cast<CMemory::CStage*&>(g_hit_lpface_min);
 }
 }
 
@@ -396,7 +402,7 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
     workSize = Align32(workSize);
 
     reader = chunkFile;
-    DAT_8032EC98 = stage;
+    MapMeshAllocStage() = stage;
     unsigned char* cursor;
     int offset;
     int dlOffset;
@@ -404,7 +410,7 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
     while (reader.GetNextChunk(chunk)) {
         switch (chunk.m_id) {
         case 0x56455254:
-            m_meshData = __nwa__FUlPQ27CMemory6CStagePci(workSize, DAT_8032EC98, s_mapmesh_cpp_801D70B0, 0x13A);
+            m_meshData = __nwa__FUlPQ27CMemory6CStagePci(workSize, MapMeshAllocStage(), s_mapmesh_cpp_801D70B0, 0x13A);
 
             float maxInit = FLOAT_8032F934;
             float minInit = FLOAT_8032F930;
@@ -499,7 +505,8 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
         case 0x444C4844:
             m_displayListCount = static_cast<unsigned short>(chunk.m_arg0);
             if (usePreallocated != 0) {
-                m_displayListData = __nwa__FUlPQ27CMemory6CStagePci(workSize, DAT_8032EC98, s_mapmesh_cpp_801D70B0, 0x1D5);
+                m_displayListData =
+                    __nwa__FUlPQ27CMemory6CStagePci(workSize, MapMeshAllocStage(), s_mapmesh_cpp_801D70B0, 0x1D5);
                 cursor = reinterpret_cast<unsigned char*>(m_displayListData);
             } else {
                 cursor = reinterpret_cast<unsigned char*>(Align32(reinterpret_cast<unsigned int>(cursor)));


### PR DESCRIPTION
## Summary
- Replace the anonymous `DAT_8032EC98` extern in `mapmesh.cpp` with the named `g_hit_lpface_min` storage that the target relocation already uses.
- Add a small typed accessor so `ReadOtmMesh` still passes the slot as a `CMemory::CStage*` for map mesh allocation.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/mapmesh -o - ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`
- `main/mapmesh` .text: 99.45081% -> 99.46514%.
- `CMapMesh::ReadOtmMesh`: 98.99651% -> 99.02269%.

## Plausibility
The change removes a fabricated address-style extern and uses the real named global already present in the project symbol map. The accessor keeps the existing allocation-stage behavior explicit without introducing new hardcoded addresses or fake symbols.