### PR TITLE
p_graphic: raise fuzzy match to 74.0%

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -742,8 +742,9 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
-        const u32 rgb = Math.Hsb2Rgb(hue / orderCount, 100, 100);
-        const float width = (kDebugBarFrameBudget * order->m_lastTime) / 16.666666f;
+        GXColor rgb;
+        *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
         if (order->m_priority == 0x26) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
@@ -751,16 +752,16 @@ void CGraphicPcs::drawBar()
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + width + kGraphicOne, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 0);
             GXPosition3f32(x + width + kGraphicOne, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 2);
             GXPosition3f32(x, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 2);
             x += width;
         } else if (order->m_priority != 0x27) {
@@ -769,23 +770,23 @@ void CGraphicPcs::drawBar()
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + width + kGraphicOne, y0, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 0);
             GXPosition3f32(x + width + kGraphicOne, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 2);
             GXPosition3f32(x, y1, kGraphicZero);
-            GXColor1u32(rgb);
+            GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 2);
             x += width;
         }
 
         if (i == lastOrder) {
             const u32 soundColor = Math.Hsb2Rgb(0, 100, 100);
-            const float soundWidth = (kDebugBarFrameBudget * Sound.GetPerformance()) / 16.666666f;
+            const float soundWidth = (kGraphicScreenCenterX * Sound.GetPerformance()) / kDebugBarFrameBudget;
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, drawText ? static_cast<float>(y) : kDebugBarMoveBottom, kGraphicZero);
@@ -844,7 +845,7 @@ void CGraphicPcs::drawBar()
         x = kGraphicZero;
         y = 0x10;
         for (int i = 0; i < orderCount; i++) {
-            const float width = (kDebugBarFrameBudget * order->m_lastTime) / 16.666666f;
+            const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
             if (order->m_priority != 0x27) {
                 char debugString[260];

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -742,9 +742,10 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
-        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
+        const float lastTime = order->m_lastTime;
         GXColor rgb;
         *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
         if (order->m_priority == 0x26) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -751,13 +751,13 @@ void CGraphicPcs::drawBar()
         if (priority == 0x26) {
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
-            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + width + kGraphicOne, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 0);
+            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
             GXPosition3f32(x + width + kGraphicOne, y1, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 2);
@@ -768,13 +768,13 @@ void CGraphicPcs::drawBar()
         } else if (priority != 0x27) {
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarObjectTop;
-            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarMoveBottom;
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + width + kGraphicOne, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 0);
+            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarMoveBottom;
             GXPosition3f32(x + width + kGraphicOne, y1, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(2, 2);
@@ -790,13 +790,13 @@ void CGraphicPcs::drawBar()
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
-            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + soundWidth + kGraphicOne, y0, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(2, 0);
+            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
             GXPosition3f32(x + soundWidth + kGraphicOne, y1, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(2, 2);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -742,12 +742,13 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
+        const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;
         GXColor rgb;
         *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
-        if (order->m_priority == 0x26) {
+        if (priority == 0x26) {
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
@@ -764,7 +765,7 @@ void CGraphicPcs::drawBar()
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 2);
             x += width;
-        } else if (order->m_priority != 0x27) {
+        } else if (priority != 0x27) {
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarObjectTop;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarMoveBottom;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -748,10 +748,9 @@ void CGraphicPcs::drawBar()
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
         if (order->m_priority == 0x26) {
+            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
-
-            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
@@ -766,10 +765,9 @@ void CGraphicPcs::drawBar()
             GXTexCoord2u16(0, 2);
             x += width;
         } else if (order->m_priority != 0x27) {
+            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarObjectTop;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarMoveBottom;
-
-            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -788,16 +788,18 @@ void CGraphicPcs::drawBar()
             const float soundWidth = (kGraphicScreenCenterX * Sound.GetPerformance()) / kDebugBarFrameBudget;
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
-            GXPosition3f32(x, drawText ? static_cast<float>(y) : kDebugBarMoveBottom, kGraphicZero);
+            const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
+            const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
+            GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(0, 0);
-            GXPosition3f32(x + soundWidth + kGraphicOne, drawText ? static_cast<float>(y) : kDebugBarMoveBottom, kGraphicZero);
+            GXPosition3f32(x + soundWidth + kGraphicOne, y0, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(2, 0);
-            GXPosition3f32(x + soundWidth + kGraphicOne, drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop, kGraphicZero);
+            GXPosition3f32(x + soundWidth + kGraphicOne, y1, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(2, 2);
-            GXPosition3f32(x, drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop, kGraphicZero);
+            GXPosition3f32(x, y1, kGraphicZero);
             GXColor1u32(soundColor);
             GXTexCoord2u16(0, 2);
         }

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -718,7 +718,7 @@ void CGraphicPcs::drawBar()
         padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
         padState = Pad.GetPadInputs()[padIndex].holdOverride;
     }
-    const bool drawText = (padState != 0) && (Joybus.GetPadType(0) != 0x40000);
+    const int drawText = (padState != 0) && (Joybus.GetPadType(0) != 0x40000);
 
     GXColor backColor = s_debug_bar_color;
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -742,9 +742,9 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
+        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
         GXColor rgb;
         *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
-        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
         if (order->m_priority == 0x26) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -353,14 +353,12 @@ void CGraphicPcs::drawScreenFade()
                 _GXSetTevOp(GX_TEVSTAGE0, GX_MODULATE);
                 GXLoadTexObj(&Graphic.m_smallBackTexObj, GX_TEXMAP0);
 
-                const float phase = slotData->m_phase;
-                const float stretch = slotData->m_stretch;
                 const float amp = slotData->m_amplitude * (kGraphicOne - t);
-                const float size = amp + kGraphicOne;
-                const float offX = stretch * (kGraphicScreenCenterX * amp) * (float)sin((double)phase);
-                const float offY = stretch * (kGraphicScreenCenterY * amp) * (float)cos((double)phase);
+                const float offX = slotData->m_stretch * ((kGraphicScreenCenterX * amp) * (float)sin((double)slotData->m_phase));
+                const float offY = slotData->m_stretch * ((kGraphicScreenCenterY * amp) * (float)cos((double)slotData->m_phase));
                 const float cx = kGraphicScreenCenterX + offX;
                 const float cy = kGraphicScreenCenterY + offY;
+                const float size = amp + kGraphicOne;
                 const float w = kGraphicScreenCenterX * size;
                 const float h = kGraphicScreenCenterY * size;
 

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -744,8 +744,8 @@ void CGraphicPcs::drawBar()
     for (int i = 0; i < orderCount; i++) {
         const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;
-        GXColor rgb;
-        *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        const u32 rgbWord = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        GXColor rgb = *reinterpret_cast<const GXColor*>(&rgbWord);
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
         if (priority == 0x26) {


### PR DESCRIPTION
Raises main/p_graphic fuzzy match from 72.25% to 74.01% (+1.76).

## Per-function gains
- drawBar: 69.99% -> 76.09%
- drawScreenFade: 58.50% -> 58.65%

## What worked
- **drawBar y0/y1 register residency**: computing the `drawText ? (float)y : k...` ternary results *after* `GXBegin` (a real call) instead of before keeps them in volatile FPRs, matching the target's f28-f31 callee-saved window instead of over-allocating f26/f27. Further splitting the y1 declaration down to its first use (so y0 and y1 are evaluated at separate program points, each reused once) matched the target's spill/reload pattern. Applied to the priority==0x26, else, and sound (i==lastOrder) blocks.
- **Statement ordering around Hsb2Rgb**: caching `order->m_lastTime` and `order->m_priority` into locals before the `Math.Hsb2Rgb` call (keeping them in callee-saved regs across the call, computing the width division afterward) matches the target's evaluate-load-then-arithmetic order.
- **drawText as int**: makes the bool checks emit `cmpwi` (word compare) instead of `clrlwi.` (byte mask), matching the target.
- **rgb via byte-copy** from the Hsb2Rgb result word.
- **drawScreenFade slot 0**: inlining the `m_stretch`/`m_phase` member reads (instead of caching them in callee-saved FPRs) and right-associating the offX/offY products (`stretch * ((centerX*amp)*sin)`) to match the target's operand order.

## Blocker
drawScreenFade (4256b, the largest function) is walled by a pervasive whole-function callee-saved FPR/GPR window shift (ours saves f26-f31 / r14-r31; target saves f28-f31 / r16-r31). The extra two FPRs come from slot==2's sx/sy clamp values living in f26/f27 across the drawSFCircle calls, where the target coalesces them into f28/f29. This is a register-allocator coalescing outcome that resisted the structural levers tried (int-conversion caching, block reordering, ternary inlining all regressed). The `__sinit` `...data.0` section-base merge (vs the target's per-named-symbol relocations) is blocked because the table-callback descriptors are file-scope statics that cannot be forward-declared-then-defined to apply the R3 anchoring fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)