### PR TITLE
Improve FunnyShape render shape zero constant

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -465,7 +465,7 @@ void CFunnyShape::RenderShape()
     offsetCopy.x = LoadFloat(kFunnyShapeDefaultOffsetX);
     offsetCopy.y = LoadFloat(kFunnyShapeDefaultOffsetY);
     FS_tagOAN3_SHAPE* shape = reinterpret_cast<FS_tagOAN3_SHAPE*>(m_meshData);
-    RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeBoundsMaxInitial));
+    RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeZero));
 }
 
 /*


### PR DESCRIPTION
## Summary
- use the shared FunnyShape zero constant for the default RenderShape angle
- avoids the unrelated bounds-initializer zero at the call site

## Objdiff Evidence
- Unit: main/FunnyShape
- Symbol: RenderShape__11CFunnyShapeFv
- Before: 99.94193% match, .text 88.22621%
- After: 99.97419% match, .text 88.2292%
- .sdata2 unchanged at 69.230774%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - RenderShape__11CFunnyShapeFv