### PR TITLE
menu_compa: raise fuzzy match to 82.3%

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -60,10 +60,8 @@ void CMenuPcs::CompaDraw()
 	MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
 	const CCaravanWork* caravanWork = reinterpret_cast<const CCaravanWork*>(Game.m_scriptFoodBase[0]);
-	CompaOpenAnimList* compaList = this->m_compaList;
-	CompaOpenAnim* entry = compaList->entries;
-	unsigned int count = compaList->count;
-	for (int i = 0; i < count; i++) {
+	CompaOpenAnim* entry = this->m_compaList->entries;
+	for (int i = 0; i < this->m_compaList->count; i++) {
 		int tex = entry->tex;
 		if (tex >= 0) {
 			float x = static_cast<float>(entry->x);
@@ -168,6 +166,7 @@ void CMenuPcs::CompaDraw()
 		entry++;
 	}
 
+	CompaOpenAnimList* compaList = this->m_compaList;
 	float globalAlpha = compaList->entries[0].alpha;
 
 	GXColor color;

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -62,7 +62,7 @@ void CMenuPcs::CompaDraw()
 	const CCaravanWork* caravanWork = reinterpret_cast<const CCaravanWork*>(Game.m_scriptFoodBase[0]);
 	CompaOpenAnimList* compaList = this->m_compaList;
 	CompaOpenAnim* entry = compaList->entries;
-	int count = compaList->count;
+	unsigned int count = compaList->count;
 	for (int i = 0; i < count; i++) {
 		int tex = entry->tex;
 		if (tex >= 0) {
@@ -137,7 +137,7 @@ void CMenuPcs::CompaDraw()
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {
 							float diff = end - static_cast<float>(yStep);
-							int tileH = (diff >= kCompaTileHeight) ? 0x18 : static_cast<int>(diff);
+							int tileH = (diff >= kCompaTileHeight) ? 0x18 : static_cast<unsigned int>(diff);
 							MenuPcs.DrawRect(
 								static_cast<unsigned long>(entry->drawFlags), x, static_cast<float>(yStep),
 								remainW, static_cast<float>(tileH), u, v,
@@ -192,7 +192,7 @@ void CMenuPcs::CompaDraw()
 		familyCount = 4;
 	}
 
-	for (unsigned int i = 0; i < familyCount; i++) {
+	for (int i = 0; i < familyCount; i++) {
 		MenuPcs.DrawRect(
 			0,
 			static_cast<float>(compaList->entries[0].x + 0x10),
@@ -248,7 +248,7 @@ void CMenuPcs::CompaDraw()
 	font->SetScaleY(kCompaOne);
 	font->DrawInit();
 
-	GXColor textColor = CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(kCompaColorMax * globalAlpha)).color;
+	GXColor textColor = CColor(0xFF, 0xFF, 0xFF, static_cast<signed char>(kCompaColorMax * globalAlpha)).color;
 	font->SetColor(textColor);
 
 	memberIndex = 0;

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -192,7 +192,7 @@ void CMenuPcs::CompaDraw()
 		familyCount = 4;
 	}
 
-	for (int i = 0; i < familyCount; i++) {
+	for (unsigned int i = 0; i < familyCount; i++) {
 		MenuPcs.DrawRect(
 			0,
 			static_cast<float>(compaList->entries[0].x + 0x10),
@@ -202,7 +202,7 @@ void CMenuPcs::CompaDraw()
 	}
 
 	int memberIndex = 0;
-	int shown = 0;
+	unsigned int shown = 0;
 	for (int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = memberIndex;
 		if (memberIndex > 1) {

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -177,7 +177,7 @@ void CMenuPcs::CompaDraw()
 	GXSetChanMatColor(GX_COLOR0A0, color);
 	MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3A));
 
-	int familyCount = 2;
+	unsigned int familyCount = 2;
 	for (int i = 2; i < 7; i++) {
 		if (caravanWork->m_evtWordArr[19 + i] > 0) {
 			familyCount++;

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -173,11 +173,11 @@ void CMenuPcs::CompaDraw()
 	color.r = 0xFF;
 	color.g = 0xFF;
 	color.b = 0xFF;
-	color.a = static_cast<unsigned char>(globalAlpha * kCompaColorMax);
+	color.a = static_cast<signed char>(globalAlpha * kCompaColorMax);
 	GXSetChanMatColor(GX_COLOR0A0, color);
 	MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3A));
 
-	unsigned int familyCount = 2;
+	int familyCount = 2;
 	for (int i = 2; i < 7; i++) {
 		if (caravanWork->m_evtWordArr[19 + i] > 0) {
 			familyCount++;
@@ -191,7 +191,7 @@ void CMenuPcs::CompaDraw()
 		familyCount = 4;
 	}
 
-	for (int i = 0; i < familyCount; i++) {
+	for (unsigned int i = 0; i < familyCount; i++) {
 		MenuPcs.DrawRect(
 			0,
 			static_cast<float>(compaList->entries[0].x + 0x10),
@@ -273,7 +273,7 @@ void CMenuPcs::CompaDraw()
 		font->SetPosY(y);
 		font->Draw(name);
 
-		unsigned short food = caravanWork->m_evtWordArr[19 + drawIndex];
+		short food = caravanWork->m_evtWordArr[19 + drawIndex];
 		const char* value = Game.m_cFlatDataArr[1].TableStrings(2)[food];
 		font->SetPosX(static_cast<float>(compaList->entries[0].x + 0x90));
 		font->SetPosY(y);

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -205,8 +205,10 @@ void CMenuPcs::CompaDraw()
 	for (int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = memberIndex;
 		if (memberIndex > 1) {
-			while (drawIndex < 8 && caravanWork->m_evtWordArr[19 + drawIndex] == 0) {
-				drawIndex++;
+			for (; drawIndex < 8; drawIndex++) {
+				if (caravanWork->m_evtWordArr[19 + drawIndex] != 0) {
+					break;
+				}
 			}
 			if (drawIndex > 7) {
 				break;
@@ -255,8 +257,10 @@ void CMenuPcs::CompaDraw()
 	for (int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = memberIndex;
 		if (memberIndex > 1) {
-			while (drawIndex < 8 && caravanWork->m_evtWordArr[19 + drawIndex] <= 0) {
-				drawIndex++;
+			for (; drawIndex < 8; drawIndex++) {
+				if (caravanWork->m_evtWordArr[19 + drawIndex] > 0) {
+					break;
+				}
 			}
 			if (drawIndex > 7) {
 				break;

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -270,7 +270,7 @@ void CMenuPcs::CompaDraw()
 		font->SetPosY(y);
 		font->Draw(name);
 
-		short food = caravanWork->m_evtWordArr[19 + drawIndex];
+		unsigned short food = caravanWork->m_evtWordArr[19 + drawIndex];
 		const char* value = Game.m_cFlatDataArr[1].TableStrings(2)[food];
 		font->SetPosX(static_cast<float>(compaList->entries[0].x + 0x90));
 		font->SetPosY(y);


### PR DESCRIPTION
Raises `main/menu_compa` fuzzy match from 80.08% to 82.25%, all gains in `CompaDraw` (69.48% -> 73.25%).

Changes (all source-level, no hacks):
- Recompute loop `count` from `this->m_compaList->count` in the main draw loop instead of caching it, matching the original's per-iteration struct re-read and register layout.
- Convert the two member search loops from `while (i < 8 && arr == 0)` to plain `for` loops, which makes mwcc emit the original's `subfic`/`mtctr`/`bdnz` counted CTR loops instead of fully unrolled checks (R10).
- Refine integer/char/short signedness on several locals (loop counters, food index, tile-height casts, color alpha) to match the target's `cmpw`/`cmplw`, `lha`/`lhz`, and signed/unsigned conversions (found via tools/permute_fn.py).

Remaining blocker: `CompaDraw` (and `CompaInit`/`CompaCtrl`) carry a consistent +1 GPR callee-saved-register window shift (target `stmw r19` vs ours `stmw r20`; target `stmw r24` vs ours `stmw r23` in CompaInit). The target keeps the `&MenuPcs` base and magic-double constants live in callee-saved regs across the draw loop while recomputing list/count, growing the frame by one register; source-level recompute/cache reshuffles regressed when forced. The setup-entry blocks are otherwise byte-identical modulo this single-register offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)