### PR TITLE
materialman: pooled string literals + -str reuse, +8.2% data match (cycle 7)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -543,7 +543,7 @@ config.libs = [
             Object(NonMatching, "mapocttree.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "mapshadow.cpp", cflags=cflags_game),
             Object(NonMatching, "maptexanim.cpp", extra_cflags=["-RTTI on", "-str reuse,pool,readonly"]),
-            Object(NonMatching, "materialman.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-inline auto,deferred", "-str reuse,pool,readonly"]),
+            Object(NonMatching, "materialman.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-inline auto,deferred", "-str reuse"]),
             Object(NonMatching, "math.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "ME_AppRequest.cpp"),
             Object(NonMatching, "ME_USB_process.cpp", cflags=[*cflags_game_cpp_exceptions, "-sdata 0"]),

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -166,7 +166,7 @@ static int HighestSetBit(unsigned int value)
 
 static CMaterial* AllocMaterial()
 {
-    return new (MaterialMan.GetMemoryStage(), const_cast<char*>(s_materialman_cpp), 0xCFF) CMaterial;
+    return new (MaterialMan.GetMemoryStage(), (char*)"materialman.cpp", 0xCFF) CMaterial;
 }
 
 static void AddTextureIndex(CMaterial* material, unsigned short textureIndex)
@@ -176,7 +176,7 @@ static void AddTextureIndex(CMaterial* material, unsigned short textureIndex)
 
 static CMapKeyFrame* AllocMapKeyFrame(int line)
 {
-    return new (MaterialMan.GetMemoryStage(), const_cast<char*>(s_materialman_cpp), line) CMapKeyFrame();
+    return new (MaterialMan.GetMemoryStage(), (char*)"materialman.cpp", line) CMapKeyFrame();
 }
 
 static void SetMaterialColor(CMaterial* material, unsigned int rgba)
@@ -3399,7 +3399,7 @@ void CMaterialSet::SetPartFromTextureSet(CTextureSet* textureSet, int pdtSlotInd
             }
 
             CMaterial* newMaterial =
-                new (MaterialMan.GetMemoryStage(), const_cast<char*>(s_materialman_cpp), 0xEE4) CMaterial;
+                new (MaterialMan.GetMemoryStage(), (char*)"materialman.cpp", 0xEE4) CMaterial;
 
             float scale = kTextureOne;
             newMaterial->m_tevBit = 0xFFF531F0;


### PR DESCRIPTION
## Summary
Cycle-7 work on `main/materialman` (baseline 97.27% fuzzy).

### What changed
- Switched the placement-`new` file-name argument in `AllocMaterial`, `AllocMapKeyFrame`, and the line-3402 `CMaterial` alloc from the named static `s_materialman_cpp` to the pooled string literal `"materialman.cpp"`, matching the target's anonymous `@1793` string anchor (the target references an individual `@NNNN` string object, not a named static).
- Changed the unit's compile flags from `-str reuse,pool,readonly` to `-str reuse` so each string literal gets its own `@NNNN` symbol instead of being merged into `@stringBase0`, matching the target's per-string anchoring.

### Evidence
- matched data: 568 -> 736 bytes (27.8% -> 36.1%) for main/materialman
- unit fuzzy: 97.268814% (unchanged; data is weighted small)
- total project fuzzy: 92.670395% (unchanged — no regression in any other unit)

### Why this is plausible source
The target emits the file-name string as an anonymous pooled literal (`@1793` in .rodata) rather than a named `static const char[]`, and emits individual `@NNNN` string symbols throughout — both consistent with `"materialman.cpp"` string literals compiled under `-str reuse` (no pool). This is the form the original FFCC source used.

### Blockers (documented walls, investigated and confirmed)
- **Create (85%)**: whole-function callee-saved register window shifted ~2 regs vs target; entangled with the inlined-AllocMaterial anchoring. The `@1699` vs `@1793` residual is a global string-numbering artifact.
- **GetCharaShadow (62%)**: `outputCount*4` CSE — target uses byte-offset `stwx` in-loop but `slwi outputCount,2` post-loop sharing one offset reg; any unifying source form regresses (61.1%).
- **SetUnderWaterTex / SetShadowBit32**: callee-saved-FPR coloring + sdata2 named-double pool (`DOUBLE_8032FB18` vs `@2738`); pure register/constant coloring.
- **addtev_bump_st**: target branches `hasProjTex?0xF:0`, ours is branchless; forcing a branch reorders arg loads (net regress).
- **SetMaterialPart**: target tail-merges N identical `vtxDesc`-reset blocks into one out-of-line block (cross-jump); ours keeps them inline — compiler-internal, not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)