### PR TITLE
Fix CUSBPcs table layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -8,7 +8,7 @@
 struct CUSBPcsTable
 {
     char* m_name;
-    unsigned int m_words[0x56];
+    unsigned int m_words[0x46];
 };
 
 extern unsigned int m_table_desc0__7CUSBPcs[];


### PR DESCRIPTION
## Summary
- correct CUSBPcsTable to match the 0x11C-byte m_table__7CUSBPcs symbol layout
- keeps the p_usb process table aligned with the PAL symbol size instead of overlapping following data

## Evidence
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_usb -o /tmp/p_usb_pr_evidence.json
- m_table__7CUSBPcs: 100.0% match, size 284 bytes
- p_usb .data: 95.94072% match

## Plausibility
The PAL symbols claim m_table__7CUSBPcs at size 0x11C. The previous CUSBPcsTable declared 0x56 words after the name pointer, making the object 0x15C bytes. The corrected 0x46-word payload gives the mapped 0x11C-byte table size without changing runtime behavior.