### PR TITLE
menu_tmparti: raise fuzzy match to 96.7%

### DIFF
--- a/src/menu_tmparti.cpp
+++ b/src/menu_tmparti.cpp
@@ -326,7 +326,7 @@ unsigned int CMenuPcs::TmpArtiClose()
 	if (this->m_tmpArtiList->count == completedItems) {
 		zero = kTmpArtiZero;
 		entry = this->m_tmpArtiList->entries;
-		for (count = itemCount; count > 0; count--) {
+		for (count = itemCount; (int)count > 0; count--) {
 			entry->startFrame = 0;
 			entry->duration = 1;
 			entry->alpha = zero;


### PR DESCRIPTION
Raise main/menu_tmparti from 96.57% to 96.65%.

## Change
TmpArtiClose final reset loop: the loop guard `count > 0` on an `unsigned int` emitted an unsigned compare (`cmplwi`) and `beq` polarity, while the target uses a signed compare (`cmpwi`) and `ble`. The Ghidra reference confirms the original tests `0 < (int)itemCount`. Changing the guard to `(int)count > 0` (keeping `count` unsigned so the `>> 3` unroll stays unsigned) matches the target's control-flow polarity.

TmpArtiClose: 97.43% -> 98.04%.

## Remaining blockers (known walls)
- TmpArtiOpen (94.3%): a global +1 register-coloring shift driven by the int->double conversion scratch slots in the inlined TmpArtiInit. The target reuses one 8-byte stack slot pair (0x8/0xc) for both entry[0].x and entry[1].x conversions; ours allocates a second pair (frame 0x30 vs 0x20). This is mwcc scheduler/liveness behavior not controllable from source order.
- TmpArtiDraw (97.0%): target frame is 0x10 larger (more distinct int->double conversion slots kept live).
- TmpArtiClose/Ctrl: residual r5/r6 (and r6/r7) coloring swaps between the loop pointer and the startFrame counter constant in the unrolled init loops, identical across functions.
- A single `clrlwi`/`extsh.` form difference on the buttonDown==0 test in TmpArtiCtrlCur.

permute_fn.py found no signedness wins on any of the four functions; the remaining diffs are pure register allocation and scratch-slot ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)