### PR TITLE
Match caravan work clearing

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -275,10 +275,10 @@ void CCaravanWork::clearCaravanWork()
 	m_evtState1 = 0;
 	memset(m_commandListInventorySlotRef, 0xFF, sizeof(m_commandListInventorySlotRef));
 	memset(m_commandListExtra, 0, sizeof(m_commandListExtra));
-	m_bonusCondition = 0;
+	memset(&m_bonusCondition, 0, sizeof(m_bonusCondition));
 	memset(m_equipEffectParams, 0, sizeof(m_equipEffectParams) - sizeof(m_equipEffectParams[0]));
-	m_shopBusyFlag = 0;
-	m_caravanLocalFlags = 0;
+	memset(&m_shopBusyFlag, 0, sizeof(m_shopBusyFlag));
+	memset(&m_caravanLocalFlags, 0, sizeof(m_caravanLocalFlags));
 	m_inventoryItemCount = 0;
 	memset(m_inventoryItems, 0xFF, sizeof(m_backupInventoryBlock));
 	m_progressValue = 0;


### PR DESCRIPTION
## Summary
- Use byte-sized memset calls for the caravan bonus/shop/local flag clears in CCaravanWork::clearCaravanWork.
- This matches the original clear routine's codegen without changing layout or behavior.

## Evidence
- ninja passes.
- objdiff: clearCaravanWork__12CCaravanWorkFv improved from 81.71795% to 100.0% (312 bytes).