### PR TITLE
Fix textureman ptrarray rodata ownership

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -72,8 +72,8 @@ extern "C" void ReleaseAndRemoveAll__21CPtrArray_P8CTexture_Fv(void*);
 static const char s_textureman_cpp_801D7974[] = "textureman.cpp";
 static const char s_Error_width_pctd_height_pctd_801D7984[] = "Error width=%d height=%d\n";
 static const char s_CTexture_texture_801D79A0[] = "CTexture.texture";
-static const char s_ptrarray_grow_error_801D79D8[] = "CPtrArray grow error";
-static const char s_collection_ptrarray_h_801D79F4[] = "collection_ptrarray.h";
+extern const char s_ptrarray_grow_error_801D79D8[];
+extern const char s_collection_ptrarray_h_801D79F4[];
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)


### PR DESCRIPTION
## Summary
- Reference the existing ptrarray diagnostic strings from textureman instead of emitting duplicate local rodata.
- Keeps main/textureman ownership aligned with the current split for the 0x801D7974..0x801D79B4 rodata range.

## Evidence
- ninja succeeds.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/textureman -o -
- Before: [.rodata-0] was 73.56322%, target size 64, current size 110.
- After: .rodata payload reports 100.0%, and [.rodata-0] is 97.6%, target size 64, current size 61. The remaining difference is trailing split padding.

## Plausibility
- config/GCCP01/splits.txt assigns textureman rodata only through 0x801D79B4; the two ptrarray strings live after that range as existing symbols.
- The change removes duplicate source-owned bytes and links to existing symbols without hand-writing RTTI or vtable data.