### PR TITLE
Use shared ghost party work storage

### DIFF
--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -73,6 +73,7 @@ extern float FLOAT_8032EE80;
 extern float FLOAT_8032EE84;
 
 struct GhostPartyWork {
+	unsigned char _pad0[0x20];
 	int mood;
 	int thresholdA;
 	int thresholdB;
@@ -89,7 +90,8 @@ struct GhostPartyWork {
 	int auraParticle;
 };
 
-static GhostPartyWork sGhostPartyWork;
+extern unsigned char m_boss__8CGMonObj_field108_0x6c[0x90];
+#define sGhostPartyWork (*reinterpret_cast<GhostPartyWork*>(m_boss__8CGMonObj_field108_0x6c))
 
 struct PartyObjFlags {
 	unsigned char commandActive : 1;


### PR DESCRIPTION
## Summary
- Redirect party object ghost work accesses to the existing shared `m_boss__8CGMonObj_field108_0x6c` BSS storage.
- Add the recovered front padding so the ghost damage counters line up at offsets 0x24/0x28/0x2c, matching the target code.

## Objdiff
- `main/partyobj`: `onDamaged__10CGPartyObjFP8CGPrgObj` improved to 100.0% (172 bytes)
- `main/partyobj`: `onAttacked__10CGPartyObjFP8CGPrgObj` improved to 100.0% (172 bytes)
- Build progress: matched code increased from 557608 to 557952 bytes, matched functions from 3347 to 3349

## Plausibility
The previous local `sGhostPartyWork` duplicated storage in `partyobj.o`; the target references the shared BSS symbol already defined in `cflat_runtime2.cpp`. The padding reflects the observed counter offsets in the matched target instructions rather than forcing codegen.