### PR TITLE
Define YmChangeTex conversion constant

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -90,7 +90,7 @@ extern const char s_pppYmChangeTex_cpp_801db4c0[] = "pppYmChangeTex.cpp";
 extern const float FLOAT_80330df8;
 extern const float FLOAT_80330dfc;
 extern const float FLOAT_80330e00;
-extern const double DOUBLE_80330E08;
+extern const double DOUBLE_80330E08 = 4503601774854144.0;
 extern const float kPppYmChangeTexInitZero = 0.0f;
 
 STATIC_ASSERT(offsetof(ChangeTexModelRaw, m_data) == 0xA4);


### PR DESCRIPTION
## Summary
- define DOUBLE_80330E08 in pppYmChangeTex.cpp instead of leaving it as an external declaration
- matches the unit owned .sdata2 conversion data used by pppFrameYmChangeTex

## Evidence
- ninja passes
- objdiff for main/pppYmChangeTex reports .sdata2 at 100% match
- pppFrameYmChangeTex code remains stable at 98.18355% match