### PR TITLE
Fix CGraphicPcs declarations and improve CMenuPcs mode branch

### DIFF
--- a/include/ffcc/p_graphic.h
+++ b/include/ffcc/p_graphic.h
@@ -9,17 +9,6 @@
 class CGraphicPcs : public CProcess
 {
 public:
-    static CProcessTableCallback m_table_desc0;
-    static CProcessTableCallback m_table_desc1;
-    static CProcessTableCallback m_table_desc2;
-    static CProcessTableCallback m_table_desc3;
-    static CProcessTableCallback m_table_desc4;
-    static CProcessTableCallback m_table_desc5;
-    static CProcessTableCallback m_table_desc6;
-    static CProcessTableCallback m_table_desc7;
-    static CProcessTableCallback m_table_desc8;
-    static CProcessTableCallback m_table_desc9;
-
     struct ScreenFadeSlot
     {
         int m_timer;         // 0x00

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -717,7 +717,7 @@ void CMenuPcs::changeMode(CMenuPcs::MENUMODE mode)
         currentMode = m_mode;
         if (currentMode != 1) {
             if (currentMode < 1) {
-                if ((currentMode != -1) && (-1 < currentMode)) {
+                if ((currentMode != -1) && (-2 < currentMode)) {
                     ReleaseRefSlot(reinterpret_cast<void**>(&m_fonts[1]));
 
                     i = 0;
@@ -766,7 +766,7 @@ void CMenuPcs::changeMode(CMenuPcs::MENUMODE mode)
         currentMode = m_mode;
         if (currentMode != 1) {
             if (currentMode < 1) {
-                if ((currentMode != -1) && (-1 < currentMode)) {
+                if ((currentMode != -1) && (-2 < currentMode)) {
                     createBattle();
                     createSingleMenu();
                 }


### PR DESCRIPTION
## Summary
- Remove duplicate CGraphicPcs table descriptor declarations that prevented the refreshed tree from compiling.
- Adjust the CMenuPcs battle-mode guard to the Ghidra-observed equivalent range check form.

## Evidence
- ninja passes: build/GCCP01/main.dol OK
- objdiff main/p_menu:
  - changeMode__8CMenuPcsFQ28CMenuPcs8MENUMODE: 89.85030% / 652b -> 91.90419% / 660b
  - calc__8CMenuPcsFv: unchanged at 85.61429% / 260b
  - __sinit_p_menu_cpp: unchanged at 77.82927% / 308b

## Plausibility
- The mode guard remains semantically equivalent for int mode values, but matches the original branch shape more closely.
- The CGraphicPcs header change removes a duplicate declaration block without changing layout or generated code intent.