### PR TITLE
Model caravan letter flags as bitfields

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -96,6 +96,14 @@ public:
             unsigned int m_word1;
             unsigned int m_word2;
         };
+        struct FlagBits {
+            unsigned char m_opened : 1;
+            unsigned char m_attachmentClaimed : 1;
+            unsigned char m_replySent : 1;
+            unsigned char m_hasReply : 1;
+            unsigned char m_attachmentIsGil : 1;
+            unsigned char m_rest : 3;
+        };
 
         unsigned int Word0() const { return m_words.m_word0; }
         void SetWord0(unsigned int word)
@@ -107,29 +115,26 @@ public:
         unsigned int Word2() const { return m_words.m_word2; }
         void SetWord2(unsigned int word) { m_words.m_word2 = word; }
         unsigned char Flags() const { return reinterpret_cast<const unsigned char*>(&m_half.m_header)[0]; }
+        const FlagBits& FlagsBits() const { return *reinterpret_cast<const FlagBits*>(&m_half.m_header); }
+        FlagBits& FlagsBits() { return *reinterpret_cast<FlagBits*>(&m_half.m_header); }
         void SetFlags(unsigned char flags)
         {
             reinterpret_cast<unsigned char*>(&m_half.m_header)[0] = flags;
         }
-        bool IsOpened() const { return static_cast<signed char>(Flags()) < 0; }
+        bool IsOpened() const { return FlagsBits().m_opened != 0; }
         void SetOpened()
         {
-            unsigned char flags = Flags();
-            flags |= 0x80;
-            SetFlags(flags);
+            FlagsBits().m_opened = 1;
         }
-        bool IsAttachmentClaimed() const { return (Flags() & 0x40) != 0; }
-        void SetAttachmentClaimed() { SetFlags((Flags() & 0xBF) | 0x40); }
-        bool IsReplySent() const { return (Flags() & 0x20) != 0; }
+        bool IsAttachmentClaimed() const { return FlagsBits().m_attachmentClaimed != 0; }
+        void SetAttachmentClaimed() { FlagsBits().m_attachmentClaimed = 1; }
+        bool IsReplySent() const { return FlagsBits().m_replySent != 0; }
         void SetReplySent()
         {
-            unsigned char flags = Flags();
-            flags &= ~0x20;
-            flags |= 0x20;
-            SetFlags(flags);
+            FlagsBits().m_replySent = 1;
         }
-        bool HasReply() const { return (Flags() & 0x10) != 0; }
-        bool AttachmentIsGil() const { return Flags() & 8; }
+        bool HasReply() const { return FlagsBits().m_hasReply != 0; }
+        bool AttachmentIsGil() const { return FlagsBits().m_attachmentIsGil != 0; }
         unsigned short HeaderWord() const { return m_half.m_header; }
         unsigned short MessageType() const { return (HeaderWord() >> 2) & 0x1FF; }
         unsigned int SenderId() const { return (Word0() >> 9) & 0x1FF; }


### PR DESCRIPTION
## Summary
- Add a typed bitfield view for CCaravanWork::CLetterWork flag bits.
- Use the bitfield view for opened, attachment-claimed, reply-sent, reply-present, and gil-attachment helpers.
- This produces the target bitfield-style codegen for letter flag updates and improves gobjwork matching.

## Evidence
- Before: main/gobjwork .text 87.76874% in objdiff for FGLetterOpen__12CCaravanWorkFi context.
- After: main/gobjwork .text 87.824196%.
- Full ninja passes; build/GCCP01/main.dol: OK.
- Progress report improved code from 649360 to 649528 matched bytes and functions from 3602 to 3603 matched.

## Plausibility
- The ROM letter header already stores multiple one-bit flags in the high byte.
- Modeling these as bitfields replaces ad hoc masks with source-like flag member access and matches Metrowerks rlwimi-style bitfield assignment.