### PR TITLE
Improve pppYmMiasma constant pooling

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -286,9 +286,9 @@ void pppDestructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(pppYmMiasma_, param_2, 2);
-    float fVar1 = YmMiasmaConst(FLOAT_80330644);
+    float fVar1 = 0.0f;
 
-    work->m_radius = YmMiasmaConst(FLOAT_80330644);
+    work->m_radius = 0.0f;
     work->m_radiusVelocity = fVar1;
     work->m_radiusAcceleration = fVar1;
 }
@@ -305,8 +305,8 @@ void pppConstruct2YmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
 {
     VYmMiasma* work = PppWorkArea<VYmMiasma>(pppYmMiasma_, param_2, 2);
-    const float& fVar2 = FLOAT_80330644;
-    const float& fVar1 = FLOAT_80330658;
+    const float fVar2 = 0.0f;
+    const float fVar1 = 1.0f;
 
     work->m_particles = 0;
     work->m_radius = fVar2;
@@ -538,14 +538,12 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     (void)pppPObject;
 
     randomValue = rand();
-    randomScale = YmMiasmaConst(FLOAT_8033065c) * (float)randomValue;
+    randomScale = 0.00003051850947599719f * (float)randomValue;
     shape = static_cast<pppShapeAnimData*>(
         ppvEnv->m_resourceTables.m_shapeTablePtr[pYmMiasma->m_dataValIndex]->m_animData);
     shapeRandom = rand();
     shapeCount = shape->m_frameCount;
-    angle = (s32)(YmMiasmaConst(FLOAT_80330650) *
-                  (YmMiasmaConst(FLOAT_80330654) * (YmMiasmaConst(FLOAT_80330660) * randomScale)) -
-                  YmMiasmaConst(FLOAT_80330664));
+    angle = (s32)(32768.0f * (3.1415927410125732f * (2.0f * randomScale)) - 16384.0f);
     shapeCount = (short)(shapeRandom % shapeCount);
     state->m_shapeDrawFrame = shapeCount;
     state->m_shapeCurrentFrame = shapeCount;
@@ -594,7 +592,7 @@ void InitParticleData(VYmMiasma* vYmMiasma, _pppPObject* pppPObject, PYmMiasma* 
     angleBase = (u32)(int)speedJitter;
     signBit = angleBase >> 0x1f;
     if ((((angleBase & 1U) ^ signBit) - signBit) != 0) {
-        speedJitter = speedJitter * YmMiasmaConst(FLOAT_80330668);
+        speedJitter = speedJitter * -1.0f;
     }
     state->m_speed = pYmMiasma->m_baseSpeed + speedJitter;
     state->m_fadeFrames = (u16)pYmMiasma->m_fadeFrames;


### PR DESCRIPTION
## Summary
- Use ordinary float literals in pppConstruct2YmMiasma, pppConstructYmMiasma, and InitParticleData where the target object uses pooled anonymous constants.
- Removes extra named-constant relocations in the generated object while preserving behavior.

## Objdiff evidence
Before this branch:
- main/pppYmMiasma .text: 99.78781%
- main/pppYmMiasma .sdata2: 84.61539%
- pppConstruct2YmMiasma: 99.44444%
- pppConstructYmMiasma: 99.5%
- InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA: 99.770645%

After:
- main/pppYmMiasma .text: 99.816025%
- main/pppYmMiasma .sdata2: 100.0%
- pppConstruct2YmMiasma: 100.0%
- pppConstructYmMiasma: 99.75%
- InitParticleData__FP9VYmMiasmaP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA: 99.83945%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o -
