### PR TITLE
Fix CLine CalcBound build

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -325,7 +325,7 @@ void CLine<10>::CalcBound()
 
         if (i != 0) {
             CLineSegment* prevSegment = segment - 1;
-            PSVECSubtract(point, &line->points[i - 1], &prevSegment->delta);
+            PSVECSubtract(point, point - 1, &prevSegment->delta);
             prevSegment->length = PSVECMag(&prevSegment->delta);
             prevSegment->startLength = totalLength;
             totalLength += prevSegment->length;


### PR DESCRIPTION
## Summary
- Fix `CLine<10>::CalcBound` to subtract the previous point via the local point cursor.
- This removes the undefined `line` identifier introduced in the current `sound.cpp` source.

## Evidence
- Before: `ninja` failed compiling `src/sound.cpp` with undefined identifier `line` at `CLine<10>::CalcBound`.
- After: `ninja` completes successfully.

## Plausibility
- `CalcBound` is a member function and already walks points through the local `point` cursor.
- The analogous line implementation in `cflat_r2system.cpp` uses `PSVECSubtract(point, point - 1, ...)`, matching this fix without adding linkage or section hacks.