### PR TITLE
Move YmDeformationMdl shared double constant

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -52,7 +52,6 @@ extern const float kYmDeformationMdlTexMtxOffset;
 extern const float kYmDeformationMdlTexMtxDepth;
 extern const float kYmDeformationMdlDegToRad;
 extern const float kYmDeformationMdlZero = 0.0f;
-extern const double kPppYmSharedDoubleBias = 4503601774854144.0;
 
 static inline Mtx& CameraMatrix()
 {
@@ -339,3 +338,5 @@ void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, str
     state->m_values[3] = zero;
     state->m_values[2] = zero;
 }
+
+extern const double kPppYmSharedDoubleBias = 4503601774854144.0;


### PR DESCRIPTION
## Summary
- Move `kPppYmSharedDoubleBias` below the functions in `pppYmDeformationMdl.cpp`.
- This makes the generated local conversion double (`@210`) emit before the named shared double, matching the target symbol order for the unit's `.sdata2` constants.

## Evidence
- `ninja` completes.
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o /tmp/ppp_ym_def_mdl_final.json`
- After: right-side `.sdata2` symbols emit as `@210` then `kPppYmSharedDoubleBias`, matching target order. Remaining difference: the built object still has an extra 4-byte alignment pad before the double constants, so this is layout progress but not a complete data match.

## Plausibility
- This keeps the normal compiler-generated constants and avoids manual section forcing or address hacks.
- The named shared double is still defined by normal C++ source, just after the code that causes the local conversion double to be emitted.
