### PR TITLE
fontman: raise fuzzy match to 97.62% (cycle 5)

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -318,7 +318,8 @@ found_fallback:
 	float y1 = y0 + static_cast<float>(m_glyphHeight) * scaleY;
 
 	if (renderFlagBits.snapPosition != 0) {
-		advance = static_cast<float>(floor(advance));
+		double flooredAdvance = floor(advance);
+		advance = static_cast<float>(flooredAdvance);
 	}
 	posX += advance;
 

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -305,8 +305,10 @@ found_fallback:
 	float x0 = posX;
 	float y0 = posY;
 	if (renderFlagBits.snapPosition != 0) {
-		x0 = static_cast<float>(floor(x0));
-		y0 = static_cast<float>(floor(y0));
+		double flooredX = floor(x0);
+		double flooredY = floor(y0);
+		x0 = static_cast<float>(flooredX);
+		y0 = static_cast<float>(flooredY);
 	}
 
 	float advance = scaleX * (margin + static_cast<float>(drawWidth));


### PR DESCRIPTION
## Summary
Raises main/fontman fuzzy match 97.563% -> 97.622% by matching the original's floor() result scheduling in CFont::Draw(unsigned short).

## What changed
- **Draw**: capture `floor()` double results in named temporaries before narrowing to `float` for the snapPosition path (x0/y0 and advance). This matches the original's separate `frsp`+`fmr` scheduling and collapses a 0x20 stack-frame-size mismatch plus a large callee-saved register-window shift (Draw 93.28% -> 93.54%; the prologue/epilogue frame now matches exactly).

`floor()` returns a `double`, so binding the result to a `double` temp before the `(float)` narrow is plausible original source, not compiler-coaxing.

## Per-function results
- Draw(unsigned short): 93.28% -> 93.54%
- SetColor / GetWidth(char*) / GetWidth(unsigned short): unchanged

## Blockers (documented walls, verified unsteerable this cycle)
- **Bias-pool naming**: target references `kFontUnsignedIntToDoubleBias@sda21` / `kFontSignedIntToDoubleBias@sda21` by name; mwcc emits anonymous `@258`/`@390` conversion-bias doubles. Tried external vs static linkage; no effect. This coloring also drives the residual FPR/GPR cascades in Draw.
- **glyphInfo +3 addressing fold**: target keeps `+3` in the pointer (`addi; add`, accesses `[0]/[1]`); mwcc folds the constant into load offsets (`[3]/[4]`) regardless of source form.
- **Glyph-search `bne;b` layout** (GetWidth/Draw): target emits `bne body; b exit`; mwcc emits `beq exit`. Loop-polarity rewrites did not flip it.
- **SetColor LR-save scheduling**: 2-register byte-copy pipeline reproduced but the LR-save slot and r5/r0 assignment are mwcc-controlled; permute found nothing.

`permute_fn.py` (2000-4000 passes) found no improvement on SetColor, Draw, or GetWidth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)