### PR TITLE
Match menu_favo and camera dir constants

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -12,27 +12,21 @@ typedef signed short s16;
 
 FoodRank s_rank[8];
 
-extern "C" const float FLOAT_80333040;
-extern "C" const float FLOAT_80333044;
-extern "C" const float FLOAT_80333048;
-extern "C" const double DOUBLE_80333050;
-extern "C" const float FLOAT_80333058;
-extern "C" const float FLOAT_8033305C;
-extern "C" const double DOUBLE_80333060;
-extern "C" const char s_FavoRankFormat_80333068[];
-extern "C" const float FLOAT_8033306C;
-extern "C" const float FLOAT_80333070;
+extern "C" const float FLOAT_80333038 = 0.75f;
+extern "C" const float FLOAT_8033303C = 72.0f;
+extern "C" const float FLOAT_80333040 = 0.0f;
+extern "C" const float FLOAT_80333044 = 32.0f;
+extern "C" const float FLOAT_80333048 = 1.0f;
+extern "C" const double DOUBLE_80333050 = 1.0;
+extern "C" const float FLOAT_80333058 = 255.0f;
+extern "C" const float FLOAT_8033305C = 24.0f;
+extern "C" const double DOUBLE_80333060 = 0.5;
+extern "C" const char s_FavoRankFormat_80333068[] = "%d";
+extern "C" const float FLOAT_8033306C = 4.0f;
+extern "C" const float FLOAT_80333070 = 0.9f;
+extern "C" const double DOUBLE_80333078 = 4503601774854144.0;
 extern "C" const float FLOAT_80333080;
 extern "C" const float FLOAT_80333084;
-
-extern "C" const char s_Force_803334F0[] = "Force";
-extern "C" const char s_Musique_803334F8[8] = "Musique";
-extern "C" const char s_Active_80333500[8] = "Activ\351";
-extern "C" const char s_Stereo_80333508[8] = "St\351r\351o";
-extern "C" const char s_Fuerza_80333510[] = "Fuerza";
-extern "C" const char s_Defensa_80333518[8] = "Defensa";
-extern "C" const char s_Musica_80333520[8] = "M\372sica";
-extern "C" const char s_Apagado_80333528[8] = "Apagado";
 
 STATIC_ASSERT(sizeof(FavoEntry) == 0x40);
 STATIC_ASSERT(sizeof(FavoListStorage) == 0x1008);

--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -123,4 +123,3 @@ void pppConstructConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir
 }
 
 extern const float kConstrainCameraDirAspectScale = 1.3333f;
-extern const float kConstrainCameraDirLocalZero = 0.0f;

--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -42,13 +42,13 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
             float cameraPosZ = CameraPcs.m_positionZ;
             float localX;
             float localY;
-            float scale = ((CameraPcs.m_fov - 0.8f) / 0.8f) + 64.0f;
+            float scale = ((CameraPcs.m_fov - 25.0f) / 25.0f) + 1.0f;
 
             PSMTXIdentity(ppvMng->m_matrix.value);
 
-            pppMngSt->m_scale.x = 56.0f * scale;
+            pppMngSt->m_scale.x = 1.3333f * scale;
             pppMngSt->m_scale.y = scale;
-            pppMngSt->m_scale.z = 64.0f;
+            pppMngSt->m_scale.z = 1.0f;
 
             Mtx scaleMtx;
             PSMTXScale(scaleMtx, pppMngSt->m_scale.x, pppMngSt->m_scale.y, pppMngSt->m_scale.z);
@@ -96,3 +96,5 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
         }
     }
 }
+
+extern const float kConstrainCameraDirLocalZero = 0.0f;


### PR DESCRIPTION
## What changed
- Define the PAL-owned menu_favo .sdata2 constants and remove duplicate localized string definitions from that unit.
- Update pppConstrainCameraDir2 camera scaling literals to the PAL constants from Ghidra/MAP ownership.
- Move kConstrainCameraDirLocalZero into pppConstrainCameraDir2, where symbols.txt/splits.txt assign it.

## Evidence
- ninja passes.
- Overall data matched: 1169827 -> 1169915 bytes (+88).
- main/menu_favo: .text 81.37776% -> 81.60513%, .sdata2 33.333336% -> 100%.
- main/pppConstrainCameraDir2: .text remains 100%, .sdata2 42.857143% -> 100%.

## Plausibility
- Constants now match the target object bytes and named PAL symbol ownership.
- The small pppConstrainCameraDir .sdata2 score drop is from removing a zero constant that MAP/symbol ownership places in pppConstrainCameraDir2.