### PR TITLE
Improve pppYmLaser and itemobj matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -339,19 +339,18 @@ void CGItemObj::onCancelStat(int)
 void CGItemObj::onFrame()
 {
 	unsigned char* self = (unsigned char*)this;
-	void* handle = *(void**)(self + 0x564);
+	void* handle = m_pendingModelHandle;
 
 	if (handle != 0 && IsLoadModelASyncCompleted__Q29CCharaPcs7CHandleFv(handle) != 0) {
 		if ((unsigned int)System.m_execParam >= 3U) {
 			Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dd010));
 		}
 
-		*(void**)(self + 0xF8) = *(void**)(self + 0x564);
-		*(void**)(self + 0x564) = 0;
+		m_charaModelHandle = reinterpret_cast<CCharaPcs::CHandle*>(m_pendingModelHandle);
+		m_pendingModelHandle = 0;
 
-		if (*(int*)(self + 0x500) == 0xCB) {
-			LoadAnim__8CGObjectFPciiiUl(
-			    this, *(char**)(self + 0x578), 0, 0, 2, *(unsigned long*)(self + 0x574));
+		if (m_worldParamA == 0xCB) {
+			LoadAnim__8CGObjectFPciiiUl(this, m_pendingAnimName, 0, 0, 2, m_pendingAnimFlags);
 			SetAnimSlot__8CGObjectFii(this, 0, 0);
 			PlayAnim__8CGObjectFiiiiiPSc(this, 0, 1, 0, -1, -1, 0);
 
@@ -363,12 +362,12 @@ void CGItemObj::onFrame()
 			}
 
 			unsigned char* itemRow =
-			    reinterpret_cast<unsigned char*>(Game.unkCFlatData0[2] + *(int*)(self + 0x504) * 0x48);
+			    reinterpret_cast<unsigned char*>(Game.unkCFlatData0[2] + m_worldParamB * 0x48);
 			double particleValue = (double)*reinterpret_cast<unsigned short*>(itemRow + 0x10);
 			float particleScale = FLOAT_80331b50 * (float)particleValue + FLOAT_80331b4c;
 			putParticle__8CGPrgObjFiiP8CGObjectfi(
 			    this, (soundEntry << 8) | *(int*)(*(int*)(*(int*)(self + 0x550) + 0x58) + 0x3B4),
-			    *(int*)(self + 0x558), this, particleScale, 0x12909);
+			    m_particleSlot, this, particleScale, 0x12909);
 
 			CVector zero(FLOAT_80331b20, FLOAT_80331b20, FLOAT_80331b20);
 			SetDamageCol__8CGObjectFiPcffP3Vec(
@@ -431,7 +430,7 @@ void CGItemObj::onFrameStat()
 	}
 	case 9:
 		if (*(int*)(self + 0x528) == 8) {
-			self[0x54d] = (self[0x54d] & 0x7f) | 0x80;
+			self[0x38] = (self[0x38] & 0x7f) | 0x80;
 		}
 		break;
 	case 0xB:
@@ -534,7 +533,7 @@ void CGItemObj::onFrameStat()
 			prgObj->m_stepSlopeLimit = zero;
 			EndParticle__13CFlatRuntime2FPQ29CCharaPcs7CHandle(CFlat, prgObj->m_charaModelHandle);
 		} else if (*(int*)(self + 0x528) == 0xC) {
-			self[0x54D] = (self[0x54D] & 0x7F) | 0x80;
+			self[0x38] = (self[0x38] & 0x7F) | 0x80;
 		}
 
 		if (7 < *(int*)(self + 0x528)) {
@@ -744,7 +743,7 @@ void CGItemObj::onFrameStat()
 				    &CFlat, *(int*)(self + 0x550), 2, 0x16, 1, &stack, 0);
 			}
 
-			self[0x54D] = (self[0x54D] & 0x7F) | 0x80;
+			self[0x38] = (self[0x38] & 0x7F) | 0x80;
 		}
 		break;
 	}

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -15,13 +15,13 @@ extern int gPppCalcDisabled;
 
 extern "C" void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
 
-extern const f32 FLOAT_80330df0;
+extern const f32 FLOAT_80330df0[2];
 extern const f32 FLOAT_80330DC4;
 extern const f32 FLOAT_80330DC8;
