### PR TITLE
Tighten pppRyjMegaBirth angle wrapping

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -656,18 +656,20 @@ void calc(
 	}
 
 	{
-		float angleMax = FLOAT_8033045c;
+		float angleMax;
 		float angleWrap = FLOAT_80330458;
 		volatile float* angle = f32_at(particlePayload, 0x28);
+		angleMax = FLOAT_8033045c;
 		while (angleMax <= *angle)
 		{
 			*angle = *angle - angleWrap;
 		}
 	}
 	{
-		float angleMin = FLOAT_80330460;
+		float angleMin;
 		float angleWrap = FLOAT_80330458;
 		volatile float* angle = f32_at(particlePayload, 0x28);
+		angleMin = FLOAT_80330460;
 		while (*angle < angleMin)
 		{
 			*angle = *angle + angleWrap;


### PR DESCRIPTION
## Summary
- Adjusts the local angle wrap temporaries in `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR` to better match the original load/use ordering.
- Leaves `birth` and `pppRyjDrawMegaBirth` unchanged after testing nearby alternatives that regressed objdiff.

## Objdiff Evidence
Before:
- `main/pppRyjMegaBirth` `.text`: 71.86922%
- `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`: 99.166664%

After:
- `main/pppRyjMegaBirth` `.text`: 71.88663%
- `calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR`: 99.31624%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppRyjMegaBirth -o /tmp/pppRyjMegaBirth_final.json`