### PR TITLE
Inline target-absent helper functions

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -1125,7 +1125,7 @@ void CAStar::CATemp::operator= (const CAStar::CATemp& other)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CAStar::addAstar(Vec& pos, int groupA, int groupB)
+inline void CAStar::addAstar(Vec& pos, int groupA, int groupB)
 {
 	int groupLow = groupA;
 	int groupHigh = groupB;

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -873,7 +873,7 @@ CFlatRuntime::CObject* CFlatRuntime::createObject(int classIndex)
  * Address:	TODO
  * Size:	TODO
  */
-int CFlatRuntime::getTopBit(unsigned int value)
+inline int CFlatRuntime::getTopBit(unsigned int value)
 {
 	int bitBase = 0x1F;
 	int scanCount = 4;

--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -562,7 +562,7 @@ static inline void RetainRefCounted(void* refObject)
 	}
 }
 
-static void CopyDuplicatedNodeState(CChara::CNode* dst, CChara::CNode* src)
+static inline void CopyDuplicatedNodeState(CChara::CNode* dst, CChara::CNode* src)
 {
 	dst->m_refData = src->m_refData;
 	PSMTXCopy(NodeLocalRuntimeMtx(src), NodeLocalRuntimeMtx(dst));
@@ -619,7 +619,7 @@ static bool s_charaMeshWorkOverflowSeen = false;
  * JP Address: TODO
  * JP Size: TODO
  */
-void D3DXMatrixMultiplyRotate(float (*out)[4], float (*a)[4], float (*b)[4])
+inline void D3DXMatrixMultiplyRotate(float (*out)[4], float (*a)[4], float (*b)[4])
 {
 	for (int r = 0; r < 3; r++) {
 		for (int c = 0; c < 3; c++) {


### PR DESCRIPTION
## Summary
- Mark unused/target-absent helper functions inline so MWCC no longer emits standalone source symbols missing from the PAL target.
- Applies to `CAStar::addAstar(Vec&, int, int)`, `CFlatRuntime::getTopBit`, `CopyDuplicatedNodeState`, and `D3DXMatrixMultiplyRotate`.

## Objdiff evidence
- `main/astar`: source `.text` shrinks `7564 -> 6972` bytes vs target `6984`; `addAstar__6CAStarFR3Vecii` source-only `592b` symbol removed; `.text` match remains `94.866554%`.
- `main/cflat_runtime`: source `.text` shrinks `15592 -> 15460` bytes vs target `15964`; `getTopBit__12CFlatRuntimeFUi` source-only `132b` symbol removed; `.text` match remains `63.527187%`.
- `main/chara`: source `.text` shrinks `22032 -> 21660` bytes vs target `20464`; source-only `D3DXMatrixMultiplyRotate__FPA4_fPA4_fPA4_f` (`176b`) and `CopyDuplicatedNodeState__19@unnamed@chara_cpp@FPQ26CChara5CNodePQ26CChara5CNode` (`196b`) removed; `.text` match remains `51.62236%`.

## Plausibility
- This follows the runbook rule for UNUSED/target-absent functions: keep known source functions while avoiding standalone emitted symbols that regress object layout.
- No manual vtable/RTTI/constructor/destructor forcing or section hacks.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/astar -o /tmp/astar_after_final3.json`
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime -o /tmp/cflat_runtime_after.json getTopBit__12CFlatRuntimeFUi`
- `build/tools/objdiff-cli diff -p . -u main/chara -o /tmp/chara_after2.json D3DXMatrixMultiplyRotate__FPA4_fPA4_fPA4_f`