### PR TITLE
Match CFile::CheckQueue

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -369,7 +369,8 @@ CFile::CHandle* CFile::CheckQueue()
             }
             else if (dvdStatus < 0)
             {
-                handle->m_completionStatus = completionStatus = 4;
+                handle->m_completionStatus = 4;
+                goto next;
             }
             else
             {
@@ -385,6 +386,7 @@ CFile::CHandle* CFile::CheckQueue()
         }
         else
         {
+next:
             handle = handle->m_previous;
         }
     } while (handle != &m_fileHandle);


### PR DESCRIPTION
## Summary
- Route negative DVD statuses in CFile::CheckQueue directly to the existing queue-advance path after marking the handle as status 4.
- This preserves behavior while matching the original unrolled control-flow shape.

## Evidence
- Before: CheckQueue__5CFileFv 99.88024% match.
- After: CheckQueue__5CFileFv 100.0% match.
- build/GCCP01 report now shows main/file at 18/19 matched functions and 2852/4548 matched code bytes.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/file -o /tmp/file_final.json CheckQueue__5CFileFv