### PR TITLE
Improve util matches and claim FunnyShape rodata

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -323,6 +323,7 @@ p_FunnyShape.cpp:
 	extabindex  start:0x8000C7A8 end:0x8000C838
 	.text       start:0x8004E210 end:0x8004EB4C
 	.ctors      start:0x801D5400 end:0x801D5404
+	.rodata     start:0x801D7DD0 end:0x801D7E80
 	.data       start:0x801EA778 end:0x801EA914
 	.data       start:0x801EA914 end:0x801EA948
 	.bss        start:0x8026D728 end:0x80273928

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1013,11 +1013,11 @@ void CUtil::DisableIndMtx()
  */
 void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
 {
+    u32* colorPtr = reinterpret_cast<u32*>(&color);
     float u1;
     float v1;
     float u2;
     float v2;
-    u32 rgba = *reinterpret_cast<u32*>(&color);
 
     if (uv1 == NULL || uv2 == NULL) {
         u1 = kUtilZero;
@@ -1032,37 +1032,43 @@ void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d
     }
 
     GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+    f32 x1 = pos1.x;
+    f32 y1 = pos1.y;
+    f32 z1 = pos1.z;
+    f32 x2 = pos2.x;
+    f32 y2 = pos2.y;
+    u32 rgba = *colorPtr;
 
-    GXWGFifo.f32 = pos1.x;
-    GXWGFifo.f32 = pos1.y;
-    GXWGFifo.f32 = pos1.z;
+    GXWGFifo.f32 = x1;
+    GXWGFifo.f32 = y1;
+    GXWGFifo.f32 = z1;
     GXWGFifo.u32 = rgba;
     GXWGFifo.f32 = u1;
     GXWGFifo.f32 = v1;
     GXWGFifo.f32 = u1;
     GXWGFifo.f32 = v1;
 
-    GXWGFifo.f32 = pos2.x;
-    GXWGFifo.f32 = pos1.y;
-    GXWGFifo.f32 = pos1.z;
+    GXWGFifo.f32 = x2;
+    GXWGFifo.f32 = y1;
+    GXWGFifo.f32 = z1;
     GXWGFifo.u32 = rgba;
     GXWGFifo.f32 = u2;
     GXWGFifo.f32 = v1;
     GXWGFifo.f32 = u2;
     GXWGFifo.f32 = v1;
 
-    GXWGFifo.f32 = pos2.x;
-    GXWGFifo.f32 = pos2.y;
-    GXWGFifo.f32 = pos1.z;
+    GXWGFifo.f32 = x2;
+    GXWGFifo.f32 = y2;
+    GXWGFifo.f32 = z1;
     GXWGFifo.u32 = rgba;
     GXWGFifo.f32 = u2;
     GXWGFifo.f32 = v2;
     GXWGFifo.f32 = u2;
     GXWGFifo.f32 = v2;
 
-    GXWGFifo.f32 = pos1.x;
-    GXWGFifo.f32 = pos2.y;
-    GXWGFifo.f32 = pos1.z;
+    GXWGFifo.f32 = x1;
+    GXWGFifo.f32 = y2;
+    GXWGFifo.f32 = z1;
     GXWGFifo.u32 = rgba;
     GXWGFifo.f32 = u1;
     GXWGFifo.f32 = v2;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1271,9 +1271,23 @@ void CUtil::GetSplinePos(Vec& out, Vec p0, Vec p1, Vec p2, Vec p3, float t, floa
 	hermite[2] = t - ((kUtilHermiteCoeff2 * t2) - t3);
 	hermite[3] = t3 - t2;
 
-	out.x = (hermite[1] * p2.x) + (hermite[0] * p1.x) + (hermite[2] * tan0.x) + (hermite[3] * tan1.x);
-	out.y = (hermite[1] * p2.y) + (hermite[0] * p1.y) + (hermite[2] * tan0.y) + (hermite[3] * tan1.y);
-	out.z = (hermite[1] * p2.z) + (hermite[0] * p1.z) + (hermite[2] * tan0.z) + (hermite[3] * tan1.z);
+	float x = hermite[1] * p2.x;
+	x += hermite[0] * p1.x;
+	x += hermite[2] * tan0.x;
+	x += hermite[3] * tan1.x;
+	out.x = x;
+
+	float y = hermite[1] * p2.y;
+	y += hermite[0] * p1.y;
+	y += hermite[2] * tan0.y;
+	y += hermite[3] * tan1.y;
+	out.y = y;
+
+	float z = hermite[1] * p2.z;
+	z += hermite[0] * p1.z;
+	z += hermite[2] * tan0.z;
+	z += hermite[3] * tan1.z;
+	out.z = z;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Claim the contiguous p_FunnyShape rodata range 0x801D7DD0..0x801D7E80 between zlist.cpp and FS_USB_Process.cpp.
- Reshape CUtil::RenderQuadTex2 to keep the packed color load in the vertex emission path, matching the nearby RenderQuad style.
- Accumulate CUtil::GetSplinePos components explicitly so the Hermite multiply-add order better matches the target.

## Evidence
- ninja succeeds.
- main/util .text: 87.84548% -> 88.70211%.
- RenderQuadTex2__5CUtilF3Vec3Vec8_GXColorP5Vec2dP5Vec2d: 82.27273% -> 90.22727%.
- GetSplinePos__5CUtilFR3Vec3Vec3Vec3Vec3Vecff: 79.68687% -> 94.34344%.
- main/util extabindex: 97.75641% -> 98.07692%.
- p_FunnyShape .text: 98.16244% -> 98.17936% after claiming the rodata range.
- drawViewer__14CFunnyShapePcsFv: 99.393936% -> 99.469696%.

## Plausibility
- The p_FunnyShape rodata claim fills an unclaimed contiguous symbol range named for FunnyShape/CFunnyShapePcs and stops exactly before s_FS_USB_Process_cpp_801D7E80.
- The util changes are source-level expression and temporary ordering changes, not forced sections or artificial symbols.