### PR TITLE
Fix menu artifact constant ownership

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -9,8 +9,8 @@
 typedef signed short s16;
 typedef unsigned char u8;
 
-static const double DOUBLE_80332fb0 = 1.0;
-static const double DOUBLE_80332fb8 = 0.5;
+extern const double DOUBLE_80332fb0;
+extern const double DOUBLE_80332fb8;
 extern const double DOUBLE_80332fe0;
 static const float FLOAT_80332fa8 = 0.0f;
 static const float FLOAT_80332fac = 1.0f;
@@ -21,8 +21,8 @@ extern const float FLOAT_80332fcc;
 extern const float FLOAT_80332fd0;
 extern const float FLOAT_80332fd4;
 extern const float FLOAT_80332fd8;
-static const float FLOAT_80332fe8 = 128.0f;
-static const float FLOAT_80332fec = 8.0f;
+extern const float FLOAT_80332fe8;
+extern const float FLOAT_80332fec;
 static const float FLOAT_80332ff0 = 0.75f;
 
 extern "C" {


### PR DESCRIPTION
## Summary
- Declare menu artifact constants owned by auto_11_803320C8_sdata2.o as extern instead of emitting local copies from menu_arti.o
- Keep the menu_arti-owned FLOAT_80333448 block unchanged

## Objdiff Evidence
Before:
- main/menu_arti right .sdata2 size: 156 bytes
- .text match: 81.72302%
- ArtiDraw__8CMenuPcsFv: 83.12479%
- ArtiInit1__8CMenuPcsFv: 49.192055%
- ArtiInit__8CMenuPcsFv: 67.00588%

After:
- main/menu_arti right .sdata2 size: 132 bytes
- .text match: 81.783394%
- ArtiDraw__8CMenuPcsFv: 83.14211%
- ArtiInit1__8CMenuPcsFv: 49.192055%
- ArtiInit__8CMenuPcsFv: 67.00588%

## Rationale
build/GCCP01/main.elf.MAP attributes DOUBLE_80332fb0, DOUBLE_80332fb8, FLOAT_80332fe8, and FLOAT_80332fec to auto_11_803320C8_sdata2.o, while menu_arti.o owns the later FLOAT_80333448 block. This change matches that ownership instead of duplicating those constants locally in menu_arti.o.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o /tmp/menu_arti_final.json