### PR TITLE
Improve LocationTitle2 and BreathModel matches

### DIFF
--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -68,7 +68,7 @@ struct pppMngStLocationTitle2Raw {
     CGObject* m_charaObj;
 };
 
-static const char s_LocationTitle2_cpp[] = "LocationTitle2.cpp";
+extern "C" const char s_LocationTitle2_cpp_801DB588[] = "LocationTitle2.cpp";
 
 /*
  * --INFO--
@@ -190,7 +190,7 @@ extern "C" void pppRenderLocationTitle2(struct pppLocationTitle2* locationTitle,
     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);
 }
 
-static const char s_locationNodeName[] = "loc";
+extern "C" const char DAT_80330f50[] = "loc";
 
 /*
  * --INFO--
@@ -238,24 +238,24 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
         CGObject* owner;
         CCharaPcs::CHandle* handle;
         work->m_particles = pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp,
+            unkB->m_maxCount * sizeof(LocationTitle2Particle), pppEnvStPtr->m_stagePtr, s_LocationTitle2_cpp_801DB588,
             0x70);
         memset(work->m_particles, 0, unkB->m_maxCount * sizeof(LocationTitle2Particle));
         LocationTitle2Particle* particles = (LocationTitle2Particle*)work->m_particles;
         CChara::CModel* model;
 
-        owner = (CGObject*)pppMngStPtr->m_lookTarget;
-        handle = 0;
-        if (owner->m_charaModelHandle != 0) {
-            handle = owner->m_charaModelHandle;
-        }
         model = 0;
+        owner = (CGObject*)pppMngStPtr->m_lookTarget;
+        handle = owner->m_charaModelHandle;
         if (handle != 0) {
-            model = handle->m_model;
+            CChara::CModel* handleModel = handle->m_model;
+            if (handleModel != 0) {
+                model = handleModel;
+            }
         }
 
         LocationTitle2ModelRaw* modelRaw = (LocationTitle2ModelRaw*)model;
-        int nodeIndex = SearchNode__Q26CChara6CModelFPc(model, const_cast<char*>(s_locationNodeName));
+        int nodeIndex = SearchNode__Q26CChara6CModelFPc(model, const_cast<char*>(DAT_80330f50));
         u8* node = modelRaw->m_nodes + nodeIndex * 0xC0;
         float zOffset = 1.0f;
 

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -490,7 +490,7 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     Mtx* particleWMat;
     Mtx* particleMtx;
     int i;
-    short groupIndex;
+    int groupIndex;
     int firstParticle;
     int groupTable;
     short slotIndex;


### PR DESCRIPTION
## Summary
- Name LocationTitle2 local constants/symbols for the cpp filename and loc node string, matching target symbol names.
- Reshape LocationTitle2 model-handle lookup to match target null-check flow.
- Widen the pppFrameBreathModel group loop counter to int, matching Ghidra's loop variable shape and improving codegen.

## Objdiff evidence
- pppFrameLocationTitle2: 94.86842% -> 95.3125%, size 1212b -> 1208b.
- LocationTitle2 symbols now match: s_LocationTitle2_cpp_801DB588 100%, DAT_80330f50 100%.
- pppFrameBreathModel: 96.110756% -> 96.427216%, size 1264b -> 1260b.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/LocationTitle2 -o - pppFrameLocationTitle2
- build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o - pppFrameBreathModel