### PR TITLE
Use array delete for chara mesh buffers

### DIFF
--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -3084,31 +3084,31 @@ CChara::CMesh::CRefData::~CRefData()
 	CCharaMeshRefRaw* ref = reinterpret_cast<CCharaMeshRefRaw*>(this);
 
 	if (ref->m_vertices != 0) {
-		operator delete(ref->m_vertices);
+		operator delete[](ref->m_vertices);
 		ref->m_vertices = 0;
 	}
 	if (ref->m_normals != 0) {
-		operator delete(ref->m_normals);
+		operator delete[](ref->m_normals);
 		ref->m_normals = 0;
 	}
 	if (ref->m_colors != 0) {
-		operator delete(ref->m_colors);
+		operator delete[](ref->m_colors);
 		ref->m_colors = 0;
 	}
 	if (ref->m_uvs != 0) {
-		operator delete(ref->m_uvs);
+		operator delete[](ref->m_uvs);
 		ref->m_uvs = 0;
 	}
 	if (ref->m_oneWeightData != 0) {
-		operator delete(ref->m_oneWeightData);
+		operator delete[](ref->m_oneWeightData);
 		ref->m_oneWeightData = 0;
 	}
 	if (ref->m_twoWeightData != 0) {
-		operator delete(ref->m_twoWeightData);
+		operator delete[](ref->m_twoWeightData);
 		ref->m_twoWeightData = 0;
 	}
 	if (ref->m_threeWeightData != 0) {
-		operator delete(ref->m_threeWeightData);
+		operator delete[](ref->m_threeWeightData);
 		ref->m_threeWeightData = 0;
 	}
 	if (ref->m_displayLists != 0) {
@@ -3150,7 +3150,7 @@ CChara::CMesh::CDisplayList::~CDisplayList()
 {
 	void** data = (void**)((u8*)this + 4);
 	if (data[0] != 0) {
-		operator delete(data[0]);
+		operator delete[](data[0]);
 		data[0] = 0;
 	}
 }


### PR DESCRIPTION
## Summary
- Use array delete for CChara::CMesh::CRefData buffer members.
- Use array delete for CChara::CMesh::CDisplayList data buffers.

## Objdiff evidence
- __dt__Q36CChara5CMesh8CRefDataFv: 99.545456% -> 100.0%
- __dt__Q36CChara5CMesh12CDisplayListFv: 99.8% -> 100.0%
- main/chara .text: 50.51857% -> 50.526386%

## Plausibility
These members are allocated as buffers/arrays and Ghidra shows the original destructors calling __dla__FPv for these frees, so the change recovers normal array-delete ownership rather than coaxing instruction output.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara -o /tmp/chara_final_refdata.json __dt__Q36CChara5CMesh8CRefDataFv