### PR TITLE
Improve caravan item deletion match

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -975,7 +975,7 @@ int CCaravanWork::DeleteItem(int itemIndex, int updateJoybus)
     int i;
 
     for (i = 0; i < 0x40; i++) {
-        if ((short)m_inventoryItems[i] != -1 && (short)m_inventoryItems[i] == itemIndex) {
+        if (m_inventoryItems[i] != -1 && m_inventoryItems[i] == itemIndex) {
             m_inventoryItems[i] = 0xFFFF;
             m_inventoryItemCount = m_inventoryItemCount - 1;
             if (updateJoybus != 0) {


### PR DESCRIPTION
## Summary
- Remove redundant casts from `CCaravanWork::DeleteItem` inventory comparisons now that `m_inventoryItems` is typed as `short[64]`.
- This produces cleaner source and avoids extra sign-extension code in the loop.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o /tmp/gobjwork_deleteitem_final.json DeleteItem__12CCaravanWorkFii`
- `DeleteItem__12CCaravanWorkFii`: baseline 92.638885% / 152b current, after 95.416664% / 148b current, target 144b.

## Plausibility
- `m_inventoryItems` is already declared as a signed short array, so the explicit `(short)` casts are redundant rather than source-like.
- The change keeps the original control flow and member access intact while improving code generation.
