### PR TITLE
Inline unused chara anim helpers

### DIFF
--- a/src/chara_anim.cpp
+++ b/src/chara_anim.cpp
@@ -323,7 +323,7 @@ CChara::CAnimNode::CAnimNode()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CChara::CAnimNode::Create(CChunkFile& chunkFile)
+inline void CChara::CAnimNode::Create(CChunkFile& chunkFile)
 {
 	CChunkFile::CChunk chunk;
 
@@ -381,7 +381,7 @@ void CChara::CAnimNode::Create(CChunkFile& chunkFile)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CChara::CAnimNode::mapping(CChara::CAnim*)
+inline void CChara::CAnimNode::mapping(CChara::CAnim*)
 {
 }
 


### PR DESCRIPTION
## Summary
- Mark CChara::CAnimNode::Create and mapping as inline because both are documented as PAL UNUSED helpers.
- This prevents the local object from emitting unused helper code/extab entries while keeping the source definitions available.

## Objdiff Evidence
- Unit: main/chara_anim
- Before: extab 92.30769%, extabindex 0.0%, .text 98.50749%
- After: extab 100.0%, extabindex 100.0%, .text 98.50749%

## Plausibility
- Matches the project runbook guidance for UNUSED functions that cause extab regressions.
- No manual vtable/RTTI/section forcing and no runtime behavior change for PAL, where these helpers are unused.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/chara_anim -o - Create__Q26CChara5CAnimFPvPQ27CMemory6CStage