### PR TITLE
Improve texture allocation matching and pppYmTracer2 data

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -407,4 +407,3 @@ void pppConstructYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkC* param_2
 
 extern const float FLOAT_80331864 = 0.0f;
 extern const char sTHPMagic[4] = "THP";
-extern const float kTHPSimpleDefaultVolume = 127.0f;

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -52,6 +52,12 @@ CTexture::CTexture()
     m_usesExternalAddress = 0;
 }
 
+static inline CTexture* NewTexture(CMemory::CStage* textureStage, char* file, int line)
+{
+    void* memory = Memory._Alloc(sizeof(CTexture), textureStage, file, line, 0);
+    return ::new (memory) CTexture;
+}
+
 /*
  * --INFO--
  * PAL Address: 0x8003A5FC
@@ -122,7 +128,7 @@ void CTextureSet::Create(CChunkFile& chunkFile, CMemory::CStage* stage, int appe
     while (chunkFile.GetNextChunk(chunk)) {
         switch (chunk.m_id) {
         case 0x54585452:
-            texture = new (TextureMan.m_memoryStage, const_cast<char*>(s_textureman_cpp), 0x2ED) CTexture;
+            texture = NewTexture(TextureMan.m_memoryStage, const_cast<char*>(s_textureman_cpp), 0x2ED);
             texture->Create(chunkFile, stage, amemCacheSet, cacheTag, useAddress);
 
             if (texture->m_name[0] != 0) {
@@ -202,7 +208,7 @@ void CTextureSet::Create(void* filePtr, CMemory::CStage* stage, int append, CAme
                         while (chunkFile.GetNextChunk(textureChunk)) {
                             switch (textureChunk.m_id) {
                             case 0x54585452:
-                                CTexture* texture = new (TextureMan.m_memoryStage, const_cast<char*>(s_textureman_cpp), 0x2ED) CTexture;
+                                CTexture* texture = NewTexture(TextureMan.m_memoryStage, const_cast<char*>(s_textureman_cpp), 0x2ED);
                                 texture->Create(chunkFile, stage, amemCacheSet, cacheTag, useAddress);
 
                                 if (texture->m_name[0] != 0) {


### PR DESCRIPTION
## Summary
- remove misplaced `kTHPSimpleDefaultVolume` definition from `pppYmTracer2.cpp`, eliminating the extra `127.0f` from `pppYmTracer2.o` `.sdata2`
- route `CTextureSet::Create` texture allocation through a small inline helper that expands to the PAL allocation shape while keeping `CTexture::operator new` intact

## Evidence
- `main/pppYmTracer2` `.sdata2`: current side went from 40 bytes with an extra `127.0f` insert to 36 bytes matching the PAL data block
- `main/textureman` `.text`: 98.27775% -> 98.71268%
- `Create__11CTextureSetFR10CChunkFilePQ27CMemory6CStageiP13CAmemCacheSetii`: 94.52857% -> 97.28571%
- `Create__11CTextureSetFPvPQ27CMemory6CStageiP13CAmemCacheSetii`: 95.52809% -> 97.69663%
- `__nw__8CTextureFUlPQ27CMemory6CStagePci` remains 100.0%

## Plausibility
- The `pppYmTracer2` change corrects data ownership; the THP default volume does not belong in that object according to objdiff.
- The texture allocation helper expresses the same allocation path as the existing `CTexture::operator new`, but allows the two create functions to compile closer to PAL's inlined allocation/constructor sequence.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o - pppRenderYmTracer2`
- `build/tools/objdiff-cli diff -p . -u main/textureman -o - Create__11CTextureSetFR10CChunkFilePQ27CMemory6CStageiP13CAmemCacheSetii`
- `build/tools/objdiff-cli diff -p . -u main/textureman -o - Create__11CTextureSetFPvPQ27CMemory6CStageiP13CAmemCacheSetii`
