### PR TITLE
Fix pppConformBGNormal duplicate cylinder struct

### DIFF
--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -29,14 +29,6 @@ struct ConformBgNormalState {
     u8 m_initialized;
 };
 
-struct ConformMapCylinder {
-    Vec m_bottom;
-    Vec m_top;
-    Vec m_axis;
-    f32 m_radius;
-    Vec m_boundsMin;
-    Vec m_boundsMax;
-};
 STATIC_ASSERT(sizeof(ConformMapCylinder) == sizeof(CMapCylinder));
 
 struct WeaponNodeFlagBits {


### PR DESCRIPTION
## Summary
- Remove the duplicate local `ConformMapCylinder` definition in `src/pppConformBGNormal.cpp`.
- Keep the existing raw cylinder layout and `sizeof(CMapCylinder)` assert intact.

## Evidence
- Before this change, `ninja` failed compiling `src/pppConformBGNormal.cpp` with a redefinition of `ConformMapCylinder`.
- After this change, `ninja` completes and reports `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/pppConformBGNormal -o -` reports `.text`, `.sdata2`, extab, and extabindex at 100%, including `pppFrameConformBGNormal` and `pppConstructConformBGNormal`.

## Plausibility
- The removed block was an exact duplicate of the same local raw cylinder helper struct immediately above the state struct.
- No generated ABI artifacts, manual section placement, or address hacks were added.