### PR TITLE
Recover Tail3 particle color allocation

### DIFF
--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -255,6 +255,14 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
             memset(work->m_wmats, 0, work->m_maxParticles * 0x30);
         }
 
+        if (paramPayload[0x69] != 0) {
+            work->m_colors = (_PARTICLE_COLOR*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+                work->m_maxParticles << 5, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMegaBirthShpTail3_cpp), 0x2eb);
+            if (work->m_colors != 0) {
+                memset(work->m_colors, 0, work->m_maxParticles << 5);
+            }
+        }
+
         work->m_tailScaleDirection = param->m_directionTail;
         pppNormalize(work->m_tailScaleDirection, work->m_tailScaleDirection);
     }
@@ -262,6 +270,8 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
     if (work->m_particles == 0) {
         hasRequiredMemory = false;
     } else if (work->m_wmats == 0) {
+        hasRequiredMemory = false;
+    } else if ((paramPayload[0x69] != 0) && (work->m_colors == 0)) {
         hasRequiredMemory = false;
     } else {
         hasRequiredMemory = true;


### PR DESCRIPTION
## Summary
- add the missing optional `_PARTICLE_COLOR` allocation path in `pppFrameYmMegaBirthShpTail3`
- mirror Tail2's memory validation by requiring `m_colors` only when the Tail3 params request color state
- keep the change localized to the Tail3 dependency cluster and preserve existing allocation/destruction behavior

## Evidence
- project matched data increased from 1,124,414 to 1,124,438 bytes after rebuild
- matched code returned to the pre-experiment baseline of 531,480 bytes after the final rebuild
- `ninja` succeeds after the change

## Plausibility
Tail3 already renders and updates optional particle colors, and its destructor already frees `m_colors`; the missing frame-time allocation and guard were the inconsistent pieces. This patch restores that normal ownership flow instead of adding compiler-coaxing hacks.