### PR TITLE
Match small cflat_r2system helpers

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1059,12 +1059,13 @@ extern "C" void ReqScreenCapture__11CGraphicPcsFv(void* graphicPcs)
  */
 extern "C" int IsUse__8CMesMenuFv(void* mesMenu)
 {
-    if (*(int*)((char*)mesMenu + 8) != 0 && *(int*)((char*)mesMenu + 0xC) < 2 &&
+    unsigned char result = 0;
+    if (*(int*)((char*)mesMenu + 8) != 0 && *(int*)((char*)mesMenu + 0xC) <= 1 &&
         GetWait__4CMesFv((char*)mesMenu + 0x1C) != 4) {
-        return 1;
+        result = 1;
     }
 
-    return 0;
+    return result;
 }
 
 /*

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1332,7 +1332,7 @@ void VECLerp(Vec* a, Vec* b, Vec* out, float t)
     Vec scaledA;
     Vec scaledB;
 
-    PSVECScale(a, &scaledA, 1.0f - t);
+    PSVECScale(a, &scaledA, FLOAT_80330B34 - t);
     PSVECScale(b, &scaledB, t);
     PSVECAdd(&scaledA, &scaledB, out);
 }


### PR DESCRIPTION
## Summary
- Match `IsUse__8CMesMenuFv` by preserving the target's byte-sized result temp and `<= 1` state check.
- Match `VECLerp__FP3VecP3VecP3Vecf` by using the shared `FLOAT_80330B34` one constant.

## Evidence
- Before: `IsUse__8CMesMenuFv` was 84.0%; after: 100.0% (88b).
- Before: `VECLerp__FP3VecP3VecP3Vecf` was 99.833%; after: 100.0% (120b).
- `ninja` passes; progress reports 3,286 matched functions and 540,844 matched code bytes.

## Plausibility
- The `IsUse` change reflects the decompiled target's explicit local result byte and equivalent state comparison.
- The `VECLerp` change reuses an existing unit float symbol already used elsewhere in this source instead of emitting a local literal.
