### PR TITLE
Improve artifact cursor control matching

### DIFF
--- a/include/ffcc/menu_arti.h
+++ b/include/ffcc/menu_arti.h
@@ -1,16 +1,6 @@
 #ifndef _FFCC_MENU_ARTI_H_
 #define _FFCC_MENU_ARTI_H_
 
-class CMenuPcs
-{
-public:
-    void ArtiInit();
-    void ArtiInit1();
-    bool ArtiOpen();
-    int ArtiCtrl();
-    bool ArtiClose();
-    void ArtiDraw();
-    int ArtiCtrlCur();
-};
+#include "ffcc/p_menu.h"
 
 #endif // _FFCC_MENU_ARTI_H_

--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -210,6 +210,13 @@ public:
     void WMSubMenuInit();
     void WMChgMenu();
     void GetOptionData();
+    void ArtiInit();
+    void ArtiInit1();
+    bool ArtiOpen();
+    int ArtiCtrl();
+    bool ArtiClose();
+    void ArtiDraw();
+    int ArtiCtrlCur();
     void SetParty();
     void SetCMakeEnd(int);
     void ClrCMakeFlg(int);
@@ -268,7 +275,11 @@ public:
     unsigned char m_pad330[0x340 - 0x330];
     unsigned char m_externalFontTlut[0x740 - 0x340];
     int m_mode;
-    unsigned char m_pad744[0x864 - 0x744];
+    unsigned char m_pad744[0x82C - 0x744];
+    short* m_artiState;
+    unsigned char m_pad830[0x850 - 0x830];
+    short* m_artiList;
+    unsigned char m_pad854[0x864 - 0x854];
     unsigned short m_battleStateFlag;
     unsigned char m_pad866[0x8A0 - 0x866];
 };

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -56,10 +56,9 @@ struct ArtiState {
 	unsigned char pad_0020[2];
 	short frame;
 	unsigned char pad_0024[2];
-	short selection;
-	unsigned char pad_0028[8];
-	short prevSelection;
+	short selections[5];
 	short currentSelection;
+	short prevSelection;
 	short scrollOffset;
 };
 
@@ -84,29 +83,16 @@ struct ArtiOpenAnim {
 	float targetY;
 };
 
-struct MenuArtiMembers {
-	unsigned char pad_0000[0xF8];
-	CFont* m_helpFont;
-	unsigned char pad_00FC[0x0C];
-	CFont* m_listFont;
-	unsigned char pad_010C[0x720];
-	s16* m_artiState;
-	unsigned char pad_0830[0x20];
-	s16* m_artiList;
-};
-
-STATIC_ASSERT(offsetof(MenuArtiMembers, m_helpFont) == 0xF8);
-STATIC_ASSERT(offsetof(MenuArtiMembers, m_listFont) == 0x108);
-STATIC_ASSERT(offsetof(MenuArtiMembers, m_artiState) == 0x82C);
-STATIC_ASSERT(offsetof(MenuArtiMembers, m_artiList) == 0x850);
+STATIC_ASSERT(offsetof(CMenuPcs, m_artiState) == 0x82C);
+STATIC_ASSERT(offsetof(CMenuPcs, m_artiList) == 0x850);
 STATIC_ASSERT(offsetof(ArtiState, initialized) == 0xB);
 STATIC_ASSERT(offsetof(ArtiState, closeRequested) == 0xD);
 STATIC_ASSERT(offsetof(ArtiState, state) == 0x10);
 STATIC_ASSERT(offsetof(ArtiState, moveDirection) == 0x1E);
 STATIC_ASSERT(offsetof(ArtiState, frame) == 0x22);
-STATIC_ASSERT(offsetof(ArtiState, selection) == 0x26);
-STATIC_ASSERT(offsetof(ArtiState, prevSelection) == 0x30);
-STATIC_ASSERT(offsetof(ArtiState, currentSelection) == 0x32);
+STATIC_ASSERT(offsetof(ArtiState, selections) == 0x26);
+STATIC_ASSERT(offsetof(ArtiState, currentSelection) == 0x30);
+STATIC_ASSERT(offsetof(ArtiState, prevSelection) == 0x32);
 STATIC_ASSERT(offsetof(ArtiState, scrollOffset) == 0x34);
 STATIC_ASSERT(offsetof(ArtiOpenAnim, alpha) == 0x10);
 STATIC_ASSERT(offsetof(ArtiOpenAnim, scale) == 0x14);
