### PR TITLE
p_graphic: raise fuzzy match to 75.2% (cycle 6)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -845,7 +845,7 @@ void CGraphicPcs::drawBar()
     GXTexCoord2u16(0, 2);
 
     GXColor fifoTmp;
-    *reinterpret_cast<u32*>(&fifoTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFifoOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF)).color);
+    *reinterpret_cast<u32*>(&fifoTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFifoOver() != 0) ? CColor(0xFF, 0, 0, 0xFF) : CColor(0, 0xFF, 0, 0xFF)).color);
     GXColor fifoGX;
     fifoGX.r = fifoTmp.r;
     fifoGX.g = fifoTmp.g;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -823,7 +823,7 @@ void CGraphicPcs::drawBar()
     }
 
     GXColor frameTmp;
-    *reinterpret_cast<u32*>(&frameTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFrameRateOver() == 0) ? CColor(0, 0xFF, 0, 0xFF) : CColor(0xFF, 0, 0, 0xFF)).color);
+    *reinterpret_cast<u32*>(&frameTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFrameRateOver() != 0) ? CColor(0xFF, 0, 0, 0xFF) : CColor(0, 0xFF, 0, 0xFF)).color);
     GXColor frameGX;
     frameGX.r = frameTmp.r;
     frameGX.g = frameTmp.g;
@@ -873,13 +873,14 @@ void CGraphicPcs::drawBar()
         x = kGraphicZero;
         y = 0x10;
         for (int i = 0; i < orderCount; i++) {
+            const int priority = order->m_priority;
             const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 
-            if (order->m_priority != 0x27) {
+            if (priority != 0x27) {
                 char debugString[260];
                 sprintf(debugString, const_cast<char*>(s_graphic_order_debug_fmt), order->m_debugName, order->m_insertIndex, order->m_lastTime);
 
-                if (order->m_priority == 0x17) {
+                if (priority == 0x17) {
                     char extraString[256];
                     sprintf(extraString, const_cast<char*>(s_graphic_move_debug_fmt),
                             CFlatMoveTime(), CFlatBgCollisionTime(),


### PR DESCRIPTION
## Summary
Raised main/p_graphic fuzzy match from 75.10% to 75.15% via two real source-correctness fixes in `CGraphicPcs::drawBar` (80.10% -> 80.29%).

## Changes
- **Cache `order->m_priority` in a local** in the debug-text loop. The original read the priority field once into a callee-saved register and reused it for both the `!= 0x27` and `== 0x17` tests; we were reloading it, inserting a spurious `lwz`. Caching collapses that mismatch and fixes the loop's register coloring.
- **Match frame-rate / fifo over-budget ternary polarity.** The indicator-color ternaries now read `(IsFrameRateOver() != 0) ? red : green` / `(IsFifoOver() != 0) ? red : green` (semantically identical to the prior `== 0 ? green : red`), matching the original's literal emission order.

## Evidence
- Unit: 75.099% -> 75.151%
- drawBar: 80.102% -> 80.279% (priority cache) + ternary polarity
- No other function regressed; data/linkage unchanged.

## Plausibility
Both changes are ordinary hand-source idioms (caching a hot field read; writing a status ternary as over->red). No compiler-coaxing, no layout or header changes.

## Remaining blockers (documented walls)
- `__sinit` (`...data.0` base-CSE), drawScreenFade (FPR-window), and drawBar's two loop register-window shifts + frame-size delta all resist source-level reordering (every attempt regressed; permute_fn found nothing). drawSFCircle is walled on int->double bias anonymous-pool naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)