### PR TITLE
Match CGItemObj::DeleteOld

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -784,8 +784,8 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 	int deletedCount = 0;
 
 	while (deletedCount < maxDeleteCount) {
-		int bestScriptObjectPos = 0x00989680;
 		unsigned char* bestItemObj = 0;
+		int bestScriptObjectPos = 0x00989680;
 
 		for (unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat);
 			 itemObj != 0;
@@ -799,19 +799,18 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 			}
 		}
 
-		if (bestItemObj == 0) {
+		if (bestItemObj != 0) {
+			deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
+		} else {
+			if ((unsigned int)System.m_execParam >= 3) {
+				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
+			}
 			break;
 		}
 
-		deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
 		deletedCount++;
 	}
 
-	if ((unsigned int)System.m_execParam < 3) {
-		return deletedCount;
-	}
-
-	Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
 	return deletedCount;
 }
 


### PR DESCRIPTION
## Summary
- Restructure CGItemObj::DeleteOld so the no-item diagnostic path branches to the shared return and successful deletion uses the target increment/test layout.
- Reorder the best-item locals to match the target register allocation.

## Evidence
- Before: DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject was 86.0%.
- After: DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject is 100.0%.
- main/itemobj now has 13/23 matched functions, with matched code at 892 bytes.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_DeleteOld_pr.json DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject