### PR TITLE
Improve MLstCtrl close animation setup

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -386,9 +386,11 @@ void CMenuPcs::MLstCtrl()
 
 	startFrame = 0;
 	duration = 4;
+	MenuLstEntry* closeEntry = &this->lstData->entries[this->lstData->count - 1];
 	for (int idx = this->lstData->count - 1; idx >= 0; idx--) {
-		this->lstData->entries[idx].startFrame = startFrame++;
-		this->lstData->entries[idx].duration = duration;
+		closeEntry->startFrame = startFrame++;
+		closeEntry->duration = duration;
+		closeEntry--;
 	}
 
 	this->lstState->frame = 0;


### PR DESCRIPTION
## Summary
- Update MLstCtrl close-animation setup to walk entries backward with a moving pointer instead of repeated indexed access.
- This better matches the target backward traversal shape for assigning start frames and durations.

## Evidence
- Built with ninja.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstCtrl__8CMenuPcsFv
- MLstCtrl improved from 77.42601% to 78.15695%.
- Neighboring menu_lst functions unchanged: MLstDraw 74.002785%, MLstClose 80.700935%, MLstOpen 83.30556%.

## Plausibility
- The code remains straightforward source: a close-animation pass over list entries from last to first.
- It removes repeated indexed member access in favor of the pointer walk shown by the decompiled target shape.