### PR TITLE
mesmenu: raise fuzzy match to 80.6%

### DIFF
--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -903,7 +903,7 @@ void CMesMenu::onCalc()
                 }
             }
 
-            unsigned int value;
+            int value;
             for (int heartIndex = 0; heartIndex < 8; heartIndex += 4) {
                 value = m_heartGrowTimers[heartIndex] - 1;
                 m_heartGrowTimers[heartIndex] = value & ~((int)value >> 0x1F);
@@ -939,7 +939,7 @@ void CMesMenu::onCalc()
         return;
     }
 
-    unsigned int state = m_state;
+    int state = m_state;
     if (state < 2) {
         if (state == 0) {
             (void)sin(FLOAT_80330980 +

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -940,11 +940,12 @@ void CMesMenu::onCalc()
     }
 
     int state = m_state;
-    if (state < 2) {
-        if (state == 0) {
-            (void)sin(FLOAT_80330980 +
-                      (FLOAT_80330910 * (float)m_stateTimer) / (float)m_stateTimerMax);
-        } else {
+    switch (state) {
+    case 0:
+        (void)sin(FLOAT_80330980 +
+                  (FLOAT_80330910 * (float)m_stateTimer) / (float)m_stateTimerMax);
+        break;
+    case 1: {
             m_windowScale = FLOAT_80330914;
             m_mes.Calc();
 
@@ -1069,11 +1070,12 @@ void CMesMenu::onCalc()
                 }
             }
         }
-    } else if (state < 4) {
-        if (state == 3) {
-            float step = FLOAT_80330914 - (float)m_stateTimer / (float)m_stateTimerMax;
-            m_windowScale = FLOAT_803308ec * (FLOAT_80330914 + (float)sin(FLOAT_80330910 * step + FLOAT_80330980));
-        }
+        break;
+    case 3: {
+        float step = FLOAT_80330914 - (float)m_stateTimer / (float)m_stateTimerMax;
+        m_windowScale = FLOAT_803308ec * (FLOAT_80330914 + (float)sin(FLOAT_80330910 * step + FLOAT_80330980));
+        break;
+    }
     }
 
     m_stateTimer = m_stateTimer + 1;

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -852,7 +852,7 @@ void CMesMenu::onCalc()
     }
 
     int desiredStageFlag = stageBit != 0;
-    if (m_stageFadeOut != desiredStageFlag) {
+    if (desiredStageFlag != m_stageFadeOut) {
         System.Printf(const_cast<char*>(s_mesMenuOnOffChangedFmt));
         m_stageFadeOut =
             ((unsigned int)__cntlzw(m_stageFadeOut) >> 5) & 0xFF;

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -904,12 +904,30 @@ void CMesMenu::onCalc()
             }
 
             unsigned int value;
-            for (int heartIndex = 0; heartIndex < 8; heartIndex++) {
+            for (int heartIndex = 0; heartIndex < 8; heartIndex += 4) {
                 value = m_heartGrowTimers[heartIndex] - 1;
                 m_heartGrowTimers[heartIndex] = value & ~((int)value >> 0x1F);
 
                 value = m_heartDropTimers[heartIndex] - 1;
                 m_heartDropTimers[heartIndex] = value & ~((int)value >> 0x1F);
+
+                value = m_heartGrowTimers[heartIndex + 1] - 1;
+                m_heartGrowTimers[heartIndex + 1] = value & ~((int)value >> 0x1F);
+
+                value = m_heartDropTimers[heartIndex + 1] - 1;
+                m_heartDropTimers[heartIndex + 1] = value & ~((int)value >> 0x1F);
+
+                value = m_heartGrowTimers[heartIndex + 2] - 1;
+                m_heartGrowTimers[heartIndex + 2] = value & ~((int)value >> 0x1F);
+
+                value = m_heartDropTimers[heartIndex + 2] - 1;
+                m_heartDropTimers[heartIndex + 2] = value & ~((int)value >> 0x1F);
+
+                value = m_heartGrowTimers[heartIndex + 3] - 1;
+                m_heartGrowTimers[heartIndex + 3] = value & ~((int)value >> 0x1F);
+
+                value = m_heartDropTimers[heartIndex + 3] - 1;
+                m_heartDropTimers[heartIndex + 3] = value & ~((int)value >> 0x1F);
             }
 
             value = m_foodShakeTimer - 1;

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -1008,7 +1008,6 @@ void CMesMenu::onCalc()
                 }
             }
 
-            bool advance = false;
             if ((downMask & 0x100) != 0) {
                 int wait2 = m_mes.GetWait();
                 if (wait2 == 0) {
@@ -1030,14 +1029,10 @@ void CMesMenu::onCalc()
                     *(int*)((char*)this + 0x3CC8) = 1;
                     *(int*)((char*)this + 0x3CD8) = 0;
                 }
-                advance = (*(int*)((char*)this + 0x3CC8) != 0) &&
-                          (*(int*)((char*)this + 0x3CD8) == *(int*)((char*)this + 0x3CD4));
-            } else {
-                advance = (*(int*)((char*)this + 0x3CC8) != 0) &&
-                          (*(int*)((char*)this + 0x3CD8) == *(int*)((char*)this + 0x3CD4));
             }
 
-            if (advance) {
+            if ((*(int*)((char*)this + 0x3CC8) != 0) &&
+                (*(int*)((char*)this + 0x3CD8) == *(int*)((char*)this + 0x3CD4))) {
                 if (*(int*)((char*)this + 0x3C90) != 0) {
                     int wait5 = m_mes.GetWait();
                     if (wait5 != 4) {


### PR DESCRIPTION
Raises `main/mesmenu` from 78.71% to 80.55% by attacking control-flow and type mismatches in `CMesMenu::onCalc` (which rose 85.5% -> 94.3%).

Changes (all in `src/mesmenu.cpp`):
- **Heart-timer loop unroll**: rewrote `onCalc`'s `for (i=0;i<8;i++)` decrement loop as a `for (i=0;i<8;i+=4)` 4x-unrolled body, matching the original's `mtctr 2` CTR loop (same shape as `CalcHeart`).
- **Switch-dispatch state machine**: converted `onCalc`'s `if (state<2){...} else if (state<4){...}` into a `switch (state)` with cases 0/1/3, matching the target's balanced compare tree (pivot at 2).
- **Inlined `advance` condition**: removed the duplicated `bool advance` materialization and inlined the condition directly into the guarding `if`, matching the target's branch-based short-circuit.
- **Stage-flag compare operand order**: `desiredStageFlag != m_stageFadeOut` instead of the reverse, matching the target `cmpw` operand order.
- **Local signedness**: `int value`/`int state` corrections found via `permute_fn`.

Remaining blockers (documented walls, not source-fixable here):
- `onDraw` (67.7%, dominant) and `Open`/`Create` are gated by the `DOUBLE_80330900` anonymous-pool issue: mwcc emits its u32->double conversion bias as a private pool constant (`@466`/`@516`) where the original references the named `.sdata2` symbol, cascading into pervasive FPR-numbering shifts.
- `onCalc`'s residual ~6% is the r28/r31 `this`-register inversion (pure register-allocation coloring; competing callee-saved set already matches the target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)