### PR TITLE
Add tmp artifact conversion constant

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -14,6 +14,7 @@ extern const float FLOAT_80332f2c;
 extern const float FLOAT_80332f30;
 extern const float FLOAT_80332F34;
 extern const float FLOAT_80332F38;
+extern const double DOUBLE_80332f40 = 4503601774854144.0;
 extern const double DOUBLE_80332f48;
 extern const double DOUBLE_80332f50;
 extern const double DOUBLE_80332f58;


### PR DESCRIPTION
## Summary
- define the shared tmp artifact signed-int conversion bias constant DOUBLE_80332f40
- lets menu_tmparti emit the expected .sdata2 contents instead of leaving that constant unnamed/local

## Evidence
- ninja passes
- build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiOpen__8CMenuPcsFv: .sdata2 reports 100.0% match, size 16
- before this change, the selector reported menu_tmparti as a data opportunity and objdiff showed .sdata2 at 80.0%

## Plausibility
- DOUBLE_80332f40 is already named in config/GCCP01/symbols.txt at .sdata2:0x80332F40 as an 8-byte double
- the value is the standard signed integer conversion bias used by the generated fade animation code