### PR TITLE
Improve mana water mesh constants

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1127,11 +1127,11 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
     int colCount;
     int pairCount;
 
-    normalY = FLOAT_803318a0;
-    zero = FLOAT_80331898;
+    normalY = LoadFloat(FLOAT_803318a0);
+    zero = LoadFloat(FLOAT_80331898);
     rowCount = 0;
     uvStep = LoadFloat(FLOAT_803318A8);
-    radius = param_5 * FLOAT_803318a4;
+    radius = param_5 * LoadFloat(FLOAT_803318a4);
     for (z = radius; -radius <= z; z -= param_5 * uvStep) {
         colCount = 0;
         rowUv = static_cast<float>(rowCount) * uvStep;

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1143,10 +1143,10 @@ static int CreateWaterMesh(Vec* positionsInOut, Vec* normalsOut, Vec2d* uvOut, u
     int pairCount;
 
     rowCount = 0;
-    radius = size * FLOAT_80330e5c;
+    radius = size * LoadFloat(FLOAT_80330e5c);
     uvStep = LoadFloat(FLOAT_80330e6c);
-    zero = FLOAT_80330e4c;
-    normalY = FLOAT_80330e58;
+    zero = LoadFloat(FLOAT_80330e4c);
+    normalY = LoadFloat(FLOAT_80330e58);
     for (z = radius; -radius <= z; z -= size * uvStep) {
         colCount = 0;
         rowUv = static_cast<float>(rowCount) * uvStep;


### PR DESCRIPTION
## Summary
- Use the existing LoadFloat helper for named water-mesh constants in pppMana2 and pppYmMana.
- Keeps the shared CreateWaterMesh source shape aligned across both mana implementations while avoiding local literal folding.

## Objdiff evidence
- main/pppMana2 .text: 83.35553% -> 83.35714% (size unchanged at 12376 bytes)
- main/pppYmMana .text: 80.967995% -> 80.97333% (size unchanged at 14996 bytes)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppMana2 -o /tmp/pppMana2.final.json
- build/tools/objdiff-cli diff -p . -u main/pppYmMana -o /tmp/pppYmMana.final.json