### PR TITLE
Fix CPad table pad RTTI layout

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -18,7 +18,7 @@ CPad Pad;
 
 void* operator new[](unsigned long, CMemory::CStage*, char*, int);
 
-extern const char __RTTI__8CManager_8032E458[];
+extern const char __RTTI__8CManager_8032E440[];
 extern const char s_CPad[] = "CPad";
 static const float FLOAT_8032f820 = 0.0f;
 static const float FLOAT_8032f824 = 0.0078125f;
@@ -33,7 +33,7 @@ PADStatus g_pad[4];
 }
 
 unsigned int s_CPadTablePad0[3] = {
-	reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E458)), 0, 0};
+	0, reinterpret_cast<unsigned int>(const_cast<char*>(__RTTI__8CManager_8032E440)), 0};
 
 namespace {
 struct ReplayFrame


### PR DESCRIPTION
## Summary
- Correct `s_CPadTablePad0` to match the extracted PAL data layout.
- Point the table pad at the `__RTTI__8CManager` instance at `0x8032E440`, matching `build/GCCP01/asm/pad.s`.

## Objdiff Evidence
- `main/pad` `.data`: 58.36735% -> 75.5102%
- `s_CPadTablePad0`: 60.0% -> 100.0%
- `main/pad` `.text`: unchanged at 94.85495%

## Verification
- `ninja`
- `git diff --check`
- `build/tools/objdiff-cli diff -p . -u main/pad -o - Frame__4CPadFv`

## Plausibility
The extracted PAL assembly shows `s_CPadTablePad0` as `{ 0, __RTTI__8CManager_8032E440, 0 }`. This changes only the table pad data and avoids hand-written vtables or compiler coaxing.