### PR TITLE
cflat_r2system: raise fuzzy match to 81.9%

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4229,7 +4229,10 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x46:
         case -0x45:
         case -0x44:
-            FlatLastResult(this) = gameWork.m_wmBackupParams[systemValue + 0x47];
+            {
+                int index = systemValue + 0x47;
+                FlatLastResult(this) = gameWork.m_wmBackupParams[index];
+            }
             break;
         case -0x56:
         case -0x55:
@@ -4246,7 +4249,10 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x4A:
         case -0x49:
         case -0x48:
-            FlatLastResult(this) = gameWork.m_bossArtifactStageTable[systemValue + 0x56];
+            {
+                int index = systemValue + 0x56;
+                FlatLastResult(this) = gameWork.m_bossArtifactStageTable[index];
+            }
             break;
         case -0x65:
         case -100:
@@ -4263,7 +4269,10 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x59:
         case -0x58:
         case -0x57:
-            FlatLastResult(this) = gameWork.m_unkStageTable[systemValue + 0x65];
+            {
+                int index = systemValue + 0x65;
+                FlatLastResult(this) = gameWork.m_unkStageTable[index];
+            }
             break;
         case -0x66:
             FlatLastResult(this) = gameWork.m_chaliceElement;
@@ -4273,7 +4282,10 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x69:
         case -0x68:
         case -0x67:
-            FlatLastResult(this) = gameWork.m_eventHeader[systemValue + 0x6B];
+            {
+                int index = systemValue + 0x6B;
+                FlatLastResult(this) = gameWork.m_eventHeader[index];
+            }
             break;
         case -0x73:
         case -0x72:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4548,17 +4548,17 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 break;
             }
             case -0x75:
-                stack[-1].m_word = static_cast<int>(gameWork.m_bossArtifactStageIndex);
+                stack[-1].m_word = static_cast<int>(Game.m_gameWork.m_bossArtifactStageIndex);
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_bossArtifactStageIndex =
-                            static_cast<short>(gameWork.m_bossArtifactStageIndex - stack->m_word);
+                        Game.m_gameWork.m_bossArtifactStageIndex =
+                            static_cast<short>(Game.m_gameWork.m_bossArtifactStageIndex - stack->m_word);
                     }
                 } else if (setMode == 0) {
-                    gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
+                    Game.m_gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
                 } else if (setMode < 2) {
-                    gameWork.m_bossArtifactStageIndex =
-                        static_cast<short>(gameWork.m_bossArtifactStageIndex + stack->m_word);
+                    Game.m_gameWork.m_bossArtifactStageIndex =
+                        static_cast<short>(Game.m_gameWork.m_bossArtifactStageIndex + stack->m_word);
                 }
                 break;
             case -0x76: {
@@ -4577,31 +4577,31 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 break;
             }
             case -0x77:
-                stack[-1].m_word = static_cast<unsigned int>(gameWork.m_soundOptionFlag);
+                stack[-1].m_word = static_cast<unsigned int>(Game.m_gameWork.m_soundOptionFlag);
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_soundOptionFlag =
-                            static_cast<unsigned char>(gameWork.m_soundOptionFlag - stack->m_word);
+                        Game.m_gameWork.m_soundOptionFlag =
+                            static_cast<unsigned char>(Game.m_gameWork.m_soundOptionFlag - stack->m_word);
                     }
                 } else if (setMode == 0) {
-                    gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
+                    Game.m_gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
                 } else if (setMode < 2) {
-                    gameWork.m_soundOptionFlag =
-                        static_cast<unsigned char>(gameWork.m_soundOptionFlag + stack->m_word);
+                    Game.m_gameWork.m_soundOptionFlag =
+                        static_cast<unsigned char>(Game.m_gameWork.m_soundOptionFlag + stack->m_word);
                 }
                 break;
             case -0x79:
