### PR TITLE
Improve CMapMng SetViewMtx match

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3097,15 +3097,14 @@ void CMapMng::GetAnimRunID(int)
 void CMapMng::SetViewMtx(float (*viewMtx)[4], float (*projMtx)[4])
 {
     float* proj = reinterpret_cast<float*>(projMtx);
+
+    PSMTXCopy(viewMtx, m_viewMtx);
     float scaleY = kMapViewScaleY * proj[5];
     float scaleX = proj[0];
-    Mtx* viewCopy = &m_viewMtx;
-
-    PSMTXCopy(viewMtx, *viewCopy);
     PSMTXScaleApply(
-        *viewCopy, m_scaledViewMtxPrimary, kMapViewScaleXPrimary * scaleX, scaleY, kMapViewScaleZ);
+        m_viewMtx, m_scaledViewMtxPrimary, kMapViewScaleXPrimary * scaleX, scaleY, kMapViewScaleZ);
     PSMTXScaleApply(
-        *viewCopy, m_scaledViewMtxSecondary, kMapViewScaleXSecondary * scaleX, scaleY, kMapViewScaleZ);
+        m_viewMtx, m_scaledViewMtxSecondary, kMapViewScaleXSecondary * scaleX, scaleY, kMapViewScaleZ);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Move `CMapMng::SetViewMtx` scale setup after the view matrix copy, matching the decompiled target order.
- Remove the temporary `Mtx*` so the compiler uses the target register/frame shape.

## Evidence
- `SetViewMtx__7CMapMngFPA4_fPA4_f`: 59.234043% (180b) -> 99.46809% (188b target-sized)
- Matched code: 618,644 -> 618,832 bytes

## Verification
- `ninja`