### PR TITLE
Improve pppInitPdt reconstruction

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -1883,13 +1883,13 @@ DataValsAllocated:
  */
 void pppInitPdt(long* progOffsetReconstructionTable, pppProg* pppProg)
 {
+	int* table = (int*)(progOffsetReconstructionTable + 6);
 	int pppProgRelocCount = *(int*)((int)progOffsetReconstructionTable + progOffsetReconstructionTable[2]);
 	int pdtRelocCount = *(int*)((int)progOffsetReconstructionTable + progOffsetReconstructionTable[3]);
 	int* pppProgRelocs = (int*)((int)progOffsetReconstructionTable + progOffsetReconstructionTable[2]) + 1;
 	int* pdtRelocs = (int*)((int)progOffsetReconstructionTable + progOffsetReconstructionTable[3]) + 1;
-	int* table = (int*)(progOffsetReconstructionTable + 6);
 
-	if (progOffsetReconstructionTable[6] == 0) {
+	if (table[0] == 0) {
 		return;
 	}
 
@@ -1911,7 +1911,7 @@ void pppInitPdt(long* progOffsetReconstructionTable, pppProg* pppProg)
 	} while (*(int*)*head != 0);
 
 	int processed = 0;
-	*entry = 0;
+	*head = 0;
 	if (pppProgRelocCount > 0) {
 		if (pppProgRelocCount > 8) {
 			unsigned int blocks = (unsigned int)(pppProgRelocCount - 1) >> 3;


### PR DESCRIPTION
Summary:
- Reorders the local table setup in pppInitPdt to match the target data flow.
- Nulls the final converted program-set link through the current head pointer instead of writing through the sentinel entry.

Evidence:
- ninja passes for GCCP01.
- objdiff pppInitPdt__FPlP7pppProg improved from 71.78808% to 72.29801%.
- Current function size remains 600 bytes vs target 604 bytes.

Plausibility:
- The final link write now matches the Ghidra/target shape: after walking the linked program-set offsets, the last reconstructed next pointer is set to null.
- The table pointer is materialized before relocation-count setup, matching the target's early base+0x18 data flow without adding compiler-coaxing hacks.