### PR TITLE
Match CMapTexAnim class name rodata

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -24,6 +24,7 @@ public:
 
 extern "C" {
 static const char s_maptexanim_cpp_801d7ec4[] = "maptexanim.cpp";
+const char s_CMapTexAnim_801D7ED4[] = "CMapTexAnim";
 char s_SetMapTexAnim_MaterialIdNotFound[];
 }
 extern "C" float FLOAT_8032fd38;


### PR DESCRIPTION
## Summary
- Add the missing CMapTexAnim class-name rodata symbol in maptexanim.cpp.
- This fills the configured s_CMapTexAnim_801D7ED4 string without changing code generation.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff main/maptexanim: s_CMapTexAnim_801D7ED4 now matches 100% (12 bytes); before it was an unmatched/null rodata symbol.
- objdiff main/maptexanim: .rodata remains 100%, .text remains unchanged at 99.94277% in objdiff-cli output.

## Plausibility
- The symbol is the class-name string immediately following s_maptexanim_cpp_801d7ec4 in the configured rodata layout.
- No manual vtable/RTTI forcing was added.