### PR TITLE
Match CChara node constructor

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -3,6 +3,7 @@
 
 #include "ffcc/memory.h"
 #include "ffcc/ref.h"
+#include "ffcc/vector.h"
 
 #include <dolphin/mtx.h>
 
@@ -91,7 +92,9 @@ public:
 		Mtx m_localRuntimeMtx;
 		u8 _pad44[0x28];
 		Mtx m_mtx;
-		u8 _pad9C[0x20];
+		u8 _pad9C[0x8];
+		CVector m_dynPosition;
+		CVector m_dynVel;
 		u8 m_flags;
 		u8 _padBD[3];
 	};

--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -2424,18 +2424,17 @@ int CChara::CModel::GetDispIndex(CChara::CNode* node)
  */
 CChara::CNode::CNode()
 {
-	new (reinterpret_cast<void*>((u8*)this + 0xA4)) CVector;
-	new (reinterpret_cast<void*>((u8*)this + 0xB0)) CVector;
+	struct Flags {
+		u8 active : 1;
+		u8 _pad : 7;
+	};
+	int active = 1;
+
 	*(u32*)((u8*)this + 0x0) = 0;
 	*(u32*)((u8*)this + 0x4) = 0;
 	*(u32*)((u8*)this + 0x9C) = 0;
 	*(u32*)((u8*)this + 0xA0) = 0;
-	static const u8 clearMask = 0x7F;
-	static const u8 setMask = 0x80;
-	u8 flags = *(u8*)((u8*)this + 0xBC);
-	flags &= clearMask;
-	flags |= setMask;
-	*(u8*)((u8*)this + 0xBC) = flags;
+	reinterpret_cast<Flags*>(&m_flags)->active = active;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Recover the embedded CVector fields in CChara::CNode at offsets 0xA4 and 0xB0 instead of treating them as padding.
- Let the CNode constructor emit normal member construction and use a bitfield write for m_flags so Metrowerks generates the original rlwimi pattern.

## Objdiff Evidence
- main/chara: __ct__Q26CChara5CNodeFv improved from 71.875% to 100.0% (96 bytes).
- main/chara .text improved from 50.51857% to 50.65051% in direct objdiff output.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara -o /tmp/chara_CNode_ctor_diff.json __ct__Q26CChara5CNodeFv

## Plausibility
- Ghidra names the two constructed members m_dynPosition and m_dynVel, both CVector-sized and located exactly in the recovered padding.
- The flag update is expressed as a normal bitfield assignment rather than hard-coded assembly or address coercion.