### PR TITLE
Improve sound RedSound call matching

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -731,10 +731,11 @@ float CSound::GetPerformance()
 void CSound::PauseDiscError(int pause)
 {
     u8* self = reinterpret_cast<u8*>(this);
+    CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
 
-    if (reinterpret_cast<CSoundLayout*>(self)->m_pauseAllSe == 0) {
-        RedSound(this)->SePause(-1, static_cast<u32>(-pause | pause) >> 31);
-        RedSound(this)->StreamPause(-1, (-static_cast<u32>(pause) | static_cast<u32>(pause)) >> 31);
+    if (sound.m_pauseAllSe == 0) {
+        reinterpret_cast<CRedSound*>(self + 8)->SePause(-1, static_cast<u32>(-pause | pause) >> 31);
+        reinterpret_cast<CRedSound*>(self + 8)->StreamPause(-1, (-static_cast<u32>(pause) | static_cast<u32>(pause)) >> 31);
     }
 }
 
@@ -747,15 +748,14 @@ void CSound::CheckDriver(int mode)
 {
     u8* self = reinterpret_cast<u8*>(this);
     CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
-    CRedSound* redSound = RedSound(this);
     unsigned int oldPrint = sound.m_debugPrint;
     sound.m_debugPrint = 1;
-    redSound->ReportPrint(1);
-    redSound->TestProcess(mode);
-    redSound->DisplayWaveInfo();
-    redSound->DisplaySePlayInfo();
+    reinterpret_cast<CRedSound*>(self + 8)->ReportPrint(1);
+    reinterpret_cast<CRedSound*>(self + 8)->TestProcess(mode);
+    reinterpret_cast<CRedSound*>(self + 8)->DisplayWaveInfo();
+    reinterpret_cast<CRedSound*>(self + 8)->DisplaySePlayInfo();
     sound.m_debugPrint = oldPrint;
-    redSound->ReportPrint((-oldPrint | oldPrint) >> 0x1F);
+    reinterpret_cast<CRedSound*>(self + 8)->ReportPrint((-oldPrint | oldPrint) >> 0x1F);
 }
 
 /*
@@ -1105,11 +1105,11 @@ int CSound::IsLoadWaveASyncCompleted()
  */
 void CSound::LoadBgm(int bgmId)
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
 
     if (bgmId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-    } else if (redSound->ReentryMusicData(bgmId) == -1) {
+    } else if (reinterpret_cast<CRedSound*>(self + 8)->ReentryMusicData(bgmId) == -1) {
         char musicPath[256];
         sprintf(musicPath, s_soundMusicPathFmt, bgmId);
 
@@ -1117,7 +1117,7 @@ void CSound::LoadBgm(int bgmId)
         if (handle != 0) {
             File.Read(handle);
             File.SyncCompleted(handle);
-            redSound->SetMusicData(File.m_readBuffer);
+            reinterpret_cast<CRedSound*>(self + 8)->SetMusicData(File.m_readBuffer);
             File.Close(handle);
         }
     }
@@ -1134,14 +1134,14 @@ void CSound::LoadBgm(int bgmId)
  */
 void CSound::PlayBgm(int bgmId)
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
 
     if (bgmId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
-        redSound->MusicStop(-1);
-        redSound->SetMusicPhraseStop(REDSOUND_MUSIC_PHRASE_STOP_OFF);
-        redSound->MusicPlay(bgmId, 0x7F, 0);
+        reinterpret_cast<CRedSound*>(self + 8)->MusicStop(-1);
+        reinterpret_cast<CRedSound*>(self + 8)->SetMusicPhraseStop(REDSOUND_MUSIC_PHRASE_STOP_OFF);
+        reinterpret_cast<CRedSound*>(self + 8)->MusicPlay(bgmId, 0x7F, 0);
     }
 }
 
