### PR TITLE
cflat_runtime2: raise fuzzy match to 88.5%

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -965,7 +965,7 @@ int CFlatRuntime2::Load(char* fileName)
 	}
 
 	resetChangeScript();
-	if (System.m_execParam > 2) {
+	if (static_cast<unsigned int>(System.m_execParam) >= 3) {
 		System.Printf(const_cast<char*>(sCFlatRuntime2LoadMsg));
 	}
 	return 1;

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1959,9 +1959,8 @@ void CFlatRuntime2::drawLayer(
 		}
 	}
 
-	Mtx44 projection;
-	PSMTX44Copy(*reinterpret_cast<Mtx44*>(CameraPcsRaw() + 0x94), projection);
-	GXSetProjection(projection, GX_PERSPECTIVE);
+	PSMTX44Copy(*reinterpret_cast<Mtx44*>(CameraPcsRaw() + 0x94), ortho);
+	GXSetProjection(ortho, GX_PERSPECTIVE);
 
 	} else {
 		if (static_cast<unsigned int>(System.m_execParam) >= 2) {


### PR DESCRIPTION
Raise main/cflat_runtime2 fuzzy match from 88.50% baseline to 88.54%.

Changes:
- drawLayer: reuse the dead `ortho` Mtx44 stack slot for the final `projection` copy instead of a separate local. The original coalesces these non-overlapping matrix lifetimes into one stack slot; matching it shrinks the frame (0x1f0 to 0x1b0) toward the target.
- Load: change `System.m_execParam > 2` to `(unsigned int)System.m_execParam >= 3` so mwcc emits the target's unsigned `cmplwi r0,0x3; blt` instead of signed `cmpwi r0,0x2; ble`.

Both verified net-positive on the unit report.json. Remaining blockers in Calc/Draw/CcClass2D/ctor and the drawLayer blend loop are register-allocation and inlining walls (callee-saved GPR/FPR count and stack-spill layout) that targeted reorderings and permute_fn did not crack without regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)