### PR TITLE
joybus: raise fuzzy match to 93.8% (cycle 20)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1606,6 +1606,172 @@ timeout_expiry:
             break;
         }
 
+        case 0x1E:
+        {
+            unsigned int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
+            if ((int)res < 0)
+            {
+                goto sleep_retry;
+            }
+            if (threadParam->m_skipProcessingFlag != 0 || (res & 1) == 0)
+            {
+                break;
+            }
+            if ((localBuf[0] & 0x3F) != 7)
+            {
+                DecRecvQueue(threadParam->m_portIndex);
+                threadParam->m_state = 'F';
+                GbaQue.ClrStageFlg(threadParam->m_portIndex);
+                break;
+            }
+            threadParam->m_state = 0x1F;
+            memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
+            m_perThreadTemp[threadParam->m_portIndex][0] = 1;
+            DecRecvQueue(threadParam->m_portIndex);
+            if (SendCancel(threadParam) != 0)
+            {
+                threadParam->m_altState = threadParam->m_state;
+                threadParam->m_recvWriteIdx = localWord;
+                threadParam->m_state = 0x84;
+                goto sleep_retry;
+            }
+            break;
+        }
+
+        case 0x1F:
+        {
+            int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
+            if (dataRes == -2)
+            {
+                threadParam->m_state = 3;
+            }
+            if (threadParam->m_skipProcessingFlag == 0 && dataRes == 1)
+            {
+                GbaQue.ClrStageFlg(threadParam->m_portIndex);
+                threadParam->m_state = 'F';
+            }
+
+            break;
+        }
+
+        case 0x21:
+        {
+            int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 &&
+                (int)GbaQue.GetLetterLstFlg(threadParam->m_portIndex) != 0)
+            {
+                threadParam->m_state = 0x22;
+            }
+
+            break;
+        }
+
+        case 0x22:
+        {
+            int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0)
+            {
+                threadParam->m_state = 0x23;
+            }
+
+            break;
+        }
+
+        case 0x23:
+        {
+            int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0)
+            {
+                threadParam->m_state = 0x24;
+                memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
+                m_perThreadTemp[threadParam->m_portIndex][0] = 3;
+                DecRecvQueue(threadParam->m_portIndex);
+                if (SendCancel(threadParam) != 0)
+                {
+                    threadParam->m_altState = threadParam->m_state;
+                    threadParam->m_recvWriteIdx = localWord;
+                    threadParam->m_state = 0x84;
+                    goto sleep_retry;
+                }
+            }
+
+            break;
+        }
+
+        case 0x24:
+        {
+            int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
+            if (dataRes == -2)
+            {
+                threadParam->m_state = 3;
+            }
+            if (threadParam->m_skipProcessingFlag == 0 && dataRes == 1)
+            {
+                threadParam->m_state = 5;
+            }
+
+            break;
+        }
+
+        case 0x25:
+        {
+            int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0 &&
+                (int)GbaQue.GetLetterDatFlg(threadParam->m_portIndex) != 0)
+            {
+                threadParam->m_state = 0x26;
+            }
+
+            break;
+        }
+
+        case 0x26:
+        {
+            int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));
+            if (res >= 0 && threadParam->m_skipProcessingFlag == 0)
+            {
+                threadParam->m_state = '\'';
+                memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
+                m_perThreadTemp[threadParam->m_portIndex][0] = 2;
+                if (SendCancel(threadParam) != 0)
+                {
+                    threadParam->m_altState = threadParam->m_state;
+                    threadParam->m_recvWriteIdx = localWord;
+                    threadParam->m_state = 0x84;
+                    goto sleep_retry;
+                }
+            }
+
+            break;
+        }
+
+        case 0x27:
+        {
+            int dataRes = SendDataFile(threadParam);
+            if (dataRes == -1)
+            {
+                goto sleep_retry;
+            }
+            if (dataRes == -2)
+            {
+                threadParam->m_state = 3;
+            }
+            if (threadParam->m_skipProcessingFlag == 0 && dataRes == 1)
+            {
+                threadParam->m_state = 5;
+            }
+
+            break;
+        }
+
         case 0x29:
         {
             int res = GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -959,14 +959,17 @@ timeout_expiry:
 
             threadParam->m_gbaStatus = GBAReset(threadParam->m_portIndex, &threadParam->m_unk3);
 
-            if ((int)threadParam->m_gbaStatus == 0)
+            if ((int)threadParam->m_gbaStatus != 0)
             {
-                threadParam->m_state    = 2;
-                threadParam->m_subState = 0;
-
-                ThreadSleep(OSMillisecondsToTicks(15));
-                stateStartTime = OSGetTime();
+                goto sleep_retry;
             }
+
+            threadParam->m_state    = 2;
+            threadParam->m_subState = 0;
+
+            ThreadSleep(OSMillisecondsToTicks(15));
+            OSGetTime();
+            threadParam->m_errorRetry = 0;
 
             break;
         }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -890,10 +890,10 @@ timeout_expiry:
             {
                 unsigned char cm = GbaQue.GetControllerMode();
 
-                if (cm == 0)
-                    m_nextModeTypeArr[threadParam->m_portIndex] = 0;
-                else
+                if (cm != 0)
                     m_nextModeTypeArr[threadParam->m_portIndex] = 4;
+                else
+                    m_nextModeTypeArr[threadParam->m_portIndex] = 0;
 
                 threadParam->m_state    = 2;
                 threadParam->m_subState = 0;
@@ -2535,10 +2535,10 @@ timeout_expiry:
             threadParam->m_errorRetry++;
             m_ctrlModeArr[threadParam->m_portIndex] = 0;
 
-            if (GbaQue.GetControllerMode() == 0)
-                m_nextModeTypeArr[threadParam->m_portIndex] = 0;
-            else
+            if (GbaQue.GetControllerMode() != 0)
                 m_nextModeTypeArr[threadParam->m_portIndex] = 4;
+            else
+                m_nextModeTypeArr[threadParam->m_portIndex] = 0;
 
             m_stateFlagArr[threadParam->m_portIndex] = 1;
             m_stateCodeArr[threadParam->m_portIndex] = 0xFF;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -939,16 +939,15 @@ timeout_expiry:
         {
             int result = InitialCode(threadParam);
 
-            if (result == 1)
+            if (result != 1)
             {
-                stateStartTime = OSGetTime();
+                if (result == 2)
+                {
+                    goto sleep_retry;
+                }
+                break;
             }
-            else if (result == 2)
-            {
-                ThreadSleep(OSMillisecondsToTicks(15));
-            }
-
-            break;
+            goto loop_body;
         }
 
         case 0x03:

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1613,24 +1613,24 @@ timeout_expiry:
             {
                 break;
             }
-            if ((localBuf[0] & 0x3F) != 7)
+            if ((localBuf[0] & 0x3F) == 7)
             {
+                threadParam->m_state = 0x1F;
+                memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
+                m_perThreadTemp[threadParam->m_portIndex][0] = 1;
                 DecRecvQueue(threadParam->m_portIndex);
-                threadParam->m_state = 'F';
-                GbaQue.ClrStageFlg(threadParam->m_portIndex);
+                if (SendCancel(threadParam) != 0)
+                {
+                    threadParam->m_altState = threadParam->m_state;
+                    threadParam->m_recvWriteIdx = localWord;
+                    threadParam->m_state = 0x84;
+                    goto sleep_retry;
+                }
                 break;
             }
-            threadParam->m_state = 0x1F;
-            memset(m_perThreadTemp[threadParam->m_portIndex], 0, sizeof(m_perThreadTemp[threadParam->m_portIndex]));
-            m_perThreadTemp[threadParam->m_portIndex][0] = 1;
             DecRecvQueue(threadParam->m_portIndex);
-            if (SendCancel(threadParam) != 0)
-            {
-                threadParam->m_altState = threadParam->m_state;
-                threadParam->m_recvWriteIdx = localWord;
-                threadParam->m_state = 0x84;
-                goto sleep_retry;
-            }
+            threadParam->m_state = 'F';
+            GbaQue.ClrStageFlg(threadParam->m_portIndex);
             break;
         }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2527,7 +2527,47 @@ timeout_expiry:
 
         default:
         {
-            // TODO: add remaining state handling as you decompile them
+            threadParam->m_flags[4] = 0;
+            GbaQue.SetChgUseItemFlg(threadParam->m_portIndex);
+            threadParam->m_sentStartFlag = 0;
+            threadParam->m_flags[1] = 0;
+            threadParam->m_flags[5] = 0;
+            threadParam->m_errorRetry++;
+            m_ctrlModeArr[threadParam->m_portIndex] = 0;
+
+            if (GbaQue.GetControllerMode() == 0)
+                m_nextModeTypeArr[threadParam->m_portIndex] = 0;
+            else
+                m_nextModeTypeArr[threadParam->m_portIndex] = 4;
+
+            m_stateFlagArr[threadParam->m_portIndex] = 1;
+            m_stateCodeArr[threadParam->m_portIndex] = 0xFF;
+
+            if (threadParam->m_errorRetry >= 0xA)
+            {
+                threadParam->m_state = 4;
+                break;
+            }
+
+            if (GetGBAStat(threadParam) != 0)
+            {
+                stateStartTime = OSGetTime();
+                goto sleep_retry;
+            }
+
+            ResetQueue(threadParam);
+
+            if (threadParam->m_prevState > 2)
+            {
+                threadParam->m_state = 3;
+            }
+            else
+            {
+                threadParam->m_subState  = 0;
+                threadParam->m_state     = 1;
+                threadParam->m_prevState = 0;
+            }
+
             break;
         }
         }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -738,32 +738,61 @@ loop_body:
         {
             int s = (unsigned int)threadParam->m_state;
 
-            if ((s >= 0x1D && s <= 0x20))
+            if (s >= 0x17)
             {
-                if (SendCancel(threadParam) < 0)
+                if (s >= 0x384)
                 {
-                    goto sleep_retry;
+                    if (s >= 0x387)
+                        goto do_recvsend;
+                    goto timeout_expiry;
                 }
-                threadParam->m_state = ';';
+                if (s >= 0x21)
+                    goto do_recvsend;
+                if (s >= 0x1D)
+                    goto do_cancel;
+                goto do_recvsend;
+            }
+            else if (s == 6)
+            {
                 goto timeout_expiry;
             }
-            else if (s == 5 || (s >= 7 && s <= 0x13) || (s >= 0x17 && s <= 0x1C) ||
-                     (s >= 0x21 && s <= 0x383) || s >= 0x387)
+            else if (s >= 7)
             {
-                if (GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf)) < 0)
-                {
-                    goto sleep_retry;
-                }
-                if (m_ctrlModeArr[threadParam->m_portIndex] == 0)
-                {
-                    goto recompute_timeout;
-                }
-                if (SendCtrlMode(threadParam, 0) < 0)
-                {
-                    goto sleep_retry;
-                }
+                if (s >= 0x14)
+                    goto timeout_expiry;
+                goto do_recvsend;
+            }
+            else if (s >= 5)
+            {
+                goto do_recvsend;
+            }
+            else
+            {
+                goto timeout_expiry;
+            }
+
+        do_cancel:
+            if (SendCancel(threadParam) < 0)
+            {
+                goto sleep_retry;
+            }
+            threadParam->m_state = ';';
+            goto timeout_expiry;
+
+        do_recvsend:
+            if (GBARecvSend(threadParam, reinterpret_cast<unsigned int*>(localBuf)) < 0)
+            {
+                goto sleep_retry;
+            }
+            if (m_ctrlModeArr[threadParam->m_portIndex] == 0)
+            {
                 goto recompute_timeout;
             }
