### PR TITLE
Improve map octtree overlap flag matching

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1044,9 +1044,9 @@ void COctTree::ClearLight()
 void InsertLight_r(COctNode* node)
 {
 	float boundMinX = node->m_boundMinX;
-	int xOverlap = false;
-	int xyOverlap = false;
 	int overlap = false;
+	int xyOverlap = false;
+	int xOverlap = false;
 
 	if (boundMinX < s_bound.m_min.x) {
 		xOverlap = s_bound.m_min.x <= node->m_boundMaxX;
@@ -1108,9 +1108,9 @@ void InsertLight_r(COctNode* node)
 		}
 
 		float childBoundMinX = child->m_boundMinX;
-		int childXOverlap = false;
-		int childXYOverlap = false;
 		int childOverlap = false;
+		int childXYOverlap = false;
+		int childXOverlap = false;
 		if (childBoundMinX < s_bound.m_min.x) {
 			childXOverlap = s_bound.m_min.x <= child->m_boundMaxX;
 		} else {
@@ -1352,9 +1352,9 @@ void COctTree::ClearShadow()
 void InsertShadow_r(COctNode* node)
 {
 	float boundMinX = node->m_boundMinX;
-	int xOverlap = false;
-	int xyOverlap = false;
 	int overlap = false;
+	int xyOverlap = false;
+	int xOverlap = false;
 
 	if (boundMinX < s_bound.m_min.x) {
 		xOverlap = s_bound.m_min.x <= node->m_boundMaxX;
@@ -1418,9 +1418,9 @@ void InsertShadow_r(COctNode* node)
 		s_light_no++;
 
 		float childBoundMinX = child->m_boundMinX;
-		int childXOverlap = false;
-		int childXYOverlap = false;
 		int childOverlap = false;
+		int childXYOverlap = false;
+		int childXOverlap = false;
 		if (childBoundMinX < s_bound.m_min.x) {
 			childXOverlap = s_bound.m_min.x <= child->m_boundMaxX;
 		} else {
@@ -1691,9 +1691,9 @@ void COctTree::ClearFlag(unsigned long flag)
 int COctTree::CheckHitCylinder_r(COctNode* node)
 {
 	float boundMinX = *reinterpret_cast<float*>(Ptr(node, 0x0));
-	int xOverlap = false;
-	int xyOverlap = false;
 	int overlap = false;
+	int xyOverlap = false;
+	int xOverlap = false;
 
 	if (boundMinX < *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28))) {
 		xOverlap = *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28)) <= *reinterpret_cast<float*>(Ptr(node, 0xC));
@@ -1757,9 +1757,9 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 		}
 
 		float childBoundMinX = *reinterpret_cast<float*>(Ptr(child, 0x0));
-		int childXOverlap = false;
-		int childXYOverlap = false;
 		int childOverlap = false;
+		int childXYOverlap = false;
+		int childXOverlap = false;
 		if (childBoundMinX < *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28))) {
 			childXOverlap = *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28)) <= *reinterpret_cast<float*>(Ptr(child, 0xC));
 		} else {
@@ -1922,9 +1922,9 @@ int COctTree::CheckHitCylinder(CMapCylinder* cylinder, Vec* move, unsigned long 
 void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 {
 	float boundMinX = *reinterpret_cast<float*>(Ptr(octNode, 0x0));
-	int xOverlap = false;
-	int xyOverlap = false;
 	int overlap = false;
+	int xyOverlap = false;
+	int xOverlap = false;
 
 	if (boundMinX < *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28))) {
 		xOverlap = *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28)) <= *reinterpret_cast<float*>(Ptr(octNode, 0xC));
@@ -1987,9 +1987,9 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 		}
 
 		float childBoundMinX = *reinterpret_cast<float*>(Ptr(child, 0x0));
-		int childXOverlap = false;
-		int childXYOverlap = false;
 		int childOverlap = false;
+		int childXYOverlap = false;
+		int childXOverlap = false;
 		if (childBoundMinX < *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28))) {
 			childXOverlap = *reinterpret_cast<float*>(Ptr(&s_cyl, 0x28)) <= *reinterpret_cast<float*>(Ptr(child, 0xC));
 		} else {
@@ -2176,12 +2176,12 @@ void CMaterialMan::InitEnv()
  */
 int CBound::CheckCross(CBound& other)
 {
-	bool xOverlap;
-	bool xyOverlap;
 	bool overlap;
+	bool xyOverlap;
+	bool xOverlap;
 
-	xyOverlap = false;
 	overlap = false;
+	xyOverlap = false;
 	if (m_min.x < other.m_min.x) {
 		xOverlap = other.m_min.x <= m_max.x;
 	} else {


### PR DESCRIPTION
## Summary
- Reorder temporary overlap flags in repeated mapocttree bounds checks to better match the target register allocation.
- Applies the same source shape to InsertLight_r, InsertShadow_r, cylinder hit checks, and CBound::CheckCross.

## Objdiff evidence
main/mapocttree .text: 95.26809% -> 95.29738%

Improved symbols:
- CheckHitCylinderNear_r__8COctTreeFP8COctNode: 95.11161% -> 95.20089%
- CheckCross__6CBoundFR6CBound: 96.17647% -> 96.47059%
- CheckHitCylinder_r__8COctTreeFP8COctNode: 89.27889% -> 89.35857%
- InsertShadow_r__FP8COctNode: 90.64082% -> 90.66122%
- InsertLight_r__FP8COctNode: 92.96279% -> 93.05582%

## Plausibility
This only changes local temporary declaration/initialization order in existing overlap tests. The control flow and data access remain unchanged, and the resulting lifetimes line up better across the repeated original-source-looking bounds check pattern.

## Verification
- ninja
- build/GCCP01/main.dol: OK
- build/tools/objdiff-cli diff -p . -u main/mapocttree -o -