### PR TITLE
Match mapocttree sdata2 initialization

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -13,10 +13,10 @@ extern "C" {
 extern const float kMapOctTreeDefaultOffsetZ;
 }
 
-// Linkage definitions from config/GCCP01/symbols.txt.
-const float kOctTreeBoundMinInit = 10000000000.0f;
-const float kOctTreeBoundMaxInit = -10000000000.0f;
-const float kOctTreeCylinderPad = 1.0f;
+// Linkage declarations for sdata2 symbols claimed in config/GCCP01/symbols.txt.
+extern "C" const float kOctTreeBoundMinInit;
+extern "C" const float kOctTreeBoundMaxInit;
+extern "C" const float kOctTreeCylinderPad;
 struct CBoundRaw
 {
     CBoundRaw()
@@ -2241,8 +2241,8 @@ int CBound::CheckCross(CBound& other)
  */
 COctNode::COctNode()
 {
-	float min = kOctTreeBoundMinInit;
 	float max = kOctTreeBoundMaxInit;
+	float min = kOctTreeBoundMinInit;
 	float* bounds = (float*)this;
 
 	bounds[2] = min;


### PR DESCRIPTION
## Summary
- Declare mapocttree sdata2 constants against the existing configured data symbols instead of defining duplicate TU-local constants.
- Adjust COctNode constructor local load order so the externalized constants still use the PAL f-register order.

## Objdiff evidence
- main/mapocttree __sinit_mapocttree_cpp: 99.47369% (2 diffs) -> 100.0% (0 diffs)
- main/mapocttree __ct__8COctNodeFv: 99.166664% (2 diffs) -> 100.0% (0 diffs)

## Verification
- ninja
- git diff --check

## Plausibility
These constants are already claimed in config/GCCP01/symbols.txt/auto sdata; treating them as declarations in mapocttree.cpp removes duplicate local constants and matches the expected static initialization/linkage shape.