### PR TITLE
Use stop flag in pppYmMelt frame

### DIFF
--- a/src/pppYmMelt.cpp
+++ b/src/pppYmMelt.cpp
@@ -12,6 +12,7 @@
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdlib.h>
 extern "C" {
 extern const float kPppYmMeltZero;
+extern int ppvUserStopPartF;
 u32 g_ymMelt;
 }
 extern const float FLOAT_80330af4;
@@ -297,7 +298,7 @@ void pppFrameYmMelt(PYmMelt* ymMelt, YmMeltCtrl* ctrl, PYmMeltDataOffsets* offse
     float z;
     Mtx rotMtx;
 
-    if (gPppCalcDisabled != 0) {
+    if (ppvUserStopPartF != 0) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Changed `pppFrameYmMelt` to guard on `ppvUserStopPartF`, matching the target object relocation instead of `gPppCalcDisabled`.
- Added a local extern declaration for the existing `ppvUserStopPartF` global defined by `pppPart.cpp`.

## Evidence
- `ninja` passes for GCCP01.
- `build/tools/objdiff-cli diff -p . -u main/pppYmMelt -o - pppFrameYmMelt` shows `.rela.text` has no relocation diff and `.sdata2` remains 100% matched.
- `pppYmMelt` report remains stable: `pppFrameYmMelt` 99.73529%, `pppRenderYmMelt` 98.96271%, helper functions unchanged at 100%.

## Plausibility
- `config/GCCP01/symbols.txt` lists `ppvUserStopPartF` and `gPppCalcDisabled` as separate globals; the target `pppFrameYmMelt` object references `ppvUserStopPartF` at this guard site.
- This is a source-level symbol correction, not a codegen hack.