### PR TITLE
Improve pppMiasma and pppYmMana matching

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -263,7 +263,6 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
     Mtx secondLocalMtx;
     Mtx secondScaleMtx;
     GXColor stepColor;
-    GXColor* modelColor;
 
     Graphic.SetDrawDoneDebugData(0x31);
 
@@ -358,13 +357,12 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
         GXSetVtxDesc((GXAttr)0xB, GX_INDEX16);
         GXSetVtxDesc((GXAttr)0xD, GX_INDEX16);
 
-        modelColor = static_cast<GXColor*>(model->m_colors);
-        modelColor->r = 0xFF;
-        modelColor->g = 0xFF;
-        modelColor->b = 0xFF;
-        modelColor->a = 0xFF;
-        GXSetChanAmbColor(GX_COLOR0A0, *modelColor);
-        GXSetChanMatColor(GX_COLOR0A0, *modelColor);
+        static_cast<GXColor*>(model->m_colors)->r = 0xFF;
+        static_cast<GXColor*>(model->m_colors)->g = 0xFF;
+        static_cast<GXColor*>(model->m_colors)->b = 0xFF;
+        static_cast<GXColor*>(model->m_colors)->a = 0xFF;
+        GXSetChanAmbColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
+        GXSetChanMatColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
         GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
 
         GXLoadPosMtxImm(pppMiasma->m_object.m_drawMatrix.value, 0);
@@ -432,13 +430,12 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
             GXSetVtxDesc((GXAttr)0xB, GX_INDEX16);
             GXSetVtxDesc((GXAttr)0xD, GX_INDEX16);
 
-            modelColor = static_cast<GXColor*>(model->m_colors);
-            modelColor->r = 0xFF;
-            modelColor->g = 0xFF;
-            modelColor->b = 0xFF;
-            modelColor->a = 0xFF;
-            GXSetChanAmbColor(GX_COLOR0A0, *modelColor);
-            GXSetChanMatColor(GX_COLOR0A0, *modelColor);
+            static_cast<GXColor*>(model->m_colors)->r = 0xFF;
+            static_cast<GXColor*>(model->m_colors)->g = 0xFF;
+            static_cast<GXColor*>(model->m_colors)->b = 0xFF;
+            static_cast<GXColor*>(model->m_colors)->a = 0xFF;
+            GXSetChanAmbColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
+            GXSetChanMatColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
             GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
             GXLoadPosMtxImm(pppMiasma->m_object.m_drawMatrix.value, 0);
             GXSetNumTevStages(1);

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -521,10 +521,10 @@ void pppConstructYmMana(PYmMana* ymMana, pppYmManaUnkC* param_2)
     work->m_displayListCopies = 0;
     work->m_reflectionVec = 0;
     work->m_colors = 0;
-    work->m_envTexture0 = 0;
     work->m_captureTexObjs = 0;
-    work->m_envTexture1 = 0;
     work->m_step = 0;
+    work->m_envTexture0 = 0;
+    work->m_envTexture1 = 0;
     work->m_meshReflectionVec = 0;
     work->m_meshColors = 0;
     work->m_meshTexCoords0 = 0;


### PR DESCRIPTION
## Summary
- Update pppRenderMiasma color writes to reload model->m_colors at each use, matching the target code shape better.
- Reorder four pppConstructYmMana zero-initializers to match the target store order.

## Objdiff evidence
- main/pppMiasma / pppRenderMiasma: 97.91863% -> 98.65524%.
- main/pppMiasma .text: 98.1114% -> 98.77979%; .sdata2 remains 100%.
- main/pppYmMana / pppConstructYmMana: 99.96% -> 100.0%, diff count 0.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppMiasma -o - pppRenderMiasma
- build/tools/objdiff-cli diff -p . -u main/pppYmMana -o - pppConstructYmMana

## Plausibility
- The Miasma change reflects normal source that writes and passes through the model color storage directly rather than caching a temporary pointer.
- The YmMana change only adjusts initializer order for adjacent fields, matching the observed target store sequence without changing layout or behavior.