### PR TITLE
gobjwork: raise fuzzy match to 95.78% (cycle 10)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1753,30 +1753,11 @@ void CCaravanWork::SafeDeleteTempItem()
 		}
 	}
 
-	short invalidSlot = -1;
-	int slot = m_commandListInventorySlotRef[2];
-	if (slot >= 0 && m_inventoryItems[slot] < 0) {
-		m_commandListInventorySlotRef[2] = invalidSlot;
-	}
-	slot = m_commandListInventorySlotRef[3];
-	if (slot >= 0 && m_inventoryItems[slot] < 0) {
-		m_commandListInventorySlotRef[3] = invalidSlot;
-	}
-	slot = m_commandListInventorySlotRef[4];
-	if (slot >= 0 && m_inventoryItems[slot] < 0) {
-		m_commandListInventorySlotRef[4] = invalidSlot;
-	}
-	slot = m_commandListInventorySlotRef[5];
-	if (slot >= 0 && m_inventoryItems[slot] < 0) {
-		m_commandListInventorySlotRef[5] = invalidSlot;
-	}
-	slot = m_commandListInventorySlotRef[6];
-	if (slot >= 0 && m_inventoryItems[slot] < 0) {
-		m_commandListInventorySlotRef[6] = invalidSlot;
-	}
-	slot = m_commandListInventorySlotRef[7];
-	if (slot >= 0 && m_inventoryItems[slot] < 0) {
-		m_commandListInventorySlotRef[7] = invalidSlot;
+	for (int slotIndex2 = 2; slotIndex2 < 8; slotIndex2++) {
+		int slot = m_commandListInventorySlotRef[slotIndex2];
+		if (slot >= 0 && m_inventoryItems[slot] < 0) {
+			m_commandListInventorySlotRef[slotIndex2] = -1;
+		}
 	}
 
 	m_currentCmdListIndex = 0;


### PR DESCRIPTION
## Summary
Raises `main/gobjwork` fuzzy match from baseline 95.72% to 95.78%.

## Change
- `SafeDeleteTempItem`: rewrote the per-slot `m_commandListInventorySlotRef[2..7]` invalidation as a `for` loop over the slot indices (cursor addressing) instead of six explicit unrolled blocks with a cached `slot` local. This matches mwcc's emitted block structure and slot-register coloring, dropping the function's flagged-instruction count from 78 to 52 and raising its match. Cleaner, plausible source.

## Evidence
- `main/gobjwork` fuzzy: 95.72% -> 95.78% (objdiff report.json).
- `SafeDeleteTempItem`: 94.41% -> 95.84%.

## Walls hit (deep effort, no net gain — reverted)
- `GetNextCmdListIdx` (90.6%): pure callee-saved register coloring of the `Game` global base (lands in top reg vs target's r29). Permute + base-local + var-reuse all no-op.
- `AddLetter` (91.0%): param register rotation by one (`this`/`senderId`/`moneyValue`/`hasMoneyFlag`) plus mwcc's unrolled 3-element struct-copy scheduling. Permute + clamp restructuring no net gain.
- `Init__8CMonWork` (94.0%): residual is the magic-double naming (`DOUBLE_803309A0@sda21` vs anonymous pooled `@1684`/`@2220`) — symbol-pooling artifact, not source-steerable. Confirmed signedness already correct (unsigned/signed swaps regress).
- `GetNumCombi` (95.1%) / `GetCmdListItemName` (95.2%): scratch/param register coloring and a multiply-CSE hoist; permute and pointer-form changes no-op.
- `SearchRomLetterWork` (89.9%): documented +2-callee-saved-register frame-size wall (target 0x40/`stmw r20`, ours 0x30/`stmw r22`).
- `FGLetterOpen` (77.5%): known 0x3ec offset-trick wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)