### PR TITLE
Tighten pppRyjMegaBirth constants

### DIFF
--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -44,6 +44,46 @@ static inline float RyjZero()
 	return *reinterpret_cast<const float*>(&kPppRyjMegaBirthZero);
 }
 
+static inline float RyjAngleWrap()
+{
+	return *reinterpret_cast<const float*>(&FLOAT_80330458);
+}
+
+static inline float RyjAngleMax()
+{
+	return *reinterpret_cast<const float*>(&FLOAT_8033045c);
+}
+
+static inline float RyjAngleMin()
+{
+	return *reinterpret_cast<const float*>(&FLOAT_80330460);
+}
+
+static inline float RyjDoubleScale()
+{
+	return *reinterpret_cast<const float*>(&FLOAT_80330470);
+}
+
+static inline float RyjSpeedFalloff()
+{
+	return *reinterpret_cast<const float*>(&FLOAT_80330474);
+}
+
+static inline float RyjHalf()
+{
+	return *reinterpret_cast<const float*>(&FLOAT_80330478);
+}
+
+static inline double RyjOneDouble()
+{
+	return *reinterpret_cast<const double*>(&DOUBLE_80330480);
+}
+
+static inline double RyjHalfDouble()
+{
+	return *reinterpret_cast<const double*>(&DOUBLE_80330488);
+}
+
 static inline float* f32_at(void* base, s32 off)
 {
 	return (float*)((u8*)base + off);
@@ -85,11 +125,11 @@ static inline float calc_mesh_sample_t(u8 mode)
 	case 2:
 		return Math.RandF() * Math.RandF() * Math.RandF();
 	case 3:
-		return (float)(DOUBLE_80330480 - (double)(Math.RandF() * Math.RandF() * Math.RandF()));
+		return (float)(RyjOneDouble() - (double)(Math.RandF() * Math.RandF() * Math.RandF()));
 	case 4:
 		return Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF();
 	case 5:
-		return (float)(DOUBLE_80330480 - (double)(Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF()));
+		return (float)(RyjOneDouble() - (double)(Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF()));
 	default:
 		return Math.RandF();
 	}
