### PR TITLE
Improve texanim SetTexGen matching

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -214,7 +214,21 @@ void CTexAnimSet::SetTexGen()
 {
     for (unsigned int i = 0; i < static_cast<unsigned int>(m_texAnims.GetSize()); i++) {
         CTexAnim* texAnim = m_texAnims[i];
-        texAnim->SetTexGen();
+        CMaterial* material = texAnim->m_refData->m_material;
+
+        if (material != 0) {
+            float y = texAnim->m_texGen.y;
+            int index = texAnim->m_refData->m_texSrtIndex;
+            float x = texAnim->m_texGen.x;
+            material->m_texScroll[index].m_u0 = x;
+            material->m_texScroll[index].m_v0 = y;
+            material->m_texScroll[index].m_u1 = FLOAT_8032fb38;
+            material->m_texScroll[index].m_v1 = FLOAT_8032fb38;
+            material->m_texScroll[index].m_type0 =
+                (FLOAT_8032fb38 == material->m_texScroll[index].m_u1) ? 0 : 1;
+            material->m_texScroll[index].m_type1 =
+                (FLOAT_8032fb38 == material->m_texScroll[index].m_v1) ? 0 : 1;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Rewrites CTexAnimSet::SetTexGen to update the target material texture-scroll slot directly.
- Keeps the same behavior while matching the target's direct m_texScroll access pattern more closely.

## Evidence
- ninja succeeds.
- objdiff main/texanim:
  - SetTexGen__11CTexAnimSetFv: 94.13207% -> 95.84906%, size 212b unchanged.
  - Change, AddFrame, AttachMaterialSet, Create, data/RTTI/extab entries unchanged in the final texanim diff.

## Plausibility
- CMaterial already exposes m_texScroll layout to CTexAnimSet as a friend, and nearby material code writes these scroll fields directly.
- This removes an inline helper shape that produced less accurate codegen for the set-level update loop.