### PR TITLE
materialman: raise fuzzy match to 98.7% (cycle 9)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -3322,31 +3322,31 @@ void CMaterialSet::SetTextureSet(CTextureSet* textureSet)
             } else {
                 for (int i = 0; i < material->m_textureCount; i++) {
                     ReleaseRef(material->m_textureData.m_textures[i]);
-                    material->m_textureData.m_textures[i] = 0;
 
-                    if (textureSet != 0) {
-                        unsigned long textureIndex = static_cast<unsigned long>(material->m_textureIndices[i]);
-                        if ((static_cast<long>(textureIndex) >= 0) &&
-                            (textureIndex < static_cast<unsigned long>(textureSet->GetNumTexture()))) {
-                            material->m_textureData.m_textures[i] =
-                                textureSet->GetTexture(textureIndex);
-                            if (material->m_textureData.m_textures[i] != 0) {
-                                bool isIntensity = true;
-                                material->m_textureData.m_textures[i]->AddRef();
-                                unsigned int format = material->m_textureData.m_textures[i]->m_format;
-                                if ((format != 9) && (format != 8)) {
-                                    isIntensity = false;
-                                }
-                                if (isIntensity) {
-                                    material->m_tevBit |= 0x200;
-                                } else if (format == 1) {
-                                    material->m_tevBit |= 0x400;
-                                }
-                                if (static_cast<int>(material->m_textureData.m_textures[i]->m_isAlphaLut) != 0) {
-                                    material->m_tevBit |= 0x800;
-                                }
+                    unsigned long textureIndex = static_cast<unsigned long>(material->m_textureIndices[i]);
+                    if ((textureSet != 0) &&
+                        (static_cast<long>(textureIndex) >= 0) &&
+                        (textureIndex < static_cast<unsigned long>(textureSet->GetNumTexture()))) {
+                        material->m_textureData.m_textures[i] =
+                            textureSet->GetTexture(textureIndex);
+                        if (material->m_textureData.m_textures[i] != 0) {
+                            bool isIntensity = true;
+                            material->m_textureData.m_textures[i]->AddRef();
+                            unsigned int format = material->m_textureData.m_textures[i]->m_format;
+                            if ((format != 9) && (format != 8)) {
+                                isIntensity = false;
+                            }
+                            if (isIntensity) {
+                                material->m_tevBit |= 0x200;
+                            } else if (format == 1) {
+                                material->m_tevBit |= 0x400;
+                            }
+                            if (static_cast<int>(material->m_textureData.m_textures[i]->m_isAlphaLut) != 0) {
+                                material->m_tevBit |= 0x800;
                             }
                         }
+                    } else {
+                        material->m_textureData.m_textures[i] = 0;
                     }
                 }
 

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2663,8 +2663,8 @@ int CMaterialMan::GetCharaShadow(
     for (int i = 0; i < candidateCount; i++) {
         float candidateDist = candidateRead->distance;
         if (nearestDist > candidateDist) {
-            nearest = candidateRead;
             nearestDist = candidateDist;
+            nearest = candidateRead;
         }
         candidateRead++;
     }

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2595,7 +2595,7 @@ int CMaterialMan::GetCharaShadow(
     ShadowCandidate shadowCandidates[128];
     ShadowCandidate* candidateWrite = shadowCandidates;
     CMaterial** materialWrite = materialsOut;
-    unsigned int candidateCount = 0;
+    int candidateCount = 0;
     int outputCount = 0;
     int outputOffset = 0;
 
@@ -2669,13 +2669,15 @@ int CMaterialMan::GetCharaShadow(
         candidateRead++;
     }
 
-    if ((nearest != 0) && (outputCount < maxShadows)) {
+    if (nearest != 0) {
         nearest->distance = kMaterialMaxDistance;
-        CMapShadow* nearestShadow = nearest->shadow;
-        materialsOut[outputCount] = MapMng.m_materialSet->m_materials[nearestShadow->m_materialIndex];
-        shadowMtxOut[outputOffset] = nearestShadow->m_shadowMtx;
-        outputCount++;
-        outputOffset++;
+        if (outputCount < maxShadows) {
+            CMapShadow* nearestShadow = nearest->shadow;
+            materialsOut[outputCount] = MapMng.m_materialSet->m_materials[nearestShadow->m_materialIndex];
+            shadowMtxOut[outputOffset] = nearestShadow->m_shadowMtx;
+            outputCount++;
+            outputOffset++;
+        }
     }
 
     return outputCount;


### PR DESCRIPTION
Raises main/materialman fuzzy match from 98.65% to 98.72% (cycle 9).

## Changes
- **GetCharaShadow**: hoisted the `nearest->distance = kMaterialMaxDistance` write out of the `outputCount < maxShadows` guard (the original assigns it whenever a nearest candidate exists, before the count check), and made `candidateCount` a signed `int` to match the target's signed `cmpwi` loop test. Also swapped the nearest-candidate update order (`nearestDist = ...; nearest = ...`) to match the target's `fmr`-then-`mr` emission.
- **SetTextureSet**: restructured the per-texture-slot assignment so the `m_textures[i] = 0` reset lives on the not-assigned (else) path with the texture-set / index-range checks combined into one guard, matching the target's branch structure and tail store.

## Evidence
- Before: 98.647%
- After: 98.718%
- GetCharaShadow flagged-line count 67 -> 64; SetTextureSet 22 -> 18.

## Remaining blockers (known walls)
The residual on GetCharaShadow, Create, SetMaterial/SetMaterialPart, SetPosition, SetShadowBit32 is dominated by register-window coloring (a uniform +1 callee-saved-GPR shift) and the outputCount*4-vs-outputOffset byte-offset CSE; SetUnderWaterTex is the sdata2 double-pool / FPR-allocation wall; the `_GXSetTev*` calls differ only by the int-wrapper vs enum-typed symbol (int-enum GX wrapper distinction). All are documented walls; multiple targeted source variants for each were tried and reverted when net-negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)