### PR TITLE
Improve mapocttree chunk parsing

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -220,11 +220,12 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
                 Printf__7CSystemFPce(&System, s_m_node_pctd_m_meshtype_pctd_801D7268, m_nodeCount);
             }
 
+            unsigned short nodeCount = m_nodeCount;
             rootNode = __nwa__FUlPQ27CMemory6CStagePci(
-                m_nodeCount * 0x4C + 0x10, *reinterpret_cast<CMemory::CStage**>(&MapMng), const_cast<char*>(s_mapocttree_cpp_801D72EC),
+                nodeCount * 0x4C + 0x10, *reinterpret_cast<CMemory::CStage**>(&MapMng), const_cast<char*>(s_mapocttree_cpp_801D72EC),
                 0x59);
             m_nodePool = reinterpret_cast<COctNode*>(
-                __construct_new_array(rootNode, reinterpret_cast<void*>(__ct__8COctNodeFv), 0, 0x4C, m_nodeCount));
+                __construct_new_array(rootNode, reinterpret_cast<void*>(__ct__8COctNodeFv), 0, 0x4C, nodeCount));
             break;
         }
 

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -206,8 +206,8 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
 
             m_mapObject = GetMapObjByIndex(objIndex);
             if (*reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x1E)) == 4) {
-                *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x15)) = -1;
-                *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x14)) = -1;
+                *reinterpret_cast<unsigned char*>(Ptr(m_mapObject, 0x15)) = 0xFF;
+                *reinterpret_cast<unsigned char*>(Ptr(m_mapObject, 0x14)) = 0xFF;
                 *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x22)) = 0;
             } else if (*reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x1E)) == 3) {
                 *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x22)) = 0;
@@ -219,9 +219,9 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
             void* rootNode;
 
             m_nodeCount = chunkFile.Get2();
-            if ((*reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x1E)) != 1) &&
-                (static_cast<unsigned int>(System.m_execParam) >= 3U)) {
-                Printf__7CSystemFPce(&System, s_m_node_pctd_m_meshtype_pctd_801D7268, m_nodeCount);
+            signed char mapObjType = *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x1E));
+            if ((mapObjType != 1) && (static_cast<unsigned int>(System.m_execParam) >= 3U)) {
+                Printf__7CSystemFPce(&System, s_m_node_pctd_m_meshtype_pctd_801D7268, m_nodeCount, mapObjType);
             }
 
             unsigned short nodeCount = m_nodeCount;
