### PR TITLE
Improve pppConformBGNormal attach flag test

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -228,7 +228,7 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     pppMngStPtr->m_matrix.value[0][3] = owner->m_worldPosition.x;
                     pppMngStPtr->m_matrix.value[1][3] = owner->m_worldPosition.y;
                     pppMngStPtr->m_matrix.value[2][3] = owner->m_worldPosition.z;
-                } else if (((*(u8*)&owner->m_weaponNodeFlags & 1) != 0) && (owner->m_attachOwner != NULL)) {
+                } else if ((((WeaponNodeFlagBits*)&owner->m_weaponNodeFlags)->m_unk01 != 0) && (owner->m_attachOwner != NULL)) {
                     ownerX = owner->m_worldPosition.x;
                     ownerY = owner->m_attachOwner->m_worldPosition.y;
                     ownerZ = owner->m_worldPosition.z;


### PR DESCRIPTION
## Summary
- Use the existing `WeaponNodeFlagBits` bitfield for the attach-owner flag test in `pppFrameConformBGNormal`.
- This recovers the signed one-bit extraction sequence used by the target and brings the frame function size back to the target size.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppConformBGNormal -o /tmp/pppConformBGNormal_pr.json`
- `pppFrameConformBGNormal`: 99.12371% -> 99.793816% symbol match.
- Function size: 1544 -> 1552 bytes, matching target 1552 bytes.

## Plausibility
- The file already had a `WeaponNodeFlagBits` bitfield type, and the target code uses a signed bitfield-style extraction rather than a raw mask comparison.
