### PR TITLE
Fix mapanim RTTI ownership

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -520,7 +520,7 @@ config.libs = [
             Object(NonMatching, "main.cpp"),
             Object(Matching, "manager.cpp"),
             Object(NonMatching, "map.cpp"),
-            Object(NonMatching, "mapanim.cpp", extra_cflags=["-RTTI on"]),
+            Object(NonMatching, "mapanim.cpp"),
             Object(NonMatching, "maphit.cpp"),
             Object(Matching, "maplight.cpp"),
             Object(NonMatching, "mapmesh.cpp", extra_cflags=["-sdata 8"]),


### PR DESCRIPTION
## Summary
- compile mapanim.cpp with the default RTTI-off game flags instead of forcing RTTI on
- removes the extra source-side RTTI data emitted before CPtrArray<CMapAnimNode*> vtable data

## Evidence
- ninja passes
- main/mapanim objdiff: [.data-0] improves from 19.78022% to 80.0%
- source-side .data size now matches target size at 12 bytes instead of carrying the extra 28-byte RTTI block
- Interp__12CMapAnimNodeFi remains unchanged at 99.05623%

## Plausibility
The target mapanim object owns only the CPtrArray<CMapAnimNode*> vtable-sized data here. Forcing RTTI on made this unit emit additional RTTI data that does not belong to the target layout, so using the normal game RTTI-off flags is closer to original source/compiler ownership.