### PR TITLE
Improve p_dbgmenu static init layout

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -61,6 +61,21 @@ extern const char sDbgMenuOn[] = "ON";
 extern const char sDbgMenuOff[] = "OFF";
 extern const char sDbgMenuUnknown[] = "?";
 
+inline CDbgMenuPcs::CDbgMenuPcs()
+{
+	static CProcessTableCallback desc0 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__11CDbgMenuPcsFv)};
+	static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__11CDbgMenuPcsFv)};
+	static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(calc__11CDbgMenuPcsFv)};
+	static CProcessTableCallback desc3 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(draw__11CDbgMenuPcsFv)};
+
+	CProcessTable* table = &m_table;
+
+	table->m_fields.m_create = desc0;
+	table->m_fields.m_destroy = desc1;
+	table->m_fields.m_entries[0].m_callback = desc2;
+	table->m_fields.m_entries[1].m_callback = desc3;
+}
+
 CProcessTable CDbgMenuPcs::m_table = {
     const_cast<char*>(sCDbgMenuPcs),
     {
@@ -173,21 +188,6 @@ void CDbgMenuPcs::create()
 void CDbgMenuPcs::destroy()
 {
 	return;
-}
-
-inline CDbgMenuPcs::CDbgMenuPcs()
-{
-	static CProcessTableCallback desc0 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(create__11CDbgMenuPcsFv)};
-	static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(destroy__11CDbgMenuPcsFv)};
-	static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(calc__11CDbgMenuPcsFv)};
-	static CProcessTableCallback desc3 = {0, 0xFFFFFFFF, reinterpret_cast<u32>(draw__11CDbgMenuPcsFv)};
-
-	CProcessTable* table = &m_table;
-
-	table->m_fields.m_create = desc0;
-	table->m_fields.m_destroy = desc1;
-	table->m_fields.m_entries[0].m_callback = desc2;
-	table->m_fields.m_entries[1].m_callback = desc3;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Move the inline `CDbgMenuPcs` constructor definition before `CDbgMenuPcs::m_table` so its local callback descriptors are emitted before the table data.
- This keeps the constructor logic unchanged while matching the target static initialization/data ordering more closely.

## Objdiff evidence
`build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o /tmp/p_dbgmenu_final.json`

Before -> after:
- `.text`: 98.39438% -> 98.4403%
- `__sinit_p_dbgmenu_cpp`: 98.86667% -> 100.0%
- `[.data-0]`: 79.77208% -> 93.29446%

## Verification
- `ninja`

The change is source-order only and matches the compiler behavior for constructor-local statics without adding forced sections or fake symbols.