### PR TITLE
Improve FunnyShape render position temp layout

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -415,11 +415,12 @@ void CFunnyShape::Render()
     work = m_anmWork;
 
     for (s32 i = 0; i < count; i++) {
+        Vec2d posCopy;
         Vec2d pos;
-        pos.x = FLOAT_8032fd9c;
-        pos.y = FLOAT_8032fda0;
-        pos.x += work->x;
-        pos.y += work->y;
+        posCopy.x = FLOAT_8032fd9c;
+        posCopy.y = FLOAT_8032fda0;
+        pos.x = posCopy.x + work->x;
+        pos.y = posCopy.y + work->y;
 
         u8* animData = reinterpret_cast<u8*>(AnimData(this));
         s16 frame = work->frame;


### PR DESCRIPTION
## Summary
- reshape the local `Vec2d` temporaries in `CFunnyShape::Render()` to match the compiler's stack usage more closely
- keep the logic identical while separating the base viewport offset from the final per-work-item position

## Evidence
- `Render__11CFunnyShapeFv`: 96.17098% -> 97.487045%
- diffing command: `build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - Render__11CFunnyShapeFv`

## Why this is plausible
- this uses ordinary source-level temporaries rather than compiler-coaxing hacks
- the change matches the observed stack/local flow in the target assembly for the render loop