### PR TITLE
Improve memorycard save/load backup cleanup

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -957,39 +957,39 @@ void CMemoryCardMan::MakeSaveData()
     save[0x11] = static_cast<u8>(Math.Rand(0xFF));
     save[0x12] = 0;
 
-    int wm0 = Game.m_gameWork.m_wmBackupParams[0];
-    int wm1 = Game.m_gameWork.m_wmBackupParams[1];
-    int wm2 = Game.m_gameWork.m_wmBackupParams[2];
-    int wm3 = Game.m_gameWork.m_wmBackupParams[3];
-    if (Game.m_caravanWorkArr[Game.m_gameWork.m_wmBackupParams[0]].m_shopState == 0)
+    int wm = Game.m_gameWork.m_wmBackupParams[0];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[0] = -1;
     }
-    if (Game.m_caravanWorkArr[wm0].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[0] = -1;
     }
-    if (Game.m_caravanWorkArr[Game.m_gameWork.m_wmBackupParams[1]].m_shopState == 0)
+    wm = Game.m_gameWork.m_wmBackupParams[1];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[1] = -1;
     }
-    if (Game.m_caravanWorkArr[wm1].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[1] = -1;
     }
-    if (Game.m_caravanWorkArr[Game.m_gameWork.m_wmBackupParams[2]].m_shopState == 0)
+    wm = Game.m_gameWork.m_wmBackupParams[2];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[2] = -1;
     }
-    if (Game.m_caravanWorkArr[wm2].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[2] = -1;
     }
-    if (Game.m_caravanWorkArr[Game.m_gameWork.m_wmBackupParams[3]].m_shopState == 0)
+    wm = Game.m_gameWork.m_wmBackupParams[3];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[3] = -1;
     }
-    if (Game.m_caravanWorkArr[wm3].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[3] = -1;
     }
@@ -1347,39 +1347,39 @@ void CMemoryCardMan::SetLoadData()
 
     }
 
-    int wm0 = gameWork->m_wmBackupParams[0];
-    int wm1 = gameWork->m_wmBackupParams[1];
-    int wm2 = gameWork->m_wmBackupParams[2];
-    int wm3 = gameWork->m_wmBackupParams[3];
-    if (Game.m_caravanWorkArr[gameWork->m_wmBackupParams[0]].m_shopState == 0)
+    int wm = gameWork->m_wmBackupParams[0];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         gameWork->m_wmBackupParams[0] = -1;
     }
-    if (Game.m_caravanWorkArr[wm0].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[0] = -1;
     }
-    if (Game.m_caravanWorkArr[gameWork->m_wmBackupParams[1]].m_shopState == 0)
+    wm = gameWork->m_wmBackupParams[1];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         gameWork->m_wmBackupParams[1] = -1;
     }
-    if (Game.m_caravanWorkArr[wm1].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[1] = -1;
     }
-    if (Game.m_caravanWorkArr[gameWork->m_wmBackupParams[2]].m_shopState == 0)
+    wm = gameWork->m_wmBackupParams[2];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         gameWork->m_wmBackupParams[2] = -1;
     }
-    if (Game.m_caravanWorkArr[wm2].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[2] = -1;
     }
-    if (Game.m_caravanWorkArr[gameWork->m_wmBackupParams[3]].m_shopState == 0)
+    wm = gameWork->m_wmBackupParams[3];
+    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
     {
         gameWork->m_wmBackupParams[3] = -1;
     }
-    if (Game.m_caravanWorkArr[wm3].m_shopBusyFlag != 0)
+    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[3] = -1;
     }

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -958,38 +958,42 @@ void CMemoryCardMan::MakeSaveData()
     save[0x12] = 0;
 
     int wm = Game.m_gameWork.m_wmBackupParams[0];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    CCaravanWork* wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[0] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[0] = -1;
     }
     wm = Game.m_gameWork.m_wmBackupParams[1];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[1] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[1] = -1;
     }
     wm = Game.m_gameWork.m_wmBackupParams[2];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[2] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[2] = -1;
     }
     wm = Game.m_gameWork.m_wmBackupParams[3];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         Game.m_gameWork.m_wmBackupParams[3] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         Game.m_gameWork.m_wmBackupParams[3] = -1;
     }
@@ -1348,38 +1352,42 @@ void CMemoryCardMan::SetLoadData()
     }
 
     int wm = gameWork->m_wmBackupParams[0];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    CCaravanWork* wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         gameWork->m_wmBackupParams[0] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[0] = -1;
     }
     wm = gameWork->m_wmBackupParams[1];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         gameWork->m_wmBackupParams[1] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[1] = -1;
     }
     wm = gameWork->m_wmBackupParams[2];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         gameWork->m_wmBackupParams[2] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[2] = -1;
     }
     wm = gameWork->m_wmBackupParams[3];
-    if (Game.m_caravanWorkArr[wm].m_shopState == 0)
+    wmWork = &Game.m_caravanWorkArr[wm];
+    if (wmWork->m_shopState == 0)
     {
         gameWork->m_wmBackupParams[3] = -1;
     }
-    if (Game.m_caravanWorkArr[wm].m_shopBusyFlag != 0)
+    if (wmWork->m_shopBusyFlag != 0)
     {
         gameWork->m_wmBackupParams[3] = -1;
     }


### PR DESCRIPTION
## Summary
- Rework memorycard world-map backup cleanup to handle each slot with its own saved index.
- Keep a `CCaravanWork*` for each selected slot so state and busy checks share the same caravan object.

## Objdiff Evidence
- `MakeSaveData__14CMemoryCardManFv`: 72.99534% -> 74.23137%
- `SetLoadData__14CMemoryCardManFv`: 80.33275% -> 82.59683%
- `Odekake__14CMemoryCardManFiRQ22Mc7SaveDatiRQ22Mc7SaveDati`: unchanged at 85.175575%
- `main/memorycard` `.text`: 89.60479% after change

## Plausibility
The original source likely preserved each world-map backup index while checking the corresponding caravan's shop state and busy flag. Using a per-slot local index and object pointer keeps the logic coherent and avoids preloading all four backup indices before any mutation.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/memorycard -o - MakeSaveData__14CMemoryCardManFv`
- `build/tools/objdiff-cli diff -p . -u main/memorycard -o - SetLoadData__14CMemoryCardManFv`
- `build/tools/objdiff-cli diff -p . -u main/memorycard -o - Odekake__14CMemoryCardManFiRQ22Mc7SaveDatiRQ22Mc7SaveDati`
