### PR TITLE
Improve pppLaser section layout

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -631,7 +631,7 @@ config.libs = [
             Object(NonMatching, "pppKeShpTail2X.cpp"),
             Object(NonMatching, "pppKeShpTail3X.cpp"),
             Object(NonMatching, "pppKeZCrctShp.cpp"),
-            Object(NonMatching, "pppLaser.cpp"),
+            Object(NonMatching, "pppLaser.cpp", extra_cflags=["-inline auto,deferred"]),
             Object(NonMatching, "pppLensFlare.cpp"),
             Object(NonMatching, "pppLerpPos.cpp"),
             Object(Matching, "pppLight.cpp"),

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -102,8 +102,290 @@ struct LaserColorData {
 
 /*
  * --INFO--
+ * PAL Address: 801766ec
+ * PAL Size: 336b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppConstructLaser(struct pppLaser *pppLaser, _pppCtrlTable *param_2)
+{
+    f32 fVar1 = kPppLaserZero;
+    LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
+    int local_24;
+    int local_28;
+    int iVar2;
+    Vec local_14;
+    Vec local_20;
+
+    work->m_length = kPppLaserZero;
+    work->m_graphValue3 = fVar1;
+    work->m_graphValue2 = fVar1;
+    work->m_halfWidth = fVar1;
+    work->m_graphValue1 = fVar1;
+    work->m_graphValue0 = fVar1;
+    work->m_lengthStep = fVar1;
+    work->m_points = 0;
+    work->m_origin.z = fVar1;
+    work->m_origin.y = fVar1;
+    work->m_origin.x = fVar1;
+
+    work->m_shapeReady = 0;
+    work->m_hitFrame = 0;
+    work->m_unused2E = 0;
+    work->m_shapeArg0 = 0;
+    work->m_shapeArg2 = 0;
+    work->m_shapeArg1 = 0;
+
+    work->m_shapeRotation = Math.RandF(FLOAT_8033345c);
+    work->m_spawnEnabled = 1;
+
+    iVar2 = GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(
+        &Game, (PPPIFPARAM*)((u8*)pppMngStPtr + 0x130), &local_24, &local_28);
+    if (iVar2 != 0) {
+        GetTargetCursor__5CGameFiR3VecR3Vec(&Game, local_28, &work->m_targetPosition, &local_20);
+
+        iVar2 = (int)GetPartyObj__5CGameFi(&Game, local_28);
+        local_14.x = *(f32*)(iVar2 + 0x15c);
+        local_14.y = *(f32*)(iVar2 + 0x160);
+        local_14.z = *(f32*)(iVar2 + 0x164);
+        if (local_24 == 0x200) {
+            work->m_maxLength = PSVECDistance(&work->m_targetPosition, &local_14);
+        } else {
+            work->m_maxLength = FLOAT_80333448;
+        }
+    } else {
+        work->m_maxLength = FLOAT_80333448;
+        *(u8*)((u8*)pppMngStPtr + 0xe8) = 1;
+        pppStopSe__FP9_pppMngStP7PPPSEST(pppMngStPtr, (PPPSEST*)((u8*)pppMngStPtr + 0x11c));
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 801766a8
+ * PAL Size: 68b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppConstruct2Laser(struct pppLaser *pppLaser, _pppCtrlTable *param_2)
+{
+    f32 fVar1 = kPppLaserZero;
+    LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
+
+    work->m_graphValue3 = kPppLaserZero;
+    work->m_graphValue2 = fVar1;
+    work->m_halfWidth = fVar1;
+    work->m_graphValue1 = fVar1;
+    work->m_graphValue0 = fVar1;
+    work->m_lengthStep = fVar1;
+    work->m_origin.z = fVar1;
+    work->m_origin.y = fVar1;
+    work->m_origin.x = fVar1;
+    work->m_shapeReady = 0;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 8017665c
+ * PAL Size: 76b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void pppDestructLaser(struct pppLaser *pppLaser, _pppCtrlTable *param_2)
+{
+    LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
+    void* alloc = work->m_points;
+    if (alloc != 0) {
+        pppHeapUseRate__FPQ27CMemory6CStage(alloc);
+        work->m_points = 0;
+    }
+}
+
+/*
+ * --INFO--
+ * PAL Address: 801760a0
+ * PAL Size: 1468b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *param_2, _pppCtrlTable *param_3)
+{
+    pppLaserUnkB* step = param_2;
+    LaserWork* work;
+    Vec localB;
+    Vec localA;
+    Mtx tempMtx;
+    Mtx charaMtx;
+    CMapCylinderRaw cyl;
+
+    int emptyHistory;
+    int fillIndex;
+
+    if (gPppCalcDisabled != 0) {
+        return;
+    }
+    if (step->m_stepValue == 0xFFFF) {
+        return;
+    }
+
+    work = (LaserWork*)((u8*)pppLaser + 0x80 + param_3->m_serializedDataOffsets[2]);
+    emptyHistory = 0;
+    if (FLOAT_80333448 == work->m_maxLength) {
+        return;
+    }
+
+    if (work->m_points == 0) {
+        work->m_points = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
+            (u32)step->m_laser.m_pointCount * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppLaser_cpp_801E3048), 0x7d);
+        memset(work->m_points, 0, (u32)step->m_laser.m_pointCount * 0xc);
+        emptyHistory = 1;
+    }
+
+    CalcGraphValue((_pppPObject*)pppLaser, step->m_graphId, work->m_halfWidth, work->m_graphValue2, work->m_graphValue3,
+        step->m_laser.m_halfWidthBase, step->m_laser.m_halfWidthVelocity, step->m_laser.m_halfWidthAccel);
+    CalcGraphValue((_pppPObject*)pppLaser, step->m_graphId, work->m_lengthStep, work->m_graphValue0, work->m_graphValue1,
+        step->m_laser.m_lengthStepBase, step->m_laser.m_lengthStepVelocity, step->m_laser.m_lengthStepAccel);
+
+    pppCalcFrameShape(
+        **(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)step->m_stepValue * 4), work->m_shapeArg1,
+        work->m_shapeArg2, work->m_shapeArg0, step->m_laser.m_shapeFrameStep);
+
+    for (int i = 0; i < (int)(u32)(step->m_laser.m_historyFrameCount + 1); i++) {
+        int max = (int)step->m_laser.m_pointCount - 2;
+
+        for (int j = max; (int)i <= j; j--) {
+            pppCopyVector(work->m_points[j + 1], work->m_points[j]);
+        }
+
+        localB.x = kPppLaserZero;
+        localB.y = kPppLaserZero;
+        localB.z = work->m_length;
+
+        if (i == 0) {
+            PSMTXConcat(pppMngStPtr->m_matrix.value, pppLaser->m_localMatrix.value, tempMtx);
+            work->m_origin.x = tempMtx[0][3];
+            work->m_origin.y = tempMtx[1][3];
+            work->m_origin.z = tempMtx[2][3];
+            PSMTXMultVec(tempMtx, &localB, work->m_points);
+        } else {
+            if (emptyHistory) {
+                continue;
+            }
+            s32 frameCount = step->m_laser.m_historyFrameCount + 1;
+            float t = FLOAT_80333448 / (float)frameCount;
+            t *= (float)i;
+            if (GetCharaNodeFrameMatrix(pppMngStPtr, t, charaMtx) == 0) {
+                emptyHistory = 1;
+                continue;
+            } else {
+                PSMTXConcat(charaMtx, pppLaser->m_localMatrix.value, charaMtx);
+                PSMTXMultVec(charaMtx, &localB, &work->m_points[i]);
+            }
+        }
+
+        pppSubVector(localA, work->m_points[i], work->m_origin);
+        PSVECScale(&localA, &localA, FLOAT_8033344c);
+
+        cyl.m_top.z = FLOAT_80333450;
+        cyl.m_top.y = FLOAT_80333450;
+        cyl.m_top.x = FLOAT_80333450;
+        cyl.m_direction2.z = FLOAT_80333454;
+        cyl.m_direction2.y = FLOAT_80333454;
+        cyl.m_direction2.x = FLOAT_80333454;
+        cyl.m_bottom = work->m_origin;
+        cyl.m_direction = localA;
+        cyl.m_radius = kPppLaserZero;
+
+        int check = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &cyl, &localA, 0xffffffff);
+        int hit = 0;
+        if (check != 0) {
+            hit = 1;
+            CalcHitPosition__7CMapObjFP3Vec(*(void**)((u8*)&MapMng + 0x22A78), &work->m_points[i]);
+            work->m_length = PSVECDistance(&work->m_points[i], &work->m_origin);
+        } else if (i == 0) {
+            if (work->m_spawnEnabled != 0) {
+                if (work->m_maxLength - FLOAT_80333458 < work->m_length) {
+                    _pppMngSt* mngSt = pppMngStPtr;
+                    s32 partIndex = ((s32)((u8*)mngSt - (reinterpret_cast<u8*>(&PartMng) + 0x2A18))) / 0x158;
+                    work->m_length = work->m_maxLength - FLOAT_80333458;
+                    ParticleFrameCallback__5CGameFiiiiiP3Vec(
+                        &Game, partIndex, (int)mngSt->m_kind, (int)mngSt->m_nodeIndex, 3,
+                        pppLaser->m_graphId / 0x1000, work->m_points);
+                    work->m_spawnEnabled = 0;
+                }
+            }
+            if (work->m_spawnEnabled != 0) {
+                work->m_length += work->m_lengthStep;
+            }
+        }
+
+        if (i == 0) {
+            localB.x = kPppLaserZero;
+            localB.y = kPppLaserZero;
+            localB.z = work->m_length;
+            PSMTXMultVec(tempMtx, &localB, &work->m_points[i]);
+        }
+
+        if (step->m_laser.m_disableHitCylinder == 0) {
+            pppHitCylinderSendSystem(
+                pppMngStPtr, &work->m_origin, &localA,
+                pppMngStPtr->m_previousPosition.z * step->m_laser.m_hitScale,
+                step->m_laser.m_hitRadius);
+        }
+
+        if (step->m_laser.m_disableHitObject == 0) {
+            int createHitObject = 0;
+            if (step->m_arg3 != -1) {
+                createHitObject = 1;
+            }
+            if (!hit) {
+                createHitObject = 0;
+            }
+
+            if (work->m_hitFrame < step->m_laser.m_hitInterval) {
+                work->m_hitFrame++;
+                createHitObject = 0;
+            } else {
+                work->m_hitFrame = 0;
+            }
+
+            if (createHitObject != 0) {
+                _pppPDataVal* dataVal = pppMngStPtr->m_pppPDataVals + step->m_arg3;
+                _pppPObject* created;
+                if (dataVal == 0) {
+                    created = 0;
+                } else {
+                    created = pppCreatePObject(pppMngStPtr, dataVal);
+                    *(_pppPObject**)((u8*)created + 4) = (_pppPObject*)pppLaser;
+                }
+
+                Vec* createdPos = (Vec*)((u8*)created + step->m_laser.m_spawnPositionOffset + 0x80);
+                createdPos->x = work->m_points[i].x;
+                createdPos->y = work->m_points[i].y + step->m_laser.m_spawnYOffset;
+                createdPos->z = work->m_points[i].z;
+            }
+        }
+    }
+
+    if (emptyHistory) {
+        for (fillIndex = 0; fillIndex < (int)(u32)step->m_laser.m_pointCount; fillIndex++) {
+            pppCopyVector(work->m_points[fillIndex], work->m_points[0]);
+        }
+    }
+}
+
+/*
+ * --INFO--
  * PAL Address: 801754e0
- * PAL Size: 3008b  
+ * PAL Size: 3008b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
@@ -369,287 +651,5 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
             Graphic.DrawSphere(sphereMtx, color);
             pppInitBlendMode();
         }
-    }
-}
-
-/*
- * --INFO--
- * PAL Address: 801760a0
- * PAL Size: 1468b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *param_2, _pppCtrlTable *param_3)
-{
-    pppLaserUnkB* step = param_2;
-    LaserWork* work;
-    Vec localB;
-    Vec localA;
-    Mtx tempMtx;
-    Mtx charaMtx;
-    CMapCylinderRaw cyl;
-
-    int emptyHistory;
-    int fillIndex;
-
-    if (gPppCalcDisabled != 0) {
-        return;
-    }
-    if (step->m_stepValue == 0xFFFF) {
-        return;
-    }
-
-    work = (LaserWork*)((u8*)pppLaser + 0x80 + param_3->m_serializedDataOffsets[2]);
-    emptyHistory = 0;
-    if (FLOAT_80333448 == work->m_maxLength) {
-        return;
-    }
-
-    if (work->m_points == 0) {
-        work->m_points = (Vec*)pppMemAlloc__FUlPQ27CMemory6CStagePci(
-            (u32)step->m_laser.m_pointCount * 0xc, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppLaser_cpp_801E3048), 0x7d);
-        memset(work->m_points, 0, (u32)step->m_laser.m_pointCount * 0xc);
-        emptyHistory = 1;
-    }
-
-    CalcGraphValue((_pppPObject*)pppLaser, step->m_graphId, work->m_halfWidth, work->m_graphValue2, work->m_graphValue3,
-        step->m_laser.m_halfWidthBase, step->m_laser.m_halfWidthVelocity, step->m_laser.m_halfWidthAccel);
-    CalcGraphValue((_pppPObject*)pppLaser, step->m_graphId, work->m_lengthStep, work->m_graphValue0, work->m_graphValue1,
-        step->m_laser.m_lengthStepBase, step->m_laser.m_lengthStepVelocity, step->m_laser.m_lengthStepAccel);
-
-    pppCalcFrameShape(
-        **(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + (u32)step->m_stepValue * 4), work->m_shapeArg1,
-        work->m_shapeArg2, work->m_shapeArg0, step->m_laser.m_shapeFrameStep);
-
-    for (int i = 0; i < (int)(u32)(step->m_laser.m_historyFrameCount + 1); i++) {
-        int max = (int)step->m_laser.m_pointCount - 2;
-
-        for (int j = max; (int)i <= j; j--) {
-            pppCopyVector(work->m_points[j + 1], work->m_points[j]);
-        }
-
-        localB.x = kPppLaserZero;
-        localB.y = kPppLaserZero;
-        localB.z = work->m_length;
-
-        if (i == 0) {
-            PSMTXConcat(pppMngStPtr->m_matrix.value, pppLaser->m_localMatrix.value, tempMtx);
-            work->m_origin.x = tempMtx[0][3];
-            work->m_origin.y = tempMtx[1][3];
-            work->m_origin.z = tempMtx[2][3];
-            PSMTXMultVec(tempMtx, &localB, work->m_points);
-        } else {
-            if (emptyHistory) {
-                continue;
-            }
-            s32 frameCount = step->m_laser.m_historyFrameCount + 1;
-            float t = FLOAT_80333448 / (float)frameCount;
-            t *= (float)i;
-            if (GetCharaNodeFrameMatrix(pppMngStPtr, t, charaMtx) == 0) {
-                emptyHistory = 1;
-                continue;
-            } else {
-                PSMTXConcat(charaMtx, pppLaser->m_localMatrix.value, charaMtx);
-                PSMTXMultVec(charaMtx, &localB, &work->m_points[i]);
-            }
-        }
-
-        pppSubVector(localA, work->m_points[i], work->m_origin);
-        PSVECScale(&localA, &localA, FLOAT_8033344c);
-
-        cyl.m_top.z = FLOAT_80333450;
-        cyl.m_top.y = FLOAT_80333450;
-        cyl.m_top.x = FLOAT_80333450;
-        cyl.m_direction2.z = FLOAT_80333454;
-        cyl.m_direction2.y = FLOAT_80333454;
-        cyl.m_direction2.x = FLOAT_80333454;
-        cyl.m_bottom = work->m_origin;
-        cyl.m_direction = localA;
-        cyl.m_radius = kPppLaserZero;
-
-        int check = CheckHitCylinderNear__7CMapMngFP12CMapCylinderP3VecUl(&MapMng, &cyl, &localA, 0xffffffff);
-        int hit = 0;
-        if (check != 0) {
-            hit = 1;
-            CalcHitPosition__7CMapObjFP3Vec(*(void**)((u8*)&MapMng + 0x22A78), &work->m_points[i]);
-            work->m_length = PSVECDistance(&work->m_points[i], &work->m_origin);
-        } else if (i == 0) {
-            if (work->m_spawnEnabled != 0) {
-                if (work->m_maxLength - FLOAT_80333458 < work->m_length) {
-                    _pppMngSt* mngSt = pppMngStPtr;
-                    s32 partIndex = ((s32)((u8*)mngSt - (reinterpret_cast<u8*>(&PartMng) + 0x2A18))) / 0x158;
-                    work->m_length = work->m_maxLength - FLOAT_80333458;
-                    ParticleFrameCallback__5CGameFiiiiiP3Vec(
-                        &Game, partIndex, (int)mngSt->m_kind, (int)mngSt->m_nodeIndex, 3,
-                        pppLaser->m_graphId / 0x1000, work->m_points);
-                    work->m_spawnEnabled = 0;
-                }
-            }
-            if (work->m_spawnEnabled != 0) {
-                work->m_length += work->m_lengthStep;
-            }
-        }
-
-        if (i == 0) {
-            localB.x = kPppLaserZero;
-            localB.y = kPppLaserZero;
-            localB.z = work->m_length;
-            PSMTXMultVec(tempMtx, &localB, &work->m_points[i]);
-        }
-
-        if (step->m_laser.m_disableHitCylinder == 0) {
-            pppHitCylinderSendSystem(
-                pppMngStPtr, &work->m_origin, &localA,
-                pppMngStPtr->m_previousPosition.z * step->m_laser.m_hitScale,
-                step->m_laser.m_hitRadius);
-        }
-
-        if (step->m_laser.m_disableHitObject == 0) {
-            int createHitObject = 0;
-            if (step->m_arg3 != -1) {
-                createHitObject = 1;
-            }
-            if (!hit) {
-                createHitObject = 0;
-            }
-
-            if (work->m_hitFrame < step->m_laser.m_hitInterval) {
-                work->m_hitFrame++;
-                createHitObject = 0;
-            } else {
-                work->m_hitFrame = 0;
-            }
-
-            if (createHitObject != 0) {
-                _pppPDataVal* dataVal = pppMngStPtr->m_pppPDataVals + step->m_arg3;
-                _pppPObject* created;
-                if (dataVal == 0) {
-                    created = 0;
-                } else {
-                    created = pppCreatePObject(pppMngStPtr, dataVal);
-                    *(_pppPObject**)((u8*)created + 4) = (_pppPObject*)pppLaser;
-                }
-
-                Vec* createdPos = (Vec*)((u8*)created + step->m_laser.m_spawnPositionOffset + 0x80);
-                createdPos->x = work->m_points[i].x;
-                createdPos->y = work->m_points[i].y + step->m_laser.m_spawnYOffset;
-                createdPos->z = work->m_points[i].z;
-            }
-        }
-    }
-
-    if (emptyHistory) {
-        for (fillIndex = 0; fillIndex < (int)(u32)step->m_laser.m_pointCount; fillIndex++) {
-            pppCopyVector(work->m_points[fillIndex], work->m_points[0]);
-        }
-    }
-}
-
-/*
- * --INFO--
- * PAL Address: 8017665c
- * PAL Size: 76b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppDestructLaser(struct pppLaser *pppLaser, _pppCtrlTable *param_2)
-{
-    LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
-    void* alloc = work->m_points;
-    if (alloc != 0) {
-        pppHeapUseRate__FPQ27CMemory6CStage(alloc);
-        work->m_points = 0;
-    }
-}
-
-/*
- * --INFO--
- * PAL Address: 801766a8
- * PAL Size: 68b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppConstruct2Laser(struct pppLaser *pppLaser, _pppCtrlTable *param_2)
-{
-    f32 fVar1 = kPppLaserZero;
-    LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
-
-    work->m_graphValue3 = kPppLaserZero;
-    work->m_graphValue2 = fVar1;
-    work->m_halfWidth = fVar1;
-    work->m_graphValue1 = fVar1;
-    work->m_graphValue0 = fVar1;
-    work->m_lengthStep = fVar1;
-    work->m_origin.z = fVar1;
-    work->m_origin.y = fVar1;
-    work->m_origin.x = fVar1;
-    work->m_shapeReady = 0;
-}
-
-/*
- * --INFO--
- * PAL Address: 801766ec
- * PAL Size: 336b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void pppConstructLaser(struct pppLaser *pppLaser, _pppCtrlTable *param_2)
-{
-    f32 fVar1 = kPppLaserZero;
-    LaserWork* work = (LaserWork*)((u8*)pppLaser + 0x80 + param_2->m_serializedDataOffsets[2]);
-    int local_24;
-    int local_28;
-    int iVar2;
-    Vec local_14;
-    Vec local_20;
-
-    work->m_length = kPppLaserZero;
-    work->m_graphValue3 = fVar1;
-    work->m_graphValue2 = fVar1;
-    work->m_halfWidth = fVar1;
-    work->m_graphValue1 = fVar1;
-    work->m_graphValue0 = fVar1;
-    work->m_lengthStep = fVar1;
-    work->m_points = 0;
-    work->m_origin.z = fVar1;
-    work->m_origin.y = fVar1;
-    work->m_origin.x = fVar1;
-
-    work->m_shapeReady = 0;
-    work->m_hitFrame = 0;
-    work->m_unused2E = 0;
-    work->m_shapeArg0 = 0;
-    work->m_shapeArg2 = 0;
-    work->m_shapeArg1 = 0;
-
-    work->m_shapeRotation = Math.RandF(FLOAT_8033345c);
-    work->m_spawnEnabled = 1;
-
-    iVar2 = GetParticleSpecialInfo__5CGameFR10PPPIFPARAMRiRi(
-        &Game, (PPPIFPARAM*)((u8*)pppMngStPtr + 0x130), &local_24, &local_28);
-    if (iVar2 != 0) {
-        GetTargetCursor__5CGameFiR3VecR3Vec(&Game, local_28, &work->m_targetPosition, &local_20);
-
-        iVar2 = (int)GetPartyObj__5CGameFi(&Game, local_28);
-        local_14.x = *(f32*)(iVar2 + 0x15c);
-        local_14.y = *(f32*)(iVar2 + 0x160);
-        local_14.z = *(f32*)(iVar2 + 0x164);
-        if (local_24 == 0x200) {
-            work->m_maxLength = PSVECDistance(&work->m_targetPosition, &local_14);
-        } else {
-            work->m_maxLength = FLOAT_80333448;
-        }
-    } else {
-        work->m_maxLength = FLOAT_80333448;
-        *(u8*)((u8*)pppMngStPtr + 0xe8) = 1;
-        pppStopSe__FP9_pppMngStP7PPPSEST(pppMngStPtr, (PPPSEST*)((u8*)pppMngStPtr + 0x11c));
     }
 }


### PR DESCRIPTION
## Summary
- Reorder pppLaser function definitions to pair with MWCC deferred emission order.
- Enable deferred inlining for pppLaser.cpp so emitted function order matches the original object layout.

## Evidence
- ninja passes.
- objdiff main/pppLaser pppRenderLaser:
  - extab: 50.0% -> 100.0%
  - extabindex: 0.0% -> 97.91667%
  - .text unchanged at 97.901535%
- pppLaser unit matched data improves from 16/96 bytes to 48/96 bytes.

## Plausibility
- This uses an existing configure.py pattern (-inline auto,deferred) and only changes definition order, not function bodies.
- The result aligns compiler emission/exception metadata with the target object without manual vtable, RTTI, section, or address hacks.