### PR TITLE
Match GbaQueue hit info accessor

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -171,7 +171,7 @@ private:
     char cmakeInfo[4][0x20];          // 0x2CB2
     unsigned char _pad2D32[0x12];     // 0x2D32
     GbaQueueHitInfo m_hitInfo[4];      // 0x2D44
-    unsigned char m_chgHitFlags;      // 0x2D54
+    char m_chgHitFlags;               // 0x2D54
     unsigned char m_chgScouFlags;     // 0x2D55
     char m_singleMode;                // 0x2D56
     char m_controllerMode;            // 0x2D57

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -4695,7 +4695,7 @@ static inline OSSemaphore* AccessSemaphoreAt(GbaQueue* self, unsigned int channe
 
 unsigned int GbaQueue::GetChgHitFlg(int channel)
 {
-	int singleMode = m_singleMode;
+	signed char singleMode = m_singleMode;
 	unsigned int actualChannel = static_cast<unsigned int>(channel) &
 	                             ~static_cast<unsigned int>((-singleMode | singleMode) >> 31);
 	OSSemaphore* semaphore = accessSemaphores + actualChannel;
@@ -4789,7 +4789,7 @@ void GbaQueue::SetHitEnemy(int channel, int enemyIdx)
  */
 int GbaQueue::GetHitEInfo(int channel)
 {
-	int singleMode = m_singleMode;
+	signed char singleMode = m_singleMode;
 	unsigned int actualChannel = static_cast<unsigned int>(channel) &
 	                             ~static_cast<unsigned int>((-singleMode | singleMode) >> 31);
 	OSSemaphore* semaphore = accessSemaphores + actualChannel;


### PR DESCRIPTION
## Summary
- Treat GbaQueue hit-change flags as signed char data, matching the surrounding signed-byte flag fields.
- Use signed-byte locals for m_singleMode in hit flag/info accessors so sign-extension matches target code.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/gbaque -o - GetHitEInfo__8GbaQueueFi: 99.69697% -> 100.0%.
- build/tools/objdiff-cli diff -p . -u main/gbaque -o - GetChgHitFlg__8GbaQueueFi: 99.117645% -> 99.411766%.
- build/tools/objdiff-cli diff -p . -u main/gbaque -o - ClrChgHitFlg__8GbaQueueFi remains 100.0%.

## Plausibility
- m_singleMode is declared as a signed byte in the class layout, and the target code sign-extends it before computing the single-player channel mask.
- Ghidra represents the hit-change flag read as a signed char, so the header correction aligns the recovered type with observed code generation.