### PR TITLE
Improve map material lookup matching

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1479,9 +1479,12 @@ void CVector::operator=(const CVector& other)
  */
 CVector::CVector(const CVector& other)
 {
-    x = other.x;
-    y = other.y;
-    z = other.z;
+    float x = other.x;
+    float y = other.y;
+    this->x = x;
+    float z = other.z;
+    this->y = y;
+    this->z = z;
 }
 
 /*

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -261,10 +261,12 @@ float CMapKeyFrame::Get()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 extern "C" unsigned long UnkMaterialSetGetter(void* ptrArray)
 {
     return *reinterpret_cast<unsigned long*>(reinterpret_cast<unsigned char*>(ptrArray) + 4);
 }
+#pragma dont_inline reset
 
 /*
  * --INFO--
@@ -3266,14 +3268,14 @@ int CMapMng::GetMapObjIdx(unsigned short id)
  */
 CMaterial* CMapMng::GetMaterialID(unsigned char materialId)
 {
-    unsigned long index = 0;
     unsigned char* materialSet = reinterpret_cast<unsigned char*>(m_materialSet);
-    CPtrArray<CMaterial*>* materials = reinterpret_cast<CPtrArray<CMaterial*>*>(materialSet + 8);
+    unsigned long index = 0;
 
-    while (index < UnkMaterialSetGetter(materials)) {
-        CMaterial* material = (*materials)[index];
-        if (material != 0 && reinterpret_cast<unsigned char*>(material)[0xA6] == materialId) {
-            return (*materials)[index];
+    while (index < UnkMaterialSetGetter(materialSet + 8)) {
+        if ((*reinterpret_cast<CPtrArray<CMaterial*>*>(materialSet + 8))[index] != 0
+            && materialId == reinterpret_cast<unsigned char*>(
+                                (*reinterpret_cast<CPtrArray<CMaterial*>*>(materialSet + 8))[index])[0xA6]) {
+            return (*reinterpret_cast<CPtrArray<CMaterial*>*>(materialSet + 8))[index];
         }
         index++;
     }


### PR DESCRIPTION
## Summary
- Keep `UnkMaterialSetGetter` out-of-line in `map.cpp` so `CMapMng::GetMaterialID` preserves the target call shape.
- Rewrite `GetMaterialID` pointer usage to match the original material-array access pattern.
- Adjust `CVector` copy construction to use the same temp-copy style as the existing assignment operator.

## Objdiff Evidence
- `main/map` `GetMaterialID__7CMapMngFUc`: 76.128204% -> 100.0%
- `main/map` `UnkMaterialSetGetter`: 100.0%
- `main/cflat_r2system` `__ct__7CVectorFRC7CVector`: 70.57143% -> 98.28571%

## Verification
- `ninja`
- `build/GCCP01/main.dol: OK`