### PR TITLE
Improve YmDrawMdlTexAnm frame match

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -174,7 +174,7 @@ void pppFrameYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step, 
     mapMesh = GetMapMeshTable()[step->m_dataValIndex];
     perU = work->m_perU;
     perV = work->m_perV;
-    if ((perU == FLOAT_8033054c) || (perV == FLOAT_8033054c)) {
+    if (!perU || !perV) {
         if (mapMesh != NULL) {
             SetUpPerUV((pppModelSt*)mapMesh, work->m_perU, work->m_perV);
         } else {


### PR DESCRIPTION
## Summary
- Change the pppFrameYmDrawMdlTexAnm zero-UV check to the compact float truthiness form.
- This matches the target compare shape more closely without changing behavior or adding hacks.

## Evidence
- ninja passes.
- Focused diff command: build/tools/objdiff-cli diff -p . -u main/pppYmDrawMdlTexAnm -o /tmp/pppYmDrawMdlTexAnm_pr.json pppFrameYmDrawMdlTexAnm
- pppFrameYmDrawMdlTexAnm: 97.985435% -> 98.08253%
- pppDestructYmDrawMdlTexAnm: unchanged at 98.29269%

## Plausibility
- The retained source is a normal C/C++ zero check for the cached per-U/per-V values.
- No address constants, section forcing, fake labels, or manual ABI artifacts were added.