### PR TITLE
Improve maphit ReadOtmHit bounds comparisons

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -660,9 +660,9 @@ int CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                 m_positionMin.y = (m_positionMin.y < v->y) ? m_positionMin.y : v->y;
                 m_positionMin.z = (m_positionMin.z < v->z) ? m_positionMin.z : v->z;
 
-                m_positionMax.x = (m_positionMax.x < v->x) ? v->x : m_positionMax.x;
-                m_positionMax.y = (m_positionMax.y < v->y) ? v->y : m_positionMax.y;
-                m_positionMax.z = (m_positionMax.z < v->z) ? v->z : m_positionMax.z;
+                m_positionMax.x = (m_positionMax.x > v->x) ? m_positionMax.x : v->x;
+                m_positionMax.y = (m_positionMax.y > v->y) ? m_positionMax.y : v->y;
+                m_positionMax.z = (m_positionMax.z > v->z) ? m_positionMax.z : v->z;
             }
 
             m_positionMin.x -= kMapHitUnitScale;
@@ -740,9 +740,9 @@ int CMapHit::ReadOtmHit(CChunkFile& chunkFile)
                     face.m_boundsMin.y = (face.m_boundsMin.y < v.y) ? face.m_boundsMin.y : v.y;
                     face.m_boundsMin.z = (face.m_boundsMin.z < v.z) ? face.m_boundsMin.z : v.z;
 
-                    face.m_boundsMax.x = (face.m_boundsMax.x < v.x) ? v.x : face.m_boundsMax.x;
-                    face.m_boundsMax.y = (face.m_boundsMax.y < v.y) ? v.y : face.m_boundsMax.y;
-                    face.m_boundsMax.z = (face.m_boundsMax.z < v.z) ? v.z : face.m_boundsMax.z;
+                    face.m_boundsMax.x = (face.m_boundsMax.x > v.x) ? face.m_boundsMax.x : v.x;
+                    face.m_boundsMax.y = (face.m_boundsMax.y > v.y) ? face.m_boundsMax.y : v.y;
+                    face.m_boundsMax.z = (face.m_boundsMax.z > v.z) ? face.m_boundsMax.z : v.z;
                 }
 
                 face.m_radiusScale *= radiusScale;


### PR DESCRIPTION
## Summary
- Rewrites ReadOtmHit max-bound ternaries to keep the current max on the true branch.
- Applies the same source form to map and face max bounds.

## Evidence
- ninja passes.
- ReadOtmHit__7CMapHitFR10CChunkFile improved from 99.57712% to 99.95025%.
- Final objdiff: build/tools/objdiff-cli diff -p . -u main/maphit -o - ReadOtmHit__7CMapHitFR10CChunkFile reports size 1608, match 99.95025%.

## Plausibility
- The change is behavior-equivalent max-bound maintenance, but matches the original compare/branch shape more closely.
- No fake symbols, address hacks, section forcing, or linkage tricks.