### PR TITLE
Improve current weapon item lookup

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2526,18 +2526,13 @@ void CCaravanWork::GetCurrentWeaponItem(int& weaponItem, int& weaponRef)
 {
 	short weaponIdx = m_weaponIdx;
 	if (weaponIdx == 0) {
-		int ref;
-		weaponItem = ref = 0;
+		weaponItem = 0;
 		CCaravanWork* ownerWork = *reinterpret_cast<CCaravanWork**>(reinterpret_cast<unsigned char*>(m_ownerObj) + 0x58);
 		int equippedSlot = ownerWork->m_equipment[0];
 		if (equippedSlot >= 0) {
-			ref = ownerWork->m_inventoryItems[equippedSlot];
+			weaponRef = ownerWork->m_inventoryItems[equippedSlot];
 		}
-		weaponRef = ref;
-		return;
-	}
-
-	if (weaponIdx != 1) {
+	} else if (weaponIdx != 1) {
 		weaponItem = weaponIdx;
 		CCaravanWork* ownerWork = *reinterpret_cast<CCaravanWork**>(reinterpret_cast<unsigned char*>(m_ownerObj) + 0x58);
 		weaponRef = ownerWork->DelCmdListAndItem(m_weaponIdx);


### PR DESCRIPTION
## Summary
- Simplify the base-weapon path in `CCaravanWork::GetCurrentWeaponItem`.
- Stop using a shared temporary `ref` value and only write `weaponRef` when an equipped weapon slot is present.
- Restructure the alternate weapon path as an `else if`, matching the intended mutually exclusive cases.

## Objdiff Evidence
- Unit: `main/gobjwork`
- Symbol: `GetCurrentWeaponItem__12CCaravanWorkFRiRi`
- Before: 98.93939%
- After: 99.242424%

## Validation
- `ninja`
- `git diff --check`
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o /tmp/gobj_weapon_final.json GetCurrentWeaponItem__12CCaravanWorkFRiRi`

## Plausibility
The new source avoids an artificial temporary that forced `weaponRef` to zero in the no-equipped-slot path. The emitted code now more closely follows the target by zeroing `weaponItem` directly and only assigning `weaponRef` from inventory when a valid equipment slot exists.