### PR TITLE
Fix maphit intersection return contract

### DIFF
--- a/include/ffcc/maphit.h
+++ b/include/ffcc/maphit.h
@@ -8,7 +8,7 @@ class CMapCylinder;
 class CMapHit;
 class CBound;
 
-void FindIntersection(const Vec&, const Vec&, const CMapCylinder&, float&);
+int FindIntersection(const Vec&, const Vec&, const CMapCylinder&, float&);
 void CheckLineCylinder(const Vec&, const Vec&, const CMapCylinder&, float&);
 
 class CMapCylinder

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -40,14 +40,14 @@ CMapHitFace* g_hit_lpface_min;
  * JP Address: TODO
  * JP Size: TODO
  */
-void FindIntersection(const Vec& start, const Vec& direction, const CMapCylinder& cyl, float& outT)
+int FindIntersection(const Vec& start, const Vec& direction, const CMapCylinder& cyl, float& outT)
 {
-    outT = -1.0f;
+    outT = 0.0f;
 
     Vec axis = cyl.m_direction2;
     f32 axisLen = PSVECMag(&axis);
     if (axisLen <= 0.0f) {
-        return;
+        return 0;
     }
     PSVECScale(&axis, &axis, 1.0f / axisLen);
 
@@ -134,6 +134,7 @@ void FindIntersection(const Vec& start, const Vec& direction, const CMapCylinder
     }
 
     outT = bestT;
+    return bestT >= 0.0f;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Change `FindIntersection` to return an `int` success flag, matching the PAL function shape without changing the mangled symbol name.
- Initialize the output intersection parameter to zero before the calculation, matching the target failure-path shape.

## Evidence
- `ninja` completes successfully; `build/GCCP01/main.dol: OK`.
- `main/maphit` `.text`: 41.344997% -> 41.613922%.
- `FindIntersection__FRC3VecRC3VecRC12CMapCylinderRf`: 31.667244% -> 32.892548%.
- Nearby selected targets unchanged: `CalcHitSlide__7CMapHitFP3Vecf` 19.464602%, `CheckHitFaceCylinder__7CMapHitFUl` 17.539131%.

## Plausibility
- Ghidra shows `FindIntersection` returning a success value; the return type is ABI-safe for the existing symbol because C++ return types are not part of this mangled name.
- The change replaces a void-only helper contract with the observed boolean-style contract rather than adding output-forcing hacks.