### PR TITLE
Fix std::exception what ownership

### DIFF
--- a/include/PowerPC_EABI_Support/Runtime/exception.h
+++ b/include/PowerPC_EABI_Support/Runtime/exception.h
@@ -9,7 +9,7 @@ class exception {
 public:
 	exception() {}
 	virtual ~exception() {}
-	virtual const char* what() const { return "exception"; }
+	virtual const char* what() const;
 };
 
 class bad_exception : public exception {


### PR DESCRIPTION
## Summary
- Moves std::exception::what() out of the runtime exception header so Gecko_ExceptionPPC no longer emits duplicate std::exception virtual data.
- Keeps std::bad_exception inline ownership in Gecko_ExceptionPPC, preserving its matched destructor, what(), and vtable output.

## Objdiff evidence
- Unit: main/Runtime.PPCEABI.H/Gecko_ExceptionPPC
- .text: 5176 bytes, 100.0% matched
- .data: 232 bytes, 100.0% matched
- .sdata: 16 bytes, 100.0% matched
- std::bad_exception dtor / what / vtable remain 100.0% matched

Before selection reported Gecko_ExceptionPPC as code 100.0%, data 4.58%; after regenerating the report the unit is code 100.0%, data 42.48%.

## Verification
- git diff --check
- ninja build/GCCP01/report.json
- build/tools/objdiff-cli diff -p . -u main/Runtime.PPCEABI.H/Gecko_ExceptionPPC -o -

Note: full ninja compiles and regenerates the report, then fails at the final build/GCCP01/main.dol checksum after this binary-affecting improvement.