### PR TITLE
cflat_r2system: raise fuzzy match to 83.6%

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1637,14 +1637,13 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
             }
         }
 
-        CLineSegment& segment = segments[i];
-        float dotTarget = PSVECDotProduct(targetPosition, &segment.delta);
-        float dotPoint = PSVECDotProduct(&points[i], &segment.delta);
-        float segmentT = (dotTarget - dotPoint) / (segment.length * segment.length);
+        float dotTarget = PSVECDotProduct(targetPosition, &segments[i].delta);
+        float dotPoint = PSVECDotProduct(&points[i], &segments[i].delta);
+        float segmentT = (dotTarget - dotPoint) / (segments[i].length * segments[i].length);
         if (((kLineSegmentMinT <= segmentT) && (segmentT <= kLineSegmentMaxT)) || infiniteRange) {
             Vec scaled;
             Vec projected;
-            PSVECScale(&segment.delta, &scaled, segmentT);
+            PSVECScale(&segments[i].delta, &scaled, segmentT);
             PSVECAdd(&points[i], &scaled, &projected);
             float distance = PSVECDistance(targetPosition, &projected);
             if (distance < bestDistance) {

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4367,14 +4367,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             stack[-1].m_word = value;
 
             int result = value;
-            if (setMode < 0) {
-                if (setMode >= -1) {
-                    result = value - stack->m_word;
-                }
-            } else if (setMode == 0) {
+            switch (setMode) {
+            case -1:
+                result = value - stack->m_word;
+                break;
+            case 0:
                 result = stack->m_word;
-            } else if (setMode < 2) {
+                break;
+            case 1:
                 result = value + stack->m_word;
+                break;
             }
 
             if (result != 0) {
@@ -4385,65 +4387,75 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
         } else if (systemValue <= -200) {
             short* artifact = &Game.m_gameWork.m_eventWork[systemValue + 0x1C7];
             stack[-1].m_word = *artifact;
-            if (setMode < 0) {
-                if (setMode >= -1) {
-                    *artifact = static_cast<short>(*artifact - stack->m_word);
-                }
-            } else if (setMode == 0) {
+            switch (setMode) {
+            case -1:
+                *artifact = static_cast<short>(*artifact - stack->m_word);
+                break;
+            case 0:
                 *artifact = static_cast<short>(stack->m_word);
-            } else if (setMode < 2) {
+                break;
+            case 1:
                 *artifact = static_cast<short>(*artifact + stack->m_word);
+                break;
             }
         } else {
             switch (systemValue) {
             case -0x40:
                 stack[-1].m_word = *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0);
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
-                            *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
+                        *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) - stack->m_word;
+                    break;
+                case 0:
                     *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) =
                         *reinterpret_cast<unsigned int*>(&gameWork.m_scriptSysVal0) + stack->m_word;
+                    break;
                 }
                 break;
             case -0x41:
                 stack[-1].m_word = gameWork.m_timerA;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        gameWork.m_timerA = gameWork.m_timerA - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    gameWork.m_timerA = gameWork.m_timerA - stack->m_word;
+                    break;
+                case 0:
                     gameWork.m_timerA = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     gameWork.m_timerA = gameWork.m_timerA + stack->m_word;
+                    break;
                 }
                 break;
             case -0x42:
                 stack[-1].m_word = gameWork.m_scriptGlobalTime;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime - stack->m_word;
+                    break;
+                case 0:
                     gameWork.m_scriptGlobalTime = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     gameWork.m_scriptGlobalTime = gameWork.m_scriptGlobalTime + stack->m_word;
+                    break;
                 }
                 break;
             case -0x43:
                 stack[-1].m_word = gameWork.m_frameCounter;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        gameWork.m_frameCounter = gameWork.m_frameCounter - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    gameWork.m_frameCounter = gameWork.m_frameCounter - stack->m_word;
+                    break;
+                case 0:
                     gameWork.m_frameCounter = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     gameWork.m_frameCounter = gameWork.m_frameCounter + stack->m_word;
+                    break;
                 }
                 break;
             case -0x56:
@@ -4463,14 +4475,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x48: {
                 int* value = &Game.m_gameWork.m_bossArtifactStageTable[systemValue + 0x56];
                 stack[-1].m_word = *value;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        *value = *value - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    *value = *value - stack->m_word;
+                    break;
+                case 0:
                     *value = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     *value = *value + stack->m_word;
+                    break;
                 }
                 break;
             }
@@ -4491,27 +4505,31 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x57: {
                 int* value = &Game.m_gameWork.m_unkStageTable[systemValue + 0x65];
                 stack[-1].m_word = *value;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        *value = *value - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    *value = *value - stack->m_word;
+                    break;
+                case 0:
                     *value = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     *value = *value + stack->m_word;
+                    break;
                 }
                 break;
             }
             case -0x66:
                 stack[-1].m_word = gameWork.m_chaliceElement;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        gameWork.m_chaliceElement = gameWork.m_chaliceElement - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    gameWork.m_chaliceElement = gameWork.m_chaliceElement - stack->m_word;
+                    break;
+                case 0:
                     gameWork.m_chaliceElement = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     gameWork.m_chaliceElement = gameWork.m_chaliceElement + stack->m_word;
+                    break;
                 }
                 break;
             case -0x6B:
