### PR TITLE
Improve FunnyShape viewer data layout match

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -66,7 +66,7 @@ extern char lbl_8032E660[];
 extern u8 ARRAY_8026D728[];
 
 extern "C" CUSBStreamData* __dt__14CUSBStreamDataFv(CUSBStreamData* self, short shouldDelete);
-extern const char s_CFunnyShapePcs[];
+static const char s_CFunnyShapePcs[] = "CFunnyShapePcs";
 extern "C" const char lbl_8032FD1C[] = "|/-\\";
 
 namespace {
@@ -438,8 +438,6 @@ void CFunnyShapePcs::drawViewer()
         Graphic.Printf(const_cast<char*>(s_funnyShapeFmt), pFan[frame % 4]);
     }
 }
-
-const char s_CFunnyShapePcs[] = "CFunnyShapePcs";
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- make `s_CFunnyShapePcs` TU-local in `p_FunnyShape.cpp` instead of leaving it as a separate extern+definition pair
- keep the viewer name string adjacent to its only use in `createViewer`
- avoid the extra external symbol plumbing that was perturbing the unit's `.data` tail

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - __sinit_p_FunnyShape_cpp` improved the aggregate `[.data-0]` symbol from `88.79131%` to `90.33194%`
- `p_FunnyShape` dropped out of the current `tools/agent_select_target.py` opportunity list after regenerating the report

## Plausibility
- this is a linkage/section cleanup around an internal-only string, not compiler coaxing
- the string is only consumed inside `p_FunnyShape.cpp`, so narrowing its linkage is a coherent source-level correction