### PR TITLE
Improve itemobj state matching

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -180,12 +180,11 @@ void CGItemObj::ItemJump(int state, float jump)
 
 		if ((object->m_objectFlags & 0x10) == 0) {
 			unsigned int mapMask = object->m_bgHitMask;
+			Vec bottom = object->m_worldPosition;
 			Vec move;
 			CItemJumpCylinder cylinder;
 
-			cylinder.m_bottom.x = object->m_worldPosition.x;
-			cylinder.m_bottom.z = object->m_worldPosition.z;
-			cylinder.m_bottom.y = object->m_worldPosition.y + FLOAT_80331b1c;
+			bottom.y += FLOAT_80331b1c;
 			move.x = FLOAT_80331b20;
 			move.z = FLOAT_80331b20;
 			move.y = FLOAT_80331b24;
@@ -195,9 +194,7 @@ void CGItemObj::ItemJump(int state, float jump)
 			cylinder.m_boundsMax.z = FLOAT_80331b2c;
 			cylinder.m_boundsMax.y = FLOAT_80331b2c;
 			cylinder.m_boundsMax.x = FLOAT_80331b2c;
-			cylinder.m_top.x = FLOAT_80331b20;
-			cylinder.m_top.y = FLOAT_80331b20;
-			cylinder.m_top.z = FLOAT_80331b20;
+			cylinder.m_bottom = bottom;
 			cylinder.m_axis.x = FLOAT_80331b20;
 			cylinder.m_axis.y = FLOAT_80331b24;
 			cylinder.m_axis.z = FLOAT_80331b20;
@@ -1004,7 +1001,7 @@ void CGItemObj::onFrameStat()
 	case 0xE:
 		if (m_stateFrame == 0) {
 			prgObj->m_bgColMask = 0;
-			prgObj->m_weaponNodeFlags &= 0xFFEF;
+			*reinterpret_cast<unsigned char*>(&prgObj->m_weaponNodeFlags) &= 0xEF;
 			prgObj->m_groundHitOffset.z = zero;
 			prgObj->m_groundHitOffset.y = zero;
 			prgObj->m_groundHitOffset.x = zero;


### PR DESCRIPTION
## Summary
- Adjust `CGItemObj::ItemJump` cylinder setup to build the bottom vector via a temporary and leave the top vector untouched before `CheckHitCylinderNear`, matching the target stack setup more closely.
- Clear the low byte of `m_weaponNodeFlags` in `onFrameStat` state `0xE` instead of masking the full halfword, matching the target byte load/store pattern and nearby source style.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/itemobj -o - onFrameStat__9CGItemObjFv`
  - `.text`: `86.45428% -> 86.62479%`
  - `extabindex`: `97.39583% -> 97.91667%`
- Same unit-level improvement is visible when diffing `ItemJump__9CGItemObjFif` after the combined changes.

## Plausibility
- The byte flag change matches existing project patterns in `cflat_r2class.cpp` and `monobj_boss.cpp` for `m_weaponNodeFlags` low-byte updates.
- The `ItemJump` change removes unnecessary top-vector initialization and matches the target's raw world-position copy into the cylinder bottom before the map hit call.
