### PR TITLE
Improve memory heap release matching

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -230,30 +230,29 @@ void* operator new[](unsigned long size, CMemory::CStage* stage, char* file, int
 void operator delete(void* ptr)
 {
     if (ptr != (void*)nullptr) {
-        unsigned char* mem = reinterpret_cast<unsigned char*>(ptr);
+        int mem = reinterpret_cast<int>(ptr);
         if ((*reinterpret_cast<short*>(mem - 0x40) != 0x4b41) ||
             (*reinterpret_cast<short*>(mem - 2) != 0x4d49)) {
             Printf__7CSystemFPce(&System, DAT_801d6648, ptr, mem - 0x26, *reinterpret_cast<unsigned short*>(mem - 0x28));
         }
 
-        mem[-0x3e] &= 0xfb;
+        *reinterpret_cast<unsigned char*>(mem - 0x3e) &= 0xfb;
 
-        int blockPrev = *reinterpret_cast<int*>(mem - 0x38);
-        if ((*(reinterpret_cast<unsigned char*>(blockPrev) + 2) & 4) == 0) {
+        if ((*reinterpret_cast<unsigned char*>(*reinterpret_cast<int*>(mem - 0x38) + 2) & 4) == 0) {
             *reinterpret_cast<int*>(mem - 0x30) =
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 0x10) +
+                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 0x10) +
                 *reinterpret_cast<int*>(mem - 0x30) + 0x40;
-            *reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8) + 4) =
-                reinterpret_cast<int>(mem) - 0x40;
+            *reinterpret_cast<int*>(*reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 8) + 4) =
+                mem - 0x40;
             *reinterpret_cast<int*>(mem - 0x38) =
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8);
+                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 8);
         }
 
         int blockNext = *reinterpret_cast<int*>(mem - 0x3c);
-        if ((*(reinterpret_cast<unsigned char*>(blockNext) + 2) & 4) == 0) {
-            *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) =
+        if ((*reinterpret_cast<unsigned char*>(blockNext + 2) & 4) == 0) {
+            *reinterpret_cast<int*>(blockNext + 0x10) =
                 *reinterpret_cast<int*>(mem - 0x30) +
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) + 0x40;
+                *reinterpret_cast<int*>(blockNext + 0x10) + 0x40;
             *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x3c) + 8) = *reinterpret_cast<int*>(mem - 0x38);
             *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 4) = *reinterpret_cast<int*>(mem - 0x3c);
         }
@@ -274,30 +273,29 @@ void operator delete(void* ptr)
 void operator delete[](void* ptr)
 {
     if (ptr != (void*)nullptr) {
-        unsigned char* mem = reinterpret_cast<unsigned char*>(ptr);
+        int mem = reinterpret_cast<int>(ptr);
         if ((*reinterpret_cast<short*>(mem - 0x40) != 0x4b41) ||
             (*reinterpret_cast<short*>(mem - 2) != 0x4d49)) {
             Printf__7CSystemFPce(&System, DAT_801d6648, ptr, mem - 0x26, *reinterpret_cast<unsigned short*>(mem - 0x28));
         }
 
-        mem[-0x3e] &= 0xfb;
+        *reinterpret_cast<unsigned char*>(mem - 0x3e) &= 0xfb;
 
-        int blockPrev = *reinterpret_cast<int*>(mem - 0x38);
-        if ((*(reinterpret_cast<unsigned char*>(blockPrev) + 2) & 4) == 0) {
+        if ((*reinterpret_cast<unsigned char*>(*reinterpret_cast<int*>(mem - 0x38) + 2) & 4) == 0) {
             *reinterpret_cast<int*>(mem - 0x30) =
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 0x10) +
+                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 0x10) +
                 *reinterpret_cast<int*>(mem - 0x30) + 0x40;
-            *reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8) + 4) =
-                reinterpret_cast<int>(mem) - 0x40;
+            *reinterpret_cast<int*>(*reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 8) + 4) =
+                mem - 0x40;
             *reinterpret_cast<int*>(mem - 0x38) =
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8);
+                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 8);
         }
 
         int blockNext = *reinterpret_cast<int*>(mem - 0x3c);
-        if ((*(reinterpret_cast<unsigned char*>(blockNext) + 2) & 4) == 0) {
-            *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) =
+        if ((*reinterpret_cast<unsigned char*>(blockNext + 2) & 4) == 0) {
+            *reinterpret_cast<int*>(blockNext + 0x10) =
                 *reinterpret_cast<int*>(mem - 0x30) +
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) + 0x40;
+                *reinterpret_cast<int*>(blockNext + 0x10) + 0x40;
             *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x3c) + 8) = *reinterpret_cast<int*>(mem - 0x38);
             *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 4) = *reinterpret_cast<int*>(mem - 0x3c);
         }
