### PR TITLE
Improve p_chara_viewer calcViewer match

### DIFF
--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -553,8 +553,7 @@ void CCharaPcs::calcViewer()
     }
 
     for (unsigned int i = 0; i < 2; i++) {
-        CChara::CModel* model = self->m_viewerModel[i];
-        if (model == 0) {
+        if (self->m_viewerModel[i] == 0) {
             continue;
         }
 
@@ -632,9 +631,12 @@ void CCharaPcs::calcViewer()
             bFirst = 0;
         }
 
-        float rotY = LoadFloat(kCharaViewerZero);
-        if (Pad._452_4_ == 0) {
-            unsigned int padIndex = (~((int)~(Pad._448_4_ - 4 | 4 - Pad._448_4_) >> 31) & 4U);
+        float rotY;
+        if (Pad._452_4_ != 0) {
+            rotY = LoadFloat(kCharaViewerZero);
+        } else {
+            unsigned int padIndex = 4;
+            padIndex &= ~((int)~(Pad._448_4_ - 4 | 4 - Pad._448_4_) >> 31);
             rotY = Pad.GetPadInputs()[padIndex].substickXF;
         }
         srt.rotY = srt.rotY + rotY;
@@ -642,26 +644,26 @@ void CCharaPcs::calcViewer()
 
         Mtx modelMtx;
         Math.SRTToMatrix(modelMtx, reinterpret_cast<SRT*>(&srt));
-        model->SetMatrix(modelMtx);
+        self->m_viewerModel[i]->SetMatrix(modelMtx);
 
         CStopWatch matrixWatch(const_cast<char*>(kCharaViewerNoName));
         matrixWatch.Reset();
         matrixWatch.Start();
-        model->CalcMatrix();
+        self->m_viewerModel[i]->CalcMatrix();
         matrixWatch.Stop();
         float matrixTime = matrixWatch.Get();
 
         matrixWatch.Reset();
         matrixWatch.Start();
-        model->CalcSkin();
+        self->m_viewerModel[i]->CalcSkin();
         matrixWatch.Stop();
         float skinTime = matrixWatch.Get();
 
         if (i == 0) {
-            CChara::CAnim* modelAnim = ViewerModelAnim(model);
+            CChara::CAnim* modelAnim = ViewerModelAnim(self->m_viewerModel[i]);
             if (modelAnim != 0) {
                 float animFrames = static_cast<float>(modelAnim->m_frameCount);
-                float frame = (float)fmod((double)ViewerModelTime(model), (double)(frameAdvance + animFrames));
+                float frame = (float)fmod((double)ViewerModelTime(self->m_viewerModel[i]), (double)(frameAdvance + animFrames));
                 Graphic.Printf(const_cast<char*>(s_frame_speed_fmt), frame, frameAdvance);
             }
             if (self->m_viewerSavedAnim != 0) {
@@ -679,7 +681,7 @@ void CCharaPcs::calcViewer()
                 Graphic.Printf(const_cast<char*>(s_cont_fmt), self->m_viewerAnimLoopIndex);
             }
             Graphic.Printf(const_cast<char*>(s_cpu_profile_fmt), matrixTime + skinTime, matrixTime, skinTime,
-                           ViewerModelNodeCount(model));
+                           ViewerModelNodeCount(self->m_viewerModel[i]));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adjust calcViewer model loop to reload m_viewerModel[i] at use sites instead of caching a local model pointer.
- Reshape viewer substick pad handling to use the locked-pad branch and masked padIndex form seen in the target.

## Objdiff evidence
Focused diff: `build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o -`

Before:
- .text: 96.44555%
- extab: 89.70589%
- calcViewer__9CCharaPcsFv: 93.642426%

After:
- .text: 96.87958%
- extab: 91.17647%
- calcViewer__9CCharaPcsFv: 94.4798%

Unaffected tracked scores:
- drawViewer__9CCharaPcsFv: 99.40476%
- createViewer__9CCharaPcsFv: 99.30986%
- .rodata/.bss/.sbss/.sdata2 remain 100% section matches

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_chara_viewer -o - > build/agent_p_chara_viewer_final.json`

## Plausibility
These changes express the same viewer logic with source shapes that match the target repeated member loads and explicit pad-index masking. No fake symbols, address constants, or manual section forcing were added.