### PR TITLE
p_light: raise fuzzy match to 96.82% (cycle 5)

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1229,12 +1229,12 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
             PSMTXIdentity(reinterpret_cast<float(*)[4]>(m_bumpTexScratch));
             float* scratch = m_bumpTexScratch;
 
+            float mtxScale = kBumpTexMtxScale;
             float scrollScale = kBumpTexScrollScale;
             float zero = kLightZero;
             scratch[0] = kBumpTexScrollScale;
             float half = kLightHalf;
             scratch[6] = scrollScale;
-            float mtxScale = kBumpTexMtxScale;
             scratch[10] = zero;
             scratch[5] = zero;
             scratch[9] = zero;


### PR DESCRIPTION
Raises main/p_light fuzzy match from 96.81% to 96.82%.

## Change
- **SetBumpTexMatirx** (99.08% -> 99.24%): reordered the texMtx scratch-matrix constant locals (`mtxScale`/`scrollScale`/`zero`/`half`) so mwcc assigns them to the same FPRs as the original. Declaring `mtxScale` first (so it colors into the low FPR it occupies in the target) collapsed a block of FPR-number ARG_MISMATCHes. Plausible source: simple local-declaration reordering, no behavior change.

## Investigated but walled (register/FPR-window coloring)
- **destroy** (84.58%): target keeps 7 callee-saved regs (frame 0x30, `stmw r25`) vs ours 6 (0x20, `stmw r26`) with a fixed `this` base + advancing cursor + three distinct zero regs. Two-pointer and base-local rewrites regress.
- **MakeLightMap (CBumpLight)** (93.07%): confirmed the original used a p_light-local sqrtf built on named constants (`kLightZero`/`kLightHalfD`/`kLightThreeD`/`kLightZeroD`) rather than MSL `sqrtf`, plus fmadds square-fusion; matching the constants/fusion fixed local lines but shifted the whole FPR window net-negative.
- **Add** (94.93%): off-by-one callee-saved window (`stmw r20` vs `r21`); a `0` kept live in r20 across the inlined `Set` struct copy.
- **AddBump / DestroyBumpLightAll / MakeLightMap (CLightPcs)**: identical `0x1cec(cursor)` base-folding pattern — target folds the `m_bumpLights` array base (0x1c3c) into the load displacement off a `this`-relative cursor; C pointer arithmetic bakes the base into the pointer instead. Not source-steerable (IV strength-reduction / base-CSE wall).
- **SetPosition** (99.97%): two identical GXSetChanCtrl call sites get swapped stack arg slots (0xc/0x10); mwcc stack-temp allocation, not steerable.
- **CBumpLight ctor** (98.91%): kLightOne/attenFalloff FPR swap; declaration reorder had no effect.
- **__sinit**: skipped per known data.0 base-CSE wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)