@@ -122,24 +108,19 @@ STATIC_ASSERT(offsetof(ArtiOpenAnim, targetX) == 0x38);
 STATIC_ASSERT(offsetof(ArtiOpenAnim, targetY) == 0x3C);
 STATIC_ASSERT(sizeof(ArtiOpenAnim) == 0x40);
 
-static inline MenuArtiMembers& GetMenuArtiMembers(CMenuPcs* menu)
-{
-	return *reinterpret_cast<MenuArtiMembers*>(menu);
-}
-
 static inline ArtiState* GetArtiStateStruct(CMenuPcs* menu)
 {
-	return reinterpret_cast<ArtiState*>(GetMenuArtiMembers(menu).m_artiState);
+	return reinterpret_cast<ArtiState*>(menu->m_artiState);
 }
 
 static inline s16* GetArtiState(CMenuPcs* menu)
 {
-	return GetMenuArtiMembers(menu).m_artiState;
+	return menu->m_artiState;
 }
 
 static inline s16* GetArtiList(CMenuPcs* menu)
 {
-	return GetMenuArtiMembers(menu).m_artiList;
+	return menu->m_artiList;
 }
 
 static inline int GetArtiStateBase(CMenuPcs* menu)
@@ -154,12 +135,12 @@ static inline int GetArtiListBase(CMenuPcs* menu)
 
 static inline CFont* GetArtiListFont(CMenuPcs* menu)
 {
-	return GetMenuArtiMembers(menu).m_listFont;
+	return menu->m_fonts[1];
 }
 
 static inline CFont* GetArtiHelpFont(CMenuPcs* menu)
 {
-	return GetMenuArtiMembers(menu).m_helpFont;
+	return menu->m_fonts[0];
 }
 } // namespace
 
@@ -198,29 +179,31 @@ int CMenuPcs::ArtiCtrlCur()
 	unsigned short uVar4;
 	int iVar5;
 	int iVar6;
+	int padLock;
 
 	bVar2 = false;
-	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+	padLock = Pad._452_4_;
+	if ((padLock != 0) || (Pad._448_4_ != -1)) {
 		bVar2 = true;
 	}
 	if (bVar2) {
 		uVar3 = 0;
 	} else {
-		int padIndex = bVar2;
+		int padIndex = 0;
 		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
-		uVar3 = *reinterpret_cast<u16*>(reinterpret_cast<u8*>(&Pad) + padIndex * 0x54 + 8);
+		uVar3 = Pad.GetPadInputs()[padIndex].buttonDown[0];
 	}
 
 	bVar2 = false;
-	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
+	if ((padLock != 0) || (Pad._448_4_ != -1)) {
 		bVar2 = true;
 	}
 	if (bVar2) {
 		uVar4 = 0;
 	} else {
-		int padIndex = bVar2;
+		int padIndex = 0;
 		padIndex &= ~-((__cntlzw((unsigned int)Pad._448_4_) & 0x20) >> 5);
-		uVar4 = *reinterpret_cast<u16*>(reinterpret_cast<u8*>(&Pad) + padIndex * 0x54 + 0x14);
+		uVar4 = Pad.GetPadInputs()[padIndex].repeatButton;
 	}
 
 	if (uVar4 == 0) {
@@ -228,33 +211,29 @@ int CMenuPcs::ArtiCtrlCur()
 	}
 
 	iVar5 = GetArtiStateBase(this);
