### PR TITLE
Improve pppMana2 water mesh index generation

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -525,8 +525,8 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
     float z;
     float rowUv;
     int indexOffset;
-    short quadIndex;
-    short rowBase;
+    int quadIndex;
+    int rowBase;
     float* positions;
     int rowCount;
     float* normals;
@@ -568,9 +568,8 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
     rowCount = 0;
     rowBase = 0;
     do {
-        pairCount = 8;
         quadIndex = rowBase;
-        do {
+        for (pairCount = 0; pairCount < 8; pairCount++) {
             param_4[indexOffset++] = quadIndex;
             param_4[indexOffset++] = quadIndex + 1;
             param_4[indexOffset++] = quadIndex + 0x12;
@@ -584,8 +583,7 @@ static int CreateWaterMesh(Vec* param_1, Vec* param_2, Vec2d* param_3, unsigned 
             param_4[indexOffset++] = quadIndex + 0x12;
             param_4[indexOffset++] = quadIndex + 1;
             quadIndex = quadIndex + 2;
-            pairCount = pairCount + -1;
-        } while (pairCount != 0);
+        }
         rowCount = rowCount + 1;
         rowBase = rowBase + 0x11;
     } while (rowCount < 0x10);


### PR DESCRIPTION
## Summary
- Adjust `CreateWaterMesh` index-generation temporaries from `short` to `int`
- Express the fixed 8-quad inner loop as a bounded `for` loop
- Keeps the generated 16-bit index data behavior unchanged while improving codegen shape

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/pppMana2 -o /tmp/pppMana2_final_create.json CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf`
- `CreateWaterMesh__FP3VecP3VecP5Vec2dPUsf`: 81.08911% -> 89.25742%
- Checked adjacent selected pppMana2 targets in the same diff snapshot; `CalculateNormal`, `UpdateWaterMesh`, `CalcReflectionVector2`, and `Mana2_DrawMeshDLCallback` stayed unchanged

## Plausibility
The index values are stored through an `unsigned short*`, but the row/base counters do not need short-lived signed 16-bit temporaries. Using `int` counters and a normal fixed-count loop better reflects plausible source and avoids unnecessary sign-extension in the generated code.
