### PR TITLE
Match pppYmDeformationShp constructors

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -627,11 +627,11 @@ void pppDestructYmDeformationShp(pppYmDeformationShp*, pppYmDeformationShpUnkC*)
  */
 void pppConstruct2YmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmDeformationShpUnkC* param_2)
 {
-	float value = kPppYmDeformationShpZero;
+	const float& value = kPppYmDeformationShpZero;
 	VYmDeformationShp* state =
 		(VYmDeformationShp*)((u8*)pppYmDeformationShp_ + 0x80 + param_2->m_serializedDataOffsets[2]);
 
-	state->m_values[1] = kPppYmDeformationShpZero;
+	state->m_values[1] = value;
 	state->m_values[0] = value;
 	state->m_scale = value;
 	state->m_values[4] = value;
@@ -650,7 +650,7 @@ void pppConstruct2YmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pp
  */
 void pppConstructYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmDeformationShpUnkC* param_2)
 {
-	float value = kPppYmDeformationShpZero;
+	const float& value = kPppYmDeformationShpZero;
 	VYmDeformationShp* state =
 		(VYmDeformationShp*)((u8*)pppYmDeformationShp_ + 0x80 + param_2->m_serializedDataOffsets[2]);
 


### PR DESCRIPTION
## Summary
- Bind the deformation shape zero constant by reference in both constructor helpers.
- This makes the compiler emit the same named sdata2 load as the target for constructor zero initialization.

## Objdiff evidence
- main/pppYmDeformationShp .text: 93.81449% -> 93.82126%
- pppConstruct2YmDeformationShp: 99.583336% -> 100.0%
- pppConstructYmDeformationShp: 99.73684% -> 100.0%
- pppRenderYmDeformationShp unchanged at 96.88292%
- RenderDeformationShape unchanged at 89.37616%

## Verification
- ninja
- git diff --check