### PR TITLE
Improve mapshadow constant layout

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -10,12 +10,12 @@
 #include "ffcc/vector.h"
 #include <dolphin/mtx.h>
 
-extern const double kMapShadowDepthBias = 0.5;
+extern const double kMapShadowDepthBias;
 static const float kMapShadowScaleStep = 0.5f;
 static const double DOUBLE_8032FCF8 = 4503599627370496.0;
-extern const float FLOAT_8032FD00 = 0.0f;
-extern const float FLOAT_8032FD04 = 1.0f;
-extern const double DOUBLE_8032FD08 = 4503601774854144.0;
+extern const float FLOAT_8032FD00;
+extern const float FLOAT_8032FD04;
+extern const double DOUBLE_8032FD08;
 
 static inline float LoadFloat(const float& value)
 {
@@ -133,3 +133,7 @@ void CMapShadow::Init()
 		                (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	}
 }
+
+extern const float FLOAT_8032FD00 = 0.0f;
+extern const float FLOAT_8032FD04 = 1.0f;
+extern const double DOUBLE_8032FD08 = 4503601774854144.0;


### PR DESCRIPTION
## Summary
- Treat kMapShadowDepthBias as an external constant instead of defining it in mapshadow.cpp, matching the split layout where it lives before this unit.
- Move the FLOAT_8032FD00, FLOAT_8032FD04, and DOUBLE_8032FD08 definitions after the functions so mapshadow local constants are emitted before exported constants.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- Build progress improves from 3560 to 3561 matched functions and code bytes from 637672 to 637756.
- main/mapshadow .text: 99.62567% -> 99.70588%.
- Init__10CMapShadowFv: 99.57627% -> 99.830505%.
- Draw__10CMapShadowFv remains 100%; Calc__10CMapShadowFv remains 99.52381%.

## Plausibility
- This removes a wrong-owner constant definition from mapshadow.cpp and leaves the shared depth bias as an external symbol, consistent with config/GCCP01/splits.txt placing it before the mapshadow .sdata2 range.
- The exported mapshadow constants remain real definitions in the same translation unit, just after the functions so the emitted constant order better matches the original object.