### PR TITLE
materialman: raise fuzzy match to 98.7% (cycle 12)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -3322,6 +3322,7 @@ void CMaterialSet::SetTextureSet(CTextureSet* textureSet)
             } else {
                 for (int i = 0; i < material->m_textureCount; i++) {
                     ReleaseRef(material->m_textureData.m_textures[i]);
+                    material->m_textureData.m_textures[i] = 0;
 
                     unsigned long textureIndex = static_cast<unsigned long>(material->m_textureIndices[i]);
                     if ((textureSet != 0) &&


### PR DESCRIPTION
## Summary
Raises `main/materialman` fuzzy match from 98.7254% to 98.7425%.

### What changed
- **CMaterialSet::SetTextureSet** (97.86% -> higher): the original zeroes each texture slot (`m_textureData.m_textures[i] = 0`) UNCONDITIONALLY at the top of the per-texture loop body, before the `textureSet != 0` null-check, in addition to the else-branch zero. The decompiled source only zeroed in the else branch, producing a DELETE/INSERT control-flow divergence. Restoring the unconditional top-of-body zero matches the target's basic-block order.

### Evidence
- Before: 98.7254% / After: 98.7425% (report.json fuzzy_match_percent).
- SetTextureSet: the DELETE run for `li r0,0; stw r0,0x3c(rN); beq` at loop top is eliminated.

### Why this is plausible source
Pre-clearing an output slot before conditionally filling it is a standard defensive idiom; the code already had the else-branch clear, and the original simply did the clear up front as well.

### Blocked (documented walls, net-negative on attempt)
- GetCharaShadow: extra callee-saved GPR (ours stmw r17 vs target r18) from a redundant shadowMtxOut base/cursor; outputOffset/outputCount merge matches the frame but regresses the body addressing (target shares one byte-offset `stwx` index across both output paths).
- SetMaterialPart / SetMaterialMenu: target saves one extra GPR for `tevBit = m_curEnvTevBit & material->m_tevBit`; register-window only, not source-steerable. SetMaterialPart 3-way vtxDesc-dispatch reconstruction regressed.
- Calc: named kTextureOne/kTextureZero symbols match but introduce f1/f2 register-window shifts that net-regress.
- addtev_bump_st: branchless-ternary lowering wall.