### PR TITLE
gobject: raise fuzzy match to 92.5% (cycle 14)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2516,10 +2516,9 @@ void CGObject::boundCheck()
     PSMTX44Concat(screenMtx, clipMtx, screenMtx);
 
     if ((m_charaModelHandle != 0) && (m_charaModelHandle->m_model != 0)) {
-        const float clipLimit = 2.0f;
+        const float zero = sZeroFloat;
         const float oneF = sAnimFrameOffset;
-        const double zero = static_cast<double>(sZeroFloat);
-        const double one = static_cast<double>(sAnimFrameOffset);
+        const float clipLimit = 2.0f;
 
         clipMask = 0x1F;
         for (s32 i = 0; (clipMask != 0) && (i < 8); i++) {
@@ -2528,7 +2527,7 @@ void CGObject::boundCheck()
             clipCorner.z = m_worldPosition.z + (((i & 2) != 0) ? -m_nearColRadius : m_nearColRadius);
 
             Math.MTX44MultVec4(screenMtx, &clipCorner, &clipPos);
-            if (static_cast<double>(clipPos.w) > zero) {
+            if (clipPos.w > zero) {
                 clipMask &= 0xFFFFFFEF;
             }
             if (clipMask == 0) {
@@ -2545,10 +2544,10 @@ void CGObject::boundCheck()
             if (clipPos.y > clipLimit) {
                 clipMask &= 0xFFFFFFFD;
             }
-            if (static_cast<double>(clipPos.x) < one) {
+            if (clipPos.x < oneF) {
                 clipMask &= 0xFFFFFFFB;
             }
-            if (static_cast<double>(clipPos.y) < one) {
+            if (clipPos.y < oneF) {
                 clipMask &= 0xFFFFFFF7;
             }
         }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2521,7 +2521,8 @@ void CGObject::boundCheck()
         const float clipLimit = 2.0f;
 
         clipMask = 0x1F;
-        for (s32 i = 0; (clipMask != 0) && (i < 8); i++) {
+        s32 i = 0;
+        do {
             clipCorner.x = m_worldPosition.x + (((i & 1) != 0) ? -m_nearColRadius : m_nearColRadius);
             clipCorner.y = m_worldPosition.y + (((i & 4) != 0) ? -m_nearColRadius : m_nearColRadius);
             clipCorner.z = m_worldPosition.z + (((i & 2) != 0) ? -m_nearColRadius : m_nearColRadius);
@@ -2550,7 +2551,7 @@ void CGObject::boundCheck()
             if (clipPos.y < oneF) {
                 clipMask &= 0xFFFFFFF7;
             }
-        }
+        } while ((clipMask != 0) && (++i < 8));
 
         m_weaponNodeFlagBits.m_unk20 = static_cast<signed char>(static_cast<u32>(__cntlzw(clipMask)) >> 5);
     }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -836,7 +836,7 @@ void CGObject::objectCollision()
                         float split;
                         if (rawSplit < sZeroFloat) {
                             split = sZeroFloat;
-                        } else if (rawSplit > sAnimFrameOffset) {
+                        } else if (sAnimFrameOffset < rawSplit) {
                             split = sAnimFrameOffset;
                         } else {
                             split = rawSplit;


### PR DESCRIPTION
## Summary
Raises main/gobject fuzzy match from 92.50% to 92.55%.

### boundCheck (the cleanest wins)
- Collapsed the four clip-bound constant locals (clipLimit / oneF / zero / one) to three, reusing the single `sAnimFrameOffset` float for both the divide and the `< one` clip comparisons. This matches the target's float-pool register coloring (zero->f29, oneF->f30, 2.0f->f31) and removes the duplicate `one` double-load.
- Converted the clip-corner `for` loop into a `do { ... } while ((clipMask != 0) && (++i < 8))`. The `do/while` removes the target-absent loop-entry pre-test branch, and `++i` in the condition places the increment after the `clipMask != 0` bottom test exactly as the target emits it. This dropped the function's flagged lines from 12 to 5.

### objectCollision
- Rewrote the push-split clamp's middle test from `rawSplit > sAnimFrameOffset` to `sAnimFrameOffset < rawSplit`, matching the target's `fcmpo f29(bound), f0(value); bge` operand order and removing an OP_MISMATCH (the `>=`/`<=` ternary forms reintroduce NaN-aware `cror`, so plain `<` polarity with fallthrough is correct).

## Evidence
- Baseline: 92.49844%
- Final: 92.54755% (matched_code 5672)
- Build clean; report.json is source of truth.

## Plausibility
All three changes are ordinary hand idioms (reusing one float constant, a bottom-tested loop with pre-increment, and a clamp written with the bound on the left). No hacks, no fake symbols, no layout changes.

## Blocker (remaining ceiling)
The rest of the unit is dominated by documented walls: anonymous float-pool naming (`@NNN` vs `FLOAT_803303xx`/`DOUBLE_xxx` named .sdata2 symbols owned elsewhere — CalcSafePos, CCClass, update, objectCollision), and register-window coloring shifts (hit `other` r31-vs-r29 2-register shift with attack/damage cursor folding; copy r4/r5 GPR swap; CCClass FPR window shift; update/onCreate/onDraw/move coloring). permute_fn found no improving mutations on boundCheck/CCClass/copy. The boundCheck residual is purely the f29/f31 zero<->2.0f swap plus the `@472` anonymous-naming wall.
🤖 Generated with [Claude Code](https://claude.com/claude-code)