### PR TITLE
Fix menu_lst constant ownership

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -27,21 +27,21 @@ extern "C" void Draw__5CFontFPc(CFont*, const char*);
 
 extern "C" const char* GetMenuStr__8CMenuPcsFi(CMenuPcs*, int);
 
-static const float FLOAT_803333D0 = 0.0f;
-static const float FLOAT_803333D4 = 255.0f;
-static const double DOUBLE_803333D8 = 20.0;
-static const float FLOAT_803333E0 = 40.0f;
-static const double DOUBLE_803333E8 = 0.5;
-static const float FLOAT_803333F0 = 1.0f;
-static const float FLOAT_803333F4 = 4.0f;
-static const float FLOAT_803333F8 = 320.0f;
-static const float FLOAT_803333FC = 0.5f;
-static const float FLOAT_80333400 = 352.0f;
-static const float FLOAT_80333404 = 3.0f;
-static const double DOUBLE_80333408 = 4503601774854144.0;
-static const double DOUBLE_80333410 = 1.0;
-static const double DOUBLE_80333418 = 0.0;
-static const double DOUBLE_80333420 = 216.0;
+extern const float FLOAT_803333D0;
+extern const float FLOAT_803333D4;
+extern const double DOUBLE_803333D8;
+extern const float FLOAT_803333E0;
+extern const double DOUBLE_803333E8;
+extern const float FLOAT_803333F0;
+extern const float FLOAT_803333F4;
+extern const float FLOAT_803333F8;
+extern const float FLOAT_803333FC;
+extern const float FLOAT_80333400;
+extern const float FLOAT_80333404;
+extern const double DOUBLE_80333408;
+extern const double DOUBLE_80333410;
+extern const double DOUBLE_80333418;
+extern const double DOUBLE_80333420;
 
 extern "C" const float FLOAT_80333614 = 196.0f;
 extern "C" const float FLOAT_80333618 = 168.0f;


### PR DESCRIPTION
## Summary
- Change the menu list references to the shared 803333xx constants from local static definitions to external declarations.
- Keeps menu_lst owning its actual 80333614..80333674 sdata2 block while avoiding duplicate private constants in the object.

## Evidence
- ninja: build/GCCP01/main.dol OK
- Full report matched data: 1122369 -> 1122381 (+12 bytes)
- main/menu_lst objdiff:
  - .sdata2 size: 200 -> 128 bytes
  - [.sdata2-0] match: 64.86486% -> 85.71429%
  - MLstClose: 78.17757% -> 80.607475%
  - MLstOpen: 78.77778% -> 78.80556%

## Notes
- There are small code-score regressions in MLstDraw and MLstCtrl from referencing external constants instead of local copies, but the data ownership is closer to the linked MAP: FLOAT_803333D0/DOUBLE_80333408 resolve from menu_equip.o, while menu_lst owns the 80333614 sdata2 block.