### PR TITLE
Match map texture animation cleanup deletes

### DIFF
--- a/include/ffcc/map.h
+++ b/include/ffcc/map.h
@@ -36,19 +36,19 @@ public:
     ~CMapKeyFrame()
     {
         if (m_junTable != 0) {
-            delete[] m_junTable;
+            delete m_junTable;
             m_junTable = 0;
         }
         if (m_keyFrame != 0) {
-            delete[] m_keyFrame;
+            delete m_keyFrame;
             m_keyFrame = 0;
         }
         if (m_keyValue != 0) {
-            delete[] m_keyValue;
+            delete m_keyValue;
             m_keyValue = 0;
         }
         if (m_splineTable != 0) {
-            delete[] m_splineTable;
+            delete m_splineTable;
             m_splineTable = 0;
         }
     }

--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -314,6 +314,6 @@ void CMapTexAnimSet::Create(CChunkFile& chunkFile, CMaterialSet* materialSet, CT
  */
 CMapTexAnim::~CMapTexAnim()
 {
-    delete[] m_frameTable;
+    delete m_frameTable;
     m_frameTable = 0;
 }


### PR DESCRIPTION
## Summary
- Change CMapKeyFrame cleanup deletes to scalar delete, matching generated target calls.
- Change CMapTexAnim::m_frameTable cleanup to scalar delete.

## Evidence
- Full `ninja` passes; `build/GCCP01/main.dol: OK`.
- `main/maptexanim` .text improves from 99.88984% to 99.925606%.
- `__dt__11CMapTexAnimFv` improves from 99.545456% to 100.0%.
- Checked `main/map` and `main/mapobj` .text before/after; both unchanged.

## Plausibility
The target destructor uses scalar `__dl__` calls for these owned buffers rather than array `__dla__` calls, so this aligns the source with observed codegen without adding manual RTTI, vtables, sections, or address hacks.