### PR TITLE
Improve FavoInit entry setup

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -658,9 +658,9 @@ void CMenuPcs::FavoInit()
 	setupEntry->duration = 5;
 
 	FavoEntry* firstEntry = favoList->entries;
-	setupEntry = &favoList->entries[6];
 	iVar17 = 4;
 	do {
+		setupEntry = &favoList->entries[entryIndex++];
 		setupEntry->flags = 2;
 		setupEntry->tex = 0x37;
 		sVar11 = sVar11 + 2;
@@ -673,8 +673,8 @@ void CMenuPcs::FavoInit()
 		setupEntry->v = fVar4;
 		setupEntry->startFrame = 7;
 		setupEntry->duration = 5;
-		setupEntry++;
 
+		setupEntry = &favoList->entries[entryIndex++];
 		setupEntry->flags = 2;
 		setupEntry->tex = 0x37;
 		setupEntry->x = firstEntry->x + 0x28;
@@ -686,7 +686,6 @@ void CMenuPcs::FavoInit()
 		setupEntry->v = fVar4;
 		setupEntry->startFrame = 7;
 		setupEntry->duration = 5;
-		setupEntry++;
 		iVar17 = iVar17 - 1;
 	} while (iVar17 != 0);
 


### PR DESCRIPTION
## Summary
- Use the existing entry index when initializing the favorite menu row entries in `CMenuPcs::FavoInit`.
- This avoids the separate moving setup pointer for that block and better matches the indexed setup shape used earlier in the function.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/menu_favo -o /tmp/menu_favo_after.json FavoInit__8CMenuPcsFv`
- `FavoInit__8CMenuPcsFv`: 77.74383% -> 77.916664%.
- Built `FavoInit` size: 1260 -> 1288 bytes, closer to the 1296-byte target.
- `.text` section match: 83.19601% -> 83.23592%.
- `extabindex` match: 94.44444% -> 95.83333%; `extab` has a small local tradeoff, 100.0% -> 97.91667%.

## Plausibility
- The changed loop now continues the same `entryIndex++` entry-selection pattern already used in the preceding setup entries, instead of switching to a separate pointer increment for the row entries.