### PR TITLE
Improve textureman TLUT initialization matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -585,17 +585,28 @@ void CTexture::InitTexObj()
         GXInitTexObjCI(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                        static_cast<GXCITexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
                        static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
-        int numEntries = (m_format == 9) ? 0x100 : 0x10;
-        GXInitTlutObj(&m_tlutObj0, m_tlutData, GX_TL_IA8, numEntries);
+        void* tlutData = m_tlutData;
+        unsigned int numEntries = 0x10;
+        if (m_format == 9) {
+            numEntries = 0x100;
+        }
+        GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
 
-        int offset = (m_format == 9) ? 0x100 : 0x10;
-        numEntries = (m_format == 9) ? 0x100 : 0x10;
-        GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(reinterpret_cast<unsigned int>(m_tlutData) + offset * 2),
-                      GX_TL_IA8, numEntries);
+        numEntries = 0x10;
+        if (m_format == 9) {
+            numEntries = 0x100;
+        }
+
+        int offset = 0x10;
+        if (m_format == 9) {
+            offset = 0x100;
+        }
+        GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(reinterpret_cast<int>(tlutData) + offset * 2), GX_TL_IA8,
+                      numEntries);
     } else {
         GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                      static_cast<GXTexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
-                     static_cast<GXTexWrapMode>(m_wrapMode), (static_cast<unsigned int>(1 - m_maxLod)) >> 31);
+                     static_cast<GXTexWrapMode>(m_wrapMode), 1 - m_maxLod >> 31);
     }
 
     if (1 < m_maxLod) {
@@ -791,18 +802,28 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
                 GXInitTexObjCI(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                                static_cast<GXCITexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
                                static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
-                int numEntries = (m_format == 9) ? 0x100 : 0x10;
-                GXInitTlutObj(&m_tlutObj0, m_tlutData, GX_TL_IA8, numEntries);
+                void* tlutData = m_tlutData;
+                unsigned int numEntries = 0x10;
+                if (m_format == 9) {
+                    numEntries = 0x100;
+                }
+                GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
 
-                int offset = (m_format == 9) ? 0x100 : 0x10;
-                numEntries = (m_format == 9) ? 0x100 : 0x10;
-                GXInitTlutObj(&m_tlutObj1,
-                              reinterpret_cast<void*>(reinterpret_cast<unsigned int>(m_tlutData) + offset * 2),
+                numEntries = 0x10;
+                if (m_format == 9) {
+                    numEntries = 0x100;
+                }
+
+                int offset = 0x10;
+                if (m_format == 9) {
+                    offset = 0x100;
+                }
+                GXInitTlutObj(&m_tlutObj1, reinterpret_cast<void*>(reinterpret_cast<int>(tlutData) + offset * 2),
                               GX_TL_IA8, numEntries);
             } else {
                 GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                              static_cast<GXTexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
-                             static_cast<GXTexWrapMode>(m_wrapMode), (static_cast<unsigned int>(1 - m_maxLod)) >> 31);
+                             static_cast<GXTexWrapMode>(m_wrapMode), 1 - m_maxLod >> 31);
             }
 
             if (1 < m_maxLod) {
@@ -879,7 +900,6 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
  */
 _GXColor CTexture::GetTlutColor(int index)
 {
-    unsigned short* tlut = reinterpret_cast<unsigned short*>(m_tlutData);
     unsigned int format = static_cast<unsigned int>(m_format);
     int offset = 0;
     if (format == 9) {
@@ -888,6 +908,7 @@ _GXColor CTexture::GetTlutColor(int index)
         offset = 0x10;
     }
 
+    unsigned short* tlut = reinterpret_cast<unsigned short*>(m_tlutData);
     unsigned int packed = tlut[index] | (tlut[index + offset] << 16);
     unsigned char* bytes = reinterpret_cast<unsigned char*>(&packed);
     _GXColor color;


### PR DESCRIPTION
## Summary
- reshape `CTexture` CI/TLUT initialization in `textureman.cpp` to follow the original control-flow more closely
- keep the duplicated `InitTexObj` and `CacheLoadTexture` TLUT setup paths aligned with the reconstructed ABI shape
- preserve the explicit bytewise `GetTlutColor` return path while improving surrounding offset handling

## Evidence
- `main/textureman` code match: `95.415215%` -> `95.8231%`
- `InitTexObj__8CTextureFv`: `81.82022%` -> `84.46067%`
- `CacheLoadTexture__8CTextureFP13CAmemCacheSet`: `85.082565%` -> `87.31193%`
- `GetTlutColor__8CTextureFi`: `80.76667%` -> `88.96667%`

## Why this is plausible source
- the changes remove some expression shaping that was steering MWCC away from the original register/branch layout, but do not introduce hacks or fake symbols
- TLUT entry count and second-palette offset handling are now expressed in the same repeated, stepwise form visible in the original binary's control flow
- the bytewise `GetTlutColor` construction is kept as normal source-level data movement rather than compiler coaxing or manual assembly tricks

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/textureman -o - InitTexObj__8CTextureFv`
- `build/tools/objdiff-cli diff -p . -u main/textureman -o - CacheLoadTexture__8CTextureFP13CAmemCacheSet`
- `build/tools/objdiff-cli diff -p . -u main/textureman -o - GetTlutColor__8CTextureFi`
