### PR TITLE
Match ghost work reset size

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -2355,7 +2355,7 @@ void CFlatRuntime2::IgnoreParticle(int slotNo, CFlatRuntime::CObject* object)
  */
 void CFlatRuntime2::initAllFinished()
 {
-	memset(&CGPartyObj::m_ghostWork, 0, sizeof(CGPartyObj::m_ghostWork));
+	memset(&CGPartyObj::m_ghostWork, 0, 0x90);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reset `CGPartyObj::m_ghostWork` using the symbol-backed 0x90 byte size.
- Matches `CFlatRuntime2::initAllFinished` by avoiding the current provisional struct size of 0xD0.

## Evidence
- Before: `initAllFinished__13CFlatRuntime2Fv` was 99.916664% in objdiff, differing on `li r5` (`0xD0` vs target `0x90`).
- After: `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o /tmp/cflat_initAllFinished_final.json --format json-pretty initAllFinished__13CFlatRuntime2Fv` reports 100.0%.
- `ninja` passes; report now shows one additional matched function (3464 / 4732).