### PR TITLE
Improve chara viewer light constant loads

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -163,6 +163,11 @@ static inline int ViewerModelFrameShift(CChara::CModel* model)
     return ViewerModel(model)->data->frameShift;
 }
 
+static inline float LoadFloat(const float& value)
+{
+    return value;
+}
+
 extern "C" const char s_no_texture____801da7e8[0x188] =
     "no texture...\0\0\0"
     "p_chara_viewer.cpp\0\0"
@@ -845,12 +850,12 @@ void CCharaPcs::createViewer()
 
     CLightPcs::CBumpLight bumpLight;
     bumpLight.m_type = 1;
-    bumpLight.m_position.x = kCharaViewerLightPosX;
-    bumpLight.m_position.y = kCharaViewerLightPosY;
-    bumpLight.m_position.z = kCharaViewerLightPosZ;
-    bumpLight.m_targetPosition.x = kCharaViewerLightTargetX;
-    bumpLight.m_targetPosition.y = kCharaViewerLightTargetY;
-    bumpLight.m_targetPosition.z = kCharaViewerLightTargetZ;
+    bumpLight.m_position.x = LoadFloat(kCharaViewerLightPosX);
+    bumpLight.m_position.y = LoadFloat(kCharaViewerLightPosY);
+    bumpLight.m_position.z = LoadFloat(kCharaViewerLightPosZ);
+    bumpLight.m_targetPosition.x = LoadFloat(kCharaViewerLightTargetX);
+    bumpLight.m_targetPosition.y = LoadFloat(kCharaViewerLightTargetY);
+    bumpLight.m_targetPosition.z = LoadFloat(kCharaViewerLightTargetZ);
     PSVECSubtract(reinterpret_cast<Vec*>(&bumpLight.m_targetPosition), reinterpret_cast<Vec*>(&bumpLight.m_position),
                   reinterpret_cast<Vec*>(&bumpLight.m_direction));
     PSVECNormalize(reinterpret_cast<Vec*>(&bumpLight.m_direction), reinterpret_cast<Vec*>(&bumpLight.m_direction));


### PR DESCRIPTION
## Summary
- Add a small LoadFloat helper in p_chara_viewer, matching an existing repo pattern used by nearby particle code.
- Use it for the chara viewer bump-light position and target constants so those values load from the named .sdata2 constants instead of emitting duplicate literals.

## Evidence
- Build: ninja
- main/p_chara_viewer .sdata2 current size: 192 -> 168 bytes, closer to the 128-byte target section.
- createViewer__9CCharaPcsFv objdiff: 85.276054% -> 85.360565%, diff instructions 120 -> 114, size unchanged at 1420 bytes.
- drawViewer__9CCharaPcsFv remains 95.65476%.
- calcViewer__9CCharaPcsFv remains 86.03333%.

## Plausibility
- The affected fields are simple assignments from existing named light constants.
- LoadFloat is already used elsewhere in the project to force loads from named float constants and avoid duplicate small-data literals.