### PR TITLE
Improve AddLetter source shape

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -432,10 +432,10 @@ int CCaravanWork::IsOutOfShouki()
 void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int hasMoneyFlag, int hasReplyFlag,
 							 int itemA, int itemB, int itemC, int itemD)
 {
-	for (int i = 98; i >= 0; i--) {
-		m_letters[i + 1].m_word0 = m_letters[i].m_word0;
-		m_letters[i + 1].m_word1 = m_letters[i].m_word1;
-		m_letters[i + 1].m_word2 = m_letters[i].m_word2;
+	for (int i = 99; i > 0; i--) {
+		m_letters[i].m_word0 = m_letters[i - 1].m_word0;
+		m_letters[i].m_word1 = m_letters[i - 1].m_word1;
+		m_letters[i].m_word2 = m_letters[i - 1].m_word2;
 	}
 
 	memset(&m_letters[0], 0, sizeof(m_letters[0]));
@@ -443,7 +443,7 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 	LetterFlags* letterFlags = reinterpret_cast<LetterFlags*>(&m_letters[0]);
 	unsigned short* letterWords16 = reinterpret_cast<unsigned short*>(&m_letters[0]);
 	unsigned int* letterWords32 = reinterpret_cast<unsigned int*>(&m_letters[0]);
-	letterWords16[0] = (unsigned short)((letterWords16[0] & 0xF803) | ((letterType << 2) & 0x7FC));
+	letterWords16[0] |= static_cast<unsigned short>(letterType << 2);
 	letterWords32[0] = (letterWords32[0] & 0xFFFC01FF) | ((senderId & 0x1FF) << 9);
 	letterFlags->hasMoney = hasMoneyFlag;
 	if (letterFlags->hasMoney != 0) {


### PR DESCRIPTION
## Summary
- Reword the AddLetter shift loop to copy destination slots directly from the prior slot.
- Simplify the letter type insertion after the zeroed letter header, reducing unnecessary masking in codegen.

## Evidence
- Built with: `ninja`
- `AddLetter__12CCaravanWorkFiiiiiiiii`: 83.5102% -> 84.438774%
- `main/gobjwork` .text: 87.57897% -> 87.59766%

## Plausibility
- The shift loop now reads as moving each letter into the next slot, which is the natural source expression for inserting a new front letter.
- The first letter is memset to zero immediately before packing fields, so OR-ing in the shifted letter type preserves behavior while producing closer codegen.