### PR TITLE
Improve CMapShadow init match

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -17,6 +17,11 @@ extern const float FLOAT_8032FD00 = 0.0f;
 extern const float FLOAT_8032FD04 = 1.0f;
 extern const double DOUBLE_8032FD08 = 4503601774854144.0;
 
+static inline float LoadFloat(const float& value)
+{
+	return value;
+}
+
 /*
  * --INFO--
  * PAL Address: 0x8004c71c
@@ -117,13 +122,13 @@ void CMapShadow::Init()
 	if (m_useFrustum != 0) {
 		float scale = m_shadowScale;
 		double scaleBias = kMapShadowDepthBias;
-		float scaleStep = kMapShadowScaleStep;
+		float scaleStep = LoadFloat(kMapShadowScaleStep);
 		C_MTXLightFrustum(m_lightMtx, -height, height, -width, width, m_frustumNear,
 		                  (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	} else {
 		float scale = m_shadowScale;
 		double scaleBias = kMapShadowDepthBias;
-		float scaleStep = kMapShadowScaleStep;
+		float scaleStep = LoadFloat(kMapShadowScaleStep);
 		C_MTXLightOrtho(m_lightMtx, -height, height, -width, width,
 		                (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	}


### PR DESCRIPTION
## Summary
- Load the map shadow scale-step constant through a reference helper in CMapShadow::Init.
- This makes the generated code load the named constant instead of an anonymous literal in both frustum and ortho setup paths.

## Objdiff Evidence
Unit: main/mapshadow
- .text: 99.679146% -> 99.73262%
- Init__10CMapShadowFv: 99.745766% -> 99.91525%
- CMapShadowInsertOctTree__FQ210CMapShadow6TARGETR8COctTree unchanged: 99.40678%
- Calc__10CMapShadowFv unchanged: 99.52381%
- .sdata2 unchanged/matched: 100.0%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/mapshadow -o build/agent_mapshadow_final.json Init__10CMapShadowFv

## Plausibility
The helper is the same const-reference load pattern used elsewhere in the project and keeps the source-level behavior unchanged while producing a more accurate named-constant access.