### PR TITLE
cmake: raise fuzzy match to 84.2% (cycle 2)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1963,7 +1963,6 @@ void CMenuPcs::CmakeJobOpen()
 void CMenuPcs::CmakeTribeDraw()
 {
     float alpha = CalcCmakeFadeAlpha(this);
-    CmakeMenuState* cmakeState = CmakeState(this);
 
     DrawWMFrame0(1, 1.0f);
 
@@ -2020,7 +2019,7 @@ void CMenuPcs::CmakeTribeDraw()
 
     DrawCmakeTitle(3, 1.0f, alpha);
     {
-        int tribe = cmakeState->m_select;
+        int tribe = CmakeState(this)->m_select;
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
@@ -2077,19 +2076,19 @@ void CMenuPcs::CmakeTribeDraw()
 
     DrawInit();
 
-    if (cmakeState->m_mode == 1) {
-        int select = cmakeState->m_select;
+    if (CmakeState(this)->m_mode == 1) {
+        int select = CmakeState(this)->m_select;
         unsigned int frame = System.m_frameCounter & 7;
         int tribeCursorY = 0x88 + select * 0x1C;
 
-        if (cmakeState->m_fieldSelect == 0) {
+        if (CmakeState(this)->m_fieldSelect == 0) {
             DrawCursor(static_cast<int>(228.0f + static_cast<float>(frame)), tribeCursorY, alpha);
         } else {
             if ((System.m_frameCounter & 1) != 0) {
                 DrawCursor(static_cast<int>(228.0f), tribeCursorY, alpha);
             }
 
-            int hairCursorY = 0x88 + cmakeState->m_row * 0x1C;
+            int hairCursorY = 0x88 + CmakeState(this)->m_row * 0x1C;
             DrawCursor(static_cast<int>(348.0f + static_cast<float>(frame)), hairCursorY, alpha);
         }
     }


### PR DESCRIPTION
## Summary
Cycle-2 deep matching pass on `main/cmake`. Raised the unit fuzzy match from 84.16% to 84.20%.

### What changed
- `CmakeTribeDraw`: removed the redundant `CmakeMenuState* cmakeState` cached local and access `CmakeState(this)->...` directly at each use site. The original re-loaded the `m_cmakeState` pointer (offset 0x82c) at each access rather than holding it in a callee-saved register; caching it forced an extra long-lived GPR and shifted the whole register window. Reloading matches the target's `lwz r4,0x82c` scratch-reload pattern, fixes the `stmw r25` save-count, and bumps `CmakeTribeDraw` 80.08% -> 80.62%. This also matches how the sibling Draw functions (CmakeJobDraw, CmakeNameDraw) are already written.

### Why it is plausible source
The accessor-per-use form is the dominant idiom in the surrounding cmake Draw functions; removing the lone cached-pointer local makes CmakeTribeDraw consistent with them.

### Blocker (remaining headroom)
The dominant residual mismatch across the alpha-based Draw functions (CmakeVillageDraw, CmakeNameDraw, CmakeTribeDraw, DrawCmakeDecision) is a systematic callee-saved-FPR allocation difference: the target holds `alpha` in f30 and the cached `255*alpha` in f31 (reused via repeated `fctiwz`), while mwcc here keeps `alpha` in f31 and rematerializes `255*alpha` into a scratch FPR at each color site. This resisted every source lever tried (float vs int caching, single/double precision, declaration reorder, live-range extension). The four `*Ctrl` pad-read functions (CmakeTribeCtrl/NameCtrl/JobCtrl) are register-coloring walls whose source already matches the Ghidra reference exactly. CalcSingCMake and DrawDiaryBase are register-window/coalescing walls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)