### PR TITLE
Improve p_dbgmenu calc matching

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -211,14 +211,15 @@ void CDbgMenuPcs::calc()
 		case 0x65:
 			stackData[0].m_word = 0;
 			stackData[2].m_word = 0;
-			flags = (unsigned int)__cntlzw((int)((signed char)CFlatGameFlags() >> 7));
-			flags = ((int)(char)(flags >> 5) & 1U) << 7 | (CFlatGameFlags() & ~CFlatGameFlag_Shouki);
-			CFlatGameFlags() = (unsigned char)flags;
-			stackData[1].m_word = (int)(flags << 0x18) >> 0x1f;
+			unsigned char gameFlags = CFlatGameFlags();
+			flags = (unsigned int)__cntlzw((int)(s8)((s32)(((u32)gameFlags << 0x18) & 0xC0000000) >> 0x1f));
+			gameFlags = ((int)(char)(flags >> 5) & 1U) << 7 | (gameFlags & ~CFlatGameFlag_Shouki);
+			CFlatGameFlags() = gameFlags;
+			stackData[1].m_word = (s32)(((u32)gameFlags << 0x18) & 0xC0000000) >> 0x1f;
 			gCFlatRuntime().SystemCall(0, 1, 9, 3, stackData, 0);
 			break;
 		case 0x66:
-			flags = (unsigned int)__cntlzw((int)(char)((int)((unsigned int)(unsigned char)CFlatGameFlags() << 0x1d) >> 0x1f));
+			flags = (unsigned int)__cntlzw((int)(s8)((s32)(((u32)(u8)CFlatGameFlags() << 0x1d) & 0xC0000000) >> 0x1f));
 			CFlatGameFlags() = (unsigned char)((((int)(char)(flags >> 5) << 2) & CFlatGameFlag_Mark) |
 			                                   (CFlatGameFlags() & ~CFlatGameFlag_Mark));
 			break;


### PR DESCRIPTION
## Summary
- Reworked the SHOUKI and MARK debug-menu flag toggles to use the same two-bit signed-mask shape seen in the original code.
- Keeps the behavior equivalent while producing closer codegen for `calc__11CDbgMenuPcsFv`.

## Evidence
- `ninja` passes for GCCP01.
- `calc__11CDbgMenuPcsFv`: 95.48252% -> 96.594406%.
- `main/p_dbgmenu` .text: 96.99676% -> 97.16856%.

## Plausibility
- The source now mirrors the existing flag-mask idiom already used elsewhere in the debug/menu code, rather than relying on narrower signed-char shifts that compile farther from the original instruction sequence.