### PR TITLE
Improve CGItemObj DeleteOld matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -782,11 +782,7 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 {
 	int deletedCount = 0;
 
-	while (true) {
-		if (maxDeleteCount <= deletedCount) {
-			return deletedCount;
-		}
-
+	while (deletedCount < maxDeleteCount) {
 		unsigned char* bestItemObj = 0;
 		int bestScriptObjectPos = 0x00989680;
 
@@ -807,8 +803,11 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 		} else {
 			break;
 		}
-
 		deletedCount++;
+	}
+
+	if ((u32)System.m_execParam >= 3U) {
+		Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
 	}
 
 	return deletedCount;


### PR DESCRIPTION
## Summary
- Restores the missing DeleteOld debug diagnostic path when no old item can be deleted and System.m_execParam is at least 3.
- Rewrites the delete loop as a bounded loop so the max-count compare matches the target control flow more closely.

## Evidence
- `ninja` passes.
- `DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject` objdiff improved from 76.46154% to 89.76923%.
- Unit: `main/itemobj`.

## Plausibility
- Uses existing shipped rodata `DAT_801dced4` and existing `Printf__7CSystemFPce` linkage already used by nearby item creation paths.
- The unsigned `System.m_execParam` compare matches target codegen and is consistent with the debug threshold check.