### PR TITLE
Improve pppChangeTex split frame conversion

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -295,21 +295,19 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 		return;
 	}
 
-	union {
-		double d;
-		u32 u[2];
-	} scale;
 	float currentValue = work->m_value0 * (work->m_bboxMax.y - work->m_bboxMin.y) + work->m_bboxMin.y;
 
-	scale.u[0] = 0x43300000;
-	scale.u[1] = (1 << model0Raw->m_data->m_frameShift) ^ 0x80000000;
-	short splitY = (short)(int)(currentValue * (scale.d - LoadDouble(DOUBLE_80332030)));
+	short splitY = (short)(int)(currentValue * (float)(1 << model0Raw->m_data->m_frameShift));
 	if (work->m_cachedValue == currentValue) {
 		return;
 	}
 
 	work->m_cachedValue = currentValue;
 
+	union {
+		double d;
+		u32 u[2];
+	} scale;
 	scale.u[0] = 0x43300000;
 	scale.u[1] = colorData[0xB];
 	double alphaBase = (double)(LoadFloat(FLOAT_80332028) * ((float)(scale.d - LoadDouble(DOUBLE_80332038)) / LoadFloat(FLOAT_80332028)));


### PR DESCRIPTION
## Summary
- Replace the manual double-pair conversion used for the ChangeTex split plane with the natural frame-shift float conversion.
- Keep the alpha byte conversion on the existing double-pair path so the surrounding register/lifetime behavior remains stable.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o - pppFrameChangeTex`
  - Before: `.text` 96.789314%
  - After: `.text` 97.172516%
  - `extab` remains 100.0%; `extabindex` remains 96.666664%

## Plausibility
- This matches the source-level intent better: the split Y threshold is computed from `currentValue * (1 << frameShift)`, not a hand-built conversion constant.
- The manual conversion is still retained for the later alpha byte path where it is needed for the current codegen shape.