### PR TITLE
maphit: raise fuzzy match to 97.3% (cycle 3)

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -120,12 +120,11 @@ void CMapHit::Draw()
     GXSetVtxDesc(GX_VA_NRM, GX_DIRECT);
     GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
 
-    CMapIdGrp* mapIdGrps = MapMng.GetMapIdGrpArray();
     CMapHitFace* face = m_faces;
     int faceIndex = 0;
     while (faceIndex < m_faceCount) {
         if ((face->m_drawFlags & 1) == 0) {
-            const CMapIdGrp* mapIdGrp = mapIdGrps + face->m_groupIndex;
+            const CMapIdGrp* mapIdGrp = &MapMng.m_mapIdGrpArray[face->m_groupIndex];
             const GXColor colorABytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_primaryColor);
             const GXColor colorBBytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_secondaryColor);
 

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -120,8 +120,8 @@ void CMapHit::Draw()
     GXSetVtxDesc(GX_VA_NRM, GX_DIRECT);
     GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
 
-    CMapHitFace* face = m_faces;
     int faceIndex = 0;
+    CMapHitFace* face = m_faces;
     while (faceIndex < m_faceCount) {
         if ((face->m_drawFlags & 1) == 0) {
             const CMapIdGrp* mapIdGrp = &MapMng.m_mapIdGrpArray[face->m_groupIndex];


### PR DESCRIPTION
Raises main/maphit fuzzy match from 96.88% to 97.27% (+0.39).

## Changes (CMapHit::Draw)
- **Direct array member access** instead of a cached base pointer: replaced `MapMng.GetMapIdGrpArray()[idx]` with `&MapMng.m_mapIdGrpArray[idx]`. The helper returning a pointer made mwcc hoist the `MapMng + 0x14e8` array base into a callee-saved register (an extra saved GPR + a hoisted invariant). Direct member-array indexing makes mwcc recompute the `MapMng` base inside the loop and fold the array offset into the load displacement (`0x14ec`/`0x14f0`), matching the target. Draw 93.78% -> 96.60%.
- **Declaration order**: declare `faceIndex` before `face` so the face pointer is colored into r31 (matching the target's loop register assignment). Draw 96.60% -> 96.77%.

## Per-function
- Draw: 93.78% -> 96.77% (+2.99)
- Unit: 96.88% -> 97.27%

## Blocker (reported, not worked around)
- **CheckHitFaceCylinder (90.59%)** is walled on a +1 callee-saved GPR window shift (`stmw r15` vs target `stmw r16`); the whole register window is renumbered by one. Confirmed in cycle 2; fresh cycle-3 levers (signed-char `m_mode` compare, chained overlap-flag init, sharing the edge-path `PSVECScale`/`PSVECAdd` per the target's block structure) do not flip the allocation. Also a `...bss.0` base-CSE on `g_hit_cyl` vs the target's named symbol.
- Remaining Draw mismatches are GX write-gather FIFO inline scratch coloring (FIFO base r3 vs r4; color-byte register order) — register-allocation artifacts of the inlined GX macros, not steerable from plausible source.

These results are plausible original source: direct member-array access and natural local declaration order, no compiler-coaxing constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)