### PR TITLE
p_graphic: raise fuzzy match to 80.1% (cycle 10)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -408,19 +408,20 @@ void CGraphicPcs::drawScreenFade()
                     _GXTexObj backTexObj;
                     const int x = (tile & 1) ? 0x140 : 0;
                     const int y = (tile & 2) ? 0xE0 : 0;
-                    const float t0 = ((tile & 2) ? kGraphicOne : kGraphicZero) * kGraphicHalf;
-                    const float t1 = t0 + kGraphicHalf;
+                    const int row = (tile & 2) ? 1 : 0;
 
                     Graphic.GetBackBufferRect2(Graphic.m_scratchTextureBuffer, &backTexObj, x, y, 0x140, 0xE0, 0,
                                                GX_LINEAR, GX_TF_RGBA8, 0);
                     GXLoadTexObj(&backTexObj, GX_TEXMAP0);
 
+                    const float t0 = (float)((double)row * kGraphicHalf);
                     CColor topColor;
                     topColor.color.r = (u8)(t0 * ((float)baseColor2.r - (float)baseColor.r) + (float)baseColor.r);
                     topColor.color.g = (u8)(t0 * ((float)baseColor2.g - (float)baseColor.g) + (float)baseColor.g);
                     topColor.color.b = (u8)(t0 * ((float)baseColor2.b - (float)baseColor.b) + (float)baseColor.b);
                     topColor.color.a = 0xFF;
 
+                    const float t1 = (float)((double)(row + 1) * kGraphicHalf);
                     CColor bottomColor;
                     bottomColor.color.r = (u8)(t1 * ((float)baseColor2.r - (float)baseColor.r) + (float)baseColor.r);
                     bottomColor.color.g = (u8)(t1 * ((float)baseColor2.g - (float)baseColor.g) + (float)baseColor.g);


### PR DESCRIPTION
Raises `main/p_graphic` fuzzy match from 79.48% to 80.15%.

## What changed
`drawScreenFade` slot==1 (mode==4) tile loop: the per-tile vertical lerp factor was cached as two `const float` locals (`t0`, `t1`) computed via `float*float`, which mwcc promoted into a callee-saved FPR (f26), shifting the entire register window by one and producing hundreds of ARG_MISMATCH/INSERT lines. Matched the original by recomputing each factor inline from a signed-int row index times a double half-constant (`(float)((double)row * kGraphicHalf)`), keeping it in a volatile register. This dropped one callee-saved FPR (f26 eliminated) and collapsed the tile-loop INSERT runs.

## Evidence
- Before: 79.48% (f26-f31 = 6 callee FPRs, frame 0x340)
- After: 80.15% (f27-f31 = 5 callee FPRs)
- Verified via build/GCCP01/report.json fuzzy_match_percent.

## Why it's plausible source
The Ghidra reference shows the original recomputes the factor (`fVar1 = (float)((double)(signed int) * 0.5)`) per use in a volatile register and hoists the bias/half/zero double constants before the loop, rather than caching float factors. The change reproduces that structure exactly. Confirmed the slot==0 amp/offX/offY math (m_amplitude/m_stretch usage) matches Ghidra after accounting for its -4 base-pointer offset artifact.

## Remaining blockers (documented walls)
- `kIntToDoubleBias` anonymous-pool naming/ordering: target references `kIntToDoubleBias@sda21`, ours emits `@640`/`@647` .data pool entries for `(float)(int)` conversions in drawBar/drawSFCircle/drawScreenFade. The pinned-address half is not source-steerable.
- drawScreenFade slot==2 trailing-block layout (drawSFCircle call vs inline-rect fall-through ordering).
- +1 callee-FPR window shift (t in f27 vs target f28): an allocation-order artifact; recompute/spill attempts regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)