### PR TITLE
Enable stopwatch exception metadata

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -759,7 +759,7 @@ config.libs = [
             Object(NonMatching, "shopmenu.cpp"),
             Object(NonMatching, "singmenu.cpp"),
             Object(NonMatching, "sound.cpp", extra_cflags=["-RTTI on"]),
-            Object(NonMatching, "stopwatch.cpp", extra_cflags=["-Cpp_exceptions off"]),
+            Object(NonMatching, "stopwatch.cpp"),
             Object(NonMatching, "system.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "texanim.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "textureman.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),


### PR DESCRIPTION
## Summary
- Remove the stopwatch.cpp override that forced C++ exceptions off.
- Let stopwatch.cpp use the game library default exception setting so the compiler emits extab/extabindex metadata for the unit.

## Evidence
- Full build passes: `ninja` reports `build/GCCP01/main.dol: OK` and final progress generation succeeds.
- `build/tools/objdiff-cli diff -p . -u main/stopwatch -o -` still reports `.text` 736 bytes at 100% and `.sdata2` 24 bytes at 100%.
- Current `stopwatch.o` now emits compiler-generated `extab` (80 bytes) and `extabindex` (120 bytes), moving the unit toward the reference metadata shape without manual extab/RTTI/vtable data.

## Notes
- Global matched-byte progress is unchanged; this is a flag/linkage cleanup for generated exception metadata, not a source-code byte match.