### PR TITLE
Match sound load logging threshold

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1335,7 +1335,7 @@ void CSound::LoadSe(int seId)
             File.SyncCompleted(handle);
             reinterpret_cast<CRedSound*>(self + 8)->SetSeSepData(File.m_readBuffer);
             File.Close(handle);
-            if (System.m_execParam != 0) {
+            if (static_cast<unsigned int>(System.m_execParam) >= 1U) {
                 Printf__7CSystemFPce(&System, s_soundLoadSeMergeFmt, seId);
             }
         }
@@ -1405,7 +1405,7 @@ void CSound::LoadWave(int waveId)
                 }
             }
 
-            if (System.m_execParam != 0) {
+            if (static_cast<unsigned int>(System.m_execParam) >= 1U) {
                 Printf__7CSystemFPce(&System, s_soundLoadWaveMergeFmt, waveId);
             }
         }


### PR DESCRIPTION
## Summary
- Update CSound load logging guards to use the unsigned >= 1 threshold form emitted by the PAL target.
- Applies to both LoadWave(int) and LoadSe(int), removing compare/branch mismatches around the debug Printf calls.

## Objdiff evidence
- LoadWave__6CSoundFi: 97.32674 -> 97.9703
- LoadSe__6CSoundFi: 98.652176 -> 99.5942

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/sound -o /tmp/sound_loadwave_after_both.json LoadWave__6CSoundFi
- build/tools/objdiff-cli diff -p . -u main/sound -o /tmp/sound_loadse_after_both.json LoadSe__6CSoundFi