### PR TITLE
Define CUSBPcs process table descriptors

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -5,23 +5,33 @@
 #include "ffcc/system.h"
 #include "ffcc/usb.h"
 
-struct CUSBPcsTable
-{
-    char* m_name;
-    unsigned int m_words[0x46];
-};
-
 extern unsigned int m_table_desc0__7CUSBPcs[];
 extern unsigned int m_table_desc1__7CUSBPcs[];
 extern unsigned int m_table_desc2__7CUSBPcs[];
-extern CUSBPcsTable m_table__7CUSBPcs;
+extern unsigned int m_table__7CUSBPcs[];
 
 class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;
 
-    CUSBPcs();
+    CUSBPcs()
+    {
+        unsigned int* table = reinterpret_cast<unsigned int*>(m_table__7CUSBPcs);
+        const unsigned int* desc0 = m_table_desc0__7CUSBPcs;
+        const unsigned int* desc1 = m_table_desc1__7CUSBPcs;
+        const unsigned int* desc2 = m_table_desc2__7CUSBPcs;
+
+        table[1] = desc0[0];
+        table[2] = desc0[1];
+        table[3] = desc0[2];
+        table[4] = desc1[0];
+        table[5] = desc1[1];
+        table[6] = desc1[2];
+        table[7] = desc2[0];
+        table[8] = desc2[1];
+        table[9] = desc2[2];
+    }
 
     void Init();
     void Quit();

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -13,21 +13,24 @@ extern "C" void create__7CUSBPcsFv(CUSBPcs*);
 extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
+CUSBPcs USBPcs;
+
 extern const char s_CUSBPcs_8032f810[] = "CUSBPcs";
-CUSBPcsTable m_table__7CUSBPcs = {
-    const_cast<char*>(s_CUSBPcs_8032f810),
-    {
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0x12,
-    },
+unsigned int m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
+unsigned int m_table__7CUSBPcs[0x11C / sizeof(unsigned int)] = {
+    reinterpret_cast<unsigned int>(const_cast<char*>(s_CUSBPcs_8032f810)),
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0x12,
 };
 unsigned int s_CUSBPcsTablePad0[3] = {0, 0, 0};
 unsigned int s_CUSBPcsTablePad1[5] = {0, 0, 0, 0, 0};
@@ -224,7 +227,7 @@ void CUSBPcs::IsBigAlloc(int param_2)
  */
 int CUSBPcs::GetTable(unsigned long param)
 {
-    return reinterpret_cast<int>(reinterpret_cast<char*>(&m_table__7CUSBPcs) + (param * 0x15c));
+    return reinterpret_cast<int>(reinterpret_cast<char*>(m_table__7CUSBPcs) + (param * 0x15c));
 }
 
 /*
@@ -268,24 +271,4 @@ void CUSBPcs::Init()
 	m_unk0x108 = 0;
 
 	USB.Connect();
-}
-
-CUSBPcs USBPcs;
-
-inline CUSBPcs::CUSBPcs()
-{
-    unsigned int* table = reinterpret_cast<unsigned int*>(&m_table__7CUSBPcs);
-    const unsigned int* desc0 = m_table_desc0__7CUSBPcs;
-    const unsigned int* desc1 = m_table_desc1__7CUSBPcs;
-    const unsigned int* desc2 = m_table_desc2__7CUSBPcs;
-
-    table[1] = desc0[0];
-    table[2] = desc0[1];
-    table[3] = desc0[2];
-    table[4] = desc1[0];
-    table[5] = desc1[1];
-    table[6] = desc1[2];
-    table[7] = desc2[0];
-    table[8] = desc2[1];
-    table[9] = desc2[2];
 }


### PR DESCRIPTION
## Summary
- Defines the three CUSBPcs process table descriptor arrays in p_usb.cpp instead of leaving them as extern-only declarations.
- Represents m_table__7CUSBPcs as the flat 0x11C-word table used by neighboring process units and moves the constructor inline with the header pattern.
- Keeps the compiler-generated CUSBPcs vtable untouched.

## Evidence
- ninja passes; build/GCCP01/main.dol reports OK.
- Focused objdiff for main/p_usb after the change: .data is 95.94% matched at 392 bytes, with rodata/bss/sdata/sbss/sdata2 all 100%.
- Baseline selector reported main/p_usb as code 100.0%, data 56.64%; this change trades a __sinit relocation-target/code score regression for real descriptor ownership and much closer data layout.

## Plausibility
The descriptor contents match the target table pattern in build/GCCP01/asm/p_usb.s: {0, -1, create}, {0, -1, destroy}, {0, -1, func}. This follows existing process-table source patterns such as p_minigame and p_dbgmenu, rather than relying on undefined extern descriptor data.