### PR TITLE
Fix material editor base class

### DIFF
--- a/include/ffcc/p_MaterialEditor.h
+++ b/include/ffcc/p_MaterialEditor.h
@@ -1,7 +1,7 @@
 #ifndef _FFCC_P_MATERIALEDITOR_H_
 #define _FFCC_P_MATERIALEDITOR_H_
 
-#include "ffcc/p_sample.h"
+#include "ffcc/system.h"
 #include "ffcc/memory.h"
 #include "ffcc/pppTypes.h"
 #include "ffcc/USBStreamData.h"
@@ -29,7 +29,7 @@ struct RSDLISTITEM {
     int flag;
 };
 
-class CMaterialEditorPcs : public CSamplePcs
+class CMaterialEditorPcs : public CProcess
 {
 public:
     static unsigned int m_table_desc0[3];

--- a/src/ME_AppRequest.cpp
+++ b/src/ME_AppRequest.cpp
@@ -9,7 +9,7 @@ void* memset(void*, int, unsigned int);
 extern const char s_ME_AppRequest_cpp[] = "ME_AppRequest.cpp";
 
 struct ZCANMGRP {
-    void* ptr;
+    u8* ptr;
     int unk4;
     int unk8;
     int unkC;
@@ -147,9 +147,9 @@ void CMaterialEditorPcs::DeleteColAnmData(ZCANMGRP** colAnmData, int colAnmCount
     if (entry != (ZCANMGRP*)0) {
         int i = 0;
         while (i < colAnmCount) {
-            if (entry->ptr != (void*)0) {
-                delete[] static_cast<u8*>(entry->ptr);
-                entry->ptr = (void*)0;
+            if (entry->ptr != (u8*)0) {
+                delete[] entry->ptr;
+                entry->ptr = (u8*)0;
             }
             entry = entry + 1;
             i = i + 1;
@@ -265,9 +265,9 @@ void CMaterialEditorPcs::ResetRsdList(ZLIST* zlist)
         colAnmData = listItem->colAnmData;
         if (colAnmData != (ZCANMGRP*)0) {
             for (i = 0; i < colAnmCount; colAnmData++, i++) {
-                if (colAnmData->ptr != (void*)0) {
-                    delete[] static_cast<u8*>(colAnmData->ptr);
-                    colAnmData->ptr = (void*)0;
+                if (colAnmData->ptr != (u8*)0) {
+                    delete[] colAnmData->ptr;
+                    colAnmData->ptr = (u8*)0;
                 }
             }
             if (listItem->colAnmData != (ZCANMGRP*)0) {


### PR DESCRIPTION
## Summary
- Change CMaterialEditorPcs to derive directly from CProcess, matching the original static initializer shape that sets CManager/CProcess/CMaterialEditorPcs vtables without calling CSamplePcs construction.
- Type ZCANMGRP::ptr as u8* and remove casts in the material editor RSD cleanup paths.

## Evidence
- ninja: build/GCCP01/main.dol OK
- p_MaterialEditor __sinit_p_MaterialEditor_cpp improved from 69.62857% to 73.24286%.
- __sinit_p_MaterialEditor_cpp generated size moved from 256 bytes to 276 bytes against the 280-byte original.
- ME_AppRequest remains stable: ResetRsdList__18CMaterialEditorPcsFP5ZLIST stays 99.24051%, other functions remain matched.

## Plausibility
CMaterialEditorPcs owns its own process table and the original initializer does not run the CSamplePcs constructor. Direct CProcess inheritance preserves object layout because CSamplePcs adds no data, while removing the extra base-constructor call from generated code.