### PR TITLE
Fix sbss2 seed symbol linkage

### DIFF
--- a/src/chara_fur.cpp
+++ b/src/chara_fur.cpp
@@ -33,8 +33,8 @@ extern "C" {
 double atan2(double, double);
 double sqrt(double);
 }
-unsigned long long g_chara_fur_1;
-unsigned long long g_chara_fur_2;
+extern const unsigned long long g_chara_fur_1;
+extern const unsigned long long g_chara_fur_2;
 
 struct Vec4d
 {

--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -51,8 +51,8 @@ union PackedColor {
     u8 bytes[4];
 };
 
-PackedColor g_pppYmTracer2_1;
-PackedColor g_pppYmTracer2_2;
+extern const PackedColor g_pppYmTracer2_1;
+extern const PackedColor g_pppYmTracer2_2;
 
 static inline void copyPolygonData(TRACE_POLYGON* dst, TRACE_POLYGON* src)
 {

--- a/src/shopmenu.cpp
+++ b/src/shopmenu.cpp
@@ -40,7 +40,7 @@ void MakeAgbString__4CMesFPcPcii(char*, char*, int, int);
 char s_shopmenu_cpp[] = "shopmenu.cpp";
 extern char s_shop_80332e54[];
 unsigned short gShopMenuInputLatch;
-CShopMenu* g_shopMenu;
+extern CShopMenu* g_shopMenu;
 extern float FLOAT_80332d28;
 extern float FLOAT_80332d2c;
 extern float FLOAT_80332d34;


### PR DESCRIPTION
## Summary
- Declare configured sbss2 seed symbols externally instead of defining mutable sbss storage in source.
- Applies to pppYmTracer2 color seeds, chara_fur seeds, and the shop menu color seed pointer.

## Evidence
- ninja
- pppYmTracer2: .text 99.3058% -> 99.32337%; pppRenderYmTracer2 98.39431% -> 98.43496%; current .sbss 8 bytes removed.
- chara_fur: current .sbss size 56 -> 40 bytes, removing the wrong-section chara_fur seed definitions.
- shopmenu: .text 52.089134% -> 52.08967%; current .sbss size 13 -> 9 bytes, matching the target sbss size.

## Plausibility
These symbols are configured as .sbss2 data in GCCP01 symbols and are only used as zero seed/template values. Referencing the configured symbols is cleaner than defining duplicate mutable .sbss storage in each source file.