### PR TITLE
Improve chara anim bank allocation

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -11,6 +11,7 @@ extern "C" const char s_charaAnimAllocWarn[32] =
     "\214\303\202\242\203\101\203\152\203\201\201\133\203\126\203\207\203\223"
     "\214\140\216\256\202\305\202\267\201\102\n";
 extern "C" void gqrInit__6CCharaFUlUlUl(void*, unsigned long, unsigned long, unsigned long);
+extern "C" void* _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(CMemory*, unsigned long, CMemory::CStage*, char*, int, int);
 extern "C" void SetGroup__7CMemoryFPvi(CMemory*, void*, int);
 extern "C" void CopyFromAMemorySync__7CMemoryFPvPvUl(CMemory*, void*, void*, unsigned long);
 extern "C" int TryReleaseAnimBank__9CCharaPcsFi(void*, int);
@@ -303,7 +304,7 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 					m_bankAddress = Chara.m_animBankAddress;
 					Chara.m_animBankAddress += m_bankSize;
 					if (m_bank != 0) {
-						delete[] static_cast<unsigned char*>(m_bank);
+						delete static_cast<unsigned char*>(m_bank);
 						m_bank = 0;
 					}
 					break;
@@ -368,8 +369,8 @@ void CChara::CAnimNode::Interp(CChara::CAnim* anim, SRT* srt, float frame)
 {
 	if (anim->m_bank == 0) {
 		while (anim->m_bank == 0) {
-			anim->m_bank =
-			    new (anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160) unsigned char[anim->m_bankSize];
+			anim->m_bank = _Alloc__7CMemoryFUlPQ27CMemory6CStagePcii(
+			    &Memory, anim->m_bankSize, anim->m_stage, const_cast<char*>(s_charaAnimSourceFile), 0x160, 1);
 
 			if (anim->m_bank != 0) {
 				break;


### PR DESCRIPTION
## Summary
- Use the underlying CMemory::_Alloc entry point for CAnimNode::Interp bank allocation with noError=1, matching the original allocator call shape.
- Free the temporary CAnim::Create AMEM upload buffer with scalar delete, matching the original call target.

## Objdiff Evidence
Before:
- Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf: 644 bytes, 96.46667%
- Create__Q26CChara5CAnimFPvPQ27CMemory6CStage: 960 bytes, 97.33334%
- main/chara_anim .text: 97.64045%
- extab/extabindex: 97.91667% / 98.61111%

After:
- Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf: 660 bytes, 99.30303%
- Create__Q26CChara5CAnimFPvPQ27CMemory6CStage: 960 bytes, 97.35416%
- main/chara_anim .text: 98.526215%
- extab/extabindex: 100.0% / 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara_anim -o - Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf