### PR TITLE
Recover CGCharaObj virtual collision hooks

### DIFF
--- a/include/ffcc/charaobj.h
+++ b/include/ffcc/charaobj.h
@@ -53,13 +53,19 @@ public:
 	int onHit(int, CGObject*, int, Vec*);
 	void onHitParticle(int, int, int, int, Vec*, PPPIFPARAM*);
 	int getReplaceStat(int);
+	virtual void onStatDie();
+	virtual void onDamage(CGPrgObj*, int, int, int, Vec*);
+	virtual void onStatMagic();
+	virtual void onStatAttack(int);
+	virtual void onStatShield();
+	virtual void enableAttackCol(int, int, int);
+	virtual void enableDamageCol(int);
 	void putHitParticleFromItem(CGPrgObj*, int);
 	void setSta(int, int);
 	void effective(int, int, CGPrgObj*, int&);
 	void calcSta(int, int, CGObject*);
 	void addHp(int, CGPrgObj*);
 	void calcRegist(int, int, int&, int&, int&, int);
-	void onDamage(CGPrgObj*, int, int, int, Vec*);
 	int getItemPdt(int, int, int&, int&, int&);
 	void putParticleFromItem(int, int, int, Vec*);
 	void statShield();
@@ -67,10 +73,6 @@ public:
 	void statDie();
 	void statMagic();
 	void statKizetsu();
-	void onStatMagic();
-	void onStatShield();
-	void onStatAttack(int);
-	void onStatDie();
 	void statDamage();
 	void statButtobi();
 	void onChangePrg(int);
@@ -84,9 +86,7 @@ public:
 	void scCheckItem(CCombi2Set*, CGCharaObj*, int);
 	void scCheckTime(CCombi2Set*, CGCharaObj*, CGCharaObj*, int);
 	int searchCombi(int, CGPartyObj **, int&);
-	void enableAttackCol(int, int, int);
 	int GetCID();
-	void enableDamageCol(int);
 
 	int m_attackAnimId;
 	int m_unk554;

--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -512,7 +512,7 @@ void CGMonObj::cancelStatFuncArmstrong()
 {
 	CGPrgObj* prgObj = reinterpret_cast<CGPrgObj*>(this);
 	if (prgObj->m_lastStateId == 100) {
-		reinterpret_cast<CGCharaObj*>(this)->enableDamageCol(1);
+		enableDamageCol(1);
 	}
 }
 


### PR DESCRIPTION
## Summary
- mark the CGCharaObj stat/collision hook cluster as virtual in the PAL vtable order
- let CGMonObj::cancelStatFuncArmstrong dispatch enableDamageCol through the recovered virtual slot

## Objdiff evidence
- main/charaobj __vt__10CGCharaObj: 82.859900% -> 97.333336%
- main/monobj_boss cancelStatFuncArmstrong__8CGMonObjFv: 60.875000% -> 93.125000%
- main/monobj_boss frameStatFuncArmstrong__8CGMonObjFv: 54.459460% -> 77.972980%
- main/partyobj onStatDie__10CGPartyObjFv: 49.521280% -> 85.287230%
- main/partyobj InitFinished__10CGPartyObjFv: 39.322582% -> 62.903225%
- main/partyobj setAlive__10CGPartyObjFii: 32.298428% -> 45.413612%
- main/charaobj .data: 29.154410% -> 34.246914%
- main/monobj_boss .text: 72.923930% -> 73.212010%

Known mixed effects from making the hooks real virtuals:
- main/partyobj onFrameStat__10CGPartyObjFv: 35.279182% -> 10.527237%
- main/monobj __vt__8CGMonObj: 58.801025% -> 48.311687%

## Rationale
The PAL assembly for CGCharaObj::__vtable shows the new virtual cluster after CGPrgObj::onAttacked in this order: onStatDie, onDamage, onStatMagic, onStatAttack, onStatShield, enableAttackCol, enableDamageCol. This puts enableDamageCol at vtable offset 0x94, matching the virtual calls seen in partyobj and monobj_boss. The regressions are in already-unmatched surrounding code/data, but the declarations are more coherent with the shipped vtable layout and unlock the correct dispatch slot.