### PR TITLE
Improve CCharaPcs viewer calc matching

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -175,6 +175,14 @@ public:
 		void (*m_drawMeshDLCallback)(CChara::CModel*, void*, void*, int, int, float (*)[4]);
 		u8 _pad100[4];
 		void (*m_afterDrawMeshCallback)(CChara::CModel*, void*, void*, int, float (*)[4]);
+		void (*m_afterDrawModelCallback)(CChara::CModel*, void*, void*);
+		u8 m_flags10C;
+		u8 _pad10D[3];
+		float m_furStep;
+		float m_furLenScale;
+		float m_furTarget;
+		float m_furCur;
+		float m_twistAngle;
 	};
 
 	class CMesh : public CRef

--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -426,13 +426,28 @@ void CCharaPcs::calcViewer()
             self->m_viewerAnimLoopIndex = 0;
             self->m_viewerAnimLoadedCount = 0;
 
-            if (self->m_viewerLoadAnim == 0) {
+            if (self->m_viewerLoadAnim != 0) {
+                System.Printf(const_cast<char*>(s_calc_viewer_fmt), self->m_viewerAnimPath);
+                fileHandle = File.Open(self->m_viewerAnimPath, 0, CFile::PRI_LOW);
+                if (fileHandle != 0) {
+                    File.Read(fileHandle);
+                    File.SyncCompleted(fileHandle);
+                    CChara::CAnim* anim =
+                        new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_viewer_cpp), 0x111) CChara::CAnim;
+                    self->m_viewerAnim[0] = anim;
+                    Create__Q26CChara5CAnimFPvPQ27CMemory6CStage(
+                        self->m_viewerAnim[0], File.m_readBuffer, self->m_viewerAnimStage);
+                    File.Close(fileHandle);
+                }
+                self->m_viewerLoadAnim = 0;
+            } else {
                 for (i = 0; i < static_cast<unsigned int>(self->m_viewerAnimRequestedCount); i++) {
                     unsigned int idx = static_cast<unsigned int>(self->m_viewerAnimLoadedCount);
                     sprintf(pathBuf, s_anim_path_fmt, self->m_viewerAnimPath, idx);
                     System.Printf(const_cast<char*>(s_calc_viewer_fmt), pathBuf);
                     fileHandle = File.Open(pathBuf, 0, CFile::PRI_LOW);
                     if (fileHandle != 0) {
+                        ReleaseShared(self->m_viewerAnimBank[idx]);
                         File.Read(fileHandle);
                         File.SyncCompleted(fileHandle);
                         CChara::CAnim* anim =
@@ -449,20 +464,6 @@ void CCharaPcs::calcViewer()
                     }
                 }
                 self->m_viewerLoadAnimContinuous = 0;
-            } else {
-                System.Printf(const_cast<char*>(s_calc_viewer_fmt), self->m_viewerAnimPath);
-                fileHandle = File.Open(self->m_viewerAnimPath, 0, CFile::PRI_LOW);
-                if (fileHandle != 0) {
-                    File.Read(fileHandle);
-                    File.SyncCompleted(fileHandle);
-                    CChara::CAnim* anim =
-                        new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_viewer_cpp), 0x111) CChara::CAnim;
-                    self->m_viewerAnim[0] = anim;
-                    Create__Q26CChara5CAnimFPvPQ27CMemory6CStage(
-                        self->m_viewerAnim[0], File.m_readBuffer, self->m_viewerAnimStage);
-                    File.Close(fileHandle);
-                }
-                self->m_viewerLoadAnim = 0;
             }
         }
 
@@ -545,17 +546,7 @@ void CCharaPcs::calcViewer()
     }
 
     float frameAdvance;
-    if (self->m_viewerStepMode == 0) {
-        float deltaY = kCharaViewerUnitStep;
-        if ((heldButtons & 0x200) != 0) {
-            deltaY = kCharaViewerFineStep;
-        }
-        float speedScale = kCharaViewerUnitStep;
-        if ((heldButtons & 0x100) != 0) {
-            speedScale = kCharaViewerLerpScale;
-        }
-        frameAdvance = deltaY * speedScale;
-    } else {
+    if (self->m_viewerStepMode != 0) {
         float offsetA = kCharaViewerZero;
         if ((triggerButtons & 0x100) != 0) {
             offsetA = kCharaViewerUnitStep;
@@ -565,6 +556,16 @@ void CCharaPcs::calcViewer()
             offsetB = kCharaViewerFineStep;
         }
         frameAdvance = kCharaViewerZero + offsetA + offsetB;
+    } else {
+        float deltaY = kCharaViewerUnitStep;
+        if ((heldButtons & 0x200) != 0) {
+            deltaY = kCharaViewerFineStep;
+        }
+        float speedScale = kCharaViewerUnitStep;
+        if ((heldButtons & 0x100) != 0) {
+            speedScale = kCharaViewerLerpScale;
+        }
+        frameAdvance = deltaY * speedScale;
     }
 
     for (unsigned int i = 0; i < 2; i++) {


### PR DESCRIPTION
## Summary
- Reordered `CCharaPcs::calcViewer` animation-load and frame-advance branches to match the target source shape.
- Added the per-slot animation-bank release emitted by the target before continuous animation loads overwrite a bank entry.
- Filled in the known tail fields of `CChara::CModel`, bringing the header size in line with the constructor and model allocation sites.

## Objdiff Evidence
`main/p_chara_viewer`:
- `calcViewer__9CCharaPcsFv`: 77.28081% -> 86.03333%
- `drawViewer__9CCharaPcsFv`: unchanged at 95.65476%
- `createViewer__9CCharaPcsFv`: unchanged at 85.276054%

## Verification
- `ninja` passes
- `build/GCCP01/main.dol: OK`
- `git diff --check` passes

## Plausibility
The changes preserve behavior while matching target branch layout and cleanup structure. The `CModel` tail fields come from existing constructor/init/fur/callback accesses rather than output-forcing section or symbol hacks.
