### PR TITLE
Improve pppPart, util, and memorycard matches

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -2201,10 +2201,10 @@ void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)
                 totalHpBonus += *(unsigned short*)(itemData + equippedItems[3] * 0x48 + 6);
             }
 
-            short finalHpMax = 0x10;
+            int finalHpMax = 0x10;
             if (totalHpBonus + 8 < 0x10)
             {
-                finalHpMax = static_cast<short>(totalHpBonus + 8);
+                finalHpMax = totalHpBonus + 8;
             }
 
             *reinterpret_cast<short*>(charData + 0x06) = finalHpMax;

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -2088,23 +2088,23 @@ void pppCalcPartStd(_pppMngSt* pppMngSt)
 		if (pDataVal != 0 && pDataVal->m_programSetDef != 0)
 		{
 			_pppProgSetDef* progSet = pDataVal->m_programSetDef;
-			u16 activeCount = pDataVal->m_activeCount;
-			DAT_8032ed80 += activeCount;
+			DAT_8032ed80 += pDataVal->m_activeCount;
 
-			if (activeCount != 0)
+			if (pDataVal->m_activeCount != 0)
 			{
 				s32 workOffsetStep = 0;
-				_pppCtrlTable* stageIter = progSet->m_stages;
+				_pppProgSetDef* stageSet = progSet;
 
 				for (s32 stage = 0; stage < progSet->m_numStages; stage++)
 				{
+					_pppCtrlTable* stageIter = stageSet->m_stages;
 					pppProg* prog = stageIter->m_prog;
 					if (prog != 0)
 					{
 						pppProgOperationCallback fn = (pppProgOperationCallback)prog->m_pppFunctionOperation;
 						if (fn != 0)
 						{
-							u16 count = activeCount;
+							u16 count = pDataVal->m_activeCount;
 							_pppPObjLink* obj = pDataVal->m_pppPObjLink;
 
 							while (count != 0)
@@ -2126,7 +2126,7 @@ void pppCalcPartStd(_pppMngSt* pppMngSt)
 						printf(s_ERROR_prog_NULL);
 					}
 
-					stageIter++;
+					stageSet = (_pppProgSetDef*)(((u8*)stageSet) + sizeof(_pppCtrlTable));
 					workOffsetStep += 4;
 				}
 			}
@@ -2134,7 +2134,7 @@ void pppCalcPartStd(_pppMngSt* pppMngSt)
 		pDataValOffset += sizeof(_pppPDataVal);
 	}
 
-	if (pppMngSt->m_prioTime != 0xFFFF)
+	if (pppMngSt->m_prioTime < 0xFFFF)
 	{
 		pppMngSt->m_prioTime++;
 	}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -863,7 +863,8 @@ void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColo
     pos1.x = x2;
     pos1.y = y2;
     pos1.z = kUtilZero;
-    u32 colorValue = *reinterpret_cast<u32*>(&color);
+    GXColor quadColor = color;
+    u32 colorValue = *reinterpret_cast<u32*>(&quadColor);
     Vec v0 = pos1;
     Vec v1 = pos0;
 


### PR DESCRIPTION
## Summary
- improve `pppCalcPartStd__FP9_pppMngSt` by matching active-count reloads, stage iteration shape, and priority timer comparison
- improve `CUtil::RenderColorQuad` by using the same local color-copy pattern as neighboring quad render helpers
- improve `CMemoryCardMan::CalcSaveDatHpMax` by keeping the HP max temporary as an `int` until the final short store

## Evidence
- `ninja` passes
- `pppCalcPartStd__FP9_pppMngSt`: 77.210526% -> 88.42105%, size 296 -> 304 (target size 304)
- `RenderColorQuad__5CUtilFffff8_GXColor`: 98.297775% -> 99.04%, size 900 unchanged
- `CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`: 89.12346% -> 89.8642%, size 324 unchanged

## Plausibility
- changes are source-level type/control-flow shape adjustments, not address hacks or forced sections
- the color-copy change follows existing `RenderTextureQuad` source style
- the HP temporary naturally narrows at the final `short` store
