### PR TITLE
cmake: raise fuzzy match to 96.4% (cycle 26)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3966,12 +3966,11 @@ void CMenuPcs::CalcSingCMake()
             if (repeat == 0) {
                 done = 0;
             } else {
-                int dirMask = repeat & 0xC;
-                if (dirMask != 0) {
+                if ((repeat & 0xC) != 0) {
                     CmakeState(this)->m_select ^= 1;
                     Sound.PlaySe(1, 0x40, 0x7F, 0);
                 }
-                if (dirMask == 0) {
+                if ((repeat & 0xC) == 0) {
                     if ((down & 0x100) != 0) {
                         s_CmakeInfo.m_gender = static_cast<signed char>(CmakeState(this)->m_select);
                         CmakeState(this)->m_resultDir = 1;
@@ -4080,12 +4079,11 @@ void CMenuPcs::CalcSingCMake()
             if (repeat == 0) {
                 done = 0;
             } else {
-                int dirMask = repeat & 3;
-                if (dirMask != 0) {
+                if ((repeat & 3) != 0) {
                     CmakeState(this)->m_select ^= 1;
                     Sound.PlaySe(1, 0x40, 0x7F, 0);
                 }
-                if (dirMask == 0) {
+                if ((repeat & 3) == 0) {
                     if ((down & 0x100) != 0) {
                         if (CmakeState(this)->m_select == 0) {
                             CmakeState(this)->m_resultDir = 1;
@@ -4176,7 +4174,6 @@ void CMenuPcs::CalcSingCMake()
             if (repeat == 0) {
                 done = 0;
             } else {
-                int dirMask = repeat & 0xC;
                 if ((repeat & 0x8) != 0) {
                     if (CmakeState(this)->m_select == 0) {
                         CmakeState(this)->m_select = 3;
@@ -4195,7 +4192,7 @@ void CMenuPcs::CalcSingCMake()
                     Sound.PlaySe(1, 0x40, 0x7F, 0);
                 }
 
-                if (dirMask == 0) {
+                if ((repeat & 0xC) == 0) {
                     if ((down & 0x100) != 0) {
                         if (CmakeState(this)->m_select < 3) {
                             ChgModel(static_cast<int>(CmakeSlot(this)), -1, -1, -1);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1173,15 +1173,7 @@ void CMenuPcs::CmakeResultDraw1()
 
     DrawWMFrame0(1, 1.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    GXColor backdropColor;
-    backdropColor.r = 0xFF;
-    backdropColor.g = 0xFF;
-    backdropColor.b = 0xFF;
-    backdropColor.a = 0xFF;
-    GXSetChanMatColor(GX_COLOR0A0, backdropColor);
+    SetCmakeBlendMatColor(1.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3F));
     MenuPcs.DrawRect(
@@ -1207,37 +1199,22 @@ void CMenuPcs::CmakeResultDraw1()
         tileX += tileW;
     }
 
-    DrawCmakePreviewChara(this);
+    DrawCmakePreviewCharaAlpha(this, 1.0f);
 
     if (CmakeState(this)->m_mode == 0) {
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-        GXColor panelCol;
-        panelCol.r = 0xFF;
-        panelCol.g = 0xFF;
-        panelCol.b = 0xFF;
-        panelCol.a = 0xFF;
-        GXSetChanMatColor(GX_COLOR0A0, panelCol);
+        SetCmakeBlendMatColor(1.0f);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
         MenuPcs.DrawRect(
             0, 192.0f, 56.0f, 416.0f, 264.0f,
             0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
     } else {
-        int panelA = static_cast<int>(255.0f * alpha);
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-        GXColor panelCol;
-        panelCol.r = 0xFF;
-        panelCol.g = 0xFF;
-        panelCol.b = 0xFF;
-        panelCol.a = static_cast<unsigned char>(panelA);
-        GXSetChanMatColor(GX_COLOR0A0, panelCol);
+        SetCmakeBlendMatColor(alpha);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
         MenuPcs.DrawRect(
             0, 192.0f, 56.0f, 416.0f, 264.0f,
             0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
     }
-    DrawCmakeTitle(7, 1.0f, alpha);
+    DrawCmakeTitle(7, alpha, 1.0f);
 
     float textAlpha = alpha;
     if (CmakeState(this)->m_mode == 0) {
@@ -1245,16 +1222,7 @@ void CMenuPcs::CmakeResultDraw1()
     }
     {
         int tribe = static_cast<int>(s_CmakeInfo.m_tribe);
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-        int crestA = static_cast<int>(255.0f * textAlpha);
-        GXColor crestCol;
-        crestCol.r = 0xFF;
-        crestCol.g = 0xFF;
-        crestCol.b = 0xFF;
-        crestCol.a = static_cast<unsigned char>(crestA);
-        GXSetChanMatColor(GX_COLOR0A0, crestCol);
+        SetCmakeBlendMatColor(textAlpha);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x31));
         MenuPcs.DrawRect(
             0,
@@ -1422,15 +1390,7 @@ void CMenuPcs::CmakeResultDraw()
 
     DrawWMFrame0(1, 1.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    GXColor backdropColor;
-    backdropColor.r = 0xFF;
-    backdropColor.g = 0xFF;
-    backdropColor.b = 0xFF;
-    backdropColor.a = 0xFF;
-    GXSetChanMatColor(GX_COLOR0A0, backdropColor);
+    SetCmakeBlendMatColor(1.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3F));
     MenuPcs.DrawRect(
@@ -1740,15 +1700,7 @@ void CMenuPcs::CmakeJobDraw()
 
     DrawWMFrame0(1, 1.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    GXColor backdropColor;
-    backdropColor.r = 0xFF;
-    backdropColor.g = 0xFF;
-    backdropColor.b = 0xFF;
-    backdropColor.a = 0xFF;
-    GXSetChanMatColor(GX_COLOR0A0, backdropColor);
+    SetCmakeBlendMatColor(1.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3F));
     MenuPcs.DrawRect(
@@ -2007,15 +1959,7 @@ void CMenuPcs::CmakeTribeDraw()
 
     DrawWMFrame0(1, 1.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    GXColor backdropColor;
-    backdropColor.r = 0xFF;
-    backdropColor.g = 0xFF;
-    backdropColor.b = 0xFF;
-    backdropColor.a = 0xFF;
-    GXSetChanMatColor(GX_COLOR0A0, backdropColor);
+    SetCmakeBlendMatColor(1.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3F));
     MenuPcs.DrawRect(

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3630,7 +3630,7 @@ void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
     float offs = static_cast<float>(offsU);
     MenuPcs.DrawRect(
         0, 278.0f, offs, 248.0f, 40.0f,
-        0.0f, 264.0f, 1.0f, alpha, 0.0f);
+        0.0f, 264.0f, 1.0f, x, 0.0f);
 
     if (x < 1.0) {
         return;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -184,8 +184,7 @@ static unsigned short GetCmakePadDown()
     if (noPad) {
         held = 0;
     } else {
-        int padIndex = 0;
-        padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+        int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
         held = Pad.GetPadInputs()[padIndex].buttonDown[0];
     }
     return static_cast<unsigned short>(held);
@@ -198,8 +197,7 @@ static unsigned short GetCmakePadRepeat()
     if (noPad) {
         held = 0;
     } else {
-        int padIndex = 0;
-        padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+        int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
         held = Pad.GetPadInputs()[padIndex].repeatButton;
     }
     return static_cast<unsigned short>(held);
@@ -932,8 +930,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
         down = static_cast<short>(static_cast<unsigned short>(held));
@@ -948,8 +945,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
         repeat = static_cast<short>(static_cast<unsigned short>(held));
@@ -1823,8 +1819,7 @@ int CMenuPcs::CmakeJobCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
         down = static_cast<short>(static_cast<unsigned short>(held));
@@ -1839,8 +1834,7 @@ int CMenuPcs::CmakeJobCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
         repeat = static_cast<short>(static_cast<unsigned short>(held));
@@ -2136,8 +2130,7 @@ int CMenuPcs::CmakeTribeCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
         down = static_cast<short>(static_cast<unsigned short>(held));
@@ -2152,8 +2145,7 @@ int CMenuPcs::CmakeTribeCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
         repeat = static_cast<short>(static_cast<unsigned short>(held));
@@ -2651,8 +2643,7 @@ int CMenuPcs::CmakeNameCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
         down = static_cast<short>(static_cast<unsigned short>(held));
@@ -2667,8 +2658,7 @@ int CMenuPcs::CmakeNameCtrl()
         if (padBusy) {
             held = 0;
         } else {
-            int padIndex = 0;
-            padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+            int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
         repeat = static_cast<short>(static_cast<unsigned short>(held));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -969,7 +969,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         }
         Sound.PlaySe(1, 0x40, 0x7f, 0);
     } else if ((repeat & 0x4) != 0) {
-        if (row < (select >= 10 ? 4 : 3)) {
+        if (row < (select >= 10 ? 5 : 4)) {
             row = static_cast<short>(row + 1);
         } else {
             row = 0;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2162,8 +2162,8 @@ int CMenuPcs::CmakeTribeCtrl()
         }
         return 0;
     } else {
-        int tribeCount = 4;
         int fieldSelect = CmakeState(this)->m_fieldSelect;
+        int tribeCount = (fieldSelect != 0) ? 4 : 4;
 
         if ((repeat & 0x8) != 0) {
             short* values = &CmakeState(this)->m_select;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -180,25 +180,29 @@ static inline float CalcCmakeFadeAlpha(CMenuPcs* menu)
 static unsigned short GetCmakePadDown()
 {
     unsigned char noPad = (Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1);
+    int held;
     if (noPad) {
-        return 0;
+        held = 0;
+    } else {
+        int padIndex = 0;
+        padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+        held = Pad.GetPadInputs()[padIndex].buttonDown[0];
     }
-
-    int padIndex = 0;
-    padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
-    return Pad.GetPadInputs()[padIndex].buttonDown[0];
+    return static_cast<unsigned short>(held);
 }
 
 static unsigned short GetCmakePadRepeat()
 {
     unsigned char noPad = (Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1);
+    int held;
     if (noPad) {
-        return 0;
+        held = 0;
+    } else {
+        int padIndex = 0;
+        padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
+        held = Pad.GetPadInputs()[padIndex].repeatButton;
     }
-
-    int padIndex = 0;
-    padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
-    return Pad.GetPadInputs()[padIndex].repeatButton;
+    return static_cast<unsigned short>(held);
 }
 
 static inline void DrawCmakePreviewCharaAlpha(CMenuPcs* menu, float alpha)

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2547,15 +2547,7 @@ void CMenuPcs::CmakeNameDraw()
     }
 
     DrawWMFrame0(1, 1.0f);
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    GXColor backdropColor;
-    backdropColor.r = 0xFF;
-    backdropColor.g = 0xFF;
-    backdropColor.b = 0xFF;
-    backdropColor.a = 0xFF;
-    GXSetChanMatColor(GX_COLOR0A0, backdropColor);
+    SetCmakeBlendMatColor(1.0f);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3F));
     MenuPcs.DrawRect(
         0, 0.0f, 24.0f, 32.0f, 336.0f,
@@ -2576,15 +2568,7 @@ void CMenuPcs::CmakeNameDraw()
         x += span;
     }
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    a255 = 255.0f * alpha;
-    GXColor col;
-    col.r = 0xFF;
-    col.g = 0xFF;
-    col.b = 0xFF;
-    col.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col);
+    SetCmakeBlendMatColor(alpha);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     MenuPcs.DrawRect(
         0, 192.0f, 56.0f, 416.0f, 264.0f,
@@ -2594,35 +2578,21 @@ void CMenuPcs::CmakeNameDraw()
         DrawNamePreviewChara(this, 1.0f, 0xFF);
         DrawCmakeTitle(1, alpha, 1.0f);
     } else if ((CmakeState(this)->m_mode != 2) || (CmakeState(this)->m_resultDir == -1)) {
-        DrawNamePreviewChara(this, alpha, static_cast<int>(a255));
+        DrawNamePreviewChara(this, alpha, static_cast<int>(255.0f * alpha));
         DrawCmakeTitle(1, 1.0f, alpha);
     } else {
         DrawNamePreviewChara(this, 1.0f, 0xFF);
         DrawCmakeTitle(1, alpha, 1.0f);
     }
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    GXColor col2;
-    col2.r = 0xFF;
-    col2.g = 0xFF;
-    col2.b = 0xFF;
-    col2.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col2);
+    SetCmakeBlendMatColor(alpha);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     float titleW = 280.0f;
     MenuPcs.DrawRect(
         0, static_cast<float>(static_cast<int>(-(titleW / 2.0 - 400.0))), 268.0f, titleW, 64.0f,
         0.0f, 304.0f, 1.0f, 1.0f, 0.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    GXColor col3;
-    col3.r = 0xFF;
-    col3.g = 0xFF;
-    col3.b = 0xFF;
-    col3.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col3);
+    SetCmakeBlendMatColor(alpha);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x68 : 0x41));
     MenuPcs.DrawRect(
         0, 184.0f, 216.0f, 48.0f, 48.0f,
@@ -2638,14 +2608,7 @@ void CMenuPcs::CmakeNameDraw()
         int cellX = static_cast<int>(
             26.9f * static_cast<float>(CmakeState(this)->m_select) +
             static_cast<float>(cursorBase));
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-        GXColor selCol;
-        selCol.r = 0xFF;
-        selCol.g = 0xFF;
-        selCol.b = 0xFF;
-        selCol.a = 0xFF;
-        GXSetChanMatColor(GX_COLOR0A0, selCol);
+        SetCmakeBlendMatColor(1.0f);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x64 : 0x3D));
         MenuPcs.DrawRect(
             0, static_cast<float>(cellX), static_cast<float>(cursorY), 48.0f, 48.0f,
@@ -2659,7 +2622,7 @@ void CMenuPcs::CmakeNameDraw()
     font->DrawInit();
     GetRenderFlagBits(font->renderFlags).fixedWidth = 1;
     font->SetMargin(4.9f);
-    font->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a255)).color);
+    SetCmakeFontColor(font, alpha);
 
     int tableBase = table * 5;
     for (int i = 0; i < 5; i++) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -282,6 +282,24 @@ static inline void DrawNamePreviewChara(CMenuPcs* menu, float modelAlpha, int gx
     menu->DrawInit();
 }
 
+static inline void SetCmakeBlendMatColor(float alpha)
+{
+    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
+    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
+
+    GXColor col;
+    col.r = 0xFF;
+    col.g = 0xFF;
+    col.b = 0xFF;
+    col.a = static_cast<unsigned char>(255.0f * alpha);
+    GXSetChanMatColor(GX_COLOR0A0, col);
+}
+
+static inline void SetCmakeFontColor(CFont* font, float alpha)
+{
+    font->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
+}
+
 static inline void DrawCmakeSelectionBackdrop(CMenuPcs* menu)
 {
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
@@ -773,7 +791,6 @@ void CMenuPcs::CmakeVillageDraw()
 {
     CmakeMenuState* villageWork = CmakeVillageState(this);
     int frame = static_cast<int>(villageWork->m_frame) - 1;
-    float a255;
     float alpha;
 
     if (frame < 0) {
@@ -788,16 +805,7 @@ void CMenuPcs::CmakeVillageDraw()
         alpha = static_cast<float>(-(0.1 * static_cast<double>(frame) - 1.0));
     }
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    a255 = 255.0f * alpha;
-    GXColor col0;
-    col0.r = 0xFF;
-    col0.g = 0xFF;
-    col0.b = 0xFF;
-    col0.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col0);
+    SetCmakeBlendMatColor(alpha);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     MenuPcs.DrawRect(
         0, 192.0f, 56.0f, 416.0f, 264.0f,
@@ -805,28 +813,14 @@ void CMenuPcs::CmakeVillageDraw()
 
     DrawCmakeTitle(0, 1.0f, alpha);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    GXColor col1;
-    col1.r = 0xFF;
-    col1.g = 0xFF;
-    col1.b = 0xFF;
-    col1.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col1);
+    SetCmakeBlendMatColor(alpha);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     float panelW = 328.0f;
     MenuPcs.DrawRect(
         0, static_cast<float>(static_cast<int>(-(panelW / 2.0 - 400.0))), 288.0f, panelW, 56.0f,
         0.0f, 368.0f, 1.0f, 1.0f, 0.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    GXColor col2;
-    col2.r = 0xFF;
-    col2.g = 0xFF;
-    col2.b = 0xFF;
-    col2.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col2);
+    SetCmakeBlendMatColor(alpha);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x68 : 0x41));
     MenuPcs.DrawRect(
         0, 184.0f, 216.0f, 48.0f, 48.0f,
@@ -837,18 +831,12 @@ void CMenuPcs::CmakeVillageDraw()
         48.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
     if (villageWork->m_mode == 1 && villageWork->m_row < 5) {
+        short sel = villageWork->m_select;
         int cursorBase = (villageWork->m_row < 5) ? 0xE5 : 0xE5;
         int cursorY = villageWork->m_row * 0x20 + 0x63;
         int cursorX = static_cast<int>(
-            26.9f * static_cast<float>(villageWork->m_select) + static_cast<float>(cursorBase));
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-        GXColor cursorColor;
-        cursorColor.r = 0xFF;
-        cursorColor.g = 0xFF;
-        cursorColor.b = 0xFF;
-        cursorColor.a = 0xFF;
-        GXSetChanMatColor(GX_COLOR0A0, cursorColor);
+            26.9f * static_cast<float>(sel) + static_cast<float>(cursorBase));
+        SetCmakeBlendMatColor(1.0f);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 100 : 0x3D));
         MenuPcs.DrawRect(
             0,
@@ -863,7 +851,7 @@ void CMenuPcs::CmakeVillageDraw()
     font->DrawInit();
     GetRenderFlagBits(font->renderFlags).fixedWidth = 1;
     font->SetMargin(4.9f);
-    font->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a255)).color);
+    SetCmakeFontColor(font, alpha);
 
     int tableBase = table * 5;
     for (int i = 0; i < 5; i++) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -936,7 +936,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -944,7 +944,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
-        down = static_cast<short>(held);
+        down = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     padBusy = false;
@@ -952,7 +952,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -960,7 +960,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
-        repeat = static_cast<short>(held);
+        repeat = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     if (repeat == 0) {
@@ -1875,7 +1875,7 @@ int CMenuPcs::CmakeJobCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -1883,7 +1883,7 @@ int CMenuPcs::CmakeJobCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
-        down = static_cast<short>(held);
+        down = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     padBusy = false;
@@ -1891,7 +1891,7 @@ int CMenuPcs::CmakeJobCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -1899,7 +1899,7 @@ int CMenuPcs::CmakeJobCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
-        repeat = static_cast<short>(held);
+        repeat = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     if (repeat == 0) {
@@ -2196,7 +2196,7 @@ int CMenuPcs::CmakeTribeCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -2204,7 +2204,7 @@ int CMenuPcs::CmakeTribeCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
-        down = static_cast<short>(held);
+        down = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     padBusy = false;
@@ -2212,7 +2212,7 @@ int CMenuPcs::CmakeTribeCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -2220,7 +2220,7 @@ int CMenuPcs::CmakeTribeCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
-        repeat = static_cast<short>(held);
+        repeat = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     if (repeat == 0) {
@@ -2748,7 +2748,7 @@ int CMenuPcs::CmakeNameCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -2756,7 +2756,7 @@ int CMenuPcs::CmakeNameCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].buttonDown[0];
         }
-        down = static_cast<short>(held);
+        down = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     padBusy = false;
@@ -2764,7 +2764,7 @@ int CMenuPcs::CmakeNameCtrl()
         padBusy = true;
     }
     {
-        unsigned short held;
+        int held;
         if (padBusy) {
             held = 0;
         } else {
@@ -2772,7 +2772,7 @@ int CMenuPcs::CmakeNameCtrl()
             padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
             held = Pad.GetPadInputs()[padIndex].repeatButton;
         }
-        repeat = static_cast<short>(held);
+        repeat = static_cast<short>(static_cast<unsigned short>(held));
     }
 
     if (repeat == 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3366,17 +3366,9 @@ void CMenuPcs::DrawCmakeBallCursor(int kind, int frame, float alpha)
  */
 void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
 {
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
+    SetCmakeBlendMatColor(alpha);
 
     float alpha255 = 255.0f * alpha;
-    GXColor col;
-    col.r = 0xFF;
-    col.g = 0xFF;
-    col.b = 0xFF;
-    col.a = static_cast<unsigned char>(alpha255);
-    GXSetChanMatColor(GX_COLOR0A0, col);
-
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     MenuPcs.DrawRect(
         0, 480.0f, 368.0f, 48.0f, 32.0f,
@@ -3386,14 +3378,7 @@ void CMenuPcs::DrawCmakeDecision(int yesNoSel, float alpha)
         296.0f, 264.0f, 1.0f, 1.0f, 0.0f);
 
     if (yesNoSel != 0) {
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-        GXColor col2;
-        col2.r = 0xFF;
-        col2.g = 0xFF;
-        col2.b = 0xFF;
-        col2.a = static_cast<unsigned char>(alpha255);
-        GXSetChanMatColor(GX_COLOR0A0, col2);
+        SetCmakeBlendMatColor(alpha);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x64 : 0x3D));
         MenuPcs.DrawRect(
             0, 516.0f, 360.0f, 48.0f, 48.0f,


### PR DESCRIPTION
Raises main/cmake from 95.72% to **96.44%** (+0.72) by attacking the c25 residual walls with the new levers.

## What landed
- **R27 redundant ternary on a loaded value** (the big one, +0.50 total): `int padIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;` replaces the decompiler `&= ~-cntlzw` garble at all 10 pad-read sites — fixes the whole pad-read scratch-register rotation (zero in r0, Pad base in r4) across CalcSingCMake (93.1→96.8), CmakeNameCtrl (96.6→96.8), CmakeTribeCtrl, CmakeVillageCtrl, CmakeJobCtrl. Same lever unfolds `tribeCount = 4` in CmakeTribeCtrl via `(fieldSelect != 0) ? 4 : 4` (94.4→96.4).
- **R29 pad-read junction**: `int held;` + `return (u16)held` / `(short)(u16)held` two-step reproduces the target's `lhz; clrlwi; extsh` in all four Ctrl functions and both static pad helpers (+0.17).
- **R41 GXColor stack-slot interleave**: new `static inline SetCmakeBlendMatColor(float alpha)` / `SetCmakeFontColor(font, alpha)` helpers convert the per-block blend+chan-mat-color sequences in CmakeVillageDraw / CmakeNameDraw / CmakeResultDraw1 / DrawCmakeDecision / backdrops — inlined-callee temps allocate per call site, giving the target's (col, arg-copy) adjacent descending pairs (CmakeVillageDraw slots now match exactly).
- **Real bugs found via DOL audit (R30/R16)**: DrawCmakeTitle scaleY arg is `x` not `alpha`; CmakeResultDraw1 passes `DrawCmakeTitle(7, alpha, 1.0f)` (args were swapped); CmakeVillageCtrl row wrap bound was off by one (`select >= 10 ? 5 : 4`); CalcSingCMake dispatch tests `repeat & mask` directly (no dirMask temp).
- ResultDraw1 calls `DrawCmakePreviewCharaAlpha(this, 1.0f)` directly (nesting depth changed temp allocation order).

## Per-function (start → end)
- CalcSingCMake 92.1 → 96.8
- CmakeTribeCtrl 93.0 → 96.4
- CmakeNameCtrl 96.2 → 96.8
- CmakeVillageCtrl 94.4 → 95.1
- CmakeVillageDraw 93.6 → 93.8
- CmakeNameDraw 95.0 → 95.1, CmakeResultDraw1 95.5 → 95.5 (shape), DrawCmakeDecision 96.5 → 96.5
- DrawCmakeTitle 91.4 (scaleY bug fixed)

## Remaining walls (documented for next cycle)
- DrawCmakeYesNo/DrawCmakeTitle: int-constant→float runtime magic conversion (`li r27, 0x1d0` + xoris) — every source form tested (named var, reassignment, struct field, static/inline/ref-param helpers, phi arms, opt_propagation off, R27 ternaries on yesNoSel/font/str) either folds or costs more in register coloring than it gains. shopmenu's matching instances use `#pragma opt_propagation off`, but cmake's baseline coloring contradicts that pragma here.
- CalcSingCMake dispatch state-ptr r6-vs-r3 rotation: R52 wrap is impossible (body too big for the all-or-nothing inline gate).
- Note: DOL shows ResultDraw1 titleX is 278-based (298) not offsU-based — value-correct fix measured -0.02, left out per net-positive rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)