### PR TITLE
pad: raise fuzzy match to 96.71% (cycle 2)

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -310,10 +310,8 @@ void CPad::Frame()
 	do
 	{
 		puVar12 = reinterpret_cast<u16*>(iVar6 + 4);
-		iVar14 = 0;
-		iVar19 = 2;
 		puVar7 = puVar10;
-		do
+		for (iVar14 = 0; iVar14 < 2; iVar14++)
 		{
 			u8* p12 = reinterpret_cast<u8*>(puVar12);
 			if ((iVar14 != 0) || (*reinterpret_cast<s8*>(puVar13 + 5) != -3))
@@ -556,9 +554,7 @@ void CPad::Frame()
 			}
 			puVar12 = puVar12 + 1;
 			puVar7 = puVar7 + 1;
-			iVar14 = iVar14 + 1;
-			iVar19 = iVar19 + -1;
-		} while (iVar19 != 0);
+		}
 		uVar17 = uVar17 + 1;
 		puVar13 = puVar13 + 6;
 		puVar18 = puVar18 + 2;

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -487,69 +487,70 @@ void CPad::Frame()
 				*puVar7 = static_cast<u16>(*puVar7 | *puVar12);
 				if (iVar14 == 0)
 				{
-					*reinterpret_cast<u32*>(self + 0x18C) =
-						*reinterpret_cast<u32*>(self + 0x18C) | *reinterpret_cast<u32*>(p12 + 0x38);
-					*reinterpret_cast<u32*>(self + 0x190) =
-						*reinterpret_cast<u32*>(self + 0x190) | *reinterpret_cast<u32*>(p12 + 0x3C);
-					*reinterpret_cast<u16*>(self + 0x162) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x162) | *reinterpret_cast<u16*>(p12 + 0x0E));
-					*reinterpret_cast<u16*>(self + 0x15E) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x15E) | *reinterpret_cast<u16*>(p12 + 0x0A));
-					*reinterpret_cast<u16*>(self + 0x160) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x160) | *reinterpret_cast<u16*>(p12 + 0x0C));
-					*reinterpret_cast<s16*>(self + 0x164) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x164) | *reinterpret_cast<u16*>(p12 + 0x10));
-					*reinterpret_cast<u16*>(self + 0x186) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x186) | *reinterpret_cast<u16*>(p12 + 0x32));
-					*reinterpret_cast<u16*>(self + 0x184) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x184) | *reinterpret_cast<u16*>(p12 + 0x30));
-					*reinterpret_cast<u16*>(self + 0x188) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x188) | *reinterpret_cast<u16*>(p12 + 0x34));
+					u8* p10 = reinterpret_cast<u8*>(puVar10);
+					*reinterpret_cast<u32*>(p10 + 0x38) =
+						*reinterpret_cast<u32*>(p10 + 0x38) | *reinterpret_cast<u32*>(p12 + 0x38);
+					*reinterpret_cast<u32*>(p10 + 0x3C) =
+						*reinterpret_cast<u32*>(p10 + 0x3C) | *reinterpret_cast<u32*>(p12 + 0x3C);
+					*reinterpret_cast<u16*>(p10 + 0x0E) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0E) | *reinterpret_cast<u16*>(p12 + 0x0E));
+					*reinterpret_cast<u16*>(p10 + 0x0A) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0A) | *reinterpret_cast<u16*>(p12 + 0x0A));
+					*reinterpret_cast<u16*>(p10 + 0x0C) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0C) | *reinterpret_cast<u16*>(p12 + 0x0C));
+					*reinterpret_cast<s16*>(p10 + 0x10) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x10) | *reinterpret_cast<u16*>(p12 + 0x10));
+					*reinterpret_cast<u16*>(p10 + 0x32) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x32) | *reinterpret_cast<u16*>(p12 + 0x32));
+					*reinterpret_cast<u16*>(p10 + 0x30) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x30) | *reinterpret_cast<u16*>(p12 + 0x30));
+					*reinterpret_cast<u16*>(p10 + 0x34) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x34) | *reinterpret_cast<u16*>(p12 + 0x34));
 					cVar9 = *reinterpret_cast<s8*>(p12 + 0x14);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x168)) >> 0x1F;
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x14)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x168))) - uVar15) <
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x14))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
-						*reinterpret_cast<s8*>(self + 0x168) = cVar9;
-						*reinterpret_cast<float*>(self + 0x174) = *reinterpret_cast<float*>(p12 + 0x20);
+						*reinterpret_cast<s8*>(p10 + 0x14) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x20) = *reinterpret_cast<float*>(p12 + 0x20);
 					}
 					cVar9 = *reinterpret_cast<s8*>(p12 + 0x15);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x169)) >> 0x1F;
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x15)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x169))) - uVar15) <
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x15))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
-						*reinterpret_cast<s8*>(self + 0x169) = cVar9;
-						*reinterpret_cast<float*>(self + 0x178) = *reinterpret_cast<float*>(p12 + 0x24);
+						*reinterpret_cast<s8*>(p10 + 0x15) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x24) = *reinterpret_cast<float*>(p12 + 0x24);
 					}
 					cVar9 = *reinterpret_cast<s8*>(p12 + 0x16);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x16A)) >> 0x1F;
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x16)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x16A))) - uVar15) <
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x16))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
-						*reinterpret_cast<s8*>(self + 0x16A) = cVar9;
-						*reinterpret_cast<float*>(self + 0x17C) = *reinterpret_cast<float*>(p12 + 0x28);
+						*reinterpret_cast<s8*>(p10 + 0x16) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x28) = *reinterpret_cast<float*>(p12 + 0x28);
 					}
 					cVar9 = *reinterpret_cast<s8*>(p12 + 0x17);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x16B)) >> 0x1F;
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x17)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x16B))) - uVar15) <
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x17))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
-						*reinterpret_cast<s8*>(self + 0x16B) = cVar9;
-						*reinterpret_cast<float*>(self + 0x180) = *reinterpret_cast<float*>(p12 + 0x2C);
+						*reinterpret_cast<s8*>(p10 + 0x17) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x2C) = *reinterpret_cast<float*>(p12 + 0x2C);
 					}
