### PR TITLE
Restore CUSBPcs direct CProcess base

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,7 +2,7 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/p_sample.h"
+#include "ffcc/system.h"
 #include "ffcc/usb.h"
 
 struct CUSBPcsTable
@@ -16,25 +16,12 @@ extern unsigned int m_table_desc1__7CUSBPcs[];
 extern unsigned int m_table_desc2__7CUSBPcs[];
 extern CUSBPcsTable m_table__7CUSBPcs;
 
-class CUSBPcs : public CSamplePcs
+class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;
 
-    CUSBPcs()
-    {
-        unsigned int* table = reinterpret_cast<unsigned int*>(&m_table__7CUSBPcs);
-
-        table[1] = m_table_desc0__7CUSBPcs[0];
-        table[2] = m_table_desc0__7CUSBPcs[1];
-        table[3] = m_table_desc0__7CUSBPcs[2];
-        table[4] = m_table_desc1__7CUSBPcs[0];
-        table[5] = m_table_desc1__7CUSBPcs[1];
-        table[6] = m_table_desc1__7CUSBPcs[2];
-        table[7] = m_table_desc2__7CUSBPcs[0];
-        table[8] = m_table_desc2__7CUSBPcs[1];
-        table[9] = m_table_desc2__7CUSBPcs[2];
-    }
+    CUSBPcs();
 
     void Init();
     void Quit();

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -37,6 +37,29 @@ extern const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 extern const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
 
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+inline CUSBPcs::CUSBPcs()
+{
+    unsigned int* table = reinterpret_cast<unsigned int*>(&m_table__7CUSBPcs);
+    const unsigned int* desc0 = m_table_desc0__7CUSBPcs;
+    const unsigned int* desc1 = m_table_desc1__7CUSBPcs;
+    const unsigned int* desc2 = m_table_desc2__7CUSBPcs;
+
+    table[1] = desc0[0];
+    table[2] = desc0[1];
+    table[3] = desc0[2];
+    table[4] = desc1[0];
+    table[5] = desc1[1];
+    table[6] = desc1[2];
+    table[7] = desc2[0];
+    table[8] = desc2[1];
+    table[9] = desc2[2];
+}
+
 static inline unsigned int Swap32(unsigned int x)
 {
     return __lwbrx((void*)&x, 0);


### PR DESCRIPTION
## Summary
- restore `CUSBPcs` to inherit directly from `CProcess`
- move the matching constructor definition back into `src/p_usb.cpp`
- keep the descriptor/table initialization logic aligned with that base-class change

## Evidence
- `main` baseline for `main/p_usb`: `.text` `95.07576`, `__sinit_p_usb_cpp` `66.86364`
- this branch for `main/p_usb`: `.text` `95.184845`, `__sinit_p_usb_cpp` `67.681816`
- `.data` stayed unchanged at `87.6933`

## Why this is plausible source
- `CUSBPcs` does not use `CSamplePcs` behavior; it only needs the `CManager`/`CProcess` interface and its own table descriptors
- making it a direct `CProcess` again removes an unnecessary inherited layer and improves the generated global-initializer code instead of relying on compiler coaxing
- the constructor still performs the same real descriptor-table setup, now in the source file where the surrounding USB process initialization lives