### PR TITLE
menu_favo: raise fuzzy match to 89.2%

### DIFF
--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -168,8 +168,8 @@ void CMenuPcs::FavoDraw()
 	FoodRank* rank = s_rank;
 	for (int i = 0; i < 8; i++) {
 		int barX = drawEntry->x + drawEntry->w + 0x18;
-		int barY = static_cast<int>((static_cast<float>(drawEntry->h) - 24.0f) * 0.5 +
-		                            static_cast<float>(drawEntry->y));
+		int barY = static_cast<int>(static_cast<float>((static_cast<float>(drawEntry->h) - 24.0f) * 0.5 +
+		                            static_cast<float>(drawEntry->y)));
 		DrawSingBar(barX, barY, rank->score, drawEntry->alpha);
 		rank++;
 		drawEntry++;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -719,17 +719,15 @@ void CMenuPcs::FavoInit()
 
 	int place = 0;
 	iVar17 = 0;
-	iVar16 = 8;
 	rank = ranks;
 	do {
 		if ((iVar17 != 0) && (rank[-1].score != rank->score)) {
 			place = iVar17;
 		}
-		iVar17++;
 		rank->place = place + 1;
 		rank++;
-		iVar16--;
-	} while (iVar16 != 0);
+		iVar17++;
+	} while (iVar17 < 8);
 
 	m_singMenuState->selectedIndex = 0;
 	m_singMenuState->initialized = 1;

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -58,7 +58,7 @@ void CMenuPcs::FavoDraw()
 			float v = entry->v;
 
 			GXColor colors[4];
-			if (i < 3) {
+			if (static_cast<int>(i) < 3) {
 				MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(1));
 				MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(entry->tex));
 

--- a/src/menu_favo.cpp
+++ b/src/menu_favo.cpp
@@ -86,9 +86,11 @@ void CMenuPcs::FavoDraw()
 						int yStep = static_cast<int>(y);
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {
-							int tileH = static_cast<unsigned int>(end - static_cast<float>(yStep));
-							if (static_cast<float>(tileH) > 32.0f) {
+							int tileH;
+							if (end - static_cast<float>(yStep) >= 32.0f) {
 								tileH = 0x20;
+							} else {
+								tileH = static_cast<int>(end - static_cast<float>(yStep));
 							}
 							MenuPcs.DrawRect(static_cast<unsigned long>(entry->drawFlags), x, static_cast<float>(yStep),
 							                 fillW, static_cast<float>(tileH), u, v, colors, entry->uvScale,
@@ -119,9 +121,11 @@ void CMenuPcs::FavoDraw()
 						int yStep = static_cast<int>(y);
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {
-							int tileH = static_cast<unsigned int>(end - static_cast<float>(yStep));
-							if (static_cast<float>(tileH) > 32.0f) {
+							int tileH;
+							if (end - static_cast<float>(yStep) >= 32.0f) {
 								tileH = 0x20;
+							} else {
+								tileH = static_cast<int>(end - static_cast<float>(yStep));
 							}
 							MenuPcs.DrawRect(static_cast<unsigned long>(entry->drawFlags), x, static_cast<float>(yStep),
 							                 remainW, static_cast<float>(tileH), u, v, colors, entry->uvScale,


### PR DESCRIPTION
Raises main/menu_favo from 87.35% to 89.24%.

Per-function gains:
- FavoDraw: 81.93% -> 85.96%
  - Clamp tile height on the float value before the signed int conversion (matches target's float compare + fctiwz instead of __cvt_fp2unsigned).
  - Signed compare for the first-three favorite check ((int)i < 3 -> cmpwi).
  - Round bar Y position to single precision before truncation (frsp before fctiwz).
- FavoInit: 83.98% -> 84.44%
  - Drop the redundant countdown counter in the rank place loop, using the index as the loop condition.

Remaining blocker: FavoDraw and FavoInit are dominated by a callee-saved register-window shift (target this=r30/entry=r31 vs ours this=r31/entry=r28; FavoInit saves one extra GPR). Source reorderings to influence the coloring (caching m_favoList, moving caravanWork, for-vs-do/while loop forms) all regressed. FavoInit/FavoInit0 also differ on mtctr/bdnz vs subic./bne for the unrolled clear loops, but every loop-form change regressed the surrounding allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)