### PR TITLE
Improve LoadFieldPdt0 loop setup

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -470,8 +470,9 @@ void LoadFieldPdt0(int mapId, int floorId)
 
             pppDataHead = PartMng.m_pdtSlots[0].m_pppDataHead;
             createParam = PartMng.pppGetDefaultCreateParam();
+            i = 0;
             fieldParticleOffset = 0;
-            for (i = 0; i < static_cast<int>((unsigned int)pppDataHead->m_partCount); i++) {
+            for (; i < static_cast<int>((unsigned int)pppDataHead->m_partCount); i++) {
                 _pppFieldParticleData* fieldParticle = reinterpret_cast<_pppFieldParticleData*>(
                     reinterpret_cast<unsigned char*>(PartMng.m_pdtSlots[0].m_pppDataHead) + sizeof(_pppDataHead) +
                     fieldParticleOffset);


### PR DESCRIPTION
## Summary
- Initialize the particle loop index before the field-particle byte offset in LoadFieldPdt0
- Matches the target loop setup order more closely without changing behavior

## Objdiff evidence
- main/p_tina LoadFieldPdt0__Fii: 99.60000% -> 99.65000%
- Function size unchanged at 400 bytes
- Instruction diffs reduced from 7 to 6

## Verification
- ninja passes
- build/tools/objdiff-cli diff -p . -u main/p_tina -o - LoadFieldPdt0__Fii