### PR TITLE
Match ChangeTex file string linkage

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -114,7 +114,7 @@ extern const char DAT_80332024[] = "obj";
 extern const float FLOAT_80332028 = 255.0f;
 extern const double DOUBLE_80332030 = 4503601774854144.0;
 extern const double DOUBLE_80332038 = 4503599627370496.0;
-static const char s_pppChangeTex_cpp_801dd660[] = "pppChangeTex.cpp";
+extern const char s_pppChangeTex_cpp_801dd660[] = "pppChangeTex.cpp";
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 

--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -86,7 +86,7 @@ extern _pppMngStYmChangeTex* pppMngStPtr;
 extern _pppEnvStYmChangeTex* pppEnvStPtr;
 
 extern float DAT_80330e10;
-static const char s_pppYmChangeTex_cpp_801db4c0[] = "pppYmChangeTex.cpp";
+extern const char s_pppYmChangeTex_cpp_801db4c0[] = "pppYmChangeTex.cpp";
 extern float FLOAT_80330df8;
 extern float FLOAT_80330dfc;
 extern float FLOAT_80330e00;


### PR DESCRIPTION
## Summary
- Give the pppChangeTex and pppYmChangeTex file-name rodata symbols external linkage.
- Matches the original object binding for `s_pppChangeTex_cpp_801dd660` and `s_pppYmChangeTex_cpp_801db4c0`.

## Evidence
- `ninja`
- Symbol-table check after rebuild:
  - `pppYmChangeTex`: original and source both emit `s_pppYmChangeTex_cpp_801db4c0` as `STB_GLOBAL`, size `0x13`.
  - `pppChangeTex`: original and source both emit `s_pppChangeTex_cpp_801dd660` as `STB_GLOBAL`, size `0x11`.
- Objdiff report scores are unchanged for both units, so this is linkage cleanup with no code/data-byte regression.

## Plausibility
- These are file-name literals passed to allocation/debug paths and already have named shipped symbols in the original objects; external linkage matches that ownership instead of leaving compiler-local rodata labels.
