### PR TITLE
Correct gobjwork virtual layout

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -12,8 +12,8 @@ public:
     CGObjWork();
     virtual ~CGObjWork();
 
-    void Init(int, CRomWork*, int);
-    virtual void CalcStatus();
+    virtual void Init(int, CRomWork*, int);
+    void CalcStatus();
 
     // void* vtable;                        // 0x0000
     int m_objType;                          // 0x0004
@@ -44,8 +44,8 @@ class CMonWork : public CGObjWork
 public:
     CMonWork();
 
-    void Init(int, CRomWork*, int);
-    virtual void CalcStatus();
+    virtual void Init(int, CRomWork*, int);
+    void CalcStatus();
     
     unsigned short unk_0xac[4];  // 0x00AC
     unsigned short unk_0xb4[14]; // 0x00B4
@@ -71,7 +71,7 @@ public:
     void LoadInit();
     void ClearEvtWork();
     void LoadFinished();
-    void Init(int, CRomWork*, int);
+    virtual void Init(int, CRomWork*, int);
     void SetBonusCondition(int);
     int IsOutOfShouki();
     void AddLetter(int, int, int, int, int, int, int, int, int);
@@ -102,7 +102,7 @@ public:
     void SafeDeleteTempItem();
     void ClampStatus(short&, unsigned short&);
     void CalcArtifactStatus(int, int, int&, int&, int&, int&, int&);
-    virtual void CalcStatus();
+    void CalcStatus();
     int CanPlayerUseItem();
     void ValidCmdList(int);
     int GetIdxCmdList();

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -4,7 +4,7 @@
 #include "ffcc/joybus.h"
 #include "ffcc/partyobj.h"
 #include "ffcc/mes.h"
-#include "ffcc/p_game.h"
+#include "ffcc/game.h"
 #include "ffcc/p_menu.h"
 #include "ffcc/system.h"
 #include <string.h>


### PR DESCRIPTION
## Summary
- Make CGObjWork/CMonWork/CCaravanWork::Init virtual and CalcStatus non-virtual to match the gobjwork vtable layout.
- Include ffcc/game.h directly from gobjwork.cpp so the object does not emit unrelated CGamePcs constructor descriptor statics from p_game.h.

## Objdiff evidence
- main/gobjwork .data section: 15.0% -> 17.285715%.
- [.data-0]: 42.01108% -> 42.417812%.
- __vt__12CCaravanWork: 71.42857% -> 85.71429%.
- __vt__9CGObjWork: 71.42857% -> 85.71429%.
- main/gobjwork .text unchanged at 82.565414%.

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/gobjwork -o /tmp/gobjwork_final1.json