### PR TITLE
Improve item object matching

### DIFF
--- a/include/ffcc/itemobj.h
+++ b/include/ffcc/itemobj.h
@@ -28,7 +28,7 @@ public:
 	void onCancelStat(int);
 	void onFrame();
 	void onFrameStat();
-	int DeleteOld(int, int, CFlatRuntime::CObject*, CFlatRuntime::CObject*);
+	static int DeleteOld(int, int, CFlatRuntime::CObject*, CFlatRuntime::CObject*);
 	unsigned int CanCreateFromScript();
 	CGPrgObj* CreateFromScript(int, int, int, CGObject*, float, CGItemObj::CCFS*);
 	void safeDetach(int, float);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2485,9 +2485,8 @@ void CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemF
     case -0xB3:
         runtime->push(
             object,
-            reinterpret_cast<CGItemObj*>(object->m_engineObject)
-                ->DeleteOld(*object->m_localBase, object->m_localBase[1], object,
-                    reinterpret_cast<CFlatRuntime::CObject*>(object->m_engineObject)));
+            CGItemObj::DeleteOld(*object->m_localBase, object->m_localBase[1], object,
+                                 reinterpret_cast<CFlatRuntime::CObject*>(object->m_engineObject)));
         outResult = 0;
         return;
     case -0xB2:

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -760,21 +760,18 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 {
 	int deletedCount = 0;
 
-	while (true) {
-		if (maxDeleteCount <= deletedCount) {
-			return deletedCount;
-		}
-
+	while (deletedCount < maxDeleteCount) {
 		int bestScriptObjectPos = 0x00989680;
 		unsigned char* bestItemObj = 0;
 
 		for (unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat);
 			 itemObj != 0;
 			 itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
-			if (*(int*)(itemObj + 0x44) == 0 &&
-				(int)(((unsigned int)itemObj[0x50] << 0x1c) | ((unsigned int)itemObj[0x50] >> 4)) < 0 &&
-				(((int)(char)itemObj[0x53] & deleteMask) != 0) && *(int*)(itemObj + 0x48) < bestScriptObjectPos) {
-				bestScriptObjectPos = *(int*)(itemObj + 0x48);
+			if (*(void**)(itemObj + 0x550) == 0 &&
+				static_cast<signed char>(
+				    static_cast<int>((static_cast<unsigned int>(itemObj[0x50]) << 28) & 0xC0000000) >> 31) != 0 &&
+				(((int)(char)itemObj[0x53] & deleteMask) != 0) && *(int*)(itemObj + 0x94) < bestScriptObjectPos) {
+				bestScriptObjectPos = *(int*)(itemObj + 0x94);
 				bestItemObj = itemObj;
 			}
 		}

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1471,7 +1471,9 @@ void CGItemObj::DispAllFieldItem(int show)
 	     itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
 		void* owner = *(void**)(itemObj + 0x550);
 
-		if (owner == 0 && (int)(((unsigned int)itemObj[0x50] << 0x1c) | ((unsigned int)itemObj[0x50] >> 4)) < 0) {
+		if (owner == 0 &&
+		    static_cast<signed char>(
+		        static_cast<int>((static_cast<unsigned int>(itemObj[0x50]) << 28) & 0xC0000000) >> 31) != 0) {
 			if (show != 0) {
 				*(unsigned int*)(itemObj + 0x60) &= 0xffbfffff;
 			} else {


### PR DESCRIPTION
## Summary
- Match `CGItemObj::DispAllFieldItem` by replacing the rotated sign check with the masked bit-extract form PAL emits.
- Improve `CGItemObj::DeleteOld` by making it static, correcting the item owner/script-position offsets, using a structured deletion-count loop, and applying the same flag extraction idiom.
- Update the CFlat system call site for the static `DeleteOld` signature.

## Evidence
- `ninja` succeeds.
- `DispAllFieldItem__9CGItemObjFi`: 95.48781% -> 100.0%, 164b exact match.
- `DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject`: 78.96923% -> 86.0%, size 260b.
- Build report now shows one additional matched game function and +164 matched game-code bytes.

## Plausibility
- The flag checks now use the same explicit masked sign-bit extraction pattern already present elsewhere in the codebase.
- `DeleteOld` does not use instance state and PAL register use treats `r3/r4` as explicit integer parameters, so the static declaration removes a fake receiver.
- The corrected offsets align with existing `CGItemObj` owner usage and the PAL object access pattern.
