### PR TITLE
Improve ringmenu onDraw command ordering

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -643,17 +643,17 @@ void CRingMenu::onDraw()
 				int prev2 = (Game.m_gameWork.m_bossArtifactStageIndex == 0x19)
 				                ? (prev1 + 4) % 5
 				                : caravanWork->GetNextCmdListIdx(prev1, -1);
+
+				drawCommand(menuIndex, font, posX, posY, caravanWork, prev2, static_cast<float>(scroll - FLOAT_80330a28),
+				            static_cast<float>(labelAlphaScale));
+				drawCommand(menuIndex, font, posX, posY, caravanWork, prev1, static_cast<float>(scroll - FLOAT_803309cc),
+				            static_cast<float>(labelAlphaScale));
 				int next1 = (Game.m_gameWork.m_bossArtifactStageIndex == 0x19)
 				                ? (cmdIndex + 1) % 5
 				                : caravanWork->GetNextCmdListIdx(cmdIndex, 1);
 				int next2 = (Game.m_gameWork.m_bossArtifactStageIndex == 0x19)
 				                ? (next1 + 1) % 5
 				                : caravanWork->GetNextCmdListIdx(next1, 1);
-
-				drawCommand(menuIndex, font, posX, posY, caravanWork, prev2, static_cast<float>(scroll - FLOAT_80330a28),
-				            static_cast<float>(labelAlphaScale));
-				drawCommand(menuIndex, font, posX, posY, caravanWork, prev1, static_cast<float>(scroll - FLOAT_803309cc),
-				            static_cast<float>(labelAlphaScale));
 				drawCommand(menuIndex, font, posX, posY, caravanWork, next2, static_cast<float>(scroll + FLOAT_80330a28),
 				            static_cast<float>(labelAlphaScale));
 				drawCommand(menuIndex, font, posX, posY, caravanWork, next1, static_cast<float>(scroll + FLOAT_803309cc),


### PR DESCRIPTION
## Summary
- Move the next-command lookup in CRingMenu::onDraw until after the previous command labels are drawn.
- This matches the order shown by the Ghidra decompilation and reduces live ranges/register pressure around the command label draw sequence.

## Objdiff evidence
- main/ringmenu onDraw__9CRingMenuFv: 51.32338% -> 54.431515% (size 3884b unchanged)
- main/ringmenu DrawIcon__9CRingMenuFv: unchanged at 70.18156%
- main/ringmenu drawGBA__9CRingMenuFv: unchanged at 76.940216%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/ringmenu -o - onDraw__9CRingMenuFv
- build/tools/objdiff-cli diff -p . -u main/ringmenu -o - DrawIcon__9CRingMenuFv
- build/tools/objdiff-cli diff -p . -u main/ringmenu -o - drawGBA__9CRingMenuFv