### PR TITLE
mesmenu: raise fuzzy match to 78.7%

### DIFF
--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -408,7 +408,7 @@ void CMesMenu::CalcHeart()
     }
 
     for (int i = 0; i < 8; i += 4) {
-        unsigned int value = m_heartGrowTimers[i] - 1;
+        int value = m_heartGrowTimers[i] - 1;
         m_heartGrowTimers[i] = value & ~((int)value >> 0x1F);
 
         value = m_heartDropTimers[i] - 1;


### PR DESCRIPTION
Raises main/mesmenu fuzzy match from 78.61% to 78.71%.

## Change
- **CalcHeart 97.62% -> 100.00%**: `m_heartGrowTimers[i] - 1` (and the parallel `m_heartDropTimers` decrement) is now stored in a signed `int` local instead of `unsigned int`. The field is `int`, so the signed decrement matches the original's instruction selection. Found via `tools/permute_fn.py`.

## Investigated but not landed
- onDraw (67.7%, dominant 6080b) is gated by a global callee-saved FPR allocation shift (stageBlend in f31 vs f29, stateBlend in f20 vs f30, etc.) and by the int->float conversion bias being emitted as an anonymous pool double (`@466`) instead of the named `DOUBLE_80330900` in sdata2. Both are systemic; partial `double`-local conversions and block-order/if-polarity edits all regressed.
- DrawHeart float-compare polarity and Open margin-store ordering were register-coloring artifacts driven by the same global allocation and resisted source-level fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)