### PR TITLE
menu_compa: raise fuzzy match to 84.7%

### DIFF
--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -193,7 +193,7 @@ void CMenuPcs::CompaDraw()
 		familyCount = 4;
 	}
 
-	for (int i = 0; i < familyCount; i++) {
+	for (unsigned int i = 0; i < familyCount; i++) {
 		MenuPcs.DrawRect(
 			0,
 			static_cast<float>(compaList->entries[0].x + 0x10),
@@ -203,7 +203,7 @@ void CMenuPcs::CompaDraw()
 	}
 
 	int memberIndex = 0;
-	int shown = 0;
+	unsigned int shown = 0;
 	for (int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = shown;
 		if (shown > 1) {
@@ -252,7 +252,7 @@ void CMenuPcs::CompaDraw()
 	font->SetScaleY(kCompaOne);
 	font->DrawInit();
 
-	GXColor textColor = CColor(0xFF, 0xFF, 0xFF, static_cast<signed char>(kCompaColorMax * compaList->entries[0].alpha)).color;
+	GXColor textColor = CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(kCompaColorMax * compaList->entries[0].alpha)).color;
 	font->SetColor(textColor);
 
 	const CCaravanWork* nameWork = reinterpret_cast<const CCaravanWork*>(Game.m_scriptFoodBase[0]);

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -61,7 +61,7 @@ void CMenuPcs::CompaDraw()
 
 	const CCaravanWork* caravanWork = reinterpret_cast<const CCaravanWork*>(Game.m_scriptFoodBase[0]);
 	CompaOpenAnim* entry = this->m_compaList->entries;
-	for (int i = 0; i < this->m_compaList->count; i++) {
+	for (unsigned int i = 0; i < this->m_compaList->count; i++) {
 		int tex = entry->tex;
 		if (tex >= 0) {
 			float x = static_cast<float>(entry->x);
@@ -177,10 +177,10 @@ void CMenuPcs::CompaDraw()
 	MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3A));
 
 	int familyCount = 2;
-	const short* evtWord = caravanWork->m_evtWordArr;
+	const short* evtWord = &caravanWork->m_evtWordArr[19];
 	int i = 2;
 	do {
-		if (evtWord[19 + i] > 0) {
+		if (evtWord[i] > 0) {
 			familyCount++;
 		}
 		i++;
@@ -278,7 +278,7 @@ void CMenuPcs::CompaDraw()
 		font->SetPosY(y);
 		font->Draw(name);
 
-		unsigned short food = nameWork->m_evtWordArr[19 + drawIndex];
+		short food = nameWork->m_evtWordArr[19 + drawIndex];
 		const char* value = Game.m_cFlatDataArr[1].TableStrings(2)[food];
 		font->SetPosX(static_cast<float>(compaList->entries[0].x + 0x90));
 		font->SetPosY(y);

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -258,7 +258,7 @@ void CMenuPcs::CompaDraw()
 	const CCaravanWork* nameWork = reinterpret_cast<const CCaravanWork*>(Game.m_scriptFoodBase[0]);
 	memberIndex = 0;
 	shown = 0;
-	for (int i = 0; i < 8 && shown < familyCount; i++) {
+	for (unsigned int i = 0; i < 8 && shown < familyCount; i++) {
 		int drawIndex = shown;
 		if (shown > 1) {
 			drawIndex = memberIndex;

--- a/src/menu_compa.cpp
+++ b/src/menu_compa.cpp
@@ -177,11 +177,14 @@ void CMenuPcs::CompaDraw()
 	MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3A));
 
 	int familyCount = 2;
-	for (int i = 2; i < 7; i++) {
-		if (caravanWork->m_evtWordArr[19 + i] > 0) {
+	const short* evtWord = caravanWork->m_evtWordArr;
+	int i = 2;
+	do {
+		if (evtWord[19 + i] > 0) {
 			familyCount++;
 		}
-	}
+		i++;
+	} while (i < 7);
 	if (familyCount > 4 && System.m_execParam >= 1) {
 		System.Printf(const_cast<char*>(sCompaFamilyCountErrorFmt), s_menu_compa_cpp, 0x1BF,
 		              familyCount);


### PR DESCRIPTION
Raises `main/menu_compa` from 83.83% to 84.68% fuzzy match.

CompaDraw is the dominant function (~76% baseline). Changes:
- Family-count loop rewritten as a `do { } while (i < 7)` over a walking `m_evtWordArr` pointer, matching the original's counted-loop shape (was fully unrolled).
- Loop indices for the entry/family/icon/name loops changed to `unsigned int`, and `food` to `short` (matches `m_evtWordArr` element type), aligning signed/unsigned compare and load idioms with the target.
- Text-color alpha cast changed to `unsigned char`, consistent with the other CColor alpha casts.

Remaining gap is dominated by a +1 callee-saved GPR window difference in CompaDraw (target saves r19-r31, ours r20-r31), shifting nearly every register/stack offset. Structural attempts to add the 13th GPR (caching m_compaList, declaration reordering) regressed; left at the proven optimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)