### PR TITLE
cmake: raise fuzzy match to 87.7% (cycle 4)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2056,7 +2056,8 @@ void CMenuPcs::CmakeTribeDraw()
     hairFont->SetShadow(1);
     hairFont->SetScale(1.0f);
     hairFont->DrawInit();
-    hairFont->SetColor(tribeRgba.color);
+    CColor hairRgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a));
+    hairFont->SetColor(hairRgba.color);
     hairFont->SetTlut(6);
 
     int hairBase = MenuS16(this, 0x862) * 8;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1244,8 +1244,7 @@ void CMenuPcs::CmakeResultDraw1()
     labelFont->SetScale(1.0f);
     labelFont->DrawInit();
 
-    int textColor = static_cast<int>(255.0f * textAlpha);
-    CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
+    CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * textAlpha));
     labelFont->SetColor(color.color);
 
     float labelWidths[4];
@@ -1266,7 +1265,7 @@ void CMenuPcs::CmakeResultDraw1()
     valueFont->SetShadow(1);
     valueFont->SetScale(1.0f);
     valueFont->DrawInit();
-    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
+    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * textAlpha));
     valueFont->SetColor(valueColor.color);
     valueFont->SetTlut(6);
 
@@ -1544,8 +1543,7 @@ void CMenuPcs::CmakeResultDraw()
     labelFont->SetScale(1.0f);
     labelFont->DrawInit();
 
-    int textColor = static_cast<int>(255.0f * textAlpha);
-    CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
+    CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * textAlpha));
     labelFont->SetColor(color.color);
 
     float labelWidths[4];
@@ -1565,7 +1563,7 @@ void CMenuPcs::CmakeResultDraw()
     valueFont->SetShadow(1);
     valueFont->SetScale(1.0f);
     valueFont->DrawInit();
-    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
+    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * textAlpha));
     valueFont->SetColor(valueColor.color);
     valueFont->SetTlut(6);
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -834,7 +834,7 @@ void CMenuPcs::CmakeVillageDraw()
     font->DrawInit();
     GetRenderFlagBits(font->renderFlags).fixedWidth = 1;
     font->SetMargin(4.9f);
-    CColor textColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
+    CColor textColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     font->SetColor(textColor.color);
 
     int tableBase = villageWork->m_table * 5;
@@ -1765,7 +1765,7 @@ void CMenuPcs::CmakeJobDraw()
     font->SetScale(1.0f);
     font->DrawInit();
 
