### PR TITLE
gobjwork: raise fuzzy match to 94.6% (cycle 4)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1931,7 +1931,7 @@ void CCaravanWork::CalcStatus()
 			m_baseDefense += itemValue;
 		apply_effect:
 			int itemEffect = GetItemDataPtr(itemIdx)[4];
-			char effectValue = (char)itemValue;
+			unsigned short effectValue = itemValue;
 			switch (itemEffect) {
 			case 1:
 				m_elementResistances[1]++;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1900,7 +1900,7 @@ void CCaravanWork::CalcStatus()
 	for (int equipIdx = 0; equipIdx < 4; equipIdx++) {
 		int equipSlot = m_equipment[equipIdx];
 		if (equipSlot >= 0) {
-			int itemIdx = (short)m_inventoryItems[equipSlot];
+			int itemIdx = m_inventoryItems[equipSlot];
 			int itemType = GetItemDataPtr(itemIdx)[0];
 
 			if (itemType == 1) {

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2000,10 +2000,9 @@ void CCaravanWork::CalcStatus()
 	}
 
 	if (m_statusTimers[9] != 0) {
-		float mul = GetStatusMultiplier(0x38);
-		m_strength = (unsigned short)((float)m_strength * mul);
-		m_magic = (unsigned short)((float)m_magic * mul);
-		m_defense = (unsigned short)((float)m_defense * mul);
+		m_strength = (unsigned short)((float)m_strength * GetStatusMultiplier(0x38));
+		m_magic = (unsigned short)((float)m_magic * GetStatusMultiplier(0x38));
+		m_defense = (unsigned short)((float)m_defense * GetStatusMultiplier(0x38));
 	}
 	if (m_statusTimers[4] != 0) {
 		m_defense = (unsigned short)((float)m_defense * GetStatusMultiplier(0x3E));

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1885,13 +1885,13 @@ void CCaravanWork::CalcStatus()
 	m_numCmdListSlots += cmdBonus;
 	m_maxHp += hpBonus;
 
-	unsigned short cappedValue = 8;
+	short cmdSlotCap = 8;
 	if ((short)m_numCmdListSlots < 8) {
-		cappedValue = m_numCmdListSlots;
+		cmdSlotCap = m_numCmdListSlots;
 	}
-	m_numCmdListSlots = cappedValue;
+	m_numCmdListSlots = cmdSlotCap;
 
-	cappedValue = 0x10;
+	unsigned short cappedValue = 0x10;
 	if (m_maxHp < 0x10) {
 		cappedValue = m_maxHp;
 	}

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1841,17 +1841,17 @@ void CCaravanWork::CalcStatus()
 		break;
 	}
 
-	unsigned short hpBonus = 0;
-	short cmdBonus = 0;
-	short strBonus = 0;
-	short magBonus = 0;
-	short defBonus = 0;
+	int hpBonus = 0;
+	int cmdBonus = 0;
+	int strBonus = 0;
+	int magBonus = 0;
+	int defBonus = 0;
 	for (int i = 0; i < 100; i++) {
 		int artifactId = m_artifacts[i];
 		if (artifactId > 0) {
 			unsigned short* artifactData = GetItemDataPtr(artifactId);
 			int artifactEffect = artifactData[0];
-			short value = artifactData[3];
+			int value = artifactData[3];
 
 			switch (artifactEffect) {
 			case 0x9F:

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1898,8 +1898,7 @@ void CCaravanWork::CalcStatus()
 	for (int equipIdx = 0; equipIdx < 4; equipIdx++) {
 		if (m_equipment[equipIdx] >= 0) {
 			int itemIdx = (short)m_inventoryItems[m_equipment[equipIdx]];
-			unsigned short* itemData = GetItemDataPtr(itemIdx);
-			int itemType = itemData[0];
+			int itemType = GetItemDataPtr(itemIdx)[0];
 
 			if (itemType == 1) {
 				int weaponItem;
@@ -1907,11 +1906,10 @@ void CCaravanWork::CalcStatus()
 				GetCurrentWeaponItem(weaponItem, weaponRef);
 				if (weaponItem > 0) {
 					itemIdx = weaponItem;
-					itemData = GetItemDataPtr(itemIdx);
 				}
 			}
 
-			unsigned short itemValue = (short)itemData[3];
+			unsigned short itemValue = (short)GetItemDataPtr(itemIdx)[3];
 			if (itemType != 0x45) {
 				if (itemType >= 0x45) {
 					if (itemType == 0x7F) {
@@ -1929,7 +1927,7 @@ void CCaravanWork::CalcStatus()
 			m_defense += itemValue;
 			m_baseDefense += itemValue;
 		apply_effect:
-			int itemEffect = itemData[4];
+			int itemEffect = GetItemDataPtr(itemIdx)[4];
 			char effectValue = (char)itemValue;
 			switch (itemEffect) {
 			case 1:

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1668,13 +1668,12 @@ void CCaravanWork::CallShop(int requestType, int arg0, int arg1, int arg2, int a
  */
 void CCaravanWork::SafeDeleteTempItem()
 {
-	int totalSlots = 0;
-	int artifactIndex = 0;
-
 	if ((unsigned int)System.m_execParam >= 3U) {
 		System.Printf(const_cast<char*>(sNoWorldReturnItemWarning));
 	}
 
+	int totalSlots = 0;
+	int artifactIndex = 0;
 	for (int i = 0; i < 50; i++, artifactIndex += 2) {
 		if (artifactIndex < 96 && m_artifacts[artifactIndex] > 0) {
 			unsigned short* artifactData =

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1858,7 +1858,6 @@ void CCaravanWork::CalcStatus()
 				strBonus += value;
 				break;
 			case 0xB6:
-			case 0xDF:
 				magBonus += value;
 				break;
 			case 0xCC:
@@ -1869,6 +1868,9 @@ void CCaravanWork::CalcStatus()
 				break;
 			case 0xE4:
 				hpBonus += value;
+				break;
+			case 0xDF:
+				magBonus += value;
 				break;
 			}
 		}

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1898,8 +1898,9 @@ void CCaravanWork::CalcStatus()
 	m_maxHp = cappedValue;
 
 	for (int equipIdx = 0; equipIdx < 4; equipIdx++) {
-		if (m_equipment[equipIdx] >= 0) {
-			int itemIdx = (short)m_inventoryItems[m_equipment[equipIdx]];
+		int equipSlot = m_equipment[equipIdx];
+		if (equipSlot >= 0) {
+			int itemIdx = (short)m_inventoryItems[equipSlot];
 			int itemType = GetItemDataPtr(itemIdx)[0];
 
 			if (itemType == 1) {


### PR DESCRIPTION
## Summary
Raises `main/gobjwork` fuzzy match from baseline **93.86%** to **94.62%** (+0.76).

All gains came from R13/R16 correctness-audit findings: lazy field/pointer reloads instead of FPR/pointer caches, removing redundant sign/zero-extension casts, matching the target's basic-block structure, and one accumulator-liveness fix.

## Per-function gains
- **CalcStatus** 92.17% -> ~98.6%: the big mover.
  - Recompute `GetStatusMultiplier(0x38)` per stat instead of caching `float mul` (matched target's lazy reload, dropped a whole int->double conversion block + the inflated frame).
  - Access item/artifact data via inline `GetItemDataPtr(idx)[N]` indexed loads instead of caching the `unsigned short*` pointer.
  - Int-width artifact bonus accumulators (dropped per-iteration extsh).
  - Split the merged `0xB6`/`0xDF` artifact-effect switch cases into separate bodies.
  - Cache the equipment slot once (dropped a redundant extsh on the `>= 0` test).
  - Drop the redundant `(short)`/`(char)` casts on already-typed members (equipped item, effect value).
  - Use a signed cap local for the cmd-slot clamp (dropped a clrlwi).
- **SafeDeleteTempItem** 89.42% -> 91.96%: move the slot/index accumulator initializers to after the early `Printf`, so they don't get promoted into callee-saved registers across the call (fixed the `this`-register window shift, -33 flagged lines).

## Why this is plausible source
Every change removes a decompiler artifact (redundant cast, premature variable hoist, an over-eager pointer/FPR cache) and makes the code read more like hand-written original. No offset tricks, no fake symbols, no header layout changes.

## Blockers (walls hit, reverted cleanly)
- **FGLetterOpen (77.5%)**: `m_letters[i]` 0x3ec base-fold requires the forbidden pointer-offset trick; removing the cached pointer regresses.
- **AddLetter / GetNextCmdListIdx / GetMagicCharge / GetCmdListItemName / DelCmdListAndItem**: dominated by parameter/`this`-register coloring cascades and the `m_commandListExtra` backward-scan `mr.`/counted-loop fusion, plus induction-variable folding (`addi rN,1` running counter vs `+const`). These resist source steering — many variants tried, all net-neutral or negative.
- **SearchRomLetterWork**: known +2 callee-saved-register-count wall (skipped per brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)