### PR TITLE
Improve USB RTTI rodata ownership

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -87,7 +87,7 @@ p_sample.cpp:
 	extabindex  start:0x8000B434 end:0x8000B440
 	.text       start:0x8001FE74 end:0x8001FF6C
 	.ctors      start:0x801D53B8 end:0x801D53BC
-	.rodata     start:0x801D6CC8 end:0x801D6CEC
+	.rodata     start:0x801D6CC8 end:0x801D6CE9
 	.data       start:0x801E8498 end:0x801E868C
 	.sdata      start:0x8032E428 end:0x8032E440
 	.sbss       start:0x8032EC60 end:0x8032EC64
@@ -97,7 +97,7 @@ p_usb.cpp:
 	extabindex  start:0x8000B440 end:0x8000B4AC
 	.text       start:0x8001FF6C end:0x80020494
 	.ctors      start:0x801D53BC end:0x801D53C0
-	.rodata     start:0x801D6D08 end:0x801D6D24
+	.rodata     start:0x801D6CF0 end:0x801D6D24
 	.data       start:0x801E8690 end:0x801E8814
 	.bss        start:0x80244028 end:0x8024413C
 	.sdata      start:0x8032E440 end:0x8032E458

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -38,6 +38,8 @@ CSmallProcessTable CUSBPcs::m_table = {
         0x12,
     },
 };
+extern const char sUsbManagerClassName[] = "CManager";
+extern const char sUsbProcessClassName[] = "CProcess";
 extern const char s_p_usb_cpp[] = "p_usb.cpp";
 extern const char s_usbRootPath[16] = "plot/kmitsuru/";
 


### PR DESCRIPTION
## Summary
- Move the p_sample/p_usb rodata boundary so USB RTTI class-name strings are owned by p_usb.
- Define the CManager/CProcess RTTI class-name strings in p_usb source before the existing USB strings.
- Keep generated RTTI/vtable data compiler-owned; no manual vtable or RTTI definitions.

## Evidence
- ninja passes and build/GCCP01/main.dol reports OK.
- main/p_usb now owns a 52-byte .rodata section containing sUsbManagerClassName, sUsbProcessClassName, s_p_usb_cpp, and s_usbRootPath; each named string matches 100%.
- main/p_usb .rodata is now 95.652176% (was 92.85714% with only the later USB strings in the split).
- Adjacent main/p_sample remains exact for checked sections: .text/.rodata/.data/.sdata all 100%.

## Plausibility
The original symbols list places sUsbManagerClassName and sUsbProcessClassName immediately before s_p_usb_cpp. This change reflects that layout while leaving RTTI/vtables generated normally by the compiler.