### PR TITLE
Fix CUSBPcs table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -9,7 +9,7 @@ class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;
-    static unsigned int m_table[0x15C / sizeof(unsigned int)];
+    static unsigned int m_table[0x11C / sizeof(unsigned int)];
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -28,7 +28,7 @@ inline CUSBPcs::CUSBPcs()
     table[9] = desc2[2];
 }
 
-unsigned int CUSBPcs::m_table[0x15C / sizeof(unsigned int)] = {
+unsigned int CUSBPcs::m_table[0x11C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(sUsbPcsClassName)),
     0,
     0,


### PR DESCRIPTION
## Summary
- Shrink `CUSBPcs::m_table` from `0x15C` bytes to `0x11C` bytes in the declaration and definition.
- This matches the original `p_usb.o` table size and moves compiler-emitted `__vt__7CUSBPcs` back to the original `.data+0x160` offset.

## Evidence
- `ninja` passes.
- Original object: `.data = 0x188`, `m_table__7CUSBPcs = 0x11C`, `__vt__7CUSBPcs @ .data:0x160`.
- Rebuilt object: `.data = 0x184`, `m_table__7CUSBPcs = 0x11C`, `__vt__7CUSBPcs @ .data:0x160`.
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o /tmp/p_usb_final.json --format json-pretty` reports `.data` fuzzy match `95.94072%` and `m_table__7CUSBPcs` `100.0%`.

## Plausibility
The change corrects a static table size used by normal source declarations. It does not manually define or force vtables, RTTI, constructors, destructors, or sections.
