### PR TITLE
Use typed PartPcs stage in minigame

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -351,8 +351,7 @@ void CMiniGamePcs::MiniGameGo(char* managerFilePath, char* managerSpFilePath)
     *reinterpret_cast<unsigned short*>(self + 0x134E) = 0;
     self[0x6494] = 0;
 
-    CMemory::CStage* stageLoad =
-        reinterpret_cast<CMemory::CStage*>(reinterpret_cast<unsigned char*>(&PartPcs) + 0x20);
+    CMemory::CStage* stageLoad = PartPcs.m_usbStreamData.m_stageLoad;
     *reinterpret_cast<void**>(self + 0x1354) =
         __nwa__FUlPQ27CMemory6CStagePci(0x40000, stageLoad, const_cast<char*>(s_miniGameSourceName), 0xF1);
     *reinterpret_cast<void**>(self + 0x135C) =


### PR DESCRIPTION
## Summary
- Replace a raw offset access to PartPcs with the typed PartPcs.m_usbStreamData.m_stageLoad member in CMiniGamePcs::MiniGameGo.
- This matches the existing CPartPcs/CUSBStreamData layout exposed by the headers and removes an offset hack around the allocation stage.

## Objdiff evidence
- Command: ninja
- Command: build/tools/objdiff-cli diff -p . -u main/p_minigame -o - MiniGameGo__12CMiniGamePcsFPcPc
- MiniGameGo__12CMiniGamePcsFPcPc: 68.509384% -> 70.45309%
- p_minigame .text: 63.017094% -> 63.223648%
- .rodata remains 100.0%; .data remains 79.42148%

## Plausibility
- Ghidra labels the allocation stage source as PartPcs.m_usbStreamData.m_stageLoad.
- include/ffcc/p_tina.h exposes CPartPcs::m_usbStreamData and the stage member, so this is normal field access instead of compiler coaxing or address hardcoding.