### PR TITLE
Improve menu list draw literal lifetime

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -66,6 +66,7 @@ void CMenuPcs::MLstDraw()
 			float w = (float)item->width;
 			float h = (float)item->height;
 			float zero = FLOAT_803333D0;
+			float v = zero;
 			float alpha = item->alpha;
 
 			MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(tex));
@@ -76,7 +77,6 @@ void CMenuPcs::MLstDraw()
 			color.a = (unsigned char)(255.0f * alpha);
 			GXSetChanMatColor(GX_COLOR0A0, color);
 
-			float v = zero;
 			if ((menuMode == 1) && (i == this->lstState->cursor)) {
 				x = (float)(x + 20.0);
 				v += (float)((double)item->height);


### PR DESCRIPTION
## Summary
- Adjust CMenuPcs::MLstDraw so the zero UV offset is materialized before alpha setup, matching the PAL function value lifetime more closely.
- This improves menu_lst codegen and the exception table without changing behavior.

## Evidence
- ninja passes.
- main/menu_lst objdiff:
  - MLstDraw__8CMenuPcsFv: 85.966576% -> 87.693596%
  - .text: 91.93326% -> 92.66974%
  - extab: 96.875% -> 100.0%
  - .sdata2: remains 96.42857%
- Overall build report data matched increased by 32 bytes: 1236927 -> 1236959.

## Plausibility
- The change only moves the local v initialization next to the existing zero local, before alpha/color setup.
- This is a normal source-lifetime adjustment, not a forced section/address hack.