### PR TITLE
Match menu tmp artifact constants

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -8,18 +8,16 @@
 #include "ffcc/linkage.h"
 #include <string.h>
 
-extern const double DOUBLE_80332f20;
-extern const float FLOAT_80332F28;
-extern const float FLOAT_80332f2c;
-extern const float FLOAT_80332f30;
-extern const float FLOAT_80332F34;
-extern const float FLOAT_80332F38;
-extern const double DOUBLE_80332f40;
-extern const double DOUBLE_80332f48;
-extern const double DOUBLE_80332f50;
-extern const double DOUBLE_80332f58;
-extern const double DOUBLE_80333418 = 0.0;
-extern const double DOUBLE_80333420 = 216.0;
+static const double DOUBLE_80332f20 = 0.5;
+static const float FLOAT_80332F28 = 255.0f;
+static const float FLOAT_80332f2c = 0.0f;
+static const float FLOAT_80332f30 = 1.0f;
+static const float FLOAT_80332F34 = 0.9f;
+static const float FLOAT_80332F38 = 4.0f;
+static const double DOUBLE_80332f40 = 4503601774854144.0;
+static const double DOUBLE_80332f48 = 1.0;
+static const double DOUBLE_80332f50 = 0.0;
+static const double DOUBLE_80332f58 = 216.0;
 
 static inline float TmpArtiIntToFloat(int value)
 {


### PR DESCRIPTION
## Summary
- Replace the out-of-range temporary artifact constant definitions with the actual constants owned by `menu_tmparti.cpp`.
- Defines the local `.sdata2` values from the PAL DOL range `0x80332F20..0x80332F60`.

## Evidence
- `ninja` succeeds.
- `main/menu_tmparti` `.sdata2`: 52.27% -> 100.0%.
- `main/menu_tmparti` current objdiff: `.text` 87.746%, `.sdata2` 100.0%, `[.sdata2-0]` 100.0%.
- Project data increased by 64 matched bytes in the final build report.

## Plausibility
- The constants are file-local numeric literals used by the temporary artifact menu code, matching this unit claimed `.sdata2` split instead of defining `80333418/80333420`, which belong outside `menu_tmparti.cpp`.