### PR TITLE
Remove current-only empty stubs

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -98,8 +98,6 @@ public:
     int ShopRequest(int, int, int, int, int, int, int);
     void CallShop(int, int, int, int, int);
     void SafeDeleteTempItem();
-    void ClampStatus(short&, unsigned short&);
-    void CalcArtifactStatus(int, int, int&, int&, int&, int&, int&);
     void CalcStatus();
     int CanPlayerUseItem();
     void ValidCmdList(int);

--- a/include/ffcc/pppYmMana.h
+++ b/include/ffcc/pppYmMana.h
@@ -22,7 +22,6 @@ void Mana_BeforeDrawShadowLockEnvCallback(CChara::CModel*, void*, void*, int);
 void Chara_DrawShadowMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*)[4]);
 void Mana_DrawMeshDLCallback(CChara::CModel*, void*, void*, int, int, float (*)[4]);
 void Mana_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*)[4], int);
-void MakeWave(Vec*, unsigned short*, float*, Vec, float, float);
 void CalcReflectionVector2(Vec*, S16Vec*, S16Vec*, long, unsigned long, unsigned long, float (*)[4], void*, unsigned long, _GXColor*, S16Vec2d*, S16Vec2d*, CChara::CNode*, PYmMana*, VYmMana*);
 
 #ifdef __cplusplus

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1740,26 +1740,6 @@ void CCaravanWork::SafeDeleteTempItem()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CCaravanWork::ClampStatus(short&, unsigned short&)
-{
-	// TODO
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CCaravanWork::CalcArtifactStatus(int, int, int&, int&, int&, int&, int&)
-{
-	// TODO
-}
-
-/*
- * --INFO--
  * PAL Address: 0x8009fa44
  * PAL Size: 1996b
  * EN Address: TODO

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -1198,16 +1198,6 @@ void Mana_BeforeDrawCallback(CChara::CModel*, void* workPtr, void* step, float (
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void MakeWave(Vec*, unsigned short*, float*, Vec, float, float)
-{
-	// TODO
-}
-
-/*
- * --INFO--
  * PAL Address: 0x800d5f7c
  * PAL Size: 404b
  * EN Address: TODO


### PR DESCRIPTION
## Summary
- Removed empty TODO-only stubs for `CCaravanWork::ClampStatus` and `CCaravanWork::CalcArtifactStatus`.
- Removed the empty TODO-only `MakeWave` stub from `pppYmMana`.
- Dropped the now-unused public declarations for those current-only symbols.

## Evidence
- `ninja` passes for `GCCP01`.
- `build/tools/objdiff-cli diff -p . -u main/pppYmMana -o -`: `MakeWave__FP3VecPUsPf3Vecff` is no longer present on the current side; neighboring `pppYmMana` scores checked unchanged.
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o -`: removed `ClampStatus__12CCaravanWorkFRsRUs` and `CalcArtifactStatus__12CCaravanWorkFiiRiRiRiRiRi` are absent; no PAL symbols exist for them.

## Plausibility
These were empty analysis/TODO stubs with no PAL symbol ownership and no references. Removing them is cleaner source/linkage and avoids carrying current-only functions that the target does not contain.
