### PR TITLE
Improve CGraphic copy filter setup

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -170,7 +170,7 @@ void CGraphic::Init()
     GXSetDispCopyDst(U16At(renderMode, 4), U16At(renderMode, 6));
     GXSetCopyFilter(reinterpret_cast<GXRenderModeObj*>(renderMode)->aa,
                     reinterpret_cast<GXRenderModeObj*>(renderMode)->sample_pattern, GX_TRUE,
-                    reinterpret_cast<GXRenderModeObj*>(renderMode)->vfilter);
+                    GXNtsc480IntDf.vfilter);
 
     if (reinterpret_cast<GXRenderModeObj*>(renderMode)->aa == 0) {
         GXSetPixelFmt(GX_PF_RGB8_Z24, GX_ZC_LINEAR);


### PR DESCRIPTION
## Summary
- Use the standard GXNtsc480IntDf vfilter for CGraphic::Init copy filter setup.
- This matches the target's relocation to the SDK render-mode vfilter table instead of loading vfilter through the active render-mode pointer.

## Evidence
- Build: ninja
- Objdiff: main/graphic Init__8CGraphicFv improved from 74.636% to 75.152%.
- Function size stayed 1000 bytes.

## Plausibility
- The active render mode still supplies aa and sample_pattern.
- The vfilter values are the standard NTSC deflicker table used by the target sequence, so this is a source-level setup correction rather than a manual codegen hack.