### PR TITLE
Clean up material editor spinner globals

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -30,10 +30,12 @@ extern "C" char lbl_8032E648[];
 extern "C" const char s_CMaterialEditorPcs_VIEWER_801D7D18[];
 extern "C" const char s_CMaterialEditorPcs_801D7D34[];
 extern "C" const char s_MaterialEditor_pctc_801D7D60[];
-extern "C" const char* gDebugSpinnerText_addr = 0;
-extern "C" char gDebugSpinnerTextInitialized_addr = 0;
-extern "C" int gDebugSpinnerFrame_addr = 0;
-extern "C" char gDebugSpinnerFrameInitialized_addr = 0;
+extern "C" {
+const char* gDebugSpinnerText_addr;
+char gDebugSpinnerTextInitialized_addr;
+int gDebugSpinnerFrame_addr;
+char gDebugSpinnerFrameInitialized_addr;
+}
 
 unsigned int m_table_desc0__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__18CMaterialEditorPcsFv)};
 unsigned int m_table_desc1__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__18CMaterialEditorPcsFv)};


### PR DESCRIPTION
## Summary
- Convert the material editor debug spinner globals from initialized extern definitions to normal C-linkage definitions.
- Keeps the same symbol names and zero-initialized .sbss layout while removing an extern-definition hack.

## Evidence
- ninja
- objdiff main/p_MaterialEditor drawViewer__18CMaterialEditorPcsFv remains 67.233376%.
- .sbss remains 16 bytes at 100%.
- gDebugSpinnerText_addr, gDebugSpinnerTextInitialized_addr, gDebugSpinnerFrame_addr, and gDebugSpinnerFrameInitialized_addr remain 100% matched.

## Plausibility
These globals are storage definitions, not external declarations. Wrapping the definitions in an extern "C" block preserves C linkage and matches normal source style without affecting layout or codegen.