### PR TITLE
Improve astar check group comparisons

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -714,7 +714,7 @@ void CAStar::check(int startGroup, int goalGroup, CATemp& temp)
 				++pathLen1;
 				visited1Bytes[other0] = 1;
 
-				if (other0 == static_cast<unsigned char>(goalGroup))
+				if (other0 == goalGroup)
 				{
 					if (cost1 < m_bestPath.m_cost)
 					{
@@ -830,7 +830,7 @@ void CAStar::check(int startGroup, int goalGroup, CATemp& temp)
 								++level2.m_pathLength;
 								level2.m_visited[other1] = 1;
 
-								if (other1 == static_cast<unsigned char>(goalGroup))
+								if (other1 == goalGroup)
 								{
 									if (level2.m_cost < m_bestPath.m_cost)
 									{


### PR DESCRIPTION
## Summary
- compare discovered A* groups directly against the goal group in CAStar::check
- avoids narrowing goalGroup to unsigned char before the comparison

## Evidence
- ninja succeeds
- objdiff check__6CAStarFiiRQ26CAStar6CATemp: 73.600815% -> 73.79837%
- objdiff __sinit_astar_cpp remains 100.0%

## Plausibility
The discovered group IDs are already byte-sized values promoted for comparison, while the target keeps the goal parameter as the original int. This removes an unnecessary source-level cast and matches the target comparison shape more closely.