### PR TITLE
Fix CTexture dimension signedness

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -67,8 +67,8 @@ public:
     GXTlutObj m_tlutObj0;
     GXTlutObj m_tlutObj1;
     unsigned int m_format;
-    int m_width;
-    int m_height;
+    unsigned int m_width;
+    unsigned int m_height;
     int m_wrapMode;
     unsigned char m_isIntensityAlpha;
     unsigned char m_isAlphaLut;


### PR DESCRIPTION
## Summary
- Change CTexture::m_width and m_height to unsigned int to match texture dimension usage from chunk data.
- Improves pppCrystal float conversion/codegen and brings its sdata2 diff to 100%.

## Evidence
- ninja: passes, build/GCCP01/main.dol OK
- main/pppCrystal objdiff:
  - pppRenderCrystal: 99.32964% -> 99.9169%
  - pppFrameCrystal: 99.0% -> 99.01852%
  - [.sdata2-0]: 86.0% -> 100.0%
  - .text section: 99.23923% -> 99.56166%

## Plausibility
- Texture dimensions are loaded from 32-bit chunk fields and used as non-negative GX texture sizes, so unsigned storage better reflects the source type and removes signed integer-to-float conversion artifacts.