### PR TITLE
Remove duplicate system CManager string

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -86,7 +86,6 @@ extern const char s_compilerMapLoaded[] =
     "\251\202\347\223\307\202\335\215\236\202\335\202\334\202\265\202\275"
     "\201\102\012";
 extern const char s_systemTemplateDebug[28] = "systemTemplateDebug\n";
-extern const char s_CManager_801D6F90[] = "CManager";
 extern const char s_systemStopwatchName[8];
 
 /*


### PR DESCRIPTION
## Summary
- Remove the duplicate `s_CManager_801D6F90` definition from `system.cpp`.
- The string is already owned by `usb.cpp` immediately before `s_usbCallbackMissingFmt`, matching the MAP layout.

## Evidence
- `ninja` succeeds.
- `main/system` code remains size-matched at 3992 bytes / 100%.
- `main/system` source `.rodata` shrinks from 549 bytes to 537 bytes against the 528-byte target.
- Objdiff `.rodata` symbol score improves from 98.05014% to 99.15493%.

## Plausibility
- This removes a duplicate string definition from the wrong unit rather than adding a matching hack.
- `config/GCCP01/symbols.txt` places `s_CManager_801D6F90` before USB strings, and `src/usb.cpp` already defines it there.