### PR TITLE
Recover CGObject movement target layout

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -120,8 +120,8 @@ public:
     char m_ownerType;                 // 0x51
     unsigned char m_classWorkIndex;   // 0x52
     unsigned char m_ownerSlot;        // 0x53
-    unsigned char m_moveMode;         // 0x54
-    unsigned char m_moveModePrevious; // 0x55
+    signed char m_moveMode;           // 0x54
+    signed char m_moveModePrevious;   // 0x55
     unsigned char m_field_0x56;       // 0x56
     unsigned char m_field_0x57;       // 0x57
     void** m_scriptHandle;            // 0x58
@@ -207,8 +207,8 @@ public:
     float m_rotTargetZ;               // 0x1B8
     unsigned int m_bgFlags;           // 0x1BC
     unsigned int m_bgColMask;         // 0x1C0
-    Vec m_moveVec;                    // 0x1C4
-    float m_moveSpeed;                // 0x1D0
+    u32 m_bgHitMask;                  // 0x1C4
+    Vec m_moveTarget;                 // 0x1C8
     float m_moveTimer;                // 0x1D4
     unsigned int m_turnFrames;        // 0x1D8
     AttackCol m_attackColliders[8];   // 0x1DC

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -331,7 +331,7 @@ void CGObject::onCreate()
 
     unk_0x184 = 0.0f;
     unk_0x188 = 0.0f;
-    *reinterpret_cast<s32*>(&m_moveVec.x) = -1;
+    m_bgHitMask = -1;
     *((u8*)&m_weaponNodeFlags) &= 0xFE;
     *((u8*)&m_weaponNodeFlags) = (*((u8*)&m_weaponNodeFlags) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags) &= 0xBF;
@@ -539,11 +539,9 @@ void CGObject::move()
     if (static_cast<int>((static_cast<u32>(weaponFlagsHi) << 0x1A) | (weaponFlagsHi >> 6)) < 0) {
         int scriptMoveEnd = 0;
         if (static_cast<int>((static_cast<u32>(weaponFlagsHi) << 0x1B) | (weaponFlagsHi >> 5)) < 0) {
-            moveVec.x = m_moveVec.y;
-            moveVec.y = m_moveVec.z;
-            moveVec.z = m_moveSpeed;
+            moveVec = m_moveTarget;
         } else {
-            PSVECSubtract(reinterpret_cast<Vec*>(&m_moveVec.y), &m_worldPosition, &moveVec);
+            PSVECSubtract(&m_moveTarget, &m_worldPosition, &moveVec);
         }
 
         if ((Game.m_currentMapId != 0x21)
@@ -1005,7 +1003,7 @@ void CGObject::bgNormalCollision()
     move.y = sZeroFloat;
     Vec pos = m_worldPosition;
     pos.y += sStepProbeHeight + m_capsuleHalfHeight;
-    const u32 hitMask = *reinterpret_cast<u32*>(&m_moveVec.x);
+    const u32 hitMask = m_bgHitMask;
 
     int retry = 4;
     while (retry != 0) {
@@ -1187,7 +1185,7 @@ void CGObject::bgWorldCollision()
     bodyCylinder.m_radius2 = sZeroFloat;
     bodyCylinder.m_height2 = sZeroFloat;
 
-    const u32 hitMask = *reinterpret_cast<u32*>(&m_moveVec.x);
+    const u32 hitMask = m_bgHitMask;
     if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(
             &MapMng, reinterpret_cast<CMapCylinder*>(&bodyCylinder), &hitMove, hitMask) == 0) {
         return;
@@ -2175,9 +2173,7 @@ void CGObject::Move(Vec* moveVec, float moveTimer, int turnFrames, int moveMode,
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xEF;
     m_turnFrames = static_cast<u32>(turnFrames);
-    m_moveVec.y = moveVec->x;
-    m_moveVec.z = moveVec->y;
-    m_moveSpeed = moveVec->z;
+    m_moveTarget = *moveVec;
     m_moveTimer = moveTimer;
     *((u8*)&m_weaponNodeFlags) = (static_cast<u8>(moveMode << 1) & 2) | (*((u8*)&m_weaponNodeFlags) & 0xFD);
     *((u8*)&m_weaponNodeFlags + 1) =
@@ -2202,9 +2198,7 @@ void CGObject::MoveVector(Vec* moveVec, float moveTimer, int turnFrames, int use
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xEF) | 0x10;
     m_turnFrames = static_cast<u32>(turnFrames);
-    m_moveVec.y = moveVec->x;
-    m_moveVec.z = moveVec->y;
-    m_moveSpeed = moveVec->z;
+    m_moveTarget = *moveVec;
     m_moveTimer = moveTimer;
     *((u8*)&m_weaponNodeFlags + 1) =
         (static_cast<u8>(useFacing << 3) & 8) | (*((u8*)&m_weaponNodeFlags + 1) & 0xF7);
@@ -2238,9 +2232,7 @@ void CGObject::moveVector(Vec* moveVec, float moveTimer, int turnFrames)
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xEF) | 0x10;
     m_turnFrames = static_cast<u32>(turnFrames);
-    m_moveVec.y = unitVec.x;
-    m_moveVec.z = unitVec.y;
-    m_moveSpeed = unitVec.z;
+    m_moveTarget = unitVec;
     m_moveTimer = moveTimer;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xF7) | 8;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xFD;
@@ -2271,9 +2263,7 @@ void CGObject::moveVectorH(Vec* moveVec, float moveTimer, int turnFrames)
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xEF) | 0x10;
     m_turnFrames = static_cast<u32>(turnFrames);
-    m_moveVec.y = unitVec.x;
-    m_moveVec.z = unitVec.y;
-    m_moveSpeed = unitVec.z;
+    m_moveTarget = unitVec;
     m_moveTimer = moveTimer;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xF7;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xFD;
@@ -2300,9 +2290,9 @@ void CGObject::moveVectorRot(float rotX, float rotY, float moveTimer, int turnFr
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xEF) | 0x10;
     m_turnFrames = static_cast<u32>(turnFrames);
-    m_moveVec.y = static_cast<float>(sinX * cosY0);
-    m_moveVec.z = static_cast<float>(sinY);
-    m_moveSpeed = static_cast<float>(cosX * cosY1);
+    m_moveTarget.x = static_cast<float>(sinX * cosY0);
+    m_moveTarget.y = static_cast<float>(sinY);
+    m_moveTarget.z = static_cast<float>(cosX * cosY1);
     m_moveTimer = moveTimer;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xF7) | 8;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xFD;
