### PR TITLE
Fix deformation split quad coordinates

### DIFF
--- a/src/pppYmDeformationShp.cpp
+++ b/src/pppYmDeformationShp.cpp
@@ -162,7 +162,7 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
 			setVertexUV(uvs, kPppYmDeformationShpZero, kPppYmDeformationShpZero, uvSplit, uvRemainder);
 			RenderDeformationShape(object, work, vertices, uvs);
 
-			setVertexPos(vertices, (s8)param_2->m_orientation, split, -split, size, split);
+			setVertexPos(vertices, (s8)param_2->m_orientation, size, -split, split, split);
 			setVertexUV(uvs, FLOAT_803305f8, uvSplit, uvRemainder, uvRemainder);
 			RenderDeformationShape(object, work, vertices, uvs);
 
@@ -171,7 +171,7 @@ void pppRenderYmDeformationShp(pppYmDeformationShp* pppYmDeformationShp_, pppYmD
 				setVertexUV(uvs, kPppYmDeformationShpZero, kPppYmDeformationShpZero, FLOAT_803305f8, uvSplit);
 				RenderDeformationShape(object, work, vertices, uvs);
 
-				setVertexPos(vertices, (s8)param_2->m_orientation, split, -size, size, size);
+				setVertexPos(vertices, (s8)param_2->m_orientation, -size, split, size, size);
 				setVertexUV(uvs, kPppYmDeformationShpZero, uvRemainder, FLOAT_803305f8, FLOAT_803305f8);
 				RenderDeformationShape(object, work, vertices, uvs);
 			}


### PR DESCRIPTION
## Summary
- Correct the two split-mode quad coordinate calls in pppYmDeformationShp so split rendering emits left/right/top/bottom bands around the center.
- This matches the plausible source shape for split-mode deformation quads and removes mismatched render setup code.

## Evidence
- ninja passes for GCCP01.
- main/pppYmDeformationShp unit improved: 96.55924% -> 96.89438%.
- pppRenderYmDeformationShp improved in report: 95.454544% -> 96.13636%.
- Direct objdiff for pppRenderYmDeformationShp improved: 95.454544% -> 96.12948%, diff instructions 290 -> 274.
- RenderDeformationShape unchanged at 97.241486%.

## Notes
- Tested and rejected adjacent size/split local type changes because they regressed pppRenderYmDeformationShp.
- Tested and rejected unrolling the fixed GX vertex loop because it compiled identically.