### PR TITLE
Improve tmp artifact reset tail matching

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -330,17 +330,16 @@ unsigned int CMenuPcs::TmpArtiClose()
 					uVar8 = uVar8 - 1;
 				} while (uVar8 != 0);
 				uVar6 = uVar6 & 7;
-				if (uVar6 == 0) {
-					return 1;
-				}
 			}
-			do {
-				*(int *)(psVar4 + 0x12) = 0;
-				*(int *)(psVar4 + 0x14) = 1;
-				*(float *)(psVar4 + 8) = fVar1;
-				psVar4 = psVar4 + 0x20;
-				uVar6 = uVar6 - 1;
-			} while (uVar6 != 0);
+			if (uVar6 != 0) {
+				do {
+					*(int *)(psVar4 + 0x12) = 0;
+					*(int *)(psVar4 + 0x14) = 1;
+					*(float *)(psVar4 + 8) = fVar1;
+					psVar4 = psVar4 + 0x20;
+					uVar6 = uVar6 - 1;
+				} while (uVar6 != 0);
+			}
 		}
 		return 1;
 	}
@@ -597,17 +596,16 @@ unsigned int CMenuPcs::TmpArtiOpen()
 					uVar11 = uVar11 - 1;
 				} while (uVar11 != 0);
 				uVar8 = uVar8 & 7;
-				if (uVar8 == 0) {
-					return 1;
-				}
 			}
-			do {
-				*(int *)(psVar7 + 0x12) = 0;
-				*(int *)(psVar7 + 0x14) = 1;
-				*(float *)(psVar7 + 8) = fVar3;
-				psVar7 = psVar7 + 0x20;
-				uVar8 = uVar8 - 1;
-			} while (uVar8 != 0);
+			if (uVar8 != 0) {
+				do {
+					*(int *)(psVar7 + 0x12) = 0;
+					*(int *)(psVar7 + 0x14) = 1;
+					*(float *)(psVar7 + 8) = fVar3;
+					psVar7 = psVar7 + 0x20;
+					uVar8 = uVar8 - 1;
+				} while (uVar8 != 0);
+			}
 		}
 		return 1;
 	}


### PR DESCRIPTION
## Summary
- Reshape the unrolled reset tails in TmpArtiClose and TmpArtiOpen to avoid the early success return when there is no tail remainder.
- This matches the PAL fallthrough pattern more closely and reduces both generated functions by 4 bytes.

## Objdiff evidence
- TmpArtiClose__8CMenuPcsFv: 72.49533% -> 73.990654%, size 460 -> 456
- TmpArtiOpen__8CMenuPcsFv: 74.95588% -> 75.495094%, size 860 -> 856

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiClose__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiOpen__8CMenuPcsFv

## Plausibility
- The reset logic is semantically unchanged, but the source now expresses the remainder loop as conditional work followed by the existing common success return instead of returning early from the unrolled path.
- No manual sections, address hacks, or generated ctor/dtor/vtable code were introduced.