-					if (*reinterpret_cast<u8*>(self + 0x166) < *reinterpret_cast<u8*>(p12 + 0x12))
+					if (*reinterpret_cast<u8*>(p10 + 0x12) < *reinterpret_cast<u8*>(p12 + 0x12))
 					{
-						*reinterpret_cast<u8*>(self + 0x166) = *reinterpret_cast<u8*>(p12 + 0x12);
-						*reinterpret_cast<float*>(self + 0x16C) = *reinterpret_cast<float*>(p12 + 0x18);
+						*reinterpret_cast<u8*>(p10 + 0x12) = *reinterpret_cast<u8*>(p12 + 0x12);
+						*reinterpret_cast<float*>(p10 + 0x18) = *reinterpret_cast<float*>(p12 + 0x18);
 					}
-					if (*reinterpret_cast<u8*>(self + 0x167) < *reinterpret_cast<u8*>(p12 + 0x13))
+					if (*reinterpret_cast<u8*>(p10 + 0x13) < *reinterpret_cast<u8*>(p12 + 0x13))
 					{
-						*reinterpret_cast<u8*>(self + 0x167) = *reinterpret_cast<u8*>(p12 + 0x13);
-						*reinterpret_cast<float*>(self + 0x170) = *reinterpret_cast<float*>(p12 + 0x1C);
+						*reinterpret_cast<u8*>(p10 + 0x13) = *reinterpret_cast<u8*>(p12 + 0x13);
+						*reinterpret_cast<float*>(p10 + 0x1C) = *reinterpret_cast<float*>(p12 + 0x1C);
 					}
 				}
 			}

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -315,12 +315,12 @@ void CPad::Frame()
 		puVar7 = puVar10;
 		do
 		{
+			u8* p12 = reinterpret_cast<u8*>(puVar12);
 			if ((iVar14 != 0) || (*reinterpret_cast<s8*>(puVar13 + 5) != -3))
 			{
-				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(iVar6 + 0x34) | *puVar12);
+				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x30) | *puVar12);
 				if (iVar14 == 0)
 				{
-					u8* p12 = reinterpret_cast<u8*>(puVar12);
 					uVar8 = *puVar18;
 					*reinterpret_cast<u16*>(p12 + 0x08) = *reinterpret_cast<u16*>(p12 + 0x0A);
 					uVar16 = (__cntlzw(1 - (uVar8 & 0x3FFF)) >> 5) & 0xFF;
@@ -329,7 +329,7 @@ void CPad::Frame()
 					*reinterpret_cast<u32*>(p12 + 0x44) = 0;
 					*reinterpret_cast<u32*>(p12 + 0x38) = 0;
 					*reinterpret_cast<u32*>(p12 + 0x3C) = 0;
-					if ((*reinterpret_cast<s8*>(iVar6 + 0x44) == 0) || reinterpret_cast<CPad::Gba*>(puVar18)->noController)
+					if ((*reinterpret_cast<s8*>(p12 + 0x40) == 0) || reinterpret_cast<CPad::Gba*>(puVar18)->noController)
 					{
 						if (reinterpret_cast<CPad::Gba*>(puVar18)->noController)
 						{
@@ -349,138 +349,138 @@ void CPad::Frame()
 						}
 						if ((DbgMenuPcs.GetDbgFlagsRaw() & 0x100) != 0)
 						{
-							uVar16 = static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x18)) >> 0x1F;
-							if ((static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<u8*>(iVar6 + 0x18))) - uVar16) >= m_stickDigitalThreshold) ||
-								((uVar16 = static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x19)) >> 0x1F),
-								 (static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x19))) - uVar16) >= m_stickDigitalThreshold)))
+							uVar16 = static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)) >> 0x1F;
+							if ((static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<u8*>(p12 + 0x14))) - uVar16) >= m_stickDigitalThreshold) ||
+								((uVar16 = static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)) >> 0x1F),
+								 (static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15))) - uVar16) >= m_stickDigitalThreshold)))
 							{
 								*puVar12 = static_cast<u16>(*puVar12 & 0xFFF0);
-								*reinterpret_cast<u32*>(iVar6 + 0x40) = 1;
-								if (m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x18)))
+								*reinterpret_cast<u32*>(p12 + 0x3C) = 1;
+								if (m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)))
 								{
 									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_RIGHT);
 								}
