### PR TITLE
Improve laser and YmMiasma matching

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -374,7 +374,7 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
     int colorOffset = serializedDataOffsets[1];
     LaserColorData* colorData = (LaserColorData*)((u8*)pppLaser + 0x80 + colorOffset);
     s32 dataValIndex = step->m_dataValIndex;
-    s32 count;
+    u32 count;
     s32 i;
     s32 alphaStep;
     char alphaMax;

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -86,7 +86,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)((u8*)laser + 0x80 + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	s32 count;
+	u32 count;
 	s32 i;
 	s32 alphaStep;
 	char alphaMax;

--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -26,6 +26,11 @@ extern const float FLOAT_80330664 = 16384.0f;
 extern const float FLOAT_80330668 = -1.0f;
 extern "C" const char s_pppYmMiasma_cpp[] = "pppYmMiasma.cpp";
 
+static inline float YmMiasmaConst(const float& value)
+{
+    return *reinterpret_cast<const float*>(&value);
+}
+
 struct PARTICLE_DATA {
     Mtx m_matrix;
     Vec m_velocity;
@@ -354,9 +359,9 @@ void pppDestructYmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
 void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, pppYmMiasmaUnkC* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_2, 2);
-    float fVar1 = FLOAT_80330644;
+    float fVar1 = YmMiasmaConst(FLOAT_80330644);
 
-    work->m_radius = FLOAT_80330644;
+    work->m_radius = YmMiasmaConst(FLOAT_80330644);
     work->m_radiusVelocity = fVar1;
     work->m_radiusAcceleration = fVar1;
 }


### PR DESCRIPTION
## Summary
- Treat laser trail point counts as unsigned in both pppLaser and pppYmLaser renderers.
- Add a narrow YmMiasma const-load helper use so pppConstruct2YmMiasma reaches a full match.

## Objdiff Evidence
- main/pppLaser pppRenderLaser: 97.885635% -> 98.03458% (3008b)
- main/pppYmLaser pppRenderYmLaser: 97.82979% -> 97.97872% (3008b)
- main/pppYmMiasma pppConstruct2YmMiasma: 99.44444% -> 100.0% (36b)

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppLaser -o /tmp/pppLaser_final.json
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o /tmp/pppYmLaser_final.json
- build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o /tmp/pppYmMiasma_final2.json

## Plausibility
- The laser count fields are byte-sized particle counts and Ghidra shows unsigned byte-to-float conversion for the UV step.
- The YmMiasma change follows the existing local particle-code pattern for forcing a named const load, scoped only to the constructor where objdiff confirms it matches.