### PR TITLE
Match pppYmLaser data layout

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -120,7 +120,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	u32 count;
+	s32 count;
 	s32 i;
 	u8 alphaStep;
 	char alphaMax;


### PR DESCRIPTION
## Summary
- Treat the local YmLaser point count as signed in `pppRenderYmLaser` so the generated constants/layout line up with the target unit.
- This removes the extra conversion data and brings the unit data/extabindex layout into line.

## Evidence
- `ninja` succeeds.
- `main/pppYmLaser` data improves from 104/152 bytes (68.42%) to 152/152 bytes (100.00%).
- `main/pppYmLaser` extabindex improves from 97.91667% to 100.00%.
- `pppRenderYmLaser` compiled size now matches the target size: 3008 bytes.

## Tradeoff
- `pppRenderYmLaser` fuzzy score moves slightly down while data/linkage improves; this change is source-plausible because the point count is byte-sized and used as a small signed loop/count value.