### PR TITLE
Improve p_graphic debug bar geometry

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -620,10 +620,11 @@ void CGraphicPcs::drawBar()
     for (int i = 0; i < orderCount; i++) {
         const u32 rgb = Math.Hsb2Rgb(hue / orderCount, 100, 100);
         const float width = (100.0f * order->m_lastTime) / 16.666666f;
-        const float y0 = drawText ? static_cast<float>(y) : ((order->m_priority == 0x26) ? 448.0f : 464.0f);
-        const float y1 = drawText ? static_cast<float>(y + 8) : 456.0f;
 
         if (order->m_priority == 0x26) {
+            const float y0 = drawText ? static_cast<float>(y) : 448.0f;
+            const float y1 = drawText ? static_cast<float>(y + 8) : 456.0f;
+
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, 0.0f);
             GXColor1u32(rgb);
@@ -639,6 +640,9 @@ void CGraphicPcs::drawBar()
             GXTexCoord2u16(0, 2);
             x += width;
         } else if (order->m_priority != 0x27) {
+            const float y0 = drawText ? static_cast<float>(y) : 464.0f;
+            const float y1 = drawText ? static_cast<float>(y + 8) : 448.0f;
+
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, 0.0f);
             GXColor1u32(rgb);


### PR DESCRIPTION
## Summary
- Split the debug timing bar Y extents by priority in `CGraphicPcs::drawBar`.
- Matches the decompiled shape where normal non-text timing bars span from 464.0f back to 448.0f, while priority 0x26 bars keep the 448.0f to 456.0f band.

## Evidence
- `ninja` passes.
- `drawBar__11CGraphicPcsFv`: 59.850640% -> 61.557610% (+1.706970).
- `main/p_graphic` `.text`: 68.127460% after the change.
- Neighbor selected symbols unchanged: `__sinit_p_graphic_cpp` 43.188680%, `drawScreenFade__11CGraphicPcsFv` 55.866543%.

## Plausibility
- This is a source-level geometry correction, not compiler coaxing: the two debug bar categories naturally have different non-text screen bands, and Ghidra shows the separate 448.0f/456.0f and 464.0f/448.0f constants in the original.