### PR TITLE
Match pppBlurChara render setup

### DIFF
--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -134,8 +134,7 @@ void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppB
     cameraTarget.x = CameraPcs.m_targetX;
     cameraTarget.y = CameraPcs.m_targetY;
     cameraTarget.z = CameraPcs.m_targetZ;
-    cameraPos.y = FLOAT_80331030;
-    cameraTarget.y = FLOAT_80331030;
+    cameraTarget.y = cameraPos.y = FLOAT_80331030;
     PSVECSubtract(&cameraTarget, &cameraPos, &cameraDir);
     cameraDir.y = FLOAT_80331030;
 
@@ -194,11 +193,11 @@ void pppRenderBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppB
     GXSetCurrentMtx(0);
 
     PSMTX44Identity(projection);
-    projection[2][2] = FLOAT_8033103c;
     projection[0][0] = FLOAT_80331034;
     projection[1][1] = FLOAT_80331038;
+    projection[2][2] = FLOAT_8033103c;
     projection[0][3] = FLOAT_80331040;
-    projection[1][3] = FLOAT_8033103c;
+    projection[1][3] = projection[2][2];
     projection[2][3] = FLOAT_80331030;
     GXSetProjection(projection, GX_ORTHOGRAPHIC);
     GXSetZMode(GX_TRUE, GX_LEQUAL, GX_FALSE);


### PR DESCRIPTION
## Summary
- Match `pppRenderBlurChara` by using the original chained zero assignment for flattened camera Y values.
- Reuse `projection[2][2]` for the orthographic matrix `1.0f` slot so the matrix setup schedules like the target.

## Evidence
- Before: `main/pppBlurChara` was 99.87371% fuzzy match, 5/6 functions matched; `pppRenderBlurChara` was 99.73151%.
- After `ninja`: `main/pppBlurChara` is 100.0% code, 100.0% data, 6/6 functions matched; `pppRenderBlurChara` is 100.0%.
- Overall progress after build: code matched 601148 / 1855224 bytes, functions 3476 / 4732.

## Plausibility
- The changes preserve source-level behavior and express shared values directly rather than introducing addresses, fake symbols, or section tricks.
- The orthographic matrix write now naturally derives the repeated `1.0f` entry from the already-written matrix cell.