### PR TITLE
Fix pppDrawMdlTs duplicate constant definition

### DIFF
--- a/src/pppDrawMdlTs.cpp
+++ b/src/pppDrawMdlTs.cpp
@@ -15,7 +15,6 @@ void SetTexScroll__12CMaterialManFffff(CMaterialMan*, float, float, float, float
 
 extern "C" const f32 kPppKeShpTail2XZero = 0.0f;
 extern const float FLOAT_803304F0;
-extern const float kPppKeShpTail2XZero = 0.0f;
 
 // Use simple forward declarations and casting approach
 


### PR DESCRIPTION
## Summary
- Remove the duplicate C++-linkage definition of `kPppKeShpTail2XZero` in `pppDrawMdlTs.cpp`.
- Keep the existing `extern "C"` definition so the symbol remains provided once.

## Evidence
- Before: fresh `main` failed during `ninja` at `src/pppDrawMdlTs.cpp:18` with `object kPppKeShpTail2XZero redefined`.
- After: `ninja` completes and `build/GCCP01/main.dol: OK`.

## Plausibility
- This is not compiler coaxing; it removes an impossible duplicate definition while preserving the named constant already required by the particle code.