### PR TITLE
Fix pppPart zero constant linkage

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -107,7 +107,7 @@ static inline unsigned char* PartPcsRaw() { return reinterpret_cast<unsigned cha
 static const char s_pppPart_cpp[] = "pppPart.cpp";
 static const char s_ERROR_prog_NULL[] = "\nERROR!!!! prog=NULL\n\n";
 static const char s_CPartPcs_heap_801D821C[] = "CPartPcs.heap";
-static const float FLOAT_8032fddc = 0.0f;
+extern "C" float FLOAT_8032fddc;
 extern "C" float FLOAT_8032fde0;
 extern "C" float FLOAT_8032fde4;
 extern "C" float FLOAT_8032FDE8;
@@ -253,7 +253,7 @@ void pppSetRowVector(pppFMATRIX& pppFMtx, Vec& vecA, Vec& vecB, Vec& vecC, Vec& 
  */
 void pppNormalize(Vec& dest, Vec source)
 { 
-	float zero = FLOAT_8032fddc;
+	float zero = kPppZero;
 	if ((source.x == zero) && (source.y == zero) && (source.z == zero)) {
 		return;
 	}


### PR DESCRIPTION
## Summary
- Treat FLOAT_8032fddc as an external shared constant instead of defining a local pppPart copy.
- Keep pppNormalize on the local zero path so its generated code shape remains intact.

## Evidence
- ninja passes for GCCP01.
- objdiff: pppInitDrawEnv__FUc is now 100.0%.
- report: pppInitDrawEnv__FUc and pppNormalize__FR3Vec3Vec both report 100.0% fuzzy match.

## Plausibility
The PAL target pppPart assembly references FLOAT_8032fddc as an external sdata2 symbol rather than defining it in pppPart, so this aligns the source linkage with the observed object layout.