### PR TITLE
Improve pppYmLaser sdata2 layout

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -63,6 +63,7 @@ void pppDrawShp__FPlsP12CMaterialSetUc(long*, short, CMaterialSet*, u8);
 }
 
 extern "C" const char s_pppYmLaser_cpp_801DB4B0[] = "pppYmLaser.cpp";
+extern const f32 FLOAT_80330de0 = -1.0f;
 
 static inline f32 LoadLaserFloat(const f32& value)
 {
@@ -377,7 +378,6 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	}
 }
 
-extern const f32 FLOAT_80330de0 = -1.0f;
 extern const f32 FLOAT_80330de4 = 1.2f;
 extern const f32 FLOAT_80330de8 = 10000000000.0f;
 extern const f32 FLOAT_80330dec = -10000000000.0f;


### PR DESCRIPTION
## Summary
- Move the FLOAT_80330de0 definition earlier in src/pppYmLaser.cpp so the local .sdata2 layout better matches PAL.
- No behavior or code changes; this is data layout/order cleanup for the pppYmLaser unit.

## Objdiff evidence
Before:
- pppRenderYmLaser: 97.57979%
- pppFrameYmLaser: 99.80122%
- [.sdata2-0]: 73.333336%

After:
- pppRenderYmLaser: 97.57979%
- pppFrameYmLaser: 99.80122%
- [.sdata2-0]: 80.0%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o /tmp/laser_final.json --format json

## Plausibility
FLOAT_80330de0 is still a normal unit-scope constant; only its placement relative to the first function changed, matching the observed PAL data ordering more closely without introducing address hacks or manual sections.