### PR TITLE
Improve CWind AddAmbient match

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -357,11 +357,11 @@ found:
  */
 int CWind::AddAmbient(float dir, float speed)
 {
-	int checked = 0;
+	int blocks = 4;
 	WindObject* scan = m_objects;
 	WindObject* obj;
 
-	for (int blocks = 4; blocks != 0; blocks--) {
+	do {
 		if (GetWindActiveFlag(scan) == 0) {
 			obj = scan;
 			goto found;
@@ -395,15 +395,14 @@ int CWind::AddAmbient(float dir, float speed)
 			goto found;
 		}
 
-		checked += 7;
 		scan++;
-	}
+	} while (--blocks != 0);
 
 	obj = 0;
 
 found:
 	if (obj == 0) {
-		System.Printf(const_cast<char*>(DAT_801db568), checked);
+		System.Printf(const_cast<char*>(DAT_801db568));
 		return -1;
 	}
 


### PR DESCRIPTION
## Summary
- Corrected CWind::AddAmbient failure logging to match the decompiled call shape: the ambient warning format is called without the checked-count argument.
- Reworked the free-object scan as the four-block do/while form shown by Ghidra, removing the unused checked counter from this path.

## Objdiff evidence
- main/wind AddAmbient__5CWindFff: 89.22222% -> 94.44444%
- main/wind .text: 95.90433% -> 96.43964%

## Plausibility
- AddDiffuse still passes the checked count, but Ghidra for AddAmbient shows Printf(&System, DAT_801db568) with no vararg.
- The search loop now matches the same four groups of eight WindObject entries without retaining an unused counter.