### PR TITLE
Improve util display list rewrite matching

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -234,6 +234,7 @@ void CUtil::ReWriteDisplayList(void* dlData, unsigned long dlSize, unsigned long
 		u32 count = *(u16*)(current + 1);
 		u8 primitive = cmd & 0xF8;
 		u8 indexFormat = cmd & 7;
+		bool isPrimitive;
 		current += 3;
 
 		switch (primitive) {
@@ -244,9 +245,15 @@ void CUtil::ReWriteDisplayList(void* dlData, unsigned long dlSize, unsigned long
 			case 0xA8:
 			case 0xB0:
 			case 0xB8:
+				isPrimitive = true;
 				break;
 			default:
-				goto flush;
+				isPrimitive = false;
+				break;
+		}
+
+		if (!isPrimitive) {
+			break;
 		}
 
 		while (count != 0) {
@@ -255,25 +262,22 @@ void CUtil::ReWriteDisplayList(void* dlData, unsigned long dlSize, unsigned long
 			if (copyPos != 0) {
 				*(u16*)(current + 4) = value;
 			}
-			current += 6;
-
 			if (copyNrm != 0) {
-				*(u16*)current = value;
+				*(u16*)(current + 6) = value;
 			}
-			current += 2;
 
+			u8* next = current + 8;
 			if (indexFormat == 2) {
 				if (copyNrm != 0) {
-					*(u16*)current = value;
+					*(u16*)next = value;
 				}
-				current += 2;
+				next = current + 10;
 			}
 
+			current = next;
 			count--;
 		}
 	}
-
-flush:
 	DCFlushRange(dlData, dlSize);
 }
 


### PR DESCRIPTION
## Summary
- Reworked CUtil::ReWriteDisplayList primitive dispatch to materialize the validity flag instead of jumping directly to flush
- Reworked the per-vertex pointer advance to compute the next input pointer after optional normal/secondary normal rewrites

## Evidence
- ninja passes
- ReWriteDisplayList__5CUtilFPvUlUl: 79.479454% -> 86.31507% objdiff match

## Plausibility
- The code keeps the same display-list rewrite behavior while matching the decompiled control-flow shape more closely
- No manual vtables, fake symbols, address hacks, or section forcing