### PR TITLE
Improve YmMiasma particle init match

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -522,7 +522,6 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     float radiusJitter;
     float randomScale;
     Vec basePos;
-    Vec normalizedPos;
     u32 angleBase;
     u32 signBit;
     float speedJitter;
@@ -562,7 +561,7 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     trigCos = trigSin * (vYmMiasma->m_radius + radiusJitter);
     particleData->m_matrix[0][2] = trigCos;
     particleData->m_matrix[1][2] = trigCos;
-    pppCopyVector(normalizedPos, *(Vec*)particleData->m_matrix[1]);
+    Vec normalizedPos = *(Vec*)particleData->m_matrix[1];
     pppNormalize__FR3Vec3Vec(particleData->m_matrix[1], &normalizedPos);
     if ((s32)Game.m_currentSceneId != 7) {
         basePos.x = pppMngStPtr->m_matrix.value[0][3];


### PR DESCRIPTION
Summary:
- Narrow the normalized position temporary in `InitParticleData` so the compiler emits the original stack/lifetime shape instead of keeping a wider function-scope temp.
- This removes the extra vector-copy call shape in `pppYmMiasma` while keeping the code as normal source.

Objdiff evidence:
- Unit: `main/pppYmMiasma`
- `InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP14_PARTICLE_DATA`: 88.54128% -> 90.11009%

Verification:
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o - pppRenderYmMiasma`