### PR TITLE
Pad p_tina debug spinner sbss

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -159,6 +159,9 @@ const char* sDebugSpinnerTextPtr;
 signed char sDebugSpinnerTextPtrInit;
 int s_debugSpinnerFrameCounter;
 signed char s_debugSpinnerFrameCounterInit;
+signed char s_debugSpinnerFrameCounterPad0;
+signed char s_debugSpinnerFrameCounterPad1;
+signed char s_debugSpinnerFrameCounterPad2;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Add explicit one-byte debug spinner padding symbols after `s_debugSpinnerFrameCounterInit`.
- This models the target `p_tina` `.sbss` tail gap so the current object's `.sbss` size matches the target span.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/p_tina -o /tmp/p_tina_final.json`
- Before: current `main/p_tina` `.sbss` size was 21 bytes.
- After: current `main/p_tina` `.sbss` size is 24 bytes, matching the target `.sbss` size.

## Plausibility
- The target already has hidden 3-byte `.sbss` gaps after one-byte init flags.
- The explicit byte pads preserve the existing global order and do not affect code generation.
