### PR TITLE
Improve GbaQueue letter list flag handling

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -2227,15 +2227,14 @@ int GbaQueue::GetPlayerHP(int channel, unsigned char* outData)
  */
 int GbaQueue::MakeLetterList(int channel, char* outData)
 {
-	GbaQueueFlagView* flags = GetFlagView(this);
 	const unsigned int scriptFood = Game.m_scriptFoodBase[channel];
 
 	if (scriptFood == 0) {
-		const unsigned char channelMask = static_cast<unsigned char>(1U << channel);
+		const unsigned int channelMask = 1U << channel;
 
-		flags->m_letterDatFlg = static_cast<unsigned char>(flags->m_letterDatFlg | channelMask);
+		GetFlagView(this)->m_letterDatFlg |= channelMask;
 		Joybus.SetLetterSize(channel, 0);
-		m_letterFlags = static_cast<unsigned char>(m_letterFlags & ~channelMask);
+		m_letterFlags &= ~channelMask;
 		return 0;
 	}
 
@@ -2391,11 +2390,11 @@ Printf__7CSystemFPce(&System, const_cast<char*>(s_letter_data_error), const_cast
 	__dla__FPv(subjectNameBuf);
 	__dla__FPv(npcNameBuf);
 
-	const unsigned char channelMask = static_cast<unsigned char>(1U << channel);
+	const unsigned int channelMask = 1U << channel;
 
-	flags->m_letterDatFlg = static_cast<unsigned char>(flags->m_letterDatFlg | channelMask);
+	GetFlagView(this)->m_letterDatFlg |= channelMask;
 	Joybus.SetLetterSize(channel, totalSize);
-	m_letterFlags = static_cast<unsigned char>(m_letterFlags & ~channelMask);
+	m_letterFlags &= ~channelMask;
 	return totalSize;
 }
 


### PR DESCRIPTION
## Summary
- remove the long-lived GbaQueueFlagView alias in MakeLetterList
- use an unsigned channel mask and compound byte flag operations for the letter-list ready bits

## Objdiff
- main/gbaque MakeLetterList__8GbaQueueFiPc: 59.172703% -> 61.013927%
- final symbol size: target 1436b, built 1420b

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/gbaque -o - MakeLetterList__8GbaQueueFiPc