### PR TITLE
Match pppBreathModel source string data

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -27,7 +27,7 @@ void _GXSetTevOp__F13_GXTevStageID10_GXTevMode(int, int);
 void DrawSphere__8CGraphicFPA4_f8_GXColor(void*, Mtx, _GXColor);
 }
 
-extern "C" const char s_pppBreathModel_cpp_801DB5A0[24] = "pppBreathModel.cpp";
+extern "C" const char s_pppBreathModel_cpp_801DB5A0[] = "pppBreathModel.cpp";
 
 struct pppBreathModelUnkC {
     unsigned char _pad[0xC];


### PR DESCRIPTION
## Summary
- Remove the artificial `[24]` bound from `s_pppBreathModel_cpp_801DB5A0` so the string emits at its natural size.
- This matches the target rodata for `main/pppBreathModel` without changing codegen.

## Evidence
- Before: `.rodata` 88.37209%; `s_pppBreathModel_cpp_801DB5A0` 88.37209%, size 19.
- After: `.rodata` 100.0%; `s_pppBreathModel_cpp_801DB5A0` 100.0%, size 19.
- `.text` remains 99.42919%.

## Verification
- `python3 configure.py --version GCCP01`
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o -`