### PR TITLE
Improve cflat map bounds checks

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -425,7 +425,7 @@ void CMapPcs::CalcHitPosition(Vec* hitPosition)
  */
 int CMapPcs::CheckHitCylinderNear(Vec* cylinderBottom, Vec* direction, float radius, unsigned long hitMask)
 {
-    CMapCylinder cylinder;
+    CMapCylinder cylinder(kMapHitBoundsMinInit, kMapHitBoundsMaxInit);
 
     cylinder.m_bottom = *cylinderBottom;
     cylinder.m_axis = *direction;
@@ -1815,14 +1815,12 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
 
 int CLine<64>::IsInner(Vec* position, float margin)
 {
-    if (pointCount == 0) {
-        return 0;
-    }
-
-    if ((min.x - margin) <= position->x && (min.y - margin) <= position->y &&
-        (min.z - margin) <= position->z && (max.x + margin) >= position->x &&
-        (max.y + margin) >= position->y && (max.z + margin) >= position->z) {
-        return 1;
+    if (pointCount != 0) {
+        if ((min.x - margin) <= position->x && (min.y - margin) <= position->y &&
+            (min.z - margin) <= position->z && (max.x + margin) >= position->x &&
+            (max.y + margin) >= position->y && (max.z + margin) >= position->z) {
+            return 1;
+        }
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- Use the existing CMapCylinder bounds constructor in CMapPcs::CheckHitCylinderNear so the local cylinder setup better matches the target code shape.
- Restructure CLine<64>::IsInner around the nonzero point-count path, matching the target branch layout.

## Objdiff Evidence
- CheckHitCylinderNear__7CMapPcsFP3VecP3VecfUl: 98.4375% -> 99.6875% (128 bytes)
- IsInner__9CLine<64>FP3Vecf: 94.75% -> 100.0% (160 bytes)
- Build progress: matched code 637884 -> 638044 bytes; matched functions 3562 -> 3563

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - CheckHitCylinderNear__7CMapPcsFP3VecP3VecfUl
- build/tools/objdiff-cli diff -p . -u main/cflat_r2system -o - 'IsInner__9CLine<64>FP3Vecf'

## Plausibility
- The cylinder change uses the existing map-hit bounds constants and constructor rather than duplicating raw float setup.
- The IsInner change preserves behavior while matching the original branch structure more closely.
