### PR TITLE
Improve sound stream and line bounds matching

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -376,13 +376,13 @@ extern "C" void CalcBound__9CLine2(CLine* line)
             line->min.z = point.z;
         }
 
-        if (line->max.x < point.x) {
+        if (point.x > line->max.x) {
             line->max.x = point.x;
         }
-        if (line->max.y < point.y) {
+        if (point.y > line->max.y) {
             line->max.y = point.y;
         }
-        if (line->max.z < point.z) {
+        if (point.z > line->max.z) {
             line->max.z = point.z;
         }
 
@@ -2452,8 +2452,7 @@ void CSound::PlayStreamASync()
         clampedVolume = volume;
     }
 
-    int streamNo = StreamPlay__9CRedSoundFPviii(
-        RedSound(this), sound.m_streamBuffer, 0x20000, 0x40, clampedVolume);
+    int streamNo = StreamPlay__9CRedSoundFPviii(redSound, streamBuffer, 0x20000, 0x40, clampedVolume);
     sound.m_streamID = streamNo;
     sound.m_streamPlaying = 1;
 }


### PR DESCRIPTION
## Summary
- Rewrite CLine max-bound comparisons to match the original operand order.
- Use the existing cached RedSound and stream buffer locals for StreamPlay in CSound::PlayStreamASync.

## Evidence
- ninja passes for GCCP01.
- main/sound .text: 90.46553% -> 90.63481%.
- CalcBound__9CLine2: 80.02273% -> 81.11364%.
- PlayStreamASync__6CSoundFv: 81.80556% -> 89.30556%.

## Plausibility
- The CalcBound change is a source-equivalent comparison order that matches the target compare operands.
- PlayStreamASync already had redSound and streamBuffer locals; using them at the call site removes redundant member access and matches the target argument setup more closely.