### PR TITLE
Improve money menu animation math

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -518,10 +518,15 @@ bool CMenuPcs::MoneyClose()
 		} else {
 			anim->frame++;
 			double one = DOUBLE_80332F90;
-			anim->alpha =
-				(float)-((DOUBLE_80332F90 / (double)anim->duration) * (double)anim->frame - DOUBLE_80332F90);
+			double duration = (double)anim->duration;
+			double animFrame = (double)anim->frame;
+			double rate = DOUBLE_80332F90 / duration;
+			anim->alpha = (float)(DOUBLE_80332F90 - rate * animFrame);
 			if ((anim->flags & 2) == 0) {
-				float ratio = (float)-((one / (double)anim->duration) * (double)anim->frame - one);
+				duration = (double)anim->duration;
+				animFrame = (double)anim->frame;
+				rate = one / duration;
+				float ratio = (float)(one - rate * animFrame);
 				float dx = anim->targetX - (float)anim->x;
 				float dy = anim->targetY - (float)anim->y;
 				anim->dx = dx * ratio;
@@ -686,9 +691,15 @@ bool CMenuPcs::MoneyOpen()
 			} else {
 				anim->frame++;
 				double one = DOUBLE_80332F90;
-				anim->alpha = (float)((DOUBLE_80332F90 / (double)anim->duration) * (double)anim->frame);
+				double duration = (double)anim->duration;
+				double animFrame = (double)anim->frame;
+				double rate = DOUBLE_80332F90 / duration;
+				anim->alpha = (float)(rate * animFrame);
 				if ((anim->flags & 2) == 0) {
-					float ratio = (float)((one / (double)anim->duration) * (double)anim->frame);
+					duration = (double)anim->duration;
+					animFrame = (double)anim->frame;
+					rate = one / duration;
+					float ratio = (float)(rate * animFrame);
 					float dx = anim->targetX - (float)anim->x;
 					float dy = anim->targetY - (float)anim->y;
 					anim->dx = dx * ratio;


### PR DESCRIPTION
## Summary
- Rewrite the money menu open/close animation interpolation as explicit rate calculations.
- Keeps the same behavior while giving the compiler source-shaped double lifetimes for the duration/frame math.

## Objdiff Evidence
- `MoneyClose__8CMenuPcsFv`: 98.76842% / 25 instruction diffs -> 99.947365% / 1 relocation-name diff. Project report now shows this function at 100.0% fuzzy match.
- `MoneyOpen__8CMenuPcsFv`: 81.06035% / 135 instruction diffs -> 81.543106% / 111 instruction diffs.
- `main/menu_money` report fuzzy match: 74.76361% -> 74.8408%; matched functions: 1 -> 2.

## Plausibility
- This is normal source-level algebra (`rate = 1.0 / duration`) instead of compiler coercion or address/section forcing.
- No symbol hacks, manual vtables, manual sections, or fake labels.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/menu_money -o /tmp/menu_money_final2.json`