### PR TITLE
Improve menu compa and screen break matches

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -317,8 +317,8 @@ bool CMenuPcs::CompaClose()
     frame = this->compaMenuState->frame;
     for (int i = 0; i < count; i++) {
         float step = FLOAT_80332FF8;
-        if (entry->startFrame <= frame) {
-            if (frame < entry->startFrame + entry->duration) {
+        if (frame >= entry->startFrame) {
+            if (entry->startFrame + entry->duration > frame) {
                 entry->frame = entry->frame + 1;
                 entry->alpha =
                     (float)-((DOUBLE_80333008 / (double)entry->duration) * (double)entry->frame - DOUBLE_80333008);
@@ -461,8 +461,8 @@ bool CMenuPcs::CompaOpen()
     frame = this->compaMenuState->frame;
     for (int i = 0; i < count; i++) {
         float step = FLOAT_80332FF8;
-        if (entry->startFrame <= frame) {
-            if (frame < entry->startFrame + entry->duration) {
+        if (frame >= entry->startFrame) {
+            if (entry->startFrame + entry->duration > frame) {
                 entry->frame = entry->frame + 1;
                 entry->alpha = (float)((DOUBLE_80333008 / (double)entry->duration) * (double)entry->frame);
                 if ((entry->flags & 2) == 0) {

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -686,7 +686,6 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
 int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* param_3)
 {
     ScreenBreakModelView* modelView = (ScreenBreakModelView*)model;
-    float* pieceData = *(float**)((u8*)param_2 + 0xC);
     float zero = 0.0f;
     Vec translation;
     Vec cameraForward;
@@ -744,6 +743,7 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
     modelView->m_drawMtx[2][3] = translation.z;
 
     mesh = modelView->m_meshes;
+    float* pieceData = *(float**)((u8*)param_2 + 0xC);
     if (*(float*)((u8*)param_3 + 0x30) != zero) {
         PSVECScale((Vec*)((u8*)param_3 + 0x20), &gravityAdd, *(float*)((u8*)param_3 + 0x30));
     }


### PR DESCRIPTION
## Summary
- Reordered equivalent CompaOpen/CompaClose frame comparisons to match the target branch operand order.
- Delayed the ScreenBreak piece data local until loop setup to reduce callback register mismatches.

## Objdiff evidence
- main/menu_compa CompaClose__8CMenuPcsFv: 66.82105% -> 66.97895%
- main/menu_compa CompaOpen__8CMenuPcsFv: 69.98148% -> 70.12037%
- main/pppScreenBreak SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv: 95.44444% -> 95.46222%

## Verification
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/menu_compa -o /tmp/final_compa_close.json CompaClose__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_compa -o /tmp/final_compa_open.json CompaOpen__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o /tmp/final_sb_calc.json SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv