### PR TITLE
Match CWind Draw

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -545,14 +545,17 @@ void CWind::Draw()
         int i = 0;
         do {
             if (GetWindActiveFlag(obj) != 0) {
-                CVector center(obj->centerX, FLOAT_80330ef0, obj->centerZ);
                 if (obj->type == 1) {
-                    CColor color(0xff, 0xff, 0, 0xff);
-                    Graphic.DrawSphere(viewMtx, reinterpret_cast<Vec*>(&center), obj->radius, &color.color);
+                    const CColor& color = CColor(0xff, 0xff, 0, 0xff);
+                    Graphic.DrawSphere(viewMtx,
+                                       reinterpret_cast<Vec*>(&CVector(obj->centerX, FLOAT_80330ef0, obj->centerZ)),
+                                       obj->radius, const_cast<_GXColor*>(&color.color));
                 } else {
                     u8 alpha = (u8)(FLOAT_80330f1c * (FLOAT_80330ef8 - obj->lifeRatio));
-                    CColor color(0xff, 0xff, 0x80, alpha);
-                    Graphic.DrawSphere(viewMtx, reinterpret_cast<Vec*>(&center), obj->radius, &color.color);
+                    const CColor& color = CColor(0xff, 0xff, 0x80, alpha);
+                    Graphic.DrawSphere(viewMtx,
+                                       reinterpret_cast<Vec*>(&CVector(obj->centerX, FLOAT_80330ef0, obj->centerZ)),
+                                       obj->radius, const_cast<_GXColor*>(&color.color));
                 }
             }
 


### PR DESCRIPTION
## Summary
- Match `CWind::Draw` by constructing the debug draw color before the temporary center vector in each branch.
- Preserve the existing temporary `CVector` style used elsewhere while keeping the constructor return for the color argument.

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/wind -o /tmp/wind_final.json`
- `Draw__5CWindFv`: 80.40426% -> 100.0%, size 528 -> 564
- Overall progress: code matched 591064 -> 591628 bytes; functions 3454 -> 3455

## Plausibility
- The change follows constructor ordering shown by the target/Ghidra shape: color temporary first, then center vector temporary, then `Graphic.DrawSphere`.
- No manual symbols, fake labels, section forcing, or address hacks.
