### PR TITLE
mapobj: raise fuzzy match to 98.5% (cycle 3)

### DIFF
--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -21,16 +21,6 @@ class CMaterialMan;
 class CCameraPcs;
 struct Vec;
 
-static inline void InitMapObjAtrColorKeyFrame(CMapKeyFrame& keyFrame)
-{
-    keyFrame.m_junTable = 0;
-    keyFrame.m_keyFrame = 0;
-    keyFrame.m_keyValue = 0;
-    keyFrame.m_splineTable = 0;
-    keyFrame.m_loop = 1;
-    keyFrame.m_isRun = 0;
-}
-
 class CMapObjAtr
 {
 public:

--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -69,8 +69,8 @@ public:
     {
         m_type = SPOT_LIGHT;
         m_light = 0;
-        m_intensity = 1.0f;
         m_falloff = 1.0f;
+        m_intensity = 1.0f;
         m_colorMode = 0;
         m_useAltColor = 0;
         m_keyFrameCount = 0;

--- a/include/ffcc/mapobj.h
+++ b/include/ffcc/mapobj.h
@@ -111,7 +111,6 @@ public:
     {
         m_type = POINT_LIGHT;
         m_colorMode = 0;
-        m_useAltColor = 0;
         m_unknown20 = 0;
     }
 

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -186,6 +186,7 @@ int CPtrArray<CMapAnimRun*>::setSize(unsigned long newSize)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 template <>
 int CPtrArray<CMapShadow*>::Add(CMapShadow* item)
 {
@@ -197,6 +198,7 @@ int CPtrArray<CMapShadow*>::Add(CMapShadow* item)
     m_numItems = m_numItems + 1;
     return 1;
 }
+#pragma dont_inline off
 
 /*
  * --INFO--

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -865,15 +865,6 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
             CChunkFile::CChunk mimeChunk;
             while (chunkFile.GetNextChunk(mimeChunk) != 0) {
                 switch (mimeChunk.m_id) {
-                case CHUNK_JUN:
-                    mime->m_keyFrame.ReadJun(chunkFile, static_cast<char>(mimeChunk.m_arg0));
-                    break;
-                case CHUNK_FRAM:
-                    mime->m_keyFrame.ReadFrame(chunkFile, mimeChunk.m_arg0);
-                    break;
-                case CHUNK_KEY:
-                    mime->m_keyFrame.ReadKey(chunkFile, mimeChunk.m_arg0);
-                    break;
                 case CHUNK_VTXL: {
                     mime->m_vertexListCount = static_cast<unsigned char>(mimeChunk.m_arg0);
                     mime->m_vertexLists = reinterpret_cast<float**>(
@@ -903,6 +894,15 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                     chunkFile.PopChunk();
                     break;
                 }
+                case CHUNK_JUN:
+                    mime->m_keyFrame.ReadJun(chunkFile, static_cast<char>(mimeChunk.m_arg0));
+                    break;
+                case CHUNK_FRAM:
+                    mime->m_keyFrame.ReadFrame(chunkFile, mimeChunk.m_arg0);
+                    break;
+                case CHUNK_KEY:
+                    mime->m_keyFrame.ReadKey(chunkFile, mimeChunk.m_arg0);
+                    break;
                 }
             }
             chunkFile.PopChunk();

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -382,7 +382,6 @@ inline CMapObjAtrPlaySta::CMapObjAtrPlaySta()
  */
 inline CMapObjAtrMime::CMapObjAtrMime()
 {
-    InitMapObjAtrColorKeyFrame(m_keyFrame);
     m_type = CMapObjAtr::MIME;
     m_vertexLists = 0;
 }

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -558,22 +558,22 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                         break;
                     }
                     case CHUNK_CJUN:
-                        pointLight->m_altColorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
-                        break;
-                    case CHUNK_CFRM:
-                        pointLight->m_altColorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
-                        break;
-                    case CHUNK_CKEY:
-                        pointLight->m_altColorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
-                        break;
-                    case CHUNK_MJUN:
                         pointLight->m_colorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
                         break;
-                    case CHUNK_MFRM:
+                    case CHUNK_CFRM:
                         pointLight->m_colorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
                         break;
-                    case CHUNK_MKEY:
+                    case CHUNK_CKEY:
                         pointLight->m_colorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
+                        break;
+                    case CHUNK_MJUN:
+                        pointLight->m_altColorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
+                        break;
+                    case CHUNK_MFRM:
+                        pointLight->m_altColorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
+                        break;
+                    case CHUNK_MKEY:
+                        pointLight->m_altColorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
                         break;
                     }
                 }
