### PR TITLE
goout: raise fuzzy match to 93.8% (cycle 6)

### DIFF
--- a/include/ffcc/goout.h
+++ b/include/ffcc/goout.h
@@ -89,7 +89,7 @@ private:
     short m_menuStringSlot;
     int m_pendingMessageTimer;
     int m_messageTimer;
-    char m_messageState;
+    unsigned char m_messageState;
     unsigned char m_messageWindowOpen;
     unsigned char m_cursorChoice;
     unsigned char m_drawCursor;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2626,9 +2626,6 @@ void CGoOutMenu::Calc()
     if (m_messageCloseMode == 0) {
         mode = m_mainMode;
         switch (mode) {
-        case 2:
-            CalcGoOut();
-            break;
         case 0:
             if (m_messageWindowOpen != 0) {
                 input = GetGoOutInputMask();
@@ -2772,6 +2769,9 @@ void CGoOutMenu::Calc()
                 }
                 }
             }
+            break;
+        case 2:
+            CalcGoOut();
             break;
         case 3:
             CalcDel();

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1878,10 +1878,18 @@ card_connected:;
         }
 
         input = GetGoOutInputMask();
-        if ((input & 0x200) != 0) {
-            Sound.PlaySe(3, 0x40, 0x7f, 0);
-            SetGoOutMode(0xf);
-            break;
+        {
+            bool pressed;
+            if ((input & 0x200) != 0) {
+                Sound.PlaySe(3, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
+                SetGoOutMode(0xf);
+                break;
+            }
         }
 
         m_drawCursor = 1;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2673,18 +2673,21 @@ void CGoOutMenu::Calc()
                 m_cursorMode = 1;
 
                 unsigned char nextMode;
-                if (MenuPcs.m_menuWindowInfo->state == 1) {
+                if (MenuPcs.m_menuWindowInfo->state != 1) {
+                    nextMode = 0;
+                    goto do_switch_calc;
+                }
+
+                input = GetGoOutInputMask();
+                if ((input & 0xC) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
                     input = GetGoOutInputMask();
-                    if ((input & 0xC) != 0) {
-                        m_cursorChoice ^= 1;
-                        Sound.PlaySe(1, 0x40, 0x7f, 0);
-                    } else {
-                        input = GetGoOutInputMask();
-                        if ((input & 0x100) != 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                            nextMode = static_cast<unsigned char>(m_cursorChoice + 1);
-                            goto do_switch_calc;
-                        }
+                    if ((input & 0x100) != 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        nextMode = static_cast<unsigned char>(m_cursorChoice + 1);
+                        goto do_switch_calc;
                     }
                 }
 

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2320,22 +2320,25 @@ void CGoOutMenu::CalcDel()
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_del3;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
                 input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
-                        next = static_cast<signed char>(m_cursorChoice + 1);
-                        goto do_switch_del3;
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_del3;
                 }
             }
 
@@ -2377,22 +2380,25 @@ void CGoOutMenu::CalcDel()
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_del4;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
                 input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
-                        next = static_cast<unsigned char>(m_cursorChoice + 1);
-                        goto do_switch_del4;
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_del4;
                 }
             }
 
@@ -2447,22 +2453,25 @@ void CGoOutMenu::CalcDel()
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_del6;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
                 input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
-                        next = static_cast<signed char>(m_cursorChoice + 1);
-                        goto do_switch_del6;
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_del6;
                 }
             }
 
@@ -2504,22 +2513,25 @@ void CGoOutMenu::CalcDel()
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_del7;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
                 input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
