### PR TITLE
Tighten p_dbgmenu object layout

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -554,7 +554,7 @@ config.libs = [
             Object(NonMatching, "p_camera.cpp", extra_cflags=["-RTTI on", "-sdata 8"]),
             Object(NonMatching, "p_chara.cpp", extra_cflags=["-RTTI on", "-sdata 8"]),
             Object(NonMatching, "p_chara_viewer.cpp"),
-            Object(NonMatching, "p_dbgmenu.cpp", extra_cflags=["-RTTI on", "-sdata 8"]),
+            Object(NonMatching, "p_dbgmenu.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "p_FunnyShape.cpp", extra_cflags=["-RTTI on", "-sdata 8"]),
             Object(NonMatching, "p_game.cpp", extra_cflags=["-RTTI on", "-sdata 8"]),
             Object(NonMatching, "p_gba.cpp", extra_cflags=["-RTTI on", "-sdata 8"]),

--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -167,7 +167,7 @@ void CDbgMenuPcs::destroy()
 	return;
 }
 
-CDbgMenuPcs::CDbgMenuPcs()
+inline CDbgMenuPcs::CDbgMenuPcs()
 {
     m_table__11CDbgMenuPcs[1] = m_table_desc0__11CDbgMenuPcs[0];
     m_table__11CDbgMenuPcs[2] = m_table_desc0__11CDbgMenuPcs[1];
@@ -188,7 +188,7 @@ CDbgMenuPcs::CDbgMenuPcs()
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::selectNext()
+inline void CDbgMenuPcs::selectNext()
 {
 	if (m_currentMenu == 0) {
 		return;
@@ -210,7 +210,7 @@ void CDbgMenuPcs::selectNext()
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::selectPrev()
+inline void CDbgMenuPcs::selectPrev()
 {
 	if (m_currentMenu == 0) {
 		return;
@@ -709,7 +709,7 @@ void CDbgMenuPcs::drawFont(int flags, int x, int y, char* text)
  * Address:	TODO
  * Size:	TODO
  */
-CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
+inline CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
 {
 	for (int i = 0; i < 0x80; i++) {
 		if ((s8)m_menuPool[i].m_status >= 0) {
@@ -931,7 +931,7 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
  * Address:	TODO
  * Size:	TODO
  */
-void CDbgMenuPcs::Delete(int id)
+inline void CDbgMenuPcs::Delete(int id)
 {
 	CDM* menu = reinterpret_cast<CDM*>(searchID(id, m_rootMenuNode));
 	if (menu == 0) {


### PR DESCRIPTION
## Summary
- Mark local-only p_dbgmenu helper definitions inline so MWCC no longer emits standalone helper bodies absent from the target object.
- Compile p_dbgmenu without RTTI while keeping its existing -sdata 8 override, matching the target unit's .sdata ownership more closely.

## Evidence
- Before: p_dbgmenu base object .text 0x1F6C, .data 0x43C, .sdata 0x20.
- After: p_dbgmenu base object .text 0x1CE4, .data 0x3F8, .sdata 0x8.
- Target: p_dbgmenu .text 0x1CEC, .data 0x408, .sdata 0x8.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o -