### PR TITLE
Improve CGame Create matching

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -502,19 +502,21 @@ void CGame::Create()
 
     if (strlen(m_startScriptName) != 0) {
         strcpy(scriptName, m_startScriptName);
-        u32* src = reinterpret_cast<u32*>(scriptName);
-        u32* dst = reinterpret_cast<u32*>(m_nextScript.m_name);
+        u32* src = reinterpret_cast<u32*>(scriptName) - 1;
+        u32* dst = reinterpret_cast<u32*>(&m_nextScript);
         int count = sizeof(scriptName) / (sizeof(u32) * 2);
         do {
-            *dst++ = *src++;
-            *dst++ = *src++;
+            dst[1] = src[1];
+            src += 2;
+            dst += 2;
+            dst[0] = src[0];
         } while (--count != 0);
         m_newGameFlag = 1;
     }
 
     if (m_newGameFlag == 0) {
-        mapId = m_currentMapId;
         mapVariant = m_currentMapVariantId;
+        mapId = m_currentMapId;
 
         Graphic._WaitDrawDone(const_cast<char*>(s_game_cpp), 0x24E);
         System.MapChanging(mapId, mapVariant);


### PR DESCRIPTION
## Summary
- Reshape the start-script copy in CGame::Create to match the object layout used by the target code.
- Load the current map variant before the map id to match the target register/order shape.

## Evidence
- ninja passes.
- Create__5CGameFv improved from 93.196075% to 94.5% at the same 408 byte size.
- LoadScript__5CGameFPc and SaveScript__5CGameFPc remain unchanged.

## Plausibility
- The copy still performs a 256-byte word copy into m_nextScript.m_name; it just uses the enclosing CNextScript layout so the stores line up with the target name offset.
- The map id/variant assignment order follows the order shown by the decompilation and does not alter behavior.