### PR TITLE
p_minigame: raise fuzzy match to 91.0%

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -733,7 +733,7 @@ void CMiniGamePcs::GbaThreadMain(void* threadParam)
 {
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
     unsigned char* param = reinterpret_cast<unsigned char*>(threadParam);
-    int message;
+    unsigned int message;
     unsigned int command;
     unsigned int command7;
     unsigned int command8;
@@ -771,7 +771,7 @@ receive_message:
         return;
     }
 
-    if (message == 7 && *reinterpret_cast<int*>(param + 0x8C) == 0)
+    if (message == 7 && *reinterpret_cast<unsigned int*>(param + 0x8C) == 0)
     {
         message = 8;
     }

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -766,7 +766,7 @@ receive_message:
             MiniGameThreadSleepTicks(OSMillisecondsToTicks(10));
         }
         MiniGameThreadSleepTicks(OSMillisecondsToTicks(10));
-        self[0x649D] |= static_cast<unsigned char>(1 << channel);
+        self[0x649D] |= (1 << channel);
         OSExitThread(0);
         return;
     }


### PR DESCRIPTION
Raises main/p_minigame fuzzy match from 90.96% to 91.04%.

Changes (both in GbaThreadMain):
- Drop redundant `static_cast<unsigned char>` on the `self[0x649D] |= (1 << channel)` flag-set. The result is stored via `stb` which already truncates, so the cast only produced a spurious `clrlwi r0,r0,24`.
- Treat the GBA thread `message` value and the `param+0x8C` word as unsigned in their equality compares, matching the original's `cmplwi` (vs our `cmpwi`).

Remaining blockers are register-coloring cascades (a uniform +4 stack-frame-slot shift in GbaThreadMain drives a systematic callee-saved register renumber across GbaThreadMain/OpenCallback/MngThreadMain) and the `...rodata.0` vs `sMiniGameGbaDvdDir` section-anchor representation, which traces to the original holding anonymous string literals in an exact data layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)