@@ -1156,13 +1156,13 @@ void CSound::PlayBgm(int bgmId)
  */
 void CSound::CrossPlayBgm(int bgmId, int crossFrames)
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
 
     if (bgmId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
-        redSound->SetMusicPhraseStop(REDSOUND_MUSIC_PHRASE_STOP_OFF);
-        redSound->MusicCrossPlay(bgmId, 0x7F, crossFrames);
+        reinterpret_cast<CRedSound*>(self + 8)->SetMusicPhraseStop(REDSOUND_MUSIC_PHRASE_STOP_OFF);
+        reinterpret_cast<CRedSound*>(self + 8)->MusicCrossPlay(bgmId, 0x7F, crossFrames);
     }
 }
 
@@ -1177,13 +1177,13 @@ void CSound::CrossPlayBgm(int bgmId, int crossFrames)
  */
 void CSound::PlayNextBgm(int bgmId)
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
 
     if (bgmId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
-        redSound->MusicNextPlay(bgmId, 0x7F, 0);
-        redSound->SetMusicPhraseStop(REDSOUND_MUSIC_PHRASE_STOP_ON);
+        reinterpret_cast<CRedSound*>(self + 8)->MusicNextPlay(bgmId, 0x7F, 0);
+        reinterpret_cast<CRedSound*>(self + 8)->SetMusicPhraseStop(REDSOUND_MUSIC_PHRASE_STOP_ON);
     }
 }
 
