### PR TITLE
Improve caravan letter flag handling

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -111,13 +111,24 @@ public:
             reinterpret_cast<unsigned char*>(&m_half.m_header)[0] = flags;
         }
         bool IsOpened() const { return static_cast<signed char>(Flags()) < 0; }
-        void SetOpened() { SetFlags(Flags() | 0x80); }
+        void SetOpened()
+        {
+            unsigned char flags = Flags();
+            flags |= 0x80;
+            SetFlags(flags);
+        }
         bool IsAttachmentClaimed() const { return (Flags() & 0x40) != 0; }
         void SetAttachmentClaimed() { SetFlags((Flags() & 0xBF) | 0x40); }
         bool IsReplySent() const { return (Flags() & 0x20) != 0; }
-        void SetReplySent() { SetFlags((Flags() & ~0x20) | (1 << 5)); }
+        void SetReplySent()
+        {
+            unsigned char flags = Flags();
+            flags &= ~0x20;
+            flags |= 0x20;
+            SetFlags(flags);
+        }
         bool HasReply() const { return (Flags() & 0x10) != 0; }
-        bool AttachmentIsGil() const { return (Flags() & 8) != 0; }
+        bool AttachmentIsGil() const { return Flags() & 8; }
         unsigned short HeaderWord() const { return m_half.m_header; }
         unsigned short MessageType() const { return (HeaderWord() >> 2) & 0x1FF; }
         unsigned int SenderId() const { return (Word0() >> 9) & 0x1FF; }

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -411,17 +411,18 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 	}
 
 	memset(&m_letters[0], 0, sizeof(m_letters[0]));
-	m_letters[0].m_half.m_header =
-		(m_letters[0].m_half.m_header & 0xF803) | static_cast<unsigned short>(letterType << 2);
+	unsigned short header = m_letters[0].m_half.m_header & 0xF803;
+	unsigned short letterTypeBits = static_cast<unsigned short>((letterType & 0x1FF) << 2);
+	m_letters[0].m_half.m_header = header | letterTypeBits;
 	m_letters[0].m_words.m_word0 = (m_letters[0].m_words.m_word0 & 0xFFFC01FF) | ((senderId & 0x1FF) << 9);
 	m_letters[0].SetFlags((m_letters[0].Flags() & ~8) | ((hasMoneyFlag << 3) & 8));
 	if (m_letters[0].AttachmentIsGil()) {
 		moneyValue /= 100;
 	}
 	m_letters[0].m_half.m_attachment = (m_letters[0].m_half.m_attachment & 0xFE00) | (moneyValue & 0x1FF);
-	m_letters[0].SetFlags(m_letters[0].Flags() & ~0x80);
-	m_letters[0].SetFlags(m_letters[0].Flags() & ~0x40);
-	m_letters[0].SetFlags(m_letters[0].Flags() & ~0x20);
+	m_letters[0].SetFlags(m_letters[0].Flags() & 0x7F);
+	m_letters[0].SetFlags(m_letters[0].Flags() & 0xBF);
+	m_letters[0].SetFlags(m_letters[0].Flags() & 0xDF);
 	m_letters[0].SetFlags((m_letters[0].Flags() & ~0x10) | ((hasReplyFlag << 4) & 0x10));
 	m_letters[0].m_half.m_tempVars[0] = static_cast<unsigned short>(itemA);
 	m_letters[0].m_half.m_tempVars[1] = static_cast<unsigned short>(itemB);


### PR DESCRIPTION
## Summary
- Rework `CCaravanWork::CLetterWork` flag setters to use explicit flag-byte updates.
- Make the `AddLetter` message-type bitfield write use explicit masked temporaries.
- Use explicit clear masks when resetting new-letter flags.

## Evidence
- `ninja` succeeds for GCCP01; `build/GCCP01/main.dol: OK`.
- `AddLetter__12CCaravanWorkFiiiiiiiii`: 79.265305% -> 79.83673%.
- `FGLetterOpen__12CCaravanWorkFi`: 76.24051% -> 76.3924%.
- `FGLetterReply__12CCaravanWorkFiiii`: 96.71429% -> 97.14286%.
- `main/gobjwork` `.text`: 87.654755% -> 87.67242%.

## Plausibility
These changes keep the existing `CLetterWork` layout and member access, but express byte flags and packed message-type bits closer to the operations in the target: explicit mask/or updates rather than broader helper expressions.
