### PR TITLE
Improve AStar escape position match

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -264,8 +264,8 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 					}
 					else if (behindBestDist < dist)
 					{
-						behindBest = &m_portals[i];
 						behindBestDist = dist;
+						behindBest = &m_portals[i];
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Reordered the behind-portal best-distance update in `CAStar::getEscapePos` to match the target instruction order.
- Keeps the algorithm unchanged while making the source closer to the observed PAL codegen.

## Evidence
- `getEscapePos__6CAStarFR3VecR3Vecii`: 95.15069% -> 96.45206%
- `main/astar` `.text`: 95.97766% -> 96.08649%
- `drawAStar__6CAStarFv` unchanged at 94.79429%
- `check__6CAStarFiiRQ26CAStar6CATemp` unchanged at 91.1446%

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/astar -o -`

## Plausibility
- This is a source-order-only change in an ordinary conditional update: the best distance is stored before the corresponding pointer, matching Ghidra/objdiff output without adding casts, address hacks, section forcing, or generated metadata.