### PR TITLE
Use shared scale constant in camera constraint

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -36,7 +36,7 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
             float cameraPosX = CameraPcs.m_positionX;
             float cameraPosY = CameraPcs.m_positionY;
             float cameraPosZ = CameraPcs.m_positionZ;
-            float scale = 1.0f + ((CameraPcs.m_fov - 25.0f) / 25.0f);
+            float scale = kConstrainCameraDirScaleOne + ((CameraPcs.m_fov - 25.0f) / 25.0f);
 
             PSMTXIdentity(ppvMng->m_matrix.value);
 


### PR DESCRIPTION
## Summary
- Use the existing kConstrainCameraDirScaleOne constant for the camera constraint scale expression instead of a local 1.0f literal.
- This matches the target shared constant reference and keeps the scale calculation source-level and plausible; the same constant is already used for m_scale.z in this function.

## Objdiff evidence
- Unit: main/pppConstrainCameraDir
- Symbol: pppFrameConstrainCameraDir
- Before: 99.76378% match
- After: 99.80315% match
- .text section: 99.79452% -> 99.828766%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir -o -