### PR TITLE
Improve memory DMA wait matches

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -909,7 +909,7 @@ void CMemory::CopyToAMemorySync(void* source, void* dest, unsigned long size)
 {
     int dmaId = RedSound(&Sound)->DMAEntry(0, 0, reinterpret_cast<int>(source), reinterpret_cast<int>(dest),
                                            static_cast<int>(size), 0, 0);
-    CStopWatch watch((char*)0);
+    CStopWatch watch(sMemoryNoNameStopwatchName);
     watch.Start();
     while (RedSound(&Sound)->DMACheck(dmaId) != 0) {
         watch.Stop();
@@ -929,21 +929,21 @@ void CMemory::CopyToAMemorySync(void* source, void* dest, unsigned long size)
  */
 void CMemory::CopyFromAMemorySync(void* source, void* dest, unsigned long size)
 {
-    CStopWatch watch((char*)0);
     int dmaId = RedSound(&Sound)->DMAEntry(0, 1, reinterpret_cast<int>(source), reinterpret_cast<int>(dest),
                                            static_cast<int>(size), 0, 0);
+    CStopWatch watch(sMemoryNoNameStopwatchName);
     watch.Start();
     float timeout = kMemoryDmaTimeout;
     while (RedSound(&Sound)->DMACheck(dmaId) != 0) {
         watch.Stop();
-        if (watch.Get() < timeout) {
-            watch.Start();
-        } else {
+        if (watch.Get() >= timeout) {
             if (static_cast<unsigned int>(System.m_execParam) >= 1) {
                 System.Printf(const_cast<char*>(sCopyFromAMemorySyncTimeoutMsg));
             }
             Sound.CheckDriver(1);
             watch.Reset();
+            watch.Start();
+        } else {
             watch.Start();
         }
     }
@@ -1740,7 +1740,7 @@ int CAmemCacheSet::GetData(short index, char* source, int line)
                 } else {
                     int dmaId = RedSound(&Sound)->DMAEntry(0, 1, reinterpret_cast<int>(entry.m_cacheData),
                                                            reinterpret_cast<int>(entry.m_workData), entry.m_size, 0, 0);
-                    CStopWatch watch((char*)0);
+                    CStopWatch watch(sMemoryNoNameStopwatchName);
                     watch.Start();
                     float timeout = kMemoryDmaTimeout;
                     while (RedSound(&Sound)->DMACheck(dmaId) != 0) {
@@ -1850,7 +1850,7 @@ int CAmemCacheSet::SetData(void* src, int size, CAmemCache::TYPE type, int dmaCo
         } else {
             int dmaId = RedSound(&Sound)->DMAEntry(0, 0, reinterpret_cast<int>(src),
                                                    reinterpret_cast<int>(entry.m_workData), entry.m_size, 0, 0);
-            CStopWatch watch((char*)0);
+            CStopWatch watch(sMemoryNoNameStopwatchName);
             watch.Start();
             while (RedSound(&Sound)->DMACheck(dmaId) != 0) {
                 watch.Stop();
@@ -1906,7 +1906,7 @@ checksum_done_copy:
     } else {
         int dmaId = RedSound(&Sound)->DMAEntry(0, 0, reinterpret_cast<int>(src),
                                                reinterpret_cast<int>(entry.m_workData), entry.m_size, 0, 0);
-        CStopWatch watch((char*)0);
+        CStopWatch watch(sMemoryNoNameStopwatchName);
         watch.Start();
         while (RedSound(&Sound)->DMACheck(dmaId) != 0) {
             watch.Stop();


### PR DESCRIPTION
## Summary
- Use the recovered no-name stopwatch symbol for memory DMA wait loops.
- Move CopyFromAMemorySync stopwatch construction after DMAEntry to match the target order.
- Flip CopyFromAMemorySync timeout handling to the target branch shape.

## Objdiff evidence
- CopyFromAMemorySync__7CMemoryFPvPvUl: 77.22973% -> 98.24324%
- CopyToAMemorySync__7CMemoryFPvPvUl: 88.40909% -> 88.52273%
- GetData__13CAmemCacheSetFsPci: 88.76316% -> 88.807014%
- SetData__13CAmemCacheSetFPviQ210CAmemCache4TYPEi: 82.53846% -> 82.5812%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/final_CopyFromAMemorySync.json CopyFromAMemorySync__7CMemoryFPvPvUl
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/final_CopyToAMemorySync.json CopyToAMemorySync__7CMemoryFPvPvUl
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/final_GetData.json GetData__13CAmemCacheSetFsPci
- build/tools/objdiff-cli diff -p . -u main/memory -o /tmp/final_SetData.json SetData__13CAmemCacheSetFPviQ210CAmemCache4TYPEi