### PR TITLE
Match bonus menu draw string

### DIFF
--- a/src/bonus_menu.cpp
+++ b/src/bonus_menu.cpp
@@ -57,7 +57,9 @@ unsigned char gBonusMenuFlagPad = 0;
 float* gBonusCheckMarkPosBuffer = 0;
 }
 #pragma force_active reset
-extern "C" const char s_draw_Bonus_pctd_801DD5C0[] = "draw Bonus[%d]\n";
+extern "C" const char s_draw_Bonus_pctd_801DD5C0[16] = {
+    'd', 'r', 'a', 'w', ' ', 'B', 'o', 'n', 'u', 's', ' ', '(', '%', 'd', ')', '\n',
+};
 extern "C" const char s_bonus_menu_cpp_801DD588[] = "bonus_menu.cpp";
 
 namespace {


### PR DESCRIPTION
## Summary
- Correct the bonus menu debug format string to match the original rodata bytes.
- Use an explicit 16-byte char array because the shipped symbol includes the trailing newline without an in-symbol null terminator.

## Evidence
- Unit: main/bonus_menu
- Symbol: s_draw_Bonus_pctd_801DD5C0
- Before: symbol 81.25%, .rodata 81.25%
- After: symbol 100.0%, .rodata 100.0%
- Build: ninja passes

## Plausibility
The target object bytes are  for the 16-byte symbol. This is a source string correction, not a section or vtable workaround.