### PR TITLE
Improve pppMana2 constant loads

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -71,6 +71,11 @@ static inline Mtx44& CameraScreenMatrix()
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 
+static inline float LoadFloat(const float& value)
+{
+    return value;
+}
+
 extern "C" {
 void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
 int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
@@ -240,7 +245,7 @@ void pppConstructMana2(pppMana2* pppMana2, pppMana2UnkC* param_2)
     gObject = *(CGObject**)((char*)pppMngStPtr + 0xDC);
     workOffset = param_2->m_serializedDataOffsets[2];
     work = (u32*)((char*)pppMana2 + 0x80 + workOffset);
-    gObject->m_stepSlopeLimit = FLOAT_803318fc;
+    gObject->m_stepSlopeLimit = LoadFloat(FLOAT_803318fc);
 
     handle = GetCharaHandlePtr__FP8CGObjectl(gObject, 0);
     GetCharaModelPtr__FPQ29CCharaPcs7CHandle(handle);
@@ -948,7 +953,7 @@ void CalcReflectionVector2(
     Mtx cameraMtx;
     u16* dl = (u16*)displayList;
     u16* dlEnd;
-    const double half = (double)FLOAT_803318a4;
+    const double half = (double)LoadFloat(FLOAT_803318a4);
 
     cameraPos.x = CameraWorldX();
     cameraPos.y = CameraWorldY();
@@ -970,9 +975,9 @@ void CalcReflectionVector2(
     matrix[2][3] = worldPos.z;
 
     PSMTXCopy(matrix, nodeRotMtx);
-    nodeRotMtx[0][3] = FLOAT_80331898;
-    nodeRotMtx[1][3] = FLOAT_80331898;
-    nodeRotMtx[2][3] = FLOAT_80331898;
+    nodeRotMtx[0][3] = LoadFloat(FLOAT_80331898);
+    nodeRotMtx[1][3] = LoadFloat(FLOAT_80331898);
+    nodeRotMtx[2][3] = LoadFloat(FLOAT_80331898);
 
     PSMTXCopy(ppvCameraMatrix0, cameraMtx);
     PSMTXConcat(cameraMtx, matrix, cameraMtx);
@@ -1031,44 +1036,47 @@ void CalcReflectionVector2(
             uv.y = (float)half;
 
             if (axis == 1) {
-                invAxis = FLOAT_803318b8 * outVec->y;
-                if (outVec->y < FLOAT_80331898) {
+                invAxis = LoadFloat(FLOAT_803318b8) * outVec->y;
+                if (outVec->y < LoadFloat(FLOAT_80331898)) {
                     clr[1] = (u8)(clr[1] - 0x7F);
-                    uv.x = (float)((half - (double)(outVec->x / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318bc);
-                    uv.y = (float)((double)((float)(half + (double)(outVec->z / invAxis)) * FLOAT_803318bc) + half);
+                    uv.x = (float)((half - (double)(outVec->x / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318bc));
+                    uv.y =
+                        (float)((double)((float)(half + (double)(outVec->z / invAxis)) * LoadFloat(FLOAT_803318bc)) + half);
                 } else {
                     clr[1] = (u8)(clr[1] + 0x7F);
-                    uv.y = (float)((half + (double)(outVec->z / invAxis)) * (double)FLOAT_803318bc);
-                    uv.x = (float)((double)((float)(half + (double)(outVec->x / invAxis)) * FLOAT_803318bc) + half);
+                    uv.y = (float)((half + (double)(outVec->z / invAxis)) * (double)LoadFloat(FLOAT_803318bc));
+                    uv.x =
+                        (float)((double)((float)(half + (double)(outVec->x / invAxis)) * LoadFloat(FLOAT_803318bc)) + half);
                 }
             } else if (axis == 0) {
-                invAxis = FLOAT_803318b8 * outVec->x;
-                if (outVec->x < FLOAT_80331898) {
+                invAxis = LoadFloat(FLOAT_803318b8) * outVec->x;
+                if (outVec->x < LoadFloat(FLOAT_80331898)) {
                     clr[0] = (u8)(clr[0] - 0x7F);
-                    uv.x = (float)((half - (double)(outVec->z / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318c0);
-                    uv.y = (float)((half + (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318bc);
+                    uv.x = (float)((half - (double)(outVec->z / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318c0));
+                    uv.y = (float)((half + (double)(outVec->y / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318bc));
                 } else {
                     clr[0] = (u8)(clr[0] + 0x7F);
-                    uv.x = (float)((half - (double)(outVec->z / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318bc);
-                    uv.y = (float)((half - (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318bc);
+                    uv.x = (float)((half - (double)(outVec->z / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318bc));
+                    uv.y = (float)((half - (double)(outVec->y / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318bc));
                 }
             } else {
-                invAxis = FLOAT_803318b8 * outVec->z;
-                if (outVec->z < FLOAT_80331898) {
+                invAxis = LoadFloat(FLOAT_803318b8) * outVec->z;
+                if (outVec->z < LoadFloat(FLOAT_80331898)) {
                     clr[2] = (u8)(clr[2] - 0x7F);
-                    uv.x = (float)((double)((float)(half + (double)(outVec->x / invAxis)) * FLOAT_803318bc) + half);
-                    uv.y = (float)((half + (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318bc);
+                    uv.x =
+                        (float)((double)((float)(half + (double)(outVec->x / invAxis)) * LoadFloat(FLOAT_803318bc)) + half);
+                    uv.y = (float)((half + (double)(outVec->y / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318bc));
                 } else {
                     clr[2] = (u8)(clr[2] + 0x7F);
-                    uv.x = (float)((half + (double)(outVec->x / invAxis)) * (double)FLOAT_803318bc);
-                    uv.y = (float)((half - (double)(outVec->y / invAxis)) * (double)FLOAT_803318bc +
-                                   (double)FLOAT_803318bc);
+                    uv.x = (float)((half + (double)(outVec->x / invAxis)) * (double)LoadFloat(FLOAT_803318bc));
+                    uv.y = (float)((half - (double)(outVec->y / invAxis)) * (double)LoadFloat(FLOAT_803318bc) +
+                                   (double)LoadFloat(FLOAT_803318bc));
                 }
             }
 
@@ -1122,7 +1130,7 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
     normalY = FLOAT_803318a0;
     zero = FLOAT_80331898;
     rowCount = 0;
-    uvStep = FLOAT_803318A8;
+    uvStep = LoadFloat(FLOAT_803318A8);
     radius = param_5 * FLOAT_803318a4;
     for (z = radius; -radius <= z; z -= param_5 * uvStep) {
         colCount = 0;


### PR DESCRIPTION
## Summary
- Add the local LoadFloat helper pattern used by nearby PPP units to pppMana2.
- Use it for constants where objdiff shows the target loading named sdata2 symbols instead of anonymous literals.
- Improves CalcReflectionVector2, CreateWaterMesh, pppConstructMana2, and pppMana2 sdata2 symbol matching.

## Evidence
- Build: ninja passes, links, and build/GCCP01/main.dol reports OK.
- Progress report: Game data improved from 944394 to 944470 bytes matched (+76 bytes).
- objdiff main/pppMana2 before -> after:
  - .text: 83.15061% -> 83.34098%
  - CalcReflectionVector2__FP3VecP6S16VecP6S16VeclUlUlPA4_fPvUlP8_GXColorP8S16Vec2dPQ26CChara5CNode: 65.15406% -> 66.77591%
  - CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf: 67.55446% -> 67.60396%
  - pppConstructMana2: 99.3421% -> 99.4079%
  - [.sdata2-0]: 66.66667% -> 75.0%

## Plausibility
- This follows the same inline LoadFloat(const float&) source pattern already present in pppYmMana.cpp.
- The change avoids hard-coded addresses, fake labels, and section forcing; it steers MWCC toward named constant loads while preserving the existing source structure.