### PR TITLE
Name mesh effect node index

### DIFF
--- a/include/ffcc/chara.h
+++ b/include/ffcc/chara.h
@@ -329,7 +329,10 @@ public:
 			CDisplayList* m_displayLists;
 			u32 m_skinCount;
 			CSkin* m_skins;
-			u32 m_infoWord1;
+			union {
+				u32 m_infoWord1;
+				u32 m_effectNodeIndex;
+			};
 			u32 m_nodeIndex;
 		};
 

--- a/src/chara.cpp
+++ b/src/chara.cpp
@@ -57,6 +57,8 @@ STATIC_ASSERT(sizeof(CCharaMeshRaw) == 0x14);
 STATIC_ASSERT(offsetof(CCharaMeshRaw, m_data) == 0x8);
 STATIC_ASSERT(offsetof(CCharaMeshRaw, m_workPositions) == 0xC);
 STATIC_ASSERT(offsetof(CCharaMeshRaw, m_workNormals) == 0x10);
+STATIC_ASSERT(offsetof(CCharaMeshRefRaw, m_effectNodeIndex) == 0x5C);
+STATIC_ASSERT(offsetof(CCharaMeshRefRaw, m_nodeIndex) == 0x60);
 STATIC_ASSERT(offsetof(CChara::CAnim, m_flags) == 0x08);
 STATIC_ASSERT(offsetof(CChara::CAnim, m_interp) == 0x09);
 STATIC_ASSERT(offsetof(CChara::CAnim, m_nodeCount) == 0x0E);

--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -1291,7 +1291,7 @@ void pppFrameMana2(pppMana2* pppMana2, pppMana2UnkB* param_2, _pppCtrlTable* par
                         model->m_data->m_normQuant, model->m_matrix,
                         mana2Work->m_displayListCopies[dlIndex], mana2Work->m_displayListSize,
                         mana2Work->m_meshColors, mana2Work->m_meshTexCoords,
-                        &model->m_nodes[meshData->m_nodeIndex]);
+                        &model->m_nodes[meshData->m_effectNodeIndex]);
                 }
             }
 

--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -364,8 +364,8 @@ void InitPieceData(CChara::CModel* model, PScreenBreak* step, VScreenBreak* work
 
     for (uVar15 = 0; uVar15 < ScreenBreakModelRef(model)->m_meshCount;) {
         ScreenBreakMeshData* meshData = mesh->m_data;
-        CChara::CNode* node = &model->m_nodes[meshData->m_nodeIndex];
-        node->m_flags &= 0x7F;
+        CChara::CNode* node = &model->m_nodes[meshData->m_effectNodeIndex];
+        node->m_flags &= ~0x80;
         PSMTXIdentity(node->m_localRuntimeMtx);
 
         u32 vertexCount = meshData->m_vertexCount;
@@ -657,7 +657,7 @@ int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* para
     for (u32 i = 0; i < ScreenBreakModelRef(model)->m_meshCount; i++) {
         ScreenBreakMeshData* meshData = mesh->m_data;
         if (pieceData->m_active != 0) {
-            MtxPtr nodeMtx = model->m_nodes[meshData->m_nodeIndex].m_localRuntimeMtx;
+            MtxPtr nodeMtx = model->m_nodes[meshData->m_effectNodeIndex].m_localRuntimeMtx;
 
             nodeMtx[0][3] = zero;
             nodeMtx[1][3] = zero;

--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -971,7 +971,7 @@ void pppFrameYmMana(PYmMana* pppYmMana, pppYmManaUnkB* param_2, _pppCtrlTable* p
                         model->m_data->m_posQuant, model->m_data->m_normQuant, model->m_matrix,
                         mana->m_displayListCopies[dlIndex], mana->m_displayListSize, mana->m_meshColors,
                         mana->m_meshTexCoords0, mana->m_meshTexCoords1,
-                        &model->m_nodes[meshShape->m_nodeIndex], pppYmMana, mana);
+                        &model->m_nodes[meshShape->m_effectNodeIndex], pppYmMana, mana);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add an explicit `m_effectNodeIndex` alias for the first mesh INFO word at offset `0x5c`
- use that alias in particle mesh callbacks that index model nodes through the effect-specific INFO word
- add static asserts for the `0x5c` effect node index and normal `0x60` mesh node index layout

## Evidence
- `ninja` passes for GCCP01
- `main/pppScreenBreak` `.text`: 97.289024% -> 97.29081%
  - `InitPieceData`: 89.380394% -> 89.384315%
  - `SB_BeforeCalcMatrixCallback`: 98.55111% -> 98.55556%
- `main/pppYmMana` `.text`: 90.84422% -> 90.84449%
  - `pppFrameYmMana`: 90.64194% -> 90.643364%
- `main/pppMana2` `.text`: 89.09147% -> 89.09179%
  - `pppFrameMana2`: 93.74022% -> 93.74178%

## Plausibility
Ghidra shows the particle mesh paths using the mesh ref word at `0x5c` when selecting a `CNode`, while core `CChara` setup still uses the normal node index at `0x60`. A union alias keeps existing `m_infoWord1` users intact while giving the particle callbacks a field name that matches their observed use.
