### PR TITLE
Improve p_minigame checksum source shape

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -382,7 +382,7 @@ void CMiniGamePcs::MiniGameGo(char* managerFilePath, char* managerSpFilePath)
 
     int offset = 0xA0;
     int managerBase = *reinterpret_cast<int*>(self + 0x1354);
-    char checksum = static_cast<char>(-0x19);
+    int checksum = -0x19;
 
     *reinterpret_cast<unsigned char*>(managerBase + 0xAC) = self[0x1344];
     *reinterpret_cast<unsigned char*>(managerBase + 0xAD) = self[0x1345];
@@ -392,23 +392,34 @@ void CMiniGamePcs::MiniGameGo(char* managerFilePath, char* managerSpFilePath)
     int checksumBlockCount = 2;
     do
     {
-        char* bytes = reinterpret_cast<char*>(managerBase + offset);
-        char* bytes2 = reinterpret_cast<char*>(managerBase + offset + 7);
+        signed char* bytes = reinterpret_cast<signed char*>(managerBase + offset);
+        signed char* bytes2 = reinterpret_cast<signed char*>(managerBase + offset + 7);
 
-        checksum = (((((((((((((checksum - bytes[0]) - bytes[1]) - bytes[2]) - bytes[3]) - bytes[4]) -
-                        bytes[5]) - bytes[6]) - bytes2[0]) - bytes2[1]) - bytes2[2]) - bytes2[3]) -
-                     bytes2[4]) - bytes2[5]) - bytes2[6];
+        checksum -= bytes[0];
+        checksum -= bytes[1];
+        checksum -= bytes[2];
+        checksum -= bytes[3];
+        checksum -= bytes[4];
+        checksum -= bytes[5];
+        checksum -= bytes[6];
+        checksum -= bytes2[0];
+        checksum -= bytes2[1];
+        checksum -= bytes2[2];
+        checksum -= bytes2[3];
+        checksum -= bytes2[4];
+        checksum -= bytes2[5];
+        checksum -= bytes2[6];
         offset += 0xE;
         checksumBlockCount--;
     } while (checksumBlockCount != 0);
 
     int remaining = 0xBD - offset;
-    char* checksumBytes = reinterpret_cast<char*>(managerBase + offset);
+    signed char* checksumBytes = reinterpret_cast<signed char*>(managerBase + offset);
     if (offset < 0xBD)
     {
         do
         {
-            char value = *checksumBytes;
+            signed char value = *checksumBytes;
             offset++;
             checksumBytes++;
             checksum -= value;
@@ -431,7 +442,7 @@ void CMiniGamePcs::MiniGameGo(char* managerFilePath, char* managerSpFilePath)
 
     offset = 0xA0;
     managerBase = *reinterpret_cast<int*>(self + 0x135C);
-    checksum = static_cast<char>(-0x19);
+    checksum = -0x19;
 
     *reinterpret_cast<unsigned char*>(managerBase + 0xAC) = self[0x1344];
     *reinterpret_cast<unsigned char*>(managerBase + 0xAD) = self[0x1345];
@@ -441,23 +452,34 @@ void CMiniGamePcs::MiniGameGo(char* managerFilePath, char* managerSpFilePath)
     checksumBlockCount = 2;
     do
     {
-        char* bytes = reinterpret_cast<char*>(managerBase + offset);
-        char* bytes2 = reinterpret_cast<char*>(managerBase + offset + 7);
+        signed char* bytes = reinterpret_cast<signed char*>(managerBase + offset);
+        signed char* bytes2 = reinterpret_cast<signed char*>(managerBase + offset + 7);
 
-        checksum = (((((((((((((checksum - bytes[0]) - bytes[1]) - bytes[2]) - bytes[3]) - bytes[4]) -
-                        bytes[5]) - bytes[6]) - bytes2[0]) - bytes2[1]) - bytes2[2]) - bytes2[3]) -
-                     bytes2[4]) - bytes2[5]) - bytes2[6];
+        checksum -= bytes[0];
+        checksum -= bytes[1];
+        checksum -= bytes[2];
+        checksum -= bytes[3];
+        checksum -= bytes[4];
+        checksum -= bytes[5];
+        checksum -= bytes[6];
+        checksum -= bytes2[0];
+        checksum -= bytes2[1];
+        checksum -= bytes2[2];
+        checksum -= bytes2[3];
+        checksum -= bytes2[4];
+        checksum -= bytes2[5];
+        checksum -= bytes2[6];
         offset += 0xE;
         checksumBlockCount--;
     } while (checksumBlockCount != 0);
 
     remaining = 0xBD - offset;
-    checksumBytes = reinterpret_cast<char*>(managerBase + offset);
+    checksumBytes = reinterpret_cast<signed char*>(managerBase + offset);
     if (offset < 0xBD)
     {
         do
         {
-            char value = *checksumBytes;
+            signed char value = *checksumBytes;
             offset++;
             checksumBytes++;
             checksum -= value;


### PR DESCRIPTION
## Summary
- Update CMiniGamePcs::MiniGameGo checksum construction to use an int accumulator over signed image bytes.
- Split the packed checksum expression into sequential signed subtractions for both manager images.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/p_minigame -o - MiniGameGo__12CMiniGamePcsFPcPc
  - .text improved from 64.954704% to 65.15669%.
  - Current .text size moved from 13548 to 13660 bytes toward the 14040-byte target.

## Plausibility
- Target assembly sign-extends each image byte before subtracting it from the checksum accumulator.
- The source now models that directly with signed char reads and an int accumulator, instead of relying on implementation-defined plain char behavior.