### PR TITLE
Improve menu command item lookup match

### DIFF
--- a/src/menu_cmd.cpp
+++ b/src/menu_cmd.cpp
@@ -1788,13 +1788,13 @@ void CMenuPcs::GetCmdItem()
 	s16* list = reinterpret_cast<s16*>(Joybus.GetLetterBuffer(0));
 	s16* write = list;
 	s32 count = 0;
-	u32 itemIndexPtr = scriptFood + 0xb6;
+	u32 itemIndexPtr = scriptFood;
 
 	for (s32 i = 0; i < 0x40; i++) {
 		s32 itemType = GetItemType(i, 0);
 		if ((itemType != 0) && (itemType != 5) && (itemType != 6) && (itemType != 8) && (itemType != 9)) {
 			if ((itemType != 1) ||
-			    (GetItemIcon(*reinterpret_cast<s16*>(itemIndexPtr)) ==
+			    (GetItemIcon(*reinterpret_cast<s16*>(itemIndexPtr + 0xb6)) ==
 			     (*reinterpret_cast<u16*>(scriptFood + 0x3e0) & 3))) {
 				write++;
 				*write = static_cast<s16>(i);


### PR DESCRIPTION
## Summary
- Keep the `GetCmdItem` item pointer based at `scriptFood` and apply the `0xb6` item offset at the load site.
- This matches Ghidra's source shape more closely and avoids pre-biasing the pointer before the first item loop.

## Evidence
- `ninja` passes.
- `GetCmdItem__8CMenuPcsFv`: 85.1194% -> 86.61194% (size remains 536b).
- `main/menu_cmd` `.text`: 49.775284% -> 49.809803% (size remains 23176b).

## Plausibility
- The pointer now represents the script-food base for the loop, with the field offset applied where the item ID is loaded. This is a cleaner expression of the data layout and matches the decompiled shape without hard-coded address tricks or fake symbols.
