### PR TITLE
Match pppConstructYmMana initialization order

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -521,10 +521,10 @@ void pppConstructYmMana(PYmMana* ymMana, pppYmManaUnkC* param_2)
     work->m_displayListCopies = 0;
     work->m_reflectionVec = 0;
     work->m_colors = 0;
-    work->m_envTexture0 = 0;
     work->m_captureTexObjs = 0;
-    work->m_envTexture1 = 0;
     work->m_step = 0;
+    work->m_envTexture0 = 0;
+    work->m_envTexture1 = 0;
     work->m_meshReflectionVec = 0;
     work->m_meshColors = 0;
     work->m_meshTexCoords0 = 0;


### PR DESCRIPTION
## Summary
- Reordered four VYmMana pointer initializers in pppConstructYmMana to match the target store order.
- This keeps the constructor source-plausible while matching the emitted code for the function.

## Evidence
- ninja passes.
- objdiff: build/tools/objdiff-cli diff -p . -u main/pppYmMana -o - pppConstructYmMana reports pppConstructYmMana at 100.0% matched (400 bytes).
- Build progress improved to 622492 matched code bytes / 3518 matched functions.

## Plausibility
- The change only reorders zero-initialization of adjacent fields: m_captureTexObjs, m_step, m_envTexture0, and m_envTexture1.
- No fake symbols, manual sections, or address-based hacks were introduced.