### PR TITLE
joybus: raise fuzzy match to 88.1% (cycle 4)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4760,7 +4760,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 {
     unsigned int result = 0;
 
-    switch ((unsigned char)threadParam->m_subState)
+    switch ((signed char)threadParam->m_subState)
     {
     case 0:
         {
@@ -4770,7 +4770,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             m_txWordIndex[threadParam->m_portIndex] = 0;
 
-            unsigned char classFlags[4];
+            signed char classFlags[4];
             memset(classFlags, 0xFF, sizeof(classFlags));
 
             unsigned char payload[0x300];

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4837,8 +4837,8 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             memcpy(&payload[0x8E], &playerData[playerOffset + 0x20], 3);
 
-            payload[0x91] = playerData[playerOffset + 0x14];
-            payload[0x92] = playerData[playerOffset + 0x15];
+            unsigned short statHalf = __lhbrx(&playerData[playerOffset + 0x14], 0);
+            memcpy(&payload[0x91], &statHalf, 2);
 
             unsigned char compatBuf[64];
             memset(compatBuf, 0, sizeof(compatBuf));
@@ -4851,10 +4851,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             memcpy(body + compatLen, &playerData[playerOffset + 0x18], 8);
 
-            unsigned int statWord = ((unsigned int)playerData[playerOffset + 0x27] << 24) |
-                                    ((unsigned int)playerData[playerOffset + 0x26] << 16) |
-                                    ((unsigned int)playerData[playerOffset + 0x25] << 8) |
-                                     (unsigned int)playerData[playerOffset + 0x24];
+            unsigned int statWord = __lwbrx(&playerData[playerOffset + 0x24], 0);
             memcpy(body + compatLen + 8, &statWord, sizeof(statWord));
 
             const int byteLen = compatLen + 0xA3;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4801,23 +4801,25 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
                     classFlags[idx] = v;
                 }
 
+                lowBits  += 0x10;
+                highBits += 1;
+
                 if (p[0xF2] != 0)
                 {
                     int idx = (int)p[0xDC] >> 1;
-                    unsigned char v =
-                        (classFlags[idx] & 0x0F) | (signed char)(lowBits + 0x10);
+                    signed char v = (classFlags[idx] & 0x0F) | lowBits;
 
                     if ((p[0xDC] & 1) != 0)
                     {
-                        v = (classFlags[idx] & 0xF0) | (signed char)(highBits + 1);
+                        v = (classFlags[idx] & 0xF0) | highBits;
                     }
 
                     classFlags[idx] = v;
                 }
 
-                p       += 0x1B8;
-                lowBits += 0x20;
-                highBits += 2;
+                p        += 0x1B8;
+                lowBits  += 0x10;
+                highBits += 1;
             }
 
             memcpy(&payload[0x81], classFlags, sizeof(classFlags));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4823,7 +4823,6 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             memcpy(&payload[0x81], classFlags, sizeof(classFlags));
 
             unsigned char* playerData = playerInfo.m_data;
-            int playerOffset = threadParam->m_portIndex * 0xDC;
 
             payload[0x85] = playerData[0x16];
             payload[0x86] = playerData[0x17];
@@ -4833,11 +4832,11 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             payload[0x8A] = playerData[0x1CF];
             payload[0x8B] = playerData[0x2AA];
             payload[0x8C] = playerData[0x2AB];
-            payload[0x8D] = playerData[playerOffset + 2];
+            payload[0x8D] = playerData[threadParam->m_portIndex * 0xDC + 2];
 
-            memcpy(&payload[0x8E], &playerData[playerOffset + 0x20], 3);
+            memcpy(&payload[0x8E], &playerData[threadParam->m_portIndex * 0xDC + 0x20], 3);
 
-            unsigned short statHalf = __lhbrx(&playerData[playerOffset + 0x14], 0);
+            unsigned short statHalf = __lhbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x14], 0);
             memcpy(&payload[0x91], &statHalf, 2);
 
             unsigned char compatBuf[64];
@@ -4849,9 +4848,9 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             memcpy(body, compatBuf, compatLen);
 
-            memcpy(body + compatLen, &playerData[playerOffset + 0x18], 8);
+            memcpy(body + compatLen, &playerData[threadParam->m_portIndex * 0xDC + 0x18], 8);
 
