### PR TITLE
gobjwork: raise fuzzy match to 95.3% (cycle 6)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2730,39 +2730,45 @@ int CCaravanWork::GetArtifactIncludeHpMax()
 	int count = 0x32;
 
 	while (count != 0) {
-		if ((artifactIndex < 0x60) && ((short)m_artifacts[artifactIndex] > 0)) {
-			unsigned short* artifactData = artifactDataBase + ((short)m_artifacts[artifactIndex] * 0x24);
-			unsigned short artifactType = artifactData[0];
-			unsigned short artifactValue = artifactData[3];
+		if (artifactIndex < 0x60) {
+			int artifactId = m_artifacts[artifactIndex];
+			if (artifactId > 0) {
+				unsigned short* artifactData = artifactDataBase + (artifactId * 0x24);
+				unsigned short artifactType = artifactData[0];
+				unsigned short artifactValue = artifactData[3];
 
-			switch (artifactType) {
-			case 0x9F:
-			case 0xB6:
-			case 0xCC:
-			case 0xDB:
-			case 0xDF:
-				break;
-			case 0xE4:
-				hpMax += artifactValue;
-				break;
+				switch (artifactType) {
+				case 0x9F:
+				case 0xB6:
+				case 0xCC:
+				case 0xDB:
+				case 0xDF:
+					break;
+				case 0xE4:
+					hpMax += artifactValue;
+					break;
+				}
 			}
 		}
 
-		if (((artifactIndex + 1) < 0x60) && ((short)m_artifacts[artifactIndex + 1] > 0)) {
-			unsigned short* artifactData = artifactDataBase + ((short)m_artifacts[artifactIndex + 1] * 0x24);
-			unsigned short artifactType = artifactData[0];
-			unsigned short artifactValue = artifactData[3];
+		if ((artifactIndex + 1) < 0x60) {
+			int artifactId = m_artifacts[artifactIndex + 1];
+			if (artifactId > 0) {
+				unsigned short* artifactData = artifactDataBase + (artifactId * 0x24);
+				unsigned short artifactType = artifactData[0];
+				unsigned short artifactValue = artifactData[3];
 
-			switch (artifactType) {
-			case 0x9F:
-			case 0xB6:
-			case 0xCC:
-			case 0xDB:
-			case 0xDF:
-				break;
-			case 0xE4:
-				hpMax += artifactValue;
-				break;
+				switch (artifactType) {
+				case 0x9F:
+				case 0xB6:
+				case 0xCC:
+				case 0xDB:
+				case 0xDF:
+					break;
+				case 0xE4:
+					hpMax += artifactValue;
+					break;
+				}
 			}
 		}
 

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2209,41 +2209,32 @@ int CCaravanWork::GetCmdListItemName(int cmdListIdx, int* firstCmdIdx, int* item
 		if (m_commandListExtra[cmdListIdx] == 0) {
 			groupedCount = 1;
 		} else {
-			int scanCount = cmdListIdx + 1;
 			int topIdx = cmdListIdx;
-			if (topIdx >= 0) {
-				for (; scanCount != 0; scanCount--) {
-					if (m_commandListExtra[topIdx] != -1) {
-						break;
-					}
-					topIdx--;
+			for (int n = cmdListIdx; n >= 0; n--) {
+				if (m_commandListExtra[topIdx] != -1) {
+					break;
 				}
+				topIdx--;
 			}
 
 			groupedCount = 1;
-			scanCount = static_cast<short>(m_numCmdListSlots) - (topIdx + 1);
 			int nextIdx = topIdx + 1;
-			if (nextIdx < static_cast<short>(m_numCmdListSlots)) {
-				for (; scanCount != 0; scanCount--) {
-					if (m_commandListExtra[nextIdx] != -1) {
-						break;
-					}
-					groupedCount++;
-					nextIdx++;
+			for (int n = topIdx + 1; n < static_cast<short>(m_numCmdListSlots); n++) {
+				if (m_commandListExtra[nextIdx] != -1) {
+					break;
 				}
+				groupedCount++;
+				nextIdx++;
 			}
 		}
 	}
 
 	if (groupedCount > 1) {
-		int scanCount = cmdListIdx + 1;
-		if (cmdListIdx >= 0) {
-			for (; scanCount != 0; scanCount--) {
-				if (m_commandListExtra[cmdListIdx] != -1) {
-					break;
-				}
-				cmdListIdx--;
+		for (int n = cmdListIdx; n >= 0; n--) {
+			if (m_commandListExtra[cmdListIdx] != -1) {
+				break;
 			}
+			cmdListIdx--;
 		}
 
 		short cmdId = m_commandListExtra[cmdListIdx];
@@ -2363,17 +2354,13 @@ int CCaravanWork::DelCmdListAndItem(int cmdListIdx)
 			}
 
 			numGrouped = 1;
-			int scanCount = (short)m_numCmdListSlots - (topIdx + 1);
 			int nextIdx = topIdx + 1;
-			if ((topIdx + 1) < (short)m_numCmdListSlots) {
-				while (scanCount != 0) {
-					if (m_commandListExtra[nextIdx] != -1) {
-						break;
-					}
-					numGrouped++;
-					nextIdx++;
-					scanCount--;
+			for (int n = topIdx + 1; n < (short)m_numCmdListSlots; n++) {
+				if (m_commandListExtra[nextIdx] != -1) {
+					break;
 				}
+				numGrouped++;
+				nextIdx++;
 			}
 		}
 

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2354,20 +2354,16 @@ int CCaravanWork::DelCmdListAndItem(int cmdListIdx)
 		} else if (m_commandListExtra[cmdListIdx] == 0) {
 			numGrouped = 1;
 		} else {
-			int scanCount = cmdListIdx + 1;
 			int topIdx = cmdListIdx;
-			if (cmdListIdx >= 0) {
-				while (scanCount != 0) {
-					if (m_commandListExtra[topIdx] != -1) {
-						break;
-					}
-					topIdx--;
-					scanCount--;
+			for (int n = cmdListIdx; n >= 0; n--) {
+				if (m_commandListExtra[topIdx] != -1) {
+					break;
 				}
+				topIdx--;
 			}
 
 			numGrouped = 1;
-			scanCount = (short)m_numCmdListSlots - (topIdx + 1);
+			int scanCount = (short)m_numCmdListSlots - (topIdx + 1);
 			int nextIdx = topIdx + 1;
 			if ((topIdx + 1) < (short)m_numCmdListSlots) {
 				while (scanCount != 0) {
@@ -2382,15 +2378,11 @@ int CCaravanWork::DelCmdListAndItem(int cmdListIdx)
 		}
 
 		if (numGrouped > 1) {
-			int scanCount = cmdListIdx + 1;
-			if (cmdListIdx >= 0) {
-				while (scanCount != 0) {
-					if (m_commandListExtra[cmdListIdx] != -1) {
-						break;
-					}
-					cmdListIdx--;
-					scanCount--;
+			for (int n = cmdListIdx; n >= 0; n--) {
+				if (m_commandListExtra[cmdListIdx] != -1) {
+					break;
 				}
+				cmdListIdx--;
 			}
 
 			int cmdResult = m_commandListExtra[cmdListIdx];

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1676,39 +1676,45 @@ void CCaravanWork::SafeDeleteTempItem()
 	int totalSlots = 0;
 	int artifactIndex = 0;
 	for (int i = 0; i < 50; i++, artifactIndex += 2) {
-		if (artifactIndex < 96 && m_artifacts[artifactIndex] > 0) {
-			unsigned short* artifactData =
-				(unsigned short*)(Game.unkCFlatData0[2] + m_artifacts[artifactIndex] * 0x48);
-			unsigned short slots = artifactData[3];
-			switch (artifactData[0]) {
-			case 0xDB:
-				totalSlots += slots;
-				break;
-			case 0x9F:
-			case 0xB6:
-			case 0xCC:
-			case 0xDF:
-			case 0xE4:
-			default:
-				break;
+		if (artifactIndex < 96) {
+			int artifactId = m_artifacts[artifactIndex];
+			if (artifactId > 0) {
+				unsigned short* artifactData =
+					(unsigned short*)(Game.unkCFlatData0[2] + artifactId * 0x48);
+				unsigned short slots = artifactData[3];
+				switch (artifactData[0]) {
+				case 0xDB:
+					totalSlots += slots;
+					break;
+				case 0x9F:
+				case 0xB6:
+				case 0xCC:
+				case 0xDF:
+				case 0xE4:
+				default:
+					break;
+				}
 			}
 		}
 
-		if ((artifactIndex + 1) < 96 && m_artifacts[artifactIndex + 1] > 0) {
-			unsigned short* artifactData = (unsigned short*)(Game.unkCFlatData0[2] +
-															 m_artifacts[artifactIndex + 1] * 0x48);
-			unsigned short slots = artifactData[3];
-			switch (artifactData[0]) {
-			case 0xDB:
-				totalSlots += slots;
-				break;
-			case 0x9F:
-			case 0xB6:
-			case 0xCC:
-			case 0xDF:
-			case 0xE4:
-			default:
-				break;
+		if ((artifactIndex + 1) < 96) {
+			int artifactId = m_artifacts[artifactIndex + 1];
+			if (artifactId > 0) {
+				unsigned short* artifactData = (unsigned short*)(Game.unkCFlatData0[2] +
+																 artifactId * 0x48);
+				unsigned short slots = artifactData[3];
+				switch (artifactData[0]) {
+				case 0xDB:
+					totalSlots += slots;
+					break;
+				case 0x9F:
+				case 0xB6:
+				case 0xCC:
+				case 0xDF:
+				case 0xE4:
+				default:
+					break;
+				}
 			}
 		}
 	}

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2141,11 +2141,7 @@ unsigned int CCaravanWork::GetMagicCharge(int cmdListIdx, int&, int&)
 			groupedCountLocal = 1;
 		} else {
 			int topIdx = cmdListIdx;
-			int scanCount = cmdListIdx + 1;
-			for (; scanCount != 0; scanCount--) {
-				if (cmdListIdx < 0) {
-					break;
-				}
+			for (int n = cmdListIdx; n >= 0; n--) {
 				if (m_commandListExtra[topIdx] != -1) {
 					break;
 				}
@@ -2155,10 +2151,7 @@ unsigned int CCaravanWork::GetMagicCharge(int cmdListIdx, int&, int&)
 			groupedCountLocal = 1;
 			int nextIdx = topIdx + 1;
 			int numSlots = static_cast<short>(m_numCmdListSlots);
-			for (int remaining = numSlots - nextIdx; remaining != 0; remaining--) {
-				if (nextIdx >= numSlots) {
-					break;
-				}
+			for (int n = topIdx + 1; n < numSlots; n++) {
 				if (m_commandListExtra[nextIdx] != -1) {
 					break;
 				}
@@ -2171,14 +2164,11 @@ unsigned int CCaravanWork::GetMagicCharge(int cmdListIdx, int&, int&)
 	if (groupedCountLocal == 1) {
 		return (((unsigned int)__cntlzw(cmdListIdx - static_cast<short>(m_currentCmdListIndex))) >> 5) & 0xFF;
 	} else {
-		int scanCount = cmdListIdx + 1;
-		if (cmdListIdx >= 0) {
-			for (; scanCount != 0; scanCount--) {
-				if (m_commandListExtra[cmdListIdx] != -1) {
-					break;
-				}
-				cmdListIdx--;
+		for (int n = cmdListIdx; n >= 0; n--) {
+			if (m_commandListExtra[cmdListIdx] != -1) {
+				break;
 			}
+			cmdListIdx--;
 		}
 
 		unsigned int selected = 0;


### PR DESCRIPTION
Raises main/gobjwork from 94.86% to 95.30%.

## What changed
- **Counted-for scan loops** (GetCmdListItemName, DelCmdListAndItem, GetMagicCharge): the three command-list grouping scan loops were written as `while (scanCount != 0)` with a separate `if (idx >= 0)` guard, which made mwcc emit a redundant `cmpwi/beq` zero-test after `mtctr`. Rewriting the backward scans as `for (int n = idx; n >= 0; n--)` and the forward scan as `for (int n = start; n < numSlots; n++)` lets the guard and the CTR trip-count fuse into the target's single `mr./blt; mtctr; bdnz` shape.
- **Cache artifact id as int** (SafeDeleteTempItem, GetArtifactIncludeHpMax): `m_artifacts[i]` (a `short`) was both compared `> 0` and reused for `* 0x48`/`* 0x24`, producing a spurious `extsh.`. Hoisting the loaded value into an `int artifactId` local matches the target's direct `lha; cmpwi r0,0` + reuse.

## Per-function gains
- GetMagicCharge: 90.8 -> 98.4
- GetCmdListItemName: 83.9 -> 91.5
- DelCmdListAndItem: 90.3 -> 96.0
- GetArtifactIncludeHpMax: 97.0 -> 100
- SafeDeleteTempItem: 92.0 -> 92.6

## Why this is plausible source
All changes are ordinary loop idioms and a local int cache for a value used in two expressions — nothing offset-trick or compiler-coaxing.

## Remaining blockers (walls)
- SearchRomLetterWork (89.9%): target saves r20-r31 (12 callee-saved) vs ours r22-r31 (10); a +2 register-count wall. Permuter (4000 passes) and explicit output-pointer locals found nothing; no out-of-line calls exist so dont_inline does not apply.
- FindItem (86.8%): induction-fold/strength-reduction wall (target keeps a running counter, ours folds constant offsets). Fixing the unrelated `clrlwi` net-regressed.
- AddLetter (91.0%): letter-array shift offset-fold (the 0x3ec base-fold) plus a 1-register window shift; permuter found nothing.
- GetNextCmdListIdx (90.6%): pure callee-saved register coloring (Game base wants r29); permuter found nothing.
- FGLetterOpen (77.5%): known offset-trick wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)