### PR TITLE
goout: raise fuzzy match to 97.78% (cycle 15)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1430,10 +1430,10 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
     case 0x13:
     {
         const char odekakeSaveIndex = m_odekakeSaveIndex;
-        const char odekakeCardChannel = m_odekakeCardChannel;
+        const unsigned char odekakeCardChannel = static_cast<unsigned char>(m_odekakeCardChannel);
         m_cardChannel = odekakeCardChannel;
         m_saveIndex = odekakeSaveIndex;
-        MenuPcs.m_mcCtrl.m_cardChannel = static_cast<unsigned char>(odekakeCardChannel);
+        MenuPcs.m_mcCtrl.m_cardChannel = odekakeCardChannel;
     }
         m_memCardBuffer = MenuPcs.m_goOutTransferWork;
         m_memCardResult = static_cast<McCtrl*>(&MenuPcs.m_mcCtrl)->ChkConnect(static_cast<unsigned char>(m_cardChannel));

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1396,10 +1396,10 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         }
 
         {
-        const char saveIndex = static_cast<char>(m_accessSaveIndex);
         const int cardChannel = m_accessCardChannel;
+        const int saveIndex = m_accessSaveIndex;
         m_cardChannel = static_cast<char>(cardChannel);
-        m_saveIndex = saveIndex;
+        m_saveIndex = static_cast<char>(saveIndex);
         MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
         }
         m_memCardBuffer = MenuPcs.m_goOutTransferSaveData;


### PR DESCRIPTION
Raises main/goout fuzzy match from 97.76% to 97.78% (cycle 15).

## Changes
- **SetGoOutMode case 0x13 (odekake)**: dropped a spurious `static_cast<unsigned char>` on the `m_mcCtrl.m_cardChannel` (int) store and modeled `odekakeCardChannel` as `unsigned char`. This removed an extra `clrlwi`/`extsb` extension before the word store and corrected the field load order. SetGoOutMode 99.75% to 99.95%.
- **SetGoOutMode case 0x12 (Odekake)**: reordered the `cardChannel`/`saveIndex` access-field temporaries (cardChannel first, both `int`) so the store register coloring (`r0`=cardChannel reused for the three stores, `r4`=saveIndex) matches the target. Fixed 3 of 5 flagged lines; remaining 2 are a pure load-schedule choice.

## Evidence
- Unit main/goout: 97.75784% to 97.78212%.
- SetGoOutMode: 99.75% to 99.95%; both changes verified via asm_match (extension/coloring lines cleared).
- No regressions elsewhere; permute_fn confirmed no further source-steerable gains on Calc, CalcDel, SetDelMode, SetMenuStr, SetGoOutMode.

## Why plausible
The casts/extensions removed were redundant: the values flow into byte members and an int mcCtrl field that the original stored directly. The temporary ordering matches the natural read/store sequence the original source used.

## Remaining blockers (documented walls)
All residual diffs reduce to known walls: jumptable/float-pool symbol naming, inlined GetGoOutInputMask `&Pad` r3-vs-r4 coloring, the this/MenuPcs r30↔r31 swap in Calc, SetMemCardError switch-pivot midpoint, and minor load-scheduling/clamp-coloring nuances that do not respond to source reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)