### PR TITLE
game: raise fuzzy match to 98.61% (cycle 7)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1217,8 +1217,8 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
         stage = 2;
     }
 
-    int stageBase = s_top[stage];
     int scaledAmount = (int)((float)amount * s_ratio[ratioIndex - 1]);
+    int stageBase = s_top[stage];
 
     u16 thresholds[4];
     memset(thresholds, 0, 8);


### PR DESCRIPTION
Raises main/game fuzzy match from 98.60% to 98.61%.

## Change
- **GetBossArtifact**: reordered the `scaledAmount`/`stageBase` local declarations so `scaledAmount` is declared first. This flips mwcc's callee-saved register coloring (stageBase now lands in the register the original used), dropping the function's flagged-diff count from 12 to 9 and matching the target's stage-table comparison register window.

## Remaining (walls, deep effort, no source-steerable lever found)
- **ChangeMap**: the only diffs are a clean 4-way parameter→callee-saved rotation (target r31←param4..r28←this vs ours r31←this..). Body structure (ternary sign-mask lowering, branch order) already matches; permute_fn found no improvement; statement/local reorders and mask-idiom rewrites all regressed.
- **GetBossArtifact / Calc**: residual diffs are anonymous-vs-named float pooling (`@949`/`@809` vs `kGameIntToDoubleBias`/`kGamePartyBoundsMinInit@sda21`). mwcc folds these `extern const float` uses into anonymous literal-pool entries regardless of declaration form; R3 def-after-use ordering did not change it.
- **Create**: copy loop wants `mtctr/bdnz` (CTR) but mwcc emits `subic./bne` for the do/while and unrolls any `for` form.
- **loadCfd**: global base-CSE coloring rotation (Game/File/s_localLangDirs into r29/r30/r31) — same class as the documented base-CSE wall.
- **LoadScript/SaveScript/clearWork/ScriptChanged/Exec**: previously documented walls (IV strength-reduction, unroll-4-vs-8, jumptable naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)