### PR TITLE
game: raise fuzzy match to 98.3% (cycle 3)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -937,7 +937,6 @@ void CGame::Calc()
 {
 	Mtx rotMtx;
     int mapObjIdx;
-    float position;
 
     if (m_frameCounterEnable != 0) {
         m_gameWork.m_frameCounter++;
@@ -954,23 +953,12 @@ void CGame::Calc()
         CGPartyObj* partyObj = m_partyObjArr[i];
 
         if (partyObj != 0) {
-            position = partyObj->m_worldPosition.x;
-            m_partyMinX = (m_partyMinX < position) ? m_partyMinX : position;
-
-            position = partyObj->m_worldPosition.y;
-            m_partyMinY = (m_partyMinY < position) ? m_partyMinY : position;
-
-            position = partyObj->m_worldPosition.z;
-            m_partyMinZ = (m_partyMinZ < position) ? m_partyMinZ : position;
-
-            position = partyObj->m_worldPosition.x;
-            m_partyMaxX = (m_partyMaxX > position) ? m_partyMaxX : position;
-
-            position = partyObj->m_worldPosition.y;
-            m_partyMaxY = (m_partyMaxY > position) ? m_partyMaxY : position;
-
-            position = partyObj->m_worldPosition.z;
-            m_partyMaxZ = (m_partyMaxZ > position) ? m_partyMaxZ : position;
+            m_partyMinX = (m_partyMinX < partyObj->m_worldPosition.x) ? m_partyMinX : partyObj->m_worldPosition.x;
+            m_partyMinY = (m_partyMinY < partyObj->m_worldPosition.y) ? m_partyMinY : partyObj->m_worldPosition.y;
+            m_partyMinZ = (m_partyMinZ < partyObj->m_worldPosition.z) ? m_partyMinZ : partyObj->m_worldPosition.z;
+            m_partyMaxX = (m_partyMaxX > partyObj->m_worldPosition.x) ? m_partyMaxX : partyObj->m_worldPosition.x;
+            m_partyMaxY = (m_partyMaxY > partyObj->m_worldPosition.y) ? m_partyMaxY : partyObj->m_worldPosition.y;
+            m_partyMaxZ = (m_partyMaxZ > partyObj->m_worldPosition.z) ? m_partyMaxZ : partyObj->m_worldPosition.z;
         }
     }
 


### PR DESCRIPTION
## Summary
Cycle-3 R16 correctness audit of main/game. Raised fuzzy match 98.29% -> 98.33%.

### What changed
- **Calc**: inlined the per-party-object world-position reads directly into the min/max clamp ternaries instead of caching them in a `position` local first. The cached local forced mwcc to load `position` (f1) before the bound member (f0); the target loads the bound member first. Inlining the field read into each `(member < pos) ? member : pos` ternary fixes the float load order across all six bounds comparisons. Calc 98.43% -> 99.02%. Removed the now-unused `position` local.

### R16 audit result
Audited every `cmpwi`/`cmplwi` immediate, every `li rN,CONST`/size constant, every memset/strncpy size, array index, and helper-call arg order across all sub-100% functions. **No boundary off-by-one, wrong-size, swapped-arg, or wrong-constant source bugs were found** — every flagged immediate matches the target's value; remaining diffs are register-allocation/scheduling only.

### Confirmed walls (deep effort, not source-steerable)
- LoadScript/SaveScript: IV strength-reduction (target keeps `stwx base,offset`; mwcc collapses to advancing pointer). for-loop variant did not change it.
- InitNewGame/CheckScriptChange: 2nd-memset `&Game` rematerialization (5 lines each).
- ChangeMap: parameter callee-saved register window (natural vs reverse order); block-reorder and explicit-mask-local variants regressed.
- GetBossArtifact: `kGameIntToDoubleBias` bias-literal pool + register window; `&stage->m_entries[i]` rewrite regressed.
- Create: mtctr-vs-GPR loop codegen; for-loop variant regressed.
- clearWork/ScriptChanged: unroll-4+cursor vs unroll-8-wide-offset; split-loop variant did not change it.
- Exec: jumptable symbol naming (`@444`/`@445` vs `jumptable_801E83A0`).
- GetTargetCursor: r3/r4 index-vs-value register coloring; cached-slot variant regressed.
- loadCfd: loop-invariant base hoist order (File/Game/s_localLangDirs register assignment).
- Calc residual: named-constant pooling (`kGamePartyBoundsMinInit`/`kGameZero`/`kGameSmallDelta` emitted as `@NNN@sda21` pooled values vs named symbols) — mwcc folds `const float` initializers; static/extern linkage changes regressed data%. The residual register window is downstream of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)