### PR TITLE
Remove stray menu mode definition from wind

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -14,20 +14,6 @@
 
 CWind Wind;
 
-/*
- * --INFO--
- * PAL Address: TODO
- * PAL Size: 8b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-int CMenuPcs::GetMenuMode()
-{
-    return m_mode;
-}
-
 extern int __float_nan[];
 extern "C" double cos(double);
 extern "C" double sin(double);
@@ -446,7 +432,7 @@ void CWind::Calc(Vec* out, const Vec* pos, int randomize)
     out->y = zero;
     out->x = zero;
 
-    if ((MenuPcs.GetMenuMode() == 2) || (Game.m_gameWork.m_gamePaused != 0)) {
+    if ((MenuPcs.m_mode == 2) || (Game.m_gameWork.m_gamePaused != 0)) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- remove the local CMenuPcs::GetMenuMode definition from wind.cpp
- have CWind::Calc read MenuPcs.m_mode directly instead of carrying a wrong-unit accessor definition

## Evidence
- ninja
- build/tools/objdiff-cli diff -p . -u main/wind -o -
  - .text remains 97.041%
  - extabindex remains 97.61904%
  - Calc__5CWindFP3VecPC3Veci remains 100.0%

## Plausibility
This removes a temporary linkage crutch from the wind unit. CMenuPcs already exposes m_mode in the header, and wind.cpp should not define menu methods.