@@ -652,22 +652,22 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                         break;
                     }
                     case CHUNK_CJUN:
-                        spotLight->m_altColorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
-                        break;
-                    case CHUNK_CFRM:
-                        spotLight->m_altColorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
-                        break;
-                    case CHUNK_CKEY:
-                        spotLight->m_altColorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
-                        break;
-                    case CHUNK_MJUN:
                         spotLight->m_colorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
                         break;
-                    case CHUNK_MFRM:
+                    case CHUNK_CFRM:
                         spotLight->m_colorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
                         break;
-                    case CHUNK_MKEY:
+                    case CHUNK_CKEY:
                         spotLight->m_colorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
+                        break;
+                    case CHUNK_MJUN:
+                        spotLight->m_altColorKeyFrame.ReadJun(chunkFile, chunk.m_arg0);
+                        break;
+                    case CHUNK_MFRM:
+                        spotLight->m_altColorKeyFrame.ReadFrame(chunkFile, chunk.m_arg0);
+                        break;
+                    case CHUNK_MKEY:
+                        spotLight->m_altColorKeyFrame.ReadKey(chunkFile, chunk.m_arg0);
                         break;
                     }
                 }

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -118,6 +118,7 @@ static inline float LoadFloatVolatile(const volatile float& value)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma dont_inline on
 template <>
 int CPtrArray<CMapAnimRun*>::Add(CMapAnimRun* item)
 {
@@ -129,6 +130,7 @@ int CPtrArray<CMapAnimRun*>::Add(CMapAnimRun* item)
     m_numItems = m_numItems + 1;
     return 1;
 }
