### PR TITLE
Fix CGPrgObj onNewFinished vtable slot

### DIFF
--- a/include/ffcc/baseobj.h
+++ b/include/ffcc/baseobj.h
@@ -8,7 +8,6 @@ class CGBaseObj : public CFlatRuntime::CObject
 public:
 	CGBaseObj();
 
-	virtual void onNewFinished();               // vtable entry 0x8
 	virtual int GetCID();                       // vtable entry 0xC
 	virtual void InitFinished();               // vtable entry 0x10
 	virtual void onPush(CGBaseObj* other, int); // vtable entry 0x14

--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -36,7 +36,7 @@ public:
 	public:
 		CObject() {}
 		~CObject() {}
-		void onNewFinished();
+		virtual void onNewFinished();
 
 		unsigned int m_id;         // 0x0
 		void** m_freeListNode;     // 0x4

--- a/include/ffcc/prgobj.h
+++ b/include/ffcc/prgobj.h
@@ -9,10 +9,10 @@ class CGObject;
 class CGPrgObj : public CGObject
 {
 public:
+    virtual int GetCID();
     void onCreate();
     void onDestroy();
     void onFrame();
-    virtual int GetCID();
     virtual void ClassControl(int, int);
     virtual int GetClassControl(int);
     virtual void bonus(int, int, CGPrgObj*);


### PR DESCRIPTION
## Summary
- Make `CFlatRuntime::CObject::onNewFinished` the virtual root slot.
- Remove the duplicate `CGBaseObj::onNewFinished` declaration so derived object vtables resolve the inherited slot correctly.
- Move `CGPrgObj::GetCID` before its lifecycle overrides in the declaration to match the vtable slot order more clearly.

## Evidence
- `main/prgobj` `.data`: 70.34001% -> 71.28112%
- `__vt__8CGPrgObj`: 96.721306% -> 98.36066%
- `main/prgobj` `.text`: 99.499306% -> 99.48133% (small score movement from the header-wide virtual layout change)

## Verification
- `ninja` passed
- `build/GCCP01/main.dol: OK`

## Plausibility
`onNewFinished` is defined on `CFlatRuntime::CObject`, and derived classes such as `CGItemObj` override it. Modeling it as the root virtual avoids a duplicate `CGBaseObj` slot and matches the observed `CGPrgObj` vtable relocation behavior more closely.
