### PR TITLE
Make process tables class statics

### DIFF
--- a/include/ffcc/p_MaterialEditor.h
+++ b/include/ffcc/p_MaterialEditor.h
@@ -28,12 +28,6 @@ struct RSDLISTITEM {
     int flag;
 };
 
-extern unsigned int m_table_desc0__18CMaterialEditorPcs[];
-extern unsigned int m_table_desc1__18CMaterialEditorPcs[];
-extern unsigned int m_table_desc2__18CMaterialEditorPcs[];
-extern unsigned int m_table_desc3__18CMaterialEditorPcs[];
-extern unsigned int m_table__18CMaterialEditorPcs[];
-
 struct pppFMATRIX {
     float value[3][4];
 };
@@ -41,6 +35,12 @@ struct pppFMATRIX {
 class CMaterialEditorPcs : public CSamplePcs
 {
 public:
+    static unsigned int m_table_desc0[3];
+    static unsigned int m_table_desc1[3];
+    static unsigned int m_table_desc2[3];
+    static unsigned int m_table_desc3[3];
+    static unsigned int m_table[0x15C / sizeof(unsigned int)];
+
     CMaterialEditorPcs() {}
     ~CMaterialEditorPcs();
 

--- a/include/ffcc/p_system.h
+++ b/include/ffcc/p_system.h
@@ -8,17 +8,18 @@ class CSystemPcs;
 extern "C" void create__10CSystemPcsFv(CSystemPcs*);
 extern "C" void destroy__10CSystemPcsFv(CSystemPcs*);
 extern "C" void calc__10CSystemPcsFv(CSystemPcs*);
-extern unsigned int m_table__10CSystemPcs[];
 
 class CSystemPcs : public CProcess
 {
 public:
+    static unsigned int m_table[0x15C / sizeof(unsigned int)];
+
     CSystemPcs()
     {
         static unsigned int desc0[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__10CSystemPcsFv)};
         static unsigned int desc1[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__10CSystemPcsFv)};
         static unsigned int desc2[] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__10CSystemPcsFv)};
-        unsigned int* table = &m_table__10CSystemPcs[1];
+        unsigned int* table = &CSystemPcs::m_table[1];
 
         table[0] = desc0[0];
         table[1] = desc0[1];

--- a/include/ffcc/p_tina.h
+++ b/include/ffcc/p_tina.h
@@ -16,30 +16,30 @@ unsigned int pppFreeMngStPrioForData();
 unsigned char pppAmemDeletePmng(unsigned long);
 unsigned int pppAmemRefCntError(unsigned long);
 
