### PR TITLE
Match CGraphic small back texture quad

### DIFF
--- a/include/ffcc/graphic_symbols.h
+++ b/include/ffcc/graphic_symbols.h
@@ -21,6 +21,8 @@ extern const float FLOAT_8032F6D0;
 extern const double kGraphicHalfF64;
 extern const float FLOAT_8032F6E0;
 extern const double DOUBLE_8032F6E8;
+extern const float FLOAT_8032F6F0;
+extern const float FLOAT_8032F6F4;
 extern const float FLOAT_8032F700;
 extern const float FLOAT_8032F704;
 extern const float kGraphicBlurAlphaScale;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1915,8 +1915,8 @@ void CGraphic::CreateSmallBackTexture(void* src, _GXTexObj* texObj, long width, 
     quadMin.x = 0.0f;
     quadMin.y = 0.0f;
     quadMin.z = 0.0f;
-    quadMax.x = 1.0f;
-    quadMax.y = 1.0f;
+    quadMax.x = FLOAT_8032F6F0;
+    quadMax.y = FLOAT_8032F6F4;
     quadMax.z = 0.0f;
     gUtil.RenderQuad(quadMin, quadMax, white, 0, 0);
 


### PR DESCRIPTION
## Summary
- Match `CGraphic::CreateSmallBackTexture` by using the original 320.0f / 224.0f sdata2 constants for the final temp texture quad.
- Declare the existing `FLOAT_8032F6F0` and `FLOAT_8032F6F4` symbols in `graphic_symbols.h` so the function references the same constants as the original object.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/graphic -o /tmp/graphic_CreateSmallBackTexture_final.json CreateSmallBackTexture__8CGraphicFPvP9_GXTexObjll12_GXTexFilter9_GXTexFmtUl` writes the final diff.
- `CreateSmallBackTexture__8CGraphicFPvP9_GXTexObjll12_GXTexFilter9_GXTexFmtUl`: 98.977615% -> 100.0%.
- `main/graphic`: matched functions 27 -> 28; matched code 3516 -> 5124 bytes.
- Overall matched code 564424 -> 566032 bytes.

## Plausibility
The final quad redraws the captured 0x140 x 0xE0 temp texture. The original references the nearby sdata2 floats at `0x8032F6F0` and `0x8032F6F4`, which are 320.0f and 224.0f in `orig/GCCP01/sys/main.dol`; using those symbols is cleaner than local literals and matches the original code generation.
