### PR TITLE
Improve item DeleteOld control flow

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -782,7 +782,11 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 {
 	int deletedCount = 0;
 
-	while (deletedCount < maxDeleteCount) {
+	while (true) {
+		if (maxDeleteCount <= deletedCount) {
+			return deletedCount;
+		}
+
 		unsigned char* bestItemObj = 0;
 		int bestScriptObjectPos = 0x00989680;
 
@@ -801,9 +805,6 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		if (bestItemObj != 0) {
 			deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
 		} else {
-			if ((unsigned int)System.m_execParam >= 3) {
-				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
-			}
 			break;
 		}
 


### PR DESCRIPTION
## Summary
- Restructure CGItemObj::DeleteOld so hitting the requested delete count returns immediately
- Keep the warning print only for the no-deletable-item exit path, matching the target control flow

## Objdiff
- main/itemobj DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject: 86.15385% -> 87.61539%
- Size: 296b -> 260b, matching target 260b
- Adjacent checked symbols unchanged: ItemJump__9CGItemObjFif and onFrameStat__9CGItemObjFv

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/itemobj -o - DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject