### PR TITLE
Fix pppPObjPoint create program index signedness

### DIFF
--- a/include/ffcc/pppPObjPoint.h
+++ b/include/ffcc/pppPObjPoint.h
@@ -8,7 +8,7 @@ struct _pppCtrlTable;
 
 struct pppPObjPointStep {
     s32 m_graphId;              // 0x0
-    u32 m_createProgramIndex;   // 0x4
+    s32 m_createProgramIndex;   // 0x4
     u8* m_sourceObject;         // 0x8
     u32 m_objectId;             // 0xc
 };


### PR DESCRIPTION
## Summary
- change `pppPObjPointStep::m_createProgramIndex` from `u32` to `s32`
- preserve the existing `-1` sentinel behavior used by `pppPObjPoint`
- keep the source clean while improving the unit match through a plausible ABI/type fix

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o /tmp/pppPObjPoint_diff.json pppPObjPoint`
- A/B result while validating this change:
  - unsigned field: `91.62162%`
  - signed field: `96.21622%`

## Why this is plausible
- the code compares `m_createProgramIndex` against `-1` as a sentinel
- representing that field as signed matches the surrounding control flow and yields better target code without compiler-forcing hacks