### PR TITLE
Fix menu_item sdata2 ownership

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -44,12 +44,12 @@ extern "C" int __cntlzw(unsigned int);
 
 extern CMenuPcs MenuPcs;
 
-static const float FLOAT_80332e60 = 0.0f;
+extern const float FLOAT_80332e60;
 extern float FLOAT_80332e64;
 extern const double DOUBLE_80332e68;
 extern float FLOAT_80332e70;
 extern float FLOAT_80332e74;
-static const double DOUBLE_80332e78 = 0.5;
+extern const double DOUBLE_80332e78;
 extern float FLOAT_80332e80;
 extern float FLOAT_80332e84;
 extern float FLOAT_80332e88;
@@ -58,9 +58,14 @@ extern float FLOAT_80332e90;
 extern float FLOAT_80332e94;
 extern float FLOAT_80332E98;
 extern const double DOUBLE_80332ea0;
-static const float FLOAT_80332EA8 = 128.0f;
-static const float FLOAT_80332EAC = 8.0f;
-static const float FLOAT_80332EB0 = 0.75f;
+extern const float FLOAT_80332EA8;
+extern const float FLOAT_80332EAC;
+extern const float FLOAT_80332EB0;
+extern const double DOUBLE_80333388 = 373.0;
+extern const float FLOAT_80333390 = 214.0f;
+extern const float FLOAT_80333394 = 112.0f;
+extern const float FLOAT_80333398 = 474.0f;
+extern const double DOUBLE_803333a0 = 32.0;
 
 struct MenuItemOpenAnim {
     s16 x;


### PR DESCRIPTION
## Summary
- Move menu_item references to shared 80332e* constants out of local static storage
- Add the menu_item-owned 80333388..803333A8 .sdata2 constants from the split/map layout

## Evidence
- ninja succeeds
- build report data matched increased by 32 bytes: 1,139,914 -> 1,139,946
- objdiff main/menu_item .sdata2 section improved from 60.526318% to 100.0%
- build/GCCP01/src/menu_item.o now defines DOUBLE_80333388, FLOAT_80333390, FLOAT_80333394, FLOAT_80333398, DOUBLE_803333a0

## Notes
- This is a MAP/splits-backed data ownership fix: menu_item owns .sdata2 0x80333388..0x803333A8, while the 80332e* constants are outside the unit.