### PR TITLE
Match Mana2 reflection vector loop

### DIFF
--- a/src/pppMana2.cpp
+++ b/src/pppMana2.cpp
@@ -152,6 +152,7 @@ static void CalcWaterReflectionVector(
     Vec reflected;
     Mtx matrixNoTranslate;
     Mtx inverseMtx;
+    Vec* positionIt;
     Vec* reflectionIt;
     Vec* normalIt;
     unsigned char* colorBytes;
@@ -189,15 +190,17 @@ static void CalcWaterReflectionVector(
     PSVECScale(&cameraPos, &cameraPos, LoadFloat(FLOAT_8033189c));
     PSMTXMultVec(inverseMtx, &cameraPos, &transformedCameraPos);
 
-    colorBytes = (unsigned char*)color;
-    texCoordFloat = (float*)texCoord;
+    zero = LoadFloat(FLOAT_80331898);
+    positionIt = positions;
+    half = LoadFloat(FLOAT_803318a4);
     reflectionIt = reflectionVec;
     normalIt = normals;
-    zero = LoadFloat(FLOAT_80331898);
-    half = LoadFloat(FLOAT_803318a4);
+    colorBytes = (unsigned char*)color;
+    texCoordFloat = (float*)texCoord;
 
-    for (i = 0; i < count; i++) {
-        PSVECSubtract(positions, &transformedCameraPos, &reflected);
+    i = 0;
+    while (i < count) {
+        PSVECSubtract(positionIt, &transformedCameraPos, &reflected);
         C_VECReflect(&reflected, normalIt, reflectionIt);
         PSMTXMultVec(matrixNoTranslate, reflectionIt, reflectionIt);
         PSVECNormalize(reflectionIt, reflectionIt);
@@ -224,10 +227,11 @@ static void CalcWaterReflectionVector(
             texCoordFloat[1] = -reflectionIt->y / (denomBase - reflectionIt->z);
         }
 
-        positions++;
+        positionIt++;
         reflectionIt++;
         normalIt++;
         colorBytes += 4;
+        i++;
         *texCoordFloat = *texCoordFloat * half;
         *texCoordFloat = *texCoordFloat + half;
         texCoordFloat[1] = texCoordFloat[1] * half;


### PR DESCRIPTION
## Summary
- Match `CalcWaterReflectionVector__FP3VecP3VecP3Vecl3VecPA4_fP8_GXColorP5Vec2d` in `pppMana2`
- Make the positions pointer an explicit loop iterator and place the loop counter increment to match target codegen

## Evidence
- `ninja` passes
- `CalcWaterReflectionVector`: 98.24% -> 100.0%, size 700b
- `pppMana2` `.text`: 91.26503% -> 91.36458%
- Project progress: matched code 643688 -> 644388 bytes, matched functions 3581 -> 3582
- `.rodata` and `.sdata2` remain 100%