### PR TITLE
Match CFont Create embedded data path

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -666,11 +666,8 @@ void CFont::Create(void* filePtr, CMemory::CStage* stage)
     CChunkFile::CChunk chunk;
 
     m_usesEmbeddedData = static_cast<unsigned char>((filePtr == 0) && (stage == 0));
-    if (m_usesEmbeddedData != 0) {
-        filePtr = g_tFont22;
-    }
 
-    CChunkFile chunkFile(filePtr);
+    CChunkFile chunkFile(m_usesEmbeddedData != 0 ? g_tFont22 : filePtr);
     while (chunkFile.GetNextChunk(chunk)) {
         switch (chunk.m_id) {
         case 'FONT':


### PR DESCRIPTION
## Summary
- Pass the embedded font archive directly into the CChunkFile constructor when CFont::Create uses internal data.
- This preserves the same behavior while matching the original constructor argument setup/order.

## Evidence
- ninja passes.
- objdiff: Create__5CFontFPvPQ27CMemory6CStage is now 100.0% matched (was 98.703705%).
- Build report improved from 3453 to 3454 matched functions and from 587816 to 588464 matched code bytes overall.

## Plausibility
- The change removes a temporary reassignment of filePtr and expresses the selected input buffer at the CChunkFile construction site, which is plausible original source and avoids any manual section/linkage tricks.