### PR TITLE
joybus: raise fuzzy match to 89.4% (cycle 9)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2353,7 +2353,7 @@ void JoyBus::ThreadInit()
         m_threadParams[i].m_portIndex = i;
         m_threadParams[i].m_gbaStatus = 1;
 
-        unsigned char* stackBase = m_sendBuffer[i] + sizeof(m_sendBuffer[0]);
+        unsigned char* stackBase = m_sendBuffer[i + 1];
 
         OSCreateThread(
             &m_threads[i],


### PR DESCRIPTION
## Summary
Raises `main/joybus` fuzzy match from 89.30% to 89.37%.

## Per-function gain
- **ThreadInit**: 83.40% -> 99.82%. The stack base for each per-port thread was written as `m_sendBuffer[i] + sizeof(m_sendBuffer[0])`, which made mwcc materialize a separate `0x1000`-advancing cursor through the loop. That extra induction variable inflated the frame by two callee-saved registers (`stmw r25` vs the target's `stmw r27`) and shifted the entire register window, costing ~17 points. Rewriting it as the byte-identical `m_sendBuffer[i + 1]` lets mwcc compute `(i+1)<<12` fresh each iteration, matching the target's three-cursor loop and frame size exactly. Only the trailing string-pool anchoring differs now.

## Why this is plausible source
`m_sendBuffer[i + 1]` is the natural way to express "the top of slot i's stack" (slot bases are contiguous 0x1000 buffers), and produces identical behavior to the previous expression.

## Blockers (documented walls, not pursued further)
- The Set*/Send* command-queue family (SetCmdLst, SetTmpArti, SendUseItem, SendHitEnemy, SendResult, SendStartBonus, RequestData, SendAddLetter) all share one residual diff class: a deterministic r29/r30 callee-saved swap (cmdWord vs &m_threadParams[portIndex]) plus the result-in-rN-then-`mr r3,rN` idiom. Caching the threadParams base, reordering locals, and permute_fn (300 passes) all failed to flip the coloring.
- RestartThread: dominated by the `...rodata.0` section-base CSE wall (target anchors to the named `s_dvd_gba_dir` symbol) plus the resulting register-window shift through the boot-image checksum.
- SendBonusStr / SendPpos: `this`/threadParam coloring + an extra per-payload cursor; removing the cached pointer locals regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)