### PR TITLE
gobject: raise fuzzy match to 91.19% (cycle 9)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1079,7 +1079,9 @@ void CGObject::bgWorldCollision()
 
     CMapCylinder bodyCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
     bodyCylinder.m_bottom = radial;
-    bodyCylinder.m_axis = hitMove;
+    bodyCylinder.m_axis.x = scaledHitMove.x;
+    bodyCylinder.m_axis.y = scaledHitMove.y;
+    bodyCylinder.m_axis.z = scaledHitMove.z;
     bodyCylinder.m_radius = sZeroFloat;
 
     const u32 hitMask = m_bgHitMask;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -983,8 +983,9 @@ void CGObject::bgNormalCollision()
         m_stateFlags0Bits.unk0 = 1;
         *reinterpret_cast<u32*>(&m_radiusCtrl.x) =
             MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask;
-        if (gMapHitFace->m_groupIndex != 0) {
-            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(gMapHitFace->m_groupIndex);
+        const int groupIndex = gMapHitFace->m_groupIndex;
+        if (groupIndex != 0) {
+            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(groupIndex);
         }
         MapMng.m_hitMapObj->GetHitFaceNormal(&HitFaceNormal());
     }
@@ -1096,10 +1097,11 @@ void CGObject::bgWorldCollision()
 
     if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
         m_stateFlags0Bits.unk0 = 1;
-        m_radiusCtrl.x =
-            *reinterpret_cast<float*>(&MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask);
-        if (gMapHitFace->m_groupIndex != 0) {
-            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(gMapHitFace->m_groupIndex);
+        *reinterpret_cast<u32*>(&m_radiusCtrl.x) =
+            MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask;
+        const int groupIndex = gMapHitFace->m_groupIndex;
+        if (groupIndex != 0) {
+            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(groupIndex);
         }
         MapMng.m_hitMapObj->GetHitFaceNormal(&HitFaceNormal());
     }


### PR DESCRIPTION
## Summary
Raises `main/gobject` fuzzy match from baseline **91.17% to 91.19%** (cycle 9).

## Changes
- **bg*Collision integer word-copy + signed groupIndex** (`bgWorldCollision`, `bgNormalCollision`): the `m_radiusCtrl.x = *(float*)&...m_mask` reinterpret-store was emitting `lfsx`/`stfs` where the target does an integer word-copy `lwzx`/`stw`; switched to the `*(u32*)&m_radiusCtrl.x = ...m_mask` idiom already used elsewhere in the file. Also cached `gMapHitFace->m_groupIndex` in a signed `int` local so the `!= 0` test emits the target's signed `cmpwi` instead of `cmplwi`.
- **bgWorldCollision cylinder axis assign**: replaced the whole-struct `bodyCylinder.m_axis = hitMove` copy with component-wise assignment from `scaledHitMove`, matching the target's common-subexpression pattern (reuses the scaled vector for both the materialized `hitMove` and the cylinder axis).

## Evidence
- Unit `main/gobject`: 91.16963% -> 91.19395% (objdiff report.json).
- `bgWorldCollision`: integer-copy and signed-compare mismatches resolved; cylinder-axis CSE nudged the function up.

## Plausibility
All changes mirror idioms already present in the file (the `u32` reinterpret store is used verbatim in adjacent collision code) and represent ordinary hand-written field assignments — not compiler coaxing.

## Blocker
The remaining gap in `bgWorldCollision`/`bgAttribCollision`/`SetPosBG`/`onCreate` is the documented CVector-materialization wall: the original caches freshly-constructed `CVector` temporary addresses in callee-saved GPRs (`mr r30,r3`/`mr r7,r3`) and copies cylinder fields by reloading those opaque objects, while mwcc constant-folds our equivalent constructions. The stack-slot coalescing (frame 0xc0 vs target 0xd0) and `this`-register coloring (r3 vs r31 in `onCreate`) are byte-identical across all source forms tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)