### PR TITLE
Match CMapMng map object lookup helpers

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3443,9 +3443,8 @@ void CMapMng::ShowMapObj(int, int)
  */
 void CMapMng::ShowMapObjID(int id, int show)
 {
-    CMapObj* mapObj = GetMapObjArray();
-
     for (int i = 0; i < m_mapObjCount; i++) {
+        CMapObj* mapObj = &m_mapObjArray[i];
         if (mapObj->m_objId == id) {
             if (show != 0) {
                 mapObj->m_showFlags = static_cast<unsigned char>(mapObj->m_showFlags | 1);
@@ -3453,7 +3452,6 @@ void CMapMng::ShowMapObjID(int id, int show)
                 mapObj->m_showFlags = static_cast<unsigned char>(mapObj->m_showFlags & 0xFE);
             }
         }
-        mapObj++;
     }
 }
 
@@ -3495,9 +3493,8 @@ void CMapMng::ShowMapObjChildID(int id, int show)
  */
 void CMapMng::ShowMapMeshID(int id, int show)
 {
-    CMapObj* mapObj = GetMapObjArray();
-
     for (int i = 0; i < m_mapObjCount; i++) {
+        CMapObj* mapObj = &m_mapObjArray[i];
         if (mapObj->m_meshId == id) {
             if (show != 0) {
                 mapObj->m_showFlags = static_cast<unsigned char>(mapObj->m_showFlags | 1);
@@ -3505,7 +3502,6 @@ void CMapMng::ShowMapMeshID(int id, int show)
                 mapObj->m_showFlags = static_cast<unsigned char>(mapObj->m_showFlags & 0xFE);
             }
         }
-        mapObj++;
     }
 }
 
@@ -3612,16 +3608,12 @@ void CMapMng::SetMapObjTransRate(int mapObjIndex, float x, float y, float z)
  */
 void CMapMng::SetMapObjPrioID(int id, unsigned char prio)
 {
-    CMapObj* mapObj = GetMapObjArray();
-    int i = 0;
-
-    while (i < m_mapObjCount) {
+    for (int i = 0; i < m_mapObjCount; i++) {
+        CMapObj* mapObj = &m_mapObjArray[i];
         if (static_cast<int>(mapObj->m_objId) == id) {
             *reinterpret_cast<unsigned char*>(Ptr(mapObj, 0x15)) = prio;
             *reinterpret_cast<unsigned char*>(Ptr(mapObj, 0x14)) = prio;
         }
-        mapObj++;
-        i++;
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3253,17 +3253,10 @@ void CMapMng::SetMeshCameraSemiTransAlpha(unsigned short id, int alpha, int fram
  */
 int CMapMng::GetMapObjIdx(unsigned short id)
 {
-    int objCount = m_mapObjCount;
-    int objIndex = 0;
-    CMapObj* mapObj = GetMapObjArray();
-
-    while (0 < objCount) {
-        if (mapObj->m_objId == id) {
-            return objIndex;
+    for (int i = 0; i < m_mapObjCount; i++) {
+        if (m_mapObjArray[i].m_objId == id) {
+            return i;
         }
-        mapObj++;
-        objIndex++;
-        objCount--;
     }
 
     return -1;


### PR DESCRIPTION
## Summary
- Use the recovered CMapMng::m_mapObjArray member directly in map-object lookup/update helpers.
- Matches four CMapMng helpers by avoiding helper-pointer loop shapes where the original code indexed the member array.

## Objdiff evidence
- main/map matched code: 3368 -> 3656 bytes (+288)
- matched functions: 57 -> 61 (+4)
- GetMapObjIdx__7CMapMngFUs: 65.875% -> 100.0% (64b)
- ShowMapObjID__7CMapMngFii: 94.04762% -> 100.0% (84b)
- ShowMapMeshID__7CMapMngFii: 94.04762% -> 100.0% (84b)
- SetMapObjPrioID__7CMapMngFiUc: 91.21429% -> 100.0% (56b)

## Plausibility
These loops now use the concrete CMapMng member array layout that is already recovered in the header. The change removes indirect GetMapObjArray() pointer-walk shapes in functions where objdiff and Ghidra both point at direct member-array indexing.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/map -o - GetMapObjIdx__7CMapMngFUs
- build/tools/objdiff-cli diff -p . -u main/map -o - ShowMapObjID__7CMapMngFii
- build/tools/objdiff-cli diff -p . -u main/map -o - ShowMapMeshID__7CMapMngFii
- build/tools/objdiff-cli diff -p . -u main/map -o - SetMapObjPrioID__7CMapMngFiUc