### PR TITLE
Improve chara viewer constants and frame step

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -24,6 +24,12 @@ extern const char sCFlatRuntime2AnimStateWarn[];
 extern const float FLOAT_80330BC8;
 extern const float FLOAT_80330BCC;
 
+extern "C" const double kCharaViewerColorCenterBias = 4503601774854144.0;
+extern "C" const float kCharaViewerZero = 0.0f;
+extern "C" const float kCharaViewerBackOrthoRight = 448.0f;
+extern "C" const float kCharaViewerBackOrthoBottom = 640.0f;
+extern "C" const float kCharaViewerGridMax = -100.0f;
+
 namespace {
 
 typedef unsigned char u8;

--- a/src/p_chara_viewer.cpp
+++ b/src/p_chara_viewer.cpp
@@ -20,11 +20,11 @@ extern "C" {
 extern u8* gCharaPartWorkPtr;
 }
 
-extern "C" const double kCharaViewerColorCenterBias = 4503601774854144.0;
-extern "C" const float kCharaViewerZero = 0.0f;
-extern "C" const float kCharaViewerBackOrthoRight = 448.0f;
-extern "C" const float kCharaViewerBackOrthoBottom = 640.0f;
-extern "C" const float kCharaViewerGridMax = -100.0f;
+extern "C" const double kCharaViewerColorCenterBias;
+extern "C" const float kCharaViewerZero;
+extern "C" const float kCharaViewerBackOrthoRight;
+extern "C" const float kCharaViewerBackOrthoBottom;
+extern "C" const float kCharaViewerGridMax;
 
 static const float kCharaViewerUnitStep = 1.0f;
 static const float kCharaViewerGridSpacing = 10.0f;
@@ -525,16 +525,16 @@ void CCharaPcs::calcViewer()
     float frameAdvance;
     if (self->m_viewerStepMode != 0) {
         frameAdvance = LoadFloat(kCharaViewerZero);
-        float offsetA = frameAdvance;
         if ((triggerButtons & 0x100) != 0) {
-            offsetA = LoadFloat(kCharaViewerUnitStep);
+            frameAdvance += LoadFloat(kCharaViewerUnitStep);
+        } else {
+            frameAdvance += LoadFloat(kCharaViewerZero);
         }
-        frameAdvance += offsetA;
-        float offsetB = LoadFloat(kCharaViewerZero);
         if ((triggerButtons & 0x200) != 0) {
-            offsetB = LoadFloat(kCharaViewerFineStep);
+            frameAdvance += LoadFloat(kCharaViewerFineStep);
+        } else {
+            frameAdvance += LoadFloat(kCharaViewerZero);
         }
-        frameAdvance += offsetB;
     } else {
         float deltaY = LoadFloat(kCharaViewerUnitStep);
         if ((heldButtons & 0x200) != 0) {
@@ -616,6 +616,7 @@ void CCharaPcs::calcViewer()
         if (bFirst != 0) {
             srt.transZ = LoadFloat(kCharaViewerZero);
             srt.transY = LoadFloat(kCharaViewerZero);
+            srt.transX = LoadFloat(kCharaViewerZero);
             srt.rotZ = LoadFloat(kCharaViewerZero);
             srt.rotY = LoadFloat(kCharaViewerZero);
             srt.rotX = LoadFloat(kCharaViewerZero);


### PR DESCRIPTION
## Summary
- Move shared chara viewer projection/grid constants to `cflat_r2class.cpp`, matching MAP ownership and leaving `p_chara_viewer.cpp` as an extern user.
- Reshape `CCharaPcs::calcViewer` step-mode frame accumulation to better match target codegen.
- Initialize `srt.transX` with the rest of the static viewer SRT state.

## Evidence
- `ninja` passes.
- `calcViewer__9CCharaPcsFv`: `.text` match improved from 97.71152% to 98.028275%.
- `main/p_chara_viewer`: compiled `.sdata2` size reduced from 0xa0 to 0x88 after removing duplicate constant definitions.
- `main/cflat_r2class`: `.sdata2` content match improved from 65.38461% to 100.0%.
- Overall build report data bytes improved from 933133 to 933157.

## Plausibility
- The moved constants follow the linker/MAP ownership shown for `cflat_r2class.o` and are referenced externally by the original `p_chara_viewer.o`.
- The SRT and frame-step changes are ordinary source-level initialization/control-flow shapes, not address or section forcing.