### PR TITLE
Match CChara refdata and map object draw helpers

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -2568,8 +2568,8 @@ void CChara::CNode::CalcBind(CChara::CModel* model)
  */
 CChara::CNode::CRefData::CRefData()
 {
-	u8* raw = reinterpret_cast<u8*>(this);
-	u16 invalidIndex = 0xFF;
+	s8* raw = reinterpret_cast<s8*>(this);
+	int invalidIndex = -1;
 
 	raw[0x8D] = invalidIndex;
 	raw[0x8E] = 0;

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -141,6 +141,11 @@ static inline CMapObj* MapObjArrayStart()
     return reinterpret_cast<CMapObj*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x954);
 }
 
+static inline Mtx& MapObjHitDrawMtx()
+{
+    return *reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x228F8);
+}
+
 }
 
 extern "C" void __dl__FPv(void*);
@@ -1368,18 +1373,17 @@ void CMapObj::Draw(unsigned char priority)
  */
 void CMapObj::SetDrawFlag()
 {
-    unsigned char* self = reinterpret_cast<unsigned char*>(this);
-    self[0x18] &= 0xFB;
+    U8At(this, 0x18) &= ~4;
 
-    if ((static_cast<signed char>(self[0x1D]) == 1) && (m_mapData != 0)) {
-        if ((static_cast<signed char>(self[0x1F]) == -1) && ((self[0x18] & 1) != 0)) {
+    if ((U8At(this, 0x1D) == 1) && (m_mapData != 0)) {
+        if ((static_cast<signed char>(U8At(this, 0x1F)) == -1) && ((U8At(this, 0x18) & 1) != 0)) {
             Mtx concatMtx;
-            unsigned char* mapMng = reinterpret_cast<unsigned char*>(&MapMng);
-            CBound* bound = reinterpret_cast<CBound*>(reinterpret_cast<unsigned char*>(m_mapData) + 0xC);
 
-            PSMTXConcat(*reinterpret_cast<Mtx*>(mapMng + 0x22958), *reinterpret_cast<Mtx*>(self + 0xB8), concatMtx);
-            if (bound->CheckFrustum(*reinterpret_cast<Vec*>(mapMng + 0x228EC), concatMtx, *reinterpret_cast<float*>(mapMng + 0x22A74)) != 0) {
-                self[0x18] |= 4;
+            PSMTXConcat(*reinterpret_cast<Mtx*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x22958), MtxAt(this, 0xB8), concatMtx);
+            if (reinterpret_cast<CBound*>(reinterpret_cast<unsigned char*>(m_mapData) + 0xC)
+                    ->CheckFrustum(*reinterpret_cast<Vec*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x228EC), concatMtx,
+                                   *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(&MapMng) + 0x22A74)) != 0) {
+                U8At(this, 0x18) |= 4;
             }
         }
     }
@@ -1397,7 +1401,7 @@ void CMapObj::SetDrawFlag()
 void CMapObj::DrawHit()
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0)) {
-        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        MaterialMan.SetObjMatrix(MapObjHitDrawMtx(), MtxAt(this, 0xB8));
         reinterpret_cast<CMapHit*>(m_mapData)->Draw();
     }
 }
@@ -1414,7 +1418,7 @@ void CMapObj::DrawHit()
 void CMapObj::DrawHitWire()
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0)) {
-        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        MaterialMan.SetObjMatrix(MapObjHitDrawMtx(), MtxAt(this, 0xB8));
         reinterpret_cast<CMapHit*>(m_mapData)->DrawWire();
     }
 }
@@ -1431,7 +1435,7 @@ void CMapObj::DrawHitWire()
 void CMapObj::DrawHitNormal()
 {
     if ((U8At(this, 0x1D) == 2) && (m_mapData != 0)) {
-        MaterialMan.SetObjMatrix(reinterpret_cast<float(*)[4]>(0x8026805C), MtxAt(this, 0xB8));
+        MaterialMan.SetObjMatrix(MapObjHitDrawMtx(), MtxAt(this, 0xB8));
         reinterpret_cast<CMapHit*>(m_mapData)->DrawNormal();
     }
 }


### PR DESCRIPTION
## Summary
- Match `CChara::CNode::CRefData` constructor by using signed `-1` sentinel initialization.
- Match `CMapObj::SetDrawFlag` byte access/source shape.
- Replace hardcoded map object hit draw matrix address with `MapMng`-relative access for `DrawHit`, `DrawHitWire`, and `DrawHitNormal`.

## Evidence
- `ninja` succeeds.
- Final report: matched code `587816 / 1855224`, matched functions `3453 / 4732`.
- Run-start report was matched code `587220`, matched functions `3448`, so this branch gains 596 matched code bytes and 5 matched functions.
- `build/tools/objdiff-cli diff -p . -u main/chara -o - __ct__Q36CChara5CNode8CRefDataFv`: 100.0%, 96 bytes.
- `build/tools/objdiff-cli diff -p . -u main/mapobj -o - SetDrawFlag__7CMapObjFv`: 100.0%, 188 bytes.
- `DrawHit__7CMapObjFv`, `DrawHitWire__7CMapObjFv`, and `DrawHitNormal__7CMapObjFv` are 100.0% in the final report.

## Plausibility
- The node refdata fields are byte-sized invalid-index sentinels, so assigning signed `-1` is plausible source and stores the same 0xff value.
- The map object changes replace raw byte/address manipulation with existing helpers and `MapMng`-relative matrix access rather than hardcoded absolute addresses.
