### PR TITLE
materialman: raise fuzzy match to 94.02% (cycle 5)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -3401,10 +3401,12 @@ void CMaterialSet::SetPartFromTextureSet(CTextureSet* textureSet, int pdtSlotInd
             CMaterial* newMaterial =
                 new (MaterialMan.GetMemoryStage(), const_cast<char*>(s_materialman_cpp), 0xEE4) CMaterial;
 
+            float scale = kTextureOne;
             newMaterial->m_tevBit = 0xFFF531F0;
             newMaterial->m_bumpLight = 0;
-            newMaterial->m_scaleU = kTextureOne;
-            newMaterial->m_scaleV = kTextureOne;
+            newMaterial->m_textureCount = 0;
+            newMaterial->m_scaleV = scale;
+            newMaterial->m_scaleU = scale;
             newMaterial->m_singleTextureFlag = 0;
             newMaterial->m_textureCount = 1;
             newMaterial->m_textureIndices[0] = static_cast<short>(textureIndex);


### PR DESCRIPTION
## Summary
Raises `main/materialman` fuzzy match from 94.01% to 94.02%.

### What changed
`CMaterialSet::SetPartFromTextureSet`: reordered the `newMaterial` field initialization to match the exact idiom used by `CMaterial::Create` in the same file (`m_textureCount = 0` before the scale fields, `m_scaleV` assigned before `m_scaleU` via a shared `scale` local, then `m_textureCount = 1`). This matches the target's store sequence at offsets 0x18/0x2c/0x30 and removes the swapped float-store and missing halfword-store diffs.

- `SetPartFromTextureSet` 98.49% -> 99.44%

### Why this is plausible source
The reordering makes `SetPartFromTextureSet` use the identical material-initialization sequence already present in `CMaterial::Create` two functions below it — clearly the same hand-written idiom, not compiler coaxing.

### Investigated but walled
The remaining gaps are dominated by the documented register-window / float-pool walls:
- `SetMaterial` (86.95%), `SetMaterialPart`, `SetMaterialMenu`: `this`/`tevBit` callee-saved coloring (target keeps one extra GPR; multiple local-reorder and member-access-rebasing attempts regressed).
- `GetCharaShadow` (62%): `outputCount*4` CSE + CTR-vs-blt loop divergence.
- `Create` (85%): register-window.
- `SetUnderWaterTex`, `Calc`: sdata2 anonymous-vs-named float/double pool and f-register allocation.

A macro-based fix to make the `_GXSetTev*` wrappers emit the enum-mangled direct calls (the correct original symbols) was confirmed correct for the `addtev_*` family (several reached 100%) but net-regressed the unit because it amplified `SetMaterial`'s register-window divergence, so it was not shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)