### PR TITLE
Simplify pppRandDownFV blend multiplies

### DIFF
--- a/src/pppRandDownFV.cpp
+++ b/src/pppRandDownFV.cpp
@@ -14,11 +14,6 @@ struct RandDownFVParams {
     u8 useNormalDistribution;
 };
 
-static float randf(float value, float scale)
-{
-    return value * scale;
-}
-
 /*
  * --INFO--
  * PAL Address: 0x80061664
@@ -60,7 +55,7 @@ void pppRandDownFV(_pppPObject* basePtr, RandDownFVParams* in, _pppCtrlTable* ct
     f32* target = (sourceOffset == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)(base + sourceOffset + 0x80);
     f32 scale = *valuePtr;
 
-    target[0] += randf(in->blend[0], scale);
-    target[1] += randf(in->blend[1], scale);
-    target[2] += randf(in->blend[2], scale);
+    target[0] += in->blend[0] * scale;
+    target[1] += in->blend[1] * scale;
+    target[2] += in->blend[2] * scale;
 }


### PR DESCRIPTION
## Summary
- replace the local `randf` helper in `pppRandDownFV` with direct blend-scale multiplies
- keep the function logic unchanged while removing the extra helper body MWCC was emitting into the unit

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppRandDownFV -o -`
- before: current object `.text` was 312 bytes because the helper emitted an extra 8-byte local function
- after: current object `.text` is 304 bytes, matching the target unit text size
- `pppRandDownFV` function match remains `99.710526%`, so the gain is the extra emitted helper removal rather than a function-body regression

## Plausibility
- multiplying the three blend components directly is simpler source and avoids an unnecessary local helper that does nothing beyond `value * scale`
- this is normal source cleanup, not compiler coaxing or a section-forcing hack