### PR TITLE
Claim astar constant data

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -1572,8 +1572,9 @@ astar.cpp:
 	extabindex  start:0x80010E34 end:0x80010EC4
 	.text       start:0x80141550 end:0x80143098
 	.ctors      start:0x801D5444 end:0x801D5448
+	.rodata     start:0x801DD6A8 end:0x801DD6F8
 	.bss        start:0x80309178 end:0x8030B62C
-	.sdata2     start:0x803320A0 end:0x803320C8
+	.sdata2     start:0x80332088 end:0x803320C8
 
 pppConstrainCameraDir.cpp:
 	extab       start:0x80009BFC end:0x80009C04

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -11,15 +11,15 @@
 #include "ffcc/partyobj.h"
 #include "ffcc/p_dbgmenu.h"
 extern "C" {
-extern char kAStarGroupDebugFormat[];
-extern char kAStarPortalDebugFormat[];
-extern char kAStarCostDebugFormat[];
-extern const float kPolyGroupBaseXZ;
-extern const float kPolyGroupBaseY;
-extern const float kPolyGroupTopOffsetY;
-extern const float kPolyGroupAabbMax;
-extern const float kPolyGroupAabbMin;
-extern const float kAStarEscapeInitialBestDist;
+extern const char kAStarGroupDebugFormat[] = "A* GROUP=%d";
+extern const char kAStarPortalDebugFormat[] = "addAStar(%.5f, %.5f, %.5f, %d, %d, 0, 0);\n";
+extern const char kAStarCostDebugFormat[0x18] = "\x8d\xc5\x92\x5a\x8c\x6f\x98\x48%d->%d=%.5fm ";
+extern const float kPolyGroupBaseXZ = 0.0f;
+extern const float kPolyGroupBaseY = -100.0f;
+extern const float kPolyGroupTopOffsetY = 5.0f;
+extern const float kPolyGroupAabbMax = 10000000000.0f;
+extern const float kPolyGroupAabbMin = -10000000000.0f;
+extern const float kAStarEscapeInitialBestDist = -1000000.0f;
 extern const char kAStarGroupDebugLabel[] = "//A*\n";
 extern const float kDrawAStarSphereRadius = 10.0f;
 extern const float kInfiniteCost = 10000000.0f;
@@ -297,7 +297,7 @@ void CAStar::addRealTime(CGPartyObj* gPartyObj)
 		m_lastSeenGroup   = static_cast<unsigned char>(gPartyObj->m_aStarGroupId);
 	}
 
-	Graphic.Printf(10, 10, kAStarGroupDebugFormat, static_cast<int>(gPartyObj->m_aStarGroupId));
+	Graphic.Printf(10, 10, const_cast<char*>(kAStarGroupDebugFormat), static_cast<int>(gPartyObj->m_aStarGroupId));
 
 	bool padBusy = false;
 
@@ -417,7 +417,7 @@ void CAStar::addRealTime(CGPartyObj* gPartyObj)
 		if (used)
 		{
 			System.Printf(
-				kAStarPortalDebugFormat,
+				const_cast<char*>(kAStarPortalDebugFormat),
 				static_cast<double>(p.m_position.x),
 				static_cast<double>(p.m_position.y),
 				static_cast<double>(p.m_position.z),


### PR DESCRIPTION
## Summary
- Claim the A* debug format `.rodata` range and the preceding A* polygon constant `.sdata2` range in the GCCP01 split.
- Define the formerly external A* strings/floats in `astar.cpp`, leaving following `singmenu` rodata outside the astar range.
- Keep call sites using the existing mutable format-string APIs via `const_cast`.

## Evidence
- `ninja` passes and `build/GCCP01/main.dol` is up to date.
- `build/tools/objdiff-cli diff -p . -u main/astar` reports `.rodata` 80 bytes at 100% and `.sdata2` 64 bytes at 100%.
- Newly claimed symbols match at 100%: `kAStarGroupDebugFormat`, `kAStarPortalDebugFormat`, `kAStarCostDebugFormat`, `kPolyGroupBaseXZ`, `kPolyGroupBaseY`, `kPolyGroupTopOffsetY`, `kPolyGroupAabbMax`, `kPolyGroupAabbMin`, `kAStarEscapeInitialBestDist`.

## Plausibility
These constants are referenced by A* code and sit immediately before the existing astar-owned `kAStarGroupDebugLabel` range. The rodata range stops before `DAT_801dd6f8`/`DAT_801dd708`, which are used by `singmenu`.
