### PR TITLE
Make CManager pure virtual

### DIFF
--- a/include/ffcc/manager.h
+++ b/include/ffcc/manager.h
@@ -3,8 +3,8 @@
 
 class CManager {
 public:
-    virtual void Init();
-    virtual void Quit();
+    virtual void Init() = 0;
+    virtual void Quit() = 0;
 };
 
 #endif // _FFCC_MANAGER_H


### PR DESCRIPTION
Summary:
- Mark CManager::Init and CManager::Quit as pure virtual to match the abstract base interface.
- This lets compiler-generated CFile static construction emit the CManager vtable data in main/file instead of leaving the base vtable undefined.

Objdiff evidence for main/file:
- .data: 95.833336% -> 100.0%
- .text: unchanged at 99.8285%
- .rodata: unchanged at 100.0%
- .sdata: unchanged at 58.333336%
- .sdata2: unchanged at 94.91525%
- extab/extabindex: unchanged at 100.0%

Plausibility:
CManager is used as a base interface and concrete managers override Init/Quit. Target file.o owns __vt__8CManager with RTTI-only relocation and no relocations to concrete CManager::Init or CManager::Quit, which matches pure virtual base slots rather than missing out-of-line methods.

Verification:
- ninja
- build/tools/objdiff-cli diff -p . -u main/file -o -