### PR TITLE
Improve CAStar addAstar group ordering

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -1089,17 +1089,15 @@ void CAStar::CATemp::operator= (const CAStar::CATemp& other)
  */
 void CAStar::addAstar(float x, float y, float z, int groupA, int groupB)
 {
-	Vec* pos = reinterpret_cast<Vec*>(&CVector(x, y, z));
 	int groupLow = groupA;
-	int groupHigh = groupB;
+	Vec* pos = reinterpret_cast<Vec*>(&CVector(x, y, z));
 
 	if (groupB < groupA)
 	{
 		groupLow = groupB;
-		groupHigh = groupA;
+		groupB = groupA;
 	}
 	groupA = groupLow;
-	groupB = groupHigh;
 
 	int index = 0;
 


### PR DESCRIPTION
## Summary
- Simplify CAStar::addAstar group ordering by reusing groupB as the high endpoint instead of carrying a separate groupHigh local.
- Keeps the source behavior equivalent while better matching the target register/lifetime shape.

## Evidence
- ninja: passes
- addAstar__6CAStarFfffii: 94.99401% -> 95.32336%
- main/astar fuzzy: 88.299545% -> 88.33104%

## Plausibility
- The change removes an unnecessary temporary and leaves the original group sorting logic in normal source form, without hard-coded addresses, fake symbols, or compiler-only hacks.