### PR TITLE
Match CGObject CancelAnim

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2991,10 +2991,20 @@ int CGObject::IsAnimFinished(int mode)
  */
 void CGObject::CancelAnim(int keepFacing)
 {
+	struct ShieldNodeFlagBits {
+	    unsigned char unk0 : 1;
+	    unsigned char unk1 : 1;
+	    unsigned char unk2 : 1;
+	    unsigned char unk3 : 1;
+	    unsigned char unk4 : 1;
+	    unsigned char unk5 : 1;
+	    unsigned char unk6 : 1;
+	    unsigned char unk7 : 1;
+	};
+
 	m_currentAnimSlot = -1;
 
-	*((u8*)&m_shieldNodeFlags) =
-	    static_cast<u8>(__rlwimi(*((u8*)&m_shieldNodeFlags), 0, 6, 25, 25));
+	reinterpret_cast<ShieldNodeFlagBits*>(&m_shieldNodeFlags)->unk1 = 0;
 
 	const float& zero = sZeroFloat;
 	m_turnSpeed = zero;


### PR DESCRIPTION
## Summary
- Match CGObject::CancelAnim by using a shield-node bitfield assignment for the first flag clear.
- This produces the target register allocation and preserves the existing behavior for clearing the 0x40 shield flag.

## Evidence
- Before: CancelAnim__8CGObjectFi was 98.25% matched, 80 bytes.
- After: CancelAnim__8CGObjectFi is 100.00% matched, 80 bytes.
- Verified with: build/tools/objdiff-cli diff -p . -u main/gobject -o - --format json CancelAnim__8CGObjectFi.
- Full ninja build passes.

## Plausibility
- The change replaces an intrinsic-based byte clear with a normal one-byte bitfield assignment, matching an existing local bitfield style already used for shield-node flags in SetDispItemName.