### PR TITLE
Match p_FunnyShape text order

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -86,90 +86,10 @@ static inline CFunnyShape* FunnyShape(CFunnyShapePcs* self)
 }
 } // namespace
 
-/*
- * --INFO--
- * PAL Address: 0x8004e844
- * PAL Size: 288b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-extern "C" void __sinit_p_FunnyShape_cpp(void)
-{
-    CFunnyShapePcs* pcs = reinterpret_cast<CFunnyShapePcs*>(&FunnyShapePcs);
-    u8* self = reinterpret_cast<u8*>(pcs);
-    unsigned int* dst = m_table__14CFunnyShapePcs;
-    unsigned int* desc0 = m_table_desc0__14CFunnyShapePcs;
-    unsigned int* desc1 = m_table_desc1__14CFunnyShapePcs;
-    unsigned int* desc2 = m_table_desc2__14CFunnyShapePcs;
-    unsigned int* desc3 = m_table_desc3__14CFunnyShapePcs;
-
-    *reinterpret_cast<void**>(self) = __vt__8CManager;
-    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
-    *reinterpret_cast<void**>(self) = __vt__14CFunnyShapePcs;
-
-    __ct__14CUSBStreamDataFv(self + 0x3C);
-    __ct__11CFunnyShapeFv(self + 0x50);
-    __ct__29CPtrArray_P15OSFS_TEXTURE_ST_Fv(self + 0x61BC);
-    __ct__22CPtrArray_P9_GXTexObj_Fv(self + 0x61D8);
-    __register_global_object(self, __dt__14CFunnyShapePcsFv, ARRAY_8026D728);
-    dst[1] = desc0[0];
-    dst[2] = desc0[1];
-    dst[3] = desc0[2];
-    dst[4] = desc1[0];
-    dst[5] = desc1[1];
-    dst[6] = desc1[2];
-    dst[7] = desc2[0];
-    dst[8] = desc2[1];
-    dst[9] = desc2[2];
-    dst[12] = desc3[0];
-    dst[13] = desc3[1];
-    dst[14] = desc3[2];
-}
-
-unsigned int m_table_desc0__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__14CFunnyShapePcsFv)};
-unsigned int m_table_desc1__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__14CFunnyShapePcsFv)};
-unsigned int m_table_desc2__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__14CFunnyShapePcsFv)};
-unsigned int m_table_desc3__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__14CFunnyShapePcsFv)};
-unsigned int m_table__14CFunnyShapePcs[0x15C / sizeof(unsigned int)] = {
-    reinterpret_cast<unsigned int>(const_cast<char*>(lbl_801D7DD0)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x21, 0, 0, 0, 0,
-    0x42, 1
-};
-unsigned int lbl_801EA904[4] = {
-    reinterpret_cast<unsigned int>(lbl_8032E660), 0, 0, reinterpret_cast<unsigned int>(lbl_8032E660)
-};
-u8 ARRAY_8026D728[0xC];
-u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];
-
 template <class T>
 CPtrArray<T>::CPtrArray()
 {
     vtable = 0;
-    numItems = 0;
-    size = 0;
-    defaultSize = 0x10;
-    items = 0;
-    stage = 0;
-    growCapacity = 1;
-}
-
-template <>
-CPtrArray<_GXTexObj*>::CPtrArray()
-{
-    vtable = gVtable_CPtrArray_GXTexObj;
-    numItems = 0;
-    size = 0;
-    defaultSize = 0x10;
-    items = 0;
-    stage = 0;
-    growCapacity = 1;
-}
-
-template <>
-CPtrArray<OSFS_TEXTURE_ST*>::CPtrArray()
-{
-    vtable = gVtable_CPtrArray_OSFSTexture;
     numItems = 0;
     size = 0;
     defaultSize = 0x10;
@@ -212,178 +132,6 @@ void CPtrArray<_GXTexObj*>::RemoveAll();
  */
 template <>
 void CPtrArray<OSFS_TEXTURE_ST*>::RemoveAll();