+            if (SendCtrlMode(threadParam, 0) < 0)
+            {
+                goto sleep_retry;
+            }
+            goto recompute_timeout;
         }
         else
         {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1077,16 +1077,16 @@ timeout_expiry:
             int cmdNumFlg = GbaQue.GetCmdNumFlg(threadParam->m_portIndex);
             if (cmdNumFlg != 0)
             {
-                if ((cmdNumFlg & 2) != 0)
+                if ((cmdNumFlg & 2) == 0)
                 {
-                    threadParam->m_state = 0x17;
+                    if (SendChgCmdNum(threadParam) < 0)
+                    {
+                        goto sleep_retry;
+                    }
+                    GbaQue.ClrCmdNumFlg(threadParam->m_portIndex);
                     goto recompute_timeout;
                 }
-                if (SendChgCmdNum(threadParam) < 0)
-                {
-                    goto sleep_retry;
-                }
-                GbaQue.ClrCmdNumFlg(threadParam->m_portIndex);
+                threadParam->m_state = 0x17;
                 goto recompute_timeout;
             }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -832,14 +832,14 @@ timeout_expiry:
             {
                 threadParam->m_prevState = threadParam->m_state;
 
-                if ((int)threadParam->m_gbaStatus == 3)
-                {
-                    threadParam->m_state = (unsigned char)0x86;
-                }
-                else
+                if ((int)threadParam->m_gbaStatus != 3)
                 {
                     threadParam->m_gbaStatus = 1;
                     threadParam->m_state = (unsigned char)0x85;
+                }
+                else
+                {
+                    threadParam->m_state = (unsigned char)0x86;
                 }
 
                 goto recompute_timeout;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -803,16 +803,9 @@ loop_body:
 
             m_ctrlModeArr[threadParam->m_portIndex] = 0;
 
-            if (Game.m_scriptFoodBase[statusIndex] != 0)
+            if (Game.m_scriptFoodBase[statusIndex] != 0 && threadParam->m_state == 2)
             {
-                if (threadParam->m_state == 2)
-                {
-                    threadParam->m_state = 1;
-                }
-                else
-                {
-                    threadParam->m_state = 0;
-                }
+                threadParam->m_state = 1;
             }
             else
             {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7952,7 +7952,7 @@ void JoyBus::RestartThread()
 {
     m_threadInitFlag = 0;
     CreateInit();
-    int err = 0;
+    int err;
 
     if (static_cast<signed char>(Joybus.m_binLoaded) == 0)
     {
@@ -8034,7 +8034,12 @@ void JoyBus::RestartThread()
             *(unsigned int*)(Joybus.m_gbaBootImage + 200) = OSGetTick();
 
             Joybus.m_binLoaded = 1;
+            err = 0;
         }
+    }
+    else
+    {
+        err = 0;
     }
 
     if (err != 0 && (unsigned int)System.m_execParam > 1)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -919,6 +919,7 @@ timeout_expiry:
                     threadParam->m_subState = 0;
                     ThreadSleep(OSMillisecondsToTicks(15));
                     stateStartTime = OSGetTime();
+                    goto loop_body;
                 }
                 else
                 {


### PR DESCRIPTION
Raises main/joybus from baseline 90.94% to 93.82% by reconstructing missing ThreadMain state-machine case bodies and fixing block ordering.

## What changed (all in ThreadMain, the 12KB anchor: 84.78% -> 96.87%)
- Rebalanced the gamePadState dispatch into a tree matching the target's signed-compare structure.
- Added the previously-absent inner-switch case bodies for states 0x1E-0x27 (GBARecvSend / SendDataFile / SendCancel transition handlers reconstructed from the Ghidra reference and the target asm).
- Implemented the inner-switch `default:` reset/retry body (the SetChgUseItemFlg / GetControllerMode / GetGBAStat error-retry cluster) that was an empty stub — a single 118-instruction missing block.
- Fixed control flow in cases 0x00 (gbaStatus==3 -> loop_body), 0x02 (InitialCode result paths), 0x03 (failure-first + errorRetry), case 0x1E (==7 fall-through ordering), and the cmdNumFlg arm.
- Reordered the timeout-expiry gbaStatus arms and merged the food-state reset into a shared else to match target block emission order.
- Aligned GetControllerMode branch polarity.

## Other
- RestartThread: lazy-init the err result (R18).

All case bodies were cross-referenced against `resources/ghidra-decomp-1-31-2026/800ae3dc_ThreadMain__6JoyBusFPv.c` and the target object, using real GbaQueue/JoyBus method calls and member access — no fake symbols or hardcoded addresses.

Remaining ceiling is the documented OSMillisecondsToTicks/__OSBusClock constant-hoist (2 extra callee-saved regs shifting the whole register window) and the rodata.0 base / result-in-rN ABI walls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)