### PR TITLE
Use user stop flag in breath particle updates

### DIFF
--- a/include/ffcc/ppp_linkage.h
+++ b/include/ffcc/ppp_linkage.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 extern int gPppCalcDisabled;
+extern int ppvUserStopPartF;
 extern unsigned char gPppInConstructor;
 extern unsigned char gPppInSubFrameCalc;
 

--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -484,7 +484,7 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     Vec origin;
     Vec target;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 
@@ -641,7 +641,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VBreathModel* vBreathModel, PBrea
     spawnCount = 0;
     emitFrameCounter = &vBreathModel->m_emitFrameCounter;
 
-    if ((gPppCalcDisabled == 0) && (params->m_stepValue != 0xFFFF)) {
+    if ((ppvUserStopPartF == 0) && (params->m_stepValue != 0xFFFF)) {
         *emitFrameCounter = *emitFrameCounter + 1;
 
         for (i = 0; i < maxParticleCount; i++) {

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -517,7 +517,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, pp
     Vec origin;
     Vec target;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 
@@ -678,7 +678,7 @@ void UpdateAllParticle(_pppPObject* pppObject, VYmBreath* vYmBreath, PYmBreath* 
     spawnCount = 0;
     emitFrameCounter = &vYmBreath->m_emitFrameCounter;
 
-    if ((gPppCalcDisabled == 0) && (params->m_shapeStepValue != 0xFFFF)) {
+    if ((ppvUserStopPartF == 0) && (params->m_shapeStepValue != 0xFFFF)) {
         *emitFrameCounter = *emitFrameCounter + 1;
 
         for (i = 0; i < maxParticleCount; i++) {


### PR DESCRIPTION
## Summary
- declare the existing `ppvUserStopPartF` PPP global in `ppp_linkage.h`
- use `ppvUserStopPartF` for the breath/YmBreath frame early-outs and emit gates
- matches the shipped small-data relocation expected by objdiff for these breath particle paths

## Objdiff evidence
- `main/pppBreathModel` `.text`: 99.5889% -> 99.59513%
- `pppFrameBreathModel`: 99.24051% -> 99.25633%
- `UpdateAllParticle__FP11_pppPObjectP12VBreathModelP12PBreathModelP6VColor`: 99.19455% -> 99.214005%
- `main/pppYmBreath` `.text`: 99.56188% -> 99.56807%
- `pppFrameYmBreath`: 99.11392% -> 99.129745%
- `UpdateAllParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColor`: 99.17164% -> 99.1903%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppBreathModel -o -`
- `build/tools/objdiff-cli diff -p . -u main/pppYmBreath -o -`
