### PR TITLE
Improve menu_compa constant layout

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -40,12 +40,17 @@ extern "C" const char s_MenuOptionNorm_803334E8[];
 
 STATIC_ASSERT(sizeof(CompaOpenAnimList) == 0x1008);
 
-static inline double LoadDouble(const double& value)
+static inline double LoadDouble(double value)
 {
 	return value;
 }
 
-static inline float LoadFloat(const float& value)
+static inline float LoadFloat(float value)
+{
+	return value;
+}
+
+static inline float LoadFloatRef(const float& value)
 {
 	return value;
 }
@@ -138,7 +143,7 @@ void CMenuPcs::CompaDraw()
 					colors[3].g = 0xFF;
 					colors[3].b = 0xFF;
 					colors[3].a = 0;
-					float remainW = (static_cast<float>(DOUBLE_80333008) / static_cast<float>(entry->duration)) * w;
+					float remainW = static_cast<float>((LoadDouble(DOUBLE_80333008) / (double)entry->duration) * (double)w);
 					if (tex == 0x51) {
 						int yStep = static_cast<int>(y);
 						float end = y + h;
@@ -590,7 +595,7 @@ void CMenuPcs::CompaInit()
 	memset(this->m_compaList, 0, sizeof(*this->m_compaList));
 
 	CompaOpenAnim* entry = this->m_compaList->entries;
-	float one = LoadFloat(FLOAT_80333000);
+	float one = LoadFloatRef(FLOAT_80333000);
 	int count = 8;
 	do {
 		entry[0].uvScale = one;


### PR DESCRIPTION
## Summary
- Adjust menu_compa constant-loading helpers so most constants are emitted anonymously instead of forcing extra named .sdata2 objects.
- Use a double-width calculation in CompaDraw so the 1.0 double lands in the target constant run.
- Preserve the CompaInit source shape with a scoped reference-load helper where it helps codegen.

## Objdiff evidence
Unit: main/menu_compa

Before -> after:
- CMenuPcs::CompaCtrl(): 89.665% -> 89.690%
- CMenuPcs::CompaOpen(): 98.778% -> 98.963%
- [.sdata2-0]: 72.727% size 68 -> 96.970% size 68
- Weighted code: 3828.510 / 5044 -> 3828.978 / 5052
- Weighted data: 143.960 / 163 -> 168.445 / 171

Tradeoffs:
- CMenuPcs::CompaDraw(): 61.918% size 2808 -> 61.787% size 2816
- CMenuPcs::CompaClose(): 98.663% -> 98.189%

The net weighted objdiff result improves both code and data, and the data layout improvement is from more plausible constant usage rather than manual section forcing.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_compa -o -