### PR TITLE
Tighten FS USB 32-bit byte swaps

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -46,13 +46,15 @@ static inline u32 LoadSwap32(u32 value) {
 }
 
 static inline void StoreSwap32(u32* value) {
-    *value = LoadSwap32(*value);
+    u32 raw = *value;
+
+    *value = __lwbrx(&raw, 0);
 }
 
 static inline void StoreSwap32(f32* value) {
-    u32 swapped;
     f32 raw = *value;
-    swapped = __lwbrx(&raw, 0);
+    u32 swapped = __lwbrx(&raw, 0);
+
     *value = *reinterpret_cast<f32*>(&swapped);
 }
 


### PR DESCRIPTION
## Summary
- rewrite the local 32-bit byte-swap helpers in `FS_USB_Process.cpp` to swap through explicit stack locals
- preserve behavior while matching the observed object code more closely in `CFunnyShapePcs::SetUSBData`

## Evidence
- `main/FS_USB_Process` improved from `98.82179%` to `98.84676%`
- `SetUSBData__14CFunnyShapePcsFv` improved from `98.82179%` to `98.84676%`
- `ninja` builds cleanly after the change

## Plausibility
- this removes an extra helper-by-value path and uses direct in-place swaps, which is a straightforward source pattern for the original code rather than compiler coaxing