### PR TITLE
Improve pppCrystal frame match

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -294,7 +294,6 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 			xCoord = FLOAT_80330FD4;
 
 			for (x = 0; x < (u32)textureInfo->m_width; x++) {
-				u32 xFine = x & 3;
 				magnitude = xCoord * xCoord + ySq;
 				if (magnitude > FLOAT_80330FD8) {
 					magnitude = CrystalSqrtPositive(magnitude);
@@ -304,6 +303,7 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 					magnitude = NAN;
 				}
 
+				u32 xFine = x & 3;
 				if (magnitude > maxMagnitude) {
 					magnitude = maxMagnitude;
 				}


### PR DESCRIPTION
## Summary
- Move the tiled pixel x-fine calculation in pppFrameCrystal to match the original source shape more closely.
- Keeps the refraction-map generation logic unchanged while improving generated code for main/pppCrystal.

## Evidence
- ninja passes.
- main/pppCrystal .text: 99.56166% -> 99.57652%.
- pppFrameCrystal: 99.01852% -> 99.05556%.
- pppRenderCrystal unchanged at 99.9169%.

## Plausibility
- This is a local source-order adjustment for the x & 3 tile coordinate used to address the generated IA8 refraction texture.
- No manual RTTI/vtable/section forcing, fake symbols, or address hacks were introduced.