### PR TITLE
Improve CSound::Draw match

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -801,6 +801,7 @@ next:
  */
 void CSound::Draw()
 {
+    CSoundLayout& sound = SoundData(this);
     Mtx cameraMatrix;
     GXColor lineColor;
     PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMatrix);
@@ -820,7 +821,6 @@ void CSound::Draw()
     GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
     GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
 
-    CSoundLayout& sound = SoundData(this);
     CSe3D* se = sound.m_seWork;
     for (u32 i = 0; i < 0x80; i++, se++) {
         if (se->m_bits.m_active) {


### PR DESCRIPTION
## Summary
- Move the CSound layout alias earlier in CSound::Draw so the compiler keeps the object pointer live in the target register shape.
- This removes the extra source-side move before drawing 3D sound debug lines and brings the function size in line with the target.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff main/sound Draw__6CSoundFv:
  - before: source size 536 vs target size 532, match 92.54135%
  - after: source size 532 vs target size 532, match 92.91729%

## Plausibility
- The change only adjusts local variable lifetime in existing CSound::Draw source.
- No hard-coded addresses, section forcing, vtable/RTTI hacks, or fake symbols were introduced.