### PR TITLE
cflat_runtime: raise fuzzy match to 80.2%

### DIFF
--- a/include/ffcc/cflat_runtime.h
+++ b/include/ffcc/cflat_runtime.h
@@ -121,12 +121,12 @@ public:
 	virtual int Frame(int, int);
 	virtual void onNewObject(CFlatRuntime::CObject*);
 	virtual void onDeleteObject(CFlatRuntime::CObject*);
-	virtual int onSystemFunc(CFlatRuntime::CObject*, int, int, int&);
 	virtual int onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&);
-	virtual CFlatRuntime::CVal* onSystemVal(CFlatRuntime::CObject*, int);
+	virtual int onSystemFunc(CFlatRuntime::CObject*, int, int, int&);
 	virtual CFlatRuntime::CVal* onClassSystemVal(CFlatRuntime::CObject*, int);
-	virtual void onSetSystemVal(int, CFlatRuntime::CStack*, int);
+	virtual CFlatRuntime::CVal* onSystemVal(CFlatRuntime::CObject*, int);
 	virtual void onSetClassSystemVal(int, CFlatRuntime::CObject*, CFlatRuntime::CStack*, int);
+	virtual void onSetSystemVal(int, CFlatRuntime::CStack*, int);
 	virtual CFlatRuntime::CObject* getFreeObject(int);
 	virtual void* intToClass(int);
 	virtual void reqFinished(int, CFlatRuntime::CObject*);

--- a/include/ffcc/cflat_runtime2.h
+++ b/include/ffcc/cflat_runtime2.h
@@ -198,11 +198,12 @@ public:
 
 private:
 	virtual int onClassSystemFunc(CFlatRuntime::CObject*, int, int, int&);
-	virtual CFlatRuntime::CVal* onClassSystemVal(CFlatRuntime::CObject*, int);
-	virtual void onSetClassSystemVal(int, CFlatRuntime::CObject*, CFlatRuntime::CStack*, int);
-
 	virtual int onSystemFunc(CFlatRuntime::CObject*, int, int, int&);
+
+	virtual CFlatRuntime::CVal* onClassSystemVal(CFlatRuntime::CObject*, int);
 	virtual CFlatRuntime::CVal* onSystemVal(CFlatRuntime::CObject*, int);
+
+	virtual void onSetClassSystemVal(int, CFlatRuntime::CObject*, CFlatRuntime::CStack*, int);
 	virtual void onSetSystemVal(int, CFlatRuntime::CStack*, int);
 
 public:

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2323,7 +2323,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			            reinterpret_cast<CStack*>(object->m_localBase + 2)) != 0) {
 				if (object == reinterpret_cast<CObject*>(object->m_engineObject)) {
 					result = 2;
-					return 1;
+					return ret;
 				}
 
 				*object->m_sp = 0;
@@ -2335,7 +2335,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			*reinterpret_cast<int*>(&object->m_reqFlag0) = 0;
 
 			if (noPush != 0) {
-				return 1;
+				return ret;
 			}
 
 			*object->m_sp = 0;

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2298,7 +2298,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			CStopWatch watch("no name");
 			watch.Reset();
 			watch.Start();
-			ret = onSystemFunc(object, systemKind, systemIndex, result);
+			ret = onClassSystemFunc(object, systemKind, systemIndex, result);
 			watch.Stop();
 			*reinterpret_cast<float*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x4C) += watch.Get();
 			*reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x44C) += 1;
@@ -2404,7 +2404,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 		CStopWatch watch("no name");
 		watch.Reset();
 		watch.Start();
-		ret = onClassSystemFunc(object, systemKind, systemIndex, result);
+		ret = onSystemFunc(object, systemKind, systemIndex, result);
 		watch.Stop();
 		*reinterpret_cast<float*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x24C) += watch.Get();
 		*reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x64C) += 1;

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2265,21 +2265,19 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 									case 'd':
 									case 'x':
 										sprintf(rendered, spec, *arg);
-										scan = const_cast<char*>("");
-										break;
+										goto renderedDone;
 									case 'f':
 										sprintf(rendered, spec, static_cast<double>(*reinterpret_cast<float*>(arg)));
-										scan = const_cast<char*>("");
-										break;
+										goto renderedDone;
 									case 's':
 										sprintf(rendered, spec, m_strBlob + m_strOffsets[*arg]);
-										scan = const_cast<char*>("");
-										break;
+										goto renderedDone;
 									default:
 										scan++;
 										break;
 									}
 								}
+							renderedDone:;
 							}
 						}
 

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2298,7 +2298,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			CStopWatch watch("no name");
 			watch.Reset();
 			watch.Start();
-			ret = onClassSystemFunc(object, 1, systemIndex, result);
+			ret = onSystemFunc(object, systemKind, systemIndex, result);
 			watch.Stop();
 			*reinterpret_cast<float*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x4C) += watch.Get();
 			*reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x44C) += 1;
@@ -2404,7 +2404,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 		CStopWatch watch("no name");
 		watch.Reset();
 		watch.Start();
