### PR TITLE
Improve pppYmMegaBirthShpTail2 frame loop

### DIFF
--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -324,7 +324,8 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
             break;
         }
 
-        spawnCount = 0;
+        i = 0;
+        spawnCount = i;
         particleData = (u8*)work->m_particles;
         worldMat = work->m_wmats;
         particleColor = work->m_colors;
@@ -332,7 +333,7 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
         if ((gPppCalcDisabled == 0) && (*(s32*)((u8*)&param->m_matrix + 4) != 0xFFFF)) {
             work->m_lifeLimit = work->m_lifeLimit + 1;
 
-            for (i = 0; i < work->m_maxParticles; i++) {
+            for (; i < work->m_maxParticles; i++) {
                 if (*(u16*)(particleData + 0x22) != 0) {
                     calc__FP11_pppPObjectP20VYmMegaBirthShpTail2P20PYmMegaBirthShpTail2P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR(
                         (_pppPObject*)object, work, param, (_PARTICLE_DATA*)particleData, colorWork, particleColor);


### PR DESCRIPTION
## Summary
- Adjusts the tail2 frame loop initialization so the particle loop index is zeroed before initializing the spawn counter.
- Keeps behavior unchanged while matching the target register/setup shape more closely.

## Evidence
- Built with `ninja`.
- `build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail2 -o - pppFrameYmMegaBirthShpTail2`

Before:
- Unit .text: 57.487167%
- `pppFrameYmMegaBirthShpTail2`: 99.029854%
- Neighboring symbols unchanged: render 37.497826%, calc 99.84456%, birth 43.719223%

After:
- Unit .text: 57.515976%
- `pppFrameYmMegaBirthShpTail2`: 99.23508%
- Neighboring symbols unchanged: render 37.497826%, calc 99.84456%, birth 43.719223%

## Plausibility
The change reflects a plausible original source shape: initialize the particle loop index, then derive the spawn counter from that zeroed local before entering the loop. This matches the observed target setup without adding hacks, labels, section forcing, or address-specific code.