### PR TITLE
Improve ChkEquipActive control flow

### DIFF
--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -142,24 +142,26 @@ int CMenuPcs::ChkEquipActive(int index)
 	int entryCount = entries[0];
 	s16* itemEntries = entries + 1;
 	int equipIndex = GetEquipState(this)[0x13];
-	unsigned int active;
 
 	if ((index < 0) || (entryCount <= index)) {
-		active = 0;
-	} else if (index == 0) {
-		if (equipIndex < 3) {
-			active = 0;
-		} else {
-			active = (unsigned int)(int)caravanWork->m_equipment[equipIndex] >> 0x1f ^ 1;
-		}
-	} else {
-		int item = caravanWork->m_inventoryItems[itemEntries[index - 1]];
-		active = ChkEquipPossible__8CMenuPcsFi(this, item);
-
-		if (((active & 0xff) != 0) && (GetEquipType__8CMenuPcsFi(this, item) != equipIndex)) {
-			active = 0;
-		}
+		return 0;
 	}
+
+	if (index == 0) {
+		if (equipIndex < 3) {
+			return 0;
+		}
+
+		return (unsigned int)(int)caravanWork->m_equipment[equipIndex] >> 0x1f ^ 1;
+	}
+
+	int item = caravanWork->m_inventoryItems[itemEntries[index - 1]];
+	unsigned int active = ChkEquipPossible__8CMenuPcsFi(this, item);
+
+	if (((active & 0xff) != 0) && (GetEquipType__8CMenuPcsFi(this, item) != equipIndex)) {
+		active = 0;
+	}
+
 	return active;
 }
 


### PR DESCRIPTION
## Summary
- Restructure CMenuPcs::ChkEquipActive to return directly for invalid and unequippable cases.
- Keeps the matched 0x10c function size while improving the control-flow shape against target.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/menu_equip -o /tmp/menu_equip_final.json ChkEquipActive__8CMenuPcsFi
- ChkEquipActive__8CMenuPcsFi: 89.402985% -> 92.83582%, size remains 268 bytes.

## Plausibility
- The change removes an artificial all-path active accumulator for cases that naturally return false immediately.
- The remaining active value is still shared for the equip-type check tail, matching the target shared-return shape more closely.