### PR TITLE
Improve maphit ReadOtmHit matching

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -311,25 +311,13 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                 v.y = chunkFile.GetF4();
                 v.z = chunkFile.GetF4();
 
-                if (v.x < m_positionMin.x) {
-                    m_positionMin.x = v.x;
-                }
-                if (v.y < m_positionMin.y) {
-                    m_positionMin.y = v.y;
-                }
-                if (v.z < m_positionMin.z) {
-                    m_positionMin.z = v.z;
-                }
+                m_positionMin.x = (m_positionMin.x < v.x) ? m_positionMin.x : v.x;
+                m_positionMin.y = (m_positionMin.y < v.y) ? m_positionMin.y : v.y;
+                m_positionMin.z = (m_positionMin.z < v.z) ? m_positionMin.z : v.z;
 
-                if (m_positionMax.x < v.x) {
-                    m_positionMax.x = v.x;
-                }
-                if (m_positionMax.y < v.y) {
-                    m_positionMax.y = v.y;
-                }
-                if (m_positionMax.z < v.z) {
-                    m_positionMax.z = v.z;
-                }
+                m_positionMax.x = (v.x < m_positionMax.x) ? m_positionMax.x : v.x;
+                m_positionMax.y = (v.y < m_positionMax.y) ? m_positionMax.y : v.y;
+                m_positionMax.z = (v.z < m_positionMax.z) ? m_positionMax.z : v.z;
             }
 
             m_positionMin.x -= 0.1f;
@@ -397,25 +385,13 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                     face.m_vertexIndices[i] = idx;
 
                     const Vec& v = m_vertices[idx];
-                    if (v.x < face.m_boundsMin.x) {
-                        face.m_boundsMin.x = v.x;
-                    }
-                    if (v.y < face.m_boundsMin.y) {
-                        face.m_boundsMin.y = v.y;
-                    }
-                    if (v.z < face.m_boundsMin.z) {
-                        face.m_boundsMin.z = v.z;
-                    }
+                    face.m_boundsMin.x = (face.m_boundsMin.x < v.x) ? face.m_boundsMin.x : v.x;
+                    face.m_boundsMin.y = (face.m_boundsMin.y < v.y) ? face.m_boundsMin.y : v.y;
+                    face.m_boundsMin.z = (face.m_boundsMin.z < v.z) ? face.m_boundsMin.z : v.z;
 
-                    if (face.m_boundsMax.x < v.x) {
-                        face.m_boundsMax.x = v.x;
-                    }
-                    if (face.m_boundsMax.y < v.y) {
-                        face.m_boundsMax.y = v.y;
-                    }
-                    if (face.m_boundsMax.z < v.z) {
-                        face.m_boundsMax.z = v.z;
-                    }
+                    face.m_boundsMax.x = (v.x < face.m_boundsMax.x) ? face.m_boundsMax.x : v.x;
+                    face.m_boundsMax.y = (v.y < face.m_boundsMax.y) ? face.m_boundsMax.y : v.y;
+                    face.m_boundsMax.z = (v.z < face.m_boundsMax.z) ? face.m_boundsMax.z : v.z;
                 }
 
                 face.m_radiusScale *= 0.5f;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -315,9 +315,9 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                 m_positionMin.y = (m_positionMin.y < v.y) ? m_positionMin.y : v.y;
                 m_positionMin.z = (m_positionMin.z < v.z) ? m_positionMin.z : v.z;
 
-                m_positionMax.x = (v.x < m_positionMax.x) ? m_positionMax.x : v.x;
-                m_positionMax.y = (v.y < m_positionMax.y) ? m_positionMax.y : v.y;
-                m_positionMax.z = (v.z < m_positionMax.z) ? m_positionMax.z : v.z;
+                m_positionMax.x = (m_positionMax.x < v.x) ? v.x : m_positionMax.x;
+                m_positionMax.y = (m_positionMax.y < v.y) ? v.y : m_positionMax.y;
+                m_positionMax.z = (m_positionMax.z < v.z) ? v.z : m_positionMax.z;
             }
 
             m_positionMin.x -= 0.1f;
@@ -389,9 +389,9 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                     face.m_boundsMin.y = (face.m_boundsMin.y < v.y) ? face.m_boundsMin.y : v.y;
                     face.m_boundsMin.z = (face.m_boundsMin.z < v.z) ? face.m_boundsMin.z : v.z;
 
-                    face.m_boundsMax.x = (v.x < face.m_boundsMax.x) ? face.m_boundsMax.x : v.x;
-                    face.m_boundsMax.y = (v.y < face.m_boundsMax.y) ? face.m_boundsMax.y : v.y;
-                    face.m_boundsMax.z = (v.z < face.m_boundsMax.z) ? face.m_boundsMax.z : v.z;
+                    face.m_boundsMax.x = (face.m_boundsMax.x < v.x) ? v.x : face.m_boundsMax.x;
+                    face.m_boundsMax.y = (face.m_boundsMax.y < v.y) ? v.y : face.m_boundsMax.y;
+                    face.m_boundsMax.z = (face.m_boundsMax.z < v.z) ? v.z : face.m_boundsMax.z;
                 }
 
                 face.m_radiusScale *= 0.5f;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -418,14 +418,14 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                     }
                 }
 
