### PR TITLE
goout: raise fuzzy match to 97.5% (cycle 13)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2157,15 +2157,17 @@ card_connected:;
             MemoryCardMan.m_currentSlot = static_cast<char>(0xff);
         }
 
+        int result;
         if (formatResult == 0) {
-            m_memCardResult = 0;
+            result = 0;
         } else if (formatResult == 1) {
-            m_memCardResult = 1;
+            result = 1;
         } else if (formatResult == -2) {
-            m_memCardResult = -5;
+            result = -5;
         } else {
-            m_memCardResult = -999;
+            result = -999;
         }
+        m_memCardResult = result;
 
         if (m_memCardResult != 0) {
             m_lastMemCardProc = m_memCardProc;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1293,10 +1293,13 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         m_pendingMessageTimer = 0;
         MenuPcs.GetMcAccessPos(&m_accessCardChannel, &m_accessSaveIndex);
         m_accessCardChannel = 0;
-        MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
-        m_cardChannel = static_cast<char>(m_accessCardChannel);
+        {
+        const int cardChannel = m_accessCardChannel;
+        MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
+        m_cardChannel = static_cast<char>(cardChannel);
         m_saveIndex = static_cast<char>(m_accessSaveIndex);
-        MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
+        MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
+        }
         m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));
         if (m_memCardResult == 1) {
             const unsigned char savedSaveIndex = static_cast<unsigned char>(m_saveIndex);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2888,8 +2888,8 @@ void CGoOutMenu::Calc()
     }
 
     if (m_messageState != 0 && MenuPcs.m_menuWindowInfo->state == 3) {
-        short x;
         short y;
+        short x;
 
         m_currentMessage = m_pendingMessage;
         if (m_pendingMessage != -1) {

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2068,7 +2068,7 @@ card_connected:;
         m_cursorListY1 = 0xde;
         m_cursorMode = 0;
         {
-            signed char next;
+            unsigned char next;
 
             if (MenuPcs.m_menuWindowInfo->state == 1) {
                 input = GetGoOutInputMask();
@@ -2084,7 +2084,7 @@ card_connected:;
                             Sound.PlaySe(3, 0x40, 0x7f, 0);
                         }
 
-                        next = static_cast<signed char>(m_cursorChoice + 1);
+                        next = static_cast<unsigned char>(m_cursorChoice + 1);
                         goto do_switch_go4;
                     }
                 }

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1294,9 +1294,10 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         MenuPcs.GetMcAccessPos(&m_accessCardChannel, &m_accessSaveIndex);
         m_accessCardChannel = 0;
         MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
-        m_cardChannel = static_cast<char>(MenuPcs.m_mcCtrl.m_cardChannel);
+        m_cardChannel = static_cast<char>(m_accessCardChannel);
         m_saveIndex = static_cast<char>(m_accessSaveIndex);
-        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(m_cardChannel);
+        MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
+        m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));
         if (m_memCardResult == 1) {
             const unsigned char savedSaveIndex = static_cast<unsigned char>(m_saveIndex);
             const unsigned char savedCardChannel = static_cast<unsigned char>(m_cardChannel);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1394,9 +1394,12 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
             MemoryCardMan.Odekake(0, *static_cast<Mc::SaveDat*>(MenuPcs.m_goOutTransferWork), m_selectedTransferChara, *MenuPcs.m_goOutTransferSaveData, freeCaravanIdx);
         }
 
-        MenuPcs.m_mcCtrl.m_cardChannel = m_accessCardChannel;
-        m_cardChannel = static_cast<char>(MenuPcs.m_mcCtrl.m_cardChannel);
+        {
+        const int cardChannel = m_accessCardChannel;
+        m_cardChannel = static_cast<char>(cardChannel);
         m_saveIndex = static_cast<char>(m_accessSaveIndex);
+        MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
+        }
         m_memCardBuffer = MenuPcs.m_goOutTransferSaveData;
         m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));
         if (m_memCardResult == 1) {

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1997,8 +1997,14 @@ card_connected:;
     case 0x14:
         if (m_messageWindowOpen != 0) {
             input = GetGoOutInputMask();
+            bool pressed;
             if ((input & 0x100) != 0) {
                 Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
                 MenuPcs.SetCaravanWork(MenuPcs.m_goOutTransferSaveData);
                 MenuPcs.ChgAllModel();
                 SetGoOutMode(1);

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -2118,9 +2118,17 @@ card_connected:;
         }
 
         input = GetGoOutInputMask();
-        if ((input & 0x100) != 0) {
-            Sound.PlaySe(2, 0x40, 0x7f, 0);
-            SetMainMode(1);
+        {
+            bool pressed;
+            if ((input & 0x100) != 0) {
+                Sound.PlaySe(2, 0x40, 0x7f, 0);
+                pressed = true;
+            } else {
+                pressed = false;
+            }
+            if (pressed) {
+                SetMainMode(1);
+            }
         }
         break;
     default:


### PR DESCRIPTION
Raises main/goout fuzzy match from 97.21% to 97.47% (cycle 13).

## Per-function gains
- SetGoOutMode 97.60 -> 98.02: matched card-channel store sequence; cached cardChannel in an int local so the duplicate m_mcCtrl.m_cardChannel store reuses the same register (target keeps cardChannel in r0 across, saveIndex in r4). Applied to both the card-init and transfer-init blocks.
- CalcGoOut 97.14 -> 97.78:
  - Materialized the explicit `bool pressed` true/false idiom in cases 0x14 and 6 (target round-trips the bool before `if (pressed)`).
  - Computed the Format() result mapping into an `int` local with a single trailing `m_memCardResult` store, while keeping the `!= 0` check reading the member back (matches target's store-then-reload).
  - `unsigned char next` (was signed char) in the case-4 cursor switch -> matched `clrlwi` instead of `extsb`.
- Calc 97.90 -> 97.91: swapped x/y local declaration order so the GetWinSize output-pointer args land in the target's stack slots.

## What worked
Single-store-via-local for if/else-if result mapping, explicit pressed-bool materialization, cardChannel int-local caching to fix store-sequence register coloring, and local declaration order for stack-slot assignment.

## Blockers (documented walls, not source-steerable)
- SetMemCardError (89.9%): switch binary-search pivot is mwcc's deterministic midpoint selection - every leaf compare is consistently +1 vs target (-5 vs -4, -1 vs 0, etc.) for the same 10-case set. Cannot be shifted from source.
- Calc / CalcDel / CalcGoOut residuals: inlined GetGoOutInputMask `&Pad` r3-vs-r4 coloring, the this/MenuPcs r30<->r31 swap, the m_menuWindowInfo r6 cross-inline CSE, the cursor `next` r5 residency (entangled with the Pad block order), and float-pool / jumptable symbol naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)