### PR TITLE
Model map cylinder bounds as aggregate

### DIFF
--- a/include/ffcc/maphit.h
+++ b/include/ffcc/maphit.h
@@ -25,6 +25,13 @@ struct CMapCylinderProbeView
 };
 typedef char CMapCylinderProbeView_size_check[(sizeof(CMapCylinderProbeView) == 0x34) ? 1 : -1];
 
+struct CMapCylinderBound
+{
+    Vec m_min; // 0x00
+    Vec m_max; // 0x0c
+};
+typedef char CMapCylinderBound_size_check[(sizeof(CMapCylinderBound) == 0x18) ? 1 : -1];
+
 class CMapCylinder
 {
 public:
@@ -32,27 +39,27 @@ public:
     {
         float min = kMapHitBoundsMinInit;
 
-        m_boundsMin.z = min;
-        m_boundsMin.y = min;
-        m_boundsMin.x = min;
+        m_bound.m_min.z = min;
+        m_bound.m_min.y = min;
+        m_bound.m_min.x = min;
 
-        m_boundsMax.z = kMapHitBoundsMaxInit;
-        m_boundsMax.y = kMapHitBoundsMaxInit;
-        m_boundsMax.x = kMapHitBoundsMaxInit;
+        m_bound.m_max.z = kMapHitBoundsMaxInit;
+        m_bound.m_max.y = kMapHitBoundsMaxInit;
+        m_bound.m_max.x = kMapHitBoundsMaxInit;
     }
 
     CMapCylinder(float min, float max)
     {
-        m_boundsMin.z = min;
-        m_boundsMin.y = min;
-        m_boundsMin.x = min;
+        m_bound.m_min.z = min;
+        m_bound.m_min.y = min;
+        m_bound.m_min.x = min;
 
-        m_boundsMax.z = max;
-        m_boundsMax.y = max;
-        m_boundsMax.x = max;
+        m_bound.m_max.z = max;
+        m_bound.m_max.y = max;
+        m_bound.m_max.x = max;
     }
 
-    CBound* GetBound() { return reinterpret_cast<CBound*>(&m_boundsMin); }
+    CBound* GetBound() { return reinterpret_cast<CBound*>(&m_bound); }
     CMapCylinderProbeView& Probe() { return *reinterpret_cast<CMapCylinderProbeView*>(&m_top); }
     const CMapCylinderProbeView& Probe() const { return *reinterpret_cast<const CMapCylinderProbeView*>(&m_top); }
 
@@ -60,8 +67,7 @@ public:
     Vec m_top;       // 0x0c
     Vec m_axis;      // 0x18
     float m_radius;  // 0x24
-    Vec m_boundsMin; // 0x28
-    Vec m_boundsMax; // 0x34
+    CMapCylinderBound m_bound; // 0x28
 };
 typedef char CMapCylinder_size_check[(sizeof(CMapCylinder) == 0x40) ? 1 : -1];
 

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -448,17 +448,17 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
     bool boundsOverlap = false;
     bool partialOverlap = false;
     bool axisOverlap;
