### PR TITLE
Model CModel draw matrix for screen break

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -243,9 +243,8 @@ public:
 	public:
 		u8 _pad0[0x8];
 		Mtx m_matrix;
-		u8 _pad38[0xC];
 		Mtx m_worldBaseMtx;
-		u8 _pad74[0x24];
+		Mtx m_drawMtx;
 		u32 m_meshVisibleMask;
 		float m_lightAlpha;
 		u8 m_flagsA0;

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -148,7 +148,7 @@ extern const Vec kScreenBreakPieceUpVector = { 0.0f, 1.0f, 0.0f };
 extern const char sF999Root[] = "f999_root";
 extern const char s_pppScreenBreak_cpp[] = "pppScreenBreak.cpp";
 
-static inline MtxPtr ScreenBreakModelMtx(CChara::CModel* model) { return reinterpret_cast<MtxPtr>(reinterpret_cast<u8*>(model) + 0x68); }
+static inline MtxPtr ScreenBreakModelMtx(CChara::CModel* model) { return model->m_drawMtx; }
 static inline ScreenBreakModelData* ScreenBreakModelRef(CChara::CModel* model) { return reinterpret_cast<ScreenBreakModelData*>(model->m_data); }
 static inline u8* GetScreenBreakWork(PScreenBreak* screenBreak, s32 offset) { return screenBreak->m_object.m_workArea + offset; }
 static inline VScreenBreak* GetScreenBreakValue(PScreenBreak* screenBreak, s32 offset) { return reinterpret_cast<VScreenBreak*>(GetScreenBreakWork(screenBreak, offset)); }
@@ -722,9 +722,9 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
 
     PSMTXInverse(cameraMtx, invCameraMtx);
     PSMTXConcat(invCameraMtx, ScreenBreakModelMtx(model), ScreenBreakModelMtx(model));
-    ScreenBreakModelMtx(model)[0][3] = translation.x;
-    ScreenBreakModelMtx(model)[1][3] = translation.y;
-    ScreenBreakModelMtx(model)[2][3] = translation.z;
+    model->m_drawMtx[0][3] = translation.x;
+    model->m_drawMtx[1][3] = translation.y;
+    model->m_drawMtx[2][3] = translation.z;
 
     mesh = model->m_meshes;
     if (step->m_gravityAmount != zero) {


### PR DESCRIPTION
## Summary
- Add the missing  member at the existing draw-matrix layout slot.
- Update  to use  member access instead of a raw  matrix helper and repeated helper stores.
- This lets  avoid the extra preserved matrix-pointer move while keeping the source layout coherent.

## Objdiff evidence
 before -> after:
- : 97.18555% -> 97.29081%
- : 97.22222% -> 98.14815%
- : 98.03111% -> 98.55556%
- callback compiled size: 904b -> 900b, matching target 900b

Checked dependent units after the header layout correction:
- : unchanged in checked section scores
- : unchanged in checked section scores
- : still 100% text/extab/extabindex/sdata2

## Validation
- [1/1] PROGRESS
Progress:
  All: 33.73% matched, 16.68% linked (204 / 576 files)
    Code: 625792 / 1855224 bytes (3527 / 4732 functions)
    Data: 1236927 / 1489351 bytes (83.05%)
  Game Code: 18.56% matched, 0.00% linked (1 / 266 files)
    Code: 274196 / 1477652 bytes (1939 / 3111 functions)
    Data: 1049861 / 1222293 bytes (85.89%)
  RedSound: 61.84% matched, 0.00% linked (0 / 8 files)
    Code: 42096 / 68072 bytes (346 / 379 functions)
    Data: 20754 / 25794 bytes (80.46%)
  SDK Code: 100.00% matched, 100.00% linked (203 / 203 files)
    Code: 309500 / 309500 bytes (1242 / 1242 functions)
    Data: 166312 / 166896 bytes (99.65%)
- 