### PR TITLE
Improve caravan letter event checks

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1056,7 +1056,6 @@ int CCaravanWork::GetFoodRank(int playerIdx)
 void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxResults)
 {
 	int foundCount = 0;
-	unsigned char* curLetter = reinterpret_cast<unsigned char*>(Game.unkCFlatData0[3]);
 
 	if (maxResults > 0) {
 		for (int i = 0; i < maxResults; i++) {
@@ -1064,6 +1063,7 @@ void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxRe
 		}
 	}
 
+	unsigned char* curLetter = reinterpret_cast<unsigned char*>(Game.unkCFlatData0[3]);
 	for (int letterIdx = 0; letterIdx < 0x200; letterIdx++, curLetter += 0x3E) {
 		unsigned short condBits = *reinterpret_cast<unsigned short*>(curLetter + 0x18);
 
@@ -1402,7 +1402,7 @@ void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxRe
 
 			if (sourceType != 3) {
 				if (sourceType == 1) {
-					cmpValue = static_cast<unsigned int>(Game.m_gameWork.m_eventWork[sourceIdx + 4]);
+					cmpValue = static_cast<unsigned int>(Game.m_gameWork.m_eventWork[sourceIdx]);
 				} else if (sourceType == 0) {
 					if (sourceIdx == 0) {
 						cmpValue = static_cast<unsigned int>(Game.m_gameWork.m_scriptSysVal0);
@@ -1468,11 +1468,11 @@ void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxRe
 					bit1 = ((evtWorkBytes[(sourceIdx + 1) >> 3] & (1 << ((sourceIdx + 1) & 7))) != 0);
 					bit2 = ((evtWorkBytes[(sourceIdx + 2) >> 3] & (1 << ((sourceIdx + 2) & 7))) != 0);
 				} else if ((sourceType < 2) && (sourceType != 0)) {
-					bit0 = ((static_cast<unsigned char>(Game.m_gameWork.m_eventFlags[(sourceIdx >> 3) + 8]) &
+					bit0 = ((static_cast<unsigned char>(Game.m_gameWork.m_eventFlags[sourceIdx >> 3]) &
 							 (1 << (sourceIdx & 7))) != 0);
-					bit1 = ((static_cast<unsigned char>(Game.m_gameWork.m_eventFlags[((sourceIdx + 1) >> 3) + 8]) &
+					bit1 = ((static_cast<unsigned char>(Game.m_gameWork.m_eventFlags[(sourceIdx + 1) >> 3]) &
 							 (1 << ((sourceIdx + 1) & 7))) != 0);
-					bit2 = ((static_cast<unsigned char>(Game.m_gameWork.m_eventFlags[((sourceIdx + 2) >> 3) + 8]) &
+					bit2 = ((static_cast<unsigned char>(Game.m_gameWork.m_eventFlags[(sourceIdx + 2) >> 3]) &
 							 (1 << ((sourceIdx + 2) & 7))) != 0);
 				}
 


### PR DESCRIPTION
## Summary
- Move the ROM letter source pointer load until after clearing the result array in `SearchRomLetterWork`.
- Use the base event work and event flag arrays directly instead of offsetting by the prior decompiler padding.

## Objdiff evidence
- `main/gobjwork` `.text`: 87.6088% -> 87.7691% (+0.1604)
- `SearchRomLetterWork__12CCaravanWorkFPP14CRomLetterWorki`: 71.3190% -> 71.9544% (+0.6355)
- No measured regressions in the checked selected symbols: `CalcStatus__12CCaravanWorkFv`, `GetCmdListItemName__12CCaravanWorkFiPiPi`

## Validation
- `ninja`
- `python3 tools/objdiff_experiment.py -u main/gobjwork SearchRomLetterWork__12CCaravanWorkFPP14CRomLetterWorki CalcStatus__12CCaravanWorkFv GetCmdListItemName__12CCaravanWorkFiPiPi --baseline /tmp/gobjwork_baseline.json --limit 30`

## Plausibility
The target assembly reads `Game.m_gameWork` event arrays from their base addresses for these comparisons. Dropping the extra offsets removes decompiler-era padding from the source and makes the code closer to the surrounding event-work access patterns.