### PR TITLE
Improve font constant references

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -118,7 +118,7 @@ found_fallback_glyph:
 	if (glyph != 0) {
 		goto found_fallback;
 	}
-	return kFontZero;
+	return LoadFloat(kFontZero);
 }
 
 /*
@@ -133,7 +133,7 @@ found_fallback_glyph:
 float CFont::GetWidth(char* text)
 {
 	char* textPtr = text;
-	float width = kFontZero;
+	float width = LoadFloat(kFontZero);
 	unsigned short ch;
 	int hasChar;
 
@@ -197,7 +197,7 @@ use_fallback_glyph:
 		if (glyph != 0) {
 			goto use_glyph;
 		}
-		charWidth = kFontZero;
+		charWidth = LoadFloat(kFontZero);
 
 add_width:
 		width += charWidth;
@@ -302,14 +302,14 @@ found_fallback:
 	posX += advance;
 
 	if (glyphInfo[0] == 0) {
-		u0 += kFontOne;
+		u0 += LoadFloat(kFontOne);
 	}
 	if (m_glyphWidth == glyphInfo[0] + glyphInfo[1]) {
-		u1 -= kFontOne;
+		u1 -= LoadFloat(kFontOne);
 	}
 
-	v0 += kFontOne;
-	v1 -= kFontOne;
+	v0 += LoadFloat(kFontOne);
+	v1 -= LoadFloat(kFontOne);
 
 	GXBegin(GX_QUADS, GX_VTXFMT0, 4);
 	GXPosition3f32(x0, y0, posZ);
@@ -795,14 +795,14 @@ CFont::CFont()
 {
 	m_glyphData = 0;
 	texturePtr = 0;
-	margin = kFontZero;
-	posZ = kFontZero;
-	posY = kFontZero;
-	posX = kFontZero;
+	margin = LoadFloat(kFontZero);
+	posZ = LoadFloat(kFontZero);
+	posY = LoadFloat(kFontZero);
+	posX = LoadFloat(kFontZero);
 	CFontRenderFlagBits& bits = GetRenderFlagBits(renderFlags);
 	bits.shadow = 0;
-	scaleY = kFontOne;
-	scaleX = kFontOne;
+	scaleY = LoadFloat(kFontOne);
+	scaleX = LoadFloat(kFontOne);
 	bits.snapPosition = 0;
 	m_color.r = 0xFF;
 	m_color.g = 0xFF;


### PR DESCRIPTION
## Summary
- route direct CFont zero/one float uses through the existing LoadFloat helper
- prevents those call sites from materializing less-plausible anonymous float constants
- improves matching in font width/draw paths and completes CFont construction/init matches

## Objdiff evidence
- main/fontman .text: 97.304565% -> 97.34606%
- GetWidth__5CFontFUs: 96.68421% -> 96.75%
- GetWidth__5CFontFPc: 93.44554% -> 93.544556%
- Draw__5CFontFUs: 92.26838% -> 92.32353%
- Init__8CFontManFv: 99.86487% -> 100.0%
- __ct__5CFontFv: 99.77273% -> 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/fontman -o -