@@ -4521,14 +4539,16 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x67: {
                 int* value = &Game.m_gameWork.m_eventHeader[systemValue + 0x6B];
                 stack[-1].m_word = *value;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        *value = *value - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    *value = *value - stack->m_word;
+                    break;
+                case 0:
                     *value = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     *value = *value + stack->m_word;
+                    break;
                 }
                 break;
             }
@@ -4538,72 +4558,82 @@ void CFlatRuntime2::onSetSystemVal(int systemValue, CFlatRuntime::CStack* stack,
             case -0x44: {
                 int* value = &Game.m_gameWork.m_wmBackupParams[systemValue + 0x47];
                 stack[-1].m_word = *value;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        *value = *value - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    *value = *value - stack->m_word;
+                    break;
+                case 0:
                     *value = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     *value = *value + stack->m_word;
+                    break;
                 }
                 break;
             }
             case -0x75:
                 stack[-1].m_word = static_cast<int>(Game.m_gameWork.m_bossArtifactStageIndex);
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        Game.m_gameWork.m_bossArtifactStageIndex =
-                            static_cast<short>(Game.m_gameWork.m_bossArtifactStageIndex - stack->m_word);
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    Game.m_gameWork.m_bossArtifactStageIndex =
+                        static_cast<short>(Game.m_gameWork.m_bossArtifactStageIndex - stack->m_word);
+                    break;
+                case 0:
                     Game.m_gameWork.m_bossArtifactStageIndex = static_cast<short>(stack->m_word);
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     Game.m_gameWork.m_bossArtifactStageIndex =
                         static_cast<short>(Game.m_gameWork.m_bossArtifactStageIndex + stack->m_word);
+                    break;
                 }
                 break;
             case -0x76: {
                 unsigned int value = static_cast<unsigned int>(gameWork.m_menuStageMode);
                 stack[-1].m_word = value;
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        value = value - stack->m_word;
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    value = value - stack->m_word;
+                    break;
+                case 0:
                     value = stack->m_word;
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     value = value + stack->m_word;
+                    break;
                 }
                 MenuPcs.ChgPlayModeFromScript(static_cast<bool>((-value | value) >> 31));
                 break;
             }
             case -0x77:
                 stack[-1].m_word = static_cast<unsigned int>(Game.m_gameWork.m_soundOptionFlag);
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        Game.m_gameWork.m_soundOptionFlag =
-                            static_cast<unsigned char>(Game.m_gameWork.m_soundOptionFlag - stack->m_word);
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    Game.m_gameWork.m_soundOptionFlag =
+                        static_cast<unsigned char>(Game.m_gameWork.m_soundOptionFlag - stack->m_word);
+                    break;
+                case 0:
                     Game.m_gameWork.m_soundOptionFlag = static_cast<unsigned char>(stack->m_word);
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     Game.m_gameWork.m_soundOptionFlag =
                         static_cast<unsigned char>(Game.m_gameWork.m_soundOptionFlag + stack->m_word);
+                    break;
                 }
                 break;
             case -0x79:
                 stack[-1].m_word = static_cast<int>(static_cast<unsigned short>(Game.m_gameWork.m_optionValue));
-                if (setMode < 0) {
-                    if (setMode >= -1) {
-                        Game.m_gameWork.m_optionValue =
-                            static_cast<unsigned short>(Game.m_gameWork.m_optionValue - stack->m_word);
-                    }
-                } else if (setMode == 0) {
+                switch (setMode) {
+                case -1:
+                    Game.m_gameWork.m_optionValue =
+                        static_cast<unsigned short>(Game.m_gameWork.m_optionValue - stack->m_word);
+                    break;
+                case 0:
                     Game.m_gameWork.m_optionValue = static_cast<unsigned short>(stack->m_word);
-                } else if (setMode < 2) {
+                    break;
+                case 1:
                     Game.m_gameWork.m_optionValue =
                         static_cast<unsigned short>(Game.m_gameWork.m_optionValue + stack->m_word);
+                    break;
                 }
                 break;
             default:


### PR DESCRIPTION
Raises main/cflat_r2system fuzzy match from 82.02% to 83.64%.

## Changes
- **onSetSystemVal**: replaced the `if (setMode < 0) {...} else if (setMode == 0) ... else if (setMode < 2)` chains with `switch (setMode) { case -1 / case 0 / case 1 }` across all ~15 store sites. mwcc emits the target's compact comparison tree (`beq` ==0 first, then `bge` >0, then `>= -1`) with all arm bodies placed after, matching the original block order (R9). This took onSetSystemVal from 61.6% to ~91%.
- **CLine<64>::Calc**: inlined the `CLineSegment& segment = segments[i]` reference into direct `segments[i].delta` / `.length` accesses, shaving register pressure.

## Remaining blockers (not source-fixable)
- onSystemFunc (the dominant 23.6KB function) is dominated by relocation-rendering differences (`subi 0x7858` resolved vs `addi CameraPcs@l` symbolic) and string-pool ordering — these resolve identically at link time and are not source-controllable.
- onSetSystemVal bit-block and CLine::Calc residual diffs are tight register-allocation/scheduling walls (r7↔r8 coloring, one extra cached points-base GPR) that resisted reordering, pointer-trick, and frame-shaping attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)