### PR TITLE
Remove duplicate pppYmChangeTex sdata2 constant

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -91,7 +91,6 @@ extern const float FLOAT_80330df8;
 extern const float FLOAT_80330dfc;
 extern const float FLOAT_80330e00;
 extern const double DOUBLE_80330E08;
-static const double sPppYmChangeTexDouble = 4503601774854144.0;
 extern const float DAT_80330e10[2] = {0.0f, 0.0f};
 
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_data) == 0xA4);


### PR DESCRIPTION
## Summary
- Removed an unused local copy of the 4503601774854144.0 double from pppYmChangeTex.
- This avoids emitting an extra 8 bytes in the units .sdata2 while keeping the declared DOUBLE_80330E08 symbol as the real reference point.

## Evidence
- ninja succeeds; build/GCCP01/main.dol: OK.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppYmChangeTex -o /tmp/pppYmChangeTex.diff.json pppConstructYmChangeTex
- .rodata: size 24, 100.0% match
- .sdata2: size 28, 100.0% match
- pppConstructYmChangeTex: 100.0% match
- python3 tools/agent_select_target.py no longer lists main/pppYmChangeTex as a data opportunity.

## Plausibility
- The removed constant was local and unused; the file already declares the shipped DOUBLE_80330E08 symbol separately. Removing the duplicate is a source cleanup and fixes data layout without adding section hacks or artificial references.