### PR TITLE
Fix CUSBPcs table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -9,7 +9,7 @@ class CUSBPcs : public CProcess
 {
 public:
     class CDataHeader;
-    static unsigned int m_table[0x15C / sizeof(unsigned int)];
+    static unsigned int m_table[0x11C / sizeof(unsigned int)];
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -31,7 +31,7 @@ inline CUSBPcs::CUSBPcs()
     table[9] = desc2[2];
 }
 
-unsigned int CUSBPcs::m_table[0x15C / sizeof(unsigned int)] = {
+unsigned int CUSBPcs::m_table[0x11C / sizeof(unsigned int)] = {
     reinterpret_cast<unsigned int>(const_cast<char*>(sUsbPcsClassName)),
     0,
     0,


### PR DESCRIPTION
## Summary
- Correct CUSBPcs::m_table storage from 0x15C bytes to 0x11C bytes
- Keep the GetTable stride unchanged; only the backing static table size is corrected
- This aligns the table with the PAL symbol size and improves p_usb data layout

## Evidence
- ninja passes
- main/p_usb .data: 88.6314% -> 95.9407%
- m_table__7CUSBPcs: 90.0140% -> 100.0000%
- [.data-0]: 85.8803% -> 93.5185%

## Plausibility
- config/GCCP01/symbols.txt lists m_table__7CUSBPcs as size 0x11C
- The previous 0x15C declaration over-allocated the static table and pushed following data out of place
