### PR TITLE
Match CMapMesh Off2Ptr

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -21,17 +21,17 @@ u32 s_insertShadowNo;
 namespace {
 static inline void AddMeshDataBase(void*& ptr, void* base)
 {
-    ptr = static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr);
+    ptr = reinterpret_cast<void*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void AddMeshDataBase(CMapMeshUvPair*& ptr, void* base)
 {
-    ptr = reinterpret_cast<CMapMeshUvPair*>(static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr));
+    ptr = reinterpret_cast<CMapMeshUvPair*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void AddMeshDataBase(CMapMeshDrawEntry*& ptr, void* base)
 {
-    ptr = reinterpret_cast<CMapMeshDrawEntry*>(static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr));
+    ptr = reinterpret_cast<CMapMeshDrawEntry*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void SubMeshDataBase(void*& ptr, void* base)
@@ -534,11 +534,8 @@ void CMapMesh::Off2Ptr()
     AddMeshDataBase(m_colors, m_meshData);
     AddMeshDataBase(m_drawEntries, m_meshData);
 
-    void* displayListBase = (m_displayListData != 0) ? m_displayListData : m_meshData;
-    CMapMeshDrawEntry* entry = m_drawEntries;
-    for (unsigned int i = 0; i < static_cast<unsigned int>(m_displayListCount); i++) {
-        entry->m_displayList = static_cast<u8*>(displayListBase) + entry->m_displayListOffset;
-        entry++;
+    for (int i = 0; i < static_cast<int>(m_displayListCount); i++) {
+        m_drawEntries[i].m_displayList = static_cast<u8*>(m_meshData) + m_drawEntries[i].m_displayListOffset;
     }
 }
 


### PR DESCRIPTION
## Summary
- Match `CMapMesh::Off2Ptr` by rebuilding display-list pointers from `m_meshData` with an indexed loop.
- Express mesh-data pointer restoration as base-address integer addition so the compiler emits the target load order.

## Objdiff
- `main/mapmesh` `.text`: 98.873924% -> 99.98567%
- `Off2Ptr__8CMapMeshFv`: 70.15385% -> 100.0%
- `ReadOtmMesh__8CMapMeshFR10CChunkFilePQ27CMemory6CStageii`: unchanged at 99.97382%

## Verification
- `ninja` passed
- Full build progress improved by one matched function and +156 matched game-code bytes