### PR TITLE
cmake: raise fuzzy match to 84.2%

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -650,19 +650,19 @@ void CMenuPcs::calcVillageMenu()
             short& frame = villageWork->m_frame;
 
             if (mode == 0) {
-                if (frame < 10) {
+                if (frame >= 10) {
+                    result = 1;
+                } else {
                     frame = frame + 1;
                     result = 0;
-                } else {
-                    result = 1;
                 }
             } else if (mode == 1) {
                 result = CmakeVillageCtrl();
-            } else if (frame < 10) {
+            } else if (frame >= 10) {
+                result = 1;
+            } else {
                 frame = frame + 1;
                 result = 0;
-            } else {
-                result = 1;
             }
 
             villageWork->m_resultFlag = static_cast<short>(result);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1745,7 +1745,6 @@ void CMenuPcs::CmakeJobDraw()
 
     DrawCmakePreviewChara(this);
 
-    int panelAlpha = static_cast<int>(255.0f * alpha);
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
@@ -1753,7 +1752,7 @@ void CMenuPcs::CmakeJobDraw()
     panelColor.r = 0xFF;
     panelColor.g = 0xFF;
     panelColor.b = 0xFF;
-    panelColor.a = static_cast<unsigned char>(panelAlpha);
+    panelColor.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
     GXSetChanMatColor(GX_COLOR0A0, panelColor);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     MenuPcs.DrawRect(
@@ -1769,7 +1768,7 @@ void CMenuPcs::CmakeJobDraw()
     font->SetScale(1.0f);
     font->DrawInit();
 
-    CColor textColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(panelAlpha));
+    CColor textColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
     font->SetColor(textColor.color);
 
     for (int i = 0; i < 8; ++i) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2321,11 +2321,14 @@ void CMenuPcs::CmakeSexDraw()
 
     DrawCmakePreviewChara(this);
 
-    int panelAlpha = static_cast<int>(255.0f * alpha);
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
-    GXColor panelColor = {0xFF, 0xFF, 0xFF, static_cast<unsigned char>(panelAlpha)};
+    GXColor panelColor;
+    panelColor.r = 0xFF;
+    panelColor.g = 0xFF;
+    panelColor.b = 0xFF;
+    panelColor.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
     GXSetChanMatColor(GX_COLOR0A0, panelColor);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     MenuPcs.DrawRect(
@@ -2339,8 +2342,7 @@ void CMenuPcs::CmakeSexDraw()
     font->SetScale(1.0f);
     font->DrawInit();
 
-    int a = static_cast<int>(255.0f * alpha);
-    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a));
+    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
     font->SetColor(rgba.color);
 
     float maxWidth = 0.0f;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3067,12 +3067,11 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
-    int a = static_cast<int>(255.0f * alpha);
     GXColor col;
     col.r = 0xFF;
     col.g = 0xFF;
     col.b = 0xFF;
-    col.a = static_cast<unsigned char>(a);
+    col.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
     GXSetChanMatColor(GX_COLOR0A0, col);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3A));
@@ -3097,8 +3096,8 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     font->DrawInit();
     font->SetTlut(7);
 
-    GXColor rgba = {0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a)};
-    font->SetColor(rgba);
+    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
+    font->SetColor(rgba.color);
 
     const char* yesStr = GetMenuStr(1);
     float yesW = static_cast<float>(font->GetWidth(yesStr));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1547,7 +1547,7 @@ void CMenuPcs::CmakeResultDraw()
     labelFont->SetScale(1.0f);
     labelFont->DrawInit();
 
-    int textColor = static_cast<int>(static_cast<double>(255.0f) * textAlpha);
+    int textColor = static_cast<int>(255.0f * textAlpha);
     CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
     labelFont->SetColor(color.color);
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1470,7 +1470,7 @@ void CMenuPcs::CmakeResultDraw()
     if ((mode == 2) && (resultDir < 0)) {
         panelAlphaValue = 1.0f;
     }
-    int panelAlpha = static_cast<int>(static_cast<double>(255.0f) * panelAlphaValue);
+    int panelAlpha = static_cast<int>(255.0f * panelAlphaValue);
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3426,9 +3426,7 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
     const char* txt = GetMenuStr(0x29);
     float w = static_cast<float>(font->GetWidth(txt));
     int tx = static_cast<int>(
-        static_cast<double>(static_cast<float>(static_cast<double>(120.0f) - static_cast<double>(w))) *
-            0.5 +
-        480.0);
+        static_cast<double>(120.0f - w) * 0.5 + 480.0);
     int cursorY = static_cast<int>(373.0);
     font->SetPosX(static_cast<float>(tx));
     font->SetPosY(static_cast<float>(cursorY - 4));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3383,12 +3383,11 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
