### PR TITLE
Match ChangeTex filename rodata padding

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -86,7 +86,7 @@ STATIC_ASSERT(offsetof(ChangeTexModelData, m_frameShift) == 0x34);
 extern const float kPppChangeTexCachedValueInit = -10000.0f;
 extern const char sPppChangeTexMeshObjectName[] = "obj";
 extern const float kPppChangeTexAlphaScale = 255.0f;
-extern "C" const char s_pppChangeTex_cpp[] ATTRIBUTE_ALIGN(8) = "pppChangeTex.cpp";
+extern "C" const char s_pppChangeTex_cpp[24] = "pppChangeTex.cpp";
 
 static inline unsigned char* MaterialManRaw() { return reinterpret_cast<unsigned char*>(&MaterialMan); }
 

--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -66,7 +66,7 @@ struct ChangeTexModelRaw {
 	ChangeTexMeshRef* m_meshes;
 };
 
-extern const char s_pppYmChangeTex_cpp[] = "pppYmChangeTex.cpp";
+extern const char s_pppYmChangeTex_cpp[24] = "pppYmChangeTex.cpp";
 extern const float FLOAT_80330df8;
 extern const float FLOAT_80330dfc;
 extern const float FLOAT_80330e00;


### PR DESCRIPTION
## Summary
- Size `s_pppChangeTex_cpp` and `s_pppYmChangeTex_cpp` so their emitted records include the target rodata padding bytes.
- Match the rebuilt `.rodata` bytes to the target objects for both ChangeTex units without adding manual gap symbols.

## Evidence
- `ninja`
- `build/GCCP01/src/pppChangeTex.o` `.rodata` now matches `build/GCCP01/obj/pppChangeTex.o`: `7070704368616e67655465782e6370700000000000000000`
- `build/GCCP01/src/pppYmChangeTex.o` `.rodata` now matches `build/GCCP01/obj/pppYmChangeTex.o`: `707070596d4368616e67655465782e637070000000000000`
- `build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o /tmp/pppChangeTex_final.json --format json`
- `build/tools/objdiff-cli diff -p . -u main/pppYmChangeTex -o /tmp/pppYmChangeTex_final.json --format json`

## Plausibility
This follows the existing fixed-size source filename array pattern used by nearby particle code such as `s_pppCharaBreak_cpp[24]`, and keeps the padding in normal C++ data layout rather than introducing explicit fake gap symbols.
