### PR TITLE
Match RedMidiCtrl sweep command read

### DIFF
--- a/src/RedSound/RedMidiCtrl.cpp
+++ b/src/RedSound/RedMidiCtrl.cpp
@@ -1426,7 +1426,7 @@ static void __MidiCtrl_Sweep(RedSoundCONTROL*, RedKeyOnDATA*, RedTrackDATA* trac
         delta[0] += 1;
     }
 
-    command = *(s8*)track->m_command++;
+    command = (s8)*track->m_command++;
     command <<= 8;
     value = 0;
     track->m_sweepAdd = DataAddCompute(&value, command, delta);


### PR DESCRIPTION
## Summary
- Match __MidiCtrl_Sweep__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA in main/RedSound/RedMidiCtrl.
- Change the command-byte read from pointer-cast dereference to value cast, keeping the source behavior but matching MWCC register selection for the signed byte load.

## Evidence
- Before: __MidiCtrl_Sweep was 99.81132% with 2 instruction diffs. The lbz/extsb sequence loaded through r4 before moving to r29.
- After: build/tools/objdiff-cli diff -p . -u main/RedSound/RedMidiCtrl -o - __MidiCtrl_Sweep__FP15RedSoundCONTROLP12RedKeyOnDATAP12RedTrackDATA reports 100.0% and 0 diffs.
- ninja completes successfully for GCCP01.

## Plausibility
- This is a source-equivalent signed-byte conversion for the MIDI command stream.
- It removes no structure and adds no matching-only hacks; it expresses the command byte as a signed value rather than reinterpreting the command pointer type.