### PR TITLE
Improve cflat_r2system fuzzy matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -498,7 +498,7 @@ config.libs = [
             Object(NonMatching, "bonus_menu.cpp"),
             Object(NonMatching, "cflat_data.cpp"),
             Object(NonMatching, "cflat_r2class.cpp"),
-            Object(NonMatching, "cflat_r2system.cpp", extra_cflags=["-opt space"]),
+            Object(NonMatching, "cflat_r2system.cpp", extra_cflags=["-opt space", "-inline auto,deferred"]),
             Object(NonMatching, "cflat_runtime.cpp"),
             Object(NonMatching, "cflat_runtime2.cpp", extra_cflags=["-inline auto,deferred"]),
             Object(NonMatching, "chara_anim.cpp", extra_cflags=["-inline auto,deferred", "-RTTI on"]),

--- a/configure.py
+++ b/configure.py
@@ -498,7 +498,7 @@ config.libs = [
             Object(NonMatching, "bonus_menu.cpp"),
             Object(NonMatching, "cflat_data.cpp"),
             Object(NonMatching, "cflat_r2class.cpp"),
-            Object(NonMatching, "cflat_r2system.cpp"),
+            Object(NonMatching, "cflat_r2system.cpp", extra_cflags=["-opt space"]),
             Object(NonMatching, "cflat_runtime.cpp"),
             Object(NonMatching, "cflat_runtime2.cpp", extra_cflags=["-inline auto,deferred"]),
             Object(NonMatching, "chara_anim.cpp", extra_cflags=["-inline auto,deferred", "-RTTI on"]),

--- a/configure.py
+++ b/configure.py
@@ -498,7 +498,11 @@ config.libs = [
             Object(NonMatching, "bonus_menu.cpp"),
             Object(NonMatching, "cflat_data.cpp"),
             Object(NonMatching, "cflat_r2class.cpp"),
-            Object(NonMatching, "cflat_r2system.cpp", extra_cflags=["-opt space", "-inline auto,deferred"]),
+            Object(
+                NonMatching,
+                "cflat_r2system.cpp",
+                extra_cflags=["-opt space", "-inline auto,deferred", "-str reuse,pool,readonly"],
+            ),
             Object(NonMatching, "cflat_runtime.cpp"),
             Object(NonMatching, "cflat_runtime2.cpp", extra_cflags=["-inline auto,deferred"]),
             Object(NonMatching, "chara_anim.cpp", extra_cflags=["-inline auto,deferred", "-RTTI on"]),

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4336,72 +4336,23 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         FlatLastResult(this) = static_cast<unsigned int>(static_cast<int>(*artifact));
     } else {
         switch (systemValue) {
-        case -0x7A:
-            FlatLastResult(this) = 1;
-            if (gameWork.m_languageId == 3) {
-                FlatLastResult(this) = 6;
-            } else if (gameWork.m_languageId < 3) {
-                if (gameWork.m_languageId == 1) {
-                    FlatLastResult(this) = 3;
-                } else if (gameWork.m_languageId == 0) {
-                    FlatLastResult(this) = 1;
-                } else {
-                    FlatLastResult(this) = 5;
-                }
-            } else if (gameWork.m_languageId == 5) {
-                FlatLastResult(this) = 7;
-            } else if (gameWork.m_languageId < 5) {
-                FlatLastResult(this) = 4;
-            }
+        case -0x40:
+            FlatLastResult(this) = gameWork.m_scriptSysVal0;
             break;
-        case -0x78:
-            FlatLastResult(this) = gameWork.m_gameOverFlag;
+        case -0x41:
+            FlatLastResult(this) = gameWork.m_timerA;
             break;
-        case -0x76:
-            FlatLastResult(this) = gameWork.m_menuStageMode;
+        case -0x42:
+            FlatLastResult(this) = gameWork.m_scriptGlobalTime;
             break;
-        case -0x73:
-        case -0x72:
-        case -0x71:
-        case -0x70:
-        case -0x6F:
-        case -0x6E:
-        case -0x6D:
-        case -0x6C: {
-            u8* usbEdit = game + (systemValue + 0x73) * 0xC30;
-            if (*(int*)(usbEdit + 0x1794) == 0) {
-                FlatLastResult(this) = 0;
-            } else {
-                FlatLastResult(this) = *(unsigned short*)(usbEdit + 0x1404);
-            }
+        case -0x43:
+            FlatLastResult(this) = gameWork.m_frameCounter;
             break;
-        }
-        case -0x6B:
-        case -0x6A:
-        case -0x69:
-        case -0x68:
-        case -0x67:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_eventWork + systemValue * 2 + 0x50);
-            break;
-        case -0x66:
-            FlatLastResult(this) = gameWork.m_chaliceElement;
-            break;
-        case -0x65:
-        case -100:
-        case -99:
-        case -0x62:
-        case -0x61:
-        case -0x60:
-        case -0x5F:
-        case -0x5E:
-        case -0x5D:
-        case -0x5C:
-        case -0x5B:
-        case -0x5A:
-        case -0x59:
-        case -0x58:
-        case -0x57:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][5][3] + systemValue * 4);
+        case -0x47:
+        case -0x46:
+        case -0x45:
+        case -0x44:
+            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][2][2] + systemValue * 4 + 4);
             break;
         case -0x56:
         case -0x55:
