### PR TITLE
ringmenu: raise fuzzy match to 76.4%

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -607,7 +607,10 @@ void CRingMenu::onDraw()
 				font->SetTlut(4);
 
 				float scroll = m_spinAccumulator;
-				while (scroll >= kRingMenuOne) {
+				for (;;) {
+					if (!(scroll >= kRingMenuOne)) {
+						break;
+					}
 					if (Game.m_gameWork.m_bossArtifactStageIndex == 0x19) {
 						cmdIndex = (cmdIndex + 1) % 5;
 					} else {
@@ -615,7 +618,10 @@ void CRingMenu::onDraw()
 					}
 					scroll -= kRingMenuOne;
 				}
-				while (scroll < kRingMenuNegativeOne) {
+				for (;;) {
+					if (!(scroll < kRingMenuNegativeOne)) {
+						break;
+					}
 					if (Game.m_gameWork.m_bossArtifactStageIndex == 0x19) {
 						cmdIndex = (cmdIndex + 4) % 5;
 					} else {


### PR DESCRIPTION
Raises main/ringmenu fuzzy match from 76.18% to 76.42%.

## Change
onDraw's two command-spin loops (`while (scroll >= One)` / `while (scroll < NegativeOne)`) were rotated by mwcc into bottom-test loops, which created a preheader where the `% 5` magic constant (`0x66666667`) got hoisted (LICM) into a callee-saved register and held across every iteration. The original keeps that magic recomputed inside each loop body.

Rewriting the loops in top-test form (`for (;;) { if (!cond) break; ... }`) reproduces the original's loop structure: the condition stays at the top with an unconditional back-edge, and mwcc no longer hoists the divide-magic. The per-iteration `0x6666/0x6667/mulhw` sequence now matches the target inline.

## Result
- onDraw: 64.73% -> 65.33%
- Unit main/ringmenu: 76.18% -> 76.42%

## Remaining blocker
The dominant remaining diffs across onDraw, drawGBA (off-by-1 FPR), and drawCommand (uniform off-by-2 GPR/FPR window) are callee-saved register-allocation window shifts: the target keeps more float/pointer values simultaneously live, giving a larger stack frame (e.g. onDraw 0x200 vs 0x1f0) and a shifted FPR start. These cascade into hundreds of ARG_MISMATCH register-number differences. Attempts to force higher liveness via ternaries / separate result vars regressed locally; cracking them cleanly needs a structural rewrite that raises peak float liveness without resorting to compiler-coaxing hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)