### PR TITLE
Match pppBlurChara conversion constant

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -65,6 +65,7 @@ extern const f32 FLOAT_8033104c;
 extern const f32 FLOAT_80331050;
 extern const f32 FLOAT_80331054;
 extern const double DOUBLE_80330FE8 = 3.0;
+extern const double DOUBLE_80331058 = 4503599627370496.0;
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 


### PR DESCRIPTION
## Summary
- Define the shared pppBlurChara double-conversion bias constant DOUBLE_80331058 in src/pppBlurChara.cpp.
- This lets the unit sdata2 data match the target layout instead of carrying an extra local conversion constant.

## Evidence
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppBlurChara -o -
- .text: 99.86727%, 3104 bytes
- .sdata2: 100.0%, 8 bytes
- Before this change, .sdata2 for main/pppBlurChara reported 66.66667% due to the local conversion-bias data mismatch.

## Plausibility
The new constant is the standard 2^52 double bias used by Metrowerks for float-to-int conversion sequences, matching the existing target symbol DOUBLE_80331058 without changing control flow or forcing sections.