### PR TITLE
memory: raise fuzzy match to 96.1% (cycle 5)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1872,10 +1872,8 @@ void CAmemCache::IsEnable()
  */
 void CAmemCacheSet::AddRef(short index)
 {
-    CAmemCache& entry = cacheEntryAt(this, index);
-
-    entry.m_refCount += 1;
-    if (entry.m_refCount >= 0xFFFF) {
+    m_cacheTable[index].m_refCount += 1;
+    if (m_cacheTable[index].m_refCount >= 0xFFFF) {
         if (static_cast<unsigned int>(System.m_execParam) >= 3) {
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt), static_cast<int>(index));
         }
@@ -1900,7 +1898,7 @@ void CAmemCacheSet::AddRef(short index)
         }
     }
 
-    entry.m_priority = 0x7FFFFFF0;
+    m_cacheTable[index].m_priority = 0x7FFFFFF0;
 }
 
 /*

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1914,10 +1914,9 @@ void CAmemCacheSet::AddRef(short index)
  */
 void CAmemCacheSet::Release(short index)
 {
-    CAmemCache& entry = cacheEntryAt(this, index);
-    entry.m_refCount -= 1;
+    m_cacheTable[index].m_refCount -= 1;
 
-    if (entry.m_refCount >= 0xFFFF) {
+    if (m_cacheTable[index].m_refCount >= 0xFFFF) {
         if (static_cast<unsigned int>(System.m_execParam) >= 3) {
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt));
         }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1921,8 +1921,9 @@ void CAmemCacheSet::Release(short index)
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt));
         }
 
-        int offset = 0;
-        for (int i = 0; i < m_cacheCount; i++) {
+        int i = 0;
+        int offset = i;
+        for (; i < m_cacheCount; i++) {
             CAmemCache& cache = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
             if (((cache.m_inUse != 0) || (cache.m_cacheData != 0)) && (static_cast<unsigned int>(System.m_execParam) >= 3)) {
                 System.Printf(

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1878,14 +1878,16 @@ void CAmemCacheSet::AddRef(short index)
             System.Printf(const_cast<char*>(sAmemCacheAddRefFmt), static_cast<int>(index));
         }
 
+        int offset = 0;
         for (int i = 0; i < m_cacheCount; i++) {
-            CAmemCache& current = cacheEntryAt(this, i);
+            CAmemCache& current = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
             if (((current.m_inUse != 0) || (current.m_cacheData != 0)) && (static_cast<unsigned int>(System.m_execParam) >= 3)) {
                 System.Printf(
                     const_cast<char*>(sAmemCacheEntryFmt), i, cacheStateName(current),
                     cacheTypeName(current), current.m_refCount, current.m_priority,
                     reinterpret_cast<int>(current.m_cacheData));
             }
+            offset += sizeof(CAmemCache);
         }
 
         if (static_cast<unsigned int>(System.m_execParam) >= 3) {


### PR DESCRIPTION
Raises main/memory fuzzy match from 95.94% to 96.11% (cycle 5).

## Changes
- **AddRef**: recompute the cache entry via indexed access `m_cacheTable[index]` instead of caching a `CAmemCache&` reference, so mwcc keeps `index*0x1c` in a callee-saved register and recomputes `base+offset` at each use (matching the target's lazy recompute). Converted the debug-dump loop to byte-offset iteration. AddRef 93.94 -> 12 flagged.
- **Release**: same indexed-access recompute for the entry, and initialized the debug-loop byte offset from the index counter (`int i = 0; int offset = i;`) so mwcc emits the target's shared-zero `li; mr` init and the matching i/offset register assignment. Release flagged 12 -> 2.

## Why plausible
These are ordinary member-access and loop-counter idioms (indexed `m_cacheTable[index]`, a byte cursor advanced by `sizeof(CAmemCache)`), consistent with how the surrounding free-list / heap-walk code in this unit is already written. No layout, vtable, or linkage hacks.

## Blockers (walled after deep effort)
- alloc / Quit / heapWalker / drawHeapBar: register-window renumbering and param-coloring (permuter found nothing; reorders neutral or negative).
- CheckSum / drawHeapBar / SetData: `mtctr`/`bdnz` counted-loop vs our `subic./bne` — `for`/`do-while` rewrites regress.
- Init: `operator new[]` null-check fold; GetData: anonymous sdata2 float pool ordering.
- freeStageBlock add operand order (`next+block`) is correct for Free/__dl/__dla but regresses Quit/AmemFreeLowPrio/DestroyStage because the helper is inlined at many sites — no single source form wins.
- `cacheStateName` `rlwinm` mask (3,29 vs 22,29) is a benign mwcc boolean-to-index encoding difference, same runtime result, not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)