### PR TITLE
menu_lst: raise fuzzy match to 96.6%

### DIFF
--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -62,11 +62,11 @@ void CMenuPcs::MLstDraw()
 		int tex = item->tex;
 		if (tex >= 0) {
 			float x = (float)item->x;
+			float zero = kMLstZero;
+			float v = zero;
 			float y = (float)item->y;
 			float w = (float)item->width;
 			float h = (float)item->height;
-			float zero = kMLstZero;
-			float v = zero;
 			float alpha = item->alpha;
 
 			MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(tex));

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -56,6 +56,7 @@ void CMenuPcs::MLstDraw()
 
 	short menuMode = this->m_menuLstState->mode;
 	MenuLstEntry* item = this->m_menuLstList->entries;
+	float rowHeight = kMLstRowHeight;
 
 	for (int i = 0; i < this->m_menuLstList->count; i++) {
 		int tex = item->tex;
@@ -94,8 +95,8 @@ void CMenuPcs::MLstDraw()
 				0,
 				iconX,
 				iconY,
-				kMLstRowHeight,
-				kMLstRowHeight,
+				rowHeight,
+				rowHeight,
 				zero,
 				v,
 				item->z,
@@ -143,8 +144,8 @@ void CMenuPcs::MLstDraw()
 	DrawInit();
 	int helpMessageId = this->m_menuLstState->cursor + 0x25c;
 	CFont* helpFont = this->m_fonts[0];
-	float helpX = kMLstHelpCenterX;
-	float helpY = 352.0f;
+	float helpX = (float)-(rowHeight * kMLstHalf - kMLstHelpCenterX);
+	float helpY = kMLstHelpY;
 	DrawHelpMessage(
 		helpMessageId,
 		helpFont,

--- a/src/menu_lst.cpp
+++ b/src/menu_lst.cpp
@@ -58,7 +58,7 @@ void CMenuPcs::MLstDraw()
 	MenuLstEntry* item = this->m_menuLstList->entries;
 	float rowHeight = kMLstRowHeight;
 
-	for (int i = 0; i < this->m_menuLstList->count; i++) {
+	for (int i = 0; i < this->m_menuLstList->count; i++, item++) {
 		int tex = item->tex;
 		if (tex >= 0) {
 			float x = (float)item->x;
@@ -103,7 +103,6 @@ void CMenuPcs::MLstDraw()
 				item->z,
 				zero);
 		}
-		item++;
 	}
 
 	CFont* font = this->m_fonts[4];


### PR DESCRIPTION
Raises main/menu_lst fuzzy match from 96.13% to 96.63%, all gains in MLstDraw (94.77% -> 95.97%).

Changes (all source-level, no hacks):
- Keep kMLstRowHeight in a local reused for the icon DrawRect size args and the help-message X position, computed as -(rowHeight*0.5 - 320). This forces rowHeight to live in callee-saved f31 across the whole function and yields the target's fnmsubs for the help X coordinate.
- Reorder the loop-1 float locals (x, zero/v, then y/w/h) toward the original's FPR allocation order.
- Use for(i++, item++) in the first draw loop so mwcc emits the index increment before the strength-reduced pointer increment, matching the target.

Remaining gap in MLstDraw is the coupled frame-size (+0x10) / GPR+FPR coloring window shift, which resists source reordering (permute finds no improvement) — the documented register-coloring wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)