### PR TITLE
joybus: raise fuzzy match to 89.38% (cycle 10)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4610,7 +4610,7 @@ int JoyBus::MakeJoyData(char* src, int length, unsigned int* outBuffer)
     while (--chunkCount >= 0) {
         bVar2 = *pbVar4;
         pbVar4 = pbVar4 + 1;
-        uVar5 = ((uVar5 << 8) ^ static_cast<unsigned int>(JoyBusCrcTable[(uVar5 >> 8) ^ static_cast<unsigned int>(bVar2)])) & 0xFFFF;
+        uVar5 = (((uVar5 & 0xFFFF) << 8) ^ static_cast<unsigned int>(JoyBusCrcTable[((uVar5 >> 8) & 0xFF) ^ static_cast<unsigned int>(bVar2)])) & 0xFFFF;
     }
 
     unsigned short inv = static_cast<unsigned short>(~static_cast<unsigned short>(uVar5));


### PR DESCRIPTION
## Summary
Cycle-10 pass on main/joybus (51KB, biggest absolute unmatched in B4).

**MakeJoyData** CRC loop: 85.81% -> 86.76% (unit 89.37347% -> 89.38127%).

### What worked
The CRC accumulation loop computed `(crc << 8)` and `(crc >> 8)` on an `unsigned int` masked only at the end. mwcc emitted plain `srwi`/`slwi`. The target uses `extrwi`/`clrlslwi` (16-bit extract/clear-shift) — the `unsigned short` byte idiom. Adding explicit `(uVar5 & 0xFFFF) << 8` and `(uVar5 >> 8) & 0xFF` masks reproduced the target's `clrlslwi`/`extrwi` opcodes exactly. (A literal `unsigned short crc` retype regressed to 79%; the explicit-mask form on the `unsigned int` is what matches.)

### Blockers (confirmed walls, per campaign notes)
- **RestartThread / CreateInit**: `...rodata.0` base-CSE vs target's named `s_dvd_gba_dir@ha/@l` anchor. R3 def-reordering not viable for static-const strings. Plus deep register-window shift (target saves r26-r31, we save r23-r31 / r24-r31).
- **GBARecvSend**: mwcc fuses the `op==0x1c||0x1d||0x1e||0x1f` dispatch into a range check (`subi;cmplwi;ble`) where the target emits 4 separate `cmpwi;beq`; this drives a whole register-window shift (one extra saved reg). OR-reordering does not defeat the fusion. Permuter found 0 candidate mutations.
- **SendPpos / SendBonusStr / SendChkCrc**: result-in-rN-vs-r3/r0 idiom + extra callee-saved regs. Permuter found no improving mutations; result-hoist and init-reorder no-changed.
- **MakeJoyData remainder**: arg-register swap (src/length r9<->r10) and the two trailing hand-unrolled `do/while` loops want `mtctr/bdnz`; R10 `for`-conversion regressed hard (0%).
- **SendMapObjDrawFlg**: byte-reverse copy load/store batching vs target interleaving — mwcc scheduling, not source-steerable (reorder regressed).

Permuter (tools/permute_fn.py) run across RestartThread, CreateInit, GBARecvSend, SendBonusStr, SendPpos, MakeJoyData, SendMapObjDrawFlg, SendAddLetter, SetMoney, SendChkCrc, SetTmpArti, SendUseItem — zero improving mutations beyond the MakeJoyData mask fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)