### PR TITLE
Improve pppYmTracer2 constant matching

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -156,11 +156,11 @@ void pppRenderYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, p
                     uTop = (f32)i * uvStep;
                     uBottom = (f32)(i + 1) * uvStep;
 
-                    if (alphaScale < 0.0f) {
-                        alphaScale = 0.0f;
+                    if (alphaScale < FLOAT_80331840) {
+                        alphaScale = FLOAT_80331840;
                     }
-                    if (alphaScale > 1.0f) {
-                        alphaScale = 1.0f;
+                    if (alphaScale > FLOAT_80331844) {
+                        alphaScale = FLOAT_80331844;
                     }
 
                     colorTop = g_pppYmTracer2_1;


### PR DESCRIPTION
## Summary
- Use the existing pppYmTracer2 zero/one constants for render alpha clamping instead of anonymous float literals.
- This restores the unit constant layout used by the later frame logic.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o -:
  - pppFrameYmTracer2: 99.96403% -> 100.0%
  - [extabindex-0]: 98.333336% -> 100.0%
  - [.sdata2-0]: 90.909096% -> 100.0%
- Build report data improved from 824786 to 824822 matched bytes overall, and game data from 648122 to 648158 matched bytes.

## Plausibility
- The clamp now uses the same unit-local constants already used throughout the file for 0.0f and 1.0f, rather than introducing duplicate anonymous literals.