### PR TITLE
Match texture pointer array release

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -1159,11 +1159,10 @@ template <>
 void CPtrArray<CTexture*>::ReleaseAndRemoveAll()
 {
     for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
-        CTexture* item = m_items[i];
+        CRef* item = reinterpret_cast<CRef*>(m_items[i]);
         if (item != 0) {
-            CRef* ref = item;
-            if (ref->DecRef() == 0) {
-                delete ref;
+            if (--item->refCount == 0) {
+                delete item;
             }
             m_items[i] = 0;
         }


### PR DESCRIPTION
## Summary
- Match `CPtrArray<CTexture*>::ReleaseAndRemoveAll()` by using the same direct `CRef::refCount` decrement pattern used by nearby pointer array specializations.
- Keeps the source plausible and avoids an out-of-line `DecRef()` call in the generated body.

## Evidence
- `ReleaseAndRemoveAll__21CPtrArray<P8CTexture>Fv`: 75.196075% -> 100.0%, compiled size 184 -> 204 bytes matching target size 204.
- Neighboring tracked symbols unchanged: `InitTexObj__8CTextureFv`, `CacheLoadTexture__8CTextureFP13CAmemCacheSet`, `Create__8CTextureFR10CChunkFilePQ27CMemory6CStageP13CAmemCacheSetii` retained their prior scores.
- `ninja` passes.

## Build Report Delta
- Game Code matched bytes: 272036 -> 272240
- Game Code matched functions: 1927 -> 1928
- Overall matched bytes: 623632 -> 623836
- Overall matched functions: 3515 -> 3516