### PR TITLE
Improve EquipClose fade math

### DIFF
--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -54,6 +54,7 @@ extern const float FLOAT_80332ef4;
 extern const float FLOAT_80332ef8;
 extern const float FLOAT_80332efc;
 extern const float FLOAT_80332f00;
+extern const double DOUBLE_80332F08;
 extern const float FLOAT_80332f10;
 extern const float FLOAT_80332f14;
 extern const float FLOAT_80332f18;
@@ -668,11 +669,12 @@ int CMenuPcs::EquipClose()
 				*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
 			} else {
 				*reinterpret_cast<int*>(item + 0x10) = *reinterpret_cast<int*>(item + 0x10) + 1;
-				float ratio = FLOAT_80332ee0 -
-				              (static_cast<float>(*reinterpret_cast<int*>(item + 0x10)) /
-				               static_cast<float>(*reinterpret_cast<int*>(item + 0x14)));
-				*reinterpret_cast<float*>(item + 8) = ratio;
-				if (*reinterpret_cast<float*>(item + 8) < FLOAT_80332eb8) {
+				*reinterpret_cast<float*>(item + 8) =
+				    (float)-((DOUBLE_80332ec0 /
+				              (static_cast<double>(*reinterpret_cast<int*>(item + 0x14)) - DOUBLE_80332ed8)) *
+				                 (static_cast<double>(*reinterpret_cast<int*>(item + 0x10)) - DOUBLE_80332ed8) -
+				             DOUBLE_80332ec0);
+				if ((double)*reinterpret_cast<float*>(item + 8) < DOUBLE_80332F08) {
 					*reinterpret_cast<float*>(item + 8) = FLOAT_80332eb8;
 				}
 			}


### PR DESCRIPTION
## Summary
- update `CMenuPcs::EquipClose` fade interpolation to use the target-like double expression
- compare the fade value against the existing double zero constant instead of forcing a float-only path

## Evidence
- `ninja` succeeds (`build/GCCP01/main.dol: OK`)
- `main/menu_equip` `.text`: `38.979984% -> 38.98897%`
- `EquipClose__8CMenuPcsFv`: `47.065422% -> 47.271027%`

## Plausibility
- keeps the normal C++ implementation path and existing constants
- no manual sections, vtables, ctor/dtor forcing, fake names, or address hacks