### PR TITLE
Match process table static initializers

### DIFF
--- a/include/ffcc/p_game.h
+++ b/include/ffcc/p_game.h
@@ -33,15 +33,17 @@ public:
         static CProcessTableCallback desc7 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw2__8CGamePcsFv)};
         static CProcessTableCallback desc8 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc2__8CGamePcsFv)};
 
-        m_table.m_fields.m_create = desc0;
-        m_table.m_fields.m_destroy = desc1;
-        m_table.m_fields.m_entries[0].m_callback = desc2;
-        m_table.m_fields.m_entries[1].m_callback = desc3;
-        m_table.m_fields.m_entries[2].m_callback = desc4;
-        m_table.m_fields.m_entries[3].m_callback = desc5;
-        m_table.m_fields.m_entries[4].m_callback = desc6;
-        m_table.m_fields.m_entries[5].m_callback = desc7;
-        m_table.m_fields.m_entries[6].m_callback = desc8;
+        CProcessTable* table = &m_table;
+
+        table->m_fields.m_create = desc0;
+        table->m_fields.m_destroy = desc1;
+        table->m_fields.m_entries[0].m_callback = desc2;
+        table->m_fields.m_entries[1].m_callback = desc3;
+        table->m_fields.m_entries[2].m_callback = desc4;
+        table->m_fields.m_entries[3].m_callback = desc5;
+        table->m_fields.m_entries[4].m_callback = desc6;
+        table->m_fields.m_entries[5].m_callback = desc7;
+        table->m_fields.m_entries[6].m_callback = desc8;
     }
 
     void Init();

--- a/include/ffcc/p_mc.h
+++ b/include/ffcc/p_mc.h
@@ -20,9 +20,11 @@ public:
         static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__6CMcPcsFv)};
         static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__6CMcPcsFv)};
 
-        m_table.m_fields.m_create = desc0;
-        m_table.m_fields.m_destroy = desc1;
-        m_table.m_fields.m_entries[0].m_callback = desc2;
+        CProcessTable* table = &m_table;
+
+        table->m_fields.m_create = desc0;
+        table->m_fields.m_destroy = desc1;
+        table->m_fields.m_entries[0].m_callback = desc2;
     }
 
     void Init();

--- a/include/ffcc/p_sound.h
+++ b/include/ffcc/p_sound.h
@@ -22,10 +22,12 @@ public:
         static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__9CSoundPcsFv)};
         static CProcessTableCallback desc3 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__9CSoundPcsFv)};
 
-        m_table.m_fields.m_create = desc0;
-        m_table.m_fields.m_destroy = desc1;
-        m_table.m_fields.m_entries[0].m_callback = desc2;
-        m_table.m_fields.m_entries[1].m_callback = desc3;
+        CProcessTable* table = &m_table;
+
+        table->m_fields.m_create = desc0;
+        table->m_fields.m_destroy = desc1;
+        table->m_fields.m_entries[0].m_callback = desc2;
+        table->m_fields.m_entries[1].m_callback = desc3;
     }
 
     void draw();

--- a/include/ffcc/p_system.h
+++ b/include/ffcc/p_system.h
@@ -20,9 +20,11 @@ public:
         static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__10CSystemPcsFv)};
         static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__10CSystemPcsFv)};
 
-        m_table.m_fields.m_create = desc0;
-        m_table.m_fields.m_destroy = desc1;
-        m_table.m_fields.m_entries[0].m_callback = desc2;
+        CProcessTable* table = &m_table;
+
+        table->m_fields.m_create = desc0;
+        table->m_fields.m_destroy = desc1;
+        table->m_fields.m_entries[0].m_callback = desc2;
     }
 
     void Init();

--- a/src/p_gba.cpp
+++ b/src/p_gba.cpp
@@ -27,10 +27,12 @@ inline CGbaPcs::CGbaPcs()
 	static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__7CGbaPcsFv)};
 	static CProcessTableCallback desc3 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__7CGbaPcsFv)};
 
-	m_table.m_fields.m_create = desc0;
-	m_table.m_fields.m_destroy = desc1;
-	m_table.m_fields.m_entries[0].m_callback = desc2;
-	m_table.m_fields.m_entries[1].m_callback = desc3;
+	CProcessTable* table = &m_table;
+
+	table->m_fields.m_create = desc0;
+	table->m_fields.m_destroy = desc1;
+	table->m_fields.m_entries[0].m_callback = desc2;
+	table->m_fields.m_entries[1].m_callback = desc3;
 }
 
 CProcessTable CGbaPcs::m_table = {

--- a/src/p_sample.cpp
+++ b/src/p_sample.cpp
@@ -16,10 +16,12 @@ inline CSamplePcs::CSamplePcs()
 	static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func0__10CSamplePcsFv)};
 	static CProcessTableCallback desc3 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func1__10CSamplePcsFv)};
 
-	m_table.m_fields.m_create = desc0;
-	m_table.m_fields.m_destroy = desc1;
-	m_table.m_fields.m_entries[0].m_callback = desc2;
-	m_table.m_fields.m_entries[1].m_callback = desc3;
+	CProcessTable* table = &m_table;
+
+	table->m_fields.m_create = desc0;
+	table->m_fields.m_destroy = desc1;
+	table->m_fields.m_entries[0].m_callback = desc2;
+	table->m_fields.m_entries[1].m_callback = desc3;
 }
 
 CProcessTable CSamplePcs::m_table = {

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -16,9 +16,11 @@ inline CUSBPcs::CUSBPcs()
     static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
     static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 
-    m_table.m_fields.m_create = desc0;
-    m_table.m_fields.m_destroy = desc1;
-    m_table.m_fields.m_entries[0].m_callback = desc2;
+    CProcessTable* table = &m_table;
+
+    table->m_fields.m_create = desc0;
+    table->m_fields.m_destroy = desc1;
+    table->m_fields.m_entries[0].m_callback = desc2;
 }
 
 CProcessTable CUSBPcs::m_table = {


### PR DESCRIPTION
## Summary
- Materialize process table pointers before copying constructor-local callback descriptors.
- Matches static initializers for CGamePcs, CMcPcs, CSystemPcs, CSoundPcs, CGbaPcs, and CSamplePcs.
- Improves CUSBPcs static initializer code; its remaining mismatch is a separate table/vtable layout issue.

## Evidence
- ninja passes.
- main/p_game __sinit_p_game_cpp: 98.17073% -> 100.0% (328 bytes)
- main/p_mc __sinit_p_mc_cpp: 98.181816% -> 100.0% (132 bytes)
- main/p_system __sinit_p_system_cpp: 98.181816% -> 100.0% (132 bytes)
- main/p_sound __sinit_p_sound_cpp: 97.97872% -> 100.0% (188 bytes)
- main/p_gba __sinit_p_gba_cpp: 98.58491% -> 100.0% (212 bytes)
- main/p_sample __sinit_p_sample_cpp: 97.97872% -> 100.0% (188 bytes)
- main/p_usb __sinit_p_usb_cpp: 98.40909% -> 99.77273% (176 bytes)

## Plausibility
This keeps the existing constructor-local descriptor pattern shown by Ghidra and only changes how the table lvalue is expressed in source. It avoids static table rewrites, vtable/RTTI hacks, and section forcing.