### PR TITLE
Improve CFile DrawError retry loop

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -157,9 +157,10 @@ void CFile::CHandle::Reset()
 void CFile::DrawError(DVDFileInfo& info, int errorCode)
 {
     _GXTexObj backupTexObj;
+    int status;
     m_isDiskError = 1;
 
-    while (true)
+    do
     {
         if ((unsigned int)System.m_execParam >= 1)
         {
@@ -292,7 +293,6 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
         VISetBlack(FALSE);
         VIFlush();
 
-        int status;
         while (true)
         {
             status = DVDGetCommandBlockStatus(&info.cb);
@@ -325,14 +325,8 @@ void CFile::DrawError(DVDFileInfo& info, int errorCode)
             status = DVDGetCommandBlockStatus(&info.cb);
         }
 
-        if (status == 0x0B || ((u32)(status - 4) <= 2U) || status == -1)
-        {
-            errorCode = status;
-            continue;
-        }
-
-        break;
-    }
+        errorCode = status;
+    } while (status == 0x0B || ((u32)(status - 4) <= 2U) || status == -1);
 
     Sound.PauseDiscError(0);
     m_isDiskError = 0;


### PR DESCRIPTION
## Summary
- Rewrites `CFile::DrawError` retry handling as a do/while loop matching the recovered control-flow shape.
- Moves the DVD status temporary to the outer loop scope so the retry status feeds the loop condition directly.

## Evidence
- `ninja` passes.
- `file.o` `.data` match improves from 85.34% to 92.11%.
- `@1166` jump table now matches 100%.
- `DrawError__5CFileFR11DVDFileInfoi` code score changes from 97.16% to 96.44%; this is a small local code regression accepted for the cleaner source shape and data-layout gain.

## Plausibility
- The resulting source is simpler structured retry logic: wait while the DVD status is busy, assign the observed status to the loop error code, and continue only for retryable disk errors.
- No manual vtable/section/address hacks were added.
