### PR TITLE
Improve p_tina drawAfterViewer rodata references

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -1208,14 +1208,16 @@ void CPartPcs::GetParColIdx(int index, pppFVECTOR4& color)
  */
 void CPartPcs::drawAfterViewer()
 {
-	Graphic._WaitDrawDone(const_cast<char*>(s_p_tina_cpp_801d8008), 0x3f1);
+	char* stringBase = const_cast<char*>(s_p_tina_rodata_801d7ee0);
+
+	Graphic._WaitDrawDone(stringBase + 0x128, 0x3f1);
 	reinterpret_cast<CStopWatch*>(&g_par_draw_prof)->Start();
 	reinterpret_cast<CStopWatch*>(&g_par_calc_prof)->Start();
 	Graphic.SetFog(1, 0);
 	pppInitDrawEnv(0);
 	PartMng.pppEditPartDrawAfter();
 	reinterpret_cast<CStopWatch*>(&g_par_calc_prof)->Stop();
-	Graphic._WaitDrawDone(const_cast<char*>(s_p_tina_cpp_801d8008), 0x3fb);
+	Graphic._WaitDrawDone(stringBase + 0x128, 0x3fb);
 	reinterpret_cast<CStopWatch*>(&g_par_draw_prof)->Stop();
 	PartMng.pppGet2Dpos();
 	pppClearDrawEnv();
@@ -1225,20 +1227,20 @@ void CPartPcs::drawAfterViewer()
 
 	alive++;
 	Graphic.Printf(
-		const_cast<char*>(s_tina_title_fmt_801d8014), pFan[(alive >> 4) % 4]);
+		stringBase + 0x134, pFan[(alive >> 4) % 4]);
 
 	g_par_calc_prof.ProfEnd();
 	g_par_draw_prof.ProfEnd();
 	Graphic.Printf(
-		const_cast<char*>(s_tina_calc_fmt_801d8020),
+		stringBase + 0x140,
 		(double)g_par_calc_prof.m_lastTime,
 		(double)g_par_calc_prof.m_maxTime);
 	Graphic.Printf(
-		const_cast<char*>(s_tina_draw_fmt_801d8038),
+		stringBase + 0x158,
 		(double)g_par_draw_prof.m_lastTime,
 		(double)g_par_draw_prof.m_maxTime);
 	Graphic.Printf(
-		const_cast<char*>(s_tina_heap_fmt_801d8050),
+		stringBase + 0x170,
 		(double)((float)gPppHeapUseRateWords[0] / kPppHeapUseRateDivisor),
 		(double)((float)gPppHeapUseRateWords[1] / kPppHeapUseRateDivisor));
 }


### PR DESCRIPTION
## Summary
- Reuse the p_tina rodata base in CPartPcs::drawAfterViewer for WaitDrawDone and debug printf strings.
- Matches the existing rodata-base pattern used elsewhere in p_tina.cpp and reduces relocation mismatches in drawAfterViewer.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff main/p_tina drawAfterViewer__8CPartPcsFv: 99.40476% -> 99.48412%, size remains 504 bytes
- Adjacent checked p_tina symbols remain at prior scores: createViewer 99.77528%, createLoad 99.48718%, create 99.756096%, pppFreeMngStPrioForData 99.121216%

## Plausibility
- This follows the same local rodata-base addressing style already present in p_tina.cpp instead of introducing new symbols or control-flow changes.