### PR TITLE
p_camera: raise fuzzy match to 88.0% (cycle 2)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1644,7 +1644,7 @@ void CCameraPcs::drawShadowBegin()
             m_targetZ = m_fullScreenShadowPosition.z;
             PSVECSubtract(reinterpret_cast<Vec*>(&m_targetX), reinterpret_cast<Vec*>(&m_positionX), &delta);
             depth = static_cast<double>(PSVECMag(&delta));
-            m_fullScreenShadow.m_span = static_cast<float>(depth * static_cast<double>(m_fullScreenShadow.m_scale));
+            m_fullScreenShadow.m_span = static_cast<float>(depth) * m_fullScreenShadow.m_scale;
         }
 
         double currentDepth = static_cast<double>(m_fullScreenShadowDepth);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -941,6 +941,9 @@ void CCameraPcs::draw()
         GXClearVtxDesc();
         GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+        float posX = g_shadow_pos.x;
+        float posY = g_shadow_pos.y;
+        float posZ = g_shadow_pos.z;
         PSMTXScale(shadowMtx, kCameraTwoF, kCameraTwoF, kCameraTwoF);
         shadowMtx[0][3] = posX;
         shadowMtx[1][3] = posY;
@@ -973,6 +976,9 @@ void CCameraPcs::draw()
         GXClearVtxDesc();
         GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+        float refPosX = g_shadow_refpos.x;
+        float refPosY = g_shadow_refpos.y;
+        float refPosZ = g_shadow_refpos.z;
         PSMTXScale(shadowMtx, kCameraTwoF, kCameraTwoF, kCameraTwoF);
         shadowMtx[0][3] = refPosX;
         shadowMtx[1][3] = refPosY;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -697,7 +697,19 @@ void CCameraPcs::CalcQuake()
         return;
     }
 
