### PR TITLE
Match MenuUtil localized option data

### DIFF
--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -82,14 +82,17 @@ extern const char sMenuUtilSpaceText[] = " ";
 extern const char sMenuUtilValueSuffixFormat[] = " %d";
 extern const char sMenuUtilSignedDeltaFormat[] = " %+d";
 extern const char sMenuUtilAttrBonusFormat[] = " %s";
-extern "C" char s_Force_803334F0[] = "Force";
-extern "C" char s_Musique_803334F8[] = "Musique";
-extern "C" char s_Active_80333500[8] = "Activ\351";
-extern "C" char s_Stereo_80333508[8] = "St\351r\351o";
-extern "C" char s_Fuerza_80333510[] = "Fuerza";
-extern "C" char s_Defensa_80333518[] = "Defensa";
-extern "C" char s_Musica_80333520[8] = "M\372sica";
-extern "C" char s_Apagado_80333528[] = "Apagado";
+extern "C" const char s_Force_803334F0[] = "Force";
+extern "C" const char s_Musique_803334F8[] = "Musique";
+extern "C" const char s_Active_80333500[8] = "Activ\351";
+extern "C" const char s_Stereo_80333508[8] = "St\351r\351o";
+extern "C" const char s_Fuerza_80333510[] = "Fuerza";
+extern "C" const char s_Defensa_80333518[] = "Defensa";
+extern "C" const char s_Musica_80333520[8] = "M\372sica";
+extern "C" const char s_Apagado_80333528[] = "Apagado";
+extern "C" const char s_MenuOptionEstereo_80333530[8] = "Est\351reo";
+extern "C" const char s_MenuOptionMinEs_80333538[8] = "M\355n.";
+extern "C" const char s_MenuOptionMaxEs_80333540[8] = "M\341x.";
 extern char s_Strength_801E30A4[];
 extern char s_Defence_801E30B0[];
 extern char s_Position_Markers_801E30BC[];
@@ -168,17 +171,17 @@ extern char s_MenuOptionMusica_803334D0[];
 extern char s_MenuOptionMonoIt_803334D8[];
 extern char s_MenuOptionContr_803334E0[];
 extern char s_MenuOptionNorm_803334E8[];
