### PR TITLE
Fix sound line bounds build

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -325,7 +325,7 @@ void CLine<10>::CalcBound()
 
         if (i != 0) {
             CLineSegment* prevSegment = segment - 1;
-            PSVECSubtract(point, &line->points[i - 1], &prevSegment->delta);
+            PSVECSubtract(point, &points[i - 1], &prevSegment->delta);
             prevSegment->length = PSVECMag(&prevSegment->delta);
             prevSegment->startLength = totalLength;
             totalLength += prevSegment->length;


### PR DESCRIPTION
## Summary
- Fix CLine<10>::CalcBound() to subtract from this line's previous point instead of an undefined line variable.
- Restores the GCCP01 build from the current checkout failure in src/sound.cpp.

## Evidence
- Before: ninja failed compiling src/sound.cpp with undefined identifier 'line' at the PSVECSubtract call.
- After: ninja completes and regenerates the progress report.

## Plausibility
- CalcBound() is a CLine member walking its own points array, so using points[i - 1] matches the surrounding member access and avoids an impossible external line dependency.