### PR TITLE
Use CProcess vtables in PCS initializers

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -57,7 +57,7 @@ extern "C" void drawViewer__14CFunnyShapePcsFv(CFunnyShapePcs*);
 extern "C" CFunnyShape* __dt__11CFunnyShapeFv(CFunnyShape*, short);
 extern "C" void __dt__14CFunnyShapePcsFv(void*);
 extern "C" void* __vt__8CManager[];
-extern "C" void* __vt__10CSamplePcs[];
+extern "C" void* __vt__8CProcess[];
 extern "C" void* gVtable_CPtrArray_OSFSTexture[];
 extern "C" void* gVtable_CPtrArray_GXTexObj[];
 extern "C" void* __vt__14CFunnyShapePcs[];
@@ -421,7 +421,7 @@ extern "C" void __sinit_p_FunnyShape_cpp(void)
     unsigned int* desc3 = m_table_desc3__14CFunnyShapePcs;
 
     *reinterpret_cast<void**>(self) = __vt__8CManager;
-    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
+    *reinterpret_cast<void**>(self) = __vt__8CProcess;
     *reinterpret_cast<void**>(self) = __vt__14CFunnyShapePcs;
 
     __ct__14CUSBStreamDataFv(self + 0x3C);

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -25,7 +25,7 @@ extern "C" void calcViewer__18CMaterialEditorPcsFv(CMaterialEditorPcs*);
 extern "C" void drawViewer__18CMaterialEditorPcsFv(CMaterialEditorPcs*);
 extern "C" void __dt__18CMaterialEditorPcsFv(void* self);
 extern "C" void* __vt__8CManager[];
-extern "C" void* __vt__10CSamplePcs[];
+extern "C" void* __vt__8CProcess[];
 extern "C" char lbl_8032E648[];
 extern "C" const char s_CMaterialEditorPcs_VIEWER_801D7D18[];
 extern "C" const char s_CMaterialEditorPcs_801D7D34[];
@@ -63,7 +63,7 @@ extern "C" void __sinit_p_MaterialEditor_cpp(void)
     unsigned int* desc3 = m_table_desc3__18CMaterialEditorPcs;
 
     *reinterpret_cast<void**>(self) = __vt__8CManager;
-    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
+    *reinterpret_cast<void**>(self) = __vt__8CProcess;
     *reinterpret_cast<void**>(self) = __vt__18CMaterialEditorPcs;
 
     __ct__14CUSBStreamDataFv(self + 0x84);

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -7,7 +7,7 @@
 #include "types.h"
 
 extern "C" void* __vt__8CManager[];
-extern "C" void* __vt__10CSamplePcs[];
+extern "C" void* __vt__8CProcess[];
 extern "C" void* __vt__7CUSBPcs[];
 extern const char lbl_801DA074[];
 int s_usbReadPollFrameCounter;
@@ -293,7 +293,7 @@ extern "C" void __sinit_p_usb_cpp(void)
     unsigned int* desc2 = m_table_desc2__7CUSBPcs;
 
     *reinterpret_cast<void**>(self) = __vt__8CManager;
-    *reinterpret_cast<void**>(self) = __vt__10CSamplePcs;
+    *reinterpret_cast<void**>(self) = __vt__8CProcess;
     *reinterpret_cast<void**>(self) = __vt__7CUSBPcs;
 
     dst[1] = desc0[0];


### PR DESCRIPTION
## Summary
- Align p_FunnyShape, p_MaterialEditor, and p_usb static initializers with their CProcess base vtable staging.
- Removes stale CSamplePcs vtable writes from these PCS singleton constructors.

## Objdiff evidence
- main/p_FunnyShape __sinit_p_FunnyShape_cpp: 86.02778% -> 86.166664% (288b)
- main/p_MaterialEditor __sinit_p_MaterialEditor_cpp: 75.22857% -> 75.37143% (280b)
- main/p_usb __sinit_p_usb_cpp remains 70.38636% (176b), but the initializer now matches the header-declared CProcess base and the target vtable staging.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - --format json __sinit_p_FunnyShape_cpp
- build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - --format json __sinit_p_MaterialEditor_cpp
- build/tools/objdiff-cli diff -p . -u main/p_usb -o - --format json __sinit_p_usb_cpp