### PR TITLE
Match main language argument string sizes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,12 +6,12 @@
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/string.h>
 
 static const char kDefaultScriptName[] = "ffcc_0";
-static const char kLanguageArgUs[4] = "us";
-static const char kLanguageArgUk[4] = "uk";
-static const char kLanguageArgGr[4] = "gr";
-static const char kLanguageArgIt[4] = "it";
-static const char kLanguageArgFr[4] = "fr";
-static const char kLanguageArgSp[4] = "sp";
+static const char kLanguageArgUs[] = "us";
+static const char kLanguageArgUk[] = "uk";
+static const char kLanguageArgGr[] = "gr";
+static const char kLanguageArgIt[] = "it";
+static const char kLanguageArgFr[] = "fr";
+static const char kLanguageArgSp[] = "sp";
 
 void game(int argc, char** argv);
 


### PR DESCRIPTION
## Summary
- Let the main language option strings use their natural literal sizes instead of fixed 4-byte arrays.
- This matches the PAL symbol sizes for kLanguageArgUs/Uk/Gr/It/Fr/Sp while preserving the existing codegen for game(int, char**).

## Evidence
- Build: ninja
- Objdiff: build/tools/objdiff-cli diff -p . -u main/main -o - game
- Before: kLanguageArgUs/Uk/Gr/It/Fr/Sp were 85.71429% each due to symbol size 4 vs target size 3; .sdata2 was 98.4127%.
- After: kLanguageArgUs/Uk/Gr/It/Fr/Sp are 100.0% each; .sdata2 reports 100.0%; .text remains 99.458824% and game(int, char**) remains 99.22689%.

## Plausibility
These are ordinary string constants used only as strcmp operands, so unsized arrays are the more natural source form and match the shipped symbol sizes without introducing artificial padding or ABI hacks.