### PR TITLE
Fix p_graphic screen fade matrix type

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -105,7 +105,7 @@ void CGraphicPcs::drawScreenFade()
 {
     Mtx44 orthoMtx;
     Mtx cameraMtx;
-    Mtx screenMtx;
+    Mtx44 screenMtx;
     Mtx44 worldScreenMtx;
     Mtx identityMtx;
 


### PR DESCRIPTION
## Summary
- Change the local screen fade matrix in CGraphicPcs::drawScreenFade from Mtx to Mtx44.
- The function writes row 3 and passes the matrix to PSMTX44Concat, so the 4x4 type better matches the original source shape.

## Objdiff evidence
Before:
- main/p_graphic .text: 66.62628%
- drawScreenFade__11CGraphicPcsFv: 53.902256%
- drawBar__11CGraphicPcsFv: 58.516357%
- __sinit_p_graphic_cpp: 49.122643%

After:
- main/p_graphic .text: 66.82573%
- drawScreenFade__11CGraphicPcsFv: 54.37876%
- drawBar__11CGraphicPcsFv: 58.516357%
- __sinit_p_graphic_cpp: 49.122643%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_graphic -o /tmp/p_graphic_final.json