### PR TITLE
Pad sound warning string data

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -32,10 +32,10 @@ extern const float FLOAT_80330d00 = 100.0f;
 extern const double DOUBLE_80330d08 = 4503599627370496.0;
 extern const float kLineBoundsInitMin = 10000000.0f;
 extern const double DOUBLE_80330d18 = 0.5;
-static const char s_soundNoFreeWaveWarn[] =
+static const char s_soundNoFreeWaveWarn[40] =
     "\x82\xb1\x82\xea\x88\xc8\x8f\xe3noFreeWaev\x82\xf0\x92\xc7\x89\xc1\x82\xc5"
     "\x82\xab\x82\xdc\x82\xb9\x82\xf1\x81\x42\n";
-static const char s_soundNoFreeSeGroupWarn[] =
+static const char s_soundNoFreeSeGroupWarn[44] =
     "\x82\xb1\x82\xea\x88\xc8\x8f\xe3noFreeSeGroup\x82\xf0\x92\xc7\x89\xc1\x82\xc5"
     "\x82\xab\x82\xdc\x82\xb9\x82\xf1\x81\x42\n";
 static const char s_soundStreamPathFmt[] = "dvd/sound/stream/str%04d.str";


### PR DESCRIPTION
## Summary
- Give the two no-free sound warning strings explicit array sizes matching their target rodata symbols.
- This preserves the existing bytes while making the source layout account for the target padding after each string.

## Evidence
- Before: compiled symbol sizes were `s_soundNoFreeWaveWarn` 38 bytes and `s_soundNoFreeSeGroupWarn` 41 bytes.
- After: compiled symbol sizes are 40 bytes and 44 bytes, matching target `s_soundNoFreeWaveWarn_801DB0BC` and `s_soundNoFreeSeGroupWarn_801DB0E4`.
- `ninja` succeeds.

## Plausibility
- These are fixed diagnostic string buffers with explicit trailing padding in the target object; modeling that as bounded char arrays is normal source-level data layout, not forced section handling.
