### PR TITLE
Match COctTree DrawTypeMesh_r

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -699,8 +699,8 @@ void COctTree::DrawTypeMesh_r(COctNode* octNode)
 		float minDepth = kOctTreeBoundMaxInit;
 
 		andMask = 0xF;
-		farCount = 0;
 		orMask = 0;
+		farCount = 0;
 
 		for (int x = 0; x < 2; x++) {
 			localCorner.x = (x == 0) ? octNode->m_boundMinX : octNode->m_boundMaxX;


### PR DESCRIPTION
## Summary
- Reordered local initialization in `COctTree::DrawTypeMesh_r` to match the original instruction scheduling.
- Improves `main/mapocttree` without adding hacks or changing linkage.

## Evidence
- `ninja` passes.
- `DrawTypeMesh_r__8COctTreeFP8COctNode`: 99.88764% -> 99.94382%.
- Build progress: matched functions 3466 -> 3467; matched code 596976 -> 597688 bytes.

## Plausibility
- The change is a normal source-level statement ordering adjustment in the existing local setup block, not an address, section, vtable, or compiler workaround.