### PR TITLE
Improve material texture lookup

### DIFF
--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -148,7 +148,7 @@ public:
     void Create(CChunkFile&, CTextureSet*, CMaterialMan::TEV_BIT, CLightPcs::CBumpLight*);
     void SetTextureSet(CTextureSet*);
     void Calc();
-    unsigned short FindTexName(char*, long*);
+    unsigned int FindTexName(char*, long*);
     void CacheLoadTexture(int, CAmemCacheSet*);
     void CacheUnLoadTexture(int, CAmemCacheSet*);
     void CacheRefCnt0UpTexture(int, CAmemCacheSet*);

--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -29,7 +29,7 @@ void SetMaterial__12CMaterialManFP12CMaterialSetii11_GXTevScale(void* materialMa
 void SetMaterialPart__12CMaterialManFP12CMaterialSetii(void* materialMan, CMaterialSet* materialSet,
                                                         unsigned int materialIdx, int partIdx);
 void SetMaterialCharaShadow__12CMaterialManFP9CMaterial(void* materialMan, void* material);
-unsigned short FindTexName__12CMaterialSetFPcPl(CMaterialSet* materialSet, char* textureName, long* outIndex);
+unsigned int FindTexName__12CMaterialSetFPcPl(CMaterialSet* materialSet, char* textureName, long* outIndex);
 void CacheLoadTexture__12CMaterialSetFiP13CAmemCacheSet(CMaterialSet* materialSet, unsigned int materialIdx,
                                                          CAmemCacheSet* cacheSet);
 void CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet(CMaterialSet* materialSet, unsigned int materialIdx,

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -3280,25 +3280,21 @@ void CMaterialSet::CacheLoadTexture(int materialIndex, CAmemCacheSet* amemCacheS
  * JP Address: TODO
  * JP Size: TODO
  */
-unsigned short CMaterialSet::FindTexName(char* textureName, long* textureIndexOut)
+unsigned int CMaterialSet::FindTexName(char* textureName, long* textureIndexOut)
 {
+    CPtrArray<CMaterial*>* materials = reinterpret_cast<CPtrArray<CMaterial*>*>(Ptr(this, 8));
     unsigned int materialIndex = 0;
 
-    while (true) {
-        if (UnkMaterialSetGetter(Ptr(this, 8)) <= materialIndex) {
-            return 0xFFFF;
-        }
-
-        CMaterial* material = (*reinterpret_cast<CPtrArray<CMaterial*>*>(Ptr(this, 8)))[materialIndex];
+    while (materialIndex < UnkMaterialSetGetter(materials)) {
+        CMaterial* material = (*materials)[materialIndex];
         if (material != 0) {
             CMaterial* textureSlot = material;
 
             for (int slot = 0; slot < static_cast<int>(static_cast<unsigned int>(*reinterpret_cast<unsigned short*>(Ptr(material, 0x18)))); slot++) {
                 if (CheckName__8CTextureFPc(*reinterpret_cast<CTexture**>(Ptr(textureSlot, 0x3C)), textureName)) {
-                    if (textureIndexOut == 0) {
-                        return materialIndex;
+                    if (textureIndexOut != 0) {
+                        *textureIndexOut = slot;
                     }
-                    *textureIndexOut = slot;
                     return materialIndex;
                 }
                 textureSlot = reinterpret_cast<CMaterial*>(Ptr(textureSlot, 4));
@@ -3306,6 +3302,8 @@ unsigned short CMaterialSet::FindTexName(char* textureName, long* textureIndexOu
         }
         materialIndex++;
     }
+
+    return 0xFFFF;
 }
 
 /*

--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -10,8 +10,8 @@ extern const float FLOAT_80330108;
 void pppSetBlendMode(unsigned char);
 
 extern "C" {
-    unsigned short FindTexName__12CMaterialSetFPcPl(CMaterialSet* materialSet, char* textureName,
-                                                     long* outIndex);
+    unsigned int FindTexName__12CMaterialSetFPcPl(CMaterialSet* materialSet, char* textureName,
+                                                  long* outIndex);
     void CacheLoadTexture__12CMaterialSetFiP13CAmemCacheSet(CMaterialSet* materialSet, unsigned int textureIndex,
                                                              void* amemCacheSet);
 }


### PR DESCRIPTION
## Summary
- Rework CMaterialSet::FindTexName to keep the material pointer table as the loop subject.
- Update the FindTexName return type/declarations to match the observed unsigned index return convention.
- Keep mapmesh and pppShape direct extern declarations consistent with the class declaration.

## Evidence
- ninja: passes, build/GCCP01/main.dol OK.
- FindTexName__12CMaterialSetFPcPl: 56.84% -> 75.93% objdiff match.
- Checked caller units: mapmesh SetDisplayListMaterial remains 100%; pppShape material setup remains 100%, cache texture functions remain 99%.

## Plausibility
- The loop now reads like original source over the material pointer array instead of repeatedly recomputing this + 8.
- The unsigned int return matches the target's material-index/0xFFFF return convention while preserving existing caller behavior.