### PR TITLE
Match pppConstrainCameraDir2 extab

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -604,7 +604,7 @@ config.libs = [
             Object(NonMatching, "pppColum.cpp"),
             Object(NonMatching, "pppConformBGNormal.cpp"),
             Object(NonMatching, "pppConstrainCameraDir.cpp", cflags=cflags_game),
-            Object(NonMatching, "pppConstrainCameraDir2.cpp", cflags=cflags_game),
+            Object(NonMatching, "pppConstrainCameraDir2.cpp", cflags=cflags_game_cpp_exceptions),
             Object(NonMatching, "pppConstrainCameraForLoc.cpp"),
             Object(NonMatching, "pppCorona.cpp"),
             Object(NonMatching, "pppCrystal.cpp"),


### PR DESCRIPTION
## Summary
- Build `pppConstrainCameraDir2.cpp` with the existing game C++ exceptions flag profile.
- This restores the target-owned `extab` and `extabindex` for the unit while preserving the already-matching code.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppConstrainCameraDir2 -o -` reports:
  - `.text`: 100.0%
  - `extab`: 100.0%
  - `extabindex`: 100.0%
  - `.sdata2`: 100.0%
  - `pppFrameConstrainCameraDir2`: 100.0% / 688 bytes

## Plausibility
- `config/GCCP01/splits.txt` assigns `extab` and `extabindex` to `pppConstrainCameraDir2.cpp`.
- The source behavior did not need coercion; this fixes the compiler profile for the unit instead of adding manual unwind data.