### PR TITLE
wind: raise fuzzy match to 98.7% (cycle 6)

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -648,7 +648,8 @@ void CWind::Frame()
                     f2 = kWindDirNegativeJitter;
                 }
 
-                obj->targetDir = f2 * obj->baseDir + obj->targetDir;
+                f1 = obj->baseDir;
+                obj->targetDir = f1 * f2 + obj->targetDir;
                 f0 = obj->targetDir;
                 f1 = obj->baseDir;
                 f1 = (f0 < f1) ? f1 : ((kWindDirMaxOffset + f1 < f0) ? kWindDirMaxOffset + f1 : f0);

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -635,15 +635,7 @@ void CWind::Frame()
                 obj->targetPower = f2 * obj->basePower + obj->targetPower;
                 f0 = obj->targetPower;
                 f1 = kWindZero;
-                if (f0 < f1) {
-                    goto storePower;
-                }
-                f1 = obj->basePower;
-                if (f1 < f0) {
-                    goto storePower;
-                }
-                f1 = f0;
-            storePower:
+                f1 = (f0 < f1) ? f1 : ((obj->basePower < f0) ? obj->basePower : f0);
                 obj->targetPower = f1;
             }
 
@@ -659,16 +651,8 @@ void CWind::Frame()
                 obj->targetDir = f2 * obj->baseDir + obj->targetDir;
                 f0 = obj->targetDir;
                 f1 = obj->baseDir;
-                if (f0 < f1) {
-                    goto storeDir;
-                }
-                f2 = kWindDirMaxOffset + f1;
-                if (f2 < f0) {
-                    goto storeDir;
-                }
-                f2 = f0;
-                obj->targetDir = f2;
-            storeDir:;
+                f1 = (f0 < f1) ? f1 : ((kWindDirMaxOffset + f1 < f0) ? kWindDirMaxOffset + f1 : f0);
+                obj->targetDir = f1;
             }
 
             if (obj->type == 2) {


### PR DESCRIPTION
## Summary
Raises `main/wind` from **98.09% -> 98.70%** fuzzy match (data 99.74% -> **100%**).

### Frame: 96.99% -> 99.82% (the old "cror-polarity" wall CRACKED)
- Both targetPower/targetDir clamps rewritten as **nested ternary selects** (R17/R47): `f1 = (f0 < f1) ? f1 : ((bound < f0) ? bound : f0);`. The target's `bge body; b join` pairs are mwcc's ternary select with the THEN-arm being the variable itself — the previous goto-chain `<` early-exits folded into single `blt`s, and positive `if (a >= b)` nesting brought back the `cror eq,gt,eq`. The ternary is the only form that reproduces the unfolded branch pairs.
- This also fixed a **real behavior divergence**: the old decompiled clamp skipped the store when below the lower bound; the original clamps to the bound (zero / baseDir).
- Dir block: naming the multiplicand (`f1 = obj->baseDir;` before the fmadds) makes the clamp's result variable coalesce into f2 in-place (kills an `fmr f0,f2` staging temp and 4 register mismatches).
- Residual (5 lines): two `fmadds` rA/rC operand-order swaps — every operand-order/named-local/+= variant either leaves it or hoists the member load above the const-select branch and rotates the f1/f2 window (net negative). Tie-break wall.

### Re-tested old walls (hold against the new kit)
- **AddSphere (95.68)** "CTR-vs-coloring tradeoff": `for (blocks=4; blocks>0; blocks--)` DOES emit `mtctr/bdnz` (the `!=0`/do-while forms never convert), but freeing r7 pulls `scan` into r7 and blocks the scan/obj coalesce into r8 (r7 conflicts with the found-block `li r7,1`), costing ~16 lines vs 4. Tried: merged scan/obj single var (loses the `bne/b` exit shape), r7-denial via a pre-loop `active=1` local (copy-propagated away even under `opt_propagation off`), checked-as-counter `while (checked < 28)`, R52 helper wraps, decl-order shuffles. GPR-counter form stays the better tradeoff.
- **AddDiffuse (93.32)** f7/f9 FPR swap (radiusSq/centerZ): scheduler fully canonicalizes this block — statement-order permutations, R48 decl-only-then-assign, Ghidra-faithful inline-at-store rewrites all compile **bit-identical**; R52 inline member-helper wrap (both decl orders) is neutral-to-negative. Confirmed allocator tie-break wall.

All variants measured via report.json; net-positive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)