### PR TITLE
Fix pppYmLaser sdata2 ownership

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -16,9 +16,9 @@
 
 #include <string.h>
 
-static const f32 kPppYmLaserOne = 0.0f;
-static const f32 FLOAT_80330DC4 = 1.0f;
-static const f32 FLOAT_80330DC8 = 2.0f;
+extern const f32 kPppYmLaserOne;
+extern const f32 FLOAT_80330DC4;
+extern const f32 FLOAT_80330DC8;
 
 static inline float YmLaserConst(const float& value) { return *reinterpret_cast<const float*>(&value); }
 
@@ -312,7 +312,7 @@ static const f32 FLOAT_80330df0[2] = {6.2831855f, 0.0f};
 extern const f32 FLOAT_80330df8 = 2.0f;
 extern const f32 FLOAT_80330dfc = 0.5f;
 extern const f32 FLOAT_80330e00 = 0.25f;
-static const f64 DOUBLE_80330E08 = 4503601774854144.0;
+extern const f64 DOUBLE_80330E08 = 4503601774854144.0;
 
 /*
  * --INFO--


### PR DESCRIPTION
## Summary
- Treat the shared zero/one/two laser constants as external data instead of local pppYmLaser definitions.
- Give DOUBLE_80330E08 external linkage so the data symbol matches the PAL split.

## Evidence
- ninja passes.
- pppYmLaser .sdata2 improves from 84.61539% to 100.0% in objdiff.
- Project progress data matched bytes improved from 923443 to 923499 (+56 bytes); game data improved from 736377 to 736433 (+56 bytes).
- Code scores are preserved: pppRenderYmLaser 97.98803%, pppFrameYmLaser 98.85321%.

## Plausibility
PAL split asm references kPppYmLaserOne/FLOAT_80330DC4/FLOAT_80330DC8 from the adjacent auto .sdata2 block, not from pppYmLaser.cpp. PAL also has a named DOUBLE_80330E08 object in this unit, so external linkage better reflects the original data layout.