### PR TITLE
singmenu: raise fuzzy match to 90.2%

### DIFF
--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -2851,7 +2851,7 @@ void CMenuPcs::DrawSingWinMess(int messageNo, int activeMask, int useDynamic)
         if (useDynamic == 0) {
             text = GetSingWinMessage(staticMessage.textIds[i], dynamicText, 0);
         }
-        if (strlen(text) != 0) {
+        if (static_cast<int>(strlen(text)) != 0) {
             char lineBuffer[128];
             strcpy(lineBuffer, text);
             font->SetPosX(x);

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -2904,10 +2904,10 @@ void CMenuPcs::GetSingWinSize(int messageNo, short* outWidth, short* outHeight, 
         dynamicText += 0x80;
     }
 
-    if (useDynamic == 0) {
-        maxWidth -= 0x18;
-    } else {
+    if (useDynamic != 0) {
         maxWidth += 0x16;
+    } else {
+        maxWidth -= 0x18;
     }
 
     int lineHeight = static_cast<int>(22.0f * FLOAT_8032ea78);

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -2234,7 +2234,7 @@ void CMenuPcs::SingleCalcCtrl()
     }
     }
 
-    reinterpret_cast<CMesMenu*>(*reinterpret_cast<void**>(reinterpret_cast<u8*>(&MenuPcs) + 0x268))->CalcHeart();
+    MenuPcs.m_battleMesMenus[0]->CalcHeart();
     m_singMenuState->result = result;
 
     bool hasInput = (Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1);
@@ -3436,8 +3436,7 @@ void CMenuPcs::DrawSingLife()
 
     int halfHearts = static_cast<unsigned int>(caravanWork->m_maxHp) >> 1;
     xBase += static_cast<float>(((8 - halfHearts) * 0x18) / 2);
-    reinterpret_cast<CMesMenu*>(*reinterpret_cast<void**>(reinterpret_cast<u8*>(&MenuPcs) + 0x268))
-        ->DrawHeart(xBase, y - 8.0f, 1.0f, 1.0f);
+    MenuPcs.m_battleMesMenus[0]->DrawHeart(xBase, y - 8.0f, 1.0f, 1.0f);
 }
 
 /*

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -3401,8 +3401,8 @@ void CMenuPcs::DrawSingLife()
 {
     const CCaravanWork* const caravanWork = SingleCaravanWork();
     int lifeTimer = m_singleLifeTimer;
-    float y = -32.0f;
     float xBase = 366.0f;
+    float y = -32.0f;
     if (lifeTimer < 0) {
         return;
     }

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -2827,7 +2827,7 @@ void CMenuPcs::DrawSingWinMess(int messageNo, int activeMask, int useDynamic)
             text = GetSingWinMessage(staticMessage.textIds[i], dynamicText, 0);
         }
         int textWidth = font->GetWidth(text);
-        if (maxWidth < textWidth) {
+        if (textWidth > maxWidth) {
             maxWidth = textWidth;
         }
         dynamicText += 0x80;
@@ -2898,7 +2898,7 @@ void CMenuPcs::GetSingWinSize(int messageNo, short* outWidth, short* outHeight, 
             text = GetSingWinMessage(staticMessage.textIds[i], dynamicText, 0);
         }
         int textWidth = font->GetWidth(text);
-        if (maxWidth < textWidth) {
+        if (textWidth > maxWidth) {
             maxWidth = textWidth;
         }
         dynamicText += 0x80;

--- a/src/singmenu.cpp
+++ b/src/singmenu.cpp
@@ -3435,8 +3435,9 @@ void CMenuPcs::DrawSingLife()
     }
 
     int halfHearts = static_cast<unsigned int>(caravanWork->m_maxHp) >> 1;
+    xBase += static_cast<float>(((8 - halfHearts) * 0x18) / 2);
     reinterpret_cast<CMesMenu*>(*reinterpret_cast<void**>(reinterpret_cast<u8*>(&MenuPcs) + 0x268))
-        ->DrawHeart(xBase + static_cast<float>(((8 - halfHearts) * 0x18) / 2), y - 8.0f, 1.0f, 1.0f);
+        ->DrawHeart(xBase, y - 8.0f, 1.0f, 1.0f);
 }
 
 /*


### PR DESCRIPTION
Raises `main/singmenu` fuzzy match from baseline 90.02% to 90.22% via source-level fixes (no hacks).

Changes:
- **DrawSingLife**: mutate `xBase` in place before passing to DrawHeart so mwcc keeps it in a callee-saved FPR (R1), and swap `xBase`/`y` declaration order to align f30/f31. 80.1% -> 89.6%.
- **DrawSingLife + SingleCalcCtrl**: replace raw `(u8*)&MenuPcs + 0x268` pointer math with the real member access `MenuPcs.m_battleMesMenus[0]` (offset 0x10C), matching the target's `lwz 0x10c`.
- **DrawSingWinMess + GetSingWinSize**: match the `maxWidth` comparison operand order (`textWidth > maxWidth`) to fix the `ble`/`cmpw` polarity.
- **GetSingWinSize**: swap `useDynamic` if/else arm order to match target block emission order (R9).
- **DrawSingWinMess**: cast `strlen()` result to `int` so the zero-check uses signed `cmpwi`.

DrawSingWin / DrawSingleStat / SingMenuInit remain blocked on the float-pool ordering / callee-saved-FPR residency wall (constant-folded float math vs the target's runtime fadds/fmadd sequences referencing named .sdata2 symbols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)