### PR TITLE
Improve pppYmDrawMdlTexAnm destructor match

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -222,7 +222,7 @@ void pppDestructYmDrawMdlTexAnm(_pppPObjLink* object, _pppCtrlTable* ctrl)
     s32 uvByteOffsetV;
     CMapMesh* mapMesh;
     s32 i;
-    s32 frameU;
+    u32 frameU;
     u32 tilesU;
 
     ymDrawMdlTexAnm = (pppYmDrawMdlTexAnmObject*)object;


### PR DESCRIPTION
## Summary
- change `frameU` in `pppDestructYmDrawMdlTexAnm` from `s32` to `u32`
- keep the existing UV restore logic intact while matching the division/remainder path more closely

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppYmDrawMdlTexAnm -o - pppDestructYmDrawMdlTexAnm`
  - before: `87.69512%`
  - after: `98.69512%`

## Plausibility
- `m_frame` and `m_tilesU` are used as frame counters/divisors in the UV wrap calculation, so making `frameU` unsigned matches the surrounding arithmetic and the generated code without introducing compiler-coaxing hacks.
