### PR TITLE
Improve menu_item matching

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -41,9 +41,9 @@ struct MenuItemOpenAnim {
     s16 y;
     s16 w;
     s16 h;
+    float u;
+    float v;
     float alpha;
-    float scale;
-    float progress;
     float uvScale;
     int unk18;
     int tex;
@@ -92,9 +92,9 @@ STATIC_ASSERT(offsetof(ItemMenuState, subMenuIndex) == 0x28);
 STATIC_ASSERT(offsetof(ItemMenuState, mode) == 0x30);
 STATIC_ASSERT(offsetof(ItemMenuState, prevMode) == 0x32);
 STATIC_ASSERT(offsetof(ItemMenuState, scroll) == 0x34);
-STATIC_ASSERT(offsetof(MenuItemOpenAnim, alpha) == 0x8);
-STATIC_ASSERT(offsetof(MenuItemOpenAnim, scale) == 0xC);
-STATIC_ASSERT(offsetof(MenuItemOpenAnim, progress) == 0x10);
+STATIC_ASSERT(offsetof(MenuItemOpenAnim, u) == 0x8);
+STATIC_ASSERT(offsetof(MenuItemOpenAnim, v) == 0xC);
+STATIC_ASSERT(offsetof(MenuItemOpenAnim, alpha) == 0x10);
 STATIC_ASSERT(offsetof(MenuItemOpenAnim, uvScale) == 0x14);
 STATIC_ASSERT(offsetof(MenuItemOpenAnim, unk18) == 0x18);
 STATIC_ASSERT(offsetof(MenuItemOpenAnim, tex) == 0x1C);
@@ -134,7 +134,7 @@ int CMenuPcs::ItemCtrlCur()
     bool blocked = false;
     unsigned int press;
     unsigned int hold;
-    int caravanWork = Game.m_scriptFoodBase[0];
+    CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
 
     if ((Pad._452_4_ != 0) || (Pad._448_4_ != -1)) {
         blocked = true;
@@ -182,15 +182,17 @@ int CMenuPcs::ItemCtrlCur()
         } else if ((hold & 4) != 0) {
             if (this->itemMenuState->selectedIndex < 7) {
                 this->itemMenuState->selectedIndex = this->itemMenuState->selectedIndex + 1;
+                Sound.PlaySe(1, 0x40, 0x7F, 0);
             } else {
                 s16 scroll = this->itemMenuState->scroll;
                 if (scroll > 0x3E) {
                     this->itemMenuState->scroll = 0;
+                    Sound.PlaySe(1, 0x40, 0x7F, 0);
                 } else {
                     this->itemMenuState->scroll = scroll + 1;
+                    Sound.PlaySe(1, 0x40, 0x7F, 0);
                 }
             }
-            Sound.PlaySe(1, 0x40, 0x7F, 0);
         }
 
         if ((hold & 0xC) == 0) {
@@ -214,8 +216,7 @@ int CMenuPcs::ItemCtrlCur()
                     idx -= 0x40;
                 }
 
-                int itemEntry = caravanWork + idx * 2;
-                s16 itemId = *(s16*)(itemEntry + 0xB6);
+                s16 itemId = caravanWork->m_inventoryItems[idx];
 
                 if ((itemId < 1) || (EquipChk(idx) != 0) ||
                     ((letterAttachFlg >= 0) && (itemId < 0x125))) {
@@ -228,10 +229,10 @@ int CMenuPcs::ItemCtrlCur()
                     this->itemMenuState->optionFlags = 0xC;
                     int itemType = GetItemType(idx, 0);
 
-                    if ((itemType == 7) && (reinterpret_cast<CCaravanWork*>(caravanWork)->CanPlayerUseItem() != 0)) {
+                    if ((itemType == 7) && (caravanWork->CanPlayerUseItem() != 0)) {
                         this->itemMenuState->optionFlags = this->itemMenuState->optionFlags | 1;
                     }
-                    if ((itemType != 1) && (reinterpret_cast<CCaravanWork*>(caravanWork)->CanPlayerPutItem() != 0)) {
+                    if ((itemType != 1) && (caravanWork->CanPlayerPutItem() != 0)) {
                         this->itemMenuState->optionFlags = this->itemMenuState->optionFlags | 2;
                     }
 
@@ -287,13 +288,13 @@ int CMenuPcs::ItemCtrlCur()
                     }
 
                     if (option == 0) {
-                        reinterpret_cast<CCaravanWork*>(caravanWork)->FGUseItem(idx, 0);
+                        caravanWork->FGUseItem(idx, 0);
                         SingLifeInit(0);
-                        reinterpret_cast<CCaravanWork*>(caravanWork)->CalcStatus();
+                        caravanWork->CalcStatus();
                     } else if (option == 1) {
-                        reinterpret_cast<CCaravanWork*>(caravanWork)->FGPutItem(idx, 0);
+                        caravanWork->FGPutItem(idx, 0);
                     } else if (option == 2) {
-                        reinterpret_cast<CCaravanWork*>(caravanWork)->DeleteItemIdx(idx, 0);
+                        caravanWork->DeleteItemIdx(idx, 0);
                     }
 
                     this->singWindowInfo[5] = 2;
@@ -327,84 +328,83 @@ void CMenuPcs::ItemDraw()
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
-    int caravanWork = Game.m_scriptFoodBase[0];
+    CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
     ItemMenuState* itemState = this->itemMenuState;
     ItemMenuAnimList* itemList = this->itemList;
     s16 listState = itemState->listState;
     s16 mode = itemState->mode;
-    int letterAttachFlg = SingGetLetterAttachflg();
+    bool hasLetterAttach = SingGetLetterAttachflg() >= 0;
     int drawIndex = 0;
     int count = itemList->count;
-    s16* entry = reinterpret_cast<s16*>(itemList->anims);
+    MenuItemOpenAnim* entry = itemList->anims;
 
-    for (int i = 0; i < count; i++, entry += 0x20) {
-        int tex = *(int*)(entry + 0xE);
+    for (int i = 0; i < count; i++, entry++) {
+        int tex = entry->tex;
         if (tex < 0) {
             continue;
         }
 
-        float x = (float)entry[0];
-        float y = (float)entry[1];
-        float w = (float)entry[2];
-        float h = (float)entry[3];
-        float u = *(float*)(entry + 4);
-        float v = *(float*)(entry + 6);
-        float alpha = *(float*)(entry + 8);
-        float uvScale = *(float*)(entry + 10);
+        float x = (float)entry->x;
+        float y = (float)entry->y;
+        float w = (float)entry->w;
+        float h = (float)entry->h;
+        float u = entry->u;
+        float v = entry->v;
+        float alpha = entry->alpha;
+        float uvScale = entry->uvScale;
 
         if (i == 0) {
             MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(1));
             MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(tex));
 
-            GXColor barColors[4];
-            barColors[0].r = 0xFF;
-            barColors[0].g = 0xFF;
-            barColors[0].b = 0xFF;
-            barColors[0].a = 0xFF;
-            barColors[1].r = 0xFF;
-            barColors[1].g = 0xFF;
-            barColors[1].b = 0xFF;
-            barColors[1].a = 0xFF;
-            barColors[2].r = 0xFF;
-            barColors[2].g = 0xFF;
-            barColors[2].b = 0xFF;
-            barColors[2].a = 0xFF;
-            barColors[3].r = 0xFF;
-            barColors[3].g = 0xFF;
-            barColors[3].b = 0xFF;
-            barColors[3].a = 0xFF;
+            GXColor colors[4];
+            colors[0].r = 0xFF;
+            colors[0].g = 0xFF;
+            colors[0].b = 0xFF;
+            colors[0].a = 0xFF;
+            colors[1].r = 0xFF;
+            colors[1].g = 0xFF;
+            colors[1].b = 0xFF;
+            colors[1].a = 0xFF;
+            colors[2].r = 0xFF;
+            colors[2].g = 0xFF;
+            colors[2].b = 0xFF;
+            colors[2].a = 0xFF;
+            colors[3].r = 0xFF;
+            colors[3].g = 0xFF;
+            colors[3].b = 0xFF;
+            colors[3].a = 0xFF;
 
-            GXSetChanMatColor(GX_COLOR0A0, barColors[0]);
+            GXSetChanMatColor(GX_COLOR0A0, colors[0]);
             float fillW = alpha * w;
             if (fillW > FLOAT_80332e60) {
                 MenuPcs.DrawRect(
-                    0, x, y, fillW, h, u, v, barColors, FLOAT_80332e64, FLOAT_80332e64, FLOAT_80332e60);
+                    0, x, y, fillW, h, u, v, colors, FLOAT_80332e64, FLOAT_80332e64, FLOAT_80332e60);
                 x += fillW;
                 u += fillW;
             }
 
             if (fillW > FLOAT_80332e60 && fillW < w) {
-                GXColor fadeColors[4];
-                fadeColors[0].r = 0xFF;
-                fadeColors[0].g = 0xFF;
-                fadeColors[0].b = 0xFF;
-                fadeColors[0].a = 0;
-                fadeColors[1].r = 0xFF;
-                fadeColors[1].g = 0xFF;
-                fadeColors[1].b = 0xFF;
-                fadeColors[1].a = 0;
-                fadeColors[2].r = 0xFF;
-                fadeColors[2].g = 0xFF;
-                fadeColors[2].b = 0xFF;
-                fadeColors[2].a = 0;
-                fadeColors[3].r = 0xFF;
-                fadeColors[3].g = 0xFF;
-                fadeColors[3].b = 0xFF;
-                fadeColors[3].a = 0;
+                colors[0].r = 0xFF;
+                colors[0].g = 0xFF;
+                colors[0].b = 0xFF;
+                colors[0].a = 0;
+                colors[1].r = 0xFF;
+                colors[1].g = 0xFF;
+                colors[1].b = 0xFF;
+                colors[1].a = 0;
+                colors[2].r = 0xFF;
+                colors[2].g = 0xFF;
+                colors[2].b = 0xFF;
+                colors[2].a = 0;
+                colors[3].r = 0xFF;
+                colors[3].g = 0xFF;
+                colors[3].b = 0xFF;
+                colors[3].a = 0;
 
-                float remainW = (float)((double)(DOUBLE_80332e68 / (double)*(int*)(entry + 0x14)) * (double)w);
+                float remainW = (float)((double)(DOUBLE_80332e68 / (double)entry->duration) * (double)w);
                 MenuPcs.DrawRect(
-                    0, x, y, remainW, h, u, v, fadeColors, FLOAT_80332e64, FLOAT_80332e64, FLOAT_80332e60);
+                    0, x, y, remainW, h, u, v, colors, FLOAT_80332e64, FLOAT_80332e64, FLOAT_80332e60);
             }
 
             MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
@@ -416,9 +416,9 @@ void CMenuPcs::ItemDraw()
                     menuIndex -= 0x40;
                 }
 
-                s16 itemId = *(s16*)(caravanWork + menuIndex * 2 + 0xB6);
+                s16 itemId = caravanWork->m_inventoryItems[menuIndex];
                 if ((itemId < 1) || (EquipChk(menuIndex) != 0) ||
-                    ((letterAttachFlg >= 0) && (itemId < 0x125))) {
+                    (hasLetterAttach && (itemId < 0x125))) {
                     if (EquipChk(menuIndex) != 0) {
                         int markX = (int)(x - FLOAT_80332e70);
                         int markY = (int)((float)((h - FLOAT_80332e74) * (float)DOUBLE_80332e78) + y);
@@ -470,7 +470,7 @@ void CMenuPcs::ItemDraw()
         CColor textColor(0xFF, 0xFF, 0xFF, (u8)(FLOAT_80332e80 * *(float*)(listStart + 8)));
         listFont->SetColor(textColor.color);
 
-        s16 itemId = *(s16*)(caravanWork + menuIndex * 2 + 0xB6);
+        s16 itemId = caravanWork->m_inventoryItems[menuIndex];
         if (itemId > 0) {
             const char* text = flatData->table[0].index[itemId * 5 + 4];
             int selectedIndex = itemState->selectedIndex + itemState->scroll;
@@ -497,7 +497,7 @@ void CMenuPcs::ItemDraw()
             menuIndex -= 0x40;
         }
 
-        s16 itemId = *(s16*)(caravanWork + menuIndex * 2 + 0xB6);
+        s16 itemId = caravanWork->m_inventoryItems[menuIndex];
         if (itemId > 0) {
             int iconY = (int)((float)(iconEntry[1] + 6) - FLOAT_80332e64);
             int iconX = (int)(float)(iconEntry[0] + iconEntry[2] - 0x10);
@@ -583,13 +583,13 @@ bool CMenuPcs::ItemClose()
         if (anim->startFrame + anim->duration <= frame) {
             float zero = FLOAT_80332e60;
             finished++;
-            anim->progress = zero;
+            anim->alpha = zero;
             anim->dx = zero;
             anim->dy = zero;
         } else {
             anim->frame++;
             double one = DOUBLE_80332e68;
-            anim->progress =
+            anim->alpha =
                 (float)-((DOUBLE_80332e68 / (double)anim->duration) * (double)anim->frame - DOUBLE_80332e68);
             if ((anim->flags & 2) == 0) {
                 float ratio = (float)-((one / (double)anim->duration) * (double)anim->frame - one);
@@ -678,13 +678,13 @@ bool CMenuPcs::ItemOpen()
         if (frame >= anim->startFrame) {
             if (anim->startFrame + anim->duration <= frame) {
                 finished++;
-                anim->progress = FLOAT_80332e64;
+                anim->alpha = FLOAT_80332e64;
                 anim->dx = FLOAT_80332e60;
                 anim->dy = FLOAT_80332e60;
             } else {
                 anim->frame++;
                 double one = DOUBLE_80332e68;
-                anim->progress = (float)((one / (double)anim->duration) * (double)anim->frame);
+                anim->alpha = (float)((one / (double)anim->duration) * (double)anim->frame);
                 if ((anim->flags & 2) == 0) {
                     float ratio = (float)((one / (double)anim->duration) * (double)anim->frame);
                     float dx = anim->targetX - (float)anim->x;
@@ -788,21 +788,21 @@ void CMenuPcs::ItemInit1()
         if (blocks != 0) {
             do {
                 entry[0].frame = 0;
-                entry[0].progress = progress;
+                entry[0].alpha = progress;
                 entry[1].frame = 0;
-                entry[1].progress = progress;
+                entry[1].alpha = progress;
                 entry[2].frame = 0;
-                entry[2].progress = progress;
+                entry[2].alpha = progress;
                 entry[3].frame = 0;
-                entry[3].progress = progress;
+                entry[3].alpha = progress;
                 entry[4].frame = 0;
-                entry[4].progress = progress;
+                entry[4].alpha = progress;
                 entry[5].frame = 0;
-                entry[5].progress = progress;
+                entry[5].alpha = progress;
                 entry[6].frame = 0;
-                entry[6].progress = progress;
+                entry[6].alpha = progress;
                 entry[7].frame = 0;
-                entry[7].progress = progress;
+                entry[7].alpha = progress;
                 entry += 8;
                 blocks--;
             } while (blocks != 0);
@@ -811,7 +811,7 @@ void CMenuPcs::ItemInit1()
         if (count != 0) {
             do {
                 entry->frame = 0;
-                entry->progress = progress;
+                entry->alpha = progress;
                 entry++;
                 count--;
             } while (count != 0);
@@ -863,8 +863,8 @@ void CMenuPcs::ItemInit()
     float titleAlpha = FLOAT_80332EA8;
     float titleScale = FLOAT_80332EAC;
     float zero = FLOAT_80332e60;
-    entry->alpha = titleAlpha;
-    entry->scale = titleScale;
+    entry->u = titleAlpha;
+    entry->v = titleScale;
     entry->uvScale = one;
     count = 4;
     entry->startFrame = 5;
@@ -876,8 +876,8 @@ void CMenuPcs::ItemInit()
     entry->y = 0xE;
     entry->w = 0x30;
     entry->h = 0x30;
-    entry->alpha = zero;
-    entry->scale = zero;
+    entry->u = zero;
+    entry->v = zero;
     entry->uvScale = one;
     entry->startFrame = 0;
     entry->duration = 5;
@@ -889,8 +889,8 @@ void CMenuPcs::ItemInit()
     entry->h = 0x30;
     entry->y = 0x150 - entry->h;
     float rightUvScale = FLOAT_80332EB0;
-    entry->alpha = zero;
-    entry->scale = zero;
+    entry->u = zero;
+    entry->v = zero;
     entry->uvScale = rightUvScale;
     entry->startFrame = 0;
     entry->duration = 5;
@@ -902,8 +902,8 @@ void CMenuPcs::ItemInit()
     entry->y = 8;
     entry->w = 0x48;
     entry->h = 0x140;
-    entry->alpha = zero;
-    entry->scale = zero;
+    entry->u = zero;
+    entry->v = zero;
     entry->startFrame = 0;
     entry->duration = 5;
 
@@ -921,8 +921,8 @@ void CMenuPcs::ItemInit()
         entry->y = itemList->anims[0].y + yOffset;
         entry->w = 200;
         entry->h = 0x28;
-        entry->alpha = zero;
-        entry->scale = zero;
+        entry->u = zero;
+        entry->v = zero;
         entry->startFrame = 7;
         entry->duration = 5;
 
@@ -936,8 +936,8 @@ void CMenuPcs::ItemInit()
         entry->y = itemList->anims[0].y + nextY;
         entry->w = 200;
         entry->h = 0x28;
-        entry->alpha = zero;
-        entry->scale = zero;
+        entry->u = zero;
+        entry->v = zero;
         entry->startFrame = 7;
         entry->duration = 5;
         loopCount--;


### PR DESCRIPTION
## Summary
- improves `CMenuPcs::ItemCtrlCur` by matching the down-scroll sound-call branch structure
- recovers `MenuItemOpenAnim` field names for UV and alpha semantics
- replaces raw caravan inventory offsets with `CCaravanWork::m_inventoryItems` member access
- cleans up `ItemDraw` state by using typed anim entries, a boolean attach flag, and a single color array for the title/fade draw

## Objdiff evidence
Baseline from branch start:
- `.text`: 80.3279%
- `ItemCtrlCur__8CMenuPcsFv`: 81.7418%
- `ItemDraw__8CMenuPcsFv`: 71.6579%

After:
- `.text`: 81.3430% (+1.0150)
- `ItemCtrlCur__8CMenuPcsFv`: 85.2459% (+3.5041)
- `ItemDraw__8CMenuPcsFv`: 71.7273% (+0.0693)

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/menu_item -o - ItemCtrlCur__8CMenuPcsFv`
- `build/tools/objdiff-cli diff -p . -u main/menu_item -o - ItemDraw__8CMenuPcsFv`

## Plausibility
The changes replace pointer-offset inventory access with existing `CCaravanWork` layout fields and rename the local item animation layout according to how those fields are used by draw/open/close. The branch duplication in `ItemCtrlCur` matches the decompiled control-flow shape without adding fake symbols, hardcoded addresses, or manual section/vtable/RTTI hacks.
