### PR TITLE
Improve mapmesh small data layout

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -17,7 +17,9 @@ extern "C" char s_mapmesh_cpp_801D70B0[];
 extern "C" const float FLOAT_8032F930 = 10000000000.0f;
 extern "C" const float FLOAT_8032F934 = -10000000000.0f;
 
+extern CMapHitFace* g_hit_lpface_min;
 CMemory::CStage* g_pStage;
+void* lbl_8032ECA4;
 
 extern "C" {
 void SetBlendMode__12CMaterialManFP12CMaterialSeti(void* materialMan, CMaterialSet* materialSet, unsigned int materialIdx);
@@ -102,7 +104,7 @@ static inline unsigned int Align32(unsigned int value)
 
 static inline CMemory::CStage*& MapMeshAllocStage()
 {
-    return g_pStage;
+    return reinterpret_cast<CMemory::CStage*&>(g_hit_lpface_min);
 }
 }
 


### PR DESCRIPTION
Summary:
- Add the missing mapmesh-owned sbss slot so the unit data layout matches the original object.
- Route the temporary ReadOtmMesh allocation stage through the external small-data symbol referenced by the original object.
- Preserve existing matched code shape while improving mapmesh linkage/data evidence.

Evidence:
- ninja passes.
- main/mapmesh .text: 99.67049% -> 99.684814%.
- ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii: 99.41536% -> 99.441536%.
- .sbss: 66.66667% -> 100.0%, with lbl_8032ECA4 now matching at 100.0%.

Notes:
- I checked p_sound, chara_anim, and wind follow-up targets, but left them unchanged because the remaining gaps were vtable/RTTI-adjacent artifacts or source-shape experiments with no objdiff gain.