### PR TITLE
Improve map hit side checks

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -529,7 +529,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
                 PSVECSubtract(&edgeEnd, &edgeStart, &edge);
                 PSVECSubtract(&point, &edgeEnd, &toPoint);
                 PSVECCrossProduct(&edge, &toPoint, &cross);
-                if (cross.z < kMapHitZero) {
+                if (cross.z <= kMapHitZero) {
                     sideMask &= 2;
                 } else {
                     sideMask &= 1;
@@ -558,7 +558,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
                 PSVECSubtract(&edgeEnd, &edgeStart, &edge);
                 PSVECSubtract(&point, &edgeEnd, &toPoint);
                 PSVECCrossProduct(&edge, &toPoint, &cross);
-                if (cross.z < kMapHitZero) {
+                if (cross.z <= kMapHitZero) {
                     sideMask &= 2;
                 } else {
                     sideMask &= 1;
@@ -587,7 +587,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
                 PSVECSubtract(&edgeEnd, &edgeStart, &edge);
                 PSVECSubtract(&point, &edgeEnd, &toPoint);
                 PSVECCrossProduct(&edge, &toPoint, &cross);
-                if (cross.z < kMapHitZero) {
+                if (cross.z <= kMapHitZero) {
                     sideMask &= 2;
                 } else {
                     sideMask &= 1;


### PR DESCRIPTION
## Summary
- Treat zero cross-product values as inside the negative side bucket in CMapHit::CheckHitFaceCylinder polygon side tests.
- Applies the same boundary handling to all three projection-axis paths.

## Evidence
- Full build: `ninja` passes; `build/GCCP01/main.dol: OK`.
- Objdiff `main/maphit` / `CheckHitFaceCylinder__7CMapHitFUl`: `57.20174% -> 57.573914%`.
- Replacement/op mismatches improved: replacements `37 -> 35`, op mismatches `4 -> 1`.

## Plausibility
- The side-mask test is geometric point-in-polygon boundary handling; including the zero cross-product case is plausible original source and matches the target branch shape more closely without hardcoded addresses or symbol hacks.