### PR TITLE
Fix p_tina sbss symbol order

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -141,12 +141,6 @@ static const char DAT_801d81d4[] = {
     (char)0x82, (char)0xDC, (char)0x82, (char)0xB7, (char)0x81, (char)0x42, (char)0x0A, (char)0x00,
     (char)0x00, (char)0x00, (char)0x00, (char)0x00,
 };
-extern "C" {
-const char* g_MaxDataSize;
-signed char g_MaxHeapSize[4];
-int lbl_8032ED48;
-signed char lbl_8032ED4C;
-}
 unsigned int CPartPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__8CPartPcsFv)};
 unsigned int CPartPcs::m_table_desc1[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__8CPartPcsFv)};
 unsigned int CPartPcs::m_table_desc2[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__8CPartPcsFv)};
@@ -197,6 +191,12 @@ char g_MsgFlashy[0x36] =
     "\x81\x9A\x81\x99\x0A";
 int DAT_8032ed38;
 int DAT_8032ed3c;
+extern "C" {
+const char* g_MaxDataSize;
+signed char g_MaxHeapSize[4];
+int lbl_8032ED48;
+signed char lbl_8032ED4C;
+}
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Move the p_tina .sbss definitions for g_MaxDataSize, g_MaxHeapSize, lbl_8032ED48, and lbl_8032ED4C after DAT_8032ed38/DAT_8032ed3c.
- This makes the compiled .sbss symbol order match the target layout while keeping section match percentages unchanged.

## Evidence
- Built with: `ninja`
- Diffed with: `build/tools/objdiff-cli diff -p . -u main/p_tina -o -`
- Final section matches for main/p_tina remain:
  - .text: 93.71578%
  - .data: 96.73827%
  - .bss: 95.833336%
  - .sbss: 100.0%

Compiled .sbss order after the change:
```
00000000 DAT_8032ed38
00000004 DAT_8032ed3c
00000008 g_MaxDataSize
0000000c g_MaxHeapSize
00000010 lbl_8032ED48
00000014 lbl_8032ED4C
```

## Plausibility
This is a source-level data layout correction: the definitions are still normal C/C++ globals, just placed in the order needed for the original object layout. No manual sections, address hacks, or fake symbols were added.