### PR TITLE
Match CRingMenu deleting destructor

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -200,24 +200,20 @@ CRingMenu::CRingMenu()
  * JP Address: TODO
  * JP Size: TODO
  */
-CRingMenu::~CRingMenu()
+extern "C" CRingMenu* __dt__9CRingMenuFv(CRingMenu* ringMenu, short shouldDelete)
 {
 	typedef void (*VFunc)(void*);
-	register short shouldDelete;
-	asm {
-		mr shouldDelete, r4
+	if (ringMenu != 0) {
+		*reinterpret_cast<void***>(ringMenu) = __vt__9CRingMenu;
+		VFunc* vtable = *reinterpret_cast<VFunc**>(ringMenu);
+		vtable[4](ringMenu);
+		__dt__5CMenuFv(ringMenu, 0);
+		if (0 < shouldDelete) {
+			__dl__FPv(ringMenu);
+		}
 	}
 
-	if (this == 0) {
-		return;
-	}
-
-	*reinterpret_cast<void***>(this) = __vt__9CRingMenu;
-	(*(VFunc*)((unsigned char*)*(void***)this + 0x10))(this);
-	__dt__5CMenuFv(this, 0);
-	if (0 < shouldDelete) {
-		__dl__FPv(this);
-	}
+	return ringMenu;
 }
 
 /*


### PR DESCRIPTION
## Summary
- rewrite `CRingMenu`'s deleting destructor in `src/ringmenu.cpp` to use the same explicit Metrowerks-style `__dt__...` surface already used by nearby matched classes
- keep the destructor logic the same while removing the manual `r4` register extraction and returning the object pointer directly from the deleting-destructor symbol

## Improved symbols
- `__dt__9CRingMenuFv`
- `main/ringmenu`

## Evidence
- `__dt__9CRingMenuFv`: `49.551723%` -> `99.48276%`
- `main/ringmenu` `.text`: `58.57208%` -> `59.171913%`
- full build still passes with `ninja`

## Why this is plausible source
- `CMenu` and other matched classes in the repo already expose deleting destructors as explicit `__dt__...` functions rather than as hand-written C++ destructor bodies
- this change makes `CRingMenu` follow that existing class/linkage pattern instead of relying on a bespoke register read in the destructor body