### PR TITLE
textureman: raise fuzzy match to 98.4%

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -59,9 +59,6 @@ CTexture::CTexture()
 static inline CTexture* NewTexture(CMemory::CStage* textureStage, char* file, int line)
 {
     void* memory = Memory._Alloc(sizeof(CTexture), textureStage, file, line, 0);
-    if (memory == 0) {
-        return 0;
-    }
     return ::new (memory) CTexture;
 }
 

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -757,10 +757,10 @@ void CTexture::InitTexObj()
 {
     unsigned int format = m_format;
     if ((format == GX_TF_C8) || (format == GX_TF_C4)) {
+        void* tlutData = m_tlutData;
         GXInitTexObjCI(&m_texObj, m_imageData, static_cast<u16>(m_width), static_cast<u16>(m_height),
                        static_cast<GXCITexFmt>(format), static_cast<GXTexWrapMode>(m_wrapMode),
                        static_cast<GXTexWrapMode>(m_wrapMode), 0, 0);
-        void* tlutData = m_tlutData;
         int numEntries = (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries;
         GXInitTlutObj(&m_tlutObj0, tlutData, GX_TL_IA8, numEntries);
         numEntries = (m_format == GX_TF_C8) ? kTextureC8TlutEntries : kTextureC4TlutEntries;

--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -35,6 +35,27 @@ enum {
     kTextureC4TlutEntries = 0x10
 };
 
+/*
+ * --INFO--
+ * PAL Address: 0x8003B988
+ * PAL Size: 100b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+CTexture::CTexture()
+{
+    m_maxLod = 0;
+    m_imageData = 0;
+    m_tlutData = 0;
+    m_isIntensityAlpha = 0;
+    m_isAlphaLut = 0;
+    m_name[0] = 0;
+    m_cacheId = -1;
+    m_usesExternalAddress = 0;
+}
+
 static inline CTexture* NewTexture(CMemory::CStage* textureStage, char* file, int line)
 {
     void* memory = Memory._Alloc(sizeof(CTexture), textureStage, file, line, 0);
@@ -800,27 +821,6 @@ CTexture::~CTexture()
             m_tlutData = 0;
         }
     }
-}
-
-/*
- * --INFO--
- * PAL Address: 0x8003B988
- * PAL Size: 100b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CTexture::CTexture()
-{
-    m_maxLod = 0;
-    m_imageData = 0;
-    m_tlutData = 0;
-    m_isIntensityAlpha = 0;
-    m_isAlphaLut = 0;
-    m_name[0] = 0;
-    m_cacheId = -1;
-    m_usesExternalAddress = 0;
 }
 
 /*


### PR DESCRIPTION
Raises main/textureman from 97.14% to 98.41% with three plausible source-level changes.

## Changes
- **Inline CTexture ctor at placement-new sites** (+0.91%): moved the `CTexture::CTexture()` definition above `CTextureSet::Create`, so mwcc inlines it at the `::new (memory) CTexture` sites (emitting `__ct__4CRefFv` + the field-init stores inline) instead of `bl __ct__8CTextureFv`. This matches the original and fixed the callee-saved register window in both `Create` overloads.
- **Hoist tlutData read in InitTexObj CI branch** (+0.003%): read `m_tlutData` at the top of the CI branch to better match the original's value scheduling.
- **Drop redundant null check in NewTexture** (+0.35%): removed the explicit `if (memory == 0) return 0;`. Placement-new already guards the constructor against a null allocation, so the original emitted a single branch rather than an early return. Both `Create` overloads jumped (~95 -> ~97.3/97.7%).

## Per-function results
| function | before | after |
|---|---|---|
| Create(CChunkFile&) | 88.96 | 97.29 |
| Create(void*) | 91.66 | 97.70 |
| InitTexObj | 92.18 | 92.25 |
| CacheLoadTexture | 93.61 | 93.61 |
| Create(CTexture, CChunkFile&) | 97.73 | 97.73 |

## Blocker
Remaining sub-100 functions are limited by mwcc's callee-saved register-window coloring (loop-invariant values vs. params occupy swapped register ranges) and instruction scheduling in `InitTexObj` (a `srwi` vs `srawi`+`clrlwi` on the mipmap arg). Targeted attempts (unsigned-shift cast, name caching, placement-new-via-operator-new, declaration reordering, signedness permutation) all regressed or were net-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)