### PR TITLE
game: raise fuzzy match to 98.8% (cycle 9)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -844,12 +844,12 @@ void CGame::ScriptChanged(char*, int)
 
     unk_flat3_0xc7d0 = 0;
 
-    for (i = 0; i < 4; i++) {
-        for (j = 0; j < 8; j++) {
+    for (i = 0; i < 8; i++) {
+        for (j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
-            m_scriptWork[i + 4][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i + 4][j][1] = 0;
+            m_scriptWork[i][j + 4][0] = 0;
+            m_scriptWork[i][j + 4][1] = 0;
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -591,19 +591,12 @@ void CGame::clearWork()
 
     unk_flat3_0xc7d0 = 0;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 8; i++) {
         for (j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
-            m_scriptWork[i + 4][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i + 4][j][1] = 0;
-        }
-
-        for (j = 0; j < 4; j++) {
             m_scriptWork[i][j + 4][0] = 0;
-            m_scriptWork[i + 4][j + 4][0] = 0;
             m_scriptWork[i][j + 4][1] = 0;
-            m_scriptWork[i + 4][j + 4][1] = 0;
         }
     }
 


### PR DESCRIPTION
Raises main/game fuzzy match from 98.61% to 98.77%.

## Changes
De-interleaved the `m_scriptWork[8][8][2]` clear loops in two functions. The original interleaved form (`m_scriptWork[i][j]` / `m_scriptWork[i+4][j]`, i=0..3) caused mwcc to merge the two stride-0x20 store groups into a single 0x40-stride continuation that diverged from the target's emission. Iterating all 8 rows linearly (`for i in 0..8`) with the inner j split into 4+4 halves aligns far more of the store offsets with the target.

- `ScriptChanged` (`ScriptChanged__5CGameFPci`): 97.29% -> ~99% (off the worst list)
- `clearWork` (`clearWork__5CGameFv`): 97.08% -> 98.23%

## Blockers (unchanged, known walls)
- `Create` inlined-memcpy: target emits `mtctr/bdnz` 2-word-stride copy; ours emits `subic./bne`. Forward-`for` made mwcc unroll worse (4x), descending `do/while` keeps right body but wrong counter.
- `GetTargetCursor`: pure r3<->r4 register coloring; permute found no mutations.
- clearWork mapLight block: `bl __vc__` (operator[]) vs inlined `GetAt` coupled with a register-window shift; `#pragma dont_inline` fixes the call but shifts registers (net zero).
- LoadScript/SaveScript/ChangeMap/Calc/Exec/GetBossArtifact remain at their prior known-wall states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)