### PR TITLE
Correct CUSBPcs base class

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,7 +2,7 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/system.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/usb.h"
 
 struct CUSBPcsTable
@@ -16,7 +16,7 @@ extern unsigned int m_table_desc1__7CUSBPcs[];
 extern unsigned int m_table_desc2__7CUSBPcs[];
 extern CUSBPcsTable m_table__7CUSBPcs;
 
-class CUSBPcs : public CProcess
+class CUSBPcs : public CSamplePcs
 {
 public:
     class CDataHeader;


### PR DESCRIPTION
## Summary
- Change CUSBPcs to derive from CSamplePcs instead of directly from CProcess.
- This matches the p_usb static initializer evidence, which constructs through the CSamplePcs vtable before installing the CUSBPcs vtable.

## Evidence
- ninja passes.
- main/p_usb matched data improves from 324 bytes (35.84071%) to 432 bytes (47.78761%).
- matched code bytes remain 612.
- SendDataCode__7CUSBPcsFiPvii remains 98.74436%.

## Notes
- __sinit_p_usb_cpp fuzzy score drops slightly because the compiler now emits the CSamplePcs base construction path, but the hierarchy and data layout are more plausible and improve matched data.