### PR TITLE
Improve usb RTTI data layout

### DIFF
--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -3,6 +3,7 @@
 #include "ffcc/system.h"
 
 extern "C" void* __vt__8CManager[];
+extern "C" void* __RTTI__8CManager[];
 
 CUSB USB;
 


### PR DESCRIPTION
## Summary
- Declare the shared CManager RTTI symbol in usb.cpp so CUSB RTTI references the existing base RTTI instead of emitting the local CManager name/RTTI data blob.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/usb -o - keeps code/rodata/bss fully matched.
- Compiled usb .data shrinks from 0x38 to 0x2c bytes, closer to the PAL target 0x1c bytes.

## Plausibility
- Other units already reference shared manager linkage symbols; this keeps usb from owning base-manager RTTI data that PAL attributes elsewhere.