### PR TITLE
cflat_r2class: raise fuzzy match to 87.7%

### DIFF
--- a/include/ffcc/gobject.h
+++ b/include/ffcc/gobject.h
@@ -47,7 +47,7 @@ public:
     void moveVectorRot(float, float, float, int);
     void moveVectorHRot(float, float, float, int);
     CGObject* CCClass(int, int, float, Vec*, float);
-    void CCClassRot(int, int, float, float, float, float);
+    CGObject* CCClassRot(int, int, float, float, float, float);
     void Attach(CGObject*, char*, Vec*);
     void Detach();
     void DispCharaParts(int);

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -834,11 +834,11 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 				engineObject->m_bodyEllipsoidRadius = radius;
 				engineObject->m_bodyEllipsoidOffset = offset;
 				break;
-			case 2:
-				engineObject->m_bodyColRadius = radius;
-				break;
 			case 3:
 				engineObject->m_attackColRadius = radius;
+				break;
+			case 2:
+				engineObject->m_bodyColRadius = radius;
 				break;
 			case 4:
 				engineObject->m_nearColRadius = radius;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -60,13 +60,9 @@ static inline CGObject* FindRuntimeObject(CFlatRuntime2* runtime, unsigned int o
 	return static_cast<CGObject*>(runtime->intToClass(static_cast<int>(objectId)));
 }
 
-static inline char* RuntimeString(CFlatRuntime2* runtime, unsigned int index)
-{
-	u8* const bytes = reinterpret_cast<u8*>(runtime);
-	char* const blob = *reinterpret_cast<char**>(bytes + 0x28);
-	unsigned short* const offsets = *reinterpret_cast<unsigned short**>(bytes + 0x2C);
-	return blob + offsets[index];
-}
+#define RuntimeString(runtime, index)                                                                         \
+	(*reinterpret_cast<char**>(reinterpret_cast<u8*>(runtime) + 0x28) +                                        \
+	 (*reinterpret_cast<unsigned short**>(reinterpret_cast<u8*>(runtime) + 0x2C))[index])
 
 static inline unsigned int& RuntimeWorkAssignIndex(CFlatRuntime2* runtime)
 {
@@ -1160,6 +1156,17 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		case -0x36: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
 			engineObject->moveVectorH(CVector(params[0], params[1], params[2]), params[3], static_cast<int>(object->m_localBase[4]));
+			PushValue(this, object, 0);
+			outResult = 0;
+			break;
+		}
+		case -0x37: {
+			Vec moveTarget;
+			float* params = reinterpret_cast<float*>(object->m_localBase);
+			moveTarget.x = params[0];
+			moveTarget.y = params[1];
+			moveTarget.z = params[2];
+			engineObject->Move(&moveTarget, params[3], static_cast<int>(object->m_localBase[4]), 1, 0, 0, 0);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1205,8 +1205,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x1B: {
-			u8 flags = *(reinterpret_cast<u8*>(&engineObject->m_weaponNodeFlags) + 1);
-			if (static_cast<int>((static_cast<unsigned int>(flags) << 0x1A) | (static_cast<unsigned int>(flags) >> 6)) >= 0) {
+			if (engineObject->m_weaponNodeFlagAll.m_bits1.m_bit20 == 0) {
 				PushValue(this, object, 0);
 				outResult = 0;
 			}

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -987,6 +987,19 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
+		case -0x23: {
+			float* params = reinterpret_cast<float*>(object->m_localBase);
+			CGObject* result = engineObject->CCClassRot(
+			    static_cast<int>(object->m_localBase[0]), static_cast<int>(object->m_localBase[1]), params[2], params[3],
+			    params[4], params[5]);
+			if (result != 0) {
+				*reinterpret_cast<int*>(object->m_localBase[6]) =
+				    *reinterpret_cast<short*>(reinterpret_cast<u8*>(result) + 0x30);
+			}
+			PushValue(this, object, result != 0);
+			outResult = 0;
+			break;
+		}
 		case -0x24: {
 			Vec hitStart;
 			Vec hitMove;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2153,14 +2153,14 @@ void CGObject::Attach(CGObject* owner, char* nodeName, Vec* attachLocal)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGObject::CCClassRot(int useBodyRadius, int classMask, float yOffset, float rotY, float distance, float radius)
+CGObject* CGObject::CCClassRot(int useBodyRadius, int classMask, float yOffset, float rotY, float distance, float radius)
 {
     Vec targetPos;
 
     targetPos.x = distance * static_cast<float>(sin(rotY)) + m_worldPosition.x;
     targetPos.y = m_worldPosition.y + yOffset;
     targetPos.z = distance * static_cast<float>(cos(rotY)) + m_worldPosition.z;
-    CCClass(useBodyRadius, classMask, yOffset, &targetPos, radius);
+    return CCClass(useBodyRadius, classMask, yOffset, &targetPos, radius);
 }
 
 /*


### PR DESCRIPTION
Raises `main/cflat_r2class` from 85.84% to **87.68%** (+1.84).

## Changes
- **onClassSystemFunc 86.77 -> 89.72%** (the bulk of the gain):
  - Recovered missing command **-0x37** (`Move(&vec, params[3], localBase[4], 1, 0, 0, 0)` with a stack `Vec`). This also restores the original 0x1b0 stack frame, fixing ~60 stack-offset mismatches across the function.
  - Recovered missing command **-0x23** (`CCClassRot(...)` then store the returned object's field). `CGObject::CCClassRot` actually returns the `CCClass` result (`CGObject*`), not `void` — fixed the signature in `gobject.h`/`gobject.cpp`, which also makes `CGObject::CCClassRot` match in the gobject unit.
  - Converted the `RuntimeString` helper to a function-like macro so it stays inlined now that the function is larger (matching the original's inlined codegen).
  - Matched the `-0xD` collision-radius inner switch case order (case 3 before case 2).
  - Case **-0x1B** now reads the `m_bit20` bitfield member instead of a manual rotate, matching the `extlwi/srawi/extsb.` sequence.

## Blocker
The remaining gap is dominated by mwcc-intrinsic behaviors that resist source restructuring: the dispatch-tree branch polarity / out-of-line body placement in `onClassSystemVal` (80.8%) and `onSetClassSystemVal` (85.2%), and a pervasive commutative `add rD, base, index` vs `add rD, index, base` operand ordering on the indexed load/store helpers. One more missing case (`-0x30`, a `m_damageColliders`-style set-all/set-one writing a field at hitMask+0x8) was left out because it could not be expressed as clean member access without an offset trick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)