-    if (g_hit_lpface->m_boundsMin.x < g_hit_cyl.m_boundsMin.x) {
-        axisOverlap = g_hit_cyl.m_boundsMin.x <= g_hit_lpface->m_boundsMax.x;
+    if (g_hit_lpface->m_boundsMin.x < g_hit_cyl.m_bound.m_min.x) {
+        axisOverlap = g_hit_cyl.m_bound.m_min.x <= g_hit_lpface->m_boundsMax.x;
     } else {
-        axisOverlap = g_hit_lpface->m_boundsMin.x <= g_hit_cyl.m_boundsMax.x;
+        axisOverlap = g_hit_lpface->m_boundsMin.x <= g_hit_cyl.m_bound.m_max.x;
     }
 
     if (axisOverlap) {
-        if (g_hit_lpface->m_boundsMin.y < g_hit_cyl.m_boundsMin.y) {
-            axisOverlap = g_hit_cyl.m_boundsMin.y <= g_hit_lpface->m_boundsMax.y;
+        if (g_hit_lpface->m_boundsMin.y < g_hit_cyl.m_bound.m_min.y) {
+            axisOverlap = g_hit_cyl.m_bound.m_min.y <= g_hit_lpface->m_boundsMax.y;
         } else {
-            axisOverlap = g_hit_lpface->m_boundsMin.y <= g_hit_cyl.m_boundsMax.y;
+            axisOverlap = g_hit_lpface->m_boundsMin.y <= g_hit_cyl.m_bound.m_max.y;
         }
 
         if (axisOverlap) {
@@ -467,10 +467,10 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
     }
 
     if (partialOverlap) {
-        if (g_hit_lpface->m_boundsMin.z < g_hit_cyl.m_boundsMin.z) {
-            axisOverlap = g_hit_cyl.m_boundsMin.z <= g_hit_lpface->m_boundsMax.z;
+        if (g_hit_lpface->m_boundsMin.z < g_hit_cyl.m_bound.m_min.z) {
+            axisOverlap = g_hit_cyl.m_bound.m_min.z <= g_hit_lpface->m_boundsMax.z;
         } else {
-            axisOverlap = g_hit_lpface->m_boundsMin.z <= g_hit_cyl.m_boundsMax.z;
+            axisOverlap = g_hit_lpface->m_boundsMin.z <= g_hit_cyl.m_bound.m_max.z;
         }
 
         if (axisOverlap) {

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -1585,49 +1585,49 @@ int CMapObj::CheckHitCylinder(CMapCylinder* cylinder, Vec* move, unsigned long m
         float margin = kMapObjZero + localCylinder.m_radius;
 
         if (localCylinder.m_bottom.x < localCylinder.m_top.x) {
-            localCylinder.m_boundsMin.x = localCylinder.m_bottom.x - margin;
-            localCylinder.m_boundsMax.x = localCylinder.m_top.x + margin;
+            localCylinder.m_bound.m_min.x = localCylinder.m_bottom.x - margin;
+            localCylinder.m_bound.m_max.x = localCylinder.m_top.x + margin;
         } else {
-            localCylinder.m_boundsMin.x = localCylinder.m_top.x - margin;
-            localCylinder.m_boundsMax.x = localCylinder.m_bottom.x + margin;
+            localCylinder.m_bound.m_min.x = localCylinder.m_top.x - margin;
+            localCylinder.m_bound.m_max.x = localCylinder.m_bottom.x + margin;
         }
 
         if (localCylinder.m_bottom.y < localCylinder.m_top.y) {
-            localCylinder.m_boundsMin.y = localCylinder.m_bottom.y - margin;
-            localCylinder.m_boundsMax.y = localCylinder.m_top.y + margin;
+            localCylinder.m_bound.m_min.y = localCylinder.m_bottom.y - margin;
+            localCylinder.m_bound.m_max.y = localCylinder.m_top.y + margin;
         } else {
-            localCylinder.m_boundsMin.y = localCylinder.m_top.y - margin;
-            localCylinder.m_boundsMax.y = localCylinder.m_bottom.y + margin;
+            localCylinder.m_bound.m_min.y = localCylinder.m_top.y - margin;
+            localCylinder.m_bound.m_max.y = localCylinder.m_bottom.y + margin;
         }
 
         if (localCylinder.m_bottom.z < localCylinder.m_top.z) {
-            localCylinder.m_boundsMin.z = localCylinder.m_bottom.z - margin;
-            localCylinder.m_boundsMax.z = localCylinder.m_top.z + margin;
+            localCylinder.m_bound.m_min.z = localCylinder.m_bottom.z - margin;
+            localCylinder.m_bound.m_max.z = localCylinder.m_top.z + margin;
         } else {
-            localCylinder.m_boundsMin.z = localCylinder.m_top.z - margin;
-            localCylinder.m_boundsMax.z = localCylinder.m_bottom.z + margin;
+            localCylinder.m_bound.m_min.z = localCylinder.m_top.z - margin;
+            localCylinder.m_bound.m_max.z = localCylinder.m_bottom.z + margin;
         }
 
         CMapHit* mapHit = reinterpret_cast<CMapHit*>(m_mapData);
         bool hitBounds = false;
         bool xyOverlap = false;
-        bool xOverlap = mapHit->m_positionMin.x < localCylinder.m_boundsMin.x
-            ? localCylinder.m_boundsMin.x <= mapHit->m_positionMax.x
-            : mapHit->m_positionMin.x <= localCylinder.m_boundsMax.x;
+        bool xOverlap = mapHit->m_positionMin.x < localCylinder.m_bound.m_min.x
+            ? localCylinder.m_bound.m_min.x <= mapHit->m_positionMax.x
+            : mapHit->m_positionMin.x <= localCylinder.m_bound.m_max.x;
 
         if (xOverlap) {
-            bool yOverlap = mapHit->m_positionMin.y < localCylinder.m_boundsMin.y
-                ? localCylinder.m_boundsMin.y <= mapHit->m_positionMax.y
-                : mapHit->m_positionMin.y <= localCylinder.m_boundsMax.y;
+            bool yOverlap = mapHit->m_positionMin.y < localCylinder.m_bound.m_min.y
+                ? localCylinder.m_bound.m_min.y <= mapHit->m_positionMax.y
+                : mapHit->m_positionMin.y <= localCylinder.m_bound.m_max.y;
             if (yOverlap) {
                 xyOverlap = true;
             }
         }
 
         if (xyOverlap) {
-            bool zOverlap = mapHit->m_positionMin.z < localCylinder.m_boundsMin.z
-                ? localCylinder.m_boundsMin.z <= mapHit->m_positionMax.z
-                : mapHit->m_positionMin.z <= localCylinder.m_boundsMax.z;
+            bool zOverlap = mapHit->m_positionMin.z < localCylinder.m_bound.m_min.z
+                ? localCylinder.m_bound.m_min.z <= mapHit->m_positionMax.z
+                : mapHit->m_positionMin.z <= localCylinder.m_bound.m_max.z;
 
             if (zOverlap) {
                 hitBounds = true;
@@ -1670,49 +1670,49 @@ void CMapObj::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned l
         float margin = kMapObjZero + localCylinder.m_radius;
 
         if (localCylinder.m_bottom.x < localCylinder.m_top.x) {
-            localCylinder.m_boundsMin.x = localCylinder.m_bottom.x - margin;
-            localCylinder.m_boundsMax.x = localCylinder.m_top.x + margin;
+            localCylinder.m_bound.m_min.x = localCylinder.m_bottom.x - margin;
+            localCylinder.m_bound.m_max.x = localCylinder.m_top.x + margin;
         } else {
-            localCylinder.m_boundsMin.x = localCylinder.m_top.x - margin;
-            localCylinder.m_boundsMax.x = localCylinder.m_bottom.x + margin;
+            localCylinder.m_bound.m_min.x = localCylinder.m_top.x - margin;
+            localCylinder.m_bound.m_max.x = localCylinder.m_bottom.x + margin;
         }
 
         if (localCylinder.m_bottom.y < localCylinder.m_top.y) {
-            localCylinder.m_boundsMin.y = localCylinder.m_bottom.y - margin;
-            localCylinder.m_boundsMax.y = localCylinder.m_top.y + margin;
+            localCylinder.m_bound.m_min.y = localCylinder.m_bottom.y - margin;
+            localCylinder.m_bound.m_max.y = localCylinder.m_top.y + margin;
         } else {
-            localCylinder.m_boundsMin.y = localCylinder.m_top.y - margin;
-            localCylinder.m_boundsMax.y = localCylinder.m_bottom.y + margin;
+            localCylinder.m_bound.m_min.y = localCylinder.m_top.y - margin;
+            localCylinder.m_bound.m_max.y = localCylinder.m_bottom.y + margin;
         }
 
         if (localCylinder.m_bottom.z < localCylinder.m_top.z) {
-            localCylinder.m_boundsMin.z = localCylinder.m_bottom.z - margin;
-            localCylinder.m_boundsMax.z = localCylinder.m_top.z + margin;
+            localCylinder.m_bound.m_min.z = localCylinder.m_bottom.z - margin;
+            localCylinder.m_bound.m_max.z = localCylinder.m_top.z + margin;
         } else {
-            localCylinder.m_boundsMin.z = localCylinder.m_top.z - margin;
-            localCylinder.m_boundsMax.z = localCylinder.m_bottom.z + margin;
+            localCylinder.m_bound.m_min.z = localCylinder.m_top.z - margin;
+            localCylinder.m_bound.m_max.z = localCylinder.m_bottom.z + margin;
         }
 
         CMapHit* mapHit = reinterpret_cast<CMapHit*>(m_mapData);
         bool hitBounds = false;
         bool xyOverlap = false;
-        bool xOverlap = mapHit->m_positionMin.x < localCylinder.m_boundsMin.x
-            ? localCylinder.m_boundsMin.x <= mapHit->m_positionMax.x
-            : mapHit->m_positionMin.x <= localCylinder.m_boundsMax.x;
+        bool xOverlap = mapHit->m_positionMin.x < localCylinder.m_bound.m_min.x
+            ? localCylinder.m_bound.m_min.x <= mapHit->m_positionMax.x
+            : mapHit->m_positionMin.x <= localCylinder.m_bound.m_max.x;
 
         if (xOverlap) {
-            bool yOverlap = mapHit->m_positionMin.y < localCylinder.m_boundsMin.y
-                ? localCylinder.m_boundsMin.y <= mapHit->m_positionMax.y
-                : mapHit->m_positionMin.y <= localCylinder.m_boundsMax.y;
+            bool yOverlap = mapHit->m_positionMin.y < localCylinder.m_bound.m_min.y
+                ? localCylinder.m_bound.m_min.y <= mapHit->m_positionMax.y
+                : mapHit->m_positionMin.y <= localCylinder.m_bound.m_max.y;
             if (yOverlap) {
                 xyOverlap = true;
             }
         }
 
         if (xyOverlap) {
-            bool zOverlap = mapHit->m_positionMin.z < localCylinder.m_boundsMin.z
-                ? localCylinder.m_boundsMin.z <= mapHit->m_positionMax.z
-                : mapHit->m_positionMin.z <= localCylinder.m_boundsMax.z;
+            bool zOverlap = mapHit->m_positionMin.z < localCylinder.m_bound.m_min.z
+                ? localCylinder.m_bound.m_min.z <= mapHit->m_positionMax.z
+                : mapHit->m_positionMin.z <= localCylinder.m_bound.m_max.z;
 
             if (zOverlap) {
                 hitBounds = true;

--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -1653,11 +1653,11 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 	bool xyOverlap = false;
 	int xOverlap = false;
 
-	if (boundMinX < s_cyl.m_boundsMin.x) {
-		xOverlap = s_cyl.m_boundsMin.x <= node->m_boundMaxX;
+	if (boundMinX < s_cyl.m_bound.m_min.x) {
+		xOverlap = s_cyl.m_bound.m_min.x <= node->m_boundMaxX;
 	} else {
-		if (boundMinX > s_cyl.m_boundsMin.x) {
-			xOverlap = boundMinX <= s_cyl.m_boundsMax.x;
+		if (boundMinX > s_cyl.m_bound.m_min.x) {
+			xOverlap = boundMinX <= s_cyl.m_bound.m_max.x;
 		} else {
 			xOverlap = true;
 		}
@@ -1665,11 +1665,11 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 
 	if (xOverlap) {
 		float boundMinY = node->m_boundMinY;
-		if (boundMinY < s_cyl.m_boundsMin.y) {
-			xOverlap = s_cyl.m_boundsMin.y <= node->m_boundMaxY;
+		if (boundMinY < s_cyl.m_bound.m_min.y) {
+			xOverlap = s_cyl.m_bound.m_min.y <= node->m_boundMaxY;
 		} else {
-			if (boundMinY > s_cyl.m_boundsMin.y) {
-				xOverlap = boundMinY <= s_cyl.m_boundsMax.y;
+			if (boundMinY > s_cyl.m_bound.m_min.y) {
+				xOverlap = boundMinY <= s_cyl.m_bound.m_max.y;
 			} else {
 				xOverlap = true;
 			}
@@ -1681,11 +1681,11 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 
 	if (xyOverlap) {
 		float boundMinZ = node->m_boundMinZ;
-		if (boundMinZ < s_cyl.m_boundsMin.z) {
-			xOverlap = s_cyl.m_boundsMin.z <= node->m_boundMaxZ;
+		if (boundMinZ < s_cyl.m_bound.m_min.z) {
+			xOverlap = s_cyl.m_bound.m_min.z <= node->m_boundMaxZ;
 		} else {
-			if (boundMinZ > s_cyl.m_boundsMin.z) {
-				xOverlap = boundMinZ <= s_cyl.m_boundsMax.z;
+			if (boundMinZ > s_cyl.m_bound.m_min.z) {
+				xOverlap = boundMinZ <= s_cyl.m_bound.m_max.z;
 			} else {
 				xOverlap = true;
 			}
@@ -1716,11 +1716,11 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 			bool childOverlap = false;
 			bool childXYOverlap = false;
 			int childXOverlap = false;
-			if (childBoundMinX < s_cyl.m_boundsMin.x) {
-				childXOverlap = s_cyl.m_boundsMin.x <= child->m_boundMaxX;
+			if (childBoundMinX < s_cyl.m_bound.m_min.x) {
+				childXOverlap = s_cyl.m_bound.m_min.x <= child->m_boundMaxX;
 			} else {
-				if (childBoundMinX > s_cyl.m_boundsMin.x) {
-					childXOverlap = childBoundMinX <= s_cyl.m_boundsMax.x;
+				if (childBoundMinX > s_cyl.m_bound.m_min.x) {
+					childXOverlap = childBoundMinX <= s_cyl.m_bound.m_max.x;
 				} else {
 					childXOverlap = true;
 				}
@@ -1728,11 +1728,11 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 
 			if (childXOverlap) {
 				float childBoundMinY = child->m_boundMinY;
-				if (childBoundMinY < s_cyl.m_boundsMin.y) {
-					childXOverlap = s_cyl.m_boundsMin.y <= child->m_boundMaxY;
+				if (childBoundMinY < s_cyl.m_bound.m_min.y) {
+					childXOverlap = s_cyl.m_bound.m_min.y <= child->m_boundMaxY;
 				} else {
-					if (childBoundMinY > s_cyl.m_boundsMin.y) {
-						childXOverlap = childBoundMinY <= s_cyl.m_boundsMax.y;
+					if (childBoundMinY > s_cyl.m_bound.m_min.y) {
+						childXOverlap = childBoundMinY <= s_cyl.m_bound.m_max.y;
 					} else {
 						childXOverlap = true;
 					}
@@ -1744,11 +1744,11 @@ int COctTree::CheckHitCylinder_r(COctNode* node)
 
 			if (childXYOverlap) {
 				float childBoundMinZ = child->m_boundMinZ;
-				if (childBoundMinZ < s_cyl.m_boundsMin.z) {
-					childXOverlap = s_cyl.m_boundsMin.z <= child->m_boundMaxZ;
+				if (childBoundMinZ < s_cyl.m_bound.m_min.z) {
+					childXOverlap = s_cyl.m_bound.m_min.z <= child->m_boundMaxZ;
 				} else {
-					if (childBoundMinZ > s_cyl.m_boundsMin.z) {
-						childXOverlap = childBoundMinZ <= s_cyl.m_boundsMax.z;
+					if (childBoundMinZ > s_cyl.m_bound.m_min.z) {
+						childXOverlap = childBoundMinZ <= s_cyl.m_bound.m_max.z;
 					} else {
 						childXOverlap = true;
 					}
@@ -1841,29 +1841,29 @@ int COctTree::CheckHitCylinder(CMapCylinder* cylinder, Vec* move, unsigned long 
 			s_cyl.m_radius = cylinder->m_radius;
 			radiusPad = kMapObjZero + s_cyl.m_radius;
 			if (s_cyl.m_bottom.x < s_cyl.m_top.x) {
-				s_cyl.m_boundsMin.x = s_cyl.m_bottom.x - radiusPad;
-				s_cyl.m_boundsMax.x = s_cyl.m_top.x + radiusPad;
+				s_cyl.m_bound.m_min.x = s_cyl.m_bottom.x - radiusPad;
+				s_cyl.m_bound.m_max.x = s_cyl.m_top.x + radiusPad;
 			} else {
-				s_cyl.m_boundsMin.x = s_cyl.m_top.x - radiusPad;
-				s_cyl.m_boundsMax.x = s_cyl.m_bottom.x + radiusPad;
+				s_cyl.m_bound.m_min.x = s_cyl.m_top.x - radiusPad;
+				s_cyl.m_bound.m_max.x = s_cyl.m_bottom.x + radiusPad;
 			}
 
 			radiusPad = kMapObjZero + s_cyl.m_radius;
 			if (s_cyl.m_bottom.y < s_cyl.m_top.y) {
-				s_cyl.m_boundsMin.y = s_cyl.m_bottom.y - radiusPad;
-				s_cyl.m_boundsMax.y = s_cyl.m_top.y + radiusPad;
+				s_cyl.m_bound.m_min.y = s_cyl.m_bottom.y - radiusPad;
+				s_cyl.m_bound.m_max.y = s_cyl.m_top.y + radiusPad;
 			} else {
-				s_cyl.m_boundsMin.y = s_cyl.m_top.y - radiusPad;
-				s_cyl.m_boundsMax.y = s_cyl.m_bottom.y + radiusPad;
+				s_cyl.m_bound.m_min.y = s_cyl.m_top.y - radiusPad;
+				s_cyl.m_bound.m_max.y = s_cyl.m_bottom.y + radiusPad;
 			}
 
 			radiusPad = kMapObjZero + s_cyl.m_radius;
 			if (s_cyl.m_bottom.z < s_cyl.m_top.z) {
-				s_cyl.m_boundsMin.z = s_cyl.m_bottom.z - radiusPad;
-				s_cyl.m_boundsMax.z = s_cyl.m_top.z + radiusPad;
+				s_cyl.m_bound.m_min.z = s_cyl.m_bottom.z - radiusPad;
+				s_cyl.m_bound.m_max.z = s_cyl.m_top.z + radiusPad;
 			} else {
-				s_cyl.m_boundsMin.z = s_cyl.m_top.z - radiusPad;
-				s_cyl.m_boundsMax.z = s_cyl.m_bottom.z + radiusPad;
+				s_cyl.m_bound.m_min.z = s_cyl.m_top.z - radiusPad;
+				s_cyl.m_bound.m_max.z = s_cyl.m_bottom.z + radiusPad;
 			}
 			InsertShadow_level = flag;
 			if (CheckHitCylinder_r(m_nodePool) != 0) {
@@ -1891,11 +1891,11 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 	bool xyOverlap = false;
 	int xOverlap = false;
 
-	if (boundMinX < s_cyl.m_boundsMin.x) {
-		xOverlap = s_cyl.m_boundsMin.x <= octNode->m_boundMaxX;
+	if (boundMinX < s_cyl.m_bound.m_min.x) {
+		xOverlap = s_cyl.m_bound.m_min.x <= octNode->m_boundMaxX;
 	} else {
-		if (boundMinX > s_cyl.m_boundsMin.x) {
-			xOverlap = boundMinX <= s_cyl.m_boundsMax.x;
+		if (boundMinX > s_cyl.m_bound.m_min.x) {
+			xOverlap = boundMinX <= s_cyl.m_bound.m_max.x;
 		} else {
 			xOverlap = true;
 		}
@@ -1903,11 +1903,11 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 
 	if (xOverlap) {
 		float boundMinY = octNode->m_boundMinY;
-		if (boundMinY < s_cyl.m_boundsMin.y) {
-			xOverlap = s_cyl.m_boundsMin.y <= octNode->m_boundMaxY;
+		if (boundMinY < s_cyl.m_bound.m_min.y) {
+			xOverlap = s_cyl.m_bound.m_min.y <= octNode->m_boundMaxY;
 		} else {
-			if (boundMinY > s_cyl.m_boundsMin.y) {
-				xOverlap = boundMinY <= s_cyl.m_boundsMax.y;
+			if (boundMinY > s_cyl.m_bound.m_min.y) {
+				xOverlap = boundMinY <= s_cyl.m_bound.m_max.y;
 			} else {
 				xOverlap = true;
 			}
@@ -1919,11 +1919,11 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 
 	if (xyOverlap) {
 		float boundMinZ = octNode->m_boundMinZ;
-		if (boundMinZ < s_cyl.m_boundsMin.z) {
-			xOverlap = s_cyl.m_boundsMin.z <= octNode->m_boundMaxZ;
+		if (boundMinZ < s_cyl.m_bound.m_min.z) {
+			xOverlap = s_cyl.m_bound.m_min.z <= octNode->m_boundMaxZ;
 		} else {
-			if (boundMinZ > s_cyl.m_boundsMin.z) {
-				xOverlap = boundMinZ <= s_cyl.m_boundsMax.z;
+			if (boundMinZ > s_cyl.m_bound.m_min.z) {
+				xOverlap = boundMinZ <= s_cyl.m_bound.m_max.z;
 			} else {
 				xOverlap = true;
 			}
@@ -1955,11 +1955,11 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 		bool childOverlap = false;
 		bool childXYOverlap = false;
 		int childXOverlap = false;
-		if (childBoundMinX < s_cyl.m_boundsMin.x) {
-			childXOverlap = s_cyl.m_boundsMin.x <= child->m_boundMaxX;
+		if (childBoundMinX < s_cyl.m_bound.m_min.x) {
+			childXOverlap = s_cyl.m_bound.m_min.x <= child->m_boundMaxX;
 		} else {
-			if (childBoundMinX > s_cyl.m_boundsMin.x) {
-				childXOverlap = childBoundMinX <= s_cyl.m_boundsMax.x;
+			if (childBoundMinX > s_cyl.m_bound.m_min.x) {
+				childXOverlap = childBoundMinX <= s_cyl.m_bound.m_max.x;
 			} else {
 				childXOverlap = true;
 			}
@@ -1967,11 +1967,11 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 
 		if (childXOverlap) {
 			float childBoundMinY = child->m_boundMinY;
-			if (childBoundMinY < s_cyl.m_boundsMin.y) {
-				childXOverlap = s_cyl.m_boundsMin.y <= child->m_boundMaxY;
+			if (childBoundMinY < s_cyl.m_bound.m_min.y) {
+				childXOverlap = s_cyl.m_bound.m_min.y <= child->m_boundMaxY;
 			} else {
-				if (childBoundMinY > s_cyl.m_boundsMin.y) {
-					childXOverlap = childBoundMinY <= s_cyl.m_boundsMax.y;
+				if (childBoundMinY > s_cyl.m_bound.m_min.y) {
+					childXOverlap = childBoundMinY <= s_cyl.m_bound.m_max.y;
 				} else {
 					childXOverlap = true;
 				}
@@ -1983,11 +1983,11 @@ void COctTree::CheckHitCylinderNear_r(COctNode* octNode)
 
 		if (childXYOverlap) {
 			float childBoundMinZ = child->m_boundMinZ;
-			if (childBoundMinZ < s_cyl.m_boundsMin.z) {
-				childXOverlap = s_cyl.m_boundsMin.z <= child->m_boundMaxZ;
+			if (childBoundMinZ < s_cyl.m_bound.m_min.z) {
+				childXOverlap = s_cyl.m_bound.m_min.z <= child->m_boundMaxZ;
 			} else {
-				if (childBoundMinZ > s_cyl.m_boundsMin.z) {
-					childXOverlap = childBoundMinZ <= s_cyl.m_boundsMax.z;
+				if (childBoundMinZ > s_cyl.m_bound.m_min.z) {
+					childXOverlap = childBoundMinZ <= s_cyl.m_bound.m_max.z;
 				} else {
 					childXOverlap = true;
 				}
@@ -2064,29 +2064,29 @@ void COctTree::CheckHitCylinderNear(CMapCylinder* cylinder, Vec* move, unsigned 
 			s_cyl.m_radius = cylinder->m_radius;
 			radiusPad = kMapObjZero + s_cyl.m_radius;
 			if (s_cyl.m_bottom.x < s_cyl.m_top.x) {
-				s_cyl.m_boundsMin.x = s_cyl.m_bottom.x - radiusPad;
-				s_cyl.m_boundsMax.x = s_cyl.m_top.x + radiusPad;
+				s_cyl.m_bound.m_min.x = s_cyl.m_bottom.x - radiusPad;
+				s_cyl.m_bound.m_max.x = s_cyl.m_top.x + radiusPad;
 			} else {
-				s_cyl.m_boundsMin.x = s_cyl.m_top.x - radiusPad;
-				s_cyl.m_boundsMax.x = s_cyl.m_bottom.x + radiusPad;
+				s_cyl.m_bound.m_min.x = s_cyl.m_top.x - radiusPad;
+				s_cyl.m_bound.m_max.x = s_cyl.m_bottom.x + radiusPad;
 			}
 
 			radiusPad = kMapObjZero + s_cyl.m_radius;
 			if (s_cyl.m_bottom.y < s_cyl.m_top.y) {
-				s_cyl.m_boundsMin.y = s_cyl.m_bottom.y - radiusPad;
-				s_cyl.m_boundsMax.y = s_cyl.m_top.y + radiusPad;
+				s_cyl.m_bound.m_min.y = s_cyl.m_bottom.y - radiusPad;
+				s_cyl.m_bound.m_max.y = s_cyl.m_top.y + radiusPad;
 			} else {
-				s_cyl.m_boundsMin.y = s_cyl.m_top.y - radiusPad;
-				s_cyl.m_boundsMax.y = s_cyl.m_bottom.y + radiusPad;
+				s_cyl.m_bound.m_min.y = s_cyl.m_top.y - radiusPad;
+				s_cyl.m_bound.m_max.y = s_cyl.m_bottom.y + radiusPad;
 			}
 
 			radiusPad = kMapObjZero + s_cyl.m_radius;
 			if (s_cyl.m_bottom.z < s_cyl.m_top.z) {
-				s_cyl.m_boundsMin.z = s_cyl.m_bottom.z - radiusPad;
-				s_cyl.m_boundsMax.z = s_cyl.m_top.z + radiusPad;
+				s_cyl.m_bound.m_min.z = s_cyl.m_bottom.z - radiusPad;
+				s_cyl.m_bound.m_max.z = s_cyl.m_top.z + radiusPad;
 			} else {
-				s_cyl.m_boundsMin.z = s_cyl.m_top.z - radiusPad;
-				s_cyl.m_boundsMax.z = s_cyl.m_bottom.z + radiusPad;
+				s_cyl.m_bound.m_min.z = s_cyl.m_top.z - radiusPad;
+				s_cyl.m_bound.m_max.z = s_cyl.m_bottom.z + radiusPad;
 			}
 			InsertShadow_level = flag;
 			CheckHitCylinderNear_r(m_nodePool);

--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -1764,12 +1764,12 @@ void CGMonObj::checkCol(int flags, float rotY, float distance, float* hitScale, 
 		hitCylinder.m_axis.y = FLOAT_80331A38;
 		hitCylinder.m_axis.z = FLOAT_80331A3C;
 		hitCylinder.m_radius = FLOAT_80331A3C;
-		hitCylinder.m_boundsMin.x = FLOAT_80331A3C;
-		hitCylinder.m_boundsMin.y = FLOAT_80331A38;
-		hitCylinder.m_boundsMin.z = FLOAT_80331A38;
-		hitCylinder.m_boundsMax.x = FLOAT_80331A38;
-		hitCylinder.m_boundsMax.y = FLOAT_80331A38;
-		hitCylinder.m_boundsMax.z = FLOAT_80331A3C;
+		hitCylinder.m_bound.m_min.x = FLOAT_80331A3C;
+		hitCylinder.m_bound.m_min.y = FLOAT_80331A38;
+		hitCylinder.m_bound.m_min.z = FLOAT_80331A38;
+		hitCylinder.m_bound.m_max.x = FLOAT_80331A38;
+		hitCylinder.m_bound.m_max.y = FLOAT_80331A38;
+		hitCylinder.m_bound.m_max.z = FLOAT_80331A3C;
 
 		int hit = MapMng.CheckHitCylinderNear(&hitCylinder, &move, *reinterpret_cast<unsigned short*>(baseScript + 0x1B2));
 		if (hit != 0) {
@@ -1863,12 +1863,12 @@ void CGMonObj::checkCol(int flags, float rotY, float distance, float* hitScale, 
 			hitCylinder.m_axis.y = FLOAT_80331A38;
 			hitCylinder.m_axis.z = FLOAT_80331A3C;
 			hitCylinder.m_radius = FLOAT_80331A3C;
-			hitCylinder.m_boundsMin.x = FLOAT_80331A3C;
-			hitCylinder.m_boundsMin.y = FLOAT_80331A38;
-			hitCylinder.m_boundsMin.z = FLOAT_80331A38;
-			hitCylinder.m_boundsMax.x = FLOAT_80331A38;
-			hitCylinder.m_boundsMax.y = FLOAT_80331A38;
-			hitCylinder.m_boundsMax.z = FLOAT_80331A3C;
+			hitCylinder.m_bound.m_min.x = FLOAT_80331A3C;
+			hitCylinder.m_bound.m_min.y = FLOAT_80331A38;
+			hitCylinder.m_bound.m_min.z = FLOAT_80331A38;
+			hitCylinder.m_bound.m_max.x = FLOAT_80331A38;
+			hitCylinder.m_bound.m_max.y = FLOAT_80331A38;
+			hitCylinder.m_bound.m_max.z = FLOAT_80331A3C;
 
 			int mapHit = MapMng.CheckHitCylinderNear(
 				&hitCylinder, &targetDelta, *reinterpret_cast<unsigned short*>(baseScript + 0x1B2));

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -2070,12 +2070,12 @@ void CGPartyObj::putTargetParticle(int targetSide, int doInit)
 		hitCylinder.m_bottom = startPos;
 		hitCylinder.m_axis = rayDir;
 		hitCylinder.m_radius = radius;
-		hitCylinder.m_boundsMin.x = FLOAT_80331a9c;
-		hitCylinder.m_boundsMin.y = FLOAT_80331a9c;
-		hitCylinder.m_boundsMin.z = FLOAT_80331a9c;
-		hitCylinder.m_boundsMax.x = FLOAT_80331aa0;
-		hitCylinder.m_boundsMax.y = FLOAT_80331aa0;
-		hitCylinder.m_boundsMax.z = FLOAT_80331aa0;
+		hitCylinder.m_bound.m_min.x = FLOAT_80331a9c;
+		hitCylinder.m_bound.m_min.y = FLOAT_80331a9c;
+		hitCylinder.m_bound.m_min.z = FLOAT_80331a9c;
+		hitCylinder.m_bound.m_max.x = FLOAT_80331aa0;
+		hitCylinder.m_bound.m_max.y = FLOAT_80331aa0;
+		hitCylinder.m_bound.m_max.z = FLOAT_80331aa0;
 
 		Vec hitPos = startPos;
 		if (MapMng.CheckHitCylinderNear(&hitCylinder, &rayDir, 0x30) != 0) {
@@ -2091,12 +2091,12 @@ void CGPartyObj::putTargetParticle(int targetSide, int doInit)
 		floorCylinder.m_bottom = m_comboCenter;
 		floorCylinder.m_axis = down;
 		floorCylinder.m_radius = FLOAT_80331a78;
-		floorCylinder.m_boundsMin.x = FLOAT_80331a9c;
-		floorCylinder.m_boundsMin.y = FLOAT_80331a9c;
-		floorCylinder.m_boundsMin.z = FLOAT_80331a9c;
-		floorCylinder.m_boundsMax.x = FLOAT_80331aa0;
-		floorCylinder.m_boundsMax.y = FLOAT_80331aa0;
-		floorCylinder.m_boundsMax.z = FLOAT_80331aa0;
+		floorCylinder.m_bound.m_min.x = FLOAT_80331a9c;
+		floorCylinder.m_bound.m_min.y = FLOAT_80331a9c;
+		floorCylinder.m_bound.m_min.z = FLOAT_80331a9c;
+		floorCylinder.m_bound.m_max.x = FLOAT_80331aa0;
+		floorCylinder.m_bound.m_max.y = FLOAT_80331aa0;
+		floorCylinder.m_bound.m_max.z = FLOAT_80331aa0;
 		if (MapMng.CheckHitCylinderNear(&floorCylinder, reinterpret_cast<Vec*>(&down), 0x30) != 0) {
 			CMapObj* hitObj = getMapHitObject();
 			hitObj->CalcHitPosition(&m_comboCenter);
@@ -2310,10 +2310,10 @@ void CGPartyObj::checkTargetParticle()
 			hitCylinder.m_axis.y = FLOAT_80331aa0;
 			hitCylinder.m_axis.z = FLOAT_80331a9c;
 			hitCylinder.m_radius = FLOAT_80331a9c;
-			hitCylinder.m_boundsMin.x = FLOAT_80331a9c;
-			hitCylinder.m_boundsMin.y = FLOAT_80331aa0;
-			hitCylinder.m_boundsMin.z = FLOAT_80331aa0;
-			hitCylinder.m_boundsMax.x = FLOAT_80331aa0;
+			hitCylinder.m_bound.m_min.x = FLOAT_80331a9c;
+			hitCylinder.m_bound.m_min.y = FLOAT_80331aa0;
+			hitCylinder.m_bound.m_min.z = FLOAT_80331aa0;
+			hitCylinder.m_bound.m_max.x = FLOAT_80331aa0;
 
 			if (MapMng.CheckHitCylinderNear(&hitCylinder, &move, 0x30) == 0) {
 				break;
@@ -2337,10 +2337,10 @@ void CGPartyObj::checkTargetParticle()
 		floorCylinder.m_axis.y = FLOAT_80331aa0;
 		floorCylinder.m_axis.z = FLOAT_80331a9c;
 		floorCylinder.m_radius = FLOAT_80331a9c;
-		floorCylinder.m_boundsMin.x = FLOAT_80331a9c;
-		floorCylinder.m_boundsMin.y = FLOAT_80331aa0;
-		floorCylinder.m_boundsMin.z = FLOAT_80331aa0;
-		floorCylinder.m_boundsMax.x = FLOAT_80331aa0;
+		floorCylinder.m_bound.m_min.x = FLOAT_80331a9c;
+		floorCylinder.m_bound.m_min.y = FLOAT_80331aa0;
+		floorCylinder.m_bound.m_min.z = FLOAT_80331aa0;
+		floorCylinder.m_bound.m_max.x = FLOAT_80331aa0;
 
 		if (MapMng.CheckHitCylinderNear(&floorCylinder, &down, 0x30) != 0) {
 			getMapHitObject()->CalcHitPosition(targetPos);
@@ -2401,10 +2401,10 @@ void CGPartyObj::moveCenterTargetParticle()
 	hitCylinder.m_axis.y = FLOAT_80331aa0;
 	hitCylinder.m_axis.z = FLOAT_80331a9c;
 	hitCylinder.m_radius = FLOAT_80331a9c;
-	hitCylinder.m_boundsMin.x = FLOAT_80331a9c;
-	hitCylinder.m_boundsMin.y = FLOAT_80331aa0;
-	hitCylinder.m_boundsMin.z = FLOAT_80331aa0;
-	hitCylinder.m_boundsMax.x = FLOAT_80331aa0;
+	hitCylinder.m_bound.m_min.x = FLOAT_80331a9c;
+	hitCylinder.m_bound.m_min.y = FLOAT_80331aa0;
+	hitCylinder.m_bound.m_min.z = FLOAT_80331aa0;
+	hitCylinder.m_bound.m_max.x = FLOAT_80331aa0;
 
 	if (MapMng.CheckHitCylinderNear(&hitCylinder, reinterpret_cast<Vec*>(&moveVec), 0x30) != 0) {
 		CMapObj* hitObj = getMapHitObject();
@@ -4040,10 +4040,10 @@ void CGPartyObj::gpmCol()
 		col.m_axis.y = m_bodyEllipsoidRadius;
 		col.m_axis.z = FLOAT_80331a9c;
 		col.m_radius = FLOAT_80331a9c;
-		col.m_boundsMin.x = FLOAT_80331a9c;
-		col.m_boundsMin.y = FLOAT_80331aa0;
-		col.m_boundsMin.z = FLOAT_80331aa0;
-		col.m_boundsMax.x = FLOAT_80331aa0;
+		col.m_bound.m_min.x = FLOAT_80331a9c;
+		col.m_bound.m_min.y = FLOAT_80331aa0;
+		col.m_bound.m_min.z = FLOAT_80331aa0;
+		col.m_bound.m_max.x = FLOAT_80331aa0;
 
 		if (MapMng.CheckHitCylinderNear(&col, &moveVec, m_attrFlags & ~0x10U) == 0) {
 			sGhostPartyWork.activeTrailCount = i + 1;


### PR DESCRIPTION
## Summary
- Add a CMapCylinderBound aggregate for the min/max bound pair and store it as CMapCylinder::m_bound.
- Update real CMapCylinder users to access m_bound.m_min / m_bound.m_max while leaving raw mirror structs unchanged.
- This matches the original aggregate copy shape for cylinder setup in maphit wrappers.

## Objdiff evidence
- ninja passes.
- Overall code: 631236 -> 631528 bytes matched (+292), functions 3538 -> 3539.
- main/maphit .text: 80.0574% -> 80.6949%.
- CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUl: 94.1918% -> 100.0000%.
- CheckHitCylinderNear__7CMapHitFP12CMapCylinderP3VecUsUsUl: 93.0000% -> 99.1791%.
- CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUl: 94.7711% -> 99.8795%.
- CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUsUsUl: 93.9872% -> 99.2949%.

## Plausibility
CMapCylinder bounds are used as a single CBound-compatible 0x18-byte region. Modeling them as an aggregate preserves the 0x40 CMapCylinder size and makes the compiler emit the original copy pattern instead of copying two independent Vec members.