### PR TITLE
gobject: raise fuzzy match to 90.2% (cycle 6)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1627,7 +1627,7 @@ void CGObject::update()
             m_weaponNodeFlagBits.m_unk20 = 0;
         }
         m_weaponNodeFlagBits.m_unk40 =
-            (static_cast<s32>(static_cast<u32>(weaponFlagsLo) << 25 | static_cast<u32>(weaponFlagsLo) >> 7) |
+            (static_cast<s32>(static_cast<s32>(weaponFlagsLo) << 25 | static_cast<u32>(weaponFlagsLo) >> 7) |
              static_cast<s32>(static_cast<u32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6)) < 0;
 
         if ((m_displayFlags & 1) != 0) {
@@ -1643,7 +1643,7 @@ void CGObject::update()
 
             ModelLightAlpha(m_charaModelHandle->m_model) = m_lookAtTimer;
             m_charaModelHandle->m_model->m_flagsA0Bits.m_flagA0_20 =
-                static_cast<s32>(static_cast<u32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0;
+                static_cast<s32>(static_cast<s32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0;
             m_charaModelHandle->m_model->m_flagsA0Bits.m_flagA0_80 = (m_displayFlags & 0x20) != 0;
         }
 
@@ -1682,7 +1682,7 @@ void CGObject::update()
             if (activeAnimIndex >= 0 && m_charaModelHandle->m_animSlot[activeAnimIndex] != 0) {
                 unsigned char* animRefBytes =
                     reinterpret_cast<unsigned char*>(m_charaModelHandle->m_animSlot[activeAnimIndex]);
-                const short pointCount = *reinterpret_cast<short*>(animRefBytes + 0x2C);
+                const unsigned short pointCount = *reinterpret_cast<short*>(animRefBytes + 0x2C);
                 if (pointCount > 0) {
                     const float animSpan =
                         sAnimFrameOffset + (ModelAnimEnd(m_charaModelHandle->m_model) - ModelAnimStart(m_charaModelHandle->m_model));
@@ -1775,7 +1775,7 @@ void CGObject::update()
 
             ModelLightAlpha(m_weaponModelHandle->m_model) = m_lookAtTimer;
             m_weaponModelHandle->m_model->m_flagsA0Bits.m_flagA0_20 =
-                static_cast<s32>(static_cast<u32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0;
+                static_cast<s32>(static_cast<s32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0;
             m_weaponModelHandle->m_model->m_flagsA0Bits.m_flagA0_80 = (m_displayFlags & 0x20) != 0;
         }
 
@@ -2501,7 +2501,7 @@ void CGObject::boundCheck()
         const float clipLimit = 2.0f;
 
         clipMask = 0x1F;
-        for (u32 i = 0; (clipMask != 0) && (i < 8); i++) {
+        for (s32 i = 0; (clipMask != 0) && (i < 8); i++) {
             clipCorner.x = m_worldPosition.x + (((i & 1) != 0) ? -m_nearColRadius : m_nearColRadius);
             clipCorner.y = m_worldPosition.y + (((i & 4) != 0) ? -m_nearColRadius : m_nearColRadius);
             clipCorner.z = m_worldPosition.z + (((i & 2) != 0) ? -m_nearColRadius : m_nearColRadius);

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1787,7 +1787,7 @@ void CGObject::update()
 
             ModelLightAlpha(m_shieldModelHandle->m_model) = m_lookAtTimer;
             m_shieldModelHandle->m_model->m_flagsA0Bits.m_flagA0_20 =
-                static_cast<s32>(static_cast<u32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0;
+                static_cast<s32>(static_cast<s32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0;
             m_shieldModelHandle->m_model->m_flagsA0Bits.m_flagA0_80 = (m_displayFlags & 0x20) != 0;
             if (static_cast<s32>(static_cast<u32>(weaponFlagsLo) << 26 | static_cast<u32>(weaponFlagsLo) >> 6) < 0) {
                 m_shieldModelHandle->m_model->CalcSkin();

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2019,7 +2019,7 @@ void CGObject::onDraw()
     }
 
     if (((CFlat.m_debugFlags & 0x40000) != 0) && ((m_bgColMask & 0x40000) != 0)) {
-        for (int i = 0; i < 8; i++) {
+        for (unsigned int i = 0; i < 8; i++) {
             AttackCol* collider = &m_attackColliders[i];
             if (*reinterpret_cast<int*>(&collider->m_localStart.x) == 0) {
                 continue;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1682,7 +1682,7 @@ void CGObject::update()
             if (activeAnimIndex >= 0 && m_charaModelHandle->m_animSlot[activeAnimIndex] != 0) {
                 unsigned char* animRefBytes =
                     reinterpret_cast<unsigned char*>(m_charaModelHandle->m_animSlot[activeAnimIndex]);
-                const unsigned short pointCount = *reinterpret_cast<unsigned short*>(animRefBytes + 0x2C);
+                const short pointCount = *reinterpret_cast<short*>(animRefBytes + 0x2C);
                 if (pointCount > 0) {
                     const float animSpan =
                         sAnimFrameOffset + (ModelAnimEnd(m_charaModelHandle->m_model) - ModelAnimStart(m_charaModelHandle->m_model));


### PR DESCRIPTION
## Summary
Raises main/gobject fuzzy match from 90.03% to 90.16% via permuter-validated signedness fixes on the largest functions.

## Per-function gains
- update (6216b): 86.88% -> 87.32% (signed short anim point count; s32 casts in shield-flag bit rotations; s32 corner loop index)
- onDraw (1180b): 84.77% -> 85.31% (unsigned collider loop index)
- boundCheck (556b): 96.97% -> 97.40% (s32 clip-corner loop index)

## What worked
- `tools/permute_fn.py` signedness/cast mutations on the highest-byte-weight functions (update, onDraw, boundCheck). Because update is the unit's largest function, small per-function gains move the unit %.

## Blocker (collision functions, ~72%)
The dominant remaining gaps (bgNormalCollision, bgAttribCollision, onCreate, SetPosBG) are blocked by the known sdata2 float-pool fold-vs-symbol wall: mwcc folds `static const float X = VAL` into anonymous `@NNNN` literal-pool entries, while the target references named `.sdata2` symbols. Converting the constants to `extern "C" const float` (no initializer) + renaming symbols.txt entries makes mwcc emit named references but regresses the collision functions' register allocation/scheduling (unit dropped to 89.88%) — consistent with prior cycles' findings. The collision functions also have a structural CVector-materialization difference (target stores ctor results to stack and copies field-by-field; ours keeps components in FPRs) that resists source steering. Local-double-cache, capsule-radius reload, and integer-bit-compare attempts all regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)