### PR TITLE
Improve deformation shape texture branch

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -515,6 +515,8 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 			projectedOffsetX = texScaleX * ((float)(left + width) - projected[maxIndex].x);
 			texMtx[0][2] = texMtx[0][2] + (projectedObj[maxIndex].x + projectedOffsetX - FLOAT_803305f8);
 		}
+	} else if ((left + width) < 641) {
+		texMtx[0][2] = texMtx[0][2] + offsetX;
 	} else {
 		texMtx[0][2] = texMtx[0][2] + offsetX;
 	}


### PR DESCRIPTION
## Summary
- restore the explicit right-edge branch shape in RenderDeformationShape for pppYmDeformationShp
- keeps the duplicated add path that appears in the PAL decompilation/output instead of collapsing it away

## Objdiff evidence
- main/pppYmDeformationShp .text: 93.41638% -> 93.81449%
- RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d: 88.46594% -> 89.37616%
- pppRenderYmDeformationShp unchanged: 96.88292%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp -o /tmp/defshp_final.json --format json