### PR TITLE
Improve wind allocation scans

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -184,52 +184,45 @@ int CWind::AddSphere(const Vec* pos, float radius, float speed, int life)
 {
 	int checked = 0;
 	int blocks = 4;
-	WindObject* obj = m_objects;
-	s8 active;
+	WindObject* scan = m_objects;
+	WindObject* obj;
 
 	do {
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
-		obj++;
-		active = GetWindActiveFlag(obj);
-		if (active == 0) {
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
 			goto found;
 		}
 
 		checked += 7;
-		obj++;
+		scan++;
 	} while (--blocks != 0);
 
 	obj = 0;
@@ -274,24 +267,45 @@ found:
 int CWind::AddDiffuse(const Vec* pos, float radius, float dir, float speed)
 {
 	int checked = 0;
-	WindObject* obj = m_objects;
+	WindObject* scan = m_objects;
+	WindObject* obj;
 
 	for (int blocks = 4; blocks != 0; blocks--) {
-		WindObject* scan = obj;
-		if ((GetWindActiveFlag(scan) == 0) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0))) {
+		if (GetWindActiveFlag(scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
 			obj = scan;
 			goto found;
 		}
 
 		checked += 7;
-		obj = scan + 1;
+		scan++;
 	}
 
 	obj = 0;
@@ -343,25 +357,46 @@ found:
  */
 int CWind::AddAmbient(float dir, float speed)
 {
-	WindObject* obj = m_objects;
 	int checked = 0;
+	WindObject* scan = m_objects;
+	WindObject* obj;
 
 	for (int blocks = 4; blocks != 0; blocks--) {
-		WindObject* scan = obj;
-		if ((GetWindActiveFlag(scan) == 0) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0)) ||
-		    ((scan++, GetWindActiveFlag(scan) == 0))) {
+		if (GetWindActiveFlag(scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
+			obj = scan;
+			goto found;
+		}
+		if (GetWindActiveFlag(++scan) == 0) {
 			obj = scan;
 			goto found;
 		}
 
 		checked += 7;
-		obj = scan + 1;
+		scan++;
 	}
 
 	obj = 0;


### PR DESCRIPTION
## Summary
- Rework the unrolled free-object scans in `CWind::AddSphere`, `CWind::AddDiffuse`, and `CWind::AddAmbient` to keep the scan pointer separate from the selected object.
- Removes the decompiler-style temporary active flag in `AddSphere` and uses direct repeated active checks, matching the surrounding wind allocation patterns more closely.

## Objdiff evidence
Before from initial run on `main/wind`:
- `.text`: 93.99203%
- `AddSphere__5CWindFPC3Vecffi`: 87.63158%
- `AddDiffuse__5CWindFPC3Vecfff`: 85.91346%
- `AddAmbient__5CWindFff`: 88.44444%

After this branch:
- `.text`: 95.79157%
- `AddSphere__5CWindFPC3Vecffi`: 95.42105%
- `AddDiffuse__5CWindFPC3Vecfff`: 93.31731%
- `AddAmbient__5CWindFff`: 89.22222%

## Validation
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/wind -o - AddSphere__5CWindFPC3Vecffi`

## Plausibility
The updated source keeps a clear scan pointer and selected object pointer for the fixed-size wind object pool, which is plausible hand-written source and avoids fake linkage, address tricks, or section forcing.