### PR TITLE
Improve CPad Frame GBA connection match

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -116,7 +116,7 @@ void CPad::Frame()
 		CPad::Gba* gba = &local_98[uVar17];
 		iVar6 = SIProbe(uVar17);
 		int padIndex = uVar17;
-		gba->connected = (0x40000 - iVar6) == 0;
+		gba->connected = static_cast<unsigned char>(static_cast<unsigned int>(__cntlzw(0x40000 - iVar6)) >> 5);
 		gba->ctrlMode = Joybus.GetCtrlMode(uVar17);
 		gba->noController = gba->connected && (gba->ctrlMode == 0);
 		gba->button = 0;


### PR DESCRIPTION
## Summary
- Express the GBA connection flag in `CPad::Frame` using the `__cntlzw(...) >> 5` boolean idiom seen in the target code.
- Keeps the existing `CPad::Gba` bitfield layout and normal compiler-generated bitfield store.

## Objdiff Evidence
`build/tools/objdiff-cli diff -p . -u main/pad -o - Frame__4CPadFv`

Before:
- `.text`: 3392 bytes, 93.9434%
- `extab`: 100.0%
- `extabindex`: 97.22222%

After:
- `.text`: 3392 bytes, 94.85495%
- `extab`: 100.0%
- `extabindex`: 97.22222%

No data, sdata, sdata2, extab, or extabindex regression in the function diff.

## Verification
- `ninja`
