### PR TITLE
p_graphic: raise fuzzy match to 75.2% (cycle 8)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -509,21 +509,22 @@ void CGraphicPcs::drawSFCircle(int innerRadius, int outerRadius, int centerX, in
     const u32 innerColorWord = *(u32*)&innerColor;
     const u32 outerColorWord = *(u32*)&outerColor;
     for (int i = 0; i < 32; i++) {
-        const int next = (i + 1) % 32;
+        const float* cur = ringPoints[i];
+        const float* nxt = ringPoints[(i + 1) % 32];
 
-        GXPosition3f32(ringPoints[i][0], ringPoints[i][1], z);
+        GXPosition3f32(cur[0], cur[1], z);
         GXColor1u32(innerColorWord);
         GXTexCoord2u16(0, 0);
 
-        GXPosition3f32(ringPoints[next][0], ringPoints[next][1], z);
+        GXPosition3f32(nxt[0], nxt[1], z);
         GXColor1u32(innerColorWord);
         GXTexCoord2u16(0, 0);
 
-        GXPosition3f32(ringPoints[next][2], ringPoints[next][3], z);
+        GXPosition3f32(nxt[2], nxt[3], z);
         GXColor1u32(outerColorWord);
         GXTexCoord2u16(0, 0);
 
-        GXPosition3f32(ringPoints[i][2], ringPoints[i][3], z);
+        GXPosition3f32(cur[2], cur[3], z);
         GXColor1u32(outerColorWord);
         GXTexCoord2u16(0, 0);
     }


### PR DESCRIPTION
## Summary
Raises main/p_graphic fuzzy match from 75.15% to 75.22%.

### What changed
- **drawSFCircle**: rewrote the ring-vertex emission loop to use two explicit `const float*` cursors (`cur`/`nxt`) instead of re-indexing `ringPoints[i]`/`ringPoints[next]` each vertex. This stops mwcc from recomputing the `ringPoints[next]` base inline and collapses part of the loop's register-window shift (flagged lines 47 -> 43 on the function). Plausible original idiom (pointer walk over a vertex array).

### Evidence
- Unit fuzzy_match_percent: 75.15146 -> 75.21636
- drawSFCircle function score improved; no regressions elsewhere.

### Blockers (documented walls, not pursued)
- `drawScreenFade` (58.6%): f26/f27 FPR-window wall.
- `drawBar` (80.3%): frame-size delta (0x360 target vs 0x340 ours) shifting all stack offsets, plus the anonymous int->double bias pool naming (`@653`/`kIntToDoubleBias`) and loop FPR/GPR window. Structural reorders (y0/y1 before GXBegin, decl reordering) all regressed.
- `__sinit_p_graphic_cpp` (48.4%): the documented `...data.0` base-CSE WALL; not source-steerable.
- `calc` (98.7%) / `drawEnd` (99.65%): single 2-register coloring quirks (`mr` vs `li`, r11/r12 swap) with no clean source lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)