-    CColor textColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
+    CColor textColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     font->SetColor(textColor.color);
 
     for (int i = 0; i < 8; ++i) {
@@ -2338,7 +2338,7 @@ void CMenuPcs::CmakeSexDraw()
     font->SetScale(1.0f);
     font->DrawInit();
 
-    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
+    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     font->SetColor(rgba.color);
 
     float maxWidth = 0.0f;
@@ -3419,7 +3419,7 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
     font->DrawInit();
     font->SetTlut(7);
 
-    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
+    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     font->SetColor(rgba.color);
 
     const char* txt = GetMenuStr(0x29);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1266,7 +1266,8 @@ void CMenuPcs::CmakeResultDraw1()
     valueFont->SetShadow(1);
     valueFont->SetScale(1.0f);
     valueFont->DrawInit();
-    valueFont->SetColor(color.color);
+    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
+    valueFont->SetColor(valueColor.color);
     valueFont->SetTlut(6);
 
     for (int i = 0; i < 4; i++) {
@@ -1564,7 +1565,8 @@ void CMenuPcs::CmakeResultDraw()
     valueFont->SetShadow(1);
     valueFont->SetScale(1.0f);
     valueFont->DrawInit();
-    valueFont->SetColor(color.color);
+    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
+    valueFont->SetColor(valueColor.color);
     valueFont->SetTlut(6);
 
     char tribeWithSlash[0x40];

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3095,7 +3095,7 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     font->DrawInit();
     font->SetTlut(7);
 
-    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(static_cast<int>(255.0f * alpha)));
+    CColor rgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     font->SetColor(rgba.color);
 
     const char* yesStr = GetMenuStr(1);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2039,7 +2039,7 @@ void CMenuPcs::CmakeTribeDraw()
     tribeFont->SetShadow(0);
     tribeFont->SetScale(1.0f);
     tribeFont->DrawInit();
-    CColor tribeRgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a));
+    CColor tribeRgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     tribeFont->SetColor(tribeRgba.color);
 
     for (int i = 0; i < 4; i++) {
@@ -2054,7 +2054,7 @@ void CMenuPcs::CmakeTribeDraw()
     hairFont->SetShadow(1);
     hairFont->SetScale(1.0f);
     hairFont->DrawInit();
-    CColor hairRgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a));
+    CColor hairRgba(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     hairFont->SetColor(hairRgba.color);
     hairFont->SetTlut(6);
 
@@ -2585,7 +2585,7 @@ void CMenuPcs::CmakeNameDraw()
     font->DrawInit();
     GetRenderFlagBits(font->renderFlags).fixedWidth = 1;
     font->SetMargin(4.9f);
-    CColor textCol(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a));
+    CColor textCol(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
     font->SetColor(textCol.color);
 
     int y = 0x6C;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1244,7 +1244,7 @@ void CMenuPcs::CmakeResultDraw1()
     labelFont->SetScale(1.0f);
     labelFont->DrawInit();
 
-    int textColor = static_cast<int>(static_cast<double>(255.0f) * textAlpha);
+    int textColor = static_cast<int>(255.0f * textAlpha);
     CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(textColor));
     labelFont->SetColor(color.color);
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2506,7 +2506,7 @@ void CMenuPcs::CmakeNameDraw()
 
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    int a = static_cast<int>(static_cast<double>(255.0f) * static_cast<double>(alpha));
+    int a = static_cast<int>(255.0f * alpha);
     GXColor col;
     col.r = 0xFF;
     col.g = 0xFF;


### PR DESCRIPTION
Raises main/cmake fuzzy match from 86.95% to 87.73% (+0.78pp).

## What worked
The dominant lever this cycle was matching the alpha-coloring precision/cast idioms in the character-maker Draw functions:

- **CColor alpha cast**: `CColor(..., static_cast<unsigned char>(static_cast<int>(255.0f * alpha)))` and the int-local form `static_cast<unsigned char>(a)` both emit a spurious `clrlwi` byte-mask before the `__ct__6CColor` call. The original passes the `fctiwz` result straight to the ctor. Switching to `static_cast<unsigned char>(255.0f * alpha)` (drop the intermediate int) removes the mask and matches.
- **Single vs double precision**: two sites used `static_cast<double>(255.0f) * ...` where the original kept the alpha multiply single-precision (`fmuls`), letting it reuse a callee-saved FPR.
- **Fresh CColor per font**: value-font `SetColor` reused the label-font's `CColor` local; the original constructed a separate CColor per font (matching the second `bl __ct__6CColor` / DrawInit block order).

## Per-function gains
- CmakeResultDraw1  90.22 -> 92.57
- CmakeResultDraw   89.76 -> 91.20
- DrawCmakeYesNo    88.88 -> 90.05
- CmakeNameDraw     84.70 -> 85.96
- CmakeTribeDraw    81.71 -> 84.03
- CmakeJobDraw      92.42 -> 93.47
- CmakeSexDraw      87.64 -> 88.63
- DrawCmakeDecision 87.56 -> 88.05
- CmakeVillageDraw  76.95 -> 77.34

## Blockers (walls, confirmed not source-steerable after multiple attempts)
- **GXColor stack-slot ordering / 16-byte frame delta** in the Draw functions (the known alpha-coloring wall).
- **tileX/tileW callee-saved register swap** (r27<->r28) in every 0x20-tile DrawRect loop; reordering the span/remaining computation does not flip the allocator.
- **`frame-1` prologue register swap** (r4<->r5) from the inlined CalcCmakeFadeAlpha.
- **DrawDiaryBase** needs one extra callee-saved GPR (the frameH magic-double pair held in two regs); not reproducible from source.
- **CmakeNameCtrl / CmakeTribeCtrl** dominated by the pad-read coloring wall.
- The 12 `Draw*`/`Is*`/`*VillageName` helpers are inlined-away in the target (no standalone symbol); marking them `inline` is net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)