### PR TITLE
Match CPartPcs GetParColIdx

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -569,13 +569,10 @@ void CPartPcs::drawAfterViewer()
  */
 void CPartPcs::GetParColIdx(int index, pppFVECTOR4& color)
 {
-	_pppMngSt* pppMngStArray = PartMng.m_pppMng;
-	_pppMngSt& pppMngSt = pppMngStArray[index];
-
-	color.x = pppMngSt.m_userFloat0;
-	color.y = pppMngSt.m_userFloat1;
-	color.z = pppMngSt.m_scaleFactor;
-	color.w = pppMngSt.m_ownerScale;
+	color.x = PartMng.m_pppMng[index].m_userFloat0;
+	color.y = PartMng.m_pppMng[index].m_userFloat1;
+	color.z = PartMng.m_pppMng[index].m_scaleFactor;
+	color.w = PartMng.m_pppMng[index].m_ownerScale;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Simplify `CPartPcs::GetParColIdx` to read `PartMng.m_pppMng[index]` directly.
- This matches the Ghidra shape and avoids the extra local pointer/reference that changed register allocation.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_tina -o - GetParColIdx__8CPartPcsFiR11pppFVECTOR4`
  - Before: 98.46154% match, 52 bytes
  - After: 100.0% match, 52 bytes
- Build report improved matched code by 52 bytes and matched functions by 1.

## Plausibility
- The resulting source is simpler and closer to original-style direct member access through the global particle manager.
- No hardcoded offsets, fake symbols, or section forcing.
