### PR TITLE
Improve pppEmission constant pool layout

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -32,8 +32,6 @@ extern const float FLOAT_803311e4;
 extern const float FLOAT_803311f8;
 extern const float FLOAT_8033111C = 15.0f;
 extern const float FLOAT_80331120 = 7.0f;
-extern const double DOUBLE_803311e8 = 4503599627370496.0;
-extern const double DOUBLE_803311f0 = 4503601774854144.0;
 static const char s_pppEmission_cpp_801db7e8[] = "pppEmission.cpp";
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }


### PR DESCRIPTION
## Summary
- remove two unused global double bias constants from `src/pppEmission.cpp`
- let `pppEmission.o` use only the anonymous conversion constants actually referenced by the compiled code
- keep the change constrained to the `main/pppEmission` data mismatch

## Evidence
- `ninja build/GCCP01/src/pppEmission.o`
- before: `.sdata2` match `65.625%`
- after: `.sdata2` match `70.83333%`
- the object no longer emits duplicate `DOUBLE_803311e8` / `DOUBLE_803311f0` globals alongside anonymous `@222` / `@223` constants

## Plausibility
This removes redundant constant definitions rather than adding compiler-coaxing code. The emitted object moves closer to the original constant pool layout while leaving behavior unchanged.