### PR TITLE
Improve mapocttree cylinder hit matching

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1747,7 +1747,7 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 
 	if (overlap) {
 		if ((node->m_meshCount != 0) &&
-			((*reinterpret_cast<CMapHit**>(Ptr(m_mapObject, 0xC)))
+			(static_cast<CMapHit*>(m_mapObject->m_mapData)
 				 ->CheckHitCylinder((CMapCylinder*)&s_cyl, &s_mvec,
 									node->m_meshStart,
 									node->m_meshCount,
@@ -1759,7 +1759,7 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 		for (int i = 0; i < 8; i++) {
 			COctNode* child = nodeIter->m_children[0];
 			if (child == 0) {
-				return 0;
+				break;
 			}
 
 			float childBoundMinX = child->m_boundMinX;
@@ -1811,7 +1811,7 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 			if (childOverlap) {
 				int childHit = false;
 				if ((child->m_meshCount != 0) &&
-					((*reinterpret_cast<CMapHit**>(Ptr(m_mapObject, 0xC)))
+					(static_cast<CMapHit*>(m_mapObject->m_mapData)
 						 ->CheckHitCylinder((CMapCylinder*)&s_cyl, &s_mvec,
 											child->m_meshStart,
 											child->m_meshCount,
@@ -1826,7 +1826,7 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 
 						if ((reinterpret_cast<CBound*>(grandChild)->CheckCross(*reinterpret_cast<CBound*>(&s_cyl.m_boundsMin))) != 0) {
 							if ((grandChild->m_meshCount != 0) &&
-								((*reinterpret_cast<CMapHit**>(Ptr(m_mapObject, 0xC)))
+								(static_cast<CMapHit*>(m_mapObject->m_mapData)
 									 ->CheckHitCylinder((CMapCylinder*)&s_cyl, &s_mvec,
 														grandChild->m_meshStart,
 														grandChild->m_meshCount,
@@ -1988,7 +1988,7 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 	}
 
 	if (octNode->m_meshCount != 0) {
-		(*reinterpret_cast<CMapHit**>(Ptr(m_mapObject, 0xC)))
+		static_cast<CMapHit*>(m_mapObject->m_mapData)
 		    ->CheckHitCylinderNear((CMapCylinder*)&s_cyl, &s_mvec,
 		                           octNode->m_meshStart,
 		                           octNode->m_meshCount,
@@ -2049,7 +2049,7 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 
 		if (childOverlap) {
 			if (child->m_meshCount != 0) {
-				(*reinterpret_cast<CMapHit**>(Ptr(m_mapObject, 0xC)))
+				static_cast<CMapHit*>(m_mapObject->m_mapData)
 				    ->CheckHitCylinderNear((CMapCylinder*)&s_cyl, &s_mvec,
 				                           child->m_meshStart,
 				                           child->m_meshCount,
@@ -2064,7 +2064,7 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 
 				if ((reinterpret_cast<CBound*>(grandChild)->CheckCross(*reinterpret_cast<CBound*>(&s_cyl.m_boundsMin))) != 0) {
 					if (grandChild->m_meshCount != 0) {
-						(*reinterpret_cast<CMapHit**>(Ptr(m_mapObject, 0xC)))
+						static_cast<CMapHit*>(m_mapObject->m_mapData)
 						    ->CheckHitCylinderNear((CMapCylinder*)&s_cyl, &s_mvec,
 						                           grandChild->m_meshStart,
 						                           grandChild->m_meshCount,


### PR DESCRIPTION
## Summary
- Use typed CMapObj::m_mapData access for recursive octtree cylinder hit checks instead of raw offset loads.
- Reshape the null child path in COctTree::CheckHitCylinder_r to fall through to the common zero-return path.

## Objdiff evidence
- main/mapocttree .text: 97.74225% -> 97.81426%
- CheckHitCylinder_r__8COctTreeFP8COctNode: 93.41833% -> 94.251%
- CheckHitCylinderNear_r__8COctTreeFP8COctNode: unchanged at 96.27232%
- InsertShadow_r__FP8COctNode: unchanged at 95.97959%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/mapocttree -o - CheckHitCylinder_r__8COctTreeFP8COctNode

## Plausibility
The typed map data access matches the declared CMapObj layout already used elsewhere in this file. The control-flow change avoids an early local return and matches the target's shared zero-return branch shape without introducing address hacks or fake symbols.