### PR TITLE
p_camera: raise fuzzy match to 93.3% (cycle 14)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -921,7 +921,7 @@ void CCameraPcs::draw()
         GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
         GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
         CColor drawColor(0xFF, 0xFF, 0xFF, 0xFF);
-        Graphic.DrawSphere(m_cameraMatrix, reinterpret_cast<Vec*>(&m_targetX), kCameraDebugZoomStep, &drawColor.color);
+        Graphic.DrawSphere(m_cameraMatrix, reinterpret_cast<Vec*>(&m_targetX), kCameraDebugZoomStep, drawColor);
     }
 
     if (g_map_draw_prof != 0) {


### PR DESCRIPTION
## Summary
Cycle-14 pass on \`main/p_camera\`. Raised the unit fuzzy match from 93.27671% to 93.28505%.

### What changed
- \`draw()\`: pass the \`CColor\` temporary to \`CGraphic::DrawSphere(..., _GXColor*)\` via the class's own \`operator _GXColor*()\` conversion instead of \`&drawColor.color\`. This lets the constructor's returned \`this\` flow toward the color argument, matching the original's argument handling. \`draw\` function match 96.32% -> 96.45%.

### Why it is plausible source
\`CColor\` defines \`operator _GXColor*()\` precisely so a \`CColor\` can be passed where a \`_GXColor*\` is expected; using that implicit conversion is the natural way the original code would have called \`DrawSphere\`.

### Blockers (documented walls, deep effort spent)
- \`calc\` (82.9%): dominated by the known \`this\`/\`&Pad\` callee-saved register swap (r30/r31). The target holds \`&Pad\` in r31 and \`this\` in r30; ours is inverted. Reference/alias locals do not shift the allocation.
- \`createFullShadow\` (60.6%): SR-counter / saved-register-count wall plus an 8x-unrolled bit-twiddling ramp-fill loop with a different register/addressing shape.
- \`CalcQuake\` (94.4%): remaining diffs are the bias-pool double-constant naming (\`@526\` vs \`kCameraS16ToDoubleBias\`) and the three-rand sign pipeline; signedness and state-hoist variants regressed.
- \`calcChara\`/\`calcMaterialEditor\`/\`calcFunnyShape\` (~97-99%): shared debug-pad rotation block. Target software-pipelines the rotate/zoom step constants across two alternating FPRs (f2/f3); ours starts one register higher. Store/declaration reorderings regressed.
- \`create\` (91.7%) and \`calcMap\` (98.1%): float-constant register-recycling / store-order scheduling; tried reuse-local and reorder variants, all regressed.
- \`__sinit\`: known \`...data.0\` base-CSE wall, not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)