### PR TITLE
Name YmChangeTex double constant

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -87,6 +87,7 @@ extern _pppEnvStYmChangeTex* pppEnvStPtr;
 
 extern float DAT_80330e10;
 static const char s_pppYmChangeTex_cpp_801db4c0[] = "pppYmChangeTex.cpp";
+extern const double DOUBLE_80330dd8 = 4503601774854144.0;
 extern float FLOAT_80330df8;
 extern float FLOAT_80330dfc;
 extern float FLOAT_80330e00;


### PR DESCRIPTION
## Summary
- Name the YmChangeTex sdata2 conversion constant as DOUBLE_80330dd8.
- This replaces the anonymous emitted constant with the shipped symbol name without changing code flow.

## Evidence
- ninja succeeds for GCCP01.
- objdiff for main/pppYmChangeTex now reports DOUBLE_80330dd8: 8 bytes, 100.0% match.
- Related code scores remain stable: pppFrameYmChangeTex 97.677216%, pppDestructYmChangeTex 97.6%, ChangeTex_AfterDrawMeshCallback 94.040405%, ChangeTex_DrawMeshDLCallback 88.37681%.
- Overall report data improves to 1,095,265 matched bytes.