### PR TITLE
Match CCharaPcs table symbol

### DIFF
--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -53,7 +53,7 @@ extern "C" void LoadSe__6CSoundFPv(void*, void*);
 extern "C" void LoadWave__6CSoundFPv(void*, void*);
 extern "C" int GetBackBufferRect__8CGraphicFRiRiRiRii(CGraphic*, int&, int&, int&, int&, int);
 extern "C" unsigned char DbgMenuPcs[];
-extern unsigned char PTR_s_CCharaPcs_GAME__801fce10[];
+extern unsigned char PTR_s_CCharaPcs_GAME_[];
 
 inline void* operator new(unsigned long, void* ptr)
 {
@@ -812,7 +812,7 @@ void CCharaPcs::Quit()
  */
 int CCharaPcs::GetTable(unsigned long index)
 {
-    unsigned char* table = PTR_s_CCharaPcs_GAME__801fce10;
+    unsigned char* table = PTR_s_CCharaPcs_GAME_;
     unsigned long offset = index * 0x15c;
     return (int)(table + offset);
 }


### PR DESCRIPTION
## Summary
- Rename the CCharaPcs table extern to match the existing PTR_s_CCharaPcs_GAME_ symbol.
- Update CCharaPcs::GetTable to reference that canonical symbol instead of the address-suffixed alias.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/p_chara -o /tmp/p_chara_gettable_final.json GetTable__9CCharaPcsFUl
- GetTable__9CCharaPcsFUl: 97.0% before, 100.0% after, 0 instruction diffs.

## Plausibility
- This is a symbol/linkage correction matching config/GCCP01/symbols.txt; no control flow or compiler-coaxing changes.