### PR TITLE
Improve p_game RTTI name-string layout

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -11,6 +11,8 @@ extern "C" void draw1__8CGamePcsFv(CGamePcs*);
 extern "C" void draw2__8CGamePcsFv(CGamePcs*);
 
 extern const char s_CGamePcs_801D7C20[] = "CGamePcs";
+extern const char s_CManager_801D7C2C[] = "CManager";
+extern const char s_CProcess_801D7C38[] = "CProcess";
 
 unsigned int m_table__8CGamePcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CGamePcs_801D7C20)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x13, 0, 0, 0, 0, 0x17, 0, 0, 0,


### PR DESCRIPTION
## Summary
- define the `CManager` and `CProcess` RTTI class-name strings explicitly in `p_game.cpp`
- keep the existing `CGamePcs` table/vtable layout intact while anchoring the missing adjacent name data in source

## Evidence
- `ninja`
- `main/p_game` data match improved from `288/860` (`33.49%`) to `328/860` (`38.14%`)
- total matched data improved from `1124238` to `1124278` (`+40` bytes)

## Why this is plausible
- sibling process units already carry explicit class-name string definitions next to their table/vtable data
- this improves the RTTI/name-string cluster without compiler coaxing, fake symbols, or section hacks