### PR TITLE
Improve CGItemObj onFrameAlways flag compare

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1160,7 +1160,7 @@ void CGItemObj::onFrameAlways()
 	if (*(int*)(self + 0x500) == 0xA) {
 		int canUseTrace;
 
-		if (Game.m_gameWork.m_gameInitFlag != 0 &&
+		if (static_cast<int>(Game.m_gameWork.m_gameInitFlag) != 0 &&
 		    static_cast<signed char>(
 		        static_cast<int>((static_cast<unsigned int>(*(unsigned char*)(CFlat + 4836)) << 28) & 0xC0000000) >> 31) != 0 &&
 		    static_cast<signed char>(


### PR DESCRIPTION
## Summary
- Cast m_gameInitFlag to int in CGItemObj::onFrameAlways so the generated compare matches the PAL code more closely.

## Evidence
- ninja passes.
- onFrameAlways__9CGItemObjFv: 96.40625% -> 97.03125% objdiff match.

## Plausibility
- The field is a byte-sized game-init flag used as a truth value; the cast preserves behavior while matching the original integer compare shape.