### PR TITLE
Match boss artifact stage offset table

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1245,7 +1245,7 @@ void CGame::Draw()
  */
 int CGame::GetBossArtifact(int ratioIndex, int amount)
 {
-    static s16 s_top[] = {0, 4, 8};
+    static s16 s_top[] = {0, 2, 4, 0};
 
     int stage =
         Game.m_gameWork.m_bossArtifactStageTable[Game.m_gameWork.m_bossArtifactStageIndex];


### PR DESCRIPTION
## Summary
- Correct `CGame::GetBossArtifact` local `s_top` table to match the target data: `{0, 2, 4, 0}`.
- This also makes the table emitted size match the original 8-byte local object.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/game -o /tmp/game_final.json`
- `s_top$724`: 71.42857% -> 100.0%.
- `game` `.sdata`: 62.698414% -> 72.22222%.
- `game` `.text` unchanged at 97.707985%.

## Plausibility
The target data decodes to four `s16` entries (`0, 2, 4, 0`). `GetBossArtifact` clamps the stage index to 0..2 before indexing this table, so the fourth entry is natural padding while the first three entries provide the original artifact stage offsets.