### PR TITLE
Match THPSimple default volume load

### DIFF
--- a/src/THPSimple.cpp
+++ b/src/THPSimple.cpp
@@ -967,8 +967,11 @@ s32 THPSimpleOpen(const char* path)
     SimpleControl.isBufferSet = 0;
     SimpleControl.isLooping = 0;
     SimpleControl.isOpen = 1;
-    SimpleControl.curVolume = kTHPSimpleDefaultVolume;
-    SimpleControl.targetVolume = kTHPSimpleDefaultVolume;
+    {
+        const f32* defaultVolume = &kTHPSimpleDefaultVolume;
+        SimpleControl.curVolume = *defaultVolume;
+        SimpleControl.targetVolume = *defaultVolume;
+    }
     SimpleControl.rampCount = 0;
 
     return 1;


### PR DESCRIPTION
## Summary
- Route THPSimpleOpen's default volume initialization through the exported kTHPSimpleDefaultVolume object.
- Removes the anonymous duplicate 127.0f literal from THPSimple .sdata2 and lets the function load the real symbol.

## Objdiff evidence
- THPSimpleOpen: 99.98583% -> 100.0%
- .sdata2: 16 bytes / 85.71429% -> 12 bytes / 100.0%
- kTHPSimpleDefaultVolume: 100.0%
- Generated load now uses: lfs f0, kTHPSimpleDefaultVolume@sda21

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/THPSimple -o - THPSimpleOpen

## Plausibility
- The change keeps the existing named constant and causes both volume fields to be initialized from the same addressable default-volume object, matching the shipped data layout instead of relying on a folded local literal.