### PR TITLE
Fix pppPObjPoint create-program index type

### DIFF
--- a/include/ffcc/pppPObjPoint.h
+++ b/include/ffcc/pppPObjPoint.h
@@ -8,7 +8,7 @@ struct _pppCtrlTable;
 
 struct pppPObjPointStep {
     s32 m_graphId;              // 0x0
-    s32 m_createProgramIndex;   // 0x4
+    u32 m_createProgramIndex;   // 0x4
     u8* m_sourceObject;         // 0x8
     u32 m_objectId;             // 0xc
 };


### PR DESCRIPTION
## Summary
- change `pppPObjPointStep::m_createProgramIndex` back to `u32`
- preserve the `0xFFFFFFFF` sentinel semantics used by `pppPObjPoint`
- avoid treating the create-program slot as a signed value in the public step layout

## Evidence
- fresh `build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o - pppPObjPoint` improved the symbol from `91.62162%` to `96.21622%`
- the target/compiled size relationship moved back to the unsigned-sentinel code shape expected by the target
- rebuilt `build/GCCP01/src/pppPObjPoint.o` successfully after the header change

## Why this is plausible source
- this field is used as an index with `0xFFFFFFFF` as the disabled sentinel, which is naturally an unsigned slot id
- the change corrects the ABI-relevant step definition instead of adding compiler-coaxing logic inside the function body
