### PR TITLE
Improve CharaBreak strip rewind matching

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -945,7 +945,7 @@ void CreatePolygon(POLYGON_DATA* polygonData, void* displayList, unsigned long, 
                         if (triCount <= 0) {
                             keepTri = 0;
                         }
-                        if (triCount != 1) {
+                        if (((u32)__cntlzw((s32)triCount) >> 5) == 0) {
                             stream = previousRestart;
                         }
                         outVertex = 0;


### PR DESCRIPTION
## Summary
- Adjust CreatePolygon triangle-strip rewind to use the compiler-style zero test after decrementing triCount
- Preserves the intended strip behavior while improving generated code for pppCharaBreak

## Evidence
- ninja passes
- objdiff CreatePolygon__FP12POLYGON_DATAPvUlPQ26CChara6CModelPQ26CChara5CMesh: 94.52702% -> 95.574326%
- main/pppCharaBreak .text: 89.18076% -> 89.28082%

## Plausibility
- The condition now tests whether any triangles remain after decrementing, matching the Ghidra-observed zero-test shape and the expected strip rewind behavior.
