### PR TITLE
Improve pppEmission matching

### DIFF
--- a/src/pppEmission.cpp
+++ b/src/pppEmission.cpp
@@ -142,7 +142,7 @@ void pppFrameEmission(pppEmission* pppEmission_, pppEmissionUnkB* param_2, _pppC
         state->m_scale0, state->m_scale1, state->m_scale2,
         param_2->m_stepValue, param_2->m_arg3, param_2->m_emission.m_scaleAccelerationAdd);
 
-    if (gPppInConstructor != 0) {
+    if (ppvIsLoopCalc != 0) {
         return;
     }
 
@@ -321,10 +321,11 @@ void Emission_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* 
     EmissionMeshData* meshData = EmissionMeshAt(model, meshIndex);
     if ((strcmp(meshData->m_name, &s_pppEmissionShapeObj2) == 0) && (state->m_colorA != 0)) {
         u32 drawTevBits = 0xACE0F;
+        CTexture* texture = state->m_texture;
 
         pppInitBlendMode();
         pppSetBlendMode(step->m_emission.m_blendMode);
-        MaterialMan.SetChangeTexReflectionTexture(&state->m_texture->m_texObj);
+        MaterialMan.SetChangeTexReflectionTexture(&texture->m_texObj);
 
         Mtx viewMtx0;
         Mtx objMtx0;


### PR DESCRIPTION
## Summary
- Use the loop-calc guard in `pppFrameEmission`, matching the target global and nearby PPP behavior.
- Preserve the emission texture pointer across blend setup in `Emission_AfterDrawMeshCallback`, matching the target register lifetime more closely.

## Evidence
- `ninja` passes.
- Build report improved from 3513 to 3514 matched functions, and code bytes from 623256 to 624472.
- `main/pppEmission` objdiff:
  - `Emission_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`: 99.240135% -> 99.98355%.
  - `pppFrameEmission`: 99.92308% -> 99.94231%.
  - `Emission_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: remains 100%.

## Plausibility
- `ppvIsLoopCalc` is the symbol at the target address and is used by adjacent PPP frame functions for loop-calculation guards.
- The texture local reflects the target holding `state->m_texture` before blend setup and using it afterward, without changing behavior or introducing output hacks.