### PR TITLE
gobject: raise fuzzy match to 92.7% (cycle 16)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -528,11 +528,11 @@ void CGObject::move()
         movingWithScript = 1;
     } else {
         const int player = static_cast<s8>(m_animStateMisc);
-        if ((player >= 0)
-            && (player < 4)
+        if ((static_cast<s8>(m_animStateMisc) >= 0)
+            && (static_cast<s8>(m_animStateMisc) < 4)
             && m_weaponNodeFlagAll.m_bits1.m_shield
             && m_weaponNodeFlagAll.m_bits1.m_menuReady
-            && ((Game.m_gameWork.m_menuStageMode == 0) || (player == 0))) {
+            && ((Game.m_gameWork.m_menuStageMode == 0) || (static_cast<s8>(m_animStateMisc) == 0))) {
             u16 buttons = (Pad.m_debugPadLock != 0 || (player == 0 && Pad.m_debugPadPort != -1))
                 ? 0
                 : Pad.GetPadInputs()[RemapPadSlot(&Pad, player)].button[0];

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1998,7 +1998,7 @@ void CGObject::onDraw()
         capsuleOffset.x = sZeroFloat;
         capsuleOffset.y = sZeroFloat;
         capsuleOffset.z = sZeroFloat;
-        if (m_bodyEllipsoidOffset == sZeroFloat) {
+        if (*reinterpret_cast<int*>(&m_bodyEllipsoidOffset) == 0) {
         } else {
             capsuleOffset.y = sZeroFloat;
             capsuleOffset.x = m_bodyEllipsoidOffset * -sinf(m_rotBaseY);


### PR DESCRIPTION
Two targeted source-level matches in main/gobject (baseline 92.66% -> 92.70%):

- **move**: lazy `(s8)m_animStateMisc` casts in the player-input gate. The original re-applies the signed-char cast at each comparison (`player >= 0`, `< 4`, `== 0`) instead of caching one sign-extended int, matching the target's repeated `extsb` of the raw byte and fixing the bitfield register coloring in the gate (94.6% -> 94.8% on the function).
- **onDraw**: integer bit-pattern compare for `m_bodyEllipsoidOffset == 0` (R13). Comparing the raw bits removes a spurious zero-FPR cache, raising the function 85.3% -> 85.7%.

Remaining gaps are dominated by documented walls: this-pointer / float-param register coloring (onDraw, hit, CCClass), anonymous float-pool slot naming (onCreate, CalcSafePos, bgNormalCollision, update), and the sda21 base-CSE in bgCollision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)