### PR TITLE
Improve pppRandUpFV value reuse

### DIFF
--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -55,7 +55,8 @@ void pppRandUpFV(_pppPObject* basePtr, RandUpFVParams* in, _pppCtrlTable* ctrl)
 
     f32* target = (in->sourceOffset == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)((u8*)basePtr + in->sourceOffset + 0x80);
 
-    target[0] += randf(in->blend[0], *valuePtr);
-    target[1] += randf(in->blend[1], *valuePtr);
-    target[2] += randf(in->blend[2], *valuePtr);
+    f32 value = *valuePtr;
+    target[0] += randf(in->blend[0], value);
+    target[1] += randf(in->blend[1], value);
+    target[2] += randf(in->blend[2], value);
 }


### PR DESCRIPTION
## Summary
- Reuse the cached random value for all three vector components in pppRandUpFV instead of reloading through valuePtr after each target write.
- This matches the original aliasing shape more closely and restores the target text size.

## Evidence
- Before: pppRandUpFV 94.86842% match, current size 312b vs target 304b.
- After: pppRandUpFV 99.710526% match, current size 304b.
- Full ninja passes: build/GCCP01/main.dol OK.

## Plausibility
- The source now stores the generated random scalar once, then applies it to X/Y/Z blends. That is natural source and avoids false alias-driven reloads from valuePtr.