### PR TITLE
Inline unused chara viewer helper

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -176,7 +176,7 @@ extern "C" const char s_back_tex_fmt[] = "%sback.tex";
  * JP Address: TODO
  * JP Size: TODO
  */
-void sendVertex(coord* vertex)
+inline void sendVertex(coord* vertex)
 {
     GXPosition3f32(vertex->pos.x, vertex->pos.y, vertex->pos.z);
     GXTexCoord2f32(vertex->s, vertex->t);


### PR DESCRIPTION
Summary
- Mark sendVertex in p_chara_viewer.cpp as inline.
- This follows the runbook rule for known UNUSED helpers so the function can remain documented without emitting a standalone unused symbol.

Evidence
- ninja passes for GCCP01.
- objdiff for main/p_chara_viewer no longer shows sendVertex__FP5coord emitted on the built/right side.
- Viewer target functions remain stable in the generated report: drawViewer 98.47381%, calcViewer 90.6697%, destroyViewer 100%, createViewer 99.323944%.

Plausibility
- The helper is explicitly marked PAL Address: UNUSED; inlining avoids a standalone unused emission without changing call behavior or adding compiler-output hacks.