### PR TITLE
Clarify pppShape texture cache stride

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -119,7 +119,7 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     short shapeOffset;
     unsigned char* shapeEntry;
     int shapeIndex;
-    int shapeStep;
+    unsigned int shapeStep;
     char* currentFrame;
     int frameIndex;
     unsigned char* texturePtr;
@@ -136,7 +136,7 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
         shapeOffset = *(short*)((int)currentFrame + 0x10);
         shapeBase = animData + shapeOffset;
         shapeIndex = 0;
-        shapeStep = shapeIndex;
+        shapeStep = 0;
         while (shapeIndex < *(short*)(shapeBase + 2)) {
             shapeEntry = (unsigned char*)(shapeBase + 8);
             shapeEntry += shapeStep;
@@ -172,7 +172,7 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
     short shapeOffset;
     unsigned char* shapeEntry;
     int shapeIndex;
-    int shapeStep;
+    unsigned int shapeStep;
     char* currentFrame;
     int frameIndex;
     unsigned char* texturePtr;
@@ -189,7 +189,7 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
         shapeOffset = *(short*)((int)currentFrame + 0x10);
         shapeBase = animData + shapeOffset;
         shapeIndex = 0;
-        shapeStep = shapeIndex;
+        shapeStep = 0;
         while (shapeIndex < *(short*)(shapeBase + 2)) {
             shapeEntry = (unsigned char*)(shapeBase + 8);
             shapeEntry += shapeStep;


### PR DESCRIPTION
## Summary
- Treat the pppShape texture cache byte stride as an unsigned stride in both dump/load walkers.
- Initialize the stride independently from the shape index instead of deriving it from the index's zero value.

## Evidence
- `ninja`: passes, `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/pppShape -o /tmp/pppshape_final.json --format json pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`
  - `pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet`: 240 bytes, 99.0% match.
  - `pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet`: 240 bytes, 99.0% match.

## Plausibility
- The loop has separate concepts for shape index and byte stride; the stride is nonnegative and advances by 8 bytes per shape entry.
- This makes the recovered source closer to the Ghidra loop shape without introducing temporary hacks or changing behavior.