### PR TITLE
goout: raise fuzzy match to 97.76% (cycle 14)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1396,9 +1396,10 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         }
 
         {
+        const int saveIndex = m_accessSaveIndex;
         const int cardChannel = m_accessCardChannel;
         m_cardChannel = static_cast<char>(cardChannel);
-        m_saveIndex = static_cast<char>(m_accessSaveIndex);
+        m_saveIndex = static_cast<char>(saveIndex);
         MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
         }
         m_memCardBuffer = MenuPcs.m_goOutTransferSaveData;

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1428,9 +1428,13 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         break;
     }
     case 0x13:
-        MenuPcs.m_mcCtrl.m_cardChannel = static_cast<unsigned char>(m_odekakeCardChannel);
-        m_cardChannel = m_odekakeCardChannel;
-        m_saveIndex = m_odekakeSaveIndex;
+    {
+        const char odekakeSaveIndex = m_odekakeSaveIndex;
+        const char odekakeCardChannel = m_odekakeCardChannel;
+        m_cardChannel = odekakeCardChannel;
+        m_saveIndex = odekakeSaveIndex;
+        MenuPcs.m_mcCtrl.m_cardChannel = static_cast<unsigned char>(odekakeCardChannel);
+    }
         m_memCardBuffer = MenuPcs.m_goOutTransferWork;
         m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));
         if (m_memCardResult == 1) {

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1396,10 +1396,10 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         }
 
         {
-        const int saveIndex = m_accessSaveIndex;
+        const char saveIndex = static_cast<char>(m_accessSaveIndex);
         const int cardChannel = m_accessCardChannel;
         m_cardChannel = static_cast<char>(cardChannel);
-        m_saveIndex = static_cast<char>(saveIndex);
+        m_saveIndex = saveIndex;
         MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
         }
         m_memCardBuffer = MenuPcs.m_goOutTransferSaveData;
@@ -1721,7 +1721,7 @@ card_connected:;
         SetGoOutMode(0xE);
         break;
     case 0xE:
-        if (static_cast<unsigned char>(MenuPcs.m_goOutLoadFinished) != 0) {
+        if (static_cast<char>(MenuPcs.m_goOutLoadFinished) != 0) {
             if (MenuPcs.m_goOutLoadResult == 4) {
                 MenuGoOutState().m_resultSelect = 0;
                 MenuPcs.InitSaveLoadMenu();

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1296,8 +1296,9 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         {
         const int cardChannel = m_accessCardChannel;
         MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
+        const int saveIndex = m_accessSaveIndex;
         m_cardChannel = static_cast<char>(cardChannel);
-        m_saveIndex = static_cast<char>(m_accessSaveIndex);
+        m_saveIndex = static_cast<char>(saveIndex);
         MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
         }
         m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));


### PR DESCRIPTION
Raises main/goout from 97.47% to 97.76% (cycle 14).

## Per-function gains
- SetGoOutMode: 98.02 -> 99.75
- CalcGoOut: 97.78 -> 98.00

## What worked
- **memcard read ordering (SetGoOutMode, 3 sites; CalcGoOut analogue):** the memory-card setup blocks read m_accessSaveIndex / m_odekakeSaveIndex into a named local before storing m_cardChannel, matching the target's "load save-index, then card-channel" schedule and the mcCtrl-store-last ordering. Recovered the original statement order across the 0xC, Odekake, and 0x13 cases.
- **CalcGoOut m_goOutLoadFinished signed-char compare:** `static_cast<unsigned char>(MenuPcs.m_goOutLoadFinished) != 0` was emitting an unsigned `cmplwi`; the target uses a signed `extsb.` test. Changed the cast to signed `char`, matching the original comparison. (+0.075 unit.)

## Blocker
Remaining misses across CalcDel / Calc / CalcGoOut are the documented walls: the inlined GetGoOutInputMask `&Pad` r3-vs-r4 register coloring (repeated at every call site, plus the m_debugPadLock CSE into r6), the this/MenuPcs r30<->r31 swap in Calc, the SetMemCardError switch-pivot, and float-pool / jumptable symbol naming. These resist source-level steering (local references, reordering, and char/int retyping were all tried and either no-op or regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)