### PR TITLE
Improve p_tina static table init order

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -209,6 +209,10 @@ int DAT_8032ed3c;
 #pragma inline_max_size(10000)
 inline CPartPcs::CPartPcs()
 {
+}
+
+static inline char* InitCPartPcsTable(char* profileName)
+{
 	unsigned int* table = reinterpret_cast<unsigned int*>(m_table__8CPartPcs);
 
 	table[1] = m_table_desc0__8CPartPcs[0];
@@ -268,10 +272,12 @@ inline CPartPcs::CPartPcs()
 	table[124] = m_table_desc18__8CPartPcs[0];
 	table[125] = m_table_desc18__8CPartPcs[1];
 	table[126] = m_table_desc18__8CPartPcs[2];
+
+	return profileName;
 }
 
 CPartPcs PartPcs;
-CProfile g_par_calc_prof(const_cast<char*>(s_no_name_8032fdcc));
+CProfile g_par_calc_prof(InitCPartPcsTable(const_cast<char*>(s_no_name_8032fdcc)));
 CProfile g_par_draw_prof(const_cast<char*>(s_no_name_8032fdcc));
 
 static int GetMngStBaseTime(const _pppMngSt* pppMngSt)


### PR DESCRIPTION
## Summary
- Move the CPartPcs table fill out of the object constructor path so it runs after PartPcs global registration, matching the target __sinit ordering more closely.
- Keep section sizes and data unchanged while improving __sinit_p_tina_cpp code match.

## Evidence
- ninja: passes
- objdiff main/p_tina __sinit_p_tina_cpp:
  - .text: 93.341896% -> 93.56738%
  - __sinit_p_tina_cpp: 40.884617% -> 42.97596%
  - .data/.bss/.sbss/.sdata2 unchanged