### PR TITLE
Link pppYmBreath sdata2 constants

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -26,9 +26,9 @@ extern const float FLOAT_80330c84;
 extern const double DOUBLE_80330c88;
 extern const float FLOAT_80330C90;
 extern const float FLOAT_80330C94;
-static const float FLOAT_80330C98 = 180.0f;
-static const float FLOAT_80330C9C = -180.0f;
-static const double DOUBLE_80330CA0 = 4503599627370496.0;
+extern const float FLOAT_80330C98 = 180.0f;
+extern const float FLOAT_80330C9C = -180.0f;
+extern const double DOUBLE_80330CA0 = 4503599627370496.0;
 extern const float FLOAT_80330CA8 = 2.0f;
 extern const double DOUBLE_80330CB0 = 0.5;
 }


### PR DESCRIPTION
## Summary
- Change three pppYmBreath .sdata2 constants from internal to external linkage.
- This lets objdiff resolve FLOAT_80330C98, FLOAT_80330C9C, and DOUBLE_80330CA0 to the PAL symbols.

## Evidence
Before:
- main/pppYmBreath .sdata2: 64.44444%
- FLOAT_80330C98, FLOAT_80330C9C, DOUBLE_80330CA0 had matching bytes but no target_symbol linkage.

After:
- main/pppYmBreath .sdata2: 100.0%
- FLOAT_80330C98 -> target symbol 28, 100.0%
- FLOAT_80330C9C -> target symbol 29, 100.0%
- DOUBLE_80330CA0 -> target symbol 30, 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - pppFrameYmBreath