### PR TITLE
Use artifact menu float constants

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -344,7 +344,7 @@ void CMenuPcs::ArtiDraw()
 
 				float fillW = *(float*)(entry + 8) * w;
 				if (fillW > 0.0f) {
-					MenuPcs.DrawRect(0, x, y, fillW, h, u, v, colors, 1.0f, 1.0f, 0.0f);
+					MenuPcs.DrawRect(0, x, y, fillW, h, u, v, colors, FLOAT_80332fac, FLOAT_80332fac, 0.0f);
 					x += fillW;
 					u += fillW;
 				}
@@ -355,7 +355,7 @@ void CMenuPcs::ArtiDraw()
 					colors[2].a = 0;
 					colors[3].a = 0;
 					float remainW = (float)(DOUBLE_80332fb0 / (double)*(int*)(entry + 0x14)) * (float)entry[2];
-					MenuPcs.DrawRect(0, x, y, remainW, h, u, v, colors, 1.0f, 1.0f, 0.0f);
+					MenuPcs.DrawRect(0, x, y, remainW, h, u, v, colors, FLOAT_80332fac, FLOAT_80332fac, 0.0f);
 				}
 
 				MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
@@ -389,7 +389,7 @@ void CMenuPcs::ArtiDraw()
 	}
 
 	CFont* listFont = GetArtiListFont(this);
-	listFont->SetMargin(1.0f);
+	listFont->SetMargin(FLOAT_80332fac);
 	listFont->SetShadow(0);
 	listFont->SetScale(FLOAT_80332fc4);
 	listFont->DrawInit();
@@ -406,7 +406,7 @@ void CMenuPcs::ArtiDraw()
 	short* textEntry = listStart;
 	const ArtiFlatData* flatData = reinterpret_cast<const ArtiFlatData*>(&Game.m_cFlatDataArr[1]);
 	for (int i = 0; i < 8; i++) {
-		u8 alpha = (u8)(255.0f * *(float*)(textEntry + 8));
+		u8 alpha = (u8)(FLOAT_80332fc0 * *(float*)(textEntry + 8));
 		CColor color(0xFF, 0xFF, 0xFF, alpha);
 		listFont->SetColor(color.color);
 


### PR DESCRIPTION
## Summary
- Use existing artifact-menu float constants for unit scale and alpha calculations in `CMenuPcs::ArtiDraw`.
- This matches the Ghidra-decompiled constant usage around the artifact list font alpha path and improves the compiled shape without changing behavior.

## Objdiff Evidence
`build/tools/objdiff-cli diff -p . -u main/menu_arti -o -`

- `.text`: 89.033966% -> 89.04528%
- `ArtiDraw__8CMenuPcsFv`: 84.43848% -> 84.46447%
- `ArtiDraw` differing instructions: 348 -> 345
- `ArtiInit`, `ArtiInit1`, extab, extabindex, and `.sdata2` unchanged.

## Verification
- `ninja`
