### PR TITLE
mes: raise fuzzy match to 85.8%

### DIFF
--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -776,7 +776,7 @@ void CMes::Calc()
 
 	int textEntry = (int)((char*)this + 0xC);
 	unsigned int maxAdvance = 0;
-	for (int i = 0; i < *(int*)((char*)this + 8); i++)
+	for (int i = 0; i < *(int*)((char*)this + 8); i++, textEntry += 0x14)
 	{
 		if ((int)(unsigned int)*(unsigned short*)(textEntry + 0xC) <= *(int*)((char*)this + 0x3C80))
 		{
@@ -790,7 +790,6 @@ void CMes::Calc()
 			    (unsigned char)((fadeMax & 0xF) | (*(unsigned char*)(textEntry + 0xF) & 0xF0));
 			maxAdvance = (unsigned int)*(unsigned char*)(textEntry + 0x13);
 		}
-		textEntry += 0x14;
 	}
 
 	unsigned char* flagEntry =

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1575,14 +1575,13 @@ void CMes::Next()
 		{
 			int j = i + 1;
 			curr = start + 5;
-			for (; j < remaining; j = j + 1)
+			for (; j < remaining; j = j + 1, curr = curr + 5)
 			{
 				if ((((unsigned int)*(unsigned char*)((char*)start + 0xe) >> 4 & 0xF) != ((unsigned int)*(unsigned char*)((char*)curr + 0xe) >> 4 & 0xF)) ||
 				    (*(short*)(start + 2) != *(short*)(curr + 2)))
 				{
 					break;
 				}
-				curr = curr + 5;
 			}
 			runLength = (unsigned int)(j - i);
 			groupWidth = (curr[-5] - *start) + (start[1] + *(float*)((char*)this + 0x3d3c));

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -596,7 +596,7 @@ void CMes::Draw()
 						if (specialPad)
 						{
 							int padType = Joybus.GetPadType(0);
-							mode = ((unsigned int)((0x40000 - padType) | (padType - 0x40000))) >> 31;
+							mode = ((unsigned int)((padType - 0x40000) | (0x40000 - padType))) >> 31;
 						}
 						else
 						{
@@ -616,7 +616,7 @@ void CMes::Draw()
 						if (specialPad)
 						{
 							int padType = Joybus.GetPadType(0);
-							mode = ((unsigned int)((0x40000 - padType) | (padType - 0x40000))) >> 31;
+							mode = ((unsigned int)((padType - 0x40000) | (0x40000 - padType))) >> 31;
 						}
 						else
 						{
@@ -636,7 +636,7 @@ void CMes::Draw()
 						if (specialPad)
 						{
 							int padType = Joybus.GetPadType(0);
-							mode = ((unsigned int)((0x40000 - padType) | (padType - 0x40000))) >> 31;
+							mode = ((unsigned int)((padType - 0x40000) | (0x40000 - padType))) >> 31;
 						}
 						else
 						{
@@ -656,7 +656,7 @@ void CMes::Draw()
 						if (specialPad)
 						{
 							int padType = Joybus.GetPadType(0);
-							mode = ((unsigned int)((0x40000 - padType) | (padType - 0x40000))) >> 31;
+							mode = ((unsigned int)((padType - 0x40000) | (0x40000 - padType))) >> 31;
 						}
 						else
 						{

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1584,7 +1584,7 @@ void CMes::Next()
 				}
 				curr = curr + 5;
 			}
-			runLength = (unsigned int)((int)curr - (int)start) / 0x14;
+			runLength = (unsigned int)(j - i);
 			groupWidth = (curr[-5] - *start) + start[1] + *(float*)((char*)this + 0x3d3c);
 			for (; runLength != 0; runLength = runLength - 1)
 			{

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -796,7 +796,7 @@ void CMes::Calc()
 
 	unsigned char* flagEntry =
 	    (unsigned char*)((char*)this + *(int*)((char*)this + 0x3C10) * 6 + 0x3C14);
-	while ((int)maxAdvance > *(int*)((char*)this + 0x3C10))
+	while (*(int*)((char*)this + 0x3C10) < (int)maxAdvance)
 	{
 		int type = *flagEntry;
 		switch (type)

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1575,14 +1575,13 @@ void CMes::Next()
 		{
 			int j = i + 1;
 			curr = start + 5;
-			for (entryCount = remaining - j; entryCount != 0; entryCount = entryCount - 1)
+			for (; j < remaining; j = j + 1)
 			{
 				if ((((unsigned int)*(unsigned char*)((char*)start + 0xe) >> 4 & 0xF) != ((unsigned int)*(unsigned char*)((char*)curr + 0xe) >> 4 & 0xF)) ||
 				    (*(short*)(start + 2) != *(short*)(curr + 2)))
 				{
 					break;
 				}
-				j = j + 1;
 				curr = curr + 5;
 			}
 			runLength = (unsigned int)((int)curr - (int)start) / 0x14;

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -673,7 +673,7 @@ void CMes::Draw()
 
 					MenuPcs.DrawRect(
 					    0, *(float*)((char*)this + 0x3C9C) + *glyph,
-					    kMesIconDrawYOffset + *(float*)((char*)this + 0x3CA0) + (float)*(short*)(glyph + 2),
+					    kMesIconDrawYOffset + *(float*)((char*)this + 0x3CA0) + (float)*(unsigned short*)(glyph + 2),
 					    kMesIconDefaultWidth, kMesIconDefaultWidth, (float)((iconId % 5) * 0x16),
 					    (float)((iconId / 5) * 0x16), kMesOne, kMesOne, 0.0f);
 
@@ -1578,7 +1578,7 @@ void CMes::Next()
 			for (; j < remaining; j = j + 1, curr = curr + 5)
 			{
 				if ((((unsigned int)*(unsigned char*)((char*)start + 0xe) >> 4 & 0xF) != ((unsigned int)*(unsigned char*)((char*)curr + 0xe) >> 4 & 0xF)) ||
-				    (*(short*)(start + 2) != *(short*)(curr + 2)))
+				    (*(unsigned short*)(start + 2) != *(short*)(curr + 2)))
 				{
 					break;
 				}
@@ -1588,7 +1588,7 @@ void CMes::Next()
 			for (; runLength != 0; runLength = runLength - 1)
 			{
 				type = (int)(((unsigned int)*(unsigned char*)((char*)start + 0xe) >> 4) & 0xF);
-				if ((unsigned int)type == 1)
+				if ((int)type == 1)
 				{
 					*start = halfVal * (*(float*)((char*)this + 0x3ca4) - groupWidth) + *start;
 				}

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1585,7 +1585,7 @@ void CMes::Next()
 				curr = curr + 5;
 			}
 			runLength = (unsigned int)(j - i);
-			groupWidth = (curr[-5] - *start) + start[1] + *(float*)((char*)this + 0x3d3c);
+			groupWidth = (curr[-5] - *start) + (start[1] + *(float*)((char*)this + 0x3d3c));
 			for (; runLength != 0; runLength = runLength - 1)
 			{
 				type = (int)(((unsigned int)*(unsigned char*)((char*)start + 0xe) >> 4) & 0xF);

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -201,7 +201,6 @@ void CMes::MakeAgbString(char* out, char* src, int playerIndex, int keepHyphenOn
 	unsigned char caseMode = 0;
 	unsigned char branchMode = 0;
 
-	char* townName = Game.m_gameWork.m_townName;
 	const unsigned char* op;
 	signed char c;
 	while ((c = in[0]) != 0)
@@ -365,9 +364,12 @@ void CMes::MakeAgbString(char* out, char* src, int playerIndex, int keepHyphenOn
 			break;
 		}
 		case 0x2F:
+		{
+			char* townName = Game.m_gameWork.m_townName;
 			strcpy(dst, townName);
 			dst += strlen(dst);
 			break;
+		}
 		case 0x30:
 		{
 			signed char varIndex = (signed char)GetMesNibbleValue((const char*)op);

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -1296,7 +1296,7 @@ void CMes::addString(char** text, int branchMode)
 			break;
 		case 0x36:
 		{
-			signed char idx = (unsigned char)ReadTagU8(text);
+			unsigned char idx = (unsigned char)ReadTagU8(text);
 			if (branchMode == 0)
 			{
 				int count = mFlagCount;


### PR DESCRIPTION
Raises main/mes fuzzy match from baseline 85.14% to 85.75% via source-level matching (no hacks).

## Per-function gains
- Next: 91.08 -> 91.23 — counted inner search loop, runLength = j - i (avoids div-by-20 strength reduction that shifted the register window), matched groupWidth associativity and inner-loop increment order.
- Calc: 91.43 -> 91.78 — matched loop increment order and while-condition operand order.
- Draw: 83.92 -> 85.08 — held the 0x40000 constant in the pad-mode calc; permute type fix (unsigned short glyph Y).
- MakeAgbString: 85.13 -> 85.70 — scoped townName to its single use site, eliminating an over-hoisted callee-saved register and aligning the stack frame to the target.
- addString: 83.64 -> 83.73 — unsigned idx for tag 0x36.

## Blocker
addString and Draw remain gated by the callee-saved register-window rotation: the target keeps one fewer value in a callee-saved GPR (addString: stmw r18 vs our r17) and spills it to a larger stack frame (0x250 vs 0x240). All remaining ARG_MISMATCH lines are this one-register shift plus the consequent stack-slot offsets, and the switch jump-tree pivot (cmpwi 3 vs 2) which is mwcc-determined. Neither is reachable from plausible C source without coercion hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)