### PR TITLE
Improve CMemory init stage linking

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -393,8 +393,8 @@ void CMemory::Init()
             *reinterpret_cast<unsigned char**>(modeBase + 4) = modeBase;
             *reinterpret_cast<unsigned char**>(modeBase + 0x130) = modeBase + 600;
 
-            unsigned char* stageBase = modeBase;
-            for (int index = 0; index < 32; index += 4) {
+            CStage* stageBase = reinterpret_cast<CStage*>(modeBase + 0x258);
+            for (int index = 0; index < 32; index++) {
                 unsigned char* next;
 
                 if (index == 0x1F) {
@@ -402,30 +402,9 @@ void CMemory::Init()
                 } else {
                     next = modeBase + (index + 1) * 300 + 600;
                 }
-                *reinterpret_cast<unsigned char**>(stageBase + 0x25C) = next;
 
-                if (index == 0x1E) {
-                    next = modeBase + 300;
-                } else {
-                    next = modeBase + (index + 2) * 300 + 600;
-                }
-                *reinterpret_cast<unsigned char**>(stageBase + 0x388) = next;
-
-                if (index == 0x1D) {
-                    next = modeBase + 300;
-                } else {
-                    next = modeBase + (index + 3) * 300 + 600;
-                }
-                *reinterpret_cast<unsigned char**>(stageBase + 0x4B4) = next;
-
-                if (index == 0x1C) {
-                    next = modeBase + 300;
-                } else {
-                    next = modeBase + (index + 4) * 300 + 600;
-                }
-                *reinterpret_cast<unsigned char**>(stageBase + 0x5E0) = next;
-
-                stageBase += 0x4B0;
+                stageBase->m_next = reinterpret_cast<CStage*>(next);
+                stageBase++;
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace the manually unrolled free-stage link setup in `CMemory::Init()` with a typed `CStage` loop.
- This keeps the same 32-stage pool layout while producing code closer to the target.

## Objdiff Evidence
- `main/memory` `.text`: 76.3072% -> 76.3544% (+0.0473)
- `Init__7CMemoryFv`: 93.7099% -> 95.0840% (+1.3740), size 524
- `[extabindex-0]`: 36.5522% -> 36.8664% (+0.3142), size 360

## Verification
- `ninja`
- `python3 tools/objdiff_experiment.py -u main/memory Init__7CMemoryFv --baseline build/agent/memory_base.json --limit 10`

## Plausibility
- The new loop expresses the original pool-linking intent directly with `CStage::m_next` instead of hand-unrolled pointer offsets.
- No fake symbols, address hacks, section forcing, or generated ctor/dtor code were introduced.