### PR TITLE
Move pad replay strings out of pad.o

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -22,14 +22,10 @@ static const char s_CPad[] = "CPad";
 static const float FLOAT_8032f820 = 0.0f;
 static const float FLOAT_8032f824 = 0.0078125f;
 static const float FLOAT_8032f828 = 255.0f;
-static const char s_pad_cpp[8] = "pad.cpp";
-static const char s_rb[3] = "rb";
-static const char s_replay_dat[12] = "/replay.dat";
-static const char s_replay_host_msg[64] =
-	"CPad.Init: host\202\251\202\347\226\361%d\225\142\202\314"
-	"\203\212\203\166\203\214\203\103\203\146\201\133\203\136"
-	"\202\360\223\307\202\335\215\236\202\335\202\334\202\265"
-	"\202\275\201\102\n";
+extern const char s_pad_cpp[8];
+extern const char s_rb[3];
+extern const char s_replay_dat[12];
+extern const char s_replay_host_msg[64];
 
 extern "C" {
 PADStatus g_pad[4];


### PR DESCRIPTION
## Summary
- Change pad replay/path/debug string declarations to external references instead of defining them in `pad.o`.
- Lets `pad.o` use the existing split data ownership for `s_pad_cpp`, `s_rb`, `s_replay_dat`, and `s_replay_host_msg`.

## Evidence
- `ninja` passes.
- `main/pad` `.sdata2`: 77.41935% -> 94.117645%.
- `main/pad` `.text`: 94.784195% -> 94.81957%.
- `Frame__4CPadFv`: 93.83544% -> 93.87764%.

## Plausibility
PAL objdiff shows these replay strings are not owned by `pad.o`; keeping them as external references removes duplicate local data and restores the float/double constant layout in `.sdata2`.