### PR TITLE
p_graphic: raise fuzzy match to 96.6% (cycle 17)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -710,12 +710,14 @@ void CGraphicPcs::drawBar()
     GXColor barColor = {0x80, 0x80, 0x80, 0xFF};
     drawSFRect(kDebugBarLeft, kDebugBarTop, kDebugBarRight, kDebugBarBottom, barColor, barColor);
 
+    int hue;
+    u32 y;
     CSystem::COrder* order = System.GetFirstOrder();
     const int orderCount = System.m_orderCount;
-    const int lastOrder = orderCount - 1;
-    int hue = 0;
-    u32 y = 0x10;
-    for (int i = 0; i < orderCount; i++) {
+    int i = 0;
+    hue = 0;
+    y = 0x10;
+    for (; i < orderCount; i++) {
         const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;
         GXColor colorTmp;
@@ -736,7 +738,7 @@ void CGraphicPcs::drawBar()
             x += width;
         }
 
-        if (i == lastOrder) {
+        if (i == orderCount - 1) {
             GXColor soundGX;
             *reinterpret_cast<u32*>(&soundGX) = Math.Hsb2Rgb(0, 100, 100);
             barColor.r = soundGX.r;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -391,7 +391,7 @@ void CGraphicPcs::drawScreenFade()
                 GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY, GX_FALSE, GX_PTIDENTITY);
                 _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
                 _GXSetTevColorIn(GX_TEVSTAGE0, (_GXTevColorArg)0xF, (_GXTevColorArg)8, (_GXTevColorArg)10, (_GXTevColorArg)0xF);
-                _GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_DIVIDE_2, GX_TRUE, GX_TEVPREV);
+                _GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_4, GX_TRUE, GX_TEVPREV);
                 _GXSetTevAlphaIn(GX_TEVSTAGE0, (_GXTevAlphaArg)7, (_GXTevAlphaArg)4, (_GXTevAlphaArg)5, (_GXTevAlphaArg)7);
                 _GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
 

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -846,14 +846,15 @@ void CGraphicPcs::drawEnd()
 		for (; port < 4; port++) {
 			bool suppress = (Pad.m_debugPadLock != 0) || ((port == 0) && (Pad.m_debugPadPort != -1));
 
-			u16 buttons;
+			u16 held;
 			if (suppress) {
-				buttons = 0;
+				held = 0;
 			} else {
 				int selectedPort = Pad.m_debugPadPort;
 				u32 portIndex = port & ~((int)~((selectedPort - port) | (port - selectedPort)) >> 31);
-				buttons = Pad.GetPadInputs()[portIndex].button[0];
+				held = Pad.GetPadInputs()[portIndex].button[0];
 			}
+			const u16 buttons = held;
 
 			const char c = ((buttons & 0x20) != 0) ? 'r' : ' ';
 			const char z = ((buttons & 0x40) != 0) ? 'l' : ' ';


### PR DESCRIPTION
Raises main/p_graphic from 96.49% to 96.56% (cycle 17).

## Per-function gains
- **drawEnd: 99.65% -> 100.00%** — the pad-button read junction is staged through a `held` temp before the `const u16 buttons` local (R29 inlined-helper return junction), matching the target's r11/r12 assignment.
- **drawBar: 96.58% -> 96.78%** — `lastOrder` local removed in favor of `i == orderCount - 1` (the target allocates the hoisted `subi` invariant LAST, landing it in r29); `hue`/`y` converted to decl-then-assign before the `GetFirstOrder` call and `int i` initialized ahead of them, fixing the r23-r29 callee-saved permutation across the whole order loop (order=r24, y=r25, hue=r26, System=r27, Math=r28).
- **drawScreenFade: 98.66% -> 98.67%** — real constant bug: slot-1 mode-4 `_GXSetTevColorOp` scale was `GX_CS_DIVIDE_2` (3), DOL has `GX_CS_SCALE_4` (2).

## Verified walls (no score change after exhaustive sweeps)
- drawSFCircle 97.85: R52 helper restructure (wgPos3f + strip helper + by-ref cursor) reproduced the target's prologue, FPR set, and fifo register exactly, but the residual 5-GPR class swap (loop temps high vs hoisted color words low) is the documented R52 tie-break wall — every decl/assign/param permutation scored at or below baseline, so the original shape was kept.
- calc 98.70: `mr r0,r5` zero-constant-CSE (documented joybus-family wall).
- __sinit data.0 anchoring (known systemic wall, skipped).

Result is plausible original source: junction temps, loop-scoped declarations, and a binary-verified GX enum fix — no pragmas or coaxing added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)