### PR TITLE
Improve CMenuPcs destroy flag signedness

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -545,7 +545,7 @@ void CMenuPcs::destroy()
     m_fonts[0] = 0;
 
     Memory.DestroyStage(m_menuStage);
-    if (*(self + 0x859) != 0) {
+    if (*reinterpret_cast<s8*>(self + 0x859) != 0) {
         m_stageF0 = 0;
         *(self + 0x859) = 0;
     }


### PR DESCRIPTION
## Summary
- Treat the CMenuPcs 0x859 flag as signed in destroy(), matching the target signed-byte test.

## Evidence
- ninja passes.
- objdiff main/p_menu destroy__8CMenuPcsFv improves from 82.079544% to 82.76136%.

## Plausibility
- Ghidra shows field_0x859 as a char and the target uses extsb. for the final destroy guard, so this is a type/signedness correction rather than output coaxing.