### PR TITLE
Inline pppRandUpFV helper

### DIFF
--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -14,7 +14,7 @@ struct RandUpFVParams {
     u8 useNormalDistribution;
 };
 
-static float randf(float value, float scale)
+static inline float randf(float value, float scale)
 {
     return value * scale;
 }


### PR DESCRIPTION
## Summary
- Mark the local pppRandUpFV multiply helper inline so MWCC does not emit it as a standalone 8-byte text symbol.
- This aligns the unit layout with the original object: pppRandUpFV now starts at offset 0 instead of after randf__Fff.

## Evidence
- ninja passes.
- Before objdiff: current .text size 312, extra randf__Fff size 8, pppRandUpFV address 8.
- After objdiff: current .text size 304, randf__Fff absent, pppRandUpFV address 0.
- pppRandUpFV remains 99.710526% matched; the remaining mismatch is only a first multiply load-order pair.