### PR TITLE
Improve texanim Create refdata access

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -582,14 +582,15 @@ void CTexAnimSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
         CTexAnimRefDataStorage* refData = reinterpret_cast<CTexAnimRefDataStorage*>(
             new (stage, const_cast<char*>(s_texanim_cpp), 0xD3) CTexAnim::CRefData);
         texAnim->refData = refData;
-        refData->texAnimSeqs.SetStage(stage);
+        reinterpret_cast<CTexAnimRefDataStorage*>(texAnim->refData)->texAnimSeqs.SetStage(stage);
 
         chunkFile.PushChunk();
         while ((int)chunkFile.GetNextChunk(middleChunk) != 0) {
             if ((int)middleChunk.m_id != seqTag) {
                 if (((int)middleChunk.m_id < seqTag) && ((int)middleChunk.m_id == nameTag)) {
-                    refData->texSrtIndex = middleChunk.m_arg0;
-                    strcpy(refData->name, chunkFile.GetString());
+                    reinterpret_cast<CTexAnimRefDataStorage*>(texAnim->refData)->texSrtIndex = middleChunk.m_arg0;
+                    strcpy(reinterpret_cast<CTexAnimRefDataStorage*>(texAnim->refData)->name,
+                           chunkFile.GetString());
                 }
                 continue;
             }
@@ -620,7 +621,8 @@ void CTexAnimSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
                 }
             }
             chunkFile.PopChunk();
-            refData->texAnimSeqs.Add(reinterpret_cast<CTexAnimSeq*>(seq));
+            reinterpret_cast<CTexAnimRefDataStorage*>(texAnim->refData)
+                ->texAnimSeqs.Add(reinterpret_cast<CTexAnimSeq*>(seq));
         }
         chunkFile.PopChunk();
         self->texAnims.Add(reinterpret_cast<CTexAnim*>(texAnim));


### PR DESCRIPTION
Summary:
- Reload CTexAnim refData through the texAnim member after assigning the new ref data object.
- Applies the member access before setting the sequence array stage, handling NAME chunks, and adding parsed sequences.

Evidence:
- ninja passes.
- objdiff: main/texanim Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage now reports 74.844444% with size 900b.
- This improves the selected texanim target from the previous ~73.7% range and matches the target function size.

Plausibility:
- The source now follows the stored object member after ownership is assigned instead of relying on a local alias, which is a plausible original-source access pattern and improves the generated code shape.