### PR TITLE
cmake: raise fuzzy match to 88.4% (cycle 11)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3753,17 +3753,29 @@ void CMenuPcs::DrawSingCMake()
 
     if (CmakeState(this)->m_step == 6) {
         CmakeState(this)->m_step = static_cast<short>(CmakeState(this)->m_select + 1);
-        CmakeState(this)->m_mode = (CmakeState(this)->m_step == 0) ? 2 : 0;
+        if (CmakeState(this)->m_step == 0) {
+            CmakeState(this)->m_mode = 2;
+        } else {
+            CmakeState(this)->m_mode = 0;
+        }
     } else if (CmakeState(this)->m_resultDir < 0) {
         if (CmakeState(this)->m_step == 5) {
             CmakeState(this)->m_step = 6;
         } else {
             CmakeState(this)->m_step = static_cast<short>(CmakeState(this)->m_step - 1);
         }
-        CmakeState(this)->m_mode = (CmakeState(this)->m_step == 0) ? 2 : 0;
+        if (CmakeState(this)->m_step == 0) {
+            CmakeState(this)->m_mode = 2;
+        } else {
+            CmakeState(this)->m_mode = 0;
+        }
     } else if (CmakeState(this)->m_step != 5) {
         CmakeState(this)->m_step = static_cast<short>(CmakeState(this)->m_step + 1);
-        CmakeState(this)->m_mode = (CmakeState(this)->m_step == 0) ? 2 : 0;
+        if (CmakeState(this)->m_step == 0) {
+            CmakeState(this)->m_mode = 2;
+        } else {
+            CmakeState(this)->m_mode = 0;
+        }
     } else {
         CmakeState(this)->m_step = 0;
         CmakeState(this)->m_mode = 2;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -612,7 +612,7 @@ void CMenuPcs::calcVillageMenu()
 
             loadTexture(PTR_s_world2, 8, 1, s_cmakeWorldTextureTable, 0x60, 9, 3);
 
-            CMemory::CStage* stage = m_menuStage;
+            CMemory::CStage* stage = MenuPcs.m_menuStage;
             void*& villageWork = CmakeVillageWork(this);
             villageWork = operator new(0x48, stage, const_cast<char*>(s_cmake_cpp), 0xCB3);
             memset(villageWork, 0, 0x48);


### PR DESCRIPTION
Raises main/cmake fuzzy match from 88.33% to 88.43%.

## Changes
- **DrawSingCMake** (84.05% -> 86.13%): the step-transition's \`m_mode = (m_step == 0) ? 2 : 0\` was emitting a branchless \`cntlzw/extrwi/neg/and\` select against the freshly-written \`m_step\`. The target re-reads \`m_step\` from memory and uses a real \`cmpwi/bne\` branch. Rewrote the three ternaries as explicit \`if/else\` blocks that reload \`m_step\`, matching the target's branch structure.
- **calcVillageMenu** (94.53%, 19 -> 12 flagged lines): \`m_menuStage\` was read through \`this\` (\`0xec(r31)\`) but the original reads it from the global \`MenuPcs\` object (\`MenuPcs@ha/@l + 0xec\`). Changed \`m_menuStage\` to \`MenuPcs.m_menuStage\`, which also corrected the downstream \`operator new\` argument register order.

## Blockers (confirmed walls, many variants tried and reverted)
- alpha-FPR coloring (f30<->f31 swap) in CmakeVillageDraw/DrawCmakeName/CmakeSexDraw
- int-Y magic-double fold for DrawRect/DrawCursor int coordinates (DrawDiaryBase, CmakeTribeDraw, CmakeJobDraw, CmakeNameDraw)
- m_cmakeState state-pointer coloring (CalcSingCMake, DrawSingCMake) - caching in a local regresses
- pad-read prologue Pad-global base register coloring (CmakeJobCtrl/CmakeVillageCtrl/CmakeNameCtrl) - down/repeat signedness and padIndex coloring
- tileX/tileW r27<->r28 swap (CmakeSexDraw)
- CmakeResultDraw1 frame inflated by 0x30 from stack temporaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)