### PR TITLE
Restore CUSBPcs direct CProcess base

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -2,7 +2,7 @@
 #define _FFCC_P_USB_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/p_sample.h"
+#include "ffcc/system.h"
 #include "ffcc/usb.h"
 
 struct CUSBPcsTable
@@ -16,7 +16,7 @@ extern unsigned int m_table_desc1__7CUSBPcs[];
 extern unsigned int m_table_desc2__7CUSBPcs[];
 extern CUSBPcsTable m_table__7CUSBPcs;
 
-class CUSBPcs : public CSamplePcs
+class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;


### PR DESCRIPTION
## Summary
- restore `CUSBPcs` to inherit directly from `CProcess`
- swap the `p_usb` header include from `p_sample.h` to `system.h` to match that ownership
- keep the change scoped to the real layout issue driving `p_usb` static init codegen

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o - __sinit_p_usb_cpp`
- `__sinit_p_usb_cpp`: `66.86364%` -> `67.681816%`

## Why this is plausible
- `CUSBPcs` behaves like its own process node rather than a `CSamplePcs` specialization
- restoring the direct `CProcess` base improves the generated static initialization path without introducing manual ctor/dtor/sinit hacks
