### PR TITLE
singmenu: raise fuzzy match to 88.5%

### DIFF
--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1578,8 +1578,8 @@ inline void CMenuPcs::SingCalcChara(float frameStep)
     float modelScale = gSingMenuRaceModelScales[modelScaleIndex];
     Mtx scaleMtx;
     PSMTXScale(scaleMtx, modelScale, modelScale, modelScale);
-    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[0][3] = 0.0f;
+    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[2][3] = 0.0f;
 
     model->m_flags10CBits.m_flag10C_80 = 1;
@@ -1878,13 +1878,13 @@ void CMenuPcs::SingleCalcFadeIn()
     int frame = static_cast<int>(m_singMenuState->frame);
     for (int i = 0; i < count; i++) {
         if (entry->startFrame <= frame) {
-            if (entry->startFrame + entry->duration > frame) {
+            if (entry->startFrame + entry->duration <= frame) {
+                completed = completed + 1;
+                entry->alpha = 1.0f;
+            } else {
                 entry->elapsed = entry->elapsed + 1;
                 entry->alpha = static_cast<float>((1.0 / (double)entry->duration) *
                                                   (double)entry->elapsed);
-            } else {
-                completed = completed + 1;
-                entry->alpha = 1.0f;
             }
         }
         entry = entry + 1;
@@ -1900,8 +1900,8 @@ void CMenuPcs::SingleCalcFadeIn()
     float modelScale = gSingMenuRaceModelScales[modelScaleIndex];
     Mtx scaleMtx;
     PSMTXScale(scaleMtx, modelScale, modelScale, modelScale);
-    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[0][3] = 0.0f;
+    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[2][3] = 0.0f;
 
     m_wm.m_handles[0]->m_model->m_flags10CBits.m_flag10C_80 = 1;
@@ -1974,14 +1974,14 @@ void CMenuPcs::SingleCalcFadeOut()
     for (int i = 0; i < count; i++) {
         if (entry->startFrame > frame) {
             entry->alpha = 1.0f;
-        } else if (entry->startFrame + entry->duration > frame) {
+        } else if (entry->startFrame + entry->duration <= frame) {
+            completed = completed + 1;
+            entry->alpha = 0.0f;
+        } else {
             entry->elapsed = entry->elapsed + 1;
             entry->alpha =
                 static_cast<float>(-((1.0 / static_cast<double>(entry->duration)) *
                                       static_cast<double>(entry->elapsed) - 1.0));
-        } else {
-            completed = completed + 1;
-            entry->alpha = 0.0f;
         }
         entry = entry + 1;
     }
@@ -1996,8 +1996,8 @@ void CMenuPcs::SingleCalcFadeOut()
     float modelScale = gSingMenuRaceModelScales[modelScaleIndex];
     Mtx scaleMtx;
     PSMTXScale(scaleMtx, modelScale, modelScale, modelScale);
-    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[0][3] = 0.0f;
+    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[2][3] = 0.0f;
 
     m_wm.m_handles[0]->m_model->m_flags10CBits.m_flag10C_80 = 1;
@@ -2065,8 +2065,8 @@ void CMenuPcs::SingleCalcCtrl()
     float modelScale = gSingMenuRaceModelScales[modelScaleIndex];
     Mtx scaleMtx;
     PSMTXScale(scaleMtx, modelScale, modelScale, modelScale);
-    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[0][3] = 0.0f;
+    scaleMtx[1][3] = gSingMenuRaceModelYOffset[modelScaleIndex];
     scaleMtx[2][3] = 0.0f;
 
     m_wm.m_handles[0]->m_model->m_flags10CBits.m_flag10C_80 = 1;

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1876,21 +1876,18 @@ void CMenuPcs::SingleCalcFadeIn()
     int count = static_cast<int>(m_singleFadeState->count);
     SingleFadeEntry* entry = m_singleFadeState->entries;
     int frame = static_cast<int>(m_singMenuState->frame);
-    if (0 < count) {
-        do {
-            if (entry->startFrame <= frame) {
-                if (frame < entry->startFrame + entry->duration) {
-                    entry->elapsed = entry->elapsed + 1;
-                    entry->alpha = static_cast<float>((1.0 / (double)entry->duration) *
-                                                      (double)entry->elapsed);
-                } else {
-                    completed = completed + 1;
-                    entry->alpha = 1.0f;
-                }
+    for (int i = 0; i < count; i++) {
+        if (entry->startFrame <= frame) {
+            if (entry->startFrame + entry->duration > frame) {
+                entry->elapsed = entry->elapsed + 1;
+                entry->alpha = static_cast<float>((1.0 / (double)entry->duration) *
+                                                  (double)entry->elapsed);
+            } else {
+                completed = completed + 1;
+                entry->alpha = 1.0f;
             }
-            entry = entry + 1;
-            count = count - 1;
-        } while (count != 0);
+        }
+        entry = entry + 1;
     }
 
     if (m_wm.m_handles[0]->m_model->m_time < m_wm.m_handles[0]->m_model->m_animEnd) {
@@ -1974,22 +1971,19 @@ void CMenuPcs::SingleCalcFadeOut()
     int count = static_cast<int>(m_singleFadeState->count);
     SingleFadeEntry* entry = m_singleFadeState->entries;
     int frame = static_cast<int>(m_singMenuState->frame);
-    if (0 < count) {
-        do {
-            if (frame < entry->startFrame) {
-                entry->alpha = 1.0f;
-            } else if (frame < entry->startFrame + entry->duration) {
-                entry->elapsed = entry->elapsed + 1;
-                entry->alpha =
-                    static_cast<float>(-((1.0 / static_cast<double>(entry->duration)) *
-                                          static_cast<double>(entry->elapsed) - 1.0));
-            } else {
-                completed = completed + 1;
-                entry->alpha = 0.0f;
-            }
-            entry = entry + 1;
-            count = count - 1;
-        } while (count != 0);
+    for (int i = 0; i < count; i++) {
+        if (entry->startFrame > frame) {
+            entry->alpha = 1.0f;
+        } else if (entry->startFrame + entry->duration > frame) {
+            entry->elapsed = entry->elapsed + 1;
+            entry->alpha =
+                static_cast<float>(-((1.0 / static_cast<double>(entry->duration)) *
+                                      static_cast<double>(entry->elapsed) - 1.0));
+        } else {
+            completed = completed + 1;
+            entry->alpha = 0.0f;
+        }
+        entry = entry + 1;
     }
 
     if (m_wm.m_handles[0]->m_model->m_time < m_wm.m_handles[0]->m_model->m_animEnd) {

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -3369,7 +3369,7 @@ void CMenuPcs::DrawSingLife()
         return;
     }
 
-    float y;
+    float y = yBase;
     if (lifeTimer < 10) {
         int phase;
         if (lifeTimer < 0) {
@@ -3380,7 +3380,7 @@ void CMenuPcs::DrawSingLife()
                 phase = lifeTimer;
             }
         }
-        y = 64.0f * static_cast<float>(sin(0.01745329238474369f * (9.0f * static_cast<float>(phase)))) + yBase;
+        y = 64.0f * static_cast<float>(sin(0.01745329238474369f * (9.0f * static_cast<float>(phase)))) + y;
     } else {
         y = 32.0f;
         if (lifeTimer >= 0x28) {

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1582,7 +1582,7 @@ inline void CMenuPcs::SingCalcChara(float frameStep)
     scaleMtx[0][3] = 0.0f;
     scaleMtx[2][3] = 0.0f;
 
-    model->m_flags10C = (model->m_flags10C & 0x7F) | 0x80;
+    model->m_flags10CBits.m_flag10C_80 = 1;
     model->SetMatrix(scaleMtx);
     model->CalcMatrix();
     model->CalcSkin();
@@ -1893,10 +1893,10 @@ void CMenuPcs::SingleCalcFadeIn()
         } while (count != 0);
     }
 
-    if (m_wm.m_handles[0]->m_model->m_animEnd < m_wm.m_handles[0]->m_model->m_time) {
-        m_wm.m_handles[0]->m_model->SetFrame(0.0f);
-    } else {
+    if (m_wm.m_handles[0]->m_model->m_time < m_wm.m_handles[0]->m_model->m_animEnd) {
         m_wm.m_handles[0]->m_model->AddFrame(1.0f);
+    } else {
+        m_wm.m_handles[0]->m_model->SetFrame(0.0f);
     }
 
     unsigned short modelScaleIndex = SingleCaravanWork()->m_tribeId;
@@ -1907,7 +1907,7 @@ void CMenuPcs::SingleCalcFadeIn()
     scaleMtx[0][3] = 0.0f;
     scaleMtx[2][3] = 0.0f;
 
-    m_wm.m_handles[0]->m_model->m_flags10C = (m_wm.m_handles[0]->m_model->m_flags10C & 0x7F) | 0x80;
+    m_wm.m_handles[0]->m_model->m_flags10CBits.m_flag10C_80 = 1;
     m_wm.m_handles[0]->m_model->SetMatrix(scaleMtx);
     m_wm.m_handles[0]->m_model->CalcMatrix();
     m_wm.m_handles[0]->m_model->CalcSkin();
@@ -1992,10 +1992,10 @@ void CMenuPcs::SingleCalcFadeOut()
         } while (count != 0);
     }
 
-    if (m_wm.m_handles[0]->m_model->m_animEnd < m_wm.m_handles[0]->m_model->m_time) {
-        m_wm.m_handles[0]->m_model->SetFrame(0.0f);
-    } else {
+    if (m_wm.m_handles[0]->m_model->m_time < m_wm.m_handles[0]->m_model->m_animEnd) {
         m_wm.m_handles[0]->m_model->AddFrame(1.0f);
+    } else {
+        m_wm.m_handles[0]->m_model->SetFrame(0.0f);
     }
 
     unsigned short modelScaleIndex = SingleCaravanWork()->m_tribeId;
@@ -2006,7 +2006,7 @@ void CMenuPcs::SingleCalcFadeOut()
     scaleMtx[0][3] = 0.0f;
     scaleMtx[2][3] = 0.0f;
 
-    m_wm.m_handles[0]->m_model->m_flags10C = (m_wm.m_handles[0]->m_model->m_flags10C & 0x7F) | 0x80;
+    m_wm.m_handles[0]->m_model->m_flags10CBits.m_flag10C_80 = 1;
     m_wm.m_handles[0]->m_model->SetMatrix(scaleMtx);
     m_wm.m_handles[0]->m_model->CalcMatrix();
     m_wm.m_handles[0]->m_model->CalcSkin();
@@ -2061,10 +2061,10 @@ void CMenuPcs::SingleCalcCtrl()
     }
 
     int result = 0;
-    if (m_wm.m_handles[0]->m_model->m_animEnd < m_wm.m_handles[0]->m_model->m_time) {
-        m_wm.m_handles[0]->m_model->SetFrame(0.0f);
-    } else {
+    if (m_wm.m_handles[0]->m_model->m_time < m_wm.m_handles[0]->m_model->m_animEnd) {
         m_wm.m_handles[0]->m_model->AddFrame(1.0f);
+    } else {
+        m_wm.m_handles[0]->m_model->SetFrame(0.0f);
     }
 
     unsigned short modelScaleIndex = SingleCaravanWork()->m_tribeId;
@@ -2075,7 +2075,7 @@ void CMenuPcs::SingleCalcCtrl()
     scaleMtx[0][3] = 0.0f;
     scaleMtx[2][3] = 0.0f;
 
-    m_wm.m_handles[0]->m_model->m_flags10C = (m_wm.m_handles[0]->m_model->m_flags10C & 0x7F) | 0x80;
+    m_wm.m_handles[0]->m_model->m_flags10CBits.m_flag10C_80 = 1;
     m_wm.m_handles[0]->m_model->SetMatrix(scaleMtx);
     m_wm.m_handles[0]->m_model->CalcMatrix();
     m_wm.m_handles[0]->m_model->CalcSkin();


### PR DESCRIPTION
Raises `main/singmenu` fuzzy match from 87.91% to 88.49%.

## Changes
- **AddFrame/SetFrame if-polarity (R9)**: rewrote `if (m_animEnd < m_time)` as `if (m_time < m_animEnd) AddFrame else SetFrame` to match the target's `fcmpo f0,f1; bge` structure (3 sites: FadeIn/FadeOut/Ctrl).
- **m_flags10C bitfield set**: replaced `(flags & 0x7F) | 0x80` with the bitfield write `m_flags10CBits.m_flag10C_80 = 1`, yielding the target's `rlwimi ...,7,24,24` single-bit insert instead of `clrlwi`+`ori`.
- **Counted fade loops (R10)**: converted the per-entry `do/while` loops to counted `for` loops, producing the target's `mtctr`/`bdnz` instead of `subic.`/`bne`; fixed the comparison operand order/polarity.
- **Block-order arm swap (R9)**: reordered the fade-entry if/else arms so the `completed/alpha` case is emitted before the `elapsed` computation, matching the target's basic-block layout — the largest single gain (FadeOut +4.7, FadeIn +3.7).
- **scaleMtx store order**: reordered `scaleMtx[0/1/2][3]` assignments to match the target's [0][3],[1][3],[2][3] emission order.
- **DrawSingLife**: accumulate `y` into its `yBase`-initialized register.

## Per-function impact
- SingleCalcFadeOut 78.16 -> 86.40
- SingleCalcFadeIn 79.27 -> 86.26
- SingleCalcCtrl 92.51 -> 93.58
- DrawSingLife 73.58 -> 74.24

## Remaining blockers
DrawSingWin (~69%) and DrawSingleStat (~81%) are gated by float-constant-pool ordering (target uses named `FLOAT_*@sda21` symbols held in callee-saved FPRs like f27 vs our anonymous shared pool entries) and FPR residency, plus a double-precision int->float conversion sequence in DrawSingWin. ChkEquipPossible/GetSmithItem share a genderFlags bitfield-positioning + single-return scheduling wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)