### PR TITLE
Tighten laser render local lifetimes

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -408,31 +408,13 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     int colorOffset = serializedDataOffsets[1];
     LaserColorData* colorData = (LaserColorData*)((u8*)pppLaser + 0x80 + colorOffset);
     s32 dataValIndex = step->m_dataValIndex;
-    Vec* points;
-    u32 count;
-    u32 i;
-    u32 colorBase;
-    u32 color0;
-    u32 color1;
-    u8 alpha0;
-    u8 alphaStep;
-    u8 alphaMax;
     float halfWidth;
     float negHalfWidth;
     float length;
-    float u0;
-    float u1;
-    float uvStep;
     pppFMATRIX unitMtx;
     pppFMATRIX modelView;
     pppFMATRIX mtxOut;
-    pppFMATRIX shapeMtx;
-    Mtx tempMtx;
-    Mtx sphereMtx;
-    Vec shapePos;
-    Vec spherePos;
     _GXColor color;
-    _GXColor debugColor;
     int tex;
 
     if (dataValIndex == 0xFFFF) {
@@ -504,7 +486,18 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     GXTexCoord2f32(FLOAT_8033342c, work->m_length);
 
     if (step->m_stepValue != 0xFFFF) {
+        u32 count;
+        u32 i;
+        u32 colorBase;
+        u8 alphaStep;
+        u8 alphaMax;
+        float uvStep;
+        Vec* points;
+        pppFMATRIX shapeMtx;
+        Mtx tempMtx;
         long** shapeTable = *(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)step->m_stepValue * 4);
+        Vec shapePos;
+
         PSMTXIdentity(shapeMtx.value);
         shapeMtx.value[0][0] = *(float*)(step->m_payload + 0x30) * pppMngStPtr->m_scale.x;
         shapeMtx.value[1][1] = *(float*)(step->m_payload + 0x30) * pppMngStPtr->m_scale.y;
@@ -540,6 +533,12 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
 
         GXBegin(GX_TRIANGLES, GX_VTXFMT7, (u16)((step->m_payload[0x1e] - 1) * 3));
         for (i = 0; (int)i < (int)(step->m_payload[0x1e] - 1); i++) {
+            u32 color0;
+            u32 color1;
+            u8 alpha0;
+            float u0;
+            float u1;
+
             alpha0 = (u8)(alphaMax - (u8)(alphaStep * i));
             color0 = colorBase | alpha0;
             color1 = colorBase | (u8)(alphaMax - (u8)(alphaStep * (i + 1)));
@@ -560,6 +559,10 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
         }
 
         if ((CFlatFlags & 0x200000) != 0) {
+            _GXColor debugColor;
+            Mtx sphereMtx;
+            Vec spherePos;
+
             SetVtxFmt_POS_CLR__5CUtilFv(&gUtil);
             _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
             _GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -360,34 +360,16 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtrlTable* data)
 {
 	pppYmLaserStep* ctrl = (pppYmLaserStep*)step;
-	Vec* points;
 	int colorOffset = data->m_serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	pppYmLaserWork* work = (pppYmLaserWork*)((u8*)laser + 0x80 + data->m_serializedDataOffsets[2]);
-	u32 count;
-	u32 i;
-	u32 colorBase;
-	u32 color0;
-	u32 color1;
-	u8 alpha0;
-	u8 alphaStep;
-	u8 alphaMax;
 	float halfWidth;
 	float negHalfWidth;
 	float length;
-	float u0;
-	float u1;
-	float uvStep;
 	pppFMATRIX unitMtx;
 	pppFMATRIX modelView;
 	pppFMATRIX mtxOut;
-	pppFMATRIX shapeMtx;
-	Mtx tempMtx;
-	Mtx sphereMtx;
-	Vec shapePos;
-	Vec spherePos;
 	_GXColor color;
-	_GXColor debugColor;
 	int tex;
 
 	if (ctrl->m_dataValIndex == 0xFFFF) {
@@ -459,7 +441,18 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	GXTexCoord2f32(FLOAT_80330DC4, work->m_length);
 
 	if (ctrl->m_stepValue != 0xFFFF) {
+		u32 count;
+		u32 i;
+		u32 colorBase;
+		u8 alphaStep;
+		u8 alphaMax;
+		float uvStep;
+		Vec* points;
+		pppFMATRIX shapeMtx;
+		Mtx tempMtx;
 		long** shapeTable = *(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)ctrl->m_stepValue * 4);
+		Vec shapePos;
+
 		PSMTXIdentity(shapeMtx.value);
 		shapeMtx.value[0][0] = *(float*)(ctrl->m_payload + 0x30) * pppMngStPtr->m_scale.x;
 		shapeMtx.value[1][1] = *(float*)(ctrl->m_payload + 0x30) * pppMngStPtr->m_scale.y;
@@ -495,6 +488,12 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 
 		GXBegin(GX_TRIANGLES, GX_VTXFMT7, (u16)((ctrl->m_payload[0x1e] - 1) * 3));
 		for (i = 0; (int)i < (int)(ctrl->m_payload[0x1e] - 1); i++) {
+			u32 color0;
+			u32 color1;
+			u8 alpha0;
+			float u0;
+			float u1;
+
 			alpha0 = (u8)(alphaMax - (u8)(alphaStep * i));
 			color0 = colorBase | alpha0;
 			color1 = colorBase | (u8)(alphaMax - (u8)(alphaStep * (i + 1)));
@@ -515,6 +514,10 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 		}
 
 		if ((CFlatFlags & 0x200000) != 0) {
+			_GXColor debugColor;
+			Mtx sphereMtx;
+			Vec spherePos;
+
 			SetVtxFmt_POS_CLR__5CUtilFv(&gUtil);
 			_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
 			_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);


### PR DESCRIPTION
## Summary
- tighten local variable lifetimes in `pppRenderLaser`
- apply the same scope tightening to the parallel `pppRenderYmLaser` path
- keep behavior unchanged while giving MWCC more room to reuse stack slots in both renderers

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppRenderLaser`
  - `pppRenderLaser`: `80.86968%` -> `81.07846%`
  - `main/pppLaser` `.text`: `88.33656%` -> `88.46328%`
- `build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppRenderYmLaser`
  - `pppRenderYmLaser`: `80.301865%` -> `80.6742%`

## Why this is plausible
- the changes only narrow scopes for temporaries that are already semantically local to the shape, triangle, and debug-draw blocks
- no fake linkage, section forcing, or hardcoded addresses were introduced
- the two laser renderers already share the same structure, so applying the same lifetime cleanup to both keeps the source coherent