### PR TITLE
Match caravan item deletion joybus call

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -982,7 +982,7 @@ int CCaravanWork::DeleteItem(int itemIndex, int updateJoybus)
             m_inventoryItems[i] = 0xFFFF;
             m_inventoryItemCount = m_inventoryItemCount - 1;
             if (updateJoybus != 0) {
-                DelItem__6JoyBusFiUc(&Joybus, m_joybusCaravanId, (char)i);
+                Joybus.DelItem(m_joybusCaravanId, static_cast<unsigned char>(i));
             }
             return 1;
         }


### PR DESCRIPTION
## Summary
- Use the real `Joybus.DelItem` member call in `CCaravanWork::DeleteItem` instead of the direct mangled extern call.
- This matches the original call setup and removes the extra generated move around `Joybus`.

## Objdiff Evidence
- Unit: `main/gobjwork`
- Symbol: `DeleteItem__12CCaravanWorkFii`
- Before: 95.416664% match, built size 148 vs target size 144, diffs: 1 arg mismatch, 1 insert, 1 replace
- After: 100.0% match, built size 144 vs target size 144, no instruction diffs
- Unit .text fuzzy match: 85.7901% -> 85.82399%
- Build report: matched code +144 bytes, matched functions +1

## Plausibility
- The original source likely called the `JoyBus::DelItem` member directly rather than routing through a manually declared mangled extern. The surrounding file already uses real `Joybus` member calls for related operations.
