### PR TITLE
Improve pppPart cache typing and allocation sizing

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -728,7 +728,7 @@ _pppPObject* pppCreatePObject(_pppMngSt* pppMngSt, _pppPDataVal* pppPDataVal)
 	_pppPDataVal* dataVal = pppPDataVal;
 	_pppProgSetDef* programSet = dataVal->m_programSetDef;
 	s16 numStages = programSet->m_numStages;
-	u32 allocSize = programSet->m_workBaseOffset + ((u32)numStages * sizeof(u32));
+	u32 allocSize = programSet->m_workBaseOffset;
 	CMemory::CStage* stage = ppvEnv->m_stagePtr;
 	_pppPObjLink* newObj = 0;
 	bool firstFailure = true;
@@ -738,7 +738,8 @@ _pppPObject* pppCreatePObject(_pppMngSt* pppMngSt, _pppPDataVal* pppPDataVal)
 	ppvMemAllocErrorF = 0;
 	do
 	{
-		newObj = (_pppPObjLink*)Memory._Alloc(allocSize, stage, const_cast<char*>(s_pppPart_cpp), 0x305, 1);
+		newObj = (_pppPObjLink*)Memory._Alloc(allocSize + ((u32)numStages * sizeof(u32)), stage,
+		                                      const_cast<char*>(s_pppPart_cpp), 0x305, 1);
 		if (newObj != 0)
 		{
 			break;

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -1495,26 +1495,24 @@ void _pppStartPart(_pppMngSt* pppMngSt, long* pdt, int runControlPrograms)
 
 	if (Game.m_currentSceneId != 7)
 	{
-		CMaterialSet* materialSet = PartMng.m_materialSet;
 		short modelCount = *modelIndices;
 		short* modelList = modelIndices + 1;
 		u32 pppResSet = *reinterpret_cast<u32*>(pppMngSt->m_pppResSet);
 
 		for (short i = 0; i < modelCount; i++, modelList++)
 		{
-			CMapMesh* mapMesh = *(CMapMesh**)(*(u32*)(pppResSet + 0x14) + *modelList * 4);
-			short cacheIndex = *reinterpret_cast<short*>(reinterpret_cast<u8*>(mapMesh) + 0x46);
+			pppModelSt* mapMesh = *(pppModelSt**)(*(u32*)(pppResSet + 0x14) + *modelList * 4);
 
-			if (ppvAmemCacheSet.IsEnable(cacheIndex) == 0)
+			if (ppvAmemCacheSet.IsEnable(mapMesh->m_cacheId) == 0)
 			{
 				mapMesh->Ptr2Off();
 				*reinterpret_cast<int*>(reinterpret_cast<u8*>(mapMesh) + 0x24) =
-				    ppvAmemCacheSet.GetData(cacheIndex, (char*)s_pppPart_cpp, 0x4E5);
+				    ppvAmemCacheSet.GetData(mapMesh->m_cacheId, (char*)s_pppPart_cpp, 0x4E5);
 				mapMesh->Off2Ptr();
 			}
 
-			ppvAmemCacheSet.AddRef(cacheIndex);
-			mapMesh->pppCacheLoadModelTexture(materialSet, &ppvAmemCacheSet);
+			ppvAmemCacheSet.AddRef(mapMesh->m_cacheId);
+			mapMesh->pppCacheLoadModelTexture(PartMng.m_materialSet, &ppvAmemCacheSet);
 		}
 
 		short shapeCount = *shapeIndices;
@@ -1524,7 +1522,7 @@ void _pppStartPart(_pppMngSt* pppMngSt, long* pdt, int runControlPrograms)
 
 		for (short i = 0; i < shapeCount; i++, shapeList++)
 		{
-			pppCacheLoadShapeTexture(*(pppShapeSt**)(shapeNames + *shapeList * 4), materialSet);
+			pppCacheLoadShapeTexture(*(pppShapeSt**)(shapeNames + *shapeList * 4), PartMng.m_materialSet);
 		}
 
 		pppMngSt->m_mapTexLoaded = 1;


### PR DESCRIPTION
## Summary
- Type _pppStartPart model entries as pppModelSt so the cache id is read via m_cacheId at the real 0x66 layout offset.
- Avoid hoisting PartMng.m_materialSet in _pppStartPart texture-loading calls, matching the source shape shown by Ghidra.
- Keep pppCreatePObject allocation sizing closer to the decompilation by preserving the base work size and adding the stage-slot tail at the allocation call.

## Objdiff Evidence
- main/pppPart .text: 83.60966% -> 83.91089%
- _pppStartPart__FP9_pppMngStPli: 72.48256% -> 75.50291%
- pppCreatePObject__FP9_pppMngStP12_pppPDataVal: 71.63214% -> 71.953575%

## Plausibility
- pppModelSt already extends CMapMesh and declares m_cacheId at 0x66, matching Ghidra's cache-id loads in _pppStartPart.
- The allocation sizing change follows Ghidra's separate objBaseSize plus numStages * 4 shape without changing behavior.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppPart -o - _pppStartPart__FP9_pppMngStPli
- build/tools/objdiff-cli diff -p . -u main/pppPart -o - pppCreatePObject__FP9_pppMngStP12_pppPDataVal