### PR TITLE
Improve mes, p_tina, and YmMana matching

### DIFF
--- a/include/ffcc/mes.h
+++ b/include/ffcc/mes.h
@@ -29,7 +29,7 @@ public:
     void SetPosition(float, float);
     int useFlag(int, int);
     void addFlag(class CFlag&);
-    void MakeAgbString(char*, char*, int, int);
+    static void MakeAgbString(char*, char*, int, int);
     static unsigned long drawTagString(CFont*, char*, int, int, int);
     static int m_tempVar[0x14];
 

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -34,6 +34,8 @@ static const char s_mesTagMissing[] = "This TAG is not created. %02x\n";
 static const char s_mesNumFmt[] = "%d";
 static const char s_mesFallback[] = "---";
 static const char s_mesEmpty[] = "";
+static char* sTag54Source;
+static unsigned char sTag54Init;
 
 struct CMesFlatTableView
 {
@@ -829,11 +831,10 @@ void CMes::Draw()
 	if (*(int*)((char*)this + 8) != 0)
 	{
 		unsigned char* menuPcs = reinterpret_cast<unsigned char*>(&MenuPcs);
-		unsigned int globalAlpha;
+		int globalAlpha;
 		if ((*(int*)((char*)this + 0x3CAC) != 0) && (*(int*)((char*)this + 0x3CB8) != 0))
 		{
-			globalAlpha = 0xFF - (unsigned int)(*(int*)((char*)this + 0x3CBC) * 0xFF) /
-			                        (unsigned int)*(int*)((char*)this + 0x3CB8);
+			globalAlpha = 0xFF - (*(int*)((char*)this + 0x3CBC) * 0xFF) / *(int*)((char*)this + 0x3CB8);
 		}
 		else
 		{
@@ -848,7 +849,7 @@ void CMes::Draw()
 		for (int i = 0; i < *(int*)((char*)this + 8); i++)
 		{
 			CFont* nextFont = font;
-			if ((int)(unsigned int)*(unsigned short*)(glyph + 2) <= *(int*)((char*)this + 0x3C80))
+			if ((int)(unsigned int)*(unsigned short*)((char*)glyph + 0x0C) <= *(int*)((char*)this + 0x3C80))
 			{
 				unsigned int ch = (unsigned int)*(unsigned char*)(glyph + 4);
 				if (ch < 0x20)
@@ -1073,8 +1074,6 @@ int CMes::useFlag(int maxCount, int stopOnClear)
  */
 void CMes::MakeAgbString(char* out, char* src, int playerIndex, int keepHyphenOnLineBreak)
 {
-	static char* sTag54Source = (char*)s_mesEmpty;
-	static int sTag54Init = 0;
 	if (sTag54Init == 0)
 	{
 		sTag54Source = (char*)s_mesEmpty;

--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -19,9 +19,6 @@ extern const float kPppHeapUseRateDivisor;
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdio.h>
 
 extern "C" const char s_no_name_8032fdcc[];
-extern "C" {
-const char s_no_name_8032fdcc[] = "no name";
-}
 
 extern "C" CProfile* __ct__8CProfileFPc(CProfile*, char*);
 extern "C" CProfile* __dt__8CProfileFv(CProfile*, short);
@@ -1205,6 +1202,10 @@ void CPartPcs::GetParColIdx(int index, pppFVECTOR4& color)
 	color.y = pppMngSt->g;
 	color.z = pppMngSt->b;
 	color.w = pppMngSt->a;
+}
+
+extern "C" {
+const char s_no_name_8032fdcc[] = "no name";
 }
 
 /*

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -19,7 +19,7 @@ extern float FLOAT_80330e48;
 extern float FLOAT_80330e4c;
 extern float FLOAT_80330e58;
 extern float FLOAT_80330e5c;
-extern char DAT_80330e50[];
+extern const char DAT_80330e50[];
 
 extern const float FLOAT_80330e60 = 2.0f;
 extern const float FLOAT_80330e64 = 0.015625f;
@@ -749,7 +749,7 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
         work[11] = (u32)pppMemAlloc(0x20, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x399);
     }
 
-    texBufferSize = GXGetTexBufferSize(0x80, 0x80, GX_TF_RGBA8, GX_FALSE, 0);
+    texBufferSize = GXGetTexBufferSize(0x80, 0x80, GX_TF_RGB565, GX_FALSE, 0);
     if (work[12] == 0) {
         work[12] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3A1);
     }
@@ -757,8 +757,8 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
         work[13] = (u32)pppMemAlloc(texBufferSize, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3A3);
     }
 
-    GXInitTexObj((GXTexObj*)work[10], (void*)work[12], 0x80, 0x80, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
-    GXInitTexObj((GXTexObj*)work[11], (void*)work[13], 0x80, 0x80, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
+    GXInitTexObj((GXTexObj*)work[10], (void*)work[12], 0x80, 0x80, GX_TF_RGB565, GX_CLAMP, GX_CLAMP, GX_FALSE);
+    GXInitTexObj((GXTexObj*)work[11], (void*)work[13], 0x80, 0x80, GX_TF_RGB565, GX_CLAMP, GX_CLAMP, GX_FALSE);
 
     if (work[8] == 0) {
         work[8] = (u32)pppMemAlloc(0xC0, pppEnvStPtr->m_stagePtr, const_cast<char*>(s_pppYmMana_cpp_801DB4D8), 0x3B0);


### PR DESCRIPTION
## Summary
- Move p_tina's small "no name" string definition after SetParColIdx so the local 1.0f constant and string match target .sdata2 order.
- Make CMes::MakeAgbString a static member, move its tag-54 state to file-scope storage, and adjust Draw alpha/reveal-counter logic to better match target codegen.
- Use RGB565 for YmMana capture texture allocation/init, matching the target texture format and slightly improving pppFrameYmMana.

## Objdiff evidence
- main/p_tina: SetParColIdx__8CPartPcsFiR11pppFVECTOR4 improved from 99.85714% to 100.0%; [.sdata2-0] improved from 60.000004% to 80.0%.
- main/mes: MakeAgbString__4CMesFPcPcii improved from 49.249065% to 51.83146% and current size shrank from 2260b to 2204b; Draw__4CMesFv improved from 57.93% to 58.235%.
- main/pppYmMana: pppFrameYmMana improved from 75.865906% to 75.870186%; Mana_BeforeDrawCallback stayed at 68.94118% after rejecting regressing candidate edits.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_tina -o -
- build/tools/objdiff-cli diff -p . -u main/mes -o -
- build/tools/objdiff-cli diff -p . -u main/pppYmMana -o -