### PR TITLE
Improve p_dbgmenu drawWindow match

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -619,16 +619,17 @@ void CDbgMenuPcs::drawWindow(int flags, int x, int y, int width, int height, cha
 		highlightColor.g = alpha;
 		highlightColor.b = alpha;
 
+		float z = FLOAT_80331C98;
 		GXBegin(GX_LINESTRIP, GX_VTXFMT1, 5);
-		GXPosition3f32((float)(x + width + 1), (float)(y - 1), 0.0f);
+		GXPosition3f32((float)(x + width + 1), (float)(y - 1), z);
 		GXColor1u32(*reinterpret_cast<u32*>(&highlightColor));
-		GXPosition3f32((float)(x - 1), (float)(y - 1), 0.0f);
+		GXPosition3f32((float)(x - 1), (float)(y - 1), z);
 		GXColor1u32(*reinterpret_cast<u32*>(&highlightColor));
-		GXPosition3f32((float)(x - 1), (float)(y + height + 1), 0.0f);
+		GXPosition3f32((float)(x - 1), (float)(y + height + 1), z);
 		GXColor1u32(*reinterpret_cast<u32*>(&highlightColor));
-		GXPosition3f32((float)(x + width + 1), (float)(y + height + 1), 0.0f);
+		GXPosition3f32((float)(x + width + 1), (float)(y + height + 1), z);
 		GXColor1u32(*reinterpret_cast<u32*>(&highlightColor));
-		GXPosition3f32((float)(x + width + 1), (float)(y - 1), 0.0f);
+		GXPosition3f32((float)(x + width + 1), (float)(y - 1), z);
 		GXColor1u32(*reinterpret_cast<u32*>(&highlightColor));
 	}
 


### PR DESCRIPTION
## Summary
- Reuse the existing zero-Z debug menu constant while drawing the selected-window outline.
- This lets MWCC keep the value live through the outline vertices and brings drawWindow back to the target size.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o - drawWindow__11CDbgMenuPcsFiiiiiPc`
- Before: .text 92.83576%, drawWindow compiled size 1352 bytes.
- After: .text 93.23285%, drawWindow compiled size 1336 bytes, matching PAL size 1336 bytes.
- Data unchanged: .data 92.236664%.

## Plausibility
- The change names the already-existing `FLOAT_80331C98` zero constant used throughout the unit instead of repeating literal zeroes in the highlight outline path.
- No manual vtables, section forcing, address constants, or fake symbols.