### PR TITLE
memory: raise fuzzy match to 97.0% (cycle 9)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1710,40 +1710,7 @@ found:
         entry.m_cacheData = 0;
         entry.m_size = static_cast<int>(allocSize);
 
-        int checksum = 0x12345678;
-        unsigned int remainingBytes = static_cast<unsigned int>(entry.m_size);
-        const unsigned char* data = reinterpret_cast<const unsigned char*>(src);
-        if (remainingBytes != 0) {
-            unsigned int chunks = remainingBytes >> 3;
-            if (chunks != 0) {
-                do {
-                    checksum += data[0];
-                    checksum += data[1];
-                    checksum += data[2];
-                    checksum += data[3];
-                    checksum += data[4];
-                    checksum += data[5];
-                    checksum += data[6];
-                    checksum += data[7];
-                    data += 8;
-                    chunks--;
-                } while (chunks != 0);
-
-                remainingBytes &= 7;
-                if (remainingBytes == 0) {
-                    goto checksum_done_dma;
-                }
-            }
-
-            do {
-                checksum += *data;
-                data++;
-                remainingBytes--;
-            } while (remainingBytes != 0);
-        }
-
-    checksum_done_dma:
-        entry.m_checksum = checksum;
+        entry.m_checksum = static_cast<int>(CheckSum(src, entry.m_size));
 
         if (entry.m_dmaCopy == 0) {
             memcpy(entry.m_workData, src, static_cast<unsigned long>(entry.m_size));
@@ -1773,40 +1740,7 @@ found:
     entry.m_cacheData = 0;
     entry.m_size = static_cast<int>(allocSize);
 
-    int checksum = 0x12345678;
-    unsigned int remainingBytes = static_cast<unsigned int>(entry.m_size);
-    const unsigned char* data = reinterpret_cast<const unsigned char*>(src);
-    if (remainingBytes != 0) {
-        unsigned int chunks = remainingBytes >> 3;
-        if (chunks != 0) {
-            do {
-                checksum += data[0];
-                checksum += data[1];
-                checksum += data[2];
-                checksum += data[3];
-                checksum += data[4];
-                checksum += data[5];
-                checksum += data[6];
-                checksum += data[7];
-                data += 8;
-                chunks--;
-            } while (chunks != 0);
-
-            remainingBytes &= 7;
-            if (remainingBytes == 0) {
-                goto checksum_done_copy;
-            }
-        }
-
-        do {
-            checksum += *data;
-            data++;
-            remainingBytes--;
-        } while (remainingBytes != 0);
-    }
-
-checksum_done_copy:
-    entry.m_checksum = checksum;
+    entry.m_checksum = static_cast<int>(CheckSum(src, entry.m_size));
 
     if (entry.m_dmaCopy == 0) {
         memcpy(entry.m_workData, src, static_cast<unsigned long>(entry.m_size));

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -311,33 +311,10 @@ unsigned int CheckSum(void* data, int size)
 {
     unsigned int checksum = 0x12345678;
     unsigned char* bytes = reinterpret_cast<unsigned char*>(data);
+    int i;
 
-    if (size != 0) {
-        unsigned int blockCount = static_cast<unsigned int>(size) >> 3;
-        if (blockCount != 0) {
-            do {
-                checksum += bytes[0];
-                checksum += bytes[1];
-                checksum += bytes[2];
-                checksum += bytes[3];
-                checksum += bytes[4];
-                checksum += bytes[5];
-                checksum += bytes[6];
-                checksum += bytes[7];
-                bytes += 8;
-                blockCount--;
-            } while (blockCount != 0);
-
-            size &= 7;
-        }
-
-        if (size != 0) {
-            do {
-                checksum += *bytes;
-                bytes++;
-                size--;
-            } while (size != 0);
-        }
+    for (i = size; i != 0; i--) {
+        checksum += *bytes++;
     }
 
     return checksum;


### PR DESCRIPTION
## Summary
Raises main/memory fuzzy match from 96.48% to 97.01%.

## Changes
- **CheckSum** (78.97% to 100%): rewrote the hand-unrolled do/while as a simple counted pointer loop `for (i = size; i != 0; i--) checksum += *bytes++;`. mwcc 2.4.2 auto-unrolls this by 8 with a `mtctr`/`bdnz` CTR loop and a single-register serial accumulator, exactly matching the original. The previous explicit unroll emitted `subic./bne` and the wrong accumulator register.
- **SetData** (91.34% to 96.82%): the two inlined checksum loops were hand-unrolled copies of CheckSum that diverged the same way. Replaced both with `CheckSum(src, entry.m_size)` calls; mwcc re-inlines them with the now-correct CTR-unroll shape.

## Evidence
- CheckSum: 78.97% to 100%
- SetData: 91.34% to 96.82%
- Unit main/memory: 96.48% to 97.01%

## Plausibility
Both changes make the source simpler and more idiomatic: CheckSum is now a plain counted accumulation loop, and SetData reuses the real CheckSum helper instead of duplicating its body twice. The inlining behavior (verified in the diff) matches the target.

## Blockers (remaining gap)
The rest of the unit is dominated by known walls: register-coloring window shifts (heapWalker is 99/116 flagged lines pure ARG_MISMATCH; CreateStage, Quit similar; permute found no improvement), float-pool naming (`@843` vs `kMemoryDmaTimeout@sda21` — the const folds because it is defined in-unit), data-base anchoring of inlined format strings, and a dead-accumulator in GetHeapUnuse that mwcc DCEs but the target preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)