### PR TITLE
Improve gobjwork command item type load

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2146,7 +2146,8 @@ extern "C" int GetCmdListItemName__12CCaravanWorkFi(CCaravanWork* caravanWork, i
 			for (int i = 0; i < groupedCount; i++) {
 				short invSlot = (short)caravanWork->m_commandListInventorySlotRef[cmdListIdx + i];
 				short itemId = (short)caravanWork->m_inventoryItems[invSlot];
-				if (*(short*)(Game.unkCFlatData0[2] + itemId * 0x48) == 1) {
+				int itemType = GetItemDataPtr(itemId)[0];
+				if (itemType == 1) {
 					*itemCmdListIdx = cmdListIdx + i;
 					return 1;
 				}


### PR DESCRIPTION
## Summary
- Use the existing item-data helper in GetCmdListItemName__12CCaravanWorkFi when reading the command item type.
- This emits the target-style unsigned halfword load for item flat-data instead of a signed load from a raw pointer expression.

## Objdiff Evidence
- main/gobjwork / GetCmdListItemName__12CCaravanWorkFi: 82.45% -> 83.08% match.
- Function size remains current 396b vs target 352b; this is a local codegen improvement, not a full match.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/gobjwork -o - GetCmdListItemName__12CCaravanWorkFi
