### PR TITLE
Fix maptexanim conversion constant

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -30,7 +30,7 @@ char s_SetMapTexAnim_MaterialIdNotFound[];
 extern "C" float FLOAT_8032fd38;
 extern "C" float FLOAT_8032fd48;
 extern "C" float FLOAT_8032fd4c;
-extern "C" const double DOUBLE_8032FCD0 = 4503599627370496.0;
+extern "C" const double DOUBLE_8032FCD0 = 4503601774854144.0;
 extern "C" const float FLOAT_8032FCD8 = 0.0f;
 
 namespace {


### PR DESCRIPTION
## Summary
- Correct DOUBLE_8032FCD0 in src/maptexanim.cpp to the signed int-to-double bias used by the target object.
- This fixes the main/maptexanim .sdata2 data mismatch without changing code generation.

## Evidence
- Before: .sdata2 91.666664%, DOUBLE_8032FCD0 87.5%.
- After: .sdata2 100.0%, DOUBLE_8032FCD0 100.0%.
- ninja passes.

## Plausibility
- The constant is the standard Metrowerks signed conversion bias, 0x4330008000000000, matching the target data layout rather than coaxing instruction output.