### PR TITLE
p_graphic: raise fuzzy match to 87.3% (cycle 13)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -310,48 +310,49 @@ void CGraphicPcs::drawScreenFade()
 
         if (slot == 2) {
             const int mode = slotData->m_mode;
-            if (mode == 1) {
+            if (mode == 0) {
+            drawSlot2Fullscreen:
+                GXBegin(GX_QUADS, GX_VTXFMT0, 4);
+                GXPosition3f32(kGraphicZero, kGraphicZero, kGraphicZero);
+                GXColor1u32(*(u32*)&baseColor);
+                GXTexCoord2u16(0, 0);
+                GXPosition3f32(kGraphicScreenWidth, kGraphicZero, kGraphicZero);
+                GXColor1u32(*(u32*)&baseColor);
+                GXTexCoord2u16(2, 0);
+                GXPosition3f32(kGraphicScreenWidth, kGraphicScreenHeight, kGraphicZero);
+                GXColor1u32(*(u32*)&baseColor);
+                GXTexCoord2u16(2, 2);
+                GXPosition3f32(kGraphicZero, kGraphicScreenHeight, kGraphicZero);
+                GXColor1u32(*(u32*)&baseColor);
+                GXTexCoord2u16(0, 2);
+            } else if (mode == 1) {
                 CGObject* obj = static_cast<CGObject*>(slotData->m_targetObj);
-                if (obj != NULL) {
-                    Vec pos = obj->m_worldPosition;
-                    pos.y += slotData->m_targetYOffs;
-                    PSMTX44MultVec(worldScreenMtx, &pos, &pos);
-
-                    const int radius = (unsigned int)(kGraphicScreenWidth * (kGraphicOne - fadeWave));
-                    float sx = pos.x * kGraphicScreenCenterX + kGraphicScreenCenterX;
-                    float sy = -(pos.y * kGraphicScreenCenterY - kGraphicScreenCenterY);
-                    if (sx < kGraphicZero) {
-                        sx = kGraphicZero;
-                    } else if (sx > kGraphicScreenWidth) {
-                        sx = kGraphicScreenWidth;
-                    }
-                    if (sy < kGraphicZero) {
-                        sy = kGraphicZero;
-                    } else if (sy > kGraphicScreenHeight) {
-                        sy = kGraphicScreenHeight;
-                    }
-
-                    const unsigned int ix = (unsigned int)sx;
-                    const unsigned int iy = (unsigned int)sy;
-                    drawSFCircle(0x500, radius, ix, iy, baseColor, baseColor);
-                    drawSFCircle(radius, radius - static_cast<unsigned int>(kScreenFadeRingWidth), ix, iy, baseColor, baseColor2);
-                    continue;
+                if (obj == NULL) {
+                    goto drawSlot2Fullscreen;
                 }
-            }
+                Vec pos = obj->m_worldPosition;
+                pos.y += slotData->m_targetYOffs;
+                PSMTX44MultVec(worldScreenMtx, &pos, &pos);
 
-            GXBegin(GX_QUADS, GX_VTXFMT0, 4);
-            GXPosition3f32(kGraphicZero, kGraphicZero, kGraphicZero);
-            GXColor1u32(*(u32*)&baseColor);
-            GXTexCoord2u16(0, 0);
-            GXPosition3f32(kGraphicScreenWidth, kGraphicZero, kGraphicZero);
-            GXColor1u32(*(u32*)&baseColor);
-            GXTexCoord2u16(2, 0);
-            GXPosition3f32(kGraphicScreenWidth, kGraphicScreenHeight, kGraphicZero);
-            GXColor1u32(*(u32*)&baseColor);
-            GXTexCoord2u16(2, 2);
-            GXPosition3f32(kGraphicZero, kGraphicScreenHeight, kGraphicZero);
-            GXColor1u32(*(u32*)&baseColor);
-            GXTexCoord2u16(0, 2);
+                float sx = pos.x * kGraphicScreenCenterX + kGraphicScreenCenterX;
+                float sy = -(pos.y * kGraphicScreenCenterY - kGraphicScreenCenterY);
+                if (sx < kGraphicZero) {
+                    sx = kGraphicZero;
+                } else if (sx > kGraphicScreenWidth) {
+                    sx = kGraphicScreenWidth;
+                }
+                if (sy < kGraphicZero) {
+                    sy = kGraphicZero;
+                } else if (sy > kGraphicScreenHeight) {
+                    sy = kGraphicScreenHeight;
+                }
+
+                const int radius = (int)(kScreenFadeCircleRadius * (kGraphicOne - fadeWave));
+                const int ix = (int)sx;
+                const int iy = (int)sy;
+                drawSFCircle(0x500, radius, ix, iy, baseColor, baseColor);
+                drawSFCircle(radius, radius - 8, ix, iy, baseColor, baseColor2);
+            }
             continue;
         }
 


### PR DESCRIPTION
## Summary
Reconstructed the drawScreenFade slot==2 dispatch from the Ghidra control-flow shape, raising the p_graphic unit from 80.17% to 87.25% (+7.08).

## What changed
- drawScreenFade slot==2 block now matches the original control flow exactly:
  - The default fullscreen quad block is emitted FIRST (mode==0 fall-through path).
  - The mode==1 circle path is emitted LAST as a trailing branch target.
  - When the target object is null, the mode==1 path branches back to the shared fullscreen quad block (matches the original's `beq` back-edge), rather than nesting the circle inside `if(obj)` and falling through afterward.
- Fixed the circle radius constant: `kScreenFadeCircleRadius` (sdata2 0x8032FBA4) instead of `kGraphicScreenWidth`, and signed `(int)` conversion to match the original `fctiwz`.
- Inner ring radius is `radius - 8` (literal) matching the original `subi r5, r16, 0x8`.

## Evidence
- main/p_graphic fuzzy_match_percent: 80.169945% -> 87.25492%
- drawScreenFade__11CGraphicPcsFv: 62.82% -> 79.75%

## Why this is plausible source
The block order and the shared-fullscreen-via-goto structure fall directly out of the Ghidra decompilation's if-ladder (`mode==0` first, `mode==1 && obj` last, obj-null reaching the mode==0 body). The radius constant is the named sdata2 symbol the original references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)