-            unsigned int statWord = __lwbrx(&playerData[playerOffset + 0x24], 0);
+            unsigned int statWord = __lwbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x24], 0);
             memcpy(body + compatLen + 8, &statWord, sizeof(statWord));
 
             const int byteLen = compatLen + 0xA3;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4783,6 +4783,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             GbaQue.GetCaravanName((char*)&payload[1]);
 
             signed char* p = (signed char*)&playerInfo;
+            unsigned char* cf = classFlags;
             unsigned char lowBits = 0;
             unsigned char highBits = 0;
 
@@ -4791,14 +4792,14 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
                 if (p[0x16] != 0)
                 {
                     int idx = (int)p[0] >> 1;
-                    signed char v = (classFlags[idx] & 0x0F) | lowBits;
+                    signed char v = (cf[idx] & 0x0F) | lowBits;
 
                     if ((p[0] & 1) != 0)
                     {
-                        v = (classFlags[idx] & 0xF0) | highBits;
+                        v = (cf[idx] & 0xF0) | highBits;
                     }
 
-                    classFlags[idx] = v;
+                    cf[idx] = v;
                 }
 
                 lowBits  += 0x10;
@@ -4807,14 +4808,14 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
                 if (p[0xF2] != 0)
                 {
                     int idx = (int)p[0xDC] >> 1;
-                    signed char v = (classFlags[idx] & 0x0F) | lowBits;
+                    signed char v = (cf[idx] & 0x0F) | lowBits;
 
                     if ((p[0xDC] & 1) != 0)
                     {
-                        v = (classFlags[idx] & 0xF0) | highBits;
+                        v = (cf[idx] & 0xF0) | highBits;
                     }
 
-                    classFlags[idx] = v;
+                    cf[idx] = v;
                 }
 
                 p        += 0x1B8;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4770,7 +4770,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             m_txWordIndex[threadParam->m_portIndex] = 0;
 
-            signed char classFlags[4];
+            unsigned char classFlags[4];
             memset(classFlags, 0xFF, sizeof(classFlags));
 
             unsigned char payload[0x300];


### PR DESCRIPTION
Raises main/joybus fuzzy match from 87.79% to 88.06%.

## What changed
All gains landed in SendPlayerStat (75.81% -> 87.13%, +11.3 points):

- signed-char m_subState switch + classFlags type (matches signed `bge` dispatch / `extsb`)
- __lhbrx/__lwbrx byte-reversed loads for the stat halfword and statWord (matches target `lhbrx`/`lwbrx` instead of manual shift-OR byte assembly) — same intrinsics already used throughout gbaque.cpp/p_usb.cpp
- recompute the per-player byte offset (`m_portIndex * 0xDC`) inline at each use instead of caching it in a local (matches the target reloading `m_portIndex` each time)
- running-counter increment idiom in the class-flag loop: increment lowBits/highBits by 0x10/1 between the two if-blocks so the second block consumes the already-advanced counters (matches the target's mid-loop `addi`)
- read classFlags as unsigned (drops a spurious `extsb` before masking)
- hold the classFlags base in an explicit pointer so it stays live across the loop (matches the target keeping the base in one register instead of rematerializing the stack address each iteration)

## Why plausible
All changes are ordinary hand-source idioms (byte-reverse load intrinsics, running counters, direct field access) consistent with the rest of the file. No offset tricks, no fake symbols, no layout hacks.

## Blockers (left for a later cycle)
- SendDataFile (60.8%) and SendPpos/ThreadInit/CreateInit: dominated by a callee-saved register-window shift (mwcc allocating one/two more saved regs than the target). Removing the cached `port`/offset locals regressed.
- SendPlayerStat residual: a 0x40 stack-frame layout difference (mwcc places compatBuf between classFlags and payload; the target places it last). Declaration-order changes don't move it.
- SetOpenMenu / the 8 Send* helpers: the documented result-in-r0-vs-r3 idiom wall.
- GBARecvSend/CreateInit: `s_dvd_gba_dir` rodata-anchoring + slightly different rodata offsets (data-layout, not source-steerable here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)