### PR TITLE
Match CGPartyObj onDestroy flag access

### DIFF
--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -88,7 +88,7 @@ struct PartyObjFlags {
 	unsigned char flag20 : 1;
 	unsigned char flag10 : 1;
 	unsigned char flag08 : 1;
-	unsigned char flag04 : 1;
+	signed char flag04 : 1;
 	unsigned char flag02 : 1;
 	unsigned char flag01 : 1;
 };
@@ -326,10 +326,10 @@ void CGPartyObj::onCreate()
  */
 void CGPartyObj::onDestroy()
 {
-	unsigned char* self = reinterpret_cast<unsigned char*>(this);
-	if ((int)(((unsigned int)self[0x6B8] << 0x1D) | ((unsigned int)self[0x6B8] >> 3)) < 0) {
+	PartyObjOverlay& party = PartyData(this);
+	if (party.flags.flag04) {
 		addHp(*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(m_scriptHandle) + 0x1A), static_cast<CGPrgObj*>(0));
-		self[0x6B8] = self[0x6B8] & 0xFB;
+		party.flags.flag04 = 0;
 	}
 
 	CGCharaObj::onDestroy();


### PR DESCRIPTION
## Summary
- Use the existing PartyObjOverlay bitfield for the 0x6B8 flag in CGPartyObj::onDestroy.
- Make flag04 a signed one-bit field so the generated sign test matches the original code.
- Clear the bit through the structured field instead of raw byte masking.

## Evidence
- Before: onDestroy__10CGPartyObjFv was 86.2% matched.
- After: build/tools/objdiff-cli diff -p . -u main/partyobj -o - onDestroy__10CGPartyObjFv reports 100.0% matched, size 100b.
- Full ninja passes; build/GCCP01/main.dol: OK.

## Plausibility
- This replaces a decompiler-style rotate/sign-byte check with the existing overlay field access, preserving the same bit and making the code look like plausible original source.