### PR TITLE
Improve CAmemCacheSet CalcPrio match

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2200,7 +2200,7 @@ void CAmemCacheSet::CalcPrio()
     for (int i = 0; i < m_cacheCount; i++) {
         CAmemCache& entry = cacheEntryAt(this, i);
 
-        if ((entry.m_inUse != 0) && (entry.m_refCount == 0) &&
+        if ((entry.m_inUse != 0) && (*reinterpret_cast<unsigned short*>(&entry.m_refCount) == 0) &&
             (entry.m_cacheData != 0) && (static_cast<unsigned int>(entry.m_priority) != 0)) {
             entry.m_priority--;
         }


### PR DESCRIPTION
## Summary
- Match CalcPrio's refcount zero check to the target's unsigned halfword load shape
- Keep CAmemCache::m_refCount signed for AddRef/Release overflow checks

## Evidence
- ninja succeeds
- objdiff: main/memory CalcPrio__13CAmemCacheSetFv improves from 93.4% to 98.0%

## Plausibility
- The change is limited to the local zero check in CalcPrio and does not alter the shared field type or refcount semantics elsewhere.