### PR TITLE
p_camera: raise fuzzy match to 90.96% (cycle 11)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1416,7 +1416,8 @@ void CCameraPcs::createFullShadow()
     m_fullScreenShadow.m_rampTexture = rampTex;
 
     for (i = 0; i < 0x100; i += 8) {
-        rampTex[(i & 0xC) * 0x10 + ((i >> 2) & 0x20) + ((i >> 4) & 7)] = static_cast<unsigned char>(i);
+        rampTex[((i & 3) << 3) + ((i << 4) & 0xC0) + ((i >> 2) & 0x20) + ((i >> 4) & 7)] =
+            static_cast<unsigned char>(i);
         rampTex[(((i + 1) * 8) & 0x18) + (((i + 1) * 0x10) & 0xC0) + (((i + 1) >> 2) & 0x20) + (((i + 1) >> 4) & 7)] =
             static_cast<unsigned char>(i + 1);
         rampTex[(((i + 2) * 8) & 0x18) + (((i + 2) * 0x10) & 0xC0) + (((i + 2) >> 2) & 0x20) + (((i + 2) >> 4) & 7)] =


### PR DESCRIPTION
## Summary
Raises main/p_camera fuzzy match from 90.95% to 90.96%.

### createFullShadow (60.31% -> 60.49%)
Rewrote the element-0 ramp-texture index expression to use the bit-shift form `((i & 3) << 3) + ((i << 4) & 0xC0) + ...` (matching the target's `clrlslwi`/`rlwinm` lowering) instead of the special-cased `(i & 0xC) * 0x10` form. This brings the first unrolled store in line with the target's uniform swizzle formula.

### Blocker (strength-reduction wall)
The remaining createFullShadow gap is entirely in the unrolled ramp loop. mwcc strength-reduces the `(i+k)` bitfield sub-expressions into three running induction counters (`addi r4,+0x2`, `addi r3,+0x80`, `addi r5,+0x8`), whereas the target computes every term from a single `i` register (`addi r3,r3,0x8`) via per-element `rlwinm` rotates. This forces 3 extra callee-saved GPRs (epilogue `lmw r26` vs target `lwz r31/r30/r29`). Verified that uniform-shift form, multiply form, non-unrolled `for(i<256)`, and per-element variants all either regress or reproduce the same strength reduction. Everything outside the loop (GX calls, allocations, float tail) matches exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)