### PR TITLE
Improve pppBreathModel frame loop structure

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -493,7 +493,6 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     int i;
     short groupIndex;
     int firstParticle;
-    int groupTableOffset;
     int groupTable;
     short slotIndex;
     unsigned int slotCount;
@@ -583,10 +582,9 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     UpdateAllParticle(reinterpret_cast<_pppPObject*>(breathModel), work, pBreathModel, color);
 
     particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
-    groupTableOffset = 0;
     for (groupIndex = 0; groupIndex < (int)pBreathModel->m_groupCount; groupIndex++) {
         slotCount = pBreathModel->m_slotCount;
-        groupTable = (int)((unsigned char*)work->m_groups + groupTableOffset);
+        groupTable = (int)((unsigned char*)work->m_groups + groupIndex * 0x5C);
         for (slotIndex = 0; slotIndex < (int)slotCount; slotIndex++) {
             if ((*(signed char*)(*(int*)(groupTable + 4) + slotIndex) == -1) ||
                 (*(signed char*)(*(int*)(groupTable + 8) + slotIndex) != 1)) {
@@ -628,7 +626,6 @@ group_ready:
             pppSubVector(hitVector, target, origin);
             pppHitCylinderSendSystem(mngSt, &origin, &hitVector, scaledOwner, pBreathModel->m_groupRadius);
         }
-        groupTableOffset += 0x5C;
     }
 }
 
@@ -656,8 +653,8 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
     BreathParticleGroup* groupData;
     short foundSlot;
     short foundGroup;
-    Vec unitVelocity;
     Vec stepVelocity;
+    Vec unitVelocity;
 
     particleData = reinterpret_cast<BreathParticleData*>(vBreathModel->m_particleData);
     particleWmat = vBreathModel->m_particleWmats;


### PR DESCRIPTION
## Summary
- tighten `pppFrameBreathModel` loop structure around group traversal to match the established `pppYmBreath` source shape more closely
- remove the extra running group offset state and compute the per-group base directly
- keep the frame/update control flow behavior intact while reducing stack/register noise in the PAL build

## Evidence
- `ninja` succeeds
- `main/pppBreathModel` `.text` match improved from `98.3718%` to `98.4791%`
- `pppFrameBreathModel` improved from `94.398735%` to `94.96835%`
- `pppRenderBreathModel` stayed at `98.77814%`
- `UpdateAllParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColor` regressed slightly from `98.21011%` to `98.178986%`, but the unit-level `.text` score still moved forward overall

## Plausibility
- the change removes bookkeeping that was not needed in source and aligns this translation unit with the already-decompiled sibling breath implementation rather than using compiler-coaxing hacks
- no symbols, sections, or generated runtime constructs were forced manually