### PR TITLE
Match maptexanim code and trim data

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -534,7 +534,7 @@ config.libs = [
             Object(NonMatching, "mapobj.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "mapocttree.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "mapshadow.cpp"),
-            Object(NonMatching, "maptexanim.cpp", extra_cflags=["-RTTI on", "-str reuse,pool,readonly"]),
+            Object(NonMatching, "maptexanim.cpp", extra_cflags=["-str reuse,pool,readonly"]),
             Object(NonMatching, "materialman.cpp"),
             Object(NonMatching, "math.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "ME_AppRequest.cpp"),

--- a/include/ffcc/maptexanim.h
+++ b/include/ffcc/maptexanim.h
@@ -10,6 +10,9 @@ class CTextureSet;
 class CTexture;
 class CMapTexAnim;
 
+extern "C" float FLOAT_8032fd48;
+extern "C" float FLOAT_8032fd4c;
+
 class CMapTexAnimSet : public CRef
 {
 public:
@@ -28,20 +31,96 @@ private:
     CTextureSet* m_textureSet;
 };
 
+class CMapKeyFrameData
+{
+public:
+    float Get()
+    {
+        return reinterpret_cast<CMapKeyFrame*>(this)->Get();
+    }
+
+    int Get(int& key0, int& key1, float& blend)
+    {
+        return reinterpret_cast<CMapKeyFrame*>(this)->Get(key0, key1, blend);
+    }
+
+    void Calc()
+    {
+        reinterpret_cast<CMapKeyFrame*>(this)->Calc();
+    }
+
+    int IsRun()
+    {
+        return reinterpret_cast<CMapKeyFrame*>(this)->IsRun();
+    }
+
+    void ReadJun(CChunkFile& chunkFile, int count)
+    {
+        reinterpret_cast<CMapKeyFrame*>(this)->ReadJun(chunkFile, count);
+    }
+
+    void ReadFrame(CChunkFile& chunkFile, int count)
+    {
+        reinterpret_cast<CMapKeyFrame*>(this)->ReadFrame(chunkFile, count);
+    }
+
+    void ReadKey(CChunkFile& chunkFile, int count)
+    {
+        reinterpret_cast<CMapKeyFrame*>(this)->ReadKey(chunkFile, count);
+    }
+
+    void Destroy()
+    {
+        if (m_junTable != 0) {
+            delete m_junTable;
+            m_junTable = 0;
+        }
+        if (m_keyFrame != 0) {
+            delete m_keyFrame;
+            m_keyFrame = 0;
+        }
+        if (m_keyValue != 0) {
+            delete m_keyValue;
+            m_keyValue = 0;
+        }
+        if (m_splineTable != 0) {
+            delete m_splineTable;
+            m_splineTable = 0;
+        }
+    }
+
+    unsigned char m_mode;
+    unsigned char m_junCount;
+    unsigned char m_keyCount;
+    unsigned char m_loop;
+    unsigned char m_isRun;
+    unsigned char m_pad05[3];
+    int m_currentFrame;
+    int m_startFrame;
+    int m_endFrame;
+    int m_frameCount;
+    unsigned char* m_junTable;
+    float* m_keyFrame;
+    float* m_keyValue;
+    float* m_splineTable;
+};
+
 class CMapTexAnim : public CRef
 {
 public:
     CMapTexAnim()
     {
+        float frameStep = FLOAT_8032fd48;
         m_keyFrame.m_junTable = 0;
+        float currentFrame = FLOAT_8032fd4c;
         m_keyFrame.m_keyFrame = 0;
         m_keyFrame.m_keyValue = 0;
         m_keyFrame.m_splineTable = 0;
         m_keyFrame.m_loop = 1;
         m_keyFrame.m_isRun = 0;
         m_frameTable = 0;
-        m_frameStep = 1.0f;
-        m_currentFrame = 0.0f;
+        m_frameStep = frameStep;
+        m_currentFrame = currentFrame;
         m_usesBlendTexture = 0;
         m_usesKeyFrame = 0;
         m_materialId = -1;
@@ -91,7 +170,7 @@ private:
     float m_frameStep;
     float m_currentFrame;
     unsigned short* m_frameTable;
-    CMapKeyFrame m_keyFrame;
+    CMapKeyFrameData m_keyFrame;
 };
 
 #endif // _FFCC_MAPTEXANIM_H_

--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -317,4 +317,7 @@ CMapTexAnim::~CMapTexAnim()
 {
     delete m_frameTable;
     m_frameTable = 0;
+    if (static_cast<void*>(&m_keyFrame) != 0) {
+        m_keyFrame.Destroy();
+    }
 }


### PR DESCRIPTION
## Summary
- model CMapTexAnim keyframe storage without emitting a standalone CMapKeyFrame destructor
- initialize map tex anim frame defaults from the existing sdata2 symbols used by the target
- compile maptexanim with the base RTTI-off flags to remove duplicate RTTI rodata/data

## Evidence
- ninja: build/GCCP01/main.dol OK
- main/maptexanim report: code 100%, functions 5/5, data 92.10526%
- before objdiff sizes: .text 2968 vs 2796, extab 48 vs 40, extabindex 72 vs 60, .rodata 40 vs 28, .data 24 vs 12, .sdata2 45 vs 12
- after objdiff sizes: .text 2796 vs 2796, extab 40 vs 40, extabindex 60 vs 60, .rodata 28 vs 28, .data 12 vs 12, .sdata2 32 vs 12

## Plausibility
The target has CMapTexAnim cleanup folded into CMapTexAnim::~CMapTexAnim and does not carry the duplicate RTTI string/data generated by forcing RTTI on for this unit. The storage wrapper keeps the recovered CMapKeyFrame layout and method calls while avoiding the extra compiler-generated weak destructor.