### PR TITLE
Improve TmpArtiOpen int conversions

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -514,7 +514,7 @@ unsigned int CMenuPcs::TmpArtiOpen()
 			*(int *)(psVar7 + 0xe) = 0x37;
 			psVar7[2] = 200;
 			psVar7[3] = 0x28;
-			psVar7[0] = (short)(int)-((TmpArtiIntToDouble(psVar7[2]) * dVar1) - dVar5);
+			psVar7[0] = (short)(int)-(((double)psVar7[2] * dVar1) - dVar5);
 			psVar7[1] = (short)iVar6 * (psVar7[3] + -8) + 0x60;
 			*(float *)(psVar7 + 4) = fVar2;
 			*(float *)(psVar7 + 6) = fVar2;
@@ -523,7 +523,7 @@ unsigned int CMenuPcs::TmpArtiOpen()
 			*(int *)(psVar7 + 0x2e) = 0x37;
 			psVar7[0x22] = 200;
 			psVar7[0x23] = 0x28;
-			psVar7[0x20] = (short)(int)-((TmpArtiIntToDouble(psVar7[0x22]) * dVar1) - dVar5);
+			psVar7[0x20] = (short)(int)-(((double)psVar7[0x22] * dVar1) - dVar5);
 			psVar7[0x21] = (short)(iVar6 + 1) * (psVar7[0x23] + -8) + 0x60;
 			*(float *)(psVar7 + 0x24) = fVar2;
 			*(float *)(psVar7 + 0x26) = fVar2;
@@ -554,8 +554,8 @@ unsigned int CMenuPcs::TmpArtiOpen()
 				else {
 					*(int *)(psVar7 + 0x10) = *(int *)(psVar7 + 0x10) + 1;
 					*(float *)(psVar7 + 8) =
-					    (float)((DOUBLE_80332f48 / TmpArtiIntToDouble(*(int *)(psVar7 + 0x14))) *
-					            TmpArtiIntToDouble(*(int *)(psVar7 + 0x10)));
+					    (float)((DOUBLE_80332f48 / (double)*(int *)(psVar7 + 0x14)) *
+					            (double)*(int *)(psVar7 + 0x10));
 				}
 			}
 			psVar7 = psVar7 + 0x20;


### PR DESCRIPTION
## Summary
- Use direct C casts for TmpArtiOpen's initial entry positioning and fade timing conversions.
- Leaves TmpArtiDraw/Close/Ctrl codegen unchanged while improving TmpArtiOpen.

## Evidence
- ninja succeeds.
- report.json: TmpArtiOpen__8CMenuPcsFv improves from 72.90686% to 75.02941%.
- objdiff-cli focused diff: TmpArtiOpen__8CMenuPcsFv improves from 72.85784% to 74.95588%, source size drops from 864b to 860b against the 816b target.
- Other menu_tmparti function report scores remain unchanged: Draw 67.818184%, Close 72.54205%, Ctrl 75.79032%.

## Plausibility
- These are ordinary integer-to-double casts at the source conversion sites Ghidra shows as casts, rather than using the local helper that manually constructs the conversion double.