### PR TITLE
Fix pppScreenBreak vector linkage

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -100,7 +100,7 @@ extern const float FLOAT_80331cec = 4.0f;
 extern const float FLOAT_80331cf0 = -3.0f;
 extern const float FLOAT_80331cf4 = 0.5f;
 
-static const Vec DAT_801dd4b0 = { 0.0f, 1.0f, 0.0f };
+extern const Vec DAT_801dd4b0;
 static const Vec DAT_801dd4bc = { 0.0f, 1.0f, 0.0f };
 static const char s_f999_root_801dd4c8[] = "f999_root";
 static const char s_pppScreenBreak_cpp_801dd4d4[] = "pppScreenBreak.cpp";


### PR DESCRIPTION
## Summary
- Treat DAT_801dd4b0 as the existing configured rodata symbol instead of defining a duplicate local vector in pppScreenBreak.cpp.
- Keep DAT_801dd4bc as the local vector used by InitPieceData.

## Evidence
- ninja succeeds.
- objdiff command: build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv
- SB_BeforeCalcMatrixCallback: 95.44444% before, 95.44444% after.
- [.rodata-0]: 86.86868% before, 98.85057% after.
- .text: 92.615524% before, 92.615524% after.

## Plausibility
- config/GCCP01/symbols.txt already owns DAT_801dd4b0 at .rodata:0x801DD4B0.
- build/GCCP01/asm/pppScreenBreak.s references DAT_801dd4b0 in SB_BeforeCalcMatrixCallback, while this object defines DAT_801dd4bc for InitPieceData.