### PR TITLE
cmake: raise fuzzy match to 86.9% (cycle 3)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1288,8 +1288,11 @@ void CMenuPcs::CmakeResultDraw1()
             break;
         }
 
-        valueFont->SetPosX(8.0f + labelWidths[i]);
-        valueFont->SetPosY(0x70 + i * 0x28 - 4.0f);
+        float x = 8.0f + labelWidths[i];
+        float y = 0x70 + i * 0x28 - 4.0f;
+        float valueWidth = static_cast<float>(valueFont->GetWidth(txt));
+        valueFont->SetPosX(x);
+        valueFont->SetPosY(y);
         valueFont->Draw(txt);
 
         if (i == 2) {
@@ -1300,10 +1303,8 @@ void CMenuPcs::CmakeResultDraw1()
 
             const char* hairTxt = GetHairStr(hairIndex + s_CmakeInfo.m_hair);
 
-            valueFont->SetPosX(
-                16.0f +
-                (8.0f + labelWidths[i] + static_cast<float>(valueFont->GetWidth(txt))));
-            valueFont->SetPosY(0x70 + i * 0x28 - 4.0f);
+            valueFont->SetPosX(16.0f + x + valueWidth);
+            valueFont->SetPosY(y);
             valueFont->Draw(hairTxt);
         }
     }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1394,8 +1394,6 @@ void CMenuPcs::CmakeResultOpen1()
  */
 void CMenuPcs::CmakeResultDraw()
 {
-    short mode = CmakeState(this)->m_mode;
-    short resultDir = CmakeState(this)->m_resultDir;
     float alpha = CalcCmakeFadeAlpha(this);
 
     DrawWMFrame0(1, 1.0f);
@@ -1467,7 +1465,7 @@ void CMenuPcs::CmakeResultDraw()
     }
 
     float panelAlphaValue = alpha;
