### PR TITLE
Match CFlatData cleanup deletes

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -20,17 +20,17 @@ void CFlatData::Destroy()
 	{
 		if (m_data[i].m_data != nullptr)
 		{
-			delete[] static_cast<unsigned char*>(m_data[i].m_data);
+			delete static_cast<unsigned char*>(m_data[i].m_data);
 			m_data[i].m_data = nullptr;
 		}
 		if (m_data[i].m_strings != nullptr)
 		{
-			delete[] m_data[i].m_strings;
+			delete m_data[i].m_strings;
 			m_data[i].m_strings = (char**)nullptr;
 		}
 		if (m_data[i].m_stringBuf != nullptr)
 		{
-			delete[] m_data[i].m_stringBuf;
+			delete m_data[i].m_stringBuf;
 			m_data[i].m_stringBuf = (char*)nullptr;
 		}
 	}
@@ -41,12 +41,12 @@ void CFlatData::Destroy()
 	{
 		if (m_tabl[i].m_strings != nullptr)
 		{
-			delete[] m_tabl[i].m_strings;
+			delete m_tabl[i].m_strings;
 			m_tabl[i].m_strings = (char**)nullptr;
 		}
 		if (m_tabl[i].m_stringBuf != nullptr)
 		{
-			delete[] m_tabl[i].m_stringBuf;
+			delete m_tabl[i].m_stringBuf;
 			m_tabl[i].m_stringBuf = (char*)nullptr;
 		}
 	}
@@ -55,7 +55,7 @@ void CFlatData::Destroy()
 	// Finally: free mes buffer
 	if (m_mesBuffer != nullptr)
 	{
-		delete[] m_mesBuffer;
+		delete m_mesBuffer;
 		m_mesBuffer = (char*)nullptr;
 	}
 	m_mesCount = 0;
@@ -188,17 +188,17 @@ CFlatData::~CFlatData()
 	{
 		if (m_data[i].m_data != nullptr)
 		{
-			delete[] static_cast<unsigned char*>(m_data[i].m_data);
+			delete static_cast<unsigned char*>(m_data[i].m_data);
 			m_data[i].m_data = nullptr;
 		}
 		if (m_data[i].m_strings != nullptr)
 		{
-			delete[] m_data[i].m_strings;
+			delete m_data[i].m_strings;
 			m_data[i].m_strings = (char**)nullptr;
 		}
 		if (m_data[i].m_stringBuf != nullptr)
 		{
-			delete[] m_data[i].m_stringBuf;
+			delete m_data[i].m_stringBuf;
 			m_data[i].m_stringBuf = (char*)nullptr;
 		}
 	}
@@ -208,12 +208,12 @@ CFlatData::~CFlatData()
 	{
 		if (m_tabl[i].m_strings != nullptr)
 		{
-			delete[] m_tabl[i].m_strings;
+			delete m_tabl[i].m_strings;
 			m_tabl[i].m_strings = (char**)nullptr;
 		}
 		if (m_tabl[i].m_stringBuf != nullptr)
 		{
-			delete[] m_tabl[i].m_stringBuf;
+			delete m_tabl[i].m_stringBuf;
 			m_tabl[i].m_stringBuf = (char*)nullptr;
 		}
 	}
@@ -221,7 +221,7 @@ CFlatData::~CFlatData()
 
 	if (m_mesBuffer != nullptr)
 	{
-		delete[] m_mesBuffer;
+		delete m_mesBuffer;
 		m_mesBuffer = (char*)nullptr;
 	}
 	m_mesCount = 0;


### PR DESCRIPTION
## Summary
- Use scalar delete for CFlatData buffer cleanup in Destroy and the destructor.
- This matches the generated calls in the original for the raw CFlatData buffers and removes the delete/delete[] call mismatches in Destroy.

## Objdiff evidence
- main/cflat_data Destroy__9CFlatDataFv: 99.583336% / 6 diffs -> 100.0% / 0 diffs
- main/cflat_data __dt__9CFlatDataFv: 98.561646% / 18 diffs -> 98.9726% / 12 diffs

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/cflat_data -o - Destroy__9CFlatDataFv
- build/tools/objdiff-cli diff -p . -u main/cflat_data -o - __dt__9CFlatDataFv