### PR TITLE
Use shared ppp object layout for location title

### DIFF
--- a/include/ffcc/pppLocationTitle.h
+++ b/include/ffcc/pppLocationTitle.h
@@ -4,15 +4,7 @@
 #include <dolphin/types.h>
 #include "ffcc/partMng.h"
 
-struct pppLocationTitle {
-    u32 m_unk0;
-    u32 m_unk4;
-    u32 m_unk8;
-    s32 m_graphId;
-    pppFMATRIX m_localMatrix;
-    char m_pad[0x54];
-    void* field_0x88;
-};
+typedef _pppPObject pppLocationTitle;
 
 struct pppLocationTitleUnkB {
     s32 m_graphId;
@@ -32,10 +24,7 @@ struct pppLocationTitleUnkB {
     u16 m_pad;
 };
 
-struct pppLocationTitleUnkC {
-    char pad[0xC];
-    s32* m_serializedDataOffsets;
-};
+typedef _pppCtrlTable pppLocationTitleUnkC;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -65,7 +65,7 @@ void pppRenderLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitle
 
     dataValIndex = param_2->m_dataValIndex;
     serializedOffset = *param_3->m_serializedDataOffsets;
-    work = (LocationTitleWork*)((u8*)pppLocationTitle + 0x80 + serializedOffset);
+    work = (LocationTitleWork*)(pppLocationTitle->m_workArea + serializedOffset);
 
     if (dataValIndex == 0xFFFF) {
         return;
@@ -138,7 +138,7 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
     LocationTitleParticle* dst;
     int serializedOffset;
     int colorOffset;
-    s32* serializedOffsets;
+    int* serializedOffsets;
     LocationTitleWork* work;
     LocationTitleColorBlock* colorData;
     int graphFrame;
@@ -161,8 +161,8 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
     serializedOffsets = param_3->m_serializedDataOffsets;
     serializedOffset = serializedOffsets[0];
     colorOffset = serializedOffsets[1];
-    work = (LocationTitleWork*)((u8*)pppLocationTitle + 0x80 + serializedOffset);
-    colorData = (LocationTitleColorBlock*)((u8*)pppLocationTitle + 0x80 + colorOffset);
+    work = (LocationTitleWork*)(pppLocationTitle->m_workArea + serializedOffset);
+    colorData = (LocationTitleColorBlock*)(pppLocationTitle->m_workArea + colorOffset);
     rand();
 
     if (param_2->m_dataValIndex == 0xFFFF) {
@@ -284,7 +284,7 @@ void pppDestructLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTit
 
     serializedOffsets = *(s32**)((u8*)param_2 + 0xC);
     serializedOffset = *serializedOffsets;
-    stagePtr = (CMemory::CStage**)((u8*)pppLocationTitle + serializedOffset + 0x80);
+    stagePtr = (CMemory::CStage**)(pppLocationTitle->m_workArea + serializedOffset);
 
     if (*stagePtr != NULL) {
         pppHeapUseRate(*stagePtr);
@@ -307,7 +307,7 @@ void pppConstructLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTi
     f32 value;
 
     value = FLOAT_80330ee0;
-    work = (LocationTitleWork*)((u8*)pppLocationTitle + 0x80 + *param_2->m_serializedDataOffsets);
+    work = (LocationTitleWork*)(pppLocationTitle->m_workArea + *param_2->m_serializedDataOffsets);
     work->m_particles = 0;
     work->m_count = 0;
     work->m_acc = value;


### PR DESCRIPTION
## Summary
- replace the local fake pppLocationTitle object header with the shared _pppPObject typedef
- replace the local control-table stub with _pppCtrlTable
- use m_workArea for serialized work/color offsets instead of manual +0x80 object arithmetic

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o - pppRenderLocationTitle: 100.0%
- build/tools/objdiff-cli diff -p . -u main/pppLocationTitle -o - pppFrameLocationTitle: 99.60912% (unchanged)

## Notes
- This is source-accuracy cleanup rather than a score change: existing matched functions remain matched and pppFrameLocationTitle remains at the same near-match score.
- MAP discrepancy tooling could not run in this checkout because orig/GCCP01/game.MAP is not present.