### PR TITLE
Improve deformation shape bounds setup

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -410,10 +410,10 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 		projected[i].y = screenCenterY - projected[i].y / screenScaleY;
 	}
 
-	minY = FLOAT_80330620;
+	maxX = FLOAT_80330624;
 	maxY = FLOAT_80330624;
-	minX = minY;
-	maxX = maxY;
+	minX = FLOAT_80330620;
+	minY = FLOAT_80330620;
 	for (i = 0; i < 4; i++) {
 		if (projected[i].x > maxX) {
 			maxX = projected[i].x;


### PR DESCRIPTION
## Summary
- Initialize RenderDeformationShape bounds directly as maxX/maxY/minX/minY constants.
- Keeps the source shape closer to the Ghidra decompilation and reduces register churn in the bounds setup.

## Evidence
- ninja passes.
- main/pppYmDeformationShp RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d: 87.743034% -> 87.990715%.
- main/pppYmDeformationShp pppRenderYmDeformationShp remained 95.48898%.

## Plausibility
- The change expresses independent bounding-box initializers instead of deriving X bounds from Y locals, matching the decompiled original shape without hardcoded addresses or section forcing.