### PR TITLE
Improve YmMegaBirthShpTail3 frame local ordering

### DIFF
--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -250,12 +250,12 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
     s8 hasRequiredMemory;
     int colorOffset;
     u8* paramPayload;
-    u8* particleData;
-    u32 i;
-    _PARTICLE_WMAT* worldMat;
-    _PARTICLE_COLOR* particleColor;
     VYmMegaBirthShpTail3* work;
     VColor* colorWork;
+    u8* particleData;
+    u32 i;
+    _PARTICLE_COLOR* particleColor;
+    _PARTICLE_WMAT* worldMat;
 
     colorOffset = offsets->m_serializedDataOffsets[1];
     work = (VYmMegaBirthShpTail3*)((u8*)object + 0x80 + offsets->m_serializedDataOffsets[2]);


### PR DESCRIPTION
## Summary
- Reorder local declarations in `pppFrameYmMegaBirthShpTail3` to better match the compiler register allocation for particle color/world-matrix loop state.
- Keeps behavior unchanged while improving the unit text match.

## Evidence
- `ninja` succeeds for GCCP01.
- `pppFrameYmMegaBirthShpTail3`: 97.1432% -> 97.2296%.
- `main/pppYmMegaBirthShpTail3 .text`: 58.7631% -> 58.7792%.

## Plausibility
- This is a source-level local declaration ordering adjustment only; no addresses, fake labels, manual sections, or ABI hacks were added.