-                        next = static_cast<unsigned char>(m_cursorChoice + 1);
-                        goto do_switch_del7;
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_del7;
                 }
             }
 

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2737,7 +2737,7 @@ void CGoOutMenu::Calc()
                     break;
                 }
                 case 2: {
-                    unsigned int activeCount = 0;
+                    int activeCount = 0;
                     for (int i = 0; i < 8; i++) {
                         if (Game.m_caravanWorkArr[i].m_shopState != 0) {
                             activeCount++;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2794,15 +2794,15 @@ void CGoOutMenu::Calc()
         short y;
 
         m_currentMessage = m_pendingMessage;
-        if (m_pendingMessage == -1) {
-            m_messageState = 1;
-        } else {
+        if (m_pendingMessage != -1) {
             MenuPcs.GetWinSize(static_cast<short>(m_currentMessage), &x, &y, (m_currentMessage < 0x1E) ? 0 : 2);
             MenuPcs.SetMcWinInfo(x, y);
             MenuPcs.m_menuWindowInfo->state = 0;
             MenuGoOutState().m_animFrame = 0;
             m_messageTimer = m_pendingMessageTimer;
             m_messageState = 0;
+        } else {
+            m_messageState = 1;
         }
     }
 

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2702,7 +2702,7 @@ void CGoOutMenu::Calc()
                         }
                     }
 
-                    if (characterCount == 0) {
+                    if (characterCount <= 0) {
                         int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
                         SetMenuStr(0, 7,
                                    GetGoOutMessageLine(languageId, 101),

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2719,9 +2719,7 @@ void CGoOutMenu::Calc()
                             }
                         }
 
-                        if (transferableCount < 8) {
-                            SetMainMode(2);
-                        } else {
+                        if (transferableCount >= 8) {
                             int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
                             SetMenuStr(0, 6,
                                        GetGoOutMessageLine(languageId, 62),
@@ -2732,6 +2730,8 @@ void CGoOutMenu::Calc()
                                        GetGoOutMessageLine(languageId, 67));
                             m_nextMainMode = 1;
                             SetMainMode(0);
+                        } else {
+                            SetMainMode(2);
                         }
                     }
                     break;
@@ -2747,14 +2747,7 @@ void CGoOutMenu::Calc()
                         }
                     }
 
-                    if (activeCount < 2) {
-                        int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
-                        SetMenuStr(0, 2,
-                                   GetGoOutMessageLine(languageId, 108),
-                                   GetGoOutMessageLine(languageId, 109));
-                        m_nextMainMode = 1;
-                        SetMainMode(0);
-                    } else {
+                    if (activeCount >= 2) {
                         SetMainMode(3);
                         if (m_currentMessage >= 0) {
                             MenuPcs.m_menuWindowInfo->state = 2;
@@ -2764,6 +2757,13 @@ void CGoOutMenu::Calc()
                         m_pendingMessage = -1;
                         m_messageCloseMode = 0;
                         m_pendingMessageTimer = 0;
+                    } else {
+                        int languageId = static_cast<int>(Game.m_gameWork.m_languageId) - 1;
+                        SetMenuStr(0, 2,
+                                   GetGoOutMessageLine(languageId, 108),
+                                   GetGoOutMessageLine(languageId, 109));
+                        m_nextMainMode = 1;
+                        SetMainMode(0);
                     }
                     break;
                 }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2675,7 +2675,7 @@ void CGoOutMenu::Calc()
                 m_cursorListY1 = 0xB0;
                 m_cursorMode = 1;
 
-                signed char nextMode;
+                unsigned char nextMode;
                 if (MenuPcs.m_menuWindowInfo->state == 1) {
                     input = GetGoOutInputMask();
                     if ((input & 0xC) != 0) {
@@ -2685,7 +2685,7 @@ void CGoOutMenu::Calc()
                         input = GetGoOutInputMask();
                         if ((input & 0x100) != 0) {
                             Sound.PlaySe(2, 0x40, 0x7f, 0);
-                            nextMode = static_cast<signed char>(m_cursorChoice + 1);
+                            nextMode = static_cast<unsigned char>(m_cursorChoice + 1);
                             goto do_switch_calc;
                         }
                     }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1813,10 +1813,18 @@ card_connected:;
         }
 
         input = GetGoOutInputMask();
-        if ((input & 0x200) != 0) {
-            Sound.PlaySe(3, 0x40, 0x7f, 0);
-            SetGoOutMode(0xf);
-            break;
+        {
+            bool pressed;
+            if ((input & 0x200) != 0) {
+                Sound.PlaySe(3, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
+                SetGoOutMode(0xf);
+                break;
+            }
         }
 
         m_drawCursor = 1;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1830,22 +1830,25 @@ card_connected:;
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_go10;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
                 input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
-                        next = static_cast<signed char>(m_cursorChoice + 1);
-                        goto do_switch_go10;
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_go10;
                 }
             }
 
@@ -1880,22 +1883,25 @@ card_connected:;
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_go11;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
                 input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
-                        next = static_cast<signed char>(m_cursorChoice + 1);
-                        goto do_switch_go11;
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_go11;
                 }
             }
 
