### PR TITLE
Recover tex scroll access in texanim

### DIFF
--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -27,7 +27,6 @@ public:
     CTexScroll();
     ~CTexScroll();
 
-private:
     unsigned char m_type0;
     unsigned char m_type1;
     unsigned char m_pad[2];
@@ -148,6 +147,10 @@ public:
     void GetNumTexture();
     void SetTag(int);
     void AddTextureIdx(int, int);
+    CTexScroll* GetTexScroll(int index)
+    {
+        return reinterpret_cast<CTexScroll*>(reinterpret_cast<unsigned char*>(this) + 0x4C) + index;
+    }
 };
 
 class CMaterialSet : public CRef

--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -74,17 +74,6 @@ struct CTexAnimSeqStorage
     unsigned int* keys;
 };
 
-struct CTexScrollStorage
-{
-    unsigned char type0;
-    unsigned char type1;
-    unsigned char pad[2];
-    float u0;
-    float v0;
-    float u1;
-    float v1;
-};
-
 struct CMaterialSetStorage
 {
     void* vtable;
@@ -303,24 +292,24 @@ void CTexAnimSet::SetTexGen()
     for (unsigned int i = 0; i < static_cast<unsigned int>(self->texAnims.GetSize()); i++) {
         CTexAnimStorage* texAnim = reinterpret_cast<CTexAnimStorage*>(self->texAnims[i]);
         CTexAnimRefDataStorage* refData = reinterpret_cast<CTexAnimRefDataStorage*>(texAnim->refData);
-        int* material = reinterpret_cast<int*>(refData->material);
+        CMaterial* material = reinterpret_cast<CMaterial*>(refData->material);
         if (material != 0) {
-            CTexScrollStorage* texScroll = reinterpret_cast<CTexScrollStorage*>(Ptr(material, 0x4C)) + refData->texSrtIndex;
+            CTexScroll* texScroll = material->GetTexScroll(refData->texSrtIndex);
             const float texGenS = F32At(texAnim, 0x18);
             const float texGenT = F32At(texAnim, 0x1C);
-            texScroll->u0 = texGenS;
-            texScroll->v0 = texGenT;
-            texScroll->u1 = zero;
-            texScroll->v1 = zero;
-            if (zero == texScroll->u1) {
-                texScroll->type0 = 0;
+            texScroll->m_u0 = texGenS;
+            texScroll->m_v0 = texGenT;
+            texScroll->m_u1 = zero;
+            texScroll->m_v1 = zero;
+            if (zero == texScroll->m_u1) {
+                texScroll->m_type0 = 0;
             } else {
-                texScroll->type0 = 1;
+                texScroll->m_type0 = 1;
             }
-            if (zero == texScroll->v1) {
-                texScroll->type1 = 0;
+            if (zero == texScroll->m_v1) {
+                texScroll->m_type1 = 0;
             } else {
-                texScroll->type1 = 1;
+                texScroll->m_type1 = 1;
             }
         }
     }


### PR DESCRIPTION
## Summary
- expose the recovered CTexScroll fields for real member access
- add a CMaterial::GetTexScroll helper for the material tex-scroll array at 0x4C
- update CTexAnimSet::SetTexGen to use CMaterial/CTexScroll instead of a local duplicate CTexScrollStorage and raw Ptr(material, 0x4C) access

## Evidence
- ninja
- build/GCCP01/main.dol: OK
- main/texanim report unchanged/codegen-neutral: fuzzy 94.74571%, matched code 2816/5128, matched data 44/684, matched functions 27/31
- SetTexGen__11CTexAnimSetFv remains at .text 94.69111% in objdiff one-shot

## Plausibility
- materialman constructs/destroys four CTexScroll objects at material + 0x4C, so this centralizes the known layout behind CMaterial rather than duplicating a storage struct inside texanim
- no manual vtable, RTTI, ctor, dtor, or section forcing changes