### PR TITLE
cflat_r2class: raise fuzzy match to 90.5%

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1224,7 +1224,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		case -0x43: {
 			float* params = reinterpret_cast<float*>(object->m_localBase);
-			engineObject->moveVectorRot(params[0], params[1], params[2], static_cast<int>(params[3]));
+			engineObject->moveVectorRot(params[0], params[1], params[2], static_cast<unsigned int>(params[3]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
@@ -1242,7 +1242,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x46: {
-			CGObject* target = static_cast<int>(object->m_localBase[0]) != 0 ? FindRuntimeObject(this, object->m_localBase[0]) : 0;
+			CGObject* target = static_cast<unsigned int>(object->m_localBase[0]) != 0 ? FindRuntimeObject(this, object->m_localBase[0]) : 0;
 			engineObject->LookAt(target, 0);
 			PushValue(this, object, 0);
 			outResult = 0;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -455,7 +455,7 @@ void CFlatRuntime2::onSetClassSystemVal(int systemVal, CFlatRuntime::CObject* ob
 					int bitValue = oldBit;
 					switch (setMode) {
 					case -1:
-						bitValue -= static_cast<int>(static_cast<unsigned char>(stack->m_word));
+						bitValue -= static_cast<int>(static_cast<signed char>(stack->m_word));
 						break;
 					case 0:
 						bitValue = static_cast<int>(static_cast<signed char>(stack->m_word));


### PR DESCRIPTION
Two signedness corrections found via token-level permutation:

- `onClassSystemFunc`: match unsigned conversions for the `moveVectorRot` turn-frames argument (case -0x43) and the `m_localBase[0]` truthiness check (case -0x46), raising that function 91.25% -> 91.33%.
- `onSetClassSystemVal`: the -0xA bit case read `stack->m_word` as `unsigned char` in the subtract branch while the assign/add branches use `signed char`; made it consistent (matches the target `extsb`), raising that function 90.53% -> 90.55%.

Unit fuzzy match 90.40% -> 90.46%. No layout or hack changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)