### PR TITLE
Match pppLaser constant layout

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -21,12 +21,12 @@
 extern const f32 kPppLaserZero = 0.0f;
 extern const f32 FLOAT_8033342c = 1.0f;
 extern const f32 FLOAT_80333430 = 2.0f;
-extern const f32 kMenuArtiNegativeOne = -1.0f;
-extern const f32 kMenuArtiDefaultScale = 1.2f;
-extern const f32 kMenuArtiBoundsMax = 10000000000.0f;
-extern const f32 kMenuArtiBoundsMin = -10000000000.0f;
-extern const f32 kMenuArtiHalfTileOffset = 15.5f;
-extern const f32 kMenuArtiTau = 6.2831855f;
+extern const f32 kMenuArtiNegativeOne;
+extern const f32 kMenuArtiDefaultScale;
+extern const f32 kMenuArtiBoundsMax;
+extern const f32 kMenuArtiBoundsMin;
+extern const f32 kMenuArtiHalfTileOffset;
+extern const f32 kMenuArtiTau;
 
 #define kPppLaserNegativeOne kMenuArtiNegativeOne
 #define kPppLaserDefaultScale kMenuArtiDefaultScale
@@ -619,3 +619,10 @@ extern "C" void pppRenderLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *p
         }
     }
 }
+
+extern const f32 kMenuArtiNegativeOne = -1.0f;
+extern const f32 kMenuArtiDefaultScale = 1.2f;
+extern const f32 kMenuArtiBoundsMax = 10000000000.0f;
+extern const f32 kMenuArtiBoundsMin = -10000000000.0f;
+extern const f32 kMenuArtiHalfTileOffset = 15.5f;
+extern const f32 kMenuArtiTau = 6.2831855f;


### PR DESCRIPTION
## Summary
- Move the shared pppLaser/menu-artifact float definitions after the render implementation while keeping early declarations for source use.
- This lets MWCC emit the local double conversion constants before the menu-artifact floats, matching the PAL .sdata2 layout.

## Evidence
- ninja passes.
- objdiff for main/pppLaser:
  - .rodata: 100.0%
  - .sdata2: 100.0%
  - .text: 97.830505% unchanged
  - pppRenderLaser: 98.03458% unchanged
  - pppFrameLaser: 96.702995% unchanged

## Plausibility
- The change only adjusts file-scope constant definition order; the constants remain real definitions with the same values.
- The resulting order matches the PAL pppLaser.cpp layout: laser scalars, compiler-generated double constants, then the menu-artifact float constants.
