### PR TITLE
Fix memorycard sprintf prototype

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -11,7 +11,7 @@
 #include "dolphin/card.h"
 #include "string.h"
 
-extern "C" int sprintf(char* s, const char* format, const char* arg0, char* arg1);
+extern "C" int sprintf(char* s, const char* format, ...);
 
 class CardConst
 {


### PR DESCRIPTION
## Summary
- Corrects the local `sprintf` declaration in `memorycard.cpp` to be variadic.
- This restores the varargs call sequence for `CMemoryCardMan::SetMcIconImage()`.

## Evidence
- `ninja` passes.
- `SetMcIconImage__14CMemoryCardManFv` objdiff improved from 99.40722% to 99.92268%.
- The missing `crclr cr1eq` before `sprintf` is now emitted; only three string-address argument mismatches remain in the symbol-filtered diff.

## Plausibility
- `sprintf` is a variadic C library function; the prior fixed-argument extern was an incorrect local prototype.