### PR TITLE
goout: raise fuzzy match to 91.7% (cycle 4)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1669,9 +1669,9 @@ card_connected:;
                 SetGoOutMode(0);
             } else {
                 m_accessCardChannel = 0;
-                MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
-                m_cardChannel = static_cast<char>(MenuPcs.m_mcCtrl.m_cardChannel);
+                m_cardChannel = static_cast<char>(m_accessCardChannel);
                 m_saveIndex = static_cast<char>(m_accessSaveIndex);
+                MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
                 SetGoOutMode(10);
             }
         }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1753,7 +1753,14 @@ card_connected:;
         }
         if (m_selectedTransferChara != -1) {
             Mc::SaveDat* transferWork = static_cast<Mc::SaveDat*>(MenuPcs.m_goOutTransferWork);
-            if (GoOutSaveDat(transferWork).m_caravan[m_selectedTransferChara].m_odekakeOutFlag == 0) {
+            if (GoOutSaveDat(transferWork).m_caravan[m_selectedTransferChara].m_odekakeOutFlag != 0) {
+                int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
+                SetMenuStr(0, 2,
+                           GetGoOutMessageLine(languageId, 57),
+                           GetGoOutMessageLine(languageId, 58));
+                m_returnGoOutMode = 0xF;
+                SetGoOutMode(0);
+            } else {
                 m_returnTransfer = 0;
                 if (GoOutSaveDat(transferWork).m_caravan[m_selectedTransferChara].m_odekakeReturnFlag == 0) {
                     int sameChara = MenuPcs.GetSameCharaData(MenuPcs.m_goOutTransferSaveData, transferWork, m_selectedTransferChara, 1);
@@ -1798,13 +1805,6 @@ card_connected:;
                     m_returnTransfer = 1;
                 }
                 SetGoOutMode(0x10);
-            } else {
-                int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
-                SetMenuStr(0, 2,
-                           GetGoOutMessageLine(languageId, 57),
-                           GetGoOutMessageLine(languageId, 58));
-                m_returnGoOutMode = 0xF;
-                SetGoOutMode(0);
             }
         }
         break;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1528,7 +1528,6 @@ void CGoOutMenu::CalcGoOut()
 {
     unsigned short input;
     unsigned char next;
-    int selResult = -1;
 
     if (m_watchCardDisconnect != 0 && m_modeFrame >= 0x14 && (m_modeFrame & 0xF) == 0) {
         if ((m_modeFrame & 0x10) != 0) {
@@ -1561,6 +1560,7 @@ void CGoOutMenu::CalcGoOut()
     }
 card_connected:;
 
+    int selResult = -1;
     if (m_saveLoadMenuOpen != 0) {
         const unsigned char selInit = static_cast<unsigned char>(__cntlzw(0xF - static_cast<int>(m_goOutMode)) >> 5 & 0xFF);
         selResult = MenuPcs.CalcGoOutSelChar(selInit, 1);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1531,8 +1531,11 @@ void CGoOutMenu::CalcGoOut()
     int selResult = -1;
 
     if (m_watchCardDisconnect != 0 && m_modeFrame >= 0x14 && (m_modeFrame & 0xF) == 0) {
-        const int cardStatus = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(((m_modeFrame & 0x10) == 0) ? 1 : 0);
-        if (cardStatus != 1) {
+        if ((m_modeFrame & 0x10) != 0) {
+            if (static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(0) == 1) {
+                goto card_connected;
+            }
+        card_disconnected:
             m_watchCardDisconnect = 0;
             m_returnGoOutMode = -1;
             m_goOutMode = 0;
@@ -1552,7 +1555,11 @@ void CGoOutMenu::CalcGoOut()
             }
             return;
         }
+        if (static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(1) != 1) {
+            goto card_disconnected;
+        }
     }
+card_connected:;
 
     if (m_saveLoadMenuOpen != 0) {
         const unsigned char selInit = static_cast<unsigned char>(__cntlzw(0xF - static_cast<int>(m_goOutMode)) >> 5 & 0xFF);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1527,7 +1527,6 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
 void CGoOutMenu::CalcGoOut()
 {
     unsigned short input;
-    unsigned char next;
 
     if (m_watchCardDisconnect != 0 && m_modeFrame >= 0x14 && (m_modeFrame & 0xF) == 0) {
         if ((m_modeFrame & 0x10) != 0) {
@@ -1828,33 +1827,35 @@ card_connected:;
         }
         m_cursorListY1 = 0xdc;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<signed char>(m_cursorChoice + 1);
                     }
-                    next = static_cast<signed char>(m_cursorChoice + 1);
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetGoOutMode(0x11);
-            break;
-        case 2:
-            SetGoOutMode(0xf);
-            break;
+            switch (next) {
+            case 1:
+                SetGoOutMode(0x11);
+                break;
+            case 2:
+                SetGoOutMode(0xf);
+                break;
+            }
         }
         break;
     case 0x11:
@@ -1873,33 +1874,35 @@ card_connected:;
         m_cursorListY0 = 0xd3;
         m_cursorListY1 = 0xe9;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<signed char>(m_cursorChoice + 1);
                     }
-                    next = static_cast<signed char>(m_cursorChoice + 1);
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetGoOutMode(0x12);
-            break;
-        case 2:
-            SetGoOutMode(0xf);
-            break;
+            switch (next) {
+            case 1:
+                SetGoOutMode(0x12);
+                break;
+            case 2:
+                SetGoOutMode(0xf);
+                break;
+            }
         }
         break;
     case 0x12:
@@ -1938,34 +1941,36 @@ card_connected:;
         m_cursorListY0 = 0xcf;
         m_cursorListY1 = 0xe7;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
-                    }
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
 
-                    next = static_cast<signed char>(m_cursorChoice + 1);
+                        next = static_cast<signed char>(m_cursorChoice + 1);
+                    }
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetGoOutMode(4);
-            break;
-        case 2:
-            SetMainMode(1);
-            break;
+            switch (next) {
+            case 1:
+                SetGoOutMode(4);
+                break;
+            case 2:
+                SetMainMode(1);
+                break;
+            }
         }
         break;
     case 4:
