### PR TITLE
Remove extra pppCrystal helper code

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -46,18 +46,6 @@ struct pppCrystalColorBlock {
     pppCVECTOR m_color;
 };
 
-struct HSD_ImageBuffer {
-    u8* m_imageData;
-    GXTexFmt m_format;
-    u32 m_width;
-    u32 m_height;
-    u32 m_imageCount;
-    u32 m_bufferSize;
-};
-
-void ImageBufferSetPixel_IA8(
-    HSD_ImageBuffer*, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long);
-
 union CrystalFloatBits {
     float value;
     u32 bits;
@@ -389,59 +377,4 @@ void pppConstructCrystal(struct pppCrystal* pppCrystal, struct _pppCtrlTable* pa
 
 	work->m_refractionMap = 0;
 	work->m_refractionTexObj = 0;
-}
-
-void MakeRefractionMap(HSD_ImageBuffer* image)
-{
-	float yCoord = FLOAT_80330FD4;
-	float stepX = 2.0f / (float)(image->m_width - 1U);
-	float stepY = 2.0f / (float)(image->m_height - 1U);
-
-	for (u32 y = 0; y < image->m_height; y++) {
-		float ySq = yCoord * yCoord;
-		float xCoord = FLOAT_80330FD4;
-
-		for (u32 x = 0; x < image->m_width; x++) {
-			float magnitude = xCoord * xCoord + ySq;
-			if (magnitude > FLOAT_80330FD8) {
-				magnitude = CrystalSqrtPositive(magnitude);
-			} else if ((double)magnitude < kPppLensFlareZeroD) {
-				magnitude = NAN;
-			} else if (CrystalFpClassify(magnitude) == 1) {
-				magnitude = NAN;
-			}
-
-			if (magnitude > kPppLensFlareOne) {
-				magnitude = kPppLensFlareOne;
-			}
-
-			double modulation = fmod(magnitude, kPppLensFlareOcclusionStep);
-			magnitude = FLOAT_80331008 * (magnitude * (float)modulation);
-			ImageBufferSetPixel_IA8(
-				image, x, y,
-				__cvt_fp2unsigned((double)(xCoord * magnitude * FLOAT_80331010 + FLOAT_8033100C)),
-				__cvt_fp2unsigned((double)(yCoord * magnitude * FLOAT_80331010 + FLOAT_8033100C)), 0, 0);
-			xCoord += stepX;
-		}
-
-		yCoord += stepY;
-	}
-
-	DCFlushRange(image->m_imageData, image->m_bufferSize);
-}
-
-void ImageBufferSetPixel_IA8(
-	HSD_ImageBuffer* image, unsigned long x, unsigned long y, unsigned long intensity, unsigned long alpha,
-	unsigned long, unsigned long)
-{
-	u32 yTile = y >> 2;
-	u32 yFine = (y & 3) * 4;
-	u32 xFine = x & 3;
-	u8* pixel = image->m_imageData +
-		yTile * ((image->m_width & 0x1FFFFFFCU) << 3) +
-		(x & 0x1FFFFFFC) * 8 +
-		(xFine + yFine) * 2;
-
-	pixel[0] = (u8)intensity;
-	pixel[1] = (u8)alpha;
 }


### PR DESCRIPTION
## Summary
- Remove unused local HSD_ImageBuffer/MakeRefractionMap/ImageBufferSetPixel_IA8 code from src/pppCrystal.cpp.
- The target pppCrystal object ends at pppConstructCrystal; these helper functions were extra emitted code in the rebuilt object.

## Evidence
- ninja passes.
- Before: pppCrystal rebuilt object emitted extra MakeRefractionMap and ImageBufferSetPixel_IA8 symbols after pppConstructCrystal; objdiff showed extab/extabindex at 85.714% and no matched .rodata/.sdata2 sections for the unit.
- After: build/tools/objdiff-cli diff -p . -u main/pppCrystal -o - --format json-pretty reports extab 100%, extabindex 100%, .rodata 100%, .sdata2 100%, .text size 2692 with pppDestructCrystal and pppConstructCrystal still 100%.

## Plausibility
- This removes analysis/helper code that is not present in the target object and leaves the actual inlined refraction-map generation inside pppFrameCrystal intact.
- No vtable/RTTI/ctor/dtor hacks or section forcing.