### PR TITLE
Match pppConformBGNormal

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -28,6 +28,15 @@ struct ConformBgNormalState {
     u8 m_initialized;
 };
 
+struct ConformMapCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    f32 m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 struct WeaponNodeFlagBits {
     signed char m_prg : 1;
     signed char m_unk40 : 1;
@@ -74,8 +83,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
     f64 trigValue;
     Mtx basisMtx;
     Mtx scaleMtx;
-    CMapCylinder firstCylinder;
-    CMapCylinder secondCylinder;
+    ConformMapCylinder firstCylinder;
+    ConformMapCylinder secondCylinder;
     Vec local_140;
     Vec local_14c;
     Vec local_158;
@@ -135,7 +144,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                 firstCylinder.m_axis.z = kPppConformBgNormalZero;
                 firstCylinder.m_radius = kPppConformBgNormalZero;
 
-                checkResult = MapMng.CheckHitCylinderNear(&firstCylinder, &firstRayDirection, 0xffffffff);
+                checkResult =
+                    MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&firstCylinder), &firstRayDirection, 0xffffffff);
                 hitFound = checkResult;
                 if (checkResult != 0) {
                     MapMng.m_hitMapObj->CalcHitPosition(&local_170);
@@ -244,7 +254,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     secondCylinder.m_axis.z = kPppConformBgNormalZero;
                     secondCylinder.m_radius = kPppConformBgNormalZero;
 
-                    hitFound = MapMng.CheckHitCylinderNear(&secondCylinder, &secondRayDirection, 0xffffffff);
+                    hitFound = MapMng.CheckHitCylinderNear(
+                        reinterpret_cast<CMapCylinder*>(&secondCylinder), &secondRayDirection, 0xffffffff);
                     if (hitFound != 0) {
                         MapMng.m_hitMapObj->CalcHitPosition(&local_170);
                         ppvMng->m_matrix.value[0][3] = local_170.x;


### PR DESCRIPTION
Summary
- Replace the stack CMapCylinder temporaries in pppFrameConformBGNormal with a POD layout used only for local hit probes.
- This removes constructor-generated stores that are not present in the target while keeping field access and casting only at the CMapMng API boundary.

Evidence
- ninja succeeds.
- objdiff reports pppFrameConformBGNormal at 100.0%.
- Unit main/pppConformBGNormal is now 100.0% text/data, with both functions matched.

Progress
- Before: pppFrameConformBGNormal 96.391754%, unit data 72.72727%.
- After: pppFrameConformBGNormal 100.0%, unit text/data 100.0%.
- Build progress increased by 1552 matched code bytes, 12 matched data bytes, and 1 matched function.