### PR TITLE
Improve pppKeShpTail2X draw match

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -262,9 +262,8 @@ draw_loop:
 
     zEnable = (u32)__cntlzw((u32)step->m_zDisable) >> 5;
     pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc((void*)0, &drawMtx,
-                                                               (step->m_useEnvDepth != 0) ? step->m_envDepth : zero, 0,
+                                                               (step->m_useEnvDepth != 0) ? step->m_envDepth : kPppKeShpTail2XZero, 0,
                                                                step->m_drawA, step->m_blendMode, 0, zEnable, 1, 0);
-    GXLoadPosMtxImm(drawMtx.value, 0);
 
     {
         GXColor amb;


### PR DESCRIPTION
## Summary
- Remove the extra explicit GXLoadPosMtxImm call from pppKeShpTail2XDraw.
- Use the shared zero constant in the draw-env depth fallback so the generated code is closer to the target.

## Evidence
- ninja: passes
- objdiff main/pppKeShpTail2X pppKeShpTail2XDraw: 70.39198% -> 70.47216%
- unit .text match: 82.05938% -> 82.10796%

## Plausibility
- The draw environment setup already receives the matrix, and the target does not emit a separate GXLoadPosMtxImm call at this site.
- The depth fallback now uses the same TU-level zero constant used elsewhere in this function instead of reusing the local zero register.