### PR TITLE
Correct CGItemObj inheritance and layout

### DIFF
--- a/include/ffcc/itemobj.h
+++ b/include/ffcc/itemobj.h
@@ -2,16 +2,18 @@
 #define _FFCC_ITEMOBJ_H_
 
 #include "ffcc/cflat_runtime.h"
+#include "ffcc/prgobj.h"
+
+#include <dolphin/types.h>
 
 class CGObject;
 class CGPartyObj;
-class CGPrgObj;
 class CFlatRuntime;
 class CFont;
 struct Vec;
 class PPPIFPARAM;
 
-class CGItemObj
+class CGItemObj : public CGPrgObj
 {
 public:
 	struct CCFS
@@ -42,6 +44,21 @@ public:
 	static void DeleteAllFieldItem();
 	static void DispAllFieldItem(int);
 	int GetCID();
+
+	CGObject* m_owner;             // 0x550
+	int m_carryFrame;              // 0x554
+	int m_scriptArg;               // 0x558
+	int m_particleSlot;            // 0x55C
+	u16 m_createFlags;             // 0x560
+	u16 unk_0x562;                 // 0x562
+	void* m_pendingModelHandle;    // 0x564
+	float m_savedBodyRadius;       // 0x568
+	int m_itemJumpCountdown;       // 0x56C
+	int m_memoryCapsuleNameIndex;  // 0x570
+	u32 m_pendingAnimFlags;        // 0x574
+	char* m_pendingAnimName;       // 0x578
 };
+
+typedef int CGItemObj_size_mismatch[(sizeof(CGItemObj) == 0x57C) ? 1 : -1];
 
 #endif // _FFCC_ITEMOBJ_H_

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -76,23 +76,25 @@ static inline unsigned int Swap32(unsigned int x)
  */
 int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 {
-    unsigned int count;
     unsigned int* ptr;
-    unsigned int* alloc;
     int connected;
     unsigned int* dstBuffer;
+    unsigned int value;
     CMemory::CStage* stage;
     int result;
+    unsigned int count;
 
-    count = (unsigned int)(elemSize * elemCount);
-    unsigned int value = (count + 0x5F) & ~0x1F;
-    stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
+    count = elemSize * elemCount;
+    value = (count + 0x5F) & ~0x1F;
+    stage = m_bigStage;
+    if (stage == (CMemory::CStage*)nullptr) {
+        stage = m_smallStage;
+    }
 
-    ptr = alloc = (unsigned int*)__nwa__FUlPQ27CMemory6CStagePci(
+    ptr = (unsigned int*)__nwa__FUlPQ27CMemory6CStagePci(
         value, stage, const_cast<char*>(s_p_usb_cpp_801D6D08), 0x1ca);
-    unsigned int type = 4;
-    alloc[1] = value;
-    ptr[0] = type;
+    ptr[1] = value;
+    ptr[0] = 4;
     ptr[9] = Swap32((unsigned int)code);
     ptr[10] = Swap32((unsigned int)elemCount);
     ptr[12] = Swap32(count);
@@ -104,7 +106,10 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     if (connected == 0) {
         result = 0;
     } else {
-        stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
+        stage = m_bigStage;
+        if (stage == (CMemory::CStage*)nullptr) {
+            stage = m_smallStage;
+        }
 
         dstBuffer = (unsigned int*)__nwa__FUlPQ27CMemory6CStagePci(
             (ptr[1] + 0x1F) & ~0x1F, stage, const_cast<char*>(s_p_usb_cpp_801D6D08), 0x19e);


### PR DESCRIPTION
## Summary
- correct `CGItemObj` to inherit from `CGPrgObj`
- add the missing `CGItemObj` tail layout fields through `0x578`
- keep the size check consistent with the `CFlatRuntime2` item-object array constructor (`0x57C` stride)

## Evidence
- `main/itemobj` `.data` match improved from `0.0%` to `15.264841%`
- `main/itemobj` `.text` stayed at `71.90299%`
- `__vt__9CGItemObj` now matches at `43.446087%`

## Why this is plausible source
- `src/cflat_runtime2.cpp` already constructs `CGItemObj` instances with the `CGPrgObj` constructor chain and a `0x57C` element size
- the previous header declared `CGItemObj` as a standalone class with no base and no trailing fields, which did not reflect the object layout used by the runtime
- this change fixes the declaration and data layout instead of using codegen hacks
