### PR TITLE
Improve CWind Draw matching

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -545,13 +545,14 @@ void CWind::Draw()
         int i = 0;
         do {
             if (GetWindActiveFlag(obj) != 0) {
-                CVector center(obj->centerX, FLOAT_80330ef0, obj->centerZ);
                 if (obj->type == 1) {
                     CColor color(0xff, 0xff, 0, 0xff);
+                    CVector center(obj->centerX, FLOAT_80330ef0, obj->centerZ);
                     Graphic.DrawSphere(viewMtx, reinterpret_cast<Vec*>(&center), obj->radius, &color.color);
                 } else {
                     u8 alpha = (u8)(FLOAT_80330f1c * (FLOAT_80330ef8 - obj->lifeRatio));
                     CColor color(0xff, 0xff, 0x80, alpha);
+                    CVector center(obj->centerX, FLOAT_80330ef0, obj->centerZ);
                     Graphic.DrawSphere(viewMtx, reinterpret_cast<Vec*>(&center), obj->radius, &color.color);
                 }
             }


### PR DESCRIPTION
## Summary
- Move the wind debug draw center vector construction into each draw branch after the branch-local color construction.
- Matches the target constructor order for CWind::Draw without changing behavior.

## Objdiff Evidence
- main/wind .text: 94.2% -> 95.831436%
- Draw__5CWindFv: 80.40426% -> 90.26241%
- Function size remains target-sized at 564 bytes.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/wind -o -