### PR TITLE
Improve CPartPcs static table initialization

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -209,8 +209,15 @@ int DAT_8032ed3c;
 #pragma inline_max_size(10000)
 inline CPartPcs::CPartPcs()
 {
+}
+
+static inline char* InitCPartPcsTable(char* profileName)
+{
 	unsigned int* table = reinterpret_cast<unsigned int*>(m_table__8CPartPcs);
 
+	table[33] = m_table_desc7__8CPartPcs[1];
+	table[37] = m_table_desc8__8CPartPcs[0];
+	table[38] = m_table_desc8__8CPartPcs[1];
 	table[1] = m_table_desc0__8CPartPcs[0];
 	table[2] = m_table_desc0__8CPartPcs[1];
 	table[3] = m_table_desc0__8CPartPcs[2];
@@ -233,45 +240,44 @@ inline CPartPcs::CPartPcs()
 	table[28] = m_table_desc6__8CPartPcs[1];
 	table[29] = m_table_desc6__8CPartPcs[2];
 	table[32] = m_table_desc7__8CPartPcs[0];
-	table[33] = m_table_desc7__8CPartPcs[1];
-	table[37] = m_table_desc8__8CPartPcs[1];
-	table[38] = m_table_desc8__8CPartPcs[2];
 	table[35] = m_table_desc7__8CPartPcs[2];
-	table[39] = m_table_desc8__8CPartPcs[0];
-	table[44] = m_table_desc9__8CPartPcs[1];
-	table[45] = m_table_desc9__8CPartPcs[2];
-	table[46] = m_table_desc9__8CPartPcs[0];
+	table[39] = m_table_desc8__8CPartPcs[2];
+	table[44] = m_table_desc9__8CPartPcs[0];
+	table[45] = m_table_desc9__8CPartPcs[1];
+	table[46] = m_table_desc9__8CPartPcs[2];
 	table[88] = m_table_desc10__8CPartPcs[0];
 	table[89] = m_table_desc10__8CPartPcs[1];
 	table[90] = m_table_desc10__8CPartPcs[2];
-	table[93] = m_table_desc11__8CPartPcs[0];
-	table[94] = m_table_desc11__8CPartPcs[1];
-	table[95] = m_table_desc11__8CPartPcs[2];
-	table[96] = m_table_desc12__8CPartPcs[0];
-	table[97] = m_table_desc12__8CPartPcs[1];
-	table[98] = m_table_desc12__8CPartPcs[2];
-	table[101] = m_table_desc13__8CPartPcs[0];
-	table[102] = m_table_desc13__8CPartPcs[1];
-	table[103] = m_table_desc13__8CPartPcs[2];
-	table[106] = m_table_desc14__8CPartPcs[0];
-	table[107] = m_table_desc14__8CPartPcs[1];
-	table[108] = m_table_desc14__8CPartPcs[2];
-	table[111] = m_table_desc15__8CPartPcs[0];
-	table[112] = m_table_desc15__8CPartPcs[1];
-	table[113] = m_table_desc15__8CPartPcs[2];
+	table[91] = m_table_desc11__8CPartPcs[0];
+	table[92] = m_table_desc11__8CPartPcs[1];
+	table[93] = m_table_desc11__8CPartPcs[2];
+	table[94] = m_table_desc12__8CPartPcs[0];
+	table[95] = m_table_desc12__8CPartPcs[1];
+	table[96] = m_table_desc12__8CPartPcs[2];
+	table[99] = m_table_desc13__8CPartPcs[0];
+	table[100] = m_table_desc13__8CPartPcs[1];
+	table[101] = m_table_desc13__8CPartPcs[2];
+	table[104] = m_table_desc14__8CPartPcs[0];
+	table[105] = m_table_desc14__8CPartPcs[1];
+	table[106] = m_table_desc14__8CPartPcs[2];
+	table[109] = m_table_desc15__8CPartPcs[0];
+	table[110] = m_table_desc15__8CPartPcs[1];
+	table[111] = m_table_desc15__8CPartPcs[2];
 	table[114] = m_table_desc16__8CPartPcs[0];
-	table[117] = m_table_desc17__8CPartPcs[0];
-	table[118] = m_table_desc17__8CPartPcs[1];
-	table[119] = m_table_desc17__8CPartPcs[2];
-	table[120] = m_table_desc16__8CPartPcs[1];
-	table[121] = m_table_desc16__8CPartPcs[2];
+	table[115] = m_table_desc16__8CPartPcs[1];
+	table[116] = m_table_desc16__8CPartPcs[2];
+	table[119] = m_table_desc17__8CPartPcs[0];
+	table[120] = m_table_desc17__8CPartPcs[1];
+	table[121] = m_table_desc17__8CPartPcs[2];
 	table[124] = m_table_desc18__8CPartPcs[0];
 	table[125] = m_table_desc18__8CPartPcs[1];
 	table[126] = m_table_desc18__8CPartPcs[2];
+
+	return profileName;
 }
 
 CPartPcs PartPcs;
-CProfile g_par_calc_prof(const_cast<char*>(s_no_name_8032fdcc));
+CProfile g_par_calc_prof(InitCPartPcsTable(const_cast<char*>(s_no_name_8032fdcc)));
 CProfile g_par_draw_prof(const_cast<char*>(s_no_name_8032fdcc));
 
 static int GetMngStBaseTime(const _pppMngSt* pppMngSt)


### PR DESCRIPTION
## Summary
- Move CPartPcs table descriptor filling out of the empty CPartPcs constructor and into static initialization before g_par_calc_prof construction.
- Correct the CPartPcs descriptor slot ordering for the draw/drawAfter entries and the second table row so it matches the row-local layout shown by Ghidra's __sinit_p_tina_cpp output.

## Evidence
- ninja passes for GCCP01.
- main/p_tina report fuzzy improved from 94.51022 to 94.91453.
- __sinit_p_tina_cpp report fuzzy improved from 50.971153 to 54.677883.
- Current objdiff check: build/tools/objdiff-cli diff -p . -u main/p_tina -o - --format json __sinit_p_tina_cpp reports 44.3125% for the symbol-level diff view.
- python3 tools/map/claim_doctor.py src/p_tina.cpp returned: No diagnoses found.

## Plausibility
- Ghidra shows PartPcs construction/registering before the table descriptor copies, then CProfile construction after those copies. Keeping CPartPcs construction empty and initializing the table as part of the g_par_calc_prof static initialization path reproduces that source-level ordering without writing sinit manually.
- The corrected descriptor indices follow the existing table row stride and descriptor triplet layout instead of hard-coded addresses or fake symbols.