### PR TITLE
Improve pppYmLaser render count typing

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -86,7 +86,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	s32 count;
+	u32 count;
 	s32 i;
 	s32 alphaStep;
 	char alphaMax;


### PR DESCRIPTION
## Summary
- Change the local render point count in pppRenderYmLaser from signed to unsigned.
- This matches the serialized m_pointCount field usage and the sibling pppRenderLaser renderer local count typing.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o /tmp/pppYmLaser_final.json pppRenderYmLaser
- .text: 98.52819% -> 98.62533%.
- extabindex: 100.0% -> 97.91667%; retained because the generated render code is closer and the source type is more plausible.

## Plausibility
- m_pointCount is serialized as an unsigned byte.
- The matching non-Ym laser renderer already uses an unsigned local for the same render count role.