### PR TITLE
Improve p_light constructor ordering

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1255,6 +1255,7 @@ CLightPcs::CLight::CLight()
     float f2 = FLOAT_8032fc14;
 
     m_radius = radius;
+    m_partMask = -1;
     float f1 = FLOAT_8032fc10;
     m_offsetZ = f2;
     m_offsetX = f2;
@@ -1263,7 +1264,6 @@ CLightPcs::CLight::CLight()
     m_spotFn = 0;
     m_unk4D = 4;
     m_specularMode = 0;
-    m_partMask = -1;
     m_part = 0;
     *(u32*)&m_targetColor[0] = 0;
     *(u32*)&m_targetColor[1] = 0;


### PR DESCRIPTION
## Summary
- Reordered the `CLightPcs::CLight` default `m_partMask` assignment earlier in the constructor.
- This is an ordinary independent member initialization reorder; no manual vtables, sections, or linkage hacks.

## Objdiff evidence
Command:
`build/tools/objdiff-cli diff -p . -u main/p_light -o - __ct__Q29CLightPcs10CBumpLightFv`

Before:
- `main/p_light` .text: 88.86569%
- `__ct__Q29CLightPcs6CLightFv`: 89.52381%
- `__ct__Q29CLightPcs10CBumpLightFv`: 85.652176%
- .data: 93.06551%

After:
- `main/p_light` .text: 88.94377%
- `__ct__Q29CLightPcs6CLightFv`: 84.42857%
- `__ct__Q29CLightPcs10CBumpLightFv`: 86.652176%
- .data: 93.06551%

Net result is a small .text improvement in `p_light`; the base light constructor moves farther away locally, while the bump-light constructor improves enough to raise the unit score.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_light -o - __ct__Q29CLightPcs10CBumpLightFv`