### PR TITLE
Define FunnyShape sdata2 constants

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -20,6 +20,7 @@ extern const float kFunnyShapeOne;
 extern const float kFunnyShapeTexCoordDivisor = 4096.0f;
 extern const float kFunnyShapePaddingScale = 0.5f;
 extern const float kFunnyShapeNegativeOne;
+extern const float FLOAT_8032fd84 = 0.0f;
 extern const float kFunnyShapeDefaultOffsetX = 480.0f;
 extern const float kFunnyShapeDefaultOffsetY = 336.0f;
 extern const float kFunnyShapeTextureViewportOrigin = 20.0f;

--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -25,7 +25,7 @@ extern const float kFunnyShapeDefaultOffsetX = 480.0f;
 extern const float kFunnyShapeDefaultOffsetY = 336.0f;
 extern const float kFunnyShapeTextureViewportOrigin = 20.0f;
 extern const float kFunnyShapeAnimOffsetX = 320.0f;
-extern const float kFunnyShapeAnimOffsetY;
+extern const float kFunnyShapeAnimOffsetY = 224.0f;
 extern const float kFunnyShapePi;
 extern const float kFunnyShapeHalfTurnDegrees[2];
 extern const char sDebugSpinnerText[5];


### PR DESCRIPTION
## Summary
- Define MAP-owned FunnyShape sdata2 constants `FLOAT_8032fd84` and `kFunnyShapeAnimOffsetY` in `FunnyShape.o`.
- Keeps these constants in source instead of leaving them as unresolved externs.

## Evidence
- `ninja` passes; final build report remains stable at 33.52% overall matched / 16.68% linked.
- `build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - Render__11CFunnyShapeFv`:
  - `.sdata2`: 69.230774% -> 71.42857%
  - `extab`: 97.5% unchanged
  - `extabindex`: 96.666664% unchanged
  - `.text`: 88.2292% -> 88.22621% (minor local movement from MAP-backed constant ownership)

## Plausibility
- Both symbols are attributed to `FunnyShape.o` in `build/GCCP01/main.elf.MAP`.
- Values match the adjacent sdata2 layout: `FLOAT_8032fd84 = 0.0f`, `kFunnyShapeAnimOffsetY = 224.0f`.
