### PR TITLE
Match pppYmEnv texture index table size

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -110,7 +110,7 @@ struct CModelRaw {
 void drawParaboloidMap(_GXTexObj* texObjs, _GXTexObj* targetTexObj, void* displayList, unsigned long displayListSize,
                        _GXTexObj* blendTexObj, unsigned char mode)
 {
-    const unsigned char s_texObjIndices[16] = {5, 2, 1, 0, 4, 5, 0, 0, 0, 0};
+    const unsigned char s_texObjIndices[] = {5, 2, 1, 0, 4, 5, 0, 0, 0, 0};
     const unsigned char s_xAxisRotIndices[] = {1, 1, 0, 0, 2, 0, 1, 3, 4, 2};
     const unsigned char s_yAxisRotIndices[] = {1, 0, 4, 3, 0, 0, 0, 0, 0, 0};
     const float s_xAxisAngles[] = {90.0f, 180.0f, 270.0f, 180.0f, -90.0f, 90.0f};


### PR DESCRIPTION
## Summary
- Shrink the local texture-index table in drawParaboloidMap to the 10 initialized entries copied by the PAL function.
- This removes the artificial six-byte tail from the source table and improves pppYmEnv codegen around the local table setup.

## Evidence
- ninja succeeds.
- main/pppYmEnv .text: 96.71648% -> 97.301285%.
- drawParaboloidMap__FP9_GXTexObjP9_GXTexObjPvUlP9_GXTexObjUc: 91.96649% -> 93.650795%.
- genParaboloidMap__FPvPUlUs9_GXVtxFmt remains 98.1459%.

## Plausibility
- Ghidra shows the PAL function copying 10 bytes for this table, matching the 10 explicit indices used by mode * 5 + i. The old [16] declaration added unused padding that does not look like source-owned data.