### PR TITLE
Match pad manager RTTI linkage

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -14,6 +14,8 @@
 
 #include <string.h>
 
+extern "C" void* __RTTI__8CManager[];
+
 CPad Pad;
 
 void* operator new[](unsigned long, CMemory::CStage*, char*, int);


### PR DESCRIPTION
## Summary
- Declare the existing CManager RTTI symbol in pad.cpp so CPad uses the shared base RTTI linkage instead of emitting a local CManager RTTI blob.
- This mirrors the established pattern used by other manager-derived units such as usb.cpp.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff main/pad Frame__4CPadFv: CPad aggregate [.data-0] improves from 54.70086% to 57.4359%.
- Frame__4CPadFv code remains unchanged at 93.87764%.

## Plausibility
- The change does not manually define RTTI or vtables; it references the existing compiler-generated CManager RTTI symbol, reducing duplicate local RTTI data in pad.o.