### PR TITLE
Improve menu list and map animation matches

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -298,8 +298,8 @@ void CMapAnimNode::Interp(int frame)
             out->y = keys[0].value.y;
             out->z = keys[0].value.z;
         } else {
-            CMapAnimNodeTrackKey* current = keys;
             unsigned int i = 0;
+            CMapAnimNodeTrackKey* current = keys;
             unsigned int keyCount = static_cast<unsigned int>(trackCount);
 
             for (; i < keyCount; i++) {

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -243,8 +243,8 @@ int CMenuPcs::MLstClose()
 			entry++;
 		}
 	}
-	zero = FLOAT_803333D0;
 	if (this->lstData->count == completedItems) {
+		zero = FLOAT_803333D0;
 		entry = this->lstData->entries;
 		if ((int)itemCount > 0) {
 			count = itemCount >> 3;
@@ -374,11 +374,11 @@ void CMenuPcs::MLstCtrl()
 		}
 	}
 
-	one = FLOAT_803333F0;
 	if (!blocked) {
 		return;
 	}
 
+	one = FLOAT_803333F0;
 	MenuLstEntry* entry = this->lstData->entries;
 	for (i = 0; (itemCount = (unsigned int)this->lstData->count), i < (int)itemCount; i++) {
 		entry->alpha = one;
@@ -482,8 +482,8 @@ int CMenuPcs::MLstOpen()
 		}
 	}
 
-	one = FLOAT_803333F0;
 	if (this->lstData->count == completedItems) {
+		one = FLOAT_803333F0;
 		entry = this->lstData->entries;
 		if ((int)itemCount > 0) {
 			count = itemCount >> 3;


### PR DESCRIPTION
## Summary
- Move `menu_lst` alpha constant loads into the branches where they are used, improving `MLstClose`, `MLstCtrl`, and `MLstOpen` codegen.
- Reorder the position-track locals in `CMapAnimNode::Interp` to better match the original register allocation.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/mapanim -o /tmp/mapanim_pr.json --format json Interp__12CMapAnimNodeFi`
  - `main/mapanim .text`: 99.792656% -> 99.8282%
  - `Interp__12CMapAnimNodeFi`: 99.29719% -> 99.41767%
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst_pr.json --format json`
  - `main/menu_lst .text`: 80.743385% -> 81.22095%
  - `MLstClose__8CMenuPcsFv`: 83.037384% -> 83.130844%
  - `MLstCtrl__8CMenuPcsFv`: 78.15695% -> 79.92825%
  - `MLstOpen__8CMenuPcsFv`: 84.69444% -> 84.75%

## Plausibility
- The changes only move local declarations/constant loads closer to their use sites.
- No asm, fake symbols, manual section forcing, or behavior-changing hacks were introduced.
