### PR TITLE
graphic: raise fuzzy match to 95.7% (cycle 5)

### DIFF
--- a/include/ffcc/graphic_symbols.h
+++ b/include/ffcc/graphic_symbols.h
@@ -17,7 +17,7 @@ extern _GXColor gGraphicDefaultClearColor;
 extern const char sGraphicInitData[];
 extern const char sGraphicStageName[];
 extern const char sGraphicSourceStrings[];
-extern char sGraphicUnknownOrderName[];
+extern const char sGraphicUnknownOrderName[4];
 extern u8 gGraphicNoiseTextureI8_64x96[];
 extern const float kGraphicZeroF;
 extern const float kGraphicOneF;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1645,13 +1645,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 
 	if (mode != 1) {
 		float targetMag = PSVECMag(&cameraToTarget);
-		if (targetMag > 0.0f) {
-			PSVECScale(&cameraToTarget, &scaledDir, farDist / targetMag);
-		} else {
-			scaledDir.x = 0.0f;
-			scaledDir.y = 0.0f;
-			scaledDir.z = 0.0f;
-		}
+		PSVECScale(&cameraToTarget, &scaledDir, farDist / targetMag);
 
 		GXProject(targetPos.x + scaledDir.x, targetPos.y, targetPos.z + scaledDir.z, cameraMtx, gxProjection,
 		          gxViewport, &projX, &projY, &projZ);


### PR DESCRIPTION
Raises main/graphic fuzzy match from 95.50% to 95.71%.

## Changes
- **RenderDOF** (93.30% -> 94.62%): the `if (targetMag > 0.0f) { PSVECScale(...) } else { scaledDir = {0,0,0} }` guard was a reconstruction artifact. The original computes `farDist / targetMag` and calls `PSVECScale` unconditionally; the defensive else-branch produced an extra `fcmpo`+`ble`+three zero-stores absent from the target. Removed the guard.
- **Thread** (89.43% -> 90.77%): declared `sGraphicUnknownOrderName` as a sized `const char[4]` so mwcc uses `@sda21` (r2-relative) addressing for the `.sdata2` symbol, matching the original instead of emitting `@ha/@l`.

## Why plausible
Both are real source-shape corrections, not compiler-coaxing: the `.sdata2` symbol genuinely lives in small read-only data (per `config/GCCP01/symbols.txt`), and the unconditional divide matches the target's straight-line codegen.

## Remaining blockers (deep walls, exhausted)
- makeSphere (80%): first-loop register-window (`stmw r21` vs `r20`); two-pointer/in-loop-base levers all regress.
- SetFog/SetCopyClear: stack-packing and `_GXColor` struct-copy interleave.
- GetBackBufferRect/Rect2, Init: uniform `this`/callee-saved register-window shifts.
- RenderTexQuadGrouad: GXWGFifo FPR-allocation coloring.
- RenderDOF residual: identical opcodes, differing absolute stack-slot offsets (same frame size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)