### PR TITLE
Improve YmBreath half-chance constant usage

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -32,6 +32,11 @@ static inline float LoadFloat(const float& value)
     return value;
 }
 
+static inline double LoadDouble(const double& value)
+{
+    return value;
+}
+
 struct pppYmBreath {
     _pppPObject m_object;
 };
@@ -968,7 +973,8 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
         particle->m_angleRandom = params->m_angleRandomRange * Math.RandF();
         flags = params->m_angleFlags;
         if (((flags & 1) != 0) && ((flags & 2) != 0)) {
-            if (kYmBreathHalfChance < Math.RandF()) {
+            float rand = Math.RandF();
+            if (LoadDouble(kYmBreathHalfChance) < rand) {
                 particle->m_angleRandom *= kCharaAnimNegativeOne;
             }
         } else if ((flags & 2) != 0) {
@@ -1001,7 +1007,8 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
             particle->m_rotationAccelY = rotationAccel;
             particle->m_rotationAccelX = rotationAccel;
             if (((params->m_rotationFlags & 1) != 0) && ((params->m_rotationFlags & 2) != 0)) {
-                if (kYmBreathHalfChance < Math.RandF()) {
+                float rand = Math.RandF();
+                if (LoadDouble(kYmBreathHalfChance) < rand) {
                     particle->m_rotationAccelX *= kCharaAnimNegativeOne;
                     particle->m_rotationAccelY *= kCharaAnimNegativeOne;
                 }
@@ -1013,10 +1020,12 @@ void BirthParticle(_pppPObject*, VYmBreath* vYmBreath, PYmBreath* pYmBreath, VCo
             particle->m_rotationAccelX = params->m_rotationRandomX * Math.RandF();
             particle->m_rotationAccelY = params->m_rotationRandomY * Math.RandF();
             if (((params->m_rotationFlags & 1) != 0) && ((params->m_rotationFlags & 2) != 0)) {
-                if (kYmBreathHalfChance < Math.RandF()) {
+                float randX = Math.RandF();
+                if (LoadDouble(kYmBreathHalfChance) < randX) {
                     particle->m_rotationAccelX *= kCharaAnimNegativeOne;
                 }
-                if (kYmBreathHalfChance < Math.RandF()) {
+                float randY = Math.RandF();
+                if (LoadDouble(kYmBreathHalfChance) < randY) {
                     particle->m_rotationAccelY *= kCharaAnimNegativeOne;
                 }
             } else if ((params->m_rotationFlags & 2) != 0) {


### PR DESCRIPTION
## What changed
- Added a double reference-load helper for `kYmBreathHalfChance` in `pppYmBreath.cpp`.
- Reordered the affected `Math.RandF()` comparisons so the generated code loads the named half-chance constant after the random call instead of emitting a duplicate local constant.

## Evidence
- `ninja` passes.
- `BirthParticle__FP11_pppPObjectP9VYmBreathP9PYmBreathP6VColorP13PARTICLE_DATAP13PARTICLE_WMATP14PARTICLE_COLOR`: 99.69873% -> 99.74937%.
- `[.sdata2-0]`: 77.77778% -> 82.35294%.
- `.sdata2` trailing inserted data shrank from 35 bytes to 27 bytes.

## Plausibility
This follows the existing `LoadFloat` pattern in the file and keeps source-level behavior unchanged while using the shipped named constant rather than a compiler-generated duplicate.
