### PR TITLE
Improve menu artifact animation matching

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -515,12 +515,16 @@ void CMenuPcs::ArtiDraw()
  */
 int CMenuPcs::ArtiClose()
 {
-	int finished = 0;
-	GetArtiState(this)[0x11]++;
+	int count;
+	int finished;
+	int frame;
 
-	int count = GetArtiList(this)[0];
+	GetArtiState(this)[0x11]++;
+	finished = 0;
+
+	count = GetArtiList(this)[0];
 	ArtiOpenAnim* anim = (ArtiOpenAnim*)((u8*)GetArtiList(this) + 8);
-	int frame = GetArtiState(this)[0x11];
+	frame = GetArtiState(this)[0x11];
 
 	for (int i = 0; i < count; i++, anim++) {
 		float zeroF = FLOAT_80332fa8;
@@ -586,16 +590,16 @@ int CMenuPcs::ArtiCtrl()
  */
 int CMenuPcs::ArtiOpen()
 {
-	int finished;
 	int count;
+	int finished;
 	int frame;
 
 	if (*(char*)(GetArtiStateBase(this) + 0xb) == '\0') {
 		ArtiInit();
 	}
 
-	finished = 0;
 	*(short*)(GetArtiStateBase(this) + 0x22) = *(short*)(GetArtiStateBase(this) + 0x22) + 1;
+	finished = 0;
 	count = *GetArtiList(this);
 	ArtiOpenAnim* entry = (ArtiOpenAnim*)((u8*)GetArtiList(this) + 8);
 	frame = (int)*(short*)(GetArtiStateBase(this) + 0x22);


### PR DESCRIPTION
## Summary
- Reshape local variable initialization in menu artifact open/close animation paths
- Keeps the frame increment before initializing the finished counter, matching the target codegen more closely

## Objdiff
Unit: main/menu_arti
- ArtiClose__8CMenuPcsFv: 95.55789% -> 96.505264%
- ArtiOpen__8CMenuPcsFv: 97.25% -> 97.43519%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o -