### PR TITLE
menu_favo: raise fuzzy match to 86.6%

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -545,7 +545,7 @@ void CMenuPcs::FavoInit()
 	int sVar9;
 	int sVar10;
 	unsigned short sVar11;
-	int iVar16;
+	unsigned int iVar16;
 	int iVar17;
 
 	CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
@@ -696,7 +696,7 @@ void CMenuPcs::FavoInit()
 		for (iVar16 = iVar17; iVar16 < 8; iVar16++) {
 			if (rank->score < compareRank->score) {
 				signed char place = rank->place;
-				unsigned char foodId = rank->foodId;
+				signed char foodId = rank->foodId;
 				short score = rank->score;
 
 				rank->place = compareRank->place;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -545,7 +545,7 @@ void CMenuPcs::FavoInit()
 	float fVar7;
 	short sVar9;
 	short sVar10;
-	short sVar11;
+	unsigned short sVar11;
 	int iVar16;
 	int iVar17;
 

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -48,7 +48,7 @@ void CMenuPcs::FavoDraw()
 	MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
 	FavoEntry* entry = m_favoList->entries;
-	for (int i = 0; i < m_favoList->count; i++) {
+	for (unsigned int i = 0; i < m_favoList->count; i++) {
 		if (entry->tex >= 0) {
 			float x = static_cast<float>(entry->x);
 			float y = static_cast<float>(entry->y);
@@ -86,7 +86,7 @@ void CMenuPcs::FavoDraw()
 						int yStep = static_cast<int>(y);
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {
-							int tileH = static_cast<int>(end - static_cast<float>(yStep));
+							int tileH = static_cast<unsigned int>(end - static_cast<float>(yStep));
 							if (static_cast<float>(tileH) > 32.0f) {
 								tileH = 0x20;
 							}

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -48,7 +48,7 @@ void CMenuPcs::FavoDraw()
 	MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
 	FavoEntry* entry = m_favoList->entries;
-	for (int i = 0; i < m_favoList->count; i++) {
+	for (unsigned int i = 0; i < m_favoList->count; i++) {
 		if (entry->tex >= 0) {
 			float x = static_cast<float>(entry->x);
 			float y = static_cast<float>(entry->y);
@@ -119,7 +119,7 @@ void CMenuPcs::FavoDraw()
 						int yStep = static_cast<int>(y);
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {
-							int tileH = static_cast<int>(end - static_cast<float>(yStep));
+							int tileH = static_cast<unsigned int>(end - static_cast<float>(yStep));
 							if (static_cast<float>(tileH) > 32.0f) {
 								tileH = 0x20;
 							}
@@ -173,7 +173,7 @@ void CMenuPcs::FavoDraw()
 
 	rank = s_rank;
 	drawEntry = rankEntry;
-	for (int i = 0; i < 8; i++) {
+	for (unsigned int i = 0; i < 8; i++) {
 		int iconX = drawEntry->x + drawEntry->w - 0x10;
 		int iconY = static_cast<int>((static_cast<float>(drawEntry->h) - 32.0f) * 0.5 +
 		                             static_cast<float>(drawEntry->y));

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -57,11 +57,11 @@ void CMenuPcs::FavoDraw()
 			float u = entry->u;
 			float v = entry->v;
 
+			GXColor colors[4];
 			if (i < 3) {
 				MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(1));
 				MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(entry->tex));
 
-				GXColor colors[4];
 				colors[0].r = 0xFF;
 				colors[0].g = 0xFF;
 				colors[0].b = 0xFF;
@@ -137,12 +137,11 @@ void CMenuPcs::FavoDraw()
 				MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 			} else {
 				MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(entry->tex));
-				GXColor color;
-				color.r = 0xFF;
-				color.g = 0xFF;
-				color.b = 0xFF;
-				color.a = static_cast<unsigned char>(entry->alpha * 255.0f);
-				GXSetChanMatColor(GX_COLOR0A0, color);
+				colors[0].r = 0xFF;
+				colors[0].g = 0xFF;
+				colors[0].b = 0xFF;
+				colors[0].a = static_cast<unsigned char>(entry->alpha * 255.0f);
+				GXSetChanMatColor(GX_COLOR0A0, colors[0]);
 				MenuPcs.DrawRect(0, x, y, w, h, u, v, entry->uvScale, entry->uvScale, 0.0f);
 			}
 		}

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -650,8 +650,7 @@ void CMenuPcs::FavoInit()
 	setupEntry->duration = 5;
 
 	FavoEntry* firstEntry = m_favoList->entries;
-	iVar17 = 4;
-	do {
+	for (iVar17 = 0; iVar17 < 4; iVar17++) {
 		setupEntry = &m_favoList->entries[entryIndex++];
 		setupEntry->flags = 2;
 		setupEntry->tex = 0x37;
@@ -678,8 +677,7 @@ void CMenuPcs::FavoInit()
 		setupEntry->v = fVar4;
 		setupEntry->startFrame = 7;
 		setupEntry->duration = 5;
-		iVar17 = iVar17 - 1;
-	} while (iVar17 != 0);
+	}
 
 	m_favoList->count = sVar11;
 

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -220,9 +220,11 @@ void CMenuPcs::FavoDraw()
 	for (int i = 0; i < 8; i++) {
 		nameFont->SetColor(
 		    CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * drawEntry->alpha)).color);
+		float posX = static_cast<float>(drawEntry->x + 0x1C);
 		const char* name = Game.m_cFlatDataArr[1].TableStrings(0)[(static_cast<char>(rank->foodId) + 0x17D) * 5 + 4];
-		nameFont->SetPosX(static_cast<float>(drawEntry->x + 0x1C));
-		nameFont->SetPosY(static_cast<float>(drawEntry->y + 0xB) - 4.0f);
+		float posY = static_cast<float>(drawEntry->y + 0xB) - 4.0f;
+		nameFont->SetPosX(posX);
+		nameFont->SetPosY(posY);
 		nameFont->Draw(const_cast<char*>(name));
 		rank++;
 		drawEntry++;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -542,7 +542,6 @@ void CMenuPcs::FavoInit()
 {
 	float fVar4;
 	float fVar5;
-	float fVar7;
 	int sVar9;
 	int sVar10;
 	unsigned short sVar11;
@@ -610,7 +609,6 @@ void CMenuPcs::FavoInit()
 	setupEntry->duration = 5;
 
 	sVar9 = 0;
-	fVar7 = kFavoIconUvScale;
 	sVar11 = 6;
 	list = this->m_favoList;
 	setupEntry = &list->entries[entryIndex++];
@@ -634,7 +632,7 @@ void CMenuPcs::FavoInit()
 	setupEntry->y = static_cast<short>(0x150 - setupEntry->h);
 	setupEntry->u = fVar4;
 	setupEntry->v = fVar4;
-	setupEntry->uvScale = fVar7;
+	setupEntry->uvScale = kFavoIconUvScale;
 	setupEntry->startFrame = 0;
 	setupEntry->duration = 5;
 
@@ -696,26 +694,22 @@ void CMenuPcs::FavoInit()
 	FoodRank* rank = ranks;
 	do {
 		iVar17 = rankIndex + 1;
-		iVar16 = 8 - iVar17;
 		FoodRank* compareRank = ranks + iVar17;
-		if (iVar17 < 8) {
-			do {
-				if (rank->score < compareRank->score) {
-					signed char place = rank->place;
-					unsigned char foodId = rank->foodId;
-					short score = rank->score;
+		for (iVar16 = iVar17; iVar16 < 8; iVar16++) {
+			if (rank->score < compareRank->score) {
+				signed char place = rank->place;
+				unsigned char foodId = rank->foodId;
+				short score = rank->score;
 
-					rank->place = compareRank->place;
-					rank->foodId = compareRank->foodId;
-					rank->score = compareRank->score;
+				rank->place = compareRank->place;
+				rank->foodId = compareRank->foodId;
+				rank->score = compareRank->score;
 
-					compareRank->place = place;
-					compareRank->foodId = foodId;
-					compareRank->score = score;
-				}
-				compareRank++;
-				iVar16--;
-			} while (iVar16 != 0);
+				compareRank->place = place;
+				compareRank->foodId = foodId;
+				compareRank->score = score;
+			}
+			compareRank++;
 		}
 		rankIndex++;
 		rank++;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -195,11 +195,13 @@ void CMenuPcs::FavoDraw()
 		rankFont->SetTlut(6);
 		rankFont->SetColor(
 		    CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * drawEntry->alpha)).color);
+		float posX = static_cast<float>(drawEntry->x - 0xC);
+		float posY = static_cast<float>(drawEntry->y + 0xA) - 4.0f;
 		rankFont->renderFlags = (rankFont->renderFlags & 0xEF) | 0x10;
 		rankFont->SetMargin(1.0f);
 		sprintf(textBuf, sFavoRankFormat, static_cast<int>(rank->place));
-		rankFont->SetPosX(static_cast<float>(drawEntry->x - 0xC));
-		rankFont->SetPosY(static_cast<float>(drawEntry->y + 0xA) - 4.0f);
+		rankFont->SetPosX(posX);
+		rankFont->SetPosY(posY);
 		rankFont->Draw(textBuf);
 		rankFont->SetShadow(0);
 		rank++;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -543,8 +543,8 @@ void CMenuPcs::FavoInit()
 	float fVar4;
 	float fVar5;
 	float fVar7;
-	short sVar9;
-	short sVar10;
+	int sVar9;
+	int sVar10;
 	unsigned short sVar11;
 	int iVar16;
 	int iVar17;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -160,8 +160,8 @@ void CMenuPcs::FavoDraw()
 		remaining--;
 	}
 
-	FoodRank* rank = s_rank;
 	FavoEntry* drawEntry = rankEntry;
+	FoodRank* rank = s_rank;
 	for (int i = 0; i < 8; i++) {
 		int barX = drawEntry->x + drawEntry->w + 0x18;
 		int barY = static_cast<int>((static_cast<float>(drawEntry->h) - 24.0f) * 0.5 +

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -48,7 +48,7 @@ void CMenuPcs::FavoDraw()
 	MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
 	FavoEntry* entry = m_favoList->entries;
-	for (unsigned int i = 0; i < m_favoList->count; i++) {
+	for (int i = 0; i < m_favoList->count; i++) {
 		if (entry->tex >= 0) {
 			float x = static_cast<float>(entry->x);
 			float y = static_cast<float>(entry->y);


### PR DESCRIPTION
Raises main/menu_favo fuzzy match from 83.94% to 86.56%.

## What changed (all in src/menu_favo.cpp)
- **FavoDraw**: reuse colors[0] for the single-color (non-textured) draw path instead of a separate GXColor local — removes a 16-byte stack slot so the frame size matches the original (0x130).
- **FavoDraw**: front-load the rank-text and name-text loops' position values (posX / posY / name lookup) into locals before the SetColor/renderFlags/sprintf sequence, matching the original's "evaluate args up front, then call" shape (recipe R5). Removed several INSERT/DELETE runs around SetPosX/SetPosY.
- **FavoDraw**: reorder drawEntry/rank pointer declarations in the bar loop to match the original's register coloring.
- **FavoInit**: sVar9/sVar10 changed from short to int (drops spurious extsh on the y-offset accumulators); sVar11 to unsigned short (permute-validated).
- **FavoDraw**: signedness of the loop counter and tileH (permute-validated).

## Per-function match (before -> after)
- FavoDraw: 76.66% -> 81.49%
- FavoInit: 79.13% -> 81.30%
- FavoInit0: 87.92% (unchanged)
- FavoCtrl: 99.25%, FavoOpen: 99.91%, FavoClose: 99.95% (unchanged)

## Remaining blocker
FavoDraw and FavoInit are now dominated by a uniform +1 callee-saved register shift (this lands in r31 vs the original's r30; FavoInit saves one extra GPR r23 vs r24) and by mwcc not emitting CTR (`bdnz`) counted loops where the original does. Neither responded to declaration-order, comma-for, literal-index, or counted-loop source rewrites — they appear to be register-allocation/loop-opt decisions not reachable from source form with these flags. The near-100% functions' residual diffs are pure register naming and float-pool (`@NNN@sda21`) numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)