@@ -4420,23 +4371,72 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x48:
             FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][3][4] + systemValue * 4);
             break;
-        case -0x47:
-        case -0x46:
-        case -0x45:
-        case -0x44:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][2][2] + systemValue * 4 + 4);
+        case -0x65:
+        case -100:
+        case -99:
+        case -0x62:
+        case -0x61:
+        case -0x60:
+        case -0x5F:
+        case -0x5E:
+        case -0x5D:
+        case -0x5C:
+        case -0x5B:
+        case -0x5A:
+        case -0x59:
+        case -0x58:
+        case -0x57:
+            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][5][3] + systemValue * 4);
             break;
-        case -0x43:
-            FlatLastResult(this) = gameWork.m_frameCounter;
+        case -0x66:
+            FlatLastResult(this) = gameWork.m_chaliceElement;
             break;
-        case -0x42:
-            FlatLastResult(this) = gameWork.m_scriptGlobalTime;
+        case -0x6B:
+        case -0x6A:
+        case -0x69:
+        case -0x68:
+        case -0x67:
+            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_eventWork + systemValue * 2 + 0x50);
             break;
-        case -0x41:
-            FlatLastResult(this) = gameWork.m_timerA;
+        case -0x73:
+        case -0x72:
+        case -0x71:
+        case -0x70:
+        case -0x6F:
+        case -0x6E:
+        case -0x6D:
+        case -0x6C: {
+            u8* usbEdit = game + (systemValue + 0x73) * 0xC30;
+            if (*(int*)(usbEdit + 0x1794) == 0) {
+                FlatLastResult(this) = 0;
+            } else {
+                FlatLastResult(this) = *(unsigned short*)(usbEdit + 0x1404);
+            }
             break;
-        case -0x40:
-            FlatLastResult(this) = gameWork.m_scriptSysVal0;
+        }
+        case -0x76:
+            FlatLastResult(this) = gameWork.m_menuStageMode;
+            break;
+        case -0x78:
+            FlatLastResult(this) = gameWork.m_gameOverFlag;
+            break;
+        case -0x7A:
+            FlatLastResult(this) = 1;
+            if (gameWork.m_languageId == 3) {
+                FlatLastResult(this) = 6;
+            } else if (gameWork.m_languageId < 3) {
+                if (gameWork.m_languageId == 1) {
+                    FlatLastResult(this) = 3;
+                } else if (gameWork.m_languageId == 0) {
+                    FlatLastResult(this) = 1;
+                } else {
+                    FlatLastResult(this) = 5;
+                }
+            } else if (gameWork.m_languageId == 5) {
+                FlatLastResult(this) = 7;
+            } else if (gameWork.m_languageId < 5) {
+                FlatLastResult(this) = 4;
+            }
             break;
         default:
             break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4496,71 +4496,72 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             }
         } else {
             switch (systemValue) {
-            case -0x79:
-                stack[-1].m_word = static_cast<int>(static_cast<short>(gameWork.m_optionValue));
+            case -0x40:
+                stack[-1].m_word = *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0);
                 if (setMode == 0) {
-                    gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
+                    *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) = stack->m_word;
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_optionValue =
-                            static_cast<unsigned short>(gameWork.m_optionValue - static_cast<short>(stack->m_word));
+                        *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
+                            *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) - stack->m_word;
                     }
                 } else if (setMode < 2) {
-                    gameWork.m_optionValue =
-                        static_cast<unsigned short>(gameWork.m_optionValue + static_cast<short>(stack->m_word));
+                    *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
+                        *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) + stack->m_word;
                 }
                 break;
