### PR TITLE
Fix textureman ptrarray string ownership

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -17,9 +17,8 @@ inline void* operator new(unsigned long, void* p)
 extern "C" const char s_textureman_cpp[] = "textureman.cpp";
 static const char s_Error_width_pctd_height_pctd_801D7984[] = "Error width=%d height=%d\n";
 static const char s_CTexture_texture_801D79A0[] = "CTexture.texture";
-static const char s_ptrarray_grow_error_801D79D8[] =
-    "\x83\x6F\x83\x62\x83\x74\x83\x40\x90\xAC\x92\xB7\x82\xAA\x95\x73\x8B\x96\x89\xC2\x82\xC5\x82\xB7\x81\x42\x0A";
-static const char s_collection_ptrarray_h_801D79F4[] = "collection_ptrarray.h";
+extern const char s_ptrarray_grow_error_801D79D8[];
+extern const char s_collection_ptrarray_h_801D79F4[];
 extern const char s_CRef_8032FAE8[];
 extern const float FLOAT_8032faf0;
 extern const float FLOAT_8032faf4;


### PR DESCRIPTION
## Summary
- Treat textureman CPtrArray diagnostic strings as extern references instead of defining them in textureman.o.
- Matches build MAP ownership: these strings live in auto_06_801D79B4_rodata.o, not textureman.o.

## Evidence
- `ninja`: build succeeds and `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/textureman -o /tmp/textureman_final.json --format json-pretty`:
  - current source-side `.rodata` shrank from 188 bytes to 136 bytes; target remains 64 bytes.
  - `[.rodata-0]` match improved from 50.793655% to 64.0%.
  - textureman code scores are unchanged.

## Plausibility
- This removes source-owned definitions for data that the MAP attributes to an auto rodata object, replacing them with normal symbol references.
- No manual section forcing, fake labels, or constructor/destructor hacks.