### PR TITLE
Define CGraphic blur state fields

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -92,7 +92,12 @@ public:
     void* m_frameBuffer;
     void* m_scratchTextureBuffer;
     void* m_savedFrameBuffer;
-    u8 _pad_0x71F0_to_0x7373[0x184];
+    u8 _pad_0x71F0_to_0x7357[0x168];
+    int m_blurActive;
+    u8 m_blurDelayCounter;
+    u8 m_blurBufferIndex;
+    u8 m_blurTextureCount;
+    u8 _pad_0x735F_to_0x7373[0x15];
 };
 
 extern CGraphic Graphic;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -232,10 +232,10 @@ void CGraphic::Init()
     S32At(this, 0x7350) = 0;
     S32At(this, 0x7354) = 0;
     makeSphere();
-    S32At(this, 0x7358) = 0;
-    U8At(this, 0x735C) = 0;
-    U8At(this, 0x735D) = 0;
-    U8At(this, 0x735E) = 0;
+    m_blurActive = 0;
+    m_blurDelayCounter = 0;
+    m_blurBufferIndex = 0;
+    m_blurTextureCount = 0;
     GXCopyDisp(PtrAt(this, 0x71E4), GX_TRUE);
     PtrAt(this, 0x7368) = const_cast<char*>(s_graphic_cpp_801d6348);
     S32At(this, 0x736C) = 0xBE;
