### PR TITLE
Fix pppYmDeformationShp constant ownership

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -5,20 +5,20 @@
 #include "ffcc/partMng.h"
 #include "ffcc/pppYmEnv.h"
 extern "C" {
-extern const float FLOAT_803305f0 = 0.01745329238474369f;
-extern const float kPppYmDeformationShpZero = 0.0f;
-extern const float FLOAT_803305f8 = 1.0f;
-extern const double DOUBLE_80330600 = 4503601774854144.0;
-extern const double DOUBLE_80330608 = 4503599627370496.0;
-extern const float FLOAT_80330610 = 320.0f;
-extern const float FLOAT_80330614 = 0.0031250000465661287f;
-extern const float FLOAT_80330618 = 224.0f;
-extern const float FLOAT_8033061c = 0.0044639999978244305f;
-extern const float FLOAT_80330620 = 1000.0f;
-extern const float FLOAT_80330624 = -1000.0f;
-extern const float FLOAT_80330628 = -0.5f;
-extern const float FLOAT_8033062c = -1.0f;
-extern const float FLOAT_80330630 = 0.5f;
+extern const float FLOAT_803305f0;
+extern const float kPppYmDeformationShpZero;
+extern const float FLOAT_803305f8;
+extern const double DOUBLE_80330600;
+extern const double DOUBLE_80330608;
+extern const float FLOAT_80330610;
+extern const float FLOAT_80330614;
+extern const float FLOAT_80330618;
+extern const float FLOAT_8033061c;
+extern const float FLOAT_80330620;
+extern const float FLOAT_80330624;
+extern const float FLOAT_80330628;
+extern const float FLOAT_8033062c;
+extern const float FLOAT_80330630;
 extern int gPppCalcDisabled;
 extern unsigned char gPppInConstructor;
 }


### PR DESCRIPTION
## Summary
- Changes pppYmDeformationShp constants from local definitions to external declarations.
- Matches the split layout: pppYmDeformationShp.cpp owns text/extab/extabindex only, not the FLOAT_803305f0/FLOAT_803306xx sdata2 table.
- Removes the fake local ownership of named sdata2 constants while preserving references to the mapped symbols.

## Evidence
- Build: ninja passes, main.dol OK.
- Before objdiff current sections for main/pppYmDeformationShp: .text 5932, .sdata2 132.
- After objdiff current sections: .text 5924, .sdata2 16.
- Target split has no .sdata2 section for pppYmDeformationShp.cpp; remaining 16 bytes are compiler-generated conversion literals, not the named FLOAT/DOUBLE table.

## Notes
- This is data/layout progress, not a code match. Text score regresses because the source now references external constants instead of locally owning them, but the ownership is more plausible and matches the split file.