### PR TITLE
Improve pppYmDeformationShp work-area access

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -74,7 +74,8 @@ static inline T* PppWorkArea(pppYmDeformationShp* object, pppYmDeformationShpUnk
  */
 void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmDeformationShpUnkB* param_2, pppYmDeformationShpUnkC* param_3)
 {
-	VYmDeformationShp* work = PppWorkArea<VYmDeformationShp>(pppYmDeformationShp_, param_3, 2);
+	_pppPObject* object = (_pppPObject*)pppYmDeformationShp_;
+	VYmDeformationShp* work = (VYmDeformationShp*)(object->m_workArea + param_3->m_serializedDataOffsets[2]);
 	int textureIndex = 0;
 	Vec2d uvs[4];
 	float indMtx[2][3];
@@ -84,7 +85,7 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
 
 	if (param_2->m_dataValIndex != 0xFFFF) {
 		YmDeformationShpColorInfo* colorInfo =
-			PppWorkArea<YmDeformationShpColorInfo>(pppYmDeformationShp_, param_3, 1);
+			(YmDeformationShpColorInfo*)(object->m_workArea + param_3->m_serializedDataOffsets[1]);
 		_pppEnvStYmDeformationShp* env = (_pppEnvStYmDeformationShp*)ppvEnv;
 		int textureBase =
 			reinterpret_cast<int>(env->m_mapMeshPtr[param_2->m_dataValIndex]->GetTexture(env->m_materialSetPtr, textureIndex));


### PR DESCRIPTION
## Summary
- Keep a local _pppPObject pointer in pppRenderYmDeformationShp
- Derive the deformation work and color info blocks from m_workArea with serialized data offsets
- Removes repeated PppWorkArea helper calls in this function without hard-coded offsets or generated-code hacks

## Evidence
- ninja: passes
- objdiff main/pppYmDeformationShp:
  - .text: 96.43873 -> 96.53013
  - pppRenderYmDeformationShp: 95.209366 -> 95.39532
  - .sdata2: remains 100.0

## Plausibility
This matches the existing object model more directly by using _pppPObject::m_workArea and the serialized data offset table. The change is normal member access, keeps linkage unchanged, and does not introduce fake symbols, manual vtables, ctor/dtor stubs, or section forcing.