@@ -1950,23 +1956,26 @@ card_connected:;
         {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state == 1) {
-                input = GetGoOutInputMask();
-                if ((input & 3) != 0) {
-                    m_cursorChoice ^= 1;
-                    Sound.PlaySe(1, 0x40, 0x7f, 0);
-                } else {
-                    input = GetGoOutInputMask();
-                    if ((input & 0x100) != 0) {
-                        if (m_cursorChoice == 0) {
-                            Sound.PlaySe(2, 0x40, 0x7f, 0);
-                        } else if (m_cursorChoice == 1) {
-                            Sound.PlaySe(3, 0x40, 0x7f, 0);
-                        }
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_go3;
+            }
 
-                        next = static_cast<signed char>(m_cursorChoice + 1);
-                        goto do_switch_go3;
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
+                input = GetGoOutInputMask();
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
+
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_go3;
                 }
             }
 


### PR DESCRIPTION
Raises main/goout fuzzy match from 92.16% to 93.78% via source-level structure fixes (no hacks, no shared-header layout changes).

## Per-function gains
- Calc: 87.66 -> 97.15
- CalcGoOut: 88.23 -> 89.04
- CalcDel: 95.57 -> 95.62
- DrawGoOutMenu: unchanged (walls)

## What worked
- **switch case-order**: reordered Calc's m_mainMode switch to source order 0,1,2,3 matching the target's body emission (resolved a CalcGoOut-call INSERT).
- **if/else arm inversion (R9)**: inverted `transferableCount < 8` and `activeCount < 2` clamps in Calc so the target's inline/forward body layout matches (largest single jump, +1.1).
- **state!=1 early-exit goto**: the cursor-menu blocks test `MenuPcs.m_menuWindowInfo->state == 1` then fall through to `next=0`. The target branches into the body via `beq` with an explicit skip; restructured to `if (state != 1) goto;` early-exit in Calc (x1), CalcDel (x4), CalcGoOut (x3).
- **pressed-bool pattern**: CalcGoOut cases 0x10/0x11 wrote a direct `if ((input & 0x200))` where the target materializes a `bool pressed` (li 1/li 0/clrlwi); rewriting to the bool form recovered a large missing-block divergence (+0.26).
- **sign/type audit (R16)**: `nextMode`/`next` cursor selectors -> `unsigned char` (clrlwi vs extsb); `m_messageState` field -> `unsigned char`; `activeCount` -> signed `int` (cmpwi vs cmplwi); `characterCount == 0` -> `<= 0` (bgt vs bne).

## Blockers (documented walls, not source-steerable)
- this/MenuPcs r30<->r31 register swap cascading through all member/Game/Pad base accesses (dominant remaining cost in Calc/CalcGoOut/CalcDel).
- Inlined GetGoOutInputMask Pad-base coloring: target caches the held-mask `0x1c4(Pad)` in a callee-saved reg and reuses it; ours reloads.
- SetMemCardError switch-pivot: mwcc binary-search midpoints differ by +1 consistently; case constants already match the target.
- Float-pool symbol naming (DOUBLE_/FLOAT_ vs @NNN) in DrawGoOutMenu.
- Deep per-case sub-block scheduling within CalcGoOut (case-body order already matches the jumptable; residual is intra-body ordering + the r30/r31 cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)