### PR TITLE
Improve CLightPcs SetPosition match

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -657,9 +657,7 @@ void CLightPcs::SetPosition(CLightPcs::TARGET target, Vec* pos, unsigned long ma
             GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, chanMask, (GXDiffuseFn)2, (GXAttnFn)1);
             GXSetChanCtrl((GXChannelID)2, (u8)1, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
 
-            _GXColor chanMat;
-            *(u32*)&chanMat = DAT_8032fc08;
-            GXSetChanMatColor((GXChannelID)4, chanMat);
+            GXSetChanMatColor((GXChannelID)4, *reinterpret_cast<_GXColor*>(&DAT_8032fc08));
         }
         return;
     }
@@ -675,15 +673,14 @@ void CLightPcs::SetPosition(CLightPcs::TARGET target, Vec* pos, unsigned long ma
     if (pos != nullptr) {
         char* bumpSlot = lightPcs + 0x63c;
         for (u32 i = 0; i < *(u32*)(lightPcs + 0xb8); i++) {
-            if ((*(char*)(bumpSlot + 0x60 + (int)target) != '\0') && ((*(u32*)(bumpSlot + 0x34) & mask) != 0) &&
+            if ((*(u8*)((int)target + (int)bumpSlot + 0x60) != 0) && ((*(u32*)(bumpSlot + 0x34) & mask) != 0) &&
                 ((double)PSVECSquareDistance(pos, (Vec*)(bumpSlot + 4)) < (double)*(float*)(bumpSlot + 0xac))) {
-                _GXColor lightColor;
-                *(u32*)&lightColor = *(u32*)(bumpSlot + 0x50 + ((int)target * 4));
-                GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c), lightColor);
+                GXInitLightColor((GXLightObj*)(bumpSlot + 0x6c),
+                                 *reinterpret_cast<_GXColor*>((int)(target * sizeof(u32)) + (int)bumpSlot + 0x50));
                 GXLoadLightObjImm((GXLightObj*)(bumpSlot + 0x6c), (GXLightID)(1 << *(u32*)(lightPcs + 0xb0)));
                 *(u32*)(lightPcs + 0xb4) |= 1 << *(u32*)(lightPcs + 0xb0);
                 *(u32*)(lightPcs + 0xb0) += 1;
-                if (*(u32*)(lightPcs + 0xb0) > 7) {
+                if (*(u32*)(lightPcs + 0xb0) >= 8) {
                     break;
                 }
             }
@@ -697,9 +694,7 @@ void CLightPcs::SetPosition(CLightPcs::TARGET target, Vec* pos, unsigned long ma
         GXSetChanCtrl((GXChannelID)0, (u8)1, (GXColorSrc)0, (GXColorSrc)1, chanMask, (GXDiffuseFn)2, (GXAttnFn)1);
         GXSetChanCtrl((GXChannelID)2, (u8)1, (GXColorSrc)0, (GXColorSrc)1, 0, (GXDiffuseFn)0, (GXAttnFn)2);
 
-        _GXColor chanMat;
-        *(u32*)&chanMat = DAT_8032fc08;
-        GXSetChanMatColor((GXChannelID)4, chanMat);
+        GXSetChanMatColor((GXChannelID)4, *reinterpret_cast<_GXColor*>(&DAT_8032fc08));
     }
 }
 


### PR DESCRIPTION
## Summary
- Tighten CLightPcs::SetPosition color loads to avoid redundant local _GXColor copies.
- Use unsigned byte access for target-enable state and express the light-count limit as >= 8.
- Preserve the existing p_light offset style while improving generated code shape.

## Evidence
- ninja passes.
- objdiff main/p_light .text: 89.62055% -> 89.979774%.
- SetPosition__9CLightPcsFQ29CLightPcs6TARGETP3VecUl: 92.9403% -> 99.56716%.

## Plausibility
- _GXColor values are already packed words in this unit; passing them directly matches the original stack usage better than creating extra temporaries.
- targetEnable is a byte field, so unsigned byte access is more accurate than signed char access.
- The loaded light count cap is naturally written as >= 8 for the eight hardware light slots.