### PR TITLE
Match CFile handle pool allocation

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -11,6 +11,7 @@
 #include "ffcc/util.h"
 
 #include <PowerPC_EABI_Support/Runtime/New.h>
+#include <PowerPC_EABI_Support/Runtime/MWCPlusLib.h>
 #include <dolphin/gx.h>
 #include <dolphin/os/OSCache.h>
 #include <dolphin/vi.h>
@@ -748,7 +749,9 @@ void CFile::Init()
     m_isDiskError = 0;
     m_readBuffer = new ((CMemory::CStage*)m_allocStage, const_cast<char*>(s_fileCpp), 0x2b) unsigned char[0x100000];
     m_handlePoolHead.m_currentOffset =
-        (u32)new ((CMemory::CStage*)m_allocStage, const_cast<char*>(s_fileCpp), 0x2e) CHandle[0x80];
+        (u32)__construct_new_array(operator new[](0x5610, (CMemory::CStage*)m_allocStage,
+                                                  const_cast<char*>(s_fileCpp), 0x2e),
+                                   0, 0, sizeof(CHandle), 0x80);
     m_fileHandle.m_next = &m_fileHandle;
     m_fileHandle.m_previous = &m_fileHandle;
     m_fileHandle.m_priority = PRI_SENTINEL;


### PR DESCRIPTION
Summary:
- Match CFile::Init by allocating the CHandle pool with the same Metrowerks array-helper shape as the target.
- Adds the runtime helper include needed for __construct_new_array.

Objdiff evidence:
- main/file Init__5CFileFv: 95.088234% -> 100.0%
- Built size now matches target: 408b -> 408b

Verification:
- ninja
- build/tools/objdiff-cli diff -p . -u main/file -o - Init__5CFileFv