### PR TITLE
Improve CGPrgObj getTargetRot vector setup

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -284,8 +284,8 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float targetRot;
 	float deltaX;
 	float deltaZ;
-	CVector basePos(m_worldPosition);
 	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));


### PR DESCRIPTION
## Summary
- Reorder the local CVector construction in CGPrgObj::getTargetRot to match the target/base setup used by the original code shape.
- This aligns the function with the surrounding rotTarget/dstTargetRot pattern and the Ghidra decompilation order.

## Objdiff Evidence
- Unit main/prgobj .text: 97.8036% -> 98.04703%
- Symbol getTargetRot__8CGPrgObjFP8CGPrgObj: 86.138885% -> 91.02778%
- Overall unit fuzzy match is now 98.10927%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/prgobj -o -

## Notes
- extabindex score shifts down locally, but the code match and plausible source shape improve. The change is limited to construction order and does not introduce compiler-forcing hacks.