### PR TITLE
Match CGObject SetDispItemName

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3073,7 +3073,7 @@ void CGObject::SetDispItemName(int showName)
         unsigned char unk0 : 1;
         unsigned char unk1 : 1;
         unsigned char unk2 : 1;
-        unsigned char dispItemName : 1;
+        signed char dispItemName : 1;
         unsigned char unk4 : 1;
         unsigned char unk5 : 1;
         unsigned char unk6 : 1;


### PR DESCRIPTION
## Summary
- Make the local display-item-name bitfield signed so CGObject::SetDispItemName sign-extends the incoming value before inserting the flag bit.
- This matches the target extsb + rlwimi sequence while preserving the existing int function signature.

## Evidence
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/gobject -o - SetDispItemName__8CGObjectFi reports SetDispItemName__8CGObjectFi: 28 bytes, 100.0% match.
- Build progress increased matched code by 28 bytes / one function, from 3514 to 3515 matched functions in the progress summary during this run.

## Plausibility
- Ghidra shows the parameter used as a signed char for this packed flag update.
- The source change keeps the packed bitfield representation and only corrects the signedness of the specific bit being assigned.