### PR TITLE
ringmenu: raise fuzzy match to 76.8%

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -872,14 +872,11 @@ void drawCommand(int state, CFont* font, float posX, float posY, CCaravanWork* c
 	int alpha = static_cast<int>((kRingMenuAlphaMax * alphaScale) * clampedAlpha);
 	CColor color(0xFF, 0xFF, 0xFF, alpha);
 	font->SetColor(color.color);
-	font->SetPosX(static_cast<float>(waveX + -(static_cast<double>(static_cast<float>(
-		textWidth * static_cast<double>(kRingMenuHalf) -
-		static_cast<double>(static_cast<float>(static_cast<double>(kRingMenuTextBaseX) + static_cast<double>(posX))))))));
-	font->SetPosY(
-		kRingMenuGbaOrbitYScale +
-			static_cast<float>(waveY + -(static_cast<double>(static_cast<float>(
-				textHeight * static_cast<double>(kRingMenuHalf) -
-				static_cast<double>(static_cast<float>(static_cast<double>(kRingMenuShadowOffset) + static_cast<double>(posY))))))));
+	font->SetPosX(static_cast<float>(waveX) +
+		((kRingMenuTextBaseX + posX) - static_cast<float>(textWidth) * kRingMenuHalf));
+	font->SetPosY(kRingMenuGbaOrbitYScale +
+		(static_cast<float>(waveY) +
+			((kRingMenuShadowOffset + posY) - static_cast<float>(textHeight) * kRingMenuHalf)));
 	font->SetPosZ(kRingMenuZero);
 	font->Draw(commandLabel);
 }

--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -751,7 +751,7 @@ void CRingMenu::onDraw()
 						for (int i = 0; i < caravanWork->m_numCmdListSlots; i++) {
 							int maxCharge;
 							int curCharge;
-							int charge = caravanWork->GetMagicCharge(i, maxCharge, curCharge);
+							unsigned int charge = caravanWork->GetMagicCharge(i, maxCharge, curCharge);
 
 							float blink = kRingMenuZero;
 							if (charge == 0) {

--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -800,8 +800,8 @@ void drawCommand(int state, CFont* font, float posX, float posY, CCaravanWork* c
 	const char* commandLabel;
 	double waveX;
 	float waveY;
-	double textWidth;
-	double textHeight;
+	float textWidth;
+	float textHeight;
 	float waveSinY;
 
 	if (Game.m_gameWork.m_bossArtifactStageIndex == 0x19) {
@@ -860,9 +860,9 @@ void drawCommand(int state, CFont* font, float posX, float posY, CCaravanWork* c
 	}
 
 	font->SetScale(static_cast<float>(-(kRingMenuSpinScaleSlopeD * fabs(static_cast<double>(angle)) - kRingMenuSpinScaleBaseD)));
-	textWidth = static_cast<double>(font->GetWidth(commandLabel));
+	textWidth = static_cast<float>(font->GetWidth(commandLabel));
 	fVar1 = static_cast<float>(-(kRingMenuSpinAlphaSlopeD * fabs(static_cast<double>(angle)) - kRingMenuOneD));
-	textHeight = static_cast<double>(static_cast<float>(font->m_glyphHeight) * font->scaleY);
+	textHeight = static_cast<float>(font->m_glyphHeight) * font->scaleY;
 
 	clampedAlpha = kRingMenuZero;
 	if ((kRingMenuZero <= fVar1) && ((clampedAlpha = fVar1), (kRingMenuOne < fVar1))) {
@@ -873,10 +873,9 @@ void drawCommand(int state, CFont* font, float posX, float posY, CCaravanWork* c
 	CColor color(0xFF, 0xFF, 0xFF, alpha);
 	font->SetColor(color.color);
 	font->SetPosX(static_cast<float>(waveX) +
-		((kRingMenuTextBaseX + posX) - static_cast<float>(textWidth) * kRingMenuHalf));
+		((kRingMenuTextBaseX + posX) - textWidth * kRingMenuHalf));
 	font->SetPosY(kRingMenuGbaOrbitYScale +
-		(static_cast<float>(waveY) +
-			((kRingMenuShadowOffset + posY) - static_cast<float>(textHeight) * kRingMenuHalf)));
+		(waveY + ((kRingMenuShadowOffset + posY) - textHeight * kRingMenuHalf)));
 	font->SetPosZ(kRingMenuZero);
 	font->Draw(commandLabel);
 }


### PR DESCRIPTION
Raises main/ringmenu fuzzy match from 76.42% to 76.84%.

Per-function gains:
- drawCommand: 83.41% -> 88.15% (+4.74). Removed double-precision over-widening in SetPosX/SetPosY (now emits single-precision fadds/fnmsubs matching target instead of fadd/frsp/fmsub chains); made textWidth/textHeight float locals to drop redundant frsp.
- onDraw: 65.33% -> 65.34%. unsigned charge local in the magic-charge bar loop.

Blocker: the remaining gap in onDraw (65%), drawGBA (81%), DrawIcon (78%), and onCalc (83%) is dominated by uniform callee-saved register-window shifts and frame-size mismatches (e.g. drawGBA saves f24-f31 vs target f23-f31; onCalc stmw r24 vs target r22), i.e. the originals kept more values live across calls. These are deep allocation walls; if-polarity inversion, statement reordering, and per-function permute passes did not crack them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)