### PR TITLE
Improve ring menu command TLUT mapping

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -820,19 +820,23 @@ void drawCommand(int state, CFont* font, float posX, float posY, CCaravanWork* c
 	}
 
 	if (Game.m_gameWork.m_bossArtifactStageIndex == 0x19) {
-		tlut = 7;
-		if (cmdIndex == 2) {
+		switch (cmdIndex) {
+		case 0:
+			tlut = 2;
+			break;
+		case 1:
+			tlut = 1;
+			break;
+		case 2:
 			tlut = 4;
-		} else if (cmdIndex < 2) {
-			if (cmdIndex == 0) {
-				tlut = 2;
-			} else if (cmdIndex >= 0) {
-				tlut = 1;
-			}
-		} else if (cmdIndex == 4) {
-			tlut = 7;
-		} else if (cmdIndex < 4) {
+			break;
+		case 3:
 			tlut = 6;
+			break;
+		case 4:
+		default:
+			tlut = 7;
+			break;
 		}
 		font->SetTlut(tlut);
 	} else if (cmdIndex == 0) {


### PR DESCRIPTION
## Summary
- Rewrites the boss-artifact command TLUT selection in `drawCommand` as an explicit switch over the five fixed command indices.
- Keeps the same TLUT mapping while matching the target branch shape more closely.

## Objdiff Evidence
- `drawCommand__FiP5CFontffP12CCaravanWorkiff`: 78.89574% -> 82.98578%
- `main/ringmenu` .text: 69.65907% -> 70.01657%

## Plausibility
The boss artifact path has a fixed five-command mapping, so a switch over command indices is plausible source and cleaner than the previous nested range checks.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/ringmenu -o - drawCommand__FiP5CFontffP12CCaravanWorkiff`