### PR TITLE
p_camera: raise fuzzy match to 90.8% (cycle 8)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1261,7 +1261,7 @@ void CCameraPcs::calcMap()
     };
     HitCylinder hitCylinder;
 
-    buttons = ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) ? 0 : CameraRawPadInput().button[0];
+    buttons = ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) ? 0 : CameraRawPadInput().buttonDown[0];
 
     stickH = ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) ? kCameraZeroF : CameraRawPadInput().substickYF;
     stickH = kCameraDegToRad * (stickH / kCameraOneEighthF);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1267,12 +1267,12 @@ void CCameraPcs::calcMap()
     stickH = kCameraDegToRad * (stickH / kCameraOneEighthF);
 
     stickV = ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) ? kCameraZeroF : *reinterpret_cast<float*>(&CameraRawPadInput().lockedButton[0]);
-    stickV = kCameraDegToRad * (stickV / kCameraOneEighthF);
+    stickV = -(kCameraDegToRad * (stickV / kCameraOneEighthF));
 
     triggerL = ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) ? kCameraZeroF : CameraRawPadInput().stickYF;
 
     m_fov += triggerL;
-    m_mapRotX -= stickV;
+    m_mapRotX += stickV;
     m_mapRotY -= stickH;
 
     PSMTXRotRad(rotXMtx, 'x', m_mapRotX);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -653,7 +653,7 @@ void CCameraPcs::CalcQuake()
 
     u32 randX = static_cast<u32>(rand());
     u16 signX = static_cast<u16>(randX >> 0x1F);
-    short jitterSignX = static_cast<short>(((randX & 1) ^ signX) - signX);
+    unsigned short jitterSignX = static_cast<short>(((randX & 1) ^ signX) - signX);
 
     u32 randY = static_cast<u32>(rand());
     u16 signY = static_cast<u16>(randY >> 0x1F);


### PR DESCRIPTION
Raises main/p_camera fuzzy match from 90.70% to 90.80% by fixing three real source-level bugs (cycle 8).

## Changes

- **CalcQuake**: `jitterSignX` typed `unsigned short` (was `short`). Cleans up the third-rand bit-twiddling/sign-extend schedule to match the target. CalcQuake 93.87% -> 94.39%. Behavior identical for the `== 0` test.
- **calcMap**: pre-negate `stickV` (`stickV = -(...)`, `m_mapRotX += stickV`). The original baked the negation into the pad-input value, producing `fneg`+`fadds` instead of `fsubs`. Identical behavior.
- **calcMap**: reads `CameraRawPadInput().buttonDown[0]` instead of `button[0]` — a real field-selection bug. The target loads the pad buttons at struct offset 0x4 (`buttonDown`), not 0x0 (`button`); this also corrects the addressing form (`add`+`lhz 0x4` vs `lhzx`). calcMap 96.57% -> 97.52%.

## Evidence
- Unit fuzzy match: 90.70% -> 90.80% (objdiff report.json).
- Per function: CalcQuake +0.51, calcMap +0.95.

## Plausibility
All three are behavior-preserving (unsigned vs signed for a zero-test) or correct genuine bugs (the `buttonDown` field selection matches the target's load offset). No compiler-coaxing hacks; no shared-header layout changes.

## Remaining blockers (documented walls)
calc this/&Pad register-swap; CopyCameraState struct word-vs-float copy ordering (drawShadowBegin, drawShadowEnd, drawShadowEndAll); createFullShadow/destroyFullShadow reg-alloc (constant-0 promotion); calcChara stack-layout; bias-pool naming (`@526` vs `kCameraS16ToDoubleBias`); draw `&g_shadow_pos` base-CSE + this-in-r30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)