### PR TITLE
Improve Tail3 birth particle layout

### DIFF
--- a/include/ffcc/pppYmMegaBirthShpTail3.h
+++ b/include/ffcc/pppYmMegaBirthShpTail3.h
@@ -39,9 +39,11 @@ struct PYmMegaBirthShpTail3
     float m_speedRandRange;        // 0x54
     float field_0x58;              // 0x58
     Vec m_speedScale;              // 0x5c
-    unsigned char m_pad0x68[0x6A - 0x68];
-    short m_pathIndex;             // 0x6a
-    unsigned char m_pad0x6C[0xB9 - 0x6C];
+    unsigned char m_randType;       // 0x68
+    unsigned char m_enableParticleColor; // 0x69
+    unsigned char m_pad0x6a[0x6C - 0x6A];
+    short m_pathIndex;             // 0x6c
+    unsigned char m_pad0x6e[0xB9 - 0x6E];
     unsigned char m_wmatCopyMode;  // 0xb9
 };
 

--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -554,18 +554,18 @@ void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail3* vYmMegaBirthShpTail3,
         }
 
         pppGetRotMatrixXYZ(rot, (pppIVECTOR4*)angles);
-        PSMTXMultVecSR(rot.value, &baseDir, &particleData->m_velocity);
-        particleData->m_velocity.x *= pYmMegaBirthShpTail3->field_0x58;
-        particleData->m_velocity.y *= pYmMegaBirthShpTail3->m_speedScale.x;
-        particleData->m_velocity.z *= pYmMegaBirthShpTail3->m_speedScale.y;
-        tempVec = particleData->m_velocity;
-        pppNormalize(particleData->m_velocity, tempVec);
+        PSMTXMultVecSR(rot.value, &baseDir, reinterpret_cast<Vec*>(particleData->m_matrix[1]));
+        reinterpret_cast<Vec*>(particleData->m_matrix[1])->x *= pYmMegaBirthShpTail3->field_0x58;
+        reinterpret_cast<Vec*>(particleData->m_matrix[1])->y *= pYmMegaBirthShpTail3->m_speedScale.x;
+        reinterpret_cast<Vec*>(particleData->m_matrix[1])->z *= pYmMegaBirthShpTail3->m_speedScale.y;
+        tempVec = *reinterpret_cast<Vec*>(particleData->m_matrix[1]);
+        pppNormalize(*reinterpret_cast<Vec*>(particleData->m_matrix[1]), tempVec);
     }
 
     if ((mode < 6) && (pYmMegaBirthShpTail3->m_speedRandRange != 0.0f)) {
         float speedRandRange = pYmMegaBirthShpTail3->m_speedRandRange;
         float speedRandHalf = FLOAT_803305D4 * speedRandRange;
-        u8 randType = paramBytes[0x6a];
+        u8 randType = pYmMegaBirthShpTail3->m_randType;
 
         if (randType <= 1) {
             if (randType == 1) {
@@ -627,7 +627,7 @@ void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail3* vYmMegaBirthShpTail3,
                 float vy;
                 float vz;
 
-                if (paramBytes[0x6A] == 0) {
+                if (pYmMegaBirthShpTail3->m_randType == 0) {
                     if ((u16)vYmMegaBirthShpTail3->m_pathIndex >= (u16)pathInfo[1]) {
                         vYmMegaBirthShpTail3->m_pathIndex = 0;
                     }
@@ -642,14 +642,14 @@ void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail3* vYmMegaBirthShpTail3,
                 } else {
                     float sampleT;
 
-                    if (paramBytes[0x6A] == 1) {
+                    if (pYmMegaBirthShpTail3->m_randType == 1) {
                         Math.RandF();
                         sampleT = Math.RandF();
-                    } else if (paramBytes[0x6A] == 3) {
+                    } else if (pYmMegaBirthShpTail3->m_randType == 3) {
                         sampleT = FLOAT_803305B0 - (Math.RandF() * Math.RandF() * Math.RandF());
-                    } else if (paramBytes[0x6A] == 5) {
+                    } else if (pYmMegaBirthShpTail3->m_randType == 5) {
                         sampleT = FLOAT_803305B0 - (Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF());
-                    } else if (paramBytes[0x6A] < 5) {
+                    } else if (pYmMegaBirthShpTail3->m_randType < 5) {
                         sampleT = Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF();
                     } else {
                         sampleT = Math.RandF() * Math.RandF() * Math.RandF();
@@ -671,14 +671,14 @@ void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail3* vYmMegaBirthShpTail3,
                 particleData->m_matrix[0][2] = vz * pYmMegaBirthShpTail3->m_speedScale.y;
 
                 if ((mode == 8) || (mode == 9)) {
-                    Vec velocity = particleData->m_velocity;
-                    pppNormalize(particleData->m_velocity, velocity);
+                    Vec velocity = *reinterpret_cast<Vec*>(particleData->m_matrix[1]);
+                    pppNormalize(*reinterpret_cast<Vec*>(particleData->m_matrix[1]), velocity);
                 }
             }
         }
     } else if (pYmMegaBirthShpTail3->m_speedRandRange != 0.0f) {
         float speedRandRange = pYmMegaBirthShpTail3->m_speedRandRange;
-        u8 randType = paramBytes[0x6a];
+        u8 randType = pYmMegaBirthShpTail3->m_randType;
         float scale = speedRandRange;
 
         if (randType == 3) {
@@ -696,8 +696,8 @@ void birth(_pppPObject* pppPObject, VYmMegaBirthShpTail3* vYmMegaBirthShpTail3,
                       speedRandRange);
         }
 
-        Vec velocity = particleData->m_velocity;
-        pppScaleVectorXYZ(particleData->m_velocity, velocity, scale);
+        Vec velocity = *reinterpret_cast<Vec*>(particleData->m_matrix[1]);
+        pppScaleVectorXYZ(*reinterpret_cast<Vec*>(particleData->m_matrix[1]), velocity, scale);
     }
 
     if (paramBytes[0x16] != 0) {


### PR DESCRIPTION
Summary
- Recover Tail3 rand/path parameter fields to match Tail2 and Ghidra layout: m_randType at 0x68, path index at 0x6c.
- Route Tail3 birth direction operations through particle matrix row 1 at offset 0x10, matching Ghidra particle overlay shape.
- Replace raw 0x6a parameter byte reads in birth with named m_randType access.

Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o - birth__FP11_pppPObjectP20VYmMegaBirthShpTail3P20PYmMegaBirthShpTail3P6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR
- Before: birth Tail3 2948 bytes, 48.561554% match.
- After: birth Tail3 2948 bytes, 48.571274% match.

Plausibility
- Tail3 now mirrors the established Tail2 parameter layout around 0x68 and 0x6c.
- Ghidra shows the rotated particle direction stored at particleData->m_matrix[1] offset 0x10, not the generic _PARTICLE_DATA::m_velocity field at 0x30.