### PR TITLE
Improve menu and texture matching

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -825,8 +825,8 @@ void CMenuPcs::ItemInit1()
 void CMenuPcs::ItemInit()
 {
     int index;
-    short yOffset;
-    short count;
+    int yOffset;
+    int count;
     MenuItemOpenAnim* entry;
     ItemMenuAnimList* itemList;
 
@@ -911,7 +911,7 @@ void CMenuPcs::ItemInit()
         entry->tex = 0x37;
         count = count + 2;
         entry->x = itemList->anims[0].x + 0x24;
-        short nextY = yOffset + 0x20;
+        int nextY = yOffset + 0x20;
         entry->y = itemList->anims[0].y + yOffset;
         entry->w = 200;
         entry->h = 0x28;

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -342,6 +342,9 @@ int CMenuPcs::MLstOpen()
 		int i;
 		short initializedCount;
 		short yPos;
+		double itemCenter;
+		double xOrigin;
+		float zero;
 
 		memset(this->lstData, 0, sizeof(MenuLstList));
 		one = FLOAT_803333F0;
@@ -350,7 +353,9 @@ int CMenuPcs::MLstOpen()
 			entry->z = one;
 		}
 
-		zero = 0.0f;
+		xOrigin = DOUBLE_80333420;
+		itemCenter = DOUBLE_803333E8;
+		zero = FLOAT_803333D0;
 		initializedCount = 0;
 		yPos = 0x18;
 		for (i = 0; i < 9; i++) {
@@ -360,7 +365,7 @@ int CMenuPcs::MLstOpen()
 			entry->tex = 0x5B;
 			entry->width = 0xE0;
 			entry->height = 0x28;
-			entry->x = (short)(int)-(((double)entry->width * DOUBLE_803333E8) - DOUBLE_80333420);
+			entry->x = (short)(int)-(((double)entry->width * itemCenter) - xOrigin);
 			entry->y = yPos;
 			yPos += 0x20;
 			entry->s = zero;

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -1108,7 +1108,7 @@ void CPtrArray<CTexture*>::ReleaseAndRemoveAll()
     for (unsigned int i = 0; i < (unsigned int)m_numItems; i++) {
         CRef* item = reinterpret_cast<CRef*>(m_items[i]);
         if (item != 0) {
-            if (item->DecRef() == 0) {
+            if (--item->refCount == 0) {
                 delete item;
             }
             m_items[i] = 0;


### PR DESCRIPTION
## Summary
- Kept the existing `menu_item` loop counter/offset cleanup that improves `ItemInit__8CMenuPcsFv`.
- Matched `CPtrArray<CTexture*>::ReleaseAndRemoveAll()` by using the same direct `CRef::refCount` decrement form as nearby matched pointer-array specializations.
- Hoisted `MLstOpen` setup constants into locals so the item setup loop is closer to the target code shape.

## Evidence
- `ninja` passes.
- `ItemInit__8CMenuPcsFv`: 78.50588% -> 83.59412%; function size 696 -> 680 bytes, matching target 680 bytes.
- `main/menu_item` .text: 84.15269% -> 84.65298%.
- `ReleaseAndRemoveAll__21CPtrArray<P8CTexture>Fv`: 75.0% -> 100.0%.
- `main/textureman` .text: 96.73916% -> 97.457466%; extab: 99.65278% -> 100.0%; extabindex: 98.11828% -> 98.3871%.
- `MLstOpen__8CMenuPcsFv`: 96.21111% -> 96.32222%.
- `main/menu_lst` .text: 92.72497% -> 92.747986%.

## Plausibility
- The item menu values are loop arithmetic counters and row offsets, so keeping them as `int` until storing into 16-bit fields is natural source and removes target-absent sign-extension instructions.
- Directly decrementing `refCount` matches existing matched `CPtrArray` specializations in `texanim` and is equivalent to the inline `DecRef()` helper.
- The `MLstOpen` constants are reused setup values for item placement and zero initialization, and hoisting them matches the decompiled target shape without changing behavior.
