### PR TITLE
Improve Ryj mega birth angle constant matching

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -769,20 +769,18 @@ void calc(
 	}
 
 	{
-		float angleMax;
-		float angleWrap = FLOAT_80330458;
+		const float& angleWrap = FLOAT_80330458;
+		const float& angleMax = FLOAT_8033045c;
 		volatile float* angle = f32_at(particlePayload, 0x28);
-		angleMax = FLOAT_8033045c;
 		while (angleMax <= *angle)
 		{
 			*angle = *angle - angleWrap;
 		}
 	}
 	{
-		float angleMin;
-		float angleWrap = FLOAT_80330458;
+		const float& angleWrap = FLOAT_80330458;
+		const float& angleMin = FLOAT_80330460;
 		volatile float* angle = f32_at(particlePayload, 0x28);
-		angleMin = FLOAT_80330460;
 		while (*angle < angleMin)
 		{
 			*angle = *angle + angleWrap;


### PR DESCRIPTION
## Summary
- Bind the Ryj Mega Birth angle wrap/min/max constants by reference in calc.
- This keeps MWCC loading the named sdata2 constants instead of anonymous local constants for the angle clamp loops.

## Evidence
- ninja: passes
- main/pppRyjMegaBirth .text: 82.602684% -> 82.61263%
- calc__FP13VRyjMegaBirthP13PRyjMegaBirthP14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR: 99.82906% -> 99.91453%
- Remaining calc diffs are the two int-to-double conversion constant pairs.

## Plausibility
- The change follows existing local style in this repo where named constants are held through const references to preserve symbol identity.
- No control flow or behavior changed; this is only constant lifetime/symbol selection in the angle wrapping code.