### PR TITLE
menu_item: raise fuzzy match to 91.4%

### DIFF
--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -145,8 +145,9 @@ int CMenuPcs::ItemCtrlCur()
         return 0;
     }
 
+    s16 letterAttachFlg;
     unsigned int mode = this->m_itemMenuState->mode;
-    s16 letterAttachFlg = SingGetLetterAttachflg();
+    letterAttachFlg = SingGetLetterAttachflg();
 
     if (mode == 0) {
         if ((hold & 8) != 0) {

--- a/src/menu_item.cpp
+++ b/src/menu_item.cpp
@@ -116,8 +116,9 @@ int CMenuPcs::ItemCtrlCur()
     unsigned int press;
     int hold;
     CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[0]);
+    int padLock = Pad.m_debugPadLock;
 
-    if ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) {
+    if ((padLock != 0) || (Pad.m_debugPadPort != -1)) {
         blocked = true;
     }
     if (blocked) {
@@ -129,7 +130,7 @@ int CMenuPcs::ItemCtrlCur()
     }
 
     blocked = false;
-    if ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) {
+    if ((padLock != 0) || (Pad.m_debugPadPort != -1)) {
         blocked = true;
     }
     if (blocked) {


### PR DESCRIPTION
Raises `main/menu_item` from 91.35% to 91.40% via two source-level register-allocation fixes in `ItemCtrlCur` (92.18% -> 92.36%):

- Cache `Pad.m_debugPadLock` in a local so both `blocked` checks reuse one loaded value (`cmpwi r6`) instead of reloading `0x1c4(r4)` twice, matching the target.
- Reorder the `mode`/`letterAttachFlg` local declarations so `mode` lands in the lower callee-saved register (r26) and the `SingGetLetterAttachflg` result in r27, matching the target's register window and fixing a cascade of downstream ARG_MISMATCH lines.

Investigated but did not land (deep register-window / type entanglement, every variant regressed): ItemInit (78.8%, 2-extra-GPR window from the threaded `index` landing in a callee-saved register), ItemDraw (89.3%, one extra saved GPR from `itemId` cached across `EquipChk`), and press/hold `extsh` typing in ItemCtrlCur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)