### PR TITLE
cmake: raise fuzzy match to 88.9% (cycle 18)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3744,9 +3744,7 @@ void CMenuPcs::DrawSingCMake()
 
     if (CmakeState(this)->m_mode < 2) {
         CmakeState(this)->m_mode = static_cast<short>(CmakeState(this)->m_mode + 1);
-        CmakeState(this)->m_frame = 0;
-        CmakeMcState(this) = 3;
-        return;
+        goto resetFrame;
     }
 
     gCmakePreviousStep = static_cast<int>(CmakeState(this)->m_step);
@@ -3772,6 +3770,7 @@ void CMenuPcs::DrawSingCMake()
     }
 
     CmakeState(this)->m_selectionInitialized = 0;
+resetFrame:
     CmakeState(this)->m_frame = 0;
     CmakeMcState(this) = 3;
 }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3753,32 +3753,22 @@ void CMenuPcs::DrawSingCMake()
 
     if (CmakeState(this)->m_step == 6) {
         CmakeState(this)->m_step = static_cast<short>(CmakeState(this)->m_select + 1);
-        if (CmakeState(this)->m_step == 0) {
-            CmakeState(this)->m_mode = 2;
-        } else {
-            CmakeState(this)->m_mode = 0;
-        }
     } else if (CmakeState(this)->m_resultDir < 0) {
         if (CmakeState(this)->m_step == 5) {
             CmakeState(this)->m_step = 6;
         } else {
             CmakeState(this)->m_step = static_cast<short>(CmakeState(this)->m_step - 1);
         }
-        if (CmakeState(this)->m_step == 0) {
-            CmakeState(this)->m_mode = 2;
-        } else {
-            CmakeState(this)->m_mode = 0;
-        }
     } else if (CmakeState(this)->m_step != 5) {
         CmakeState(this)->m_step = static_cast<short>(CmakeState(this)->m_step + 1);
-        if (CmakeState(this)->m_step == 0) {
-            CmakeState(this)->m_mode = 2;
-        } else {
-            CmakeState(this)->m_mode = 0;
-        }
     } else {
         CmakeState(this)->m_step = 0;
+    }
+
+    if (CmakeState(this)->m_step == 0) {
         CmakeState(this)->m_mode = 2;
+    } else {
+        CmakeState(this)->m_mode = 0;
     }
 
     CmakeState(this)->m_selectionInitialized = 0;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1066,7 +1066,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
                 if (nameLen == 0) {
                     strcat(s_CmakeInfo.m_name, picked);
                     ret = 0;
-                } else if (strlen(rowText) != 0 && nameLen >= 7) {
+                } else if ((__cntlzw(static_cast<unsigned int>(strlen(rowText))) >> 5 & 1) == 0 && nameLen >= 7) {
                     ret = -1;
                 } else {
                     strcat(s_CmakeInfo.m_name, picked);


### PR DESCRIPTION
## Summary
Raised `main/cmake` fuzzy match from baseline **88.58%** to **88.95%** via control-flow restructuring backed by the target asm.

## Changes (all confirmed via report.json fuzzy_match_percent)
- **DrawSingCMake** 86.27% -> 97.03% (the dominant win):
  - Shared the `if (m_step == 0) m_mode = 2; else m_mode = 0;` block across the four step-transition arms instead of duplicating it in each arm. The target reaches a single mode-set block from all arms (R22/R9).
  - Shared the `m_frame = 0; CmakeMcState = 3;` epilogue between the `m_mode < 2` arm and the function tail via a `goto` (R14), matching the target's branch to a common reset block instead of an early return.
- **CmakeVillageCtrl** 93.17% -> 93.47%: the `strlen(rowText) != 0` emptiness test now uses the `(__cntlzw(len) >> 5 & 1) == 0` idiom the original source used, matching the target's `cntlzw; extrwi; neg.; bne` lowering instead of `cmplwi`.

## Why this is plausible source
All changes are ordinary control-flow factorings (shared tail blocks, a single common epilogue) and reuse of the same `__cntlzw` emptiness idiom already present elsewhere in this file. No hardcoded addresses, fake symbols, or layout hacks.

## Blocker / remaining ceiling
The remaining gap is concentrated in documented walls: the magic-double int<->float coordinate conversion + float-pool symbol naming (`@NNN` vs `DOUBLE_8033xxxx`) across the DrawRect-heavy functions, the pad-read signed/unsigned register coloring in the Ctrl functions, and frame-size / extra-callee-saved-register windows (e.g. DrawCmakeDecision needs one more saved GPR). These were probed and are not source-steerable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)