### PR TITLE
Fix pppScreenBreak rodata ownership

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -125,7 +125,7 @@ extern const float FLOAT_80331cec = 4.0f;
 extern const float FLOAT_80331cf0 = -3.0f;
 extern const float FLOAT_80331cf4 = 0.5f;
 
-extern const Vec DAT_801dd4b0 = { 0.0f, 1.0f, 0.0f };
+extern const Vec DAT_801dd4b0;
 extern const Vec DAT_801dd4bc = { 0.0f, 1.0f, 0.0f };
 extern const char s_f999_root_801dd4c8[] = "f999_root";
 extern const char s_pppScreenBreak_cpp_801dd4d4[] = "pppScreenBreak.cpp";


### PR DESCRIPTION
## Summary
- Declare `DAT_801dd4b0` as an external vector in `pppScreenBreak.cpp` instead of defining it in this unit.
- Leaves `DAT_801dd4bc` as the vector owned by `pppScreenBreak`, matching the split ownership around `801DD4BC`.

## Evidence
- `ninja` succeeds for GCCP01.
- `build/GCCP01/report.json` for `main/pppScreenBreak` now reports `.rodata`, `.sdata2`, and `.data` at 100% fuzzy match.
- `SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi` is 100% matched; `SB_BeforeCalcMatrixCallback__FPQ26CChara6CModelPvPv` remains 98.755554%.
- Built source `.rodata` shrinks by removing the misplaced `DAT_801dd4b0` definition from this object.

## Plausibility
`config/GCCP01/splits.txt` places `pppScreenBreak.cpp` `.rodata` starting at `0x801DD4BC`, while `DAT_801dd4b0` is immediately before that range. Treating it as an external constant is consistent with MAP/split ownership and avoids claiming data from the previous unit.