### PR TITLE
Match CMapObj SetDrawEnv

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1422,7 +1422,7 @@ void CMapObj::SetDrawEnv()
 
     _GXColor lightColor = s_mapObjLightColor;
     LightPcs.SetMapColorAlpha(m_worldMtx, mapColor, lightColor, U8At(this, 0x26), F32At(this, 0x44), F32At(this, 0x48),
-                              F32At(this, 0x54), (S16At(this, 0x28) >> 7) & 0xFF);
+                              F32At(this, 0x54), static_cast<unsigned char>(S16At(this, 0x28) >> 7));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Match CMapObj::SetDrawEnv by preserving the signed shift before truncating the rotation argument to an unsigned byte.
- Keeps the change in normal source form with no ABI, section, vtable, or symbol forcing.

## Objdiff Evidence
- main/mapobj SetDrawEnv__7CMapObjFv: 95.95652% -> 100.0%
- Matched code: 618644 -> 619012 bytes (+368)
- Matched functions: 3501 -> 3502 (+1)
- Game Code matched code: 267048 -> 267416 bytes (+368)
- Game Code matched functions: 1913 -> 1914 (+1)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/mapobj -o /tmp/mapobj_final.json SetDrawEnv__7CMapObjFv