### PR TITLE
Match YmMegaBirthShpTail2 calc frame wrap

### DIFF
--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -435,11 +435,13 @@ extern "C" void calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTa
     frameEntry = colorTable + (u32)frameIndex * 8 + 0x10;
     *(u16*)(color + 0x1c) =
         *(u16*)(color + 0x1c) + *reinterpret_cast<s32*>((u8*)pYmMegaBirthShpTail2->m_matrix[0] + 8);
-    if ((int)*(u16*)(color + 0x1c) < *(s16*)(frameEntry + 2)) {
+    int elapsedFrame = *(u16*)(color + 0x1c);
+    int frameDuration = *(s16*)(frameEntry + 2);
+    if ((int)elapsedFrame < frameDuration) {
         return;
     }
 
-    *(u16*)(color + 0x1c) = *(u16*)(color + 0x1c) - *(s16*)(frameEntry + 2);
+    *(u16*)(color + 0x1c) = (u16)(elapsedFrame - frameDuration);
     *(u16*)(color + 0x1e) = *(u16*)(color + 0x1e) + 1;
     if ((int)*(u16*)(color + 0x1e) >= *(s16*)(colorTable + 6)) {
         if ((*(u8*)(frameEntry + 4) & 0x80) != 0) {


### PR DESCRIPTION
## Summary
- Splits the YmMegaBirthShpTail2 calc frame wrap into explicit elapsed-frame and frame-duration locals.
- This matches the compiler's source shape for the animation frame carry and completes the calc function in the generated report.

## Evidence
- ninja succeeds.
- report: main/pppYmMegaBirthShpTail2 fuzzy 57.5385, matched_code 1020, matched_functions 3/6.
- report: calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR is 100.0% matched, size 772.
- objdiff-cli: .text match 57.484547; calc reports 99.84456 in CLI output.

## Plausibility
- Keeps the same behavior while naming the two values the original source likely kept live: elapsed frame accumulator and current frame duration.
- No section forcing, address hacks, or fake symbols.