### PR TITLE
Use item object members in onNewFinished

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -275,8 +275,8 @@ void CGItemObj::DrawOmoideName(CFont* font)
  */
 void CGItemObj::onNewFinished()
 {
-	*(float*)((u8*)this + 0x568) = *(float*)((u8*)this + 0x144);
-	*(u16*)((u8*)this + 0x560) = (u16)((gItemObjCreateFlags >> 3) & 1);
+	m_savedBodyRadius = m_bodyEllipsoidRadius;
+	m_createFlags = static_cast<u16>((gItemObjCreateFlags >> 3) & 1);
 	loadModel();
 }
 


### PR DESCRIPTION
## Summary
- Replace raw pointer-offset writes in `CGItemObj::onNewFinished` with established `CGItemObj`/`CGObject` members.
- Keeps the matched function's codegen unchanged while making the source layout intent clearer.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/itemobj --format json-pretty -o /tmp/itemobj_unit_after_cleanup.json`
- `onNewFinished__9CGItemObjFv`: remains `100.0%`, size `52b`, with `0` instruction diffs.
- `main/itemobj` changed rows versus baseline: `0`; this is source-quality/member-access cleanup, not a score change.

## Plausibility
- `m_savedBodyRadius` is the field at `0x568`; `m_createFlags` is the field at `0x560`; `m_bodyEllipsoidRadius` is the inherited field at `0x144`.
- Ghidra for `80124fac_onNewFinished__9CGItemObjFv` shows the same `0x144 -> 0x568` copy and `0x560` flag write.
