### PR TITLE
Improve GbaQueue radar matching

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -197,7 +197,7 @@ private:
     int m_mapNo;                      // 0x0448
     unsigned char m_stageFlags;       // 0x044C
     unsigned char _pad44D[0x26A7];    // 0x044D
-    unsigned char m_mapItemCount;     // 0x2AF4
+    char m_mapItemCount;              // 0x2AF4
     unsigned char _pad2AF5[0x3];      // 0x2AF5
     int m_scrInitEnd;                 // 0x2AF8
     unsigned char m_letterDatFlg;     // 0x2AFC
@@ -215,7 +215,7 @@ private:
     unsigned char m_moneyFlags;       // 0x2CB0
     unsigned char m_favoriteFlags;    // 0x2CB1
     GbaCMakeInfo cmakeInfo[4];        // 0x2CB2
-    unsigned char m_radarType[4];     // 0x2D32
+    char m_radarType[4];              // 0x2D32
     unsigned char m_artifactFlags;    // 0x2D36
     unsigned char m_chgUseItemFlags;  // 0x2D37
     unsigned char m_shopFlags;        // 0x2D38

--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -227,8 +227,8 @@ private:
     unsigned char m_strengthFlags;    // 0x2D3E
     unsigned char m_artiDatFlags;     // 0x2D3F
     unsigned char m_radarTypeFlags;   // 0x2D40
-    unsigned char m_radarMode;        // 0x2D41
-    unsigned char m_chgRadarMode;     // 0x2D42
+    char m_radarMode;                 // 0x2D41
+    char m_chgRadarMode;              // 0x2D42
     unsigned char _pad2D43;           // 0x2D43
     GbaQueueHitInfo m_hitInfo[4];      // 0x2D44
     unsigned char m_chgHitFlags;      // 0x2D54

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1893,35 +1893,41 @@ void GbaQueue::GetTreasurePos(int channel, unsigned int* outData, int* outCount)
 	memcpy(localMapItems, obj + 0x2434, sizeof(localMapItems));
 
 	localEntry = localMapItems;
-	for (i = 0; i < m_mapItemCount; i++) {
-		int localX = static_cast<int>(*reinterpret_cast<short*>(localEntry + 8)) - static_cast<int>(baseX);
-		int localZ = static_cast<int>(*reinterpret_cast<short*>(localEntry + 10)) - static_cast<int>(baseZ);
+	i = 0;
+	while (i < m_mapItemCount) {
+		*reinterpret_cast<short*>(localEntry + 8) =
+			static_cast<short>(*reinterpret_cast<short*>(localEntry + 8) - baseX);
+		*reinterpret_cast<short*>(localEntry + 10) =
+			static_cast<short>(*reinterpret_cast<short*>(localEntry + 10) - baseZ);
 
-		*reinterpret_cast<short*>(localEntry + 8) = static_cast<short>(localX);
-		*reinterpret_cast<short*>(localEntry + 10) = static_cast<short>(localZ);
+		short localX = *reinterpret_cast<short*>(localEntry + 8);
+		short localZ = *reinterpret_cast<short*>(localEntry + 10);
 
 		if ((localX < 0 ? -localX : localX) < 0x50 && (localZ < 0 ? -localZ : localZ) < 0x40) {
 			localEntry[0] = 1;
 		} else {
-			localEntry[8] = -1;
-			localEntry[9] = -1;
-			localEntry[10] = -1;
-			localEntry[11] = -1;
+			*reinterpret_cast<short*>(localEntry + 8) = -1;
+			*reinterpret_cast<short*>(localEntry + 10) = -1;
 			localEntry[0] = 0;
 		}
 
-		if (localEntry[2] == 0 || m_radarType[channel] != 3) {
+		if (localEntry[2] == 0) {
+			localEntry[0] = 0;
+		}
+		if (m_radarType[channel] != 3) {
 			localEntry[0] = 0;
 		}
 
 		localEntry += 0x14;
+		i++;
 	}
 
 	count = 0;
 	localEntry = localMapItems;
 	prevEntry = obj + channel * kGbaQueueMapItemDataBytes + 0x2574;
 	outPtr = reinterpret_cast<unsigned char*>(outData);
-	for (i = 0; i < m_mapItemCount; i++) {
+	i = 0;
+	while (i < m_mapItemCount) {
 		if ((localEntry[0] != 0 || prevEntry[0] != 0) && memcmp(localEntry, prevEntry, 0x14) != 0) {
 			count++;
 			outPtr[0] = 0x21;
@@ -1933,6 +1939,7 @@ void GbaQueue::GetTreasurePos(int channel, unsigned int* outData, int* outCount)
 
 		localEntry += 0x14;
 		prevEntry += 0x14;
+		i++;
 	}
 
 	*outCount = count;

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -4499,7 +4499,8 @@ unsigned int GbaQueue::GetChgRadarMode(int channel)
 void GbaQueue::ClrChgRadarMode(int channel)
 {
 	OSWaitSemaphore(accessSemaphores + channel);
-	m_chgRadarMode = static_cast<unsigned char>(m_chgRadarMode & ~(1U << channel));
+	unsigned char radarMode = m_chgRadarMode;
+	m_chgRadarMode = static_cast<char>(radarMode & ~(1U << channel));
 	OSSignalSemaphore(accessSemaphores + channel);
 }
 


### PR DESCRIPTION
## Summary
- Correct several GbaQueue byte fields to signed char where the PAL code sign-extends them.
- Reshape GetTreasurePos to use stored short coordinate deltas, halfword clearing, and separate visibility/radar checks.
- Preserve byte-mask behavior in ClrChgRadarMode while matching signed mode reads.

## Evidence
- ninja passes.
- GetRadarType__8GbaQueueFi: 79.8% -> 100.0%.
- GetRadarMode__8GbaQueueFi: 96.55173% -> 100.0%.
- GetChgRadarMode__8GbaQueueFi: 96.55173% -> 100.0%.
- SetRadarMode__8GbaQueueFii: 87.875% -> 100.0%.
- GetTreasurePos__8GbaQueueFiPUiPi: 67.66406% -> 77.90625%.

## Plausibility
- The changed fields are one-byte mode/count values that Ghidra and objdiff show being sign-extended in PAL.
- GetTreasurePos now treats stored map item coordinates as shorts instead of manually writing byte lanes.
- No vtable/section/address forcing or fake symbol hacks.