### PR TITLE
Fix mapocttree shadow bound check receiver

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1492,7 +1492,7 @@ void InsertShadow_r(COctNode* node)
 				s_light_no++;
 				COctNode* grandChild = childIter->m_children[0];
 
-				if ((reinterpret_cast<CBound*>(&s_bound)->CheckCross(*reinterpret_cast<CBound*>(grandChild))) != 0) {
+				if ((reinterpret_cast<CBound*>(grandChild)->CheckCross(*reinterpret_cast<CBound*>(&s_bound))) != 0) {
 					if ((s_light_no >= 3) && (grandChild->m_meshCount != 0)) {
 						setbit32(reinterpret_cast<unsigned long*>(Ptr(grandChild, 0x48)), s_insertShadowNo);
 					}


### PR DESCRIPTION
## Summary
- Update InsertShadow_r to call CBound::CheckCross on the grandchild node bound, passing s_bound as the argument.
- This matches the Ghidra call shape for 8002d628_InsertShadow_r__FP8COctNode and the objdiff register flow at the call site.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- build/tools/objdiff-cli diff -p . -u main/mapocttree -o - InsertShadow_r__FP8COctNode
  - InsertShadow_r__FP8COctNode: 95.30612% -> 95.38776%
  - main/mapocttree .text: 97.086494% -> 97.09338%

## Plausibility
- The source now treats each octree node as the bound being tested and the shared shadow bound as the query bound, matching adjacent InsertLight_r/cylinder traversal patterns rather than compiler coaxing.