### PR TITLE
Improve particle birth matching

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -46,7 +46,9 @@ struct pppBreathModelUnkC {
 };
 
 struct pppBreathModel {
-    unsigned char _pad[8];
+    s32 m_graphId;
+    unsigned char _pad04[0x0C];
+    pppFMATRIX m_localMatrix;
 };
 
 struct BreathParticleGroup {
@@ -1052,7 +1054,7 @@ extern "C" void BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VC
     (*(Mtx*)particleWmat)[1][3] = pos.y;
     (*(Mtx*)particleWmat)[2][3] = pos.z;
 
-    PSMTXConcat(*(Mtx*)particleWmat, pppObject->m_localMatrix.value, *(Mtx*)particleData);
+    PSMTXConcat(*(Mtx*)particleWmat, reinterpret_cast<pppBreathModel*>(pppObject)->m_localMatrix.value, *(Mtx*)particleData);
     PSMTXConcat(ppvCameraMatrix02, *(Mtx*)particleData, cameraMtx);
 
     particle->m_direction.x = kPppBreathModelZero;

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -115,11 +115,15 @@ void birth(
 	u8* particlePayload;
 	u8 mode;
 	float speed;
+	float spread;
+	float range;
 	s16 life;
 
 	payload = (u8*)param;
 	particlePayload = (u8*)particle;
 	mode = payload[0x2A];
+	spread = (float)payload[0x2B];
+	range = FLOAT_80330470 * spread;
 
 	memset(particle, 0, 0x60);
 	if (worldMat != NULL) {
@@ -134,14 +138,10 @@ void birth(
 		Vec* direction;
 		pppIVECTOR4 angle;
 		pppFMATRIX rot;
-		float spread;
-		float range;
 
 		baseDirection.x = *f32_at(payload, 0xA0);
 		baseDirection.y = *f32_at(payload, 0xA4);
 		baseDirection.z = *f32_at(payload, 0xA8);
-		spread = (float)payload[0x2B];
-		range = FLOAT_80330470 * spread;
 
 		angle.x = (s16)(range * Math.RandF() - spread);
 		angle.y = (s16)(range * Math.RandF() - spread);


### PR DESCRIPTION
Summary:
- Hoist Ryj Mega Birth spread/range setup before particle buffer clears to match the original instruction schedule.
- Give pppBreathModel its local matrix field at 0x10 and use it when composing BirthParticle matrices.

Objdiff evidence:
- main/pppRyjMegaBirth .text: 62.76032% -> 63.26753%
- birth__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR: 56.857655% -> 57.770813%
- main/pppBreathModel .text: 96.18153% -> 96.18216%
- BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR: 99.69133% -> 99.69388%

Validation:
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRyjMegaBirth -o /tmp/pppRyjMegaBirth_after.json birth__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR
- build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o /tmp/pppBreathModel_after_patch.json BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR

Plausibility:
- The Ryj change only extends the lifetime of values read from the parameter payload; behavior is unchanged and the ordering matches the original codegen better.
- The BreathModel change replaces an inherited object-layout assumption with the local particle object layout: graph id, padding, then the local matrix at 0x10.