@@ -1226,18 +1226,18 @@ void CSound::FadeOutBgm(int fadeFrames)
  */
 void CSound::LoadBlock()
 {
-    CRedSound* redSound = RedSound(this);
-    CSoundLayout& sound = SoundData(this);
+    u8* self = reinterpret_cast<u8*>(this);
+    CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
     CFile::CHandle*& waveFile = sound.m_waveFile;
 
-    if (redSound->ReentryWaveData(0) == -1) {
+    if (reinterpret_cast<CRedSound*>(self + 8)->ReentryWaveData(0) == -1) {
         if (waveFile != 0) {
             File.Close(waveFile);
             waveFile = 0;
             Printf__7CSystemFPce(&System, s_soundLoadWaveErrorFmt);
         }
 
-        redSound->SetWaveData(-1, 0, 0);
+        reinterpret_cast<CRedSound*>(self + 8)->SetWaveData(-1, 0, 0);
 
         char wavePath[256];
         sprintf(wavePath, s_soundWavePathFmt, 0);
@@ -1254,14 +1254,14 @@ void CSound::LoadBlock()
         }
     }
 
-    if (redSound->ReentryWaveData(500) == -1) {
+    if (reinterpret_cast<CRedSound*>(self + 8)->ReentryWaveData(500) == -1) {
         if (waveFile != 0) {
             File.Close(waveFile);
             waveFile = 0;
             Printf__7CSystemFPce(&System, s_soundLoadWaveErrorFmt);
         }
 
-        redSound->SetWaveData(-1, 0, 0);
+        reinterpret_cast<CRedSound*>(self + 8)->SetWaveData(-1, 0, 0);
 
         char wavePath[256];
         sprintf(wavePath, s_soundWavePathFmt, 500);
@@ -1285,7 +1285,7 @@ void CSound::LoadBlock()
         if (handle != 0) {
             File.Read(handle);
             File.SyncCompleted(handle);
-            redSound->SetSeBlockData(i, File.m_readBuffer);
+            reinterpret_cast<CRedSound*>(self + 8)->SetSeBlockData(i, File.m_readBuffer);
             File.Close(handle);
         }
     }
@@ -1302,12 +1302,12 @@ void CSound::LoadBlock()
  */
 void CSound::FreeBlock()
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
 
-    redSound->ClearWaveBank(500);
-    redSound->ClearWaveBank(0);
+    reinterpret_cast<CRedSound*>(self + 8)->ClearWaveBank(500);
+    reinterpret_cast<CRedSound*>(self + 8)->ClearWaveBank(0);
     for (int i = 0; i < 4; i++) {
-        redSound->SetSeBlockData(i, 0);
+        reinterpret_cast<CRedSound*>(self + 8)->SetSeBlockData(i, 0);
     }
 }
 
@@ -1322,18 +1322,18 @@ void CSound::FreeBlock()
  */
 void CSound::LoadSe(int seId)
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
 
     if (seId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-    } else if (redSound->ReentrySeSepData(seId) == -1) {
+    } else if (reinterpret_cast<CRedSound*>(self + 8)->ReentrySeSepData(seId) == -1) {
         char sePath[264];
         sprintf(sePath, s_soundSeSepPathFmt, seId);
         CFile::CHandle* handle = File.Open(sePath, 0, CFile::PRI_LOW);
         if (handle != 0) {
             File.Read(handle);
             File.SyncCompleted(handle);
-            redSound->SetSeSepData(File.m_readBuffer);
+            reinterpret_cast<CRedSound*>(self + 8)->SetSeSepData(File.m_readBuffer);
             File.Close(handle);
             if (System.m_execParam != 0) {
                 Printf__7CSystemFPce(&System, s_soundLoadSeMergeFmt, seId);
@@ -1353,9 +1353,9 @@ void CSound::LoadSe(int seId)
  */
 void CSound::LoadSe(void* seData)
 {
-    CRedSound* redSound = RedSound(this);
-    if (redSound->ReentrySeSepData(*reinterpret_cast<s32*>((u8*)seData + 8)) == -1) {
-        redSound->SetSeSepData(seData);
+    u8* self = reinterpret_cast<u8*>(this);
+    if (reinterpret_cast<CRedSound*>(self + 8)->ReentrySeSepData(*reinterpret_cast<s32*>((u8*)seData + 8)) == -1) {
+        reinterpret_cast<CRedSound*>(self + 8)->SetSeSepData(seData);
     }
 }
 
@@ -1370,24 +1370,24 @@ void CSound::LoadSe(void* seData)
  */
 void CSound::LoadWave(int waveId)
 {
-    CRedSound* redSound = RedSound(this);
-    CSoundLayout& sound = SoundData(this);
+    u8* self = reinterpret_cast<u8*>(this);
+    CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
     CFile::CHandle*& waveFile = sound.m_waveFile;
 
     if (waveId < 0) {
         Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
     } else {
-        if (redSound->ReentryWaveData(waveId) == -1) {
+        if (reinterpret_cast<CRedSound*>(self + 8)->ReentryWaveData(waveId) == -1) {
             if (waveId < 0) {
                 Printf__7CSystemFPce(&System, s_soundMinusOneFmt);
-            } else if (redSound->ReentryWaveData(waveId) == -1) {
+            } else if (reinterpret_cast<CRedSound*>(self + 8)->ReentryWaveData(waveId) == -1) {
                 if (waveFile != 0) {
                     File.Close(waveFile);
                     waveFile = 0;
                     Printf__7CSystemFPce(&System, s_soundLoadWaveErrorFmt);
                 }
 
-                redSound->SetWaveData(-1, nullptr, 0);
+                reinterpret_cast<CRedSound*>(self + 8)->SetWaveData(-1, nullptr, 0);
 
                 char wavePath[260];
                 sprintf(wavePath, s_soundWavePathFmt, waveId);
@@ -1423,17 +1423,18 @@ void CSound::LoadWave(int waveId)
  */
 void CSound::LoadWave(void* waveData)
 {
-    CRedSound* redSound = RedSound(this);
-    CFile::CHandle*& waveFile = SoundData(this).m_waveFile;
+    u8* self = reinterpret_cast<u8*>(this);
+    CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
+    CFile::CHandle*& waveFile = sound.m_waveFile;
 
-    if (redSound->ReentryWaveData(reinterpret_cast<s16*>(waveData)[1]) == -1) {
+    if (reinterpret_cast<CRedSound*>(self + 8)->ReentryWaveData(reinterpret_cast<s16*>(waveData)[1]) == -1) {
         if (waveFile != 0) {
             File.Close(waveFile);
             waveFile = 0;
             Printf__7CSystemFPce(&System, s_soundLoadWaveErrorFmt);
         }
-        redSound->SetWaveData(-1, nullptr, 0);
-        redSound->SetWaveData(-1, waveData, -1);
+        reinterpret_cast<CRedSound*>(self + 8)->SetWaveData(-1, nullptr, 0);
+        reinterpret_cast<CRedSound*>(self + 8)->SetWaveData(-1, waveData, -1);
     }
 }
 
@@ -1468,18 +1469,17 @@ void CSound::StopAndFreeAllSe(int clearMode)
 {
     u8* self = reinterpret_cast<u8*>(this);
     CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
-    CRedSound* redSound = RedSound(this);
     if (clearMode != 0) {
-        redSound->SeStop(-1);
-        redSound->ClearSeSepData(-1);
-        redSound->ClearWaveData(-3);
+        reinterpret_cast<CRedSound*>(self + 8)->SeStop(-1);
+        reinterpret_cast<CRedSound*>(self + 8)->ClearSeSepData(-1);
+        reinterpret_cast<CRedSound*>(self + 8)->ClearWaveData(-3);
     } else {
-        redSound->SeStopMG(sound.m_noFreeSeGroups[0], sound.m_noFreeSeGroups[1],
-                           sound.m_noFreeSeGroups[2], sound.m_noFreeSeGroups[3]);
-        redSound->ClearSeSepDataMG(sound.m_noFreeSeGroups[0], sound.m_noFreeSeGroups[1],
-                                   sound.m_noFreeSeGroups[2], sound.m_noFreeSeGroups[3]);
-        redSound->ClearWaveDataM(sound.m_noFreeWaves[0], sound.m_noFreeWaves[1],
-                                 sound.m_noFreeWaves[2], sound.m_noFreeWaves[3]);
+        reinterpret_cast<CRedSound*>(self + 8)->SeStopMG(sound.m_noFreeSeGroups[0], sound.m_noFreeSeGroups[1],
+                                                         sound.m_noFreeSeGroups[2], sound.m_noFreeSeGroups[3]);
+        reinterpret_cast<CRedSound*>(self + 8)->ClearSeSepDataMG(sound.m_noFreeSeGroups[0], sound.m_noFreeSeGroups[1],
+                                                                 sound.m_noFreeSeGroups[2], sound.m_noFreeSeGroups[3]);
+        reinterpret_cast<CRedSound*>(self + 8)->ClearWaveDataM(sound.m_noFreeWaves[0], sound.m_noFreeWaves[1],
+                                                               sound.m_noFreeWaves[2], sound.m_noFreeWaves[3]);
     }
 
     sound.m_seCount = 10000000;
@@ -2479,11 +2479,12 @@ void CSound::IsDebugPrint(int)
  */
 void CSound::PauseAllSe(int pause)
 {
-    CRedSound* redSound = RedSound(this);
+    u8* self = reinterpret_cast<u8*>(this);
+    CSoundLayout& sound = *reinterpret_cast<CSoundLayout*>(self);
 
-    redSound->SePause(-1, static_cast<u32>(-pause | pause) >> 31);
-    redSound->StreamPause(-1, (-static_cast<u32>(pause) | static_cast<u32>(pause)) >> 31);
-    SoundData(this).m_pauseAllSe = pause;
+    reinterpret_cast<CRedSound*>(self + 8)->SePause(-1, static_cast<u32>(-pause | pause) >> 31);
+    reinterpret_cast<CRedSound*>(self + 8)->StreamPause(-1, (-static_cast<u32>(pause) | static_cast<u32>(pause)) >> 31);
+    sound.m_pauseAllSe = pause;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Use the known embedded CRedSound storage at this + 8 directly in several CSound call wrappers and load paths.
- Keep CSoundLayout member access for sound state while avoiding long-lived local CRedSound* values that caused extra saved registers.

## Objdiff evidence
- main/sound .text: 90.39553% -> 92.537926%
- Newly matched at 100%: PauseDiscError, CheckDriver, LoadBgm, PlayBgm, CrossPlayBgm, PlayNextBgm, LoadSe(void*), LoadWave(void*), StopAndFreeAllSe, FreeBlock, PauseAllSe
- Additional improvements: LoadSe(int) 93.72464% -> 98.652176%, LoadBlock 90.52564% -> 97.589745%, LoadWave(int) 88.61386% -> 97.32674%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/sound -o -

## Plausibility
CSound already constructs CRedSound at offset 8 and uses a local layout mirror for the rest of the object. These changes make the source reflect that embedded-object access pattern directly instead of keeping a separate CRedSound* live across calls.
