### PR TITLE
Fix CLine sound bound calculation

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -289,8 +289,8 @@ void CLine<10>::Draw()
 
 void CLine<10>::CalcBound()
 {
-    Vec* point = points;
-    CLineSegment* segment = segments;
+    Vec* point;
+    CLineSegment* segment;
 
     min.x = kLineBoundsInitMin;
     min.y = kLineBoundsInitMin;
@@ -299,6 +299,9 @@ void CLine<10>::CalcBound()
     max.y = kLineBoundsInitMax;
     max.z = kLineBoundsInitMax;
     totalLength = kLineSegmentMinT;
+
+    point = points;
+    segment = segments;
 
     u32 i = 0;
     while (i < pointCount) {
@@ -325,7 +328,7 @@ void CLine<10>::CalcBound()
 
         if (i != 0) {
             CLineSegment* prevSegment = segment - 1;
-            PSVECSubtract(point, &line->points[i - 1], &prevSegment->delta);
+            PSVECSubtract(point, point - 1, &prevSegment->delta);
             prevSegment->length = PSVECMag(&prevSegment->delta);
             prevSegment->startLength = totalLength;
             totalLength += prevSegment->length;


### PR DESCRIPTION
## Summary
- Fix `CLine<10>::CalcBound` so the previous point passed to `PSVECSubtract` is the prior element in the local point walk.
- Move point/segment pointer setup after the bounds reset so the source shape follows the target calculation flow more closely.

## Evidence
- Before this change, `ninja` stopped in `src/sound.cpp` with undefined identifier `line`.
- After this change, `ninja` completes for GCCP01.
- `build/tools/objdiff-cli diff -p . -u main/sound -o /tmp/sound_unit_final.json` reports `.text` size 15028 at 95.84322% and `CalcBound__9CLine<10>Fv` size 352 at 85.454544%.

## Plausibility
- The fix matches the adjacent `CLine<64>` implementation pattern, which subtracts `point - 1` from the current point when building the previous segment delta.
- This removes an invalid identifier without adding section hacks, address constants, or fake symbols.