### PR TITLE
Recover menu_favo localized strings

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -20,6 +20,15 @@ extern CMenuPcs MenuPcs;
 
 unsigned char s_rank[0x20];
 
+static const char s_favoForceFr[] = "Force";
+static const char s_favoMusicFr[] = "Musique";
+static const char s_favoActiveFr[] = "Activ\xE9";
+static const char s_favoStereoFr[] = "St\xE9r\xE9o";
+static const char s_favoStrengthEs[] = "Fuerza";
+static const char s_favoDefenseEs[] = "Defensa";
+static const char s_favoMusicEs[] = "M\xFAsica";
+static const char s_favoOffEs[] = "Apagado";
+
 extern float FLOAT_80333040;
 extern float FLOAT_80333044;
 extern float FLOAT_80333048;


### PR DESCRIPTION
## Summary
- Adds the localized French/Spanish string literals present in menu_favo .sdata2.
- Keeps the strings as local constants using byte escapes for accented characters.

## Evidence
- ninja passes: build/GCCP01/main.dol OK.
- objdiff menu_favo .sdata2 now matches the recovered 64-byte string block at 91.42857% section match; before this change the same section was a string-vs-constant mismatch at 23.684212%.
- .bss remains 100% and .text is unchanged.

## Plausibility
- The recovered data is a contiguous block of UI labels (Force, Musique, Activé, Stéréo, Fuerza, Defensa, Música, Apagado), which matches normal source string literals rather than address or section forcing.