### PR TITLE
Use real particle object types for ChangeTex

### DIFF
--- a/include/ffcc/pppChangeTex.h
+++ b/include/ffcc/pppChangeTex.h
@@ -4,12 +4,13 @@
 #include "ffcc/chara.h"
 #include "ffcc/materialman.h"
 #include "ffcc/mapmesh.h"
+#include "ffcc/partMng.h"
 #include "dolphin/gx/GXDispList.h"
 #include "dolphin/gx/GXVert.h"
 #include <dolphin/types.h>
 
 struct pppChangeTex {
-    u32 m_graphId;
+    _pppPObject m_object;
 };
 
 struct pppChangeTexUnkB {

--- a/include/ffcc/pppYmChangeTex.h
+++ b/include/ffcc/pppYmChangeTex.h
@@ -2,11 +2,11 @@
 #define _PPP_YMCHANGETEX_H_
 
 #include "ffcc/chara.h"
+#include "ffcc/partMng.h"
 #include <dolphin/types.h>
 
 struct pppYmChangeTex {
-    u8 _pad0[0xC];
-    s32 m_graphId;
+    _pppPObject m_object;
 };
 
 struct pppYmChangeTexStep {

--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -12,19 +12,6 @@ extern unsigned char gPppInConstructor;
 #include <string.h>
 #include <dolphin/os/OSCache.h>
 
-struct _pppMngStChangeTex {
-	char _pad0[0xd8];
-	void* m_charaObj;
-};
-
-struct _pppEnvStChangeTex {
-	void* m_stagePtr;
-	CMaterialSet* m_materialSetPtr;
-	CMapMesh** m_mapMeshPtr;
-};
-extern _pppMngStChangeTex* pppMngStPtr;
-extern _pppEnvStChangeTex* pppEnvStPtr;
-
 struct ChangeTexDisplayList {
 	u32 m_size;
 	void* m_data;
@@ -136,8 +123,8 @@ extern "C" {
 		void* GetCharaHandlePtr__FP8CGObjectl(void* obj, long index);
 		int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void* handle);
 		void pppHeapUseRate__FPQ27CMemory6CStage(void* stage);
-		void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(void*, long, float&, float&, float&, float, float&, float&);
-		void* GetTextureFromRSD__FiP9_pppEnvSt(int, _pppEnvStChangeTex*);
+		void CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(_pppPObject*, long, float&, float&, float&, float, float&, float&);
+		void* GetTextureFromRSD__FiP9_pppEnvSt(int, _pppEnvSt*);
 		void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
 		void ReWriteDisplayList__5CUtilFPvUlUl(CUtil*, void*, unsigned long, unsigned long);
 		void CalcBoundaryBoxQuantized__5CUtilFP3VecP3VecP6S16VecUlUl(CUtil*, Vec*, Vec*, S16Vec*, unsigned long, unsigned long);
@@ -157,7 +144,7 @@ void pppRenderChangeTex(pppChangeTex*, pppChangeTexUnkB* step, pppChangeTexUnkC*
 	int textureIndex;
 
 	if (step->m_dataValIndex != 0xffff) {
-		_pppEnvStChangeTex* env = pppEnvStPtr;
+		_pppEnvSt* env = pppEnvStPtr;
 		CMapMesh* mapMesh = env->m_mapMeshPtr[step->m_dataValIndex];
 		textureIndex = 0;
 		GetTexture__8CMapMeshFP12CMaterialSetRi(
@@ -183,18 +170,17 @@ void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChang
 	}
 
 	s32* serializedDataOffsets = data->m_serializedDataOffsets;
-	u8* base = (u8*)changeTex;
-	ChangeTexWork* work = (ChangeTexWork*)(base + serializedDataOffsets[2] + 0x80);
-	u8* colorData = base + serializedDataOffsets[1] + 0x80;
-	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_charaObj, 0);
+	ChangeTexWork* work = (ChangeTexWork*)(changeTex->m_object.m_workArea + serializedDataOffsets[2]);
+	u8* colorData = changeTex->m_object.m_workArea + serializedDataOffsets[1];
+	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_owner, 0);
 	CChara::CModel* model0 = GetCharaModelPtr(handle0);
 	ChangeTexModelRaw* model0Raw = (ChangeTexModelRaw*)model0;
 
 	CalcGraphValue__FP11_pppPObjectlRfRfRffRfRf(
-	    changeTex, step->m_graphId, work->m_value0, work->m_value1, work->m_value2, step->m_initWOrk,
+	    &changeTex->m_object, step->m_graphId, work->m_value0, work->m_value1, work->m_value2, step->m_initWOrk,
 	    step->m_stepValue, step->m_arg3);
 
-	work->m_charaObj = (CGObject*)pppMngStPtr->m_charaObj;
+	work->m_charaObj = (CGObject*)pppMngStPtr->m_owner;
 	work->m_context = pppEnvStPtr;
 	model0Raw->m_state = work;
 	model0Raw->m_step = step;
@@ -343,7 +329,7 @@ void pppDestructChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
 {
 	_WaitDrawDone__8CGraphicFPci(&Graphic, const_cast<char*>(s_pppChangeTex_cpp_801dd660), 0x9d);
 	int dataOffset = data->m_serializedDataOffsets[2];
-	ChangeTexWork* work = (ChangeTexWork*)((char*)changeTex + dataOffset + 0x80);
+	ChangeTexWork* work = (ChangeTexWork*)(changeTex->m_object.m_workArea + dataOffset);
 	void* handle0 = GetCharaHandlePtr__FP8CGObjectl(work->m_charaObj, 0);
 	void* handle1 = GetCharaHandlePtr__FP8CGObjectl(work->m_charaObj, 1);
 	void* handle2 = GetCharaHandlePtr__FP8CGObjectl(work->m_charaObj, 2);
@@ -435,7 +421,7 @@ freeArrays:
  */
 void pppConstruct2ChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
 {
-	ChangeTexWork* work = (ChangeTexWork*)((char*)changeTex + data->m_serializedDataOffsets[2] + 0x80);
+	ChangeTexWork* work = (ChangeTexWork*)(changeTex->m_object.m_workArea + data->m_serializedDataOffsets[2]);
 	float init = kPppChangeTexInit;
 
 	work->m_value0 = init;
@@ -455,7 +441,7 @@ void pppConstruct2ChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
 void pppConstructChangeTex(pppChangeTex* changeTex, pppChangeTexUnkC* data)
 {
 	float init = kPppChangeTexInit;
-	ChangeTexWork* work = (ChangeTexWork*)((char*)changeTex + data->m_serializedDataOffsets[2] + 0x80);
+	ChangeTexWork* work = (ChangeTexWork*)(changeTex->m_object.m_workArea + data->m_serializedDataOffsets[2]);
 
 	work->m_value0 = init;
 	work->m_value2 = init;

--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -8,17 +8,6 @@
 #include <dolphin/os/OSCache.h>
 #include "ffcc/ppp_linkage.h"
 
-struct _pppMngStYmChangeTex {
-	char _pad0[0xd8];
-	void* m_charaObj;
-};
-
-struct _pppEnvStYmChangeTex {
-	void* m_stagePtr;
-	CMaterialSet* m_materialSetPtr;
-	CMapMesh** m_mapMeshPtr;
-};
-
 struct ChangeTexDisplayList {
 	u32 m_size;
 	void* m_data;
@@ -83,9 +72,6 @@ struct ChangeTexModelRaw {
 	void (*m_afterDrawMeshCallback)(CChara::CModel*, void*, void*, int, float (*)[4]);
 };
 
-extern _pppMngStYmChangeTex* pppMngStPtr;
-extern _pppEnvStYmChangeTex* pppEnvStPtr;
-
 extern const char s_pppYmChangeTex_cpp_801db4c0[] = "pppYmChangeTex.cpp";
 extern const float FLOAT_80330df8;
 extern const float FLOAT_80330dfc;
@@ -119,7 +105,7 @@ extern "C" {
 	void _GXSetTevSwapMode__F13_GXTevStageID13_GXTevSwapSel13_GXTevSwapSel(int, int, int);
 	void* GetCharaHandlePtr__FP8CGObjectl(void*, long);
 	int GetCharaModelPtr__FPQ29CCharaPcs7CHandle(void*);
-	void* GetTextureFromRSD__FiP9_pppEnvSt(int, _pppEnvStYmChangeTex*);
+	void* GetTextureFromRSD__FiP9_pppEnvSt(int, _pppEnvSt*);
 	void* pppMemAlloc__FUlPQ27CMemory6CStagePci(unsigned long, void*, char*, int);
 	void ReWriteDisplayList__5CUtilFPvUlUl(CUtil*, void*, unsigned long, unsigned long);
 	void pppHeapUseRate__FPQ27CMemory6CStage(void*);
@@ -139,7 +125,7 @@ void pppRenderYmChangeTex(pppYmChangeTex*, pppYmChangeTexStep* step, pppYmChange
 {
 	int textureIndex;
 	if (step->m_dataValIndex != 0xffff) {
-		_pppEnvStYmChangeTex* env = pppEnvStPtr;
+		_pppEnvSt* env = pppEnvStPtr;
 		CMapMesh* mapMesh = env->m_mapMeshPtr[step->m_dataValIndex];
 		textureIndex = 0;
 		GetTexture__8CMapMeshFP12CMaterialSetRi(mapMesh, env->m_materialSetPtr, textureIndex);
@@ -163,13 +149,12 @@ void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, 
 	}
 
 	s32* serializedDataOffsets = data->m_serializedDataOffsets;
-	u8* base = (u8*)ymChangeTex;
-	pppYmChangeTexState* state = (pppYmChangeTexState*)(base + serializedDataOffsets[2] + 0x80);
-	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_charaObj, 0);
+	pppYmChangeTexState* state = (pppYmChangeTexState*)(ymChangeTex->m_object.m_workArea + serializedDataOffsets[2]);
+	CCharaPcs::CHandle* handle0 = GetCharaHandlePtr((CGObject*)pppMngStPtr->m_owner, 0);
 	CChara::CModel* model0 = GetCharaModelPtr(handle0);
 	ChangeTexModelRaw* model0Raw = (ChangeTexModelRaw*)model0;
 
-	state->m_charaObj = (CGObject*)pppMngStPtr->m_charaObj;
+	state->m_charaObj = (CGObject*)pppMngStPtr->m_owner;
 	state->m_context = pppEnvStPtr;
 	model0Raw->m_state = state;
 	model0Raw->m_step = step;
@@ -202,7 +187,7 @@ void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, 
 
 	state->m_value1 = state->m_value1 + state->m_value2;
 	state->m_value0 = state->m_value0 + state->m_value1;
-	if (step->m_graphId == ymChangeTex->m_graphId) {
+	if (step->m_graphId == ymChangeTex->m_object.m_graphId) {
 		state->m_value0 = state->m_value0 + step->m_initWOrk;
 		state->m_value1 = state->m_value1 + step->m_stepValue;
 		state->m_value2 = state->m_value2 + step->m_arg3;
@@ -319,7 +304,7 @@ void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, 
 void pppDestructYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexData* data)
 {
 	pppYmChangeTexState* state =
-	    (pppYmChangeTexState*)((char*)ymChangeTex + 0x80 + data->m_serializedDataOffsets[2]);
+	    (pppYmChangeTexState*)(ymChangeTex->m_object.m_workArea + data->m_serializedDataOffsets[2]);
 	void* handle0 = GetCharaHandlePtr__FP8CGObjectl(state->m_charaObj, 0);
 	void* handle1 = GetCharaHandlePtr__FP8CGObjectl(state->m_charaObj, 1);
 	void* handle2 = GetCharaHandlePtr__FP8CGObjectl(state->m_charaObj, 2);
@@ -413,7 +398,7 @@ void pppConstructYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexData* da
 {
 	float init = ChangeTexConst(kPppYmChangeTexInitZero);
 	pppYmChangeTexState* state =
-	    (pppYmChangeTexState*)((char*)ymChangeTex + data->m_serializedDataOffsets[2] + 0x80);
+	    (pppYmChangeTexState*)(ymChangeTex->m_object.m_workArea + data->m_serializedDataOffsets[2]);
 
 	state->m_value0 = init;
 	state->m_value2 = init;


### PR DESCRIPTION
## Summary
- Model pppChangeTex and pppYmChangeTex as full _pppPObject instances instead of small padded stand-ins.
- Use the shared _pppMngSt/_pppEnvSt declarations and m_owner/m_workArea member access in the ChangeTex sources.
- Remove local manager/env shim structs and tighten CalcGraphValue/GetTextureFromRSD declarations.

## Evidence
- ninja passes for GCCP01.
- pppChangeTex objdiff remains stable: .text 97.64122%, pppFrameChangeTex 98.56347%, pppDestructChangeTex 98.888885%, render/construct functions 100%.
- pppYmChangeTex objdiff remains stable: .text 97.134056%, pppFrameYmChangeTex 98.18355%, pppDestructYmChangeTex 98.88%, render/construct functions 100%.

## Plausibility
- These particle objects are accessed through the standard _pppPObject work area at 0x80 and graph id in the embedded object header. Using the existing shared declarations is closer to source than private pad structs and raw base+0x80 arithmetic.