### PR TITLE
Use external CharaBreak vertex flag constants

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -19,9 +19,9 @@
 #include "ffcc/ppp_linkage.h"
 
 extern Vec kPppCharaBreakUpVector;
-extern const int kCharaBreakInitialVertexFlag0 = 0;
-extern const int kCharaBreakInitialVertexFlag1 = 0;
-extern const int kCharaBreakInitialVertexFlag2 = 0;
+extern const int kCharaBreakInitialVertexFlag0;
+extern const int kCharaBreakInitialVertexFlag1;
+extern const int kCharaBreakInitialVertexFlag2;
 extern "C" const char s_pppCharaBreak_cpp[24] = "pppCharaBreak.cpp";
 extern const float FLOAT_80332048;
 extern const float FLOAT_8033204c;


### PR DESCRIPTION
## Summary
- Change pppCharaBreak initial vertex flag constants from duplicate definitions to external declarations.
- This keeps the flag data owned by its existing target symbols instead of emitting duplicate data in pppCharaBreak.o.

## Evidence
- ninja passes.
- pppCharaBreak code scores are unchanged:
  - pppFrameCharaBreak: 97.05965%
  - pppDestructCharaBreak: 97.82417%
  - UpdatePolygonData: 93.04144%
- Current pppCharaBreak.o extra .sdata2 shrinks from 32 bytes to 16 bytes after removing the three duplicate flag definitions.

## Plausibility
- The constants are already listed as real symbols adjacent to the pppCharaBreak data in config/GCCP01/symbols.txt.
- The source now references those constants instead of defining extra copies in this unit.