### PR TITLE
p_graphic: raise fuzzy match to 79.5% (cycle 9)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -808,21 +808,20 @@ void CGraphicPcs::drawBar()
             soundGX.g = soundTmp.g;
             soundGX.b = soundTmp.b;
             soundGX.a = soundTmp.a;
-            const u32 soundColor = *reinterpret_cast<u32*>(&soundGX);
             const float soundWidth = (kGraphicScreenCenterX * Sound.GetPerformance()) / kDebugBarFrameBudget;
 
             GXBegin(GX_QUADS, GX_VTXFMT0, 4);
             GXPosition3f32(x, drawText ? static_cast<float>(static_cast<int>(y)) : kDebugBarMoveBottom, kGraphicZero);
-            GXColor1u32(soundColor);
+            GXColor1u32(*reinterpret_cast<u32*>(&soundGX));
             GXTexCoord2u16(0, 0);
             GXPosition3f32(x + soundWidth + kGraphicOne, drawText ? static_cast<float>(static_cast<int>(y)) : kDebugBarMoveBottom, kGraphicZero);
-            GXColor1u32(soundColor);
+            GXColor1u32(*reinterpret_cast<u32*>(&soundGX));
             GXTexCoord2u16(2, 0);
             GXPosition3f32(x + soundWidth + kGraphicOne, kDebugBarTop, kGraphicZero);
-            GXColor1u32(soundColor);
+            GXColor1u32(*reinterpret_cast<u32*>(&soundGX));
             GXTexCoord2u16(2, 2);
             GXPosition3f32(x, kDebugBarTop, kGraphicZero);
-            GXColor1u32(soundColor);
+            GXColor1u32(*reinterpret_cast<u32*>(&soundGX));
             GXTexCoord2u16(0, 2);
         }
 
@@ -838,19 +837,18 @@ void CGraphicPcs::drawBar()
     frameGX.g = frameTmp.g;
     frameGX.b = frameTmp.b;
     frameGX.a = frameTmp.a;
-    const u32 frameColorWord = *reinterpret_cast<u32*>(&frameGX);
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(frameColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
     GXTexCoord2u16(0, 0);
     GXPosition3f32(kDebugIndicatorFrameRight, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(frameColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
     GXTexCoord2u16(2, 0);
     GXPosition3f32(kDebugIndicatorFrameRight, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(frameColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
     GXTexCoord2u16(2, 2);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(frameColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
     GXTexCoord2u16(0, 2);
 
     GXColor fifoTmp;
@@ -860,19 +858,18 @@ void CGraphicPcs::drawBar()
     fifoGX.g = fifoTmp.g;
     fifoGX.b = fifoTmp.b;
     fifoGX.a = fifoTmp.a;
-    const u32 fifoColorWord = *reinterpret_cast<u32*>(&fifoGX);
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(fifoColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
     GXTexCoord2u16(0, 0);
     GXPosition3f32(kDebugIndicatorFifoRight, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(fifoColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
     GXTexCoord2u16(2, 0);
     GXPosition3f32(kDebugIndicatorFifoRight, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(fifoColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
     GXTexCoord2u16(2, 2);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(fifoColorWord);
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
     GXTexCoord2u16(0, 2);
 
     if (drawText) {

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -754,8 +754,8 @@ void CGraphicPcs::drawBar()
     CSystem::COrder* order = System.GetFirstOrder();
     const int orderCount = System.m_orderCount;
     const int lastOrder = orderCount - 1;
-    int hue = 0;
     u32 y = 0x10;
+    int hue = 0;
     for (int i = 0; i < orderCount; i++) {
         const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -837,18 +837,21 @@ void CGraphicPcs::drawBar()
     frameGX.g = frameTmp.g;
     frameGX.b = frameTmp.b;
     frameGX.a = frameTmp.a;
+    GXColor frameGX1 = frameGX;
+    GXColor frameGX2 = frameGX;
+    GXColor frameGX3 = frameGX;
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorTop, kGraphicZero);
     GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
     GXTexCoord2u16(0, 0);
     GXPosition3f32(kDebugIndicatorFrameRight, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX1));
     GXTexCoord2u16(2, 0);
     GXPosition3f32(kDebugIndicatorFrameRight, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX2));
     GXTexCoord2u16(2, 2);
     GXPosition3f32(kDebugBarLeft, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&frameGX));
+    GXColor1u32(*reinterpret_cast<u32*>(&frameGX3));
     GXTexCoord2u16(0, 2);
 
     GXColor fifoTmp;
@@ -858,18 +861,21 @@ void CGraphicPcs::drawBar()
     fifoGX.g = fifoTmp.g;
     fifoGX.b = fifoTmp.b;
     fifoGX.a = fifoTmp.a;
+    GXColor fifoGX1 = fifoGX;
+    GXColor fifoGX2 = fifoGX;
+    GXColor fifoGX3 = fifoGX;
     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorTop, kGraphicZero);
     GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
     GXTexCoord2u16(0, 0);
     GXPosition3f32(kDebugIndicatorFifoRight, kDebugIndicatorTop, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX1));
     GXTexCoord2u16(2, 0);
     GXPosition3f32(kDebugIndicatorFifoRight, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX2));
     GXTexCoord2u16(2, 2);
     GXPosition3f32(kDebugIndicatorFifoLeft, kDebugIndicatorBottom, kGraphicZero);
-    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX));
+    GXColor1u32(*reinterpret_cast<u32*>(&fifoGX3));
     GXTexCoord2u16(0, 2);
 
     if (drawText) {


### PR DESCRIPTION
Raises main/p_graphic fuzzy match from 79.28% to 79.48%.

## What changed (drawBar)
- Inline the `*(u32*)&color` reinterpret at each `GXColor1u32` call site for the frame-rate / fifo / sound quads instead of caching a `u32` word local. Matches the target's per-vertex word materialization.
- Build three per-vertex `GXColor` copies (`frameGX1..3`, `fifoGX1..3`) for the two non-loop indicator quads, reproducing the target's 4-distinct-stack-slot color staging (frame grew 0x330 -> 0x350 toward target 0x360).
- Reorder the `y` / `hue` loop-induction declarations so mwcc colors `y`->r25 and `hue`->r26, matching the target loop's register assignment.

drawBar: 91.14% -> 91.87%.

## Blocker
The remaining drawBar cost is a consistent off-by-one loop register-window shift (r23-r29) feeding the per-iteration color quads; adding the analogous per-vertex copy locals inside the loop reproduces the target's extra stack slots but shifts the loop-carried window further and net-regresses. drawScreenFade (61%) is dominated by the confirmed f26-f31-vs-f28-f31 FPR/GPR-window wall and the kIntToDoubleBias pooled-vs-named-symbol wall; all GX constants and array indices were audited and are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)