### PR TITLE
Match ring menu create zero constant

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -61,7 +61,7 @@ static const char DAT_801da01c[] = {
 	(char)0xBD, (char)0x81, (char)0x42, 0x25, 0x64, 0x2D, 0x25, 0x64,
 	0x0A, 0x00, 0x00, 0x00
 };
-extern float FLOAT_803309c0;
+extern const float FLOAT_803309c0;
 extern float FLOAT_803309c4;
 extern float FLOAT_803309c8;
 extern float FLOAT_803309cc;
@@ -234,14 +234,14 @@ void CRingMenu::Create()
 	m_buttonTimers[8] = 0;
 	m_ringRotation = -1;
 	m_rotationPhase = -1;
-	m_spinPhase = 0.0f;
+	m_spinPhase = FLOAT_803309c0;
 	m_gbaConnectedFlag = 0;
 	m_gbaAnimCounter = 0;
 	m_commonFrameCounter = 0;
 	m_unk4f8 = 0;
 	m_timerB = 0;
 	m_currentCommandIndex = 0;
-	m_spinAccumulator = 0.0f;
+	m_spinAccumulator = FLOAT_803309c0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Treat `FLOAT_803309c0` as a const recovered sdata2 constant in `ringmenu.cpp`.
- Use that constant for `CRingMenu::Create` zero-float initialization of `m_spinPhase` and `m_spinAccumulator`.

## Objdiff Evidence
- `main/ringmenu` `.text`: `60.565037%` -> `60.68683%`.
- `Create__9CRingMenuFv`: `99.90741%` -> `100.0%`.

## Plausibility
- The target already references `FLOAT_803309c0` for this zero float load.
- The source change replaces literal zero initialization with the recovered read-only constant, without hardcoded addresses or manual vtable/RTTI/data hacks.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/ringmenu -o -`