### PR TITLE
Improve p_chara_viewer small data flags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -560,7 +560,7 @@ config.libs = [
             Object(NonMatching, "monobj_table.cpp"),
             Object(NonMatching, "p_camera.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "p_chara.cpp", extra_cflags=["-sdata 8"]),
-            Object(NonMatching, "p_chara_viewer.cpp"),
+            Object(NonMatching, "p_chara_viewer.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "p_dbgmenu.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "p_FunnyShape.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "p_game.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,readonly"]),


### PR DESCRIPTION
## Summary
- Build `p_chara_viewer.cpp` with `-sdata 8`, matching neighboring character process units.
- Improves objdiff report scores for `p_chara_viewer` without changing source behavior or data layout declarations.

## Evidence
- `ninja` passes.
- `objdiff-cli report generate -p .` for `main/p_chara_viewer`:
  - unit fuzzy: 93.16178% -> 93.250786%
  - `drawViewer__9CCharaPcsFv`: 95.65476% -> 95.72619%
  - `calcViewer__9CCharaPcsFv`: 88.89798% -> 89.03434%
  - `createViewer__9CCharaPcsFv`: 99.30986% -> 99.323944%
  - data remains 84.0% matched (`.rodata`, `.bss`, `.sbss`, `.sdata2` all 100% fuzzy).

## Plausibility
`p_chara.cpp`, the adjacent owning unit for the preceding viewer constants, already uses `-sdata 8`. Applying the same threshold to `p_chara_viewer.cpp` is a compiler-flag correction rather than source coercion.
