### PR TITLE
Improve sound driver matches

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -778,8 +778,8 @@ float CSound::GetPerformance()
 {
     unsigned int programTime = GetProgramTime__9CRedSoundFv(RedSound(this));
     float numer = (float)(programTime / 0xF);
-    float denom = (float)(((OS_BUS_CLOCK / 500000) * 0x8235) >> 3);
-    return FLOAT_80330d00 * (numer / denom);
+    float denom = (float)(((OS_TIMER_CLOCK / 125000) * 0x8235) >> 3);
+    return 100.0f * (numer / denom);
 }
 
 /*
@@ -809,15 +809,16 @@ void CSound::PauseDiscError(int pause)
  */
 void CSound::CheckDriver(int mode)
 {
-    CSoundLayout& sound = SoundData(this);
+    u8* self = reinterpret_cast<u8*>(this);
+    CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
     unsigned int oldPrint = sound.m_debugPrint;
     sound.m_debugPrint = 1;
-    ReportPrint__9CRedSoundFi(RedSound(this), 1);
-    TestProcess__9CRedSoundFi(RedSound(this), mode);
-    DisplayWaveInfo__9CRedSoundFv(RedSound(this));
-    DisplaySePlayInfo__9CRedSoundFv(RedSound(this));
+    ReportPrint__9CRedSoundFi(reinterpret_cast<CRedSound*>(self + 8), 1);
+    TestProcess__9CRedSoundFi(reinterpret_cast<CRedSound*>(self + 8), mode);
+    DisplayWaveInfo__9CRedSoundFv(reinterpret_cast<CRedSound*>(self + 8));
+    DisplaySePlayInfo__9CRedSoundFv(reinterpret_cast<CRedSound*>(self + 8));
     sound.m_debugPrint = oldPrint;
-    ReportPrint__9CRedSoundFi(RedSound(this), (-oldPrint | oldPrint) >> 0x1F);
+    ReportPrint__9CRedSoundFi(reinterpret_cast<CRedSound*>(self + 8), (-oldPrint | oldPrint) >> 0x1F);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Matched CSound::CheckDriver by keeping the object byte pointer shape used by adjacent sound routines.
- Improved CSound::GetPerformance by using the timer-clock expression that emits the expected Metrowerks division sequence.

## Evidence
- ninja passes.
- objdiff: CheckDriver__6CSoundFi is 100.0% (136 bytes).
- objdiff: GetPerformance__6CSoundFv is 99.72973% directly, and build report marks it 100.0% fuzzy (148 bytes).
- Overall progress after build: code 540452 / 1855224 bytes, 3284 / 4732 functions.

## Plausibility
- OS_TIMER_CLOCK / 125000 is algebraically equivalent to OS_BUS_CLOCK / 500000 and matches existing SDK-style timing code elsewhere in the repo.
- The CheckDriver pointer shape mirrors nearby routines that operate on the CSound object storage and RedSound subobject.