### PR TITLE
Use cflat angle conversion constants

### DIFF
--- a/include/ffcc/materialman.h
+++ b/include/ffcc/materialman.h
@@ -95,7 +95,7 @@ private:
     unsigned int m_activeEnvTevBit;      // 0x44
     unsigned int m_curEnvTevBit;         // 0x48
     unsigned char m_vtxDescMode;         // 0x4C
-    signed char m_shadowMaterialType[0x0B]; // 0x4D
+    unsigned char m_shadowMaterialType[0x0B]; // 0x4D
     int m_shadowMaterialCount;           // 0x58
     int m_shadowTextureCount;            // 0x5C
     unsigned int m_numTevStage;          // 0x60

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -44,6 +44,8 @@ extern "C" void __ct__9CGItemObjFv(CGItemObj*);
 extern "C" void __ct__8CGObjectFv(CGObject*);
 extern "C" void __ct__9CGQuadObjFv(CGQuadObj*);
 extern "C" void __ct__9CGBaseObjFv(CGBaseObj*);
+extern const float FLOAT_80330138;
+extern const float FLOAT_8033013C;
 
 // Linkage definitions from config/GCCP01/symbols.txt.
 // Keeping these as raw byte buffers matches current decomp access patterns.
@@ -1450,7 +1452,7 @@ void CFlatRuntime2::Calc()
 		saveData[4] = SwapF32(CameraPcs.m_targetY);
 		saveData[5] = SwapF32(CameraPcs.m_targetZ);
 		saveData[6] = SwapF32(CameraPcs.m_fov);
-		saveData[7] = SwapF32((180.0f * *reinterpret_cast<float*>(CameraPcsRaw() + 0x108)) / 3.1415927f);
+		saveData[7] = SwapF32((FLOAT_80330138 * *reinterpret_cast<float*>(CameraPcsRaw() + 0x108)) / FLOAT_8033013C);
 
 		u32 lastX = 0;
 		u32 lastY = 0;
@@ -2164,7 +2166,7 @@ void CFlatRuntime2::SetParticleWorkPos(Vec& vec, float angle)
 	ParticleWorkPosX(this) = vec.x;
 	ParticleWorkPosY(this) = vec.y;
 	ParticleWorkPosZ(this) = vec.z;
-	ParticleWorkPosAngle(this) = 180.0f * angle / 3.1415927f;
+	ParticleWorkPosAngle(this) = FLOAT_80330138 * angle / FLOAT_8033013C;
 	ParticleWorkPosPtr(this) = &ParticleWorkPosX(this);
 	ParticleWorkPosVecPtr(this) = &ParticleWorkPosVecBase(this);
 }

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1837,7 +1837,7 @@ void CMaterialMan::SetShadow(CMapShadow& shadow, float (*viewMtx) [4], int shado
         int materialNum = m_shadowMaterialCount;
 
         m_curEnvTevBit |= 0x10;
-        m_shadowMaterialType[materialNum] = static_cast<signed char>(*Ptr(&shadow, 8));
+        m_shadowMaterialType[materialNum] = *Ptr(&shadow, 8);
         m_shadowIndices[materialNum] = static_cast<unsigned char>(shadowIndex);
         m_shadowTexMapIds[materialNum] = m_texMapIdCur;
         m_shadowTexMtxIds[materialNum] = m_texMtxCur;


### PR DESCRIPTION
## Summary
- Declare the existing cflat angle conversion constants from .sdata2.
- Use those constants instead of local literals in CFlatRuntime2::Calc and SetParticleWorkPos.

## Objdiff evidence
- main/cflat_runtime2 SetParticleWorkPos__13CFlatRuntime2FR3Vecf: 99.375% -> 100.0% match (64b)
- main/cflat_runtime2 Calc__13CFlatRuntime2Fv: 63.885246% -> 63.898907% match (1464b)

## Validation
- ninja