### PR TITLE
Improve part manager heap and PDT scans

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -972,10 +972,11 @@ void CPartMng::setProcSpeed(ProcSpdSt*, int)
 void CPartMng::drawEnd()
 {
     gPppHeapUseRateWords[0] = pppHeapCheckLeak__FPQ27CMemory6CStage2(pppEnvStPtr->m_stagePtr);
-    if ((gPppHeapUseRateWords[2] == 0)
-        || ((gPppHeapUseRateWords[2] = gPppHeapUseRateWords[2] - 1), gPppHeapUseRateWords[1] < gPppHeapUseRateWords[0])) {
-        gPppHeapUseRateWords[2] = *(int*)((char*)this + 0x16C) << 1;
+    int heapCheckCount = gPppHeapUseRateWords[2];
+    gPppHeapUseRateWords[2] = heapCheckCount - 1;
+    if ((heapCheckCount == 0) || (gPppHeapUseRateWords[1] < gPppHeapUseRateWords[0])) {
         gPppHeapUseRateWords[1] = gPppHeapUseRateWords[0];
+        gPppHeapUseRateWords[2] = *(int*)((char*)this + 0x16C) << 1;
     }
 }
 

--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -3759,13 +3759,17 @@ int CPartMng::pppLoadPdt(const char* baseName, int pdtSlotIndex, int cachePriori
 int CPartMng::pppGetFreeDataMng()
 {
     PppPdtSlot* freeSlot = 0;
-    for (int slotIndex = 8; slotIndex < 0x20; slotIndex++) {
-        PppPdtSlot* slot = &m_pdtSlots[slotIndex];
+    PppPdtSlot* slot = &m_pdtSlots[8];
+    int slotIndex = 8;
+    int count = 0x18;
+    do {
         if (slot->m_pppDataHead == 0) {
-            freeSlot = slot;
+            freeSlot = &m_pdtSlots[slotIndex];
             break;
         }
-    }
+        slot++;
+        slotIndex++;
+    } while (--count != 0);
 
     if (freeSlot == 0) {
         if ((unsigned int)System.m_execParam >= 1) {


### PR DESCRIPTION
## Summary
- Rework `CPartMng::pppGetFreeDataMng` to use the counted slot scan shape from the target code.
- Reorder `CPartMng::drawEnd` heap usage countdown/update logic to better match target instruction order.

## Evidence
- `pppGetFreeDataMng__8CPartMngFv`: 7.09434% -> 91.73585%
- `drawEnd__8CPartMngFv`: 72.166664% -> 98.0%
- `main/partMng` .text: 52.947193% -> 53.591766%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/partMng -o -`