### PR TITLE
Improve THPSimple read buffer setup

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -728,9 +728,6 @@ s32 THPSimpleSetBuffer(u8* buffer)
         SimpleControl.readBuffer[6].mPtr = cursor;
         cursor += frameBufferSize;
 
-        SimpleControl.readBuffer[7].mPtr = cursor;
-        cursor += frameBufferSize;
-
         SimpleControl.readBuffer[1].mIsValid = 0;
         SimpleControl.readBuffer[2].mIsValid = 0;
         SimpleControl.readBuffer[3].mIsValid = 0;


### PR DESCRIPTION
## Summary
- Stop assigning SimpleControl.readBuffer[7].mPtr in THPSimpleSetBuffer.
- Leave buffer 7 as a validity-only sentinel before the THP work area, matching the decompiled layout for the selected target.

## Evidence
- ninja passes.
- THPSimpleSetBuffer: 95.72642% -> 96.01887%.
- main/THPSimple .text: 99.33713% -> 99.356735%.
- THPSimpleCalcNeedMemory remains 98.75%.
- MixAudio__FPsPsUl remains 98.80282%.

## Plausibility
- The change removes an extra pointer assignment and cursor advance for read buffer 7.
- Ghidra shows the work area cursor derived after buffer 6 plus one frame-buffer stride, while only readBuffer[7].mIsValid is cleared. This is a data-layout correction rather than a codegen hack.