### PR TITLE
Improve Ym particle objdiff ordering

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -898,11 +898,6 @@ void UpdateParticle(VYmBreath* vYmBreath, PYmBreath* pYmBreath, PARTICLE_DATA* p
     }
 }
 
-extern "C" const char lbl_80330CB8[] = "FFCC";
-extern "C" const char lbl_80330CC0[] = "GDS";
-extern "C" const char lbl_80330CC4[] = "GC";
-extern "C" const char lbl_80330CC8[] = "1.00";
-
 /*
  * --INFO--
  * PAL Address: 0x800c118c
@@ -1064,6 +1059,11 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         particleColor->m_colorFrameDeltas[3] = params->m_colorFrameDelta3;
     }
 }
+
+extern "C" const char lbl_80330CB8[] = "FFCC";
+extern "C" const char lbl_80330CC0[] = "GDS";
+extern "C" const char lbl_80330CC4[] = "GC";
+extern "C" const char lbl_80330CC8[] = "1.00";
 
 /*
  * --INFO--

--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -182,12 +182,12 @@ void pppRenderYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, pppYmDe
         PSMTX44Copy(CameraScreenMatrix(), screenMtx);
         PSMTXCopy(CameraMatrix(), cameraMtx);
 
-        texMtx[0][0] = screenMtx[0][0];
-        texMtx[1][1] = screenMtx[1][1];
         texMtx[1][0] = screenMtx[1][0];
         texMtx[2][0] = screenMtx[2][0];
         texMtx[0][1] = screenMtx[0][1];
         texMtx[2][1] = screenMtx[2][1];
+        texMtx[0][0] = screenMtx[0][0];
+        texMtx[1][1] = screenMtx[1][1];
         texMtx[0][2] = screenMtx[0][2];
         texMtx[1][2] = screenMtx[1][2];
         texMtx[2][2] = screenMtx[2][2];


### PR DESCRIPTION
## Summary
- Reorder `pppRenderYmDeformationMdl` texture matrix copies to better match the PAL render function codegen.
- Move the `pppYmBreath` SDK string constants after `BirthParticle` so `.sdata2` numeric constants and strings emit in a better order.

## Objdiff evidence
- `main/pppYmDeformationMdl` / `pppRenderYmDeformationMdl`: 99.609825% -> 99.69653%.
- `main/pppYmBreath` / `.sdata2`: 55.6391% -> 81.53846%.
- `main/pppYmBreath` / `[.sdata2-0]`: 58.823532% -> 79.69925%.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o - pppRenderYmDeformationMdl`
- `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -`

## Plausibility
- The matrix assignment change only reorders independent copies from `screenMtx` before the existing scale/offset overwrites.
- The string-constant move matches the observed data-emission order without adding fake labels, hardcoded addresses, or section forcing.
