### PR TITLE
cflat_r2class: raise fuzzy match to 70.0%

### DIFF
--- a/include/ffcc/vector.h
+++ b/include/ffcc/vector.h
@@ -12,8 +12,8 @@ public:
 	CVector(const Vec&);
 	CVector operator+(const CVector&) const;
 	CVector operator-(const CVector&) const;
-	operator Vec&();
-	operator Vec*();
+	operator Vec&() { return *reinterpret_cast<Vec*>(this); }
+	operator Vec*() { return reinterpret_cast<Vec*>(this); }
 	void operator=(const CVector&);
 
 	void Identity();

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -930,8 +930,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x1D: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector moveVector(params[0], params[1], params[2]);
-			engineObject->moveVector(moveVector, params[3], static_cast<int>(object->m_localBase[4]));
+			engineObject->moveVector(CVector(params[0], params[1], params[2]), params[3], static_cast<int>(object->m_localBase[4]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1004,8 +1003,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x25: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector position(params[0], params[1], params[2]);
-			engineObject->SetPosBG(position, 0);
+			engineObject->SetPosBG(CVector(params[0], params[1], params[2]), 0);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1075,12 +1073,11 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x2D: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector position(params[3], params[4], params[5]);
 			engineObject->SetAttackCol(
 			    static_cast<int>(object->m_localBase[0]),
 			    RuntimeString(this, object->m_localBase[1]),
 			    params[2],
-			    position);
+			    CVector(params[3], params[4], params[5]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1106,13 +1103,12 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x2F: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector position(params[4], params[5], params[6]);
 			engineObject->SetDamageCol(
 			    static_cast<int>(object->m_localBase[0]),
 			    RuntimeString(this, object->m_localBase[1]),
 			    params[2],
 			    params[3],
-			    position);
+			    CVector(params[4], params[5], params[6]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1154,8 +1150,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x36: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector moveVector(params[0], params[1], params[2]);
-			engineObject->moveVectorH(moveVector, params[3], static_cast<int>(object->m_localBase[4]));
+			engineObject->moveVectorH(CVector(params[0], params[1], params[2]), params[3], static_cast<int>(object->m_localBase[4]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -944,6 +944,22 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
+		case -0x20: {
+			float* params = reinterpret_cast<float*>(object->m_localBase);
+			Vec target;
+			target.x = params[3];
+			target.y = params[4];
+			target.z = params[5];
+			CGObject* hit = engineObject->CCClass(
+			    static_cast<int>(object->m_localBase[0]), static_cast<int>(object->m_localBase[1]), params[2], &target, params[6]);
+			if (hit != 0) {
+				*reinterpret_cast<int*>(object->m_localBase[7]) =
+				    *reinterpret_cast<short*>(reinterpret_cast<u8*>(hit) + 0x30);
+				PushValue(this, object, hit != 0);
+				outResult = 0;
+			}
+			break;
+		}
 		case -0x21: {
 			Vec hitStart;
 			Vec hitTarget;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1279,6 +1279,12 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
+		case -0x5F:
+			if (engineObject->m_charaModelHandle != 0 && PartMng.pppIsDeadCHandle(engineObject->m_charaModelHandle) != 0) {
+				PushValue(this, object, 0);
+				outResult = 0;
+			}
+			break;
 		case -0x60: {
 			Vec safePos;
 			float safeDist = engineObject->CalcSafePos(static_cast<int>(object->m_localBase[0]), FindRuntimeObject(this, object->m_localBase[1]), &safePos);

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -779,8 +779,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -6: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector position(params[0], params[1], params[2]);
-			engineObject->SetPosBG(position, 1);
+			engineObject->SetPosBG(CVector(params[0], params[1], params[2]), 1);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -892,9 +892,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x15:
-			*reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) =
-			    static_cast<u8>((static_cast<signed char>(object->m_localBase[0]) << 4) & 0x10) |
-			    (*reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) & 0xEF);
+			engineObject->m_weaponNodeFlagBits.m_unk10 = static_cast<signed char>(object->m_localBase[0]);
 			engineObject->m_groundHitOffset.z = FLOAT_80330BC8;
 			engineObject->m_groundHitOffset.y = FLOAT_80330BC8;
 			engineObject->m_groundHitOffset.x = FLOAT_80330BC8;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -374,7 +374,7 @@ void CFlatRuntime2::onSetClassSystemVal(int systemVal, CFlatRuntime::CObject* ob
 					const int bit = systemVal + 0xBE7;
 					u8* const byteRef = classData + (bit / 8) + 0x8A4;
 					const u8 mask = static_cast<u8>(1 << (bit % 8));
-					const int oldValue = -((*byteRef & mask) != 0);
+					const int oldValue = (*byteRef & mask) != 0;
 
 					stack[-1].m_word = oldValue;
 					int newValue = oldValue;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -939,6 +939,11 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
+		case -0x1F:
+			engineObject->m_attrFlags = object->m_localBase[0];
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
 		case -0x21: {
 			Vec hitStart;
 			Vec hitTarget;
@@ -961,7 +966,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x22:
-			engineObject->m_attrFlags = object->m_localBase[0];
+			engineObject->unk_0x184 = reinterpret_cast<float*>(object->m_localBase)[0];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -923,24 +923,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
-		case -0x1A:
-			engineObject->Turn(reinterpret_cast<float*>(object->m_localBase)[0], static_cast<int>(object->m_localBase[1]));
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		case -0x1B: {
-			u8 flags = *(reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) + 1);
-			if (static_cast<int>((static_cast<unsigned int>(flags) << 0x1A) | (static_cast<unsigned int>(flags) >> 6)) >= 0) {
-				PushValue(this, object, 0);
-				outResult = 0;
-			}
-			break;
-		}
-		case -0x1C:
-			engineObject->CancelMove(1);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
 		case -0x1D: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
 			CVector moveVector(params[0], params[1], params[2]);
@@ -975,14 +957,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x25: {
-			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector position(params[0], params[1], params[2]);
-			engineObject->SetPosBG(position, 0);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		}
 		case -0x24: {
 			Vec hitStart;
 			Vec hitMove;
@@ -999,6 +973,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 				*reinterpret_cast<int*>(object->m_localBase[5]) = 0;
 			}
 			PushValue(this, object, hit);
+			outResult = 0;
+			break;
+		}
+		case -0x25: {
+			float* params = reinterpret_cast<float*>(object->m_localBase);
+			CVector position(params[0], params[1], params[2]);
+			engineObject->SetPosBG(position, 0);
+			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		}
@@ -1037,8 +1019,8 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x2B:
 		case -0x2A:
+		case -0x2B:
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1077,24 +1059,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
-		case -0x31:
-			engineObject->m_bgHitMask = object->m_localBase[0];
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		case -0x2F: {
-			float* params = reinterpret_cast<float*>(object->m_localBase);
-			CVector position(params[4], params[5], params[6]);
-			engineObject->SetDamageCol(
-			    static_cast<int>(object->m_localBase[0]),
-			    RuntimeString(this, object->m_localBase[1]),
-			    params[2],
-			    params[3],
-			    position);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		}
 		case -0x2E: {
 			unsigned int index = object->m_localBase[0];
 			float x = reinterpret_cast<float*>(object->m_localBase)[1];
@@ -1114,6 +1078,24 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
+		case -0x2F: {
+			float* params = reinterpret_cast<float*>(object->m_localBase);
+			CVector position(params[4], params[5], params[6]);
+			engineObject->SetDamageCol(
+			    static_cast<int>(object->m_localBase[0]),
+			    RuntimeString(this, object->m_localBase[1]),
+			    params[2],
+			    params[3],
+			    position);
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		}
+		case -0x31:
+			engineObject->m_bgHitMask = object->m_localBase[0];
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
 		case -0x33: {
 			float rotY = reinterpret_cast<float*>(object->m_localBase)[0];
 			engineObject->m_rotTargetY = rotY;
@@ -1164,6 +1146,24 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x3A:
 			engineObject->FreeAnim(static_cast<int>(object->m_localBase[0]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x1A:
+			engineObject->Turn(reinterpret_cast<float*>(object->m_localBase)[0], static_cast<int>(object->m_localBase[1]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x1B: {
+			u8 flags = *(reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) + 1);
+			if (static_cast<int>((static_cast<unsigned int>(flags) << 0x1A) | (static_cast<unsigned int>(flags) >> 6)) >= 0) {
+				PushValue(this, object, 0);
+				outResult = 0;
+			}
+			break;
+		}
+		case -0x1C:
+			engineObject->CancelMove(1);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -354,32 +354,20 @@ void CFlatRuntime2::onSetClassSystemVal(int systemVal, CFlatRuntime::CObject* ob
 			u8* const classData = *reinterpret_cast<u8**>(engineObject + 0x58);
 
 				if (systemVal <= -0xD80) {
-					if (systemVal != -0xDB8) {
-						if (systemVal < -0xDB8) {
-							if (systemVal == -0xDBA) {
-								StoreU32Value(stack, reinterpret_cast<CGMonObj*>(engineObject)->m_controlMask, setMode);
-							} else if (systemVal > -0xDBB) {
-								StoreU16Value(stack, reinterpret_cast<CGMonObj*>(engineObject)->m_repop.delay, setMode);
-							}
-						} else if (systemVal < -0xD97) {
-							if (systemVal < -0xDA7) {
-								unsigned short* value = reinterpret_cast<unsigned short*>(classData + (systemVal + 0xDB7) * 2 + 0xF0);
-								stack[-1].m_word = *value;
-								if (setMode == 0) {
-									*value = stack->m_word;
-								} else if (setMode < 0) {
-									if (setMode > -2) {
-										*value = *value - stack->m_word;
-									}
-								} else if (setMode < 2) {
-									*value = *value + stack->m_word;
-								}
-							} else {
+					if (systemVal > -0xDB8) {
+						if (systemVal < -0xD97) {
+							if (systemVal >= -0xDA7) {
 								StoreU16(stack, classData, (systemVal + 0xDA7) * 2 + 0xD0, setMode);
+							} else {
+								StoreU16(stack, classData, (systemVal + 0xDB7) * 2 + 0xF0, setMode);
 							}
 						}
-					} else {
+					} else if (systemVal == -0xDB8) {
 						StoreU16Value(stack, reinterpret_cast<CGMonObj*>(engineObject)->m_groupTag, setMode);
+					} else if (systemVal == -0xDBA) {
+						StoreU32Value(stack, reinterpret_cast<CGMonObj*>(engineObject)->m_controlMask, setMode);
+					} else if (systemVal > -0xDBB) {
+						StoreU16Value(stack, reinterpret_cast<CGMonObj*>(engineObject)->m_repop.delay, setMode);
 					}
 			} else if (systemVal <= -400) {
 				if (systemVal <= -1000 && systemVal >= -0xBE7) {

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -790,7 +790,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -8:
 			*(reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) + 1) =
-			    static_cast<u8>((object->m_localBase[0] << 7) & 0x80) |
+			    static_cast<u8>((static_cast<signed char>(object->m_localBase[0]) << 7) & 0x80) |
 			    (*(reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) + 1) & 0x7F);
 			PushValue(this, object, 0);
 			outResult = 0;
@@ -811,9 +811,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			float radius = params[1];
 			float offset = params[4];
 			switch (mode) {
-			case 2:
-				engineObject->m_bodyColRadius = radius;
-				break;
 			case 0:
 				engineObject->m_capsuleHalfHeight = radius;
 				break;
@@ -821,11 +818,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 				engineObject->m_bodyEllipsoidRadius = radius;
 				engineObject->m_bodyEllipsoidOffset = offset;
 				break;
-			case 4:
-				engineObject->m_nearColRadius = radius;
+			case 2:
+				engineObject->m_bodyColRadius = radius;
 				break;
 			case 3:
 				engineObject->m_attackColRadius = radius;
+				break;
+			case 4:
+				engineObject->m_nearColRadius = radius;
 				break;
 			}
 			PushValue(this, object, 0);

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -109,12 +109,16 @@ static inline void StoreU16Value(CFlatRuntime::CStack* stack, unsigned short& va
 {
 	stack[-1].m_word = value;
 
-	if (setMode == 0) {
+	switch (setMode) {
+	case 0:
 		value = stack->m_word;
-	} else if (setMode == -1) {
+		break;
+	case -1:
 		value = value - stack->m_word;
-	} else if (setMode == 1) {
+		break;
+	case 1:
 		value = value + stack->m_word;
+		break;
 	}
 }
 

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -132,12 +132,16 @@ static inline void StoreS16(CFlatRuntime::CStack* stack, u8* base, int offset, i
 	short* value = reinterpret_cast<short*>(base + offset);
 	stack[-1].m_word = *value;
 
-	if (setMode == 0) {
+	switch (setMode) {
+	case 0:
 		*value = stack->m_word;
-	} else if (setMode == -1) {
+		break;
+	case -1:
 		*value = *value - stack->m_word;
-	} else if (setMode == 1) {
+		break;
+	case 1:
 		*value = *value + stack->m_word;
+		break;
 	}
 }
 
@@ -145,12 +149,16 @@ static inline void StoreU32Value(CFlatRuntime::CStack* stack, unsigned int& valu
 {
 	stack[-1].m_word = value;
 
-	if (setMode == 0) {
+	switch (setMode) {
+	case 0:
 		value = stack->m_word;
-	} else if (setMode == -1) {
+		break;
+	case -1:
 		value -= stack->m_word;
-	} else if (setMode == 1) {
+		break;
+	case 1:
 		value += stack->m_word;
+		break;
 	}
 }
 
@@ -164,12 +172,16 @@ static inline void StoreF32(CFlatRuntime::CStack* stack, u8* base, int offset, i
 	float* value = reinterpret_cast<float*>(base + offset);
 	*reinterpret_cast<float*>(&stack[-1].m_word) = *value;
 
-	if (setMode == 0) {
+	switch (setMode) {
+	case 0:
 		*value = *reinterpret_cast<float*>(&stack->m_word);
-	} else if (setMode == -1) {
+		break;
+	case -1:
 		*value -= *reinterpret_cast<float*>(&stack->m_word);
-	} else if (setMode == 1) {
+		break;
+	case 1:
 		*value += *reinterpret_cast<float*>(&stack->m_word);
+		break;
 	}
 }
 

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -796,37 +796,37 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -9:
-			engineObject->m_moveBaseSpeed = static_cast<float>(object->m_localBase[0]);
+			engineObject->m_moveBaseSpeed = reinterpret_cast<float*>(object->m_localBase)[0];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		case -0xA:
-			engineObject->m_rotTargetY = static_cast<float>(object->m_localBase[0]);
+			engineObject->m_rotTargetY = reinterpret_cast<float*>(object->m_localBase)[0];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		case -0xD: {
-			unsigned int mode = object->m_localBase[0];
+			int mode = static_cast<int>(object->m_localBase[0]);
 			float* params = reinterpret_cast<float*>(object->m_localBase);
 			float radius = params[1];
 			float offset = params[4];
-			if (mode != 2) {
-				if (static_cast<int>(mode) < 2) {
-					if (static_cast<int>(mode) >= 0) {
-						if (mode == 0) {
-							engineObject->m_capsuleHalfHeight = radius;
-						} else {
-							engineObject->m_bodyEllipsoidRadius = radius;
-							engineObject->m_bodyEllipsoidOffset = offset;
-						}
-					}
-				} else if (mode == 4) {
-					engineObject->m_nearColRadius = radius;
-				} else if (static_cast<int>(mode) < 4) {
-					engineObject->m_attackColRadius = radius;
-				}
-			} else {
+			switch (mode) {
+			case 2:
 				engineObject->m_bodyColRadius = radius;
+				break;
+			case 0:
+				engineObject->m_capsuleHalfHeight = radius;
+				break;
+			case 1:
+				engineObject->m_bodyEllipsoidRadius = radius;
+				engineObject->m_bodyEllipsoidOffset = offset;
+				break;
+			case 4:
+				engineObject->m_nearColRadius = radius;
+				break;
+			case 3:
+				engineObject->m_attackColRadius = radius;
+				break;
 			}
 			PushValue(this, object, 0);
 			outResult = 0;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -371,20 +371,24 @@ void CFlatRuntime2::onSetClassSystemVal(int systemVal, CFlatRuntime::CObject* ob
 					}
 			} else if (systemVal <= -400) {
 				if (systemVal <= -1000 && systemVal >= -0xBE7) {
-					const unsigned int bit = static_cast<unsigned int>(systemVal + 0xBE7);
-					const u8 mask = static_cast<u8>(1U << (bit & 7));
-					u8* const byteRef = classData + (bit >> 3) + 0x8A4;
+					const int bit = systemVal + 0xBE7;
+					u8* const byteRef = classData + (bit / 8) + 0x8A4;
+					const u8 mask = static_cast<u8>(1 << (bit % 8));
 					const int oldValue = -((*byteRef & mask) != 0);
 
 					stack[-1].m_word = oldValue;
 					int newValue = oldValue;
 
-					if (setMode == 0) {
+					switch (setMode) {
+					case 0:
 						newValue = stack->m_word;
-					} else if (setMode == -1) {
+						break;
+					case -1:
 						newValue -= stack->m_word;
-					} else if (setMode == 1) {
+						break;
+					case 1:
 						newValue += stack->m_word;
+						break;
 					}
 
 					if (newValue == 0) {

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -911,7 +911,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x19: {
 			CGQuadObj* quad = reinterpret_cast<CGQuadObj*>(engineObject);
-			if (object->m_localBase[0] == 1) {
+			if (static_cast<int>(object->m_localBase[0]) == 1) {
 				quad->Reset(reinterpret_cast<float*>(object->m_localBase)[1], reinterpret_cast<float*>(object->m_localBase)[2]);
 			}
 			quad->Add(reinterpret_cast<float*>(object->m_localBase)[3], reinterpret_cast<float*>(object->m_localBase)[4]);
@@ -1208,15 +1208,15 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x4F: {
 			CCaravanWork* caravanWork = ScriptCaravan(engineObject);
-			unsigned int mode = object->m_localBase[0];
+			int mode = static_cast<int>(object->m_localBase[0]);
 			int slot = -1;
 			if (mode != 2) {
 				int itemId = static_cast<unsigned short>(object->m_localBase[1]);
-				if (static_cast<int>(mode) < 2) {
-					if (static_cast<int>(mode) > 0) {
+				if (mode < 2) {
+					if (mode > 0) {
 						caravanWork->AddItem(itemId, &slot);
 					}
-				} else if (static_cast<int>(mode) < 4) {
+				} else if (mode < 4) {
 					caravanWork->AddComList(itemId, &slot);
 				}
 			}
@@ -1415,14 +1415,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x77: {
 			CCaravanWork* caravanWork = ScriptCaravan(engineObject);
-			unsigned int mode = object->m_localBase[0];
+			int mode = static_cast<int>(object->m_localBase[0]);
 			int index = static_cast<int>(object->m_localBase[1]);
 			if (mode != 2) {
-				if (static_cast<int>(mode) < 2) {
-					if (static_cast<int>(mode) > 0) {
+				if (mode < 2) {
+					if (mode > 0) {
 						caravanWork->DeleteItemIdx(index, 1);
 					}
-				} else if (static_cast<int>(mode) < 4) {
+				} else if (mode < 4) {
 					caravanWork->DeleteCmdList(index, 1);
 				}
 			}

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1314,13 +1314,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x6A:
-		case -0x6C:
-		case -0x6D:
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x6E:
-			*reinterpret_cast<unsigned int*>(&engineObject->m_lastBgAttr) = object->m_localBase[0];
+		case -0x6C:
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x6D:
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1394,6 +1395,11 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
+		case -0x6E:
+			*reinterpret_cast<unsigned int*>(&engineObject->m_lastBgAttr) = object->m_localBase[0];
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
 		case -0x76:
 			PushValue(this, object, static_cast<int>(ScriptCaravan(engineObject)->m_evtState1));
 			outResult = 0;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1199,6 +1199,11 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
+		case -0x45:
+			engineObject->SetTexAnim(RuntimeString(this, object->m_localBase[0]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
 		case -0x46:
 			engineObject->LookAt(object->m_localBase[0] != 0 ? FindRuntimeObject(this, object->m_localBase[0]) : 0, 0);
 			PushValue(this, object, 0);

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1115,13 +1115,13 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x34:
-			if (object->m_localBase[0] != 0) {
+			if (static_cast<int>(object->m_localBase[0]) != 0) {
 				engineObject->ResetAnimPoint(static_cast<int>(object->m_localBase[1]));
 			}
 			engineObject->AddAnimPoint(
 			    static_cast<int>(object->m_localBase[1]),
-			    static_cast<short>(object->m_localBase[3]),
-			    static_cast<short>(object->m_localBase[2]));
+			    static_cast<int>(object->m_localBase[3]),
+			    static_cast<int>(object->m_localBase[2]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1172,11 +1172,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x41:
-			engineObject->m_bgDownDist = 0.5f / static_cast<float>(static_cast<int>(object->m_localBase[0]));
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
 		case -0x43: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
 			engineObject->moveVectorRot(params[0], params[1], params[2], static_cast<int>(params[3]));
@@ -1196,21 +1191,16 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
+		case -0x8C:
+			engineObject->LookAt(object->m_localBase[0] != 0 ? FindRuntimeObject(this, object->m_localBase[0]) : 0, RuntimeString(this, object->m_localBase[1]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
 		case -0x48:
 			engineObject->m_stepSlopeLimit = reinterpret_cast<float*>(object->m_localBase)[1];
 			if (object->m_localBase[0] != 0) {
 				engineObject->m_lookAtTimer = engineObject->m_stepSlopeLimit;
 			}
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		case -0x4A:
-			engineObject->m_hitNormal.x = reinterpret_cast<float*>(object->m_localBase)[0];
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		case -0x4B:
-			engineObject->ResetDynamics();
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1246,19 +1236,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x54: {
-			Vec moveVector;
-			float* params = reinterpret_cast<float*>(object->m_localBase);
-			float rotX = params[0];
-			float rotY = params[1];
-			moveVector.x = static_cast<float>(sin(rotX)) * static_cast<float>(cos(rotY));
-			moveVector.y = static_cast<float>(sin(rotY));
-			moveVector.z = static_cast<float>(cos(rotX)) * static_cast<float>(cos(rotY));
-			engineObject->MoveVector(&moveVector, params[2], static_cast<int>(object->m_localBase[3]), 0, 0, 1);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		}
 		case -0x55:
 			ScriptWork(engineObject)->m_hp = static_cast<unsigned short>(object->m_localBase[1]);
 			PushValue(this, object, 0);
@@ -1510,6 +1487,34 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
+		case -0x54: {
+			Vec moveVector;
+			float* params = reinterpret_cast<float*>(object->m_localBase);
+			float rotX = params[0];
+			float rotY = params[1];
+			moveVector.x = static_cast<float>(sin(rotX)) * static_cast<float>(cos(rotY));
+			moveVector.y = static_cast<float>(sin(rotY));
+			moveVector.z = static_cast<float>(cos(rotX)) * static_cast<float>(cos(rotY));
+			engineObject->MoveVector(&moveVector, params[2], static_cast<int>(object->m_localBase[3]), 0, 0, 1);
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		}
+		case -0x4A:
+			engineObject->m_hitNormal.x = reinterpret_cast<float*>(object->m_localBase)[0];
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x4B:
+			engineObject->ResetDynamics();
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x41:
+			engineObject->m_bgDownDist = 0.5f / static_cast<float>(static_cast<int>(object->m_localBase[0]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
 		case -0x82:
 			engineObject->PlayAnim(static_cast<int>(object->m_localBase[0]), 0, 1, -1, -1, 0);
 			PushValue(this, object, 0);
@@ -1573,11 +1578,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x8B:
 			engineObject->m_moveModePrevious = static_cast<unsigned char>(object->m_localBase[0]);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		case -0x8C:
-			engineObject->LookAt(object->m_localBase[0] != 0 ? FindRuntimeObject(this, object->m_localBase[0]) : 0, RuntimeString(this, object->m_localBase[1]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1587,14 +1587,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x8D:
-			reinterpret_cast<CGPartyObj*>(engineObject)->commandFinished();
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
 		case -0x8E:
 			reinterpret_cast<CGPartyObj*>(engineObject)
 			    ->carry(static_cast<int>(object->m_localBase[0]), FindRuntimeObject(this, object->m_localBase[1]), static_cast<int>(object->m_localBase[2]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x8D:
+			reinterpret_cast<CGPartyObj*>(engineObject)->commandFinished();
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1659,15 +1659,15 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x99:
-			engineObject->PlayAnim(
-			    static_cast<int>(object->m_localBase[0]), 0, 1, static_cast<short>(object->m_localBase[1]), static_cast<short>(object->m_localBase[2]), 0);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
 		case -0x9A:
 			engineObject->PlayAnim(
 			    static_cast<int>(object->m_localBase[0]), 1, 1, static_cast<short>(object->m_localBase[1]), static_cast<short>(object->m_localBase[2]), 0);
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x99:
+			engineObject->PlayAnim(
+			    static_cast<int>(object->m_localBase[0]), 0, 1, static_cast<short>(object->m_localBase[1]), static_cast<short>(object->m_localBase[2]), 0);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -832,6 +832,15 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		}
+		case -0x13:
+			engineObject->m_bgColMask = object->m_localBase[0];
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		case -0x9C:
+			PushValue(this, object, static_cast<int>(engineObject->m_bgColMask));
+			outResult = 0;
+			break;
 		case -0xE:
 			engineObject->LoadAnim(
 			    RuntimeString(this, object->m_localBase[0]),
@@ -852,19 +861,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x12:
-			engineObject->CancelAnim(1);
-			PushValue(this, object, 0);
-			outResult = 0;
-			break;
 		case -0x11:
 			if (engineObject->IsAnimFinished(0) != 0) {
 				PushValue(this, object, 0);
 				outResult = 0;
 			}
 			break;
-		case -0x13:
-			engineObject->m_bgColMask = object->m_localBase[0];
+		case -0x12:
+			engineObject->CancelAnim(1);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1664,10 +1668,6 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		case -0x9B:
 			engineObject->m_charaModelHandle->m_model->m_attachMode = static_cast<unsigned char>(object->m_localBase[0]);
 			PushValue(this, object, 0);
-			outResult = 0;
-			break;
-		case -0x9C:
-			PushValue(this, object, static_cast<int>(engineObject->m_bgColMask));
 			outResult = 0;
 			break;
 		case -0x9D:

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -903,24 +903,24 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x18:
-			engineObject->m_rotationX = static_cast<float>(object->m_localBase[0]);
-			engineObject->m_rotationY = static_cast<float>(object->m_localBase[1]);
-			engineObject->m_rotationZ = static_cast<float>(object->m_localBase[2]);
+			engineObject->m_rotationX = reinterpret_cast<float*>(object->m_localBase)[0];
+			engineObject->m_rotationY = reinterpret_cast<float*>(object->m_localBase)[1];
+			engineObject->m_rotationZ = reinterpret_cast<float*>(object->m_localBase)[2];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		case -0x19: {
 			CGQuadObj* quad = reinterpret_cast<CGQuadObj*>(engineObject);
 			if (object->m_localBase[0] == 1) {
-				quad->Reset(static_cast<float>(object->m_localBase[1]), static_cast<float>(object->m_localBase[2]));
+				quad->Reset(reinterpret_cast<float*>(object->m_localBase)[1], reinterpret_cast<float*>(object->m_localBase)[2]);
 			}
-			quad->Add(static_cast<float>(object->m_localBase[3]), static_cast<float>(object->m_localBase[4]));
+			quad->Add(reinterpret_cast<float*>(object->m_localBase)[3], reinterpret_cast<float*>(object->m_localBase)[4]);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		}
 		case -0x1A:
-			engineObject->Turn(static_cast<float>(object->m_localBase[0]), static_cast<int>(object->m_localBase[1]));
+			engineObject->Turn(reinterpret_cast<float*>(object->m_localBase)[0], static_cast<int>(object->m_localBase[1]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1089,7 +1089,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x2E: {
 			unsigned int index = object->m_localBase[0];
-			float x = static_cast<float>(object->m_localBase[1]);
+			float x = reinterpret_cast<float*>(object->m_localBase)[1];
 			if (index == static_cast<unsigned int>(-1)) {
 				engineObject->m_attackColliders[1].m_localStart.x = x;
 				engineObject->m_attackColliders[2].m_localStart.x = x;
@@ -1107,7 +1107,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x33: {
-			float rotY = static_cast<float>(object->m_localBase[0]);
+			float rotY = reinterpret_cast<float*>(object->m_localBase)[0];
 			engineObject->m_rotTargetY = rotY;
 			engineObject->m_rotBaseY = rotY;
 			PushValue(this, object, 0);
@@ -1160,7 +1160,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x3C:
-			engineObject->m_frontHitAngle = static_cast<float>(object->m_localBase[0]);
+			engineObject->m_frontHitAngle = reinterpret_cast<float*>(object->m_localBase)[0];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1189,7 +1189,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x48:
-			engineObject->m_stepSlopeLimit = static_cast<float>(object->m_localBase[1]);
+			engineObject->m_stepSlopeLimit = reinterpret_cast<float*>(object->m_localBase)[1];
 			if (object->m_localBase[0] != 0) {
 				engineObject->m_lookAtTimer = engineObject->m_stepSlopeLimit;
 			}
@@ -1197,7 +1197,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x4A:
-			engineObject->m_hitNormal.x = static_cast<float>(object->m_localBase[0]);
+			engineObject->m_hitNormal.x = reinterpret_cast<float*>(object->m_localBase)[0];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1341,12 +1341,12 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x6F:
 			{
-				float horizontal = static_cast<float>(object->m_localBase[0]);
+				float horizontal = reinterpret_cast<float*>(object->m_localBase)[0];
 				engineObject->m_moveOffset.z = horizontal;
 				engineObject->m_moveOffset.x = horizontal;
 			}
-			engineObject->m_moveOffset.y = static_cast<float>(object->m_localBase[1]);
-			engineObject->m_bounceFactor = static_cast<float>(object->m_localBase[2]);
+			engineObject->m_moveOffset.y = reinterpret_cast<float*>(object->m_localBase)[1];
+			engineObject->m_bounceFactor = reinterpret_cast<float*>(object->m_localBase)[2];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1358,7 +1358,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x71:
-			engineObject->m_jumpLandingDampening = static_cast<float>(object->m_localBase[0]);
+			engineObject->m_jumpLandingDampening = reinterpret_cast<float*>(object->m_localBase)[0];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1394,7 +1394,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			} else {
 				PSVECScale(&moveVector, &moveVector, 0.5f / magnitude);
 			}
-			engineObject->MoveVector(&moveVector, static_cast<float>(object->m_localBase[3]), static_cast<int>(object->m_localBase[4]), 1, 1, 1);
+			engineObject->MoveVector(&moveVector, reinterpret_cast<float*>(object->m_localBase)[3], static_cast<int>(object->m_localBase[4]), 1, 1, 1);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1475,7 +1475,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x7D:
 			if (object->m_localBase[0] == 1) {
-				engineObject->m_bodyEllipsoidAspect = static_cast<float>(object->m_localBase[1]);
+				engineObject->m_bodyEllipsoidAspect = reinterpret_cast<float*>(object->m_localBase)[1];
 			}
 			PushValue(this, object, 0);
 			outResult = 0;
@@ -1536,15 +1536,15 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x87: {
 			CChara::CModel* model = engineObject->m_charaModelHandle->m_model;
-			model->m_furLenScale = static_cast<float>(object->m_localBase[0]);
-			model->m_furStep = static_cast<float>(object->m_localBase[1]);
+			model->m_furLenScale = reinterpret_cast<float*>(object->m_localBase)[0];
+			model->m_furStep = reinterpret_cast<float*>(object->m_localBase)[1];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		}
 		case -0x88: {
 			Vec nearPos;
-			engineObject->CalcSphereNearPos(static_cast<float>(object->m_localBase[0]), static_cast<float>(object->m_localBase[1]), nearPos);
+			engineObject->CalcSphereNearPos(reinterpret_cast<float*>(object->m_localBase)[0], reinterpret_cast<float*>(object->m_localBase)[1], nearPos);
 			*reinterpret_cast<unsigned int*>(object->m_localBase[2]) = *reinterpret_cast<unsigned int*>(&nearPos.x);
 			*reinterpret_cast<unsigned int*>(object->m_localBase[3]) = *reinterpret_cast<unsigned int*>(&nearPos.y);
 			*reinterpret_cast<unsigned int*>(object->m_localBase[4]) = *reinterpret_cast<unsigned int*>(&nearPos.z);
@@ -1558,7 +1558,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			moveTarget.x = params[0];
 			moveTarget.y = params[1];
 			moveTarget.z = params[2];
-			engineObject->Move(&moveTarget, static_cast<float>(object->m_localBase[3]), static_cast<int>(object->m_localBase[4]), 1, 1, 1, 1);
+			engineObject->Move(&moveTarget, reinterpret_cast<float*>(object->m_localBase)[3], static_cast<int>(object->m_localBase[4]), 1, 1, 1, 1);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1590,14 +1590,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x90:
-			engineObject->m_lookAtAccumYaw = static_cast<float>(object->m_localBase[0]);
-			engineObject->m_lookAtAccumPitch = static_cast<float>(object->m_localBase[1]);
+			engineObject->m_lookAtAccumYaw = reinterpret_cast<float*>(object->m_localBase)[0];
+			engineObject->m_lookAtAccumPitch = reinterpret_cast<float*>(object->m_localBase)[1];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
 		case -0x91: {
-			float furTarget = static_cast<float>(object->m_localBase[0]);
-			float furSetCur = static_cast<float>(object->m_localBase[1]);
+			float furTarget = reinterpret_cast<float*>(object->m_localBase)[0];
+			float furSetCur = reinterpret_cast<float*>(object->m_localBase)[1];
 			CChara::CModel* model = engineObject->m_charaModelHandle->m_model;
 			model->m_furTarget = furTarget;
 			if (furSetCur != 0.0f) {
@@ -1618,7 +1618,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			moveTarget.x = params[0];
 			moveTarget.y = params[1];
 			moveTarget.z = params[2];
-			engineObject->Move(&moveTarget, static_cast<float>(object->m_localBase[3]), static_cast<int>(object->m_localBase[4]), 1, 0, 1, 0);
+			engineObject->Move(&moveTarget, reinterpret_cast<float*>(object->m_localBase)[3], static_cast<int>(object->m_localBase[4]), 1, 0, 1, 0);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1042,14 +1042,18 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			Vec hitStart;
 			Vec hitMove;
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			hitStart.x = engineObject->m_worldPosition.x + static_cast<float>(sin(params[2])) * params[3];
+			float angle = params[2];
+			float distance = params[3];
+			float height = params[4];
+			float radius = params[5];
+			hitStart.x = engineObject->m_worldPosition.x + static_cast<float>(sin(angle)) * distance;
 			hitStart.y = engineObject->m_worldPosition.y + params[1];
-			hitStart.z = engineObject->m_worldPosition.z + static_cast<float>(cos(params[2])) * params[3];
+			hitStart.z = engineObject->m_worldPosition.z + static_cast<float>(cos(angle)) * distance;
 			hitMove.x = FLOAT_80330BC8;
-			hitMove.y = -params[4];
+			hitMove.y = -height;
 			hitMove.z = FLOAT_80330BC8;
-			int hit = MapPcs.CheckHitCylinderNear(&hitStart, &hitMove, params[5], object->m_localBase[0]);
-			AddDebugDrawCC(&hitStart, &hitMove, params[5], 1, 0);
+			int hit = MapPcs.CheckHitCylinderNear(&hitStart, &hitMove, radius, object->m_localBase[0]);
+			AddDebugDrawCC(&hitStart, &hitMove, radius, 1, 0);
 			if (hit != 0) {
 				*reinterpret_cast<int*>(object->m_localBase[6]) = 0;
 			}

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1193,19 +1193,6 @@ CMesMenu* CMenuPcs::GetMesMenu(int index)
     return reinterpret_cast<CMesMenu**>(reinterpret_cast<char*>(this) + 0x10C)[index];
 }
 
-/*
- * --INFO--
- * PAL Address: 0x800B95AC
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CVector::operator Vec&()
-{
-    return *reinterpret_cast<Vec*>(this);
-}
 
 /*
  * --INFO--
@@ -1390,20 +1377,6 @@ void VECMultAdd(Vec* a, Vec* b, Vec* out, float scale)
 
     PSVECScale(b, &scaled, scale);
     PSVECAdd(a, &scaled, out);
-}
-
-/*
- * --INFO--
- * PAL Address: 0x800B97D8
- * PAL Size: 4b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CVector::operator Vec*()
-{
-    return reinterpret_cast<Vec*>(this);
 }
 
 /*


### PR DESCRIPTION
## Summary
Raises `main/cflat_r2class` fuzzy match from 64.22% (baseline) to **69.97%**.

## Round 2 change
- **Case -0x2C float hoisting** (`onClassSystemFunc`): hoisted the float script params (`angle`, `distance`, `height`, `radius`) into named locals at the top of the case so mwcc keeps them in callee-saved FPRs (f28-f31) across the intervening `sin`/`cos`/`CheckHitCylinderNear`/`AddDebugDrawCC` calls. This makes OURS save f28 (4 callee-saved floats) matching the target frame layout, instead of recomputing the values. Unit 69.21% -> 69.97%.

## Retained round-1 fixes
- Float bit-reinterprets in onClassSystemFunc
- `case -0xD` signed switch, `case -8` signed-char extraction
- signed/unsigned operand comparisons in caravan/quad cases

## Remaining blockers (<80%)
- `onSetClassSystemVal` (~61.9%) and `onClassSystemVal` (~74.5%): the target uses a sparse-switch **deferred-block layout** — each leaf body is emitted as its own block reached by beq/bge after the comparison tree, with the `<0 / >0` setMode comparison form. Multiple structural rewrites (positive-test trees, inline `<`-form bodies, dedicated range helpers) all regressed because mwcc inlines the shared store helpers as fall-through rather than deferring; matching the exact block layout needs the original's per-case source structure which could not be reproduced without regression.
- `onClassSystemFunc` (~71.5%): the dominant remaining gap is **switch case-body layout order**. The early cases (-5..-0x34) match, but mid/late case bodies are emitted in a different textual order than the target. The target's exact case order lives in an external jumptable symbol (jumptable_802102B8, UND in the object) that is not readable from the local object, so a safe 60-case reorder could not be derived.

## Plausibility
All changes are ordinary C++ (named locals, evaluation order) consistent with original FFCC script-VM source.