### PR TITLE
Improve compa menu open and close matches

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -316,7 +316,7 @@ bool CMenuPcs::CompaClose()
     for (int i = 0; i < count; i++) {
         float step = FLOAT_80332FF8;
         if (frame >= entry->startFrame) {
-            if (entry->startFrame + entry->duration <= frame) {
+            if (frame >= entry->startFrame + entry->duration) {
                 finishedCount = finishedCount + 1;
                 entry->alpha = FLOAT_80332FF8;
                 entry->dx = step;
@@ -462,7 +462,7 @@ bool CMenuPcs::CompaOpen()
     for (int i = 0; i < count; i++) {
         float step = FLOAT_80332FF8;
         if (frame >= entry->startFrame) {
-            if (entry->startFrame + entry->duration <= frame) {
+            if (frame >= entry->startFrame + entry->duration) {
                 finishedCount = finishedCount + 1;
                 entry->alpha = FLOAT_80333000;
                 entry->dx = step;


### PR DESCRIPTION
## Summary
- Rewrote the compa open/close completion test as `frame >= startFrame + duration`.
- This preserves behavior while matching the target compare direction and branch layout more closely.

## Objdiff evidence
- `CompaClose__8CMenuPcsFv`: 66.97895% -> 95.29474%
- `CompaOpen__8CMenuPcsFv`: 70.12037% -> 97.15741%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/menu_compa -o /tmp/menu_compa_close_pr.json CompaClose__8CMenuPcsFv`
- `build/tools/objdiff-cli diff -p . -u main/menu_compa -o /tmp/menu_compa_open_pr.json CompaOpen__8CMenuPcsFv`