### PR TITLE
Improve pppChangeTex frame split conversion

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -302,7 +302,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 
 	scale.u[0] = 0x43300000;
 	scale.u[1] = (1 << model0Raw->m_data->m_frameShift) ^ 0x80000000;
-	short splitY = (short)(int)(currentValue * (float)(scale.d - LoadDouble(DOUBLE_80332030)));
+	short splitY = (short)(int)(currentValue * (scale.d - LoadDouble(DOUBLE_80332030)));
 	if (work->m_cachedValue == currentValue) {
 		return;
 	}


### PR DESCRIPTION
## Summary
- Remove an unnecessary float cast in pppFrameChangeTex split-height conversion so MWCC keeps the closer conversion sequence.

## Objdiff Evidence
- main/pppChangeTex .text: 95.998474% -> 96.67939%
- pppFrameChangeTex: 95.79566% -> 97.17647%
- pppDestructChangeTex: unchanged at 97.54074%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o -

## Plausibility
- The expression still mirrors the decompiled formula for the conversion double; it simply avoids forcing an intermediate float before the final integer conversion.