### PR TITLE
memory: raise fuzzy match to 95.9% (cycle 3)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1984,11 +1984,7 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
         }
 
         if (currentSize != 0) {
-            currentSize -= size / 2;
-            if (currentSize < 0) {
-                currentSize = 0;
-            }
-            continue;
+            goto shrink;
         }
 
         if (bestPriority != 0xFFFFFFFF) {
@@ -2018,6 +2014,13 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
                 System.Printf(const_cast<char*>(sAmemCacheSeparator));
             }
             m_rStage->heapWalker(-1, nullptr, static_cast<unsigned long>(-1));
+        }
+        continue;
+
+    shrink:
+        currentSize -= size / 2;
+        if (currentSize < 0) {
+            currentSize = 0;
         }
     }
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1988,8 +1988,7 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
         }
 
         if (bestPriority != 0xFFFFFFFF) {
-            bestPriority = 0xFFFFFFFF;
-            continue;
+            goto dropPriority;
         }
 
         if (m_releaseAction == 0 || m_releaseAction(m_releaseActionArg) == 0) {
@@ -2015,6 +2014,10 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
             }
             m_rStage->heapWalker(-1, nullptr, static_cast<unsigned long>(-1));
         }
+        continue;
+
+    dropPriority:
+        bestPriority = 0xFFFFFFFF;
         continue;
 
     shrink:

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1922,14 +1922,16 @@ void CAmemCacheSet::Release(short index)
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt));
         }
 
