### PR TITLE
Use Chara global in memorycard

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -193,7 +193,7 @@ enum {
 
 static inline CChara* GetCharaGlobal()
 {
-    return &gChara;
+    return &Chara;
 }
 
 static inline CRedSound* GetRedSoundGlobal()


### PR DESCRIPTION
## Summary
- Change memorycard local character accessor to use the real `Chara` global instead of the `gChara` reference alias.
- This matches the target relocations for `LoadFurTexBuffer` and `SaveFurTexBuffer` call sites.

## Evidence
- `ninja` passes.
- `main/memorycard` `.text` objdiff improved from 90.48181% to 90.60883%.
- Source relocations now use `R_PPC_ADDR16_HA/LO Chara`, matching the target object.

## Plausibility
- Other code already uses the `Chara` global directly for this manager.
- Avoids the reference alias in this translation unit and recovers the target linkage shape without changing behavior.