### PR TITLE
Match gobjwork shouki threshold data

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -12,7 +12,7 @@
 
 extern const float FLOAT_80330998;
 extern const float FLOAT_8033099C;
-extern const float FLOAT_803309a8 = 0.95f;
+extern const float FLOAT_803309a8[2] = {0.95f, 0.0f};
 
 namespace {
 static inline unsigned short* GetItemDataPtr(int itemIdx)
@@ -459,7 +459,7 @@ int CCaravanWork::IsOutOfShouki()
 	void* ownerObj = m_ownerObj;
 
 	if (*reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(ownerObj) + 0x5BC) >
-		FLOAT_803309a8 * Game.unkFloat_0xca10) {
+		FLOAT_803309a8[0] * Game.unkFloat_0xca10) {
 		if (m_hp != 0) {
 			unsigned char cflatFlag = CFlat[4836];
 			if (((char)(((int)(((unsigned int)cflatFlag << 24) & 0xC0000000)) >> 31) != 0 ||


### PR DESCRIPTION
## Summary
- Model FLOAT_803309a8 as the 8-byte sdata2 object shown in config/GCCP01/symbols.txt.
- Update CCaravanWork::IsOutOfShouki to use the first float element, avoiding the duplicate compiler-generated 0.95f constant.

## Objdiff Evidence
Before -> after for main/gobjwork:
- IsOutOfShouki__12CCaravanWorkFv: 99.84849% -> 100.0%
- FLOAT_803309a8: 66.66667% -> 100.0%
- [.sdata2-0]: 56.25% -> 81.25%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/gobjwork -o /tmp/gobjwork_final.json