### PR TITLE
Fix FunnyShape spinner symbol ownership

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -75,7 +75,7 @@ extern char lbl_8032E660[];
 extern u8 ARRAY_8026D728[];
 
 extern "C" CUSBStreamData* __dt__14CUSBStreamDataFv(CUSBStreamData* self, short shouldDelete);
-extern "C" const char lbl_8032FD1C[] = "|/-\\";
+extern "C" const char lbl_8032FD1C[5];
 
 namespace {
 static inline u8* Ptr(CFunnyShapePcs* self, u32 offset)


### PR DESCRIPTION
## Summary
- declare lbl_8032FD1C as an external 5-byte small-data string in p_FunnyShape.cpp instead of defining it in p_FunnyShape.o
- aligns ownership with the MAP, where lbl_8032FD1C belongs to auto_11_8032FCE8_sdata2.o

## Evidence
- ninja passes for GCCP01
- before: p_FunnyShape current object emitted an extra .sdata2 section of size 5 for lbl_8032FD1C
- after: build/GCCP01/src/p_FunnyShape.o has no .sdata2 section and nm reports lbl_8032FD1C as undefined
- drawViewer remains 528 bytes at 99.51515% objdiff match