### PR TITLE
Improve CBound frustum matching

### DIFF
--- a/src/math.cpp
+++ b/src/math.cpp
@@ -687,13 +687,14 @@ int CBound::CheckFrustum0(CBound& outBound)
 
     if ((s_f_vpos.x <= m_max.x) && (s_f_vpos.y <= m_max.y) && (s_f_vpos.z <= m_max.z) &&
         (s_f_vpos.x >= m_min.x) && (s_f_vpos.y >= m_min.y) && (s_f_vpos.z >= m_min.z)) {
+        int yIndex;
         for (int xIndex = 0; xIndex < 2; xIndex++) {
             if (xIndex == 0) {
                 vertex.x = m_min.x;
             } else {
                 vertex.x = m_max.x;
             }
-            for (int yIndex = 0; yIndex < 2; yIndex++) {
+            for (yIndex = 0; yIndex < 2; yIndex++) {
                 vertex.y = (yIndex == 0) ? m_min.y : m_max.y;
                 for (int zIndex = 0; zIndex < 2; zIndex++) {
                     vertex.z = (zIndex == 0) ? m_min.z : m_max.z;


### PR DESCRIPTION
## Summary
- Adjust the y-index loop scope in CBound::CheckFrustum0(CBound&) to better match the original loop lifetime.
- Keeps the source behavior unchanged while improving the generated code for the inside-camera frustum path.

## Evidence
- ninja passes.
- objdiff main/math CheckFrustum0__6CBoundFR6CBound: 97.54613% -> 97.73063%, size unchanged at 1084 bytes.

## Plausibility
- The change only widens an existing loop counter lifetime to match the surrounding loop shape seen in the decompilation; it does not add fake control flow, hardcoded addresses, or compiler-only barriers.