### PR TITLE
Improve KeShpTail trail advancement

### DIFF
--- a/src/pppKeShpTail2X.cpp
+++ b/src/pppKeShpTail2X.cpp
@@ -130,6 +130,7 @@ void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XStep* step, _p
     Vec zeroVec ATTRIBUTE_ALIGN(8);
     Vec pos ATTRIBUTE_ALIGN(8);
     Vec seg ATTRIBUTE_ALIGN(8);
+    Vec initialSeg ATTRIBUTE_ALIGN(8);
     float trailLen;
     float segLen;
     float segCursor;
@@ -218,13 +219,13 @@ void pppKeShpTail2XDraw(struct pppKeShpTail2X* obj, pppKeShpTail2XStep* step, _p
     segDx = nextBaseX - segBaseX;
     segDy = nextBaseY - segBaseY;
     segDz = nextBaseZ - segBaseZ;
-    seg.x = segDx;
-    seg.y = segDy;
-    seg.z = segDz;
+    initialSeg.x = segDx;
+    initialSeg.y = segDy;
+    initialSeg.z = segDz;
     zeroVec.x = zero;
     zeroVec.y = zero;
     zeroVec.z = zero;
-    segLen = PSVECDistance(&zeroVec, &seg);
+    segLen = PSVECDistance(&zeroVec, &initialSeg);
     segRemain = segLen;
     segCursor = zero;
 
@@ -287,6 +288,7 @@ update_step:
         return;
     }
 
+advance_segment:
     if (segRemain >= trailStep) {
         pos.x = (segDx * segCursor) / segLen + segBaseX;
         pos.y = (segDy * segCursor) / segLen + segBaseY;
@@ -299,7 +301,6 @@ update_step:
         goto draw_loop;
     }
 
-advance_segment:
     nextIndex++;
     if (nextIndex > lastIndex) {
         nextIndex = 0;
@@ -328,7 +329,7 @@ move_next_segment:
     segLen = PSVECDistance(&zeroVec, &seg);
     segCursor = trailLen;
     segRemain += segLen;
-    goto draw_loop;
+    goto advance_segment;
 }
 
 /*

--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -167,6 +167,7 @@ void pppKeShpTail3XDraw(struct pppKeShpTail3X* obj, struct pppKeShpTail3XStep* s
     Vec zeroVec ATTRIBUTE_ALIGN(8);
     Vec pos ATTRIBUTE_ALIGN(8);
     Vec seg ATTRIBUTE_ALIGN(8);
+    Vec initialSeg ATTRIBUTE_ALIGN(8);
     float drawScale;
     float segDx;
     float segDy;
@@ -257,13 +258,13 @@ void pppKeShpTail3XDraw(struct pppKeShpTail3X* obj, struct pppKeShpTail3XStep* s
     segDx = nextBaseX - segBaseX;
     segDy = nextBaseY - segBaseY;
     segDz = nextBaseZ - segBaseZ;
-    seg.x = segDx;
-    seg.y = segDy;
-    seg.z = segDz;
+    initialSeg.x = segDx;
+    initialSeg.y = segDy;
+    initialSeg.z = segDz;
     zeroVec.x = zero;
     zeroVec.y = zero;
     zeroVec.z = zero;
-    segLen = PSVECDistance(&zeroVec, &seg);
+    segLen = PSVECDistance(&zeroVec, &initialSeg);
     segRemain = segLen;
     segCursor = kPppKeShpTail3XZero;
     life = work->m_shapeData;
@@ -355,6 +356,7 @@ update_step:
         return;
     }
 
+advance_segment:
     if (segRemain >= trailStep) {
         pos.x = segDx * (segCursor / segLen) + segBaseX;
         pos.y = segDy * (segCursor / segLen) + segBaseY;
@@ -367,7 +369,6 @@ update_step:
         goto draw_loop;
     }
 
-advance_segment:
     nextIndex++;
     if (nextIndex > 0x1b) {
         nextIndex = 0;
@@ -389,10 +390,13 @@ advance_segment:
     seg.x = segDx;
     seg.y = segDy;
     seg.z = segDz;
+    zeroVec.x = zero;
+    zeroVec.y = zero;
+    zeroVec.z = zero;
     segLen = PSVECDistance(&zeroVec, &seg);
     segCursor = trailLen;
     segRemain += segLen;
-    goto draw_loop;
+    goto advance_segment;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Update KeShpTail2X and KeShpTail3X draw traversal to keep advancing through history segments until enough trail distance is available.
- Use a distinct initial segment vector before the advance loop, matching the source shape indicated by the Tail3X decompilation and improving both sibling draw functions.

## Objdiff evidence
- `main/pppKeShpTail2X` `.text`: 87.91228% -> 87.931175%
- `pppKeShpTail2XDraw`: 80.05122% -> 80.082405%
- `main/pppKeShpTail3X` `.text`: 90.43435% -> 90.59442%
- `pppKeShpTail3XDraw`: 83.785065% -> 84.056404%
- Existing matched symbols stayed matched: `pppKeShpTail2XDes`, `pppKeShpTail2XCon`, `pppKeShpTail2X`, `pppKeShpTail3XDes`, `pppKeShpTail3XCon`, `pppKeShpTail3X`.

## Validation
- `ninja`
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail2X -o /tmp/pppKeShpTail2X_after_initialseg.json`
- `build/tools/objdiff-cli diff -p . -u main/pppKeShpTail3X -o /tmp/pppKeShpTail3X_after_initialseg.json`

## Plausibility
The new loop shape reflects trail traversal behavior: if one stored segment is shorter than the requested trail step, the draw code advances through additional stored segments before interpolating the next draw position. This also follows the Tail3X Ghidra shape, which uses a separate local segment vector for the initial distance and the later advance distance.