### PR TITLE
gobject: raise fuzzy match to 90.57% (cycle 7)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -983,7 +983,7 @@ void CGObject::bgNormalCollision()
     }
 
     if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
-        m_stateFlags0Bits.unk7 = 1;
+        m_stateFlags0Bits.unk0 = 1;
         m_radiusCtrl.x =
             *reinterpret_cast<float*>(&MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask);
         if (gMapHitFace->m_groupIndex != 0) {
@@ -1095,7 +1095,7 @@ void CGObject::bgWorldCollision()
     m_groundHitOffset.z = newOffset.z;
 
     if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
-        m_stateFlags0Bits.unk7 = 1;
+        m_stateFlags0Bits.unk0 = 1;
         m_radiusCtrl.x =
             *reinterpret_cast<float*>(&MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask);
         if (gMapHitFace->m_groupIndex != 0) {

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -957,9 +957,9 @@ void CGObject::bgNormalCollision()
     }
 
     if (retry == 0) {
-        m_groundHitOffset.x = sZeroFloat;
-        m_groundHitOffset.y = sZeroFloat;
         m_groundHitOffset.z = sZeroFloat;
+        m_groundHitOffset.y = sZeroFloat;
+        m_groundHitOffset.x = sZeroFloat;
         return;
     }
 
@@ -1009,10 +1009,7 @@ void CGObject::bgNormalCollision()
     PSVECAdd(&pos, &move, &pos);
 
     if (!(m_jumpLandingDampening > sZeroFloat) || !(m_groundHitOffset.y < sLandingDampenCutoff)) {
-        m_groundHitOffset.x = pos.x - m_worldPosition.x;
-        m_groundHitOffset.y = pos.y - m_worldPosition.y;
-        m_groundHitOffset.z = pos.z - m_worldPosition.z;
-        return;
+        goto simple;
     }
 
     float oldY = m_groundHitOffset.y;
@@ -1039,6 +1036,12 @@ void CGObject::bgNormalCollision()
             sHitProbeHeight + (sHitProbeHeight * m_gravityY) / sStepProbeHeight,
             0);
     }
+    return;
+
+simple:
+    m_groundHitOffset.x = pos.x - m_worldPosition.x;
+    m_groundHitOffset.y = pos.y - m_worldPosition.y;
+    m_groundHitOffset.z = pos.z - m_worldPosition.z;
 }
 
 /*


### PR DESCRIPTION
Raises main/gobject fuzzy match from 90.16% to 90.57% with two real source-level fixes found via an R16 audit of the background-collision functions.

## Changes
- **Wrong state-flag bit in bg collision** (`bgNormalCollision`, `bgWorldCollision`): the source set `m_stateFlags0Bits.unk7` (rlwimi position 31) where the target sets `unk0` (position 24). A genuine bitfield-member bug. Fixed both occurrences.
- **Shared simple-offset block via goto** (`bgNormalCollision`): the landing-dampen early-exit guard and the dampening fall-through both reach one shared `m_groundHitOffset = pos - m_worldPosition` block in the original; the structured `if {...; return;}` duplicated it inline. Restructured with an R14 `goto` to a shared label matching the target's physical block layout. Also fixed the retry==0 zeroing write order (z, y, x).

## Results
- bgNormalCollision: 72.46% -> 79.83%
- bgWorldCollision: 82.68% -> 82.79%
- Unit main/gobject: 90.16% -> 90.57%

## Why plausible
Both are real behavioral/structural facts proven by the target asm (rlwimi bit position; a single shared basic block reached by two branches), not compiler-coaxing. The remaining gap in the collision functions is the known sdata2 float-pool fold-vs-symbol wall plus CVector-materialization / this-register coloring, confirmed to resist source steering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)