### PR TITLE
Improve MaterialEditor init constants

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -633,8 +633,8 @@ void CMaterialEditorPcs::Init()
     m_viewerLightColors[0].b = 0x7f;
     m_viewerLightColors[0].a = 0xff;
 
-    float minusOne = FLOAT_8032FCDC;
-    float zero = FLOAT_8032FCD8;
+    float zero = LoadFloat(FLOAT_8032FCD8);
+    float minusOne = LoadFloat(FLOAT_8032FCDC);
     float one = LoadFloat(FLOAT_8032FCC8);
 
     for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
## Summary
- Load MaterialEditor init constants through the existing LoadFloat helper in target order.
- Improves named sdata2 constant usage for CMaterialEditorPcs::Init.

## Evidence
- ninja succeeds.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/p_MaterialEditor -o - Init__18CMaterialEditorPcsFv
- CMaterialEditorPcs::Init: 99.02655% -> 99.24779%.
- main/p_MaterialEditor .text: 84.45387% -> 84.47247%.
- main/p_MaterialEditor .sdata2: 78.78788% -> 84.210526%.

## Plausibility
- This keeps the local helper pattern already used in the file for address-owned float constants.
- Behavior is unchanged; only local load order and source form now better match the target code and data references.