### PR TITLE
Match YmMana shadow mesh callback

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -335,8 +335,7 @@ void Chara_DrawShadowMeshDLCallback(CChara::CModel* model, void* work, void* vYm
 {
     VYmMana* mana = static_cast<VYmMana*>(work);
     VYmMana* sourceMana = static_cast<VYmMana*>(vYmMana);
-    CChara::CMesh::CRefData* meshData = model->m_meshes[meshIndex].m_data;
-    CChara::CMesh::CDisplayList* displayList = &meshData->m_displayLists[dlIndex];
+    CChara::CMesh* meshes = model->m_meshes;
     u8 alpha = sourceMana->m_runtimeColor.a;
     if (alpha != 0) {
         mana->m_shadowColor.r = 0xFF;
@@ -353,6 +352,10 @@ void Chara_DrawShadowMeshDLCallback(CChara::CModel* model, void* work, void* vYm
     DCFlushRange(&mana->m_shadowColor, 4);
     GXSetArray((GXAttr)0xB, &mana->m_shadowColor, 4);
 
+    meshes += meshIndex;
+    CChara::CMesh::CRefData* meshData = meshes->m_data;
+    CChara::CMesh::CDisplayList* displayList = meshData->m_displayLists;
+    displayList += dlIndex;
     MaterialMan.SetMaterial(model->m_data->m_materialSet, displayList->m_material, 0, (_GXTevScale)0);
     GXCallDisplayList(displayList->m_data, displayList->m_size);
 }


### PR DESCRIPTION
## Summary
- Reordered Chara_DrawShadowMeshDLCallback display-list lookup to match the original source shape.
- Keeps the mesh array live through the shadow color setup, then resolves the mesh/display-list pointers immediately before material setup.

## Evidence
- ninja passes.
- Chara_DrawShadowMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f: 47.75926% -> 100.0%.
- Build report improved by one matched function and +216 matched code bytes.

## Plausibility
- This is normal source-level pointer staging, not a forced section, fake symbol, or manual vtable/RTTI change.
- The final display-list lookup now follows the same order as the Ghidra shape: fetch model meshes early, set up shadow color state, then resolve mesh/display-list immediately before material and display-list calls.