### PR TITLE
Match CPartPcs color identity constant

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -20,7 +20,7 @@ extern const float kPppHeapUseRateDivisor;
 
 extern "C" const char s_no_name_8032fdcc[];
 extern "C" {
-extern const float kPartColorIdentityOne = 1.0f;
+extern volatile const float kPartColorIdentityOne = 1.0f;
 const char s_no_name_8032fdcc[] = "no name";
 }
 
@@ -1173,7 +1173,7 @@ void CPartPcs::SetParColIdx(int index, pppFVECTOR4& color)
 	};
 	PartMngColorView* pppMngSt =
 	    reinterpret_cast<PartMngColorView*>(reinterpret_cast<u8*>(&PartMng) + (index * 0x158));
-	float one = 1.0f;
+	float one = *reinterpret_cast<volatile const float*>(&kPartColorIdentityOne);
 
 	pppMngSt->r = color.x;
 	pppMngSt->g = color.y;


### PR DESCRIPTION
## Summary
- Make the CPartPcs color identity constant an owned stored constant and read it in SetParColIdx.
- This makes SetParColIdx reference the named kPartColorIdentityOne sdata2 symbol instead of an anonymous float literal.

## Evidence
- ninja passes for GCCP01.
- build/tools/objdiff-cli diff -p . -u main/p_tina -o /tmp/p_tina_pr_evidence.json SetParColIdx__8CPartPcsFiR11pppFVECTOR4
- SetParColIdx__8CPartPcsFiR11pppFVECTOR4: 99.85714% -> 100.0% objdiff match.
- p_tina data remains at 0.9633912% matched in the build report.

## Plausibility
- The PAL symbols already name kPartColorIdentityOne at .sdata2:0x8032FDC8.
- SetParColIdx compares the incoming pppFVECTOR4 against this identity value, so loading the named constant is more coherent than using an anonymous literal.