### PR TITLE
Improve CGPrgObj target rotation diff

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -284,8 +284,8 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float targetRot;
 	float deltaX;
 	float deltaZ;
-	CVector basePos(m_worldPosition);
 	CVector targetPos(target->m_worldPosition);
+	CVector basePos(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));


### PR DESCRIPTION
## Summary
- Reorder the local CVector construction in CGPrgObj::getTargetRot to better match the target stack/setup order.
- Keeps behavior unchanged: the subtraction still uses base position minus target position.

## Objdiff Evidence
- main/prgobj getTargetRot__8CGPrgObjFP8CGPrgObj: 86.138885% -> 91.02778%
- Current size: 140 bytes
- rotTarget__8CGPrgObjFP8CGPrgObj remains 86.23077%
- dstTargetRot__8CGPrgObjFP8CGPrgObj remains 87.795456%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/prgobj -o /tmp/prgobj_getTargetRot_diff_result.json --format json getTargetRot__8CGPrgObjFP8CGPrgObj

## Plausibility
- This is a source-level local declaration order change, not a forced section/address/register hack.
- The resulting order is consistent with the target constructor call sequence while preserving the same vector math.