### PR TITLE
Move pppLaser constants to mapped owners

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -29,6 +29,9 @@ extern const float FLOAT_80332f84;
 extern const double DOUBLE_80332F90;
 extern const double DOUBLE_80332F98;
 extern const double DOUBLE_80332FA0;
+extern const float kPppLaserZero = 0.0f;
+extern const float FLOAT_8033342c = 1.0f;
+extern const float FLOAT_80333430 = 2.0f;
 
 unsigned int s_Money = 0;
 signed char s_place[16];

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -16,17 +16,21 @@
 extern const f32 kPppLaserZero;
 extern const f32 FLOAT_8033342c;
 extern const f32 FLOAT_80333430;
-static const f32 kPppLaserNegativeOne = -1.0f;
-static const f32 kPppLaserDefaultScale = 1.2f;
-static const f32 kPppLaserBoundsMax = 10000000000.0f;
-static const f32 kPppLaserBoundsMin = -10000000000.0f;
-static const f32 kPppLaserHalfTileOffset = 15.5f;
-static const f32 kPppLaserTau = 6.2831855f;
+extern const f32 kMenuArtiNegativeOne;
+extern const f32 kMenuArtiDefaultScale;
+extern const f32 kMenuArtiBoundsMax;
+extern const f32 kMenuArtiBoundsMin;
+extern const f32 kMenuArtiHalfTileOffset;
+extern const f32 kMenuArtiTau;
+
+#define kPppLaserNegativeOne kMenuArtiNegativeOne
+#define kPppLaserDefaultScale kMenuArtiDefaultScale
+#define kPppLaserBoundsMax kMenuArtiBoundsMax
+#define kPppLaserBoundsMin kMenuArtiBoundsMin
+#define kPppLaserHalfTileOffset kMenuArtiHalfTileOffset
+#define kPppLaserTau kMenuArtiTau
 
 extern "C" const char s_pppLaser_cpp[] = "pppLaser.cpp";
-extern const f32 kPppLaserZero = 0.0f;
-extern const f32 FLOAT_8033342c = 1.0f;
-extern const f32 FLOAT_80333430 = 2.0f;
 
 static inline f32 LaserConst(const f32& value)
 {


### PR DESCRIPTION
## Summary
- Define the shared pppLaser zero/one/two constants in `menu_money.cpp`, matching the `.sdata2` ownership shown in `config/GCCP01/splits.txt` and `config/GCCP01/symbols.txt`.
- Make `pppLaser.cpp` reference those constants and the existing menu artifact constants instead of emitting duplicate local `.sdata2` data.

## Objdiff evidence
- `main/pppLaser` `.text`: 98.70218% -> 98.7385%.
- `pppFrameLaser`: 99.7139% -> 99.79564%.
- `pppConstructLaser`: 99.82143% -> 100.0%.
- `pppLaser.o` emitted `.sdata2`: 56 bytes -> 16 bytes.

## Plausibility
The constant ownership follows the configured PAL splits: `menu_money.cpp` owns `.sdata2:0x80333428..0x80333448`, and `menu_arti.cpp` owns the neighboring negative/default/bounds/tau constants. This removes duplicate data from `pppLaser.cpp` rather than coercing code generation.