-	if ((uVar4 & 8) == 0) {
-		if ((uVar4 & 4) != 0) {
-			iVar6 = iVar5 + *(short*)(iVar5 + 0x30) * 2;
-			sVar1 = *(short*)(iVar6 + 0x26);
-			if (sVar1 < 7) {
-				*(short*)(iVar6 + 0x26) = sVar1 + 1;
-				Sound.PlaySe(1, 0x40, 0x7f, 0);
-			} else if ((int)*(short*)(iVar5 + 0x34) + (int)sVar1 < 0x48) {
-				*(short*)(iVar5 + 0x34) = *(short*)(iVar5 + 0x34) + 1;
-				Sound.PlaySe(1, 0x40, 0x7f, 0);
-			} else {
-				Sound.PlaySe(4, 0x40, 0x7f, 0);
-			}
-		}
-	} else {
+	if ((uVar4 & 8) != 0) {
 		iVar6 = iVar5 + *(short*)(iVar5 + 0x30) * 2;
 		sVar1 = *(short*)(iVar6 + 0x26);
-		if (sVar1 == 0) {
-			if (*(short*)(iVar5 + 0x34) == 0) {
-				Sound.PlaySe(4, 0x40, 0x7f, 0);
-			} else {
-				*(short*)(iVar5 + 0x34) = *(short*)(iVar5 + 0x34) + -1;
-				Sound.PlaySe(1, 0x40, 0x7f, 0);
-			}
-		} else {
+		if (sVar1 != 0) {
 			*(short*)(iVar6 + 0x26) = sVar1 + -1;
 			Sound.PlaySe(1, 0x40, 0x7f, 0);
+		} else if (*(short*)(iVar5 + 0x34) != 0) {
+			*(short*)(iVar5 + 0x34) = *(short*)(iVar5 + 0x34) + -1;
+			Sound.PlaySe(1, 0x40, 0x7f, 0);
+		} else {
+			Sound.PlaySe(4, 0x40, 0x7f, 0);
+		}
+	} else if ((uVar4 & 4) != 0) {
+		iVar6 = iVar5 + *(short*)(iVar5 + 0x30) * 2;
+		sVar1 = *(short*)(iVar6 + 0x26);
+		if (sVar1 < 7) {
+			*(short*)(iVar6 + 0x26) = sVar1 + 1;
+			Sound.PlaySe(1, 0x40, 0x7f, 0);
+		} else if ((int)*(short*)(iVar5 + 0x34) + (int)sVar1 < 0x48) {
+			*(short*)(iVar5 + 0x34) = *(short*)(iVar5 + 0x34) + 1;
+			Sound.PlaySe(1, 0x40, 0x7f, 0);
+		} else {
+			Sound.PlaySe(4, 0x40, 0x7f, 0);
 		}
 	}
 
@@ -269,14 +248,12 @@ int CMenuPcs::ArtiCtrlCur()
 			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
 			return 1;
 		}
-		if ((uVar3 & 0x100) == 0) {
-			if ((uVar3 & 0x200) != 0) {
-				*(char*)(GetArtiStateBase(this) + 0xd) = 1;
-				Sound.PlaySe(3, 0x40, 0x7f, 0);
-				return 1;
-			}
-		} else {
+		if ((uVar3 & 0x100) != 0) {
 			Sound.PlaySe(4, 0x40, 0x7f, 0);
+		} else if ((uVar3 & 0x200) != 0) {
+			*(char*)(GetArtiStateBase(this) + 0xd) = 1;
+			Sound.PlaySe(3, 0x40, 0x7f, 0);
+			return 1;
 		}
 	}
 
@@ -562,7 +539,7 @@ int CMenuPcs::ArtiCtrl()
 	ArtiState* state = GetArtiStateStruct(this);
 	int result;
 
-	state->currentSelection = state->prevSelection;
+	state->prevSelection = state->currentSelection;
 	result = ArtiCtrlCur();
 	if (result != 0) {
 		ArtiInit1();


### PR DESCRIPTION
## Summary
- Split the artifact state/list pointers out of CMenuPcs padding and route menu_arti through the real CMenuPcs layout.
- Replace raw artifact pad reads in ArtiCtrlCur with the existing CPad::PadInput access pattern used by menu_lst.
- Reorder ArtiCtrlCur cursor and cancel branch structure to match the target control flow more closely.

## Evidence
- ninja: passes for GCCP01 (existing wm_menu warnings only).
- Objdiff ArtiCtrlCur__8CMenuPcsFv: 74.2266% -> 94.6798%.
- Current target checks:
  - ArtiCtrl__8CMenuPcsFv: 100.0%, size 84
  - ArtiCtrlCur__8CMenuPcsFv: 94.6798%, size 812
  - ArtiInit__8CMenuPcsFv: 61.658825%, size 680
  - ArtiInit1__8CMenuPcsFv: 49.192055%, size 604
- Unit report: main/menu_arti fuzzy_match_percent = 78.975845.

## Plausibility
- Uses the established pad input accessor pattern rather than raw byte offsets.
- Recovers CMenuPcs artifact member layout at known offsets 0x82C and 0x850.
- Branch rewrites preserve behavior while matching the target's likely original source ordering.