-extern char s_Force_803334F0[];
-extern char s_Musique_803334F8[];
-extern char s_Active_80333500[];
-extern char s_Stereo_80333508[];
-extern char s_Fuerza_80333510[];
-extern char s_Defensa_80333518[];
-extern char s_Musica_80333520[];
-extern char s_Apagado_80333528[];
-extern char s_MenuOptionEstereo_80333530[];
-extern char s_MenuOptionMinEs_80333538[];
-extern char s_MenuOptionMaxEs_80333540[];
+extern const char s_Force_803334F0[];
+extern const char s_Musique_803334F8[];
+extern const char s_Active_80333500[];
+extern const char s_Stereo_80333508[];
+extern const char s_Fuerza_80333510[];
+extern const char s_Defensa_80333518[];
+extern const char s_Musica_80333520[];
+extern const char s_Apagado_80333528[];
+extern const char s_MenuOptionEstereo_80333530[];
+extern const char s_MenuOptionMinEs_80333538[];
+extern const char s_MenuOptionMaxEs_80333540[];
 extern "C" char* g_strMenuUtilMes[] = {
 	s_Strength_801E30A4, s_Defence_801E30B0, s_Position_Markers_801E30BC, s_Sound_Mode_801E30D0,
 	s_MenuOptionMusic, s_Sound_Effects_801E30DC, s_GBA_Colour_Balance_801E30EC,
@@ -200,17 +203,17 @@ extern "C" char* g_strMenuUtilMes[] = {
 	s_Regola_il_volume_degli_effetti_sonori_801E33D4, s_Regola_il_colore_sul_Game_Boy_Advance_801E33FC,
 	s_MenuOptionOn, s_MenuOptionOff, s_MenuOptionStereo, s_MenuOptionMonoIt_803334D8, s_MenuOptionMin, s_MenuOptionMax,
 	s_MenuOptionContr_803334E0, s_MenuOptionNorm_803334E8,
-	s_Force_803334F0, s_ResistanceFr_801E3424, s_Sceau_de_position_801E3430, s_Signal_sonore_801E3444,
-	s_Musique_803334F8, s_Effets_sonores_801E3454, s_Affichage_du_GBA_801E3464,
+	const_cast<char*>(s_Force_803334F0), s_ResistanceFr_801E3424, s_Sceau_de_position_801E3430, s_Signal_sonore_801E3444,
+	const_cast<char*>(s_Musique_803334F8), s_Effets_sonores_801E3454, s_Affichage_du_GBA_801E3464,
 	s_Affichage_du_sceau_de_position_aux_pieds_des_personnages_801E3478,
-	s_Choisissez_le_signal_sonore_stereo_ou_mono_801E34B4, s_Reglez_le_volume_de_la_musique_801E34E0, s_Reglez_le_volume_des_effets_sonores_801E3500, s_Reglez_le_contraste_des_couleurs_du_Game_Boy_Advance_801E3524, s_Active_80333500,
-	s_MenuOptionDesactive_801E355C, s_Stereo_80333508, s_MenuOptionMonoIt_803334D8, s_MenuOptionMin, s_MenuOptionMax,
+	s_Choisissez_le_signal_sonore_stereo_ou_mono_801E34B4, s_Reglez_le_volume_de_la_musique_801E34E0, s_Reglez_le_volume_des_effets_sonores_801E3500, s_Reglez_le_contraste_des_couleurs_du_Game_Boy_Advance_801E3524, const_cast<char*>(s_Active_80333500),
+	s_MenuOptionDesactive_801E355C, const_cast<char*>(s_Stereo_80333508), s_MenuOptionMonoIt_803334D8, s_MenuOptionMin, s_MenuOptionMax,
 	s_MenuOptionAmeliore_801E3568, s_Standard_801E31E8,
-	s_Fuerza_80333510, s_Defensa_80333518, s_Aro_de_posicion_801E3574, s_Tipo_de_sonido_801E3584,
-	s_Musica_80333520, s_Efectos_de_sonido_801E3594, s_Color_de_la_GBA_801E35A8,
+	const_cast<char*>(s_Fuerza_80333510), const_cast<char*>(s_Defensa_80333518), s_Aro_de_posicion_801E3574, s_Tipo_de_sonido_801E3584,
+	const_cast<char*>(s_Musica_80333520), s_Efectos_de_sonido_801E3594, s_Color_de_la_GBA_801E35A8,
 	s_Senala_la_posicion_bajo_los_pies_de_cada_personaje_801E35B8, s_Selecciona_sonido_estereo_o_monoaural_801E35EC, s_Ajusta_el_volumen_de_la_musica_de_fondo_801E3614, s_Ajusta_el_volumen_de_los_efectos_de_sonido_801E3640,
 	s_Ajusta_el_balance_del_color_de_la_Game_Boy_Advance_801E366C, s_Encendido_801E36A0,
-	s_Apagado_80333528, s_MenuOptionEstereo_80333530, s_Monoaural_801E36AC, s_MenuOptionMinEs_80333538, s_MenuOptionMaxEs_80333540,
+	const_cast<char*>(s_Apagado_80333528), const_cast<char*>(s_MenuOptionEstereo_80333530), s_Monoaural_801E36AC, const_cast<char*>(s_MenuOptionMinEs_80333538), const_cast<char*>(s_MenuOptionMaxEs_80333540),
 	s_Mejorado_801E36B8, s_MenuOptionEstandar_801E36C4,
 };
 


### PR DESCRIPTION
## What changed
- Moves the French and Spanish option literals in `MenuUtil.cpp` to const `.sdata2` data, matching `config/GCCP01/symbols.txt` placement.
- Adds the missing Spanish option literals `Estéreo`, `Mín.`, and `Máx.` at their named symbols.
- Keeps the existing `g_strMenuUtilMes` `char*` table shape with local casts for the now-const literals.

## Objdiff evidence
Command: `build/tools/objdiff-cli diff -p . -u main/MenuUtil -o -`

Before:
- `.data`: 96.0%
- `.sdata2`: 31.52174%
- `g_strMenuUtilMes`: 96.0%

After:
- `.data`: 100.0%
- `.sdata2`: 47.023808%
- `g_strMenuUtilMes`: 100.0%
- `s_Force_803334F0` through `s_Apagado_80333528`: 100.0%
- `s_MenuOptionEstereo_80333530`, `s_MenuOptionMinEs_80333538`, `s_MenuOptionMaxEs_80333540`: 100.0%

## Verification
- `ninja`

## Plausibility
The changed objects are read-only localized UI strings whose addresses and sizes are named in `symbols.txt` as `.sdata2` string data. The Spanish abbreviations were confirmed from objdiff byte differences (`Mín.` and `Máx.`), and the menu message pointer table now matches completely.