### PR TITLE
joybus: raise fuzzy match to 89.6% (cycle 12)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -307,7 +307,7 @@ void JoyBus::CreateInit()
 
     if (m_fileBaseA == 0)
     {
-        m_fileBaseA = reinterpret_cast<unsigned int*>(new (GbaPcs.m_stage, const_cast<char*>(s_joybus_cpp), 0x137) char[len + 0x20]);
+        m_fileBaseA = reinterpret_cast<unsigned int*>(new (GbaPcs.m_stage, const_cast<char*>(s_joybus_cpp), 0x137) char[m_fileBaseA_dup + 0x20]);
 
         if (m_fileBaseA == (unsigned int*)nullptr && (unsigned int)System.m_execParam >= 1)
         {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -315,8 +315,8 @@ void JoyBus::CreateInit()
         }
     }
 
-    memset((void*)m_fileBaseA, 0, len);
-    memcpy((void*)m_fileBaseA, File.m_readBuffer, len);
+    memset((void*)m_fileBaseA, 0, m_fileBaseA_dup);
+    memcpy((void*)m_fileBaseA, File.m_readBuffer, m_fileBaseA_dup);
 
     File.Close(file);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2744,8 +2744,8 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
         unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(cmdOut);
         int op = cmdBytes[0] & 0x3F;
 
-        if (op == 0x14 || op == 0x17 || op == 0x1A ||
-            op == 0x1C || op == 0x1D || op == 0x1E ||
+        if (op == 0x14 || op == 0x1C || op == 0x17 ||
+            op == 0x1D || op == 0x1A || op == 0x1E ||
             op == 0x1F || (op == 0x06 && cmdBytes[1] == 0x18))
         {
             OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
@@ -4427,7 +4427,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         m_cmdBuffer[4 + threadParam->m_portIndex] = (unsigned char)enemyCount;
 
         // If there are no enemies, skip straight to treasure (state 4)
-        if (m_cmdBuffer[4 + threadParam->m_portIndex] == 0)
+        if (static_cast<signed char>(m_cmdBuffer[4 + threadParam->m_portIndex]) == 0)
         {
             state += 2; // 2 -> 4
         }
@@ -4500,7 +4500,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
 
         m_cmdBuffer[4 + threadParam->m_portIndex] = (unsigned char)treasureCount;
 
-        if (m_cmdBuffer[4 + threadParam->m_portIndex] == 0)
+        if (static_cast<signed char>(m_cmdBuffer[4 + threadParam->m_portIndex]) == 0)
         {
             state = 0;
         }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2744,8 +2744,8 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
         unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(cmdOut);
         int op = cmdBytes[0] & 0x3F;
 
-        if (op == 0x14 || op == 0x1C || op == 0x17 ||
-            op == 0x1D || op == 0x1A || op == 0x1E ||
+        if (op == 0x14 || op == 0x17 || op == 0x1A ||
+            op == 0x1C || op == 0x1D || op == 0x1E ||
             op == 0x1F || (op == 0x06 && cmdBytes[1] == 0x18))
         {
             OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);


### PR DESCRIPTION
Raises main/joybus from 89.48% to 89.56% via source-level fixes.

## Changes
- **CreateInit (+4.1)**: read back `m_fileBaseA_dup` (the just-stored file length) for the buffer allocation size and the memset/memcpy lengths instead of caching `len` in a register. Matches the original's lazy field-reload, which frees the register and corrects the callee-saved window through the function tail.
- **SendPpos (+0.29)**: the enemy/treasure-count zero tests compare a `signed char`, matching the target's `extsb.` (we previously emitted an unsigned `cmplwi`).

## Evidence
- Unit fuzzy_match_percent: 89.480385% -> 89.557910%
- CreateInit: 86.51% -> 90.57%
- SendPpos: 88.78% -> 89.07%

## Plausibility
Both changes are ordinary source idioms: reading a member back from memory rather than via a stale cached local, and a signed-char comparison on a count field. No hacks, no layout changes, behavior identical.

## Blockers (documented walls, not pursued)
Remaining mid-% functions (SendResult, SetCmdLst, SetTmpArti, SendUseItem, SendHitEnemy, SendChkCrc, SendPlayerStat) are dominated by the result-in-rN-vs-r3 ABI idiom and its register-window cascade; MakeJoyData/SendMapObjDrawFlg by the CRC16 register-numbering; RestartThread/GBARecvSend by the s_dvd_gba_dir rodata.0 base anchoring; SendDataFile by the slot-window. These were attempted and reverted as net-neutral or regressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)