### PR TITLE
Clean up pppChangeTex model access

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -85,7 +85,9 @@ struct ChangeTexModelRaw {
 	u8 _padB0[0x34];
 	ChangeTexWork* m_state;
 	pppChangeTexUnkB* m_step;
-	u8 _padEC[0x10];
+	u8 _padEC[0x8];
+	void* m_beforeDrawCallback;
+	u8 _padF8[0x4];
 	void (*m_drawMeshDlCallback)(CChara::CModel*, void*, void*, int, int, float (*)[4]);
 	u8 _pad100[0x4];
 	void (*m_afterDrawMeshCallback)(CChara::CModel*, void*, void*, int, float (*)[4]);
@@ -95,6 +97,7 @@ STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_data) == 0xA4);
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_meshes) == 0xAC);
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_state) == 0xE4);
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_step) == 0xE8);
+STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_beforeDrawCallback) == 0xF4);
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_drawMeshDlCallback) == 0xFC);
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_afterDrawMeshCallback) == 0x104);
 STATIC_ASSERT(offsetof(ChangeTexMeshData, m_vertexCount) == 0x14);
@@ -190,6 +193,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	u8* colorData = base + serializedDataOffsets[1] + 0x80;
 	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_charaObj, 0);
 	CChara::CModel* model0 = GetCharaModelPtr(handle0);
+	ChangeTexModelRaw* model0Raw = (ChangeTexModelRaw*)model0;
 
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
 	    changeTex, step->m_graphId, work->m_value0, work->m_value1, work->m_value2, step->m_initWOrk,
@@ -197,10 +201,10 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 
 	work->m_charaObj = (CGObject*)pppMngStPtr->m_charaObj;
 	work->m_context = pppEnvStPtr;
