### PR TITLE
gobject: raise fuzzy match to 92.4% (cycle 13)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2903,13 +2903,16 @@ int CGObject::IsAnimFinished(int mode)
     CCharaPcs::CHandle* handle;
     double threshold;
 
+    char slot;
+
     handle = m_charaModelHandle;
     if ((handle != 0) && (handle->m_model != 0)) {
         hasModel = true;
     }
 
     if (hasModel) {
-        if (m_currentAnimSlot == -1) {
+        slot = m_currentAnimSlot;
+        if (slot == -1) {
             return 1;
         }
         {
@@ -2923,7 +2926,7 @@ int CGObject::IsAnimFinished(int mode)
                     hasModel = true;
                 }
 
-                if (hasModel && (m_currentAnimSlot != -1)) {
+                if (hasModel && (slot != -1)) {
                     CModelAnimState& model = ModelAnimState(handle->m_model);
                     if (model.m_anim != 0) {
                         animSpan = sAnimFrameOffset + (model.m_animEnd - model.m_animStart);


### PR DESCRIPTION
## Summary
Raised main/gobject fuzzy match from baseline 92.42% to 92.43%.

### What changed
- **IsAnimFinished** (89.51% -> 90.91%): cached `m_currentAnimSlot` in a local `char slot` so the raw animation-slot byte stays resident in a callee-saved register and is re-sign-extended at each `== -1` / `!= -1` comparison, matching the target's `lbz r7; extsb r0,r7` reuse pattern instead of reloading the member each time.

### Why this is plausible source
Caching a frequently-compared member in a local is idiomatic; the value is read twice in the original control flow and the compiler keeps the raw byte live, exactly as the target does.

### Remaining blockers (documented walls)
The rest of the unit gap is dominated by known, non-source-steerable walls: anonymous float-pool naming/ordering (`@NNNN` vs named `FLOAT_*@sda21`) across onCreate/update/move/bgNormalCollision/CalcSafePos/boundCheck; CVector-FPR-hoisting in bgWorldCollision/bgAttribCollision/SetPosBG; and `this`/integer-zero/result register-coloring in onCreate/onDraw/move/IsAnimFinished. Multiple targeted attempts (arm inversion, `(x|-x)>>31` reduction, FPR-order reordering, slot caching in the inlined update copy) were tried and reverted as net-negative or neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)