### PR TITLE
Improve chara viewer model layouts

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -36,6 +36,7 @@ class CChara : public CManager
 public:
 	class CModel;
 	class CMesh;
+	class CAnimNode;
 
 	class CSkin
 	{
@@ -63,8 +64,22 @@ public:
         void SetInterp(int);
         void InitQuantize();
 
-		u8 _pad8[0x8];
-		u16 m_frameCount;
+		u8 m_flags;                     // 0x08
+		char m_interp;                  // 0x09
+		u8 m_quantizeX;                 // 0x0A
+		u8 m_quantizeY;                 // 0x0B
+		u8 m_quantizeZ;                 // 0x0C
+		u8 _pad0D;                      // 0x0D
+		u16 m_nodeCount;                // 0x0E
+		u16 m_frameCount;               // 0x10
+		u8 _pad12[0x2];                 // 0x12
+		CAnimNode* m_nodes;             // 0x14
+		u32 m_interpOffset;             // 0x18
+		u32 m_bankSize;                 // 0x1C
+		void* m_bank;                   // 0x20
+		int m_lastFrame;                // 0x24
+		int m_bankAddress;              // 0x28
+		CMemory::CStage* m_stage;       // 0x2C
 	};
 
 	class CAnimNode
@@ -181,8 +196,11 @@ public:
 		}
 
 	public:
-		u8 _pad0[0x68];
+		u8 _pad0[0x8];
 		Mtx m_matrix;
+		u8 _pad38[0xC];
+		Mtx m_worldBaseMtx;
+		u8 _pad74[0x24];
 		u32 m_meshVisibleMask;
 		float m_lightAlpha;
 		u8 m_flagsA0;
@@ -193,11 +211,16 @@ public:
 		CMesh* m_meshes;
 		CTextureSet* m_texSet;
 		float m_curFrame;
-		CAnim* m_anim;
 		float m_time;
 		float m_animStart;
 		float m_animEnd;
-		u8 _padC8[0x1C];
+		CVector m_dynJitter;
+		CAnim* m_anim;
+		CTexAnimSet* m_texAnimSet;
+		u16 m_blendCur;
+		u16 m_blendMax;
+		float m_chestTilt;
+		float m_chestAmp;
 		void* m_callbackContext;
 		void* m_callbackParam;
 		BeforeCalcMatrixCallback m_beforeCalcMatrixCallback;

--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -140,12 +140,12 @@ static inline float& ViewerModelTime(CChara::CModel* model)
 
 static inline CChara::CAnim*& ViewerModelAnim(CChara::CModel* model)
 {
-    return ViewerModel(model)->anim;
+    return model->m_anim;
 }
 
 static inline CTexAnimSet*& ViewerModelTexAnimSet(CChara::CModel* model)
 {
-    return ViewerModel(model)->texAnimSet;
+    return model->m_texAnimSet;
 }
 
 static inline CTextureSet*& ViewerModelTextureSet(CChara::CModel* model)
@@ -326,7 +326,7 @@ void CCharaPcs::drawViewer()
 
                 Mtx scratchMtx;
                 Vec lightPos;
-                PSMTXCopy((const float(*)[4])(reinterpret_cast<unsigned char*>(model) + 8), scratchMtx);
+                PSMTXCopy(model->m_matrix, scratchMtx);
                 lightPos.x = scratchMtx[0][3];
                 lightPos.y = scratchMtx[1][3];
                 lightPos.z = scratchMtx[2][3];
@@ -395,7 +395,8 @@ void CCharaPcs::calcViewer()
                     new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_viewer_cpp), 0xEA) CChara::CModel;
                 self->m_viewerModel[0] = model;
                 self->m_viewerModel[0]->Create(File.m_readBuffer, self->m_viewerModelStage);
