### PR TITLE
Fix YmBreath param rotation padding

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -71,7 +71,7 @@ struct YmBreathParams {
     float m_colorFrameAccel1;
     float m_colorFrameAccel2;
     float m_colorFrameAccel3;
-    unsigned char _pad48[0x08];
+    unsigned char _pad4C[0x04];
     float m_rotationStartX;
     float m_rotationStartY;
     unsigned char _pad58[0x08];


### PR DESCRIPTION
## Summary
- Correct the YmBreath parameter padding before the rotation fields so m_rotationStartX begins at offset 0x50, matching the Ghidra/PAL access pattern.
- This shifts the subsequent rotation fields back into the expected layout and improves nearby particle update/birth codegen.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR
- UpdateParticle__FP9VYmBreathP9PYmBreathP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR: 97.00000% -> 97.05882%
- BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR: 86.46329% -> 86.51646%

## Plausibility
- The removed padding byte range was placing rotation parameters four bytes later than the decompiled PAL field accesses at 0x50 and 0x54.
- The change is a normal struct layout correction, with no manual sectioning, vtable forcing, address hardcoding, or compiler coaxing.
