### PR TITLE
Improve CFont glyph bucket setup

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -693,21 +693,29 @@ void CFont::Create(void* filePtr, CMemory::CStage* stage)
                     unsigned short** bucketSlot = m_glyphBuckets;
                     for (int i = 0; i < 32; i++) {
                         bucketSlot[0] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[1] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[2] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[3] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[4] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[5] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[6] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot[7] = bucket;
-                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4 + 1;
+                        bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
+                        bucket++;
                         bucketSlot += 8;
                     }
                 } else if (chunk.m_id == 0x54585452) {


### PR DESCRIPTION
## Summary
- split glyph bucket advancement in CFont::Create into an explicit glyph-data stride followed by the bucket count word skip
- keeps the parser behavior unchanged while matching the target instruction shape more closely

## Evidence
- ninja succeeds for GCCP01
- objdiff main/fontman Create__5CFontFPvPQ27CMemory6CStage: 67.17% -> 76.43% (648 bytes)

## Plausibility
- the code now describes the actual font bucket layout more directly: advance over count * 4 glyph records, then skip the next bucket count header
- no vtable, ctor/dtor, section, or address forcing hacks