### PR TITLE
Match CSound SetReverb

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -2274,8 +2274,9 @@ void CSound::Add3DLine(int lineIndex, Vec* position)
  */
 void CSound::SetReverb(int reverb, int depth)
 {
-    RedSound(this)->SetReverb(1, reverb);
-    RedSound(this)->SetReverbDepth(1, depth, 0xF);
+    u8* soundObj = reinterpret_cast<u8*>(this);
+    reinterpret_cast<CRedSound*>(soundObj + 8)->SetReverb(1, reverb);
+    reinterpret_cast<CRedSound*>(soundObj + 8)->SetReverbDepth(1, depth, 0xF);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reshape CSound::SetReverb to keep the CSound object pointer live and recompute the CRedSound subobject for each call
- Matches the PAL SetReverb function without changing behavior

## Evidence
- ninja passes
- objdiff: SetReverb__6CSoundFii improved from 91.304344% to 100.0%
- build report matched function count increased by 1 (3427 -> 3428)