@@ -858,30 +856,29 @@ void* CMemory::_Alloc(unsigned long size, CMemory::CStage* stage, char* source, 
 void CMemory::Free(void* ptr)
 {
     if (ptr != (void*)nullptr) {
-        unsigned char* mem = reinterpret_cast<unsigned char*>(ptr);
+        int mem = reinterpret_cast<int>(ptr);
         if ((*reinterpret_cast<short*>(mem - 0x40) != 0x4b41) ||
             (*reinterpret_cast<short*>(mem - 2) != 0x4d49)) {
             Printf__7CSystemFPce(&System, DAT_801d6648, ptr, mem - 0x26, *reinterpret_cast<unsigned short*>(mem - 0x28));
         }
 
-        mem[-0x3e] &= 0xfb;
+        *reinterpret_cast<unsigned char*>(mem - 0x3e) &= 0xfb;
 
-        int blockPrev = *reinterpret_cast<int*>(mem - 0x38);
-        if ((*(reinterpret_cast<unsigned char*>(blockPrev) + 2) & 4) == 0) {
+        if ((*reinterpret_cast<unsigned char*>(*reinterpret_cast<int*>(mem - 0x38) + 2) & 4) == 0) {
             *reinterpret_cast<int*>(mem - 0x30) =
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 0x10) +
+                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 0x10) +
                 *reinterpret_cast<int*>(mem - 0x30) + 0x40;
-            *reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8) + 4) =
-                reinterpret_cast<int>(mem) - 0x40;
+            *reinterpret_cast<int*>(*reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 8) + 4) =
+                mem - 0x40;
             *reinterpret_cast<int*>(mem - 0x38) =
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8);
+                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 8);
         }
 
         int blockNext = *reinterpret_cast<int*>(mem - 0x3c);
-        if ((*(reinterpret_cast<unsigned char*>(blockNext) + 2) & 4) == 0) {
-            *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) =
+        if ((*reinterpret_cast<unsigned char*>(blockNext + 2) & 4) == 0) {
+            *reinterpret_cast<int*>(blockNext + 0x10) =
                 *reinterpret_cast<int*>(mem - 0x30) +
-                *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) + 0x40;
+                *reinterpret_cast<int*>(blockNext + 0x10) + 0x40;
             *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x3c) + 8) = *reinterpret_cast<int*>(mem - 0x38);
             *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 4) = *reinterpret_cast<int*>(mem - 0x3c);
         }
@@ -2092,13 +2089,13 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
         }
 
         if (bestEntry != 0) {
-            operator delete(bestEntry->m_cacheData);
+            freeAmemCacheBlock(reinterpret_cast<unsigned long>(bestEntry->m_cacheData));
             bestEntry->m_cacheData = 0;
         }
 
         int allocated = reinterpret_cast<int>(m_rStage->alloc(size, const_cast<char*>(s_memory_cpp), 0x86D, 1));
         if (allocated != 0) {
-            operator delete(reinterpret_cast<void*>(allocated));
+            freeAmemCacheBlock(static_cast<unsigned long>(allocated));
             return;
         }
 
@@ -2156,33 +2153,7 @@ void CAmemCacheSet::CacheClear()
         if ((entry.m_inUse != 0) && (entry.m_refCount == 0) && (entry.m_dmaCopy != 0)) {
             int data = reinterpret_cast<int>(entry.m_cacheData);
             if (data != 0) {
-                unsigned char* mem = reinterpret_cast<unsigned char*>(data);
-                if ((*reinterpret_cast<short*>(mem - 0x40) != 0x4B41) ||
-                    (*reinterpret_cast<short*>(mem - 2) != 0x4D49)) {
-                    Printf__7CSystemFPce(&System, DAT_801d6648, data, mem - 0x26, *reinterpret_cast<unsigned short*>(mem - 0x28));
-                }
-
-                mem[-0x3E] &= 0xFB;
-
-                int blockPrev = *reinterpret_cast<int*>(mem - 0x38);
-                if ((*(reinterpret_cast<unsigned char*>(blockPrev) + 2) & 4) == 0) {
-                    *reinterpret_cast<int*>(mem - 0x30) =
-                        *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 0x10) +
-                        *reinterpret_cast<int*>(mem - 0x30) + 0x40;
-                    *reinterpret_cast<int*>(*reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8) + 4) = data - 0x40;
-                    *reinterpret_cast<int*>(mem - 0x38) = *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockPrev) + 8);
-                }
-
-                int blockNext = *reinterpret_cast<int*>(mem - 0x3C);
-                if ((*(reinterpret_cast<unsigned char*>(blockNext) + 2) & 4) == 0) {
-                    *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) =
-                        *reinterpret_cast<int*>(mem - 0x30) +
-                        *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(blockNext) + 0x10) + 0x40;
-                    *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x3C) + 8) = *reinterpret_cast<int*>(mem - 0x38);
-                    *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x38) + 4) = *reinterpret_cast<int*>(mem - 0x3C);
-                }
-
-                *reinterpret_cast<int*>(*reinterpret_cast<int*>(mem - 0x34) + 0x124) -= 1;
+                freeAmemCacheBlock(static_cast<unsigned long>(data));
                 entry.m_cacheData = 0;
             }
         }


### PR DESCRIPTION
## Summary
- Reworked heap release code in memory delete/free paths to use the integer-offset form seen in the target decompilation.
- Reused the existing AMEM heap block release helper from cache eviction/clear paths instead of routing through global delete calls.

## Objdiff evidence
- main/memory fuzzy match: 74.22184% -> 75.574165%.
- CacheClear__13CAmemCacheSetFv: 79.48276% -> 85.05747%.
- AmemFreeLowPrio__13CAmemCacheSetFi: 62.96838% -> 74.332016%.
- Free__7CMemoryFPv: 73.55385% -> 76.83077%.
- __dl__FPv / __dla__FPv: 76.75676% -> 79.63513%.
- __dt__10CAmemCacheFv: 81.9125% -> 84.7625%.

## Verification
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_AmemFreeLowPrio.json AmemFreeLowPrio__13CAmemCacheSetFi
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_CacheClear.json CacheClear__13CAmemCacheSetFv
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_Delete.json __dl__FPv
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/memory_Free.json Free__7CMemoryFPv

## Plausibility
These changes keep the same heap-header semantics and avoid artificial addresses or section forcing. The code is closer to the target compiler output by expressing the release paths with direct header-relative integer accesses where the target does the same, and by using the already-local AMEM release helper where cache methods inline that behavior.