### PR TITLE
Improve menu list close animation indexing

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -386,11 +386,10 @@ int CMenuPcs::MLstCtrl()
 
 		startFrame = 0;
 		duration = 4;
-		MenuLstEntry* closeEntry = &this->lstData->entries[this->lstData->count - 1];
 		for (int idx = this->lstData->count - 1; idx >= 0; idx--) {
+			MenuLstEntry* closeEntry = &this->lstData->entries[idx];
 			closeEntry->startFrame = startFrame++;
 			closeEntry->duration = duration;
-			closeEntry--;
 		}
 
 		this->lstState->frame = 0;


### PR DESCRIPTION
## Summary
- Change MLstCtrl close animation setup to index entries from lstData instead of walking a decrementing pointer.
- This matches the target's reverse-indexed entry access pattern and improves the generated unrolled close-animation block.

## Objdiff evidence
- main/menu_lst .text: 81.318756% -> 85.08861%
- MLstCtrl__8CMenuPcsFv: 80.30942% -> 95.0%
- .sdata2 remains 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o -