### PR TITLE
Improve CLightPcs init constant reuse

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -113,15 +113,18 @@ void CLightPcs::Init()
     m_mapLightColor[0].b = 0x3F;
     m_mapLightColor[0].a = 0xFF;
 
+    float lightParam = FLOAT_8032fc14;
+    float lightRange = FLOAT_8032fc2c;
+
     for (int i = 0; i < 3; i++) {
         unsigned char color = (i == 0) ? 0x3F : 0;
         m_mapLightColor[i + 1].r = color;
         m_mapLightColor[i + 1].g = color;
         m_mapLightColor[i + 1].b = color;
         m_mapLightColor[i + 1].a = 0xFF;
-        m_mapLightParams[i * 3 + 0] = FLOAT_8032fc14;
-        m_mapLightParams[i * 3 + 1] = FLOAT_8032fc14;
-        m_mapLightParams[i * 3 + 2] = FLOAT_8032fc2c;
+        m_mapLightParams[i * 3 + 0] = lightParam;
+        m_mapLightParams[i * 3 + 1] = lightParam;
+        m_mapLightParams[i * 3 + 2] = lightRange;
     }
 }
 


### PR DESCRIPTION
## Summary
- Hoist the repeated `CLightPcs::Init` map-light float constants into locals before the initialization loop.
- This matches the target's reuse of the two constants across the unrolled stores and avoids repeated source-level constant loads.

## Evidence
- `ninja` passes for GCCP01.
- `build/tools/objdiff-cli diff -p . -u main/p_light -o /tmp/p_light_pr_diff.json Init__9CLightPcsFv`
- `Init__9CLightPcsFv`: 73.56% -> 87.40% match.

## Plausibility
- The change is ordinary source: two loop-invariant constants are named once and reused for the three map-light parameter triplets.
- No address hacks, fake symbols, manual section placement, or generated constructor/destructor code.
