### PR TITLE
Improve pppFrameRain register allocation

### DIFF
--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -160,9 +160,9 @@ void pppRenderRain(pppRain* pppRain, PRain* param_2, RAIN_DATA* param_3)
  */
 void pppFrameRain(pppRain* pppRain, PRain* param_2, RAIN_DATA* param_3)
 {
-    int i;
-    RainDrop* drop;
     VRain* work;
+    RainDrop* drop;
+    int i;
     int randA;
     int randB;
     if (ppvUserStopPartF != 0) {


### PR DESCRIPTION
## Summary
- Reordered the pppFrameRain local declarations so MWCC keeps the rain work pointer and drop cursor in a register layout closer to the original object.
- No behavior changes; this is a plausible source-order adjustment in the existing local declaration block.

## Objdiff Evidence
- Unit: main/pppRain
- Symbol: pppFrameRain
- Before: 97.74254% match, 1072 bytes
- After: 98.041046% match, 1072 bytes
- Other checked symbols unchanged: pppRenderRain 99.25548%, pppDestructRain 100%, pppConstructRain 100%.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRain -o - pppFrameRain
