### PR TITLE
Improve util display list polygon decoding

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -86,16 +86,16 @@ void CUtil::GetDirectVector(Vec* param_2, Vec* param_3, Vec param_4)
 int CUtil::GetNumPolygonFromDL(void* dlData, unsigned long)
 {
     u8* data = static_cast<u8*>(dlData);
-    bool running = true;
+    int running = true;
     int polygonCount = 0;
 
     while (running) {
-        u8 opcode = *data;
+        u32 opcode = *data;
         u16 vertexCount = *(u16*)(data + 1);
         int count = vertexCount;
-        u8 vertexFormat = opcode & 7;
-        u8 primitive = opcode & 0xF8;
-        bool isPrimitive;
+        u32 vertexFormat = opcode & 7;
+        u32 primitive = opcode & 0xF8;
+        int isPrimitive;
 
         data += 3;
 


### PR DESCRIPTION
## Summary
- Recover wider integer locals for display-list opcode decoding in CUtil::GetNumPolygonFromDL.
- Keep primitive, vertex format, and loop predicates closer to the target codegen.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/util -o /tmp/util_final.json GetNumPolygonFromDL__5CUtilFPvUl
- GetNumPolygonFromDL__5CUtilFPvUl: 87.96296% -> 89.69136%.
- main/util .text: 94.42374% -> 94.47153%.

## Plausibility
The change preserves behavior while replacing byte/bool temporaries with word-sized decoded fields and integer predicates, matching how the target function carries those values through its primitive switch and loop control.