### PR TITLE
Improve pppKeShpTail3XDraw index types

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -180,8 +180,8 @@ void pppKeShpTail3XDraw(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* p
     float nextBaseX;
     float nextBaseY;
     float nextBaseZ;
-    u32 currentIndex;
-    u32 nextIndex;
+    s32 currentIndex;
+    s32 nextIndex;
     u8 zEnable;
     const float zero = kPppKeShpTail3XZero;
     s32 dataValIndex;


### PR DESCRIPTION
## Summary
- Change pppKeShpTail3XDraw history indices from unsigned to signed integers.
- This matches the signed index checks used by the target code for the tail history ring buffer.

## Objdiff evidence
- main/pppKeShpTail3X pppKeShpTail3XDraw: 72.90854% -> 73.097565%
- main/pppKeShpTail3X .text: 84.01798% -> 84.12949%
- No regressions observed in pppKeShpTail3XCon or pppKeShpTail3X, both remain 100%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o - pppKeShpTail3XDraw