### PR TITLE
Match pppBreathModel BirthParticle

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -162,6 +162,12 @@ struct BreathParticleData {
     u8 _pad91[0x07];
 };
 
+struct BreathParticleObject {
+    _pppPObjLink m_link;
+    s32 m_graphId;
+    pppFMATRIX m_localMatrix;
+};
+
 /*
  * --INFO--
  * PAL Address: UNUSED
@@ -895,6 +901,7 @@ extern "C" void BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VC
     _pppPObject* pppObject, VBreathModel* vBreathModel, PBreathModel* pBreathModel, VColor* vColor,
     PARTICLE_DATA* particleData, PARTICLE_WMAT* particleWmat, PARTICLE_COLOR* particleColor)
 {
+    BreathParticleObject* object = reinterpret_cast<BreathParticleObject*>(pppObject);
     PBreathModel* params = reinterpret_cast<PBreathModel*>(pBreathModel);
     BreathParticleData* particle = reinterpret_cast<BreathParticleData*>(particleData);
     Mtx workMtx;
@@ -1052,7 +1059,7 @@ extern "C" void BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VC
     (*(Mtx*)particleWmat)[1][3] = pos.y;
     (*(Mtx*)particleWmat)[2][3] = pos.z;
 
-    PSMTXConcat(*(Mtx*)particleWmat, pppObject->m_localMatrix.value, *(Mtx*)particleData);
+    PSMTXConcat(*(Mtx*)particleWmat, object->m_localMatrix.value, *(Mtx*)particleData);
     PSMTXConcat(ppvCameraMatrix02, *(Mtx*)particleData, cameraMtx);
 
     particle->m_direction.x = kPppBreathModelZero;


### PR DESCRIPTION
## Summary
- Add a linked-object view for BirthParticle's ppp object parameter so its local matrix is read from the target 0x10 offset.
- This removes the remaining non-relocation instruction mismatch in BirthParticle.

## Evidence
- ninja passes with build/GCCP01/main.dol: OK
- build/tools/objdiff-cli diff -p . -u main/pppBreathModel -c functionRelocDiffs=none -o /tmp/pppBreath_birth_final_noreloc.json BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR reports 100.0%
- build/GCCP01/report.json now lists BirthParticle at 100.0% and pppBreathModel code progress at 96.31004%

## Plausibility
- Several PPP matrix helpers already operate on object + 0x10 for the callback object matrix. Keeping this view local avoids disturbing wrapper structs that still match with the existing shared _pppPObject layout.