### PR TITLE
Match CModel texture set attach

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -7,6 +7,7 @@
 #include "ffcc/p_camera.h"
 #include "ffcc/p_light.h"
 #include "ffcc/texanim.h"
+#include "ffcc/textureman.h"
 
 #include <PowerPC_EABI_Support/Runtime/MWCPlusLib.h>
 #include <math.h>
@@ -2281,8 +2282,8 @@ void CChara::CModel::AttachTextureSet(CTextureSet* texSet)
 			int* refData = reinterpret_cast<int*>(oldTexSet);
 			int refCount = refData[1] - 1;
 			refData[1] = refCount;
-			if ((refCount == 0) && (oldTexSet != 0)) {
-				(*(void (**)(void*, int))(*refData + 8))(oldTexSet, 1);
+			if (refCount == 0) {
+				delete oldTexSet;
 			}
 			m_texSet = 0;
 		}


### PR DESCRIPTION
## Summary
- Include the complete CTextureSet definition in chara.cpp so AttachTextureSet can use the normal C++ delete expression.
- Replace the hand-written vtable destructor call with delete oldTexSet when the texture-set refcount reaches zero.

## Objdiff
- main/chara AttachTextureSet__Q26CChara6CModelFP11CTextureSet: 99.77273% -> 100.0% (diff_count 2 -> 0), size 176b.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara -o - AttachTextureSet__Q26CChara6CModelFP11CTextureSet

## Plausibility
- CTextureSet derives from CRef and has a virtual destructor, so delete oldTexSet naturally emits the same deleting-destructor dispatch instead of manually spelling the vtable call.