### PR TITLE
Improve FunnyShape render stack layout matching

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -415,11 +415,12 @@ void CFunnyShape::Render()
     work = m_anmWork;
 
     for (s32 i = 0; i < count; i++) {
+        Vec2d posCopy;
         Vec2d pos;
-        pos.x = FLOAT_8032fd9c;
-        pos.y = FLOAT_8032fda0;
-        pos.x += work->x;
-        pos.y += work->y;
+        posCopy.x = FLOAT_8032fd9c + work->x;
+        posCopy.y = FLOAT_8032fda0 + work->y;
+        pos.x = posCopy.x;
+        pos.y = posCopy.y;
 
         u8* animData = reinterpret_cast<u8*>(AnimData(this));
         s16 frame = work->frame;


### PR DESCRIPTION
## Summary
- tighten `CFunnyShape::Render()` stack temporaries to mirror the original two-stage `Vec2d` setup
- keep behavior unchanged while improving the call-site layout for `RenderShape`

## Evidence
- `Render__11CFunnyShapeFv`: `96.17098%` -> `97.487045%`
- `main/FunnyShape` `.text`: `76.09216%` -> `76.24416%`
- `RenderTexture__11CFunnyShapeFv` remains `97.7957%`
- `RenderShape__11CFunnyShapeFv` remains `99.97419%`

## Verification
- `ninja` recompiles `build/GCCP01/src/FunnyShape.o`, then stops at the existing top-level checksum check: `build/GCCP01/main.dol: FAILED`
- `build/tools/objdiff-cli diff -p . -u main/FunnyShape`

## Plausibility
- the change only restores the original temporary-copy shape around the per-particle screen position
- no hacks, symbol forcing, or ABI workarounds were introduced
