### PR TITLE
cmake: raise fuzzy match to 89.1% (cycle 20)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2533,11 +2533,12 @@ void CMenuPcs::CmakeNameDraw()
 
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    col.r = 0xFF;
-    col.g = 0xFF;
-    col.b = 0xFF;
-    col.a = static_cast<unsigned char>(a);
-    GXSetChanMatColor(GX_COLOR0A0, col);
+    GXColor col2;
+    col2.r = 0xFF;
+    col2.g = 0xFF;
+    col2.b = 0xFF;
+    col2.a = static_cast<unsigned char>(a);
+    GXSetChanMatColor(GX_COLOR0A0, col2);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     unsigned int titleU = static_cast<unsigned int>(
         -(static_cast<double>(280.0f) * 0.5 - 400.0));
@@ -2547,11 +2548,12 @@ void CMenuPcs::CmakeNameDraw()
 
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    col.r = 0xFF;
-    col.g = 0xFF;
-    col.b = 0xFF;
-    col.a = static_cast<unsigned char>(a);
-    GXSetChanMatColor(GX_COLOR0A0, col);
+    GXColor col3;
+    col3.r = 0xFF;
+    col3.g = 0xFF;
+    col3.b = 0xFF;
+    col3.a = static_cast<unsigned char>(a);
+    GXSetChanMatColor(GX_COLOR0A0, col3);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x68 : 0x41));
     MenuPcs.DrawRect(
         0, 184.0f, 216.0f, 48.0f, 48.0f,

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2764,8 +2764,8 @@ int CMenuPcs::CmakeNameCtrl()
             } else if ((down & 0x100) != 0) {
                 short curRow = CmakeState(this)->m_row;
                 if (curRow >= 5) {
-                    unsigned int emptyLen = strlen(s_CmakeInfo.m_name);
-                    if ((emptyLen & (static_cast<unsigned int>(-emptyLen | emptyLen) >> 31)) == 0) {
+                    int emptyLen = strlen(s_CmakeInfo.m_name);
+                    if ((emptyLen & ((-emptyLen | emptyLen) >> 31)) == 0) {
                         Sound.PlaySe(4, 0x40, 0x7F, 0);
                         return 0;
                     }


### PR DESCRIPTION
Raises main/cmake from baseline 89.10087% to 89.11418%.

## Changes
- **CmakeNameCtrl**: the `strlen()==0` blank-name idiom `(len & ((-len|len)>>31))` used `unsigned int` with a redundant `static_cast<unsigned int>` on the shift, emitting a logical `srwi`. The target uses an arithmetic `srawi` — i.e. a signed `int`. Changed `emptyLen` to `int` and dropped the cast so the shift is signed, matching the target.
- **CmakeNameDraw**: the three `GXSetChanMatColor` blocks reused a single `GXColor col` local. The original allocated a distinct `GXColor` per block (as the sibling CmakeVillageDraw does), giving each its own stack slot. Split into `col`/`col2`/`col3`; the frame grew toward the target's size and the function rose 86.24 -> 86.64 (asm_match).

## Evidence
- Unit fuzzy_match_percent (report.json): 89.100870 -> 89.114180.
- No regressions; net-positive, plausible source (real signedness fix + per-block color locals matching the codebase's existing pattern).

## Blockers (known walls, not pursued)
- Pad-read `__cntlzw` register coloring cascades through every Cmake*Ctrl/Calc function (down/repeat get sign-extended into a callee-saved reg with a different number than target), shifting the whole register window.
- Magic-double int->float bias + anonymous float-pool ordering (`@NNN` vs named `FLOAT_*`/`DOUBLE_*`) dominates every Draw function.
- alpha f30/f31 FPR-window in DrawCmakeName.
Borrow-form rewrites of the `sel>=10?4:3` ternary regressed in both NameCtrl and VillageCtrl (the register window, not the boundary, is the cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)