### PR TITLE
Improve menu artifact draw matching

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -325,27 +325,14 @@ void CMenuPcs::ArtiDraw()
 					u += fillW;
 				}
 
-				if (fillW > 0.0f && fillW < w) {
-					GXColor fadeColors[4];
-					fadeColors[0].r = 0xFF;
-					fadeColors[0].g = 0xFF;
-					fadeColors[0].b = 0xFF;
-					fadeColors[0].a = 0;
-					fadeColors[1].r = 0xFF;
-					fadeColors[1].g = 0xFF;
-					fadeColors[1].b = 0xFF;
-					fadeColors[1].a = 0;
-					fadeColors[2].r = 0xFF;
-					fadeColors[2].g = 0xFF;
-					fadeColors[2].b = 0xFF;
-					fadeColors[2].a = 0;
-					fadeColors[3].r = 0xFF;
-					fadeColors[3].g = 0xFF;
-					fadeColors[3].b = 0xFF;
-					fadeColors[3].a = 0;
-					float remainW = (1.0f / (float)*(int*)(entry + 0x14)) * w;
+				if (fillW > 0.0f && fillW < (float)entry[2]) {
+					colors[0].a = 0;
+					colors[1].a = 0;
+					colors[2].a = 0;
+					colors[3].a = 0;
+					float remainW = (float)(DOUBLE_80332fb0 / (double)*(int*)(entry + 0x14)) * (float)entry[2];
 					DrawRect__8CMenuPcsFUlffffffP8_GXColorfff(
-						&MenuPcs, 0, x, y, remainW, h, u, v, fadeColors, 1.0f, 1.0f, 0.0f);
+						&MenuPcs, 0, x, y, remainW, h, u, v, colors, 1.0f, 1.0f, 0.0f);
 				}
 
 				SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(&MenuPcs, 0);

--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -4,6 +4,7 @@
 #include "ffcc/game.h"
 #include "ffcc/pppPart.h"
 #include "ffcc/partMng.h"
+#include "ffcc/mapmesh.h"
 #include "ffcc/util.h"
 
 #include <string.h>
@@ -17,10 +18,6 @@ static const float FLOAT_8033193c = 0.0f;
 static const float FLOAT_80331940 = 1.0f;
 
 extern "C" {
-int GetTexture__8CMapMeshFP12CMaterialSetRi(CMapMesh*, CMaterialSet*, int&);
-
-void pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(void*, void*, float, u8, u8, u8, u8, u8, u8, u8);
-void pppDrawMesh__FP10pppModelStP3Veci(pppModelSt*, Vec*, s32);
 void _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(int, int, int, int);
 void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
 void _GXSetTevSwapModeTable__F13_GXTevSwapSel15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan15_GXTevColorChan(
@@ -191,7 +188,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
 
     textureIndex = 0;
     model = (pppModelSt*)(((CMapMesh**)pppEnvStPtr->m_mapMeshPtr)[param_2->m_dataValIndex]);
-    GetTexture__8CMapMeshFP12CMaterialSetRi((CMapMesh*)model, pppEnvStPtr->m_materialSetPtr, textureIndex);
+    ((CMapMesh*)model)->GetTexture(pppEnvStPtr->m_materialSetPtr, textureIndex);
 
     if (param_2->m_payload[0x1E] == 0xFF) {
         param_2->m_payload[0x1E] = 0xFE;
@@ -273,7 +270,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
         }
         gUtil.RenderColorQuad(FLOAT_8033193c, yPos, FLOAT_80331928, FLOAT_8033192c, *(GXColor*)drawColor.rgba);
 
-        pppSetDrawEnv__FP10pppCVECTORP10pppFMATRIXfUcUcUcUcUcUcUc(
+        pppSetDrawEnv(
             &drawColor, &pppMiasma->m_drawMatrix, FLOAT_8033193c, 0, 0, 1, 0, 1, 1, 1);
 
         _GXSetTevOrder__F13_GXTevStageID13_GXTexCoordID11_GXTexMapID12_GXChannelID(0, 0xFF, 0xFF, 4);
@@ -320,7 +317,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
 
         if (!isCameraInside) {
             Graphic.SetDrawDoneDebugData(0x32);
-            pppDrawMesh__FP10pppModelStP3Veci(model, pppMiasma->m_meshPoints, 0);
+            pppDrawMesh(model, pppMiasma->m_meshPoints, 0);
             Graphic.SetDrawDoneDebugData(0x33);
         }
 
@@ -337,7 +334,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
         _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 2, 1, 0);
 
         Graphic.SetDrawDoneDebugData(0x34);
-        pppDrawMesh__FP10pppModelStP3Veci(model, pppMiasma->m_meshPoints, 0);
+        pppDrawMesh(model, pppMiasma->m_meshPoints, 0);
         Graphic.SetDrawDoneDebugData(0x35);
 
         Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backRgba8Tex, 0, yOffset, texWidth, texHeight, i4TexSize,
@@ -392,7 +389,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
 
             if (!isCameraInside) {
                 Graphic.SetDrawDoneDebugData(0x36);
-                pppDrawMesh__FP10pppModelStP3Veci(model, pppMiasma->m_meshPoints, 0);
+                pppDrawMesh(model, pppMiasma->m_meshPoints, 0);
                 Graphic.SetDrawDoneDebugData(0x37);
             }
 
@@ -409,7 +406,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
             _GXSetTevAlphaOp__F13_GXTevStageID8_GXTevOp10_GXTevBias11_GXTevScaleUc11_GXTevRegID(0, 0, 0, 0, 1, 0);
 
             Graphic.SetDrawDoneDebugData(0x38);
-            pppDrawMesh__FP10pppModelStP3Veci(model, pppMiasma->m_meshPoints, 0);
+            pppDrawMesh(model, pppMiasma->m_meshPoints, 0);
             Graphic.SetDrawDoneDebugData(0x39);
 
             Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backRgba8Tex2, 0, yOffset, texWidth, texHeight,


### PR DESCRIPTION
## Summary
- Reuse the artifact draw color array for the fade strip instead of keeping a second stack color array.
- Match the target's fade-width source shape by re-reading the entry width and using the double literal division path.
- Replace `pppMiasma`'s manually mangled extern calls with existing typed C++ declarations.

## Evidence
- `ninja` passes.
- `ArtiDraw__8CMenuPcsFv`: 80.135185% -> 83.12479%.
- `main/menu_arti` `.text`: 78.86566% -> 80.16755%.
- `pppRenderMiasma`: unchanged at 97.45753%, with cleaner declarations and no regression.

## Plausibility
- The artifact draw change removes an unnecessary second local `GXColor[4]` and matches the target stack frame (`stwu r1, -0x120`).
- The `pppMiasma` changes use real declarations already present in headers instead of manually spelling mangled names.
