### PR TITLE
Improve pppYmDeformationShp render sizing

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -149,7 +149,7 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
 		GXSetIndTexMtx(GX_ITM_0, indMtx, 1);
 
 		if (param_2->m_splitMode == 0) {
-			short size = param_2->m_size;
+			u8 size = param_2->m_size;
 			float quadSize = (float)size;
 			if (param_2->m_orientation == 0) {
 				vertices[0].x = -quadSize;


### PR DESCRIPTION
## Summary
- Use a byte-sized local for the non-split pppYmDeformationShp quad size.
- Matches the serialized field width and removes extra signed promotion in the render path.

## Objdiff Evidence
- main/pppYmDeformationShp .text: 89.89709% -> 90.15572%
- pppRenderYmDeformationShp: 94.63636% -> 95.16254%
- RenderDeformationShape unchanged at 82.928795%

## Verification
- ninja