### PR TITLE
Inline pppRandFV helpers

### DIFF
--- a/src/pppRandDownFV.cpp
+++ b/src/pppRandDownFV.cpp
@@ -14,7 +14,7 @@ struct RandDownFVParams {
     u8 useNormalDistribution;
 };
 
-static float randf(float value, float scale)
+static inline float randf(float value, float scale)
 {
     float result = value * scale;
     return result;

--- a/src/pppRandFV.cpp
+++ b/src/pppRandFV.cpp
@@ -14,7 +14,7 @@ struct RandFVParams {
     u8 useNormalDistribution;
 };
 
-static float randf(float value, float scale)
+static inline float randf(float value, float scale)
 {
     return value * scale - value;
 }

--- a/src/pppRandUpFV.cpp
+++ b/src/pppRandUpFV.cpp
@@ -14,7 +14,7 @@ struct RandUpFVParams {
     u8 useNormalDistribution;
 };
 
-static float randf(float value, float scale)
+static inline float randf(float value, float scale)
 {
     return value * scale;
 }


### PR DESCRIPTION
## Summary
- Mark the tiny local randf helpers in pppRandFV, pppRandDownFV, and pppRandUpFV as inline.
- This removes the extra emitted local randf__Fff symbol from all three units while preserving the known function codegen.

## Evidence
- ninja passes for GCCP01.
- objdiff after the change:
  - main/pppRandFV: pppRandFV 308b, 100.0%, randf__Fff no longer emitted.
  - main/pppRandDownFV: pppRandDownFV 304b, 99.73684%, randf__Fff no longer emitted.
  - main/pppRandUpFV: pppRandUpFV 304b, 99.73684%, randf__Fff no longer emitted.

## Plausibility
- The helper is a single arithmetic expression and is only used inside each translation unit.
- Inlining it matches the target object shape more closely without introducing manual symbols or address hacks.