### PR TITLE
Model debug menu status bits

### DIFF
--- a/include/ffcc/p_dbgmenu.h
+++ b/include/ffcc/p_dbgmenu.h
@@ -23,7 +23,16 @@ public:
         u32 m_unk28;                            // 0x28
         u32 m_unk2C;                            // 0x2C
         s32 m_state;                            // 0x30
-        u8 m_status;                            // 0x34
+        union
+        {
+            u8 m_status;                        // 0x34
+            struct
+            {
+                u8 m_used : 1;
+                u8 m_selected : 1;
+                u8 m_statusRest : 6;
+            } m_statusBits;
+        };
         u8 m_pad35[3];                          // 0x35
         s32 m_id;                               // 0x38
         s32 m_drawX;                            // 0x3C

--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -303,14 +303,14 @@ void CDbgMenuPcs::calc()
 	}
 	if ((padInput & 4) != 0) {
 		CDM* start = m_selectedMenu;
-		m_selectedMenu->m_status &= 0xBF;
+		m_selectedMenu->m_statusBits.m_selected = 0;
 		do {
 			m_selectedMenu = m_selectedMenu->m_next;
 			if ((m_selectedMenu->m_flags & 1) != 0) {
 				break;
 			}
 		} while (m_selectedMenu != start);
-		m_selectedMenu->m_status = (m_selectedMenu->m_status & 0xBF) | 0x40;
+		m_selectedMenu->m_statusBits.m_selected = 1;
 	}
 
 	if (Pad._452_4_ != 0) {
@@ -322,14 +322,14 @@ void CDbgMenuPcs::calc()
 	}
 	if ((padInput & 8) != 0) {
 		CDM* start = m_selectedMenu;
-		m_selectedMenu->m_status &= 0xBF;
+		m_selectedMenu->m_statusBits.m_selected = 0;
 		do {
 			m_selectedMenu = m_selectedMenu->m_prev;
 			if ((m_selectedMenu->m_flags & 1) != 0) {
 				break;
 			}
 		} while (m_selectedMenu != start);
-		m_selectedMenu->m_status = (m_selectedMenu->m_status & 0xBF) | 0x40;
+		m_selectedMenu->m_statusBits.m_selected = 1;
 	}
 
 	if (m_rootMenuNode.m_firstChild != 0) {
@@ -606,7 +606,7 @@ void CDbgMenuPcs::drawWindow(int flags, int x, int y, int width, int height, cha
 	GXPosition3f32((float)x, (float)(y + height), 0.0f);
 	GXColor1u32(gDbgMenuWindowFillColors[1 - fillColorIndex]);
 
-	if (((m_currentMenu->m_status << 25) & 0x80000000) != 0) {
+	if (m_currentMenu->m_statusBits.m_selected != 0) {
 		u8 alpha = 0xC0;
 
 		if ((System.m_frameCounter >> 2 & 1) != 0) {
@@ -685,7 +685,7 @@ void CDbgMenuPcs::drawFont(int flags, int x, int y, char* text)
 CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
 {
 	for (int i = 0; i < 0x80; i++) {
-		if ((s8)m_menuPool[i].m_status >= 0) {
+		if (m_menuPool[i].m_statusBits.m_used == 0) {
 			return &m_menuPool[i];
 		}
 	}
@@ -850,7 +850,7 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
 	CDM* menu = searchFreeCDM();
 
 	memset(&menu->m_status, 0, 0x20);
-	menu->m_status = (menu->m_status & 0x7F) | 0x80;
+	menu->m_statusBits.m_used = 1;
 
 	menu->m_type = param.m_type;
 	menu->m_flags = param.m_flags;
@@ -877,7 +877,7 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
 		do {
 			if (found == 0 && ((child->m_flags & 1) != 0)) {
 				found = 1;
-				child->m_status |= 0x40;
+				child->m_statusBits.m_selected = 1;
 				m_selectedMenu = child;
 			}
 			child = child->m_next;
@@ -890,7 +890,7 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
 	} else {
 		parentMenu->m_firstChild = menu;
 		if ((menu->m_flags & 1) != 0) {
-			menu->m_status |= 0x40;
+			menu->m_statusBits.m_selected = 1;
 			m_selectedMenu = menu;
 		}
 		if ((menu->m_flags & 2) != 0) {


### PR DESCRIPTION
## Summary
- model CDbgMenuPcs::CDM status byte as used/selected bitfields while preserving raw byte access
- replace raw status masks in debug menu calc/add/draw paths with named bitfield access

## Objdiff evidence
- main/p_dbgmenu .text: 91.55483% -> 92.08968%
- Add__11CDbgMenuPcsFiiRQ211CDbgMenuPcs8CDMParam: 93.42593% -> 97.03704%
- calc__11CDbgMenuPcsFv: 91.72028% -> 93.818184%
- drawWindow__11CDbgMenuPcsFiiiiiPc unchanged at 82.31437%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o - Add__11CDbgMenuPcsFiiRQ211CDbgMenuPcs8CDMParam