### PR TITLE
Match material pointer array constructor

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -107,7 +107,6 @@ private:
 template <>
 CPtrArray<CMaterial*>::CPtrArray()
 {
-    m_vtable = __vt__8CPtrArrayIP9CMaterial;
     m_size = 0;
     m_numItems = 0;
     m_defaultSize = 0x10;


### PR DESCRIPTION
## Summary
- Remove the manual vtable assignment from the local `CPtrArray<CMaterial*>` constructor in `materialman.cpp`.
- Let the compiler-generated virtual class vptr initialization handle the vtable, matching the established `CPtrArray` pattern used by other units.

## Evidence
- Before this change, current `main` failed to build in `src/materialman.cpp` with undefined identifier `m_vtable`.
- After this change, `ninja` passes.
- `main/materialman` now reports `CPtrArray<CMaterial*>` constructor/destructor and adjacent array methods at 100%:
  - `__ct__22CPtrArray<P9CMaterial>Fv`: 100.0%
  - `__dt__22CPtrArray<P9CMaterial>Fv`: 100.0%
  - `Add__22CPtrArray<P9CMaterial>FP9CMaterial`: 100.0%
  - `SetAt__22CPtrArray<P9CMaterial>FUlP9CMaterial`: 100.0%
  - `RemoveAll__22CPtrArray<P9CMaterial>Fv`: 100.0%
  - `SetStage__22CPtrArray<P9CMaterial>FPQ27CMemory6CStage`: 100.0%
  - `setSize__22CPtrArray<P9CMaterial>FUl`: 100.0%
- Overall progress after build: 28.12% matched; Game Code: 12.42% matched.

## Plausibility
This is plausible original source because `CPtrArray` has a virtual destructor, so the compiler emits the vptr store. The neighboring `CPtrArray` implementations rely on that same compiler-generated initialization instead of assigning a fake member.
