### PR TITLE
Type FunnyShape texture headers

### DIFF
--- a/include/ffcc/FS_USB_Process.h
+++ b/include/ffcc/FS_USB_Process.h
@@ -47,7 +47,15 @@ struct OSFS_ANM_ST
 
 struct OSFS_TEXTURE_ST
 {
-    u8 data[0x30];
+    s16 unk00;      // 0x00
+    s16 unk02;      // 0x02
+    s16 width;      // 0x04
+    s16 height;     // 0x06
+    s16 unk08;      // 0x08
+    s16 unk0A;      // 0x0A
+    s16 unk0C;      // 0x0C
+    s16 unk0E;      // 0x0E
+    u8 unk10[0x20]; // 0x10
 };
 
 #endif // _FFCC_FS_USB_PROCESS_H_

--- a/include/ffcc/FunnyShape.h
+++ b/include/ffcc/FunnyShape.h
@@ -45,7 +45,7 @@ public:
     OSFS_SHAPE_ST m_shape;               // 0x6000
     void* m_meshData;                    // 0x6010
     void* m_texObjData[0x10];            // 0x6014
-    void* m_textureHeaders[0x10];        // 0x6054
+    OSFS_TEXTURE_ST* m_textureHeaders[0x10]; // 0x6054
     void* m_textureData[0x10];           // 0x6094
     s8 m_textureCount;                   // 0x60D4
     u8 m_textureCountPad[3];             // 0x60D5

--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -351,7 +351,7 @@ void CFunnyShape::ClearTextureData()
         }
 
         if (iter->m_textureHeaders[0] != 0) {
-            delete static_cast<OSFS_TEXTURE_ST*>(iter->m_textureHeaders[0]);
+            delete iter->m_textureHeaders[0];
             iter->m_textureHeaders[0] = 0;
         }
         iter = reinterpret_cast<CFunnyShape*>(Ptr(iter, 4));
@@ -467,9 +467,8 @@ void CFunnyShape::RenderTexture()
     _GXSetBlendMode__F12_GXBlendMode14_GXBlendFactor14_GXBlendFactor10_GXLogicOp(1, 4, 2, 3);
     GXLoadTexObj(reinterpret_cast<GXTexObj*>(m_texObjData[0]), GX_TEXMAP0);
 
-    const u8* texData = reinterpret_cast<const u8*>(m_textureHeaders[0]);
-    const s16 width = *reinterpret_cast<const s16*>(texData + 4);
-    const s16 height = *reinterpret_cast<const s16*>(texData + 6);
+    const s16 width = m_textureHeaders[0]->width;
+    const s16 height = m_textureHeaders[0]->height;
     GXSetViewport(FLOAT_8032fd98, FLOAT_8032fd98, static_cast<float>(width), static_cast<float>(height),
                   FLOAT_8032fd6c, FLOAT_8032fd74);
 
@@ -741,7 +740,7 @@ CFunnyShape::~CFunnyShape()
         }
 
         if (iter->m_textureHeaders[0] != 0) {
-            delete static_cast<OSFS_TEXTURE_ST*>(iter->m_textureHeaders[0]);
+            delete iter->m_textureHeaders[0];
             iter->m_textureHeaders[0] = 0;
         }
 


### PR DESCRIPTION
## Summary
- model OSFS_TEXTURE_ST with the 16-bit header fields used by the FunnyShape loader
- type CFunnyShape::m_textureHeaders as OSFS_TEXTURE_ST pointers
- replace RenderTexture width/height raw offsets and matching delete casts with member access

## Evidence
- The loader in FS_USB_Process swaps texture header halfwords at offsets 0x00..0x0E and copies a 0x30-byte header, which supports width and height at offsets 0x04 and 0x06.
- ninja passes for GCCP01.
- objdiff checks remain stable: RenderTexture__11CFunnyShapeFv 97.7957%, SetUSBData__14CFunnyShapePcsFv 99.086266%.

## Plausibility
This does not manually define generated data or force codegen. It replaces raw byte access with the packet layout already implied by the USB import path, making the FunnyShape texture data model more coherent for future matching work.