### PR TITLE
pppYmBreath: declare missing DOUBLE_80330c88 reference

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -23,6 +23,7 @@ extern "C" void pppNormalize__FR3Vec3Vec(float*, Vec*);
 extern "C" {
 extern const float FLOAT_80330c80;
 extern const float FLOAT_80330c84;
+extern const double DOUBLE_80330c88;
 extern const float FLOAT_80330C90;
 extern const float FLOAT_80330C94;
 extern const float FLOAT_80330C98 = 180.0f;


### PR DESCRIPTION
## Summary
- declare the missing `DOUBLE_80330c88` external in `src/pppYmBreath.cpp`
- keep the unit's owned `.sdata2` constants intact while restoring the intended double-conversion reference used by particle update logic

## Evidence
- `main/pppYmBreath` fuzzy match improved from `97.7401` on `main` to `97.78899` on this branch
- `UpdateParticle__FP9VYmBreathP9PYmBreathP13PARTICLE_DATAP6VColorP14PARTICLE_COLOR` improved from `98.23529` to `98.28054`
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR` improved from `98.23038` to `98.36962`

## Plausibility
- this is a source-level declaration fix, not compiler coaxing
- the file already referenced the surrounding shared `.sdata2` constants; this change restores the missing bias constant used by the original integer-to-double conversion path

## Build
- `ninja build/GCCP01/src/pppYmBreath.o`
- full `ninja` still stops at the project checksum check (`build/GCCP01/main.dol: FAILED`), which is expected for a non-matching decomp state
