### PR TITLE
Match CUSBPcs process table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -21,7 +21,7 @@ public:
         u8 m_reserved34[0xC];
     };
 
-    static CProcessTable m_table;
+    static CSmallProcessTable m_table;
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -16,14 +16,14 @@ inline CUSBPcs::CUSBPcs()
     static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
     static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 
-    CProcessTable* table = &m_table;
+    CProcessTable* table = reinterpret_cast<CProcessTable*>(&m_table);
 
     table->m_fields.m_create = desc0;
     table->m_fields.m_destroy = desc1;
     table->m_fields.m_entries[0].m_callback = desc2;
 }
 
-CProcessTable CUSBPcs::m_table = {
+CSmallProcessTable CUSBPcs::m_table = {
     const_cast<char*>(sUsbPcsClassName),
     {
         0,
@@ -230,7 +230,7 @@ void CUSBPcs::IsBigAlloc(int param_2)
  */
 int CUSBPcs::GetTable(unsigned long param)
 {
-    return reinterpret_cast<int>(&m_table + param);
+    return reinterpret_cast<int>(reinterpret_cast<unsigned char*>(&m_table) + param * sizeof(CProcessTable));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Change CUSBPcs::m_table to use the 0x11C CSmallProcessTable layout shown by the PAL MAP.
- Keep GetTable’s 0x15C process-table stride explicit so the matched code remains unchanged.
- Treat the constructor table writes as an overlay onto the small table, matching the existing static descriptor layout.

## Evidence
- config/GCCP01/symbols.txt: m_table__7CUSBPcs is size 0x11C.
- Before: compiled m_table__7CUSBPcs was size 348 (0x15C) and only 90.01405% matched.
- After: m_table__7CUSBPcs is size 284 (0x11C) and 100.0% matched.
- GetTable__7CUSBPcsFUl remains size 20, 100.0% matched.
- ninja passes.