### PR TITLE
Improve deformation shape clipping branch

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -494,7 +494,7 @@ int RenderDeformationShape(_pppPObject* obj, VYmDeformationShp* work, Vec* verti
 			projectedOffsetX = texScaleX * (((float)left + (float)width) - projected[maxIndex].x);
 			texMtx[0][2] = texMtx[0][2] + (projectedObj[maxIndex].x + projectedOffsetX - FLOAT_803305f8);
 		}
-	} else if ((left + width) <= 640) {
+	} else if (640 < (left + width)) {
 		texMtx[0][2] = texMtx[0][2] + offsetX;
 	} else {
 		texMtx[0][2] = texMtx[0][2] + offsetX;


### PR DESCRIPTION
## Summary
- Adjust RenderDeformationShape right-edge clipping branch to use the overflow-side comparison shape seen in the target.
- Keeps behavior equivalent while improving the generated branch direction in main/pppYmDeformationShp.

## Objdiff Evidence
Command: build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp

Before:
- .text: 96.43534%
- RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d: 97.23375%

After:
- .text: 96.43873%
- RenderDeformationShape__FP11_pppPObjectP17VYmDeformationShpP3VecP5Vec2d: 97.241486%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp -o /tmp/pppYmDeformationShp_after.json --format json

## Notes
- Tried adjacent changes in pppYmDeformationMdl, pppLaser, chara_anim, and nearby pppYmDeformationShp scheduling; dropped them when they regressed or produced identical output.
