### PR TITLE
Fix CUSBPcs table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -8,7 +8,7 @@
 struct CUSBPcsTable
 {
     char* m_name;
-    unsigned int m_words[0x56];
+    unsigned int m_words[0x46];
 };
 
 extern unsigned int m_table_desc0__7CUSBPcs[];


### PR DESCRIPTION
## Summary
- Correct CUSBPcsTable to match the target m_table__7CUSBPcs size of 0x11c bytes.
- This moves the following pad and vtable data back to the target layout without changing GetTable observed 0x15c stride.

## Evidence
- ninja passes.
- main/p_usb .data improves from 88.631424% to 95.94072%.
- m_table__7CUSBPcs improves from 90.01405% to 100.0%.
- SendDataCode__7CUSBPcsFiPvii remains 98.49624%; .text remains 95.44546%.

## Plausibility
- The target object reports m_table__7CUSBPcs as 0x11c bytes, while the prior struct was 0x15c bytes and pushed subsequent data 0x40 bytes too late.
- The 0x15c stride in GetTable is preserved because it is emitted as an explicit multiply, not derived from sizeof(CUSBPcsTable).