### PR TITLE
Improve CAStar path cost matching

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -712,7 +712,8 @@ void CAStar::check(int startGroup, int goalGroup, CATemp& temp)
 				path1[14] = reinterpret_cast<unsigned int*>(temp.m_path)[14];
 				path1[15] = reinterpret_cast<unsigned int*>(temp.m_path)[15];
 
-				float cost1 = temp.m_cost + PSVECDistance(&pos0->m_position, &m_portals[other0].m_position);
+				double dist1 = PSVECDistance(&pos0->m_position, &m_portals[other0].m_position);
+				float cost1 = temp.m_cost + dist1;
 				path1Bytes[pathLen1] = static_cast<unsigned char>(idx0);
 				++pathLen1;
 				visited1Bytes[other0] = 1;


### PR DESCRIPTION
## Summary
- preserve the first CAStar path distance as a double before storing back to float cost
- improves the emitted code for CAStar::check without changing pathfinding behavior

## Objdiff
- main/astar .text: 90.185% -> 90.28694%
- check__6CAStarFiiRQ26CAStar6CATemp: 80.49084% -> 80.85336%
- size unchanged: 1964 bytes

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/astar -o /tmp/astar_final.json --format json check__6CAStarFiiRQ26CAStar6CATemp

## Plausibility
The target Ghidra decompilation carries the distance through a double-like temporary before converting back to the path cost float. This change reflects that source shape directly and avoids address, section, or symbol hacks.