### PR TITLE
joybus: raise fuzzy match to 90.5% (cycle 16)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1095,8 +1095,8 @@ timeout_expiry:
                 if ((int)GbaQue.GetChgHitFlg(threadParam->m_portIndex) != 0)
                 {
                     unsigned int hitInfo = GbaQue.GetHitEInfo(threadParam->m_portIndex);
-                    if (SendHitEnemy(threadParam->m_portIndex, (char)(unsigned short)(hitInfo >> 16),
-                                     (short)hitInfo) < 0)
+                    if (SendHitEnemy(threadParam->m_portIndex, (char)reinterpret_cast<short*>(&hitInfo)[0],
+                                     reinterpret_cast<short*>(&hitInfo)[1]) < 0)
                     {
                         goto sleep_retry;
                     }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -996,7 +996,7 @@ timeout_expiry:
                 }
             }
 
-            if (GbaQue.GetPlayModeFlg(threadParam->m_portIndex))
+            if ((GbaQue.GetPlayModeFlg(threadParam->m_portIndex) & 0xFF) != 0)
             {
                 threadParam->m_state = 2;
                 goto recompute_timeout;
@@ -1082,7 +1082,7 @@ timeout_expiry:
             }
 
             char radarType = GbaQue.GetRadarType(threadParam->m_portIndex);
