### PR TITLE
Improve prgobj getTargetRot diff

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -284,8 +284,8 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float targetRot;
 	float deltaX;
 	float deltaZ;
-	CVector basePos(m_worldPosition);
 	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));


### PR DESCRIPTION
## Summary
- Reorder local CVector construction in CGPrgObj::getTargetRot to better match the target constructor sequence.
- Keeps behavior unchanged while improving objdiff for main/prgobj.

## Evidence
- ninja: build/GCCP01/main.dol OK
- main/prgobj unit fuzzy match: 97.86584% -> 98.10927%
- getTargetRot__8CGPrgObjFP8CGPrgObj: 86.416664% -> 91.30556%
- objdiff command run: build/tools/objdiff-cli diff -p . -u main/prgobj -o - getTargetRot__8CGPrgObjFP8CGPrgObj

## Plausibility
- The target Ghidra output constructs the target position CVector before the base position CVector in getTargetRot. This source order now reflects that without introducing casts, fake symbols, or ABI hacks.