### PR TITLE
Improve menu_money and pppChangeTex matches

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -563,7 +563,7 @@ bool CMenuPcs::MoneyOpen()
 		firstAnim->u = 0.0f;
 		firstAnim->v = 0.0f;
 		firstAnim->uvScale = 1.0f;
-		firstAnim->flags = 0;
+		firstAnim->startFrame = 0;
 		firstAnim->duration = 10;
 		this->m_moneyPanel->count = 1;
 

--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -453,7 +453,7 @@ static void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, v
 	CTexture* texture = work->m_texture;
 
 	if (step->m_changeTex.m_mode == 0) {
-		unsigned int drawTevBits = 0xACE0F;
+		unsigned int drawTevBits = 0xADE0F;
 		unsigned int fullTevBits = drawTevBits | 0x1000;
 		MaterialMan.SetChangeTexReflectionState(
 		    &texture->m_texObj, drawTevBits, fullTevBits);


### PR DESCRIPTION
## Summary
- Store the initialized money panel animation start frame directly in MoneyOpen, matching the target field write after the panel memset.
- Use the final ChangeTex reflection TEV mask in the draw callback, matching the inline material state writes.

## Objdiff evidence
- MoneyOpen__8CMenuPcsFv: 83.35345% -> 83.35776%
- ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f: 90.95082% -> 91.065575%
- Adjacent checked symbols unchanged: MoneyCtrlCur, MoneyDraw, MoneyClose, pppFrameChangeTex, ChangeTex_AfterDrawMeshCallback.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_money -o - MoneyOpen__8CMenuPcsFv
- build/tools/objdiff-cli diff -p . -u main/pppChangeTex -o - ChangeTex_DrawMeshDLCallback__FPQ26CChara6CModelPvPviiPA4_f