### PR TITLE
Improve p_usb and maptexanim data layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -9,7 +9,7 @@ class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;
-    static unsigned int m_table[0x15C / sizeof(unsigned int)];
+    static unsigned int m_table[0x11C / sizeof(unsigned int)];
 
     CUSBPcs();
 

--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -30,8 +30,8 @@ char s_SetMapTexAnim_MaterialIdNotFound[];
 extern "C" float FLOAT_8032fd38;
 extern "C" float FLOAT_8032fd48;
 extern "C" float FLOAT_8032fd4c;
-extern "C" const double DOUBLE_8032FCD0;
-extern "C" const float FLOAT_8032FCD8;
+extern "C" const double DOUBLE_8032FCD0 = 4503601774854144.0;
+extern "C" const float FLOAT_8032FCD8 = 0.0f;
 
 namespace {
 static inline unsigned char* Ptr(void* p, unsigned int offset)

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -28,7 +28,7 @@ inline CUSBPcs::CUSBPcs()
     table[9] = desc2[2];
 }
 
-unsigned int CUSBPcs::m_table[0x15C / sizeof(unsigned int)] = {
+unsigned int CUSBPcs::m_table[0x11C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(sUsbPcsClassName)),
     0,
     0,


### PR DESCRIPTION
Summary:
- Correct CUSBPcs::m_table to the PAL symbol size of 0x11C bytes.
- Define the maptexanim-owned sdata2 constants DOUBLE_8032FCD0 and FLOAT_8032FCD8.

Evidence:
- ninja passes.
- p_usb .data improves to 95.94072%, with m_table__7CUSBPcs now 100.0%.
- maptexanim .sdata2 improves to 100.0%, with DOUBLE_8032FCD0 and FLOAT_8032FCD8 now 100.0%.

Plausibility:
- The CUSBPcs table size now matches config/GCCP01/symbols.txt ownership for m_table__7CUSBPcs.
- The maptexanim constants are defined in the unit that owns their PAL sdata2 symbols, instead of leaving compiler/local generated constants to stand in.
- Remaining vtable/RTTI mismatches were left untouched rather than hand-authored.