### PR TITLE
Improve memory card dummy wait loops

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1510,7 +1510,7 @@ int CMemoryCardMan::DummySave()
     m_result = result;
 
     // Busy-wait for async completion
-    while ((-((int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0)
+    while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
     {
     }
 
@@ -1526,7 +1526,7 @@ int CMemoryCardMan::DummySave()
         }
         m_result = result;
 
-        while ((-((int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0)
+        while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
         {
         }
 
@@ -1590,7 +1590,7 @@ int CMemoryCardMan::DummySave()
         }
         m_result = result;
 
-        while ((-((int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0)
+        while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
         {
         }
 
@@ -1665,7 +1665,7 @@ int CMemoryCardMan::DummySave()
         }
         m_result = result;
 
-        while ((-((int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0)
+        while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
         {
         }
 
@@ -1753,7 +1753,7 @@ int CMemoryCardMan::DummySave()
     }
     m_result = result;
 
-    while ((-((int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0)
+    while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
     {
     }
 
@@ -1848,7 +1848,7 @@ int CMemoryCardMan::DummyLoad()
     m_result = result;
 
     // Busy wait for async completion
-    while ( ((-(int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0 )
+    while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
     {
     }
 
@@ -1924,7 +1924,7 @@ int CMemoryCardMan::DummyLoad()
     m_result = result;
 
     // Wait for read to finish
-    while ( ((-(int)m_opDoneFlag) | (int)m_opDoneFlag) >= 0 )
+    while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
     {
     }
 


### PR DESCRIPTION
## Summary
- Rewrites the async completion spin tests in `CMemoryCardMan::DummySave` and `CMemoryCardMan::DummyLoad` to use the explicit sign-bit extraction shape produced by the target.
- Keeps behavior equivalent while matching the original compiler output more closely.

## Evidence
- `ninja` passes for GCCP01.
- `DummySave__14CMemoryCardManFv`: 87.225876% -> 89.057014%.
- `DummyLoad__14CMemoryCardManFv`: 81.82204% -> 83.00848%.
- `main/memorycard` `.text`: 84.41946% -> 84.74134%.

## Plausibility
The wait loops are checking whether the signed byte completion flag has become nonzero. The updated expression makes the sign-bit test explicit, matching the decompiled target shape without changing the underlying async wait behavior.