### PR TITLE
materialman: raise fuzzy match to 98.73% (cycle 9)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2457,9 +2457,9 @@ void CMaterialMan::SetPosition(
     searchBound.m_max.y = position->y + rangeY;
 
     if (target == static_cast<CMapShadow::TARGET>(0)) {
-        CPtrArray<CMapShadow*>* mapShadowArray = &MapMng.GetMapShadowArray();
         ShadowCandidate shadowCandidates[128];
         ShadowCandidate* candidateWrite = shadowCandidates;
+        CPtrArray<CMapShadow*>* mapShadowArray = &MapMng.GetMapShadowArray();
         int candidateCount = 0;
 
         for (unsigned int i = 0; i < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {


### PR DESCRIPTION
Raises `main/materialman` from 98.72% to 98.73%.

## Change
- **SetPosition** (97.01% → 97.32%): reordered the candidate-buffer and map-shadow-array local declarations in the `target == 0` branch so mwcc colors the candidates buffer pointer and MapMng base into the same callee-saved registers as the original (r26/r25 instead of the swapped r25/r26). Declaring `shadowCandidates`/`candidateWrite` before `mapShadowArray` matches the original's allocation order, collapsing a run of DIFF_ARG_MISMATCH lines.

## Why this is plausible source
The reorder is a trivial, behavior-preserving change to the order of local variable declarations — exactly the kind of thing the original authors could have written. No hacks, no fake symbols, no layout changes.

## Investigated but walled (no net gain)
- **GetCharaShadow** (90.93%): residual is IV strength-reduction — the original keeps `shadowMtxOut[outputOffset]` as a byte-offset `stwx` index while ours strength-reduces to a pointer. Byte-cursor rewrites regressed (75%); known IV wall.
- **Create / SetMaterial / SetShadowBit32 / SetUnderWaterTex**: dominated by pure register/FPR-coloring window shifts and magic float-pool naming (`@1793`/`DOUBLE_*`) walls.
- **SetMaterial** GX helper calls: the int-wrapper helpers (`_GXSetTevColorIn__Fiiiii` etc.) inline in the original but exceed mwcc's inline budget in the 8.5KB SetMaterial; forcing inline_max_total_size regressed the whole unit.
- **SetMaterialMenu** (99.21%): target keeps `material` and `tevBit` in separate callee-saved regs (one more saved GPR than ours); couldn't identify the source local that adds the register without regressing.
- **Calc**: `1.0f`/`0.0f` → `kTextureOne`/`kTextureZero` fixes the SDA symbol but flips FPR coloring for a net loss (float-pool wall).
- **SetTextureSet**: unconditional `textures[i]=0` matches the target's store placement but mwcc sinks it past the null-check; net negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)