### PR TITLE
Improve monobj boss matching

### DIFF
--- a/include/ffcc/monobj.h
+++ b/include/ffcc/monobj.h
@@ -256,7 +256,7 @@ public:
     void moveFrameFuncLastBoss();
 
     void teleport(int, int, int, int, int, int, int, int, int, Vec*, int&, Vec&);
-    void suikomiSub(CGObject*, float);
+    inline void suikomiSub(CGObject*, float);
     void suikomi(int, float);
     int tgtFuncGigasLoad(int);
 

--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -1431,9 +1431,12 @@ void CGMonObj::frameStatFuncTetsukyojin()
 			*reinterpret_cast<Vec*>(SoundBuffer + 0x4F0) = attackVec;
 
 			CVector objectPos(object->m_worldPosition);
-			Vec delta;
-			PSVECSubtract(&attackVec, reinterpret_cast<Vec*>(&objectPos), &delta);
-			float distance = PSVECDistance(&delta, &object->m_worldPosition);
+			CVector delta;
+			PSVECSubtract(&attackVec, reinterpret_cast<Vec*>(&objectPos), reinterpret_cast<Vec*>(&delta));
+			attackVec.x = delta.x;
+			attackVec.y = delta.y;
+			attackVec.z = delta.z;
+			float distance = PSVECDistance(&attackVec, &object->m_worldPosition);
 			float cappedDistance = FLOAT_80331d88;
 			if (distance < FLOAT_80331d88) {
 				cappedDistance = distance;
@@ -1441,7 +1444,7 @@ void CGMonObj::frameStatFuncTetsukyojin()
 
 			memset(&m_moveWork, 0, sizeof(m_moveWork));
 			m_moveWork.m_flags = 0x2114;
-			m_moveWork.m_targetPos = delta;
+			m_moveWork.m_targetPos = attackVec;
 			m_moveWork.m_speed = FLOAT_80331d58;
 			m_moveWork.m_limitFrame = static_cast<int>(cappedDistance * FLOAT_80331d30);
 			m_moveWork.m_changeStat = 0x67;
@@ -2722,7 +2725,7 @@ void CGMonObj::teleport(
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGMonObj::suikomiSub(CGObject*, float)
+inline void CGMonObj::suikomiSub(CGObject*, float)
 {
 	unsigned char* self = reinterpret_cast<unsigned char*>(this);
 	unsigned char* target = reinterpret_cast<unsigned char*>(Game.unk_flat3_0xc7d0);


### PR DESCRIPTION
## Summary
- Mark unused `CGMonObj::suikomiSub` inline so it no longer emits a non-PAL text symbol.
- Shape the Tetsukyojin attack-vector path to use a `CVector` subtract temporary and copy the result back into the move vector, matching the Ghidra-observed constructor/copy flow more closely.

## Evidence
- `ninja` passes, including `build/GCCP01/main.dol: OK`.
- `frameStatFuncTetsukyojin__8CGMonObjFv`: 55.023647% -> 57.719593%.
- `main/monobj_boss` text fuzzy: 75.48306% -> 75.64789%.
- `suikomiSub__8CGMonObjFP8CGObjectf` no longer appears in `build/GCCP01/src/monobj_boss.o`; `suikomi` and `teleport` remain emitted.

## Plausibility
- `suikomiSub` has no PAL symbol and no Ghidra function at that location; marking it inline follows the project rule for known unused functions that should not emit.
- The Tetsukyojin change reflects the target temporary `CVector` construction and explicit copy-back before distance/move-work setup, rather than adding coercion or section hacks.
