### PR TITLE
Remove stray pppRain sdata2 constant

### DIFF
--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -428,5 +428,4 @@ inline void InitRainData(VRain* work, PRain* rain, RAIN_DATA*)
 
 extern const float FLOAT_80330FD4 = -1.0f;
 extern const float FLOAT_80330FD8 = 0.0f;
-extern const float FLOAT_80330FDC = 0.0f;
 extern const double DOUBLE_80330FE0 = 0.5;


### PR DESCRIPTION
## Summary
- Remove the unclaimed `FLOAT_80330FDC` definition from `src/pppRain.cpp`.
- Keep `pppRain.o` ownership aligned with `config/GCCP01/symbols.txt` and the linked MAP: `FLOAT_80330FD4`, `FLOAT_80330FD8`, and `DOUBLE_80330FE0` remain the only `pppRain.o` constants in that range.

## Evidence
- `ninja` passes.
- `main/pppRain` remains at 100% data in `build/GCCP01/report.json` (`.rodata`, `.sdata2`, `extab`, and `extabindex` all 100%).
- `build/GCCP01/main.elf.MAP` shows no `FLOAT_80330FDC` owner; the nearby owned symbols are the three constants retained in source.

## Plausibility
- This removes an address-style stray constant rather than adding compiler coaxing or fake linkage.
