### PR TITLE
Improve itemobj matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -431,7 +431,7 @@ void CGItemObj::onFrameStat()
 	}
 	case 9:
 		if (*(int*)(self + 0x528) == 8) {
-			self[0x38] = (self[0x38] & 0x7f) | 0x80;
+			self[0x38] = static_cast<unsigned char>(__rlwimi(self[0x38], 1, 7, 24, 24));
 		}
 		break;
 	case 0xB:
@@ -551,7 +551,7 @@ void CGItemObj::onFrameStat()
 			prgObj->m_stepSlopeLimit = zero;
 			EndParticle__13CFlatRuntime2FPQ29CCharaPcs7CHandle(CFlat, prgObj->m_charaModelHandle);
 		} else if (*(int*)(self + 0x528) == 0xC) {
-			self[0x38] = (self[0x38] & 0x7F) | 0x80;
+			self[0x38] = static_cast<unsigned char>(__rlwimi(self[0x38], 1, 7, 24, 24));
 		}
 
 		if (7 < *(int*)(self + 0x528)) {
@@ -623,7 +623,7 @@ void CGItemObj::onFrameStat()
 			CCharaPcs::CHandle* handle = prgObj->m_charaModelHandle;
 			if (handle != 0 && handle->m_model != 0) {
 				unsigned char* model = reinterpret_cast<unsigned char*>(handle->m_model);
-				model[0x10C] = (model[0x10C] & 0x7F) | 0x80;
+				model[0x10C] = static_cast<unsigned char>(__rlwimi(model[0x10C], 1, 7, 24, 24));
 			}
 
 			if (*(int*)(self + 0x530) < 9) {
@@ -761,7 +761,7 @@ void CGItemObj::onFrameStat()
 				    &CFlat, *(int*)(self + 0x550), 2, 0x16, 1, &stack, 0);
 			}
 
-			self[0x38] = (self[0x38] & 0x7F) | 0x80;
+			self[0x38] = static_cast<unsigned char>(__rlwimi(self[0x38], 1, 7, 24, 24));
 		}
 		break;
 	}
@@ -784,8 +784,8 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 	int deletedCount = 0;
 
 	while (deletedCount < maxDeleteCount) {
-		int bestScriptObjectPos = 0x00989680;
 		unsigned char* bestItemObj = 0;
+		int bestScriptObjectPos = 0x00989680;
 
 		for (unsigned char* itemObj = (unsigned char*)FindGItemObjFirst__13CFlatRuntime2Fv(CFlat);
 			 itemObj != 0;
@@ -807,11 +807,10 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		deletedCount++;
 	}
 
-	if ((unsigned int)System.m_execParam < 3) {
-		return deletedCount;
+	if ((unsigned int)System.m_execParam >= 3) {
+		Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
 	}
 
-	Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
 	return deletedCount;
 }
 
@@ -1489,7 +1488,7 @@ void CGItemObj::DeleteAllFieldItem()
 		if (itemObj->m_owner == 0 &&
 		    static_cast<signed char>(
 		        static_cast<int>((static_cast<unsigned int>(itemObj->m_stateFlags0) << 28) & 0xC0000000) >> 31) != 0) {
-			itemObj->m_flags |= 0x80;
+			itemObj->m_flags = static_cast<unsigned char>(__rlwimi(itemObj->m_flags, 1, 7, 24, 24));
 		}
 	}
 }

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -99,7 +99,6 @@ extern double DOUBLE_80331b60;
 extern double DOUBLE_80331b70;
 u32 gItemObjCreateFlags;
 extern char SoundBuffer[];
-extern char SoundBuffer_1260_[];
 extern const char DAT_80331b7c[];
 extern const char DAT_80331b84[];
 extern char DAT_80331bc8[];
@@ -357,7 +356,7 @@ void CGItemObj::onFrame()
 
 			CGObject* owner = m_owner;
 			int ownerScriptSlot = *(int*)(*(int*)((unsigned char*)owner + 0x58) + 0x3B4);
-			int soundEntry = *(int*)(*(int*)(*(int*)SoundBuffer_1260_ + 0xF8) + 0x178);
+			int soundEntry = *(int*)(*(int*)(*(int*)(SoundBuffer + 0x4EC) + 0xF8) + 0x178);
 			if (soundEntry != 0) {
 				soundEntry = *(int*)(soundEntry + 0x14);
 			} else {
@@ -714,7 +713,7 @@ void CGItemObj::onFrameStat()
 			prgObj->m_stepSlopeLimit = zero;
 			EndParticleSlot__13CFlatRuntime2Fii(CFlat, *(int*)(self + 0x55C), 0);
 
-			int soundEntry = *(int*)(*(int*)(*(int*)SoundBuffer_1260_ + 0xF8) + 0x178);
+			int soundEntry = *(int*)(*(int*)(*(int*)(SoundBuffer + 0x4EC) + 0xF8) + 0x178);
 			if (soundEntry != 0) {
 				pdtNo = *(int*)(soundEntry + 0x14);
 			}


### PR DESCRIPTION
## Summary
- Match CGItemObj::DeleteAllFieldItem by using the same rlwimi flag insertion idiom used by the original codegen.
- Improve CGItemObj::DeleteOld register allocation and final debug-print branch shape with source-equivalent local ordering/condition form.
- Apply the same flag insertion idiom in CGItemObj::onFrameStat and replace the synthetic SoundBuffer_1260_ reference with SoundBuffer + 0x4EC.

## Evidence
- ninja passes.
- main/itemobj matched functions: 12/23 -> 13/23.
- main/itemobj matched code: 632 -> 772 bytes.
- DeleteAllFieldItem__9CGItemObjFv: 89.71429% -> 100.0% (140b matched).
- DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject: 86.0% -> 89.76923%.
- onFrameStat__9CGItemObjFv: 56.4274% -> 57.6089% by objdiff symbol check.

## Plausibility
- The rlwimi form is already present elsewhere in itemobj.cpp for byte flag insertion and matches the original emitted instruction.
- DeleteOld remains the same high-level deletion loop; changes only express the same source semantics in a layout/register-friendly way.
- SoundBuffer access now uses the real base symbol and offset instead of a synthetic extern.