### PR TITLE
Improve pppPObjPoint data value offset

### DIFF
--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -5,6 +5,12 @@
 #include "ffcc/ppp_default_buffer.h"
 #include "ffcc/ppp_linkage.h"
 
+struct PObjPointDataVal {
+    void* m_programSetDef;
+    s32 m_sourceOffset;
+    u8 _pad8[0x8];
+};
+
 /*
  * --INFO--
  * PAL Address: 0x80060AEC
@@ -30,9 +36,9 @@ void pppPObjPoint(_pppPObject* pObject, pppPObjPointStep* step, _pppCtrlTable* c
             vecPtr = gPppDefaultValueBuffer;
         } else {
             u8* data = step->m_sourceObject;
-            _pppPDataVal* pDataVal = pppMngStPtr->m_pppPDataVals;
+            PObjPointDataVal* pDataVal = (PObjPointDataVal*)pppMngStPtr->m_pppPDataVals;
             pDataVal = &pDataVal[step->m_createProgramIndex];
-            s32 vecOffset = pDataVal->m_nextSpawnTime;
+            s32 vecOffset = pDataVal->m_sourceOffset;
             vecPtr = data + 0x80;
             vecPtr += vecOffset;
         }


### PR DESCRIPTION
## Summary
- Add a local typed view for the pppPObjPoint data-val entry shape.
- Read the source vector offset from the entry's 0x4 field while preserving the 0x10 table stride.

## Evidence
- Before: pppPObjPoint 96.189186% match.
- After: pppPObjPoint 96.21622% match.
- Verified with: ninja
- Verified with: build/tools/objdiff-cli diff -p . -u main/pppPObjPoint -o /tmp/pppPObjPoint.final.json

## Plausibility
- The change replaces use of _pppPDataVal::m_nextSpawnTime for this control path with a local structure naming the source-offset field used by pppPObjPoint.
- This avoids hard-coded pointer arithmetic and keeps the existing table stride explicit in the type layout.