### PR TITLE
Match pppYmChangeTex local sdata2 layout

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -91,6 +91,7 @@ extern const float FLOAT_80330df8;
 extern const float FLOAT_80330dfc;
 extern const float FLOAT_80330e00;
 extern const double DOUBLE_80330E08;
+static const double sPppYmChangeTexDouble = 4503601774854144.0;
 extern const float DAT_80330e10[2] = {0.0f, 0.0f};
 
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_data) == 0xA4);


### PR DESCRIPTION
## Summary
- add the missing local 8-byte conversion constant in `pppYmChangeTex.cpp`
- keep the unit ownership/layout aligned with the target `.sdata2` block
- bring `main/pppYmChangeTex` to a full code/data/function match

## Evidence
- before: `main/pppYmChangeTex` was reported at `96.9%` code, `60.53%` data, with `2/6` functions matched
- after: `build/GCCP01/report.json` reports `100.0%` code, `100.0%` data, and `6/6` functions matched for `main/pppYmChangeTex`
- symbol checks: `pppRenderYmChangeTex`, `pppFrameYmChangeTex`, `pppDestructYmChangeTex`, `pppConstructYmChangeTex`, `ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`, and `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f` all diff at `100.0%`

## Plausibility
- this is a data-ownership fix, not compiler coaxing: the file was already owning the surrounding `.sdata2` constants, and adding the missing local double restores the original constant layout for the unit

## Build
- `ninja` links successfully through `build/GCCP01/main.dol`; the final checksum step still fails because the full game image is not matched yet