### PR TITLE
Match pppYmDeformationScreen render

### DIFF
--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -102,7 +102,6 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 	float one;
 	float quadRight;
 	float zero;
-	float quadBottom;
 	pppCVECTOR color;
 	int textureBase;
 
@@ -213,27 +212,30 @@ void pppRenderYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, 
 	GXLoadTexObj(&backTexObj, GX_TEXMAP0);
 	depth = work->m_depth;
 	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-	zero = kYmDeformationScreenZero;
-	quadMiddleY = kYmDeformationScreenQuadMiddleY;
-	quadRight = kYmDeformationScreenQuadRight;
-	one = kYmDeformationScreenOne;
-	quadBottom = kYmDeformationScreenQuadBottom;
-	GXPosition3f32(zero, quadMiddleY, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(zero, zero);
-	GXTexCoord2f32(zero, zero);
-	GXPosition3f32(quadRight, quadMiddleY, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(one, zero);
-	GXTexCoord2f32(texU, zero);
-	GXPosition3f32(quadRight, quadBottom, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(one, one);
-	GXTexCoord2f32(texU, texV);
-	GXPosition3f32(zero, quadBottom, depth);
-	GXColor1u32(*(u32*)color.rgba);
-	GXTexCoord2f32(zero, one);
-	GXTexCoord2f32(zero, texV);
+	{
+		float bottomQuadBottom = kYmDeformationScreenQuadBottom;
+		float bottomOne = kYmDeformationScreenOne;
+		float bottomRight = kYmDeformationScreenQuadRight;
+		float bottomMiddleY = kYmDeformationScreenQuadMiddleY;
+		float bottomZero = kYmDeformationScreenZero;
+
+		GXPosition3f32(bottomZero, bottomMiddleY, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(bottomZero, bottomZero);
+		GXTexCoord2f32(bottomZero, bottomZero);
+		GXPosition3f32(bottomRight, bottomMiddleY, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(bottomOne, bottomZero);
+		GXTexCoord2f32(texU, bottomZero);
+		GXPosition3f32(bottomRight, bottomQuadBottom, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(bottomOne, bottomOne);
+		GXTexCoord2f32(texU, texV);
+		GXPosition3f32(bottomZero, bottomQuadBottom, depth);
+		GXColor1u32(*(u32*)color.rgba);
+		GXTexCoord2f32(bottomZero, bottomOne);
+		GXTexCoord2f32(bottomZero, texV);
+	}
 
 	gUtil.EndQuadEnv();
 	DisableIndWarp(GX_TEVSTAGE1, GX_INDTEXSTAGE0);


### PR DESCRIPTION
## Summary
- Isolate the bottom-half quad constants in pppRenderYmDeformationScreen so the render function matches the expected code shape.
- Remove the now-unused shared bottom quad local from the top-level render locals.

## Evidence
- Before: agent target selector reported main/pppYmDeformationScreen at code 99.8%, functions 4/5; objdiff reported pppRenderYmDeformationScreen at 99.71322%.
- After: ninja report shows main/pppYmDeformationScreen at 2236/2236 matched code, 40/40 matched data, and 5/5 matched functions.
- After: objdiff for pppRenderYmDeformationScreen is 99.96259% with only local constant relocation-label mismatches remaining.

## Plausibility
- The change keeps the same GX immediate-mode drawing flow and expresses the bottom screen quad with its own local constants, matching how the compiler allocates the constants for that half of the draw without adding address hacks or fake symbols.