### PR TITLE
Match CFile::Quit cleanup

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -723,7 +723,9 @@ void CFile::Quit()
 
     u32 nextOffset = m_handlePoolHead.m_currentOffset;
     if (nextOffset != 0) {
-        operator delete[](reinterpret_cast<void*>(nextOffset - 0x10));
+        if (nextOffset != 0) {
+            operator delete[](reinterpret_cast<void*>(nextOffset - 0x10));
+        }
         m_handlePoolHead.m_currentOffset = 0;
     }
 


### PR DESCRIPTION
## Summary
- Matches `CFile::Quit` by preserving the handle-pool null guard before deleting the array cookie allocation.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/file -o - Quit__5CFileFv`: `Quit__5CFileFv` improved from `96.42857%` to `100.0%`.
- Full build progress increased game-code matched functions by one: `1874 / 3111` to `1875 / 3111`.

## Plausibility
- `Init` stores a constructed array pointer for the handle pool; `Quit` frees the underlying array-cookie allocation and clears the stored pointer. The extra guard mirrors the original array-delete null-check shape without changing behavior.