### PR TITLE
Improve p_dbgmenu drawMenu state flag

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -513,7 +513,7 @@ void CDbgMenuPcs::drawMenu(CDbgMenuPcs::CDM* menu)
 		if (type != 2) {
 			if (type >= 2) {
 				if (type < 4) {
-					drawWindow(((-menu->m_state | menu->m_state) >> 0x1F) & 2, 1, 1, 0x1E, 0xE, 0);
+					drawWindow((menu->m_state != 0) ? 2 : 0, 1, 1, 0x1E, 0xE, 0);
 				}
 			} else if (type == 0) {
 				drawWindow(menu->m_y, 0, 0, menu->m_unk18, menu->m_unk1C, menu->m_text);
@@ -521,7 +521,7 @@ void CDbgMenuPcs::drawMenu(CDbgMenuPcs::CDM* menu)
 				drawFont(menu->m_y, 0, 0, menu->m_text);
 			}
 		} else {
-			drawWindow(((-menu->m_state | menu->m_state) >> 0x1F) & 2, 1, 1, 0x1E, 0xE, 0);
+			drawWindow((menu->m_state != 0) ? 2 : 0, 1, 1, 0x1E, 0xE, 0);
 
 			const char* stateText;
 			if (menu->m_state == 1) {


### PR DESCRIPTION
## Summary
- Replace the output-shaped debug-menu state flag expression with a source-level boolean ternary in drawMenu.
- Keeps behavior identical while producing code closer to the PAL target for the type 2/type 3 drawWindow calls.

## Evidence
- ninja passes.
- objdiff main/p_dbgmenu drawMenu__11CDbgMenuPcsFPQ211CDbgMenuPcs3CDM improved from 71.909836% to 74.508194%.
- drawMenu mismatches dropped from 80 to 72; rebuilt size moved closer to target, 0x1d8 -> 0x1e0 vs target 0x1e8.
- Adjacent checks unchanged: drawWindow__11CDbgMenuPcsFiiiiiPc remains 81.6018%, __sinit_p_dbgmenu_cpp remains 70.68%.

## Plausibility
The new expression is normal C++ source for passing a two-state flag, replacing manual sign-bit arithmetic that looked like decompiler/output-shaped code.