### PR TITLE
Fix p_map loaded map sbss ownership

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -121,8 +121,8 @@ unsigned int m_table__7CMapPcs[3][0x414 / 3 / sizeof(unsigned int)] = {
     },
 };
 
-unsigned int s_loadedStageNo__7CMapPcs;
-unsigned int s_loadedMapNo__7CMapPcs;
+extern unsigned int s_loadedStageNo__7CMapPcs;
+extern unsigned int s_loadedMapNo__7CMapPcs;
 unsigned int g_mapStage;
 unsigned int g_mapSection;
 unsigned char g_hit_prof;


### PR DESCRIPTION
## Summary
- Change `s_loadedStageNo__7CMapPcs` and `s_loadedMapNo__7CMapPcs` in `p_map.cpp` from definitions to extern references.
- Leaves ownership of the 0x8032ECC0/0x8032ECC4 sbss symbols with the generated `auto_10_8032ECC0_sbss` split, matching `config/GCCP01/splits.txt` where `p_map.cpp` starts sbss at 0x8032ECC8.

## Evidence
- `ninja` passes.
- `nm -a build/GCCP01/obj/auto_10_8032ECC0_sbss.o` defines `s_loadedStageNo__7CMapPcs` at 0 and `s_loadedMapNo__7CMapPcs` at 4.
- `nm -a build/GCCP01/src/p_map.o` now shows those two symbols as undefined references instead of local sbss definitions.
- `build/tools/objdiff-cli diff -p . -u main/p_map -o -` still reports p_map `.bss` and `.sbss` at 100%.

## Plausibility
This removes an over-claim from `p_map.cpp` and follows the split/MAP ownership boundary instead of duplicating data that belongs to the adjacent auto sbss object.