### PR TITLE
Match CCameraPcs SetViewerSRT

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -911,8 +911,9 @@ void CCameraPcs::SetViewerSRT(const SRT* srt)
 {
     u32* dst = reinterpret_cast<u32*>(reinterpret_cast<u8*>(this) + 0x448);
     const u32* src = reinterpret_cast<const u32*>(srt);
-    u32 value1 = src[1];
+    u32 value1;
     u32 value0 = *src++;
+    value1 = *src;
     dst[0] = value0;
     u32 value2 = src[1];
     dst[1] = value1;


### PR DESCRIPTION
## Summary
- Adjusts the staged copy in `CCameraPcs::SetViewerSRT` so MWCC emits the target load order for the first two SRT words.
- Matches `SetViewerSRT__10CCameraPcsFPC3SRT` exactly.

## Evidence
- Before: `SetViewerSRT__10CCameraPcsFPC3SRT` was 99.42857% matched (84b).
- After: `SetViewerSRT__10CCameraPcsFPC3SRT` is 100.0% matched (84b).
- `ninja` passes; report shows matched game code increased by 84 bytes and matched functions increased by 1.

## Plausibility
- Keeps the existing word-copy structure and only separates declaration/assignment of `value1` to preserve source-like staged loads.
- No fake symbols, hardcoded addresses, section forcing, or linkage hacks.