### PR TITLE
Match CGItemObj::DeleteAllFieldItem

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1490,7 +1490,7 @@ void CGItemObj::DeleteAllFieldItem()
 		if (owner == 0 &&
 		    static_cast<signed char>(
 		        static_cast<int>((static_cast<unsigned int>(itemObj[0x50]) << 28) & 0xC0000000) >> 31) != 0) {
-			itemObj[0x38] |= 0x80;
+			itemObj[0x38] = static_cast<unsigned char>(__rlwimi(itemObj[0x38], 1, 7, 24, 24));
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Match `CGItemObj::DeleteAllFieldItem` by using the byte-bit insert pattern the compiler emits for setting object flag bit 7.

## Evidence
- Before: `DeleteAllFieldItem__9CGItemObjFv` was 89.71429% matched, 128 compiled bytes.
- After: `DeleteAllFieldItem__9CGItemObjFv` is 100.0% matched, 140 bytes.
- `ninja` reports matched code increased from 558656 to 558796 bytes overall, and game code from 211784 to 211924 bytes.

## Plausibility
- This uses the existing local `__rlwimi(..., 1, 7, 24, 24)` idiom already present in `itemobj.cpp` for byte flag updates, instead of a one-off manual instruction hack.
