### PR TITLE
Improve map animation codegen

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -533,11 +533,13 @@ void CPtrArray<CMapAnim*>::RemoveAll()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 template <>
 CMapAnim* CPtrArray<CMapAnim*>::operator[](unsigned long index)
 {
     return GetAt(index);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--
@@ -548,11 +550,13 @@ CMapAnim* CPtrArray<CMapAnim*>::operator[](unsigned long index)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 template <>
 int CPtrArray<CMapAnimNode*>::GetSize()
 {
     return m_numItems;
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--
@@ -563,11 +567,13 @@ int CPtrArray<CMapAnimNode*>::GetSize()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 template <>
 CMapAnimNode* CPtrArray<CMapAnimNode*>::operator[](unsigned long index)
 {
     return GetAt(index);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--
@@ -1030,11 +1036,13 @@ CMapAnim* CPtrArray<CMapAnim*>::GetAt(unsigned long index)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma dont_inline on
 template <>
 int CPtrArray<CMapAnimRun*>::GetSize()
 {
     return m_numItems;
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--
@@ -1065,11 +1073,13 @@ void CPtrArray<CMapAnimRun*>::RemoveAll()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 template <>
 CMapAnimRun* CPtrArray<CMapAnimRun*>::operator[](unsigned long index)
 {
     return GetAt(index);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3372,7 +3372,7 @@ void CMapMng::SetMapObjAnim(int mapObjIndex, int startFrame, int endFrame, int l
     CMapObj* mapObj = GetMapObjArray() + mapObjIndex;
     int mapAnimRunCount = mapAnimRunArray->GetSize();
 
-    for (unsigned int mapAnimRunIndex = 0; mapAnimRunIndex < static_cast<unsigned int>(mapAnimRunCount); mapAnimRunIndex++) {
+    for (int mapAnimRunIndex = 0; mapAnimRunIndex < mapAnimRunCount; mapAnimRunIndex++) {
         CMapAnimRun* mapAnimRun = (*mapAnimRunArray)[mapAnimRunIndex];
         CPtrArray<CMapAnimNode*>* mapAnimNodeArray =
             reinterpret_cast<CPtrArray<CMapAnimNode*>*>((*mapAnimArray)[mapAnimRun->m_mapAnimIndex]);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3403,17 +3403,19 @@ startMapObjAnim:
 void CMapMng::SetMapAnimID(int animId, int startFrame, int endFrame, int loop)
 {
     CPtrArray<CMapAnimRun*>* mapAnimRunArray = &GetMapAnimRunArray();
-    CMapAnimRun* mapAnimRun = 0;
+    CMapAnimRun* mapAnimRun;
     int mapAnimRunCount = mapAnimRunArray->GetSize();
 
-    for (unsigned long i = 0; i < static_cast<unsigned long>(mapAnimRunCount); i++) {
+    for (int i = 0; i < mapAnimRunCount; i++) {
         CMapAnimRun* current = (*mapAnimRunArray)[i];
         if (current->m_animId == static_cast<unsigned char>(animId)) {
             mapAnimRun = current;
-            break;
+            goto startMapAnim;
         }
     }
 
+    mapAnimRun = 0;
+startMapAnim:
     mapAnimRun->Start(startFrame, endFrame, loop);
 }
 


### PR DESCRIPTION
## Summary
- prevent inlining for the map animation CPtrArray accessors that PAL calls out of line
- adjust SetMapAnimID control flow and loop signedness to better match PAL
- use a signed run loop in SetMapObjAnim

## Evidence
- ninja passes
- main/map unit fuzzy match: 62.121445% baseline -> 63.0255%
- SetMapObjAnim__7CMapMngFiiii: 18.600000% -> 65.690910%
- SetMapAnimID__7CMapMngFiiii: 43.918920% -> 82.432434%
- Calc__7CMapMngFv: 64.210144% -> 71.789856%

## Notes
- DestroyMap__7CMapMngFv has a small local score movement, 53.089687% -> 52.470850%, from the shared accessor codegen change.
- The accessor pragmas match existing project practice for tiny template specializations and preserve normal C++ linkage rather than adding fake symbols or address hacks.