### PR TITLE
Improve TmpArtiOpen loop shape

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -483,7 +483,8 @@ unsigned int CMenuPcs::TmpArtiOpen()
 	entry = this->m_tmpArtiList->entries;
 	currentFrame = (int)this->m_tmpArtiState->frame;
 	if ((int)itemCount > 0) {
-		for (unsigned int remaining = itemCount; remaining != 0; remaining--) {
+		unsigned int remaining = itemCount;
+		do {
 			if (entry->startFrame <= currentFrame) {
 				if (entry->startFrame + entry->duration <= currentFrame) {
 					completedItems++;
@@ -495,7 +496,8 @@ unsigned int CMenuPcs::TmpArtiOpen()
 				}
 			}
 			entry++;
-		}
+			remaining--;
+		} while (remaining != 0);
 	}
 
 	one = FLOAT_80332f30;


### PR DESCRIPTION
## Summary
- Change the TmpArtiOpen animation update loop from a pre-checked for loop to a counted do/while form.
- This better matches the target control-flow shape after the existing positive item-count guard.

## Evidence
- ninja: passes
- objdiff main/menu_tmparti TmpArtiOpen__8CMenuPcsFv: 80.31373% -> 80.36275%
- Other checked menu_tmparti symbols unchanged in direct objdiff: TmpArtiDraw 85.89015%, TmpArtiClose 83.83178%, TmpArtiCtrl 76.247314%

## Plausibility
- The loop is only entered when itemCount is positive, so the do/while form is equivalent and matches the counted loop shape shown by Ghidra for this function.