### PR TITLE
Improve mapshadow constant references

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -11,11 +11,11 @@
 #include <dolphin/mtx.h>
 
 extern const double kMapShadowDepthBias;
-extern const float kMapShadowScaleStep = 0.5f;
-extern const double DOUBLE_8032FCF8 = 4503599627370496.0;
-extern const float FLOAT_8032FD00 = 0.0f;
-extern const float FLOAT_8032FD04 = 1.0f;
-extern const double DOUBLE_8032FD08 = 4503601774854144.0;
+extern const float kMapShadowScaleStep;
+extern const double DOUBLE_8032FCF8;
+extern const float FLOAT_8032FD00;
+extern const float FLOAT_8032FD04;
+extern const double DOUBLE_8032FD08;
 
 /*
  * --INFO--
@@ -128,3 +128,9 @@ void CMapShadow::Init()
 		                (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	}
 }
+
+extern const float kMapShadowScaleStep = 0.5f;
+extern const double DOUBLE_8032FCF8 = 4503599627370496.0;
+extern const float FLOAT_8032FD00 = 0.0f;
+extern const float FLOAT_8032FD04 = 1.0f;
+extern const double DOUBLE_8032FD08 = 4503601774854144.0;


### PR DESCRIPTION
## Summary
- split mapshadow sdata2 constant declarations from definitions so MWCC emits symbol references instead of folding local literals
- improves CMapShadow::Init constant references while preserving the existing data symbols

## Evidence
- ninja passes
- main/mapshadow before: Init__10CMapShadowFv 99.745766%, [.sdata2-0] 80.0%
- main/mapshadow after: Init__10CMapShadowFv 99.830505%, [.sdata2-0] 88.88889%

## Plausibility
- keeps the same named constants in src/mapshadow.cpp
- only moves definitions after function bodies to avoid compile-time folding, matching the target symbol loads for kMapShadowScaleStep
