### PR TITLE
Improve CFile DrawError compact flag

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -185,7 +185,7 @@ retry:
 
         int hasScratchTexture = (int)Graphic.m_scratchTextureBuffer;
         hasScratchTexture = hasScratchTexture != 0;
-        u8 compactLayout = 0;
+        int compactLayout = 0;
         if (hasScratchTexture && usingFallbackFont == 0)
         {
             compactLayout = 1;


### PR DESCRIPTION
## Summary
- use an int for DrawError's compact-layout flag so the generated code treats it as a word temporary
- improves the remaining CFile::DrawError mismatch without changing behavior

## Evidence
- ninja succeeds
- objdiff main/file .text: 99.727356% -> 99.8285%
- objdiff DrawError__5CFileFR11DVDFileInfoi: 99.26887% -> 99.54009%

## Plausibility
- the flag is consumed through word comparisons in the target code; representing it as an int is closer to the original ABI-relevant temporary than an 8-bit local