### PR TITLE
joybus: raise fuzzy match to 89.3% (cycle 8)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7038,15 +7038,13 @@ int JoyBus::SetCtrlMode(int portIndex, int controlMode)
         return 0;
 	}
 
-    unsigned char modeFlag =
-        (unsigned char)(((unsigned int)(-controlMode | controlMode)) >> 31);
-
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
 
-    bool isSinglePort = GbaQue.IsSingleMode(m_threadParams[portIndex].m_portIndex);
+    unsigned char modeFlag =
+        (unsigned char)(((unsigned int)(-controlMode | controlMode)) >> 31);
 
-    if (isSinglePort)
+    if (GbaQue.IsSingleMode(m_threadParams[portIndex].m_portIndex))
 	{
         modeFlag = 0;
 	}
@@ -7357,37 +7355,35 @@ bool JoyBus::IsLetterMenu(int portIndex)
  */
 int JoyBus::SendAddLetter(int portIndex)
 {
-    int port;
-    int result;
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
     cmdBytes[0] = 0x14;
     cmdBytes[1] = 1;
     unsigned int cmdWord = cmd;
+    unsigned int port;
 
     if (static_cast<signed char>(m_threadRunningMask) == 0)
     {
-        result = 0;
+        return 0;
+    }
+
+    OSWaitSemaphore(m_accessSemaphores + m_threadParams[portIndex].m_portIndex);
+
+    unsigned int result = 0;
+
+    port = m_threadParams[portIndex].m_portIndex;
+    if ((int)m_cmdCount[port] >= 0x40)
+    {
+        OSSignalSemaphore(m_accessSemaphores + port);
+        result = 0xFFFFFFFF;
     }
     else
     {
-        OSWaitSemaphore(m_accessSemaphores + m_threadParams[portIndex].m_portIndex);
-
+        m_cmdQueueData[port][m_cmdCount[port]] = cmdWord;
         port = m_threadParams[portIndex].m_portIndex;
-        if ((int)m_cmdCount[port] >= 0x40)
-        {
-            OSSignalSemaphore(m_accessSemaphores + port);
-            result = -1;
-        }
-        else
-        {
-            m_cmdQueueData[port][ m_cmdCount[port] ] = cmdWord;
-            port = m_threadParams[portIndex].m_portIndex;
-            m_cmdCount[port]++;
-
-            OSSignalSemaphore(m_accessSemaphores + m_threadParams[portIndex].m_portIndex);
-            result = 0;
-        }
+        m_cmdCount[port]++;
+        OSSignalSemaphore(m_accessSemaphores + m_threadParams[portIndex].m_portIndex);
+        result = 0;
     }
 
     return result;


### PR DESCRIPTION
## Summary
Cycle-8 pass on `main/joybus` (51KB, B4's largest unmatched unit). Raised the unit fuzzy match from baseline **89.286%** to **89.301%**.

## Per-function gains
- **SetCtrlMode** `93.62% -> 95.75%`: hoisted the `cmd`/buffer zero-init above the `modeFlag` bit computation. This is the proven "hoist cmd/buffer init above the dispatch" lever — it lets mwcc color the threadParam base and modeFlag into the target's register order and removes the deferred `srwi`+`mr` pair.

## What worked
- Init-hoist (cmd buffer above preceding scalar computation) on SetCtrlMode.

## Blocker (walls confirmed, not source-steerable)
The remaining mid-% pool (SendChkCrc, SendAddLetter, SendUseItem, SetCmdLst, SetTmpArti, SendHitEnemy, SendResult, RequestData, SendStartBonus) is dominated by two register-numbering walls:
1. **result-in-rN-vs-r3 idiom** — the target keeps the return value in a volatile rN throughout and does a final `mr r3,rN`, also reusing that zero register to clear the cmd stack buffer. Restructuring to single-return regressed (e.g. SetTmpArti 92.78 -> 86.75).
2. **r29/r30 word-vs-base swap** — the target reloads the assembled command word from the stack into r30 before the mask branch and the threadParam base into r29; ours colors them swapped. Caching the threadParam base, moving the word reload, and obj-pointer access all regressed or were neutral.

**Crc16** improves standalone (83.75 -> 92.75 via signed-`idx` arithmetic-shift form) but regresses the inlined copy in the 3364-byte SendDataFile (76.07 -> 75.28, a net loss), so it was reverted. SendPpos / SendBonusStr carry a +2 saved-register over-allocation plus control-flow divergence that resisted scope-narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)