### PR TITLE
Match texanim flag parsing

### DIFF
--- a/include/ffcc/texanim.h
+++ b/include/ffcc/texanim.h
@@ -64,7 +64,15 @@ private:
     char m_name[0x100];
     unsigned int m_totalFrames;
     int m_keyCount;
-    unsigned char m_flags;
+    union {
+        unsigned char m_flags;
+        struct {
+            signed char m_interp : 1;
+            signed char m_chin : 1;
+            signed char m_e1 : 1;
+            signed char m_flagsRest : 5;
+        } m_flagBits;
+    };
     unsigned char m_pad111[3];
     CTexAnimKey* m_keys;
 };

--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -579,12 +579,10 @@ inline void CTexAnimSeq::Create(CChunkFile& chunkFile, CMemory::CStage* stage)
         case 'INFO': {
             m_totalFrames = chunkFile.Get4();
             chunkFile.Get4();
-            char b7 = (char)chunkFile.Get4();
-            m_flags = (unsigned char)(((int)b7 << 7) | (m_flags & 0x7F));
-            char b6 = (char)chunkFile.Get4();
-            m_flags = (unsigned char)((((int)b6 << 6) & 0x40) | (m_flags & 0xBF));
+            m_flagBits.m_interp = (char)chunkFile.Get4();
+            m_flagBits.m_chin = (char)chunkFile.Get4();
             unsigned int eq = (unsigned int)__cntlzw((unsigned int)strcmp(m_name, s_texAnimSeqE1));
-            m_flags = (unsigned char)(((unsigned char)((int)(char)(eq >> 5) << 5) & 0x20) | (m_flags & 0xDF));
+            m_flagBits.m_e1 = (char)(eq >> 5);
             continue;
         }
         case 'KEY ':


### PR DESCRIPTION
## Summary
- Add a typed bitfield overlay for CTexAnimSeq flags while preserving the raw flag byte.
- Parse the INFO chunk flags through named bitfields so Metrowerks emits the target rlwimi bit updates.
- This fully matches CTexAnimSet::Create.

## Evidence
- ninja: passed
- main/texanim unit: 98.84555% -> 99.73089%
- CTexAnimSet::Create: 94.95556% -> 100.0%
- matched code in main/texanim: 3168 -> 4068 bytes
