### PR TITLE
Improve caravan letter money division

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -513,8 +513,7 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 	letterWords32[0] = (letterWords32[0] & 0xFFFC01FF) | ((senderId & 0x1FF) << 9);
 	letterFlags->hasMoney = hasMoneyFlag;
 	if (letterFlags->hasMoney != 0) {
-		int divValue = (moneyValue / 100) + (moneyValue >> 31);
-		moneyValue = divValue - (divValue >> 31);
+		moneyValue = moneyValue / 100;
 	}
 	letterWords16[1] = (unsigned short)((letterWords16[1] & 0xFE00) | (moneyValue & 0x1FF));
 	letterFlags->opened = 0;


### PR DESCRIPTION
## Summary
- Simplify the money scaling in CCaravanWork::AddLetter to a direct signed divide by 100 when the money flag is set.
- Removes the extra sign-adjust sequence that was not present in the target code.

## Evidence
- ninja passes.
- Objdiff for AddLetter__12CCaravanWorkFiiiiiiiii in main/gobjwork:
  - before selector baseline: 83.7% match, 392b
  - after: 86.6% match, 388b

## Plausibility
- The decompiled target sequence is the standard signed /100 lowering. The previous source added extra quotient correction, which generated additional instructions and moved the function away from plausible original code.