### PR TITLE
Improve astar escape position local layout

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -149,15 +149,19 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 }
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
+ * PAL Address: 0x80141820
+ * PAL Size: 584b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
  */
 CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int forbiddenGroup)
 {
+	Vec escapeDir;
 	CVector baseVec(base);
 	CVector fromVec(from);
 	CVector escapeDirSource;
-	Vec escapeDir;
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&fromVec),
 	              reinterpret_cast<Vec*>(&baseVec),


### PR DESCRIPTION
## Summary
- Move the scratch escape direction Vec before the constructed CVector locals in CAStar::getEscapePos to better match the original stack/code layout.
- Fill in the PAL address/size metadata for getEscapePos.

## Evidence
- ninja passes.
- objdiff main/astar getEscapePos__6CAStarFR3VecR3Vecii: 87.712326% -> 87.753426%.
- astar .text: 90.28694% -> 90.290375%.

## Plausibility
- This is a local declaration-order cleanup for an existing scratch vector, not a manual asm or linkage hack. The behavior is unchanged and the function metadata now matches the known PAL symbol.