### PR TITLE
Improve YmMana and CharaBreak matching

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -82,8 +82,21 @@ struct CharaBreakDisplayListPair {
 };
 
 typedef CChara::CMesh::CDisplayList CharaBreakDisplayList;
-typedef CChara::CMesh::CRefData CharaBreakMeshData;
 typedef CChara::CMesh CharaBreakMeshRef;
+
+struct CharaBreakMeshData {
+    char m_name[0x10];
+    u8 m_flags;
+    u8 _pad11[3];
+    u32 m_vertexCount;
+    S16Vec* m_vertices;
+    u8 _pad1C[0x30];
+    u32 m_displayListCount;
+    CharaBreakDisplayList* m_displayLists;
+    u32 m_skinCount;
+    void* m_skins;
+    u32 m_nodeIndex;
+};
 
 STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_data) == 0x8);
 STATIC_ASSERT(offsetof(CharaBreakMeshRef, m_workPositions) == 0xC);
@@ -95,7 +108,7 @@ STATIC_ASSERT(offsetof(CCharaModelData, m_normQuant) == 0x38);
 STATIC_ASSERT(offsetof(CharaBreakMeshData, m_displayListCount) == 0x4C);
 STATIC_ASSERT(offsetof(CharaBreakMeshData, m_displayLists) == 0x50);
 STATIC_ASSERT(offsetof(CharaBreakMeshData, m_skinCount) == 0x54);
-STATIC_ASSERT(offsetof(CharaBreakMeshData, m_nodeIndex) == 0x60);
+STATIC_ASSERT(offsetof(CharaBreakMeshData, m_nodeIndex) == 0x5C);
 STATIC_ASSERT(offsetof(CharaBreakStep, m_worldSpaceMode) == 0x42);
 
 static inline MtxPtr ModelDrawMtx(CChara::CModel* model)
@@ -120,7 +133,7 @@ static inline CharaBreakMeshRef* ModelMeshes(CChara::CModel* model)
 
 static inline CharaBreakMeshData* MeshData(CChara::CMesh* mesh)
 {
-    return mesh->m_data;
+    return reinterpret_cast<CharaBreakMeshData*>(mesh->m_data);
 }
 
 static inline CharaBreakDisplayListPair*** MeshDisplayListPairs(CharaBreakWork* work)

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -335,8 +335,7 @@ void Chara_DrawShadowMeshDLCallback(CChara::CModel* model, void* work, void* vYm
 {
     VYmMana* mana = static_cast<VYmMana*>(work);
     VYmMana* sourceMana = static_cast<VYmMana*>(vYmMana);
-    CChara::CMesh::CRefData* meshData = model->m_meshes[meshIndex].m_data;
-    CChara::CMesh::CDisplayList* displayList = &meshData->m_displayLists[dlIndex];
+    CChara::CMesh* meshes = model->m_meshes;
     u8 alpha = sourceMana->m_runtimeColor.a;
     if (alpha != 0) {
         mana->m_shadowColor.r = 0xFF;
@@ -353,6 +352,9 @@ void Chara_DrawShadowMeshDLCallback(CChara::CModel* model, void* work, void* vYm
     DCFlushRange(&mana->m_shadowColor, 4);
     GXSetArray((GXAttr)0xB, &mana->m_shadowColor, 4);
 
+    meshes += meshIndex;
+    CChara::CMesh::CRefData* meshData = meshes->m_data;
+    CChara::CMesh::CDisplayList* displayList = meshData->m_displayLists + dlIndex;
     MaterialMan.SetMaterial(model->m_data->m_materialSet, displayList->m_material, 0, (_GXTevScale)0);
     GXCallDisplayList(displayList->m_data, displayList->m_size);
 }

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1796,16 +1796,16 @@ void CalcReflectionVector2(
                 PSMTXMultVec(rotateMtx, &reflectionVec[posIndex], &reflectionVec[posIndex]);
             }
 
-            if (reflectionVec[posIndex].z < zero) {
-                colorBytes[0] = 0;
-                colorBytes[1] = 0;
-                colorBytes[2] = 0;
-                colorBytes[3] = 0;
-            } else {
+            if (zero <= reflectionVec[posIndex].z) {
                 colorBytes[0] = 0xFF;
                 colorBytes[1] = 0xFF;
                 colorBytes[2] = 0xFF;
                 colorBytes[3] = 0xFF;
+            } else {
+                colorBytes[0] = 0;
+                colorBytes[1] = 0;
+                colorBytes[2] = 0;
+                colorBytes[3] = 0;
             }
 
             denom = denomBias + reflectionVec[posIndex].z;


### PR DESCRIPTION
## Summary
- improve `Chara_DrawShadowMeshDLCallback` by matching the original display-list lookup order and mesh pointer shape
- improve `CalcReflectionVector2` branch shape for reflection color selection
- correct the local `pppCharaBreak` mesh-data layout used by particle code so `m_nodeIndex` sits at 0x5c, matching the local particle mesh layouts

## Objdiff evidence
`main/pppYmMana`:
- `Chara_DrawShadowMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: 47.75926% -> 95.0%
- `CalcReflectionVector2__FP3VecP6S16VecP6S16VeclUlUlPA4_fPvUlP8_GXColorP8S16Vec2dP8S16Vec2dPQ26CChara5CNodeP7PYmManaP7VYmMana`: 79.796425% -> 81.16428%
- checked adjacent targets `UpdateWaterMesh__FP7VYmMana` and `pppFrameYmMana`: unchanged

`main/pppCharaBreak`:
- `UpdatePolygonData__FP11PCharaBreakP11VCharaBreakPQ26CChara6CModel`: 90.01982% -> 90.02162%
- `CreatePolygon__FP12POLYGON_DATAPvUlPQ26CChara6CModelPQ26CChara5CMesh`: 99.72298% -> 99.72973%
- checked `pppFrameCharaBreak` and `pppDestructCharaBreak`: unchanged

## Plausibility
- The `pppYmMana` callback now delays display-list lookup until after shadow color upload, matching Ghidra's operation order and preserving behavior.
- The reflection color branch is a semantic no-op (`zero <= z` versus `z < zero` with reversed arms) that matches the target branch shape better.
- The `pppCharaBreak` local mesh data struct mirrors the particle-local layout already used by `pppScreenBreak`, where `m_nodeIndex` is at 0x5c rather than the broader shared header layout.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMana -o /tmp/pppYmMana.final.json`
- `build/tools/objdiff-cli diff -p . -u main/pppCharaBreak -o /tmp/pppCharaBreak.final2.json`