### PR TITLE
Correct letter attach item index signedness

### DIFF
--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -69,7 +69,7 @@ static unsigned char s_OpenClose = 0;
 static unsigned char s_ReplyMax = 0;
 static unsigned char s_ReplyPos = 0;
 static signed char s_Attach = 0;
-static unsigned char s_AttachItemIdx = 0;
+static signed char s_AttachItemIdx = 0;
 static int s_AttachItem = 0;
 static int s_AttachMode = 0;
 static int s_BackUpCur[2];
@@ -2555,7 +2555,7 @@ void CMenuPcs::LetterSetAttachItem(unsigned int itemIndex, int flag)
 	unsigned int caravanWork = Game.m_scriptFoodBase[0];
 
 	if (s_Attach == 0) {
-		s_AttachItemIdx = static_cast<unsigned char>(itemIndex);
+		s_AttachItemIdx = static_cast<signed char>(itemIndex);
 		caravanWork += itemIndex * 2;
 		s_AttachItem = *reinterpret_cast<short*>(caravanWork + 0xB6);
 	} else {


### PR DESCRIPTION
## Summary
- Change `s_AttachItemIdx` in `menu_letter.cpp` from unsigned to signed storage.
- Store the attach item index through a signed-char cast to match its signed consumption path.

## Evidence
- `ninja` passes for GCCP01.
- `LetterSetAttachItem__8CMenuPcsFUii`: 100.0% match, 64b.
- `LetterCtrlCur__8CMenuPcsFv`: improved from 25.685743% baseline to 25.790842% in this run.
- `LetterMessDraw__8CMenuPcsFv`: unchanged at 56.51574%.

## Plausibility
`s_AttachItemIdx` is later passed as an integer to item deletion logic; treating the stored byte as signed matches the target sign-extension behavior more closely than preserving it as unsigned.