### PR TITLE
Fix pppEmission sdata2 conversion constants

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -32,8 +32,8 @@ extern const float FLOAT_803311e4;
 extern const float FLOAT_803311f8;
 extern const float FLOAT_8033111C = 15.0f;
 extern const float FLOAT_80331120 = 7.0f;
-extern const double DOUBLE_80331128 = 4503599627370496.0;
-extern const float FLOAT_80331130 = 10000000.0f;
+extern const double DOUBLE_803311e8 = 4503599627370496.0;
+extern const double DOUBLE_803311f0 = 4503601774854144.0;
 static const char s_pppEmission_cpp_801db7e8[] = "pppEmission.cpp";
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }


### PR DESCRIPTION
## Summary
- replace the local `pppEmission` integer-conversion constants with the correct double-valued forms
- remove the stray `10000000.0f` local constant that was occupying the wrong `.sdata2` slot

## Evidence
- `ninja` succeeds
- `main/pppEmission` `.sdata2` match improved from `55.0%` to `65.625%`
- overall matched data bytes increased from `1124166` to `1124246`

## Why this is plausible
- the affected functions (`pppFrameEmission` and `Emission_AfterDrawMeshCallback`) use the standard PowerPC int-to-float conversion pattern that expects the `0x4330...` double helpers in `.sdata2`
- this change corrects the constant block rather than coercing control flow or adding hacks