### PR TITLE
Improve CGame Exec scenegraph matching

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -375,6 +375,9 @@ void CGame::Exec()
 		}
 
 		switch (m_currentSceneId) {
+		case 0:
+		case 1:
+			break;
 		case 2:
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&CameraPcs), 1);
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&CharaPcs), 1);
@@ -390,7 +393,7 @@ void CGame::Exec()
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&MapPcs), 0);
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&CameraPcs), 6);
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&CharaPcs), 0);
-			System.AddScenegraph(reinterpret_cast<CProcess*>(&Game), 0);
+			System.AddScenegraph(reinterpret_cast<CProcess*>(&GamePcs), 0);
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&PartPcs), 0);
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&GbaPcs), 0);
 			System.AddScenegraph(reinterpret_cast<CProcess*>(&MiniGamePcs), 0);
@@ -419,6 +422,9 @@ void CGame::Exec()
 		System.ExecScenegraph();
 
 		switch (m_currentSceneId) {
+		case 0:
+		case 1:
+			break;
 		case 2:
 			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&CameraPcs), 1);
 			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&CharaPcs), 1);
@@ -437,7 +443,7 @@ void CGame::Exec()
 			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&CharaPcs), 0);
 			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&PartPcs), 0);
 			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&GbaPcs), 0);
-			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&Game), 0);
+			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&GamePcs), 0);
 			System.RemoveScenegraph(reinterpret_cast<CProcess*>(&MenuPcs), 0);
 			break;
 		case 5:


### PR DESCRIPTION
## Summary
- Add explicit empty scene cases for scene IDs 0 and 1 in both CGame::Exec scenegraph switches.
- Register/remove GamePcs for the game scene process instead of casting the CGame manager object.

## Objdiff Evidence
- main/game Exec__5CGameFv: 93.03855% -> 98.45805%
- LoadScript__5CGameFPc remains 79.04762%
- SaveScript__5CGameFPc remains 88.52941%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/game -o - --format json Exec__5CGameFv

## Plausibility
The explicit empty cases preserve source behavior while matching the dense scene switch shape. Using GamePcs is more coherent with the scenegraph API because it expects a CProcess, while Game is the manager.