### PR TITLE
Fix CGObject virtual order

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -78,9 +78,9 @@ public:
     float CalcSafePos(int, CGObject*, Vec*);
     void PutDropItem();
     virtual unsigned int IsDispRader();
-    virtual int onHit(int, CGObject*, int, Vec*);
-    virtual void onAnimPoint(int, int);
     virtual float onAlphaUpdate();
+    virtual void onAnimPoint(int, int);
+    virtual int onHit(int, CGObject*, int, Vec*);
     virtual void onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*);
     virtual void onDrawDebug(CFont*, float, float&, float);
 


### PR DESCRIPTION
## Summary
- Reordered CGObject virtual declarations to match the original vtable order: IsDispRader, onAlphaUpdate, onAnimPoint, onHit, onHitParticle, onDrawDebug.
- This improves generated derived vtable layout without manually defining vtables or changing code bodies.

## Evidence
- Built with ninja: main.dol OK.
- main/prgobj objdiff .data: 58.15017% -> 60.032383%.
- CGPrgObj::__vtable: 83.55191% -> 86.830605%.
- Global progress remained unchanged: All 27.61% matched, 18.45% linked.

## Plausibility
- The relocation order in original prgobj.o places onAlphaUpdate before onAnimPoint and onHit, matching the adjusted CGObject declaration order.
- The change is a header declaration correction, not compiler coaxing or manual vtable data.