-    int a = static_cast<int>(255.0f * alpha);
     GXColor col;
     col.r = 0xFF;
     col.g = 0xFF;
     col.b = 0xFF;
-    col.a = static_cast<unsigned char>(a);
+    col.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
     GXSetChanMatColor(GX_COLOR0A0, col);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
@@ -3420,7 +3419,7 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
     font->DrawInit();
     font->SetTlut(7);
 
-    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a));
+    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
     font->SetColor(rgba.color);
 
     const char* txt = GetMenuStr(0x29);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3554,8 +3554,8 @@ void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x65 : 0x3E));
 
-    float titleX = static_cast<float>(offsU + static_cast<unsigned int>(20.0));
-    float titleY = static_cast<float>(offsU + static_cast<int>(8.0));
+    float titleX = static_cast<float>(static_cast<int>(static_cast<double>(offsU) + 20.0));
+    float titleY = static_cast<float>(static_cast<int>(static_cast<double>(offsU) + 8.0));
     MenuPcs.DrawRect(
         0, titleX, titleY, 208.0f, 24.0f,
         0.0f, static_cast<float>(page * 0x18), 1.0f, 1.0f, 0.0f);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3797,7 +3797,7 @@ void CMenuPcs::CalcSingCMake()
         CmakeMcState(this) = 3;
     }
 
-    unsigned short result = 0;
+    unsigned short result;
 
     switch (CmakeState(this)->m_step) {
     case 0:


### PR DESCRIPTION
Raises main/cmake fuzzy match from 83.18% to 84.16% via source-level matching fixes (all changes in src/cmake.cpp only).

## Per-function gains
- DrawCmakeTitle: 79.98 -> 91.37 (double-precision arithmetic for titleX/titleY: `(int)((double)offsU + 20.0)` instead of integer add-then-convert)
- DrawCmakeYesNo: 82.09 -> 86.46 (re-derive `255*alpha` int at each color site instead of caching `int a`; CColor font color with field-init GXColor)
- CmakeSexDraw: 85.04 -> 86.10 (re-derive alpha int + per-field GXColor init instead of aggregate init)
- CmakeJobDraw: 85.02 -> 90.86 (re-derive alpha int at both color sites)
- CmakeResultDraw: 85.80 -> 86.58 (single-precision `255.0f * textAlpha`/`255.0f * panelAlphaValue`)
- calcVillageMenu: 87.29 -> 94.53 (invert `frame < 10` to `frame >= 10` so failure path falls through, matching mwcc block order)
- CalcSingCMake: 82.58 -> 82.71 (drop `result` pre-initialization so it lands in a volatile register per-case like the target)
- DrawCmakeDecision: 82.91 -> 83.86 (single-precision inner `fsubs` for tx; re-derive alpha)

## What worked
- mwcc emits the magic-double int->float sequence for `(int)((double)x + N)` runtime conversions; matching the target's float-vs-double split (single `fsubs`/`fmadds` inner, double outer) converts INSERT/DELETE runs straight to score.
- The target keeps `255.0f * alpha` in a callee-saved FPR and re-derives the int color value at each GXSetChanMatColor/SetColor site rather than caching `int a` once — replacing the cached int with inline `static_cast<int>(255.0f * alpha)` matches this (works only when the value is used purely at color sites).
- if-polarity inversion (R9) to make the failure path fall through.

## Blocker
The four `*Ctrl` functions (CmakeTribeCtrl, CmakeJobCtrl, CmakeVillageCtrl, CmakeNameCtrl) share a `down`/`repeat` pad-read idiom where the target sign-extends both into callee-saved registers (`short`), but changing the locals to `short` regresses overall because the `bool padBusy` materialization at the top of those functions colors registers differently. The down/repeat extsh fix and the padBusy register window are coupled — neither can be matched without regressing the other. CmakeVillageDraw/CmakeNameDraw have a hard f30/f31 callee-saved-FPR allocation swap. DrawDiaryBase converts a runtime int Y-coordinate (24) that constant-folds in our source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)