### PR TITLE
cmake: raise fuzzy match to 89.1% (cycle 19)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -943,7 +943,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         }
         Sound.PlaySe(1, 0x40, 0x7f, 0);
     } else if ((repeat & 0x4) != 0) {
-        if (row < (4 + static_cast<int>((static_cast<unsigned long long>(select) - 10) >> 32))) {
+        if (row < (select >= 10 ? 4 : 3)) {
             row = static_cast<short>(row + 1);
         } else {
             row = 0;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1030,7 +1030,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             const char* rowText = s_NameEntryStr[curRow + curTable * 5];
             int rowLen = strlen(rowText);
             if (rowLen != 0) {
-                unsigned int i = 0;
+                int i = 0;
                 int j = 0;
                 for (; 0 < rowLen; rowLen = rowLen - 1) {
                     if (i == curSelect) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1903,8 +1903,8 @@ unsigned short CMenuPcs::CmakeJobCtrl()
 
                 if (slot < 8) {
                     Sound.PlaySe(4, 0x40, 0x7F, 0);
-                    short winX = 0;
-                    short winY = 0;
+                    short winX;
+                    short winY;
                     GetWinSize(0x16, &winX, &winY, 0);
                     SetMcWinInfo((int)winX, (int)winY);
                     CmakeMcState(this) = 0;
@@ -2223,8 +2223,8 @@ unsigned short CMenuPcs::CmakeTribeCtrl()
 
                 if (slot < 8) {
                     Sound.PlaySe(4, 0x40, 0x7F, 0);
-                    short winX = 0;
-                    short winY = 0;
+                    short winX;
+                    short winY;
                     GetWinSize(0x15, &winX, &winY, 0);
                     SetMcWinInfo(static_cast<int>(winX), static_cast<int>(winY));
                     CmakeMcState(this) = 0;
@@ -2788,8 +2788,8 @@ int CMenuPcs::CmakeNameCtrl()
 
                     if (IsDuplicateCmakeName(this, s_CmakeInfo.m_name)) {
                         Sound.PlaySe(4, 0x40, 0x7F, 0);
-                        short winX = 0;
-                        short winY = 0;
+                        short winX;
+                        short winY;
                         GetWinSize(0x14, &winX, &winY, 0);
                         SetMcWinInfo((int)winX, (int)winY);
                         CmakeMcState(this) = 0;


### PR DESCRIPTION
Raises main/cmake fuzzy match from 88.95% to 89.10%.

## Changes
- **Drop dead winX/winY zero-init before GetWinSize** (3 sites in CmakeJobCtrl/CmakeTribeCtrl/CmakeNameCtrl). The out-params are written by GetWinSize, so the original left them uninitialized; the `= 0` produced target-absent zero stores. CmakeJobCtrl 95.7->96.7, CmakeTribeCtrl 90.9->92.0, CmakeNameCtrl 86.4->87.1.
- **Ternary for CmakeVillageCtrl row clamp**: replaced the explicit 64-bit borrow trick `4 + (int)((u64(select)-10)>>32)` with the equivalent `select >= 10 ? 4 : 3`, which mwcc lowers to the target's `subfc`/`adde`/`srawi` sequence (same idiom CmakeNameCtrl already uses).
- **Signed loop index in CmakeVillageCtrl name-pick loop**: `unsigned int i` -> `int i` so `i == curSelect` emits the target's signed `cmpw` instead of `cmplw`.

## Plausibility
All changes are behavior-preserving and match how equivalent code is already written elsewhere in cmake.cpp (the ternary form mirrors CmakeNameCtrl; signed index mirrors the sibling loops).

## Blockers (documented walls, not pursued)
- Pad-read `__cntlzw` register coloring (r0/r3/r4 base-vs-index swap) recurs across all Ctrl functions and is not source-steerable.
- CalcSingCMake `result` lives in r27 (target) vs r29/scratch (ours) - register-window allocation wall.
- DrawRect-heavy Draw functions (DrawDiaryBase, CmakeVillageDraw, CmakeNameDraw, CmakeTribeDraw) blocked on magic-double int<->float conversion + anonymous-vs-named float-pool ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)