### PR TITLE
Name p_FunnyShape RTTI references

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -61,6 +61,8 @@ extern "C" void* __vt__8CProcess[];
 extern "C" void* gVtable_CPtrArray_OSFSTexture[];
 extern "C" void* gVtable_CPtrArray_GXTexObj[];
 extern "C" void* __vt__14CFunnyShapePcs[];
+extern const char __RTTI__8CManager_8032E660[];
+extern const char __RTTI__8CProcess_8032E668[];
 static const char lbl_801D7DD0[] = "CFunnyShapePcs(VIEWER)";
 static const Vec s_funnyEye = {0.0f, 0.0f, 4.0f};
 static const Vec s_funnyAt = {0.0f, 0.0f, 0.0f};
@@ -71,7 +73,6 @@ static const char s_CProcess_801D7E28[] = "CProcess";
 static const char s_funnyShapeFmt[] = "FunnyShape [%c]";
 static const char s_CPtrArray_OSFS_TEXTURE_ST_801D7E44[] = "CPtrArray<OSFS_TEXTURE_ST *>";
 static const char s_CPtrArray_GXTexObj[] = "CPtrArray<_GXTexObj *>";
-extern char lbl_8032E660[];
 extern u8 ARRAY_8026D728[];
 
 extern "C" CUSBStreamData* __dt__14CUSBStreamDataFv(CUSBStreamData* self, short shouldDelete);
@@ -457,10 +458,11 @@ unsigned int m_table__14CFunnyShapePcs[0x15C / sizeof(unsigned int)] = {
     0x42, 1
 };
 unsigned int lbl_801EA904[4] = {
-    reinterpret_cast<unsigned int>(lbl_8032E660), 0, 0, reinterpret_cast<unsigned int>(lbl_8032E660)
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E660)), 0, 0,
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E660))
 };
 unsigned int lbl_801EA914[4] = {
-    0, 0, 0, 0
+    0, reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CProcess_8032E668)), 0, 0
 };
 u8 ARRAY_8026D728[0xC];
 u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];


### PR DESCRIPTION
## Summary
- Replace the generic lbl_8032E660 reference in p_FunnyShape data with the matching CManager RTTI symbol.
- Populate the adjacent CProcess RTTI reference in lbl_801EA914.

## Evidence
- ninja passes.
- objdiff main/p_FunnyShape .data improves from 92.89939% to 94.64802%.
- lbl_801EA904 improves to 100%.
- lbl_801EA914 improves to 100%.
- .text remains 99.89171%, .rodata remains 100%, .bss remains 100%.

## Plausibility
These entries are inheritance/RTTI descriptor data next to the CFunnyShapePcs vtable. Naming the real local RTTI symbols is closer to the original C++ data layout than a generic lbl reference or zero padding.