### PR TITLE
Add missing system manager string

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -86,6 +86,7 @@ extern const char s_compilerMapLoaded[] =
     "\251\202\347\223\307\202\335\215\236\202\335\202\334\202\265\202\275"
     "\201\102\012";
 extern const char s_systemTemplateDebug[28] = "systemTemplateDebug\n";
+extern const char s_CManager_801D6F90[] = "CManager";
 extern const char s_systemStopwatchName[8];
 
 /*


### PR DESCRIPTION
## Summary
- Add the missing trailing CManager rodata string in system.cpp.
- This matches the symbol order around systemTemplateDebug from config/GCCP01/symbols.txt.

## Objdiff evidence
- main/system .text: 100.0% (unchanged)
- main/system .rodata: 99.15493% -> 100.0%
- main/system build remains clean with ninja

## Plausibility
- The added string corresponds to s_CManager_801D6F90 in the PAL symbols file and sits immediately after s_systemTemplateDebug in rodata order.
