### PR TITLE
Improve chara_anim bank allocation matching

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -13,6 +13,7 @@ extern "C" const char s_charaAnimAllocWarn[32] =
 extern "C" void gqrInit__6CCharaFUlUlUl(void*, unsigned long, unsigned long, unsigned long);
 extern "C" void SetGroup__7CMemoryFPvi(CMemory*, void*, int);
 extern "C" void CopyFromAMemorySync__7CMemoryFPvPvUl(CMemory*, void*, void*, unsigned long);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" int TryReleaseAnimBank__9CCharaPcsFi(void*, int);
 class CCharaPcs;
 extern CChara Chara;
@@ -303,7 +304,7 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 					m_bankAddress = Chara.m_animBankAddress;
 					Chara.m_animBankAddress += m_bankSize;
 					if (m_bank != 0) {
-						delete[] static_cast<unsigned char*>(m_bank);
+						delete static_cast<unsigned char*>(m_bank);
 						m_bank = 0;
 					}
 					break;
@@ -368,8 +369,8 @@ void CChara::CAnimNode::Interp(CChara::CAnim* anim, SRT* srt, float frame)
 {
 	if (anim->m_bank == 0) {
 		while (anim->m_bank == 0) {
-			anim->m_bank =
-			    new (anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160) unsigned char[anim->m_bankSize];
+			anim->m_bank = _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+			    &Memory, anim->m_bankSize, anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160, 1);
 
 			if (anim->m_bank != 0) {
 				break;


### PR DESCRIPTION
## Summary
- Use `CMemory::_Alloc(..., 1)` for `CChara::CAnimNode::Interp` bank reloads, matching the target allocation path instead of placement array-new.
- Match the temporary bank cleanup in `CChara::CAnim::Create` by using scalar delete at that call site.

## Evidence
- `ninja` passes.
- `main/chara_anim` report is now code `98.544945%`, data `84.375%`, matched functions `4/7`.
- `Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf` improves from the selected target bucket's ~`96.6%` to `99.30303%` by objdiff.
- `Create__Q26CChara5CAnimFPvPQ27CMemory6CStage` improves from `97.333336%` to `97.354164%`.

## Plausibility
The target decompilation shows this bank reload path using `CMemory::_Alloc` with the final group/alignment argument set to `1`, followed by the existing `SetGroup` and AMEM copy. This change replaces a higher-level array-new expression with the project memory API already used throughout adjacent code, without introducing addresses, fake symbols, or generated vtable/RTTI hacks.