### PR TITLE
Fix MenuUtil effect work layout

### DIFF
--- a/include/ffcc/MenuUtil.h
+++ b/include/ffcc/MenuUtil.h
@@ -89,6 +89,7 @@ public:
     ArtiState* m_artiState;             // 0x82C
     char pad_830[0x838 - 0x830];
     EffectEntry* m_effectEntries;       // 0x838
+    char pad_83C[0x840 - 0x83C];
     EffectInfo* m_effectWork;           // 0x840
     char pad_844[0x864 - 0x844];
     unsigned short m_battleStateFlag;   // 0x864


### PR DESCRIPTION
## Summary
- Added the missing padding before `CMenuPcs::m_effectWork` in `MenuUtil.h` so this duplicate layout matches the established `0x840` offset from `p_menu.h`.
- This lets `SetManaWaterEffect__8CMenuPcsFv` use the original effect-work pointer offset.

## Evidence
- `ninja` passes.
- `main/MenuUtil` matched functions: 6 -> 7.
- `main/MenuUtil` matched code: 1020 -> 1136 bytes.
- `SetManaWaterEffect__8CMenuPcsFv`: 99.965515% -> 100.0%.
- `BindMcObj__8CMenuPcsFi` also now uses the correct `m_effectWork` offset and improved slightly: 98.02381% -> 98.03571%.

## Plausibility
- `include/ffcc/p_menu.h` already asserts `offsetof(CMenuPcs, m_effectWork) == 0x840`; this patch makes the slimmer `MenuUtil.h` layout agree with that source-of-truth layout instead of changing code flow or forcing output.