-            case -0x77:
-                stack[-1].m_word = static_cast<unsigned int>(gameWork.m_soundOptionFlag);
+            case -0x41:
+                stack[-1].m_word = gameWork.m_timerA;
                 if (setMode == 0) {
-                    gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
+                    gameWork.m_timerA = stack->m_word;
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_soundOptionFlag =
-                            static_cast<unsigned char>(gameWork.m_soundOptionFlag - static_cast<char>(stack->m_word));
+                        gameWork.m_timerA = gameWork.m_timerA - stack->m_word;
                     }
                 } else if (setMode < 2) {
-                    gameWork.m_soundOptionFlag =
-                        static_cast<unsigned char>(gameWork.m_soundOptionFlag + static_cast<char>(stack->m_word));
+                    gameWork.m_timerA = gameWork.m_timerA + stack->m_word;
                 }
                 break;
-            case -0x76: {
-                unsigned int value = static_cast<unsigned int>(gameWork.m_menuStageMode);
-                stack[-1].m_word = value;
+            case -0x42:
+                stack[-1].m_word = gameWork.m_scriptGlobalTime;
                 if (setMode == 0) {
-                    value = stack->m_word;
+                    gameWork.m_scriptGlobalTime = stack->m_word;
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        value = value - stack->m_word;
+                        gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime - stack->m_word;
                     }
                 } else if (setMode < 2) {
-                    value = value + stack->m_word;
+                    gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime + stack->m_word;
                 }
-                MenuPcs.ChgPlayModeFromScript(static_cast<bool>((static_cast<unsigned char>(-value >> 24) |
-                                                                static_cast<unsigned char>(value >> 24)) >>
-                                                               7));
                 break;
-            }
-            case -0x75:
-                stack[-1].m_word = static_cast<int>(gameWork.m_bossArtifactStageIndex);
+            case -0x43:
+                stack[-1].m_word = gameWork.m_frameCounter;
                 if (setMode == 0) {
-                    gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
+                    gameWork.m_frameCounter = stack->m_word;
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_bossArtifactStageIndex =
-                            static_cast<short>(gameWork.m_bossArtifactStageIndex - static_cast<short>(stack->m_word));
+                        gameWork.m_frameCounter = gameWork.m_frameCounter - stack->m_word;
                     }
                 } else if (setMode < 2) {
-                    gameWork.m_bossArtifactStageIndex =
-                        static_cast<short>(gameWork.m_bossArtifactStageIndex + static_cast<short>(stack->m_word));
+                    gameWork.m_frameCounter = gameWork.m_frameCounter + stack->m_word;
                 }
                 break;
