### PR TITLE
Match pppConstructYmMana

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -521,10 +521,10 @@ void pppConstructYmMana(PYmMana* ymMana, pppYmManaUnkC* param_2)
     work->m_displayListCopies = 0;
     work->m_reflectionVec = 0;
     work->m_colors = 0;
-    work->m_envTexture0 = 0;
     work->m_captureTexObjs = 0;
-    work->m_envTexture1 = 0;
     work->m_step = 0;
+    work->m_envTexture0 = 0;
+    work->m_envTexture1 = 0;
     work->m_meshReflectionVec = 0;
     work->m_meshColors = 0;
     work->m_meshTexCoords0 = 0;


### PR DESCRIPTION
## Summary
- Reordered the zero-initialization sequence in pppConstructYmMana to match the original store order for the mana texture/callback fields.
- This keeps the constructor source coherent while matching the compiler output exactly.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppYmMana -o - reports pppConstructYmMana at 100.0% for 400 bytes.
- Overall progress moved from 622092 / 1855224 code bytes and 3517 / 4732 functions to 622492 / 1855224 code bytes and 3518 / 4732 functions.

## Plausibility
- The change is only assignment order among adjacent VYmMana pointer fields during construction.
- No fake symbols, manual sections, or generated ctor/dtor hacks were introduced.