### PR TITLE
Use shared constants in pppYmLaser

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -16,9 +16,9 @@
 
 #include <string.h>
 
-static const f32 kPppYmLaserOne = 0.0f;
-static const f32 FLOAT_80330DC4 = 1.0f;
-static const f32 FLOAT_80330DC8 = 2.0f;
+extern const f32 kPppYmLaserOne;
+extern const f32 FLOAT_80330DC4;
+extern const f32 FLOAT_80330DC8;
 
 static inline float YmLaserConst(const float& value) { return *reinterpret_cast<const float*>(&value); }
 


### PR DESCRIPTION
## Summary
- Changed pppYmLaser to reference the shared zero/one/debug-scale constants instead of emitting local copies in this object.
- This better matches the extracted target object's constant ownership and trims the current pppYmLaser local .sdata2 from 72 bytes to 52 bytes, closer to the target 56 bytes.

## Evidence
- \[1/1] PROGRESS
Progress:
  All: 34.69% matched, 19.32% linked (322 / 561 files)
    Code: 643512 / 1855224 bytes (3582 / 4732 functions)
    Data: 923555 / 1489300 bytes (62.01%)
  Game Code: 19.76% matched, 3.31% linked (119 / 266 files)
    Code: 291916 / 1477652 bytes (1994 / 3111 functions)
    Data: 736489 / 1224222 bytes (60.16%)
  RedSound: 61.84% matched, 0.00% linked (0 / 8 files)
    Code: 42096 / 68072 bytes (346 / 379 functions)
    Data: 20754 / 25794 bytes (80.46%)
  SDK Code: 100.00% matched, 100.00% linked (203 / 203 files)
    Code: 309500 / 309500 bytes (1242 / 1242 functions)
    Data: 166312 / 166896 bytes (99.65%) passes.
- pppYmLaser unit fuzzy score after the change: 98.41891%.
- objdiff section evidence for pppYmLaser: current .sdata2 shrank from 72 bytes before this change to 52 bytes after; target .sdata2 is 56 bytes.
- pppRenderYmLaser .text section comparison baseline was 98.35386%; after this change the unit report shows .text at 98.41891%.

## Plausibility
- The target object treats these render constants as shared SDA references rather than local definitions in pppYmLaser.
- The change removes duplicated constant ownership without forcing sections, addresses, constructors, destructors, or vtables.