### PR TITLE
joybus: raise fuzzy match to 89.82% (cycle 14)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2897,14 +2897,27 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             if ((header >> 6) == 2)
             {
                 unsigned short crc = 0xFFFF;
-                unsigned int len = buf.m_length;
+                int len = buf.m_length;
                 unsigned char* data = buf.m_payload;
+                unsigned int idx;
+                unsigned int hi;
 
-                while (len-- > 0)
+                goto crc_check_len;
+
+            crc_loop:
+                idx = crc;
+                hi = idx << 8;
+                idx = (unsigned int)((int)(short)idx >> 8);
+                idx = (unsigned char)idx;
+                idx = idx ^ (unsigned int)*data;
+                data = data + 1;
+                crc = (unsigned short)(hi ^ JoyBusCrcTable[idx]);
+
+            crc_check_len:
+                len = len - 1;
+                if (len >= 0)
                 {
-                    unsigned char b = *data++;
-                    unsigned char idxC = static_cast<signed char>(((crc >> 8) ^ b));
-                    crc = static_cast<unsigned short>((crc << 8) ^ JoyBusCrcTable[idxC]);
+                    goto crc_loop;
                 }
 
                 if (static_cast<short>(~crc) == buf.m_crc)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6005,10 +6005,12 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
                 strcpy((char*)bonusStr, bonusTable[bonusIndex * 2]);
 
                 int firstLen = strlen((char*)bonusStr);
-                strcpy((char*)(bonusStr + 1) + firstLen, bonusTable[bonusIndex * 2 + 1]);
+                byteLen = firstLen + 1;
+                strcpy((char*)(bonusStr + firstLen + 1), bonusTable[bonusIndex * 2 + 1]);
 
-                int secondLen = strlen((char*)(bonusStr + 1) + firstLen);
-                byteLen = firstLen + secondLen + 3;
+                byteLen = byteLen + 1;
+                byteLen = byteLen + strlen((char*)(bonusStr + firstLen + 1));
+                byteLen = byteLen + 1;
             }
             else
             {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5986,7 +5986,6 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
             payload[0] = 7;
 
             unsigned char* bonusStr = &payload[1];
-            unsigned char* extraBuf = &payload[2];
 
             int byteLen;
             if (Game.m_gameWork.m_bossArtifactStageIndex < 0xE)
@@ -6006,16 +6005,16 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
                 strcpy((char*)bonusStr, bonusTable[bonusIndex * 2]);
 
                 int firstLen = strlen((char*)bonusStr);
-                strcpy((char*)extraBuf + firstLen, bonusTable[bonusIndex * 2 + 1]);
+                strcpy((char*)(bonusStr + 1) + firstLen, bonusTable[bonusIndex * 2 + 1]);
 
-                int secondLen = strlen((char*)extraBuf + firstLen);
+                int secondLen = strlen((char*)(bonusStr + 1) + firstLen);
                 byteLen = firstLen + secondLen + 3;
             }
             else
             {
                 byteLen = 3;
                 bonusStr[0] = 0;
-                extraBuf[0] = 0;
+                bonusStr[1] = 0;
             }
 
             int wordCount = MakeJoyData((char*)payload, byteLen, (unsigned int*)(m_joyDataPacketBuffer[threadParam->m_portIndex] + 2));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2839,9 +2839,10 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
 
             if ((header >> 6) == 0)
             {
-                OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
+                OSSemaphore* sem = &m_accessSemaphores[threadParam->m_portIndex];
+                OSWaitSemaphore(sem);
                 memset(&m_recvBuffer[threadParam->m_portIndex], 0, sizeof(m_recvBuffer[threadParam->m_portIndex]));
-                OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
+                OSSignalSemaphore(sem);
             }
 
             unsigned int word = *cmdOut;


### PR DESCRIPTION
Raises `main/joybus` fuzzy match from baseline **89.56%** to **89.82%** (+0.26%).

## Changes
- **GBARecvSend** (77.62% -> 82.00%): de-unrolled the inlined CRC16 loop by rewriting the `while(len-- > 0)` body into the same `goto`/check-at-bottom structure as the standalone `Crc16`, so mwcc emits the target's single-byte `subic.; bge` loop instead of a 4x `mtctr/bdnz` unroll + remainder. Also cached `&m_accessSemaphores[port]` in a local across the recv-buffer-clear Wait/Signal pair (matches the target's cached semaphore pointer).
- **SendBonusStr** (92.99% -> higher): removed the redundant `extraBuf` pointer local (derived `&payload[2]` from `bonusStr + 1`), which dropped an extra callee-saved register; and rewrote the `byteLen = firstLen + secondLen + 3` computation as a sequential running accumulator, matching the target's incremental `add`/`addi` chain.

## Plausibility
All changes are ordinary source-level idioms (loop structure, pointer derivation, running accumulation) that match how the original was written. No hacks, no layout changes, version headers preserved.

## Blockers (walls, left untouched after deep effort)
- result-in-rN-vs-r3 ABI + `lwzx`-vs-displacement coloring across the SendResult/SetCmdLst/SetTmpArti/SendUseItem/SendHitEnemy cluster (caching the threadParam base fixed the register number but regressed addressing).
- `s_dvd_gba_dir`/rodata.0 merged-section base in GBARecvSend/RestartThread.
- GBARecvSend dispatch range-merge (`op==0x1C||...||0x1F` folds to a `subi;cmplwi` range; target keeps separate `cmpwi;beq` — reordering does not defeat mwcc's run detection).
- MakeJoyData CRC register-numbering (r9/r10 arg swap) and ctr-vs-subic loop form.
- ThreadMain (83%, 12KB) has two ~120-line case-body blocks present/reordered in the target switch — large reconstruction, not attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)