### PR TITLE
p_camera: raise fuzzy match to 89.4% (cycle 5)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1588,15 +1588,10 @@ void CCameraPcs::drawShadowBegin()
     CopyCameraState(m_shadowCamera, CurrentCameraState());
 
     if (Game.m_currentSceneId == 3) {
-        float stickX = kCameraZeroF;
-        float stickY = kCameraZeroF;
-
-        if (Pad.m_debugPadLock == 0) {
-            stickX = CameraShadowPadInput().stickXF;
-            stickY = CameraShadowPadInput().stickYF;
-        }
-
+        float stickX = (Pad.m_debugPadLock != 0) ? kCameraZeroF : CameraShadowPadInput().stickXF;
         m_fullScreenShadow.m_rotY += kCameraDegToRad * kCameraDebugMoveStep * stickX;
+
+        float stickY = (Pad.m_debugPadLock != 0) ? kCameraZeroF : CameraShadowPadInput().stickYF;
         m_fullScreenShadow.m_rotX += kCameraDegToRad * kCameraTwoF * stickY;
     }
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1589,10 +1589,10 @@ void CCameraPcs::drawShadowBegin()
 
     if (Game.m_currentSceneId == 3) {
         float stickX = (Pad.m_debugPadLock != 0) ? kCameraZeroF : CameraShadowPadInput().stickXF;
-        m_fullScreenShadow.m_rotY += kCameraDegToRad * kCameraDebugMoveStep * stickX;
+        m_fullScreenShadow.m_rotY += kCameraDegToRad * (kCameraDebugMoveStep * stickX);
 
         float stickY = (Pad.m_debugPadLock != 0) ? kCameraZeroF : CameraShadowPadInput().stickYF;
-        m_fullScreenShadow.m_rotX += kCameraDegToRad * kCameraTwoF * stickY;
+        m_fullScreenShadow.m_rotX += kCameraDegToRad * (kCameraTwoF * stickY);
     }
 
     PSMTXRotRad(rotX, 'x', -m_fullScreenShadow.m_rotX);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1528,13 +1528,13 @@ int CCameraPcs::GetShadowRect(CBound& shadowRectBound)
         if (worldBound->CheckFrustum0(*clipBound) == 0) {
             continue;
         }
