### PR TITLE
Match CMapPcs load completion check

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -427,15 +427,42 @@ void CMapPcs::LoadMap(int stageNo, int mapNo, void* mapPtr, unsigned long mapSiz
 unsigned long long CMapPcs::IsLoadMapCompleted()
 {
     unsigned int value = 0;
-    int index = 0;
+    CMapMng* map = &MapMng;
 
     for (int count = 2; count != 0; count--) {
-        for (int handle = 8; handle != 0; handle--) {
-            if (MapMng.m_asyncLoadState.m_asyncHandles[index] != 0) {
-                return (unsigned long long)value;
-            }
-            index++;
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
         }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
+        if (map->m_asyncLoadState.m_asyncHandles[0] != 0) {
+            return (unsigned long long)value;
+        }
+
+        map = reinterpret_cast<CMapMng*>(reinterpret_cast<unsigned char*>(map) + 4);
         value += 7;
     }
 


### PR DESCRIPTION
## Summary
- Reworked CMapPcs::IsLoadMapCompleted to mirror the recovered async-handle scan shape.
- The function now checks each of the two 8-handle groups in the same unrolled order as the target.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/p_map -o build/agent_p_map_isload_final.json IsLoadMapCompleted__7CMapPcsFv
- Before: 88.84615%, size 260 vs 288.
- After: 100.0%, size 260 vs 260.
- Build report increased matched functions from 3481 to 3482 and matched code from 600960 to 601220 bytes.

## Notes
- Left unrelated local modifications in src/pppYmChangeTex.cpp uncommitted.