### PR TITLE
Improve YmBreath particle matching

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1669,8 +1669,9 @@ void CCameraPcs::drawShadowChrBegin()
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
 
     if (self[0x404] != 0) {
-        *reinterpret_cast<float*>(self + 0x3E0) *= FLOAT_8032fa58;
-        *reinterpret_cast<float*>(self + 0x3F0) *= FLOAT_8032fa58;
+        float scale;
+        *reinterpret_cast<float*>(self + 0x3E0) *= (scale = FLOAT_8032fa58);
+        *reinterpret_cast<float*>(self + 0x3F0) *= scale;
         PSMTXConcat(reinterpret_cast<MtxPtr>(self + 0x3D4),
                     reinterpret_cast<MtxPtr>(self + 0x214),
                     reinterpret_cast<MtxPtr>(self + 0x3A4));

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -71,7 +71,7 @@ struct YmBreathParams {
     float m_colorFrameAccel1;
     float m_colorFrameAccel2;
     float m_colorFrameAccel3;
-    unsigned char _pad48[0x08];
+    unsigned char _pad48[0x04];
     float m_rotationStartX;
     float m_rotationStartY;
     unsigned char _pad58[0x08];
@@ -858,7 +858,7 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, _PARTICLE_DATA* 
 
     particle->m_scale += params->m_scaleAccel;
     if (params->m_disableScaleClamp == 0) {
-        float zero = 0.0f;
+        float zero = FLOAT_80330c80;
         if (zero < params->m_scaleClampStart) {
             if (params->m_scaleAccel < zero) {
                 if (particle->m_scale < zero) {
@@ -924,8 +924,8 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         memset(particleColor, 0, 0x20);
     }
 
-    baseDir.x = 0.0f;
-    baseDir.y = 0.0f;
+    baseDir.x = FLOAT_80330c80;
+    baseDir.y = FLOAT_80330c80;
     baseDir.z = FLOAT_80330C90;
 
     angle[0] = (int)((float)((int)(range * Math.RandF() - spread) << 15) / FLOAT_80330C98);

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1227,13 +1227,13 @@ void CSound::CrossPlayBgm(int bgmId, int crossFrames)
  */
 void CSound::PlayNextBgm(int bgmId)
 {
-    CSound* sound = this;
+    CRedSound* redSound = RedSound(this);
 
     if (bgmId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
-        MusicNextPlay__9CRedSoundFiii(RedSound(sound), bgmId, 0x7F, 0);
-        SetMusicPhraseStop__9CRedSoundFi(RedSound(sound), 1);
+        MusicNextPlay__9CRedSoundFiii(redSound, bgmId, 0x7F, 0);
+        SetMusicPhraseStop__9CRedSoundFi(redSound, 1);
     }
 }
 


### PR DESCRIPTION
## Summary
- Corrected the late YmBreath parameter layout around the rotation fields by shrinking the padding after the color acceleration values.
- Reused the shared zero constant in particle scale clamping and birth direction initialization.

## Evidence
- Built with `ninja` successfully.
- `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -`:
  - `.text`: 92.83911% -> 92.86633%
  - `UpdateParticle__FP9VYmBreathP9PYmBreathP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`: 97.0% -> 97.08145%
  - `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP14_PARTICLE_DATAPA3_A4_fP15_PARTICLE_COLOR`: 86.46329% -> 86.52911%

## Plausibility
- The layout change removes excess padding in the recovered `YmBreathParams` structure and aligns subsequent member accesses with the target object.
- The constant changes use existing shared sdata2 symbols already used elsewhere in this unit, rather than introducing manual sections or compiler-forcing hacks.