### PR TITLE
Match pad sdata2 constants

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -18,10 +18,14 @@ CPad Pad;
 
 void* operator new[](unsigned long, CMemory::CStage*, char*, int);
 
-static const char s_CPad[] = "CPad";
-static const float FLOAT_8032f820 = 0.0f;
-static const float FLOAT_8032f824 = 0.0078125f;
-static const float FLOAT_8032f828 = 255.0f;
+extern "C" {
+extern const char s_CPad[] = "CPad";
+extern const float FLOAT_8032f820 = 0.0f;
+extern const float FLOAT_8032f824 = 0.0078125f;
+extern const float FLOAT_8032f828 = 255.0f;
+extern const double DOUBLE_8032f830 = 4503601774854144.0;
+extern const double DOUBLE_8032f838 = 4503599627370496.0;
+}
 static const char s_pad_cpp[] = { 'p', 'a', 'd', '.', 'c', 'p', 'p', 0 };
 static const char s_rb[] = { 'r', 'b', 0 };
 static const char s_replay_dat[] = "/replay.dat";


### PR DESCRIPTION
## Summary
- Define the pad float and double literals as real C-linkage objects in source order.
- Keeps the existing pad strings in place while matching the target `.sdata2` layout for the unit.

## Evidence
- `ninja` passes for GCCP01.
- `build/tools/objdiff-cli diff -p . -u main/pad -o /tmp/pad_final.json Frame__4CPadFv`
- `main/pad` `.sdata2`: 100.0% match.
- `main/pad` matched data: 668 / 752 bytes, 88.83% (selector baseline showed 81.38%).
- `Frame__4CPadFv` remains unchanged at 93.83544% in objdiff; this PR is a data/layout improvement.

## Plausibility
- These constants already appear in the PAL symbol config as `FLOAT_8032f820`, `FLOAT_8032f824`, `FLOAT_8032f828`, `DOUBLE_8032f830`, and `DOUBLE_8032f838`.
- The change replaces compiler-emitted anonymous literals with named source constants instead of forcing sections or hand-writing generated metadata.
