### PR TITLE
Match pppConformBGNormal frame

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -15,12 +15,13 @@ extern const f32 kPppConformBgNormalOne;
 #include "dolphin/gx.h"
 #include <math.h>
 
-struct ConformCylinderQuery {
-    Vec m_pos;
-    Vec m_fieldC;
-    Vec m_field18;
-    Vec m_field24;
-    f32 m_field30;
+struct CMapCylinderRaw {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    f32 m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
 };
 
 struct ConformBgNormalState {
@@ -74,8 +75,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
     f64 trigValue;
     Mtx basisMtx;
     Mtx scaleMtx;
-    CMapCylinder firstCylinder;
-    CMapCylinder secondCylinder;
+    CMapCylinderRaw firstCylinder;
+    CMapCylinderRaw secondCylinder;
     Vec local_140;
     Vec local_14c;
     Vec local_158;
@@ -135,7 +136,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                 firstCylinder.m_axis.z = kPppConformBgNormalZero;
                 firstCylinder.m_radius = kPppConformBgNormalZero;
 
-                checkResult = MapMng.CheckHitCylinderNear(&firstCylinder, &firstRayDirection, 0xffffffff);
+                checkResult = MapMng.CheckHitCylinderNear(
+                    reinterpret_cast<CMapCylinder*>(&firstCylinder), &firstRayDirection, 0xffffffff);
                 hitFound = checkResult;
                 if (checkResult != 0) {
                     MapMng.m_hitMapObj->CalcHitPosition(&local_170);
@@ -244,7 +246,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     secondCylinder.m_axis.z = kPppConformBgNormalZero;
                     secondCylinder.m_radius = kPppConformBgNormalZero;
 
-                    hitFound = MapMng.CheckHitCylinderNear(&secondCylinder, &secondRayDirection, 0xffffffff);
+                    hitFound = MapMng.CheckHitCylinderNear(
+                        reinterpret_cast<CMapCylinder*>(&secondCylinder), &secondRayDirection, 0xffffffff);
                     if (hitFound != 0) {
                         MapMng.m_hitMapObj->CalcHitPosition(&local_170);
                         ppvMng->m_matrix.value[0][3] = local_170.x;

--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -54,7 +54,7 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, pppYmTraceMoveStep* par
 
 	_pppMngSt* pppMngSt = ppvMng;
 	pppYmTraceMoveWork* work = GetYmTraceMoveWork(pppYmTraceMove, param_3);
-	CGObject* owner = pppMngSt->m_owner;
+	CGObject* owner = pppMngSt->m_lookTarget;
 	Vec local_20;
 	Vec local_2c;
 	Vec local_8c;


### PR DESCRIPTION
## Summary
- Use an unconstructed raw map-cylinder layout in pppFrameConformBGNormal so the function only initializes cylinder fields in the branches that need them.
- Correct pppFrameYmTraceMove to follow m_lookTarget, matching the object pointer used by the target function.

## Objdiff evidence
- main/pppConformBGNormal: pppFrameConformBGNormal 96.391754% -> 100.0%; unit is now 100% code/data matched.
- main/pppYmTraceMove: pppFrameYmTraceMove 99.01282% -> 99.01710%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppConformBGNormal -o -
- build/tools/objdiff-cli diff -p . -u main/pppYmTraceMove -o -