### PR TITLE
materialman: raise fuzzy match to 93.68% (cycle 3)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1028,15 +1028,18 @@ void CMaterialMan::SetUnderWaterTex()
 
     matrixA[0][0] = screenMtx[0][0];
     matrixA[1][1] = screenMtx[1][1];
+    matrixA[0][2] = screenMtx[0][2];
+    matrixA[1][2] = screenMtx[1][2];
+    matrixA[2][2] = screenMtx[2][2];
     matrixA[1][0] = screenMtx[1][0];
     matrixA[2][0] = screenMtx[2][0];
     matrixA[0][1] = screenMtx[0][1];
     matrixA[2][1] = screenMtx[2][1];
+    matrixA[0][0] *= (kMaterialProjectionWidthScale / static_cast<float>(width));
+    matrixA[1][1] *= -(kMaterialProjectionHeightScale / static_cast<float>(height));
     matrixA[0][2] = kMaterialProjectionCenter;
     matrixA[1][2] = kMaterialProjectionCenter;
     matrixA[2][2] = kMaterialProjectionDepthScale;
-    matrixA[0][0] *= (kMaterialProjectionWidthScale / static_cast<float>(width));
-    matrixA[1][1] *= -(kMaterialProjectionHeightScale / static_cast<float>(height));
 
     PSMTXConcat(matrixA, matrixB, m_underWaterTexMtx);
 }


### PR DESCRIPTION
## Summary
Raises main/materialman fuzzy match from 93.51% to 93.68% (cycle 3).

### SetUnderWaterTex: 83.7% -> 98.2% (function level)
Reordered the projection-matrix element assignments to match the original's
store scheduling:
- Copy the full screen-matrix 3x3 block into matrixA first (in the target's
  order: [0][0],[1][1],[0][2],[1][2],[2][2],[1][0],[2][0],[0][1],[2][1]),
  then overwrite the projection center/depth elements last.
This makes every store offset and every opcode line up with the target; the
only residual diff is FPR register numbering (a hard register-coloring wall,
confirmed by permute finding no improvement).

## Blocker
- **GetCharaShadow (61.70%)**: register-window shifted by one register
  throughout (target dedicates r18 to the persistent `outputCount*4` byte
  offset and writes shadowMtxOut via base+offset `stwx`, while our codegen
  strength-reduces it to a plain advancing cursor), plus a basic-block
  placement divergence of the nearest-candidate search loop. Multiple
  structural rewrites (cursor vs index for the output arrays, nested-if to
  reproduce the unconditional `nearest->distance` store, loop-store ordering)
  and a permute pass produced no movement. This is a register-allocation /
  strength-reduction wall not steerable from source.

## Plausibility
The SetUnderWaterTex change is ordinary matrix-copy-then-overwrite source the
FFCC developers plausibly wrote; no hacks, addresses, or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)