### PR TITLE
Fix ME_AppRequest filename symbol linkage

### DIFF
--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -9,7 +9,7 @@ void __dla__FPv(void*);
 void* memset(void*, int, unsigned int);
 }
 
-static const char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
+extern const char s_ME_AppRequest_cpp_801d7da8[] = "ME_AppRequest.cpp";
 
 struct ZCANMGRP {
     void* ptr;


### PR DESCRIPTION
## Summary
- Give s_ME_AppRequest_cpp_801d7da8 external linkage so the compiled symbol binding matches the target object.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/ME_AppRequest -o - shows s_ME_AppRequest_cpp_801d7da8 at size 18, 100.0% match, flags 1 on both target and rebuilt object.
- ResetRsdList__18CMaterialEditorPcsFP5ZLIST remains 99.24051% at size 316; the remaining mismatch is unchanged.

## Plausibility
- Other source-file filename constants in this codebase are commonly emitted as externally linked symbols when referenced by allocation/debug helpers.
- This removes an unnecessary local-linkage mismatch without changing code generation.