### PR TITLE
Tighten tracer texture index locals

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -114,7 +114,7 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
     f32 uTop;
     f32 uBottom;
     f32 uvStep;
-    int textureIndex[2];
+    int textureIndex;
 
     dataValIndex = param_2->m_dataValIndex;
     dataOffset = *param_3->m_serializedDataOffsets;
@@ -131,9 +131,9 @@ void pppRenderYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYm
             param_2->m_payload[0xC], param_2->m_payload[0xB], param_2->m_payload[10], 0, 1, 1, 0);
         SetVtxFmt_POS_CLR_TEX__5CUtilFv(&gUtil);
 
-        textureIndex[0] = 0;
+        textureIndex = 0;
         texture = (CTexture*)GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr,
-                                                                     textureIndex[0]);
+                                                                     textureIndex);
         if (texture != 0) {
             GXLoadTexObj(&texture->m_texObj, GX_TEXMAP0);
             GXSetNumChans(1);

--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -117,7 +117,7 @@ void pppRenderYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, p
     f32 uTop;
     f32 uBottom;
     f32 uvStep;
-    int textureIndex[2];
+    int textureIndex;
 
     dataValIndex = param_2->m_dataValIndex;
     dataOffset = *param_3->m_serializedDataOffsets;
@@ -134,9 +134,9 @@ void pppRenderYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, p
             param_2->m_payload[0xC], param_2->m_payload[0xB], param_2->m_payload[10], 0, 1, 1, 0);
         SetVtxFmt_POS_CLR_TEX__5CUtilFv(&gUtil);
 
-        textureIndex[0] = 0;
+        textureIndex = 0;
         texture = (CTexture*)GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, pppEnvStPtr->m_materialSetPtr,
-                                                                     textureIndex[0]);
+                                                                     textureIndex);
         if (texture != 0) {
             GXLoadTexObj(&texture->m_texObj, GX_TEXMAP0);
             GXSetNumChans(1);


### PR DESCRIPTION
## Summary
- replace the temporary `textureIndex[2]` arrays in `pppRenderYmTracer` and `pppRenderYmTracer2` with plain `int` locals
- keep the original behavior while matching the by-reference `GetTexture` usage already used in sibling particle renderers

## Evidence
- `pppRenderYmTracer`: `98.72609%` -> `98.76087%`
- `pppFrameYmTracer`: `94.734566%` -> `95.47325%`
- `pppRenderYmTracer2`: `97.95122%` -> `98.00813%`
- `pppFrameYmTracer2`: unchanged at `97.51798%`
- `ninja -j4`: passes

## Why this is plausible
- `GetTexture__8CMapMeshFP12CMaterialSetRi` takes an `int&`, and nearby effect code consistently stages that out-parameter with a single local `int`
- removing the unnecessary two-slot arrays improves stack layout without introducing any compiler coaxing or fake linkage