### PR TITLE
Mark unused pppCrystal helpers inline

### DIFF
--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -55,7 +55,7 @@ struct HSD_ImageBuffer {
     u32 m_bufferSize;
 };
 
-void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32);
+inline void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32);
 
 static inline CrystalWork* GetCrystalWork(pppCrystal* crystal, _pppCtrlTable* ctrl)
 {
@@ -402,7 +402,7 @@ void pppConstructCrystal(struct pppCrystal* pppCrystal, struct _pppCtrlTable* pa
  * JP Address: TODO
  * JP Size: TODO
  */
-void MakeRefractionMap(HSD_ImageBuffer* imageBuffer)
+inline void MakeRefractionMap(HSD_ImageBuffer* imageBuffer)
 {
     u32 y;
     u32 x;
@@ -471,7 +471,7 @@ void MakeRefractionMap(HSD_ImageBuffer* imageBuffer)
  * JP Address: TODO
  * JP Size: TODO
  */
-void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32)
+inline void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32)
 {
     u32 yTile = y >> 2;
     u32 yFine = (y & 3) * 4;


### PR DESCRIPTION
## What changed
- Marked the UNUSED `MakeRefractionMap` and `ImageBufferSetPixel_IA8` helpers in `src/pppCrystal.cpp` as `inline`.
- This keeps the recovered helper source available without emitting non-original out-of-line functions, matching the runbook guidance for UNUSED functions that cause extab regressions.

## Evidence
- `ninja` passes.
- `main/pppCrystal` data improved from `132 / 192` matched (`68.75%`) to `192 / 192` matched (`100.0%`).
- `extab` improved from `85.71429%` to `100.0%`.
- `extabindex` improved from `85.71429%` to `100.0%`.
- Code function scores are unchanged: `pppRenderCrystal` `99.9169%`, `pppFrameCrystal` `98.833336%`, destruct/construct `100.0%`.
- Global matched data increased by 60 bytes: `1236738` to `1236798`.

## Plausibility
The two helpers are already marked `PAL Address: UNUSED`; inlining prevents them from being emitted while preserving plausible source and avoiding extra non-original symbols/extab entries.