### PR TITLE
Improve cflat CLine64 matching

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1836,37 +1836,38 @@ extern "C" void CalcBound__9CLine(CLine<64>* line)
     line->m_max.z = kLineBoundsInitMax;
     line->m_totalLength = kLineSegmentMinT;
 
-    for (unsigned int i = 0; i < line->m_numPoints; i++) {
-        const Vec& point = line->m_points[i];
+    Vec* point = line->m_points;
+    CLineSegment64* segment = line->m_segments;
+    for (unsigned int i = 0; i < line->m_numPoints; i++, point++, segment++) {
 
-        if (point.x < line->m_min.x) {
-            line->m_min.x = point.x;
+        if (point->x < line->m_min.x) {
+            line->m_min.x = point->x;
         }
-        if (point.y < line->m_min.y) {
-            line->m_min.y = point.y;
+        if (point->y < line->m_min.y) {
+            line->m_min.y = point->y;
         }
-        if (point.z < line->m_min.z) {
-            line->m_min.z = point.z;
+        if (point->z < line->m_min.z) {
+            line->m_min.z = point->z;
         }
 
-        if (line->m_max.x < point.x) {
-            line->m_max.x = point.x;
+        if (point->x > line->m_max.x) {
+            line->m_max.x = point->x;
         }
-        if (line->m_max.y < point.y) {
-            line->m_max.y = point.y;
+        if (point->y > line->m_max.y) {
+            line->m_max.y = point->y;
         }
-        if (line->m_max.z < point.z) {
-            line->m_max.z = point.z;
+        if (point->z > line->m_max.z) {
+            line->m_max.z = point->z;
         }
 
         if (i != 0) {
-            CLineSegment64& segment = line->m_segments[i - 1];
-            PSVECSubtract(&line->m_points[i], &line->m_points[i - 1], &segment.delta);
-            segment.length = PSVECMag(&segment.delta);
-            segment.startLength = line->m_totalLength;
-            line->m_totalLength += segment.length;
-            if (segment.length != kLineSegmentMinT) {
-                PSVECNormalize(&segment.delta, &segment.normal);
+            CLineSegment64* prevSegment = segment - 1;
+            PSVECSubtract(point, point - 1, &prevSegment->delta);
+            prevSegment->length = PSVECMag(&prevSegment->delta);
+            prevSegment->startLength = line->m_totalLength;
+            line->m_totalLength += prevSegment->length;
+            if (prevSegment->length != kLineSegmentMinT) {
+                PSVECNormalize(&prevSegment->delta, &prevSegment->normal);
             }
         }
     }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1733,7 +1733,7 @@ public:
 int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long* nearestSegment,
                     float* nearestSegmentRatio, Vec* targetPosition, float maxDistance)
 {
-    const bool infiniteRange = (maxDistance == kLineSegmentMinT);
+    const bool infiniteRange = (kLineSegmentMinT == maxDistance);
     float bestDistance = infiniteRange ? kLineBoundsInitMin : maxDistance;
     const float maxDistanceSq = maxDistance * maxDistance;
     int found = 0;
@@ -1746,13 +1746,7 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
         float distanceSq = PSVECSquareDistance(candidate, targetPosition);
         if (distanceSq < maxDistanceSq || infiniteRange) {
             Vec candidatePosition = *candidate;
-            float distance = distanceSq;
-            if (distanceSq <= kLineSegmentMinT) {
-                distance = NAN;
-            } else {
-                distance = (float)sqrt(distanceSq);
-            }
-
+            float distance = sqrtf(distanceSq);
             if (distance < bestDistance) {
                 bestDistance = distance;
                 bestPosition = candidatePosition;
@@ -1767,13 +1761,7 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
             distanceSq = PSVECSquareDistance(candidate, targetPosition);
             if (distanceSq < maxDistanceSq || infiniteRange) {
                 Vec candidatePosition = *candidate;
-                float distance = distanceSq;
-                if (distanceSq <= kLineSegmentMinT) {
-                    distance = NAN;
-                } else {
-                    distance = (float)sqrt(distanceSq);
-                }
-
+                float distance = sqrtf(distanceSq);
                 if (distance < bestDistance) {
                     bestDistance = distance;
                     bestPosition = candidatePosition;


### PR DESCRIPTION
## Summary
- Rework CLine<64>::Calc distance checks to keep candidate point copies and use sqrtf, matching the existing CLine source pattern in sound.cpp.
- Rework CalcBound__9CLine to iterate with point/segment pointers, again matching the generic line helper shape.

## Objdiff Evidence
- main/cflat_r2system Calc__9CLine<64>FP3VecPfPUlPfP3Vecf: 62.496502% -> 88.534966%, size 1144 unchanged.
- main/cflat_r2system CalcBound__9CLine: 79.568184% -> 84.681816%, size 352 unchanged.
- Full-unit comparison only changed these two symbols; no symbol regressions observed.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o /tmp/cflat_final.json --format json