### PR TITLE
Fix octree material env setup in DrawTypeMeshFlag_r

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -321,12 +321,12 @@ void COctTree::DrawTypeMeshFlag_r(COctNode* octNode)
 		env->m_curEnvTevBit = 0xACE0F;
 		env->m_activeEnvTevBit = 0xFFFFFFFF;
 		env->m_alphaRef = 0xFF;
-		env->m_texMapIdCurShadow = 0;
 		env->m_stdTexMapId = 0;
-		env->m_texMtxCurShadow = 0x1E;
+		env->m_texMapIdCur = 0;
 		env->m_stdTexMtx = 0x1E;
-		env->m_texCoordIdCurShadow = 0;
+		env->m_texMtxCur = 0x1E;
 		env->m_stdTexCoordId = 0;
+		env->m_texCoordIdCur = 0;
 		env->m_blendMode = 0xFF;
 		env->m_fogEnable = 0xFF;
 		env->m_lockedEnvTevBit = 0;
@@ -339,9 +339,9 @@ void COctTree::DrawTypeMeshFlag_r(COctNode* octNode)
 			MaterialMan.SetShadowBit32(static_cast<CMapShadow::TARGET>(1), reinterpret_cast<unsigned long*>(Ptr(octNode, 0x48)),
 			                           reinterpret_cast<float(*)[4]>(Ptr(mapObj, 0xB8)));
 		}
-		env->m_texMapIdCurShadow = env->m_stdTexMapId;
-		env->m_texMtxCurShadow = env->m_stdTexMtx;
-		env->m_texCoordIdCurShadow = env->m_stdTexCoordId;
+		env->m_stdTexMapId = env->m_texMapIdCur;
+		env->m_stdTexMtx = env->m_texMtxCur;
+		env->m_stdTexCoordId = env->m_texCoordIdCur;
 		env->m_stdEnvTevBit = env->m_curEnvTevBit;
 		LightPcs.SetBit32(static_cast<CLightPcs::TARGET>(1), reinterpret_cast<unsigned long*>(Ptr(octNode, 0x44)));
 		mapObj->SetDrawEnv();
@@ -359,12 +359,12 @@ void COctTree::DrawTypeMeshFlag_r(COctNode* octNode)
 			env->m_curEnvTevBit = 0xACE0F;
 			env->m_activeEnvTevBit = 0xFFFFFFFF;
 			env->m_alphaRef = 0xFF;
-			env->m_texMapIdCurShadow = 0;
 			env->m_stdTexMapId = 0;
-			env->m_texMtxCurShadow = 0x1E;
+			env->m_texMapIdCur = 0;
 			env->m_stdTexMtx = 0x1E;
-			env->m_texCoordIdCurShadow = 0;
+			env->m_texMtxCur = 0x1E;
 			env->m_stdTexCoordId = 0;
+			env->m_texCoordIdCur = 0;
 			env->m_blendMode = 0xFF;
 			env->m_fogEnable = 0xFF;
 			env->m_lockedEnvTevBit = 0;
@@ -377,9 +377,9 @@ void COctTree::DrawTypeMeshFlag_r(COctNode* octNode)
 				MaterialMan.SetShadowBit32(static_cast<CMapShadow::TARGET>(1), reinterpret_cast<unsigned long*>(Ptr(pCVar4, 0x48)),
 				                           reinterpret_cast<float(*)[4]>(Ptr(mapObj, 0xB8)));
 			}
-			env->m_texMapIdCurShadow = env->m_stdTexMapId;
-			env->m_texMtxCurShadow = env->m_stdTexMtx;
-			env->m_texCoordIdCurShadow = env->m_stdTexCoordId;
+			env->m_stdTexMapId = env->m_texMapIdCur;
+			env->m_stdTexMtx = env->m_texMtxCur;
+			env->m_stdTexCoordId = env->m_texCoordIdCur;
 			env->m_stdEnvTevBit = env->m_curEnvTevBit;
 			LightPcs.SetBit32(static_cast<CLightPcs::TARGET>(1), reinterpret_cast<unsigned long*>(Ptr(pCVar4, 0x44)));
 			mapObj->SetDrawEnv();


### PR DESCRIPTION
## Summary
- switch `COctTree::DrawTypeMeshFlag_r` to initialize the normal current/std material env fields instead of the shadow-only tex state fields
- mirror the shipped object's lock step by copying the current tex ids back into the std tex ids after `SetShadowBit32`
- keep the change scoped to `src/mapocttree.cpp`

## Evidence
- `ninja`
- `build/GCCP01/report.json`
- `main/mapocttree` function score for `DrawTypeMeshFlag_r__8COctTreeFP8COctNode` improved from `82.77419` to `82.884796`

## Plausibility
- this aligns the function with the existing `CMaterialMan::InitEnv` / `LockEnv` behavior already present in the codebase rather than adding compiler-coaxing hacks
- the change corrects which material env fields are being touched during octree draw setup, which is a coherent source-level fix rather than a formatting or naming-only change