### PR TITLE
Fix menu artifact sdata ownership

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -25,7 +25,7 @@ extern const float FLOAT_80332fd4;
 extern const float FLOAT_80332fd8;
 extern const float FLOAT_80332fe8;
 extern const float FLOAT_80332fec;
-static const float FLOAT_80332ff0 = 0.75f;
+extern const float FLOAT_80332ff0;
 
 extern "C" {
 extern const float kMenuArtiNegativeOne = -1.0f;


### PR DESCRIPTION
## Summary
- Treat FLOAT_80332ff0 as externally owned in menu_arti instead of defining another local sdata2 constant.
- This preserves the named menu artifact constants in this unit and improves the aggregate sdata2 match.

## Objdiff Evidence
- main/menu_arti [.sdata2-0]: 90.56604% -> 92.30769%
- kMenuArtiNegativeOne, kMenuArtiDefaultScale, and kMenuArtiTau remain 100.0% matched.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o -

## Plausibility
- The change removes a duplicate definition and leaves menu_arti referencing an sdata2 value owned elsewhere, which matches the surrounding constant ownership pattern better than defining this float locally.