### PR TITLE
Improve pppFrameYmBreath object-pointer usage

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -627,7 +627,7 @@ group_ready:
             scaleMtx[1][1] = scaledOwner;
             scaleMtx[2][2] = scaledOwner;
             particleMtx = (Mtx*)((unsigned char*)particleWMat + firstParticle * 0x30);
-            PSMTXConcat(*particleMtx, object->m_localMatrix.value, worldMtx);
+            PSMTXConcat(*particleMtx, ymBreath->m_localMatrix.value, worldMtx);
             PSMTXMultVec(worldMtx, (Vec*)(groupTable + 0xC), &origin);
             pppCopyMatrix(rotMtx, *reinterpret_cast<pppFMATRIX*>(particleMtx));
             rotMtx.value[0][3] = FLOAT_80330c80;

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -526,6 +526,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
         return;
     }
 
+    _pppPObject* object = reinterpret_cast<_pppPObject*>(ymBreath);
     dataOffsets = offsets->m_serializedDataOffsets;
     _pppMngSt* mngSt = pppMngStPtr;
     colorOffset = dataOffsets[1];
@@ -595,7 +596,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     }
 
     PSMTXCopy(pppMngStPtr->m_matrix.value, work->m_matrix);
-    UpdateAllParticle(reinterpret_cast<_pppPObject*>(ymBreath), work, pYmBreath, color);
+    UpdateAllParticle(object, work, pYmBreath, color);
 
     particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
     for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
@@ -626,7 +627,7 @@ group_ready:
             scaleMtx[1][1] = scaledOwner;
             scaleMtx[2][2] = scaledOwner;
             particleMtx = (Mtx*)((unsigned char*)particleWMat + firstParticle * 0x30);
-            PSMTXConcat(*particleMtx, ymBreath->m_localMatrix.value, worldMtx);
+            PSMTXConcat(*particleMtx, object->m_localMatrix.value, worldMtx);
             PSMTXMultVec(worldMtx, (Vec*)(groupTable + 0xC), &origin);
             pppCopyMatrix(rotMtx, *reinterpret_cast<pppFMATRIX*>(particleMtx));
             rotMtx.value[0][3] = FLOAT_80330c80;


### PR DESCRIPTION
## Summary
- introduce a local `_pppPObject*` in `pppFrameYmBreath`
- use that local when calling `UpdateAllParticle`
- keep the direct `ymBreath->m_localMatrix` access, which scored better than routing matrix access through the local object

## Evidence
- `pppFrameYmBreath`: `94.22152%` -> `94.56962%`
- `pppRenderYmBreath`: unchanged at `98.09907%`
- rebuilt with `ninja build/GCCP01/src/pppYmBreath.o`

## Plausibility
This keeps the source-level change minimal and compiler-driven: the function now names the object base once and reuses it at the helper call site, without introducing offset hacks or ABI workarounds.
