### PR TITLE
Fix duplicate CPtrArray declaration in pppScreenBreak

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -137,13 +137,6 @@ static inline Mtx44Ptr CameraScreenMatrix() { return reinterpret_cast<Mtx44Ptr>(
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 static inline int GraphicScreenBreakBlurEnabled() { return Graphic.m_blurActive; }
 
-template <typename T>
-class CPtrArray
-{
-public:
-    T operator[](unsigned long);
-};
-
 extern "C" {
 int GetBackBufferRect2__8CGraphicFPvP9_GXTexObjiiiii12_GXTexFilter9_GXTexFmti(
     CGraphic*, void*, _GXTexObj*, int, int, int, int, int, int, int, int);


### PR DESCRIPTION
## Summary
- Remove the second local CPtrArray template declaration from src/pppScreenBreak.cpp.
- This unblocks the GCCP01 build after main started failing in pppScreenBreak.cpp with a redefined CPtrArray tag error.

## Evidence
- Before: ninja stopped at build/GCCP01/src/pppScreenBreak.o with 'struct/union/enum/class tag CPtrArray redefined'.
- After: ninja completes and build/GCCP01/main.dol checks OK.
- Objdiff sanity check for main/pppScreenBreak still reports pppRenderScreenBreak, pppFrameScreenBreak, pppDesScreenBreak, pppCon2ScreenBreak, pppConScreenBreak, and SB_BeforeMeshLockEnvCallback at 100%.

## Plausibility
- The file already has an identical CPtrArray declaration earlier in the same translation unit; removing the duplicate preserves the existing source shape and changes no generated code for the matched pppScreenBreak functions.