### PR TITLE
Match pppYmDeformationMdl zero data

### DIFF
--- a/src/pppYmDeformationMdl.cpp
+++ b/src/pppYmDeformationMdl.cpp
@@ -46,6 +46,7 @@ extern const float kYmDeformationMdlScreenHeight;
 extern const float kYmDeformationMdlTexOffset;
 extern const float kYmDeformationMdlTexDepth;
 extern const float kYmDeformationMdlDegToRad;
+static const float kYmDeformationMdlZero = 0.0f;
 
 static inline Mtx& CameraMatrix()
 {
@@ -59,7 +60,7 @@ static inline Mtx44& CameraScreenMatrix()
 
 static inline float DeformationMdlZero()
 {
-    return 0.0f;
+    return kYmDeformationMdlZero;
 }
 
 /*
@@ -304,7 +305,7 @@ void pppDestructYmDeformationMdl(pppYmDeformationMdl*, _pppCtrlTable*)
  */
 void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, _pppCtrlTable* param_2)
 {
-    const float& value = DeformationMdlZero();
+    const float& value = kYmDeformationMdlZero;
     YmDeformationMdlState* state = PppWorkArea<YmDeformationMdlState>(pppYmDeformationMdl_, param_2, 2);
 
     state->m_values[1] = value;
@@ -326,7 +327,7 @@ void pppConstruct2YmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, _p
  */
 void pppConstructYmDeformationMdl(pppYmDeformationMdl* pppYmDeformationMdl_, _pppCtrlTable* param_2)
 {
-    const float& zero = DeformationMdlZero();
+    const float& zero = kYmDeformationMdlZero;
     YmDeformationMdlState* state = PppWorkArea<YmDeformationMdlState>(pppYmDeformationMdl_, param_2, 2);
 
     state->m_angle = 0;


### PR DESCRIPTION
## Summary
- Define the local `kYmDeformationMdlZero` constant in `pppYmDeformationMdl.cpp`.
- Bind the two constructor zero references directly to that constant so the unit emits the expected single zero in `.sdata2`.
- Keeps the existing render/code score unchanged while fixing the unit data section.

## Evidence
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmDeformationMdl -o /tmp/deform_mdl_final_diff.json pppRenderYmDeformationMdl`
- Before: `main/pppYmDeformationMdl` data was 40/60 bytes matched (66.67%), `.sdata2` 90.91%.
- After: `main/pppYmDeformationMdl` data is 60/60 bytes matched (100%), `.sdata2` 100%.
- Code remains unchanged at `.text` 99.63496% and `pppRenderYmDeformationMdl` 99.523125%.

## Plausibility
This mirrors the neighboring particle/deformation units that keep frequently reused zero literals as named local float constants, and removes an extra temporary zero emitted from binding a returned literal to `const float&`.