### PR TITLE
p_graphic: raise fuzzy match to 75.5% (cycle 5)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -358,8 +358,8 @@ void CGraphicPcs::drawScreenFade()
                 const float phase = slotData->m_phase;
                 const float stretch = slotData->m_stretch;
                 const float amp = slotData->m_amplitude * (kGraphicOne - t);
-                const float size = amp + kGraphicOne;
                 const float offX = stretch * (kGraphicScreenCenterX * amp) * (float)sin((double)phase);
+                const float size = amp + kGraphicOne;
                 const float offY = stretch * (kGraphicScreenCenterY * amp) * (float)cos((double)phase);
 
                 GXBegin(GX_QUADS, GX_VTXFMT0, 4);

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -361,22 +361,18 @@ void CGraphicPcs::drawScreenFade()
                 const float size = amp + kGraphicOne;
                 const float offX = stretch * (kGraphicScreenCenterX * amp) * (float)sin((double)phase);
                 const float offY = stretch * (kGraphicScreenCenterY * amp) * (float)cos((double)phase);
-                const float cx = kGraphicScreenCenterX + offX;
-                const float cy = kGraphicScreenCenterY + offY;
-                const float w = kGraphicScreenCenterX * size;
-                const float h = kGraphicScreenCenterY * size;
 
                 GXBegin(GX_QUADS, GX_VTXFMT0, 4);
-                GXPosition3f32(cx - w, cy - h, kGraphicZero);
+                GXPosition3f32((kGraphicScreenCenterX + offX) - kGraphicScreenCenterX * size, (kGraphicScreenCenterY + offY) - kGraphicScreenCenterY * size, kGraphicZero);
                 GXColor1u32(*(u32*)&baseColor);
                 GXTexCoord2u16(0, 0);
-                GXPosition3f32(cx + w, cy - h, kGraphicZero);
+                GXPosition3f32((kGraphicScreenCenterX + offX) + kGraphicScreenCenterX * size, (kGraphicScreenCenterY + offY) - kGraphicScreenCenterY * size, kGraphicZero);
                 GXColor1u32(*(u32*)&baseColor);
                 GXTexCoord2u16(2, 0);
-                GXPosition3f32(cx + w, cy + h, kGraphicZero);
+                GXPosition3f32((kGraphicScreenCenterX + offX) + kGraphicScreenCenterX * size, (kGraphicScreenCenterY + offY) + kGraphicScreenCenterY * size, kGraphicZero);
                 GXColor1u32(*(u32*)&baseColor);
                 GXTexCoord2u16(2, 2);
-                GXPosition3f32(cx - w, cy + h, kGraphicZero);
+                GXPosition3f32((kGraphicScreenCenterX + offX) - kGraphicScreenCenterX * size, (kGraphicScreenCenterY + offY) + kGraphicScreenCenterY * size, kGraphicZero);
                 GXColor1u32(*(u32*)&baseColor);
                 GXTexCoord2u16(0, 2);
                 continue;


### PR DESCRIPTION
Raises main/p_graphic from 75.22% to 75.47% via drawScreenFade wave-quad refactor.

## Changes
- **drawScreenFade slot==0 wave block**: inlined the `cx/cy/w/h` named locals directly into the four `GXPosition3f32` vertex calls, keeping only `offX`/`offY`/`size` as locals. This matches the target's lazy per-vertex computation (target keeps size/offX/offY in callee-saved FPRs and computes cx±w, cy±h as scratch) instead of pinning all four into separate FPRs.
- **size ordering**: moved `size = amp + 1.0` between the offX and offY computations to match the target's instruction order (target reuses the amp FPR for size after offX).

## Evidence
- Unit fuzzy_match_percent: 75.22% -> 75.47% (report.json).
- Both changes are net-positive and confirmed via report.json after each.

## Plausibility
Computing quad corners inline from the center/offset/size is ordinary hand-written draw code; no compiler-coaxing constructs introduced.

## Blockers (documented walls, confirmed)
- drawScreenFade FPR-window (f26/f27-vs-f28/f29): root cause is the sx/sy circle-center clamp being held in callee-saved FPRs via select, where the target spills to stack and reloads. Pos-reuse and select rewrites both regressed.
- drawBar drawText register-window + signed/unsigned padState compare: matching the signed cmpwi shifts the byte-aligner window net-negative.
- __sinit and the kIntToDoubleBias/@NNN anonymous magic-double pool naming remain the universal walls (.sdata2 at 41.8%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)