### PR TITLE
Match CChara node refdata constructor

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -2568,8 +2568,8 @@ void CChara::CNode::CalcBind(CChara::CModel* model)
  */
 CChara::CNode::CRefData::CRefData()
 {
-	u8* raw = reinterpret_cast<u8*>(this);
-	u16 invalidIndex = 0xFF;
+	s8* raw = reinterpret_cast<s8*>(this);
+	int invalidIndex = -1;
 
 	raw[0x8D] = invalidIndex;
 	raw[0x8E] = 0;


### PR DESCRIPTION
## What changed
- Treat the CChara::CNode::CRefData constructor raw byte view as signed bytes.
- Initialize the node refdata sentinel index with -1 instead of an unsigned 0xFF literal.

## Objdiff evidence
- main/chara __ct__Q36CChara5CNode8CRefDataFv: 99.916664% -> 100.0% (96 bytes matched)
- main/chara .text: 49.41165% -> 49.41204%

## Plausibility
The affected fields are sentinel byte indices. Using a signed -1 sentinel preserves the stored byte value while matching the original compiler output and better expresses the invalid-index intent.