### PR TITLE
Inline non-emitted color helpers

### DIFF
--- a/include/ffcc/color.h
+++ b/include/ffcc/color.h
@@ -12,7 +12,13 @@ public:
 	CColor(_GXColor& other);
 	operator _GXColor();
 	operator _GXColor*();
-	void Identity();
+	void Identity()
+	{
+		color.r = 0xFF;
+		color.g = 0xFF;
+		color.b = 0xFF;
+		color.a = 0xFF;
+	}
 
 	GXColor color;
 };
@@ -21,7 +27,13 @@ class CColor3
 {
 public:
 	CColor3();
-	CColor3(unsigned char r, unsigned char g, unsigned char b);
+	CColor3(unsigned char r, unsigned char g, unsigned char b)
+	{
+		color.r = r;
+		color.g = g;
+		color.b = b;
+		color.a = 0xFF;
+	}
 	CColor3(CColor3& other);
 	CColor3(_GXColor& other);
 

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -25,19 +25,6 @@ CColor3::CColor3(CColor3& other)
  * Address:	TODO
  * Size:	TODO
  */
-CColor3::CColor3(unsigned char r, unsigned char g, unsigned char b)
-{
-	this->color.r = r;
-	this->color.g = g;
-	this->color.b = b;
-	this->color.a = 0xFF;
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
 CColor3::CColor3()
 {
 }
@@ -82,17 +69,4 @@ CColor::CColor(unsigned char r, unsigned char g, unsigned char b, unsigned char 
  */
 CColor::CColor()
 {
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CColor::Identity()
-{
-	this->color.r = 0xFF;
-	this->color.g = 0xFF;
-	this->color.b = 0xFF;
-	this->color.a = 0xFF;
 }


### PR DESCRIPTION
## Summary
- Move `CColor3(u8, u8, u8)` and `CColor::Identity()` inline in `color.h`.
- Remove their out-of-line definitions from `color.cpp`, matching the PAL symbol set for `color.o`.

## Evidence
- `ninja` succeeds.
- `main/color` objdiff after this change: target `.text` 76 bytes, current `.text` 76 bytes.
- Emitted `color.o` symbols are now only the seven PAL symbols, all 100% matched:
  - `__ct__7CColor3FR8_GXColor`
  - `__ct__7CColor3FR7CColor3`
  - `__ct__7CColor3Fv`
  - `__ct__6CColorFR8_GXColor`
  - `__ct__6CColorFR6CColor`
  - `__ct__6CColorFUcUcUcUc`
  - `__ct__6CColorFv`

## Plausibility
PAL has no out-of-line symbols for `CColor3(u8, u8, u8)` or `CColor::Identity()`, and the runbook explicitly allows marking unused/non-emitted helpers inline to avoid score regressions. This keeps the helper source available while removing extra emitted text from `color.o`.
