### PR TITLE
Improve p_system rodata matching

### DIFF
--- a/src/p_system.cpp
+++ b/src/p_system.cpp
@@ -5,13 +5,9 @@
 extern "C" void create__10CSystemPcsFv(CSystemPcs*);
 extern "C" void destroy__10CSystemPcsFv(CSystemPcs*);
 extern "C" void calc__10CSystemPcsFv(CSystemPcs*);
-extern const char s_CSystemPcs_801D7C48[] = "CSystemPcs";
-extern const char s_CManager_801D7C54[] = "CManager";
-extern const char s_CProcess_801D7C60[] = "CProcess";
-
 CSystemPcs SystemPcs;
 unsigned int m_table__10CSystemPcs[0x15C / sizeof(unsigned int)] = {
-    reinterpret_cast<unsigned int>(const_cast<char*>(s_CSystemPcs_801D7C48)),
+    reinterpret_cast<unsigned int>("CSystemPcs"),
     0,
     0,
     0,


### PR DESCRIPTION
## Summary
- Remove redundant explicit process name string definitions from p_system.cpp.
- Use the process table string literal directly for CSystemPcs, allowing the compiler's pooled string layout to better match the target rodata.

## Objdiff evidence
Unit: main/p_system

Before:
```
__vt__10CSystemPcs    36    94.117645
[.rodata-0]           40    73.39449
[.data-0]             452   96.875
```

After:
```
__vt__10CSystemPcs    36    94.117645
[.rodata-0]           40    90.41096
[.data-0]             452   96.875
```

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_system -o -

The change keeps all p_system code matched and improves the rodata symbol match without changing data/table scores.