### PR TITLE
Fix UniteCloseAnim x position type

### DIFF
--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -2427,7 +2427,7 @@ int CMenuPcs::UniteCloseAnim(int topIdx)
 	}
 
 	s16** listPtr = reinterpret_cast<s16**>(reinterpret_cast<u8*>(this) + 0x850);
-	double baseX = static_cast<double>((*listPtr)[4]);
+	float baseX = static_cast<float>((*listPtr)[4]);
 	int caravanWork = Game.m_scriptFoodBase[0];
 
 	if (topIdx < 0) {
@@ -2444,7 +2444,7 @@ int CMenuPcs::UniteCloseAnim(int topIdx)
 				}
 
 				*entry = static_cast<s16>(static_cast<double>(*entry) - DOUBLE_80332ab8);
-				if (static_cast<double>(*entry) <= baseX) {
+				if (static_cast<float>(*entry) <= baseX) {
 					*entry = static_cast<s16>(baseX);
 					if (j == 0) {
 						finished++;
@@ -2471,7 +2471,7 @@ int CMenuPcs::UniteCloseAnim(int topIdx)
 			}
 
 			*entry = static_cast<s16>(static_cast<double>(*entry) - DOUBLE_80332ab8);
-			if (static_cast<double>(*entry) <= baseX) {
+			if (static_cast<float>(*entry) <= baseX) {
 				finished = true;
 				*entry = static_cast<s16>(baseX);
 			}


### PR DESCRIPTION
## Summary
- Use a float base x value in CMenuPcs::UniteCloseAnim, matching the decompiled comparison and assignment shape.
- Keeps close animation behavior the same while producing code closer to the original PAL function.

## Evidence
- ninja: passes
- main/menu_cmd objdiff .text: 43.47739% -> 43.49137%
- UniteCloseAnim__8CMenuPcsFi report score: 4.9264708% -> 5.852941%