### PR TITLE
Improve sound CLine calc source shape

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -167,31 +167,31 @@ extern "C" int Calc__9CLine(float maxDistance, CLine<10>* line, Vec* outPos, flo
     u32 bestIndex = 0;
     float bestT = kLineSegmentMinT;
     Vec bestPos;
-    Vec* point = line->points;
-    CLineSegment* segment = line->segments;
 
-    for (u32 i = 0; i < line->pointCount - 1; i++, point++, segment++) {
-        const Vec* candidate = point;
+    for (u32 i = 0; i + 1 < line->pointCount; i++) {
+        Vec* candidate = &line->points[i];
         float distanceSq = PSVECSquareDistance(candidate, queryPos);
         if (distanceSq < maxDistanceSq || infiniteRange) {
+            Vec candidatePosition = *candidate;
             float distance = sqrtf(distanceSq);
             if (distance < bestDistance) {
                 bestDistance = distance;
-                bestPos = *candidate;
+                bestPos = candidatePosition;
                 bestIndex = i;
                 bestT = kLineSegmentMinT;
                 found = 1;
             }
         }
 
-        if (i == line->pointCount - 2) {
-            candidate = point + 1;
+        if (i + 1 == line->pointCount - 1) {
+            candidate = &line->points[i + 1];
             distanceSq = PSVECSquareDistance(candidate, queryPos);
             if (distanceSq < maxDistanceSq || infiniteRange) {
+                Vec candidatePosition = *candidate;
                 float distance = sqrtf(distanceSq);
                 if (distance < bestDistance) {
                     bestDistance = distance;
-                    bestPos = *candidate;
+                    bestPos = candidatePosition;
                     bestIndex = i;
                     bestT = kLineSegmentMaxT;
                     found = 1;
@@ -199,14 +199,15 @@ extern "C" int Calc__9CLine(float maxDistance, CLine<10>* line, Vec* outPos, flo
             }
         }
 
-        const float dotQuery = PSVECDotProduct(queryPos, &segment->delta);
-        const float dotStart = PSVECDotProduct(point, &segment->delta);
-        const float t = (dotQuery - dotStart) / (segment->length * segment->length);
+        CLineSegment& segment = line->segments[i];
+        const float dotQuery = PSVECDotProduct(queryPos, &segment.delta);
+        const float dotStart = PSVECDotProduct(&line->points[i], &segment.delta);
+        const float t = (dotQuery - dotStart) / (segment.length * segment.length);
         if (((kLineSegmentMinT <= t) && (t <= kLineSegmentMaxT)) || infiniteRange) {
             Vec scaled;
             Vec projected;
-            PSVECScale(&segment->delta, &scaled, t);
-            PSVECAdd(point, &scaled, &projected);
+            PSVECScale(&segment.delta, &scaled, t);
+            PSVECAdd(&line->points[i], &scaled, &projected);
             const float distance = PSVECDistance(queryPos, &projected);
             if (distance < bestDistance) {
                 bestDistance = distance;


### PR DESCRIPTION
## Summary
- Rework `Calc__9CLine` to use indexed `CLine` member access and candidate copies matching the existing `CLine<64>::Calc` source pattern.
- Keep behavior and function size unchanged while improving the sound unit objdiff score.

## Objdiff Evidence
- `Calc__9CLine`: 87.01049% -> 88.58741% (size 1144b unchanged)
- `CalcBound__9CLine2`: unchanged at 85.454544%
- `ChangeSe3DPitch__6CSoundFiii`: unchanged at 87.67242%
- `main/sound` final one-shot `.text`: 95.79132%

## Plausibility
- The new source shape mirrors the already-present `CLine<64>::Calc` implementation in `cflat_r2system.cpp`, using direct indexed point/segment access instead of pointer walking.
- This is a clearer template-style line nearest-point implementation and not a forced section, fake symbol, or address hack.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/sound -o /tmp/sound_final.json Calc__9CLine`