-    if (m_quake.m_startTimer <= 0) {
+    if (m_quake.m_startTimer > 0) {
+        float ratio = static_cast<float>(m_quake.m_startTimer) /
+                      static_cast<float>(m_quake.m_startDuration);
+        PSVECScale(&offset, &offset, ratio);
+        PSVECAdd(&offset, &jitter, &offset);
+        PSVECAdd(&offset, &PositionVec(), &PositionVec());
+        PSVECAdd(&offset, &TargetVec(), &TargetVec());
+        m_quake.m_startTimer = m_quake.m_startTimer - 1;
+
+        if ((m_quake.m_startTimer == 0) && (m_quake.m_keepMoving == 0)) {
+            m_quake.m_state = 0;
+        }
+    } else {
         if (m_quake.m_state == 0) {
             if (m_quake.m_endTimer <= 0) {
                 m_quake.m_state = 0;
@@ -724,18 +736,6 @@ void CCameraPcs::CalcQuake()
             PSVECAdd(&offset, &jitter, &offset);
             PSVECAdd(&offset, &PositionVec(), &PositionVec());
             PSVECAdd(&offset, &TargetVec(), &TargetVec());
-        }
-    } else {
-        float ratio = static_cast<float>(m_quake.m_startTimer) /
-                      static_cast<float>(m_quake.m_startDuration);
-        PSVECScale(&offset, &offset, ratio);
-        PSVECAdd(&offset, &jitter, &offset);
-        PSVECAdd(&offset, &PositionVec(), &PositionVec());
-        PSVECAdd(&offset, &TargetVec(), &TargetVec());
-        m_quake.m_startTimer = m_quake.m_startTimer - 1;
-
-        if ((m_quake.m_startTimer == 0) && (m_quake.m_keepMoving == 0)) {
-            m_quake.m_state = 0;
         }
     }
 }

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -608,8 +608,14 @@ void CCameraPcs::CalcQuake()
     Vec offset;
     Vec jitter;
 
-    if ((System.m_scenegraphStepMode == 2) || ((m_quake.m_mode == 2) && (m_quake.m_state == 0)) ||
-        ((m_quake.m_mode == 1) && (m_quake.m_state == 0) && (m_quake.m_endTimer <= 0))) {
+    if (System.m_scenegraphStepMode == 2) {
+        return;
+    }
+    unsigned char mode = m_quake.m_mode;
+    if (mode == 2 && m_quake.m_state == 0) {
+        return;
+    }
+    if (mode == 1 && m_quake.m_state == 0 && m_quake.m_endTimer <= 0) {
         return;
     }
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1529,11 +1529,15 @@ int CCameraPcs::GetShadowRect(CBound& shadowRectBound)
         if (worldBound->CheckFrustum0(*clipBound) == 0) {
             continue;
         }
-        if (kCameraClipMinZ >= clipBoundData[0]) {
+        if (clipBoundData[0] <= kCameraClipMinZ) {
             continue;
         }
-        if ((kCameraDebugRotateStep >= (clipBoundData[5] - clipBoundData[2]) / -clipBoundData[0]) &&
-            (kCameraDebugRotateStep >= (clipBoundData[4] - clipBoundData[1]) / -clipBoundData[0])) {
+        float negMinX = -clipBoundData[0];
+        float ratioZ = (clipBoundData[5] - clipBoundData[2]) / negMinX;
+        float ratioY = (clipBoundData[4] - clipBoundData[1]) / negMinX;
+        if (ratioZ > kCameraDebugRotateStep) {
+            // proceed
+        } else if (ratioY <= kCameraDebugRotateStep) {
             continue;
         }
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -941,9 +941,6 @@ void CCameraPcs::draw()
         GXClearVtxDesc();
         GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
-        float posX = g_shadow_pos.x;
-        float posY = g_shadow_pos.y;
-        float posZ = g_shadow_pos.z;
         PSMTXScale(shadowMtx, kCameraTwoF, kCameraTwoF, kCameraTwoF);
         shadowMtx[0][3] = posX;
         shadowMtx[1][3] = posY;
@@ -976,9 +973,6 @@ void CCameraPcs::draw()
         GXClearVtxDesc();
         GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
-        float refPosX = g_shadow_refpos.x;
-        float refPosY = g_shadow_refpos.y;
-        float refPosZ = g_shadow_refpos.z;
         PSMTXScale(shadowMtx, kCameraTwoF, kCameraTwoF, kCameraTwoF);
         shadowMtx[0][3] = refPosX;
         shadowMtx[1][3] = refPosY;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1648,7 +1648,7 @@ void CCameraPcs::drawShadowBegin()
         }
 
         double currentDepth = static_cast<double>(m_fullScreenShadowDepth);
-        if (static_cast<double>(kCameraZeroF) <= currentDepth) {
+        if (currentDepth >= static_cast<double>(kCameraZeroF)) {
             m_fullScreenShadowDepth = static_cast<float>(currentDepth +
                                                          static_cast<double>((static_cast<float>(depth - currentDepth)) * kCameraShadowDepthBlend));
         } else {

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -710,32 +710,30 @@ void CCameraPcs::CalcQuake()
             m_quake.m_state = 0;
         }
     } else {
-        if (m_quake.m_state == 0) {
-            if (m_quake.m_endTimer <= 0) {
-                m_quake.m_state = 0;
-                m_quake.m_startTimer = 0;
-                m_quake.m_startDuration = 0;
-                m_quake.m_endTimer = 0;
-                m_quake.m_endDuration = 0;
-                m_quake.m_positionAmplitude.z = kCameraZeroF;
-                m_quake.m_positionAmplitude.y = kCameraZeroF;
-                m_quake.m_positionAmplitude.x = kCameraZeroF;
-                m_quake.m_jitterAmplitude.z = kCameraZeroF;
-                m_quake.m_jitterAmplitude.y = kCameraZeroF;
-                m_quake.m_jitterAmplitude.x = kCameraZeroF;
-            } else {
-                float ratio = static_cast<float>(m_quake.m_endTimer) /
-                              static_cast<float>(m_quake.m_endDuration);
-                PSVECScale(&offset, &offset, ratio);
-                PSVECSubtract(&offset, &jitter, &offset);
-                PSVECAdd(&offset, &PositionVec(), &PositionVec());
-                PSVECAdd(&offset, &TargetVec(), &TargetVec());
-                m_quake.m_endTimer = m_quake.m_endTimer - 1;
-            }
-        } else {
+        if (m_quake.m_state != 0) {
             PSVECAdd(&offset, &jitter, &offset);
             PSVECAdd(&offset, &PositionVec(), &PositionVec());
             PSVECAdd(&offset, &TargetVec(), &TargetVec());
+        } else if (m_quake.m_endTimer > 0) {
+            float ratio = static_cast<float>(m_quake.m_endTimer) /
+                          static_cast<float>(m_quake.m_endDuration);
+            PSVECScale(&offset, &offset, ratio);
+            PSVECSubtract(&offset, &jitter, &offset);
+            PSVECAdd(&offset, &PositionVec(), &PositionVec());
+            PSVECAdd(&offset, &TargetVec(), &TargetVec());
+            m_quake.m_endTimer = m_quake.m_endTimer - 1;
+        } else {
+            m_quake.m_state = 0;
+            m_quake.m_startTimer = 0;
+            m_quake.m_startDuration = 0;
+            m_quake.m_endTimer = 0;
+            m_quake.m_endDuration = 0;
+            m_quake.m_positionAmplitude.z = kCameraZeroF;
+            m_quake.m_positionAmplitude.y = kCameraZeroF;
+            m_quake.m_positionAmplitude.x = kCameraZeroF;
+            m_quake.m_jitterAmplitude.z = kCameraZeroF;
+            m_quake.m_jitterAmplitude.y = kCameraZeroF;
+            m_quake.m_jitterAmplitude.x = kCameraZeroF;
         }
     }
 }


### PR DESCRIPTION
Cycle-2 deep pass on main/p_camera. Raised unit fuzzy match 86.26% -> 88.04% (+1.78) via plausible source-level idioms; no header layout changes, no hacks.

## Per-function gains
- CalcQuake: 74.0% -> 93.9%. Cached quake mode in a local and split the compound early-return guard; reordered the startTimer branch (startTimer>0 first) and the inner state/endTimer branches to match the target's basic-block emission order (R9).
- GetShadowRect: 81.4% -> 86.0%. R11 strict-comparison rewrite of the frustum-cull guard: the `>=`/`<=` clamps against sda21 floats were emitting NaN-aware `fcmpo`+`cror`; rewrote the compound condition as a short-circuit chain with strict `>` (fall-through on failure) and precomputed the shared `-clipBoundData[0]` denominator. Drops two `cror` sequences.
- drawShadowBegin: 78.8% -> 81.1%. Single-precision `m_span = (float)depth * m_scale` instead of a double multiply (R2), plus depth-blend comparison polarity flip.

## What worked
- R9 basic-block source-order reordering (CalcQuake) was the biggest lever: the target emits if/else arm bodies in source order; matching the fall-through structure converted INSERT/DELETE control-flow runs straight to score.
- R11 cror-elimination on float clamps.
- R2 single-precision correction guided by the target asm (`fmuls` vs `fmul`+`frsp`).

## Blocker
Remaining headroom is walled on deep register/FPR-coloring and data anchoring:
- createFullShadow (60%): the unrolled ramp-texture loop hinges on the loop counter living in r3 vs r6, driven by a prologue that caches `&MapMng`/`s_p_camera_cpp` in callee-saved regs (reproducing requires `&MapMng` offset-0 deref tricks that are banned).
- calc (81%): a `this`(r30) vs `&Pad`(r31) callee-saved swap cascades ARG_MISMATCH through the whole function; not steerable without restructuring every Pad access.
- CameraState struct copies in drawShadowBegin (word-copy bulk + float tail in target, all-float in ours) are mwcc struct-copy codegen tied to the shared header layout.
- `__sinit` and the `@530`/anonymous-double + bss-base CSE are the known data.0 wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)