### PR TITLE
Improve pppInitData allocation matching

### DIFF
--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -1829,15 +1829,14 @@ void pppInitData(_pppDataHead* pppDataHead, pppProg* pppProg, int param_3)
 	pppDataHead->m_shapeGroups = pppDataHead->m_shapeGroups + reinterpret_cast<u32>(dataBase);
 
 	int* chunkOffsets = reinterpret_cast<int*>(pppDataHead->m_cacheChunks);
-	CMemory::CStage* stageLoad = PartPcs.m_usbStreamData.m_stageLoad;
-	s16* cacheChunks = new (stageLoad, const_cast<char*>(s_pppPart_cpp), 0x620)
+	s16* cacheChunks = new (PartPcs.m_usbStreamData.m_stageLoad, const_cast<char*>(s_pppPart_cpp), 0x620)
 	    s16[static_cast<u32>(pppDataHead->m_cacheChunkCount) * 4];
 	pppDataHead->m_cacheChunks = reinterpret_cast<u32>(cacheChunks);
 
 	for (int i = 0; i < pppDataHead->m_cacheChunkCount; i++) {
 		int chunkOffset = chunkOffsets[0];
 		int chunkSize = chunkOffsets[1] - chunkOffset;
-		u8* chunkData = new (stageLoad, const_cast<char*>(s_pppPart_cpp), 0x626) u8[chunkSize];
+		u8* chunkData = new (PartPcs.m_usbStreamData.m_stageLoad, const_cast<char*>(s_pppPart_cpp), 0x626) u8[chunkSize];
 
 		memcpy(chunkData, dataBase + chunkOffset, chunkSize);
 		cacheChunks[(i << 2)] = ppvAmemCacheSet.SetData(chunkData, chunkSize, CAmemCache::PDT, param_3);
@@ -1846,7 +1845,7 @@ void pppInitData(_pppDataHead* pppDataHead, pppProg* pppProg, int param_3)
 	}
 
 	char* modelName = reinterpret_cast<char*>(pppDataHead->m_modelNames);
-	pppModelSt** modelRefs = new (stageLoad, const_cast<char*>(s_pppPart_cpp), 0x636)
+	pppModelSt** modelRefs = new (PartPcs.m_usbStreamData.m_stageLoad, const_cast<char*>(s_pppPart_cpp), 0x636)
 	    pppModelSt*[pppDataHead->m_modelCount];
 	pppDataHead->m_modelNames = reinterpret_cast<u32>(modelRefs);
 
@@ -1866,7 +1865,7 @@ void pppInitData(_pppDataHead* pppDataHead, pppProg* pppProg, int param_3)
 	}
 
 	char* shapeName = reinterpret_cast<char*>(pppDataHead->m_shapeNames);
-	pppShapeSt** shapeRefs = new (stageLoad, const_cast<char*>(s_pppPart_cpp), 0x643)
+	pppShapeSt** shapeRefs = new (PartPcs.m_usbStreamData.m_stageLoad, const_cast<char*>(s_pppPart_cpp), 0x643)
 	    pppShapeSt*[pppDataHead->m_shapeCount];
 	pppDataHead->m_shapeNames = reinterpret_cast<u32>(shapeRefs);
 
@@ -1886,7 +1885,7 @@ void pppInitData(_pppDataHead* pppDataHead, pppProg* pppProg, int param_3)
 	}
 
 	pppShapeGroupRaw* shapeGroups = reinterpret_cast<pppShapeGroupRaw*>(pppDataHead->m_shapeGroups);
-	pppShapeGroupRaw* shapeGroupRefs = new (stageLoad, const_cast<char*>(s_pppPart_cpp), 0x651)
+	pppShapeGroupRaw* shapeGroupRefs = new (PartPcs.m_usbStreamData.m_stageLoad, const_cast<char*>(s_pppPart_cpp), 0x651)
 	    pppShapeGroupRaw[pppDataHead->m_shapeGroupCount];
 	pppDataHead->m_shapeGroups = reinterpret_cast<u32>(shapeGroupRefs);
 
@@ -1894,7 +1893,7 @@ void pppInitData(_pppDataHead* pppDataHead, pppProg* pppProg, int param_3)
 		shapeGroupRefs[i].m_groupId = shapeGroups[i].m_groupId;
 		shapeGroupRefs[i].m_shapeCount = shapeGroups[i].m_shapeCount;
 		shapeGroupRefs[i].m_shapeList =
-		    new (stageLoad, const_cast<char*>(s_pppPart_cpp), 0x656) s16[shapeGroups[i].m_shapeCount];
+		    new (PartPcs.m_usbStreamData.m_stageLoad, const_cast<char*>(s_pppPart_cpp), 0x656) s16[shapeGroups[i].m_shapeCount];
 
 		shapeGroups[i].m_shapeList = reinterpret_cast<s16*>(reinterpret_cast<u8*>(shapeGroups[i].m_shapeList) + reinterpret_cast<u32>(dataBase));
 		memcpy(shapeGroupRefs[i].m_shapeList, shapeGroups[i].m_shapeList, static_cast<int>(shapeGroups[i].m_shapeCount) << 1);


### PR DESCRIPTION
## Summary
- Stop hoisting `PartPcs.m_usbStreamData.m_stageLoad` into a long-lived local in `pppInitData`
- Keep each allocation using the stage expression directly, matching the target lifetime/register shape more closely

## Evidence
- `ninja`: passes, `build/GCCP01/main.dol: OK`
- `build/tools/objdiff-cli diff -p . -u main/pppPart -o -`
  - `pppInitData__FP12_pppDataHeadP7pppProgi`: 73.1592% -> 75.72139%
  - `pppInitPdt__FPlP7pppProg`: unchanged at 73.456955%
  - `pppCreatePObject__FP9_pppMngStP12_pppPDataVal`: unchanged at 71.953575%

## Plausibility
This keeps the original behavior while reducing the lifetime of the stage pointer in source. The result is closer to the target allocation setup without hardcoded addresses, fake symbols, or section forcing.