### PR TITLE
Improve memory allocation wrapper matching

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -211,13 +211,7 @@ static void stageDestroyInternal(CMemory::CStage* stage)
  */
 void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int line)
 {
-    char* source;
-    if (file == (char*)nullptr) {
-        source = DAT_8032f7d4;
-    } else {
-        source = file;
-    }
-    return stage->alloc(size, source, line, 0);
+    return stage->alloc(size, file == (char*)nullptr ? DAT_8032f7d4 : file, line, 0);
 }
 
 /*
@@ -231,13 +225,7 @@ void* operator new(unsigned long size, CMemory::CStage* stage, char* file, int l
  */
 void* operator new[](unsigned long size, CMemory::CStage* stage, char* file, int line)
 {
-    char* source;
-    if (file == (char*)nullptr) {
-        source = DAT_8032f7d4;
-    } else {
-        source = file;
-    }
-    return stage->alloc(size, source, line, 0);
+    return stage->alloc(size, file == (char*)nullptr ? DAT_8032f7d4 : file, line, 0);
 }
 
 /*
@@ -865,13 +853,7 @@ void CMemory::DestroyStage(CMemory::CStage* stage)
  */
 void* CMemory::_Alloc(unsigned long size, CMemory::CStage* stage, char* source, int line, int noError)
 {
-    char* allocSource;
-    if (source == (char*)nullptr) {
-        allocSource = DAT_8032f7d4;
-    } else {
-        allocSource = source;
-    }
-    return stage->alloc(size, allocSource, line, noError);
+    return stage->alloc(size, source == (char*)nullptr ? DAT_8032f7d4 : source, line, noError);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Simplify the default-source selection in the placement new, placement new[], and CMemory::_Alloc wrappers.
- Keeps the same behavior while giving MWCC a call shape closer to the target.

## Objdiff evidence
Unit: main/memory
- _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii: 68.125% -> 74.375%
- __nw__FUlPQ27CMemory6CStagePci: 68.125% -> 93.125%
- __nwa__FUlPQ27CMemory6CStagePci: 68.125% -> 93.125%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_final.json _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii