### PR TITLE
goout: raise fuzzy match to 95.0% (cycle 9)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2193,7 +2193,7 @@ void CGoOutMenu::SetDelMode(unsigned char mode)
         if (Game.m_caravanWorkArr[m_selectedChara].m_caravanLocalFlags == 0) {
             int activeMainCharacterCount = 0;
             for (int i = 0; i < 8; i++) {
-                if (Game.m_caravanWorkArr[i].m_objType != 0 && Game.m_caravanWorkArr[i].m_caravanLocalFlags == 0) {
+                if (Game.m_caravanWorkArr[i].m_shopState != 0 && Game.m_caravanWorkArr[i].m_caravanLocalFlags == 0) {
                     activeMainCharacterCount++;
                 }
             }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2598,8 +2598,14 @@ void CGoOutMenu::CalcDel()
     case 8:
         if (m_messageWindowOpen != 0 && static_cast<int>(MenuPcs.IsMenuCharaAnimIdle(m_selectedChara)) != 0) {
             input = GetGoOutInputMask();
+            bool pressed;
             if ((input & 0x100) != 0) {
                 Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
                 SetDelMode(1);
             }
         }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1296,7 +1296,7 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
         m_cardChannel = static_cast<char>(MenuPcs.m_mcCtrl.m_cardChannel);
         m_saveIndex = static_cast<char>(m_accessSaveIndex);
-        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<signed char>(m_cardChannel));
+        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(m_cardChannel);
         if (m_memCardResult == 1) {
             const unsigned char savedSaveIndex = static_cast<unsigned char>(m_saveIndex);
             const unsigned char savedCardChannel = static_cast<unsigned char>(m_cardChannel);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2458,8 +2458,14 @@ void CGoOutMenu::CalcDel()
     case 5:
         if (m_messageWindowOpen != 0 && static_cast<int>(MenuPcs.IsMenuCharaAnimIdle(m_selectedChara)) != 0) {
             input = GetGoOutInputMask();
+            bool pressed;
             if ((input & 0x100) != 0) {
                 Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
                 CCaravanWork& caravanWork = Game.m_caravanWorkArr[m_selectedChara];
                 caravanWork.m_shopState = 0;
                 memset(reinterpret_cast<unsigned char*>(&caravanWork) + 0x8A4, 0, 0x100);


### PR DESCRIPTION
Raises main/goout fuzzy match from 94.71% to 95.00% (cycle 9).

## Changes
- **CalcDel case 5 / case 8**: model the `bool pressed` intermediate (PlaySe sets `pressed=true`, then `if(pressed)` guards the body) so mwcc emits the target's bool round-trip (`li r0,1; b; li r0,0; clrlwi.; beq`) instead of folding the test into a single branch. Matches the original idiom used in the other cases of the same switch.
- **SetDelMode active-character count loop**: fixed a real field bug. The loop counted characters by testing `m_caravanWorkArr[i].m_objType` (offset 0x4) but the original tested `m_shopState` (offset 0x3A4). The load offset (`0x1794`/`0x23c4`) now matches the target exactly; `m_caravanLocalFlags` confirms the array base was already correct, so this was a genuine wrong-field bug, not codegen.
- **SetGoOutMode**: dropped a redundant `static_cast<signed char>` on the `m_cardChannel` argument to `ChkConnect(int)`. The cast forced an `extsb`; the target reloads the `char` field directly (`lbz`), so the cast was spurious.

## Evidence
Per-function: CalcDel 95.8% to 97.3%, SetDelMode and SetGoOutMode each improved. Unit 94.71% to 95.00%.

## Blockers (walls, deep effort, reported)
- Inlined `GetGoOutInputMask` Pad-base coloring: target keeps `&Pad` in r4 / index in r0 (`add r3,r4,r0`); ours colors base into r3 / index into r4. Pure register-numbering shift, repeats ~15x in both CalcGoOut and CalcDel; not source-steerable (tried reference local, explicit pointer, direct member access).
- `SetMemCardError` switch-pivot: the comparison-tree split constants (-5 vs -4, -999 vs -998, etc.) and case-body emission order are mwcc's binary-search choices; reordering source cases regressed.
- `0x1c4(r30)` (m_resultSelect) caching and `next=0` lazy materialization in CalcDel/CalcGoOut; `this`/MenuPcs r30<->r31 swap in Calc; SetMenuStr cntlzw r6/r7 register swap; float-pool/jumptable symbol naming in DrawGoOutMenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)