### PR TITLE
Match CMapHitFace bounds constant loads

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -6,6 +6,9 @@
 
 #include <math.h>
 
+extern "C" const float FLOAT_8032F8EC;
+extern "C" const float FLOAT_8032F8F0;
+
 CMapCylinder g_hit_cyl;
 CMapCylinder g_hit_cyl_min;
 Vec g_hit_mvec;
@@ -954,11 +957,11 @@ void CMapHit::DrawNormal()
  */
 CMapHitFace::CMapHitFace()
 {
-    m_boundsMin.z = 0.0f;
-    m_boundsMin.y = 0.0f;
-    m_boundsMin.x = 0.0f;
+    m_boundsMin.z = FLOAT_8032F8EC;
+    m_boundsMin.y = FLOAT_8032F8EC;
+    m_boundsMin.x = FLOAT_8032F8EC;
 
-    m_boundsMax.z = 1.0f;
-    m_boundsMax.y = 1.0f;
-    m_boundsMax.x = 1.0f;
+    m_boundsMax.z = FLOAT_8032F8F0;
+    m_boundsMax.y = FLOAT_8032F8F0;
+    m_boundsMax.x = FLOAT_8032F8F0;
 }


### PR DESCRIPTION
## Summary
- update `CMapHitFace::CMapHitFace()` to load the named `.sdata2` zero/one constants used by the original binary
- keep the surrounding `maphit` initialization logic unchanged
- preserve the existing near-match for `__sinit_maphit_cpp`

## Evidence
- `__ct__11CMapHitFaceFv`: `98.888885%` -> `100.0%`
- `__sinit_maphit_cpp`: remains `99.47369%`
- `ninja`: passes

## Plausibility
This change replaces anonymous literal loads with the original named float symbols in `maphit.cpp`. It improves the generated relocation targets without adding hacks or changing control flow.