### PR TITLE
Make CPad Frame virtual

### DIFF
--- a/include/ffcc/pad.h
+++ b/include/ffcc/pad.h
@@ -57,7 +57,7 @@ public:
 
     void Init();
     void Quit();
-    void Frame();
+    virtual void Frame();
     unsigned short GetButtonDown(long);
     PadInput* GetPadInputs() { return reinterpret_cast<PadInput*>(&_4_2_); }
     const PadInput* GetPadInputs() const { return reinterpret_cast<const PadInput*>(&_4_2_); }


### PR DESCRIPTION
## Summary
- Mark CPad::Frame() as virtual so the compiler emits the expected extra CPad vtable slot.
- This brings the generated __vt__4CPad size in pad.o to 0x14, matching config/GCCP01/symbols.txt.

## Evidence
- ninja succeeds.
- objdump -t build/GCCP01/src/pad.o now reports __vt__4CPad as size 00000014.
- build/tools/objdiff-cli diff -p . -u main/pad -o - Frame__4CPadFv keeps Frame__4CPadFv at 93.87764%; this is a data/layout declaration fix, not a text-code score change.

## Plausibility
- CPad::Frame() is a normal per-frame manager entry point, and the PAL symbol data expects a larger CPad vtable than the current non-virtual declaration generated.