### PR TITLE
Add default command skill name table

### DIFF
--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -100,6 +100,12 @@ extern "C" const char s_Blitz_Hieb_801DEAAC[] = "Blitz-Hieb";
 extern "C" const char s_Colpo_Fire_801DEAB8[] = "Colpo Fire";
 extern "C" const char s_Colpo_Blizzard_801DEAC4[] = "Colpo Blizzard";
 
+extern "C" const char* PTR_s_Flamestrike[] = {
+    s_Flamestrike_801DEA6C,
+    s_Icestrike_801DEA78,
+    s_Thunderstrike_801DEA84,
+};
+
 extern "C" const char* PTR_s_Pyro_Frappe[] = {
     s_Pyro_Frappe_801DEAE4,
     s_Cryo_Frappe_801DEAF0,


### PR DESCRIPTION
## Summary
- Adds the missing default command skill-name pointer table before the localized French/Spanish tables in menu_cmd.
- Restores the .data layout so PTR_s_Pyro_Frappe and PTR_s_Efecto_Fuego land at the target offsets.

## Evidence
- ninja passes: build/GCCP01/main.dol OK.
- objdiff main/menu_cmd: [.data-0] improved from 44 bytes / 45.62963% to 56 bytes / 88.88889%.
- GetSkillStr__8CMenuPcsFi code match is unchanged at 86.92308%.

## Plausibility
- Ghidra's GetSkillStr default path indexes the Flamestrike/Icestrike/Thunderstrike table directly before PTR_s_Pyro_Frappe.
- This defines that real pointer table instead of adding anonymous padding.