### PR TITLE
Match FunnyShape pointer array destructor order

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -473,6 +473,12 @@ CPtrArray<_GXTexObj*>::CPtrArray()
 }
 
 template <>
+CPtrArray<_GXTexObj*>::~CPtrArray()
+{
+    RemoveAll();
+}
+
+template <>
 CPtrArray<OSFS_TEXTURE_ST*>::CPtrArray()
 {
     numItems = 0;
@@ -485,12 +491,6 @@ CPtrArray<OSFS_TEXTURE_ST*>::CPtrArray()
 
 template <>
 CPtrArray<OSFS_TEXTURE_ST*>::~CPtrArray()
-{
-    RemoveAll();
-}
-
-template <>
-CPtrArray<_GXTexObj*>::~CPtrArray()
 {
     RemoveAll();
 }


### PR DESCRIPTION
## Summary
- Reorders the explicit CPtrArray<_GXTexObj*> destructor specialization in p_FunnyShape.cpp so the emitted constructor/destructor sequence matches the target order for the GX pointer-array specialization.
- Leaves the existing source-level destructor bodies unchanged; this is a definition-order fix, not a manual vtable or section workaround.

## Evidence
- Built with: ninja
- p_FunnyShape objdiff before: extabindex symbol [extabindex-0] 93.333336%
- p_FunnyShape objdiff after: extabindex symbol [extabindex-0] 95.0%
- main/gxfunc was inspected but left unchanged; its objdiff remained identical.

## Plausibility
The target object emits the _GXTexObj pointer-array constructor followed by its destructor before the OSFS_TEXTURE_ST pointer-array constructor/destructor pair. Reordering the explicit specialization definitions makes the generated code order match that target layout while keeping normal compiler-generated destructors and vtables.