### PR TITLE
Use look target for YmTraceMove

### DIFF
--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -54,7 +54,7 @@ void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, pppYmTraceMoveStep* par
 
 	_pppMngSt* pppMngSt = ppvMng;
 	pppYmTraceMoveWork* work = GetYmTraceMoveWork(pppYmTraceMove, param_3);
-	CGObject* owner = pppMngSt->m_owner;
+	CGObject* owner = pppMngSt->m_lookTarget;
 	Vec local_20;
 	Vec local_2c;
 	Vec local_8c;


### PR DESCRIPTION
## Summary
- Update pppFrameYmTraceMove to trace ppvMng->m_lookTarget instead of m_owner.
- This matches the original object's access at _pppMngSt + 0xDC and aligns with nearby Ym look-target effects.

## Evidence
- ninja passes.
- objdiff main/pppYmTraceMove .text: 99.16606% -> 99.16968%.
- pppFrameYmTraceMove: 99.01282% -> 99.01710%.
- pppConstructYmTraceMove remains 100.0%.

## Plausibility
- _pppMngSt::m_owner remains at 0xD8 for owner-based character effects.
- The target code for pppFrameYmTraceMove loads the object pointer from offset 0xDC, which corresponds to m_lookTarget in the current layout, and pppYmLookOn uses the same field for target-following behavior.