### PR TITLE
Improve mapmesh allocation stage linkage

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -13,6 +13,7 @@ class CMapHitFace;
 extern "C" void __dl__FPv(void* ptr);
 extern "C" void __dla__FPv(void* ptr);
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long size, CMemory::CStage* stage, char* file, int line);
+extern "C" CMemory::CStage* g_hit_lpface_min;
 extern "C" char s_mapmesh_cpp_801D70B0[];
 extern "C" const float FLOAT_8032F930;
 extern "C" const float FLOAT_8032F934;
@@ -103,7 +104,7 @@ static inline unsigned int Align32(unsigned int value)
 
 static inline CMemory::CStage*& MapMeshAllocStage()
 {
-    return g_pStage;
+    return g_hit_lpface_min;
 }
 }
 


### PR DESCRIPTION
## Summary
- Update CMapMesh::ReadOtmMesh allocation-stage storage to reference the external symbol used by the extracted PAL mapmesh.o relocations.
- Keeps the existing g_pStage definition in the unit, matching the target object defined-but-unused sbss symbol.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/mapmesh -o -:
  - .text: 99.68959% -> 99.70392%
  - ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii: 99.43281% -> 99.458984%
- Current rebuilt mapmesh.o now has the three ReadOtmMesh allocation-stage relocations against g_hit_lpface_min, matching the extracted target object relocation target.

## Plausibility
The PAL target object already defines g_pStage in mapmesh.o but uses an external relocation for the allocation-stage temporary in ReadOtmMesh. This change follows that linkage rather than adding manual sections, vtables, addresses, or code-shaping hacks.