### PR TITLE
Improve prgobj target rotation matches

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -19,9 +19,9 @@ static inline float LoadFloat(const float& value)
 	return value;
 }
 
-static inline Vec* AsVec(CVector& vec)
+static inline Vec* AsVec(const CVector& vec)
 {
-	return reinterpret_cast<Vec*>(&vec);
+	return reinterpret_cast<Vec*>(const_cast<CVector*>(&vec));
 }
 
 static inline CFlatRuntime2* GetCFlatRuntime2()
@@ -225,7 +225,7 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	float deltaX;
 	float deltaZ;
 	CVector targetPos(target->m_worldPosition);
-	CVector basePos(m_worldPosition);
+	const CVector& basePos = CVector(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));
@@ -256,7 +256,7 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 	float deltaX;
 	float deltaZ;
 	CVector targetPos(target->m_worldPosition);
-	CVector basePos(m_worldPosition);
+	const CVector& basePos = CVector(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));
@@ -285,7 +285,7 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	float deltaX;
 	float deltaZ;
 	CVector targetPos(target->m_worldPosition);
-	CVector basePos(m_worldPosition);
+	const CVector& basePos = CVector(m_worldPosition);
 	CVector deltaPos;
 
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));


### PR DESCRIPTION
## Summary
- Bind the base target-rotation vector as a temporary reference so MWCC preserves the constructor result in the same shape as the target.
- Applies to CGPrgObj::dstTargetRot, rotTarget, and getTargetRot.

## Objdiff Evidence
Before:
- dstTargetRot__8CGPrgObjFP8CGPrgObj: 87.795456%
- rotTarget__8CGPrgObjFP8CGPrgObj: 86.23077%
- getTargetRot__8CGPrgObjFP8CGPrgObj: 91.02778%
- prgobj .text: 98.04703%
- extab: 98.4375%, extabindex: 93.22917%

After:
- dstTargetRot__8CGPrgObjFP8CGPrgObj: 97.27273%
- rotTarget__8CGPrgObjFP8CGPrgObj: 96.92308%
- getTargetRot__8CGPrgObjFP8CGPrgObj: 96.611115%
- prgobj .text: 99.47856%
- extab: 100.0%, extabindex: 98.4375%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/prgobj -o - dstTargetRot__8CGPrgObjFP8CGPrgObj