### PR TITLE
p_light: raise fuzzy match to 96.71% (cycle 2)

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1203,27 +1203,25 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
     GXLoadNrmMtxImm(nrm, 0);
 
     if ((bump != nullptr) && (bump->m_hasTexture != 0)) {
-        Mtx* bumpMat0 = &m_bumpTexMtx0;
-        Mtx* bumpMat1 = &m_bumpTexMtx1;
         Mtx texMtx;
 
         if (bump->m_useViewSpace == 1) {
             PSMTXTrans(texMtx, kLightHalf, kLightHalf, kLightZero);
-            PSMTXConcat(texMtx, nrm, *bumpMat0);
+            PSMTXConcat(texMtx, nrm, m_bumpTexMtx0);
             PSMTXScale(texMtx, kBumpTexMtxScale, kBumpTexMtxScale, kBumpTexMtxScale);
-            PSMTXConcat(*bumpMat0, texMtx, *bumpMat0);
+            PSMTXConcat(m_bumpTexMtx0, texMtx, m_bumpTexMtx0);
             Mtx posOnly;
             PSMTXCopy(out, posOnly);
             posOnly[0][3] = kLightZero;
             posOnly[1][3] = kLightZero;
             posOnly[2][3] = kLightZero;
-            PSMTXConcat(posOnly, texMtx, *bumpMat1);
+            PSMTXConcat(posOnly, texMtx, m_bumpTexMtx1);
         } else {
             PSMTXIdentity(nrm);
             PSMTXTrans(texMtx, kLightHalf, kLightHalf, kLightZero);
-            PSMTXConcat(texMtx, nrm, *bumpMat0);
+            PSMTXConcat(texMtx, nrm, m_bumpTexMtx0);
             PSMTXScale(texMtx, kBumpTexMtxScale, kBumpTexMtxScale, kBumpTexMtxScale);
-            PSMTXConcat(*bumpMat0, texMtx, *bumpMat0);
+            PSMTXConcat(m_bumpTexMtx0, texMtx, m_bumpTexMtx0);
 
             float camX = CameraPosX();
             float camZ = CameraPosZ();

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -977,7 +977,7 @@ void CLightPcs::CBumpLight::MakeLightMap()
 
         GXLoadLightObjImm(&lightObj, (GXLightID)1);
 
-        unsigned int y = 0;
+        int y = 0;
         do {
             unsigned int yBase = y;
             GXBegin((GXPrimitive)0x98, (GXVtxFmt)0, 0x42);

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1110,8 +1110,9 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
 {
     Mtx cam;
     PSMTXCopy(CameraMatrix(), cam);
-    Mtx nrm;
+    Mtx texMtx;
     Mtx out;
+    Mtx nrm;
 
     if (mode != 0) {
         Vec pos;
@@ -1203,8 +1204,6 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
     GXLoadNrmMtxImm(nrm, 0);
 
     if ((bump != nullptr) && (bump->m_hasTexture != 0)) {
-        Mtx texMtx;
-
         if (bump->m_useViewSpace == 1) {
             PSMTXTrans(texMtx, kLightHalf, kLightHalf, kLightZero);
             PSMTXConcat(texMtx, nrm, m_bumpTexMtx0);

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -927,9 +927,11 @@ void CLightPcs::CBumpLight::MakeLightMap()
         Vec diff;
         PSVECSubtract(&lightPos, &nrm, &diff);
 
-        float scale = kLightOne;
+        float scale;
         if (m_target == 1) {
             scale = kBumpLightTargetScale;
+        } else {
+            scale = kLightOne;
         }
         PSVECScale(&diff, &diff, scale);
         PSVECAdd(&nrm, &diff, &nrm);


### PR DESCRIPTION
Raises main/p_light fuzzy match from 95.86% to 96.71% (+0.85).

## Changes
- **SetBumpTexMatirx** (94.38% -> 98.87%): access m_bumpTexMtx0/m_bumpTexMtx1 members directly instead of caching them in local pointers (removes the cached-pointer register window), and reorder the Mtx locals (texMtx/out/nrm) to match the original stack-slot layout.
- **MakeLightMap (CBumpLight)** (91.11% -> 92.86%): rewrite the target-scale selection as an explicit if/else (matches the original's block order), and use a signed loop counter for the vertex-grid loop.

## Plausibility
All changes are ordinary source-level shapes (direct member access, explicit if/else, signed loop index), no compiler-coaxing tricks.

## Remaining blockers (walls)
- `__sinit` merged-section base-CSE (systematic across the p_* family; not source-steerable).
- `destroy`/`Add`/`AddBump`: whole-function register-window shifts (target keeps one extra callee-saved register live across loops/struct-copies; cannot be forced from source).
- `MakeLightMap (CBumpLight)` inner loop: anonymous literal pool entries vs named SDA constants emitted by the inlined shared-header `sqrtf` and the `(float)(unsigned)` conversion bias -- a shared-header bias-constant naming wall.
- `SetBumpTexMatirx` nrm-copy block: residual FPR off-by-one rotation (constant lands in f0 vs f9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)