### PR TITLE
Improve pppRenderRain work pointer access

### DIFF
--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -13,6 +13,7 @@ extern const float FLOAT_80331020;
 #include "ffcc/util.h"
 #include "dolphin/gx.h"
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdlib.h>
+#include <stddef.h>
 extern const char s_pppRain_cpp[] = "pppRain.cpp";
 
 struct RainColorData {
@@ -36,7 +37,6 @@ void pppRenderRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_D
     int workOffset;
     RainColorData* colorData;
     RainDrop* drop;
-    RainWork* work;
     float tex1;
     float tex0;
     float baseX;
@@ -45,7 +45,7 @@ void pppRenderRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_D
     Vec segment;
 
     colorOffset = param_3->m_serializedDataOffsets[1];
-    workOffset = param_3->m_serializedDataOffsets[2];
+    workOffset = param_3->m_serializedDataOffsets[2] + offsetof(_pppPObject, m_workArea);
     colorData = (RainColorData*)(pppRain->m_object.m_workArea + colorOffset);
     pppSetBlendMode(param_2->m_blendMode);
     pppSetDrawEnv(
@@ -68,8 +68,7 @@ void pppRenderRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_D
     GXSetLineWidth(param_2->m_lineWidth, GX_TO_ZERO);
     gUtil.SetVtxFmt_POS_CLR_TEX();
 
-    work = (RainWork*)(pppRain->m_object.m_workArea + workOffset);
-    drop = work->drops;
+    drop = *(RainDrop**)((u8*)pppRain + workOffset);
     baseX = ppvMng->m_matrix.value[0][3];
     baseY = ppvMng->m_matrix.value[1][3];
     baseZ = ppvMng->m_matrix.value[2][3];


### PR DESCRIPTION
## Summary
- compute the rain work slot as an object-relative work-area offset in pppRenderRain
- load the drop array directly from that work slot while keeping the color slot expression that already matched

## Evidence
- ninja passes
- pppRenderRain objdiff improved from 97.60584% to 99.62044% (size remains 548 bytes)
- main/pppRain .text improved from 98.64302% to 99.2746% in the pppRenderRain diff
- pppDestructRain and pppConstructRain remain 100% matched; .sdata2 remains 100%

## Plausibility
This uses offsetof(_pppPObject, m_workArea) to represent the serialized work-area slot as an object-relative offset, matching the target address calculation without hard-coded addresses or manual generated-code hacks.