### PR TITLE
Fix pppYmTracer2 source string sizing

### DIFF
--- a/src/pppYmTracer2.cpp
+++ b/src/pppYmTracer2.cpp
@@ -17,7 +17,7 @@ extern f32 gPppDefaultValueBuffer[];
 extern const float FLOAT_80331840;
 extern const float FLOAT_80331844;
 
-static const char s_pppYmTracer2_cpp[24] = "pppYmTracer2.cpp";
+static const char s_pppYmTracer2_cpp[] = "pppYmTracer2.cpp";
 
 struct TRACE_POLYGON {
     Vec pos;


### PR DESCRIPTION
## What changed
- Let `s_pppYmTracer2_cpp` use the compiler-derived array size instead of forcing a 24-byte buffer.
- This removes extra source-level padding from the local file-name string while preserving all code generation.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/pppYmTracer2 -o /tmp/pppYmTracer2_final.json`
- `main/pppYmTracer2` `.rodata`: 82.92683% -> 100.0%.
- `pppRenderYmTracer2`: unchanged at 98.373985%, size 984 bytes.
- `pppFrameYmTracer2` and constructors remain matched.
- Overall build data improved: Game Code data 736793 -> 736817 matched bytes.

## Plausibility
This is a normal C string declaration for the original file-name literal. It removes an artificial fixed array size rather than adding padding or section hacks.
