### PR TITLE
mapobj: raise fuzzy match to 93.7%

### DIFF
--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -84,8 +84,6 @@ public:
         m_colorMode = 0;
         m_useAltColor = 0;
         m_keyFrameCount = 0;
-        InitMapObjAtrColorKeyFrame(m_colorKeyFrame);
-        InitMapObjAtrColorKeyFrame(m_altColorKeyFrame);
     }
 
     ~CMapObjAtrSpotLight();
@@ -121,8 +119,6 @@ class CMapObjAtrPointLight : public CMapObjAtr
 public:
     CMapObjAtrPointLight()
     {
-        InitMapObjAtrColorKeyFrame(m_colorKeyFrame);
-        InitMapObjAtrColorKeyFrame(m_altColorKeyFrame);
         m_type = POINT_LIGHT;
         m_colorMode = 0;
         m_useAltColor = 0;

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -528,7 +528,8 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
             if (chunk.m_version == 2) {
                 chunkFile.PushChunk();
                 while (chunkFile.GetNextChunk(chunk) != 0) {
-                    if (chunk.m_id == CHUNK_LDAT) {
+                    switch (chunk.m_id) {
+                    case CHUNK_LDAT: {
                         pointLight->m_radius = chunkFile.GetF4();
                         pointLight->m_intensity = chunkFile.GetF4();
                         pointLight->m_colorMode = chunkFile.Get1();
@@ -555,18 +556,26 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
 
                         pointLight->m_color = pointLight->m_colors[0];
                         pointLight->m_altColor = pointLight->m_altColors[0];
-                    } else if (chunk.m_id == CHUNK_CJUN) {
+                        break;
+                    }
+                    case CHUNK_CJUN:
                         pointLight->m_altColorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_CFRM) {
+                        break;
+                    case CHUNK_CFRM:
                         pointLight->m_altColorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_CKEY) {
+                        break;
+                    case CHUNK_CKEY:
                         pointLight->m_altColorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_MJUN) {
+                        break;
+                    case CHUNK_MJUN:
                         pointLight->m_colorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_MFRM) {
+                        break;
+                    case CHUNK_MFRM:
                         pointLight->m_colorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_MKEY) {
+                        break;
+                    case CHUNK_MKEY:
                         pointLight->m_colorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
+                        break;
                     }
                 }
                 chunkFile.PopChunk();

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -606,7 +606,8 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
             if (chunk.m_version == 6) {
                 chunkFile.PushChunk();
                 while (chunkFile.GetNextChunk(chunk) != 0) {
-                    if (chunk.m_id == CHUNK_LDAT) {
+                    switch (chunk.m_id) {
+                    case CHUNK_LDAT: {
                         spotLight->m_baseColor.r = chunkFile.Get1();
                         spotLight->m_baseColor.g = chunkFile.Get1();
                         spotLight->m_baseColor.b = chunkFile.Get1();
@@ -649,18 +650,26 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
 
                         spotLight->m_color = spotLight->m_colors[0];
                         spotLight->m_altColor = spotLight->m_altColors[0];
-                    } else if (chunk.m_id == CHUNK_CJUN) {
+                        break;
+                    }
+                    case CHUNK_CJUN:
                         spotLight->m_altColorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_CFRM) {
+                        break;
+                    case CHUNK_CFRM:
                         spotLight->m_altColorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_CKEY) {
+                        break;
+                    case CHUNK_CKEY:
                         spotLight->m_altColorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_MJUN) {
+                        break;
+                    case CHUNK_MJUN:
                         spotLight->m_colorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_MFRM) {
+                        break;
+                    case CHUNK_MFRM:
                         spotLight->m_colorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
-                    } else if (chunk.m_id == CHUNK_MKEY) {
+                        break;
+                    case CHUNK_MKEY:
                         spotLight->m_colorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
+                        break;
                     }
                 }
                 chunkFile.PopChunk();

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -865,13 +865,17 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
             chunkFile.PushChunk();
             CChunkFile::CChunk mimeChunk;
             while (chunkFile.GetNextChunk(mimeChunk) != 0) {
-                if (mimeChunk.m_id == CHUNK_JUN) {
+                switch (mimeChunk.m_id) {
+                case CHUNK_JUN:
                     mime->m_keyFrame.ReadJun(chunkFile, static_cast<char>(mimeChunk.m_arg0));
-                } else if (mimeChunk.m_id == CHUNK_FRAM) {
+                    break;
+                case CHUNK_FRAM:
                     mime->m_keyFrame.ReadFrame(chunkFile, mimeChunk.m_arg0);
-                } else if (mimeChunk.m_id == CHUNK_KEY) {
+                    break;
+                case CHUNK_KEY:
                     mime->m_keyFrame.ReadKey(chunkFile, mimeChunk.m_arg0);
-                } else if (mimeChunk.m_id == CHUNK_VTXL) {
+                    break;
+                case CHUNK_VTXL: {
                     mime->m_vertexListCount = static_cast<unsigned char>(mimeChunk.m_arg0);
                     mime->m_vertexLists = reinterpret_cast<float**>(
                         operator new[](static_cast<unsigned long>(mime->m_vertexListCount) << 2,
@@ -898,6 +902,8 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                         }
                     }
                     chunkFile.PopChunk();
+                    break;
+                }
                 }
             }
             chunkFile.PopChunk();

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -537,9 +537,8 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                         pointLight->m_unknown20 = chunkFile.Get1();
                         chunkFile.Get1();
 
-                        unsigned char colorCount = chunkFile.Get1();
-                        pointLight->m_colorCount = colorCount;
-                        for (int i = 0; i < static_cast<int>(colorCount); i++) {
+                        pointLight->m_colorCount = chunkFile.Get1();
+                        for (int i = 0; i < static_cast<int>(pointLight->m_colorCount); i++) {
                             pointLight->m_colors[i].r = chunkFile.Get1();
                             pointLight->m_colors[i].g = chunkFile.Get1();
                             pointLight->m_colors[i].b = chunkFile.Get1();


### PR DESCRIPTION
Raises main/mapobj fuzzy match from 90.06% to 93.67%.

## Changes
- **Drop redundant keyframe init in light-attr ctors.** The CMapKeyFrame default constructor already zero-inits junTable/keyFrame/keyValue/splineTable and sets loop/isRun, so the explicit InitMapObjAtrColorKeyFrame calls in the CMapObjAtrPointLight/CMapObjAtrSpotLight constructors duplicated that init. Removing them matches the single-init sequence mwcc emits when ReadOtmObj inlines these constructors. (+0.6%)
- **PLIT/SLIT/MIME inner chunk dispatch are switches.** The point-light, spot-light, and mime inner LDAT/CJUN/CFRM/CKEY/MJUN/MFRM/MKEY (and JUN/FRAM/KEY/VTXL) chunk dispatches were written as if/else-if chains, which mwcc lowers to a flat compare sequence. The originals used a switch on chunk.m_id; mwcc emits the balanced cmpw/beq/bge comparison tree the target shows. (+2.7%)
- **Re-read m_colorCount in the PLIT color loop** instead of caching it in a local, matching the per-iteration lbz the original emits (the adjacent alt-color loop already reads the member). (+0.3%)

## Evidence
ReadOtmObj (6240 bytes, the unit's dominant function) rose from 74.86% to 83.40%. No other unit regressed (verified by full report diff). All matched-function counts preserved.

## Why this is plausible source
All changes recover ordinary C++ shapes: removing duplicate initialization, using switch statements for integer dispatch, and reading struct members directly. No compiler-coaxing hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)