### PR TITLE
Claim maptexanim local data

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -340,7 +340,7 @@ maptexanim.cpp:
 	extabindex  start:0x8000C844 end:0x8000C880
 	.text       start:0x8004F910 end:0x800503FC
 	.rodata     start:0x801D7EC4 end:0x801D7EE0
-	.data       start:0x801EA9A4 end:0x801EA9B0
+	.data       start:0x801EA998 end:0x801EA9B0
 	.sdata      start:0x8032E688 end:0x8032E698
 	.sdata2     start:0x8032FCD0 end:0x8032FCDC
 


### PR DESCRIPTION
Summary
- Extend the maptexanim.cpp .data split to include the 12-byte local object at 0x801EA998 before __vt__11CMapTexAnim.
- This aligns splits.txt with the existing symbols.txt ownership for @960 and lets objdiff compare the full generated .data for the unit.

Evidence
- ninja passes, including build/GCCP01/main.dol: OK.
- build/tools/objdiff-cli diff -p . -u main/maptexanim -o - now reports .data size 24 at 100.0%.
- @960 and __vt__11CMapTexAnim both report 100.0%; [.data-0] is 24 bytes at 100.0%.

Plausibility
- No C/C++ source was changed; this is a section ownership correction for data already emitted by the compiler.
- config/GCCP01/symbols.txt places @960 immediately before __vt__11CMapTexAnim, matching the adjusted range.