### PR TITLE
Improve pppFrameLocationTitle2 stack layout

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -208,7 +208,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     s32* serializedOffsets;
     LocationTitle2Work* work;
     LocationTitle2ColorBlock* colorData;
-    Vec interp[20];
+    Vec interp[21];
 
     if (gPppCalcDisabled != 0) {
         return;


### PR DESCRIPTION
## Summary
- fix the interpolation scratch buffer size in `pppFrameLocationTitle2`
- keep the surrounding source shape intact while matching the function's stack layout more closely

## Evidence
- `ninja` succeeds
- `pppFrameLocationTitle2` objdiff improved from `74.81579%` before to `95.98355%` after
- `pppRenderLocationTitle2` remains at `99.832535%`

## Why this is plausible
- Ghidra shows a larger interpolation scratch region in this function
- changing the local `Vec interp` count from `20` to `21` improves the generated stack frame without introducing compiler-coaxing hacks or fake linkage
