### PR TITLE
Improve pppKeShpTail3X draw matching

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -189,10 +189,9 @@ void pppKeShpTail3XDraw(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* p
     u32 currentIndex;
     u32 nextIndex;
     u8 zEnable;
-    float zero;
+    const float zero = kPppKeShpTail3XZero;
     s32 dataValIndex;
 
-    zero = kPppKeShpTail3XZero;
     work = (KeShpTail3XWork*)((u8*)obj + 0x80 + offsets->m_serializedDataOffsets[0]);
     dataValIndex = step->m_dataValIndex;
     if (dataValIndex == 0xffff) {


### PR DESCRIPTION
## Summary
- Initialize the local zero value in `pppKeShpTail3XDraw` as a const local instead of a separate mutable declaration and assignment.
- This gives Metrowerks a slightly closer code shape without changing runtime behavior.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o -`
  - `.text`: 80.399284% -> 80.40378%
  - `pppKeShpTail3XDraw`: 66.77439% -> 66.78201%
  - `extab`, `extabindex`, and `.sdata2` unchanged.

## Plausibility
- The change is a source-level cleanup: the zero value is a constant used throughout the draw routine, so declaring it as const reflects intent and removes an unnecessary assignment.