-								if (-static_cast<int>(m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x18)))
+								if (-static_cast<int>(m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)))
 								{
 									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_LEFT);
 								}
-								if (m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x19)))
+								if (m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)))
 								{
 									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_UP);
 								}
-								if (-static_cast<int>(m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(iVar6 + 0x19)))
+								if (-static_cast<int>(m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)))
 								{
 									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_DOWN);
 								}
 							}
 						}
-						*reinterpret_cast<u32*>(iVar6 + 0x48) = *reinterpret_cast<u32*>(iVar6 + 0x48) | 1;
-						*reinterpret_cast<u8*>(iVar6 + 0x18) = *reinterpret_cast<u8*>(puVar13 + 1);
-						*reinterpret_cast<u16*>(iVar6 + 0x0E) = 0;
-						if (*reinterpret_cast<s8*>(iVar6 + 0x18) < 0)
+						*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
+						*reinterpret_cast<u8*>(p12 + 0x14) = *reinterpret_cast<u8*>(puVar13 + 1);
+						*reinterpret_cast<u16*>(p12 + 0x0A) = 0;
+						if (*reinterpret_cast<s8*>(p12 + 0x14) < 0)
 						{
-							*reinterpret_cast<u16*>(iVar6 + 0x0E) = *reinterpret_cast<u16*>(iVar6 + 0x0E) | 1;
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 1;
 						}
-						if (0 < *reinterpret_cast<s8*>(iVar6 + 0x18))
+						if (0 < *reinterpret_cast<s8*>(p12 + 0x14))
 						{
-							*reinterpret_cast<u16*>(iVar6 + 0x0E) = *reinterpret_cast<u16*>(iVar6 + 0x0E) | 2;
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 2;
 						}
-						*reinterpret_cast<u8*>(iVar6 + 0x19) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 3);
-						if (*reinterpret_cast<s8*>(iVar6 + 0x19) < 0)
+						*reinterpret_cast<u8*>(p12 + 0x15) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 3);
+						if (*reinterpret_cast<s8*>(p12 + 0x15) < 0)
 						{
-							*reinterpret_cast<u16*>(iVar6 + 0x0E) = *reinterpret_cast<u16*>(iVar6 + 0x0E) | 4;
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 4;
 						}
-						if (0 < *reinterpret_cast<s8*>(iVar6 + 0x19))
+						if (0 < *reinterpret_cast<s8*>(p12 + 0x15))
 						{
-							*reinterpret_cast<u16*>(iVar6 + 0x0E) = *reinterpret_cast<u16*>(iVar6 + 0x0E) | 8;
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 8;
 						}
 						fVar2 = kPadAnalogScale;
 						fVar3 = kPadTriggerMax;
