### PR TITLE
memory: raise fuzzy match to 95.4%

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1650,13 +1650,10 @@ int CAmemCacheSet::GetData(short index, char* source, int line)
 
         if (entry.m_cacheData == 0) {
             if (entry.m_dmaCopy != 0) {
-                char* allocSource = source;
-                if (allocSource == 0) {
-                    allocSource = const_cast<char*>(sEmptyAllocSourceName);
-                }
-
                 entry.m_cacheData =
-                    m_rStage->alloc(static_cast<unsigned long>(entry.m_size), allocSource, static_cast<unsigned long>(line), 1);
+                    m_rStage->alloc(static_cast<unsigned long>(entry.m_size),
+                                    source != 0 ? source : const_cast<char*>(sEmptyAllocSourceName),
+                                    static_cast<unsigned long>(line), 1);
                 if (entry.m_cacheData == 0) {
                     data = 0;
                 } else {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1876,7 +1876,7 @@ void CAmemCacheSet::AddRef(short index)
     CAmemCache& entry = cacheEntryAt(this, index);
 
     entry.m_refCount += 1;
-    if (entry.m_refCount == 0xFFFF) {
+    if (entry.m_refCount >= 0xFFFF) {
         if (static_cast<unsigned int>(System.m_execParam) >= 3) {
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt), static_cast<int>(index));
         }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2001,11 +2001,11 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
 
             for (unsigned int i = 0; i < m_cacheCount; i++) {
                 CAmemCache& entry = cacheEntryAt(this, i);
-                int data = reinterpret_cast<int>(entry.m_cacheData);
-                if (((entry.m_inUse != 0) || (data != 0)) && (static_cast<int>(System.m_execParam) >= 3)) {
+                if (((entry.m_inUse != 0) || (entry.m_cacheData != 0)) && (static_cast<int>(System.m_execParam) >= 3)) {
                     System.Printf(
                         const_cast<char*>(strBase + 0xd8), i, cacheStateName(entry),
-                        cacheTypeName(entry), entry.m_refCount, entry.m_priority, data);
+                        cacheTypeName(entry), entry.m_refCount, entry.m_priority,
+                        reinterpret_cast<int>(entry.m_cacheData));
                 }
             }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1688,7 +1688,7 @@ int CAmemCacheSet::GetData(short index, char* source, int line)
         if (data != 0) {
             return data;
         }
-        AmemFreeLowPrio(entry.m_size);
+        AmemFreeLowPrio(cacheEntryAt(this, index).m_size);
     }
 }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1883,13 +1883,11 @@ void CAmemCacheSet::AddRef(short index)
 
         for (int i = 0; i < m_cacheCount; i++) {
             CAmemCache& current = cacheEntryAt(this, i);
-            unsigned int data = reinterpret_cast<int>(current.m_cacheData);
-            if ((current.m_inUse != 0) || (data != 0)) {
-                if (static_cast<unsigned int>(System.m_execParam) >= 3) {
-                    System.Printf(
-                        const_cast<char*>(sAmemCacheEntryFmt), i, cacheStateName(current),
-                        cacheTypeName(current), current.m_refCount, current.m_priority, data);
-                }
+            if (((current.m_inUse != 0) || (current.m_cacheData != 0)) && (static_cast<unsigned int>(System.m_execParam) >= 3)) {
+                System.Printf(
+                    const_cast<char*>(sAmemCacheEntryFmt), i, cacheStateName(current),
+                    cacheTypeName(current), current.m_refCount, current.m_priority,
+                    reinterpret_cast<int>(current.m_cacheData));
             }
         }
 


### PR DESCRIPTION
Raises main/memory fuzzy match from 94.77% to 95.38% through source-level corrections that match the original Metrowerks codegen.

## Changes
- **AddRef** (85.1% -> 93.9%): refCount overflow guard written as `>= 0xFFFF` to match the target's `blt` branch; inlined `m_cacheData` access into the debug-dump condition/Printf instead of precomputing a `data` local (matches the target's lazy short-circuit load).
- **GetData** (90.3% -> 95.2%): inlined the alloc source-name selection (`source != 0 ? source : sEmpty`) directly at the `alloc` call site to match the target's interleaved argument evaluation; re-derive `entry.m_size` via a fresh `cacheEntryAt` for the `AmemFreeLowPrio` call so the entry pointer dies and the result variable reuses its register (r30) as in the target.
- **AmemFreeLowPrio** (87.6% -> 91.5%): inlined `m_cacheData` into the debug-dump condition/Printf (same lazy-load pattern as AddRef).

## Evidence
objdiff report.json: main/memory fuzzy_match_percent 94.768 -> 95.379. Full build links; data section unchanged at 99.65%.

## Why plausible
All changes mirror idioms already present in sibling functions (e.g. `Release`/`DumpCache` already use the inline `m_cacheData` form) and reflect how the original code evaluated short-circuit conditions and alloc arguments. No hacks, no layout changes, no fake symbols.

## Remaining blockers (walls)
- **CheckSum / SetData**: target uses `mtctr`/`bdnz` counted loops; mwcc emits `subic./bne` for the `do/while` form, and `for` triggers a 2x unroll the target lacks. Could not coax `bdnz`.
- **heapWalker** (87.3%): systematic callee-saved register renumbering (same frame, same `stmw r17`, different coloring) — needs large-scale restructuring.
- **Frame**: decompiler-artifact `port & ~-(cntlzw...)` index that mwcc constant-folds (port=0) but the target keeps live; unmatchable without the real source shape.
- **Init**: inlined `operator new[]` null-check on the constant `s_memory_cpp` file arg is folded away by the target but not by ours; modifying the operator would break its two 100%-matched standalone definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)