### PR TITLE
Improve pppRenderYmBreath match

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -287,13 +287,13 @@ extern "C" void pppRenderYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, p
     PARTICLE_WMAT* matrixList;
     PARTICLE_COLOR* particleColor;
     YmBreathParticleGroup* groupData;
+    int i;
     int groupCount;
     long** shape;
-    unsigned char colorR;
-    unsigned char colorG;
-    unsigned char colorB;
-    unsigned char colorA;
-    int i;
+    int colorR;
+    int colorG;
+    int colorB;
+    int colorA;
     _GXColor drawColor;
     _GXColor debugColor;
     Vec debugPos;


### PR DESCRIPTION
Summary
- Use integer locals for the persistent render color channels in pppRenderYmBreath.
- Move the main loop counter declaration next to the other long-lived render locals to better match register allocation.

Evidence
- ninja passes.
- Objdiff for main/pppYmBreath pppRenderYmBreath:
  - pppRenderYmBreath: 98.83282% -> 99.80805%.
  - unit .text: 99.36076% -> 99.555695%.
  - extab, extabindex, and .sdata2 remain 100%.

Plausibility
- The color channels are immediately promoted for integer arithmetic and clamped before being written to GXColor, so keeping them as int locals is plausible original C source.
- The loop counter declaration change only affects local lifetime/register allocation and keeps render control flow unchanged.