### PR TITLE
Improve pppScreenBreak before-draw callback

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -630,7 +630,7 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
     Vec lightDir;
     GXLightObj lightObj;
     u8* camera = reinterpret_cast<u8*>(&CameraPcs);
-    const float& cameraOffset = FLOAT_80331ce8;
+    const float cameraOffset = FLOAT_80331ce8;
     const float& zero = FLOAT_80331cc4;
     const float& one = FLOAT_80331cd0;
     const float& attnA = FLOAT_80331cec;


### PR DESCRIPTION
## Summary
- Change the camera offset local in SB_BeforeDrawCallback from a reference alias to a local float value.
- This improves MWCC register allocation for the callback while preserving the same lighting calculation.

## Evidence
- ninja passes.
- objdiff command: build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi
- SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi: 99.554054% -> 99.89189%.
- main/pppScreenBreak .text: 92.615524% -> 92.637825%.

## Plausibility
- The recovered source still expresses the same camera offset scalar directly; it avoids pointer/reference aliasing for a simple constant used in arithmetic and better matches the original callback codegen.