### PR TITLE
Match main language string data

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ static const char kLanguageArgUk[] = "uk";
 static const char kLanguageArgGr[] = "gr";
 static const char kLanguageArgIt[] = "it";
 static const char kLanguageArgFr[] = "fr";
-static const char kLanguageArgSp[] = "sp";
+static const char kLanguageArgSp[4] = "sp";
 
 void game(int argc, char** argv);
 


### PR DESCRIPTION
## Summary
- Sized the PAL Spanish language argument string as a 4-byte array to match the original string block layout.

## Evidence
- Before: `main/main` `[.sdata2-0]` was 31 bytes at 98.4127%.
- After: `main/main` `[.sdata2-0]` is 32 bytes at 100%.
- `main` remains 100%; `game__FiPPc` remains 99.22689%.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/main -o - game__FiPPc`