### PR TITLE
Fix p_map profile globals

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -29,15 +29,6 @@ private:
     unsigned int m_data;
 };
 
-class CRelStopWatch
-{
-public:
-    ~CRelStopWatch();
-
-private:
-    unsigned char m_data;
-};
-
 unsigned int CMapPcs::m_table_desc0[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__7CMapPcsFv)};
 unsigned int CMapPcs::m_table_desc1[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CMapPcsFv)};
 unsigned int CMapPcs::m_table_desc2[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calcInit__7CMapPcsFv)};
@@ -119,14 +110,8 @@ extern unsigned int s_loadedStageNo__7CMapPcs;
 extern unsigned int s_loadedMapNo__7CMapPcs;
 CRelProfile g_mapStage;
 CRelProfile g_mapSection;
-CRelStopWatch g_hit_prof;
-static unsigned char g_hit_prof_padding0;
-static unsigned char g_hit_prof_padding1;
-static unsigned char g_hit_prof_padding2;
+CRelProfile g_hit_prof;
 unsigned char g_map_calc_prof;
-static unsigned char g_map_calc_prof_padding0;
-static unsigned char g_map_calc_prof_padding1;
-static unsigned char g_map_calc_prof_padding2;
 unsigned char g_map_draw_prof;
 extern const float DrawRangeDefault;
 extern const float kPMapBoundMinInit;
@@ -258,19 +243,6 @@ CMapPcs::CMapPcs()
  * JP Size: TODO
  */
 CRelProfile::~CRelProfile()
-{
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 60b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CRelStopWatch::~CRelStopWatch()
 {
 }
 


### PR DESCRIPTION
## Summary
- Model `g_hit_prof` as `CRelProfile` instead of the synthetic one-byte `CRelStopWatch`.
- Remove manual padding globals so `g_hit_prof`, `g_map_calc_prof`, and `g_map_draw_prof` land at the target `.sbss` offsets naturally.
- Drop the unused `CRelStopWatch` destructor, matching the target's static init registration pattern.

## Evidence
- `ninja` passes: `build/GCCP01/main.dol: OK`.
- `main/p_map` `.sbss` is now 100% matched.
- Before: current object had `__dt__13CRelStopWatchFv`, `g_hit_prof` size 1 at 50%, and `g_map_draw_prof` at offset 16.
- After: no `CRelStopWatch` destructor in `p_map.o`; `g_hit_prof` is size 4 at 100%, `g_map_calc_prof` is offset 12 at 100%, and `g_map_draw_prof` is offset 13 at 100%.
- `__sinit_p_map_cpp` improves from 60.47131% to 60.512295%.

## Plausibility
The target registers `g_hit_prof` with `CRelProfile` destruction like `g_mapStage` and `g_mapSection`; the previous one-byte stop-watch type plus padding was a layout workaround. This change replaces that workaround with the coherent original-style profile object layout.
