### PR TITLE
Match map mesh draw slices

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -225,12 +225,13 @@ void CMapMesh::Draw(CMaterialSet* materialSet)
 void CMapMesh::DrawMeshCharaShadow(unsigned short startIdx, unsigned short count)
 {
     int remaining = count;
+    CMapMng* mapMng = &MapMng;
     CMapMeshDrawEntry* entry = m_drawEntries + startIdx;
 
     while (remaining-- != 0) {
         if (entry->m_size != 0) {
             CMaterial* material =
-                (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(MapMng.m_materialSet) + 8))[
+                (*reinterpret_cast<CPtrArray<CMaterial*>*>(reinterpret_cast<unsigned char*>(mapMng->m_materialSet) + 8))[
                     entry->m_materialIdx];
 
             if ((*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(material) + 0x24) &
@@ -255,12 +256,13 @@ void CMapMesh::DrawMeshCharaShadow(unsigned short startIdx, unsigned short count
 void CMapMesh::DrawMesh(unsigned short startIdx, unsigned short count)
 {
     int remaining = count;
+    CMapMng* mapMng = &MapMng;
     CMapMeshDrawEntry* entry = m_drawEntries + startIdx;
 
     while (remaining-- != 0) {
         if (entry->m_size != 0) {
-            MaterialMan.SetBlendMode(MapMng.m_materialSet, entry->m_materialIdx);
-            MaterialMan.SetMaterial(MapMng.m_materialSet, entry->m_materialIdx, 0, (_GXTevScale)1);
+            MaterialMan.SetBlendMode(mapMng->m_materialSet, entry->m_materialIdx);
+            MaterialMan.SetMaterial(mapMng->m_materialSet, entry->m_materialIdx, 0, (_GXTevScale)1);
             GXCallDisplayList(entry->m_displayList, entry->m_size);
         }
         entry++;


### PR DESCRIPTION
## Summary
- Added a local CMapMng base in the two map mesh draw-slice helpers so MWCC keeps the same stable global base as the original code.
- Matches DrawMeshCharaShadow__8CMapMeshFUsUs and DrawMesh__8CMapMeshFUsUs without changing behavior or introducing manual linkage/data hacks.

## Objdiff evidence
- DrawMeshCharaShadow__8CMapMeshFUsUs: 62.92857% -> 100.0%
- DrawMesh__8CMapMeshFUsUs: 70.318184% -> 100.0%
- main/mapmesh .text: 97.0745% -> 99.808975%
- main/mapmesh extab: 98.07692% -> 100.0%
- main/mapmesh extabindex: 98.71795% -> 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/mapmesh -o - DrawMesh__8CMapMeshFUsUs
- build/tools/objdiff-cli diff -p . -u main/mapmesh -o - DrawMeshCharaShadow__8CMapMeshFUsUs

## Plausibility
This keeps the existing high-level member access and only names the map manager base once before walking the draw entries. The generated code now matches the original functions while remaining plausible C++ source.