### PR TITLE
Improve menu list animation loops

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -220,7 +220,8 @@ int CMenuPcs::MLstClose()
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
 	if ((int)itemCount > 0) {
-		for (unsigned int i = itemCount; i != 0; i--) {
+		int i = (int)itemCount;
+		do {
 			if (entry->startFrame <= currentFrame) {
 				if (entry->startFrame + entry->duration <= currentFrame) {
 					completedItems++;
@@ -235,7 +236,8 @@ int CMenuPcs::MLstClose()
 				}
 			}
 			entry++;
-		}
+			i--;
+		} while (i != 0);
 	}
 	zero = FLOAT_803333D0;
 	if (this->lstData->count == completedItems) {
@@ -461,7 +463,8 @@ int CMenuPcs::MLstOpen()
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
 	if ((int)itemCount > 0) {
-		for (unsigned int i = itemCount; i != 0; i--) {
+		int i = (int)itemCount;
+		do {
 			if (entry->startFrame <= currentFrame) {
 				if (entry->startFrame + entry->duration <= currentFrame) {
 					completedItems++;
@@ -473,7 +476,8 @@ int CMenuPcs::MLstOpen()
 				}
 			}
 			entry++;
-		}
+			i--;
+		} while (i != 0);
 	}
 
 	one = FLOAT_803333F0;


### PR DESCRIPTION
## Summary
- Rework the MLstOpen and MLstClose animation item walks to use guarded do loops after the positive count check.
- This matches the target's single-entry loop shape more closely and avoids the extra unsigned loop guard emitted by the previous source.

## Objdiff evidence
- main/menu_lst MLstClose__8CMenuPcsFv: 80.607475% -> 80.700935%
- main/menu_lst MLstOpen__8CMenuPcsFv: 83.25% -> 83.30556%
- main/menu_lst MLstCtrl__8CMenuPcsFv: unchanged at 77.42601%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_close_final.json MLstClose__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_open_final.json MLstOpen__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_ctrl_final.json MLstCtrl__8CMenuPcsFv