### PR TITLE
Fix p_sample CProcess virtual declarations

### DIFF
--- a/include/ffcc/system.h
+++ b/include/ffcc/system.h
@@ -15,8 +15,6 @@ class CProcess : public CManager
 {
 public:
     CProcess() {}
-    virtual void Init();
-    virtual void Quit();
     virtual int GetTable(unsigned long) = 0;
     virtual void onScriptChanging(char*);
     virtual void onScriptChanged(char*, int);

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -80,24 +80,6 @@ void CProcess::onMapChanged(int, int, int)
 
 /*
  * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void CProcess::Quit()
-{
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void CProcess::Init()
-{
-}
-
-/*
- * --INFO--
  * PAL Address: 0x8001FE84
  * PAL Size: 4b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- remove the redundant  /  declarations from 
- drop the stray  /  definitions from 
- let  use 's virtuals instead of emitting local  stubs in this unit

## Evidence
- [1/1] PROGRESS
Progress:
  All: 28.65% matched, 18.76% linked (310 / 625 files)
    Code: 531480 / 1855224 bytes (3249 / 4732 functions)
    Data: 1124294 / 1489498 bytes (75.48%)
  Game Code: 12.88% matched, 2.35% linked (107 / 265 files)
    Code: 190348 / 1477652 bytes (1693 / 3111 functions)
    Data: 946534 / 1131898 bytes (83.62%)
  RedSound: 46.47% matched, 5.55% linked (1 / 8 files)
    Code: 31632 / 68072 bytes (314 / 379 functions)
    Data: 20090 / 25790 bytes (77.90%)
  SDK Code: 100.00% matched, 100.00% linked (202 / 202 files)
    Code: 309500 / 309500 bytes (1242 / 1242 functions)
    Data: 157670 / 158254 bytes (99.63%) succeeds on GCCP01 after the change
-  no longer defines  / ; it now references  / 
- the  text symbol order now lines up with the original  ordering (, , , , , , ) instead of being shifted by bogus  method bodies

## Why this is plausible
These functions already belong to , and keeping duplicate  declarations forced this unit to emit override bodies that are not present in the original object. Removing that override path is a linkage/layout fix, not compiler coaxing.