-                stack[-1].m_word = static_cast<int>(static_cast<short>(gameWork.m_optionValue));
+                stack[-1].m_word = static_cast<int>(static_cast<short>(Game.m_gameWork.m_optionValue));
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        gameWork.m_optionValue =
-                            static_cast<unsigned short>(gameWork.m_optionValue - stack->m_word);
+                        Game.m_gameWork.m_optionValue =
+                            static_cast<unsigned short>(Game.m_gameWork.m_optionValue - stack->m_word);
                     }
                 } else if (setMode == 0) {
-                    gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
+                    Game.m_gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
                 } else if (setMode < 2) {
-                    gameWork.m_optionValue =
-                        static_cast<unsigned short>(gameWork.m_optionValue + stack->m_word);
+                    Game.m_gameWork.m_optionValue =
+                        static_cast<unsigned short>(Game.m_gameWork.m_optionValue + stack->m_word);
                 }
                 break;
             default:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4373,12 +4373,12 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             stack[-1].m_word = *artifact;
             if (setMode < 0) {
                 if (setMode >= -1) {
-                    *artifact = static_cast<short>(*artifact - static_cast<short>(stack->m_word));
+                    *artifact = static_cast<short>(*artifact - stack->m_word);
                 }
             } else if (setMode == 0) {
                 *artifact = static_cast<short>(stack->m_word);
             } else if (setMode < 2) {
-                *artifact = static_cast<short>(*artifact + static_cast<short>(stack->m_word));
+                *artifact = static_cast<short>(*artifact + stack->m_word);
             }
         } else {
             switch (systemValue) {

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4369,7 +4369,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 *flagByte &= ~mask;
             }
         } else if (systemValue <= -200) {
-            short* artifact = Game.m_gameWork.m_eventWork + systemValue + 0x1C7;
+            short* artifact = &Game.m_gameWork.m_eventWork[systemValue + 0x1C7];
             stack[-1].m_word = *artifact;
             if (setMode < 0) {
                 if (setMode >= -1) {

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4349,7 +4349,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             unsigned char* flagByte = reinterpret_cast<unsigned char*>(gameWork.m_eventFlags) + bitIndex / 8;
             unsigned int mask = 1U << (bitIndex % 8);
             unsigned int flag = *flagByte & mask;
-            unsigned int value = (-flag | flag) >> 31;
+            int value = (-flag | flag) >> 31;
             stack[-1].m_word = value;
 
             if (setMode < 0) {

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4475,18 +4475,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x59:
             case -0x58:
             case -0x57: {
-                unsigned char* value = gameWork.m_linkTable[0][5][3] + systemValue * 4;
-                stack[-1].m_word = *reinterpret_cast<unsigned int*>(value);
+                int* value = &gameWork.m_unkStageTable[systemValue + 0x65];
+                stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        *reinterpret_cast<unsigned int*>(value) =
-                            *reinterpret_cast<int*>(value) - stack->m_word;
+                        *value = *value - stack->m_word;
                     }
                 } else if (setMode == 0) {
-                    *reinterpret_cast<unsigned int*>(value) = stack->m_word;
+                    *value = stack->m_word;
                 } else if (setMode < 2) {
-                    *reinterpret_cast<unsigned int*>(value) =
-                        *reinterpret_cast<int*>(value) + stack->m_word;
+                    *value = *value + stack->m_word;
                 }
                 break;
             }
@@ -4507,18 +4505,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x69:
             case -0x68:
             case -0x67: {
-                int* value = reinterpret_cast<int*>(gameWork.m_eventWork + systemValue * 2 + 0x50);
-                stack[-1].m_word = *reinterpret_cast<unsigned int*>(value);
+                int* value = &gameWork.m_eventHeader[systemValue + 0x6B];
+                stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        *reinterpret_cast<unsigned int*>(value) =
-                            *reinterpret_cast<int*>(value) - stack->m_word;
+                        *value = *value - stack->m_word;
                     }
                 } else if (setMode == 0) {
-                    *reinterpret_cast<unsigned int*>(value) = stack->m_word;
+                    *value = stack->m_word;
                 } else if (setMode < 2) {
-                    *reinterpret_cast<unsigned int*>(value) =
-                        *reinterpret_cast<int*>(value) + stack->m_word;
+                    *value = *value + stack->m_word;
                 }
                 break;
             }
