### PR TITLE
memorycard: raise fuzzy match to 95.4% (cycle 5)

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1215,7 +1215,7 @@ int CMemoryCardMan::DummySave()
     }
     m_result = result;
 
-    while ((((u32)(-((int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
+    while ((((u32)(-((unsigned int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
     {
     }
 

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1387,7 +1387,7 @@ void CMemoryCardMan::SetLoadData()
         } while (inventoryCount != 0);
         if (itemCount != *reinterpret_cast<u16*>(src + 0x28))
         {
-            if (static_cast<int>(System.m_execParam) >= 1)
+            if (static_cast<unsigned int>(System.m_execParam) >= 1)
             {
                 System.Printf(const_cast<char*>(sLoadDataItemCountError), c);
             }

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1387,7 +1387,7 @@ void CMemoryCardMan::SetLoadData()
         } while (inventoryCount != 0);
         if (itemCount != *reinterpret_cast<u16*>(src + 0x28))
         {
-            if (static_cast<unsigned int>(System.m_execParam) >= 1)
+            if (static_cast<int>(System.m_execParam) >= 1)
             {
                 System.Printf(const_cast<char*>(sLoadDataItemCountError), c);
             }
@@ -1437,7 +1437,7 @@ void CMemoryCardMan::SetLoadData()
                 (*reinterpret_cast<u32*>(letterDst + 0x3EC) & 0xFFFC01FF);
             *reinterpret_cast<u16*>(letterDst + 0x3EE) =
                 (*reinterpret_cast<u16*>(letterSrc + 0x106) & 0x01FF) |
-                (*reinterpret_cast<u16*>(letterDst + 0x3EE) & 0xFE00);
+                (*reinterpret_cast<s16*>(letterDst + 0x3EE) & 0xFE00);
             memcpy(letterDst + 0x3F0, letterSrc + 0x108, 8);
             letterDst[0x3EC] = (letterSrc[0x104] & 0x80) | (letterDst[0x3EC] & 0x7F);
             letterDst[0x3EC] = (letterSrc[0x104] & 0x40) | (letterDst[0x3EC] & 0xBF);

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1575,7 +1575,7 @@ void CMemoryCardMan::MakeSaveData()
     *reinterpret_cast<int*>(save + 0x24) = gameWork->m_timerA;
     *reinterpret_cast<int*>(save + 0x28) = gameWork->m_scriptGlobalTime;
     *reinterpret_cast<int*>(save + 0x2C) = gameWork->m_frameCounter;
-    memcpy(save + 0x30, Game.m_gameWork.m_wmBackupParams, 0x10);
+    memcpy(save + 0x30, gameWork->m_wmBackupParams, 0x10);
     memcpy(save + 0x40, Game.m_gameWork.m_bossArtifactStageTable, 0x3C);
     memcpy(save + 0x7C, Game.m_gameWork.m_unkStageTable, 0x3C);
     *reinterpret_cast<int*>(save + 0xB8) = Game.m_gameWork.m_chaliceElement;


### PR DESCRIPTION
## Summary
Raises `main/memorycard` fuzzy match from baseline 95.29% to 95.38%.

## Per-function gains
- **MakeSaveData** 91.25 -> 91.50: unified the gameWork base pointer so the contiguous `gameWork->` member reads address off one cached pointer (matching the target's single callee-saved Game-base register) instead of mixing `gameWork->`/`Game.` aliases.
- **SetLoadData** 89.73 -> 91.17: corrected a letter-field read to signed (`s16`) where the value is immediately masked, matching the target's `lha`.
- **DummySave** 97.21 -> 97.23: made one busy-wait loop's cast `(unsigned int)` consistent with the function's other identical busy-wait loops.

## Why this is plausible source
- The gameWork unification removes redundant pointer aliases and reads every contiguous member off one base, which is how the original clearly addressed them (single live base register).
- The signedness fixes align casts that were inconsistent across otherwise-identical code paths; behavior is unchanged (values are masked / compared the same way).

## Blocker (remaining ceiling)
The top three functions (SetLoadData, Odekake, MakeSaveData) are dominated by two known walls:
- **rodata string-pool base anchoring**: the target addresses Printf format strings as `sMemoryCardGbaDvdDir@ha + offset` (named first-symbol pool base) while our build emits the synthetic `...rodata.0` base. Switching `-str reuse` to `-str reuse,pool,readonly` did not change the anchoring.
- This forces a **callee-saved register-window shift** (target keeps the string-pool base in the top register, displacing the saveDat pointer from r31 to r30), which cascades as hundreds of ARG_MISMATCH lines across all three functions.
- The SetLoadData inventory-count loop is **not unrolled in the target** but mwcc unrolls our equivalent (do/while, for, and pointer-cursor forms all unroll); no source form prevented it.
- Odekake's inner loop keeps the mask constant 0x32 in a live register (target `li r3,0x32; and`) vs our `andi.`; not source-steerable.

permute_fn found no further reorder/type wins on any function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)