### PR TITLE
Match CFlatData destructor

### DIFF
--- a/src/cflat_data.cpp
+++ b/src/cflat_data.cpp
@@ -182,49 +182,7 @@ void CFlatData::Create(void* filePtr)
  */
 CFlatData::~CFlatData()
 {
-	int i;
-
-	for (i = 0; i < m_dataCount; i++)
-	{
-		if (m_data[i].m_data != nullptr)
-		{
-			delete static_cast<unsigned char*>(m_data[i].m_data);
-			m_data[i].m_data = nullptr;
-		}
-		if (m_data[i].m_strings != nullptr)
-		{
-			delete m_data[i].m_strings;
-			m_data[i].m_strings = (char**)nullptr;
-		}
-		if (m_data[i].m_stringBuf != nullptr)
-		{
-			delete m_data[i].m_stringBuf;
-			m_data[i].m_stringBuf = (char*)nullptr;
-		}
-	}
-	m_dataCount = 0;
-
-	for (i = 0; i < m_tableCount; i++)
-	{
-		if (m_tabl[i].m_strings != nullptr)
-		{
-			delete m_tabl[i].m_strings;
-			m_tabl[i].m_strings = (char**)nullptr;
-		}
-		if (m_tabl[i].m_stringBuf != nullptr)
-		{
-			delete m_tabl[i].m_stringBuf;
-			m_tabl[i].m_stringBuf = (char*)nullptr;
-		}
-	}
-	m_tableCount = 0;
-
-	if (m_mesBuffer != nullptr)
-	{
-		delete m_mesBuffer;
-		m_mesBuffer = (char*)nullptr;
-	}
-	m_mesCount = 0;
+	Destroy();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Replace the duplicated CFlatData destructor cleanup body with a call to the existing Destroy() helper.
- This matches the source shape already used by Create(), which calls Destroy() before loading new data.

## Evidence
- Before: __dt__9CFlatDataFv was 98.9726% matched.
- After: __dt__9CFlatDataFv is 100.0% matched, size 292 bytes.
- After: main/cflat_data .text is 100.0% matched.
- Build: ninja passes; report gained one matched function and 292 matched code bytes.

## Plausibility
- The destructor delegating to Destroy() is cleaner original-source structure than duplicating the exact cleanup loops.
- Destroy() already contains the matching cleanup implementation and is called by Create(), so the shared cleanup path is consistent with the class design.