### PR TITLE
Improve menu item draw selection fallback

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -344,8 +344,7 @@ int CMenuPcs::ItemCtrlCur()
  */
 void CMenuPcs::ItemDraw()
 {
-    bool hasSelectedItem = false;
-    int selectedItemId;
+    int selectedItemId = -1;
 
     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 4, 5, 1);
     SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(&MenuPcs, 0);
@@ -501,7 +500,6 @@ void CMenuPcs::ItemDraw()
                 selectedIndex -= 0x40;
             }
             if (menuIndex == selectedIndex) {
-                hasSelectedItem = true;
                 selectedItemId = itemId;
             }
 
@@ -566,10 +564,6 @@ void CMenuPcs::ItemDraw()
 
     DrawInit__8CMenuPcsFv(this);
     DrawSingLife__8CMenuPcsFv(this);
-
-    if (!hasSelectedItem) {
-        selectedItemId = -1;
-    }
 
     CFont* helpFont = this->helpFont;
     CColor helpColor(0xFF, 0xFF, 0xFF, (u8)(FLOAT_80332e80 * *(float*)(cursorEntry + 8)));


### PR DESCRIPTION
## Summary
- Initialize the item help-message selection id to the fallback value up front in ItemDraw.
- Remove the separate hasSelectedItem flag and final fallback assignment.

## Objdiff evidence
- main/menu_item ItemDraw__8CMenuPcsFv: 67.993835% -> 68.44992%
- ItemClose__8CMenuPcsFv remains 98.76842%
- ItemOpen__8CMenuPcsFv remains 98.72072%

## Plausibility
This keeps the same behavior while expressing the default no-selection item id directly at initialization, which is plausible source and avoids carrying a redundant boolean through the draw loop.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_item -o /tmp/menu_item_ItemDraw_diff.json ItemDraw__8CMenuPcsFv