### PR TITLE
cflat_runtime2: raise fuzzy match to 88.5%

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1413,9 +1413,9 @@ void CFlatRuntime2::Calc()
 void CFlatRuntime2::Draw()
 {
 	CFont* font = MenuPcs.m_fonts[0];
-	font->SetScale(0.65f);
+	font->SetScale(FLOAT_80330180);
 	font->SetShadow(1);
-	font->SetMargin(0.0f);
+	font->SetMargin(FLOAT_80330140);
 	font->SetZMode(0, 0);
 	font->DrawInit();
 	font->SetTlut(7);
@@ -1431,15 +1431,15 @@ void CFlatRuntime2::Draw()
 	}
 
 	font->SetZMode(0, 0);
-	font->SetPosZ(1.0f);
+	font->SetPosZ(FLOAT_80330144);
 	Mtx44 projection;
 	PSMTX44Copy(*reinterpret_cast<Mtx44*>(CameraPcsRaw() + 0x94), projection);
 	GXSetProjection(projection, GX_PERSPECTIVE);
 
 	font = MenuPcs.m_fonts[0];
-	font->SetScale(0.85f);
+	font->SetScale(FLOAT_80330184);
 	font->SetShadow(1);
-	font->SetMargin(0.0f);
+	font->SetMargin(FLOAT_80330140);
 	font->SetZMode(1, 1);
 	font->DrawInit();
 
@@ -1452,7 +1452,7 @@ void CFlatRuntime2::Draw()
 	}
 
 	font->SetZMode(0, 0);
-	font->SetPosZ(1.0f);
+	font->SetPosZ(FLOAT_80330144);
 	Mtx44 projection2;
 	PSMTX44Copy(*reinterpret_cast<Mtx44*>(CameraPcsRaw() + 0x94), projection2);
 	GXSetProjection(projection2, GX_PERSPECTIVE);

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1332,16 +1332,26 @@ void CFlatRuntime2::Calc()
 		Graphic.Printf(2, 3, const_cast<char*>(sCFlatRuntime2SaveSceneMsg));
 
 		u32* saveData = new (getStage(), const_cast<char*>(sCFlatRuntime2FileTag), 0x36F) u32[0x3FF];
+
+		u32 headerX = SwapF32(CameraPcs.m_positionX);
+		u32 headerY = SwapF32(CameraPcs.m_positionY);
+		u32 headerZ = SwapF32(CameraPcs.m_positionZ);
+		u32 headerTargetX = SwapF32(CameraPcs.m_targetX);
+		u32 headerTargetY = SwapF32(CameraPcs.m_targetY);
+		u32 headerTargetZ = SwapF32(CameraPcs.m_targetZ);
+		u32 headerFov = SwapF32(CameraPcs.m_fov);
+		u32 headerRotate = SwapF32((kCFlatAngleHalfTurnDeg * CameraPcs.m_zRotate) / kCFlatAnglePi);
+
 		u32* objectData = saveData + 8;
 
