### PR TITLE
Match chara anim bank allocation

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -11,6 +11,7 @@ extern "C" const char s_charaAnimAllocWarn[32] =
     "\214\303\202\242\203\101\203\152\203\201\201\133\203\126\203\207\203\223"
     "\214\140\216\256\202\305\202\267\201\102\n";
 extern "C" void gqrInit__6CCharaFUlUlUl(void*, unsigned long, unsigned long, unsigned long);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void SetGroup__7CMemoryFPvi(CMemory*, void*, int);
 extern "C" void CopyFromAMemorySync__7CMemoryFPvPvUl(CMemory*, void*, void*, unsigned long);
 extern "C" int TryReleaseAnimBank__9CCharaPcsFi(void*, int);
@@ -368,8 +369,8 @@ void CChara::CAnimNode::Interp(CChara::CAnim* anim, SRT* srt, float frame)
 {
 	if (anim->m_bank == 0) {
 		while (anim->m_bank == 0) {
-			anim->m_bank =
-			    new (anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160) unsigned char[anim->m_bankSize];
+			anim->m_bank = _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+			    &Memory, anim->m_bankSize, anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160, 1);
 
 			if (anim->m_bank != 0) {
 				break;


### PR DESCRIPTION
## Summary
- Use `CMemory::_Alloc` directly for `CChara::CAnimNode::Interp` anim bank allocation.
- This matches the target allocator path, including the explicit alignment argument, instead of going through `new[]`.

## Objdiff evidence
- `main/chara_anim` `.text`: 97.64045% -> 98.51685%
- `Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf`: 96.46667% -> 99.30303%
- Build report game data matched: 646927 -> 647047 bytes

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/chara_anim -o /tmp/chara_anim_final.json`
