### PR TITLE
Suppress mapshadow ptrarray accessors

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -1,3 +1,4 @@
+#define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 #include "ffcc/mapshadow.h"
 #include "ffcc/linkage.h"
 #include "ffcc/map.h"


### PR DESCRIPTION
## Summary
- define `FFCC_PTRARRAY_NO_INLINE_ACCESSORS` for `mapshadow.cpp`
- prevents this unit from emitting local `CPtrArray` accessor helper bodies already owned elsewhere
- reduces `mapshadow.o` text/data ownership to the expected target layout

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/mapshadow -o -`
- `.text` size: 852 -> 748, now target-sized
- extra helper symbols removed: `__vc__22CPtrArray<P9CMaterial>FUl`, `GetSize__24CPtrArray<P10CMapShadow>Fv`, `__vc__24CPtrArray<P10CMapShadow>FUl`, `GetAt__22CPtrArray<P9CMaterial>FUl`, `GetAt__24CPtrArray<P10CMapShadow>FUl`
- `extab`: 40 -> 24, `[extab-0]` now 100%
- `extabindex`: 60 -> 36, `[extabindex-0]` now 100%

## Plausibility
This matches the existing pattern in `mapanim.cpp` and `texanim.cpp`: units that should call out-of-line `CPtrArray` accessors suppress inline accessor emission instead of owning duplicate template helper code.