### PR TITLE
Recover CSound member layout

### DIFF
--- a/include/ffcc/RedSound/RedSound.h
+++ b/include/ffcc/RedSound/RedSound.h
@@ -138,6 +138,9 @@ public:
 	void SetWaveAdsr(int attack, RedAdsrDATA* adsr);
 
 	void TestProcess(int mode);
+
+private:
+	unsigned int m_storage;
 };
 
 #endif // _FFCC_REDSOUND_REDSOUND_H

--- a/include/ffcc/sound.h
+++ b/include/ffcc/sound.h
@@ -3,9 +3,32 @@
 
 #include "ffcc/file.h"
 #include "ffcc/manager.h"
+#include "ffcc/memory.h"
+#include "ffcc/RedSound/RedSound.h"
+#include <dolphin/mtx.h>
 
 struct _pppMngSt;
-struct Vec;
+
+struct CLineSegment {
+    Vec delta;
+    Vec normal;
+    float length;
+    float startLength;
+};
+
+template <int PointCount>
+struct CLine {
+    CLine();
+
+    Vec min;
+    Vec max;
+    unsigned int pointCount;
+    unsigned int unused;
+    float unk20[4];
+    Vec points[PointCount];
+    CLineSegment segments[PointCount - 1];
+    float totalLength;
+};
 
 class CSound : public CManager
 {
@@ -77,7 +100,35 @@ public:
     void WaitASync();
 
 private:
-    unsigned char m_storage[0x22D4];
+    CMemory::CStage* m_stage;
+    CRedSound m_redSound;
+    unsigned char* m_aramBuffer;
+    CFile::CHandle* m_waveFile;
+    int m_waveRemain;
+    int m_waveOffset;
+    int m_waveID;
+    int m_waveState;
+    int m_waveSyncMode;
+    int m_seCount;
+    unsigned char m_seWork[0x1400];
+    CLine<10> m_lines[8];
+    unsigned char* m_streamBuffer;
+    CFile::CHandle* m_streamFile;
+    int m_streamOffset;
+    int m_streamID;
+    unsigned int m_streamHalf;
+    int m_streamPlaying;
+    int m_streamRemain;
+    int m_streamState;
+    int m_streamWaveID;
+    int m_bgmMasterVolume;
+    int m_seMasterVolume;
+    int m_curMusicVolume;
+    int m_seMaxVolume;
+    short m_noFreeSeGroups[4];
+    short m_noFreeWaves[4];
+    int m_pauseAllSe;
+    int m_debugPrint;
 };
 
 extern CSound Sound;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -82,27 +82,6 @@ inline void* operator new(unsigned long, void* ptr)
     return ptr;
 }
 
-struct CLineSegment {
-    Vec delta;
-    Vec normal;
-    float length;
-    float startLength;
-};
-
-template <int PointCount>
-struct CLine {
-    CLine();
-
-    Vec min;
-    Vec max;
-    u32 pointCount;
-    u32 unused;
-    float unk20[4];
-    Vec points[PointCount];
-    CLineSegment segments[PointCount - 1];
-    float totalLength;
-};
-
 class CSound::CSe3D {
 public:
     union {
@@ -362,12 +341,6 @@ extern "C" void CalcBound__9CLine2(CLine<10>* line)
  */
 inline CSound::CSound()
 {
-    unsigned char* sound = reinterpret_cast<unsigned char*>(this);
-
-    __ct__9CRedSoundFv(sound + 8);
-    for (int i = 0; i < 8; i++) {
-        new (&SoundData(this).m_lines[i]) CLine<10>;
-    }
 }
 
 /*
@@ -377,7 +350,6 @@ inline CSound::CSound()
  */
 CSound::~CSound()
 {
-    RedSound(this)->~CRedSound();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replaces CSound raw backing storage with recovered member fields for the sound manager layout.
- Adds the missing CRedSound storage word so CSound member offsets line up with the original object.
- Lets the compiler generate CSound construction/destruction for CRedSound and CLine<10>[8] instead of manually calling them.

## Evidence
- Before: __sinit_sound_cpp 59.393940% match.
- After: __sinit_sound_cpp 100.000000% match.
- __dt__6CSoundFv remains 100.000000% after removing the now-redundant manual RedSound destructor call.
- Full ninja build passes; build/GCCP01/main.dol: OK.

## Plausibility
- The target sinit uses compiler-generated member construction for CRedSound and the CLine array. Exposing the recovered CSound layout is closer to plausible source than raw storage plus manual placement-new loops.