@@ -4526,18 +4522,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x46:
             case -0x45:
             case -0x44: {
-                unsigned char* value = gameWork.m_linkTable[0][2][2] + systemValue * 4 + 4;
-                stack[-1].m_word = *reinterpret_cast<unsigned int*>(value);
+                int* value = &gameWork.m_wmBackupParams[systemValue + 0x47];
+                stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        *reinterpret_cast<unsigned int*>(value) =
-                            *reinterpret_cast<int*>(value) - stack->m_word;
+                        *value = *value - stack->m_word;
                     }
                 } else if (setMode == 0) {
-                    *reinterpret_cast<unsigned int*>(value) = stack->m_word;
+                    *value = stack->m_word;
                 } else if (setMode < 2) {
-                    *reinterpret_cast<unsigned int*>(value) =
-                        *reinterpret_cast<int*>(value) + stack->m_word;
+                    *value = *value + stack->m_word;
                 }
                 break;
             }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4546,13 +4546,13 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode < 0) {
                     if (setMode >= -1) {
                         gameWork.m_bossArtifactStageIndex =
-                            static_cast<short>(gameWork.m_bossArtifactStageIndex - static_cast<short>(stack->m_word));
+                            static_cast<short>(gameWork.m_bossArtifactStageIndex - stack->m_word);
                     }
                 } else if (setMode == 0) {
                     gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
                 } else if (setMode < 2) {
                     gameWork.m_bossArtifactStageIndex =
-                        static_cast<short>(gameWork.m_bossArtifactStageIndex + static_cast<short>(stack->m_word));
+                        static_cast<short>(gameWork.m_bossArtifactStageIndex + stack->m_word);
                 }
                 break;
             case -0x76: {
@@ -4575,13 +4575,13 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode < 0) {
                     if (setMode >= -1) {
                         gameWork.m_soundOptionFlag =
-                            static_cast<unsigned char>(gameWork.m_soundOptionFlag - static_cast<char>(stack->m_word));
+                            static_cast<unsigned char>(gameWork.m_soundOptionFlag - stack->m_word);
                     }
                 } else if (setMode == 0) {
                     gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
                 } else if (setMode < 2) {
                     gameWork.m_soundOptionFlag =
-                        static_cast<unsigned char>(gameWork.m_soundOptionFlag + static_cast<char>(stack->m_word));
+                        static_cast<unsigned char>(gameWork.m_soundOptionFlag + stack->m_word);
                 }
                 break;
             case -0x79:
@@ -4589,13 +4589,13 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 if (setMode < 0) {
                     if (setMode >= -1) {
                         gameWork.m_optionValue =
-                            static_cast<unsigned short>(gameWork.m_optionValue - static_cast<short>(stack->m_word));
+                            static_cast<unsigned short>(gameWork.m_optionValue - stack->m_word);
                     }
                 } else if (setMode == 0) {
                     gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
                 } else if (setMode < 2) {
                     gameWork.m_optionValue =
-                        static_cast<unsigned short>(gameWork.m_optionValue + static_cast<short>(stack->m_word));
+                        static_cast<unsigned short>(gameWork.m_optionValue + stack->m_word);
                 }
                 break;
             default:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4229,7 +4229,7 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x46:
         case -0x45:
         case -0x44:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][2][2] + systemValue * 4 + 4);
+            FlatLastResult(this) = gameWork.m_wmBackupParams[systemValue + 0x47];
             break;
         case -0x56:
         case -0x55:
@@ -4246,7 +4246,7 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x4A:
         case -0x49:
         case -0x48:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][3][4] + systemValue * 4);
+            FlatLastResult(this) = gameWork.m_bossArtifactStageTable[systemValue + 0x56];
             break;
         case -0x65:
         case -100:
@@ -4263,7 +4263,7 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x59:
         case -0x58:
         case -0x57:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_linkTable[0][5][3] + systemValue * 4);
+            FlatLastResult(this) = gameWork.m_unkStageTable[systemValue + 0x65];
             break;
         case -0x66:
             FlatLastResult(this) = gameWork.m_chaliceElement;
@@ -4273,7 +4273,7 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x69:
         case -0x68:
         case -0x67:
-            FlatLastResult(this) = *reinterpret_cast<unsigned int*>(gameWork.m_eventWork + systemValue * 2 + 0x50);
+            FlatLastResult(this) = gameWork.m_eventHeader[systemValue + 0x6B];
             break;
         case -0x73:
         case -0x72:

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4352,17 +4352,18 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             int value = (-flag | flag) >> 31;
             stack[-1].m_word = value;
 
