### PR TITLE
Use generated copy for FS display tail

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -25,6 +25,10 @@ struct CUSBStreamDataHeader {
     u32 m_packetCode;
 };
 
+struct DisplayTail {
+    u8 m_bytes[0xB];
+};
+
 static inline CUSBStreamDataHeader* UsbStream(CFunnyShapePcs* self) {
     return reinterpret_cast<CUSBStreamDataHeader*>(self->m_usbStreamDataStorage);
 }
@@ -119,7 +123,8 @@ void CFunnyShapePcs::SetUSBData()
         m_displayCurrent.unk2C = display.unk2C;
         m_displayCurrent.unk30 = display.unk30;
         m_displayCurrent.unk34[0] = display.unk34[0];
-        memcpy(&m_displayCurrent.unk34[1], &display.unk34[1], sizeof(m_displayCurrent.unk34) - 1);
+        *reinterpret_cast<DisplayTail*>(&m_displayCurrent.unk34[1]) =
+            *reinterpret_cast<DisplayTail*>(&display.unk34[1]);
         break;
     }
     case 5: {


### PR DESCRIPTION
## Summary
- Add a small POD tail type for the trailing display-status bytes in `CFunnyShapePcs::SetUSBData`
- Assign the display tail as a POD object so MWCC emits the generated copy helper shape instead of a direct `memcpy` call

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/FS_USB_Process -o /tmp/FS_USB_Process.final.json SetUSBData__14CFunnyShapePcsFv`
- `SetUSBData__14CFunnyShapePcsFv`: 96.44722% -> 96.452896%
- `main/FS_USB_Process` `.text`: 96.44722% -> 96.452896%

## Plausibility
- The copied range is the 11-byte tail of `FS_DISPLAY_STATUS::unk34`, after byte 0 is assigned separately.
- A POD assignment is a plausible original-source shape for this fixed-size tail and matches the generated-copy behavior more closely than an explicit `memcpy`.