### PR TITLE
Mark unused YmMiasma render helper inline

### DIFF
--- a/src/pppYmMiasma.cpp
+++ b/src/pppYmMiasma.cpp
@@ -63,7 +63,7 @@ struct YmMiasmaRenderParticleState {
 
 void InitParticleData(VYmMiasma*, _pppPObject*, PYmMiasma*, PARTICLE_DATA*);
 void UpdateParticleData(_pppPObject*, _pppCtrlTable*, PYmMiasma*, PARTICLE_DATA*);
-void RenderParticle(_pppPObject*, PYmMiasma*, PARTICLE_DATA*);
+inline void RenderParticle(_pppPObject*, PYmMiasma*, PARTICLE_DATA*);
 
 struct YmMiasmaDataOffsets {
     s32 _unused0[2];
@@ -325,7 +325,7 @@ void pppConstructYmMiasma(pppYmMiasma* pppYmMiasma_, _pppCtrlTable* param_2)
  * JP Address: TODO
  * JP Size: TODO
  */
-void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
+inline void RenderParticle(_pppPObject* pppPObject, PYmMiasma* pYmMiasma, PARTICLE_DATA* particleData)
 {
     YmMiasmaRenderParticleState* state = (YmMiasmaRenderParticleState*)particleData;
     YmMiasmaRenderStep* step = (YmMiasmaRenderStep*)pYmMiasma;


### PR DESCRIPTION
## Summary
- Marks the UNUSED RenderParticle helper in pppYmMiasma as inline.
- Keeps the known helper source without emitting an extra standalone symbol.

## Evidence
- ninja passes for GCCP01.
- Before this change, build/GCCP01/src/pppYmMiasma.o emitted RenderParticle__FP11_pppPObjectP9PYmMiasmaP13PARTICLE_DATA and had .text size 0x1068 while the target object .text is 0x0dd8.
- After this change, the emitted RenderParticle symbol is gone and build/GCCP01/src/pppYmMiasma.o .text is 0x0dd8, matching build/GCCP01/obj/pppYmMiasma.o.
- Existing pppYmMiasma function scores are preserved: pppRenderYmMiasma 99.559784%, pppFrameYmMiasma 99.82888%, and all remaining listed functions stay 100%.

## Plausibility
- The function is already marked PAL Address: UNUSED, so making it inline follows the project rule for known unused helpers and avoids introducing text/extab output that is not present in the target object.