### PR TITLE
Improve pppYmLaser render UV conversion

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -9,7 +9,6 @@
 #include "ffcc/linkage.h"
 extern "C" {
 extern const f32 kPppYmLaserOne;
-extern const f64 kPppVertexApMtxDoubleBias;
 }
 #include "ffcc/util.h"
 #include "ffcc/pppPart.h"
@@ -35,21 +34,6 @@ extern "C" const char s_pppYmLaser_cpp[] = "pppYmLaser.cpp";
 static inline f32 LoadLaserFloat(const f32& value)
 {
 	return value;
-}
-
-static inline f32 YmLaserU32ToFloat(u32 value)
-{
-	union {
-		struct {
-			u32 hi;
-			u32 lo;
-		} words;
-		f64 value;
-	} cvt;
-
-	cvt.words.hi = 0x43300000;
-	cvt.words.lo = value;
-	return static_cast<f32>(cvt.value - kPppVertexApMtxDoubleBias);
 }
 
 static inline pppYmLaserWork* GetYmLaserWork(pppYmLaser* laser, _pppCtrlTable* ctrlTable)
@@ -180,7 +164,7 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppYmLaserUnkB* step, _pppCt
 		           step->m_laser.m_blendMode);
 
 		count = step->m_laser.m_pointCount;
-		uvStep = YmLaserConst(FLOAT_80330DC4) / YmLaserU32ToFloat(count);
+		uvStep = YmLaserConst(FLOAT_80330DC4) / (float)count;
 		if (step->m_initWOrk == 0xFFFF) {
 			_GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
 			_GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);


### PR DESCRIPTION
## Summary
- Use the compiler normal float conversion for the pppRenderYmLaser point-count UV step.
- Remove the now-unused custom YmLaserU32ToFloat helper and bias constant declaration.

## Evidence
- ninja passes.
- main/pppYmLaser .text: 98.142235% -> 98.4059%.
- pppRenderYmLaser: 97.63032% -> 98.03458%.
- pppFrameYmLaser remains 98.899086%; data sections remain matched.

## Rationale
The direct float cast emits the target-style double conversion with frsp, while the previous hand-written helper folded the conversion differently. This is a simpler and more plausible source expression for deriving the trail UV step from m_pointCount.