### PR TITLE
Match pppChangeTex cached value data

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -50,7 +50,7 @@ STATIC_ASSERT(offsetof(ChangeTexWork, m_bboxMax) == 0x38);
 STATIC_ASSERT(offsetof(ChangeTexWork, m_cachedValue) == 0x44);
 STATIC_ASSERT(sizeof(ChangeTexDisplayListCopy) == 0x8);
 
-static const float kPppChangeTexCachedValueInit = -10000.0f;
+extern const float kPppChangeTexCachedValueInit = -10000.0f;
 static const char sPppChangeTexMeshObjectName[] = "obj";
 static const float kPppChangeTexAlphaScale = 255.0f;
 static const char s_pppChangeTex_cpp[] = "pppChangeTex.cpp";


### PR DESCRIPTION
Summary:
- Give kPppChangeTexCachedValueInit external linkage so it emits before the local mesh object name, matching the target .sdata2 layout.
- This brings pppChangeTex .sdata2 from 87.5% to 100% and slightly improves pppFrameChangeTex.

Evidence:
- ninja passes.
- build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o - pppFrameChangeTex
- pppFrameChangeTex: 98.619194% -> 98.650154%
- [.sdata2-0]: 87.5% -> 100.0%
- Aggregate report data: 922788 -> 922820 bytes matched (+32).

Plausibility:
- The target layout places -10000.0f before the "obj" mesh-name string and 255.0f. Giving the cached-value constant real linkage restores that emitted order without changing code size or behavior.