### PR TITLE
Fix FunnyShapePcs storage initialization

### DIFF
--- a/include/ffcc/p_FunnyShape.h
+++ b/include/ffcc/p_FunnyShape.h
@@ -55,6 +55,10 @@ public:
     u8 m_gxTexObjPtrArrayStorage[0x1C];    // 0x61D8
 };
 
+#ifdef FFCC_DEFINE_FUNNYSHAPEPCS_STORAGE
+extern u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];
+#else
 extern CFunnyShapePcs FunnyShapePcs;
+#endif
 
 #endif // _FFCC_P_FUNNYSHAPE_H_

--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -1,3 +1,4 @@
+#define FFCC_DEFINE_FUNNYSHAPEPCS_STORAGE
 #include "ffcc/p_FunnyShape.h"
 #include "ffcc/FunnyShape.h"
 #include "ffcc/USBStreamData.h"
@@ -102,7 +103,8 @@ static inline CFunnyShape* FunnyShape(CFunnyShapePcs* self)
  */
 extern "C" void __sinit_p_FunnyShape_cpp(void)
 {
-    u8* self = reinterpret_cast<u8*>(&FunnyShapePcs);
+    CFunnyShapePcs* pcs = reinterpret_cast<CFunnyShapePcs*>(&FunnyShapePcs);
+    u8* self = reinterpret_cast<u8*>(pcs);
     unsigned int* dst = m_table__14CFunnyShapePcs;
     unsigned int* desc0 = m_table_desc0__14CFunnyShapePcs;
     unsigned int* desc1 = m_table_desc1__14CFunnyShapePcs;
@@ -136,7 +138,6 @@ unsigned int m_table_desc0__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_ca
 unsigned int m_table_desc1__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__14CFunnyShapePcsFv)};
 unsigned int m_table_desc2__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__14CFunnyShapePcsFv)};
 unsigned int m_table_desc3__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__14CFunnyShapePcsFv)};
-CFunnyShapePcs FunnyShapePcs;
 unsigned int m_table__14CFunnyShapePcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(lbl_801D7DD0)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x21, 0, 0, 0, 0,
     0x42, 1
@@ -145,6 +146,7 @@ unsigned int lbl_801EA904[4] = {
     reinterpret_cast<unsigned int>(lbl_8032E660), 0, 0, reinterpret_cast<unsigned int>(lbl_8032E660)
 };
 u8 ARRAY_8026D728[0xC];
+u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];
 
 template <class T>
 CPtrArray<T>::CPtrArray()


### PR DESCRIPTION
## Summary
- Define FunnyShapePcs as raw storage in p_FunnyShape.cpp while preserving the typed extern declaration for other translation units.
- Keep ARRAY_8026D728 immediately before FunnyShapePcs so the compiled BSS layout matches the target.
- Avoid the extra compiler-generated local static initializer; the hand-matched __sinit_p_FunnyShape_cpp remains the only initializer in the unit.

## Evidence
- ninja passes.
- Objdiff p_FunnyShape before: source .text 2492 vs target 2364, source .bss 25100 vs target 25088, source extabindex 156 vs target 144.
- Objdiff p_FunnyShape after: source .text 2364 vs target 2364, source .bss 25088 vs target 25088, source extabindex 144 vs target 144.
- Symbol check after: ARRAY_8026D728 at BSS +0x0 size 0xC, FunnyShapePcs at BSS +0xC size 0x61F4, single global __sinit_p_FunnyShape_cpp size 0x120.

## Plausibility
This keeps the existing explicit initializer code and models the object as static storage owned by the unit, matching the observed BSS order without adding section directives, fake labels, or manual vtable data.