### PR TITLE
menu_item: raise fuzzy match to 91.3%

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -329,9 +329,9 @@ void CMenuPcs::ItemDraw()
         float h = (float)entry->h;
         float u = entry->u;
         float v = entry->v;
-        float alpha = entry->alpha;
 
         if (i == 0) {
+            float alpha = entry->alpha;
             MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(1));
             MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(tex));
 
@@ -387,6 +387,7 @@ void CMenuPcs::ItemDraw()
 
             MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
         } else {
+            float alpha = entry->alpha;
             float itemAlpha = alpha;
             if (tex == 0x37) {
                 unsigned int menuIndex = drawIndex + this->m_itemMenuState->scroll;

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -144,7 +144,7 @@ int CMenuPcs::ItemCtrlCur()
         return 0;
     }
 
-    int mode = this->m_itemMenuState->mode;
+    unsigned int mode = this->m_itemMenuState->mode;
     s16 letterAttachFlg = SingGetLetterAttachflg();
 
     if (mode == 0) {

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -536,7 +536,7 @@ void CMenuPcs::ItemDraw()
     }
     float helpBaseX = LoadFloat(kItemHelpCenterX);
     float helpOffsetX = LoadFloat(kItemHalf);
-    int helpX = (unsigned int)(helpBaseX - (float)(LoadDouble(kItemHalfDouble) * (double)helpOffsetX));
+    int helpX = (int)(helpBaseX - LoadFloat(kItemHalf) * helpOffsetX);
     int helpY = (int)LoadFloat(kItemHelpY);
     DrawHelpMessage(
         selectedItemId,

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -447,9 +447,11 @@ void CMenuPcs::ItemDraw()
                 selectedItemId = itemId;
             }
 
+            float textX = (float)(textEntry->x + 0x1C);
+            float textY = (float)(textEntry->y + 0xB);
             listFont->GetWidth(text);
-            listFont->SetPosX((float)(textEntry->x + 0x1C));
-            listFont->SetPosY((float)(textEntry->y + 0xB) - LoadFloat(kItemTextYOffset));
+            listFont->SetPosX(textX);
+            listFont->SetPosY(textY - LoadFloat(kItemTextYOffset));
             listFont->Draw(text);
         }
     }

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -520,10 +520,11 @@ void CMenuPcs::ItemDraw()
     DrawSingLife();
 
     CFont* helpFont = this->m_fonts[0];
-    CColor helpColor(0xFF, 0xFF, 0xFF, (u8)(LoadFloat(kItemColorMax) * cursorEntry->alpha));
+    u8 helpAlpha = (u8)(LoadFloat(kItemColorMax) * cursorEntry->alpha);
     if (!foundSelected) {
         selectedItemId = -1;
     }
+    CColor helpColor(0xFF, 0xFF, 0xFF, helpAlpha);
     float helpBaseX = LoadFloat(kItemHelpCenterX);
     float helpOffsetX = LoadFloat(kItemHalf);
     int helpX = (int)(helpBaseX - LoadFloat(kItemHalf) * helpOffsetX);

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -513,7 +513,7 @@ void CMenuPcs::ItemDraw()
 
             cursorEntry += this->m_itemMenuState->cursorIndex[0];
             cursorX = (float)(cursorEntry->x - 0x14);
-            cursorY = (float)((float)(cursorEntry->h - 0x20) * (float)LoadDouble(kItemHalfDouble) + (float)cursorEntry->y);
+            cursorY = (float)((double)(cursorEntry->h - 0x20) * LoadDouble(kItemHalfDouble) + (double)cursorEntry->y);
         } else {
             MenuWindowInfo* window = this->m_menuWindowInfo;
             cursorX = (float)window->x;

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -363,18 +363,6 @@ void CMenuPcs::ItemDraw()
             }
 
             if (w > LoadFloat(kItemZero) && w < entry->w) {
-                colors[0].r = 0xFF;
-                colors[0].g = 0xFF;
-                colors[0].b = 0xFF;
-                colors[0].a = 0;
-                colors[1].r = 0xFF;
-                colors[1].g = 0xFF;
-                colors[1].b = 0xFF;
-                colors[1].a = 0;
-                colors[2].r = 0xFF;
-                colors[2].g = 0xFF;
-                colors[2].b = 0xFF;
-                colors[2].a = 0;
                 colors[3].r = 0xFF;
                 colors[3].g = 0xFF;
                 colors[3].b = 0xFF;

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -447,9 +447,9 @@ void CMenuPcs::ItemDraw()
                 selectedItemId = itemId;
             }
 
