### PR TITLE
Define PPP default data buffers

### DIFF
--- a/src/partMng.cpp
+++ b/src/partMng.cpp
@@ -24,7 +24,6 @@ extern "C" {
 extern float ppvScreenMatrixXbuff;
 extern float ppvScreenMatrixYbuff;
 extern float ppvScreenMatrixZbuff;
-extern int gPppHeapUseRateWords[3];
 }
 #include "ffcc/stopwatch.h"
 
@@ -65,6 +64,8 @@ extern "C" {
 extern int ppvSysStopPartF;
 extern int ppvSysGoPartF;
 extern int ppvUserStopPartF;
+unsigned char gPppDefaultValueBuffer[0x40] = {0};
+int gPppHeapUseRateWords[3] = {0, 0, 0};
 unsigned char gPppInConstructor = 0;
 unsigned char gPppInSubFrameCalc = 0;
 extern int ppvEmptyLoop;


### PR DESCRIPTION
## Summary
- Define the `partMng`-owned `gPppDefaultValueBuffer` and `gPppHeapUseRateWords` data symbols instead of leaving the heap-use words as extern-only.
- Keeps both buffers zero-initialized, matching the target data bytes and giving other PPP units a real definition to link against.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/partMng -o -`
  - `.data`: 0.00% -> 37.2549%
  - `gPppDefaultValueBuffer`: 100.0% (64 bytes)
  - `gPppHeapUseRateWords`: 100.0% (12 bytes)

## Plausibility
- `config/GCCP01/symbols.txt` attributes both symbols to `partMng` data (`0x801EADC8` and `0x801EAE08`).
- The target bytes are zeroes, so ordinary zero-initialized definitions match without forcing sections or addresses.