### PR TITLE
Fix YmMiasma constant references

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -128,7 +128,7 @@ void pppRenderYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaRenderStep* step, _ppp
             model.value[2][3] = worldPos.z;
 
             pppSetDrawEnv(
-                0, &model, YmMiasmaConst(FLOAT_80330644), step->m_drawEnvB, step->m_drawEnvA, step->m_blendMode, 0, 1, 1, 0);
+                0, &model, FLOAT_80330644, step->m_drawEnvB, step->m_drawEnvA, step->m_blendMode, 0, 1, 1, 0);
 
             amb.r = state->m_color.m_r;
             amb.g = state->m_color.m_g;
@@ -214,12 +214,12 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, _pppCt
         }
 
         angleDelta += step->m_baseAngle;
-        angleScale = (YmMiasmaConst(FLOAT_80330650) * (YmMiasmaConst(FLOAT_80330640) * (float)angleDelta)) /
-                     YmMiasmaConst(FLOAT_80330654);
+        angleScale = (FLOAT_80330650 * (FLOAT_80330640 * (float)angleDelta)) /
+                     FLOAT_80330654;
         angleIdx = (s32)angleScale;
         impulseX = *(float*)((u8*)ppvSinTbl + ((angleIdx + 0x4000) & 0xfffc));
         impulseZ = *(float*)((u8*)ppvSinTbl + (angleIdx & 0xfffc));
-        zero = YmMiasmaConst(FLOAT_80330644);
+        zero = FLOAT_80330644;
         work->m_impulse.x = impulseX;
         work->m_impulse.y = zero;
         work->m_impulse.z = impulseZ;
@@ -238,7 +238,7 @@ void pppFrameYmMiasma(pppYmMiasma* pppYmMiasma_, YmMiasmaFrameStep* step, _pppCt
 
     pppSubVector(delta, matrixPos, work->m_prevPosition);
     distance = PSVECDistance(&matrixPos, &work->m_prevPosition);
-    if (distance != YmMiasmaConst(FLOAT_80330644)) {
+    if (distance != FLOAT_80330644) {
         work->m_prevPositionChanged = 0xff;
     } else {
         work->m_prevPositionChanged = 0;


### PR DESCRIPTION
## Summary
- Replace stale `YmMiasmaConst(...)` references in `pppYmMiasma.cpp` with the actual local float constants.
- Restores successful compilation of `src/pppYmMiasma.cpp` on current `main` without introducing fake helpers or section/linkage hacks.

## Evidence
- Before: `ninja` failed compiling `src/pppYmMiasma.cpp` with undefined identifier `YmMiasmaConst`.
- After: `ninja` completes, `build/GCCP01/main.dol: OK`, and report generation completes.
- Objdiff after fix:
  - `main/pppYmMiasma` text: 99.816025% match, size 3544
  - `pppRenderYmMiasma`: 99.559784% match, size 736
  - `pppFrameYmMiasma`: 99.7754% match, size 748

## Plausibility
- The replacements use existing local constants already declared in the same translation unit and used elsewhere in the file.
- No generated ctor/dtor/vtable hacks, fake labels, address constants, or section forcing were added.