### PR TITLE
ringmenu: raise fuzzy match to 78.6%

### DIFF
--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -225,6 +225,10 @@ void CRingMenu::DrawIcon()
 	    angle);
 
 	MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x18));
+	unsigned int colValue = iconCol;
+	int colSign = colValue >> 31;
+	int uInt = (((colSign * 8) | (colValue * 0x20000000 + colSign) >> 29) - colSign) * 0x30;
+	int vInt = ((colValue >> 3) + ((colValue < 0) && ((iconCol & 7) != 0))) * 0x30;
 	void* tlut = MenuPcs.m_externalFontTlut;
 	if (caravanWork->m_hp != 0) {
 		tlut = 0;
@@ -241,10 +245,8 @@ void CRingMenu::DrawIcon()
 	CColor iconColor(0xFF, 0xFF, 0xFF, blinkAlpha);
 	MenuPcs.SetColor(iconColor);
 
-	unsigned int colValue = iconCol;
-	int colSign = colValue >> 31;
-	float u = static_cast<float>((((colSign * 8) | (colValue * 0x20000000 + colSign) >> 29) - colSign) * 0x30);
-	float v = static_cast<float>(((colValue >> 3) + ((colValue < 0) && ((iconCol & 7) != 0))) * 0x30);
+	float u = static_cast<float>(uInt);
+	float v = static_cast<float>(vInt);
 	MenuPcs.DrawRect(3, static_cast<float>(posX), static_cast<float>(posY), kRingMenuMarkerSize,
 	                                 kRingMenuMarkerSize, u, v, kRingMenuMarkerUvScale, kRingMenuMarkerUvScale, angle);
 }

--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -770,7 +770,7 @@ void CRingMenu::onDraw()
 							float blink = kRingMenuZero;
 							if (charge == 0) {
 								if (!caravanWork->IsSelectedCmdList(i)) {
-									CColor color(0x80, 0x80, 0x80, static_cast<unsigned char>(static_cast<int>(dimAlpha)));
+									CColor color(0x80, 0x80, 0x80, static_cast<signed char>(static_cast<int>(dimAlpha)));
 									MenuPcs.SetColor(color);
 								} else {
 									CColor color(0x20, 0xFF, 0x20, static_cast<unsigned char>(static_cast<int>(fullAlpha)));

--- a/src/ringmenu.cpp
+++ b/src/ringmenu.cpp
@@ -173,23 +173,23 @@ void CRingMenu::DrawIcon()
 	}
 
 	float clampedX;
-	if (clipPos.x >= kRingMenuClipMinX) {
+	if (kRingMenuClipMinX > clipPos.x) {
+		clampedX = kRingMenuClipMinX;
+	} else {
 		clampedX = clipPos.x;
 		if (kRingMenuClipMaxX < clipPos.x) {
 			clampedX = kRingMenuClipMaxX;
 		}
-	} else {
-		clampedX = kRingMenuClipMinX;
 	}
 
 	float clampedY;
-	if (clipPos.y >= kRingMenuClipMinY) {
+	if (kRingMenuClipMinY > clipPos.y) {
+		clampedY = kRingMenuClipMinY;
+	} else {
 		clampedY = clipPos.y;
 		if (kRingMenuClipMaxY < clipPos.y) {
 			clampedY = kRingMenuClipMaxY;
 		}
-	} else {
-		clampedY = kRingMenuClipMinY;
 	}
 
 	float angle = static_cast<float>(atan2(static_cast<double>(clampedX), static_cast<double>(clampedY)));


### PR DESCRIPTION
Raises `main/ringmenu` fuzzy match from 77.91% to **78.63%**.

## Changes
- **DrawIcon (+1.1%)**: front-load the icon u/v integer computation before `SetTexture(0x18)` so the products stay resident in callee-saved registers (r28/r31), matching the target's evaluation order.
- **DrawIcon (+0.04%)**: invert the X/Y clamp if-polarity (test `Min > clipPos` first) to drop a spurious `cror eq,gt,eq` and match the target's clean `blt`/`bge` branch shape (R9).
- **onDraw (+0.5%)**: signed-char cast for the dim-color alpha byte in the magic-charge bar loop (matches `extsb` sign behavior).

## Blocker
The remaining gap in onDraw (~68%, the dominant 3884-byte function), drawGBA, onCalc, and drawCommand is the **callee-saved FPR register-window shift** (target saves from f16/f26; ours from f20/f21), compounded by the **anonymous magic-double bias literal** (`@NNN@sda21` in ours vs the named `lbl_80330A00@sda21` in the target). The latter is a constant-pool layout artifact that isn't source-fixable without reordering the whole unit's literal pool. Permute (signedness/width), if-polarity inversion, in-place clamp stores, struct-pointer loop rewrites, and CTR-loop (`for`) conversions were all tried against these; only the changes above produced net gains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)