### PR TITLE
Improve menu list control matching

### DIFF
--- a/include/ffcc/itemobj.h
+++ b/include/ffcc/itemobj.h
@@ -31,10 +31,8 @@ public:
 	static int DeleteOld(int, int, CFlatRuntime::CObject*, CFlatRuntime::CObject*);
 	static unsigned int CanCreateFromScript();
 	static CGPrgObj* CreateFromScript(int, int, int, CGObject*, float, CGItemObj::CCFS*);
-	void safeDetach(int, float);
 	void carry(CGPartyObj*, int, int);
 	void onChangePrg(int);
-	void statPot();
 	void onFrameAlways();
 	void onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*);
 	void loadModel();

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -1003,16 +1003,6 @@ CGPrgObj* CGItemObj::CreateFromScript(
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGItemObj::safeDetach(int, float)
-{
-	// TODO
-}
-
-/*
- * --INFO--
  * PAL Address: 0x80125650
  * PAL Size: 916b
  * EN Address: TODO
@@ -1154,16 +1144,6 @@ void CGItemObj::carry(CGPartyObj* partyObj, int carryState, int carryMode)
  * JP Size: TODO
  */
 void CGItemObj::onChangePrg(int)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGItemObj::statPot()
 {
 	// TODO
 }

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -386,11 +386,10 @@ int CMenuPcs::MLstCtrl()
 
 		startFrame = 0;
 		duration = 4;
-		MenuLstEntry* closeEntry = &this->lstData->entries[this->lstData->count - 1];
 		for (int idx = this->lstData->count - 1; idx >= 0; idx--) {
+			MenuLstEntry* closeEntry = &this->lstData->entries[idx];
 			closeEntry->startFrame = startFrame++;
 			closeEntry->duration = duration;
-			closeEntry--;
 		}
 
 		this->lstState->frame = 0;


### PR DESCRIPTION
## Summary
- Changed MLstCtrl close-animation setup to index entries from lstData instead of walking a cached pointer backward, matching the target access pattern more closely.
- Removed unmapped CGItemObj TODO stubs (safeDetach/statPot) that are not present in PAL symbols.

## Evidence
- ninja passes.
- main/menu_lst unit fuzzy match: 85.1519% after this change (was 81.4% in the target selector before this run).
- MLstCtrl__8CMenuPcsFv: 95.0% match, size 892b (was 80.3% in the target selector before this run).

## Plausibility
- The MLstCtrl loop still expresses the same close-animation behavior, but uses direct indexed entry access consistent with Ghidra/target assembly.
- The itemobj cleanup removes declarations/definitions with no PAL address or symbol entry rather than adding fake linkage.