### PR TITLE
Match CMapHit cylinder wrapper

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -279,8 +279,10 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
     g_hit_cyl = *mapCylinder;
     g_hit_mvec = *position;
 
-    int faceOffset = 0;
-    int faceIndex = 0;
+    int faceOffset;
+    int faceIndex;
+    faceIndex = 0;
+    faceOffset = 0;
     while (faceIndex < static_cast<int>(m_faceCount)) {
         g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
         g_hit_t_min = kMapHitInitialTMin;


### PR DESCRIPTION
## Summary
- Split the face loop declarations in CMapHit::CheckHitCylinder(CMapCylinder*, Vec*, unsigned long) from their initializers so the compiler emits the original initialization order.
- This matches the remaining register-order drift in the wrapper without changing control flow or data layout.

## Evidence
- ninja passes.
- Objdiff command: build/tools/objdiff-cli diff -p . -u main/maphit -o - CheckHitCylinder__7CMapHitFP12CMapCylinderP3VecUl
- Function score is now 100.0%, up from 99.87952%.
- Full report improved by one matched function and +332 matched code bytes: 3595 / 4732 functions, 647240 / 1855224 code bytes.