### PR TITLE
Improve maphit face bounds constant matching

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -6,6 +6,9 @@
 
 #include <math.h>
 
+extern "C" const float FLOAT_8032F8EC;
+extern "C" const float FLOAT_8032F8F0;
+
 CMapCylinder g_hit_cyl;
 CMapCylinder g_hit_cyl_min;
 Vec g_hit_mvec;
@@ -949,11 +952,11 @@ void CMapHit::DrawNormal()
  */
 CMapHitFace::CMapHitFace()
 {
-    m_boundsMin.z = 0.0f;
-    m_boundsMin.y = 0.0f;
-    m_boundsMin.x = 0.0f;
+    m_boundsMin.z = FLOAT_8032F8EC;
+    m_boundsMin.y = FLOAT_8032F8EC;
+    m_boundsMin.x = FLOAT_8032F8EC;
 
-    m_boundsMax.z = 1.0f;
-    m_boundsMax.y = 1.0f;
-    m_boundsMax.x = 1.0f;
+    m_boundsMax.z = FLOAT_8032F8F0;
+    m_boundsMax.y = FLOAT_8032F8F0;
+    m_boundsMax.x = FLOAT_8032F8F0;
 }


### PR DESCRIPTION
## Summary
- switch `CMapHitFace::CMapHitFace()` to use the named map hit bounds constants instead of float literals
- keep the constructor aligned with the unit's existing constant pool and symbol usage

## Evidence
- `__ct__11CMapHitFaceFv`: `98.888885%` -> `100.0%`
- `main/maphit` `.text`: `44.609737%` -> `44.61354%`

## Plausibility
- the constructor is still just initializing default bounds
- using the named constants is consistent with the original binary's constant references rather than compiler coaxing

## Build
- `ninja build/GCCP01/src/maphit.o` succeeds
- full `ninja` still stops at the existing `config/GCCP01/build.sha1` checksum gate (`build/GCCP01/main.dol: FAILED`), but the modified object rebuilds and diffs correctly