### PR TITLE
Improve astar polygon group cylinder layout

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -39,6 +39,16 @@ struct CAStarTempWork
 	float m_cost;
 };
 
+struct CMapCylinderRaw
+{
+	Vec m_bottom;
+	Vec m_top;
+	Vec m_axis;
+	float m_radius;
+	Vec m_boundsMin;
+	Vec m_boundsMax;
+};
+
 static inline CAStar::CATemp& AsCATemp(CAStarTempWork& temp)
 {
 	return *reinterpret_cast<CAStar::CATemp*>(&temp);
@@ -70,7 +80,7 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		const CVector& topVec = CVector(pos->x, kPolyGroupTopOffsetY + pos->y, pos->z);
 		Vec* base = reinterpret_cast<Vec*>(const_cast<CVector*>(&baseVec));
 		Vec* top = reinterpret_cast<Vec*>(const_cast<CVector*>(&topVec));
-		CMapCylinder cyl;
+		CMapCylinderRaw cyl;
 		float aabbMin = LoadFloat(kPolyGroupAabbMin);
 		float aabbMax = LoadFloat(kPolyGroupAabbMax);
 
@@ -84,7 +94,7 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		cyl.m_axis = *base;
 		cyl.m_radius = LoadFloat(kPolyGroupBaseXZ);
 
-		if (MapMng.CheckHitCylinderNear(&cyl, base, mask) != 0)
+		if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), base, mask) != 0)
 		{
 			return gMapHitFace->m_groupIndex;
 		}
@@ -98,7 +108,7 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		const CVector& topVec = CVector(pos->x, kPolyGroupTopOffsetY + pos->y, pos->z);
 		Vec* base = reinterpret_cast<Vec*>(const_cast<CVector*>(&baseVec));
 		Vec* top = reinterpret_cast<Vec*>(const_cast<CVector*>(&topVec));
-		CMapCylinder cyl;
+		CMapCylinderRaw cyl;
 		float aabbMin = LoadFloat(kPolyGroupAabbMin);
 		float aabbMax = LoadFloat(kPolyGroupAabbMax);
 
@@ -112,7 +122,7 @@ unsigned char CAStar::calcPolygonGroup(Vec* pos, int hitAttributeMask)
 		cyl.m_axis = *base;
 		cyl.m_radius = LoadFloat(kPolyGroupBaseXZ);
 
-		if (MapMng.CheckHitCylinderNear(&cyl, base, hitAttributeMask) != 0)
+		if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), base, hitAttributeMask) != 0)
 		{
 			return gMapHitFace->m_groupIndex;
 		}
@@ -137,7 +147,7 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 	const CVector& topVec = CVector(pos->x, kPolyGroupTopOffsetY + pos->y, pos->z);
 	Vec* base = reinterpret_cast<Vec*>(const_cast<CVector*>(&baseVec));
 	Vec* top = reinterpret_cast<Vec*>(const_cast<CVector*>(&topVec));
-	CMapCylinder cyl;
+	CMapCylinderRaw cyl;
 	float aabbMin = LoadFloat(kPolyGroupAabbMin);
 	float aabbMax = LoadFloat(kPolyGroupAabbMax);
 
@@ -151,7 +161,7 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
 	cyl.m_axis = *base;
 	cyl.m_radius = LoadFloat(kPolyGroupBaseXZ);
 
-	if (MapMng.CheckHitCylinderNear(&cyl, base, mask) != 0)
+	if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cyl), base, mask) != 0)
 	{
 		return gMapHitFace->m_groupIndex;
 	}


### PR DESCRIPTION
## Summary
- Add a raw CMapCylinder-compatible local layout for astar polygon group probes.
- Use that raw layout in calcPolygonGroup and calcSpecialPolygonGroup before passing to CheckHitCylinderNear.
- Avoids the inline CMapCylinder default constructor stores that are immediately overwritten by these functions.

## Objdiff evidence
Command: `build/tools/objdiff-cli diff -p . -u main/astar -o - calcPolygonGroup__6CAStarFP3Veci`

Before -> after:
- `calcPolygonGroup__6CAStarFP3Veci`: 85.19658% -> 99.128204%
- `calcSpecialPolygonGroup__6CAStarFP3Vec`: 86.42857% -> 99.333336%
- `[extabindex-0]`: 92.916664% -> 98.75%

## Plausibility
The original code appears to build the cylinder fields directly rather than default-constructing `CMapCylinder` and overwriting its bounds. This matches existing raw cylinder usage elsewhere in the repo and removes constructor noise without hardcoded addresses or manual section/layout tricks.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/astar -o - calcPolygonGroup__6CAStarFP3Veci`