### PR TITLE
cmake: raise fuzzy match to 88.2% (cycle 8)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -904,8 +904,8 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
     unsigned short repeat;
     char picked[8];
 
-    int padLock = Pad.m_debugPadLock;
     bool padBusy = false;
+    int padLock = Pad.m_debugPadLock;
     if ((padLock != 0) || (Pad.m_debugPadPort != -1)) {
         padBusy = true;
     }
@@ -2128,8 +2128,8 @@ unsigned short CMenuPcs::CmakeTribeCtrl()
     unsigned short down;
     unsigned short repeat;
 
-    int padLock = Pad.m_debugPadLock;
     bool padBusy = false;
+    int padLock = Pad.m_debugPadLock;
     if ((padLock != 0) || (Pad.m_debugPadPort != -1)) {
         padBusy = true;
     }
@@ -2664,8 +2664,8 @@ int CMenuPcs::CmakeNameCtrl()
     unsigned short down;
     unsigned short repeat;
 
-    int padLock = Pad.m_debugPadLock;
     bool padBusy = false;
+    int padLock = Pad.m_debugPadLock;
     if ((padLock != 0) || (Pad.m_debugPadPort != -1)) {
         padBusy = true;
     }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1003,8 +1003,8 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             }
 
             int nameLen = strlen(s_CmakeInfo.m_name);
-            int spaceCount = 0;
             const char* scan = s_CmakeInfo.m_name;
+            int spaceCount = 0;
             int remain = nameLen;
             for (; 0 < remain; remain = remain - 1) {
                 if (*scan != ' ') {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1823,8 +1823,8 @@ unsigned short CMenuPcs::CmakeJobCtrl()
     unsigned short down;
     unsigned short repeat;
 
-    int padLock = Pad.m_debugPadLock;
     bool padBusy = false;
+    int padLock = Pad.m_debugPadLock;
     if ((padLock != 0) || (Pad.m_debugPadPort != -1)) {
         padBusy = true;
     }


### PR DESCRIPTION
Raises main/cmake from 88.08% to 88.24% via plausible source-ordering fixes in the controller functions.

## Changes
- **CmakeJobCtrl / CmakeVillageCtrl / CmakeTribeCtrl / CmakeNameCtrl**: declare `bool padBusy = false;` before `int padLock = Pad.m_debugPadLock;`. This matches the original's pad-read prologue: `padBusy=false` is materialized (`li rN,0`) before the padLock load, keeping padLock in the register the target uses (r5) and dropping a spurious `li r5,0x0`. Net: TribeCtrl 96->87 flagged lines, NameCtrl 206->199, plus Village/Job gains.
- **CmakeVillageCtrl**: declare `scan` before `spaceCount` in the name whitespace-skip loop. Matches the target's two-pointer register assignment (scan in r4, counter in r5) and the post-loop `spaceCount == nameLen` reuse. 99->94 flagged lines.

## Evidence
objdiff report.json main/cmake fuzzy_match_percent: 88.07642 -> 88.24283.

## Why plausible
All three changes are pure local-declaration reordering with identical behavior; they recover the original statement/declaration order that drives mwcc's register allocation. No hacks, no layout changes.

## Blockers (documented walls, confirmed this cycle)
- Pad-read prologue `padIndex` block: target keeps `&Pad` in a callee-saved base reg and reads `m_debugPadPort` through it; our codegen swaps the base/scratch registers. Multiple R8/cache restructurings all regressed.
- `down`/`repeat` signedness (`extsh`): making them `short` regresses; the redundant `extsh.` is incidental to the prologue window, not independently fixable.
- DrawDiaryBase int-Y fold (frame 0x80 vs 0x70); CalcSingCMake m_cmakeState state-pointer coloring (full caching regressed 88.2->87.9); DrawCmakeName constant-nameX (target computes SetPosX X from a pooled constant, not GetWidth -- exact constant unrecoverable without behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)