### PR TITLE
Improve AStar escape vector temporaries

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -155,7 +155,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 	CVector baseVec(base);
 	CVector fromVec(from);
 	CVector escapeDirSource;
-	CVector escapeDir;
+	Vec escapeDir;
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&fromVec),
 	              reinterpret_cast<Vec*>(&baseVec),
@@ -164,7 +164,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 	escapeDir.x = escapeDirSource.x;
 	escapeDir.y = escapeDirSource.y;
 	escapeDir.z = escapeDirSource.z;
-	escapeDir.Normalize();
+	reinterpret_cast<CVector*>(&escapeDir)->Normalize();
 
 	float behindBestDist = kAStarEscapeInitialBestDist;
 	CAPos* behindBest = (CAPos*)0;
@@ -204,7 +204,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 					CVector portalDirBase(base);
 					CVector portalDirPos(portal->m_position);
 					CVector dirToPortalSource;
-					CVector portalVec;
+					Vec portalVec;
 
 					PSVECSubtract(reinterpret_cast<Vec*>(&portalDirPos),
 					              reinterpret_cast<Vec*>(&portalDirBase),
@@ -213,7 +213,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 					portalVec.x = dirToPortalSource.x;
 					portalVec.y = dirToPortalSource.y;
 					portalVec.z = dirToPortalSource.z;
-					portalVec.Normalize();
+					reinterpret_cast<CVector*>(&portalVec)->Normalize();
 
 					float dot = PSVECDotProduct(reinterpret_cast<Vec*>(&escapeDir),
 					                            reinterpret_cast<Vec*>(&portalVec));


### PR DESCRIPTION
## Summary
- Use plain Vec stack storage for normalized direction temporaries in CAStar::getEscapePos.
- Keep CVector construction only where the source values need constructors, then normalize the Vec storage through CVector like the target stack shape.

## Objdiff evidence
- main/astar getEscapePos__6CAStarFR3VecR3Vecii: 85.404106% -> 85.863014%
- main/astar calcPolygonGroup__6CAStarFP3Veci: unchanged at 85.59829%
- main/astar check__6CAStarFiiRQ26CAStar6CATemp: unchanged at 76.643585%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/astar -o - getEscapePos__6CAStarFR3VecR3Vecii
- build/tools/objdiff-cli diff -p . -u main/astar -o - calcPolygonGroup__6CAStarFP3Veci
- build/tools/objdiff-cli diff -p . -u main/astar -o - check__6CAStarFiiRQ26CAStar6CATemp

## Notes
- I also tested a few menu_arti cleanup candidates, but left them out because objdiff regressed despite plausible decompiler hints.