### PR TITLE
Match mapmesh float constant loads

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -104,6 +104,11 @@ static inline CMemory::CStage*& MapMeshAllocStage()
 {
     return g_pStage;
 }
+
+static inline float LoadMapMeshFloat(const float& value)
+{
+    return value;
+}
 }
 
 /*
@@ -413,8 +418,8 @@ unsigned int CMapMesh::ReadOtmMesh(CChunkFile& chunkFile, CMemory::CStage* stage
         case 0x56455254:
             m_meshData = __nwa__FUlPQ27CMemory6CStagePci(workSize, MapMeshAllocStage(), s_mapmesh_cpp_801D70B0, 0x13A);
 
-            float maxInit = FLOAT_8032F934;
-            float minInit = FLOAT_8032F930;
+            float maxInit = LoadMapMeshFloat(FLOAT_8032F934);
+            float minInit = LoadMapMeshFloat(FLOAT_8032F930);
             cursor = reinterpret_cast<unsigned char*>(Align32(reinterpret_cast<unsigned int>(m_meshData)));
             m_vertexCount = static_cast<unsigned short>(chunk.m_size / 0xC);
             m_vertices = cursor;
@@ -707,8 +712,8 @@ void CMapMesh::Destroy()
  */
 CMapMesh::CMapMesh()
 {
-    const float minInit = 10000000000.0f;
-    const float maxInit = -10000000000.0f;
+    float maxInit = LoadMapMeshFloat(FLOAT_8032F934);
+    float minInit = LoadMapMeshFloat(FLOAT_8032F930);
 
     F32At(this, 0x14) = minInit;
     F32At(this, 0x10) = minInit;


### PR DESCRIPTION
## Summary
- Add a small mapmesh float-load helper so MWCC loads the existing FLOAT_8032F930/FLOAT_8032F934 symbols instead of materializing local literals.
- Use the named constants in CMapMesh::CMapMesh and the vertex chunk path in CMapMesh::ReadOtmMesh.

## Objdiff evidence
- main/mapmesh .text: 99.67049% -> 99.68959%.
- __ct__8CMapMeshFv: 99.47369% -> 100.0%.
- ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii: 99.41536% -> 99.43281%.

## Plausibility
- This follows the existing decomp pattern of using a by-reference load helper to preserve real small-data symbol references.
- No fake vtables, manual sections, address constants, or unrelated refactors.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/mapmesh -o -