### PR TITLE
Match material shadow TEV dispatch

### DIFF
--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -95,7 +95,7 @@ private:
     unsigned int m_activeEnvTevBit;      // 0x44
     unsigned int m_curEnvTevBit;         // 0x48
     unsigned char m_vtxDescMode;         // 0x4C
-    signed char m_shadowMaterialType[0x0B]; // 0x4D
+    unsigned char m_shadowMaterialType[0x0B]; // 0x4D
     int m_shadowMaterialCount;           // 0x58
     int m_shadowTextureCount;            // 0x5C
     unsigned int m_numTevStage;          // 0x60

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1837,7 +1837,7 @@ void CMaterialMan::SetShadow(CMapShadow& shadow, float (*viewMtx) [4], int shado
         int materialNum = m_shadowMaterialCount;
 
         m_curEnvTevBit |= 0x10;
-        m_shadowMaterialType[materialNum] = static_cast<signed char>(*Ptr(&shadow, 8));
+        m_shadowMaterialType[materialNum] = *Ptr(&shadow, 8);
         m_shadowIndices[materialNum] = static_cast<unsigned char>(shadowIndex);
         m_shadowTexMapIds[materialNum] = m_texMapIdCur;
         m_shadowTexMtxIds[materialNum] = m_texMtxCur;


### PR DESCRIPTION
## Summary
- Treat material shadow type entries as unsigned bytes.
- Remove the signed cast when storing shadow material types in SetShadow.
- This lets addtev_stdShadow use the target unsigned-byte comparison and match.

## Evidence
- Before: addtev_stdShadow__12CMaterialManFUl was 98.064514% matched, 124 bytes.
- After: addtev_stdShadow__12CMaterialManFUl is 100.0% matched, 124 bytes.
- ninja passes, including build/GCCP01/main.dol SHA check.
- Build report moved from 3497 to 3498 matched functions and game code from 266460 to 266584 matched bytes.

## Plausibility
m_shadowMaterialType is tested only as a nonzero byte for shadow TEV dispatch. The target performs an unsigned byte compare, so declaring the field unsigned matches the observed ABI and avoids signed extension noise.