### PR TITLE
p_MaterialEditor: raise fuzzy match to 96.54% (cycle 2)

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -203,9 +203,9 @@ void CMaterialEditorPcs::drawViewer()
                     }
 
                     u16 blendMode = polygon->blendMode;
-                    int blend = 1;
                     int srcFactor = 1;
                     int dstFactor = 1;
+                    int blend = 1;
                     int src = blendMode & 3;
                     int dst = (blendMode >> 2) & 3;
 

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -370,7 +370,7 @@ void CMaterialEditorPcs::drawViewer()
                 GXSetArray(GX_VA_TEX0, polygon->texCoord, 8);
 
                 u32 vertexIndex[8];
-                unsigned int vertexCount = 3;
+                int vertexCount = 3;
                 vertexIndex[4] = polygon->index0;
                 vertexIndex[5] = polygon->index1;
                 vertexIndex[6] = polygon->index2;
@@ -390,13 +390,17 @@ void CMaterialEditorPcs::drawViewer()
                     vertexIndex[3] = 2;
                 }
 
+                u32* posIndex = &vertexIndex[4];
+                u32* clrIndex = &vertexIndex[0];
                 u8 i = 0;
                 while (i < vertexCount) {
-                    GXWGFifo.u16 = static_cast<u16>((&vertexIndex[4])[i]);
-                    GXWGFifo.u16 = static_cast<u16>((&vertexIndex[4])[i]);
-                    GXWGFifo.u8 = static_cast<u8>(vertexIndex[i]);
-                    GXWGFifo.u16 = static_cast<u16>(vertexIndex[i]);
+                    u32 pos = posIndex[i];
+                    u32 clr = clrIndex[i];
                     i++;
+                    GXWGFifo.u16 = static_cast<u16>(pos);
+                    GXWGFifo.u16 = static_cast<u16>(pos);
+                    GXWGFifo.u8 = static_cast<u8>(clr);
+                    GXWGFifo.u16 = static_cast<u16>(clr);
                 }
 #undef polygon
             }

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -277,22 +277,22 @@ void CMaterialEditorPcs::drawViewer()
                         pp->texCoord[3][0] = scaleU * static_cast<float>(S16ToDouble(u));
                     }
 
-                    s16 v;
+                    int v;
                     v = polygon->v0;
                     if (v < 0) {
-                        polygon->v0 = -v;
+                        polygon->v0 = v * -1;
                     }
                     v = polygon->v1;
                     if (v < 0) {
-                        polygon->v1 = -v;
+                        polygon->v1 = v * -1;
                     }
                     v = polygon->v2;
                     if (v < 0) {
-                        polygon->v2 = -v;
+                        polygon->v2 = v * -1;
                     }
                     v = polygon->v3;
                     if (v < 0) {
-                        polygon->v3 = -v;
+                        polygon->v3 = v * -1;
                     }
 
                     pp = polygon;

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -277,17 +277,22 @@ void CMaterialEditorPcs::drawViewer()
                         pp->texCoord[3][0] = scaleU * static_cast<float>(S16ToDouble(u));
                     }
 
-                    if (polygon->v0 < 0) {
-                        polygon->v0 = -polygon->v0;
+                    s16 v;
+                    v = polygon->v0;
+                    if (v < 0) {
+                        polygon->v0 = -v;
                     }
-                    if (polygon->v1 < 0) {
-                        polygon->v1 = -polygon->v1;
+                    v = polygon->v1;
+                    if (v < 0) {
+                        polygon->v1 = -v;
                     }
-                    if (polygon->v2 < 0) {
-                        polygon->v2 = -polygon->v2;
+                    v = polygon->v2;
+                    if (v < 0) {
+                        polygon->v2 = -v;
                     }
-                    if (polygon->v3 < 0) {
-                        polygon->v3 = -polygon->v3;
+                    v = polygon->v3;
+                    if (v < 0) {
+                        polygon->v3 = -v;
                     }
 
                     pp = polygon;

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -390,10 +390,10 @@ void CMaterialEditorPcs::drawViewer()
                     vertexIndex[3] = 2;
                 }
 
-                u32* posIndex = &vertexIndex[4];
-                u32* clrIndex = &vertexIndex[0];
                 u8 i = 0;
                 while (i < vertexCount) {
+                    u32* posIndex = &vertexIndex[4];
+                    u32* clrIndex = &vertexIndex[0];
                     u32 pos = posIndex[i];
                     u32 clr = clrIndex[i];
                     i++;

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -390,7 +390,7 @@ void CMaterialEditorPcs::drawViewer()
                     vertexIndex[3] = 2;
                 }
 
-                u8 i = 0;
+                s8 i = 0;
                 while (i < vertexCount) {
                     u32* posIndex = &vertexIndex[4];
                     u32* clrIndex = &vertexIndex[0];

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -237,6 +237,7 @@ void CMaterialEditorPcs::drawViewer()
                 }
 
                 int flags = polygon->flags & 0xf;
+                int vertexCount = 3;
                 switch (polygon->textureMarker) {
                 case 'H':
                 if (static_cast<s16>(m_loadedTextureCount) > polygon->textureIndex) {
@@ -370,7 +371,6 @@ void CMaterialEditorPcs::drawViewer()
                 GXSetArray(GX_VA_TEX0, polygon->texCoord, 8);
 
                 u32 vertexIndex[8];
-                int vertexCount = 3;
                 vertexIndex[4] = polygon->index0;
                 vertexIndex[5] = polygon->index1;
                 vertexIndex[6] = polygon->index2;


### PR DESCRIPTION
Raises main/p_MaterialEditor fuzzy match from 95.88% to 96.54% (cycle-2, R16 correctness-audit focus). All work in drawViewer (94.77% -> 95.74%); the other 9 code functions stay at 100% and __sinit remains the data.0 wall.

## What changed (drawViewer)
- **Vertex-emit loop rewritten as a two-pointer single-load loop** (R12/R14): cache each index value once in a local, walk `&vertexIndex[4]` / `&vertexIndex[0]`, declared **inside** the loop body so mwcc does not hoist the base address into a callee-saved register. This removed an extra saved GPR, shrinking the saved-register window back to `r23-r31` and collapsing a function-wide off-by-one register shift (`model` r28->r29, etc.).
- **`vertexCount` typed `int`** (signed) and its `= 3` init **hoisted before the texture `switch`**, matching the target's early signed `cmpw`/`li r25,3`.
- **Loop counter typed `s8`** (signed) — matches the target's signed comparison and improved register coloring in the emit loop body.
- **`v0..v3` negation rewritten** as `int v = polygon->vN; if (v < 0) polygon->vN = v * -1;` — matches the target's `lhax`/`cmpwi r0,0`/`mulli` shape (was emitting `extsh.`/`neg`).
- **Blend-factor locals reordered** (`srcFactor, dstFactor, blend`) to match the target's r24/r25/r26 coloring and the `_GXSetBlendMode` argument register order.

## R16 audit result
Audited every GX*/GXSet* immediate, every `li rN,CONST`, all comparison boundaries, and array indices against the target: **no wrong enum/constant/boundary found** — the unit's GX call values were already correct. The gains came from the loop-structure and register-coloring fixes above.

## Blocker
Remaining diff is the documented cycle-1 magic-double wall: each inlined `S16ToDouble` union gets its own stack slot (frame 0xf0 vs target 0xa0) and the `(float)(conv.value - bias)` narrow emits `fsub`+`frsp` where the target fuses `fsubs`. A shared-union-by-reference refactor regressed (95.49%); `mulli`-vs-`neg` is an unavoidable mwcc peephole. These are source-non-steerable in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)