### PR TITLE
Match Tetsukyojin cancel state handler

### DIFF
--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -1515,19 +1515,17 @@ void CGMonObj::cancelStatFuncTetsukyojin()
 	CGPrgObj* prgObj = reinterpret_cast<CGPrgObj*>(this);
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	const int state = prgObj->m_lastStateId;
-	if (state != 0x66) {
-		if (state < 0x66) {
-			if (state != 100) {
-				return;
-			}
-		} else if (state >= 0x68) {
-			return;
-		}
-	} else {
+	switch (state) {
+	case 0x66:
 		object->m_bgColMask |= 0xC0002;
 		return;
+	case 100:
+	case 0x67:
+		CGMonObj_ResetActionState(this);
+		return;
+	default:
+		return;
 	}
-	CGMonObj_ResetActionState(this);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rewrites CGMonObj::cancelStatFuncTetsukyojin() as a direct switch over the handled states.
- Preserves behavior for state 0x66 bg collision mask updates and states 100/0x67 action reset.

## Evidence
- ninja passes.
- objdiff for cancelStatFuncTetsukyojin__8CGMonObjFv reports match_percent: 100.0, diffs: 0.
- Build report increased matched code by 92 bytes and matched functions by 1.

## Plausibility
- The switch matches the recovered control flow directly without fake symbols, address hacks, or manual linkage.