### PR TITLE
Fix CGraphic thread stack setup

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -170,7 +170,7 @@ void CGraphic::Init()
     U8At(this, 0x7362) = U8At(this, 0x7203);
     memset(reinterpret_cast<u8*>(this) + 0x7364, 0, 0x10);
 
-    OSCreateThread(&m_thread, reinterpret_cast<void* (*)(void*)>(checkThread), nullptr, m_threadStack, 0x4000, 1, 1);
+    OSCreateThread(&m_thread, reinterpret_cast<void* (*)(void*)>(checkThread), nullptr, m_threadStack + 0x4000, 0x4000, 1, 1);
     OSResumeThread(&m_thread);
 
     VIInit();


### PR DESCRIPTION
## Summary
- pass the top of `m_threadStack` to `OSCreateThread` in `CGraphic::Init()`
- keep the change limited to the thread ABI detail that objdiff responded to

## Evidence
- `Init__8CGraphicFv`: `72.528%` -> `73.824%`
- `main/graphic` `.text` match: `88.93753%` -> `89.022575%`

## Why this is plausible
- other thread creation sites in the repo pass `stack + size` rather than the stack base
- the updated `Init()` instruction shape now matches the target stack-pointer setup more closely