### PR TITLE
Improve CGItemObj DeleteOld matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -782,11 +782,7 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 {
 	int deletedCount = 0;
 
-	while (true) {
-		if (maxDeleteCount <= deletedCount) {
-			return deletedCount;
-		}
-
+	while (deletedCount < maxDeleteCount) {
 		unsigned char* bestItemObj = 0;
 		int bestScriptObjectPos = 0x00989680;
 
@@ -805,7 +801,10 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		if (bestItemObj != 0) {
 			deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
 		} else {
-			break;
+			if ((unsigned int)System.m_execParam > 2U) {
+				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
+			}
+			return deletedCount;
 		}
 
 		deletedCount++;


### PR DESCRIPTION
## Summary
- Restructure `CGItemObj::DeleteOld` as a bounded loop.
- Restore the retail debug print when no deletable item is found and `System.m_execParam > 2`.

## Evidence
- `DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject`: 76.46% -> 98.22% match.
- `main/itemobj` `.text`: 79.17% -> 79.78% match.
- `ninja` passes.

## Plausibility
The change mirrors the same no-free-item debug path already present in `CreateFromScript`, and keeps the function behavior as a normal early return when no candidate can be deleted.