### PR TITLE
Improve menu repeat input typing

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -198,7 +198,7 @@ int CMenuPcs::ArtiCtrlCur()
 {
 	int sVar1;
 	bool bVar2;
-	int uVar4;
+	u16 uVar4;
 	int uVar3;
 	int iVar5;
 	int iVar6;

--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -1288,7 +1288,7 @@ unsigned int CMenuPcs::CmdCtrlCur()
 {
 	bool blocked = false;
 	unsigned int press;
-	unsigned int hold;
+	u16 hold;
 	int caravanWork = Game.m_scriptFoodBase[0];
 
 	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -1705,7 +1705,7 @@ int CMenuPcs::LetterCtrlCur()
 {
 	bool blocked = false;
 	unsigned int press;
-	unsigned int hold;
+	u16 hold;
 	int caravanWork = Game.m_scriptFoodBase[0];
 
 	if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -263,7 +263,7 @@ int CMenuPcs::MLstCtrl()
 	bool blocked;
 	float one;
 	unsigned int press;
-	unsigned int hold;
+	u16 hold;
 	unsigned int itemCount;
 	unsigned int chunkCount;
 	int i;


### PR DESCRIPTION
## Summary
- Narrow repeat-button temporaries to `u16` in menu cursor/controller handlers where values come from `Pad.GetPadInputs()[...].repeatButton`
- Keep button-down temporaries unchanged where testing showed they regress codegen

## Objdiff evidence
- `main/menu_arti` `ArtiCtrlCur__8CMenuPcsFv`: 97.0936% -> 97.36453%
- `main/menu_cmd` `CmdCtrlCur__8CMenuPcsFv`: 50.149506% -> 50.454163%
- `main/menu_lst` `MLstCtrl__8CMenuPcsFv`: 94.97758% -> 95.246635%
- `main/menu_letter` `LetterCtrlCur__8CMenuPcsFv`: 18.57336% -> 19.279917%

## Plausibility
`repeatButton` is declared as `u16` in the pad input structure, so these changes make the local temporaries match the real field width instead of carrying them as wider unsigned ints.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/menu_arti -o -`
- `build/tools/objdiff-cli diff -p . -u main/menu_cmd -o -`
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o -`
- `build/tools/objdiff-cli diff -p . -u main/menu_letter -o -`