### PR TITLE
Tighten math data split ranges

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -62,9 +62,9 @@ math.cpp:
 	extabindex  start:0x8000B1F4 end:0x8000B2CC
 	.text       start:0x8001A230 end:0x8001C2F0
 	.ctors      start:0x801D53B0 end:0x801D53B4
-	.data       start:0x801E8450 end:0x801E8470
+	.data       start:0x801E8450 end:0x801E846C
 	.bss        start:0x8023C4D8 end:0x8023C884
-	.sdata2     start:0x8032F740 end:0x8032F798
+	.sdata2     start:0x8032F740 end:0x8032F794
 
 memory.cpp:
 	extab       start:0x800059C0 end:0x80005BDC


### PR DESCRIPTION
## Summary
- tighten math.cpp .data and .sdata2 split endpoints to stop claiming trailing padding bytes
- removes main/math from the current agent_select_target data-opportunity list

## Evidence
- Before: agent_select_target listed main/math as a data opportunity with code 100.0%, data 97.75%
- After: main/math is no longer listed as a selected data opportunity
- ninja completes and build/GCCP01/main.dol matches config/GCCP01/build.sha1

## Plausibility
- The new endpoints line up with the last math-owned data symbols instead of extending into padding before the next file's data.
- No source-level compiler coaxing or manual vtable/RTTI definitions were added.