### PR TITLE
Improve font DrawInit z mode flags

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -409,14 +409,14 @@ void CFont::DrawInit()
 
     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 4, 5, 1);
 
-    int zCompareFlag = renderFlagBits.zCompare;
-    int zUpdateFlag = renderFlagBits.zUpdate;
+    signed char zCompareFlag = renderFlagBits.zCompare;
     int zFunction = 7;
     int zUpdate = (zCompareFlag != 0) ? 1 : 0;
+    signed char zUpdateFlag = renderFlagBits.zUpdate;
     if (zUpdateFlag != 0) {
         zFunction = 3;
     }
-    int zEnable = (zCompareFlag != 0 || zUpdateFlag != 0) ? 1 : 0;
+    signed char zEnable = (zCompareFlag != 0 || zUpdateFlag != 0) ? 1 : 0;
     GXSetZMode(zEnable, (GXCompare)zFunction, zUpdate);
 
     _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(6, 1, 0, 7, 0);


### PR DESCRIPTION
## Summary
- Use signed-byte locals for CFont::DrawInit z-compare/z-update flag handling
- Reorder z-update flag extraction to match the target codegen more closely

## Evidence
- ninja passes
- fontman DrawInit before: 98.09896% match, size 760
- fontman DrawInit after: 99.97396% match, size 768
- Remaining DrawInit diff is a single generated double-constant relocation label: @370 vs DOUBLE_803306D0
- Build progress increased from 576116 to 576884 matched code bytes and 3418 to 3419 matched functions

## Plausibility
The change keeps the existing CFontRenderFlagBits model and makes the local temporaries match the signed-byte nature of the render flag bitfields instead of widening them too early.