### PR TITLE
Model Ym particle objects with ppp object layout

### DIFF
--- a/include/ffcc/pppYmMiasma.h
+++ b/include/ffcc/pppYmMiasma.h
@@ -1,11 +1,10 @@
 #ifndef _FFCC_PPP_YMMIASMA_H_
 #define _FFCC_PPP_YMMIASMA_H_
 
-#include <dolphin/types.h>
+#include "ffcc/partMng.h"
 
 struct pppYmMiasma {
-    u8 m_pad0[0xc];
-    s32 m_graphId;
+    _pppPObject m_object;
 };
 struct pppYmMiasmaUnkB;
 struct pppYmMiasmaUnkC {

--- a/include/ffcc/pppYmMoveParabola.h
+++ b/include/ffcc/pppYmMoveParabola.h
@@ -1,11 +1,10 @@
 #ifndef _FFCC_PPP_YMMOVEPARABOLA_H_
 #define _FFCC_PPP_YMMOVEPARABOLA_H_
 
-#include "types.h"
+#include "ffcc/partMng.h"
 
 struct pppYmMoveParabola {
-    u8 _pad0x00[0xC];
-    s32 m_graphId;
+    _pppPObject m_object;
 };
 
 struct pppYmMoveParabolaUnkB {

--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -161,7 +161,7 @@ static inline T* PppWorkArea(_pppPObject* object, pppYmMiasmaUnkC* ctrl, int ind
  */
 void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaRenderStep* step, pppYmMiasmaUnkC* param_3)
 {
-    VYmMiasma* work = PppWorkArea<VYmMiasma>(reinterpret_cast<_pppPObject*>(pppYmMiasma_), param_3, 2);
+    VYmMiasma* work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_3, 2);
     PARTICLE_DATA* particleData = work->m_particles;
     int i;
 
@@ -239,9 +239,9 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, pppYmM
         return;
     }
 
-    work = PppWorkArea<VYmMiasma>(reinterpret_cast<_pppPObject*>(pppYmMiasma_), param_3, 2);
+    work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_3, 2);
 
-    if (step->m_graphId == pppYmMiasma_->m_graphId) {
+    if (step->m_graphId == pppYmMiasma_->m_object.m_graphId) {
         work->m_radius = work->m_radius + step->m_radiusDelta;
         work->m_radiusVelocity = work->m_radiusVelocity + step->m_radiusVelocity;
         work->m_radiusAcceleration = work->m_radiusAcceleration + step->m_radiusAcceleration;
@@ -254,7 +254,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, pppYmM
             0x18d);
         particle = work->m_particles;
         for (i = 0; i < step->m_particleCount; i++) {
-            InitParticleData(work, (_pppPObject*)pppYmMiasma_, step, particle);
+            InitParticleData(work, &pppYmMiasma_->m_object, step, particle);
             particle++;
         }
     }
@@ -304,7 +304,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, pppYmM
     work->m_radius = work->m_radius + work->m_radiusVelocity;
 
     for (i = 0, particle = work->m_particles; i < step->m_particleCount; i++, particle++) {
-        UpdateParticleData((_pppPObject*)pppYmMiasma_, (_pppCtrlTable*)param_3, step, particle);
+        UpdateParticleData(&pppYmMiasma_->m_object, (_pppCtrlTable*)param_3, step, particle);
     }
 
     matrixPos.x = ppvMng->m_matrix.value[0][3];
@@ -333,7 +333,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, pppYmM
  */
 void pppDestructYmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
 {
-    VYmMiasma* work = PppWorkArea<VYmMiasma>(reinterpret_cast<_pppPObject*>(pppYmMiasma_), param_2, 2);
+    VYmMiasma* work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_2, 2);
     void* heap = work->m_particles;
 
     if (heap != 0) {
@@ -352,7 +352,7 @@ void pppDestructYmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
  */
 void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
 {
-    VYmMiasma* work = PppWorkArea<VYmMiasma>(reinterpret_cast<_pppPObject*>(pppYmMiasma_), param_2, 2);
+    VYmMiasma* work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_2, 2);
     float fVar1 = FLOAT_80330644;
 
     work->m_radius = FLOAT_80330644;
@@ -371,7 +371,7 @@ void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
  */
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
 {
-    VYmMiasma* work = PppWorkArea<VYmMiasma>(reinterpret_cast<_pppPObject*>(pppYmMiasma_), param_2, 2);
+    VYmMiasma* work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_2, 2);
     float fVar1;
     float fVar2 = FLOAT_80330644;
 

--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -20,8 +20,7 @@ struct pppYmMoveParabolaWork {
 
 static inline pppYmMoveParabolaWork* ParabolaWork(pppYmMoveParabola* object, pppYmMoveParabolaUnkC* ctrl)
 {
-    return reinterpret_cast<pppYmMoveParabolaWork*>(
-        reinterpret_cast<_pppPObject*>(object)->m_workArea + *ctrl->m_serializedDataOffsets);
+    return reinterpret_cast<pppYmMoveParabolaWork*>(object->m_object.m_workArea + *ctrl->m_serializedDataOffsets);
 }
 
 /*
@@ -44,7 +43,7 @@ extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct
 
     work->m_velocity = work->m_velocity + work->m_acceleration;
     work->m_distance = work->m_distance + work->m_velocity;
-    if (stepData->m_graphId == basePtr->m_graphId) {
+    if (stepData->m_graphId == basePtr->m_object.m_graphId) {
         work->m_distance = work->m_distance + stepData->m_stepValue;
         work->m_velocity = work->m_velocity + stepData->m_arg3;
         work->m_acceleration = work->m_acceleration + stepData->m_payload;


### PR DESCRIPTION
## Summary
- Replace fake graph-id padding in pppYmMiasma and pppYmMoveParabola with embedded _pppPObject members.
- Update work-area and graph-id accesses to use the real object member instead of casts through the wrapper address.

## Evidence
- ninja
- objdiff main/pppYmMoveParabola: pppFrameYmMoveParabola 99.646736%, pppConstructYmMoveParabola 100.0%.
- objdiff main/pppYmMiasma: pppRenderYmMiasma 97.277176%, pppFrameYmMiasma 99.26738%, constructors/destructor and InitParticleData remain 100.0%.

## Plausibility
- Nearby particle wrappers such as pppMiasma, pppYmTraceMove, and pppYmTracer model the same object prefix as _pppPObject.
- This removes padding-based layout recovery and makes the work-area base explicit without changing codegen.