### PR TITLE
Improve MeteoParasiteC damage handling

### DIFF
--- a/src/monobj_boss.cpp
+++ b/src/monobj_boss.cpp
@@ -1763,19 +1763,19 @@ void CGMonObj::damagedFuncMeteoParasiteC()
 {
 	CGObject* object = reinterpret_cast<CGObject*>(this);
 	unsigned short* script = reinterpret_cast<unsigned short*>(object->m_scriptHandle);
-	int& timer = *reinterpret_cast<int*>(SoundBuffer + 1364);
-	if (script == 0) {
-		return;
-	}
+	MeteoParasiteCBossWork* work = reinterpret_cast<MeteoParasiteCBossWork*>(CGMonObj::m_boss);
 
-	if (script[7] < ((script[0x1A / 2] * 2) / 3)) {
-		timer = 0;
-		reinterpret_cast<CGPrgObj*>(this)->changeStat(0x66, 0, 0);
-		object->m_bgColMask &= 0xFFF7FFFF;
-	} else if (timer > 0x31) {
-		timer = 0;
-		reinterpret_cast<CGPrgObj*>(this)->changeStat(0x67, 0, 0);
-		object->m_bgColMask &= 0xFFF7FFFF;
+	if ((work->m_coreFlags & 0x40) == 0) {
+		if (((work->m_coreIndex == 0) && (script[7] < ((script[0x1A / 2] * 2) / 3))) ||
+		    ((work->m_coreIndex == 1) && (script[7] < (script[0x1A / 2] / 3)))) {
+			work->m_coreWait = 0;
+			reinterpret_cast<CGPrgObj*>(this)->changeStat(0x66, 0, 0);
+			object->m_bgColMask &= 0xFFF7FFFF;
+		} else if (work->m_coreWait > 0x31) {
+			work->m_coreWait = 0;
+			reinterpret_cast<CGPrgObj*>(this)->changeStat(0x67, 0, 0);
+			object->m_bgColMask &= 0xFFF7FFFF;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace the scratch SoundBuffer timer logic in MeteoParasiteC damage handling with the typed boss work fields.
- Add the core flag gate and core-index-specific HP thresholds shown by the decompilation.
- Reset the MeteoParasiteC core wait through boss work before transitioning to states 0x66 or 0x67.

## Evidence
- Build: `ninja`
- Objdiff: `damagedFuncMeteoParasiteC__8CGMonObjFv` improved from 57.450703% to 78.71831%.
- Adjacent target `frameStatFuncMeteoParasiteC__8CGMonObjFv` remains at 19.821428% after reverting a no-gain control-flow experiment.

## Plausibility
This follows the existing `MeteoParasiteCBossWork` layout already used in `monobj_boss.cpp` and removes a scratch-buffer alias in favor of the actual boss work fields at offsets 0x7C, 0x78, and 0x84.