### PR TITLE
Improve CFlat runtime storage call matching

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -577,7 +577,7 @@ void CGame::clearWork()
     int i;
     int j;
 
-    gCFlatRuntime2.Destroy();
+    CFlatRuntime2Storage().Destroy();
 
     for (i = 0; i < 4; i++) {
         m_cFlatDataArr[i].Destroy();
@@ -733,7 +733,7 @@ void CGame::CheckScriptChange()
 
     if (strcmp(m_nextScript.m_name, s_defaultScriptName) != 0) {
         if (m_cfdLoadedFlag == 0) {
-            gCFlatRuntime2.Destroy();
+            CFlatRuntime2Storage().Destroy();
             loadCfd();
             m_cfdLoadedFlag = 1;
 
@@ -754,7 +754,7 @@ void CGame::CheckScriptChange()
         }
     }
 
-    int scriptResult = gCFlatRuntime2.Load(m_nextScript.m_name);
+    int scriptResult = CFlatRuntime2Storage().Load(m_nextScript.m_name);
     strcpy(m_currentScriptName, m_nextScript.m_name);
 
     if (m_nextScript.m_flags != 0) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -559,7 +559,7 @@ void CGame::InitNewGame()
     *reinterpret_cast<unsigned int*>(&game->m_gameWork.m_scriptSysVal0) = 1;
     game->m_gameWork.m_chaliceElement = 1;
     strcpy(game->m_gameWork.m_townName, game->m_gameWork.m_languageId == 3 ? s_townNameTepa : s_townNameTipa);
-    gCFlatRuntime2.ResetNewGame();
+    CFlatRuntime2Storage().ResetNewGame();
     Chara.InitFurTexBuffer();
 }
 
@@ -770,7 +770,7 @@ void CGame::CheckScriptChange()
         *reinterpret_cast<unsigned int*>(&game->m_gameWork.m_scriptSysVal0) = 1;
         game->m_gameWork.m_chaliceElement = 1;
         strcpy(game->m_gameWork.m_townName, game->m_gameWork.m_languageId == 3 ? s_townNameTepa : s_townNameTipa);
-        gCFlatRuntime2.ResetNewGame();
+        CFlatRuntime2Storage().ResetNewGame();
         Chara.InitFurTexBuffer();
         m_nextScript.m_flags = 0;
     }

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1415,8 +1415,8 @@ int CCameraPcs::GetShadowRect(CBound& shadowRectBound)
                     FLOAT_8032fa1c);
     CBound::SetFrustum(eyePos, frustumMtx);
 
-    for (CGObject* gObject = gCFlatRuntime2.FindGObjFirst(); gObject != 0;
-         gObject = gCFlatRuntime2.FindGObjNext(gObject))
+    for (CGObject* gObject = CFlatRuntime2Storage().FindGObjFirst(); gObject != 0;
+         gObject = CFlatRuntime2Storage().FindGObjNext(gObject))
     {
         bool include = false;
         if (gObject->m_charaModelHandle != 0) {

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1228,9 +1228,6 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
 CLightPcs::CBumpLight::CBumpLight()
     : CLight()
 {
-    float radius = FLOAT_8032fc1c;
-
-    m_radius = radius;
     m_hasTexture = 0;
 }
 


### PR DESCRIPTION
## Summary
- Use `CFlatRuntime2Storage()` for several game and camera calls that target the direct PAL `CFlat` storage call shape.
- Remove a redundant bump-light radius assignment; `CLight()` already initializes the radius before the derived constructor body.

## Objdiff evidence
- `main/game` `InitNewGame__5CGameFv`: 90.830185% -> 93.84906%
- `main/game` `CheckScriptChange__5CGameFv`: 90.92593% -> 93.51852%
- `main/game` `clearWork__5CGameFv`: 93.01198% -> 93.97006%
- `main/p_camera` `GetShadowRect__10CCameraPcsFR6CBound`: 68.988235% -> 71.81177%
- `main/p_light` `__ct__Q29CLightPcs10CBumpLightFv`: 85.652176% -> 85.86957%

## Verification
- `ninja`
- `git diff --check`
- Targeted `build/tools/objdiff-cli diff -p . -u ... -o - <symbol>` checks for each symbol above

## Plausibility
The storage call changes replace global-reference calls with the existing direct storage accessor, matching the Ghidra/PAL call shape without introducing new linkage or address hacks. The bump-light constructor change relies on normal base constructor initialization instead of repeating the same radius store in the derived constructor.