### PR TITLE
Correct CMenuPcs base class

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -30,7 +30,7 @@ struct McListInfo
     void operator=(const McListInfo&);
 };
 
-class CMenuPcs : public CSamplePcs
+class CMenuPcs : public CProcess
 {
 public:
     struct BattleHudState


### PR DESCRIPTION
## Summary
- change `CMenuPcs` to inherit directly from `CProcess` instead of `CSamplePcs`
- removes the spurious `CSamplePcs` constructor path from `p_menu` static initialization

## Evidence
- `ninja` passes
- `main/p_menu` fuzzy match improves from `85.26825%` to `85.511986%`
- `__sinit_p_menu_cpp` improves from `72.0%` to `82.914635%`
- focused diff captured with `build/tools/objdiff-cli diff -p . -u main/p_menu -o - __sinit_p_menu_cpp`

## Plausibility
The target static initializer sets the `CManager`, `CProcess`, then `CMenuPcs` vtables directly and does not construct a `CSamplePcs` base. `CSamplePcs` contributes no instance fields, so direct `CProcess` inheritance preserves layout while matching the observed constructor shape.