@@ -241,7 +241,7 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
             chunkFile.PushChunk();
             while (chunkFile.GetNextChunk(chunk)) {
                 if (chunk.m_id == 'NODE') {
-                    COctNode* node = 0;
+                    COctNode* node;
 
                     chunkFile.PushChunk();
                     while (chunkFile.GetNextChunk(chunk)) {
@@ -266,21 +266,18 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
 
                         case 'CHLD':
                             int childCount = 0;
-                            COctNode* childNode = node;
 
                             for (int i = 0; i < 8; i++) {
-                                short childIndex = chunkFile.Get2();
+                                unsigned short childIndex = chunkFile.Get2();
 
-                                if (childIndex != -1) {
-                                    childNode->m_children[0] = m_nodePool + childIndex;
-                                    childNode = reinterpret_cast<COctNode*>(Ptr(childNode, 4));
+                                if (static_cast<short>(childIndex) != -1) {
+                                    node->m_children[childCount] = m_nodePool + childIndex;
                                     childCount++;
                                 }
                             }
 
                             for (int i = childCount; i < 8; i++) {
-                                childNode->m_children[0] = 0;
-                                childNode = reinterpret_cast<COctNode*>(Ptr(childNode, 4));
+                                node->m_children[i] = 0;
                             }
                             break;
                         }

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -266,21 +266,21 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
 
                         case 'CHLD':
                             int childCount = 0;
-                            COctNode** childNode = node->m_children;
+                            COctNode* childNode = node;
 
                             for (int i = 0; i < 8; i++) {
                                 short childIndex = chunkFile.Get2();
 
                                 if (childIndex != -1) {
-                                    *childNode = m_nodePool + childIndex;
-                                    childNode++;
+                                    childNode->m_children[0] = m_nodePool + childIndex;
+                                    childNode = reinterpret_cast<COctNode*>(Ptr(childNode, 4));
                                     childCount++;
                                 }
                             }
 
                             for (int i = childCount; i < 8; i++) {
-                                *childNode = 0;
-                                childNode++;
+                                childNode->m_children[0] = 0;
+                                childNode = reinterpret_cast<COctNode*>(Ptr(childNode, 4));
                             }
                             break;
                         }

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -107,7 +107,7 @@ extern "C" void Printf__7CSystemFPce(CSystem* system, const char* format, ...);
 extern "C" const char s_m_node_pctd_m_meshtype_pctd_801D7268[];
 extern unsigned long s_insertShadowNo;
 
-static const char s_mapocttree_cpp[] = "mapocttree.cpp";
+extern "C" const char s_mapocttree_cpp_801D72EC[] = "mapocttree.cpp";
 
 namespace {
 static inline unsigned char* Ptr(void* ptr, unsigned int offset)
@@ -223,7 +223,7 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
             }
 
             rootNode = __nwa__FUlPQ27CMemory6CStagePci(
-                m_nodeCount * 0x4C + 0x10, *reinterpret_cast<CMemory::CStage**>(&MapMng), const_cast<char*>(s_mapocttree_cpp),
+                m_nodeCount * 0x4C + 0x10, *reinterpret_cast<CMemory::CStage**>(&MapMng), const_cast<char*>(s_mapocttree_cpp_801D72EC),
                 0x59);
             m_nodePool = reinterpret_cast<COctNode*>(
                 __construct_new_array(rootNode, reinterpret_cast<void*>(__ct__8COctNodeFv), 0, 0x4C, m_nodeCount));

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -199,16 +199,14 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
         switch (chunk.m_id) {
         case 'OBJN': {
             unsigned short objIndex = chunkFile.Get2();
-            signed char* mapObj;
 
             m_mapObject = GetMapObjByIndex(objIndex);
-            mapObj = reinterpret_cast<signed char*>(m_mapObject);
-            if (mapObj[0x1E] == 4) {
-                mapObj[0x15] = -1;
-                mapObj[0x14] = -1;
-                mapObj[0x22] = 0;
-            } else if (mapObj[0x1E] == 3) {
-                mapObj[0x22] = 0;
+            if (*reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x1E)) == 4) {
+                *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x15)) = -1;
+                *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x14)) = -1;
+                *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x22)) = 0;
+            } else if (*reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x1E)) == 3) {
+                *reinterpret_cast<signed char*>(Ptr(m_mapObject, 0x22)) = 0;
             }
             break;
         }

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -197,6 +197,10 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
 
     while (chunkFile.GetNextChunk(chunk)) {
         switch (chunk.m_id) {
+        case 'TYPE':
+            m_type = static_cast<unsigned char>(chunkFile.Get2());
+            break;
+
         case 'OBJN': {
             unsigned short objIndex = chunkFile.Get2();
 
@@ -231,10 +235,6 @@ int COctTree::ReadOtmOctTree(CChunkFile& chunkFile)
 
         case 'INFO':
             m_unk01 = chunkFile.Get1();
-            break;
-
-        case 'TYPE':
-            m_type = static_cast<unsigned char>(chunkFile.Get2());
             break;
 
         case 'TREE':


### PR DESCRIPTION
## Summary
- name the mapocttree rodata filename symbol so the data symbol matches
- tighten `COctTree::ReadOtmOctTree` source shape around map object setup, node allocation, chunk switch layout, debug printing, and child parsing
- replace pointer-stepping child setup with indexed `m_children` access that matches the target zero-fill pattern

## Evidence
- `ninja` passes
- `ReadOtmOctTree__8COctTreeFR10CChunkFile`: 90.56303% before this branch -> 99.78992% after
- `s_mapocttree_cpp_801D72EC`: 100.0%
- nearby tracked symbols unchanged: `InsertShadow_r__FP8COctNode` 89.32653%, `CheckHitCylinder_r__8COctTreeFP8COctNode` 89.278885%

## Plausibility
- the rodata name is backed by the mapocttree filename string and normal linkage, not a forced section
- the debug `Printf` now supplies both integers named by `s_m_node_pctd_m_meshtype_pctd_801D7268`
- child indices are parsed as unsigned values with the original signed `-1` sentinel check, matching target codegen and the file format shape
- child storage now uses normal `node->m_children[index]` member access instead of pointer-offset stepping
