### PR TITLE
Match pppConstrainCameraDir scale data

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -8,8 +8,8 @@
 void pppSetFpMatrix(_pppMngSt*);
 extern const float FLOAT_803320BC;
 extern const float FLOAT_803320B8;
-extern const float FLOAT_803320C0;
 extern const float FLOAT_803320C4;
+static const float kConstrainCameraDirXScale = 1.3333f;
 
 /*
  * --INFO--
@@ -46,7 +46,7 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
 
             PSMTXIdentity(pppMngStPtr->m_matrix.value);
 
-            pppMngSt->m_scale.x = FLOAT_803320C0 * scale;
+            pppMngSt->m_scale.x = kConstrainCameraDirXScale * scale;
             pppMngSt->m_scale.y = scale;
             pppMngSt->m_scale.z = FLOAT_803320B8;
 


### PR DESCRIPTION
## Summary
- Make the ConstrainCameraDir X scale a local 1.3333f constant, matching the unit's local .sdata2 layout.
- Remove the now-unused external FLOAT_803320C0 declaration from this unit.

## Objdiff evidence
Before:
- main/pppConstrainCameraDir .sdata2: 85.71429% (16 bytes)
- pppFrameConstrainCameraDir: 99.76378% (508 bytes)

After:
- main/pppConstrainCameraDir .sdata2: 100.0% (16 bytes)
- @196 local constant: 100.0% (4 bytes)
- pppFrameConstrainCameraDir: 99.72441% (508 bytes)

Full build/progress:
- ninja passes
- matched data increases by 16 bytes in the progress report

The small code fuzzy-score movement comes from using the local constant relocation, while the recovered .sdata2 entry now matches the target data layout.