### PR TITLE
Improve pppScreenBreak and TmpArtiCtrl matching

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -373,7 +373,7 @@ void CMenuPcs::TmpArtiCtrl()
 	if (hasInput) {
 		uVar3 = 0;
 	} else {
-		int padIndex = hasInput;
+		int padIndex = 0;
 		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
 		uVar3 = *reinterpret_cast<u16*>(reinterpret_cast<u8*>(&Pad) + padIndex * 0x54 + 8);
 	}

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -72,6 +72,12 @@ struct ScreenBreakModelView {
     ScreenBreakMeshRef* m_meshes;
 };
 
+struct ScreenBreakNode {
+    u8 _pad0[0xBC];
+    u8 _padBC_0 : 7;
+    u8 m_disabled : 1;
+};
+
 struct pppScreenBreakUnkB {
     s32 m_graphId;
     s32 m_dataValIndex;
@@ -437,7 +443,7 @@ void InitPieceData(CChara::CModel* model, PScreenBreak* step, VScreenBreak* work
     for (uVar15 = 0; uVar15 < *(u32*)(modelData + 0xC); uVar15++) {
         iVar14 = *(s32*)(iVar16 + 8);
         iVar5 = *(s32*)((u8*)model + 0xA8) + (*(s32*)(iVar14 + 0x5C) * 0xC0);
-        *(u8*)(iVar5 + 0xBC) &= 0x7F;
+        ((ScreenBreakNode*)iVar5)->m_disabled = 0;
         PSMTXIdentity((float(*)[4])(iVar5 + 0x14));
 
         iVar5 = *(s32*)(iVar14 + 0x14);
@@ -531,8 +537,7 @@ void InitPieceData(CChara::CModel* model, PScreenBreak* step, VScreenBreak* work
         inVec->y = dVar20;
         inVec->z = dVar21;
         PSVECNormalize(inVec, inVec);
-        Vec local_c8 = DAT_801dd4bc;
-        PSVECCrossProduct(inVec, &local_c8, inVec + 2);
+        PSVECCrossProduct(inVec, const_cast<Vec*>(&DAT_801dd4bc), inVec + 2);
 
         dVar17 = Math.RandF(*(float*)((u8*)step + 0x3C));
         PSVECScale(inVec, inVec, *(float*)((u8*)step + 0x38) + dVar17);


### PR DESCRIPTION
## Summary
- Model the screen-break node flag byte as a bitfield and clear the disabled/high bit through member access.
- Pass the shared up vector directly into PSVECCrossProduct, reducing the InitPieceData stack/register mismatch.
- Simplify TmpArtiCtrl's debug pad fallback index to a literal zero in the no-input branch, matching the target's zero-based pad read setup more closely.

## Objdiff evidence
- Unit main/pppScreenBreak .text: 92.615524% -> 92.90098%
- InitPieceData__FPQ26CChara6CModelP12PScreenBreakP12VScreenBreak: 71.745094% -> 73.0%
- SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv: unchanged at 95.44444%
- Unit main/menu_tmparti target symbols:
  - TmpArtiDraw__8CMenuPcsFv: unchanged at 67.79924%
  - TmpArtiClose__8CMenuPcsFv: unchanged at 75.06542%
  - TmpArtiCtrl__8CMenuPcsFv: 75.79032% -> 76.247314%
  - TmpArtiOpen__8CMenuPcsFv: unchanged at 76.05882%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o /tmp/pppScreenBreak_final.json
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiDraw__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiClose__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiCtrl__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiOpen__8CMenuPcsFv

The flag-byte change matches the target bitfield-style clear instruction, the up-vector change removes unnecessary local vector materialization, and the TmpArtiCtrl fallback now expresses the zero pad index directly instead of carrying a false boolean through the address calculation.