@@ -1977,34 +1982,36 @@ card_connected:;
         m_cursorListY0 = 0xce;
         m_cursorListY1 = 0xde;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
-                    }
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
 
-                    next = static_cast<signed char>(m_cursorChoice + 1);
+                        next = static_cast<signed char>(m_cursorChoice + 1);
+                    }
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetGoOutMode(5);
-            break;
-        case 2:
-            SetMainMode(1);
-            break;
+            switch (next) {
+            case 1:
+                SetGoOutMode(5);
+                break;
+            case 2:
+                SetMainMode(1);
+                break;
+            }
         }
         break;
     case 5:

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2242,7 +2242,6 @@ void CGoOutMenu::CalcDel()
     const unsigned char selInit = static_cast<unsigned char>(__cntlzw(2 - static_cast<int>(m_deleteMode)) >> 5 & 0xFF);
     const int selResult = MenuPcs.CalcGoOutSelChar(selInit, 0);
     unsigned short input;
-    unsigned char next;
 
     switch (m_deleteMode) {
     case 0:
@@ -2299,33 +2298,35 @@ void CGoOutMenu::CalcDel()
         m_cursorListY0 = 0xad;
         m_cursorListY1 = 0xbc;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<signed char>(m_cursorChoice + 1);
                     }
-                    next = static_cast<signed char>(m_cursorChoice + 1);
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetDelMode(4);
-            break;
-        case 2:
-            SetDelMode(2);
-            break;
+            switch (next) {
+            case 1:
+                SetDelMode(4);
+                break;
+            case 2:
+                SetDelMode(2);
+                break;
+            }
         }
         break;
     case 4:
@@ -2351,33 +2352,35 @@ void CGoOutMenu::CalcDel()
         m_cursorListY0 = 0xc2;
         m_cursorListY1 = 0xd1;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<unsigned char>(m_cursorChoice + 1);
                     }
