### PR TITLE
Avoid map cylinder init in laser frames

### DIFF
--- a/src/pppLaser.cpp
+++ b/src/pppLaser.cpp
@@ -71,12 +71,22 @@ struct LaserColorData {
     pppCVECTOR m_color;
 };
 
+struct LaserMapCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    float m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 static inline LaserWork* GetLaserWork(pppLaser* laser, _pppCtrlTable* ctrlTable)
 {
     return reinterpret_cast<LaserWork*>(laser->m_workArea + ctrlTable->m_serializedDataOffsets[2]);
 }
 
 STATIC_ASSERT(offsetof(struct pppLaser, m_workArea) == 0x80);
+STATIC_ASSERT(sizeof(LaserMapCylinder) == sizeof(CMapCylinder));
 
 /*
  * --INFO--
@@ -199,7 +209,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
     Vec localA;
     Mtx tempMtx;
     Mtx charaMtx;
-    CMapCylinder cyl;
+    LaserMapCylinder cyl;
 
     int emptyHistory;
     int fillIndex;
@@ -280,7 +290,7 @@ extern "C" void pppFrameLaser(struct pppLaser *pppLaser, struct pppLaserUnkB *pa
         cyl.m_axis = localA;
         cyl.m_radius = LaserConst(kPppLaserZero);
 
-        int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
+        int check = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), &localA, 0xffffffff);
         int hit = 0;
         if (check != 0) {
             hit = 1;

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -65,12 +65,22 @@ struct pppYmLaserColorData {
 	pppCVECTOR m_color;
 };
 
+struct pppYmLaserMapCylinder {
+	Vec m_bottom;
+	Vec m_top;
+	Vec m_axis;
+	float m_radius;
+	Vec m_boundsMin;
+	Vec m_boundsMax;
+};
+
 static inline pppYmLaserWork* GetYmLaserWork(pppYmLaser* laser, _pppCtrlTable* ctrlTable)
 {
 	return reinterpret_cast<pppYmLaserWork*>(laser->m_workArea + ctrlTable->m_serializedDataOffsets[2]);
 }
 
 STATIC_ASSERT(offsetof(struct pppYmLaser, m_workArea) == 0x80);
+STATIC_ASSERT(sizeof(pppYmLaserMapCylinder) == sizeof(CMapCylinder));
 
 /*
  * --INFO--
@@ -360,7 +370,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 	Vec localA;
 	Mtx tempMtx;
 	Mtx charaMtx;
-	CMapCylinder cyl;
+	pppYmLaserMapCylinder cyl;
 	int emptyHistory;
 	int fillIndex;
 
@@ -435,7 +445,7 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCtr
 		cyl.m_axis = localA;
 		cyl.m_radius = kPppYmLaserOne;
 
-		int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
+		int check = MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), &localA, 0xffffffff);
 		int hit = 0;
 		if (check != 0) {
 			hit = 1;


### PR DESCRIPTION
## Summary
- Add layout-compatible raw map cylinder structs for pppLaser and pppYmLaser frame code.
- Pass those raw cylinders to the existing CMapCylinder API only at the call boundary.
- Avoid the CMapCylinder default constructor stores that do not appear in the target frame functions.

## Evidence
- ninja: clean build.
- main/pppLaser pppFrameLaser: 96.702995% -> 98.882835%.
- main/pppLaser .text: 97.830505% -> 98.47619%; extabindex section: 95.83333% -> 97.91667%.
- main/pppYmLaser pppFrameYmLaser: 96.4526% -> 98.899086%.
- main/pppYmLaser .text: 97.71206% -> 98.4059%; extabindex section: 95.83333% -> 97.91667%.

## Plausibility
- The target code writes every cylinder member used before calling CheckHitCylinderNear, with no initial default bounds stores.
- This follows existing raw-cylinder patterns in nearby particle/map code while preserving typed member access and API calls.