### PR TITLE
Improve pppCrystal2 frame loop scheduling

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -269,7 +269,6 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCt
             xCoord = -1.0f;
 
             for (x = 0; x < (u32)textureInfo->m_width; x++) {
-                u32 xFine = x & 3;
                 magnitude = xCoord * xCoord + ySq;
 
                 if (magnitude > 0.0f) {
@@ -280,6 +279,7 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCt
                     magnitude = *(float*)__float_nan;
                 }
 
+                u32 xFine = x & 3;
                 if (magnitude > 1.0f) {
                     magnitude = 1.0f;
                 }


### PR DESCRIPTION
## Summary
- Move the x fine-coordinate calculation in pppFrameCrystal2 until after the magnitude classification path.
- This matches the target scheduling more closely while keeping the refraction-map generation logic unchanged.

## Evidence
- ninja
- objdiff pppFrameCrystal2 before: 99.09091% (924 bytes)
- objdiff pppFrameCrystal2 after: 99.1342% (924 bytes)

## Plausibility
- The change preserves the same x & 3 value and only places it nearer to the pixel address calculation, matching the original instruction order without adding temporaries or hard-coded addresses.