### PR TITLE
Clean p_usb data symbols

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -9,17 +9,14 @@
 extern const char lbl_801DA074[];
 int s_usbReadPollFrameCounter;
 char s_usbReadPollInitialized;
-char s_usbReadPollPadding0;
-char s_usbReadPollPadding1;
-char s_usbReadPollPadding2;
 extern "C" void create__7CUSBPcsFv(CUSBPcs*);
 extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 extern const char s_CUSBPcs_8032f810[] = "CUSBPcs";
-static unsigned int m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
-static unsigned int m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
-static unsigned int m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
+extern "C" unsigned int m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+extern "C" unsigned int m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+extern "C" unsigned int m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 unsigned int m_table__7CUSBPcs[0x11C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CUSBPcs_8032f810)),
     0,


### PR DESCRIPTION
## Summary
- give the CUSBPcs table descriptor objects C linkage so they emit as the configured global data symbols
- remove named sbss padding globals and let the compiler/object layout leave the anonymous gap

## Evidence
- ninja passes
- p_usb objdiff remains stable: __sinit_p_usb_cpp 73.454544%, .text 96.46061%, .data 95.94072%, sbss/sdata/sdata2 100%
- symbol table now exposes m_table_desc0__7CUSBPcs, m_table_desc1__7CUSBPcs, and m_table_desc2__7CUSBPcs as global .data objects, matching config/GCCP01/symbols.txt

## Plausibility
This removes artificial padding names and aligns the table descriptor linkage with the shipped symbol names without adding manual vtable, ctor, dtor, or sinit code.