### PR TITLE
Remove extra p_tina stubs

### DIFF
--- a/include/ffcc/p_tina.h
+++ b/include/ffcc/p_tina.h
@@ -9,7 +9,6 @@ struct Vec;
 struct pppIVECTOR3;
 struct pppFVECTOR4;
 
-void loadPdtPtx(char*, void*, int, void*, int, int);
 void LoadFieldPdt0(int, int);
 unsigned char pppNotAllocAmemCacheRmem(unsigned long);
 unsigned int pppFreeMngStPrioForData();
@@ -51,23 +50,17 @@ public:
     void onScriptChanging(char*);
     int GetTable(unsigned long);
 
-    void create0();
     void create();
     void createLoad();
     void createViewer();
     void destroy();
 
-    void ChangeDataStage(CMemory::CStage*);
-    void ResetDataStage();
-
     void calcInit();
     void calc();
     void calcViewer();
     void calcDead();
-    void CalcTick();
 
     void ClearOt();
-    void DrawInit();
 
     void drawShadow();
     void drawCharaBefore();
@@ -101,7 +94,6 @@ public:
     void EndMiruraEvent();
 
     void pppSetDebugHide(unsigned char);
-    void SetUSBData();
 };
 
 extern CPartPcs PartPcs;

--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -513,16 +513,6 @@ unsigned char pppAmemRefCntError(unsigned long)
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CPartPcs::create0()
-{
-	// TODO
-}
-
-/*
- * --INFO--
  * PAL Address: 0x8005357c
  * PAL Size: 328b
  * EN Address: TODO
@@ -683,26 +673,6 @@ void CPartPcs::destroy()
     if (usb->m_stageExtra != 0) {
         Memory.DestroyStage(usb->m_stageExtra);
     }
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CPartPcs::ChangeDataStage(CMemory::CStage*)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CPartPcs::ResetDataStage()
-{
-	// TODO
 }
 
 /*
@@ -1220,32 +1190,6 @@ unsigned int CPartPcs::IsLoadPartCompleted()
 
 /*
  * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CPartPcs::CalcTick()
-{
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CPartPcs::DrawInit()
-{
-}
-
-/*
- * --INFO--
  * PAL Address: 0x800524d0
  * PAL Size: 400b
  * EN Address: TODO
@@ -1330,16 +1274,6 @@ void CPartPcs::LoadFieldPdt(int mapId, int floorId, void* amemBase, unsigned lon
     }
 
     LoadFieldPdt0(mapId, floorId);
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void loadPdtPtx(char*, void*, int, void*, int, int)
-{
-	// TODO
 }
 
 /*
@@ -1530,26 +1464,4 @@ void CPartPcs::EndMiruraEvent()
 {
     PartMng.pppReleasePdt(7);
     m_usbStreamData.m_miruraEventActive = 0;
-}
-
-/*
- * --INFO--
- * PAL Address: UNUSED
- * PAL Size: 64b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CPartPcs::SetUSBData()
-{
-    int packetCode;
-
-    if (m_usbStreamData.IsUSBStreamDataDone()) {
-        packetCode = m_usbStreamData.m_packetCode;
-        if (packetCode != 0) {
-            PartMng.pppDataRcv(packetCode, reinterpret_cast<char*>(m_usbStreamData.m_data), m_usbStreamData.m_sizeBytes);
-        }
-        m_usbStreamData.SetUSBStreamDataDone();
-    }
 }


### PR DESCRIPTION
## Summary
- Remove CPartPcs TODO/UNUSED stub definitions that are not present in the target p_tina object
- Drop the matching unused declarations from p_tina.h

## Evidence
- ninja succeeds
- p_tina generated .text size improved from 7792 bytes before this change to 7672 bytes after; target is 7628 bytes
- objdiff no longer reports the extra create0, ChangeDataStage, ResetDataStage, CalcTick, DrawInit, loadPdtPtx, or SetUSBData symbols in p_tina
- Current p_tina sections after the change: .text target 7628/current 7672, .data 1048/current 1048, .bss 320/current 320, .sbss 24/current 24

## Plausibility
These were empty or unused placeholder functions with no corresponding target symbols. Removing them makes the translation unit closer to the shipped object instead of adding fake linkage.