### PR TITLE
Fix CManager virtual declarations

### DIFF
--- a/include/ffcc/manager.h
+++ b/include/ffcc/manager.h
@@ -3,8 +3,8 @@
 
 class CManager {
 public:
-    virtual void Init() = 0;
-    virtual void Quit() = 0;
+    virtual void Init();
+    virtual void Quit();
 };
 
 #endif // _FFCC_MANAGER_H


### PR DESCRIPTION
## Summary
- Change CManager::Init and CManager::Quit from pure virtual declarations to ordinary virtual declarations.
- This stops manager-derived source units from emitting duplicate weak CManager vtables and lets them reference the existing shared PAL vtable owner instead.

## Evidence
- ninja passes.
- Overall matched data improved from 1,169,503 to 1,170,727 bytes (+1,224); code matched bytes unchanged at 622,092.
- Game data improved from 982,437 to 983,661 bytes (+1,224); game code unchanged.
- main/usb .data improved from 77.78% to 100.00% while .text remains 100.00%.

## Plausibility
- PAL symbols contain a single shared __vt__8CManager owner, while repeated weak local base vtables in derived units were extra data.
- This uses normal C++ virtual declaration/linkage behavior instead of manual vtable/RTTI definitions.