### PR TITLE
Improve chara anim interp data pointer setup

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -475,9 +475,10 @@ void CChara::CAnimNode::Interp(CChara::CAnim* anim, SRT* srt, float frame)
 	}
 
 	register int flags = static_cast<int>((m_flags >> 0xD) & 0x3FFFF);
+	register unsigned int dataOffset = m_dataOffset;
 	frameInt *= 2;
 	register unsigned short* inData =
-	    reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(anim->m_bank) + m_dataOffset);
+	    reinterpret_cast<unsigned short*>(dataOffset + reinterpret_cast<unsigned int>(anim->m_bank));
 	register float* outData = reinterpret_cast<float*>(srt);
 
 	for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
## Summary
- Adjust CChara::CAnimNode::Interp to materialize the node data offset before adding the animation bank pointer.
- This matches the target load order more closely while preserving the same data address calculation.

## Evidence
- Before: Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf 99.2303% match, 660b.
- After: Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf 99.30303% match, 660b.
- ninja completes successfully.

## Plausibility
- The change keeps the original source-level operation explicit: data offset plus animation bank base.
- No hardcoded addresses, fake labels, or section forcing were added.