### PR TITLE
goout: raise fuzzy match to 91.1% (cycle 3)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2645,36 +2645,8 @@ void CGoOutMenu::Calc()
                     }
                 }
 
-                if (nextMode == 2) {
-                    unsigned int activeCount = 0;
-                    for (int i = 0; i < 8; i++) {
-                        if (Game.m_caravanWorkArr[i].m_shopState != 0) {
-                            activeCount++;
-                            if (Game.m_caravanWorkArr[i].m_shopBusyFlag != 0) {
-                                activeCount++;
-                            }
-                        }
-                    }
-
-                    if (activeCount < 2) {
-                        int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
-                        SetMenuStr(0, 2,
-                                   GetGoOutMessageLine(languageId, 108),
-                                   GetGoOutMessageLine(languageId, 109));
-                        m_nextMainMode = 1;
-                        SetMainMode(0);
-                    } else {
-                        SetMainMode(3);
-                        if (m_currentMessage >= 0) {
-                            MenuPcs.m_menuWindowInfo->state = 2;
-                            MenuGoOutState().m_animFrame = 0;
-                        }
-                        m_messageWindowOpen = 0;
-                        m_pendingMessage = -1;
-                        m_messageCloseMode = 0;
-                        m_pendingMessageTimer = 0;
-                    }
-                } else if (nextMode == 1) {
+                switch (nextMode) {
+                case 1: {
                     int characterCount = 0;
                     for (unsigned int i = 0; i < 8; i++) {
                         if (Game.m_caravanWorkArr[i].m_shopState != 0) {
@@ -2717,6 +2689,39 @@ void CGoOutMenu::Calc()
                             SetMainMode(0);
                         }
                     }
+                    break;
+                }
+                case 2: {
+                    unsigned int activeCount = 0;
+                    for (int i = 0; i < 8; i++) {
+                        if (Game.m_caravanWorkArr[i].m_shopState != 0) {
+                            activeCount++;
+                            if (Game.m_caravanWorkArr[i].m_shopBusyFlag != 0) {
+                                activeCount++;
+                            }
+                        }
+                    }
+
+                    if (activeCount < 2) {
+                        int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
+                        SetMenuStr(0, 2,
+                                   GetGoOutMessageLine(languageId, 108),
+                                   GetGoOutMessageLine(languageId, 109));
+                        m_nextMainMode = 1;
+                        SetMainMode(0);
+                    } else {
+                        SetMainMode(3);
+                        if (m_currentMessage >= 0) {
+                            MenuPcs.m_menuWindowInfo->state = 2;
+                            MenuGoOutState().m_animFrame = 0;
+                        }
+                        m_messageWindowOpen = 0;
+                        m_pendingMessage = -1;
+                        m_messageCloseMode = 0;
+                        m_pendingMessageTimer = 0;
+                    }
+                    break;
+                }
                 }
             }
             break;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2295,11 +2295,11 @@ void CGoOutMenu::CalcDel()
         }
 
         switch (next) {
-        case 2:
-            SetDelMode(2);
-            break;
         case 1:
             SetDelMode(4);
+            break;
+        case 2:
+            SetDelMode(2);
             break;
         }
         break;
@@ -2347,11 +2347,11 @@ void CGoOutMenu::CalcDel()
         }
 
         switch (next) {
-        case 2:
-            SetDelMode(2);
-            break;
         case 1:
             SetDelMode(5);
+            break;
+        case 2:
+            SetDelMode(2);
             break;
         }
         break;
@@ -2412,11 +2412,11 @@ void CGoOutMenu::CalcDel()
         }
 
         switch (next) {
-        case 2:
-            SetDelMode(2);
-            break;
         case 1:
             SetDelMode(7);
+            break;
+        case 2:
+            SetDelMode(2);
             break;
         }
         break;
