### PR TITLE
Improve CalcOptionMenu input lifetime

### DIFF
--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -701,9 +701,9 @@ void CMenuPcs::CalcOptionMenu()
 {
 	unsigned char* const self = reinterpret_cast<unsigned char*>(this);
 	unsigned short press;
-	bool optionChanged = false;
+	unsigned int pressRaw;
 
-	press = GetMenuPress();
+	pressRaw = GetMenuPress();
 
 	signed char& menuState = *reinterpret_cast<signed char*>(self + 0x9C);
 	float& openAnim = *reinterpret_cast<float*>(self + 0x98);
@@ -720,6 +720,8 @@ void CMenuPcs::CalcOptionMenu()
 	signed char& rightHintTimer = *reinterpret_cast<signed char*>(self + 0x94);
 	int& specialModeEdit = *reinterpret_cast<int*>(self + 0xB0);
 	signed char& specialModeCursor = *reinterpret_cast<signed char*>(self + 0xB4);
+	press = static_cast<unsigned short>(pressRaw);
+	bool optionChanged = false;
 
 	if (menuState == 0) {
 		openAnim += kOptionOpenAnimStep;


### PR DESCRIPTION
## Summary
- keep the raw menu press value separate until after the option menu field aliases are established
- move the optionChanged initialization to match the lifetime/order indicated by the decompilation

## Evidence
- ninja passes for GCCP01
- objdiff main/MenuUtil CalcOptionMenu__8CMenuPcsFv: 84.154686% (2540b) -> 84.8125% (2540b)
- neighboring symbols unchanged: DrawOptionMenu__8CMenuPcsFv 0.037551634% (4b), DrawHelpMessageUS__8CMenuPcsFiP5CFontii8_GXColoriff 36.972466% (2800b)

## Plausibility
- this is a source-lifetime/order change only; behavior is unchanged
- the raw/narrowed input split better matches the original code shape around the inlined pad read and menu-state setup