### PR TITLE
Improve dbgmenu calc flag scheduling

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -228,9 +228,9 @@ void CDbgMenuPcs::calc()
 			CFlatEventMask() = ~CFlatEventMask();
 			break;
 		case 0x65:
+			unsigned char gameFlags = CFlatGameFlags();
 			stackData[0].m_word = 0;
 			stackData[2].m_word = 0;
-			unsigned char gameFlags = CFlatGameFlags();
 			flags = (unsigned int)__cntlzw((int)(s8)((s32)(((u32)gameFlags << 0x18) & 0xC0000000) >> 0x1f));
 			gameFlags = ((int)(char)(flags >> 5) & 1U) << 7 | (gameFlags & ~CFlatGameFlag_Shouki);
 			CFlatGameFlags() = gameFlags;


### PR DESCRIPTION
## Summary
- Reordered the CFlat game flag read in `CDbgMenuPcs::calc()` case 0x65 to better match the target instruction schedule.
- Keeps the existing behavior while improving the generated code for `main/p_dbgmenu`.

## Objdiff evidence
- `calc__11CDbgMenuPcsFv`: 95.171326% -> 97.828674%
- `main/p_dbgmenu` `.text`: 98.21232% -> 98.62291%
- `extabindex`: 98.71795% -> 98.07692% (small tradeoff from the altered function shape)

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o - calc__11CDbgMenuPcsFv`
- `build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o -`
