### PR TITLE
Improve chara_anim matching

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -21,6 +21,9 @@ extern const float FLOAT_80330C94 = 360.0f;
 
 class CCharaPcs
 {
+private:
+	unsigned char _pad[0x71C];
+
 public:
 	int TryReleaseAnimBank(int);
 };
@@ -302,7 +305,7 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 					m_bankAddress = Chara.m_animBankAddress;
 					Chara.m_animBankAddress += m_bankSize;
 					if (m_bank != 0) {
-						delete[] static_cast<unsigned char*>(m_bank);
+						delete static_cast<unsigned char*>(m_bank);
 						m_bank = 0;
 					}
 					break;


### PR DESCRIPTION
## Summary
- make the local CCharaPcs declaration size-aware so CharaPcs is addressed as the large .bss object shown by symbols
- use scalar delete for the temporary animation bank buffer after it is copied to animation memory

## Evidence
- ninja: build/GCCP01/main.dol OK
- main/chara_anim .text fuzzy match: 97.95131% -> 98.526215%
- Interp__Q26CChara9CAnimNodeFPQ26CChara5CAnimP3SRTf: 97.472725% -> 99.30303%
- Create__Q26CChara5CAnimFPvPQ27CMemory6CStage: 97.333336% -> 97.354164%
- report now counts one additional matched function globally (3461 -> 3462) and +220 matched code bytes

## Plausibility
- CharaPcs is listed as a 0x71C-byte .bss object in config/GCCP01/symbols.txt, so the prior empty local class made the compiler treat the global as small data incorrectly
- the post-copy buffer free now matches the target call to scalar operator delete while leaving the already-matching CAnim destructor unchanged