### PR TITLE
Fix pppScreenBreak CPtrArray redeclaration

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -137,13 +137,6 @@ static inline Mtx44Ptr CameraScreenMatrix() { return reinterpret_cast<Mtx44Ptr>(
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 static inline int GraphicScreenBreakBlurEnabled() { return Graphic.m_blurActive; }
 
-template <typename T>
-class CPtrArray
-{
-public:
-    T operator[](unsigned long);
-};
-
 extern "C" {
 int GetBackBufferRect2__8CGraphicFPvP9_GXTexObjiiiii12_GXTexFilter9_GXTexFmti(
     CGraphic*, void*, _GXTexObj*, int, int, int, int, int, int, int, int);


### PR DESCRIPTION
## Summary
- Remove the duplicate local CPtrArray template declaration in src/pppScreenBreak.cpp.
- Restores PAL GCCP01 build after updated main failed compiling pppScreenBreak.cpp with a CPtrArray tag redefinition.

## Evidence
- Before: ninja failed at build/GCCP01/src/pppScreenBreak.o with "struct/union/enum/class tag 'CPtrArray' redefined".
- After: ninja succeeds and reports build/GCCP01/main.dol: OK.
- Objdiff for main/pppScreenBreak now runs normally; .text remains 93.22212% and data sections are unchanged/matching where expected.

## Plausibility
- The file already had an identical CPtrArray template declaration earlier in the same translation unit. Removing the duplicate keeps the existing source-level helper and avoids any linkage, section, ctor/dtor, or address hacks.