### PR TITLE
Improve p_dbgmenu calc matching

### DIFF
--- a/include/ffcc/p_dbgmenu.h
+++ b/include/ffcc/p_dbgmenu.h
@@ -60,8 +60,6 @@ public:
     int GetTable(unsigned long);
     void create();
     void destroy();
-    void selectNext();
-    void selectPrev();
     void calc();
     void draw();
     void calcMenu(CDM*);
@@ -73,7 +71,6 @@ public:
     int searchID(int, CDM&);
     void Add();
     void Add(int, int, CDMParam&);
-    void Delete(int);
     int GetDbgFlag();
     inline u32 GetDbgFlagsRaw() const { return m_dbgFlags; }
 

--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -167,7 +167,7 @@ void CDbgMenuPcs::destroy()
 	return;
 }
 
-CDbgMenuPcs::CDbgMenuPcs()
+inline CDbgMenuPcs::CDbgMenuPcs()
 {
     m_table__11CDbgMenuPcs[1] = m_table_desc0__11CDbgMenuPcs[0];
     m_table__11CDbgMenuPcs[2] = m_table_desc0__11CDbgMenuPcs[1];
@@ -181,50 +181,6 @@ CDbgMenuPcs::CDbgMenuPcs()
     m_table__11CDbgMenuPcs[12] = m_table_desc3__11CDbgMenuPcs[0];
     m_table__11CDbgMenuPcs[13] = m_table_desc3__11CDbgMenuPcs[1];
     m_table__11CDbgMenuPcs[14] = m_table_desc3__11CDbgMenuPcs[2];
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CDbgMenuPcs::selectNext()
-{
-	if (m_currentMenu == 0) {
-		return;
-	}
-
-	CDM* start = m_currentMenu;
-	m_currentMenu->m_status &= 0xBF;
-	do {
-		m_currentMenu = m_currentMenu->m_next;
-		if ((m_currentMenu->m_flags & 1) != 0) {
-			break;
-		}
-	} while (m_currentMenu != start);
-	m_currentMenu->m_status = (m_currentMenu->m_status & 0xBF) | 0x40;
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CDbgMenuPcs::selectPrev()
-{
-	if (m_currentMenu == 0) {
-		return;
-	}
-
-	CDM* start = m_currentMenu;
-	m_currentMenu->m_status &= 0xBF;
-	do {
-		m_currentMenu = m_currentMenu->m_prev;
-		if ((m_currentMenu->m_flags & 1) != 0) {
-			break;
-		}
-	} while (m_currentMenu != start);
-	m_currentMenu->m_status = (m_currentMenu->m_status & 0xBF) | 0x40;
 }
 
 /*
@@ -253,7 +209,7 @@ void CDbgMenuPcs::calc()
 	}
 
 	if ((padInput & 0x100) != 0) {
-		switch (m_currentMenu->m_id) {
+		switch (m_selectedMenu->m_id) {
 		case 100:
 			*(unsigned int*)(CFlat + 0x12A4) = ~*(unsigned int*)(CFlat + 0x12A4);
 			break;
@@ -345,7 +301,15 @@ void CDbgMenuPcs::calc()
 		padInput = 0;
 	}
 	if ((padInput & 4) != 0) {
-		selectNext();
+		CDM* start = m_selectedMenu;
+		m_selectedMenu->m_status &= 0xBF;
+		do {
+			m_selectedMenu = m_selectedMenu->m_next;
+			if ((m_selectedMenu->m_flags & 1) != 0) {
+				break;
+			}
+		} while (m_selectedMenu != start);
+		m_selectedMenu->m_status = (m_selectedMenu->m_status & 0xBF) | 0x40;
 	}
 
 	if (Pad._452_4_ == 0) {
@@ -356,7 +320,15 @@ void CDbgMenuPcs::calc()
 		padInput = 0;
 	}
 	if ((padInput & 8) != 0) {
-		selectPrev();
+		CDM* start = m_selectedMenu;
+		m_selectedMenu->m_status &= 0xBF;
+		do {
+			m_selectedMenu = m_selectedMenu->m_prev;
+			if ((m_selectedMenu->m_flags & 1) != 0) {
+				break;
+			}
+		} while (m_selectedMenu != start);
+		m_selectedMenu->m_status = (m_selectedMenu->m_status & 0xBF) | 0x40;
 	}
 
 	if (m_rootMenuNode.m_firstChild != 0) {
@@ -924,35 +896,6 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
 			m_defaultMenu = menu;
 		}
 	}
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CDbgMenuPcs::Delete(int id)
-{
-	CDM* menu = reinterpret_cast<CDM*>(searchID(id, m_rootMenuNode));
-	if (menu == 0) {
-		return;
-	}
-
-	if (m_selectedMenu == menu) {
-		m_selectedMenu = 0;
-	}
-	if (m_defaultMenu == menu) {
-		m_defaultMenu = 0;
-	}
-
-	CDM* parent = menu->m_parent;
-	if (parent != 0 && parent->m_firstChild == menu) {
-		parent->m_firstChild = (menu->m_next != menu) ? menu->m_next : 0;
-	}
-
-	menu->m_prev->m_next = menu->m_next;
-	menu->m_next->m_prev = menu->m_prev;
-	memset(&menu->m_status, 0, 0x20);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Inline the debug-menu selection traversal into `CDbgMenuPcs::calc`, matching the target function shape and using `m_selectedMenu` for action/selection state.
- Mark the `CDbgMenuPcs` constructor inline so its initialization folds into `__sinit_p_dbgmenu_cpp` instead of emitting a non-target constructor symbol.
- Remove non-target `selectNext`, `selectPrev`, and unused `Delete` declarations/definitions.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o -`
- `.text` current size improved from 8052 to 7452 bytes against a 7404-byte target.
- Removed non-target symbols: `__ct__11CDbgMenuPcsFv` (240b), `selectNext__11CDbgMenuPcsFv` (80b), `selectPrev__11CDbgMenuPcsFv` (80b), `Delete__11CDbgMenuPcsFi` (184b).
- `calc__11CDbgMenuPcsFv`: 1172b / 82.22378% -> 1156b / 82.48252%.

## Plausibility
- The target decompilation has the selected-menu traversal directly inside `calc`, with no separate next/prev helpers.
- Input actions operate on the selected menu slot rather than the draw/current menu slot, matching the observed target offsets.
- The target `__sinit_p_dbgmenu_cpp` contains the constructor work inline, so removing the out-of-line constructor symbol aligns with compiler-generated initialization rather than manual vtable or ctor forcing.