@@ -2464,12 +2464,12 @@ void CGoOutMenu::CalcDel()
         }
 
         switch (next) {
-        case 2:
-            SetDelMode(2);
-            break;
         case 1:
             Game.m_caravanWorkArr[m_selectedChara].m_shopBusyFlag = 0;
             SetDelMode(8);
+            break;
+        case 2:
+            SetDelMode(2);
             break;
         }
         break;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2356,7 +2356,7 @@ void CGoOutMenu::CalcDel()
         }
         break;
     case 5:
-        if (m_messageWindowOpen != 0 && MenuPcs.IsMenuCharaAnimIdle(m_selectedChara) != 0) {
+        if (m_messageWindowOpen != 0 && static_cast<int>(MenuPcs.IsMenuCharaAnimIdle(m_selectedChara)) != 0) {
             input = GetGoOutInputMask();
             if ((input & 0x100) != 0) {
                 Sound.PlaySe(2, 0x40, 0x7f, 0);
@@ -2474,7 +2474,7 @@ void CGoOutMenu::CalcDel()
         }
         break;
     case 8:
-        if (m_messageWindowOpen != 0 && MenuPcs.IsMenuCharaAnimIdle(m_selectedChara) != 0) {
+        if (m_messageWindowOpen != 0 && static_cast<int>(MenuPcs.IsMenuCharaAnimIdle(m_selectedChara)) != 0) {
             input = GetGoOutInputMask();
             if ((input & 0x100) != 0) {
                 Sound.PlaySe(2, 0x40, 0x7f, 0);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1296,7 +1296,7 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
         m_cardChannel = static_cast<char>(MenuPcs.m_mcCtrl.m_cardChannel);
         m_saveIndex = static_cast<char>(m_accessSaveIndex);
-        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));
+        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<signed char>(m_cardChannel));
         if (m_memCardResult == 1) {
             MenuPcs.m_mcCtrl.m_saveIndex = static_cast<unsigned char>(m_saveIndex);
             MenuPcs.m_mcCtrl.m_cardChannel = static_cast<unsigned char>(m_cardChannel);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1608,9 +1608,15 @@ void CGoOutMenu::CalcGoOut()
         }
 
         input = GetGoOutInputMask();
-        if ((input & 0x100) != 0) {
-            Sound.PlaySe(2, 0x40, 0x7f, 0);
+        {
+            bool pressed;
             if ((input & 0x100) != 0) {
+                Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
                 SetGoOutMode(8);
             }
         }
@@ -2581,11 +2587,15 @@ void CGoOutMenu::Calc()
         case 0:
             if (m_messageWindowOpen != 0) {
                 input = GetGoOutInputMask();
+                bool pressed;
                 if ((input & 0x100) != 0) {
                     Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    if ((input & 0x100) != 0) {
-                        SetMainMode(m_nextMainMode);
-                    }
+                    pressed = true;
+                } else {
+                    pressed = false;
+                }
+                if (pressed) {
+                    SetMainMode(m_nextMainMode);
                 }
             }
             break;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1566,9 +1566,15 @@ void CGoOutMenu::CalcGoOut()
         }
 
         input = GetGoOutInputMask();
-        if ((input & 0x100) != 0) {
-            Sound.PlaySe(2, 0x40, 0x7f, 0);
+        {
+            bool pressed;
             if ((input & 0x100) != 0) {
+                Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
                 if (m_returnGoOutMode == -1) {
                     SetMainMode(1);
                 } else {
@@ -1583,9 +1589,15 @@ void CGoOutMenu::CalcGoOut()
         }
 
         input = GetGoOutInputMask();
-        if ((input & 0x100) != 0) {
-            Sound.PlaySe(2, 0x40, 0x7f, 0);
+        {
+            bool pressed;
             if ((input & 0x100) != 0) {
+                Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
                 SetMainMode(1);
             }
         }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1824,11 +1824,11 @@ void CGoOutMenu::CalcGoOut()
         }
 
         switch (next) {
-        case 2:
-            SetGoOutMode(0xf);
-            break;
         case 1:
             SetGoOutMode(0x11);
+            break;
+        case 2:
+            SetGoOutMode(0xf);
             break;
         }
         break;
@@ -1869,11 +1869,11 @@ void CGoOutMenu::CalcGoOut()
         }
 
         switch (next) {
-        case 2:
-            SetGoOutMode(0xf);
-            break;
         case 1:
             SetGoOutMode(0x12);
+            break;
+        case 2:
+            SetGoOutMode(0xf);
             break;
         }
         break;
@@ -1935,11 +1935,11 @@ void CGoOutMenu::CalcGoOut()
         }
 
         switch (next) {
-        case 2:
-            SetMainMode(1);
-            break;
         case 1:
             SetGoOutMode(4);
+            break;
+        case 2:
+            SetMainMode(1);
             break;
         }
         break;
@@ -1974,11 +1974,11 @@ void CGoOutMenu::CalcGoOut()
         }
 
         switch (next) {
-        case 2:
-            SetMainMode(1);
-            break;
         case 1:
             SetGoOutMode(5);
+            break;
+        case 2:
+            SetMainMode(1);
             break;
         }
         break;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2630,7 +2630,7 @@ void CGoOutMenu::Calc()
                 m_cursorListY1 = 0xB0;
                 m_cursorMode = 1;
 
-                unsigned char nextMode = 0;
+                signed char nextMode = 0;
                 if (MenuPcs.m_menuWindowInfo->state == 1) {
                     input = GetGoOutInputMask();
                     if ((input & 0xC) != 0) {
@@ -2640,7 +2640,7 @@ void CGoOutMenu::Calc()
                         input = GetGoOutInputMask();
                         if ((input & 0x100) != 0) {
                             Sound.PlaySe(2, 0x40, 0x7f, 0);
-                            nextMode = static_cast<unsigned char>(m_cursorChoice + 1);
+                            nextMode = static_cast<signed char>(m_cursorChoice + 1);
                         }
                     }
                 }


### PR DESCRIPTION
Cycle-3 matching pass on `main/goout`, raising the unit from 89.27% to 91.06% (+1.79pp).

## Per-function gains
- **Calc**: 78.85% -> 87.40% (convert nextMode if-chain to a switch with case 1 before case 2; explicit bool pressed; signed char nextMode)
- **CalcGoOut**: 84.56% -> 85.79% (inner-switch case order; explicit bool pressed in cases 0/2/7)
- **CalcDel**: 93.31% -> 94.21% (inner-switch case order; signed compare on IsMenuCharaAnimIdle)
- **SetGoOutMode**: 94.56% -> 94.88% (signed char cast for m_cardChannel)

## What worked
- **switch instead of if-chain** (R4): the nextMode dispatch in Calc was an `if (nextMode == 2) ... else if (== 1)` chain. Converting it to a `switch` with case 1 emitted before case 2 reproduced the target's signed balanced cmpwi tree and source-order body emission — the single biggest win (+1.1pp on the unit).
- **Inner-switch case order** (R9): the `switch (next)` blocks in CalcGoOut/CalcDel emitted case 2 before case 1; reordering to case-1-first matched mwcc's source-order block emission.
- **Explicit bool pressed**: the nested redundant `(input & 0x100)` re-check let mwcc reuse the first test in a callee-saved register; an explicit `bool pressed` flag matches the target's materialize-bool-after-PlaySe lowering.
- **Signedness**: signed compares on IsMenuCharaAnimIdle and m_cardChannel (a signed char field).

All changes are plausible original source (real control-flow restructuring and correct field signedness), verified net-positive against objdiff after every step.

## Blocker
The remaining gap is dominated by three documented walls confirmed again this cycle: the this/MenuPcs callee-saved register window swap (r30/r31), the inlined GetGoOutInputMask Pad-base register coloring, and the next/selResult temps being promoted to callee-saved registers (frame-size). These resisted block-order, bool, single-store, and dual-call restructuring attempts. SetMemCardError's switch-tree pivot boundaries are off-by-one in a compiler-determined binary search that source restructuring did not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)