### PR TITLE
Use typed breath particle matrix arrays

### DIFF
--- a/src/pppBreathModel.cpp
+++ b/src/pppBreathModel.cpp
@@ -420,8 +420,8 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     BreathModelDataOffsets* dataOffsets;
     VColor* color;
     VBreathModel* work;
-    Mtx* particleWMat;
-    Mtx* particleMtx;
+    PARTICLE_WMAT* particleWMat;
+    PARTICLE_WMAT* particleMtx;
     int groupIndex;
     int firstParticle;
     short slotIndex;
@@ -511,7 +511,7 @@ extern "C" void pppFrameBreathModel(pppBreathModel* breathModel, PBreathModel* p
     PSMTXCopy(ppvMng->m_matrix.value, work->m_matrix);
     UpdateAllParticle(breathModel, work, pBreathModel, color);
 
-    particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
+    particleWMat = work->m_particleWmats;
     groupData = work->m_groups;
     for (groupIndex = 0; groupIndex < (int)pBreathModel->m_groupCount; groupIndex++) {
         groupCheck = &work->m_groups[(short)groupIndex];
@@ -538,8 +538,8 @@ group_ready:
             scaleMtx[0][0] = scaledOwner;
             scaleMtx[1][1] = scaledOwner;
             scaleMtx[2][2] = scaledOwner;
-            particleMtx = (Mtx*)((unsigned char*)particleWMat + firstParticle * sizeof(PARTICLE_WMAT));
-            PSMTXConcat(*particleMtx, object->m_localMatrix.value, worldMtx);
+            particleMtx = &particleWMat[firstParticle];
+            PSMTXConcat(particleMtx->m_matrix, object->m_localMatrix.value, worldMtx);
             PSMTXMultVec(worldMtx, &groupData->position, &origin);
             pppCopyMatrix(rotMtx, *reinterpret_cast<pppFMATRIX*>(particleMtx));
             rotMtx.value[0][3] = 0.0f;

--- a/src/pppYmBreath.cpp
+++ b/src/pppYmBreath.cpp
@@ -442,8 +442,8 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, _p
     YmBreathDataOffsets* dataOffsets;
     VColor* color;
     VYmBreath* work;
-    Mtx* particleWMat;
-    Mtx* particleMtx;
+    PARTICLE_WMAT* particleWMat;
+    PARTICLE_WMAT* particleMtx;
     int i;
     int groupIndex;
     int firstParticle;
@@ -534,7 +534,7 @@ extern "C" void pppFrameYmBreath(pppYmBreath* ymBreath, PYmBreath* pYmBreath, _p
     PSMTXCopy(ppvMng->m_matrix.value, work->m_matrix);
     UpdateAllParticle(ymBreath, work, pYmBreath, color);
 
-    particleWMat = reinterpret_cast<Mtx*>(work->m_particleWmats);
+    particleWMat = work->m_particleWmats;
     groupData = work->m_groups;
     for (groupIndex = 0; groupIndex < (int)params->m_groupCount; groupIndex++) {
         groupCheck = &work->m_groups[(short)groupIndex];
@@ -561,8 +561,8 @@ group_ready:
             scaleMtx[0][0] = scaledOwner;
             scaleMtx[1][1] = scaledOwner;
             scaleMtx[2][2] = scaledOwner;
-            particleMtx = (Mtx*)((unsigned char*)particleWMat + firstParticle * sizeof(PARTICLE_WMAT));
-            PSMTXConcat(*particleMtx, ymBreath->m_localMatrix.value, worldMtx);
+            particleMtx = &particleWMat[firstParticle];
+            PSMTXConcat(particleMtx->m_matrix, ymBreath->m_localMatrix.value, worldMtx);
             PSMTXMultVec(worldMtx, &groupData->position, &origin);
             pppCopyMatrix(rotMtx, *reinterpret_cast<pppFMATRIX*>(particleMtx));
             rotMtx.value[0][3] = kCharaAnimZero;


### PR DESCRIPTION
## Summary
- Use `PARTICLE_WMAT*` for breath particle world-matrix arrays in `pppFrameBreathModel` and `pppFrameYmBreath`.
- Replace manual byte-offset matrix indexing with typed array indexing through `PARTICLE_WMAT::m_matrix`.

## Evidence
- `ninja` passes.
- `pppBreathModel` objdiff remains neutral: `.text` 99.691826%, `pppFrameBreathModel` 99.25633% before and after.
- `pppYmBreath` objdiff remains neutral after the cleanup: `.text` 99.56807%, `pppFrameYmBreath` 99.129745%.

## Plausibility
This removes pointer-offset arithmetic over `PARTICLE_WMAT` storage and uses the real particle world-matrix type already present in `pppBreathParticle.h`. The generated code is unchanged, but the source is closer to the underlying data layout and easier to continue matching without unsafe casts around the array access.