### PR TITLE
gobject: raise fuzzy match to 91.2% (cycle 8)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -976,10 +976,7 @@ void CGObject::bgNormalCollision()
     stepCylinder.m_radius = m_capsuleHalfHeight;
 
     if (MapMng.CheckHitCylinderNear(&stepCylinder, &move, m_bgHitMask) == 0) {
-        pos.y -= m_capsuleHalfHeight;
-        PSVECAdd(&pos, &move, &pos);
-        PSVECSubtract(&pos, &m_worldPosition, &m_groundHitOffset);
-        return;
+        goto stepMiss;
     }
 
     if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
@@ -1036,6 +1033,12 @@ simple:
     m_groundHitOffset.x = pos.x - m_worldPosition.x;
     m_groundHitOffset.y = pos.y - m_worldPosition.y;
     m_groundHitOffset.z = pos.z - m_worldPosition.z;
+    return;
+
+stepMiss:
+    pos.y -= m_capsuleHalfHeight;
+    PSVECAdd(&pos, &move, &pos);
+    PSVECSubtract(&pos, &m_worldPosition, &m_groundHitOffset);
 }
 
 /*

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1012,15 +1012,8 @@ void CGObject::bgNormalCollision()
         goto simple;
     }
 
-    float oldY = m_groundHitOffset.y;
-    if (oldY < sMinGroundClamp) {
-        oldY = sMinGroundClamp;
-    }
-
-    float clampedY = m_groundHitOffset.y;
-    if (clampedY < sMinGroundClamp) {
-        clampedY = sMinGroundClamp;
-    }
+    float oldY = (m_groundHitOffset.y < sMinGroundClamp) ? sMinGroundClamp : m_groundHitOffset.y;
+    float clampedY = (m_groundHitOffset.y < sMinGroundClamp) ? sMinGroundClamp : m_groundHitOffset.y;
 
     m_worldPosition.y = pos.y;
     m_gravityY = m_jumpLandingDampening * -((clampedY - (oldY - move.y)) + (oldY - move.y));

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -984,8 +984,8 @@ void CGObject::bgNormalCollision()
 
     if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
         m_stateFlags0Bits.unk0 = 1;
-        m_radiusCtrl.x =
-            *reinterpret_cast<float*>(&MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask);
+        *reinterpret_cast<u32*>(&m_radiusCtrl.x) =
+            MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask;
         if (gMapHitFace->m_groupIndex != 0) {
             m_lastBgGroup = static_cast<short>(gMapHitFace->m_groupIndex);
         }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -987,7 +987,7 @@ void CGObject::bgNormalCollision()
         *reinterpret_cast<u32*>(&m_radiusCtrl.x) =
             MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask;
         if (gMapHitFace->m_groupIndex != 0) {
-            m_lastBgGroup = static_cast<short>(gMapHitFace->m_groupIndex);
+            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(gMapHitFace->m_groupIndex);
         }
         MapMng.m_hitMapObj->GetHitFaceNormal(&HitFaceNormal());
     }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1099,7 +1099,7 @@ void CGObject::bgWorldCollision()
         m_radiusCtrl.x =
             *reinterpret_cast<float*>(&MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask);
         if (gMapHitFace->m_groupIndex != 0) {
-            m_lastBgGroup = static_cast<short>(gMapHitFace->m_groupIndex);
+            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(gMapHitFace->m_groupIndex);
         }
         MapMng.m_hitMapObj->GetHitFaceNormal(&HitFaceNormal());
     }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1015,8 +1015,9 @@ void CGObject::bgNormalCollision()
     float oldY = (m_groundHitOffset.y < sMinGroundClamp) ? sMinGroundClamp : m_groundHitOffset.y;
     float clampedY = (m_groundHitOffset.y < sMinGroundClamp) ? sMinGroundClamp : m_groundHitOffset.y;
 
+    float delta = oldY - move.y;
     m_worldPosition.y = pos.y;
-    m_gravityY = m_jumpLandingDampening * -((clampedY - (oldY - move.y)) + (oldY - move.y));
+    m_gravityY = m_jumpLandingDampening * -((clampedY - delta) + delta);
     m_groundHitOffset.y = sZeroFloat;
     m_groundHitOffset.x = pos.x - m_worldPosition.x;
     m_groundHitOffset.z = pos.z - m_worldPosition.z;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -929,12 +929,12 @@ void CGObject::bgNormalCollision()
     pos.y += sStepProbeHeight + m_capsuleHalfHeight;
 
     unsigned int retry = 4;
-    const float capsuleRadius = m_capsuleHalfHeight;
+    const double epsilon = DOUBLE_80330400;
     while (retry != 0) {
         CMapCylinder bodyCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
         bodyCylinder.m_bottom = pos;
         bodyCylinder.m_axis = move;
-        bodyCylinder.m_radius = capsuleRadius;
+        bodyCylinder.m_radius = m_capsuleHalfHeight;
 
         if (MapMng.CheckHitCylinderNear(&bodyCylinder, &move, m_bgHitMask) == 0) {
             break;
@@ -943,13 +943,13 @@ void CGObject::bgNormalCollision()
         m_stateFlags0Bits.unk1 = 1;
         MapMng.m_hitMapObj->CalcHitSlide(&move, sJumpLift);
 
-        if (fabs(static_cast<double>(move.x)) < DOUBLE_80330400) {
+        if (fabs(static_cast<double>(move.x)) < epsilon) {
             move.x = sZeroFloat;
         }
-        if (fabs(static_cast<double>(move.y)) < DOUBLE_80330400) {
+        if (fabs(static_cast<double>(move.y)) < epsilon) {
             move.y = sZeroFloat;
         }
-        if (fabs(static_cast<double>(move.z)) < DOUBLE_80330400) {
+        if (fabs(static_cast<double>(move.z)) < epsilon) {
             move.z = sZeroFloat;
         }
 


### PR DESCRIPTION
Raises main/gobject fuzzy match from 90.57% to 91.17% (cycle 8).

## What changed
All gains landed in bgNormalCollision (79.83 -> 90.38) with a small assist to bgWorldCollision (82.79 -> 83.21):

- **R14 out-of-line goto for the stepCylinder-miss block** (biggest lever, +~9 on the function): the `if (CheckHitCylinderNear(&stepCylinder, ...) == 0) { ... return; }` early-return body was emitted inline by mwcc, but the target places that body out of line, reached by a forward `beq`. Converted to `goto stepMiss;` with the body emitted after the `simple:` block, matching the target's basic-block order exactly.
- **clamp-as-select** for the landing-dampen `oldY`/`clampedY` clamps (ternary instead of `if (x < c) x = c;`) — matches the target's `bge; b; fmr` select instead of the NaN-aware `fcmpo`/`cror` form.
- **shared `delta` subexpression** (`oldY - move.y`) so the gravity-Y computation reuses one value instead of recomputing, matching the target's operand association.
- **loop-scoped `epsilon` double cache** of DOUBLE_80330400 so mwcc keeps it in callee-saved f31 across the retry-loop's three fabs comparisons (the top-level three intentionally still reload, as the target does).
- **integer word-copy** for `m_radiusCtrl.x = mask` (target uses `lwzx`/`stw`, not `lfsx`/`stfs`).
- **byte store** for `m_lastBgGroup` (target uses `stb` at 0xe8) in both bgNormalCollision and bgWorldCollision.

## Why it's plausible source
The goto reproduces the original control flow (no fake labels/addresses); the clamp ternary, shared subexpression, and int/byte field accesses are ordinary hand-written idioms that map to the shipped codegen.

## Blockers (documented walls, left as-is)
- bgAttribCollision (~72%), SetPosBG (~77%), bgWorldCollision: dominated by the CVector-temporary materialization coloring — the target keeps each `CVector` ctor return pointer in r30/r7 and copies cylinder fields through it, while mwcc batch-loads the components. Multiple source forms (conversion-operator deref, explicit Vec& / Vec* casts, per-component assignment) produced identical codegen.
- onCreate (~76%): the whole function is shifted by `this` living in r3 (target) vs r31 (ours); this-coloring wall.
- The `@NNNN` anonymous float-pool vs named-symbol differences are the known sdata2 fold-vs-symbol wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)