-            case -0x6B:
-            case -0x6A:
-            case -0x69:
-            case -0x68:
-            case -0x67: {
-                int* value = reinterpret_cast<int*>(gameWork.m_eventWork + systemValue * 2 + 0x50);
+            case -0x56:
+            case -0x55:
+            case -0x54:
+            case -0x53:
+            case -0x52:
+            case -0x51:
+            case -0x50:
+            case -0x4F:
+            case -0x4E:
+            case -0x4D:
+            case -0x4C:
+            case -0x4B:
+            case -0x4A:
+            case -0x49:
+            case -0x48: {
+                unsigned char* value = gameWork.m_linkTable[0][3][4] + systemValue * 4;
                 stack[-1].m_word = *reinterpret_cast<unsigned int*>(value);
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(value) = stack->m_word;
@@ -4573,18 +4574,6 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 }
                 break;
             }
-            case -0x66:
-                stack[-1].m_word = gameWork.m_chaliceElement;
-                if (setMode == 0) {
-                    gameWork.m_chaliceElement = stack->m_word;
-                } else if (setMode < 0) {
-                    if (setMode >= -1) {
-                        gameWork.m_chaliceElement = gameWork.m_chaliceElement - stack->m_word;
-                    }
-                } else if (setMode < 2) {
-                    gameWork.m_chaliceElement = gameWork.m_chaliceElement + stack->m_word;
-                }
-                break;
             case -0x65:
             case -100:
             case -99:
@@ -4615,22 +4604,24 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 }
                 break;
             }
-            case -0x56:
-            case -0x55:
-            case -0x54:
-            case -0x53:
-            case -0x52:
-            case -0x51:
-            case -0x50:
-            case -0x4F:
-            case -0x4E:
-            case -0x4D:
-            case -0x4C:
-            case -0x4B:
-            case -0x4A:
-            case -0x49:
-            case -0x48: {
-                unsigned char* value = gameWork.m_linkTable[0][3][4] + systemValue * 4;
+            case -0x66:
+                stack[-1].m_word = gameWork.m_chaliceElement;
+                if (setMode == 0) {
+                    gameWork.m_chaliceElement = stack->m_word;
+                } else if (setMode < 0) {
+                    if (setMode >= -1) {
+                        gameWork.m_chaliceElement = gameWork.m_chaliceElement - stack->m_word;
+                    }
+                } else if (setMode < 2) {
+                    gameWork.m_chaliceElement = gameWork.m_chaliceElement + stack->m_word;
+                }
+                break;
+            case -0x6B:
+            case -0x6A:
+            case -0x69:
+            case -0x68:
+            case -0x67: {
+                int* value = reinterpret_cast<int*>(gameWork.m_eventWork + systemValue * 2 + 0x50);
                 stack[-1].m_word = *reinterpret_cast<unsigned int*>(value);
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(value) = stack->m_word;
@@ -4664,54 +4655,63 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 }
                 break;
             }
-            case -0x43:
-                stack[-1].m_word = gameWork.m_frameCounter;
+            case -0x75:
+                stack[-1].m_word = static_cast<int>(gameWork.m_bossArtifactStageIndex);
                 if (setMode == 0) {
-                    gameWork.m_frameCounter = stack->m_word;
+                    gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_frameCounter = gameWork.m_frameCounter - stack->m_word;
+                        gameWork.m_bossArtifactStageIndex =
+                            static_cast<short>(gameWork.m_bossArtifactStageIndex - static_cast<short>(stack->m_word));
                     }
                 } else if (setMode < 2) {
-                    gameWork.m_frameCounter = gameWork.m_frameCounter + stack->m_word;
+                    gameWork.m_bossArtifactStageIndex =
+                        static_cast<short>(gameWork.m_bossArtifactStageIndex + static_cast<short>(stack->m_word));
                 }
                 break;
