### PR TITLE
pppCharaBreak: use RGBA vertex color format

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -1026,7 +1026,7 @@ extern "C" void CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f(v
             GXSetVtxDesc((GXAttr)14, GX_INDEX16);
             GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)9, GX_POS_XYZ, GX_S16, *(u32*)((u8*)*(s32*)((u8*)model + 0xA4) + 0x34) & 0xFF);
             GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)10, GX_NRM_XYZ, GX_S16, *(u32*)((u8*)*(s32*)((u8*)model + 0xA4) + 0x38) & 0xFF);
-            GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)11, GX_CLR_RGB, GX_RGBA8, 0);
+            GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)11, GX_CLR_RGBA, GX_RGBA8, 0);
             GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)13, GX_TEX_ST, GX_S16, 0xC);
             GXSetVtxAttrFmt((GXVtxFmt)7, (GXAttr)14, GX_TEX_ST, GX_S16, 0xC);
 


### PR DESCRIPTION
## Summary
- switch `CharaBreak_AfterDrawMeshCallback` to use `GX_CLR_RGBA` for the color vertex attribute
- keep the change scoped to `src/pppCharaBreak.cpp`
- leave the unrelated local `src/RedSound/RedMidiCtrl.cpp` edit out of the commit

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f` reports `match_percent: 83.333336`
- `build/GCCP01/report.json` now reports `83.39548` fuzzy match for `CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`
- `build/GCCP01/report.json` now reports `84.90316` fuzzy match for `main/pppCharaBreak`

## Plausibility
- the target assembly expects color component count `1` in the `GXSetVtxAttrFmt` call for attribute `11`
- `GX_CLR_RGBA` is the matching Dolphin enum value, so this is a source-correct fix rather than compiler coaxing
