### PR TITLE
Improve CFlatRuntime init matching

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -145,15 +145,15 @@ private:
     CClass* m_classes;              // 0x0018
     int m_funcCount;                // 0x001C
     u8* m_funcs;                    // 0x0020
-    void* m_0x24;                   // 0x0024
-    void* m_0x28;                   // 0x0028
-    void* m_0x2C;                   // 0x002C
-    void* m_0x30;                   // 0x0030
-    void* m_0x34;                   // 0x0034
-    void* m_0x38;                   // 0x0038
-    void* m_0x3C;                   // 0x003C
-    void* m_0x40;                   // 0x0040
-    void* m_0x44;                   // 0x0044
+    int m_strCount;                 // 0x0024
+    char* m_strBlob;                // 0x0028
+    u16* m_strOffsets;              // 0x002C
+    int m_fstrCount;                // 0x0030
+    char* m_fstrBlob;               // 0x0034
+    u16* m_fstrOffsets;             // 0x0038
+    int m_vstrCount;                // 0x003C
+    char* m_vstrBlob;               // 0x0040
+    u16* m_vstrOffsets;             // 0x0044
     u8 m_performanceBlock[0x804];   // 0x0048
     u8 m_pad_084C[0x80];            // 0x084C
     CObject m_objectSentinel;       // 0x08CC

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -86,13 +86,14 @@ CFlatRuntime::~CFlatRuntime()
 void CFlatRuntime::Init()
 {
 	typedef void* (*GetStageFn)(CFlatRuntime*);
-	GetStageFn getStage = reinterpret_cast<GetStageFn>((*reinterpret_cast<void***>(this))[0x11]);
 
 	m_permanentVarValues = static_cast<u8*>(
 	    __nwa__FUlPQ27CMemory6CStagePci(
-	        0x3000, getStage(this), const_cast<char*>(s_cflat_runtime_cpp_801d8ef8), 0x2A));
+	        0x3000, reinterpret_cast<GetStageFn>((*reinterpret_cast<void***>(this))[0x11])(this),
+	        const_cast<char*>(s_cflat_runtime_cpp_801d8ef8), 0x2A));
 	m_initScratchA = __nwa__FUlPQ27CMemory6CStagePci(
-	    0x14880, getStage(this), const_cast<char*>(s_cflat_runtime_cpp_801d8ef8), 0x2B);
+	    0x14880, reinterpret_cast<GetStageFn>((*reinterpret_cast<void***>(this))[0x11])(this),
+	    const_cast<char*>(s_cflat_runtime_cpp_801d8ef8), 0x2B);
 }
 
 /*
@@ -170,32 +171,32 @@ void CFlatRuntime::Destroy()
 		__dla__FPv(reinterpret_cast<u8*>(ptr) - 0x10);
 	}
 
-	ptr = m_0x28;
+	ptr = m_strBlob;
 	if (ptr != 0) {
 		__dla__FPv(ptr);
 	}
 
-	ptr = m_0x2C;
+	ptr = m_strOffsets;
 	if (ptr != 0) {
 		__dla__FPv(ptr);
 	}
 
-	ptr = m_0x34;
+	ptr = m_fstrBlob;
 	if (ptr != 0) {
 		__dla__FPv(ptr);
 	}
 
-	ptr = m_0x38;
+	ptr = m_fstrOffsets;
 	if (ptr != 0) {
 		__dla__FPv(ptr);
 	}
 
-	ptr = m_0x40;
+	ptr = m_vstrBlob;
 	if (ptr != 0) {
 		__dla__FPv(ptr);
 	}
 
-	ptr = m_0x44;
+	ptr = m_vstrOffsets;
 	if (ptr != 0) {
 		__dla__FPv(ptr);
 	}
@@ -222,15 +223,15 @@ void CFlatRuntime::clear()
 	m_funcCount = 0;
 	m_classes = 0;
 	m_initScratchB = 0;
-	m_0x2C = 0;
-	m_0x28 = 0;
-	m_0x24 = 0;
-	m_0x38 = 0;
-	m_0x34 = 0;
-	m_0x30 = 0;
-	m_0x44 = 0;
-	m_0x40 = 0;
-	m_0x3C = 0;
+	m_strOffsets = 0;
+	m_strBlob = 0;
+	m_strCount = 0;
+	m_fstrOffsets = 0;
+	m_fstrBlob = 0;
+	m_fstrCount = 0;
+	m_vstrOffsets = 0;
+	m_vstrBlob = 0;
+	m_vstrCount = 0;
 
 	*reinterpret_cast<short*>(self + 0x964) =
 	    static_cast<short>((*reinterpret_cast<short*>(self + 0x964) & 0x000F) | (clearMaskBits << 4));


### PR DESCRIPTION
## Summary
- Avoid caching the CFlatRuntime getStage vtable entry in Init so the compiler reloads the virtual slot like the target.
- Name the adjacent CFlatRuntime string table fields used by clear/Destroy for clearer layout documentation.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff: Init__12CFlatRuntimeFv improved from 81.32% / 144 bytes to 99.41% / 136 bytes
- report: main/cflat_runtime fuzzy match improved from 48.49% to 48.65%

## Plausibility
- The Init change removes an artificial function-pointer cache and emits the two virtual stage lookups directly, matching the target shape more closely.
- The field names reflect the string/fstring/vstring table layout already implied by clear and Destroy without adding manual vtable, RTTI, or section hacks.