### PR TITLE
maphit: raise fuzzy match to 97.3% (cycle 4)

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -130,7 +130,7 @@ void CMapHit::Draw()
 
             GXBegin(GX_TRIANGLES, GX_VTXFMT7, 3);
             int i = 0;
-            while (i < static_cast<int>(face->m_vertexCount)) {
+            while (i < static_cast<unsigned int>(face->m_vertexCount)) {
                 Vec* vertex = m_vertices + face->m_vertexIndices[i];
                 GXPosition3f32(vertex->x, vertex->y, vertex->z);
                 GXNormal3f32(face->m_normal.x, face->m_normal.y, face->m_normal.z);


### PR DESCRIPTION
Raises `main/maphit` fuzzy match from 97.27% to 97.30%.

## Change
- `Draw`: the first per-face vertex loop now bounds its index against `static_cast<unsigned int>(face->m_vertexCount)` instead of a signed cast. `m_vertexCount` is an `unsigned short`, so an unsigned loop bound is plausible original source, and it matches the target's register coloring in that loop (Draw 96.77% -> 96.99%).

## Investigated, not landed (walls)
- `CheckHitFaceCylinder` (90.77%): uniform +1 callee-saved-GPR window shift (`stmw r15` vs target `stmw r16`) producing ~200 ARG_MISMATCH. The genuine sub-findings (`s_bitMask.m_fields.m_mode` read as signed -> `extsb.`, and the `s_bitMask+0x1` drawFlags fold) each regress net because they are entangled with the register window. Documented wall.
- `FindIntersection` (98.85%): remaining gap is anonymous literal-pool doubles (`@1021`) vs the target's named shared `DOUBLE_8032F9xx` sqrt constants, plus sqrt-result float coloring (f0 vs f3) — the literal-pool-naming wall.
- `CheckHitCylinder`/`CheckHitCylinderNear` overloads (99.3-99.4%): pure callee-saved register-assignment swaps on the face-iteration loop counters; resisted declaration/increment reordering and permute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)