### PR TITLE
Match CMenu RTTI string ownership

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -1063,6 +1063,7 @@ menu.cpp:
 	.text       start:0x8009B3B4 end:0x8009B4E4
 	.data       start:0x8020F968 end:0x8020F998
 	.sdata      start:0x8032E7D8 end:0x8032E7E8
+	.sdata2     start:0x803308B8 end:0x803308C8
 
 mesmenu.cpp:
 	extab       start:0x80007DA0 end:0x80007E04

--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -182,7 +182,10 @@ private:
     unsigned char m_letterFlags;      // 0x2C89
     unsigned char _pad2C8A[0x28];     // 0x2C8A
     GbaCMakeInfo cmakeInfo[4];        // 0x2CB2
-    unsigned char _pad2D32[0x12];     // 0x2D32
+    unsigned char _pad2D32[0x6];      // 0x2D32
+    unsigned char m_shopFlags;        // 0x2D38
+    unsigned char m_shopModeFlags;    // 0x2D39
+    unsigned char _pad2D3A[0xA];      // 0x2D3A
     GbaQueueHitInfo m_hitInfo[4];      // 0x2D44
     unsigned char m_chgHitFlags;      // 0x2D54
     unsigned char m_chgScouFlags;     // 0x2D55

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -3635,18 +3635,17 @@ int GbaQueue::GetEquipData(int channel, unsigned char* outData)
 void GbaQueue::SetShopFlg(int channel)
 {
 	OSSemaphore* semaphore = accessSemaphores + channel;
-	u8* flags = reinterpret_cast<u8*>(this) + 0x2D38;
 
 	OSWaitSemaphore(semaphore);
 	int mask = 1;
 	mask <<= channel;
-	*flags = static_cast<u8>(*flags | mask);
+	m_shopFlags = static_cast<u8>(m_shopFlags | mask);
 	OSSignalSemaphore(semaphore);
 
 	if (Joybus.SetMType(channel, 2) != 0) {
-		flags[1] = static_cast<u8>(flags[1] | mask);
+		m_shopModeFlags = static_cast<u8>(m_shopModeFlags | mask);
 	} else {
-		flags[1] = static_cast<u8>(flags[1] & ~mask);
+		m_shopModeFlags = static_cast<u8>(m_shopModeFlags & ~mask);
 	}
 }
 
@@ -3658,11 +3657,10 @@ void GbaQueue::SetShopFlg(int channel)
 void GbaQueue::ClrShopFlg(int channel)
 {
 	const unsigned char playerMask = static_cast<unsigned char>(1 << channel);
-	unsigned char* flags = reinterpret_cast<unsigned char*>(this) + 0x2D38;
 
 	OSWaitSemaphore(accessSemaphores + channel);
-	flags[0] = static_cast<unsigned char>(flags[0] & ~playerMask);
-	flags[1] = static_cast<unsigned char>(flags[1] & ~playerMask);
+	m_shopFlags = static_cast<unsigned char>(m_shopFlags & ~playerMask);
+	m_shopModeFlags = static_cast<unsigned char>(m_shopModeFlags & ~playerMask);
 	OSSignalSemaphore(accessSemaphores + channel);
 
 	for (int retry = 0; retry < 10; retry++) {
@@ -3684,18 +3682,17 @@ void GbaQueue::ClrShopFlg(int channel)
 void GbaQueue::SetSmithFlg(int channel)
 {
 	OSSemaphore* semaphore = accessSemaphores + channel;
-	u8* flags = reinterpret_cast<u8*>(this) + 0x2D38;
 
 	OSWaitSemaphore(semaphore);
 	int mask = 0x10;
 	mask <<= channel;
-	*flags = static_cast<u8>(*flags | mask);
+	m_shopFlags = static_cast<u8>(m_shopFlags | mask);
 	OSSignalSemaphore(semaphore);
 
 	if (Joybus.SetMType(channel, 3) != 0) {
-		flags[1] = static_cast<u8>(flags[1] | mask);
+		m_shopModeFlags = static_cast<u8>(m_shopModeFlags | mask);
 	} else {
-		flags[1] = static_cast<u8>(flags[1] & ~mask);
+		m_shopModeFlags = static_cast<u8>(m_shopModeFlags & ~mask);
 	}
 }
 
@@ -3707,11 +3704,10 @@ void GbaQueue::SetSmithFlg(int channel)
 void GbaQueue::ClrSmithFlg(int channel)
 {
 	const unsigned char shopMask = static_cast<unsigned char>(0x10 << channel);
-	unsigned char* flags = reinterpret_cast<unsigned char*>(this) + 0x2D38;
 
 	OSWaitSemaphore(accessSemaphores + channel);
-	flags[0] = static_cast<unsigned char>(flags[0] & ~shopMask);
-	flags[1] = static_cast<unsigned char>(flags[1] & ~shopMask);
+	m_shopFlags = static_cast<unsigned char>(m_shopFlags & ~shopMask);
+	m_shopModeFlags = static_cast<unsigned char>(m_shopModeFlags & ~shopMask);
 	OSSignalSemaphore(accessSemaphores + channel);
 
 	for (int retry = 0; retry < 10; retry++) {


### PR DESCRIPTION
## Summary
- Assign menu.cpp ownership of its generated RTTI name strings in .sdata2.
- Name the GbaQueue shop flag bytes at 0x2D38/0x2D39 and use member access in shop/smith flag helpers.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/menu -o - now reports .text, .data, .sdata, and .sdata2 all at 100.0%.
- build/GCCP01/report.json: main/menu is now 100.0% code and 100.0% data, with matched data increasing from 164 bytes to 180 bytes.
- SetShopFlg__8GbaQueueFi and SetSmithFlg__8GbaQueueFi remain score-neutral at 99.52381%, but now reference real fields instead of raw 0x2D38 pointer arithmetic.

## Plausibility
- The .sdata2 range contains compiler-generated CMenu/CRef RTTI name strings already referenced by target menu.o relocations.
- The GbaQueue fields replace known bytes used consistently as shop/smith flag storage without changing layout or behavior.