### PR TITLE
Fix pppChangeTex reflection TEV bits

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -421,7 +421,7 @@ static void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, v
 	CTexture* texture = work->m_texture;
 
 	if (step->m_changeTex.m_mode == 0) {
-		int drawTevBits = 0xADE0F;
+		int drawTevBits = 0xACE0F;
 		int fullTevBits = drawTevBits;
 		fullTevBits |= 0x1000;
 		MaterialMan.SetChangeTexReflectionState(


### PR DESCRIPTION
## Summary
- Correct `ChangeTex_DrawMeshDLCallback` to use `0xACE0F` as the base reflection TEV bit mask and OR `0x1000` for the full mask.
- This matches the target constant materialization and fixes the `main/pppChangeTex` data/constant layout.

## Evidence
- `ninja` passes.
- `build/GCCP01/report.json` for `main/pppChangeTex`: data is now `156 / 156` matched (`100.0%`).
- Selected baseline from `tools/agent_select_target.py` had `main/pppChangeTex` data at `61.54%`.
- Target symbol checked: `ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f`.

## Plausibility
- `0xACE0F` is the base mask used before adding the `0x1000` bit; this mirrors the surrounding callback logic and avoids treating the full mask as the base draw mask.