### PR TITLE
Use CNode matrix fields in mana reflection

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -629,16 +629,16 @@ void CalcReflectionVector2(
     cameraPos.z = CameraWorldZ();
 
     PSMTXCopy(matrix, nodeMtx);
-    nodeOffset.x = *(float*)((char*)node + 0x78);
-    nodeOffset.y = *(float*)((char*)node + 0x88);
-    nodeOffset.z = *(float*)((char*)node + 0x98);
+    nodeOffset.x = node->m_mtx[0][3];
+    nodeOffset.y = node->m_mtx[1][3];
+    nodeOffset.z = node->m_mtx[2][3];
 
     worldPos.x = nodeMtx[0][3];
     worldPos.y = nodeMtx[1][3];
     worldPos.z = nodeMtx[2][3];
     PSVECAdd(&nodeOffset, &worldPos, &worldPos);
 
-    PSMTXCopy((float(*)[4])((char*)node + 0x6C), matrix);
+    PSMTXCopy(node->m_mtx, matrix);
     matrix[0][3] = worldPos.x;
     matrix[1][3] = worldPos.y;
     matrix[2][3] = worldPos.z;

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1656,8 +1656,8 @@ void CalcReflectionVector2(
     cameraPos.z = CameraWorldZ();
 
     PSMTXCopy(matrix, matrixCopy);
-    PSMTXCopy((float (*)[4])((u8*)node + 0x14), nodeOffsetMtx);
-    PSMTXCopy((float (*)[4])((u8*)node + 0x6C), workMtx);
+    PSMTXCopy(node->m_localRuntimeMtx, nodeOffsetMtx);
+    PSMTXCopy(node->m_mtx, workMtx);
 
     nodePos.x = workMtx[0][3];
     nodePos.y = workMtx[1][3];


### PR DESCRIPTION
## Summary
- Replace raw CNode matrix offsets in pppMana2 CalcReflectionVector2 with CNode::m_mtx access.
- Replace raw CNode matrix offsets in pppYmMana CalcReflectionVector2 with CNode::m_localRuntimeMtx and CNode::m_mtx access.
- Keeps generated code stable while recovering real struct/member access around the Mana reflection mismatch cluster.

## Evidence
- ninja passes.
- pppMana2 CalcReflectionVector2 remains 73.15686% / 1428b.
- pppYmMana CalcReflectionVector2 remains 73.63928% / 1120b.

## Plausibility
These offsets correspond to the existing CChara::CNode layout in include/ffcc/chara.h: m_localRuntimeMtx at 0x14 and m_mtx at 0x6C. This removes pointer-offset tricks in favor of fields the original source likely used.