### PR TITLE
Improve p_light target indexing

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -858,22 +858,22 @@ void CLightPcs::SetBit32(CLightPcs::TARGET target, unsigned long* bits)
 {
     char* lightPcs = (char*)this;
     char* bumpSlot = lightPcs + 0x63c;
-    _GXColor lightColor;
 
     *(u32*)(lightPcs + 0xb0) = 0;
     *(u32*)(lightPcs + 0xb4) = 0;
 
     for (u32 i = 0; i < *(u32*)(lightPcs + 0xb8); i++, bumpSlot += 0xb0) {
-        if ((*(char*)((int)target + (int)bumpSlot + 0x60) != '\0') &&
+        if ((*(u8*)((int)target + (int)bumpSlot + 0x60) != 0) &&
             (((1 << (i & 0x1f)) & *(u32*)((char*)bits + ((i >> 3) & 0x1ffffffc))) != 0))
         {
-            *(u32*)&lightColor = *(u32*)(bumpSlot + 0x50 + ((int)target * 4));
-            GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c), lightColor);
+            GXInitLightColor(
+                (GXLightObj*)(bumpSlot + 0x6c),
+                *reinterpret_cast<_GXColor*>(bumpSlot + 0x50 + ((int)target * 4)));
             GXLoadLightObjImm((GXLightObj*)(bumpSlot + 0x6c), (GXLightID)(1 << *(u32*)(lightPcs + 0xb0)));
             *(u32*)(lightPcs + 0xb4) |= 1 << *(u32*)(lightPcs + 0xb0);
             *(u32*)(lightPcs + 0xb0) += 1;
 
-            if (*(u32*)(lightPcs + 0xb0) > 7) {
+            if (*(u32*)(lightPcs + 0xb0) >= 8) {
                 return;
             }
         }
@@ -948,7 +948,7 @@ void CLightPcs::InsertOctTree(CLightPcs::TARGET target, COctTree& octTree)
     octTree.ClearLight();
     CLight* light = m_sceneLights;
     for (u32 i = 0; i < m_sceneLightCount; i++, light++) {
-        if (reinterpret_cast<u8*>(&light->m_targetEnableMask)[target] != 0) {
+        if ((reinterpret_cast<u8*>(light) + 0x60)[target] != 0) {
             octTree.InsertLight(i, *reinterpret_cast<Vec*>(&light->m_position), light->m_range, light->m_partMask);
         }
     }


### PR DESCRIPTION
Summary:
- Reworked p_light target-enable byte indexing to match the recovered byte-addressing pattern.
- Passed SetBit32 target colors directly from the stored color array instead of materializing an extra color temporary.
- Normalized the loaded-light limit check to the original >= 8 form.

Objdiff evidence:
- main/p_light .text: 85.020226% -> 85.13633%
- InsertOctTree__9CLightPcsFQ29CLightPcs6TARGETR8COctTree: 96.25% -> 100.0%
- SetBit32__9CLightPcsFQ29CLightPcs6TARGETPUl: 96.94827% -> 99.82758%

Verification:
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_light -o -