### PR TITLE
Improve astar path cost matching

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -712,7 +712,8 @@ void CAStar::check(int startGroup, int goalGroup, CATemp& temp)
 				path1[14] = reinterpret_cast<unsigned int*>(temp.m_path)[14];
 				path1[15] = reinterpret_cast<unsigned int*>(temp.m_path)[15];
 
-				float cost1 = temp.m_cost + PSVECDistance(&pos0->m_position, &m_portals[other0].m_position);
+				double dist1 = PSVECDistance(&pos0->m_position, &m_portals[other0].m_position);
+				float cost1 = temp.m_cost + dist1;
 				path1Bytes[pathLen1] = static_cast<unsigned char>(idx0);
 				++pathLen1;
 				visited1Bytes[other0] = 1;


### PR DESCRIPTION
## Summary
- Promote the first CAStar::check path distance through a double before truncating back to float.
- Matches the Ghidra-observed cost calculation shape more closely and improves the compiled astar unit.

## Objdiff Evidence
- main/astar .text: 90.1850% -> 90.28694%
- check__6CAStarFiiRQ26CAStar6CATemp: 80.49084% -> 80.85336% (1964b)

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/astar -o -