### PR TITLE
Match p_game process table data

### DIFF
--- a/src/p_game.cpp
+++ b/src/p_game.cpp
@@ -1,13 +1,9 @@
 #include "ffcc/p_game.h"
 
-extern const char sGamePcsClassName[] = "CGamePcs";
-static const char sGameManagerClassName[] = "CManager";
-static const char sGameProcessClassName[] = "CProcess";
-
 CProcessTable CGamePcs::m_table = {
-    const_cast<char*>(sGamePcsClassName),
+    "CGamePcs",
     {
-        0, 0, 0, 0, 0, 0, 0, 0, 0x13, 0, 0, 0, 0, 0x17, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0x13, 0, 0, 0, 0, 0x17, 0, 0, 0,
         0, 0x19, 0, 0, 0, 0, 0x3A, 1, 0, 0, 0, 0x3C, 1, 0, 0, 0, 0x47, 1, 0, 0, 0, 0x4C,
     },
 };


### PR DESCRIPTION
## Summary
- Use the process table class-name literal in p_game so RTTI/class-name rodata pools like the original object.
- Correct the CGamePcs::m_table initializer by adding the missing zero word before the first process entry.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/p_game -o - now reports 100% for extab, extabindex, .text, .ctors, .rodata, .data, .sdata, and .sbss.
- Overall reported data progress increased from 1,165,130 to 1,165,682 matched bytes.

## Plausibility
- This follows the matched pattern used by nearby process units: the table points at the class string literal and the descriptor table layout includes the expected empty slot before the first priority value.
- No manual section placement, synthetic symbols, or address hacks were added.