### PR TITLE
Add p_map RTTI name symbols

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -84,6 +84,8 @@ CProcessTableCallback CMapPcs::m_table_desc23 = {0, 0xFFFFFFFF, reinterpret_cast
 extern "C" const char s_CMapPcs_GAME_801D76E0[] = "CMapPcs(GAME)";
 extern "C" const char s_CMapPcs_VIEWER_801D76F0[] = "CMapPcs(VIEWER)";
 extern "C" const char s_CMapPcs_PART_801D7700[] = "CMapPcs(PART)";
+extern const char s_CManager_801D7710[] = "CManager";
+extern const char s_CProcess_801D771C[] = "CProcess";
 
 CProcessTable CMapPcs::m_table[3] = {
     {


### PR DESCRIPTION
## Summary
- define the p_map-local CManager and CProcess RTTI name strings next to the CMapPcs table names
- improves p_map rodata ownership without changing codegen

## Evidence
- ninja succeeds
- main/p_map matched data: 1677 -> 2057 bytes
- main/p_map .rodata: 95.09537% -> 100.0%
- total matched data: 1241076 -> 1241456 bytes

## Plausibility
- the recovered strings are the standard RTTI name payloads for CManager/CProcess and sit directly after the CMapPcs process table names in p_map rodata
