### PR TITLE
Fix CDbgMenuPcs descriptor linkage

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -71,10 +71,10 @@ static const char lbl_80331CB4[] = "ON";
 static const char lbl_80331CB8[] = "OFF";
 static const char lbl_80331CBC[] = "?";
 
-static u32 m_table_desc0__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__11CDbgMenuPcsFv)};
-static u32 m_table_desc1__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__11CDbgMenuPcsFv)};
-static u32 m_table_desc2__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(calc__11CDbgMenuPcsFv)};
-static u32 m_table_desc3__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(draw__11CDbgMenuPcsFv)};
+u32 m_table_desc0__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__11CDbgMenuPcsFv)};
+u32 m_table_desc1__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__11CDbgMenuPcsFv)};
+u32 m_table_desc2__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(calc__11CDbgMenuPcsFv)};
+u32 m_table_desc3__11CDbgMenuPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<u32>(draw__11CDbgMenuPcsFv)};
 u32 m_table__11CDbgMenuPcs[0x15C / sizeof(u32)] = {
     reinterpret_cast<u32>(const_cast<char*>(s_CDbgMenuPcs_801DD428)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x11, 0, 0, 0, 0, 0x4A, 1
 };


### PR DESCRIPTION
## Summary
- Give the four `CDbgMenuPcs` table descriptor arrays external linkage instead of file-local linkage.
- This matches the PAL symbol ownership for `m_table_desc0__11CDbgMenuPcs` through `m_table_desc3__11CDbgMenuPcs` and the nearby `CMiniGamePcs` table descriptor pattern.

## Evidence
- `ninja` succeeds for GCCP01.
- `build/tools/dtk elf disasm build/GCCP01/src/p_dbgmenu.o /tmp/p_dbgmenu_src_after.s` now emits `m_table_desc0__11CDbgMenuPcs` through `m_table_desc3__11CDbgMenuPcs` as global objects.
- `build/GCCP01/report.json` remains stable for `main/p_dbgmenu`: unit fuzzy `92.41329%`, `.data` `92.236664%`, data `89.617485%`.

## Plausibility
- These descriptors are MAP/symbol-named data objects and parallel the non-static `m_table_desc*__12CMiniGamePcs` definitions used by `CMiniGamePcs`.