### PR TITLE
Match pppScaleLoopAuto

### DIFF
--- a/src/pppScaleLoopAuto.cpp
+++ b/src/pppScaleLoopAuto.cpp
@@ -126,7 +126,8 @@ void pppScaleLoopAutoCon(void* arg1, void* arg2)
 	int** arg2Data = (int**)arg2;
 	int* data = arg2Data[3];
 	int* ptr = (int*)data[0];
-	float zero = gPppScaleLoopAutoZero;
+	const float* zeroPtr = &gPppScaleLoopAutoZero;
+	float zero = *zeroPtr;
 	
 	void* targetPtr = (void*)((char*)arg1 + (int)ptr + 0x80);
 	float* targetData = (float*)targetPtr;


### PR DESCRIPTION
## Summary
- Preserve the named gPppScaleLoopAutoZero load in pppScaleLoopAutoCon by reading through a pointer.
- Brings the whole main/pppScaleLoopAuto unit to 100% code and data match.

## Evidence
- objdiff: pppScaleLoopAutoCon 99.73684% -> 100.0%.
- Final unit report: main/pppScaleLoopAuto text 616/616 and data 36/36, all sections 100%.
- ninja passes and regenerates the report.