### PR TITLE
Improve pppYmBreath frame codegen

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -515,7 +515,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     int firstParticle;
     int groupTable;
     short slotIndex;
-    unsigned int slotCount;
+    int slotCount;
     int ready;
     float scaledOwner;
     Mtx scaleMtx;
@@ -530,7 +530,6 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
         return;
     }
 
-    _pppPObject* object = reinterpret_cast<_pppPObject*>(ymBreath);
     dataOffsets = offsets->m_serializedDataOffsets;
     _pppMngSt* mngSt = pppMngStPtr;
     colorOffset = dataOffsets[1];
@@ -600,7 +599,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     }
 
     PSMTXCopy(pppMngStPtr->m_matrix.value, work->m_matrix);
-    UpdateAllParticle(object, work, pYmBreath, color);
+    UpdateAllParticle(reinterpret_cast<_pppPObject*>(ymBreath), work, pYmBreath, color);
 
     particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
     for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
@@ -932,7 +931,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
     YmBreathParticleData* particle = reinterpret_cast<YmBreathParticleData*>(particleData);
     Vec baseDir;
-    int angle[3];
+    int angle[4];
     pppFMATRIX rotMtx;
     float spread;
     float range;


### PR DESCRIPTION
## Summary
- Removes a redundant _pppPObject local in pppFrameYmBreath so the call uses the existing object pointer directly.
- Makes the frame slot-count local signed, matching the target signed loop compare.
- Uses a 4-int angle buffer for BirthParticle to match the pppIVECTOR4 helper signature.

## Evidence
- ninja passes.
- main/pppYmBreath fuzzy code: 98.012375% -> 98.123764%.
- pppFrameYmBreath: 95.71519% -> 96.28481%.
- Data score unchanged at 33.962265%.

## Plausibility
- The frame change removes an unnecessary alias that increased register pressure and stack size.
- The slot-count signedness matches the target compare shape.
- The angle buffer size follows the pppGetRotMatrixXYZ pppIVECTOR4 parameter rather than a three-int ad hoc array.