### PR TITLE
Improve CGItemObj DeleteOld matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -780,13 +780,8 @@ void CGItemObj::onFrameStat()
  */
 int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObject*, CFlatRuntime::CObject*)
 {
-	int deletedCount = 0;
-
-	while (true) {
-		if (maxDeleteCount <= deletedCount) {
-			return deletedCount;
-		}
-
+	int deletedCount;
+	for (deletedCount = 0; deletedCount < maxDeleteCount; deletedCount++) {
 		unsigned char* bestItemObj = 0;
 		int bestScriptObjectPos = 0x00989680;
 
@@ -805,10 +800,11 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		if (bestItemObj != 0) {
 			deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
 		} else {
-			break;
+			if ((unsigned int)System.m_execParam > 2U) {
+				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
+			}
+			return deletedCount;
 		}
-
-		deletedCount++;
 	}
 
 	return deletedCount;


### PR DESCRIPTION
## Summary
- Rework `CGItemObj::DeleteOld` as a bounded deletion loop.
- Restore the missing debug diagnostic when no deletable item is found.

## Evidence
- `ninja` passes.
- `DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject` improves from 76.4615% to 98.2154%.
- Remaining differences are limited to the diagnostic threshold branch shape and return register move.

## Plausibility
- The loop shape matches the Ghidra decompilation: return once `maxDeleteCount` is reached, scan for the oldest matching object, delete it when found, and print the existing no-delete message when none is found at debug exec levels.