### PR TITLE
Improve pppFrameConformBGNormal matching

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -198,9 +198,9 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                 PSVECCrossProduct(&local_158, &local_140, &local_14c);
                 PSVECNormalize(&local_14c, &local_14c);
             } else {
+                local_140.x = kPppConformBgNormalOne;
                 local_140.y = kPppConformBgNormalZero;
                 local_140.z = kPppConformBgNormalZero;
-                local_140.x = kPppConformBgNormalOne;
                 PSVECCrossProduct(&local_158, &local_140, &local_14c);
                 PSVECNormalize(&local_14c, &local_14c);
                 PSVECCrossProduct(&local_14c, &local_158, &local_140);
@@ -228,8 +228,7 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     pppMngStPtr->m_matrix.value[0][3] = owner->m_worldPosition.x;
                     pppMngStPtr->m_matrix.value[1][3] = owner->m_worldPosition.y;
                     pppMngStPtr->m_matrix.value[2][3] = owner->m_worldPosition.z;
-                } else if (((WeaponNodeFlagBits*)&owner->m_weaponNodeFlags)->m_unk01 &&
-                    (owner->m_attachOwner != NULL)) {
+                } else if (((*(u8*)&owner->m_weaponNodeFlags & 1) != 0) && (owner->m_attachOwner != NULL)) {
                     ownerX = owner->m_worldPosition.x;
                     ownerY = owner->m_attachOwner->m_worldPosition.y;
                     ownerZ = owner->m_worldPosition.z;


### PR DESCRIPTION
## Summary
- reorder the fallback basis vector initialization to use the natural x/y/z source order
- replace the ad hoc weapon-node bitfield test with an explicit low-byte flag check
- keep the surrounding control flow and data layout unchanged

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/pppConformBGNormal -o - pppFrameConformBGNormal`
- before: `98.51031%`
- after: `98.72165%`

## Why this is plausible source
- the basis vector now uses straightforward component initialization instead of an unusual field order
- the weapon-node condition now matches existing low-byte flag usage patterns elsewhere in the repo rather than relying on a local bitfield overlay
- no compiler-coaxing hacks or artificial linkage changes were introduced

## Verification
- `ninja`