### PR TITLE
Match CGoOutMenu SetMainMode

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -564,9 +564,8 @@ void CGoOutMenu::SetMenuStr(long timer, int lineCount, ...)
 
     messageIndex = field_0x38;
     if (field_0x36 >= 0) {
-        CMenuPcsGoOutLayout& menuPcsLayout = *reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs);
-        MenuMcWinState(menuPcsLayout).m_mode = 2;
-        MenuGoOutState(menuPcsLayout).m_animFrame = 0;
+        MenuMcWinState(*reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs)).m_mode = 2;
+        MenuGoOutState(*reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs)).m_animFrame = 0;
     }
 
     field_0x45 = 0;
@@ -695,9 +694,8 @@ void CGoOutMenu::SetMainMode(unsigned char mode)
         }
         MenuPcs.ChgAllModel();
         if (field_0x36 >= 0) {
-            CMenuPcsGoOutLayout& menuPcsLayout = *reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs);
-            MenuMcWinState(menuPcsLayout).m_mode = 2;
-            MenuGoOutState(menuPcsLayout).m_animFrame = 0;
+            MenuMcWinState(*reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs)).m_mode = 2;
+            MenuGoOutState(*reinterpret_cast<CMenuPcsGoOutLayout*>(&MenuPcs)).m_animFrame = 0;
         }
         field_0x45 = 0;
         field_0x34 = 0x1e;


### PR DESCRIPTION
## Summary
- Adjust the `MenuPcs` layout accesses in `CGoOutMenu::SetMenuStr` and `CGoOutMenu::SetMainMode` to use direct member access instead of a temporary layout reference in the close-window update blocks.
- This matches the original register allocation for `SetMainMode` and slightly improves `SetMenuStr`.

## Evidence
- `ninja` passes.
- `main/goout` before: fuzzy 44.49205%, matched code 44 bytes, matched functions 1/10.
- `main/goout` after: fuzzy 44.502792%, matched code 660 bytes, matched functions 2/10.
- `SetMainMode__10CGoOutMenuFUc`: 99.83766% -> 100.0%.
- `SetMenuStr__10CGoOutMenuFlie`: 78.43023% -> 78.72093%.

## Plausibility
- The behavior is unchanged: both edited blocks still set the memory-card window mode and go-out animation frame through the same `MenuPcs` layout.
- The source is closer to the emitted code without adding manual vtable/data hacks, hard-coded addresses, or artificial labels.
