### PR TITLE
joybus: raise fuzzy match to 89.0% (cycle 6)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -529,7 +529,7 @@ config.libs = [
             Object(NonMatching, "graphic.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "gxfunc.cpp"),
             Object(NonMatching, "itemobj.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
-            Object(NonMatching, "joybus.cpp"),
+            Object(NonMatching, "joybus.cpp", extra_cflags=["-inline auto,deferred"]),
             Object(Matching, "KeLns.cpp"),
             Object(NonMatching, "LocationTitle2.cpp"),
             Object(NonMatching, "main.cpp"),

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -8113,7 +8113,7 @@ unsigned short JoyBus::Crc16(int len, unsigned char* data, unsigned short* crc)
 loop:
     idx = *crc;
     hi = idx << 8;
-    idx = (unsigned int)((int)idx >> 8);
+    idx = (unsigned int)((int)(short)idx >> 8);
     idx = (unsigned char)idx;
     idx = idx ^ (unsigned int)*data;
     data = data + 1;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3800,11 +3800,11 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
     OSSignalSemaphore(&m_accessSemaphores[port]);
 
-    if ((static_cast<unsigned char>(localWord >> 24) & 0x3F) == 7)
+    if ((*reinterpret_cast<unsigned char*>(&localWord) & 0x3F) == 7)
     {
         step = 0;
-        phase = 0;
         blockIndex = 0;
+        phase = 0;
         localWord = 0;
 
         ResetQueue(threadParam);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3864,9 +3864,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
     {
         if (step == 0)
         {
-            signed char type = sendType;
-
-            if (type != 3 && type != 2 && type != 6 && type != 7 && type != 8 && type != 9)
+            if ((signed char)sendType != 3 && (signed char)sendType != 2 && (signed char)sendType != 6 && (signed char)sendType != 7 && (signed char)sendType != 8 && (signed char)sendType != 9)
             {
                 GbaQue.IsSingleMode(threadParam->m_portIndex);
 
@@ -3902,13 +3900,13 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
                 m_ctrlModeArr[port] = 0;
             }
 
-            if (type == 0)
+            if ((signed char)sendType == 0)
             {
                 dataBase = reinterpret_cast<unsigned char*>(m_fileBaseA);
                 dataPtr = dataBase;
                 totalSize = static_cast<unsigned short>(m_fileBaseA_dup);
             }
-            else if (type == 1)
+            else if ((signed char)sendType == 1)
             {
                 dataBase = reinterpret_cast<unsigned char*>(m_fileBaseB);
                 dataPtr = dataBase;
@@ -3916,7 +3914,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             }
             else
             {
-                if (type != 3 && type != 2 && type != 6 && type != 7 && type != 8 && type != 9)
+                if ((signed char)sendType != 3 && (signed char)sendType != 2 && (signed char)sendType != 6 && (signed char)sendType != 7 && (signed char)sendType != 8 && (signed char)sendType != 9)
                 {
                     if (System.m_execParam != 0)
                     {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3940,21 +3940,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             blockCount = blocks;
 
             unsigned short crcAcc = 0xFFFF;
-            unsigned char* p = dataBase;
-            unsigned int count = size;
-
-            while (static_cast<int>(count) > 0)
-            {
-                unsigned char b = *p++;
-                count--;
-
-                crcAcc = static_cast<unsigned short>(
-                    (crcAcc << 8) ^
-                    JoyBusCrcTable[(crcAcc >> 8) ^ b]
-                );
-            }
-
-            crc = static_cast<unsigned short>(~crcAcc);
+            crc = Crc16(size, dataBase, &crcAcc);
 
             unsigned int word =
                 (static_cast<unsigned int>(0x0B) << 24) |
@@ -4034,21 +4020,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
         else
         {
             unsigned short crcAcc = 0xFFFF;
-            unsigned char* p = dataBase;
-            unsigned int count = chunkSize;
-
-            while (static_cast<int>(count) > 0)
-            {
-                unsigned char b = *p++;
-                count--;
-
-                crcAcc = static_cast<unsigned short>(
-                    (crcAcc << 8) ^
-                    JoyBusCrcTable[(crcAcc >> 8) ^ b]
-                );
-            }
-
-            unsigned short crcChunk = static_cast<unsigned short>(~crcAcc);
+            unsigned short crcChunk = Crc16(chunkSize, dataBase, &crcAcc);
 
             unsigned int word =
                 (static_cast<unsigned int>(0x0B00) << 16) |
@@ -4156,21 +4128,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
         else
         {
             unsigned short crcAcc = 0xFFFF;
-            unsigned char* p = dataPtr;
-            unsigned int count = chunkSize;
-
-            while (static_cast<int>(count) > 0)
-            {
-                unsigned char b = *p++;
-                count--;
-
-                crcAcc = static_cast<unsigned short>(
-                    (crcAcc << 8) ^
-                    JoyBusCrcTable[(crcAcc >> 8) ^ b]
-                );
-            }
-
-            unsigned short crcChunk = static_cast<unsigned short>(~crcAcc);
+            unsigned short crcChunk = Crc16(chunkSize, dataPtr, &crcAcc);
 
             unsigned int word =
                 (static_cast<unsigned int>(0x4B) << 24) |


### PR DESCRIPTION
Raises main/joybus fuzzy match from 88.16% to 89.05% (cycle 6), focused on SendDataFile (60.78% -> 74.64%).

## What changed
- **Crc16 helper in SendDataFile**: the three inline CRC loops were replaced with calls to the existing `JoyBus::Crc16` helper, matching the original which factored the CRC out. This stopped mwcc from auto-unrolling the loop 4x (the helper keeps the accumulator pointer-resident), eliminating large INSERT runs. Biggest single win (+8.5% on the function).
- **Deferred inlining** (`-inline auto,deferred` on joybus.cpp): lets mwcc inline `Crc16` (defined later in the file) into SendDataFile, matching the target which emits the CRC loop body inline rather than a `bl`.
- **Signed-shift CRC accumulator**: the accumulator `>> 8` is a signed shift in the original (`srawi`); modeled it so the inlined loop matches.
- **sendType reload**: removed the cached `signed char type` local; the original reloads `temp[0]` at each dispatch test instead of pinning it in a callee-saved register.
- **localWord type byte read + reset store order**: read the command type via the first byte of `localWord` (`& 0x3F`) instead of recomputing `>> 24`, and reordered the reset stores (step, blockIndex, phase) to match the target's emission order.

## Evidence
- main/joybus: 88.16% -> 89.05% fuzzy.
- SendDataFile: 60.78% -> 74.64%.
- No other function regressed; net +0.89% on the unit.

## Plausibility
All changes reflect the original source shape recovered from the DOL/Ghidra: SendDataFile called a shared `Crc16(len, data, &crc)` routine (its own DOL symbol), composed commands from reloaded `temp` fields, and used a signed CRC accumulator. The deferred-inline flag matches the inlining behavior other objects in the project already use.

## Blocker (remaining ~25% on SendDataFile)
- **Callee-saved register-window**: ours saves r26-r31 (6) vs target r27-r31 (5) because `port` is pinned in a callee-saved reg. Decaching `port` fixes the count but shifts the whole allocation +1 (this->r28 vs r27), netting worse. Classic coloring wall.
- **Byteswap-struct command-word assembly**: the original builds each joybus command word as a packed byte struct on the stack with `lhbrx` byteswaps, then loads it as a word; ours uses register shift/OR. Matching this is a pervasive rewrite across ~8 word-building sites with high regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)