### PR TITLE
Improve pppKeShpTail2X draw traversal

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -317,11 +317,10 @@ update_step:
 advance_segment:
     if (nextIndex == lastIndex) {
         nextIndex = 0;
-        goto wrapped_segment;
+    } else {
+        nextIndex++;
     }
-    nextIndex++;
-wrapped_segment:
-    if (nextIndex == work->m_head) {
+    if (nextIndex == curIndex) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Preserve the initial tail head index when checking for ring-buffer wrap termination in `pppKeShpTail2XDraw`.
- Simplify the segment-advance branch so the compiler keeps the saved head value live, matching the target shape more closely.

## Objdiff Evidence
- Unit: `main/pppKeShpTail2X`
- Symbol: `pppKeShpTail2XDraw`
- Before: 80.358574% match, 1776-byte current symbol, 384 instruction diffs
- After: 81.017815% match, 1772-byte current symbol, 349 instruction diffs
- Target size: 1796 bytes

## Validation
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail2X -o /tmp/ppp_tail_final.json pppKeShpTail2XDraw`

## Plausibility
The code already saved `curIndex = work->m_head`; the wrap termination should compare against that original ring-buffer head rather than rereading the mutable work field. This is normal source-level ring traversal logic and removes an unnecessary goto without introducing compiler-coaxing hacks.