### PR TITLE
gobjwork: raise fuzzy match to 95.9% (cycle 13)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2011,41 +2011,12 @@ void CCaravanWork::CalcStatus()
 		m_defense = (unsigned short)((float)m_defense * GetStatusMultiplier(0x44));
 	}
 
-	cappedValue = 99;
-	if (m_strength <= 99) {
-		cappedValue = m_strength;
-	}
-	m_strength = cappedValue;
-
-	cappedValue = 99;
-	if (m_defense <= 99) {
-		cappedValue = m_defense;
-	}
-	m_defense = cappedValue;
-
-	cappedValue = 99;
-	if (m_magic <= 99) {
-		cappedValue = m_magic;
-	}
-	m_magic = cappedValue;
-
-	cappedValue = 99;
-	if (m_baseStrength <= 99) {
-		cappedValue = m_baseStrength;
-	}
-	m_baseStrength = cappedValue;
-
-	cappedValue = 99;
-	if (m_baseDefense <= 99) {
-		cappedValue = m_baseDefense;
-	}
-	m_baseDefense = cappedValue;
-
-	cappedValue = 99;
-	if (m_baseMagic <= 99) {
-		cappedValue = m_baseMagic;
-	}
-	m_baseMagic = cappedValue;
+	m_strength = (m_strength > 99) ? 99 : m_strength;
+	m_defense = (m_defense > 99) ? 99 : m_defense;
+	m_magic = (m_magic > 99) ? 99 : m_magic;
+	m_baseStrength = (m_baseStrength > 99) ? 99 : m_baseStrength;
+	m_baseDefense = (m_baseDefense > 99) ? 99 : m_baseDefense;
+	m_baseMagic = (m_baseMagic > 99) ? 99 : m_baseMagic;
 }
 
 /*

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1988,11 +1988,7 @@ void CCaravanWork::CalcStatus()
 	}
 
 	for (int i = 0; i < 11; i++) {
-		unsigned short resistance = 2;
-		if (m_elementResistances[i] < 2) {
-			resistance = m_elementResistances[i];
-		}
-		m_elementResistances[i] = resistance;
+		m_elementResistances[i] = (m_elementResistances[i] < 2) ? m_elementResistances[i] : 2;
 	}
 
 	if (m_hp > m_maxHp) {

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1903,8 +1903,8 @@ void CCaravanWork::CalcStatus()
 			int itemType = GetItemDataPtr(itemIdx)[0];
 
 			if (itemType == 1) {
-				int weaponItem;
 				int weaponRef;
+				int weaponItem;
 				GetCurrentWeaponItem(weaponItem, weaponRef);
 				if (weaponItem > 0) {
 					itemIdx = weaponItem;


### PR DESCRIPTION
Raises main/gobjwork fuzzy match from 95.82% to 95.86%.

## Changes (all in CCaravanWork::CalcStatus)
- **Clamp-as-select for stat caps**: rewrote the six `cappedValue = 99; if (x <= 99) cappedValue = x; x = cappedValue;` clamps as `x = (x > 99) ? 99 : x;` ternaries. Against memory operands the if-form emitted a NaN-aware compare + extra register; the ternary matches the target's select, dropping ~30 flagged lines.
- **Clamp-as-select for element resistances**: same idiom for the `m_elementResistances[i] < 2` cap loop.
- **weaponItem/weaponRef arg slot order**: swapped the declaration order of the two `GetCurrentWeaponItem(weaponItem, weaponRef)` reference locals so they land in the target's stack slots (0x8 / 0xc).

## Result
- CCaravanWork::CalcStatus: 112 -> 76 flagged asm lines (98.43% -> ~98.9%)
- Unit fuzzy: 95.82111% -> 95.86445%

These are plausible source idioms (ternary clamps, local declaration order), not compiler coaxing.

## Remaining blockers (walls)
- `DOUBLE_803309A0` magic-double naming: target references a named `.sdata2` double for the unsigned->float bias; mwcc emits an anonymous pooled double for our inline `(float)` conversions. Not source-steerable (matches the documented Init__8CMonWork wall).
- Index-scaling register coloring (GetMagicCharge, GetNextCmdListIdx, GetCmdListItemName, DelCmdListAndItem, GetNumCombi, SafeDeleteTempItem, GetArtifactIncludeHpMax): consistent off-by-N callee-saved register rotations from `cmdListIdx*2` / `this`-base coloring. permute_fn found no improvement; source reordering regresses.
- FGLetterOpen / AddLetter: the 0x3ec offset-trick (target keeps `i*0xc` and `this+i*0xc` in separate callee-saved regs with the array-base offset deferred to displacements). Documented wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)