### PR TITLE
Improve material cache and laser rendering matches

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2999,7 +2999,7 @@ void CMaterialSet::CacheDumpTexture(int materialIndex, CAmemCacheSet* amemCacheS
     CMaterial* material =
         m_materials[static_cast<unsigned long>(materialIndex)];
     if (material != 0) {
-        material->CacheDumpTexture(amemCacheSet);
+        material->CacheUnLoadTexture(amemCacheSet);
     }
 }
 

--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -61,7 +61,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 	int colorOffset = serializedDataOffsets[1];
 	pppYmLaserColorData* colorData = (pppYmLaserColorData*)(laser->m_workArea + colorOffset);
 	s32 dataValIndex = step->m_dataValIndex;
-	s32 count;
+	u32 count;
 	s32 i;
 	s32 alphaStep;
 	char alphaMax;


### PR DESCRIPTION
## Summary
- Route CMaterialSet::CacheDumpTexture through CacheUnLoadTexture, matching the target call path.
- Treat the pppRenderYmLaser polygon count as unsigned, matching Ghidra uint flow and improving objdiff.

## Objdiff evidence
- main/materialman CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet: 98.78788% -> 98.93939%.
- main/pppYmLaser pppRenderYmLaser: 97.885635% -> 98.03458%.

## Validation
- ninja
- git diff --check
- build/tools/objdiff-cli diff -p . -u main/materialman -o /tmp/mat_dump_final.json CacheDumpTexture__12CMaterialSetFiP13CAmemCacheSet
- build/tools/objdiff-cli diff -p . -u main/pppYmLaser -o /tmp/pppYmLaser_final.json pppRenderYmLaser