-                self->m_viewerModel[0]->m_flags10C = (self->m_viewerModel[0]->m_flags10C & 0xBF) | 0x40;
+                self->m_viewerModel[0]->m_flags10C =
+                    static_cast<unsigned char>(__rlwimi(self->m_viewerModel[0]->m_flags10C, 1, 6, 25, 25));
                 File.Close(fileHandle);
             }
             self->m_viewerLoadModel = 0;
@@ -437,20 +438,20 @@ void CCharaPcs::calcViewer()
                 self->m_viewerLoadAnim = 0;
             } else {
                 for (i = 0; i < static_cast<unsigned int>(self->m_viewerAnimRequestedCount); i++) {
-                    unsigned int idx = static_cast<unsigned int>(self->m_viewerAnimLoadedCount);
-                    sprintf(pathBuf, s_anim_path_fmt, self->m_viewerAnimPath, idx);
+                    sprintf(pathBuf, s_anim_path_fmt, self->m_viewerAnimPath, self->m_viewerAnimLoadedCount);
                     System.Printf(const_cast<char*>(s_calc_viewer_fmt), pathBuf);
                     fileHandle = File.Open(pathBuf, 0, CFile::PRI_LOW);
                     if (fileHandle != 0) {
-                        ReleaseShared(self->m_viewerAnimBank[idx]);
+                        ReleaseShared(self->m_viewerAnimBank[self->m_viewerAnimLoadedCount]);
                         File.Read(fileHandle);
                         File.SyncCompleted(fileHandle);
                         CChara::CAnim* anim =
                             new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_viewer_cpp), 0x124) CChara::CAnim;
-                        self->m_viewerAnimBank[idx] = anim;
-                        self->m_viewerAnimBank[idx]->Create(File.m_readBuffer, self->m_viewerAnimStage);
+                        self->m_viewerAnimBank[self->m_viewerAnimLoadedCount] = anim;
+                        self->m_viewerAnimBank[self->m_viewerAnimLoadedCount]->Create(File.m_readBuffer,
+                                                                                      self->m_viewerAnimStage);
                         File.Close(fileHandle);
-                        if (idx == 0) {
+                        if (self->m_viewerAnimLoadedCount == 0) {
                             self->m_viewerAnim[0] = self->m_viewerAnimBank[0];
                             AddSharedRef(self->m_viewerAnim[0]);
                         }
@@ -682,13 +683,13 @@ void CCharaPcs::calcViewer()
                 Graphic.Printf(const_cast<char*>(s_frame_speed_fmt), frame, frameAdvance);
             }
             if (self->m_viewerSavedAnim != 0) {
-                const char* iframeMode = kCharaViewerOff;
-                if (self->m_viewerIFrameEnabled != 0) {
-                    iframeMode = kCharaViewerOn;
-                }
                 const char* iframeState = kCharaViewerKeep;
                 if (self->m_viewerSavedAnimState == 0) {
                     iframeState = kCharaViewerOrg;
+                }
+                const char* iframeMode = kCharaViewerOff;
+                if (self->m_viewerIFrameEnabled != 0) {
+                    iframeMode = kCharaViewerOn;
                 }
                 Graphic.Printf(const_cast<char*>(s_iframe_fmt), iframeMode, self->m_viewerSavedFrame, iframeState);
             }


### PR DESCRIPTION
## Summary
- expand `CChara::CAnim` in `chara.h` to the recovered 0x30-byte layout used by `chara_anim.cpp`
- align key `CChara::CModel` runtime fields with recovered offsets, including `m_matrix`, `m_anim`, and `m_texAnimSet`
- update `p_chara_viewer` to use recovered members and avoid caching the continuous anim-bank index where the original reloads it

## Objdiff evidence
- `main/p_chara_viewer` `calcViewer__9CCharaPcsFv`: 88.89798% -> 90.1596%
- matched instructions: 716 -> 739
- deletes: 57 -> 49
- replaces: 29 -> 24
- op mismatches: 5 -> 3

`drawViewer__9CCharaPcsFv` remains at 95.683334%, but now uses the recovered model matrix member instead of a raw `+8` access.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o - calcViewer__9CCharaPcsFv`
