### PR TITLE
menu_money: raise fuzzy match to 87.6%

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -155,9 +155,9 @@ int CMenuPcs::MoneyCtrlCur()
 	int attachFlag = SingGetLetterAttachflg();
 
 	if (mode == 0) {
-		unsigned int cursor = this->m_moneyState->selections[mode];
+		int cursor = this->m_moneyState->selections[mode];
 		unsigned int placeValue = 1;
-		while (cursor != 0) {
+		while (0 < cursor) {
 			placeValue *= 10;
 			cursor--;
 		}

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -43,7 +43,7 @@ inline void CMenuPcs::MoneySetPlace(int row)
 	int started = 0;
 
 	do {
-		if ((!started) && (digitPlace <= gil)) {
+		if ((!started) && (gil >= digitPlace)) {
 			started = 1;
 		}
 		if (((!started) && (gil < digitPlace)) && (digitIndex != 7)) {

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -46,7 +46,7 @@ inline void CMenuPcs::MoneySetPlace(int row)
 		if ((!started) && (gil >= digitPlace)) {
 			started = 1;
 		}
-		if (((!started) && (gil < digitPlace)) && (digitIndex != 7)) {
+		if (((!started) && (gil < digitPlace)) && (digitIndex < 7)) {
 			*place = -1;
 		} else {
 			int digit = gil / digitPlace;

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -167,7 +167,7 @@ int CMenuPcs::MoneyCtrlCur()
 				Sound.PlaySe(4, 0x40, 0x7F, 0);
 			} else {
 				unsigned int gil = s_Money + placeValue;
-				gil = ((unsigned int)caravanWork->m_gil < gil) ? 0u : gil;
+				gil = (gil <= (unsigned int)caravanWork->m_gil) ? gil : 0u;
 				s_Money = gil;
 				Sound.PlaySe(1, 0x40, 0x7F, 0);
 				gil = s_Money;

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -258,7 +258,7 @@ int CMenuPcs::MoneyCtrlCur()
 		}
 	} else {
 		if ((hold & 8) != 0) {
-			if (this->m_moneyState->selections[mode] != 0) {
+			if ((int)this->m_moneyState->selections[mode] != 0) {
 				this->m_moneyState->selections[mode] = this->m_moneyState->selections[mode] - 1;
 			} else {
 				this->m_moneyState->selections[mode] = 1;
@@ -266,7 +266,7 @@ int CMenuPcs::MoneyCtrlCur()
 			Sound.PlaySe(1, 0x40, 0x7F, 0);
 		} else {
 			if ((hold & 4) != 0) {
-				if (this->m_moneyState->selections[mode] < 1) {
+				if ((int)this->m_moneyState->selections[mode] < 1) {
 					this->m_moneyState->selections[mode] = this->m_moneyState->selections[mode] + 1;
 				} else {
 					this->m_moneyState->selections[mode] = 0;

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -30,10 +30,10 @@ inline void CMenuPcs::MoneySetPlace(int row)
 {
 	CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
 	int gil;
-	if (row == 0) {
-		gil = caravanWork->m_gil;
-	} else {
+	if (row != 0) {
 		gil = s_Money;
+	} else {
+		gil = caravanWork->m_gil;
 	}
 
 	signed char* place = s_place + row * 8;

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -227,7 +227,7 @@ int CMenuPcs::MoneyCtrlCur()
 				if (s_Money < 1) {
 					Sound.PlaySe(4, 0x40, 0x7F, 0);
 				} else {
-					if (-1 < attachFlag) {
+					if (attachFlag >= 0) {
 						LetterSetAttachItem(s_Money, 1);
 						Sound.PlaySe(2, 0x40, 0x7F, 0);
 						return 1;
@@ -246,7 +246,7 @@ int CMenuPcs::MoneyCtrlCur()
 					Sound.PlaySe(2, 0x40, 0x7F, 0);
 				}
 			} else if ((press & 0x200) != 0) {
-				if (-1 < attachFlag) {
+				if (attachFlag >= 0) {
 					LetterSetAttachItem(0, 0xFFFFFFFF);
 					Sound.PlaySe(3, 0x40, 0x7F, 0);
 					return 1;


### PR DESCRIPTION
Raises `main/menu_money` fuzzy match from 87.35% to 87.59% via source-level matching fixes.

## Changes (all in src/menu_money.cpp)
- **MoneyCtrlCur** (85.85 -> 86.29): flip the gil-cap ternary polarity (`gil <= max ? gil : 0`), use `attachFlag >= 0` instead of `-1 < attachFlag`, and make `cursor` a signed `int` with a `0 < cursor` loop so mwcc emits the target's `cmpwi/ble` + CTR strength-reduced loop. Cast a selections compare to `(int)` to drop a redundant `extsh`.
- **MoneySetPlace** (inlined everywhere): flip the `started` compare to `gil >= digitPlace`, use `digitIndex < 7`, and swap the `row` if/else arms (`if (row != 0)` first) to match the target's branch fallthrough order.
- **MoneyOpen** (85.43 -> 85.69): benefits from the shared MoneySetPlace fixes.

## Remaining blockers
- **MoneyDraw whole-function register window shift**: target assigns `this`->r30 / `mode`->r31 (frame 0xf0); ours `this`->r31 (frame 0xe0). This is a register-coloring root that declaration/statement reordering does not flip.
- **Inlined MoneySetPlace CTR loop**: target emits `mtctr/bdnz`; ours emits `subic./bne`. Converting the do/while to a `for` triggers CTR but regresses net (the for-loop shape mismatches in MoneyCtrlCur/MoneyOpen), so the do/while is kept.
- **press/hold blocked-input register window** (known wall) and the DrawCursor `__cvt_fp2unsigned` cast (switching to `(int)` produces `fctiwz` but net-regresses, so left as unsigned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)