### PR TITLE
Fix Ym deformation shape constant linkage

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -5,20 +5,20 @@
 #include "ffcc/partMng.h"
 #include "ffcc/pppYmEnv.h"
 extern "C" {
-extern const float FLOAT_803305f0 = 0.017453292f;
-extern const float kPppYmDeformationShpZero = 0.0f;
-extern const float FLOAT_803305f8 = 1.0f;
-extern const double DOUBLE_80330600 = 4503601774854144.0;
-extern const double DOUBLE_80330608 = 4503599627370496.0;
-extern const float FLOAT_80330610 = 320.0f;
-extern const float FLOAT_80330614 = 0.003125f;
-extern const float FLOAT_80330618 = 224.0f;
-extern const float FLOAT_8033061c = 0.004464f;
-extern const float FLOAT_80330620 = 1000.0f;
-extern const float FLOAT_80330624 = -1000.0f;
-extern const float FLOAT_80330628 = -0.5f;
-extern const float FLOAT_8033062c = -1.0f;
-extern const float FLOAT_80330630 = 0.5f;
+extern const float FLOAT_803305f0;
+extern const float kPppYmDeformationShpZero;
+extern const float FLOAT_803305f8;
+extern const double DOUBLE_80330600;
+extern const double DOUBLE_80330608;
+extern const float FLOAT_80330610;
+extern const float FLOAT_80330614;
+extern const float FLOAT_80330618;
+extern const float FLOAT_8033061c;
+extern const float FLOAT_80330620;
+extern const float FLOAT_80330624;
+extern const float FLOAT_80330628;
+extern const float FLOAT_8033062c;
+extern const float FLOAT_80330630;
 extern int gPppCalcDisabled;
 extern unsigned char gPppInConstructor;
 }


### PR DESCRIPTION
## Summary
- Change `pppYmDeformationShp` constants from local definitions to external declarations.
- This makes the unit reference the configured `.sdata2` symbols instead of emitting duplicate constant definitions in the object.

## Evidence
- `ninja` passes for `GCCP01`.
- `objdiff` for `main/pppYmDeformationShp` shows the emitted right-side `.sdata2` payload reduced from 132 bytes to 16 bytes.
- `pppRenderYmDeformationShp` now has the target size: 2904 bytes.
- `RenderDeformationShape` improved size from 2600 bytes to 2596 bytes, closer to the 2584-byte target.
- `extabindex` fuzzy match improved from 94.44% to 97.22%.

## Notes
- The source now matches the existing `config/GCCP01/symbols.txt` ownership for these constants rather than defining them again in this unit.