### PR TITLE
Fix sound warning string symbol sizes

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -33,10 +33,10 @@ extern const float FLOAT_80330d00 = 100.0f;
 extern const double DOUBLE_80330d08 = 4503599627370496.0;
 extern const float kLineBoundsInitMin = 10000000.0f;
 extern const double DOUBLE_80330d18 = 0.5;
-extern const char s_soundNoFreeWaveWarn_801DB0BC[] =
+extern const char s_soundNoFreeWaveWarn_801DB0BC[40] =
     "\x82\xb1\x82\xea\x88\xc8\x8f\xe3noFreeWaev\x82\xf0\x92\xc7\x89\xc1\x82\xc5"
     "\x82\xab\x82\xdc\x82\xb9\x82\xf1\x81\x42\n";
-extern const char s_soundNoFreeSeGroupWarn_801DB0E4[] =
+extern const char s_soundNoFreeSeGroupWarn_801DB0E4[44] =
     "\x82\xb1\x82\xea\x88\xc8\x8f\xe3noFreeSeGroup\x82\xf0\x92\xc7\x89\xc1\x82\xc5"
     "\x82\xab\x82\xdc\x82\xb9\x82\xf1\x81\x42\n";
 extern const char s_dvd_sound_stream_strpct04d_str_801DB110[] = "dvd/sound/stream/str%04d.str";


### PR DESCRIPTION
## Summary
- Give the no-free wave and no-free SE group warning strings their shipped symbol sizes.
- This keeps the existing string bytes and assigns the trailing padding to the correct rodata symbols.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/sound -o /tmp/sound_final.json`:
  - `s_soundNoFreeWaveWarn_801DB0BC`: 97.4359% -> 100.0%, size 40
  - `s_soundNoFreeSeGroupWarn_801DB0E4`: 96.47059% -> 100.0%, size 44

## Plausibility
- The explicit array bounds match the symbol sizes in `config/GCCP01/symbols.txt` and do not change the warning text contents.