### PR TITLE
Improve menu arti help draw constants

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -421,12 +421,14 @@ void CMenuPcs::ArtiDraw()
 		const char* text = GetMenuStr(0x14);
 		CColor color(0xFF, 0xFF, 0xFF, helpAlpha);
 		int x = (int)CalcCenteringPos(const_cast<char*>(text), helpFont);
-		DrawFont(x, (int)FLOAT_80332fcc, color.color, 10, const_cast<char*>(text), FLOAT_80332fac,
+		float helpY = FLOAT_80332fcc;
+		DrawFont(x, (int)helpY, color.color, 10, const_cast<char*>(text), FLOAT_80332fac,
 		         FLOAT_80332fd0);
 	} else {
 		CColor helpColor(0xFF, 0xFF, 0xFF, helpAlpha);
 		int x = (int)-(helpWidth * FLOAT_80332fd8 - FLOAT_80332fd4);
-		DrawHelpMessage(selectedArtifactId, helpFont, x, (int)FLOAT_80332fcc, helpColor.color, 10,
+		float helpY = FLOAT_80332fcc;
+		DrawHelpMessage(selectedArtifactId, helpFont, x, (int)helpY, helpColor.color, 10,
 		                FLOAT_80332fac, FLOAT_80332fd0);
 	}
 }


### PR DESCRIPTION
## Summary
- keep the artifact help text Y coordinate as a float before converting for draw calls
- restores the expected 352.0f sdata2 constant in menu_arti

## Objdiff evidence
- main/menu_arti .text: 88.923775% -> 89.16%
- main/menu_arti .sdata2: 94.44444% -> 100.0%
- ArtiDraw__8CMenuPcsFv: 84.513% -> 85.03813%
- ArtiInit1__8CMenuPcsFv unchanged at 89.11258%
- ArtiInit__8CMenuPcsFv unchanged at 81.63529%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o /tmp/menu_arti.diff.final.json

## Plausibility
The change keeps a UI coordinate in floating-point form until the call-site cast, which matches the target constant layout without adding ABI hacks or manually defining compiler-generated data.