### PR TITLE
Fix THPSimple read buffer layout

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -734,6 +734,8 @@ s32 THPSimpleSetBuffer(u8* buffer)
         SimpleControl.readBuffer[4].mIsValid = 0;
         SimpleControl.readBuffer[5].mIsValid = 0;
         SimpleControl.readBuffer[6].mIsValid = 0;
+        SimpleControl.readBuffer[7].mPtr = cursor;
+        cursor += frameBufferSize;
         SimpleControl.readBuffer[7].mIsValid = 0;
 
         if (SimpleControl.hasAudio != 0) {


### PR DESCRIPTION
## Summary
- assign the eighth THP read buffer pointer in THPSimpleSetBuffer
- advance the cursor for all 8 frame buffers before audio/work-area allocation

## Evidence
- ninja passes for GCCP01
- THPSimpleSetBuffer compiled size now matches PAL: 424 bytes before/after target vs built 416 -> 424
- This matches THPSimpleCalcNeedMemory reserving 8 frame buffers and Ghidra showing readBuffer[7].mPtr before the work area

## Notes
- objdiff instruction match shifts slightly (96.01887% -> 95.72642%) because adding the missing slot changes local scheduling, but the buffer layout is more plausible original source and fixes the work-area cursor placement.