### PR TITLE
Use shared gobjwork status multiplier constants

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -10,6 +10,9 @@
 #include <string.h>
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdio.h>
 
+extern const float FLOAT_80330998;
+extern const float FLOAT_8033099C;
+
 namespace {
 static inline unsigned short* GetItemDataPtr(int itemIdx)
 {
@@ -35,7 +38,7 @@ struct ShoukiByteFlags {
 
 static inline float GetStatusMultiplier(int offset)
 {
-	return ((float)(*(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + offset)) * 0.01f) + 1.0f;
+	return ((float)(*(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + offset)) * FLOAT_8033099C) + FLOAT_80330998;
 }
 }
 
@@ -2843,7 +2846,7 @@ void CMonWork::Init(int baseDataIndex, CRomWork* romWork, int)
 		unsigned int bossArtifact = Game.m_bossArtifactBase;
 		bossArtifact += Game.m_gameWork.m_bossArtifactStageIndex * 0x168;
 		unsigned short artifactScale = *(unsigned short*)(bossArtifact + 0x60);
-		m_maxHp = (unsigned short)((float)m_maxHp * ((((float)artifactScale) * 0.01f) + 1.0f));
+		m_maxHp = (unsigned short)((float)m_maxHp * ((((float)artifactScale) * FLOAT_8033099C) + FLOAT_80330998));
 	}
 
 	m_hp = m_maxHp;


### PR DESCRIPTION
## Summary
- Replaced local 0.01f/1.0f status multiplier literals in gobjwork with the existing FLOAT_8033099C and FLOAT_80330998 sdata2 constants.
- Applies to the shared GetStatusMultiplier helper and the matching monster artifact HP multiplier path.

## Objdiff evidence
- main/gobjwork Init__8CMonWorkFiP8CRomWorki: 98.43961% -> 98.48792%
- main/gobjwork CalcStatus__8CMonWorkFv: 99.59641% -> 99.77579%
- main/gobjwork CalcStatus__12CCaravanWorkFv: 83.62124% -> 83.681366%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/gobjwork -o - CalcStatus__8CMonWorkFv

## Plausibility
- The target object already names these multiplier constants in .sdata2, so using them directly is closer to the original constant layout than emitting local literals.