### PR TITLE
Claim additional sdata2 ranges

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -147,6 +147,7 @@ maphit.cpp:
 	.rodata     start:0x801D7088 end:0x801D7094
 	.bss        start:0x80245640 end:0x802456F0
 	.sbss       start:0x8032EC78 end:0x8032EC9C
+	.sdata2     start:0x8032F888 end:0x8032F8B4
 
 mapmesh.cpp:
 	extab       start:0x80005E60 end:0x80005EC8
@@ -239,6 +240,7 @@ p_graphic.cpp:
 	.ctors      start:0x801D53EC end:0x801D53F0
 	.data       start:0x801E9C90 end:0x801E9EC0
 	.bss        start:0x80268E90 end:0x80268F84
+	.sdata2     start:0x8032FBFC end:0x8032FC64
 
 p_game.cpp:
 	extab       start:0x800068A8 end:0x80006918
@@ -267,6 +269,7 @@ p_light.cpp:
 	.data       start:0x801EA298 end:0x801EA484
 	.bss        start:0x80268F88 end:0x8026D338
 	.sbss       start:0x8032ED10 end:0x8032ED18
+	.sdata2     start:0x8032FC68 end:0x8032FC88
 
 mapanim.cpp:
 	extab       start:0x800069C8 end:0x80006A44


### PR DESCRIPTION
## Summary
- Claim `.sdata2` ranges for `maphit.cpp`, `p_graphic.cpp`, and `p_light.cpp` in `config/GCCP01/splits.txt`
- Leave broader `.rodata`, `.sdata`, `.sbss`, and rejected `.sdata2` candidates unclaimed because they introduced splitter link-order cycles

## Evidence
- `ninja` passes
- `build/GCCP01/main.dol: OK`
- `main/maphit` now owns `.sdata2` at `0x8032F888`, 44 bytes
- `main/p_graphic` now owns `.sdata2` at `0x8032FBFC`, 104 bytes
- `main/p_light` now owns `.sdata2` at `0x8032FC68`, 32 bytes

## Plausibility
These are contiguous constant-data ranges accepted by the splitter and associated with nearby game source units. Broader automatic claims were tested and discarded when they caused cyclic link-order dependencies.
