### PR TITLE
Improve menu arti and material editor matches

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -740,7 +740,7 @@ void CMenuPcs::ArtiInit()
 	float fVar3;
 	float fVar4;
 	int iVar5;
-	short sVar6;
+	int sVar6;
 	short sVar7;
 	short* psVar8;
 	int iVar9;
@@ -823,10 +823,8 @@ void CMenuPcs::ArtiInit()
 	iVar11 = 4;
 	do {
 		psVar8 = (short*)(GetArtiListBase(this) + iVar5 + 8);
-		psVar8[0x16] = 0;
-		psVar8[0x17] = 2;
-		psVar8[0xe] = 0;
-		psVar8[0xf] = 0x37;
+		*(int*)(psVar8 + 0x16) = 2;
+		*(int*)(psVar8 + 0xe) = 0x37;
 		sVar7 = sVar7 + 2;
 		*psVar8 = *(short*)(iVar10 + 8) + 0x24;
 		sVar1 = sVar6 + 0x20;
@@ -842,10 +840,8 @@ void CMenuPcs::ArtiInit()
 		iVar9 = iVar5 + 0x48;
 		iVar5 = iVar5 + 0x80;
 		psVar8 = (short*)(GetArtiListBase(this) + iVar9);
-		psVar8[0x16] = 0;
-		psVar8[0x17] = 2;
-		psVar8[0xe] = 0;
-		psVar8[0xf] = 0x37;
+		*(int*)(psVar8 + 0x16) = 2;
+		*(int*)(psVar8 + 0xe) = 0x37;
 		*psVar8 = *(short*)(iVar10 + 8) + 0x24;
 		sVar6 = sVar6 + 0x40;
 		psVar8[1] = *(short*)(iVar10 + 10) + sVar1;

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -575,10 +575,8 @@ void CMaterialEditorPcs::drawViewer()
         _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(7, 0, 0, 7, 0);
         GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
 
-        GXColor ambColor;
-        GXColor matColor;
-        *reinterpret_cast<u32*>(&ambColor) = kMaterialEditorDefaultColorRgba;
-        *reinterpret_cast<u32*>(&matColor) = *reinterpret_cast<u32*>(&ambColor);
+        GXColor ambColor = {0xff, 0xff, 0xff, 0xff};
+        GXColor matColor = ambColor;
         GXSetChanAmbColor(GX_COLOR0, ambColor);
         GXSetChanMatColor(GX_COLOR0, matColor);
 


### PR DESCRIPTION
## Summary
- Improve `CMenuPcs::ArtiInit` by using a 32-bit row offset accumulator and word stores for the existing 32-bit `tex` / `flags` fields.
- Improve `CMaterialEditorPcs::drawViewer` by initializing `GXColor` values directly instead of aliasing through `u32` stores.

## Evidence
- `ninja` passes.
- `main/menu_arti`: `.text` `80.953964% -> 81.64%`; `ArtiInit__8CMenuPcsFv` `61.658825% -> 67.00588%` and generated size `664 -> 640`.
- `main/p_MaterialEditor`: `.text` `79.41815% -> 79.520836%`; `drawViewer__18CMaterialEditorPcsFv` `68.34811% -> 68.52803%`.

## Plausibility
- `ArtiOpenAnim` already models `tex` and `flags` as 32-bit fields, so storing them as words is closer to the declared layout than paired halfword writes.
- Direct `GXColor` aggregate initialization is normal source-shaped code and reduces the mismatch in the generated `drawViewer` call setup.
