### PR TITLE
Use shared compa alpha constant

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -440,7 +440,7 @@ activeHold:
 		CompaOpenAnim* entry = compaList->entries;
 		while (entryCount != 0) {
 			entry->frame = 0;
-			entry->alpha = 1.0f;
+			entry->alpha = FLOAT_80333000;
 			entry++;
 			entryCount--;
 		}


### PR DESCRIPTION
## Summary
- Use the existing FLOAT_80333000 constant when resetting CompaCtrl entry alpha instead of emitting a literal 1.0f.
- Removes one generated local float constant from menu_compa's compiled data path.

## Evidence
- ninja: passes, build/GCCP01/main.dol OK.
- objdiff main/menu_compa:
  - .text: 65.1417% -> 65.1455%
  - CompaCtrl__8CMenuPcsFv: 77.0450% -> 77.0700%
  - [.sdata2-0]: 87.8049% -> 90.0000%

## Plausibility
- The file already uses FLOAT_80333000 as the shared 1.0f menu constant throughout CompaOpen, CompaInit, and drawing setup. This change makes the reset path use the same original-style constant instead of a fresh literal.