### PR TITLE
Improve CGObject SetDispItemName flag update

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3079,10 +3079,18 @@ void CGObject::PlayAnim(int slot, int param2, int param3, int param4, int param5
  */
 void CGObject::SetDispItemName(int showName)
 {
-    u8 flags = *((u8*)&m_shieldNodeFlags);
-    u8 masked = flags;
-    masked = (u8)__rlwimi(masked, showName, 4, 27, 27);
-    *((u8*)&m_shieldNodeFlags) = masked;
+    struct ShieldNodeFlagBits {
+        unsigned char unk0 : 1;
+        unsigned char unk1 : 1;
+        unsigned char unk2 : 1;
+        unsigned char dispItemName : 1;
+        unsigned char unk4 : 1;
+        unsigned char unk5 : 1;
+        unsigned char unk6 : 1;
+        unsigned char unk7 : 1;
+    };
+
+    reinterpret_cast<ShieldNodeFlagBits*>(&m_shieldNodeFlags)->dispItemName = showName;
     m_dispItemTimer = 13;
 }
 


### PR DESCRIPTION
## Summary
- Replaces the manual low-byte `__rlwimi` sequence in `CGObject::SetDispItemName` with a local bitfield view of the shield-node flag byte.
- Keeps the public `SetDispItemName(int)` signature and timer behavior unchanged while making the source closer to an original one-bit flag assignment.

## Objdiff evidence
- `SetDispItemName__8CGObjectFi`: 82.85714% -> 91.42857% match, 28 bytes.
- Final check: `build/tools/objdiff-cli diff -p . -u main/gobject --format json-pretty -o /tmp/gobject_setdisp_pr.json SetDispItemName__8CGObjectFi` reports 91.42857%.

## Verification
- `ninja` passed.
