### PR TITLE
game: raise fuzzy match to 98.3%

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1232,8 +1232,8 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
     memset(thresholds, 0, 8);
 
     int stageIndex = (int)Game.m_gameWork.m_bossArtifactStageIndex;
-    CBossArtifactStage* artifactBase = Game.m_bossArtifactBase;
     int stageByteOffset = stageIndex * sizeof(CBossArtifactStage);
+    CBossArtifactStage* artifactBase = Game.m_bossArtifactBase;
     CBossArtifactStage* stageArtifacts =
         reinterpret_cast<CBossArtifactStage*>(reinterpret_cast<char*>(artifactBase) + stageByteOffset);
     int artifactRank = 3;
@@ -1251,9 +1251,9 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
     int divisor = artifactRank + 1;
     int quotient = scaledAmount / divisor;
     stageBase += scaledAmount - quotient * divisor;
-    int entryOffset = (stageByteOffset + offsetof(CBossArtifactStage, m_entries)) +
-        stageBase * (int)sizeof(CBossArtifactEntry);
-    return reinterpret_cast<int>(reinterpret_cast<char*>(artifactBase) + entryOffset);
+    int entriesByteOffset = stageByteOffset + offsetof(CBossArtifactStage, m_entries);
+    return reinterpret_cast<int>(reinterpret_cast<char*>(artifactBase) +
+        (entriesByteOffset + stageBase * (int)sizeof(CBossArtifactEntry)));
 }
 
 /*

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -738,7 +738,7 @@ void CGame::CheckScriptChange()
     int scriptResult = CFlatRuntime2Storage().Load(m_nextScript.m_name);
     strcpy(m_currentScriptName, m_nextScript.m_name);
 
-    if (m_nextScript.m_flags != 0) {
+    if ((int)m_nextScript.m_flags != 0) {
         System.Printf(const_cast<char*>(s_gameDebugMarker));
         System.Printf(const_cast<char*>(assetNameBlock + kNewGameInitMsg));
         System.Printf(const_cast<char*>(s_gameDebugMarker));

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -492,10 +492,12 @@ void CGame::Create()
         u32* dst = reinterpret_cast<u32*>(&m_nextScript);
         int count = sizeof(scriptName) / (sizeof(u32) * 2);
         do {
-            dst[1] = src[1];
+            u32 a = src[1];
+            u32 b = src[2];
             src += 2;
+            dst[1] = a;
+            dst[2] = b;
             dst += 2;
-            dst[0] = src[0];
         } while (--count != 0);
         m_newGameFlag = 1;
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1067,9 +1067,8 @@ void CGame::LoadScript(char* scriptData)
 
     while (i < CFlatPermanentVarCount()) {
         if ((CFlatPermanentVarFlagByte(entryOffset) & 0x20) != 0) {
-            u32* src = reinterpret_cast<u32*>(scriptData + scriptOffset);
+            CFlatPermanentVarWord(entryOffset) = *reinterpret_cast<u32*>(scriptData + scriptOffset);
             scriptOffset += 4;
-            CFlatPermanentVarWord(entryOffset) = *src;
         }
 
         entryOffset += 4;
@@ -1233,7 +1232,10 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
     memset(thresholds, 0, 8);
 
     int stageIndex = (int)Game.m_gameWork.m_bossArtifactStageIndex;
-    CBossArtifactStage* stageArtifacts = &Game.m_bossArtifactBase[stageIndex];
+    CBossArtifactStage* artifactBase = Game.m_bossArtifactBase;
+    int stageByteOffset = stageIndex * sizeof(CBossArtifactStage);
+    CBossArtifactStage* stageArtifacts =
+        reinterpret_cast<CBossArtifactStage*>(reinterpret_cast<char*>(artifactBase) + stageByteOffset);
     int artifactRank = 3;
 
     thresholds[1] = stageArtifacts->m_rankThresholds[1];
@@ -1249,7 +1251,9 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
     int divisor = artifactRank + 1;
     int quotient = scaledAmount / divisor;
     stageBase += scaledAmount - quotient * divisor;
-    return reinterpret_cast<int>(&stageArtifacts->m_entries[stageBase]);
+    int entryOffset = (stageByteOffset + offsetof(CBossArtifactStage, m_entries)) +
+        stageBase * (int)sizeof(CBossArtifactEntry);
+    return reinterpret_cast<int>(reinterpret_cast<char*>(artifactBase) + entryOffset);
 }
 
 /*


### PR DESCRIPTION
Raises main/game fuzzy match from 97.77% to 98.29% via source-level structural fixes.

## Per-function gains
- **GetBossArtifact** (79.0% region of diffs → ~93%): kept the boss-artifact `base` pointer and `stageIndex*sizeof(stage)` byte offset as separate live locals instead of caching a combined `stageArtifacts` pointer. This recovers the target's 5-register `stmw r27`/`lmw r27` frame (0x40) and the final address computation `base + (byteOffset + 0x20 + stageBase*8)` with base added last. Also reordered the offset/base evaluation so `mulli` precedes the base load.
- **Create** (94.5% → ~96%): rewrote the start-script copy loop to read both source words then store both (`lwz/lwzu` then `stw/stwu`), matching the target's read-read-write-write body order and the `-0x34d4` dst anchor.
- **CheckScriptChange** (97.6% → ~98.9%): cast `m_nextScript.m_flags` to signed `int` at the `!= 0` test so mwcc emits `cmpwi` instead of `cmplwi`.

## What worked
- Splitting an obj base pointer into base + scaled-index locals to grow the callee-saved frame to match `stmw`/`lmw`.
- Matching memory read/write batching order in unrolled copy loops.
- Signedness cast at a comparison site to flip `cmplwi`→`cmpwi`.

## Blocker
The remaining sub-100% functions are dominated by mwcc-internal effects that did not respond to source restructuring across many attempts: callee-saved register-coloring rotations (ChangeMap, loadCfd, GetTargetCursor); section-base / jumptable anchoring (Exec `@445`/`@446` vs named `jumptable_*`, the `m_scriptWork` clear loop's `addis` re-anchor in clearWork/ScriptChanged); rematerialization of the constant `&Game` address for the second `memset` (InitNewGame, CheckScriptChange, Create); the anonymous int→double bias literal `@949` (GetBossArtifact); and loop strength-reduction / CTR promotion in LoadScript/SaveScript (`lwzx`/`stwx` vs pointer-increment) and Create (`mtctr/bdnz` vs `subic./bne`). `__sinit_game_cpp` is the data.0 wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)