### PR TITLE
Improve p_usb sbss and ME_AppRequest rodata

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -9,7 +9,7 @@ void __dla__FPv(void*);
 void* memset(void*, int, unsigned int);
 }
 
-static const char s_ME_AppRequest_cpp_801d7da8[24] = "ME_AppRequest.cpp";
+static const char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
 
 struct ZCANMGRP {
     void* ptr;

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -9,6 +9,9 @@
 extern const char lbl_801DA074[];
 int s_usbReadPollFrameCounter;
 char s_usbReadPollInitialized;
+char s_usbReadPollPadding0;
+char s_usbReadPollPadding1;
+char s_usbReadPollPadding2;
 extern "C" void create__7CUSBPcsFv(CUSBPcs*);
 extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);


### PR DESCRIPTION
## Summary
- add the missing byte padding after the p_usb read-poll initialized flag so the compiled `.sbss` size reaches the PAL 8-byte layout
- trim the ME_AppRequest source filename literal to its natural 18-byte string size

## Evidence
- `ninja` passes
- `main/p_usb`: report now shows 100% fuzzy/code/functions; `.sbss` target/current size is 8 and `mccReadData__7CUSBPcsFv` remains 100%
- `main/ME_AppRequest`: `.rodata` improves to 100%; `s_ME_AppRequest_cpp_801d7da8` is size 18 and 100%; game matched data increased by 24 bytes (`1140014 -> 1140038` all-data report during this run)

## Plausibility
- p_usb already had nearby explicit data padding for table layout; these extra bytes account for the small-data tail without altering codegen or public headers
- ME_AppRequest now lets the filename string use its actual NUL-terminated size, matching the symbol table instead of carrying six extra zero bytes
