### PR TITLE
Improve THPSimpleCalcNeedMemory match

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -772,13 +772,13 @@ s32 THPSimpleSetBuffer(u8* buffer)
  */
 s32 THPSimpleCalcNeedMemory(void)
 {
+    s32 need;
+
     if (SimpleControl.isOpen != 0) {
-        s32 need = ((SimpleControl.header.mBufferSize + 0x1F) * 8) & ~0xFF;
-        s32 frameSize = SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize;
-        need += (frameSize + 0x1F) & ~0x1F;
-        frameSize = (((u32)frameSize >> 2) + 0x1F) & ~0x1F;
-        need += frameSize;
-        need += frameSize;
+        need = ((SimpleControl.header.mBufferSize + 0x1F) * 8) & ~0xFF;
+        need += (SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize + 0x1F) & ~0x1F;
+        need += ((((u32)(SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize)) >> 2) + 0x1F) & ~0x1F;
+        need += ((((u32)(SimpleControl.videoInfo.mXSize * SimpleControl.videoInfo.mYSize)) >> 2) + 0x1F) & ~0x1F;
 
         if (SimpleControl.hasAudio != 0) {
             need += (((SimpleControl.header.mAudioMaxSamples * 4) + 0x1F) & ~0x1F) * 3;


### PR DESCRIPTION
## Summary
- rewrite `THPSimpleCalcNeedMemory` to use the combined arithmetic shape from the THP decomp
- keep behavior unchanged while matching the original memory-size calculation more closely

## Evidence
- `THPSimpleCalcNeedMemory`: `96.875%` -> `98.75%` fuzzy match
- `main/THPSimple`: `99.305504%` -> `99.34345%` fuzzy match
- `ninja` rebuild completed successfully

## Plausibility
- the change removes an unnecessary temporary decomposition and expresses the allocation math in the same grouped form shown by Ghidra
- this is source cleanup toward the original arithmetic, not compiler coaxing or section-forcing hacks