### PR TITLE
Match main language string data

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ static const char kLanguageArgUk[] = "uk";
 static const char kLanguageArgGr[] = "gr";
 static const char kLanguageArgIt[] = "it";
 static const char kLanguageArgFr[] = "fr";
-static const char kLanguageArgSp[] = "sp";
+static const char kLanguageArgSp[4] = "sp";
 
 void game(int argc, char** argv);
 


### PR DESCRIPTION
## Summary
- Size the final language argument string to include the trailing pad byte in main's .sdata2 string table.
- Leaves main/game code output unchanged while matching the unit's small data section.

## Evidence
- Before: main/main [.sdata2-0] 98.4127% match, 31 bytes actual.
- After: main/main [.sdata2-0] 100.0% match, 32 bytes actual.
- After: main remains 100.0%; game__FiPPc remains 99.22689%.

## Plausibility
- The language option strings are fixed two-character command-line tokens; giving the last one an explicit 4-byte char array accounts for the same trailing null padding present in the target data without changing strcmp behavior.