### PR TITLE
Improve CLightPcs destroy indexing

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -208,36 +208,32 @@ void CLightPcs::create()
  */
 void CLightPcs::destroy()
 {
-    CBumpLight* light = &m_bumpLights[8];
     u32 i = 0;
     do {
-        if (light->m_textureData != 0) {
-            bool hasTexture = light->m_textureData != 0;
+        if (m_bumpLights[i + 8].m_textureData != 0) {
+            bool hasTexture = m_bumpLights[i + 8].m_textureData != 0;
             if (hasTexture) {
-                Memory.Free(light->m_textureData);
-                light->m_textureData = 0;
+                Memory.Free(m_bumpLights[i + 8].m_textureData);
+                m_bumpLights[i + 8].m_textureData = 0;
             }
-            light->m_hasTexture = 0;
-            light->m_useViewSpace = 0;
+            m_bumpLights[i + 8].m_hasTexture = 0;
+            m_bumpLights[i + 8].m_useViewSpace = 0;
         }
         i++;
-        light++;
     } while (i < 8);
 
-    light = &m_bumpLights[0];
     i = 0;
     do {
-        if (light->m_textureData != 0) {
-            bool hasTexture = light->m_textureData != 0;
+        if (m_bumpLights[i].m_textureData != 0) {
+            bool hasTexture = m_bumpLights[i].m_textureData != 0;
             if (hasTexture) {
-                Memory.Free(light->m_textureData);
-                light->m_textureData = 0;
+                Memory.Free(m_bumpLights[i].m_textureData);
+                m_bumpLights[i].m_textureData = 0;
             }
-            light->m_hasTexture = 0;
-            light->m_useViewSpace = 0;
+            m_bumpLights[i].m_hasTexture = 0;
+            m_bumpLights[i].m_useViewSpace = 0;
         }
         i++;
-        light++;
     } while (i < 8);
 }
 


### PR DESCRIPTION
## Summary
- Update CLightPcs::destroy to index m_bumpLights directly instead of walking two pre-offset CBumpLight pointers.
- This keeps the source using real member access while moving codegen closer to the PAL target for both bump-light banks.

## Evidence
- ninja passes for GCCP01.
- main/p_light destroy__9CLightPcsFv improved from 79.32% to 84.58% in objdiff.
- Final objdiff: build/tools/objdiff-cli diff -p . -u main/p_light -o /tmp/diff_p_light_destroy_final.json destroy__9CLightPcsFv

## Plausibility
- Direct array indexing reflects the two fixed 8-light banks without raw offsets or address hacks.
- The change removes redundant pre-offset pointer setup and leaves the existing texture/free behavior unchanged.