### PR TITLE
Improve CWind AddAmbient diagnostic codegen

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -354,6 +354,7 @@ found:
  */
 int CWind::AddAmbient(float dir, float speed)
 {
+	int checked = 0;
 	WindObject* obj = m_objects;
 	s8 active;
 
@@ -398,6 +399,7 @@ int CWind::AddAmbient(float dir, float speed)
 			goto found;
 		}
 
+		checked += 7;
 		obj++;
 	}
 
@@ -405,7 +407,7 @@ int CWind::AddAmbient(float dir, float speed)
 
 found:
 	if (obj == 0) {
-		System.Printf(const_cast<char*>(DAT_801db568));
+		System.Printf(const_cast<char*>(DAT_801db568), checked);
 		return -1;
 	}
 


### PR DESCRIPTION
## Summary
- Restore the checked free-slot counter in CWind::AddAmbient.
- Pass the counter through the ambient allocation failure diagnostic, matching the surrounding wind allocation helpers and improving codegen.

## Objdiff Evidence
- main/wind unit fuzzy: 93.24602% -> 93.45672%
- AddAmbient__5CWindFff: 86.111115% -> 88.166664%
- AddAmbient size remains 360b on the target side.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/wind -o /tmp/wind_addambient_after.json AddAmbient__5CWindFff