### PR TITLE
Improve pppYmBreath group cursor loops

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -411,7 +411,7 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
 
     if ((*reinterpret_cast<unsigned int*>(CFlat + 0x129C) & 0x200000) != 0) {
         YmBreathParticleGroup* debugGroupData = groupData;
-        for (i = 0; i < (int)params->m_groupCount; i++) {
+        for (i = 0; i < (int)params->m_groupCount; i++, debugGroupData++) {
             if (debugGroupData->active == 1) {
                 int firstParticle;
                 int j;
@@ -472,7 +472,6 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
                 sphereMtx[2][3] = debugPos.z;
                 Graphic.DrawSphere(sphereMtx, debugColor);
             }
-            debugGroupData++;
         }
 
         pppSetBlendMode(1);
@@ -694,7 +693,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                 groupCursor = vYmBreath->m_groups;
                 foundGroup = -1;
                 foundSlot = -1;
-                for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
+                for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++, groupCursor++) {
                     for (slotIndex = 0; slotIndex < (int)params->m_slotCount; slotIndex++) {
                         signed char* particleIndices = groupCursor->particleIndices;
                         if ((short)i == *(signed char*)(particleIndices + (short)slotIndex)) {
@@ -704,7 +703,6 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
                             goto found_index;
                         }
                     }
-                    groupCursor++;
                 }
                 found = false;
 


### PR DESCRIPTION
## Summary
- Move two pppYmBreath group cursor increments into their for-loop increment clauses.
- Improves loop scheduling for the render debug group walk and UpdateAllParticle group search without changing behavior.

## Objdiff
Unit: main/pppYmBreath
- .text: 99.35087% -> 99.36076%
- pppRenderYmBreath: 98.80805% -> 98.83282% (1292/1292 bytes)
- UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor: 99.160446% -> 99.1903% (1072/1072 bytes)
- pppFrameYmBreath unchanged: 99.129745% (1264/1264 bytes)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -