### PR TITLE
Improve CCharaPcs viewer layout matching

### DIFF
--- a/include/ffcc/p_chara.h
+++ b/include/ffcc/p_chara.h
@@ -194,6 +194,7 @@ public:
     int LoadAnim(int, int, char*, int, int, int);
     void GetAnimStage();
 
+    u8 _pad004[0xC8];                         // 0x004
     CMemory::CStage* m_viewerModelStage;      // 0x0CC
     CMemory::CStage* m_viewerTextureStage;    // 0x0D0
     CMemory::CStage* m_viewerAnimStage;       // 0x0D4

--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -788,8 +788,12 @@ extern "C" void createViewer__9CCharaPcsFv(void* param_1)
         p[0x12C + i * 4 + 3] = colorCopy[3];
     }
 
-    unsigned int clearColor = 0x404040FF;
-    *(unsigned int*)(p + 0x0C) = 0x404040FF;
+    _GXColor clearColor;
+    clearColor.r = 0x40;
+    clearColor.g = 0x40;
+    clearColor.b = 0x40;
+    clearColor.a = 0xFF;
+    *(unsigned int*)(p + 0x0C) = *reinterpret_cast<unsigned int*>(&clearColor);
     SetCopyClear__8CGraphicF8_GXColori(&Graphic, &clearColor, 0xFFFF);
 
     self->m_viewerModel[0] = 0;

--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -722,9 +722,9 @@ extern "C" void createViewer__9CCharaPcsFv(void* param_1)
     register const char* viewerStrings = s_no_texture____801da7e8;
     unsigned int i;
     unsigned int x;
-    CColor colorTmp;
-    CColor colorCopy;
-    CColor white;
+    unsigned char colorTmp[4];
+    unsigned char colorCopy[4];
+    unsigned char white[4];
     char pathBuf[256];
     CFile::CHandle* fileHandle;
     unsigned char bumpLight[0x138];
@@ -773,19 +773,19 @@ extern "C" void createViewer__9CCharaPcsFv(void* param_1)
 
     for (i = 0; i < 5; i++) {
         unsigned char* whiteChannels =
-            reinterpret_cast<unsigned char*>(__ct__6CColorFUcUcUcUc(&white, 0xFF, 0xFF, 0xFF, 0xFF));
-        __ct__6CColorFv(&colorTmp);
+            reinterpret_cast<unsigned char*>(__ct__6CColorFUcUcUcUc(reinterpret_cast<CColor*>(white), 0xFF, 0xFF, 0xFF, 0xFF));
+        __ct__6CColorFv(reinterpret_cast<CColor*>(colorTmp));
         x = i ^ 0x80000000;
         float scale = static_cast<float>(static_cast<double>(x) - kCharaViewerColorCenterBias) * kCharaViewerLerpScale;
         for (int c = 0; c < 4; c++) {
             float channel = static_cast<float>(static_cast<double>(whiteChannels[c]) - kCharaViewerColorWhiteBias);
-            reinterpret_cast<unsigned char*>(&colorTmp)[c] = static_cast<unsigned char>(static_cast<int>(channel * scale));
+            colorTmp[c] = static_cast<unsigned char>(static_cast<int>(channel * scale));
         }
-        __ct__6CColorFR6CColor(&colorCopy, &colorTmp);
-        p[0x12C + i * 4 + 0] = reinterpret_cast<unsigned char*>(&colorCopy)[0];
-        p[0x12C + i * 4 + 1] = reinterpret_cast<unsigned char*>(&colorCopy)[1];
-        p[0x12C + i * 4 + 2] = reinterpret_cast<unsigned char*>(&colorCopy)[2];
-        p[0x12C + i * 4 + 3] = reinterpret_cast<unsigned char*>(&colorCopy)[3];
+        __ct__6CColorFR6CColor(reinterpret_cast<CColor*>(colorCopy), reinterpret_cast<CColor*>(colorTmp));
+        p[0x12C + i * 4 + 0] = colorCopy[0];
+        p[0x12C + i * 4 + 1] = colorCopy[1];
+        p[0x12C + i * 4 + 2] = colorCopy[2];
+        p[0x12C + i * 4 + 3] = colorCopy[3];
     }
 
     unsigned int clearColor = 0x404040FF;


### PR DESCRIPTION
## Summary
- add the missing pre-viewer padding to CCharaPcs so documented viewer fields land at their PAL offsets
- use raw color storage for createViewer temporary CColor construction to avoid extra automatic local constructors
- build the viewer clear color as GX channel fields instead of a packed integer

## Objdiff evidence
- p_chara: CharaPcs data 1620 bytes / 50.0% -> 1820 bytes / 100.0%
- p_chara_viewer: createViewer__9CCharaPcsFv 1488 bytes / 79.59718% -> 1480 bytes / 84.4169%
- p_chara_viewer: calcViewer__9CCharaPcsFv 74.57071% -> 74.679794%
- p_chara_viewer: drawViewer__9CCharaPcsFv 86.35953% -> 86.37381%
- p_chara_viewer: destroyViewer__9CCharaPcsFv unchanged at 96.55173%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_chara -o - CharaPcs
- build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o -