### PR TITLE
Improve CMapPcs load completion loop

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -430,29 +430,11 @@ unsigned long long CMapPcs::IsLoadMapCompleted()
     int index = 0;
 
     for (int count = 2; count != 0; count--) {
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
-        }
-        if (MapMng.m_asyncLoadState.m_asyncHandles[index++] != 0) {
-            return (unsigned long long)value;
+        for (int handle = 8; handle != 0; handle--) {
+            if (MapMng.m_asyncLoadState.m_asyncHandles[index] != 0) {
+                return (unsigned long long)value;
+            }
+            index++;
         }
         value += 7;
     }


### PR DESCRIPTION
## Summary
- Rewrite `CMapPcs::IsLoadMapCompleted` as a small nested loop over the 16 async map handles.
- Keeps the recovered `CMapMngAsyncLoadState::m_asyncHandles` access instead of expanding each slot manually.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_map -o - IsLoadMapCompleted__7CMapPcsFv` reports `match_percent: 88.84615` for `IsLoadMapCompleted__7CMapPcsFv` after the change.
- Baseline measured before the change in this run was `74.15385`, so this is a real objdiff improvement.

## Plausibility
- The new source expresses the actual loop over two groups of eight async handles instead of hand-unrolling every slot.
- The behavior is unchanged: any non-null async handle returns incomplete, otherwise the function returns the same completed value after scanning all handles.