### PR TITLE
Add explicit CProcess init/quit stubs

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -15,6 +15,8 @@ class CProcess : public CManager
 {
 public:
     CProcess() {}
+    virtual void Init();
+    virtual void Quit();
     virtual int GetTable(unsigned long) = 0;
     virtual void onScriptChanging(char*);
     virtual void onScriptChanged(char*, int);

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -80,6 +80,24 @@ void CProcess::onMapChanged(int, int, int)
 
 /*
  * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+void CProcess::Quit()
+{
+}
+
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+void CProcess::Init()
+{
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x8001FE84
  * PAL Size: 4b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- add explicit `CProcess::Init()` and `CProcess::Quit()` declarations in `include/ffcc/system.h`
- define the two empty base stubs in `src/p_sample.cpp` alongside the existing `CProcess` virtual hooks
- keep the change localized to the `CProcess`/`CSamplePcs` dependency cluster that feeds `system`

## Evidence
- before: code `529044 / 1855224` bytes, `3241 / 4732` functions matched
- after: code `529232 / 1855224` bytes, `3242 / 4732` functions matched
- net: `+188` matched code bytes and `+1` matched function
- `ninja` builds cleanly after the change

## Why this is plausible
`CProcess` is an abstract base used by scenegraph ownership in `system`. Giving it explicit `Init`/`Quit` slots makes the interface more coherent and aligns better with how the engine treats manager-like process objects, without resorting to symbol hacks or manual metadata forcing.