-						*reinterpret_cast<u8*>(iVar6 + 0x1A) = *reinterpret_cast<u8*>(puVar13 + 2);
-						*reinterpret_cast<u8*>(iVar6 + 0x1B) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 5);
-						*reinterpret_cast<u8*>(iVar6 + 0x16) = *reinterpret_cast<u8*>(puVar13 + 3);
-						*reinterpret_cast<u8*>(iVar6 + 0x17) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7);
-						*reinterpret_cast<float*>(iVar6 + 0x24) =
-							static_cast<float>(*reinterpret_cast<s8*>(iVar6 + 0x18)) * fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x28) =
-							static_cast<float>(*reinterpret_cast<s8*>(iVar6 + 0x19)) * fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x2C) =
-							static_cast<float>(*reinterpret_cast<s8*>(iVar6 + 0x1A)) * fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x30) =
-							static_cast<float>(*reinterpret_cast<s8*>(iVar6 + 0x1B)) * fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x1C) =
-							static_cast<float>(*reinterpret_cast<u8*>(iVar6 + 0x16)) / fVar3;
-						*reinterpret_cast<float*>(iVar6 + 0x20) =
-							static_cast<float>(*reinterpret_cast<u8*>(iVar6 + 0x17)) / fVar3;
+						*reinterpret_cast<u8*>(p12 + 0x16) = *reinterpret_cast<u8*>(puVar13 + 2);
+						*reinterpret_cast<u8*>(p12 + 0x17) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 5);
+						*reinterpret_cast<u8*>(p12 + 0x12) = *reinterpret_cast<u8*>(puVar13 + 3);
+						*reinterpret_cast<u8*>(p12 + 0x13) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7);
+						*reinterpret_cast<float*>(p12 + 0x20) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x14)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x24) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x15)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x28) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x16)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x2C) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x17)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x18) =
+							static_cast<float>(*reinterpret_cast<u8*>(p12 + 0x12)) / fVar3;
+						*reinterpret_cast<float*>(p12 + 0x1C) =
+							static_cast<float>(*reinterpret_cast<u8*>(p12 + 0x13)) / fVar3;
 					}
 					else
 					{
 						*puVar12 = 0;
 						fVar2 = kPadAnalogZero;
-						*reinterpret_cast<u8*>(iVar6 + 0x18) = 0;
-						*reinterpret_cast<u8*>(iVar6 + 0x19) = 0;
-						*reinterpret_cast<u8*>(iVar6 + 0x1A) = 0;
-						*reinterpret_cast<u8*>(iVar6 + 0x1B) = 0;
-						*reinterpret_cast<u8*>(iVar6 + 0x16) = 0;
-						*reinterpret_cast<u8*>(iVar6 + 0x17) = 0;
-						*reinterpret_cast<float*>(iVar6 + 0x24) = fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x28) = fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x2C) = fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x30) = fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x1C) = fVar2;
-						*reinterpret_cast<float*>(iVar6 + 0x20) = fVar2;
+						*reinterpret_cast<u8*>(p12 + 0x14) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x15) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x16) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x17) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x12) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x13) = 0;
+						*reinterpret_cast<float*>(p12 + 0x20) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x24) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x28) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x2C) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x18) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x1C) = fVar2;
 					}
 				}
 				else if (reinterpret_cast<CPad::Gba*>(puVar18)->connected)
 				{
 					uVar8 = puVar18[1];
-					*reinterpret_cast<u32*>(iVar6 + 0x48) = *reinterpret_cast<u32*>(iVar6 + 0x48) | 1;
+					*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
 					*puVar12 = uVar8;
 				}
 				puVar12[2] = static_cast<u16>(*puVar12 & (puVar12[0x26] ^ *puVar12));
 				if (iVar14 == 0)
 				{
-					*reinterpret_cast<u16*>(iVar6 + 0x12) =
+					*reinterpret_cast<u16*>(p12 + 0x0E) =
 						static_cast<u16>(puVar12[0x26] & (puVar12[0x26] ^ *puVar12));
-					*reinterpret_cast<u16*>(iVar6 + 0x10) =
-						static_cast<u16>(*reinterpret_cast<u16*>(iVar6 + 0x0E) &
-						                 (*reinterpret_cast<u16*>(iVar6 + 0x0C) ^ *reinterpret_cast<u16*>(iVar6 + 0x0E)));
-					*reinterpret_cast<u16*>(iVar6 + 0x14) = static_cast<u16>(puVar12[0x26] & *puVar12 & 0x1F7F);
-					if (*reinterpret_cast<u16*>(iVar6 + 0x14) != 0)
+					*reinterpret_cast<u16*>(p12 + 0x0C) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x0A) &
+						                 (*reinterpret_cast<u16*>(p12 + 0x08) ^ *reinterpret_cast<u16*>(p12 + 0x0A)));
+					*reinterpret_cast<u16*>(p12 + 0x10) = static_cast<u16>(puVar12[0x26] & *puVar12 & 0x1F7F);
+					if (*reinterpret_cast<u16*>(p12 + 0x10) != 0)
 					{
-						*reinterpret_cast<int*>(iVar6 + 0x4C) = *reinterpret_cast<int*>(iVar6 + 0x4C) + 1;
-						if (*reinterpret_cast<u32*>(iVar6 + 0x4C) < 0x10)
+						*reinterpret_cast<int*>(p12 + 0x48) = *reinterpret_cast<int*>(p12 + 0x48) + 1;
+						if (*reinterpret_cast<u32*>(p12 + 0x48) < 0x10)
 						{
-							*reinterpret_cast<u16*>(iVar6 + 0x14) = 0;
+							*reinterpret_cast<u16*>(p12 + 0x10) = 0;
 						}
-						else if ((*reinterpret_cast<u32*>(iVar6 + 0x4C) & 1) != 0)
+						else if ((*reinterpret_cast<u32*>(p12 + 0x48) & 1) != 0)
 						{
-							*reinterpret_cast<u16*>(iVar6 + 0x14) = 0;
+							*reinterpret_cast<u16*>(p12 + 0x10) = 0;
 						}
 					}
 					else
 					{
-						*reinterpret_cast<u32*>(iVar6 + 0x4C) = 0;
+						*reinterpret_cast<u32*>(p12 + 0x48) = 0;
 					}
