### PR TITLE
Use ppvUserStopPartF for PPP guard checks

### DIFF
--- a/include/ffcc/partMng.h
+++ b/include/ffcc/partMng.h
@@ -516,6 +516,7 @@ extern CPartMng PartMng;
 
 extern _pppEnvSt* ppvEnv;
 extern _pppMngSt* ppvMng;
+extern int ppvUserStopPartF;
 extern int gPppCalcDisabled;
 extern unsigned char gPppInConstructor;
 

--- a/include/ffcc/ppp_linkage.h
+++ b/include/ffcc/ppp_linkage.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+extern int ppvUserStopPartF;
 extern int gPppCalcDisabled;
 extern unsigned char gPppInConstructor;
 extern unsigned char gPppInSubFrameCalc;

--- a/src/LocationTitle2.cpp
+++ b/src/LocationTitle2.cpp
@@ -223,7 +223,7 @@ extern "C" void pppFrameLocationTitle2(struct pppLocationTitle2* locationTitle, 
     LocationTitle2Work* work;
     LocationTitle2ColorBlock* colorData;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppAccele.cpp
+++ b/src/pppAccele.cpp
@@ -39,7 +39,7 @@ void pppAccele(_pppPObject* obj, pppAcceleUnkB* param_2, _pppCtrlTable* param_3)
 	float* pfVar1 = (float*)(obj->m_workArea + *param_3->m_serializedDataOffsets);
 	float* pfVar2 = (float*)(obj->m_workArea + param_3->m_serializedDataOffsets[1]);
 
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppAlignmentScale.cpp
+++ b/src/pppAlignmentScale.cpp
@@ -27,7 +27,7 @@ void pppFrameAlignmentScale(struct pppAlignmentScale*, struct pppAlignmentScaleD
     Vec objPos;
     Mtx scaleMtx;
 
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         pppMngSt = ppvMng;
         cameraPos.x = CameraPcs.m_positionX;
         cameraPos.y = CameraPcs.m_positionY;

--- a/src/pppAngAccele.cpp
+++ b/src/pppAngAccele.cpp
@@ -35,7 +35,7 @@ void pppAngAccele(_pppPObject* obj, pppAngAcceleUnkB* param_2, _pppCtrlTable* pa
     int* angularVelocity = (int*)(obj->m_workArea + *param_3->m_serializedDataOffsets);
     int* angularAccel = (int*)(obj->m_workArea + param_3->m_serializedDataOffsets[1]);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppAngMove.cpp
+++ b/src/pppAngMove.cpp
@@ -55,7 +55,7 @@ void pppAngMove(_pppPObject* basePtr, void* input, _pppCtrlTable* ctrlTable)
     PppAngMoveObj* b = (PppAngMoveObj*)(basePtr->m_workArea + offsets->b);
     PppAngMoveInput* inputData = (PppAngMoveInput*)input;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppAngle.cpp
+++ b/src/pppAngle.cpp
@@ -29,7 +29,7 @@ void pppAngleCon(_pppPObject* dest, _pppCtrlTable* ctrlTable)
  */
 void pppAngle(_pppPObject* dest, void* src, _pppCtrlTable* ctrlTable)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppBindOnlyPos.cpp
+++ b/src/pppBindOnlyPos.cpp
@@ -13,7 +13,7 @@
  */
 void pppFrameBindOnlyPos(_pppPObject*, void*, _pppCtrlTable*)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppBlurChara.cpp
+++ b/src/pppBlurChara.cpp
@@ -244,7 +244,7 @@ void pppFrameBlurChara(pppBlurChara* blurChara, pppBlurCharaUnkB* param_2, pppBl
     CCharaPcs::CHandle* handle;
     CChara::CModel* model;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -484,7 +484,7 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     Vec origin;
     Vec target;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 
@@ -641,7 +641,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
     spawnCount = 0;
     emitFrameCounter = &vBreathModel->m_emitFrameCounter;
 
-    if ((gPppCalcDisabled == 0) && (params->m_stepValue != 0xFFFF)) {
+    if ((ppvUserStopPartF == 0) && (params->m_stepValue != 0xFFFF)) {
         *emitFrameCounter = *emitFrameCounter + 1;
 
         for (i = 0; i < maxParticleCount; i++) {

--- a/src/pppChangeBGColor.cpp
+++ b/src/pppChangeBGColor.cpp
@@ -17,7 +17,7 @@ void pppFrameChangeBGColor(_pppPObject* pppChangeBGColor, void* param_2, _pppCtr
     unsigned char* data;
     int dataOffset;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -121,7 +121,7 @@ void pppRenderChangeTex(pppChangeTex*, pppChangeTexUnkB* step, pppChangeTexUnkC*
  */
 void pppFrameChangeTex(pppChangeTex* changeTex, pppChangeTexUnkB* step, pppChangeTexUnkC* data)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -227,7 +227,7 @@ void pppFrameCharaBreak(pppCharaBreak* charaBreak, CharaBreakUnkB* step, CharaBr
     u32 i;
 
     stepData = (CharaBreakStep*)step;
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppCharaZEnvCtrl.cpp
+++ b/src/pppCharaZEnvCtrl.cpp
@@ -14,7 +14,7 @@
  */
 void pppFrameCharaZEnvCtrl(pppCharaZEnvCtrl* pppCharaZEnvCtrl, pppCharaZEnvCtrlUnkB* param_2, _pppCtrlTable* param_3)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppColAccele.cpp
+++ b/src/pppColAccele.cpp
@@ -40,7 +40,7 @@ void pppColAccele(_pppPObject* object, void* data, _pppCtrlTable* ctrlTable)
     int frameData;
     short* accel2 = (short*)(object->m_workArea + offset1);
     
-    if (gPppCalcDisabled != 0)
+    if (ppvUserStopPartF != 0)
         return;
     
     frameData = *(int*)data;

--- a/src/pppColMove.cpp
+++ b/src/pppColMove.cpp
@@ -53,7 +53,7 @@ void pppColMove(void* param1, void* param2, void* param3)
     pppColMoveVec4S* sourceMove = (pppColMoveVec4S*)(object->m_workArea + input->id);
     pppColMoveVec4S* movementMove = (pppColMoveVec4S*)(object->m_workArea + input->pad);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppColor.cpp
+++ b/src/pppColor.cpp
@@ -40,7 +40,7 @@ void pppColor(_pppPObject* param1, void* param2, _pppCtrlTable* param3){
     _pppColorWork* work = (_pppColorWork*)(param1->m_workArea + param3->m_serializedDataOffsets[0]);
     pppColorStep* step = static_cast<pppColorStep*>(param2);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppColum.cpp
+++ b/src/pppColum.cpp
@@ -261,7 +261,7 @@ void pppFrameColum(pppColum *column, pppColumUnkB *param_2, pppColumUnkC *param_
     pppColumFrameWork* work;
     int i;
 
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         serializedDataOffsets = param_3->m_serializedDataOffsets;
         work = (pppColumFrameWork*)(column->m_object.m_workArea + serializedDataOffsets[3]);
         if (work->m_values == 0) {

--- a/src/pppConformBGNormal.cpp
+++ b/src/pppConformBGNormal.cpp
@@ -91,7 +91,7 @@ void pppFrameConformBGNormal(struct pppConformBGNormal* pppConformBGNormal, stru
     Vec secondRayDirection;
     s32 dataOffset;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppConstrainCameraDir.cpp
+++ b/src/pppConstrainCameraDir.cpp
@@ -30,7 +30,7 @@ STATIC_ASSERT(offsetof(pppConstrainCameraDir, m_workArea) == 0x80);
 void pppFrameConstrainCameraDir(pppConstrainCameraDir* pppConstrainCameraDir, pppConstrainCameraDirUnkB* param_2,
                                 _pppCtrlTable* param_3)
 {
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         _pppMngSt* pppMngSt = ppvMng;
         float* value = (float*)(pppConstrainCameraDir->m_workArea + *param_3->m_serializedDataOffsets);
 

--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -20,7 +20,7 @@
 void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCameraDirUnkB* param_2,
                                  _pppCtrlTable* param_3)
 {
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         _pppMngSt* pppMngSt = ppvMng;
         float* value = (float*)(param_1->m_workArea + *param_3->m_serializedDataOffsets);
 

--- a/src/pppConstrainCameraForLoc.cpp
+++ b/src/pppConstrainCameraForLoc.cpp
@@ -40,7 +40,7 @@ void pppDestructConstrainCameraForLoc(pppConstrainCameraForLoc* constrainCameraF
 	float* value;
 	CChara::CModel* model;
 
-	if (gPppCalcDisabled == 0) {
+	if (ppvUserStopPartF == 0) {
 		value = GetConstrainCameraWork(constrainCameraForLoc, data);
 		CGObject* obj = ppvMng->m_owner;
 		model = GetModelPtr(obj);

--- a/src/pppCorona.cpp
+++ b/src/pppCorona.cpp
@@ -143,7 +143,7 @@ void pppFrameCorona(_pppPObject* object, CoronaParam* data, _pppCtrlTable* ctrl)
     pppShapeSt* shape;
     s32 shapeId;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -242,7 +242,7 @@ void pppFrameCrystal(struct pppCrystal* pppCrystal, struct pppCrystalUnkB* param
 	CMapMesh* mapMesh;
 	int textureIndex;
 
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppCrystal2.cpp
+++ b/src/pppCrystal2.cpp
@@ -212,7 +212,7 @@ void pppFrameCrystal2(pppCrystal2* pppCrystal2, pppCrystal2UnkB* param_2, _pppCt
     float xCoord;
     float ySq;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppDrawMdlTs.cpp
+++ b/src/pppDrawMdlTs.cpp
@@ -83,7 +83,7 @@ void pppDrawMdlTs(struct _pppPObject* obj, struct PDrawMdlTs* data, struct _pppC
 {
     f32* texCoords = PppDrawMdlTsTexCoords(obj, ctrl);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppDrawShape.cpp
+++ b/src/pppDrawShape.cpp
@@ -95,7 +95,7 @@ void pppDrawShape(void* pppShape, ShapeControlData* data, void* additionalData){
  * JP Size: TODO
  */
 void pppCalcShape(void* pppShape, ShapeControlData* data, void* additionalData){
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppDrawShape2.cpp
+++ b/src/pppDrawShape2.cpp
@@ -94,7 +94,7 @@ void pppDrawShape2(void* param1, ShapeControlData* param2, void* param3){
  * JP Size: TODO
  */
 void pppCalcShape2(void* param1, ShapeControlData* param2, void* param3){
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -119,7 +119,7 @@ void pppRenderEmission(pppEmission*, pppEmissionUnkB*, pppEmissionUnkC*) {
  * JP Size: TODO
  */
 void pppFrameEmission(pppEmission* pppEmission_, pppEmissionUnkB* param_2, pppEmissionUnkC* param_3) {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppEraseCharaParts.cpp
+++ b/src/pppEraseCharaParts.cpp
@@ -35,7 +35,7 @@ void pppFrameEraseCharaParts(pppEraseCharaParts* pppEraseCharaParts, pppEraseCha
     u8* dstColor;
     u8* srcColor;
 
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         offsets = param_3->m_serializedDataOffsets;
         colorIndex = offsets[0];
         dstColor = GetEraseCharaPartsWork(pppEraseCharaParts, offsets[1]);

--- a/src/pppFilter.cpp
+++ b/src/pppFilter.cpp
@@ -70,7 +70,7 @@ void pppRenderFilter(_pppPObject* pppFilterObj, pppFilterUnkB* param_2, _pppCtrl
  */
 void pppFrameFilter(_pppPObject*, void*, _pppCtrlTable*)
 {
-	volatile int* stateFlag = &gPppCalcDisabled;
+	volatile int* stateFlag = &ppvUserStopPartF;
 	if (*stateFlag == 0) {
 		return;
 	}

--- a/src/pppKeShpTail.cpp
+++ b/src/pppKeShpTail.cpp
@@ -67,7 +67,7 @@ void pppKeShpTailCon(_pppPObject* obj, _pppCtrlTable* ctrlTable)
 void pppKeShpTail(_pppPObject* obj, pppKeShpTailUnkB*, pppKeShpTailUnkC* offsets)
 {
 	KeShpTailWork* work;
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -364,7 +364,7 @@ void pppKeShpTail2X(struct pppKeShpTail2X* obj, pppKeShpTail2XUnkB* param_2, _pp
     Vec initPos ATTRIBUTE_ALIGN(8);
     Vec pos ATTRIBUTE_ALIGN(8);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -410,7 +410,7 @@ void pppKeShpTail3X(struct pppKeShpTail3X* obj, struct pppKeShpTail3XUnkB* param
     Vec initPos ATTRIBUTE_ALIGN(8);
     Vec pos ATTRIBUTE_ALIGN(8);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -209,7 +209,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     int emptyHistory;
     int fillIndex;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
     if (step->m_stepValue == 0xFFFF) {

--- a/src/pppLensFlare.cpp
+++ b/src/pppLensFlare.cpp
@@ -105,7 +105,7 @@ void pppRenderLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTa
  */
 void pppFrameLensFlare(pppColum* obj, pppColumUnkB* unkB, _pppCtrlTable* ctrlTable)
 {
-	if (gPppCalcDisabled == 0) {
+	if (ppvUserStopPartF == 0) {
 		int shapeOffset = ctrlTable->m_serializedDataOffsets[2];
 		int colorOffset = ctrlTable->m_serializedDataOffsets[1];
 		u8* colorBase = obj->m_object.m_workArea + colorOffset;

--- a/src/pppLerpPos.cpp
+++ b/src/pppLerpPos.cpp
@@ -39,7 +39,7 @@ void pppFrameLerpPos(_pppPObject* object, pppLerpPosStep* step, _pppCtrlTable* c
     Vec local_2c;
     u32 count;
 
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         pppMngSt = ppvMng;
         historyPtr = GetLerpPosHistory(object, ctrl);
         if (*historyPtr == 0) {

--- a/src/pppLight.cpp
+++ b/src/pppLight.cpp
@@ -144,10 +144,10 @@ void pppLight(_pppPObject* param1, void* param2, void* param3)
 	PppLightStep* step = (PppLightStep*)param2;
 	_pppCtrlTable* ctrlTable = (_pppCtrlTable*)param3;
 
-	if (gPppCalcDisabled == 0) {
+	if (ppvUserStopPartF == 0) {
 		PppLightWork* work = (PppLightWork*)(param1->m_workArea + ctrlTable->m_serializedDataOffsets[0]);
 
-		if (gPppCalcDisabled != 0) {
+		if (ppvUserStopPartF != 0) {
 			goto create_light;
 		}
 

--- a/src/pppLocationTitle.cpp
+++ b/src/pppLocationTitle.cpp
@@ -145,7 +145,7 @@ void pppFrameLocationTitle(pppLocationTitle* pppLocationTitle, pppLocationTitleU
     float t;
     int nextCount;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1085,7 +1085,7 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, pppMana2UnkC* para
     u32 meshIndex;
     u32 vertexIndex;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppMiasma.cpp
+++ b/src/pppMiasma.cpp
@@ -128,7 +128,7 @@ void pppFrameMiasma(pppMiasma* pppMiasma, pppMiasmaFrameStep* param_2, _pppCtrlT
 {
     MiasmaFrameWork* work;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppMove.cpp
+++ b/src/pppMove.cpp
@@ -52,7 +52,7 @@ void pppMove(_pppPObject* basePtr, PppMoveInput* input, _pppCtrlTable* ctrlTable
     PppMoveObj* a = (PppMoveObj*)(basePtr->m_workArea + offsets->a);
     PppMoveObj* b = (PppMoveObj*)(basePtr->m_workArea + offsets->b);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppPObjPoint.cpp
+++ b/src/pppPObjPoint.cpp
@@ -16,7 +16,7 @@
  */
 void pppPObjPoint(_pppPObject* pObject, pppPObjPointStep* step, _pppCtrlTable* ctrlTable)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -2069,7 +2069,7 @@ void _pppDeadPart(_pppMngSt* pppMngSt)
 	pppMngStDeadRaw* mng = (pppMngStDeadRaw*)pppMngSt;
 	u32 maxDeleteFrame = 0;
 
-	if (gPppCalcDisabled == 0)
+	if (ppvUserStopPartF == 0)
 	{
 		_pppPObjLink* prev = &mng->m_objHead;
 		for (_pppPObjLink* obj = prev->m_next; obj != 0;)
@@ -2181,7 +2181,7 @@ void _pppDeadPart(_pppMngSt* pppMngSt)
 		}
 	}
 
-	if (gPppCalcDisabled == 0)
+	if (ppvUserStopPartF == 0)
 	{
 		mng->m_prevFrame = mng->m_currentFrame;
 		mng->m_currentFrame += 0x1000;
@@ -2216,7 +2216,7 @@ void _pppDeadPart(_pppMngSt* pppMngSt)
  */
 void _pppInitPart(_pppMngSt* pppMngSt)
 {
-	if (gPppCalcDisabled != 0)
+	if (ppvUserStopPartF != 0)
 	{
 		return;
 	}

--- a/src/pppPoint.cpp
+++ b/src/pppPoint.cpp
@@ -34,7 +34,7 @@ void pppPointCon(_pppPObject* pObject, _pppCtrlTable* ctrlTable)
  */
 void pppPoint(_pppPObject* pObject, pppPointStep* step, _pppCtrlTable* ctrlTable)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppPointAp.cpp
+++ b/src/pppPointAp.cpp
@@ -37,7 +37,7 @@ void pppPointAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
     u8* target = pObject->m_workArea + targetOffset;
     _pppPointApStep* payload = (_pppPointApStep*)step;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppPointApMtx.cpp
+++ b/src/pppPointApMtx.cpp
@@ -30,7 +30,7 @@ void pppPointApMtx(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
 	u8* state = pObject->m_workArea + offsets[1];
 	Mtx* target = (Mtx*)state;
 
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppPointRAp.cpp
+++ b/src/pppPointRAp.cpp
@@ -37,7 +37,7 @@ void pppPointRAp(_pppPObject* pObject, void* step, _pppCtrlTable* ctrlTable)
     pppPointRApOffsets* ctrlData = (pppPointRApOffsets*)ctrlTable->m_serializedDataOffsets;
     u8* state = pObject->m_workArea + ctrlData->m_stateOffset;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -143,7 +143,7 @@ void pppFrameRain(struct pppRain* pppRain, struct PRain* param_2, struct RAIN_DA
     RainWork* work;
     int randA;
     int randB;
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandCV.cpp
+++ b/src/pppRandCV.cpp
@@ -33,7 +33,7 @@ void pppRandCV(_pppPObject* basePtr, RandCVParams* in, _pppCtrlTable* ctrl)
 {
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandChar.cpp
+++ b/src/pppRandChar.cpp
@@ -28,7 +28,7 @@ void pppRandChar(_pppPObject* basePtr, RandCharParam* in, _pppCtrlTable* ctrl)
     u8* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownCV.cpp
+++ b/src/pppRandDownCV.cpp
@@ -41,7 +41,7 @@ void pppRandDownCV(_pppPObject* basePtr, RandDownCVParams* in, _pppCtrlTable* ct
     u8* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownChar.cpp
+++ b/src/pppRandDownChar.cpp
@@ -24,7 +24,7 @@ struct RandDownCharParams {
  */
 void pppRandDownChar(_pppPObject* basePtr, RandDownCharParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownFV.cpp
+++ b/src/pppRandDownFV.cpp
@@ -31,7 +31,7 @@ static inline float randf(float value, float scale)
  */
 void pppRandDownFV(_pppPObject* basePtr, RandDownFVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownFloat.cpp
+++ b/src/pppRandDownFloat.cpp
@@ -24,7 +24,7 @@ struct RandDownFloatParam {
  */
 void pppRandDownFloat(_pppPObject* basePtr, RandDownFloatParam* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownHCV.cpp
+++ b/src/pppRandDownHCV.cpp
@@ -32,7 +32,7 @@ void pppRandDownHCV(_pppPObject* basePtr, RandDownHCVParams* in, _pppCtrlTable* 
     s16* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownIV.cpp
+++ b/src/pppRandDownIV.cpp
@@ -39,7 +39,7 @@ static inline int randint(int value, float scale)
  */
 void pppRandDownIV(_pppPObject* basePtr, RandDownIVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownInt.cpp
+++ b/src/pppRandDownInt.cpp
@@ -24,7 +24,7 @@ struct RandDownIntParams {
  */
 void pppRandDownInt(_pppPObject* basePtr, RandDownIntParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandDownShort.cpp
+++ b/src/pppRandDownShort.cpp
@@ -27,7 +27,7 @@ void pppRandDownShort(_pppPObject* basePtr, RandDownShortParam* in, _pppCtrlTabl
     s16* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandFV.cpp
+++ b/src/pppRandFV.cpp
@@ -30,7 +30,7 @@ static float randf(float value, float scale)
  */
 void pppRandFV(_pppPObject* basePtr, RandFVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandFloat.cpp
+++ b/src/pppRandFloat.cpp
@@ -26,7 +26,7 @@ void pppRandFloat(_pppPObject* basePtrIn, RandFloatParam* in, _pppCtrlTable* ctr
 {
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandHCV.cpp
+++ b/src/pppRandHCV.cpp
@@ -32,7 +32,7 @@ void pppRandHCV(_pppPObject* basePtr, RandHCVParams* in, _pppCtrlTable* ctrl)
     s16* target;
     f32* randomValue;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandIV.cpp
+++ b/src/pppRandIV.cpp
@@ -33,7 +33,7 @@ void pppRandIV(_pppPObject* basePtr, RandIVParams* in, _pppCtrlTable* ctrl)
     f32 value;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandInt.cpp
+++ b/src/pppRandInt.cpp
@@ -26,7 +26,7 @@ void pppRandInt(_pppPObject* basePtr, RandIntParams* in, _pppCtrlTable* ctrl)
 {
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandShort.cpp
+++ b/src/pppRandShort.cpp
@@ -26,7 +26,7 @@ void pppRandShort(_pppPObject* basePtr, RandShortParams* in, _pppCtrlTable* ctrl
 {
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpCV.cpp
+++ b/src/pppRandUpCV.cpp
@@ -42,7 +42,7 @@ void pppRandUpCV(_pppPObject* basePtr, RandUpCVParam* in, _pppCtrlTable* ctrl)
     u8* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpChar.cpp
+++ b/src/pppRandUpChar.cpp
@@ -28,7 +28,7 @@ void pppRandUpChar(_pppPObject* basePtr, RandUpCharParam* in, _pppCtrlTable* ctr
     u8* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -30,7 +30,7 @@ static inline float randf(float value, float scale)
  */
 void pppRandUpFV(_pppPObject* basePtr, RandUpFVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpFloat.cpp
+++ b/src/pppRandUpFloat.cpp
@@ -23,7 +23,7 @@ struct RandUpFloatParam {
  * JP Size: TODO
  */
 void pppRandUpFloat(_pppPObject* basePtr, RandUpFloatParam* in, _pppCtrlTable* ctrl) {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpHCV.cpp
+++ b/src/pppRandUpHCV.cpp
@@ -32,7 +32,7 @@ void pppRandUpHCV(_pppPObject* basePtr, RandUpHCVParams* in, _pppCtrlTable* ctrl
     s16* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpIV.cpp
+++ b/src/pppRandUpIV.cpp
@@ -39,7 +39,7 @@ static inline int randint(int value, float scale)
  */
 void pppRandUpIV(_pppPObject* basePtr, RandUpIVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpInt.cpp
+++ b/src/pppRandUpInt.cpp
@@ -24,7 +24,7 @@ struct RandUpIntParams {
  */
 void pppRandUpInt(_pppPObject* basePtr, RandUpIntParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRandUpShort.cpp
+++ b/src/pppRandUpShort.cpp
@@ -27,7 +27,7 @@ void pppRandUpShort(_pppPObject* basePtr, RandUpShortParam* in, _pppCtrlTable* c
     s16* target;
     f32* valuePtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppRyjMegaBirth.cpp
+++ b/src/pppRyjMegaBirth.cpp
@@ -648,7 +648,7 @@ void calc_particle(_pppPObject* pObject, VRyjMegaBirth* work, PRyjMegaBirth* par
 	colorData = work->m_colorBlock;
 	maxParticles = work->m_numParticles;
 
-	if ((gPppCalcDisabled == 0) && (param->m_shapeIndex != 0xFFFF))
+	if ((ppvUserStopPartF == 0) && (param->m_shapeIndex != 0xFFFF))
 	{
 		work->m_emitTimer = work->m_emitTimer + 1;
 

--- a/src/pppRyjMegaBirthModel.cpp
+++ b/src/pppRyjMegaBirthModel.cpp
@@ -334,7 +334,7 @@ void calc_particle(_pppPObject* pObject, VRyjMegaBirthModel* work, PRyjMegaBirth
     maxParticles = work->m_numParticles;
     emitTimer = &work->m_emitTimer;
 
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         float posX = pObject->m_localMatrix.value[0][3];
         float posY = pObject->m_localMatrix.value[1][3];
         float posZ = pObject->m_localMatrix.value[2][3];

--- a/src/pppSRandCV.cpp
+++ b/src/pppSRandCV.cpp
@@ -43,7 +43,7 @@ static inline char randchar(char value, float scale)
  */
 void pppSRandCV(_pppPObject* basePtr, SRandCVParam* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSRandDownCV.cpp
+++ b/src/pppSRandDownCV.cpp
@@ -43,7 +43,7 @@ static inline char randchar(char value, float scale)
  */
 void pppSRandDownCV(_pppPObject* basePtr, SRandDownCVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSRandDownFV.cpp
+++ b/src/pppSRandDownFV.cpp
@@ -42,7 +42,7 @@ static inline float randfloat(float value, float scale)
  */
 void pppSRandDownFV(_pppPObject* basePtr, SRandDownFVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSRandDownHCV.cpp
+++ b/src/pppSRandDownHCV.cpp
@@ -41,7 +41,7 @@ static inline short randshort(short value, float scale)
  */
 void pppSRandDownHCV(_pppPObject* basePtr, SRandDownHCVParams* in, _pppCtrlTable* ctrl)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppSRandFV.cpp
+++ b/src/pppSRandFV.cpp
@@ -43,7 +43,7 @@ struct SRandFVParams {
 void pppSRandFV(_pppPObject* basePtr, SRandFVParams* in, _pppCtrlTable* ctrl)
 {
     f32* randVec;
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSRandHCV.cpp
+++ b/src/pppSRandHCV.cpp
@@ -42,7 +42,7 @@ static inline short randshort(short value, float scale)
  */
 void pppSRandHCV(_pppPObject* basePtr, SRandHCVParams* in, _pppCtrlTable* ctrl)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppSRandUpCV.cpp
+++ b/src/pppSRandUpCV.cpp
@@ -42,7 +42,7 @@ static inline char randchar(char value, float scale)
  */
 void pppSRandUpCV(_pppPObject* basePtr, SRandUpCVParam* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSRandUpFV.cpp
+++ b/src/pppSRandUpFV.cpp
@@ -42,7 +42,7 @@ static inline float randfloat(float value, float scale)
  */
 void pppSRandUpFV(_pppPObject* basePtr, SRandUpFVParams* in, _pppCtrlTable* ctrl)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSRandUpHCV.cpp
+++ b/src/pppSRandUpHCV.cpp
@@ -41,7 +41,7 @@ static inline short randshort(short value, float scale)
  */
 void pppSRandUpHCV(_pppPObject* basePtr, SRandUpHCVParams* in, _pppCtrlTable* ctrl)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppScale.cpp
+++ b/src/pppScale.cpp
@@ -41,7 +41,7 @@ void pppScaleCon(_pppPObject* obj, _pppCtrlTable* ctrlTable)
  */
 void pppScale(_pppPObject* obj, void* param2, _pppCtrlTable* ctrlTable)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppScaleLoopAuto.cpp
+++ b/src/pppScaleLoopAuto.cpp
@@ -47,7 +47,7 @@ struct pppScaleLoopAutoContext {
  * JP Size: TODO
  */
 void pppScaleLoopAuto(_pppPObject* arg1, pppScaleLoopAutoStep* arg2, pppScaleLoopAutoContext* arg3){
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSclAccele.cpp
+++ b/src/pppSclAccele.cpp
@@ -43,7 +43,7 @@ void pppSclAccele(_pppPObject* arg1, PppSclAcceleStep* arg2, _pppCtrlTable* arg3
     float* scale = (float*)(arg1->m_workArea + arg3->m_serializedDataOffsets[0]);
     float* accel = (float*)(arg1->m_workArea + arg3->m_serializedDataOffsets[1]);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppSclMove.cpp
+++ b/src/pppSclMove.cpp
@@ -50,7 +50,7 @@ void pppSclMove(_pppPObject* param1, void* param2, _pppCtrlTable* param3)
     float* dataA = (float*)(param1->m_workArea + offsets->m_scaleOffset);
     float* dataB = (float*)(param1->m_workArea + offsets->m_velocityOffset);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppScreenBlur.cpp
+++ b/src/pppScreenBlur.cpp
@@ -42,7 +42,7 @@ void pppRenderScreenBlur(_pppPObject* blur, pppScreenBlurUnkB* blurParam, _pppCt
  */
 void pppFrameScreenBlur(_pppPObject*, void*, _pppCtrlTable*)
 {
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         return;
     }
     return;

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -200,7 +200,7 @@ void pppRenderScreenBreak(PScreenBreak* pppScreenBreak, pppScreenBreakUnkB*, ppp
  */
 void pppFrameScreenBreak(PScreenBreak* pppScreenBreak, pppScreenBreakUnkB* param_2, pppScreenBreakUnkC* param_3)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppScreenQuake.cpp
+++ b/src/pppScreenQuake.cpp
@@ -35,7 +35,7 @@ void pppRenderScreenQuake(pppScreenQuake*, pppScreenQuakeStep*, pppScreenQuakeCt
  */
 void pppFrameScreenQuake(pppScreenQuake *quake, pppScreenQuakeStep *param2, pppScreenQuakeCtrl *param3)
 {
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         float *value = GetScreenQuakeWork(quake, param3);
 
         CalcGraphValue(&quake->m_object, param2->m_graphId, value[0], value[1], value[2], param2->m_dataValIndex, param2->m_initWOrk, param2->m_stepValue);

--- a/src/pppVertexAp.cpp
+++ b/src/pppVertexAp.cpp
@@ -68,7 +68,7 @@ void pppVertexAp(_pppPObject* parent, PVertexAp* dataRaw, void* ctrlRaw)
     s32 stateOffset = *ctrl->stateOffset;
     VertexApState* state = (VertexApState*)(parent->m_workArea + stateOffset);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         goto exitStub;
     }
 

--- a/src/pppVertexApAt.cpp
+++ b/src/pppVertexApAt.cpp
@@ -60,7 +60,7 @@ void pppVertexApAt(_pppPObject* parent, PVertexApAt* data, void* ctrl)
     s32 stateOffset = *vtxCtrl->stateOffset;
     VertexApAtState* state = (VertexApAtState*)(parent->m_workArea + stateOffset);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppVertexApLc.cpp
+++ b/src/pppVertexApLc.cpp
@@ -65,7 +65,7 @@ void pppVertexApLc(_pppPObject* parent, PVertexApLc* dataRaw, void* ctrlRaw)
     s32 stateOffset = *ctrl->stateOffset;
     VertexApLcState* state = (VertexApLcState*)(parent->m_workArea + stateOffset);
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppVertexApMtx.cpp
+++ b/src/pppVertexApMtx.cpp
@@ -71,7 +71,7 @@ void pppVertexApMtx(_pppPObject* parent, PVertexApMtx* dataRaw, void* ctrlRaw)
 	s32 stateOffset = *ctrl->stateOffset;
 	VertexApMtxState* state = (VertexApMtxState*)(parent->m_workArea + stateOffset);
 
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		goto exitStub;
 	}
 

--- a/src/pppVtMime.cpp
+++ b/src/pppVtMime.cpp
@@ -181,7 +181,7 @@ void pppVtMime(_pppPObject* object, void* step, _pppCtrlTable* ctrl)
     VtMimeState* state = GetVtMimeState(object, ctrl);
     VtMimeData* data = (VtMimeData*)step;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -517,7 +517,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     Vec origin;
     Vec target;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 
@@ -678,7 +678,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
     spawnCount = 0;
     emitFrameCounter = &vYmBreath->m_emitFrameCounter;
 
-    if ((gPppCalcDisabled == 0) && (params->m_shapeStepValue != 0xFFFF)) {
+    if ((ppvUserStopPartF == 0) && (params->m_shapeStepValue != 0xFFFF)) {
         *emitFrameCounter = *emitFrameCounter + 1;
 
         for (i = 0; i < maxParticleCount; i++) {

--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -120,7 +120,7 @@ void pppRenderYmChangeTex(pppYmChangeTex*, pppYmChangeTexStep* step, pppYmChange
  */
 void pppFrameYmChangeTex(pppYmChangeTex* ymChangeTex, pppYmChangeTexStep* step, pppYmChangeTexData* data)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -59,7 +59,7 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(
     float bottomY;
     float bottomZ;
 
-    if (gPppCalcDisabled == 0) {
+    if (ppvUserStopPartF == 0) {
         pppMngSt = ppvMng;
         zero = 0.0f;
         probeY = -2000.0f;

--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -229,7 +229,7 @@ void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, pppYmDef
 {
     YmDeformationMdlState* state;
 
-    if ((gPppCalcDisabled == 0) &&
+    if ((ppvUserStopPartF == 0) &&
         ((state = PppWorkArea<YmDeformationMdlState>(pppYmDeformationMdl, param_3, 2)),
          (param_2->m_dataValIndex != 0xFFFF))) {
         CalcGraphValue(

--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -266,7 +266,7 @@ void pppFrameYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, v
 	float cameraZ;
 	YmDeformationScreenStep* step;
 
-	if (gPppCalcDisabled == 0) {
+	if (ppvUserStopPartF == 0) {
 		step = (YmDeformationScreenStep*)param2;
 		serializedDataOffsets = ((YmDeformationScreenData*)param3)->m_serializedDataOffsets;
 		work = (VYmDeformationScreen*)(param1->m_object.m_workArea + serializedDataOffsets[2]);

--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -415,7 +415,7 @@ void pppFrameYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmDe
 {
 	VYmDeformationShp* state;
 
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -131,7 +131,7 @@ void pppFrameYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step, 
     s32 i;
 
     work = GetYmDrawMdlTexAnmWork(object, ctrl);
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -378,7 +378,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 	int emptyHistory;
 	int fillIndex;
 
-	if ((gPppCalcDisabled == 0) && (step->m_stepValue != 0xFFFF)) {
+	if ((ppvUserStopPartF == 0) && (step->m_stepValue != 0xFFFF)) {
 	work = (pppYmLaserWork*)(laser->m_workArea + data->m_serializedDataOffsets[2]);
 	emptyHistory = 0;
 

--- a/src/pppYmLookOn.cpp
+++ b/src/pppYmLookOn.cpp
@@ -31,7 +31,7 @@ void pppFrameYmLookOn(struct pppYmLookOn* pppYmLookOn, struct pppYmLookOnStep* p
     Vec local_4c;
     Vec local_58;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -741,7 +741,7 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, pppYmManaUnkC* p
     u32 vertexIndex;
     s32 setupOffset;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmMegaBirthShpTail2.cpp
+++ b/src/pppYmMegaBirthShpTail2.cpp
@@ -326,7 +326,7 @@ void pppFrameYmMegaBirthShpTail2(pppYmMegaBirthShpTail2* object, PYmMegaBirthShp
         worldMat = work->m_wmats;
         particleColor = work->m_colors;
 
-        if ((gPppCalcDisabled == 0) && (*(s32*)((u8*)&param->m_matrix + 4) != 0xFFFF)) {
+        if ((ppvUserStopPartF == 0) && (*(s32*)((u8*)&param->m_matrix + 4) != 0xFFFF)) {
             work->m_lifeLimit = work->m_lifeLimit + 1;
 
             for (; i < work->m_maxParticles; i++) {

--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -406,7 +406,7 @@ void pppFrameYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* object, PYmMegaBirthShp
         particleColor = work->m_colors;
         spawnCount = i;
 
-        if ((gPppCalcDisabled == 0) && (*(s32*)(paramPayload + 4) != 0xffff)) {
+        if ((ppvUserStopPartF == 0) && (*(s32*)(paramPayload + 4) != 0xffff)) {
             work->m_lifeLimit = work->m_lifeLimit + 1;
             for (; i < work->m_maxParticles; i++) {
                 if (*(u16*)(particleData + 0x22) != 0) {

--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -297,7 +297,7 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
     float z;
     Mtx rotMtx;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -241,7 +241,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, pppYmM
     float distance;
     float zero;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmMoveCircle.cpp
+++ b/src/pppYmMoveCircle.cpp
@@ -53,7 +53,7 @@ extern "C" void pppFrameYmMoveCircle(_pppPObject* basePtr, pppYmMoveCircleStep* 
     f32 sinAngle;
     f32 cosAngle;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmMoveParabola.cpp
+++ b/src/pppYmMoveParabola.cpp
@@ -41,7 +41,7 @@ static inline Vec* ParabolaBasePosition(_pppMngSt* mng)
  */
 extern "C" void pppFrameYmMoveParabola(struct pppYmMoveParabola* basePtr, struct pppYmMoveParabolaUnkB* stepData, struct pppYmMoveParabolaUnkC* offsetData)
 {
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -48,7 +48,7 @@ static inline Vec* GetYmTraceMoveBasePosition(_pppMngSt* pppMngSt)
  */
 void pppFrameYmTraceMove(pppYmTraceMove* pppYmTraceMove, pppYmTraceMoveStep* param_2, pppYmTraceMoveCtrl* param_3)
 {
-	if (gPppCalcDisabled != 0) {
+	if (ppvUserStopPartF != 0) {
 		return;
 	}
 

--- a/src/pppYmTracer.cpp
+++ b/src/pppYmTracer.cpp
@@ -197,7 +197,7 @@ void pppFrameYmTracer(pppYmTracer* pppYmTracer, pppYmTracerStep* param_2, pppYmT
     s32 i;
     TRACE_POLYGON* entriesPtr;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 

--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -228,7 +228,7 @@ void pppFrameYmTracer2(pppYmTracer2* pppYmTracer2, pppYmTracer2UnkB* param_2, pp
     Mtx MStack_78;
     float frameT;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Expose `ppvUserStopPartF` through the PPP headers.
- Update PPP frame/helper guard checks that Ghidra shows as `DAT_8032ed70` to use `ppvUserStopPartF` instead of `gPppCalcDisabled`.
- Leave the separate `gPppCalcDisabled` storage and `partMng.cpp` manager updates intact.

## Evidence
- `ninja` completes successfully.
- `ninja build/GCCP01/main.dol config/GCCP01/build.sha1` reports no pending work after the rebuild.
- Focused objdiff samples after the change:
  - `main/pppAccele`: `pppAccele` is 100.0% (was 99.871796%).
  - `main/pppMiasma`: `pppFrameMiasma` is 100.0% (was 99.945656%).
  - `main/pppAlignmentScale`: `pppFrameAlignmentScale` is 100.0% (was 99.92958%).
  - `main/pppYmMiasma`: `pppFrameYmMiasma` is 99.26738% (was 99.24064%).
  - `main/pppConstrainCameraDir`: `pppFrameConstrainCameraDir` is 99.76378% (was 99.72441%).

## Plausibility
Ghidra consistently identifies these PPP guard reads as `DAT_8032ed70`, which maps to `ppvUserStopPartF` in `config/GCCP01/symbols.txt`; `gPppCalcDisabled` is a distinct `.sbss` symbol at `0x8032ED94`. This is a symbol/linkage correction, not a control-flow rewrite.