### PR TITLE
graphic: raise fuzzy match to 95.82% (cycle 7)

### DIFF
--- a/include/ffcc/graphic.h
+++ b/include/ffcc/graphic.h
@@ -129,7 +129,7 @@ public:
     s32 m_drawDoneWaiting;
     char* m_drawDoneFile;
     s32 m_drawDoneLine;
-    s32 m_drawDoneCounter;
+    volatile s32 m_drawDoneCounter;
 };
 
 extern CGraphic Graphic;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1343,9 +1343,9 @@ _GXTexObj* CGraphic::GetBackBufferRect(int& x, int& y, int& width, int& height, 
     if ((xEnd >= 0) && (yEnd >= 0)) {
         GXRenderModeObj* renderMode = m_renderMode;
         int efbWidth = static_cast<int>(renderMode->fbWidth);
-        int efbHeight = static_cast<int>(renderMode->efbHeight);
 
-        if ((x <= efbWidth) && (yEnd >= 0) && (y <= efbHeight) && (width > 0) && (height > 0)) {
+        if ((x <= efbWidth) && (yEnd >= 0) && (y <= static_cast<int>(renderMode->efbHeight)) &&
+            (width > 0) && (height > 0)) {
             if (xEnd > efbWidth) {
                 width -= (xEnd - efbWidth);
                 xEnd = static_cast<int>(m_renderMode->fbWidth);
@@ -1361,13 +1361,13 @@ _GXTexObj* CGraphic::GetBackBufferRect(int& x, int& y, int& width, int& height, 
                 y = 0;
             }
 
-            efbHeight = static_cast<int>(m_renderMode->efbHeight);
+            int efbHeight = static_cast<int>(m_renderMode->efbHeight);
             if (yEnd > efbHeight) {
                 height -= (yEnd - efbHeight);
                 yEnd = static_cast<int>(m_renderMode->efbHeight);
             }
 
-            if ((xEnd != x) && (yEnd != y)) {
+            if (((xEnd - x) != 0) && ((yEnd - y) != 0)) {
                 int texFormat = 6;
                 int textureSize = width * height * 4;
                 int maxTextureSize =


### PR DESCRIPTION
Raises main/graphic from baseline 95.71% to 95.82%.

## Changes
- **GetBackBufferRect** (92.40 -> 94.16): made the second `efbHeight` read lazy so `m_renderMode` stays in one register across the bounds-check chain (R13 lazy-field-reload), and rewrote `xEnd != x` / `yEnd != y` as subtraction tests `(xEnd - x) != 0` to match the target's `subf.` lowering instead of `cmpw`. These collapsed the renderMode-load and short-circuit comparison blocks to match exactly.
- **Thread** (90.77 -> 91.09): marked `m_drawDoneCounter` as `volatile`. The field is bumped from other contexts (it is a draw-done counter), so the original re-reads it; mwcc was CSE-ing the two reads in `if (lastCounter != m_drawDoneCounter) { ...; lastCounter = m_drawDoneCounter; }`. The volatile qualifier forces the target's reload without changing layout.

## Why plausible
Both are real source idioms: a draw-done counter touched across threads is genuinely volatile, and lazy field reads / subtraction-based inequality are ordinary hand-written C.

## Remaining blockers
The rest of the unit is dominated by documented walls: register-window off-by-one (GetBackBufferRect/Rect2, Thread, Init, DrawDebugString shift `this`/args by one register within an identical save-set), makeSphere IV strength-reduction, SetFog/SetCopyClear struct-by-value ABI, BeginFrame/DrawDebugString 0.5-double pooling (@286), and anonymous float/double constant pooling (@697/@1068 vs named sdata2 symbols) in RenderDOF/makeSphere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)