-            case -0x42:
-                stack[-1].m_word = gameWork.m_scriptGlobalTime;
+            case -0x76: {
+                unsigned int value = static_cast<unsigned int>(gameWork.m_menuStageMode);
+                stack[-1].m_word = value;
                 if (setMode == 0) {
-                    gameWork.m_scriptGlobalTime = stack->m_word;
+                    value = stack->m_word;
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime - stack->m_word;
+                        value = value - stack->m_word;
                     }
                 } else if (setMode < 2) {
-                    gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime + stack->m_word;
+                    value = value + stack->m_word;
+                }
+                MenuPcs.ChgPlayModeFromScript(static_cast<bool>((static_cast<unsigned char>(-value >> 24) |
+                                                                static_cast<unsigned char>(value >> 24)) >>
+                                                               7));
+                break;
+            }
+            case -0x77:
+                stack[-1].m_word = static_cast<unsigned int>(gameWork.m_soundOptionFlag);
+                if (setMode == 0) {
+                    gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
+                } else if (setMode < 0) {
+                    if (setMode >= -1) {
+                        gameWork.m_soundOptionFlag =
+                            static_cast<unsigned char>(gameWork.m_soundOptionFlag - static_cast<char>(stack->m_word));
+                    }
+                } else if (setMode < 2) {
+                    gameWork.m_soundOptionFlag =
+                        static_cast<unsigned char>(gameWork.m_soundOptionFlag + static_cast<char>(stack->m_word));
                 }
                 break;
-            case -0x41:
-                stack[-1].m_word = gameWork.m_timerA;
+            case -0x79:
+                stack[-1].m_word = static_cast<int>(static_cast<short>(gameWork.m_optionValue));
                 if (setMode == 0) {
-                    gameWork.m_timerA = stack->m_word;
+                    gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
                 } else if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_timerA = gameWork.m_timerA - stack->m_word;
+                        gameWork.m_optionValue =
+                            static_cast<unsigned short>(gameWork.m_optionValue - static_cast<short>(stack->m_word));
                     }
                 } else if (setMode < 2) {
-                    gameWork.m_timerA = gameWork.m_timerA + stack->m_word;
-                }
-                break;
-            case -0x40:
-                stack[-1].m_word = *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0);
-                if (setMode == 0) {
-                    *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) = stack->m_word;
-                } else if (setMode < 0) {
-                    if (setMode >= -1) {
-                        *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
-                            *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) - stack->m_word;
-                    }
-                } else if (setMode < 2) {
-                    *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
-                        *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) + stack->m_word;
+                    gameWork.m_optionValue =
+                        static_cast<unsigned short>(gameWork.m_optionValue + static_cast<short>(stack->m_word));
                 }
                 break;
             default:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4330,10 +4330,8 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         int bitIndex = systemValue + 0x9F3;
         int byteIndex = bitIndex / 8 + 8;
         unsigned int mask = 1U << (bitIndex % 8);
