### PR TITLE
Improve water mesh update loop matching

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -418,10 +418,14 @@ static int UpdateWaterMesh(VMana2* mana2)
         return 0;
     }
 
-    for (int row = 1, rowBase = 0x11; row < 0x10; row++, rowBase += 0x11) {
-        currentScale = FLOAT_80331898;
-        neighborScale = FLOAT_803318a4;
-        for (int col = 1; col < 0x10; col += 5) {
+    int row = 1;
+    int rowBase = 0x11;
+    currentScale = FLOAT_80331898;
+    neighborScale = FLOAT_803318a4;
+    do {
+        int col = 1;
+        int batch = 3;
+        do {
             int index = rowBase + col;
             int above0 = index - 0x11;
             int below0 = index + 0x11;
@@ -462,8 +466,12 @@ static int UpdateWaterMesh(VMana2* mana2)
                                    neighborScale * (waterHeightA[above4] + waterHeightA[below4] +
                                                     waterHeightA[index4 - 1] + waterHeightA[index4 + 1]) -
                                    waterHeightB[index4];
-        }
-    }
+            col += 5;
+            batch--;
+        } while (batch != 0);
+        row++;
+        rowBase += 0x11;
+    } while (row < 0x10);
 
     for (int i = 0; i < 0x121; i++) {
         float tmp = waterHeightA[i];

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1240,10 +1240,14 @@ static int UpdateWaterMesh(VYmMana* mana)
         return 0;
     }
 
-    for (int row = 1, rowBase = 0x11; row < 0x10; row++, rowBase += 0x11) {
+    int row = 1;
+    int rowBase = 0x11;
+    do {
         currentScale = FLOAT_80330e4c;
         neighborScale = FLOAT_80330e5c;
-        for (int col = 1; col < 0x10; col += 5) {
+        int col = 1;
+        int batch = 3;
+        do {
             int index = rowBase + col;
             int above0 = index - 0x11;
             int below0 = index + 0x11;
@@ -1284,8 +1288,12 @@ static int UpdateWaterMesh(VYmMana* mana)
                                    neighborScale * (waterHeightA[above4] + waterHeightA[below4] +
                                                     waterHeightA[index4 - 1] + waterHeightA[index4 + 1]) -
                                    waterHeightB[index4];
-        }
-    }
+            col += 5;
+            batch--;
+        } while (batch != 0);
+        row++;
+        rowBase += 0x11;
+    } while (row < 0x10);
 
     for (int i = 0; i < 0x121; i++) {
         float tmp = waterHeightA[i];


### PR DESCRIPTION
## Summary
- Reshape the inner water mesh update loops in pppMana2 and pppYmMana to use explicit three-batch processing.
- Keep the existing five-column unrolled body while making the loop bounds closer to the fixed 15x15 interior mesh traversal.

## Objdiff evidence
- main/pppMana2 UpdateWaterMesh__FP6VMana2: 76.0909% -> 77.2273%
- main/pppMana2 .text: 87.2030% -> 87.2919%
- main/pppYmMana UpdateWaterMesh__FP7VYmMana: 78.1405% -> 78.4215%
- main/pppYmMana .text: 87.5812% -> 87.5994%

## Verification
- ninja
- python3 tools/objdiff_experiment.py -u main/pppMana2 UpdateWaterMesh__FP6VMana2 --explain --limit 1
- python3 tools/objdiff_experiment.py -u main/pppYmMana UpdateWaterMesh__FP7VYmMana --explain --limit 1

## Plausibility
The water mesh has a fixed 15-column interior, already processed in groups of five. Expressing that as three fixed batches keeps the source-level algorithm intact while matching the compiler's expected loop shape more closely.