### PR TITLE
p_light: raise fuzzy match to 96.8% (cycle 3)

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -902,9 +902,9 @@ void CLightPcs::CBumpLight::MakeLightMap()
 
         Vec eye;
         Vec up;
-        eye.x = kLightZero;
-        eye.y = kLightZero;
         eye.z = kLightZero;
+        eye.y = kLightZero;
+        eye.x = kLightZero;
         up.x = kLightZero;
         up.y = kLightOne;
         up.z = kLightZero;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1115,6 +1115,7 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
     Mtx texMtx;
     Mtx out;
     Mtx nrm;
+    Mtx posOnly;
 
     if (mode != 0) {
         Vec pos;
@@ -1211,7 +1212,6 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
             PSMTXConcat(texMtx, nrm, m_bumpTexMtx0);
             PSMTXScale(texMtx, kBumpTexMtxScale, kBumpTexMtxScale, kBumpTexMtxScale);
             PSMTXConcat(m_bumpTexMtx0, texMtx, m_bumpTexMtx0);
-            Mtx posOnly;
             PSMTXCopy(out, posOnly);
             posOnly[0][3] = kLightZero;
             posOnly[1][3] = kLightZero;
@@ -1229,26 +1229,26 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
             PSMTXIdentity(reinterpret_cast<float(*)[4]>(m_bumpTexScratch));
             float* scratch = m_bumpTexScratch;
 
-            float f0 = kBumpTexScrollScale;
-            float f1 = kLightZero;
+            float scrollScale = kBumpTexScrollScale;
+            float zero = kLightZero;
             scratch[0] = kBumpTexScrollScale;
-            float f2 = kLightHalf;
-            scratch[6] = f0;
-            float f3 = kBumpTexMtxScale;
-            scratch[10] = f1;
-            scratch[5] = f1;
-            scratch[9] = f1;
+            float half = kLightHalf;
+            scratch[6] = scrollScale;
+            float mtxScale = kBumpTexMtxScale;
+            scratch[10] = zero;
+            scratch[5] = zero;
+            scratch[9] = zero;
             scratch[3] =
-                -(f0 * (camX + bump->m_offsetX) - f2);
+                -(scrollScale * (camX + bump->m_offsetX) - half);
             scratch[7] =
-                -(f0 * (camZ + bump->m_offsetZ) - f2);
-            scratch[11] = f1;
-            scratch[16] = f3;
-            scratch[12] = f3;
-            scratch[17] = f1;
-            scratch[15] = f1;
-            scratch[14] = f1;
-            scratch[13] = f1;
+                -(scrollScale * (camZ + bump->m_offsetZ) - half);
+            scratch[11] = zero;
+            scratch[16] = mtxScale;
+            scratch[12] = mtxScale;
+            scratch[17] = zero;
+            scratch[15] = zero;
+            scratch[14] = zero;
+            scratch[13] = zero;
         }
     }
 }

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1140,11 +1140,11 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
             yAxis.y = cam[1][1];
             yAxis.z = cam[2][1];
             PSVECNormalize(&yAxis, &yAxis);
-            xAxis.y = -yAxis.x;
             cam[0][1] = yAxis.x;
             cam[1][1] = yAxis.y;
             cam[2][1] = yAxis.z;
             xAxis.x = yAxis.y;
+            xAxis.y = -yAxis.x;
             xAxis.z = kLightZero;
             PSVECNormalize(&xAxis, &xAxis);
             cam[0][0] = xAxis.x;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -865,9 +865,9 @@ void CLightPcs::CBumpLight::MakeLightMap()
     _GXColor chanMat2;
 
     unsigned char u0 = m_bumpShade[0];
-    unsigned char u1 = m_bumpShade[1];
-    unsigned char u2 = m_bumpShade[2];
-    unsigned char u3 = m_bumpShade[3];
+    signed char u1 = m_bumpShade[1];
+    signed char u2 = m_bumpShade[2];
+    signed char u3 = m_bumpShade[3];
 
     chanAmb.a = u0;
     chanAmb.b = u0;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -378,7 +378,7 @@ CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs
     CBumpLight* bumpLight = GetFreeBumpLight(target);
 
     if (bumpLight == 0) {
-        if (static_cast<unsigned int>(System.m_execParam) >= 1) {
+        if (static_cast<int>(System.m_execParam) >= 1) {
             System.Printf(const_cast<char*>(sLightTextureFullMsg));
         }
         return 0;


### PR DESCRIPTION
Raises main/p_light fuzzy match from 96.71% to 96.81% (cycle 3).

## Changes (per-function gains)
- **SetBumpTexMatirx** 98.87% -> 99.08%: reordered mode==2 axis writes (cam[*][1] / xAxis.x / xAxis.y) to match the target's store sequence; hoisted `posOnly` Mtx to function scope so the else-branch `tmp` matrix claims the target's stack slot (0x50 vs 0x80).
- **AddBump** 97.56% -> 97.95%: signed compare on the `execParam` full-texture guard (`(int)System.m_execParam >= 1`) — matches the target's `cmpwi`.
- **CBumpLight::MakeLightMap** 92.86% -> 93.07%: typed the per-channel shade temporaries as `signed char`; reversed the eye-vector zero-init order (z,y,x) to match the store sequence.

## What worked
Statement/field-write reordering to match mwcc's source-order store emission (R9), function-scope hoisting to control stack-slot coloring, and permute-discovered signedness fixes (signed char shade temps, signed execParam compare).

## Blockers (walls, confirmed not source-steerable)
- `__sinit_p_light_cpp` ...data.0 base-CSE (documented WALL, skipped).
- **destroy / Add / AddBump / DestroyBumpLightAll / CLightPcs::MakeLightMap**: a consistent `this`-pointer coloring where the original keeps `this` as a cursor and folds the `m_bumpLights` base (0x1c3c) into field offsets, plus an off-by-one callee-saved register window. Cursor/index/two-pointer rewrites all regressed.
- **CBumpLight::MakeLightMap inner loop**: the u32->float bias must reference the named `kLightU32ToDoubleBias` (target) but mwcc's built-in cast emits an anonymous `@N` literal; routing through a `U32ToFloat` helper names the bias but adds a stack slot that shifts GXLightObj (net-negative). The loop-constant FPR cluster assignment direction (f26..f31) is allocator-driven and not reliably source-steerable.

All gains verified net-positive on the objdiff report; data % unchanged (97.29%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)