### PR TITLE
singmenu: raise fuzzy match to 88.6%

### DIFF
--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1296,9 +1296,6 @@ void CMenuPcs::drawSingleMenu()
 
         s16 mode = m_singleMenuPhase;
         switch (mode) {
-        case 1:
-            SingleDrawCtrl();
-            return;
         case 0:
         {
             SingleFadeState* fadeState = m_singleFadeState;
@@ -1368,6 +1365,9 @@ void CMenuPcs::drawSingleMenu()
             }
             return;
         }
+        case 1:
+            SingleDrawCtrl();
+            return;
         case 2:
         {
             SingleFadeState* fadeState = m_singleFadeState;

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1876,21 +1876,18 @@ void CMenuPcs::SingleCalcFadeIn()
     int count = static_cast<int>(m_singleFadeState->count);
     SingleFadeEntry* entry = m_singleFadeState->entries;
     int frame = static_cast<int>(m_singMenuState->frame);
-    if (0 < count) {
-        do {
-            if (entry->startFrame <= frame) {
-                if (frame < entry->startFrame + entry->duration) {
-                    entry->elapsed = entry->elapsed + 1;
-                    entry->alpha = static_cast<float>((1.0 / (double)entry->duration) *
-                                                      (double)entry->elapsed);
-                } else {
-                    completed = completed + 1;
-                    entry->alpha = 1.0f;
-                }
+    for (int i = 0; i < count; i++) {
+        if (entry->startFrame <= frame) {
+            if (entry->startFrame + entry->duration <= frame) {
+                completed = completed + 1;
+                entry->alpha = 1.0f;
+            } else {
+                entry->elapsed = entry->elapsed + 1;
+                entry->alpha = static_cast<float>((1.0 / (double)entry->duration) *
+                                                  (double)entry->elapsed);
             }
-            entry = entry + 1;
-            count = count - 1;
-        } while (count != 0);
+        }
+        entry = entry + 1;
     }
 
     if (m_wm.m_handles[0]->m_model->m_animEnd < m_wm.m_handles[0]->m_model->m_time) {

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1476,7 +1476,9 @@ void CMenuPcs::loadTextureAsync(char **, int, int, CMenuPcs::CTmp*, int, int, in
 
     if (SingleCaravanWork()->m_shopRequestState == 0) {
         int loadIndex = m_singleMenuTextureLoadIndex;
-        if (loadIndex < 2) {
+        if (loadIndex >= 2) {
+            gSingMenuAsyncLoadCompleted = 1;
+        } else {
             if (m_singleMenuTextureLoadState == 0) {
                 char path[260];
                 const char* language = Game.GetLangString();
@@ -1514,8 +1516,6 @@ void CMenuPcs::loadTextureAsync(char **, int, int, CMenuPcs::CTmp*, int, int, in
                 }
                 gSingMenuAsyncLoadCompleted = 1;
             }
-        } else {
-            gSingMenuAsyncLoadCompleted = 1;
         }
     }
 

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -3363,13 +3363,12 @@ void CMenuPcs::DrawSingLife()
 {
     const CCaravanWork* const caravanWork = SingleCaravanWork();
     int lifeTimer = m_singleLifeTimer;
+    float y = -32.0f;
     float xBase = 366.0f;
-    float yBase = -32.0f;
     if (lifeTimer < 0) {
         return;
     }
 
-    float y;
     if (lifeTimer < 10) {
         int phase;
         if (lifeTimer < 0) {
@@ -3380,22 +3379,21 @@ void CMenuPcs::DrawSingLife()
                 phase = lifeTimer;
             }
         }
-        y = 64.0f * static_cast<float>(sin(0.01745329238474369f * (9.0f * static_cast<float>(phase)))) + yBase;
-    } else {
+        y += 64.0f * static_cast<float>(sin(0.01745329238474369f * (9.0f * static_cast<float>(phase))));
+    } else if (lifeTimer < 0x28) {
         y = 32.0f;
-        if (lifeTimer >= 0x28) {
-            int t = 10 - (lifeTimer - 0x28);
-            int phase;
-            if (t < 0) {
-                phase = 0;
-            } else {
-                phase = 10;
-                if (t <= 10) {
-                    phase = t;
-                }
+    } else {
+        int t = 10 - (lifeTimer - 0x28);
+        int phase;
+        if (t < 0) {
+            phase = 0;
+        } else {
+            phase = 10;
+            if (t <= 10) {
+                phase = t;
             }
-            y = 64.0f * static_cast<float>(sin(0.01745329238474369f * (9.0f * static_cast<float>(phase)))) + yBase;
         }
+        y += 64.0f * static_cast<float>(sin(0.01745329238474369f * (9.0f * static_cast<float>(phase))));
     }
 
     int halfHearts = static_cast<unsigned int>(caravanWork->m_maxHp) >> 1;

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1974,22 +1974,19 @@ void CMenuPcs::SingleCalcFadeOut()
     int count = static_cast<int>(m_singleFadeState->count);
     SingleFadeEntry* entry = m_singleFadeState->entries;
     int frame = static_cast<int>(m_singMenuState->frame);
-    if (0 < count) {
-        do {
-            if (frame < entry->startFrame) {
-                entry->alpha = 1.0f;
-            } else if (frame < entry->startFrame + entry->duration) {
-                entry->elapsed = entry->elapsed + 1;
-                entry->alpha =
-                    static_cast<float>(-((1.0 / static_cast<double>(entry->duration)) *
-                                          static_cast<double>(entry->elapsed) - 1.0));
-            } else {
-                completed = completed + 1;
-                entry->alpha = 0.0f;
-            }
-            entry = entry + 1;
-            count = count - 1;
-        } while (count != 0);
+    for (int i = 0; i < count; i++) {
+        if (entry->startFrame > frame) {
+            entry->alpha = 1.0f;
+        } else if (entry->startFrame + entry->duration <= frame) {
+            completed = completed + 1;
+            entry->alpha = 0.0f;
+        } else {
+            entry->elapsed = entry->elapsed + 1;
+            entry->alpha =
+                static_cast<float>(-((1.0 / static_cast<double>(entry->duration)) *
+                                      static_cast<double>(entry->elapsed) - 1.0));
+        }
+        entry = entry + 1;
     }
 
     if (m_wm.m_handles[0]->m_model->m_animEnd < m_wm.m_handles[0]->m_model->m_time) {


### PR DESCRIPTION
Raises main/singmenu fuzzy match from 87.91% to 88.60% via source-level matching fixes (no hacks).

Per-function gains:
- DrawSingLife 73.6% -> 80.1%: accumulate the y wave into the yBase local (`y += 64*sin(...)`) instead of recomputing, so the base/accumulator stay in callee-saved FPRs matching the target's f30/f31 residency.
- SingleCalcFadeOut 78.2% -> 84.4%: reorder if/else arms to match block emission order, flip comparison polarity to put entry fields first, and use a counted for loop to get the target's mtctr/bdnz.
- SingleCalcFadeIn 79.3% -> 84.4%: same fade-loop restructuring (counted loop, entry-field-first comparison, inner arm order).
- drawSingleMenu 85.1% -> 86.1%: reorder switch so case 0 body emits before case 1 (SingleDrawCtrl), matching the target's case VA order.
- loadTextureAsync 84.4% -> 86.1%: invert the loadIndex branch (`if (loadIndex >= 2) {completed} else {...}`) so the completed arm emits first as in the target.

Remaining blockers: DrawSingWin, DrawSingleStat, and SingMenuInit are gated by the float-constant-pool ordering wall (named FLOAT_* symbols vs our anonymous pool entries drive callee-saved-FPR promotion and double-vs-single op selection). DrawSingWinMess, GetSingWinSize, loadTextureAsync, and EquipChk are dominated by a whole-register-window off-by-N coloring difference (e.g. `this`/Game-base register choice) that source reordering alone does not move. drawSingleMenu's case-2 path appears to inline the menu teardown block that our source currently places in the outer if; relocating it is a larger, riskier refactor left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)