### PR TITLE
memorycard: raise fuzzy match to 95.2%

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1503,12 +1503,12 @@ void CMemoryCardMan::SetLoadData()
 
     for (unsigned int i = 0; i < 4; i++)
     {
-        CCaravanWork* wmWork = &Game.m_caravanWorkArr[Game.m_gameWork.m_wmBackupParams[i]];
-        if (wmWork->m_shopState == 0)
+        int idx = Game.m_gameWork.m_wmBackupParams[i];
+        if (Game.m_caravanWorkArr[idx].m_shopState == 0)
         {
             Game.m_gameWork.m_wmBackupParams[i] = -1;
         }
-        if (wmWork->m_shopBusyFlag != 0)
+        if (Game.m_caravanWorkArr[idx].m_shopBusyFlag != 0)
         {
             Game.m_gameWork.m_wmBackupParams[i] = -1;
         }

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -506,21 +506,43 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
         *reinterpret_cast<u32*>(dstCharData + 0x8D0) = *reinterpret_cast<u32*>(srcSaveData + 0x13D8);
 
         u8* dstWork = dstSaveData + dstChar * 0x200;
-        for (int i = 0; i < 8; i++)
+        int i = 0;
+        do
         {
             u8* item = dstWork + dstChar * 8;
             int row = 0;
             for (int j = 0; j < 2; j++)
             {
-                item[0xC0] = ((i == 0) && (row == 0)) ? 0x32 : 0;
-                item[0xC1] = ((i == 0) && (row == -1)) ? 0x32 : 0;
-                item[0xC2] = ((i == 0) && (row == -2)) ? 0x32 : 0;
-                item[0xC3] = ((i == 0) && (row == -3)) ? 0x32 : 0;
+                u8 a = 0;
+                if ((i == 0) && (row == 0))
+                {
+                    a = 1;
+                }
+                u8 b = 0;
+                item[0xC0] = (-a | a) >> 0x1F & 0x32;
+                if ((i == 0) && (row == -1))
+                {
+                    b = 1;
+                }
+                a = 0;
+                item[0xC1] = (-b | b) >> 0x1F & 0x32;
+                if ((i == 0) && (row == -2))
+                {
+                    a = 1;
+                }
+                b = 0;
+                item[0xC2] = (-a | a) >> 0x1F & 0x32;
+                if ((i == 0) && (row == -3))
+                {
+                    b = 1;
+                }
                 row += 4;
+                item[0xC3] = (-b | b) >> 0x1F & 0x32;
                 item += 4;
             }
+            i++;
             dstWork += 0x40;
-        }
+        } while (i < 8);
 
         memset(dstCharData + 0xC8, 0xFF, 0x10);
         memset(dstCharData + 0xD8, 0, 0x10);

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1564,12 +1564,12 @@ void CMemoryCardMan::MakeSaveData()
     CGame* g = &Game;
     for (int i = 0; i < 4; i++)
     {
-        CCaravanWork* cw = &g->m_caravanWorkArr[g->m_gameWork.m_wmBackupParams[i]];
-        if (cw->m_shopState == 0)
+        int idx = g->m_gameWork.m_wmBackupParams[i];
+        if (g->m_caravanWorkArr[idx].m_shopState == 0)
         {
             g->m_gameWork.m_wmBackupParams[i] = -1;
         }
-        if (cw->m_shopBusyFlag != 0)
+        if (g->m_caravanWorkArr[idx].m_shopBusyFlag != 0)
         {
             g->m_gameWork.m_wmBackupParams[i] = -1;
         }


### PR DESCRIPTION
Raises `main/memorycard` fuzzy match from **94.84%** to **95.23%**.

## Changes
- **Odekake**: rewrote the caravan slot-init inner loop to match the original's per-byte boolean idiom `(-a | a) >> 31 & 0x32` with `u8` booleans, recovering the `mtctr/bdnz` counted inner loop and the hoisted `0x32` mask. (88.95% → 89.80% on the function diff tool.)
- **MakeSaveData** & **SetLoadData**: in the `m_wmBackupParams` validation loops, replaced the cached `CCaravanWork*` pointer (`&Game.m_caravanWorkArr[idx]`) with a cached integer index and direct subscript access (`Game.m_caravanWorkArr[idx].m_shopState` / `.m_shopBusyFlag`). This lets mwcc fold the array base offset (0x13F0) into each member-load displacement (0x1794 / 0x1F95) using the `Game` base directly, eliminating the redundant `addi r4,r4,0x13f0` and matching the original's addressing. (SetLoadData 88.95% → 89.73%, MakeSaveData 90.30% → 91.25%.)

## Evidence
objdiff report.json: `main/memorycard` fuzzy_match_percent 94.84209 → 95.225174.

## Plausibility
All changes are ordinary source-level forms (a boolean-materialization loop, integer index caching with array subscripts) that produce the target instruction sequences; no hacks, hardcoded addresses, or layout tricks.

## Blocker
Remaining mismatches in the three large functions are dominated by callee-saved register-allocation window shifts (e.g. `r21/r22` vs `r26/r27`, `r25` vs `r6` for the Game base) and loop induction-variable canonicalization. The permuter found no improving mutations and manual statement reorders regressed. A unit-wide `...rodata.0` anchoring difference (target references `sMemoryCardGbaDvdDir` by name) stems from currently-unused static strings that the original referenced from GBA-odekake code not yet decompiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)