### PR TITLE
Fix CUSBPcs table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -9,7 +9,7 @@ class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;
-    static unsigned int m_table[0x15C / sizeof(unsigned int)];
+    static unsigned int m_table[0x11C / sizeof(unsigned int)];
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -28,7 +28,7 @@ inline CUSBPcs::CUSBPcs()
     table[9] = desc2[2];
 }
 
-unsigned int CUSBPcs::m_table[0x15C / sizeof(unsigned int)] = {
+unsigned int CUSBPcs::m_table[0x11C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(sUsbPcsClassName)),
     0,
     0,


### PR DESCRIPTION
## Summary
- Correct `CUSBPcs::m_table` from `0x15C` bytes to the target `0x11C` bytes.
- This moves `s_CUSBPcsTablePad0`, `s_CUSBPcsTablePad1`, and `__vt__7CUSBPcs` to the target offsets in `p_usb.o`.

## Evidence
- `ninja` passes.
- `main/p_usb` objdiff `.data` improved from `88.631424%` to `95.94072%`.
- Source `.data` size moved from `452` to `388`, matching the target symbol layout for:
  - `m_table__7CUSBPcs`: `0x24`, size `0x11c`
  - `s_CUSBPcsTablePad0`: `0x140`, size `0xc`
  - `s_CUSBPcsTablePad1`: `0x14c`, size `0x14`
  - `__vt__7CUSBPcs`: `0x160`, size `0x24`

## Plausibility
The constructor only fills the first scenegraph descriptors, and the target object reports `m_table__7CUSBPcs` as `0x11C` bytes. The previous `0x15C` declaration was shifting adjacent data by `0x40` bytes.
