### PR TITLE
Improve pppConstrainCameraDir scale constant

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -6,6 +6,7 @@
 #include <dolphin/mtx.h>
 
 void pppSetFpMatrix(_pppMngSt*);
+extern const float FLOAT_803320C0;
 extern const float FLOAT_803320C4;
 
 /*
@@ -42,7 +43,7 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
 
             PSMTXIdentity(pppMngStPtr->m_matrix.value);
 
-            pppMngSt->m_scale.x = 1.3333f * scale;
+            pppMngSt->m_scale.x = FLOAT_803320C0 * scale;
             pppMngSt->m_scale.y = scale;
             pppMngSt->m_scale.z = 1.0f;
 
@@ -119,4 +120,5 @@ void pppConstructConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir
     puVar2[0] = uVar1;
 }
 
+extern const float kConstrainCameraDirAspectScale = 1.3333f;
 extern const float FLOAT_803331ec = 0.0f;


### PR DESCRIPTION
## Summary
- Use the existing shared FLOAT_803320C0 value for the camera-dir X scale multiply.
- Preserve the unit-local aspect-scale literal so pppConstrainCameraDir .sdata2 remains matched.

## Evidence
- Before: pppFrameConstrainCameraDir 99.685036%, .text 99.72603%, .sdata2 100.0%.
- After: pppFrameConstrainCameraDir 99.72441%, .text 99.76028%, .sdata2 100.0%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir -o /tmp/pppConstrainCameraDir_pr.json