### PR TITLE
Model FunnyShape USB storage destruction

### DIFF
--- a/include/ffcc/p_FunnyShape.h
+++ b/include/ffcc/p_FunnyShape.h
@@ -7,6 +7,13 @@
 #include "ffcc/system.h"
 #include "ffcc/FS_USB_Process.h"
 
+struct CUSBStreamDataStorage
+{
+    ~CUSBStreamDataStorage();
+
+    u8 m_storage[0x14];
+};
+
 class CFunnyShapePcs : public CProcess
 {
 public:
@@ -33,7 +40,7 @@ public:
 
     CMemory::CStage* m_viewerStage;        // 0x04
     u8 m_viewerState[0x34];                // 0x08
-    u8 m_usbStreamDataStorage[0x14];       // 0x3C
+    CUSBStreamDataStorage m_usbStreamDataStorage; // 0x3C
     CFunnyShape m_funnyShape;              // 0x50
     FS_DISPLAY_STATUS m_displayPending;    // 0x6178
     u32 m_displayTextureEnabled;           // 0x61B8

--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -26,7 +26,7 @@ struct DisplayTail {
 };
 
 static inline CUSBStreamDataHeader* UsbStream(CFunnyShapePcs* self) {
-    return reinterpret_cast<CUSBStreamDataHeader*>(self->m_usbStreamDataStorage);
+    return reinterpret_cast<CUSBStreamDataHeader*>(&self->m_usbStreamDataStorage);
 }
 
 static inline CFunnyShape* FunnyShape(CFunnyShapePcs* self) {

--- a/src/p_FunnyShape.cpp
+++ b/src/p_FunnyShape.cpp
@@ -69,7 +69,7 @@ struct CFunnyShapeViewerState {
 
 static inline CUSBStreamData* UsbStream(CFunnyShapePcs* self)
 {
-    return reinterpret_cast<CUSBStreamData*>(self->m_usbStreamDataStorage);
+    return reinterpret_cast<CUSBStreamData*>(&self->m_usbStreamDataStorage);
 }
 
 static inline CFunnyShape* FunnyShape(CFunnyShapePcs* self)
@@ -441,7 +441,11 @@ CFunnyShapePcs::~CFunnyShapePcs()
 {
     TextureObjects(this)->CPtrArray<_GXTexObj*>::~CPtrArray();
     TextureHeaders(this)->CPtrArray<OSFS_TEXTURE_ST*>::~CPtrArray();
-    UsbStream(this)->~CUSBStreamData();
+}
+
+CUSBStreamDataStorage::~CUSBStreamDataStorage()
+{
+    reinterpret_cast<CUSBStreamData*>(this)->~CUSBStreamData();
 }
 
 template <>


### PR DESCRIPTION
## Summary
- model the FunnyShape USB stream prefix as a small storage type with its own destructor
- keep the existing 0x3c layout while letting member destruction run CFunnyShape before the USB stream cleanup
- update USB stream casts to take the storage address explicitly

## Evidence
- ninja passes
- p_FunnyShape .text improves from 95.913704% to 95.92555%
- __dt__14CFunnyShapePcsFv improves from 99.64706% to 99.85294%
- overall matched code improves from 603820 to 603956 bytes and matched functions from 3488 to 3489

## Plausibility
The old byte array required manually destroying CUSBStreamData in the CFunnyShapePcs destructor body, which forced that cleanup before the compiler-generated CFunnyShape member destructor. The wrapper preserves the 0x14 prefix layout at 0x3c and lets normal member destruction order place CFunnyShape before USB stream cleanup, matching the original destructor shape more closely.