### PR TITLE
goout: raise fuzzy match to 92.2% (cycle 5)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2675,7 +2675,7 @@ void CGoOutMenu::Calc()
                 m_cursorListY1 = 0xB0;
                 m_cursorMode = 1;
 
-                signed char nextMode = 0;
+                signed char nextMode;
                 if (MenuPcs.m_menuWindowInfo->state == 1) {
                     input = GetGoOutInputMask();
                     if ((input & 0xC) != 0) {
@@ -2686,10 +2686,13 @@ void CGoOutMenu::Calc()
                         if ((input & 0x100) != 0) {
                             Sound.PlaySe(2, 0x40, 0x7f, 0);
                             nextMode = static_cast<signed char>(m_cursorChoice + 1);
+                            goto do_switch_calc;
                         }
                     }
                 }
 
+                nextMode = 0;
+            do_switch_calc:
                 switch (nextMode) {
                 case 1: {
                     int characterCount = 0;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2306,7 +2306,7 @@ void CGoOutMenu::CalcDel()
         m_cursorListY1 = 0xbc;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -2322,10 +2322,13 @@ void CGoOutMenu::CalcDel()
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
                         next = static_cast<signed char>(m_cursorChoice + 1);
+                        goto do_switch_del3;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_del3:
             switch (next) {
             case 1:
                 SetDelMode(4);
@@ -2360,7 +2363,7 @@ void CGoOutMenu::CalcDel()
         m_cursorListY1 = 0xd1;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -2376,10 +2379,13 @@ void CGoOutMenu::CalcDel()
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
                         next = static_cast<unsigned char>(m_cursorChoice + 1);
+                        goto do_switch_del4;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_del4:
             switch (next) {
             case 1:
                 SetDelMode(5);
@@ -2427,7 +2433,7 @@ void CGoOutMenu::CalcDel()
         m_cursorListY1 = 0xe9;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -2443,10 +2449,13 @@ void CGoOutMenu::CalcDel()
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
                         next = static_cast<signed char>(m_cursorChoice + 1);
+                        goto do_switch_del6;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_del6:
             switch (next) {
             case 1:
                 SetDelMode(7);
@@ -2481,7 +2490,7 @@ void CGoOutMenu::CalcDel()
         m_cursorListY1 = 0xdb;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -2497,10 +2506,13 @@ void CGoOutMenu::CalcDel()
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
                         next = static_cast<unsigned char>(m_cursorChoice + 1);
+                        goto do_switch_del7;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_del7:
             switch (next) {
             case 1:
                 Game.m_caravanWorkArr[m_selectedChara].m_shopBusyFlag = 0;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1828,7 +1828,7 @@ card_connected:;
         m_cursorListY1 = 0xdc;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -1844,10 +1844,13 @@ card_connected:;
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
                         next = static_cast<signed char>(m_cursorChoice + 1);
+                        goto do_switch_go10;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_go10:
             switch (next) {
             case 1:
                 SetGoOutMode(0x11);
@@ -1875,7 +1878,7 @@ card_connected:;
         m_cursorListY1 = 0xe9;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -1891,10 +1894,13 @@ card_connected:;
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
                         next = static_cast<signed char>(m_cursorChoice + 1);
+                        goto do_switch_go11;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_go11:
             switch (next) {
             case 1:
                 SetGoOutMode(0x12);
@@ -1942,7 +1948,7 @@ card_connected:;
         m_cursorListY1 = 0xe7;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -1959,10 +1965,13 @@ card_connected:;
                         }
 
                         next = static_cast<signed char>(m_cursorChoice + 1);
+                        goto do_switch_go3;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_go3:
             switch (next) {
             case 1:
                 SetGoOutMode(4);
@@ -1983,7 +1992,7 @@ card_connected:;
         m_cursorListY1 = 0xde;
         m_cursorMode = 0;
         {
-            unsigned char next = 0;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -2000,10 +2009,13 @@ card_connected:;
                         }
 
                         next = static_cast<signed char>(m_cursorChoice + 1);
+                        goto do_switch_go4;
                     }
                 }
             }
 
+            next = 0;
+        do_switch_go4:
             switch (next) {
             case 1:
                 SetGoOutMode(5);


### PR DESCRIPTION
## Summary
Raises `main/goout` fuzzy match from **91.67%** to **92.16%** by recovering the original's late-initialization control-flow idiom in the cursor-dispatch blocks of three functions.

## What changed
All four `CGoOutMenu` calc functions reuse the same deferred-dispatch pattern: a cursor `next` selector is conditionally set inside a `state == 1` input-handling block (which spans `GetGoOutInputMask`/`Sound.PlaySe` calls), then read by a `switch (next)`. The source initialized `next = 0` at the top of the block, which forced the value to stay live across the calls — so mwcc promoted it to a callee-saved register.

Restructured so the success path sets `next` and jumps (`goto`) straight to the switch, while every other path falls through to a single `next = 0` placed immediately before the switch. The selector then never spans a call and mwcc keeps it in a volatile register, matching the original's block order and register usage.

- **CalcDel** 94.28 -> 95.57: this also shrank the frame from `0x20` to `0x10` (eliminated the spurious callee-saved `r29`), fixing the prologue and a cascade of register-window mismatches.
- **CalcGoOut** 87.59 -> 88.23 (4 cursor blocks).
- **Calc** 87.40 -> 87.66 (1 `nextMode` block).

## Evidence
| function | before | after |
|---|---|---|
| Calc | 87.40 | 87.66 |
| CalcGoOut | 87.59 | 88.23 |
| CalcDel | 94.28 | 95.57 |
| **unit** | **91.67** | **92.16** |

## Why this is plausible source
The `goto`-to-switch with a single fall-through default is a common hand-written C idiom and exactly reproduces the original's basic-block order (success branch sets the selector then jumps; all other paths share one default-init site before the dispatch). No fake symbols, addresses, or layout changes.

## Blocker (remaining walls, not pursued)
The bulk of the residual diff in Calc/CalcGoOut is the documented `this`/`MenuPcs` r30<->r31 coloring swap (mwcc assigns the more-frequently-used `MenuPcs` global to r31 in the original) and the inlined `GetGoOutInputMask` Pad-base register coloring. `SetMemCardError` (89.89%) is the switch-pivot-tree wall: mwcc selected a different balanced binary-search shape over the negative case values; case-body reordering regressed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)