### PR TITLE
p_camera: raise fuzzy match to 90.7% (cycle 7)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1646,10 +1646,10 @@ void CCameraPcs::drawShadowBegin()
         }
 
         float currentDepth = m_fullScreenShadowDepth;
-        if (currentDepth >= kCameraZeroF) {
-            m_fullScreenShadowDepth = currentDepth + (depth - currentDepth) * kCameraShadowDepthBlend;
-        } else {
+        if (currentDepth < kCameraZeroF) {
             m_fullScreenShadowDepth = depth;
+        } else {
+            m_fullScreenShadowDepth = currentDepth + (depth - currentDepth) * kCameraShadowDepthBlend;
         }
     } else {
         m_fullScreenShadow.m_span = kCameraHundredF;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1324,9 +1324,9 @@ void CCameraPcs::calcMap()
     }
 
     if ((kCameraZeroF != moveDelta.x) || (kCameraZeroF != moveDelta.y) || (kCameraZeroF != moveDelta.z)) {
-        double boundsMin = kCameraBoundsMinInitial;
-        double boundsMax = kCameraBoundsMaxInitial;
         double radius = kCameraDefaultNearZ;
+        double boundsMax = kCameraBoundsMaxInitial;
+        double boundsMin = kCameraBoundsMinInitial;
         for (i = 4; i != 0; i--) {
             hitCylinder.m_min.z = boundsMin;
             hitCylinder.m_min.y = boundsMin;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1355,7 +1355,7 @@ void CCameraPcs::calcMap()
     C_MTXPerspective(m_screenMatrix, m_fov, kCameraAspectRatio, m_nearZ, m_farZ);
     GXSetProjection(m_screenMatrix, GX_PERSPECTIVE);
 
-    PSVECAdd(&TargetVec(), &PositionVec(), &DirectionVec());
+    PSVECAdd(&PositionVec(), &DirectionVec(), &TargetVec());
 
     upVec.x = kCameraZeroF;
     upVec.y = kCameraOneF;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1306,15 +1306,17 @@ void CCameraPcs::calcMap()
     }
 
     if ((buttons & 0x1) != 0) {
-        sideVec.y = kCameraZeroF;
+        sideVec.x = kCameraZeroF;
         sideVec.z = kCameraZeroF;
+        sideVec.y = kCameraZeroF;
         sideVec.x = kCameraDebugMoveStep;
         PSMTXMultVecSR(rotMtx, &sideVec, &sideVec);
         sideVec.y = kCameraZeroF;
         PSVECAdd(&sideVec, &moveDelta, &moveDelta);
     } else if ((buttons & 0x2) != 0) {
-        sideVec.y = kCameraZeroF;
+        sideVec.x = kCameraZeroF;
         sideVec.z = kCameraZeroF;
+        sideVec.y = kCameraZeroF;
         sideVec.x = kCameraNegativeDebugMoveStep;
         PSMTXMultVecSR(rotMtx, &sideVec, &sideVec);
         sideVec.y = kCameraZeroF;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1324,10 +1324,11 @@ void CCameraPcs::calcMap()
     }
 
     if ((kCameraZeroF != moveDelta.x) || (kCameraZeroF != moveDelta.y) || (kCameraZeroF != moveDelta.z)) {
-        double radius = kCameraDefaultNearZ;
-        double boundsMax = kCameraBoundsMaxInitial;
-        double boundsMin = kCameraBoundsMinInitial;
-        for (i = 4; i != 0; i--) {
+        i = 4;
+        while (i-- != 0) {
+            double radius = kCameraDefaultNearZ;
+            double boundsMax = kCameraBoundsMaxInitial;
+            double boundsMin = kCameraBoundsMinInitial;
             hitCylinder.m_min.z = boundsMin;
             hitCylinder.m_min.y = boundsMin;
             hitCylinder.m_min.x = boundsMin;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1324,15 +1324,23 @@ void CCameraPcs::calcMap()
     }
 
     if ((kCameraZeroF != moveDelta.x) || (kCameraZeroF != moveDelta.y) || (kCameraZeroF != moveDelta.z)) {
+        double boundsMin = kCameraBoundsMinInitial;
+        double boundsMax = kCameraBoundsMaxInitial;
+        double radius = kCameraDefaultNearZ;
         for (i = 4; i != 0; i--) {
-            hitCylinder.m_min.x = kCameraBoundsMinInitial;
-            hitCylinder.m_min.y = kCameraBoundsMinInitial;
-            hitCylinder.m_min.z = kCameraBoundsMinInitial;
-            hitCylinder.m_max.x = kCameraBoundsMaxInitial;
-            hitCylinder.m_max.y = kCameraBoundsMaxInitial;
-            hitCylinder.m_max.z = kCameraBoundsMaxInitial;
-            hitCylinder.m_radius = kCameraDefaultNearZ;
-            hitCylinder.m_bottom = PositionVec();
+            hitCylinder.m_min.z = boundsMin;
+            hitCylinder.m_min.y = boundsMin;
+            hitCylinder.m_min.x = boundsMin;
+            hitCylinder.m_max.z = boundsMax;
+            hitCylinder.m_max.y = boundsMax;
+            hitCylinder.m_max.x = boundsMax;
+            hitCylinder.m_bottom.x = PositionVec().x;
+            hitCylinder.m_bottom.y = PositionVec().y;
+            hitCylinder.m_bottom.z = PositionVec().z;
+            hitCylinder.m_axis.x = moveDelta.x;
+            hitCylinder.m_axis.y = moveDelta.y;
+            hitCylinder.m_axis.z = moveDelta.z;
+            hitCylinder.m_radius = radius;
             if (MapMng.CheckHitCylinder(reinterpret_cast<CMapCylinder*>(&hitCylinder), &moveDelta, 0xFFFFFFFF) != 0) {
                 MapMng.m_hitMapObj->CalcHitSlide(&moveDelta, kCameraTwoF);
             } else {

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -836,16 +836,15 @@ void CCameraPcs::calc()
             const double t = static_cast<double>(kCameraPi *
                 (kCameraOneF - static_cast<float>(m_worldMapEffect.m_timer) /
                 static_cast<float>(m_worldMapEffect.m_duration)));
-            const double f = static_cast<double>(kCameraHalfF * (kCameraOneF + static_cast<float>(cos(t))));
+            const float f = kCameraHalfF * (kCameraOneF + static_cast<float>(cos(t)));
 
-            PSMTXRotRad(tempMtx, 'x', static_cast<float>(static_cast<double>(m_worldMapEffect.m_rotX) * f));
+            PSMTXRotRad(tempMtx, 'x', m_worldMapEffect.m_rotX * f);
             PSMTXConcat(tempMtx, worldMapMtx, worldMapMtx);
-            PSMTXRotRad(tempMtx, 'y', static_cast<float>(static_cast<double>(m_worldMapEffect.m_rotY) * f));
+            PSMTXRotRad(tempMtx, 'y', m_worldMapEffect.m_rotY * f);
             PSMTXConcat(tempMtx, worldMapMtx, worldMapMtx);
 
-            const float scale = -static_cast<float>(
-                static_cast<double>(m_worldMapEffect.m_scale) * (static_cast<double>(kCameraOneF) - f) -
-                static_cast<double>(kCameraOneF + m_worldMapEffect.m_scale));
+            const float scale = (kCameraOneF + m_worldMapEffect.m_scale) -
+                m_worldMapEffect.m_scale * (kCameraOneF - f);
             PSMTXScale(tempMtx, scale, scale, scale);
             PSMTXConcat(tempMtx, worldMapMtx, worldMapMtx);
 


### PR DESCRIPTION
Raises main/p_camera fuzzy match from 89.69% to 90.70% (cycle 7).

## Per-function gains
- **calcMap**: 90.87% → ~93%+. Matched the hit-cylinder init: added the missing `m_axis = moveDelta` assignment, hoisted the bounds/radius constants as `double` locals in the loop-invariant FPR order, reordered min/max stores to z,y,x, and reshaped the retry loop as a comma-`while` so the bounds constants reload at the loop bottom like the target. Also fixed a real `PSVECAdd` argument-order bug (`PSVECAdd(&Target,&Position,&Direction)` → `(&Position,&Direction,&Target)`; result vector is the 3rd arg, so Target = Position + Direction). Matched the sideVec zero-init store ordering.
- **calc**: 81.47% → 82.93%. Made the world-map effect math single-precision: `f` (the cos blend factor) and the rotX/rotY products are now `float` (matching target `fmuls`), and the scale term is reassociated to `(1+s) - s*(1-f)` so mwcc emits the target's fused `fnmsubs` instead of `fmsub`+`frsp`+`fneg`.
- **drawShadowBegin**: 85.18% → 87.67%. Flipped the shadow depth-blend clamp to `if (currentDepth < 0)` so the failure path falls through, eliminating the NaN-aware `fcmpo`+`cror` and matching the target's `bge`/block ordering.

## Plausibility
All changes are ordinary source-level edits: a corrected vector-add argument order (a genuine behavioral bug), a missing struct-field assignment recovered from the DOL/Ghidra, single-precision arithmetic where the target uses single-precision ops, and an equivalent clamp written with the opposite branch polarity. No layout changes, no hardcoded addresses, no compiler-coaxing hacks.

## Blockers (known walls, left untouched)
- `calc`/`draw`: pervasive `this` (r30) vs `&Pad` (r31) callee-saved register-coloring swap shifts ~200 lines; not source-steerable.
- `CopyCameraState` struct-copy: target word-copies the trailing float scalars and uses a different word-pair load order; gated by the shared CameraState header layout (affects 4 functions including drawShadowEndAll).
- `__sinit_p_camera_cpp` `...data.0` base-CSE and the S16-to-double bias-pool symbol naming (CalcQuake) are documented non-steerable walls.
- createFullShadow reg-alloc wall (60%) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)