### PR TITLE
Improve light bump texture cleanup

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -212,29 +212,29 @@ void CLightPcs::create()
  */
 void CLightPcs::destroy()
 {
-    for (u32 i = 0; i < 8; i++) {
-        CBumpLight& light = m_bumpLights[8 + i];
-        if (light.m_textureData != 0) {
-            bool hasTexture = light.m_textureData != 0;
+    CBumpLight* light = &m_bumpLights[8];
+    for (u32 i = 0; i < 8; i++, light++) {
+        if (light->m_textureData != 0) {
+            bool hasTexture = light->m_textureData != 0;
             if (hasTexture) {
-                delete[] light.m_textureData;
-                light.m_textureData = 0;
+                Memory.Free(light->m_textureData);
+                light->m_textureData = 0;
             }
-            light.m_hasTexture = 0;
-            light.m_useViewSpace = 0;
+            light->m_hasTexture = 0;
+            light->m_useViewSpace = 0;
         }
     }
 
-    for (u32 i = 0; i < 8; i++) {
-        CBumpLight& light = m_bumpLights[i];
-        if (light.m_textureData != 0) {
-            bool hasTexture = light.m_textureData != 0;
+    light = &m_bumpLights[0];
+    for (u32 i = 0; i < 8; i++, light++) {
+        if (light->m_textureData != 0) {
+            bool hasTexture = light->m_textureData != 0;
             if (hasTexture) {
-                delete[] light.m_textureData;
-                light.m_textureData = 0;
+                Memory.Free(light->m_textureData);
+                light->m_textureData = 0;
             }
-            light.m_hasTexture = 0;
-            light.m_useViewSpace = 0;
+            light->m_hasTexture = 0;
+            light->m_useViewSpace = 0;
         }
     }
 }
@@ -256,7 +256,7 @@ void CLightPcs::DestroyBumpLightAll(CLightPcs::TARGET target)
         if (light[i].m_textureData != 0) {
             bool hasTexture = light[i].m_textureData != 0;
             if (hasTexture) {
-                delete[] light[i].m_textureData;
+                Memory.Free(light[i].m_textureData);
                 light[i].m_textureData = 0;
             }
 


### PR DESCRIPTION
## Summary
- Release `CLightPcs::CBumpLight::m_textureData` with `Memory.Free` instead of `delete[]`.
- Walk the two `CLightPcs::destroy` bump-light ranges with advancing pointers, matching the target cleanup shape more closely.

## Objdiff evidence
- `destroy__9CLightPcsFv`: 41.82% -> 62.62%
- `DestroyBumpLightAll__9CLightPcsFQ29CLightPcs6TARGET`: 77.411766% -> 90.588234%

## Plausibility
`AddBump__9CLightPcs...` allocates `m_textureData` through the project memory allocator path, and the target code calls `Free__7CMemoryFPv`, so freeing through `Memory.Free` is more coherent original source than using `delete[]`.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_light -o - --format json destroy__9CLightPcsFv`
- `build/tools/objdiff-cli diff -p . -u main/p_light -o - --format json DestroyBumpLightAll__9CLightPcsFQ29CLightPcs6TARGET`