### PR TITLE
Improve texanim constructor constant usage

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -177,13 +177,14 @@ inline CTexAnim::CRefData::CRefData()
  */
 inline CTexAnim::CTexAnim()
 {
+    const float& zero = FLOAT_8032fb38;
     m_refData = 0;
     m_seqIndex = 0;
-    m_frame = FLOAT_8032fb38;
+    m_frame = zero;
     m_mode = -2;
-    m_chin = FLOAT_8032fb38;
-    m_texGenT = FLOAT_8032fb38;
-    m_texGenS = FLOAT_8032fb38;
+    m_chin = zero;
+    m_texGenT = zero;
+    m_texGenS = zero;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Use a local reference to the shared zero constant in the inline CTexAnim constructor.
- This makes constructor inline expansions in texanim load FLOAT_8032fb38 instead of emitting a local zero literal.

## Evidence
- ninja passes.
- main/texanim objdiff improvements:
  - Duplicate__11CTexAnimSetFPQ27CMemory6CStage: 98.52273% -> 98.579544%
  - Create__11CTexAnimSetFR10CChunkFilePQ27CMemory6CStage: 74.844444% -> 74.86667%

## Plausibility
- Matches the existing CTexAnimSet constructor style in this file, which already takes FLOAT_8032fb38 through a local reference.
- No section forcing, symbol hacks, or address-based changes.