### PR TITLE
Improve pppYmTracer frame spline temp

### DIFF
--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -314,10 +314,11 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerUnkB* param_2, pppYmT
             Vec splineFrom[4];
             Vec splineTo[4];
             s16 splineCount = 0;
+            f32 t;
             f32 stepScale = FLOAT_803306ec / (f32)(param_2->m_payload[9] + 1);
 
             for (i = 0; i < (s32)(u32)param_2->m_payload[9]; i++) {
-                f32 t = stepScale * (f32)(i + 1);
+                t = stepScale * (f32)(i + 1);
 
                 gUtil.GetSplinePos(splineFrom[(param_2->m_payload[9] - 1) - i], entries[3].from, entries[2].from,
                                           entries[1].from, entries[0].from, t, FLOAT_803306ec);


### PR DESCRIPTION
## Summary
- Hoist the spline interpolation parameter temporary in `pppFrameYmTracer` so MWCC keeps it live across the loop in a way closer to the original codegen.

## Evidence
- `ninja` passes.
- `pppFrameYmTracer`: 97.90741% -> 97.95885%, size unchanged at 1944 bytes, instruction diffs 139 -> 135.
- `pppRenderYmTracer`: unchanged at 98.847824%.

## Plausibility
- This is a source-level lifetime/order adjustment for a real spline interpolation value, not a hardcoded address or section/codegen hack.