### PR TITLE
Define chara viewer sdata2 constants

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -36,6 +36,11 @@ extern const float kCharaViewerLightTargetY;
 extern const float kCharaViewerLightTargetZ;
 }
 
+extern "C" const double kCharaViewerColorCenterBias = 4503601774854144.0;
+extern "C" const float kCharaViewerZero = 0.0f;
+extern "C" const float kCharaViewerBackOrthoRight = 448.0f;
+extern "C" const float kCharaViewerBackOrthoBottom = 640.0f;
+extern "C" const float kCharaViewerGridMax = -100.0f;
 extern "C" const float kCharaViewerUnitStep = 1.0f;
 extern "C" const float kCharaViewerGridSpacing = 10.0f;
 extern "C" const float kCharaViewerGridMin = 100.0f;
@@ -68,9 +73,6 @@ extern "C" const double kCharaSharedSignedIntBias = 4503601774854144.0;
 #include <math.h>
 #include <string.h>
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdio.h>
-
-extern "C" const float kCharaViewerBackOrthoRight;
-extern "C" const float kCharaViewerBackOrthoBottom;
 
 struct CharaViewerSRT {
     float transX;


### PR DESCRIPTION
## Summary
- Define the missing p_chara_viewer .sdata2 constants for the viewer color conversion bias and camera/grid floats.
- Remove redundant extern-only declarations for the background ortho constants now that the unit owns the definitions.

## Evidence
- Values are backed by orig/GCCP01/sys/main.dol at .sdata2 addresses 0x80330BE0 through 0x80330BF4.
- build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o - reports .sdata2: 128 bytes, 100.0% match.
- ninja succeeds.

## Plausibility
- These constants are normal source-level data definitions adjacent to the existing p_chara_viewer constants, not section forcing or hand-written generated data.