### PR TITLE
p_graphic: raise fuzzy match to 73.4% (cycle 4)

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -49,8 +49,8 @@ public:
     void SetDrawDoneDebugDataPartControl(int);
     void _WaitDrawDone(char*, int);
     void Thread();
-    u8 IsFifoOver();
-    u32 IsFrameRateOver();
+    int IsFifoOver();
+    int IsFrameRateOver();
     void Flip();
 
     void Printf(char*, ...);

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -596,7 +596,7 @@ void CGraphic::Thread()
  * Address:	TODO
  * Size:	TODO
  */
-u8 CGraphic::IsFifoOver()
+int CGraphic::IsFifoOver()
 {
 	GXBool overhi;
 	GXBool underflow;
@@ -614,7 +614,7 @@ u8 CGraphic::IsFifoOver()
  * Address:	TODO
  * Size:	TODO
  */
-u32 CGraphic::IsFrameRateOver()
+int CGraphic::IsFrameRateOver()
 {
 	return m_frameRateOver;
 }

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -751,10 +751,9 @@ void CGraphicPcs::drawBar()
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
         if (priority == 0x26) {
+            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
-
-            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);
@@ -769,10 +768,9 @@ void CGraphicPcs::drawBar()
             GXTexCoord2u16(0, 2);
             x += width;
         } else if (priority != 0x27) {
+            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarObjectTop;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarMoveBottom;
-
-            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, y0, kGraphicZero);
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 0);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -720,7 +720,7 @@ void CGraphicPcs::drawBar()
         padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
         padState = Pad.GetPadInputs()[padIndex].holdOverride;
     }
-    const bool drawText = (padState != 0) && (Joybus.GetPadType(0) != 0x40000);
+    const int drawText = (padState != 0) && (Joybus.GetPadType(0) != 0x40000);
 
     GXColor backColor = s_debug_bar_color;
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -811,33 +811,35 @@ void CGraphicPcs::drawBar()
     }
 
     CColor frameColor = (Graphic.IsFrameRateOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF);
+    const u32 frameColorWord = *reinterpret_cast<u32*>(&frameColor.color);
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameColor.color));
+    GXColor1u32(frameColorWord);
     GXTexCoord2u16(0, 0);
     GXPosition3f32(kDebugIndicatorFrameRight, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameColor.color));
+    GXColor1u32(frameColorWord);
     GXTexCoord2u16(2, 0);
     GXPosition3f32(kDebugIndicatorFrameRight, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameColor.color));
+    GXColor1u32(frameColorWord);
     GXTexCoord2u16(2, 2);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameColor.color));
+    GXColor1u32(frameColorWord);
     GXTexCoord2u16(0, 2);
 
     CColor fifoColor = (Graphic.IsFifoOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF);
+    const u32 fifoColorWord = *reinterpret_cast<u32*>(&fifoColor.color);
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoColor.color));
+    GXColor1u32(fifoColorWord);
     GXTexCoord2u16(0, 0);
     GXPosition3f32(kDebugIndicatorFifoRight, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoColor.color));
+    GXColor1u32(fifoColorWord);
     GXTexCoord2u16(2, 0);
     GXPosition3f32(kDebugIndicatorFifoRight, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoColor.color));
+    GXColor1u32(fifoColorWord);
     GXTexCoord2u16(2, 2);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoColor.color));
+    GXColor1u32(fifoColorWord);
     GXTexCoord2u16(0, 2);
 
     if (drawText) {

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -744,11 +744,13 @@ void CGraphicPcs::drawBar()
     int hue = 0;
     u32 y = 0x10;
     for (int i = 0; i < orderCount; i++) {
-        const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
+        const int priority = order->m_priority;
+        const float lastTime = order->m_lastTime;
         GXColor rgb;
         *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
-        if (order->m_priority == 0x26) {
+        if (priority == 0x26) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarMoveBottom;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarTop;
 
@@ -766,7 +768,7 @@ void CGraphicPcs::drawBar()
             GXColor1u32(*reinterpret_cast<u32*>(&rgb));
             GXTexCoord2u16(0, 2);
             x += width;
-        } else if (order->m_priority != 0x27) {
+        } else if (priority != 0x27) {
             const float y0 = drawText ? static_cast<float>(y) : kDebugBarObjectTop;
             const float y1 = drawText ? static_cast<float>(y + kDebugBarLineStep) : kDebugBarMoveBottom;
 


### PR DESCRIPTION
Raises `main/p_graphic` from 72.30% to 73.35% via a GX-argument/structure audit on `drawBar` (69.99% -> 73.79%).

## Changes (all in `drawBar`)
- **Evaluate `rgb` before `width`**: matches the target's order (Hsb2Rgb call, then width division). Also caches `order->m_priority`/`m_lastTime` into locals up front.
- **Compute `y0`/`y1` after `GXBegin`**: the ternary `drawText ? (float)y : const` was precomputed before the `GXBegin` call, pinning the two results into callee-saved FPRs (f26/f27) the target never saves. Moving them after GXBegin keeps them as scratch and drops the extra FPR saves.
- **Cache indicator color word in a `u32` local**: `frameColor`/`fifoColor` were read via `*(u32*)&color.color` at each of the 4 vertices, forcing a copy-construct + per-vertex reload. The target reads the color word once. Caching into a `u32` removes the spurious `__ct__6CColorFR6CColor` copy and the reloads.
- **Signed comparisons**: `drawText` changed `bool`->`int` (target uses full-word `cmpwi`, not a byte-masked `clrlwi.`); `CGraphic::IsFrameRateOver`/`IsFifoOver` return types changed `u32`/`u8`->`int` so the `== 0` callers emit signed `cmpwi` like the target. Both functions remain 100% in `main/graphic`; they have no other callers.

## Evidence
- `main/p_graphic`: 72.30% -> 73.35%
- `drawBar`: 69.99% -> 73.79%
- `main/graphic`: 95.50% unchanged (IsFrameRateOver/IsFifoOver still 100%)
- Full `ninja` clean, SDK 100% linked.

## Plausibility
All changes reflect ordinary source idioms (evaluate-then-use ordering, scalar caching of a color word, `int`-typed booleans/predicate returns). No layout changes to shared headers; only return-type signedness on two predicate methods.

## Blocker
`drawScreenFade` (58.6%) remains walled on its f26/f27 callee-saved-FPR window (confirmed across cycles 1-4); its GX setup-call arguments were audited and all match the target — no wrong-enum bug. The recurring `kIntToDoubleBias`/`kUnsignedToDoubleBias` named-symbol vs anonymous pool-double mismatch (drawScreenFade/drawBar/drawSFCircle) is a data-naming artifact: defining the named consts does not redirect mwcc's implicit `(float)(int)` conversion bias, so it is not source-steerable. `__sinit` is the known data.0 base-CSE wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)