### PR TITLE
Improve pppYmLaser render matrix setup

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -119,10 +119,6 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	Mtx debugMtx ATTRIBUTE_ALIGN(8);
 	Mtx pointMtx;
 	Mtx sphereMtx;
-	pppFMATRIX managerMtx;
-	pppFMATRIX localMtx;
-	pppFMATRIX cameraMtx;
-	pppFMATRIX modelMtx;
 	Vec shapePos;
 	Vec spherePos;
 	Vec debugSource;
@@ -159,12 +155,8 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	negHalfWidth = -halfWidth;
 
 	pppUnitMatrix(unitMtx);
-	localMtx = laser->m_localMatrix;
-	managerMtx = pppMngStPtr->m_matrix;
-	pppMulMatrix(mtxOut, managerMtx, localMtx);
-	modelMtx = mtxOut;
-	cameraMtx = *(pppFMATRIX*)&ppvCameraMatrix;
-	pppMulMatrix(mtxOut, cameraMtx, modelMtx);
+	pppMulMatrix(mtxOut, pppMngStPtr->m_matrix, laser->m_localMatrix);
+	pppMulMatrix(mtxOut, *(pppFMATRIX*)&ppvCameraMatrix, mtxOut);
 	GXLoadPosMtxImm(mtxOut.value, 0);
 
 	GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT7, 4);


### PR DESCRIPTION
## Summary
- Simplify the pppRenderYmLaser matrix setup to pass the manager/local and camera/output matrices directly into pppMulMatrix.
- This matches the established pppLaser render pattern and removes extra recovered temporaries that were changing the generated code shape.

## Objdiff Evidence
- main/pppYmLaser .text: 88.854294% -> 98.30182%
- pppRenderYmLaser: 82.99734% -> 97.48271%
- pppRenderYmLaser current size: 3232b -> 3008b, matching target size
- extabindex: 97.5% -> 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o -