### PR TITLE
Improve AmemFreeLowPrio comparison shape

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2084,7 +2084,7 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
         for (int i = 0; i < m_cacheCount; i++) {
             CAmemCache& entry = cacheEntryAt(this, i);
             if (entry.m_inUse != 0 && entry.m_refCount == 0 && entry.m_dmaCopy != 0 &&
-                entry.m_cacheData != 0 && currentSize <= entry.m_size &&
+                entry.m_cacheData != 0 && entry.m_size >= currentSize &&
                 static_cast<unsigned int>(entry.m_priority) < bestPriority) {
                 bestEntry = &entry;
                 bestPriority = static_cast<unsigned int>(entry.m_priority);


### PR DESCRIPTION
## Summary
- Reordered the cache-size comparison in CAmemCacheSet::AmemFreeLowPrio to match the target compare direction.
- Keeps behavior equivalent while making the generated code closer to PAL.

## Evidence
- ninja passes.
- AmemFreeLowPrio__13CAmemCacheSetFi improved from 61.976284% to 62.015812% in objdiff.
- The target comparison shape is now entry.m_size >= currentSize, matching the PAL cmpw entry size against current size / blt pattern.

## Plausibility
- This is normal source-level boolean expression ordering, not a vtable/RTTI/ctor/dtor hack or hardcoded address.