### PR TITLE
memory: raise fuzzy match to 96.5% (cycle 7)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1137,13 +1137,12 @@ int CMemory::CStage::heapWalker(int flag, void*, unsigned long group)
             unsigned char nodeFlags = node->m_flags;
             int nodeGroup = node->m_defaultParam;
             if ((group == static_cast<unsigned long>(-1)) || (static_cast<unsigned long>(nodeGroup) == group)) {
-                bool isUsed = (nodeFlags & 4) != 0;
-                if ((isUsed && ((flag & 2) != 0)) || (!isUsed && ((flag & 1) != 0))) {
-                    const char* kind = isUsed ? sHeapWalkerUsed : sHeapWalkerFree;
-                    unsigned char level = isUsed ? node->m_level : 0;
-                    const char* source = isUsed ? node->m_source : sEmptyAllocSourceName;
-                    unsigned short line = isUsed ? node->m_line : 0;
-                    int index = isUsed ? usedCount : freeCount;
+                if ((((nodeFlags & 4) != 0) && ((flag & 2) != 0)) || (((nodeFlags & 4) == 0) && ((flag & 1) != 0))) {
+                    const char* kind = ((nodeFlags & 4) != 0) ? sHeapWalkerUsed : sHeapWalkerFree;
+                    unsigned char level = ((nodeFlags & 4) != 0) ? node->m_level : 0;
+                    const char* source = ((nodeFlags & 4) != 0) ? node->m_source : sEmptyAllocSourceName;
+                    unsigned short line = ((nodeFlags & 4) != 0) ? node->m_line : 0;
+                    int index = ((nodeFlags & 4) != 0) ? usedCount : freeCount;
                     System.Printf(
                         const_cast<char*>(strBase + 0x430), index, kind, level, node->m_size,
                         totalSize, payloadFromBlock(node), node->m_prev, node->m_next,


### PR DESCRIPTION
Raises `main/memory` fuzzy match from 96.35% to 96.48%.

## Change
- **heapWalker** 87.33% -> 89.75%: inlined the `(node->m_flags & 4)` used-flag test at each ternary use instead of caching it in a local `bool isUsed`. The original re-tested the flag bit at each conditional (`rlwinm. r0,flags,0,29,29`) rather than computing a cached `extrwi.` boolean. This is plausible original source (re-reading the flag is a natural hand idiom) and collapses the cached-bool register coloring.

## Walls confirmed (no net-positive change found after deep effort)
- **CheckSum / SetData inlined checksum**: target emits `mtctr`/`bdnz` counted CTR loops; our `do/while` and `for`/`while--` variants all emit `subic.`/`bne` or trigger further unrolling. Net-negative on every attempt.
- **GetHeapUnuse**: target carries a second pointer-difference accumulator that is dead (not returned); mwcc DCEs it in our build and it cannot be made plausibly live without changing the return value.
- **Frame**: `port & ~mask` with `port == 0` constant-folds to `nor`/`andi.` (or fully to 0 when restructured) instead of the target's `andc`. Port-fold wall.
- **Init (CacheSet)**: operator-new emits a null-check (`addic.`/`beq`/reload) the target's array-new lacks.
- **heapWalker / drawHeapBar / CreateStage / alloc**: remaining diffs are pervasive callee-saved register-window renumbering plus a `.sdata2`-pooled "FREE" string literal (`lbl_8032F7EC`) shared from another unit's pool — not source-steerable from this unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)