### PR TITLE
Remove textureman RTTI override

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -756,7 +756,7 @@ config.libs = [
             Object(NonMatching, "stopwatch.cpp"),
             Object(NonMatching, "system.cpp", extra_cflags=["-RTTI on"]),
             Object(NonMatching, "texanim.cpp"),
-            Object(NonMatching, "textureman.cpp", extra_cflags=["-RTTI on", "-str reuse,pool,readonly"]),
+            Object(NonMatching, "textureman.cpp", extra_cflags=["-str reuse,pool,readonly"]),
             Object(
                 NonMatching,
                 "THPDraw.cpp",


### PR DESCRIPTION
Summary
- Removes the per-object RTTI-on override from textureman.cpp.
- This stops the compiled textureman.o from emitting right-side RTTI objects and an extra sdata section that are not present in the objdiff target object.

Evidence
Built with: python3 configure.py --version GCCP01 && ninja

Before objdiff compiled right-side sections for main/textureman:
- rodata: 260 bytes
- data: 132 bytes
- sdata: 48 bytes
- sdata2: 37 bytes
- right-side RTTI symbols: 6

After:
- rodata: 186 bytes
- data: 96 bytes
- no sdata section
- sdata2: 32 bytes
- right-side RTTI symbols: 0

Target-byte match percentages for existing target sections are unchanged, so this PR is intentionally limited to removing extra generated RTTI/linkage payload from the compiled object.

Plausibility
textureman does not use RTTI behavior in source, and the target object does not carry the emitted RTTI objects/section shape produced by the override. Removing the override lets the unit inherit the default game C++ RTTI setting instead of forcing extra compiler metadata.