### PR TITLE
Improve YmChangeTex draw callback TEV state

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -343,8 +343,8 @@ void ChangeTex_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void*
 	ChangeTexMeshRef* meshes = ChangeTexMeshes(model);
 	int displayListIdx;
 	ChangeTexDisplayListCopy* displayListPtr;
-	unsigned int drawTevBits;
-	unsigned int fullTevBits;
+	int drawTevBits;
+	int fullTevBits;
 	GXColor** meshColorArrays;
 	GXColor* meshColorArray;
 	ChangeTexMeshData* meshData;
@@ -408,9 +408,8 @@ void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void* pa
 	CTexture* texture = state->m_texture;
 
 	if (step->m_changeTex.m_mode == 0) {
-		unsigned int drawTevBits = 0xACE0F;
-		unsigned int fullTevBits = drawTevBits;
-		fullTevBits |= 0x1000;
+		int drawTevBits = 0xADE0F;
+		int fullTevBits = drawTevBits;
 		MaterialMan.SetChangeTexReflectionState(
 		    &texture->m_texObj, drawTevBits, fullTevBits);
 	}


### PR DESCRIPTION
## Summary
- Align `ChangeTex_DrawMeshDLCallback` with the PAL-decompiled reflected TEV state by using `0xADE0F` for both current and standard TEV bits.
- Use signed local TEV bit variables in `pppYmChangeTex` callbacks, matching the nearby `pppChangeTex` callback style.

## Evidence
- `ninja` passes.
- `main/pppYmChangeTex` `.text`: 97.15254% -> 97.16333%.
- `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`: 92.0% -> 92.10145%.
- `ChangeTex_AfterDrawMeshCallback__FPQ26CChara6CModelPvPviPA4_f`: unchanged at 94.14141%.
- `pppFrameYmChangeTex`: unchanged at 98.177216%.

## Plausibility
The PAL Ghidra output writes `0xADE0F` for the reflected TEV state in the draw callback. The previous source built that value indirectly from `0xACE0F | 0x1000`; this makes the source state match the decompiled material writes directly without adding fake symbols, address hacks, or manual section control.