### PR TITLE
graphic: raise fuzzy match to 96.9% (cycle 11)

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -52,7 +52,7 @@ graphic.cpp:
 	.bss        start:0x80230E48 end:0x8023C4D8
 	.sdata      start:0x8032E3E8 end:0x8032E400
 	.sbss       start:0x8032EC48 end:0x8032EC55
-	.sdata2     start:0x8032F6E8 end:0x8032F718
+	.sdata2     start:0x8032F6C0 end:0x8032F718
 
 main.cpp:
 	extab       start:0x80005920 end:0x80005930

--- a/include/ffcc/graphic_symbols.h
+++ b/include/ffcc/graphic_symbols.h
@@ -17,20 +17,7 @@ extern _GXColor gGraphicDefaultClearColor;
 extern const char sGraphicInitData[];
 extern const char sGraphicStageName[];
 extern const char sGraphicSourceStrings[];
-extern const char sGraphicUnknownOrderName[4];
 extern u8 gGraphicNoiseTextureI8_64x96[];
-extern const float kGraphicZeroF;
-extern const float kGraphicOneF;
-extern const float kGraphicSphereNegativeX;
-extern const double kGraphicHalfF64;
-extern const float kGraphicSpherePi;
-extern const float kGraphicSmallBackTextureWidth;
-extern const float kGraphicSmallBackTextureHeight;
-extern const float kGraphicSphereRingDivisor;
-extern const float kGraphicSphereSegmentAngle;
-extern const float kGraphicBlurAlphaScale;
-extern const float kGraphicNoiseTexScaleU;
-extern const float kGraphicNoiseTexScaleV;
 
 #ifdef __cplusplus
 }

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1606,8 +1606,6 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	float projY;
 	float projZ;
 	unsigned int texBufferSize;
-	unsigned int depthAlphaNear;
-	unsigned int depthAlphaFar;
 	int nearAlpha;
 	int farAlpha;
 	float xOffset;
@@ -1654,11 +1652,10 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		GXProject(cameraPos.x + scaledDir.x, targetPos.y, cameraPos.z + scaledDir.z, cameraMtx, gxProjection,
 		          gxViewport, &projX, &projY, &projZ);
 
-		depthAlphaNear = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
-		if (depthAlphaNear >= 0xFF) {
-			depthAlphaNear = 0xFF;
+		nearAlpha = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
+		if (nearAlpha >= 0xFF) {
+			nearAlpha = 0xFF;
 		}
-		nearAlpha = depthAlphaNear;
 		hasNearAlpha = 1;
 	}
 
@@ -1669,14 +1666,13 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		GXProject(targetPos.x + scaledDir.x, targetPos.y, targetPos.z + scaledDir.z, cameraMtx, gxProjection,
 		          gxViewport, &projX, &projY, &projZ);
 
