### PR TITLE
gobjwork: raise fuzzy match to 94.9% (cycle 5)

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -140,6 +140,19 @@ public:
             unsigned char m_attachmentIsGil : 1;
             unsigned char m_rest : 3;
         };
+        struct HeaderBits {
+            unsigned short m_opened : 1;
+            unsigned short m_attachmentClaimed : 1;
+            unsigned short m_replySent : 1;
+            unsigned short m_hasReply : 1;
+            unsigned short m_attachmentIsGil : 1;
+            unsigned short m_messageType : 9;
+            unsigned short m_pad : 2;
+        };
+        struct AttachmentBits {
+            unsigned short m_pad : 7;
+            unsigned short m_value : 9;
+        };
 
         unsigned int Word0() const { return m_words.m_word0; }
         void SetWord0(unsigned int word)
@@ -172,10 +185,14 @@ public:
         bool HasReply() const { return FlagsBits().m_hasReply != 0; }
         bool AttachmentIsGil() const { return FlagsBits().m_attachmentIsGil != 0; }
         unsigned short HeaderWord() const { return m_half.m_header; }
+        HeaderBits& HeaderBitsRef() { return *reinterpret_cast<HeaderBits*>(&m_half.m_header); }
+        void SetMessageType(unsigned short type) { HeaderBitsRef().m_messageType = type; }
         unsigned short MessageType() const { return (HeaderWord() >> 2) & 0x1FF; }
         unsigned int SenderId() const { return (Word0() >> 9) & 0x1FF; }
         unsigned short AttachmentWord() const { return m_half.m_attachment; }
         unsigned int AttachmentValue() const { return AttachmentWord() & 0x1FF; }
