### PR TITLE
Match BreathModel birth particle matrix access

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -162,6 +162,11 @@ struct BreathParticleData {
     u8 _pad91[0x07];
 };
 
+static inline Mtx& PppObjectLocalMatrix(_pppPObject* object)
+{
+    return *reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(object) + 0x10);
+}
+
 /*
  * --INFO--
  * PAL Address: UNUSED
@@ -1052,7 +1057,7 @@ extern "C" void BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VC
     (*(Mtx*)particleWmat)[1][3] = pos.y;
     (*(Mtx*)particleWmat)[2][3] = pos.z;
 
-    PSMTXConcat(*(Mtx*)particleWmat, pppObject->m_localMatrix.value, *(Mtx*)particleData);
+    PSMTXConcat(*(Mtx*)particleWmat, PppObjectLocalMatrix(pppObject), *(Mtx*)particleData);
     PSMTXConcat(ppvCameraMatrix02, *(Mtx*)particleData, cameraMtx);
 
     particle->m_direction.x = kPppBreathModelZero;


### PR DESCRIPTION
## Summary
- Use the particle object local matrix at the observed object-layout offset when composing BreathModel birth particle matrices.
- Isolate the layout access behind a small helper in src/pppBreathModel.cpp.

## Evidence
- ninja passes.
- main/pppBreathModel matched code increased to 1936 bytes, matched functions 3/7.
- Overall matched code increased to 508324 bytes and matched functions to 3151/4732.
- BirthParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR reports 100.0 fuzzy match in build/GCCP01/report.json.

## Plausibility
- Existing matched code such as pppDrawMatrix accesses _pppPObject matrix data at the same 0x10 layout offset, and this change applies that layout only to the BreathModel birth path that needed it.