### PR TITLE
Improve pppRandDownFV update ordering

### DIFF
--- a/src/pppRandDownFV.cpp
+++ b/src/pppRandDownFV.cpp
@@ -59,9 +59,10 @@ void pppRandDownFV(_pppPObject* basePtr, RandDownFVParams* in, _pppCtrlTable* ct
 
     s32 sourceOffset = in->sourceOffset;
     f32* target = (sourceOffset == -1) ? (f32*)gPppDefaultValueBuffer : (f32*)(base + sourceOffset + 0x80);
+    f32 delta = randf(in->blend[0], *valuePtr);
     f32 scale = *valuePtr;
 
-    target[0] += randf(in->blend[0], scale);
+    target[0] = delta + target[0];
     target[1] += randf(in->blend[1], scale);
     target[2] += randf(in->blend[2], scale);
 }


### PR DESCRIPTION
## Summary
- Reorders the first vector component update in `pppRandDownFV` to compute the blend delta before reusing the saved random scale.
- Mirrors the existing `pppRandUpFV` source shape and improves the generated instruction ordering without changing size or data.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppRandDownFV -o /tmp/randdownfv_final.json`
- `pppRandDownFV`: 99.710526% -> 99.73684%
- `@199`, `extab`, `extabindex`, and `.sdata2` remain 100%.

## Plausibility
- This is ordinary source-level expression ordering, matching the nearby `pppRandUpFV` pattern.
- No address constants, fake symbols, section forcing, or vtable/RTTI coercion.