### PR TITLE
Improve ME app request rodata layout

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -9,7 +9,7 @@ void __dla__FPv(void*);
 void* memset(void*, int, unsigned int);
 }
 
-static const char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
+static const char s_ME_AppRequest_cpp_801d7da8[24] = "ME_AppRequest.cpp";
 
 struct ZCANMGRP {
     void* ptr;

--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -731,14 +731,15 @@ s32 THPSimpleSetBuffer(u8* buffer)
         SimpleControl.readBuffer[6].mPtr = cursor;
         cursor += frameBufferSize;
 
+        SimpleControl.readBuffer[7].mPtr = cursor;
+        cursor += frameBufferSize;
+
         SimpleControl.readBuffer[1].mIsValid = 0;
         SimpleControl.readBuffer[2].mIsValid = 0;
         SimpleControl.readBuffer[3].mIsValid = 0;
         SimpleControl.readBuffer[4].mIsValid = 0;
         SimpleControl.readBuffer[5].mIsValid = 0;
         SimpleControl.readBuffer[6].mIsValid = 0;
-        SimpleControl.readBuffer[7].mPtr = cursor;
-        cursor += frameBufferSize;
         SimpleControl.readBuffer[7].mIsValid = 0;
 
         if (SimpleControl.hasAudio != 0) {


### PR DESCRIPTION
## Summary
- Size the ME_AppRequest filename rodata symbol to match the 24-byte target layout.
- Group THPSimple read-buffer pointer assignment for buffer 7 with the other pointer assignments; this matches the Ghidra source order and does not change codegen.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/ME_AppRequest -o /tmp/me_apprequest_final.json`: `[.rodata-0]` is now 24 bytes and 100.0% matched (was 85.71429%).
- `ResetRsdList__18CMaterialEditorPcsFP5ZLIST` remains 99.24051%.
- `build/tools/objdiff-cli diff -p . -u main/THPSimple -o /tmp/thpsimple_final.json THPSimpleSetBuffer`: remains 95.72642%; THP change is source-order cleanup only.

## Plausibility
- The ME_AppRequest filename string now carries the target trailing rodata padding in the owning symbol.
- The THPSimple order keeps all read-buffer pointer layout assignments together before clearing validity flags, matching the Ghidra decompilation shape.