+        int offset = 0;
         for (int i = 0; i < m_cacheCount; i++) {
-            CAmemCache& cache = cacheEntryAt(this, i);
+            CAmemCache& cache = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
             if (((cache.m_inUse != 0) || (cache.m_cacheData != 0)) && (static_cast<unsigned int>(System.m_execParam) >= 3)) {
                 System.Printf(
                     const_cast<char*>(sAmemCacheEntryFmt), i, cacheStateName(cache),
                     cacheTypeName(cache), cache.m_refCount,
                     cache.m_priority, reinterpret_cast<int>(cache.m_cacheData));
             }
+            offset += sizeof(CAmemCache);
         }
 
         if (static_cast<unsigned int>(System.m_execParam) >= 3) {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -213,7 +213,7 @@ static inline int stageHasUnfreedBlocks(CMemory::CStage* stage)
 
 static inline void stageReleaseMode2Buffer(CMemory::CStage* stage)
 {
-    int ptr = stageGetHeapHead(stage);
+    unsigned int ptr = static_cast<unsigned int>(stageGetHeapHead(stage));
     if (ptr != 0) {
         if (ptr != 0x10) {
             operator delete[](reinterpret_cast<void*>(ptr - 0x10));

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -222,14 +222,14 @@ static inline void stageReleaseMode2Buffer(CMemory::CStage* stage)
     }
 }
 
-static inline void stageDestroyAndPool(CMemory* memory, CMemory::CStage* stage)
+static inline void stageDestroyAndPool(CMemory* memory, CMemory::CStage* stage, const char* strBase)
 {
     int mode = stageGetAllocationMode(stage);
     CMemory::CMode& modeData = memory->Mode(mode);
 
     if (mode != 2) {
         if (stageHasUnfreedBlocks(stage)) {
-            System.Printf(const_cast<char*>(sStageQuitBlockUnfreedAllocFmt), stageGetSourceName(stage));
+            System.Printf(const_cast<char*>(strBase + 0x5d4), stageGetSourceName(stage));
             stage->heapWalker(-1, nullptr, static_cast<unsigned long>(-1));
         }
     } else {
@@ -423,7 +423,7 @@ void CMemory::Quit()
 {
     const char* strBase = reinterpret_cast<const char*>(sHeapBarColors);
 
-    stageDestroyAndPool(this, m_mainMemoryStage);
+    stageDestroyAndPool(this, m_mainMemoryStage, strBase);
 
     CMode* modeData = m_modes;
     for (int pass = 0; pass < 3; pass++, modeData++) {
@@ -436,18 +436,18 @@ void CMemory::Quit()
                 if (pass == 0) {
                     if (stage != m_currentMemoryStage) {
                         System.Printf(const_cast<char*>(strBase + 0x7b0), stage->m_allocationSourceStr);
-                        stageDestroyAndPool(this, stage);
+                        stageDestroyAndPool(this, stage, strBase);
                     }
                 } else {
                     System.Printf(const_cast<char*>(strBase + 0x7b0), stage->m_allocationSourceStr);
-                    stageDestroyAndPool(this, stage);
+                    stageDestroyAndPool(this, stage, strBase);
                 }
                 stage = next;
             }
         }
     }
 
-    stageDestroyAndPool(this, m_currentMemoryStage);
+    stageDestroyAndPool(this, m_currentMemoryStage, strBase);
 }
 
 /*

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2002,14 +2002,16 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
                 System.Printf(const_cast<char*>(strBase + 0x4c));
             }
 
-            for (unsigned int i = 0; i < m_cacheCount; i++) {
-                CAmemCache& entry = cacheEntryAt(this, i);
-                if (((entry.m_inUse != 0) || (entry.m_cacheData != 0)) && (static_cast<int>(System.m_execParam) >= 3)) {
+            int offset2 = 0;
+            for (int i = 0; i < m_cacheCount; i++) {
+                CAmemCache& entry = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset2);
+                if (((entry.m_inUse != 0) || (entry.m_cacheData != 0)) && (static_cast<unsigned int>(System.m_execParam) >= 3)) {
                     System.Printf(
                         const_cast<char*>(strBase + 0xd8), i, cacheStateName(entry),
                         cacheTypeName(entry), entry.m_refCount, entry.m_priority,
                         reinterpret_cast<int>(entry.m_cacheData));
                 }
+                offset2 += sizeof(CAmemCache);
             }
 
             if (static_cast<unsigned int>(System.m_execParam) >= 3) {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -609,7 +609,8 @@ CMemory::CStage* CMemory::CreateStage(unsigned long size, char* source, int mode
     }
 
     {
-        unsigned int alignedSize = (size + 0x3F) & ~0x3FU;
+        size = (size + 0x3F) & ~0x3FU;
+        unsigned int alignedSize = static_cast<unsigned int>(size);
         CMode& modeData = m_modes[mode];
         CStage* stage = modeData.m_freeList.m_next;
         CStage* list = &modeData.m_activeList;


### PR DESCRIPTION
Raises main/memory fuzzy match from 95.52% to 95.94% (+0.42) via source-level matching of register allocation and control-flow block order.

## Per-function gains
- AmemFreeLowPrio: 91.71% -> 96.21% (byte-offset diag-loop cursor; unsigned execParam compare; emit currentSize-shrink and dropPriority blocks last to match the target's late block emission via goto/labels)
- CreateStage: 97.19% -> 97.30% (reuse the size local for the aligned size so it colors into the same callee-saved register r27 as the target)
- Quit: 93.17% -> 94.63% (thread strBase into stageDestroyAndPool so the pooled format string sStageQuitBlockUnfreedAllocFmt resolves as strBase+0x5d4, matching the target's CSE off sHeapBarColors; verified offsets against symbols.txt: 0x801D6A7C - 0x801D64A8 = 0x5D4)
- Quit (cont.): unsigned heap-head pointer in stageReleaseMode2Buffer (cmplwi vs cmpwi)
- Release: 96.24% -> 96.29% (byte-offset diag-loop cursor)

## What worked
- R14 goto/label block reordering: the biggest single lever (AmemFreeLowPrio +4.5) - the target emits the loop's shrink/priority-drop blocks physically last, reachable only via forward goto.
- R12 byte-offset array iteration for diagnostic loops.
- Threading a shared string base into an inlined helper so pooled format strings CSE off it (data layout confirmed against symbols.txt).
- Register-coloring via local reuse (CreateStage size/alignedSize).
- Signedness fixes (unsigned heap-head ptr).

## Blockers (walls, left as-is)
- CheckSum / SetData: counted CTR loop (mtctr/bdnz) the manual do/while can't reproduce - prompt-flagged wall.
- heapWalker: uniform callee-saved register renumbering.
- alloc: entire diff is a uniform off-by-one callee-saved register window shift rooted in mwcc's param coloring (size->r30 vs target r24); local-reuse attempts regressed.
- AddRef / GetData / drawHeapBar: register-window shifts; the target re-reads m_cacheTable[index] forming a full base+offset pointer where our source emits indexed lhzx/sthx.
- Frame: port=0 constant-fold artifact (andc vs nor+andi.) not source-steerable.
- Init: extern-array null-check (file != nullptr) fails to fold for the inlined operator new[] even though the address is a known-non-null constant.
- GetHeapUnuse: target has a dead address-gap accumulator that mwcc DCEs in our source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)