### PR TITLE
Fix material editor texture wrap check

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -419,7 +419,7 @@ extern "C" void SetUSBData__18CMaterialEditorPcsFv(CMaterialEditorPcs* materialE
         while ((heightFactor & 1) == 0) {
             heightFactor >>= 1;
         }
-        if ((heightFactor != 1) || (heightFactor != 1)) {
+        if ((widthFactor != 1) || (heightFactor != 1)) {
             isPowerOfTwo = GX_FALSE;
         }
 


### PR DESCRIPTION
## Summary
- Fix the material editor texture wrap/power-of-two check to test both width and height factors.
- This keeps the texture setup logic plausible and removes a duplicated height check in SetUSBData.

## Evidence
- ninja
- objdiff main/ME_USB_process SetUSBData__18CMaterialEditorPcsFv improved from 63.24582% to 63.307693%.
- main/ME_USB_process .text improved from 63.610928% to 63.672184%.