### PR TITLE
cflat_r2system: raise fuzzy match to 83.7%

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1607,10 +1607,9 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
     Vec bestPosition;
 
     for (unsigned int i = 0; i + 1 < pointCount; i++) {
-        Vec* candidate = &points[i];
-        float distanceSq = PSVECSquareDistance(candidate, targetPosition);
+        float distanceSq = PSVECSquareDistance(&points[i], targetPosition);
         if (distanceSq < maxDistanceSq || infiniteRange) {
-            Vec candidatePosition = *candidate;
+            Vec candidatePosition = points[i];
             float distance = sqrtf(distanceSq);
             if (distance < bestDistance) {
                 bestDistance = distance;
@@ -1622,10 +1621,9 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
         }
 
         if (i + 1 == pointCount - 1) {
-            candidate = &points[i + 1];
-            distanceSq = PSVECSquareDistance(candidate, targetPosition);
+            distanceSq = PSVECSquareDistance(&points[i + 1], targetPosition);
             if (distanceSq < maxDistanceSq || infiniteRange) {
-                Vec candidatePosition = *candidate;
+                Vec candidatePosition = points[i + 1];
                 float distance = sqrtf(distanceSq);
                 if (distance < bestDistance) {
                     bestDistance = distance;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1606,7 +1606,7 @@ int CLine<64>::Calc(Vec* nearestPosition, float* nearestDistance, unsigned long*
     float bestT = kLineSegmentMinT;
     Vec bestPosition;
 
-    for (unsigned int i = 0; i + 1 < pointCount; i++) {
+    for (int i = 0; i + 1 < pointCount; i++) {
         float distanceSq = PSVECSquareDistance(&points[i], targetPosition);
         if (distanceSq < maxDistanceSq || infiniteRange) {
             Vec candidatePosition = points[i];


### PR DESCRIPTION
Raises main/cflat_r2system from 83.64% to 83.72% via two source-level matching fixes in `CLine<64>::Calc`:

- Inline the per-iteration `candidate` point pointer instead of caching it in a callee-saved register. The original recomputes `&points[i]` inline at each use; caching it added an extra saved GPR (r19) and grew the stack frame (0x100 vs target 0xe0). Removing the cache shrinks the frame toward the target and drops the saved-register window to match `stmw r20`.
- Use a signed (`int`) loop index instead of `unsigned int`. This matches the target's signed `cmpwi` comparisons in the loop body (found via permute_fn).

Calc improved from 91.5% to 92.5%.

Other functions were investigated but found walled:
- `onSystemFunc` (79.6%, 23664 bytes): dominated by a 0x20 stack-frame-size delta that cascades into every stack-temp offset; the buffer sizes and Vec-temp scoping do not drive it. Relocation/string-pool rendering as noted.
- `SetNextScript`: target uses a non-unrolled `mtctr/bdnz` CTR loop; mwcc either emits `subic./bne` (do/while) or unrolls (for/while) — no source form reproduces CTR-without-unroll.
- `SetMapShadeColor`, `SetDiffuse`, `__mi__/__pl__ CVector`, `onSetSystemVal`, `CalcBound`, `onSystemVal`: remaining diffs are register-coloring / instruction-scheduling (load-ahead vs sequential, this-register assignment, dual-walker float-counter) that source reordering and permute could not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)