-
-/*
- * --INFO--
- * PAL Address: 0x8004e69c
- * PAL Size: 136b
- */
-template <>
-void CPtrArray<_GXTexObj*>::DeleteAndRemoveAll();
-
-/*
- * --INFO--
- * PAL Address: 0x8004e724
- * PAL Size: 136b
- */
-template <>
-void CPtrArray<OSFS_TEXTURE_ST*>::DeleteAndRemoveAll();
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-inline CFunnyShapePcs::CFunnyShapePcs()
-{
-    u8* self = reinterpret_cast<u8*>(this);
-
-    __ct__14CUSBStreamDataFv(self + 0x3C);
-    __ct__11CFunnyShapeFv(self + 0x50);
-    __ct__29CPtrArray_P15OSFS_TEXTURE_ST_Fv(self + 0x61BC);
-    __ct__22CPtrArray_P9_GXTexObj_Fv(self + 0x61D8);
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-CFunnyShapePcs::~CFunnyShapePcs()
-{
-    reinterpret_cast<CPtrArray<_GXTexObj*>*>(reinterpret_cast<u8*>(this) + 0x61D8)->~CPtrArray<_GXTexObj*>();
-    reinterpret_cast<CPtrArray<OSFS_TEXTURE_ST*>*>(reinterpret_cast<u8*>(this) + 0x61BC)->~CPtrArray<OSFS_TEXTURE_ST*>();
-    __dt__11CFunnyShapeFv(reinterpret_cast<CFunnyShape*>(reinterpret_cast<u8*>(this) + 0x50), -1);
-    __dt__14CUSBStreamDataFv(reinterpret_cast<CUSBStreamData*>(reinterpret_cast<u8*>(this) + 0x3C), -1);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8004e5e4
- * PAL Size: 184b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CFunnyShapePcs::Init()
-{
-    GXColor* colors = reinterpret_cast<GXColor*>(m_viewerState);
-    Vec* positions = reinterpret_cast<Vec*>(&m_viewerState[0x10]);
-
-    colors[0].r = 0x7F;
-    colors[0].g = 0x7F;
-    colors[0].b = 0x7F;
-    colors[0].a = 0xFF;
-
-    for (int i = 0; i < 3; i++) {
-        u8 shade = (i == 0) ? 0x3F : 0;
-
-        colors[i + 1].r = shade;
-        colors[i + 1].g = shade;
-        colors[i + 1].b = shade;
-        colors[i + 1].a = 0xFF;
-
-        positions[i].x = kFunnyShapeViewportOrigin;
-        positions[i].y = kFunnyShapeViewportOrigin;
-        positions[i].z = kFunnyShapeNdcMin;
-    }
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void CFunnyShapePcs::Quit()
-{
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8004e5cc
- * PAL Size: 20b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-int CFunnyShapePcs::GetTable(unsigned long index)
-{
-    return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(m_table__14CFunnyShapePcs) + index * 0x15C);
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void CFunnyShapePcs::createViewer()
-{
-    *reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x4)) =
-        Memory.CreateStage(0x200000, const_cast<char*>(s_CFunnyShapePcs), 0);
-    USBPcs.IsBigAlloc(1);
-
-    GXColor clearColor;
-    clearColor.r = 0x40;
-    clearColor.g = 0x40;
-    clearColor.b = 0x40;
-    clearColor.a = 0xFF;
-    GXSetCopyClear(clearColor, 0xFFFFFF);
-
-    memset(Ptr(this, 0x6178), 0, 0x40);
-    UsbStream(this)->CreateBuffer();
-    *reinterpret_cast<u32*>(Ptr(this, 0x61B8)) = 0;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8004e48c
- * PAL Size: 152b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CFunnyShapePcs::destroyViewer()
-{
-    USBPcs.IsBigAlloc(0);
-
-    GXColor clearColor;
-    clearColor.r = 0;
-    clearColor.g = 0;
-    clearColor.b = 0;
-    clearColor.a = 0;
-    GXSetCopyClear(clearColor, 0xFFFFFF);
-
-    reinterpret_cast<CPtrArray<OSFS_TEXTURE_ST*>*>(Ptr(this, 0x61BC))->DeleteAndRemoveAll();
-    reinterpret_cast<CPtrArray<_GXTexObj*>*>(Ptr(this, 0x61D8))->DeleteAndRemoveAll();
-
-    DeleteBuffer__14CUSBStreamDataFv(UsbStream(this));
-    __dt__11CFunnyShapeFv(FunnyShape(this), -1);
-    Memory.DestroyStage(*reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x4)));
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void CFunnyShapePcs::calcViewer()
-{
-    u8* self = reinterpret_cast<u8*>(this);
-
-    if (reinterpret_cast<CUSBStreamData*>(self + 0x3C)->IsUSBStreamDataDone()) {
-        SetUSBData();
-        reinterpret_cast<CUSBStreamData*>(self + 0x3C)->SetUSBStreamDataDone();
-    }
-
-    if ((static_cast<s8>(self[0x6124]) == 0) || (*reinterpret_cast<u32*>(self + 0x6134) == 0)) {
-        return;
-    }
-
-    reinterpret_cast<CFunnyShape*>(self + 0x50)->Update();
-}
 
 /*
  * --INFO--
@@ -438,6 +186,150 @@ void CFunnyShapePcs::drawViewer()
         Graphic.Printf(const_cast<char*>(s_funnyShapeFmt), pFan[frame % 4]);
     }
 }
+
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+void CFunnyShapePcs::calcViewer()
+{
+    u8* self = reinterpret_cast<u8*>(this);
+
+    if (reinterpret_cast<CUSBStreamData*>(self + 0x3C)->IsUSBStreamDataDone()) {
+        SetUSBData();
+        reinterpret_cast<CUSBStreamData*>(self + 0x3C)->SetUSBStreamDataDone();
+    }
+
+    if ((static_cast<s8>(self[0x6124]) == 0) || (*reinterpret_cast<u32*>(self + 0x6134) == 0)) {
+        return;
+    }
+
+    reinterpret_cast<CFunnyShape*>(self + 0x50)->Update();
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004e48c
+ * PAL Size: 152b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CFunnyShapePcs::destroyViewer()
+{
+    USBPcs.IsBigAlloc(0);
+
+    GXColor clearColor;
+    clearColor.r = 0;
+    clearColor.g = 0;
+    clearColor.b = 0;
+    clearColor.a = 0;
+    GXSetCopyClear(clearColor, 0xFFFFFF);
+
+    reinterpret_cast<CPtrArray<OSFS_TEXTURE_ST*>*>(Ptr(this, 0x61BC))->DeleteAndRemoveAll();
+    reinterpret_cast<CPtrArray<_GXTexObj*>*>(Ptr(this, 0x61D8))->DeleteAndRemoveAll();
+
+    DeleteBuffer__14CUSBStreamDataFv(UsbStream(this));
+    __dt__11CFunnyShapeFv(FunnyShape(this), -1);
+    Memory.DestroyStage(*reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x4)));
+}
+
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+void CFunnyShapePcs::createViewer()
+{
+    *reinterpret_cast<CMemory::CStage**>(Ptr(this, 0x4)) =
+        Memory.CreateStage(0x200000, const_cast<char*>(s_CFunnyShapePcs), 0);
+    USBPcs.IsBigAlloc(1);
+
+    GXColor clearColor;
+    clearColor.r = 0x40;
+    clearColor.g = 0x40;
+    clearColor.b = 0x40;
+    clearColor.a = 0xFF;
+    GXSetCopyClear(clearColor, 0xFFFFFF);
+
+    memset(Ptr(this, 0x6178), 0, 0x40);
+    UsbStream(this)->CreateBuffer();
+    *reinterpret_cast<u32*>(Ptr(this, 0x61B8)) = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004e5cc
+ * PAL Size: 20b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+int CFunnyShapePcs::GetTable(unsigned long index)
+{
+    return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(m_table__14CFunnyShapePcs) + index * 0x15C);
+}
+
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+void CFunnyShapePcs::Quit()
+{
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004e5e4
+ * PAL Size: 184b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CFunnyShapePcs::Init()
+{
+    GXColor* colors = reinterpret_cast<GXColor*>(m_viewerState);
+    Vec* positions = reinterpret_cast<Vec*>(&m_viewerState[0x10]);
+
+    colors[0].r = 0x7F;
+    colors[0].g = 0x7F;
+    colors[0].b = 0x7F;
+    colors[0].a = 0xFF;
+
+    for (int i = 0; i < 3; i++) {
+        u8 shade = (i == 0) ? 0x3F : 0;
+
+        colors[i + 1].r = shade;
+        colors[i + 1].g = shade;
+        colors[i + 1].b = shade;
+        colors[i + 1].a = 0xFF;
+
+        positions[i].x = kFunnyShapeViewportOrigin;
+        positions[i].y = kFunnyShapeViewportOrigin;
+        positions[i].z = kFunnyShapeNdcMin;
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004e69c
+ * PAL Size: 136b
+ */
+template <>
+void CPtrArray<_GXTexObj*>::DeleteAndRemoveAll();
+
+/*
+ * --INFO--
+ * PAL Address: 0x8004e724
+ * PAL Size: 136b
+ */
+template <>
+void CPtrArray<OSFS_TEXTURE_ST*>::DeleteAndRemoveAll();
 
 /*
  * --INFO--
@@ -507,5 +399,124 @@ void CPtrArray<OSFS_TEXTURE_ST*>::RemoveAll()
     size = 0;
 }
 
-template class CPtrArray<_GXTexObj*>;
-template class CPtrArray<OSFS_TEXTURE_ST*>;
+/*
+ * --INFO--
+ * PAL Address: 0x8004e844
+ * PAL Size: 288b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void __sinit_p_FunnyShape_cpp(void)
+{
+    CFunnyShapePcs* pcs = reinterpret_cast<CFunnyShapePcs*>(&FunnyShapePcs);
+    u8* self = reinterpret_cast<u8*>(pcs);
+    unsigned int* dst = m_table__14CFunnyShapePcs;
+    unsigned int* desc0 = m_table_desc0__14CFunnyShapePcs;
+    unsigned int* desc1 = m_table_desc1__14CFunnyShapePcs;
+    unsigned int* desc2 = m_table_desc2__14CFunnyShapePcs;
+    unsigned int* desc3 = m_table_desc3__14CFunnyShapePcs;
+
+    *reinterpret_cast<void**>(self) = __vt__8CManager;
+    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
+    *reinterpret_cast<void**>(self) = __vt__14CFunnyShapePcs;
+
+    __ct__14CUSBStreamDataFv(self + 0x3C);
+    __ct__11CFunnyShapeFv(self + 0x50);
+    __ct__29CPtrArray_P15OSFS_TEXTURE_ST_Fv(self + 0x61BC);
+    __ct__22CPtrArray_P9_GXTexObj_Fv(self + 0x61D8);
+    __register_global_object(self, __dt__14CFunnyShapePcsFv, ARRAY_8026D728);
+    dst[1] = desc0[0];
+    dst[2] = desc0[1];
+    dst[3] = desc0[2];
+    dst[4] = desc1[0];
+    dst[5] = desc1[1];
+    dst[6] = desc1[2];
+    dst[7] = desc2[0];
+    dst[8] = desc2[1];
+    dst[9] = desc2[2];
+    dst[12] = desc3[0];
+    dst[13] = desc3[1];
+    dst[14] = desc3[2];
+}
+
+unsigned int m_table_desc0__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__14CFunnyShapePcsFv)};
+unsigned int m_table_desc1__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__14CFunnyShapePcsFv)};
+unsigned int m_table_desc2__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__14CFunnyShapePcsFv)};
+unsigned int m_table_desc3__14CFunnyShapePcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__14CFunnyShapePcsFv)};
+unsigned int m_table__14CFunnyShapePcs[0x15C / sizeof(unsigned int)] = {
+    reinterpret_cast<unsigned int>(const_cast<char*>(lbl_801D7DD0)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x21, 0, 0, 0, 0,
+    0x42, 1
+};
+unsigned int lbl_801EA904[4] = {
+    reinterpret_cast<unsigned int>(lbl_8032E660), 0, 0, reinterpret_cast<unsigned int>(lbl_8032E660)
+};
+u8 ARRAY_8026D728[0xC];
+u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];
+
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+CFunnyShapePcs::~CFunnyShapePcs()
+{
+    reinterpret_cast<CPtrArray<_GXTexObj*>*>(reinterpret_cast<u8*>(this) + 0x61D8)->~CPtrArray<_GXTexObj*>();
+    reinterpret_cast<CPtrArray<OSFS_TEXTURE_ST*>*>(reinterpret_cast<u8*>(this) + 0x61BC)->~CPtrArray<OSFS_TEXTURE_ST*>();
+    __dt__11CFunnyShapeFv(reinterpret_cast<CFunnyShape*>(reinterpret_cast<u8*>(this) + 0x50), -1);
+    __dt__14CUSBStreamDataFv(reinterpret_cast<CUSBStreamData*>(reinterpret_cast<u8*>(this) + 0x3C), -1);
+}
+
+template <>
+CPtrArray<_GXTexObj*>::CPtrArray()
+{
+    vtable = gVtable_CPtrArray_GXTexObj;
+    numItems = 0;
+    size = 0;
+    defaultSize = 0x10;
+    items = 0;
+    stage = 0;
+    growCapacity = 1;
+}
+
+template <>
+CPtrArray<_GXTexObj*>::~CPtrArray()
+{
+    SetPtrArrayDtorVtable(this);
+    RemoveAll();
+}
+
+template <>
+CPtrArray<OSFS_TEXTURE_ST*>::CPtrArray()
+{
+    vtable = gVtable_CPtrArray_OSFSTexture;
+    numItems = 0;
+    size = 0;
+    defaultSize = 0x10;
+    items = 0;
+    stage = 0;
+    growCapacity = 1;
+}
+
+template <>
+CPtrArray<OSFS_TEXTURE_ST*>::~CPtrArray()
+{
+    SetPtrArrayDtorVtable(this);
+    RemoveAll();
+}
+
+/*
+ * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+inline CFunnyShapePcs::CFunnyShapePcs()
+{
+    u8* self = reinterpret_cast<u8*>(this);
+
+    __ct__14CUSBStreamDataFv(self + 0x3C);
+    __ct__11CFunnyShapeFv(self + 0x50);
+    __ct__29CPtrArray_P15OSFS_TEXTURE_ST_Fv(self + 0x61BC);
+    __ct__22CPtrArray_P9_GXTexObj_Fv(self + 0x61D8);
+}


### PR DESCRIPTION
## Summary
- Reordered p_FunnyShape function definitions to follow the target object text order.
- Moved __sinit_p_FunnyShape_cpp and CFunnyShapePcs/CPtrArray helpers to the later cluster used by the target.
- Kept function bodies unchanged; this is source-order/linkage recovery, not compiler coaxing.

## Evidence
- ninja succeeds.
- p_FunnyShape report remains stable: fuzzy 98.666664%, data 97.0162%.
- Before: source extabindex started with __sinit_p_FunnyShape_cpp, __dt__14CFunnyShapePcsFv, createViewer, destroyViewer, calcViewer, drawViewer.
- After: source extabindex starts with drawViewer, calcViewer, destroyViewer, createViewer, then the CPtrArray helper cluster, matching the target order through the main function cluster.
- objdiff target check: __sinit_p_FunnyShape_cpp remains 86.02778% match, size 288b.

## Plausibility
Metrowerks emits functions and extabindex entries in source definition order. The new order mirrors config/GCCP01/symbols.txt and the target object layout while preserving existing source bodies.