### PR TITLE
Improve chara cast time and ppp object layout

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -147,7 +147,12 @@ struct _pppPObject
     _pppPObjLink m_link;        // 0x0
     s32 m_graphId;              // 0xc
     pppFMATRIX m_localMatrix;   // 0x10 (size 0x30)
-    char m_pad40[0x80 - 0x40];  // 0x40
+    char m_pad40[0x70 - 0x40];  // 0x40
+    void* m_field70;            // 0x70
+    void* m_field74;            // 0x74
+    char m_pad78[0x7C - 0x78];  // 0x78
+    u8 m_field7C;               // 0x7C
+    char m_pad7D[0x80 - 0x7D];  // 0x7D
     u8 m_workArea[1];           // 0x80 - per-instance work block, indexed by _pppCtrlTable::m_serializedDataOffsets[N]
 };
 

--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -2607,86 +2607,73 @@ void CGCharaObj::onChangePrg(int arg)
  */
 int CGCharaObj::calcCastTime(int itemId)
 {
-	m_castTimeTick += 1;
-
-	if (m_scriptHandle == 0) {
-		return 0;
-	}
-
-	unsigned char* script = reinterpret_cast<unsigned char*>(m_scriptHandle);
-	unsigned char* script9 = (m_scriptHandle[9] != 0) ? reinterpret_cast<unsigned char*>(m_scriptHandle[9]) : 0;
 	unsigned int cid = GetCID();
 
-	if (CharaObjIsPlayerCid(cid) &&
+	if ((cid & 0x6D) == 0x6D &&
 		Game.m_gameWork.m_menuStageMode != 0 &&
 		Game.m_gameWork.m_bossArtifactStageIndex < 0xF &&
-		(cid & 0x6D) == 0x6D &&
-		*reinterpret_cast<int*>(script + 0x3B4) != 0) {
-		m_castFrameStart = 0;
-		m_castFrameEnd = 1;
-		m_castFrameCurrent = 1;
+		(GetCID() & 0x6D) == 0x6D &&
+		*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(m_scriptHandle) + 0x3B4) != 0) {
 		return 0;
 	}
 
 	int itemOffset = itemId * 0x48;
+	unsigned char* script = reinterpret_cast<unsigned char*>(m_scriptHandle);
+	unsigned char* script9 = reinterpret_cast<unsigned char*>(m_scriptHandle[9]);
 	unsigned char* itemData = reinterpret_cast<unsigned char*>(Game.unkCFlatData0[2]) + itemOffset;
 	unsigned short itemNo = *reinterpret_cast<unsigned short*>(itemData + 0x0);
-	unsigned short itemType = *reinterpret_cast<unsigned short*>(itemData + 0xE);
 	unsigned int baseCast = *reinterpret_cast<unsigned short*>(itemData + 0x2E);
-	unsigned int cast = baseCast;
+	unsigned short itemType = *reinterpret_cast<unsigned short*>(itemData + 0xE);
+	float castScale = 1.0f;
 
-	if (itemType == 2 || itemNo == 0x1F8) {
-		float castScale = 1.0f;
-		unsigned int castBonus = 0;
-		unsigned int castReduction = 0;
-
-		if (*reinterpret_cast<short*>(script + 0x4E) != 0) {
-			castScale = CharaObjGetStatusMultiplier(0x0);
-		} else if (*reinterpret_cast<short*>(script + 0x4C) != 0) {
-			castScale = CharaObjGetStatusMultiplier(0x2);
-		}
-
-		if (itemType == 2) {
-			if (script9 != 0) {
-				castBonus = *reinterpret_cast<unsigned short*>(script9 + 0x194);
-			}
-
-			if ((cid & 0xAD) == 0xAD && Game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
-				int stage = Game.m_gameWork.m_bossArtifactStageTable[Game.m_gameWork.m_bossArtifactStageIndex];
-				if (stage > 2) {
-					stage = 2;
-				}
-				if (stage > 0) {
-					castBonus -= *reinterpret_cast<unsigned short*>(Game.unk_flat3_field_8_0xc7dc + 0x58 + (stage * 2));
-					castBonus &= ~((int)castBonus >> 31);
-				}
-			}
-
-			if (CharaObjIsPlayerCid(cid)) {
-				castReduction = static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(script + 0xBD8));
-			}
-		} else if (itemNo == 0x1F8) {
-			if (script9 != 0) {
-				castBonus = *reinterpret_cast<unsigned short*>(script9 + 0x196);
-			}
-
-			if (CharaObjIsPlayerCid(cid)) {
-				castReduction = static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(script + 0xBD9));
-			}
-		}
-
-		int totalCast = static_cast<int>(baseCast + castBonus) - static_cast<int>(castReduction);
-		if (totalCast < 0) {
-			totalCast = 0;
-		}
-
-		cast = static_cast<unsigned int>(castScale * static_cast<float>(totalCast));
+	if (*reinterpret_cast<short*>(script + 0x4E) != 0) {
+		castScale = CharaObjGetStatusMultiplier(0x0);
+	} else if (*reinterpret_cast<short*>(script + 0x4C) != 0) {
+		castScale = CharaObjGetStatusMultiplier(0x2);
 	}
 
