### PR TITLE
game: raise fuzzy match to 98.60% (cycle 6)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -488,8 +488,8 @@ void CGame::Create()
 
     if (strlen(m_startScriptName) != 0) {
         strcpy(scriptName, m_startScriptName);
-        u32* src = reinterpret_cast<u32*>(scriptName) - 1;
         u32* dst = reinterpret_cast<u32*>(&m_nextScript);
+        u32* src = reinterpret_cast<u32*>(scriptName) - 1;
         int count = sizeof(scriptName) / (sizeof(u32) * 2);
         do {
             u32 a = src[1];

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1241,11 +1241,11 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
 
     scaledAmount = rand();
     int divisor = artifactRank + 1;
+    int entriesByteOffset = stageByteOffset + offsetof(CBossArtifactStage, m_entries);
     int quotient = scaledAmount / divisor;
     stageBase += scaledAmount - quotient * divisor;
-    int entriesByteOffset = stageByteOffset + offsetof(CBossArtifactStage, m_entries);
     return reinterpret_cast<int>(reinterpret_cast<char*>(artifactBase) +
-        (entriesByteOffset + stageBase * (int)sizeof(CBossArtifactEntry)));
+        entriesByteOffset + stageBase * (int)sizeof(CBossArtifactEntry));
 }
 
 /*


### PR DESCRIPTION
Raises main/game fuzzy match from 98.55% to 98.60% (cycle 6).

## Changes
- **Create**: declare `dst` before `src` local in the start-script copy loop. Aligns the source-pointer (r4) coloring with the target; flagged lines 11→10. The remaining mtctr-vs-GPR counted-loop difference is a known codegen wall.
- **GetBossArtifact**: compute `entriesByteOffset` (= stageByteOffset + offsetof(m_entries)) before the divide/quotient, matching the target's early `addi rN, stageByteOffset, 0x20`. Function 96.23%→97.73%, flagged lines 17→12.

## Evidence
- Unit fuzzy: 98.55075% → 98.602745%.
- Both functions rebuilt and re-measured per-function via objdiff report.json.

## Plausibility
Both edits are pure source-level statement/declaration ordering that any developer could have written; no hacks, no layout changes, version headers preserved.

## Remaining (documented walls, not source-steerable)
- LoadScript / SaveScript: induction-variable strength-reduction (target keeps base+index `lwzx/stwx`; mwcc reduces to an advancing pointer). Permutation found no improvement.
- ChangeMap: param→callee-saved-register allocation order (systematic r28–r31 rotation). Permutation found no improvement.
- Calc / GetBossArtifact tail: named-vs-anonymous float/double pooling (target references `kGameZero@sda21`, `kGameIntToDoubleBias@sda21`; mwcc folds the in-TU `const` and re-pools anonymously). Defining them in another TU would change data ownership.
- Exec: compiler jumptable naming (`jumptable_801E83A0` vs `@444`).
- clearWork / ScriptChanged: loop unroll factor (target stride 0x20 vs ours 0x40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)