### PR TITLE
Fix particle manager state flag size

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -105,7 +105,7 @@ extern "C" void Create__9CMaterialFUlQ212CMaterialMan7TEV_BIT(CMaterial*, unsign
 extern "C" void AddMaterial__12CMaterialSetFP9CMateriali(CMaterialSet*, CMaterial*, int);
 PPPCREATEPARAM g_dcp;
 extern "C" {
-unsigned char DAT_8032ed68 = 0;
+int DAT_8032ed68 = 0;
 int DAT_8032ed6c = 0;
 int DAT_8032ed74 = 0;
 unsigned char gPppInConstructor = 0;


### PR DESCRIPTION
## Summary
- Change DAT_8032ed68 in partMng from an 8-bit object to a 32-bit int.
- This matches config/GCCP01/symbols.txt, where DAT_8032ed68 is a 4-byte .sbss object, and the PAL assembly, which accesses it with lwz/stw.

## Evidence
- ninja passes.
- main/partMng objdiff: DAT_8032ed68 improves from 50.0% to 100.0%.
- Nearby fuzzy scores also move in plausible directions for functions that read/write the corrected flag:
  - pppDataRcv__8CPartMngFUlPcUl: 21.767801 -> 22.977554
  - pppEditDrawShadow__8CPartMngFv: 52.07377 -> 53.057377
  - pppEditPartDrawAfter__8CPartMngFv: 23.133333 -> 23.657576

## Notes
- Create__8CPartMngFv has a small fuzzy-score drop, but the underlying data layout is now consistent with the symbol size and target word accesses.
- I also checked nearby .sbss flags; the surrounding byte flags remain byte-accessed in target assembly, so this change is scoped to the one 4-byte flag.