### PR TITLE
Improve TmpArtiOpen row math

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -421,7 +421,7 @@ unsigned int CMenuPcs::TmpArtiOpen()
 			entry[0].width = 200;
 			entry[0].height = 0x28;
 			entry[0].x = (short)(int)-(((double)entry[0].width * half) - center);
-			entry[0].y = (short)row * (entry[0].height - 8) + 0x60;
+			entry[0].y = row * (entry[0].height - 8) + 0x60;
 			entry[0].s = zero;
 			entry[0].t = zero;
 			entry[0].startFrame = row++;
@@ -430,7 +430,7 @@ unsigned int CMenuPcs::TmpArtiOpen()
 			entry[1].width = 200;
 			entry[1].height = 0x28;
 			entry[1].x = (short)(int)-(((double)entry[1].width * half) - center);
-			entry[1].y = (short)row * (entry[1].height - 8) + 0x60;
+			entry[1].y = row * (entry[1].height - 8) + 0x60;
 			entry[1].s = zero;
 			entry[1].t = zero;
 			entry[1].startFrame = row++;


### PR DESCRIPTION
## Summary
- remove premature short casts from TmpArtiOpen row position calculations
- lets the compiler keep the row index as an int until the final short field assignment, matching the target more closely

## Evidence
- ninja
- TmpArtiOpen__8CMenuPcsFv: 85.132355% -> 85.40196% match, size unchanged at 816 bytes
- Adjacent TmpArtiDraw, TmpArtiClose, and TmpArtiCtrl scores unchanged in objdiff

## Plausibility
- the y fields are already short, so truncation still happens at the assignment
- avoiding an intermediate short cast removes extra sign-extension while preserving source-level intent