### PR TITLE
goout: raise fuzzy match to 97.2% (cycle 12)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1837,78 +1837,69 @@ card_connected:;
             }
         }
 
-        if (m_returnTransfer == 0) {
-            m_drawCursor = 1;
-            m_cursorListY0 = 0xb1;
-            m_cursorListY1 = 0xdc;
-            m_cursorMode = 0;
-
+        {
             unsigned char next;
 
-            if (MenuPcs.m_menuWindowInfo->state != 1) {
-                next = 0;
-                goto do_switch_go10a;
-            }
+            if (m_returnTransfer == 0) {
+                m_drawCursor = 1;
+                m_cursorListY0 = 0xb1;
+                m_cursorListY1 = 0xdc;
+                m_cursorMode = 0;
 
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
-                input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
-                    }
-                    next = static_cast<unsigned char>(m_cursorChoice + 1);
-                    goto do_switch_go10a;
+                if (MenuPcs.m_menuWindowInfo->state != 1) {
+                    next = 0;
+                    goto do_switch_go10;
                 }
-            }
 
-            next = 0;
-        do_switch_go10a:
-            switch (next) {
-            case 1:
-                SetGoOutMode(0x11);
-                break;
-            case 2:
-                SetGoOutMode(0xf);
-                break;
-            }
-        } else {
-            m_drawCursor = 1;
-            m_cursorListY0 = 0x8b;
-            m_cursorListY1 = 0xdc;
-            m_cursorMode = 0;
-
-            unsigned char next;
-
-            if (MenuPcs.m_menuWindowInfo->state != 1) {
-                next = 0;
-                goto do_switch_go10b;
-            }
-
-            input = GetGoOutInputMask();
-            if ((input & 3) != 0) {
-                m_cursorChoice ^= 1;
-                Sound.PlaySe(1, 0x40, 0x7f, 0);
-            } else {
                 input = GetGoOutInputMask();
-                if ((input & 0x100) != 0) {
-                    if (m_cursorChoice == 0) {
-                        Sound.PlaySe(2, 0x40, 0x7f, 0);
-                    } else if (m_cursorChoice == 1) {
-                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<unsigned char>(m_cursorChoice + 1);
+                        goto do_switch_go10;
                     }
-                    next = static_cast<unsigned char>(m_cursorChoice + 1);
-                    goto do_switch_go10b;
                 }
-            }
 
-            next = 0;
-        do_switch_go10b:
+                next = 0;
+            } else {
+                m_drawCursor = 1;
+                m_cursorListY0 = 0x8b;
+                m_cursorListY1 = 0xdc;
+                m_cursorMode = 0;
+
+                if (MenuPcs.m_menuWindowInfo->state != 1) {
+                    next = 0;
+                    goto do_switch_go10;
+                }
+
+                input = GetGoOutInputMask();
+                if ((input & 3) != 0) {
+                    m_cursorChoice ^= 1;
+                    Sound.PlaySe(1, 0x40, 0x7f, 0);
+                } else {
+                    input = GetGoOutInputMask();
+                    if ((input & 0x100) != 0) {
+                        if (m_cursorChoice == 0) {
+                            Sound.PlaySe(2, 0x40, 0x7f, 0);
+                        } else if (m_cursorChoice == 1) {
+                            Sound.PlaySe(3, 0x40, 0x7f, 0);
+                        }
+                        next = static_cast<unsigned char>(m_cursorChoice + 1);
+                        goto do_switch_go10;
+                    }
+                }
+
+                next = 0;
+            }
+        do_switch_go10:
             switch (next) {
             case 1:
                 SetGoOutMode(0x11);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2008,7 +2008,7 @@ card_connected:;
         m_cursorListY1 = 0xe7;
         m_cursorMode = 0;
         {
-            signed char next;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state != 1) {
                 next = 0;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1842,18 +1842,12 @@ card_connected:;
             m_cursorListY0 = 0xb1;
             m_cursorListY1 = 0xdc;
             m_cursorMode = 0;
-        } else {
-            m_drawCursor = 1;
-            m_cursorListY0 = 0x8b;
-            m_cursorListY1 = 0xdc;
-            m_cursorMode = 0;
-        }
-        {
+
             unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state != 1) {
                 next = 0;
-                goto do_switch_go10;
+                goto do_switch_go10a;
             }
 
             input = GetGoOutInputMask();
@@ -1869,12 +1863,52 @@ card_connected:;
                         Sound.PlaySe(3, 0x40, 0x7f, 0);
                     }
                     next = static_cast<unsigned char>(m_cursorChoice + 1);
-                    goto do_switch_go10;
+                    goto do_switch_go10a;
                 }
             }
 
             next = 0;
-        do_switch_go10:
+        do_switch_go10a:
+            switch (next) {
+            case 1:
+                SetGoOutMode(0x11);
+                break;
+            case 2:
+                SetGoOutMode(0xf);
+                break;
+            }
+        } else {
+            m_drawCursor = 1;
+            m_cursorListY0 = 0x8b;
+            m_cursorListY1 = 0xdc;
+            m_cursorMode = 0;
+
+            unsigned char next;
+
+            if (MenuPcs.m_menuWindowInfo->state != 1) {
+                next = 0;
+                goto do_switch_go10b;
+            }
+
+            input = GetGoOutInputMask();
+            if ((input & 3) != 0) {
+                m_cursorChoice ^= 1;
+                Sound.PlaySe(1, 0x40, 0x7f, 0);
+            } else {
+                input = GetGoOutInputMask();
+                if ((input & 0x100) != 0) {
+                    if (m_cursorChoice == 0) {
+                        Sound.PlaySe(2, 0x40, 0x7f, 0);
+                    } else if (m_cursorChoice == 1) {
+                        Sound.PlaySe(3, 0x40, 0x7f, 0);
+                    }
+                    next = static_cast<unsigned char>(m_cursorChoice + 1);
+                    goto do_switch_go10b;
+                }
+            }
+
+            next = 0;
+        do_switch_go10b:
             switch (next) {
             case 1:
                 SetGoOutMode(0x11);


### PR DESCRIPTION
Raises main/goout fuzzy match from 95.16% to 97.21% by recovering the original control-flow shape of the cursor-selection switches in CalcGoOut.

## What changed
- **case 0x10 block duplication + shared switch**: the `m_returnTransfer` if/else arms each duplicate the full cursor-set + window-state-check + input-handling block (the target emits two physical copies), while the final `switch(next)` dispatch is shared between arms (both arms branch to one dispatch block). Matching this block layout converted a ~100-instruction INSERT/DELETE divergence to score.
- **case 3 switch variable signedness**: the `next` switch variable was `signed char` (emitting `extsb`) where the target truncates as unsigned (`clrlwi`). Changed to `unsigned char`.

CalcGoOut: 91.03% -> 97.14%.

## Blocker
The dominant remaining diff is the inlined `GetGoOutInputMask` Pad-base register coloring (`&Pad` in r3 vs r4, switch var `next` in r0 vs r5). This is a pure register-number coloring wall that recurs identically in the never-cracked MenuUtil unit (CalcOptionMenu / GetMenuPress). Multiple source forms (cached `CPad&`/base pointer, `opt_lifetimes off`, statement reorders) were tried with no movement. SetMemCardError (89.9%) remains the switch-pivot wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)