### PR TITLE
Improve CharaBreak rigid mesh node lookup

### DIFF
--- a/src/pppCharaBreak.cpp
+++ b/src/pppCharaBreak.cpp
@@ -460,7 +460,7 @@ void UpdatePolygonData(PCharaBreak* step, VCharaBreak* work, CChara::CModel* mod
 
         if (meshData->m_skinCount == 0 && stepData->m_worldSpaceMode == 1) {
             needsMtxUpdate = 1;
-            PSMTXConcat(model->m_matrix, model->m_nodes[meshData->m_nodeIndex].m_mtx, meshToWorld);
+            PSMTXConcat(model->m_matrix, model->m_nodes[meshData->m_infoWord1].m_mtx, meshToWorld);
         }
 
         for (int dl = meshData->m_displayListCount - 1; dl >= 0; dl--) {
@@ -740,7 +740,7 @@ void CreatePolygon(POLYGON_DATA* polygonData, void* displayList, unsigned long, 
 
     if (meshData->m_skinCount == 0) {
         isRigid = 1;
-        PSMTXConcat(ModelDrawMtx(model), model->m_nodes[meshData->m_nodeIndex].m_mtx, meshMtx);
+        PSMTXConcat(ModelDrawMtx(model), model->m_nodes[meshData->m_infoWord1].m_mtx, meshMtx);
     }
     workPositions = mesh->m_workPositions;
     u16* stream = (u16*)displayList;


### PR DESCRIPTION
Summary:\n- Use the mesh INFO word for CharaBreak rigid-mesh matrix lookup paths in UpdatePolygonData and CreatePolygon.\n- This matches the target load at CRefData offset 0x5c in both matrix setup paths, while keeping real member access instead of pointer offsets.\n\nEvidence:\n- ninja: passes\n- main/pppCharaBreak unit fuzzy: 96.843124 -> 96.84441\n- UpdatePolygonData: 93.08469 -> 93.08649\n- CreatePolygon: 99.72298 -> 99.72973\n\nPlausibility:\n- The affected code is specific to CharaBreak rigid mesh transform setup. The target uses the first INFO word for these paths, and the patch expresses that through the existing CRefData member rather than raw offsets.