### PR TITLE
Use material editor float symbol in init

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -676,7 +676,7 @@ void CMaterialEditorPcs::Init()
     self[0xf] = 0xff;
     float minusOne = FLOAT_8032FCDC;
     float zero = FLOAT_8032FCD8;
-    float one = FLOAT_8032FCC8;
+    float one = LoadFloat(FLOAT_8032FCC8);
 
     *reinterpret_cast<float*>(self + 0x18) = zero;
     *reinterpret_cast<float*>(self + 0x1c) = zero;


### PR DESCRIPTION
## Summary
- Load the material editor `1.0f` initializer through `LoadFloat(FLOAT_8032FCC8)`.
- This keeps `CMaterialEditorPcs::Init` referencing the existing sdata2 symbol instead of generating a local literal relocation.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o /tmp/p_MaterialEditor_init_final.json Init__18CMaterialEditorPcsFv` still reports `86.548676%` for `Init__18CMaterialEditorPcsFv`.
- The compiled instruction changes from `lfs f0, @387@sda21` to `lfs f0, FLOAT_8032FCC8@sda21`, matching the intended named constant relocation.