### PR TITLE
Improve goout and cmake menu matching

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -473,13 +473,13 @@ static inline char* GetCmakeNameBuffer()
 
 static void LoadCmakeVillageName()
 {
-    strcpy(s_CmakeInfo.m_name, s_CmakeVillageName);
+    strcpy(s_CmakeInfo.m_name, Game.m_gameWork.m_townName);
 }
 
 static void StoreCmakeVillageName()
 {
-    memset(s_CmakeVillageName, 0, sizeof(s_CmakeVillageName));
-    strcpy(s_CmakeVillageName, s_CmakeInfo.m_name);
+    memset(Game.m_gameWork.m_townName, 0, sizeof(Game.m_gameWork.m_townName));
+    strcpy(Game.m_gameWork.m_townName, s_CmakeInfo.m_name);
 }
 
 static bool IsCmakeNameBlank(const char* name)
@@ -3686,8 +3686,9 @@ void CMenuPcs::CmakeVillageDraw()
     font->SetMargin(FLOAT_803332c4);
     font->SetColor(col);
 
+    int tableBase = villageWork->m_table * 5;
     for (int i = 0; i < 5; i++) {
-        const char* rowText = s_NameEntryStr[villageWork->m_table * 5 + i];
+        const char* rowText = s_NameEntryStr[tableBase + i];
         font->SetPosX(FLOAT_803332c8);
         font->SetPosY(static_cast<float>(0x6C + i * 0x20));
         font->Draw(rowText);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2075,7 +2075,7 @@ void CGoOutMenu::SetDelMode(unsigned char mode)
         if (m_deleteInitSelChar == 0) {
             MenuPcs.InitSaveLoadMenu();
         }
-        MenuPcs.SetMenuCharaAnim(m_selectedChara, 0);
+        SetMenuCharaAnim__8CMenuPcsFii2(&MenuPcs);
         m_deleteInitSelChar = 1;
         break;
     case 1:
@@ -2092,7 +2092,7 @@ void CGoOutMenu::SetDelMode(unsigned char mode)
                 }
             }
 
-            if (activeMainCharacterCount < 2) {
+            if (activeMainCharacterCount <= 1) {
                 int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
                 SetMenuStr(0, 4,
                            GetGoOutMessageLine(languageId, 70),


### PR DESCRIPTION
## Summary
- Use the reset-style SetMenuCharaAnim helper and original comparison spelling in goout delete mode.
- Back cmake village-name editing with Game.m_gameWork.m_townName instead of the local buffer.
- Hoist the cmake village keyboard table base outside the draw loop.

## Objdiff evidence
- main/goout .text: 58.5376% -> 58.595833%
- SetDelMode__10CGoOutMenuFUc: 89.52708% -> 90.50542%
- main/cmake .text: 53.360855% -> 53.722607%
- calcVillageMenu__8CMenuPcsFv: 86.22069% -> 87.28966%
- CmakeVillageCtrl__8CMenuPcsFv: 52.43299% -> 53.70722%
- CmakeVillageDraw__8CMenuPcsFv: 38.7551% -> 43.41043%

## Plausibility
- The goout helper call matches the original reset animation call shape already used elsewhere in this unit.
- The cmake village-name copy now uses the existing game work town-name field, matching target loads from Game and preserving the existing local bss layout.
- The draw-loop table-base hoist is ordinary source and matches the target loop setup without forcing compiler data.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/goout -o build/agent/goout_final.json
- build/tools/objdiff-cli diff -p . -u main/cmake -o build/agent/cmake_final.json