### PR TITLE
joybus: raise fuzzy match to 93.9% (cycle 21)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7985,7 +7985,6 @@ void JoyBus::RestartThread()
             Joybus.m_gbaBootImage[0xAF] = Joybus.m_diskId[3];
 
             char* p = Joybus.m_gbaBootImage + 0xBC;
-            int left = 1;
 
             unsigned char sum =
                 (signed char)(
@@ -8020,14 +8019,10 @@ void JoyBus::RestartThread()
                     - Joybus.m_gbaBootImage[0xBB])
                 );
 
-            do
+            for (; idx < 0xBD; idx++)
             {
-                unsigned char v = *p++;
-                idx++;
-                sum -= v;
-                left--;
+                sum -= *p++;
             }
-            while (left != 0);
 
             Joybus.m_gbaBootImage[idx] = sum;
 
@@ -8042,7 +8037,7 @@ void JoyBus::RestartThread()
         err = 0;
     }
 
-    if (err != 0 && (unsigned int)System.m_execParam > 1)
+    if (err != 0 && (unsigned int)System.m_execParam >= 2)
 	{
         System.Printf(const_cast<char*>(s_load_bin_error));
 	}
@@ -8052,36 +8047,27 @@ void JoyBus::RestartThread()
     Joybus.m_threadInitFlag = 0;
     Joybus.m_threadRunningMask = 0;
 
-    JoyBus* jbA = &Joybus;
-    JoyBus* jbB = &Joybus;
-
     for (int i = 0; i < 4; i++)
     {
-        jbB->m_threadParams[i].m_portIndex = i;
-        jbB->m_threadParams[i].m_gbaStatus = 1;
-
-        unsigned char* stackBase = (unsigned char*)m_sendBuffer;
+        Joybus.m_threadParams[i].m_portIndex = i;
+        Joybus.m_threadParams[i].m_gbaStatus = 1;
 
         OSCreateThread(
-            &jbA->m_threads[i],
+            &Joybus.m_threads[i],
             (void* (*)(void*))JoyBus::_ThreadMain,
-            &jbB->m_threadParams[i],
-            stackBase,
-            sizeof(jbA->m_sendBuffer[0]),
+            &Joybus.m_threadParams[i],
+            &Joybus.m_sendBuffer[i + 1],
+            sizeof(Joybus.m_sendBuffer[0]),
             8,
             1
         );
 
-        OSResumeThread(&jbA->m_threads[0]);
+        OSResumeThread(&Joybus.m_threads[i]);
 
-        Joybus.m_threadRunningMask |= (unsigned char)(1 << i);
-
-        jbA = (JoyBus*)(jbA->m_recvBuffer[0].m_payload + 0x290);
-        jbB = (JoyBus*)(jbB->m_pathBuf + 0x3C);
-
+        Joybus.m_threadRunningMask |= (1 << i);
     }
 
-    if ((unsigned int)System.m_execParam > 1)
+    if ((unsigned int)System.m_execParam >= 2)
         System.Printf(const_cast<char*>(s_thread_init_end));
 }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7988,39 +7988,40 @@ void JoyBus::RestartThread()
             Joybus.m_gbaBootImage[0xAE] = Joybus.m_diskId[2];
             Joybus.m_gbaBootImage[0xAF] = Joybus.m_diskId[3];
 
-            char* p = Joybus.m_gbaBootImage + 0xBC;
+            unsigned char* img = (unsigned char*)Joybus.m_gbaBootImage;
+            unsigned char* p = img + 0xBC;
 
-            unsigned char sum =
-                (signed char)(
+            int sum =
+                (
                     ((((((((((((((((((((((((((((-0x19
-                    - Joybus.m_gbaBootImage[0xA0])
-                    - Joybus.m_gbaBootImage[0xA1])
-                    - Joybus.m_gbaBootImage[0xA2])
-                    - Joybus.m_gbaBootImage[0xA3])
-                    - Joybus.m_gbaBootImage[0xA4])
-                    - Joybus.m_gbaBootImage[0xA5])
-                    - Joybus.m_gbaBootImage[0xA6])
-                    - Joybus.m_gbaBootImage[0xA7])
-                    - Joybus.m_gbaBootImage[0xA8])
-                    - Joybus.m_gbaBootImage[0xA9])
-                    - Joybus.m_gbaBootImage[0xAA])
-                    - Joybus.m_gbaBootImage[0xAB])
-                    - Joybus.m_gbaBootImage[0xAC])
-                    - Joybus.m_gbaBootImage[0xAD])
-                    - Joybus.m_gbaBootImage[0xAE])
-                    - Joybus.m_gbaBootImage[0xAF])
-                    - Joybus.m_gbaBootImage[0xB0])
-                    - Joybus.m_gbaBootImage[0xB1])
-                    - Joybus.m_gbaBootImage[0xB2])
-                    - Joybus.m_gbaBootImage[0xB3])
-                    - Joybus.m_gbaBootImage[0xB4])
-                    - Joybus.m_gbaBootImage[0xB5])
-                    - Joybus.m_gbaBootImage[0xB6])
-                    - Joybus.m_gbaBootImage[0xB7])
-                    - Joybus.m_gbaBootImage[0xB8])
-                    - Joybus.m_gbaBootImage[0xB9])
-                    - Joybus.m_gbaBootImage[0xBA])
-                    - Joybus.m_gbaBootImage[0xBB])
+                    - img[0xA0])
+                    - img[0xA1])
+                    - img[0xA2])
+                    - img[0xA3])
+                    - img[0xA4])
+                    - img[0xA5])
+                    - img[0xA6])
+                    - img[0xA7])
+                    - img[0xA8])
+                    - img[0xA9])
+                    - img[0xAA])
+                    - img[0xAB])
+                    - img[0xAC])
+                    - img[0xAD])
+                    - img[0xAE])
+                    - img[0xAF])
+                    - img[0xB0])
+                    - img[0xB1])
+                    - img[0xB2])
+                    - img[0xB3])
+                    - img[0xB4])
+                    - img[0xB5])
+                    - img[0xB6])
+                    - img[0xB7])
+                    - img[0xB8])
+                    - img[0xB9])
+                    - img[0xBA])
+                    - img[0xBB])
                 );
 
             for (; idx < 0xBD; idx++)
