### PR TITLE
Match maptexanim texture slot updates

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -104,8 +104,7 @@ static inline void ReplaceRef(void** slot, void* ref)
 
 static inline void SetMaterialTextureSlot(void* material, unsigned long slotIndex, void* texture)
 {
-    void** slot = reinterpret_cast<void**>(Ptr(material, 0x3C) + (slotIndex * 4));
-    ReplaceRef(slot, texture);
+    ReplaceRef(reinterpret_cast<void**>(Ptr(material, 0x3C) + (slotIndex * 4)), texture);
 
     unsigned short& numTexture = *reinterpret_cast<unsigned short*>(Ptr(material, 0x18));
     if (slotIndex >= numTexture) {


### PR DESCRIPTION
## Summary
- Match `main/maptexanim` by simplifying the inlined material texture slot replacement in `CMapTexAnim::Calc`.
- This removes an unnecessary temporary pointer and lets the compiler emit the target register allocation for the texture-slot update path.

## Evidence
- Before: `main/maptexanim` was selected at code 99.9%, functions 4/5.
- After `ninja`: `main/maptexanim` reports code 2796/2796, data 152/152, functions 5/5.
- Overall build progress increased by one matched function and 1496 matched code bytes.

## Plausibility
- The change keeps the same helper abstraction and behavior, but expresses the slot address directly at the call to `ReplaceRef`, which is a plausible source shape and avoids fake symbols, hardcoded addresses, or manual section manipulation.
