### PR TITLE
mapobj: raise fuzzy match to 98.7% (cycle 8)

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -471,7 +471,7 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                 m_drawPriority = 0;
             } else if ((m_mapDataType == 2) || (m_mapDataType == 3)) {
                 if (meshOrHitIdx != -2) {
-                    m_mapData = MapMng.GetMapHitArray() + meshOrHitIdx;
+                    m_mapData = &MapMng.m_mapHitArray[meshOrHitIdx];
                 } else {
                     CMapObjAtrMeshName* meshName =
                         new (MapMng.m_stage, const_cast<char*>(s_mapobj_cpp), 0x84) CMapObjAtrMeshName();

--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -913,7 +913,8 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                     CChunkFile::CChunk vtxChunk;
                     int vtxTableIndex = 0;
                     while (chunkFile.GetNextChunk(vtxChunk) != 0) {
-                        if (vtxChunk.m_id == CHUNK_VTX) {
+                        switch (vtxChunk.m_id) {
+                        case CHUNK_VTX: {
                             float* vtx = reinterpret_cast<float*>(operator new[](
                                 static_cast<unsigned long>(vtxChunk.m_arg0) * 0xC,
                                 MapMng.m_stage, const_cast<char*>(s_mapobj_cpp), 0x353));
@@ -927,6 +928,8 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
                                 vtx[2] = chunkFile.GetF4();
                                 vtx += 3;
                             }
+                            break;
+                        }
                         }
                     }
                     chunkFile.PopChunk();


### PR DESCRIPTION
Raises main/mapobj fuzzy match from 98.52% to 98.67%.

## Changes
- **ReadOtmObj hit-array access** (+0.02): `MapMng.GetMapHitArray() + idx` -> `&MapMng.m_mapHitArray[idx]`. Stops mwcc from hoisting the m_mapHitArray base (`MapMng+0x4d4`) into a callee-saved register; it now re-derives off the plain MapMng base each use, matching the target. This collapsed the `stmw r14` vs `stmw r15` off-by-one saved-register window, aligning the whole callee-saved register count.
- **ReadOtmObj VTX inner-loop if->switch** (+0.13): rewrote `if (vtxChunk.m_id == CHUNK_VTX)` as `switch (vtxChunk.m_id) { case CHUNK_VTX: ... }`. mwcc now hoists the 32-bit chunk-id constant (`0x56545820`) into a register and emits `cmpw` against it, matching the sibling chunk-scan loops instead of the inline `subis`/`cmplwi` split.

ReadOtmObj: 96.96% -> 97.41%.

## Remaining (documented walls, not source-steerable)
- ReadOtmObj prologue base-CSE / register-coloring of hoisted MapMng-derived array bases and chunk-id constants.
- sda21 named-float-pool: `kMapObj*` constants emit as anonymous pool entries (`@NNN@sda21`) rather than named `kMapObj*_addr@sda21` symbols (universal across Init/Calc/CheckHitCylinder/ct_CBound).
- SetLink/SetShow_r/CalcMtx pure register-window coloring; Draw stack-slot ordering.

Verified via build/GCCP01/report.json fuzzy_match_percent. Never dropped below baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)