### PR TITLE
Fix material ptr array constructor build

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -107,7 +107,6 @@ private:
 template <>
 CPtrArray<CMaterial*>::CPtrArray()
 {
-    m_vtable = __vt__8CPtrArrayIP9CMaterial;
     m_size = 0;
     m_numItems = 0;
     m_defaultSize = 0x10;


### PR DESCRIPTION
## Summary
- Removed the stray manual m_vtable assignment from the local CPtrArray<CMaterial*> constructor in materialman.cpp.
- The local template already has a compiler-generated vptr through its virtual destructor, so m_vtable is not a declared source member and the assignment prevents the unit from compiling.

## Evidence
- Before: ninja failed compiling src/materialman.cpp with undefined identifier 'm_vtable'.
- After: ninja completes successfully and reports build/GCCP01/main.dol: OK.

## Plausibility
- This matches the existing CPtrArray implementations in nearby units such as textureman/map: constructors initialize the real array fields and rely on the compiler-generated vptr, not a manually declared vtable member.