### PR TITLE
Gate non-PAL p_tina stubs

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -575,10 +575,12 @@ unsigned int pppAmemRefCntError(unsigned long)
  * Address:	TODO
  * Size:	TODO
  */
+#ifndef VERSION_GCCP01
 void CPartPcs::create0()
 {
 	// TODO
 }
+#endif
 
 /*
  * --INFO--
@@ -751,20 +753,24 @@ void CPartPcs::destroy()
  * Address:	TODO
  * Size:	TODO
  */
+#ifndef VERSION_GCCP01
 void CPartPcs::ChangeDataStage(CMemory::CStage*)
 {
 	// TODO
 }
+#endif
 
 /*
  * --INFO--
  * Address:	TODO
  * Size:	TODO
  */
+#ifndef VERSION_GCCP01
 void CPartPcs::ResetDataStage()
 {
 	// TODO
 }
+#endif
 
 /*
  * --INFO--
@@ -1370,10 +1376,12 @@ void CPartPcs::LoadFieldPdt(int mapId, int floorId, void* amemBase, unsigned lon
  * Address:	TODO
  * Size:	TODO
  */
+#ifndef VERSION_GCCP01
 void loadPdtPtx(char*, void*, int, void*, int, int)
 {
 	// TODO
 }
+#endif
 
 /*
  * --INFO--
@@ -1570,7 +1578,9 @@ void CPartPcs::EndMiruraEvent()
  * Address:	TODO
  * Size:	TODO
  */
+#ifndef VERSION_GCCP01
 void CPartPcs::SetUSBData()
 {
 	// TODO
 }
+#endif


### PR DESCRIPTION
## Summary
- Gate five TODO-only p_tina definitions out of the GCCP01 build with VERSION_GCCP01 guards.
- Removes PAL-emitted empty symbols that are absent from config/GCCP01/symbols.txt: create0, ChangeDataStage, ResetDataStage, loadPdtPtx, and SetUSBData.

## Evidence
- ninja completes successfully.
- objdiff main/p_tina rebuilt .text size improved from 7776 bytes before this change to 7756 bytes after this change.
- The five extra rebuilt symbols are no longer present in the p_tina objdiff symbol list.

## Plausibility
- These definitions had TODO addresses/sizes and no PAL symbol entries, so excluding them for GCCP01 matches the PAL map/symbol ownership instead of emitting placeholder code.