@@ -1920,9 +1920,9 @@ void CGraphic::CreateSmallBackTexture(void* src, _GXTexObj* texObj, long width, 
  */
 void CGraphic::InitBlurParameter()
 {
-    U8At(this, 0x735D) = 0;
-    U8At(this, 0x735E) = 0;
-    U8At(this, 0x735C) = 0xE8;
+    m_blurBufferIndex = 0;
+    m_blurTextureCount = 0;
+    m_blurDelayCounter = 0xE8;
 }
 
 /*
@@ -1975,7 +1975,7 @@ void CGraphic::RenderBlur(int unused0, unsigned char mode, unsigned char unused2
     GXSetNumTexGens(1);
 
     int textureOffset = 0;
-    for (int i = 0; i < static_cast<int>(U8At(this, 0x735E)); i++) {
+    for (int i = 0; i < static_cast<int>(m_blurTextureCount); i++) {
         u8* textureBase = reinterpret_cast<u8*>(PtrAt(this, 0x71EC)) + textureOffset;
         GXInitTexObj(&texObj, textureBase, 0x140, 0xE0, GX_TF_I8, GX_CLAMP, GX_CLAMP, GX_FALSE);
         GXInitTexObjLOD(&texObj, GX_NEAR, GX_NEAR, 0.0f, 0.0f, 0.0f, GX_FALSE, GX_FALSE, GX_ANISO_1);
@@ -2009,19 +2009,19 @@ void CGraphic::RenderBlur(int unused0, unsigned char mode, unsigned char unused2
     GXSetProjection(CameraPcs.m_screenMatrix, GX_PERSPECTIVE);
     GXSetAlphaUpdate(GX_TRUE);
 
-    if (U8At(this, 0x735C) < textureDelay) {
-        U8At(this, 0x735C) += 1;
+    if (m_blurDelayCounter < textureDelay) {
+        m_blurDelayCounter += 1;
     } else if (System.m_scenegraphStepMode != 2) {
         CreateSmallBackTexture(PtrAt(this, 0x71EC), &texObj, 0x140, 0xE0, GX_NEAR, GX_TF_I8,
-                               static_cast<unsigned long>(U8At(this, 0x735D)) * 0x46000);
-        U8At(this, 0x735C) = 0;
-        U8At(this, 0x735E) += 1;
-        if (U8At(this, 0x735E) > 2) {
-            U8At(this, 0x735E) = 2;
+                               static_cast<unsigned long>(m_blurBufferIndex) * 0x46000);
+        m_blurDelayCounter = 0;
+        m_blurTextureCount += 1;
+        if (m_blurTextureCount > 2) {
+            m_blurTextureCount = 2;
         }
-        U8At(this, 0x735D) += 1;
-        if (U8At(this, 0x735D) > 1) {
-            U8At(this, 0x735D) = 0;
+        m_blurBufferIndex += 1;
+        if (m_blurBufferIndex > 1) {
+            m_blurBufferIndex = 0;
         }
     }
 }

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -51,7 +51,6 @@ u32 m_table__11CGraphicPcs[0x15C / sizeof(u32)] = {
     0x9, 0, 0, 0, 0x48, 1, 0, 0, 0, 0x4B, 0x9, 0, 0, 0, 0x2B, 0x9, 0, 0, 0, 0x34, 0x9
 };
 
-extern int DAT_802381a0;
 extern "C" float FLOAT_8032fb78;
 extern "C" float FLOAT_8032fbfc;
 extern "C" float FLOAT_8032fc00;
@@ -568,16 +567,16 @@ void CGraphicPcs::drawCopy()
 	}
 
 	int initBlur = 0;
-	if ((m_blurMode == 1) && (DAT_802381a0 == 0)) {
-		DAT_802381a0 = 1;
+	if ((m_blurMode == 1) && (Graphic.m_blurActive == 0)) {
+		Graphic.m_blurActive = 1;
 		Graphic.InitBlurParameter();
 		initBlur = 1;
 		m_blurStep = m_blurB / m_blurR;
 		m_blurFadeOutFlag = 0;
 	}
 
-	if ((m_blurMode != 0) || (DAT_802381a0 != 0) || (m_blurFadeOutFlag != 0)) {
-		if (m_blurMode != DAT_802381a0) {
+	if ((m_blurMode != 0) || (Graphic.m_blurActive != 0) || (m_blurFadeOutFlag != 0)) {
+		if (m_blurMode != Graphic.m_blurActive) {
 			m_blurFadeOutFlag = 1;
 		}
 
@@ -588,7 +587,7 @@ void CGraphicPcs::drawCopy()
 				m_blurB = 0;
 				m_blurFadeOutFlag = 0;
 				m_blurMode = 0;
-				DAT_802381a0 = 0;
+				Graphic.m_blurActive = 0;
 			} else {
 				m_blurB = m_blurB - m_blurStep;
 			}

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -114,7 +114,7 @@ static inline MtxPtr CameraMatrix() { return reinterpret_cast<MtxPtr>(reinterpre
 static inline Mtx44Ptr CameraScreenMatrix() { return reinterpret_cast<Mtx44Ptr>(reinterpret_cast<unsigned char*>(&CameraPcs) + 0x48); }
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
-static inline int GraphicScreenBreakBlurEnabled() { return *reinterpret_cast<int*>(reinterpret_cast<u8*>(&Graphic) + 0x7358); }
+static inline int GraphicScreenBreakBlurEnabled() { return Graphic.m_blurActive; }
 
 extern "C" {
 int GetBackBufferRect2__8CGraphicFPvP9_GXTexObjiiiii12_GXTexFilter9_GXTexFmti(


### PR DESCRIPTION
## Summary
- Add named CGraphic fields for the blur state at 0x7358-0x735E.
- Replace p_graphic and pppScreenBreak raw/extern blur-state access with member access.
- Use the named blur fields inside CGraphic::Init, InitBlurParameter, and RenderBlur.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK
- main/p_graphic .text improved from 54.14044% to 54.662865%
- drawCopy__11CGraphicPcsFv improved from 75.09% to 88.37%
- main/graphic InitBlurParameter__8CGraphicFv remains 100.0%; Graphic remains 100.0%
- main/pppScreenBreak screen-break symbols remain 100.0%

## Plausibility
- The blur state is inside the existing CGraphic object per the known Graphic bss range, so this removes an extern/raw-offset hack and models the original object layout more directly.