### PR TITLE
map: raise fuzzy match to 95.9% (cycle 8)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2021,7 +2021,13 @@ int CMapMng::ReadMpl(char* mapName)
                 }
             } else {
                 while (chunkFile.GetNextChunk(chunk)) {
-                    if (chunk.m_id == 0x4D455348 && chunk.m_arg0 == 1) {
+                    switch (chunk.m_id) {
+                    case 0x4D455348:
+                        break;
+                    default:
+                        continue;
+                    }
+                    if (chunk.m_arg0 == 1) {
                         return 1;
                     }
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2762,10 +2762,7 @@ void CMapMng::Draw()
 
                 int startIndex = 0;
                 do {
-                    int batchCount = 8;
-                    if (shadowCount < batchCount) {
-                        batchCount = shadowCount;
-                    }
+                    int batchCount = (shadowCount > 8) ? 8 : shadowCount;
 
                     CharaPcs.GetTexShadow(startIndex, batchCount, texObjs, shadowPositions, shadowMatrices);
 


### PR DESCRIPTION
Raises main/map fuzzy match from 95.75% to 95.87%.

## Changes
- **Draw**: rewrote the texture-shadow batch clamp `int batchCount = 8; if (shadowCount < batchCount) batchCount = shadowCount;` as the ternary `batchCount = (shadowCount > 8) ? 8 : shadowCount;`. The target emits a `cmpwi 8; bgt; mr` select; the if-form emitted a `>= 8` (`bge`) boundary. Draw 96.40% -> 96.65%.
- **ReadMpl**: rewrote the `else`-branch MESH-chunk scan loop from `if (chunk.m_id == 0x4D455348 && ...)` to a `switch (chunk.m_id) { case 0x4D455348: break; default: continue; }` matching the sibling loop above it. mwcc then hoists the `0x4D455348` chunk-id constant into a callee-saved register shared across both loops (`cmpw r0, rN`) instead of recomputing `subis`/`cmplwi` inline. ReadMpl 92.72% -> 94.27%.

## Plausibility
Both forms are ordinary FFCC idioms: a min-clamp ternary, and a switch-on-chunk-id matching the adjacent loop's exact structure.

## Blockers (not pursued)
Remaining sub-100% functions in this unit are dominated by known walls: the magic-float-pool naming (kMapZero/kMapViewScaleZ emitted as anonymous `@NNN` sda2 entries vs the named symbols), the `/0xf0` mapObj find-loop IV strength-reduction + entry-guard (GetDebugPlaySta, AttachMapHit), pure register-window off-by-one coloring (SetLightSource, DestroyMap, SetMapObjWorldMapLightID), and the merged-rodata-base/data-anchoring + string-ordering shift across the Read* family. Verified each via report.json fuzzy_match_percent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)