### PR TITLE
Fix constrain camera dir PPP state globals

### DIFF
--- a/include/ffcc/ppp_linkage.h
+++ b/include/ffcc/ppp_linkage.h
@@ -10,6 +10,8 @@ extern "C" {
 extern int gPppCalcDisabled;
 extern unsigned char gPppInConstructor;
 extern unsigned char gPppInSubFrameCalc;
+extern int ppvUserStopPartF;
+extern unsigned char ppvIsLoopCalc;
 
 #ifdef __cplusplus
 }

--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -30,14 +30,14 @@ STATIC_ASSERT(offsetof(pppConstrainCameraDir, m_workArea) == 0x80);
 void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pppConstrainCameraDirUnkB* param_2,
                                 _pppCtrlTable* param_3)
 {
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         _pppMngSt* pppMngSt = ppvMng;
         float* value = (float*)(pppConstrainCameraDir->m_workArea + *param_3->m_serializedDataOffsets);
 
         CalcGraphValue((_pppPObject*)pppConstrainCameraDir, param_2->m_graphId, value[0], value[1], value[2],
                        param_2->m_dataValIndex, param_2->m_initWOrk, param_2->m_stepValue);
 
-        if ((gPppInConstructor != 1) && ((param_2->m_applyCameraInverse != 0 || param_2->m_applyPosition != 0))) {
+        if ((ppvIsLoopCalc != 1) && ((param_2->m_applyCameraInverse != 0 || param_2->m_applyPosition != 0))) {
             float cameraDirX = CameraPcs.m_directionX;
             float cameraDirY = CameraPcs.m_directionY;
             float cameraDirZ = CameraPcs.m_directionZ;


### PR DESCRIPTION
## What changed
- Declared `ppvUserStopPartF` and `ppvIsLoopCalc` in `ppp_linkage.h` alongside the other PPP globals.
- Updated `pppFrameConstrainCameraDir` to reference those shipped globals instead of the adjacent constructor/calc-disabled globals.

## Evidence
- `ninja` passes for GCCP01.
- `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir -o - pppFrameConstrainCameraDir` improved `pppFrameConstrainCameraDir` from 99.72441% to 99.80315%.
- Unit `.text` improved to 99.828766%.

## Plausibility
Ghidra and objdiff relocations both point at `ppvUserStopPartF` (`0x8032ED70`) and `ppvIsLoopCalc` (`0x8032ED78`) for this routine. These globals are already defined by `pppPart.cpp`; this change uses their real linkage instead of nearby PPP state globals.