### PR TITLE
Improve CRingMenu DrawIcon z clamp

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -1077,9 +1077,7 @@ void CRingMenu::DrawIcon()
 	viewPos.y = worldPos.y;
 	viewPos.z = worldPos.z;
 	PSMTXMultVec(cameraMtx, &viewPos, &viewPos);
-	if (FLOAT_803309c8 < viewPos.z) {
-		viewPos.z = FLOAT_803309c8;
-	}
+	viewPos.z = (FLOAT_803309c8 < viewPos.z) ? FLOAT_803309c8 : viewPos.z;
 
 	Mtx44 screenMtx;
 	PSMTX44Copy(CameraPcs.m_screenMatrix, screenMtx);


### PR DESCRIPTION
## Summary
- rewrites the DrawIcon camera-space z clamp as an equivalent ternary expression
- this matches the original code shape a bit more closely without changing behavior

## Evidence
- ninja: passes
- objdiff DrawIcon__9CRingMenuFv before: 62.9049% match, 252 diffs
- objdiff DrawIcon__9CRingMenuFv after: 63.6513% match, 251 diffs

## Plausibility
- the expression is a normal source-level clamp of view-space z to FLOAT_803309c8
- no hardcoded addresses, fake symbols, or linkage hacks