### PR TITLE
Improve pppRain frame matching

### DIFF
--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -861,9 +861,9 @@ doneAdvance:
  */
 int CMes::GetWait()
 {
-	if (*(int*)((char*)this + 0x3c7c) < *(int*)((char*)this + 0x3c80))
+	if (mRevealCursor < mDrawCursor)
 	{
-		return *(int*)((char*)this + 0x3c78);
+		return mWaitFrames;
 	}
 	return 0;
 }

--- a/src/pppRain.cpp
+++ b/src/pppRain.cpp
@@ -171,14 +171,12 @@ void pppFrameRain(pppRain* pppRain, PRain* param_2, RAIN_DATA* param_3)
 
     work = GetRainWork(pppRain, param_3);
     if (work->drops == 0) {
-        RainDrop* dropData;
-
         work->drops = (RainDrop*)pppMemAlloc(
             param_2->m_dataValIndex * sizeof(RainDrop),
             ppvEnv->m_stagePtr,
             const_cast<char*>(s_pppRain_cpp),
             0x7f);
-        dropData = work->drops;
+        drop = work->drops;
         for (i = 0; i < (int)param_2->m_dataValIndex; i++) {
             float minX;
             float maxX;
@@ -198,29 +196,29 @@ void pppFrameRain(pppRain* pppRain, PRain* param_2, RAIN_DATA* param_3)
             minX = param_2->m_minX;
             maxX = param_2->m_maxX;
             zRange = param_2->m_maxZ - param_2->m_minZ;
-            dropData->posX = unitA * (maxX - minX) + minX;
-            dropData->posY = param_2->m_maxY;
-            dropData->posZ = unitB * zRange + param_2->m_minZ;
-            dropData->dirX = -param_2->m_initWOrk;
-            dropData->dirY = param_2->m_driftY;
-            dropData->dirZ = -param_2->m_arg3;
-            PSVECNormalize((Vec*)&dropData->dirX, (Vec*)&dropData->dirX);
+            drop->posX = unitA * (maxX - minX) + minX;
+            drop->posY = param_2->m_maxY;
+            drop->posZ = unitB * zRange + param_2->m_minZ;
+            drop->dirX = -param_2->m_initWOrk;
+            drop->dirY = param_2->m_driftY;
+            drop->dirZ = -param_2->m_arg3;
+            PSVECNormalize((Vec*)&drop->dirX, (Vec*)&drop->dirX);
 
             lengthDelta = unitA * param_2->m_lengthRand;
-            dropData->length = param_2->m_lengthBase;
+            drop->length = param_2->m_lengthBase;
             lengthDelta = (randA % 2 == 0) ? lengthDelta : -lengthDelta;
-            dropData->length += lengthDelta;
+            drop->length += lengthDelta;
 
             lifeRange = param_2->m_lifeRange;
             lifeBase = param_2->m_lifeBase;
             lifeRemainder = randA % lifeRange;
-            dropData->life = lifeBase;
+            drop->life = lifeBase;
             lifeJitter = -lifeRemainder;
             if (randA % 2 == 0) {
                 lifeJitter = lifeRemainder;
             }
-            dropData->life = (s16)(dropData->life + lifeJitter);
-            dropData++;
+            drop->life = (s16)(drop->life + lifeJitter);
+            drop++;
         }
     }
 


### PR DESCRIPTION
## Summary
- Reuse the pppFrameRain drop cursor for initial allocation setup instead of a separate dropData cursor.
- Replace CMes::GetWait raw offset reads with the existing named fields while preserving the 100% match.

## Objdiff Evidence
- main/pppRain / pppFrameRain: 97.74254% -> 98.54478%; instruction diffs 113 -> 74.
- main/mes / GetWait__4CMesFv: remains 100.0% with 0 diffs.

## Plausibility
- The rain change removes a redundant local cursor and uses a single RainDrop* cursor through initialization, which is plausible original source and improves saved-register allocation.
- The message wait cleanup uses named CMes members instead of hard-coded offsets without changing generated code.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/pppRain -o - pppFrameRain
- build/tools/objdiff-cli diff -p . -u main/mes -o - GetWait__4CMesFv
