### PR TITLE
Improve map semi-trans found flag matching

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3301,7 +3301,7 @@ void CMapMng::SetIdGrpColor(int mapIdGrpIndex, int channelIndex, _GXColor color)
 void CMapMng::SetMeshCameraSemiTransRange(unsigned short id, float nearRange, float farRange, float minAlpha,
                                           float maxAlpha, float fadeRange)
 {
-    bool found = false;
+    int found = 0;
     unsigned char* mapObj = reinterpret_cast<unsigned char*>(this);
 
     for (int i = 0; i < *reinterpret_cast<short*>(Ptr(this, 0xC)); i++) {
@@ -3318,7 +3318,7 @@ void CMapMng::SetMeshCameraSemiTransRange(unsigned short id, float nearRange, fl
                 *reinterpret_cast<unsigned char*>(mapObj + 0x97A) = 1;
             }
             *reinterpret_cast<short*>(mapObj + 0x97E) = 0x4000;
-            found = true;
+            found = 1;
             *reinterpret_cast<short*>(mapObj + 0x97C) = 0x4000;
             *reinterpret_cast<short*>(mapObj + 0x980) = 0;
         }
@@ -3352,13 +3352,13 @@ void CMapMng::SetMeshCameraSemiTransRange(unsigned short id, float nearRange, fl
  */
 void CMapMng::SetMeshCameraSemiTransAlpha(unsigned short id, int alpha, int frameCount)
 {
-    bool found = false;
+    int found = 0;
     unsigned char* mapObj = reinterpret_cast<unsigned char*>(this);
 
     for (int i = 0; i < *reinterpret_cast<short*>(Ptr(this, 0xC)); i++) {
         if (*reinterpret_cast<unsigned short*>(mapObj + 0x988) == id) {
             *reinterpret_cast<short*>(mapObj + 0x97E) = static_cast<short>(alpha << 7);
-            found = true;
+            found = 1;
             *reinterpret_cast<short*>(mapObj + 0x980) = static_cast<short>(
                 (static_cast<int>(*reinterpret_cast<short*>(mapObj + 0x97E)) -
                  static_cast<int>(*reinterpret_cast<short*>(mapObj + 0x97C))) /


### PR DESCRIPTION
## Summary
- change the local found flags in CMapMng::SetMeshCameraSemiTransRange and CMapMng::SetMeshCameraSemiTransAlpha from bool to int
- matches the target signed compare shape more closely without changing behavior

## Objdiff evidence
- SetMeshCameraSemiTransRange__7CMapMngFUsfffff: 95.333336% -> 95.94444%
- SetMeshCameraSemiTransAlpha__7CMapMngFUsii: 94.861115% -> 95.625%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/map -o - SetMeshCameraSemiTransRange__7CMapMngFUsfffff
- build/tools/objdiff-cli diff -p . -u main/map -o - SetMeshCameraSemiTransAlpha__7CMapMngFUsii