### PR TITLE
Match SetParticleWorkVector add order

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -2186,7 +2186,7 @@ void CFlatRuntime2::SetParticleWorkVector(float angle1, float angle2)
 
 	float sinAngle2 = static_cast<float>(sin(angle2));
 	*reinterpret_cast<float*>(runtime + 0x1768) =
-		sinAngle2 + *reinterpret_cast<float*>(runtime + 0x1744);
+		*reinterpret_cast<float*>(runtime + 0x1744) + sinAngle2;
 
 	cosAngle2 = static_cast<float>(cos(angle2));
 	float cosAngle1 = static_cast<float>(cos(angle1));


### PR DESCRIPTION
## Summary
- Reordered the Y component addition in `CFlatRuntime2::SetParticleWorkVector` so MWCC emits the target `fadds` operand order.
- This matches `SetParticleWorkVector__13CFlatRuntime2Fff` without changing behavior.

## Evidence
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - SetParticleWorkVector__13CFlatRuntime2Fff`: `100.0%`, size `200`.
- `ninja`: passes.
- Progress after rebuild: matched functions `3473 / 4732`, matched code `599328 / 1855224` bytes.

## Plausibility
- The change is only commutative source expression ordering for the existing vector Y component calculation.
- No hardcoded addresses, fake symbols, or section forcing.