### PR TITLE
Use raw storage for MaterialEditorPcs

### DIFF
--- a/include/ffcc/p_MaterialEditor.h
+++ b/include/ffcc/p_MaterialEditor.h
@@ -114,6 +114,10 @@ public:
     unsigned char _pad3BD[0x3E0 - 0x3BD];
 };
 
+#ifdef FFCC_DEFINE_MATERIALEDITORPCS_STORAGE
+extern u8 MaterialEditorPcs[sizeof(CMaterialEditorPcs)];
+#else
 extern CMaterialEditorPcs MaterialEditorPcs;
+#endif
 
 #endif // _FFCC_P_MATERIALEDITOR_H_

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -1,3 +1,4 @@
+#define FFCC_DEFINE_MATERIALEDITORPCS_STORAGE
 #include "ffcc/p_MaterialEditor.h"
 #include "ffcc/p_usb.h"
 #include "ffcc/ME_USB_process.h"
@@ -41,7 +42,7 @@ unsigned int m_table__18CMaterialEditorPcs[0x15C / sizeof(unsigned int)] = {
 };
 unsigned int lbl_801EA624[3] = {reinterpret_cast<unsigned int>(lbl_8032E648), 0, 0};
 unsigned int lbl_801EA630 = reinterpret_cast<unsigned int>(lbl_8032E648);
-CMaterialEditorPcs MaterialEditorPcs;
+u8 MaterialEditorPcs[sizeof(CMaterialEditorPcs)];
 u8 lbl_8026D338[0xC];
 
 /*


### PR DESCRIPTION
## Summary
- switch `MaterialEditorPcs` to the same raw backing-storage pattern already used by other manually-initialized viewer processes
- keep the typed declaration for all non-owning translation units while letting `p_MaterialEditor.cpp` provide the raw symbol storage
- avoid relying on an automatic global object construction path for a class that already has an explicit `__sinit`

## Evidence
- full rebuild succeeds with `ninja`
- overall progress moved from `529108 / 1855224` matched code bytes to `529232 / 1855224` (`+124`)
- matched functions moved from `3241 / 4732` to `3242 / 4732` (`+1`)
- game code matched bytes moved from `189224 / 1477652` to `189348 / 1477652` (`+124`)
- `main/p_MaterialEditor` now reports `CMaterialEditorPcs::~CMaterialEditorPcs()` at `100.0%` fuzzy match, with `createViewer()` also at `100.0%`
- global data regressed slightly (`1123962 -> 1123958` matched bytes), but the source is more plausible and the unit gains a real destructor/codegen improvement

## Why this is plausible source
- `p_MaterialEditor.cpp` already performs explicit subobject construction in `__sinit_p_MaterialEditor_cpp`
- `p_FunnyShape.cpp` uses the same raw-storage pattern for another viewer process with manual static initialization
- this removes an extra typed-global construction path instead of adding compiler-coaxing hacks