### PR TITLE
Improve CAnim node iteration

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -223,7 +223,7 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 
 			m_nodes = new (stage, const_cast<char*>(s_charaAnimSourceFile), 0x5F) CChara::CAnimNode[nodeCount];
 
-			CAnimNode* node = m_nodes;
+			unsigned int nodeOffset = 0;
 			chunkFile.PushChunk();
 			while (chunkFile.GetNextChunk(chunk)) {
 				chunkId = static_cast<int>(chunk.m_id);
@@ -244,8 +244,9 @@ void CChara::CAnim::Create(void* data, CMemory::CStage* stage)
 					m_quantizeZ = static_cast<unsigned char>(chunkFile.Get4());
 					break;
 				case 0x4E4F4445: {
-					CAnimNode* currentNode = node;
-					node++;
+					CAnimNode* currentNode =
+					    reinterpret_cast<CAnimNode*>(reinterpret_cast<unsigned char*>(m_nodes) + nodeOffset);
+					nodeOffset += sizeof(CAnimNode);
 
 					chunkFile.PushChunk();
 					while (chunkFile.GetNextChunk(nodeChunk)) {


### PR DESCRIPTION
## Summary
- Track CChara::CAnim::Create node traversal with a byte offset instead of an advancing typed pointer.
- This matches the target function size and improves the selected chara_anim target.

## Evidence
- ninja: passes
- Create__Q26CChara5CAnimFPvPQ27CMemory6CStage: 96.39% -> 97.35%
- Function size: 956b -> 960b, matching PAL target size 960b

## Plausibility
- Ghidra shows the original target computing m_nodes + nodeOffset and incrementing by 0x18 per NODE chunk.
- The source now reflects that serialized-node traversal pattern while preserving existing member access for node fields.