### PR TITLE
Improve ChangeMap and TmpArtiDraw matches

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -793,31 +793,35 @@ void CGame::CheckScriptChange()
  */
 void CGame::ChangeMap(int mapId, int mapVariant, int param4, int param5)
 {
-    int hasParamMask;
-
     if (param5 != 0) {
         Graphic._WaitDrawDone(const_cast<char*>(s_game_cpp), 0x24E);
         System.MapChanging(mapId, mapVariant);
 
         m_currentMapId = mapId;
         m_currentMapVariantId = mapVariant;
-        hasParamMask = (-param4 | param4) >> 31;
 
         MapPcs.LoadMap(
-            mapId, mapVariant, (void*)(hasParamMask & 0x800000), hasParamMask & 0x580000, 0);
+            mapId, mapVariant, param4 != 0 ? (void*)0x800000 : 0, param4 != 0 ? 0x580000 : 0, 0);
 
         PartPcs.LoadFieldPdt(
-            mapId, mapVariant, (void*)(hasParamMask & 0xD80000), hasParamMask & 0x80000, 0);
+            mapId, mapVariant, param4 != 0 ? (void*)0xD80000 : 0, param4 != 0 ? 0x80000 : 0, 0);
 
         System.MapChanged(mapId, mapVariant, 1);
     } else {
         u8 loadStep = param4;
-        hasParamMask = (-param4 | param4) >> 31;
         MapPcs.LoadMap(
-            mapId, mapVariant, (void*)(hasParamMask & 0x800000), hasParamMask & 0x580000, loadStep);
+            mapId,
+            mapVariant,
+            param4 != 0 ? (void*)0x800000 : 0,
+            param4 != 0 ? 0x580000 : 0,
+            loadStep);
 
         PartPcs.LoadFieldPdt(
-            mapId, mapVariant, (void*)(hasParamMask & 0xD80000), hasParamMask & 0x80000, loadStep);
+            mapId,
+            mapVariant,
+            param4 != 0 ? (void*)0xD80000 : 0,
+            param4 != 0 ? 0x80000 : 0,
+            loadStep);
     }
 }
 

--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -150,9 +150,8 @@ void CMenuPcs::TmpArtiDraw()
 
 			const char* text = flatData->table[0].strings[*(short*)(foodPtr + 0x1F6) * 5 + 4];
 			float width = font->GetWidth(text);
-			float posX = (float)(((TmpArtiIntToFloat(entry->width) - width) * DOUBLE_80332f20) +
-			                       TmpArtiIntToFloat(entry->x));
-			float posY = TmpArtiIntToFloat(entry->y + 11);
+			float posX = (float)((((float)entry->width - width) * DOUBLE_80332f20) + (float)entry->x);
+			float posY = (float)(entry->y + 11);
 
 			font->SetPosX(posX);
 			font->SetPosY(posY - FLOAT_80332F38);


### PR DESCRIPTION
## Summary
- replace the generated-looking ChangeMap nonzero mask local with source-like ternary load flags
- simplify TmpArtiDraw text positioning casts around artifact entry dimensions and coordinates

## Objdiff evidence
- main/game ChangeMap__5CGameFiiii: 67.989586% -> 95.260414%, size remains 384 bytes
- main/menu_tmparti TmpArtiDraw__8CMenuPcsFv: 90.38636% -> 90.57576%
- main/menu_tmparti TmpArtiCtrl__8CMenuPcsFv and TmpArtiOpen__8CMenuPcsFv unchanged

## Verification
- ninja