### PR TITLE
Improve mapanim CPtrArray linkage

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -276,7 +276,7 @@ mapanim.cpp:
 	extab       start:0x800069C8 end:0x80006A44
 	extabindex  start:0x8000C610 end:0x8000C6AC
 	.text       start:0x8004A4A0 end:0x8004B1D0
-	.rodata     start:0x801D7CB8 end:0x801D7CF8
+	.rodata     start:0x801D7CB8 end:0x801D7D18
 	.data       start:0x801EA488 end:0x801EA494
 	.sdata2     start:0x8032FC98 end:0x8032FCA8
 

--- a/include/ffcc/ptrarray.h
+++ b/include/ffcc/ptrarray.h
@@ -51,6 +51,7 @@ CPtrArray<T>::~CPtrArray()
     RemoveAll();
 }
 
+#ifndef FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 template <class T>
 int CPtrArray<T>::GetSize()
 {
@@ -68,6 +69,7 @@ T CPtrArray<T>::operator[](unsigned long index)
 {
     return GetAt(index);
 }
+#endif
 
 template <class T>
 void CPtrArray<T>::SetStage(CMemory::CStage* stage)

--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -1,3 +1,4 @@
+#define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 #include "ffcc/mapanim.h"
 #include "ffcc/chunkfile.h"
 #include "ffcc/linkage.h"


### PR DESCRIPTION
## Summary
- Keep mapanim CPtrArray accessors external so the unit no longer emits local weak GetSize/operator[]/GetAt copies.
- Extend the mapanim rodata split to include the CPtrArray<CMapAnimNode *> RTTI name already identified in symbols.txt.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- mapanim before: .text current 3480 vs target 3376; extab 140 vs 124; extabindex 180 vs 156.
- mapanim after: .text 3376 vs 3376; extab 124 vs 124; extabindex 156 vs 156.
- Progress report data matched bytes improved from 1,127,455 to 1,127,767 (+312 bytes).

## Plausibility
- The target object leaves GetSize__26CPtrArray<P12CMapAnimNode>Fv, __vc__21CPtrArray<P8CMapAnim>FUl, and __vc__26CPtrArray<P12CMapAnimNode>FUl undefined; this change makes the source do the same without hand-written symbols or vtable data.