### PR TITLE
Improve pppYmBreath sdata2 layout

### DIFF
--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -17,17 +17,16 @@ extern const float kCharaAnimZero;
 extern const float kCharaAnimDegToRad;
 extern const float kCharaAnimNegativeOne;
 extern const float kCharaAnimFullTurnDegrees;
-extern const char s_CardGameCode_80330CB8[] = "FFCC";
-extern const char s_CardMakerCode_80330CC0[] = "GDS";
-extern const char s_CardMachineCode_80330CC4[] = "GC";
-extern const char s_CardVersion_80330CC8[] = "1.00";
-extern const double kYmBreathSignedDoubleMagic = 4503601774854144.0;
-extern const float kYmBreathZero = 0.0f;
 extern const float kYmBreathHalfCircleDegrees = 180.0f;
 extern const float kYmBreathNegativeHalfCircleDegrees = -180.0f;
 extern const double DOUBLE_80330CA0 = 4503599627370496.0;
 extern const float kYmBreathSpreadScale = 2.0f;
 extern const double kYmBreathHalfChance = 0.5;
+extern const char s_CardGameCode_80330CB8[] = "FFCC";
+extern const char s_CardMakerCode_80330CC0[] = "GDS";
+extern const char s_CardMachineCode_80330CC4[] = "GC";
+extern const char s_CardVersion_80330CC8[] = "1.00";
+extern const float kYmBreathZero = 0.0f;
 
 static inline float LoadFloat(const float& value)
 {


### PR DESCRIPTION
## Summary
- reorder pppYmBreath local constants to match the PAL .sdata2 layout
- remove the extra local signed double-magic definition from the named constant block
- keep code generation stable while improving the unit data layout

## Evidence
- ninja: passes
- objdiff main/pppYmBreath:
  - .text: size 6464, match 99.56807
  - .rodata: size 16, match 100.0
  - .sdata2: target size 56, match 100.0
  - [.sdata2-0]: match improves to 73.68421; prior baseline was 30.000002
- code symbol scores remain at the prior baseline:
  - pppRenderYmBreath: 99.80805
  - pppFrameYmBreath: 99.129745
  - UpdateAllParticle: 99.1903
  - UpdateParticle: 99.88688
  - BirthParticle: 99.69873

## Plausibility
The PAL symbols list has the YmBreath constants before the card strings and does not include the removed signed double-magic symbol. This change makes the source-owned constant block closer to that layout without adding section hacks or changing function bodies.