-		ret = onSystemFunc(object, systemKind, systemIndex, result);
+		ret = onClassSystemFunc(object, systemKind, systemIndex, result);
 		watch.Stop();
 		*reinterpret_cast<float*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x24C) += watch.Get();
 		*reinterpret_cast<int*>(reinterpret_cast<u8*>(this) + ((-systemIndex) * 4) + 0x64C) += 1;

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2303,67 +2303,9 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			break;
 		}
 		}
-	} else if (systemIndex == -2) {
-		CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
-		const u32 scriptGroup = *object->m_localBase;
-
-		engineObject->m_next->m_previous = engineObject->m_previous;
-		engineObject->m_previous->m_next = engineObject->m_next;
-
-		CObject* const root = &m_objectSentinel;
-		CObject* begin = root->m_next;
-		CObject* it = begin;
-		do {
-			if (static_cast<int>(scriptGroup) < it->m_0x32) {
-				break;
-			}
-			it = it->m_next;
-		} while (it != begin);
-
-		it = it->m_previous;
-		engineObject->m_next = it;
-		engineObject->m_previous = it->m_previous;
-		it->m_previous->m_next = engineObject;
-		it->m_previous = engineObject;
-		engineObject->m_0x32 = static_cast<s16>(scriptGroup);
-
-		*object->m_sp++ = 0;
-		result = 0;
 	} else {
-		if (systemIndex < -2) {
-			if (systemIndex == -4) {
-				SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
-				    this, object, 2, *object->m_localBase, object->m_argCount - 1,
-				    reinterpret_cast<CStack*>(object->m_localBase + 1), 0);
-				*object->m_sp++ = 0;
-				result = 0;
-				return 1;
-			}
-
-			if (-5 < systemIndex) {
-				CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
-				if ((static_cast<u32>(__cntlzw(static_cast<u32>(reinterpret_cast<u8*>(engineObject) - reinterpret_cast<u8*>(object)))) >> 5) == 0) {
-					engineObject->m_previous->m_next = engineObject->m_next;
-					engineObject->m_next->m_previous = engineObject->m_previous;
-
-					*reinterpret_cast<void**>(reinterpret_cast<u8*>(*engineObject->m_freeListNode) + 0x04) =
-					    engineObject->m_freeListNode[1];
-					*reinterpret_cast<void**>(engineObject->m_freeListNode[1]) = *engineObject->m_freeListNode;
-
-					engineObject->m_freeListNode[1] = m_objectFreeListHead;
-					m_objectFreeListHead = engineObject->m_freeListNode;
-					engineObject->m_flags = static_cast<u8>(__rlwimi(engineObject->m_flags, 0, 4, 27, 27));
-
-					onDeleteObject(engineObject);
-				} else {
-					object->m_flagBits.m_deleteFlag = 1;
-				}
-
-				*object->m_sp++ = 0;
-				result = 0;
-				return 1;
-			}
-		} else if (systemIndex < 0) {
+		switch (systemIndex) {
+		case -1: {
 			const u32 reqFlags = *reinterpret_cast<u32*>(&object->m_reqFlag0);
 			if (reqFlags != 0) {
 				*object->m_sp++ = 0;
@@ -2394,6 +2336,65 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 				return 1;
 			}
 
+			*object->m_sp++ = 0;
+			result = 0;
+			return 1;
+		}
+		case -2: {
+			CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
+			const u32 scriptGroup = *object->m_localBase;
+
+			engineObject->m_next->m_previous = engineObject->m_previous;
+			engineObject->m_previous->m_next = engineObject->m_next;
+
+			CObject* const root = &m_objectSentinel;
+			CObject* begin = root->m_next;
+			CObject* it = begin;
+			do {
+				if (static_cast<int>(scriptGroup) < it->m_0x32) {
+					break;
+				}
+				it = it->m_next;
+			} while (it != begin);
+
+			it = it->m_previous;
+			engineObject->m_next = it;
+			engineObject->m_previous = it->m_previous;
+			it->m_previous->m_next = engineObject;
+			it->m_previous = engineObject;
+			engineObject->m_0x32 = static_cast<s16>(scriptGroup);
+
+			*object->m_sp++ = 0;
+			result = 0;
+			return ret;
+		}
+		case -3: {
+			CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
+			if ((static_cast<u32>(__cntlzw(static_cast<u32>(reinterpret_cast<u8*>(engineObject) - reinterpret_cast<u8*>(object)))) >> 5) == 0) {
+				engineObject->m_previous->m_next = engineObject->m_next;
+				engineObject->m_next->m_previous = engineObject->m_previous;
+
+				*reinterpret_cast<void**>(reinterpret_cast<u8*>(*engineObject->m_freeListNode) + 0x04) =
+				    engineObject->m_freeListNode[1];
+				*reinterpret_cast<void**>(engineObject->m_freeListNode[1]) = *engineObject->m_freeListNode;
+
+				engineObject->m_freeListNode[1] = m_objectFreeListHead;
+				m_objectFreeListHead = engineObject->m_freeListNode;
+				engineObject->m_flags = static_cast<u8>(__rlwimi(engineObject->m_flags, 0, 4, 27, 27));
+
+				onDeleteObject(engineObject);
+			} else {
+				object->m_flagBits.m_deleteFlag = 1;
+			}
+
+			*object->m_sp++ = 0;
+			result = 0;
+			return 1;
+		}
+		case -4:
+			SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
+			    this, object, 2, *object->m_localBase, object->m_argCount - 1,
+			    reinterpret_cast<CStack*>(object->m_localBase + 1), 0);
 			*object->m_sp++ = 0;
 			result = 0;
 			return 1;

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -2306,15 +2306,16 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 	} else {
 		switch (systemIndex) {
 		case -1: {
-			const u32 reqFlags = *reinterpret_cast<u32*>(&object->m_reqFlag0);
+			const int reqFlags = *reinterpret_cast<int*>(&object->m_reqFlag0);
 			if (reqFlags != 0) {
-				*object->m_sp++ = 0;
+				*object->m_sp = 0;
+				object->m_sp++;
 				result = 0;
-				return 1;
+				return ret;
 			}
 
 			const u32 requestIndex = object->m_localBase[0];
-			const u32 noPush = object->m_localBase[1];
+			const int noPush = object->m_localBase[1];
 			object->m_waitCounter = 1;
 			*reinterpret_cast<int*>(&object->m_reqFlag0) = 1;
 
@@ -2325,9 +2326,10 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 					return 1;
 				}
 
-				*object->m_sp++ = 0;
+				*object->m_sp = 0;
+				object->m_sp++;
 				result = 0;
-				return 1;
+				return ret;
 			}
 
 			*reinterpret_cast<int*>(&object->m_reqFlag0) = 0;
@@ -2336,9 +2338,10 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 				return 1;
 			}
 
