### PR TITLE
Inline unused mapanim helpers

### DIFF
--- a/src/mapanim.cpp
+++ b/src/mapanim.cpp
@@ -220,7 +220,7 @@ CMapAnim::CMapAnim()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMapAnimNode::interp(Vec* out, CMapAnimKey* track, int frameInLoop, int loopFrameCount)
+inline void CMapAnimNode::interp(Vec* out, CMapAnimKey* track, int frameInLoop, int loopFrameCount)
 {
     CMapAnimNodeTrackKey* keys = track->keys;
     int trackCount = track->count;
@@ -452,7 +452,7 @@ void CMapAnimNode::Interp(int frame)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CMapAnimNode::ReadOtmAnimNode(CChunkFile& chunkFile, CMapAnim* mapAnim)
+inline void CMapAnimNode::ReadOtmAnimNode(CChunkFile& chunkFile, CMapAnim* mapAnim)
 {
     unsigned int chunkData[4];
     unsigned int& chunkId = chunkData[0];
@@ -502,7 +502,7 @@ void CMapAnimNode::ReadOtmAnimNode(CChunkFile& chunkFile, CMapAnim* mapAnim)
  * JP Address: TODO
  * JP Size: TODO
  */
-CMapAnimNode::~CMapAnimNode()
+inline CMapAnimNode::~CMapAnimNode()
 {
     m_mapAnim = 0;
 }
@@ -516,7 +516,7 @@ CMapAnimNode::~CMapAnimNode()
  * JP Address: TODO
  * JP Size: TODO
  */
-CMapAnimNode::CMapAnimNode()
+inline CMapAnimNode::CMapAnimNode()
 {
     m_tracks = 0;
 }
@@ -555,7 +555,7 @@ CMapAnimKeyDt::~CMapAnimKeyDt()
  * JP Address: TODO
  * JP Size: TODO
  */
-CMapAnimKeyDt::CMapAnimKeyDt()
+inline CMapAnimKeyDt::CMapAnimKeyDt()
 {
     m_positionKeys = 0;
     m_rotationKeys = 0;


### PR DESCRIPTION
## Summary
- Mark unused CMapAnimNode/CMapAnimKeyDt helper definitions inline so they are retained in source without being emitted into mapanim.o.
- Removes extra emitted UNUSED functions from the compiled unit, matching the target section sizes and generated exception tables.

## Objdiff evidence
Before:
- main/mapanim extab: 91.17647%
- main/mapanim extabindex: 0.0%
- report data matched: 1167995 / 1489351 bytes

After:
- main/mapanim extab: 100.0%
- main/mapanim extabindex: 100.0%
- main/mapanim .text size: 3376, match 99.8282% unchanged
- main/mapanim .rodata/.data/.sdata/.sdata2: 100.0%
- report data matched: 1168275 / 1489351 bytes

## Plausibility
These functions are already marked PAL Address: UNUSED in source. Inlining them follows the repo runbook guidance for keeping known-unused source while avoiding extab and emitted-code regressions.