### PR TITLE
p_usb: raise fuzzy match to 99.4%

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -84,7 +84,6 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     int result;
     int connected;
     unsigned char* packetStorage;
-    unsigned char* dstStorage;
     CDataHeader* packet;
     CDataHeader* dstBuffer;
     CMemory::CStage* stage;
@@ -111,9 +110,8 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     } else {
         stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
 
-        dstStorage = new (stage, const_cast<char*>(s_p_usb_cpp), 0x19e)
-            unsigned char[(packet->m_packetSize + 0x1F) & ~0x1F];
-        dstBuffer = reinterpret_cast<CDataHeader*>(dstStorage);
+        dstBuffer = reinterpret_cast<CDataHeader*>(new (stage, const_cast<char*>(s_p_usb_cpp), 0x19e)
+            unsigned char[(packet->m_packetSize + 0x1F) & ~0x1F]);
         memcpy(dstBuffer, packet, (packet->m_packetSize + 0x1F) & ~0x1F);
 
         dstBuffer->m_packetType = Swap32(packet->m_packetType);
@@ -123,13 +121,13 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
         DCInvalidateRange(dstBuffer, (packet->m_packetSize + 0x1F) & ~0x1F);
 
         if (USB.Write(dstBuffer, (packet->m_packetSize + 0x1F) & ~0x1F) == 0) {
-            delete[] dstStorage;
+            delete[] dstBuffer;
             result = 0;
         } else if (USB.SendMessage(0, (MCCChannel)9) == 0) {
-            delete[] dstStorage;
+            delete[] dstBuffer;
             result = 0;
         } else {
-            delete[] dstStorage;
+            delete[] dstBuffer;
             result = 1;
         }
     }

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -96,10 +96,10 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     packet->m_packetSize = value;
     packet->m_packetType = 4;
     packet->m_packetCode = Swap32((unsigned int)code);
-    packet->m_payloadSize = Swap32(count);
     packet->m_elementCount = Swap32((unsigned int)elemCount);
-    packet->m_reserved2C = Swap32(0);
     packet->m_dataSize = Swap32(count);
+    packet->m_reserved2C = Swap32(0);
+    packet->m_payloadSize = Swap32(count);
     memcpy(packet + 1, src, count);
 
     connected = USB.IsConnected();

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -82,8 +82,7 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 {
     unsigned int count;
     int result;
-    int connected;
-    unsigned char* packetStorage;
+    unsigned int connected;
     CDataHeader* packet;
     CDataHeader* dstBuffer;
     CMemory::CStage* stage;
@@ -93,8 +92,7 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     value = (count + 0x5F) & ~0x1F;
     stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
 
-    packetStorage = new (stage, const_cast<char*>(s_p_usb_cpp), 0x1ca) unsigned char[value];
-    packet = reinterpret_cast<CDataHeader*>(packetStorage);
+    packet = reinterpret_cast<CDataHeader*>(new (stage, const_cast<char*>(s_p_usb_cpp), 0x1ca) unsigned char[value]);
     packet->m_packetType = 4;
     packet->m_packetSize = value;
     packet->m_payloadSize = Swap32(count);
@@ -133,7 +131,7 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     }
 
     if (packet != (CDataHeader*)nullptr) {
-        delete[] packetStorage;
+        delete[] packet;
     }
     return result;
 }

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -93,10 +93,10 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
 
     packet = reinterpret_cast<CDataHeader*>(new (stage, const_cast<char*>(s_p_usb_cpp), 0x1ca) unsigned char[value]);
-    packet->m_packetType = 4;
     packet->m_packetSize = value;
-    packet->m_payloadSize = Swap32(count);
+    packet->m_packetType = 4;
     packet->m_packetCode = Swap32((unsigned int)code);
+    packet->m_payloadSize = Swap32(count);
     packet->m_elementCount = Swap32((unsigned int)elemCount);
     packet->m_reserved2C = Swap32(0);
     packet->m_dataSize = Swap32(count);

--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -82,7 +82,7 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
 {
     unsigned int count;
     int result;
-    unsigned int connected;
+    int connected;
     CDataHeader* packet;
     CDataHeader* dstBuffer;
     CMemory::CStage* stage;


### PR DESCRIPTION
Raises main/p_usb from 97.65% to 99.39%.

All gains are in CUSBPcs::SendDataCode (94.16% -> 98.50% function-level):

- Coalesced dstStorage/dstBuffer into a single CDataHeader* pointer (the new[] result is reinterpret_cast directly and deleted as-is), matching the original's single-register lifetime and shrinking the stack frame from 0x50/r25-r31 to 0x40/r26-r31.
- Coalesced packetStorage/packet into a single pointer for symmetry/plausibility.
- Reordered the CDataHeader header writes to match the original emission order: m_packetSize before m_packetType, and the byte-swapped fields in the order packetCode, elementCount, dataSize, reserved2C, payloadSize. This fixed both the staging-slot offsets and the callee-saved register coloring of the parameters (elemCount->r26, value->r27, this->r28, src->r29) as a side effect.
- connected kept as int (confirmed via permute_fn signedness search).

Remaining: a 2-instruction scheduling artifact (placement of `li r3,0x4` for m_packetType relative to the m_packetSize store) that cannot be steered from source without regressing the frame, and __sinit_p_usb_cpp at 99.77% (the known data.0 base-CSE WALL). All other functions are 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)