### PR TITLE
Match pppConformBGNormal cylinder locals

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -28,6 +28,15 @@ struct ConformBgNormalState {
     u8 m_initialized;
 };
 
+struct CMapCylinderRaw {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    f32 m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 struct WeaponNodeFlagBits {
     signed char m_prg : 1;
     signed char m_unk40 : 1;
@@ -38,6 +47,8 @@ struct WeaponNodeFlagBits {
     signed char m_unk02 : 1;
     signed char m_unk01 : 1;
 };
+
+STATIC_ASSERT(sizeof(CMapCylinderRaw) == sizeof(CMapCylinder));
 
 static inline Vec* ConformBgNormalHitNormal(CGObject* owner)
 {
@@ -74,8 +85,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
     f64 trigValue;
     Mtx basisMtx;
     Mtx scaleMtx;
-    CMapCylinder firstCylinder;
-    CMapCylinder secondCylinder;
+    CMapCylinderRaw firstCylinder;
+    CMapCylinderRaw secondCylinder;
     Vec local_140;
     Vec local_14c;
     Vec local_158;
@@ -135,7 +146,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                 firstCylinder.m_axis.z = kPppConformBgNormalZero;
                 firstCylinder.m_radius = kPppConformBgNormalZero;
 
-                checkResult = MapMng.CheckHitCylinderNear(&firstCylinder, &firstRayDirection, 0xffffffff);
+                checkResult = MapMng.CheckHitCylinderNear(
+                    reinterpret_cast<CMapCylinder*>(&firstCylinder), &firstRayDirection, 0xffffffff);
                 hitFound = checkResult;
                 if (checkResult != 0) {
                     MapMng.m_hitMapObj->CalcHitPosition(&local_170);
@@ -244,7 +256,8 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
                     secondCylinder.m_axis.z = kPppConformBgNormalZero;
                     secondCylinder.m_radius = kPppConformBgNormalZero;
 
-                    hitFound = MapMng.CheckHitCylinderNear(&secondCylinder, &secondRayDirection, 0xffffffff);
+                    hitFound = MapMng.CheckHitCylinderNear(
+                        reinterpret_cast<CMapCylinder*>(&secondCylinder), &secondRayDirection, 0xffffffff);
                     if (hitFound != 0) {
                         MapMng.m_hitMapObj->CalcHitPosition(&local_170);
                         ppvMng->m_matrix.value[0][3] = local_170.x;


### PR DESCRIPTION
## Summary
- replace the manually initialized `CMapCylinder` stack locals in `pppFrameConformBGNormal` with a same-layout raw cylinder record
- keep the layout guarded with a static size assertion and pass the records through the existing `CMapCylinder` API at the map hit queries

## Evidence
- `ninja` succeeds
- `build/tools/objdiff-cli diff -p . -u main/pppConformBGNormal -o -` reports `.text` 100.0% and `.sdata2` 100.0%
- `pppFrameConformBGNormal`: 100.0% match, 1552b
- `pppConstructConformBGNormal`: 100.0% match, 44b
- build progress improved by +1552 matched code bytes, +1 matched function, and +12 matched data bytes

## Plausibility
The function initializes every cylinder field explicitly before each collision query. Using a plain stack collision record avoids constructor stores while preserving the same memory layout passed to `MapMng.CheckHitCylinderNear`, matching what the original source likely did for this local working data.