### PR TITLE
Inline unused FunnyShape clear stub

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -350,7 +350,7 @@ void CFunnyShape::RenderShape(FS_tagOAN3_SHAPE* shape, Vec2d offset, float angle
  * JP Address: TODO
  * JP Size: TODO
  */
-void CFunnyShape::ClearShapeData()
+inline void CFunnyShape::ClearShapeData()
 {
 }
 


### PR DESCRIPTION
## Summary
- Mark CFunnyShape::ClearShapeData as inline so the unused empty stub is not emitted into FunnyShape.o.
- This follows the project rule for UNUSED functions that cause object/layout regressions.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/FunnyShape -o - shows the rebuilt symbol list no longer emits ClearShapeData__11CFunnyShapeFv; ClearTextureData__11CFunnyShapeFv now follows RenderShape__11CFunnyShapeFP16FS_tagOAN3_SHAPE5Vec2df directly, matching the target symbol ownership.
- Existing matched symbols such as ClearTextureData__11CFunnyShapeFv and ClearAnmData__11CFunnyShapeFv remain 100% matched.

## Plausibility
- The function is already marked PAL Address: UNUSED and has an empty body, so making it inline is consistent with repo guidance for unused functions and avoids emitting a non-target standalone stub.