### PR TITLE
Match CDbgMenuPcs Add

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -606,7 +606,8 @@ void CDbgMenuPcs::drawWindow(int flags, int x, int y, int width, int height, cha
 	GXPosition3f32((float)x, (float)(y + height), 0.0f);
 	GXColor1u32(gDbgMenuWindowFillColors[1 - fillColorIndex]);
 
-	if (m_currentMenu->m_statusBits.m_selected != 0) {
+	s8 selected = static_cast<s32>((static_cast<u32>(m_currentMenu->m_status) << 25) & 0xC0000000) >> 31;
+	if (selected != 0) {
 		u8 alpha = 0xC0;
 
 		if ((System.m_frameCounter >> 2 & 1) != 0) {
@@ -682,10 +683,11 @@ void CDbgMenuPcs::drawFont(int flags, int x, int y, char* text)
  * Address:	TODO
  * Size:	TODO
  */
-CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
+inline CDbgMenuPcs::CDM* CDbgMenuPcs::searchFreeCDM()
 {
 	for (int i = 0; i < 0x80; i++) {
-		if (m_menuPool[i].m_statusBits.m_used == 0) {
+		s8 used = static_cast<s32>((static_cast<u32>(m_menuPool[i].m_status) << 24) & 0xC0000000) >> 31;
+		if (used == 0) {
 			return &m_menuPool[i];
 		}
 	}
@@ -871,8 +873,8 @@ void CDbgMenuPcs::Add(int parentID, int id, CDbgMenuPcs::CDMParam& param)
 	menu->m_next = menu;
 	menu->m_id = id;
 
-	CDM* child = parentMenu->m_firstChild;
-	if (child != 0) {
+	if (parentMenu->m_firstChild != 0) {
+		CDM* child = parentMenu->m_firstChild;
 		int found = 0;
 		do {
 			if (found == 0 && ((child->m_flags & 1) != 0)) {


### PR DESCRIPTION
## Summary
- Match CDbgMenuPcs::Add(int, int, CDMParam&) by using the raw CDM status-byte bit layout for the used/selected checks
- Inline the local searchFreeCDM helper so the unit no longer emits a non-original out-of-line helper symbol
- Keep the child-list traversal closer to the original register/control-flow shape

## Evidence
- ninja: passes
- objdiff main/p_dbgmenu Add__11CDbgMenuPcsFiiRQ211CDbgMenuPcs8CDMParam: 97.03704% -> 100.0%, current size 420b -> 432b matching target 432b
- p_dbgmenu .text: 92.08968% -> 92.30038%, current size 7460b -> 7416b vs target 7404b

## Plausibility
- The status checks now reflect the byte/bit layout already used by the compiler-generated stores in this unit, instead of relying on the C++ bitfield read shape.
- searchFreeCDM was only a local helper and is absent from the PAL symbol list/original p_dbgmenu assembly, so inlining it removes invented linkage rather than adding a workaround.