### PR TITLE
Improve CGame SetNextScript loop

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1571,17 +1571,19 @@ void CCameraPcs::SetZRotate(float zRotate)
  */
 void CGame::SetNextScript(CGame::CNextScript* nextScript)
 {
-    unsigned int* dst = (unsigned int*)((char*)&m_nextScript - 4);
+    int count = 0x20;
+    unsigned int* dst = (unsigned int*)&m_nextScript;
     unsigned int* src = (unsigned int*)((char*)nextScript - 4);
 
-    for (int i = 0; i < 0x20; i++) {
+    do {
         unsigned int a = src[1];
         src += 2;
         unsigned int b = src[0];
         dst[1] = a;
         dst += 2;
         dst[0] = b;
-    }
+        count--;
+    } while (count != 0);
 
     m_newGameFlag = 1;
 }


### PR DESCRIPTION
## Summary
- Rework CGame::SetNextScript as a counted do/while word-copy loop.
- Match the target function size and improve the selected symbol without changing adjacent cflat runtime output.

## Objdiff Evidence
- main/cflat_r2system SetNextScript__5CGameFPQ25CGame11CNextScript: 0.0% -> 73.5%
- Source symbol size: 296 bytes -> 56 bytes, matching the target size.
- SetNextScriptNewGame__5CGameFv remains 100.0%.
- onSystemFunc__13CFlatRuntime2FPQ212CFlatRuntime7CObjectiiRi unchanged at 10.44405%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o /tmp/cflat_setnext_final.json SetNextScript__5CGameFPQ25CGame11CNextScript

## Plausibility
- The emitted code is now a compact counted copy loop instead of a fully unrolled manual copy, matching the decompiled target structure more closely and removing artificial code bloat.