### PR TITLE
Match p_game rodata strings

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -11,6 +11,8 @@ extern "C" void draw1__8CGamePcsFv(CGamePcs*);
 extern "C" void draw2__8CGamePcsFv(CGamePcs*);
 
 extern const char s_CGamePcs_801D7C20[] = "CGamePcs";
+static const char s_CManager_801D7C2C[] = "CManager";
+static const char s_CProcess_801D7C38[] = "CProcess";
 
 unsigned int m_table__8CGamePcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CGamePcs_801D7C20)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x13, 0, 0, 0, 0, 0x17, 0, 0, 0,


### PR DESCRIPTION
## Summary
- Add the missing CManager and CProcess class-name strings emitted with p_game rodata.
- Matches the surrounding PCS string layout pattern used by other process units.

## Evidence
- Before objdiff main/p_game: .text 100.0%, .rodata 84.61539%, .data 100.0%.
- After objdiff main/p_game: .text 100.0%, .rodata 100.0%, .data 100.0%.
- ninja passes; project data progress increased by 40 bytes.

## Plausibility
- These are normal class-name rodata strings adjacent to CGamePcs, consistent with nearby PCS units, and no vtables/RTTI/ctors were hand-authored.