### PR TITLE
Match CLightPcs EnableLight

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -599,12 +599,10 @@ void CLightPcs::EnableLight(int param_1, int param_2)
         light_mask = 0;
     }
 
-    GXSetChanCtrl((GXChannelID)0, (u8)(((unsigned int)(-enabled | enabled)) >> 0x1f), (GXColorSrc)0,
-                  (GXColorSrc)(__cntlzw((unsigned int)colorSrcParam) >> 5), light_mask, (GXDiffuseFn)2,
-                  (GXAttnFn)1);
-    GXSetChanCtrl((GXChannelID)2, (u8)(((unsigned int)(-enabled | enabled)) >> 0x1f), (GXColorSrc)0,
-                  (GXColorSrc)(__cntlzw((unsigned int)colorSrcParam) >> 5), 0, (GXDiffuseFn)0,
-                  (GXAttnFn)2);
+    GXSetChanCtrl((GXChannelID)0, enabled ? GX_TRUE : GX_FALSE, (GXColorSrc)0,
+                  colorSrcParam ? GX_SRC_REG : GX_SRC_VTX, light_mask, (GXDiffuseFn)2, (GXAttnFn)1);
+    GXSetChanCtrl((GXChannelID)2, enabled ? GX_TRUE : GX_FALSE, (GXColorSrc)0,
+                  colorSrcParam ? GX_SRC_REG : GX_SRC_VTX, 0, (GXDiffuseFn)0, (GXAttnFn)2);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rewrites CLightPcs::EnableLight to use normal boolean/source enum arguments instead of manual bit-twiddling for GXSetChanCtrl parameters.
- This makes the source more plausible and matches the shipped function output.

## Evidence
- objdiff: EnableLight__9CLightPcsFii improved from 72.710526% to 100.0%.
- Function size remains 152 bytes.
- Full ninja build succeeds.
- Build report: matched code increased from 578488 to 578640 bytes; matched functions increased from 3423 to 3424.

## Plausibility
- The resulting source expresses the intended GX enable and color-source choices directly with ternaries and SDK enum values.
- No section forcing, address hacks, fake symbols, or manual compiler artifacts were added.