### PR TITLE
Fix small data ownership for PPP and chara viewer

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -20,6 +20,8 @@ extern "C" {
 extern u8* gCharaPartWorkPtr;
 extern const double kCharaViewerColorCenterBias;
 extern const float kCharaViewerZero;
+extern const float kCharaViewerBackOrthoRight;
+extern const float kCharaViewerBackOrthoBottom;
 extern const float kCharaViewerGridMax;
 extern const float kCharaViewerUnitStep;
 extern const float kCharaViewerGridSpacing;
@@ -36,11 +38,6 @@ extern const float kCharaViewerLightTargetY;
 extern const float kCharaViewerLightTargetZ;
 }
 
-extern "C" const double kCharaViewerColorCenterBias = 4503601774854144.0;
-extern "C" const float kCharaViewerZero = 0.0f;
-extern "C" const float kCharaViewerBackOrthoRight = 448.0f;
-extern "C" const float kCharaViewerBackOrthoBottom = 640.0f;
-extern "C" const float kCharaViewerGridMax = -100.0f;
 extern "C" const float kCharaViewerUnitStep = 1.0f;
 extern "C" const float kCharaViewerGridSpacing = 10.0f;
 extern "C" const float kCharaViewerGridMin = 100.0f;

--- a/src/pppParMoveMatrix.cpp
+++ b/src/pppParMoveMatrix.cpp
@@ -67,6 +67,3 @@ void pppParMoveMatrix(_pppPObject* obj, void* stepData, _pppCtrlTable* ctrlTable
 		pppSetFpMatrix(pppMngSt);
 	}
 }
-
-extern const float gPppParMoveMatrixZero = 0.0f;
-extern const float gPppParMoveMatrixOne = 1.0f;

--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -125,9 +125,9 @@ extern "C" void pppConstructYmMoveParabola(struct pppYmMoveParabola* basePtr, st
     }
 }
 
-extern const float FLOAT_80330e38 = 0.0f;
-extern const float FLOAT_80330e3c = 1.0f;
-extern const float FLOAT_80330e40 = 0.0f;
-extern const float FLOAT_80330e44 = 1.0f;
+extern const float gPppParMoveMatrixZero = 0.0f;
+extern const float gPppParMoveMatrixOne = 1.0f;
+extern const float kPppYmTraceMoveZero = 0.0f;
+extern const float kPppYmTraceMoveOne = 1.0f;
 extern const float FLOAT_80330e48 = -1.5707964f;
 extern const float FLOAT_80330e4c = 0.0f;

--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -138,8 +138,3 @@ void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, pppYmTraceMoveCtrl*
 	work->m_velocity = zero;
 	work->m_distance = zero;
 }
-
-extern "C" {
-extern const float kPppYmTraceMoveZero = 0.0f;
-extern const float kPppYmTraceMoveOne = 1.0f;
-}


### PR DESCRIPTION
## Summary
- Move PPP small-data definitions back to the unit that owns the reference .sdata2 block.
- Remove duplicate .sdata emission from pppYmTraceMove and pppParMoveMatrix while keeping their matched code unchanged.
- Treat leading p_chara_viewer constants as external ownership so its .sdata2 section starts at kCharaViewerUnitStep like the reference object.

## Objdiff evidence
- pppYmTraceMove: removed extra base .sdata 8 bytes; pppFrameYmTraceMove and pppConstructYmTraceMove stay 100%.
- pppParMoveMatrix: removed extra base .sdata 8 bytes; pppParMoveMatrix stays 100%.
- pppYmMoveParabola: gPppParMoveMatrixZero/One and kPppYmTraceMoveZero/One now pair as 100% matching .sdata2 symbols at the reference offsets; function scores unchanged.
- p_chara_viewer: base .sdata2 shrinks 168 -> 144 bytes and section match improves 86.49% -> 94.12%; drawViewer/calcViewer/createViewer scores unchanged.

## Verification
- ninja