### PR TITLE
Match CNode ref data constructor

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -2568,15 +2568,14 @@ void CChara::CNode::CalcBind(CChara::CModel* model)
  */
 CChara::CNode::CRefData::CRefData()
 {
-	u8* raw = reinterpret_cast<u8*>(this);
-	u16 invalidIndex = 0xFF;
+	s8* raw = reinterpret_cast<s8*>(this);
 
-	raw[0x8D] = invalidIndex;
+	raw[0x8D] = -1;
 	raw[0x8E] = 0;
 	raw[0x8A] = 0;
 	memset(raw + 0x6A, 0, 0x20);
 	*reinterpret_cast<float*>(raw + 0x60) = FLOAT_803301b0;
-	raw[0x90] = invalidIndex;
+	raw[0x90] = -1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Match `CChara::CNode::CRefData::CRefData` by treating sentinel byte fields as signed `-1` values.
- Removes the unsigned `0xFF` temporary that emitted `li 255` instead of the target `li -1`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/chara -o - __ct__Q36CChara5CNode8CRefDataFv`
  - before: 99.916664%, 2 instruction diffs
  - after: 100.0%, 0 instruction diffs
- Build progress increased by one matched function and 96 matched code bytes.

## Plausibility
- These fields are sentinel byte indices/flags, and the target code materializes them as signed `-1` before byte stores. The source now expresses that directly without address or section hacks.