### PR TITLE
Fix favorite menu rank text positions

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -209,7 +209,7 @@ void CMenuPcs::FavoDraw()
 		rankFont->SetMargin(LoadFloat(FLOAT_80333048));
 		sprintf(textBuf, s_FavoRankFormat_80333068, static_cast<int>(rank->place));
 		rankFont->SetPosX(static_cast<float>(drawEntry->x - 0xC));
-		rankFont->SetPosY(static_cast<float>(drawEntry->y) - LoadFloat(FLOAT_8033306C));
+		rankFont->SetPosY(static_cast<float>(drawEntry->y + 0xA) - LoadFloat(FLOAT_8033306C));
 		rankFont->Draw(textBuf);
 		rankFont->SetShadow(0);
 		rank++;
@@ -230,7 +230,7 @@ void CMenuPcs::FavoDraw()
 		    CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(LoadFloat(FLOAT_80333058) * drawEntry->alpha)).color);
 		const char* name = Game.m_cFlatDataArr[1].TableStrings(0)[(static_cast<char>(rank->foodId) + 0x17D) * 5 + 4];
 		nameFont->SetPosX(static_cast<float>(drawEntry->x + 0x1C));
-		nameFont->SetPosY(static_cast<float>(drawEntry->y) - LoadFloat(FLOAT_8033306C));
+		nameFont->SetPosY(static_cast<float>(drawEntry->y + 0xB) - LoadFloat(FLOAT_8033306C));
 		nameFont->Draw(const_cast<char*>(name));
 		rank++;
 		drawEntry++;


### PR DESCRIPTION
Summary
- Restores the vertical offsets used when drawing favorite rank numbers and food names in CMenuPcs::FavoDraw.
- Matches Ghidra shape: rank numbers use entry->y + 0xA, food names use entry->y + 0xB, both before subtracting FLOAT_8033306C.

Evidence
- ninja succeeds.
- objdiff command: build/tools/objdiff-cli diff -p . -u main/menu_favo -o - FavoDraw__8CMenuPcsFv
- FavoDraw size is now 2440 bytes, moving toward the target 2488-byte size from the previous 2432-byte compiled size.
- Local score changes from 76.77% to 76.68%, so this is a source-correctness/layout improvement rather than a score-only patch.

Plausibility
- These are UI text baseline offsets, not compiler coaxing.
- The offsets are directly reflected in resources/ghidra-decomp-1-31-2026/80162360_FavoDraw__8CMenuPcsFv.c.