### PR TITLE
Improve map texture animation ptr array calls

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -3,6 +3,8 @@
 #include "ffcc/map.h"
 #include "ffcc/memory.h"
 #include "ffcc/system.h"
+#define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
+#include "ffcc/ptrarray.h"
 
 class CMaterial;
 
@@ -10,8 +12,6 @@ extern "C" void Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet(CMapTexAnim*, 
 extern "C" void __ct__4CRefFv(void*);
 extern "C" void __dt__4CRefFv(void*, int);
 extern "C" CMapTexAnim* __dt__11CMapTexAnimFv(CMapTexAnim*, short);
-extern "C" void* __vc__21CPtrArray_P8CTexture_FUl(void*, unsigned long);
-extern "C" void* __vc__22CPtrArray_P9CMaterial_FUl(void*, unsigned long);
 extern "C" void* __nw__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void* __nwa__FUlPQ27CMemory6CStagePci(unsigned long, CMemory::CStage*, char*, int);
 extern "C" void __dl__FPv(void*);
@@ -64,12 +64,12 @@ static inline unsigned char& U8At(void* p, unsigned int offset)
 
 static inline void* MaterialAt(CMaterialSet* materialSet, unsigned long index)
 {
-    return __vc__22CPtrArray_P9CMaterial_FUl(Ptr(materialSet, 8), index);
+    return (*reinterpret_cast<CPtrArray<CMaterial*>*>(materialSet))[index];
 }
 
 static inline void* TextureAt(CTextureSet* textureSet, unsigned long index)
 {
-    return __vc__21CPtrArray_P8CTexture_FUl(Ptr(textureSet, 8), index);
+    return (*reinterpret_cast<CPtrArray<CTexture*>*>(textureSet))[index];
 }
 
 static inline void ReplaceRef(void** slot, void* ref)
@@ -79,7 +79,8 @@ static inline void ReplaceRef(void** slot, void* ref)
         int refCount = current[1] - 1;
         current[1] = refCount;
         if ((refCount == 0) && (current != 0)) {
-            reinterpret_cast<void (**)(void*, int)>(*reinterpret_cast<void**>(current))[2](current, 1);
+            void** vtable = *reinterpret_cast<void***>(current);
+            reinterpret_cast<void (*)(void*, int)>(vtable[2])(current, 1);
         }
         *slot = 0;
     }
@@ -164,32 +165,32 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
 
             if (reachedFrame != 0) {
                 const unsigned short textureIndex = m_frameTable[keyFrameIndex];
-                void* texture = __vc__21CPtrArray_P8CTexture_FUl(textureSet, textureIndex);
-                SetMaterialTextureSlot(__vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex)),
+                void* texture = TextureAt(textureSet, textureIndex);
+                SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
                     static_cast<unsigned long>(m_textureSlot), texture);
 
                 if (m_usesBlendTexture != 0) {
                     const unsigned short nextTextureIndex = m_frameTable[keyFrameIndexNext];
-                    void* nextTexture = __vc__21CPtrArray_P8CTexture_FUl(textureSet, nextTextureIndex);
-                    SetMaterialTextureSlot(__vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex)),
+                    void* nextTexture = TextureAt(textureSet, nextTextureIndex);
+                    SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
                         static_cast<unsigned long>(m_textureSlot + 1), nextTexture);
                     char blendValue = static_cast<char>(FLOAT_8032fd38 * frame);
-                    void* material = __vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex));
+                    void* material = MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex));
                     *reinterpret_cast<char*>(Ptr(material, 0xA4)) = blendValue;
                     *reinterpret_cast<unsigned int*>(Ptr(material, 0x24)) |= 0x8000;
                 }
             } else {
                 const unsigned short textureIndex = m_frameTable[keyFrameIndex];
-                void* texture = __vc__21CPtrArray_P8CTexture_FUl(textureSet, textureIndex);
-                SetMaterialTextureSlot(__vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex)),
+                void* texture = TextureAt(textureSet, textureIndex);
+                SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
                     static_cast<unsigned long>(m_textureSlot), texture);
 
                 if (m_usesBlendTexture != 0) {
                     const unsigned short nextTextureIndex = m_frameTable[keyFrameIndexNext];
-                    void* nextTexture = __vc__21CPtrArray_P8CTexture_FUl(textureSet, nextTextureIndex);
-                    SetMaterialTextureSlot(__vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex)),
+                    void* nextTexture = TextureAt(textureSet, nextTextureIndex);
+                    SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
                         static_cast<unsigned long>(m_textureSlot + 1), nextTexture);
-                    void* material = __vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex));
+                    void* material = MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex));
                     *reinterpret_cast<char*>(Ptr(material, 0xA4)) = 0;
                     *reinterpret_cast<unsigned int*>(Ptr(material, 0x24)) |= 0x8000;
                 }
@@ -203,8 +204,8 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
     frame = m_currentFrame;
     const int frameIndex = static_cast<int>(frame);
     const unsigned short textureIndex = m_frameTable[frameIndex & 0xFFFF];
-    SetMaterialTextureSlot(__vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex)),
-        static_cast<unsigned long>(m_textureSlot), __vc__21CPtrArray_P8CTexture_FUl(textureSet, textureIndex));
+    SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
+        static_cast<unsigned long>(m_textureSlot), TextureAt(textureSet, textureIndex));
 
     m_currentFrame = m_currentFrame + m_frameStep;
     if (m_currentFrame >= static_cast<float>(m_endFrame)) {
@@ -222,9 +223,9 @@ void CMapTexAnim::Calc(CMaterialSet* materialSet, CTextureSet* textureSet)
         }
 
         const unsigned short nextTextureIndex = m_frameTable[static_cast<unsigned short>(nextFrame)];
-        SetMaterialTextureSlot(__vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex)),
-            static_cast<unsigned long>(m_textureSlot + 1), __vc__21CPtrArray_P8CTexture_FUl(textureSet, nextTextureIndex));
-        void* material = __vc__22CPtrArray_P9CMaterial_FUl(materialSet, static_cast<unsigned long>(m_materialIndex));
+        SetMaterialTextureSlot(MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex)),
+            static_cast<unsigned long>(m_textureSlot + 1), TextureAt(textureSet, nextTextureIndex));
+        void* material = MaterialAt(materialSet, static_cast<unsigned long>(m_materialIndex));
         *reinterpret_cast<char*>(Ptr(material, 0xA4)) =
             static_cast<char>(FLOAT_8032fd38 * (frame - static_cast<float>(static_cast<unsigned short>(frameIndex))));
         *reinterpret_cast<unsigned int*>(Ptr(material, 0x24)) |= 0x8000;


### PR DESCRIPTION
## Summary
- Use typed `CPtrArray` accessors in `CMapTexAnim::Calc` instead of sanitized `extern "C"` subscript declarations.
- Keep the existing pointer-array storage shape while producing relocations against the real template symbols.
- Clean up the local ref-release virtual destructor call shape in the texture slot replacement helper.

## Evidence
- `ninja` passes for `GCCP01`.
- `CMapTexAnim::Calc(CMaterialSet*, CTextureSet*)` objdiff improved from `95.89037%` to `96.06417%`.
- `main/maptexanim` `.text` improved from `97.80115%` to `97.894135%`.

## Plausibility
This replaces manual symbol-name externs with the existing `CPtrArray<T>` template API used elsewhere in the project, so the source is more coherent and the relocation targets are closer to the shipped symbols without forcing vtables, sections, or addresses.