-    if ((mode == 2) && (resultDir < 0)) {
+    if ((CmakeState(this)->m_mode == 2) && (CmakeState(this)->m_resultDir < 0)) {
         panelAlphaValue = 1.0f;
     }
     int panelAlpha = static_cast<int>(255.0f * panelAlphaValue);
@@ -1485,13 +1483,13 @@ void CMenuPcs::CmakeResultDraw()
         0, 192.0f, 56.0f, 416.0f, 264.0f,
         0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
-    if ((mode == 2) && (resultDir > 0)) {
+    if ((CmakeState(this)->m_mode == 2) && (CmakeState(this)->m_resultDir > 0)) {
         DrawCmakeTitle(6, 1.0f, alpha);
     } else {
         DrawCmakeTitle(6, alpha, 1.0f);
     }
 
-    if ((mode == 2) && (resultDir < 0)) {
+    if ((CmakeState(this)->m_mode == 2) && (CmakeState(this)->m_resultDir < 0)) {
         int tribe = static_cast<int>(s_CmakeInfo.m_tribe);
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
@@ -1537,7 +1535,7 @@ void CMenuPcs::CmakeResultDraw()
     DrawCmakeYesNo(yesNoSel, alpha);
 
     float textAlpha = alpha;
-    if ((mode == 2) && (resultDir < 0)) {
+    if ((CmakeState(this)->m_mode == 2) && (CmakeState(this)->m_resultDir < 0)) {
         textAlpha = 1.0f;
     }
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2219,7 +2219,14 @@ unsigned short CMenuPcs::CmakeTribeCtrl()
                     duplicateSlot = slot;
                 }
 
-                if (slot > 7) {
+                if (slot < 8) {
+                    Sound.PlaySe(4, 0x40, 0x7F, 0);
+                    short winX = 0;
+                    short winY = 0;
+                    GetWinSize(0x15, &winX, &winY, 0);
+                    SetMcWinInfo(static_cast<int>(winX), static_cast<int>(winY));
+                    CmakeMcState(this) = 0;
+                } else {
                     s_CmakeInfo.m_tribe = static_cast<signed char>(CmakeState(this)->m_select);
                     s_CmakeInfo.m_hair = static_cast<signed char>(CmakeState(this)->m_row);
                     ChgModel(static_cast<int>(CmakeSlot(this)),
@@ -2229,13 +2236,6 @@ unsigned short CMenuPcs::CmakeTribeCtrl()
                     CmakeState(this)->m_resultDir = 1;
                     return 1;
                 }
-
-                Sound.PlaySe(4, 0x40, 0x7F, 0);
-                short winX = 0;
-                short winY = 0;
-                GetWinSize(0x15, &winX, &winY, 0);
-                SetMcWinInfo(static_cast<int>(winX), static_cast<int>(winY));
-                CmakeMcState(this) = 0;
             } else if ((down & 0x200) != 0) {
                 Sound.PlaySe(3, 0x40, 0x7F, 0);
                 if (fieldSelect == 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -789,7 +789,8 @@ void CMenuPcs::CmakeVillageDraw()
     col.a = static_cast<unsigned char>(static_cast<int>(a255));
     GXSetChanMatColor(GX_COLOR0A0, col);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
-    float panelX = -(328.0f * static_cast<float>(0.5) - static_cast<float>(400.0));
+    float panelX = static_cast<float>(static_cast<int>(
+        -(static_cast<double>(328.0f) * 0.5 - 400.0)));
     MenuPcs.DrawRect(
         0, panelX, 288.0f, 328.0f, 56.0f,
         0.0f, 368.0f, 1.0f, 1.0f, 0.0f);
@@ -855,11 +856,11 @@ void CMenuPcs::CmakeVillageDraw()
     }
 
     int showNameCursor = __cntlzw(static_cast<unsigned int>(1 - villageWork->m_mode)) >> 5;
-    if (villageWork->m_row > 4) {
+    if (villageWork->m_row >= 5) {
         showNameCursor = 0;
     }
     unsigned int nameLen = strlen(s_CmakeInfo.m_name);
-    if (6 < static_cast<int>(nameLen & (static_cast<int>(-nameLen | nameLen) >> 31))) {
+    if (7 <= static_cast<int>(nameLen & (static_cast<int>(-nameLen | nameLen) >> 31))) {
         showNameCursor = 0;
     }
     DrawCmakeName(1, showNameCursor, s_CmakeInfo.m_name, alpha);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -180,9 +180,9 @@ static inline float CalcCmakeFadeAlpha(CMenuPcs* menu)
 
 static inline void DrawCmakePreviewCharaAlpha(CMenuPcs* menu, float alpha)
 {
-    int slot = static_cast<int>(CmakeSlot(menu));
+    int handleIndex = static_cast<int>(CmakeSlot(menu)) + 0x20;
     int modelBlock = MenuS32(menu, 0x814);
-    if (*reinterpret_cast<int*>(modelBlock + (slot + 0x20) * 0x50) == 0) {
+    if (*reinterpret_cast<int*>(modelBlock + handleIndex * 0x50) == 0) {
         return;
     }
 
@@ -190,7 +190,6 @@ static inline void DrawCmakePreviewCharaAlpha(CMenuPcs* menu, float alpha)
     *reinterpret_cast<unsigned short*>(modelBlock + 0x6EA) = 4;
     menu->DrawInit();
 
-    int handleIndex = slot + 0x20;
     if (menu->m_wm.m_handles[handleIndex]->m_charaKind != 3) {
         menu->SetProjection(0x16);
         menu->SetLight(2);
@@ -222,9 +221,9 @@ static inline void DrawCmakePreviewChara(CMenuPcs* menu)
 
 static inline void DrawNamePreviewChara(CMenuPcs* menu, float modelAlpha, int gxAlpha)
 {
-    int slot = static_cast<int>(CmakeSlot(menu));
+    int handleIndex = static_cast<int>(CmakeSlot(menu)) + 0x20;
     int modelBlock = MenuS32(menu, 0x814);
-    if (*reinterpret_cast<int*>(modelBlock + (slot + 0x20) * 0x50) == 0) {
+    if (*reinterpret_cast<int*>(modelBlock + handleIndex * 0x50) == 0) {
         return;
     }
 
@@ -232,7 +231,6 @@ static inline void DrawNamePreviewChara(CMenuPcs* menu, float modelAlpha, int gx
     *reinterpret_cast<unsigned short*>(modelBlock + 0x6EA) = 4;
     menu->DrawInit();
 
-    int handleIndex = slot + 0x20;
     if (menu->m_wm.m_handles[handleIndex]->m_charaKind != 3) {
         menu->SetProjection(0x16);
         menu->SetLight(2);
@@ -1432,14 +1430,13 @@ void CMenuPcs::CmakeResultDraw()
         tileX += tileW;
     }
 
-    int slot = static_cast<int>(CmakeSlot(this));
+    int handleIndex = static_cast<int>(CmakeSlot(this)) + 0x20;
     int modelBlock = MenuS32(this, 0x814);
-    if (*reinterpret_cast<int*>(modelBlock + (slot + 0x20) * 0x50) != 0) {
+    if (*reinterpret_cast<int*>(modelBlock + handleIndex * 0x50) != 0) {
         *reinterpret_cast<short*>(modelBlock + 0x6E8) = 0xFF24;
         *reinterpret_cast<unsigned short*>(modelBlock + 0x6EA) = 4;
         DrawInit();
 
-        int handleIndex = slot + 0x20;
         if (m_wm.m_handles[handleIndex]->m_charaKind != 3) {
             SetProjection(0x16);
             SetLight(2);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2880,10 +2880,10 @@ int CMenuPcs::CmakeNameCtrl()
                     }
                     bsRet = 0;
                 }
-                if (bsRet == 0) {
-                    Sound.PlaySe(3, 0x40, 0x7F, 0);
-                } else {
+                if (bsRet != 0) {
                     Sound.PlaySe(4, 0x40, 0x7F, 0);
+                } else {
+                    Sound.PlaySe(3, 0x40, 0x7F, 0);
                 }
                 return 0;
             }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3067,11 +3067,12 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
+    float alpha255 = 255.0f * alpha;
     GXColor col;
     col.r = 0xFF;
     col.g = 0xFF;
     col.b = 0xFF;
-    col.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
+    col.a = static_cast<unsigned char>(static_cast<int>(alpha255));
     GXSetChanMatColor(GX_COLOR0A0, col);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3A));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -190,12 +190,12 @@ static inline void DrawCmakePreviewCharaAlpha(CMenuPcs* menu, float alpha)
     *reinterpret_cast<unsigned short*>(modelBlock + 0x6EA) = 4;
     menu->DrawInit();
 
-    CCharaPcs::CHandle* handle = GetCmakeCharaHandle(menu, slot);
-    if (handle->m_charaKind != 3) {
+    int handleIndex = slot + 0x20;
+    if (menu->m_wm.m_handles[handleIndex]->m_charaKind != 3) {
         menu->SetProjection(0x16);
         menu->SetLight(2);
-        *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(handle->m_model) + 0x9C) = alpha;
-        handle->Draw(5);
+        *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(menu->m_wm.m_handles[handleIndex]->m_model) + 0x9C) = alpha;
+        menu->m_wm.m_handles[handleIndex]->Draw(5);
         menu->RestoreProjection();
     } else {
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x32));
@@ -232,12 +232,12 @@ static inline void DrawNamePreviewChara(CMenuPcs* menu, float modelAlpha, int gx
     *reinterpret_cast<unsigned short*>(modelBlock + 0x6EA) = 4;
     menu->DrawInit();
 
-    CCharaPcs::CHandle* handle = GetCmakeCharaHandle(menu, slot);
-    if (handle->m_charaKind != 3) {
+    int handleIndex = slot + 0x20;
+    if (menu->m_wm.m_handles[handleIndex]->m_charaKind != 3) {
         menu->SetProjection(0x16);
         menu->SetLight(2);
-        *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(handle->m_model) + 0x9C) = modelAlpha;
-        handle->Draw(5);
+        *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(menu->m_wm.m_handles[handleIndex]->m_model) + 0x9C) = modelAlpha;
+        menu->m_wm.m_handles[handleIndex]->Draw(5);
         menu->RestoreProjection();
     } else {
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x32));
@@ -1702,7 +1702,6 @@ void CMenuPcs::CmakeResultOpen()
  */
 void CMenuPcs::CmakeJobDraw()
 {
-    short mode = CmakeState(this)->m_mode;
     float alpha = CalcCmakeFadeAlpha(this);
 
     DrawWMFrame0(1, 1.0f);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2169,10 +2169,10 @@ unsigned short CMenuPcs::CmakeTribeCtrl()
             reinterpret_cast<char*>(CmakeState(this)) + fieldSelect * 2 + offsetof(CmakeMenuState, m_select));
 
         if ((repeat & 0x8) != 0) {
-            if (currentValue == 0) {
-                currentValue = 3;
-            } else {
+            if (currentValue != 0) {
                 currentValue = static_cast<short>(currentValue - 1);
+            } else {
+                currentValue = 3;
             }
             Sound.PlaySe(1, 0x40, 0x7F, 0);
         } else if ((repeat & 0x4) != 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2819,7 +2819,9 @@ int CMenuPcs::CmakeNameCtrl()
                     unsigned int rawLen = strlen(s_CmakeInfo.m_name);
                     int nameLen = rawLen & (static_cast<int>(-rawLen | rawLen) >> 31);
                     int ret;
-                    if (nameLen < 7) {
+                    if (nameLen >= 7) {
+                        ret = -1;
+                    } else {
                         picked[0] = '\0';
                         rowLen = strlen(rowText);
                         if (rowLen != 0) {
@@ -2844,8 +2846,6 @@ int CMenuPcs::CmakeNameCtrl()
                             strcat(s_CmakeInfo.m_name, picked);
                             ret = 0;
                         }
-                    } else {
-                        ret = -1;
                     }
                     if (ret == 0) {
                         unsigned int finalLen = strlen(s_CmakeInfo.m_name);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2847,15 +2847,15 @@ int CMenuPcs::CmakeNameCtrl()
                             ret = 0;
                         }
                     }
-                    if (ret == 0) {
+                    if (ret != 0) {
+                        Sound.PlaySe(4, 0x40, 0x7F, 0);
+                    } else {
                         unsigned int finalLen = strlen(s_CmakeInfo.m_name);
                         if (static_cast<int>(finalLen & (static_cast<int>(-finalLen | finalLen) >> 31)) >= 7) {
                             CmakeState(this)->m_select = 0xB;
                             CmakeState(this)->m_row = 5;
                         }
                         Sound.PlaySe(2, 0x40, 0x7F, 0);
-                    } else {
-                        Sound.PlaySe(4, 0x40, 0x7F, 0);
                     }
                     return 0;
                 }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1439,12 +1439,12 @@ void CMenuPcs::CmakeResultDraw()
         *reinterpret_cast<unsigned short*>(modelBlock + 0x6EA) = 4;
         DrawInit();
 
-        CCharaPcs::CHandle* handle = GetCmakeCharaHandle(this, slot);
-        if (handle->m_charaKind != 3) {
+        int handleIndex = slot + 0x20;
+        if (m_wm.m_handles[handleIndex]->m_charaKind != 3) {
             SetProjection(0x16);
             SetLight(2);
-            *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(handle->m_model) + 0x9C) = 1.0f;
-            handle->Draw(5);
+            *reinterpret_cast<float*>(reinterpret_cast<unsigned char*>(m_wm.m_handles[handleIndex]->m_model) + 0x9C) = 1.0f;
+            m_wm.m_handles[handleIndex]->Draw(5);
             RestoreProjection();
         } else {
             MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x32));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3383,11 +3383,12 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
 
+    float alpha255 = 255.0f * alpha;
     GXColor col;
     col.r = 0xFF;
     col.g = 0xFF;
     col.b = 0xFF;
-    col.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
+    col.a = static_cast<unsigned char>(static_cast<int>(alpha255));
     GXSetChanMatColor(GX_COLOR0A0, col);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
@@ -3404,7 +3405,7 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
         col.r = 0xFF;
         col.g = 0xFF;
         col.b = 0xFF;
-        col.a = static_cast<unsigned char>(static_cast<int>(255.0f * alpha));
+        col.a = static_cast<unsigned char>(static_cast<int>(alpha255));
         GXSetChanMatColor(GX_COLOR0A0, col);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x64 : 0x3D));
         MenuPcs.DrawRect(

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1902,12 +1902,7 @@ unsigned short CMenuPcs::CmakeJobCtrl()
                 }
             found:
 
-                if (slot > 7) {
-                    s_CmakeInfo.m_job = static_cast<signed char>(CmakeState(this)->m_select);
-                    CmakeState(this)->m_resultDir = 1;
-                    Sound.PlaySe(2, 0x40, 0x7F, 0);
-                    return 1;
-                } else {
+                if (slot < 8) {
                     short winX = 0;
                     short winY = 0;
                     Sound.PlaySe(4, 0x40, 0x7F, 0);
@@ -1915,6 +1910,11 @@ unsigned short CMenuPcs::CmakeJobCtrl()
                     SetMcWinInfo((int)winX, (int)winY);
                     CmakeMcState(this) = 0;
                     return 0;
+                } else {
+                    s_CmakeInfo.m_job = static_cast<signed char>(CmakeState(this)->m_select);
+                    CmakeState(this)->m_resultDir = 1;
+                    Sound.PlaySe(2, 0x40, 0x7F, 0);
+                    return 1;
                 }
             } else if ((down & 0x200) != 0) {
                 ChgModel(static_cast<int>(CmakeSlot(this)), -1, -1, -1);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1289,7 +1289,7 @@ void CMenuPcs::CmakeResultDraw1()
         }
 
         float x = 8.0f + labelWidths[i];
-        float y = 0x70 + i * 0x28 - 4.0f;
+        float y = static_cast<float>(0x70 + i * 0x28) - 4.0f;
         float valueWidth = static_cast<float>(valueFont->GetWidth(txt));
         valueFont->SetPosX(x);
         valueFont->SetPosY(y);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -334,10 +334,10 @@ static inline unsigned char* GetCmakeRosterEntry(CMenuPcs* menu, int slot)
 
 static inline CFont* GetCmakeKeyboardFont(CMenuPcs* menu)
 {
-    if (CmakeResult(menu) == 0) {
-        return menu->m_fonts[CMAKE_FONT_LABEL];
+    if (CmakeResult(menu) != 0) {
+        return menu->m_fonts[CMAKE_FONT_VILLAGE];
     }
-    return menu->m_fonts[CMAKE_FONT_VILLAGE];
+    return menu->m_fonts[CMAKE_FONT_LABEL];
 }
 
 extern "C" const char s_ABCDEFGHIJKL_801E2F30[];

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1045,7 +1045,9 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             unsigned int rawLen = strlen(s_CmakeInfo.m_name);
             int nameLen = rawLen & (static_cast<int>(-rawLen | rawLen) >> 31);
             int ret;
-            if (nameLen < 7) {
+            if (nameLen >= 7) {
+                ret = -1;
+            } else {
                 picked[0] = '\0';
                 rowLen = strlen(rowText);
                 if (rowLen != 0) {
@@ -1070,18 +1072,16 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
                     strcat(s_CmakeInfo.m_name, picked);
                     ret = 0;
                 }
-            } else {
-                ret = -1;
             }
-            if (ret == 0) {
+            if (ret != 0) {
+                Sound.PlaySe(4, 0x40, 0x7f, 0);
+            } else {
                 unsigned int finalLen = strlen(s_CmakeInfo.m_name);
                 if (static_cast<int>(finalLen & (static_cast<int>(-finalLen | finalLen) >> 31)) > 6) {
                     select = 0xB;
                     row = 5;
                 }
                 Sound.PlaySe(2, 0x40, 0x7f, 0);
-            } else {
-                Sound.PlaySe(4, 0x40, 0x7f, 0);
             }
             }
         } else if ((down & 0x200) != 0) {
@@ -1103,10 +1103,10 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
                 }
                 bsRet = 0;
             }
-            if (bsRet == 0) {
-                Sound.PlaySe(3, 0x40, 0x7f, 0);
-            } else {
+            if (bsRet != 0) {
                 Sound.PlaySe(4, 0x40, 0x7f, 0);
+            } else {
+                Sound.PlaySe(3, 0x40, 0x7f, 0);
             }
             return 0;
         }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1143,9 +1143,8 @@ void CMenuPcs::CmakeVillageOpen()
  */
 void CMenuPcs::CmakeResultDraw1()
 {
-    short mode = CmakeState(this)->m_mode;
     float alpha = CalcCmakeFadeAlpha(this);
-    float popupAlpha = (mode == 0) ? 1.0f : alpha;
+    float popupAlpha = (CmakeState(this)->m_mode == 0) ? 1.0f : alpha;
 
     DrawWMFrame0(1, 1.0f);
 
@@ -1185,7 +1184,7 @@ void CMenuPcs::CmakeResultDraw1()
 
     DrawCmakePreviewChara(this);
 
-    if (mode == 0) {
+    if (CmakeState(this)->m_mode == 0) {
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
         GXColor panelCol;
@@ -1216,7 +1215,7 @@ void CMenuPcs::CmakeResultDraw1()
     DrawCmakeTitle(7, 1.0f, alpha);
 
     float textAlpha = alpha;
-    if (mode == 0) {
+    if (CmakeState(this)->m_mode == 0) {
         textAlpha = 1.0f;
     }
     {


### PR DESCRIPTION
Raises main/cmake fuzzy match from 84.20% to 86.95% (+2.75).

## What worked
- **R13 lazy field reload (biggest cluster):** the inlined `DrawCmakePreviewCharaAlpha`/`DrawNamePreviewChara` helpers cached the `CHandle*` in a register; the target reloads `m_wm.m_handles[slot+0x20]` at each deref. Reading the array element directly (and hoisting `slot+0x20` so it is computed once) fixed every caller that inlines these helpers (CmakeJobDraw, CmakeTribeDraw, CmakeResultDraw1, CmakeNameDraw, CmakeSexDraw). Same lazy-reload applied to `mode`/`resultDir` in CmakeResultDraw and `mode` in CmakeResultDraw1.
- **R9 basic-block ordering (largest single jumps):** the Ctrl functions placed the early-`return`/false body where the target placed the branch-taken body. Reordering `if/else` arms (slot<8 first, nameLen>=7 first, ret!=0/bsRet!=0 first, currentValue!=0 first) converted long INS/DEL+OP_MISMATCH runs straight to score in CmakeJobCtrl (79.4 to 94.3), CmakeTribeCtrl (74.7 to 86.7), CmakeVillageCtrl (87.9 to 92.1), CmakeNameCtrl (82.1 to 85.4).
- **f30 alpha residency:** caching `255.0f * alpha` in a float local (DrawCmakeDecision, DrawCmakeYesNo) promotes the product to the target's callee-saved FPR. The `rgba`-site cache regresses, so only the GXColor sites are cached.
- **Explicit x/y/valueWidth locals** in the CmakeResultDraw1 value loop (matching its CmakeResultDraw twin) restored callee-saved FPR liveness (84.8 to 90.2).
- **Compare polarity:** `m_row >= 5`, `slot >= 8`, and the keyboard-font branch flipped to match the target's `blt`/`bge`/`beq` encodings; `panelX` made an int-truncated float.

## Per-function gains
- CmakeJobCtrl 79.44 to 94.29
- CmakeTribeCtrl 74.65 to 86.66
- CmakeVillageCtrl 87.94 to 92.12
- CmakeResultDraw1 84.76 to 90.22
- CmakeResultDraw 86.58 to 89.76
- CmakeNameCtrl 82.13 to 85.35
- CmakeJobDraw 90.86 to 92.42
- CmakeSexDraw 86.10 to 87.64
- DrawCmakeYesNo 86.46 to 88.88
- DrawCmakeDecision 83.86 to 87.50
- CmakeTribeDraw 80.62 to 81.71

## Blockers (walled)
- The `alpha` f30/f31 coloring swap in CmakeVillageDraw/CmakeNameDraw/CmakeTribeDraw (target keeps alpha in f30, product in f31) is not source-forceable.
- The pad-read prologue (`clrlwi.`/`extrwi.`/`extsh.` register coloring) in every Ctrl function, and the remaining early-return guards (`emptyLen==0`, `spaceCount==nameLen`) that the target placed out-of-line, resist source restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)