### PR TITLE
Improve maptexanim ref replacement

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -87,18 +87,19 @@ static inline void* TextureAt(CTextureSet* textureSet, unsigned long index)
 
 static inline void ReplaceRef(void** slot, void* ref)
 {
-    int* current = reinterpret_cast<int*>(*slot);
+    CRef* current = reinterpret_cast<CRef*>(*slot);
     if (current != 0) {
-        int refCount = current[1] - 1;
-        current[1] = refCount;
-        if ((refCount == 0) && (current != 0)) {
-            (*reinterpret_cast<void (**)(int*, int)>(*current + 8))(current, 1);
+        int* refCountPtr = reinterpret_cast<int*>(Ptr(current, 4));
+        int refCount = *refCountPtr - 1;
+        *refCountPtr = refCount;
+        if (refCount == 0) {
+            delete current;
         }
         *slot = 0;
     }
 
     *slot = ref;
-    *reinterpret_cast<int*>(Ptr(ref, 4)) = *reinterpret_cast<int*>(Ptr(ref, 4)) + 1;
+    reinterpret_cast<CRef*>(ref)->AddRef();
 }
 
 static inline void SetMaterialTextureSlot(void* material, unsigned long slotIndex, void* texture)


### PR DESCRIPTION
## Summary
- Replace the manual integer/vtable ref release in maptexanim with CRef* handling and compiler-generated virtual delete.
- Use CRef::AddRef() for the replacement texture ref increment.

## Objdiff evidence
- main/maptexanim CMapTexAnim::Calc: 99.59893% -> 99.73262%.
- Remaining mismatches reduced from 30 to 20 diff instructions in the focused symbol diff.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/maptexanim -o /tmp/maptexanim.pr.json --format json Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet