### PR TITLE
maptexanim: raise fuzzy match to 100.0%

### DIFF
--- a/include/ffcc/maptexanim.h
+++ b/include/ffcc/maptexanim.h
@@ -38,13 +38,7 @@ public:
     CMapTexAnim()
     {
         float frameStep = kMapTexAnimDefaultFrameStep;
-        m_keyFrame.m_junTable = 0;
         float currentFrame = kMapTexAnimZero;
-        m_keyFrame.m_keyFrame = 0;
-        m_keyFrame.m_keyValue = 0;
-        m_keyFrame.m_splineTable = 0;
-        m_keyFrame.m_loop = 1;
-        m_keyFrame.m_isRun = 0;
         m_frameTable = 0;
         m_frameStep = frameStep;
         m_currentFrame = currentFrame;


### PR DESCRIPTION
Raises `main/maptexanim` from 99.14% to **100.0%** (all 5 functions match).

## What changed
The only sub-100% function was `CMapTexAnimSet::Create`, where the `CMapTexAnim` default constructor is inlined. That ctor body explicitly re-initialized the `m_keyFrame` sub-object fields (`m_junTable`, `m_keyFrame`, `m_keyValue`, `m_splineTable`, `m_loop`, `m_isRun`) that `CMapKeyFrame`'s own default constructor already sets. This produced a duplicated init-store block in the inlined ctor (one block from the member ctor, one from the body assignments).

Removing the redundant body assignments lets the `CMapKeyFrame` member constructor handle them, which emits exactly the original's single init block (offsets 0x3c/0x40/0x44/0x48/0x27/0x28 followed by m_frameTable 0x20).

## Why this is plausible source
- No layout changes; `CMapKeyFrame`'s constructor and class layout are untouched.
- Other users of `CMapKeyFrame` (materialman, mapobj) are unaffected — they construct `CMapKeyFrame` directly, not via `CMapTexAnim`.
- Relying on a member's own default ctor instead of re-assigning its fields is the natural way the original would have been written.

## Evidence
- Before: `Create__14CMapTexAnimSet...` 96.57%, unit 99.14%.
- After: all 5 functions 100.00%, unit fuzzy_match 100.0% (code/data/functions all 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)