### PR TITLE
Match ConstrainCameraDir scale constants

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -36,13 +36,13 @@ void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pp
             float cameraPosX = CameraPcs.m_positionX;
             float cameraPosY = CameraPcs.m_positionY;
             float cameraPosZ = CameraPcs.m_positionZ;
-            float scale = kConstrainCameraDirScaleOne + ((CameraPcs.m_fov - 25.0f) / 25.0f);
+            float scale = 1.0f + ((CameraPcs.m_fov - 25.0f) / 25.0f);
 
             PSMTXIdentity(ppvMng->m_matrix.value);
 
             pppMngSt->m_scale.x = kConstrainCameraDirWideAspect * scale;
             pppMngSt->m_scale.y = scale;
-            pppMngSt->m_scale.z = kConstrainCameraDirScaleOne;
+            pppMngSt->m_scale.z = 1.0f;
 
             Mtx scaleMtx;
             PSMTXScale(scaleMtx, pppMngSt->m_scale.x, pppMngSt->m_scale.y, pppMngSt->m_scale.z);


### PR DESCRIPTION
## Summary
- use local literal 1.0f scale constants in pppConstrainCameraDir instead of the shared kConstrainCameraDirScaleOne symbol
- matches the unit-local .sdata2 layout shown in the target assembly for pppConstrainCameraDir.cpp

## Evidence
- ninja builds successfully
- objdiff main/pppConstrainCameraDir: .sdata2 improved from 85.71429% to 100.0%
- objdiff [ .sdata2-0 ] improved from 85.71429% to 100.0%
- total matched data increased from 824911 to 824927 bytes in ninja progress

## Notes
- pppFrameConstrainCameraDir text score shifts slightly from 99.80315% to 99.72441% because the local literal relocations differ from the shared symbol names, but this is the source form needed to emit the target unit's local 1.0f data entry.