-                    next = static_cast<unsigned char>(m_cursorChoice + 1);
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetDelMode(5);
-            break;
-        case 2:
-            SetDelMode(2);
-            break;
+            switch (next) {
+            case 1:
+                SetDelMode(5);
+                break;
+            case 2:
+                SetDelMode(2);
+                break;
+            }
         }
         break;
     case 5:
@@ -2416,33 +2419,35 @@ void CGoOutMenu::CalcDel()
         m_cursorListY0 = 0x97;
         m_cursorListY1 = 0xe9;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<signed char>(m_cursorChoice + 1);
                     }
-                    next = static_cast<signed char>(m_cursorChoice + 1);
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            SetDelMode(7);
-            break;
-        case 2:
-            SetDelMode(2);
-            break;
+            switch (next) {
+            case 1:
+                SetDelMode(7);
+                break;
+            case 2:
+                SetDelMode(2);
+                break;
+            }
         }
         break;
     case 7:
@@ -2468,34 +2473,36 @@ void CGoOutMenu::CalcDel()
         m_cursorListY0 = 0x9f;
         m_cursorListY1 = 0xdb;
         m_cursorMode = 0;
-        next = 0;
+        {
+            unsigned char next = 0;
 
-        if (MenuPcs.m_menuWindowInfo->state == 1) {
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
+            if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<unsigned char>(m_cursorChoice + 1);
                     }
-                    next = static_cast<unsigned char>(m_cursorChoice + 1);
                 }
             }
-        }
 
-        switch (next) {
-        case 1:
-            Game.m_caravanWorkArr[m_selectedChara].m_shopBusyFlag = 0;
-            SetDelMode(8);
-            break;
-        case 2:
-            SetDelMode(2);
-            break;
+            switch (next) {
+            case 1:
+                Game.m_caravanWorkArr[m_selectedChara].m_shopBusyFlag = 0;
+                SetDelMode(8);
+                break;
+            case 2:
+                SetDelMode(2);
+                break;
+            }
         }
         break;
     case 8:


### PR DESCRIPTION
Raises main/goout fuzzy match from 91.06% to 91.67% (+0.61pp), cycle 4.

## What changed (all in src/goout.cpp)
- **CalcGoOut card-disconnect guard**: rewrote the `m_modeFrame & 0x10` ternary that fed `ChkConnect` as an explicit branch with a shared disconnect-handler body reached by fall-through (bit-set arm) and a backward goto (bit-clear arm), matching the original's physical block order (R14). Fixed the whole guard region exactly.
- **CalcGoOut selResult scope**: moved `int selResult = -1;` from function top to just before its first use, dropping a spurious callee-saved r30 promotion (`li r30,-1` / `mr r30,r3`).
- **CalcGoOut case 0xF**: inverted the `m_odekakeOutFlag` if/else so the `!= 0` (short message) arm is emitted first, matching the target's source-order block emission (R9).
- **CalcGoOut access-pos store fold**: assigned `m_cardChannel` directly from `m_accessCardChannel` and reordered the channel/index/mcCtrl stores to the target's order.
- **CalcGoOut / CalcDel per-case `next` locals**: scoped the cursor-`next` variable into per-case blocks instead of a single function-scope declaration, reducing callee-saved-register pressure.

Per-function: CalcGoOut 85.79% -> 87.59% (+1.8), CalcDel 94.21% -> 94.28%.

## Remaining blockers (documented walls, not source-steerable)
- `this`/MenuPcs callee-saved r30<->r31 swap in Calc (dominates its diff).
- Inlined GetGoOutInputMask Pad-base register coloring (repeated in CalcGoOut/CalcDel).
- SetMemCardError switch-tree pivot boundaries (all off by 1).
- mwcc auto-named jumptable/float-pool symbols (`@710` vs `jumptable_...`, `@301` vs `DOUBLE_...`) counted as operand mismatches but not renameable from source.
- DrawGoOutMenu r3->r31 base establishment order.

All changes are plausible original source (control-flow restructuring and local scoping), verified net-positive by objdiff at each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)