### PR TITLE
Match map object debug draw helpers

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -141,6 +141,11 @@ static inline CMapObj* MapObjArrayStart()
     return reinterpret_cast<CMapObj*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x954);
 }
 
+static inline Mtx& MapObjHitDrawMtx()
+{
+    return *reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x228F8);
+}
+
 }
 
 extern "C" void __dl__FPv(void*);
@@ -1397,7 +1402,7 @@ void CMapObj::SetDrawFlag()
 void CMapObj::DrawHit()
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0)) {
-        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        MaterialMan.SetObjMatrix(MapObjHitDrawMtx(), MtxAt(this, 0xB8));
         reinterpret_cast<CMapHit*>(m_mapData)->Draw();
     }
 }
@@ -1414,7 +1419,7 @@ void CMapObj::DrawHit()
 void CMapObj::DrawHitWire()
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0)) {
-        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        MaterialMan.SetObjMatrix(MapObjHitDrawMtx(), MtxAt(this, 0xB8));
         reinterpret_cast<CMapHit*>(m_mapData)->DrawWire();
     }
 }
@@ -1431,7 +1436,7 @@ void CMapObj::DrawHitWire()
 void CMapObj::DrawHitNormal()
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0)) {
-        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        MaterialMan.SetObjMatrix(MapObjHitDrawMtx(), MtxAt(this, 0xB8));
         reinterpret_cast<CMapHit*>(m_mapData)->DrawNormal();
     }
 }

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1373,18 +1373,17 @@ void CMapObj::Draw(unsigned char priority)
  */
 void CMapObj::SetDrawFlag()
 {
-    unsigned char* self = reinterpret_cast<unsigned char*>(this);
-    self[0x18] &= 0xFB;
+    U8At(this, 0x18) &= ~4;
 
-    if ((static_cast<signed char>(self[0x1D]) == 1) && (m_mapData != 0)) {
-        if ((static_cast<signed char>(self[0x1F]) == -1) && ((self[0x18] & 1) != 0)) {
+    if ((U8At(this, 0x1D) == 1) && (m_mapData != 0)) {
+        if ((static_cast<signed char>(U8At(this, 0x1F)) == -1) && ((U8At(this, 0x18) & 1) != 0)) {
             Mtx concatMtx;
-            unsigned char* mapMng = reinterpret_cast<unsigned char*>(&MapMng);
-            CBound* bound = reinterpret_cast<CBound*>(reinterpret_cast<unsigned char*>(m_mapData) + 0xC);
 
-            PSMTXConcat(*reinterpret_cast<Mtx*>(mapMng + 0x22958), *reinterpret_cast<Mtx*>(self + 0xB8), concatMtx);
-            if (bound->CheckFrustum(*reinterpret_cast<Vec*>(mapMng + 0x228EC), concatMtx, *reinterpret_cast<float*>(mapMng + 0x22A74)) != 0) {
-                self[0x18] |= 4;
+            PSMTXConcat(*reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x22958), MtxAt(this, 0xB8), concatMtx);
+            if (reinterpret_cast<CBound*>(reinterpret_cast<unsigned char*>(m_mapData) + 0xC)
+                    ->CheckFrustum(*reinterpret_cast<Vec*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x228EC), concatMtx,
+                                   *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x22A74)) != 0) {
+                U8At(this, 0x18) |= 4;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace the hardcoded hit debug draw matrix address with a MapMng-relative matrix helper.
- Reshape CMapObj::SetDrawFlag to use the same MapMng-relative accesses and bit-clear form as the target.

## Objdiff evidence
- main/mapobj .text: 51.590607% -> 52.100124%
- SetDrawFlag__7CMapObjFv: 75.38298% -> 100.0%
- DrawHit__7CMapObjFv: 91.5% -> 100.0%
- DrawHitWire__7CMapObjFv: 91.5% -> 100.0%
- DrawHitNormal__7CMapObjFv: 91.5% -> 100.0%
- mapobj matched functions: 16/32 -> 20/32

## Plausibility
- The target loads the debug draw matrix from MapMng + 0x228F8, not an absolute literal address.
- The SetDrawFlag rewrite keeps the same behavior while matching the target's direct MapMng-relative matrix/frustum accesses.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/mapobj -o - SetDrawFlag__7CMapObjFv