### PR TITLE
menu_letter: raise fuzzy match to 77.5%

### DIFF
--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2093,16 +2093,16 @@ int CMenuPcs::LetterCtrlCur()
 		}
 
 		if ((hold & 8) != 0) {
-			if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) == 0) {
+			if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) != 0) {
+				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) - 1;
+				Sound.PlaySe(1, 0x40, 0x7F, 0);
+			} else {
 				if (*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) == 0) {
 					Sound.PlaySe(4, 0x40, 0x7F, 0);
 				} else {
 					*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) - 1;
 					Sound.PlaySe(1, 0x40, 0x7F, 0);
 				}
-			} else {
-				*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26) - 1;
-				Sound.PlaySe(1, 0x40, 0x7F, 0);
 			}
 		} else if ((hold & 4) != 0) {
 			int cursor = static_cast<int>(*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26));

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2130,21 +2130,13 @@ int CMenuPcs::LetterCtrlCur()
 			Sound.PlaySe(0x5A, 0x40, 0x7F, 0);
 			return 1;
 		}
-		if ((press & 0x100) == 0) {
-			if ((press & 0x200) == 0) {
+		if ((press & 0x100) != 0) {
+			if (letterCount == 0) {
+				Sound.PlaySe(4, 0x40, 0x7F, 0);
 				return 0;
 			}
-			*reinterpret_cast<u8*>(GetLetterStateBase(this) + 0xD) = 1;
-			Sound.PlaySe(3, 0x40, 0x7F, 0);
-			return 1;
-		}
 
-		if (letterCount == 0) {
-			Sound.PlaySe(4, 0x40, 0x7F, 0);
-			return 0;
-		}
-
-		*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x12) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x12) + 1;
+			*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x12) = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x12) + 1;
 		s_SelLetter = *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x34) + *reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x26);
 		CCaravanWork::CLetterWork* letter = &caravanWork->m_letters[s_SelLetter];
 		CMes::m_tempVar[0] = letter->TempVar(0);
@@ -2168,9 +2160,17 @@ int CMenuPcs::LetterCtrlCur()
 			*reinterpret_cast<float*>(panel + 8) = f;
 		}
 
-		*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x22) = 0;
-		Sound.PlaySe(2, 0x40, 0x7F, 0);
-		return 0;
+			*reinterpret_cast<s16*>(GetLetterStateBase(this) + 0x22) = 0;
+			Sound.PlaySe(2, 0x40, 0x7F, 0);
+			return 0;
+		}
+
+		if ((press & 0x200) == 0) {
+			return 0;
+		}
+		*reinterpret_cast<u8*>(GetLetterStateBase(this) + 0xD) = 1;
+		Sound.PlaySe(3, 0x40, 0x7F, 0);
+		return 1;
 	}
 
 	if (menuMode == 1) {


### PR DESCRIPTION
Raise `main/menu_letter` from 76.82% to 77.52% via R9 if-polarity inversions in `LetterCtrlCur`.

## Changes
- **LetterCtrlCur** `press & 0x100` dispatch: inverted the if-polarity so the bit-set (letter-open) path is the fallthrough arm and the `press & 0x200` handling becomes the else arm, matching the target's basic-block source order (`beq` epilogue vs inline return blocks).
- **LetterCtrlCur** `0x26` cursor block: flipped `== 0` to `!= 0` so the decrement path is the fallthrough, matching target block emission order.

## Per-function
- LetterCtrlCur: 70.11% -> 72.76%

## Blocker
The three worst functions are gated by register-coloring walls that resisted 10+ targeted attempts each:
- **LetterLstBaseDraw** (~67%): target keeps 14 callee-saved FPRs (f18-f31) vs ours 12 (f20-f31); R1 vec-scalarization / if-else restructuring of the corner-coordinate loops did not raise peak float-liveness enough to allocate f18/f19. Loop x/y selectors land in different scratch FPRs.
- **LetterCtrl** (~69%): pervasive `this`-register swap (target r31, ours r30) propagates a one-register shift through every member access; declaration reordering did not flip it.
- **LetterCtrlCur** remaining: signed/unsigned register-numbering shifts (press/hold/letterCount coloring) and a shared return-0 epilogue (tail-merge) the target uses but ours emits per-site.
- Inlined 8-iteration float-init loops want `mtctr/bdnz` but `for` fully unrolls and `do/while` emits `subic./bne`; neither form matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)