### PR TITLE
Align p_gba JoyBus error string

### DIFF
--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -6,12 +6,12 @@
 #include <dolphin/gba/GBA.h>
 
 extern const char s_CGbaPcs_80330870[];
-extern const char s_JoyBus__LoadBin___error_801d9de0[];
+extern const char s_JoyBus__LoadBin___error_801d9de0[] ATTRIBUTE_ALIGN(8);
 extern const char __RTTI__8CManager_8032E7C0[];
 extern const char __RTTI__8CProcess_8032E7C8[];
 
 const char s_CGbaPcs_80330870[] = "CGbaPcs";
-const char s_JoyBus__LoadBin___error_801d9de0[] = "JoyBus::LoadBin() error\n";
+const char s_JoyBus__LoadBin___error_801d9de0[] ATTRIBUTE_ALIGN(8) = "JoyBus::LoadBin() error\n";
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Align the p_gba JoyBus::LoadBin error string to 8 bytes so the emitted .rodata tail padding matches the target object.
- Leaves p_gba code unchanged and still 100% matched.

## Evidence
- Before: main/p_gba .rodata 32 bytes at 87.7193%.
- After: main/p_gba .rodata 32 bytes at 100.0%.
- Current objdiff: .text 752 bytes 100.0%, .rodata 32 bytes 100.0%, .data 464 bytes 99.54361%, .sdata2 8 bytes 100.0%.
- Build: ninja passes; build/GCCP01/main.dol OK.

## Plausibility
- This uses normal compiler alignment for an existing string object, matching the original section padding without introducing fake labels or manual data blobs.