### PR TITLE
Improve GbaQueue SetQueue match

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -108,6 +108,15 @@ struct GbaQueueCMakeInfoView
 };
 STATIC_ASSERT(sizeof(GbaQueueCMakeInfoView) == 0x20);
 
+struct GbaQueueSetQueueView
+{
+	unsigned char _pad00[0x30];
+	unsigned int m_queue[4][0x40];
+	int m_queueCount[4];
+	char m_queueFull[4];
+};
+STATIC_ASSERT(sizeof(GbaQueueSetQueueView) == 0x444);
+
 static inline GbaQueueFlagView* GetFlagView(GbaQueue* gbaQueue)
 {
 	return reinterpret_cast<GbaQueueFlagView*>(gbaQueue);
@@ -580,23 +589,23 @@ void GbaQueue::LoadMask()
  */
 int GbaQueue::SetQueue(int channel, unsigned int value)
 {
-	char* obj = reinterpret_cast<char*>(this);
+	GbaQueueSetQueueView* queue = reinterpret_cast<GbaQueueSetQueueView*>(this);
 	OSSemaphore* semaphore = accessSemaphores + channel;
 	int ret;
 
 	OSWaitSemaphore(semaphore);
-	if (obj[0x440 + channel] == 0) {
-		int* queueCount = reinterpret_cast<int*>(obj + 0x430 + channel * 4);
-		if (*queueCount < 0x40) {
-			ret = 0;
-			reinterpret_cast<unsigned int*>(obj + 0x30 + channel * 0x100)[*queueCount] = value;
-			*queueCount = *queueCount + 1;
-		} else {
-			ret = -1;
-			obj[0x440 + channel] = 1;
-		}
-	} else {
+	if (queue->m_queueFull[channel] != 0) {
 		ret = -1;
+	} else {
+		int* queueCount = &queue->m_queueCount[channel];
+		if (*queueCount >= 0x40) {
+			ret = -1;
+			queue->m_queueFull[channel] = 1;
+		} else {
+			ret = 0;
+			queue->m_queue[channel][*queueCount] = value;
+			*queueCount = *queueCount + 1;
+		}
 	}
 	OSSignalSemaphore(semaphore);
 	return ret;


### PR DESCRIPTION
## Summary
- Add a local queue layout view for GbaQueue queue buffers, counts, and full flags.
- Rewrite SetQueue branch order to match the target control flow while keeping the same behavior.
- Replace raw byte-offset writes in SetQueue with member-array access.

## Evidence
- ninja passes for GCCP01.
- objdiff SetQueue__8GbaQueueFiUi: 50.7% -> 94.69388%, size remains 196 bytes.
- main/gbaque fuzzy score is now 73.58994% in build/GCCP01/report.json.

## Plausibility
- The new view names the queue data layout already implied by offsets 0x30, 0x430, and 0x440.
- The branch rewrite follows the decompiled target shape without adding manual sectioning, fake symbols, or address hacks.