### PR TITLE
Fix mapshadow constant data layout

### DIFF
--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -10,8 +10,7 @@
 #include "ffcc/vector.h"
 #include <dolphin/mtx.h>
 
-extern const double kMapShadowDepthBias = 0.5;
-static const float kMapShadowScaleStep = 0.5f;
+extern const double kMapShadowDepthBias;
 static const double DOUBLE_8032FCF8 = 4503599627370496.0;
 extern const float FLOAT_8032FD00 = 0.0f;
 extern const float FLOAT_8032FD04 = 1.0f;
@@ -122,13 +121,13 @@ void CMapShadow::Init()
 	if (m_useFrustum != 0) {
 		float scale = m_shadowScale;
 		double scaleBias = kMapShadowDepthBias;
-		float scaleStep = LoadFloat(kMapShadowScaleStep);
+		float scaleStep = 0.5f;
 		C_MTXLightFrustum(m_lightMtx, -height, height, -width, width, m_frustumNear,
 		                  (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	} else {
 		float scale = m_shadowScale;
 		double scaleBias = kMapShadowDepthBias;
-		float scaleStep = LoadFloat(kMapShadowScaleStep);
+		float scaleStep = 0.5f;
 		C_MTXLightOrtho(m_lightMtx, -height, height, -width, width,
 		                (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	}


### PR DESCRIPTION
## Summary
- Treat kMapShadowDepthBias as an external constant instead of defining an extra local copy in src/mapshadow.cpp.
- Use an unnamed 0.5f literal for the shadow scale step so the unit no longer emits the extra named kMapShadowScaleStep object.

## Evidence
- ninja passes.
- Init__10CMapShadowFv: 99.57627% -> 99.745766%.
- Init__10CMapShadowFv instruction diffs: 5 -> 3.
- main/mapshadow .sdata2 size: 48 -> 32 bytes, matching the original unit size.
- Overall game data matched increased from 735722 -> 735754 bytes in the build progress output.

## Plausibility
- This removes compiler-emitted duplicate constants and restores the original anonymous/local constant layout seen by objdiff.
- No manual section forcing or address hardcoding; source now relies on normal external linkage and literal constant emission.