-extern unsigned int m_table_desc0__8CPartPcs[];
-extern unsigned int m_table_desc1__8CPartPcs[];
-extern unsigned int m_table_desc2__8CPartPcs[];
-extern unsigned int m_table_desc3__8CPartPcs[];
-extern unsigned int m_table_desc4__8CPartPcs[];
-extern unsigned int m_table_desc5__8CPartPcs[];
-extern unsigned int m_table_desc6__8CPartPcs[];
-extern unsigned int m_table_desc7__8CPartPcs[];
-extern unsigned int m_table_desc8__8CPartPcs[];
-extern unsigned int m_table_desc9__8CPartPcs[];
-extern unsigned int m_table_desc10__8CPartPcs[];
-extern unsigned int m_table_desc11__8CPartPcs[];
-extern unsigned int m_table_desc12__8CPartPcs[];
-extern unsigned int m_table_desc13__8CPartPcs[];
-extern unsigned int m_table_desc14__8CPartPcs[];
-extern unsigned int m_table_desc15__8CPartPcs[];
-extern unsigned int m_table_desc16__8CPartPcs[];
-extern unsigned int m_table_desc17__8CPartPcs[];
-extern unsigned int m_table_desc18__8CPartPcs[];
-extern unsigned int m_table__8CPartPcs[][0x15C / sizeof(unsigned int)];
-
 class CPartPcs : public CProcess
 {
 public:
+    static unsigned int m_table_desc0[3];
+    static unsigned int m_table_desc1[3];
+    static unsigned int m_table_desc2[3];
+    static unsigned int m_table_desc3[3];
+    static unsigned int m_table_desc4[3];
+    static unsigned int m_table_desc5[3];
+    static unsigned int m_table_desc6[3];
+    static unsigned int m_table_desc7[3];
+    static unsigned int m_table_desc8[3];
+    static unsigned int m_table_desc9[3];
+    static unsigned int m_table_desc10[3];
+    static unsigned int m_table_desc11[3];
+    static unsigned int m_table_desc12[3];
+    static unsigned int m_table_desc13[3];
+    static unsigned int m_table_desc14[3];
+    static unsigned int m_table_desc15[3];
+    static unsigned int m_table_desc16[3];
+    static unsigned int m_table_desc17[3];
+    static unsigned int m_table_desc18[3];
+    static unsigned int m_table[2][0x15C / sizeof(unsigned int)];
+
     CUSBStreamData m_usbStreamData; // 0x04
 
     CPartPcs();

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -33,13 +33,13 @@ extern "C" const char s_CMaterialEditorPcs_801D7D34[] = "CMaterialEditorPcs";
 extern "C" const char s_CManager_801D7D48[] = "CManager";
 extern "C" const char s_CProcess_801D7D54[] = "CProcess";
 extern "C" const char s_MaterialEditor_pctc_801D7D60[] = "MaterialEditor [%c]";
-unsigned int m_table_desc0__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__18CMaterialEditorPcsFv)};
-unsigned int m_table_desc1__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__18CMaterialEditorPcsFv)};
-unsigned int m_table_desc2__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__18CMaterialEditorPcsFv)};
-unsigned int m_table_desc3__18CMaterialEditorPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__18CMaterialEditorPcsFv)};
+unsigned int CMaterialEditorPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__18CMaterialEditorPcsFv)};
+unsigned int CMaterialEditorPcs::m_table_desc1[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__18CMaterialEditorPcsFv)};
+unsigned int CMaterialEditorPcs::m_table_desc2[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__18CMaterialEditorPcsFv)};
+unsigned int CMaterialEditorPcs::m_table_desc3[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__18CMaterialEditorPcsFv)};
 
 extern "C" void* __vt__18CMaterialEditorPcs[];
-unsigned int m_table__18CMaterialEditorPcs[0x15C / sizeof(unsigned int)] = {
+unsigned int CMaterialEditorPcs::m_table[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CMaterialEditorPcs_VIEWER_801D7D18)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x20, 0, 0, 0, 0, 0x41, 1
 };
 unsigned int lbl_801EA624[3] = {reinterpret_cast<unsigned int>(lbl_8032E648), 0, 0};
@@ -59,11 +59,11 @@ u8 lbl_8026D338[0xC];
 extern "C" void __sinit_p_MaterialEditor_cpp(void)
 {
     u8* self = reinterpret_cast<u8*>(&MaterialEditorPcs);
-    unsigned int* dst = m_table__18CMaterialEditorPcs;
-    unsigned int* desc0 = m_table_desc0__18CMaterialEditorPcs;
-    unsigned int* desc1 = m_table_desc1__18CMaterialEditorPcs;
-    unsigned int* desc2 = m_table_desc2__18CMaterialEditorPcs;
-    unsigned int* desc3 = m_table_desc3__18CMaterialEditorPcs;
+    unsigned int* dst = CMaterialEditorPcs::m_table;
+    unsigned int* desc0 = CMaterialEditorPcs::m_table_desc0;
+    unsigned int* desc1 = CMaterialEditorPcs::m_table_desc1;
+    unsigned int* desc2 = CMaterialEditorPcs::m_table_desc2;
+    unsigned int* desc3 = CMaterialEditorPcs::m_table_desc3;
 
     *reinterpret_cast<void**>(self) = __vt__8CManager;
     *reinterpret_cast<void**>(self) = __vt__8CProcess;
@@ -299,7 +299,7 @@ void CMaterialEditorPcs::Quit()
  */
 int CMaterialEditorPcs::GetTable(unsigned long index)
 {
-    return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(m_table__18CMaterialEditorPcs) + index * 0x15C);
+    return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(CMaterialEditorPcs::m_table) + index * 0x15C);
 }
 
 /*

--- a/src/p_system.cpp
+++ b/src/p_system.cpp
@@ -6,7 +6,7 @@ extern "C" void create__10CSystemPcsFv(CSystemPcs*);
 extern "C" void destroy__10CSystemPcsFv(CSystemPcs*);
 extern "C" void calc__10CSystemPcsFv(CSystemPcs*);
 CSystemPcs SystemPcs;
-unsigned int m_table__10CSystemPcs[0x15C / sizeof(unsigned int)] = {
+unsigned int CSystemPcs::m_table[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>("CSystemPcs"),
     0,
     0,
@@ -94,7 +94,7 @@ void CSystemPcs::create()
  */
 int CSystemPcs::GetTable(unsigned long index)
 {
-	unsigned char* table = reinterpret_cast<unsigned char*>(m_table__10CSystemPcs);
+	unsigned char* table = reinterpret_cast<unsigned char*>(CSystemPcs::m_table);
 	unsigned long offset = index * 0x15c;
 	return (int)(table + offset);
 }

