### PR TITLE
Match material editor color literal data

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -578,8 +578,10 @@ void CMaterialEditorPcs::drawViewer()
         _GXSetAlphaCompare__F10_GXCompareUc10_GXAlphaOp10_GXCompareUc(7, 0, 0, 7, 0);
         GXSetZMode(GX_TRUE, GX_LEQUAL, GX_TRUE);
 
-        GXColor ambColor = {0xff, 0xff, 0xff, 0xff};
-        GXColor matColor = ambColor;
+        GXColor ambColor;
+        *reinterpret_cast<u32*>(&ambColor) = kMaterialEditorDefaultColorRgba;
+        GXColor matColor;
+        *reinterpret_cast<u32*>(&matColor) = kMaterialEditorDefaultColorRgba;
         GXSetChanAmbColor(GX_COLOR0, ambColor);
         GXSetChanMatColor(GX_COLOR0, matColor);
 
@@ -703,8 +705,16 @@ void CMaterialEditorPcs::drawViewer()
                     }
 
                     if ((textureHeader[1] == 4) || (textureHeader[1] == 8)) {
-                        GXColor red = {0xff, 0xff, 0, 0};
-                        GXColor blue = {0, 0, 0xff, 0xff};
+                        GXColor red;
+                        GXColor blue;
+                        red.r = 0xff;
+                        red.g = 0xff;
+                        red.b = 0;
+                        red.a = 0;
+                        blue.r = 0;
+                        blue.g = 0;
+                        blue.b = 0xff;
+                        blue.a = 0xff;
 
                         GXSetNumTevStages(3);
                         GXSetNumTexGens(1);


### PR DESCRIPTION
## Summary
- Initialize material editor viewer colors without generating extra anonymous `.sdata2` literals.
- Use the existing default RGBA constant for white channel colors and assign palette debug colors by component.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - drawViewer__18CMaterialEditorPcsFv`
- `.sdata2`: 62.068962% -> 100.0%, current size now matches the 40-byte target section.
- `drawViewer__18CMaterialEditorPcsFv`: 69.039116% -> 68.391136%; current function size moves from 2964 bytes to 2988 bytes against the 3068-byte target.
- `.text`: 79.86161% -> 79.49181%.

## Plausibility
The change removes compiler-emitted aggregate color literals from the material editor unit and keeps the color setup as ordinary source-level GXColor initialization. The small code-score regression is accepted here because the data section now matches and the drawViewer body size moves closer to target.