### PR TITLE
Improve pppYmLaser render matching

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -120,7 +120,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	s32 count;
+	u32 count;
 	s32 i;
 	u8 alphaStep;
 	char alphaMax;
@@ -134,7 +134,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	pppFMATRIX unitMtx;
 	Mtx shapeMtx;
 	Mtx rotateMtx;
-	Mtx debugMtx;
+	Mtx debugMtx ATTRIBUTE_ALIGN(8);
 	Mtx pointMtx;
 	Mtx sphereMtx;
 	pppFMATRIX managerMtx;


### PR DESCRIPTION
## Summary
- Treat the YM laser render point count as unsigned, matching the sibling laser render path and the payload byte semantics.
- Align the debug matrix local like `pppLaser` so the render stack layout better matches the target.

## Evidence
- Built with `ninja`.
- `pppRenderYmLaser`: 97.40426% -> 97.60506%.
- `main/pppYmLaser` `.text`: 98.25499% -> 98.381615%.

## Plausibility
- Both changes mirror established `pppLaser` source structure rather than adding output-forcing hacks.
- No manual section placement, fake symbols, or address hardcoding.