### PR TITLE
Fix CUSBPcs table layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -8,7 +8,7 @@
 struct CUSBPcsTable
 {
     char* m_name;
-    unsigned int m_words[0x56];
+    unsigned int m_words[0x46];
 };
 
 extern unsigned int m_table_desc0__7CUSBPcs[];


### PR DESCRIPTION
## Summary
- Correct `CUSBPcsTable` to the PAL-sized 0x11c-byte layout by reducing `m_words` from 0x56 to 0x46 entries.
- This moves following `p_usb` data back to the expected offsets and makes `m_table__7CUSBPcs` match exactly.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o - __sinit_p_usb_cpp`
- `main/p_usb` `.data`: 95.94072% match, size 392
- `m_table__7CUSBPcs`: 100.0% match, size 284

## Plausibility
- The new table size matches the PAL symbol claim for `m_table__7CUSBPcs` (0x11c bytes) and removes an oversized struct declaration rather than adding padding or section hacks.