### PR TITLE
Inline unused YmMiasma render helper

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -64,7 +64,7 @@ struct YmMiasmaRenderParticleState {
 
 void InitParticleData(VYmMiasma*, _pppPObject*, PYmMiasma*, PARTICLE_DATA*);
 void UpdateParticleData(_pppPObject*, _pppCtrlTable*, PYmMiasma*, PARTICLE_DATA*);
-void RenderParticle(_pppPObject*, PYmMiasma*, PARTICLE_DATA*);
+inline void RenderParticle(_pppPObject*, PYmMiasma*, PARTICLE_DATA*);
 
 template <typename T>
 static inline T* PppWorkArea(_pppPObject* object, _pppCtrlTable* ctrl, int index)
@@ -315,7 +315,7 @@ void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
+inline void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
 {
     YmMiasmaRenderParticleState* state = (YmMiasmaRenderParticleState*)particleData;
     YmMiasmaRenderStep* step = (YmMiasmaRenderStep*)pYmMiasma;


### PR DESCRIPTION
## Summary
- Mark `RenderParticle` in `pppYmMiasma.cpp` as `inline`, matching its `PAL Address: UNUSED` annotation.
- Prevents the unused helper from being emitted into `main/pppYmMiasma` while keeping the recovered source available.

## Objdiff Evidence
Before:
- `main/pppYmMiasma` compiled `.text`: 4200 bytes vs target 3544 bytes
- extra compiled symbol: `RenderParticle__FP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA` (656 bytes)

After:
- `main/pppYmMiasma` compiled `.text`: 3544 bytes vs target 3544 bytes
- `RenderParticle__FP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA` is no longer emitted
- existing matched functions remain stable: `pppDestructYmMiasma`, `pppConstruct2YmMiasma`, `pppConstructYmMiasma`, `UpdateParticleData`, and `InitParticleData` are still 100% matched

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppYmMiasma -o /tmp/pppYmMiasma_final.json`
