### PR TITLE
cmake: raise fuzzy match to 88.56% (cycle 16)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -599,7 +599,7 @@ void CMenuPcs::drawVillageMenu()
  */
 void CMenuPcs::calcVillageMenu()
 {
-    if (MenuU8(this, 0x16) != 0) {
+    if (MenuU8(this, 0x16) != 0 && CmakeResult(this) == 0) {
         if (CmakeResult(this) == 0 && MenuU8(this, 0x16) != 0) {
             if (Game.m_gameWork.m_menuStageMode == 0) {
                 char path[128];


### PR DESCRIPTION
## Summary
Raises main/cmake fuzzy match from 88.53% to 88.56%.

## Change
- **calcVillageMenu 96.48% -> 98.41%**: the village-load guard now rechecks `CmakeResult(this) == 0` in both the outer and inner condition (`if (MenuU8(0x16) != 0 && CmakeResult == 0) { if (CmakeResult == 0 && MenuU8(0x16) != 0) {`), matching the target's two consecutive `extsh.`/`bne` tests on the 0x86c field. Plausible defensive double-guard.

## Plausibility
The redundant `CmakeResult == 0` re-check is a common defensive idiom and produces the exact control-flow the shipped binary has. No layout, header, or hack changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)