### PR TITLE
Use mon object work symbols

### DIFF
--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -30,7 +30,6 @@ u8 m_aiWork__8CGMonObj[0xC];
 u8 m_boss__8CGMonObj[0x8C];
 }
 
-extern "C" char SoundBuffer_1248_[];
 extern "C" float g_hit_t;
 extern float FLOAT_803319C0;
 extern float FLOAT_803319D8;
@@ -684,7 +683,7 @@ void CGMonObj::onCancelStat(int state)
 		break;
 
 	case 0x21:
-		*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+		*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 		memset(mon + 0x70C, 0, 0x34);
 		if ((*reinterpret_cast<unsigned int*>(mon + 0x710) & 2) == 0) {
 			(this->*m_funcs->moveCancel)();
@@ -721,7 +720,7 @@ void CGMonObj::isValidTarget()
 
 	if ((*reinterpret_cast<int*>(mon + 0x6C4) >= 0) &&
 	    ((*reinterpret_cast<unsigned short*>(aiData + 0x102) & 0x20) != 0)) {
-		*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+		*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 		memset(mon + 0x70C, 0, 0x34);
 		*reinterpret_cast<int*>(mon + 0x6D8) = 2;
 		*reinterpret_cast<int*>(mon + 0x6DC) = 0;
@@ -731,7 +730,7 @@ void CGMonObj::isValidTarget()
 
 	if (((*reinterpret_cast<unsigned short*>(aiData + 0x102) & 0x20) != 0) ||
 	    ((*reinterpret_cast<unsigned short*>(script9 + 0xFE) & 8) != 0)) {
-		*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+		*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 		memset(mon + 0x70C, 0, 0x34);
 		*reinterpret_cast<int*>(mon + 0x6D8) = 0;
 		*reinterpret_cast<int*>(mon + 0x6DC) = 0;
@@ -740,7 +739,7 @@ void CGMonObj::isValidTarget()
 	}
 
 	if (*reinterpret_cast<short*>(script9 + 0x10C) == 1) {
-		*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x21;
+		*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x21;
 		if (*reinterpret_cast<int*>(mon + 0x734) != 3) {
 			memset(mon + 0x70C, 0, 0x34);
 			*reinterpret_cast<int*>(mon + 0x70C) = 0x806;
@@ -793,13 +792,13 @@ check_home:
 		*reinterpret_cast<int*>(mon + 0x6F8) = *reinterpret_cast<int*>(mon + 0x15C);
 		*reinterpret_cast<int*>(mon + 0x6FC) = *reinterpret_cast<int*>(mon + 0x160);
 		*reinterpret_cast<int*>(mon + 0x700) = *reinterpret_cast<int*>(mon + 0x164);
-		*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+		*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 		memset(mon + 0x70C, 0, 0x34);
 		*reinterpret_cast<int*>(mon + 0x6D8) = 0;
 		*reinterpret_cast<int*>(mon + 0x6DC) = 0;
 		mon[0x6BB] = 1;
 	} else if (*reinterpret_cast<short*>(script9 + 0x10C) != 1) {
-		*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x1C;
+		*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x1C;
 	}
 }
 
@@ -851,13 +850,13 @@ void CGMonObj::seKiduki()
 
 		if ((action == 0) && ((noticeFlags & 0x80) != 0)) {
 			notice = true;
-			*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x32;
+			*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x32;
 		} else if ((action == 0) && ((noticeFlags & 0x20) != 0)) {
 			notice = true;
-			*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x33;
+			*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x33;
 		} else if ((action == 0) && (((noticeFlags & 0x40) != 0) || (scriptHandle[4] == 0x39))) {
 			notice = true;
-			*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x34;
+			*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x34;
 		}
 	}
 
@@ -866,7 +865,7 @@ void CGMonObj::seKiduki()
 		if (classId < 0x70) {
 			if (classId == 0x6A) {
 				notice = true;
-				*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x35;
+				*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x35;
 			}
 		} else if (classId == 0x7B) {
 			notice = true;
@@ -3052,7 +3051,7 @@ extern "C" void CGMonObj_UpdateActionStateFromTarget(CGMonObj* monObj)
 	unsigned char* mon = reinterpret_cast<unsigned char*>(monObj);
 	CGObject* object = reinterpret_cast<CGObject*>(monObj);
 	int& targetPartyIndex = *reinterpret_cast<int*>(mon + 0x6C4);
-	int& actionState = *reinterpret_cast<int*>(SoundBuffer_1248_ + 4);
+	int& actionState = *reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4);
 	unsigned char* script = reinterpret_cast<unsigned char*>(object->m_scriptHandle[9]);
 
 	if (targetPartyIndex >= 0) {
@@ -3249,7 +3248,7 @@ extern "C" void CGMonObj_TickActionState(CGMonObj* monObj)
 			(((*reinterpret_cast<unsigned int*>(mon + 0x710) & 1) != 0) ||
 			 (static_cast<int>(*reinterpret_cast<unsigned short*>(script + 0x1BC)) <=
 			  *reinterpret_cast<int*>(mon + 0x730)))) {
-			*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+			*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 			memset(mon + 0x70C, 0, 0x34);
 			*reinterpret_cast<int*>(mon + 0x6D8) = 3;
 			*reinterpret_cast<int*>(mon + 0x6DC) = 0;
@@ -3275,7 +3274,7 @@ extern "C" void CGMonObj_TickActionState(CGMonObj* monObj)
 extern "C" void CGMonObj_ResetActionState(CGMonObj* monObj)
 {
 	unsigned char* mon = reinterpret_cast<unsigned char*>(monObj);
-	*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+	*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 	memset(mon + 0x70C, 0, 0x34);
 }
 
@@ -3305,13 +3304,13 @@ extern "C" void MonObjRelated(CGMonObj* monObj, int* targetIndex)
 	if (state > 2) {
 		if (state == 5) {
 			if (*targetPartyIdx < 0) {
-				*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+				*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 				memset(mon + 0x70C, 0, 0x34);
 				*chaseState = 0;
 				*chaseTimer = 0;
 				mon[0x6BB] = 1;
 			} else {
-				*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0x21;
+				*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0x21;
 				CGPartyObj* partyObj = Game.m_partyObjArr[*targetPartyIdx];
 				if (*reinterpret_cast<int*>(mon + 0x734) != 4) {
 					memset(mon + 0x70C, 0, 0x34);
@@ -3343,7 +3342,7 @@ extern "C" void MonObjRelated(CGMonObj* monObj, int* targetIndex)
 				*reinterpret_cast<CGPartyObj**>(mon + 0x714) = partyObj;
 				if (((*reinterpret_cast<unsigned int*>(mon + 0x710) & 1) != 0) ||
 					((object->m_stateFlags0 & 0x40) != 0)) {
-					*reinterpret_cast<int*>(SoundBuffer_1248_ + 4) = 0;
+					*reinterpret_cast<int*>(m_aiWork__8CGMonObj + 4) = 0;
 					memset(mon + 0x70C, 0, 0x34);
 					if (*targetPartyIdx >= 0) {
 						object->m_rotTargetY = prgObj->getTargetRot(reinterpret_cast<CGPrgObj*>(Game.m_partyObjArr[*targetPartyIdx]));

--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -56,7 +56,6 @@ extern double DOUBLE_80331d38;
 extern double DOUBLE_80331dc0;
 extern "C" char s_meteo_3_80331D64[8];
 extern char SoundBuffer[];
-extern char SoundBuffer_1260_[];
 extern "C" float MG_GBA_THREAD_MSG_SETPORT_ct;
 extern "C" char g_errCt;
 extern "C" Vec gGoblinKingTeleportPoints[] = {
@@ -115,6 +114,22 @@ struct MeteoParasiteCBossWork {
 struct DuctBossWork {
     u8 m_pad00[0x38];
     CGMonObj* m_objs[3];
+};
+
+struct LKShooterBossWork {
+    u8 m_pad00[0x08];
+    int m_stunTimer;
+    int m_leftCooldown;
+    int m_rightCooldown;
+    union {
+        u8 m_flags;
+        struct {
+            u8 m_bit80 : 1;
+            u8 m_bit40 : 1;
+            u8 m_bit20 : 1;
+            u8 m_rest : 5;
+        } bits;
+    };
 };
 
 /*
@@ -949,8 +964,9 @@ void CGMonObj::attackedFuncSaw()
 	CGPrgObj* prgObj = reinterpret_cast<CGPrgObj*>(this);
 	if (prgObj->m_lastStateId == 100) {
 		prgObj->addSubStat();
-		*reinterpret_cast<unsigned char*>(SoundBuffer_1260_ + 0x14) |= 0x80;
-		*reinterpret_cast<int*>(SoundBuffer_1260_ + 0x8) = 0xFA;
+		LKShooterBossWork* work = reinterpret_cast<LKShooterBossWork*>(m_boss__8CGMonObj);
+		work->bits.m_bit80 = 1;
+		work->m_stunTimer = 0xFA;
 	}
 }
 
@@ -967,10 +983,10 @@ void CGMonObj::frameStatFuncLKShooter()
 {
 	u8* self = reinterpret_cast<u8*>(this);
 
-	int cooldown0 = *reinterpret_cast<int*>(SoundBuffer_1260_ + 0xC) - 1;
-	int cooldown1 = *reinterpret_cast<int*>(SoundBuffer_1260_ + 0x10) - 1;
-	*reinterpret_cast<int*>(SoundBuffer_1260_ + 0xC) = cooldown0 & ~(cooldown0 >> 31);
-	*reinterpret_cast<int*>(SoundBuffer_1260_ + 0x10) = cooldown1 & ~(cooldown1 >> 31);
+	int cooldown0 = *reinterpret_cast<int*>(m_boss__8CGMonObj + 0xC) - 1;
+	int cooldown1 = *reinterpret_cast<int*>(m_boss__8CGMonObj + 0x10) - 1;
+	*reinterpret_cast<int*>(m_boss__8CGMonObj + 0xC) = cooldown0 & ~(cooldown0 >> 31);
+	*reinterpret_cast<int*>(m_boss__8CGMonObj + 0x10) = cooldown1 & ~(cooldown1 >> 31);
 
 	const int state = *reinterpret_cast<int*>(self + 0x520);
 	if (state == 0x65) {
@@ -1008,7 +1024,7 @@ state100:
 	moveFrame();
 	const int branch = *reinterpret_cast<int*>(self + 0x6D0);
 	const int flatFlags = CFlatBossState();
-	if ((*reinterpret_cast<volatile signed char*>(SoundBuffer_1260_ + 0x14) < 0) ||
+	if ((*reinterpret_cast<volatile signed char*>(m_boss__8CGMonObj + 0x14) < 0) ||
 	    ((branch == 1) && ((flatFlags & 1) != 0)) || ((branch == 2) && ((flatFlags & 2) != 0))) {
 		reinterpret_cast<CGPrgObj*>(this)->changeStat(0, 0, 0);
 	}
@@ -1019,7 +1035,7 @@ state101:
 		reinterpret_cast<CGPrgObj*>(this)->reqAnim(-1, 0, 0);
 		rotTarget(*reinterpret_cast<int*>(self + 0x6C4), FLOAT_80331da4);
 	}
-	if ((*reinterpret_cast<volatile signed char*>(SoundBuffer_1260_ + 0x14) < 0) ||
+	if ((*reinterpret_cast<volatile signed char*>(m_boss__8CGMonObj + 0x14) < 0) ||
 	    (*reinterpret_cast<float*>(self + 0x5D0 + *reinterpret_cast<int*>(self + 0x620) * 4) < FLOAT_80331da8)) {
 		reinterpret_cast<CGPrgObj*>(this)->changeStat(0, 0, 0);
 	}
@@ -1028,13 +1044,13 @@ state101:
 resetBranch:
 	if (*reinterpret_cast<int*>(self + 0x6D0) == 1) {
 		*reinterpret_cast<int*>(self + 0x6D0) = 0;
-		*reinterpret_cast<volatile unsigned char*>(SoundBuffer_1260_ + 0x14) &= 0xDF;
-		*reinterpret_cast<int*>(SoundBuffer_1260_ + 0x10) = 0xFA;
+		*reinterpret_cast<volatile unsigned char*>(m_boss__8CGMonObj + 0x14) &= 0xDF;
+		*reinterpret_cast<int*>(m_boss__8CGMonObj + 0x10) = 0xFA;
 	}
 	if (*reinterpret_cast<int*>(self + 0x6D0) == 2) {
 		*reinterpret_cast<int*>(self + 0x6D0) = 0;
-		*reinterpret_cast<volatile unsigned char*>(SoundBuffer_1260_ + 0x14) &= 0xBF;
-		*reinterpret_cast<int*>(SoundBuffer_1260_ + 0xC) = 0xFA;
+		*reinterpret_cast<volatile unsigned char*>(m_boss__8CGMonObj + 0x14) &= 0xBF;
+		*reinterpret_cast<int*>(m_boss__8CGMonObj + 0xC) = 0xFA;
 	}
 }
 
@@ -1051,24 +1067,24 @@ int CGMonObj::attackCheckFuncLKShooter(int)
 {
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	unsigned char* mon = reinterpret_cast<unsigned char*>(this);
-	unsigned char* work = reinterpret_cast<unsigned char*>(SoundBuffer_1260_);
+	LKShooterBossWork* work = reinterpret_cast<LKShooterBossWork*>(m_boss__8CGMonObj);
 
-	if (*reinterpret_cast<int*>(work + 8) == 0) {
-		if ((work[0x14] & 0x40) == 0 && (CFlatBossState() & 2) == 0) {
+	if (work->m_stunTimer == 0) {
+		if (work->bits.m_bit40 == 0 && (CFlatBossState() & 2) == 0) {
 			CVector left(FLOAT_80331d90, FLOAT_80331cf8, FLOAT_80331d94);
 			if (PSVECDistance(reinterpret_cast<Vec*>(&left), &object->m_worldPosition) < FLOAT_80331d98 &&
-			    *reinterpret_cast<int*>(work + 0xC) == 0) {
-				work[0x14] |= 0x40;
-				*reinterpret_cast<int*>(work + 0xC) = 300;
+			    work->m_leftCooldown == 0) {
+				work->bits.m_bit40 = 1;
+				work->m_leftCooldown = 300;
 				*reinterpret_cast<int*>(mon + 0x6D0) = 2;
 				return 100;
 			}
 		}
-		if ((work[0x14] & 0x20) == 0 && (CFlatBossState() & 1) == 0) {
+		if (work->bits.m_bit20 == 0 && (CFlatBossState() & 1) == 0) {
 			CVector right(FLOAT_80331d9c, FLOAT_80331cf8, FLOAT_80331d9c);
 			if (PSVECDistance(reinterpret_cast<Vec*>(&right), &object->m_worldPosition) < FLOAT_80331d98 &&
-			    *reinterpret_cast<int*>(work + 0x10) == 0) {
-				work[0x14] |= 0x20;
+			    work->m_rightCooldown == 0) {
+				work->bits.m_bit20 = 1;
 				*reinterpret_cast<int*>(mon + 0x6D0) = 1;
 				return 100;
 			}


### PR DESCRIPTION
## Summary
- Replace SoundBuffer_1248_ alias usage in monobj with the owned m_aiWork__8CGMonObj work buffer.
- Replace SoundBuffer_1260_ alias usage in LKShooter/Saw boss logic with m_boss__8CGMonObj.
- Add a small LKShooterBossWork view so nearby boss flag writes compile closer to PAL source.

## Objdiff evidence
monobj:
- CGMonObj_ResetActionState: 99.000000% -> 100.000000%
- seKiduki__8CGMonObjFv: 74.170370% -> 74.614815%
- isValidTarget__8CGMonObjFv: 68.387100% -> 68.732720%
- MonObjRelated: 32.698112% -> 32.792454%
- CGMonObj_UpdateActionStateFromTarget: 49.652680% -> 49.710957%
- CGMonObj_TickActionState: 6.883161% -> 6.908935%

monobj_boss:
- attackedFuncSaw__8CGMonObjFv: 82.315790% -> 98.421050%
- attackCheckFuncLKShooter__8CGMonObjFi: 79.376470% -> 83.447060%
- frameStatFuncLKShooter__8CGMonObjFv: 78.132454% -> 78.860920%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/monobj -o /tmp/monobj_final.json
- build/tools/objdiff-cli diff -p . -u main/monobj_boss -o /tmp/monobj_boss_final.json

## Plausibility
The changed addresses are mon object static work buffers already defined by this unit. Using m_aiWork__8CGMonObj and m_boss__8CGMonObj removes misleading SoundBuffer aliases and gives the compiler the relocations expected by PAL.