### PR TITLE
Match sqrtf inline constants

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -36,8 +36,8 @@ extern inline double sqrt(double x)
 
 extern inline float sqrtf(float x)
 {
-    static const double _half = .5;
-    static const double _three = 3.0;
+    const double _half = .5;
+    const double _three = 3.0;
     union {
         float f;
         unsigned long bits;


### PR DESCRIPTION
## Summary
- Change the inline `sqrtf` helper constants from static locals to plain local constants.
- Removes the extra weak `_half`/`_three` localstatic objects emitted into `math.o` while preserving the existing full `sqrtf` logic.
- This lets `CMath::CrossCheckSphereVector` match exactly.

## Evidence
- `ninja` passes for GCCP01.
- Overall progress improved from 547,348 to 548,120 matched code bytes (+772) and from 3309 to 3310 matched functions.
- `main/math` objdiff:
  - `CrossCheckSphereVector__5CMathFP3VecPfP3VecP3VecP3Vecf`: 100.0% match, target 772b / built 772b.
  - `.sdata2`: 100.0% match; bogus weak `sqrtf` localstatic symbols are no longer emitted.

## Plausibility
The Dolphin-style inline uses ordinary local constants for `_half` and `_three`; keeping them non-static avoids creating TU-local data while leaving the original numerical logic intact.