### PR TITLE
Fix duplicate CTexture constructor

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -63,27 +63,6 @@ static inline unsigned short& U16At(void* p, unsigned int offset)
     return *reinterpret_cast<unsigned short*>(Ptr(p, offset));
 }
 
-/*
- * --INFO--
- * PAL Address: 0x8003B988
- * PAL Size: 100b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CTexture::CTexture()
-{
-    m_maxLod = 0;
-    m_imageData = 0;
-    m_tlutData = 0;
-    m_isIntensityAlpha = 0;
-    m_isAlphaLut = 0;
-    m_name[0] = 0;
-    m_cacheId = -1;
-    m_usesExternalAddress = 0;
-}
-
 static inline CTexture* AllocTexture()
 {
     return ::new (Memory._Alloc(sizeof(CTexture), *reinterpret_cast<CMemory::CStage**>(Ptr(&TextureMan, 4)),


### PR DESCRIPTION
## Summary
- remove a duplicate out-of-namespace CTexture::CTexture definition in textureman.cpp
- keep the remaining constructor implementation unchanged

## Evidence
- ninja completes successfully for GCCP01
- objdiff: __ct__8CTextureFv remains 100% matched (100 bytes)
- objdiff: __dt__8CTextureFv remains 100% matched (176 bytes)

## Plausibility
This removes an accidental duplicate definition introduced in the source while preserving the original constructor body. It restores a buildable unit without adding coercive data, fake symbols, or manual vtable/RTTI definitions.