--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -150,26 +150,26 @@ signed char g_MaxHeapSize[4];
 int lbl_8032ED48;
 signed char lbl_8032ED4C;
 }
-unsigned int m_table_desc0__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__8CPartPcsFv)};
-unsigned int m_table_desc1__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__8CPartPcsFv)};
-unsigned int m_table_desc2__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__8CPartPcsFv)};
-unsigned int m_table_desc3__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__8CPartPcsFv)};
-unsigned int m_table_desc4__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcDead__8CPartPcsFv)};
-unsigned int m_table_desc5__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(ClearOt__8CPartPcsFv)};
-unsigned int m_table_desc6__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawShadow__8CPartPcsFv)};
-unsigned int m_table_desc7__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawCharaBefore__8CPartPcsFv)};
-unsigned int m_table_desc8__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__8CPartPcsFv)};
-unsigned int m_table_desc9__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawAfter__8CPartPcsFv)};
-unsigned int m_table_desc10__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__8CPartPcsFv)};
-unsigned int m_table_desc11__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__8CPartPcsFv)};
-unsigned int m_table_desc12__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__8CPartPcsFv)};
-unsigned int m_table_desc13__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__8CPartPcsFv)};
-unsigned int m_table_desc14__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcDead__8CPartPcsFv)};
-unsigned int m_table_desc15__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(ClearOt__8CPartPcsFv)};
-unsigned int m_table_desc16__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawShadowViewer__8CPartPcsFv)};
-unsigned int m_table_desc17__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__8CPartPcsFv)};
-unsigned int m_table_desc18__8CPartPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawAfterViewer__8CPartPcsFv)};
-unsigned int m_table__8CPartPcs[2][0x15C / sizeof(unsigned int)] = {
+unsigned int CPartPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc1[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc2[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc3[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc4[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcDead__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc5[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(ClearOt__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc6[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawShadow__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc7[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawCharaBefore__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc8[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc9[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawAfter__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc10[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(createViewer__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc11[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc12[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc13[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc14[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcDead__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc15[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(ClearOt__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc16[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawShadowViewer__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc17[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__8CPartPcsFv)};
+unsigned int CPartPcs::m_table_desc18[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawAfterViewer__8CPartPcsFv)};
+unsigned int CPartPcs::m_table[2][0x15C / sizeof(unsigned int)] = {
     {
         reinterpret_cast<unsigned int>(const_cast<char*>(s_CPartPcs_GAME_801D7F2C)), 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
         0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000015, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x0000001D,
@@ -213,65 +213,65 @@ inline CPartPcs::CPartPcs()
 
 static inline char* InitCPartPcsTable(char* profileName)
 {
-	unsigned int* table = reinterpret_cast<unsigned int*>(m_table__8CPartPcs);
+	unsigned int* table = reinterpret_cast<unsigned int*>(CPartPcs::m_table);
 
-	table[33] = m_table_desc7__8CPartPcs[1];
-	table[37] = m_table_desc8__8CPartPcs[0];
-	table[38] = m_table_desc8__8CPartPcs[1];
-	table[1] = m_table_desc0__8CPartPcs[0];
-	table[2] = m_table_desc0__8CPartPcs[1];
-	table[3] = m_table_desc0__8CPartPcs[2];
-	table[4] = m_table_desc1__8CPartPcs[0];
-	table[5] = m_table_desc1__8CPartPcs[1];
-	table[6] = m_table_desc1__8CPartPcs[2];
-	table[7] = m_table_desc2__8CPartPcs[0];
-	table[8] = m_table_desc2__8CPartPcs[1];
-	table[9] = m_table_desc2__8CPartPcs[2];
-	table[12] = m_table_desc3__8CPartPcs[0];
-	table[13] = m_table_desc3__8CPartPcs[1];
-	table[14] = m_table_desc3__8CPartPcs[2];
-	table[17] = m_table_desc4__8CPartPcs[0];
-	table[18] = m_table_desc4__8CPartPcs[1];
-	table[19] = m_table_desc4__8CPartPcs[2];
-	table[22] = m_table_desc5__8CPartPcs[0];
-	table[23] = m_table_desc5__8CPartPcs[1];
-	table[24] = m_table_desc5__8CPartPcs[2];
-	table[27] = m_table_desc6__8CPartPcs[0];
-	table[28] = m_table_desc6__8CPartPcs[1];
-	table[29] = m_table_desc6__8CPartPcs[2];
-	table[32] = m_table_desc7__8CPartPcs[0];
-	table[35] = m_table_desc7__8CPartPcs[2];
-	table[39] = m_table_desc8__8CPartPcs[2];
-	table[44] = m_table_desc9__8CPartPcs[0];
-	table[45] = m_table_desc9__8CPartPcs[1];
-	table[46] = m_table_desc9__8CPartPcs[2];
-	table[88] = m_table_desc10__8CPartPcs[0];
-	table[89] = m_table_desc10__8CPartPcs[1];
-	table[90] = m_table_desc10__8CPartPcs[2];
-	table[91] = m_table_desc11__8CPartPcs[0];
-	table[92] = m_table_desc11__8CPartPcs[1];
-	table[93] = m_table_desc11__8CPartPcs[2];
-	table[94] = m_table_desc12__8CPartPcs[0];
-	table[95] = m_table_desc12__8CPartPcs[1];
-	table[96] = m_table_desc12__8CPartPcs[2];
-	table[99] = m_table_desc13__8CPartPcs[0];
-	table[100] = m_table_desc13__8CPartPcs[1];
-	table[101] = m_table_desc13__8CPartPcs[2];
-	table[104] = m_table_desc14__8CPartPcs[0];
-	table[105] = m_table_desc14__8CPartPcs[1];
-	table[106] = m_table_desc14__8CPartPcs[2];
-	table[109] = m_table_desc15__8CPartPcs[0];
-	table[110] = m_table_desc15__8CPartPcs[1];
-	table[111] = m_table_desc15__8CPartPcs[2];
-	table[114] = m_table_desc16__8CPartPcs[0];
-	table[115] = m_table_desc16__8CPartPcs[1];
-	table[116] = m_table_desc16__8CPartPcs[2];
-	table[119] = m_table_desc17__8CPartPcs[0];
-	table[120] = m_table_desc17__8CPartPcs[1];
-	table[121] = m_table_desc17__8CPartPcs[2];
-	table[124] = m_table_desc18__8CPartPcs[0];
-	table[125] = m_table_desc18__8CPartPcs[1];
-	table[126] = m_table_desc18__8CPartPcs[2];
+	table[33] = CPartPcs::m_table_desc7[1];
+	table[37] = CPartPcs::m_table_desc8[0];
+	table[38] = CPartPcs::m_table_desc8[1];
+	table[1] = CPartPcs::m_table_desc0[0];
+	table[2] = CPartPcs::m_table_desc0[1];
+	table[3] = CPartPcs::m_table_desc0[2];
+	table[4] = CPartPcs::m_table_desc1[0];
+	table[5] = CPartPcs::m_table_desc1[1];
+	table[6] = CPartPcs::m_table_desc1[2];
+	table[7] = CPartPcs::m_table_desc2[0];
+	table[8] = CPartPcs::m_table_desc2[1];
+	table[9] = CPartPcs::m_table_desc2[2];
+	table[12] = CPartPcs::m_table_desc3[0];
+	table[13] = CPartPcs::m_table_desc3[1];
+	table[14] = CPartPcs::m_table_desc3[2];
+	table[17] = CPartPcs::m_table_desc4[0];
+	table[18] = CPartPcs::m_table_desc4[1];
+	table[19] = CPartPcs::m_table_desc4[2];
+	table[22] = CPartPcs::m_table_desc5[0];
+	table[23] = CPartPcs::m_table_desc5[1];
+	table[24] = CPartPcs::m_table_desc5[2];
+	table[27] = CPartPcs::m_table_desc6[0];
+	table[28] = CPartPcs::m_table_desc6[1];
+	table[29] = CPartPcs::m_table_desc6[2];
+	table[32] = CPartPcs::m_table_desc7[0];
+	table[35] = CPartPcs::m_table_desc7[2];
+	table[39] = CPartPcs::m_table_desc8[2];
+	table[44] = CPartPcs::m_table_desc9[0];
+	table[45] = CPartPcs::m_table_desc9[1];
+	table[46] = CPartPcs::m_table_desc9[2];
+	table[88] = CPartPcs::m_table_desc10[0];
+	table[89] = CPartPcs::m_table_desc10[1];
+	table[90] = CPartPcs::m_table_desc10[2];
+	table[91] = CPartPcs::m_table_desc11[0];
+	table[92] = CPartPcs::m_table_desc11[1];
+	table[93] = CPartPcs::m_table_desc11[2];
+	table[94] = CPartPcs::m_table_desc12[0];
+	table[95] = CPartPcs::m_table_desc12[1];
+	table[96] = CPartPcs::m_table_desc12[2];
+	table[99] = CPartPcs::m_table_desc13[0];
+	table[100] = CPartPcs::m_table_desc13[1];
+	table[101] = CPartPcs::m_table_desc13[2];
+	table[104] = CPartPcs::m_table_desc14[0];
+	table[105] = CPartPcs::m_table_desc14[1];
+	table[106] = CPartPcs::m_table_desc14[2];
+	table[109] = CPartPcs::m_table_desc15[0];
+	table[110] = CPartPcs::m_table_desc15[1];
+	table[111] = CPartPcs::m_table_desc15[2];
+	table[114] = CPartPcs::m_table_desc16[0];
+	table[115] = CPartPcs::m_table_desc16[1];
+	table[116] = CPartPcs::m_table_desc16[2];
+	table[119] = CPartPcs::m_table_desc17[0];
+	table[120] = CPartPcs::m_table_desc17[1];
+	table[121] = CPartPcs::m_table_desc17[2];
+	table[124] = CPartPcs::m_table_desc18[0];
+	table[125] = CPartPcs::m_table_desc18[1];
+	table[126] = CPartPcs::m_table_desc18[2];
 
 	return profileName;
 }
@@ -447,7 +447,7 @@ void CPartPcs::onScriptChanging(char*)
  */
 int CPartPcs::GetTable(unsigned long index)
 {
-	return reinterpret_cast<int>(m_table__8CPartPcs[index]);
+	return reinterpret_cast<int>(CPartPcs::m_table[index]);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Move CSystemPcs, CPartPcs, and CMaterialEditorPcs process table storage from free extern globals into class static members.
- Update table initialization and GetTable callers to reference the owning class static data.
- Keep emitted table symbols stable while removing extern-table hacks from headers.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff focused checks remain stable:
  - main/p_system: GetTable__10CSystemPcsFUl 100%, __sinit_p_system_cpp 100%, m_table__10CSystemPcs 100%
  - main/p_tina: GetTable__8CPartPcsFUl 100%, m_table__8CPartPcs 100%, __sinit_p_tina_cpp unchanged at 44.3125%
  - main/p_MaterialEditor: GetTable__18CMaterialEditorPcsFUl 100%, m_table__18CMaterialEditorPcs 100%, __sinit_p_MaterialEditor_cpp unchanged at 75.37143%

## Plausibility
These table and descriptor objects are already emitted with class-scoped mangled symbols. Declaring them as class statics matches that ownership directly instead of exposing manually mangled free-global externs.