### PR TITLE
Add CMapPcs loaded map number symbol

### DIFF
--- a/config/GCCP01/symbols.txt
+++ b/config/GCCP01/symbols.txt
@@ -13826,6 +13826,7 @@ s_bitMask = .sbss:0x8032ECB8; // type:object size:0x4 data:4byte
 octtree_draw_node_ct = .sbss:0x8032ECBC; // type:object size:0x4 data:4byte
 g_MapHitDrawMode = .sbss:0x8032ECC0; // type:object size:0x1 data:byte
 g_MapHitFaceFlag = .sbss:0x8032ECC1; // type:object size:0x1 data:byte
+s_loadedMapNo__7CMapPcs = .sbss:0x8032ECC4; // type:object size:0x4 data:4byte
 g_mapStage = .sbss:0x8032ECC8; // type:object size:0x4 data:4byte
 g_mapSection = .sbss:0x8032ECCC; // type:object size:0x4 data:4byte
 g_hit_prof = .sbss:0x8032ECD0; // type:object size:0x4 data:4byte


### PR DESCRIPTION
## Summary
- Add the missing PAL sbss symbol for CMapPcs' loaded map number at 0x8032ECC4.
- This lets p_map.cpp's LoadMap relocations resolve to the recovered source name for the map number global.

## Evidence
- ninja passes, including build/GCCP01/main.dol: OK.
- objdiff: LoadMap__7CMapPcsFiiPvUlUc improves from 99.85782% to 99.92891%.
- map.cpp .sbss remains at 80.0%, so the existing g_MapHitDrawMode/g_MapHitFaceFlag symbols are preserved without a section regression.

## Plausibility
- Ghidra's LoadMap decomp uses DAT_8032ECC4 as the saved/restored map number paired with the stage number at 0x8032ECC0.
- The new symbol is a real 4-byte object at an unclaimed aligned word and does not overlap the existing map hit byte symbols.