### PR TITLE
Fix CPartPcs table descriptor slots

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -237,11 +237,11 @@ static inline char* InitCPartPcsTable(char* profileName)
 	table[28] = CPartPcs::m_table_desc6[1];
 	table[29] = CPartPcs::m_table_desc6[2];
 	table[32] = CPartPcs::m_table_desc7[0];
-	table[35] = CPartPcs::m_table_desc7[2];
+	table[34] = CPartPcs::m_table_desc7[2];
 	table[39] = CPartPcs::m_table_desc8[2];
-	table[44] = CPartPcs::m_table_desc9[0];
-	table[45] = CPartPcs::m_table_desc9[1];
-	table[46] = CPartPcs::m_table_desc9[2];
+	table[42] = CPartPcs::m_table_desc9[0];
+	table[43] = CPartPcs::m_table_desc9[1];
+	table[44] = CPartPcs::m_table_desc9[2];
 	table[88] = CPartPcs::m_table_desc10[0];
 	table[89] = CPartPcs::m_table_desc10[1];
 	table[90] = CPartPcs::m_table_desc10[2];


### PR DESCRIPTION
## Summary
- Correct InitCPartPcsTable so m_table_desc7[2] is written to flattened table index 34.
- Correct the m_table_desc9 triplet to indices 42-44, matching the m_table__8CPartPcs data layout and __sinit_p_tina_cpp Ghidra/MAP offsets.

## Evidence
- ninja passes for GCCP01.
- build/tools/objdiff-cli diff -p . -u main/p_tina -o - __sinit_p_tina_cpp: unchanged score, 44.3125%, current size 820b vs target 832b.
- build/tools/objdiff-cli diff -p . -u main/p_tina -o - m_table__8CPartPcs: 100.0%, size 696b.

## Notes
- This is a source/data-layout correction rather than a code-score improvement. The corrected indices line up with the target __sinit_p_tina_cpp stores at m_table__8CPartPcs + 0x88 and +0xA8..+0xB0, and avoid overwriting the next command marker slot.