### PR TITLE
Fix p_map hit profile type

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -29,15 +29,6 @@ private:
     unsigned int m_data;
 };
 
-class CRelStopWatch
-{
-public:
-    ~CRelStopWatch();
-
-private:
-    unsigned char m_data;
-};
-
 unsigned int CMapPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CMapPcsFv)};
 unsigned int CMapPcs::m_table_desc1[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CMapPcsFv)};
 unsigned int CMapPcs::m_table_desc2[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__7CMapPcsFv)};
@@ -119,10 +110,7 @@ extern unsigned int s_loadedStageNo__7CMapPcs;
 extern unsigned int s_loadedMapNo__7CMapPcs;
 CRelProfile g_mapStage;
 CRelProfile g_mapSection;
-CRelStopWatch g_hit_prof;
-static unsigned char g_hit_prof_padding0;
-static unsigned char g_hit_prof_padding1;
-static unsigned char g_hit_prof_padding2;
+CRelProfile g_hit_prof;
 unsigned char g_map_calc_prof;
 static unsigned char g_map_calc_prof_padding0;
 static unsigned char g_map_calc_prof_padding1;
@@ -258,19 +246,6 @@ CMapPcs::CMapPcs()
  * JP Size: TODO
  */
 CRelProfile::~CRelProfile()
-{
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CRelStopWatch::~CRelStopWatch()
 {
 }
 


### PR DESCRIPTION
## Summary
- Change `g_hit_prof` from the placeholder `CRelStopWatch` type to `CRelProfile`.
- Remove the stale `CRelStopWatch` placeholder and manual padding around `g_hit_prof`.

## Evidence
- `ninja` succeeds.
- `main/p_map` objdiff:
  - `g_hit_prof`: 50.0% -> 100.0%
  - `__sinit_p_map_cpp`: 60.47131% -> 60.512295%
- Build report data matched increased by 16 bytes: `826459 / 1489399` -> `826475 / 1489399`.

## Plausibility
Ghidra shows `__sinit_p_map_cpp` registers `g_mapStage`, `g_mapSection`, and `g_hit_prof` with `__dt__11CRelProfileFv`, so `g_hit_prof` should use the same 4-byte profile type instead of a separate stopwatch placeholder plus padding.
