### PR TITLE
Match CGObject item name display flag

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3073,7 +3073,7 @@ void CGObject::SetDispItemName(int showName)
         unsigned char unk0 : 1;
         unsigned char unk1 : 1;
         unsigned char unk2 : 1;
-        unsigned char dispItemName : 1;
+        signed char dispItemName : 1;
         unsigned char unk4 : 1;
         unsigned char unk5 : 1;
         unsigned char unk6 : 1;


### PR DESCRIPTION
## Summary
- Mark the local `dispItemName` bitfield view as signed in `CGObject::SetDispItemName`
- Matches the target sign-extension behavior while preserving the shipped `SetDispItemName__8CGObjectFi` signature

## Evidence
- Before: `SetDispItemName__8CGObjectFi` was 91.42857% matched, 28 bytes
- After: `SetDispItemName__8CGObjectFi` is 100.0% matched, 28 bytes
- `ninja` passes; report improved from 3514 to 3515 matched functions and from 623332 to 623360 matched code bytes

## Plausibility
- Ghidra infers the argument value as `char`, and the known caller casts the script local to `signed char`
- The change is a signedness correction on the existing local bitfield view, not a linkage or codegen hack