### PR TITLE
Improve camera map init match

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1115,8 +1115,8 @@ void CCameraPcs::createMap()
     float fVar2;
     float fVar1;
 
-    fVar2 = FLOAT_8032fa5c;
     fVar1 = FLOAT_8032fa34;
+    fVar2 = FLOAT_8032fa5c;
     *reinterpret_cast<float*>(self + 0x478) = fVar1;
     fVar4 = FLOAT_8032fab0;
     *reinterpret_cast<float*>(self + 0x474) = fVar1;


### PR DESCRIPTION
## Summary
- reorder the initial CCameraPcs::createMap float constant setup so the zero/default value is materialized before FLOAT_8032fa5c
- keeps the initializer behavior unchanged while matching the target instruction order more closely

## Evidence
- ninja passes
- build/tools/objdiff-cli diff -p . -u main/p_camera -o - createMap__10CCameraPcsFv
  - before: 76 bytes, 96.052635%
  - after: 76 bytes, 96.31579%

## Plausibility
- this is a source-level initializer ordering change, not a linkage or section hack
- it preserves the existing local variables and assignments while making the constant setup order closer to the original output