### PR TITLE
Match pppCrystal2 destructor

### DIFF
--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -291,11 +291,9 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCt
  */
 void pppDestructCrystal2(pppCrystal2* pppCrystal2, _pppCtrlTable* param_2)
 {
-    CMemory::CStage* stage;
-
     Crystal2Work* work = reinterpret_cast<Crystal2Work*>(
         pppCrystal2->m_object.m_workArea + param_2->m_serializedDataOffsets[2]);
-    stage = reinterpret_cast<CMemory::CStage*>(work->m_refractionMap);
+    CMemory::CStage* stage = reinterpret_cast<CMemory::CStage*>(work->m_refractionMap);
 
     if (work->m_refractionTexObj != 0) {
         pppHeapUseRate(reinterpret_cast<CMemory::CStage*>(work->m_refractionTexObj));


### PR DESCRIPTION
## Summary
- Adjust local initialization order in pppDestructCrystal2 so MWCC allocates the work/refraction map locals like the target.
- This fully matches pppDestructCrystal2 without changing behavior or manually forcing codegen artifacts.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppCrystal2 -o -
- main/pppCrystal2 .text: 99.49653% -> 99.60069%.
- pppDestructCrystal2: 98.23529% -> 100%.
- Overall matched code: 594820 -> 594956 bytes (+136); matched functions: 3461 -> 3462.

## Plausibility
- The change keeps the same control flow and data accesses, only narrowing the lifetime/initialization of the refraction-map local to match the original register allocation.