### PR TITLE
Improve pppKeShpTail2X draw matching

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -327,6 +327,9 @@ move_next_segment:
     seg.x = segDx;
     seg.y = segDy;
     seg.z = segDz;
+    zeroVec.x = zero;
+    zeroVec.y = zero;
+    zeroVec.z = zero;
     segLen = PSVECDistance(&zeroVec, &seg);
     segCursor = trailLen;
     segRemain += segLen;


### PR DESCRIPTION
## Summary
- Reinitialize the zero vector before the second segment-distance calculation in `pppKeShpTail2XDraw`.
- This matches PAL emitted zero-vector stores before the later `PSVECDistance` call and keeps the source behavior coherent.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail2X -o /tmp/pppKeShpTail2X_keeper.json`
- `pppKeShpTail2XDraw`: 82.11804% -> 82.31403% match.

## Plausibility
- The existing code already initializes `zeroVec` before the first distance calculation. Reinitializing it before the later distance calculation reflects the PAL code shape and is normal source rather than a section/address hack.