### PR TITLE
Improve caravan item deletion match

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -975,7 +975,7 @@ int CCaravanWork::DeleteItem(int itemIndex, int updateJoybus)
     int i;
 
     for (i = 0; i < 0x40; i++) {
-        if ((short)m_inventoryItems[i] != -1 && (short)m_inventoryItems[i] == itemIndex) {
+        if (m_inventoryItems[i] != -1 && m_inventoryItems[i] == itemIndex) {
             m_inventoryItems[i] = 0xFFFF;
             m_inventoryItemCount = m_inventoryItemCount - 1;
             if (updateJoybus != 0) {


### PR DESCRIPTION
## Summary
- Compare caravan inventory entries with their stored unsigned value in `CCaravanWork::DeleteItem`.
- Removes signed casts that were forcing worse codegen for the item search loop.

## Evidence
- `ninja` passes for `GCCP01`.
- `main/gobjwork` `DeleteItem__12CCaravanWorkFii`: 92.638885% / 152 bytes -> 95.416664% / 148 bytes.
- `DeleteItemIdx__12CCaravanWorkFii` remains matched at 100%.

## Plausibility
- `m_inventoryItems` stores the unsigned 0xFFFF sentinel, so comparing the stored value directly is cleaner than forcing signed halfword comparisons.