### PR TITLE
Improve YmLaser point count typing

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -86,7 +86,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	s32 count;
+	u32 count;
 	s32 i;
 	s32 alphaStep;
 	char alphaMax;
@@ -307,7 +307,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 			color.g = 0xFF;
 			color.b = 0xFF;
 			color.a = 0xFF;
-			for (i = 0; (int)i < (int)step->m_laser.m_pointCount; i++) {
+			for (i = 0; (int)i < (int)(u32)step->m_laser.m_pointCount; i++) {
 				if ((work->m_points[i].x == kPppYmLaserOne) && (work->m_points[i].y == kPppYmLaserOne) &&
 					(work->m_points[i].z == kPppYmLaserOne)) {
 					continue;


### PR DESCRIPTION
## Summary
- Treat the YmLaser render point count as unsigned, matching the payload field and the sibling pppLaser implementation.
- Use the unsigned point count in the debug point loop bound.

## Evidence
- Built with `ninja`.
- `pppRenderYmLaser`: 97.82979% -> 97.97872%.
- `main/pppYmLaser` .text: 98.52819% -> 98.62533%.
- Other checked YmLaser symbols remain unchanged: `pppFrameYmLaser` 99.80122%, destructor/constructors 100%.

## Plausibility
- The payload point count is a byte count and the nearby `pppLaser` implementation already carries this as an unsigned count.
- The change removes signed count handling without adding address, section, or vtable/RTTI hacks.