### PR TITLE
Improve menu_tmparti draw conversion

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -31,7 +31,6 @@ extern const float FLOAT_80332f2c;
 extern const float FLOAT_80332f30;
 extern const float FLOAT_80332F34;
 extern const float FLOAT_80332F38;
-extern const double DOUBLE_80332f40;
 extern const double DOUBLE_80332f48;
 extern const double DOUBLE_80332f50;
 extern const double DOUBLE_80332f58;
@@ -40,17 +39,7 @@ extern const double DOUBLE_80333420 = 216.0;
 
 static inline double TmpArtiIntToDouble(int value)
 {
-    union {
-        struct {
-            unsigned int hi;
-            unsigned int lo;
-        } words;
-        double value;
-    } conv;
-
-    conv.words.hi = 0x43300000;
-    conv.words.lo = (unsigned int)value ^ 0x80000000U;
-    return conv.value - DOUBLE_80332f40;
+    return (double)value;
 }
 
 STATIC_ASSERT(offsetof(TmpArtiState, initialized) == 0xB);


### PR DESCRIPTION
## Summary
- Replace the manual TmpArti int-to-double bit conversion helper with a normal C++ cast.
- Removes the now-unused external conversion constant declaration.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o -:
  - TmpArtiDraw__8CMenuPcsFv: 85.89015% -> 86.09849%
  - .text: 81.78844% -> 81.86071%

## Plausibility
- This is more natural original source than constructing IEEE-754 conversion bits by hand.
- The compiler still emits the expected integer-to-double conversion sequence while improving the draw routine match.
