### PR TITLE
Fix pppYmEnv texture index table size

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -110,7 +110,7 @@ struct CModelRaw {
 void drawParaboloidMap(_GXTexObj* texObjs, _GXTexObj* targetTexObj, void* displayList, unsigned long displayListSize,
                        _GXTexObj* blendTexObj, unsigned char mode)
 {
-    const unsigned char s_texObjIndices[16] = {5, 2, 1, 0, 4, 5, 0, 0, 0, 0};
+    const unsigned char s_texObjIndices[] = {5, 2, 1, 0, 4, 5, 0, 0, 0, 0};
     const unsigned char s_xAxisRotIndices[] = {1, 1, 0, 0, 2, 0, 1, 3, 4, 2};
     const unsigned char s_yAxisRotIndices[] = {1, 0, 4, 3, 0, 0, 0, 0, 0, 0};
     const float s_xAxisAngles[] = {90.0f, 180.0f, 270.0f, 180.0f, -90.0f, 90.0f};


### PR DESCRIPTION
## Summary
- Corrects the local texture index table in drawParaboloidMap from an explicit 16-byte array to the actual 10-byte initializer length.
- Removes unintended zero padding from the generated constant table and improves the function objdiff match.

## Objdiff Evidence
- drawParaboloidMap__FP9_GXTexObjP9_GXTexObjPvUlP9_GXTexObjUc: 91.96649% -> 93.650795%
- main/pppYmEnv .text: 96.71648% -> 97.301285%
- main/pppYmEnv extabindex: 98.61111% -> 100.0%

## Plausibility
- The function indexes this table as two groups of five entries using mode * 5 + i. The initializer contains exactly ten values, so the explicit 16-byte bound was adding unused padding rather than representing source intent.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmEnv -o - drawParaboloidMap__FP9_GXTexObjP9_GXTexObjPvUlP9_GXTexObjUc