@@ -2329,9 +2319,9 @@ void CGObject::moveVectorHRot(float rotX, float rotY, float moveTimer, int turnF
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xDF) | 0x20;
     *((u8*)&m_weaponNodeFlags + 1) = (*((u8*)&m_weaponNodeFlags + 1) & 0xEF) | 0x10;
     m_turnFrames = static_cast<u32>(turnFrames);
-    m_moveVec.y = static_cast<float>(sinX * cosY0);
-    m_moveVec.z = static_cast<float>(sinY);
-    m_moveSpeed = static_cast<float>(cosX * cosY1);
+    m_moveTarget.x = static_cast<float>(sinX * cosY0);
+    m_moveTarget.y = static_cast<float>(sinY);
+    m_moveTarget.z = static_cast<float>(cosX * cosY1);
     m_moveTimer = moveTimer;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xF7;
     *((u8*)&m_weaponNodeFlags + 1) &= 0xFD;
@@ -3259,7 +3249,7 @@ void CGObject::SetPosBG(Vec* position, int useCapsuleOffset)
             bodyCylinder.m_radius2 = 0.6f;
             bodyCylinder.m_height2 = 0.0f;
 
-            u32 hitMask = *reinterpret_cast<u32*>(&m_moveVec.x);
+            u32 hitMask = m_bgHitMask;
             if (CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(
                     &MapMng, reinterpret_cast<CMapCylinder*>(&bodyCylinder), &bodyCylinder.m_direction, hitMask) != 0) {
                 CalcHitPosition__7CMapObjFP3Vec(

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1438,7 +1438,7 @@ void CGItemObj::ItemJump(int state, float jump)
 		CGObject* object = reinterpret_cast<CGObject*>(itemObj);
 
 		if ((object->m_objectFlags & 0x10) == 0) {
-			unsigned int mapMask = *reinterpret_cast<unsigned int*>(&object->m_moveVec.x);
+			unsigned int mapMask = object->m_bgHitMask;
 			CMapCylinderRaw cylinder;
 			Vec move;
 

--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -2793,7 +2793,7 @@ void CGMonObj::moveFrame()
 		in_f29 = PSVECDistance(&local_68, &object->m_worldPosition);
 
 		if (((moveFlags & 0x30000) != 0) && (*reinterpret_cast<unsigned int*>(ARRAY_8030918c) != 0)) {
-			int polygonGroup = AStar.calcPolygonGroup(&local_68, static_cast<int>(object->m_moveVec.x));
+			int polygonGroup = AStar.calcPolygonGroup(&local_68, static_cast<int>(object->m_bgHitMask));
 			moveAStar(aStarGroupId, polygonGroup, local_68);
 		}
 	} else if ((moveFlags & 0x2000) != 0) {


### PR DESCRIPTION
## Summary
- Split `CGObject` movement storage into a `m_bgHitMask` word plus `m_moveTarget` vector.
- Updated movement, background collision, item, and monster call sites to use the recovered fields instead of pointer-offset reinterpret casts.
- Marked attach interpolation counters as signed bytes to match decompilation usage.

## Evidence
- `ninja` passes.
- `main/gobject` fuzzy score: 67.68% selector baseline -> 67.83% after this change.
- `update__8CGObjectFv`: ~50.58% baseline -> 51.20%.
- `move__8CGObjectFv`: 57.10% after change.
- `bgNormalCollision__8CGObjectFv`: 56.06% after change.

## Plausibility
The old layout treated the first word of a `Vec` as a `u32` map hit mask, while the following three words were used as movement target coordinates. The recovered fields preserve offsets and replace those casts with source-like member access.
