### PR TITLE
cmake: raise fuzzy match to 88.5% (cycle 13)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1565,7 +1565,7 @@ void CMenuPcs::CmakeResultDraw()
     valueFont->SetColor(valueColor.color);
     valueFont->SetTlut(6);
 
-    char tribeWithSlash[0x40];
+    char tribeWithSlash[0x20];
     for (int i = 0; i < 4; i++) {
         const char* value = "";
         if (i == 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1268,7 +1268,7 @@ void CMenuPcs::CmakeResultDraw1()
     valueFont->SetColor(valueColor.color);
     valueFont->SetTlut(6);
 
-    char tribeWithSlash[0x40];
+    char tribeWithSlash[0x10];
     for (int i = 0; i < 4; i++) {
         const char* txt = "";
 


### PR DESCRIPTION
Cycle 13 on main/cmake. Baseline 88.504% -> 88.516%.

## What changed
Two oversized stack-buffer fixes (target frame SMALLER than ours -> trim a local):
- **CmakeResultDraw1**: `tribeWithSlash[0x40]` -> `[0x10]`. Frame 0x150 -> 0x120 (matches target). Flagged asm lines 261 -> 197; frame prologue/epilogue and all dependent stack-slot offsets now match.
- **CmakeResultDraw**: `tribeWithSlash[0x40]` -> `[0x20]`. Frame 0x130 -> 0x110 (matches target). Flagged asm lines 292 -> 262.

Both buffers only ever hold a tribe-name string plus a "/" separator (short), so the smaller size is plausible original source and the frame now matches the shipped binary exactly.

## Blockers (documented walls, deep effort, reverted)
- **alpha f30/f31 coloring**: CmakeVillageDraw, DrawCmakeDecision, DrawCmakeYesNo, CmakeResultDraw1 all swap the two callee-saved FPRs (alpha vs 255*alpha). Inlining/reordering the 255*alpha computation was neutral.
- **pad-read prologue**: CmakeNameCtrl and CalcSingCMake. `short`/`unsigned short` audits on `down`/`repeat` regressed the prologue while only partially fixing the body bit-tests (target keeps `down` raw in r29; our bit-tests re-mask via clrlwi/extsh).
- **int->double magic-fold**: DrawDiaryBase int-Y fold (Y=0x18 int constant-folds instead of staying in a callee-saved reg) and CmakeTribeDraw (target emits extra `stfd` magic-double scratch we fold away).
- **GXColor scratch-slot packing / tileX register shift**: CmakeResultDraw/Draw1 remaining diffs are the target packing per-block GXColor scratch into a tight descending stack region vs our scattered slots, shifting the tile-loop register window (r28 vs r24). Single-`col` reuse refactor not expressible without scope conflicts.
- **float-pool naming**: pervasive `FLOAT_xxx@sda21` vs `@NNN@sda21` (mostly unscored layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)