### PR TITLE
Improve goout mode guard

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1895,7 +1895,7 @@ void CGoOutMenu::Calc()
                         SetMainMode(field_0x2d);
                     }
                 }
-            } else if (field_0x45 != 0) {
+            } else if (mode >= 0 && field_0x45 != 0) {
                 input = GetGoOutInputMask();
                 if ((input & 0x200) != 0) {
                     Sound.PlaySe(3, 0x40, 0x7f, 0);


### PR DESCRIPTION
## Summary
- tighten the `CGoOutMenu::Calc` go-out branch so the pending `field_0x45` path only runs for non-negative go-out modes
- preserves the existing mode-zero fallback while matching more of the PAL control flow

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/goout -o - Calc__10CGoOutMenuFv`
  - before: 2620 bytes, 52.31756% match
  - after: 2620 bytes, 53.98626% match

## Plausibility
- the added signed mode guard matches the surrounding mode tests and avoids treating negative sentinel modes as active go-out modes
- no layout, symbol, section, or generated-function hacks