### PR TITLE
Inline Ryj mega birth matrix init

### DIFF
--- a/include/ffcc/pppRyjMegaBirthModel.h
+++ b/include/ffcc/pppRyjMegaBirthModel.h
@@ -89,7 +89,6 @@ struct PRyjMegaBirthModelOffsets
 void calc_particle(_pppPObject*, VRyjMegaBirthModel*, PRyjMegaBirthModel*, VColor*);
 void birth(_pppPObject*, VRyjMegaBirthModel*, PRyjMegaBirthModel*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
 void calc(_pppPObject*, VRyjMegaBirthModel*, PRyjMegaBirthModel*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
-void init_matrix(_pppPObject*, pppFMATRIX&, PRyjMegaBirthModel*, VRyjMegaBirthModel*);
 void set_matrix(_pppPObject*, pppFMATRIX, pppFMATRIX, PRyjMegaBirthModel*, _PARTICLE_DATA*, _PARTICLE_WMAT*, pppFMATRIX&, unsigned char);
 
 #ifdef __cplusplus

--- a/src/pppRyjMegaBirthModel.cpp
+++ b/src/pppRyjMegaBirthModel.cpp
@@ -877,6 +877,40 @@ void calc(_pppPObject* pppPObject, VRyjMegaBirthModel* vRyjMegaBirthModel,
 
 /*
  * --INFO--
+ * Address: TODO
+ * Size: TODO
+ */
+static inline void init_matrix(_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirthModel* params, VRyjMegaBirthModel* work)
+{
+    (void)pObject;
+    switch (params->m_spawnMode) {
+    case 1:
+    case 3:
+    case 5:
+    case 7:
+    case 9:
+        PSMTXIdentity(out.value);
+        out.value[0][0] = ppvMng->m_scale.x;
+        out.value[1][1] = ppvMng->m_scale.y;
+        out.value[2][2] = ppvMng->m_scale.z;
+        out.value[0][3] = ppvMng->m_position.x;
+        out.value[1][3] = ppvMng->m_position.y;
+        out.value[2][3] = ppvMng->m_position.z;
+        break;
+    case 8:
+        PSMTXIdentity(out.value);
+        out.value[0][3] = work->m_currentPosition.x;
+        out.value[1][3] = work->m_currentPosition.y;
+        out.value[2][3] = work->m_currentPosition.z;
+        break;
+    default:
+        PSMTXCopy(ppvMng->m_matrix.value, out.value);
+        break;
+    }
+}
+
+/*
+ * --INFO--
  * PAL Address: 0x8008521c
  * PAL Size: 2076b
  * EN Address: TODO
@@ -975,40 +1009,6 @@ void pppRyjDrawMegaBirthModel(_pppPObject* obj, void* stepData, _pppCtrlTable* c
         pppSetBlendMode(params->m_blendMode);
         pppDrawMesh((pppModelSt*)ppvEnv->m_mapMeshPtr[modelIndex], obj->m_drawMatrixPtr, 1);
         pppCopyMatrix(obj->m_localMatrix, *(pppFMATRIX*)&g_matTmp);
-    }
-}
-
-/*
- * --INFO--
- * Address: TODO
- * Size: TODO
- */
-void init_matrix(_pppPObject* pObject, pppFMATRIX& out, PRyjMegaBirthModel* params, VRyjMegaBirthModel* work)
-{
-    (void)pObject;
-    switch (params->m_spawnMode) {
-    case 1:
-    case 3:
-    case 5:
-    case 7:
-    case 9:
-        PSMTXIdentity(out.value);
-        out.value[0][0] = ppvMng->m_scale.x;
-        out.value[1][1] = ppvMng->m_scale.y;
-        out.value[2][2] = ppvMng->m_scale.z;
-        out.value[0][3] = ppvMng->m_position.x;
-        out.value[1][3] = ppvMng->m_position.y;
-        out.value[2][3] = ppvMng->m_position.z;
-        break;
-    case 8:
-        PSMTXIdentity(out.value);
-        out.value[0][3] = work->m_currentPosition.x;
-        out.value[1][3] = work->m_currentPosition.y;
-        out.value[2][3] = work->m_currentPosition.z;
-        break;
-    default:
-        PSMTXCopy(ppvMng->m_matrix.value, out.value);
-        break;
     }
 }
 


### PR DESCRIPTION
## Summary
- Make init_matrix a private inline helper in pppRyjMegaBirthModel.cpp.
- Remove the public header declaration for a helper that only has a local call site.
- This prevents the compiler from emitting an extra standalone init_matrix__FP11_pppPObjectR10pppFMATRIXP18PRyjMegaBirthModelP18VRyjMegaBirthModel symbol.

## Objdiff Evidence
Command: build/tools/objdiff-cli diff -p . -u main/pppRyjMegaBirthModel -o -

Before:
- extra compiled symbol: init_matrix__FP11_pppPObjectR10pppFMATRIXP18PRyjMegaBirthModelP18VRyjMegaBirthModel size 224, no target match
- extab: 64 bytes, 35.294117%
- pppRyjDrawMegaBirthModel: compiled size 1616 vs target 2076, 43.183044%

After:
- extra init_matrix symbol removed
- extab: 64 bytes, 37.5%
- pppRyjDrawMegaBirthModel: compiled size 1752 vs target 2076, 40.77842%

## Plausibility
init_matrix has no target symbol and is only used by pppRyjDrawMegaBirthModel, so treating it as an inline file-local helper is more plausible than exposing it through the header. The local draw-function instruction score still needs follow-up work, but the emitted symbol and extab shape move closer to the target.