### PR TITLE
cflat_r2system: raise fuzzy match to 82.0%

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4358,7 +4358,8 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
     if (systemValue > -0x1000) {
         if (systemValue <= -500) {
             int bitIndex = systemValue + 0x9F3;
-            unsigned char* flagByte = reinterpret_cast<unsigned char*>(gameWork.m_eventFlags) + bitIndex / 8;
+            int byteIndex = bitIndex / 8 + 8;
+            unsigned char* flagByte = reinterpret_cast<unsigned char*>(gameWork.m_eventFlags) + byteIndex;
             unsigned int mask = 1U << (bitIndex % 8);
             unsigned int flag = *flagByte & mask;
             int value = (-flag | flag) >> 31;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4209,7 +4209,7 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         unsigned int flag = static_cast<unsigned int>(static_cast<unsigned char>(gameWork.m_eventFlags[byteIndex])) & mask;
         FlatLastResult(this) = (-flag | flag) >> 31;
     } else if (systemValue <= -200) {
-        short* artifact = gameWork.m_eventWork + systemValue + 0x1C7;
+        short* artifact = &gameWork.m_eventWork[systemValue + 0x1C7];
         FlatLastResult(this) = static_cast<unsigned int>(static_cast<int>(*artifact));
     } else {
         switch (systemValue) {

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4591,7 +4591,7 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
                 }
                 break;
             case -0x79:
-                stack[-1].m_word = static_cast<int>(static_cast<short>(Game.m_gameWork.m_optionValue));
+                stack[-1].m_word = static_cast<int>(static_cast<unsigned short>(Game.m_gameWork.m_optionValue));
                 if (setMode < 0) {
                     if (setMode >= -1) {
                         Game.m_gameWork.m_optionValue =

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4296,10 +4296,10 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
         case -0x6D:
         case -0x6C: {
             u8* usbEdit = game + (systemValue + 0x73) * 0xC30;
-            if (*(int*)(usbEdit + 0x1794) == 0) {
-                FlatLastResult(this) = 0;
-            } else {
+            if (*(int*)(usbEdit + 0x1794) != 0) {
                 FlatLastResult(this) = *(unsigned short*)(usbEdit + 0x1404);
+            } else {
+                FlatLastResult(this) = 0;
             }
             break;
         }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4318,18 +4318,19 @@ CFlatRuntime::CVal* CFlatRuntime2::onSystemVal(CFlatRuntime::CObject*, int syste
             case 1:
                 languageValue = 3;
                 break;
+            case 2:
+                languageValue = 5;
+                break;
             case 3:
                 languageValue = 6;
+                break;
+            case 4:
+                languageValue = 4;
                 break;
             case 5:
                 languageValue = 7;
                 break;
             default:
-                if (gameWork.m_languageId < 3) {
-                    languageValue = 5;
-                } else if (gameWork.m_languageId < 5) {
-                    languageValue = 4;
-                }
                 break;
             }
             FlatLastResult(this) = languageValue;


### PR DESCRIPTION
Raises `main/cflat_r2system` fuzzy match from 81.88% to 82.02%.

## Changes
- **onSystemVal** (92.0% → 96.3%):
  - Language-id `switch` made fully explicit (cases 0–5) so mwcc builds the target's balanced compare tree instead of a default-range if-chain.
  - usbEdit `if`-polarity flipped (`!= 0` first) to match target block order.
  - Artifact read via array index (`&m_eventWork[i]`) to keep the member offset 0x11cc as displacement instead of a folded flat byte offset.
- **onSetSystemVal**: flag byteIndex `+8` correction to match the read path (recovers the `lbzu 0x10d4` offset).
- **optionValue** read uses `unsigned short` (lhz) — found via permute.

## Blocker
The dominant remaining loss is onSetSystemVal's setMode if-chain (~134 INSERT/DELETE): the target emits test order `==0`/`>0`/`<0` with body memory order subtract/assign/add. No single C control-flow structure reproduces both simultaneously — mwcc reorders the blocks by branch distance, not source order. The leftover register-coloring shift (r6↔r7, r3↔r4) also resisted declaration-order and expression-order changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)