### PR TITLE
Improve gobject animation flag codegen

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2151,7 +2151,9 @@ void CGObject::onDraw()
  */
 void CGObject::CancelMove(int moveType)
 {
-    *((u8*)&m_weaponNodeFlags + 1) &= 0xDF;
+    u8 flags = *((u8*)&m_weaponNodeFlags + 1);
+    flags = static_cast<u8>(__rlwimi(flags, 0, 5, 26, 26));
+    *((u8*)&m_weaponNodeFlags + 1) = flags;
 
     CFlatRuntime::CStack arg;
     arg.m_word = static_cast<u32>(moveType);
@@ -2654,7 +2656,7 @@ void CGObject::Turn(float targetRot, int turnFrames)
 {
     u8* shieldFlags = reinterpret_cast<u8*>(&m_shieldNodeFlags);
 
-    *shieldFlags = (*shieldFlags & 0xBF) | 0x40;
+    *shieldFlags = static_cast<u8>(__rlwimi(*shieldFlags, 1, 6, 25, 25));
     m_rotTargetY = targetRot;
     m_turnBaseSpeed =
         Math.DstRot(m_rotBaseY, m_rotTargetY) / static_cast<float>(turnFrames);
@@ -2666,12 +2668,13 @@ void CGObject::Turn(float targetRot, int turnFrames)
     }
 
     m_currentAnimSlot = m_animQueue[animSlot - 0x41];
-    *(reinterpret_cast<u8*>(&m_weaponNodeFlags) + 1) &= 0xFE;
+    *(reinterpret_cast<u8*>(&m_weaponNodeFlags) + 1) =
+        static_cast<u8>(__rlwimi(*(reinterpret_cast<u8*>(&m_weaponNodeFlags) + 1), 0, 0, 31, 31));
     m_animExtraIndex = -1;
     m_collisionPushTimer = -1;
-    *shieldFlags &= 0xFD;
-    *shieldFlags &= 0x7F;
-    *shieldFlags = (*shieldFlags & 0xF7) | 8;
+    *shieldFlags = static_cast<u8>(__rlwimi(*shieldFlags, 0, 1, 30, 30));
+    *shieldFlags = static_cast<u8>(__rlwimi(*shieldFlags, 0, 7, 24, 24));
+    *shieldFlags = static_cast<u8>(__rlwimi(*shieldFlags, 1, 3, 28, 28));
     m_turnSpeed = sZeroFloat;
 }
 
@@ -3109,7 +3112,7 @@ void CGObject::CancelAnim(int keepFacing)
 	m_currentAnimSlot = -1;
 
 	u8 flags = *((u8*)&m_shieldNodeFlags);
-	flags &= 0xbf;
+	flags = static_cast<u8>(__rlwimi(flags, 0, 6, 25, 25));
 	*((u8*)&m_shieldNodeFlags) = flags;
 
 	m_turnSpeed = sZeroFloat;
@@ -3120,11 +3123,11 @@ void CGObject::CancelAnim(int keepFacing)
 	}
 
 	flags = *((u8*)&m_shieldNodeFlags);
-	flags &= 0xf7;
+	flags = static_cast<u8>(__rlwimi(flags, 0, 3, 28, 28));
 	*((u8*)&m_shieldNodeFlags) = flags;
 
 	flags = *((u8*)&m_shieldNodeFlags);
-	flags &= 0x7f;
+	flags = static_cast<u8>(__rlwimi(flags, 0, 7, 24, 24));
 	*((u8*)&m_shieldNodeFlags) = flags;
 }
 
@@ -3140,7 +3143,6 @@ void CGObject::CancelAnim(int keepFacing)
 void CGObject::PlayAnim(int slot, int param2, int param3, int param4, int param5, signed char* animData)
 {
     signed char weaponFlag = static_cast<signed char>(param2);
-    signed char shieldFlag = static_cast<signed char>(param3);
     u8 flags;
 
     m_currentAnimSlot = m_animQueue[slot - 0x41];
@@ -3152,20 +3154,21 @@ void CGObject::PlayAnim(int slot, int param2, int param3, int param4, int param5
     m_animExtraIndex = static_cast<short>(param4);
     m_collisionPushTimer = static_cast<short>(param5);
 
+    signed char shieldFlag = static_cast<signed char>(param3);
     flags = *reinterpret_cast<u8*>(&m_shieldNodeFlags);
     flags = static_cast<u8>(__rlwimi(flags, shieldFlag, 1, 30, 30));
     *reinterpret_cast<u8*>(&m_shieldNodeFlags) = flags;
 
-    if (animData == 0) {
-        flags = *reinterpret_cast<u8*>(&m_shieldNodeFlags);
-        flags = static_cast<u8>(__rlwimi(flags, 0, 7, 24, 24));
-        *reinterpret_cast<u8*>(&m_shieldNodeFlags) = flags;
-    } else {
+    if (animData != 0) {
         flags = *reinterpret_cast<u8*>(&m_shieldNodeFlags);
         flags = static_cast<u8>(__rlwimi(flags, 1, 7, 24, 24));
         *reinterpret_cast<u8*>(&m_shieldNodeFlags) = flags;
         m_animQueuePos = '\0';
         memcpy(m_animQueue, animData, 4);
+    } else {
+        flags = *reinterpret_cast<u8*>(&m_shieldNodeFlags);
+        flags = static_cast<u8>(__rlwimi(flags, 0, 7, 24, 24));
+        *reinterpret_cast<u8*>(&m_shieldNodeFlags) = flags;
     }
 
     flags = *reinterpret_cast<u8*>(&m_shieldNodeFlags);


### PR DESCRIPTION
## Summary
- Use rlwimi-style bit updates for gobject animation/movement flag fields where the target does the same.
- Reorder PlayAnim's animation queue branch so the non-null anim data path matches the original fallthrough shape.

## Evidence
- ninja passes.
- main/gobject fuzzy match improved from 67.06782% to 67.495636%.
- CancelMove__8CGObjectFi: 69.954544% -> 96.86364%.
- CancelAnim__8CGObjectFi: 61.0% -> 96.0%.
- PlayAnim__8CGObjectFiiiiiPSc: 71.78261% -> 92.78261%.
- Turn__8CGObjectFfi: 69.82258% -> 77.66129%.

## Plausibility
- The changes keep the same C++ behavior while expressing flag writes in the compiler idiom already used in nearby matched code.
- No manual section forcing, fake symbols, or vtable/RTTI hacks.