### PR TITLE
memory: raise fuzzy match to 97.25% (cycle 10)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -455,8 +455,8 @@ frame_input_done:
         trigger = 0;
     } else {
         int port = 0;
-        unsigned int clamped = (unsigned int)port & ~-(int)((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) >> 5) & 1);
-        trigger = Pad.GetPadInputs()[clamped].lockedButton[1];
+        port &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+        trigger = Pad.GetPadInputs()[port].lockedButton[1];
     }
 
     if ((trigger & 0x200) != 0) {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1623,12 +1623,13 @@ int CAmemCacheSet::GetData(short index, char* source, int line)
 {
     while (true) {
         CAmemCache& entry = cacheEntryAt(this, index);
+        CMemory::CStage* rStage = m_rStage;
         unsigned int data;
 
         if (entry.m_cacheData == 0) {
             if (entry.m_dmaCopy != 0) {
                 entry.m_cacheData =
-                    m_rStage->alloc(static_cast<unsigned long>(entry.m_size),
+                    rStage->alloc(static_cast<unsigned long>(entry.m_size),
                                     source != 0 ? source : const_cast<char*>(sEmptyAllocSourceName),
                                     static_cast<unsigned long>(line), 1);
                 if (entry.m_cacheData == 0) {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1377,12 +1377,14 @@ int CMemory::CStage::GetHeapUnuse()
     } else {
         node = stageBlockAt(stageGetHeapHead(this))->m_next;
     }
+    int totalSize = 0;
     int total = 0;
 
     while ((node->m_flags & 2) == 0) {
         if ((node->m_flags & kMemoryBlockUsedFlag) == 0) {
             total += node->m_size;
         }
+        totalSize += reinterpret_cast<int>(node->m_next) - reinterpret_cast<int>(node);
         node = node->m_next;
     }
 


### PR DESCRIPTION
Raises main/memory fuzzy match from 97.01% to 97.25%.

## Changes
- **GetHeapUnuse 81.36% -> 100%**: restored a dead per-block span accumulator (`totalSize += node->m_next - node`) that mwcc had been DCE-ing in our simplified loop. The original kept this computation (the same shape as the heapWalker loop), which also pins the prev-node tracking register. Reordering the two accumulator declarations matched the init order exactly.
- **GetData 97.84% -> 99.69%**: hoisted the `m_rStage` load to the top of the loop body (before the `entry.m_cacheData == 0` check), matching the target's early load of offset 0x20. Remaining diff is the kMemoryDmaTimeout float-pool naming wall plus one register-window quirk.
- **Frame 88.59% -> 97.66%**: rewrote the debug-pad clamp to the exact idiom used in MenuUtil's GetMenuPress (`port &= ~-((__cntlzw(...) & 0x20) >> 5)`), which produces the target's `andc` instead of our `nor`+`andi 0`. Remaining diff is a register-window permutation.

## Blockers (confirmed walls, not pursued further)
- **Float-pool naming** (kMemoryDmaTimeout/kMemoryDrawZero/etc.): even when forced to emit the named `@sda21` symbols (def-after-use), objdiff still scores the relocation as mismatched - the .sdata2 layout differs from the target. Affects Draw, drawHeapBar, drawHeapTitle, GetData, CopyFromAMemorySync.
- **sStageFreeCorruptBlockFmt data anchoring**: the inlined freeStageBlock in AmemFreeLowPrio wants `strBase + 0x1a0`, but standalone callers (operator delete) need the named symbol; one source form cannot satisfy both.
- **heapWalker / alloc / drawHeapTitle register-window shifts**: consistent +N register-number offsets (e.g. this->r22 vs r19); same saved-reg count, different coloring order. Not source-steerable.
- **freeStageBlock commutative add-fold** (`add r3,r0,r3` vs `add r3,r3,r0`) and the **Init AmemCacheSet placement-new null-check fold** (mwcc won't fold `&s_memory_cpp != 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)