### PR TITLE
menu_arti: raise fuzzy match to 90.2%

### DIFF
--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -267,7 +267,7 @@ void CMenuPcs::ArtiDraw()
 					u += fillW;
 				}
 
-				if (fillW > 0.0f && fillW < (float)entry->w) {
+				if (fillW > LoadFloat(kArtiZero) && fillW < (float)entry->w) {
 					colors[0].a = 0;
 					colors[1].a = 0;
 					colors[2].a = 0;

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -88,7 +88,7 @@ static inline ArtiOpenAnim* GetArtiOpenAnim(CMenuPcs* menu, int index)
 
 static inline CFont* GetArtiListFont(CMenuPcs* menu)
 {
-	return menu->m_fonts[1];
+	return menu->m_fonts[4];
 }
 
 static inline CFont* GetArtiHelpFont(CMenuPcs* menu)

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -239,7 +239,7 @@ void CMenuPcs::ArtiDraw()
 
 			if (i == 0) {
 				MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(1));
-				MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(tex));
+				MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(entry->tex));
 
 				GXColor colors[4];
 				colors[0].r = 0xFF;

--- a/src/menu_arti.cpp
+++ b/src/menu_arti.cpp
@@ -223,7 +223,7 @@ void CMenuPcs::ArtiDraw()
 	const CCaravanWork* const caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
 	short artiState = m_artiState->state;
 	ArtiOpenAnim* entry = GetArtiOpenAnimList(this)->entries;
-	int drawIndex = 0;
+	unsigned int drawIndex = 0;
 	float helpWidth;
 
 	for (int i = 0; i < GetArtiOpenAnimList(this)->count; i++) {
@@ -324,7 +324,7 @@ void CMenuPcs::ArtiDraw()
 
 	ArtiOpenAnim* textEntry = listStart;
 	for (int i = 0; i < 8; i++) {
-		s8 alpha = (u8)(kArtiColorMax * textEntry->alpha);
+		u8 alpha = (u8)(kArtiColorMax * textEntry->alpha);
 		CColor color(0xFF, 0xFF, 0xFF, alpha);
 		listFont->SetColor(color.color);
 


### PR DESCRIPTION
Raises main/menu_arti from 89.86% to 90.23%.

Changes (all clean, semantically-correct source fixes):
- ArtiDraw: reload entry->tex for SetTexture instead of caching it in a register, matching the original's register window (eliminates a mr-from-cached-reg).
- ArtiDraw: GetArtiListFont reads m_fonts[4] (was m_fonts[1]); the binary loads 0xF8+0x10 = m_fonts[4], confirmed by asm.
- ArtiDraw: correct signedness of drawIndex (unsigned int) and the text alpha local (u8).
- ArtiDraw: route the second fillW>0 comparison through the by-reference LoadFloat helper so the kArtiZero load uses its named sdata2 symbol like the original.

Per-function: ArtiDraw 85.64 -> 86.31. ArtiOpen/ArtiClose dip slightly (shared anonymous float-pool reindexing) but net unit is up.

Remaining blockers: a one-extra callee-saved-GPR (r19 vs r20) frame-window difference in ArtiDraw and a register-coloring order difference in ArtiInit/ArtiInit1's precomputed entry offsets — both mwcc-internal allocation choices that resisted source reordering and permute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)