### PR TITLE
Improve pppFrameLaser timing conversion

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -302,17 +302,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
             if (emptyHistory) {
                 continue;
             }
-            LaserDoubleBits countDouble;
-            LaserDoubleBits indexDouble;
-
-            countDouble.u[0] = 0x43300000;
-            countDouble.u[1] = (u32)(int)(step->m_payload[0x3a] + 1) ^ 0x80000000;
-            indexDouble.u[0] = 0x43300000;
-            indexDouble.u[1] = (u32)(int)i ^ 0x80000000;
-
-            float count = (float)(countDouble.d - DOUBLE_80333440);
-            float index = (float)(indexDouble.d - DOUBLE_80333440);
-            float t = (FLOAT_80333448 / count) * index;
+            float t = (FLOAT_80333448 / (float)(s32)(step->m_payload[0x3a] + 1)) * (float)i;
             if (GetCharaNodeFrameMatrix(pppMngStPtr, t, charaMtx) == 0) {
                 emptyHistory = 1;
                 continue;


### PR DESCRIPTION
## Summary
- simplify `pppFrameLaser`'s history-frame timing calculation to use direct signed int-to-float casts
- remove the manual double-bit conversion path that was skewing the generated conversion sequence

## Improved symbols
- `main/pppLaser`: `pppFrameLaser`

## Evidence
- `pppFrameLaser` objdiff match improved from `96.05722%` to `97.411446%`
- repo rebuilds successfully with `ninja`

## Why this is plausible source
- the new expression matches the already-decompiled sibling logic in `pppFrameYmLaser`
- this replaces compiler-coaxing style bit manipulation with a straightforward source-level cast, which is more likely to reflect the original code
