### PR TITLE
Match CMapCylinder bounds init order

### DIFF
--- a/include/ffcc/maphit.h
+++ b/include/ffcc/maphit.h
@@ -18,8 +18,8 @@ class CMapCylinder
 public:
     CMapCylinder()
     {
-        float max = FLOAT_8032F8F0;
         float min = FLOAT_8032F8EC;
+        float max = FLOAT_8032F8F0;
 
         m_boundsMin.z = min;
         m_boundsMin.y = min;


### PR DESCRIPTION
## Summary
- Reorders CMapCylinder constructor locals so the min bound value is established before max, matching the bounds assignment order.
- Improves main/maphit code matching through the shared constructor in CMapHit collision code.

## Evidence
- ninja: passes, build/GCCP01/main.dol OK
- main/maphit .text: 74.32788% -> 74.33701%
- CheckHitFaceCylinder__7CMapHitFUl: 29.90087% -> 29.970434%
- __sinit_maphit_cpp: 97.1579% -> 96.31579% due f0/f1 allocation only; value order remains min bounds then max bounds

## Plausibility
- Source now declares the min bound local before max, matching the constructor's initialization flow for m_boundsMin before m_boundsMax.