-	*(ChangeTexWork**)((char*)model0 + 0xE4) = work;
-	*(pppChangeTexUnkB**)((char*)model0 + 0xE8) = step;
-	*(void**)((char*)model0 + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
-	*(void**)((char*)model0 + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
+	model0Raw->m_state = work;
+	model0Raw->m_step = step;
+	model0Raw->m_drawMeshDlCallback = ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
+	model0Raw->m_afterDrawMeshCallback = ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
 
 	work->m_texture = GetTextureFromRSD__FiP9_pppEnvSt(step->m_dataValIndex, pppEnvStPtr);
 
@@ -209,17 +213,19 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 
 	CChara::CModel* model;
 	if ((handle1 != 0) && ((model = GetCharaModelPtr(handle1)), model != 0)) {
-		*(ChangeTexWork**)((char*)model + 0xE4) = work;
-		*(pppChangeTexUnkB**)((char*)model + 0xE8) = step;
-		*(void**)((char*)model + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
-		*(void**)((char*)model + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
+		ChangeTexModelRaw* modelRaw = (ChangeTexModelRaw*)model;
+		modelRaw->m_state = work;
+		modelRaw->m_step = step;
+		modelRaw->m_drawMeshDlCallback = ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
+		modelRaw->m_afterDrawMeshCallback = ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
 	}
 
 	if ((handle2 != 0) && ((model = GetCharaModelPtr(handle2)), model != 0)) {
-		*(ChangeTexWork**)((char*)model + 0xE4) = work;
-		*(pppChangeTexUnkB**)((char*)model + 0xE8) = step;
-		*(void**)((char*)model + 0xFC) = (void*)ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
-		*(void**)((char*)model + 0x104) = (void*)ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
+		ChangeTexModelRaw* modelRaw = (ChangeTexModelRaw*)model;
+		modelRaw->m_state = work;
+		modelRaw->m_step = step;
+		modelRaw->m_drawMeshDlCallback = ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2;
+		modelRaw->m_afterDrawMeshCallback = ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2;
 	}
 
 	if (step->m_payload[0] == 0) {
@@ -232,19 +238,19 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	}
 	work->m_texture = texObj;
 
-	int meshList = *(int*)((char*)model0 + 0xAC);
+	int meshList = (int)model0Raw->m_meshes;
 	if ((work->m_meshColorArrays == 0) && (work->m_displayListArrays == 0)) {
 		work->m_cachedValue = LoadFloat(FLOAT_80332020);
 		work->m_meshColorArrays = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-		    *(int*)(*(int*)((char*)model0 + 0xA4) + 0xC) << 2, pppEnvStPtr->m_stagePtr,
+		    model0Raw->m_data->m_meshCount << 2, pppEnvStPtr->m_stagePtr,
 		    const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x163);
 		work->m_displayListArrays = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-		    *(int*)(*(int*)((char*)model0 + 0xA4) + 0xC) << 2, pppEnvStPtr->m_stagePtr,
+		    model0Raw->m_data->m_meshCount << 2, pppEnvStPtr->m_stagePtr,
 		    const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x166);
 
 		int* meshColorArrays = (int*)work->m_meshColorArrays;
 		int arrayOffset = 0;
-		for (unsigned int meshIdx = 0; meshIdx < *(unsigned int*)(*(int*)((char*)model0 + 0xA4) + 0xC); meshIdx++) {
+		for (unsigned int meshIdx = 0; meshIdx < model0Raw->m_data->m_meshCount; meshIdx++) {
 			int meshHdr = *(int*)(meshList + 8);
 			if (strcmp((char*)meshHdr, DAT_80332024) == 0) {
 				CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl(
@@ -293,7 +299,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	float currentValue = work->m_value0 * (work->m_bboxMax.y - work->m_bboxMin.y) + work->m_bboxMin.y;
 
 	scale.u[0] = 0x43300000;
-	scale.u[1] = (1 << *(int*)(*(int*)((char*)model0 + 0xA4) + 0x34)) ^ 0x80000000;
+	scale.u[1] = (1 << model0Raw->m_data->m_frameShift) ^ 0x80000000;
 	short splitY = (short)(int)(currentValue * (float)(scale.d - LoadDouble(DOUBLE_80332030)));
 	if (work->m_cachedValue == currentValue) {
 		return;
@@ -306,8 +312,8 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	double alphaBase = (double)(LoadFloat(FLOAT_80332028) * ((float)(scale.d - LoadDouble(DOUBLE_80332038)) / LoadFloat(FLOAT_80332028)));
 
 	int arrayOffset = 0;
-	meshList = *(int*)((char*)model0 + 0xAC);
-	for (unsigned int meshIdx = 0; meshIdx < *(unsigned int*)(*(int*)((char*)model0 + 0xA4) + 0xC); meshIdx++) {
+	meshList = (int)model0Raw->m_meshes;
+	for (unsigned int meshIdx = 0; meshIdx < model0Raw->m_data->m_meshCount; meshIdx++) {
 		int pointOffset = 0;
 		int colorBase = *(int*)((u8*)work->m_meshColorArrays + arrayOffset);
 		int colorPtr = colorBase;
@@ -354,40 +360,40 @@ void pppDestructChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
 	void* handle0 = GetCharaHandlePtr__FP8CGObjectl(work->m_charaObj, 0);
 	void* handle1 = GetCharaHandlePtr__FP8CGObjectl(work->m_charaObj, 1);
 	void* handle2 = GetCharaHandlePtr__FP8CGObjectl(work->m_charaObj, 2);
-	u32 model = 0;
+	ChangeTexModelRaw* model = 0;
 
 	if (handle0 != 0) {
-		model = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle0);
-		*(void**)(model + 0xe4) = 0;
-		*(void**)(model + 0xe8) = 0;
-		*(void**)(model + 0xf4) = 0;
-		*(void**)(model + 0xfc) = 0;
-		*(void**)(model + 0x104) = 0;
+		model = (ChangeTexModelRaw*)GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle0);
+		model->m_state = 0;
+		model->m_step = 0;
+		model->m_beforeDrawCallback = 0;
+		model->m_drawMeshDlCallback = 0;
+		model->m_afterDrawMeshCallback = 0;
 	}
-	u32 model1;
-	if ((handle1 != 0) && ((model1 = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle1)), model1 != 0)) {
-		*(void**)(model1 + 0xe4) = 0;
-		*(void**)(model1 + 0xe8) = 0;
-		*(void**)(model1 + 0xf4) = 0;
-		*(void**)(model1 + 0xfc) = 0;
-		*(void**)(model1 + 0x104) = 0;
+	ChangeTexModelRaw* model1;
+	if ((handle1 != 0) && ((model1 = (ChangeTexModelRaw*)GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle1)), model1 != 0)) {
+		model1->m_state = 0;
+		model1->m_step = 0;
+		model1->m_beforeDrawCallback = 0;
+		model1->m_drawMeshDlCallback = 0;
+		model1->m_afterDrawMeshCallback = 0;
 	}
-	u32 model2;
-	if ((handle2 != 0) && ((model2 = GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle2)), model2 != 0)) {
-		*(void**)(model2 + 0xe4) = 0;
-		*(void**)(model2 + 0xe8) = 0;
-		*(void**)(model2 + 0xf4) = 0;
-		*(void**)(model2 + 0xfc) = 0;
-		*(void**)(model2 + 0x104) = 0;
+	ChangeTexModelRaw* model2;
+	if ((handle2 != 0) && ((model2 = (ChangeTexModelRaw*)GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle2)), model2 != 0)) {
+		model2->m_state = 0;
+		model2->m_step = 0;
+		model2->m_beforeDrawCallback = 0;
+		model2->m_drawMeshDlCallback = 0;
+		model2->m_afterDrawMeshCallback = 0;
 	}
 
 	void** stageArray = (void**)work->m_displayListArrays;
 	void** meshArray;
 	if ((stageArray != 0) && ((meshArray = (void**)work->m_meshColorArrays), meshArray != 0)) {
-		int meshList = *(int*)(model + 0xac);
+		int meshList = (int)model->m_meshes;
 		void** curStageArray = stageArray;
 		void** curMeshArray = meshArray;
-		for (unsigned int i = 0; i < *(unsigned int*)(*(int*)(model + 0xA4) + 0xC); i++) {
+		for (unsigned int i = 0; i < model->m_data->m_meshCount; i++) {
 			int meshData = *(int*)(meshList + 8);
 			void** dlEntries = (void**)*curStageArray;
 			for (unsigned int j = 0; j < *(unsigned int*)(meshData + 0x4c); j++) {


### PR DESCRIPTION
## Summary
- Names the ChangeTex model callback slot at 0xF4 as m_beforeDrawCallback.
- Replaces repeated raw model callback/state stores in pppFrameChangeTex and pppDestructChangeTex with ChangeTexModelRaw member access.
- Uses existing model data fields for mesh count/frame shift access where the layout is already asserted.

## Evidence
- ninja: build/GCCP01/main.dol OK
- Objdiff for main/pppChangeTex is preserved:
  - pppRenderChangeTex: 100.0%
  - pppFrameChangeTex: 95.79566%
  - pppDestructChangeTex: 97.54074%
  - pppConstruct2ChangeTex: 100.0%
  - pppConstructChangeTex: 100.0%
  - ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f2: 95.639534%
  - ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f2: 90.88525%

## Plausibility
This keeps generated code stable while replacing raw offset writes with the struct layout already used by the ChangeTex callbacks and mirrored by pppYmChangeTex. The new 0xF4 field is backed by the existing destructor behavior that clears that callback slot.