### PR TITLE
joybus: raise fuzzy match to 87.79% (cycle 3)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -8055,7 +8055,11 @@ int JoyBus::SetOpenMenu(int playerIndex, char menuId)
     {
         bool isSingle = GbaQue.IsSingleMode(m_threadParams[playerIndex].m_portIndex);
 
-        if (!isSingle)
+        if (isSingle)
+        {
+            result = 0;
+        }
+        else
         {
             unsigned int cmd = 0;
             unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
@@ -8086,16 +8090,16 @@ int JoyBus::SetOpenMenu(int playerIndex, char menuId)
                 }
             }
         }
-        else
-        {
-            result = 0;
-        }
     }
     else
     {
         bool isSingle = GbaQue.IsSingleMode(m_threadParams[playerIndex].m_portIndex);
 
-        if (!isSingle)
+        if (isSingle)
+        {
+            result = 0;
+        }
+        else
         {
             unsigned int cmd = 0;
             unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
@@ -8124,10 +8128,6 @@ int JoyBus::SetOpenMenu(int playerIndex, char menuId)
                     result = 0;
                 }
             }
-        }
-        else
-        {
-            result = 0;
         }
     }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3795,15 +3795,14 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
     m_recvQueueEntriesArr[port][m_secCmdCount[port]] = 0;
     m_secCmdCount[port]--;
 
-    localWord = (localWord & 0xFFFF0000u) |
-                static_cast<unsigned short>(static_cast<char>(localWord >> 24));
+    *reinterpret_cast<unsigned short*>(&localWord) =
+        static_cast<unsigned short>(static_cast<short>(localWord >> 24));
 
     OSSignalSemaphore(&m_accessSemaphores[port]);
 
-    const unsigned char cmd = static_cast<unsigned char>(localWord & 0x3F);
-    const unsigned char seq = static_cast<signed char>((localWord >> 8) & 0xFF);
+    const unsigned char seq = static_cast<signed char>((localWord >> 16) & 0xFF);
 
-    if (cmd == 7)
+    if ((static_cast<unsigned char>(localWord >> 24) & 0x3F) == 7)
     {
         step = 0;
         phase = 0;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3800,8 +3800,6 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
     OSSignalSemaphore(&m_accessSemaphores[port]);
 
-    const unsigned char seq = static_cast<signed char>((localWord >> 16) & 0xFF);
-
     if ((static_cast<unsigned char>(localWord >> 24) & 0x3F) == 7)
     {
         step = 0;
@@ -3834,7 +3832,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
         }
 
         const unsigned int typeVal = static_cast<char>(sendType);
-        const int respVal = seq;
+        const int respVal = static_cast<signed char>((localWord >> 16) & 0xFF);
 
         if (result != 0)
         {
@@ -3846,7 +3844,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
         return diffMask - 1;
     }
 
-    if ((int)seq == (int)static_cast<char>(sendType))
+    if ((int)static_cast<signed char>((localWord >> 16) & 0xFF) == (int)static_cast<char>(sendType))
     {
         step = 0;
         phase = 1;


### PR DESCRIPTION
## Summary
Raises main/joybus fuzzy match from 87.72% to 87.79% via source-correctness fixes guided by the Ghidra reference.

## Changes
- **SetOpenMenu (83.74% -> 87.29%)**: flipped both `IsSingleMode` branches from `if(!isSingle){work}else{result=0}` to `if(isSingle){result=0}else{work}`. This matches the target's basic-block emission order (common/work path falls through inline, trivial path out-of-line) - the R9 block-order lever.
- **SendDataFile (60.41% -> 60.78%)**: corrected the `localWord` command/sequence byte extraction. The Ghidra reference shows the post-semaphore masking is a 16-bit partial store (`(short)(localWord>>24)` into the low-address half) and that `cmd`/`seq` read bytes 0/1 (`(localWord>>24)&0x3F` and `(signed char)(localWord>>16)`) rather than the low bytes. Also stopped caching `seq` in a local so it reloads lazily at each use, matching the original (the cmd==7 reset path reads it after `localWord` is zeroed).

## Plausibility
Both changes make the source match the decompiled reference more faithfully: the localWord byte layout now reflects the actual GBA command-word format the hardware returns, and the SetOpenMenu branch polarity is a natural hand idiom. No header layout changes, no compiler-coaxing hacks.

## Blockers (documented walls, left untouched)
The remaining large functions (SendDataFile body, ThreadMain 12KB, SendPlayerStat, RestartThread, the 8x Send* family at 98%) are blocked on the cycle-2 walls: callee-saved register COUNT mismatches from `OSMillisecondsToTicks` division-magic/`__OSBusClock`-base hoisting we cannot suppress without a shared-header `volatile` change (20 affected units), merged `...rodata.0` section-base anchoring vs per-named-symbol relocs, and the `result`-in-r0-vs-r3 return idiom. Restructuring attempts (if/else-if dispatch, port/seq decaching, err-variable reuse) all regressed and were reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)