### PR TITLE
Match pppConformBGNormal

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -28,6 +28,20 @@ struct ConformBgNormalState {
     u8 m_initialized;
 };
 
+struct ConformMapCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    f32 m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
+STATIC_ASSERT(sizeof(ConformMapCylinder) == sizeof(CMapCylinder));
+STATIC_ASSERT(offsetof(ConformMapCylinder, m_axis) == 0x18);
+STATIC_ASSERT(offsetof(ConformMapCylinder, m_boundsMin) == 0x28);
+STATIC_ASSERT(offsetof(ConformMapCylinder, m_boundsMax) == 0x34);
+
 struct WeaponNodeFlagBits {
     signed char m_prg : 1;
     signed char m_unk40 : 1;
@@ -74,8 +88,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
     f64 trigValue;
     Mtx basisMtx;
     Mtx scaleMtx;
-    CMapCylinder firstCylinder;
-    CMapCylinder secondCylinder;
+    ConformMapCylinder firstCylinder;
+    ConformMapCylinder secondCylinder;
     Vec local_140;
     Vec local_14c;
     Vec local_158;
@@ -135,7 +149,7 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                 firstCylinder.m_axis.z = kPppConformBgNormalZero;
                 firstCylinder.m_radius = kPppConformBgNormalZero;
 
-                checkResult = MapMng.CheckHitCylinderNear(&firstCylinder, &firstRayDirection, 0xffffffff);
+                checkResult = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&firstCylinder), &firstRayDirection, 0xffffffff);
                 hitFound = checkResult;
                 if (checkResult != 0) {
                     MapMng.m_hitMapObj->CalcHitPosition(&local_170);
@@ -244,7 +258,7 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     secondCylinder.m_axis.z = kPppConformBgNormalZero;
                     secondCylinder.m_radius = kPppConformBgNormalZero;
 
-                    hitFound = MapMng.CheckHitCylinderNear(&secondCylinder, &secondRayDirection, 0xffffffff);
+                    hitFound = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&secondCylinder), &secondRayDirection, 0xffffffff);
                     if (hitFound != 0) {
                         MapMng.m_hitMapObj->CalcHitPosition(&local_170);
                         ppvMng->m_matrix.value[0][3] = local_170.x;


### PR DESCRIPTION
## Summary
- Avoid implicit CMapCylinder construction in pppFrameConformBGNormal by using a raw local cylinder layout that is fully populated before each map query.
- Add layout assertions so the raw cylinder remains ABI-compatible with CMapCylinder at the CheckHitCylinderNear call sites.

## Evidence
- ninja passes.
- Before: pppFrameConformBGNormal 96.391754% match, target 1552b, current 1608b.
- After: pppFrameConformBGNormal 100.0% match, target 1552b, current 1552b.
- pppConstructConformBGNormal remains 100.0% match, target 44b, current 44b.
- build report: main/pppConformBGNormal is now 100.0% code and 100.0% data matched.

## Plausibility
The function manually fills every cylinder field before calling CheckHitCylinderNear. The raw local layout removes unintended constructor-generated bounds initialization while preserving the CMapCylinder ABI at the API boundary.