### PR TITLE
Match CLightPcs SetPart and improve EquipDraw

### DIFF
--- a/src/menu_equip.cpp
+++ b/src/menu_equip.cpp
@@ -30,7 +30,7 @@ extern "C" void DrawRect__8CMenuPcsFUlfffffffff(double, double, double, double, 
                                                  int);
 extern "C" void DrawRect__8CMenuPcsFUlffffffP8_GXColorfff(double, double, double, double, double, double, double, double,
                                                            CMenuPcs*, int, void*);
-extern "C" void DrawSingleIcon__8CMenuPcsFiiifif(double, CMenuPcs*, int, int, int, float);
+extern "C" void DrawSingleIcon__8CMenuPcsFiiifif(CMenuPcs*, int, int, int, float, int, float);
 extern "C" void DrawInit__8CMenuPcsFv(CMenuPcs*);
 extern "C" s16* GetLetterBuffer__6JoyBusFi(void*, int);
 extern "C" double CalcListPos__8CMenuPcsFiii(CMenuPcs*, int, int, int);
@@ -543,7 +543,7 @@ void CMenuPcs::EquipDraw()
 			int iconY = (int)((float)(item[1] + 6) - FLOAT_80332ee0);
 			int iconX = item[0] + item[2] - 0x10;
 			int itemIdx = *(s16*)(caravanWork + *(s16*)(caravanWork + 0xac + i * 2) * 2 + 0xb6);
-			DrawSingleIcon__8CMenuPcsFiiifif((double)*(float*)(item + 8), this, itemIdx, iconX, iconY, FLOAT_80332ee0);
+			DrawSingleIcon__8CMenuPcsFiiifif(this, itemIdx, iconX, iconY, *(float*)(item + 8), 0, FLOAT_80332ee0);
 		}
 		item += 0x20;
 	}
@@ -720,7 +720,7 @@ void CMenuPcs::EquipDraw()
 				int iconY = (int)((float)(iconItem[1] + 6) - FLOAT_80332ee0);
 				int iconX = (int)(float)(iconItem[0] + iconItem[2] - 0x10);
 				int itemIdx = *(s16*)(caravanWork + letter[idx] * 2 + 0xb6);
-				DrawSingleIcon__8CMenuPcsFiiifif((double)*(float*)(listStart + 8), this, itemIdx, iconX, iconY, FLOAT_80332ee0);
+				DrawSingleIcon__8CMenuPcsFiiifif(this, itemIdx, iconX, iconY, *(float*)(listStart + 8), 0, FLOAT_80332ee0);
 			}
 			iconItem += 0x20;
 		}

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -752,8 +752,6 @@ void CLightPcs::SetBit32(CLightPcs::TARGET target, unsigned long* bits)
  */
 void CLightPcs::SetPart(CLightPcs::TARGET target, void* part, unsigned char mode)
 {
-    char* lightPcs = (char*)this;
-
     if (mode == 0) {
         GXSetNumChans((u8)1);
         GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
@@ -761,36 +759,34 @@ void CLightPcs::SetPart(CLightPcs::TARGET target, void* part, unsigned char mode
         return;
     }
 
-    char* bumpSlot = lightPcs + 0x63c;
-    *(u32*)(lightPcs + 0xb0) = 0;
-    *(u32*)(lightPcs + 0xb4) = 0;
     GXAttnFn attnFn = (GXAttnFn)1;
+    CLight* light = m_sceneLights;
+    m_loadedLightCount = 0;
+    m_loadedLightMask = 0;
 
-    for (u32 i = 0; i < *(u32*)(lightPcs + 0xb8); i++) {
-        if ((*(char*)(bumpSlot + 0x60 + (int)target) != '\0') && (*(u32*)(bumpSlot + 0x64) == (u32)part)) {
-            _GXColor lightColor;
-            *(u32*)&lightColor = *(u32*)(bumpSlot + 0x50 + ((int)target * 4));
-            GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c), lightColor);
-            GXLoadLightObjImm((GXLightObj*)(bumpSlot + 0x6c), (GXLightID)(1 << *(u32*)(lightPcs + 0xb0)));
+    for (u32 i = 0; i < m_sceneLightCount; i++, light++) {
+        if ((light->m_targetEnable[target] != 0) && (light->m_part == part)) {
+            _GXColor lightColor = light->m_targetColor[target];
+            GXInitLightColor(&light->m_gxLightObj, lightColor);
+            GXLoadLightObjImm(&light->m_gxLightObj, (GXLightID)(1 << m_loadedLightCount));
 
-            if (*(char*)(bumpSlot + 0x4f) != '\0') {
+            if (light->m_specularMode != 0) {
                 attnFn = (GXAttnFn)0;
             }
 
-            *(u32*)(lightPcs + 0xb4) |= 1 << *(u32*)(lightPcs + 0xb0);
-            *(u32*)(lightPcs + 0xb0) += 1;
-            if (*(u32*)(lightPcs + 0xb0) > 7) {
+            m_loadedLightMask |= 1 << m_loadedLightCount;
+            m_loadedLightCount += 1;
+            if (m_loadedLightCount >= 8) {
                 break;
             }
         }
-        bumpSlot += 0xb0;
     }
 
     GXSetNumChans((u8)1);
     if (mode == 1) {
-        GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, *(u32*)(lightPcs + 0xb4), (GXDiffuseFn)2, attnFn);
+        GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, m_loadedLightMask, (GXDiffuseFn)2, attnFn);
     } else {
-        GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)1, (GXColorSrc)0, *(u32*)(lightPcs + 0xb4), (GXDiffuseFn)2, attnFn);
+        GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)1, (GXColorSrc)0, m_loadedLightMask, (GXDiffuseFn)2, attnFn);
     }
     GXSetChanCtrl((GXChannelID)2, (u8)1, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
 }


### PR DESCRIPTION
## Summary
- Rewrote CLightPcs::SetPart to use real CLightPcs/CLight members instead of manual byte offsets.
- Fixed the menu_equip DrawSingleIcon declaration/calls to use the real argument order with rawIcon = 0.

## Evidence
- ninja passes.
- main/p_light SetPart__9CLightPcsFQ29CLightPcs6TARGETPvUc: 89.01802% -> 100.0%.
- main/menu_equip EquipDraw__8CMenuPcsFv: 56.928036% -> 57.29626%.
- main/menu_equip .text: 60.797386% -> 60.958332%.

## Plausibility
- SetPart now matches the surrounding typed CLightPcs member layout and removes offset arithmetic where fields are already known.
- DrawSingleIcon now matches the signature used by other menu code and passes the rawIcon argument explicitly.