### PR TITLE
Improve texture allocation construction matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -33,6 +33,9 @@ extern const float FLOAT_8032faf4;
 static inline CTexture* NewTexture(CMemory::CStage* textureStage, char* file, int line)
 {
     void* memory = Memory._Alloc(sizeof(CTexture), textureStage, file, line, 0);
+    if (memory == 0) {
+        return 0;
+    }
     return ::new (memory) CTexture;
 }
 


### PR DESCRIPTION
## Summary
- Add the missing null check after allocating a CTexture in the shared NewTexture helper.
- This matches the constructor guard shown in the target CTextureSet::Create paths before constructing into allocated storage.

## Objdiff evidence
Command: build/tools/objdiff-cli diff -p . -u main/textureman -o -

Before:
- .text: 97.457466%
- extabindex: 98.3871%
- Create__11CTextureSetFR10CChunkFilePQ27CMemory6CStageiP13CAmemCacheSetii: 87.32143%, compiled size 508
- Create__11CTextureSetFPvPQ27CMemory6CStageiP13CAmemCacheSetii: 90.365166%, compiled size 660

After:
- .text: 97.71662%
- extabindex: 98.655914%
- Create__11CTextureSetFR10CChunkFilePQ27CMemory6CStageiP13CAmemCacheSetii: 88.96429%, compiled size 520
- Create__11CTextureSetFPvPQ27CMemory6CStageiP13CAmemCacheSetii: 91.6573%, compiled size 672

## Validation
- ninja