### PR TITLE
materialman: raise fuzzy match to 93.5% (cycle 2)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2517,8 +2517,8 @@ void CMaterialMan::SetPosition(
         for (int i = 0; i < candidateCount; i++) {
             float candidateDist = candidateRead->distance;
             if (nearestDist > candidateDist) {
-                nearest = candidateRead;
                 nearestDist = candidateDist;
+                nearest = candidateRead;
             }
             candidateRead++;
         }

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2510,6 +2510,7 @@ void CMaterialMan::SetPosition(
             }
         }
 
+        float maxDist = kMaterialMaxDistance;
         ShadowCandidate* nearest = 0;
         float nearestDist = kMaterialNearestDistanceInit;
         ShadowCandidate* candidateRead = shadowCandidates;
@@ -2523,7 +2524,7 @@ void CMaterialMan::SetPosition(
         }
 
         if (nearest != 0) {
-            nearest->distance = kMaterialMaxDistance;
+            nearest->distance = maxDist;
             SetShadow(*nearest->shadow, viewMtx, nearest->index, 0xFFFFFFFF);
         }
     } else {

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2620,13 +2620,12 @@ int CMaterialMan::GetCharaShadow(
             continue;
         }
 
-        bool yFilterPass =
-            !((shadow->m_yFilterMode == 1) && (position->y < shadowPos.y)) &&
-            !((shadow->m_yFilterMode == 2) && (position->y > shadowPos.y));
-        if ((ignoreFrustumCheck != 0) ||
-            (yFilterPass &&
-             (reinterpret_cast<CBound*>(searchBoundStorage)
-                  ->CheckFrustum(shadowPos, scaledShadowMtx, kMaterialShadowBoundsRadius) != 0))) {
+        if (ignoreFrustumCheck == 0) {
+            goto frustumCheck;
+        }
+
+    writeCandidate:
+        {
             Vec delta;
             PSVECSubtract(&shadowPos, position, &delta);
             candidateWrite->distance = PSVECSquareMag(&delta);
@@ -2634,6 +2633,19 @@ int CMaterialMan::GetCharaShadow(
             candidateWrite->index = i;
             candidateWrite++;
             candidateCount++;
+        }
+        continue;
+
+    frustumCheck:
+        if ((shadow->m_yFilterMode == 1) && (position->y < shadowPos.y)) {
+            continue;
+        }
+        if ((shadow->m_yFilterMode == 2) && (position->y > shadowPos.y)) {
+            continue;
+        }
+        if (reinterpret_cast<CBound*>(searchBoundStorage)
+                ->CheckFrustum(shadowPos, scaledShadowMtx, kMaterialShadowBoundsRadius) != 0) {
+            goto writeCandidate;
         }
     }
 

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2511,11 +2511,12 @@ void CMaterialMan::SetPosition(
         }
 
         float maxDist = kMaterialMaxDistance;
+        float candidateDist;
         ShadowCandidate* nearest = 0;
         float nearestDist = kMaterialNearestDistanceInit;
         ShadowCandidate* candidateRead = shadowCandidates;
         for (int i = 0; i < candidateCount; i++) {
-            float candidateDist = candidateRead->distance;
+            candidateDist = candidateRead->distance;
             if (nearestDist > candidateDist) {
                 nearestDist = candidateDist;
                 nearest = candidateRead;

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2484,30 +2484,29 @@ void CMaterialMan::SetPosition(
             }
 
             Vec delta;
-            if (ignoreFrustumCheck != 0) {
-                PSVECSubtract(&shadowPos, position, &delta);
-                candidateWrite->distance = PSVECSquareMag(&delta);
-                candidateWrite->shadow = shadow;
-                candidateWrite->index = i;
-                candidateWrite++;
-                candidateCount++;
-            } else {
-                if ((shadow->m_yFilterMode == 1) && (position->y < shadowPos.y)) {
-                    continue;
-                }
-                if ((shadow->m_yFilterMode == 2) && (position->y > shadowPos.y)) {
-                    continue;
-                }
-                if (reinterpret_cast<CBound*>(searchBoundStorage)
-                        ->CheckFrustum(shadowPos, scaledShadowMtx, kMaterialShadowBoundsRadius) == 0) {
-                    continue;
-                }
-                PSVECSubtract(&shadowPos, position, &delta);
-                candidateWrite->distance = PSVECSquareMag(&delta);
-                candidateWrite->shadow = shadow;
-                candidateWrite->index = i;
-                candidateWrite++;
-                candidateCount++;
+            if (ignoreFrustumCheck == 0) {
+                goto frustumCheck;
+            }
+
+        writeCandidate:
+            PSVECSubtract(&shadowPos, position, &delta);
+            candidateWrite->distance = PSVECSquareMag(&delta);
+            candidateWrite->shadow = shadow;
+            candidateWrite->index = i;
+            candidateWrite++;
+            candidateCount++;
+            continue;
+
+        frustumCheck:
+            if ((shadow->m_yFilterMode == 1) && (position->y < shadowPos.y)) {
+                continue;
+            }
+            if ((shadow->m_yFilterMode == 2) && (position->y > shadowPos.y)) {
+                continue;
+            }
+            if (reinterpret_cast<CBound*>(searchBoundStorage)
+                    ->CheckFrustum(shadowPos, scaledShadowMtx, kMaterialShadowBoundsRadius) != 0) {
+                goto writeCandidate;
             }
         }
 


### PR DESCRIPTION
Cycle-2 float/control-flow pass on `main/materialman`. Baseline 93.30% -> 93.51%.

## Per-function gains
- **SetPosition** 88.16% -> 97.01% (the big win). Matched the target's loop block order (shared candidate-write block reached via early `goto` for the `ignoreFrustumCheck` fast-path, with the y-filter/frustum checks placed after and branching back — R9/R11), preloaded `kMaterialMaxDistance` into a callee-saved FPR before the nearest-distance loop (R13), and corrected the nearest-distance FPR allocation (maxDist=f0, candidateDist=f1, nearestDist=f2) by declaring `candidateDist` before the loop and assigning `nearestDist` before `nearest` inside it.
- **GetCharaShadow** 61.47% -> 61.70%. Matched the loop block order with the same goto-restructure (write block physically before the filter checks, reached by fall-through on `ignoreFrustumCheck != 0` and a backward branch from the frustum pass). Flagged lines dropped from 103 to 89.

## What worked
The dominant lever was control-flow block ordering: both functions share an `ignoreFrustumCheck ? write : (filter; write)` loop body whose original shape places a single shared candidate-write block before the filter checks. Rewriting with explicit early-exit `goto` matched the target's branch structure and eliminated the boolean-materialization (`cror`-style) sequences. Float-residency tweaks (FPR preload + declaration order) then cleaned up the nearest-distance reduction in SetPosition.

## Blocker
GetCharaShadow is now at the register-window wall (R8): after block order matches, essentially every remaining line is a uniform off-by-one callee-saved register shift, driven by the target keeping `outputCount*4` in a persistent byte-offset register (r18) that mwcc CSEs across two write sites. Float-residency tricks that helped SetPosition regress GetCharaShadow here because its register window is constrained differently (extra output-array params). SetPosition's residual ~3% is the same register-coloring swap (array-base vs candidate-write pointer). Neither yields to declaration reordering without resorting to pointer-offset hacks disallowed by AGENTS.md.

The result is plausible original source (early-exit guards + goto to a shared block is a common hand idiom); no layout hacks, no fake symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)