### PR TITLE
Improve CFlatRuntime2 class system setter

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -15,7 +15,9 @@
 #include <math.h>
 
 extern "C" int IsAnimFinished__8CGObjectFi(CGObject*, int);
+extern "C" void Printf__7CSystemFPce(CSystem*, const char*, ...);
 extern "C" void push__12CFlatRuntimeFPQ212CFlatRuntime7CObjecti(CFlatRuntime2*, CFlatRuntime::CObject*, int);
+extern const char lbl_801DA778[];
 
 namespace {
 
@@ -834,13 +836,19 @@ CFlatRuntime::CVal* CFlatRuntime2::onClassSystemVal(CFlatRuntime::CObject* objec
  * JP Address: TODO
  * JP Size: TODO
  */
-void CFlatRuntime2::onSetClassSystemVal(int, CFlatRuntime::CObject* object, CFlatRuntime::CStack* stack, int setMode)
+void CFlatRuntime2::onSetClassSystemVal(int systemVal, CFlatRuntime::CObject* object, CFlatRuntime::CStack* stack, int setMode)
 {
-	u8* const engineObject = reinterpret_cast<u8*>(object->m_engineObject);
+	u8* const engineObject = reinterpret_cast<u8*>(object);
 	const unsigned int engineFlags = CallEngineFlags(engineObject);
-	const int systemVal = static_cast<int>(object->m_localBase[0]);
 
-	if ((engineFlags & 5) == 5 || systemVal != -0x1B) {
+	if ((engineFlags & 5) != 5 && systemVal == -0x1B) {
+		if (static_cast<unsigned int>(System.m_execParam) >= 2) {
+			Printf__7CSystemFPce(&System, lbl_801DA778);
+		}
+		return;
+	}
+
+	{
 		if (systemVal < -0x3F) {
 			u8* const classData = *reinterpret_cast<u8**>(engineObject + 0x58);
 
@@ -1002,6 +1010,5 @@ void CFlatRuntime2::onSetClassSystemVal(int, CFlatRuntime::CObject* object, CFla
 					break;
 			}
 		}
-	} else if (System.m_execParam > 1) {
 	}
 }


### PR DESCRIPTION
## Summary
- Use the explicit system value parameter in CFlatRuntime2::onSetClassSystemVal instead of re-reading object local state.
- Treat the second argument as the engine object pointer for this override, matching the target prologue and virtual engine flag call shape.
- Split the disabled -0x1B debug path into the early-return form used by the target and declare the referenced debug print symbol/string.

## Evidence
- ninja: passes
- objdiff main/cflat_r2class onSetClassSystemVal__13CFlatRuntime2FiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime6CStacki: 20.294737% -> 21.62421%

## Plausibility
- The PAL target prologue keeps r4 as systemVal and uses r5 directly as the engine object for the flag vcall; this source now models that ABI shape instead of loading through CFlatRuntime::CObject fields.
- The -0x1B guarded debug print is present in target code before the main setter body, so the early-return branch reflects original control flow rather than coaxing output.