### PR TITLE
Fix PartyObj flag08 signedness

### DIFF
--- a/include/ffcc/partyobj.h
+++ b/include/ffcc/partyobj.h
@@ -25,7 +25,7 @@ struct PartyObjFlags {
     unsigned char flag40 : 1;
     unsigned char flag20 : 1;
     unsigned char flag10 : 1;
-    unsigned char flag08 : 1;
+    signed char flag08 : 1;
     signed char flag04 : 1;
     unsigned char flag02 : 1;
     unsigned char flag01 : 1;


### PR DESCRIPTION
## Summary
- Change PartyObjFlags::flag08 from unsigned to signed bitfield semantics.
- This matches CGPrgObj::ClassControl case 3 codegen, which treats the input value as signed before inserting bit 3.

## Evidence
- ninja passes.
- Overall build report improved:
  - matched code: 623332 -> 623680 (+348 bytes)
  - matched functions: 3514 -> 3515 (+1)
  - matched data: 1236738 -> 1236954 (+216 bytes)
- main/prgobj objdiff improved:
  - .text: 99.35408% -> 99.499306%
  - ClassControl__8CGPrgObjFii: 98.62069% -> 99.82758%

## Plausibility
- Adjacent flag04 was already signed in PartyObjFlags.
- Ghidra for ClassControl shows flag08 assignment using signed-char semantics before the bit insert, so this is a type correction rather than output coaxing.