### PR TITLE
Match CLightPcs draw

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -330,19 +330,22 @@ void CLightPcs::draw()
     CLight* light = m_sceneLights;
     for (u32 i = 0; i < m_sceneLightCount; i++, light++) {
         if (light->m_specularMode == 0) {
-            PSMTXMultVec(mtx, reinterpret_cast<Vec*>(&light->m_position), &vec);
-            GXInitLightPos(&light->m_gxLightObj, vec.x, vec.y, vec.z);
-
-            if (light->m_directionMode == 0) {
+            if (light->m_directionMode != 0) {
+                PSMTXMultVec(mtx, reinterpret_cast<Vec*>(&light->m_position), &vec);
+                GXInitLightPos(&light->m_gxLightObj, vec.x, vec.y, vec.z);
+                GXInitLightDir(&light->m_gxLightObj, light->m_direction.x, light->m_direction.y, light->m_direction.z);
+            } else {
+                PSMTXMultVec(mtx, reinterpret_cast<Vec*>(&light->m_position), &vec);
+                GXInitLightPos(&light->m_gxLightObj, vec.x, vec.y, vec.z);
                 PSMTXMultVecSR(mtx, reinterpret_cast<Vec*>(&light->m_direction), &vec);
                 GXInitLightDir(&light->m_gxLightObj, vec.x, vec.y, vec.z);
-            } else {
-                GXInitLightDir(&light->m_gxLightObj, light->m_direction.x, light->m_direction.y, light->m_direction.z);
             }
 
-            float cutoff = FLOAT_8032fc74;
-            if (light->m_type == 1) {
+            float cutoff;
+            if (static_cast<int>(light->m_type) == 1) {
                 cutoff = FLOAT_8032fc94 * light->m_spotScale;
+            } else {
+                cutoff = FLOAT_8032fc74;
             }
 
             GXInitLightSpot(&light->m_gxLightObj, cutoff, (GXSpotFn)light->m_unk4D);


### PR DESCRIPTION
## Summary
- Restructure CLightPcs::draw non-specular direction handling to match the original branch shape.
- Move cutoff selection into an explicit signed type check/else so GXInitLightSpot setup matches the target instruction stream.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/p_light -o - draw__9CLightPcsFv reports 100.0% for draw__9CLightPcsFv.
- Build progress increased by one matched function and 420 matched code bytes: Game Code 203748 -> 204168 bytes.

## Plausibility
- The change keeps normal member access and GX calls; it does not add fake symbols, manual sections, or vtable/ctor hacks.
- The branch structure reflects the two original direction modes directly instead of hoisting shared setup in a way MWCC did not emit.