### PR TITLE
Improve monobj texture animation string refs

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -20,8 +20,8 @@
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdio.h>
 
 extern unsigned char ARRAY_8030918c[];
-extern "C" char DAT_803319ec[];
-extern "C" char DAT_80331a4c[];
+extern "C" const char DAT_803319ec[3];
+extern "C" const char DAT_80331a4c[3];
 extern "C" {
 u8 m_aiWork__8CGMonObj[0xC];
 u8 m_boss__8CGMonObj[0x8C];
@@ -302,7 +302,7 @@ void CGMonObj::undeadOff()
 	}
 
 	if (*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(object->m_scriptHandle[9]) + 0xFC) == 0xB) {
-		object->SetTexAnim(DAT_80331a4c);
+		object->SetTexAnim(const_cast<char*>(DAT_80331a4c));
 	}
 
 	mon[0x6BA] = 1;
@@ -347,7 +347,7 @@ void CGMonObj::undeadOn()
 	}
 
 	if (*reinterpret_cast<short*>(reinterpret_cast<unsigned char*>(object->m_scriptHandle[9]) + 0xFC) == 0xB) {
-		object->SetTexAnim(DAT_803319ec);
+		object->SetTexAnim(const_cast<char*>(DAT_803319ec));
 	}
 
 	if (static_cast<int>((static_cast<unsigned int>(object->m_weaponNodeFlags) << 24)) < 0) {
@@ -2668,7 +2668,7 @@ void CGMonObj::setRepop(int mode)
 	}
 
 	if (*reinterpret_cast<short*>(reinterpret_cast<unsigned char*>(scriptHandle[9]) + 0xFC) == 0xB) {
-		object->SetTexAnim(DAT_803319ec);
+		object->SetTexAnim(const_cast<char*>(DAT_803319ec));
 	}
 
 	if (static_cast<int>((static_cast<unsigned int>(object->m_weaponNodeFlags) << 24)) < 0) {


### PR DESCRIPTION
## Summary
- declare `DAT_803319ec` and `DAT_80331a4c` as const size-known `.sdata2` strings
- keep `SetTexAnim` calls compatible with the existing `char*` signature via local `const_cast`

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/monobj -o /tmp/monobj_final.json --format json-pretty`
- `monobj` `.text`: 45.5186% -> 45.584938%
- `setRepop__8CGMonObjFi`: 59.908077% -> 60.270195%
- `undeadOn__8CGMonObjFv`: 75.552086% -> 77.21875%
- `undeadOff__8CGMonObjFv`: 82.22973% -> 85.202705%

## Plausibility
`config/GCCP01/symbols.txt` identifies both texture animation names as 3-byte `.sdata2` strings, so the declarations now reflect read-only small data while preserving the existing `SetTexAnim(char*)` call surface.