### PR TITLE
Improve texture TLUT initialization matching

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -477,12 +477,9 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
         tlutData = m_tlutData;
     }
 
+    GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8,
+                  (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries);
     int numEntries = kTextureC4TlutEntries;
-    if (m_format == GX_TF_C8) {
-        numEntries = kTextureC8TlutEntries;
-    }
-    GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-    numEntries = kTextureC4TlutEntries;
     if (m_format == GX_TF_C8) {
         numEntries = kTextureC8TlutEntries;
     }
@@ -552,12 +549,10 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
                                static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
                 tlutData = m_tlutData;
                 if (tlutData != 0) {
+                    GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8,
+                                  (m_format == GX_TF_C8) ? kTextureC8TlutEntries
+                                                          : kTextureC4TlutEntries);
                     int numEntries = kTextureC4TlutEntries;
-                    if (m_format == GX_TF_C8) {
-                        numEntries = kTextureC8TlutEntries;
-                    }
-                    GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-                    numEntries = kTextureC4TlutEntries;
                     if (m_format == GX_TF_C8) {
                         numEntries = kTextureC8TlutEntries;
                     }
@@ -728,12 +723,9 @@ void CTexture::Create(CChunkFile& chunkFile, CMemory::CStage* stage, CAmemCacheS
                        static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
         tlutData = m_tlutData;
         if (m_tlutData != 0) {
+            GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8,
+                          (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries);
             int numEntries = kTextureC4TlutEntries;
-            if (m_format == GX_TF_C8) {
-                numEntries = kTextureC8TlutEntries;
-            }
-            GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-            numEntries = kTextureC4TlutEntries;
             if (m_format == GX_TF_C8) {
                 numEntries = kTextureC8TlutEntries;
             }
@@ -774,12 +766,9 @@ void CTexture::InitTexObj()
                        static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
         tlutData = m_tlutData;
         if (tlutData != 0) {
+            GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8,
+                          (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries);
             int numEntries = kTextureC4TlutEntries;
-            if (m_format == GX_TF_C8) {
-                numEntries = kTextureC8TlutEntries;
-            }
-            GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-            numEntries = kTextureC4TlutEntries;
             if (m_format == GX_TF_C8) {
                 numEntries = kTextureC8TlutEntries;
             }

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -477,9 +477,20 @@ void CTexture::SetExternalTlut(void* tlutData, int loadToGX)
         tlutData = m_tlutData;
     }
 
-    int numEntries = (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries;
+    int numEntries = kTextureC4TlutEntries;
+    if (m_format == GX_TF_C8) {
+        numEntries = kTextureC8TlutEntries;
+    }
     GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-    GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + numEntries * 2, GX_TL_IA8, numEntries);
+    numEntries = kTextureC4TlutEntries;
+    if (m_format == GX_TF_C8) {
+        numEntries = kTextureC8TlutEntries;
+    }
+    int offset = kTextureC4TlutEntries;
+    if (m_format == GX_TF_C8) {
+        offset = kTextureC8TlutEntries;
+    }
+    GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + offset * 2, GX_TL_IA8, numEntries);
 
     if (loadToGX != 0) {
         GXLoadTlut(&m_tlutObj0, GX_TLUT0);
@@ -541,10 +552,21 @@ void CTexture::CacheLoadTexture(CAmemCacheSet* amemCacheSet)
                                static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
                 tlutData = m_tlutData;
                 if (tlutData != 0) {
-                    int numEntries = (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries;
+                    int numEntries = kTextureC4TlutEntries;
+                    if (m_format == GX_TF_C8) {
+                        numEntries = kTextureC8TlutEntries;
+                    }
                     GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-                    GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + numEntries * 2,
-                                  GX_TL_IA8, numEntries);
+                    numEntries = kTextureC4TlutEntries;
+                    if (m_format == GX_TF_C8) {
+                        numEntries = kTextureC8TlutEntries;
+                    }
+                    int offset = kTextureC4TlutEntries;
+                    if (m_format == GX_TF_C8) {
+                        offset = kTextureC8TlutEntries;
+                    }
+                    GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + offset * 2, GX_TL_IA8,
+                                  numEntries);
                 }
             } else {
                 GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
@@ -706,10 +728,20 @@ void CTexture::Create(CChunkFile& chunkFile, CMemory::CStage* stage, CAmemCacheS
                        static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
         tlutData = m_tlutData;
         if (m_tlutData != 0) {
-            int numEntries = (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries;
+            int numEntries = kTextureC4TlutEntries;
+            if (m_format == GX_TF_C8) {
+                numEntries = kTextureC8TlutEntries;
+            }
             GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-            GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + numEntries * 2,
-                          GX_TL_IA8, numEntries);
+            numEntries = kTextureC4TlutEntries;
+            if (m_format == GX_TF_C8) {
+                numEntries = kTextureC8TlutEntries;
+            }
+            int offset = kTextureC4TlutEntries;
+            if (m_format == GX_TF_C8) {
+                offset = kTextureC8TlutEntries;
+            }
+            GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + offset * 2, GX_TL_IA8, numEntries);
         }
     } else {
         GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
@@ -742,10 +774,20 @@ void CTexture::InitTexObj()
                        static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
         tlutData = m_tlutData;
         if (tlutData != 0) {
-            int numEntries = (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries;
+            int numEntries = kTextureC4TlutEntries;
+            if (m_format == GX_TF_C8) {
+                numEntries = kTextureC8TlutEntries;
+            }
             GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
-            GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + numEntries * 2,
-                          GX_TL_IA8, numEntries);
+            numEntries = kTextureC4TlutEntries;
+            if (m_format == GX_TF_C8) {
+                numEntries = kTextureC8TlutEntries;
+            }
+            int offset = kTextureC4TlutEntries;
+            if (m_format == GX_TF_C8) {
+                offset = kTextureC8TlutEntries;
+            }
+            GXInitTlutObj(&m_tlutObj1, static_cast<u8*>(tlutData) + offset * 2, GX_TL_IA8, numEntries);
         }
     } else {
         GXInitTexObj(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),


### PR DESCRIPTION
## Summary
- Reworked texture TLUT object initialization to recompute C4/C8 entry counts in the same source shape used by the target.
- Applied the pattern to `CTexture::SetExternalTlut`, `CacheLoadTexture`, `Create`, and `InitTexObj`.

## Evidence
- `ninja` passes.
- `main/textureman` objdiff:
  - `.text`: 93.50591% -> 96.98422%
  - `extab`: 98.95833% -> 100.0%
  - `extabindex`: 98.3871% -> 98.655914%
  - `SetExternalTlut__8CTextureFPvi`: 58.156864% -> 90.39216% (size 176 -> 204, target 204)
  - `CacheLoadTexture__8CTextureFP13CAmemCacheSet`: 79.02752% -> 94.44037%
  - `Create__8CTextureFR10CChunkFilePQ27CMemory6CStageP13CAmemCacheSetii`: 94.33968% -> 98.02857%
  - `InitTexObj__8CTextureFv`: 74.22472% -> 93.19101%

## Plausibility
The target decompilation shows the TLUT entry count being recomputed around each `GXInitTlutObj` call rather than shared through one reused local. This keeps the source straightforward and avoids section or symbol hacks.