-	m_castFrameStart = static_cast<int>(cast);
-	m_castFrameEnd = static_cast<int>(cast) + 1;
-	m_castFrameCurrent = m_castFrameEnd;
-	return static_cast<int>(cast);
+	if (itemType != 2 || itemNo == 0x1F8) {
+		if (itemType == 3) {
+			System.Printf(sCharaObjDebugStatFormat + 0x38, baseCast);
+			return static_cast<int>(baseCast);
+		}
+		if (itemType == 4) {
+			System.Printf(sCharaObjDebugStatFormat + 0x4C, baseCast);
+			return static_cast<int>(baseCast);
+		}
+		if (itemNo == 0x1F8) {
+			unsigned int castBonus = *reinterpret_cast<unsigned short*>(script9 + 0x196);
+			unsigned int castReduction = (GetCID() & 0x6D) == 0x6D
+			                                 ? static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(script + 0xBD9))
+			                                 : 0;
+			int totalCast = static_cast<int>(baseCast + castBonus) - static_cast<int>(castReduction);
+			unsigned int cast = static_cast<unsigned int>(castScale * static_cast<float>(totalCast));
+			System.Printf(sCharaObjDebugStatFormat + 0x60, baseCast, castBonus);
+			return static_cast<int>(cast & ~(static_cast<int>(cast) >> 31));
+		}
+
+		return static_cast<int>(baseCast);
+	}
+
+	unsigned int castBonus = *reinterpret_cast<unsigned short*>(script9 + 0x194);
+	if ((GetCID() & 0xAD) == 0xAD && Game.m_gameWork.m_bossArtifactStageIndex < 0xF) {
+		int stage = Game.m_gameWork.m_bossArtifactStageTable[Game.m_gameWork.m_bossArtifactStageIndex];
+		if (stage > 2) {
+			stage = 2;
+		}
+		if (stage > 0) {
+			castBonus -= *reinterpret_cast<unsigned short*>(Game.unk_flat3_field_8_0xc7dc + 0x58 + (stage * 2));
+			castBonus &= ~((int)castBonus >> 31);
+		}
+	}
+
+	unsigned int castReduction = (GetCID() & 0x6D) == 0x6D
+	                                 ? static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(script + 0xBD8))
+	                                 : 0;
+	int totalCast = static_cast<int>(baseCast + castBonus) - static_cast<int>(castReduction);
+	unsigned int cast = static_cast<unsigned int>(castScale * static_cast<float>(totalCast));
+	System.Printf(sCharaObjDebugStatFormat + 0x10, baseCast, castBonus);
+	return static_cast<int>(cast & ~(static_cast<int>(cast) >> 31));
 }
 
 /*

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -750,17 +750,6 @@ void callConProg(_pppPObject*)
  */
 _pppPObject* pppCreatePObject(_pppMngSt* pppMngSt, _pppPDataVal* pppPDataVal)
 {
-	struct pppPObjectRaw
-	{
-		_pppPObjLink m_link;
-		s32 m_graphId;
-		u8 m_pad10[0x70 - 0x10];
-		void* m_field70;
-		void* m_field74;
-		u8 m_pad78[4];
-		u8 m_field7C;
-	};
-
 	_pppPDataVal* dataVal = pppPDataVal;
 	_pppProgSetDef* programSet = dataVal->m_programSetDef;
 	s16 numStages = programSet->m_numStages;
@@ -881,12 +870,12 @@ _pppPObject* pppCreatePObject(_pppMngSt* pppMngSt, _pppPDataVal* pppPDataVal)
 	}
 	else
 	{
-		pppPObjectRaw* newObjectRaw = (pppPObjectRaw*)newObj;
-		newObjectRaw->m_graphId = 0;
-		newObjectRaw->m_field70 = 0;
-		newObjectRaw->m_field74 = 0;
-		newObjectRaw->m_link.m_owner = pppPDataVal;
-		newObjectRaw->m_field7C = 1;
+		_pppPObject* newObject = (_pppPObject*)newObj;
+		newObject->m_graphId = 0;
+		newObject->m_field70 = 0;
+		newObject->m_field74 = 0;
+		newObject->m_link.m_owner = pppPDataVal;
+		newObject->m_field7C = 1;
 
 		_pppPObjLink* objHead = &pppMngSt->m_pppPObjLinkHead;
 		_pppPObjLink* firstObj = objHead->m_next;


### PR DESCRIPTION
## Summary
- Reworked CGCharaObj::calcCastTime toward the Ghidra/target shape: pure cast-time calculation, debug prints for cast categories, and no cast-frame state writes.
- Promoted _pppPObject fields at 0x70/0x74/0x7C into the shared layout and removed the local raw struct in pppCreatePObject.

## Evidence
- ninja passes.
- objdiff calcCastTime__10CGCharaObjFi: 26.950207% -> 39.149376%.
- objdiff pppCreatePObject__FP9_pppMngStP12_pppPDataVal remains 69.03571% while using real _pppPObject member access instead of a local offset-only struct.

## Plausibility
- calcCastTime now matches the target's pure calculation behavior and observed debug Printf calls instead of mutating unrelated frame fields.
- The ppp object fields were already being accessed at fixed offsets in pppCreatePObject; moving them into _pppPObject makes the layout explicit without forcing vtables, RTTI, or sections.