### PR TITLE
Match CGMonObj radar display check

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -2449,7 +2449,8 @@ unsigned int CGMonObj::IsDispRader()
 {
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	unsigned char result = 0;
-	if (object->CGObject::IsDispRader() != 0 &&
+	int isDispRader = object->CGObject::IsDispRader();
+	if (isDispRader != 0 &&
 	    static_cast<signed char>(
 	        static_cast<int>((static_cast<unsigned int>(*reinterpret_cast<unsigned char*>(&object->m_weaponNodeFlags)) << 24) &
 	                         0xC0000000) >>


### PR DESCRIPTION
## Summary
- Store the base radar display result in a signed local before testing it in CGMonObj::IsDispRader.
- This matches the target signed compare shape while keeping the existing weapon-node flag check behavior.

## Evidence
- ninja passes.
- Before: IsDispRader__8CGMonObjFv was 97.391304% matched, 92 bytes.
- After: build/tools/objdiff-cli diff -p . -u main/monobj -o - IsDispRader__8CGMonObjFv reports 100.0% matched, 92 bytes.
- Report improved matched code from 591564 to 591656 bytes and matched functions from 3459 to 3460.