### PR TITLE
Match CUSBPcs process table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -21,7 +21,7 @@ public:
         u8 m_reserved34[0xC];
     };
 
-    static CProcessTable m_table;
+    static CSmallProcessTable m_table;
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -28,7 +28,7 @@ inline CUSBPcs::CUSBPcs()
     table[9] = desc2[2];
 }
 
-CProcessTable CUSBPcs::m_table = {
+CSmallProcessTable CUSBPcs::m_table = {
     const_cast<char*>(sUsbPcsClassName),
     {
         0,


### PR DESCRIPTION
## Summary
- Change `CUSBPcs::m_table` from `CProcessTable` to `CSmallProcessTable`.
- This matches the PAL symbol size for `m_table__7CUSBPcs` (`0x11C`) instead of emitting a full `0x15C` table.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_usb -o -` after the change:
  - `.data`: `93.387764%` match, improved from `92.38095%` observed before the change.
  - `m_table__7CUSBPcs`: size `284` / `0x11C`, `100.0%` match, improved from the previous oversized `0x15C` table.
  - All 11 `p_usb` functions remain matched in the report.

## Plausibility
`system.h` already defines `CSmallProcessTable` as the `0x11C` table form. `p_usb` only has the three descriptor entries initialized by `CUSBPcs::CUSBPcs`, and `symbols.txt` identifies `m_table__7CUSBPcs` as `0x11C`, so this is a source-level table layout correction rather than compiler coaxing.
