### PR TITLE
goout: raise fuzzy match to 97.8% (cycle 15)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -656,9 +656,9 @@ static inline int FindFreeCaravanIdx(Mc::SaveDat* saveData)
  */
 void DrawGoOutMenu()
 {
-    CGoOutMenu& goOutMenu = g_GoOutMenu;
-    g_pGoOutMenu = &goOutMenu;
-    unsigned char mode = goOutMenu.m_mainMode;
+    g_pGoOutMenu = &g_GoOutMenu;
+    CGoOutMenu& goOutMenu = *g_pGoOutMenu;
+    char mode = goOutMenu.m_mainMode;
 
     switch (mode) {
     case 2:


### PR DESCRIPTION
Raises main/goout fuzzy match from 97.78% to 97.82%.

## Change
In `DrawGoOutMenu`, fixed the `m_mainMode` access to match the original:
- `mode` is read as a signed `char` (target uses `extsb` after the load), not `unsigned char`.
- `g_pGoOutMenu` is stored before dereferencing, with member reads going through the stored pointer (`*g_pGoOutMenu`), matching the target's pointer-in-r31 access pattern.

This brought `DrawGoOutMenu__Fv` from 97.60% to 98.52%, and a comparison-boundary/block-order mismatch in the `m_goOutMode` range test resolved as a side effect.

## Blockers (documented walls, not pursued)
- `SetMemCardError` (89.89%): split-arm switch BST midpoint divergence for a fixed case set — not source-steerable.
- `CalcDel`/`CalcGoOut`: inlined `GetGoOutInputMask` Pad-block register coloring + jumptable/float-pool symbol naming. A real signed/unsigned-byte fix (`extsb`→`clrlwi`) in the `switch(next)` dispatch was confirmed but is net-negative because removing it shifts the entangled pad-block register window.
- `Calc`: `this`↔`MenuPcs` r30/r31 coloring.
- The `m_accessSaveIndex`/`m_accessCardChannel` (0x10/0xc) load-order swap in `SetGoOutMode`/`CalcGoOut` resists reordering (swaps the r0/r4 assignment instead of fixing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)