### PR TITLE
Improve menu list cursor draw conversion

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -136,7 +136,8 @@ void CMenuPcs::MLstDraw()
 	DrawInit();
 	if (menuMode == 1) {
 		MenuLstEntry* curItem = &this->lstData->entries[this->lstState->cursor];
-		int cursorY = (int)((double)curItem->y + (double)(curItem->height - 0x20) * 0.5);
+		float cursorYF = (float)((double)(curItem->height - 0x20) * DOUBLE_803333E8 + (double)curItem->y);
+		int cursorY = (int)cursorYF;
 		int cursorX = (int)((float)(curItem->x - 0x38) + (float)((int)System.m_frameCounter % 8));
 		DrawCursor(cursorX, cursorY, FLOAT_803333F0);
 	}


### PR DESCRIPTION
## Summary
- Route the menu-list cursor Y calculation through a float temporary before integer conversion.
- This matches the target float rounding path more closely in MLstDraw.

## Evidence
- ninja passes.
- MLstDraw__8CMenuPcsFv: 87.8273% -> 91.119774% match.
- main/menu_lst .text: 92.8% selector baseline -> 94.10817% current.

## Plausibility
The code now preserves the intermediate single-precision value before converting to an integer cursor coordinate, matching the target frsp/conversion shape instead of converting directly from the double expression.