### PR TITLE
Align YM breath group iteration with breath model

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -497,8 +497,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     _pppMngSt* mngSt;
     VYmBreath* work;
     VColor* color;
-    int* groupData;
-    PARTICLE_WMAT* particleWMat;
+    Mtx* particleWMat;
     Mtx* particleMtx;
     int i;
     short groupIndex;
@@ -592,11 +591,10 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     PSMTXCopy(mngSt->m_matrix.value, work->m_matrix);
     UpdateAllParticle(reinterpret_cast<_pppPObject*>(ymBreath), work, pYmBreath, color);
 
-    particleWMat = work->m_particleWmats;
-    groupData = (int*)work->m_groups;
+    particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
     for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
         slotCount = params->m_slotCount;
-        groupTable = (int)groupData;
+        groupTable = (int)((unsigned char*)work->m_groups + groupIndex * 0x5C);
         for (slotIndex = 0; slotIndex < (int)slotCount; slotIndex++) {
             if ((*(signed char*)(*(int*)(groupTable + 4) + slotIndex) == -1) ||
                 (*(signed char*)(*(int*)(groupTable + 8) + slotIndex) != 1)) {
@@ -621,7 +619,7 @@ group_ready:
             scaleMtx[0][0] = scaledOwner;
             scaleMtx[1][1] = scaledOwner;
             scaleMtx[2][2] = scaledOwner;
-            particleMtx = &particleWMat[firstParticle].m_matrix;
+            particleMtx = (Mtx*)((unsigned char*)particleWMat + firstParticle * 0x30);
             PSMTXConcat(*particleMtx, ymBreath->m_localMatrix.value, worldMtx);
             PSMTXMultVec(worldMtx, (Vec*)(groupTable + 0xC), &origin);
             pppCopyMatrix(rotMtx, *reinterpret_cast<pppFMATRIX*>(particleMtx));
@@ -638,8 +636,6 @@ group_ready:
             pppSubVector(hitVector, target, origin);
             pppHitCylinderSendSystem(mngSt, &origin, &hitVector, scaledOwner, params->m_groupRadius);
         }
-
-        groupData += 0x17;
     }
 }
 
@@ -749,23 +745,25 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                 }
 
                 if ((params->m_emitInterval <= *emitFrameCounter) && (spawnCount < (int)params->m_emitCount)) {
+                    bool placing;
+
                     BirthParticle(pppObject, vYmBreath, pYmBreath, vColor, (PARTICLE_DATA*)particleData,
                                   (PARTICLE_WMAT*)particleWmat, (PARTICLE_COLOR*)particleColor);
-                    found = true;
+                    placing = true;
                     spawnCount += 1;
                     groupData = groupTable;
                     for (j = 0; j < (int)params->m_groupCount; j++) {
                         for (k = 0; k < (int)params->m_slotCount; k++) {
                             if ((groupData->particleIndices[k] == -1) && (groupData->particleStates[k] == -1)) {
                                 groupData->particleIndices[k] = (signed char)i;
-                                found = false;
+                                placing = false;
                                 groupData->particleStates[k] = 1;
                             }
-                            if (!found) {
+                            if (!placing) {
                                 break;
                             }
                         }
-                        if (!found) {
+                        if (!placing) {
                             break;
                         }
                         groupData += 1;
@@ -789,13 +787,13 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
         groupData = groupTable;
         for (i = 0; i < (int)params->m_groupCount; i++) {
             if ((groupData->active != 1) && (*groupData->particleIndices != -1) && (*groupData->particleStates == 1)) {
+                float zero = 0.0f;
+
                 unitVelocity.x = FLOAT_80330c80;
                 unitVelocity.y = FLOAT_80330c80;
                 unitVelocity.z = FLOAT_80330C90;
                 groupData->speed = params->m_groupSpeed;
                 pppCopyVector(groupData->direction, unitVelocity);
-                float zero = 0.0f;
-
                 groupData->position.z = zero;
                 groupData->position.y = zero;
                 groupData->position.x = zero;
@@ -805,12 +803,13 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
             groupData += 1;
         }
 
+        groupData = groupTable;
         for (i = 0; i < (int)params->m_groupCount; i++) {
-            if (groupTable->active != 0) {
-                PSVECScale(&groupTable->direction, &stepVelocity, groupTable->speed);
-                PSVECAdd(&stepVelocity, &groupTable->position, &groupTable->position);
+            if (groupData->active != 0) {
+                PSVECScale(&groupData->direction, &stepVelocity, groupData->speed);
+                PSVECAdd(&stepVelocity, &groupData->position, &groupData->position);
             }
-            groupTable += 1;
+            groupData += 1;
         }
     }
 }


### PR DESCRIPTION
## Summary
- align `pppFrameYmBreath` and `UpdateAllParticle` group iteration with the already-closer `pppBreathModel` implementation
- remove redundant pointer stepping and reset the group pointer before the final active-group update loop
- keep behavior unchanged while making the source shape more plausible and compiler-friendly

## Evidence
- `ninja` succeeds
- `pppFrameYmBreath`: `94.379745%` -> `94.93355%`
- `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`: `96.14552%` -> `96.481346%`
- `pppRenderYmBreath`, `UpdateParticle`, and `BirthParticle` stayed stable

## Why this is plausible source
- the YM breath code now follows the same control-flow and pointer-iteration structure as the neighboring breath-model implementation instead of relying on extra temporary state
- this is source cleanup around the target dependency cluster, not symbol renaming or compiler coaxing