### PR TITLE
Improve MaterialEditor table initialization

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -36,30 +36,30 @@ unsigned int CMaterialEditorPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_
 unsigned int CMaterialEditorPcs::m_table_desc1[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroyViewer__18CMaterialEditorPcsFv)};
 unsigned int CMaterialEditorPcs::m_table_desc2[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcViewer__18CMaterialEditorPcsFv)};
 unsigned int CMaterialEditorPcs::m_table_desc3[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__18CMaterialEditorPcsFv)};
+u8 gMaterialEditorPcsGuard[0xC];
+CMaterialEditorPcs MaterialEditorPcs;
 
 unsigned int CMaterialEditorPcs::m_table[0x15C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(s_CMaterialEditorPcsViewer)),
-    0,
-    0xFFFFFFFF,
-    reinterpret_cast<unsigned int>(createViewer__18CMaterialEditorPcsFv),
-    0,
-    0xFFFFFFFF,
-    reinterpret_cast<unsigned int>(destroyViewer__18CMaterialEditorPcsFv),
-    0,
-    0xFFFFFFFF,
-    reinterpret_cast<unsigned int>(calcViewer__18CMaterialEditorPcsFv),
+    m_table_desc0[0],
+    m_table_desc0[1],
+    m_table_desc0[2],
+    m_table_desc1[0],
+    m_table_desc1[1],
+    m_table_desc1[2],
+    m_table_desc2[0],
+    m_table_desc2[1],
+    m_table_desc2[2],
     0x20,
     0,
-    0,
-    0xFFFFFFFF,
-    reinterpret_cast<unsigned int>(drawViewer__18CMaterialEditorPcsFv),
+    m_table_desc3[0],
+    m_table_desc3[1],
+    m_table_desc3[2],
     0x41,
     1
 };
 unsigned int s_CMaterialEditorPcsTablePad0[3] = {reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E648)), 0, 0};
 unsigned int s_CMaterialEditorPcsTablePad1[5] = {reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E648)), 0, reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CProcess_8032E650)), 0, 0};
-u8 gMaterialEditorPcsGuard[0xC];
-CMaterialEditorPcs MaterialEditorPcs;
 
 
 extern "C" const double DOUBLE_8032FCC0 = 1.0;


### PR DESCRIPTION
## Summary
- Reuse the existing MaterialEditor table descriptor arrays when initializing CMaterialEditorPcs::m_table instead of flattening duplicate entries.
- Move MaterialEditorPcs storage earlier in source order so static initialization constructs/registers the object before filling the table, matching the target initializer order more closely.

## Evidence
- ninja passes.
- Objdiff: build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - __sinit_p_MaterialEditor_cpp
- m_table__18CMaterialEditorPcs: 91.30435% -> 100.0%
- .data: 93.02187% -> 99.54361%
- __sinit_p_MaterialEditor_cpp: 33.7% -> 69.62857%
- .text: 77.14955% -> 79.020836%

## Plausibility
This matches a normal original-source pattern: the process table is built from reusable descriptor arrays, and the generated static initializer performs the descriptor copies after constructing the global MaterialEditorPcs object.