### PR TITLE
Improve mapobj and menu command matching

### DIFF
--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -142,7 +142,7 @@ public:
     void DrawHitWire();
     void DrawHitNormal();
     int CheckHitCylinder(CMapCylinder*, Vec*, unsigned long);
-    int CheckHitCylinderNear(CMapCylinder*, Vec*, unsigned long);
+    void CheckHitCylinderNear(CMapCylinder*, Vec*, unsigned long);
     void GetHitFaceNormal(Vec*);
     int CalcHitSlide(Vec*, float);
     void CalcHitPosition(Vec*);

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1549,7 +1549,7 @@ int CMapObj::CheckHitCylinder(CMapCylinder* cylinder, Vec* move, unsigned long m
  * JP Address: TODO
  * JP Size: TODO
  */
-int CMapObj::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned long mask)
+void CMapObj::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned long mask)
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0) && (S8At(this, 0x1F) == -1)) {
         Mtx inverseMtx;
@@ -1640,7 +1640,6 @@ int CMapObj::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned lo
         }
     }
 
-    return 0;
 }
 
 /*

--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -2442,28 +2442,24 @@ int CMenuPcs::UniteCloseAnim(int topIdx)
 		int finished = 0;
 		s32* top = s_UniteTop;
 		for (int i = 0; i < DAT_8032eec8; i++) {
-			int j = 0;
-			int k = 3;
-			do {
+			for (int j = 0; j < 3; j++) {
 				int idx = j + *top;
 				int entryOffset = idx * 0x40 + 8;
 				if ((j != 0) && (*reinterpret_cast<s16*>(caravanWork + idx * 2 + 0x214) != -1)) {
 					break;
 				}
 
-				*reinterpret_cast<s16*>(listBase + entryOffset) =
-				    static_cast<s16>(static_cast<double>(*reinterpret_cast<s16*>(listBase + entryOffset)) -
+				int entryBase = GetCmdListBase(this);
+				*reinterpret_cast<s16*>(entryBase + entryOffset) =
+				    static_cast<s16>(static_cast<double>(*reinterpret_cast<s16*>(entryBase + entryOffset)) -
 				                     DOUBLE_80332ab8);
-				if (static_cast<float>(*reinterpret_cast<s16*>(listBase + entryOffset)) <= baseX) {
-					*reinterpret_cast<s16*>(listBase + entryOffset) = static_cast<s16>(baseX);
+				if (static_cast<float>(*reinterpret_cast<s16*>(entryBase + entryOffset)) <= baseX) {
+					*reinterpret_cast<s16*>(entryBase + entryOffset) = static_cast<s16>(baseX);
 					if (j == 0) {
 						finished++;
 					}
 				}
-
-				j++;
-				k--;
-			} while (k != 0);
+			}
 			top++;
 		}
 		if (finished == DAT_8032eec8) {
@@ -2471,26 +2467,22 @@ int CMenuPcs::UniteCloseAnim(int topIdx)
 		}
 	} else {
 		bool finished = false;
-		int i = 0;
-		int k = 3;
-		do {
+		for (int i = 0; i < 3; i++) {
 			int idx = i + s_UniteTop[topIdx];
 			int entryOffset = idx * 0x40 + 8;
 			if ((i != 0) && (*reinterpret_cast<s16*>(caravanWork + idx * 2 + 0x214) != -1)) {
 				break;
 			}
 
-			*reinterpret_cast<s16*>(listBase + entryOffset) =
-			    static_cast<s16>(static_cast<double>(*reinterpret_cast<s16*>(listBase + entryOffset)) -
+			int entryBase = GetCmdListBase(this);
+			*reinterpret_cast<s16*>(entryBase + entryOffset) =
+			    static_cast<s16>(static_cast<double>(*reinterpret_cast<s16*>(entryBase + entryOffset)) -
 			                     DOUBLE_80332ab8);
-			if (static_cast<float>(*reinterpret_cast<s16*>(listBase + entryOffset)) <= baseX) {
+			if (static_cast<float>(*reinterpret_cast<s16*>(entryBase + entryOffset)) <= baseX) {
 				finished = true;
-				*reinterpret_cast<s16*>(listBase + entryOffset) = static_cast<s16>(baseX);
+				*reinterpret_cast<s16*>(entryBase + entryOffset) = static_cast<s16>(baseX);
 			}
-
-			i++;
-			k--;
-		} while (k != 0);
+		}
 		if (finished) {
 			return 1;
 		}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -12,7 +12,6 @@ extern const float kUtilQuadDepth;
 extern const float kUtilHermiteCoeff2;
 extern const float kUtilHermiteCoeff3;
 extern const float kUtilHermiteCoeffNeg2;
-extern "C" const Vec gUtilUpVector = {0.0f, 1.0f, 0.0f};
 static Vec s_zeroVector = {0.0f, 0.0f, 0.0f};
 
 static inline MtxPtr GetCameraMatrix()


### PR DESCRIPTION
Summary:
- Correct CMapObj::CheckHitCylinderNear to void, matching the caller pattern and CMapHit/COctTree near-hit helpers that report through shared hit state.
- Reshape CMenuPcs::UniteCloseAnim inner loops to reload the command list entry base inside the loop and use bounded for loops, matching the target loop shape better.
- Remove the duplicate source definition of gUtilUpVector; the MAP attributes that rodata symbol to the auto rodata object, and util no longer needs to define it locally.

Objdiff evidence:
- main/mapobj CheckHitCylinderNear__7CMapObjFP12CMapCylinderP3VecUl: 57.452515% -> 58.793297%
- main/menu_cmd UniteCloseAnim__8CMenuPcsFi: 8.3970585% -> 8.838235%
- main/util [extabindex-0]: 98.65385% -> 98.84615%

Verification:
- ninja
- git diff --check