### PR TITLE
Match CGItemObj::DeleteOld

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -804,7 +804,7 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 			if ((unsigned int)System.m_execParam >= 3U) {
 				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
 			}
-			return deletedCount;
+			break;
 		}
 
 		deletedCount++;

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -782,11 +782,7 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 {
 	int deletedCount = 0;
 
-	while (true) {
-		if (maxDeleteCount <= deletedCount) {
-			return deletedCount;
-		}
-
+	while (deletedCount < maxDeleteCount) {
 		unsigned char* bestItemObj = 0;
 		int bestScriptObjectPos = 0x00989680;
 
@@ -805,7 +801,10 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		if (bestItemObj != 0) {
 			deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject(CFlat, bestItemObj);
 		} else {
-			break;
+			if ((unsigned int)System.m_execParam >= 3U) {
+				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
+			}
+			return deletedCount;
 		}
 
 		deletedCount++;


### PR DESCRIPTION
## Summary
- Reshape CGItemObj::DeleteOld into the original bounded deletion loop.
- Restore the missing no-candidate diagnostic print guarded by System.m_execParam >= 3.
- Keep the diagnostic on the no-candidate path, while max-count exit returns without printing.

## Evidence
- ninja: passes
- objdiff main/itemobj DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject: 76.46154% -> 100.0% match, size remains 260 bytes
- overall progress after build: All 30.95% matched; Game Code 15.07% matched

## Plausibility
- The result follows the Ghidra control flow and uses existing itemobj diagnostic strings and System/Printf patterns already present in this file.
- No manual linkage, section forcing, fake symbols, or address hardcoding added.