### PR TITLE
Match graphic temp buffer allocation

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -174,9 +174,9 @@ void CGraphic::Init()
         u8[alignedWidth * efbHeight * 2];
     memset(PtrAt(this, 0x71EC), 0, 4);
 
-    PtrAt(this, 0x71E8) = new (reinterpret_cast<CMemory::CStage*>(PtrAt(this, 0x8)),
-                               graphicRodata + kGraphicRodataFileName, 0xB53)
-        u8[alignedWidth * efbHeight * 2 + 0x46000];
+    PtrAt(this, 0x71E8) =
+        Memory._Alloc(alignedWidth * efbHeight * 2 + 0x46000, reinterpret_cast<CMemory::CStage*>(PtrAt(this, 0x8)),
+                      graphicRodata + kGraphicRodataFileName, 0xB53, 0);
     memset(PtrAt(this, 0x71E8), 0, 0x46004);
 
     PtrAt(this, 0x10) =
@@ -2047,11 +2047,9 @@ void CGraphic::CreateTempBuffer()
 	void* renderMode = PtrAt(this, 0x71E0);
 	u16 efbHeight = U16At(renderMode, 6);
 	u32 alignedWidth = (U16At(renderMode, 4) + 0xF) & 0xFFF0;
-	u8* tempBuffer = new (reinterpret_cast<CMemory::CStage*>(PtrAt(this, 0x8)),
-	                      const_cast<char*>(s_graphic_cpp_801d6348), 0xB53)
-	    u8[alignedWidth * (u32)efbHeight * 2 + 0x46000];
-
-	PtrAt(this, 0x71E8) = tempBuffer;
+	PtrAt(this, 0x71E8) =
+	    Memory._Alloc(alignedWidth * (u32)efbHeight * 2 + 0x46000, reinterpret_cast<CMemory::CStage*>(PtrAt(this, 0x8)),
+	                  const_cast<char*>(s_graphic_cpp_801d6348), 0xB53, 0);
 	memset(PtrAt(this, 0x71E8), 0, 0x46004);
 }
 


### PR DESCRIPTION
## Summary
- Use `Memory._Alloc` for the graphic temporary back-buffer allocation in `CGraphic::Init`
- Use the same allocator path in `CGraphic::CreateTempBuffer`

## Evidence
- `ninja` passes
- `CreateTempBuffer__8CGraphicFv`: 78.45% -> 100.00% match
- `Init__8CGraphicFv`: 79.27% -> 79.75% match
- Build progress gained one matched function: 3461 -> 3462 matched functions

## Plausibility
Ghidra shows this temporary buffer being allocated through `CMemory::_Alloc` with stage `this+0x8`, source `graphic.cpp`, line `0xB53`, and no-error flag `0`, while the other graphic buffers still use placement `new[]`. This change matches that allocator distinction without changing ownership or free behavior.