### PR TITLE
Use shared PPP ctrl table for particle callbacks

### DIFF
--- a/include/ffcc/pppCrystal2.h
+++ b/include/ffcc/pppCrystal2.h
@@ -40,11 +40,6 @@ struct pppCrystal2UnkB {
     f32 m_perspectiveScale;
 };
 
-struct pppCrystal2UnkC {
-    u8 _pad0[0xC];
-    s32* m_serializedDataOffsets;
-};
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -52,10 +47,10 @@ extern "C" {
 void ImageBufferSetPixel_IA8(HSD_ImageBuffer*, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long);
 void MakeRefractionMap(HSD_ImageBuffer*);
 
-void pppConstructCrystal2(pppCrystal2* crystal, pppCrystal2UnkC* param_2);
-void pppDestructCrystal2(pppCrystal2* crystal, pppCrystal2UnkC* param_2);
-void pppFrameCrystal2(pppCrystal2* crystal, pppCrystal2UnkB* param_2, pppCrystal2UnkC* param_3);
-void pppRenderCrystal2(pppCrystal2* crystal, pppCrystal2UnkB* param_2, pppCrystal2UnkC* param_3);
+void pppConstructCrystal2(pppCrystal2* crystal, _pppCtrlTable* param_2);
+void pppDestructCrystal2(pppCrystal2* crystal, _pppCtrlTable* param_2);
+void pppFrameCrystal2(pppCrystal2* crystal, pppCrystal2UnkB* param_2, _pppCtrlTable* param_3);
+void pppRenderCrystal2(pppCrystal2* crystal, pppCrystal2UnkB* param_2, _pppCtrlTable* param_3);
 
 #ifdef __cplusplus
 }

--- a/include/ffcc/pppKeShpTail2X.h
+++ b/include/ffcc/pppKeShpTail2X.h
@@ -11,16 +11,15 @@ struct pppKeShpTail2X
 };
 
 struct pppKeShpTail2XUnkB;
-struct pppKeShpTail2XUnkC;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void pppKeShpTail2X(struct pppKeShpTail2X*, struct pppKeShpTail2XUnkB*, struct pppKeShpTail2XUnkC*);
-void pppKeShpTail2XDraw(struct pppKeShpTail2X*, struct pppKeShpTail2XUnkB*, struct pppKeShpTail2XUnkC*);
-void pppKeShpTail2XCon(void*, void*);
-void pppKeShpTail2XDes(void*, void*);
+void pppKeShpTail2X(struct pppKeShpTail2X*, struct pppKeShpTail2XUnkB*, _pppCtrlTable*);
+void pppKeShpTail2XDraw(struct pppKeShpTail2X*, struct pppKeShpTail2XUnkB*, _pppCtrlTable*);
+void pppKeShpTail2XCon(void*, _pppCtrlTable*);
+void pppKeShpTail2XDes(void*, _pppCtrlTable*);
 
 #ifdef __cplusplus
 }

