### PR TITLE
Improve FunnyShape animation frame modulo

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -676,7 +676,8 @@ void CFunnyShape::InitAnmWork()
 
         r = rand();
         const s16 shapeCount = *reinterpret_cast<s16*>(reinterpret_cast<u8*>(AnimData(this)) + 6);
-        work->frame = static_cast<s16>(r - (r / shapeCount) * shapeCount);
+        const s32 shapeDiv = r / shapeCount;
+        work->frame = static_cast<s16>(r - shapeDiv * shapeCount);
         work->delay = 0x200;
         work->viewportY = zero;
         work->viewportX = zero;


### PR DESCRIPTION
## Summary
- Split the random frame modulo in CFunnyShape::InitAnmWork into an explicit quotient local.
- This matches the target multiply operand order for the shape frame calculation and improves objdiff without changing behavior.

## Evidence
- Before: build report showed 591064 matched code bytes and 3454 matched functions; InitAnmWork__11CFunnyShapeFv was 99.72%.
- After: ninja reports 591564 matched code bytes and 3455 matched functions.
- After: build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - reports InitAnmWork__11CFunnyShapeFv at 99.8%.

## Plausibility
- The change keeps the same modulo calculation but names the quotient, which is a normal source expression and matches the target codegen order for quotient * shapeCount.