### PR TITLE
gobjwork: raise fuzzy match to 93.6%

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -89,7 +89,7 @@ public:
     unsigned short m_strength;              // 0x001E
     unsigned short m_magic;                 // 0x0020
     unsigned short m_defense;               // 0x0022
-    CRomWork* m_romWork;                    // 0x0024
+    unsigned short* m_romWork;              // 0x0024
     unsigned short* RomStatusBlock() { return m_elementResistances; }
     unsigned short m_elementResistances[8]; // 0x0028 physical, fire, freeze, stun, slow, stop, gravity, holy
     unsigned short m_statusTimers[42];      // 0x0038

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -89,9 +89,9 @@ void CGObjWork::Init(int baseDataIndex, CRomWork* romWork, int idOffset)
 	m_strength = romWork->m_strength;
 	m_magic = romWork->m_magic;
 	m_defense = romWork->m_defense;
-	m_romWork = romWork;
+	m_romWork = romWork->Data();
 
-	memcpy(RomStatusBlock(), m_romWork->ElementResistances(), RomStatusBlockHalfwordCount * sizeof(unsigned short));
+	memcpy(RomStatusBlock(), (m_romWork + CRomWork::ElementResistanceOffset), RomStatusBlockHalfwordCount * sizeof(unsigned short));
 	memset(m_statusTimers + 3, 0, sizeof(m_statusTimers) - 3 * sizeof(m_statusTimers[0]));
 	m_statusValues[0] = 0xFFFF;
 	m_statusValues[1] = 0xFFFF;
@@ -271,7 +271,7 @@ void CCaravanWork::LoadFinished()
 
 	CGame* game = &Game;
 	m_baseDataIndex = (m_id / 100) - 1;
-	m_romWork = reinterpret_cast<CRomWork*>(game->unkCFlatData0[0] + (m_baseDataIndex * 0x1D0));
+	m_romWork = reinterpret_cast<unsigned short*>(game->unkCFlatData0[0] + (m_baseDataIndex * 0x1D0) + 0x10);
 }
 
 /*
@@ -295,8 +295,8 @@ void CCaravanWork::Init(int baseDataIndex, CRomWork* romWork, int idOffset)
 	m_strength = romWork->m_strength;
 	m_magic = romWork->m_magic;
 	m_defense = romWork->m_defense;
-	m_romWork = romWork;
-	memcpy(RomStatusBlock(), m_romWork->ElementResistances(), RomStatusBlockHalfwordCount * sizeof(unsigned short));
+	m_romWork = romWork->Data();
+	memcpy(RomStatusBlock(), (m_romWork + CRomWork::ElementResistanceOffset), RomStatusBlockHalfwordCount * sizeof(unsigned short));
 	memset(m_statusTimers + 3, 0, sizeof(m_statusTimers) - 3 * sizeof(m_statusTimers[0]));
 	m_statusValues[0] = 0xFFFF;
 	m_statusValues[1] = 0xFFFF;
@@ -1783,7 +1783,7 @@ void CCaravanWork::CalcStatus()
 {
 	CRomWork* baseData = reinterpret_cast<CRomWork*>(Game.unkCFlatData0[0] + (m_baseDataIndex * 0x1D0));
 
-	memcpy(RomStatusBlock(), m_romWork->ElementResistances(), RomStatusBlockHalfwordCount * sizeof(unsigned short));
+	memcpy(RomStatusBlock(), (m_romWork + CRomWork::ElementResistanceOffset), RomStatusBlockHalfwordCount * sizeof(unsigned short));
 
 	unsigned short stat = baseData->m_strength;
 	m_strength = stat;
@@ -2834,9 +2834,9 @@ void CMonWork::Init(int baseDataIndex, CRomWork* romWork, int)
 	m_strength = romWork->m_strength;
 	m_magic = romWork->m_magic;
 	m_defense = romWork->m_defense;
-	m_romWork = romWork;
+	m_romWork = romWork->Data();
 
-	memcpy(RomStatusBlock(), m_romWork->ElementResistances(), RomStatusBlockHalfwordCount * sizeof(unsigned short));
+	memcpy(RomStatusBlock(), (m_romWork + CRomWork::ElementResistanceOffset), RomStatusBlockHalfwordCount * sizeof(unsigned short));
 	memset(m_statusTimers + 3, 0, sizeof(m_statusTimers) - 3 * sizeof(m_statusTimers[0]));
 	m_statusValues[0] = 0xFFFF;
 	m_statusValues[1] = 0xFFFF;
@@ -2927,7 +2927,7 @@ void CMonWork::CalcStatus()
 {
 	CRomWork* baseData = reinterpret_cast<CRomWork*>(Game.unkCFlatData0[1] + (m_baseDataIndex * 0x1D0));
 
-	memcpy(RomStatusBlock(), m_romWork->ElementResistances(), RomStatusBlockHalfwordCount * sizeof(unsigned short));
+	memcpy(RomStatusBlock(), (m_romWork + CRomWork::ElementResistanceOffset), RomStatusBlockHalfwordCount * sizeof(unsigned short));
 
 	m_strength = baseData->m_strength;
 	m_magic = baseData->m_magic;


### PR DESCRIPTION
## Summary
Raises `main/gobjwork` fuzzy match from **93.40% to 93.64%** (41 -> 43 matched functions) by correcting how the `m_romWork` pointer is modeled in `CGObjWork`.

## What changed
The shipped code stores `m_romWork` as a pointer **into** the ROM data block (`romWork->m_data`, i.e. `romWork + 0x10`), not the `CRomWork` base. The Ghidra reference and the original PPC asm both confirm this:
- `Init__9CGObjWork` / `LoadFinished`: target emits `addi rN, base, 0x10` before storing to `m_romWork` (0x24); the element-resistance memcpy then reads at `m_romWork + 0x6F` halfwords.

Changes:
- `m_romWork` retyped from `CRomWork*` to `unsigned short*` (same 0x24 offset / pointer width, no layout change).
- All assignment sites now store `romWork->Data()` (= `m_data`, offset 0x10); the computed site in `LoadFinished` adds the `+0x10`.
- `m_romWork->ElementResistances()` accesses become `m_romWork + CRomWork::ElementResistanceOffset`.

## Per-function gains
- `Init__9CGObjWork`: 93.02% -> 99.79%
- `LoadFinished`: 94.77% -> 100.00%
- `Init__8CMonWork`: 92.57% -> 94.00%
- `CalcStatus__8CMonWork`: 99.77% -> 99.78%

## Why this is plausible source
`CRomWork` has its variable-length `m_data[]` block at offset 0x10 after a fixed header; the originals clearly cached a pointer to that data block rather than re-deriving the offset on every status copy. No layout, vtable, or RTTI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)