### PR TITLE
fontman: raise fuzzy match to 97.56% (cycle 4)

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -93,8 +93,10 @@ found_glyph:
 
 found_fallback:
 	int drawWidth;
-	float localMargin = margin;
-	float localScaleX = scaleX;
+	float localMargin;
+	float localScaleX;
+	localScaleX = scaleX;
+	localMargin = margin;
 	CFontRenderFlagBits& renderFlagBits = GetRenderFlagBits(renderFlags);
 
 	if (renderFlagBits.fixedWidth != 0) {
@@ -174,8 +176,10 @@ found_glyph:
 use_glyph:
 		CFontRenderFlagBits& renderFlagBits = GetRenderFlagBits(renderFlags);
 		int drawWidth;
-		float localMargin = margin;
-		float localScaleX = scaleX;
+		float localMargin;
+		float localScaleX;
+		localScaleX = scaleX;
+		localMargin = margin;
 
 		if (renderFlagBits.fixedWidth != 0) {
 			drawWidth = static_cast<int>(m_glyphWidth);


### PR DESCRIPTION
## Summary
Raises `main/fontman` from 97.54% to 97.56% by correcting the FPR read order for the `scaleX * (margin + width)` advance computation in both `GetWidth` overloads.

## What changed
In `CFont::GetWidth(unsigned short)` and `CFont::GetWidth(char*)`, the target reads `scaleX` (offset 0x28) into f3 *first*, then `margin` (offset 0x20) into f2. The previous source cached both in init-at-declaration locals (`localMargin = margin; localScaleX = scaleX;`), which forced mwcc to read them in declaration order (margin first → f2), producing a register/read-order mismatch on the `floor`/snap path.

Splitting declaration from assignment — declaring `localMargin` first (so it colors to f2) but assigning `localScaleX = scaleX` first (so scaleX is read first and colors to f3) — reproduces the target's exact `lfs f3,0x28; ...; lfs f2,0x20` sequence. This removed the f2/f3 ARG_MISMATCH pair in both functions.

- `GetWidth(unsigned short)`: 96.88% → higher (float diff gone; 7→5 flagged lines)
- `GetWidth(char*)`: float diff gone

## Blockers (confirmed walls, not pursued further)
- **SetColor**: the remaining 4-line diff is the red-byte `lbz` scheduling into the LR-save prologue slot — pure mwcc instruction scheduling on the byte-copy struct param, not source-steerable.
- **Glyph-search `bne;b` layout**: target emits `bne continue; b found`; mwcc peephole-merges our equivalent source into a single `beq found` regardless of whether the loop is written `!=`+else-goto or `==`+goto. Verified unbreakable.
- **Draw**: dominated by a frame-size overage (0xe0 target vs 0x100 ours) from int↔float magic-double conversion scratch slots — the target round-robins ~4 slots while mwcc allocates a fresh slot per `(u16)`/`(float)` conversion for us. Documented conversion-scratch wall; not steerable from source.
- **Bias-pool naming** (`@258`/`kFont...Bias` anonymous double pool): known wall.

## Plausibility
The split decl/assign of two float locals is ordinary hand-written source; behavior is identical. No layout/header changes, no hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)