### PR TITLE
gobjwork: raise fuzzy match to 93.9% (cycle 3)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1801,14 +1801,27 @@ void CCaravanWork::CalcStatus()
 	if (m_tempStatBuffTimer != 0) {
 		int tempStatBuffId = m_tempStatBuffId;
 		if (tempStatBuffId >= 0x183) {
-			if (tempStatBuffId < 0x185) {
-				m_strength += *(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + 0x6A);
-			}
-		} else if (tempStatBuffId >= 0x180) {
-			m_defense += *(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + 0x6C);
-		} else if (tempStatBuffId > 0x17C) {
-			m_magic += *(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + 0x6E);
+			goto TempStatStr;
 		}
+		if (tempStatBuffId >= 0x180) {
+			goto TempStatDef;
+		}
+		if (tempStatBuffId >= 0x17D) {
+			goto TempStatMag;
+		}
+		goto TempStatDone;
+	TempStatStr:
+		if (tempStatBuffId >= 0x185) {
+			goto TempStatDone;
+		}
+		m_strength += *(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + 0x6A);
+		goto TempStatDone;
+	TempStatDef:
+		m_defense += *(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + 0x6C);
+		goto TempStatDone;
+	TempStatMag:
+		m_magic += *(unsigned short*)(Game.unk_flat3_field_8_0xc7dc + 0x6E);
+	TempStatDone:;
 		m_tempStatBuffTimer--;
 	}
 

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2140,9 +2140,9 @@ unsigned int CCaravanWork::GetMagicCharge(int cmdListIdx, int&, int&)
 
 			groupedCountLocal = 1;
 			int nextIdx = topIdx + 1;
-			scanCount = static_cast<short>(m_numCmdListSlots) - nextIdx;
+			int remaining = static_cast<short>(m_numCmdListSlots) - nextIdx;
 			if (nextIdx < static_cast<short>(m_numCmdListSlots)) {
-				for (; scanCount != 0; scanCount--) {
+				for (; remaining != 0; remaining--) {
 					if (m_commandListExtra[nextIdx] != -1) {
 						break;
 					}

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -967,10 +967,8 @@ void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxRe
 {
 	int foundCount = 0;
 
-	if (maxResults > 0) {
-		for (int i = 0; i < maxResults; i++) {
-			romLetterWork[i] = 0;
-		}
+	for (int i = 0; i < maxResults; i++) {
+		romLetterWork[i] = 0;
 	}
 
 	CRomLetterWork* curLetter = reinterpret_cast<CRomLetterWork*>(Game.m_romLetterWorkBase);


### PR DESCRIPTION
Raises main/gobjwork from 93.64% to 93.86%.

## Per-function gains
- **CalcStatus (CCaravanWork)**: 90.33% -> 92.17%. Flattened the temp-stat-buff dispatch (0x17D/0x180/0x183/0x185 range) into a consecutive comparison ladder followed by labeled bodies via goto, matching the target's block emission order (R14). mwcc was inlining each range test before its body; the target emits the full ladder up front then the str/def/mag bodies.
- **GetMagicCharge**: 86.99% -> 87.41%. Gave the second command-list scan loop its own counter variable instead of reusing the shared `scanCount`; this let mwcc fuse the loop guard with the bdnz CTR loop, dropping a redundant zero-check and matching the target's bdnz.
- **SearchRomLetterWork**: 89.79% -> 89.88%. Dropped the redundant `if (maxResults > 0)` guard around the result-clearing for-loop, removing extra setup instructions and matching the target's unrolled zero-loop induction.

## Plausibility
All changes are ordinary source-level restructurings (loop-counter scoping, removing a redundant guard, expressing a range dispatch as a labeled ladder). No hardcoded addresses, fake symbols, pointer-offset tricks, or layout hacks.

## Blocker
The dominant remaining gap is a callee-saved register-COUNT wall: SearchRomLetterWork's target saves r20-r31 (12 regs) while ours saves r22-r31 (10) — the target promotes the zero-loop induction variables to the two extra low callee-saved registers, shifting nearly every register number. GetCmdListItemName/DelCmdListAndItem/GetNextCmdListIdx/FindItem are blocked by mwcc strength-reduction and register-coloring order (the shared command-list scan-loop idiom emits one extra count-zero check the target elides; FindItem folds a running index into base+constant). These resisted 10+ targeted variants (do-while, for, fresh vars, type changes, index-bound loops) and signedness permutation found no wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)