### PR TITLE
map: raise fuzzy match to 95.49% (cycle 5)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2491,17 +2491,19 @@ int CMapMng::ReadMid(char* mapName)
         chunkFile.PopChunk();
     }
 
-    for (int i = 0; i < m_mapObjCount; i++) {
-        CMapObj* obj = &MapMng.m_mapObjArray[i];
+    CMapObj* obj = MapMng.m_mapObjArray;
+    for (int i = 0; i < m_mapObjCount; i++, obj++) {
         unsigned char type = obj->m_mapDataType;
-        CMapHit* hit = static_cast<CMapHit*>(obj->m_mapData);
-        if ((type == 2 || type == 3) && hit != 0) {
-            int hitIndex = hit - GetMapHitArray();
-            if (hitIndex >= m_mapHitCount) {
-                if (static_cast<unsigned int>(System.m_execParam) >= 1) {
-                    System.Printf(const_cast<char*>(s_read_mid_hit_error));
+        if (type == 2 || type == 3) {
+            CMapHit* hit = static_cast<CMapHit*>(obj->m_mapData);
+            if (hit != 0) {
+                int hitIndex = hit - GetMapHitArray();
+                if (hitIndex >= m_mapHitCount) {
+                    if (static_cast<unsigned int>(System.m_execParam) >= 1) {
+                        System.Printf(const_cast<char*>(s_read_mid_hit_error));
+                    }
+                    obj->m_mapData = 0;
                 }
-                obj->m_mapData = 0;
             }
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2338,7 +2338,7 @@ int CMapMng::ReadMid(char* mapName)
     sprintf(strTmp, const_cast<char*>(s_mapMidPathFmt), mapName);
     int ok = 1;
 
-    if (static_cast<int>(System.m_execParam) >= 3) {
+    if (static_cast<unsigned int>(System.m_execParam) >= 3) {
         System.Printf(const_cast<char*>(s_read_mid_fmt), strTmp);
     }
 


### PR DESCRIPTION
Raises `main/map` fuzzy match from 95.38% to 95.49% by fixing two real source issues in `CMapMng::ReadMid`.

## Changes
- **ReadMid: unsigned execParam compare.** The first `m_execParam >= 3` debug-trace check used a signed `static_cast<int>`, emitting `cmpwi`; the original is unsigned (`cmplwi`), matching every other execParam check in the function.
- **ReadMid: lazy `m_mapData` load + cursor in the hit-validity loop.** The final loop over `m_mapObjArray` eagerly loaded `obj->m_mapData` before the type test; the original loads it lazily inside the `type == 2 || type == 3` branch and walks the array with a `CMapObj*` cursor rather than re-indexing. This collapses a run of mismatched register/branch lines.

## Evidence
- main/map fuzzy: 95.37773% -> 95.48725%.
- ReadMid flagged diff lines: 141 -> 133.
- No data/linkage regressions (data 98.89%, 78/94 functions still matched).

## Plausibility
Both edits are ordinary source forms (an unsigned debug-level comparison and a lazy field read with a pointer cursor), consistent with the rest of the file's idioms — not compiler-coaxing.

## Remaining (walled)
ReadMid/ReadMpl/ReadMtx residuals are the documented `...rodata.0` merged-base vs named `DAT_801D7300` anchor (a constant 0xe0 string-cluster offset shifting the whole register window). SetIdGrpColor (slot-register coloring) and GetDebugPlaySta/AttachMapHit (loop strength-reduction trip-count lowering) were each attacked with multiple structural variants and `permute_fn.py`; all regressed or were no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)