### PR TITLE
Improve fontman matching

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -19,6 +19,8 @@ extern "C" void _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(in
 extern "C" void* __vt__5CFont[];
 extern "C" const float FLOAT_803306B8;
 extern "C" const float FLOAT_803306C8;
+extern "C" const float FLOAT_803306D8;
+extern "C" const float FLOAT_803306DC;
 
 static const char s_fontman_cpp[] = "fontman.cpp";
 static const char s_CFontMan[] = "CFontMan";
@@ -392,11 +394,11 @@ void CFont::DrawInit()
 
     CFontRenderFlagBits& renderFlagBits = GetRenderFlagBits(renderFlags);
     if (renderFlagBits.zCompare != 0 || renderFlagBits.zUpdate != 0) {
-        C_MTXOrtho(projMtx, 0.0f, 480.0f, 0.0f, 640.0f, 0.0f, 1.0f);
-        projMtx[2][2] = 1.0f;
-        projMtx[2][3] = 0.0f;
+        C_MTXOrtho(projMtx, FLOAT_803306B8, FLOAT_803306D8, FLOAT_803306B8, FLOAT_803306DC, FLOAT_803306B8, FLOAT_803306C8);
+        projMtx[2][2] = FLOAT_803306C8;
+        projMtx[2][3] = FLOAT_803306B8;
     } else {
-        C_MTXOrtho(projMtx, 0.0f, 480.0f, 0.0f, 640.0f, 0.0f, 1.0f);
+        C_MTXOrtho(projMtx, FLOAT_803306B8, FLOAT_803306D8, FLOAT_803306B8, FLOAT_803306DC, FLOAT_803306B8, FLOAT_803306C8);
     }
     GXSetProjection(projMtx, GX_ORTHOGRAPHIC);
 
@@ -426,7 +428,7 @@ void CFont::DrawInit()
 
     float texWidth = static_cast<float>(*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(texturePtr) + 0x64));
     float texHeight = static_cast<float>(*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(texturePtr) + 0x68));
-    PSMTXScale(texMtx, 1.0f / texWidth, 1.0f / texHeight, 1.0f);
+    PSMTXScale(texMtx, FLOAT_803306C8 / texWidth, FLOAT_803306C8 / texHeight, FLOAT_803306C8);
     GXLoadTexMtxImm(texMtx, GX_TEXMTX0, GX_MTX2x4);
 
     GXSetNumTexGens(1);

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -693,34 +693,34 @@ void CFont::Create(void* filePtr, CMemory::CStage* stage)
                         chunkFile.Get(m_glyphData, chunk.m_size);
                     }
 
-                    unsigned short** bucketSlot = m_glyphBuckets;
+                    CFont* font = this;
                     unsigned short* bucket = static_cast<unsigned short*>(m_glyphData);
                     for (int i = 0; i < 32; i++) {
-                        bucketSlot[0] = bucket;
+                        font->m_glyphBuckets[0] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[1] = bucket;
+                        font->m_glyphBuckets[1] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[2] = bucket;
+                        font->m_glyphBuckets[2] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[3] = bucket;
+                        font->m_glyphBuckets[3] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[4] = bucket;
+                        font->m_glyphBuckets[4] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[5] = bucket;
+                        font->m_glyphBuckets[5] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[6] = bucket;
+                        font->m_glyphBuckets[6] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot[7] = bucket;
+                        font->m_glyphBuckets[7] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        bucketSlot += 8;
+                        font = reinterpret_cast<CFont*>(&font->margin);
                     }
                     break;
                 case 'TXTR':


### PR DESCRIPTION
## Summary
- Change the CFont glyph bucket setup loop to advance through CFont member layout, matching the target store pattern more closely.
- Use named fontman .sdata2 projection/scale constants in DrawInit instead of local float literals.

## Objdiff evidence
- fontman .text: 96.47967% -> 96.58174%
- Create__5CFontFPvPQ27CMemory6CStage: 98.28395% (13 diffs) -> 98.703705% (4 diffs)
- DrawInit__5CFontFv: 97.8125% (23 diffs) -> 98.09896% (12 diffs)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/fontman -o -

The glyph bucket loop now follows the decompiled member-store shape instead of a raw pointer-to-pointer cursor, and the DrawInit constants correspond to existing named .sdata2 symbols, so these are source/layout improvements rather than temporary codegen hacks.