### PR TITLE
cmake: raise fuzzy match to 88.1% (cycle 7)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2165,21 +2165,23 @@ unsigned short CMenuPcs::CmakeTribeCtrl()
         return 0;
     } else {
         int fieldSelect = CmakeState(this)->m_fieldSelect;
-        short& currentValue = *reinterpret_cast<short*>(
-            reinterpret_cast<char*>(CmakeState(this)) + fieldSelect * 2 + offsetof(CmakeMenuState, m_select));
 
         if ((repeat & 0x8) != 0) {
-            if (currentValue != 0) {
-                currentValue = static_cast<short>(currentValue - 1);
+            short* values = &CmakeState(this)->m_select;
+            int idx = CmakeState(this)->m_fieldSelect;
+            if (values[idx] != 0) {
+                values[idx] = static_cast<short>(values[idx] - 1);
             } else {
-                currentValue = 3;
+                values[idx] = 3;
             }
             Sound.PlaySe(1, 0x40, 0x7F, 0);
         } else if ((repeat & 0x4) != 0) {
-            if (currentValue < 3) {
-                currentValue = static_cast<short>(currentValue + 1);
+            short* values = &CmakeState(this)->m_select;
+            int idx = CmakeState(this)->m_fieldSelect;
+            if (values[idx] < 3) {
+                values[idx] = static_cast<short>(values[idx] + 1);
             } else {
-                currentValue = 0;
+                values[idx] = 0;
             }
             Sound.PlaySe(1, 0x40, 0x7F, 0);
         }


### PR DESCRIPTION
Raises main/cmake from 88.00% to 88.08%.

## Change
**CmakeTribeCtrl (86.66% -> 88.73%)**: The tribe/hair selection up/down handler indexed into the `m_select`/`m_row` pair via a cached `short&` reference (`*(short*)((char*)state + fieldSelect*2 + offsetof(m_select))`). mwcc colored that into indexed `lhax`/`sthx` accesses with the index held separately. The original recomputed the element pointer inside each repeat-branch, so it emits `slwi; add; lha 0x26(rN)` / `sth 0x26(rN)` instead. Replacing the cached reference with `short* values = &state->m_select; int idx = state->m_fieldSelect; values[idx]` per branch matches the original's addressing and removes the indexed-store mismatch run.

## Blockers (deep effort, reverted)
- DrawDiaryBase int-Y fold: making the Y coordinate an int (24) converted via the 0x4330 magic-double matched the conversion shape but propagated a register-window shift (frame 0x70 vs target 0x80, `stmw r27` vs `r26`) that regressed the function net. Known wall.
- CmakeVillageDraw / DrawCmakeName / CmakeNameDraw: alpha f30/f31 callee-saved-FPR coloring and frame-size (extra scratch) differences; perturbations did not net-improve.
- *Ctrl pad-read prologue (`down`/`repeat` GetPadInputs block) and m_cmakeState state-pointer register coloring (redundant `extsh.`/`clrlwi.` vs `cmpwi`) are systematic across CmakeNameCtrl/TribeCtrl/JobCtrl/CalcSingCMake.
- CmakeNameCtrl 64-bit signed subtract (`(s64)m_select - 10`) matched locally but was net-neutral on the unit.
- DrawCmakeYesNo yesX/noX base-offset float lowering: target magic-double-converts the int base (0x1D0/0x218); could not coax mwcc to emit a runtime conversion of the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)