### PR TITLE
Improve astar escape vector temporaries

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -182,7 +182,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 	Vec escapeDir;
 	CVector baseVec(base);
 	CVector fromVec(from);
-	CVector escapeDirSource;
+	Vec escapeDirSource;
 
 	PSVECSubtract(reinterpret_cast<Vec*>(&fromVec),
 	              reinterpret_cast<Vec*>(&baseVec),
@@ -229,7 +229,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 				{
 					CVector portalDirBase(base);
 					CVector portalDirPos(m_portals[i].m_position);
-					CVector dirToPortalSource;
+					Vec dirToPortalSource;
 					Vec portalVec;
 
 					PSVECSubtract(reinterpret_cast<Vec*>(&portalDirPos),
@@ -246,7 +246,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 
 					CVector distBase(base);
 					CVector distPortal(m_portals[i].m_position);
-					CVector distVecSource;
+					Vec distVecSource;
 
 					PSVECSubtract(reinterpret_cast<Vec*>(&distPortal),
 					              reinterpret_cast<Vec*>(&distBase),


### PR DESCRIPTION
## Summary
- Change output-only CVector temporaries in CAStar::getEscapePos to plain Vec buffers.
- Avoid unnecessary default CVector construction for PSVECSubtract outputs while preserving the surrounding CVector inputs and normalization flow.

## Objdiff Evidence
- main/astar .text: 95.639175% -> 95.655785%
- getEscapePos__6CAStarFR3VecR3Vecii: 91.10274% -> 91.30137%
- .rodata remains 100%; .bss remains 100%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/astar -o - --format json

## Plausibility
These temporaries are only used as PSVECSubtract destination buffers before being copied into Vec values, so plain Vec storage is a more plausible original source shape than default-constructed CVector objects.