### PR TITLE
Improve CSystem Init map size lifetime

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -602,6 +602,7 @@ void CSystem::Init()
     CFile::CHandle* fileHandle;
     unsigned int count;
     int mapSize;
+    unsigned int mapSizeValue;
     unsigned int offset;
 
     m_initialized = 1;
@@ -655,9 +656,10 @@ void CSystem::Init()
         fileHandle = File.Open(const_cast<char*>(s_gamePalM_map), 0, CFile::PRI_LOW);
         if (fileHandle != (CFile::CHandle*)0)
         {
-            mapSize = File.GetLength(fileHandle);
-            m_mapSize = mapSize;
-            m_mapBuffer = new ((CMemory::CStage*)m_mapStage, const_cast<char*>(s_system_cpp), 0x123) unsigned char[mapSize];
+            mapSizeValue = File.GetLength(fileHandle);
+            m_mapSize = mapSizeValue;
+            mapSize = mapSizeValue;
+            m_mapBuffer = new ((CMemory::CStage*)m_mapStage, const_cast<char*>(s_system_cpp), 0x123) unsigned char[mapSizeValue];
             for (offset = 0; (int)mapSize != 0; mapSize -= count)
             {
                 count = 0x100000;


### PR DESCRIPTION
## Summary
- Split the compiler map length value from the mutable remaining-size counter in `CSystem::Init`
- This preserves the loaded map size for allocation while matching the original register lifetime more closely

## Evidence
- `ninja` passes
- `main/system` objdiff `.text`: 99.77655% -> 99.88677%
- `CSystem::Init`: size 852b -> 856b, matching target size 856b
- `CSystem::Init`: 98.95795% -> 99.47196%
- `main/system` `extabindex`: 99.30556% -> 100.0%

## Plausibility
- The change is source-level lifetime cleanup: one variable keeps the file length used for `m_mapSize` and allocation, while `mapSize` remains the loop countdown value.
- No manual sections, address constants, or generated function hacks were introduced.
