### PR TITLE
Match MaterialEditor destroyViewer loop

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -525,15 +525,17 @@ void CMaterialEditorPcs::destroyViewer()
     MemFree(reinterpret_cast<void*>(m_rsdIndex));
 
     unsigned int textureIndex;
+    CMaterialEditorPcs* textureSlot = this;
     m_loadedTextureCount = static_cast<s8>(textureIndex = 0);
     do {
-        MemFree(m_textureData[textureIndex]);
-        MemFree(m_tlutData[textureIndex]);
-        MemFree(m_texObj[textureIndex]);
-        MemFree(m_tlutObj0[textureIndex]);
-        MemFree(m_tlutObj1[textureIndex]);
-        MemFree(m_textureHeader[textureIndex]);
+        MemFree(textureSlot->m_textureData[0]);
+        MemFree(textureSlot->m_tlutData[0]);
+        MemFree(textureSlot->m_texObj[0]);
+        MemFree(textureSlot->m_tlutObj0[0]);
+        MemFree(textureSlot->m_tlutObj1[0]);
+        MemFree(textureSlot->m_textureHeader[0]);
         textureIndex += 1;
+        textureSlot = reinterpret_cast<CMaterialEditorPcs*>(reinterpret_cast<char*>(textureSlot) + sizeof(void*));
     } while (textureIndex < 0x10);
 
     Memory.DestroyStage(m_stage);


### PR DESCRIPTION
## Summary
- Updates CMaterialEditorPcs::destroyViewer to walk texture slots with a pointer, matching the existing Quit cleanup pattern and Ghidra shape.
- Keeps the cleanup order unchanged while making the generated loop match the target.

## Objdiff Evidence
- destroyViewer__18CMaterialEditorPcsFv: 98.888885% -> 100.0%
- main/p_MaterialEditor .text: 84.12128% -> 84.17336%

## Plausibility
- The pointer-walk form is already used by CMaterialEditorPcs::Quit for the same texture-slot arrays.
- No manual section forcing, address hacks, or fake symbols were added.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o /tmp/pme_destroy_pr.json destroyViewer__18CMaterialEditorPcsFv