### PR TITLE
Improve item object and chara cleanup matches

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -104,7 +104,19 @@ public:
         int m_active;           // 0x24
     };
 
-    unsigned char m_stateFlags0;      // 0x50
+    union {
+        unsigned char m_stateFlags0;  // 0x50
+        struct {
+            unsigned char unk0 : 1;
+            unsigned char unk1 : 1;
+            unsigned char unk2 : 1;
+            unsigned char unk3 : 1;
+            unsigned char unk4 : 1;
+            unsigned char unk5 : 1;
+            unsigned char unk6 : 1;
+            unsigned char unk7 : 1;
+        } m_stateFlags0Bits;
+    };
     char m_ownerType;                 // 0x51
     unsigned char m_classWorkIndex;   // 0x52
     unsigned char m_ownerSlot;        // 0x53

--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -60,7 +60,19 @@ public:
         } bits;
     } m_animFlagBits;
     int m_reqAnimId;       // 0x548
-    unsigned char m_flags; // 0x54D-0x550
+    union Flags {
+        unsigned char m_flags;
+        struct Bits {
+            unsigned char unk0 : 1;
+            unsigned char unk1 : 1;
+            unsigned char unk2 : 1;
+            unsigned char unk3 : 1;
+            unsigned char unk4 : 1;
+            unsigned char unk5 : 1;
+            unsigned char unk6 : 1;
+            unsigned char unk7 : 1;
+        } bits;
+    } m_flagBits;          // 0x54C
 };
 
 #endif // _FFCC_PPP_PRGOBJ_H_

--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -673,7 +673,7 @@ void CChara::Quit()
 		__dla__FPv(*buf1);
 		*buf1 = 0;
 	}
-	*(void**)((u8*)this + 0x2058) = 0;
+	Memory.DestroyStage(*reinterpret_cast<CMemory::CStage**>((u8*)this + 0x2058));
 }
 
 /*

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -69,7 +69,7 @@ extern float FLOAT_80331b1c;
 extern float FLOAT_80331b24;
 extern float FLOAT_80331b28;
 extern float FLOAT_80331b2c;
-extern float FLOAT_80331b18;
+extern const float FLOAT_80331b18;
 extern float FLOAT_80331b30;
 extern float FLOAT_80331b34;
 extern float FLOAT_80331b38;
@@ -223,18 +223,16 @@ int CGPrgObj::getReplaceStat(int state)
  */
 void CGItemObj::onCreate()
 {
-	unsigned char* self = (unsigned char*)this;
-
-	onCreate__8CGPrgObjFv(self);
-	self[0x54c] &= 0x7f;
-	*(int*)(self + 0x550) = 0;
-	*(int*)(self + 0x558) = 0;
-	*(unsigned short*)(self + 0x560) = 0;
-	*(unsigned short*)(self + 0x562) = 0;
-	*(int*)(self + 0x564) = 0;
-	*(int*)(self + 0x56c) = 0;
-	memset(self + 0x570, 0, 0xc);
-	*(int*)(self + 0x55c) = GetFreeParticleSlot__13CFlatRuntime2Fv(CFlat);
+	onCreate__8CGPrgObjFv(this);
+	m_flagBits.bits.unk0 = 0;
+	m_owner = 0;
+	m_scriptArg = 0;
+	m_createFlags = 0;
+	unk_0x562 = 0;
+	m_pendingModelHandle = 0;
+	m_itemJumpCountdown = 0;
+	memset(&m_memoryCapsuleNameIndex, 0, 0xc);
+	m_particleSlot = GetFreeParticleSlot__13CFlatRuntime2Fv(CFlat);
 }
 
 /*
@@ -280,11 +278,8 @@ void CGItemObj::onFramePreCalc()
  */
 void CGItemObj::onFramePostCalc()
 {
-	unsigned char* self = (unsigned char*)this;
-	unsigned int stateBits = ((unsigned int)self[0x50] << 0x1c) | ((unsigned int)self[0x50] >> 4);
-
-	if ((int)stateBits < 0 && *(int*)(self + 0x550) == 0) {
-		*(int*)(self + 0x94) = *(int*)(self + 0x94) - 1;
+	if (m_stateFlags0Bits.unk4 != 0 && m_owner == 0) {
+		*(int*)((u8*)this + 0x94) = *(int*)((u8*)this + 0x94) - 1;
 	}
 }
 
@@ -321,9 +316,9 @@ void CGItemObj::onCancelStat(int)
 
 	if (*(int*)(self + 0x520) == 0x1b) {
 		*(unsigned int*)(self + 0x1c0) = *(unsigned int*)(self + 0x1c0) | 2;
-		*(float*)(self + 0x17c) = 1.0f;
-		*(float*)(self + 0x178) = 1.0f;
-		*(float*)(self + 0x174) = 1.0f;
+		*(float*)(self + 0x17c) = FLOAT_80331b18;
+		*(float*)(self + 0x178) = FLOAT_80331b18;
+		*(float*)(self + 0x174) = FLOAT_80331b18;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add bitfield views for `CGObject::m_stateFlags0` and `CGPrgObj::m_flagBits` so item object code can use real member access instead of raw byte/offset manipulation.
- Rewrite `CGItemObj::onCreate` around existing members; this now matches exactly.
- Use the linked `FLOAT_80331b18` constant in `CGItemObj::onCancelStat`; this now matches exactly.
- Restore the real `Memory.DestroyStage` cleanup in `CChara::Quit`; this now matches exactly.

## Evidence
- `ninja` passes.
- Progress improved from `Code: 536604 / 1855224 bytes (3269 / 4732 functions)` before these changes to `Code: 536824 / 1855224 bytes (3271 / 4732 functions)`.
- Verified instruction diffs:
  - `onCreate__9CGItemObjFv`: `0` diffs, `29/29` instructions
  - `onCancelStat__9CGItemObjFi`: `0` diffs, `11/11` instructions
  - `Quit__6CCharaFv`: `0` diffs, `26/26` instructions

## Plausibility
- The item object changes replace raw offsets with existing class fields and modeled flag bits, matching the compiler bitfield-style codegen for `onCreate`.
- `FLOAT_80331b18` is the existing linked constant used by the target instead of an anonymous literal.
- `CChara::Quit` now performs the same stage destruction shown by Ghidra and target assembly instead of only clearing the pointer.