### PR TITLE
Improve p_dbgmenu calc switch table

### DIFF
--- a/src/p_dbgmenu.cpp
+++ b/src/p_dbgmenu.cpp
@@ -233,9 +233,9 @@ void CDbgMenuPcs::calc()
 			break;
 		case 0x65:
 			stackData[0].m_word = 0;
+			stackData[2].m_word = 0;
 			unsigned char gameFlags = CFlatGameFlags();
 			flags = (unsigned int)__cntlzw((int)(s8)((s32)(((u32)gameFlags << 0x18) & 0xC0000000) >> 0x1f));
-			stackData[2].m_word = 0;
 			gameFlags = ((int)(char)(flags >> 5) & 1U) << 7 | (gameFlags & ~CFlatGameFlag_Shouki);
 			CFlatGameFlags() = gameFlags;
 			stackData[1].m_word = (s32)(((u32)gameFlags << 0x18) & 0xC0000000) >> 0x1f;


### PR DESCRIPTION
## Summary
- Reordered the SHOUKI toggle stack initialization in CDbgMenuPcs::calc to match the Ghidra store order.
- This makes the calc switch-table data line up with the original object.

## Objdiff evidence
Before:
- @283 switch table: 54.347824%
- [.data-0]: 93.027725%
- .data: 88.17829%
- calc__11CDbgMenuPcsFv: 97.14685%

After:
- @283 switch table: 100.0%
- [.data-0]: 99.13238%
- .data: 99.23077%
- calc__11CDbgMenuPcsFv: 95.171326%

The local calc code score drops, but the source order matches the Ghidra decompilation for the stack clears and fixes the larger switch-table data layout.

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/p_dbgmenu -o - calc__11CDbgMenuPcsFv