### PR TITLE
Match memory card HP max calculation

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -281,16 +281,16 @@ void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)
             {
                 if (itemSlot >= 0x45)
                 {
-                    int equippedSlot;
-                    equippedSlot = itemSlot - 0x45;
                     const int word = itemSlot >> 5;
                     const int bit = itemSlot % 32;
                     if ((*reinterpret_cast<u32*>(charData + 0xBC + word * 4) & (1 << bit)) != 0)
                     {
+                        int equippedSlot = itemSlot - 0x45;
                         equippedItems[equippedSlot] = static_cast<short>(itemSlot + 0x9F);
                     }
                     else
                     {
+                        int equippedSlot = itemSlot - 0x45;
                         equippedItems[equippedSlot] = -1;
                     }
                 }


### PR DESCRIPTION
## Summary
- Adjust `CMemoryCardMan::CalcSaveDatHpMax` so the equipped artifact slot is computed inside each result branch.
- This matches the original branch-local codegen while preserving the existing save-data logic.

## Evidence
- `ninja` passes.
- `build/tools/objdiff-cli diff -p . -u main/memorycard -o - CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`
  - `CalcSaveDatHpMax__14CMemoryCardManFPQ22Mc7SaveDat`: 92.765434% -> 100.0%
  - `main/memorycard` `.text`: 90.23701% -> 90.40618%
- Overall progress after build: 3589 / 4732 functions matched, up from 3588 / 4732 before this change.

## Plausibility
- The change is a source-level expression lifetime adjustment, not an address, section, or symbol hack.
- The slot value is only needed after the artifact bit result is known, so computing it in each branch is a plausible original-source shape.