### PR TITLE
Match CGObject alpha update constant

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -178,6 +178,7 @@ static bool sBgCollisionActive;
 extern "C" const char s_gobject_cpp[] = "gobject.cpp";
 static const char s_l_item2[] = "l_item2";
 static const char s_r_item[] = "r_item";
+extern "C" float FLOAT_80330338;
 static const float sAnimFrameOffset = 1.0f;           // FLOAT_80330338
 static const float sHugeCylinderExtent = 10000000000.0f; // FLOAT_8033033c
 static const float sNegHugeCylinderExtent = -10000000000.0f; // FLOAT_80330340
@@ -3497,7 +3498,7 @@ void CGObject::onAnimPoint(int, int)
  */
 float CGObject::onAlphaUpdate()
 {
-	return sAnimFrameOffset;
+	return FLOAT_80330338;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Declare the PAL float symbol used for the 1.0f alpha update constant in gobject.cpp.
- Return that symbol from CGObject::onAlphaUpdate so the relocation matches the target instead of the compiler-local literal.

## Evidence
- ninja: passes
- objdiff main/gobject onAlphaUpdate__8CGObjectFv: 97.5% -> 100.0%
- main/gobject .text: 68.90926% -> 68.91004%