### PR TITLE
Name material editor RTTI references

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -26,8 +26,8 @@ extern "C" void drawViewer__18CMaterialEditorPcsFv(CMaterialEditorPcs*);
 extern "C" void __dt__18CMaterialEditorPcsFv(void* self);
 extern "C" void* __vt__8CManager[];
 extern "C" void* __vt__8CProcess[];
-extern "C" char lbl_8032E648[];
-extern "C" char lbl_8032E650[];
+extern const char __RTTI__8CManager_8032E648[];
+extern const char __RTTI__8CProcess_8032E650[];
 extern "C" const char s_CMaterialEditorPcs_VIEWER_801D7D18[] = "CMaterialEditorPcs(VIEWER)";
 extern "C" const char s_CMaterialEditorPcs_801D7D34[] = "CMaterialEditorPcs";
 extern "C" const char s_CManager_801D7D48[] = "CManager";
@@ -42,8 +42,10 @@ extern "C" void* __vt__18CMaterialEditorPcs[];
 unsigned int m_table__18CMaterialEditorPcs[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CMaterialEditorPcs_VIEWER_801D7D18)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x20, 0, 0, 0, 0, 0x41, 1
 };
-unsigned int lbl_801EA624[3] = {reinterpret_cast<unsigned int>(lbl_8032E648), 0, 0};
-unsigned int lbl_801EA630[5] = {reinterpret_cast<unsigned int>(lbl_8032E648), 0, reinterpret_cast<unsigned int>(lbl_8032E650), 0, 0};
+unsigned int lbl_801EA624[3] = {reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E648)), 0, 0};
+unsigned int lbl_801EA630[5] = {
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E648)), 0,
+    reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CProcess_8032E650)), 0, 0};
 CMaterialEditorPcs MaterialEditorPcs;
 u8 lbl_8026D338[0xC];
 


### PR DESCRIPTION
## Summary
- Replace placeholder material-editor RTTI label refs with the real CManager/CProcess RTTI symbols.
- Matches the RTTI reference style used by nearby process units.

## Evidence
- ninja
- objdiff main/p_MaterialEditor:
  - lbl_801EA624: 75.0% -> 100.0%
  - lbl_801EA630: 71.42857% -> 100.0%
  - [.data-0]: 96.969696% -> 99.242424%

## Plausibility
- This is a symbol ownership/name cleanup for existing RTTI references, not manual RTTI/vtable construction or section forcing.