### PR TITLE
Remove unused astar debug strings

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -26,8 +26,6 @@ extern const float kInfiniteCost;
 extern const char kAStarStepDebugFormat[4];
 extern const char kAStarNewLine[2];
 }
-static const char kAStarCalcStepDebugFormat[] = "%d ";
-static const char kAStarCalcNewLine[] = "\n";
 #include "ffcc/system.h"
 #include "ffcc/vector.h"
 


### PR DESCRIPTION
## Summary
- Remove two unused file-local astar debug string constants that duplicated the real named .sdata2 debug format symbols.
- Leaves astar code generation unchanged while improving the local .sdata2 symbol diff.

## Evidence
- Built with: ninja
- astar code scores unchanged:
  - getEscapePos__6CAStarFR3VecR3Vecii: 91.10274%
  - drawAStar__6CAStarFv: 93.73143%
  - calcAStar__6CAStarFv: 98.14815%
  - check__6CAStarFiiRQ26CAStar6CATemp: 91.1446%
- astar [.sdata2-0] improved from 81.08108% to 90.909096% in objdiff.

## Plausibility
The removed constants were never referenced. The code already uses the real exported kAStarStepDebugFormat and kAStarNewLine symbols for calcAStar output, so keeping extra local duplicates was not plausible original source.