### PR TITLE
Improve MaterialEditor cleanup loop matching

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -556,14 +556,16 @@ void CMaterialEditorPcs::destroyViewer()
     m_loadedTextureCount = 0;
 
     unsigned int textureIndex = 0;
+    CMaterialEditorPcs* iter = this;
     do {
-        MemFree(m_textureData[textureIndex]);
-        MemFree(m_tlutData[textureIndex]);
-        MemFree(m_texObj[textureIndex]);
-        MemFree(m_tlutObj0[textureIndex]);
-        MemFree(m_tlutObj1[textureIndex]);
-        MemFree(m_textureHeader[textureIndex]);
+        MemFree(iter->m_textureData[0]);
+        MemFree(iter->m_tlutData[0]);
+        MemFree(iter->m_texObj[0]);
+        MemFree(iter->m_tlutObj0[0]);
+        MemFree(iter->m_tlutObj1[0]);
+        MemFree(iter->m_textureHeader[0]);
         textureIndex += 1;
+        iter = reinterpret_cast<CMaterialEditorPcs*>(reinterpret_cast<unsigned char*>(iter) + 4);
     } while (textureIndex < 0x10);
 
     Memory.DestroyStage(m_stage);
@@ -629,15 +631,17 @@ void CMaterialEditorPcs::Quit()
 {
     unsigned int textureIndex;
     m_loadedTextureCount = static_cast<s8>(textureIndex = 0);
+    CMaterialEditorPcs* iter = this;
 
     do {
-        MemFree(m_textureData[textureIndex]);
-        MemFree(m_tlutData[textureIndex]);
-        MemFree(m_texObj[textureIndex]);
-        MemFree(m_tlutObj0[textureIndex]);
-        MemFree(m_tlutObj1[textureIndex]);
-        MemFree(m_textureHeader[textureIndex]);
+        MemFree(iter->m_textureData[0]);
+        MemFree(iter->m_tlutData[0]);
+        MemFree(iter->m_texObj[0]);
+        MemFree(iter->m_tlutObj0[0]);
+        MemFree(iter->m_tlutObj1[0]);
+        MemFree(iter->m_textureHeader[0]);
         textureIndex += 1;
+        iter = reinterpret_cast<CMaterialEditorPcs*>(reinterpret_cast<unsigned char*>(iter) + 4);
     } while (textureIndex < 0x10);
 
     if (m_rsdIndex != 0) {


### PR DESCRIPTION
## Summary
- rewrite MaterialEditor texture cleanup loops to use a moving object pointer over the parallel texture arrays
- improves cleanup loop register allocation without changing behavior

## Objdiff evidence
- main/p_MaterialEditor destroyViewer__18CMaterialEditorPcsFv: 97.30159% -> 98.25397%
- main/p_MaterialEditor Quit__18CMaterialEditorPcsFv: 93.86364% -> 100.0%

## Verification
- ninja
- git diff --check