### PR TITLE
Define YmTracer2 color words

### DIFF
--- a/include/ffcc/pppConstrainCameraDir.h
+++ b/include/ffcc/pppConstrainCameraDir.h
@@ -16,8 +16,9 @@ typedef struct pppConstrainCameraDirUnkB {
     float m_dataValIndex;
     float m_initWOrk;
     float m_stepValue;
-    char m_arg3;
-    char pad[3];
+    u8 m_applyPosition;
+    u8 m_applyCameraInverse;
+    u8 _pad12[2];
 } pppConstrainCameraDirUnkB;
 
 #ifdef __cplusplus

--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -23,12 +23,11 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
     if (gPppCalcDisabled == 0) {
         _pppMngSt* pppMngSt = pppMngStPtr;
         float* value = (float*)((char*)pppConstrainCameraDir + *param_3->m_serializedDataOffsets + 0x80);
-        unsigned char* flags = (unsigned char*)&param_2->m_arg3;
 
         CalcGraphValue((_pppPObject*)pppConstrainCameraDir, param_2->m_graphId, value[0], value[1], value[2],
                        param_2->m_dataValIndex, param_2->m_initWOrk, param_2->m_stepValue);
 
-        if ((gPppInConstructor != 1) && ((flags[1] != 0 || flags[0] != 0))) {
+        if ((gPppInConstructor != 1) && ((param_2->m_applyCameraInverse != 0 || param_2->m_applyPosition != 0))) {
             float cameraDirX = CameraPcs._236_4_;
             float cameraDirY = CameraPcs._240_4_;
             float cameraDirZ = CameraPcs._244_4_;
@@ -50,13 +49,13 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
             Mtx scaleMtx;
             PSMTXScale(scaleMtx, pppMngSt->m_scale.x, pppMngSt->m_scale.y, pppMngSt->m_scale.z);
 
-            if (flags[1] != 0) {
+            if (param_2->m_applyCameraInverse != 0) {
                 PSMTXInverse(cameraMtx, pppMngStPtr->m_matrix.value);
             }
 
             PSMTXConcat(scaleMtx, pppMngStPtr->m_matrix.value, pppMngStPtr->m_matrix.value);
 
-            if (flags[0] != 0) {
+            if (param_2->m_applyPosition != 0) {
                 float resultZ = cameraDirZ * *value + cameraPosZ;
                 float resultY = cameraDirY * *value + cameraPosY;
                 float resultX = cameraDirX * *value + cameraPosX;

--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -28,12 +28,11 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
     if (gPppCalcDisabled == 0) {
         _pppMngSt* pppMngSt = pppMngStPtr;
         float* value = (float*)((char*)param_1 + *param_3->m_serializedDataOffsets + 0x80);
-        unsigned char* flags = (unsigned char*)&param_2->m_arg3;
 
         CalcGraphValue((_pppPObject*)param_1, param_2->m_graphId, value[0], value[1], value[2], param_2->m_dataValIndex,
                        param_2->m_initWOrk, param_2->m_stepValue);
 
-        if ((gPppInConstructor != 1) && ((flags[1] != 0 || flags[0] != 0))) {
+        if ((gPppInConstructor != 1) && ((param_2->m_applyCameraInverse != 0 || param_2->m_applyPosition != 0))) {
             Vec resultPos;
             Vec cameraDir;
             cameraDir.x = CameraPcs._236_4_;
@@ -59,13 +58,13 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
             Mtx scaleMtx;
             PSMTXScale(scaleMtx, pppMngSt->m_scale.x, pppMngSt->m_scale.y, pppMngSt->m_scale.z);
 
-            if (flags[1] != 0) {
+            if (param_2->m_applyCameraInverse != 0) {
                 PSMTXInverse(cameraMtx, pppMngStPtr->m_matrix.value);
             }
 
             PSMTXConcat(scaleMtx, pppMngStPtr->m_matrix.value, pppMngStPtr->m_matrix.value);
 
-            if (flags[0] != 0) {
+            if (param_2->m_applyPosition != 0) {
                 resultPos.x = cameraPosX;
                 resultPos.y = cameraPosY;
                 resultPos.z = cameraPosZ;

--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -90,15 +90,15 @@ inline void U8ToF32(pppFVECTOR4* dest, u8* src)
  */
 void pppKeShpTail2XDes(void* obj, void* param_2)
 {
-	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
-	u8* tail = (u8*)obj + serializedOffset + 0x80;
+    KeShpTail2XOffsets* offsets = (KeShpTail2XOffsets*)param_2;
+    KeShpTail2XWork* work = (KeShpTail2XWork*)((u8*)obj + offsets->m_serializedDataOffsets[0] + 0x80);
 
-	*(u16*)(tail + 2) = 0;
-	*(u16*)(tail + 4) = 0;
-	*(u16*)(tail + 6) = 0;
-	tail[1] = 0;
-	tail[0] = 0x1f;
-	memset(tail + 8, 0, 0x174);
+    work->m_frameAcc = 0;
+    work->m_shapeFrame = 0;
+    work->m_shapePrevFrame = 0;
+    work->m_head = 0;
+    work->m_count = 0x1f;
+    memset(work->m_posHistory, 0, sizeof(work->m_posHistory));
 }
 
 /*
@@ -112,15 +112,15 @@ void pppKeShpTail2XDes(void* obj, void* param_2)
  */
 void pppKeShpTail2XCon(void* obj, void* param_2)
 {
-	u32 serializedOffset = **(u32**)((u8*)param_2 + 0xc);
-	u8* tail = (u8*)obj + serializedOffset + 0x80;
+    KeShpTail2XOffsets* offsets = (KeShpTail2XOffsets*)param_2;
+    KeShpTail2XWork* work = (KeShpTail2XWork*)((u8*)obj + offsets->m_serializedDataOffsets[0] + 0x80);
 
-	*(u16*)(tail + 2) = 0;
-	*(u16*)(tail + 4) = 0;
-	*(u16*)(tail + 6) = 0;
-	tail[1] = 0;
-	tail[0] = 0x1f;
-	memset(tail + 8, 0, 0x174);
+    work->m_frameAcc = 0;
+    work->m_shapeFrame = 0;
+    work->m_shapePrevFrame = 0;
+    work->m_head = 0;
+    work->m_count = 0x1f;
+    memset(work->m_posHistory, 0, sizeof(work->m_posHistory));
 }
 
 /*

--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -72,8 +72,8 @@ union PackedColor {
     u8 bytes[4];
 };
 
-extern const PackedColor g_pppYmTracer2_1;
-extern const PackedColor g_pppYmTracer2_2;
+__declspec(section ".sdata2") PackedColor g_pppYmTracer2_1;
+__declspec(section ".sdata2") PackedColor g_pppYmTracer2_2;
 
 static inline void copyPolygonData(TRACE_POLYGON* dst, TRACE_POLYGON* src)
 {


### PR DESCRIPTION
## Summary
- Defines the two YmTracer2 packed color words in their owning unit instead of leaving them as extern-only references.
- Names the ConstrainCameraDir flag bytes and uses the typed KeShpTail2X work struct for constructor/destructor initialization, preserving existing matches while removing raw byte/offset access.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - --format json-pretty`:
  - `.sbss2`: 0.0% before, 100.0% after, size 8
  - `g_pppYmTracer2_1`: 100.0%, size 4
  - `g_pppYmTracer2_2`: 100.0%, size 4
  - `pppRenderYmTracer2`: remains 98.06911%, size 984
- Cleanup checks preserve existing scores:
  - `pppFrameConstrainCameraDir`: 99.685036%, size 508
  - `pppFrameConstrainCameraDir2`: 99.88372%, size 688
  - `pppKeShpTail2XCon` / `pppKeShpTail2XDes`: 100.0%, size 88 each

## Plausibility
- The YmTracer2 color globals are real object-owned data in the target object; defining them in the unit fixes ownership/linkage instead of relying on unresolved externs.
- The ConstrainCameraDir and KeShpTail2X changes make existing structure usage clearer without changing output.