### PR TITLE
mes: raise fuzzy match to 85.1%

### DIFF
--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -899,13 +899,8 @@ void CMes::addString(char** text, int branchMode)
 	unsigned char caseMode = 0;
 	signed char flowMode = 0;
 
-	do
+	while (running)
 	{
-		if (!running)
-		{
-			return;
-		}
-
 		unsigned char* p = (unsigned char*)*text;
 		*text = (char*)(p + 1);
 		unsigned char ch = *p;
@@ -1506,7 +1501,7 @@ void CMes::addString(char** text, int branchMode)
 			}
 			mLineHeight = h;
 		}
-	} while (true);
+	}
 }
 
 /*

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -22,6 +22,8 @@ extern float kMesHalf;
 // PAL map: CMes::m_tempVar in mes.o, .bss size 0x50.
 int CMes::m_tempVar[0x14];
 
+extern char lbl_801D9E58[];
+
 static const char s_mesTagUnknown[] = "Not corresponding TAG is used. %02x\n";
 static const char s_mesTagMissing[] = "This TAG is not created. %02x\n";
 static const char s_mesNumFmt[] = "%d";
@@ -1218,7 +1220,7 @@ void CMes::addString(char** text, int branchMode)
 			{
 				if (System.m_execParam != 0)
 				{
-					System.Printf(const_cast<char*>(s_mesTagUnknown), uch + 0xA0);
+					System.Printf(lbl_801D9E58);
 				}
 			}
 			else if (value == 0x7F)

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1147,8 +1147,8 @@ void CMes::addString(char** text, int branchMode)
 		}
 		case 0x2F:
 		{
-			char* fallback = (char*)s_mesFallback;
-			addString(&fallback, branchMode);
+			char* townName = Game.m_gameWork.m_townName;
+			addString(&townName, branchMode);
 			break;
 		}
 		case 0x30:
@@ -1219,20 +1219,20 @@ void CMes::addString(char** text, int branchMode)
 		case 0x25:
 		{
 			unsigned int value = ReadTagS8(text);
-			if (mFontCount == 0)
+			if (mFontCount != 0)
 			{
-				if (value == 0x7F)
+				if (System.m_execParam != 0)
 				{
-					mAdvanceEnabled = 0;
-				}
-				else
-				{
-					mAdvanceStep = value;
+					System.Printf(const_cast<char*>(s_mesTagUnknown), uch + 0xA0);
 				}
 			}
-			else if (System.m_execParam != 0)
+			else if (value == 0x7F)
 			{
-				System.Printf(const_cast<char*>(s_mesTagUnknown), uch + 0xA0);
+				mAdvanceEnabled = 0;
+			}
+			else
+			{
+				mAdvanceStep = value;
 			}
 			break;
 		}

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1573,19 +1573,19 @@ void CMes::Next()
 		memcpy(mFlagVars, tempFlags, sizeof(tempFlags));
 		halfVal = kMesHalf;
 		i = 0;
-		curr = (float*)((char*)this + 0xc);
-		while ((start = curr, remaining = mCounter, i < remaining))
+		start = (float*)((char*)this + 0xc);
+		while ((remaining = mCounter, i < remaining))
 		{
-			i = i + 1;
+			int j = i + 1;
 			curr = start + 5;
-			for (entryCount = remaining - i; entryCount != 0; entryCount = entryCount - 1)
+			for (entryCount = remaining - j; entryCount != 0; entryCount = entryCount - 1)
 			{
 				if ((((unsigned int)*(unsigned char*)((char*)start + 0xe) >> 4 & 0xF) != ((unsigned int)*(unsigned char*)((char*)curr + 0xe) >> 4 & 0xF)) ||
 				    (*(short*)(start + 2) != *(short*)(curr + 2)))
 				{
 					break;
 				}
-				i = i + 1;
+				j = j + 1;
 				curr = curr + 5;
 			}
 			runLength = (unsigned int)((int)curr - (int)start) / 0x14;
@@ -1603,6 +1603,8 @@ void CMes::Next()
 				}
 				start = start + 5;
 			}
+			i = j;
+			start = curr;
 		}
 	}
 }


### PR DESCRIPTION
Raises main/mes fuzzy match from baseline 84.50% to 85.14%.

## Changes
- **Next** (81.6% -> 83.9%): restructured the glyph-grouping inner loop to use a separate forward cursor (j/curr) leaving the outer i/start fixed for the run-length pass, then advancing i=j; start=curr at loop bottom. Matches the target's mtctr/bdnz counted inner loop and basic-block shape.
- **addString** (82.6% -> 83.6%):
  - case 0x2F fallback string is `Game.m_gameWork.m_townName` (Game+0x10a8), not the "---" literal (confirmed via DOL: Game@0x8021eec0 + 0x10a8 = 0x8021ff68 = m_townName). This restores the `r19 = Game+0x10a8` cached pointer in the prologue.
  - case 0x25 tag-validation: inverted the if-polarity (`mFontCount != 0` first) to match the target's block order, and the `else if (System.m_execParam)` branch calls `Printf(lbl_801D9E58)` with the real shipped debug string and no format arg (confirmed via Ghidra + DOL string read).
  - converted the main `do { if(!running) return; ... } while(true)` parser loop into `while (running) { ... }`, matching the target's bottom-tested loop.

## Remaining blocker
addString/Draw/MakeAgbString are dominated by a uniform off-by-one callee-saved register-window rotation (ours allocates one extra GPR vs target; frame 0x240 vs 0x250). The townName + loop fixes brought the prologue much closer (r19=Game+0x10a8 now present) but one extra register-resident local remains that the target spills to stack; isolating it would convert ~700 ARG_MISMATCH lines at once. The advanceLine fma-fusion (target splits fmuls+fadds, ours emits fmadds) also resists source-level control short of fp_contract pragmas that regress neighbors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)