### PR TITLE
Improve pppScreenBreak before draw callback

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -635,15 +635,14 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
     Vec lightDir;
     GXLightObj lightObj;
     u8* camera = reinterpret_cast<u8*>(&CameraPcs);
-    float cameraOffset = FLOAT_80331ce8;
-    float zero = FLOAT_80331cc4;
-    float one = FLOAT_80331cd0;
-    float attnA = FLOAT_80331cec;
-    float attnB = FLOAT_80331cf0;
+    const float& zero = FLOAT_80331cc4;
+    const float& one = FLOAT_80331cd0;
+    const float& attnA = FLOAT_80331cec;
+    const float& attnB = FLOAT_80331cf0;
 
-    lightDir.x = *(float*)(camera + 0xEC) - (cameraOffset + *(float*)(camera + 0xE0));
-    lightDir.y = *(float*)(camera + 0xF0) - (cameraOffset + *(float*)(camera + 0xE4));
-    lightDir.z = *(float*)(camera + 0xF4) - (cameraOffset + *(float*)(camera + 0xE8));
+    lightDir.x = *(float*)(camera + 0xEC) - (FLOAT_80331ce8 + *(float*)(camera + 0xE0));
+    lightDir.y = *(float*)(camera + 0xF0) - (FLOAT_80331ce8 + *(float*)(camera + 0xE4));
+    lightDir.z = *(float*)(camera + 0xF4) - (FLOAT_80331ce8 + *(float*)(camera + 0xE8));
     PSVECNormalize(&lightDir, &lightDir);
 
     GXInitSpecularDirHA(&lightObj, lightDir.x, lightDir.y, lightDir.z, zero, one, zero);


### PR DESCRIPTION
## Summary
- Use named shared float constants in SB_BeforeDrawCallback instead of local float copies where the original code references shared constants.
- Inline the camera offset expression to keep the original floating-point register shape while avoiding extra local constant setup.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o - SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi
- Before: 99.48649%
- After: 99.89189%

## Plausibility
- The surrounding file already uses const float references for shared float constants to preserve references to named sdata2 objects.
- Behavior is unchanged; this only reshapes how constants are referenced in the callback.