-        if (!(clipBoundData[0] > kCameraClipMinZ)) {
+        if (!(clipBoundData[2] > kCameraClipMinZ)) {
             continue;
         }
-        float negMinX = -clipBoundData[0];
-        float ratioZ = (clipBoundData[5] - clipBoundData[2]) / negMinX;
-        float ratioY = (clipBoundData[4] - clipBoundData[1]) / negMinX;
-        if (ratioZ > kCameraDebugRotateStep) {
+        float negMinZ = -clipBoundData[2];
+        float ratioX = (clipBoundData[3] - clipBoundData[0]) / negMinZ;
+        float ratioY = (clipBoundData[4] - clipBoundData[1]) / negMinZ;
+        if (ratioX > kCameraDebugRotateStep) {
             // proceed
         } else if (!(ratioY > kCameraDebugRotateStep)) {
             continue;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1600,12 +1600,12 @@ void CCameraPcs::drawShadowBegin()
     PSMTXConcat(rotY, rotX, rotXY);
 
     if (Game.m_currentSceneId == 4) {
-        m_shadowRectBound.m_min.x = kCameraBoundsMinInitial;
-        m_shadowRectBound.m_min.y = kCameraBoundsMinInitial;
         m_shadowRectBound.m_min.z = kCameraBoundsMinInitial;
-        m_shadowRectBound.m_max.x = kCameraBoundsMaxInitial;
-        m_shadowRectBound.m_max.y = kCameraBoundsMaxInitial;
+        m_shadowRectBound.m_min.y = kCameraBoundsMinInitial;
+        m_shadowRectBound.m_min.x = kCameraBoundsMinInitial;
         m_shadowRectBound.m_max.z = kCameraBoundsMaxInitial;
+        m_shadowRectBound.m_max.y = kCameraBoundsMaxInitial;
+        m_shadowRectBound.m_max.x = kCameraBoundsMaxInitial;
 
         if (m_shadowAuto == 1 && GetShadowRect(m_shadowRectBound) != 0) {
             m_targetX = (m_shadowRectBound.m_min.x + m_shadowRectBound.m_max.x) * kCameraHalfF;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1513,22 +1513,22 @@ int CCameraPcs::GetShadowRect(CBound& shadowRectBound)
         float clipBoundData[6];
         CBound* clipBound = reinterpret_cast<CBound*>(clipBoundData);
         worldBoundData[0] = gObject->m_worldPosition.x - radius;
-        clipBoundData[0] = kCameraBoundsMinInitial;
         worldBoundData[3] = gObject->m_worldPosition.x + radius;
-        clipBoundData[3] = kCameraBoundsMaxInitial;
-        worldBoundData[1] = gObject->m_worldPosition.y;
-        clipBoundData[1] = kCameraBoundsMinInitial;
-        worldBoundData[4] = gObject->m_worldPosition.y + radius;
-        clipBoundData[4] = kCameraBoundsMaxInitial;
         worldBoundData[2] = gObject->m_worldPosition.z - radius;
-        clipBoundData[2] = kCameraBoundsMinInitial;
         worldBoundData[5] = gObject->m_worldPosition.z + radius;
+        worldBoundData[1] = gObject->m_worldPosition.y;
+        clipBoundData[2] = kCameraBoundsMinInitial;
+        worldBoundData[4] = gObject->m_worldPosition.y + radius;
+        clipBoundData[1] = kCameraBoundsMinInitial;
+        clipBoundData[0] = kCameraBoundsMinInitial;
         clipBoundData[5] = kCameraBoundsMaxInitial;
+        clipBoundData[4] = kCameraBoundsMaxInitial;
+        clipBoundData[3] = kCameraBoundsMaxInitial;
 
         if (worldBound->CheckFrustum0(*clipBound) == 0) {
             continue;
         }
-        if (clipBoundData[0] <= kCameraClipMinZ) {
+        if (!(clipBoundData[0] > kCameraClipMinZ)) {
             continue;
         }
         float negMinX = -clipBoundData[0];
@@ -1536,7 +1536,7 @@ int CCameraPcs::GetShadowRect(CBound& shadowRectBound)
         float ratioY = (clipBoundData[4] - clipBoundData[1]) / negMinX;
         if (ratioZ > kCameraDebugRotateStep) {
             // proceed
-        } else if (ratioY <= kCameraDebugRotateStep) {
+        } else if (!(ratioY > kCameraDebugRotateStep)) {
             continue;
         }
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1791,10 +1791,10 @@ void CCameraPcs::drawShadowEnd()
 
     {
         float span = m_fullScreenShadow.m_span;
-        float depthSpan = m_shadowCamera.m_farZ - m_shadowCamera.m_nearZ;
         C_MTXLightOrtho(m_fullScreenShadow.m_shadowTexMtx, -span, span, -span, span,
                         kCameraHalfF, kCameraHalfF, kCameraHalfF, kCameraHalfF);
         PSMTXScale(m_fullScreenShadow.m_depthScaleMtx, kCameraZeroF, kCameraZeroF, kCameraZeroF);
+        float depthSpan = m_shadowCamera.m_farZ - m_shadowCamera.m_nearZ;
         m_fullScreenShadow.m_depthScaleMtx[0][2] = kCameraNegativeOneF / depthSpan;
         m_fullScreenShadow.m_depthScaleMtx[0][3] = -(m_shadowCamera.m_nearZ / depthSpan);
         m_fullScreenShadow.m_depthScaleMtx[1][2] = m_fullScreenShadow.m_depthScaleMtx[0][2] * kCameraShadowDepthScaleY;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1785,7 +1785,7 @@ void CCameraPcs::drawShadowEnd()
     GXPosition3f32(static_cast<float>(x0), static_cast<float>(x0), z);
 
     GXSetTexCopySrc(0, 0, 0x1E0, 0x1E0);
-    GXSetTexCopyDst(0x1E0, 0x1E0, GX_TF_I8, GX_FALSE);
+    GXSetTexCopyDst(0x1E0, 0x1E0, GX_TF_Z8, GX_FALSE);
     GXCopyTex(m_fullScreenShadow.m_shadowTexture, GX_TRUE);
     GXSetCullMode(GX_CULL_FRONT);
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1540,24 +1540,18 @@ int CCameraPcs::GetShadowRect(CBound& shadowRectBound)
             continue;
         }
 
-        if (worldBoundData[0] < shadowRectBound.m_min.x) {
-            shadowRectBound.m_min.x = worldBoundData[0];
-        }
-        if (worldBoundData[1] < shadowRectBound.m_min.y) {
-            shadowRectBound.m_min.y = worldBoundData[1];
-        }
-        if (worldBoundData[2] < shadowRectBound.m_min.z) {
-            shadowRectBound.m_min.z = worldBoundData[2];
-        }
-        if (shadowRectBound.m_max.x < worldBoundData[3]) {
-            shadowRectBound.m_max.x = worldBoundData[3];
-        }
-        if (shadowRectBound.m_max.y < worldBoundData[4]) {
-            shadowRectBound.m_max.y = worldBoundData[4];
-        }
-        if (shadowRectBound.m_max.z < worldBoundData[5]) {
-            shadowRectBound.m_max.z = worldBoundData[5];
-        }
+        shadowRectBound.m_min.x =
+            (shadowRectBound.m_min.x < worldBoundData[0]) ? shadowRectBound.m_min.x : worldBoundData[0];
+        shadowRectBound.m_min.y =
+            (shadowRectBound.m_min.y < worldBoundData[1]) ? shadowRectBound.m_min.y : worldBoundData[1];
+        shadowRectBound.m_min.z =
+            (shadowRectBound.m_min.z < worldBoundData[2]) ? shadowRectBound.m_min.z : worldBoundData[2];
+        shadowRectBound.m_max.x =
+            (shadowRectBound.m_max.x > worldBoundData[3]) ? shadowRectBound.m_max.x : worldBoundData[3];
+        shadowRectBound.m_max.y =
+            (shadowRectBound.m_max.y > worldBoundData[4]) ? shadowRectBound.m_max.y : worldBoundData[4];
+        shadowRectBound.m_max.z =
+            (shadowRectBound.m_max.z > worldBoundData[5]) ? shadowRectBound.m_max.z : worldBoundData[5];
         count += 1;
     }
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1609,8 +1609,8 @@ void CCameraPcs::drawShadowBegin()
 
         if (m_shadowAuto == 1 && GetShadowRect(m_shadowRectBound) != 0) {
             m_targetX = (m_shadowRectBound.m_min.x + m_shadowRectBound.m_max.x) * kCameraHalfF;
-            m_targetY = m_fullScreenShadowPosition.y;
             m_targetZ = (m_shadowRectBound.m_min.z + m_shadowRectBound.m_max.z) * kCameraHalfF;
+            m_targetY = m_fullScreenShadowPosition.y;
 
             double w = static_cast<double>(m_shadowRectBound.m_max.x - m_shadowRectBound.m_min.x);
             double h = static_cast<double>(m_shadowRectBound.m_max.z - m_shadowRectBound.m_min.z);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1576,7 +1576,7 @@ void CCameraPcs::drawShadowBegin()
     Mtx tempMtx;
     Vec up;
     Vec delta;
-    double depth;
+    float depth;
 
     if (m_fullScreenShadowEnabled == 0) {
         return;
@@ -1612,35 +1612,34 @@ void CCameraPcs::drawShadowBegin()
             m_targetZ = (m_shadowRectBound.m_min.z + m_shadowRectBound.m_max.z) * kCameraHalfF;
             m_targetY = m_fullScreenShadowPosition.y;
 
-            double w = static_cast<double>(m_shadowRectBound.m_max.x - m_shadowRectBound.m_min.x);
-            double h = static_cast<double>(m_shadowRectBound.m_max.z - m_shadowRectBound.m_min.z);
+            float w = m_shadowRectBound.m_max.x - m_shadowRectBound.m_min.x;
+            float h = m_shadowRectBound.m_max.z - m_shadowRectBound.m_min.z;
             if (w < h) {
                 w = h;
             }
-            m_fullScreenShadow.m_span = static_cast<float>(static_cast<double>(kCameraHalfF) * w);
+            m_fullScreenShadow.m_span = kCameraHalfF * w;
             depth = w;
         } else if (m_shadowAuto == 2) {
             m_targetX = m_fullScreenShadowPosition.x;
             m_targetY = m_fullScreenShadowPosition.y;
             m_targetZ = m_fullScreenShadowPosition.z;
             PSVECSubtract(reinterpret_cast<Vec*>(&m_targetX), reinterpret_cast<Vec*>(&m_positionX), &delta);
-            depth = static_cast<double>(m_fullScreenShadowCamLen);
+            depth = m_fullScreenShadowCamLen;
             m_fullScreenShadow.m_span = kCameraShadowSpanScale * m_fullScreenShadow.m_scale;
         } else {
             m_targetX = m_fullScreenShadowPosition.x;
             m_targetY = m_fullScreenShadowPosition.y;
             m_targetZ = m_fullScreenShadowPosition.z;
             PSVECSubtract(reinterpret_cast<Vec*>(&m_targetX), reinterpret_cast<Vec*>(&m_positionX), &delta);
-            depth = static_cast<double>(PSVECMag(&delta));
-            m_fullScreenShadow.m_span = static_cast<float>(depth) * m_fullScreenShadow.m_scale;
+            depth = PSVECMag(&delta);
+            m_fullScreenShadow.m_span = depth * m_fullScreenShadow.m_scale;
         }
 
-        double currentDepth = static_cast<double>(m_fullScreenShadowDepth);
-        if (currentDepth >= static_cast<double>(kCameraZeroF)) {
-            m_fullScreenShadowDepth = static_cast<float>(currentDepth +
-                                                         static_cast<double>((static_cast<float>(depth - currentDepth)) * kCameraShadowDepthBlend));
+        float currentDepth = m_fullScreenShadowDepth;
+        if (currentDepth >= kCameraZeroF) {
+            m_fullScreenShadowDepth = currentDepth + (depth - currentDepth) * kCameraShadowDepthBlend;
         } else {
-            m_fullScreenShadowDepth = static_cast<float>(depth);
+            m_fullScreenShadowDepth = depth;
         }
     } else {
         m_fullScreenShadow.m_span = kCameraHundredF;


### PR DESCRIPTION
Cycle-5 GX-argument-correctness audit and shadow-function matching pass on main/p_camera, 88.12% -> 89.45%.

## What changed
**GetShadowRect (85.98% -> 98.88%)**
- Rewrote the bound min/max clamps as `(cur < world) ? cur : world` ternaries to match the target's `bge/ble; b; fmr` select (no `cror`).
- Reordered the world/clip bound array fills to match the target's field-evaluation order (x, z, y) and stack layout.
- Corrected the projected-clip indices: the post-`CheckFrustum0` depth uses `clipBoundData[2]` and the ratios use `[3]-[0]` / `[4]-[1]`.
- Flipped the z/ratio guard polarity to `!(a > b)` so mwcc emits plain `ble` instead of `cror + beq`.

**drawShadowBegin (81.12% -> 85.18%)**
- Split the shadow-stick reads into two independently guarded per-axis ternaries (matching the target's two separate `m_debugPadLock` checks), instead of one combined `if` block.
- Re-associated the rot fmadds grouping to `DegToRad * (step * stick)`.
- Ordered the `m_shadowRectBound` init z-to-x like the constructor; ordered the target X/Z/Y averaging to match.
- Made the shadow depth/span math single-precision (`float`), matching the target's `fsubs/fmuls/fcmpo`.

**drawShadowEnd (95.35% -> 96.71%)**
- Fixed a real GX correctness bug: the full-screen shadow buffer copies a depth texture, so the `GXSetTexCopyDst` format must be `GX_TF_Z8` (0x11), not `GX_TF_I8` (0x1).
- Reload `depthSpan` lazily after the matrix-setup calls instead of caching it in a pinned FPR across them (R13).

## Why it is plausible source
All changes are ordinary C++ idioms (clamp ternaries, per-axis input guards, expression re-association, single-precision floats, lazy reloads) plus one genuine enum-correctness fix (`GX_TF_Z8` for a Z-buffer copy). No layout changes, pointer tricks, or compiler-coaxing hacks.

## Blockers (left as walls)
- `g_shadow_pos` / `g_shadow_refpos` base-register hoist in `draw` and `drawShadowBegin`: the target keeps a single `&g_shadow_pos` callee-saved base and addresses `g_shadow_refpos` as `base+0xC`. The two are contiguous in `.bss` but are distinct symbols; folding them needs a layout/pointer change that is out of scope.
- The `CopyCameraState` struct copies (int-vs-float word ordering) and the `calc`/`draw` `this`/`&Pad` register swap remain known walls.
- `__sinit` `.data.0` base-CSE ceiling (per TECHNIQUE.md WALL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)