### PR TITLE
Match pppRandDownFV

### DIFF
--- a/src/pppRandDownFV.cpp
+++ b/src/pppRandDownFV.cpp
@@ -14,11 +14,6 @@ struct RandDownFVParams {
     u8 useNormalDistribution;
 };
 
-static float randf(float value, float scale)
-{
-    return value * scale;
-}
-
 /*
  * --INFO--
  * PAL Address: 0x80061664
@@ -46,21 +41,27 @@ void pppRandDownFV(_pppPObject* basePtr, RandDownFVParams* in, _pppCtrlTable* ct
             value = randomValue * scale;
         }
 
-        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
+        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
         *valuePtr = value;
     } else {
         if (in->targetId != baseState) {
             return;
         }
 
-        valuePtr = (f32*)(basePtr->m_workArea + *ctrl->m_serializedDataOffsets);
+        valuePtr = (f32*)(base + *ctrl->m_serializedDataOffsets + 0x80);
     }
 
     s32 sourceOffset = in->sourceOffset;
     f32* target = (sourceOffset == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)(base + sourceOffset + 0x80);
-    f32 scale = *valuePtr;
 
-    target[0] += randf(in->blend[0], scale);
-    target[1] += randf(in->blend[1], scale);
-    target[2] += randf(in->blend[2], scale);
+    f32 base0 = target[0];
+    f32 value = in->blend[0];
+    f32 scale = *valuePtr;
+    f32 delta0 = value * scale;
+    target[0] = base0 + delta0;
+
+    value = in->blend[1] * scale;
+    target[1] = target[1] + value;
+    value = in->blend[2] * scale;
+    target[2] = target[2] + value;
 }


### PR DESCRIPTION
## Summary
- match `pppRandDownFV` in `src/pppRandDownFV.cpp`
- restore the original address arithmetic for the per-instance work slot (`base + offset + 0x80`)
- spell out the blended vector updates directly instead of routing them through the helper form that was shifting the tail codegen

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/pppRandDownFV -o - pppRandDownFV`
  - before: `99.710526%` match, `2` instruction diffs
  - after: `100.0%` match, `0` instruction diffs
- `ninja -j4`
  - before progress: `523420 / 1855224` code bytes, `3212 / 4732` functions
  - after progress: `523724 / 1855224` code bytes, `3213 / 4732` functions

## Plausibility
- this keeps the typed public signature from current `main`, but restores the more literal pointer arithmetic and value-update order that the matched historical source used
- no section forcing, fake symbols, or ABI hacks were introduced