@@ -8028,7 +8029,7 @@ void JoyBus::RestartThread()
                 sum -= *p++;
             }
 
-            Joybus.m_gbaBootImage[idx] = sum;
+            img[idx] = (unsigned char)sum;
 
             *(unsigned int*)(Joybus.m_gbaBootImage + 200) = OSGetTick();
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5673,7 +5673,7 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
 
         if (result == 0)
         {
-            if (m_threadRunningMask == 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
             {
                 result = 0;
             }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4201,7 +4201,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             localBytes[1] = sendType;
             *reinterpret_cast<unsigned short*>(localBytes + 2) = __lhbrx(&blockHalf, 0);
 
-            if (m_threadRunningMask == 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
             {
                 result = 0;
             }
@@ -4236,7 +4236,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             unsigned short len = totalSize;
             *reinterpret_cast<unsigned short*>(localBytes + 2) = __lhbrx(&len, 0);
 
-            if (m_threadRunningMask != 0)
+            if (static_cast<signed char>(m_threadRunningMask) != 0)
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4269,7 +4269,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
             *reinterpret_cast<unsigned short*>(localBytes + 2) = crcChunk;
 
-            if (m_threadRunningMask != 0)
+            if (static_cast<signed char>(m_threadRunningMask) != 0)
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4333,7 +4333,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
             unsigned int word = localWord;
 
-            if (m_threadRunningMask == 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
             {
                 result = 0;
             }
@@ -4375,7 +4375,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
                 (static_cast<unsigned int>(blockIndex) << 16) |
                 static_cast<unsigned int>(crcChunk);
 
-            if (m_threadRunningMask == 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
             {
                 result = 0;
             }
@@ -4418,7 +4418,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
         unsigned int word = localWord;
 
-        if (m_threadRunningMask != 0)
+        if (static_cast<signed char>(m_threadRunningMask) != 0)
         {
             localWord = word;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7954,7 +7954,11 @@ void JoyBus::RestartThread()
     CreateInit();
     int err;
 
-    if (static_cast<signed char>(Joybus.m_binLoaded) == 0)
+    if (static_cast<signed char>(Joybus.m_binLoaded) != 0)
+    {
+        err = 0;
+    }
+    else
     {
         CFile::CHandle* file = File.Open((char*)&Joybus, 0, CFile::PRI_LOW);
 
@@ -8031,10 +8035,6 @@ void JoyBus::RestartThread()
             Joybus.m_binLoaded = 1;
             err = 0;
         }
-    }
-    else
-    {
-        err = 0;
     }
 
     if (err != 0 && (unsigned int)System.m_execParam >= 2)


### PR DESCRIPTION
Raises main/joybus fuzzy match from 93.82% to 93.94% via source-level matching of RestartThread and the running-mask command guards.

## What changed
- **RestartThread (81.7 -> 86.3):**
  - Thread-creation loop rewritten to index a fixed `&Joybus` base (`m_threadParams[i]`, `m_threads[i]`, `&m_sendBuffer[i+1]`) instead of two extra advancing `jbA`/`jbB` cursors. This collapses three extra callee-saved GPRs, matching the target frame (`stmw r26`, `stwu -0x20`).
  - `System.m_execParam > 1` -> `>= 2` boundary correction (matches `cmplwi 0x2; blt`).
  - Dropped the spurious `(unsigned char)` cast on `m_threadRunningMask |= (1 << i)` (matches the target's direct `or`).
  - Inverted the `m_binLoaded` guard so the already-loaded (`err = 0`) arm is emitted first, matching the target's `beq load` + fall-through-to-skip block order.
  - Checksum accumulator widened to `int` to match the target's full-word `subf` chain.
- **SendDataFile (80.6 -> 81.3):** added the missing `static_cast<signed char>` on six `m_threadRunningMask` comparisons (matches the target's `extsb.` rather than `cmplwi`).
- **SendMapObjDrawFlg (86.7 -> 87.0):** same signed-char cast on its running-mask check.

## Evidence
report.json fuzzy_match_percent for main/joybus: 93.81845 -> 93.93933.

## Why this is plausible source
`m_threadRunningMask` is a `uchar` flag that the shipped code consistently tests as a signed char (Ghidra shows `!= '\0'`); the casts make all the sibling checks consistent. The thread-loop indexing and inverted guard match the original control-flow/register shape exactly. No hacks, no hardcoded addresses, no layout changes.

## Remaining blockers (confirmed walls)
SendDataFile / GBARecvSend / the Send*/Set* command family are dominated by the result-in-rN-vs-r3 ABI pattern (return value held in a scratch GPR then `mr r3,rN`), the `s_dvd_gba_dir`-anchored rodata base vs our merged `...rodata.0` base, the GBARecvSend opcode range-collapse, and MakeJoyData's CTR-vs-decrement copy loop. These are not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)