### PR TITLE
menu_compa: raise fuzzy match to 82.6%

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -205,7 +205,7 @@ void CMenuPcs::CompaDraw()
 	for (int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = memberIndex;
 		if (memberIndex > 1) {
-			for (; drawIndex < 8; drawIndex++) {
+			for (; drawIndex < 7; drawIndex++) {
 				if (caravanWork->m_evtWordArr[19 + drawIndex] != 0) {
 					break;
 				}
@@ -257,7 +257,7 @@ void CMenuPcs::CompaDraw()
 	for (int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = memberIndex;
 		if (memberIndex > 1) {
-			for (; drawIndex < 8; drawIndex++) {
+			for (; drawIndex < 7; drawIndex++) {
 				if (caravanWork->m_evtWordArr[19 + drawIndex] > 0) {
 					break;
 				}

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -96,7 +96,7 @@ void CMenuPcs::CompaDraw()
 
 				float fillW = entry->alpha * w;
 				if (fillW > kCompaZero) {
-					if (tex == 0x51) {
+					if (entry->tex == 0x51) {
 						int yStep = static_cast<int>(y);
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {
@@ -130,7 +130,7 @@ void CMenuPcs::CompaDraw()
 					colors[3].b = 0xFF;
 					colors[3].a = 0;
 					float remainW = static_cast<float>((LoadDouble(kCompaOneDouble) / (double)entry->duration) * (double)static_cast<float>(entry->w));
-					if (tex == 0x51) {
+					if (entry->tex == 0x51) {
 						int yStep = static_cast<int>(y);
 						float end = y + h;
 						while (static_cast<float>(yStep) < end) {


### PR DESCRIPTION
Raises `main/menu_compa` from 82.25% to 82.56% via two source-level structural corrections in `CompaDraw`:

- **Re-read `entry->tex` for the `== 0x51` checks** instead of using the cached `int tex`. The original re-reads the texture id from memory at the inner tile-loop guards (matches the target's repeated `lwz r0,0x1c(r19)`), rather than holding it in a callee-saved register.
- **Match the `drawIndex` skip-loop bound (`< 7`)** in both the icon and name draw loops. The target emits a `subfic rN,i,0x7` / `mtctr` counted loop (trip count `7 - i`); our `< 8` bound produced `0x8`. The post-loop `> 7` break is unchanged, preserving behavior.

CompaDraw: 73.25% -> 73.79%. Other functions (CompaCtrl, CompaInit, CompaOpen, CompaClose) unchanged.

Blocker: the unit is dominated by a whole-function callee-saved register-coloring offset (CompaDraw saves r20-r31 vs target's r19-r31; CompaInit saves one extra GPR). Every isolated source edit that touched liveness rippled the entire allocation and regressed. The remaining mismatches are overwhelmingly `DIFF_ARG_MISMATCH` register-number shifts and equivalent stack-slot scheduling (e.g. CompaOpen's magic-double conversion slots), not logic differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)