### PR TITLE
Improve pppMiasma render matching

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -622,7 +622,6 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
                 _GXSetTevColorOp(0, 0, 0, 0, 1, 0);
                 _GXSetTevAlphaIn(0, 7, 6, 4, 6);
                 _GXSetTevAlphaOp(0, 1, 0, 0, 1, 0);
-                texGenCount = 1;
 
                 GXSetTevDirect((GXTevStageID)1);
                 _GXSetTevOrder(1, 0, 0, 4);
@@ -631,6 +630,7 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
                 _GXSetTevColorOp(1, 0, 0, 0, 1, 0);
                 _GXSetTevAlphaIn(1, 7, 0, 4, 7);
                 _GXSetTevAlphaOp(1, 0, 0, 0, 1, 0);
+                texGenCount = 1;
 
                 GXSetTevDirect((GXTevStageID)2);
                 _GXSetTevSwapMode(2, 0, 0);


### PR DESCRIPTION
## Summary
- Move `texGenCount = 1` in the no-secondary-texture branch of `pppRenderMiasma` so it is assigned after stage 1 TEV setup, matching the target instruction order more closely.
- This is a source-plausible ordering change only; no fake labels, section forcing, or address hacks.

## Objdiff Evidence
`build/tools/objdiff-cli diff -p . -u main/pppMiasma -o - pppRenderMiasma`

Before:
- unit `.text`: 98.632774%
- `pppRenderMiasma`: 98.49322%

After:
- unit `.text`: 98.77979%
- `pppRenderMiasma`: 98.65524%

## Verification
- `ninja`

## Notes
Also investigated `menu_lst` and `pppChangeTex` follow-up candidates, but reverted those experiments because objdiff worsened.