### PR TITLE
Match pppYmBreath sdata2 constants

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -27,9 +27,11 @@ extern const float FLOAT_80330C90;
 extern const float FLOAT_80330C94;
 }
 extern const float FLOAT_80330c80;
-static const float FLOAT_80330C98 = 180.0f;
-static const float FLOAT_80330C9C = -180.0f;
-static const float FLOAT_80330CA8 = 2.0f;
+extern const float FLOAT_80330C98 = 180.0f;
+extern const float FLOAT_80330C9C = -180.0f;
+extern const double DOUBLE_80330CA0 = 4503599627370496.0;
+extern const float FLOAT_80330CA8 = 2.0f;
+extern const double DOUBLE_80330CB0 = 0.5;
 
 struct pppYmBreathUnkC {
     unsigned char _pad[0xC];


### PR DESCRIPTION
## Summary
- Give the pppYmBreath-owned FLOAT_80330C98, FLOAT_80330C9C, DOUBLE_80330CA0, FLOAT_80330CA8, and DOUBLE_80330CB0 constants real linked definitions.
- Replaces anonymous/static local constants with the PAL split symbols recorded in config/GCCP01/symbols.txt.

## Evidence
- ninja passes.
- pppYmBreath .sdata2 improved from 86.88525% to 100.0%.
- Individual objdiff symbols now match: FLOAT_80330C98, DOUBLE_80330CA0, FLOAT_80330CA8, DOUBLE_80330CB0 all 100%.
- pppYmBreath .text stayed at 98.63614%; no code regression.

## Plausibility
- These constants are already attributed to pppYmBreath in the PAL symbol file and are generated as normal C++ data definitions, not manual sections or vtable/ctor hacks.