### PR TITLE
Improve CGraphicPcs table init order

### DIFF
--- a/include/ffcc/p_graphic.h
+++ b/include/ffcc/p_graphic.h
@@ -68,6 +68,10 @@ public:
     CGraphicPcs()
     {
         u32* table = &m_table__11CGraphicPcs[1];
+        table[31] = m_table_desc7__11CGraphicPcs[0];
+        table[32] = m_table_desc7__11CGraphicPcs[1];
+        table[36] = m_table_desc8__11CGraphicPcs[0];
+        table[37] = m_table_desc8__11CGraphicPcs[1];
         table[0] = m_table_desc0__11CGraphicPcs[0];
         table[1] = m_table_desc0__11CGraphicPcs[1];
         table[2] = m_table_desc0__11CGraphicPcs[2];
@@ -89,11 +93,7 @@ public:
         table[26] = m_table_desc6__11CGraphicPcs[0];
         table[27] = m_table_desc6__11CGraphicPcs[1];
         table[28] = m_table_desc6__11CGraphicPcs[2];
-        table[31] = m_table_desc7__11CGraphicPcs[0];
-        table[32] = m_table_desc7__11CGraphicPcs[1];
         table[33] = m_table_desc7__11CGraphicPcs[2];
-        table[36] = m_table_desc8__11CGraphicPcs[0];
-        table[37] = m_table_desc8__11CGraphicPcs[1];
         table[38] = m_table_desc8__11CGraphicPcs[2];
         table[41] = m_table_desc9__11CGraphicPcs[0];
         table[42] = m_table_desc9__11CGraphicPcs[1];


### PR DESCRIPTION
## Summary
- Reorder the CGraphicPcs constructor table writes to better match the generated static initializer order.
- Keeps the existing process table contents unchanged; this only changes assignment order in normal C++ source.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_graphic -o -`
  - `.text`: 65.92407% -> 66.11448%
  - `__sinit_p_graphic_cpp`: 44.556602% -> 49.122643%
  - `.data`: unchanged at 93.90756%
  - `m_table__11CGraphicPcs`: remains 100.0%

## Plausibility
- The change reflects the observed constructor/static-initializer store order without adding fake symbols, manual vtables, address constants, or padding.