-		saveData[0] = SwapF32(CameraPcs.m_positionX);
-		saveData[1] = SwapF32(CameraPcs.m_positionY);
-		saveData[2] = SwapF32(CameraPcs.m_positionZ);
-		saveData[3] = SwapF32(CameraPcs.m_targetX);
-		saveData[4] = SwapF32(CameraPcs.m_targetY);
-		saveData[5] = SwapF32(CameraPcs.m_targetZ);
-		saveData[6] = SwapF32(CameraPcs.m_fov);
-		saveData[7] = SwapF32((kCFlatAngleHalfTurnDeg * CameraPcs.m_zRotate) / kCFlatAnglePi);
+		saveData[0] = headerX;
+		saveData[1] = headerY;
+		saveData[2] = headerZ;
+		saveData[3] = headerTargetX;
+		saveData[4] = headerTargetY;
+		saveData[5] = headerTargetZ;
+		saveData[6] = headerFov;
+		saveData[7] = headerRotate;
 
 		u32 lastX = 0;
 		u32 lastY = 0;

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1653,7 +1653,6 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 					if ((0.0f < distanceSq) && (distanceSq < radiusSq)) {
 						const float distance = sqrtf(distanceSq);
 						if (distance < radius) {
-							bool rejected = false;
 							if ((flags & 2) != 0) {
 								Vec facing;
 								PSVECScale(&offset, &offset, 1.0f / distance);
@@ -1661,36 +1660,34 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 								facing.y = 0.0f;
 								facing.z = cos(angle);
 								if (PSVECDotProduct(&offset, &facing) <= 0.0f) {
-									rejected = true;
+									goto advance;
 								}
 							}
 
-							if (!rejected) {
-								if ((flags & 4) == 0) {
-									int insertIndex = 0;
-									for (; insertIndex < count; insertIndex++) {
-										if (distance < *reinterpret_cast<float*>(&objects[insertIndex]->m_0x44)) {
-											break;
-										}
+							if ((flags & 4) == 0) {
+								int insertIndex = 0;
+								for (; insertIndex < count; insertIndex++) {
+									if (distance < *reinterpret_cast<float*>(&objects[insertIndex]->m_0x44)) {
+										break;
 									}
+								}
 
-									const int endIndex = (count < (maxCount - 1)) ? count : (maxCount - 1);
-									for (int i = endIndex; i > insertIndex; i--) {
-										objects[i] = objects[i - 1];
-									}
+								const int endIndex = (count < (maxCount - 1)) ? count : (maxCount - 1);
+								for (int i = endIndex; i > insertIndex; i--) {
+									objects[i] = objects[i - 1];
+								}
 
-									*reinterpret_cast<float*>(&object->m_0x44) = distance;
-									objects[insertIndex] = object;
-									newCount = maxCount;
-									if (count + 1 < maxCount) {
-										newCount = count + 1;
-									}
-								} else {
+								*reinterpret_cast<float*>(&object->m_0x44) = distance;
+								objects[insertIndex] = object;
+								newCount = maxCount;
+								if (count + 1 < maxCount) {
 									newCount = count + 1;
-									objects[count] = object;
-									if (newCount == maxCount) {
-										return newCount;
-									}
+								}
+							} else {
+								newCount = count + 1;
+								objects[count] = object;
+								if (newCount == maxCount) {
+									return newCount;
 								}
 							}
 						}
@@ -1699,6 +1696,7 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 			}
 		}
 
+	advance:
 		baseObj = FindNextGBaseObjByCidMask(&CFlat, reinterpret_cast<CFlatRuntime::CObject*>(object)->m_next, 5);
 		count = newCount;
 	} while (true);

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1624,15 +1624,16 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 	const float radiusSq = radius * radius;
 	CFlatRuntime::CObject* root = FlatObjectRoot(&CFlat);
 
-	if (maxCount <= 0 || objects == 0) {
-		return 0;
-	}
-
 	CGBaseObj* baseObj = FindNextGBaseObjByCidMask(&CFlat, root->m_next->m_next, 5);
 	int count = 0;
 
-	while (baseObj != 0) {
+	do {
+		if (baseObj == 0) {
+			return count;
+		}
+
 		CGObject* object = reinterpret_cast<CGObject*>(baseObj);
+		int newCount = count;
 		const bool passesClassMask = (object->m_attrFlags & static_cast<unsigned int>(classMask)) != 0;
 		const bool passesScriptFilter =
 			((flags & 1) == 0) ||
@@ -1652,6 +1653,7 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 					if ((0.0f < distanceSq) && (distanceSq < radiusSq)) {
 						const float distance = sqrtf(distanceSq);
 						if (distance < radius) {
+							bool rejected = false;
 							if ((flags & 2) != 0) {
 								Vec facing;
 								PSVECScale(&offset, &offset, 1.0f / distance);
@@ -1659,35 +1661,36 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 								facing.y = 0.0f;
 								facing.z = cos(angle);
 								if (PSVECDotProduct(&offset, &facing) <= 0.0f) {
-									baseObj = FindNextGBaseObjByCidMask(
-										&CFlat, reinterpret_cast<CFlatRuntime::CObject*>(object)->m_next, 5);
-									continue;
+									rejected = true;
 								}
 							}
 
-							if ((flags & 4) != 0) {
-								objects[count] = object;
-								count++;
-								if (count == maxCount) {
-									return count;
-								}
-							} else {
-								int insertIndex = 0;
-								for (; insertIndex < count; insertIndex++) {
-									if (distance < *reinterpret_cast<float*>(&objects[insertIndex]->m_0x44)) {
-										break;
+							if (!rejected) {
+								if ((flags & 4) == 0) {
+									int insertIndex = 0;
+									for (; insertIndex < count; insertIndex++) {
+										if (distance < *reinterpret_cast<float*>(&objects[insertIndex]->m_0x44)) {
+											break;
+										}
 									}
-								}
 
-								const int endIndex = (count < (maxCount - 1)) ? count : (maxCount - 1);
-								for (int i = endIndex; i > insertIndex; i--) {
-									objects[i] = objects[i - 1];
-								}
+									const int endIndex = (count < (maxCount - 1)) ? count : (maxCount - 1);
+									for (int i = endIndex; i > insertIndex; i--) {
+										objects[i] = objects[i - 1];
+									}
 
-								*reinterpret_cast<float*>(&object->m_0x44) = distance;
-								objects[insertIndex] = object;
-								if (count < maxCount) {
-									count++;
+									*reinterpret_cast<float*>(&object->m_0x44) = distance;
+									objects[insertIndex] = object;
+									newCount = maxCount;
+									if (count + 1 < maxCount) {
+										newCount = count + 1;
+									}
+								} else {
+									newCount = count + 1;
+									objects[count] = object;
+									if (newCount == maxCount) {
+										return newCount;
+									}
 								}
 							}
 						}
@@ -1697,9 +1700,8 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 		}
 
 		baseObj = FindNextGBaseObjByCidMask(&CFlat, reinterpret_cast<CFlatRuntime::CObject*>(object)->m_next, 5);
-	}
-
-	return count;
+		count = newCount;
+	} while (true);
 }
 
 /*

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1587,15 +1587,15 @@ void CFlatRuntime2::AddDebugDrawCC(Vec* from, Vec* to, float radius, int bit7, i
 	int& count = DebugDrawCCCount(runtime);
 
 	if (static_cast<unsigned int>(count) < 0x10U) {
-		DebugDrawCCEntries(runtime)[count].m_from = *from;
-		DebugDrawCCEntries(runtime)[count].m_to = *to;
+		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_from = *from;
+		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_to = *to;
 
-		DebugDrawCCEntries(runtime)[count].m_flagBits.m_bit7 = bit7;
-		DebugDrawCCEntries(runtime)[count].m_flagBits.m_bit6 = bit6;
+		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_flagBits.m_bit7 = bit7;
+		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_flagBits.m_bit6 = bit6;
 
 		const int index = count;
 		count = index + 1;
-		DebugDrawCCEntries(runtime)[index].m_radius = radius;
+		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[index].m_radius = radius;
 		return;
 	}
 

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -470,10 +470,10 @@ CFlatRuntime2::CFlatRuntime2()
 		gObj++;
 	}
 
-	CGPartyObj* partyObj = reinterpret_cast<CGPartyObj*>(m_objParty);
-	for (int i = 0; i < kFlatPartyObjCount; i++, partyObj++) {
-		InitFlatObjectSlot(partyObj, static_cast<u16>((i + 1) | 0x300));
-	}
+	InitFlatObjectSlot(&m_objParty[0], 0x301);
+	InitFlatObjectSlot(&m_objParty[1], 0x302);
+	InitFlatObjectSlot(&m_objParty[2], 0x303);
+	InitFlatObjectSlot(&m_objParty[3], 0x304);
 
 	CGMonObj* monObj = reinterpret_cast<CGMonObj*>(m_objMon);
 	for (int i = 0; i < kFlatMonObjCount; i++, monObj++) {


### PR DESCRIPTION
Raises main/cflat_runtime2 fuzzy match from 87.48% to 88.50%.

Per-function gains:
- AddDebugDrawCC 83.5% -> 95.9%: access m_debugDrawCCEntries directly through the typed `this` member instead of a helper that returns the array pointer; this stops mwcc from CSE-ing the entries base into a register and matches the target's inline `this + count*0x20 + offset` recomputation per field.
- CcClass2D 76.5% -> 85.2%: restructured to the original do-while shape (separate find-first, then `do { if (obj==0) return count; ... }`), removed the spurious early `maxCount<=0||objects==0` guard, matched the count-clamp logic (`count = (count+1<maxCount)?count+1:maxCount`), and used a goto for the (flags&2) reject path to match the target block order.
- __ct__13CFlatRuntime2 84.8% -> 89.2%: unrolled the 4-iteration party-object init loop into explicit calls, matching mwcc's full unroll + batched loads/stores.
- Calc 73.3% -> 73.9%: save-scene header SwapF32 results staged into named locals before writing the heap buffer (matches Ghidra local layout).
- Draw 74.3% -> 74.3%: font scale/margin/posZ use the named float SDA constants the target references.

Remaining blockers (reg-alloc / frame-size driven, not source-fixable here):
- drawLayer (77%) and Draw (74%): frame-size/saved-FPR differences from extra/long-lived locals.
- PutParticle / ResetParticleWork (84-85%): `= CParticleWork()` copies field-by-field (byte loads for u8 fields) while the target does a flat word copy; would need pad/extra fields initialized or a flat-copy form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)