### PR TITLE
Claim p_sample RTTI data

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -83,6 +83,7 @@ p_sample.cpp:
 	.ctors      start:0x801D53B8 end:0x801D53BC
 	.rodata     start:0x801D6CC8 end:0x801D6CEC
 	.data       start:0x801E8498 end:0x801E868C
+	.sdata      start:0x8032E428 end:0x8032E440
 	.sbss       start:0x8032EC60 end:0x8032EC64
 
 p_usb.cpp:

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -224,9 +224,7 @@ void CMenuPcs::CompaDraw()
 			}
 		}
 
-		const u8* compatibility =
-			reinterpret_cast<const u8*>(&Game) + caravanWork->m_saveSlot * 0x208 + drawIndex + 0xA9;
-		u8 food = *compatibility;
+		u8 food = Game.m_gameWork.m_linkTable[caravanWork->m_saveSlot][0][caravanWork->m_saveSlot][drawIndex + 1];
 		if (food == 0 && System.m_execParam >= 1) {
 			System.Printf(const_cast<char*>(s_pcts_pctd_family_cnt_error_pctd_801DEDC8), s_menu_compa_cpp, 0x1E0,
 			              shown);


### PR DESCRIPTION
## Summary
- claim the p_sample RTTI .sdata range in GCCP01 splits so generated RTTI/vtable data belongs to p_sample
- replace menu_compa compatibility byte pointer arithmetic with CGameWork::m_linkTable member access

## Evidence
- ninja passes and build/GCCP01/main.dol matches build.sha1
- main/p_sample: .rodata, .data, .sdata, and .sbss all report 100% in objdiff
- p_sample RTTI/vtable symbols now report 100%: @49, @46, __vt__10CSamplePcs, __vt__8CProcess, __RTTI__8CManager, __RTTI__8CProcess, __RTTI__10CSamplePcs
- main/menu_compa CompaDraw improves from 59.092594% to 59.333332%
- python3 tools/map/claim_doctor.py src/p_sample.cpp reports no diagnoses

## Plausibility
- p_sample .sdata claim is backed by build/GCCP01/main.elf.MAP ownership for the compiler-generated RTTI block at 0x8032E428..0x8032E440
- menu_compa now uses the real m_linkTable field for the same effective offset instead of raw Game-pointer arithmetic