### PR TITLE
Use shared menu constants in menu_lst

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -8,21 +8,21 @@
 #include "ffcc/system.h"
 #include <string.h>
 
-static const float FLOAT_803333D0 = 0.0f;
-static const float FLOAT_803333D4 = 255.0f;
-static const double DOUBLE_803333D8 = 20.0;
-static const float FLOAT_803333E0 = 40.0f;
-static const double DOUBLE_803333E8 = 0.5;
-static const float FLOAT_803333F0 = 1.0f;
-static const float FLOAT_803333F4 = 4.0f;
-static const float FLOAT_803333F8 = 320.0f;
-static const float FLOAT_803333FC = 0.5f;
-static const float FLOAT_80333400 = 352.0f;
-static const float FLOAT_80333404 = 3.0f;
-static const double DOUBLE_80333408 = 4503601774854144.0;
-static const double DOUBLE_80333410 = 1.0;
-static const double DOUBLE_80333418 = 0.0;
-static const double DOUBLE_80333420 = 216.0;
+extern const float FLOAT_803333D0;
+extern const float FLOAT_803333D4;
+extern const double DOUBLE_803333D8;
+extern const float FLOAT_803333E0;
+extern const double DOUBLE_803333E8;
+extern const float FLOAT_803333F0;
+extern const float FLOAT_803333F4;
+extern const float FLOAT_803333F8;
+extern const float FLOAT_803333FC;
+extern const float FLOAT_80333400;
+extern const float FLOAT_80333404;
+extern const double DOUBLE_80333408;
+extern const double DOUBLE_80333410;
+extern const double DOUBLE_80333418;
+extern const double DOUBLE_80333420;
 
 STATIC_ASSERT(offsetof(CMenuPcs, listFont) == 0x108);
 STATIC_ASSERT(offsetof(CMenuPcs, helpFont) == 0xF8);


### PR DESCRIPTION
## Summary
- Replace local `menu_lst` copies of shared menu constants with extern declarations.
- Let the unit reference the symbols already owned in neighboring menu objects instead of claiming a local `.sdata2` block.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst_after_extern.json MLstDraw__8CMenuPcsFv`
- `menu_lst` right-side `.text` size now matches target size: 3476 bytes.
- Local `.sdata2` claim shrank from 96 bytes to 16 bytes.
- `MLstClose__8CMenuPcsFv` improved from 86.35514% / 436b to 89.345795% / 432b.
- `MLstOpen__8CMenuPcsFv` improved from 88.155556% / 728b to 88.21111% / 724b.

## Notes
- `MLstDraw__8CMenuPcsFv` local fuzzy score regresses while the unit moves toward shared constant ownership; this matches the symbol table layout around `FLOAT_803333D0` through `DOUBLE_80333420` rather than duplicating those values in `menu_lst`.
