### PR TITLE
Fix CLine CalcBound source binding

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -289,6 +289,7 @@ void CLine<10>::Draw()
 
 void CLine<10>::CalcBound()
 {
+    CLine<10>* line = this;
     Vec* point = points;
     CLineSegment* segment = segments;
 


### PR DESCRIPTION
## Summary
- Defines the intended local CLine pointer in CLine<10>::CalcBound so the existing previous-point expression compiles.
- Preserves the recent source shape around &line->points[i - 1] instead of reverting to the lower-scoring pointer form.

## Evidence
- ninja passes for GCCP01.
- objdiff: main/sound CalcBound__9CLine<10>Fv remains 88.75% match (target 352b, current 344b).

## Plausibility
- The code now explicitly binds the local line alias to this, matching the existing member-access style and avoiding an undeclared identifier.