### PR TITLE
Match Goblin King frame state branch

### DIFF
--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -727,10 +727,12 @@ void CGMonObj::cancelStatFuncGoblinKing()
 void CGMonObj::frameStatFuncGoblinKing()
 {
 	CGPrgObj* prgObj = reinterpret_cast<CGPrgObj*>(this);
-	if (prgObj->m_lastStateId == 100) {
+	switch (prgObj->m_lastStateId) {
+	case 100:
 		teleport__8CGMonObjFiiiiiiiiiP3VecRiR3Vec(
 		    this, 0, 0xd, 8, 0x42, 0xa03e, 0xa03f, 3, 4, 5, &DAT_802127c0,
 		    *reinterpret_cast<int*>(SoundBuffer_1260_), *reinterpret_cast<Vec*>(SoundBuffer_1260_ + 4));
+		break;
 	}
 	return;
 }


### PR DESCRIPTION
## Summary
- Rewrites CGMonObj::frameStatFuncGoblinKing as a single-case switch to match the original branch shape.
- Keeps the same teleport behavior for state 100 while matching the target codegen.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/monobj_boss -o - frameStatFuncGoblinKing__8CGMonObjFv
- Before: 96.5625% match, 128 bytes.
- After: 100.0% match, 128 bytes.
- Build report now shows one additional matched function and +128 matched game-code bytes.