### PR TITLE
Improve deformation screen projection setup

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -163,9 +163,9 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 		GXSetCurrentMtx(0);
 
 		PSMTX44Identity(orthoMtx);
-		orthoMtx[2][2] = FLOAT_8033067C;
 		orthoMtx[0][0] = FLOAT_80330674;
 		orthoMtx[1][1] = FLOAT_80330678;
+		orthoMtx[2][2] = FLOAT_8033067C;
 		orthoMtx[0][3] = FLOAT_80330680;
 		orthoMtx[1][3] = FLOAT_8033067C;
 		orthoMtx[2][3] = FLOAT_80330670;


### PR DESCRIPTION
## Summary
- Move the deformation screen orthographic matrix diagonal writes into the same top-down order shown by the decompilation.
- This slightly improves the generated instruction ordering for pppRenderYmDeformationScreen without changing behavior.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- main/pppYmDeformationScreen .text fuzzy match improves from 99.52057% to 99.52594%.
- pppRenderYmDeformationScreen fuzzy match in build/GCCP01/report.json is now 99.33915%.
- Unit remains 4/5 matched functions and 100% data matched.

## Plausibility
- The assignment order now follows the natural matrix row/diagonal setup order from Ghidra: [0][0], [1][1], [2][2], then translation terms.
- No forced sections, hardcoded addresses, or synthetic symbols were added.