### PR TITLE
p_graphic: raise fuzzy match to 75.1% (cycle 5)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -714,7 +714,7 @@ void CGraphicPcs::drawBar()
     _GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
 
     const bool useDebugPad = (Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1);
-    int padState = 0;
+    unsigned int padState = 0;
     if (!useDebugPad) {
         int padIndex = useDebugPad;
         padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -746,8 +746,8 @@ void CGraphicPcs::drawBar()
     for (int i = 0; i < orderCount; i++) {
         const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;
-        GXColor rgb;
-        *reinterpret_cast<u32*>(&rgb) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        const u32 colorWord = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        GXColor rgb = *reinterpret_cast<const GXColor*>(&colorWord);
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
         if (priority == 0x26) {

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -815,8 +815,14 @@ void CGraphicPcs::drawBar()
         hue += 0x168;
     }
 
-    CColor frameColor = (Graphic.IsFrameRateOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF);
-    const u32 frameColorWord = *reinterpret_cast<u32*>(&frameColor.color);
+    GXColor frameTmp;
+    *reinterpret_cast<u32*>(&frameTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFrameRateOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF)).color);
+    GXColor frameGX;
+    frameGX.r = frameTmp.r;
+    frameGX.g = frameTmp.g;
+    frameGX.b = frameTmp.b;
+    frameGX.a = frameTmp.a;
+    const u32 frameColorWord = *reinterpret_cast<u32*>(&frameGX);
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorTop, kGraphicZero);
     GXColor1u32(frameColorWord);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -837,8 +837,14 @@ void CGraphicPcs::drawBar()
     GXColor1u32(frameColorWord);
     GXTexCoord2u16(0, 2);
 
-    CColor fifoColor = (Graphic.IsFifoOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF);
-    const u32 fifoColorWord = *reinterpret_cast<u32*>(&fifoColor.color);
+    GXColor fifoTmp;
+    *reinterpret_cast<u32*>(&fifoTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFifoOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF)).color);
+    GXColor fifoGX;
+    fifoGX.r = fifoTmp.r;
+    fifoGX.g = fifoTmp.g;
+    fifoGX.b = fifoTmp.b;
+    fifoGX.a = fifoTmp.a;
+    const u32 fifoColorWord = *reinterpret_cast<u32*>(&fifoGX);
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorTop, kGraphicZero);
     GXColor1u32(fifoColorWord);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -792,7 +792,14 @@ void CGraphicPcs::drawBar()
         }
 
         if (i == lastOrder) {
-            const u32 soundColor = Math.Hsb2Rgb(0, 100, 100);
+            GXColor soundTmp;
+            *reinterpret_cast<u32*>(&soundTmp) = Math.Hsb2Rgb(0, 100, 100);
+            GXColor soundGX;
+            soundGX.r = soundTmp.r;
+            soundGX.g = soundTmp.g;
+            soundGX.b = soundTmp.b;
+            soundGX.a = soundTmp.a;
+            const u32 soundColor = *reinterpret_cast<u32*>(&soundGX);
             const float soundWidth = (kGraphicScreenCenterX * Sound.GetPerformance()) / kDebugBarFrameBudget;
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -746,8 +746,13 @@ void CGraphicPcs::drawBar()
     for (int i = 0; i < orderCount; i++) {
         const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;
-        const u32 colorWord = Math.Hsb2Rgb(hue / orderCount, 100, 100);
-        GXColor rgb = *reinterpret_cast<const GXColor*>(&colorWord);
+        GXColor colorTmp;
+        *reinterpret_cast<u32*>(&colorTmp) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        GXColor rgb;
+        rgb.r = colorTmp.r;
+        rgb.g = colorTmp.g;
+        rgb.b = colorTmp.b;
+        rgb.a = colorTmp.a;
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
 
         if (priority == 0x26) {


### PR DESCRIPTION
Raises `main/p_graphic` from 73.35% to 75.10% (+1.75%), all in `drawBar`.

## What changed
All gains come from matching the original's GXColor handling in `drawBar`:

- **Hsb2Rgb color**: split the `*(u32*)&rgb = Hsb2Rgb(...)` into a `u32` word stored into a GXColor temp, then a field-wise byte-copy into the final `rgb`. The original byte-assembles the GXColor (lbz/stb runs), which our single-store reinterpret collapsed; the field copy forces mwcc to emit the target's byte-shuffle and grows the frame toward the target's 0x360.
- **frameColor / fifoColor**: read the color word directly from the ternary `CColor(...)` temporary (no named `CColor` local) into a GXColor, then field-wise byte-copy. This elides the spurious `__ct__6CColorFR6CColor` copy constructor the named-local form produced, and reproduces the target's byte-copy through a GXColor.
- **soundColor**: same GXColor byte-copy pattern as `rgb`.
- **padState**: typed `unsigned int` to match `PadInputs::holdOverride` (`u32`) — found via permuter, also more correct.

## Evidence
- `main/p_graphic` fuzzy: 73.353% -> 75.099% (report.json).
- `drawBar` function: 73.79% -> 80.10%.
- Full build links (Code 100%, Data 99.65% unchanged).

## Plausibility
All changes are normal GXColor value handling — byte-wise channel copies and reading a color word from a constructed color — exactly the lowering the original objects show. The `unsigned` type matches the real field type. No hacks, no layout/header changes.

## Blocker (remaining ceiling)
`drawScreenFade` (58.6%) and the rest of `drawBar` are walled by the documented `__sinit`/anonymous int->double bias pool naming (`@653`/`@646` vs `kIntToDoubleBias`) and the f26/f27 FPR-window in `drawScreenFade` — not source-steerable. `__sinit` is the known section-base WALL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)