### PR TITLE
Improve menu list cursor frame remainder

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -178,7 +178,7 @@ void CMenuPcs::MLstDraw()
 		MenuLstEntry* curItem = &this->lstData->entries[this->lstState->cursor];
 		float cursorYOffset = (float)((double)(float)(curItem->height - 0x20) * DOUBLE_803333E8);
 		int cursorY = (int)((float)curItem->y + cursorYOffset);
-		int cursorX = (int)((float)(curItem->x - 0x38) + (float)(System.m_frameCounter % 8));
+		int cursorX = (int)((float)(curItem->x - 0x38) + (float)((int)System.m_frameCounter % 8));
 		DrawCursor__8CMenuPcsFiif(this, cursorX, cursorY, FLOAT_803333F0);
 	}
 


### PR DESCRIPTION
## Summary
- Cast the menu list cursor frame counter to signed before `% 8` in `CMenuPcs::MLstDraw`.
- This matches the target signed power-of-two remainder shape for the cursor wobble expression.

## Evidence
Before:
- `MLstDraw__8CMenuPcsFv`: 74.002785%, 274 instruction diffs
- `[.sdata2-0]`: 92.30769%

After:
- `MLstDraw__8CMenuPcsFv`: 73.922005%, 270 instruction diffs
- `[.sdata2-0]`: 96.0%

Command used:
```sh
build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst_final.json
```

## Plausibility
The target assembly uses signed remainder code for the cursor frame wobble. Keeping the cast local avoids changing the wider `CSystem` layout/type while recovering the signed expression shape for this callsite.

## Verification
- `ninja`