### PR TITLE
Expose USB process table descriptors

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -6,6 +6,9 @@
 #include "ffcc/usb.h"
 
 extern unsigned int m_table__7CUSBPcs[];
+extern unsigned int m_table_desc0__7CUSBPcs[];
+extern unsigned int m_table_desc1__7CUSBPcs[];
+extern unsigned int m_table_desc2__7CUSBPcs[];
 
 class CUSBPcs : public CProcess
 {

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -17,9 +17,9 @@ extern "C" void destroy__7CUSBPcsFv(CUSBPcs*);
 extern "C" void func__7CUSBPcsFv(CUSBPcs*);
 
 extern const char s_CUSBPcs_8032f810[] = "CUSBPcs";
-static unsigned int m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
-static unsigned int m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
-static unsigned int m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
+unsigned int m_table_desc0__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CUSBPcsFv)};
+unsigned int m_table_desc1__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
+unsigned int m_table_desc2__7CUSBPcs[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 unsigned int m_table__7CUSBPcs[0x11C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CUSBPcs_8032f810)),
     0,


### PR DESCRIPTION
## Summary
- expose the CUSBPcs process table descriptor arrays instead of keeping them TU-local
- add matching p_usb header declarations alongside m_table__7CUSBPcs
- align the source linkage with the PAL symbol ownership for m_table_desc0/1/2__7CUSBPcs

## Evidence
- ninja builds cleanly
- objdiff is byte-identical for main/p_usb: __sinit_p_usb_cpp remains 73.454544%, .data remains 95.94072%

## Plausibility
These descriptor arrays follow the same externally visible process-table pattern used by neighboring process units such as p_graphic and p_map, and config/GCCP01/symbols.txt lists the CUSBPcs descriptors as real .data symbols rather than local-scope data.