### PR TITLE
Improve p_FunnyShape storage linkage

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -1,4 +1,3 @@
-#define FFCC_DEFINE_FUNNYSHAPEPCS_STORAGE
 #include "ffcc/p_FunnyShape.h"
 #include "ffcc/FunnyShape.h"
 #include "ffcc/USBStreamData.h"
@@ -455,7 +454,7 @@ unsigned int lbl_801EA910[5] = {
     0,
 };
 u8 ARRAY_8026D728[0xC];
-u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];
+CFunnyShapePcs FunnyShapePcs;
 
 /*
  * --INFO--

--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -80,7 +80,7 @@ static const CrystalTexMtx s_crystalTexMtxBase = {
 
 static const CrystalIndTexMtx s_crystalIndTexMtxBase = {{{0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}}};
 
-static const char s_pppCrystalCpp[] = "pppCrystal.cpp";
+extern const char s_pppCrystalCpp[] = "pppCrystal.cpp";
 
 static inline int CrystalFpClassify(float value)
 {


### PR DESCRIPTION
## Summary
- define FunnyShapePcs as a real CFunnyShapePcs object instead of byte storage, allowing the unit .ctors entry to match
- give s_pppCrystalCpp external linkage to match the neighboring pppCrystal2 pattern and symbol ownership

## Evidence
- ninja succeeds
- main/p_FunnyShape data matched bytes improved from 25277 to 25281, and .ctors now reports 100% matched
- final report: main/p_FunnyShape data 25281 / 26069 (96.97725%), text fuzzy 99.98477%
- final report: main/pppCrystal data remains 192 / 192 (100%)

## Plausibility
- FunnyShapePcs is constructed/destructed as a normal C++ process object in the original static initializer, so typed storage is closer than raw u8 storage
- pppCrystal2 already exposes its cpp-name string with external linkage, matching the same particle source pattern