### PR TITLE
wind: raise fuzzy match to 98.1% (cycle 2)

### DIFF
--- a/include/ffcc/wind.h
+++ b/include/ffcc/wind.h
@@ -4,9 +4,19 @@
 #include "types.h"
 #include <dolphin/mtx.h>
 
+struct WindObjectFlags
+{
+    u8 active : 1;
+    u8 secondary : 1;
+    u8 _unused : 6;
+};
+
 struct WindObject
 {
-    u8 flags;
+    union {
+        u8 flags;
+        WindObjectFlags flagBits;
+    };
     u8 _pad01[3];
     f32 centerX;
     f32 centerZ;
@@ -34,7 +44,10 @@ struct WindObject
 
 struct WindGrassObject
 {
-    u8 flags;
+    union {
+        u8 flags;
+        WindObjectFlags flagBits;
+    };
     u8 _pad01[3];
     Vec pos;
     s32 id;

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -208,7 +208,7 @@ inline int CWind::AddGrass(const Vec* pos)
         return -1;
     }
 
-    grass->flags = static_cast<u8>(__rlwimi(grass->flags, 1, 7, 24, 24));
+    grass->flagBits.active = 1;
     grass->pos = *pos;
 
     int id = m_nextGrassId;
@@ -317,7 +317,7 @@ found:
 	obj->type = 2;
 	float centerZ = pos->z;
 	float centerX = pos->x;
-	obj->flags = static_cast<u8>(__rlwimi(obj->flags, 1, 7, 24, 24));
+	obj->flagBits.active = 1;
 
 	int id = m_nextId;
 	m_nextId = id + 1;
@@ -404,7 +404,7 @@ found:
 	float centerZ = pos->z;
 	float minX = centerX - radius;
 	float minZ = centerZ - radius;
-	obj->flags = static_cast<u8>(__rlwimi(obj->flags, 1, 7, 24, 24));
+	obj->flagBits.active = 1;
 	float maxX = centerX + radius;
 	float maxZ = centerZ + radius;
 
@@ -464,7 +464,7 @@ found:
 	}
 
 	obj->type = 0;
-	obj->flags = static_cast<u8>(__rlwimi(obj->flags, 1, 7, 24, 24));
+	obj->flagBits.active = 1;
 
 	int id = m_nextId;
 	m_nextId = id + 1;
@@ -674,7 +674,7 @@ void CWind::Frame()
             if (obj->type == 2) {
                 obj->lifeTimer = obj->lifeTimer + 1;
                 if (obj->life <= obj->lifeTimer) {
-                    obj->flags = static_cast<u8>(__rlwimi(obj->flags, 0, 7, 24, 24));
+                    obj->flagBits.active = 0;
                     goto next;
                 }
 


### PR DESCRIPTION
## Summary
Raises `main/wind` from 97.99% to 98.09% by modeling the `WindObject`/`WindGrassObject` flags byte as a named bitfield and writing the active bit through a member instead of the `__rlwimi` intrinsic.

## What changed
- Added `WindObjectFlags` bitfield struct (1 byte, MSB-first: `active:1`, `secondary:1`, `_unused:6`) and wrapped the existing `u8 flags` field of both `WindObject` and `WindGrassObject` in an anonymous union with it. Struct size/layout is unchanged.
- Replaced all flag-bit manipulation `obj->flags = (u8)__rlwimi(obj->flags, v, 7, 24, 24)` with named writes `obj->flagBits.active = v` across `AddSphere`, `AddDiffuse`, `AddAmbient`, `AddGrass`, and the `Frame` expiry clear.

## Why this matches
The `__rlwimi` intrinsic forced the loaded flags byte and the bit constant into a swapped GPR pairing versus the target (e.g. AddSphere: target `lbz r6; rlwimi r6,r7; stb r6` vs ours `lbz r7; rlwimi r7,r6; stb r7`). A named bitfield-member write lets mwcc pick its own scratch registers, reproducing the target's `lbz/rlwimi/stb` pattern exactly. This is plausible original source: the FFCC code clearly treated these as flag bits.

## Evidence (before -> after)
- Unit `main/wind`: 97.99% -> 98.09%
- `AddAmbient`: 99.61% -> 100%
- `AddSphere`: 95.42% -> 95.68%
- `Frame`: 96.86% -> 96.99%
- No regression in the four other units that include `wind.h` (game 98.29, gobject 90.03, cflat_r2system 85.50, bonus_menu 71.81 — all unchanged); full build still 1242/1242 functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)