### PR TITLE
Improve CAStar drawAStar frame gating

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -505,9 +505,7 @@ void CAStar::drawAStar()
 {
 	if ((DbgMenuPcs.GetDbgFlagsRaw() & 0x400) != 0)
 	{
-		int frameGroup = System.m_frameCounter / 0x1e + (System.m_frameCounter >> 31);
-
-		if (System.m_frameCounter == (frameGroup - (frameGroup >> 31)) * 0x1e)
+		if ((System.m_frameCounter % 0x1e) == 0)
 		{
 			for (int group = 0; group < 64; ++group)
 			{


### PR DESCRIPTION
## Summary
- simplify `CAStar::drawAStar()`'s 30-frame gate to a direct modulo check
- keep the source plausible while matching the unsigned `m_frameCounter` code shape more closely

## Improved units / symbols
- `main/astar`
- `drawAStar__6CAStarFv`

## Evidence
- `main/astar` `.text` match: `82.81157%` -> `83.004005%`
- `drawAStar__6CAStarFv` match: `76.23428%` -> `78.15429%`
- `ninja` succeeds after the change

## Why this is plausible source
`System::m_frameCounter` is an unsigned counter, and the original code shape is consistent with a normal modulo-based periodic gate rather than a hand-expanded signed division sequence.
