### PR TITLE
Improve ArtiOpen match

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -213,7 +213,7 @@ public:
     void GetOptionData();
     void ArtiInit();
     void ArtiInit1();
-    bool ArtiOpen();
+    int ArtiOpen();
     int ArtiCtrl();
     int ArtiClose();
     void ArtiDraw();

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -563,7 +563,7 @@ int CMenuPcs::ArtiCtrl()
  * JP Address: TODO
  * JP Size: TODO
  */
-bool CMenuPcs::ArtiOpen()
+int CMenuPcs::ArtiOpen()
 {
 	int finished;
 	int count;
@@ -602,7 +602,11 @@ bool CMenuPcs::ArtiOpen()
 		}
 	}
 
-	return count == finished;
+	int result = 0;
+	if (count == finished) {
+		result = 1;
+	}
+	return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Change CMenuPcs::ArtiOpen to return int, matching neighboring artifact menu routines.
- Expand the final boolean return into the target-style result variable and branch.

## Evidence
- ninja passes for GCCP01.
- objdiff main/menu_arti ArtiOpen__8CMenuPcsFv improves from 94.638885% to 97.25%.
- ArtiOpen size now matches target: 428b -> 432b.
- [extabindex-0] improves from 82.96703% to 83.73626%.

## Plausibility
- This mirrors the existing int-return pattern used by CMenuPcs::ArtiClose and avoids compiler-coaxing hacks.