### PR TITLE
Improve p_map header dependencies

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -8,7 +8,7 @@
 #include "ffcc/materialman.h"
 #include "ffcc/maplight.h"
 #include "ffcc/p_camera.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/p_light.h"
 #include "ffcc/ptrarray.h"
 #include "ffcc/mapocttree.h"
@@ -496,11 +496,11 @@ void CMapPcs::calc()
                     *reinterpret_cast<COctNode**>(reinterpret_cast<char*>(&MapMng) + 0x18);
                 if (rootNode != 0) {
                     cameraPos.x =
-                        kMapBoundsCenterScale * (rootNode->m_boundMinX + rootNode->m_boundMaxX);
+                        (rootNode->m_boundMinX + rootNode->m_boundMaxX) * kMapBoundsCenterScale;
                     cameraPos.y =
-                        kMapBoundsCenterScale * (rootNode->m_boundMinY + rootNode->m_boundMaxY);
+                        (rootNode->m_boundMinY + rootNode->m_boundMaxY) * kMapBoundsCenterScale;
                     cameraPos.z =
-                        kMapBoundsCenterScale * (rootNode->m_boundMinZ + rootNode->m_boundMaxZ);
+                        (rootNode->m_boundMinZ + rootNode->m_boundMaxZ) * kMapBoundsCenterScale;
                 } else {
                     float* mapCenter =
                         reinterpret_cast<float*>(reinterpret_cast<char*>(&MapMng) + 0xAA8);
@@ -527,7 +527,7 @@ void CMapPcs::calc()
 
         CPtrArray<CMapLightHolder*>& mapLightHolderArr =
             reinterpret_cast<CPtrArray<CMapLightHolder*>*>(reinterpret_cast<char*>(&MapMng) + 0x21450)[1];
-        if (static_cast<unsigned int>(mapLightHolderArr.GetSize()) > 0) {
+        if (static_cast<unsigned int>(mapLightHolderArr.GetSize()) != 0) {
             mapLightHolderArr[0]->GetLightHolder(reinterpret_cast<_GXColor*>(reinterpret_cast<char*>(&MapMng) + 0x2298C),
                                                  static_cast<Vec*>(0));
         }


### PR DESCRIPTION
## Summary
- Replace the broad p_game include in p_map with game.h, avoiding unrelated CGamePcs inline constructor static data in p_map.o.
- Adjust nearby calc source shape to match the recovered expression/check form from Ghidra without changing behavior.

## Evidence
- ninja passes.
- main/p_map .text improved from 92.34956% to 93.19289%.
- __sinit_p_map_cpp improved from 51.67623% to 57.213116%.
- LoadMap__7CMapPcsFiiPvUlUc remains 98.009476%.
- m_table__7CMapPcs remains 100%.
- After this change, tools/agent_select_target.py no longer selects main/p_map in the top buckets.

## Plausibility
p_map only needs CGame for Game.m_currentSceneId, not the CGamePcs process wrapper. Including game.h directly is a cleaner dependency and avoids compiler-emitted inline constructor artifacts from p_game.h.