### PR TITLE
memory: raise fuzzy match to 96.35% (cycle 6)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1741,7 +1741,14 @@ found:
             unsigned int chunks = remainingBytes >> 3;
             if (chunks != 0) {
                 do {
-                    checksum += data[0] + data[1] + data[2] + data[3] + data[4] + data[5] + data[6] + data[7];
+                    checksum += data[0];
+                    checksum += data[1];
+                    checksum += data[2];
+                    checksum += data[3];
+                    checksum += data[4];
+                    checksum += data[5];
+                    checksum += data[6];
+                    checksum += data[7];
                     data += 8;
                     chunks--;
                 } while (chunks != 0);
@@ -1797,7 +1804,14 @@ found:
         unsigned int chunks = remainingBytes >> 3;
         if (chunks != 0) {
             do {
-                checksum += data[0] + data[1] + data[2] + data[3] + data[4] + data[5] + data[6] + data[7];
+                checksum += data[0];
+                checksum += data[1];
+                checksum += data[2];
+                checksum += data[3];
+                checksum += data[4];
+                checksum += data[5];
+                checksum += data[6];
+                checksum += data[7];
                 data += 8;
                 chunks--;
             } while (chunks != 0);


### PR DESCRIPTION
Raises main/memory fuzzy match from 96.11% to 96.35%.

## Change
- **SetData**: the two inlined CheckSum loops were written as a single tree-summed expression (`data[0]+data[1]+...+data[7]`), which mwcc reduced with a different scratch-register pattern than the target. Splitting them into sequential `checksum += data[N];` statements matches the original's `lbz r0; add r5,r5,r0` accumulation chain. SetData function 87.46% -> 91.34%, unit 96.11% -> 96.35%.

## Investigated, blocked
Remaining gap is dominated by compiler-allocation walls confirmed by manual asm analysis and `permute_fn.py` (zero improving mutations found on alloc, AddRef, SetData, Init, drawHeapBar, drawHeapTitle):
- **bdnz/mtctr wall** (CheckSum, inlined checksum in SetData/drawHeapBar): target emits counted `mtctr`/`bdnz` loops; mwcc emits `subic.`/`bne` from the down-counting `do/while`. `for`-loop forms trigger unwanted software-pipelining/unrolling (regresses).
- **Register-renumbering walls** (alloc size-param r24 vs r30; heapWalker uniform +3 shift; DestroyStage/CreateStage modeData base coloring; drawHeapTitle/drawHeapBar node-pointer coloring) — not steerable by declaration order, pointer-vs-reference, byte-offset iteration, or `offset=i` idioms.
- **Init operator-new null-check**: inlined `operator new[]`'s `?:` fold on the constant source string doesn't fold in ours.
- **GetHeapUnuse DCE'd accumulator**: target keeps a dead span-accumulator; mwcc eliminates it (no clean way to keep it live).
- **Frame port-fold**: `0 & ~mask` constant-folds; target keeps the runtime `andc`.
- **sdata2 float-pool** (GetData/CopyFromAMemorySync): `kMemoryDmaTimeout` const-folds into an anonymous `@857` pool entry instead of a named-symbol load; forcing the symbol reference via def-ordering regresses sdata2 layout (90.3% -> 86.4%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)