### PR TITLE
Improve pppCrystal2 frame loop scheduling

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -269,7 +269,6 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCt
             xCoord = -1.0f;
 
             for (x = 0; x < (u32)textureInfo->m_width; x++) {
-                u32 xFine = x & 3;
                 magnitude = xCoord * xCoord + ySq;
 
                 if (magnitude > 0.0f) {
@@ -280,6 +279,7 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCt
                     magnitude = *(float*)__float_nan;
                 }
 
+                u32 xFine = x & 3;
                 if (magnitude > 1.0f) {
                     magnitude = 1.0f;
                 }


### PR DESCRIPTION
## Summary
- Move the pppCrystal2 refraction-loop fine-coordinate calculation closer to its pixel packing use.
- This improves the generated scheduling around the magnitude classification/clamp path in pppFrameCrystal2.

## Evidence
- Built with: ninja
- main/pppCrystal2 .text objdiff improved from 99.583336% to 99.60069%.
- The xFine calculation now occurs after magnitude NaN handling instead of before the full magnitude path, which is closer to the target instruction order while keeping the same behavior.

## Plausibility
- The change keeps the loop logic and data layout unchanged.
- It places the tile fine-coordinate local near the pixel-address calculation it feeds, which is plausible original source rather than a forced section/address hack.