### PR TITLE
map: raise fuzzy match to 95.7% (cycle 7)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1593,14 +1593,15 @@ search:
             (reinterpret_cast<unsigned int>(mapObjEnd) + (stride - 1) - reinterpret_cast<unsigned int>(mapObj)) /
             stride;
 
-        if (mapObj < mapObjEnd) {
-            for (unsigned int i = 0; i < remaining; i++) {
-                CMapObjAtr* mapObjAtr = mapObj->m_attribute;
-                if (mapObjAtr != 0 && mapObjAtr->m_type == CMapObjAtr::PLAY_STA) {
-                    goto found;
-                }
-                mapObj++;
+        for (unsigned int i = 0; i < remaining; i++) {
+            if (mapObj >= mapObjEnd) {
+                break;
             }
+            CMapObjAtr* mapObjAtr = mapObj->m_attribute;
+            if (mapObjAtr != 0 && mapObjAtr->m_type == CMapObjAtr::PLAY_STA) {
+                goto found;
+            }
+            mapObj++;
         }
 
         mapObj = 0;


### PR DESCRIPTION
Raises main/map fuzzy match from baseline 95.74% to 95.75%.

## Change
- GetDebugPlaySta: moved the `mapObj >= mapObjEnd` loop-bound check inside the for-body (matching the sibling AttachMapHit idiom), dropping the redundant `if (mapObj < mapObjEnd)` wrapper. Function 80.98% -> 82.09%. Plausible original source: the two find-loops now share one structure.

## Walls encountered (not source-steerable)
- Magic-float-pool naming (kMapZero/kMapViewScale emitted as anonymous @NNN pool entries) dominates SetViewMtx/SetLightSource/SetMeshCamera*; R3 def-after-functions regressed code%.
- IV strength-reduction (/0xf0 divide) in mapObj find-loops (GetDebugPlaySta/AttachMapHit/ReadMid) leaves an extra zero-precheck and register-coloring shifts.
- Pure register coloring in SetIdGrpColor (add r3 vs add r5 element-address) and SetMapObjAnim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)