### PR TITLE
Improve CGQuadObj::onDraw matching

### DIFF
--- a/src/quadobj.cpp
+++ b/src/quadobj.cpp
@@ -108,30 +108,30 @@ extern const float kOneF32 = 1.0f;
 void CGQuadObj::onDraw()
 {
     if (m_vertexCount != 0 && (*(u32*)(CFlat + 0x129C) & 0x10000) != 0) {
-        GXSetChanMatColor(GX_COLOR0A0, CColor(0xff, 0xff, 0xff, 0xff).color);
+        CColor color(0xff, 0xff, 0xff, 0xff);
+        GXColor drawColor = color.color;
+        GXSetChanMatColor(GX_COLOR0A0, drawColor);
         GXLoadPosMtxImm(CameraPcs.m_cameraMatrix, GX_PNMTX0);
         GXBegin(GX_LINES, GX_VTXFMT0, ((u32)m_vertexCount << 1) + ((u32)m_vertexCount << 2));
 
-        int next;
-        QuadVertex* vertex;
-        CGQuadObj* current = this;
         int i = 0;
+        CGQuadObj* current = this;
 
         while (i < (int)(u32)m_vertexCount) {
             u32 count;
+            QuadVertex* vertex = current->m_vertices;
+            int next = i + 1;
 
-            next = i + 1;
             i = i + 1;
             GXPosition3f32(current->m_vertices[0].x, m_yBase, current->m_vertices[0].z);
             count = m_vertexCount;
-            int nextIndex = next % (int)count;
-            GXPosition3f32(m_vertices[nextIndex].x, m_yBase, m_vertices[nextIndex].z);
+            int nextBase = next % (int)count;
+            GXPosition3f32(m_vertices[nextBase].x, m_yBase, m_vertices[nextBase].z);
             GXPosition3f32(current->m_vertices[0].x, m_yBase + m_yHeight, current->m_vertices[0].z);
             count = m_vertexCount;
-            nextIndex = next % (int)count;
-            GXPosition3f32(m_vertices[nextIndex].x, m_yBase + m_yHeight, m_vertices[nextIndex].z);
+            int nextTop = next % (int)count;
+            GXPosition3f32(m_vertices[nextTop].x, m_yBase + m_yHeight, m_vertices[nextTop].z);
             GXPosition3f32(current->m_vertices[0].x, m_yBase, current->m_vertices[0].z);
-            vertex = current->m_vertices;
             current = reinterpret_cast<CGQuadObj*>(reinterpret_cast<unsigned char*>(current) + sizeof(QuadVertex));
             GXPosition3f32(vertex->x, m_yBase + m_yHeight, vertex->z);
         }


### PR DESCRIPTION
## Summary
- reshape `CGQuadObj::onDraw()` loop locals to better match the original modulo/indexing codegen
- keep the explicit `CColor`/`GXColor` setup that produces the better register allocation in the draw prologue
- preserve the existing behavior while making the source shape closer to plausible original code

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/quadobj -o - onDraw__9CGQuadObjFv`
- `onDraw__9CGQuadObjFv` match percent improved from `97.35849%` to `98.63207%`
- `main/quadobj` fuzzy match is now `99.3933%`

## Why this is plausible source
- the change replaces a reused modulo temporary with separate wrapped indices for the base and top edge draws
- the color setup now uses explicit locals instead of an inline temporary, which is a normal source-level formulation and improves codegen without adding hacks
- no manual section forcing, fake symbols, or compiler-coaxing constructs were introduced