### PR TITLE
Remove extra p_graphic screen fade stubs

### DIFF
--- a/include/ffcc/p_graphic.h
+++ b/include/ffcc/p_graphic.h
@@ -61,8 +61,6 @@ public:
     void preDrawEnvInit();
     void stdDrawEnvInit();
 
-    void calcScreenFade();
-    void drawSFRect(float, float, float, float, _GXColor, _GXColor);
     void drawSFCircle(int, int, int, int, _GXColor, _GXColor);
     unsigned int GetScreenFadeExecutingBit();
     void drawScreenFade();

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -397,26 +397,6 @@ unsigned int CGraphicPcs::GetScreenFadeExecutingBit()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGraphicPcs::calcScreenFade()
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CGraphicPcs::drawSFRect(float, float, float, float, _GXColor, _GXColor)
-{
-	// TODO
-}
-
-/*
- * --INFO--
  * PAL Address: 0x800462b8
  * PAL Size: 596b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Removed two current-only empty CGraphicPcs stubs: calcScreenFade and drawSFRect.
- Removed their unused declarations from the p_graphic header.

## Evidence
- ninja passes.
- Before: objdiff for main/p_graphic reported current-only symbols calcScreenFade__11CGraphicPcsFv and drawSFRect__11CGraphicPcsFffff8_GXColor8_GXColor, each 4 bytes.
- After: those extra symbols are absent, right-side symbol count drops from 90 to 88, and .text size drops from 9828 to 9820 bytes.

## Plausibility
- Neither symbol appears in config/GCCP01/symbols.txt or the Ghidra dump, and rg found no call sites beyond their own declarations/definitions.
- Keeping them emitted extra non-target code; removing them makes the unit linkage closer to the shipped object without adding manual labels or section hacks.