### PR TITLE
Improve item jump cylinder layout

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -79,6 +79,16 @@ static inline CFlatRuntime2* ItemCFlatRuntime()
 	return reinterpret_cast<CFlatRuntime2*>(CFlat);
 }
 
+struct CMapCylinderRaw
+{
+	Vec m_bottom;
+	Vec m_top;
+	Vec m_axis;
+	float m_radius;
+	Vec m_boundsMin;
+	Vec m_boundsMax;
+};
+
 /*
  * --INFO--
  * PAL Address: 0x80124b78
@@ -169,7 +179,7 @@ void CGItemObj::ItemJump(int state, float jump)
 
 		if ((object->m_objectFlags & 0x10) == 0) {
 			unsigned int mapMask = object->m_bgHitMask;
-			CMapCylinder cylinder;
+			CMapCylinderRaw cylinder;
 			Vec move;
 
 			move.x = FLOAT_80331b20;
@@ -192,7 +202,7 @@ void CGItemObj::ItemJump(int state, float jump)
 			cylinder.m_boundsMax.y = FLOAT_80331b2c;
 			cylinder.m_boundsMax.z = FLOAT_80331b2c;
 
-			if (MapMng.CheckHitCylinderNear(&cylinder, &move, mapMask) != 0 &&
+			if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cylinder), &move, mapMask) != 0 &&
 			    g_hit_f->m_groupIndex == state) {
 				object->m_groundHitOffset.y += jump;
 			}


### PR DESCRIPTION
## Summary
- Replace the constructed CMapCylinder local in CGItemObj::ItemJump with a raw cylinder layout.
- Keep the existing manual field initialization and cast at the CheckHitCylinderNear call.
- This avoids constructor-generated bounds initialization that the target function does not have.

## Evidence
- ninja passes.
- ItemJump__9CGItemObjFif objdiff improved from 78.01205% to 85.421684%.
- pppRenderYmTracer2 was explored but no changes were kept; final score remains at its baseline 98.414635%.

## Plausibility
The function already manually initializes every CMapCylinder field before use. Using a raw layout matches the target code shape and follows existing collision-call patterns in the repo where constructor output would be wrong for matching.