-        FlatLastResult(this) =
-            ((static_cast<unsigned int>(static_cast<unsigned char>(gameWork.m_eventFlags[byteIndex])) & mask) != 0)
-                ? 1U
-                : 0U;
+        unsigned int flag = static_cast<unsigned int>(static_cast<unsigned char>(gameWork.m_eventFlags[byteIndex])) & mask;
+        FlatLastResult(this) = (flag | -flag) >> 31;
     } else if (systemValue <= -200) {
         FlatLastResult(this) = static_cast<unsigned int>(
             static_cast<int>(static_cast<short>(Game.m_caravanWorkArr[0].m_artifacts[systemValue + 0x1E])));
@@ -4466,7 +4464,8 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             int bitIndex = systemValue + 0x9F3;
             unsigned char* flagByte = reinterpret_cast<unsigned char*>(gameWork.m_eventFlags) + bitIndex / 8;
             unsigned int mask = 1U << (bitIndex % 8);
-            unsigned int value = (*flagByte & mask) != 0;
+            unsigned int flag = *flagByte & mask;
+            unsigned int value = (flag | -flag) >> 31;
             stack[-1].m_word = value;
 
             if (setMode == 0) {

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4333,8 +4333,8 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         unsigned int flag = static_cast<unsigned int>(static_cast<unsigned char>(gameWork.m_eventFlags[byteIndex])) & mask;
         FlatLastResult(this) = (flag | -flag) >> 31;
     } else if (systemValue <= -200) {
-        FlatLastResult(this) = static_cast<unsigned int>(
-            static_cast<int>(static_cast<short>(Game.m_caravanWorkArr[0].m_artifacts[systemValue + 0x1E])));
+        short* artifact = gameWork.m_eventWork + systemValue + 0x1C7;
+        FlatLastResult(this) = static_cast<unsigned int>(static_cast<int>(*artifact));
     } else {
         switch (systemValue) {
         case -0x7A:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4420,24 +4420,26 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x78:
             FlatLastResult(this) = gameWork.m_gameOverFlag;
             break;
-        case -0x7A:
-            FlatLastResult(this) = 1;
+        case -0x7A: {
+            unsigned int languageValue = 1;
             if (gameWork.m_languageId == 3) {
-                FlatLastResult(this) = 6;
+                languageValue = 6;
             } else if (gameWork.m_languageId < 3) {
                 if (gameWork.m_languageId == 1) {
-                    FlatLastResult(this) = 3;
+                    languageValue = 3;
                 } else if (gameWork.m_languageId == 0) {
-                    FlatLastResult(this) = 1;
+                    languageValue = 1;
                 } else {
-                    FlatLastResult(this) = 5;
+                    languageValue = 5;
                 }
             } else if (gameWork.m_languageId == 5) {
-                FlatLastResult(this) = 7;
+                languageValue = 7;
             } else if (gameWork.m_languageId < 5) {
-                FlatLastResult(this) = 4;
+                languageValue = 4;
             }
+            FlatLastResult(this) = languageValue;
             break;
+        }
         default:
             break;
         }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -121,6 +121,12 @@ static const char s_cflatAddNoFreeWaveFmt[] =
 static const char s_cflatLoadCompleted[] = "\212\256\227\271";
 static const char s_cflatLoadNotCompleted[] = "\226\242\212\256\227\271";
 
+static inline int RemapPadSlot(CPad* pad, unsigned int padIndex)
+{
+    int activePad = pad->_448_4_;
+    return static_cast<int>(padIndex & ~(static_cast<int>(~((activePad - padIndex) | (padIndex - activePad))) >> 31));
+}
+
 static inline void StoreSetU32(CFlatRuntime::CStack* stack, int setMode, unsigned int* value)
 {
     stack[-1].m_word = *value;
@@ -721,7 +727,7 @@ done_check:
     if (isInvalidPad) {
         result = 0;
     } else {
-        int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+        int slot = RemapPadSlot(this, padIndex);
         result = GetPadInputs()[slot].buttonDown[1];
     }
 
@@ -756,7 +762,7 @@ done_check:
         return FLOAT_80330B30;
     }
 
-    int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+    int slot = RemapPadSlot(this, padIndex);
     return GetPadInputs()[slot].substickYF;
 }
 
@@ -788,7 +794,7 @@ done_check:
         return FLOAT_80330B30;
     }
 
-    int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+    int slot = RemapPadSlot(this, padIndex);
     return GetPadInputs()[slot].substickXF;
 }
 
@@ -820,7 +826,7 @@ done_check:
         return FLOAT_80330B30;
     }
 
-    int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+    int slot = RemapPadSlot(this, padIndex);
     return GetPadInputs()[slot].stickYF;
 }
 
@@ -852,7 +858,7 @@ done_check:
         return FLOAT_80330B30;
     }
 
-    int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+    int slot = RemapPadSlot(this, padIndex);
     return GetPadInputs()[slot].stickXF;
 }
 
@@ -884,7 +890,7 @@ done_check:
     if (isInvalidPad) {
         result = 0;
     } else {
-        int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+        int slot = RemapPadSlot(this, padIndex);
         result = GetPadInputs()[slot].repeatButton;
     }
 
