### PR TITLE
gobject: raise fuzzy match to 92.5% (cycle 15)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1038,8 +1038,8 @@ void CGObject::bgNormalCollision()
     return;
 
 simple:
-    m_groundHitOffset.x = pos.x - m_worldPosition.x;
     m_groundHitOffset.y = pos.y - m_worldPosition.y;
+    m_groundHitOffset.x = pos.x - m_worldPosition.x;
     m_groundHitOffset.z = pos.z - m_worldPosition.z;
     return;
 


### PR DESCRIPTION
Reorder bgNormalCollision `simple:` block field stores to y,x,z to match the target's emission order (m_groundHitOffset.y store precedes .x). Net unit fuzzy match 92.5476% -> 92.5485%.

Remaining gobject diffs are dominated by documented matching walls: anonymous float/double sdata2-pool symbol naming (FLOAT_8033033c etc. emit as @NNNN locals; extern-naming regresses), FPR/GPR register-coloring (CCClass, copy, boundCheck, objectCollision), CVector stack-slot hoisting (update, CalcSafePos), result-in-rN-vs-r3 ABI (IsAnimFinished), and bgCollision sda21 offset folding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)