### PR TITLE
Match laser point count conversions

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -373,7 +373,7 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     int colorOffset = serializedDataOffsets[1];
     LaserColorData* colorData = (LaserColorData*)((u8*)pppLaser + 0x80 + colorOffset);
     s32 dataValIndex = step->m_dataValIndex;
-    u32 count;
+    s32 count;
     s32 i;
     s32 alphaStep;
     char alphaMax;

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -86,7 +86,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	u32 count;
+	s32 count;
 	s32 i;
 	s32 alphaStep;
 	char alphaMax;


### PR DESCRIPTION
## Summary
- Treat the laser trail point-count local as signed in both pppLaser and pppYmLaser render paths.
- This removes the extra unsigned float-conversion shape and matches the target render function size for both units.

## Evidence
- ninja: builds successfully.
- Overall data matched bytes: 1165718 -> 1165814 (+96).
- main/pppYmLaser pppRenderYmLaser: current size 3004 -> 3008, matching target size 3008; extabindex 97.91667% -> 100%; [.sdata2-0] size 64 -> 56 and match 80.0% -> 85.71429%.
- main/pppLaser pppRenderLaser: current size 3004 -> 3008, matching target size 3008; extabindex 97.91667% -> 100%.

## Plausibility
- The source field is a byte-sized point count but the local is used for signed float conversion in the target codegen. Using s32 avoids generating the unsigned conversion constant/path and keeps the sibling laser renderers consistent.