### PR TITLE
Match CFile handle pool allocation

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -11,6 +11,7 @@
 #include "ffcc/util.h"
 
 #include <PowerPC_EABI_Support/Runtime/New.h>
+#include <PowerPC_EABI_Support/Runtime/MWCPlusLib.h>
 #include <dolphin/gx.h>
 #include <dolphin/os/OSCache.h>
 #include <dolphin/vi.h>
@@ -745,8 +746,9 @@ void CFile::Init()
     m_fatalDiskErrorFlag = 0;
     m_isDiskError = 0;
     m_readBuffer = new ((CMemory::CStage*)m_allocStage, const_cast<char*>(s_fileCpp), 0x2b) unsigned char[0x100000];
-    m_handlePoolHead.m_currentOffset =
-        (u32)new ((CMemory::CStage*)m_allocStage, const_cast<char*>(s_fileCpp), 0x2e) CHandle[0x80];
+    void* handlePool = operator new[](sizeof(CHandle) * 0x80 + 0x10, (CMemory::CStage*)m_allocStage,
+                                      const_cast<char*>(s_fileCpp), 0x2e);
+    m_handlePoolHead.m_currentOffset = (u32)__construct_new_array(handlePool, 0, 0, sizeof(CHandle), 0x80);
     m_fileHandle.m_next = &m_fileHandle;
     m_fileHandle.m_previous = &m_fileHandle;
     m_fileHandle.m_priority = PRI_SENTINEL;


### PR DESCRIPTION
## Summary
- Allocate the CFile handle pool with the runtime array construction helper using null ctor/dtor pointers, matching the target Init codegen.
- Keep the normal CHandle type semantics so Quit still performs the array-cookie delete path.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- main/file Init__5CFileFv: 98.382355% -> 100.0% (408b).
- main/file .text: 99.68338% -> 99.8285%.
- main/file extabindex: 99.44444% -> 100.0%.

## Plausibility
- This reflects the target runtime allocation shape: raw staged array allocation followed by __construct_new_array with null ctor/dtor pointers. It avoids manually defining ctor/dtor/vtable artifacts and preserves the compiler-generated delete behavior used by Quit.