### PR TITLE
Improve deformation shape projection loop

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -488,10 +488,11 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 	PSMTXConcat(texMtx, layout->m_modelMatrix.value, tempMtx);
 
 	for (i = 0; i < 4; i++) {
-		projectedObjPtrs[i] = &projectedObj[i];
+		Vec* projectedObjPtr = &projectedObj[i];
+		projectedObjPtrs[i] = projectedObjPtr;
 		PSMTXMultVec(tempMtx, &vertices[i], projectedObjPtrs[i]);
-		projectedObjPtrs[i]->x = projectedObjPtrs[i]->x / projectedObjPtrs[i]->z;
-		projectedObjPtrs[i]->y = projectedObjPtrs[i]->y / projectedObjPtrs[i]->z;
+		projectedObjPtr->x = projectedObjPtr->x / projectedObjPtr->z;
+		projectedObjPtr->y = projectedObjPtr->y / projectedObjPtr->z;
 	}
 
 	minXIndex = 0;


### PR DESCRIPTION
## Summary
- Keep a direct projected-object pointer through the projection/divide loop in `RenderDeformationShape`
- Reduces pointer reload churn and better matches the PAL code shape while preserving the projected pointer array

## Objdiff Evidence
- `RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d`: 94.9257% -> 95.9613%
- `pppRenderYmDeformationShp`: remains 95.333336%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp -o /tmp/defshp.final.json`