### PR TITLE
Match YM change texture TEV data

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -408,8 +408,9 @@ void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, void* pa
 	CTexture* texture = state->m_texture;
 
 	if (step->m_changeTex.m_mode == 0) {
-		int drawTevBits = 0xADE0F;
-		int fullTevBits = drawTevBits;
+		unsigned int drawTevBits = 0xACE0F;
+		unsigned int fullTevBits = drawTevBits;
+		fullTevBits |= 0x1000;
 		MaterialMan.SetChangeTexReflectionState(
 		    &texture->m_texObj, drawTevBits, fullTevBits);
 	}


### PR DESCRIPTION
## Summary
- Build the YM change texture reflection TEV state from the base draw bits plus the std TEV bit, matching the sibling change texture path.
- This removes the extra direct 0xADE0F data constant from pppYmChangeTex and brings the unit data to a full match.

## Evidence
- ninja passes.
- main/pppYmChangeTex data: 92 / 152 bytes (60.53%) -> 152 / 152 bytes (100%).
- Current report: .sdata2 100%, extabindex 100%, unit data 100%.

## Plausibility
- The source now mirrors the existing pppChangeTex TEV setup pattern: drawTevBits = 0xACE0F, then fullTevBits |= 0x1000 for the standard state.
