### PR TITLE
Improve pppYmLaser render matching

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -119,7 +119,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	int count;
+	u32 count;
 	s32 i;
 	s32 alphaStep;
 	char alphaMax;
@@ -133,7 +133,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	pppFMATRIX unitMtx;
 	Mtx shapeMtx;
 	Mtx rotateMtx;
-	Mtx debugMtx;
+	Mtx debugMtx ATTRIBUTE_ALIGN(8);
 	Mtx pointMtx;
 	Mtx sphereMtx;
 	pppFMATRIX managerMtx;


### PR DESCRIPTION
## Summary
- align pppRenderYmLaser debug matrix local with the sibling pppLaser implementation
- use an unsigned point count for the trail UV divisor, matching the payload byte semantics

## Evidence
- ninja passes
- main/pppYmLaser pppRenderYmLaser: 97.430855% -> 97.631645%
- main/pppYmLaser .text: 98.268% -> 98.39896%
- .rodata and .sdata2 remain 100.0%

## Plausibility
- pppLaser already uses the same 8-byte debug matrix alignment pattern
- m_pointCount is an unsigned byte, so using u32 for the float conversion is the coherent source shape