### PR TITLE
Improve pppShape texture cache matching

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -123,9 +123,9 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     int shapeStep;
     char* currentFrame;
     int frameIndex;
-    unsigned int textureIndex;
     char* animData;
     unsigned char* texturePtr;
+    unsigned int textureIndex;
     unsigned char* shapeEntry;
     unsigned char textureUsed[0x100];
 
@@ -175,9 +175,9 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     int shapeStep;
     char* currentFrame;
     int frameIndex;
-    unsigned int textureIndex;
     char* animData;
     unsigned char* texturePtr;
+    unsigned int textureIndex;
     unsigned char* shapeEntry;
     unsigned char textureUsed[0x100];
 


### PR DESCRIPTION
## Summary
- Reorder texture cache scan locals in pppShape cache dump/load helpers.
- This gives MWCC the target register assignment for the texture pointer/index scan without changing behavior or function size.

## Objdiff evidence
- main/pppShape .text: 99.16876% -> 99.29471%
- pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet: 97.666664% -> 98.083336% (240b unchanged)
- pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet: 97.666664% -> 98.083336% (240b unchanged)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppShape -o - pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet
- build/tools/objdiff-cli diff -p . -u main/pppShape -o - pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet