### PR TITLE
Improve pppYmBreath shared constant usage

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -20,6 +20,12 @@ extern "C" void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSe
 extern "C" void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 extern "C" void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, unsigned char);
 extern "C" void pppNormalize__FR3Vec3Vec(float*, Vec*);
+extern "C" {
+extern const float FLOAT_80330c80;
+extern const float FLOAT_80330c84;
+extern const float FLOAT_80330C90;
+extern const float FLOAT_80330C94;
+}
 
 struct pppYmBreathUnkC {
     unsigned char _pad[0xC];
@@ -244,9 +250,9 @@ extern "C" void pppConstructYmBreath(pppYmBreath* ymBreath, pppYmBreathUnkC* dat
     float zero;
 
     PSMTXIdentity(state->m_matrix);
-    zero = 0.0f;
+    zero = FLOAT_80330c80;
 
-    state->m_direction.z = 0.0f;
+    state->m_direction.z = zero;
     state->m_direction.y = zero;
     state->m_direction.x = zero;
 
@@ -335,8 +341,8 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
             drawMtx[0][0] = source[4].y * pppMngStPtr->m_scale.x;
             drawMtx[1][1] = source[4].z * pppMngStPtr->m_scale.y;
             drawMtx[2][2] = drawMtx[0][0];
-            if (0.0f != source[3].y) {
-                PSMTXRotRad(rotMtx, 'z', 0.017453292f * source[3].y);
+            if (FLOAT_80330c80 != source[3].y) {
+                PSMTXRotRad(rotMtx, 'z', FLOAT_80330c84 * source[3].y);
                 PSMTXConcat(drawMtx, rotMtx, drawMtx);
             }
 
@@ -573,9 +579,9 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
             }
         }
 
-        work->m_direction.x = 0.0f;
-        work->m_direction.y = 0.0f;
-        work->m_direction.z = 1.0f;
+        work->m_direction.x = FLOAT_80330c80;
+        work->m_direction.y = FLOAT_80330c80;
+        work->m_direction.z = FLOAT_80330C90;
         PSVECNormalize(&work->m_direction, &work->m_direction);
     }
 
@@ -615,9 +621,9 @@ group_ready:
             PSMTXConcat(*particleMtx, ymBreath->m_localMatrix.value, worldMtx);
             PSMTXMultVec(worldMtx, (Vec*)(groupTable + 0xC), &origin);
             pppCopyMatrix(rotMtx, *reinterpret_cast<pppFMATRIX*>(particleMtx));
-            rotMtx.value[0][3] = 0.0f;
-            rotMtx.value[1][3] = 0.0f;
-            rotMtx.value[2][3] = 0.0f;
+            rotMtx.value[0][3] = FLOAT_80330c80;
+            rotMtx.value[1][3] = FLOAT_80330c80;
+            rotMtx.value[2][3] = FLOAT_80330c80;
             *(float*)(groupTable + 0x28) = scaledOwner;
             pppCopyVector(dir, *(Vec*)(groupTable + 0x18));
             PSMTXMultVec(rotMtx.value, &dir, &dir);
@@ -779,9 +785,9 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
         groupData = groupTable;
         for (i = 0; i < (int)params->m_groupCount; i++) {
             if ((groupData->active != 1) && (*groupData->particleIndices != -1) && (*groupData->particleStates == 1)) {
-                unitVelocity.x = 0.0f;
-                unitVelocity.y = 0.0f;
-                unitVelocity.z = -1.0f;
+                unitVelocity.x = FLOAT_80330c80;
+                unitVelocity.y = FLOAT_80330c80;
+                unitVelocity.z = FLOAT_80330C94;
                 groupData->speed = params->m_groupSpeed;
                 pppCopyVector(groupData->direction, unitVelocity);
                 float zero = 0.0f;
@@ -866,7 +872,7 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, PARTICLE_DATA* p
 
     particle->m_scale += params->m_scaleAccel;
     if (params->m_disableScaleClamp == 0) {
-        float zero = 0.0f;
+        float zero = FLOAT_80330c80;
         if (zero < params->m_scaleClampStart) {
             if (params->m_scaleAccel < zero) {
                 if (particle->m_scale < zero) {


### PR DESCRIPTION
## Summary
- Reference existing shared PAL sdata2 constants for common pppYmBreath float values instead of emitting local literals.
- This matches pppConstructYmBreath and improves nearby render/frame/update particle code without regressing BirthParticle.

## Objdiff Evidence
Baseline -> after:
- pppConstructYmBreath: 99.833336% -> 100.0%
- pppRenderYmBreath: 95.10526% -> 95.13622%
- pppFrameYmBreath: 94.332275% -> 94.379745%
- UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor: 96.10821% -> 96.12687%
- UpdateParticle__FP9VYmBreathP9PYmBreathP13PARTICLE_DATAP6VColorP14PARTICLE_COLOR: 98.07692% -> 98.09955%
- [.sdata2-0]: 53.333336% -> 57.692307%
- BirthParticle remains 97.288605%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - pppConstructYmBreath