### PR TITLE
memory: raise fuzzy match to 95.5% (cycle 2)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1959,14 +1959,16 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
     while (true) {
         CAmemCache* bestEntry = 0;
 
+        int offset = 0;
         for (int i = 0; i < m_cacheCount; i++) {
-            CAmemCache& entry = cacheEntryAt(this, i);
+            CAmemCache& entry = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
             if (entry.m_inUse != 0 && entry.m_refCount == 0 && entry.m_dmaCopy != 0 &&
                 entry.m_cacheData != 0 && entry.m_size >= currentSize &&
                 static_cast<unsigned int>(entry.m_priority) < bestPriority) {
                 bestEntry = &entry;
                 bestPriority = static_cast<unsigned int>(entry.m_priority);
             }
+            offset += sizeof(CAmemCache);
         }
 
         if (bestEntry != 0) {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1685,10 +1685,11 @@ int CAmemCacheSet::GetData(short index, char* source, int line)
             data = 0;
         }
 
-        if (data != 0) {
-            return data;
+        if (data == 0) {
+            AmemFreeLowPrio(cacheEntryAt(this, index).m_size);
+            continue;
         }
-        AmemFreeLowPrio(cacheEntryAt(this, index).m_size);
+        return data;
     }
 }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1916,7 +1916,7 @@ void CAmemCacheSet::Release(short index)
     CAmemCache& entry = cacheEntryAt(this, index);
     entry.m_refCount -= 1;
 
-    if (entry.m_refCount == 0xFFFF) {
+    if (entry.m_refCount >= 0xFFFF) {
         if (static_cast<unsigned int>(System.m_execParam) >= 3) {
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt));
         }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2031,8 +2031,9 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
  */
 void CAmemCacheSet::CacheClear()
 {
+    int offset = 0;
     for (int i = 0; i < m_cacheCount; i++) {
-        CAmemCache& entry = cacheEntryAt(this, i);
+        CAmemCache& entry = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
 
         if ((entry.m_inUse != 0) && (entry.m_refCount == 0) && (entry.m_dmaCopy != 0)) {
             void* data = entry.m_cacheData;
@@ -2041,6 +2042,7 @@ void CAmemCacheSet::CacheClear()
                 entry.m_cacheData = 0;
             }
         }
+        offset += sizeof(CAmemCache);
     }
 }
 


### PR DESCRIPTION
Cycle-2 pass on main/memory (heap/memory manager). Baseline 95.379% -> 95.518% (+0.14).

## What worked
- **AmemFreeLowPrio**: walk the low-priority cache search with an explicit byte offset into m_cacheTable instead of an index subscript, matching the original's strength-reduced offset/pointer register pairing. Flagged lines 49 -> 39.
- **GetData**: invert the success check so the cache-miss retry path (AmemFreeLowPrio) falls through inline and the data-ready return branches away (R9 block-order). 97.84% (was 95.17%).
- **Release**: express the refcount-underflow guard as `>= 0xFFFF` so mwcc emits the original `cmplwi 0xFFFF / blt` skip-branch instead of `bne`.
- **CacheClear**: same byte-offset iteration as AmemFreeLowPrio. Flagged 17 -> 4; 95.5%.

## Blockers (walls, not re-ground)
- heapWalker, SetData/CheckSum: known callee-saved register-renumbering / bdnz walls (cycle-1 noted).
- Quit / alloc / CreateStage / drawHeapBar / AddRef: pervasive callee-saved register-window shifts (off-by-one). The byte-offset and pointer-reuse levers that fixed the simpler loops regress these because the live-value count differs; permute found no signedness fix for AddRef.
- Init: `operator new[]` array-ctor lowering (count-guard branch + arg ordering) — not source-steerable.
- Frame: `port & ~mask` index fold-resistance (target keeps `andc`, mwcc folds to `& 0`).
- GetHeapUnuse: target keeps a dead byte-span accumulator mwcc would eliminate.
- The shared inline helpers (freeStageBlock / stageDestroyAndPool) resist per-call-site strBase-relative string anchoring: relativizing regresses the callers that lack a live strBase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)