### PR TITLE
Improve YmMegaBirth tail direction sources

### DIFF
--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -258,7 +258,7 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
             }
         }
 
-        work->m_tailScaleDirection = param->m_directionTail;
+        work->m_tailScaleDirection = param->m_velocity;
         pppNormalize(work->m_tailScaleDirection, work->m_tailScaleDirection);
     }
 

--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -257,7 +257,7 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
             memset(work->m_wmats, 0, work->m_maxParticles * 0x30);
         }
 
-        work->m_tailScaleDirection = param->m_directionTail;
+        work->m_tailScaleDirection = param->m_velocity;
         tailScale = work->m_tailScaleDirection;
         pppNormalize(work->m_tailScaleDirection, tailScale);
     }


### PR DESCRIPTION
## Summary
- Use the parameter vector at offset 0x30 as the tail-scale direction source for YmMegaBirthShpTail2 and YmMegaBirthShpTail3.
- This matches the target access pattern and avoids reading the later direction-tail field at 0x3c for these param blocks.

## Evidence
- ninja passes.
- objdiff main/pppYmMegaBirthShpTail2 pppFrameYmMegaBirthShpTail2: 96.761190% -> 96.772385%, compiled size unchanged at 1072 bytes.
- objdiff main/pppYmMegaBirthShpTail3 pppFrameYmMegaBirthShpTail3: 69.335800% -> 69.343210%, compiled size unchanged at 1664 bytes.

## Plausibility
- The PAL target loads the source vector from param + 0x30 in both Tail2 and Tail3 frame setup.
- The local work field remains m_tailScaleDirection; only the source param vector is corrected.