### PR TITLE
Match pppYmMiasma constant pool

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -14,22 +14,17 @@
 #include <string.h>
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdlib.h>
 
-static const float FLOAT_80330640 = 0.01745329238474369f;
-static const float FLOAT_80330644 = 0.0f;
-static const double DOUBLE_80330648 = 4503601774854144.0;
-static const float FLOAT_80330650 = 32768.0f;
-static const float FLOAT_80330654 = 3.1415927410125732f;
-static const float FLOAT_80330658 = 1.0f;
-static const float FLOAT_8033065c = 0.00003051850947599719f;
-static const float FLOAT_80330660 = 2.0f;
-static const float FLOAT_80330664 = 16384.0f;
-static const float FLOAT_80330668 = -1.0f;
+#define FLOAT_80330640 0.01745329238474369f
+#define FLOAT_80330644 0.0f
+#define DOUBLE_80330648 4503601774854144.0
+#define FLOAT_80330650 32768.0f
+#define FLOAT_80330654 3.1415927410125732f
+#define FLOAT_80330658 1.0f
+#define FLOAT_8033065c 0.00003051850947599719f
+#define FLOAT_80330660 2.0f
+#define FLOAT_80330664 16384.0f
+#define FLOAT_80330668 -1.0f
 static const char s_pppYmMiasma_cpp[] = "pppYmMiasma.cpp";
-
-static inline float YmMiasmaConst(const float& value)
-{
-    return *reinterpret_cast<const float*>(&value);
-}
 
 struct PARTICLE_DATA {
     Mtx m_matrix;
@@ -113,7 +108,6 @@ void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaRenderStep* step, _ppp
             GXColor amb;
             float scale;
             s16 shapeAngle;
-            const float& degToRad = FLOAT_80330640;
 
             pppUnitMatrix(model);
             scale = state->m_speed;
@@ -122,7 +116,7 @@ void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaRenderStep* step, _ppp
             model.value[2][2] = ppvMng->m_scale.z * scale;
 
             shapeAngle = state->m_shapeAngle;
-            PSMTXRotRad(rotMatrix.value, 'z', degToRad * (float)shapeAngle);
+            PSMTXRotRad(rotMatrix.value, 'z', FLOAT_80330640 * (float)shapeAngle);
             pppMulMatrix(model, rotMatrix, model);
 
             pppCopyVector(worldPos, state->m_position);
@@ -286,9 +280,9 @@ void pppDestructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(pppYmMiasma_, param_2, 2);
-    float fVar1 = YmMiasmaConst(FLOAT_80330644);
+    float fVar1 = FLOAT_80330644;
 
-    work->m_radius = YmMiasmaConst(FLOAT_80330644);
+    work->m_radius = FLOAT_80330644;
     work->m_radiusVelocity = fVar1;
     work->m_radiusAcceleration = fVar1;
 }
@@ -305,8 +299,8 @@ void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(pppYmMiasma_, param_2, 2);
-    const float& fVar2 = FLOAT_80330644;
-    const float& fVar1 = FLOAT_80330658;
+    float fVar2 = FLOAT_80330644;
+    float fVar1 = FLOAT_80330658;
 
     work->m_particles = 0;
     work->m_radius = fVar2;
@@ -538,14 +532,12 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     (void)pppPObject;
 
     randomValue = rand();
-    randomScale = YmMiasmaConst(FLOAT_8033065c) * (float)randomValue;
+    randomScale = FLOAT_8033065c * (float)randomValue;
     shape = static_cast<pppShapeAnimData*>(
         ppvEnv->m_resourceTables.m_shapeTablePtr[pYmMiasma->m_dataValIndex]->m_animData);
     shapeRandom = rand();
     shapeCount = shape->m_frameCount;
-    angle = (s32)(YmMiasmaConst(FLOAT_80330650) *
-                  (YmMiasmaConst(FLOAT_80330654) * (YmMiasmaConst(FLOAT_80330660) * randomScale)) -
-                  YmMiasmaConst(FLOAT_80330664));
+    angle = (s32)(FLOAT_80330650 * (FLOAT_80330654 * (FLOAT_80330660 * randomScale)) - FLOAT_80330664);
     shapeCount = (short)(shapeRandom % shapeCount);
     state->m_shapeDrawFrame = shapeCount;
     state->m_shapeCurrentFrame = shapeCount;
@@ -594,7 +586,7 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     angleBase = (u32)(int)speedJitter;
     signBit = angleBase >> 0x1f;
     if ((((angleBase & 1U) ^ signBit) - signBit) != 0) {
-        speedJitter = speedJitter * YmMiasmaConst(FLOAT_80330668);
+        speedJitter = speedJitter * FLOAT_80330668;
     }
     state->m_speed = pYmMiasma->m_baseSpeed + speedJitter;
     state->m_fadeFrames = (u16)pYmMiasma->m_fadeFrames;


### PR DESCRIPTION
## Summary
- Replace emitted static float/double objects in src/pppYmMiasma.cpp with source literals so MWCC builds the target constant pool.
- Remove the YmMiasmaConst helper and literal-bound references that created duplicate .sdata2 objects.
- Improve pppYmMiasma code and data matches without section forcing or address hacks.

## Objdiff Evidence
Command: build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o - pppFrameYmMiasma

Before:
- .text: 99.78781%, size 3544 / 3544
- .sdata2: 84.61539%, target 44 bytes, compiled 60 bytes
- pppConstruct2YmMiasma: 99.44444%
- pppConstructYmMiasma: 99.5%
- pppFrameYmMiasma: 99.7754%
- InitParticleData: 99.770645%

After:
- .text: 99.861176%, size 3544 / 3544
- .sdata2: 100.0%, target 44 bytes, compiled 44 bytes
- pppConstruct2YmMiasma: 100.0%
- pppConstructYmMiasma: 100.0%
- pppFrameYmMiasma: 99.82888%
- InitParticleData: 99.95413%

## Validation
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o - pppFrameYmMiasma

## Plausibility
config/GCCP01/splits.txt assigns pppYmMiasma.cpp .sdata2 as 0x80330640..0x8033066C, which is 44 bytes. Letting MWCC emit the literals directly removes the duplicate named constants and matches that layout.