### PR TITLE
Fix pppBlurChara double ownership

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -62,7 +62,7 @@ extern float FLOAT_8033104c;
 extern float FLOAT_80331050;
 extern float FLOAT_80331054;
 extern const double DOUBLE_80330FE8 = 3.0;
-extern const double DOUBLE_80331058 = 4503601774854144.0;
+extern const double DOUBLE_80331058;
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 


### PR DESCRIPTION
## Summary
- Treat DOUBLE_80331058 in pppBlurChara.cpp as an external shared constant instead of defining it in this unit.
- This matches the PAL split ownership: pppBlurChara.cpp owns .sdata2 80330FE8..80330FF0, while DOUBLE_80331058 is outside that range and owned later.

## Evidence
- ninja succeeds.
- main/pppBlurChara code scores are unchanged:
  - pppRenderBlurChara: 98.19726%, size 1460/1460
  - BlurChara_AfterDrawModelCallback__FPQ26CChara6CModelPvPv: 97.6679%, size 1084/1084
- .sdata2 improves:
  - before: target/current size 8/24, match 50.0%
  - after: target/current size 8/16, match 66.66667%

## Plausibility
- This removes an incorrect local definition and lets the reference resolve to the shared double at 80331058, consistent with the MAP/split data rather than adding padding or fake data.