### PR TITLE
p_graphic: raise fuzzy match to 72.3% (cycle 2)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -309,6 +309,7 @@ void CGraphicPcs::drawScreenFade()
                     pos.y += slotData->m_targetYOffs;
                     PSMTX44MultVec(worldScreenMtx, &pos, &pos);
 
+                    const int radius = (unsigned int)(kGraphicScreenWidth * (kGraphicOne - fadeWave));
                     float sx = pos.x * kGraphicScreenCenterX + kGraphicScreenCenterX;
                     float sy = -(pos.y * kGraphicScreenCenterY - kGraphicScreenCenterY);
                     if (sx < kGraphicZero) {
@@ -322,7 +323,6 @@ void CGraphicPcs::drawScreenFade()
                         sy = kGraphicScreenHeight;
                     }
 
-                    const int radius = (unsigned int)(kGraphicScreenWidth * (kGraphicOne - fadeWave));
                     drawSFCircle(static_cast<unsigned int>(kScreenFadeCircleRadius), radius, (unsigned int)sx, (unsigned int)sy, baseColor, baseColor);
                     drawSFCircle(radius, radius - static_cast<unsigned int>(kScreenFadeRingWidth), (int)sx, (int)sy, baseColor, baseColor2);
                     continue;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -323,8 +323,10 @@ void CGraphicPcs::drawScreenFade()
                         sy = kGraphicScreenHeight;
                     }
 
-                    drawSFCircle(static_cast<unsigned int>(kScreenFadeCircleRadius), radius, (unsigned int)sx, (unsigned int)sy, baseColor, baseColor);
-                    drawSFCircle(radius, radius - static_cast<unsigned int>(kScreenFadeRingWidth), (int)sx, (int)sy, baseColor, baseColor2);
+                    const unsigned int ix = (unsigned int)sx;
+                    const unsigned int iy = (unsigned int)sy;
+                    drawSFCircle(static_cast<unsigned int>(kScreenFadeCircleRadius), radius, ix, iy, baseColor, baseColor);
+                    drawSFCircle(radius, radius - static_cast<unsigned int>(kScreenFadeRingWidth), ix, iy, baseColor, baseColor2);
                     continue;
                 }
             }


### PR DESCRIPTION
Raises `main/p_graphic` from 72.25% to 72.30% by improving `drawScreenFade` slot-2 (object-targeted screen fade) liveness.

## Changes
- **Hoist radius before sx/sy clamp**: compute `radius` (which consumes `fadeWave`) before the sx/sy screen-position clamps so `fadeWave`'s live range ends earlier, matching the original's evaluation order.
- **Convert sx/sy to int once**: the two `drawSFCircle` calls both consume `(unsigned int)sx/sy`; converting once into named `ix`/`iy` locals lets the float values die before the first call instead of being held in callee-saved FPRs across both calls.

## Result
- drawScreenFade: 58.50% -> 58.60%
- Unit main/p_graphic: 72.25% -> 72.30%

Both changes are plausible original source (ordinary local hoisting / common-subexpression naming), not compiler coaxing.

## Blocker
The dominant remaining gap in both `drawScreenFade` and `drawBar` is a callee-saved FPR-window coloring difference: the originals save f28-f31 (4 FPRs) while our build saves f26-f31 (6). The loop-spanning `t`/`fadeWave` pair colors to f26/f27 in our build vs f28/f29 in the target, cascading hundreds of register-number ARG_MISMATCHes. This is a byproduct of the upstream drawBar rewrite's structure and resisted 10+ liveness/order/struct-copy variants. A secondary recurring wall is the compiler-generated int->double bias constant being emitted as an anonymous `@NNN` symbol vs the target's named `kIntToDoubleBias` (same class as the documented data.0 sdata2 wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)