### PR TITLE
Use shared constants in pppConstrainCameraDir

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -6,6 +6,8 @@
 #include <dolphin/mtx.h>
 
 void pppSetFpMatrix(_pppMngSt*);
+extern const float FLOAT_803320B8;
+extern const float FLOAT_803320C0;
 extern const float FLOAT_803320C4;
 
 /*
@@ -43,9 +45,9 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
 
             PSMTXIdentity(pppMngStPtr->m_matrix.value);
 
-            pppMngSt->m_scale.x = 1.3333f * scale;
+            pppMngSt->m_scale.x = FLOAT_803320C0 * scale;
             pppMngSt->m_scale.y = scale;
-            pppMngSt->m_scale.z = 1.0f;
+            pppMngSt->m_scale.z = FLOAT_803320B8;
 
             Mtx scaleMtx;
             PSMTXScale(scaleMtx, pppMngSt->m_scale.x, pppMngSt->m_scale.y, pppMngSt->m_scale.z);


### PR DESCRIPTION
## Summary
- Use the existing shared sdata2 constants for the camera-dir scale vector instead of float literals.
- This matches the Ghidra decomp naming for FLOAT_803320C0 and FLOAT_803320B8 and avoids relying on pooled literals in source.

## Evidence
- Built with `ninja`.
- `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir -o /tmp/camdir_pr.json pppFrameConstrainCameraDir`
- `pppFrameConstrainCameraDir`: 99.685036% -> 99.76378%, size remains 508b.
- Remaining diffs dropped from 8 instruction mismatches to 6; the scale constant loads now use `FLOAT_803320C0` and `FLOAT_803320B8` directly.

## Plausibility
- These constants already exist in `config/GCCP01/symbols.txt` and are used in adjacent source.
- The generated code remains the same size and the source better reflects the original shared constant usage shown by the decompilation.