### PR TITLE
Define maptexanim sdata2 constants

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -41,6 +41,8 @@ char s_SetMapTexAnim_MaterialIdNotFound[];
 extern "C" float FLOAT_8032fd38;
 extern "C" float FLOAT_8032fd48;
 extern "C" float FLOAT_8032fd4c;
+extern "C" const double DOUBLE_8032FCD0 = 4503601774854144.0;
+extern "C" const float FLOAT_8032FCD8 = 0.0f;
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)


### PR DESCRIPTION
## Summary
- Defines the DOUBLE_8032FCD0 and FLOAT_8032FCD8 sdata2 constants for src/maptexanim.cpp using the names already present in config/GCCP01/symbols.txt.
- This turns the target-owned .sdata2 data for main/maptexanim into a full match.

## Evidence
- ninja passes.
- Before: objdiff for main/maptexanim reported .sdata2 at 85.71429% with target size 12 and current size 16.
- After: objdiff reports .sdata2 at 100.0% with target size 12. Code remains unchanged: .text is still 99.842636%, and Calc__11CMapTexAnimFP12CMaterialSetP11CTextureSet remains 99.73262%.

## Plausibility
- The added symbols are not invented names; both constants are already attributed to this unit in config/GCCP01/symbols.txt.
- This is data/linkage cleanup rather than control-flow coaxing. The compiler still emits later anonymous conversion constants, but the known target-owned constants now exist with their expected values.