--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -111,9 +111,9 @@ static inline float Crystal2SqrtPositive(float value)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppRenderCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCrystal2UnkC* param_3)
+void pppRenderCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCtrlTable* param_3)
 {
-    s32* serializedDataOffsets = param_3->m_serializedDataOffsets;
+    int* serializedDataOffsets = param_3->m_serializedDataOffsets;
     s32 dataValIndex = param_2->m_dataValIndex;
     Crystal2Work* work = (Crystal2Work*)((u8*)pppCrystal2 + serializedDataOffsets[2] + 0x80);
     pppCrystal2ColorBlock* colorBlock = (pppCrystal2ColorBlock*)((u8*)pppCrystal2 + serializedDataOffsets[1] + 0x80);
@@ -224,7 +224,7 @@ void pppRenderCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCr
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCrystal2UnkC* param_3)
+void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCtrlTable* param_3)
 {
     u32 x;
     u32 y;
@@ -316,7 +316,7 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, pppCry
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppDestructCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkC* param_2)
+void pppDestructCrystal2(pppCrystal2* pppCrystal2, _pppCtrlTable* param_2)
 {
     u32* puVar1;
     CMemory::CStage* stage;
@@ -348,7 +348,7 @@ void pppDestructCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkC* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppConstructCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkC* param_2)
+void pppConstructCrystal2(pppCrystal2* pppCrystal2, _pppCtrlTable* param_2)
 {
     s32 iVar1 = param_2->m_serializedDataOffsets[2];
     u32* data = (u32*)((char*)pppCrystal2 + iVar1 + 0x80);

--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -50,11 +50,6 @@ struct KeShpTail2XStep {
     float m_envDepth;
 };
 
-struct KeShpTail2XOffsets {
-    u8 _pad0[0xc];
-    s32* m_serializedDataOffsets;
-};
-
 struct KeShpTail2XShapeFrame {
     s16 m_shapeOffset;
     s16 m_duration;
@@ -88,10 +83,9 @@ inline void U8ToF32(pppFVECTOR4* dest, u8* src)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail2XDes(void* obj, void* param_2)
+void pppKeShpTail2XDes(void* obj, _pppCtrlTable* param_2)
 {
-    KeShpTail2XOffsets* offsets = (KeShpTail2XOffsets*)param_2;
-    KeShpTail2XWork* work = (KeShpTail2XWork*)((u8*)obj + offsets->m_serializedDataOffsets[0] + 0x80);
+    KeShpTail2XWork* work = (KeShpTail2XWork*)((u8*)obj + param_2->m_serializedDataOffsets[0] + 0x80);
 
     work->m_frameAcc = 0;
     work->m_shapeFrame = 0;
@@ -110,10 +104,9 @@ void pppKeShpTail2XDes(void* obj, void* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail2XCon(void* obj, void* param_2)
+void pppKeShpTail2XCon(void* obj, _pppCtrlTable* param_2)
 {
-    KeShpTail2XOffsets* offsets = (KeShpTail2XOffsets*)param_2;
-    KeShpTail2XWork* work = (KeShpTail2XWork*)((u8*)obj + offsets->m_serializedDataOffsets[0] + 0x80);
+    KeShpTail2XWork* work = (KeShpTail2XWork*)((u8*)obj + param_2->m_serializedDataOffsets[0] + 0x80);
 
     work->m_frameAcc = 0;
     work->m_shapeFrame = 0;
@@ -132,10 +125,9 @@ void pppKeShpTail2XCon(void* obj, void* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2, pppKeShpTail2XUnkC* param_3)
+void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2, _pppCtrlTable* param_3)
 {
     KeShpTail2XStep* step = (KeShpTail2XStep*)param_2;
-    KeShpTail2XOffsets* offsets = (KeShpTail2XOffsets*)param_3;
     KeShpTail2XWork* work;
     long** shapeTable;
     long* shapeEntry;
@@ -186,7 +178,7 @@ void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2,
 
     count = step->m_drawCount;
     invCountMinusOne = (float)(count - 1);
-    alphaMul = (float)*(s16*)((u8*)obj + 0x86 + offsets->m_serializedDataOffsets[1]) / kPppKeShpTail2XAlphaScale;
+    alphaMul = (float)*(s16*)((u8*)obj + 0x86 + param_3->m_serializedDataOffsets[1]) / kPppKeShpTail2XAlphaScale;
     colorR = step->m_colorStartR;
     colorG = step->m_colorStartG;
     colorB = step->m_colorStartB;
@@ -203,7 +195,7 @@ void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2,
         colorStepA = FLOAT_80330508;
     }
 
-    work = (KeShpTail2XWork*)((u8*)obj + 0x80 + offsets->m_serializedDataOffsets[0]);
+    work = (KeShpTail2XWork*)((u8*)obj + 0x80 + param_3->m_serializedDataOffsets[0]);
     shapeTable = *(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + dataValIndex * 4);
     shapeEntry = (long*)((u8*)*shapeTable + *(s16*)((u8*)*shapeTable + (work->m_shapePrevFrame << 3) + 0x10));
 
@@ -352,7 +344,7 @@ move_next_segment:
  * JP Address: TODO
  * JP Size: TODO
  */
-void pppKeShpTail2X(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2, pppKeShpTail2XUnkC* param_3)
+void pppKeShpTail2X(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2, _pppCtrlTable* param_3)
 {
     KeShpTail2XStep* step;
     KeShpTail2XWork* work;
@@ -366,7 +358,7 @@ void pppKeShpTail2X(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2, ppp
     }
 
     step = (KeShpTail2XStep*)param_2;
-    work = (KeShpTail2XWork*)((u8*)obj + ((KeShpTail2XOffsets*)param_3)->m_serializedDataOffsets[0] + 0x80);
+    work = (KeShpTail2XWork*)((u8*)obj + param_3->m_serializedDataOffsets[0] + 0x80);
 
     if (obj->pppPObject.m_graphId == 0) {
         if (step->m_worldSpaceMode == 0) {


### PR DESCRIPTION
## Summary
- replace local Crystal2 and KeShpTail2X ctrl-table wrapper types with the shared `_pppCtrlTable`
- update callback declarations/definitions to match the PPP function table ABI
- remove duplicated serialized-offset struct definitions while preserving generated code

## Evidence
- `ninja`
- `python3 tools/objdiff_experiment.py -u main/pppCrystal2 pppRenderCrystal2 pppFrameCrystal2 pppDestructCrystal2 pppConstructCrystal2 --limit 12`: no section or symbol score changes
- `python3 tools/objdiff_experiment.py -u main/pppKeShpTail2X pppKeShpTail2XDes pppKeShpTail2XCon pppKeShpTail2XDraw pppKeShpTail2X --limit 12`: no section or symbol score changes

## Plausibility
These callbacks are registered through `pppfunctbl.h`, whose operation/render/construct/destruct callback typedefs use `_pppCtrlTable*`. The removed local structs only duplicated `_pppCtrlTable::m_serializedDataOffsets` at offset 0xC, so using the shared type is a more accurate source declaration without compiler coaxing.