### PR TITLE
Match PPPCREATEPARAM constructor

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -62,6 +62,8 @@ struct pppModelSt : public CMapMesh
 
 struct PPPCREATEPARAM
 {
+    PPPCREATEPARAM();
+
     Vec* m_positionOffsetPtr;         // 0x0
     Vec* m_rotationPtr;               // 0x4
     Vec* m_scalePtr;                  // 0x8

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1143,7 +1143,7 @@ extern "C" char* GetNumSysMes__5CGameFv(void* game, int index)
 
 /*
  * --INFO--
- * PAL Address: 0x800B9538
+ * PAL Address: 0x800B9528
  * PAL Size: 16b
  * EN Address: TODO
  * EN Size: TODO
@@ -1157,38 +1157,38 @@ CMesMenu* CMenuPcs::GetMesMenu(int index)
 
 /*
  * --INFO--
- * PAL Address: 0x800B9548
+ * PAL Address: 0x800B9538
  * PAL Size: 116b
  * EN Address: TODO
  * EN Size: TODO
  * JP Address: TODO
  * JP Size: TODO
  */
-static void InitCreateParam(PPPCREATEPARAM* createParam)
+PPPCREATEPARAM::PPPCREATEPARAM()
 {
-    createParam->m_soundEffectParams.m_soundEffectHandle = -1;
-    createParam->m_soundEffectParams.m_soundEffectSlot = -1;
-    createParam->m_soundEffectParams.m_soundEffectStopFlag = 0;
-    createParam->m_soundEffectParams.m_soundEffectKind = 1;
-    createParam->m_soundEffectParams.m_soundEffectStartFrame = 0;
-    createParam->m_soundEffectParams.m_soundEffectStartedOnce = 0;
-    createParam->m_soundEffectParams.m_soundEffectFadeFrames = 30;
-    createParam->m_hitParamA = 0;
-    createParam->m_hitParamB = 0;
-    createParam->m_hitObjectCount = 0;
-    createParam->m_hitFlags = 0;
-    createParam->m_positionOffsetPtr = 0;
-    createParam->m_rotationPtr = 0;
-    createParam->m_scalePtr = 0;
-    createParam->m_extraPositionPtr = 0;
-    createParam->m_paramA = 0;
-    createParam->m_paramB = 0;
-    createParam->m_lookTargetPtr = 0;
-    createParam->m_objectHitMask = 0;
-    createParam->m_cylinderAttribute = 0;
-    createParam->m_paramC = 1.0f;
-    createParam->m_paramD = 1.0f;
-    *reinterpret_cast<unsigned char*>(&createParam->m_owner) = 0;
+    m_soundEffectParams.m_soundEffectHandle = -1;
+    m_soundEffectParams.m_soundEffectSlot = -1;
+    m_soundEffectParams.m_soundEffectStopFlag = 0;
+    m_soundEffectParams.m_soundEffectKind = 1;
+    m_soundEffectParams.m_soundEffectStartFrame = 0;
+    m_soundEffectParams.m_soundEffectStartedOnce = 0;
+    m_soundEffectParams.m_soundEffectFadeFrames = 30;
+    m_hitParamA = 0;
+    m_hitParamB = 0;
+    m_hitObjectCount = 0;
+    m_hitFlags = 0;
+    m_positionOffsetPtr = 0;
+    m_rotationPtr = 0;
+    m_scalePtr = 0;
+    m_extraPositionPtr = 0;
+    m_paramA = 0;
+    m_paramB = 0;
+    m_lookTargetPtr = 0;
+    m_objectHitMask = 0;
+    m_cylinderAttribute = 0;
+    m_paramC = 1.0f;
+    m_paramD = 1.0f;
+    *reinterpret_cast<unsigned char*>(&m_owner) = 0;
 }
 
 /*
@@ -2413,7 +2413,6 @@ void CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemF
         return;
     case -0xBB: {
         PPPCREATEPARAM createParam;
-        InitCreateParam(&createParam);
         PartMng.pppCreate(0, *object->m_localBase, &createParam, 1);
         runtime->push(object, 0);
         outResult = 0;


### PR DESCRIPTION
## Summary
- Declares and defines `PPPCREATEPARAM::PPPCREATEPARAM()` instead of keeping the initializer as a private helper.
- Lets the `CFlatRuntime2::onSystemFunc` stack local use the real constructor automatically.
- Corrects the nearby `GetMesMenu`/constructor version header addresses.

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- Overall progress improved from 591064 to 591180 matched code bytes and from 3454 to 3455 matched functions.
- `main/cflat_r2system` now reports `__ct__14PPPCREATEPARAMFv` as matched: 116 bytes, 100.0% in `build/GCCP01/report.json`.

## Plausibility
- The initializer body was already present and matches the shipped constructor layout; this change gives it the correct C++ linkage and uses normal automatic construction instead of a manual helper call.