### PR TITLE
Match mapocttree static bounds init

### DIFF
--- a/include/ffcc/maphit.h
+++ b/include/ffcc/maphit.h
@@ -41,6 +41,17 @@ public:
         m_boundsMax.x = kMapHitBoundsMaxInit;
     }
 
+    CMapCylinder(float min, float max)
+    {
+        m_boundsMin.z = min;
+        m_boundsMin.y = min;
+        m_boundsMin.x = min;
+
+        m_boundsMax.z = max;
+        m_boundsMax.y = max;
+        m_boundsMax.x = max;
+    }
+
     CBound* GetBound() { return reinterpret_cast<CBound*>(&m_boundsMin); }
     CMapCylinderProbeView& Probe() { return *reinterpret_cast<CMapCylinderProbeView*>(&m_top); }
     const CMapCylinderProbeView& Probe() const { return *reinterpret_cast<const CMapCylinderProbeView*>(&m_top); }

--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -43,6 +43,15 @@ class CBound
 {
 public:
 	CBound();
+	CBound(float min, float max)
+	{
+		m_min.z = min;
+		m_min.y = min;
+		m_min.x = min;
+		m_max.z = max;
+		m_max.y = max;
+		m_max.x = max;
+	}
 	void operator=(const CBound& other)
 	{
 		m_min = other.m_min;

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -18,8 +18,8 @@ extern const float kMapObjBoundMinInit = 10000000000.0f;
 extern const float kMapObjBoundMaxInit = -10000000000.0f;
 extern const float kMapObjZero = 1.0f;
 
-CBound s_bound;
-CMapCylinder s_cyl;
+CBound s_bound(kMapObjBoundMinInit, kMapObjBoundMaxInit);
+CMapCylinder s_cyl(kMapObjBoundMinInit, kMapObjBoundMaxInit);
 Vec s_mvec;
 int s_light_no = 0;
 unsigned long s_shadow_no = 0;


### PR DESCRIPTION
## Summary
- Add explicit bounds constructors for CBound and CMapCylinder so mapocttree globals can express their original static initialization.
- Initialize s_bound and s_cyl with the map-object bound constants used by the target static initializer.

## Evidence
- ninja passes.
- main/mapocttree .text: 96.5448% -> 96.950035%.
- __sinit_mapocttree_cpp: 37.57895% -> 99.47369%.
- extab: 43.617023% -> 44.56522%.

## Plausibility
The target __sinit directly stores the same min/max bounds into s_bound and s_cyl. This keeps the existing default constructors intact for other callers and uses normal C++ construction instead of manual labels or section forcing.