### PR TITLE
Match pppConformBGNormal

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -28,6 +28,15 @@ struct ConformBgNormalState {
     u8 m_initialized;
 };
 
+struct CMapCylinderRaw {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    f32 m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 struct WeaponNodeFlagBits {
     signed char m_prg : 1;
     signed char m_unk40 : 1;
@@ -38,6 +47,8 @@ struct WeaponNodeFlagBits {
     signed char m_unk02 : 1;
     signed char m_unk01 : 1;
 };
+
+STATIC_ASSERT(sizeof(CMapCylinderRaw) == sizeof(CMapCylinder));
 
 static inline Vec* ConformBgNormalHitNormal(CGObject* owner)
 {
@@ -74,8 +85,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
     f64 trigValue;
     Mtx basisMtx;
     Mtx scaleMtx;
-    CMapCylinder firstCylinder;
-    CMapCylinder secondCylinder;
+    CMapCylinderRaw firstCylinder;
+    CMapCylinderRaw secondCylinder;
     Vec local_140;
     Vec local_14c;
     Vec local_158;
@@ -135,7 +146,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                 firstCylinder.m_axis.z = kPppConformBgNormalZero;
                 firstCylinder.m_radius = kPppConformBgNormalZero;
 
-                checkResult = MapMng.CheckHitCylinderNear(&firstCylinder, &firstRayDirection, 0xffffffff);
+                checkResult = MapMng.CheckHitCylinderNear(
+                    reinterpret_cast<CMapCylinder*>(&firstCylinder), &firstRayDirection, 0xffffffff);
                 hitFound = checkResult;
                 if (checkResult != 0) {
                     MapMng.m_hitMapObj->CalcHitPosition(&local_170);
@@ -244,7 +256,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     secondCylinder.m_axis.z = kPppConformBgNormalZero;
                     secondCylinder.m_radius = kPppConformBgNormalZero;
 
-                    hitFound = MapMng.CheckHitCylinderNear(&secondCylinder, &secondRayDirection, 0xffffffff);
+                    hitFound = MapMng.CheckHitCylinderNear(
+                        reinterpret_cast<CMapCylinder*>(&secondCylinder), &secondRayDirection, 0xffffffff);
                     if (hitFound != 0) {
                         MapMng.m_hitMapObj->CalcHitPosition(&local_170);
                         ppvMng->m_matrix.value[0][3] = local_170.x;


### PR DESCRIPTION
## Summary
- Replace constructor-emitting CMapCylinder stack locals in pppConformBGNormal with a raw layout matching CMapCylinder.
- Keep calls going through the real CMapCylinder API via reinterpret_cast after manually populating the same fields.

## Evidence
- Before: main/pppConformBGNormal .text 96.49123%, extabindex 91.66667%, pppFrameConformBGNormal 96.391754%.
- After: main/pppConformBGNormal .text 100.0%, extabindex 100.0%, .sdata2 100.0%.
- After: pppFrameConformBGNormal 100.0%, pppConstructConformBGNormal 100.0%.
- Build: ninja completed successfully.

## Plausibility
- The function already manually fills every CMapCylinder field before use; avoiding the default constructor removes only the extra prologue bounds initialization that was absent in the target.
- This follows existing raw CMapCylinder layout patterns used elsewhere in the project for map-hit calls.