### PR TITLE
Match pppYmEnv paraboloid camera vectors

### DIFF
--- a/src/pppYmEnv.cpp
+++ b/src/pppYmEnv.cpp
@@ -148,8 +148,8 @@ void drawParaboloidMap(_GXTexObj* texObjs, _GXTexObj* targetTexObj, void* displa
     clearColor.g = 0;
     clearColor.b = 0;
     clearColor.a = 0xFF;
-    const Vec s_cameraPos = {0.0f, 6.0f, 0.0f};
-    const Vec s_cameraUp = {1.0f, 0.0f, 0.0f};
+    const Vec s_cameraPos = {0.0f, 0.0f, 6.0f};
+    const Vec s_cameraUp = {0.0f, 1.0f, 0.0f};
     const Vec s_cameraLook = {0.0f, 0.0f, 0.0f};
 
     gUtil.RenderColorQuad(0.0f, 0.0f, texWidth, texHeight, clearColor);


### PR DESCRIPTION
## Summary
- Correct the paraboloid map camera position/up vectors in `drawParaboloidMap` to match the target rodata.
- This changes the camera from Y-up-at-height to Z-offset with Y-up, matching the compiled constants in `build/GCCP01/obj/pppYmEnv.o`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppYmEnv -o /tmp/pppYmEnv.after.json`
- `pppYmEnv` `.rodata`: 97.2028% -> 100.0%.
- Local rodata symbols `@237`, `@238`, and `@239`: now all 100.0%.
- `drawParaboloidMap` code score unchanged at 93.650795%; no code-size regression.

## Plausibility
- The target object stores the camera vectors as `{0, 0, 6}`, `{0, 1, 0}`, and `{0, 0, 0}`. The source now expresses those vectors directly instead of relying on raw data or manual section tricks.
