### PR TITLE
textureman: raise fuzzy match to 99.11% (cycle 5)

### DIFF
--- a/src/textureman.cpp
+++ b/src/textureman.cpp
@@ -227,8 +227,8 @@ void CTextureSet::Create(void* filePtr, CMemory::CStage* stage, int append, CAme
                                 texture->Create(chunkFile, stage, amemCacheSet, cacheTag, useAddress);
 
                                 if (texture->m_name[0] != 0) {
-                                    char* textureName = texture->m_name;
                                     unsigned int duplicateIdx;
+                                    char* textureName = texture->m_name;
                                     for (duplicateIdx = 0; duplicateIdx < (unsigned int)m_textureArray.GetSize(); duplicateIdx++) {
                                         CTexture* existing = m_textureArray[duplicateIdx];
                                         if ((existing != 0)


### PR DESCRIPTION
Raises `main/textureman` from 99.08% to 99.11%.

## What changed
In `CTextureSet::Create(void*, ...)`, reordered the duplicate-search locals so `duplicateIdx` is declared before `textureName`. This matches the original's callee-saved register window: the loop counter and the cached `texture->m_name` pointer were swapping registers (r21/r22) versus the target. The reorder fixes the coloring, dropping the void* overload's flagged-line count from 59 to 51.

## Per-function
- `Create__11CTextureSetFPv...`: register-window coloring of the dup-search loop now matches (counter/name pointer no longer swapped).

## Blockers (documented walls, attempted and confirmed)
- **Loop-invariant register-window** on both `CTextureSet::Create` overloads: the function args land in r25-r31 (target) vs r22-r28 (ours), with hoisted invariants (&TextureMan, chunk-id const, allocated texture) in the opposite block. Every remaining flagged line is the same value in a shifted callee-saved register. `permute_fn` found no improvement; converting the while+switch to the Ghidra do/while shape regressed to 98.1%.
- **InitTexObj srwi-vs-srawi** (shared by InitTexObj, CacheLoadTexture, CTexture::Create): the `(1 - m_maxLod) >> 31` mipmap flag wants a logical shift. Casting to `unsigned` produces the correct `srwi` but mwcc reschedules the surrounding GXInitTexObj arg loads, a net regression at every call site (99.05% / 99.00%).
- **Float literal-pool naming** (@374 vs @506) in the inlined GXInitTexObjLOD constants - layout-level, not source-steerable.

Result is plausible original source (a one-line local-declaration reordering); no hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)