### PR TITLE
Improve LocationTitle2 model handle setup

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -235,27 +235,23 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     }
 
     if (work->m_particles == 0) {
+        CGObject* owner;
+        CCharaPcs::CHandle* handle;
         work->m_particles = pppMemAlloc__FUlPQ27CMemory6CStagePci(
             unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp,
             0x70);
         memset(work->m_particles, 0, unkB->m_maxCount * sizeof(LocationTitle2Particle));
         LocationTitle2Particle* particles = (LocationTitle2Particle*)work->m_particles;
+        CChara::CModel* model;
 
-        CChara::CModel* model = 0;
-        {
-            CGObject* owner = ((pppMngStLocationTitle2Raw*)pppMngStPtr)->m_charaObj;
-            CCharaPcs::CHandle* handle = 0;
-            CCharaPcs::CHandle* ownerHandle = owner->m_charaModelHandle;
-            if (ownerHandle != 0) {
-                handle = ownerHandle;
-            }
-
-            {
-                CChara::CModel* handleModel = handle->m_model;
-                if (handleModel != 0) {
-                    model = handleModel;
-                }
-            }
+        owner = (CGObject*)pppMngStPtr->m_owner;
+        handle = 0;
+        if (owner->m_charaModelHandle != 0) {
+            handle = owner->m_charaModelHandle;
+        }
+        model = 0;
+        if (handle != 0) {
+            model = handle->m_model;
         }
 
         LocationTitle2ModelRaw* modelRaw = (LocationTitle2ModelRaw*)model;


### PR DESCRIPTION
## Summary
- simplify `pppFrameLocationTitle2` model lookup to load the owner handle first, then read the model from that handle
- keep the resulting control flow closer to the original handle/model setup without introducing new linkage hacks

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/LocationTitle2 -o - pppRenderLocationTitle2`
  - before: `93.0%`
  - after: `99.832535%`
- `build/tools/objdiff-cli diff -p . -u main/LocationTitle2 -o - pppFrameLocationTitle2`
  - before: `96.01974%`
  - after: `96.01974%`

## Plausibility
- this change only restructures the existing owner/model-handle access path in `LocationTitle2.cpp`
- it replaces a nested temporary setup with the same two-step handle-to-model flow the game commonly uses elsewhere, improving codegen without compiler-coaxing hacks

## Build
- `ninja -j4 build/GCCP01/src/LocationTitle2.o`
- full `ninja -j4` still stops at the expected `build.sha1` checksum check for the non-matching DOL, but the target object rebuilt successfully