### PR TITLE
Match CGItemObj DeleteOld

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -809,7 +809,7 @@ int CGItemObj::DeleteOld(int deleteMask, int maxDeleteCount, CFlatRuntime::CObje
 			if ((unsigned int)System.m_execParam >= 3U) {
 				Printf__7CSystemFPce(&System, const_cast<char*>(DAT_801dced4));
 			}
-			return deletedCount;
+			break;
 		}
 
 		deletedCount++;


### PR DESCRIPTION
## Summary
- Changed CGItemObj::DeleteOld to break to the shared return path when no delete candidate is found.
- This matches the Ghidra-observed control flow and avoids the duplicate return setup emitted by the early return.

## Evidence
- Before: DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject was 264 bytes at 98.30769%.
- After: DeleteOld__9CGItemObjFiiPQ212CFlatRuntime7CObjectPQ212CFlatRuntime7CObject is 260 bytes at 100.0%.
- ninja passes; report gained one matched function and 260 matched code bytes.

## Plausibility
- The source now uses a normal loop break and common function epilogue, matching the decompiled shape without fake symbols, address constants, or compiler-forcing hacks.