### PR TITLE
Improve font string width shadow flag handling

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -150,23 +150,22 @@ found_glyph:
 		}
 
 use_glyph:
-		unsigned char flags = renderFlags;
+		CFontRenderFlagBits& renderFlagBits = GetRenderFlagBits(renderFlags);
 		int drawWidth;
 		float localMargin = margin;
 		float localScaleX = scaleX;
 
-		if (GetRenderFlagBits(renderFlags).fixedWidth != 0) {
+		if (renderFlagBits.fixedWidth != 0) {
 			drawWidth = static_cast<int>(m_glyphWidth);
 		} else {
-			signed char sign = static_cast<signed char>(flags);
-			sign >>= 7;
+			signed char sign = static_cast<signed char>(renderFlagBits.shadow);
 			drawWidth = static_cast<int>(
 			    *(reinterpret_cast<unsigned char*>(glyph) +
 			      ((static_cast<unsigned int>(-static_cast<int>(sign) | static_cast<int>(sign)) >> 30 & 2) + 4)));
 		}
 
 		charWidth = localScaleX * (localMargin + static_cast<float>(drawWidth));
-		if (GetRenderFlagBits(renderFlags).snapPosition != 0) {
+		if (renderFlagBits.snapPosition != 0) {
 			charWidth = static_cast<float>(floor(charWidth));
 		}
 		goto add_width;


### PR DESCRIPTION
## Summary
- Update `CFont::GetWidth(char*)` to read render flag bits through `CFontRenderFlagBits`, matching the other font width/draw paths.
- Use the shadow bitfield directly instead of deriving shadow state from the raw sign bit of `renderFlags`.

## Evidence
- `ninja` passes.
- `main/fontman` objdiff for `GetWidth__5CFontFPc`: 92.90099% -> 93.544556%.
- Nearby selected fontman symbols are unchanged: `GetWidth__5CFontFUs` 96.75%, `Draw__5CFontFUs` 92.10294%, `SetColor__5CFontF8_GXColor` 89.4%.

## Plausibility
This makes the string width path consistent with `GetWidth(unsigned short)` and `Draw(unsigned short)`, which already access `renderFlags` through the bitfield helper. It removes a raw-byte sign-bit interpretation that did not match the surrounding source model.