+#pragma dont_inline off
 
 /*
  * --INFO--

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -35,6 +35,7 @@ static const float kMapObjInitNegOne = 1000000000000000.0f;
 static const float kMapObjColorBlendScale = 255.0f;
 static const float kMapObjDegToRad = 0.017453292f;
 static const float kMapObjInitValue50 = -1.0f;
+static const float kMapObjDefaultAngle = 48.0f;
 extern const char s_mapobj_cpp[] = "mapobj.cpp";
 extern const char sMapObjScaleWithoutNameWarn[0x78] = {
     (char)0x83, (char)0x47, (char)0x83, (char)0x89, (char)0x81, (char)0x5b, (char)0x81, (char)0x49,
@@ -706,6 +707,31 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                 spotLight->m_useAltColor = chunkFile.Get1();
                 spotLight->m_angle = chunkFile.GetF4();
                 spotLight->m_unknown2E = chunkFile.Get1();
+            } else if (chunk.m_version == 4) {
+                spotLight->m_color.r = chunkFile.Get1();
+                spotLight->m_color.g = chunkFile.Get1();
+                spotLight->m_color.b = chunkFile.Get1();
+                spotLight->m_color.a = chunkFile.Get1();
+                spotLight->m_altColor.r = chunkFile.Get1();
+                spotLight->m_altColor.g = chunkFile.Get1();
+                spotLight->m_altColor.b = chunkFile.Get1();
+                spotLight->m_altColor.a = chunkFile.Get1();
+                spotLight->m_baseColor.r = chunkFile.Get1();
+                spotLight->m_baseColor.g = chunkFile.Get1();
+                spotLight->m_baseColor.b = chunkFile.Get1();
+                spotLight->m_baseColor.a = chunkFile.Get1();
+                spotLight->m_radius = chunkFile.GetF4();
+                spotLight->m_nearRange = chunkFile.GetF4();
+                spotLight->m_farRange = chunkFile.GetF4();
+                spotLight->m_intensity = chunkFile.GetF4();
+                chunkFile.GetF4();
+                spotLight->m_falloff = chunkFile.GetF4();
+                unsigned short targetIndex = chunkFile.Get2();
+                spotLight->m_target = MapMng.m_mapObjArray + targetIndex;
+                spotLight->m_colorMode = chunkFile.Get1();
+                spotLight->m_useAltColor = chunkFile.Get1();
+                spotLight->m_angle = kMapObjDefaultAngle;
+                spotLight->m_unknown2E = 0;
             }
             m_attribute = spotLightAttr;
             break;

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -850,10 +850,10 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                 m_shadowTarget = static_cast<int>(chunkFile.Get4());
             } else if (chunk.m_version == 1) {
                 m_enableFullScreenShadow = chunkFile.Get1();
-                if (chunkFile.Get1() == 0) {
-                    m_shadowTarget = 0;
-                } else {
+                if (chunkFile.Get1() != 0) {
                     m_shadowTarget = -1;
+                } else {
+                    m_shadowTarget = 0;
                 }
             } else {
                 m_enableFullScreenShadow = chunkFile.Get1();

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -477,11 +477,20 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                 }
             }
 
-            if (((Game.m_currentSceneId == 4) || (Game.m_currentSceneId == 7)) &&
-                (m_meshType < 10) && (m_meshType >= 8)) {
+            if (Game.m_currentSceneId == 4) {
+                goto checkScaleMeshType;
+            }
+            goto checkScaleScene7;
+        checkScaleMeshType:
+            if ((m_meshType < 10) && (m_meshType >= 8)) {
                 m_transRateX = kMapObjZero;
                 m_transRateY = kMapObjOne;
                 m_transRateZ = kMapObjZero;
+            }
+            break;
+        checkScaleScene7:
+            if (Game.m_currentSceneId == 7) {
+                goto checkScaleMeshType;
             }
             break;
         }


### PR DESCRIPTION
Raises main/mapobj from 93.67% to 98.52% (+4.85), driven almost entirely by ReadOtmObj (84.16% -> 96.94%).

## What changed (all in src/mapobj.cpp + include/ffcc/mapobj.h, no layout changes)
- **Add missing SLIT spotlight version-4 handler** (+0.95): the chunk dispatch had version 6 and 5 paths but the original also handles version 4 (recovered the field-read sequence + default m_angle=48.0f / m_unknown2E=0 from the DOL at 0x8002B348). Largest single win.
- **Call CPtrArray<CMapAnimRun*>::Add and CPtrArray<CMapShadow*>::Add out-of-line** (+1.40, +1.77): mwcc was auto-inlining these into ReadOtmObj (emitting the full setSize/grow/memcpy bodies), but the original calls them via `bl`. Wrapped each Add definition in `#pragma dont_inline on/off`.
- **Emit MIME VTXL case body before keyframe cases** (+0.52): reordered the inner switch so the VTXL vertex-loop body is emitted ahead of JUN/FRAM/KEY, matching the target's physical block order.
- **Match keyframe member offsets in PLIT/SLIT handlers**: CJUN/CFRM/CKEY write m_colorKeyFrame and MJUN/MFRM/MKEY write m_altColorKeyFrame (offsets verified against Calc, which reads them identically).
- **Match scene-id scale guard branch order in PIDX**: restructured the `(sceneId==4 || sceneId==7) && meshType in [8,10)` test with labeled blocks so the ==7 test lands after the body, matching the target's branch ladder.
- **Drop redundant keyframe init in CMapObjAtrMime ctor**: removed the explicit InitMapObjAtrColorKeyFrame call (duplicated the CMapKeyFrame member ctor, emitting the init block twice). Removed the now-dead helper.
- **Match SDST shadow-target branch order** and **PointLight/SpotLight ctor field-init set/order** to the original.

## Blocker (walled)
The remaining ~377 diffs are dominated by the prologue merged-rodata-base register coloring: the target references `s_mapobj_cpp` by named symbol while our `.o` uses a `...rodata.0@ha` merged base, costing one extra callee-saved register (stmw r14 vs r15). This propagates a fixed register-window shift (ARG_MISMATCH) across the whole body. Confirmed walled: R3 (moving string defs after the functions) regressed 98.5% -> 97.1%. SetLink's deep-nested-loop frame layout is the same class of register/frame wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)