### PR TITLE
Match caravan bonus condition lookup

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -350,11 +350,10 @@ void CCaravanWork::SetBonusCondition(int bonusCondition)
 {
 	m_bonusCondition = static_cast<unsigned char>(bonusCondition);
 	memset(m_artifactRelated, 0, sizeof(m_artifactRelated));
-	CGame::CBossArtifactStage* bossArtifacts =
-		&Game.m_bossArtifactBase[Game.m_gameWork.m_bossArtifactStageIndex];
-	CGame::CBossArtifactEntry* entry = &bossArtifacts->m_entries[bonusCondition + 8];
-	m_artifactRelated[3] = entry->m_values[1];
-	m_artifactRelated[4] = entry->m_values[2];
+	m_artifactRelated[3] =
+		Game.m_bossArtifactBase[Game.m_gameWork.m_bossArtifactStageIndex].m_entries[bonusCondition + 8].m_values[1];
+	m_artifactRelated[4] =
+		Game.m_bossArtifactBase[Game.m_gameWork.m_bossArtifactStageIndex].m_entries[bonusCondition + 8].m_values[2];
 }
 
 /*


### PR DESCRIPTION
## Summary
- Remove the cached boss artifact entry pointer in `CCaravanWork::SetBonusCondition`
- Access the boss artifact table directly for each artifact value, matching the target address recomputation pattern

## Objdiff evidence
- `SetBonusCondition__12CCaravanWorkFi`: 62.58% -> 100.00%
- `main/gobjwork` `.text`: 87.2% selector baseline -> 87.41549% after change

## Verification
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/gobjwork -o - --format json SetBonusCondition__12CCaravanWorkFi`
- `git diff --check`

## Plausibility
The code now expresses the two reads as direct source-level accesses to `Game.m_bossArtifactBase[...]` rather than caching a derived entry pointer. That matches the target codegen without fake symbols, address constants, or section forcing.
