### PR TITLE
Mark pppYmMoveCircle matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -730,7 +730,7 @@ config.libs = [
             Object(NonMatching, "pppYmMegaBirthShpTail3.cpp"),
             Object(NonMatching, "pppYmMelt.cpp"),
             Object(NonMatching, "pppYmMiasma.cpp"),
-            Object(NonMatching, "pppYmMoveCircle.cpp"),
+            Object(Matching, "pppYmMoveCircle.cpp"),
             Object(NonMatching, "pppYmMoveParabola.cpp"),
             Object(Matching, "pppYmTraceMove.cpp"),
             Object(NonMatching, "pppYmTracer.cpp"),


### PR DESCRIPTION
## Summary
- Promotes pppYmMoveCircle.cpp from NonMatching to Matching.
- Links the already-matched source object for main/pppYmMoveCircle.

## Evidence
- objdiff for main/pppYmMoveCircle / pppFrameYmMoveCircle: .text 860 bytes at 100%, data/extab sections at 100%.
- ninja passes, including the final DOL checksum.
- Linked progress improves from 310/620 to 311/620 units, and game linked units from 107/265 to 108/265.

## Notes
- I tested a broader batch of fully section-matched units, but only pppYmMoveCircle was checksum-clean when promoted. The rest were left unchanged.