### PR TITLE
Match JoyBus LoadMap

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -543,7 +543,7 @@ int JoyBus::LoadMap(int stageId, int mapId)
 
     m_fileBaseB_dup = 0;
 
-    char path[132];
+    char path[128];
     char tmp[16];
 
     strcpy(path, JoyBusConst::DVD_DIR);


### PR DESCRIPTION
## Summary
- reduce the local `path` buffer in `JoyBus::LoadMap` to 128 bytes, matching the original stack frame layout
- fully matches `LoadMap__6JoyBusFii`

## Evidence
- `ninja` passes
- `build/tools/objdiff-cli diff -p . -u main/joybus -o - LoadMap__6JoyBusFii`
  - before: `99.935486%`, size 372
  - after: `100.0%`, size 372
- matched code increased from `633488 / 1855224` bytes to `633860 / 1855224` bytes

## Plausibility
- the function builds `dvd/gba/m%02d_%d.mcd`; `path[128]` is a normal source-level pathname buffer and removes only the extra stack space that prevented the match
