### PR TITLE
fontman: raise fuzzy match to 97.5%

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -317,14 +317,14 @@ found_fallback:
 	posX += advance;
 
 	if (glyphInfo[0] == 0) {
-		u0 += kFontOne;
+		u0 += LoadFloat(kFontOne);
 	}
 	if (m_glyphWidth == glyphInfo[0] + glyphInfo[1]) {
-		u1 -= kFontOne;
+		u1 -= LoadFloat(kFontOne);
 	}
 
-	v0 += kFontOne;
-	v1 -= kFontOne;
+	v0 += LoadFloat(kFontOne);
+	v1 -= LoadFloat(kFontOne);
 
 	GXBegin(GX_QUADS, GX_VTXFMT0, 4);
 	GXPosition3f32(x0, y0, posZ);


### PR DESCRIPTION
## Summary
Improves `main/fontman` matching by routing the `kFontOne` reads in `CFont::Draw(unsigned short)` through the existing `LoadFloat(const float&)` helper instead of using the bare `const` value.

mwcc constant-folds an initialized `const float` at its use site, emitting an anonymous `.sdata2` pool entry (`@380@sda21`) rather than a load from the named global. Passing the value by reference (as the file already does for `kFontZero`) prevents the fold, so the conversions now reference the real `kFontOne@sda21` symbol exactly like the original. `Draw(unsigned short)` rises 93.22% -> 93.28% and its `.rela` relocations now match the target's named-symbol form.

## Why this is plausible source
`LoadFloat` is an existing helper in this unit, already used for `kFontZero`. Reusing it for `kFontOne` is consistent with how the original referenced its `.sdata2` float constants.

## Blocker / remaining diffs
The residual mismatches in `Draw`, `GetWidth`, and `SetColor` are backend artifacts that are not source-steerable here:
- **Anonymous int->float conversion bias** (`@258`/`@390` vs `kFontUnsignedIntToDoubleBias`/`kFontSignedIntToDoubleBias`): the bias is generated by mwcc's conversion backend and does not dedupe against the named `extern const double` globals. Tested R3 def-reordering (forward `extern` decl + `extern "C"` definition after the functions, matching the p_menu idiom) — no effect.
- **Glyph-search loop branch polarity** (`bne <cont>; b <found>` vs `beq <found>`): a fixed mwcc block-layout choice; inverting the `if` condition and `==`/`!=` phrasing does not change it. `permute_fn` found no improvement on `GetWidth(char*)`.
- **`SetColor` r0/r5 register coloring**: the load/store pipeline order can be matched but mwcc deterministically colors the first-loaded byte into r0 where the target uses r5; not steerable by local/temp renaming.
- **`Draw` frame size 0x100 vs 0xe0**: the 4 GXTexCoord2u16 `(unsigned short)(float)` conversions each allocate fresh stack scratch instead of reusing one slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)