### PR TITLE
Improve chara anim bank allocation

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -11,6 +11,8 @@ extern "C" const char s_charaAnimAllocWarn[32] =
     "\214\303\202\242\203\101\203\152\203\201\201\133\203\126\203\207\203\223"
     "\214\140\216\256\202\305\202\267\201\102\n";
 extern "C" void gqrInit__6CCharaFUlUlUl(void*, unsigned long, unsigned long, unsigned long);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+    CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void SetGroup__7CMemoryFPvi(CMemory*, void*, int);
 extern "C" void CopyFromAMemorySync__7CMemoryFPvPvUl(CMemory*, void*, void*, unsigned long);
 extern "C" int TryReleaseAnimBank__9CCharaPcsFi(void*, int);
@@ -368,8 +370,8 @@ void CChara::CAnimNode::Interp(CChara::CAnim* anim, SRT* srt, float frame)
 {
 	if (anim->m_bank == 0) {
 		while (anim->m_bank == 0) {
-			anim->m_bank =
-			    new (anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160) unsigned char[anim->m_bankSize];
+			anim->m_bank = _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+			    &Memory, anim->m_bankSize, anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160, 1);
 
 			if (anim->m_bank != 0) {
 				break;


### PR DESCRIPTION
## Summary
- Route CChara::CAnimNode::Interp animation bank allocation through CMemory::_Alloc with the no-error/group flag used by the target
- Keep the existing retry/release flow while avoiding the global array-new wrapper

## Evidence
- ninja passes
- Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf: 96.46667% -> 99.30303%, size now 660 bytes
- main/chara_anim .text: 97.64045% -> 98.51685%
- Data sections unchanged: .data 50.0%, .sdata 25.0%, .sdata2 100.0%

## Plausibility
Ghidra shows the target calling CMemory::_Alloc(&Memory, size, stage, chara_anim.cpp, 0x160, 1) for this bank reload path. This source change represents that directly instead of relying on the generic placement array-new helper, which used the wrong allocator path for the target.