### PR TITLE
Improve menu artifact control matching

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -155,26 +155,25 @@ int CMenuPcs::ArtiCtrlCur()
 		return 0;
 	}
 
-	ArtiState* state = GetArtiState(this);
-	selection = state->currentSelection;
+	selection = GetArtiState(this)->currentSelection;
 	if ((uVar4 & 8) != 0) {
-		sVar1 = state->selections[selection];
+		sVar1 = GetArtiState(this)->selections[selection];
 		if (sVar1 != 0) {
-			state->selections[selection] = sVar1 + -1;
+			GetArtiState(this)->selections[selection] = sVar1 + -1;
 			Sound.PlaySe(1, 0x40, 0x7f, 0);
-		} else if (state->scrollOffset != 0) {
-			state->scrollOffset = state->scrollOffset + -1;
+		} else if (GetArtiState(this)->scrollOffset != 0) {
+			GetArtiState(this)->scrollOffset = GetArtiState(this)->scrollOffset + -1;
 			Sound.PlaySe(1, 0x40, 0x7f, 0);
 		} else {
 			Sound.PlaySe(4, 0x40, 0x7f, 0);
 		}
 	} else if ((uVar4 & 4) != 0) {
-		sVar1 = state->selections[selection];
+		sVar1 = GetArtiState(this)->selections[selection];
 		if (sVar1 < 7) {
-			state->selections[selection] = sVar1 + 1;
+			GetArtiState(this)->selections[selection] = sVar1 + 1;
 			Sound.PlaySe(1, 0x40, 0x7f, 0);
-		} else if ((int)state->scrollOffset + (int)sVar1 < 0x48) {
-			state->scrollOffset = state->scrollOffset + 1;
+		} else if ((int)GetArtiState(this)->scrollOffset + (int)sVar1 < 0x48) {
+			GetArtiState(this)->scrollOffset = GetArtiState(this)->scrollOffset + 1;
 			Sound.PlaySe(1, 0x40, 0x7f, 0);
 		} else {
 			Sound.PlaySe(4, 0x40, 0x7f, 0);
@@ -183,19 +182,19 @@ int CMenuPcs::ArtiCtrlCur()
 
 	if ((uVar4 & 0xc) == 0) {
 		if ((uVar3 & 0x20) != 0) {
-			state->moveDirection = 1;
+			GetArtiState(this)->moveDirection = 1;
 			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
 			return 1;
 		}
 		if ((uVar3 & 0x40) != 0) {
-			state->moveDirection = -1;
+			GetArtiState(this)->moveDirection = -1;
 			Sound.PlaySe(0x5a, 0x40, 0x7f, 0);
 			return 1;
 		}
 		if ((uVar3 & 0x100) != 0) {
 			Sound.PlaySe(4, 0x40, 0x7f, 0);
 		} else if ((uVar3 & 0x200) != 0) {
-			state->closeRequested = 1;
+			GetArtiState(this)->closeRequested = 1;
 			Sound.PlaySe(3, 0x40, 0x7f, 0);
 			return 1;
 		}
@@ -425,13 +424,12 @@ int CMenuPcs::ArtiClose()
 	int frame;
 	int finished;
 
-	ArtiState* state = GetArtiState(this);
-	state->frame++;
+	GetArtiState(this)->frame++;
 	finished = 0;
 
 	count = GetArtiOpenAnimList(this)->count;
 	anim = GetArtiOpenAnimList(this)->entries;
-	frame = state->frame;
+	frame = GetArtiState(this)->frame;
 
 	for (int i = 0; i < count; i++, anim++) {
 		float zeroF = FLOAT_80332fa8;
@@ -501,16 +499,15 @@ int CMenuPcs::ArtiOpen()
 	int finished;
 	int frame;
 
-	ArtiState* state = GetArtiState(this);
-	if (state->initialized == '\0') {
+	if (GetArtiState(this)->initialized == '\0') {
 		ArtiInit();
 	}
 
-	state->frame = state->frame + 1;
+	GetArtiState(this)->frame = GetArtiState(this)->frame + 1;
 	finished = 0;
 	count = GetArtiOpenAnimList(this)->count;
 	ArtiOpenAnim* entry = GetArtiOpenAnimList(this)->entries;
-	frame = (int)state->frame;
+	frame = (int)GetArtiState(this)->frame;
 
 	for (int i = 0; i < count; i++, entry++) {
 		float zero = FLOAT_80332fa8;


### PR DESCRIPTION
## Summary
- Adjust menu_arti artifact control/open/close state access to better match the original pointer lifetime and reload pattern.
- Improves ArtiCtrlCur, ArtiClose, and ArtiOpen without changing artifact draw/init output.

## Objdiff evidence
build/tools/objdiff-cli diff -p . -u main/menu_arti -o -

Before -> after:
- ArtiCtrlCur__8CMenuPcsFv: 784b / 88.68965% -> 800b / 97.31527%
- ArtiClose__8CMenuPcsFv: 376b / 94.8% -> 380b / 98.189476%
- ArtiOpen__8CMenuPcsFv: 432b / 89.361115% -> 432b / 97.62037%
- [extab-0]: 56b / 94.64286% -> 56b / 96.42857%
- [extabindex-0]: 84b / 95.71428% -> 84b / 96.42857%

Unchanged:
- ArtiDraw__8CMenuPcsFv: 2252b / 79.37088%
- ArtiInit1__8CMenuPcsFv: 612b / 89.11258%
- ArtiInit__8CMenuPcsFv: 684b / 77.26471%
- [.sdata2-0]: 80b / 90.0%

## Plausibility
The changes keep real member access and avoid offset tricks. They shorten the lifetime of cached ArtiState pointer locals so the compiler reloads m_artiState around list setup and command handling, matching the shape shown by Ghidra for the original functions.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o -