### PR TITLE
Match pppYmMiasma constant data

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -14,21 +14,20 @@
 #include <string.h>
 #include <PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/stdlib.h>
 
-static const float FLOAT_80330640 = 0.01745329238474369f;
-static const float FLOAT_80330644 = 0.0f;
-static const double DOUBLE_80330648 = 4503601774854144.0;
-static const float FLOAT_80330650 = 32768.0f;
-static const float FLOAT_80330654 = 3.1415927410125732f;
-static const float FLOAT_80330658 = 1.0f;
-static const float FLOAT_8033065c = 0.00003051850947599719f;
-static const float FLOAT_80330660 = 2.0f;
-static const float FLOAT_80330664 = 16384.0f;
-static const float FLOAT_80330668 = -1.0f;
+#define FLOAT_80330640 0.01745329238474369f
+#define FLOAT_80330644 0.0f
+#define FLOAT_80330650 32768.0f
+#define FLOAT_80330654 3.1415927410125732f
+#define FLOAT_80330658 1.0f
+#define FLOAT_8033065c 0.00003051850947599719f
+#define FLOAT_80330660 2.0f
+#define FLOAT_80330664 16384.0f
+#define FLOAT_80330668 -1.0f
 static const char s_pppYmMiasma_cpp[] = "pppYmMiasma.cpp";
 
-static inline float YmMiasmaConst(const float& value)
+static inline float YmMiasmaConst(float value)
 {
-    return *reinterpret_cast<const float*>(&value);
+    return value;
 }
 
 struct PARTICLE_DATA {
@@ -113,7 +112,7 @@ void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaRenderStep* step, _ppp
             GXColor amb;
             float scale;
             s16 shapeAngle;
-            const float& degToRad = FLOAT_80330640;
+            float degToRad = FLOAT_80330640;
 
             pppUnitMatrix(model);
             scale = state->m_speed;
@@ -305,8 +304,8 @@ void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(pppYmMiasma_, param_2, 2);
-    const float& fVar2 = FLOAT_80330644;
-    const float& fVar1 = FLOAT_80330658;
+    float fVar2 = FLOAT_80330644;
+    float fVar1 = FLOAT_80330658;
 
     work->m_particles = 0;
     work->m_radius = fVar2;


### PR DESCRIPTION
## Summary
- stop emitting named FLOAT_803306xx objects in pppYmMiasma so the unit uses the anonymous local constants shown in symbols.txt
- keep the constructor zero/one setup as plain float locals so codegen stays aligned
- this makes pppYmMiasma .sdata2 exact and matches both constructor functions

## Evidence
- ninja passes
- pppYmMiasma section diff after change:
  - .text: 3544 bytes, 99.849884% match
  - .rodata: 16 bytes, 100.0% match
  - .sdata2: 44 bytes, 100.0% match
- symbol scores after change:
  - pppConstruct2YmMiasma: 100.0%
  - pppConstructYmMiasma: 100.0%
  - UpdateParticleData__FP11_pppPObjectP13_pppCtrlTableP9PYmMiasmaP13PARTICLE_DATA: 100.0%
  - pppDestructYmMiasma: 100.0%
  - pppFrameYmMiasma: 99.82888%
  - InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA: 99.90826%

## Plausibility
symbols.txt attributes the PAL .sdata2 range for pppYmMiasma to anonymous local constants (@983, @984, @986, @1023, @1024, @1036, @1115-@1118), not named FLOAT_ globals. Using literal constants lets Metrowerks emit that local constant pool while preserving the existing source behavior.