### PR TITLE
Match GXBump indirect matrix scale data

### DIFF
--- a/include/dolphin/gx/__gx.h
+++ b/include/dolphin/gx/__gx.h
@@ -352,7 +352,7 @@ extern void* __memReg;
 extern void* __peReg;
 extern void* __cpReg;
 extern void* __piReg;
-extern const f32 GXIndTexMtxScale1024;
+extern const f32 GXIndTexMtxScale1024[2];
 
 // #if DEBUG
 extern GXBool __GXinBegin;

--- a/src/gx/GXBump.c
+++ b/src/gx/GXBump.c
@@ -70,24 +70,24 @@ void GXSetIndTexMtx(GXIndTexMtxID mtx_id, const f32 offset[2][3], s8 scale_exp) 
     mtx_id = (GXIndTexMtxID)(mtx_id * 3);
     scale_exp += 17;
 
-    mtx[0][0] = (s32)(GXIndTexMtxScale1024 * offset[0][0]);
-    mtx[1][0] = (s32)(GXIndTexMtxScale1024 * offset[1][0]);
+    mtx[0][0] = (s32)(GXIndTexMtxScale1024[0] * offset[0][0]);
+    mtx[1][0] = (s32)(GXIndTexMtxScale1024[0] * offset[1][0]);
     reg0 = mtx[0][0] & 0x7FF;
     reg0 = (reg0 & 0xFFC007FF) | ((mtx[1][0] & 0x7FF) << 11);
     reg0 = (reg0 & 0xFF3FFFFF) | (((u32)(s8)scale_exp & 3) << 22);
     reg0 = (reg0 & 0x00FFFFFF) | ((mtx_id + 6) << 24);
     GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, reg0);
 
-    mtx[0][1] = (s32)(GXIndTexMtxScale1024 * offset[0][1]);
-    mtx[1][1] = (s32)(GXIndTexMtxScale1024 * offset[1][1]);
+    mtx[0][1] = (s32)(GXIndTexMtxScale1024[0] * offset[0][1]);
+    mtx[1][1] = (s32)(GXIndTexMtxScale1024[0] * offset[1][1]);
     reg1 = mtx[0][1] & 0x7FF;
     reg1 = (reg1 & 0xFFC007FF) | ((mtx[1][1] & 0x7FF) << 11);
     reg1 = (reg1 & 0xFF3FFFFF) | (((u32)(s8)scale_exp & 0xC) << 20);
     reg1 = (reg1 & 0x00FFFFFF) | ((mtx_id + 7) << 24);
     GX_WRITE_SOME_REG5(GX_LOAD_BP_REG, reg1);
 
-    mtx[0][2] = (s32)(GXIndTexMtxScale1024 * offset[0][2]);
-    mtx[1][2] = (s32)(GXIndTexMtxScale1024 * offset[1][2]);
+    mtx[0][2] = (s32)(GXIndTexMtxScale1024[0] * offset[0][2]);
+    mtx[1][2] = (s32)(GXIndTexMtxScale1024[0] * offset[1][2]);
     reg2 = mtx[0][2] & 0x7FF;
     reg2 = (reg2 & 0xFFC007FF) | ((mtx[1][2] & 0x7FF) << 11);
     reg2 = (reg2 & 0xFF3FFFFF) | (((u32)(s8)scale_exp & 0x30) << 18);
@@ -244,4 +244,4 @@ void __GXFlushTextureState(void) {
     gx->bpSentNot = 0;
 }
 
-const f32 GXIndTexMtxScale1024 = 1024.0f;
+const f32 GXIndTexMtxScale1024[2] = { 1024.0f, 0.0f };


### PR DESCRIPTION
## Summary
- Model `GXIndTexMtxScale1024` as the 8-byte float table described by `config/GCCP01/symbols.txt`.
- Update the internal declaration and uses to load element zero, preserving generated code while matching the data symbol size.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/gx/GXBump -o /tmp/gxbump_final.json`
- `GXBump` `.text`: 1684 bytes, 100.0% match.
- `GXBump` `.sdata2`: 8 bytes, 100.0% match.
- `GXIndTexMtxScale1024`: 8 bytes, 100.0% match.

## Plausibility
- The PAL symbols list marks `GXIndTexMtxScale1024` as an 8-byte `.sdata2` float object.
- Representing it as a two-element `f32` table matches that layout without section forcing, address hacks, or code changes.