### PR TITLE
gobject: raise fuzzy match to 92.7% (cycle 17)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1369,7 +1369,8 @@ void CGObject::update()
             m_currentAnimSlot != -1) {
             float frame = sZeroFloat;
             if (m_lastBgAttr < sZeroFloat) {
-                frame = ModelAnimEnd(m_charaModelHandle->m_model) - ModelAnimStart(m_charaModelHandle->m_model);
+                const float animStart = ModelAnimStart(m_charaModelHandle->m_model);
+                frame = ModelAnimEnd(m_charaModelHandle->m_model) - animStart;
             }
             m_turnSpeed = frame;
             m_charaModelHandle->m_model->SetFrame(m_turnSpeed);
@@ -1384,14 +1385,9 @@ void CGObject::update()
     float turnFactor;
     if (m_animSlotSel != -1 && m_shieldNodeFlagBits.m_bit40) {
         const double turnLimit = fabs(m_turnBaseSpeed);
-        double clampedTurn;
-        if (turnDelta < -turnLimit) {
-            clampedTurn = -turnLimit;
-        } else if (turnLimit < turnDelta) {
-            clampedTurn = turnLimit;
-        } else {
-            clampedTurn = turnDelta;
-        }
+        double clampedTurn = (turnDelta < -turnLimit)
+                                 ? -turnLimit
+                                 : (turnLimit < turnDelta ? turnLimit : turnDelta);
         turnDelta = clampedTurn;
         turnFactor = sAnimFrameOffset;
     } else {


### PR DESCRIPTION
Raises main/gobject fuzzy match from 92.70% to 92.72%.

## Changes (all in CGObject::update)
- **Clamp-as-select (R17):** rewrote the turn-limit three-way clamp (`turnDelta` vs `±fabs(m_turnBaseSpeed)`) from an if/else-if chain into a nested ternary. Matches the target's branch-select control flow (drops a spurious `fmr` insert and aligns the bge/b block structure).
- **Lazy anim-start eval:** in the SetAnim frame computation, hoist `ModelAnimStart(...)` into a local before `ModelAnimEnd(...) - animStart`, matching the target's load order (`lfs start; lfs end; fsubs end-start`).

## Evidence
- report.json fuzzy_match_percent: 92.70222 → 92.717026
- update__8CGObject: 88.68% → 88.74%

## Plausibility
Both edits are ordinary source forms (a ternary clamp; a named temp for a subexpression) consistent with the rest of the file. No layout, header, or naming hacks.

## Remaining ceiling (confirmed walls)
The bulk of remaining diff is anonymous float/double constant-pool naming (`@NNNN` vs `FLOAT_/DOUBLE_` symbols) and ordering, register-window coloring in onCreate/move (off-by-one on the zero/-1 constants), and the shared-header `s_bitMask` sda base-CSE in bgCollision. Each was tried and either regressed or was net-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)