### PR TITLE
pppLocationTitle: match source filename rodata emission

### DIFF
--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -41,7 +41,7 @@ struct LocationTitleColorBlock {
     GXColor m_color;
 };
 
-static const char s_pppLocationTitle_cpp_801DB510[] = "pppLocationTitle.cpp";
+extern "C" const char s_pppLocationTitle_cpp_801DB510[] = "pppLocationTitle.cpp";
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- give `s_pppLocationTitle_cpp_801DB510` C linkage so the compiler emits the filename string in `.rodata` without the extra trailing gap bytes
- keep code generation unchanged for `pppFrameLocationTitle`

## Evidence
- `main/pppLocationTitle` `.rodata` match: `93.333336%` -> `100.0%`
- `main/pppLocationTitle` `.text` match remains `99.71591%`
- `pppFrameLocationTitle` remains `99.592834%`

## Plausibility
- this is a linkage/storage fix for a file-scope source-name constant used by `pppMemAlloc`
- the emitted object now matches the expected `.rodata` layout without coercing codegen or introducing hacks