### PR TITLE
Improve mesmenu and cflat_runtime2 matching

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -102,7 +102,7 @@ static inline void InitFlatObjectSlot(CGBaseObj* object, u16 particleId)
 	object->m_particleId = particleId;
 }
 
-static CGBaseObj* FindNextGBaseObjByCidMask(CFlatRuntime2* runtime, CFlatRuntime::CObject* object, unsigned int cidMask)
+static inline CGBaseObj* FindNextGBaseObjByCidMask(CFlatRuntime2* runtime, CFlatRuntime::CObject* object, unsigned int cidMask)
 {
 	CFlatRuntime::CObject* const root =
 		reinterpret_cast<CFlatRuntime::CObject*>(reinterpret_cast<u8*>(runtime) + 0x8CC);

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -539,10 +539,9 @@ void CMesMenu::onDraw()
         if (stateBlend > FLOAT_803308d8) {
             float width = *(float*)((char*)this + 0x3D7C) * stateBlend;
             float height = *(float*)((char*)this + 0x3D80) * stateBlend;
-            float drawX = baseX;
-            if ((menuIndex & 1) == 0) {
-                drawX -= *(float*)((char*)this + 0x3D7C) - width;
-            }
+            float drawX = baseX + (((menuIndex & 1) == 0)
+                ? (*(float*)((char*)this + 0x3D7C) - width)
+                : -*(float*)((char*)this + 0x3D7C));
 
             float edgeY = FLOAT_803308f8;
             if ((menuIndex & 2) != 0) {


### PR DESCRIPTION
## Summary
- Fix `CMesMenu::onDraw` battle-window X anchoring to match the decompiled target shape for left/right menu positioning.
- Mark `FindNextGBaseObjByCidMask` inline so it no longer emits as an extra standalone helper in `cflat_runtime2`.

## Evidence
- `main/mesmenu` `onDraw__8CMesMenuFv`: 57.19342% -> 57.90263%; current size 5828 -> 5832 bytes. `DrawHeart__8CMesMenuFffff` remains 86.53712% with no size change.
- `main/cflat_runtime2`: extra emitted `FindNextGBaseObjByCidMask__FP13CFlatRuntime2PQ212CFlatRuntime7CObjectUi` helper removed from the rebuilt object.
- `main/cflat_runtime2` `.text`: current size 20860 -> 20684 bytes while the main target function scores remain unchanged.

## Plausibility
- The mesmenu expression matches the Ghidra/original arithmetic: compute the X offset from full width and blended width, then add it to `baseX` for both menu sides.
- The cflat helper is used as an internal scan helper and Ghidra shows the scans inline in callers; marking it inline avoids an emitted unused helper without changing source behavior.

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/mesmenu -o - onDraw__8CMesMenuFv`
- `build/tools/objdiff-cli diff -p . -u main/cflat_runtime2 -o - Draw__13CFlatRuntime2Fv`
