### PR TITLE
Match GbaQueue hit info channel masks

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -4695,7 +4695,7 @@ static inline OSSemaphore* AccessSemaphoreAt(GbaQueue* self, unsigned int channe
 
 unsigned int GbaQueue::GetChgHitFlg(int channel)
 {
-	int singleMode = m_singleMode;
+	signed char singleMode = m_singleMode;
 	unsigned int actualChannel = static_cast<unsigned int>(channel) &
 	                             ~static_cast<unsigned int>((-singleMode | singleMode) >> 31);
 	OSSemaphore* semaphore = accessSemaphores + actualChannel;
@@ -4789,7 +4789,7 @@ void GbaQueue::SetHitEnemy(int channel, int enemyIdx)
  */
 int GbaQueue::GetHitEInfo(int channel)
 {
-	int singleMode = m_singleMode;
+	signed char singleMode = m_singleMode;
 	unsigned int actualChannel = static_cast<unsigned int>(channel) &
 	                             ~static_cast<unsigned int>((-singleMode | singleMode) >> 31);
 	OSSemaphore* semaphore = accessSemaphores + actualChannel;


### PR DESCRIPTION
## Summary
- use signed-char single-mode temporaries in GbaQueue hit flag/info channel masking
- matches the signed byte behavior shown in the decompile and improves register selection for the channel mask path

## Evidence
- ninja
- GetHitEInfo__8GbaQueueFi: 99.69697% -> 100.0% (132 bytes matched)
- GetChgHitFlg__8GbaQueueFi: 99.117645% -> 99.411766%
- build report matched functions: 3298 -> 3299; matched code: 545428 -> 545560 bytes