### PR TITLE
Improve CLine point distance flow

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1741,9 +1741,10 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
     Vec bestPosition;
 
     for (unsigned int i = 0; i + 1 < m_numPoints; i++) {
-        Vec candidate = m_points[i];
-        float distanceSq = PSVECSquareDistance(&candidate, targetPosition);
+        Vec* candidate = &m_points[i];
+        float distanceSq = PSVECSquareDistance(candidate, targetPosition);
         if (distanceSq < maxDistanceSq || infiniteRange) {
+            Vec candidatePosition = *candidate;
             float distance = distanceSq;
             if (distanceSq <= kLineSegmentMinT) {
                 distance = NAN;
@@ -1753,7 +1754,7 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
 
             if (distance < bestDistance) {
                 bestDistance = distance;
-                bestPosition = candidate;
+                bestPosition = candidatePosition;
                 bestIndex = i;
                 bestT = kLineSegmentMinT;
                 found = 1;
@@ -1761,9 +1762,10 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
         }
 
         if (i + 1 == m_numPoints - 1) {
-            candidate = m_points[i + 1];
-            distanceSq = PSVECSquareDistance(&candidate, targetPosition);
+            candidate = &m_points[i + 1];
+            distanceSq = PSVECSquareDistance(candidate, targetPosition);
             if (distanceSq < maxDistanceSq || infiniteRange) {
+                Vec candidatePosition = *candidate;
                 float distance = distanceSq;
                 if (distanceSq <= kLineSegmentMinT) {
                     distance = NAN;
@@ -1773,7 +1775,7 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
 
                 if (distance < bestDistance) {
                     bestDistance = distance;
-                    bestPosition = candidate;
+                    bestPosition = candidatePosition;
                     bestIndex = i;
                     bestT = kLineSegmentMaxT;
                     found = 1;


### PR DESCRIPTION
## Summary
- update CLine<64>::Calc to pass line points directly into PSVECSquareDistance
- keep the local Vec copy only after the point passes the range/infinite-range check

## Evidence
- ninja
- objdiff: Calc__9CLine<64>FP3VecPfPUlPfP3Vecf improved from 57.237762% to 62.496502%

## Plausibility
- Ghidra shows the original distance checks operating on the point pointer and copying the point into a local only inside the accepted branch
- this removes an eager stack Vec copy and better reflects the original control/data flow