### PR TITLE
Improve CFlatRuntime free list relinking

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -136,8 +136,9 @@ void CFlatRuntime::Destroy()
 		*reinterpret_cast<void**>(reinterpret_cast<u8*>(*object->m_freeListNode) + 4) = object->m_freeListNode[1];
 		*reinterpret_cast<void**>(object->m_freeListNode[1]) = *object->m_freeListNode;
 
-		object->m_freeListNode[1] = *m_objectFreeListHead;
-		*m_objectFreeListHead = object->m_freeListNode;
+		void** freeHead = m_objectFreeListHead;
+		object->m_freeListNode[1] = freeHead[0];
+		freeHead[0] = object->m_freeListNode;
 
 		object->m_flags &= 0xEF;
 
@@ -706,8 +707,9 @@ void CFlatRuntime::AfterFrame(int mode)
 			*reinterpret_cast<void**>(reinterpret_cast<u8*>(*object->m_freeListNode) + 4) = object->m_freeListNode[1];
 			*reinterpret_cast<void**>(object->m_freeListNode[1]) = *object->m_freeListNode;
 
-			object->m_freeListNode[1] = *m_objectFreeListHead;
-			*m_objectFreeListHead = object->m_freeListNode;
+			void** freeHead = m_objectFreeListHead;
+			object->m_freeListNode[1] = freeHead[0];
+			freeHead[0] = object->m_freeListNode;
 
 			object->m_flags &= 0xEF;
 
@@ -736,8 +738,9 @@ void CFlatRuntime::deleteObject(CFlatRuntime::CObject* object)
 	*(void**)((char*)*object->m_freeListNode + 4) = object->m_freeListNode[1];
 	*(void**)object->m_freeListNode[1] = *object->m_freeListNode;
 
-	object->m_freeListNode[1] = *m_objectFreeListHead;
-	*m_objectFreeListHead = object->m_freeListNode;
+	void** freeHead = m_objectFreeListHead;
+	object->m_freeListNode[1] = freeHead[0];
+	freeHead[0] = object->m_freeListNode;
 
 	object->m_flags &= 0xEF;
 


### PR DESCRIPTION
## Summary
- Route CFlatRuntime object free-list relinks through a local head pointer in Destroy, AfterFrame, and deleteObject.
- Keeps the existing structure and member layout while producing better codegen for the repeated unlink/relink sequence.

## Evidence
- Build: `ninja`
- Objdiff/report movement for `main/cflat_runtime`:
  - `AfterFrame__12CFlatRuntimeFi`: 88.45763% -> 90.15254%
  - `Destroy__12CFlatRuntimeFv`: 80.61539% -> 81.57692%
  - `deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject`: 86.44118% -> 89.38236%

## Plausibility
- The change expresses the free-list head as a local slot before updating the node links, matching a normal source-level linked-list relink pattern without hard-coded addresses or synthetic symbols.