### PR TITLE
p_graphic: raise fuzzy match to 80.2% (cycle 12)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -414,14 +414,14 @@ void CGraphicPcs::drawScreenFade()
                                                GX_LINEAR, GX_TF_RGBA8, 0);
                     GXLoadTexObj(&backTexObj, GX_TEXMAP0);
 
-                    const float t0 = (float)((double)row * kGraphicHalf);
+                    const float t0 = (float)row * kGraphicHalf;
                     CColor topColor;
                     topColor.color.r = (u8)(t0 * ((float)baseColor2.r - (float)baseColor.r) + (float)baseColor.r);
                     topColor.color.g = (u8)(t0 * ((float)baseColor2.g - (float)baseColor.g) + (float)baseColor.g);
                     topColor.color.b = (u8)(t0 * ((float)baseColor2.b - (float)baseColor.b) + (float)baseColor.b);
                     topColor.color.a = 0xFF;
 
-                    const float t1 = (float)((double)(row + 1) * kGraphicHalf);
+                    const float t1 = (float)(row + 1) * kGraphicHalf;
                     CColor bottomColor;
                     bottomColor.color.r = (u8)(t1 * ((float)baseColor2.r - (float)baseColor.r) + (float)baseColor.r);
                     bottomColor.color.g = (u8)(t1 * ((float)baseColor2.g - (float)baseColor.g) + (float)baseColor.g);


### PR DESCRIPTION
## Summary
Raises main/p_graphic from 80.15% to 80.17% by correcting double-precision intermediate math to single-precision in drawScreenFade's per-row color interpolation.

## What changed
In `CGraphicPcs::drawScreenFade()`, the slot==1 mode==4 tiled-color path computed the row interpolation factors as `(float)((double)row * kGraphicHalf)`. Rewriting these as single-precision `(float)row * kGraphicHalf` produces the target's `fmuls` (single multiply) instead of `fmul`+`frsp` (double multiply then narrow), matching the original codegen.

- drawScreenFade: 62.77% -> 62.82%

## Why this is plausible source
`kGraphicHalf` is a `const float`; the original developers would naturally have written the interpolation in single precision. The decompiler-style double widening was a transcription artifact, not the original arithmetic.

## Remaining blockers (not source-steerable)
The two lowest functions (drawScreenFade 62.8%, drawBar 91.9%) are dominated by known walls:
- `kIntToDoubleBias` is referenced as an anonymous `@640` constant-pool double in our output vs the target's named sdata2 symbol; this caps the f27 callee-saved FPR window and shifts the entire register/stack-offset window (every store offset is uniformly off, generating hundreds of ARG_MISMATCH lines).
- drawBar has a uniform 0x10 frame-size delta plus a loop-local register permutation that resists declaration reordering (every tested reorder regressed).
- drawScreenFade's slot==2 trailing-block layout differs in physical block order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)