### PR TITLE
game: raise fuzzy match to 98.55% (cycle 5)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -546,8 +546,9 @@ void CGame::InitNewGame()
 
     CGame* game = &Game;
 
-    memset(&game->m_gameWork.m_gameDataStartMarker, 0, kGameWorkDataClearSize);
-    memset(game->m_gameWork.m_wmBackupParams, 0xFF, sizeof(game->m_gameWork.m_wmBackupParams));
+    CGameWork* work = &game->m_gameWork;
+    memset(&work->m_gameDataStartMarker, 0, kGameWorkDataClearSize);
+    memset(work->m_wmBackupParams, 0xFF, sizeof(work->m_wmBackupParams));
 
     *reinterpret_cast<unsigned int*>(&game->m_gameWork.m_scriptSysVal0) = 1;
     game->m_gameWork.m_chaliceElement = 1;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -746,8 +746,9 @@ void CGame::CheckScriptChange()
 
         CGame* game = &Game;
 
-        memset(&game->m_gameWork.m_gameDataStartMarker, 0, kGameWorkDataClearSize);
-        memset(game->m_gameWork.m_wmBackupParams, 0xFF, sizeof(game->m_gameWork.m_wmBackupParams));
+        CGameWork* work = &game->m_gameWork;
+        memset(&work->m_gameDataStartMarker, 0, kGameWorkDataClearSize);
+        memset(work->m_wmBackupParams, 0xFF, sizeof(work->m_wmBackupParams));
 
         *reinterpret_cast<unsigned int*>(&game->m_gameWork.m_scriptSysVal0) = 1;
         game->m_gameWork.m_chaliceElement = 1;


### PR DESCRIPTION
## Summary
Raises `main/game` fuzzy match from 98.33% to **98.55%** (cycle 5).

Two functions went from partial to fully matched (100%) by caching the `m_gameWork` member base in a local pointer, which lets mwcc reuse the same callee-saved register (`r31`) as the base for the second `memset` instead of rematerializing the `Game@ha/@l` global address.

## Per-function gains
- **InitNewGame** 93.85% -> 100% — `CGameWork* work = &game->m_gameWork;` then memset via `work->...`
- **CheckScriptChange** 97.99% -> 100% — same fix in the in-place NewGame-init block

## Why this is plausible source
The new-game data clear writes two adjacent regions of the same `m_gameWork` struct. Binding the struct base to a local `work` pointer (rather than repeating `game->m_gameWork.`) is idiomatic and matches the original codegen: the base stays in one register across both clears.

## Blockers (unchanged walls)
- **LoadScript / SaveScript**: target keeps `scriptData` as a fixed base with an advancing byte index (`lwzx/stwx base,index`); mwcc strength-reduces our singly-subscripted offset into a moving pointer regardless of phrasing (temp pointer, word index, decl reorder, signedness all tried).
- **ChangeMap**: param->callee-saved register-window rotation (this->r28 vs r31); permute and reorderings did not shift it net-positive.
- **GetTargetCursor**: clean two-register swap on the array-element-address vs loaded-pointer coloring.
- **Create**: copy loop is `mtctr/bdnz` (CTR) in target vs `subic./bne` (GPR) in ours; `for` form regressed.
- **GetBossArtifact / Calc**: anonymous-vs-named float/double pool literal (`@NNN@sda21` vs named) plus register shifts.
- **Exec**: jumptable symbol naming (`@444` vs `jumptable_...`) plus arg-materialization scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)