### PR TITLE
joybus: raise fuzzy match to 90.9% (cycle 18)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5982,7 +5982,7 @@ int JoyBus::SendCmd(ThreadParam* threadParam)
 int JoyBus::SendBonusStr(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -6100,9 +6100,12 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4978,7 +4978,7 @@ int JoyBus::SendPlayerHP(ThreadParam* threadParam)
 int JoyBus::SendItemAll(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -5207,7 +5207,7 @@ int JoyBus::SendMapObj(ThreadParam* threadParam)
 int JoyBus::SendCompatibility(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -5294,9 +5294,12 @@ int JoyBus::SendCompatibility(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -5566,9 +5569,12 @@ int JoyBus::SendFavorite(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -5754,7 +5760,7 @@ int JoyBus::SendMType(ThreadParam* threadParam, int modeType)
 int JoyBus::SendEquip(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -5842,9 +5848,12 @@ int JoyBus::SendEquip(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -5868,7 +5877,7 @@ int JoyBus::SendEquip(ThreadParam* threadParam)
 int JoyBus::SendCmd(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -5956,9 +5965,12 @@ int JoyBus::SendCmd(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -6129,7 +6141,7 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
 int JoyBus::SendArtifact(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -6216,9 +6228,12 @@ int JoyBus::SendArtifact(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -6242,7 +6257,7 @@ int JoyBus::SendArtifact(ThreadParam* threadParam)
 int JoyBus::SendTmpArtifact(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -6329,9 +6344,12 @@ int JoyBus::SendTmpArtifact(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -6355,7 +6373,7 @@ int JoyBus::SendTmpArtifact(ThreadParam* threadParam)
 int JoyBus::SendMapObjInfo(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -6446,9 +6464,12 @@ int JoyBus::SendMapObjInfo(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)
@@ -6598,7 +6619,7 @@ int JoyBus::SendRaderMode(ThreadParam* threadParam)
 int JoyBus::SendScouInfo(ThreadParam* threadParam)
 {
     unsigned int port;
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -6685,9 +6706,12 @@ int JoyBus::SendScouInfo(ThreadParam* threadParam)
                 result = 0;
             }
         }
-    
+
         break;
     }
+    default:
+        result = 0;
+        break;
     }
 
     if (result == 0)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4750,7 +4750,8 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             payload[0] = 1;
 
-            GbaQue.GetCaravanName((char*)&payload[1]);
+            unsigned char* body = &payload[1];
+            GbaQue.GetCaravanName((char*)body);
 
             signed char* p = (signed char*)&playerInfo;
             unsigned char* cf = classFlags;
@@ -4793,33 +4794,33 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
                 highBits += 1;
             }
 
-            memcpy(&payload[0x81], classFlags, sizeof(classFlags));
+            memcpy(&body[0x80], classFlags, sizeof(classFlags));
 
             unsigned char* playerData = playerInfo.m_data;
 
-            payload[0x85] = playerData[0x16];
-            payload[0x86] = playerData[0x17];
-            payload[0x87] = playerData[0xF2];
-            payload[0x88] = playerData[0xF3];
-            payload[0x89] = playerData[0x1CE];
-            payload[0x8A] = playerData[0x1CF];
-            payload[0x8B] = playerData[0x2AA];
-            payload[0x8C] = playerData[0x2AB];
-            payload[0x8D] = playerData[threadParam->m_portIndex * 0xDC + 2];
+            body[0x84] = playerData[0x16];
+            body[0x85] = playerData[0x17];
+            body[0x86] = playerData[0xF2];
+            body[0x87] = playerData[0xF3];
+            body[0x88] = playerData[0x1CE];
+            body[0x89] = playerData[0x1CF];
+            body[0x8A] = playerData[0x2AA];
+            body[0x8B] = playerData[0x2AB];
+            body[0x8C] = playerData[threadParam->m_portIndex * 0xDC + 2];
 
-            memcpy(&payload[0x8E], &playerData[threadParam->m_portIndex * 0xDC + 0x20], 3);
+            memcpy(&body[0x8D], &playerData[threadParam->m_portIndex * 0xDC + 0x20], 3);
 
             unsigned short statHalf = __lhbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x14], 0);
-            memcpy(&payload[0x91], &statHalf, 2);
+            memcpy(&body[0x90], &statHalf, 2);
 
-            unsigned char* body = &payload[0x93];
+            unsigned char* compatBody = &body[0x92];
 
-            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, body);
+            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, compatBody);
 
-            memcpy(body + compatLen, &playerData[threadParam->m_portIndex * 0xDC + 0x18], 8);
+            memcpy(compatBody + compatLen, &playerData[threadParam->m_portIndex * 0xDC + 0x18], 8);
 
             unsigned int statWord = __lwbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x24], 0);
-            memcpy(body + compatLen + 8, &statWord, sizeof(statWord));
+            memcpy(compatBody + compatLen + 8, &statWord, sizeof(statWord));
 
             const int byteLen = compatLen + 0xA3;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4727,7 +4727,7 @@ int JoyBus::MakeJoyData(char* src, int length, unsigned int* outBuffer)
  */
 int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 {
-    unsigned int result = 0;
+    unsigned int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)
@@ -4891,6 +4891,10 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
                 }
             }
         }
+        break;
+
+    default:
+        result = 0;
         break;
     }
 


### PR DESCRIPTION
Raises main/joybus fuzzy match from 90.82% to 90.92%.

## What changed
- **SendPlayerStat** 89.92% -> 93.17%: lazy `result` init (no eager `li r3,0`) + cached a `body = &payload[1]` cursor so payload writes address off one base pointer (matches the target's single advancing pointer instead of recomputing `&payload[N]` from the frame each time).
- **SendBonusStr** 94.88% -> 95.01%: lazy `result` init via `default:` case, dropping the eager `li r3,0`.
- **Send packet family** (SendArtifact, SendItemAll, SendCmd, SendTmpArtifact, SendMapObjInfo, SendEquip, SendCompatibility, SendScouInfo) 98.01% -> 98.12-98.58%: same lazy `result` init, removing the eager zero materialization.

All changes are plausible original source idioms (deferring a default value into the switch's `default` arm; caching a packet cursor). No header layout changes, no hacks.

## Blockers (verified, not pursued)
- **result-in-rN-vs-r3 ABI**: the small command-queue functions (SendCancel, SetCmdLst, SendUseItem, SendChkCrc, etc.) hold the return value in r5/r7/r8/r9 and deliver via `mr r3,rN`, with the `cmd=0`/`result=0` constant CSE'd into that register. Could not be reproduced from source (CSE attempts and single-exit restructuring both no-op or regress).
- **SendDataFile / GBARecvSend register window**: both save one extra callee-saved register vs the target (frame +0x8/+0x10), shifting the whole window. Inlining/relocating the `port` cache regressed both. GBARecvSend also references the rodata.0 merged base vs the target's per-named-symbol relocs.
- **ThreadMain**: 2-extra-callee-saved frame + missing switch cases (no MAP to recover them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)