### PR TITLE
Expose Material Editor rodata labels

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -9,7 +9,7 @@ void __dla__FPv(void*);
 void* memset(void*, int, unsigned int);
 }
 
-static const char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
+extern "C" const char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
 
 struct ZCANMGRP {
     void* ptr;

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -22,8 +22,8 @@ extern "C" int AddRsdList__18CMaterialEditorPcsFP5ZLIST(CMaterialEditorPcs* mate
 extern "C" void SetRsdIndex__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialEditorPcs);
 extern "C" void SetRsdFlag__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialEditorPcs);
 
-static const char s_ME_USB_process_cpp_801d7d78[] = "ME_USB_process.cpp";
-static const char s_MemAlloc_Error____size__d_801d7d8c[] = "MemAlloc Error!!! size=%d\n";
+extern "C" const char s_ME_USB_process_cpp_801d7d78[] = "ME_USB_process.cpp";
+extern "C" const char s_MemAlloc_Error____size__d_801d7d8c[] = "MemAlloc Error!!! size=%d\n";
 
 namespace {
 struct ViewerSRT {

--- a/src/zlist.cpp
+++ b/src/zlist.cpp
@@ -2,7 +2,7 @@
 
 #include "ffcc/p_MaterialEditor.h"
 
-static const char s_zlist_cpp_801d7dc0[] = "zlist.cpp";
+extern "C" const char s_zlist_cpp_801d7dc0[] = "zlist.cpp";
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Give the Material Editor and zlist filename/error rodata labels C linkage so the compiled objects emit the same global symbol bindings as the target assembly.
- Keeps the source definitions in their owning units instead of relying on local-only labels for named rodata.

## Evidence
- ninja passes.
- objdiff zlist: all functions and s_zlist_cpp_801d7dc0 remain 100%; .rodata-0 remains 76.92308%.
- objdiff ME_AppRequest: existing function scores preserved, s_ME_AppRequest_cpp_801d7da8 remains 100%; .rodata-0 remains 85.71429%.
- objdiff ME_USB_process: existing scores preserved, both rodata symbols remain 100%; .rodata-0 remains 98.94737%.

## Plausibility
The extracted target assembly marks these named rodata labels as global symbols in their owning object files. C linkage matches that object-level symbol ownership without changing behavior or manually forcing sections.