### PR TITLE
Match pppConstrainCameraForLoc sdata2

### DIFF
--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -4,7 +4,7 @@
 #include "ffcc/partMng.h"
 #include "ffcc/pppYmEnv.h"
 extern "C" {
-extern const float kPppConstrainCameraForLocZero;
+extern const float kPppConstrainCameraForLocZero[2] = {0.0f, 0.0f};
 }
 #include "ffcc/util.h"
 #include <dolphin/mtx.h>
@@ -76,7 +76,7 @@ void pppConstructConstrainCameraForLoc(_pppPObjLink*, _pppCtrlTable*)
 void pppConstruct2ConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCameraForLoc,
                                         _pppCtrlTable* data)
 {
-    float fVar1 = kPppConstrainCameraForLocZero;
+    float fVar1 = kPppConstrainCameraForLocZero[0];
     float* value = GetConstrainCameraWork(constrainCameraForLoc, data);
     value[2] = fVar1;
     value[1] = fVar1;
@@ -94,7 +94,7 @@ void pppConstruct2ConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCamer
  */
 void pppConstruct3ConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCameraForLoc, _pppCtrlTable* data)
 {
-    float fVar1 = kPppConstrainCameraForLocZero;
+    float fVar1 = kPppConstrainCameraForLocZero[0];
     float* value = GetConstrainCameraWork(constrainCameraForLoc, data);
     value[2] = fVar1;
     value[1] = fVar1;
@@ -179,8 +179,8 @@ int CC_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void*)
     PSVECAdd(&local_a4, &local_e0, &local_a4);
     PSVECAdd(&local_a4, &local_ec, &local_a4);
 
-    fVar1 = kPppConstrainCameraForLocZero;
-    constrainModel->m_worldBaseMtx[0][3] = kPppConstrainCameraForLocZero;
+    fVar1 = kPppConstrainCameraForLocZero[0];
+    constrainModel->m_worldBaseMtx[0][3] = kPppConstrainCameraForLocZero[0];
     constrainModel->m_worldBaseMtx[1][3] = fVar1;
     constrainModel->m_worldBaseMtx[2][3] = fVar1;
     if ((s32)Game.m_currentSceneId == 7) {


### PR DESCRIPTION
## Summary
- Define kPppConstrainCameraForLocZero as the two-float .sdata2 object shown in the split assembly.
- Keep all call sites reading element 0 so the already-matched code remains unchanged.

## Evidence
- ninja succeeds.
- Before: main/pppConstrainCameraForLoc .text 100.0%, .sdata2 0.0%.
- After: main/pppConstrainCameraForLoc .text 100.0%, .sdata2 100.0%.
- kPppConstrainCameraForLocZero: 8 bytes, 100.0% match.

## Plausibility
- The original split assembly declares kPppConstrainCameraForLocZero as an 8-byte .sdata2 symbol containing two zero floats.
- The source now models that data object directly without changing control flow or hand-writing generated artifacts.