### PR TITLE
Fix cflat r2class math linkage

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -12,6 +12,9 @@
 #include "ffcc/ringmenu.h"
 #include "ffcc/system.h"
 
+extern "C" double sin(double);
+extern "C" double cos(double);
+
 #include <math.h>
 
 extern "C" int IsAnimFinished__8CGObjectFi(CGObject*, int);


### PR DESCRIPTION
## Summary
- Declare cflat_r2class sin/cos imports with C linkage so the compiled object imports target symbols `sin` and `cos` instead of C++ mangled `sin__Fd` / `cos__Fd`.

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- `objdump -t build/GCCP01/src/cflat_r2class.o` now shows unresolved `cos` and `sin`, matching `build/GCCP01/obj/cflat_r2class.o`.
- `objdiff-cli` for `main/cflat_r2class` / `onClassSystemFunc__13CFlatRuntime2FPQ212CFlatRuntime7CObjectiiRi` remains code-neutral at 31.079813%, with linkage improved.

## Plausibility
- Neighboring source files that call MSL math from C++ use explicit `extern "C"` declarations for these imports; this follows that pattern and removes an ABI-level mismatch without coercing codegen.