### PR TITLE
Fix pppScreenBreak light vector

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -647,9 +647,9 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
     const float& attnA = FLOAT_80331cec;
     const float& attnB = FLOAT_80331cf0;
 
-    lightDir.x = camera->m_positionX - (FLOAT_80331ce8 + camera->m_targetX);
-    lightDir.y = camera->m_positionY - (FLOAT_80331ce8 + camera->m_targetY);
-    lightDir.z = camera->m_positionZ - (FLOAT_80331ce8 + camera->m_targetZ);
+    lightDir.x = camera->m_directionX - (FLOAT_80331ce8 + camera->m_positionX);
+    lightDir.y = camera->m_directionY - (FLOAT_80331ce8 + camera->m_positionY);
+    lightDir.z = camera->m_directionZ - (FLOAT_80331ce8 + camera->m_positionZ);
     PSVECNormalize(&lightDir, &lightDir);
 
     GXInitSpecularDirHA(&lightObj, lightDir.x, lightDir.y, lightDir.z, zero, one, zero);


### PR DESCRIPTION
## Summary
- Correct `SB_BeforeDrawCallback` to build its light direction from `CameraPcs` direction minus the offset camera position.
- This matches the verified `CCameraPcs` layout: `SetPosition` writes position at 0xe0 and direction lives at 0xec, while the old source used target/position fields.

## Objdiff Evidence
- `main/pppScreenBreak` `.text`: 97.63693% -> 97.66904%
- `SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi`: 99.44595% -> 99.93243%
- Matched code: 624772 -> 625068 bytes
- Matched functions: 3516 -> 3517

Remaining mismatch in the callback is only the `FLOAT_80331ce8` constant label versus an anonymous local constant.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppScreenBreak -o /tmp/screenbreak_final.json SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi`
