### PR TITLE
Improve pppLaser and chara viewer matches

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -412,7 +412,7 @@ void CCharaPcs::calcViewer()
                 }
                 self->m_viewerLoadAnim = 0;
             } else {
-                for (i = 0; i < static_cast<unsigned int>(self->m_viewerAnimRequestedCount); i++) {
+                for (int animIndex = 0; animIndex < self->m_viewerAnimRequestedCount; animIndex++) {
                     sprintf(pathBuf, s_anim_path_fmt, self->m_viewerAnimPath, self->m_viewerAnimLoadedCount);
                     System.Printf(const_cast<char*>(s_calc_viewer_fmt), pathBuf);
                     fileHandle = File.Open(pathBuf, 0, CFile::PRI_LOW);

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -71,7 +71,17 @@ struct LaserColorData {
     pppCVECTOR m_color;
 };
 
+struct LaserMapCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    float m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 STATIC_ASSERT(offsetof(struct pppLaser, m_workArea) == 0x80);
+STATIC_ASSERT(sizeof(LaserMapCylinder) == sizeof(CMapCylinder));
 
 /*
  * --INFO--
@@ -194,7 +204,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     Vec localA;
     Mtx tempMtx;
     Mtx charaMtx;
-    CMapCylinder cyl;
+    LaserMapCylinder cyl;
 
     int emptyHistory;
     int fillIndex;
@@ -275,7 +285,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
         cyl.m_axis = localA;
         cyl.m_radius = LaserConst(kPppLaserZero);
 
-        int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
+        int check = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), &localA, 0xffffffff);
         int hit = 0;
         if (check != 0) {
             hit = 1;


### PR DESCRIPTION
## Summary
- Avoid default CMapCylinder construction in pppFrameLaser by using a raw local cylinder layout that is fully initialized before the map hit call.
- Use a signed requested-count loop in CCharaPcs::calcViewer continuous animation loading.

## Objdiff evidence
- main/pppLaser .text: 98.108955% -> 98.75464%
- pppFrameLaser: 97.64305% -> 99.82289%
- main/p_chara_viewer .text: 94.643456% -> 94.73508%
- calcViewer__9CCharaPcsFv: 90.49899% -> 90.67576%

## Plausibility
- The laser cylinder is fully assigned before use, so avoiding the constructor removes dead default-bound stores while keeping normal field access and a guarded layout assertion.
- The viewer animation request count is an int; comparing it as signed matches the surrounding source and removes an unnecessary unsigned cast.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser
- build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o - calcViewer__9CCharaPcsFv