### PR TITLE
Improve TmpArtiCtrl entry access

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -441,11 +441,11 @@ void CMenuPcs::TmpArtiCtrl()
 		float fVar2 = FLOAT_80332f30;
 		unsigned int uVar4 = Game.m_scriptFoodBase[0];
 
-		iVar6 = reinterpret_cast<int>(this->m_tmpArtiList) + 8;
+		TmpArtiEntry* entry = this->m_tmpArtiList->entries;
 		for (iVar7 = 0; iVar7 < this->m_tmpArtiList->count; iVar7 = iVar7 + 1) {
-			*(float *)(iVar6 + 0x10) = fVar2;
-			*(float *)(iVar6 + 0x14) = fVar2;
-			iVar6 = iVar6 + 0x40;
+			entry->alpha = fVar2;
+			entry->z = fVar2;
+			entry++;
 		}
 
 		uVar5 = (unsigned int)*(short *)(uVar4 + 0xbaa);


### PR DESCRIPTION
## Summary
- Replace raw pointer arithmetic in CMenuPcs::TmpArtiCtrl with typed TmpArtiEntry member access.
- This matches the asserted TmpArtiEntry::alpha and TmpArtiEntry::z layout while making the source more coherent.

## Objdiff Evidence
Command: build/tools/objdiff-cli diff -p . -u main/menu_tmparti -o - TmpArtiCtrl__8CMenuPcsFv

- TmpArtiCtrl__8CMenuPcsFv: 80.849464% -> 81.01075%, size 768 -> 768
- TmpArtiDraw__8CMenuPcsFv: unchanged at 91.81061%, size 1052 -> 1052
- TmpArtiClose__8CMenuPcsFv: unchanged at 87.897194%, size 440 -> 440
- TmpArtiOpen__8CMenuPcsFv: unchanged at 89.43137%, size 824 -> 824

## Validation
- ninja passes.

## Plausibility
The changed offsets were already documented by local static asserts (alpha == 0x10, z == 0x14) on TmpArtiEntry. Using the real struct fields is more plausible original source than hand-written integer pointer offsets.