### PR TITLE
Match pppYmDeformationMdl zero constant

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -41,7 +41,6 @@ static inline _pppEnvStYmDeformationMdl* DeformationMdlEnv()
     return reinterpret_cast<_pppEnvStYmDeformationMdl*>(ppvEnv);
 }
 
-static const float kYmDeformationMdlZero = 0.0f;
 extern const float kYmDeformationMdlScreenWidth;
 extern const float kYmDeformationMdlScreenHeight;
 extern const float kYmDeformationMdlTexOffset;
@@ -60,7 +59,7 @@ static inline Mtx44& CameraScreenMatrix()
 
 static inline float DeformationMdlZero()
 {
-    return *reinterpret_cast<const float*>(&kYmDeformationMdlZero);
+    return 0.0f;
 }
 
 /*
@@ -336,7 +335,7 @@ void pppDestructYmDeformationMdl(pppYmDeformationMdl*, _pppCtrlTable*)
  */
 void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, _pppCtrlTable* param_2)
 {
-    const float& value = kYmDeformationMdlZero;
+    float value = DeformationMdlZero();
     YmDeformationMdlState* state = PppWorkArea<YmDeformationMdlState>(pppYmDeformationMdl_, param_2, 2);
 
     state->m_values[1] = value;
@@ -358,7 +357,7 @@ void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, _p
  */
 void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, _pppCtrlTable* param_2)
 {
-    const float& zero = kYmDeformationMdlZero;
+    float zero = DeformationMdlZero();
     YmDeformationMdlState* state = PppWorkArea<YmDeformationMdlState>(pppYmDeformationMdl_, param_2, 2);
 
     state->m_angle = 0;


### PR DESCRIPTION
## Summary
- Remove the named local zero constant in `pppYmDeformationMdl.cpp` so MWCC emits the anonymous zero constant used by the target.
- Keep constructor zero initialization through the local helper, matching the plausible source intent without manual section or symbol hacks.

## Evidence
- `ninja` succeeds.
- `main/pppYmDeformationMdl` data is now fully matched in the generated report: `.sdata2` is 100.0% and unit data is 60/60 bytes matched.
- `pppConstruct2YmDeformationMdl`, `pppConstructYmDeformationMdl`, `pppFrameYmDeformationMdl`, and `pppDestructYmDeformationMdl` remain 100.0% matched.
- `pppRenderYmDeformationMdl` reports 99.523125% in the current report.

## Plausibility
The target uses an anonymous zero in `.sdata2` for this unit rather than a named local `kYmDeformationMdlZero`. Returning `0.0f` from the existing helper lets the compiler emit that constant naturally and removes the unnecessary named definition.