### PR TITLE
p_camera: raise fuzzy match to 90.9% (cycle 10)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -928,9 +928,9 @@ void CCameraPcs::draw()
         {
         Mtx cameraMtx;
         Mtx shadowMtx;
-        float posZ = shadowPos->z;
-        float posY = shadowPos->y;
         float posX = shadowPos->x;
+        float posY = shadowPos->y;
+        float posZ = shadowPos->z;
         PSMTXCopy(m_cameraMatrix, cameraMtx);
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         GXSetZCompLoc(0);
@@ -966,8 +966,8 @@ void CCameraPcs::draw()
         Mtx shadowMtx;
         Vec* shadowRefPos = shadowPos + 1;
         float refPosX = shadowRefPos->x;
-        float refPosZ = shadowRefPos->z;
         float refPosY = shadowRefPos->y;
+        float refPosZ = shadowRefPos->z;
         PSMTXCopy(m_cameraMatrix, cameraMtx);
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         GXSetZCompLoc(0);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -902,8 +902,6 @@ void CCameraPcs::SetStdProjectionMatrix()
 void CCameraPcs::draw()
 {
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
-    Mtx shadowMtx;
-    Mtx cameraMtx;
     Vec* shadowPos = &g_shadow_pos;
 
     if ((m_isAbsolute == 0) ||
@@ -927,6 +925,9 @@ void CCameraPcs::draw()
     }
 
     if (g_map_draw_prof != 0) {
+        {
+        Mtx cameraMtx;
+        Mtx shadowMtx;
         float posZ = shadowPos->z;
         float posY = shadowPos->y;
         float posX = shadowPos->x;
@@ -958,7 +959,11 @@ void CCameraPcs::draw()
         redColor.a = 0xFF;
         GXSetChanMatColor(GX_COLOR0A0, redColor);
         Graphic.DrawSphere();
+        }
 
+        {
+        Mtx cameraMtx;
+        Mtx shadowMtx;
         Vec* shadowRefPos = shadowPos + 1;
         float refPosX = shadowRefPos->x;
         float refPosZ = shadowRefPos->z;
@@ -991,6 +996,7 @@ void CCameraPcs::draw()
         magentaColor.a = 0xFF;
         GXSetChanMatColor(GX_COLOR0A0, magentaColor);
         Graphic.DrawSphere();
+        }
     }
 }
 

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -960,8 +960,8 @@ void CCameraPcs::draw()
         Graphic.DrawSphere();
 
         Vec* shadowRefPos = shadowPos + 1;
-        float refPosZ = shadowRefPos->z;
         float refPosX = shadowRefPos->x;
+        float refPosZ = shadowRefPos->z;
         float refPosY = shadowRefPos->y;
         PSMTXCopy(m_cameraMatrix, cameraMtx);
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -904,6 +904,7 @@ void CCameraPcs::draw()
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
     Mtx shadowMtx;
     Mtx cameraMtx;
+    Vec* shadowPos = &g_shadow_pos;
 
     if ((m_isAbsolute == 0) ||
         ((CFlatRuntimeDebugFlags() & CFlatRuntimeDebugFlag_Camera) != 0)) {
@@ -926,9 +927,9 @@ void CCameraPcs::draw()
     }
 
     if (g_map_draw_prof != 0) {
-        float posX = g_shadow_pos.x;
-        float posY = g_shadow_pos.y;
-        float posZ = g_shadow_pos.z;
+        float posZ = shadowPos->z;
+        float posY = shadowPos->y;
+        float posX = shadowPos->x;
         PSMTXCopy(m_cameraMatrix, cameraMtx);
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         GXSetZCompLoc(0);
@@ -958,9 +959,10 @@ void CCameraPcs::draw()
         GXSetChanMatColor(GX_COLOR0A0, redColor);
         Graphic.DrawSphere();
 
-        float refPosX = g_shadow_refpos.x;
-        float refPosY = g_shadow_refpos.y;
-        float refPosZ = g_shadow_refpos.z;
+        Vec* shadowRefPos = shadowPos + 1;
+        float refPosZ = shadowRefPos->z;
+        float refPosX = shadowRefPos->x;
+        float refPosY = shadowRefPos->y;
         PSMTXCopy(m_cameraMatrix, cameraMtx);
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         GXSetZCompLoc(0);


### PR DESCRIPTION
Raises main/p_camera fuzzy match from 90.80% to 90.95% by attacking the register-window / stack-layout walls in CCameraPcs::draw.

## What changed (all in draw)
- Pin the g_shadow_pos base pointer into a persistent callee-saved register and access g_shadow_refpos through it (pos + 1) instead of via its own symbol. This flips this/global into the target's r30/r31 register window.
- Give each debug-sphere draw its own scope with its own shadowMtx/cameraMtx locals, matching the target's four distinct matrix stack slots (frame 0x120 vs 0xc0) instead of two reused slots.
- Order the matrix declarations (cameraMtx before shadowMtx) and the Vec component reads to match the target's stack-offset and callee-saved-FPR assignment.

draw flagged-line count dropped from 76 to 34.

## Investigated but walled (reported, not changed)
- calc / drawShadowBegin: this(r30) vs &Pad/global(r31) register-window swap; a CPad& reference local and pointer hoisting both regressed.
- createFullShadow: unrolled ramp-texture loop is a pure register-allocation wall (target keeps 3 callee-saved regs, ours 5); index-formula uniformity changes regressed.
- drawShadowEndAll / drawShadowEnd: CopyCameraState word-pair struct-copy load-order swap and int-vs-float copy codegen (the known CopyCameraState wall); temp/decl reordering had no effect.
- CalcQuake: state-cache and jitter-init reorder both regressed.
- create: float-load scheduling only; permuter found no signedness win.
- __sinit: known ...data.0 base-CSE wall, skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)