-			*object->m_sp++ = 0;
+			*object->m_sp = 0;
+			object->m_sp++;
 			result = 0;
-			return 1;
+			return ret;
 		}
 		case -2: {
 			CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
@@ -2364,7 +2367,8 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			it->m_previous = engineObject;
 			engineObject->m_0x32 = static_cast<s16>(scriptGroup);
 
-			*object->m_sp++ = 0;
+			*object->m_sp = 0;
+			object->m_sp++;
 			result = 0;
 			return ret;
 		}
@@ -2387,17 +2391,19 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 				object->m_flagBits.m_deleteFlag = 1;
 			}
 
-			*object->m_sp++ = 0;
+			*object->m_sp = 0;
+			object->m_sp++;
 			result = 0;
-			return 1;
+			return ret;
 		}
 		case -4:
 			SystemCall__12CFlatRuntimeFPQ212CFlatRuntime7CObjectiiiPQ212CFlatRuntime6CStackPQ212CFlatRuntime6CStack(
 			    this, object, 2, *object->m_localBase, object->m_argCount - 1,
 			    reinterpret_cast<CStack*>(object->m_localBase + 1), 0);
-			*object->m_sp++ = 0;
+			*object->m_sp = 0;
+			object->m_sp++;
 			result = 0;
-			return 1;
+			return ret;
 		}
 
 		CStopWatch watch("no name");


### PR DESCRIPTION
Raises main/cflat_runtime from 77.24% to 80.24%.

## Changes
- **Fixed virtual vtable order** in CFlatRuntime: the onClassSystemFunc/onSystemFunc, onClassSystemVal/onSystemVal, and onSetClassSystemVal/onSetSystemVal pairs were declared in the wrong order, placing each method at the swapped vtable slot. The target asm in both systemFunc and objectFrame loads the Class* method at the lower slot. Reordering the declarations matches every virtual-dispatch slot in both functions with no call-site changes. No regressions in cflat_runtime2 / cflat_r2class / cflat_r2system.
- **systemFunc 64.4% to 91.6%:**
  - Replaced the `scan = ""` loop-exit trick in the printf-style render switch with a goto past the loop, removing spurious sda21 literal loads and the extra register pressure that shifted the whole saved-register window.
  - Converted the systemIndex dispatch (systemKind != 1) from a nested if/else-if chain into a switch with cases ordered -1,-2,-3,-4,default, matching the target's balanced compare tree and block layout.
  - Split the `*sp++ = 0` stack-push idiom into `*m_sp = 0; m_sp++;` so the increment reloads object->m_sp like the target, shared the common epilogue via `return ret`, and typed reqFlag/noPush as signed int for cmpwi.

## Remaining blockers
- objectFrame (66%) is walled by a this/code r29<->r30 callee-saved register swap that dominates its mismatches, plus a target frame that spills several extra per-case stack locals; neither yielded to declaration-order or local-caching attempts.
- systemFunc's residual diffs are register-allocation in the spec-parsing loop and a string-pool literal that objdiff names @NNNN vs the target's lbl_ symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)