### PR TITLE
p_camera: raise fuzzy match to 88.1% (cycle 4)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1285,9 +1285,9 @@ void CCameraPcs::calcMap()
     DirectionVec().z = kCameraOneF;
     PSMTXMultVecSR(rotMtx, &DirectionVec(), &DirectionVec());
 
-    moveDelta.x = kCameraZeroF;
-    moveDelta.y = kCameraZeroF;
     moveDelta.z = kCameraZeroF;
+    moveDelta.y = kCameraZeroF;
+    moveDelta.x = kCameraZeroF;
 
     if ((buttons & 0x100) != 0) {
         PSVECScale(&moveDelta, &DirectionVec(), kCameraDebugMoveStep);
@@ -1306,23 +1306,23 @@ void CCameraPcs::calcMap()
     }
 
     if ((buttons & 0x1) != 0) {
-        sideVec.x = kCameraDebugMoveStep;
         sideVec.y = kCameraZeroF;
         sideVec.z = kCameraZeroF;
+        sideVec.x = kCameraDebugMoveStep;
         PSMTXMultVecSR(rotMtx, &sideVec, &sideVec);
         sideVec.y = kCameraZeroF;
         PSVECAdd(&moveDelta, &moveDelta, &sideVec);
     } else if ((buttons & 0x2) != 0) {
-        sideVec.x = kCameraNegativeDebugMoveStep;
         sideVec.y = kCameraZeroF;
         sideVec.z = kCameraZeroF;
+        sideVec.x = kCameraNegativeDebugMoveStep;
         PSMTXMultVecSR(rotMtx, &sideVec, &sideVec);
         sideVec.y = kCameraZeroF;
         PSVECAdd(&moveDelta, &moveDelta, &sideVec);
     }
 
     if ((moveDelta.x != kCameraZeroF) || (moveDelta.y != kCameraZeroF) || (moveDelta.z != kCameraZeroF)) {
-        for (i = 0; i < 4; i++) {
+        for (i = 4; i != 0; i--) {
             hitCylinder.m_min.x = kCameraBoundsMinInitial;
             hitCylinder.m_min.y = kCameraBoundsMinInitial;
             hitCylinder.m_min.z = kCameraBoundsMinInitial;
@@ -1331,13 +1331,14 @@ void CCameraPcs::calcMap()
             hitCylinder.m_max.z = kCameraBoundsMaxInitial;
             hitCylinder.m_radius = kCameraDefaultNearZ;
             hitCylinder.m_bottom = PositionVec();
-            if (MapMng.CheckHitCylinder(reinterpret_cast<CMapCylinder*>(&hitCylinder), &moveDelta, 0xFFFFFFFF) == 0) {
+            if (MapMng.CheckHitCylinder(reinterpret_cast<CMapCylinder*>(&hitCylinder), &moveDelta, 0xFFFFFFFF) != 0) {
+                MapMng.m_hitMapObj->CalcHitSlide(&moveDelta, kCameraTwoF);
+            } else {
                 PositionVec().x += moveDelta.x;
                 PositionVec().y += moveDelta.y;
                 PositionVec().z += moveDelta.z;
                 break;
             }
-            MapMng.m_hitMapObj->CalcHitSlide(&moveDelta, kCameraTwoF);
         }
     }
 
@@ -1441,8 +1442,6 @@ void CCameraPcs::createFullShadow()
  */
 void CCameraPcs::destroyFullShadow()
 {
-    unsigned char* self = reinterpret_cast<unsigned char*>(this);
-
     if (m_fullScreenShadow.m_shadowTexture != 0) {
         delete static_cast<u8*>(m_fullScreenShadow.m_shadowTexture);
         m_fullScreenShadow.m_shadowTexture = 0;


### PR DESCRIPTION
## Summary
Raises `main/p_camera` fuzzy match from **88.04%** to **88.12%** (+0.081).

## What changed (calcMap, 89.20% -> 90.24%)
- **Vec component store ordering**: `moveDelta` zero-init reordered to z,y,x and `sideVec` init reordered to y,z,x to match the target's stack-store sequence.
- **Debug move loop restructured**: the 4-iteration collision-resolve loop now counts down (`for (i = 4; i != 0; i--)`) and the `CheckHitCylinder` arms are ordered hit-then-miss (`!= 0` body first, miss path in the `else` with the break). This matches the target's `cmpwi/subi/bne` countdown counter and basic-block emission order (R9/R14), converting a large run of branch/INS-DEL mismatches to a clean match.

## Why this is plausible source
The reorderings are pure statement-order changes with identical semantics; the countdown loop and hit-first/miss-second branch structure are exactly the control flow the shipped binary emits.

## Investigated but blocked (register-allocation / layout walls, left unchanged)
- **createFullShadow (60.3%)**: the 8x-unrolled ramp-texture index loop is a register-allocation wall (target keeps the counter in r3 + only 3 callee-saved GPRs; ours spills to r27/r28). Prologue caching of `&MapMng`/`&s_p_camera_cpp` and uniform index formulas all net-regressed; permuter found no improvement.
- **calc (81.5%)**: the documented `this`/`&Pad` callee-saved register swap (r30<->r31) cascades through the whole function.
- **draw (93.6%)**: analogous `this`/`&g_shadow_pos` register swap + larger target frame.
- **drawShadowBegin / drawShadowEndAll**: struct-copy word/float ordering walls inside `CameraState` `dst = src`; fixable only by shared-header layout changes (disallowed).
- **__sinit**: documented dead-end `...data.0` base-CSE wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)