### PR TITLE
Improve ShpTail3 and paraboloid codegen

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -122,7 +122,7 @@ void drawParaboloidMap(_GXTexObj* texObjs, _GXTexObj* targetTexObj, void* displa
 
     _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(0, 0, 0);
 
-    const int modeOffset = mode * 5;
+    const unsigned int modeOffset = mode * 5;
 
     _GXColor clearColor;
     clearColor.r = 0;

--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -248,7 +248,6 @@ void pppRenderYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, pppYmMegaBirth
 void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShpTail3* param, pppYmMegaBirthShpTail3UnkC* offsets)
 {
     s8 hasRequiredMemory;
-    int spawnCount;
     int colorOffset;
     u8* paramPayload;
     u8* particleData;
@@ -393,15 +392,14 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
             break;
         }
 
-        i = 0;
         particleData = (u8*)work->m_particles;
         worldMat = work->m_wmats;
         particleColor = work->m_colors;
+        int spawnCount = 0;
 
         if ((gPppCalcDisabled == 0) && (*(s32*)(paramPayload + 4) != 0xffff)) {
-            spawnCount = i;
             work->m_lifeLimit = work->m_lifeLimit + 1;
-            for (; i < work->m_maxParticles; i++) {
+            for (i = 0; i < work->m_maxParticles; i++) {
                 if (*(u16*)(particleData + 0x22) != 0) {
                     calc((_pppPObject*)object, work, param, (_PARTICLE_DATA*)particleData, colorWork, particleColor);
                 } else {
@@ -462,17 +460,12 @@ extern "C" void calc(_pppPObject* pppPObject, VYmMegaBirthShpTail3* vYmMegaBirth
     *velocityScale = *velocityScale + pYmMegaBirthShpTail3->m_colorDeltaAdd[2];
     *tailScale = *tailScale + pYmMegaBirthShpTail3->m_sizeVal;
 
-    {
-        Vec scaled;
-        pppScaleVectorXYZ(scaled, *(Vec*)(particleBytes + 0x10), *velocityScale);
-        pppAddVector(*(Vec*)particleData, *(Vec*)particleData, scaled);
-    }
+    Vec scaled;
+    pppScaleVectorXYZ(scaled, *(Vec*)(particleBytes + 0x10), *velocityScale);
+    pppAddVector(*(Vec*)particleData, *(Vec*)particleData, scaled);
 
-    {
-        Vec scaled;
-        pppScaleVectorXYZ(scaled, vYmMegaBirthShpTail3->m_tailScaleDirection, *tailScale);
-        pppAddVector(*(Vec*)particleData, *(Vec*)particleData, scaled);
-    }
+    pppScaleVectorXYZ(scaled, vYmMegaBirthShpTail3->m_tailScaleDirection, *tailScale);
+    pppAddVector(*(Vec*)particleData, *(Vec*)particleData, scaled);
 
     if (*(u16*)((u8*)&pYmMegaBirthShpTail3->m_matrix[1] + 0x4) != 0) {
         *(u16*)(particleBytes + 0x22) = *(u16*)(particleBytes + 0x22) - 1;

--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -393,8 +393,8 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
         }
 
         particleData = (u8*)work->m_particles;
-        worldMat = work->m_wmats;
         particleColor = work->m_colors;
+        worldMat = work->m_wmats;
         int spawnCount = 0;
 
         if ((gPppCalcDisabled == 0) && (*(s32*)(paramPayload + 4) != 0xffff)) {


### PR DESCRIPTION
## Summary
- Reuse the ShpTail3 calc vector temporary and hoist the frame spawn counter to match the surrounding codegen more closely.
- Use an unsigned paraboloid mode offset in pppYmEnv, matching the unsigned byte mode arithmetic from the target.

## Evidence
- ninja passes: final report is 566752 / 1855224 matched code bytes, 3378 / 4732 matched functions.
- pppYmEnv drawParaboloidMap: 92.7866% -> 93.650795%; unit .text: 97.00123% -> 97.301285%.
- pppYmMegaBirthShpTail3 final targeted objdiff: pppFrameYmMegaBirthShpTail3 97.14321%, calc 99.833336%.

## Plausibility
- The pppYmEnv change follows the actual unsigned mode input and Ghidra's (uint)param_6 * 5 shape.
- The ShpTail3 changes are scoped local lifetime/order adjustments around existing temporaries and counters; no address, section, or fake-symbol coercion.