### PR TITLE
Match menu option data ownership

### DIFF
--- a/src/MenuUtil.cpp
+++ b/src/MenuUtil.cpp
@@ -21,6 +21,27 @@ struct Vec2d {
 
 extern "C" char s_MenuUtil_cpp_801e37fc[];
 extern char lbl_801E3058[];
+extern "C" const char s_MenuOptionMusic[] = "Music";
+extern "C" const char s_MenuOptionOn[] = "On";
+extern "C" const char s_MenuOptionOff[] = "Off";
+extern "C" const char s_MenuOptionStereo[] = "Stereo";
+extern "C" const char s_MenuOptionMin[] = "Min";
+extern "C" const char s_MenuOptionMax[] = "Max";
+extern "C" const char s_MenuOptionStrengthDe[] = {'S', 't', '\xe4', 'r', 'k', 'e', '\0', '\0'};
+extern "C" const char s_MenuOptionDefenceDe[] = "Abwehr";
+extern "C" const char s_MenuOptionMusicDe[] = "Musik";
+extern "C" const char s_MenuOptionOnDe[] = "AN";
+extern "C" const char s_MenuOptionOffDe[] = "AUS";
+extern "C" const char s_MenuOptionStereoDe[] = "STEREO";
+extern "C" const char s_MenuOptionMonoUpper_803334A8[] = "MONO";
+extern "C" const char s_MenuOptionNormalIt_803334B0[] = "Normal";
+extern "C" const char s_MenuOptionForza_803334B8[] = "Forza";
+extern "C" const char s_MenuOptionDifesa_803334C0[] = "Difesa";
+extern "C" const char s_MenuOptionSonoro_803334C8[] = "Sonoro";
+extern "C" const char s_MenuOptionMusica_803334D0[] = "Musica";
+extern "C" const char s_MenuOptionMonoIt_803334D8[] = "Mono";
+extern "C" const char s_MenuOptionContr_803334E0[] = "Contr.";
+extern "C" const char s_MenuOptionNorm_803334E8[] = "Norm.";
 extern "C" const float FLOAT_80333614 = 196.0f;
 extern "C" const float FLOAT_80333618 = 168.0f;
 extern "C" const float FLOAT_8033361C = 24.0f;
@@ -150,27 +171,27 @@ extern char s_Encendido_801E36A0[];
 extern char s_Monoaural_801E36AC[];
 extern char s_Mejorado_801E36B8[];
 extern char s_MenuOptionEstandar_801E36C4[];
-extern char s_MenuOptionMusic[];
-extern char s_MenuOptionOn[];
-extern char s_MenuOptionOff[];
-extern char s_MenuOptionStereo[];
-extern char s_MenuOptionMin[];
-extern char s_MenuOptionMax[];
-extern char s_MenuOptionStrengthDe[];
-extern char s_MenuOptionDefenceDe[];
-extern char s_MenuOptionMusicDe[];
-extern char s_MenuOptionOnDe[];
-extern char s_MenuOptionOffDe[];
-extern char s_MenuOptionStereoDe[];
-extern char s_MenuOptionMonoUpper_803334A8[];
-extern char s_MenuOptionNormalIt_803334B0[];
-extern char s_MenuOptionForza_803334B8[];
-extern char s_MenuOptionDifesa_803334C0[];
-extern char s_MenuOptionSonoro_803334C8[];
-extern char s_MenuOptionMusica_803334D0[];
-extern char s_MenuOptionMonoIt_803334D8[];
-extern char s_MenuOptionContr_803334E0[];
-extern char s_MenuOptionNorm_803334E8[];
+extern const char s_MenuOptionMusic[];
+extern const char s_MenuOptionOn[];
+extern const char s_MenuOptionOff[];
+extern const char s_MenuOptionStereo[];
+extern const char s_MenuOptionMin[];
+extern const char s_MenuOptionMax[];
+extern const char s_MenuOptionStrengthDe[];
+extern const char s_MenuOptionDefenceDe[];
+extern const char s_MenuOptionMusicDe[];
+extern const char s_MenuOptionOnDe[];
+extern const char s_MenuOptionOffDe[];
+extern const char s_MenuOptionStereoDe[];
+extern const char s_MenuOptionMonoUpper_803334A8[];
+extern const char s_MenuOptionNormalIt_803334B0[];
+extern const char s_MenuOptionForza_803334B8[];
+extern const char s_MenuOptionDifesa_803334C0[];
+extern const char s_MenuOptionSonoro_803334C8[];
+extern const char s_MenuOptionMusica_803334D0[];
+extern const char s_MenuOptionMonoIt_803334D8[];
+extern const char s_MenuOptionContr_803334E0[];
+extern const char s_MenuOptionNorm_803334E8[];
 extern const char s_Force_803334F0[];
 extern const char s_Musique_803334F8[];
 extern const char s_Active_80333500[];
@@ -184,30 +205,30 @@ extern const char s_MenuOptionMinEs_80333538[];
 extern const char s_MenuOptionMaxEs_80333540[];
 extern "C" char* g_strMenuUtilMes[] = {
 	s_Strength_801E30A4, s_Defence_801E30B0, s_Position_Markers_801E30BC, s_Sound_Mode_801E30D0,
-	s_MenuOptionMusic, s_Sound_Effects_801E30DC, s_GBA_Colour_Balance_801E30EC,
+	const_cast<char*>(s_MenuOptionMusic), s_Sound_Effects_801E30DC, s_GBA_Colour_Balance_801E30EC,
 	s_Show_or_hide_position_marker_under_each_character_s_feet_801E3100,
 	s_Select_stereo_or_monaural_sound_801E313C, s_Adjust_volume_of_background_music_801E3160,
 	s_Adjust_volume_of_sound_effects_801E3184, s_Adjust_colour_balance_of_Game_Boy_Advance_801E31A4,
-	s_MenuOptionOn, s_MenuOptionOff, s_MenuOptionStereo, s_Monaural_801E31D0,
-	s_MenuOptionMin, s_MenuOptionMax, s_Enhanced_801E31DC, s_Standard_801E31E8,
-	s_MenuOptionStrengthDe, s_MenuOptionDefenceDe, s_Erkennungskreisel_801E31F4, s_Tonausgabe_801E3208,
-	s_MenuOptionMusicDe, s_MenuOptionSoundEffectsDe_801E3214, s_Farbeinstellung_801E3224,
+	const_cast<char*>(s_MenuOptionOn), const_cast<char*>(s_MenuOptionOff), const_cast<char*>(s_MenuOptionStereo), s_Monaural_801E31D0,
+	const_cast<char*>(s_MenuOptionMin), const_cast<char*>(s_MenuOptionMax), s_Enhanced_801E31DC, s_Standard_801E31E8,
+	const_cast<char*>(s_MenuOptionStrengthDe), const_cast<char*>(s_MenuOptionDefenceDe), s_Erkennungskreisel_801E31F4, s_Tonausgabe_801E3208,
+	const_cast<char*>(s_MenuOptionMusicDe), s_MenuOptionSoundEffectsDe_801E3214, s_Farbeinstellung_801E3224,
 	s_Erkennungskreisel_des_Charakters_AN_AUS_schalten_801E3234,
 	s_Tonausgabe_auf_Stereo_oder_Mono_schalten_801E3268, s_Lautstaerke_der_Musik_aendern_801E3294, s_Lautstaerke_der_Geraeuscheffekte_aendern_801E32B4,
-	s_Farbeinstellung_des_Game_Boy_Advance_aendern_801E32DC, s_MenuOptionOnDe, s_MenuOptionOffDe, s_MenuOptionStereoDe, s_MenuOptionMonoUpper_803334A8,
-	s_MenuOptionMin, s_MenuOptionMax, s_Erweitert_801E330C, s_MenuOptionNormalIt_803334B0,
-	s_MenuOptionForza_803334B8, s_MenuOptionDifesa_803334C0, s_Indicatori_di_posizione_801E3318, s_MenuOptionSonoro_803334C8,
-	s_MenuOptionMusica_803334D0, s_Effetti_sonori_801E3330, s_Bilanc_colore_GBA_801E3340,
+	s_Farbeinstellung_des_Game_Boy_Advance_aendern_801E32DC, const_cast<char*>(s_MenuOptionOnDe), const_cast<char*>(s_MenuOptionOffDe), const_cast<char*>(s_MenuOptionStereoDe), const_cast<char*>(s_MenuOptionMonoUpper_803334A8),
+	const_cast<char*>(s_MenuOptionMin), const_cast<char*>(s_MenuOptionMax), s_Erweitert_801E330C, const_cast<char*>(s_MenuOptionNormalIt_803334B0),
+	const_cast<char*>(s_MenuOptionForza_803334B8), const_cast<char*>(s_MenuOptionDifesa_803334C0), s_Indicatori_di_posizione_801E3318, const_cast<char*>(s_MenuOptionSonoro_803334C8),
+	const_cast<char*>(s_MenuOptionMusica_803334D0), s_Effetti_sonori_801E3330, s_Bilanc_colore_GBA_801E3340,
 	s_Attiva_o_disattiva_l_indicatore_ai_piedi_dei_personaggi_801E3354,
 	s_Scegli_tra_sonoro_mono_o_stereo_801E3390, s_Regola_il_volume_della_musica_801E33B4,
 	s_Regola_il_volume_degli_effetti_sonori_801E33D4, s_Regola_il_colore_sul_Game_Boy_Advance_801E33FC,
-	s_MenuOptionOn, s_MenuOptionOff, s_MenuOptionStereo, s_MenuOptionMonoIt_803334D8, s_MenuOptionMin, s_MenuOptionMax,
-	s_MenuOptionContr_803334E0, s_MenuOptionNorm_803334E8,
+	const_cast<char*>(s_MenuOptionOn), const_cast<char*>(s_MenuOptionOff), const_cast<char*>(s_MenuOptionStereo), const_cast<char*>(s_MenuOptionMonoIt_803334D8), const_cast<char*>(s_MenuOptionMin), const_cast<char*>(s_MenuOptionMax),
+	const_cast<char*>(s_MenuOptionContr_803334E0), const_cast<char*>(s_MenuOptionNorm_803334E8),
 	const_cast<char*>(s_Force_803334F0), s_ResistanceFr_801E3424, s_Sceau_de_position_801E3430, s_Signal_sonore_801E3444,
 	const_cast<char*>(s_Musique_803334F8), s_Effets_sonores_801E3454, s_Affichage_du_GBA_801E3464,
 	s_Affichage_du_sceau_de_position_aux_pieds_des_personnages_801E3478,
 	s_Choisissez_le_signal_sonore_stereo_ou_mono_801E34B4, s_Reglez_le_volume_de_la_musique_801E34E0, s_Reglez_le_volume_des_effets_sonores_801E3500, s_Reglez_le_contraste_des_couleurs_du_Game_Boy_Advance_801E3524, const_cast<char*>(s_Active_80333500),
-	s_MenuOptionDesactive_801E355C, const_cast<char*>(s_Stereo_80333508), s_MenuOptionMonoIt_803334D8, s_MenuOptionMin, s_MenuOptionMax,
+	s_MenuOptionDesactive_801E355C, const_cast<char*>(s_Stereo_80333508), const_cast<char*>(s_MenuOptionMonoIt_803334D8), const_cast<char*>(s_MenuOptionMin), const_cast<char*>(s_MenuOptionMax),
 	s_MenuOptionAmeliore_801E3568, s_Standard_801E31E8,
 	const_cast<char*>(s_Fuerza_80333510), const_cast<char*>(s_Defensa_80333518), s_Aro_de_posicion_801E3574, s_Tipo_de_sonido_801E3584,
 	const_cast<char*>(s_Musica_80333520), s_Efectos_de_sonido_801E3594, s_Color_de_la_GBA_801E35A8,

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -11,35 +11,35 @@
 typedef signed short s16;
 typedef unsigned char u8;
 
-extern const double DOUBLE_80332fb0;
-extern const double DOUBLE_80332fb8;
-extern const double DOUBLE_80332fe0;
-static const float FLOAT_80332fa8 = 0.0f;
-extern const float FLOAT_80332fac;
-extern const float FLOAT_80332fc0;
-extern const float FLOAT_80332fc4;
-extern const float FLOAT_80332fc8;
-extern const float FLOAT_80332fcc;
-extern const float FLOAT_80332fd0;
-extern const float FLOAT_80332fd4;
-extern const float FLOAT_80332fd8;
-extern const float FLOAT_80332fe8;
-extern const float FLOAT_80332fec;
-extern const float FLOAT_80332ff0;
+extern const float FLOAT_80332fa8 = 0.0f;
+extern const float FLOAT_80332fac = 1.0f;
+extern const double DOUBLE_80332fb0 = 1.0;
+extern const double DOUBLE_80332fb8 = 0.5;
+extern const float FLOAT_80332fc0 = 255.0f;
+extern const float FLOAT_80332fc4 = 0.9f;
+extern const float FLOAT_80332fc8 = 4.0f;
+extern const float FLOAT_80332fcc = 352.0f;
+extern const float FLOAT_80332fd0 = 3.0f;
+extern const float FLOAT_80332fd4 = 320.0f;
+extern const float FLOAT_80332fd8 = 0.5f;
+extern const double DOUBLE_80332fe0 = 4503601774854144.0;
+extern const float FLOAT_80332fe8 = 128.0f;
+extern const float FLOAT_80332fec = 8.0f;
+extern const float FLOAT_80332ff0 = 0.75f;
 
 extern "C" {
-extern const char s_MenuOptionMusic[] = "Music";
-extern const char s_MenuOptionOn[] = "On";
-extern const char s_MenuOptionOff[] = "Off";
-extern const char s_MenuOptionStereo[] = "Stereo";
-extern const char s_MenuOptionMin[] = "Min";
-extern const char s_MenuOptionMax[] = "Max";
-extern const char s_MenuOptionStrengthDe[] = {'S', 't', '\xe4', 'r', 'k', 'e', '\0', '\0'};
-extern const char s_MenuOptionDefenceDe[] = "Abwehr";
-extern const char s_MenuOptionMusicDe[] = "Musik";
-extern const char s_MenuOptionOnDe[] = "AN";
-extern const char s_MenuOptionOffDe[] = "AUS";
-extern const char s_MenuOptionStereoDe[] = "STEREO";
+extern const char s_MenuOptionMusic[];
+extern const char s_MenuOptionOn[];
+extern const char s_MenuOptionOff[];
+extern const char s_MenuOptionStereo[];
+extern const char s_MenuOptionMin[];
+extern const char s_MenuOptionMax[];
+extern const char s_MenuOptionStrengthDe[];
+extern const char s_MenuOptionDefenceDe[];
+extern const char s_MenuOptionMusicDe[];
+extern const char s_MenuOptionOnDe[];
+extern const char s_MenuOptionOffDe[];
+extern const char s_MenuOptionStereoDe[];
 }
 
 namespace {

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -10,32 +10,33 @@
 
 typedef unsigned char u8;
 
-extern "C" const float FLOAT_80332FF8;
-extern "C" const float FLOAT_80332FFC;
-extern "C" const float FLOAT_80333000;
-extern "C" const double DOUBLE_80333008;
-extern "C" const float FLOAT_80333010;
-extern "C" const float FLOAT_80333014;
-extern "C" const float FLOAT_80333018;
-extern "C" const float FLOAT_8033301C;
-extern "C" const float FLOAT_80333020;
-extern "C" const float FLOAT_80333024;
-extern "C" const float FLOAT_80333028;
+extern "C" const float FLOAT_80332FF8 = 0.0f;
+extern "C" const float FLOAT_80332FFC = 24.0f;
+extern "C" const float FLOAT_80333000 = 1.0f;
+extern "C" const double DOUBLE_80333008 = 1.0;
+extern "C" const float FLOAT_80333010 = 255.0f;
+extern "C" const float FLOAT_80333014 = 328.0f;
+extern "C" const float FLOAT_80333018 = 40.0f;
+extern "C" const float FLOAT_8033301C = 0.8f;
+extern "C" const float FLOAT_80333020 = 4.0f;
+extern "C" const float FLOAT_80333024 = 1.2f;
+extern "C" const float FLOAT_80333028 = 2.0f;
+extern "C" const double DOUBLE_80333030 = 4503601774854144.0;
 extern "C" const float FLOAT_80333038;
 extern "C" const float FLOAT_8033303C;
 
 extern "C" const char s_pcts_pctd_family_cnt_error_pctd_801DEDC8[] = "%s(%d):family cnt error!!(%d)\n";
 extern "C" const char s_menu_compa_cpp[] = "menu_compa.cpp";
 
-extern "C" const char s_MenuOptionMonoUpper_803334A8[] = "MONO";
-extern "C" const char s_MenuOptionNormalIt_803334B0[] = "Normal";
-extern "C" const char s_MenuOptionForza_803334B8[] = "Forza";
-extern "C" const char s_MenuOptionDifesa_803334C0[] = "Difesa";
-extern "C" const char s_MenuOptionSonoro_803334C8[] = "Sonoro";
-extern "C" const char s_MenuOptionMusica_803334D0[] = "Musica";
-extern "C" const char s_MenuOptionMonoIt_803334D8[] = "Mono";
-extern "C" const char s_MenuOptionContr_803334E0[] = "Contr.";
-extern "C" const char s_MenuOptionNorm_803334E8[] = "Norm.";
+extern "C" const char s_MenuOptionMonoUpper_803334A8[];
+extern "C" const char s_MenuOptionNormalIt_803334B0[];
+extern "C" const char s_MenuOptionForza_803334B8[];
+extern "C" const char s_MenuOptionDifesa_803334C0[];
+extern "C" const char s_MenuOptionSonoro_803334C8[];
+extern "C" const char s_MenuOptionMusica_803334D0[];
+extern "C" const char s_MenuOptionMonoIt_803334D8[];
+extern "C" const char s_MenuOptionContr_803334E0[];
+extern "C" const char s_MenuOptionNorm_803334E8[];
 
 STATIC_ASSERT(sizeof(CompaOpenAnimList) == 0x1008);
 


### PR DESCRIPTION
## Summary
- Move menu option string definitions from `menu_arti` and `menu_compa` into `MenuUtil`, where the symbol range is owned.
- Define the numeric `.sdata2` constants owned by `menu_arti` and `menu_compa` instead of leaving them as extern declarations.
- Keep the menu users as declarations and cast through the existing `char*` table where needed.

## Evidence
- `ninja` builds clean.
- Overall matched data improves from 1,169,503 to 1,169,647 bytes (+144).
- Game matched data improves from 982,437 to 982,581 bytes (+144).
- `main/menu_arti` `.sdata2`: 46.34% -> 100.00%, matched data now 80 bytes.
- `main/menu_compa` `.sdata2`: 45.83% -> 100.00%, matched data 48 -> 112 bytes.
- `main/MenuUtil` `.sdata2`: 48.33% -> 57.81%.

## Plausibility
The option strings now live with the adjacent `MenuUtil` symbol block, while `menu_arti` and `menu_compa` own the numeric constants present in their target `.sdata2` sections. This replaces extern-only data placeholders with real definitions and improves linkage/data layout without manual section forcing.