### PR TITLE
Improve item object active flag checks

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -776,7 +776,8 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		for (unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat);
 			 itemObj != 0;
 			 itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
-			if (*(int*)(itemObj + 0x44) == 0 && (itemObj[0x50] & 8) != 0 &&
+			if (*(int*)(itemObj + 0x44) == 0 &&
+				(int)(((unsigned int)itemObj[0x50] << 0x1c) | ((unsigned int)itemObj[0x50] >> 4)) < 0 &&
 				(((int)(char)itemObj[0x53] & deleteMask) != 0) && *(int*)(itemObj + 0x48) < bestScriptObjectPos) {
 				bestScriptObjectPos = *(int*)(itemObj + 0x48);
 				bestItemObj = itemObj;
@@ -1475,7 +1476,7 @@ void CGItemObj::DispAllFieldItem(int show)
 	     itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
 		void* owner = *(void**)(itemObj + 0x550);
 
-		if (owner == 0 && (itemObj[0x50] & 8) != 0) {
+		if (owner == 0 && (int)(((unsigned int)itemObj[0x50] << 0x1c) | ((unsigned int)itemObj[0x50] >> 4)) < 0) {
 			if (show != 0) {
 				*(unsigned int*)(itemObj + 0x60) &= 0xffbfffff;
 			} else {


### PR DESCRIPTION
## Summary
- Use the rotated state-flag expression for item active checks in DeleteOld and DispAllFieldItem.
- This matches the expression shown in the Ghidra output for these functions and avoids treating the active bit as a standalone mask in these paths.

## Objdiff evidence
- main/itemobj DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject: 77.58462% -> 78.96923%
- main/itemobj DispAllFieldItem__9CGItemObjFi: 93.65854% -> 95.48781%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_DeleteOld_final.json DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject
- build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_DispAll_final.json DispAllFieldItem__9CGItemObjFi

The change is ordinary source-level condition recovery, not a temporary assembly or linkage hack.