### PR TITLE
Match CGObject::SetClassWork

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2717,26 +2717,27 @@ void CGObject::SetClassWork(int ownerType, int workIndex)
     m_ownerType = (char)ownerType;
     m_classWorkIndex = (unsigned char)workIndex;
 
-    if (ownerType == 1) {
+    switch (ownerType) {
+    case 0: {
+        m_scriptHandle = reinterpret_cast<void**>(&Game.m_caravanWorkArr[Game.m_gameWork.m_wmBackupParams[workIndex]]);
+        m_scriptHandle[2] = reinterpret_cast<void*>(Game.m_gameWork.m_wmBackupParams[workIndex]);
+        m_scriptHandle[3] = this;
+        Game.m_scriptFoodBase[workIndex] = reinterpret_cast<u32>(m_scriptHandle);
+        return;
+    }
+
+    case 1:
         m_scriptHandle = reinterpret_cast<void**>(&Game.m_monWorkArr[workIndex]);
         m_scriptHandle[3] = this;
         m_scriptHandle[2] = reinterpret_cast<void*>(workIndex);
         Game.m_scriptWork[0][0][workIndex] = reinterpret_cast<u32>(this);
         Game.m_scriptWork[2][0][workIndex] = reinterpret_cast<u32>(m_scriptHandle);
         return;
-    }
 
-    if ((ownerType < 1) && (-1 < ownerType)) {
-        int backupIndex = Game.m_gameWork.m_wmBackupParams[workIndex];
-
-        m_scriptHandle = reinterpret_cast<void**>(&Game.m_caravanWorkArr[backupIndex]);
-        m_scriptHandle[2] = reinterpret_cast<void*>(backupIndex);
-        m_scriptHandle[3] = this;
-        Game.m_scriptFoodBase[workIndex] = reinterpret_cast<u32>(m_scriptHandle);
+    default:
+        m_scriptHandle = 0;
         return;
     }
-
-    m_scriptHandle = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rework CGObject::SetClassWork as a switch over owner type.
- Preserve the original behavior while matching the original case order for caravan, monster, and default script handles.

## Objdiff evidence
- main/gobject SetClassWork__8CGObjectFii: 54.583332% -> 100.0%
- Function size: 184 -> 192 bytes, matching target size
- Full build progress: matched functions 3432 -> 3433; matched code 580368 -> 580560 bytes

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/gobject -o - SetClassWork__8CGObjectFii