### PR TITLE
Avoid CGamePcs descriptor data in PPP units

### DIFF
--- a/src/pppCallBackDistance.cpp
+++ b/src/pppCallBackDistance.cpp
@@ -1,7 +1,6 @@
 #include "ffcc/pppCallBackDistance.h"
 #include "ffcc/partMng.h"
 #include "ffcc/game.h"
-#include "ffcc/p_game.h"
 #include <dolphin/mtx.h>
 
 extern "C" {
@@ -98,5 +97,3 @@ void pppConstructCallBackDistance(pppCallBackDistance* param1, pppCallBackDistan
     local_1c.z = *(f32*)(pppMngSt + 0x70);
     *distancePtr = PSVECDistance(&local_28, &local_1c);
 }
-
-

--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -1,5 +1,5 @@
 #include "ffcc/pppConstrainCameraForLoc.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/p_camera.h"
 #include "ffcc/partMng.h"
 extern "C" {

--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -2,7 +2,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/memory.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/pppPart.h"
 
 #include <dolphin/gx.h>

--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -3,7 +3,7 @@
 #include "ffcc/render_buffers.h"
 #include "ffcc/mapmesh.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/util.h"
 

--- a/src/pppDrawMng.cpp
+++ b/src/pppDrawMng.cpp
@@ -3,7 +3,7 @@
 #include "ffcc/graphic.h"
 #include "ffcc/linkage.h"
 #include "ffcc/p_chara.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
 extern "C" {

--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -4,7 +4,7 @@
 #include "ffcc/gobject.h"
 #include "ffcc/linkage.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/pppYmEnv.h"
 #include "ffcc/util.h"

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppPart.h"
 
 #include "ffcc/map.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/p_tina.h"
 #include "ffcc/memory.h"
 #include "ffcc/sound.h"

--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppRain.h"
 #include "ffcc/memory.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/partMng.h"
 #include "ffcc/pppPart.h"
 extern "C" {

--- a/src/pppYmCallBack.cpp
+++ b/src/pppYmCallBack.cpp
@@ -1,7 +1,6 @@
 #include "ffcc/pppYmCallBack.h"
 #include "ffcc/game.h"
 #include "ffcc/partMng.h"
-#include "ffcc/p_game.h"
 
 #include <dolphin/mtx.h>
 

--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -1,7 +1,7 @@
 #include "ffcc/pppYmEnv.h"
 #include "ffcc/gobject.h"
 #include "ffcc/mapmesh.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/partMng.h"
 #include "ffcc/graphic.h"
 #include "ffcc/pppGetRotMatrixXYZ.h"

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -4,7 +4,7 @@
 #include "ffcc/gobject.h"
 #include "ffcc/linkage.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/pppYmEnv.h"
 


### PR DESCRIPTION
## Summary
- Replace broad p_game.h includes with game.h in PPP units that only need the CGame interface.
- Removes unrelated CGamePcs constructor descriptor local statics from those object files.
- Keeps generated code behavior unchanged while preventing wrong .data emission in these units.

## Evidence
- ninja completes and build/GCCP01/main.dol validates OK.
- Verified affected objects now report .data=0 and CGamePcs local statics=0 for pppCrystal, pppCrystal2, pppMana2, pppRain, pppPart, pppConstrainCameraForLoc, pppCallBackDistance, pppDrawMng, pppYmMana, pppYmEnv, and pppYmCallBack.
- agent_select_target now reports main/pppCrystal2 data at 100.00%, and pppCrystal no longer appears as a data opportunity.

## Plausibility
These files reference Game fields or methods, but none uses GamePcs or CGamePcs construction. Pulling in game.h directly matches that dependency and avoids emitting constructor helper data from p_game.h in unrelated PPP objects.