### PR TITLE
Fix menu_arti sdata2 ownership

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -25,7 +25,7 @@ extern const float FLOAT_80332fd4;
 extern const float FLOAT_80332fd8;
 extern const float FLOAT_80332fe8;
 extern const float FLOAT_80332fec;
-static const float FLOAT_80332ff0 = 0.75f;
+extern const float FLOAT_80332ff0;
 
 extern "C" {
 extern const float kMenuArtiNegativeOne = -1.0f;


### PR DESCRIPTION
## Summary
- Treat `FLOAT_80332ff0` as an external sdata2 constant instead of defining it in `menu_arti.cpp`.
- This matches MAP ownership: `FLOAT_80332ff0` is attributed to `auto_11_803320C8_sdata2.o`, while `menu_arti.o` owns only the 0x60-byte option/constant block at `0x80333448`.

## Evidence
- `ninja` passes.
- `main/menu_arti` `.sdata2` section: 132 bytes / 84.210526% before, 96 bytes / 100.0% after.
- Tradeoff: `ArtiInit__8CMenuPcsFv` moves from 70.91765% to 70.564705%; this is accepted because the data ownership now matches the MAP and removes an incorrect local constant definition.

## Plausibility
- The original object should reference the existing shared `FLOAT_80332ff0` symbol rather than emit a duplicate local 0.75f constant in `menu_arti.o`.
