### PR TITLE
p_graphic: raise fuzzy match to 79.3% (cycle 8)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -226,15 +226,23 @@ void CGraphicPcs::drawScreenFade()
         _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
         _GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
 
-        _GXColor baseColor = slotData->m_colorA;
-        _GXColor baseColor2 = slotData->m_colorB;
-
         float t = (float)slotData->m_timer / (float)slotData->m_duration;
         if (slotData->m_invert != 0) {
             t = kGraphicOne - t;
         }
         const float fadeWave = (float)sin((double)(kScreenFadeHalfPi * t));
         const u8 fadeAlpha = (u8)(kGraphicColorMax * fadeWave);
+
+        _GXColor baseColor;
+        baseColor.r = slotData->m_colorA.r;
+        baseColor.g = slotData->m_colorA.g;
+        baseColor.b = slotData->m_colorA.b;
+        baseColor.a = slotData->m_colorA.a;
+        _GXColor baseColor2;
+        baseColor2.r = slotData->m_colorA.r;
+        baseColor2.g = slotData->m_colorA.g;
+        baseColor2.b = slotData->m_colorA.b;
+        baseColor2.a = slotData->m_colorA.a;
         baseColor.a = fadeAlpha;
         baseColor2.a = fadeAlpha;
 


### PR DESCRIPTION
Raises `main/p_graphic` from 78.77% to 79.28%.

## What changed
`CGraphicPcs::drawScreenFade` now constructs both per-vertex fade colors (`baseColor` and `baseColor2`) by copying the slot's `m_colorA` RGBA bytes individually, then overwriting the alpha channel with the computed fade alpha. This replaces the previous word-wise `_GXColor` struct copies (one from `m_colorA`, one from `m_colorB`).

## Why this is correct source
The target materializes the fade color per-byte (`lbz`/`stb` of each channel) and uses a single source color (`m_colorA`) for both vertex color slots, not two distinct colors. With the byte-wise copy from `m_colorA`, our compiled field loads now resolve to the same offsets as the target (0xc/0xd/0xe/0xf off the slot base) and the store pattern into both color slots matches. This is a behavioral correction (the screen-fade overlay shares one color), not compiler coaxing.

## Evidence
- main/p_graphic fuzzy match: 78.77% -> 79.28%
- drawScreenFade: 59.95% -> 61.1%

## Remaining blocker
drawScreenFade's residual is the documented +2-FPR/+2-GPR callee-saved window shift (ours saves f26-f31/extra GPRs vs the target's f28-f31) plus the `kIntToDoubleBias` anonymous-pool naming/ordering wall - neither source-steerable. The slot==2 circle block-order restructure (goto and inverted-guard forms) was attempted and regressed in both this cycle and cycle 7, so it was reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)