### PR TITLE
Use zero angle constant for FunnyShape render

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -465,7 +465,7 @@ void CFunnyShape::RenderShape()
     offsetCopy.x = LoadFloat(kFunnyShapeDefaultOffsetX);
     offsetCopy.y = LoadFloat(kFunnyShapeDefaultOffsetY);
     FS_tagOAN3_SHAPE* shape = reinterpret_cast<FS_tagOAN3_SHAPE*>(m_meshData);
-    RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeBoundsMaxInitial));
+    RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeZero));
 }
 
 /*


### PR DESCRIPTION
## Summary
- Use `kFunnyShapeZero` for the default `CFunnyShape::RenderShape()` angle instead of the aliased bounds constant.
- This keeps the behavior identical but matches the intended symbol relocation for the angle argument.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - RenderShape__11CFunnyShapeFv`
  - before: 99.94193% match, 620 bytes
  - after: 99.97419% match, 620 bytes
  - remaining diffs are stack temp offsets for the color setup only.

## Plausibility
- `kFunnyShapeZero` and `kFunnyShapeBoundsMaxInitial` alias the same PAL sdata2 address, but the call argument is an angle. The zero constant is the plausible original source name here; the bounds name remains used for bounds initialization.