### PR TITLE
Fix FunnyShape viewer eye vector

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -146,7 +146,7 @@ void CFunnyShapePcs::drawViewer()
 {
     Mtx44 ortho;
     Mtx view;
-    Vec eye = {0.0f, 0.0f, 0.0f};
+    Vec eye = {0.0f, 0.0f, 4.0f};
     Vec at = {0.0f, 0.0f, 0.0f};
     Vec up = {0.0f, 1.0f, 0.0f};
     static const char s_funnyShapeFmt[] = "FunnyShape [%c]";


### PR DESCRIPTION
## Summary
- Correct `CFunnyShapePcs::drawViewer` camera eye vector to `{0.0f, 0.0f, 4.0f}`.
- This matches the target rodata constant at `lbl_801D7DD0 + 0x20` and leaves generated text unchanged.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o -`
  - `.text`: unchanged at `98.21151%`
  - `.rodata`: `61.068703% -> 62.59542%`
  - `[.rodata-0]`: `59.92509% -> 61.423218%`
- `drawViewer__14CFunnyShapePcsFv` direct diff remains `528b`, `99.53788%`.

## Plausibility
The original object initializes the viewer eye vector with `z = 4.0f`; the previous source had all-zero eye coordinates. This is a straightforward source correction, not compiler coaxing.