### PR TITLE
Match pppConstrainCameraDir2 sdata2

### DIFF
--- a/config/GCCP01/symbols.txt
+++ b/config/GCCP01/symbols.txt
@@ -16959,6 +16959,7 @@ DOUBLE_803331D0 = .sdata2:0x803331D0; // type:object size:0x8 align:8 data:doubl
 @188 = .sdata2:0x803331E0; // type:object size:0x4 scope:local align:4 data:float
 @189 = .sdata2:0x803331E4; // type:object size:0x4 scope:local align:4 data:float
 @190 = .sdata2:0x803331E8; // type:object size:0x4 scope:local align:4 data:float
+kConstrainCameraDir2Zero = .sdata2:0x803331EC; // type:object size:0x4 align:4 data:float
 lbl_803331F0 = .sdata2:0x803331F0; // type:object size:0x7 data:string
 lbl_803331F8 = .sdata2:0x803331F8; // type:object size:0x8 data:string
 lbl_80333200 = .sdata2:0x80333200; // type:object size:0x8 data:string

--- a/src/pppConstrainCameraDir2.cpp
+++ b/src/pppConstrainCameraDir2.cpp
@@ -96,3 +96,5 @@ void pppFrameConstrainCameraDir2(pppConstrainCameraDir* param_1, pppConstrainCam
         }
     }
 }
+
+extern const float kConstrainCameraDir2Zero = 0.0f;


### PR DESCRIPTION
## Summary
- Add the missing trailing zero constant for `pppConstrainCameraDir2`'s `.sdata2` layout.
- Name the `0x803331EC` symbol as `kConstrainCameraDir2Zero` in `symbols.txt`.

## Evidence
- `ninja` passes, including `build/GCCP01/main.dol: OK`.
- `objdiff` for `main/pppConstrainCameraDir2` / `pppFrameConstrainCameraDir2`:
  - `.text`: 100.0%
  - `.sdata2`: 100.0%, now matching all 16 bytes: `1.0f, 25.0f, 1.3333f, 0.0f`
  - `pppFrameConstrainCameraDir2`: 100.0%
- `tools/agent_select_target.py` no longer lists `main/pppConstrainCameraDir2` as a data opportunity.

## Plausibility
- The added value is a real float constant adjacent to the existing three camera-dir scale constants, not section padding or a forced section placement.
- The function code remains a full match.
