### PR TITLE
Match menu_compa small data strings

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -40,15 +40,15 @@ const float FLOAT_8033303C = 72.0f;
 extern "C" const char s_pcts_pctd_family_cnt_error_pctd_801DEDC8[] = "%s(%d):family cnt error!!(%d)\n";
 extern "C" const char s_menu_compa_cpp_801DEDE8[] = "menu_compa.cpp";
 
-static const char s_compa_mono_upper[] = "MONO";
-static const char s_compa_normal[] = "Normal";
-static const char s_compa_forza[] = "Forza";
-static const char s_compa_difesa[] = "Difesa";
-static const char s_compa_sonoro[] = "Sonoro";
-static const char s_compa_musica[] = "Musica";
-static const char s_compa_mono[] = "Mono";
-static const char s_compa_contr[] = "Contr.";
-static const char s_compa_norm[] = "Norm.";
+extern "C" const char lbl_803334A8[] = "MONO";
+extern "C" const char lbl_803334B0[] = "Normal";
+extern "C" const char lbl_803334B8[] = "Forza";
+extern "C" const char lbl_803334C0[] = "Difesa";
+extern "C" const char lbl_803334C8[] = "Sonoro";
+extern "C" const char lbl_803334D0[] = "Musica";
+extern "C" const char lbl_803334D8[] = "Mono";
+extern "C" const char lbl_803334E0[] = "Contr.";
+extern "C" const char lbl_803334E8[] = "Norm.";
 
 struct CompaFlatTableEntry
 {


### PR DESCRIPTION
## Summary
- Give the menu_compa small-data string literals external symbol definitions matching the current PAL symbols.
- This lets the string symbols in the unit match instead of being emitted as local static objects.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/menu_compa -o - CompaInit__8CMenuPcsFv`:
  - `.sdata2` section: 65.42056% -> 100.0%.
  - `lbl_803334A8` and `lbl_803334E8`: now 100% matched.
  - `CompaDraw__8CMenuPcsFv` and `CompaInit__8CMenuPcsFv`: unchanged.
- Overall progress report matched data: 1139402 -> 1139474 bytes (+72).
