### PR TITLE
Improve item object memory name color temp

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -297,8 +297,7 @@ void CGItemObj::DrawOmoideName(CFont* font)
 			font->SetTlut(7);
 
 			int alphaInt = (int)(255.0f * *(float*)(self + 0x4B0));
-			CColor textColor(0xFF, 0xFF, 0xFF, alphaInt);
-			font->SetColor(textColor.color);
+			font->SetColor(CColor(0xFF, 0xFF, 0xFF, alphaInt).color);
 
 			const ItemObjFlatData* flatData = reinterpret_cast<const ItemObjFlatData*>(&Game.m_cFlatDataArr[1]);
 			const char* name = flatData->table[2].index[*(int*)(self + 0x570)];


### PR DESCRIPTION
## Summary
- Use an inline CColor temporary when setting the memory item name color in CGItemObj::DrawOmoideName.
- This matches the target temporary/copy shape more closely and removes stack-slot-related instruction differences.

## Objdiff Evidence
- Unit: main/itemobj
- Symbol: DrawOmoideName__9CGItemObjFP5CFont
- Before: 98.64151% fuzzy, 12 instruction diffs
- After: 99.00944% fuzzy in build report; direct objdiff shows 8 instruction diffs

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/itemobj -o /tmp/itemobj_omoide_final.json DrawOmoideName__9CGItemObjFP5CFont