### PR TITLE
Improve chara viewer texture access

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -1,6 +1,8 @@
 #define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 #include "ffcc/ptrarray.h"
+#define FFCC_TEXTUREMAN_USE_PTRARRAY_MEMBER
 #include "ffcc/p_chara.h"
+#undef FFCC_TEXTUREMAN_USE_PTRARRAY_MEMBER
 #include "ffcc/chara.h"
 #include "ffcc/color.h"
 #include "ffcc/file.h"
@@ -220,7 +222,7 @@ void CCharaPcs::drawViewer()
     Mtx cameraMtx;
 
     if ((self->m_viewerBackTextureSet != 0) &&
-        (static_cast<unsigned int>(self->m_viewerBackTextureSet->GetNumTexture()) != 0)) {
+        (static_cast<unsigned int>(self->m_viewerBackTextureSet->m_textureArray.GetSize()) != 0)) {
         C_MTXOrtho(projMtx, LoadFloat(kCharaViewerZero), LoadFloat(kCharaViewerBackOrthoRight),
                    LoadFloat(kCharaViewerZero), LoadFloat(kCharaViewerBackOrthoBottom), LoadFloat(kCharaViewerZero),
                    LoadFloat(kCharaViewerGridMax));
@@ -237,7 +239,7 @@ void CCharaPcs::drawViewer()
         PSMTXIdentity(backCameraMtx);
         GXLoadPosMtxImm(backCameraMtx, 0);
         GXSetCullMode(GX_CULL_NONE);
-        CTexture* texture = self->m_viewerBackTextureSet->GetTexture(0);
+        CTexture* texture = self->m_viewerBackTextureSet->m_textureArray[0];
         TextureMan.SetTexture(GX_TEXMAP0, texture);
         unsigned int width = texture->m_width;
         unsigned int height = texture->m_height;


### PR DESCRIPTION
## Summary
- Expose `CTextureSet::m_textureArray` in `p_chara_viewer.cpp` so `drawViewer` uses the same direct pointer-array access shape as the target binary.
- Replace the back-texture `GetNumTexture()` / `GetTexture(0)` wrapper calls with direct `m_textureArray.GetSize()` / `m_textureArray[0]` access.

## Evidence
- `drawViewer__9CCharaPcsFv` improved from 98.059525% to 98.61905%.
- Instruction diffs dropped from 47 to 40.
- `calcViewer__9CCharaPcsFv` was checked before/after and remained unchanged at 90.49798% with 281 instruction diffs.
- `ninja` passes.

## Plausibility
The target binary calls the underlying `CPtrArray<CTexture*>` methods on the texture set storage in this path. Exposing the real member layout for this translation unit removes wrapper-call mismatches without changing behavior.
