### PR TITLE
Align pppLaser debug matrix

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -413,7 +413,7 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     pppFMATRIX unitMtx;
     Mtx shapeMtx;
     Mtx rotateMtx;
-    Mtx debugMtx;
+    Mtx debugMtx ATTRIBUTE_ALIGN(8);
     Mtx pointMtx;
     Mtx sphereMtx;
     pppFMATRIX managerMtx;


### PR DESCRIPTION
## Summary
- Align the local debug matrix in pppRenderLaser to 8 bytes.
- This matches the target stack layout used by the debug sphere path and reduces pppRenderLaser argument mismatches.

## Evidence
- Built with ninja.
- pppRenderLaser objdiff improved from 96.64229% to 96.694145%.
- main/pppLaser .text fuzzy match improved to 97.94108%.
- Function size remains 3008 bytes.

## Plausibility
- This uses the existing local ATTRIBUTE_ALIGN(8) pattern already used for matrix/vector temporaries in nearby particle code, such as pppParHitSph.cpp and pppParHitSphMat.cpp.
- No manual section forcing, fake symbols, or address hacks.