### PR TITLE
Improve pppLaser frame cylinder layout

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -71,6 +71,15 @@ struct LaserColorData {
     pppCVECTOR m_color;
 };
 
+struct LaserMapCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    float m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 STATIC_ASSERT(offsetof(struct pppLaser, m_workArea) == 0x80);
 
 /*
@@ -194,7 +203,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     Vec localA;
     Mtx tempMtx;
     Mtx charaMtx;
-    CMapCylinder cyl;
+    LaserMapCylinder cyl;
 
     int emptyHistory;
     int fillIndex;
@@ -275,7 +284,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
         cyl.m_axis = localA;
         cyl.m_radius = LaserConst(kPppLaserZero);
 
-        int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
+        int check = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), &localA, 0xffffffff);
         int hit = 0;
         if (check != 0) {
             hit = 1;


### PR DESCRIPTION
## Summary
- Add a raw `LaserMapCylinder` layout for `pppFrameLaser` so the frame path does not emit `CMapCylinder` constructor initialization at function entry.
- Keep named cylinder field assignments and cast only at the `CMapMng::CheckHitCylinderNear` API boundary.

## Evidence
- `ninja` passes.
- `main/pppLaser` objdiff text improved from `98.108955%` to `98.75464%`.
- `extabindex` improved from `95.83333%` to `97.91667%`.
- Compiled `.text` size moved from `4984` bytes to `4952` bytes, closer to the expected `4956` bytes.
- `.rodata`, `.sdata2`, and `extab` remain at `100.0%`.

## Plausibility
The original code initializes the map cylinder fields at the point of use in `pppFrameLaser`; emitting the class constructor at function entry was extra generated code. The raw layout follows existing decomp patterns for map cylinder ABI layouts while preserving readable member access.