### PR TITLE
map: raise fuzzy match to 91.84%

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2151,7 +2151,26 @@ int CMapMng::ReadOtm(char* mapName)
 
             chunkFile.PushChunk();
             while (chunkFile.GetNextChunk(chunk)) {
-                if (chunk.m_id == 0x4D455348) {
+                switch (chunk.m_id) {
+                case 0x4D534554: {
+                    CMaterialSet* materialSet =
+                        new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x482) CMaterialSet();
+                    m_materialSet = materialSet;
+                    materialSet->m_materials.SetDefaultSize(0x180);
+                    materialSet->m_materials.SetGrow(0);
+                    materialSet->Create(chunkFile, m_textureSet, static_cast<CMaterialMan::TEV_BIT>(0xFFF53060), 0);
+                    break;
+                }
+
+                case 0x41534554: {
+                    CMapTexAnimSet* texAnimSet =
+                        new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x49A) CMapTexAnimSet();
+                    m_mapTexAnimSet = texAnimSet;
+                    texAnimSet->Create(chunkFile, m_materialSet, m_textureSet);
+                    break;
+                }
+
+                case 0x4D455348: {
                     short& meshCount = m_mapMeshCount;
                     if (meshCount > 0x9F) {
                         return 0;
@@ -2159,25 +2178,10 @@ int CMapMng::ReadOtm(char* mapName)
                     CMapMesh* mesh = GetMapMeshArray() + meshCount;
                     mesh->ReadOtmMesh(chunkFile, MapMng.m_stage, 0, 1);
                     meshCount += 1;
-                    continue;
+                    break;
                 }
 
-                if (chunk.m_id == 0x41534554) {
-                    CMapTexAnimSet* texAnimSet =
-                        new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x49A) CMapTexAnimSet();
-                    m_mapTexAnimSet = texAnimSet;
-                    texAnimSet->Create(chunkFile, m_materialSet, m_textureSet);
-                    continue;
-                }
-
-                if (chunk.m_id == 0x414E494D) {
-                    CMapAnim* mapAnim = new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x4BF) CMapAnim();
-                    mapAnim->ReadOtmAnim(chunkFile);
-                    GetMapAnimArray().Add(mapAnim);
-                    continue;
-                }
-
-                if (chunk.m_id == 0x48495420) {
+                case 0x48495420: {
                     short& hitCount = m_mapHitCount;
                     if (hitCount > 0x1F) {
                         return 0;
@@ -2185,10 +2189,10 @@ int CMapMng::ReadOtm(char* mapName)
                     CMapHit* hit = GetMapHitArray() + hitCount;
                     hit->ReadOtmHit(chunkFile);
                     hitCount += 1;
-                    continue;
+                    break;
                 }
 
-                if (chunk.m_id == 0x4E4F4445) {
+                case 0x4E4F4445: {
                     short& mapObjCount = m_mapObjCount;
                     if (mapObjCount > 0x1FF) {
                         return 0;
@@ -2196,16 +2200,15 @@ int CMapMng::ReadOtm(char* mapName)
                     CMapObj* mapObj = GetMapObjArray() + mapObjCount;
                     mapObj->ReadOtmObj(chunkFile);
                     mapObjCount += 1;
-                    continue;
+                    break;
                 }
 
-                if (chunk.m_id == 0x4D534554) {
-                    CMaterialSet* materialSet =
-                        new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x482) CMaterialSet();
-                    m_materialSet = materialSet;
-                    materialSet->m_materials.SetDefaultSize(0x180);
-                    materialSet->m_materials.SetGrow(0);
-                    materialSet->Create(chunkFile, m_textureSet, static_cast<CMaterialMan::TEV_BIT>(0xFFF53060), 0);
+                case 0x414E494D: {
+                    CMapAnim* mapAnim = new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x4BF) CMapAnim();
+                    mapAnim->ReadOtmAnim(chunkFile);
+                    GetMapAnimArray().Add(mapAnim);
+                    break;
+                }
                 }
             }
             chunkFile.PopChunk();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2330,15 +2330,13 @@ int CMapMng::ReadMid(char* mapName)
 
     void* filePtr;
     if (m_asyncLoadState.m_mapReadMode == 1) {
-        int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-        const int size = m_asyncLoadState.m_fileSizes[readIndex];
-        void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
+        const int size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
         filePtr = File.m_readBuffer;
 
-        Memory.CopyFromAMemorySync(filePtr, amemCursor, static_cast<unsigned long>((size + 0x1F) & ~0x1F));
+        Memory.CopyFromAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>((size + 0x1F) & ~0x1F));
         m_asyncLoadState.m_mapLoadCursor = reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
         CheckSum(filePtr, size);
-        readIndex += 1;
+        m_asyncLoadState.m_asyncReadIndex += 1;
     } else {
         CFile::CHandle* fileHandle = File.Open(strTmp, 0, CFile::PRI_LOW);
         if (fileHandle == 0) {
@@ -2348,9 +2346,8 @@ int CMapMng::ReadMid(char* mapName)
             if (m_asyncLoadState.m_mapReadMode == 3) {
                 File.ReadASync(fileHandle);
                 filePtr = reinterpret_cast<void*>(1);
-                int& openIndex = m_asyncLoadState.m_asyncOpenIndex;
-                m_asyncLoadState.m_asyncHandles[openIndex] = fileHandle;
-                openIndex += 1;
+                m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = fileHandle;
+                m_asyncLoadState.m_asyncOpenIndex += 1;
             } else {
                 File.Read(fileHandle);
                 File.SyncCompleted(fileHandle);
@@ -2358,12 +2355,10 @@ int CMapMng::ReadMid(char* mapName)
                 File.Close(fileHandle);
 
                 if (m_asyncLoadState.m_mapReadMode == 2) {
-                    int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-                    void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
-                    Memory.CopyToAMemorySync(filePtr, amemCursor, static_cast<unsigned long>(size));
-                    m_asyncLoadState.m_fileSizes[readIndex] = size;
-                    m_asyncLoadState.m_fileChecksums[readIndex] = CheckSum(filePtr, size);
-                    readIndex += 1;
+                    Memory.CopyToAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>(size));
+                    m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex] = size;
+                    m_asyncLoadState.m_fileChecksums[m_asyncLoadState.m_asyncReadIndex] = CheckSum(filePtr, size);
+                    m_asyncLoadState.m_asyncReadIndex += 1;
                     m_asyncLoadState.m_mapLoadCursor =
                         reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1934,15 +1934,13 @@ int CMapMng::ReadMpl(char* mapName)
 
         void* filePtr;
         if (m_asyncLoadState.m_mapReadMode == 1) {
-            int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-            const int size = m_asyncLoadState.m_fileSizes[readIndex];
-            void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
+            const int size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
             filePtr = File.m_readBuffer;
 
-            Memory.CopyFromAMemorySync(filePtr, amemCursor, (size + 0x1F) & ~0x1F);
+            Memory.CopyFromAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, (size + 0x1F) & ~0x1F);
             m_asyncLoadState.m_mapLoadCursor = reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
             CheckSum(filePtr, size);
-            readIndex += 1;
+            m_asyncLoadState.m_asyncReadIndex += 1;
         } else {
             CFile::CHandle* fileHandle = File.Open(strTmp, 0, CFile::PRI_LOW);
             if (fileHandle == 0) {
@@ -1952,21 +1950,18 @@ int CMapMng::ReadMpl(char* mapName)
                 if (m_asyncLoadState.m_mapReadMode == 3) {
                     File.ReadASync(fileHandle);
                     filePtr = reinterpret_cast<void*>(1);
-                    int& openIndex = m_asyncLoadState.m_asyncOpenIndex;
-                    m_asyncLoadState.m_asyncHandles[openIndex] = fileHandle;
-                    openIndex += 1;
+                    m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = fileHandle;
+                    m_asyncLoadState.m_asyncOpenIndex += 1;
                 } else {
                     File.Read(fileHandle);
                     File.SyncCompleted(fileHandle);
                     filePtr = File.m_readBuffer;
                     File.Close(fileHandle);
                     if (m_asyncLoadState.m_mapReadMode == 2) {
-                        int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-                        void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
-                        Memory.CopyToAMemorySync(filePtr, amemCursor, static_cast<unsigned long>(size));
-                        m_asyncLoadState.m_fileSizes[readIndex] = size;
-                        m_asyncLoadState.m_fileChecksums[readIndex] = CheckSum(filePtr, size);
-                        readIndex += 1;
+                        Memory.CopyToAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>(size));
+                        m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex] = size;
+                        m_asyncLoadState.m_fileChecksums[m_asyncLoadState.m_asyncReadIndex] = CheckSum(filePtr, size);
+                        m_asyncLoadState.m_asyncReadIndex += 1;
                         m_asyncLoadState.m_mapLoadCursor =
                             reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
                     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2376,7 +2376,8 @@ int CMapMng::ReadMid(char* mapName)
 
         chunkFile.PushChunk();
         while (chunkFile.GetNextChunk(chunk)) {
-            if (chunk.m_id == 0x5343454E) {
+            switch (chunk.m_id) {
+            case 0x5343454E: {
                 chunkFile.PushChunk();
                 while (chunkFile.GetNextChunk(chunk)) {
                     if (chunk.m_id != 0x48495420) {
@@ -2394,8 +2395,9 @@ int CMapMng::ReadMid(char* mapName)
                 chunkFile.PopChunk();
                 continue;
             }
-
-            if (chunk.m_id != 0x4F43544D) {
+            case 0x4F43544D:
+                break;
+            default:
                 continue;
             }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2125,11 +2125,7 @@ int CMapMng::ReadOtm(char* mapName)
                 continue;
             }
 
-            if (static_cast<int>(chunk.m_id) < 0x4F43544D) {
-                if (chunk.m_id != 0x4C495448) {
-                    break;
-                }
-
+            if (chunk.m_id == 0x4C495448) {
                 CMapLightHolder* light = static_cast<CMapLightHolder*>(
                     operator new(0x10, MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x4D3));
                 unsigned char* lightRaw = reinterpret_cast<unsigned char*>(light);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1795,7 +1795,7 @@ int CMapMng::ReadMtx(char* mapName)
                 return 1;
             }
             if (loadIndex == 0) {
-                if (System.m_execParam != 0) {
+                if (static_cast<unsigned int>(System.m_execParam) >= 1) {
                     System.Printf(const_cast<char*>(s_mapReadOpenErrorFmt), strTmp);
                 }
                 return 0;
@@ -1844,7 +1844,7 @@ int CMapMng::ReadMtx(char* mapName)
         }
 
         if (filePtr == 0) {
-            if (System.m_execParam != 0) {
+            if (static_cast<unsigned int>(System.m_execParam) >= 1) {
                 System.Printf(const_cast<char*>(s_mapReadErrorFmt), strTmp);
             }
             return 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2324,7 +2324,7 @@ int CMapMng::ReadMid(char* mapName)
     sprintf(strTmp, const_cast<char*>(s_mapMidPathFmt), mapName);
     int ok = 1;
 
-    if (static_cast<int>(System.m_execParam) >= 3) {
+    if (static_cast<unsigned int>(System.m_execParam) >= 3) {
         System.Printf(const_cast<char*>(s_read_mid_fmt), strTmp);
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2084,7 +2084,7 @@ int CMapMng::ReadOtm(char* mapName)
     }
 
     if (filePtr == 0) {
-        if (System.m_execParam != 0) {
+        if (static_cast<unsigned int>(System.m_execParam) >= 1) {
             System.Printf(const_cast<char*>(s_mapReadErrorFmt), strTmp);
         }
         return 0;
@@ -2099,7 +2099,10 @@ int CMapMng::ReadOtm(char* mapName)
 
     CChunkFile::CChunk chunk;
     while (chunkFile.GetNextChunk(chunk)) {
-        if (chunk.m_id != 0x4F544D20) {
+        switch (chunk.m_id) {
+        case 0x4F544D20:
+            break;
+        default:
             continue;
         }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1986,7 +1986,10 @@ int CMapMng::ReadMpl(char* mapName)
                 }
             } else {
                 while (chunkFile.GetNextChunk(chunk)) {
-                    if (chunk.m_id != 0x4D455348) {
+                    switch (chunk.m_id) {
+                    case 0x4D455348:
+                        break;
+                    default:
                         continue;
                     }
 
@@ -2380,7 +2383,10 @@ int CMapMng::ReadMid(char* mapName)
     CMapObj* nextMapObj = GetMapObjArray();
     CChunkFile::CChunk chunk;
     while (chunkFile.GetNextChunk(chunk)) {
-        if (chunk.m_id != 0x4D494420) {
+        switch (chunk.m_id) {
+        case 0x4D494420:
+            break;
+        default:
             continue;
         }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1807,14 +1807,12 @@ int CMapMng::ReadMtx(char* mapName)
 
         void* filePtr;
         if (m_asyncLoadState.m_mapReadMode == 1) {
-            int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-            int size = m_asyncLoadState.m_fileSizes[readIndex];
-            void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
+            int size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
             filePtr = File.m_readBuffer;
-            Memory.CopyFromAMemorySync(filePtr, amemCursor, static_cast<unsigned long>((size + 0x1F) & ~0x1F));
+            Memory.CopyFromAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>((size + 0x1F) & ~0x1F));
             m_asyncLoadState.m_mapLoadCursor = reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
             CheckSum(filePtr, size);
-            readIndex += 1;
+            m_asyncLoadState.m_asyncReadIndex += 1;
         } else {
             CFile::CHandle* handle = File.Open(strTmp, 0, CFile::PRI_LOW);
             if (handle == 0) {
@@ -1824,21 +1822,18 @@ int CMapMng::ReadMtx(char* mapName)
                 if (m_asyncLoadState.m_mapReadMode == 3) {
                     File.ReadASync(handle);
                     filePtr = reinterpret_cast<void*>(1);
-                    int& openIndex = m_asyncLoadState.m_asyncOpenIndex;
-                    m_asyncLoadState.m_asyncHandles[openIndex] = handle;
-                    openIndex += 1;
+                    m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = handle;
+                    m_asyncLoadState.m_asyncOpenIndex += 1;
                 } else {
                     File.Read(handle);
                     File.SyncCompleted(handle);
                     filePtr = File.m_readBuffer;
                     File.Close(handle);
                     if (m_asyncLoadState.m_mapReadMode == 2) {
-                        int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-                        void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
-                        Memory.CopyToAMemorySync(filePtr, amemCursor, static_cast<unsigned long>(size));
-                        m_asyncLoadState.m_fileSizes[readIndex] = size;
-                        m_asyncLoadState.m_fileChecksums[readIndex] = CheckSum(filePtr, size);
-                        readIndex += 1;
+                        Memory.CopyToAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>(size));
+                        m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex] = size;
+                        m_asyncLoadState.m_fileChecksums[m_asyncLoadState.m_asyncReadIndex] = CheckSum(filePtr, size);
+                        m_asyncLoadState.m_asyncReadIndex += 1;
                         m_asyncLoadState.m_mapLoadCursor =
                             reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
                     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1543,14 +1543,16 @@ search:
             stride;
 
         if (mapObj < mapObjEnd) {
-            do {
+            for (unsigned int i = 0; i < remaining; i++) {
+                if (mapObj >= mapObjEnd) {
+                    break;
+                }
                 CMapObjAtr* mapObjAtr = mapObj->m_attribute;
                 if (mapObjAtr != 0 && mapObjAtr->m_type == CMapObjAtr::MESH_NAME) {
                     goto found;
                 }
                 mapObj++;
-                remaining--;
-            } while (remaining != 0);
+            }
         }
 
         mapObj = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1857,18 +1857,24 @@ int CMapMng::ReadMtx(char* mapName)
 
             if (m_asyncLoadState.m_mapReadMode == 2) {
                 while (chunkFile.GetNextChunk(chunk)) {
-                    if (chunk.m_id == 0x54534554 && chunk.m_arg0 == 1) {
-                        return 1;
+                    switch (chunk.m_id) {
+                    case 0x54534554:
+                        if (chunk.m_arg0 == 1) {
+                            return 1;
+                        }
+                        break;
                     }
                 }
             } else {
                 while (chunkFile.GetNextChunk(chunk)) {
-                    if (chunk.m_id == 0x54534554) {
+                    switch (chunk.m_id) {
+                    case 0x54534554:
                         m_textureSet->Create(chunkFile, MapMng.m_stage, append, 0, 0, 0);
                         append = 1;
                         if (chunk.m_arg0 == 1) {
                             return 1;
                         }
+                        break;
                     }
                 }
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2050,15 +2050,13 @@ int CMapMng::ReadOtm(char* mapName)
     m_mapAnimFrame = 0;
 
     if (m_asyncLoadState.m_mapReadMode == 1) {
-        int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-        const int size = m_asyncLoadState.m_fileSizes[readIndex];
-        void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
+        const int size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
         filePtr = File.m_readBuffer;
 
-        Memory.CopyFromAMemorySync(filePtr, amemCursor, (size + 0x1F) & ~0x1F);
+        Memory.CopyFromAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, (size + 0x1F) & ~0x1F);
         m_asyncLoadState.m_mapLoadCursor = reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
         CheckSum(filePtr, size);
-        readIndex += 1;
+        m_asyncLoadState.m_asyncReadIndex += 1;
     } else {
         CFile::CHandle* fileHandle = File.Open(strTmp, 0, CFile::PRI_LOW);
         if (fileHandle != 0) {
@@ -2066,9 +2064,8 @@ int CMapMng::ReadOtm(char* mapName)
             if (m_asyncLoadState.m_mapReadMode == 3) {
                 File.ReadASync(fileHandle);
                 filePtr = reinterpret_cast<void*>(1);
-                int& openIndex = m_asyncLoadState.m_asyncOpenIndex;
-                m_asyncLoadState.m_asyncHandles[openIndex] = fileHandle;
-                openIndex += 1;
+                m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = fileHandle;
+                m_asyncLoadState.m_asyncOpenIndex += 1;
             } else {
                 File.Read(fileHandle);
                 File.SyncCompleted(fileHandle);
@@ -2076,12 +2073,10 @@ int CMapMng::ReadOtm(char* mapName)
                 File.Close(fileHandle);
 
                 if (m_asyncLoadState.m_mapReadMode == 2) {
-                    int& readIndex = m_asyncLoadState.m_asyncReadIndex;
-                    void* amemCursor = m_asyncLoadState.m_mapLoadCursor;
-                    Memory.CopyToAMemorySync(filePtr, amemCursor, static_cast<unsigned long>(size));
-                    m_asyncLoadState.m_fileSizes[readIndex] = size;
-                    m_asyncLoadState.m_fileChecksums[readIndex] = CheckSum(filePtr, size);
-                    readIndex += 1;
+                    Memory.CopyToAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>(size));
+                    m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex] = size;
+                    m_asyncLoadState.m_fileChecksums[m_asyncLoadState.m_asyncReadIndex] = CheckSum(filePtr, size);
+                    m_asyncLoadState.m_asyncReadIndex += 1;
                     m_asyncLoadState.m_mapLoadCursor =
                         reinterpret_cast<unsigned char*>(m_asyncLoadState.m_mapLoadCursor) + size;
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1993,18 +1993,23 @@ int CMapMng::ReadMpl(char* mapName)
                     chunkFile.PushChunk();
                     CChunkFile::CChunk meshChunk;
                     while (chunkFile.GetNextChunk(meshChunk)) {
-                        if (meshChunk.m_id == 0x56534554) {
+                        switch (meshChunk.m_id) {
+                        case 0x56534554: {
                             short& meshCount = m_mapMeshCount;
                             if (meshCount >= 0xA0) {
                                 return 0;
                             }
                             CMapMesh* mesh = GetMapMeshArray() + meshCount;
                             mesh->ReadOtmMesh(chunkFile, m_stage, 1, 1);
-                        } else if (meshChunk.m_id == 0x44534554) {
+                            break;
+                        }
+                        case 0x44534554: {
                             short& meshCount = m_mapMeshCount;
                             CMapMesh* mesh = GetMapMeshArray() + meshCount;
                             mesh->ReadOtmMesh(chunkFile, m_stage, 1, 1);
                             meshCount += 1;
+                            break;
+                        }
                         }
                     }
                     chunkFile.PopChunk();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2105,7 +2105,8 @@ int CMapMng::ReadOtm(char* mapName)
 
         chunkFile.PushChunk();
         while (chunkFile.GetNextChunk(chunk)) {
-            if (chunk.m_id == 0x4F43544D) {
+            switch (chunk.m_id) {
+            case 0x4F43544D: {
                 short& octTreeCount = m_octTreeCount;
                 if (octTreeCount >= 0x10) {
                     return 0;
@@ -2117,7 +2118,7 @@ int CMapMng::ReadOtm(char* mapName)
                 continue;
             }
 
-            if (chunk.m_id == 0x4C495448) {
+            case 0x4C495448: {
                 CMapLightHolder* light = static_cast<CMapLightHolder*>(
                     operator new(0x10, MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x4D3));
                 unsigned char* lightRaw = reinterpret_cast<unsigned char*>(light);
@@ -2133,28 +2134,28 @@ int CMapMng::ReadOtm(char* mapName)
                 continue;
             }
 
-            if (chunk.m_id != 0x5343454E) {
+            case 0x5343454E:
                 break;
+            default:
+                goto otmDone;
             }
 
             chunkFile.PushChunk();
             while (chunkFile.GetNextChunk(chunk)) {
                 switch (chunk.m_id) {
                 case 0x4D534554: {
-                    CMaterialSet* materialSet =
+                    m_materialSet =
                         new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x482) CMaterialSet();
-                    m_materialSet = materialSet;
-                    materialSet->m_materials.SetDefaultSize(0x180);
-                    materialSet->m_materials.SetGrow(0);
-                    materialSet->Create(chunkFile, m_textureSet, static_cast<CMaterialMan::TEV_BIT>(0xFFF53060), 0);
+                    m_materialSet->m_materials.SetDefaultSize(0x180);
+                    m_materialSet->m_materials.SetGrow(0);
+                    m_materialSet->Create(chunkFile, m_textureSet, static_cast<CMaterialMan::TEV_BIT>(0xFFF53060), 0);
                     break;
                 }
 
                 case 0x41534554: {
-                    CMapTexAnimSet* texAnimSet =
+                    m_mapTexAnimSet =
                         new (MapMng.m_stage, const_cast<char*>(s_map_cpp), 0x49A) CMapTexAnimSet();
-                    m_mapTexAnimSet = texAnimSet;
-                    texAnimSet->Create(chunkFile, m_materialSet, m_textureSet);
+                    m_mapTexAnimSet->Create(chunkFile, m_materialSet, m_textureSet);
                     break;
                 }
 
@@ -2201,6 +2202,7 @@ int CMapMng::ReadOtm(char* mapName)
             }
             chunkFile.PopChunk();
         }
+    otmDone:
         chunkFile.PopChunk();
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1995,7 +1995,7 @@ int CMapMng::ReadMpl(char* mapName)
                     while (chunkFile.GetNextChunk(meshChunk)) {
                         if (meshChunk.m_id == 0x56534554) {
                             short& meshCount = m_mapMeshCount;
-                            if (meshCount > 0x9F) {
+                            if (meshCount >= 0xA0) {
                                 return 0;
                             }
                             CMapMesh* mesh = GetMapMeshArray() + meshCount;
@@ -2102,7 +2102,7 @@ int CMapMng::ReadOtm(char* mapName)
         while (chunkFile.GetNextChunk(chunk)) {
             if (chunk.m_id == 0x4F43544D) {
                 short& octTreeCount = m_octTreeCount;
-                if (octTreeCount > 0xF) {
+                if (octTreeCount >= 0x10) {
                     return 0;
                 }
 
@@ -2155,7 +2155,7 @@ int CMapMng::ReadOtm(char* mapName)
 
                 case 0x4D455348: {
                     short& meshCount = m_mapMeshCount;
-                    if (meshCount > 0x9F) {
+                    if (meshCount >= 0xA0) {
                         return 0;
                     }
                     CMapMesh* mesh = GetMapMeshArray() + meshCount;
@@ -2166,7 +2166,7 @@ int CMapMng::ReadOtm(char* mapName)
 
                 case 0x48495420: {
                     short& hitCount = m_mapHitCount;
-                    if (hitCount > 0x1F) {
+                    if (hitCount >= 0x20) {
                         return 0;
                     }
                     CMapHit* hit = GetMapHitArray() + hitCount;
@@ -2177,7 +2177,7 @@ int CMapMng::ReadOtm(char* mapName)
 
                 case 0x4E4F4445: {
                     short& mapObjCount = m_mapObjCount;
-                    if (mapObjCount > 0x1FF) {
+                    if (mapObjCount >= 0x200) {
                         return 0;
                     }
                     CMapObj* mapObj = GetMapObjArray() + mapObjCount;
@@ -2384,7 +2384,7 @@ int CMapMng::ReadMid(char* mapName)
                     }
 
                     short& hitCount = m_mapHitCount;
-                    if (hitCount > 0x1F) {
+                    if (hitCount >= 0x20) {
                         return 0;
                     }
                     CMapHit* hit = GetMapHitArray() + hitCount;
@@ -2404,7 +2404,7 @@ int CMapMng::ReadMid(char* mapName)
             while (mapObjIndex < m_mapObjCount) {
                 if (mapObj->m_meshType == 1 || mapObj->m_meshType == 2) {
                     short& octTreeCount = m_octTreeCount;
-                    if (octTreeCount > 0xF) {
+                    if (octTreeCount >= 0x10) {
                         return 0;
                     }
 


### PR DESCRIPTION
Raises main/map fuzzy match from 89.93% to 91.84% (data match unchanged at 98.89%).

## What changed
All work in the four large chunk-file readers (CMapMng::ReadOtm/ReadMid/ReadMpl/ReadMtx), recovering the original control-flow and access idioms.

### Per-function gains
- ReadOtm: 65.63% -> 74.40%
- ReadMid: 69.89% -> 78.22%
- ReadMpl: 76.91% -> 81.88%
- ReadMtx: 85.02% -> 88.11%
- AttachMapHit: 86.10% -> 86.81%

### Techniques applied
- **Chunk-ID dispatch as `switch`** (R4): the inner SCEN/MESH/mesh-sub dispatches and the outer single-ID guards (`if (id != X) continue`) were if/else chains; rewriting them as `switch` makes mwcc emit the original balanced `cmpw`/`beq`/`bge` comparison tree (with the chunk-id constant materialized into a register) instead of a flat `subis`/`cmplwi`/`bne` chain. Case bodies ordered to match the target's source-order emission (R9).
- **Direct `m_asyncLoadState` member access** (R8): removed the `int& readIndex = ...` / `void* amemCursor = ...` reference-locals in the async-load preamble (shared by all four readers) and accessed the members directly. This fixes the callee-saved-register window shift (e.g. `stmw r24` -> matching `stmw r25`).
- **Member access through `m_materialSet`/`m_mapTexAnimSet`** instead of a local in ReadOtm's MSET/ASET cases, matching the target's store-then-reload of the member.
- **`>=` bound checks**: count guards (`count > 0x9F` -> `count >= 0xA0`, etc.) to match the target's `cmpwi 0xA0 / blt`.
- **Unsigned `m_execParam` comparisons**: `m_execParam != 0` / `(int)>= 3` -> `(unsigned)>= 1` / `(unsigned)>= 3` to match `cmplwi`.
- **Counted `for` loop** in AttachMapHit's find-if to trigger `mtctr`/`bdnz`.

## Why this is plausible source
Every change makes the code read more like normal original FFCC source: real `switch` statements on the FOURCC chunk ids, direct member access instead of decompiler-style reference aliases, and standard bound/`for` idioms. No hardcoded addresses, vtables, or layout hacks; map.h is untouched.

## Blocker
The residual diff in the readers is dominated by callee-saved register-window / frame-size shifts and a few `mtctr` loop-idiom mismatches that resist source-level coaxing, plus a `.rodata` string-offset labeling difference (data already matches at 98.89%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)