### PR TITLE
goout: raise fuzzy match to 95.2% (cycle 10)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1708,7 +1708,7 @@ card_connected:;
         SetGoOutMode(0xE);
         break;
     case 0xE:
-        if (static_cast<signed char>(MenuPcs.m_goOutLoadFinished) != 0) {
+        if (static_cast<unsigned char>(MenuPcs.m_goOutLoadFinished) != 0) {
             if (MenuPcs.m_goOutLoadResult == 4) {
                 MenuGoOutState().m_resultSelect = 0;
                 MenuPcs.InitSaveLoadMenu();
@@ -2030,7 +2030,7 @@ card_connected:;
         m_cursorListY1 = 0xde;
         m_cursorMode = 0;
         {
-            unsigned char next;
+            signed char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2098,16 +2098,14 @@ card_connected:;
         }
         break;
     case 2:
-        static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->SaveDataBuffer(static_cast<char*>(m_memCardBuffer));
-        m_memCardResult = MenuPcs.m_mcCtrl.m_lastResult;
+        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->SaveDataBuffer(static_cast<char*>(m_memCardBuffer));
         if (m_memCardResult != 0) {
             m_lastMemCardProc = m_memCardProc;
             m_memCardProc = 0;
         }
         break;
     case 3: {
-        static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->Format(1);
-        int formatResult = MenuPcs.m_mcCtrl.m_lastResult;
+        int formatResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->Format(1);
         if (formatResult < 0) {
             MemoryCardMan.m_opDoneFlag = 1;
             MemoryCardMan.m_currentSlot = static_cast<char>(0xff);


### PR DESCRIPTION
Raises main/goout from 95.00% to 95.16% via two real source-fix categories.

## Changes

**1. CalcGoOut: assign McCtrl call returns directly (R16 audit)**
The `case 2`/`case 3` memcard-proc handlers discarded the return value of `SaveDataBuffer()`/`Format()` and reloaded `MenuPcs.m_mcCtrl.m_lastResult` (offset 0x2c) instead. The target stores the call's return register (r3) directly. Changed to:
- `m_memCardResult = ...SaveDataBuffer(...)`
- `int formatResult = ...Format(1)`

These methods return `int`, so assigning the result directly is correct and matches the target's `stw r3` (no redundant member reload).

**2. CalcGoOut: signedness corrections (permuter-found, verified plausible)**
- `MenuPcs.m_goOutLoadFinished` cast as `unsigned char` instead of `signed char` (a load-finished flag byte; `lbz` not `lha`).
- `next` switch dispatch local as `signed char` instead of `unsigned char`.

CalcGoOut function score: 90.54% -> 91.03%.

## Walls confirmed (not source-steerable, deep effort spent)
- Inlined `GetGoOutInputMask` Pad-base register coloring (`li r0,0/addi r4,r3,Pad@l/lwz r3,0x1c0(r4)` vs ours) — dominates CalcGoOut/CalcDel; the `hasPendingInput` bool-modeling is required (removing it regresses to ~89%).
- SetMemCardError switch-pivot tree: every comparison pivot is off-by-one vs target; case-body reorder regressed the unit (89.9->93.4 unit). Documented wall.
- DrawGoOutMenu `g_pGoOutMenu` store-order (address in r3 vs callee-saved r31) — same class as the this/MenuPcs coloring wall.
- Float-pool/jumptable symbol naming.

Permuter run on all sub-95% functions (CalcDel, Calc, SetGoOutMode, SetDelMode, SetMenuStr, DrawGoOutMenu, SetMemCardError) found no further improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)