### PR TITLE
Improve pppCharaBreak display-list loop matching

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -386,7 +386,7 @@ void pppFrameCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkB* step, CharaBr
                 CharaBreakDisplayList* displayList = reinterpret_cast<CharaBreakMeshRef*>(mesh)->m_data->m_displayLists;
                 CharaBreakDisplayListPair** dlEntries =
                     (CharaBreakDisplayListPair**)(((u32*)work->m_meshBuffers)[i] + ((displayListCount - 1) << 2));
-                for (int dl = displayListCount - 1; dl >= 0; dl--) {
+                for (int dl = displayListCount - 1; dl >= 0; dl--, displayList++) {
                     *dlEntries = (CharaBreakDisplayListPair*)pppMemFree__FPv(
                         0x10, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppCharaBreak_cpp_801dd690), 0x3FC);
                     if (*dlEntries == NULL) {
@@ -425,7 +425,6 @@ void pppFrameCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkB* step, CharaBr
                                          (*dlEntries)->m_polygonCount, (CChara::CModel*)model, (CChara::CMesh*)mesh);
 
                     dlEntries--;
-                    displayList++;
                 }
             }
 
@@ -1010,7 +1009,7 @@ extern "C" void CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f(v
         s32 materialIndex = meshData->m_displayListCount - 1;
         s32 materialOffset = materialIndex * 4;
 
-        for (; materialIndex >= 0; materialIndex--) {
+        for (; materialIndex >= 0; materialIndex--, materialData++) {
             CharaBreakDisplayListPair** meshTable =
                 reinterpret_cast<CharaBreakDisplayListPair**>(workData->m_meshBuffers) + meshIndex;
             CharaBreakDisplayListPair** displayListEntry =
@@ -1081,7 +1080,6 @@ extern "C" void CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f(v
             }
 
             materialOffset -= 4;
-            materialData++;
         }
     }
 }

--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -369,13 +369,14 @@ void pppFrameCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkB* step, CharaBr
             ((u32*)work->m_meshBuffers)[i] = (u32)pppMemFree__FPv(
                 reinterpret_cast<CharaBreakMeshRef*>(mesh)->m_data->m_displayListCount << 2, pppEnvStPtr->m_stagePtr,
                 const_cast<char*>(s_pppCharaBreak_cpp_801dd690), 0x3E9);
-            if (((u32*)work->m_meshBuffers)[i] == 0) {
+            u32 meshBuffer = ((u32*)work->m_meshBuffers)[i];
+            if (meshBuffer == 0) {
                 goto fail;
             }
 
             {
                 int displayListCount = reinterpret_cast<CharaBreakMeshRef*>(mesh)->m_data->m_displayListCount;
-                int* dlEntries = (int*)((u32*)work->m_meshBuffers)[i];
+                int* dlEntries = (int*)meshBuffer;
                 for (int dl = displayListCount - 1; dl >= 0; dl--) {
                     dlEntries[dl] = 0;
                 }
@@ -384,9 +385,10 @@ void pppFrameCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkB* step, CharaBr
             {
                 int displayListCount = reinterpret_cast<CharaBreakMeshRef*>(mesh)->m_data->m_displayListCount;
                 CharaBreakDisplayList* displayList = reinterpret_cast<CharaBreakMeshRef*>(mesh)->m_data->m_displayLists;
+                int dl = displayListCount - 1;
                 CharaBreakDisplayListPair** dlEntries =
-                    (CharaBreakDisplayListPair**)(((u32*)work->m_meshBuffers)[i] + ((displayListCount - 1) << 2));
-                for (int dl = displayListCount - 1; dl >= 0; dl--, displayList++) {
+                    (CharaBreakDisplayListPair**)(meshBuffer + (dl << 2));
+                for (; dl >= 0; dl--, displayList++) {
                     *dlEntries = (CharaBreakDisplayListPair*)pppMemFree__FPv(
                         0x10, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppCharaBreak_cpp_801dd690), 0x3FC);
                     if (*dlEntries == NULL) {


### PR DESCRIPTION
## Summary
- Keep the allocated per-mesh display-list table pointer live while initializing pppCharaBreak mesh display-list data.
- Move display-list pointer advances into the loop increments for pppFrameCharaBreak and CharaBreak_AfterDrawMeshCallback.
- These changes match the decompiled loop structure more closely without changing behavior.

## Objdiff Evidence
- main/pppCharaBreak unit fuzzy: 88.70303% -> 88.952225%
- pppFrameCharaBreak: 95.67368% -> 97.02105%
- CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f: 98.97175% -> 98.98305%

## Verification
- ninja
- build/tools/objdiff-cli report generate -p . --format json --output /tmp/report.pr.json
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o /tmp/frame.pr.json pppFrameCharaBreak
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o /tmp/afterdraw.pr.json CharaBreak_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f