### PR TITLE
Inline unused texture cache helpers

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -571,7 +571,7 @@ int CTexture::CheckName(char* name)
  * Address: TODO
  * Size: TODO
  */
-void CTexture::CacheDumpTexture(CAmemCacheSet* amemCacheSet)
+inline void CTexture::CacheDumpTexture(CAmemCacheSet* amemCacheSet)
 {
     if (m_cacheId != -1) {
         if (GetRef() <= 1) {
@@ -586,7 +586,7 @@ void CTexture::CacheDumpTexture(CAmemCacheSet* amemCacheSet)
  * Address: TODO
  * Size: TODO
  */
-void CTexture::CacheRefCnt0UpTexture(CAmemCacheSet* amemCacheSet)
+inline void CTexture::CacheRefCnt0UpTexture(CAmemCacheSet* amemCacheSet)
 {
     if (m_cacheId != -1) {
         amemCacheSet->RefCnt0Up(m_cacheId);


### PR DESCRIPTION
## Summary
- Mark `CTexture::CacheDumpTexture` and `CTexture::CacheRefCnt0UpTexture` as inline.
- These helpers have no PAL addresses in `textureman` and were contributing emitted unused code/exception table noise.

## Evidence
- `ninja` passes.
- `textureman` objdiff named function scores stayed stable:
  - `CacheLoadTexture__8CTextureFP13CAmemCacheSet`: 96.33028%
  - `InitTexObj__8CTextureFv`: 95.505615%
- Synthetic exception table symbols improved:
  - `[extab-0]`: 87.56925% -> 89.61594%
  - `[extabindex-0]`: 68.93939% -> 72.3123%

## Plausibility
- This follows the repo runbook rule for UNUSED functions: keep known-unused helpers inline to avoid extab regressions instead of forcing standalone emitted functions.
