### PR TITLE
joybus: raise fuzzy match to 89.48% (cycle 11)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4367,11 +4367,11 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
     case 1:
     {
         int sent = m_pposWordIndex[threadParam->m_portIndex];
-        int totalWord = (int)(signed char)m_cmdBuffer[threadParam->m_portIndex];
+        unsigned int* wordPtr = &posWords[sent];
 
-        while (sent < totalWord)
+        while (sent < (int)(signed char)m_cmdBuffer[threadParam->m_portIndex])
         {
-            unsigned int word = posWords[sent];
+            unsigned int word = *wordPtr;
 
             if (static_cast<signed char>(m_threadRunningMask) != 0)
             {
@@ -4398,6 +4398,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
                 break;
             }
 
+            wordPtr++;
             sent++;
         }
 
@@ -4440,11 +4441,11 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
     case 3:
     {
         int sent = m_pposWordIndex[threadParam->m_portIndex];
-        int totalWord = (int)(unsigned char)m_cmdBuffer[4 + threadParam->m_portIndex];
+        unsigned int* wordPtr = &posWords[sent];
 
-        while (sent < totalWord)
+        while (sent < (int)(unsigned char)m_cmdBuffer[4 + threadParam->m_portIndex])
         {
-            unsigned int word = posWords[sent];
+            unsigned int word = *wordPtr;
 
             if (static_cast<signed char>(m_threadRunningMask) != 0)
             {
@@ -4471,6 +4472,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
                 break;
             }
 
+            wordPtr++;
             sent++;
         }
 
@@ -4513,11 +4515,11 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
     case 5:
     {
         int sent = m_pposWordIndex[threadParam->m_portIndex];
-        int totalWord = (int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex];
+        unsigned int* wordPtr = &posWords[sent];
 
-        while (sent < totalWord)
+        while (sent < (int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex])
         {
-            unsigned int word = posWords[sent];
+            unsigned int word = *wordPtr;
 
             if (static_cast<signed char>(m_threadRunningMask) != 0)
             {
@@ -4544,6 +4546,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
                 break;
             }
 
+            wordPtr++;
             sent++;
         }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -114,9 +114,9 @@ static const char s_not_found_error_fmt[] = "Error: %s not found";
 static const char s_map_filename_fmt[] = "m%02d_%d.mcd";
 static const char s_thread_init_end_nl[] = "JoyBus::ThreadInit end\n";
 static const char s_recv_type_mismatch_warn_fmt[] = "(%d):%s(%d): Warning: Recv data type mismatch";
-static const char s_send_ppos_bad_state_fmt[] = "JoyBus::SendPpos: bad state (port=%d, cnt=%d)\n";
 static const char s_load_bin_error[] = "JoyBus::LoadBin() error";
 static const char s_thread_init_end[] = "JoyBus::ThreadInit end";
+extern char s_pctd_Error_m_PposCnt_error_pctd_801DA32C[];
 extern char s_pctd_Error_send_type_error_pct02x_801DA350[];
 
 extern const u32 kPppYmMeltMaskBit0;
@@ -4568,7 +4568,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         {
             signed char cnt = (signed char)m_cmdBuffer[threadParam->m_portIndex];
 
-            System.Printf(const_cast<char*>(s_send_ppos_bad_state_fmt), threadParam->m_portIndex, (int)cnt);
+            System.Printf(s_pctd_Error_m_PposCnt_error_pctd_801DA32C, threadParam->m_portIndex, (int)cnt);
         }
 
         m_cmdBuffer[threadParam->m_portIndex] = 0;


### PR DESCRIPTION
## Summary
Raises main/joybus fuzzy match from 89.38% to 89.48%.

### What changed
- **SendPpos two-pointer loops** (85.62% -> 88.76%): rewrote the case 1/3/5 send loops to walk an advancing word-pointer cursor alongside the `sent` counter, and re-read the `m_cmdBuffer` length each iteration instead of caching `totalWord`. This matches the original's two-pointer loop emission (separate `+4` pointer advance and `+1` counter advance with a per-iteration length reload), converting whole INSERT/DELETE runs to matched code.
- **SendPpos error string**: the default-case diagnostic used a bespoke local format string; the original referenced the shared external rodata string `s_pctd_Error_m_PposCnt_error_pctd_801DA32C` ("(%d) Error: m_PposCnt error(%d)\n", confirmed by reading 0x801DA32C in the DOL). Switched to the real symbol and dropped the now-unused local. A genuine source-correctness fix.

### Why plausible
Both changes recover original source shape: the two-pointer cursor is a common hand idiom for streaming a buffer, and the error string is the actual shipped diagnostic (the symbol already existed in symbols.txt).

### Blocker (remaining ceiling)
The bulk of the remaining unmatched code in the Send*/Set* family (SendResult, SetCmdLst, SetTmpArti, SendAddLetter, SendUseItem, SendHitEnemy) is two coupled mwcc register-allocation walls that are not source-steerable:
1. **result-in-rN ABI**: the original keeps `result` in a volatile reg (r5/r6/r7/r8) and shares it with the cmd-buffer zero-init, emitting `mr r3,rN` at a single epilogue; we fold the result directly into r3. Many source forms tried (shared-zero `cmd=result`, init-order, single-return goto) all get constant-folded by mwcc and do not reproduce the share.
2. **r29/r30 base/word swap** + whole-function register-window shifts (GBARecvSend, SendDataFile saved-reg count 0x40 vs 0x30) driven by which base pointers the original cached in callee-saved regs across OSWait/OSSignalSemaphore pairs. Confirmed via asm but not reliably reproducible without regressing the matched head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)