### PR TITLE
Improve CUSBPcs static initialization

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -21,7 +21,7 @@ class CUSBPcs : public CSamplePcs
 public:
     class CDataHeader;
 
-    CUSBPcs();
+    CUSBPcs() {}
 
     void Init();
     void Quit();

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -6,6 +6,9 @@
 #include "string.h"
 #include "types.h"
 
+extern "C" void* __vt__8CManager[];
+extern "C" void* __vt__10CSamplePcs[];
+extern "C" void* __vt__7CUSBPcs[];
 int s_usbReadPollFrameCounter;
 char s_usbReadPollInitialized;
 extern "C" void create__7CUSBPcsFv(CUSBPcs*);
@@ -36,29 +39,6 @@ static unsigned int s_CUSBPcsTablePad1[5] = {0, 0, 0, 0, 0};
 extern const char s_p_usb_cpp_801D6D08[] = "p_usb.cpp";
 extern const char s_usbRootPath[16] = "plot/kmitsuru/";
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(u32 size, CMemory::CStage* stage, char* file, int line);
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-inline CUSBPcs::CUSBPcs()
-{
-    unsigned int* table = reinterpret_cast<unsigned int*>(&m_table__7CUSBPcs);
-    const unsigned int* desc0 = m_table_desc0__7CUSBPcs;
-    const unsigned int* desc1 = m_table_desc1__7CUSBPcs;
-    const unsigned int* desc2 = m_table_desc2__7CUSBPcs;
-
-    table[1] = desc0[0];
-    table[2] = desc0[1];
-    table[3] = desc0[2];
-    table[4] = desc1[0];
-    table[5] = desc1[1];
-    table[6] = desc1[2];
-    table[7] = desc2[0];
-    table[8] = desc2[1];
-    table[9] = desc2[2];
-}
 
 static inline unsigned int Swap32(unsigned int x)
 {
@@ -292,6 +272,38 @@ void CUSBPcs::Init()
 	m_unk0x108 = 0;
 
 	USB.Connect();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800203e4
+ * PAL Size: 176b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_usb_cpp(void)
+{
+    unsigned char* self = reinterpret_cast<unsigned char*>(&USBPcs);
+    unsigned int* dst = reinterpret_cast<unsigned int*>(&m_table__7CUSBPcs);
+    unsigned int* desc0 = m_table_desc0__7CUSBPcs;
+    unsigned int* desc1 = m_table_desc1__7CUSBPcs;
+    unsigned int* desc2 = m_table_desc2__7CUSBPcs;
+
+    *reinterpret_cast<void**>(self) = __vt__8CManager;
+    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
+    *reinterpret_cast<void**>(self) = __vt__7CUSBPcs;
+
+    dst[1] = desc0[0];
+    dst[2] = desc0[1];
+    dst[3] = desc0[2];
+    dst[4] = desc1[0];
+    dst[5] = desc1[1];
+    dst[6] = desc1[2];
+    dst[7] = desc2[0];
+    dst[8] = desc2[1];
+    dst[9] = desc2[2];
 }
 
 CUSBPcs USBPcs;


### PR DESCRIPTION
## Summary
- improve `CUSBPcs` static initialization in `p_usb`
- move the table/vtable setup into `__sinit_p_usb_cpp` and leave the class constructor empty
- keep the generated init flow closer to compiler-emitted static object setup instead of hand-populating state inside the constructor

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o - __sinit_p_usb_cpp`
- before: `66.86364%`
- after: `70.38636%`

## Why this is plausible source
- the original game likely relied on normal static object initialization for `USBPcs`
- the change shifts initialization work out of the inline constructor and into the translation unit static initializer, which better matches compiler-generated C++ startup behavior
