### PR TITLE
Fix pppYmLaser constant linkage

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -327,10 +327,10 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppLaserStep* step, _pppCtrl
 	}
 }
 
-static const f32 FLOAT_80330de0 = -1.0f;
-static const f32 FLOAT_80330de4 = 1.2f;
-static const f32 FLOAT_80330de8 = 10000000000.0f;
-static const f32 FLOAT_80330dec = -10000000000.0f;
+extern "C" const f32 FLOAT_80330de0 = -1.0f;
+extern "C" const f32 FLOAT_80330de4 = 1.2f;
+extern "C" const f32 FLOAT_80330de8 = 10000000000.0f;
+extern "C" const f32 FLOAT_80330dec = -10000000000.0f;
 static const f32 FLOAT_80330df0[2] = {6.2831855f, 0.0f};
 extern const f32 FLOAT_80330df8 = 2.0f;
 extern const f32 FLOAT_80330dfc = 0.5f;


### PR DESCRIPTION
## Summary
- Give the pppYmLaser FLOAT_80330de0/FLOAT_80330de4/FLOAT_80330de8/FLOAT_80330dec constants explicit C linkage.
- This restores the emitted .sdata2 ordering for the pppYmLaser constant block without changing function code scores.

## Evidence
- Built with ninja.
- main/pppYmLaser .text remains 98.40243%.
- pppRenderYmLaser remains 98.03458%.
- main/pppYmLaser [.sdata2-0] improves from 40.0% to 80.0%.

## Plausibility
- These constants are named PAL .sdata2 symbols and are referenced as raw C-style data constants by the particle effect code.
- Explicit C linkage is consistent with nearby decomp patterns for named data symbols and avoids leaving them as TU-local compiler-reordered constants.