### PR TITLE
menu_letter: raise fuzzy match to 77.85%

### DIFF
--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2218,7 +2218,7 @@ int CMenuPcs::LetterCtrlCur()
 		*reinterpret_cast<int*>(openAnim + 0x70) = 10;
 
 		float f = FLOAT_803330f8;
-		int panelCount = static_cast<int>(GetLetterAnimStorage(this)->count);
+		unsigned int panelCount = static_cast<int>(GetLetterAnimStorage(this)->count);
 		s16* panel = GetLetterPanelBase(this);
 		for (int i = 0; i < panelCount; ++i, panel += 0x20) {
 			*reinterpret_cast<int*>(panel + 0x10) = 0;

--- a/src/menu_letter.cpp
+++ b/src/menu_letter.cpp
@@ -2559,7 +2559,7 @@ void CMenuPcs::LetterLstBaseDraw(float param_1)
 	double decoY0 = y0 - DOUBLE_80333100;
 	double decoX1 = DOUBLE_80333100 + decoX0;
 	double decoY1 = DOUBLE_80333100 + static_cast<double>(static_cast<float>(yh - static_cast<double>(FLOAT_8033310c)));
-	for (int i = 0; i < 4; ++i) {
+	for (unsigned int i = 0; i < 4; ++i) {
 		double x;
 		if ((i & 1) == 0) {
 			x = x0 - static_cast<double>(FLOAT_80333110);


### PR DESCRIPTION
Raises `main/menu_letter` fuzzy match from 77.80% to 77.85%.

Gains (both verified via objdiff report.json, both plausible source changes):
- `LetterLstBaseDraw`: the decoration-corner loop counter is `unsigned int` (matches the target's loop codegen). LetterLstBaseDraw 69.17% -> 69.55%.
- `LetterCtrlCur`: the menuMode==1 panel-reset loop's `panelCount` is `unsigned int`. LetterCtrlCur 73.52% -> 73.57%.

Both found and confirmed with `tools/permute_fn.py`.

Blocker for further progress: the dominant mismatch in `LetterCtrl` (68.7%), `LetterCtrlCur` (73.6%), `LetterLstBaseDraw` (69.6%) and `LetterListDraw` (87.8%) is a register-coloring wall — mwcc colors `this` into a different callee-saved register than the target (e.g. r30 vs r31, r25 vs r30), shifting every `this`-relative member access by one or more registers and producing hundreds of ARG_MISMATCH lines that are otherwise opcode-identical. Tried (all reverted, no gain): declaration-order swaps, removing/adding the cached `state` local, dropping redundant `done = 0`, R10 CTR-loop conversion, R9 if-polarity flips in the menuMode dispatch, field caching, and signedness changes on `press`. None moved mwcc's allocator onto the target's coloring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)