### PR TITLE
Improve SetMapObjLMtx match

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3462,11 +3462,14 @@ int CMapMng::GetMapObjEffectIdx(unsigned short effectId)
  */
 void CMapMng::SetMapObjLMtx(int mapObjIndex, float (*source)[4])
 {
-    CMapObj* mapObj = reinterpret_cast<CMapObj*>(Ptr(this, 0x954)) + mapObjIndex;
-    PSMTXCopy(source, mapObj->m_localMtx);
-    mapObj->m_localMtxDirty = 1;
-    mapObj->m_calcMtxPending = 1;
-    mapObj->m_localMtxDirty = 0;
+    int offset = mapObjIndex * 0xF0;
+    CMapMng* self = this;
+    PSMTXCopy(source, reinterpret_cast<MtxPtr>(Ptr(self, offset + 0x9DC)));
+
+    u8* mapObj = Ptr(self, offset);
+    mapObj[0x970] = 1;
+    mapObj[0x96F] = 1;
+    mapObj[0x970] = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reshape CMapMng::SetMapObjLMtx around the target's map-object offset calculation.
- Keep the map object offset live across PSMTXCopy and update the local-matrix flags through that same base.

## Objdiff
- main/map .text: 63.2539% -> 63.33407%
- SetMapObjLMtx__7CMapMngFiPA4_f: 63.391304% / 76b -> 82.391304% / 92b

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/map -o - SetMapObjLMtx__7CMapMngFiPA4_f