### PR TITLE
Improve laser frame cylinder layout

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -71,7 +71,17 @@ struct LaserColorData {
     pppCVECTOR m_color;
 };
 
+struct LaserMapCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    float m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 STATIC_ASSERT(offsetof(struct pppLaser, m_workArea) == 0x80);
+STATIC_ASSERT(sizeof(LaserMapCylinder) == sizeof(CMapCylinder));
 
 /*
  * --INFO--
@@ -194,7 +204,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     Vec localA;
     Mtx tempMtx;
     Mtx charaMtx;
-    CMapCylinder cyl;
+    LaserMapCylinder cyl;
 
     int emptyHistory;
     int fillIndex;
@@ -275,7 +285,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
         cyl.m_axis = localA;
         cyl.m_radius = LaserConst(kPppLaserZero);
 
-        int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
+        int check = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), &localA, 0xffffffff);
         int hit = 0;
         if (check != 0) {
             hit = 1;

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -76,7 +76,17 @@ struct pppYmLaserColorData {
 	pppCVECTOR m_color;
 };
 
+struct pppYmLaserCylinder {
+	Vec m_bottom;
+	Vec m_top;
+	Vec m_axis;
+	float m_radius;
+	Vec m_boundsMin;
+	Vec m_boundsMax;
+};
+
 STATIC_ASSERT(offsetof(struct pppYmLaser, m_workArea) == 0x80);
+STATIC_ASSERT(sizeof(pppYmLaserCylinder) == sizeof(CMapCylinder));
 
 /*
  * --INFO--
@@ -364,7 +374,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 	Vec localA;
 	Mtx tempMtx;
 	Mtx charaMtx;
-	CMapCylinder cyl;
+	pppYmLaserCylinder cyl;
 	int emptyHistory;
 	int fillIndex;
 
@@ -439,7 +449,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 		cyl.m_axis = localA;
 		cyl.m_radius = kPppYmLaserOne;
 
-		int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
+		int check = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), &localA, 0xffffffff);
 		int hit = 0;
 		if (check != 0) {
 			hit = 1;


### PR DESCRIPTION
## Summary
- Replace constructed `CMapCylinder` stack locals with POD cylinder layouts in `pppFrameYmLaser` and `pppFrameLaser`.
- Keep the same field layout and cast at the `CMapMng::CheckHitCylinderNear` boundary to avoid unwanted constructor-generated bounds initialization.

## Objdiff Evidence
- `main/pppYmLaser` / `pppFrameYmLaser`: 1340 bytes, 97.35474% -> 1308 bytes, 99.80122%; remaining diffs: 2 instructions.
- `main/pppLaser` / `pppFrameLaser`: 1500 bytes, 97.64305% -> 1468 bytes, 99.82289%; remaining diffs: 2 instructions.

## Plausibility
- The shipped functions initialize cylinder bounds inside the frame loop; the previous `CMapCylinder` local emitted constructor initialization at function entry that was absent from target code.
- The replacement structs preserve the real `CMapCylinder` member layout and keep normal member access for all populated fields.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o - pppFrameYmLaser`
- `build/tools/objdiff-cli diff -p . -u main/pppLaser -o - pppFrameLaser`
