### PR TITLE
Match CFont constructor constants

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -757,14 +757,14 @@ CFont::CFont()
 {
 	m_glyphData = 0;
 	texturePtr = 0;
-	margin = 0.0f;
-	posZ = 0.0f;
-	posY = 0.0f;
-	posX = 0.0f;
+	margin = FLOAT_803306B8;
+	posZ = FLOAT_803306B8;
+	posY = FLOAT_803306B8;
+	posX = FLOAT_803306B8;
 	CFontRenderFlagBits& bits = GetRenderFlagBits(renderFlags);
 	bits.shadow = 0;
-	scaleY = 1.0f;
-	scaleX = 1.0f;
+	scaleY = FLOAT_803306C8;
+	scaleX = FLOAT_803306C8;
 	bits.fixedWidth = 0;
 	m_color.r = 0xFF;
 	m_color.g = 0xFF;


### PR DESCRIPTION
## Summary
- Use the existing named float constants for the CFont constructor zero and one initializers.
- This lets the constructor reference the same constant pool entries as the target instead of anonymous literals.

## Evidence
- ninja: passed
- __ct__5CFontFv: 99.77273% -> 100.0% match, size 176
- main/fontman .text: 84.77013% -> 84.77842% match, size 4820

## Plausibility
- The change preserves the existing constructor field initialization order and only swaps anonymous 0.0f/1.0f literals for the unit's already-known named constants.
- No vtable, ctor/dtor, section, or address-forcing hacks.