### PR TITLE
Improve item script creation and post-calc matching

### DIFF
--- a/include/ffcc/itemobj.h
+++ b/include/ffcc/itemobj.h
@@ -29,8 +29,8 @@ public:
 	void onFrame();
 	void onFrameStat();
 	static int DeleteOld(int, int, CFlatRuntime::CObject*, CFlatRuntime::CObject*);
-	unsigned int CanCreateFromScript();
-	CGPrgObj* CreateFromScript(int, int, int, CGObject*, float, CGItemObj::CCFS*);
+	static unsigned int CanCreateFromScript();
+	static CGPrgObj* CreateFromScript(int, int, int, CGObject*, float, CGItemObj::CCFS*);
 	void safeDetach(int, float);
 	void carry(CGPartyObj*, int, int);
 	void onChangePrg(int);

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -825,44 +825,40 @@ CGPrgObj* CGItemObj::CreateFromScript(
 
 	if (freeItemCount == 0) {
 		int deletedCount = 0;
+		int bestScriptObjectPos = 0x00989680;
 		unsigned char* bestItemObj = 0;
-		void* bestScriptPos = reinterpret_cast<void*>(0x00989680);
 
 		for (unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat);
 		     itemObj != 0;
 		     itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
-			int isActive = (itemObj[0x50] & 8) != 0;
 			int canDelete = (itemObj[0x53] & 1) != 0;
-			int scriptPos = *(int*)(itemObj + 0x48);
+			int scriptObjectPos = *(int*)(itemObj + 0x94);
 
-			if (*(int*)(itemObj + 0x44) == 0 && isActive != 0 && canDelete != 0 &&
-			    scriptPos < (int)bestScriptPos) {
-				bestScriptPos = (void*)scriptPos;
+			if (*(void**)(itemObj + 0x550) == 0 &&
+			    static_cast<signed char>(
+			        static_cast<int>((static_cast<unsigned int>(itemObj[0x50]) << 28) & 0xC0000000) >> 31) != 0 &&
+			    canDelete != 0 && scriptObjectPos < bestScriptObjectPos) {
+				bestScriptObjectPos = scriptObjectPos;
 				bestItemObj = itemObj;
 			}
 		}
 
-		if (bestItemObj == 0) {
-			if ((unsigned int)System.m_execParam > 2U) {
-				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
-			}
-		} else {
+		if (bestItemObj != 0) {
 			deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
 			deletedCount = 1;
+		} else {
+			if (2U < (unsigned int)System.m_execParam) {
+				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
+			}
 		}
 
 		Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dcef8), deletedCount);
 		if (deletedCount == 0) {
-			if ((unsigned int)System.m_execParam > 2U) {
+			if (2U < (unsigned int)System.m_execParam) {
 				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dcf10));
 			}
 			return 0;
 		}
-	}
-
-	int ownerParticleId = 0;
-	if (owner != 0) {
-		ownerParticleId = *(short*)((unsigned char*)owner + 0x30);
 	}
 
 	gItemObjCreateFlags = createFlags;
@@ -948,7 +944,6 @@ CGPrgObj* CGItemObj::CreateFromScript(
 		*(int*)(itemSelf + 0x574) = (int)ccfsData[0];
 	}
 
-	(void)ownerParticleId;
 	return newItem;
 }
 
@@ -1447,7 +1442,9 @@ void CGItemObj::DeleteAllFieldItem()
 	     itemObj = (unsigned char*)FindGItemObjNext__13CFlatRuntime2FP9CGItemObj(CFlat, itemObj)) {
 		void* owner = *(void**)(itemObj + 0x550);
 
-		if (owner == 0 && (itemObj[0x50] & 8) != 0) {
+		if (owner == 0 &&
+		    static_cast<signed char>(
+		        static_cast<int>((static_cast<unsigned int>(itemObj[0x50]) << 28) & 0xC0000000) >> 31) != 0) {
 			itemObj[0x38] |= 0x80;
 		}
 	}

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -278,8 +278,12 @@ void CGItemObj::onFramePreCalc()
  */
 void CGItemObj::onFramePostCalc()
 {
-	if (m_stateFlags0Bits.unk4 != 0 && m_owner == 0) {
-		*(int*)((u8*)this + 0x94) = *(int*)((u8*)this + 0x94) - 1;
+	unsigned char* self = (unsigned char*)this;
+
+	if (static_cast<signed char>(
+	        static_cast<int>((static_cast<unsigned int>(self[0x50]) << 28) & 0xC0000000) >> 31) != 0 &&
+	    *(void**)(self + 0x550) == 0) {
+		*(int*)(self + 0x94) = *(int*)(self + 0x94) - 1;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Mark CGItemObj script creation helpers as static to match shipped call sites.
- Update CreateFromScript's old-item deletion scan to use the real item owner field, script object position, and the same state flag test used by the matched field-item helpers.
- Match CGItemObj::onFramePostCalc by using the target state flag expression and owner field check.

## Objdiff evidence
Against current origin/main:
- CreateFromScript__9CGItemObjFiiiP8CGObjectfPQ29CGItemObj4CCFS: 79.2774% -> 82.928085%
- onFramePostCalc__9CGItemObjFv: 82.5% -> 100.0%
- onFrameStat__9CGItemObjFv: 53.078453% -> 53.99063% from the corrected static CreateFromScript call shape
- Project code matched: 545428 -> 545476 bytes
- Matched functions: 3298 -> 3299

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/itemobj -o -