### PR TITLE
Fix pppYmTracer2 color global linkage

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -72,8 +72,8 @@ union PackedColor {
     u8 bytes[4];
 };
 
-static PackedColor g_pppYmTracer2_1;
-static PackedColor g_pppYmTracer2_2;
+extern PackedColor g_pppYmTracer2_1;
+extern PackedColor g_pppYmTracer2_2;
 
 static inline void copyPolygonData(TRACE_POLYGON* dst, TRACE_POLYGON* src)
 {


### PR DESCRIPTION
## Summary
- Change pppYmTracer2 color seed storage from file-local definitions to extern references.
- Matches the original pppYmTracer2 object, which references g_pppYmTracer2_1 and g_pppYmTracer2_2 rather than owning their storage.

## Evidence
- ninja passes.
- objdiff for main/pppYmTracer2 before: current source emitted an extra .sbss section, size 8, 0.0% match.
- objdiff for main/pppYmTracer2 after: current source no longer emits .sbss; g_pppYmTracer2_1 and g_pppYmTracer2_2 are undefined references in build/GCCP01/src/pppYmTracer2.o.
- Code scores are unchanged: pppRenderYmTracer2 remains 98.06911%, pppFrameYmTracer2 remains 98.47122%.

## Plausibility
This is linkage/data ownership cleanup, not compiler coaxing: the PAL target object references these globals externally, and config symbols place g_pppYmTracer2_1/2 outside pppYmTracer2.cpp ownership.