### PR TITLE
Improve YmMiasma particle initialization

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -542,9 +542,9 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     trigSin = gPppTrigTable[(s32)(angle & 0xffff) >> 2];
     *(short*)((u8*)&particleData->m_velocity.x + 8) = (short)(randomValue % 0x168);
     radiusJitter = randomScale * pYmMiasma->m_radiusJitter;
-    trigCos = trigCos * (vYmMiasma->m_radius + radiusJitter);
-    particleData->m_matrix[0][0] = trigCos;
-    particleData->m_matrix[1][0] = trigCos;
+    float posX = trigCos * (vYmMiasma->m_radius + radiusJitter);
+    particleData->m_matrix[0][0] = posX;
+    particleData->m_matrix[1][0] = posX;
     randomHeight = Math.RandF(pYmMiasma->m_spawnHeightJitter);
     particleData->m_matrix[0][1] = randomHeight;
     particleData->m_matrix[1][1] = randomHeight;


### PR DESCRIPTION
## Summary
- Materialize the computed X position in InitParticleData before writing both matrix rows.
- This matches the original register flow more closely for the YmMiasma particle spawn path.

## Evidence
- ninja passes.
- objdiff command: build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o - InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA
- InitParticleData: 99.90826% -> 99.977066%.
- main/pppYmMiasma text: 98.62641% -> 98.64334%.
- Build report now shows one additional matched function and +872 matched code bytes compared to the baseline for this run.

## Plausibility
- The change names the computed X component instead of reusing the trig cosine variable after scaling.
- Behavior is unchanged, but the source now reflects the distinct position value used for both matrix rows.