### PR TITLE
Improve screen break light callback

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -647,9 +647,9 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
     const float& attnA = FLOAT_80331cec;
     const float& attnB = FLOAT_80331cf0;
 
-    lightDir.x = camera->m_positionX - (FLOAT_80331ce8 + camera->m_targetX);
-    lightDir.y = camera->m_positionY - (FLOAT_80331ce8 + camera->m_targetY);
-    lightDir.z = camera->m_positionZ - (FLOAT_80331ce8 + camera->m_targetZ);
+    lightDir.x = camera->m_directionX - (FLOAT_80331ce8 + camera->m_positionX);
+    lightDir.y = camera->m_directionY - (FLOAT_80331ce8 + camera->m_positionY);
+    lightDir.z = camera->m_directionZ - (FLOAT_80331ce8 + camera->m_positionZ);
     PSVECNormalize(&lightDir, &lightDir);
 
     GXInitSpecularDirHA(&lightObj, lightDir.x, lightDir.y, lightDir.z, zero, one, zero);


### PR DESCRIPTION
## Summary
- Update SB_BeforeDrawCallback to build the specular light direction from the camera direction and position fields used by the target binary.
- This matches the camera offsets shown by the adjacent screen-break matrix callback and removes the field-offset mismatch in the light vector setup.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o -:
  - SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi: 99.445946 -> 99.932434, size unchanged at 296 bytes.
  - build/GCCP01/report.json now reports SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi as 100.0 fuzzy match.

## Plausibility
- The target loads camera offsets 0xec/0xf0/0xf4 against 0xe0/0xe4/0xe8, which correspond to m_direction and m_position in the current CCameraPcs layout.
- SB_BeforeCalcMatrixCallback in the same unit already uses those same fields as camera forward and position.