### PR TITLE
Improve cflat runtime object deletion paths

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -133,6 +133,7 @@ void CFlatRuntime::Destroy()
 	typedef void (*OnDeleteFn)(CFlatRuntime*, CFlatRuntime::CObject*);
 
 	u8* const self = reinterpret_cast<u8*>(this);
+	const u32 clearBit = 0;
 	CObject* const root = &m_objectSentinel;
 	CObject* object = m_objectSentinel.m_next;
 
@@ -145,11 +146,10 @@ void CFlatRuntime::Destroy()
 		*reinterpret_cast<void**>(reinterpret_cast<u8*>(*object->m_freeListNode) + 4) = object->m_freeListNode[1];
 		*reinterpret_cast<void**>(object->m_freeListNode[1]) = *object->m_freeListNode;
 
-		void** freeHead = m_objectFreeListHead;
-		object->m_freeListNode[1] = freeHead[0];
-		freeHead[0] = object->m_freeListNode;
+		object->m_freeListNode[1] = m_objectFreeListHead;
+		m_objectFreeListHead = object->m_freeListNode;
 
-		object->m_flags &= 0xEF;
+		object->m_flags = static_cast<u8>(__rlwimi(object->m_flags, clearBit, 4, 27, 27));
 
 		OnDeleteFn onDelete = reinterpret_cast<OnDeleteFn>((*reinterpret_cast<void***>(this))[7]);
 		onDelete(this, object);
@@ -721,7 +721,7 @@ int CFlatRuntime::Frame(int unused, int mode)
 			object->m_freeListNode[1] = *reinterpret_cast<void***>(self + 0x98C);
 			*reinterpret_cast<void***>(self + 0x98C) = object->m_freeListNode;
 
-			object->m_flags &= 0xEF;
+			object->m_flags = static_cast<u8>(__rlwimi(object->m_flags, 0, 4, 27, 27));
 
 			typedef void (*OnDeleteFn)(CFlatRuntime*, CObject*);
 			reinterpret_cast<OnDeleteFn>((*reinterpret_cast<void***>(this))[7])(this, object);
@@ -744,6 +744,7 @@ int CFlatRuntime::Frame(int unused, int mode)
  */
 void CFlatRuntime::AfterFrame(int mode)
 {
+	const u32 clearBit = 0;
 	CObject* object = m_objectSentinel.m_next;
 
 	while (object != &m_objectSentinel) {
@@ -756,11 +757,10 @@ void CFlatRuntime::AfterFrame(int mode)
 			*reinterpret_cast<void**>(reinterpret_cast<u8*>(*object->m_freeListNode) + 4) = object->m_freeListNode[1];
 			*reinterpret_cast<void**>(object->m_freeListNode[1]) = *object->m_freeListNode;
 
-			void** freeHead = m_objectFreeListHead;
-			object->m_freeListNode[1] = freeHead[0];
-			freeHead[0] = object->m_freeListNode;
+			object->m_freeListNode[1] = m_objectFreeListHead;
+			m_objectFreeListHead = object->m_freeListNode;
 
-			object->m_flags &= 0xEF;
+			object->m_flags = static_cast<u8>(__rlwimi(object->m_flags, clearBit, 4, 27, 27));
 
 			typedef void (*OnDeleteFn)(CFlatRuntime*, CObject*);
 			reinterpret_cast<OnDeleteFn>((*reinterpret_cast<void***>(this))[7])(this, object);
@@ -781,17 +781,18 @@ void CFlatRuntime::AfterFrame(int mode)
  */
 void CFlatRuntime::deleteObject(CFlatRuntime::CObject* object)
 {
+	const u32 clearBit = 0;
+
 	object->m_previous->m_next = object->m_next;
 	object->m_next->m_previous = object->m_previous;
 
 	*(void**)((char*)*object->m_freeListNode + 4) = object->m_freeListNode[1];
 	*(void**)object->m_freeListNode[1] = *object->m_freeListNode;
 
-	void** freeHead = m_objectFreeListHead;
-	object->m_freeListNode[1] = freeHead[0];
-	freeHead[0] = object->m_freeListNode;
+	object->m_freeListNode[1] = m_objectFreeListHead;
+	m_objectFreeListHead = object->m_freeListNode;
 
-	object->m_flags &= 0xEF;
+	object->m_flags = static_cast<u8>(__rlwimi(object->m_flags, clearBit, 4, 27, 27));
 
 	typedef void (*OnDeleteFn)(CFlatRuntime*, CObject*);
 	reinterpret_cast<OnDeleteFn>((*reinterpret_cast<void***>(this))[7])(this, object);
@@ -2231,7 +2232,8 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 					*reinterpret_cast<void**>(*reinterpret_cast<u8**>(engineObject + 0x04) + 0x04) =
 					    *reinterpret_cast<void**>(self + 0x98C);
 					*reinterpret_cast<void**>(self + 0x98C) = *reinterpret_cast<void**>(engineObject + 0x04);
-					*reinterpret_cast<u8*>(engineObject + 0x38) &= 0xEF;
+					*reinterpret_cast<u8*>(engineObject + 0x38) =
+					    static_cast<u8>(__rlwimi(*reinterpret_cast<u8*>(engineObject + 0x38), 0, 4, 27, 27));
 
 					typedef void (*OnDeleteFn)(CFlatRuntime*, CFlatRuntime::CObject*);
 					reinterpret_cast<OnDeleteFn>((*reinterpret_cast<void***>(this))[7])(


### PR DESCRIPTION
## Summary
- Treat m_objectFreeListHead as the free-list head node in CFlatRuntime deletion paths, matching the allocation path and Ghidra shape.
- Use the existing rlwimi flag-clear idiom for object deletion state updates.

## Objdiff Evidence
- main/cflat_runtime .text: 58.40541% -> 58.50689%
- Destroy__12CFlatRuntimeFv: 81.57692% -> 82.11539%
- Frame__12CFlatRuntimeFii: 60.539684% -> 61.015873%
- AfterFrame__12CFlatRuntimeFi: 90.15254% -> 93.47458%
- systemFunc__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiRi: 52.072727% -> 52.247726%
- deleteObject__12CFlatRuntimeFPQ212CFlatRuntime7CObject: 89.382355% -> 88.97059% (small local regression from the same direct free-list shape used by the improved paths)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o /tmp/cflat_runtime_final_diff.json
- build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o /tmp/cflat_runtime_systemFunc_diff.json systemFunc__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiRi