### PR TITLE
Inline unused pppCrystal helpers

### DIFF
--- a/src/p_tina.cpp
+++ b/src/p_tina.cpp
@@ -470,8 +470,9 @@ void LoadFieldPdt0(int mapId, int floorId)
 
             pppDataHead = PartMng.m_pdtSlots[0].m_pppDataHead;
             createParam = PartMng.pppGetDefaultCreateParam();
+            i = 0;
             fieldParticleOffset = 0;
-            for (i = 0; i < static_cast<int>((unsigned int)pppDataHead->m_partCount); i++) {
+            for (; i < static_cast<int>((unsigned int)pppDataHead->m_partCount); i++) {
                 _pppFieldParticleData* fieldParticle = reinterpret_cast<_pppFieldParticleData*>(
                     reinterpret_cast<unsigned char*>(PartMng.m_pdtSlots[0].m_pppDataHead) + sizeof(_pppDataHead) +
                     fieldParticleOffset);

--- a/src/pppCrystal.cpp
+++ b/src/pppCrystal.cpp
@@ -70,7 +70,7 @@ struct CrystalDataOffsets {
 STATIC_ASSERT(offsetof(CrystalDataOffsets, m_colorBlockOffset) == 0x4);
 STATIC_ASSERT(offsetof(CrystalDataOffsets, m_workOffset) == 0x8);
 
-void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32);
+inline void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32);
 
 static inline CrystalDataOffsets* GetCrystalDataOffsets(_pppCtrlTable* ctrl)
 {
@@ -425,7 +425,7 @@ void pppConstructCrystal(pppCrystal* pppCrystal, _pppCtrlTable* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void MakeRefractionMap(HSD_ImageBuffer* imageBuffer)
+inline void MakeRefractionMap(HSD_ImageBuffer* imageBuffer)
 {
     u32 y;
     u32 x;
@@ -494,7 +494,7 @@ void MakeRefractionMap(HSD_ImageBuffer* imageBuffer)
  * JP Address: TODO
  * JP Size: TODO
  */
-void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32)
+inline void ImageBufferSetPixel_IA8(HSD_ImageBuffer* imageBuffer, u32 x, u32 y, u32 intensity, u32 alpha, u32, u32)
 {
     u32 yTile = y >> 2;
     u32 yFine = (y & 3) * 4;


### PR DESCRIPTION
## Summary
- Mark unused pppCrystal refraction helpers as inline so they remain documented source without emitting out-of-line code.
- Removes the extra unused helper text/extab contribution from the built pppCrystal object.

## Evidence
- Before: current object emitted unused `MakeRefractionMap` (724b) and `ImageBufferSetPixel_IA8` (64b), with `.text` 3520b, extab 32b, extabindex 48b.
- After: `main/pppCrystal` objdiff shows `.text` 2692b, extab 24b, extabindex 36b; extab and extabindex are 100% matched.
- `build/binutils/powerpc-eabi-nm -S build/GCCP01/src/pppCrystal.o` no longer lists those helper symbols.

## Verification
- `ninja`
- `ninja build/GCCP01/main.dol`
- `git diff --check`

## Plausibility
Both helpers are marked `PAL Address: UNUSED`; the project runbook explicitly calls for marking UNUSED functions inline when they cause extab regressions. This keeps the recovered source while matching the original object layout more closely.