### PR TITLE
Restore p_graphic drawBar projection state

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -764,6 +764,9 @@ void CGraphicPcs::drawBar()
             y += 8;
         }
     }
+
+    PSMTX44Copy(CameraPcs.m_screenMatrix, ortho);
+    GXSetProjection(ortho, GX_PERSPECTIVE);
 }
 
 /*


### PR DESCRIPTION
## Summary
- restore the original projection reset at the end of `CGraphicPcs::drawBar()`
- keep the fix isolated to the `p_graphic` unit

## Evidence
- `drawBar__11CGraphicPcsFv`: `53.604553%` -> `53.990044%`
- `main/p_graphic` `.text`: `59.554287%` -> `59.660896%`

## Why this is plausible
- Ghidra for `drawBar__11CGraphicPcsFv` shows the function restoring `CameraPcs.m_screenMatrix` with `PSMTX44Copy` and then calling `GXSetProjection(..., GX_PERSPECTIVE)` before returning.
- The current source was missing that tail entirely, so this is a source-correct state restore rather than compiler coaxing.

## Verification
- `ninja build/GCCP01/src/p_graphic.o`
- full `ninja` still stops at the repo checksum check for `build/GCCP01/main.dol`, but `p_graphic.o` rebuilds successfully and objdiff reflects the improvement.