### PR TITLE
Improve pppYmBreath birth particle codegen

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -916,7 +916,7 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
     u8 flags;
 
     spread = (float)(unsigned int)reinterpret_cast<YmBreathParams*>(pYmBreath)->m_spread;
-    range = LoadFloat(kYmBreathSpreadScale) * spread;
+    range = spread * LoadFloat(kYmBreathSpreadScale);
 
     memset(particleData, 0, sizeof(PARTICLE_DATA));
     if (particleWmat != NULL) {
@@ -1036,10 +1036,11 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         particle->m_rotationVelocityY += particle->m_rotationAccelY;
     }
 
+    float zero = kCharaAnimZero;
     particle->m_scale = params->m_groupSpeed;
-    if (params->m_scaleRandomRange != kCharaAnimZero) {
+    if (zero != params->m_scaleRandomRange) {
         float rand = Math.RandF();
-        float scaledRange = LoadFloat(kYmBreathSpreadScale) * params->m_scaleRandomRange;
+        float scaledRange = params->m_scaleRandomRange * LoadFloat(kYmBreathSpreadScale);
         particle->m_scale += scaledRange * rand - params->m_scaleRandomRange;
     }
 


### PR DESCRIPTION
Summary
- Reordered the spread-scale expression in BirthParticle to better match target instruction ordering.
- Kept the scale-random zero in a local temporary before comparison, matching the target register flow more closely.

Objdiff evidence
Unit: main/pppYmBreath

Before:
- BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR: 99.6481%

After:
- BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR: 99.69873%
- Other measured pppYmBreath symbols unchanged.
- .sdata2 unchanged at 75.17731%.

Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -

Plausibility
The changes preserve behavior and express the same arithmetic in plausible original-source form. They avoid hardcoded addresses, fake symbols, section forcing, or generated-function hacks.