### PR TITLE
Improve CBound frustum matching

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -687,13 +687,14 @@ int CBound::CheckFrustum0(CBound& outBound)
 
     if ((s_f_vpos.x <= m_max.x) && (s_f_vpos.y <= m_max.y) && (s_f_vpos.z <= m_max.z) &&
         (s_f_vpos.x >= m_min.x) && (s_f_vpos.y >= m_min.y) && (s_f_vpos.z >= m_min.z)) {
+        int yIndex;
         for (int xIndex = 0; xIndex < 2; xIndex++) {
             if (xIndex == 0) {
                 vertex.x = m_min.x;
             } else {
                 vertex.x = m_max.x;
             }
-            for (int yIndex = 0; yIndex < 2; yIndex++) {
+            for (yIndex = 0; yIndex < 2; yIndex++) {
                 vertex.y = (yIndex == 0) ? m_min.y : m_max.y;
                 for (int zIndex = 0; zIndex < 2; zIndex++) {
                     vertex.z = (zIndex == 0) ? m_min.z : m_max.z;


### PR DESCRIPTION
## Summary
- Hoists the `yIndex` loop variable in `CBound::CheckFrustum0(CBound&)` to better match the original Metrowerks source shape.

## Objdiff evidence
- `CheckFrustum0__6CBoundFR6CBound`: 97.54613% -> 97.73063% match, same 1084 byte target size.
- `main/math` `.text`: 99.637405% -> 99.66126%.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/math -o - CheckFrustum0__6CBoundFR6CBound`
