### PR TITLE
Improve menu list draw constants

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -93,7 +93,7 @@ void CMenuPcs::MLstDraw()
 			}
 			MenuPcs.DrawRect(
 				0,
-				iconX - 20.0f,
+				(float)-((FLOAT_803333E0 * DOUBLE_803333E8) - (double)iconX),
 				iconY,
 				40.0f,
 				40.0f,
@@ -145,7 +145,7 @@ void CMenuPcs::MLstDraw()
 	int helpMessageId = this->lstState->cursor + 0x25c;
 	CFont* helpFont = this->helpFont;
 	CColor helpColor(0xff, 0xff, 0xff, (unsigned char)(255.0f * this->lstData->entries[0].alpha));
-	float helpX = (float)-((40.0f * (double)0.5f) - (double)320.0f);
+	float helpX = (float)-((FLOAT_803333E0 * (double)FLOAT_803333FC) - (double)FLOAT_803333F8);
 	float helpY = 352.0f;
 	DrawHelpMessage(
 		helpMessageId,


### PR DESCRIPTION
## Summary
- Rewrite two MLstDraw position expressions to use existing menu-list constants instead of folded literals.
- Keeps the source closer to the target constant usage for the list cursor/icon and help-message positioning.

## Evidence
- ninja completed successfully and build/GCCP01/main.dol: OK.
- build/tools/objdiff-cli diff -p . -u main/menu_lst -o /tmp/menu_lst.final.json
  - MLstDraw__8CMenuPcsFv: 87.693596% -> 87.827300%, size unchanged at 1436 bytes.
  - MLstClose__8CMenuPcsFv: unchanged at 98.037384%.
  - MLstCtrl__8CMenuPcsFv: unchanged at 95.246635%.
  - MLstOpen__8CMenuPcsFv: unchanged at 96.211110%.

## Plausibility
- The updated expressions preserve the same menu coordinates while making the source use the surrounding named constants (FLOAT_803333E0, DOUBLE_803333E8, FLOAT_803333FC, FLOAT_803333F8) instead of new one-off folded literals.