### PR TITLE
Claim p_tina sdata2 conversion constant

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -356,7 +356,7 @@ p_tina.cpp:
 	.data       start:0x801EA9B0 end:0x801EADC8
 	.bss        start:0x80273928 end:0x80273A68
 	.sbss       start:0x8032ED38 end:0x8032ED50
-	.sdata2     start:0x8032FDC8 end:0x8032FDD8
+	.sdata2     start:0x8032FDC0 end:0x8032FDD8
 
 pppPart.cpp:
 	extab       start:0x80006D48 end:0x80006E80


### PR DESCRIPTION
## Summary
- extend the p_tina.cpp sdata2 split to include @541 at 0x8032FDC0
- claims the double conversion constant used by CPartPcs::drawAfterViewer heap-rate printing

## Evidence
- ninja passes and build/GCCP01/main.dol remains OK
- All Data: 823591 / 1489419 -> 823599 / 1489419 (+8)
- Game Data: 646927 / 1137399 -> 646935 / 1137407 (+8)
- main/p_tina .sdata2 section: size 24, 100.0%
- @541: size 8, 100.0%

## Plausibility
- config/GCCP01/symbols.txt attributes @541 to .sdata2:0x8032FDC0
- the current p_tina split started at 0x8032FDC8, excluding the constant immediately before the existing p_tina sdata2 range