### PR TITLE
Suppress maptexanim ptrarray accessors

### DIFF
--- a/src/maptexanim.cpp
+++ b/src/maptexanim.cpp
@@ -1,3 +1,4 @@
+#define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 #include "ffcc/maptexanim.h"
 #include "ffcc/chunkfile.h"
 #include "ffcc/map.h"


### PR DESCRIPTION
## Summary
- Define `FFCC_PTRARRAY_NO_INLINE_ACCESSORS` in `maptexanim.cpp` before including ptrarray-dependent headers.
- Removes unused weak `CPtrArray<CTexture*>` / `CPtrArray<CMaterial*>` accessor bodies from `maptexanim.o` while preserving the matched function bodies.

## Evidence
`build/tools/objdiff-cli diff -p . -u main/maptexanim -o -`

Before:
- `.text`: 99.957085%, size 2796
- `extab`: 76.92308%, size 40
- `extabindex`: 76.92308%, size 60
- unmatched non-@ extras: `__dt__12CMapKeyFrameFv`, `__vc__21CPtrArray<P8CTexture>FUl`, `__vc__22CPtrArray<P9CMaterial>FUl`, `GetAt__21CPtrArray<P8CTexture>FUl`, `GetAt__22CPtrArray<P9CMaterial>FUl`

After:
- `.text`: 99.957085%, size 2796
- `extab`: 90.909096%, size 40
- `extabindex`: 90.909096%, size 60
- unmatched non-@ extras: `__dt__12CMapKeyFrameFv`

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/maptexanim -o -`

This follows the existing `mapanim.cpp` / `texanim.cpp` pattern for suppressing unused ptrarray accessor emission, so the change is source-plausible rather than compiler coaxing.
