### PR TITLE
Improve CGPrgObj zero rotation loads

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -227,7 +227,7 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	deltaX = deltaPos.x;
 	deltaZ = deltaPos.z;
 	if ((deltaX == FLOAT_80331BD4) || (deltaZ == FLOAT_80331BD4)) {
-		targetRot = FLOAT_80331BD4;
+		targetRot = LoadFloat(FLOAT_80331BD4);
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
@@ -258,7 +258,7 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 	deltaX = deltaPos.x;
 	deltaZ = deltaPos.z;
 	if ((deltaX == FLOAT_80331BD4) || (deltaZ == FLOAT_80331BD4)) {
-		targetRot = FLOAT_80331BD4;
+		targetRot = LoadFloat(FLOAT_80331BD4);
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
@@ -287,7 +287,7 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	deltaX = deltaPos.x;
 	deltaZ = deltaPos.z;
 	if ((deltaX == FLOAT_80331BD4) || (deltaZ == FLOAT_80331BD4)) {
-		targetRot = FLOAT_80331BD4;
+		targetRot = LoadFloat(FLOAT_80331BD4);
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}


### PR DESCRIPTION
## Summary
- route the zero-angle assignment in the three CGPrgObj target rotation helpers through the existing LoadFloat helper
- keeps the control flow and stack shape unchanged while making the zero load use the named FLOAT_80331BD4 relocation on the assignment path

## Objdiff evidence
- main/prgobj getTargetRot__8CGPrgObjFP8CGPrgObj: 96.611115% -> 96.75%
- main/prgobj rotTarget__8CGPrgObjFP8CGPrgObj: 96.92308% -> 97.051285%
- main/prgobj dstTargetRot__8CGPrgObjFP8CGPrgObj: 97.27273% -> 97.38636%

## Plausibility
- LoadFloat is already used in this file to force named float loads without changing behavior
- the zero branch still assigns the same 0.0f value, but now follows the named constant load pattern expected by the original object

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/prgobj -o - getTargetRot__8CGPrgObjFP8CGPrgObj
- build/tools/objdiff-cli diff -p . -u main/prgobj -o - rotTarget__8CGPrgObjFP8CGPrgObj
- build/tools/objdiff-cli diff -p . -u main/prgobj -o - dstTargetRot__8CGPrgObjFP8CGPrgObj