### PR TITLE
Match material editor init constants

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -633,9 +633,9 @@ void CMaterialEditorPcs::Init()
     m_viewerLightColors[0].b = 0x7f;
     m_viewerLightColors[0].a = 0xff;
 
-    float minusOne = FLOAT_8032FCDC;
-    float zero = FLOAT_8032FCD8;
     float one = LoadFloat(FLOAT_8032FCC8);
+    float minusOne = LoadFloat(FLOAT_8032FCDC);
+    float zero = LoadFloat(FLOAT_8032FCD8);
 
     for (int i = 0; i < 3; i++) {
         u8 shade = (i == 0) ? 0x3f : 0;


### PR DESCRIPTION
## Summary
- Reordered and loaded CMaterialEditorPcs::Init float constants through the existing LoadFloat helper.
- This matches the original float register allocation for the viewer light direction/scale initialization.

## Evidence
- Objdiff: Init__18CMaterialEditorPcsFv is 100.0%, size 452b.
- ninja passes.
- Progress after build: matched code 648624 / 1855224 bytes, matched functions 3598 / 4732.

## Plausibility
- Keeps the existing initialization logic intact and uses the file-local LoadFloat pattern already present for material-editor constants.
- No manual constructor/sinit forcing, section hacks, or symbol-name workarounds.