### PR TITLE
joybus: raise fuzzy match to 94.2% (cycle 22)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4060,9 +4060,11 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
         ResetQueue(threadParam);
 
-        result = 0;
-
-        if (static_cast<signed char>(m_threadRunningMask) != 0)
+        if (static_cast<signed char>(m_threadRunningMask) == 0)
+        {
+            result = 0;
+        }
+        else
         {
             OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4244,7 +4246,11 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             unsigned short len = totalSize;
             *reinterpret_cast<unsigned short*>(localBytes + 2) = __lhbrx(&len, 0);
 
-            if (static_cast<signed char>(m_threadRunningMask) != 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
+            {
+                result = 0;
+            }
+            else
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4277,7 +4283,11 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
             *reinterpret_cast<unsigned short*>(localBytes + 2) = crcChunk;
 
-            if (static_cast<signed char>(m_threadRunningMask) != 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
+            {
+                result = 0;
+            }
+            else
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4426,7 +4436,11 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
         unsigned int word = localWord;
 
-        if (static_cast<signed char>(m_threadRunningMask) != 0)
+        if (static_cast<signed char>(m_threadRunningMask) == 0)
+        {
+            result = 0;
+        }
+        else
         {
             localWord = word;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4474,9 +4474,13 @@ int JoyBus::SendMBase(ThreadParam* threadParam)
     cmdBytes[0] = 0x0F;
     *reinterpret_cast<unsigned short*>(cmdBytes + 2) = __lhbrx(&posX, 0);
     unsigned int word = cmd;
-    int result = 0;
+    int result;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4505,7 +4509,11 @@ int JoyBus::SendMBase(ThreadParam* threadParam)
     *reinterpret_cast<unsigned short*>(cmdBytes + 2) = __lhbrx(&posY, 0);
     word = cmd;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7847,7 +7847,11 @@ int JoyBus::SetMoney(int portIndex, unsigned int money)
 		cmdBytes[3] = money >> 16;
 		unsigned int word = cmd;
 
-		if (static_cast<signed char>(m_threadRunningMask) != 0)
+		if (static_cast<signed char>(m_threadRunningMask) == 0)
+		{
+			result = 0;
+		}
+		else
 		{
 
 			OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
@@ -7879,7 +7883,11 @@ int JoyBus::SetMoney(int portIndex, unsigned int money)
 		cmdBytes[2] = money;
 		unsigned int word = cmd;
 
-		if (static_cast<signed char>(m_threadRunningMask) != 0)
+		if (static_cast<signed char>(m_threadRunningMask) == 0)
+		{
+			result = 0;
+		}
+		else
 		{
 
 			OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5646,7 +5646,7 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
         cmdBytes[5] = crcBytes[1];
         cmdBytes[6] = crcBytes[2];
         cmdBytes[7] = crcBytes[3];
-        unsigned int cmd1 = cmds[0];
+        unsigned int cmd = cmds[0];
 
         if (static_cast<signed char>(m_threadRunningMask) == 0)
         {
@@ -5664,7 +5664,7 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
             }
             else
             {
-                m_cmdQueueData[port][m_cmdCount[port]] = cmd1;
+                m_cmdQueueData[port][m_cmdCount[port]] = cmd;
                 m_cmdCount[threadParam->m_portIndex]++;
                 OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
                 result = 0;
@@ -5673,6 +5673,8 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
 
         if (result == 0)
         {
+            cmd = cmds[1];
+
             if (static_cast<signed char>(m_threadRunningMask) == 0)
             {
                 result = 0;
@@ -5689,7 +5691,7 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
                 }
                 else
                 {
-                    m_cmdQueueData[port][m_cmdCount[port]] = cmds[1];
+                    m_cmdQueueData[port][m_cmdCount[port]] = cmd;
                     m_cmdCount[threadParam->m_portIndex]++;
                     OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
                     result = 0;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4659,7 +4659,11 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         {
             unsigned int word = *wordPtr;
 
-            if (static_cast<signed char>(m_threadRunningMask) != 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
+            {
+                result = 0;
+            }
+            else
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4733,7 +4737,11 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         {
             unsigned int word = *wordPtr;
 
-            if (static_cast<signed char>(m_threadRunningMask) != 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
+            {
+                result = 0;
+            }
+            else
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -4807,7 +4815,11 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         {
             unsigned int word = *wordPtr;
 
-            if (static_cast<signed char>(m_threadRunningMask) != 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
+            {
+                result = 0;
+            }
+            else
             {
                 OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4557,9 +4557,13 @@ int JoyBus::SendMapNo(ThreadParam* threadParam)
     cmdBytes[3] = stageMinor[3];
     unsigned int queueCmd = cmd;
 
-    unsigned int result = 0;
+    unsigned int result;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5766,14 +5766,17 @@ int JoyBus::SendFavorite(ThreadParam* threadParam)
                 return wordCount;
             }
 
-            result = 0;
             m_txWordCount[threadParam->m_portIndex] = wordCount;
             m_txWordIndex[threadParam->m_portIndex] = 0;
 
             unsigned int port = threadParam->m_portIndex;
             unsigned int word = *(unsigned int*)&m_joyDataPacketBuffer[port][2 + m_txWordIndex[port] * 4];
 
-            if (static_cast<signed char>(m_threadRunningMask) != 0)
+            if (static_cast<signed char>(m_threadRunningMask) == 0)
+            {
+                result = 0;
+            }
+            else
             {
                 OSWaitSemaphore(&m_accessSemaphores[port]);
 
@@ -5794,7 +5797,7 @@ int JoyBus::SendFavorite(ThreadParam* threadParam)
             }
 
             threadParam->m_subState = (unsigned char)(threadParam->m_subState + 1);
-        
+
         break;
     }
     case 1:
@@ -5936,9 +5939,13 @@ int JoyBus::SendMType(ThreadParam* threadParam, int modeType)
     cmd0Bytes[0] = 0x10;
     unsigned int word0 = cmd0;
 
-    int result = 0;
+    int result;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -5969,7 +5976,11 @@ int JoyBus::SendMType(ThreadParam* threadParam, int modeType)
     cmdBytes[1] = static_cast<unsigned char>(modeType);
     unsigned int word = cmd;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -7309,9 +7320,13 @@ int JoyBus::ChgCtrlMode(int portIndex)
     wordBytes[0] = 0x09;
     wordBytes[1] = mode;
     unsigned int wordCache = word;
-    int ret = 0;
+    int ret;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        ret = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3833,9 +3833,13 @@ int JoyBus::SendGBAStart(ThreadParam* threadParam, unsigned int* outCmd)
     *outCmd = cmd;
     unsigned int word = cmd;
 
-    int result = 0;
+    int result;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 
@@ -3875,9 +3879,13 @@ int JoyBus::SendGBAStop(ThreadParam* threadParam)
     cmdBytes[1] = 0;
     unsigned int word = cmd;
 
-    int result = 0;
+    int result;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5575,9 +5575,13 @@ int JoyBus::SendCtrlMode(ThreadParam* threadParam, int controlMode)
     cmdBytes[0] = 9;
     cmdBytes[1] = modeByte;
     unsigned int cmdWord = cmd;
-    int result = 0;
+    int result;
 
-    if (static_cast<signed char>(m_threadRunningMask) != 0)
+    if (static_cast<signed char>(m_threadRunningMask) == 0)
+    {
+        result = 0;
+    }
+    else
     {
         OSWaitSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4469,11 +4469,11 @@ int JoyBus::SendMBase(ThreadParam* threadParam)
 
     GbaQue.GetMBasePos(threadParam->m_portIndex, &posX, &posY);
 
-    unsigned int cmdX = 0;
-    unsigned char* cmdXBytes = reinterpret_cast<unsigned char*>(&cmdX);
-    cmdXBytes[0] = 0x0F;
-    *reinterpret_cast<unsigned short*>(cmdXBytes + 2) = __lhbrx(&posX, 0);
-    unsigned int wordX = cmdX;
+    unsigned int cmd = 0;
+    unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
+    cmdBytes[0] = 0x0F;
+    *reinterpret_cast<unsigned short*>(cmdBytes + 2) = __lhbrx(&posX, 0);
+    unsigned int word = cmd;
     int result = 0;
 
     if (static_cast<signed char>(m_threadRunningMask) != 0)
@@ -4488,7 +4488,7 @@ int JoyBus::SendMBase(ThreadParam* threadParam)
         }
         else
         {
-            m_cmdQueueData[queuePort][m_cmdCount[queuePort]] = wordX;
+            m_cmdQueueData[queuePort][m_cmdCount[queuePort]] = word;
             m_cmdCount[threadParam->m_portIndex]++;
             OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
             result = 0;
@@ -4500,11 +4500,10 @@ int JoyBus::SendMBase(ThreadParam* threadParam)
         return -1;
 	}
 
-    unsigned int cmdY = 0;
-    unsigned char* cmdYBytes = reinterpret_cast<unsigned char*>(&cmdY);
-    cmdYBytes[0] = 0x4F;
-    *reinterpret_cast<unsigned short*>(cmdYBytes + 2) = __lhbrx(&posY, 0);
-    unsigned int wordY = cmdY;
+    cmd = 0;
+    cmdBytes[0] = 0x4F;
+    *reinterpret_cast<unsigned short*>(cmdBytes + 2) = __lhbrx(&posY, 0);
+    word = cmd;
 
     if (static_cast<signed char>(m_threadRunningMask) != 0)
     {
@@ -4518,7 +4517,7 @@ int JoyBus::SendMBase(ThreadParam* threadParam)
         }
         else
         {
-            m_cmdQueueData[queuePort][m_cmdCount[queuePort]] = wordY;
+            m_cmdQueueData[queuePort][m_cmdCount[queuePort]] = word;
             m_cmdCount[threadParam->m_portIndex]++;
             OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
             result = 0;


### PR DESCRIPTION
## Summary
Raises `main/joybus` fuzzy match from **93.94%** to **94.19%** by attacking the command-send family's control-flow shape.

The dominant lever this cycle was **R7/R18 failure-arm-first** (`if (mask != 0) { body }` → `if (mask == 0) { result = 0; } else { body }`). The target's `bl`-queue helpers consistently emit a `bne body; b skip` two-branch sequence with the failure (`result = 0`) arm placed first; our `if (mask != 0)` form emitted a single `beq skip` fall-through, producing block-order (`DIFF_OP_MISMATCH`) divergences. Restructuring to failure-arm-first matched the target's basic-block emission order.

Also matched **SendMBase frame size** (0x30 → 0x20) by merging the redundant `cmdX`/`cmdY`/`wordX`/`wordY` locals into single reused `cmd`/`word` variables, and reused a single `cmd` local across the two send blocks in **SendMapObjDrawFlg**.

## Per-function gains
- SendCtrlMode: 95.75 → **100.0** (fn now fully matched; matched_functions 42→43)
- ChgCtrlMode: 94.29 → 99.01
- SendFavorite: 95.06 → 97.46
- SetMoney: 92.31 → 96.74
- SendMapNo: 89.07 → 95.78
- SendMType: 95.10 → 96.00
- SendGBAStop: 94.92 → 96.64
- SendMBase: 97.07 → ~99 (frame + branch layout)
- SendPpos: 89.07 → 90.66
- SendGBAStart, SendDataFile: smaller gains from the same lever

## Why this is plausible source
The failure-arm-first / lazy-result-init idiom (`int result; if (notRunning) result = 0; else { ... }`) is ordinary hand-written C and behavior-identical to the prior form (the empty arm only ever sets the already-zero result). Merging duplicate per-axis command locals into one reused local is a natural way the original would have written the two-command senders.

## Blockers (not source-steerable)
Remaining sub-95% functions are walled by documented issues: result-held-in-rN-vs-r3 ABI + constant-CSE (Send*/Set* return family), the `s_dvd_gba_dir`/`...rodata.0` string-base anchoring (RestartThread/CreateInit/LoadBin), the GBA-header checksum's single-accumulator coloring + CTR-loop scheduling (RestartThread/LoadBin), and register-window allocation in the init loops (CreateInit/Destroy). SendDataFile/GBARecvSend retain deep structural divergences beyond the easy levers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)