-                float width = face.m_radiusScale * 0.5f;
-                face.m_boundsMin.x -= (0.1f + width);
-                face.m_boundsMin.y -= (0.1f + width);
-                face.m_boundsMin.z -= (0.1f + width);
-                face.m_boundsMax.x += (0.1f + width);
-                face.m_boundsMax.y += (0.1f + width);
-                face.m_boundsMax.z += (0.1f + width);
-                face.m_radiusScale = 1.0f - width;
+                face.m_radiusScale *= 0.5f;
+                face.m_boundsMin.x -= (0.1f + face.m_radiusScale);
+                face.m_boundsMin.y -= (0.1f + face.m_radiusScale);
+                face.m_boundsMin.z -= (0.1f + face.m_radiusScale);
+                face.m_boundsMax.x += (0.1f + face.m_radiusScale);
+                face.m_boundsMax.y += (0.1f + face.m_radiusScale);
+                face.m_boundsMax.z += (0.1f + face.m_radiusScale);
+                face.m_radiusScale = 1.0f - face.m_radiusScale;
             }
         } else if (chunk.m_id == 'NAME') {
             char* mapHitName = chunkFile.GetString();

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -295,14 +295,15 @@ CMapHit::~CMapHit()
 void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
 {
     CChunkFile::CChunk chunk;
-    CMemory::CStage* const stage = *reinterpret_cast<CMemory::CStage**>(&MapMng);
 
     chunkFile.PushChunk();
 
     while (chunkFile.GetNextChunk(chunk)) {
         if (chunk.m_id == 'HITV') {
             m_vertexCount = static_cast<unsigned short>(chunk.m_arg0);
-            m_vertices = new (stage, const_cast<char*>(s_maphit_cpp), 0x143) Vec[m_vertexCount];
+            m_vertices =
+                new (*reinterpret_cast<CMemory::CStage**>(&MapMng), const_cast<char*>(s_maphit_cpp), 0x143)
+                    Vec[m_vertexCount];
 
             for (unsigned int i = 0; i < m_vertexCount; i++) {
                 Vec& v = m_vertices[i];
@@ -339,7 +340,9 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
             m_positionMax.z += 0.1f;
         } else if (chunk.m_id == 'HITF') {
             m_faceCount = static_cast<unsigned short>(chunk.m_arg0);
-            m_faces = new (stage, const_cast<char*>(s_maphit_cpp), 0x159) CMapHitFace[m_faceCount];
+            m_faces =
+                new (*reinterpret_cast<CMemory::CStage**>(&MapMng), const_cast<char*>(s_maphit_cpp), 0x159)
+                    CMapHitFace[m_faceCount];
 
             for (unsigned int faceIdx = 0; faceIdx < m_faceCount; faceIdx++) {
                 chunkFile.Align(4);

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -304,13 +304,6 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
             m_vertexCount = static_cast<unsigned short>(chunk.m_arg0);
             m_vertices = new (stage, const_cast<char*>(s_maphit_cpp), 0x143) Vec[m_vertexCount];
 
-            m_positionMin.x = s_large_pos;
-            m_positionMin.y = s_large_pos;
-            m_positionMin.z = s_large_pos;
-            m_positionMax.x = s_large_neg;
-            m_positionMax.y = s_large_neg;
-            m_positionMax.z = s_large_neg;
-
             for (unsigned int i = 0; i < m_vertexCount; i++) {
                 Vec& v = m_vertices[i];
                 v.x = chunkFile.GetF4();
@@ -395,13 +388,6 @@ void CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                         face.m_vertexOffsets[i][1] = chunkFile.GetF4() * 0.01f;
                     }
                 }
-
-                face.m_boundsMin.x = s_large_pos;
-                face.m_boundsMin.y = s_large_pos;
-                face.m_boundsMin.z = s_large_pos;
-                face.m_boundsMax.x = s_large_neg;
-                face.m_boundsMax.y = s_large_neg;
-                face.m_boundsMax.z = s_large_neg;
 
                 for (unsigned int i = 0; i < vertexCount; i++) {
                     const unsigned short idx = chunkFile.Get2();


### PR DESCRIPTION
## Summary
- Remove redundant bounds resets in `CMapHit::ReadOtmHit`, relying on constructor-initialized map/face bounds.
- Keep the `MapMng` stage load local to the allocation sites.
- Reshape bounds min/max and face radius updates to better match the original source pattern.

## Objdiff evidence
Unit: `main/maphit`

Before:
- `ReadOtmHit__7CMapHitFR10CChunkFile`: 54.16169%
- `.text`: 65.513885%

After:
- `ReadOtmHit__7CMapHitFR10CChunkFile`: 73.079605%
- `.text`: 68.40662%

Function and section sizes are unchanged.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/maphit -o -`
