### PR TITLE
Match CFont text draw loop

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -317,17 +317,22 @@ found_fallback:
  */
 void CFont::Draw(char* text)
 {
-	unsigned short ch = 0;
+	char* textPtr = text;
+	unsigned short ch;
+	int hasChar;
 
 	goto read_char;
 
-	while (ch != '\0') {
+	while (hasChar != 0) {
 		Draw(ch);
 
 read_char:
-		ch = static_cast<unsigned char>(*text);
-		if (ch != '\0') {
-			text++;
+		if (static_cast<unsigned char>(*textPtr) == 0) {
+			hasChar = 0;
+		} else {
+			ch = static_cast<unsigned char>(*textPtr);
+			hasChar = 1;
+			textPtr++;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Reworked CFont::Draw(char*) to use the explicit text pointer / character / has-character state shape emitted by the target.
- This keeps the existing single-byte text behavior while matching the PAL function exactly.

## Evidence
- ninja passes.
- Objdiff: build/tools/objdiff-cli diff -p . -u main/fontman -o - Draw__5CFontFPc
- Draw__5CFontFPc: 72.13793% -> 100.0% match, 0 diffs
- main/fontman .text: 84.77013% -> 85.44067%

## Plausibility
- The loop now mirrors a normal decoded-character state machine: keep a local text cursor, emit the current character, then read the next byte and track whether a character was present.
- No hard-coded addresses, fake symbols, section forcing, or generated ctor/dtor hacks.