### PR TITLE
Improve debug menu pad input matching

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -211,8 +211,7 @@ void CDbgMenuPcs::calc()
 	if (Pad._452_4_ != 0) {
 		padInput = 0;
 	} else {
-		padOffset = 4U;
-		padOffset &= (Pad._448_4_ - 4 | 4 - Pad._448_4_) >> 0x1f;
+		padOffset = (Pad._448_4_ == 4) ? 0 : 4U;
 		padInput = Pad.GetPadInputs()[padOffset].buttonDown[0];
 	}
 
@@ -305,8 +304,7 @@ void CDbgMenuPcs::calc()
 	if (Pad._452_4_ != 0) {
 		padInput = 0;
 	} else {
-		padOffset = 4U;
-		padOffset &= (Pad._448_4_ - 4 | 4 - Pad._448_4_) >> 0x1f;
+		padOffset = (Pad._448_4_ == 4) ? 0 : 4U;
 		padInput = Pad.GetPadInputs()[padOffset].buttonDown[0];
 	}
 	if ((padInput & 4) != 0) {
@@ -324,8 +322,7 @@ void CDbgMenuPcs::calc()
 	if (Pad._452_4_ != 0) {
 		padInput = 0;
 	} else {
-		padOffset = 4U;
-		padOffset &= (Pad._448_4_ - 4 | 4 - Pad._448_4_) >> 0x1f;
+		padOffset = (Pad._448_4_ == 4) ? 0 : 4U;
 		padInput = Pad.GetPadInputs()[padOffset].buttonDown[0];
 	}
 	if ((padInput & 8) != 0) {
@@ -347,8 +344,7 @@ void CDbgMenuPcs::calc()
 	if (Pad._452_4_ != 0) {
 		padInput = 0;
 	} else {
-		padOffset = 4U;
-		padOffset &= (Pad._448_4_ - 4 | 4 - Pad._448_4_) >> 0x1f;
+		padOffset = (Pad._448_4_ == 4) ? 0 : 4U;
 		padInput = Pad.GetPadInputs()[padOffset].buttonDown[0];
 	}
 	if ((padInput & 0x200) != 0) {


### PR DESCRIPTION
## Summary
- Simplify the debug-menu pad input selection to an equality test against the PAL pad state.
- Keeps the existing behavior while matching the target branch/codegen more closely.

## Objdiff evidence
- main/p_dbgmenu .text: 98.461914% -> 98.84279%
- calc__11CDbgMenuPcsFv: 96.78671% -> 99.25175%
- .rodata remains 100.0%; .data remains 88.17829%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o - calc__11CDbgMenuPcsFv