### PR TITLE
Match material editor viewer SRT defaults

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -445,16 +445,16 @@ void CMaterialEditorPcs::calcViewer()
         m_usbStream.SetUSBStreamDataDone();
     }
 
-    rotationValue = FLOAT_8032FCC8;
+    rotationValue = FLOAT_8032FCD8;
     srt.transZ = FLOAT_8032FCD8;
     srt.transY = FLOAT_8032FCD8;
     srt.transX = FLOAT_8032FCD8;
     srt.rotZ = rotationValue;
     srt.rotY = rotationValue;
     srt.rotX = rotationValue;
-    srt.scaleZ = FLOAT_8032FCD8;
-    srt.scaleY = FLOAT_8032FCD8;
-    srt.scaleX = FLOAT_8032FCD8;
+    srt.scaleZ = FLOAT_8032FCC8;
+    srt.scaleY = FLOAT_8032FCC8;
+    srt.scaleX = FLOAT_8032FCC8;
     srt.transX = field268_0x15c.x;
     srt.transY = field268_0x15c.y;
     srt.transZ = -field268_0x15c.z;


### PR DESCRIPTION
## Summary
- Initialize `CMaterialEditorPcs::calcViewer` SRT rotation to zero and scale to one.
- This matches the normal SRT default layout and the target store order for the viewer camera setup.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o /tmp/p_MaterialEditor_calcViewer_final.json --format json calcViewer__18CMaterialEditorPcsFv`
- `calcViewer__18CMaterialEditorPcsFv`: 99.74138% before -> 99.956894% objdiff symbol score after; build report now marks the function as matched, adding 464 matched code bytes and one matched function.

## Plausibility
- Translation and rotation default to `0.0f`, scale defaults to `1.0f`, which is the expected SRT identity initialization.
- The change removes an implausible zero-scale viewer setup rather than adding compiler coaxing.