### PR TITLE
Improve tmp artifact int conversion

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -41,11 +41,12 @@ extern const double DOUBLE_80333420 = 216.0;
 static inline double TmpArtiIntToDouble(int value)
 {
     union {
-        unsigned long long bits;
         double value;
+        u32 words[2];
     } conv;
 
-    conv.bits = 0x4330000000000000ULL | (unsigned int)(value ^ 0x80000000U);
+    conv.words[0] = 0x43300000;
+    conv.words[1] = value ^ 0x80000000U;
     return conv.value - DOUBLE_80332f40;
 }
 


### PR DESCRIPTION
## Summary
- Rework TmpArtiIntToDouble to build the 0x4330 conversion value from explicit high/low words instead of a 64-bit literal.
- This matches the target conversion pattern more closely and improves the menu_tmparti text diff.

## Evidence
- ninja passes.
- objdiff main/menu_tmparti .text: 80.625496% -> 81.07227%.
- TmpArtiDraw__8CMenuPcsFv: 84.318184% -> 85.89015%.

## Plausibility
- The helper now uses the same high-word/biased-low-word integer-to-double construction already visible in target code, rather than relying on a compiler-emitted 64-bit literal.