### PR TITLE
Declare YmBreath zero constant

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -21,6 +21,8 @@ extern "C" void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 extern "C" void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, unsigned char);
 extern "C" void pppNormalize__FR3Vec3Vec(float*, Vec*);
 
+extern const float FLOAT_80330c80;
+
 struct pppYmBreathUnkC {
     unsigned char _pad[0xC];
     int* m_serializedDataOffsets;


### PR DESCRIPTION
## Summary
- Declares the existing `FLOAT_80330c80` sdata2 constant in `pppYmBreath.cpp` where `UpdateAllParticle` uses it.
- Keeps the constant definition/linkage owned by `chara_anim.cpp` and avoids duplicating sdata2 storage.

## Evidence
- Before: `ninja` failed compiling `src/pppYmBreath.cpp` with undefined identifier `FLOAT_80330c80` at line 786.
- After: `ninja` completes successfully and `build/GCCP01/main.dol: OK`.
- Focused exploratory objdiff checks were restored to baseline for `menu_tmparti` and `p_tina`; no speculative target edits are included.

## Plausibility
- `config/GCCP01/symbols.txt` already maps `FLOAT_80330c80` as a 4-byte `.sdata2` float at `0x80330C80`.
- `src/chara_anim.cpp` already provides the external definition, so this is a declaration/linkage fix rather than a new constant or address hack.