### PR TITLE
Match pppConstrainCameraDir local sdata

### DIFF
--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -6,6 +6,8 @@
 #include "ffcc/pppYmEnv.h"
 #include <dolphin/mtx.h>
 
+extern const float kConstrainCameraDirLocalOne = 1.0f;
+
 /*
  * --INFO--
  * PAL Address: 80143098


### PR DESCRIPTION
## Summary
- Add the missing local 1.0f constant in pppConstrainCameraDir so the unit emits the expected 16-byte .sdata2 layout.
- Leaves pppFrameConstrainCameraDir codegen unchanged while matching the local data block.

## Evidence
- ninja passes.
- objdiff main/pppConstrainCameraDir before: .text 99.828766%, .sdata2 85.71429% (target 16 bytes, current 12 bytes), pppFrameConstrainCameraDir 99.80315%.
- objdiff main/pppConstrainCameraDir after: .text 99.828766%, .sdata2 100.0% (target/current 16 bytes), pppFrameConstrainCameraDir 99.80315%.

## Plausibility
- The added constant matches the target unit's local .sdata2 ordering without changing function codegen or moving shared constants out of their current owner units.