### PR TITLE
Match pppYmLaser sdata2 bias constant

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -7,6 +7,7 @@
 #include "ffcc/linkage.h"
 extern "C" {
 extern const f32 kPppYmLaserOne;
+extern const f64 kPppVertexApMtxDoubleBias;
 }
 #include "ffcc/util.h"
 #include "ffcc/pppPart.h"
@@ -34,6 +35,17 @@ extern "C" const char s_pppYmLaser_cpp[] = "pppYmLaser.cpp";
 static inline f32 LoadLaserFloat(const f32& value)
 {
 	return value;
+}
+
+static inline f64 U32ToDouble(u32 value)
+{
+	union {
+		u64 bits;
+		f64 value;
+	} conv;
+
+	conv.bits = 0x4330000000000000ULL | value;
+	return conv.value - kPppVertexApMtxDoubleBias;
 }
 
 struct CMapCylinderRaw {
@@ -192,7 +204,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 		pppDrawShp(*shapeTable, work->m_shapeArg2, ppvEnv->m_materialSetPtr, step->m_laser.m_blendMode);
 
 		count = step->m_laser.m_pointCount;
-		uvStep = FLOAT_80330DC4 / (float)count;
+		uvStep = FLOAT_80330DC4 / (f32)U32ToDouble(count);
 		if (step->m_initWOrk == 0xFFFF) {
 			_GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
 			_GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);


### PR DESCRIPTION
## Summary
- Use the existing shared `kPppVertexApMtxDoubleBias` for the `pppYmLaser` unsigned point-count conversion.
- This removes the duplicate compiler-emitted unsigned double-bias constant from `pppYmLaser` and matches the original `.sdata2` layout.

## Evidence
- `ninja` passes.
- Before: `build/GCCP01/src/pppYmLaser.o` had `.sdata2` size `0x40` while original had `0x38`.
- After: objdiff for `main/pppYmLaser` reports `.sdata2` size `56` and `100.0%` match.
- After: objdiff reports `.rodata`, `.sdata2`, `extab`, and `extabindex` all at `100.0%` for `main/pppYmLaser`.
- Overall build data progress increased from `1168755` to `1168803` matched bytes.

## Notes
- `pppRenderYmLaser` code score moves slightly down while the function size now aligns with the original render size; the improvement is in real data/linkage layout and removes a duplicate bias constant in favor of the shared symbol used by the original object.
