### PR TITLE
Fix YmBreath rotation angle storage

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -918,7 +918,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     YmBreathParams* params = reinterpret_cast<YmBreathParams*>(pYmBreath);
     YmBreathParticleData* particle = reinterpret_cast<YmBreathParticleData*>(particleData);
     Vec baseDir;
-    int angle[4];
+    int angle[3];
     pppFMATRIX rotMtx;
     float spread;
     float range;


### PR DESCRIPTION
## Summary
- Change BirthParticle temporary rotation angle array from 4 ints to 3 ints.
- The function only fills XYZ rotation components before calling pppGetRotMatrixXYZ, so the smaller array better reflects the data actually used.

## Objdiff Evidence
- main/pppYmBreath .sdata2-0 improved from 73.68421% to 82.051285%.
- BirthParticle remains 98.23038%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -