### PR TITLE
Recover maptexanim set array layouts

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -8,6 +8,18 @@
 
 class CMaterial;
 
+class CMaterialSet : public CRef
+{
+public:
+    CPtrArray<CMaterial*> m_materials;
+};
+
+class CTextureSet : public CRef
+{
+public:
+    CPtrArray<CTexture*> m_textures;
+};
+
 extern "C" void Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet(CMapTexAnim*, CMaterialSet*, CTextureSet*);
 extern "C" void __ct__4CRefFv(void*);
 extern "C" void __dt__4CRefFv(void*, int);
@@ -65,12 +77,12 @@ static inline unsigned char& U8At(void* p, unsigned int offset)
 
 static inline void* MaterialAt(CMaterialSet* materialSet, unsigned long index)
 {
-    return (*reinterpret_cast<CPtrArray<CMaterial*>*>(materialSet))[index];
+    return materialSet->m_materials[index];
 }
 
 static inline void* TextureAt(CTextureSet* textureSet, unsigned long index)
 {
-    return (*reinterpret_cast<CPtrArray<CTexture*>*>(textureSet))[index];
+    return textureSet->m_textures[index];
 }
 
 static inline void ReplaceRef(void** slot, void* ref)


### PR DESCRIPTION
## Summary
- Add local CMaterialSet and CTextureSet layouts for maptexanim with embedded CPtrArray members after CRef
- Use member access for material and texture lookup instead of casting the outer set object directly
- Improves CMapTexAnim::Calc by matching the expected +0x8 array-subobject accesses

## Objdiff Evidence
- main/maptexanim unit fuzzy score: 98.296135 -> 99.79971
- Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet symbol score: 96.815506 -> 99.59893
- Data remains fully matched: 100%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/maptexanim -o - --format json Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet