### PR TITLE
Refine pppBreathModel group traversal

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -491,8 +491,9 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     Mtx* particleWMat;
     Mtx* particleMtx;
     int i;
-    int groupIndex;
+    short groupIndex;
     int firstParticle;
+    int groupTableOffset;
     int groupTable;
     short slotIndex;
     unsigned int slotCount;
@@ -582,9 +583,10 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     UpdateAllParticle(reinterpret_cast<_pppPObject*>(breathModel), work, pBreathModel, color);
 
     particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
+    groupTableOffset = 0;
     for (groupIndex = 0; groupIndex < (int)pBreathModel->m_groupCount; groupIndex++) {
         slotCount = pBreathModel->m_slotCount;
-        groupTable = (int)((unsigned char*)work->m_groups + groupIndex * 0x5C);
+        groupTable = (int)((unsigned char*)work->m_groups + groupTableOffset);
         for (slotIndex = 0; slotIndex < (int)slotCount; slotIndex++) {
             if ((*(signed char*)(*(int*)(groupTable + 4) + slotIndex) == -1) ||
                 (*(signed char*)(*(int*)(groupTable + 8) + slotIndex) != 1)) {
@@ -626,6 +628,7 @@ group_ready:
             pppSubVector(hitVector, target, origin);
             pppHitCylinderSendSystem(mngSt, &origin, &hitVector, scaledOwner, pBreathModel->m_groupRadius);
         }
+        groupTableOffset += 0x5C;
     }
 }
 


### PR DESCRIPTION
## Summary
- change `pppFrameBreathModel` to track group storage with a running byte offset instead of recomputing `groupIndex * 0x5C`
- keep the existing raw group-table access pattern, but align the loop variable types more closely with the target code shape

## Evidence
- `python3 tools/agent_select_target.py` no longer lists `main/pppBreathModel` in the top code/data opportunity buckets after this change
- `build/GCCP01/report.json` now reports `main/pppBreathModel` at `74.55%` matched data, up from the earlier target-selection report showing `36.36%`
- `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o - pppFrameBreathModel` reports `94.398735%` fuzzy match for the function on this branch

## Plausibility
- this keeps the original control flow and field accesses intact
- the change only adjusts how the compiler walks the adjacent `BreathParticleGroup` records, which is a natural source-level layout fix rather than compiler coaxing