### PR TITLE
Improve textureman ptrarray matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -110,7 +110,7 @@ int CTextureSet::Find(char* name)
  * Address: TODO
  * Size: TODO
  */
-CTexture* CTextureSet::GetTexture(long index)
+inline CTexture* CTextureSet::GetTexture(long index)
 {
     return m_textureArray[static_cast<unsigned long>(index)];
 }
@@ -120,7 +120,7 @@ CTexture* CTextureSet::GetTexture(long index)
  * Address: TODO
  * Size: TODO
  */
-int CTextureSet::GetNumTexture()
+inline int CTextureSet::GetNumTexture()
 {
     return m_textureArray.GetSize();
 }
@@ -1126,6 +1126,8 @@ int CPtrArray<CTexture*>::GetSize()
     return m_numItems;
 }
 
+#pragma dont_inline reset
+
 /*
  * --INFO--
  * PAL Address: 0x8003BF54
@@ -1176,6 +1178,8 @@ void CPtrArray<CTexture*>::ReleaseAndRemoveAll()
     m_size = 0;
     m_numItems = 0;
 }
+
+#pragma dont_inline on
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- mark unused `CTextureSet` accessors inline so they do not emit extra TODO-address symbols
- narrow the `dont_inline` pragma span around `CPtrArray<CTexture*>::ReleaseAndRemoveAll`
- lets `CRef::DecRef()` inline inside the texture release loop, matching the target code shape

## Objdiff evidence
Before:
- `main/textureman` `.text`: 98.25465%
- `ReleaseAndRemoveAll__21CPtrArray<P8CTexture>Fv`: 75.196075%
- `[extab-0]`: 89.29588%
- `[extabindex-0]`: 72.15998%

After:
- `main/textureman` `.text`: 98.96732%
- `ReleaseAndRemoveAll__21CPtrArray<P8CTexture>Fv`: 100.0%
- `[extab-0]`: 92.10526%
- `[extabindex-0]`: 83.70968%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/textureman -o -`
