### PR TITLE
Improve ME USB SRT conversions

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -165,13 +165,13 @@ void CMaterialEditorPcs::SetUSBData()
         s32 yDiff = static_cast<s32>(maxPos.z - minPos.z);
 
         srt.rotZ = FLOAT_8032FD00;
-        srt.transY = (float)(-xDiff / 2);
+        srt.transY = S32ToFloat(-xDiff / 2);
         srt.rotY = FLOAT_8032FD00;
         srt.rotX = FLOAT_8032FD00;
         srt.scaleZ = FLOAT_8032FD04;
         srt.scaleY = FLOAT_8032FD04;
         srt.scaleX = FLOAT_8032FD04;
-        srt.transZ = (float)(-yDiff * (xDiff / 0x14) - 10);
+        srt.transZ = S32ToFloat(-yDiff * (xDiff / 0x14) - 10);
         srt.transX = FLOAT_8032FD00;
         CameraPcs.SetViewerSRT(reinterpret_cast<const SRT*>(&srt));
         break;


### PR DESCRIPTION
## Summary
- Use the existing signed-int-to-float conversion helper for material editor viewer SRT translations in SetUSBData.
- Removes the anonymous conversion constant emitted by direct casts and aligns the function size with the target.

## Evidence
- ninja passes for GCCP01.
- SetUSBData__18CMaterialEditorPcsFv: 95.82525% -> 96.051%.
- SetUSBData__18CMaterialEditorPcsFv size: built 4764b -> 4784b, matching target 4784b.
- extabindex: 97.5% -> 100.0%.
- .data: 55.147057% -> 94.85294%.

## Plausibility
- S32ToFloat already existed in this source file and references the real DOUBLE_8032FD08 conversion bias.
- The edited expressions preserve the original integer arithmetic and only make the conversion path explicit.