### PR TITLE
Improve FavoCtrl matching

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -380,7 +380,7 @@ active:
 	}
 	press = rawPress;
 
-	if ((rawPress & 0xffff) == 0) {
+	if (static_cast<s16>(press) == 0) {
 		doReset = 0;
 	} else if ((press & 0x20) != 0) {
 		singMenuState->cursorMove = 1;
@@ -390,15 +390,18 @@ active:
 		singMenuState->cursorMove = -1;
 		Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
 		doReset = 1;
-	} else if ((press & 0x100) != 0) {
-		Sound.PlaySe(4, 0x40, 0x7f, 0);
-		doReset = 0;
-	} else if ((press & 0x200) != 0) {
-		singMenuState->closeRequested = 1;
-		Sound.PlaySe(3, 0x40, 0x7f, 0);
-		doReset = 1;
 	} else {
-		doReset = 0;
+		if ((press & 0x100) != 0) {
+			Sound.PlaySe(4, 0x40, 0x7f, 0);
+			goto noReset;
+		} else if ((press & 0x200) != 0) {
+			singMenuState->closeRequested = 1;
+			Sound.PlaySe(3, 0x40, 0x7f, 0);
+			doReset = 1;
+		} else {
+noReset:
+			doReset = 0;
+		}
 	}
 
 	if (doReset != 0) {


### PR DESCRIPTION
## Summary
- Refine FavoCtrl button press narrowing to match the target sign-extension path.
- Restructure the A-button no-reset path so it shares the common zero-result block with other no-reset cases.

## Evidence
- ninja passes for GCCP01.
- Objdiff for main/menu_favo FavoCtrl__8CMenuPcsFv improves from 97.1% to 99.1%.
- FavoCtrl size remains 400 bytes, matching the PAL target size.

## Plausibility
- Keeps the existing input priority and side effects unchanged.
- Uses a 16-bit signed zero-test for the button word and shared no-reset control flow, matching the recovered branch shape without hard-coded addresses or fake symbols.