### PR TITLE
Fix MenuUtil effect work offset

### DIFF
--- a/include/ffcc/MenuUtil.h
+++ b/include/ffcc/MenuUtil.h
@@ -89,6 +89,7 @@ public:
     ArtiState* m_artiState;             // 0x82C
     char pad_830[0x838 - 0x830];
     EffectEntry* m_effectEntries;       // 0x838
+    void* m_pad83C;                     // 0x83C
     EffectInfo* m_effectWork;           // 0x840
     char pad_844[0x864 - 0x844];
     unsigned short m_battleStateFlag;   // 0x864


### PR DESCRIPTION
## Summary
- Add the missing 0x83C pad member to the partial CMenuPcs declaration in MenuUtil.h.
- This aligns m_effectWork with the full CMenuPcs layout in p_menu.h at offset 0x840.

## Evidence
- ninja passes for GCCP01.
- SetManaWaterEffect__8CMenuPcsFv: 99.965515% -> 100.0% (116b matched).
- BindMcObj__8CMenuPcsFi: 98.02381% -> 98.03571%.
- MenuUtil .text: 61.63917% -> 61.63961%.
- Overall progress after build: matched functions 3581 -> 3582, matched code 643688 -> 643804.

## Plausibility
- p_menu.h already models the same class with a pad at 0x83C and m_effectWork at 0x840.
- The Ghidra decomp for SetManaWaterEffect reads the effect work pointer from this+0x840, matching the corrected layout.