### PR TITLE
Improve monobj table default initializer

### DIFF
--- a/src/monobj_table.cpp
+++ b/src/monobj_table.cpp
@@ -21,20 +21,30 @@ struct MonAiFuncTable {
     MonVoidFunc always;
 };
 
+static const MonVoidFunc funcsDefault_initFinished = &CGMonObj::initFinishedFuncDefault;
+static const MonVoidFunc funcsDefault_moveFrame = &CGMonObj::moveFrameFuncDefault;
+static const MonVoidFunc funcsDefault_moveCancel = &CGMonObj::moveCancelFuncDefault;
+static const MonStateFunc funcsDefault_changeStat = &CGMonObj::changeStatFuncDefault;
+static const MonVoidFunc funcsDefault_cancelStat = &CGMonObj::cancelStatFuncDefault;
+static const MonVoidFunc funcsDefault_frameStat = &CGMonObj::frameStatFuncDefault;
+static const MonVoidFunc funcsDefault_logic = &CGMonObj::logicFuncDefault;
+static const MonCalcFunc funcsDefault_calcBranch = &CGMonObj::calcBranchFuncDefault;
+static const MonVoidFunc funcsDefault_always = &CGMonObj::alwaysFuncDefault;
+
 extern "C" MonAiFuncTable funcsDefault = {
-    &CGMonObj::initFinishedFuncDefault,
-    &CGMonObj::moveFrameFuncDefault,
-    &CGMonObj::moveCancelFuncDefault,
-    &CGMonObj::changeStatFuncDefault,
-    &CGMonObj::cancelStatFuncDefault,
-    &CGMonObj::frameStatFuncDefault,
-    &CGMonObj::logicFuncDefault,
+    funcsDefault_initFinished,
+    funcsDefault_moveFrame,
+    funcsDefault_moveCancel,
+    funcsDefault_changeStat,
+    funcsDefault_cancelStat,
+    funcsDefault_frameStat,
+    funcsDefault_logic,
     0,
-    &CGMonObj::calcBranchFuncDefault,
+    funcsDefault_calcBranch,
     0,
     0,
     0,
-    &CGMonObj::alwaysFuncDefault,
+    funcsDefault_always,
 };
 
 extern "C" MonAiFuncTable funcsGiantCrab = {


### PR DESCRIPTION
## Summary
- Introduce file-local pointer-to-member variables for funcsDefault entries in monobj_table
- Initialize funcsDefault from those variables to better match the generated static initializer shape

## Objdiff Evidence
- Unit: main/monobj_table
- Symbol: __sinit_monobj_table_cpp
- Before: 22.68597%
- After: 23.203695%
- Unit .text: 24.93456% -> 25.437227%
- Unit .data remains 100.0%

## Plausibility
The target static initializer copies pointer-to-member values into the exported function table. Naming the default table's pointer-to-member values as file-local objects gives MWCC a source-level reason to emit a less compact initializer while leaving table contents unchanged.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/monobj_table -o build/monobj_final.json __sinit_monobj_table_cpp