### PR TITLE
Fix CLine sound bound build

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -325,7 +325,7 @@ void CLine<10>::CalcBound()
 
         if (i != 0) {
             CLineSegment* prevSegment = segment - 1;
-            PSVECSubtract(point, &line->points[i - 1], &prevSegment->delta);
+            PSVECSubtract(point, &points[i - 1], &prevSegment->delta);
             prevSegment->length = PSVECMag(&prevSegment->delta);
             prevSegment->startLength = totalLength;
             totalLength += prevSegment->length;


### PR DESCRIPTION
## Summary
- Fix the undefined line reference in CLine CalcBound by using the member points array directly.
- Restores the GCCP01 full build after the recent CLine source-shape change.

## Evidence
- ninja passes.
- Objdiff for CalcBound__9CLine<10>Fv reports size 352, 88.75% match.

## Plausibility
- CalcBound is a CLine<10> member, so &points[i - 1] is the direct member-array form of the intended previous point reference and avoids pointer-offset hacks.