### PR TITLE
Improve pppYmBreath constant linkage

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -26,9 +26,9 @@ extern const float FLOAT_80330c84;
 extern const double DOUBLE_80330c88;
 extern const float FLOAT_80330C90;
 extern const float FLOAT_80330C94;
-extern const float FLOAT_80330C98 = 180.0f;
-extern const float FLOAT_80330C9C = -180.0f;
-extern const double DOUBLE_80330CA0 = 4503599627370496.0;
+static const float FLOAT_80330C98 = 180.0f;
+static const float FLOAT_80330C9C = -180.0f;
+static const double DOUBLE_80330CA0 = 4503599627370496.0;
 extern const float FLOAT_80330CA8 = 2.0f;
 extern const double DOUBLE_80330CB0 = 0.5;
 }


### PR DESCRIPTION
## Summary
- Gives the pppYmBreath-local 180.0f, -180.0f, and conversion-bias constants internal linkage so they line up with the shipped local sdata2 symbols (@550, @551, @554).
- Keeps FLOAT_80330CA8 and DOUBLE_80330CB0 externally linked, matching the named symbols that follow in sdata2.

## Evidence
- ninja: passes
- objdiff main/pppYmBreath [.sdata2-0]: 67.51592% -> 75.17731%
- objdiff confirms @550, @551, and @554 are 100% matched after the change.
- pppYmBreath code symbol scores are unchanged by this data-layout cleanup.

## Plausibility
The PAL symbol table names 0x80330C98, 0x80330C9C, and 0x80330CA0 as compiler-local @ constants, while the subsequent 2.0 and 0.5 constants are named globals. Internal linkage reflects that boundary without introducing manual section placement or address hacks.