### PR TITLE
Match RedExecute ADSR data compute

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -1395,11 +1395,11 @@ static void _AdsrDataCompute(RedVoiceDATA* voice)
         *stage = *stage + 1;
     }
 
-    voice->m_adsrStepFrames = stepCount;
+    stage[1] = stepCount;
     if (stepCount != 0) {
         voice->m_adsrCurrentLevel = prevValue;
         level |= REDSOUND_FIXED_HALF;
-        voice->m_adsrStepAdd = (level - prevValue) / stepCount;
+        stage[2] = (level - prevValue) / stepCount;
     } else {
         voice->m_adsrCurrentLevel = level;
     }


### PR DESCRIPTION
## Summary
- Write ADSR step frame/add fields relative to the existing ADSR stage pointer in _AdsrDataCompute
- Matches the compiler's original neighboring-field access pattern without changing behavior

## Evidence
- Before: _AdsrDataCompute__FP12RedVoiceDATA was 99.70731% matched with two store-address mismatches
- After: _AdsrDataCompute__FP12RedVoiceDATA is 100.0% matched
- ninja passes; overall matched functions increased from 3279 to 3280 in the generated progress report