### PR TITLE
gobjwork: raise fuzzy match to 95.9% (cycle 14)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1913,16 +1913,19 @@ void CCaravanWork::CalcStatus()
 
 			unsigned short itemValue = (short)GetItemDataPtr(itemIdx)[3];
 			if (itemType != 0x45) {
-				if (itemType >= 0x45) {
-					if (itemType == 0x7F) {
-						goto apply_effect;
+				if (itemType < 0x45) {
+					if (itemType == 1) {
+						goto apply_str;
 					}
 					goto no_effect;
 				}
-				if (itemType == 1) {
-					m_strength += itemValue;
-					m_baseStrength += itemValue;
+				if (itemType == 0x7F) {
+					goto apply_effect;
 				}
+				goto no_effect;
+			apply_str:
+				m_strength += itemValue;
+				m_baseStrength += itemValue;
 				goto no_effect;
 			}
 

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2528,9 +2528,9 @@ void CCaravanWork::SortBeforeReturnWorldMap()
 	for (int i = 0; i < 0x3F; i++) {
 		for (int j = i + 1; j < 0x40; j++) {
 			short lhs = m_inventoryItems[i];
-			short rhs = m_inventoryItems[j];
 
-			if (lhs < 1) {
+			if (lhs <= 0) {
+				short rhs = m_inventoryItems[j];
 				if (rhs > 0) {
 					m_inventoryItems[i] = rhs;
 					m_inventoryItems[j] = 0xFFFF;
@@ -2547,7 +2547,9 @@ void CCaravanWork::SortBeforeReturnWorldMap()
 						}
 					}
 				}
-			} else if ((rhs > 0) && (rhs < lhs)) {
+			} else {
+				short rhs = m_inventoryItems[j];
+				if ((rhs > 0) && (rhs < lhs)) {
 				m_inventoryItems[i] = rhs;
 				m_inventoryItems[j] = lhs;
 
@@ -2566,6 +2568,7 @@ void CCaravanWork::SortBeforeReturnWorldMap()
 					} else if (m_equipment[equip] == j) {
 						m_equipment[equip] = static_cast<short>(i);
 					}
+				}
 				}
 			}
 		}


### PR DESCRIPTION
Raises main/gobjwork fuzzy match from 95.86% to 95.91% via two source-shape fixes.

- **SortBeforeReturnWorldMap**: changed `lhs < 1` to `lhs <= 0` (matches target's `extsh.`/`bgt` zero-test instead of `cmpwi 1`/`bge`), and made `rhs` a lazy per-branch reload instead of a top-of-loop cache.
- **CalcStatus (CCaravanWork)**: reordered the `itemType` dispatch so the `< 0x45` arm (containing the `== 1` strength case) is emitted before the `>= 0x45` arm (the `== 0x7F` case), matching the target's basic-block order.

Remaining diffs are documented walls: the `cmdListIdx*2`/artifact-loop index-scaling register coloring (GetMagicCharge, DelCmdListAndItem, GetCmdListItemName, GetArtifactIncludeHpMax, SafeDeleteTempItem), the `DOUBLE_803309A0` magic-double and `jumptable_*` symbol naming (CalcStatus, CMonWork::CalcStatus, CMonWork::Init), and prologue/epilogue restore scheduling (Init CGObjWork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)