### PR TITLE
gobject: raise fuzzy match to 97.0% (cycle 22)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1215,6 +1215,7 @@ static inline int checkProbeHit(CMapCylinder* cylinder, CVector* base, CVector* 
 }
 
 #pragma push
+#pragma optimization_level 1
 #pragma opt_common_subs off
 void CGObject::bgAttribCollision()
 {

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3173,23 +3173,25 @@ void CGObject::SetPosBG(Vec* position, int useCapsuleOffset)
     if (m_weaponNodeFlagBits.m_unk10 && (Game.m_currentMapId != 0x21)) {
         {
             Vec bottom = m_worldPosition;
-            bottom.y += useCapsuleOffset != 0 ? m_capsuleHalfHeight : sPushDistance;
+            const float bottomY = (useCapsuleOffset != 0 ? m_capsuleHalfHeight : sPushDistance) + bottom.y;
+            bottom.y = bottomY;
             Vec direction = bottom;
             direction.x = sZeroFloat;
             direction.y = sDownUnitY;
             direction.z = sZeroFloat;
+            const u32 hitMask = m_bgHitMask;
             CMapCylinder bodyCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
             bodyCylinder.m_bottom.x = bottom.x;
-            bodyCylinder.m_bottom.y = bottom.y;
+            bodyCylinder.m_bottom.y = bottomY;
             bodyCylinder.m_bottom.z = bottom.z;
-            bodyCylinder.m_axis.x = direction.x;
-            bodyCylinder.m_axis.y = direction.y;
-            bodyCylinder.m_axis.z = direction.z;
+            bodyCylinder.m_axis.x = sZeroFloat;
+            bodyCylinder.m_axis.y = sDownUnitY;
+            bodyCylinder.m_axis.z = sZeroFloat;
             bodyCylinder.m_radius = sZeroFloat;
 
             if (MapMng.CheckHitCylinderNear(
                     &bodyCylinder, &direction,
-                    m_bgHitMask) != 0) {
+                    hitMask) != 0) {
                 MapMng.m_hitMapObj->CalcHitPosition(&m_worldPosition);
             }
         }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1122,61 +1122,71 @@ stepMiss:
  * JP Address: TODO
  * JP Size: TODO
  */
+static inline const Vec& vecAdd(const CVector* a, const CVector& b)
+{
+    CVector out;
+
+    PSVECAdd(reinterpret_cast<const Vec*>(a), reinterpret_cast<const Vec*>(&b),
+             reinterpret_cast<Vec*>(&out));
+    return reinterpret_cast<Vec&>(out);
+}
+
+static inline const Vec& vecScale(const CVector& v, float scale)
+{
+    CVector out;
+
+    PSVECScale(reinterpret_cast<const Vec*>(&v), reinterpret_cast<Vec*>(&out), scale);
+    return reinterpret_cast<Vec&>(out);
+}
+
+static inline const Vec& vecSub(const CVector& a, const CVector& b)
+{
+    CVector out;
+
+    PSVECSubtract(reinterpret_cast<const Vec*>(&a), reinterpret_cast<const Vec*>(&b),
+                  reinterpret_cast<Vec*>(&out));
+    return reinterpret_cast<Vec&>(out);
+}
+
 void CGObject::bgWorldCollision()
 {
-    CVector groundOffset(m_groundHitOffset);
-    CVector* worldPosition = &CVector(m_worldPosition);
-    CVector radialSum;
-    PSVECAdd(reinterpret_cast<Vec*>(worldPosition), reinterpret_cast<Vec*>(&groundOffset),
-             reinterpret_cast<Vec*>(&radialSum));
-
     Vec radial;
-    radial.x = radialSum.x;
-    radial.y = radialSum.y;
-    radial.z = radialSum.z;
+    Vec hitMove;
+
+    radial = vecAdd(&CVector(m_worldPosition), CVector(m_groundHitOffset));
 
     if (PSVECMag(&radial) > sZeroFloat) {
         reinterpret_cast<CVector*>(&radial)->Normalize();
     }
     PSVECScale(&radial, &radial, sPushDistance);
 
-    CVector reverseRadial(-radial.x, -radial.y, -radial.z);
-    CVector scaledHitMove;
-    PSVECScale(reinterpret_cast<Vec*>(&reverseRadial), reinterpret_cast<Vec*>(&scaledHitMove), sHitMoveScale);
-    Vec hitMove;
-    hitMove.x = scaledHitMove.x;
-    hitMove.y = scaledHitMove.y;
-    hitMove.z = scaledHitMove.z;
-
-    CMapCylinder bodyCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
-    bodyCylinder.m_bottom = radial;
-    bodyCylinder.m_axis.x = scaledHitMove.x;
-    bodyCylinder.m_axis.y = scaledHitMove.y;
-    bodyCylinder.m_axis.z = scaledHitMove.z;
-    bodyCylinder.m_radius = sZeroFloat;
+    hitMove = vecScale(CVector(-radial.x, -radial.y, -radial.z), sHitMoveScale);
 
     const u32 hitMask = m_bgHitMask;
-    if (MapMng.CheckHitCylinderNear(&bodyCylinder, &hitMove, hitMask) == 0) {
-        return;
-    }
+    CMapCylinder bodyCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
+    bodyCylinder.m_bottom = radial;
+    bodyCylinder.m_axis.x = hitMove.x;
+    bodyCylinder.m_axis.y = hitMove.y;
+    bodyCylinder.m_axis.z = hitMove.z;
+    bodyCylinder.m_radius = sZeroFloat;
 
-    MapMng.m_hitMapObj->CalcHitPosition(&radial);
-    CVector hitWorldPosition(m_worldPosition);
-    CVector newOffset;
-    PSVECSubtract(&radial, reinterpret_cast<Vec*>(&hitWorldPosition), reinterpret_cast<Vec*>(&newOffset));
-    m_groundHitOffset.x = newOffset.x;
-    m_groundHitOffset.y = newOffset.y;
-    m_groundHitOffset.z = newOffset.z;
+    if (MapMng.CheckHitCylinderNear(&bodyCylinder, &hitMove, hitMask) != 0) {
+        Vec delta;
 
-    if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
-        m_stateFlags0Bits.unk0 = 1;
-        *reinterpret_cast<u32*>(&m_radiusCtrl.x) =
-            MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask;
-        const int groupIndex = gMapHitFace->m_groupIndex;
-        if (groupIndex != 0) {
-            *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(groupIndex);
+        MapMng.m_hitMapObj->CalcHitPosition(&radial);
+        delta = vecSub(reinterpret_cast<CVector&>(radial), CVector(m_worldPosition));
+        m_groundHitOffset = delta;
+
+        if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
+            m_stateFlags0Bits.unk0 = 1;
+            *reinterpret_cast<u32*>(&m_radiusCtrl.x) =
+                MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask;
+            const int groupIndex = gMapHitFace->m_groupIndex;
+            if (groupIndex != 0) {
+                *reinterpret_cast<char*>(&m_lastBgGroup) = static_cast<char>(groupIndex);
+            }
+            MapMng.m_hitMapObj->GetHitFaceNormal(&HitFaceNormal());
         }
-        MapMng.m_hitMapObj->GetHitFaceNormal(&HitFaceNormal());
     }
 }
 
@@ -1189,6 +1199,21 @@ void CGObject::bgWorldCollision()
  * JP Address: TODO
  * JP Size: TODO
  */
+static inline int checkProbeHit(CMapCylinder* cylinder, CVector* base, CVector* move, unsigned long mask)
+{
+    CMapMng* mapMng = &MapMng;
+
+    cylinder->m_bottom.x = base->x;
+    cylinder->m_bottom.y = base->y;
+    cylinder->m_bottom.z = base->z;
+    cylinder->m_axis.x = move->x;
+    cylinder->m_axis.y = move->y;
+    cylinder->m_axis.z = move->z;
+    cylinder->m_radius = sZeroFloat;
+
+    return mapMng->CheckHitCylinderNear(cylinder, reinterpret_cast<Vec*>(move), mask);
+}
+
 #pragma push
 #pragma opt_common_subs off
 void CGObject::bgAttribCollision()
@@ -1200,20 +1225,9 @@ void CGObject::bgAttribCollision()
     m_shieldNodeFlagBits.m_bit20 = 0;
 
     if ((m_displayFlags & 4) != 0) {
-        CVector* probeMove = &CVector(sZeroFloat, sDownProbeDistance, sZeroFloat);
-        CVector* probeBase = &CVector(m_worldPosition.x, sHitProbeHeight + m_worldPosition.y, m_worldPosition.z);
-
-        CMapCylinder charmCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
-        charmCylinder.m_bottom.x = probeBase->x;
-        charmCylinder.m_bottom.y = probeBase->y;
-        charmCylinder.m_bottom.z = probeBase->z;
-        charmCylinder.m_axis.x = probeMove->x;
-        charmCylinder.m_axis.y = probeMove->y;
-        charmCylinder.m_axis.z = probeMove->z;
-        charmCylinder.m_radius = sZeroFloat;
-
-        if (MapMng.CheckHitCylinderNear(
-                &charmCylinder, reinterpret_cast<Vec*>(probeMove),
+        if (checkProbeHit(&CMapCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent),
+                &CVector(m_worldPosition.x, sHitProbeHeight + m_worldPosition.y, m_worldPosition.z),
+                &CVector(sZeroFloat, sDownProbeDistance, sZeroFloat),
                 0x80000000) != 0) {
             Vec hitPos;
             MapMng.m_hitMapObj->CalcHitPosition(&hitPos);
@@ -1231,20 +1245,10 @@ void CGObject::bgAttribCollision()
         if ((sZeroFloat != m_groundHitOffset.x) || (sZeroFloat != m_groundHitOffset.z)) {
             if (HasLoadedModel(m_charaModelHandle)) {
                 CVector* probeMove = &CVector(sZeroFloat, sDownProbeDistance, sZeroFloat);
-                CVector* probeBase = &CVector(m_worldPosition.x, sStepProbeHeight + m_worldPosition.y, m_worldPosition.z);
 
-                CMapCylinder attrCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
-                attrCylinder.m_bottom.x = probeBase->x;
-                attrCylinder.m_bottom.y = probeBase->y;
-                attrCylinder.m_bottom.z = probeBase->z;
-                attrCylinder.m_axis.x = probeMove->x;
-                attrCylinder.m_axis.y = probeMove->y;
-                attrCylinder.m_axis.z = probeMove->z;
-                attrCylinder.m_radius = sZeroFloat;
-
-                if (MapMng.CheckHitCylinderNear(
-                        &attrCylinder, reinterpret_cast<Vec*>(probeMove),
-                        0x78000000) != 0) {
+                if (checkProbeHit(&CMapCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent),
+                        &CVector(m_worldPosition.x, sStepProbeHeight + m_worldPosition.y, m_worldPosition.z),
+                        probeMove, 0x78000000) != 0) {
                     switch (gMapHitFace->m_groupIndex - 0x28) {
                     case 0:
                         m_bgAttrValue = sBgAttrSlow;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3184,8 +3184,8 @@ void CGObject::SetPosBG(Vec* position, int useCapsuleOffset)
             bodyCylinder.m_bottom.x = bottom.x;
             bodyCylinder.m_bottom.y = bottomY;
             bodyCylinder.m_bottom.z = bottom.z;
-            bodyCylinder.m_axis.x = sZeroFloat;
             bodyCylinder.m_axis.y = sDownUnitY;
+            bodyCylinder.m_axis.x = sZeroFloat;
             bodyCylinder.m_axis.z = sZeroFloat;
             bodyCylinder.m_radius = sZeroFloat;
 
@@ -3201,8 +3201,9 @@ void CGObject::SetPosBG(Vec* position, int useCapsuleOffset)
             hasModel = true;
         }
         if (hasModel) {
+            CVector* attrBottom;
             CVector* attrDirection = &CVector(sZeroFloat, sDownProbeDistance, sZeroFloat);
-            CVector* attrBottom = &CVector(m_worldPosition.x, sStepProbeHeight + m_worldPosition.y, m_worldPosition.z);
+            attrBottom = &CVector(m_worldPosition.x, sStepProbeHeight + m_worldPosition.y, m_worldPosition.z);
             CMapCylinder attrCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
 
             attrCylinder.m_bottom.x = attrBottom->x;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1139,6 +1139,14 @@ static inline const Vec& vecScale(const CVector& v, float scale)
     return reinterpret_cast<Vec&>(out);
 }
 
+static inline const Vec& vecScaleV(const Vec& v, float scale)
+{
+    Vec out;
+
+    PSVECScale(&v, &out, scale);
+    return out;
+}
+
 static inline const Vec& vecSub(const CVector& a, const CVector& b)
 {
     CVector out;
@@ -1616,10 +1624,8 @@ void CGObject::update()
             m_worldPosition = attachPos;
         } else {
             float interp = static_cast<float>(m_moveMode) / static_cast<float>(m_moveModePrevious);
-            Vec fromSelf;
-            Vec fromOwner;
-            PSVECScale(&attachPos, &fromOwner, sAnimFrameOffset - interp);
-            PSVECScale(&m_worldPosition, &fromSelf, interp);
+            const Vec& fromOwner = vecScaleV(attachPos, sAnimFrameOffset - interp);
+            const Vec& fromSelf = vecScaleV(m_worldPosition, interp);
             PSVECAdd(&fromOwner, &fromSelf, &m_worldPosition);
             m_moveMode--;
         }

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1174,8 +1174,8 @@ void CGObject::bgWorldCollision()
         Vec delta;
 
         MapMng.m_hitMapObj->CalcHitPosition(&radial);
-        delta = vecSub(reinterpret_cast<CVector&>(radial), CVector(m_worldPosition));
-        m_groundHitOffset = delta;
+        const Vec& newOffset = vecSub(reinterpret_cast<CVector&>(radial), CVector(m_worldPosition));
+        m_groundHitOffset = delta = newOffset;
 
         if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
             m_stateFlags0Bits.unk0 = 1;


### PR DESCRIPTION
Raises main/gobject from 96.35% to 96.98% (+0.63).

Per-function gains:
- bgWorldCollision 86.06 -> 99.23: reconstructed inline CVector helpers (vecAdd/vecScale/vecSub mirroring the out-of-line CVector::operator+/- bodies) consumed via reference binding, restored the dead delta struct copy via chained struct assignment (`m_groundHitOffset = delta = newOffset;`), hoisted hitMask local.
- bgAttribCollision 88.58 -> 96.96: checkProbeHit inline helper with ctor-temp arguments (fixes CVector temp-pool slot ordering: call-arg temps allocate LTR, evaluate RTL) + `#pragma optimization_level 1` (matches the r7-vacate register pattern; discovered via SetPosBG's pragma).
- SetPosBG 91.90 -> 96.11: bottomY named local reused for cylinder bottom (kills reload), direct constant axis stores, hitMask hoist, axis store order.
- update 94.02 -> 94.03: vecScaleV inline helper for the attach interpolation (fixes fromOwner/fromSelf temp slots).

Key new technique findings (for TECHNIQUE.md): mwcc allocates ctor-temp slots LTR within an argument list while evaluating RTL; inline helpers returning a reference to a body local reproduce "NRV-slot read" patterns without a copy-ctor call; a chained struct assignment survives mwcc's struct copy-forwarding where two separate assignments get DSE'd; per-function `#pragma optimization_level 1` flips the ctor-return r3-coalescing to an r7-vacate.

Remaining walls: update sway-block FPR permutation + 0x30 missing frame bytes, onCreate r5/r6/r7 constant window, move Pad result-in-r3 chains, bgShadeCollision blr stub, __sinit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)