### PR TITLE
Improve CheckSum control flow

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -316,16 +316,15 @@ unsigned int CheckSum(void* data, int size)
             } while (blockCount != 0);
 
             size &= 7;
-            if (size == 0) {
-                return checksum;
-            }
         }
 
-        do {
-            checksum += *bytes;
-            bytes++;
-            size--;
-        } while (size != 0);
+        if (size != 0) {
+            do {
+                checksum += *bytes;
+                bytes++;
+                size--;
+            } while (size != 0);
+        }
     }
 
     return checksum;


### PR DESCRIPTION
## Summary
- Remove the early return in CheckSum after the unrolled 8-byte loop.
- Guard the remaining byte loop so the function uses the shared return path.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff: CheckSum__FPvi improved from 74.97059% to 78.97059% (size remains 136b)
- command: build/tools/objdiff-cli diff -p . -u main/memory -o - CheckSum__FPvi

## Plausibility
- This is equivalent control flow and avoids a separate early return, matching the reference shape more closely without changing checksum behavior.