### PR TITLE
joybus: raise fuzzy match to 88.2% (cycle 5)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4843,14 +4843,9 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             unsigned short statHalf = __lhbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x14], 0);
             memcpy(&payload[0x91], &statHalf, 2);
 
-            unsigned char compatBuf[64];
-            memset(compatBuf, 0, sizeof(compatBuf));
-
-            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, compatBuf);
-
             unsigned char* body = &payload[0x93];
 
-            memcpy(body, compatBuf, compatLen);
+            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, body);
 
             memcpy(body + compatLen, &playerData[threadParam->m_portIndex * 0xDC + 0x18], 8);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7095,7 +7095,7 @@ int JoyBus::SetCtrlMode(int portIndex, int controlMode)
 	}
 
     unsigned char modeFlag =
-        (unsigned char)(((unsigned int)(controlMode | -controlMode)) >> 31);
+        (unsigned char)(((unsigned int)(-controlMode | controlMode)) >> 31);
 
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7047,10 +7047,9 @@ int JoyBus::ChgCtrlMode(int portIndex)
         return 0;
     }
 
-    unsigned int x = mode ^ kPppYmMeltMaskBit0;
+    mode = (unsigned char)(mode ^ kPppYmMeltMaskBit0);
     wordBytes[0] = 0x09;
-    wordBytes[1] = (unsigned char)x;
-    mode = (unsigned char)x;
+    wordBytes[1] = mode;
     unsigned int wordCache = word;
     int ret = 0;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7199,31 +7199,32 @@ int JoyBus::IsInitSend(int portIndex)
     int state = m_threadParams[portIndex].m_state;
     OSSignalSemaphore(&m_accessSemaphores[portIndex]);
 
-    unsigned int result = 0;
+    unsigned int result;
 
     // Determine desired "init send" state
-    if (m_threadParams[portIndex].m_sentStartFlag == 0 && state <= 0x384)
-    {
-        if (state < 2)
-        {
-            result = 0;
-        }
-        else if (state == 2)
-        {
-            result = (m_threadParams[portIndex].m_flags[0] ? 1 : 0);
-        }
-        else
-        {
-            result = 1;
-        }
-    }
-    else
+    if (m_threadParams[portIndex].m_sentStartFlag != 0)
     {
         result = 0;
     }
+    else if (state > 0x384)
+    {
+        result = 0;
+    }
+    else if (state < 2)
+    {
+        result = 0;
+    }
+    else if (state == 2)
+    {
+        result = (m_threadParams[portIndex].m_flags[0] ? 1 : 0);
+    }
+    else
+    {
+        result = 1;
+    }
 
     // Stabilizer logic: detect and debounce changes to result
-    if (m_threadParams[portIndex].m_flags[2] == result)
+    if (m_threadParams[portIndex].m_flags[2] == (unsigned char)result)
     {
         m_threadParams[portIndex].m_flags[3] = 0;
     }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4759,8 +4759,9 @@ int JoyBus::MakeJoyData(char* src, int length, unsigned int* outBuffer)
 int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 {
     unsigned int result = 0;
+    unsigned char subState = threadParam->m_subState;
 
-    switch ((signed char)threadParam->m_subState)
+    switch (subState)
     {
     case 0:
         {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5443,7 +5443,6 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
         cmdBytes[6] = crcBytes[2];
         cmdBytes[7] = crcBytes[3];
         unsigned int cmd1 = cmds[0];
-        unsigned int cmd2 = cmds[1];
 
         if (static_cast<signed char>(m_threadRunningMask) == 0)
         {
@@ -5486,7 +5485,7 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
                 }
                 else
                 {
-                    m_cmdQueueData[port][m_cmdCount[port]] = cmd2;
+                    m_cmdQueueData[port][m_cmdCount[port]] = cmds[1];
                     m_cmdCount[threadParam->m_portIndex]++;
                     OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
                     result = 0;


### PR DESCRIPTION
Raises main/joybus fuzzy match 88.06% -> 88.16% via per-function structural fixes.

## Per-function gains
- **SendMapObjDrawFlg** 84.4% -> 85.1%: stop caching cmd2 in a callee-saved register across the semaphore calls (read cmds[1] at point of use), removing the extra preserved-register window.
- **SendPlayerStat** 87.1% -> 89.9%: read m_subState as unsigned char in the switch (drops a spurious extsb, matching the unsigned lbz dispatch); write GetCompatibility directly into the payload buffer instead of a separate 64-byte compatBuf, shrinking the frame from 0x6e0 to the target 0x6a0.
- **IsInitSend** 90.6% -> ~97%: split the `flag==0 && state<=0x384` guard into separate arms (matches the target's distinct result=0 blocks) and compare m_flags[2] against (unsigned char)result, which fixes both the truncation and the base-pointer register coloring (18 -> 3 flagged lines).
- **ChgCtrlMode** 93.9% -> ~94%: consolidate the `mode`/`x` intermediates into one local so mwcc reuses a single register instead of keeping both live.
- **SetCtrlMode** 93.5% -> ~94%: match the modeFlag `-controlMode | controlMode` operand order.

## What worked
Worst-first structural attacks: register-liveness reduction (drop redundant cached values across calls), signedness/truncation matching (unsigned char switch + byte compare), buffer-aliasing (write helper output straight into the destination), control-flow arm splitting (R9/R14), and operand-order matching.

## Blocker
The dominant remaining ceiling is the "result-in-rN-vs-r3" idiom shared across the Send*/Set* family (SendResult, SendChkCrc, SendAddLetter, SendUseItem, SetCmdLst, SetTmpArti, SendHitEnemy, RequestData, SendStartBonus, SetOpenMenu, SetMoney): the target keeps `result` in a volatile register that doubles as the cmd zero-init and moves it to r3 only at the single return, while mwcc materializes our constant results directly in r3 at each leaf. Multiple source restructurings (single-return, shared zero-init, result-first declaration) were tried and either no-op or regressed. The previously-documented walls (ThreadMain division-magic, RestartThread/CreateInit rodata.0 base, SendDataFile/SendPpos/ThreadInit register windows, MakeJoyData CRC byteswap, LoadBin CTR-remainder unroll) remain. SendPlayerStat still carries a this/threadParam callee-saved binding swap plus a payload-cursor difference that resisted reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)