### PR TITLE
Name chara animation bank fields

### DIFF
--- a/include/ffcc/chara_anim.h
+++ b/include/ffcc/chara_anim.h
@@ -49,6 +49,11 @@ public:
 		unsigned int m_dataOffset;
 		unsigned int m_flags;
 	};
+
+	unsigned char _pad0[0x205C];
+	void* m_animAmemBase;
+	unsigned char _pad2060[0x14];
+	int m_animBankAddress;
 };
 
 #endif // _FFCC_CHARA_ANIM_H_

--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -19,7 +19,7 @@ extern "C" void SetGroup__7CMemoryFPvi(CMemory*, void*, int);
 extern "C" void CopyFromAMemorySync__7CMemoryFPvPvUl(CMemory*, void*, void*, unsigned long);
 extern "C" int TryReleaseAnimBank__9CCharaPcsFi(void*, int);
 class CCharaPcs;
-extern unsigned char Chara[];
+extern CChara Chara;
 extern CCharaPcs CharaPcs;
 extern const float kCharaSharedZeroF;
 extern const float kCharaSharedOneF;
@@ -60,11 +60,6 @@ static inline unsigned int FourCC(char a, char b, char c, char d)
 {
 	return (static_cast<unsigned int>(a) << 24) | (static_cast<unsigned int>(b) << 16) |
 	       (static_cast<unsigned int>(c) << 8) | static_cast<unsigned int>(d);
-}
-
-static inline int& CharaS32(unsigned int offset)
-{
-	return S32At(Chara, offset);
 }
 
 static inline void i2f_5(float* out, register const unsigned short* in)
@@ -268,7 +263,7 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 							break;
 						case 0x44415441: {
 							int i = 0;
-							int shift = i;
+							int shift = 0;
 							do {
 								int type = chunkFile.Get4();
 								int mode;
@@ -311,12 +306,11 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 
 					Memory.CopyToAMemorySync(
 					    m_bank,
-					    reinterpret_cast<void*>(
-					        CharaS32(8308) + S32At(reinterpret_cast<void*>(CharaS32(8284)), 8)),
+					    reinterpret_cast<void*>(Chara.m_animBankAddress + S32At(Chara.m_animAmemBase, 8)),
 					    m_bankSize);
 
-					m_bankAddress = CharaS32(8308);
-					CharaS32(8308) += m_bankSize;
+					m_bankAddress = Chara.m_animBankAddress;
+					Chara.m_animBankAddress += m_bankSize;
 					if (m_bank != 0) {
 						__dl__FPv(m_bank);
 						m_bank = 0;
@@ -345,7 +339,7 @@ void CChara::CAnim::InitQuantize()
 	unsigned long qy = ((unsigned long)m_quantizeY << 0x18) | 0x70000 | ((unsigned long)m_quantizeY << 8) | 7;
 	unsigned long qz = ((unsigned long)m_quantizeZ << 0x18) | 0x70000 | ((unsigned long)m_quantizeZ << 8) | 7;
 
-	gqrInit__6CCharaFUlUlUl(Chara, qx, qy, qz);
+	gqrInit__6CCharaFUlUlUl(&Chara, qx, qy, qz);
 }
 
 /*
@@ -397,8 +391,7 @@ void CChara::CAnimNode::Interp(CChara::CAnim* anim, SRT* srt, float frame)
 		SetGroup__7CMemoryFPvi(&Memory, anim->m_bank, 1);
 		CopyFromAMemorySync__7CMemoryFPvPvUl(
 		    &Memory, anim->m_bank,
-		    reinterpret_cast<void*>(
-		        anim->m_bankAddress + S32At(reinterpret_cast<void*>(CharaS32(8284)), 8)),
+		    reinterpret_cast<void*>(anim->m_bankAddress + S32At(Chara.m_animAmemBase, 8)),
 		    anim->m_bankSize);
 	}
 


### PR DESCRIPTION
## Summary
- add recovered `CChara` animation bank fields at offsets `0x205c` and `0x2074` in the `chara_anim` view of the singleton
- replace raw `CharaS32(8284/8308)` offset access in `CAnim::Create` and `CAnimNode::Interp` with named member access
- clean up the DATA loop shift initialization so it no longer depends on the loop index variable for its zero value

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/chara_anim -o /tmp/chara_anim.final.json Create__Q26CChara5CAnimFPvPQ27CMemory6CStage`
- `Create__Q26CChara5CAnimFPvPQ27CMemory6CStage`: 97.354164%, stable
- `Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf`: 99.2303%, stable
- `InitQuantize__Q26CChara5CAnimFv`: 100.0%, stable

## Plausibility
Ghidra references `Chara._8284_4_` as the AMEM base pointer and `Chara._8308_4_` as the animation bank cursor. The compiled `Chara` symbol is `0x2078` bytes, so naming fields at `0x205c` and `0x2074` removes fake offset access without changing codegen.