### PR TITLE
Fix pppCharaBreak constant ownership

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -18,22 +18,22 @@
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdlib.h>
 #include "ffcc/ppp_linkage.h"
 
-extern Vec kPppCharaBreakUpVector = {0.0f, 1.0f, 0.0f};
-extern int kCharaBreakInitialVertexFlag0 = 0;
-extern int kCharaBreakInitialVertexFlag1 = 0;
-extern int kCharaBreakInitialVertexFlag2 = 0;
+extern Vec kPppCharaBreakUpVector;
+extern int kCharaBreakInitialVertexFlag0;
+extern int kCharaBreakInitialVertexFlag1;
+extern int kCharaBreakInitialVertexFlag2;
 extern "C" const char s_pppCharaBreak_cpp[] = "pppCharaBreak.cpp";
-extern const float FLOAT_80332048 = 0.0f;
-extern const float FLOAT_8033204c = 1.0f;
-extern const float FLOAT_80332050 = -10000.0f;
-extern const char sPppCharaBreakObjMeshName[4] = "obj";
-extern const float FLOAT_80332058 = 0.333333313f;
-extern const float FLOAT_8033205c = 0.017453292f;
-extern const float FLOAT_80332060 = 180.0f;
-extern const float FLOAT_80332064 = 0.8f;
-extern const double DOUBLE_80332068 = 4503601774854144.0;
-extern const double DOUBLE_80332070 = 4503599627370496.0;
-extern const float FLOAT_80332078 = -1.0f;
+extern const float FLOAT_80332048;
+extern const float FLOAT_8033204c;
+extern const float FLOAT_80332050;
+extern const char sPppCharaBreakObjMeshName[4];
+extern const float FLOAT_80332058;
+extern const float FLOAT_8033205c;
+extern const float FLOAT_80332060;
+extern const float FLOAT_80332064;
+extern const double DOUBLE_80332068;
+extern const double DOUBLE_80332070;
+extern const float FLOAT_80332078;
 
 static inline Mtx& CameraMatrix()
 {


### PR DESCRIPTION
## Summary
- Convert pppCharaBreak's neighboring rodata/sdata2 symbols from local definitions to extern declarations.
- This matches the target object's ownership: pppCharaBreak.o imports these constants from the adjacent auto-generated data objects instead of defining them itself.

## Objdiff Evidence
Unit: main/pppCharaBreak
- .text: 92.95481% -> 93.04196%
- pppRenderCharaBreak: 99.90385% -> 100.0%
- pppFrameCharaBreak: 96.90176% -> 96.954384%
- pppConstruct2CharaBreak: 99.583336% -> 100.0%
- pppConstructCharaBreak: 99.6875% -> 100.0%
- UpdatePolygonData: 83.52612% -> 83.60721%
- InitPolygonParameter: 99.70444% -> 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o /tmp/pppCharaBreak.final.json pppRenderCharaBreak
- git diff --check