### PR TITLE
Match Tail3 construct zero load

### DIFF
--- a/src/pppYmMegaBirthShpTail3.cpp
+++ b/src/pppYmMegaBirthShpTail3.cpp
@@ -57,6 +57,11 @@ static inline YmMegaBirthShpTail3DataOffsets* GetYmMegaBirthShpTail3DataOffsets(
 void birth(_pppPObject*, VYmMegaBirthShpTail3*, PYmMegaBirthShpTail3*, VColor*, _PARTICLE_DATA*, _PARTICLE_WMAT*, _PARTICLE_COLOR*);
 void calc(_pppPObject*, VYmMegaBirthShpTail3*, PYmMegaBirthShpTail3*, _PARTICLE_DATA*, VColor*, _PARTICLE_COLOR*);
 
+static inline float LoadFloat(const float& value)
+{
+    return value;
+}
+
 /*
  * --INFO--
  * PAL Address: 8008ca98
@@ -851,8 +856,8 @@ void pppConstructYmMegaBirthShpTail3(pppYmMegaBirthShpTail3* pppYmMegaBirthShpTa
     float initVal;
 
     pppUnitMatrix(*work);
-    initVal = kPppYmMegaBirthShpTail3Zero;
-    work[1].value[0][2] = kPppYmMegaBirthShpTail3Zero;
+    initVal = LoadFloat(kPppYmMegaBirthShpTail3Zero);
+    work[1].value[0][2] = initVal;
     work[1].value[0][1] = initVal;
     work[1].value[0][0] = initVal;
     *reinterpret_cast<u32*>(&work[1].value[0][3]) = 0;


### PR DESCRIPTION
## Summary
- Add the Tail2-style LoadFloat helper to pppYmMegaBirthShpTail3
- Reuse the loaded zero when initializing the Tail3 construct work data

## Objdiff evidence
- main/pppYmMegaBirthShpTail3 builds cleanly
- pppConstructYmMegaBirthShpTail3: 99.91228% -> 100.0%
- pppRenderYmMegaBirthShpTail3 remains 40.183075%
- pppFrameYmMegaBirthShpTail3 remains 99.37037%
- calc__FP11_pppPObjectP20VYmMegaBirthShpTail3P20PYmMegaBirthShpTail3P14_PARTICLE_DATAP6VColorP15_PARTICLE_COLOR remains 99.833336%
- birth__FP11_pppPObjectP20VYmMegaBirthShpTail3P20PYmMegaBirthShpTail3P6VColorP14_PARTICLE_DATAP14_PARTICLE_WMATP15_PARTICLE_COLOR remains 51.2365%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppYmMegaBirthShpTail3 -o /tmp/pppYmMegaBirthShpTail3_final.json

## Plausibility
This follows the existing pppYmMegaBirthShpTail2 pattern, where zero constants are loaded through a small LoadFloat helper before construct initialization. It avoids fake symbols or manual section/linkage tricks and keeps the surrounding Tail3 behavior unchanged.