### PR TITLE
Fix ChangeTex reflection TEV bits

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -453,8 +453,9 @@ static void ChangeTex_DrawMeshDLCallback(CChara::CModel* model, void* param_2, v
 	CTexture* texture = work->m_texture;
 
 	if (step->m_changeTex.m_mode == 0) {
-		unsigned int drawTevBits = 0xADE0F;
-		unsigned int fullTevBits = drawTevBits | 0x1000;
+		unsigned int drawTevBits = 0xACE0F;
+		unsigned int fullTevBits = drawTevBits;
+		fullTevBits |= 0x1000;
 		MaterialMan.SetChangeTexReflectionState(
 		    &texture->m_texObj, drawTevBits, fullTevBits);
 	}


### PR DESCRIPTION
## Summary
- Update `ChangeTex_DrawMeshDLCallback` to use the same `0xACE0F` draw TEV bits as `ChangeTex_AfterDrawMeshCallback`.
- Keep the full TEV bits as an explicit OR from the draw bits, matching the neighboring callback source shape.

## Objdiff evidence
- `ninja` passes.
- Global data match improves by 60 bytes: `932138 / 1489282` -> `932198 / 1489282`.
- Game data match improves by 60 bytes: `745072 / 1233824` -> `745132 / 1233824`.
- `main/pppChangeTex` data improves from `100 / 160` to `160 / 160`; `extabindex` goes from `98.333336%` to `100.0%`.
- Global matched code bytes stay unchanged at `647768 / 1855224`.

## Plausibility
The draw callback now uses the same reflection TEV draw mask already present in the after-draw callback. This is a source-level consistency fix to shared ChangeTex reflection state, not a manual section/vtable/RTTI coercion or address hack.

Note: the local fuzzy score for `ChangeTex_DrawMeshDLCallback` shifts slightly because the compiler folds the related full mask differently, but the net data/linkage evidence improves and the constant is more coherent with adjacent source.