### PR TITLE
Match menu_item sdata2 constants

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -23,9 +23,9 @@ static const float FLOAT_80332e80 = 255.0f;
 static const float FLOAT_80332e84 = 0.9f;
 static const float FLOAT_80332e88 = 4.0f;
 static const float FLOAT_80332e8c = 320.0f;
-static const float FLOAT_80332e90 = 0.5f;
 static const float FLOAT_80332e94 = 352.0f;
 static const float FLOAT_80332E98 = 3.0f;
+static const float FLOAT_80332e90 = 0.5f;
 static const double DOUBLE_80332ea0 = 4503601774854144.0;
 static const float FLOAT_80332EA8 = 128.0f;
 static const float FLOAT_80332EAC = 8.0f;
@@ -537,11 +537,15 @@ void CMenuPcs::ItemDraw()
     if (!foundSelected) {
         selectedItemId = -1;
     }
+    float helpBaseX = LoadFloat(FLOAT_80332e8c);
+    float helpOffsetX = LoadFloat(FLOAT_80332e90);
+    int helpX = (int)(helpBaseX - (float)(LoadDouble(DOUBLE_80332e78) * (double)helpOffsetX));
+    int helpY = (int)LoadFloat(FLOAT_80332e94);
     DrawHelpMessage(
         selectedItemId,
         helpFont,
-        (int)-((double)(LoadDouble(DOUBLE_80332e78) * (double)LoadFloat(FLOAT_80332e90)) - (double)LoadFloat(FLOAT_80332e8c)),
-        (int)LoadFloat(FLOAT_80332e94),
+        helpX,
+        helpY,
         helpColor.color,
         10,
         LoadFloat(FLOAT_80332e64),
@@ -829,7 +833,7 @@ void CMenuPcs::ItemInit()
     ItemMenuAnimList* itemList;
 
     memset(this->itemList, 0, sizeof(*this->itemList));
-    float one = FLOAT_80332e64;
+    float one = LoadFloat(FLOAT_80332e64);
     entry = this->itemList->anims;
     int initCount = 8;
     do {
@@ -854,7 +858,7 @@ void CMenuPcs::ItemInit()
     entry->h = 0x108;
     float titleAlpha = LoadFloat(FLOAT_80332EA8);
     float titleScale = FLOAT_80332EAC;
-    float zero = FLOAT_80332e60;
+    float zero = LoadFloat(FLOAT_80332e60);
     entry->u = titleAlpha;
     entry->v = titleScale;
     entry->uvScale = one;


### PR DESCRIPTION
Summary
- Reorder and spell menu_item float constant uses so .sdata2 matches the target object exactly.
- Reuse existing LoadFloat patterns for ItemInit constants to avoid duplicate anonymous literals.
- Split the help-message coordinate calculation so the constant emission order matches the original object.

Evidence
- objdiff command: build/tools/objdiff-cli diff -p . -u main/menu_item -o -
- .sdata2: 90.909096% -> 100.0%
- .text: 84.82417% -> 84.28513% (localized tradeoff while matching constant data layout)
- extab: 94.64286% -> 94.64286%
- extabindex: 95.2381% -> 95.2381%
- Full ninja passes.
- Build report data matched count increased from 933105 to 933193 bytes during this run, matching the 88-byte menu_item .sdata2 section.

Plausibility
- The changes use existing source helpers, not manual section forcing or address hacks.
- The resulting .sdata2 bytes match the target layout exactly, including constant order and removal of duplicate local literals.