### PR TITLE
Match pppYmCheckBGHeight frame

### DIFF
--- a/src/pppYmCheckBGHeight.cpp
+++ b/src/pppYmCheckBGHeight.cpp
@@ -24,6 +24,15 @@ static inline Vec* CheckBGHeightTargetPosition(_pppMngSt* mng)
     return &mng->m_paramVec0;
 }
 
+struct CheckBGHeightCylinder {
+    Vec m_bottom;
+    Vec m_top;
+    Vec m_axis;
+    float m_radius;
+    Vec m_boundsMin;
+    Vec m_boundsMax;
+};
+
 /*
  * --INFO--
  * PAL Address: 0x800d8abc
@@ -38,7 +47,7 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(
 {
     _pppMngSt* pppMngSt;
     Vec direction;
-    CMapCylinder cylinder;
+    CheckBGHeightCylinder cylinder;
     Vec hitPos;
     float nextY;
     float zero;
@@ -79,7 +88,7 @@ struct pppYmCheckBGHeight* pppFrameYmCheckBGHeight(
         cylinder.m_axis.z = zero;
         cylinder.m_radius = zero;
 
-        if (MapMng.CheckHitCylinderNear(&cylinder, &direction, (unsigned long)-1) != 0) {
+        if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cylinder), &direction, (unsigned long)-1) != 0) {
             MapMng.m_hitMapObj->CalcHitPosition(&hitPos);
             if ((nextY - param_2->m_unk0xC) > hitPos.y) {
                 finalY = nextY;


### PR DESCRIPTION
## Summary
- replace the constructed CMapCylinder local in pppFrameYmCheckBGHeight with a raw cylinder layout matching the fields this function initializes manually
- pass the raw layout to CheckHitCylinderNear, avoiding the redundant CMapCylinder constructor stores that were emitted before the user-stop check

## Evidence
Before:
- main/pppYmCheckBGHeight .text: 90.90909%
- pppFrameYmCheckBGHeight: 90.804596%
- extabindex: 91.66667%

After:
- main/pppYmCheckBGHeight .text: 100.0%
- pppFrameYmCheckBGHeight: 100.0%
- extabindex: 100.0%
- .sdata2 remains 100.0%

Verification:
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmCheckBGHeight -o -