### PR TITLE
menu_letter: raise fuzzy match to 76.8%

### DIFF
--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2179,13 +2179,13 @@ int CMenuPcs::LetterCtrlCur()
 			if ((letter->AttachmentValue() != 0) && !letter->IsAttachmentClaimed()) {
 				*reinterpret_cast<u8*>(GetLetterStateBase(this) + 8) = 1;
 				*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) = 5;
-				if (!letter->AttachmentIsGil()) {
-					if (caravanWork->m_inventoryItemCount + 1 < 0x41) {
+				if (letter->AttachmentIsGil()) {
+					int canAdd = caravanWork->CanAddGil(letter->AttachmentValue() * 100);
+					if (canAdd != 0) {
 						*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) |= 2;
 					}
 				} else {
-					int canAdd = caravanWork->CanAddGil(letter->AttachmentValue() * 100);
-					if (canAdd != 0) {
+					if (caravanWork->m_inventoryItemCount + 1 < 0x41) {
 						*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) |= 2;
 					}
 				}

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2184,7 +2184,7 @@ int CMenuPcs::LetterCtrlCur()
 						*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) |= 2;
 					}
 				} else {
-					if (caravanWork->m_inventoryItemCount + 1 < 0x41) {
+					if (caravanWork->m_inventoryItemCount + 1 <= 0x40) {
 						*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) |= 2;
 					}
 				}

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2175,12 +2175,11 @@ int CMenuPcs::LetterCtrlCur()
 
 	if (menuMode == 1) {
 		if ((press & 0x100) != 0) {
-			CCaravanWork::CLetterWork* letter = &caravanWork->m_letters[s_SelLetter];
-			if ((letter->AttachmentValue() != 0) && !letter->IsAttachmentClaimed()) {
+			if ((caravanWork->m_letters[s_SelLetter].AttachmentValue() != 0) && !caravanWork->m_letters[s_SelLetter].IsAttachmentClaimed()) {
 				*reinterpret_cast<u8*>(GetLetterStateBase(this) + 8) = 1;
 				*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) = 5;
-				if (letter->AttachmentIsGil()) {
-					int canAdd = caravanWork->CanAddGil(letter->AttachmentValue() * 100);
+				if (caravanWork->m_letters[s_SelLetter].AttachmentIsGil()) {
+					int canAdd = caravanWork->CanAddGil(caravanWork->m_letters[s_SelLetter].AttachmentValue() * 100);
 					if (canAdd != 0) {
 						*reinterpret_cast<u8*>(GetLetterStateBase(this) + 9) |= 2;
 					}
@@ -2195,8 +2194,8 @@ int CMenuPcs::LetterCtrlCur()
 			}
 
 			if ((CFlatLetterEventEnabled() != 0) &&
-			    letter->HasReply() &&
-			    !letter->IsReplySent()) {
+			    caravanWork->m_letters[s_SelLetter].HasReply() &&
+			    !caravanWork->m_letters[s_SelLetter].IsReplySent()) {
 				*reinterpret_cast<u8*>(GetLetterStateBase(this) + 8) = 2;
 				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x12) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x12) + 1;
 				Sound.PlaySe(2, 0x40, 0x7F, 0);

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2092,29 +2092,29 @@ int CMenuPcs::LetterCtrlCur()
 			return 0;
 		}
 
-		if ((hold & 8) == 0) {
-			if ((hold & 4) != 0) {
-				int cursor = static_cast<int>(*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26));
-				if ((cursor < 8) && (cursor < letterCount - 1)) {
-					*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) + 1;
-					Sound.PlaySe(1, 0x40, 0x7F, 0);
-				} else if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) + cursor < letterCount - 1) {
-					*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) + 1;
-					Sound.PlaySe(1, 0x40, 0x7F, 0);
-				} else {
+		if ((hold & 8) != 0) {
+			if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) == 0) {
+				if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) == 0) {
 					Sound.PlaySe(4, 0x40, 0x7F, 0);
+				} else {
+					*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) - 1;
+					Sound.PlaySe(1, 0x40, 0x7F, 0);
 				}
-			}
-		} else if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) == 0) {
-			if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) == 0) {
-				Sound.PlaySe(4, 0x40, 0x7F, 0);
 			} else {
-				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) - 1;
+				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) - 1;
 				Sound.PlaySe(1, 0x40, 0x7F, 0);
 			}
-		} else {
-			*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) - 1;
-			Sound.PlaySe(1, 0x40, 0x7F, 0);
+		} else if ((hold & 4) != 0) {
+			int cursor = static_cast<int>(*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26));
+			if ((cursor < 8) && (cursor < letterCount - 1)) {
+				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) + 1;
+				Sound.PlaySe(1, 0x40, 0x7F, 0);
+			} else if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) + cursor < letterCount - 1) {
+				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) + 1;
+				Sound.PlaySe(1, 0x40, 0x7F, 0);
+			} else {
+				Sound.PlaySe(4, 0x40, 0x7F, 0);
+			}
 		}
 
 		if ((hold & 0xC) != 0) {


### PR DESCRIPTION
Raises `main/menu_letter` from 76.45% to 76.82% via source-level structural fixes in `LetterCtrlCur` (68.41% -> 70.11%).

## Changes
- **Invert cursor hold-direction block order**: emit the `hold & 8` (decrement) branch before `hold & 4` (increment) to match the target's basic-block emission order (R9).
- **Swap AttachmentIsGil branch order**: put the gil/`CanAddGil` path first and the inventory-count path in the `else`, matching the original's block order.
- **Inline `m_letters[s_SelLetter]` access**: stop caching the `CLetterWork*` pointer in a local so the address is recomputed at each access, matching the original's codegen.
- **Use `<= 0x40` inventory check**: matches the target's `cmpwi 0x40 / bgt` compare form instead of `cmpwi 0x41 / bge`.

## Remaining blockers
The three largest functions are dominated by interlocked callee-saved register-allocation differences that resist single-source-change fixes:
- `LetterLstBaseDraw` (66.8%): target saves f18-f31 vs ours f20-f31; needs 2 more callee-saved FPRs promoted, but constant-hoisting and liveness tweaks were CSE'd back.
- `LetterCtrl` (68.7%): `this`/`done` are swapped between r30/r31 vs the target; declaration reordering and panelCount signedness changes shifted coloring without net gain.
- `LetterOpen` (79.7%) and `LetterConfirmOpen` (88.4%): panel-init loop is emitted via indexed addressing / mtctr in the target vs our do-while pointer walk; switch-case dispatch tree differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)