### PR TITLE
Improve YmMoveParabola frame scene check

### DIFF
--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -63,6 +63,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
     pppNormalize(direction, normalizedSource);
 
     s32 sceneDiff = (s32)Game.m_currentSceneId - 7;
+    bool isSceneSeven = sceneDiff == 0;
     s32 sinIndex = (s32)((gPppYmMoveParabolaAngleScale * stepData->m_dataValIndex) / gPppYmMoveParabolaAngleDivisor);
     f32 xzScale = frameCount * (work->m_distance * *(f32*)((u8*)gPppTrigTable + ((sinIndex + 0x4000) & 0xFFFC)));
     newPosition.x = direction.x * xzScale;
@@ -70,7 +71,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
     newPosition.y = (frameCount * (work->m_distance * *(f32*)((u8*)gPppTrigTable + (sinIndex & 0xFFFC)))) -
                     (frameCount * (gravityOffset * frameCount));
     newPosition.z = direction.z * xzScale;
-    if (sceneDiff == 0) {
+    if (isSceneSeven) {
         Vec basePosition = work->m_basePosition;
         pppAddVector(newPosition, newPosition, basePosition);
     } else {


### PR DESCRIPTION
## Summary
- Preserve the scene-7 condition in pppFrameYmMoveParabola as an explicit boolean before the parabola position math.
- This keeps the source behavior the same while matching the target instruction scheduling more closely around the scene branch.

## Evidence
- Built successfully with `ninja`.
- `build/tools/objdiff-cli diff -p . -u main/pppYmMoveParabola -o - pppFrameYmMoveParabola` now reports `pppFrameYmMoveParabola` at 99.646736% with 2 remaining diffs.

## Plausibility
- The change is a normal source-level preservation of a branch condition that is reused after intermediate math.
- No fake symbols, hard-coded addresses, or section forcing were introduced.