### PR TITLE
Move laser constants to pppLaser

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -28,12 +28,6 @@ extern const float FLOAT_80332fec;
 extern const float FLOAT_80332ff0;
 
 extern "C" {
-extern const float kMenuArtiNegativeOne = -1.0f;
-extern const float kMenuArtiDefaultScale = 1.2f;
-extern const float kMenuArtiBoundsMax = 10000000000.0f;
-extern const float kMenuArtiBoundsMin = -10000000000.0f;
-extern const float kMenuArtiHalfTileOffset = 15.5f;
-extern const float kMenuArtiTau = 6.2831855f;
 extern const char s_MenuOptionMusic[] = "Music";
 extern const char s_MenuOptionOn[] = "On";
 extern const char s_MenuOptionOff[] = "Off";

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -17,12 +17,12 @@
 extern const f32 kPppLaserZero = 0.0f;
 extern const f32 FLOAT_8033342c = 1.0f;
 extern const f32 FLOAT_80333430 = 2.0f;
-extern const f32 kMenuArtiNegativeOne;
-extern const f32 kMenuArtiDefaultScale;
-extern const f32 kMenuArtiBoundsMax;
-extern const f32 kMenuArtiBoundsMin;
-extern const f32 kMenuArtiHalfTileOffset;
-extern const f32 kMenuArtiTau;
+extern const f32 kMenuArtiNegativeOne = -1.0f;
+extern const f32 kMenuArtiDefaultScale = 1.2f;
+extern const f32 kMenuArtiBoundsMax = 10000000000.0f;
+extern const f32 kMenuArtiBoundsMin = -10000000000.0f;
+extern const f32 kMenuArtiHalfTileOffset = 15.5f;
+extern const f32 kMenuArtiTau = 6.2831855f;
 
 #define kPppLaserNegativeOne kMenuArtiNegativeOne
 #define kPppLaserDefaultScale kMenuArtiDefaultScale


### PR DESCRIPTION
## Summary
- Move the six kMenuArti* float definitions out of menu_arti.cpp and into pppLaser.cpp, next to the existing pppLaser .sdata2 constants.
- This matches the configured symbol order around kPppLaserZero/FLOAT_8033342c/FLOAT_80333430 and makes the pppLaser constant block locally owned instead of imported from menu_arti.

## Evidence
- ninja passes.
- Overall matched data increased from 1,169,827 to 1,169,883 bytes (+56).
- main/pppLaser .sdata2 improved from 72.727% to 100%.
- kPppLaserZero, FLOAT_8033342c, FLOAT_80333430, and all six kMenuArti* symbols now report 100% in objdiff.

## Notes
- I tested moving the adjacent menu option strings toward MenuUtil as well, but reverted it because it regressed MenuUtil .data and worsened local data matches. This PR keeps only the confirmed net improvement.