### PR TITLE
Fix mapshadow depth bias linkage

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -10,7 +10,7 @@
 #include "ffcc/vector.h"
 #include <dolphin/mtx.h>
 
-extern const double kMapShadowDepthBias = 0.5;
+extern const double kMapShadowDepthBias;
 static const float kMapShadowScaleStep = 0.5f;
 static const double DOUBLE_8032FCF8 = 4503599627370496.0;
 extern const float FLOAT_8032FD00 = 0.0f;


### PR DESCRIPTION
## Summary
- Move kMapShadowDepthBias ownership out of mapshadow.cpp by changing it from a definition to an external reference.
- This matches the split layout where mapshadow.cpp starts its .sdata2 range at 0x8032FCF0, while the depth-bias symbol is at 0x8032FCE8.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/mapshadow -o build/mapshadow_diff_result.json Init__10CMapShadowFv
- Before: mapshadow text 99.62567%, Init__10CMapShadowFv 99.57627%.
- After: mapshadow text 99.679146%, Init__10CMapShadowFv 99.745766%.

## Plausibility
- The change removes an incorrect definition from mapshadow.cpp and leaves the function referencing the shared depth-bias constant through normal linkage.
- No manual section placement, address hardcoding, or generated-function hacks.