### PR TITLE
Improve CLightPcs AddBump falloff match

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -371,6 +371,7 @@ void CLightPcs::Add(CLightPcs::CLight* light)
 CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs::TARGET target,
                                           CMemory::CStage* stage, int count)
 {
+    float minFalloff = FLOAT_8032fc10;
     CBumpLight* bumpLight = 0;
     CBumpLight* bumpLights = &m_bumpLights[target * 8];
 
@@ -390,7 +391,7 @@ CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs
 
     *static_cast<CLight*>(bumpLight) = *srcLight;
 
-    if (FLOAT_8032fc10 <= bumpLight->m_attenFalloff) {
+    if (minFalloff <= bumpLight->m_attenFalloff) {
         bumpLight->m_attenFalloff = bumpLight->m_attenRadius;
     }
 


### PR DESCRIPTION
## Summary
- Hoist the AddBump falloff threshold into a local before searching for an available bump light slot.
- This better matches the original function shape while keeping the existing behavior and clean source structure.

## Evidence
- Build: `ninja` passes.
- Objdiff: `AddBump__9CLightPcsFPQ29CLightPcs6CLightQ29CLightPcs6TARGETPQ27CMemory6CStagei` improves from 93.85909% to 94.76818%.
- Current `main/p_light` sections: .text 90.98099%, .data 93.06551%, .bss 100.0%.

## Plausibility
- The change is a normal source-level local for the shared falloff threshold, not a section or symbol hack.
- It matches the nearby decompiled structure where `FLOAT_8032fc10` is materialized before the bump-light slot search.