### PR TITLE
Fix FunnyShape default bound constant

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -13,7 +13,7 @@ extern const GXColor kFunnyShapeTextureChanColor;
 extern const GXColor kFunnyShapeTextureColor;
 extern GXColor kFunnyShapeRenderColor;
 extern const float kFunnyShapeBoundsMinInitial;
-extern const float kFunnyShapeBoundsMaxInitial = -1000.0f;
+extern const float kFunnyShapeBoundsMaxInitial = 0.0f;
 extern const float kFunnyShapeZero;
 extern const float kFunnyShapeViewportScale = 2.0f;
 extern const float kFunnyShapeOne;


### PR DESCRIPTION
## Summary
- Correct `kFunnyShapeBoundsMaxInitial` from `-1000.0f` to `0.0f` in `FunnyShape.cpp`.
- This matches the target value used by the default `CFunnyShape::RenderShape()` call path.

## Evidence
- `ninja` passes for GCCP01.
- `build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - RenderShape__11CFunnyShapeFv`
  - `kFunnyShapeBoundsMaxInitial`: `50.0%` -> `100.0%`
  - `RenderShape__11CFunnyShapeFv`: unchanged at `99.97419%`
  - `RenderShape__11CFunnyShapeFP16FS_tagOAN3_SHAPE5Vec2df`: unchanged at `72.78014%`
  - `.text`, `.sdata2`, `extab`, and `extabindex` section scores unchanged; no regressions observed.

## Plausibility
- The parameterless `RenderShape()` passes this constant as the default angle. The target decompilation uses the zero-valued slot for that call, so `0.0f` is a plausible original-source value rather than a compiler-output workaround.