### PR TITLE
Improve CMapMesh Off2Ptr matching

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -21,17 +21,17 @@ u32 s_insertShadowNo;
 namespace {
 static inline void AddMeshDataBase(void*& ptr, void* base)
 {
-    ptr = static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr);
+    ptr = reinterpret_cast<void*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void AddMeshDataBase(CMapMeshUvPair*& ptr, void* base)
 {
-    ptr = reinterpret_cast<CMapMeshUvPair*>(static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr));
+    ptr = reinterpret_cast<CMapMeshUvPair*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void AddMeshDataBase(CMapMeshDrawEntry*& ptr, void* base)
 {
-    ptr = reinterpret_cast<CMapMeshDrawEntry*>(static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr));
+    ptr = reinterpret_cast<CMapMeshDrawEntry*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void SubMeshDataBase(void*& ptr, void* base)
@@ -534,11 +534,12 @@ void CMapMesh::Off2Ptr()
     AddMeshDataBase(m_colors, m_meshData);
     AddMeshDataBase(m_drawEntries, m_meshData);
 
-    void* displayListBase = (m_displayListData != 0) ? m_displayListData : m_meshData;
-    CMapMeshDrawEntry* entry = m_drawEntries;
-    for (unsigned int i = 0; i < static_cast<unsigned int>(m_displayListCount); i++) {
-        entry->m_displayList = static_cast<u8*>(displayListBase) + entry->m_displayListOffset;
-        entry++;
+    unsigned int offset = 0;
+    CMapMeshDrawEntry* entry;
+    for (int i = 0; i < static_cast<int>(m_displayListCount); i++) {
+        entry = reinterpret_cast<CMapMeshDrawEntry*>(reinterpret_cast<u8*>(m_drawEntries) + offset);
+        offset += sizeof(CMapMeshDrawEntry);
+        entry->m_displayList = static_cast<u8*>(m_meshData) + entry->m_displayListOffset;
     }
 }
 


### PR DESCRIPTION
## Summary
- Rework CMapMesh::Off2Ptr pointer rebasing to use integer offset addition matching the target code shape.
- Rebase display-list pointers from m_meshData using explicit draw-entry offsets instead of a conditional display-list base pointer.

## Evidence
- ninja: passes
- Off2Ptr__8CMapMeshFv: 70.15385% -> 99.74359%, compiled size 164 -> 156 bytes matching target 156 bytes
- main/mapmesh .text: 98.873924% -> 99.97612%

## Plausibility
- The updated source keeps normal pointer-offset conversion semantics and matches the target Ghidra shape for Off2Ptr.
- No manual vtable/RTTI/section forcing or address hacks.