### PR TITLE
Improve CUSBPcs SendDataCode matching

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -56,18 +56,19 @@ static inline unsigned int Swap32(unsigned int x)
  */
 int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 {
+    unsigned int count;
     unsigned int* ptr;
     int connected;
     unsigned int* dstBuffer;
-    unsigned int value;
     CMemory::CStage* stage;
+    unsigned int value;
     int result;
-    unsigned int count;
 
     count = elemSize * elemCount;
     value = (count + 0x5F) & ~0x1F;
-    stage = m_bigStage;
-    if (stage == (CMemory::CStage*)nullptr) {
+    if (m_bigStage != (CMemory::CStage*)nullptr) {
+        stage = m_bigStage;
+    } else {
         stage = m_smallStage;
     }
 
@@ -86,8 +87,9 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     if (connected == 0) {
         result = 0;
     } else {
-        stage = m_bigStage;
-        if (stage == (CMemory::CStage*)nullptr) {
+        if (m_bigStage != (CMemory::CStage*)nullptr) {
+            stage = m_bigStage;
+        } else {
             stage = m_smallStage;
         }
 


### PR DESCRIPTION
## Summary
- Reshape the two `CUSBPcs::SendDataCode` stage selections into explicit `m_bigStage` / `m_smallStage` branches.
- Move `count` earlier in the local declaration order to match the target saved-register allocation more closely.

## Evidence
- `ninja` passes.
- `SendDataCode__7CUSBPcsFiPvii`: 95.330826% -> 96.61654%, size 524b -> 532b matching target size.
- `main/p_usb` `.text`: 94.1697% -> 94.68788%.
- `main/p_usb` `extabindex`: 99.07407% -> 100.0%.

## Plausibility
- The change keeps the same behavior and expresses the stage fallback as straightforward original-style control flow.
- No manual vtable, RTTI, section forcing, address constants, or fake symbols were added.
