### PR TITLE
ME_USB_process cycle 5: place kMapEditor constants in sdata2 (mapshadow 100.0%)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -541,7 +541,7 @@ config.libs = [
             Object(NonMatching, "mapmesh.cpp", extra_cflags=["-sdata 8"]),
             Object(NonMatching, "mapobj.cpp", extra_cflags=["-RTTI on", "-str reuse,pool,readonly"]),
             Object(NonMatching, "mapocttree.cpp", extra_cflags=["-sdata 8"]),
-            Object(NonMatching, "mapshadow.cpp", cflags=cflags_game),
+            Object(NonMatching, "mapshadow.cpp", cflags=cflags_game, extra_cflags=["-sdata2 8"]),
             Object(NonMatching, "maptexanim.cpp", extra_cflags=["-RTTI on", "-str reuse,pool,readonly"]),
             Object(NonMatching, "materialman.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-inline auto,deferred", "-str reuse"]),
             Object(NonMatching, "math.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),


### PR DESCRIPTION
## Summary
Worked main/ME_USB_process (baseline 96.10%). The single mismatched function `SetUSBData` is walled: remaining diffs are pure register-window coloring in the byte-swap loops, instruction scheduling, and cross-TU `@sda21` extern-const addressing that mwcc will not emit for an undefined `extern const` (verified: even with `-sdata2 8` on the consuming unit, the references stay `@ha/@l`). No R16 correctness issues found — all GX format constants, comparison boundaries, and immediates already match the target; only register numbers differ.

## Real gain found (adjacent)
The shared `kMapEditorZero`/`kMapEditorOne`/`kMapEditorS32ToDoubleBias` constants (defined in mapshadow.cpp, referenced by ME_USB_process) belong in `.sdata2`. Compiling mapshadow.cpp with `-sdata2 8` places them there:
- **main/mapshadow: 99.52% -> 100.0%** (data relocations in `Calc` resolved)
- main/ME_USB_process: 96.10% (unchanged; walled)

## Plausibility
Const float/double globals in `.sdata2` is the normal Metrowerks layout for small read-only constants; this is a data-section correctness fix, not compiler coaxing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)