### PR TITLE
Improve pppYmTracer frame matching

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -266,16 +266,10 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
             TRACE_POLYGON* current = &entries[i];
             TRACE_POLYGON* next = &entries[i + 1];
 
-            pppCopyVector(next->from, current->from);
-            pppCopyVector(next->to, current->to);
-            next->life = current->life;
-            next->decay = current->decay;
-            next->colorR = current->colorR;
-            next->colorG = current->colorG;
-            next->colorB = current->colorB;
-            next->alpha = current->alpha;
+            copyPolygonData(next, current);
         }
 
+        entries = work->entries;
         entries[0].life = -1;
         entries[0].alpha = param_2->m_payload[8];
         entries[0].decay = (u8)((u16)param_2->m_payload[8] / *(u16*)(param_2->m_payload + 6));


### PR DESCRIPTION
## Summary
- Use the existing TRACE_POLYGON copy helper in the pppYmTracer history shift loop.
- Reload the entries pointer from the tracer work block before rebuilding the head entry, matching the target control/data flow more closely.

## Objdiff Evidence
- Unit: main/pppYmTracer
- pppFrameYmTracer: 95.47325% -> 96.19341%
- .text: 96.721634% -> 97.18338%
- Current pppFrameYmTracer size: 1932b -> 1936b, closer to target 1944b

## Plausibility
- The change reuses an existing local helper that already captures the full TRACE_POLYGON copy semantics.
- The explicit entries reload reflects the work-block ownership of the allocated entry array and matches the surrounding decompiled flow without hardcoded addresses or fake symbols.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmTracer -o -