### PR TITLE
gobjwork: raise fuzzy match to 95.7% (cycle 9)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2355,12 +2355,11 @@ int CCaravanWork::DelCmdListAndItem(int cmdListIdx)
 		} else if (m_commandListExtra[cmdListIdx] == 0) {
 			numGrouped = 1;
 		} else {
-			unsigned int topIdx = cmdListIdx;
-			for (int n = cmdListIdx; n >= 0; n--) {
+			int topIdx;
+			for (topIdx = cmdListIdx; topIdx >= 0; topIdx--) {
 				if (m_commandListExtra[topIdx] != -1) {
 					break;
 				}
-				topIdx--;
 			}
 
 			numGrouped = 1;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2218,12 +2218,11 @@ int CCaravanWork::GetCmdListItemName(int cmdListIdx, int* firstCmdIdx, int* item
 		if (m_commandListExtra[cmdListIdx] == 0) {
 			groupedCount = 1;
 		} else {
-			int topIdx = cmdListIdx;
-			for (int n = cmdListIdx; n >= 0; n--) {
+			int topIdx;
+			for (topIdx = cmdListIdx; topIdx >= 0; topIdx--) {
 				if (m_commandListExtra[topIdx] != -1) {
 					break;
 				}
-				topIdx--;
 			}
 
 			groupedCount = 1;


### PR DESCRIPTION
Raises main/gobjwork from 95.60% to 95.72%.

## Changes
Rewrote the `topIdx` scan loops in `DelCmdListAndItem` and `GetCmdListItemName` to use a single loop variable instead of a separate counter and a parallel index. The original source walked one index down (`for (topIdx = cmdListIdx; topIdx >= 0; topIdx--)`), which lets mwcc fuse the initialization and the `>= 0` test into a single record-form `mr.` instruction — matching the target's basic-block structure and eliminating the INSERT/DELETE/OP_MISMATCH run around the loop head.

## Per-function results
- `DelCmdListAndItem`: structural diffs (mr./cmpwi split) eliminated; all remaining diffs are pure register-window coloring.
- `GetCmdListItemName`: flagged lines 21 -> 19.

## Plausibility
The single-variable down-counting loop is the natural idiom and is functionally identical to the prior two-variable form; it is closer to the original source shape implied by the target asm.

## Blockers (left as-is, confirmed walls)
- `SearchRomLetterWork` / `AddLetter` / `SafeDeleteTempItem` / `GetNextCmdListIdx` / `GetNumCombi` / `GetMagicCharge`: remaining diffs are pure register-coloring / +2-callee-saved-register-count cascades (e.g. SearchRomLetterWork keeps condBits+excludeFlag in callee-saved r28/r26 across calls; ours uses scratch). Caching globals/pointers as locals was tried and regressed. `FGLetterOpen`: 0x3ec offset-trick wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)