### PR TITLE
Match ptmf null data

### DIFF
--- a/src/Runtime.PPCEABI.H/ptmf.c
+++ b/src/Runtime.PPCEABI.H/ptmf.c
@@ -1,6 +1,11 @@
 #include "PowerPC_EABI_Support/Runtime/ptmf.h"
 
-const __ptmf __ptmf_null = {0, 0, {0}};
+typedef struct __ptmf_null_data {
+    __ptmf ptmf;
+    long pad;
+} __ptmf_null_data;
+
+const __ptmf_null_data __ptmf_null = {{0, 0, {0}}, 0};
 
 asm long __ptmf_test(register __ptmf* ptmf) {
     // clang-format off


### PR DESCRIPTION
## Summary
- widen the local storage used for `__ptmf_null` to the 16-byte layout present in the target runtime object
- keep `__ptmf_test` and `__ptmf_scall` code unchanged and matched

## Evidence
- `ninja` passes, including `build/GCCP01/main.dol: OK`
- `build/tools/objdiff-cli diff -p . -u main/Runtime.PPCEABI.H/ptmf -o -`:
  - `.text`: 88 bytes, 100.0%
  - `.rodata`: 16 bytes, 100.0% (was 85.71429%)
  - `__ptmf_test`: 48 bytes, 100.0%
  - `__ptmf_scall`: 40 bytes, 100.0%
  - `__ptmf_null`: 16 bytes, 100.0% (was 85.71429%)

## Plausibility
The runtime assembly only consumes the first three PTMF words, while the shipped `__ptmf_null` object occupies four words. Modeling the null object with explicit padded storage matches the data layout without changing the shared PTMF header or unrelated pointer arithmetic.