### PR TITLE
Improve pppYmBreath particle lookup typing

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -697,7 +697,8 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                 foundSlot = -1;
                 for (short groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
                     for (short slotIndex = 0; slotIndex < (int)params->m_slotCount; slotIndex++) {
-                        if ((int)(short)i == (int)*(signed char*)(*(int*)(groupTableWork + 4) + (int)slotIndex)) {
+                        signed char* particleIndices = *(signed char**)(groupTableWork + 4);
+                        if ((short)i == *(signed char*)(particleIndices + (short)slotIndex)) {
                             foundGroup = groupIndex;
                             foundSlot = slotIndex;
                             found = true;


### PR DESCRIPTION
## Summary
- clean up the dead-particle group lookup in `UpdateAllParticle` in `src/pppYmBreath.cpp`
- load the group's particle index array through a typed local pointer before comparing slots
- keep behavior unchanged while moving the generated code closer to the sibling `pppBreathModel` implementation

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`
  - before: `97.731346%`
  - after: `98.216415%`
- `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -`
  - unit `.text` before: `96.993195%`
  - unit `.text` after: `97.07364%`

## Why this is plausible
- the change replaces raw repeated pointer arithmetic with a typed local for the serialized particle index table
- that matches the style already used in the closely related `pppBreathModel` particle update path
- no fake linkage, section forcing, or compiler-only scaffolding was added