### PR TITLE
Improve CMenuPcs SetTexture constant load

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1299,7 +1299,8 @@ void CMenuPcs::SetTexture(CMenuPcs::TEX tex)
 
         width = *(u32*)((u8*)texture + 0x64);
         height = *(u32*)((u8*)texture + 0x68);
-        PSMTXScale(texMtx, FLOAT_80330808 / (f32)width, FLOAT_80330808 / (f32)height, FLOAT_80330808);
+        PSMTXScale(texMtx, LoadFloat(FLOAT_80330808) / (f32)width, LoadFloat(FLOAT_80330808) / (f32)height,
+                   LoadFloat(FLOAT_80330808));
         GXLoadTexMtxImm(texMtx, GX_TEXMTX0, GX_MTX2x4);
         GXSetNumTexGens(1);
         GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_TEXMTX0, GX_FALSE, GX_PTIDENTITY);


### PR DESCRIPTION
## Summary
- Use the existing LoadFloat helper for CMenuPcs::SetTexture texture scale constants.
- This keeps the FLOAT_80330808 load aligned with the target object instead of emitting an extra local float constant reference.

## Objdiff Evidence
- main/p_menu .text fuzzy: 88.24292% -> 88.25654%
- SetTexture__8CMenuPcsFQ28CMenuPcs3TEX: 99.81132% -> 99.90566%
- Function size remains 212 bytes.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_menu -o - SetTexture__8CMenuPcsFQ28CMenuPcs3TEX
