### PR TITLE
Limit CGamePcs constructor data emission

### DIFF
--- a/include/ffcc/p_game.h
+++ b/include/ffcc/p_game.h
@@ -21,6 +21,7 @@ extern unsigned int m_table__8CGamePcs[];
 class CGamePcs : public CProcess
 {
 public:
+#ifdef FFCC_DEFINE_CGAMEPCS_CTOR
     CGamePcs()
     {
         unsigned int* table = reinterpret_cast<unsigned int*>(m_table__8CGamePcs);
@@ -62,6 +63,9 @@ public:
         table[38] = desc8[1];
         table[39] = desc8[2];
     }
+#else
+    CGamePcs();
+#endif
 
     void Init();
     void Quit();

--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -1,3 +1,4 @@
+#define FFCC_DEFINE_CGAMEPCS_CTOR
 #include "ffcc/p_game.h"
 
 extern "C" void create__8CGamePcsFv(CGamePcs*);


### PR DESCRIPTION
## Summary
- Gate the inline CGamePcs constructor body so only p_game.cpp emits its local descriptor statics.
- Leave other includers with only a constructor declaration, avoiding duplicate CGamePcs descriptor data in unrelated objects.

## Evidence
- Before: p_tina.o emitted desc0..desc8 localstatic CGamePcs constructor descriptors, adding 108 bytes of extra .data in the p_tina objdiff view.
- After: build/GCCP01/src/p_tina.o no longer contains those desc0..desc8 symbols; p_tina objdiff .data right side shrinks from 1152 bytes to 1044 bytes.
- Final build passed with build/GCCP01/main.dol: OK.

## Plausibility
- The CGamePcs constructor-local descriptors belong with the CGamePcs implementation in p_game.cpp, not every translation unit that includes p_game.h.
- This is a linkage/data ownership cleanup, not a section-forcing or address hack.