### PR TITLE
Match PPP deformation loop checks

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -239,7 +239,7 @@ void pppFrameYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl, pppYmDef
             &pppYmDeformationMdl->m_object, param_2->m_graphId, state->m_values[2], state->m_values[3],
             state->m_values[4], param_2->m_payload0, param_2->m_payload1, param_2->m_payload2);
 
-        if (gPppInConstructor == 0) {
+        if (ppvIsLoopCalc == 0) {
             if (state->m_direction != 0) {
                 state->m_angle = state->m_angle + (int)state->m_values[2];
                 if (state->m_angle > param_2->m_payload3) {

--- a/src/pppYmDeformationScreen.cpp
+++ b/src/pppYmDeformationScreen.cpp
@@ -278,7 +278,7 @@ void pppFrameYmDeformationScreen(pppYmDeformationScreen* param1, void* param2, v
 			&param1->m_object, step->m_graphId, work->m_values[2], work->m_values[3], work->m_values[4],
 			step->m_payload0, step->m_payload1, step->m_payload2);
 
-		if (gPppInConstructor == 0) {
+		if (ppvIsLoopCalc == 0) {
 			if (work->m_direction != 0) {
 				work->m_angle += (int)work->m_values[2];
 				if (work->m_angle > step->m_payload3) {

--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -428,7 +428,7 @@ void pppFrameYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmDe
 		&pppYmDeformationShp_->m_object, param_2->m_graphId, state->m_values[2], state->m_values[3], state->m_values[4],
 		param_2->m_payload[3], param_2->m_payload[4], param_2->m_payload[5]);
 
-	if (gPppInConstructor != 0) {
+	if (ppvIsLoopCalc != 0) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- Use ppvIsLoopCalc for the Ym deformation frame update guards in Mdl, Screen, and Shp.
- This matches the target global used by those frame routines and removes the final relocation mismatch in each frame function.

## Objdiff evidence
- main/pppYmDeformationMdl pppFrameYmDeformationMdl: 99.93507% -> 100.0%
- main/pppYmDeformationScreen pppFrameYmDeformationScreen: 99.96124% -> 100.0%
- main/pppYmDeformationShp pppFrameYmDeformationShp: 99.9315% -> 100.0%
- main/pppYmDeformationMdl .text: 99.60177% -> 99.61283%

## Plausibility
- These routines should skip frame advancement during PPP loop calculation, matching the target address/symbol behavior.
- No hard-coded addresses, section forcing, or generated ctor/dtor/vtable changes.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o - pppFrameYmDeformationMdl
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationScreen -o - pppFrameYmDeformationScreen
- build/tools/objdiff-cli diff -p . -u main/pppYmDeformationShp -o - pppFrameYmDeformationShp