### PR TITLE
Improve pppKeShpTail2X color setup

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -143,6 +143,9 @@ void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2,
     float colorStepB;
     float colorStepA;
     float invCountMinusOne;
+    pppFVECTOR4 colorStart;
+    pppFVECTOR4 colorEnd;
+    pppFVECTOR4 colorStep;
     pppFMATRIX localBase;
     pppFMATRIX drawMtx;
     Vec zeroVec ATTRIBUTE_ALIGN(8);
@@ -179,21 +182,29 @@ void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2,
     count = step->m_drawCount;
     invCountMinusOne = (float)(count - 1);
     alphaMul = (float)*(s16*)((u8*)obj + 0x86 + param_3->m_serializedDataOffsets[1]) / kPppKeShpTail2XAlphaScale;
-    colorR = step->m_colorStartR;
-    colorG = step->m_colorStartG;
-    colorB = step->m_colorStartB;
-    colorA = (float)step->m_colorStartA * alphaMul;
+    U8ToF32(&colorStart, &step->m_colorStartR);
+    U8ToF32(&colorEnd, &step->m_colorEndR);
+    colorStart.w *= alphaMul;
+    colorEnd.w *= alphaMul;
+    colorR = colorStart.x;
+    colorG = colorStart.y;
+    colorB = colorStart.z;
+    colorA = colorStart.w;
     if (invCountMinusOne != zero) {
-        colorStepR = (colorR - (float)step->m_colorEndR) / invCountMinusOne;
-        colorStepG = (colorG - (float)step->m_colorEndG) / invCountMinusOne;
-        colorStepB = (colorB - (float)step->m_colorEndB) / invCountMinusOne;
-        colorStepA = (colorA - ((float)step->m_colorEndA * alphaMul)) / invCountMinusOne;
+        colorStep.x = (colorStart.x - colorEnd.x) / invCountMinusOne;
+        colorStep.y = (colorStart.y - colorEnd.y) / invCountMinusOne;
+        colorStep.z = (colorStart.z - colorEnd.z) / invCountMinusOne;
+        colorStep.w = (colorStart.w - colorEnd.w) / invCountMinusOne;
     } else {
-        colorStepR = FLOAT_80330508;
-        colorStepG = FLOAT_80330508;
-        colorStepB = FLOAT_80330508;
-        colorStepA = FLOAT_80330508;
+        colorStep.x = FLOAT_80330508;
+        colorStep.y = FLOAT_80330508;
+        colorStep.z = FLOAT_80330508;
+        colorStep.w = FLOAT_80330508;
     }
+    colorStepR = colorStep.x;
+    colorStepG = colorStep.y;
+    colorStepB = colorStep.z;
+    colorStepA = colorStep.w;
 
     work = (KeShpTail2XWork*)((u8*)obj + 0x80 + param_3->m_serializedDataOffsets[0]);
     shapeTable = *(long***)(*(u32*)&pppEnvStPtr->m_particleColors[0] + dataValIndex * 4);


### PR DESCRIPTION
## Summary
- Use the existing U8ToF32 helper to materialize pppKeShpTail2X start/end color vectors.
- Derive per-segment color deltas from those vector values before copying into the existing scalar draw loop state.

## Objdiff evidence
- main/pppKeShpTail2X .text: 86.05668% -> 87.69366%
- pppKeShpTail2XDraw: 76.98886% -> 79.69042%
- pppKeShpTail2X, pppKeShpTail2XCon, pppKeShpTail2XDes remain 100.0%
- .sdata2 remains 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppKeShpTail2X -o /tmp/pppKeShpTail2X.pr.json

## Plausibility
The file already had an unused U8ToF32 helper for converting packed u8 color channels into pppFVECTOR4 values. This change uses that helper for the tail color endpoints, which matches the target's heavier vector-backed color setup while leaving the matched frame/constructor/destructor functions untouched.