### PR TITLE
Improve pppYmChangeTex draw callback match

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -455,9 +455,10 @@ void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void* pa
 {
 	pppYmChangeTexState* state = (pppYmChangeTexState*)param_2;
 	pppYmChangeTexStep* step = (pppYmChangeTexStep*)param_3;
-	int textureInfo = (int)state->m_texture;
 	ChangeTexMeshRef* meshes = ChangeTexMeshes(model);
-	ChangeTexMeshData* meshData = meshes[meshIdx].m_data;
+	meshes += meshIdx;
+	int textureInfo = (int)state->m_texture;
+	ChangeTexMeshData* meshData = meshes->m_data;
 	ChangeTexDisplayList* displayList = meshData->m_displayLists + displayListIdx;
 
 	if (step->m_payload[0] == 0) {


### PR DESCRIPTION
## What changed
- Adjusted `ChangeTex_DrawMeshDLCallback` to advance the mesh pointer before loading mesh data.
- This matches the target access pattern more closely while keeping the callback logic unchanged.

## Evidence
- `ninja` passes.
- `main/pppYmChangeTex` objdiff `.text`: 96.670265% -> 96.98613%.
- `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: 91.94203% -> 94.91304%.
- `.rodata`, `.sdata2`, `extab`, and `extabindex` remain 100%.
- Full progress report after build: All 33.55% matched, Game Code 18.33% matched.

## Plausibility
- The change replaces indexed mesh access with an explicit pointer advance, which is a normal source shape for iterating or selecting an already-indexed mesh record.
- No manual data, section, vtable, RTTI, or address hacks.