### PR TITLE
Improve pppShape texture cache matches

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -123,8 +123,8 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     int shapeStep;
     char* currentFrame;
     int frameIndex;
-    char* animData;
     unsigned char* texturePtr;
+    char* animData;
     unsigned int textureIndex;
     unsigned char* shapeEntry;
     unsigned char textureUsed[0x100];
@@ -175,8 +175,8 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     int shapeStep;
     char* currentFrame;
     int frameIndex;
-    char* animData;
     unsigned char* texturePtr;
+    char* animData;
     unsigned int textureIndex;
     unsigned char* shapeEntry;
     unsigned char textureUsed[0x100];


### PR DESCRIPTION
## Summary
- Reorder local declarations in pppShape texture cache helpers to match Metrowerks register allocation more closely.
- Improves both pppCacheDumpShapeTexture and pppCacheLoadShapeTexture without changing behavior.

## Objdiff evidence
- pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet: 98.083336% -> 98.416664%
- pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet: 98.083336% -> 98.416664%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppShape -o - pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet
- build/tools/objdiff-cli diff -p . -u main/pppShape -o - pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet