### PR TITLE
Match p_gba RTTI table pads

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -11,6 +11,8 @@ extern "C" void calc__7CGbaPcsFv(CGbaPcs*);
 extern "C" void draw__7CGbaPcsFv(CGbaPcs*);
 extern const char s_CGbaPcs_80330870[];
 extern const char s_JoyBus__LoadBin___error_801d9de0[];
+extern const char __RTTI__8CManager_8032E7C0[];
+extern const char __RTTI__8CProcess_8032E7C8[];
 
 const char s_CGbaPcs_80330870[] = "CGbaPcs";
 const char s_JoyBus__LoadBin___error_801d9de0[] = "JoyBus::LoadBin() error\n";
@@ -68,8 +70,15 @@ CGbaPcsTable CGbaPcs::m_table = {
     },
 };
 
-unsigned int s_CGbaPcsTablePad0[3] = {0, 0, 0};
-unsigned int s_CGbaPcsTablePad1[5] = {0, 0, 0, 0, 0};
+unsigned int s_CGbaPcsTablePad0[3] = {
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E7C0)), 0, 0};
+unsigned int s_CGbaPcsTablePad1[5] = {
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E7C0)),
+    0,
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CProcess_8032E7C8)),
+    0,
+    0,
+};
 CGbaPcs GbaPcs;
 
 /*


### PR DESCRIPTION
## Summary
- Replace zeroed CGbaPcs table-pad placeholders with the RTTI descriptor references shown in the target object.
- Matches the existing p_mc table-pad pattern while leaving the compiler-generated CGbaPcs vtable untouched.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_gba -o -`:
  - `.data`: 97.66553% -> 99.54361%
  - `[.data-0]`: 96.969696% -> 99.242424%
  - `s_CGbaPcsTablePad0`: 75.0% -> 100.0%
  - `s_CGbaPcsTablePad1`: 71.42857% -> 100.0%
  - `.text`: remains 100.0%

## Plausibility
These pad records sit between `CGbaPcs::m_table` and `CGbaPcs`'s vtable and correspond to the same CManager/CProcess RTTI descriptor layout already represented in nearby process units such as p_mc.
