### PR TITLE
Fix YmEnv character handle selection

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -466,13 +466,13 @@ CCharaPcs::CHandle* GetCharaHandlePtr(CGObject* gObject, long modelType)
                 return gObject->m_charaModelHandle;
             }
         } else if (modelType < 3) {
-            if (gObject->m_shieldModelHandle != 0) {
-                return gObject->m_shieldModelHandle;
+            if (gObject->m_weaponModelHandle != 0) {
+                return gObject->m_weaponModelHandle;
             }
         }
     } else {
-        if (gObject->m_weaponModelHandle != 0) {
-            return gObject->m_weaponModelHandle;
+        if (gObject->m_shieldModelHandle != 0) {
+            return gObject->m_shieldModelHandle;
         }
     }
 


### PR DESCRIPTION
## Summary
- update GetCharaHandlePtr to return the target-backed handles for modelType 1 and 2
- keeps the existing 104-byte control-flow shape while correcting the 0xFC/0x100 field loads

## Evidence
- ninja passes
- objdiff for main/pppYmEnv GetCharaHandlePtr__FP8CGObjectl improves from 79.53846% to 79.61539%
- function size remains 104 bytes

## Plausibility
- the change follows the target assembly's CGObject field offsets for the helper instead of adding compiler coaxing or address hacks