### PR TITLE
Improve CGraphic back buffer texture format matching

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1466,30 +1466,28 @@ void CGraphic::GetBackBufferRect2(void* dstBuffer, _GXTexObj* texObj, int x, int
     GXPixModeSync();
     GXInvalidateTexAll();
 
-    int initFormat = format;
     switch (format) {
     case GX_CTF_R4:
     case GX_CTF_RA4:
-        initFormat = 0;
+        format = GX_TF_I4;
         break;
     case GX_CTF_RA8:
     case GX_CTF_A8:
     case GX_CTF_R8:
     case GX_CTF_G8:
     case GX_CTF_B8:
-        initFormat = 1;
+        format = GX_TF_I8;
         break;
     case GX_CTF_RG8:
     case GX_CTF_GB8:
-        initFormat = 3;
+        format = GX_TF_IA8;
         break;
     default:
         break;
     }
 
     if (texObj != nullptr) {
-        GXInitTexObj(texObj, textureBase, width & 0xFFFF, height & 0xFFFF, static_cast<_GXTexFmt>(initFormat), GX_CLAMP,
-                     GX_CLAMP, GX_FALSE);
+        GXInitTexObj(texObj, textureBase, width & 0xFFFF, height & 0xFFFF, format, GX_CLAMP, GX_CLAMP, GX_FALSE);
         GXInitTexObjLOD(texObj, filter, filter, kGraphicZeroF, kGraphicZeroF, kGraphicZeroF, GX_FALSE, GX_FALSE,
                         GX_ANISO_1);
     }


### PR DESCRIPTION
## Summary
- Reuse the copy texture format parameter in CGraphic::GetBackBufferRect2 after converting CTF formats to texture formats.
- Removes the separate initFormat local so the source better matches the decompiled parameter-mutation shape used for GXInitTexObj.

## Objdiff evidence
- main/graphic GetBackBufferRect2__8CGraphicFPvP9_GXTexObjiiiii12_GXTexFilter9_GXTexFmti: 76.89815% -> 78.00926%
- main/graphic .text: 89.022575% -> 89.05407%
- Size unchanged: 432 bytes

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/graphic -o - GetBackBufferRect2__8CGraphicFPvP9_GXTexObjiiiii12_GXTexFilter9_GXTexFmti