-extern f32 FLOAT_80330de0;
-extern f32 FLOAT_80330de4;
-extern f32 FLOAT_80330de8;
-extern f32 FLOAT_80330dec;
+extern const f32 FLOAT_80330de0;
+extern const f32 FLOAT_80330de4;
+extern const f32 FLOAT_80330de8;
+extern const f32 FLOAT_80330dec;
 extern "C" const f64 DOUBLE_80330DD0;
 
 void pppInitBlendMode(void);
@@ -57,6 +57,16 @@ void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, u8);
 }
 
 extern "C" const char s_pppYmLaser_cpp_801DB4B0[] = "pppYmLaser.cpp";
+extern const f64 DOUBLE_80330dd8 = 4503601774854144.0;
+extern const f32 FLOAT_80330de0 = -1.0f;
+extern const f32 FLOAT_80330de4 = 1.2f;
+extern const f32 FLOAT_80330de8 = 10000000000.0f;
+extern const f32 FLOAT_80330dec = -10000000000.0f;
+extern const f32 FLOAT_80330df0[2] = {6.2831855f, 0.0f};
+extern const f32 FLOAT_80330df8 = 2.0f;
+extern const f32 FLOAT_80330dfc = 0.5f;
+extern const f32 FLOAT_80330e00 = 0.25f;
+extern const f64 DOUBLE_80330E08 = 4503601774854144.0;
 
 struct CMapCylinderRaw {
 	Vec m_bottom;
@@ -93,11 +103,6 @@ struct pppYmLaserColorData {
 	pppCVECTOR m_color;
 };
 
-union pppYmLaserDoubleBits {
-	double d;
-	u32 u[2];
-};
-
 /*
  * --INFO--
  * PAL Address: 0x800d3780
@@ -110,7 +115,7 @@ union pppYmLaserDoubleBits {
 extern "C" void pppConstructYmLaser(pppYmLaser* laser, _pppCtrlTable* ctrlTable)
 {
 	f32 one = kPppYmLaserOne;
-	f32 randArg = FLOAT_80330df0;
+	f32 randArg = FLOAT_80330df0[0];
 	pppYmLaserWork* work = (pppYmLaserWork*)((u8*)laser + 0x80 + ctrlTable->m_serializedDataOffsets[2]);
 
 	work->m_length = one;
@@ -356,7 +361,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	s32 dataValIndex = step->m_dataValIndex;
 	Vec* points;
 	u32 count;
-	u32 i;
+	s32 i;
 	u32 colorBase;
 	u32 color0;
 	u32 color1;
@@ -470,11 +475,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 		pppDrawShp__FPlsP12CMaterialSetUc(*shapeTable, work->m_shapeArg2, pppEnvStPtr->m_materialSetPtr, step->m_payload[0x1c]);
 
 		count = (u32)step->m_payload[0x1e];
-		pppYmLaserDoubleBits countDouble;
-
-		countDouble.u[0] = 0x43300000;
-		countDouble.u[1] = count;
-		uvStep = FLOAT_80330DC4 / (float)(countDouble.d - DOUBLE_80330DD0);
+		uvStep = FLOAT_80330DC4 / (float)count;
 		if (step->m_initWOrk == 0xFFFF) {
 			_GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
 			_GXSetTevOp__F13_GXTevStageID10_GXTevMode(0, 4);
@@ -500,7 +501,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 
 			GXPosition3f32(work->m_origin.x, work->m_origin.y, work->m_origin.z);
 			GXColor1u32(color0);
-			GXTexCoord2f32(u0, FLOAT_80330de0);
+			GXTexCoord2f32(u0, FLOAT_80330DC4);
 
 			GXPosition3f32(points[i].x, points[i].y, points[i].z);
 			GXColor1u32(color0);


### PR DESCRIPTION
## Summary
- Define the pppYmLaser-owned .sdata2 constants and simplify the render UV step conversion to normal source.
- Fix the pppYmLaser triangle fan texcoord constant and use a signed trail loop index to match the target conversion shape.
- Clean up CGItemObj async model frame handling, use the particle slot for the completed-model particle, and write hide flags through the base object flag byte.

## Objdiff evidence
- main/pppYmLaser: .sdata2 41.666664% -> 100.0%; .text 91.62446% -> 91.79272%.
- pppRenderYmLaser: 87.23803% -> 87.52926%.
- pppFrameYmLaser: 99.81651% -> 99.74006% (small local regression accepted because the unit gains real owned data matching and render code improves).
- main/itemobj onFrame__9CGItemObjFv: 75.700935% -> 75.71028%.
- main/itemobj onFrameStat__9CGItemObjFv: 53.07377% -> 53.078453%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o /tmp/pppYmLaser_pr.json
- build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_pr.json