### PR TITLE
Improve CMonWork status multiplier codegen

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2880,10 +2880,9 @@ void CMonWork::CalcStatus()
 	}
 
 	if (stageRank > 0) {
-		const int stageOffset = stageRank * 2;
-		m_strength = (unsigned short)((float)m_strength * GetStatusMultiplier(stageOffset + 0x48));
-		m_magic = (unsigned short)((float)m_magic * GetStatusMultiplier(stageOffset + 0x4C));
-		m_defense = (unsigned short)((float)m_defense * GetStatusMultiplier(stageOffset + 0x50));
+		m_strength = (unsigned short)((float)m_strength * GetStatusMultiplier(stageRank * 2 + 0x48));
+		m_magic = (unsigned short)((float)m_magic * GetStatusMultiplier(stageRank * 2 + 0x4C));
+		m_defense = (unsigned short)((float)m_defense * GetStatusMultiplier(stageRank * 2 + 0x50));
 	}
 
 	if (m_statusTimers[9] != 0) {


### PR DESCRIPTION
## Summary
- Inline the stage-rank multiplier expression in CMonWork::CalcStatus instead of preserving a separate stageOffset temporary.
- This keeps the source consistent with nearby status scaling code and improves register allocation for the PAL build.

## Evidence
- ninja passes.
- CMonWork::CalcStatus improved from 99.64126% to 99.86547% in build/GCCP01/report.json.
- Verified with: build/tools/objdiff-cli diff -p . -u main/gobjwork -o - CalcStatus__8CMonWorkFv

## Plausibility
- The change removes an unnecessary temporary and uses the same direct stageRank * 2 + offset form already used by nearby status-scaling code.