### PR TITLE
Improve prgobj target rotation match

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -284,8 +284,8 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float targetRot;
 	float deltaX;
 	float deltaZ;
-	CVector basePos(m_worldPosition);
 	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));


### PR DESCRIPTION
## Summary
- Reordered the local vector construction in `CGPrgObj::getTargetRot` to match the target constructor order.
- Keeps the existing target rotation logic unchanged while improving generated code shape.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o /tmp/prgobj_final.json getTargetRot__8CGPrgObjFP8CGPrgObj`
- `main/prgobj` `.text` match improved from 97.8036% to 98.0470%.
- `python3 tools/agent_select_target.py` no longer lists `main/prgobj` in the selected opportunity buckets after the change.

## Plausibility
- The target assembly constructs the target position vector before the base position vector in `getTargetRot`; the source now reflects that natural local ordering without adding fake symbols, offsets, or compiler-only hacks.