### PR TITLE
Match memory warning string size

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -21,7 +21,7 @@ extern "C" const char DAT_801d669c[] =
     "                          GetData  TimeOut\n"
     "===================================================================\n"
     "===================================================================\n";
-extern "C" const char DAT_801d67d8[] =
+extern "C" const char DAT_801d67d8[40] =
     "\x83\x71\x81\x5b\x83\x76\x82\xaa\x88\xd9\x8f\xed\x82\xc8\x82\xcc"
     "\x82\xc5\x95\x60\x89\xe6\x82\xf0\x92\x86\x8e\x7e\x82\xb5\x82\xdc"
     "\x82\xb7\x81\x42\n";


### PR DESCRIPTION
## Summary
- Fix the recovered size for the memory heap warning string at DAT_801d67d8 by declaring the trailing padded bytes.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/memory -o - DAT_801d67d8 now reports DAT_801d67d8 as 40 bytes and 100.0% matched.
- Baseline before this change was 40 bytes at 97.4359% for the same symbol.

## Plausibility
- The target rodata contains the Japanese warning string plus trailing zero padding to a 40-byte object (0x0A000000). Declaring the array size recovers that object boundary without changing codegen or adding address hacks.