+            int result = value;
             if (setMode < 0) {
                 if (setMode >= -1) {
-                    value = value - stack->m_word;
+                    result = value - stack->m_word;
                 }
             } else if (setMode == 0) {
-                value = stack->m_word;
+                result = stack->m_word;
             } else if (setMode < 2) {
-                value = value + stack->m_word;
+                result = value + stack->m_word;
             }
 
-            if (value != 0) {
+            if (result != 0) {
                 *flagByte |= mask;
             } else {
                 *flagByte &= ~mask;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4447,16 +4447,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x4A:
             case -0x49:
             case -0x48: {
-                unsigned char* value = gameWork.m_linkTable[0][3][4] + systemValue * 4;
-                stack[-1].m_word = *reinterpret_cast<unsigned int*>(value);
+                int* value = &gameWork.m_bossArtifactStageTable[systemValue + 0x56];
+                stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
-                        *reinterpret_cast<unsigned int*>(value) = *value - stack->m_word;
+                        *value = *value - stack->m_word;
                     }
                 } else if (setMode == 0) {
-                    *reinterpret_cast<unsigned int*>(value) = stack->m_word;
+                    *value = stack->m_word;
                 } else if (setMode < 2) {
-                    *reinterpret_cast<unsigned int*>(value) = *value + stack->m_word;
+                    *value = *value + stack->m_word;
                 }
                 break;
             }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4447,7 +4447,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x4A:
             case -0x49:
             case -0x48: {
-                int* value = &gameWork.m_bossArtifactStageTable[systemValue + 0x56];
+                int* value = &Game.m_gameWork.m_bossArtifactStageTable[systemValue + 0x56];
                 stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
@@ -4475,7 +4475,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x59:
             case -0x58:
             case -0x57: {
-                int* value = &gameWork.m_unkStageTable[systemValue + 0x65];
+                int* value = &Game.m_gameWork.m_unkStageTable[systemValue + 0x65];
                 stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
@@ -4505,7 +4505,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x69:
             case -0x68:
             case -0x67: {
-                int* value = &gameWork.m_eventHeader[systemValue + 0x6B];
+                int* value = &Game.m_gameWork.m_eventHeader[systemValue + 0x6B];
                 stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {
@@ -4522,7 +4522,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x46:
             case -0x45:
             case -0x44: {
-                int* value = &gameWork.m_wmBackupParams[systemValue + 0x47];
+                int* value = &Game.m_gameWork.m_wmBackupParams[systemValue + 0x47];
                 stack[-1].m_word = *value;
                 if (setMode < 0) {
                     if (setMode >= -1) {


### PR DESCRIPTION
Raises main/cflat_r2system fuzzy match from 81.30% to 81.88%.

Key fixes (all in onSetSystemVal and onSystemVal):
- Replaced pointer-offset tricks (m_linkTable[0][3][4] + sysval*4) with proper member array access into the real fields: m_bossArtifactStageTable, m_unkStageTable, m_eventHeader, m_wmBackupParams (indices recovered from the target's bias constants and field offsets). This was the largest win.
- Separate `result` local in the flag case so value stays live in r3 while the working copy lands in r0 (matches target's `mr r0,r3` + r0-based arithmetic).
- Dropped spurious inner `static_cast<short>/<char>` on stack->m_word in the short/char field cases, removing extsh/extsb that the target lacks.
- Explicit index locals to stop mwcc from folding the bias constant into the load displacement (matches target's `addi; slwi; add` index sequence).
- High-offset fields (m_bossArtifactStageIndex/m_optionValue/m_soundOptionFlag) accessed via Game base instead of the gameWork reference, matching the target's base-register choice.

Per-function: onSetSystemVal 55.8% -> 61.6%, onSystemVal 88.7% -> 92.0%.

Blocker for further gains: the remaining diffs are dominated by mwcc's gameWork r3/r7 base-register split and the setMode if-chain test polarity (target emits `beq`==0 first vs `bge`), both resistant to source-level restructuring after extensive attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)