### PR TITLE
Improve CGPartyObj::onDestroy match

### DIFF
--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -296,10 +296,10 @@ void CGPartyObj::onCreate()
  */
 void CGPartyObj::onDestroy()
 {
-	unsigned char* partyFlags = &PartyData(this).partyFlags;
-	if ((*partyFlags & 0x04) != 0) {
+	unsigned char* self = reinterpret_cast<unsigned char*>(this);
+	if ((int)(((unsigned int)self[0x6B8] << 0x1D) | ((unsigned int)self[0x6B8] >> 3)) < 0) {
 		addHp(*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(m_scriptHandle) + 0x1A), static_cast<CGPrgObj*>(0));
-		*partyFlags &= ~0x04;
+		self[0x6B8] = self[0x6B8] & 0xFB;
 	}
 
 	CGCharaObj::onDestroy();


### PR DESCRIPTION
Summary:
- rewrite CGPartyObj::onDestroy to use the raw party flag byte at 0x6B8
- keep the HP refund and flag clear in the same byte-oriented form shown by the target

Evidence:
- onDestroy__10CGPartyObjFv fuzzy match improved from 83.2% to 86.2% in objdiff
- rebuilt build/GCCP01/src/partyobj.o after the change

Why this is plausible source:
- the new code removes an overlay helper access and matches the target's direct byte test/clear on the underlying object state
- behavior is unchanged: it still refunds HP when the carry/restore bit is set and then clears that bit before chaining to CGCharaObj::onDestroy