### PR TITLE
Use zero angle for FunnyShape render

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -465,7 +465,7 @@ void CFunnyShape::RenderShape()
     offsetCopy.x = LoadFloat(kFunnyShapeDefaultOffsetX);
     offsetCopy.y = LoadFloat(kFunnyShapeDefaultOffsetY);
     FS_tagOAN3_SHAPE* shape = reinterpret_cast<FS_tagOAN3_SHAPE*>(m_meshData);
-    RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeBoundsMaxInitial));
+    RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeZero));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Update `CFunnyShape::RenderShape()` to pass `kFunnyShapeZero` for the no-arg render angle instead of reusing `kFunnyShapeBoundsMaxInitial`.
- This matches the intended source role of the argument and removes one objdiff instruction mismatch.

## Evidence
- `RenderShape__11CFunnyShapeFv` improved from 99.94193% to 99.97419%.
- Instruction diff count improved from 5 to 4.
- Remaining diffs are stack-slot placement around the color temporary.

## Verification
- `ninja` passes.