### PR TITLE
Improve CharaBreak triangle strip restart

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -972,7 +972,7 @@ void CreatePolygon(POLYGON_DATA* polygonData, void* displayList, unsigned long, 
                         if (triCount <= 0) {
                             keepTri = 0;
                         }
-                        if (triCount != 0) {
+                        if (triCount != 1) {
                             stream = previousRestart;
                         }
                         outVertex = 0;


### PR DESCRIPTION
## Summary
- Adjust `CreatePolygon` triangle-strip restart handling in `pppCharaBreak` to skip rewinding when the decremented triangle count is exactly 1.
- Matches the target control-flow condition more closely and brings the function size to the target size.

## Objdiff Evidence
- `CreatePolygon__FP12POLYGON_DATAPvUlPQ26CChara6CModelPQ26CChara5CMesh`: 91.83784% -> 92.14189%, size 588b -> 592b target-sized
- `main/pppCharaBreak` `.text`: 88.90381% -> 88.93286%

## Validation
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - CreatePolygon__FP12POLYGON_DATAPvUlPQ26CChara6CModelPQ26CChara5CMesh`
