### PR TITLE
Improve FunnyShape default offset matching

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -21,8 +21,8 @@ static const float kFunnyShapeTexCoordDivisor = 4096.0f;
 static const float kFunnyShapePaddingScale = 0.5f;
 extern const float kFunnyShapeNegativeOne;
 static const float FLOAT_8032fd84 = 0.0f;
-static const float kFunnyShapeDefaultOffsetX = 480.0f;
-static const float kFunnyShapeDefaultOffsetY = 336.0f;
+extern const float kFunnyShapeDefaultOffsetX = 480.0f;
+extern const float kFunnyShapeDefaultOffsetY = 336.0f;
 extern const float kFunnyShapeTextureViewportOrigin = 20.0f;
 static const float kFunnyShapeAnimOffsetX = 320.0f;
 static const float kFunnyShapeAnimOffsetY = 224.0f;
@@ -463,8 +463,8 @@ void CFunnyShape::RenderShape()
     GXSetChanMatColor(GX_COLOR0, color);
 
     Vec2d offsetCopy;
-    offsetCopy.x = LoadFloat(kFunnyShapeDefaultOffsetX);
-    offsetCopy.y = LoadFloat(kFunnyShapeDefaultOffsetY);
+    offsetCopy.x = kFunnyShapeDefaultOffsetX;
+    offsetCopy.y = kFunnyShapeDefaultOffsetY;
     FS_tagOAN3_SHAPE* shape = reinterpret_cast<FS_tagOAN3_SHAPE*>(m_meshData);
     RenderShape(shape, offsetCopy, LoadFloat(kFunnyShapeZero));
 }


### PR DESCRIPTION
## Summary
- Give the default FunnyShape render offsets external constant linkage like the surrounding named constants.
- Load the default offsets directly in CFunnyShape::RenderShape so objdiff aligns the sdata2 references.

## Evidence
- Built with ninja.
- main/FunnyShape RenderShape__11CFunnyShapeFv improved from 99.909676% to 99.97419% in objdiff.
- The default offset constants now resolve as matched 4-byte sdata2 symbols in the focused objdiff output.

## Plausibility
- The offsets are named constants used as the default render position, matching the existing style for nearby FunnyShape constants.
- This avoids wrapper-induced anonymous constant references without changing behavior.