### PR TITLE
graphic: raise fuzzy match to 95.5% (cycle 3)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1615,13 +1615,13 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 
 	nearAlpha = 0;
 	farAlpha = 0;
-	hasNearAlpha = 0;
-	hasFarAlpha = 0;
 	texBufferSize = GXGetTexBufferSize(0x140, 0xE0, GX_TF_RGBA8, GX_FALSE, GX_FALSE);
 
 	cameraPos.x = CameraWorldX();
 	cameraPos.z = CameraWorldZ();
+	hasNearAlpha = 0;
 	cameraPos.y = kGraphicZeroF;
+	hasFarAlpha = 0;
 
 	targetPos.y = kGraphicZeroF;
 	PSVECSubtract(&targetPos, &cameraPos, &cameraToTarget);

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1636,7 +1636,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		          gxViewport, &projX, &projY, &projZ);
 
 		depthAlphaNear = static_cast<unsigned int>(projZ * 16777215.0f) >> 16;
-		if (depthAlphaNear > 0xFF) {
+		if (depthAlphaNear >= 0xFF) {
 			depthAlphaNear = 0xFF;
 		}
 		nearAlpha = (signed char)depthAlphaNear;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1589,7 +1589,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	unsigned int texBufferSize;
 	unsigned int depthAlphaNear;
 	unsigned int depthAlphaFar;
-	unsigned char nearAlpha;
+	signed char nearAlpha;
 	unsigned char farAlpha;
 	float xOffset;
 	float yOffset;
@@ -1663,7 +1663,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		if (depthAlphaFar > 0xFF) {
 			depthAlphaFar = 0xFF;
 		}
-		farAlpha = (unsigned char)depthAlphaFar;
+		farAlpha = (signed char)depthAlphaFar;
 		hasFarAlpha = 1;
 	}
 
@@ -1687,7 +1687,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	for (int pass = 0; pass < 2; pass++) {
 		int kColorSel = 0x0C;
 		int kAlphaSel = 0x1C;
-		unsigned char passAlpha = nearAlpha;
+		signed char passAlpha = nearAlpha;
 
 		if ((pass == 0) && !((mode != 2) && hasNearAlpha && (mode != 1) && hasFarAlpha)) {
 			continue;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1958,7 +1958,7 @@ void CGraphic::RenderBlur(int unused0, unsigned char mode, unsigned char unused2
     int blurOffsetInt = offset;
     int textureOffset = 0;
     for (int i = 0; i < static_cast<int>(m_blurTextureCount); i++) {
-        unsigned int negativeBlurOffset = -blurOffsetInt;
+        int negativeBlurOffset = -blurOffsetInt;
         u8* textureBase = reinterpret_cast<u8*>(m_savedFrameBuffer) + textureOffset;
         GXInitTexObj(&texObj, textureBase, 0x140, 0xE0, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
         GXInitTexObjLOD(&texObj, GX_LINEAR, GX_LINEAR, 0.0f, 0.0f, 0.0f, GX_FALSE, GX_FALSE, GX_ANISO_1);

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1660,7 +1660,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		if (depthAlphaFar == 0) {
 			depthAlphaFar = 0xFF;
 		}
-		if (depthAlphaFar > 0xFF) {
+		if (depthAlphaFar >= 0xFF) {
 			depthAlphaFar = 0xFF;
 		}
 		farAlpha = (signed char)depthAlphaFar;
@@ -1675,8 +1675,8 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	}
 
 	gUtil.SetVtxFmt_POS_CLR_TEX();
-	Graphic.CreateSmallBackTexture(Graphic.m_scratchTextureBuffer, &smallBackTex, 0x140, 0xE0, GX_NEAR, GX_TF_RGBA8, 0);
-	Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backBufferTex, 0, 0, 0x280, 0x1C0, texBufferSize, GX_NEAR,
+	Graphic.CreateSmallBackTexture(Graphic.m_scratchTextureBuffer, &smallBackTex, 0x140, 0xE0, GX_LINEAR, GX_TF_RGBA8, 0);
+	Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backBufferTex, 0, 0, 0x280, 0x1C0, texBufferSize, GX_LINEAR,
 	                   (_GXTexFmt)0x11, 0);
 	gUtil.SetVtxFmt_POS_CLR_TEX0_TEX1();
 	gUtil.SetOrthoEnv();

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -534,6 +534,7 @@ void CGraphic::Thread()
                 }
 
                 CSystem::COrder* order = System.GetOrder(drawSyncPart >> 8);
+                int drawSyncByte = static_cast<int>(static_cast<char>(drawSyncPart));
                 int orderIndex;
                 if (order != nullptr) {
                     orderIndex = order->m_insertIndex;
@@ -547,7 +548,7 @@ void CGraphic::Thread()
                     orderName = sGraphicUnknownOrderName;
                 }
                 System.Printf(debugFmtBase + kGraphicCppDrawDoneFmt, m_drawDoneFile, m_drawDoneLine, orderName, orderIndex,
-                              static_cast<int>(static_cast<char>(drawSyncPart)));
+                              drawSyncByte);
             }
         } else {
             debugCountdown = 5;


### PR DESCRIPTION
Raises main/graphic fuzzy match from 94.97% to 95.50% (+0.53) via source-level fixes.

## Changes
- **RenderDOF GX_LINEAR** (90.8 -> 93.3): the DOF small-back-texture and back-buffer-rect copies use GX_LINEAR, not GX_NEAR. The target asm passes filter=1 for both CreateSmallBackTexture and GetBackBufferRect2. Real behavioral correction.
- **RenderDOF alpha signedness** (permuter): nearAlpha and passAlpha are signed char (matching the existing `(signed char)` cast on the depth-alpha value); farAlpha cast to signed char.
- **RenderDOF deferred inits**: hasNearAlpha/hasFarAlpha zero-inits emitted after the camera-position setup, matching the target's interleaving past GXGetTexBufferSize.
- **RenderDOF clamp polarity**: near/far depth-alpha clamps use `>= 0xFF` (the value maxes at 0xFF, so identical behavior; matches the target's `blt`).
- **RenderBlur signedness** (97.2 -> 99.3, permuter): negativeBlurOffset is a plain int, not unsigned.
- **Thread drawSyncByte hoist** (89.1 -> 89.4): the `(char)drawSyncPart` Printf argument is computed into a named local right after GetOrder, matching the target keeping it live in a callee-saved register across the order branches.

## Blockers (walls, left as-is)
- makeSphere (80%), SetFog (86%), SetCopyClear (87%), GetBackBufferRect/Rect2, Thread tail: register-window / frame-layout / struct-copy-interleave / sGraphicUnknownOrderName@sda21 walls. Permuter and targeted reorderings found no further net gain. RenderDOF's residual gap is a +4/+0x44 stack-frame-layout shift that pervades the body and is not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)