### PR TITLE
Match COctTree::InsertShadow bound copy

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -43,11 +43,6 @@ class CBound
 {
 public:
 	CBound();
-	void operator=(const CBound& other)
-	{
-		m_min = other.m_min;
-		m_max = other.m_max;
-	}
 	static void SetFrustum(Vec&, float(*)[4]);
 	int CheckFrustum0(CBound&);
 	int CheckFrustum0(float);


### PR DESCRIPTION
## Summary
- Remove the custom CBound assignment operator so MWCC uses the implicit memberwise copy.
- This matches the target InsertShadow bound copy as word loads/stores instead of float loads/stores.

## Evidence
- ninja passes for GCCP01.
- main/mapocttree .text: 96.5448% -> 96.94659%.
- InsertShadow__8COctTreeFlR3VecR6CBound: 78.40741% -> 100.0%, size 212 -> 216.
- Full report code: +216 matched bytes and +1 matched function.

## Notes
- extabindex score in main/mapocttree moves down while the function body becomes a full match; this is a localized data-score tradeoff from the corrected function size/source shape.
