### PR TITLE
Improve itemobj carry and frame-always matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -452,7 +452,7 @@ void CGItemObj::onFrameStat()
 					condC = true;
 				}
 				if (condC) {
-					unsigned int cid = static_cast<unsigned int>(carryObj->GetCID());
+					unsigned int cid = static_cast<unsigned short>(carryObj->GetCID());
 					unsigned int stageCarry = (unsigned int)__cntlzw(0x6D - (cid & 0x6D));
 					if (((stageCarry >> 5) & 0xFF) != 0) {
 						condB = true;
@@ -488,7 +488,7 @@ void CGItemObj::onFrameStat()
 				bool useMenuLaunchSpeed = false;
 
 				if (Game.m_gameWork.m_menuStageMode != 0 && Game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
-					unsigned int carryCid = static_cast<unsigned int>(carryObj->GetCID());
+					unsigned int carryCid = static_cast<unsigned short>(carryObj->GetCID());
 					if ((carryCid & 0x6D) == 0x6D &&
 					    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(carryObj->m_scriptHandle) + 0x3B4) != 0) {
 						useMenuLaunchSpeed = true;
@@ -498,7 +498,7 @@ void CGItemObj::onFrameStat()
 				if (useMenuLaunchSpeed) {
 					launchSpeed = FLOAT_80331b18;
 				} else if (*(int*)(CFlat + 0x4780) == 1) {
-					unsigned int carryCid = static_cast<unsigned int>(carryObj->GetCID());
+					unsigned int carryCid = static_cast<unsigned short>(carryObj->GetCID());
 					if ((carryCid & 0x6D) == 0x6D &&
 					    1 < *reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(carryObj->m_scriptHandle) + 0x3E0)) {
 						launchSpeed = FLOAT_80331b18;

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -259,8 +259,12 @@ void CGItemObj::onDestroy()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80126f38
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::onFramePreCalc()
 {
@@ -1001,9 +1005,7 @@ void CGItemObj::carry(CGPartyObj* partyObj, int carryState, int carryMode)
 			isMenuBossStage = true;
 		}
 		if (isMenuBossStage) {
-			typedef unsigned int (*PartyVFunc)(CGPartyObj*);
-			PartyVFunc getCid = reinterpret_cast<PartyVFunc>((*reinterpret_cast<void***>(partyObj))[3]);
-			unsigned int cid = getCid(partyObj);
+			unsigned int cid = static_cast<unsigned short>(partyObj->GetCID());
 			unsigned int stageCarry = (unsigned int)__cntlzw(0x6D - (cid & 0x6D));
 			if (((stageCarry >> 5) & 0xFF) != 0) {
 				isStageCarry = true;
@@ -1030,9 +1032,7 @@ void CGItemObj::carry(CGPartyObj* partyObj, int carryState, int carryMode)
 					condC = true;
 				}
 				if (condC) {
-					typedef unsigned int (*PartyVFunc)(CGPartyObj*);
-					PartyVFunc getCid = reinterpret_cast<PartyVFunc>((*reinterpret_cast<void***>(partyObj))[3]);
-					unsigned int cid = getCid(partyObj);
+					unsigned int cid = static_cast<unsigned short>(partyObj->GetCID());
 					unsigned int stageCarry = (unsigned int)__cntlzw(0x6D - (cid & 0x6D));
 					if (((stageCarry >> 5) & 0xFF) != 0) {
 						condB = true;
@@ -1066,9 +1066,7 @@ void CGItemObj::carry(CGPartyObj* partyObj, int carryState, int carryMode)
 		}
 		if (isMenuBossStage) {
 			CGPartyObj* carryObj = *(CGPartyObj**)(self + 0x550);
-			typedef unsigned int (*PartyVFunc)(CGPartyObj*);
-			PartyVFunc getCid = reinterpret_cast<PartyVFunc>((*reinterpret_cast<void***>(carryObj))[3]);
-			unsigned int cid = getCid(carryObj);
+			unsigned int cid = static_cast<unsigned short>(carryObj->GetCID());
 			unsigned int stageCarry = (unsigned int)__cntlzw(0x6D - (cid & 0x6D));
 			if (((stageCarry >> 5) & 0xFF) != 0) {
 				isStageCarry = true;
@@ -1117,8 +1115,12 @@ void CGItemObj::carry(CGPartyObj* partyObj, int carryState, int carryMode)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x8012564c
+ * PAL Size: 4b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::onChangePrg(int)
 {
@@ -1137,28 +1139,39 @@ void CGItemObj::statPot()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x801254cc
+ * PAL Size: 384b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 void CGItemObj::onFrameAlways()
 {
 	unsigned char* self = (unsigned char*)this;
-	unsigned int countdown = *(unsigned int*)(self + 0x56C);
+	int countdown = *(int*)(self + 0x56C);
 
 	if (countdown != 0) {
-		unsigned int next = countdown - 1;
-		*(unsigned int*)(self + 0x56C) = next & ~((int)next >> 0x1F);
+		int next = countdown - 1;
+		*(int*)(self + 0x56C) = next & ~(next >> 0x1F);
 		*(float*)(self + 0x144) = *(float*)(self + 0x568) * (float)(8 - *(int*)(self + 0x56C)) * FLOAT_80331b68;
 	}
 
 	if (*(int*)(self + 0x500) == 0xA) {
-		int canUseTrace =
-		    Game.m_gameWork.m_gameInitFlag != 0 &&
-		    (signed char)(*(unsigned char*)(CFlat + 4836) << 4) < 0 &&
-		    (signed char)(*(unsigned char*)(CFlat + 4836) << 3) < 0 &&
-		    (signed char)*(unsigned char*)(self + 0x9A) < 0 &&
-		    *(int*)(CFlat + 4780) == 0 &&
-		    *(int*)(self + 0x550) == 0;
+		int canUseTrace;
+
+		if (Game.m_gameWork.m_gameInitFlag != 0 &&
+		    static_cast<signed char>(
+		        static_cast<int>((static_cast<unsigned int>(*(unsigned char*)(CFlat + 4836)) << 28) & 0xC0000000) >> 31) != 0 &&
+		    static_cast<signed char>(
+		        static_cast<int>((static_cast<unsigned int>(*(unsigned char*)(CFlat + 4836)) << 29) & 0xC0000000) >> 31) != 0 &&
+		    static_cast<signed char>(
+		        static_cast<int>((static_cast<unsigned int>(*(unsigned char*)(self + 0x9A)) << 24) & 0xC0000000) >> 31) != 0 &&
+		    *(int*)(CFlat + 4780) == 0 && *(void**)(self + 0x550) == 0) {
+			canUseTrace = true;
+		} else {
+			canUseTrace = false;
+		}
 
 		if (canUseTrace && *(int*)(CFlat + 66604) == 0) {
 			*(int*)(CFlat + 66604) = GetFreeParticleSlot__13CFlatRuntime2Fv(CFlat);


### PR DESCRIPTION
## Summary
- Replace manual item carry vtable calls with normal GetCID() calls through the CGObject vptr layout.
- Narrow carry CID masks to the 16-bit form emitted by the target in carry/onFrameStat.
- Reshape CGItemObj::onFrameAlways countdown and trace-gate control flow to better match target code.
- Fill known PAL address/size headers for onFramePreCalc, onChangePrg, and onFrameAlways.

## Evidence
- ninja passes.
- main/itemobj report text fuzzy: 76.916664%.
- onFrameAlways__9CGItemObjFv: 96.458336%, size 384.
- carry__9CGItemObjFP10CGPartyObjii: 84.66812%, size 916.
- onFrameStat__9CGItemObjFv: 56.300938%, size 3416.
- onFramePreCalc__9CGItemObjFv and onChangePrg__9CGItemObjFi remain 100% matched.

## Plausibility
- The vtable call cleanup removes an incorrect offset-0 vtable hack and uses the existing class method instead.
- The CID narrowing matches the target's 16-bit mask pattern without hardcoding addresses or forcing sections.
- The onFrameAlways changes preserve behavior while matching the target's signed countdown clamp and explicit trace predicate shape.