### PR TITLE
Match CUSBPcs process table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -8,6 +8,20 @@
 class CUSBPcs : public CProcess
 {
 public:
+    struct CUSBProcessTable
+    {
+        char* m_name;
+        union
+        {
+            u32 m_words[(0x11C - sizeof(char*)) / sizeof(u32)];
+            struct Fields
+            {
+                CProcessTableCallback m_create;
+                CProcessTableCallback m_destroy;
+                CProcessTableEntry m_entries[12];
+            } m_fields;
+        };
+    };
     class CDataHeader
     {
     public:
@@ -21,7 +35,7 @@ public:
         u8 m_reserved34[0xC];
     };
 
-    static CProcessTable m_table;
+    static CUSBProcessTable m_table;
 
     CUSBPcs();
 

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -23,14 +23,14 @@ inline CUSBPcs::CUSBPcs()
     static CProcessTableCallback desc1 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__7CUSBPcsFv)};
     static CProcessTableCallback desc2 = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(func__7CUSBPcsFv)};
 
-    CProcessTable* table = &m_table;
+    CUSBProcessTable* table = &m_table;
 
     table->m_fields.m_create = desc0;
     table->m_fields.m_destroy = desc1;
     table->m_fields.m_entries[0].m_callback = desc2;
 }
 
-CProcessTable CUSBPcs::m_table = {
+CUSBPcs::CUSBProcessTable CUSBPcs::m_table = {
     const_cast<char*>(sUsbPcsClassName),
     {
         0,
@@ -245,7 +245,7 @@ void CUSBPcs::IsBigAlloc(int param_2)
  */
 int CUSBPcs::GetTable(unsigned long param)
 {
-    return reinterpret_cast<int>(&m_table + param);
+    return reinterpret_cast<int>(reinterpret_cast<CProcessTable*>(&m_table) + param);
 }
 
 /*


### PR DESCRIPTION
## Summary
- Add a USB-specific process table storage type for CUSBPcs so m_table__7CUSBPcs emits as the PAL-sized 0x11C object instead of the generic 0x15C CProcessTable size.
- Keep GetTable__7CUSBPcsFUl using the generic CProcessTable stride, preserving the already matched function code.

## Evidence
- ninja passes.
- p_usb functions remain matched at 100%, including GetTable__7CUSBPcsFUl.
- objdiff main/p_usb: m_table__7CUSBPcs improved from 90.01405% to 100.0%.
- objdiff main/p_usb .data improved from 82.24299% to 93.387764%.

## Plausibility
PAL symbols list m_table__7CUSBPcs as a 0x11C data object, while GetTable still uses a 0x15C process-table stride. Modeling the stored table separately matches that layout without manually defining compiler-generated vtables, RTTI, constructors, or destructors.