### PR TITLE
maphit: raise fuzzy match to 95.7%

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -981,70 +981,72 @@ cylinder_body:
             }
         }
 
-        if (g_hit_lpface->m_projectionAxis == 1) {
-            f32 capC = (pz * pz) + radialC;
-            f32 capB = (pz * vz) + radialB;
-            disc = capB * capB - capC;
-            if (disc > 0.0) {
-                disc = sqrtf(disc);
-                f32 t = -capB - disc;
-                if ((t * vz) + pz <= kMapHitZero) {
-                    outT = t * tScale;
-                    if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
-                        return 1;
-                    }
-                    return 0;
-                }
+        if (g_hit_lpface->m_projectionAxis != 1) {
+            return 0;
+        }
 
-                t = -capB + disc;
-                if ((t * vz) + pz <= kMapHitZero) {
-                    outT = t * tScale;
-                    if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
-                        return 1;
-                    }
-                    return 0;
+        f32 capC = (pz * pz) + radialC;
+        f32 capB = (pz * vz) + radialB;
+        disc = capB * capB - capC;
+        if (disc > 0.0) {
+            disc = sqrtf(disc);
+            f32 t = -capB - disc;
+            if ((t * vz) + pz <= kMapHitZero) {
+                outT = t * tScale;
+                if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
+                    return 1;
                 }
-            } else if (disc == 0.0) {
-                const f32 t = -capB;
-                if ((t * vz) + pz <= kMapHitZero) {
-                    outT = t * tScale;
-                    if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
-                        return 1;
-                    }
-                    return 0;
-                }
+                return 0;
             }
 
-            capB = -((vz * axisLen) - capB);
-            disc = capB * capB - (axisLen * -((2.0f * pz) - axisLen) + capC);
-            if (disc > 0.0) {
-                disc = sqrtf(disc);
-                f32 t = -capB - disc;
-                if ((t * vz) + pz >= axisLen) {
-                    outT = t * tScale;
-                    if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
-                        return 1;
-                    }
-                    return 0;
+            t = -capB + disc;
+            if ((t * vz) + pz <= kMapHitZero) {
+                outT = t * tScale;
+                if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
+                    return 1;
                 }
+                return 0;
+            }
+        } else if (disc == 0.0) {
+            const f32 t = -capB;
+            if ((t * vz) + pz <= kMapHitZero) {
+                outT = t * tScale;
+                if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
+                    return 1;
+                }
+                return 0;
+            }
+        }
 
-                t = -capB + disc;
-                if ((t * vz) + pz >= axisLen) {
-                    outT = t * tScale;
-                    if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
-                        return 1;
-                    }
-                    return 0;
+        capB = -((vz * axisLen) - capB);
+        disc = capB * capB - (axisLen * -((2.0f * pz) - axisLen) + capC);
+        if (disc > 0.0) {
+            disc = sqrtf(disc);
+            f32 t = -capB - disc;
+            if ((t * vz) + pz >= axisLen) {
+                outT = t * tScale;
+                if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
+                    return 1;
                 }
-            } else if (disc == 0.0) {
-                const f32 t = -capB;
-                if ((t * vz) + pz >= axisLen) {
-                    outT = t * tScale;
-                    if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
-                        return 1;
-                    }
-                    return 0;
+                return 0;
+            }
+
+            t = -capB + disc;
+            if ((t * vz) + pz >= axisLen) {
+                outT = t * tScale;
+                if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
+                    return 1;
                 }
+                return 0;
+            }
+        } else if (disc == 0.0) {
+            const f32 t = -capB;
+            if ((t * vz) + pz >= axisLen) {
+                outT = t * tScale;
+                if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
+                    return 1;
+                }
+                return 0;
             }
         }
 

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -214,8 +214,8 @@ void CMapHit::CheckHitCylinderNear(CMapCylinder* mapCylinder, Vec* position, uns
     while (static_cast<int>(faceIndex) < endFace) {
         g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
         CheckHitFaceCylinder(mask);
-        faceOffset += sizeof(CMapHitFace);
         faceIndex++;
+        faceOffset += sizeof(CMapHitFace);
     }
 }
 
@@ -259,8 +259,8 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
             return 1;
         }
 
-        faceOffset += sizeof(CMapHitFace);
         faceIndex++;
+        faceOffset += sizeof(CMapHitFace);
     }
 
     return 0;


### PR DESCRIPTION
Raises main/maphit fuzzy match from 95.57% to 95.66%.

## Changes
- **FindIntersection**: inverted the `m_projectionAxis == 1` cap-test into an early `!= 1` return so the failure path falls through, matching the target's branch polarity (R9). 92.77% -> 93.28%.
- **CheckHitCylinder / CheckHitCylinderNear (face-range overloads)**: increment `faceIndex` before `faceOffset` in the face loop to match the target's induction-variable update order. 99.18% -> 99.30% and 99.29% -> 99.40%; also nudged CheckHitFaceCylinder 90.59% -> 90.77% (shared inlined loop).

## Why plausible
Both changes are ordinary source-level forms (early-return guard; statement ordering) that a developer could have written; no hacks, no layout changes.

## Blockers (remaining < 100%)
- CheckHitFaceCylinder (90.77%) and Draw (93.80%): dominated by a single extra callee-saved GPR shifting the whole register window plus a different stack-local layout; structural attempts (bool init order, inlining the MapMng group-array access, edge-path hpv recompute) all regressed or were neutral.
- FindIntersection (93.28%): remaining diffs are FPR-numbering shifts and anonymous-vs-named double/`kMapHitZero` constant pooling artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)