### PR TITLE
Inline texture helper methods

### DIFF
--- a/include/ffcc/textureman.h
+++ b/include/ffcc/textureman.h
@@ -26,8 +26,21 @@ public:
     void Create(CChunkFile&, CMemory::CStage*, CAmemCacheSet*, int, int);
     void CacheLoadTexture(CAmemCacheSet*);
     void CacheUnLoadTexture(CAmemCacheSet*);
-    void CacheRefCnt0UpTexture(CAmemCacheSet*);
-    void CacheDumpTexture(CAmemCacheSet*);
+    void CacheRefCnt0UpTexture(CAmemCacheSet* amemCacheSet)
+    {
+        if (m_cacheId != -1) {
+            amemCacheSet->RefCnt0Up(m_cacheId);
+        }
+    }
+    void CacheDumpTexture(CAmemCacheSet* amemCacheSet)
+    {
+        if (m_cacheId != -1) {
+            if (GetRef() <= 1) {
+                m_imageData = 0;
+            }
+            amemCacheSet->Release(m_cacheId);
+        }
+    }
     int CheckName(char*);
     void SetExternalTlut(void*, int);
     void FlushExternalTlut(void*, int);
@@ -68,8 +81,8 @@ public:
     void Create(CChunkFile&, CMemory::CStage*, int, CAmemCacheSet*, int, int);
     int Find(char*);
     void ReleaseTextureIdx(int, CAmemCacheSet*);
-    CTexture* GetTexture(long);
-    int GetNumTexture();
+    CTexture* GetTexture(long index) { return m_textureArray[static_cast<unsigned long>(index)]; }
+    int GetNumTexture() { return m_textureArray.GetSize(); }
 
     CPtrArray<CTexture*> m_textureArray;
 };

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -107,26 +107,6 @@ int CTextureSet::Find(char* name)
 
 /*
  * --INFO--
- * Address: TODO
- * Size: TODO
- */
-CTexture* CTextureSet::GetTexture(long index)
-{
-    return m_textureArray[static_cast<unsigned long>(index)];
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-int CTextureSet::GetNumTexture()
-{
-    return m_textureArray.GetSize();
-}
-
-/*
- * --INFO--
  * PAL Address: 0x8003A77C
  * PAL Size: 560b
  * EN Address: TODO
@@ -563,41 +543,6 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
 int CTexture::CheckName(char* name)
 {
     return strcmp(m_name, name) == 0;
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8003EC14
- * PAL Size: 84b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CTexture::CacheDumpTexture(CAmemCacheSet* amemCacheSet)
-{
-    if (m_cacheId != -1) {
-        if (GetRef() <= 1) {
-            m_imageData = 0;
-        }
-        amemCacheSet->Release(m_cacheId);
-    }
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8003EC68
- * PAL Size: 52b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-void CTexture::CacheRefCnt0UpTexture(CAmemCacheSet* amemCacheSet)
-{
-    if (m_cacheId != -1) {
-        amemCacheSet->RefCnt0Up(m_cacheId);
-    }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Move simple `CTextureSet` accessors into the header as inline methods.
- Move `CTexture` cache dump/ref-count helpers into the header as inline methods.
- Remove the out-of-line `textureman.cpp` definitions that were emitted as extra functions in `textureman.o`.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/textureman -o /tmp/textureman_final.json`
- Before: current `.text` size 7304 vs target 7100, extab 320 vs 288, extabindex 420 vs 372.
- After: current `.text` size 7104 vs target 7100, extab 288 vs 288, extabindex 372 vs 372.
- Removed unmatched current-side functions: `GetTexture__11CTextureSetFl`, `GetNumTexture__11CTextureSetFv`, `CacheDumpTexture__8CTextureFP13CAmemCacheSet`, `CacheRefCnt0UpTexture__8CTextureFP13CAmemCacheSet`.

## Plausibility
These are small accessors/cache wrappers that are natural header-inline methods in the original source. Making them inline removes standalone functions that were not present in the target `textureman` unit and fixes the exception table section sizes without changing behavior.