### PR TITLE
astar: raise fuzzy match to 95.10% (cycle 2)

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -544,7 +544,7 @@ void CAStar::calcAStar()
 {
 	memset(m_routeTable, 0, sizeof(m_routeTable));
 
-	for (int to = 0; to < 64; ++to)
+	for (unsigned int to = 0; to < 64; ++to)
 	{
 		for (int from = 0; from < 64; ++from)
 		{


### PR DESCRIPTION
## Summary
Raises main/astar fuzzy match from 95.08% to 95.10% (cycle 2, R16 correctness audit).

## Change
- `calcAStar`: the outer route-table loop index `to` is now `unsigned int` instead of `int`. It always ranges 0-63 and is used purely as an array subscript / `check()` argument, so unsigned is both behavior-preserving and plausible source. mwcc's resulting codegen matches the target (`calcAStar` 98.15% -> 98.52%).

## Audit notes (no further net-positive change found)
A full R16 audit (field offsets, array indices, comparison boundaries, call-arg order, memset/memcpy sizes, discarded returns) plus R8/R12/R13/R14 structural attempts were run on every sub-100 function:
- `check` (87.3%): the inner CATemp `level1` copy is inlined in the target with a deep callee-saved-register carry window (r14-r31) and a dual-destination copy; copy-construction, sequential, and carry-pattern rewrites all regressed. Confirmed register-window wall.
- `getEscapePos` (96.5%): CVector temporary stack-slot coloring wall.
- `addRealTime` (97.9%): global r4<->r5 register-window shift plus a Pad-base caching difference; load-order swap regressed.
- `drawAStar` (94.8%): register-window shift; group-pointer access rewrite regressed.

The automated permuter found no additional improvement on any function. Remaining gaps are callee-saved register-window / stack-coloring permutations consistent with the cycle-1 wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)