### PR TITLE
pppYmTracer: align double bias symbols

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -16,8 +16,8 @@ extern const f32 FLOAT_803306e8;
 extern const f32 FLOAT_803306ec;
 extern u32 DAT_803306e0;
 extern u32 DAT_803306e4;
-extern const f64 DOUBLE_80330578 = 4503601774854144.0;
-extern const f64 DOUBLE_80330580 = 4503599627370496.0;
+extern const f64 DOUBLE_803306f0 = 4503601774854144.0;
+extern const f64 DOUBLE_803306f8 = 4503599627370496.0;
 
 extern "C" {
 void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);


### PR DESCRIPTION
## Summary
- rename the two integer-to-float bias doubles in `pppYmTracer.cpp` to the symbols this unit actually wants to reference
- keep the change scoped to the tracer unit so the small-data relocations and generated conversions line up more closely with PAL

## Evidence
- `pppRenderYmTracer`: `98.76087%` -> `98.847824%`
- `main/pppYmTracer` `.text`: `97.7124%` -> `97.738785%`
- full PAL build still succeeds with `ninja`

## Plausibility
- this is not compiler coaxing or formatting churn; it corrects the unit-local double-bias symbol identities used for the existing integer-to-float conversion pattern
- the code generation improvement comes from cleaner symbol/layout alignment, not from introducing fake control flow or hardcoded addresses