### PR TITLE
Match JoyBus GBAReady

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -98,6 +98,8 @@ extern const unsigned short JoyBusCrcTable[256] =
     0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
 };
 
+extern "C" int __cntlzw(unsigned int);
+
 static const char s_dvd_gba_dir[] = "dvd/gba/";
 static const char s_ffcc_cli_bin[] = "ffcc_cli.bin";
 static const char s_objdat_spt[] = "objdat.spt";
@@ -5766,11 +5768,8 @@ int JoyBus::GBAReady(int portIndex)
     padType = m_threadParams[portIndex].m_padType;
     OSSignalSemaphore(&m_accessSemaphores[portIndex]);
 
-	// TODO: No idea
-    int ready = padType;
-
-    // TODO: IsSingleMode__8GbaQueueFi
-    bool isSingle = (bool)this;
+    int ready = static_cast<unsigned int>(__cntlzw(0x40000 - padType)) >> 5;
+    bool isSingle = GbaQue.IsSingleMode(portIndex);
 
     if (isSingle)
     {


### PR DESCRIPTION
## Summary
- Replace the placeholder JoyBus::GBAReady logic with the original pad-type readiness check.
- Use the existing __cntlzw idiom and GbaQue::IsSingleMode gate seen in the decompilation.

## Objdiff evidence
- main/joybus GBAReady__6JoyBusFi: 76.35135% -> 100.0%
- main/joybus .text: 35.33853% -> 35.40677%
- Overall matched code: 596248 -> 596396 bytes

## Plausibility
The previous source returned the raw pad type and used (bool)this as the single-mode flag. The new code matches the decompiled control flow: check for pad type 0x40000 via the project-standard __cntlzw expression, then suppress readiness while GbaQue reports single mode.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/joybus -o -