### PR TITLE
Enable RTTI for textureman

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -752,7 +752,7 @@ config.libs = [
             Object(NonMatching, "stopwatch.cpp"),
             Object(NonMatching, "system.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "texanim.cpp"),
-            Object(NonMatching, "textureman.cpp"),
+            Object(NonMatching, "textureman.cpp", extra_cflags=["-RTTI on", "-str reuse,pool,readonly"]),
             Object(
                 NonMatching,
                 "THPDraw.cpp",


### PR DESCRIPTION
## Summary
- Enable RTTI for textureman.cpp and keep RTTI strings pooled/read-only for the unit.
- This lets the compiled object emit RTTI-bearing vtables for CTextureSet, CTexture, CTextureMan, and CPtrArray<CTexture*> through normal compiler output.

## Evidence
- ninja passes for GCCP01.
- Compiled .data size for build/GCCP01/src/textureman.o is now 0x84, matching build/GCCP01/obj/textureman.o.
- .data relocations now include RTTI references for the textureman polymorphic classes instead of RTTI-less vtable entries.
- Build report for main/textureman: fuzzy 98.484505%; key remaining mismatches include InitTexObj 92.41573%, CacheLoadTexture 93.80734%, and CTexture::Create 97.82539%.

## Plausibility
- The PAL object references RTTI from its vtable groups, and neighboring polymorphic manager/ref units already use -RTTI on.
- This avoids hand-written vtables/RTTI and relies on Metrowerks to generate the ABI data.