### PR TITLE
cmake: raise fuzzy match to 89.2% (cycle 23)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1985,17 +1985,19 @@ void CMenuPcs::CmakeTribeDraw()
         0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x40));
-    for (int tileX = 0x20; tileX < 0x260; ) {
-        int tileW = 0x20;
-        if (0x260 - tileX < 0x20) {
-            tileW = 0x260 - tileX;
-        }
+    {
+        int tileW;
+        for (int tileX = 0x20; tileX < 0x260; tileX += tileW) {
+            tileW = 0x20;
+            if (0x260 - tileX < 0x20) {
+                tileW = 0x260 - tileX;
+            }
 
-        MenuPcs.DrawRect(
-            0,
-            static_cast<float>(tileX), 24.0f, static_cast<float>(tileW), 336.0f,
-            0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
-        tileX += tileW;
+            MenuPcs.DrawRect(
+                0,
+                static_cast<float>(tileX), 24.0f, static_cast<float>(tileW), 336.0f,
+                0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+        }
     }
 
     DrawCmakePreviewChara(this);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3696,17 +3696,19 @@ void CMenuPcs::DrawSingCMake()
             0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x40));
-        for (int x = 0x20; x < 0x260;) {
-            int span = 0x20;
-            if ((0x260 - x) < span) {
-                span = 0x260 - x;
-            }
+        {
+            int span;
+            for (int x = 0x20; x < 0x260; x += span) {
+                span = 0x20;
+                if ((0x260 - x) < span) {
+                    span = 0x260 - x;
+                }
 
-            MenuPcs.DrawRect(
-                0,
-                static_cast<float>(x), 24.0f, static_cast<float>(span), 336.0f,
-                0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
-            x += span;
+                MenuPcs.DrawRect(
+                    0,
+                    static_cast<float>(x), 24.0f, static_cast<float>(span), 336.0f,
+                    0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+            }
         }
 
         if (CmakeState(this)->m_resultFlag != 0 && CmakeState(this)->m_mode == 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1726,17 +1726,19 @@ void CMenuPcs::CmakeJobDraw()
         0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x40));
-    for (int x = 0x20; x < 0x260;) {
-        int span = 0x20;
-        if ((0x260 - x) < span) {
-            span = 0x260 - x;
-        }
+    {
+        int span;
+        for (int x = 0x20; x < 0x260; x += span) {
+            span = 0x20;
+            if ((0x260 - x) < span) {
+                span = 0x260 - x;
+            }
 
-        MenuPcs.DrawRect(
-            0,
-            static_cast<float>(x), 24.0f, static_cast<float>(span), 336.0f,
-            0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
-        x += span;
+            MenuPcs.DrawRect(
+                0,
+                static_cast<float>(x), 24.0f, static_cast<float>(span), 336.0f,
+                0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
+        }
     }
 
     DrawCmakePreviewChara(this);


### PR DESCRIPTION
## Summary
Raises `main/cmake` fuzzy match from baseline **89.156%** to **89.176%** via a structural loop-restructuring lever applied to three tile-drawing functions.

## What changed
The frame-border tile loop (`for (x=0x20; x<0x260;) { span=0x20; if (0x260-x < span) span=0x260-x; ...; x+=span; }`) was emitting its two loop variables (`x` and `span`) in the opposite callee-saved registers vs the target (target: x in the lower reg r27, span in r28; ours had them swapped). Hoisting the `span`/`tileW` declaration out of the loop body and moving the increment into the `for` step clause makes mwcc assign the registers in the target's order, eliminating the ARG_MISMATCH run across the loop and its dependent block.

Applied to the three functions whose loop showed the clean register *swap*:
- **CmakeJobDraw** (93.7% region; loop reg pairing now matches)
- **DrawSingCMake** (96.7%; 52 to 44 flagged lines)
- **CmakeTribeDraw** (84.9%; flagged-line drop)

## What did not work (left untouched)
- The same loop in **DrawDiaryBase**, **CmakeResultDraw1**, **CmakeResultDraw** showed a full register-*window shift* (not a simple swap) driven by the magic-double int-to-float conversion frame layout; the hoist regressed those, so they were reverted.
- Confirmed the documented walls: anonymous float/double pool naming (`@NNN` vs `FLOAT_/DOUBLE_*@sda21`) dominates all Draw fns; pad-read `__cntlzw` r0/r3/r4 coloring dominates all Ctrl fns; `CalcSingCMake` result-in-r27 window. Type/boundary/pointer-order experiments on these all regressed or were constant-folded into no-ops.

## Plausibility
Declaring a loop-carried scratch outside the loop and advancing the index in the `for` step clause is ordinary idiomatic C and changes no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)