### PR TITLE
Inline unused p_light helpers

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -101,7 +101,7 @@ static inline double U32ToDouble(unsigned int value)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CLightPcs::CLight::Set(CLightPcs::CLight* light)
+inline void CLightPcs::CLight::Set(CLightPcs::CLight* light)
 {
     *this = *light;
 
@@ -494,7 +494,7 @@ CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs
  * JP Address: TODO
  * JP Size: TODO
  */
-CLightPcs::CBumpLight* CLightPcs::GetFreeBumpLight(CLightPcs::TARGET target)
+inline CLightPcs::CBumpLight* CLightPcs::GetFreeBumpLight(CLightPcs::TARGET target)
 {
     CBumpLight* bumpLights = &m_bumpLights[target * 8];
 
@@ -516,7 +516,7 @@ CLightPcs::CBumpLight* CLightPcs::GetFreeBumpLight(CLightPcs::TARGET target)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CLightPcs::Clear()
+inline void CLightPcs::Clear()
 {
     m_numDiffuse = 0;
     m_loadedLightCount = 0;


### PR DESCRIPTION
## What changed
- Marked three PAL-unused `p_light` helper definitions as `inline`:
  - `CLightPcs::CLight::Set`
  - `CLightPcs::GetFreeBumpLight`
  - `CLightPcs::Clear`

## Evidence
- `ninja` succeeds.
- The extra emitted PAL symbols are gone from `build/GCCP01/src/p_light.o`.
- Compiled `p_light` `.text` shrank from `0x2944` to `0x26b8`, much closer to the target `0x26a0`.
- `main/p_light` `.text` objdiff improved from `91.32726%` to `91.54288%`.
- `extabindex` remains at `97.91667%`; `extab` remains at `98.125%`.

## Plausibility
The affected functions are already documented as `PAL Address: UNUSED` while retaining EN addresses. Marking them inline follows the project rule for keeping known unused functions in source without emitting PAL code or introducing manual linkage hacks.