### PR TITLE
Improve MLstOpen loop shape

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -463,22 +463,21 @@ int CMenuPcs::MLstOpen()
 	itemCount = (unsigned int)this->lstData->count;
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
-	if ((int)itemCount > 0) {
-		for (unsigned int remaining = itemCount; remaining != 0; remaining--) {
-			if (entry->startFrame <= currentFrame) {
-				if (entry->startFrame + entry->duration <= currentFrame) {
-					completedItems++;
-					entry->alpha = FLOAT_803333F0;
-				} else {
-					entry->timer = entry->timer + 1;
-					double ratio = DOUBLE_80333410 / (double)entry->duration;
-					entry->alpha = (float)(ratio * (double)entry->timer);
-				}
+	for (int remaining = itemCount; remaining > 0; remaining--) {
+		if (entry->startFrame <= currentFrame) {
+			if (entry->startFrame + entry->duration <= currentFrame) {
+				completedItems++;
+				entry->alpha = FLOAT_803333F0;
+			} else {
+				entry->timer = entry->timer + 1;
+				double ratio = DOUBLE_80333410 / (double)entry->duration;
+				entry->alpha = (float)(ratio * (double)entry->timer);
 			}
-			entry++;
 		}
+		entry++;
 	}
 
+	int result = 0;
 	if (this->lstData->count == completedItems) {
 		one = FLOAT_803333F0;
 		entry = this->lstData->entries;
@@ -522,7 +521,7 @@ int CMenuPcs::MLstOpen()
 				} while (itemCount != 0);
 			}
 		}
-		return 1;
+		result = 1;
 	}
-	return 0;
+	return result;
 }


### PR DESCRIPTION
## Summary
- Reshape the MLstOpen animation update loop to match the target counted loop pattern more closely.
- Keep the return value in a local result variable so the success path sets it after cleanup instead of returning immediately.

## Objdiff evidence
Measured with:
`build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstOpen__8CMenuPcsFv`

Before:
- `MLstOpen__8CMenuPcsFv`: 84.98889%
- `main/menu_lst` .text: 85.44304%
- extabindex: 93.75%

After:
- `MLstOpen__8CMenuPcsFv`: 88.21111%
- `main/menu_lst` .text: 86.11047%
- extabindex: 93.75%

Other menu_lst functions are unchanged by score:
- `MLstDraw__8CMenuPcsFv`: 79.685234%
- `MLstClose__8CMenuPcsFv`: 85.607475%
- `MLstCtrl__8CMenuPcsFv`: 95.0%

## Plausibility
This keeps the same behavior while making MLstOpen use the same simple countdown loop shape already used by the close animation pass. I tested adjacent source-shape changes in MLstDraw and MLstClose, but left them out because they either moved metadata negatively or regressed function matching.