-					*reinterpret_cast<u16*>(iVar6 + 0x14) =
-						static_cast<u16>(*reinterpret_cast<u16*>(iVar6 + 0x14) | puVar12[2]);
-					if (*reinterpret_cast<int*>(iVar6 + 0x3C) != 0)
+					*reinterpret_cast<u16*>(p12 + 0x10) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x10) | puVar12[2]);
+					if (*reinterpret_cast<int*>(p12 + 0x38) != 0)
 					{
-						*reinterpret_cast<u16*>(iVar6 + 0x34) = *puVar12;
-						*reinterpret_cast<u16*>(iVar6 + 0x36) = puVar12[2];
-						*reinterpret_cast<u16*>(iVar6 + 0x38) = *reinterpret_cast<u16*>(iVar6 + 0x14);
-						*reinterpret_cast<u16*>(iVar6 + 0x0E) = 0;
-						*reinterpret_cast<u16*>(iVar6 + 0x10) = 0;
-						*reinterpret_cast<u16*>(iVar6 + 0x14) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x30) = *puVar12;
+						*reinterpret_cast<u16*>(p12 + 0x32) = puVar12[2];
+						*reinterpret_cast<u16*>(p12 + 0x34) = *reinterpret_cast<u16*>(p12 + 0x10);
+						*reinterpret_cast<u16*>(p12 + 0x0A) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x0C) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x10) = 0;
 						puVar12[2] = 0;
-						*reinterpret_cast<u16*>(iVar6 + 0x12) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x0E) = 0;
 						*puVar12 = 0;
 					}
 					else
 					{
-						*reinterpret_cast<u16*>(iVar6 + 0x38) = 0;
-						*reinterpret_cast<u16*>(iVar6 + 0x36) = 0;
-						*reinterpret_cast<u16*>(iVar6 + 0x34) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x34) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x32) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x30) = 0;
 					}
 				}
 				puVar7[2] = static_cast<u16>(puVar7[2] | puVar12[2]);
