### PR TITLE
Use maphit constants in FindIntersection setup

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -884,14 +884,14 @@ int FindIntersection(const Vec& start, const Vec& direction, const CMapCylinder&
     Vec bitangent;
     Vec axis = cyl.m_axis;
     const f32 axisLen = PSVECMag(&axis);
-    PSVECScale(&axis, &axis, 1.0f / axisLen);
+    PSVECScale(&axis, &axis, kMapHitUnitScale / axisLen);
 
     if (fabs(axis.x) >= fabs(axis.y) && fabs(axis.x) >= fabs(axis.z)) {
         orthogonal.x = -axis.y;
         orthogonal.y = axis.x;
-        orthogonal.z = 0.0f;
+        orthogonal.z = kMapHitZero;
     } else {
-        orthogonal.x = 0.0f;
+        orthogonal.x = kMapHitZero;
         orthogonal.y = axis.z;
         orthogonal.z = -axis.y;
     }
@@ -905,7 +905,7 @@ int FindIntersection(const Vec& start, const Vec& direction, const CMapCylinder&
     localDirection.z = PSVECDotProduct(&axis, &direction);
 
     const f32 directionLen = PSVECMag(&localDirection);
-    const f32 tScale = 1.0f / directionLen;
+    const f32 tScale = kMapHitUnitScale / directionLen;
     PSVECScale(&localDirection, &localDirection, tScale);
 
     Vec relStart;


### PR DESCRIPTION
## Summary
- Replaced duplicate `1.0f`/`0.0f` literals in the setup portion of `FindIntersection` with existing `kMapHitUnitScale` and `kMapHitZero` constants.
- Keeps the function size unchanged while aligning more loads with the target constant symbols.

## Evidence
- `ninja` passes.
- `FindIntersection__FRC3VecRC3VecRC12CMapCylinderRf` objdiff: 60.147312% -> 60.181976%, size 2224 unchanged.

## Plausibility
- These constants are already declared and used throughout `maphit.cpp` for the same values.
- The change removes duplicate literals in favor of named unit-owned constants without altering control flow or data layout.