### PR TITLE
gobjwork: raise fuzzy match to 95.31% (cycle 7)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1675,9 +1675,10 @@ void CCaravanWork::SafeDeleteTempItem()
 
 	int totalSlots = 0;
 	int artifactIndex = 0;
-	for (int i = 0; i < 50; i++, artifactIndex += 2) {
+	CCaravanWork* artifactCur = this;
+	for (int i = 50; i != 0; i--) {
 		if (artifactIndex < 96) {
-			int artifactId = m_artifacts[artifactIndex];
+			int artifactId = artifactCur->m_artifacts[0];
 			if (artifactId > 0) {
 				unsigned short* artifactData =
 					(unsigned short*)(Game.unkCFlatData0[2] + artifactId * 0x48);
@@ -1697,11 +1698,12 @@ void CCaravanWork::SafeDeleteTempItem()
 			}
 		}
 
-		if ((artifactIndex + 1) < 96) {
-			int artifactId = m_artifacts[artifactIndex + 1];
+		artifactIndex++;
+		if (artifactIndex < 96) {
+			int artifactId = artifactCur->m_artifacts[1];
 			if (artifactId > 0) {
-				unsigned short* artifactData = (unsigned short*)(Game.unkCFlatData0[2] +
-																 artifactId * 0x48);
+				unsigned short* artifactData =
+					(unsigned short*)(Game.unkCFlatData0[2] + artifactId * 0x48);
 				unsigned short slots = artifactData[3];
 				switch (artifactData[0]) {
 				case 0xDB:
@@ -1717,6 +1719,9 @@ void CCaravanWork::SafeDeleteTempItem()
 				}
 			}
 		}
+
+		artifactCur = (CCaravanWork*)&artifactCur->m_objType;
+		artifactIndex++;
 	}
 
 	totalSlots += (short)m_baseCmdListSlots;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2346,7 +2346,7 @@ int CCaravanWork::DelCmdListAndItem(int cmdListIdx)
 		} else if (m_commandListExtra[cmdListIdx] == 0) {
 			numGrouped = 1;
 		} else {
-			int topIdx = cmdListIdx;
+			unsigned int topIdx = cmdListIdx;
 			for (int n = cmdListIdx; n >= 0; n--) {
 				if (m_commandListExtra[topIdx] != -1) {
 					break;


### PR DESCRIPTION
Raises main/gobjwork from 95.30% to 95.31% by matching two functions more closely to the shipped Metrowerks output, both backed by the Ghidra reference decompilation.

## Changes

- **SafeDeleteTempItem** (92.56% -> 92.67%): rewrote the artifact-scan loop to walk a `CCaravanWork*` cursor advancing by `m_objType` (one slot stride) per iteration, reading `m_artifacts[0]`/`[1]` off the cursor with a running index incremented by 1 between the two halves. This mirrors the original's `pCVar4` cursor idiom and folds the `+2` induction split into the target's `+1`/`+1` form.
- **DelCmdListAndItem** (95.98% -> 96.12%): typed the grouped-command top index as `unsigned int` (it only walks non-negative slot indices), matching the original index codegen. Found via the permuter.

## Investigated but walled (no net-positive lever found)

- **FindItem** (86.8%): induction-variable fold wall — signedness and increment-reorder variants both regress.
- **GetNextCmdListIdx / GetNumCombi / GetMagicCharge**: identical structure to target, only callee-saved register *numbering* differs (window shifted by one); permuter exhausted, no structural lever.
- **GetCmdListItemName** (91.5%): CSE of `idx*2` not hoisted; pointer-cursor rewrite regresses, permuter finds nothing.
- **AddLetter** (91.0%): union struct-copy lowering splits 2+1 vs target's 1+2, plus register window; not source-steerable without changing the shared layout.
- **SearchRomLetterWork** (89.9%): +2 callee-saved register-count wall (frame 0x40/`stmw r20` vs 0x30/`stmw r22`).
- **FGLetterOpen** (77.5%): 0x3ec base-fold requiring a forbidden offset-trick.
- **Init__8CMonWork** (94.0%): indexed-vs-displacement addressing and compiler magic-double symbol naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)