### PR TITLE
Fix pppCharaBreak constant linkage

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -23,17 +23,17 @@ extern int kCharaBreakInitialVertexFlag0 = 0;
 extern int kCharaBreakInitialVertexFlag1 = 0;
 extern int kCharaBreakInitialVertexFlag2 = 0;
 extern "C" const char s_pppCharaBreak_cpp[] = "pppCharaBreak.cpp";
-extern const float FLOAT_80332048 = 0.0f;
-extern const float FLOAT_8033204c = 1.0f;
-extern const float FLOAT_80332050 = -10000.0f;
-extern const char sPppCharaBreakObjMeshName[4] = "obj";
-extern const float FLOAT_80332058 = 0.333333313f;
-extern const float FLOAT_8033205c = 0.017453292f;
-extern const float FLOAT_80332060 = 180.0f;
-extern const float FLOAT_80332064 = 0.8f;
-extern const double DOUBLE_80332068 = 4503601774854144.0;
-extern const double DOUBLE_80332070 = 4503599627370496.0;
-extern const float FLOAT_80332078 = -1.0f;
+extern const float FLOAT_80332048;
+extern const float FLOAT_8033204c;
+extern const float FLOAT_80332050;
+extern const char sPppCharaBreakObjMeshName[4];
+extern const float FLOAT_80332058;
+extern const float FLOAT_8033205c;
+extern const float FLOAT_80332060;
+extern const float FLOAT_80332064;
+extern const double DOUBLE_80332068;
+extern const double DOUBLE_80332070;
+extern const float FLOAT_80332078;
 
 static inline Mtx& CameraMatrix()
 {


### PR DESCRIPTION
## Summary
- Change pppCharaBreak sdata2 constants from definitions to external declarations.
- This matches the split ownership: pppCharaBreak.cpp does not claim .sdata2, and the target object references the named constants externally instead of emitting local duplicate constants.

## Objdiff Evidence
- pppRenderCharaBreak: 99.90385% -> 100.0%
- pppConstruct2CharaBreak: 99.583336% -> 100.0%
- pppConstructCharaBreak: 99.6875% -> 100.0%
- InitPolygonParameter: 99.70444% -> 100.0%
- pppFrameCharaBreak: 96.90176% -> 96.954384%
- UpdatePolygonData: 83.52612% -> 83.60721%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - pppRenderCharaBreak
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - pppConstruct2CharaBreak
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - pppConstructCharaBreak
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - InitPolygonParameter__FP11PCharaBreakP11VCharaBreakP12POLYGON_DATAUlPQ26CChara6CModelPQ26CChara5CMesh
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - pppFrameCharaBreak
- build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o - UpdatePolygonData__FP11PCharaBreakP11VCharaBreakPQ26CChara6CModel