### PR TITLE
Use CameraPcs fields in YmMana

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -42,27 +42,27 @@ extern const float FLOAT_80330ec0 = 255.0f;
 
 static inline float CameraWorldX()
 {
-    return *reinterpret_cast<float*>(reinterpret_cast<u8*>(&CameraPcs) + 0xE0);
+    return CameraPcs._224_4_;
 }
 
 static inline float CameraWorldY()
 {
-    return *reinterpret_cast<float*>(reinterpret_cast<u8*>(&CameraPcs) + 0xE4);
+    return CameraPcs._228_4_;
 }
 
 static inline float CameraWorldZ()
 {
-    return *reinterpret_cast<float*>(reinterpret_cast<u8*>(&CameraPcs) + 0xE8);
+    return CameraPcs._232_4_;
 }
 
 static inline Mtx& CameraMatrix()
 {
-    return *reinterpret_cast<Mtx*>(reinterpret_cast<u8*>(&CameraPcs) + 0x4);
+    return CameraPcs.m_cameraMatrix;
 }
 
 static inline Mtx44& CameraScreenMatrix()
 {
-    return *reinterpret_cast<Mtx44*>(reinterpret_cast<u8*>(&CameraPcs) + 0x94);
+    return CameraPcs.m_screenMatrix;
 }
 
 struct Vec2d {


### PR DESCRIPTION
## Summary
- Replace raw CameraPcs byte-offset helpers in pppYmMana with recovered CCameraPcs member access.
- Keeps generated code and objdiff scores unchanged while making the source layout more coherent.

## Evidence
- ninja
- objdiff main/pppYmMana unchanged for checked targets:
  - Mana_BeforeDrawCallback: 68.94118%
  - CalcReflectionVector2: 73.63928%
  - UpdateWaterMesh: 75.69835%
  - CalculateNormal: 92.781456%
  - CalcWaterReflectionVector: 96.52571%

## Plausibility
- p_camera.h already defines these CameraPcs fields at the same offsets.
- pppMana2 already uses the same typed camera access pattern, so this removes hard-coded offsets without compiler coaxing.