### PR TITLE
Improve pppRenderMiasma color setup

### DIFF
--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -263,7 +263,6 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
     Mtx secondLocalMtx;
     Mtx secondScaleMtx;
     GXColor stepColor;
-    GXColor* modelColor;
 
     Graphic.SetDrawDoneDebugData(0x31);
 
@@ -358,13 +357,12 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
         GXSetVtxDesc((GXAttr)0xB, GX_INDEX16);
         GXSetVtxDesc((GXAttr)0xD, GX_INDEX16);
 
-        modelColor = static_cast<GXColor*>(model->m_colors);
-        modelColor->r = 0xFF;
-        modelColor->g = 0xFF;
-        modelColor->b = 0xFF;
-        modelColor->a = 0xFF;
-        GXSetChanAmbColor(GX_COLOR0A0, *modelColor);
-        GXSetChanMatColor(GX_COLOR0A0, *modelColor);
+        static_cast<GXColor*>(model->m_colors)->r = 0xFF;
+        static_cast<GXColor*>(model->m_colors)->g = 0xFF;
+        static_cast<GXColor*>(model->m_colors)->b = 0xFF;
+        static_cast<GXColor*>(model->m_colors)->a = 0xFF;
+        GXSetChanAmbColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
+        GXSetChanMatColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
         GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
 
         GXLoadPosMtxImm(pppMiasma->m_object.m_drawMatrix.value, 0);
@@ -432,13 +430,12 @@ void pppRenderMiasma(pppMiasma* pppMiasma, pppMiasmaRenderStep* param_2, _pppCtr
             GXSetVtxDesc((GXAttr)0xB, GX_INDEX16);
             GXSetVtxDesc((GXAttr)0xD, GX_INDEX16);
 
-            modelColor = static_cast<GXColor*>(model->m_colors);
-            modelColor->r = 0xFF;
-            modelColor->g = 0xFF;
-            modelColor->b = 0xFF;
-            modelColor->a = 0xFF;
-            GXSetChanAmbColor(GX_COLOR0A0, *modelColor);
-            GXSetChanMatColor(GX_COLOR0A0, *modelColor);
+            static_cast<GXColor*>(model->m_colors)->r = 0xFF;
+            static_cast<GXColor*>(model->m_colors)->g = 0xFF;
+            static_cast<GXColor*>(model->m_colors)->b = 0xFF;
+            static_cast<GXColor*>(model->m_colors)->a = 0xFF;
+            GXSetChanAmbColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
+            GXSetChanMatColor(GX_COLOR0A0, *static_cast<GXColor*>(model->m_colors));
             GXSetChanCtrl(GX_COLOR0A0, GX_TRUE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE, GX_AF_NONE);
             GXLoadPosMtxImm(pppMiasma->m_object.m_drawMatrix.value, 0);
             GXSetNumTevStages(1);


### PR DESCRIPTION
## Summary
- Update `pppRenderMiasma` to write and pass `model->m_colors` directly instead of caching a `GXColor*` local.
- This matches the Ghidra-observed source shape where the color pointer is reloaded for each byte store and color register call.

## Evidence
- `ninja` succeeds.
- `pppRenderMiasma` objdiff improved from 97.91863% to 98.65524%.
- Current check: `build/tools/objdiff-cli diff -p . -u main/pppMiasma -o - pppRenderMiasma` reports 98.65524% for the 5604-byte symbol.

## Plausibility
- The change removes a cached helper pointer and uses the underlying model color member directly, matching the decompiled access pattern without hardcoded addresses or fake linkage.