### PR TITLE
Improve pppYmLaser trail alpha codegen

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -208,7 +208,6 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 		color.b = step->m_laser.m_trailColorB;
 		color.a = alphaMax;
 		GXBegin(GX_TRIANGLES, GX_VTXFMT7, (u16)((step->m_laser.m_pointCount - 1) * 3));
-		int alpha = 0;
 		u8 trailColorR = color.r;
 		u8 trailColorG = color.g;
 		u8 trailColorB = color.b;
@@ -219,8 +218,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			trailStartColor.r = trailColorR;
 			trailStartColor.g = trailColorG;
 			trailStartColor.b = trailColorB;
-			trailStartColor.a = (u8)alphaMax - alpha;
-			alpha += alphaStep;
+			trailStartColor.a = (u8)alphaMax - alphaStep * j;
 
 			GXPosition3f32(work->m_origin.x, work->m_origin.y, work->m_origin.z);
 			GXColor1u32(*(u32*)&trailStartColor);


### PR DESCRIPTION
## Summary
- Simplify the pppRenderYmLaser trail alpha expression to match the better codegen form used by the non-YM laser path.
- Removes the explicit running alpha local and computes the start alpha from alphaStep * j.

## Objdiff Evidence
- main/pppYmLaser pppRenderYmLaser: 97.48271% -> 97.82979% match
- Verified with: build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppRenderYmLaser

## Validation
- ninja passes

## Plausibility
- The resulting loop is simpler source and mirrors the existing pppLaser trail alpha source form, while improving objdiff for the YM variant.