### PR TITLE
Improve CMapMng::DrawMapShadow matching

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2831,16 +2831,18 @@ void CMapMng::Calc()
  * Address:	TODO
  * Size:	TODO
  */
+#pragma dont_inline on
 void CMapMng::DrawMapShadow()
 {
-    if (*reinterpret_cast<short*>(Ptr(this, 0xC)) != 0) {
-        CPtrArray<CMapShadow*>* mapShadowArray = reinterpret_cast<CPtrArray<CMapShadow*>*>(Ptr(this, 0x21434));
-        for (unsigned int i = 0; i < mapShadowArray->GetSize(); i++) {
-            CMapShadow* mapShadow = (*mapShadowArray)[i];
+    unsigned char* self = reinterpret_cast<unsigned char*>(this);
+    if (*reinterpret_cast<short*>(self + 0xC) != 0) {
+        for (unsigned int i = 0; i < reinterpret_cast<CPtrArray<CMapShadow*>*>(self + 0x21434)->GetSize(); i++) {
+            CMapShadow* mapShadow = (*reinterpret_cast<CPtrArray<CMapShadow*>*>(self + 0x21434))[i];
             mapShadow->Draw();
         }
     }
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Adjust CMapMng::DrawMapShadow so it keeps the map manager base pointer and uses the map shadow array access shape expected by the PAL target.
- Scope #pragma dont_inline to this function so the shadow array accessor calls remain out-of-line here without changing other callers.

## Evidence
- ninja passes.
- DrawMapShadow__7CMapMngFv: 52.32143% -> 92.85714%.
- main/map fuzzy match: 61.7894% -> 61.997616%.
- Nearby tracked functions unchanged in report: Calc__7CMapMngFv, ReadOtm__7CMapMngFPc, DestroyMap__7CMapMngFv.

## Plausibility
- The body still uses the existing CPtrArray<CMapShadow*> methods and normal CMapShadow::Draw() call path.
- The local shape matches nearby recovered map.cpp code that works from a recovered self byte pointer while the full CMapMng layout is still placeholder storage.