### PR TITLE
Improve pppRyjMegaBirth calc matching

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -656,8 +656,8 @@ void calc(
 	}
 
 	{
-		float angleWrap = FLOAT_80330458;
 		float angleMax = FLOAT_8033045c;
+		float angleWrap = FLOAT_80330458;
 		volatile float* angle = f32_at(particlePayload, 0x28);
 		while (angleMax <= *angle)
 		{
@@ -665,8 +665,8 @@ void calc(
 		}
 	}
 	{
-		float angleWrap = FLOAT_80330458;
 		float angleMin = FLOAT_80330460;
+		float angleWrap = FLOAT_80330458;
 		volatile float* angle = f32_at(particlePayload, 0x28);
 		while (*angle < angleMin)
 		{


### PR DESCRIPTION
## Summary
- Reordered the local angle wrap/bound constants in `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR` so the generated angle wrap loops line up better with PAL.
- Keeps the existing volatile angle reload behavior, which objdiff showed is needed for the target loop shape.

## Evidence
- `ninja` succeeds.
- `main/pppRyjMegaBirth` unit fuzzy match: 71.90502% -> 71.91248%.
- `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`: 99.273506% -> 99.33761%.
- Data score unchanged: 43.548386%.

## Plausibility
- This is a source-level ordering correction for existing local constants in the angle normalization loops, not a hardcoded address or artificial control-flow change.