### PR TITLE
Improve menu money message mask typing

### DIFF
--- a/include/ffcc/menu_money.h
+++ b/include/ffcc/menu_money.h
@@ -35,7 +35,7 @@ struct MoneyMenuAnimList
 struct MoneyMenuState
 {
     char pad_00[0x09];
-    unsigned char messageMask;
+    signed char messageMask;
     char pad_0a;
     char initialized;
     char pad_0c;

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -268,9 +268,9 @@ int CMenuPcs::MoneyCtrlCur()
 					}
 					s16 winW;
 					s16 winH;
-					*(u8*)(menuState + 9) = 2;
+					this->moneyState->messageMask = 2;
 					if (CanPlayerPutItem__12CCaravanWorkFv((void*)caravanWork) != 0) {
-						*(u8*)(menuState + 9) = *(u8*)(menuState + 9) | 1;
+						this->moneyState->messageMask = this->moneyState->messageMask | 1;
 					}
 					GetSingWinSize__8CMenuPcsFiPsPsi(this, 1, &winW, &winH, 0);
 					SetSingWinInfo__8CMenuPcsFiiii(this, 0xF0, 0xD0, winW, winH);
@@ -304,7 +304,7 @@ int CMenuPcs::MoneyCtrlCur()
 
 		if ((hold & 0xC) == 0) {
 			if ((press & 0x100) != 0) {
-				if (((int)*(u8*)(menuState + 9) & (1 << *(s16*)(optBase + 0x26))) == 0) {
+				if (((int)this->moneyState->messageMask & (1 << *(s16*)(optBase + 0x26))) == 0) {
 					Sound.PlaySe(4, 0x40, 0x7F, 0);
 					return 0;
 				}


### PR DESCRIPTION
## Summary
- Change MoneyMenuState::messageMask to signed char, matching the signed byte use in the decompilation.
- Replace raw offset accesses for the message mask in MoneyCtrlCur with typed member access.

## Objdiff evidence
- main/menu_money MoneyCtrlCur__8CMenuPcsFv: 54.38095% -> 55.95238%
- main/menu_money MoneyDraw__8CMenuPcsFv: 81.50122% -> 82.02445%

## Rationale
The mask is consumed as a signed byte in the target code paths, including the option mask check and DrawSingWinMess argument. Using the real typed field removes unsigned-byte raw offset handling and gives both affected functions better codegen.