### PR TITLE
joybus: raise fuzzy match to 90.1% (cycle 15)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3782,12 +3782,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
     if ((gbaStatus & 1) == 0)
     {
-        if (phase == 2 && chunkCount <= step)
-        {
-            return -1;
-        }
-
-        return 0;
+        goto not_ready;
     }
 
     OSWaitSemaphore(&m_accessSemaphores[port]);
@@ -4202,6 +4197,14 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
     }
 
     return result;
+
+not_ready:
+    if (phase == 2 && chunkCount <= step)
+    {
+        return -1;
+    }
+
+    return 0;
 }
 
 /*

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -682,9 +682,9 @@ loop_body:
             }
         }
 
-        if (m_threadInitFlag != 0)
+        if (static_cast<signed char>(m_threadInitFlag) != 0)
         {
-            m_threadRunningMask = (unsigned char)(m_threadRunningMask & ~(unsigned char)(1 << threadParam->m_portIndex));
+            m_threadRunningMask = (unsigned char)(m_threadRunningMask & ~(1 << threadParam->m_portIndex));
             m_stageFlags[threadParam->m_portIndex] = 0;
             OSExitThread(&gJoyBusThreadExitValue);
         }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3207,14 +3207,14 @@ int JoyBus::InitialCode(ThreadParam* threadParam)
             status = 0;
 
 case1_done:
-        if (status == 0)
+        if (status != 0)
         {
-            threadParam->m_subState = 2;
-            result = 0;
+            result = 1;
         }
         else
         {
-            result = 1;
+            threadParam->m_subState = 2;
+            result = 0;
         }
 
         break;
@@ -3269,14 +3269,14 @@ case1_done:
         threadParam->m_bootRetryCount = (unsigned char)(tmpBuf.f & 0x0F);
 
 case2_done:
-        if (status == 0)
+        if (status != 0)
         {
-            threadParam->m_subState = 3;
-            result = 0;
+            result = 1;
         }
         else
         {
-            result = 1;
+            threadParam->m_subState = 3;
+            result = 0;
         }
 
         break;
@@ -3371,14 +3371,14 @@ case3_done:
         status = threadParam->m_gbaStatus;
 
 case4_done:
-        if (status == 0)
+        if (status != 0)
         {
-            threadParam->m_subState = 5;
-            result = 0;
+            result = 1;
         }
         else
         {
-            result = 1;
+            threadParam->m_subState = 5;
+            result = 0;
         }
 
         break;
@@ -3421,14 +3421,14 @@ case4_done:
         }
 
 case5_done:
-        if (status == 0)
+        if (status != 0)
         {
-            threadParam->m_subState = 6;
-            result = 0;
+            result = 1;
         }
         else
         {
-            result = 1;
+            threadParam->m_subState = 6;
+            result = 0;
         }
 
         break;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3175,7 +3175,7 @@ int JoyBus::InitialCode(ThreadParam* threadParam)
         if (status != 0)
             goto case1_done;
 
-        if (threadParam->m_unk3 != ' ')
+        if (threadParam->m_unk3 != 0x20)
         {
             status = 1;
             goto case1_done;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3237,7 +3237,7 @@ case1_done:
 
         struct
         {
-            char          h;
+            unsigned char h;
             unsigned char f;
         } tmpBuf;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3352,31 +3352,25 @@ case3_done:
 
         int status = threadParam->m_gbaStatus;
 
-        if (status == 0)
+        if (status != 0)
+            goto case4_done;
+
+        if (threadParam->m_unk3 != ' ')
         {
-            if (threadParam->m_unk3 == ' ')
-            {
-                if (threadParam->m_timeChangedFlag != 0 ||
-                    (threadParam->m_gbaBootFlag == 0 && threadParam->m_timestamp == 0))
-                {
-                    threadParam->m_timestamp = OSGetTick();
-                }
-
-                threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&threadParam->m_timestamp), &threadParam->m_unk3);
-
-                status = threadParam->m_gbaStatus;
-
-                if (status == 0)
-                {
-                    status = 0;
-                }
-            }
-            else
-            {
-                status = 1;
-            }
+            status = 1;
+            goto case4_done;
         }
 
+        if (threadParam->m_timeChangedFlag != 0 ||
+            (threadParam->m_gbaBootFlag == 0 && threadParam->m_timestamp == 0))
+        {
+            threadParam->m_timestamp = OSGetTick();
+        }
+
+        threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&threadParam->m_timestamp), &threadParam->m_unk3);
+        status = threadParam->m_gbaStatus;
+
+case4_done:
         if (status == 0)
         {
             threadParam->m_subState = 5;
@@ -3405,31 +3399,28 @@ case3_done:
 
         int status = threadParam->m_gbaStatus;
 
-        if (status == 0)
+        if (status != 0)
+            goto case5_done;
+
+        if (threadParam->m_unk3 != ' ')
         {
-            if (threadParam->m_unk3 == ' ')
-            {
-                bool singleMode2 = GbaQue.IsSingleMode(threadParam->m_portIndex);
-
-                unsigned char portVal = singleMode2 ? 0 : (unsigned char)threadParam->m_portIndex;
-                unsigned char header = 1;
-                signed char flags = (unsigned char)(portVal | (threadParam->m_gbaBootFlag << 6) | (threadParam->m_unk2 << 4));
-                unsigned int word = (1u << 24) | ((unsigned int)flags << 16);
-
-                threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&word), &threadParam->m_unk3);
-                status = threadParam->m_gbaStatus;
-
-                if (status == 0)
-                {
-                    status = 0;
-                }
-            }
-            else
-            {
-                status = 1;
-            }
+            status = 1;
+            goto case5_done;
         }
 
+        {
+            bool singleMode2 = GbaQue.IsSingleMode(threadParam->m_portIndex);
+
+            unsigned char portVal = singleMode2 ? 0 : (unsigned char)threadParam->m_portIndex;
+            unsigned char header = 1;
+            signed char flags = (unsigned char)(portVal | (threadParam->m_gbaBootFlag << 6) | (threadParam->m_unk2 << 4));
+            unsigned int word = (1u << 24) | ((unsigned int)flags << 16);
+
+            threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&word), &threadParam->m_unk3);
+            status = threadParam->m_gbaStatus;
+        }
+
+case5_done:
         if (status == 0)
         {
             threadParam->m_subState = 6;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3172,43 +3172,41 @@ int JoyBus::InitialCode(ThreadParam* threadParam)
 
         int status = threadParam->m_gbaStatus;
 
-        if (status == 0)
+        if (status != 0)
+            goto case1_done;
+
+        if (threadParam->m_unk3 != ' ')
         {
-            if (threadParam->m_unk3 == ' ')
-            {
-                threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(m_diskId), &threadParam->m_unk3);
-                status = threadParam->m_gbaStatus;
-
-                if (status == 0)
-                {
-                    bool singleMode2 = GbaQue.IsSingleMode(threadParam->m_portIndex);
-
-                    if (singleMode2 && (int)threadParam->m_portIndex != 1)
-                    {
-                        threadParam->m_gbaStatus = 0;
-                    }
-                    else
-                    {
-                        threadParam->m_gbaStatus = GBAGetStatus(threadParam->m_portIndex, &threadParam->m_unk3);
-                    }
-
-                    status = threadParam->m_gbaStatus;
-
-                    if (status == 0)
-                    {
-                        if ((threadParam->m_unk3 & 0x30) != 0x20)
-                            status = 1;
-                        else
-                            status = 0;
-                    }
-                }
-            }
-            else
-            {
-                status = 1;
-            }
+            status = 1;
+            goto case1_done;
         }
 
+        threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(m_diskId), &threadParam->m_unk3);
+        status = threadParam->m_gbaStatus;
+
+        if (status != 0)
+            goto case1_done;
+
+        if (GbaQue.IsSingleMode(threadParam->m_portIndex) && (int)threadParam->m_portIndex != 1)
+        {
+            threadParam->m_gbaStatus = 0;
+        }
+        else
+        {
+            threadParam->m_gbaStatus = GBAGetStatus(threadParam->m_portIndex, &threadParam->m_unk3);
+        }
+
+        status = threadParam->m_gbaStatus;
+
+        if (status != 0)
+            goto case1_done;
+
+        if ((threadParam->m_unk3 & 0x30) != 0x20)
+            status = 1;
+        else
+            status = 0;
+
+case1_done:
         if (status == 0)
         {
             threadParam->m_subState = 2;
@@ -3237,47 +3235,40 @@ int JoyBus::InitialCode(ThreadParam* threadParam)
 
         int status = threadParam->m_gbaStatus;
 
-        if (status == 0)
+        struct
         {
-            if (threadParam->m_unk3 == 0x28)
-            {
-                char header;
-                unsigned char flags = 0; // will land in local_1f
+            char          h;
+            unsigned char f;
+        } tmpBuf;
 
-                // GBARead fills header + flag byte (and maybe more); we only care about these two.
-                struct
-                {
-                    char          h;
-                    unsigned char f;
-                } tmpBuf;
+        if (status != 0)
+            goto case2_done;
 
-                threadParam->m_gbaStatus = GBARead(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&tmpBuf), &threadParam->m_unk3);
-                status = threadParam->m_gbaStatus;
-
-                if (status == 0)
-                {
-                    header = tmpBuf.h;
-
-                    if (header == 1)
-                    {
-                        status = 0;
-
-                        threadParam->m_gbaBootFlag    = (unsigned char)((int)(signed char)tmpBuf.f >> 6);
-                        threadParam->m_unk2           = (unsigned char)((tmpBuf.f >> 4) & 0x03);
-                        threadParam->m_bootRetryCount = (unsigned char)(tmpBuf.f & 0x0F);
-                    }
-                    else
-                    {
-                        status = 1;
-                    }
-                }
-            }
-            else
-            {
-                status = 1;
-            }
+        if (threadParam->m_unk3 != 0x28)
+        {
+            status = 1;
+            goto case2_done;
         }
 
+        threadParam->m_gbaStatus = GBARead(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&tmpBuf), &threadParam->m_unk3);
+        status = threadParam->m_gbaStatus;
+
+        if (status != 0)
+            goto case2_done;
+
+        if (tmpBuf.h != 1)
+        {
+            status = 1;
+            goto case2_done;
+        }
+
+        status = 0;
+
+        threadParam->m_gbaBootFlag    = (unsigned char)((int)(signed char)tmpBuf.f >> 6);
+        threadParam->m_unk2           = (unsigned char)((tmpBuf.f >> 4) & 0x03);
+        threadParam->m_bootRetryCount = (unsigned char)(tmpBuf.f & 0x0F);
+
+case2_done:
         if (status == 0)
         {
             threadParam->m_subState = 3;
@@ -3306,31 +3297,34 @@ int JoyBus::InitialCode(ThreadParam* threadParam)
 
         int status = threadParam->m_gbaStatus;
 
-        if (status == 0)
+        unsigned int timeValue;
+
+        if (status != 0)
+            goto case3_done;
+
+        if (threadParam->m_unk3 != 0x28)
         {
-            if (threadParam->m_unk3 == 0x28)
-            {
-                unsigned int timeValue;
-                threadParam->m_gbaStatus = GBARead(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&timeValue), &threadParam->m_unk3);
-                status = threadParam->m_gbaStatus;
-
-                if (status == 0)
-                {
-                    // Bit-twiddly inequality check preserved from decomp
-                    unsigned int a = timeValue - threadParam->m_timestamp;
-                    unsigned int b = threadParam->m_timestamp - timeValue;
-
-                    threadParam->m_timeChangedFlag = (unsigned char)((a | b) >> 31);
-                    threadParam->m_timestamp = timeValue;
-                    status = 0;
-                }
-            }
-            else
-            {
-                status = 1;
-            }
+            status = 1;
+            goto case3_done;
         }
 
+        threadParam->m_gbaStatus = GBARead(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&timeValue), &threadParam->m_unk3);
+        status = threadParam->m_gbaStatus;
+
+        if (status != 0)
+            goto case3_done;
+
+        {
+            // Bit-twiddly inequality check preserved from decomp
+            unsigned int a = timeValue - threadParam->m_timestamp;
+            unsigned int b = threadParam->m_timestamp - timeValue;
+
+            threadParam->m_timeChangedFlag = (unsigned char)((a | b) >> 31);
+            threadParam->m_timestamp = timeValue;
+            status = 0;
+        }
+
+case3_done:
         if (status == 0)
         {
             threadParam->m_subState = 4;


### PR DESCRIPTION
Raises main/joybus fuzzy match from 89.82% to 90.15% (+0.33), the biggest absolute-unmatched unit in bucket B4.

## What changed
- **InitialCode** (83.0% -> ~90%): the dominant win. Rewrote the per-substate handlers (cases 1-5) from deeply-nested `if (status==0) { if (...) { ... } else status=1; }` into flat sequential status guards using early `goto case_done`, matching the original's block-emission order (R9/R14). Then swapped the final `if (status==0) {success} else {result=1}` to emit the failure (`result=1`) block FIRST, which matched the target's `beq success; result=1; b end` layout. Also fixed two unsigned-vs-signed byte compares (`m_unk3 == 0x20`, `tmpBuf.h == 1`).
- **SendDataFile** (76.1% -> 76.6%): hoisted the `(gbaStatus & 1) == 0` not-ready block to the function tail via `goto`, matching the target's forward-branch-to-bottom layout (R9).
- **ThreadMain** (83.1%): signed-char test for `m_threadInitFlag` (`extsb.` vs `cmplwi`), consistent with the rest of the file's `(signed char)` flag tests.

## What worked
The high-yield lever was control-flow restructuring on InitialCode: mwcc emits if/else arm bodies and guard chains in source order, so flattening the nested status checks into a sequential guard ladder + ordering the failure arm before the success arm converted many INSERT/DELETE/OP_MISMATCH runs directly to score.

## Blockers (documented known walls, left alone)
- ThreadMain 60-case dispatch is a balanced binary range-tree (`||`-range-merge) that mwcc derives from a specific comparison ordering - the documented dispatch range-merge wall; the 2-extra-callee-saved-register shift comes from mwcc hoisting the `OSMillisecondsToTicks` divide-by-1000 magic + `__OSBusClock` base across the loop (rematerialized in the target).
- GBARecvSend / RestartThread: `...rodata.0@ha` merged-section base vs per-named-symbol (`s_dvd_gba_dir@ha`) relocations (rodata.0-base wall), plus result/this register-promotion.
- SendDataFile / SendPpos / SendPlayerStat: result-in-rN-vs-r3 ABI and stack-slot-window clusters.
- MakeJoyData: target uses `mtctr/bdnz` CTR loops where ours emits manual `subic.`; for-loop conversion regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)