### PR TITLE
cmake: raise fuzzy match to 89.2% (cycle 22)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3406,11 +3406,12 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
     if (yesNoSel != 0) {
         _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
         MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-        col.r = 0xFF;
-        col.g = 0xFF;
-        col.b = 0xFF;
-        col.a = static_cast<unsigned char>(static_cast<int>(alpha255));
-        GXSetChanMatColor(GX_COLOR0A0, col);
+        GXColor col2;
+        col2.r = 0xFF;
+        col2.g = 0xFF;
+        col2.b = 0xFF;
+        col2.a = static_cast<unsigned char>(static_cast<int>(alpha255));
+        GXSetChanMatColor(GX_COLOR0A0, col2);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x64 : 0x3D));
         MenuPcs.DrawRect(
             0, 516.0f, 360.0f, 48.0f, 48.0f,

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -623,6 +623,7 @@ void CMenuPcs::calcVillageMenu()
     if (active != 0) {
         if (MenuU8(this, 0x16) == 0) {
             if (active != 0) {
+              if (active != 0) {
                 if (Game.m_gameWork.m_menuStageMode == 0) {
                     CFont*& font = m_fonts[CMAKE_FONT_VILLAGE];
                     if (font != 0) {
@@ -638,6 +639,7 @@ void CMenuPcs::calcVillageMenu()
                     villageWork = nullptr;
                 }
                 CmakeResult(this) = 0;
+              }
             }
         } else {
             CmakeMenuState* villageWork = CmakeVillageState(this);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3106,8 +3106,7 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     const char* yesStr = GetMenuStr(1);
     float yesW = static_cast<float>(font->GetWidth(yesStr));
     int yesX = static_cast<int>(
-        (static_cast<float>(static_cast<double>(48.0f) - static_cast<double>(yesW)) * 0.5f) +
-        0x1D0);
+        (48.0f - yesW) * 0.5f + static_cast<float>(0x1D0));
     font->SetPosX(static_cast<float>(yesX));
     font->SetPosY(369.0f);
     font->Draw(yesStr);
@@ -3115,8 +3114,7 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     const char* noStr = GetMenuStr(2);
     float noW = static_cast<float>(font->GetWidth(noStr));
     int noX = static_cast<int>(
-        (static_cast<float>(static_cast<double>(48.0f) - static_cast<double>(noW)) * 0.5f) +
-        0x218);
+        (48.0f - noW) * 0.5f + static_cast<float>(0x218));
     font->SetPosX(static_cast<float>(noX));
     font->SetPosY(369.0f);
     font->Draw(noStr);


### PR DESCRIPTION
Raises main/cmake fuzzy match from 89.11% to 89.16%.

## Changes
- **calcVillageMenu** (98.41 -> 99.79): Added the redundant nested `if (active != 0)` guard the target emits as a doubled `extsh./beq` before the destroy block. The original re-tested the cached result short three times; mwcc did not fold the third test.
- **DrawCmakeDecision** (88.5 -> 88.52): Gave the second GXColor block its own local instead of reusing one `col`, matching the target's separate stack slot.
- **DrawCmakeYesNo** (90.56 -> 91.13): Rewrote the yes/no label X positions from the double-precision `(double)(48 - w) * 0.5 + 0xNNN` form to the single-precision `(48.0f - w) * 0.5f + (float)0xNNN` form, producing the target's `fsubs` + `fmadds` (single FMA) with the constant offset converted via the int->float magic-double, instead of `fsub`/`frsp` and an integer add.

## Why plausible
All three are ordinary source idioms (an extra guard test, a fresh color struct per draw, single-precision float arithmetic). No hardcoded addresses, vtables, or layout hacks.

## Blockers (documented walls, not source-steerable)
The remaining diffs are dominated by: pad-read `__cntlzw` r0/r3/r4 register coloring across all Ctrl functions; magic-double int<->float plus anonymous float-pool ordering (`@NNN` vs named `FLOAT_`/`DOUBLE_` sda21 symbols) across all Draw functions; and the alpha-fade f30/f31 callee-saved FPR window. Several targeted attempts (frame-Y int reconstruction in DrawDiaryBase, address reassociation in CalcSingleCMakeChara, sign-fold in DrawCmakeTitle, signed pad-input casts) each matched an opcode but net-regressed the byte aligner and were reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)