### PR TITLE
Use raw storage for FunnyShapePcs

### DIFF
--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -1,3 +1,4 @@
+#define FFCC_DEFINE_FUNNYSHAPEPCS_STORAGE
 #include "ffcc/p_FunnyShape.h"
 #include "ffcc/FunnyShape.h"
 #include "ffcc/USBStreamData.h"
@@ -456,7 +457,7 @@ unsigned int lbl_801EA910[5] = {
     0,
 };
 u8 ARRAY_8026D728[0xC];
-CFunnyShapePcs FunnyShapePcs;
+u8 FunnyShapePcs[sizeof(CFunnyShapePcs)];
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Define `FFCC_DEFINE_FUNNYSHAPEPCS_STORAGE` in `p_FunnyShape.cpp`
- Store `FunnyShapePcs` as raw storage so the existing manual `__sinit_p_FunnyShape_cpp` is the only initializer emitted

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o -`
  - source `.text` size is now 2364 bytes, matching target
  - removed the extra source-only `__sinit_p_FunnyShape_cpp` (140 bytes at source offset 2364)
- `build/tools/objdiff-cli diff -p . -u main/p_FunnyShape -o - __sinit_p_FunnyShape_cpp`
  - `__sinit_p_FunnyShape_cpp`: 288 bytes, 99.861115% match

## Plausibility
`p_FunnyShape.cpp` already builds its process singleton through the explicit static initializer and the header already has a raw-storage mode for `FunnyShapePcs`; this prevents a duplicate compiler-generated initializer instead of adding new constructor/vtable machinery.