### PR TITLE
Improve Ryj mega birth draw alpha

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -486,7 +486,8 @@ void pppRyjDrawMegaBirth(_pppPObject* obj, void* stepData, _pppCtrlTable* ctrlTa
 			red = baseRed + (int)*(s8*)((u8*)particle + 0x24);
 			green = baseGreen + (int)*(s8*)((u8*)particle + 0x25);
 			blue = baseBlue + (int)*(s8*)((u8*)particle + 0x26);
-			alpha = baseAlpha + (int)*(s8*)((u8*)particle + 0x27) - (int)*f32_at(particle, 0x54);
+			alpha = (int)(
+				(float)(baseAlpha + (int)*(s8*)((u8*)particle + 0x27)) - *f32_at(particle, 0x54));
 
 			if (colorData != NULL) {
 				red += (int)colorData->m_color[0];


### PR DESCRIPTION
## Summary
- Compute pppRyjDrawMegaBirth alpha by subtracting the particle fade in float before converting to int.
- This matches the target code shape more closely than truncating the fade first.

## Objdiff Evidence
- Unit main/pppRyjMegaBirth .text: 81.766785% -> 82.602684%
- pppRyjDrawMegaBirth: 85.68389% -> 90.79331% (diffs now 129)
- birth__FP11_pppPObjectP13VRyjMegaBirthP13PRyjMegaBirthP6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR: unchanged at 71.42614%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRyjMegaBirth -o - --format json pppRyjDrawMegaBirth
