### PR TITLE
Improve FS USB and Arti matching

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -223,7 +223,8 @@ void CFunnyShapePcs::SetUSBData()
             for (; j < static_cast<s16>(list[1]);
                  src2c += 0x2C, src24 += 0x24, j++, dst24 += 0x24, dst2c += 0x2C) {
                 if ((list[0] & 8) != 0) {
-                    u8* src = listData + 0x10 + src2c;
+                    u8* src = listData + 0x10;
+                    src += src2c;
                     u32* p32 = reinterpret_cast<u32*>(src);
                     StoreSwap32(&p32[0]);
                     StoreSwap32(&p32[1]);
@@ -240,11 +241,13 @@ void CFunnyShapePcs::SetUSBData()
                     *reinterpret_cast<s16*>(src + 0x24) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x24));
                     *reinterpret_cast<s16*>(src + 0x26) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x26));
 
-                    u8* dst = listData + 0x10 + dst2c;
+                    u8* dst = listData + 0x10;
+                    dst += dst2c;
                     memcpy(dst, src, 0x2C);
                     DCStoreRange(dst, 0x2C);
                 } else {
-                    u8* src = listData + 0x10 + src24;
+                    u8* src = listData + 0x10;
+                    src += src24;
                     u32* p32 = reinterpret_cast<u32*>(src);
                     StoreSwap32(&p32[0]);
                     StoreSwap32(&p32[1]);
@@ -257,7 +260,8 @@ void CFunnyShapePcs::SetUSBData()
                     *reinterpret_cast<s16*>(src + 0x1C) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x1C));
                     *reinterpret_cast<s16*>(src + 0x1E) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x1E));
 
-                    u8* dst = listData + 0x10 + dst24;
+                    u8* dst = listData + 0x10;
+                    dst += dst24;
                     memcpy(dst, src, 0x24);
                     DCStoreRange(dst, 0x24);
                 }
@@ -299,7 +303,8 @@ void CFunnyShapePcs::SetUSBData()
         for (; i < m_shape.count;
              src2c += 0x2C, src24 += 0x24, i++, dst24 += 0x24, dst2c += 0x2C) {
             if ((m_shape.flags & 8) != 0) {
-                u8* src = meshData + 0x10 + src2c;
+                u8* src = meshData + 0x10;
+                src += src2c;
                 u32* p32 = reinterpret_cast<u32*>(src);
                 StoreSwap32(&p32[0]);
                 StoreSwap32(&p32[1]);
@@ -316,11 +321,13 @@ void CFunnyShapePcs::SetUSBData()
                 *reinterpret_cast<s16*>(src + 0x24) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x24));
                 *reinterpret_cast<s16*>(src + 0x26) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x26));
 
-                u8* dst = meshData + 0x10 + dst2c;
+                u8* dst = meshData + 0x10;
+                dst += dst2c;
                 memcpy(dst, src, 0x2C);
                 DCStoreRange(dst, 0x2C);
             } else {
-                u8* src = meshData + 0x10 + src24;
+                u8* src = meshData + 0x10;
+                src += src24;
                 u32* p32 = reinterpret_cast<u32*>(src);
                 StoreSwap32(&p32[0]);
                 StoreSwap32(&p32[1]);
@@ -333,7 +340,8 @@ void CFunnyShapePcs::SetUSBData()
                 *reinterpret_cast<s16*>(src + 0x1C) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x1C));
                 *reinterpret_cast<s16*>(src + 0x1E) = LoadSwap16(*reinterpret_cast<s16*>(src + 0x1E));
 
-                u8* dst = meshData + 0x10 + dst24;
+                u8* dst = meshData + 0x10;
+                dst += dst24;
                 memcpy(dst, src, 0x24);
                 DCStoreRange(dst, 0x24);
             }

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -858,10 +858,8 @@ void CMenuPcs::ArtiInit()
 		psVar8[3] = 0x28;
 		*(float*)(psVar8 + 4) = fVar2;
 		*(float*)(psVar8 + 6) = fVar2;
-		psVar8[0x12] = 0;
-		psVar8[0x13] = 7;
-		psVar8[0x14] = 0;
-		psVar8[0x15] = 5;
+		reinterpret_cast<ArtiOpenAnim*>(psVar8)->startFrame = 7;
+		reinterpret_cast<ArtiOpenAnim*>(psVar8)->duration = 5;
 		iVar9 = iVar5 + 0x48;
 		iVar5 = iVar5 + 0x80;
 		psVar8 = (short*)(GetArtiListBase(this) + iVar9);
@@ -874,10 +872,8 @@ void CMenuPcs::ArtiInit()
 		psVar8[3] = 0x28;
 		*(float*)(psVar8 + 4) = fVar2;
 		*(float*)(psVar8 + 6) = fVar2;
-		psVar8[0x12] = 0;
-		psVar8[0x13] = 7;
-		psVar8[0x14] = 0;
-		psVar8[0x15] = 5;
+		reinterpret_cast<ArtiOpenAnim*>(psVar8)->startFrame = 7;
+		reinterpret_cast<ArtiOpenAnim*>(psVar8)->duration = 5;
 		iVar11 = iVar11 - 1;
 	} while (iVar11 != 0);
 


### PR DESCRIPTION
## Summary
- split FS USB vertex record base pointers from loop offsets in the animation and mesh packet paths
- use recovered ArtiOpenAnim timing fields for ArtiInit startFrame/duration stores

## Objdiff evidence
- main/FS_USB_Process SetUSBData__14CFunnyShapePcsFv: 98.96141% -> 99.086266% (3524b)
- main/menu_arti ArtiInit__8CMenuPcsFv: 67.00588% -> 70.91765% (680b)
- main/menu_arti .text: 81.72302% -> 82.22491%

## Plausibility
- FS USB still performs the same vertex record conversion and cache store work, but expresses the shared record base separately from the per-record offset, matching the generated address shape more closely.
- ArtiInit already has ArtiOpenAnim fields recovered at offsets 0x24 and 0x28; writing startFrame and duration as int fields replaces decompiler-style paired short stores with the struct fields the original source likely used.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/FS_USB_Process -o /tmp/fs_usb_final.json SetUSBData__14CFunnyShapePcsFv
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o /tmp/menu_arti_final.json