### PR TITLE
Improve item object frame-always match

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1154,13 +1154,14 @@ void CGItemObj::onFrameAlways()
 	if (countdown != 0) {
 		int next = countdown - 1;
 		*(int*)(self + 0x56C) = next & ~(next >> 0x1F);
-		*(float*)(self + 0x144) = *(float*)(self + 0x568) * (float)(8 - *(int*)(self + 0x56C)) * FLOAT_80331b68;
+		float radius = *(float*)(self + 0x568) * (float)(8 - *(int*)(self + 0x56C));
+		*(float*)(self + 0x144) = radius * FLOAT_80331b68;
 	}
 
 	if (*(int*)(self + 0x500) == 0xA) {
 		int canUseTrace;
 
-		if (Game.m_gameWork.m_gameInitFlag != 0 &&
+		if (static_cast<int>(Game.m_gameWork.m_gameInitFlag) != 0 &&
 		    static_cast<signed char>(
 		        static_cast<int>((static_cast<unsigned int>(*(unsigned char*)(CFlat + 4836)) << 28) & 0xC0000000) >> 31) != 0 &&
 		    static_cast<signed char>(


### PR DESCRIPTION
## Summary
- Split the item jump radius update in `CGItemObj::onFrameAlways` into an intermediate radius calculation.
- Cast `Game.m_gameWork.m_gameInitFlag` before the nonzero comparison to match the target signedness/codegen shape.

## Objdiff Evidence
- `onFrameAlways__9CGItemObjFv`: 96.40625% -> 97.552086% match.
- `main/itemobj` unit summary shows no other function regressions from this change.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_onFrameAlways_diff.json onFrameAlways__9CGItemObjFv`
- `build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_unit_diff.json itemobj`

## Plausibility
- The radius split preserves the original arithmetic while matching a more likely source-level intermediate expression.
- The game-init flag comparison now uses the integer comparison shape emitted by the target without hardcoded addresses or fake symbols.
