### PR TITLE
Improve maptexanim create match

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -319,6 +319,3 @@ CMapTexAnim::~CMapTexAnim()
         m_keyFrame.Destroy();
     }
 }
-
-extern "C" const float FLOAT_8032fd48 = 1.0f;
-extern "C" const float FLOAT_8032fd4c = 0.0f;


### PR DESCRIPTION
## Summary
- Remove the local FLOAT_8032fd48/FLOAT_8032fd4c definitions from maptexanim.cpp so Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet uses the expected external constant relocations.
- This makes CMapTexAnimSet::Create fully match without changing data section match percentages.

## Objdiff Evidence
Before:
- main/maptexanim .text: 99.97139%
- Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet: 99.942856%
- .rodata/.data/.sdata unchanged at 100%; .sdata2 unchanged at 59.016396%

After:
- main/maptexanim .text: 99.985695%
- Create__14CMapTexAnimSetFR10CChunkFileP12CMaterialSetP11CTextureSet: 100.0%
- .rodata/.data/.sdata unchanged at 100%; .sdata2 unchanged at 59.016396%

## Plausibility
The removed definitions were producing the wrong relocation shape for Create. The constants remain declared externally and the matched function now uses the expected external references instead of local definitions in this translation unit.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/maptexanim -o -