### PR TITLE
Assign p_menu rodata ownership

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -136,7 +136,7 @@ usb.cpp:
 	extabindex  start:0x8000B5D8 end:0x8000B5FC
 	.text       start:0x8002244C end:0x80022724
 	.ctors      start:0x801D53C8 end:0x801D53CC
-	.rodata     start:0x801D6F9C end:0x801D7058
+	.rodata     start:0x801D6F90 end:0x801D7058
 	.data       start:0x801E8898 end:0x801E88B4
 	.bss        start:0x802455C0 end:0x80245640
 	.sdata      start:0x8032E478 end:0x8032E488
@@ -1017,6 +1017,7 @@ p_menu.cpp:
 	extabindex  start:0x8000DF6C end:0x8000E0A4
 	.text       start:0x80093E78 end:0x800977D8
 	.ctors      start:0x801D541C end:0x801D5420
+	.rodata     start:0x801D9D3C end:0x801D9DE0
 	.data       start:0x8020EDF8 end:0x8020F2F8
 	.bss        start:0x802EA1A0 end:0x802EAA60
 	.sdata      start:0x8032E7A0 end:0x8032E7C0

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -51,8 +51,7 @@ extern const f32 FLOAT_8033086C;
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdio.h>
 
 CMenuPcs MenuPcs ATTRIBUTE_ALIGN(32);
-static const char kMenuPcsStageName[] = "CMenuPcs";
-extern "C" const char s_p_menu_cpp[];
+extern const char s_CMenuPcs_801d9d3c[] = "CMenuPcs";
 
 struct Vec4d
 {
@@ -68,7 +67,10 @@ struct MenuFontTlutPalette
     _GXColor highlight;
 };
 static const char s_win_kazari_801D9D48[] = "win_kazari";
+extern const char s_CManager_801D9D54[] = "CManager";
+extern const char s_CProcess_801D9D60[] = "CProcess";
 static const char s_dvd__smenu__s_tex_801d9d6c[] = "dvd/%smenu/%s.tex";
+extern "C" const char s_p_menu_cpp[] = "p_menu.cpp";
 static const char s_dvd__smenu_gc23_fnt_801d9d8c[] = "dvd/%smenu/gc23.fnt";
 static const char s_dvd__smenu__s_fnt_801d9da0[] = "dvd/%smenu/%s.fnt";
 static const char s_dvd__smenu_gc22_fnt_801d9db4[] = "dvd/%smenu/gc22.fnt";
@@ -138,7 +140,7 @@ unsigned int CMenuPcs::m_table_desc4[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsig
 unsigned int CMenuPcs::m_table_desc5[3] = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawSingleMenu__8CMenuPcsFv)};
 
 CProcessTable CMenuPcs::m_table = {
-    const_cast<char*>(kMenuPcsStageName),
+    const_cast<char*>(s_CMenuPcs_801d9d3c),
     {
         m_table_desc0[0], m_table_desc0[1], m_table_desc0[2],
         m_table_desc1[0], m_table_desc1[1], m_table_desc1[2],
@@ -350,7 +352,7 @@ void CMenuPcs::create()
         menuHeapSize -= FontMan.GetInternal22Size();
     }
 
-    m_menuStage = Memory.CreateStage(menuHeapSize, const_cast<char*>(kMenuPcsStageName), 0);
+    m_menuStage = Memory.CreateStage(menuHeapSize, const_cast<char*>(s_CMenuPcs_801d9d3c), 0);
     *reinterpret_cast<int*>(self + 0x740) = -1;
 
     memset(m_textureSets, 0, sizeof(m_textureSets));

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -1,5 +1,7 @@
 #include "ffcc/usb.h"
 
+extern const char s_CManager_801D6F90[] = "CManager";
+
 #include "ffcc/system.h"
 
 CUSB USB;


### PR DESCRIPTION
## Summary
- Add the missing p_menu.cpp .rodata split covering 0x801D9D3C..0x801D9DE0.
- Define the p_menu class-name/path strings in source order so the newly claimed rodata block is real source data.
- Include the adjacent usb.cpp CManager RTTI class-name ownership at 0x801D6F90 and move the usb rodata split start accordingly.

## Evidence
- ninja: build/GCCP01/main.dol OK
- Overall game data improved from 85.20% to 85.30% (982753 / 1152181 bytes).
- p_menu objdiff now includes .rodata: 164 bytes at 96.40719%; .data is now 100.0%.
- p_menu .text improved to 94.284584% from the previous 93.828156% due relocation/source ownership alignment.
- usb remains code matched, with .rodata now claimed from the real CManager RTTI name at 0x801D6F90.

## Plausibility
These are normal compiler-owned class-name and file/path string definitions backed by symbols.txt addresses, not manually forced sections or vtable/RTTI hacks.