### PR TITLE
Correct FadeOutSe3D signature

### DIFF
--- a/include/ffcc/sound.h
+++ b/include/ffcc/sound.h
@@ -90,7 +90,7 @@ public:
     int SetSe3DGroup(int, int);
     void StopSe3DGroup(int);
     void StopSe3D(int);
-    _pppMngSt* FadeOutSe3D(int, int);
+    void FadeOutSe3D(int, int);
     int ChangeSe3DPos(int, Vec*);
     void ChangeSe3DPitch(int, int, int);
     void Clear3DLine(int);

--- a/src/pppPart.cpp
+++ b/src/pppPart.cpp
@@ -105,7 +105,7 @@ _pppMngSt* pppStopSe(_pppMngSt* pppMngSt, PPPSEST* pppSest)
 {
 	if (pppSest->m_soundEffectSlot >= 0 && pppSest->m_soundEffectHandle >= 0)
 	{
-		pppMngSt = Sound.FadeOutSe3D(pppSest->m_soundEffectHandle, pppSest->m_soundEffectFadeFrames);
+		Sound.FadeOutSe3D(pppSest->m_soundEffectHandle, pppSest->m_soundEffectFadeFrames);
 		pppSest->m_soundEffectHandle = -1;
 	}
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1974,7 +1974,7 @@ found_entry:
  * JP Address: TODO
  * JP Size: TODO
  */
-_pppMngSt* CSound::FadeOutSe3D(int se3dHandle, int fadeFrames)
+void CSound::FadeOutSe3D(int se3dHandle, int fadeFrames)
 {
     if (se3dHandle < 0) {
         System.Printf(const_cast<char*>(s_soundMinusOneFmt));


### PR DESCRIPTION
## Summary
- Change `CSound::FadeOutSe3D` to return `void`, matching the decompiled target shape.
- Update `pppStopSe` so it calls `FadeOutSe3D` for its side effect instead of assigning a nonexistent return value.

## Evidence
- `ninja` passes and `build/GCCP01/main.dol: OK`.
- `build/tools/objdiff-cli diff -p . -u main/sound -o build/agent_sound_final.json FadeOutSe3D__6CSoundFii`
  - `FadeOutSe3D__6CSoundFii`: 93.75% -> 93.888885%
  - `sound` `.text`: 97.80836%
- `build/tools/objdiff-cli diff -p . -u main/pppPart -o build/agent_pppPart_final.json pppStopSe__FP9_pppMngStP7PPPSEST`
  - `pppStopSe__FP9_pppMngStP7PPPSEST`: 81.545456%

## Plausibility
Ghidra shows `FadeOutSe3D__6CSoundFii` returning `void`, and the function only fades/stops the matching 3D sound entry. The old `_pppMngSt*` return type forced callers to treat an incidental register value as a real return, which is less plausible original source.
