### PR TITLE
Use m_boss for Meteo Parasite boss state

### DIFF
--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -1983,11 +1983,11 @@ void CGMonObj::frameStatFuncMolbol()
 void CGMonObj::initFinishedFuncMeteoParasiteC()
 {
 	initFinishedFuncDefault__8CGMonObjFv(this);
-	*reinterpret_cast<CGMonObj**>(SoundBuffer_1260_ + 0x74) = this;
+	*reinterpret_cast<CGMonObj**>(m_boss__8CGMonObj + 0x74) = this;
 
 	if (strcmp(Game.m_currentScriptName, s_meteo_3_80331D64) == 0) {
 		CGObject* object = reinterpret_cast<CGObject*>(this);
-		MeteoParasiteCBossWork* work = reinterpret_cast<MeteoParasiteCBossWork*>(SoundBuffer_1260_);
+		MeteoParasiteCBossWork* work = reinterpret_cast<MeteoParasiteCBossWork*>(m_boss__8CGMonObj);
 		work->bits.m_meteo3 = 1;
 		work->m_index = 3;
 		*reinterpret_cast<u16*>(reinterpret_cast<u8*>(object->m_scriptHandle) + 0x1C) = 1;
@@ -2248,7 +2248,7 @@ void CGMonObj::frameStatFuncMeteoParasiteC()
  */
 int CGMonObj::calcBranchFuncMeteoParasiteC(int)
 {
-	return *reinterpret_cast<int*>(SoundBuffer_1260_ + 0x78);
+	return *reinterpret_cast<int*>(m_boss__8CGMonObj + 0x78);
 }
 
 /*
@@ -2264,7 +2264,7 @@ void CGMonObj::logicFuncMeteoParasiteC()
 {
 	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
 	int nextState = -1;
-	MeteoParasiteCBossWork* work = reinterpret_cast<MeteoParasiteCBossWork*>(SoundBuffer_1260_);
+	MeteoParasiteCBossWork* work = reinterpret_cast<MeteoParasiteCBossWork*>(m_boss__8CGMonObj);
 	if (work->bits.m_meteo3 != 0) {
 		nextState = 0x68;
 	} else {
@@ -2365,7 +2365,7 @@ void CGMonObj::changeStatFuncMeteoParasite(int stat)
 	int scriptKind = reinterpret_cast<int>(object->m_scriptHandle[4]);
 	if (scriptKind == 0x87) {
 		if (stat == 0x67) {
-			CGMonObj* meteoC = *reinterpret_cast<CGMonObj**>(SoundBuffer_1260_ + 0x74);
+			CGMonObj* meteoC = *reinterpret_cast<CGMonObj**>(m_boss__8CGMonObj + 0x74);
 			if (*reinterpret_cast<int*>(reinterpret_cast<u8*>(meteoC) + 0x6D0) == 1) {
 				setActionParam__8CGMonObjFi(this, -13);
 			} else {
@@ -2533,12 +2533,12 @@ int CGMonObj::attackCheckFuncMeteoParasite(int)
 	case 0x85:
 		return -2;
 	case 0x86:
-		if (*reinterpret_cast<int*>(SoundBuffer_1260_ + 0x78) == 1 && *reinterpret_cast<int*>(mon + 0x6D0) == 1) {
+		if (*reinterpret_cast<int*>(m_boss__8CGMonObj + 0x78) == 1 && *reinterpret_cast<int*>(mon + 0x6D0) == 1) {
 			return -1;
 		}
 		return -2;
 	case 0x87:
-		if (*reinterpret_cast<int*>(SoundBuffer_1260_ + 0x78) == 2 && *reinterpret_cast<int*>(mon + 0x6D0) < 2) {
+		if (*reinterpret_cast<int*>(m_boss__8CGMonObj + 0x78) == 2 && *reinterpret_cast<int*>(mon + 0x6D0) < 2) {
 			return -1;
 		}
 		return -2;


### PR DESCRIPTION
## Summary
- Use the named m_boss__8CGMonObj buffer for Meteo Parasite boss state instead of the overlapping SoundBuffer_1260_ alias.
- This fixes relocations/source ownership for branch, attack-check, logic, change-stat, and init-finished Meteo Parasite helpers.

## Objdiff evidence
Before -> after on main/monobj_boss:
- calcBranchFuncMeteoParasiteC__8CGMonObjFi: 96.25% -> 100.00%
- attackCheckFuncMeteoParasite__8CGMonObjFi: 99.23077% -> 100.00%
- changeStatFuncMeteoParasite__8CGMonObjFi: 90.96154% -> 91.53846%
- logicFuncMeteoParasiteC__8CGMonObjFv: 93.91892% -> 94.5946%
- initFinishedFuncMeteoParasiteC__8CGMonObjFv: 98.46939% -> 99.28571%

## Verification
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/monobj_boss -o /tmp/monobj_calcBranchFuncMeteoParasiteC.json calcBranchFuncMeteoParasiteC__8CGMonObjFi
- build/tools/objdiff-cli diff -p . -u main/monobj_boss -o /tmp/monobj_attackCheckFuncMeteoParasite.json attackCheckFuncMeteoParasite__8CGMonObjFi
- build/tools/objdiff-cli diff -p . -u main/monobj_boss -o /tmp/monobj_initFinishedFuncMeteoParasiteC.json initFinishedFuncMeteoParasiteC__8CGMonObjFv