### PR TITLE
Fix CStage memory field offsets

### DIFF
--- a/include/ffcc/memory.h
+++ b/include/ffcc/memory.h
@@ -22,12 +22,12 @@ public:
         unsigned long m_heapTop;
         unsigned long m_heapBottom;
         char m_allocationSourceStr[0xF8];
-        unsigned long m_group;
-        int m_allocationMode;
+        unsigned long m_unknown108;
+        int m_unknown10C;
         int m_heapHead;
         int m_heapTail;
         int m_unknown118;
-        int m_unknown11C;
+        int m_allocationMode;
         int m_blockCount;
         int m_allocCount;
         unsigned long m_defaultParam;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -731,7 +731,7 @@ CMemory::CStage* CMemory::CreateStage(unsigned long size, char* source, int mode
                         source = DAT_8032f7d4;
                     }
                     strcpy(reinterpret_cast<char*>(stageBytes + 0x10), source);
-                    *reinterpret_cast<int*>(stageBytes + 0x10C) = mode;
+                    stage->m_allocationMode = mode;
 
                     if (mode != 2) {
                         unsigned char* fill = reinterpret_cast<unsigned char*>(
@@ -781,7 +781,7 @@ CMemory::CStage* CMemory::CreateStage(unsigned long size, char* source, int mode
                         *reinterpret_cast<int*>(stageBytes + 0x120) = 0;
                     }
 
-                    *reinterpret_cast<unsigned int*>(stageBytes + 0x108) = static_cast<unsigned int>(-1);
+                    stage->m_defaultParam = static_cast<unsigned int>(-1);
                     return stage;
                 }
                 list = next;
@@ -1079,7 +1079,7 @@ void* CMemory::CStage::alloc(unsigned long size, char* source, unsigned long lin
                         static_cast<unsigned char>(
                             *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&Memory) + 0x779C) << 4);
                     *reinterpret_cast<unsigned long*>(node + 0x14) =
-                        *reinterpret_cast<unsigned long*>(reinterpret_cast<unsigned char*>(this) + 0x108);
+                        m_defaultParam;
                     *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x124) += 1;
                     *reinterpret_cast<CStage**>(node + 0x0C) = this;
                     break;
@@ -2327,7 +2327,7 @@ void CMemory::CStage::heapInfo(unsigned long& heapTotal, unsigned long& heapUse,
     int top;
     int node;
 
-    if (m_unknown11C == 2) {
+    if (m_allocationMode == 2) {
         node = stageGetHeapHead(this);
     } else {
         node = *reinterpret_cast<int*>(stageGetHeapHead(this) + 8);
@@ -2337,7 +2337,7 @@ void CMemory::CStage::heapInfo(unsigned long& heapTotal, unsigned long& heapUse,
     heapUse = 0;
     heapUnuse = 0;
 
-    if (m_unknown11C == 2) {
+    if (m_allocationMode == 2) {
         top = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 8);
 
         for (i = 0; i <= *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(this) + 0x120); i++, node += 0x40) {


### PR DESCRIPTION
## Summary
- move recovered CStage allocation mode to offset 0x11c while preserving heap head/tail at 0x110/0x114
- use the recovered default param field at 0x128 in CreateStage and alloc
- update heapInfo to use the corrected allocation mode member

## Objdiff evidence
Compared with `build/tools/objdiff-cli diff -p . -u main/memory -o - CreateStage__7CMemoryFUlPci` before/after:
- `CreateStage__7CMemoryFUlPci`: 82.300000% -> 82.313330%
- `DestroyStage__7CMemoryFPQ27CMemory6CStage`: 72.896000% -> 72.904000%
- `GetHeapUnuse__Q27CMemory6CStageFv`: 81.318184% -> 81.363640%
- `Quit__7CMemoryFv`: 38.287235% -> 38.291490%
- `alloc__Q27CMemory6CStageFUlPcUli`: 77.847330% -> 77.854965%
- `drawHeapBar__Q27CMemory6CStageFi`: 24.687500% -> 24.698530%
- `drawHeapTitle__Q27CMemory6CStageFi`: 93.707070% -> 93.717170%
- `heapWalker__Q27CMemory6CStageFiPvUl`: 67.155660% -> 67.160380%

## Plausibility
This is a layout correction rather than compiler coaxing: target code stores allocation mode at 0x11c and default param at 0x128, and existing heap metadata still uses 0x110/0x114/0x120/0x124.

## Verification
- `ninja`