### PR TITLE
Correct CPartPcs base class

### DIFF
--- a/include/ffcc/p_tina.h
+++ b/include/ffcc/p_tina.h
@@ -2,7 +2,7 @@
 #define _FFCC_P_TINA_H_
 
 #include "ffcc/memory.h"
-#include "ffcc/system.h"
+#include "ffcc/p_sample.h"
 #include "ffcc/USBStreamData.h"
 
 struct Vec;
@@ -37,7 +37,7 @@ extern unsigned int m_table_desc17__8CPartPcs[];
 extern unsigned int m_table_desc18__8CPartPcs[];
 extern unsigned int m_table__8CPartPcs[][0x15C / sizeof(unsigned int)];
 
-class CPartPcs : public CProcess
+class CPartPcs : public CSamplePcs
 {
 public:
     CUSBStreamData m_usbStreamData; // 0x04

--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -200,6 +200,75 @@ unsigned int lbl_801EAD84[3] = {reinterpret_cast<unsigned int>(lbl_8032E69C), 0x
 unsigned int lbl_801EAD90 = reinterpret_cast<unsigned int>(lbl_8032E69C);
 int DAT_8032ed38;
 int DAT_8032ed3c;
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+inline CPartPcs::CPartPcs()
+{
+	unsigned int* table = reinterpret_cast<unsigned int*>(m_table__8CPartPcs);
+
+	table[1] = m_table_desc0__8CPartPcs[0];
+	table[2] = m_table_desc0__8CPartPcs[1];
+	table[3] = m_table_desc0__8CPartPcs[2];
+	table[4] = m_table_desc1__8CPartPcs[0];
+	table[5] = m_table_desc1__8CPartPcs[1];
+	table[6] = m_table_desc1__8CPartPcs[2];
+	table[7] = m_table_desc2__8CPartPcs[0];
+	table[8] = m_table_desc2__8CPartPcs[1];
+	table[9] = m_table_desc2__8CPartPcs[2];
+	table[12] = m_table_desc3__8CPartPcs[0];
+	table[13] = m_table_desc3__8CPartPcs[1];
+	table[14] = m_table_desc3__8CPartPcs[2];
+	table[17] = m_table_desc4__8CPartPcs[0];
+	table[18] = m_table_desc4__8CPartPcs[1];
+	table[19] = m_table_desc4__8CPartPcs[2];
+	table[22] = m_table_desc5__8CPartPcs[0];
+	table[23] = m_table_desc5__8CPartPcs[1];
+	table[24] = m_table_desc5__8CPartPcs[2];
+	table[27] = m_table_desc6__8CPartPcs[0];
+	table[28] = m_table_desc6__8CPartPcs[1];
+	table[29] = m_table_desc6__8CPartPcs[2];
+	table[32] = m_table_desc7__8CPartPcs[0];
+	table[33] = m_table_desc7__8CPartPcs[1];
+	table[37] = m_table_desc8__8CPartPcs[1];
+	table[38] = m_table_desc8__8CPartPcs[2];
+	table[35] = m_table_desc7__8CPartPcs[2];
+	table[39] = m_table_desc8__8CPartPcs[0];
+	table[44] = m_table_desc9__8CPartPcs[1];
+	table[45] = m_table_desc9__8CPartPcs[2];
+	table[46] = m_table_desc9__8CPartPcs[0];
+	table[88] = m_table_desc10__8CPartPcs[0];
+	table[89] = m_table_desc10__8CPartPcs[1];
+	table[90] = m_table_desc10__8CPartPcs[2];
+	table[93] = m_table_desc11__8CPartPcs[0];
+	table[94] = m_table_desc11__8CPartPcs[1];
+	table[95] = m_table_desc11__8CPartPcs[2];
+	table[96] = m_table_desc12__8CPartPcs[0];
+	table[97] = m_table_desc12__8CPartPcs[1];
+	table[98] = m_table_desc12__8CPartPcs[2];
+	table[101] = m_table_desc13__8CPartPcs[0];
+	table[102] = m_table_desc13__8CPartPcs[1];
+	table[103] = m_table_desc13__8CPartPcs[2];
+	table[106] = m_table_desc14__8CPartPcs[0];
+	table[107] = m_table_desc14__8CPartPcs[1];
+	table[108] = m_table_desc14__8CPartPcs[2];
+	table[111] = m_table_desc15__8CPartPcs[0];
+	table[112] = m_table_desc15__8CPartPcs[1];
+	table[113] = m_table_desc15__8CPartPcs[2];
+	table[114] = m_table_desc16__8CPartPcs[0];
+	table[117] = m_table_desc17__8CPartPcs[0];
+	table[118] = m_table_desc17__8CPartPcs[1];
+	table[119] = m_table_desc17__8CPartPcs[2];
+	table[120] = m_table_desc16__8CPartPcs[1];
+	table[121] = m_table_desc16__8CPartPcs[2];
+	table[124] = m_table_desc18__8CPartPcs[0];
+	table[125] = m_table_desc18__8CPartPcs[1];
+	table[126] = m_table_desc18__8CPartPcs[2];
+}
+
 CPartPcs PartPcs;
 CProfile g_par_calc_prof(const_cast<char*>(s_no_name_8032fdcc));
 CProfile g_par_draw_prof(const_cast<char*>(s_no_name_8032fdcc));
@@ -329,74 +398,6 @@ static CPartMngState* GetPartMngState()
 static PppPdtSlotRaw* GetPartMngPdtSlots()
 {
     return reinterpret_cast<PppPdtSlotRaw*>(reinterpret_cast<char*>(&PartMng) + 0x22E18);
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-CPartPcs::CPartPcs()
-{
-	unsigned int* table = reinterpret_cast<unsigned int*>(m_table__8CPartPcs);
-
-	table[1] = m_table_desc0__8CPartPcs[0];
-	table[2] = m_table_desc0__8CPartPcs[1];
-	table[3] = m_table_desc0__8CPartPcs[2];
-	table[4] = m_table_desc1__8CPartPcs[0];
-	table[5] = m_table_desc1__8CPartPcs[1];
-	table[6] = m_table_desc1__8CPartPcs[2];
-	table[7] = m_table_desc2__8CPartPcs[0];
-	table[8] = m_table_desc2__8CPartPcs[1];
-	table[9] = m_table_desc2__8CPartPcs[2];
-	table[12] = m_table_desc3__8CPartPcs[0];
-	table[13] = m_table_desc3__8CPartPcs[1];
-	table[14] = m_table_desc3__8CPartPcs[2];
-	table[17] = m_table_desc4__8CPartPcs[0];
-	table[18] = m_table_desc4__8CPartPcs[1];
-	table[19] = m_table_desc4__8CPartPcs[2];
-	table[22] = m_table_desc5__8CPartPcs[0];
-	table[23] = m_table_desc5__8CPartPcs[1];
-	table[24] = m_table_desc5__8CPartPcs[2];
-	table[27] = m_table_desc6__8CPartPcs[0];
-	table[28] = m_table_desc6__8CPartPcs[1];
-	table[29] = m_table_desc6__8CPartPcs[2];
-	table[32] = m_table_desc7__8CPartPcs[0];
-	table[33] = m_table_desc7__8CPartPcs[1];
-	table[37] = m_table_desc8__8CPartPcs[1];
-	table[38] = m_table_desc8__8CPartPcs[2];
-	table[35] = m_table_desc7__8CPartPcs[2];
-	table[39] = m_table_desc8__8CPartPcs[0];
-	table[44] = m_table_desc9__8CPartPcs[1];
-	table[45] = m_table_desc9__8CPartPcs[2];
-	table[46] = m_table_desc9__8CPartPcs[0];
-	table[88] = m_table_desc10__8CPartPcs[0];
-	table[89] = m_table_desc10__8CPartPcs[1];
-	table[90] = m_table_desc10__8CPartPcs[2];
-	table[93] = m_table_desc11__8CPartPcs[0];
-	table[94] = m_table_desc11__8CPartPcs[1];
-	table[95] = m_table_desc11__8CPartPcs[2];
-	table[96] = m_table_desc12__8CPartPcs[0];
-	table[97] = m_table_desc12__8CPartPcs[1];
-	table[98] = m_table_desc12__8CPartPcs[2];
-	table[101] = m_table_desc13__8CPartPcs[0];
-	table[102] = m_table_desc13__8CPartPcs[1];
-	table[103] = m_table_desc13__8CPartPcs[2];
-	table[106] = m_table_desc14__8CPartPcs[0];
-	table[107] = m_table_desc14__8CPartPcs[1];
-	table[108] = m_table_desc14__8CPartPcs[2];
-	table[111] = m_table_desc15__8CPartPcs[0];
-	table[112] = m_table_desc15__8CPartPcs[1];
-	table[113] = m_table_desc15__8CPartPcs[2];
-	table[114] = m_table_desc16__8CPartPcs[0];
-	table[117] = m_table_desc17__8CPartPcs[0];
-	table[118] = m_table_desc17__8CPartPcs[1];
-	table[119] = m_table_desc17__8CPartPcs[2];
-	table[120] = m_table_desc16__8CPartPcs[1];
-	table[121] = m_table_desc16__8CPartPcs[2];
-	table[124] = m_table_desc18__8CPartPcs[0];
-	table[125] = m_table_desc18__8CPartPcs[1];
-	table[126] = m_table_desc18__8CPartPcs[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Change CPartPcs to inherit from CSamplePcs, matching the static init/vtable lineage used by nearby process classes.
- Move the CPartPcs constructor definition before the global PartPcs object so the constructor is visible at static initialization time.

## Evidence
- ninja passes for GCCP01.
- p_tina objdiff after change:
  - __sinit_p_tina_cpp: 12.235577% (unchanged)
  - __vt__8CPartPcs: 94.117645% (unchanged)
  - [extab-0]: improved from 41.044773% to 44.02985%
  - [extabindex-0]: improved from 40.414696% to 41.290558%

## Plausibility
- CSamplePcs is the common base for adjacent process classes such as CMaterialEditorPcs and CFunnyShapePcs.
- The target static initializer references the CSamplePcs vtable path, so this removes an incorrect direct CProcess inheritance assumption.