### PR TITLE
Improve FS USB animation data matching

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -213,6 +213,7 @@ void CFunnyShapePcs::SetUSBData()
             }
 
             s16* list = reinterpret_cast<s16*>(AnmData(this) + *reinterpret_cast<s16*>(group + 0x10));
+            u8* listData = reinterpret_cast<u8*>(list);
             list[0] = LoadSwap16(list[0]);
             list[1] = LoadSwap16(list[1]);
 
@@ -222,7 +223,7 @@ void CFunnyShapePcs::SetUSBData()
             int dst2c = 0;
             for (int j = 0; j < static_cast<s16>(list[1]); j++) {
                 if ((list[0] & 8) != 0) {
-                    u8* src = reinterpret_cast<u8*>(list) + 0x10 + src2c;
+                    u8* src = listData + 0x10 + src2c;
                     u32* p32 = reinterpret_cast<u32*>(src);
                     StoreSwap32(&p32[0]);
                     StoreSwap32(&p32[1]);
@@ -239,11 +240,11 @@ void CFunnyShapePcs::SetUSBData()
                     *reinterpret_cast<s16*>(src + 0x24) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x24));
                     *reinterpret_cast<s16*>(src + 0x26) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x26));
 
-                    u8* dst = reinterpret_cast<u8*>(list) + 0x10 + dst2c;
+                    u8* dst = listData + 0x10 + dst2c;
                     memcpy(dst, src, 0x2C);
                     DCStoreRange(dst, 0x2C);
                 } else {
-                    u8* src = reinterpret_cast<u8*>(list) + 0x10 + src24;
+                    u8* src = listData + 0x10 + src24;
                     u32* p32 = reinterpret_cast<u32*>(src);
                     StoreSwap32(&p32[0]);
                     StoreSwap32(&p32[1]);
@@ -256,7 +257,7 @@ void CFunnyShapePcs::SetUSBData()
                     *reinterpret_cast<s16*>(src + 0x1C) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x1C));
                     *reinterpret_cast<s16*>(src + 0x1E) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x1E));
 
-                    u8* dst = reinterpret_cast<u8*>(list) + 0x10 + dst24;
+                    u8* dst = listData + 0x10 + dst24;
                     memcpy(dst, src, 0x24);
                     DCStoreRange(dst, 0x24);
                 }


### PR DESCRIPTION
## Summary
- Keep a byte pointer for the animation list payload in CFunnyShapePcs::SetUSBData.
- This nudges MWCC back to the original address-calculation shape for the case 11 animation loop.

## Evidence
- main/FS_USB_Process data: 33.33% -> 100.00%
- SetUSBData__14CFunnyShapePcsFv code: 97.57321% -> 98.799095%
- SetUSBData size now matches: 3524 bytes
- Full ninja passes and main.dol remains OK

## Plausibility
- The change is a local source cleanup: reuse the already-derived byte view of the animation list instead of repeating casts from s16*.
- No generated symbols, hard-coded addresses, or section forcing.