### PR TITLE
Improve GbaQueue GetPlayerHP matching

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -2179,7 +2179,7 @@ unsigned int GbaQueue::GetScrFlg()
  */
 int GbaQueue::GetPlayerHP(int channel, unsigned char* outData)
 {
-	unsigned char* obj = reinterpret_cast<unsigned char*>(this);
+	char* obj = reinterpret_cast<char*>(this);
 	char hpFlags = 0;
 	char prevHpFlags = 0;
 	char hp;
@@ -2188,10 +2188,10 @@ int GbaQueue::GetPlayerHP(int channel, unsigned char* outData)
 	for (int i = 0; i < 4; i++) {
 		OSWaitSemaphore(accessSemaphores + i);
 
-		unsigned char* playerData = obj + i * 0xDC;
+		char* playerData = obj + i * 0xDC;
 		if (i == channel) {
-			hp = static_cast<char>(playerData[0x46B]);
-			prevHp = static_cast<char>(playerData[0x7DB]);
+			hp = playerData[0x46B];
+			prevHp = playerData[0x7DB];
 		}
 		if (playerData[0x46B] != 0) {
 			hpFlags = static_cast<char>(hpFlags | (1 << i));
@@ -2203,8 +2203,15 @@ int GbaQueue::GetPlayerHP(int channel, unsigned char* outData)
 		OSSignalSemaphore(accessSemaphores + i);
 	}
 
-	unsigned char channelMask = static_cast<unsigned char>(1 << channel);
-	unsigned int changed = (prevHpFlags != hpFlags);
+	int hpChanged = hp != prevHp;
+	unsigned int changed = static_cast<unsigned int>(
+	    (static_cast<int>(prevHpFlags) - static_cast<int>(hpFlags)) |
+	    (static_cast<int>(hpFlags) - static_cast<int>(prevHpFlags))) >> 31;
+	if (hpChanged) {
+		changed = 1;
+	}
+
+	int channelMask = 1 << channel;
 	if (hp != prevHp) {
 		changed = 1;
 	}


### PR DESCRIPTION
## Summary
- Treat the HP flag backing bytes as signed chars in `GbaQueue::GetPlayerHP`
- Match the original change-detection arithmetic for current/previous HP flag masks
- Preserve the channel-mask change check used for the output payload

## Evidence
- `GetPlayerHP__8GbaQueueFiPUc`: 67.16868% -> 81.74699%
- `main/gbaque` .text: 80.900764% -> 81.03629%
- Full `ninja` build succeeds

## Plausibility
The change removes unsigned-byte reads from fields that the target code sign-extends, and expresses the nonzero/change tests using the same signed `char` semantics visible in the decompilation.