### PR TITLE
p_minigame: raise fuzzy match to 91.6%

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1055,22 +1055,17 @@ comm_fail:
             }
             else
             {
-                int status = GBAGetStatus(channel, param + 0xC0);
-                if (status == 0)
+                int status;
+                if (GBAGetStatus(channel, param + 0xC0) == 0 && param[0xC0] == 0x28 &&
+                    GBARead(channel, reinterpret_cast<u8*>(&identity7), param + 0xC0) == 0)
                 {
-                    if (param[0xC0] == 0x28)
-                    {
-                        status = GBARead(channel, reinterpret_cast<u8*>(&identity7), param + 0xC0);
-                        if (status == 0)
-                        {
-                            *reinterpret_cast<unsigned int*>(param + 0xA4) = identity7;
-                            param[0xC3] = 1;
-                        }
-                    }
-                    else
-                    {
-                        status = 1;
-                    }
+                    *reinterpret_cast<unsigned int*>(param + 0xA4) = identity7;
+                    param[0xC3] = 1;
+                    status = 0;
+                }
+                else
+                {
+                    status = 1;
                 }
                 if (status == 0 &&
                     (memcmp(param + 0xA4, self + 0x1344, 4) == 0 || *reinterpret_cast<unsigned int*>(param + 0xA4) == 0x414D4752))
@@ -1137,22 +1132,17 @@ comm_fail:
         ret = GBAReset(channel, param + 0xC0);
         if (ret == 0)
         {
-            int status = GBAGetStatus(channel, param + 0xC0);
-            if (status == 0)
+            int status;
+            if (GBAGetStatus(channel, param + 0xC0) == 0 && param[0xC0] == 0x28 &&
+                GBARead(channel, reinterpret_cast<u8*>(&identity8), param + 0xC0) == 0)
             {
-                if (param[0xC0] == 0x28)
-                {
-                    status = GBARead(channel, reinterpret_cast<u8*>(&identity8), param + 0xC0);
-                    if (status == 0)
-                    {
-                        *reinterpret_cast<unsigned int*>(param + 0xA4) = identity8;
-                        param[0xC3] = 1;
-                    }
-                }
-                else
-                {
-                    status = 1;
-                }
+                *reinterpret_cast<unsigned int*>(param + 0xA4) = identity8;
+                param[0xC3] = 1;
+                status = 0;
+            }
+            else
+            {
+                status = 1;
             }
             if (status == 0 &&
                 (memcmp(param + 0xA4, self + 0x1344, 4) == 0 || *reinterpret_cast<unsigned int*>(param + 0xA4) == 0x414D4752))

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1794,12 +1794,12 @@ void CMiniGamePcs::MngThreadMain(void*)
     int managerStackOffset = 0x1000;
     unsigned char* threadParam = self;
     unsigned char* threadState = self;
-    unsigned char* spMode = Game.m_gameWork.m_spModeFlags;
+    unsigned char* spMode = reinterpret_cast<unsigned char*>(&Game);
 
     int i = 0;
     do
     {
-        int mode = *spMode;
+        int mode = spMode[0xA];
         unsigned int imageSize = (mode == 0)
                                      ? *reinterpret_cast<unsigned int*>(self + 0x1358)
                                      : *reinterpret_cast<unsigned int*>(self + 0x1360);

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1080,21 +1080,11 @@ comm_fail:
                         *reinterpret_cast<int*>(param + 0x9C) = 0;
                     }
 
-                    status = GBAGetStatus(channel, param + 0xC0);
-                    if (status == 0 && param[0xC0] == 0x20)
+                    if (GBAGetStatus(channel, param + 0xC0) == 0 && param[0xC0] == 0x20 &&
+                        GBAWrite(channel, self + 0x1344, param + 0xC0) == 0 &&
+                        GBAGetStatus(channel, param + 0xC0) == 0 && param[0xC0] == 0x30)
                     {
-                        status = GBAWrite(channel, self + 0x1344, param + 0xC0);
-                        if (status == 0 && GBAGetStatus(channel, param + 0xC0) == 0)
-                        {
-                            if (param[0xC0] == 0x30)
-                            {
-                                status = 0;
-                            }
-                            else
-                            {
-                                status = 1;
-                            }
-                        }
+                        status = 0;
                     }
                     else
                     {

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1161,21 +1161,11 @@ comm_fail:
                 {
                     *reinterpret_cast<int*>(param + 0x9C) = 0;
                 }
-                status = GBAGetStatus(channel, param + 0xC0);
-                if (status == 0 && param[0xC0] == 0x20)
+                if (GBAGetStatus(channel, param + 0xC0) == 0 && param[0xC0] == 0x20 &&
+                    GBAWrite(channel, self + 0x1344, param + 0xC0) == 0 &&
+                    GBAGetStatus(channel, param + 0xC0) == 0 && param[0xC0] == 0x30)
                 {
-                    status = GBAWrite(channel, self + 0x1344, param + 0xC0);
-                    if (status == 0 && GBAGetStatus(channel, param + 0xC0) == 0)
-                    {
-                        if (param[0xC0] == 0x30)
-                        {
-                            status = 0;
-                        }
-                        else
-                        {
-                            status = 1;
-                        }
-                    }
+                    status = 0;
                 }
                 else
                 {

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1014,13 +1014,7 @@ comm_fail:
         *reinterpret_cast<int*>(param + 0x9C) = 1;
         param[0xC3] = 0;
 
-        if (param[0xC7] < 2)
-        {
-            ret = GBAJoyBoot(channel, channel << 1, 2, *reinterpret_cast<u8**>(param + 0x8C),
-                             *reinterpret_cast<int*>(param + 0x90), param + 0xC0);
-            param[0xC7]++;
-        }
-        else
+        if (param[0xC7] >= 2)
         {
             ret = 1;
             for (unsigned int i = 0; i < 100; i++)
@@ -1032,6 +1026,12 @@ comm_fail:
                     break;
                 }
             }
+        }
+        else
+        {
+            ret = GBAJoyBoot(channel, channel << 1, 2, *reinterpret_cast<u8**>(param + 0x8C),
+                             *reinterpret_cast<int*>(param + 0x90), param + 0xC0);
+            param[0xC7]++;
         }
 
         if (ret == 0)

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -733,7 +733,8 @@ void CMiniGamePcs::GbaThreadMain(void* threadParam)
 {
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
     unsigned char* param = reinterpret_cast<unsigned char*>(threadParam);
-    unsigned int message;
+    unsigned int messageBuf[2];
+    unsigned char gbaReadScratch[4];
     unsigned int command;
     unsigned int command7;
     unsigned int command8;
@@ -746,13 +747,14 @@ void CMiniGamePcs::GbaThreadMain(void* threadParam)
     OSTime timeoutTicks;
     OSTime startTime;
 #define channel (reinterpret_cast<signed char*>(param)[0xBC])
+#define message (messageBuf[0])
 
 receive_message:
-    ret = OSReceiveMessage(reinterpret_cast<OSMessageQueue*>(param), reinterpret_cast<OSMessage*>(&message), 0);
+    ret = OSReceiveMessage(reinterpret_cast<OSMessageQueue*>(param), reinterpret_cast<OSMessage*>(messageBuf), 0);
     if (ret == 0)
     {
         param[0xBD] = 0;
-        OSReceiveMessage(reinterpret_cast<OSMessageQueue*>(param), reinterpret_cast<OSMessage*>(&message), 1);
+        OSReceiveMessage(reinterpret_cast<OSMessageQueue*>(param), reinterpret_cast<OSMessage*>(messageBuf), 1);
         param[0xBE] = 0;
     }
 
@@ -1050,7 +1052,7 @@ comm_fail:
             {
                 if ((param[0xC0] & GBA_JSTAT_FLAGS_MASK) != GBA_JSTAT_PSF0)
                 {
-                    GBARead(channel, param + 0x254, param + 0xC0);
+                    GBARead(channel, gbaReadScratch, param + 0xC0);
                 }
             }
             else

--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1841,7 +1841,7 @@ void CMiniGamePcs::MngThreadMain(void*)
         {
             self[0x649D] = 0;
 
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i <= 3; i++)
             {
                 MiniGameThreadSleepTicks(OSMillisecondsToTicks(100));
 


### PR DESCRIPTION
Raises main/p_minigame fuzzy match from 91.09% to 91.58%.

## Changes
- **MngThreadMain**: player-send loop bound `< 4` → `<= 3` (matches target `ble`); access spMode flags via the Game base pointer + 0xA offset (matches target's base+index addressing, `lbz r0, 0xa(rN)`).
- **GbaThreadMain**:
  - Inverted the JoyBoot retry if/else so the `>= 2` (100-iteration loop) arm is the fall-through, matching the target's basic-block source order (R9).
  - Rewrote the four GBA verify chains (msg7/msg8 status checks and identity-read paths) as single boolean `&&` expressions with `status = 0 / else status = 1`, matching the target's materialized-boolean lowering instead of short-circuit jumps.
  - Declared the OSReceiveMessage buffer as `unsigned int[2]` (8 bytes) and added a 4-byte stack scratch buffer for the reconnect GBARead (was incorrectly reading `param + 0x254`). This fixed the persistent +4/+8 stack-local layout shift, aligning ~40 stack-offset operands.

## Remaining blockers
- GbaThreadMain still has a register-coloring cascade (off-by-2 callee-saved numbering) seeded by the jump-table pointer register choice, plus a `...rodata.0`/anonymous-jumptable relocation-naming difference (2-4 lines).
- MiniGameGo's checksum loop has a pointer-cache-vs-base+offset-recompute register cascade resistant to type/structure changes.
- OpenCallback's param pointer lands in r31 vs the target's r26 (coloring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)