@@ -488,68 +488,68 @@ void CPad::Frame()
 				if (iVar14 == 0)
 				{
 					*reinterpret_cast<u32*>(self + 0x18C) =
-						*reinterpret_cast<u32*>(self + 0x18C) | *reinterpret_cast<u32*>(iVar6 + 0x3C);
+						*reinterpret_cast<u32*>(self + 0x18C) | *reinterpret_cast<u32*>(p12 + 0x38);
 					*reinterpret_cast<u32*>(self + 0x190) =
-						*reinterpret_cast<u32*>(self + 0x190) | *reinterpret_cast<u32*>(iVar6 + 0x40);
+						*reinterpret_cast<u32*>(self + 0x190) | *reinterpret_cast<u32*>(p12 + 0x3C);
 					*reinterpret_cast<u16*>(self + 0x162) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x162) | *reinterpret_cast<u16*>(iVar6 + 0x12));
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x162) | *reinterpret_cast<u16*>(p12 + 0x0E));
 					*reinterpret_cast<u16*>(self + 0x15E) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x15E) | *reinterpret_cast<u16*>(iVar6 + 0x0E));
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x15E) | *reinterpret_cast<u16*>(p12 + 0x0A));
 					*reinterpret_cast<u16*>(self + 0x160) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x160) | *reinterpret_cast<u16*>(iVar6 + 0x10));
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x160) | *reinterpret_cast<u16*>(p12 + 0x0C));
 					*reinterpret_cast<s16*>(self + 0x164) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x164) | *reinterpret_cast<u16*>(iVar6 + 0x14));
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x164) | *reinterpret_cast<u16*>(p12 + 0x10));
 					*reinterpret_cast<u16*>(self + 0x186) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x186) | *reinterpret_cast<u16*>(iVar6 + 0x36));
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x186) | *reinterpret_cast<u16*>(p12 + 0x32));
 					*reinterpret_cast<u16*>(self + 0x184) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x184) | *reinterpret_cast<u16*>(iVar6 + 0x34));
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x184) | *reinterpret_cast<u16*>(p12 + 0x30));
 					*reinterpret_cast<u16*>(self + 0x188) =
-						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x188) | *reinterpret_cast<u16*>(iVar6 + 0x38));
-					cVar9 = *reinterpret_cast<s8*>(iVar6 + 0x18);
+						static_cast<u16>(*reinterpret_cast<u16*>(self + 0x188) | *reinterpret_cast<u16*>(p12 + 0x34));
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x14);
 					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x168)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
 					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x168))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
 						*reinterpret_cast<s8*>(self + 0x168) = cVar9;
-						*reinterpret_cast<float*>(self + 0x174) = *reinterpret_cast<float*>(iVar6 + 0x24);
+						*reinterpret_cast<float*>(self + 0x174) = *reinterpret_cast<float*>(p12 + 0x20);
 					}
-					cVar9 = *reinterpret_cast<s8*>(iVar6 + 0x19);
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x15);
 					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x169)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
 					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x169))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
 						*reinterpret_cast<s8*>(self + 0x169) = cVar9;
-						*reinterpret_cast<float*>(self + 0x178) = *reinterpret_cast<float*>(iVar6 + 0x28);
+						*reinterpret_cast<float*>(self + 0x178) = *reinterpret_cast<float*>(p12 + 0x24);
 					}
-					cVar9 = *reinterpret_cast<s8*>(iVar6 + 0x1A);
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x16);
 					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x16A)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
 					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x16A))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
 						*reinterpret_cast<s8*>(self + 0x16A) = cVar9;
-						*reinterpret_cast<float*>(self + 0x17C) = *reinterpret_cast<float*>(iVar6 + 0x2C);
+						*reinterpret_cast<float*>(self + 0x17C) = *reinterpret_cast<float*>(p12 + 0x28);
 					}
-					cVar9 = *reinterpret_cast<s8*>(iVar6 + 0x1B);
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x17);
 					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(self + 0x16B)) >> 0x1F;
 					uVar16 = static_cast<int>(cVar9) >> 0x1F;
 					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(self + 0x16B))) - uVar15) <
 					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
 					{
 						*reinterpret_cast<s8*>(self + 0x16B) = cVar9;
-						*reinterpret_cast<float*>(self + 0x180) = *reinterpret_cast<float*>(iVar6 + 0x30);
+						*reinterpret_cast<float*>(self + 0x180) = *reinterpret_cast<float*>(p12 + 0x2C);
 					}