@@ -919,7 +925,7 @@ done_check:
     if (isInvalidPad) {
         result = 0;
     } else {
-        int slot = (_448_4_ == padIndex) ? 0 : static_cast<int>(padIndex);
+        int slot = RemapPadSlot(this, padIndex);
         result = GetPadInputs()[slot].button[0];
     }
 

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -681,8 +681,9 @@ int CCaravanWork::GetEvtFlag(int evtFlagIndex)
     int byteIndex = evtFlagIndex / 8;
     unsigned char value = evtFlags[byteIndex];
     int mask = 1 << (evtFlagIndex % 8);
+    unsigned int flag = value & mask;
 
-    return (value & mask) != 0;
+    return (flag | -flag) >> 31;
 }
 
 /*

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1447,7 +1447,7 @@ CVector CVector::operator+(const CVector& other) const
     CVector out;
 
     PSVECAdd((const Vec*)this, (const Vec*)&other, (Vec*)&out);
-    return CVector(out.x, out.y, out.z);
+    return out;
 }
 
 /*

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1559,17 +1559,15 @@ void CGame::SetNextScript(CGame::CNextScript* nextScript)
 {
     unsigned int* dst = (unsigned int*)((char*)&m_nextScript - 4);
     unsigned int* src = (unsigned int*)((char*)nextScript - 4);
-    int count = 0x20;
 
-    do {
+    for (int i = 0; i < 0x20; i++) {
         unsigned int a = src[1];
         src += 2;
         unsigned int b = src[0];
         dst[1] = a;
         dst += 2;
         dst[0] = b;
-        count--;
-    } while (count != 0);
+    }
 
     m_newGameFlag = 1;
 }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4683,9 +4683,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 } else if (setMode < 2) {
                     value = value + stack->m_word;
                 }
-                MenuPcs.ChgPlayModeFromScript(static_cast<bool>((static_cast<unsigned char>(-value >> 24) |
-                                                                static_cast<unsigned char>(value >> 24)) >>
-                                                               7));
+                MenuPcs.ChgPlayModeFromScript(static_cast<bool>((value | -value) >> 31));
                 break;
             }
             case -0x77:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4471,7 +4471,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             if (setMode == 0) {
                 value = stack->m_word;
             } else if (setMode < 0) {
-                if (-2 < setMode) {
+                if (setMode >= -1) {
                     value = value - stack->m_word;
                 }
             } else if (setMode < 2) {
@@ -4489,7 +4489,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             if (setMode == 0) {
                 *artifact = static_cast<short>(stack->m_word);
             } else if (setMode < 0) {
-                if (-2 < setMode) {
+                if (setMode >= -1) {
                     *artifact = static_cast<short>(*artifact - static_cast<short>(stack->m_word));
                 }
             } else if (setMode < 2) {
@@ -4502,7 +4502,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_optionValue =
                             static_cast<unsigned short>(gameWork.m_optionValue - static_cast<short>(stack->m_word));
                     }
@@ -4516,7 +4516,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_soundOptionFlag =
                             static_cast<unsigned char>(gameWork.m_soundOptionFlag - static_cast<char>(stack->m_word));
                     }
@@ -4531,7 +4531,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     value = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         value = value - stack->m_word;
                     }
                 } else if (setMode < 2) {
@@ -4547,7 +4547,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_bossArtifactStageIndex =
                             static_cast<short>(gameWork.m_bossArtifactStageIndex - static_cast<short>(stack->m_word));
                     }
@@ -4566,7 +4566,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(value) = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         *reinterpret_cast<unsigned int*>(value) = *value - stack->m_word;
                     }
                 } else if (setMode < 2) {
@@ -4579,7 +4579,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_chaliceElement = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_chaliceElement = gameWork.m_chaliceElement - stack->m_word;
                     }
                 } else if (setMode < 2) {
@@ -4606,7 +4606,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(value) = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         *reinterpret_cast<unsigned int*>(value) =
                             *reinterpret_cast<int*>(value) - stack->m_word;
                     }
@@ -4636,7 +4636,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(value) = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         *reinterpret_cast<unsigned int*>(value) =
                             *reinterpret_cast<int*>(value) - stack->m_word;
                     }
@@ -4655,7 +4655,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(value) = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         *reinterpret_cast<unsigned int*>(value) =
                             *reinterpret_cast<int*>(value) - stack->m_word;
                     }
@@ -4670,7 +4670,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_frameCounter = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_frameCounter = gameWork.m_frameCounter - stack->m_word;
                     }
                 } else if (setMode < 2) {
@@ -4682,7 +4682,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_scriptGlobalTime = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime - stack->m_word;
                     }
                 } else if (setMode < 2) {
@@ -4694,7 +4694,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     gameWork.m_timerA = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         gameWork.m_timerA = gameWork.m_timerA - stack->m_word;
                     }
                 } else if (setMode < 2) {
@@ -4706,7 +4706,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode == 0) {
                     *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) = stack->m_word;
                 } else if (setMode < 0) {
-                    if (-2 < setMode) {
+                    if (setMode >= -1) {
                         *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
                             *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) - stack->m_word;
                     }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1834,14 +1834,13 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
 
 int CLine<64>::IsInner(Vec* position, float margin)
 {
-    float* values = (float*)this;
-    if (values[6] == 0.0f) {
+    if (m_numPoints == 0) {
         return 0;
     }
 
-    if ((values[0] - margin) <= position->x && (values[1] - margin) <= position->y &&
-        (values[2] - margin) <= position->z && position->x <= (values[3] + margin) &&
-        position->y <= (values[4] + margin) && position->z <= (values[5] + margin)) {
+    if ((m_min.x - margin) <= position->x && (m_min.y - margin) <= position->y &&
+        (m_min.z - margin) <= position->z && (m_max.x + margin) >= position->x &&
+        (m_max.y + margin) >= position->y && (m_max.z + margin) >= position->z) {
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- Tune `main/cflat_r2system` compiler flags toward the PAL object fingerprint.
- Keep pushing low-fuzzy source shapes in this unit: pad helper remaps, event flag reads, system-value artifact reads, setter mode checks, switch case layout, and line bounds checks.
- Reorder `onSystemVal` and `onSetSystemVal` case bodies to match the emitted PAL layout, and normalize remaining boolean values with the target `neg/or/srwi` shape.

## Objdiff Evidence
Original baseline before this PR:
- Unit fuzzy: `31.12239%`
- `onSystemFunc`: `16.02637%`
- `extab`: `23.979591%`

Earlier PR checkpoint:
- Unit fuzzy: `59.69415%`
- `onSystemFunc`: `54.714333%`
- `extab`: `81.63265%`
- `CVector::operator+`: `72.32143% -> 73.14286%`
- `CGame::SetNextScript`: `73.5% -> 96.35714%`

Latest checkpoint:
- Unit fuzzy: `61.041225%`
- `onSetSystemVal`: `38.70714% -> 54.442856%`
- `onSystemVal`: `63.592106% -> 75.38158%`
- `GetEvtFlag`: `91.875% -> 99.375%`
- pad helpers (`GetLeftStickX/Y`, `GetRightStickX/Y`, `GetButton`, `GetButtonRepeat`, `GetGbaButtonDown`): roughly `90-91% -> 95%+`
- `CLine<64>::IsInner`: `88.125% -> 94.75%`

Notes:
- The largest win remains `-opt space`, which lines up the giant dispatcher much better.
- `-inline auto,deferred` mostly improves exception table matching.
- `-str reuse,pool,readonly` gives a small additional `onSystemFunc` gain and matches flag patterns already used by neighboring game objects.
- Latest source passes stay within `main/cflat_r2system` and favor coherent original-source shapes over address forcing.

## Verification
- `ninja`
- `build/tools/objdiff-cli report generate -p . -o .agent/cflat_r2system_final_loop2.json`