### PR TITLE
Match ptmf null data size

### DIFF
--- a/src/Runtime.PPCEABI.H/ptmf.c
+++ b/src/Runtime.PPCEABI.H/ptmf.c
@@ -1,6 +1,11 @@
 #include "PowerPC_EABI_Support/Runtime/ptmf.h"
 
-const __ptmf __ptmf_null = {0, 0, {0}};
+typedef struct __ptmf_null_data {
+    __ptmf ptmf;
+    long pad;
+} __ptmf_null_data;
+
+const __ptmf_null_data __ptmf_null = {{0, 0, {0}}, 0};
 
 asm long __ptmf_test(register __ptmf* ptmf) {
     // clang-format off


### PR DESCRIPTION
## Summary
- Give `__ptmf_null` an explicit padded data wrapper so the compiled symbol is 16 bytes like the target object.
- This keeps the normal `__ptmf` initializer intact while matching the extra trailing word present in `.rodata`.

## Evidence
- Before: `main/Runtime.PPCEABI.H/ptmf` `__ptmf_null` current symbol size was 12 bytes vs target 16 bytes, `.rodata` match 85.71429%.
- After: `__ptmf_null` target/current sizes are both 16 bytes, symbol match 100%, `.rodata` match 100%.
- Final `ninja`: `build/GCCP01/main.dol: OK`; SDK data increased to 166302 / 166902 bytes (99.64%).

## Plausibility
- This models the target data as a normal const aggregate with an explicit trailing word, rather than forcing sections or hand-writing linker data.