+            listFont->GetWidth(text);
             float textX = (float)(textEntry->x + 0x1C);
             float textY = (float)(textEntry->y + 0xB);
-            listFont->GetWidth(text);
             listFont->SetPosX(textX);
             listFont->SetPosY(textY - LoadFloat(kItemTextYOffset));
             listFont->Draw(text);

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -387,24 +387,23 @@ void CMenuPcs::ItemDraw()
 
             MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
         } else {
-            float alpha = entry->alpha;
-            float itemAlpha = alpha;
+            float itemAlpha = entry->alpha;
             if (tex == 0x37) {
-                unsigned int menuIndex = drawIndex + this->m_itemMenuState->scroll;
-                if (menuIndex > 0x3F) {
+                int menuIndex = drawIndex + this->m_itemMenuState->scroll;
+                if (menuIndex >= 0x40) {
                     menuIndex -= 0x40;
                 }
 
                 s16 itemId = caravanWork->m_inventoryItems[menuIndex];
-                if ((itemId < 1) || (EquipChk(menuIndex) != 0) ||
+                if ((itemId <= 0) || (EquipChk(menuIndex) != 0) ||
                     (hasLetterAttach && (itemId < 0x125))) {
                     if (EquipChk(menuIndex) != 0) {
                         int markX = (int)(x - LoadFloat(kItemMarkXOffset));
                         int markY = (int)((h - LoadFloat(kItemMarkHeight)) * LoadDouble(kItemHalfDouble) + y);
-                        DrawEquipMark(markX, markY, alpha);
+                        DrawEquipMark(markX, markY, entry->alpha);
                     }
                     tex = 0x34;
-                    itemAlpha = (float)((double)LoadDouble(kItemHalfDouble) * (double)alpha);
+                    itemAlpha = (float)((double)LoadDouble(kItemHalfDouble) * (double)entry->alpha);
                 }
 
                 if (tex == 0x37 && drawIndex == this->m_itemMenuState->cursorIndex[0]) {


### PR DESCRIPTION
Raises `main/menu_item` fuzzy match from baseline 88.70% to 91.35%.

## Per-function gains
- **ItemDraw**: 82.27% -> 89.30% (largest contributor)
  - Defer `entry->alpha` load; read it directly at use sites instead of caching across the loop (removes an extra live FPR).
  - `double`-precision `cursorY` computation (matches target `fsub`/`fmadd` vs spurious `frsp`/`fsubs`).
  - Single-precision `helpX` with a signed `(int)` cast (removes `__cvt_fp2unsigned` runtime call, emits `fnmsubs`).
  - Second "remaining time" rect only resets `colors[3]` (target writes one GXColor, not four).
  - Front-load text X/Y float conversions and place them after `GetWidth` (matches emission order).
  - Evaluate `helpAlpha` before the `!foundSelected` check so the CColor ctor is emitted after.
  - Signed `menuIndex` comparison.
- **ItemCtrlCur**: 92.15% -> 92.18% (`unsigned int mode`).

## Blocker
The remaining gap is a callee-saved register-window shift of one (ItemDraw, ItemCtrlCur) or two (ItemInit) GPRs. The cached `m_itemList` local is the extra register in ItemDraw, but removing it over-reloads and regresses; ItemInit's `index`/constant residency resists literal-index and front-loading rewrites. The persistent `@NNN` vs `kItemIntToDoubleBias@sda21` anonymous-bias naming and the `clrlwi.` vs `cmpwi` on `EquipChk` results are compiler/prototype-level artifacts not cleanly source-fixable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)