### PR TITLE
Fix p_map profile global layout

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -26,7 +26,7 @@ public:
     ~CRelProfile();
 
 private:
-    unsigned char m_data;
+    unsigned int m_data;
 };
 
 unsigned int CMapPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CMapPcsFv)};
@@ -111,8 +111,8 @@ extern unsigned int s_loadedMapNo__7CMapPcs;
 CRelProfile g_mapStage;
 CRelProfile g_mapSection;
 CRelProfile g_hit_prof;
-unsigned char g_map_calc_prof;
-unsigned char g_map_draw_prof;
+unsigned char g_map_calc_prof ATTRIBUTE_ALIGN(4);
+unsigned char g_map_draw_prof ATTRIBUTE_ALIGN(4);
 extern const float DrawRangeDefault;
 extern const float kPMapBoundMinInit;
 extern const float kPMapBoundMaxInit;


### PR DESCRIPTION
## Summary
- Model CRelProfile storage as 4 bytes in p_map.
- Preserve 4-byte placement for g_map_calc_prof and g_map_draw_prof with explicit alignment.

## Evidence
- Built with ninja successfully.
- objdiff main/p_map __sinit_p_map_cpp:
  - g_mapStage: 50% -> 100% (size 4)
  - g_mapSection: 50% -> 100% (size 4)
  - g_map_calc_prof: remains 100% at offset 12
  - g_map_draw_prof: remains 100% at offset 16
  - __sinit_p_map_cpp text unchanged at 60.512295%
  - .data unchanged at 99.87212%

## Notes
- g_hit_prof remains a symbol-size mismatch in objdiff (100% -> 50%) after applying the 4-byte CRelProfile layout, but the surrounding profile globals now match the observed 4-byte object spacing.