### PR TITLE
Recover viewer spinner local statics

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -68,12 +68,6 @@ extern u8 ARRAY_8026D728[];
 extern "C" CUSBStreamData* __dt__14CUSBStreamDataFv(CUSBStreamData* self, short shouldDelete);
 extern const char s_CFunnyShapePcs[];
 extern "C" const char lbl_8032FD1C[] = "|/-\\";
-extern "C" {
-char* gFunnyShapeSpinnerText;
-s8 gFunnyShapeSpinnerTextInitialized;
-int gFunnyShapeSpinnerFrame;
-s8 gFunnyShapeSpinnerFrameInitialized;
-}
 
 namespace {
 static inline u8* Ptr(CFunnyShapePcs* self, u32 offset)
@@ -430,24 +424,18 @@ void CFunnyShapePcs::drawViewer()
         FunnyShape(this)->Render();
     }
 
-    if (!gFunnyShapeSpinnerTextInitialized) {
-        gFunnyShapeSpinnerText = const_cast<char*>(lbl_8032FD1C);
-        gFunnyShapeSpinnerTextInitialized = true;
-    }
-    if (!gFunnyShapeSpinnerFrameInitialized) {
-        gFunnyShapeSpinnerFrame = 0;
-        gFunnyShapeSpinnerFrameInitialized = true;
-    }
+    static char* pFan = const_cast<char*>(lbl_8032FD1C);
+    static int alive = 0;
 
-    gFunnyShapeSpinnerFrame++;
-    if (gFunnyShapeSpinnerFrame > 100000) {
-        gFunnyShapeSpinnerFrame = 0;
+    alive++;
+    if (alive > 100000) {
+        alive = 0;
     }
 
     GXSetViewport(kFunnyShapeViewportOrigin, kFunnyShapeViewportOrigin, kFunnyShapeViewportWidth, kFunnyShapeViewportHeight, kFunnyShapeViewportOrigin, kFunnyShapeNdcMax);
     {
-        int frame = gFunnyShapeSpinnerFrame >> 4;
-        Graphic.Printf(const_cast<char*>(s_funnyShapeFmt), gFunnyShapeSpinnerText[frame % 4]);
+        int frame = alive >> 4;
+        Graphic.Printf(const_cast<char*>(s_funnyShapeFmt), pFan[frame % 4]);
     }
 }
 

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -30,13 +30,6 @@ extern "C" char lbl_8032E648[];
 extern "C" const char s_CMaterialEditorPcs_VIEWER_801D7D18[];
 extern "C" const char s_CMaterialEditorPcs_801D7D34[];
 extern "C" const char s_MaterialEditor_pctc_801D7D60[];
-extern "C" {
-const char* gDebugSpinnerText_addr;
-char gDebugSpinnerTextInitialized_addr;
-int gDebugSpinnerFrame_addr;
-char gDebugSpinnerFrameInitialized_addr;
-}
-
 unsigned int m_table_desc0__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__18CMaterialEditorPcsFv)};
 unsigned int m_table_desc1__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__18CMaterialEditorPcsFv)};
 unsigned int m_table_desc2__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__18CMaterialEditorPcsFv)};
@@ -544,18 +537,12 @@ void CMaterialEditorPcs::drawViewer()
 {
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
 
-    if (gDebugSpinnerTextInitialized_addr == 0) {
-        gDebugSpinnerText_addr = sMaterialEditorSpinnerText;
-        gDebugSpinnerTextInitialized_addr = 1;
-    }
-    if (gDebugSpinnerFrameInitialized_addr == 0) {
-        gDebugSpinnerFrame_addr = 0;
-        gDebugSpinnerFrameInitialized_addr = 1;
-    }
+    static const char* pFan = sMaterialEditorSpinnerText;
+    static int alive = 0;
 
-    gDebugSpinnerFrame_addr = gDebugSpinnerFrame_addr + 1;
-    int idx = (gDebugSpinnerFrame_addr >> 4) % 4;
-    Printf__8CGraphicFPce(&Graphic, s_MaterialEditor_pctc_801D7D60, (int)(char)gDebugSpinnerText_addr[idx]);
+    alive = alive + 1;
+    int idx = (alive >> 4) % 4;
+    Printf__8CGraphicFPce(&Graphic, s_MaterialEditor_pctc_801D7D60, (int)(char)pFan[idx]);
 
     if (*reinterpret_cast<int*>(self + 0xE8) != 0) {
         return;

--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -200,10 +200,6 @@ unsigned int lbl_801EAD84[3] = {reinterpret_cast<unsigned int>(lbl_8032E69C), 0x
 unsigned int lbl_801EAD90 = reinterpret_cast<unsigned int>(lbl_8032E69C);
 int DAT_8032ed38;
 int DAT_8032ed3c;
-static const char* s_drawAfterViewerFan;
-static char s_drawAfterViewerFanInitialized;
-static int s_drawAfterViewerAlive;
-static char s_drawAfterViewerAliveInitialized;
 CPartPcs PartPcs;
 CProfile g_par_calc_prof(const_cast<char*>(s_no_name_8032fdcc));
 CProfile g_par_draw_prof(const_cast<char*>(s_no_name_8032fdcc));
@@ -1258,18 +1254,12 @@ void CPartPcs::drawAfterViewer()
 	PartMng.pppGet2Dpos();
 	pppClearDrawEnv();
 
-	if (s_drawAfterViewerFanInitialized == 0) {
-		s_drawAfterViewerFan = sDebugSpinnerText;
-		s_drawAfterViewerFanInitialized = 1;
-	}
-	if (s_drawAfterViewerAliveInitialized == 0) {
-		s_drawAfterViewerAlive = 0;
-		s_drawAfterViewerAliveInitialized = 1;
-	}
+	static const char* pFan = sDebugSpinnerText;
+	static int alive = 0;
 
-	s_drawAfterViewerAlive++;
+	alive++;
 	Graphic.Printf(
-		const_cast<char*>(s_tina_title_fmt_801d8014), s_drawAfterViewerFan[(s_drawAfterViewerAlive >> 4) % 4]);
+		const_cast<char*>(s_tina_title_fmt_801d8014), pFan[(alive >> 4) % 4]);
 
 	g_par_calc_prof.ProfEnd();
 	g_par_draw_prof.ProfEnd();


### PR DESCRIPTION
## Summary
- Replaced manually modeled viewer spinner globals with function-local statics in FunnyShape, MaterialEditor, and Tina viewer draw paths.
- This matches the shipped local-static symbol layout for the spinner pointer/counter guards instead of exporting artificial globals.

## Objdiff Evidence
- main/p_FunnyShape: alive, init, pFan, init now report 100.0%; drawViewer__14CFunnyShapePcsFv remains 99.46212%.
- main/p_MaterialEditor: pFan and init now report 100.0%; drawViewer__18CMaterialEditorPcsFv remains 67.233376%.
- main/p_tina: alive and init now report 100.0%; drawAfterViewer__8CPartPcsFv remains 99.40476%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o -
- build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o -
- build/tools/objdiff-cli diff -p . -u main/p_tina -o -