### PR TITLE
Improve FunnyShape viewer rodata layout

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -62,7 +62,7 @@ extern "C" void* gVtable_CPtrArray_OSFSTexture[];
 extern "C" void* gVtable_CPtrArray_GXTexObj[];
 extern "C" void* __vt__14CFunnyShapePcs[];
 static const char lbl_801D7DD0[] = "CFunnyShapePcs(VIEWER)";
-static const char s_CFunnyShapePcs[] = "CFunnyShapePcs";
+extern const char s_CFunnyShapePcs[];
 extern char lbl_8032E660[];
 extern u8 ARRAY_8026D728[];
 
@@ -438,6 +438,8 @@ void CFunnyShapePcs::drawViewer()
         Graphic.Printf(const_cast<char*>(s_funnyShapeFmt), pFan[frame % 4]);
     }
 }
+
+const char s_CFunnyShapePcs[] = "CFunnyShapePcs";
 
 /*
  * --INFO--


### PR DESCRIPTION
Summary:
- Move the CFunnyShapePcs stage-name string after drawViewer so drawViewer's local vector constants sit at the target rodata offsets.
- This reduces the remaining drawViewer argument/offset mismatches without changing behavior.

Evidence:
- build: ninja
- objdiff: main/p_FunnyShape drawViewer__14CFunnyShapePcsFv improves from 99.393936% to 99.46212%.
- createViewer__14CFunnyShapePcsFv remains 100.0%.
- __sinit_p_FunnyShape_cpp remains 86.02778%.

Plausibility:
- The change only adjusts the declaration/definition order of an existing string used by createViewer.
- No manual vtables, ctor/dtor stubs, sections, addresses, or fake symbols were added.