### PR TITLE
Improve LocationTitle2 frame matching

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -68,7 +68,7 @@ struct pppMngStLocationTitle2Raw {
     CGObject* m_charaObj;
 };
 
-static const char s_LocationTitle2_cpp[] = "LocationTitle2.cpp";
+static const char s_LocationTitle2_cpp_801DB588[] = "LocationTitle2.cpp";
 
 /*
  * --INFO--
@@ -190,7 +190,7 @@ extern "C" void pppRenderLocationTitle2(struct pppLocationTitle2* locationTitle,
     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
 }
 
-static const char s_locationNodeName[] = "loc";
+static const char DAT_80330f50[] = "loc";
 
 /*
  * --INFO--
@@ -258,7 +258,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
 
     if (work->m_particles == 0) {
         work->m_particles = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp,
+            unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp_801DB588,
             0x70);
         memset(work->m_particles, 0, unkB->m_maxCount * sizeof(LocationTitle2Particle));
         particles = (LocationTitle2Particle*)work->m_particles;
@@ -281,7 +281,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         }
 
         modelRaw = (LocationTitle2ModelRaw*)model;
-        nodeIndex = SearchNode__Q26CChara6CModelFPc(model, const_cast<char*>(s_locationNodeName));
+        nodeIndex = SearchNode__Q26CChara6CModelFPc(model, const_cast<char*>(DAT_80330f50));
         node = modelRaw->m_nodes + nodeIndex * 0xC0;
         zOffset = 1.0f;
 
@@ -318,9 +318,8 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                 int nextIndex = startIndex + 1;
                 inserted = 0;
                 startPos = &particles[startIndex].m_pos;
-                Vec* nextPos = &particles[nextIndex].m_pos;
                 stepScale = 1.0f / (float)(unkB->m_stepCount + 1);
-                PSVECSubtract(nextPos, startPos, &stepDir);
+                PSVECSubtract(&particles[nextIndex].m_pos, startPos, &stepDir);
                 interpRead = interp;
                 interpWrite = interpRead;
 
@@ -342,7 +341,8 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
                     interpWrite++;
                 }
 
-                pppCopyVector(particles[nextIndex + inserted].m_pos, particles[nextIndex].m_pos);
+                Vec nextPos = startPos[3];
+                pppCopyVector(particles[nextIndex + inserted].m_pos, nextPos);
 
                 for (int i = 0; i < inserted; i++) {
                     dst = &particles[startIndex + (i + 1)];


### PR DESCRIPTION
## Summary
- Rename LocationTitle2 local data to the PAL symbol names already present in symbols.txt.
- Adjust the interpolation copy path in pppFrameLocationTitle2 to copy from the particle-position stride via startPos[3], matching the Ghidra/original source shape more closely.

## Evidence
- ninja: passes
- objdiff main/LocationTitle2 pppFrameLocationTitle2:
  - before: 95.78619%
  - after: 96.30592%
- pppRenderLocationTitle2, pppDestructLocationTitle2, and pppConstructLocationTitle2 scores are unchanged.

## Plausibility
The particle copy now uses the Vec stride implied by the 0x24-byte particle layout rather than carrying a redundant pointer to the next particle. The symbol names match the shipped PAL names for the file string and loc node string.