### PR TITLE
Improve CMapMesh Off2Ptr matching

### DIFF
--- a/src/mapmesh.cpp
+++ b/src/mapmesh.cpp
@@ -21,17 +21,17 @@ u32 s_insertShadowNo;
 namespace {
 static inline void AddMeshDataBase(void*& ptr, void* base)
 {
-    ptr = static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr);
+    ptr = reinterpret_cast<void*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void AddMeshDataBase(CMapMeshUvPair*& ptr, void* base)
 {
-    ptr = reinterpret_cast<CMapMeshUvPair*>(static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr));
+    ptr = reinterpret_cast<CMapMeshUvPair*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void AddMeshDataBase(CMapMeshDrawEntry*& ptr, void* base)
 {
-    ptr = reinterpret_cast<CMapMeshDrawEntry*>(static_cast<u8*>(base) + reinterpret_cast<unsigned int>(ptr));
+    ptr = reinterpret_cast<CMapMeshDrawEntry*>(reinterpret_cast<unsigned int>(ptr) + reinterpret_cast<unsigned int>(base));
 }
 
 static inline void SubMeshDataBase(void*& ptr, void* base)
@@ -534,11 +534,9 @@ void CMapMesh::Off2Ptr()
     AddMeshDataBase(m_colors, m_meshData);
     AddMeshDataBase(m_drawEntries, m_meshData);
 
-    void* displayListBase = (m_displayListData != 0) ? m_displayListData : m_meshData;
-    CMapMeshDrawEntry* entry = m_drawEntries;
-    for (unsigned int i = 0; i < static_cast<unsigned int>(m_displayListCount); i++) {
-        entry->m_displayList = static_cast<u8*>(displayListBase) + entry->m_displayListOffset;
-        entry++;
+    for (int i = 0; i < static_cast<int>(m_displayListCount); i++) {
+        CMapMeshDrawEntry* entry = &m_drawEntries[i];
+        entry->m_displayList = static_cast<u8*>(m_meshData) + entry->m_displayListOffset;
     }
 }
 


### PR DESCRIPTION
## Summary
- Treat CMapMesh stored pointer fields as integer offsets when rebasing them onto m_meshData.
- Rebase display-list pointers from m_meshData directly in Off2Ptr, matching the target behavior.
- Use indexed draw-entry access with a signed loop counter to match the target loop shape.

## Evidence
- build/tools/objdiff-cli diff -p . -u main/mapmesh -o - Off2Ptr__8CMapMeshFv
- Before: Off2Ptr 70.15385% match, compiled size 164 bytes
- After: Off2Ptr 99.10256% match, compiled size 156 bytes (target size 156 bytes)

## Verification
- ninja
- ninja build/GCCP01/main.dol