### PR TITLE
Improve pppPart exception metadata matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -659,7 +659,7 @@ config.libs = [
             Object(Matching, "pppParMatrix.cpp"),
             Object(Matching, "pppParMoveLine.cpp"),
             Object(Matching, "pppParMoveMatrix.cpp"),
-            Object(NonMatching, "pppPart.cpp"),
+            Object(NonMatching, "pppPart.cpp", extra_cflags=["-inline auto,deferred"]),
             Object(Matching, "pppPObjPoint.cpp"),
             Object(Matching, "pppPoint.cpp"),
             Object(Matching, "pppPointAp.cpp"),


### PR DESCRIPTION
## Summary
- Compile `pppPart.cpp` with `-inline auto,deferred`.
- This leaves `pppPart` text matching unchanged while substantially improving exception metadata matching.

## Objdiff evidence
Unit: `main/pppPart`

Before:
- `.text`: 77.3143%
- `[extab-0]`: 2.4390%
- `[extabindex-0]`: 23.3840%

After:
- `.text`: 77.3143%
- `[extab-0]`: 93.5976%
- `[extabindex-0]`: 74.4653%

Checked target symbols remain unchanged, including:
- `pppSetMatrix__FP9_pppMngSt`: 59.0276%
- `pppCopyVector__FR3Vec3Vec`: 98.2857%

## Validation
- `python3 configure.py --version GCCP01`
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppPart -o -`
