### PR TITLE
p_graphic: raise fuzzy match to 72.25%

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -742,8 +742,9 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
-        const u32 rgb = Math.Hsb2Rgb(hue / orderCount, 100, 100);
-        const float width = (kDebugBarFrameBudget * order->m_lastTime) / 16.666666f;
+        GXColor rgb;
+        *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
         if (order->m_priority == 0x26) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
@@ -751,16 +752,16 @@ void CGraphicPcs::drawBar()
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + width + kGraphicOne, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 0);
             GXPosition3f32(x + width + kGraphicOne, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 2);
             GXPosition3f32(x, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 2);
             x += width;
         } else if (order->m_priority != 0x27) {
@@ -769,23 +770,23 @@ void CGraphicPcs::drawBar()
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + width + kGraphicOne, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 0);
             GXPosition3f32(x + width + kGraphicOne, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 2);
             GXPosition3f32(x, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 2);
             x += width;
         }
 
         if (i == lastOrder) {
             const u32 soundColor = Math.Hsb2Rgb(0, 100, 100);
-            const float soundWidth = (kDebugBarFrameBudget * Sound.GetPerformance()) / 16.666666f;
+            const float soundWidth = (kGraphicScreenCenterX * Sound.GetPerformance()) / kDebugBarFrameBudget;
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, drawText ? static_cast<float>(y) : kDebugBarMoveBottom, kGraphicZero);
@@ -844,7 +845,7 @@ void CGraphicPcs::drawBar()
         x = kGraphicZero;
         y = 0x10;
         for (int i = 0; i < orderCount; i++) {
-            const float width = (kDebugBarFrameBudget * order->m_lastTime) / 16.666666f;
+            const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
             if (order->m_priority != 0x27) {
                 char debugString[260];

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -742,9 +742,9 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
+        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
         GXColor rgb;
         *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
-        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
         if (order->m_priority == 0x26) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;


### PR DESCRIPTION
## Summary
Raises `main/p_graphic` fuzzy match from **72.17% → 72.25%** via plausible source corrections in `CGraphicPcs::drawBar`.

## What changed
- **Debug-bar width formula corrected** (`drawBar`, 3 sites). The bar width was computed as `(kDebugBarFrameBudget * lastTime) / 16.666666f` using an anonymous inline float literal. The target asm computes `(kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget` — i.e. the screen-width scale (320) is the multiplier and the frame-budget constant (16.666ms) is the divisor. Replaced the inline literal with the named `kDebugBarFrameBudget` constant and used `kGraphicScreenCenterX` as the multiplier, matching the original's `fmuls`/`fdivs` operand order and eliminating the spurious anonymous `.sdata2` pool entry.
- **GXColor byte-store for the per-order hue color** (`drawBar`). The Hsb2Rgb result was held as a bare `u32`; the target stores it into a `GXColor` and reads it back byte-wise before each `GXColor1u32`. Changed `rgb` to a `GXColor` written via `*reinterpret_cast<u32*>(&rgb)` to match the target's per-member byte extraction.
- **Statement reorder**: compute `width` before `Hsb2Rgb` so `order->m_lastTime` is read before the call, matching the target's evaluation order.

## Evidence
- `drawBar`: 69.65% → 69.99%
- unit `main/p_graphic`: 72.165% → 72.255% (objdiff report.json)

## Why this is plausible source
The width formula now uses the same named constants the rest of the file already declares (`kGraphicScreenCenterX`, `kDebugBarFrameBudget`) instead of a magic literal, and matches the target's exact `fmuls f30,lastTime` / `fdivs f31` shape. The `GXColor` color handling mirrors the byte-wise pattern the original uses throughout the GX draw code in this codebase.

## Remaining blocker
`drawScreenFade` (58.5%) and `drawBar` (70%) are dominated by a frame-size / callee-saved-FPR cascade: our builds save two extra FPRs (f26, f27) and use a smaller stack-temp area, shifting every register number and producing hundreds of `DIFF_ARG_MISMATCH`. Several attempts to relieve this (byte-wise baseColor construction, lazy ternary inlining for y0/y1, soundColor restructuring) all regressed and were reverted. `drawSFCircle` (96.7%) is blocked by a single signed-vs-unsigned int→double bias symbol (`kIntToDoubleBias` vs an anonymous unsigned-conversion table) that cascades into register renames. `__sinit` (48%) needs the R3 data-anchoring fix (named table-descriptor symbols vs a merged `...data.0` base) which is risky given the inlined ctor consuming the statics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)