### PR TITLE
Improve pppShape cache texture init

### DIFF
--- a/src/pppShape.cpp
+++ b/src/pppShape.cpp
@@ -118,7 +118,7 @@ void pppCacheDumpShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
         shapeOffset = *(short*)((int)currentFrame + 0x10);
         shapeBase = animData + shapeOffset;
         shapeIndex = 0;
-        shapeStep = 0;
+        shapeStep = shapeIndex;
         while (shapeIndex < *(short*)(shapeBase + 2)) {
             shapeEntry = (unsigned char*)(shapeBase + 8);
             shapeEntry += shapeStep;
@@ -171,7 +171,7 @@ void pppCacheLoadShapeTexture(pppShapeSt* shapeSt, CMaterialSet* materialSet)
         shapeOffset = *(short*)((int)currentFrame + 0x10);
         shapeBase = animData + shapeOffset;
         shapeIndex = 0;
-        shapeStep = 0;
+        shapeStep = shapeIndex;
         while (shapeIndex < *(short*)(shapeBase + 2)) {
             shapeEntry = (unsigned char*)(shapeBase + 8);
             shapeEntry += shapeStep;


### PR DESCRIPTION
## Summary
- Update both pppShape texture cache walkers to initialize shapeStep from the zeroed shapeIndex.
- This better reflects the shared zero initialization in the original loop setup without changing control flow or data layout.

## Objdiff evidence
- Unit: main/pppShape
- Before: fuzzy_match_percent 99.67255
- After: fuzzy_match_percent 99.69773
- Affected symbols remain size-stable:
  - pppCacheDumpShapeTexture__FP10pppShapeStP12CMaterialSet: 240 bytes, 99.0%
  - pppCacheLoadShapeTexture__FP10pppShapeStP12CMaterialSet: 240 bytes, 99.0%
- Data remains 100% matched: 168 / 168 bytes

## Plausibility
- The change expresses that shapeStep starts from the same zero value as shapeIndex before stepping by 8 through shape entries.
- No hardcoded addresses, fake labels, section forcing, or ABI hacks.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppShape -o /tmp/pppShape_final.json