### PR TITLE
Improve fontman DrawInit constant matching

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -45,6 +45,11 @@ inline CFontRenderFlagBits& GetRenderFlagBits(unsigned char& flags)
 {
 	return reinterpret_cast<CFontRenderFlagBits&>(flags);
 }
+
+static inline float LoadFloat(const float& value)
+{
+	return value;
+}
 }
 
 /*
@@ -392,11 +397,13 @@ void CFont::DrawInit()
 
     CFontRenderFlagBits& renderFlagBits = GetRenderFlagBits(renderFlags);
     if (renderFlagBits.zCompare != 0 || renderFlagBits.zUpdate != 0) {
-        C_MTXOrtho(projMtx, kFontZero, kFontOrthoHeight, kFontZero, kFontOrthoWidth, kFontZero, kFontOne);
-        projMtx[2][2] = kFontOne;
-        projMtx[2][3] = kFontZero;
+        C_MTXOrtho(projMtx, LoadFloat(kFontZero), LoadFloat(kFontOrthoHeight), LoadFloat(kFontZero),
+            LoadFloat(kFontOrthoWidth), LoadFloat(kFontZero), LoadFloat(kFontOne));
+        projMtx[2][2] = LoadFloat(kFontOne);
+        projMtx[2][3] = LoadFloat(kFontZero);
     } else {
-        C_MTXOrtho(projMtx, kFontZero, kFontOrthoHeight, kFontZero, kFontOrthoWidth, kFontZero, kFontOne);
+        C_MTXOrtho(projMtx, LoadFloat(kFontZero), LoadFloat(kFontOrthoHeight), LoadFloat(kFontZero),
+            LoadFloat(kFontOrthoWidth), LoadFloat(kFontZero), LoadFloat(kFontOne));
     }
     GXSetProjection(projMtx, GX_ORTHOGRAPHIC);
 
@@ -426,7 +433,7 @@ void CFont::DrawInit()
 
     float texWidth = static_cast<float>(*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(texturePtr) + 0x64));
     float texHeight = static_cast<float>(*reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(texturePtr) + 0x68));
-    PSMTXScale(texMtx, kFontOne / texWidth, kFontOne / texHeight, kFontOne);
+    PSMTXScale(texMtx, LoadFloat(kFontOne) / texWidth, LoadFloat(kFontOne) / texHeight, LoadFloat(kFontOne));
     GXLoadTexMtxImm(texMtx, GX_TEXMTX0, GX_MTX2x4);
 
     GXSetNumTexGens(1);


### PR DESCRIPTION
## Summary
- Add a small LoadFloat helper in fontman to force DrawInit to reference the named font constants.
- Use the named constants for the ortho projection and texture matrix scale setup.

## Objdiff evidence
- main/fontman DrawInit__5CFontFv: 99.6875% -> 99.97396%
- main/fontman [.sdata2-0]: 67.87879% -> 71.33758%

## Verification
- ninja build/GCCP01/src/fontman.o
- build/tools/objdiff-cli diff -p . -u main/fontman -o -
- Full ninja still stops at build/GCCP01/main.dol checksum mismatch (existing repo-level final checksum issue observed before this change).