### PR TITLE
Match CTexScroll destructor

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -130,7 +130,7 @@ static inline CLightPcs::CBumpLight* GetMapBumpLight(int bumpIndex)
     return LightPcs.GetBumpLight(static_cast<CLightPcs::TARGET>(1), bumpIndex);
 }
 
-static inline void DestroyTexScrollKeyFrame(void*& keyFrame)
+static inline void DestroyTexScrollKeyFrame(void* keyFrame)
 {
     if (keyFrame == 0) {
         return;
@@ -161,7 +161,6 @@ static inline void DestroyTexScrollKeyFrame(void*& keyFrame)
     }
 
     operator delete(keyFrame);
-    keyFrame = 0;
 }
 
 static void ReleaseRefNonNull(CRef* object)
@@ -2324,11 +2323,19 @@ void CMaterialMan::ErrorTexMapIdCur()
 CTexScroll::~CTexScroll()
 {
     if (m_type0 == 2) {
-        DestroyTexScrollKeyFrame(*reinterpret_cast<void**>(&m_u1));
+        void* keyFrame = *reinterpret_cast<void**>(&m_u1);
+        if (keyFrame != 0) {
+            DestroyTexScrollKeyFrame(keyFrame);
+            *reinterpret_cast<void**>(&m_u1) = 0;
+        }
     }
 
     if (m_type1 == 2) {
-        DestroyTexScrollKeyFrame(*reinterpret_cast<void**>(&m_v1));
+        void* keyFrame = *reinterpret_cast<void**>(&m_v1);
+        if (keyFrame != 0) {
+            DestroyTexScrollKeyFrame(keyFrame);
+            *reinterpret_cast<void**>(&m_v1) = 0;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Match `CTexScroll::~CTexScroll` in `main/materialman` by keeping the keyframe pointer local while clearing the owning scroll member after deletion.
- This mirrors the target control flow: delete keyframe tables, delete the keyframe, then zero `m_u1` / `m_v1` at the call site.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/materialman -o /tmp/materialman_pr.json __dt__10CTexScrollFv` reports `__dt__10CTexScrollFv` at `100.0%` for 364 bytes.
- Build progress improved by one matched function: game code matched bytes `274284 -> 274648`, functions `1938 -> 1939`.

## Plausibility
- Avoids address hacks or manual generated functions.
- Keeps the real `CTexScroll` destructor and keyframe cleanup semantics while matching the compiler original pointer lifetime and codegen.