### PR TITLE
Improve pppYmDeformationScreen projection setup

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -163,9 +163,9 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 		GXSetCurrentMtx(0);
 
 		PSMTX44Identity(orthoMtx);
+		orthoMtx[2][2] = FLOAT_8033067C;
 		orthoMtx[0][0] = FLOAT_80330674;
 		orthoMtx[1][1] = FLOAT_80330678;
-		orthoMtx[2][2] = FLOAT_8033067C;
 		orthoMtx[0][3] = FLOAT_80330680;
 		orthoMtx[1][3] = FLOAT_8033067C;
 		orthoMtx[2][3] = FLOAT_80330670;


### PR DESCRIPTION
## Summary
- Reordered the orthographic projection matrix writes in pppRenderYmDeformationScreen to better match the original codegen.

## Evidence
- ninja passes.
- objdiff: main/pppYmDeformationScreen pppRenderYmDeformationScreen improved from 99.30174% to 99.33167%.
- Function size remains 1604 bytes; neighboring functions stay matched.

## Plausibility
- This is a source-shape-only adjustment in the projection setup block, with no hardcoded addresses or fake linkage.