### PR TITLE
Improve chara color setter matches

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -490,7 +490,14 @@ void CCharaPcs::SetTexShadowRadius(float texShadowRadius)
  */
 void CCharaPcs::SetTexShadowColor(_GXColor color)
 {
-    m_texShadowColor = color;
+    unsigned char r = color.r;
+    unsigned char g = color.g;
+    m_texShadowColor.r = r;
+    unsigned char b = color.b;
+    m_texShadowColor.g = g;
+    unsigned char a = color.a;
+    m_texShadowColor.b = b;
+    m_texShadowColor.a = a;
 }
 
 /*
@@ -865,7 +872,7 @@ done_check:
  */
 void CCharaPcs::SetMapShadeColor(int shadeIndex, CColor color)
 {
-    m_viewerChoiceColor[shadeIndex] = color;
+    m_viewerChoiceColor[shadeIndex].color = color.color;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Copy tex shadow color channels with explicit temporaries to match the target load/store order more closely.
- Assign map shade color through the underlying GXColor payload instead of the CColor wrapper assignment.

## Objdiff evidence
- SetTexShadowColor__9CCharaPcsF8_GXColor: 75.888885% -> 96.44444%
- SetMapShadeColor__9CCharaPcsFi6CColor: 33.18182% -> 77.545456%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o /tmp/cflat_final.json SetTexShadowColor__9CCharaPcsF8_GXColor
- build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o /tmp/cflat_final_map.json SetMapShadeColor__9CCharaPcsFi6CColor