### PR TITLE
Improve YmDeformationShp render shape matching

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -368,8 +368,6 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 {
 	pppYmDeformationShpLayout* layout = (pppYmDeformationShpLayout*)obj;
 	Vec4d projected[4];
-	Vec4d clipPos;
-	Vec worldPos;
 	float minY;
 	float maxY;
 	float minX;
@@ -400,6 +398,8 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 
 	for (i = 0; i < 4; i++) {
 		Vec localVertex = vertices[i];
+		Vec4d clipPos;
+		Vec worldPos;
 		PSMTXMultVec(layout->m_modelMatrix.value, &localVertex, &worldPos);
 		clipPos.x = worldPos.x;
 		clipPos.y = worldPos.y;
@@ -413,10 +413,10 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 		projected[i].y = screenCenterY - projected[i].y / screenScaleY;
 	}
 
-	maxX = FLOAT_80330624;
-	maxY = FLOAT_80330624;
-	minX = FLOAT_80330620;
 	minY = FLOAT_80330620;
+	maxY = FLOAT_80330624;
+	minX = minY;
+	maxX = maxY;
 	for (i = 0; i < 4; i++) {
 		if (projected[i].x > maxX) {
 			maxX = projected[i].x;


### PR DESCRIPTION
## Summary
- Move RenderDeformationShape's per-vertex temporary projection locals into the loop scope to better match target stack lifetime/layout.
- Reuse bounding-box min/max initializer values in the same shape as the target code.

## Evidence
- ninja passes.
- main/pppYmDeformationShp unit fuzzy match: 96.94651% -> 96.975624%.
- RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d: 95.5387% -> 95.60526%.
- pppRenderYmDeformationShp unchanged at 97.757576%.

## Plausibility
- Changes only adjust local variable lifetime and initializer expression shape.
- No address hacks, fake symbols, or section forcing.