### PR TITLE
Define p_map local strings

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -51,9 +51,9 @@ CProcessTableCallback CMapPcs::m_table_desc21 = {0, 0xFFFFFFFF, reinterpret_cast
 CProcessTableCallback CMapPcs::m_table_desc22 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawViewer__7CMapPcsFv)};
 CProcessTableCallback CMapPcs::m_table_desc23 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawAfterViewer__7CMapPcsFv)};
 
-extern const char s_CMapPcs_GAME_801D76E0[];
-extern const char s_CMapPcs_VIEWER_801D76F0[];
-extern const char s_CMapPcs_PART_801D7700[];
+extern "C" const char s_CMapPcs_GAME_801D76E0[] = "CMapPcs(GAME)";
+extern "C" const char s_CMapPcs_VIEWER_801D76F0[] = "CMapPcs(VIEWER)";
+extern "C" const char s_CMapPcs_PART_801D7700[] = "CMapPcs(PART)";
 
 CProcessTable CMapPcs::m_table[3] = {
     {
@@ -115,9 +115,15 @@ extern const float DrawRangeDefault;
 extern const float kPMapBoundMinInit;
 extern const float kPMapBoundMaxInit;
 char s_lastLoadedMapPath__7CMapPcs[0x100] = "";
-extern const char s_p_map_cpp[];
-extern const char s_map_load_ok_fmt[];
-extern const char s_dvd_map_stage_map_fmt[];
+extern "C" const char s_p_map_cpp[] = "p_map.cpp";
+extern "C" const char s_map_load_ok_fmt[] =
+    "\n\n=============================================================\n"
+    "                   LoadMap [%s] OK\n"
+    "                   m_mapobj_n = %d\n"
+    "                   m_octtree_n = %d\n"
+    "                   memFree=%d Kbyte\n"
+    "=============================================================\n\n\n";
+extern "C" const char s_dvd_map_stage_map_fmt[] = "dvd/map/stg%03d/map%03d";
 extern "C" void MapFileRead__7CMapMngFPcRUl(CMapMng*);
 
 namespace {


### PR DESCRIPTION
## Summary
- define the local CMapPcs table labels in `p_map.cpp`
- define the local `p_map.cpp`, map-load log, and DVD map path strings instead of leaving them as externs

## Objdiff evidence
Before:
- `main/p_map` `.rodata`: 10.473815%
- `s_CMapPcs_GAME_801D76E0`, `s_CMapPcs_VIEWER_801D76F0`, `s_CMapPcs_PART_801D7700`, `s_p_map_cpp`, `s_map_load_ok_fmt`, `s_dvd_map_stage_map_fmt`: not matched as local definitions

After:
- `main/p_map` `.rodata`: 95.09537%
- all six local strings match 100%
- `.data` and `.bss` remain 100%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_map -o /tmp/p_map_final.json`

## Plausibility
These strings are referenced directly by `p_map.cpp` tables and functions and are attributed to `p_map.cpp` in `config/GCCP01/symbols.txt`, so defining them in this translation unit is source-shaped linkage cleanup rather than output coaxing.
