### PR TITLE
Improve memory card CRC match

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1450,9 +1450,9 @@ unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
 unsigned int CMemoryCardMan::ChkCrc(Mc::SaveDat* saveData)
 {
     unsigned int crc;
+    unsigned char* crcData;
     int count;
     unsigned char* ptr;
-    unsigned char* crcData;
     unsigned char* data = (unsigned char*)saveData;
 
     if (data == nullptr)


### PR DESCRIPTION
## Summary
- Reorder ChkCrc locals to better match the target register allocation
- Improves the memorycard ChkCrc objdiff score without changing behavior

## Evidence
- ninja: passes
- objdiff main/memorycard ChkCrc__14CMemoryCardManFPQ22Mc7SaveDat: 98.04348% -> 99.23913% (184 bytes)
- Checked nearby near-miss memorycard functions remained unchanged: DebugReadWrite 99.12698%, DummyLoad 97.80085%, DummySave 96.66009%

## Plausibility
- This keeps the existing CRC logic intact and only adjusts local declaration order, matching the compiler's allocation pattern for the original source shape.