### PR TITLE
Mark pppAlignmentScale as matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -581,7 +581,7 @@ config.libs = [
             Object(NonMatching, "partMng.cpp"),
             Object(NonMatching, "partyobj.cpp"),
             Object(Matching, "pppAccele.cpp"),
-            Object(NonMatching, "pppAlignmentScale.cpp"),
+            Object(Matching, "pppAlignmentScale.cpp"),
             Object(Matching, "pppAngAccele.cpp"),
             Object(Matching, "pppAngle.cpp"),
             Object(Matching, "pppAngMove.cpp"),


### PR DESCRIPTION
## Summary
- Promote `pppAlignmentScale.cpp` from `NonMatching` to `Matching`.
- This is linkage-only progress; source output was already exact for the unit.

## Evidence
- `ninja` passes and `build/GCCP01/main.dol: OK`.
- Linked progress increased from 315/641 to 316/641 files.
- Game linked progress increased from 110/265 to 111/265 files.
- `objdiff-cli diff -p . -u main/pppAlignmentScale -o -`: extab, extabindex, .text, and .sdata2 are all 100%.

## Plausibility
- No C/C++ behavior changed; this only updates the build configuration to reflect an already exact unit.
- I tested other 100% report units, but left them non-matching when link/checksum validation failed.