### PR TITLE
Improve prgobj target rotation helpers

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -228,14 +228,16 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	Vec targetPos;
 	Vec basePos;
 	Vec deltaPos;
-	CVector* baseVec;
+	Vec* baseVec;
 
 	__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&targetPos), target->m_worldPosition);
-	baseVec = __ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition);
+	baseVec = reinterpret_cast<Vec*>(__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition));
 	__ct__7CVectorFv(reinterpret_cast<CVector*>(&deltaPos));
-	PSVECSubtract(reinterpret_cast<Vec*>(baseVec), &targetPos, &deltaPos);
+	PSVECSubtract(baseVec, &targetPos, &deltaPos);
 	targetRot = FLOAT_80331BD4;
-	if (((double)FLOAT_80331BD4 != (double)deltaPos.x) && ((double)FLOAT_80331BD4 != (double)deltaPos.z)) {
+	if (((double)targetRot == (double)deltaPos.x) || ((double)targetRot == (double)deltaPos.z)) {
+		targetRot = FLOAT_80331BD4;
+	} else {
 		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 	}
 
@@ -257,14 +259,16 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 	Vec targetPos;
 	Vec basePos;
 	Vec deltaPos;
-	CVector* baseVec;
+	Vec* baseVec;
 
 	__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&targetPos), target->m_worldPosition);
-	baseVec = __ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition);
+	baseVec = reinterpret_cast<Vec*>(__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition));
 	__ct__7CVectorFv(reinterpret_cast<CVector*>(&deltaPos));
-	PSVECSubtract(reinterpret_cast<Vec*>(baseVec), &targetPos, &deltaPos);
+	PSVECSubtract(baseVec, &targetPos, &deltaPos);
 	targetRot = FLOAT_80331BD4;
-	if (((double)FLOAT_80331BD4 != (double)deltaPos.x) && ((double)FLOAT_80331BD4 != (double)deltaPos.z)) {
+	if (((double)targetRot == (double)deltaPos.x) || ((double)targetRot == (double)deltaPos.z)) {
+		targetRot = FLOAT_80331BD4;
+	} else {
 		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 	}
 	m_rotTargetY = targetRot;
@@ -285,18 +289,18 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	Vec basePos;
 	Vec targetPos;
 	Vec deltaPos;
-	CVector* baseVec;
+	Vec* baseVec;
 
 	__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&targetPos), target->m_worldPosition);
-	baseVec = __ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition);
+	baseVec = reinterpret_cast<Vec*>(__ct__7CVectorFRC3Vec(reinterpret_cast<CVector*>(&basePos), m_worldPosition));
 	__ct__7CVectorFv(reinterpret_cast<CVector*>(&deltaPos));
-	PSVECSubtract(reinterpret_cast<Vec*>(baseVec), &targetPos, &deltaPos);
+	PSVECSubtract(baseVec, &targetPos, &deltaPos);
 	targetRot = FLOAT_80331BD4;
-	if (((double)FLOAT_80331BD4 != (double)deltaPos.x) && ((double)FLOAT_80331BD4 != (double)deltaPos.z)) {
-		targetRot = (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
+	if (((double)targetRot == (double)deltaPos.x) || ((double)targetRot == (double)deltaPos.z)) {
+		return targetRot;
 	}
 
-	return targetRot;
+	return (float)atan2(-(double)deltaPos.x, -(double)deltaPos.z);
 }
 
 /*


### PR DESCRIPTION
## Summary
- rewrite the `CGPrgObj` target-rotation helpers to use the constructor return as a `Vec*` and share the explicit zero-angle fast path
- keep the three helpers behaviorally aligned while matching the original control-flow shape more closely

## Improved symbols
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: `83.05556%` -> `91.083336%`
- `rotTarget__8CGPrgObjFP8CGPrgObj`: `84.35897%` -> `91.76923%`
- `dstTargetRot__8CGPrgObjFP8CGPrgObj`: `86.02273%` -> `92.59091%`

## Verification
- `ninja -j4`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - getTargetRot__8CGPrgObjFP8CGPrgObj`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - rotTarget__8CGPrgObjFP8CGPrgObj`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o - dstTargetRot__8CGPrgObjFP8CGPrgObj`

## Plausibility
- the changes simplify the shared zero-angle path and make the vector subtraction helpers use the constructor return directly, which is closer to the surrounding game code style than output-chasing hacks