### PR TITLE
Guard PAL-unused CWind helpers

### DIFF
--- a/include/ffcc/wind.h
+++ b/include/ffcc/wind.h
@@ -48,15 +48,19 @@ public:
     void Frame();
     void Draw();
     void Calc(Vec*, const Vec*, int);
+#ifndef VERSION_GCCP01
     WindObject* searchFreeObj();
     WindObject* getObj(int);
+#endif
     int AddAmbient(float, float);
     int AddDiffuse(const Vec*, float, float, float);
     int AddSphere(const Vec*, float, float, int);
     void ChangePower(int, float);
+#ifndef VERSION_GCCP01
     WindGrassObject* searchFreeGrass();
     WindGrassObject* getGrass(int);
     int AddGrass(const Vec*);
+#endif
 
 private:
     WindObject m_objects[32];

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -411,6 +411,7 @@ found:
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 WindObject* CWind::getObj(int id)
 {
     WindObject* obj = m_objects;
@@ -425,6 +426,7 @@ WindObject* CWind::getObj(int id)
 
     return 0;
 }
+#endif
 
 /*
  * --INFO--
@@ -435,6 +437,7 @@ WindObject* CWind::getObj(int id)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 WindObject* CWind::searchFreeObj()
 {
     WindObject* obj = m_objects;
@@ -447,6 +450,7 @@ WindObject* CWind::searchFreeObj()
 
     return 0;
 }
+#endif
 
 /*
  * --INFO--
@@ -694,6 +698,7 @@ void CWind::ClearAll()
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 WindGrassObject* CWind::searchFreeGrass()
 {
     WindGrassObject* obj = m_grass;
@@ -706,6 +711,7 @@ WindGrassObject* CWind::searchFreeGrass()
 
     return 0;
 }
+#endif
 
 /*
  * --INFO--
@@ -716,6 +722,7 @@ WindGrassObject* CWind::searchFreeGrass()
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 WindGrassObject* CWind::getGrass(int id)
 {
     WindGrassObject* obj = m_grass;
@@ -730,6 +737,7 @@ WindGrassObject* CWind::getGrass(int id)
 
     return 0;
 }
+#endif
 
 /*
  * --INFO--
@@ -740,6 +748,7 @@ WindGrassObject* CWind::getGrass(int id)
  * JP Address: TODO
  * JP Size: TODO
  */
+#ifndef VERSION_GCCP01
 int CWind::AddGrass(const Vec* pos)
 {
     WindGrassObject* obj = searchFreeGrass();
@@ -757,3 +766,4 @@ int CWind::AddGrass(const Vec* pos)
 
     return obj->id;
 }
+#endif


### PR DESCRIPTION
## Summary
- Guard CWind::getObj, searchFreeObj, and grass helper declarations/definitions out of VERSION_GCCP01 builds.
- These functions already carry PAL Address: UNUSED headers and have no PAL callers, so they should not be emitted into main/wind for the active PAL target.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/wind -o - AddSphere__5CWindFPC3Vecffi
- Compiled main/wind .text size moved from 4508 bytes before this change to 3492 bytes after; target .text is 3512 bytes.
- Removed PAL object symbols: getObj__5CWindFi, searchFreeObj__5CWindFv, searchFreeGrass__5CWindFv, getGrass__5CWindFi, AddGrass__5CWindFPC3Vec.

## Plausibility
The change follows the existing repo pattern of #ifndef VERSION_GCCP01 around functions marked PAL Address: UNUSED, and keeps the non-PAL declarations/definitions available.