### PR TITLE
Improve CGame Init language setup

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -233,27 +233,30 @@ CGame::~CGame()
  */
 void CGame::Init()
 {
-    switch (OSSetProgressiveMode()) {
+    int languageId;
+
+    switch (static_cast<unsigned char>(OSSetProgressiveMode())) {
     case 3:
-        m_gameWork.m_languageId = 5;
+        languageId = 5;
         break;
 
     case 1:
-        m_gameWork.m_languageId = 2;
+        languageId = 2;
         break;
 
     case 2:
-        m_gameWork.m_languageId = 4;
+        languageId = 4;
         break;
 
     case 4:
-        m_gameWork.m_languageId = 3;
+        languageId = 3;
         break;
 
     default:
-        m_gameWork.m_languageId = 1;
+        languageId = 1;
         break;
     }
+    Game.m_gameWork.m_languageId = static_cast<unsigned char>(languageId);
 
     CameraPcs.Init();
     GraphicPcs.Init();


### PR DESCRIPTION
## Summary
- Rework CGame::Init language selection to compute a local language id from the unsigned progressive-mode value.
- Store the selected language through the Game singleton, matching the original access pattern more closely.

## Objdiff evidence
- main/game Init__5CGameFv: 90.56303% -> 98.882355% (size remains 476 bytes)
- LoadScript__5CGameFPc remains 79.04762% (84 bytes)
- SaveScript__5CGameFPc remains 88.52941% (136 bytes)

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/game -o - Init__5CGameFv