### PR TITLE
Improve CGItemObj memory name drawing match

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -58,7 +58,8 @@ extern "C" void LoadModelASync__Q29CCharaPcs7CHandleFiUlUl(void*, int, unsigned 
 extern "C" int IsLoadModelASyncCompleted__Q29CCharaPcs7CHandleFv(void*);
 extern "C" void SetDamageCol__8CGObjectFiPcffP3Vec(void*, int, char*, float, float, Vec*);
 extern "C" void onFrame__8CGPrgObjFv(void*);
-extern "C" void* __ct__6CColorFUcUcUcUc(void*, unsigned char, unsigned char, unsigned char, unsigned char);
+extern "C" void* __ct__6CColorFUcUcUcUc(void*, int, int, int, int);
+extern "C" void SetColor__5CFontF8_GXColor(CFont*, GXColor*);
 extern "C" int CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(CMapMng*, CMapCylinder*, Vec*, unsigned int);
 extern "C" void putParticle__8CGPrgObjFiiP3Vecfi(void*, int, int, Vec*, float, int);
 extern "C" void playSe3D__8CGPrgObjFiiiiP3Vec(void*, int, int, int, int, Vec*);
@@ -1356,7 +1357,7 @@ void CGItemObj::DrawOmoideName(CFont* font)
 {
 	unsigned char* self = (unsigned char*)this;
 
-	if ((*(unsigned char*)(self + 0x9A) & 0x20) != 0) {
+	if ((signed char)((int)(((unsigned int)*(unsigned char*)(self + 0x9A) << 0x1A) & 0xC0000000) >> 31) != 0) {
 		void* charaHandle = *(void**)(self + 0xF8);
 		bool hasModel = false;
 		if (charaHandle != 0 && *(void**)((unsigned char*)charaHandle + 0x168) != 0) {
@@ -1368,19 +1369,18 @@ void CGItemObj::DrawOmoideName(CFont* font)
 			font->SetTlut(7);
 
 			int alphaInt = (int)(FLOAT_80331b30 * *(float*)(self + 0x4B0));
-			unsigned char alpha = alphaInt;
 			GXColor constructedColor;
-			GXColor textColor = *(GXColor*)__ct__6CColorFUcUcUcUc(&constructedColor, 0xFF, 0xFF, 0xFF, alpha);
-			font->SetColor(textColor);
+			GXColor textColor = *(GXColor*)__ct__6CColorFUcUcUcUc(&constructedColor, 0xFF, 0xFF, 0xFF, alphaInt);
+			SetColor__5CFontF8_GXColor(font, &textColor);
 
 			const ItemObjFlatData* flatData = reinterpret_cast<const ItemObjFlatData*>(&Game.m_cFlatDataArr[1]);
 			const char* name = flatData->table[2].index[*(int*)(self + 0x570)];
-			int width = font->GetWidth(name);
+			float width = font->GetWidth(name);
 			float depthScale = FLOAT_80331b18 / (*(float*)(self + 0x74) - FLOAT_80331b1c);
+			float posY = FLOAT_80331b34 - FLOAT_80331b34 * *(float*)(self + 0x6C) * depthScale;
 			float posZ = *(float*)(self + 0x70) * depthScale;
-			float posY = -(FLOAT_80331b34 * *(float*)(self + 0x6C) * depthScale - FLOAT_80331b34);
 			float posX =
-			    -(FLOAT_80331b3c * (float)width - (FLOAT_80331b38 * *(float*)(self + 0x68) * depthScale + FLOAT_80331b38));
+			    -(FLOAT_80331b3c * width - (FLOAT_80331b38 * *(float*)(self + 0x68) * depthScale + FLOAT_80331b38));
 
 			font->SetPosX(posX);
 			font->SetPosY(posY - FLOAT_80331b40);


### PR DESCRIPTION
## Summary
- Improve CGItemObj::DrawOmoideName source shape for the item memory-name draw path
- Preserve the original bit-test codegen for the display flag
- Keep CFont::GetWidth as a float and use the raw SetColor ABI call to avoid an extra by-value temp
- Reorder the projected position math to better match the original fused operations

## Objdiff Evidence
- Unit: main/itemobj
- Symbol: DrawOmoideName__9CGItemObjFP5CFont
- Before: 75.4434% match, 424b
- After: 98.98113% match, 424b

## Verification
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/itemobj -o - DrawOmoideName__9CGItemObjFP5CFont

## Plausibility
The changes are local to the existing decompiled function and replace misleading types/source forms with the types and expressions implied by nearby APIs and the original codegen: GetWidth returns float, the object flag is tested through the same rotate/sign shape seen in the target, and the color call now follows the raw ABI style already used elsewhere for CFont color calls.