### PR TITLE
Improve pppYmEnv display list size typing

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -294,7 +294,7 @@ void genParaboloidMap(void* displayListBuffer, unsigned long* outDisplayListSize
     static const char s_pppYmEnv_cpp[] = "pppYmEnv.cpp";
     static const char s_exiting[] = "Exiting";
     const int ringVertexCount = detail + 1;
-    const unsigned int displayListSize =
+    unsigned long displayListSize =
         ((ringVertexCount + (detail - 2) * ringVertexCount * 2) * 6 * sizeof(float) + 0x1F) & ~0x1F;
 
     DCInvalidateRange(displayListBuffer, displayListSize);


### PR DESCRIPTION
## Summary
- Change `genParaboloidMap` display list size from `unsigned int` to `unsigned long`, matching the function signature and target codegen more closely.
- This removes the extra 4-byte codegen difference in `genParaboloidMap`.

## Evidence
- `ninja` passes and `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/pppYmEnv`:
  - `genParaboloidMap__FPvPUlUs9_GXVtxFmt`: 1320 bytes / 97.811554% before -> 1316 bytes / 98.1459% after.
  - Unit `.text`: 96.93386% before -> 97.00123% after.
  - `extabindex`: 98.61111% before -> 100.0% after.

## Plausibility
- `GXBeginDisplayList`, `DCInvalidateRange`, and `OSReport` all consume word-sized length values in this code path. Keeping the computed length as `unsigned long` is consistent with adjacent APIs and avoids a temporary-size mismatch without forcing code shape.