### PR TITLE
memory: raise fuzzy match to 97.5% (cycle 12)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -590,11 +590,11 @@ CMemory::CStage* CMemory::CreateStage(unsigned long size, char* source, int mode
         unsigned int alignedSize = static_cast<unsigned int>(size);
         CMode& modeData = m_modes[mode];
         CStage* stage = modeData.m_freeList.m_next;
-        CStage* list = &modeData.m_activeList;
 
         if (stage == &modeData.m_freeList) {
             System.Printf(const_cast<char*>(strBase + 0x6d4));
         } else {
+            CStage* list = &modeData.m_activeList;
             do {
                 CStage* next = list->m_next;
                 if (static_cast<unsigned int>(list->m_heapBottom) + alignedSize <=

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1115,10 +1115,10 @@ int CMemory::CStage::heapWalker(int flag, void*, unsigned long group)
             int nodeGroup = node->m_defaultParam;
             if ((group == static_cast<unsigned long>(-1)) || (static_cast<unsigned long>(nodeGroup) == group)) {
                 if ((((nodeFlags & 4) != 0) && ((flag & 2) != 0)) || (((nodeFlags & 4) == 0) && ((flag & 1) != 0))) {
-                    const char* kind = ((nodeFlags & 4) != 0) ? sHeapWalkerUsed : sHeapWalkerFree;
-                    unsigned char level = ((nodeFlags & 4) != 0) ? node->m_level : 0;
-                    const char* source = ((nodeFlags & 4) != 0) ? node->m_source : sEmptyAllocSourceName;
                     unsigned short line = ((nodeFlags & 4) != 0) ? node->m_line : 0;
+                    const char* source = ((nodeFlags & 4) != 0) ? node->m_source : sEmptyAllocSourceName;
+                    unsigned char level = ((nodeFlags & 4) != 0) ? node->m_level : 0;
+                    const char* kind = ((nodeFlags & 4) != 0) ? sHeapWalkerUsed : sHeapWalkerFree;
                     int index = ((nodeFlags & 4) != 0) ? usedCount : freeCount;
                     System.Printf(
                         const_cast<char*>(strBase + 0x430), index, kind, level, node->m_size,


### PR DESCRIPTION
Raises main/memory fuzzy match from 97.25% to 97.53%.

## Changes
- **CreateStage**: scope the `m_activeList` walk cursor (`list`) into the else-branch after the empty-free-list check, matching the target's deferred cursor/return-value initialization. 97.30% -> 98.60% on the function.
- **heapWalker**: reorder the per-block Printf-argument ternaries (`line`, `source`, `level`, `kind`, `index`) to match the target's basic-block emission order. 89.75% -> 93.98% on the function.

## Why this is plausible source
Both changes are ordinary source-level reorderings: scoping a local to the branch that uses it, and arranging temporaries in the order the original developer evaluated them. No hacks, no layout changes.

## Evidence
report.json main/memory fuzzy_match_percent: 97.247 -> 97.533.

## Remaining blockers (known walls)
The rest of the unit is dominated by register-window off-by-N shifts (heapWalker/Quit/SetData/AmemFreeLowPrio/AddRef), the freeStageBlock commutative-add and ptr-0x50 fold, the placement-new null-check fold in CAmemCacheSet::Init, the cacheStateName rlwinm mask-width codegen difference, and string/data anchoring (FREE/USED, sStageFreeCorruptBlockFmt) - all confirmed non-source-steerable this cycle (each attempted fix regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)