### PR TITLE
Improve pppScreenBreak zero constant reuse

### DIFF
--- a/src/pppScreenBreak.cpp
+++ b/src/pppScreenBreak.cpp
@@ -571,14 +571,15 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
     Vec lightDir;
     GXLightObj lightObj;
     CCameraPcs* camera = &CameraPcs;
+    const float& zero = FLOAT_80331cc4;
 
     lightDir.x = camera->m_directionX - (30.0f + camera->m_positionX);
     lightDir.y = camera->m_directionY - (30.0f + camera->m_positionY);
     lightDir.z = camera->m_directionZ - (30.0f + camera->m_positionZ);
     PSVECNormalize(&lightDir, &lightDir);
 
-    GXInitSpecularDirHA(&lightObj, lightDir.x, lightDir.y, lightDir.z, 0.0f, 1.0f, 0.0f);
-    GXInitLightAttn(&lightObj, 0.0f, 0.0f, 1.0f, 4.0f, 0.0f, -3.0f);
+    GXInitSpecularDirHA(&lightObj, lightDir.x, lightDir.y, lightDir.z, zero, 1.0f, zero);
+    GXInitLightAttn(&lightObj, zero, zero, 1.0f, 4.0f, zero, -3.0f);
 
     GXInitLightColor(&lightObj, CColor(0xFF, 0xFF, 0xFF, 0xFF).color);
     GXLoadLightObjImm(&lightObj, (GXLightID)1);
@@ -597,7 +598,7 @@ void SB_BeforeDrawCallback(CChara::CModel*, void*, void*, float (*) [4], int)
  */
 int SB_BeforeCalcMatrixCallback(CChara::CModel* model, void* param_2, void* param_3)
 {
-    float zero = 0.0f;
+    float zero = FLOAT_80331cc4;
     VScreenBreak* work = static_cast<VScreenBreak*>(param_2);
     PScreenBreak* step = static_cast<PScreenBreak*>(param_3);
     ScreenBreakPiece* pieceData = work->m_pieces;


### PR DESCRIPTION
## Summary
- Reuse the existing screen-break zero constant in draw/calc callbacks instead of introducing fresh zero literals.
- Improves SB_BeforeDrawCallback codegen by aligning its zero-constant references with the target.

## Evidence
- Built with `ninja`: OK.
- `main/pppScreenBreak` .text match improved from 96.90276% to 96.91169%.
- `SB_BeforeDrawCallback__FPQ26CChara6CModelPvPvPA4_fi` improved from 99.66216% to 99.797295%.
- No size change for the improved callback: 296 bytes.

## Plausibility
- The change reuses an already-present file-local zero constant (`FLOAT_80331cc4`) that other pppScreenBreak code already depends on, rather than adding new control flow or compiler-only hacks.