### PR TITLE
joybus: raise fuzzy match to 94.3% (cycle 23)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4088,16 +4088,17 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             }
         }
 
-        const unsigned int typeVal = static_cast<char>(sendType);
-        const int respVal = static_cast<signed char>(localBytes[1]);
-
         if (result != 0)
         {
+            unsigned int typeVal = static_cast<char>(sendType);
+            int respVal = localBytes[1];
             int diffMask = ((typeVal - respVal) | (respVal - typeVal)) >> 31;
-            return -2 - diffMask;
+            return diffMask - 2;
         }
 
-        int diffMask = ((respVal - typeVal) | (typeVal - respVal)) >> 31;
+        int signedType = static_cast<signed char>(sendType);
+        int respVal = localBytes[1];
+        int diffMask = ((respVal - signedType) | (signedType - respVal)) >> 31;
         return diffMask - 1;
     }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3664,7 +3664,7 @@ case4_done:
 
             unsigned char portVal = singleMode2 ? 0 : (unsigned char)threadParam->m_portIndex;
             unsigned char header = 1;
-            signed char flags = (unsigned char)(portVal | (threadParam->m_gbaBootFlag << 6) | (threadParam->m_unk2 << 4));
+            unsigned char flags = (unsigned char)(portVal | (threadParam->m_gbaBootFlag << 6) | (threadParam->m_unk2 << 4));
             unsigned int word = (1u << 24) | ((unsigned int)flags << 16);
 
             threadParam->m_gbaStatus = GBAWrite(threadParam->m_portIndex, reinterpret_cast<unsigned char*>(&word), &threadParam->m_unk3);
@@ -3700,7 +3700,7 @@ case5_done:
         GbaQue.GetStageNo(threadParam->m_portIndex, &stageMajor, &stageMinor);
 
         unsigned int cmdStage = MakeJoyCmd32(0x0E, 1, ((unsigned char*)&stageMajor)[3], ((unsigned char*)&stageMinor)[3]);
-        int stageResult = 0;
+        unsigned int stageResult = 0;
 
         if (static_cast<signed char>(m_threadRunningMask) == 0)
         {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5008,7 +5008,7 @@ int JoyBus::MakeJoyData(char* src, int length, unsigned int* outBuffer)
  */
 int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 {
-    unsigned int result;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7653,7 +7653,7 @@ int JoyBus::SendResult(int portIndex, int param3, int param4, int param5)
 {
     unsigned char a = static_cast<signed char>(param4);
     unsigned char b = static_cast<unsigned char>(param5);
-    unsigned char firstByte = static_cast<unsigned char>(7 - (param3 == 0));
+    signed char firstByte = static_cast<unsigned char>(7 - (param3 == 0));
 
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4102,7 +4102,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
         return diffMask - 1;
     }
 
-    if ((int)static_cast<signed char>(localBytes[1]) == (int)static_cast<char>(sendType))
+    if ((int)localBytes[1] == (int)static_cast<signed char>(sendType))
     {
         step = 0;
         phase = 1;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4096,9 +4096,9 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             return diffMask - 2;
         }
 
-        int signedType = static_cast<signed char>(sendType);
+        int typeVal = static_cast<unsigned char>(sendType);
         int respVal = localBytes[1];
-        int diffMask = ((respVal - signedType) | (signedType - respVal)) >> 31;
+        int diffMask = ((respVal - typeVal) | (typeVal - respVal)) >> 31;
         return diffMask - 1;
     }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -7402,7 +7402,7 @@ int JoyBus::SetCtrlMode(int portIndex, int controlMode)
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
 
     unsigned char modeFlag =
-        (unsigned char)(((unsigned int)(-controlMode | controlMode)) >> 31);
+        (signed char)(((unsigned int)(-controlMode | controlMode)) >> 31);
 
     if (GbaQue.IsSingleMode(m_threadParams[portIndex].m_portIndex))
 	{

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4060,6 +4060,10 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
 
         ResetQueue(threadParam);
 
+        localWord = 0;
+        localBytes[0] = 0x10;
+        unsigned int restartCmd = localWord;
+
         if (static_cast<signed char>(m_threadRunningMask) == 0)
         {
             result = 0;
@@ -4076,7 +4080,7 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
             }
             else
             {
-                m_cmdQueueData[qPort][m_cmdCount[qPort]] = 0x10000000;
+                m_cmdQueueData[qPort][m_cmdCount[qPort]] = restartCmd;
                 m_cmdCount[threadParam->m_portIndex]++;
 
                 OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);


### PR DESCRIPTION
Raises main/joybus fuzzy match from 94.19% to 94.34%.

## Changes
- **SendDataFile**: byte-pack the 0x10000000 restart command via the stack `localWord`/`localBytes` idiom (matches target's `stw/stb/lwz` construction); rewrite the two match-result return paths (`result!=0` / equal) to recompute `typeVal`/`respVal` inside each branch with the correct logical-vs-arithmetic shift (`srwi` for `mask-2`, `srawi` for `mask-1`), correct OR-operand order, and unsigned `localBytes[1]` (drops the spurious `extsb`); fix the sendType equality compare load order/signedness.
- **InitialCode**: `flags` and `stageResult` corrected to unsigned (bit-packed command byte / unsigned status word).
- **SendPlayerStat**: `result` is signed `int` (can return -1).
- **SetCtrlMode**: signed-char cast on the nonzero-test mode flag (matches `extsb`).
- **SendResult**: signed-char `firstByte` command byte.

All changes are signedness/idiom corrections backed by member types (e.g. `System.m_execParam` is `int`) and confirmed net-positive via report.json fuzzy_match_percent.

## Blockers (documented walls, not source-steerable)
- SendDataFile / GBARecvSend register-window off-by-one and `...rodata.0@ha` merged-section base anchoring.
- GBARecvSend opcode `==` chain range-collapse (`(op-0x1C)<=3`).
- Crc16 inlining (crc accumulator in stack slot vs register; `extrwi`/`clrlslwi` coloring).
- Send*/Set* result-in-rN ABI (return held in scratch reg with `mr r3,rN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)