### PR TITLE
Fix camera invalid FOV clamp

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -790,8 +790,10 @@ void CCameraPcs::calc()
     CalcQuake();
 
     float fov = m_fov;
-    if (fov < FLOAT_8032fac8 && static_cast<unsigned int>(System.m_execParam) >= 1) {
-        System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
+    if (fov < FLOAT_8032fac8) {
+        if (static_cast<unsigned int>(System.m_execParam) >= 1) {
+            System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
+        }
         fov = FLOAT_8032fab4;
     }
     C_MTXPerspective(m_screenMatrix, fov, FLOAT_8032fa3c, m_nearZ, m_farZ);
@@ -853,8 +855,10 @@ void CCameraPcs::SetStdProjectionMatrix()
 {
     float fov = m_fov;
 
-    if (fov < FLOAT_8032fac8 && static_cast<unsigned int>(System.m_execParam) >= 1) {
-        System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
+    if (fov < FLOAT_8032fac8) {
+        if (static_cast<unsigned int>(System.m_execParam) >= 1) {
+            System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
+        }
         fov = FLOAT_8032fab4;
     }
 


### PR DESCRIPTION
## Summary
- Clamp invalid camera FOV values to the fallback value even when debug warning output is disabled.
- Apply the same source shape in both CCameraPcs::calc and CCameraPcs::SetStdProjectionMatrix.

## Evidence
- ninja: passes
- main/p_camera .text objdiff: 73.571724 -> 73.57404
- calc__10CCameraPcsFv: 58.34426 -> 58.355972
- SetStdProjectionMatrix__10CCameraPcsFv: 99.375 -> 99.53125
- Full report after build: matched code 645764, matched functions 3589

## Plausibility
Ghidra shows the original code assigns the fallback FOV whenever the value is below the minimum threshold, and only guards the warning printf on System.m_execParam. The new source keeps that behavior explicit without introducing address, section, or codegen hacks.