### PR TITLE
Improve p_map load completion match

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -426,42 +426,34 @@ void CMapPcs::LoadMap(int stageNo, int mapNo, void* mapPtr, unsigned long mapSiz
  */
 unsigned long long CMapPcs::IsLoadMapCompleted()
 {
-    void** handle = MapMng.m_asyncLoadState.m_asyncHandles;
     unsigned int value = 0;
+    int index = 0;
 
     for (int count = 2; count != 0; count--) {
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
-        if (*handle != 0) {
+        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
             return (unsigned long long)value;
         }
-        handle++;
         value += 7;
     }
 


### PR DESCRIPTION
## Summary
- Reworked CMapPcs::IsLoadMapCompleted to check async load handles through indexed member access instead of a separate handle pointer.
- Keeps the source tied to MapMng.m_asyncLoadState.m_asyncHandles and moves codegen closer to the original addressing pattern.

## Evidence
- Full build: ninja
- Objdiff main/p_map IsLoadMapCompleted .text: 92.70537% -> 92.93695%
- .data unchanged: 99.87212%

## Plausibility
- This removes an extra local pointer and expresses the original data being checked directly through the CMapMng member array, rather than relying on a derived pointer into the object.