### PR TITLE
Match Duct init boss work access

### DIFF
--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -111,6 +111,11 @@ struct MeteoParasiteCBossWork {
     int m_wait;
 };
 
+struct DuctBossWork {
+    u8 m_pad00[0x38];
+    CGMonObj* m_objs[3];
+};
+
 /*
  * --INFO--
  * PAL Address: 0x80132f68
@@ -2493,7 +2498,8 @@ void CGMonObj::initFinishedFuncDuct()
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	initFinishedFuncDefault__8CGMonObjFv(this);
 	const int slot = static_cast<int>(reinterpret_cast<long>(object->m_scriptHandle[4])) - 0x8E;
-	reinterpret_cast<CGMonObj**>(m_boss__8CGMonObj + 0x18)[slot] = this;
+	DuctBossWork* bossWork = reinterpret_cast<DuctBossWork*>(SoundBuffer_1260_);
+	bossWork->m_objs[slot] = this;
 }
 
 /*


### PR DESCRIPTION
## Summary
- model the Duct boss work storage with a small local struct over the existing boss SoundBuffer work area
- update initFinishedFuncDuct to write through that work layout instead of the overlapping m_boss byte pointer

## Evidence
- ninja passes
- build report: initFinishedFuncDuct__8CGMonObjFv improves from 99.947365% to 100.0% (76 bytes)
- progress report: matched code increases by 76 bytes and matched functions increases by 1 (3388 -> 3389)

## Plausibility
- this uses the same SoundBuffer_1260_ work area already used by adjacent monobj_boss boss routines
- the added struct documents the Duct object array field instead of hard-coding the final object-array offset at the call site