### PR TITLE
Improve pppRenderColum draw env depth handling

### DIFF
--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -213,8 +213,9 @@ void pppRenderColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param
                 color.rgba[2] = *((u8*)&param_2->m_stepValue + 2) + values->m_colorB;
                 color.rgba[3] = alpha;
 
+                const float depth = FLOAT_80331084;
                 pppSetDrawEnv(
-                    &color, (pppFMATRIX*)0, zero, (u8)param_2->m_payload[0x15],
+                    &color, (pppFMATRIX*)0, depth, (u8)param_2->m_payload[0x15],
                     (u8)param_2->m_payload[0x14],
                     param_2->m_arg3, 0, 0, 1, 0);
 


### PR DESCRIPTION
## Summary
- introduce a dedicated loop-local `depth` constant for the `pppSetDrawEnv` call in `pppRenderColum`
- keep the existing `zero` local for the per-segment center computation instead of reusing it as the draw-env depth argument
- preserve plausible original source structure while improving MWCC codegen in `main/pppColum`

## Objdiff evidence
- `main/pppColum` `.text` match: `97.39492%` -> `98.58891%`
- `pppRenderColum`: `96.50774%` -> `98.10836%`

## Why this is plausible source
- this is a small source-level cleanup around two semantically distinct zero-valued uses
- it avoids hacks, hardcoded addresses, and compiler-forcing tricks
- the generated code moves materially closer to the target while keeping the render path straightforward and readable

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppColum -o /tmp/pppColum_diff_repro.json pppRenderColum`
