### PR TITLE
Use 16-bit material vertex descriptors

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1213,10 +1213,10 @@ void CMaterialMan::SetMaterialCharaShadow(CMaterial* material)
     if ((bumpLight != 0) && (materialType != 3) && (materialType != 2)) {
         if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 1) {
             GXClearVtxDesc();
-            GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_NBT, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+            GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_NBT, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
             *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 1;
         }
         GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 0x12);
@@ -1225,19 +1225,19 @@ void CMaterialMan::SetMaterialCharaShadow(CMaterial* material)
             if ((bumpLight != 0) || ((tevBit & 1) == 0)) {
                 if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) {
                     GXClearVtxDesc();
-                    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
                     *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
                 }
                 GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 6);
             } else {
                 if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 3) {
                     GXClearVtxDesc();
-                    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
                     *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 3;
                 }
                 GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 6);
@@ -1245,11 +1245,11 @@ void CMaterialMan::SetMaterialCharaShadow(CMaterial* material)
         } else {
             if (*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 2) {
                 GXClearVtxDesc();
-                GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_TEX1, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_TEX1, GX_INDEX16);
                 *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 2;
             }
             GXSetArray(GX_VA_NRM, *reinterpret_cast<void**>(Ptr(this, 4)), 6);
@@ -1309,9 +1309,9 @@ void CMaterialMan::SetMaterialPart(CMaterialSet* materialSet, int materialIndex,
 
             if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 3) && (setVtxDesc != 0)) {
                 GXClearVtxDesc();
-                GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
                 *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 3;
             }
 
@@ -1347,20 +1347,20 @@ void CMaterialMan::SetMaterialPart(CMaterialSet* materialSet, int materialIndex,
                 if ((tevBit == 0) || ((tevBit & 2) == 0)) {
                     if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) && (setVtxDesc != 0)) {
                         GXClearVtxDesc();
-                        GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                        GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
                         *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
                     }
                 } else {
                     if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 2) && (setVtxDesc != 0)) {
                         GXClearVtxDesc();
-                        GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
-                        GXSetVtxDesc(GX_VA_TEX1, GX_INDEX8);
+                        GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
+                        GXSetVtxDesc(GX_VA_TEX1, GX_INDEX16);
                         *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 2;
                     }
 
@@ -1436,10 +1436,10 @@ void CMaterialMan::SetMaterialPart(CMaterialSet* materialSet, int materialIndex,
 
                 if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) && (setVtxDesc != 0)) {
                     GXClearVtxDesc();
-                    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                    GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                    GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                    GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
                     *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
                 }
             }
@@ -1497,10 +1497,10 @@ void CMaterialMan::SetMaterialPart(CMaterialSet* materialSet, int materialIndex,
             *reinterpret_cast<unsigned int*>(Ptr(this, 0x60)) = 3;
             if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) && (setVtxDesc != 0)) {
                 GXClearVtxDesc();
-                GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
                 *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
             }
         }
@@ -1527,10 +1527,10 @@ void CMaterialMan::SetMaterialPart(CMaterialSet* materialSet, int materialIndex,
 
         if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) && (setVtxDesc != 0)) {
             GXClearVtxDesc();
-            GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+            GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
             *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
         }
     }
@@ -1606,10 +1606,10 @@ void CMaterialMan::SetMaterialMenu(CMaterialSet* materialSet, int materialIndex,
 
             if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) && (setVtxDesc != 0)) {
                 GXClearVtxDesc();
-                GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+                GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+                GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
                 *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
             }
         }
@@ -1658,10 +1658,10 @@ void CMaterialMan::SetMaterialMenu(CMaterialSet* materialSet, int materialIndex,
         *reinterpret_cast<int*>(Ptr(this, 0x60)) = 3;
         if ((*reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) != 0) && (setVtxDesc != 0)) {
             GXClearVtxDesc();
-            GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX8);
-            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+            GXSetVtxDesc(GX_VA_POS, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_NRM, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_CLR0, GX_INDEX16);
+            GXSetVtxDesc(GX_VA_TEX0, GX_INDEX16);
             *reinterpret_cast<unsigned char*>(Ptr(this, 0x4C)) = 0;
         }
     }


### PR DESCRIPTION
## Summary
- Update materialman vertex descriptor setup to use GX_INDEX16 for the material POS/NRM/NBT/CLR/TEX attributes.
- This matches the PAL decompilation's GXSetVtxDesc attr type value (3) in SetMaterialCharaShadow, SetMaterialPart, and SetMaterialMenu.

## Objdiff evidence
- SetMaterialCharaShadow__12CMaterialManFP9CMaterial: 37.721893% -> 37.786983%
- SetMaterialPart__12CMaterialManFP12CMaterialSetii: 54.294796% -> 54.32081%
- SetMaterialMenu__12CMaterialManFP12CMaterialSetii: 61.17685% -> 61.18971%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/materialman -o build/materialman_SetMaterialCharaShadow_pr.json SetMaterialCharaShadow__12CMaterialManFP9CMaterial
- build/tools/objdiff-cli diff -p . -u main/materialman -o build/materialman_SetMaterialPart_pr.json SetMaterialPart__12CMaterialManFP12CMaterialSetii
- build/tools/objdiff-cli diff -p . -u main/materialman -o build/materialman_SetMaterialMenu_pr.json SetMaterialMenu__12CMaterialManFP12CMaterialSetii

## Plausibility
The change replaces an 8-bit indexed vertex descriptor with the 16-bit indexed descriptor that the PAL output passes to GXSetVtxDesc. It is a source-level descriptor correction, not a manual section or symbol hack.