### PR TITLE
game: raise fuzzy match to 98.8% (cycle 11)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -591,12 +591,12 @@ void CGame::clearWork()
 
     unk_flat3_0xc7d0 = 0;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
+            m_scriptWork[i + 4][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i][j + 4][0] = 0;
-            m_scriptWork[i][j + 4][1] = 0;
+            m_scriptWork[i + 4][j][1] = 0;
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -837,12 +837,12 @@ void CGame::ScriptChanged(char*, int)
 
     unk_flat3_0xc7d0 = 0;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
+            m_scriptWork[i + 4][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i][j + 4][0] = 0;
-            m_scriptWork[i][j + 4][1] = 0;
+            m_scriptWork[i + 4][j][1] = 0;
         }
     }
 


### PR DESCRIPTION
## Summary
Raises main/game fuzzy match from 98.77% to 98.79% by fixing the m_scriptWork clear-loop structure in two functions.

## Changes
- **clearWork** (98.23% to 98.37%): rewrote the `m_scriptWork` clearing loop from the half-row `[i][j]`/`[i][j+4]` form to the two-bank `[i]`/`[i+4]` form (banks 0x100 apart), matching the target's interleaved store offsets (`-0x3a30`/`-0x3930`...). Flagged lines dropped 68 to 45.
- **ScriptChanged** (99.67% to 99.96%): same two-bank `m_scriptWork` clear fix. Flagged lines dropped 26 to 3.

Both loops now emit the target's exact store-offset sequence; the residual is a compiler unroll trip-count difference (count 4/stride 0x20 vs count 2/stride 0x40) that is context-dependent register-pressure driven, not source-steerable. This mirrors the already-100% InitNewGame, which uses the identical source form.

## Why plausible
The two-bank form (`m_scriptWork[i]`/`m_scriptWork[i+4]`) matches the inlined `clearWorkScript` helper already present in the file and the 100%-matched InitNewGame. No layout, header, or hack changes; data match preserved at 98.64%.

## Blocked (confirmed walls, not pursued further)
LoadScript/SaveScript IV strength-reduction; ChangeMap parameter register-coloring; Create mtctr memcpy unroll (3 loop-form variants tested, all worse); GetBossArtifact/Calc named-bias/named-float sda2 pool-ordering + register cascade (R3 data-def move regressed data); GetTargetCursor/loadCfd register-coloring; Exec jumptable naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)