### PR TITLE
Fix CLine CalcBound point delta

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -325,7 +325,7 @@ void CLine<10>::CalcBound()
 
         if (i != 0) {
             CLineSegment* prevSegment = segment - 1;
-            PSVECSubtract(point, &line->points[i - 1], &prevSegment->delta);
+            PSVECSubtract(point, point - 1, &prevSegment->delta);
             prevSegment->length = PSVECMag(&prevSegment->delta);
             prevSegment->startLength = totalLength;
             totalLength += prevSegment->length;


### PR DESCRIPTION
## Summary
- Fix `CLine<10>::CalcBound()` to subtract the previous point from the current point using the local point cursor.
- Removes the undefined `line` reference that prevented `src/sound.cpp` from compiling.

## Evidence
- Before: `ninja` failed in `src/sound.cpp` with undefined identifier `line` at `PSVECSubtract(point, &line->points[i - 1], &prevSegment->delta);`.
- After: `ninja` completes successfully.
- Objdiff: `build/tools/objdiff-cli diff -p . -u main/sound -o - 'CalcBound__9CLine<10>Fv'` reports `CalcBound__9CLine<10>Fv` at 85.454544%.

## Plausibility
- `CalcBound()` already advances a `Vec* point` cursor through `points`, so `point - 1` is the direct previous point.
- This matches the nearby recovered `CLineSegment64` pattern, which uses `PSVECSubtract(point, point - 1, &prevSegment->delta);`.
