### PR TITLE
cflat_runtime2: raise fuzzy match to 88.9%

### DIFF
--- a/include/ffcc/cflat_runtime2.h
+++ b/include/ffcc/cflat_runtime2.h
@@ -77,9 +77,12 @@ public:
 			m_seKind = 1;
 			m_seParam = 0;
 			m_seUnk2 = 0;
+			m_seUnk3 = 0;
 			m_seDelay = 0x1E;
 			m_paramNo = 0;
 			m_paramId = 0;
+			m_pad4A[0] = 0;
+			m_pad4A[1] = 0;
 			m_pos = 0;
 			m_posVec = 0;
 			m_scale = 0;

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1634,12 +1634,11 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 
 		CGObject* object = reinterpret_cast<CGObject*>(baseObj);
 		int newCount = count;
-		const bool passesClassMask = (object->m_attrFlags & static_cast<unsigned int>(classMask)) != 0;
-		const bool passesScriptFilter =
-			((flags & 1) == 0) ||
-			((object->m_scriptHandle != 0) && (*reinterpret_cast<short*>(reinterpret_cast<u8*>(object->m_scriptHandle) + 0x1C) != 0));
 
-		if (passesClassMask && passesScriptFilter) {
+		if (((object->m_attrFlags & static_cast<unsigned int>(classMask)) != 0) &&
+		    (((flags & 1) == 0) ||
+		     ((object->m_scriptHandle != 0) &&
+		      (*reinterpret_cast<short*>(reinterpret_cast<u8*>(object->m_scriptHandle) + 0x1C) != 0)))) {
 			if ((object->m_worldPosition.x != center->x) || (object->m_worldPosition.z != center->z)) {
 				if ((center->x - radius <= object->m_worldPosition.x) &&
 				    (center->z - radius <= object->m_worldPosition.z) &&

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1638,12 +1638,12 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float radius
 		if (((object->m_attrFlags & static_cast<unsigned int>(classMask)) != 0) &&
 		    (((flags & 1) == 0) ||
 		     ((object->m_scriptHandle != 0) &&
-		      (*reinterpret_cast<short*>(reinterpret_cast<u8*>(object->m_scriptHandle) + 0x1C) != 0)))) {
+		      (*reinterpret_cast<unsigned short*>(reinterpret_cast<u8*>(object->m_scriptHandle) + 0x1C) != 0)))) {
 			if ((object->m_worldPosition.x != center->x) || (object->m_worldPosition.z != center->z)) {
 				if ((center->x - radius <= object->m_worldPosition.x) &&
 				    (center->z - radius <= object->m_worldPosition.z) &&
-				    (object->m_worldPosition.x <= center->x + radius) &&
-				    (object->m_worldPosition.z <= center->z + radius)) {
+				    (center->x + radius >= object->m_worldPosition.x) &&
+				    (center->z + radius >= object->m_worldPosition.z)) {
 					Vec offset;
 					PSVECSubtract(&object->m_worldPosition, center, &offset);
 					offset.y = 0.0f;

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -941,8 +941,9 @@ int CFlatRuntime2::Load(char* fileName)
 	File.Close(fileHandle);
 
 	if (getDebugStage() != 0) {
+		int debugIndex = 0;
 		int debugChunk = 0;
-		for (int debugIndex = 0;; debugIndex++) {
+		for (;; debugIndex++) {
 			sprintf(path, sCFlatRuntime2DebugFileNameFmt, fileName);
 			if (debugIndex != 0) {
 				sprintf(path, "%s%d", path, debugIndex);


### PR DESCRIPTION
Raises `main/cflat_runtime2` fuzzy match from 88.54% to 88.86%.

Changes:
- **CcClass2D**: inlined the class-mask/script filter as a lazy short-circuit branch (was materializing booleans with neg/or/srwi); made the script-handle flag read `unsigned short` (lhz+cmplwi); flipped the bbox upper-bound comparisons to `center+radius >= pos` form to match operand order.
- **CParticleWork ctor**: initialize previously-uninitialized `m_seUnk3` and `m_pad4A[2]` so the copy region is fully defined.
- **Load**: declare `debugIndex` before `debugChunk` to match the target's callee-saved register assignment.

Remaining losses are dominated by deep register-allocation / frame-size walls (Draw's extra callee-saved FPR, drawLayer's global GPR shift) and a struct-copy word-merge difference in PutParticle/ResetParticleWork that resists source-level changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)