### PR TITLE
gobject: raise fuzzy match to 89.8% (cycle 4)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2021,7 +2021,7 @@ void CGObject::onDraw()
     if (((CFlat.m_debugFlags & 0x40000) != 0) && ((m_bgColMask & 0x40000) != 0)) {
         for (int i = 0; i < 8; i++) {
             AttackCol* collider = &m_attackColliders[i];
-            if (collider->m_localStart.x == sZeroFloat) {
+            if (*reinterpret_cast<int*>(&collider->m_localStart.x) == 0) {
                 continue;
             }
 
@@ -2038,7 +2038,7 @@ void CGObject::onDraw()
     if (((CFlat.m_debugFlags & 0x80000) != 0) && ((m_bgColMask & 0x80000) != 0)) {
         for (int i = 0; i < 8; i++) {
             DamageCol* collider = &m_damageColliders[i];
-            if (collider->m_localPosition.x == sZeroFloat) {
+            if (*reinterpret_cast<int*>(&collider->m_localPosition.x) == 0) {
                 continue;
             }
 

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1364,7 +1364,7 @@ void CGObject::update()
         double clampedTurn;
         if (turnDelta < -turnLimit) {
             clampedTurn = -turnLimit;
-        } else if (turnDelta > turnLimit) {
+        } else if (turnLimit < turnDelta) {
             clampedTurn = turnLimit;
         } else {
             clampedTurn = turnDelta;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3080,10 +3080,7 @@ void CGObject::SetDispItemName(int showName)
  */
 void CGObject::DrawDebug(CFont* font)
 {
-    if ((static_cast<int>((static_cast<unsigned int>(*reinterpret_cast<u8*>(&m_weaponNodeFlags)) << 0x1A)
-                          | (*reinterpret_cast<u8*>(&m_weaponNodeFlags) >> 6))
-         < 0)
-        && (sZeroFloat < m_screenDepth)) {
+    if (m_weaponNodeFlagBits.m_unk20 && (sZeroFloat < m_screenDepth)) {
         float invDepth = sAnimFrameOffset / m_screenDepth;
         float xProd = sDebugScreenX * m_projection.z;
         float yProd = sDebugScreenY * m_projection.y;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2488,7 +2488,7 @@ void CGObject::boundCheck()
     Mtx cameraMtx;
     Mtx44 clipMtx;
     Mtx44 screenMtx;
-    u32 clipMask;
+    int clipMask;
 
     PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
     PSMTXCopy(cameraMtx, clipMtx);

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3380,8 +3380,8 @@ void CGObject::PutDropItem()
     s32 dropCount = 0;
 
     for (int i = 0; i < 4; i++) {
-        s32 dropCode = static_cast<u16>(m_dropItemCodes[i]);
-        if ((short)m_dropItemCodes[i] > 0) {
+        s32 dropCode = *reinterpret_cast<s16*>(&m_dropItemCodes[i]);
+        if (dropCode > 0) {
             int createMode;
             if ((dropCode & 0xC000) == 0x4000) {
                 dropCode &= 0x3FFF;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3085,11 +3085,13 @@ void CGObject::DrawDebug(CFont* font)
          < 0)
         && (sZeroFloat < m_screenDepth)) {
         float invDepth = sAnimFrameOffset / m_screenDepth;
+        float xProd = sDebugScreenX * m_projection.z;
+        float yProd = sDebugScreenY * m_projection.y;
         float screenX[2];
-        screenX[0] = -(sDebugScreenX * m_projection.z * invDepth - sDebugScreenX);
+        screenX[0] = -(xProd * invDepth - sDebugScreenX);
 
         onDrawDebug(font,
-                    sDebugScreenY * m_projection.y * invDepth + sDebugScreenY,
+                    yProd * invDepth + sDebugScreenY,
                     screenX[0],
                     m_projection.w * invDepth);
     }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3128,7 +3128,11 @@ void CGObject::SetPosBG(Vec* position, int useCapsuleOffset)
             }
         }
 
+        bool hasModel = false;
         if ((m_charaModelHandle != 0) && (m_charaModelHandle->m_model != 0)) {
+            hasModel = true;
+        }
+        if (hasModel) {
             CVector attrDirection(sZeroFloat, sDownProbeDistance, sZeroFloat);
             CVector attrBottom(m_worldPosition.x, m_worldPosition.y + sStepProbeHeight, m_worldPosition.z);
             CMapCylinder attrCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);


### PR DESCRIPTION
Raises main/gobject fuzzy match from baseline 89.38% to 89.78% (+0.40), matched functions 32 -> 33.

## Per-function gains
- DrawDebug 74.26% -> 99.71%: front-loaded the two projection products (sDebugScreenX*proj.z, sDebugScreenY*proj.y) into named float locals so mwcc interleaves the fmuls/fnmsubs/fmadds as the target does, and expressed the visibility test as the real m_unk20 bitfield read.
- onDraw 81.48% -> 84.77%: compare the collider start fields as integer bit patterns (*(int*)&field == 0) instead of float == sZeroFloat, removing a spurious callee-saved f31 cache of sZeroFloat that shifted the whole register window.
- PutDropItem 93.12% -> 95.00%: read m_dropItemCodes[i] through a signed-short element pointer so the loop emits lha at 0x510(this) like the target.
- SetPosBG 74.82% -> 77.32%: model presence test rewritten with an explicit hasModel bool.
- boundCheck 93.27% -> 94.05%: clipMask typed int so the !=0 break compiles to signed cmpwi.
- update: matched the turnDelta clamp branch polarity (turnLimit < turnDelta).

## Plausibility
All changes are ordinary source-level idioms (front-loading subexpressions into locals, integer bit comparisons of float fields, signed-short field access, explicit bool flags, signed mask type) that the FFCC developers could have written. No data-layout, vtable, or symbol-table changes; data match is unchanged at 7.17%.

## Blocker
The four lowest functions (bgNormalCollision 72.5%, bgAttribCollision 72.2%, onCreate 75.7%, and the remainder of SetPosBG) are walled by the .sdata2 float fold-vs-named-symbol tension documented in cycle 3: the shared FLOAT_8033xxxx constants get pooled (@NNNN) where the target references them by symbol. Converting them to declaration-only externs helps SetPosBG/onCreate but regresses the larger bg-collision functions (net negative), and the entangled r30/r3-vs-r31 this-pointer coloring follows from it. Remaining gaps in move/CCClass/Turn are pure callee-saved register/FPR allocation swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)