### PR TITLE
singmenu: raise fuzzy match to 90.0%

### DIFF
--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1263,9 +1263,9 @@ void CMenuPcs::drawSingleMenu()
                 m_wm.m_handles[0] = 0;
             }
 
-            if (m_bonus.m_bonusBoardPtr != 0) {
-                delete[] static_cast<u8*>(reinterpret_cast<void*>(m_bonus.m_bonusBoardPtr));
-                m_bonus.m_bonusBoardPtr = 0;
+            if (m_wm.m_worldObjData != 0) {
+                delete[] m_wm.m_worldObjData;
+                m_wm.m_worldObjData = 0;
             }
 
             if (m_singMenuState != 0) {
@@ -1453,9 +1453,9 @@ void CMenuPcs::drawSingleMenu()
                     m_wm.m_handles[0] = 0;
                 }
 
-                if (m_bonus.m_bonusBoardPtr != 0) {
-                    delete[] static_cast<u8*>(reinterpret_cast<void*>(m_bonus.m_bonusBoardPtr));
-                    m_bonus.m_bonusBoardPtr = 0;
+                if (m_wm.m_worldObjData != 0) {
+                    delete[] m_wm.m_worldObjData;
+                    m_wm.m_worldObjData = 0;
                 }
 
                 if (m_singMenuState != 0) {

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -1435,6 +1435,50 @@ void CMenuPcs::drawSingleMenu()
                 }
                 ++entry;
             }
+
+            if (m_singleFadeState->done != 0) {
+                Game.m_gameWork.m_singleShopOrSmithMenuActiveFlag = 0;
+                Graphic._WaitDrawDone(s_singmenu_cpp, 0x62B);
+                m_singleMenuInitialized = 0;
+
+                if (gSingMenuAsyncFileHandle != 0) {
+                    File.Close(gSingMenuAsyncFileHandle);
+                    gSingMenuAsyncFileHandle = 0;
+                }
+
+                freeTexture(5, 2, 0x2D, 0x33);
+
+                if (m_wm.m_handles[0] != 0) {
+                    delete m_wm.m_handles[0];
+                    m_wm.m_handles[0] = 0;
+                }
+
+                if (m_bonus.m_bonusBoardPtr != 0) {
+                    delete[] static_cast<u8*>(reinterpret_cast<void*>(m_bonus.m_bonusBoardPtr));
+                    m_bonus.m_bonusBoardPtr = 0;
+                }
+
+                if (m_singMenuState != 0) {
+                    delete[] reinterpret_cast<u8*>(m_singMenuState);
+                    m_singMenuState = 0;
+                }
+
+                if (m_singleFadeState != 0) {
+                    delete m_singleFadeState;
+                    m_singleFadeState = 0;
+                }
+
+                if (m_menuWindowInfo != 0) {
+                    delete m_menuWindowInfo;
+                    m_menuWindowInfo = 0;
+                }
+
+                m_stageF4->heapWalker(-1, 0, 0xFFFFFFFF);
+                Graphic.CreateTempBuffer();
+                m_stageF4 = 0;
+                m_singleMenuCtrlResetFlag = 0;
+                Joybus.SetCtrlMode(0, 0);
+            }
             return;
         }
         }


### PR DESCRIPTION
Raises main/singmenu from 88.60% to 90.02%.

Changes:
- Relocated the menu teardown (WaitDrawDone / File.Close / freeTexture / deletes / heapWalker / SetCtrlMode) into drawSingleMenu's case-2 fade-out path, after the fade-entry loop, guarded by m_singleFadeState->done. This was the largest remaining DELETE block (~75 instrs); the original emits this teardown a second time inside case 2. drawSingleMenu went 86.1% -> 99.1%, and the added register pressure corrected the function's frame size (0x80 -> 0x90) and the callee-saved GPR window (stmw r24 -> r23).
- Fixed the teardown's second delete[] to use the real pointer member m_wm.m_worldObjData (offset 0x814) instead of the m_bonus.m_bonusBoardPtr int alias, producing the target's unsigned pointer comparison (cmplwi vs cmpwi).

Remaining blockers: DrawSingWin, DrawSingWinMess, SingMenuInit, and DrawSingleStat are walled by float-pool symbol ordering (named FLOAT_* vs anonymous @NNN sda21 entries) and, in SingMenuInit, a constant-fold mismatch where the original computes centerX/centerY/screenX at runtime while mwcc folds our literal expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)