### PR TITLE
Improve pppMana2 water mesh constant loads

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1217,8 +1217,8 @@ static int UpdateWaterMesh(VMana2* mana2)
     }
 
     for (int row = 1, rowBase = 0x11; row < 0x10; row++, rowBase += 0x11) {
-        currentScale = FLOAT_80331898;
-        neighborScale = FLOAT_803318a4;
+        currentScale = LoadFloat(FLOAT_80331898);
+        neighborScale = LoadFloat(FLOAT_803318a4);
         for (int col = 1; col < 0x10; col += 5) {
             int index = rowBase + col;
             int above0 = index - 0x11;


### PR DESCRIPTION
## Summary
- Load the `UpdateWaterMesh` scale constants through the existing `LoadFloat` helper.
- This keeps the source aligned with nearby constant-load patterns and improves `pppMana2` `.sdata2` matching.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppMana2 -o /tmp/pppMana2.pr.json UpdateWaterMesh__FP6VMana2`
- Before: `.sdata2` 94.44444%, `.text` 85.23238%, `UpdateWaterMesh__FP6VMana2` 76.09091%.
- After: `.sdata2` 95.96774%, `.text` 85.216225%, `UpdateWaterMesh__FP6VMana2` 75.8843%.

The small local code-score dip is from the constant load shape; the data section moves closer to target without changing behavior.
