### PR TITLE
Improve menu list animation matching

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -8,6 +8,9 @@
 #include "ffcc/system.h"
 #include <string.h>
 
+extern const float FLOAT_803333D0;
+extern const float FLOAT_803333F0;
+extern const double DOUBLE_803333E8;
 extern const double DOUBLE_80333410;
 extern const double DOUBLE_80333418;
 extern const double DOUBLE_80333420;
@@ -161,27 +164,27 @@ int CMenuPcs::MLstClose()
 	float zero;
 	MenuLstEntry* entry;
 	int completedItems;
-	unsigned int itemCount;
+	int itemCount;
 	int currentFrame;
-	unsigned int count;
+	int count;
 	int result;
 
 	completedItems = 0;
 	this->lstState->frame = this->lstState->frame + 1;
-	itemCount = (unsigned int)this->lstData->count;
+	itemCount = this->lstData->count;
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
 	for (int remaining = itemCount; remaining > 0; remaining--) {
 		if (entry->startFrame <= currentFrame) {
 			if (entry->startFrame + entry->duration <= currentFrame) {
 				completedItems++;
-				entry->alpha = 0.0f;
+				entry->alpha = FLOAT_803333D0;
 			} else {
 				entry->timer = entry->timer + 1;
 				double ratio = DOUBLE_80333410 / (double)entry->duration;
 				entry->alpha = (float)(DOUBLE_80333410 - ratio * (double)entry->timer);
 				if ((double)entry->alpha < DOUBLE_80333418) {
-					entry->alpha = 0.0f;
+					entry->alpha = FLOAT_803333D0;
 				}
 			}
 		}
@@ -189,9 +192,9 @@ int CMenuPcs::MLstClose()
 	}
 	result = 0;
 	if (this->lstData->count == completedItems) {
-		zero = 0.0f;
+		zero = FLOAT_803333D0;
 		entry = this->lstData->entries;
-		for (count = itemCount; count != 0; count--) {
+		for (count = itemCount; count > 0; count--) {
 			entry->startFrame = 0;
 			entry->duration = 1;
 			entry->alpha = zero;
@@ -287,7 +290,7 @@ int CMenuPcs::MLstCtrl()
 	}
 
 	if (result != 0) {
-		one = 1.0f;
+		one = FLOAT_803333F0;
 		MenuLstEntry* entry = this->lstData->entries;
 		for (i = 0; (itemCount = (unsigned int)this->lstData->count), i < (int)itemCount; i++) {
 			entry->alpha = one;
@@ -323,9 +326,9 @@ int CMenuPcs::MLstOpen()
 	float zero;
 	int completedItems;
 	MenuLstEntry* entry;
-	unsigned int itemCount;
+	int itemCount;
 	int currentFrame;
-	unsigned int count;
+	int count;
 
 	if (this->lstState->initialized == '\0') {
 		int i;
@@ -349,7 +352,7 @@ int CMenuPcs::MLstOpen()
 			entry->tex = 0x5B;
 			entry->width = 0xE0;
 			entry->height = 0x28;
-			entry->x = (short)(int)-(((double)entry->width * 0.5) - DOUBLE_80333420);
+			entry->x = (short)(int)-(((double)entry->width * DOUBLE_803333E8) - DOUBLE_80333420);
 			entry->y = yPos;
 			yPos += 0x20;
 			entry->s = zero;
@@ -363,14 +366,14 @@ int CMenuPcs::MLstOpen()
 
 	completedItems = 0;
 	this->lstState->frame = this->lstState->frame + 1;
-	itemCount = (unsigned int)this->lstData->count;
+	itemCount = this->lstData->count;
 	entry = this->lstData->entries;
 	currentFrame = (int)this->lstState->frame;
 	for (int remaining = itemCount; remaining > 0; remaining--) {
 		if (entry->startFrame <= currentFrame) {
 			if (entry->startFrame + entry->duration <= currentFrame) {
 				completedItems++;
-				entry->alpha = 1.0f;
+				entry->alpha = FLOAT_803333F0;
 			} else {
 				entry->timer = entry->timer + 1;
 				double ratio = DOUBLE_80333410 / (double)entry->duration;
@@ -382,9 +385,9 @@ int CMenuPcs::MLstOpen()
 
 	int result = 0;
 	if (this->lstData->count == completedItems) {
-		one = 1.0f;
+		one = FLOAT_803333F0;
 		entry = this->lstData->entries;
-		for (count = itemCount; count != 0; count--) {
+		for (count = itemCount; count > 0; count--) {
 			entry->startFrame = 0;
 			entry->duration = 1;
 			entry->alpha = one;


### PR DESCRIPTION
## Summary
- Use signed item counts in menu list open/close reset loops to match the original signed completion checks.
- Reuse existing shared constants for menu list alpha/scale timing values where objdiff shows they align with the binary.

## Evidence
- Built with `ninja`.
- `build/tools/objdiff-cli diff -p . -u main/menu_lst -o - MLstOpen__8CMenuPcsFv`:
  - `MLstClose__8CMenuPcsFv`: 97.24299% -> 97.990654% (428b unchanged)
  - `MLstOpen__8CMenuPcsFv`: 95.79444% -> 96.32222% (720b unchanged)
  - `MLstCtrl__8CMenuPcsFv`: 95.246635% -> 95.26906% (888b unchanged)
  - `MLstDraw__8CMenuPcsFv`: unchanged at 82.62674%

## Plausibility
- The loop signedness matches the signed comparisons visible in the Ghidra output.
- The constants are already present as named shared menu constants in the linked binary; no address hacks or manual section forcing were added.