### PR TITLE
Simplify CMcPcs table init

### DIFF
--- a/include/ffcc/p_mc.h
+++ b/include/ffcc/p_mc.h
@@ -15,20 +15,17 @@ class CMcPcs : public CProcess
 public:
     CMcPcs()
     {
-        static unsigned int desc0[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__6CMcPcsFv)};
-        static unsigned int desc1[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__6CMcPcsFv)};
-        static unsigned int desc2[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__6CMcPcsFv)};
         unsigned int* table = &m_table__6CMcPcs[1];
 
-        table[0] = desc0[0];
-        table[1] = desc0[1];
-        table[2] = desc0[2];
-        table[3] = desc1[0];
-        table[4] = desc1[1];
-        table[5] = desc1[2];
-        table[6] = desc2[0];
-        table[7] = desc2[1];
-        table[8] = desc2[2];
+        table[0] = 0;
+        table[1] = 0xFFFFFFFF;
+        table[2] = reinterpret_cast<unsigned int>(create__6CMcPcsFv);
+        table[3] = 0;
+        table[4] = 0xFFFFFFFF;
+        table[5] = reinterpret_cast<unsigned int>(destroy__6CMcPcsFv);
+        table[6] = 0;
+        table[7] = 0xFFFFFFFF;
+        table[8] = reinterpret_cast<unsigned int>(calc__6CMcPcsFv);
     }
 
     void Init();


### PR DESCRIPTION
## Summary
- simplify `CMcPcs` constructor table initialization in `include/ffcc/p_mc.h`
- remove temporary static descriptor arrays and write descriptor entries directly into `m_table__6CMcPcs`
- preserve `game.o` symbol matches while improving `p_mc` startup/data layout

## Evidence
- `p_mc::__sinit_p_mc_cpp`: `32.878788%` -> `100.0%`
- `p_mc [ .data-0 ]`: `81.19658%` -> `87.87003%`
- `game` verification: no symbol match-percent changes after the header edit

## Why this is plausible
- the previous constructor shape synthesized three local static descriptor arrays and copied them into the table at startup
- the improved shape directly writes the expected descriptor triplets, which better matches the generated startup sequence without introducing hacks or fake linkage
