### PR TITLE
Use pooled CSamplePcs string

### DIFF
--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -1,6 +1,6 @@
 #include "ffcc/p_sample.h"
 
-static const char s_CSamplePcs_801D6CC8[] = "CSamplePcs";
+extern const char s_CSamplePcs_801D6CC8[];
 
 CSamplePcsTable m_table__10CSamplePcs = {
     const_cast<char*>(s_CSamplePcs_801D6CC8),


### PR DESCRIPTION
## Summary
- Treat s_CSamplePcs_801D6CC8 as the existing pooled external string instead of emitting a local copy in p_sample.cpp.
- Removes the extra generated .rodata contribution from the compiled p_sample.o, matching the target object external string reference shape.

## Evidence
- ninja completes successfully.
- build/tools/objdiff-cli diff -p . -u main/p_sample -o - shows the built object no longer has a right-side .rodata section for a local CSamplePcs string; .text, .data, and .sbss section sizes remain aligned with the target.