### PR TITLE
Improve scenegraph pad trigger typing

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -281,8 +281,8 @@ void CSystem::ExecScenegraph()
 
     do
     {
-        int stepTrigger;
-        int perfTrigger;
+        u16 stepTrigger;
+        u16 perfTrigger;
 
         if (Game.m_gameWork.m_singleShopOrSmithMenuActiveFlag != Game.m_gameWork.m_gamePaused)
         {
@@ -354,8 +354,8 @@ void CSystem::ExecScenegraph()
         {
             for (int port = 0; port < 4; port++)
             {
-                int trigger;
-                int held;
+                u16 trigger;
+                u16 held;
                 bool noInput;
 
                 noInput = false;


### PR DESCRIPTION
## Summary
- type `CSystem::ExecScenegraph` pad trigger temporaries as `u16`
- applies the same typing to per-port debug pause trigger/held reads

## Evidence
- `ninja` passes
- `ExecScenegraph__7CSystemFv`: 97.45946% -> 97.554054%
- built size moves from 1460 bytes to 1472 bytes toward the 1480-byte PAL target

## Plausibility
Pad reads in this function load 16-bit controller fields. Keeping those temporaries as `u16` better reflects the original data width and recovers closer code generation without introducing address hacks or forced sections.