### PR TITLE
Improve texture set creation matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -42,6 +42,27 @@ static inline unsigned short& U16At(void* p, unsigned int offset)
     return *reinterpret_cast<unsigned short*>(Ptr(p, offset));
 }
 
+/*
+ * --INFO--
+ * PAL Address: 0x8003B988
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CTexture::CTexture()
+{
+    m_maxLod = 0;
+    m_imageData = 0;
+    m_tlutData = 0;
+    m_isIntensityAlpha = 0;
+    m_isAlphaLut = 0;
+    m_name[0] = 0;
+    m_cacheId = -1;
+    m_usesExternalAddress = 0;
+}
+
 static inline CTexture* AllocTexture()
 {
     return ::new (Memory._Alloc(sizeof(CTexture), *reinterpret_cast<CMemory::CStage**>(Ptr(&TextureMan, 4)),
@@ -778,27 +799,6 @@ CTexture::~CTexture()
             m_tlutData = 0;
         }
     }
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8003B988
- * PAL Size: 100b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CTexture::CTexture()
-{
-    m_maxLod = 0;
-    m_imageData = 0;
-    m_tlutData = 0;
-    m_isIntensityAlpha = 0;
-    m_isAlphaLut = 0;
-    m_name[0] = 0;
-    m_cacheId = -1;
-    m_usesExternalAddress = 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Move the CTexture constructor definition before the texture allocation helper so Metrowerks can inline normal construction at allocation sites.
- Keeps the real CTexture::CTexture() body and symbol intact; no manual vtable/ctor construction was added.

## Objdiff evidence
ninja passes for GCCP01.

main/textureman before -> after:
- Create__11CTextureSetFR10CChunkFilePQ27CMemory6CStageiP13CAmemCacheSetii: 87.32143% (508/560b) -> 97.28571% (556/560b)
- Create__11CTextureSetFPvPQ27CMemory6CStageiP13CAmemCacheSetii: 90.365166% (660/712b) -> 98.455055% (708/712b)
- __ct__8CTextureFv: remains 100.0% (100/100b)
- .text: 97.19155% -> 98.788734%

## Plausibility
This uses ordinary C++ placement-new construction. The improved output comes from the compiler seeing the real constructor body at the allocation helper, not from hand-written constructor expansion or section forcing.