### PR TITLE
Align pppLaser rodata string

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -60,7 +60,7 @@ void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, u8);
 
 }
 
-extern "C" const char s_pppLaser_cpp_801E3048[] = "pppLaser.cpp";
+extern "C" const char s_pppLaser_cpp_801E3048[] ATTRIBUTE_ALIGN(4) = "pppLaser.cpp";
 
 struct CMapCylinderRaw {
     Vec m_bottom;


### PR DESCRIPTION
## Summary
- Add 4-byte alignment to the pppLaser source filename rodata symbol.
- Keeps s_pppLaser_cpp_801E3048 at its mapped 13-byte symbol size while matching the unit rodata section padding.

## Evidence
- Before: main/pppLaser .rodata size 16, 89.655174% match; .text 97.76675% match.
- After: main/pppLaser .rodata size 16, 100.0% match; .text 97.795% match.
- s_pppLaser_cpp_801E3048 remains size 13, 100.0% match.
- ninja passes.

## Plausibility
- ATTRIBUTE_ALIGN(4) models normal compiler/object alignment for the rodata string without changing the symbol contents, hardcoding data bytes, or adding fake padding symbols.