### PR TITLE
gobject: raise fuzzy match to 92.8% (cycle 18)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1991,10 +1991,7 @@ void CGObject::onDraw()
 
     if (((CFlat.m_debugFlags & 0x2) != 0) && ((m_bgColMask & 0x2) != 0)) {
         CVector capsuleOffset;
-        capsuleOffset.x = sZeroFloat;
-        capsuleOffset.y = sZeroFloat;
-        capsuleOffset.z = sZeroFloat;
-        if (*reinterpret_cast<int*>(&m_bodyEllipsoidOffset) == 0) {
+        if (sZeroFloat == m_bodyEllipsoidOffset) {
         } else {
             capsuleOffset.y = sZeroFloat;
             capsuleOffset.x = m_bodyEllipsoidOffset * -sinf(m_rotBaseY);

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1991,11 +1991,14 @@ void CGObject::onDraw()
 
     if (((CFlat.m_debugFlags & 0x2) != 0) && ((m_bgColMask & 0x2) != 0)) {
         CVector capsuleOffset;
-        if (sZeroFloat == m_bodyEllipsoidOffset) {
-        } else {
+        if (sZeroFloat != m_bodyEllipsoidOffset) {
             capsuleOffset.y = sZeroFloat;
             capsuleOffset.x = m_bodyEllipsoidOffset * -sinf(m_rotBaseY);
             capsuleOffset.z = m_bodyEllipsoidOffset * -cosf(m_rotBaseY);
+        } else {
+            capsuleOffset.z = sZeroFloat;
+            capsuleOffset.y = sZeroFloat;
+            capsuleOffset.x = sZeroFloat;
         }
 
         Mtx scaleMtx;


### PR DESCRIPTION
Raises main/gobject from 92.72% to 92.83% by correcting two source-level
issues in onDraw (CGObject::onDraw, 85.65% -> 87.31%):

- The m_bodyEllipsoidOffset zero-test used an integer bit-pattern compare
  (*(int*)&field == 0); the original used a plain float compare against
  sZeroFloat (matches the target's lfs/fcmpu).
- The capsuleOffset CVector explicitly zeroed each component after a
  default ctor. The original relied solely on the default CVector() ctor,
  then set components only in each branch.
- The zero-test branch fell through to the wrong arm. Inverting the
  condition to (sZeroFloat != offset) with the zero-init arm last (reverse
  component order) reproduces the target's beq-to-merge control flow.

Both changes are plausible original source, confirmed via report.json
fuzzy_match_percent.

Remaining gap is dominated by documented walls: CVector ctor-result
FPR-hoisting (bgAttribCollision/SetPosBG/bgWorldCollision), anonymous
float-pool naming/ordering (update/objectCollision), and the
register-window coloring on onCreate/onDraw/move/hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)