### PR TITLE
Improve pppChangeTex draw callback match

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -409,7 +409,8 @@ static void ChangeTex_AfterDrawMeshCallback(CChara::CModel* model, void* param_2
 				GXSetArray((GXAttr)0xb, meshColorArray, 4);
 				MaterialMan.SetChangeTexReflectionTexture(&texture->m_texObj);
 				drawTevBits = 0xACE0F;
-				fullTevBits = drawTevBits | 0x1000;
+				fullTevBits = drawTevBits;
+				fullTevBits |= 0x1000;
 				displayListIdx = meshData->m_displayListCount - 1;
 				while (displayListIdx >= 0) {
 					ChangeTexDisplayListCopy** displayListCopies = work->m_displayListArrays[meshIdx];
@@ -441,13 +442,16 @@ static void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, v
 	ChangeTexMeshRef* meshes = ChangeTexMeshes(model);
 	meshes += param_4;
 	ChangeTexMeshData* meshData = meshes->m_data;
-	ChangeTexDisplayList* displayList = meshData->m_displayLists + param_5;
+	ChangeTexDisplayList* displayList = meshData->m_displayLists;
+	displayList += param_5;
+	CTexture* texture = work->m_texture;
 
 	if (step->m_changeTex.m_mode == 0) {
 		int drawTevBits = 0xACE0F;
-		int fullTevBits = drawTevBits | 0x1000;
+		int fullTevBits = drawTevBits;
+		fullTevBits |= 0x1000;
 		MaterialMan.SetChangeTexReflectionState(
-		    &work->m_texture->m_texObj, drawTevBits, fullTevBits);
+		    &texture->m_texObj, drawTevBits, fullTevBits);
 	}
 
 	MaterialMan.SetMaterial(model->m_data->m_materialSet, displayList->m_material, 0, (_GXTevScale)0);


### PR DESCRIPTION
## Summary
- Adjust `ChangeTex_DrawMeshDLCallback` source shape to keep the texture pointer as a local and split display-list pointer advancement.
- Compute the derived TEV bit through an explicit update in both change-tex callbacks.

## Objdiff evidence
Before:
- `main/pppChangeTex` .text: 96.81374%
- `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: 81.62295%

After:
- `main/pppChangeTex` .text: 97.68244%
- `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: 90.95082%
- `ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`: unchanged at 95.75581%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o - --format json`

## Plausibility
The changes preserve the existing callback behavior while expressing intermediate values as named locals and updates that better match the generated code. No fake symbols, hard-coded addresses, or linkage hacks were added.