### PR TITLE
Use CRef delete for menu font releases

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -170,7 +170,7 @@ static inline void ReleaseRefObject(void* object)
     int refCount = raw[1] - 1;
     raw[1] = refCount;
     if (refCount == 0) {
-        reinterpret_cast<void (*)(void*, int)>(*reinterpret_cast<int*>(raw[0] + 8))(object, 1);
+        delete reinterpret_cast<CRef*>(object);
     }
 }
 

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1522,7 +1522,7 @@ void CMenuPcs::LoadExtraFont(int fontNo, char* fileName)
     if (font != 0) {
         u32* raw = reinterpret_cast<u32*>(font);
         if (--raw[1] == 0) {
-            reinterpret_cast<void (*)(void*, int)>(*reinterpret_cast<u32*>(raw[0] + 8))(font, 1);
+            delete reinterpret_cast<CRef*>(font);
         }
         *reinterpret_cast<u32*>(reinterpret_cast<u8*>(this) + slot) = 0;
     }

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -965,7 +965,7 @@ void CMenuPcs::createSingleMenu()
                 int refCount = raw[1] - 1;
                 raw[1] = refCount;
                 if (refCount == 0) {
-                    reinterpret_cast<void (*)(void*, int)>(*reinterpret_cast<int*>(raw[0] + 8))(font, 1);
+                    delete reinterpret_cast<CRef*>(font);
                 }
                 *reinterpret_cast<void**>(self + 0x108) = 0;
             }
@@ -1024,7 +1024,7 @@ void CMenuPcs::destroySingleMenu()
         int refCount = raw[1] - 1;
         raw[1] = refCount;
         if (refCount == 0) {
-            reinterpret_cast<void (*)(void*, int)>(*reinterpret_cast<int*>(raw[0] + 8))(font, 1);
+            delete reinterpret_cast<CRef*>(font);
         }
         *reinterpret_cast<void**>(self + 0x108) = 0;
     }


### PR DESCRIPTION
## Summary
- replace manual CRef virtual destructor dispatches with normal delete expressions in menu font release paths
- improves matching in p_menu, singmenu, and cmake while keeping the existing refcount and slot-clear behavior

## Objdiff evidence
- main/p_menu: 83.61874 -> 83.67593
  - LoadExtraFont__8CMenuPcsFiPc: 95.76923 -> 99.80769, size remains 208
- main/singmenu: 61.685474 -> 61.76241
  - createSingleMenu__8CMenuPcsFv: 96.16129 -> 98.41936, size remains 372
  - destroySingleMenu__8CMenuPcsFv: 91.65476 -> 94.15476, size remains 336
- main/cmake: 33.064133 -> 33.117897
  - destroyVillageMenu__8CMenuPcsFv: 94.270836 -> 98.645836, size remains 192

## Plausibility
These sites were manually dispatching the virtual destructor through vtable slot 2 after decrementing CRef's refcount. The replacement is the source-level form the original code would plausibly use: delete through CRef*, letting the compiler emit the destructor dispatch.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_menu -o - LoadExtraFont__8CMenuPcsFiPc
- build/tools/objdiff-cli diff -p . -u main/singmenu -o - createSingleMenu__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/singmenu -o - destroySingleMenu__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/cmake -o - destroyVillageMenu__8CMenuPcsFv