### PR TITLE
Improve quad object draw loop matching

### DIFF
--- a/include/ffcc/pppPObjPoint.h
+++ b/include/ffcc/pppPObjPoint.h
@@ -1,53 +1,31 @@
 #ifndef _PPP_POBJPOINT_H_
 #define _PPP_POBJPOINT_H_
 
-#include <stddef.h>
 #include <dolphin/types.h>
 
-struct PppObjData {
-    int id;          // 0x0
-    unsigned int field_4;     // 0x4
-    u8* data;      // 0x8
-    unsigned int objId;       // 0xc
+struct _pppPObject;
+struct _pppCtrlTable;
+
+struct pppPObjPointStep {
+    s32 m_graphId;              // 0x0
+    u32 m_createProgramIndex;   // 0x4
+    u8* m_sourceObject;         // 0x8
+    u32 m_objectId;             // 0xc
 };
 
-struct PppPointData {
-    void* field_0;   // 0x0
-    void* matrix;    // 0x4 - points to transformation matrix
-    unsigned int field_8;     // 0x8
-    int id;          // 0xc
-    float field_10;    // 0x10
-    float field_14;    // 0x14
-    float field_18;    // 0x18
-    float x;           // 0x1c
-    float field_20;    // 0x20
-    float field_24;    // 0x24
-    float field_28;    // 0x28
-    float y;           // 0x2c
-    float field_30;    // 0x30
-    float field_34;    // 0x34
-    float field_38;    // 0x38
-    float z;           // 0x3c
-};
-
-struct PppContainer {
-    unsigned int field_0[3];  // 0x0-0x8
-    void* ptrData;   // 0xc
-};
-
-struct PppPointObj {
-    float x;           // 0x0
-    float y;           // 0x4
-    float z;           // 0x8
-    unsigned char padding[4];   // 0xc
-    u8* vecPtr;    // 0x10
+struct pppPObjPointWork {
+    float m_x;         // 0x0
+    float m_y;         // 0x4
+    float m_z;         // 0x8
+    u8 m_pad[4];       // 0xc
+    u8* m_source;      // 0x10
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* container);
+void pppPObjPoint(_pppPObject* pObject, pppPObjPointStep* step, _pppCtrlTable* ctrlTable);
 
 #ifdef __cplusplus
 }

--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -14,33 +14,33 @@
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppPObjPoint(PppPointData* pointData, PppObjData* objData, PppContainer* container)
+void pppPObjPoint(_pppPObject* pObject, pppPObjPointStep* step, _pppCtrlTable* ctrlTable)
 {
     if (gPppCalcDisabled != 0) {
         return;
     }
 
-    s32 objOffset = *(s32*)container->ptrData;
-    PppPointObj* objPtr = (PppPointObj*)((u8*)pointData + objOffset + 0x80);
+    s32 objOffset = ctrlTable->m_serializedDataOffsets[0];
+    pppPObjPointWork* objPtr = (pppPObjPointWork*)((u8*)pObject + objOffset + 0x80);
 
-    if (objData->id == pointData->id) {
+    if (step->m_graphId == pObject->m_graphId) {
         u8* vecPtr;
 
-        if (objData->field_4 == -1) {
+        if (step->m_createProgramIndex == -1) {
             vecPtr = gPppDefaultValueBuffer;
         } else {
-            u8* data = objData->data;
+            u8* data = step->m_sourceObject;
             _pppPDataVal* pDataVal = pppMngStPtr->m_pppPDataVals;
-            pDataVal = &pDataVal[objData->field_4];
+            pDataVal = &pDataVal[step->m_createProgramIndex];
             s32 vecOffset = pDataVal->m_nextSpawnTime;
             vecPtr = data + 0x80;
             vecPtr += vecOffset;
         }
 
-        objPtr->vecPtr = vecPtr;
+        objPtr->m_source = vecPtr;
     }
 
-    objPtr->x = ((f32*)objPtr->vecPtr)[0];
-    objPtr->y = ((f32*)objPtr->vecPtr)[1];
-    objPtr->z = ((f32*)objPtr->vecPtr)[2];
+    objPtr->m_x = ((f32*)objPtr->m_source)[0];
+    objPtr->m_y = ((f32*)objPtr->m_source)[1];
+    objPtr->m_z = ((f32*)objPtr->m_source)[2];
 }

--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -111,9 +111,9 @@ void CGQuadObj::onDraw()
         GXLoadPosMtxImm(CameraPcs.m_cameraMatrix, GX_PNMTX0);
         GXBegin(GX_LINES, GX_VTXFMT0, ((u32)m_vertexCount << 1) + ((u32)m_vertexCount << 2));
 
-        QuadVertex* vertex;
-        CGQuadObj* current = this;
         int i = 0;
+        CGQuadObj* current = this;
+        QuadVertex* vertex;
 
         while (i < (int)(u32)m_vertexCount) {
             int next = i + 1;


### PR DESCRIPTION
## Summary
- Reordered the local declarations in `CGQuadObj::onDraw` to improve MWCC register allocation in the draw loop.
- Replaced the ad-hoc `pppPObjPoint` argument/work structs with the shared particle object/control-table types and a named step/work payload layout.

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- `main/quadobj` `onDraw__9CGQuadObjFv`: 97.92453% -> 98.4434%, size remains 424 bytes.
- `main/pppPObjPoint` `pppPObjPoint`: remains 96.21622%, target size 148 bytes / base size 152 bytes, with cleaner source types for future matching.

## Plausibility
- The quad object change is only declaration ordering, matching normal MWCC source-shape sensitivity without changing behavior.
- The pppPObjPoint cleanup removes duplicate fake layouts and uses the same `_pppPObject` and `_pppCtrlTable` convention already used by neighboring PPP functions.
