### PR TITLE
Align pppYmEnv frame matrix local

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -612,7 +612,7 @@ int GetCharaNodeFrameMatrix(_pppMngSt* mngSt, float frameAdd, float (*outMatrix)
     Vec local100;
     Vec local10C;
     Vec local118;
-    pppFMATRIX localMatrix;
+    pppFMATRIX localMatrix ATTRIBUTE_ALIGN(8);
 
     owner = (CGObject*)mngSt->m_owner;
     if ((s32)Game.m_currentSceneId == 7) {


### PR DESCRIPTION
## Summary
- Align the local pppFMATRIX in GetCharaNodeFrameMatrix to 8 bytes.
- This matches the stack layout expected by the target for the matrix passed through PSMTX/PSVEC routines.

## Evidence
- ninja: passes
- objdiff main/pppYmEnv:
  - GetCharaNodeFrameMatrix__FP9_pppMngStfPA4_f: 99.564156% -> 99.75221%
  - drawParaboloidMap__FP9_GXTexObjP9_GXTexObjPvUlP9_GXTexObjUc remains 93.650795%
  - genParaboloidMap__FPvPUlUs9_GXVtxFmt remains 98.1459%

## Plausibility
- The local is a matrix object used with Dolphin matrix/vector routines, and 8-byte local alignment is already used elsewhere in the codebase for similar matrix/vector temporaries.