### PR TITLE
Improve pppYmBreath sdata2 layout

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -914,11 +914,6 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, PARTICLE_DATA* p
     }
 }
 
-extern "C" const char lbl_80330CB8[] = "FFCC";
-extern "C" const char lbl_80330CC0[] = "GDS";
-extern "C" const char lbl_80330CC4[] = "GC";
-extern "C" const char lbl_80330CC8[] = "1.00";
-
 /*
  * --INFO--
  * PAL Address: 0x800c118c
@@ -1080,6 +1075,11 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         particleColor->m_colorFrameDeltas[3] = params->m_colorFrameDelta3;
     }
 }
+
+extern "C" const char lbl_80330CB8[] = "FFCC";
+extern "C" const char lbl_80330CC0[] = "GDS";
+extern "C" const char lbl_80330CC4[] = "GC";
+extern "C" const char lbl_80330CC8[] = "1.00";
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Move the FFCC/GDS/GC/version string definitions after BirthParticle so the compiler emits the preceding float/double constants in the target sdata2 order.
- This exposes the expected FLOAT_80330C98, FLOAT_80330C9C, FLOAT_80330CA8, and DOUBLE_80330CB0 symbols before the trailing string labels.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o - --format json
- .sdata2: now 100.0% match, size 56
- FLOAT_80330C98: 100.0%
- FLOAT_80330C9C: 100.0%
- FLOAT_80330CA8: 100.0%
- DOUBLE_80330CB0: 100.0%
- trailing labels lbl_80330CB8, lbl_80330CC0, lbl_80330CC4, lbl_80330CC8: 100.0%

## Plausibility
- This is source-order/data-layout recovery only: no manual vtables, RTTI, section forcing, hardcoded addresses, or fake code paths.
- The moved strings are still defined normally, just in the order needed for the compiler to lay out the local constants before them.
