### PR TITLE
Improve CMenuPcs calc match

### DIFF
--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -791,17 +791,9 @@ void CMenuPcs::changeMode(CMenuPcs::MENUMODE mode)
 void CMenuPcs::calc()
 {
     u8* self = reinterpret_cast<u8*>(this);
-    int mode = m_mode;
-
-    if (mode != 1) {
-        if (mode >= 1) {
-            if (mode < 3) {
-                calcBonus();
-            }
-            return;
-        }
-
-        if (mode >= 0) {
+    switch (m_mode) {
+        case 0:
+        {
             int i = 0;
             CMenuPcs* menu = this;
             do {
@@ -818,15 +810,15 @@ void CMenuPcs::calc()
                 menu = reinterpret_cast<CMenuPcs*>(reinterpret_cast<u8*>(menu) + 4);
             } while (i < 0xc);
 
-            int limit = m_battleHud.m_gaugeTarget;
             int current = m_battleHud.m_gaugeValue;
             int value = current - 1;
-            if (value <= limit) {
-                int alt = current + 1;
-                value = limit;
-                if (alt < limit) {
-                    value = alt;
+            int limit = current + (m_battleHud.m_gaugeTarget - current);
+            if (limit >= value) {
+                current++;
+                if (current < limit) {
+                    limit = current;
                 }
+                value = limit;
             }
             m_battleHud.m_gaugeValue = value;
 
@@ -836,11 +828,15 @@ void CMenuPcs::calc()
             m_battleHud.m_gaugeCounter = counter & ~((int)counter >> 31);
 
             calcVillageMenu();
+            break;
         }
-        return;
+        case 1:
+            CalcDiaryMenu();
+            break;
+        case 2:
+            calcBonus();
+            break;
     }
-
-    CalcDiaryMenu();
 }
 
 /*


### PR DESCRIPTION
## Summary
- Reworked CMenuPcs::calc mode dispatch as a switch over m_mode.
- Rephrased the battle HUD gauge clamp to better match the target control flow.

## Evidence
- ninja passes for GCCP01.
- calc__8CMenuPcsFv improved from ~85.6% to 94.14286% objdiff match.
- main/p_menu report fuzzy score improved from ~94.64% to 94.797386%.

## Plausibility
- The change keeps the same behavior while expressing the mode cases directly and keeping the gauge clamp as normal source logic.
- No section forcing, fake symbols, or manual compiler artifacts were introduced.