### PR TITLE
Match p_usb read poll sbss layout

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -8,6 +8,9 @@
 
 int s_usbReadPollFrameCounter;
 char s_usbReadPollInitialized;
+char s_usbReadPollPad0;
+char s_usbReadPollPad1;
+char s_usbReadPollPad2;
 
 extern const char sUsbPcsClassName[] = "CUSBPcs";
 inline CUSBPcs::CUSBPcs()


### PR DESCRIPTION
Summary
- Add the three-byte read-poll padding after s_usbReadPollInitialized in src/p_usb.cpp.
- This brings the compiled p_usb .sbss size/layout in line with the target object.

Evidence
- ninja completes successfully.
- objdiff for main/p_usb now reports .sbss size 8 at 100% match, with .bss/.rodata/.sdata2 also at 100%.
- p_usb dropped out of tools/agent_select_target.py data opportunities after this change.

Plausibility
The target object has s_usbReadPollFrameCounter followed by the one-byte initialization flag and three bytes of small-BSS tail padding. Keeping the flag byte-sized preserves the matched polling code while matching the object layout.