### PR TITLE
Improve TmpArtiCtrl input branch shape

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -359,9 +359,7 @@ unsigned int CMenuPcs::TmpArtiClose()
 void CMenuPcs::TmpArtiCtrl()
 {
 	bool hasInput;
-	float fVar2;
 	unsigned short uVar3;
-	unsigned int uVar4;
 	unsigned int uVar5;
 	int iVar6;
 	int iVar7;
@@ -403,9 +401,10 @@ void CMenuPcs::TmpArtiCtrl()
 		hasInput = false;
 	}
 
-	fVar2 = FLOAT_80332f30;
-	uVar4 = Game.m_scriptFoodBase[0];
 	if (hasInput) {
+		float fVar2 = FLOAT_80332f30;
+		unsigned int uVar4 = Game.m_scriptFoodBase[0];
+
 		iVar6 = reinterpret_cast<int>(this->m_tmpArtiList) + 8;
 		for (iVar7 = 0; iVar7 < *this->m_tmpArtiList; iVar7 = iVar7 + 1) {
 			*(float *)(iVar6 + 0x10) = fVar2;


### PR DESCRIPTION
## Summary
- Move TmpArtiCtrl's zero-alpha value and script-food base load into the input-handling branch.
- This matches the expected branch shape more closely by avoiding work on the no-input path.

## Evidence
- ninja passes.
- main/menu_tmparti .text: 70.72011% -> 71.646515%.
- TmpArtiCtrl__8CMenuPcsFv: 72.0% -> 75.79032%.
- .sdata2 remains 100.0%.

## Plausibility
- The source now keeps values local to the only branch that uses them, which is a natural original-source lifetime reduction rather than a compiler coaxing hack.