### PR TITLE
Improve maphit range loop types

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -210,9 +210,9 @@ void CMapHit::Draw()
  */
 void CMapHit::CheckHitCylinderNear(CMapCylinder* mapCylinder, Vec* position, unsigned short startFace, unsigned short faceCount, unsigned long mask)
 {
-    int faceIndex = static_cast<unsigned short>(startFace);
-    int faceOffset = faceIndex * 0x50;
-    int endFace = static_cast<unsigned short>(faceCount + startFace);
+    unsigned int faceIndex = startFace;
+    unsigned int faceOffset = faceIndex * sizeof(CMapHitFace);
+    unsigned int endFace = static_cast<unsigned short>(faceCount + startFace);
 
     g_hit_cyl = *mapCylinder;
     g_hit_mvec = *position;
@@ -220,7 +220,7 @@ void CMapHit::CheckHitCylinderNear(CMapCylinder* mapCylinder, Vec* position, uns
     while (faceIndex < endFace) {
         g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
         CheckHitFaceCylinder(mask);
-        faceOffset += 0x50;
+        faceOffset += sizeof(CMapHitFace);
         faceIndex++;
     }
 }
@@ -250,9 +250,9 @@ void CMapHit::CheckHitCylinderNear(CMapCylinder* mapCylinder, Vec* position, uns
  */
 int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned short startFace, unsigned short faceCount, unsigned long mask)
 {
-    int faceIndex = static_cast<unsigned short>(startFace);
-    int faceOffset = faceIndex * 0x50;
-    int endFace = static_cast<unsigned short>(faceCount + startFace);
+    unsigned int faceIndex = startFace;
+    unsigned int faceOffset = faceIndex * sizeof(CMapHitFace);
+    unsigned int endFace = static_cast<unsigned short>(faceCount + startFace);
 
     g_hit_cyl = *mapCylinder;
     g_hit_mvec = *position;
@@ -265,7 +265,7 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
             return 1;
         }
 
-        faceOffset += 0x50;
+        faceOffset += sizeof(CMapHitFace);
         faceIndex++;
     }
 


### PR DESCRIPTION
## Summary
- Update the bounded CMapHit cylinder range loops to use unsigned 16-bit-style counters from the u16 parameters.
- Replace the face stride literal with sizeof(CMapHitFace) in those loops.

## Objdiff evidence
- main/maphit CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUsUsUl: 85.731346% -> 92.25373%, size remains 268 bytes.
- main/maphit CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUsUsUl: 92.80769% -> 93.34615%, current size improves 316 -> 312 bytes and now matches target size 312.

## Plausibility
Ghidra and the target assembly both show the bounded overloads treating startFace and faceCount as 16-bit range inputs, wrapping the end face to u16 before iterating. Using sizeof(CMapHitFace) preserves the existing 0x50 stride while tying the loop to the recovered face layout instead of a raw byte literal.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/maphit -o /tmp/pr_maphit_near.json CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUsUsUl
- build/tools/objdiff-cli diff -p . -u main/maphit -o /tmp/pr_maphit_check.json CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUsUsUl