### PR TITLE
Improve astar constant linkage

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -23,12 +23,9 @@ extern const float kAStarEscapeInitialBestDist = -1000000.0f;
 extern const char kAStarGroupDebugLabel[] = "//A*\n";
 extern const float kDrawAStarSphereRadius;
 extern const float kInfiniteCost;
-extern const char kAStarStepDebugFormat[];
-extern const char kAStarNewLine[];
+extern const char kAStarStepDebugFormat[4];
+extern const char kAStarNewLine[2];
 }
-static const float kAStarCalcInfiniteCost = 10000000.0f;
-static const char kAStarCalcStepDebugFormat[] = "%d ";
-static const char kAStarCalcNewLine[] = "\n";
 #include "ffcc/system.h"
 #include "ffcc/vector.h"
 
@@ -582,13 +579,13 @@ void CAStar::calcAStar()
 				continue;
 			}
 
-			m_bestPath.m_cost = LoadFloat(kAStarCalcInfiniteCost);
+			m_bestPath.m_cost = LoadFloat(kInfiniteCost);
 
 			CATemp temp;
 
 			check(from, to, temp);
 
-			if (m_bestPath.m_cost < LoadFloat(kAStarCalcInfiniteCost))
+			if (m_bestPath.m_cost < LoadFloat(kInfiniteCost))
 			{
 				System.Printf(const_cast<char*>(kAStarCostDebugFormat), from, to, m_bestPath.m_cost);
 
@@ -611,10 +608,10 @@ void CAStar::calcAStar()
 
 					current = static_cast<unsigned char>(next);
 
-					System.Printf(const_cast<char*>(kAStarCalcStepDebugFormat), current);
+					System.Printf(const_cast<char*>(kAStarStepDebugFormat), current);
 				}
 
-				System.Printf(const_cast<char*>(kAStarCalcNewLine));
+				System.Printf(const_cast<char*>(kAStarNewLine));
 			}
 		}
 	}
@@ -1125,7 +1122,7 @@ void CAStar::CATemp::operator= (const CAStar::CATemp& other)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CAStar::addAstar(Vec& pos, int groupA, int groupB)
+inline void CAStar::addAstar(Vec& pos, int groupA, int groupB)
 {
 	int groupLow = groupA;
 	int groupHigh = groupB;


### PR DESCRIPTION
## Summary
- Reuse the shipped A* small-data symbols for calcAStar instead of emitting astar-local duplicate constants.
- Size the debug string externs so MWCC keeps the same small-data access form.
- Mark the unused Vec overload of CAStar::addAstar inline so it is not emitted in astar.o.

## Evidence
- Build: ninja
- Objdiff unit: build/tools/objdiff-cli diff -p . -u main/astar -o -
- main/astar .text: 94.866554% -> 94.878006%
- calcAStar__6CAStarFv: 97.90124% -> 98.14815%
- [.sdata2-0]: 69.76744% -> 81.08108%
- Extra emitted addAstar__6CAStarFR3Vecii is removed from the built object; the used float overload remains at 98.83234%.

## Plausibility
These constants already exist as named shipped symbols in config/GCCP01/symbols.txt and are defined by another translation unit. The Vec overload is marked UNUSED in astar.cpp and has no callers in this checkout, matching the runbook guidance for UNUSED functions that otherwise create object-size/section regressions.