### PR TITLE
maphit: raise fuzzy match to 97.31% (cycle 6)

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -505,6 +505,12 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
         PSVECScale(hitDirection, &g_hit_hpv, hitT);
         PSVECAdd(&g_hit_cyl.m_bottom, &g_hit_hpv, &g_hit_hpv);
 
+        Vec point;
+        Vec edgeStart;
+        Vec edgeEnd;
+        Vec edge;
+        Vec toPoint;
+        Vec cross;
         Vec scaledNormal;
         PSVECScale(&g_hit_lpface->m_normal, &scaledNormal, g_hit_cyl.m_radius);
         Vec pushedHit;
@@ -513,12 +519,6 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
         unsigned int sideMask = 3;
         Vec previous = m_vertices[g_hit_lpface->m_vertexIndices[g_hit_lpface->m_vertexCount - 1]];
         Vec current;
-        Vec edgeStart;
-        Vec edgeEnd;
-        Vec point;
-        Vec edge;
-        Vec toPoint;
-        Vec cross;
         switch (g_hit_lpface->m_projectionAxis) {
         case 0:
             point.x = pushedHit.y;


### PR DESCRIPTION
Raises `main/maphit` from 97.30% to 97.31%.

## Change
- **CheckHitFaceCylinder**: reordered the switch-block `Vec` scratch locals (`point` declared first; `scaledNormal`/`pushedHit`/`previous`/`current` after the `point/edge*/cross` group). This makes mwcc coalesce `point` with `pushedHit` into the same high stack slot (matching the target, where the case-0 `point.x = pushedHit.x` becomes a no-op) and shifts the scratch-Vec stack offsets toward the target layout. Flagged-line count on the function dropped from 255 to 230 (90.59% -> 90.64%).

## Why plausible
Pure local-declaration ordering inside one function body; no layout, signature, or shared-header changes. Matches how the original arranged its geometry scratch vectors.

## Investigated but walled (reverted, net-negative or no-op)
- CheckHitFaceCylinder +1 callee-saved GPR (`stmw r15` vs target `stmw r16`): the three loop-induction registers are colored high (r28/r29) and not reused by the commit-block struct copies, costing one extra register and shifting the whole callee-saved window. Declaration reorder, statement reorder, and moving the struct copies did not move the coloring — pure register-number coloring wall.
- CheckHitCylinder / CheckHitCylinderNear (Us,Us overloads, 99.3-99.4%): identical faceIndex/faceOffset/endFace induction-register permutation (r29/r31/r30 vs r30/r29/r31); declaration and statement reorders did not shift it.
- FindIntersection (98.67%): remaining diffs are the sqrtf Newton-Raphson anonymous-double pool (`@1021..@1025` vs named `DOUBLE_*`/`kMapHitZero`) plus an FPR coloring shift around the sqrt result — the documented double-pool wall. `disc >= kMapHitZero` regressed.
- Draw (96.99%): GX color-byte load scheduling + induction-register coloring in the vertex loop; `< (int)` signedness fix matched one `cmpw` but regressed the loop net (96.99 -> 96.77).
- Signed-char cast on `s_bitMask.m_fields.m_mode` (matching map.cpp idiom) removed the `extsb` mismatch but regressed via the adjacent `m_drawFlags` reload pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)