### PR TITLE
Use CMapCylinder in item jump

### DIFF
--- a/src/itemobj.cpp
+++ b/src/itemobj.cpp
@@ -80,16 +80,6 @@ static inline CFlatRuntime2* ItemCFlatRuntime()
 	return reinterpret_cast<CFlatRuntime2*>(CFlat);
 }
 
-struct CItemJumpCylinder
-{
-	Vec m_bottom;
-	Vec m_top;
-	Vec m_axis;
-	float m_radius;
-	Vec m_boundsMin;
-	Vec m_boundsMax;
-};
-
 /*
  * --INFO--
  * PAL Address: 0x80124b78
@@ -182,25 +172,19 @@ void CGItemObj::ItemJump(int state, float jump)
 			unsigned int mapMask = object->m_bgHitMask;
 			Vec bottom = object->m_worldPosition;
 			Vec move;
-			CItemJumpCylinder cylinder;
 
 			bottom.y += FLOAT_80331b1c;
 			move.x = FLOAT_80331b20;
 			move.z = FLOAT_80331b20;
 			move.y = FLOAT_80331b24;
-			cylinder.m_boundsMin.z = FLOAT_80331b28;
-			cylinder.m_boundsMin.y = FLOAT_80331b28;
-			cylinder.m_boundsMin.x = FLOAT_80331b28;
-			cylinder.m_boundsMax.z = FLOAT_80331b2c;
-			cylinder.m_boundsMax.y = FLOAT_80331b2c;
-			cylinder.m_boundsMax.x = FLOAT_80331b2c;
+			CMapCylinder cylinder(FLOAT_80331b28, FLOAT_80331b2c);
 			cylinder.m_bottom = bottom;
 			cylinder.m_axis.x = FLOAT_80331b20;
 			cylinder.m_axis.y = FLOAT_80331b24;
 			cylinder.m_axis.z = FLOAT_80331b20;
 			cylinder.m_radius = FLOAT_80331b20;
 
-			if (MapMng.CheckHitCylinderNear(reinterpret_cast<CMapCylinder*>(&cylinder), &move, mapMask) != 0 &&
+			if (MapMng.CheckHitCylinderNear(&cylinder, &move, mapMask) != 0 &&
 			    g_hit_f->m_groupIndex == state) {
 				object->m_groundHitOffset.y += jump;
 			}


### PR DESCRIPTION
## Summary
- Replace the local duplicate ItemJump cylinder layout with the existing CMapCylinder type.
- Use the CMapCylinder min/max constructor for the same bounds initialization.
- Pass the typed cylinder directly into CheckHitCylinderNear instead of casting a local lookalike struct.

## Evidence
- ninja passes for GCCP01.
- ItemJump__9CGItemObjFif remains stable at 84.518074% in objdiff, with no score regression.
- main/itemobj report remains stable: onFrameAlways 99.6875%, onFrame 86.58878%, ItemJump 84.63856% in report output.

## Plausibility
This removes a hand-duplicated CMapCylinder-compatible struct and uses the real map-hit collision type already present in the project. The emitted code stays neutral while the source layout is more coherent for future matching work.