-					if (*reinterpret_cast<u8*>(self + 0x166) < *reinterpret_cast<u8*>(iVar6 + 0x16))
+					if (*reinterpret_cast<u8*>(self + 0x166) < *reinterpret_cast<u8*>(p12 + 0x12))
 					{
-						*reinterpret_cast<u8*>(self + 0x166) = *reinterpret_cast<u8*>(iVar6 + 0x16);
-						*reinterpret_cast<float*>(self + 0x16C) = *reinterpret_cast<float*>(iVar6 + 0x1C);
+						*reinterpret_cast<u8*>(self + 0x166) = *reinterpret_cast<u8*>(p12 + 0x12);
+						*reinterpret_cast<float*>(self + 0x16C) = *reinterpret_cast<float*>(p12 + 0x18);
 					}
-					if (*reinterpret_cast<u8*>(self + 0x167) < *reinterpret_cast<u8*>(iVar6 + 0x17))
+					if (*reinterpret_cast<u8*>(self + 0x167) < *reinterpret_cast<u8*>(p12 + 0x13))
 					{
-						*reinterpret_cast<u8*>(self + 0x167) = *reinterpret_cast<u8*>(iVar6 + 0x17);
-						*reinterpret_cast<float*>(self + 0x170) = *reinterpret_cast<float*>(iVar6 + 0x20);
+						*reinterpret_cast<u8*>(self + 0x167) = *reinterpret_cast<u8*>(p12 + 0x13);
+						*reinterpret_cast<float*>(self + 0x170) = *reinterpret_cast<float*>(p12 + 0x1C);
 					}
 				}
 			}

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -320,14 +320,15 @@ void CPad::Frame()
 				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(iVar6 + 0x34) | *puVar12);
 				if (iVar14 == 0)
 				{
+					u8* p12 = reinterpret_cast<u8*>(puVar12);
 					uVar8 = *puVar18;
-					*reinterpret_cast<u16*>(iVar6 + 0x0C) = *reinterpret_cast<u16*>(iVar6 + 0x0E);
+					*reinterpret_cast<u16*>(p12 + 0x08) = *reinterpret_cast<u16*>(p12 + 0x0A);
 					uVar16 = (__cntlzw(1 - (uVar8 & 0x3FFF)) >> 5) & 0xFF;
-					*reinterpret_cast<s8*>(iVar6 + 0x44) = *reinterpret_cast<s8*>(puVar13 + 5);
-					*reinterpret_cast<u32*>(iVar6 + 0x54) = uVar16;
-					*reinterpret_cast<u32*>(iVar6 + 0x48) = 0;
-					*reinterpret_cast<u32*>(iVar6 + 0x3C) = 0;
-					*reinterpret_cast<u32*>(iVar6 + 0x40) = 0;
+					*reinterpret_cast<s8*>(p12 + 0x40) = *reinterpret_cast<s8*>(puVar13 + 5);
+					*reinterpret_cast<u32*>(p12 + 0x50) = uVar16;
+					*reinterpret_cast<u32*>(p12 + 0x44) = 0;
+					*reinterpret_cast<u32*>(p12 + 0x38) = 0;
+					*reinterpret_cast<u32*>(p12 + 0x3C) = 0;
 					if ((*reinterpret_cast<s8*>(iVar6 + 0x44) == 0) || reinterpret_cast<CPad::Gba*>(puVar18)->noController)
 					{
 						if (reinterpret_cast<CPad::Gba*>(puVar18)->noController)

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -310,10 +310,10 @@ void CPad::Frame()
 	do
 	{
 		puVar12 = reinterpret_cast<u16*>(iVar6 + 4);
+		u8* p12 = reinterpret_cast<u8*>(iVar6 + 4);
 		puVar7 = puVar10;
 		for (iVar14 = 0; iVar14 < 2; iVar14++)
 		{
-			u8* p12 = reinterpret_cast<u8*>(puVar12);
 			if ((iVar14 != 0) || (*reinterpret_cast<s8*>(puVar13 + 5) != -3))
 			{
 				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x30) | *puVar12);

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -229,32 +229,42 @@ void CPad::Frame()
 	{
 		cVar9 = *reinterpret_cast<s8*>(puVar7 + 5);
 		uVar15 = 0x80000000 >> uVar17;
-		if (cVar9 != -1)
+		if (cVar9 == -1)
 		{
-			if (cVar9 >= -1)
-			{
-				if (cVar9 < 1)
-				{
-					_1a8_4_ = _1a8_4_ | uVar15;
-				}
-			}
-			else if (cVar9 == -3)
-			{
-				_1a8_4_ = _1a8_4_ | uVar15;
-			}
-			else if (cVar9 >= -3)
-			{
-				_1a8_4_ = _1a8_4_ & ~uVar15;
-			}
+			goto gba_ready;
 		}
-		else
+		if (cVar9 >= -1)
 		{
-			if (static_cast<u8>(Joybus.GBAReady(uVar17)) == 0)
-			{
-				uVar16 = uVar16 | uVar15;
-			}
-			_1a8_4_ = _1a8_4_ & ~uVar15;
+			goto flag_set_low;
 		}
+		if (cVar9 == -3)
+		{
+			goto flag_set_neg3;
+		}
+		if (cVar9 >= -3)
+		{
+			goto flag_clear;
+		}
+		goto flag_done;
+	flag_set_low:
+		if (cVar9 < 1)
+		{
+			_1a8_4_ = _1a8_4_ | uVar15;
+		}
+		goto flag_done;
+	flag_set_neg3:
+		_1a8_4_ = _1a8_4_ | uVar15;
+		goto flag_done;
+	gba_ready:
+		if (static_cast<u8>(Joybus.GBAReady(uVar17)) == 0)
+		{
+			uVar16 = uVar16 | uVar15;
+		}
+		_1a8_4_ = _1a8_4_ & ~uVar15;
+		goto flag_done;
+	flag_clear:
+		_1a8_4_ = _1a8_4_ & ~uVar15;
+	flag_done:
 		uVar17 = uVar17 + 1;
 		puVar7 = puVar7 + 6;
 	} while (uVar17 < 4);


### PR DESCRIPTION
Raises main/pad fuzzy match from 94.88% to 96.71% (Frame 93.86% -> 96.04%, data 88.83% -> 93.62%).

## What changed (all in CPad::Frame, src/pad.cpp)
- **goto branch-ladder for the cVar9 flag dispatch** (+1.06%). The target emits the four dispatch tests (==-1, >=-1, ==-3, >=-3) as a pure consecutive branch ladder, then the arm bodies in physical order A, B, else(GBAReady), C — with the ==-1 else-body sitting between B and C. A nested if/else cannot reproduce this interleaving. Rewrote as labeled blocks reached by explicit goto, with the inner `< 1` test moved into the A-body label so the head stays a flat ladder.
- **puVar12-relative member access in the inner per-port loop** (+0.16%). The original accesses the per-port scratch fields through `puVar12` (= iVar6+4), not through iVar6; every `iVar6 + 0xNN` became `p12 + (0xNN-4)`, matching the target's offsets exactly.
- **puVar10-relative merge-output fields** (+0.04%). The `self + 0x15E..0x190` merge accumulator fields are accessed relative to `puVar10` (= self+0x154) in the target.
- **for-loop on iVar14 triggers mtctr/bdnz** (+0.24%). The count-2 inner loop is a CTR loop in the target; a `for (iVar14=0; iVar14<2; iVar14++)` makes mwcc emit `mtctr`/`bdnz` instead of `subic.`/`bne`, while keeping iVar14 as the live index.
- **fixed p12 base separate from advancing puVar12** (+0.37%, plus data 88.8% -> 93.6%). The target keeps two pointers: a fixed `iVar6+4` base for the iteration-0 field block and the advancing `puVar12` for per-iteration accesses. Declaring `p12` once as a fixed base (not recomputed from the advancing pointer each iteration) matches this split.

## Blocker
The remaining ~400 flagged lines are a single coherent global register-coloring permutation (e.g. target r28 / ours r25 for the merged pointer, target r8 / ours r9 for the per-port base, shifted loop-counter colors). Opcodes, offsets, control-flow shape, and the CTR loop all match now; only the allocator's register choices differ. Source-level attempts to steer this (splitting the shared loop counter into distinct per-loop variables) regressed, confirming the original reused one counter variable. The one residual structural INSERT is the `connected` 1-bit bitfield store (`cntlzw`+`rlwimi` raw-insert vs our `extrwi`-normalize), a mwcc bitfield-lowering detail not steerable without a shared-header layout change. __sinit is the data.0 wall and was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)