### PR TITLE
Improve menu item draw constants

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -399,7 +399,7 @@ void CMenuPcs::ItemDraw()
             float fillW = alpha * w;
             if (fillW > FLOAT_80332e60) {
                 DrawRect__8CMenuPcsFUlffffffP8_GXColorfff(
-                    &MenuPcs, 0, x, y, fillW, h, u, v, barColors, FLOAT_80332e64, FLOAT_80332e64, 0.0f);
+                    &MenuPcs, 0, x, y, fillW, h, u, v, barColors, FLOAT_80332e64, FLOAT_80332e64, FLOAT_80332e60);
                 x += fillW;
                 u += fillW;
             }
@@ -425,7 +425,7 @@ void CMenuPcs::ItemDraw()
 
                 float remainW = (float)((double)(DOUBLE_80332e68 / (double)*(int*)(entry + 0x14)) * (double)w);
                 DrawRect__8CMenuPcsFUlffffffP8_GXColorfff(
-                    &MenuPcs, 0, x, y, remainW, h, u, v, fadeColors, FLOAT_80332e64, FLOAT_80332e64, 0.0f);
+                    &MenuPcs, 0, x, y, remainW, h, u, v, fadeColors, FLOAT_80332e64, FLOAT_80332e64, FLOAT_80332e60);
             }
 
             SetAttrFmt__8CMenuPcsFQ28CMenuPcs3FMT(&MenuPcs, 0);
@@ -520,9 +520,9 @@ void CMenuPcs::ItemDraw()
 
         s16 itemId = *(s16*)(caravanWork + menuIndex * 2 + 0xB6);
         if (itemId > 0) {
-            int iconY = (int)((float)iconEntry[1] + 6.0f - FLOAT_80332e64);
+            int iconY = (int)((float)(iconEntry[1] + 6) - FLOAT_80332e64);
             int iconX = (int)(float)(iconEntry[0] + iconEntry[2] - 0x10);
-            DrawSingleIcon__8CMenuPcsFiiifif(this, itemId, iconX, iconY, *(float*)(listStart + 8), 0, 0.0f);
+            DrawSingleIcon__8CMenuPcsFiiifif(this, itemId, iconX, iconY, *(float*)(listStart + 8), 0, FLOAT_80332e60);
         }
     }
 


### PR DESCRIPTION
## Summary
- Use the existing menu item zero float constant for ItemDraw draw calls instead of emitting local 0.0f literals.
- Keep item icon Y arithmetic as integer addition before float conversion, matching the Ghidra/decompiled shape more closely.

## Evidence
- Built successfully with ninja.
- Objdiff ItemDraw__8CMenuPcsFv improved from 68.44992% to 70.24962%.
- Compiled ItemDraw size moved from 2504 bytes to 2492 bytes toward the 2596-byte target.
- The extra local .sdata2 inserted literal changed from 0.0f + conversion data to only the remaining conversion data, removing the local zero literal.

## Plausibility
- This reuses existing constants already owned by the unit and keeps arithmetic in the same source-level shape shown by the decompilation, without adding address hacks or fake symbols.