### PR TITLE
Improve CChara node flag initialization

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -2440,7 +2440,12 @@ CChara::CNode::CNode()
 	*(u32*)((u8*)this + 0x4) = 0;
 	*(u32*)((u8*)this + 0x9C) = 0;
 	*(u32*)((u8*)this + 0xA0) = 0;
-	*(u8*)((u8*)this + 0xBC) = (*(u8*)((u8*)this + 0xBC) & 0x7F) | 0x80;
+	static const u8 clearMask = 0x7F;
+	static const u8 setMask = 0x80;
+	u8 flags = *(u8*)((u8*)this + 0xBC);
+	flags &= clearMask;
+	flags |= setMask;
+	*(u8*)((u8*)this + 0xBC) = flags;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Rewrites CChara::CNode::CNode runtime flag initialization into explicit mask/load/update steps.
- Keeps behavior equivalent while producing closer codegen for the node constructor.

## Objdiff Evidence
- main/chara .text: 50.5665% -> 50.5899% (+0.0235)
- __ct__Q26CChara5CNodeFv: 80.2083% -> 85.2083% (+5.0000)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara -o - __ct__Q26CChara5CNodeFv