### PR TITLE
Improve YmMegaBirthShpTail3 frame loop matching

### DIFF
--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -398,14 +398,15 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
             break;
         }
 
-        spawnCount = 0;
+        i = 0;
         particleData = (u8*)work->m_particles;
         worldMat = work->m_wmats;
         particleColor = work->m_colors;
+        spawnCount = i;
 
         if ((gPppCalcDisabled == 0) && (*(s32*)(paramPayload + 4) != 0xffff)) {
             work->m_lifeLimit = work->m_lifeLimit + 1;
-            for (i = 0; i < work->m_maxParticles; i++) {
+            for (; i < work->m_maxParticles; i++) {
                 if (*(u16*)(particleData + 0x22) != 0) {
                     calc((_pppPObject*)object, work, param, (_PARTICLE_DATA*)particleData, colorWork, particleColor);
                 } else {


### PR DESCRIPTION
## Summary
- Reorders the particle loop initialization in pppFrameYmMegaBirthShpTail3 so the zeroed loop index feeds spawnCount before iteration.
- Keeps behavior equivalent while moving register allocation closer to the target.

## Objdiff
- main/pppYmMegaBirthShpTail3 pppFrameYmMegaBirthShpTail3: 99.22222% -> 99.37037%
- pppRenderYmMegaBirthShpTail3, calc, and birth unchanged.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o -