@@ -97,7 +137,7 @@ static inline float calc_mesh_sample_t(u8 mode)
 
 static inline float calc_spawn_speed(float speed, u8 mode)
 {
-	float halfSpeed = FLOAT_80330478 * speed;
+	float halfSpeed = RyjHalf() * speed;
 
 	switch (mode) {
 	case 1:
@@ -106,11 +146,11 @@ static inline float calc_spawn_speed(float speed, u8 mode)
 	case 2:
 		return speed * Math.RandF() * Math.RandF() - halfSpeed;
 	case 3:
-		return -(FLOAT_80330474 * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
+		return -(RyjSpeedFalloff() * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
 	case 4:
 		return Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * speed - halfSpeed;
 	case 5:
-		return -(FLOAT_80330478 * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
+		return -(RyjHalf() * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
 	default:
 		return speed * Math.RandF() - halfSpeed;
 	}
@@ -125,11 +165,11 @@ static inline float calc_direction_speed(float speed, u8 mode)
 	case 2:
 		return speed * Math.RandF() * Math.RandF();
 	case 3:
-		return -(FLOAT_80330474 * (speed * Math.RandF() * Math.RandF()) - speed);
+		return -(RyjSpeedFalloff() * (speed * Math.RandF() * Math.RandF()) - speed);
 	case 4:
 		return Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * speed;
 	case 5:
-		return -(FLOAT_80330478 * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed);
+		return -(RyjHalf() * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed);
 	default:
 		return speed;
 	}
@@ -137,7 +177,7 @@ static inline float calc_direction_speed(float speed, u8 mode)
 
 static inline void calc_spawn_position(Vec* out, float speed, u8 mode)
 {
-	float halfSpeed = FLOAT_80330478 * speed;
+	float halfSpeed = RyjHalf() * speed;
 
 	switch (mode) {
 	case 1:
@@ -152,9 +192,9 @@ static inline void calc_spawn_position(Vec* out, float speed, u8 mode)
 		out->z = speed * Math.RandF() * Math.RandF() - halfSpeed;
 		break;
 	case 3:
-		out->x = -(FLOAT_80330474 * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
-		out->y = -(FLOAT_80330474 * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
-		out->z = -(FLOAT_80330474 * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
+		out->x = -(RyjSpeedFalloff() * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
+		out->y = -(RyjSpeedFalloff() * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
+		out->z = -(RyjSpeedFalloff() * (speed * Math.RandF() * Math.RandF()) - speed) - halfSpeed;
 		break;
 	case 4:
 		out->x = Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * speed - halfSpeed;
@@ -162,9 +202,9 @@ static inline void calc_spawn_position(Vec* out, float speed, u8 mode)
 		out->z = Math.RandF() * Math.RandF() * Math.RandF() * Math.RandF() * speed - halfSpeed;
 		break;
 	case 5:
-		out->x = -(FLOAT_80330478 * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
-		out->y = -(FLOAT_80330478 * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
-		out->z = -(FLOAT_80330478 * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
+		out->x = -(RyjHalf() * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
+		out->y = -(RyjHalf() * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
+		out->z = -(RyjHalf() * (Math.RandF() * (speed * Math.RandF() * Math.RandF())) - speed) - halfSpeed;
 		break;
 	default:
 		out->x = speed * Math.RandF() - halfSpeed;
@@ -182,10 +222,10 @@ static inline signed char random_signed_byte_span(u8 span)
 static inline void apply_signed_randomization_2(u8* particle, s32 offset, u8 flags)
 {
 	if (((flags & 1) != 0) && ((flags & 2) != 0)) {
-		if (DOUBLE_80330488 < (double)Math.RandF()) {
+		if (RyjHalfDouble() < (double)Math.RandF()) {
 			*f32_at(particle, offset) = *f32_at(particle, offset) * FLOAT_80330490[0];
 		}
-		if (DOUBLE_80330488 < (double)Math.RandF()) {
+		if (RyjHalfDouble() < (double)Math.RandF()) {
 			*f32_at(particle, offset + 4) = *f32_at(particle, offset + 4) * FLOAT_80330490[0];
 		}
 	} else if ((flags & 2) != 0) {
@@ -875,7 +915,7 @@ void birth(
 	payload = (u8*)param;
 	particlePayload = (u8*)particle;
 	float spread = (float)payload[0x2B];
-	float range = FLOAT_80330470 * spread;
+	float range = RyjDoubleScale() * spread;
 
 	memset(particle, 0, 0x60);
 	if (worldMat != NULL) {
@@ -895,9 +935,9 @@ void birth(
 		baseDirection.y = *f32_at(payload, 0xA4);
 		baseDirection.z = *f32_at(payload, 0xA8);
 
-		angle[0] = (s32)((float)((s32)(range * Math.RandF() - spread) << 15) / FLOAT_8033045c);
-		angle[1] = (s32)((float)((s32)(range * Math.RandF() - spread) << 15) / FLOAT_8033045c);
-		angle[2] = (s32)((float)((s32)(range * Math.RandF() - spread) << 15) / FLOAT_8033045c);
+		angle[0] = (s32)((float)((s32)(range * Math.RandF() - spread) << 15) / RyjAngleMax());
+		angle[1] = (s32)((float)((s32)(range * Math.RandF() - spread) << 15) / RyjAngleMax());
+		angle[2] = (s32)((float)((s32)(range * Math.RandF() - spread) << 15) / RyjAngleMax());
 		angle[3] = 0;
 
 		if ((payload[0x2A] == 2) || (payload[0x2A] == 3)) {
@@ -989,7 +1029,7 @@ void birth(
 	if (payload[0xEB] != 0) {
 		*f32_at(particlePayload, 0x30) = *f32_at(payload, 0x9C) * Math.RandF();
 		if (((payload[0xEB] & 1) != 0) && ((payload[0xEB] & 2) != 0)) {
-			if (DOUBLE_80330488 < (double)Math.RandF()) {
+			if (RyjHalfDouble() < (double)Math.RandF()) {
 				*f32_at(particlePayload, 0x30) = *f32_at(particlePayload, 0x30) * FLOAT_80330490[0];
 			}
 		} else if ((payload[0xEB] & 2) != 0) {
@@ -1003,15 +1043,15 @@ void birth(
 		*f32_at(particlePayload, 0x2C) = *f32_at(particlePayload, 0x2C) + *f32_at(particlePayload, 0x30);
 	}
 	{
-		float angleWrap = FLOAT_80330458;
-		float angleMax = FLOAT_8033045c;
+		float angleWrap = RyjAngleWrap();
+		float angleMax = RyjAngleMax();
 		while (angleMax <= *f32_at(particlePayload, 0x28)) {
 			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) - angleWrap;
 		}
 	}
 	{
-		float angleWrap = FLOAT_80330458;
-		float angleMin = FLOAT_80330460;
+		float angleWrap = RyjAngleWrap();
+		float angleMin = RyjAngleMin();
 		while (*f32_at(particlePayload, 0x28) < angleMin) {
 			*f32_at(particlePayload, 0x28) = *f32_at(particlePayload, 0x28) + angleWrap;
 		}
@@ -1032,7 +1072,7 @@ void birth(
 			*f32_at(particlePayload, 0x44) = randomRotation;
 			*f32_at(particlePayload, 0x48) = randomRotation;
 			if (((payload[0xEA] & 1) != 0) && ((payload[0xEA] & 2) != 0)) {
-				if (DOUBLE_80330488 < (double)Math.RandF()) {
+				if (RyjHalfDouble() < (double)Math.RandF()) {
 					*f32_at(particlePayload, 0x44) = *f32_at(particlePayload, 0x44) * FLOAT_80330490[0];
 					*f32_at(particlePayload, 0x48) = *f32_at(particlePayload, 0x48) * FLOAT_80330490[0];
 				}
@@ -1057,7 +1097,7 @@ void birth(
 		float velocityRandom = *f32_at(payload, 0xC8);
 		if (velocityRandom != kPppRyjMegaBirthZero) {
 			*f32_at(particlePayload, 0x4C) =
-				*f32_at(particlePayload, 0x4C) + FLOAT_80330470 * velocityRandom * Math.RandF() - velocityRandom;
+				*f32_at(particlePayload, 0x4C) + RyjDoubleScale() * velocityRandom * Math.RandF() - velocityRandom;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Route repeated pppRyjMegaBirth scalar constants through small inline accessors, matching the style already used by related MegaBirth code.
- Reduces duplicate local .sdata2 literals emitted by the current translation unit.

## Evidence
- Built with `ninja`.
- `main/pppRyjMegaBirth` .sdata2 target/current improved from `80 / 136` to `80 / 96` bytes.
- `[.sdata2-0]` score improved from `74.07407%` to `90.909096%`.
- Tradeoff: `.text` score moves from `84.28095%` to `83.95724%`; `birth` size moves closer to target from `4008` to `4036` bytes against target `4468`, with match `71.972244%` to `71.389435%`.

## Plausibility
- The new accessors are normal source-level constant references, not section forcing or address hacks.
- This mirrors the existing constant-accessor pattern in `pppRyjMegaBirthModel.cpp` and avoids duplicated literal data while keeping named constants as the source of truth.