-            if (GbaQue.GetStageFlg(threadParam->m_portIndex) == 0 && radarType == 2)
+            if ((int)GbaQue.GetStageFlg(threadParam->m_portIndex) == 0 && radarType == 2)
             {
                 if (GbaQue.GetChgScouFlg(threadParam->m_portIndex) != 0 ||
                     (m_stateFlagArr[threadParam->m_portIndex] != 0 &&
@@ -1162,7 +1162,7 @@ timeout_expiry:
                 goto recompute_timeout;
             }
 
-            if (GbaQue.GetStageFlg(threadParam->m_portIndex) != 0 && GbaQue.GetScrFlg() != 0)
+            if ((int)GbaQue.GetStageFlg(threadParam->m_portIndex) != 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 ResetQueue(threadParam);
                 threadParam->m_subState = 0;
@@ -1411,7 +1411,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendItemAll(threadParam);
@@ -1484,7 +1484,7 @@ timeout_expiry:
         case 0x1A:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendPlayerStat(threadParam);
@@ -1576,7 +1576,7 @@ timeout_expiry:
         case 0x29:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendMapObj(threadParam);
@@ -1632,7 +1632,7 @@ timeout_expiry:
         case 0x2C:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendFavorite(threadParam);
@@ -1689,7 +1689,7 @@ timeout_expiry:
         case 0x2F:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendCompatibility(threadParam);
@@ -1747,7 +1747,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendEquip(threadParam);
@@ -1913,7 +1913,7 @@ timeout_expiry:
             if (res >= 0)
             {
                 int stopRes = SendGBAStop(threadParam);
-                if (stopRes >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+                if (stopRes >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
                 {
                     threadParam->m_subState = 0;
                     int sendRes = SendBonusStr(threadParam);
@@ -1971,7 +1971,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendArtifact(threadParam);
@@ -2028,7 +2028,7 @@ timeout_expiry:
         case 0x41:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetArtiDatFlg(threadParam->m_portIndex) != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (GbaQue.GetArtiDatFlg(threadParam->m_portIndex) & 0xFF) != 0)
             {
                 threadParam->m_state = 'B';
                 memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
@@ -2065,7 +2065,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendTmpArtifact(threadParam);
@@ -2123,7 +2123,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 int typeRes = SendRaderType(threadParam);
                 if (typeRes >= 0)
@@ -2188,7 +2188,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 ResetQueue(threadParam);
                 threadParam->m_subState = 0;
@@ -2247,7 +2247,7 @@ timeout_expiry:
         {
             m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetScrFlg() != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 threadParam->m_subState = 0;
                 int sendRes = SendCmd(threadParam);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1549,7 +1549,7 @@ timeout_expiry:
                 int sendRes = SendMapNo(threadParam);
                 if (sendRes >= 0)
                 {
-                    if (m_fileBaseB_dup == 0)
+                    if ((int)m_fileBaseB_dup == 0)
                     {
                         GbaQue.ClrStageFlg(threadParam->m_portIndex);
                         threadParam->m_state = 'F';

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1092,7 +1092,7 @@ timeout_expiry:
                     goto recompute_timeout;
                 }
 
-                if (GbaQue.GetChgHitFlg(threadParam->m_portIndex) != 0)
+                if ((int)GbaQue.GetChgHitFlg(threadParam->m_portIndex) != 0)
                 {
                     unsigned int hitInfo = GbaQue.GetHitEInfo(threadParam->m_portIndex);
                     if (SendHitEnemy(threadParam->m_portIndex, (char)(unsigned short)(hitInfo >> 16),
@@ -1142,7 +1142,7 @@ timeout_expiry:
                 GbaQue.ClrMemorysFlg(threadParam->m_portIndex);
             }
 
-            if (GbaQue.GetChgRadarMode(threadParam->m_portIndex))
+            if ((int)GbaQue.GetChgRadarMode(threadParam->m_portIndex) != 0)
             {
                 if (SendRaderMode(threadParam) < 0)
                 {
@@ -1225,14 +1225,14 @@ timeout_expiry:
 
             if (m_stateCodeArr[threadParam->m_portIndex] == 7)
             {
-                if (GbaQue.GetFavoriteFlg(threadParam->m_portIndex) != 0)
+                if ((int)GbaQue.GetFavoriteFlg(threadParam->m_portIndex) != 0)
                 {
                     threadParam->m_state = 0x2c;
                     goto recompute_timeout;
                 }
             }
 
-            if (GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
+            if ((int)GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
             {
                 unsigned int money = GbaQue.GetMoney(threadParam->m_portIndex);
                 if (SetMoney(threadParam->m_portIndex, money) == 0)
@@ -1303,7 +1303,7 @@ timeout_expiry:
                 goto recompute_timeout;
             }
 
-            if (GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
+            if ((int)GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
             {
                 unsigned int money = GbaQue.GetMoney(threadParam->m_portIndex);
                 if (SetMoney(threadParam->m_portIndex, money) == 0)
@@ -1803,7 +1803,7 @@ timeout_expiry:
         case 0x35:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetSellFlg(threadParam->m_portIndex) != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetSellFlg(threadParam->m_portIndex) != 0)
             {
                 threadParam->m_state = '6';
                 memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1241,7 +1241,7 @@ timeout_expiry:
                 }
             }
 
-            if (GbaQue.GetCompatibilityFlg(threadParam->m_portIndex) == 1 &&
+            if ((int)GbaQue.GetCompatibilityFlg(threadParam->m_portIndex) == 1 &&
                 m_stateCodeArr[threadParam->m_portIndex] != 0)
             {
                 threadParam->m_state = 0x2f;
@@ -1838,7 +1838,7 @@ timeout_expiry:
         case 0x37:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetBuyFlg(threadParam->m_portIndex) != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetBuyFlg(threadParam->m_portIndex) != 0)
             {
                 threadParam->m_state = '8';
                 memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
@@ -1873,7 +1873,7 @@ timeout_expiry:
         case 0x39:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
-            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && GbaQue.GetMkSmithFlg(threadParam->m_portIndex) != 0)
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 && (int)GbaQue.GetMkSmithFlg(threadParam->m_portIndex) != 0)
             {
                 threadParam->m_state = ':';
                 memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1381,6 +1381,10 @@ timeout_expiry:
         case 0x16:
         {
             int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
             if (dataRes == -2)
             {
                 threadParam->m_state = 3;
@@ -1823,6 +1827,10 @@ timeout_expiry:
         case 0x36:
         {
             int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
             if (dataRes == -2)
             {
                 threadParam->m_state = 3;
@@ -1858,6 +1866,10 @@ timeout_expiry:
         case 0x38:
         {
             int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
             if (dataRes == -2)
             {
                 threadParam->m_state = 3;
@@ -1893,6 +1905,10 @@ timeout_expiry:
         case 0x3A:
         {
             int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
             if (dataRes == -2)
             {
                 threadParam->m_state = 3;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1073,7 +1073,7 @@ timeout_expiry:
                 }
             }
 
-            if (System.GetCounter() % 3 == 0)
+            if ((int)System.GetCounter() % 3 == 0)
             {
                 if (SendItemUse(threadParam) < 0)
                 {
@@ -1202,7 +1202,7 @@ timeout_expiry:
             {
                 if (GbaQue.GetRadarType(threadParam->m_portIndex) == 0)
                 {
-                    if (System.GetCounter() % 5 == 0)
+                    if ((int)System.GetCounter() % 5 == 0)
                     {
                         if (SendMapObjDrawFlg(threadParam) < 0)
                         {
@@ -1210,7 +1210,7 @@ timeout_expiry:
                         }
                     }
                 }
-                if (System.GetCounter() % 3 == 0)
+                if ((int)System.GetCounter() % 3 == 0)
                 {
                     if (SendMBase(threadParam) < 0)
                     {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1002,7 +1002,7 @@ timeout_expiry:
                 goto recompute_timeout;
             }
 
-            unsigned char spMode = (GbaQue.GetSPMode(threadParam->m_portIndex) & 0xFF) != 0;
+            int spMode = (GbaQue.GetSPMode(threadParam->m_portIndex) & 0xFF) != 0;
             if (threadParam->m_flags[5] == 0 ||
                 (GbaQue.GetSPModeFlg(threadParam->m_portIndex) & 0xFF) != 0 ||
                 spMode != threadParam->m_flags[6])
@@ -1015,7 +1015,7 @@ timeout_expiry:
                 GbaQue.ClrSPModeFlg(threadParam->m_portIndex);
             }
 
-            if (threadParam->m_flags[4] != GbaQue.GetPauseMode())
+            if (threadParam->m_flags[4] != (int)GbaQue.GetPauseMode())
             {
                 char menuId = (char)((threadParam->m_flags[4] != 0) + 0xB);
                 if (SendOpenMenu(threadParam, menuId) < 0)
@@ -1270,7 +1270,7 @@ timeout_expiry:
                 }
             }
 
-            unsigned char spMode = (GbaQue.GetSPMode(threadParam->m_portIndex) & 0xFF) != 0;
+            int spMode = (GbaQue.GetSPMode(threadParam->m_portIndex) & 0xFF) != 0;
             if (threadParam->m_flags[5] == 0 ||
                 (GbaQue.GetSPModeFlg(threadParam->m_portIndex) & 0xFF) != 0 ||
                 spMode != threadParam->m_flags[6])
@@ -1283,7 +1283,7 @@ timeout_expiry:
                 GbaQue.ClrSPModeFlg(threadParam->m_portIndex);
             }
 
-            if (threadParam->m_flags[4] != GbaQue.GetPauseMode())
+            if (threadParam->m_flags[4] != (int)GbaQue.GetPauseMode())
             {
                 char menuId = (char)((threadParam->m_flags[4] != 0) + 0xB);
                 if (SendOpenMenu(threadParam, menuId) < 0)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -689,7 +689,7 @@ loop_body:
             OSExitThread(&gJoyBusThreadExitValue);
         }
 
-        if (GbaQue.IsSingleMode(threadParam->m_portIndex) && threadParam->m_portIndex != 1)
+        if (GbaQue.IsSingleMode(threadParam->m_portIndex) && (int)threadParam->m_portIndex != 1)
         {
             threadParam->m_state = 0;
             stateStartTime = OSGetTime();
@@ -723,7 +723,7 @@ loop_body:
         }
 
         unsigned int statusIndex;
-        if (GbaQue.IsSingleMode(threadParam->m_portIndex) && threadParam->m_portIndex == 1)
+        if (GbaQue.IsSingleMode(threadParam->m_portIndex) && (int)threadParam->m_portIndex == 1)
         {
             statusIndex = 0;
         }
@@ -803,7 +803,7 @@ timeout_expiry:
             {
                 threadParam->m_prevState = threadParam->m_state;
 
-                if (threadParam->m_gbaStatus == 3)
+                if ((int)threadParam->m_gbaStatus == 3)
                 {
                     threadParam->m_state = (unsigned char)0x86;
                 }
@@ -859,12 +859,12 @@ timeout_expiry:
                 GBAJoyBoot(threadParam->m_portIndex, threadParam->m_portIndex << 1, 2, reinterpret_cast<unsigned char*>(m_gbaBootImage), m_gbaBootImageSize,
                            &threadParam->m_unk3);
 
-            if (threadParam->m_gbaStatus == 3 && (threadParam->m_unk3 & 0x10) != 0)
+            if ((int)threadParam->m_gbaStatus == 3 && (threadParam->m_unk3 & 0x10) != 0)
             {
                 threadParam->m_flags[0] = 0;
                 threadParam->m_state    = 4;
             }
-            else if (threadParam->m_gbaStatus == 0)
+            else if ((int)threadParam->m_gbaStatus == 0)
             {
                 unsigned char cm = GbaQue.GetControllerMode();
 
@@ -881,7 +881,7 @@ timeout_expiry:
                 ThreadSleep(OSMillisecondsToTicks(15));
                 stateStartTime = OSGetTime();
             }
-            else if (threadParam->m_gbaStatus == 3)
+            else if ((int)threadParam->m_gbaStatus == 3)
             {
                 int stat = GetGBAStat(threadParam);
                 if (stat == 0)
@@ -930,7 +930,7 @@ timeout_expiry:
 
             threadParam->m_gbaStatus = GBAReset(threadParam->m_portIndex, &threadParam->m_unk3);
 
-            if (threadParam->m_gbaStatus == 0)
+            if ((int)threadParam->m_gbaStatus == 0)
             {
                 threadParam->m_state    = 2;
                 threadParam->m_subState = 0;
@@ -953,14 +953,14 @@ timeout_expiry:
                     GBAJoyBoot(threadParam->m_portIndex, threadParam->m_portIndex << 1, 2,
                                reinterpret_cast<unsigned char*>(m_gbaBootImage), m_gbaBootImageSize,
                                &threadParam->m_unk3);
-                if (threadParam->m_gbaStatus == 1)
+                if ((int)threadParam->m_gbaStatus == 1)
                 {
                     break;
                 }
                 bootRetry++;
             } while (bootRetry < 100);
 
-            if (threadParam->m_gbaStatus == 1)
+            if ((int)threadParam->m_gbaStatus == 1)
             {
                 threadParam->m_state = 0;
                 ThreadSleep(OSMillisecondsToTicks(15));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1156,7 +1156,7 @@ timeout_expiry:
                 goto sleep_retry;
             }
 
-            if (GbaQue.GetArtifactFlg(threadParam->m_portIndex))
+            if ((GbaQue.GetArtifactFlg(threadParam->m_portIndex) & 0xFF) != 0)
             {
                 threadParam->m_state = 0x3e;
                 goto recompute_timeout;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -846,7 +846,7 @@ timeout_expiry:
 
             m_ctrlModeArr[threadParam->m_portIndex] = 0;
 
-            char controllerMode = GbaQue.GetControllerMode();
+            unsigned char controllerMode = GbaQue.GetControllerMode();
 
             if (controllerMode == 0)
                 m_nextModeTypeArr[threadParam->m_portIndex] = 0;
@@ -866,7 +866,7 @@ timeout_expiry:
             }
             else if (threadParam->m_gbaStatus == 0)
             {
-                char cm = GbaQue.GetControllerMode();
+                unsigned char cm = GbaQue.GetControllerMode();
 
                 if (cm == 0)
                     m_nextModeTypeArr[threadParam->m_portIndex] = 0;
@@ -1004,7 +1004,7 @@ timeout_expiry:
 
             unsigned char spMode = (GbaQue.GetSPMode(threadParam->m_portIndex) & 0xFF) != 0;
             if (threadParam->m_flags[5] == 0 ||
-                GbaQue.GetSPModeFlg(threadParam->m_portIndex) != 0 ||
+                (GbaQue.GetSPModeFlg(threadParam->m_portIndex) & 0xFF) != 0 ||
                 spMode != threadParam->m_flags[6])
             {
                 if (SendSPMode(threadParam) < 0)
@@ -1025,7 +1025,7 @@ timeout_expiry:
                 threadParam->m_flags[4] = (threadParam->m_flags[4] == 0);
             }
 
-            if (GbaQue.GetControllerMode() != 0)
+            if ((GbaQue.GetControllerMode() & 0xFF) != 0)
             {
                 m_ctrlModeArr[threadParam->m_portIndex] = 4;
             }
@@ -1040,7 +1040,7 @@ timeout_expiry:
                 goto recompute_timeout;
             }
 
-            if (GbaQue.GetStartBonusFlg(threadParam->m_portIndex))
+            if ((GbaQue.GetStartBonusFlg(threadParam->m_portIndex) & 0xFF) != 0)
             {
                 if (SendStartBonus(threadParam) < 0)
                 {
@@ -1084,7 +1084,7 @@ timeout_expiry:
             char radarType = GbaQue.GetRadarType(threadParam->m_portIndex);
             if ((int)GbaQue.GetStageFlg(threadParam->m_portIndex) == 0 && radarType == 2)
             {
-                if (GbaQue.GetChgScouFlg(threadParam->m_portIndex) != 0 ||
+                if ((char)GbaQue.GetChgScouFlg(threadParam->m_portIndex) != 0 ||
                     (m_stateFlagArr[threadParam->m_portIndex] != 0 &&
                      m_stateCodeArr[threadParam->m_portIndex] == 0))
                 {
@@ -1106,7 +1106,7 @@ timeout_expiry:
 
             if (m_stateCodeArr[threadParam->m_portIndex] == 2)
             {
-                if (GbaQue.GetChgUseItemFlg(threadParam->m_portIndex))
+                if ((GbaQue.GetChgUseItemFlg(threadParam->m_portIndex) & 0xFF) != 0)
                 {
                     char useItem = (char)GbaQue.GetUseItemFlg(threadParam->m_portIndex);
                     if (SendUseItem(threadParam->m_portIndex, useItem) < 0)
@@ -1124,7 +1124,7 @@ timeout_expiry:
                 goto recompute_timeout;
             }
 
-            if (GbaQue.GetStrengthFlg(threadParam->m_portIndex))
+            if ((GbaQue.GetStrengthFlg(threadParam->m_portIndex) & 0xFF) != 0)
             {
                 if (SendStrength(threadParam) < 0)
                 {
@@ -1133,7 +1133,7 @@ timeout_expiry:
                 GbaQue.ClrStrengthFlg(threadParam->m_portIndex);
             }
 
-            if (GbaQue.GetMemorysFlg(threadParam->m_portIndex))
+            if ((GbaQue.GetMemorysFlg(threadParam->m_portIndex) & 0xFF) != 0)
             {
                 if (SendMemorys(threadParam) < 0)
                 {
@@ -1272,7 +1272,7 @@ timeout_expiry:
 
             unsigned char spMode = (GbaQue.GetSPMode(threadParam->m_portIndex) & 0xFF) != 0;
             if (threadParam->m_flags[5] == 0 ||
-                GbaQue.GetSPModeFlg(threadParam->m_portIndex) != 0 ||
+                (GbaQue.GetSPModeFlg(threadParam->m_portIndex) & 0xFF) != 0 ||
                 spMode != threadParam->m_flags[6])
             {
                 if (SendSPMode(threadParam) < 0)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2048,6 +2048,10 @@ timeout_expiry:
         case 0x42:
         {
             int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
             if (dataRes == -2)
             {
                 threadParam->m_state = 3;


### PR DESCRIPTION
Raises main/joybus from 90.15% to 90.53% by fixing signedness/width of comparisons and adding a missing defensive check in ThreadMain (the unit's 12KB anchor function, 83.15% -> 84.78%).

## What changed (all in ThreadMain's 60-case state machine)
- **Flag-getter comparison width/signedness**: The GbaQueue flag getters (GetPlayModeFlg, GetSPModeFlg, GetStartBonusFlg, GetControllerMode, GetStrengthFlg, GetMemorysFlg, GetArtifactFlg, GetChgUseItemFlg) return 0/1 values that the original tested as a narrowed byte (`& 0xFF`, emitting `clrlwi.`). Other getters (GetScrFlg, GetStageFlg, GetChgHitFlg, GetChgRadarMode, GetFavoriteFlg, GetMoneyFlg, GetSellFlg, GetBuyFlg, GetMkSmith, GetCompatibilityFlg) were tested as signed ints (`(int)`, emitting `cmpwi` not `cmplwi`). Matched both to the target. The getters themselves are unchanged (already 100% in main/gbaque) -- only the call-site comparison form.
- **Signed field compares**: `m_portIndex`, `m_gbaStatus`, `m_fileBaseB_dup`, and the `spMode`/`PauseMode` flag comparison are compared as signed in the target; added `(int)` casts.
- **Signed modulo**: `System::GetCounter() % 3`/`% 5` use signed division in the target (`mulhw`); cast to `(int)`.
- **GetHitEInfo halves via stack spill**: the original stored the packed word and re-read the high/low halves as signed `short`s (`stw` + two `lha`); reproduced with `reinterpret_cast<short*>(&hitInfo)[0/1]`.
- **Missing `dataRes == -1` guard**: every SendDataFile case in the target begins `if (dataRes == -1) goto sleep_retry;`. Our 5 SendDataFile cases were missing it; added it to all (biggest single gain, +0.06 unit).

DIFF_REPLACE count in ThreadMain dropped from 60 to 9.

## Remaining blockers (not addressed)
- **2-extra-callee-saved-register frame**: mwcc hoists its own divide-by-1000 magic constant (`0x10624dd3`) and the `__OSBusClock` base (`0x80000000`) from the inlined `OSMillisecondsToTicks` into r21/r24, growing the frame to 0x50 (target 0x40, `stmw r22`). The target re-materializes both at every site. Breaking the CSE requires a shared-header semantics change to `__OSBusClock` (forbidden, used by 23 units). This drives the ~352 residual ARG_MISMATCH register-window shifts and the stack-local offset deltas (0x14 vs 0x8).
- **Missing/reordered case bodies**: the target emits ~3 additional state handlers (incl. an SetChgUseItemFlg/SetResetFlg/GetGBAStat reset cluster) that our source's empty `default` swallows; reconstructing them precisely needs the jumptable case->VA order, which isn't recoverable here (no MAP file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)