-		depthAlphaFar = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
-		if (depthAlphaFar == 0) {
-			depthAlphaFar = 0xFF;
+		farAlpha = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
+		if (farAlpha == 0) {
+			farAlpha = 0xFF;
 		}
-		if (depthAlphaFar >= 0xFF) {
-			depthAlphaFar = 0xFF;
+		if (farAlpha >= 0xFF) {
+			farAlpha = 0xFF;
 		}
-		farAlpha = depthAlphaFar;
 		hasFarAlpha = 1;
 	}
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1263,8 +1263,8 @@ void CGraphic::SetFogParam(float startZ, float endZ)
  */
 void CGraphic::SetFog(int useFog, int useGlobalColor)
 {
-    float farZ;
     float nearZ;
+    float farZ;
 
     if (&nearZ != 0) {
         nearZ = CameraNearZ();

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -79,6 +79,11 @@ static inline float CameraWorldX()
     return CameraPcs.m_positionX;
 }
 
+static inline float CameraWorldY()
+{
+    return CameraPcs.m_positionY;
+}
+
 static inline float CameraWorldZ()
 {
     return CameraPcs.m_positionZ;
@@ -1605,9 +1610,9 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	float projX;
 	float projY;
 	float projZ;
-	unsigned int texBufferSize;
 	int nearAlpha;
 	int farAlpha;
+	unsigned int texBufferSize;
 	float xOffset;
 	float yOffset;
 	int hasNearAlpha;
@@ -1635,6 +1640,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	texBufferSize = GXGetTexBufferSize(0x140, 0xE0, GX_TF_RGBA8, GX_FALSE, GX_FALSE);
 
 	cameraPos.x = CameraWorldX();
+	cameraPos.y = CameraWorldY();
 	cameraPos.z = CameraWorldZ();
 	hasNearAlpha = 0;
 	cameraPos.y = kGraphicZeroF;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1462,28 +1462,39 @@ void CGraphic::RenderTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor
 {
 	GXBegin(GX_QUADS, GX_VTXFMT7, 4);
 
-	float x1 = pos1.x;
-	float y1 = pos1.y;
-	float tex0 = kGraphicZeroF;
-	float tex1 = kGraphicOneF;
-	float z1 = pos1.z;
+	float tex1;
+	float x2;
+	float tex0;
+	float x1;
+	float y1;
+	float z1;
+	float y2;
+	u32 rgba1;
+	u32 rgba4;
+	u32 rgba2;
+	u32 rgba3;
 
+	x1 = pos1.x;
+	y1 = pos1.y;
 	GXWGFifo.f32 = x1;
+	z1 = pos1.z;
 	GXWGFifo.f32 = y1;
-	u32 rgba1 = *(u32*)&color1;
+	rgba1 = *(u32*)&color1;
 	GXWGFifo.f32 = z1;
+	tex0 = kGraphicZeroF;
 	GXWGFifo.u32 = rgba1;
-	float x2 = pos2.x;
+	x2 = pos2.x;
 	GXWGFifo.f32 = tex0;
-	u32 rgba2 = *(u32*)&color2;
+	rgba2 = *(u32*)&color2;
 	GXWGFifo.f32 = tex0;
+	tex1 = kGraphicOneF;
 
 	GXWGFifo.f32 = x2;
-	float y2 = pos2.y;
+	y2 = pos2.y;
 	GXWGFifo.f32 = y1;
-	u32 rgba4 = *(u32*)&color4;
+	rgba4 = *(u32*)&color4;
 	GXWGFifo.f32 = z1;
-	u32 rgba3 = *(u32*)&color3;
+	rgba3 = *(u32*)&color3;
 	GXWGFifo.u32 = rgba2;
 	GXWGFifo.f32 = tex1;
 	GXWGFifo.f32 = tex0;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1593,6 +1593,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	_GXTexObj smallBackTex;
 	_GXTexObj backBufferTex;
 	_GXColor dofColor;
+	_GXColor chanColor;
 	Vec cameraPos;
 	Vec cameraToTarget;
 	Vec scaledDir;
@@ -1607,8 +1608,8 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	unsigned int texBufferSize;
 	unsigned int depthAlphaNear;
 	unsigned int depthAlphaFar;
-	signed char nearAlpha;
-	unsigned char farAlpha;
+	int nearAlpha;
+	int farAlpha;
 	float xOffset;
 	float yOffset;
 	int hasNearAlpha;
@@ -1657,7 +1658,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		if (depthAlphaNear >= 0xFF) {
 			depthAlphaNear = 0xFF;
 		}
-		nearAlpha = (signed char)depthAlphaNear;
+		nearAlpha = depthAlphaNear;
 		hasNearAlpha = 1;
 	}
 
@@ -1675,7 +1676,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		if (depthAlphaFar >= 0xFF) {
 			depthAlphaFar = 0xFF;
 		}
-		farAlpha = (signed char)depthAlphaFar;
+		farAlpha = depthAlphaFar;
 		hasFarAlpha = 1;
 	}
 
@@ -1699,7 +1700,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	for (int pass = 0; pass < 2; pass++) {
 		int kColorSel = 0x0C;
 		int kAlphaSel = 0x1C;
-		signed char passAlpha = nearAlpha;
+		int passAlpha = nearAlpha;
 
 		if ((pass == 0) && !((mode != 2) && hasNearAlpha && (mode != 1) && hasFarAlpha)) {
 			continue;
@@ -1717,9 +1718,12 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		dofColor.a = passAlpha;
 		GXSetTevKColor((GXTevKColorID)pass, dofColor);
 
-		dofColor.a = 0x80;
-		GXSetChanAmbColor(GX_COLOR0A0, dofColor);
-		GXSetChanMatColor(GX_COLOR0A0, dofColor);
+		chanColor.r = passAlpha;
+		chanColor.g = passAlpha;
+		chanColor.b = passAlpha;
+		chanColor.a = 0x80;
+		GXSetChanAmbColor(GX_COLOR0A0, chanColor);
+		GXSetChanMatColor(GX_COLOR0A0, chanColor);
 
 		_GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_NOOP);
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1659,7 +1659,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		          gxViewport, &projX, &projY, &projZ);
 
 		nearAlpha = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
-		if (nearAlpha >= 0xFF) {
+		if ((unsigned int)nearAlpha >= 0xFF) {
 			nearAlpha = 0xFF;
 		}
 		hasNearAlpha = 1;
@@ -1676,7 +1676,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		if (farAlpha == 0) {
 			farAlpha = 0xFF;
 		}
-		if (farAlpha >= 0xFF) {
+		if ((unsigned int)farAlpha >= 0xFF) {
 			farAlpha = 0xFF;
 		}
 		hasFarAlpha = 1;
@@ -1700,15 +1700,17 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	yOffset = xOffset * FLOAT_8032F6FC;
 
 	for (int pass = 0; pass < 2; pass++) {
-		int kColorSel = 0x0C;
-		int kAlphaSel = 0x1C;
-		int passAlpha = nearAlpha;
-
 		if ((pass == 0) && !((mode != 2) && hasNearAlpha && (mode != 1) && hasFarAlpha)) {
 			continue;
 		}
 
+		GXTevKColorID kColorId = (GXTevKColorID)0;
+		int kColorSel = 0x0C;
+		int kAlphaSel = 0x1C;
+		int passAlpha = nearAlpha;
+
 		if (pass != 0) {
+			kColorId = (GXTevKColorID)1;
 			kColorSel = 0x0D;
 			kAlphaSel = 0x1D;
 			passAlpha = farAlpha;
@@ -1722,7 +1724,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		chanColor.g = passAlpha;
 		chanColor.b = passAlpha;
 		chanColor.a = 0x80;
-		GXSetTevKColor((GXTevKColorID)pass, dofColor);
+		GXSetTevKColor(kColorId, dofColor);
 		GXSetChanAmbColor(GX_COLOR0A0, chanColor);
 		GXSetChanMatColor(GX_COLOR0A0, chanColor);
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1420,56 +1420,49 @@ _GXTexObj* CGraphic::GetBackBufferRect(int& x, int& y, int& width, int& height, 
 void CGraphic::GetBackBufferRect2(void* dstBuffer, _GXTexObj* texObj, int x, int y, int width, int height, int dstOffset,
                                   _GXTexFilter filter, _GXTexFmt format, int doClear)
 {
-    int copyX = x;
-    int copyY = y;
-    int copyWidth = width;
-    int copyHeight = height;
-    _GXTexFmt copyFormat = format;
-    _GXTexFilter copyFilter = filter;
-    int copyClear = doClear;
-    int xEnd = copyX + copyWidth;
-    int yEnd = copyY + copyHeight;
-    if ((xEnd >= 0) && (yEnd >= 0) && (copyX <= m_renderMode->fbWidth) &&
-        ((yEnd >= 0) && (copyY <= m_renderMode->efbHeight)) &&
-        ((copyWidth > 0) && ((copyHeight > 0) && (xEnd != copyX))) && (yEnd != copyY)) {
+    int xEnd = x + width;
+    int yEnd = y + height;
+    if ((xEnd >= 0) && (yEnd >= 0) && (x <= m_renderMode->fbWidth) &&
+        ((yEnd >= 0) && (y <= m_renderMode->efbHeight)) &&
+        ((width > 0) && ((height > 0) && (xEnd != x))) && (yEnd != y)) {
         void* textureBase;
-        int textureSize = GXGetTexBufferSize((u16)copyWidth, (u16)copyHeight, copyFormat, GX_FALSE, GX_FALSE);
+        int textureSize = GXGetTexBufferSize((u16)width, (u16)height, format, GX_FALSE, GX_FALSE);
         textureBase =
             reinterpret_cast<void*>((reinterpret_cast<u32>(dstBuffer) + ((dstOffset + 0x1F) & 0xFFFFFFE0) + 0x1F) &
                                     0xFFFFFFE0);
 
-        GXSetTexCopySrc(copyX & 0xFFFF, copyY & 0xFFFF, (u16)copyWidth, (u16)copyHeight);
-        GXSetTexCopyDst((u16)copyWidth, (u16)copyHeight, copyFormat, GX_FALSE);
+        GXSetTexCopySrc(x & 0xFFFF, y & 0xFFFF, (u16)width, (u16)height);
+        GXSetTexCopyDst((u16)width, (u16)height, format, GX_FALSE);
         DCInvalidateRange(textureBase, textureSize);
-        GXCopyTex(textureBase, copyClear);
+        GXCopyTex(textureBase, doClear);
         GXPixModeSync();
         GXInvalidateTexAll();
 
-        switch (copyFormat) {
+        switch (format) {
         case GX_CTF_R4:
         case GX_CTF_RA4:
-            copyFormat = GX_TF_I4;
+            format = GX_TF_I4;
             break;
         case GX_CTF_RA8:
         case GX_CTF_A8:
         case GX_CTF_R8:
         case GX_CTF_G8:
         case GX_CTF_B8:
-            copyFormat = GX_TF_I8;
+            format = GX_TF_I8;
             break;
         case GX_CTF_RG8:
         case GX_CTF_GB8:
-            copyFormat = GX_TF_IA8;
+            format = GX_TF_IA8;
             break;
         default:
             break;
         }
 
         if (texObj != nullptr) {
-            GXInitTexObj(texObj, textureBase, (u16)copyWidth, (u16)copyHeight, copyFormat, GX_CLAMP, GX_CLAMP,
+            GXInitTexObj(texObj, textureBase, (u16)width, (u16)height, format, GX_CLAMP, GX_CLAMP,
                          GX_FALSE);
             float zero = LoadFloat(kGraphicZeroF);
-            GXInitTexObjLOD(texObj, copyFilter, copyFilter, zero, zero, zero, GX_FALSE, GX_FALSE,
+            GXInitTexObjLOD(texObj, filter, filter, zero, zero, zero, GX_FALSE, GX_FALSE,
                             GX_ANISO_1);
         }
     }

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1263,8 +1263,6 @@ void CGraphic::SetFogParam(float startZ, float endZ)
  */
 void CGraphic::SetFog(int useFog, int useGlobalColor)
 {
-    _GXColor* colorPtr;
-    GXFogType fogType;
     float farZ;
     float nearZ;
 
@@ -1275,19 +1273,7 @@ void CGraphic::SetFog(int useFog, int useGlobalColor)
         farZ = CameraFarZ();
     }
 
-    if (useGlobalColor != 0) {
-        colorPtr = &gGraphicDefaultClearColor;
-    } else {
-        colorPtr = &m_fogColor;
-    }
-
-    _GXColor fogColor = *colorPtr;
-    fogType = GX_FOG_NONE;
-    if (useFog != 0) {
-        fogType = GX_FOG_LIN;
-    }
-
-    GXSetFog(fogType, m_fogStart, m_fogEnd, nearZ, farZ, fogColor);
+    GXSetFog(useFog != 0 ? GX_FOG_LIN : GX_FOG_NONE, m_fogStart, m_fogEnd, nearZ, farZ, useGlobalColor != 0 ? gGraphicDefaultClearColor : m_fogColor);
 }
 
 /*

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1712,12 +1712,11 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		dofColor.g = passAlpha;
 		dofColor.b = passAlpha;
 		dofColor.a = passAlpha;
-		GXSetTevKColor((GXTevKColorID)pass, dofColor);
-
 		chanColor.r = passAlpha;
 		chanColor.g = passAlpha;
 		chanColor.b = passAlpha;
 		chanColor.a = 0x80;
+		GXSetTevKColor((GXTevKColorID)pass, dofColor);
 		GXSetChanAmbColor(GX_COLOR0A0, chanColor);
 		GXSetChanMatColor(GX_COLOR0A0, chanColor);
 
@@ -1759,7 +1758,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		quadMax.x = FLOAT_8032F6C8;
 		quadMax.y = FLOAT_8032F6CC;
 		quadMax.z = kGraphicZeroF;
-		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+		gUtil.RenderQuadTex2(quadMin, quadMax, chanColor, 0, 0);
 
 		quadMin.x = -xOffset;
 		quadMin.y = kGraphicZeroF;
@@ -1767,7 +1766,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		quadMax.x = FLOAT_8032F6C8 - xOffset;
 		quadMax.y = FLOAT_8032F6CC;
 		quadMax.z = kGraphicZeroF;
-		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+		gUtil.RenderQuadTex2(quadMin, quadMax, chanColor, 0, 0);
 
 		quadMin.x = xOffset;
 		quadMin.y = kGraphicZeroF;
@@ -1775,7 +1774,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		quadMax.x = FLOAT_8032F6C8 + xOffset;
 		quadMax.y = FLOAT_8032F6CC;
 		quadMax.z = kGraphicZeroF;
-		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+		gUtil.RenderQuadTex2(quadMin, quadMax, chanColor, 0, 0);
 
 		quadMin.x = kGraphicZeroF;
 		quadMin.y = -yOffset;
@@ -1783,7 +1782,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		quadMax.x = FLOAT_8032F6C8;
 		quadMax.y = FLOAT_8032F6CC - yOffset;
 		quadMax.z = kGraphicZeroF;
-		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+		gUtil.RenderQuadTex2(quadMin, quadMax, chanColor, 0, 0);
 
 		quadMin.x = kGraphicZeroF;
 		quadMin.y = yOffset;
@@ -1791,7 +1790,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		quadMax.x = FLOAT_8032F6C8;
 		quadMax.y = FLOAT_8032F6CC + yOffset;
 		quadMax.z = kGraphicZeroF;
-		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
+		gUtil.RenderQuadTex2(quadMin, quadMax, chanColor, 0, 0);
 	}
 }
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -421,7 +421,7 @@ void CGraphic::BeginFrame()
     if (useDebugPad) {
         buttons = 0;
     } else {
-        int padIndex = (Pad.m_debugPadPort == 0) ? Pad.m_debugPadPort : 0;
+        int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
         buttons = Pad.GetPadInputs()[padIndex].lockedButton[1];
     }
 

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -44,6 +44,26 @@ static inline float LoadFloat(const float& value) {
     return value;
 }
 
+
+extern const float kGraphicZeroF = 0.0f;
+extern const float kGraphicOneF = 1.0f;
+extern const float FLOAT_8032F6C8 = 640.0f;
+extern const float FLOAT_8032F6CC = 448.0f;
+extern const float kGraphicSphereNegativeX = -1.0f;
+extern const double kGraphicHalfF64 = 4503599627370496.0;
+extern const float kGraphicSpherePi = 3.1415927410125732f;
+extern const double DOUBLE_8032F6E8 = 4503601774854144.0;
+extern const float kGraphicSmallBackTextureWidth = 320.0f;
+extern const float kGraphicSmallBackTextureHeight = 224.0f;
+extern const float FLOAT_8032F6F8 = 16777215.0f;
+extern const float FLOAT_8032F6FC = 0.7f;
+extern const float kGraphicSphereRingDivisor = 6.0f;
+extern const float kGraphicSphereSegmentAngle = 0.7853981852531433f;
+extern const float kGraphicBlurAlphaScale = -100.0f;
+extern const float kGraphicNoiseTexScaleU = 0.015625f;
+extern const float kGraphicNoiseTexScaleV = 0.010416667163372f;
+extern const char sGraphicUnknownOrderName[4] = "---";
+
 static inline float CameraNearZ()
 {
     return CameraPcs.m_nearZ;
@@ -366,8 +386,8 @@ void CGraphic::SetStdPixelFmt()
  */
 void CGraphic::SetViewport()
 {
-    GXSetViewport(0.0f, 0.0f, static_cast<f32>(m_renderMode->fbWidth), static_cast<f32>(m_renderMode->efbHeight),
-                  0.0f, 1.0f);
+    GXSetViewport(kGraphicZeroF, kGraphicZeroF, static_cast<f32>(m_renderMode->fbWidth), static_cast<f32>(m_renderMode->efbHeight),
+                  kGraphicZeroF, kGraphicOneF);
     GXSetScissor(0, 0, m_renderMode->fbWidth, m_renderMode->efbHeight);
 }
 
@@ -1633,7 +1653,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		GXProject(cameraPos.x + scaledDir.x, targetPos.y, cameraPos.z + scaledDir.z, cameraMtx, gxProjection,
 		          gxViewport, &projX, &projY, &projZ);
 
-		depthAlphaNear = static_cast<unsigned int>(projZ * 16777215.0f) >> 16;
+		depthAlphaNear = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
 		if (depthAlphaNear >= 0xFF) {
 			depthAlphaNear = 0xFF;
 		}
@@ -1648,7 +1668,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		GXProject(targetPos.x + scaledDir.x, targetPos.y, targetPos.z + scaledDir.z, cameraMtx, gxProjection,
 		          gxViewport, &projX, &projY, &projZ);
 
-		depthAlphaFar = static_cast<unsigned int>(projZ * 16777215.0f) >> 16;
+		depthAlphaFar = static_cast<unsigned int>(projZ * FLOAT_8032F6F8) >> 16;
 		if (depthAlphaFar == 0) {
 			depthAlphaFar = 0xFF;
 		}
@@ -1674,7 +1694,7 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 	gUtil.SetOrthoEnv();
 
 	xOffset = (float)blurWidth;
-	yOffset = xOffset * 0.35f;
+	yOffset = xOffset * FLOAT_8032F6FC;
 
 	for (int pass = 0; pass < 2; pass++) {
 		int kColorSel = 0x0C;
@@ -1733,44 +1753,44 @@ void CGraphic::RenderDOF(signed char mode, signed char blurWidth, float nearDist
 		GXSetNumTevStages(2);
 		GXSetNumTexGens(2);
 
-		quadMin.x = 0.0f;
-		quadMin.y = 0.0f;
-		quadMin.z = 0.0f;
-		quadMax.x = 640.0f;
-		quadMax.y = 224.0f;
-		quadMax.z = 0.0f;
+		quadMin.x = kGraphicZeroF;
+		quadMin.y = kGraphicZeroF;
+		quadMin.z = kGraphicZeroF;
+		quadMax.x = FLOAT_8032F6C8;
+		quadMax.y = FLOAT_8032F6CC;
+		quadMax.z = kGraphicZeroF;
 		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
 
 		quadMin.x = -xOffset;
-		quadMin.y = 0.0f;
-		quadMin.z = 0.0f;
-		quadMax.x = 640.0f - xOffset;
-		quadMax.y = 224.0f;
-		quadMax.z = 0.0f;
+		quadMin.y = kGraphicZeroF;
+		quadMin.z = kGraphicZeroF;
+		quadMax.x = FLOAT_8032F6C8 - xOffset;
+		quadMax.y = FLOAT_8032F6CC;
+		quadMax.z = kGraphicZeroF;
 		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
 
 		quadMin.x = xOffset;
-		quadMin.y = 0.0f;
-		quadMin.z = 0.0f;
-		quadMax.x = 640.0f + xOffset;
-		quadMax.y = 224.0f;
-		quadMax.z = 0.0f;
+		quadMin.y = kGraphicZeroF;
+		quadMin.z = kGraphicZeroF;
+		quadMax.x = FLOAT_8032F6C8 + xOffset;
+		quadMax.y = FLOAT_8032F6CC;
+		quadMax.z = kGraphicZeroF;
 		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
 
-		quadMin.x = 0.0f;
+		quadMin.x = kGraphicZeroF;
 		quadMin.y = -yOffset;
-		quadMin.z = 0.0f;
-		quadMax.x = 640.0f;
-		quadMax.y = 224.0f - yOffset;
-		quadMax.z = 0.0f;
+		quadMin.z = kGraphicZeroF;
+		quadMax.x = FLOAT_8032F6C8;
+		quadMax.y = FLOAT_8032F6CC - yOffset;
+		quadMax.z = kGraphicZeroF;
 		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
 
-		quadMin.x = 0.0f;
+		quadMin.x = kGraphicZeroF;
 		quadMin.y = yOffset;
-		quadMin.z = 0.0f;
-		quadMax.x = 640.0f;
-		quadMax.y = 224.0f + yOffset;
-		quadMax.z = 0.0f;
+		quadMin.z = kGraphicZeroF;
+		quadMax.x = FLOAT_8032F6C8;
+		quadMax.y = FLOAT_8032F6CC + yOffset;
+		quadMax.z = kGraphicZeroF;
 		gUtil.RenderQuadTex2(quadMin, quadMax, dofColor, 0, 0);
 	}
 }
@@ -1825,53 +1845,53 @@ void CGraphic::CreateSmallBackTexture(void* src, _GXTexObj* texObj, long width, 
     white.a = 0xFF;
 
     GetBackBufferRect2(m_scratchTextureBuffer, &tempTex, 0, 0, 0x140, 0xE0, 0x46000, filter, GX_TF_RGBA8, 0);
-    quadMin.x = 0.0f;
-    quadMin.y = 0.0f;
-    quadMin.z = 0.0f;
+    quadMin.x = kGraphicZeroF;
+    quadMin.y = kGraphicZeroF;
+    quadMin.z = kGraphicZeroF;
     quadMax.x = static_cast<float>(halfWidth);
     quadMax.y = static_cast<float>(halfHeight);
-    quadMax.z = 0.0f;
+    quadMax.z = kGraphicZeroF;
     GXLoadTexObj(&tempTex, GX_TEXMAP0);
     gUtil.RenderQuad(quadMin, quadMax, white, 0, 0);
 
     GetBackBufferRect2(m_scratchTextureBuffer, texObj, 0x140, 0, 0x140, 0xE0, 0, filter, format, 0);
     quadMin.x = static_cast<float>(halfWidth);
-    quadMin.y = 0.0f;
-    quadMin.z = 0.0f;
+    quadMin.y = kGraphicZeroF;
+    quadMin.z = kGraphicZeroF;
     quadMax.x = static_cast<float>(width);
     quadMax.y = static_cast<float>(halfHeight);
-    quadMax.z = 0.0f;
+    quadMax.z = kGraphicZeroF;
     GXLoadTexObj(texObj, GX_TEXMAP0);
     gUtil.RenderQuad(quadMin, quadMax, white, 0, 0);
 
     GetBackBufferRect2(m_scratchTextureBuffer, texObj, 0, 0xE0, 0x140, 0xE0, 0, filter, format, 0);
-    quadMin.x = 0.0f;
+    quadMin.x = kGraphicZeroF;
     quadMin.y = static_cast<float>(halfHeight);
-    quadMin.z = 0.0f;
+    quadMin.z = kGraphicZeroF;
     quadMax.x = static_cast<float>(halfWidth);
     quadMax.y = static_cast<float>(height);
-    quadMax.z = 0.0f;
+    quadMax.z = kGraphicZeroF;
     GXLoadTexObj(texObj, GX_TEXMAP0);
     gUtil.RenderQuad(quadMin, quadMax, white, 0, 0);
 
     GetBackBufferRect2(m_scratchTextureBuffer, texObj, 0x140, 0xE0, 0x140, 0xE0, 0, filter, format, 0);
     quadMin.x = static_cast<float>(halfWidth);
     quadMin.y = static_cast<float>(halfHeight);
-    quadMin.z = 0.0f;
+    quadMin.z = kGraphicZeroF;
     quadMax.x = static_cast<float>(width);
     quadMax.y = static_cast<float>(height);
-    quadMax.z = 0.0f;
+    quadMax.z = kGraphicZeroF;
     GXLoadTexObj(texObj, GX_TEXMAP0);
     gUtil.RenderQuad(quadMin, quadMax, white, 0, 0);
 
     GetBackBufferRect2(src, texObj, 0, 0, static_cast<int>(width), static_cast<int>(height), textureSize, filter, format, 0);
     GXLoadTexObj(&tempTex, GX_TEXMAP0);
-    quadMin.x = 0.0f;
-    quadMin.y = 0.0f;
-    quadMin.z = 0.0f;
+    quadMin.x = kGraphicZeroF;
+    quadMin.y = kGraphicZeroF;
+    quadMin.z = kGraphicZeroF;
     quadMax.x = kGraphicSmallBackTextureWidth;
     quadMax.y = kGraphicSmallBackTextureHeight;
-    quadMax.z = 0.0f;
+    quadMax.z = kGraphicZeroF;
     gUtil.RenderQuad(quadMin, quadMax, white, 0, 0);
 
     PSMTXCopy(CameraMatrix(), cameraMtx);
@@ -1953,24 +1973,24 @@ void CGraphic::RenderBlur(int unused0, unsigned char mode, unsigned char unused2
         int negativeBlurOffset = -blurOffsetInt;
         u8* textureBase = reinterpret_cast<u8*>(m_savedFrameBuffer) + textureOffset;
         GXInitTexObj(&texObj, textureBase, 0x140, 0xE0, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP, GX_FALSE);
-        GXInitTexObjLOD(&texObj, GX_LINEAR, GX_LINEAR, 0.0f, 0.0f, 0.0f, GX_FALSE, GX_FALSE, GX_ANISO_1);
+        GXInitTexObjLOD(&texObj, GX_LINEAR, GX_LINEAR, kGraphicZeroF, kGraphicZeroF, kGraphicZeroF, GX_FALSE, GX_FALSE, GX_ANISO_1);
         GXLoadTexObj(&texObj, GX_TEXMAP0);
 
         if (mode == 1) {
-            quadMin.x = 0.0f;
-            quadMin.y = 0.0f;
-            quadMin.z = 0.0f;
-            quadMax.x = 640.0f;
-            quadMax.y = 448.0f;
-            quadMax.z = 0.0f;
+            quadMin.x = kGraphicZeroF;
+            quadMin.y = kGraphicZeroF;
+            quadMin.z = kGraphicZeroF;
+            quadMax.x = FLOAT_8032F6C8;
+            quadMax.y = FLOAT_8032F6CC;
+            quadMax.z = kGraphicZeroF;
             gUtil.RenderQuad(quadMin, quadMax, blurColor, 0, 0);
         } else if (mode == 0) {
             quadMin.x = static_cast<float>(negativeBlurOffset);
             quadMin.y = static_cast<float>(negativeBlurOffset);
-            quadMin.z = 0.0f;
+            quadMin.z = kGraphicZeroF;
             quadMax.x = static_cast<float>(640 - negativeBlurOffset);
             quadMax.y = static_cast<float>(448 - negativeBlurOffset);
-            quadMax.z = 0.0f;
+            quadMax.z = kGraphicZeroF;
             gUtil.RenderQuad(quadMin, quadMax, blurColor, 0, 0);
         }
         textureOffset += 0x46000;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1407,8 +1407,9 @@ void CGraphic::GetBackBufferRect2(void* dstBuffer, _GXTexObj* texObj, int x, int
     if ((xEnd >= 0) && (yEnd >= 0) && (copyX <= m_renderMode->fbWidth) &&
         ((yEnd >= 0) && (copyY <= m_renderMode->efbHeight)) &&
         ((copyWidth > 0) && ((copyHeight > 0) && (xEnd != copyX))) && (yEnd != copyY)) {
+        void* textureBase;
         int textureSize = GXGetTexBufferSize((u16)copyWidth, (u16)copyHeight, copyFormat, GX_FALSE, GX_FALSE);
-        void* textureBase =
+        textureBase =
             reinterpret_cast<void*>((reinterpret_cast<u32>(dstBuffer) + ((dstOffset + 0x1F) & 0xFFFFFFE0) + 0x1F) &
                                     0xFFFFFFE0);
 


### PR DESCRIPTION
Raises main/graphic from 95.82% to 96.89% (+1.07), data 97.996% -> 98.098%, matched functions 32 -> 34.

## Per-function gains
- SetFog 86.3 -> **100%**: both ternaries (fogType + color select) inline in the GXSetFog call; nearZ/farZ decl order.
- RenderDOF 94.6 -> **99.75%**: merged depthAlpha temps into near/farAlpha; separate chanColor struct stored BEFORE GXSetTevKColor (quads pass chanColor); recovered dead `cameraPos.y = CameraWorldY()` store; kColorId variable instead of `(GXTevKColorID)pass`; unsigned clamp compares; texBufferSize decl order; constant fixes 0.35->0.7 (FLOAT_8032F6FC) and 224->448 (FLOAT_8032F6CC) matching DOL values.
- BeginFrame 95.97 -> **99.78%**: R27 redundant ternary `(port == 0) ? 0 : 0` keeps the branchless cntlzw/andc select.
- sdata2 reconstruction (R43/R46): claimed 0x8032F6C0-0x718 for graphic.cpp and defined all 18 pool constants (incl. both int->double biases) in exact DOL order — fontman-style C++-linkage defs (extern "C" header decls forced .sdata placement; moved out).
- RenderTexQuadGrouad 87.3 -> 88.4: FPR numbering = declaration order (uninitialized decls tex1,x2,tex0,x1,y1,z1,y2 + interleaved assignments).
- GetBackBufferRect2 88.7 -> 89.6: textureBase decl-first register roles; dropped param-copy locals (stack-arg load order).

## Walls (documented)
- makeSphere (80.1): generation-loop IV structure (one extra GPR: element-index IV pair vs target's byte IV + dual pointer cursors) — ~15 variants tried, mwcc either folds the z-store into the cursor or keeps the element IV.
- Thread (91.1)/Init/GetBackBufferRect/quad-fn fifo r5: callee-saved/scratch allocation rotation (one value allocated first) not source-steerable.
- Anonymous pool reloc names (@NNN vs named) cost no fuzzy points (verified by symbols.txt rename test).
- Manual union bias conversion (ME_USB style) regresses — compiler conversion shape differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)