### PR TITLE
Improve FavoClose matching

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -298,8 +298,9 @@ bool CMenuPcs::FavoClose()
     count = *favoList;
     entry = reinterpret_cast<FavoEntry*>(favoList + 4);
     frame = singMenuState->frame;
+    int remaining = count;
     if (0 < count) {
-        for (int i = 0; i < count; i++) {
+        do {
             if (frame >= entry->startFrame) {
                 if (entry->startFrame + entry->duration <= frame) {
                     float step = FLOAT_80333040;
@@ -310,17 +311,18 @@ bool CMenuPcs::FavoClose()
                 } else {
                     entry->step = entry->step + 1;
                     entry->alpha =
-                        (float)-((DOUBLE_80333050 / (double)entry->duration) * (double)entry->step - DOUBLE_80333050);
+                        (float)(DOUBLE_80333050 - (DOUBLE_80333050 / (double)entry->duration) * (double)entry->step);
                     if ((entry->flags & 2) == 0) {
                         float step =
-                            (float)-((DOUBLE_80333050 / (double)entry->duration) * (double)entry->step - DOUBLE_80333050);
+                            (float)(DOUBLE_80333050 - (DOUBLE_80333050 / (double)entry->duration) * (double)entry->step);
                         entry->dx = (entry->targetX - (float)entry->x) * step;
                         entry->dy = (entry->targetY - (float)entry->y) * step;
                     }
                 }
             }
             entry++;
-        }
+            remaining = remaining - 1;
+        } while (remaining != 0);
     }
 
 	bool finished = false;


### PR DESCRIPTION
## Summary
- Rework FavoClose to use a count-down loop matching the Ghidra/target control flow more closely.
- Express close alpha as 1.0 - progress, avoiding the extra negate sequence in the generated code.

## Evidence
- ninja succeeds.
- FavoClose__8CMenuPcsFv: 65.778946% -> 68.76842%.
- compiled FavoClose size: 396 -> 388 bytes, target is 380 bytes.
- menu_favo .text match: 64.594444% -> 64.79687%.

## Plausibility
- The loop now mirrors the decompiled count-down traversal of the favorite entry list.
- The arithmetic is equivalent source-level animation progress logic, not an address or section hack.