### PR TITLE
Match pppDrawMdlTs zero data

### DIFF
--- a/src/pppDrawMdlTs.cpp
+++ b/src/pppDrawMdlTs.cpp
@@ -14,6 +14,7 @@ void SetTexScroll__12CMaterialManFffff(CMaterialMan*, float, float, float, float
 }
 
 extern const float FLOAT_803304F0;
+extern const float kPppKeShpTail2XZero = 0.0f;
 
 // Use simple forward declarations and casting approach
 


### PR DESCRIPTION
## Summary
- Define the kPppKeShpTail2XZero zero constant in pppDrawMdlTs.cpp.
- This gives the unit the 4-byte .sdata2 symbol present in the target object while keeping code unchanged.

## Evidence
Before:
- main/pppDrawMdlTs .text: 100.0%
- main/pppDrawMdlTs .sdata2: 0.0%

After:
- main/pppDrawMdlTs .text: 100.0%
- main/pppDrawMdlTs .sdata2: 100.0%
- kPppKeShpTail2XZero: 100.0%

Verification:
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppDrawMdlTs -o -

## Plausibility
The target object owns a global 4-byte .sdata2 symbol named kPppKeShpTail2XZero; adding the constant to this unit matches that ownership and does not alter the already-matching code.