### PR TITLE
Use scale constant in pppConstrainCameraDir

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -36,7 +36,7 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
             float cameraPosX = CameraPcs.m_positionX;
             float cameraPosY = CameraPcs.m_positionY;
             float cameraPosZ = CameraPcs.m_positionZ;
-            float scale = 1.0f + ((CameraPcs.m_fov - 25.0f) / 25.0f);
+            float scale = kConstrainCameraDirScaleOne + ((CameraPcs.m_fov - 25.0f) / 25.0f);
 
             PSMTXIdentity(ppvMng->m_matrix.value);
 


### PR DESCRIPTION
## Summary
- Use the existing `kConstrainCameraDirScaleOne` constant for the camera scale baseline instead of a literal `1.0f`.

## Evidence
- `ninja` passes.
- `pppFrameConstrainCameraDir` objdiff improved from 99.76378% with 6 mismatches to 99.80315% with 5 mismatches.

## Plausibility
- The constant is already part of this unit declared PPP constants and is used nearby for the Z scale, so this is closer to plausible source than an inline literal.