### PR TITLE
Fix CUSBPcs table layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -8,7 +8,7 @@
 struct CUSBPcsTable
 {
     char* m_name;
-    unsigned int m_words[0x56];
+    unsigned int m_words[0x46];
 };
 
 extern unsigned int m_table_desc0__7CUSBPcs[];


### PR DESCRIPTION
## Summary
- Resize CUSBPcsTable to match the split symbol size for m_table__7CUSBPcs.
- This moves s_CUSBPcsTablePad0, s_CUSBPcsTablePad1, and __vt__7CUSBPcs back to their expected data offsets.

## Evidence
- ninja passes.
- main/p_usb .data fuzzy match improved from 88.631424% to 95.94072%.
- Compiled m_table__7CUSBPcs size is now 0x11c, matching config/GCCP01/symbols.txt; compiled .data shrank from 0x1c4 to 0x184.
- Code match is unchanged for p_usb: .text remains 95.44546% in objdiff.

## Plausibility
- The previous table declaration was 0x40 bytes larger than the symbol-owned object. The existing pad symbols immediately following the table already account for the remaining layout before the CUSBPcs vtable, so shrinking the table type is a source-level layout correction rather than compiler coaxing.