### PR TITLE
Fix CManager vtable ownership

### DIFF
--- a/include/ffcc/manager.h
+++ b/include/ffcc/manager.h
@@ -3,8 +3,8 @@
 
 class CManager {
 public:
-    virtual void Init() = 0;
-    virtual void Quit() = 0;
+    virtual void Init();
+    virtual void Quit();
 };
 
 #endif // _FFCC_MANAGER_H


### PR DESCRIPTION
## Summary
- Declare CManager virtual hooks without pure-virtual ownership so derived process units reference the single real CManager vtable instead of emitting duplicate weak vtables.
- Removes extra __vt__8CManager data from process objects such as p_sound, p_gba, p_system, p_mc, and p_sample.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- Overall matched data improved from 930,426 to 932,138 bytes (+1,712), with code bytes unchanged.
- Targeted objdiff after the change:
  - p_sound: .text 100%, .data 464/464, 100%
  - p_gba: .text 100%, .data 464/464, 100%
  - p_system: .text 100%, .data 452/452, 100%
  - p_mc: .text 100%, .data 452/452, 100%
  - p_sample: .text 100%, .data 500/500, 100%

## Plausibility
- The PAL symbols contain a single __vt__8CManager owner, while many process units previously emitted extra weak copies from the abstract header declaration. This change makes those units model the original linkage more closely without manual vtable definitions or section forcing.