### PR TITLE
Fix prgobj float constant size

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -16,16 +16,15 @@ extern "C" void SetParticleWorkTrace__13CFlatRuntime2FPQ212CFlatRuntime7CObject(
 extern "C" void SetParticleWorkPos__13CFlatRuntime2FR3Vecf(void*, Vec&, float);
 extern "C" void SetParticleWorkSe__13CFlatRuntime2Fiii(void*, int, int, int);
 extern "C" void PutParticleWork__13CFlatRuntime2Fv(void*);
-struct FloatPair {
+struct FloatValue {
 	float value;
-	float pad;
 };
 
 extern "C" const float FLOAT_80331BD0 = 1.0f;
 extern "C" const float FLOAT_80331BD4 = 0.0f;
 extern "C" const float FLOAT_80331BD8 = 3.1415927f;
 extern "C" const double DOUBLE_80331BE0 = 4503601774854144.0;
-extern "C" const FloatPair FLOAT_80331BE8 = {-1.0f, 0.0f};
+extern "C" const FloatValue FLOAT_80331BE8 = {-1.0f};
 extern "C" const char DAT_80331bf0[] = "GMGR";
 extern "C" const float FLOAT_80331bf8 = 0.0f;
 extern "C" const float FLOAT_80331bfc = 1.0f;


### PR DESCRIPTION
## Summary
- change FLOAT_80331BE8 from an 8-byte padded pair to a single-field 4-byte float wrapper
- preserves the existing member access while matching the original symbol size

## Evidence
- ninja passes
- main/prgobj .sdata2: 97.03704% -> 100.0%
- FLOAT_80331BE8: 66.66667% -> 100.0%
- onFrame__8CGPrgObjFv remains 99.92% in objdiff output