### PR TITLE
Define p_light sdata2 constants

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -31,18 +31,18 @@ extern float FLOAT_8032fc3c;
 extern float FLOAT_8032fc40;
 extern float FLOAT_8032fc44;
 extern float FLOAT_8032fc60;
-extern float FLOAT_8032fc70;
-extern float FLOAT_8032fc74;
-extern float FLOAT_8032fc78;
-extern const float FLOAT_8032fc7c;
-extern float FLOAT_8032fc80;
-extern float FLOAT_8032fc84;
+extern const float FLOAT_8032fc70 = 100000.0f;
+extern const float FLOAT_8032fc74 = 360.0f;
+extern const float FLOAT_8032fc78 = 4.999999873689376e-06f;
+extern const float FLOAT_8032fc7c = 255.0f;
+extern const float FLOAT_8032fc80 = 999999986991104.0f;
+extern const float FLOAT_8032fc84 = 0.125f;
 extern const float FLOAT_8032fc90;
 extern float FLOAT_8032fc88;
 extern float FLOAT_8032fc8c;
 extern float FLOAT_8032fc94;
 float FLOAT_8032ed10;
-extern double DOUBLE_8032fc68;
+extern const double DOUBLE_8032fc68 = 4503599627370496.0;
 extern _GXColor s_mapLightAlphaColor;
 
 static inline float CameraPosX() { return CameraPcs.m_positionX; }


### PR DESCRIPTION
## Summary
- Define the p_light-owned .sdata2 constants instead of leaving them as unresolved externs.
- This matches the named floating-point data symbols recorded in config/GCCP01/symbols.txt.

## Objdiff evidence
Command: `build/tools/objdiff-cli diff -p . -u main/p_light -o /tmp/p_light_final.json`

Before -> after:
- `.sdata2`: 43.75% -> 100.0%
- `.text`: 92.73867% -> 92.847084%
- `extab`: 97.5% -> 98.125%
- `MakeLightMap__Q29CLightPcs10CBumpLightFv`: 86.53623% -> 87.28019%
- `DOUBLE_8032fc68`, `FLOAT_8032fc70`, `FLOAT_8032fc74`, `FLOAT_8032fc78`, `FLOAT_8032fc7c`, `FLOAT_8032fc80`, and `FLOAT_8032fc84`: previously unmatched -> 100.0%

Overall report after rebuild:
- All data: 826491 / 1489399 bytes
- Game data: 649827 / 1139403 bytes
- All code: 618428 / 1855224 bytes

## Notes
- `extabindex` score moves down because relocation ordering shifts after emitting the owned constants, but the named data ownership and p_light text/extab scores improve.
- Also tested mutable and volatile definitions; both regressed and were discarded.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_light -o /tmp/p_light_final.json`