### PR TITLE
Improve texanim create chunk dispatch

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -723,8 +723,7 @@ void CTexAnimSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
                         seq->flags = (unsigned char)((((int)b6 << 6) & 0x40) | (seq->flags & 0xBF));
                         unsigned int eq = (unsigned int)__cntlzw((unsigned int)strcmp(seqName, DAT_8032fb48));
                         seq->flags = (unsigned char)(((unsigned char)((int)(char)(eq >> 5) << 5) & 0x20) | (seq->flags & 0xDF));
-                    }
-                    if (((int)innerChunkData[0] >= keyTag) && ((int)innerChunkData[0] == nameTag)) {
+                    } else if (((int)innerChunkData[0] >= keyTag) && ((int)innerChunkData[0] == nameTag)) {
                         strcpy(seqName, chunkFile.GetString());
                     }
                 } else {


### PR DESCRIPTION
## Summary
- Make the CTexAnimSet::Create inner chunk dispatch use an else-if for NAME after INFO handling.
- This matches the mutually exclusive chunk cases more closely and avoids an unnecessary fallthrough check.

## Objdiff evidence
- Unit main/texanim .text: 94.22387% -> 94.22699%
- Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage: 74.51111% -> 74.52889%
- Size remains 900 bytes.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/texanim -o - Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage