### PR TITLE
Improve astar portal loop matching

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -172,8 +172,8 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 	CAPos* behindBest = (CAPos*)0;
 	CAPos* aheadBest = (CAPos*)0;
 	float aheadBestDist = behindBestDist;
-	int i = 0;
 	CAPos* portal = m_portals;
+	int i = 0;
 
 	do
 	{

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -1089,14 +1089,14 @@ void CAStar::CATemp::operator= (const CAStar::CATemp& other)
 void CAStar::addAstar(float x, float y, float z, int groupA, int groupB)
 {
 	int groupLow = groupA;
+	int groupHigh = groupB;
 	Vec* pos = reinterpret_cast<Vec*>(&CVector(x, y, z));
 
 	if (groupB < groupA)
 	{
 		groupLow = groupB;
-		groupB = groupA;
+		groupHigh = groupA;
 	}
-	groupA = groupLow;
 
 	int index = 0;
 
@@ -1104,7 +1104,7 @@ void CAStar::addAstar(float x, float y, float z, int groupA, int groupB)
 	{
 		CAPos& p = m_portals[index];
 
-		if (p.m_groupA == groupA && p.m_groupB == groupB)
+		if (p.m_groupA == groupLow && p.m_groupB == groupHigh)
 		{
 			break;
 		}
@@ -1136,8 +1136,8 @@ void CAStar::addAstar(float x, float y, float z, int groupA, int groupB)
 	portal.m_position.x = pos->x;
 	portal.m_position.y = pos->y;
 	portal.m_position.z = pos->z;
-	m_portals[index].m_groupA = static_cast<unsigned char>(groupA);
-	m_portals[index].m_groupB = static_cast<unsigned char>(groupB);
+	m_portals[index].m_groupA = static_cast<unsigned char>(groupLow);
+	m_portals[index].m_groupB = static_cast<unsigned char>(groupHigh);
 }
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- keep explicit low/high portal group variables in `CAStar::addAstar`
- move the `getEscapePos` portal pointer declaration ahead of the loop counter to match the target loop shape better

## Objdiff evidence
- `addAstar__6CAStarFfffii`: 95.32336% -> 98.83234%
- `getEscapePos__6CAStarFR3VecR3Vecii`: 87.57534% -> 87.712326%

## Plausibility
- preserves behavior while expressing stable portal endpoints and the portal iteration object more directly
- no hardcoded addresses, fake symbols, manual sections, constructors, destructors, vtables, or linkage hacks

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/astar -o - --format json`