### PR TITLE
Reduce LocationTitle2 interpolation buffer

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -221,7 +221,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     Mtx nodeMtx;
     int nextCount;
     Vec stepDir;
-    Vec interp[21];
+    Vec interp[20];
     int startIndex;
     int inserted;
     float stepScale;


### PR DESCRIPTION
## Summary
- reduce the local interpolation buffer in pppFrameLocationTitle2 from 21 Vec entries to 20
- matches the target stack frame size more closely and improves objdiff for LocationTitle2

## Evidence
- ninja passes
- objdiff main/LocationTitle2:
  - pppFrameLocationTitle2: 95.78619% -> 95.822365%
  - pppRenderLocationTitle2: unchanged at 99.832535%

## Plausibility
- the interpolation loop is bounded by m_stepCount, and 20 entries matches the smaller target frame without introducing control-flow or linkage hacks
- change is a real local stack/layout correction, not a manual symbol or section workaround