### PR TITLE
Fix pppDrawMdlTs zero constant linkage

### DIFF
--- a/src/pppDrawMdlTs.cpp
+++ b/src/pppDrawMdlTs.cpp
@@ -15,7 +15,6 @@ void SetTexScroll__12CMaterialManFffff(CMaterialMan*, float, float, float, float
 
 extern "C" const f32 kPppKeShpTail2XZero = 0.0f;
 extern const float FLOAT_803304F0;
-extern const float kPppKeShpTail2XZero = 0.0f;
 
 // Use simple forward declarations and casting approach
 


### PR DESCRIPTION
Summary
- Remove the duplicate C++ definition of kPppKeShpTail2XZero.
- Keep the C-linkage .sdata2 definition used by pppKeShpTail2X.
- Restores a clean PAL build from fresh main.

Evidence
- Before: ninja failed compiling src/pppDrawMdlTs.cpp with object kPppKeShpTail2XZero redefined.
- After: ninja succeeds.
- Objdiff for main/pppDrawMdlTs reports .text 100.0% / 512 bytes and .sdata2 100.0% / 4 bytes.
- kPppKeShpTail2XZero remains 100.0% matched / 4 bytes.

Plausibility
The unit already had the real C-linkage symbol definition. The removed line was a second definition of the same constant in the same translation unit, so this is a linkage repair rather than compiler coaxing.