### PR TITLE
Fix Saw attacked shared work state

### DIFF
--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -967,8 +967,8 @@ void CGMonObj::attackedFuncSaw()
 	CGPrgObj* prgObj = reinterpret_cast<CGPrgObj*>(this);
 	if (prgObj->m_lastStateId == 100) {
 		prgObj->addSubStat();
-		*reinterpret_cast<unsigned char*>(reinterpret_cast<unsigned char*>(this) + 0x6D4) |= 0x80;
-		*reinterpret_cast<int*>(SoundBuffer + 1268) = 0xFA;
+		*reinterpret_cast<unsigned char*>(SoundBuffer_1260_ + 0x14) |= 0x80;
+		*reinterpret_cast<int*>(SoundBuffer_1260_ + 0x8) = 0xFA;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update `CGMonObj::attackedFuncSaw` to set the Saw shared AI work flag via `SoundBuffer_1260_` instead of the per-object `this + 0x6D4` byte.
- Store the Saw cooldown through the same shared work buffer alias.

## Objdiff Evidence
- `attackedFuncSaw__8CGMonObjFv`: 34.16% -> 83.63% match
- `main/monobj_boss` `.text`: improved to 45.958843%

## Plausibility
Adjacent Saw code in `monobj_boss.cpp` already treats `SoundBuffer_1260_ + 0x14` and nearby fields as shared Saw AI work/cooldown state. Ghidra also points this function at the shared `m_aiWork`/`SoundBuffer` storage, so this removes an incorrect per-object offset rather than coercing codegen.