### PR TITLE
Improve CAStar polygon group control flow

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -85,6 +85,8 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		{
 			return gMapHitFace->m_groupIndex;
 		}
+
+		return 0;
 	}
 	else
 	{
@@ -107,9 +109,9 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		{
 			return gMapHitFace->m_groupIndex;
 		}
-	}
 
-	return 0;
+		return 0;
+	}
 }
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Return zero from each calcPolygonGroup branch instead of sharing a trailing fallback.
- This restores the original branch-local return shape and the PAL function size for CAStar::calcPolygonGroup.

## Evidence
- ninja passes.
- objdiff for main/astar calcPolygonGroup__6CAStarFP3Veci improved from 460 bytes / 85.68376% to 468 bytes / 92.11966%.
- build/GCCP01/report.json now reports calcPolygonGroup__6CAStarFP3Veci at 468 bytes / 92.11966% and main/astar fuzzy at 88.75945%.

## Plausibility
- The change is ordinary source control flow: each side of the AStar flag branch returns 0 locally when no cylinder hit is found.
- No ABI tricks, fake labels, section forcing, or address-based hacks.