### PR TITLE
Improve camera world map matrix and fur color source

### DIFF
--- a/include/ffcc/p_camera.h
+++ b/include/ffcc/p_camera.h
@@ -143,7 +143,7 @@ public:
     void GetWorldMapInverseMatrix(float (*)[4]);
 
     Mtx m_cameraMatrix;
-    u8 _pad34[0x64 - 0x34];
+    Mtx m_worldMapMatrix; // 0x34
     Mtx m_cameraWorldMtx; // 0x64
     Mtx44 m_screenMatrix;
     float m_targetX;

--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -147,12 +147,12 @@ static inline CMaterialSet* ModelMaterialSet(CChara::CModel* model)
 
 static inline int ModelPosQuant(CChara::CModel* model)
 {
-	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(ModelRef(model)) + 0x2C);
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(ModelRef(model)) + 0x34);
 }
 
 static inline int ModelNormQuant(CChara::CModel* model)
 {
-	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(ModelRef(model)) + 0x30);
+	return *reinterpret_cast<int*>(reinterpret_cast<u8*>(ModelRef(model)) + 0x38);
 }
 
 static inline CCharaMeshRaw* ModelMeshes(CChara::CModel* model)
@@ -2370,22 +2370,23 @@ void CChara::CModel::SetFrame(float frame)
  */
 void CChara::CModel::CalcFurColor()
 {
-	float* furTarget = (float*)((u8*)this + 0x118);
-	float* furCur = (float*)((u8*)this + 0x11C);
-	float delta = *furTarget - *furCur;
+	float delta = m_furTarget - m_furCur;
 	float step = -0.01f;
-	if (delta >= -0.01f) {
+	if (!(delta < -0.01f)) {
 		step = delta;
 		if (0.01f < delta) {
 			step = 0.01f;
 		}
 	}
-	*furCur += step;
-	if (*furCur < 0.0f) {
-		*furCur = 0.0f;
-	} else if (*furCur > 1.0f) {
-		*furCur = 1.0f;
+	m_furCur += step;
+	float furColor = 0.0f;
+	if (!(m_furCur < 0.0f)) {
+		furColor = m_furCur;
+		if (1.0f < m_furCur) {
+			furColor = 1.0f;
+		}
 	}
+	m_furCur = furColor;
 }
 
 /*

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -2258,9 +2258,24 @@ void CCameraPcs::SetIsAbsolute(int)
  * Address:	TODO
  * Size:	TODO
  */
-void CCameraPcs::SetWorldMapMatrix(float (*) [4])
+void CCameraPcs::SetWorldMapMatrix(float (*mtx) [4])
 {
-	// TODO
+	PSMTXCopy(mtx, m_worldMapMatrix);
+	PSMTXInverse(mtx, m_cameraWorldMtx);
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800B95FC
+ * PAL Size: 36b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+void CCameraPcs::GetWorldMapMatrix(float (*mtx) [4])
+{
+	PSMTXCopy(m_worldMapMatrix, mtx);
 }
 
 /*


### PR DESCRIPTION
## Summary
- add the world-map matrix field at `CCameraPcs + 0x34`
- implement `SetWorldMapMatrix` and `GetWorldMapMatrix` from the bundled Ghidra shapes
- correct chara model quantization helper offsets and rewrite `CalcFurColor` to clamp through a single final store

## Evidence
- `ninja` passes and `build/GCCP01/main.dol: OK`
- `CalcFurColor__Q26CChara6CModelFv`: 65.74074% -> 73.703705%
- `CalcSkin__Q26CChara6CModelFv`: 71.47727% -> 71.52273%
- `main/chara` `.text`: 50.577404% -> 50.578575%
- report shows `main/p_camera` fuzzy score at 60.997913% after filling the world-map matrix stubs (baseline noted during target search: 60.39745%)

## Plausibility
- `SetWorldMapMatrix`/`GetWorldMapMatrix` are direct matrix copy/inverse operations shown by Ghidra, using an offset that was anonymous padding in the header
- model quantization offsets now match existing model-data assertions used elsewhere in the repo (`0x34`/`0x38`)
- `CalcFurColor` now matches the decompiled single-store clamp structure more closely
