### PR TITLE
Improve CMapHit cylinder loop match

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -284,8 +284,8 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
     g_hit_cyl = *mapCylinder;
     g_hit_mvec = *position;
 
-    int faceIndex = 0;
     int faceOffset = 0;
+    int faceIndex = 0;
     while (faceIndex < static_cast<int>(m_faceCount)) {
         g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
         g_hit_t_min = FLOAT_8032F8C0;


### PR DESCRIPTION
## Summary
- Adjust the local variable order in `CMapHit::CheckHitCylinder(CMapCylinder*, Vec*, unsigned long)` so the face offset/index loop is allocated closer to the original code shape.

## Evidence
- `ninja` passes.
- `main/maphit` `.text`: 72.96615% -> 72.977554%.
- `CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUl`: 94.40964% -> 94.77109%.
- Adjacent checked symbols remained stable:
  - `CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUsUsUl`: 92.25373%
  - `CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUsUsUl`: 93.34615%
  - `Draw__7CMapHitFv`: 83.67732%

## Plausibility
- This keeps the existing logic and data layout intact.
- The change only affects declaration order for the loop locals, aligning generated register use without adding hacks, fake symbols, or address/section forcing.