### PR TITLE
Match pppConstructYmMana initialization order

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -521,10 +521,10 @@ void pppConstructYmMana(PYmMana* ymMana, pppYmManaUnkC* param_2)
     work->m_displayListCopies = 0;
     work->m_reflectionVec = 0;
     work->m_colors = 0;
-    work->m_envTexture0 = 0;
     work->m_captureTexObjs = 0;
-    work->m_envTexture1 = 0;
     work->m_step = 0;
+    work->m_envTexture0 = 0;
+    work->m_envTexture1 = 0;
     work->m_meshReflectionVec = 0;
     work->m_meshColors = 0;
     work->m_meshTexCoords0 = 0;


### PR DESCRIPTION
## Summary
- Reordered adjacent VYmMana pointer clears in pppConstructYmMana to match the original store order.
- This makes pppConstructYmMana fully match without changing field values or adding compiler hacks.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppYmMana -o - pppConstructYmMana: pppConstructYmMana is 100.0% match, size 400.
- Progress report after build: +400 matched game-code bytes and one additional matched function compared with the pre-change run in this branch.