### PR TITLE
cmake: raise fuzzy match to 88.5% (cycle 12)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -513,11 +513,10 @@ void CMenuPcs::DrawSingleCMakeChara(float alpha)
 void CMenuPcs::CalcSingleCMakeChara()
 {
     int slot = static_cast<int>(CmakeSlot(this));
-    CCharaPcs::CHandle* handle = GetCmakeCharaHandle(this, slot);
     unsigned char* modelWork = reinterpret_cast<unsigned char*>(MenuS32(this, 0x814) + slot * 0x50 + 0xA00);
 
-    if (handle->m_model == nullptr ||
-        *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(handle->m_model) + 0xB0) == 0) {
+    if (GetCmakeCharaHandle(this, slot)->m_model == nullptr ||
+        *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(GetCmakeCharaHandle(this, slot)->m_model) + 0xB0) == 0) {
         *reinterpret_cast<int*>(modelWork + 0x00) = 0;
         return;
     }
@@ -525,12 +524,12 @@ void CMenuPcs::CalcSingleCMakeChara()
     unsigned char* animWork = reinterpret_cast<unsigned char*>(MenuS32(this, 0x824) + slot * 0x34);
     if (animWork[0x0C] == 1) {
         *reinterpret_cast<float*>(modelWork + 0x2C) = 0.2617994f;
-        SetAnim(slot);
+        SetAnim(CmakeSlot(this));
         animWork[0x0C] = 0;
     }
 
     *reinterpret_cast<int*>(modelWork + 0x00) = 1;
-    if (handle->m_charaKind != 3) {
+    if (GetCmakeCharaHandle(this, slot)->m_charaKind != 3) {
         Mtx scaleMtx;
         Mtx rotXMtx;
         Mtx rotYMtx;
@@ -556,9 +555,9 @@ void CMenuPcs::CalcSingleCMakeChara()
         rotXMtx[1][3] = *reinterpret_cast<float*>(modelWork + 0x20);
         rotXMtx[2][3] = *reinterpret_cast<float*>(modelWork + 0x24);
         PSMTXConcat(rotXMtx, scaleMtx, scaleMtx);
-        handle->m_model->SetMatrix(scaleMtx);
-        handle->m_model->CalcMatrix();
-        handle->m_model->CalcSkin();
+        GetCmakeCharaHandle(this, slot)->m_model->SetMatrix(scaleMtx);
+        GetCmakeCharaHandle(this, slot)->m_model->CalcMatrix();
+        GetCmakeCharaHandle(this, slot)->m_model->CalcSkin();
         PCAnimCtrl();
     }
 }


### PR DESCRIPTION
Cycle 12 of raising main/cmake fuzzy match. Climbed 88.43% -> 88.50%.

## What changed
**CalcSingleCMakeChara** (91.2% -> ~97%, 28 -> 13 flagged lines): applied the R8/R13 lazy-reload lever. The original does NOT cache the `CCharaPcs::CHandle*` returned by `GetCmakeCharaHandle` nor the chara slot; it re-derives `m_wm.m_handles[slot+0x20]` and re-reads `m_singleCmakeSlot` at each use, keeping only the handle-slot address cached. Replaced the cached `handle` local with fresh `GetCmakeCharaHandle(this, slot)` accesses and `SetAnim(CmakeSlot(this))`, matching the target's per-use reload of offset 0x774 and 0x86a.

## Why it is plausible source
The reload pattern is exactly what writing `m_wm.m_handles[index]->m_model` repeatedly (rather than stashing the handle in a local) produces. No offset tricks, no fake symbols.

## Blockers (documented walls, confirmed still walled this cycle)
- alpha f30/f31 coloring (CmakeVillageDraw, DrawCmakeName, CmakeSexDraw extra callee-saved FPR)
- DrawDiaryBase int-Y fold (y=24 int-convert reproduces the magic-double but regresses 1 line)
- pad-read prologue register allocation (all *Ctrl functions; `short` vs `unsigned short` for down/repeat regressed)
- CalcCmakeFadeAlpha inline prologue: state-ptr vs frame in r4/r5 is consistent across all Draw inline sites; reorder regressed every site
- DrawRect call-arg staging inflates ResultDraw frames by 0x20-0x30 (compiler-controlled scratch; single-`col` reuse did not shrink it)
- Float-literal pooling: ~20-30% of remaining flagged lines per Draw function are `FLOAT_xxxxxxxx@sda21` (named) vs our `@NNN@sda21` (anonymous pool) — systematic data-anchoring, same values, not source-steerable

🤖 Generated with [Claude Code](https://claude.com/claude-code)