### PR TITLE
Improve CChara node constructors

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -2431,7 +2431,7 @@ CChara::CNode::CNode()
 	*(u32*)((u8*)this + 0x4) = 0;
 	*(u32*)((u8*)this + 0x9C) = 0;
 	*(u32*)((u8*)this + 0xA0) = 0;
-	*(u8*)((u8*)this + 0xBC) = (*(u8*)((u8*)this + 0xBC) & 0x7F) | 0x80;
+	*(u8*)((u8*)this + 0xBC) = static_cast<u8>(__rlwimi(*(u8*)((u8*)this + 0xBC), 1, 7, 24, 24));
 }
 
 /*
@@ -2569,14 +2569,14 @@ void CChara::CNode::CalcBind(CChara::CModel* model)
 CChara::CNode::CRefData::CRefData()
 {
 	u8* raw = reinterpret_cast<u8*>(this);
-	u16 invalidIndex = 0xFF;
+	s8* sraw = reinterpret_cast<s8*>(this);
 
-	raw[0x8D] = invalidIndex;
+	sraw[0x8D] = -1;
 	raw[0x8E] = 0;
 	raw[0x8A] = 0;
 	memset(raw + 0x6A, 0, 0x20);
 	*reinterpret_cast<float*>(raw + 0x60) = FLOAT_803301b0;
-	raw[0x90] = invalidIndex;
+	sraw[0x90] = -1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Use the established rlwimi bit-set idiom in CChara::CNode::CNode for the node flag byte.
- Store CChara::CNode::CRefData invalid byte sentinels through a signed-byte view, matching the original -1 immediate while preserving the stored 0xff value.

## Evidence
- ninja passes for GCCP01.
- objdiff main/chara:
  - __ct__Q26CChara5CNodeFv: 80.2083% -> 97.4167%
  - __ct__Q36CChara5CNode8CRefDataFv: 99.9167% -> 100.0000%
  - .text: 49.4117% -> 49.4928% from the ref-data baseline including both constructor improvements.

## Plausibility
- The rlwimi form matches existing flag manipulation style used elsewhere in this codebase.
- The signed-byte sentinel keeps the same byte data value but matches the original compiler immediate for invalid byte fields.