### PR TITLE
Match pppConstructYmMiasma constants

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -376,10 +376,8 @@ void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(&pppYmMiasma_->m_object, param_2, 2);
-    float fVar1;
-    float fVar2 = FLOAT_80330644;
-
-    fVar1 = FLOAT_80330658;
+    const float& fVar2 = FLOAT_80330644;
+    const float& fVar1 = FLOAT_80330658;
 
     work->m_particles = 0;
     work->m_radius = fVar2;


### PR DESCRIPTION
## Summary
- Use const references for the zero/one constants in `pppConstructYmMiasma`.
- This makes the constructor load the named `.sdata2` symbols instead of anonymous literals.

## Objdiff evidence
- `main/pppYmMiasma` `.text`: 99.69187% -> 99.70316%.
- `pppConstructYmMiasma`: 99.5% -> 100.0% (0 instruction diffs).

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o /tmp/pppYmMiasma.pr.json --format json`