### PR TITLE
gxfunc: raise fuzzy match to 97.8% (cycle 6)

### DIFF
--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -186,6 +186,7 @@ void _InitGxFunc()
 	s_GXSetNumTevStages_nStages = 0xFFFF;
 	s_GXSetBlendMode_Reg.mode = static_cast<_GXBlendMode>(-1);
 }
+#pragma always_inline off
 
 /*
  * --INFO--

--- a/src/gxfunc.cpp
+++ b/src/gxfunc.cpp
@@ -83,13 +83,14 @@ unsigned short s_GXSetNumTevStages_nStages;
  * JP Address: TODO
  * JP Size: TODO
  */
-void _InitGxFunc()
+#pragma always_inline on
+static inline void initTevRegs()
 {
+	int* puVar2 = (int*)s_GXSetTevOrder_Reg;
 	int iVar1 = 0;
 	int iVar8 = 0;
 	int iVar10 = 0;
 	int iVar9 = 0;
-	int* puVar2 = (int*)s_GXSetTevOrder_Reg;
 	int* colorIn = (int*)s_GXSetTevColorIn_Reg;
 	int* alphaIn = (int*)s_GXSetTevAlphaIn_Reg;
 	int* colorOp = (int*)s_GXSetTevColorOp_Reg;
@@ -171,6 +172,11 @@ void _InitGxFunc()
 		alphaOp[iVar11 * 5] = -1;
 		swapMode[iVar11 * 2] = -1;
 	}
+}
+
+void _InitGxFunc()
+{
+	initTevRegs();
 
 	s_GXSetTevSwapModeTable_Reg[0].red = static_cast<_GXTevColorChan>(-1);
 	s_GXSetTevSwapModeTable_Reg[1].red = static_cast<_GXTevColorChan>(-1);


### PR DESCRIPTION
Raises main/gxfunc from 93.69% to 97.82% (+4.13) by cracking the _InitGxFunc register-coloring wall (78.4% -> 92.5%).

**What worked:** the "interlinked register-coloring swap" (bases in callee-saved r24-r29 instead of volatile r3-r9) was fixed by moving the table-init loop into a `static inline` helper forced inline with `#pragma always_inline on`. mwcc colors an inlined callee's body locals into the volatile pool (descending from r9 in declaration order), which lands all six table base pointers exactly on the target's r3-r7/r9 and `i` on r8. Declaring the order-table cursor (`puVar2`) first fixed the final r8/r9 swap.

**Residual (~2.2 pts):** a single allocator tie-break — target rematerializes `-1` in scratch r0 while ours hoists it to r16, permuting the temp registers. ~25 perturbations tested (decl orders, accumulators-as-params, helper return junctions, split constants, do/while, mw_version 1.3/1.3.2r/2.0, -O4 variants, opt_lifetimes/peephole/scheduling pragmas) all produce bit-identical output or regress; both colorings are self-consistent 29-register fixed points.

Data 100%, all 10 other functions 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)