+        AttachmentBits& AttachmentBitsRef() { return *reinterpret_cast<AttachmentBits*>(&m_half.m_attachment); }
+        void SetAttachmentValue(unsigned short value) { AttachmentBitsRef().m_value = value; }
         unsigned short TempVar(int index) const { return m_half.m_tempVars[index]; }
 
         union {

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -400,29 +400,30 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 							 int itemA, int itemB, int itemC, int itemD)
 {
 	for (int i = 99; i > 0; i--) {
-		m_letters[i].m_words.m_word0 = m_letters[i - 1].m_words.m_word0;
-		m_letters[i].m_words.m_word1 = m_letters[i - 1].m_words.m_word1;
-		m_letters[i].m_words.m_word2 = m_letters[i - 1].m_words.m_word2;
+		m_letters[i] = m_letters[i - 1];
 	}
 
 	memset(&m_letters[0], 0, sizeof(m_letters[0]));
-	m_letters[0].m_half.m_header = (m_letters[0].m_half.m_header & 0xF803) | ((letterType & 0x1FF) << 2);
+	m_letters[0].SetMessageType(letterType);
 	m_letters[0].m_words.m_word0 = (m_letters[0].m_words.m_word0 & 0xFFFC01FF) | ((senderId & 0x1FF) << 9);
 	m_letters[0].SetFlags((m_letters[0].Flags() & ~8) | ((hasMoneyFlag << 3) & 8));
+	int attachmentValue;
 	if (m_letters[0].AttachmentIsGil()) {
-		moneyValue /= 100;
+		attachmentValue = moneyValue / 100;
+	} else {
+		attachmentValue = moneyValue;
 	}
-	m_letters[0].m_half.m_attachment = (m_letters[0].m_half.m_attachment & 0xFE00) | (moneyValue & 0x1FF);
-	m_letters[0].SetFlags(m_letters[0].Flags() & 0x7F);
-	m_letters[0].SetFlags(m_letters[0].Flags() & 0xBF);
-	m_letters[0].SetFlags(m_letters[0].Flags() & 0xDF);
-	m_letters[0].SetFlags((m_letters[0].Flags() & ~0x10) | ((hasReplyFlag << 4) & 0x10));
+	m_letters[0].SetAttachmentValue(attachmentValue);
+	m_letters[0].FlagsBits().m_opened = 0;
+	m_letters[0].FlagsBits().m_attachmentClaimed = 0;
+	m_letters[0].FlagsBits().m_replySent = 0;
+	m_letters[0].FlagsBits().m_hasReply = hasReplyFlag;
 	m_letters[0].m_half.m_tempVars[0] = static_cast<unsigned short>(itemA);
 	m_letters[0].m_half.m_tempVars[1] = static_cast<unsigned short>(itemB);
 	m_letters[0].m_half.m_tempVars[2] = static_cast<unsigned short>(itemC);
 	m_letters[0].m_half.m_tempVars[3] = static_cast<unsigned short>(itemD);
 
-	unsigned int nextCount = m_letterCount + 1;
+	int nextCount = m_letterCount + 1;
 	int letterCount = 100;
 	if (nextCount < 100) {
 		letterCount = nextCount;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2141,26 +2141,28 @@ unsigned int CCaravanWork::GetMagicCharge(int cmdListIdx, int&, int&)
 		} else {
 			int topIdx = cmdListIdx;
 			int scanCount = cmdListIdx + 1;
-			if (cmdListIdx >= 0) {
-				for (; scanCount != 0; scanCount--) {
-					if (m_commandListExtra[topIdx] != -1) {
-						break;
-					}
-					topIdx--;
+			for (; scanCount != 0; scanCount--) {
+				if (cmdListIdx < 0) {
+					break;
 				}
+				if (m_commandListExtra[topIdx] != -1) {
+					break;
+				}
+				topIdx--;
 			}
 
 			groupedCountLocal = 1;
 			int nextIdx = topIdx + 1;
-			int remaining = static_cast<short>(m_numCmdListSlots) - nextIdx;
-			if (nextIdx < static_cast<short>(m_numCmdListSlots)) {
-				for (; remaining != 0; remaining--) {
-					if (m_commandListExtra[nextIdx] != -1) {
-						break;
-					}
-					groupedCountLocal++;
-					nextIdx++;
+			int numSlots = static_cast<short>(m_numCmdListSlots);
+			for (int remaining = numSlots - nextIdx; remaining != 0; remaining--) {
+				if (nextIdx >= numSlots) {
+					break;
 				}
+				if (m_commandListExtra[nextIdx] != -1) {
+					break;
+				}
+				groupedCountLocal++;
+				nextIdx++;
 			}
 		}
 	}


### PR DESCRIPTION
Raises main/gobjwork from 94.62% to 94.86%.

## Changes

### GetMagicCharge (87.41% -> 90.84%)
Restructured the two command-list scan loops to match the target's CTR-driven block order: pushed the `cmdListIdx < 0` guard into the first scan-loop body, and derived the second loop's trip count from `numSlots - nextIdx` with the bound check as a guard. This eliminates the redundant `scanCount != 0` / `nextIdx < numSlots` entry tests the original folded into the CTR.

### AddLetter (82.30% -> 91.02%)
- Replaced the manual 3-word shift loop body with a whole-struct copy `m_letters[i] = m_letters[i-1]`, matching the target's grouped load/store scheduling.
- Modeled the letter header and attachment fields as real bitfields (`m_messageType : 9`, attachment `m_value : 9`) and the flag clears/sets as named bitfield-member writes, removing spurious `andi` masks and matching the target's clean `rlwimi` inserts.
- Made the AttachmentIsGil money adjustment an explicit if/else so both arms join into one value (matches the target's `b`/`mr` merge).
- Made the letter-count clamp comparison signed (`cmpwi` not `cmplwi`).

## Plausibility
All changes are ordinary C++ idioms (struct assignment, named bitfield members modeled in the unit's own header, signed locals, explicit if/else). No offset tricks, no hardcoded addresses, no layout changes to shared headers.

## Blockers (left at baseline)
- FGLetterOpen (77.5%): target addresses `m_letters[idx]` via `this + idx*0xc` base with `0x3ec` folded into each member offset; reproducing it needs a forbidden offset-trick. Direct array access regresses (recomputes the index).
- FindItem (86.75%): signed-short fix removes the `clrlwi` but exposes the advancing-cursor induction fold; net regresses. Cursor strength-reduction is the wall.
- AddLetter / GetMagicCharge residuals are callee-saved register-window coloring shifts; permute found no improving variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)