### PR TITLE
Improve memorycard load serial stores

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1313,8 +1313,9 @@ void CMemoryCardMan::SetLoadData()
     memcpy(Game.m_gameWork.m_townName, save + 0x10C0, 0x10);
     memcpy(Game.m_gameWork.m_eventFlags, save + 0x10D0, 0x100);
     memcpy(Game.m_gameWork.m_eventWork, save + 0x11D0, 0x200);
-    Game.m_gameWork.m_mcSerial0 = *reinterpret_cast<u32*>(save + 0x13D0);
+    u32 serial0 = *reinterpret_cast<u32*>(save + 0x13D0);
     Game.m_gameWork.m_mcSerial1 = *reinterpret_cast<u32*>(save + 0x13D4);
+    Game.m_gameWork.m_mcSerial0 = serial0;
     Game.m_gameWork.m_mcRandom = *reinterpret_cast<u32*>(save + 0x13D8);
     Game.m_gameWork.m_mcHasSerial = save[0x13DC];
     Sound.SetBgmMasterVolume(static_cast<s8>(save[0x13DD]));


### PR DESCRIPTION
## Summary
- Preserve the first memory-card serial word in a local before loading the second word in `CMemoryCardMan::SetLoadData`
- Store `m_mcSerial1` before writing the saved `m_mcSerial0`, matching the target code shape more closely while keeping the same load-data semantics

## Objdiff evidence
- `main/memorycard` / `SetLoadData__14CMemoryCardManFv`: `82.77289% -> 83.19718%`
- `MakeSaveData__14CMemoryCardManFv`: unchanged at `75.76398%`
- `Odekake__14CMemoryCardManFPUcUcUi`: unchanged at `87.86768%`

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/memorycard -o - SetLoadData__14CMemoryCardManFv`

## Plausibility
The change keeps the save-buffer field layout intact and expresses the adjacent serial-word loads in a source-plausible way. It avoids address hacks, section forcing, or fake symbols.
