### PR TITLE
Align async chara model load flow

### DIFF
--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -27,6 +27,7 @@ extern "C" void __dla__FPv(void*);
 extern "C" void __dl__FPv(void*);
 extern "C" int __cntlzw(unsigned int);
 extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
+extern "C" void* __nw__11CTextureSetFUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void __dt__4CRefFv(void*, int);
 extern "C" void __dt__Q29CCharaPcs7CHandleFv(void*, int);
@@ -3084,70 +3085,63 @@ void CCharaPcs::CHandle::loadModelASyncFrame()
             loadModelASyncFrame();
             return;
         }
-        if (m_asyncFileHandle != 0) {
-            File.ReadASync(m_asyncFileHandle);
-        }
+        File.ReadASync(m_asyncFileHandle);
         m_asyncState++;
         return;
     }
 
-    if ((asyncState != 2 && asyncState != 4 && asyncState != 6) || m_asyncFileHandle == 0 ||
-        !File.IsCompleted(m_asyncFileHandle)) {
+    if ((asyncState != 2 && asyncState != 4 && asyncState != 6) || !File.IsCompleted(m_asyncFileHandle)) {
         return;
     }
 
     if (m_asyncState == 2) {
         CLoadModel* loadModel = new (StageAt(&CharaPcs, 0xC0), const_cast<char*>(s_p_chara_cpp), 0x5E8) CLoadModel;
-        if (loadModel != 0) {
-            loadModel->m_keyTag = reinterpret_cast<void*>(m_asyncCharaKind);
-            loadModel->m_keyId = m_asyncCharaNo;
-            loadModel->m_mergeFileId = -1;
-            loadModel->m_mergeFlags = 0;
-            loadModel->m_model = reinterpret_cast<CChara::CModel*>(
-                __nw__FUlPQ27CMemory6CStagePci(0x124, StageAt(&CharaPcs, 0xC0), const_cast<char*>(s_p_chara_cpp), 0x5F1));
-            loadModel->m_streamMode = 0;
-            loadModel->m_streamOffset = 0;
-            loadModel->m_streamSize = 0;
-            if (loadModel->m_model != 0) {
-                loadModel->m_model = reinterpret_cast<CChara::CModel*>(__ct__Q26CChara6CModelFv(loadModel->m_model));
-                Create__Q26CChara6CModelFPvPQ27CMemory6CStage(
-                    loadModel->m_model, File.m_readBuffer, HandleModelStage(m_asyncCharaKind, 0));
-            }
-            LoadModelArray(&CharaPcs)->Add(loadModel);
-            m_modelLoadRef = loadModel;
-            AddSharedRef(m_modelLoadRef);
-            m_model = loadModel->m_model;
-            AddSharedRef(m_model);
-            m_charaKind = m_asyncCharaKind;
-            m_charaNo = m_asyncCharaNo;
+        loadModel->m_keyTag = reinterpret_cast<void*>(m_asyncCharaKind);
+        loadModel->m_keyId = m_asyncCharaNo;
+        loadModel->m_mergeFileId = -1;
+        loadModel->m_mergeFlags = 0;
+        LoadModelArray(&CharaPcs)->Add(loadModel);
+        loadModel->m_model = reinterpret_cast<CChara::CModel*>(
+            __nw__FUlPQ27CMemory6CStagePci(0x124, StageAt(&CharaPcs, 0xC0), const_cast<char*>(s_p_chara_cpp), 0x5F1));
+        loadModel->m_streamMode = 0;
+        loadModel->m_streamOffset = 0;
+        loadModel->m_streamSize = 0;
+        if (loadModel->m_model != 0) {
+            loadModel->m_model = reinterpret_cast<CChara::CModel*>(__ct__Q26CChara6CModelFv(loadModel->m_model));
         }
+        Create__Q26CChara6CModelFPvPQ27CMemory6CStage(
+            loadModel->m_model, File.m_readBuffer, HandleModelStage(m_asyncCharaKind, 0));
+        m_modelLoadRef = loadModel;
+        AddSharedRef(m_modelLoadRef);
+        m_model = loadModel->m_model;
+        AddSharedRef(m_model);
+        m_charaKind = m_asyncCharaKind;
+        m_charaNo = m_asyncCharaNo;
     } else if (m_asyncState == 4) {
-        if (m_model != 0) {
-            CreateDynamics__Q26CChara6CModelFPvPQ27CMemory6CStage(m_model, File.m_readBuffer, HandleModelStage(m_asyncCharaKind, 0));
-        }
+        CreateDynamics__Q26CChara6CModelFPvPQ27CMemory6CStage(m_model, File.m_readBuffer, HandleModelStage(m_asyncCharaKind, 0));
     } else {
         CLoadTexture* loadTexture = new (StageAt(&CharaPcs, 0xC0), const_cast<char*>(s_p_chara_cpp), 0x609) CLoadTexture;
-        if (loadTexture != 0) {
-            loadTexture->m_keyTag = reinterpret_cast<void*>(m_asyncCharaKind);
-            loadTexture->m_keyId = m_asyncCharaNo;
-            loadTexture->m_mergeFileId = -1;
-            loadTexture->m_mergeFlags = 0;
-            loadTexture->m_variantTag = reinterpret_cast<void*>(m_asyncTextureVariant);
-            loadTexture->m_textureSet = new (StageAt(&CharaPcs, 0xC0), const_cast<char*>(s_p_chara_cpp), 0x397) CTextureSet;
-            loadTexture->m_streamMode = 0;
-            loadTexture->m_streamOffset = 0;
-            loadTexture->m_streamSize = 0;
-            if (loadTexture->m_textureSet != 0) {
-                loadTexture->m_textureSet->Create(File.m_readBuffer, HandleTextureStage(m_asyncCharaKind), 0, 0, 0, 0);
-            }
-            LoadTextureArray(&CharaPcs)->Add(loadTexture);
-            m_texLoadRef = loadTexture;
-            AddSharedRef(m_texLoadRef);
-            m_textureSet = loadTexture->m_textureSet;
-            AddSharedRef(m_textureSet);
-            AttachTextureSet__Q26CChara6CModelFP11CTextureSet(m_model, m_textureSet);
-            m_textureVariant = m_asyncTextureVariant;
+        loadTexture->m_keyTag = reinterpret_cast<void*>(m_asyncCharaKind);
+        loadTexture->m_keyId = m_asyncCharaNo;
+        loadTexture->m_mergeFileId = -1;
+        loadTexture->m_mergeFlags = 0;
+        loadTexture->m_variantTag = reinterpret_cast<void*>(m_asyncTextureVariant);
+        LoadTextureArray(&CharaPcs)->Add(loadTexture);
+        loadTexture->m_textureSet = reinterpret_cast<CTextureSet*>(
+            __nw__11CTextureSetFUlPQ27CMemory6CStagePci(0x24, StageAt(&CharaPcs, 0xC0), const_cast<char*>(s_p_chara_cpp), 0x397));
+        loadTexture->m_streamMode = 0;
+        loadTexture->m_streamOffset = 0;
+        loadTexture->m_streamSize = 0;
+        if (loadTexture->m_textureSet != 0) {
+            loadTexture->m_textureSet = ::new (loadTexture->m_textureSet) CTextureSet;
         }
+        loadTexture->m_textureSet->Create(File.m_readBuffer, HandleTextureStage(m_asyncCharaKind), 0, 0, 0, 0);
+        m_texLoadRef = loadTexture;
+        AddSharedRef(m_texLoadRef);
+        m_textureSet = loadTexture->m_textureSet;
+        AddSharedRef(m_textureSet);
+        AttachTextureSet__Q26CChara6CModelFP11CTextureSet(m_model, m_textureSet);
+        m_textureVariant = m_asyncTextureVariant;
     }
 
     File.Close(m_asyncFileHandle);


### PR DESCRIPTION
## Summary
- Reshapes `CCharaPcs::CHandle::loadModelASyncFrame` toward the decompiled PAL control flow.
- Removes extra null guards around async read/completion paths that are not present in the target.
- Moves async load record insertion ahead of payload allocation for model and texture loads, matching the Ghidra function shape.

## Evidence
- `ninja` passes.
- `objdiff-cli diff -p . -u main/p_chara -o - loadModelASyncFrame__Q29CCharaPcs7CHandleFv` still reports a 0% instruction match, but the compiled function size now matches the PAL target size: 1440 bytes. Before this change, the compiled side was 1480 bytes.
- Overall report totals are unchanged; this is a source-shape and size-alignment improvement for a currently unmatched async-load function.

## Plausibility
- The changes are backed by `resources/ghidra-decomp-1-31-2026/80073dbc_loadModelASyncFrame__Q29CCharaPcs7CHandleFv.c`.
- The resulting code removes defensive guards that were not in the original control flow and keeps normal C++ allocation/construction patterns rather than introducing section or symbol hacks.