### PR TITLE
Improve fontman RTTI and constants

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -510,7 +510,7 @@ config.libs = [
             Object(Matching, "color.cpp"),
             Object(NonMatching, "file.cpp"),
             Object(Matching, "strcase.c"),
-            Object(NonMatching, "fontman.cpp"),
+            Object(NonMatching, "fontman.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "FS_USB_Process.cpp"),
             Object(NonMatching, "FunnyShape.cpp"),
             Object(NonMatching, "game.cpp"),

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -125,7 +125,7 @@ found_fallback_glyph:
 float CFont::GetWidth(char* text)
 {
 	char* textPtr = text;
-	float width = 0.0f;
+	float width = FLOAT_803306B8;
 	unsigned short ch;
 	int hasChar;
 
@@ -295,14 +295,14 @@ found_fallback:
 	posX += advance;
 
 	if (glyphInfo[0] == 0) {
-		u0 += 1.0f;
+		u0 += FLOAT_803306C8;
 	}
 	if (m_glyphWidth == glyphInfo[0] + glyphInfo[1]) {
-		u1 -= 1.0f;
+		u1 -= FLOAT_803306C8;
 	}
 
-	v0 += 1.0f;
-	v1 -= 1.0f;
+	v0 += FLOAT_803306C8;
+	v1 -= FLOAT_803306C8;
 
 	GXBegin(GX_QUADS, GX_VTXFMT0, 4);
 	GXPosition3f32(x0, y0, posZ);


### PR DESCRIPTION
## Summary
- Enable RTTI for fontman.cpp so compiler-generated vtable data gains the expected RTTI relocations.
- Replace local 0.0f/1.0f literals in font width/draw code with the existing shared FLOAT_803306B8/FLOAT_803306C8 constants.

## Evidence
- ninja succeeds for GCCP01.
- objdiff main/fontman improves:
  - GetWidth__5CFontFPc: 92.80198% -> 92.85149%
  - Draw__5CFontFUs: 91.80882% -> 91.86397%
  - .data: 99.933334% -> 99.93915%
- fontman.o now emits 7 .rela.data RTTI/vtable relocations matching the original relocation shape, instead of only 3 vtable function relocations.

## Plausibility
- The original fontman object references __RTTI__4CRef, __RTTI__5CFont, __RTTI__8CManager, and __RTTI__8CFontMan, so enabling RTTI is source-plausible and avoids hand-authored vtables.
- Shared float constants match the existing symbol map usage in nearby fontman code.