### PR TITLE
Refine pppFrameConstrainCameraDir result ordering

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -57,9 +57,13 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
             PSMTXConcat(scaleMtx, pppMngStPtr->m_matrix.value, pppMngStPtr->m_matrix.value);
 
             if (flags[0] != 0) {
-                float resultZ = cameraDirZ * *value + cameraPosZ;
-                float resultY = cameraDirY * *value + cameraPosY;
-                float resultX = cameraDirX * *value + cameraPosX;
+                float resultX;
+                float resultY;
+                float resultZ;
+
+                resultX = cameraDirX * *value + cameraPosX;
+                resultY = cameraDirY * *value + cameraPosY;
+                resultZ = cameraDirZ * *value + cameraPosZ;
                 pppMngStPtr->m_matrix.value[0][3] = resultX;
                 pppMngStPtr->m_matrix.value[1][3] = resultY;
                 pppMngStPtr->m_matrix.value[2][3] = resultZ;


### PR DESCRIPTION
## Summary
- reorder the temporary translation values in `pppFrameConstrainCameraDir`
- keep behavior unchanged while nudging MWCC toward the original result register/store ordering

## Evidence
- `ninja` succeeds for `GCCP01`
- the rebuild moved project progress from `1124254` to `1124270` matched data bytes overall, and from `946494` to `946510` matched game-data bytes
- `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir -o - pppFrameConstrainCameraDir` no longer reports instruction-level diffs for the function body

## Plausibility
- this is a source-shape cleanup only: it replaces reverse-order temporary initialization with explicit `resultX/resultY/resultZ` assignments in the same semantic order as the final matrix stores
- no hacks, manual section forcing, or fake symbols were introduced
