### PR TITLE
Improve graphic quad FIFO ordering

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1560,29 +1560,32 @@ void CGraphic::RenderNoTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXCol
 
 	float x1 = pos1.x;
 	float y1 = pos1.y;
-	float z1 = pos1.z;
 
 	GXWGFifo.f32 = x1;
+	float z1 = pos1.z;
 	GXWGFifo.f32 = y1;
+	u32 rgba1 = *(u32*)&color1;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color1;
 
 	float x2 = pos2.x;
+	GXWGFifo.u32 = rgba1;
+	u32 rgba2 = *(u32*)&color2;
 	GXWGFifo.f32 = x2;
-	GXWGFifo.f32 = y1;
-	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color2;
-
 	float y2 = pos2.y;
+	GXWGFifo.f32 = y1;
+	u32 rgba4 = *(u32*)&color4;
+	GXWGFifo.f32 = z1;
+	u32 rgba3 = *(u32*)&color3;
+	GXWGFifo.u32 = rgba2;
 	GXWGFifo.f32 = x2;
 	GXWGFifo.f32 = y2;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color4;
 
+	GXWGFifo.u32 = rgba4;
 	GXWGFifo.f32 = x1;
 	GXWGFifo.f32 = y2;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color3;
+	GXWGFifo.u32 = rgba3;
 }
 
 /*

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1510,37 +1510,41 @@ void CGraphic::RenderTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor
 
 	float x1 = pos1.x;
 	float y1 = pos1.y;
-	float z1 = pos1.z;
-	float tex0 = kGraphicZeroF;
 
 	GXWGFifo.f32 = x1;
+	float z1 = pos1.z;
 	GXWGFifo.f32 = y1;
+	u32 rgba1 = *(u32*)&color1;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color1;
+	float tex0 = kGraphicZeroF;
+	GXWGFifo.u32 = rgba1;
 	float x2 = pos2.x;
 	GXWGFifo.f32 = tex0;
+	u32 rgba2 = *(u32*)&color2;
 	GXWGFifo.f32 = tex0;
 
 	float tex1 = kGraphicOneF;
 	GXWGFifo.f32 = x2;
 	float y2 = pos2.y;
 	GXWGFifo.f32 = y1;
+	u32 rgba4 = *(u32*)&color4;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color2;
+	u32 rgba3 = *(u32*)&color3;
+	GXWGFifo.u32 = rgba2;
 	GXWGFifo.f32 = tex1;
 	GXWGFifo.f32 = tex0;
 
 	GXWGFifo.f32 = x2;
 	GXWGFifo.f32 = y2;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color4;
+	GXWGFifo.u32 = rgba4;
 	GXWGFifo.f32 = tex1;
 	GXWGFifo.f32 = tex1;
 
 	GXWGFifo.f32 = x1;
 	GXWGFifo.f32 = y2;
 	GXWGFifo.f32 = z1;
-	GXWGFifo.u32 = *(u32*)&color3;
+	GXWGFifo.u32 = rgba3;
 	GXWGFifo.f32 = tex0;
 	GXWGFifo.f32 = tex1;
 }


### PR DESCRIPTION
## Summary
- Reordered local temporaries in CGraphic::RenderTexQuadGrouad and CGraphic::RenderNoTexQuadGrouad so FIFO writes line up more closely with the target instruction stream.
- Kept vertex, color, and texcoord output order unchanged; this is source-order/lifetime cleanup rather than a behavior change.

## Objdiff Evidence
- main/graphic unit fuzzy: now 89.09947%.
- RenderNoTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor: 73.111115% -> 95.888885%, size 180b unchanged.
- RenderTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor: 79.181816% -> 87.27273%, size 220b unchanged.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/graphic -o /tmp/graphic_final2.json

## Plausibility
- The changes model the apparent original FIFO emission order: load/write the first vertex fields, then introduce color and subsequent vertex temporaries only when needed.
- No hard-coded addresses, fake labels, generated ctor/dtor code, or section forcing were added.