### PR TITLE
Improve Duct boss helper matching

### DIFF
--- a/config/GCCP01/symbols.txt
+++ b/config/GCCP01/symbols.txt
@@ -13312,6 +13312,7 @@ s_GXSetBlendMode_Reg = .bss:0x802FFA60; // type:object size:0x10 data:4byte
 SimpleControl = .bss:0x802FFA80; // type:object size:0x18C
 WorkBuffer = .bss:0x802FFC20; // type:object size:0x40 scope:local align:32 data:byte
 SoundBuffer = .bss:0x802FFC60; // type:object size:0x500 scope:local align:32
+m_boss__8CGMonObj = .bss:0x8030016C; // type:object size:0x6C data:byte
 m_boss__8CGMonObj_field108_0x6c = .bss:0x803001D8; // type:object size:0x90 data:byte
 MiniGamePcs = .bss:0x80300268; // type:object size:0x64A0 data:4byte
 DbgMenuPcs = .bss:0x80306708; // type:object size:0x2A6C data:4byte

--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -2468,9 +2468,8 @@ int CGMonObj::attackCheckFuncMeteoParasite(int)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGMonObj::aiAddDuct(int&)
+void CGMonObj::aiAddDuct(int& seq)
 {
-	int seq = 0;
 	if (Rand__5CMathFUl(&Math, 300) == 0) {
 		aiTarget__8CGMonObjFv(this);
 		_aiSeq__8CGMonObjFiiiiii(this, -14, seq, 0, 1, 100, -1);
@@ -2494,9 +2493,7 @@ void CGMonObj::initFinishedFuncDuct()
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	initFinishedFuncDefault__8CGMonObjFv(this);
 	const int slot = static_cast<int>(reinterpret_cast<long>(object->m_scriptHandle[4])) - 0x8E;
-	if (slot >= 0 && slot < 8) {
-		reinterpret_cast<CGMonObj**>(SoundBuffer + 1400)[slot] = this;
-	}
+	reinterpret_cast<CGMonObj**>(m_boss__8CGMonObj + 0x18)[slot] = this;
 }
 
 /*


### PR DESCRIPTION
## Summary
- use the Duct AI sequence reference parameter instead of a local zero
- write Duct init state through m_boss__8CGMonObj rather than a SoundBuffer alias with an extra bounds check
- add the missing PAL BSS base symbol for m_boss__8CGMonObj

## Evidence
- ninja: build/GCCP01/main.dol OK
- aiAddDuct__8CGMonObjFRi: 69.78% -> 89.66% objdiff
- initFinishedFuncDuct__8CGMonObjFv: 50.63% -> 98.89% objdiff

## Plausibility
- Ghidra shows aiAddDuct reads the int& sequence value for both _aiSeq calls.
- The Duct init write targets the recovered boss state object; the previous SoundBuffer expression was an alias plus a guard not present in the target.