### PR TITLE
Use shared constants in menu list timing

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -8,6 +8,13 @@
 #include "ffcc/system.h"
 #include <string.h>
 
+extern const float FLOAT_803333D0;
+extern const double DOUBLE_803333E8;
+extern const float FLOAT_803333F0;
+extern const double DOUBLE_80333410;
+extern const double DOUBLE_80333418;
+extern const double DOUBLE_80333420;
+
 STATIC_ASSERT(offsetof(CMenuPcs, listFont) == 0x108);
 STATIC_ASSERT(offsetof(CMenuPcs, helpFont) == 0xF8);
 STATIC_ASSERT(offsetof(CMenuPcs, lstState) == 0x82C);
@@ -171,13 +178,13 @@ int CMenuPcs::MLstClose()
 		if (entry->startFrame <= currentFrame) {
 			if (entry->startFrame + entry->duration <= currentFrame) {
 				completedItems++;
-				entry->alpha = 0.0f;
+				entry->alpha = FLOAT_803333D0;
 			} else {
 				entry->timer = entry->timer + 1;
-				double ratio = 1.0 / (double)entry->duration;
-				entry->alpha = (float)(1.0 - ratio * (double)entry->timer);
-				if ((double)entry->alpha < 0.0) {
-					entry->alpha = 0.0f;
+				double ratio = DOUBLE_80333410 / (double)entry->duration;
+				entry->alpha = (float)(DOUBLE_80333410 - ratio * (double)entry->timer);
+				if ((double)entry->alpha < DOUBLE_80333418) {
+					entry->alpha = FLOAT_803333D0;
 				}
 			}
 		}
@@ -185,7 +192,7 @@ int CMenuPcs::MLstClose()
 	}
 	result = 0;
 	if (this->lstData->count == completedItems) {
-		zero = 0.0f;
+		zero = FLOAT_803333D0;
 		entry = this->lstData->entries;
 		if ((int)itemCount > 0) {
 			count = itemCount >> 3;
@@ -317,7 +324,7 @@ int CMenuPcs::MLstCtrl()
 	}
 
 	if (result != 0) {
-		one = 1.0f;
+		one = FLOAT_803333F0;
 		MenuLstEntry* entry = this->lstData->entries;
 		for (i = 0; (itemCount = (unsigned int)this->lstData->count), i < (int)itemCount; i++) {
 			entry->alpha = one;
@@ -363,7 +370,7 @@ int CMenuPcs::MLstOpen()
 		short yPos;
 
 		memset(this->lstData, 0, sizeof(MenuLstList));
-		one = 1.0f;
+		one = FLOAT_803333F0;
 		entry = this->lstData->entries;
 		i = 8;
 		do {
@@ -379,7 +386,7 @@ int CMenuPcs::MLstOpen()
 			i--;
 		} while (i != 0);
 
-		zero = 0.0f;
+		zero = FLOAT_803333D0;
 		initializedCount = 0;
 		yPos = 0x18;
 		for (i = 0; i < 9; i++) {
@@ -389,7 +396,7 @@ int CMenuPcs::MLstOpen()
 			entry->tex = 0x5B;
 			entry->width = 0xE0;
 			entry->height = 0x28;
-			entry->x = (short)(int)-(((double)entry->width * 0.5) - 216.0);
+			entry->x = (short)(int)-(((double)entry->width * DOUBLE_803333E8) - DOUBLE_80333420);
 			entry->y = yPos;
 			yPos += 0x20;
 			entry->s = zero;
@@ -410,10 +417,10 @@ int CMenuPcs::MLstOpen()
 		if (entry->startFrame <= currentFrame) {
 			if (entry->startFrame + entry->duration <= currentFrame) {
 				completedItems++;
-				entry->alpha = 1.0f;
+				entry->alpha = FLOAT_803333F0;
 			} else {
 				entry->timer = entry->timer + 1;
-				double ratio = 1.0 / (double)entry->duration;
+				double ratio = DOUBLE_80333410 / (double)entry->duration;
 				entry->alpha = (float)(ratio * (double)entry->timer);
 			}
 		}
@@ -422,7 +429,7 @@ int CMenuPcs::MLstOpen()
 
 	int result = 0;
 	if (this->lstData->count == completedItems) {
-		one = 1.0f;
+		one = FLOAT_803333F0;
 		entry = this->lstData->entries;
 		if ((int)itemCount > 0) {
 			count = itemCount >> 3;


### PR DESCRIPTION
## Summary
- Reference existing shared menu constants in the menu list open/close/control timing paths instead of local literals.
- Leaves the draw path unchanged after testing showed those constant substitutions regressed its match.

## Objdiff evidence
- Unit: main/menu_lst
- .text: 87.451096% -> 87.83659%
- MLstClose__8CMenuPcsFv: 86.35514% -> 89.345795%
- MLstCtrl__8CMenuPcsFv: 95.246635% -> 95.26906%
- MLstOpen__8CMenuPcsFv: 88.155556% -> 88.21111%
- MLstDraw__8CMenuPcsFv unchanged at 82.58218%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst_after_narrow.json

This follows the existing constant ownership from the adjacent menu code and reduces local literal-pool drift without changing behavior.