### PR TITLE
Claim early sdata2 ranges

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -52,6 +52,7 @@ graphic.cpp:
 	.bss        start:0x80230E48 end:0x8023C4D8
 	.sdata      start:0x8032E3E8 end:0x8032E400
 	.sbss       start:0x8032EC48 end:0x8032EC55
+	.sdata2     start:0x8032F6E8 end:0x8032F718
 
 main.cpp:
 	extab       start:0x80005920 end:0x80005930
@@ -139,6 +140,7 @@ usb.cpp:
 	.data       start:0x801E8898 end:0x801E88B4
 	.bss        start:0x802455C0 end:0x80245640
 	.sdata      start:0x8032E478 end:0x8032E488
+	.sdata2     start:0x8032F880 end:0x8032F885
 
 util.cpp:
 	extab       start:0x80005D30 end:0x80005E00


### PR DESCRIPTION
## Summary
- Claim the early .sdata2 range for graphic.cpp covering 0x8032F6E8-0x8032F718.
- Claim the .sdata2 range for usb.cpp covering 0x8032F880-0x8032F885.

## Evidence
- ninja
- build/GCCP01/main.dol: OK
- objdiff: usb .sdata2 size 5, 100.0% match
- objdiff: graphic .sdata2 now attributed to graphic.cpp (48 bytes)

## Plausibility
These are split ownership updates only. The ranges are contiguous symbol-backed .sdata2 data in link order, and the splitter/build accepts them without changing source code or forcing sections.