### PR TITLE
Match pppYmDeformationMdl sdata2 constants

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -52,7 +52,12 @@ extern float FLOAT_80330DA0;
 extern float FLOAT_80330DA4;
 extern float FLOAT_80330DA8;
 extern const float FLOAT_80330dac = 0.0f;
-extern const double DOUBLE_80330DB0 = 4503601774854144.0;
+struct DoubleWords {
+    u32 u[2];
+};
+
+extern const DoubleWords DOUBLE_80330DB0 = {{0x43300000, 0x80000000}};
+extern const DoubleWords kPppYmSharedDoubleBias = {{0x43300000, 0x80000000}};
 
 static inline Mtx& CameraMatrix()
 {


### PR DESCRIPTION
## Summary
- define pppYmDeformationMdl's signed-int conversion bias as 32-bit words so DOUBLE_80330DB0 lands at the target .sdata2 offset
- add the adjacent kPppYmSharedDoubleBias data definition at the expected address
- leave render code shape unchanged while improving data/linkage for the unit

## Evidence
- ninja passes and build/GCCP01/main.dol remains OK
- progress data increased from 1123218 to 1123242 matched bytes (+24)
- objdiff main/pppYmDeformationMdl:
  - pppRenderYmDeformationMdl remains 99.580925%
  - pppFrameYmDeformationMdl remains 100%
  - DOUBLE_80330DB0 now matches at .sdata2+0x4
  - kPppYmSharedDoubleBias now matches at .sdata2+0xC

## Plausibility
- These constants are data definitions, not section forcing or generated ctor/dtor code.
- Using word storage matches the object layout for doubles in this unaligned .sdata2 region and avoids changing the already-close render function body.