### PR TITLE
Fix mog fur work buffer size

### DIFF
--- a/src/chara_fur.cpp
+++ b/src/chara_fur.cpp
@@ -45,7 +45,7 @@ extern "C" char* sMogRadarTypeLabels[];
 extern "C" char sMogRadarDebugFormatBlock[];
 extern "C" char sMogFurTextureName[];
 extern "C" {
-extern unsigned char m_mogWork[0x2C];
+extern unsigned char m_mogWork[0x30];
 void* gMogFurTexBuffer;
 }
 extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
@@ -694,7 +694,7 @@ static Vec s_mogFurVelocityRand;
 static Vec s_mogFurAccel;
 static Vec s_mogFurAccelRand;
 extern "C" {
-unsigned char m_mogWork[0x2C];
+unsigned char m_mogWork[0x30];
 }
 static unsigned int s_mogFurRand;
 static float s_mogFurMaxY;


### PR DESCRIPTION
## Summary
- Resize `m_mogWork` storage in `chara_fur` from 0x2c to 0x30 bytes.
- Keep the existing 0x2c memset behavior intact; the extra word is reserved storage, matching the symbol size.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/chara_fur -o /tmp/chara_fur_final.json`:
  - `m_mogWork`: 50.0% -> 100.0%
  - `.bss`: 50.0% -> 100.0%
  - `.text`: unchanged at 27.87986%

## Plausibility
`config/GCCP01/symbols.txt` claims `m_mogWork` as a 0x30-byte bss object. Ghidra shows only 0x2c bytes are cleared during mode reset, so the source now reserves the correct object size without changing runtime initialization behavior.