### PR TITLE
Fix tmp arti double constant ownership

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -14,7 +14,7 @@ extern const float FLOAT_80332f2c;
 extern const float FLOAT_80332f30;
 extern const float FLOAT_80332F34;
 extern const float FLOAT_80332F38;
-extern const double DOUBLE_80332f40 = 4503601774854144.0;
+extern const double DOUBLE_80332f40;
 extern const double DOUBLE_80332f48;
 extern const double DOUBLE_80332f50;
 extern const double DOUBLE_80332f58;


### PR DESCRIPTION
Summary:
- Treat DOUBLE_80332f40 in menu_tmparti as an external shared constant instead of defining it in this unit.
- Removes one incorrect local ownership claim while leaving code generation unchanged.

Evidence:
- ninja passes.
- objdiff for main/menu_tmparti: .text unchanged at 87.2431%; .sdata2 remains 100.0% section data match; [.sdata2-0] symbol match improves from 66.66667% to 80.0%.

Plausibility:
- Ghidra references DOUBLE_80332f40 as a shared conversion-bias constant; this unit owns DOUBLE_80333418 and DOUBLE_80333420 in .sdata2.