### PR TITLE
Match maphit rodata ordering

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -20,6 +20,7 @@ extern "C" const float kMapHitEdgeMinT;
 extern "C" const float kMapHitVertexOffsetScale;
 extern "C" const float kMapHitRadiusScale;
 extern "C" const double kMapHitRadiusBase;
+extern const char s_maphit_cpp[] = "maphit.cpp";
 extern "C" const char sOldMidFormat[] = {
     (char)0x8C, (char)0xC3, (char)0x82, (char)0xA2, (char)0x20, (char)0x4D, (char)0x49, (char)0x44,
     (char)0x20, (char)0x82, (char)0xCC, (char)0x8C, (char)0x60, (char)0x8E, (char)0xAE, (char)0x82,
@@ -39,8 +40,6 @@ static inline unsigned char* Ptr(void* p, unsigned int offset)
     return reinterpret_cast<unsigned char*>(p) + offset;
 }
 }
-
-extern const char s_maphit_cpp[] = "maphit.cpp";
 
 int g_hit_edge_idx_min;
 float g_hit_t;


### PR DESCRIPTION
## What changed
- Moved the `s_maphit_cpp` definition before `sOldMidFormat` in `src/maphit.cpp`.
- This matches the symbol-file/MAP order for the unit's `.rodata`: `s_maphit_cpp` first, then `sOldMidFormat` at offset `0x0c`.

## Evidence
- `ninja` passes.
- `powerpc-eabi-nm -S -n build/GCCP01/src/maphit.o` now reports:
  - `00000000 0000000b R s_maphit_cpp`
  - `0000000c 00000017 R sOldMidFormat`
- `objdiff-cli` still reports both strings as 100% matched and `CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUsUsUl` unchanged at 93.0%.

## Plausibility
- This is a source-layout correction for real string objects, not compiler coaxing or fake labels.
