### PR TITLE
Fix CUSBPcs table layout

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -21,7 +21,7 @@ public:
         u8 m_reserved34[0xC];
     };
 
-    static CProcessTable m_table;
+    static CSmallProcessTable m_table;
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -28,7 +28,7 @@ inline CUSBPcs::CUSBPcs()
     table[9] = desc2[2];
 }
 
-CProcessTable CUSBPcs::m_table = {
+CSmallProcessTable CUSBPcs::m_table = {
     const_cast<char*>(sUsbPcsClassName),
     {
         0,


### PR DESCRIPTION
## Summary
- change CUSBPcs::m_table to use the existing CSmallProcessTable type
- keep GetTable's explicit 0x15c stride unchanged, so codegen for GetTable remains matched
- moves the compiler-generated RTTI/vtable data after the table to the PAL symbol layout implied by config/GCCP01/symbols.txt

## Evidence
- ninja passes
- p_usb .data improved from 92.38095% to 93.387764%
- m_table__7CUSBPcs improved from 90.01405% to 100.0%
- GetTable__7CUSBPcsFUl remains 100.0%
- global progress report increased matched data by 100 bytes

## Plausibility
CUSBPcs only has one process table instance, and PAL symbols size m_table__7CUSBPcs as 0x11C. Using the smaller table type matches that layout without hand-writing vtables, RTTI, constructors, or section placement.