### PR TITLE
Improve prgobj target rotation matching

### DIFF
--- a/src/prgobj.cpp
+++ b/src/prgobj.cpp
@@ -221,6 +221,7 @@ void CGPrgObj::ClassControl(int classControl, int value)
 void CGPrgObj::dstTargetRot(CGPrgObj* target)
 {
 	float targetRot;
+	float zero;
 	float deltaX;
 	float deltaZ;
 	CVector targetPos(target->m_worldPosition);
@@ -230,8 +231,9 @@ void CGPrgObj::dstTargetRot(CGPrgObj* target)
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));
 	deltaX = deltaPos.x;
 	deltaZ = deltaPos.z;
-	if ((LoadFloat(FLOAT_80331BD4) == deltaX) || (LoadFloat(FLOAT_80331BD4) == deltaZ)) {
-		targetRot = LoadFloat(FLOAT_80331BD4);
+	zero = LoadFloat(FLOAT_80331BD4);
+	if ((zero == deltaX) || (zero == deltaZ)) {
+		targetRot = zero;
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}
@@ -281,6 +283,7 @@ void CGPrgObj::rotTarget(CGPrgObj* target)
 float CGPrgObj::getTargetRot(CGPrgObj* target)
 {
 	float targetRot;
+	float zero;
 	float deltaX;
 	float deltaZ;
 	CVector targetPos(target->m_worldPosition);
@@ -290,8 +293,9 @@ float CGPrgObj::getTargetRot(CGPrgObj* target)
 	PSVECSubtract(AsVec(basePos), AsVec(targetPos), AsVec(deltaPos));
 	deltaX = deltaPos.x;
 	deltaZ = deltaPos.z;
-	if ((LoadFloat(FLOAT_80331BD4) == deltaX) || (LoadFloat(FLOAT_80331BD4) == deltaZ)) {
-		targetRot = LoadFloat(FLOAT_80331BD4);
+	zero = LoadFloat(FLOAT_80331BD4);
+	if ((zero == deltaX) || (zero == deltaZ)) {
+		targetRot = zero;
 	} else {
 		targetRot = (float)atan2(-(double)deltaX, -(double)deltaZ);
 	}


### PR DESCRIPTION
## Summary
- Reuse the loaded zero value in `CGPrgObj::dstTargetRot` and `CGPrgObj::getTargetRot`.
- This matches the target codegen more closely in the zero-angle branch without changing the rotation logic.

## Objdiff
- `main/prgobj` fuzzy: `99.12586% -> 99.25726%`
- `dstTargetRot__8CGPrgObjFP8CGPrgObj`: `95.568184% -> 96.13636%`
- `getTargetRot__8CGPrgObjFP8CGPrgObj`: `93.27778% -> 95.22222%`
- `rotTarget__8CGPrgObjFP8CGPrgObj`: remains `95.0%`

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o /tmp/prgobj_final_get.json getTargetRot__8CGPrgObjFP8CGPrgObj`
- `build/tools/objdiff-cli diff -p . -u main/prgobj -o /tmp/prgobj_final_dst.json dstTargetRot__8CGPrgObjFP8CGPrgObj`