### PR TITLE
Define YmChangeTex parabola constants

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -561,3 +561,9 @@ void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void* pa
 		GXCallDisplayList(displayList->m_data, displayList->m_size);
 	}
 }
+
+extern const float gPppYmMoveParabolaYOffsetStep = 1.0f;
+extern const float gPppYmMoveParabolaZero = 0.0f;
+extern const float gPppYmMoveParabolaAngleScale = 32768.0f;
+extern const float gPppYmMoveParabolaAngleDivisor = 180.0f;
+extern const float gPppYmMoveParabolaGravityScale = 0.5f;


### PR DESCRIPTION
## Summary
- define the five `gPppYmMoveParabola*` constants currently owned by `pppYmChangeTex.o`
- removes the unresolved/linkage gap for those `.sdata2` entries while leaving `pppYmChangeTex` code score unchanged

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/pppYmChangeTex -o -`
  - `.text`: remains `96.64098%`, size `2596`
  - `.sdata2`: improves from `33.333336%` to `89.28571%`, size `28`
  - `gPppYmMoveParabolaYOffsetStep`: `100.0%`
  - `gPppYmMoveParabolaZero`: `100.0%`
  - `gPppYmMoveParabolaAngleScale`: `100.0%`
  - `gPppYmMoveParabolaAngleDivisor`: `100.0%`
  - `gPppYmMoveParabolaGravityScale`: `100.0%`

## Plausibility
These are real float constants used by the parabola particle code and already present as named PAL symbols. Defining them normally gives the linker real data instead of leaving the symbols as extern-only references; no section forcing or manual vtable/ctor work is involved.
