### PR TITLE
Move TraceMove float constants

### DIFF
--- a/src/pppYmMana.cpp
+++ b/src/pppYmMana.cpp
@@ -23,7 +23,7 @@ extern const float FLOAT_80330e4c = 0.0f;
 extern const char s_ymManaRuin2Name[] = "ruin_2";
 extern const float FLOAT_80330e58;
 static const float LOCAL_FLOAT_80330e58 = 1.0f;
-extern const float FLOAT_80330e5c = 0.5f;
+extern const float FLOAT_80330e5c;
 
 extern const float FLOAT_80330e60 = 2.0f;
 extern const float FLOAT_80330e64 = 0.015625f;

--- a/src/pppYmTraceMove.cpp
+++ b/src/pppYmTraceMove.cpp
@@ -130,3 +130,6 @@ void pppConstructYmTraceMove(pppYmTraceMove* pppYmTraceMove, pppYmTraceMoveCtrl*
 	work->m_velocity = zero;
 	work->m_distance = zero;
 }
+
+extern const float FLOAT_80330e58 = 1.0f;
+extern const float FLOAT_80330e5c = 0.5f;


### PR DESCRIPTION
## Summary
- Move `FLOAT_80330e58` and `FLOAT_80330e5c` definitions into `pppYmTraceMove.cpp`, matching the `config/GCCP01/splits.txt` `.sdata2` range for `pppYmTraceMove.cpp` (`0x80330E58..0x80330E60`).
- Leave `pppYmMana.cpp` with declarations for those shared constants.

## Evidence
- `ninja` succeeds.
- Project report data matched increased by 8 bytes: `1239258 -> 1239266`.
- `main/pppYmTraceMove` `.sdata2`: `0.0% -> 100.0%`.
- `FLOAT_80330e58` and `FLOAT_80330e5c`: now both `100.0%` in `pppYmTraceMove`.
- Adjacent `main/pppYmMoveParabola` remained unchanged: `.text 99.74708%`, `.sdata2 100.0%`.

## Plausibility
The split file assigns `0x80330E58..0x80330E60` to `pppYmTraceMove.cpp`, so defining the two floats there removes an ownership mismatch instead of forcing codegen.
