### PR TITLE
Improve pppYmLaser constant ordering

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -15,7 +15,7 @@ extern const f32 kPppYmLaserOne;
 #include <string.h>
 
 extern const f32 FLOAT_80330df0[2];
-extern const f32 FLOAT_80330de0;
+extern const f32 FLOAT_80330de0 = -1.0f;
 extern const f32 FLOAT_80330de4;
 extern const f32 FLOAT_80330de8;
 extern const f32 FLOAT_80330dec;
@@ -330,7 +330,6 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	}
 }
 
-extern const f32 FLOAT_80330de0 = -1.0f;
 extern const f32 FLOAT_80330de4 = 1.2f;
 extern const f32 FLOAT_80330de8 = 10000000000.0f;
 extern const f32 FLOAT_80330dec = -10000000000.0f;


### PR DESCRIPTION
## Summary
- Move the FLOAT_80330de0 definition ahead of pppRenderYmLaser so its emitted sdata2 ordering better matches the target object.
- Leaves pppRenderYmLaser and pppFrameYmLaser code scores unchanged while improving the unit data layout.

## Evidence
- ninja passes.
- main/pppYmLaser fuzzy score improved from 98.619255 to 98.633995.
- objdiff now reports [.sdata2-0] at 80.0% (was 73.333336%).
- Code symbols unchanged: pppRenderYmLaser 97.97872%, pppFrameYmLaser 99.80122%.

## Plausibility
- This is source-order data layout cleanup for an existing named constant, not a forced section or synthetic symbol.