### PR TITLE
Define p_sample rodata strings

### DIFF
--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -1,6 +1,8 @@
 #include "ffcc/p_sample.h"
 
-extern const char s_CSamplePcs_801D6CC8[];
+extern const char s_CSamplePcs_801D6CC8[] = "CSamplePcs";
+extern const char s_CManager_801D6CD4[] = "CManager";
+extern const char s_CProcess_801D6CE0[] = "CProcess";
 extern "C" void create__10CSamplePcsFv(CSamplePcs*);
 extern "C" void destroy__10CSamplePcsFv(CSamplePcs*);
 extern "C" void func0__10CSamplePcsFv(CSamplePcs*);


### PR DESCRIPTION
## Summary
- define the three p_sample rodata strings with their shipped symbol names
- preserves existing matched code while making the rodata symbols resolve directly in objdiff

## Evidence
- Before: s_CSamplePcs_801D6CC8, s_CManager_801D6CD4, and s_CProcess_801D6CE0 appeared as unmatched symbols in main/p_sample objdiff.
- After: all three symbols are 100% matched in main/p_sample objdiff.
- ninja passes.