### PR TITLE
joybus: raise fuzzy match to 90.9% (cycle 19)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7201,11 +7201,7 @@ int JoyBus::IsInitSend(int portIndex)
     unsigned int result;
 
     // Determine desired "init send" state
-    if (m_threadParams[portIndex].m_sentStartFlag != 0)
-    {
-        result = 0;
-    }
-    else if (state > 0x384)
+    if (m_threadParams[portIndex].m_sentStartFlag != 0 || state > 0x384)
     {
         result = 0;
     }


### PR DESCRIPTION
## Summary
Raises `main/joybus` fuzzy match from 90.92007% to 90.93644%.

## Change
**IsInitSend (96.61% -> 100%)**: combined the `m_sentStartFlag != 0` and `state > 0x384` zero-result cases with `||` so they share a single `result = 0` block, matching the target's branch layout (the target emits `bne <sharedZero>` for the first condition and falls through to the same `li r3,0` block for the second). Behaviorally identical; matched_functions 41 -> 42.

## Investigation notes (walls confirmed, not source-steerable)
The bulk of the remaining unmatched code is the Send*/Set* command-queue family (SetCmdLst, SetTmpArti, SendUseItem, SendHitEnemy, SendResult, SetMoney, SendAddLetter, SendCancel, SendStartBonus, RequestData, SendChkCrc, SendGBAStart/Stop, SendCtrlMode, SendMapNo, SendPpos). They all share one coupled, unbreakable wall:
- mwcc materializes `result` and the shared `cmd = 0` constant into a low caller-saved scratch register (r5-r9) with a terminal `mr r3,rN`, instead of `li r3,0` directly.
- a fixed r29/r30 coloring swap of the threadParams-base pointer vs the cmd word.

Verified per-function that lazy-result, result-at-top, char[4]-vs-uint cmd construction, declaration reordering, value-vs-pointer caching, and condition inversion do not move it.

Other functions are walled by codegen-internal decisions: LoadBin (loop unroll factor - looping regresses 89.5->77), Destroy (saved-register-window off by one), MakeJoyData/SendMapObjDrawFlg (CRC-loop register coloring + load/store scheduling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)