### PR TITLE
Improve CGPrgObj target rotation matching

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -8,6 +8,8 @@
 #include "ffcc/vector.h"
 
 extern "C" double atan2(double, double);
+extern "C" CVector* __ct__7CVectorFRC3Vec(CVector*, const Vec&);
+extern "C" CVector* __ct__7CVectorFv(CVector*);
 
 extern "C" void ResetParticleWork__13CFlatRuntime2Fii(void*, int, int);
 extern "C" void SetParticleWorkScale__13CFlatRuntime2Ff(void*, float);
@@ -224,14 +226,18 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 {
 	CGPrgObj* self = this;
 	float targetRot;
-	CVector targetPos(target->m_worldPosition);
-	CVector basePos(self->m_worldPosition);
-	CVector deltaPos;
+	Vec targetPos;
+	Vec basePos;
+	Vec deltaPos;
+	CVector* baseVec;
 	float deltaX;
 	float zero;
 	float deltaZ;
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&targetPos), target->m_worldPosition);
+	baseVec = __ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), self->m_worldPosition);
+	__ct__7CVectorFv(reinterpret_cast<CVector*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(baseVec), &targetPos, &deltaPos);
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
@@ -255,15 +261,20 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
  */
 void CGPrgObj::rotTarget(CGPrgObj* target)
 {
-	CVector targetPos(target->m_worldPosition);
-	CVector basePos(m_worldPosition);
-	CVector deltaPos;
+	CGPrgObj* self = this;
 	float targetRot;
+	Vec targetPos;
+	Vec basePos;
+	Vec deltaPos;
+	CVector* baseVec;
 	float deltaX;
 	float zero;
 	float deltaZ;
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&targetPos), target->m_worldPosition);
+	baseVec = __ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), self->m_worldPosition);
+	__ct__7CVectorFv(reinterpret_cast<CVector*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(baseVec), &targetPos, &deltaPos);
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;
@@ -272,7 +283,7 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
-	m_rotTargetY = targetRot;
+	self->m_rotTargetY = targetRot;
 }
 
 /*
@@ -287,14 +298,18 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 float CGPrgObj::getTargetRot(CGPrgObj* target)
 {
 	float targetRot;
-	CVector targetPos(target->m_worldPosition);
-	CVector basePos(m_worldPosition);
-	CVector deltaPos;
+	Vec basePos;
+	Vec targetPos;
+	Vec deltaPos;
+	CVector* baseVec;
 	float deltaX;
 	float zero;
 	float deltaZ;
 
-	PSVECSubtract(reinterpret_cast<Vec*>(&basePos), reinterpret_cast<Vec*>(&targetPos), reinterpret_cast<Vec*>(&deltaPos));
+	__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&targetPos), target->m_worldPosition);
+	baseVec = __ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition);
+	__ct__7CVectorFv(reinterpret_cast<CVector*>(&deltaPos));
+	PSVECSubtract(reinterpret_cast<Vec*>(baseVec), &targetPos, &deltaPos);
 	deltaX = deltaPos.x;
 	zero = FLOAT_80331BD4;
 	deltaZ = deltaPos.z;


### PR DESCRIPTION
## Summary
- Rework CGPrgObj target rotation helpers to explicitly preserve CVector constructor return values for the base vector.
- Apply the same construction shape to dstTargetRot, rotTarget, and getTargetRot.

## Objdiff evidence
Before -> after for main/prgobj:
- dstTargetRot__8CGPrgObjFP8CGPrgObj: 87.681816% -> 97.27273%
- rotTarget__8CGPrgObjFP8CGPrgObj: 86.23077% -> 97.051285%
- getTargetRot__8CGPrgObjFP8CGPrgObj: 91.02778% -> 96.80556%

## Plausibility
- Ghidra shows the original code using the return value of the CVector(Vec const&) constructor as the input vector for PSVECSubtract.
- The change keeps the same vector math and object fields, while aligning stack layout and constructor-return use with the target.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/prgobj -o -