### PR TITLE
Match CMesh ref data constructor

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -3047,7 +3047,7 @@ CChara::CMesh::CRefData::CRefData()
 	ref->m_threeWeightCountOrSize = 0;
 	ref->m_displayListCount = 0;
 	ref->m_skinCount = 0;
-	ref->m_infoWord1 = 0;
+	ref->m_nodeIndex = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Initialize the mesh ref node index in `CChara::CMesh::CRefData::CRefData()` instead of the preceding info word.
- This matches the target constructor's final zero store at offset `0x60`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/chara -o - __ct__Q36CChara5CMesh8CRefDataFv`
  - before: 99.95238%
  - after: 100.0%
- Aggregate progress: matched code increased from 558260 to 558344 bytes; matched functions increased from 3350 to 3351.
