### PR TITLE
Improve ExecScenegraph pad trigger types

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -281,8 +281,8 @@ void CSystem::ExecScenegraph()
 
     do
     {
-        int stepTrigger;
-        int perfTrigger;
+        u16 stepTrigger;
+        u16 perfTrigger;
 
         if (Game.m_gameWork.m_singleShopOrSmithMenuActiveFlag != Game.m_gameWork.m_gamePaused)
         {
@@ -354,8 +354,8 @@ void CSystem::ExecScenegraph()
         {
             for (int port = 0; port < 4; port++)
             {
-                int trigger;
-                int held;
+                u16 trigger;
+                u16 held;
                 bool noInput;
 
                 noInput = false;


### PR DESCRIPTION
## Summary
- Use u16 locals for ExecScenegraph pad trigger/held values read from the pad buffer.
- This matches the underlying halfword data and improves generated code for main/system.

## Objdiff
- ExecScenegraph__7CSystemFv: 97.45946% -> 97.554054%
- main/system .text: 98.83467% -> 98.869736%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/system -o - ExecScenegraph__7CSystemFv