### PR TITLE
Improve gobject cancel flag updates

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2149,9 +2149,8 @@ void CGObject::onDraw()
  */
 void CGObject::CancelMove(int moveType)
 {
-    u8 flags = *((u8*)&m_weaponNodeFlags + 1);
-    flags = static_cast<u8>(__rlwimi(flags, 0, 5, 26, 26));
-    *((u8*)&m_weaponNodeFlags + 1) = flags;
+    *((u8*)&m_weaponNodeFlags + 1) =
+        static_cast<u8>(__rlwimi(*((u8*)&m_weaponNodeFlags + 1), 0, 5, 26, 26));
 
     CFlatRuntime::CStack arg;
     arg.m_word = static_cast<u32>(moveType);
@@ -3105,9 +3104,8 @@ void CGObject::CancelAnim(int keepFacing)
 {
 	m_currentAnimSlot = -1;
 
-	u8 flags = *((u8*)&m_shieldNodeFlags);
-	flags = static_cast<u8>(__rlwimi(flags, 0, 6, 25, 25));
-	*((u8*)&m_shieldNodeFlags) = flags;
+	*((u8*)&m_shieldNodeFlags) =
+	    static_cast<u8>(__rlwimi(*((u8*)&m_shieldNodeFlags), 0, 6, 25, 25));
 
 	m_turnSpeed = sZeroFloat;
 
@@ -3116,13 +3114,11 @@ void CGObject::CancelAnim(int keepFacing)
 		m_rotTargetY = m_rotBaseY;
 	}
 
-	flags = *((u8*)&m_shieldNodeFlags);
-	flags = static_cast<u8>(__rlwimi(flags, 0, 3, 28, 28));
-	*((u8*)&m_shieldNodeFlags) = flags;
+	*((u8*)&m_shieldNodeFlags) =
+	    static_cast<u8>(__rlwimi(*((u8*)&m_shieldNodeFlags), 0, 3, 28, 28));
 
-	flags = *((u8*)&m_shieldNodeFlags);
-	flags = static_cast<u8>(__rlwimi(flags, 0, 7, 24, 24));
-	*((u8*)&m_shieldNodeFlags) = flags;
+	*((u8*)&m_shieldNodeFlags) =
+	    static_cast<u8>(__rlwimi(*((u8*)&m_shieldNodeFlags), 0, 7, 24, 24));
 }
 
 /*


### PR DESCRIPTION
## Summary
- simplify CGObject cancel flag updates to write rlwimi results directly back to the backing flag bytes
- improves matching for CancelMove and CancelAnim without changing behavior

## Evidence
- ninja
- objdiff main/gobject CancelMove__8CGObjectFi: 96.86364% -> 97.40909%
- objdiff main/gobject CancelAnim__8CGObjectFi: 96.0% -> 98.0% (report: 98.25%)

## Plausibility
- source keeps the same bit operations and field writes, but removes redundant temporary flag variables
- direct byte updates match nearby flag-manipulation style in gobject and better reflect the generated code shape