### PR TITLE
Improve menu artifact draw matching

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -223,6 +223,7 @@ void CMenuPcs::ArtiDraw()
 
 	const CCaravanWork* const caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
 	ArtiState* state = GetArtiState(this);
+	short drawState = state->state;
 	ArtiOpenAnim* entry = GetArtiOpenAnimList(this)->entries;
 	int drawIndex = 0;
 	float helpWidth;
@@ -363,7 +364,7 @@ void CMenuPcs::ArtiDraw()
 		iconEntry++;
 	}
 
-	if (state->state == 1) {
+	if (drawState == 1) {
 		ArtiOpenAnim* firstEntry = GetArtiOpenAnimList(this)->entries;
 		float mark = static_cast<float>(CalcListPos(state->scrollOffset, 0x49, 0));
 		if (mark > 0.0f) {
@@ -371,7 +372,7 @@ void CMenuPcs::ArtiDraw()
 		}
 	}
 
-	if (state->state == 1) {
+	if (drawState == 1) {
 		ArtiOpenAnim* cursorBase = GetArtiOpenAnimList(this)->entries;
 		int cursorCount = GetArtiOpenAnimList(this)->count;
 		for (int i = 0; i < cursorCount; i++) {


### PR DESCRIPTION
## Summary
- Cache ArtiDraw's artifact menu state in a short local before the two draw-state checks.
- This matches the source shape implied by the original code, where the state value is loaded once and reused for list marker and cursor drawing.

## Objdiff Evidence
- Unit: main/menu_arti
- Symbol: ArtiDraw__8CMenuPcsFv
- Before: 79.37088% match, size 2252
- After: 80.09532% match, size 2248
- .text: 83.88604% -> 84.20151%
- extab: 94.64286% -> 96.42857%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/menu_arti -o /tmp/menu_arti_final_diff.json ArtiDraw__8CMenuPcsFv