### PR TITLE
Correct CFlatRuntime intToClass return type

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -127,7 +127,7 @@ public:
 	void onDeleteObject(CFlatRuntime::CObject*);
 	void onNewObject(CFlatRuntime::CObject*);
 	CFlatRuntime::CObject* getFreeObject(int);
-	CFlatRuntime::CClass* intToClass(int);
+	void* intToClass(int);
 
 	CFlatRuntime::CVal* onSystemVal(CFlatRuntime::CObject*, int);
 	CFlatRuntime::CVal* onClassSystemVal(CFlatRuntime::CObject*, int);

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -1868,7 +1868,7 @@ int CFlatRuntime::objectFrame(CFlatRuntime::CObject* object)
 				reinterpret_cast<SetSystemValFn>((*reinterpret_cast<void***>(this))[12])(
 				    this, static_cast<int>(systemValue) >> 13, reinterpret_cast<CStack*>(sp), setMode);
 			} else {
-				typedef CClass* (*IntToClassFn)(CFlatRuntime*, int);
+				typedef void* (*IntToClassFn)(CFlatRuntime*, int);
 				typedef void (*SetClassSystemValFn)(CFlatRuntime*, int, CObject*, CStack*, int);
 				CObject* target = reinterpret_cast<CObject*>(
 				    reinterpret_cast<IntToClassFn>((*reinterpret_cast<void***>(this))[15])(this, systemValue & 0xFFF));
@@ -1984,7 +1984,7 @@ int CFlatRuntime::objectFrame(CFlatRuntime::CObject* object)
 			const u32 returnValue = *object->m_sp;
 			--object->m_sp;
 			const u32 classWord = *object->m_sp;
-			typedef CClass* (*IntToClassFn)(CFlatRuntime*, int);
+			typedef void* (*IntToClassFn)(CFlatRuntime*, int);
 			CObject* target = reinterpret_cast<CObject*>(
 			    reinterpret_cast<IntToClassFn>((*reinterpret_cast<void***>(this))[15])(this, classWord >> 16));
 			object->m_engineObject = target;
@@ -2432,9 +2432,9 @@ CFlatRuntime::CObject* CFlatRuntime::getFreeObject(int)
  * Address:	TODO
  * Size:	TODO
  */
-CFlatRuntime::CClass* CFlatRuntime::intToClass(int)
+void* CFlatRuntime::intToClass(int)
 {
-    return 0;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Change the base CFlatRuntime::intToClass return type from CClass* to void*.
- Update objectFrame vtable-call typedefs to match the actual runtime contract used by CFlatRuntime2.
- Keep call sites casting to the concrete object type they consume.

## Evidence
- ninja passes for GCCP01.
- objdiff remains stable:
  - main/cflat_runtime intToClass__12CFlatRuntimeFi: 100.0%
  - main/cflat_runtime objectFrame__12CFlatRuntimeFPQ212CFlatRuntime7CObject: 43.56643%
  - main/cflat_runtime2 intToClass__13CFlatRuntime2Fi: 100.0%

## Plausibility
CFlatRuntime2::intToClass returns engine object storage such as base objects, quad objects, game objects, party/monster/item object arrays, or this. Returning void* in the base API avoids pretending that this vtable slot returns CFlatRuntime::CClass metadata and makes the source match the observed ABI.