### PR TITLE
Fix item memory capsule CCFS fields

### DIFF
--- a/include/ffcc/itemobj.h
+++ b/include/ffcc/itemobj.h
@@ -18,11 +18,11 @@ class CGItemObj : public CGPrgObj
 public:
 	struct CCFS
 	{
-		int m_arg0;
+		int m_memoryCapsuleNameIndex;
 		unsigned int m_modelId;
 		unsigned int m_modelParam;
-		int m_itemJumpCountdown;
-		char* m_memoryCapsuleName;
+		unsigned int m_pendingAnimFlags;
+		char* m_pendingAnimName;
 	};
 
 	void onCreate();

--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -871,9 +871,9 @@ CGPrgObj* CGItemObj::CreateFromScript(
 				System.Printf(const_cast<char*>(DAT_801dcf64));
 			}
 
-			*(int*)(itemSelf + 0x56C) = ccfs->m_itemJumpCountdown;
-			*(char**)(itemSelf + 0x570) = ccfs->m_memoryCapsuleName;
-			*(int*)(itemSelf + 0x574) = ccfs->m_arg0;
+			reinterpret_cast<CGItemObj*>(newItem)->m_pendingAnimFlags = ccfs->m_pendingAnimFlags;
+			reinterpret_cast<CGItemObj*>(newItem)->m_pendingAnimName = ccfs->m_pendingAnimName;
+			reinterpret_cast<CGItemObj*>(newItem)->m_memoryCapsuleNameIndex = ccfs->m_memoryCapsuleNameIndex;
 		}
 	}
 

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -3183,11 +3183,11 @@ void CGPartyObj::setAlive(int restoreDamageCol, int keepTarget)
 void CGPartyObj::PutMemoryCapsule(int arg0, int arg1, int arg2, int arg3, char* arg4)
 {
 	CGItemObj::CCFS ccfs;
-	ccfs.m_arg0 = arg0;
+	ccfs.m_memoryCapsuleNameIndex = arg0;
 	ccfs.m_modelId = arg1;
 	ccfs.m_modelParam = arg2;
-	ccfs.m_itemJumpCountdown = arg3;
-	ccfs.m_memoryCapsuleName = arg4;
+	ccfs.m_pendingAnimFlags = arg3;
+	ccfs.m_pendingAnimName = arg4;
 	CreateFromScript__9CGItemObjFiiiP8CGObjectfPQ29CGItemObj4CCFS(0, 2, 399, this, FLOAT_80331a78, &ccfs);
 }
 


### PR DESCRIPTION
## Summary
- Rename CGItemObj::CCFS fields to reflect the memory capsule payload layout
- Store CCFS pending animation flags/name and name index into the matching CGItemObj fields in CreateFromScript
- Update CGPartyObj::PutMemoryCapsule call-site field names

## Evidence
- ninja passes for GCCP01
- main/itemobj CreateFromScript__9CGItemObjFiiiP8CGObjectfPQ29CGItemObj4CCFS: 87.00% -> 87.01028%
- main/itemobj .text: 85.30214% -> 85.30342%
- ItemJump__9CGItemObjFif unchanged at 85.421684%
- onFrame__9CGItemObjFv unchanged at 85.439255%

## Plausibility
Ghidra and objdiff both show the CCFS memory capsule path writing the payload tail to item fields 0x574, 0x578, and 0x570. Those are already represented as pending animation flags, pending animation name, and memory capsule name index on CGItemObj, so this removes an incorrect 0x56C write and replaces raw offsets with the existing typed fields.