### PR TITLE
pad: raise fuzzy match to 97.39% (cycle 6)

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -106,6 +106,7 @@ void CPad::Frame()
 	int iVar14;
 	u32 port;
 	u32 uVar15;
+	u32 gbaIdx;
 	u32 uVar16;
 	u32 uVar17;
 	u16* puVar18;
@@ -223,12 +224,12 @@ void CPad::Frame()
 	puVar13 = reinterpret_cast<u16*>(local_88);
 	puVar10 = reinterpret_cast<u16*>(self + 0x154);
 	uVar16 = 0;
-	uVar17 = 0;
+	gbaIdx = 0;
 	puVar7 = puVar13;
 	do
 	{
 		cVar9 = *reinterpret_cast<s8*>(puVar7 + 5);
-		uVar15 = 0x80000000 >> uVar17;
+		uVar15 = 0x80000000 >> gbaIdx;
 		if (cVar9 == -1)
 		{
 			goto gba_ready;
@@ -256,7 +257,7 @@ void CPad::Frame()
 		_1a8_4_ = _1a8_4_ | uVar15;
 		goto flag_done;
 	gba_ready:
-		if (static_cast<u8>(Joybus.GBAReady(uVar17)) == 0)
+		if (static_cast<u8>(Joybus.GBAReady(gbaIdx)) == 0)
 		{
 			uVar16 = uVar16 | uVar15;
 		}
@@ -265,9 +266,9 @@ void CPad::Frame()
 	flag_clear:
 		_1a8_4_ = _1a8_4_ & ~uVar15;
 	flag_done:
-		uVar17 = uVar17 + 1;
+		gbaIdx = gbaIdx + 1;
 		puVar7 = puVar7 + 6;
-	} while (uVar17 < 4);
+	} while (gbaIdx < 4);
 
 	if ((uVar16 & 0xF0000000) != 0)
 	{

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -104,6 +104,7 @@ void CPad::Frame()
 	u16* puVar12;
 	u16* puVar13;
 	int iVar14;
+	u32 port;
 	u32 uVar15;
 	u32 uVar16;
 	u32 uVar17;
@@ -117,23 +118,22 @@ void CPad::Frame()
 	PADClamp(local_88);
 	memcpy(g_pad, local_88, sizeof(g_pad));
 	*reinterpret_cast<u32*>(self + 0x1C4) = 0;
-	uVar17 = 0;
+	port = 0;
 	puVar18 = reinterpret_cast<u16*>(local_98);
 	do
 	{
-		CPad::Gba* gba = &local_98[uVar17];
-		iVar6 = SIProbe(uVar17);
-		int padIndex = uVar17;
+		CPad::Gba* gba = &local_98[port];
+		iVar6 = SIProbe(port);
 		gba->connected = (0x40000 - iVar6) == 0;
-		gba->ctrlMode = Joybus.GetCtrlMode(uVar17);
+		gba->ctrlMode = Joybus.GetCtrlMode(port);
 		gba->noController = gba->connected && (gba->ctrlMode == 0);
 		gba->button = 0;
 		if (gba->connected)
 		{
-			gba->button = Joybus.GetPadData(padIndex);
+			gba->button = Joybus.GetPadData(port);
 		}
-		uVar17 = uVar17 + 1;
-	} while (uVar17 < 4);
+		port = port + 1;
+	} while (port < 4);
 
 	if ((_1b0_4_ != 0) && ((iVar14 = _1bc_4_), iVar14 >= 0))
 	{

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -82,8 +82,7 @@ inline void CPad::SaveReplayData()
 }
 
 #pragma always_inline on
-#pragma inline_max_size 100000
-#pragma inline_max_total_size 100000
+#pragma inline_max_total_size(100000)
 static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* puVar10)
 {
 	int iVar14;
@@ -92,7 +91,6 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* pu
 	int iVar6;
 	u16* puVar7;
 	u16* puVar12;
-	u16 uVar8;
 	u32 uVar15;
 	s8 cVar9;
 	u32 uVar16;

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -144,9 +144,8 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* pu
 				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x30) | *puVar12);
 				if (iVar14 == 0)
 				{
-					uVar8 = *puVar18;
 					*reinterpret_cast<u16*>(p12 + 0x08) = *reinterpret_cast<u16*>(p12 + 0x0A);
-					uVar16 = (__cntlzw(1 - (uVar8 & 0x3FFF)) >> 5) & 0xFF;
+					uVar16 = (__cntlzw(1 - (*puVar18 & 0x3FFF)) >> 5) & 0xFF;
 					*reinterpret_cast<s8*>(p12 + 0x40) = *reinterpret_cast<s8*>(puVar13 + 5);
 					*reinterpret_cast<u32*>(p12 + 0x50) = uVar16;
 					*reinterpret_cast<u32*>(p12 + 0x44) = 0;
@@ -256,9 +255,8 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* pu
 				}
 				else if (reinterpret_cast<CPad::Gba*>(puVar18)->connected)
 				{
-					uVar8 = puVar18[1];
 					*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
-					*puVar12 = uVar8;
+					*puVar12 = puVar18[1];
 				}
 				puVar12[2] = static_cast<u16>(*puVar12 & (puVar12[0x26] ^ *puVar12));
 				if (iVar14 == 0)

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -471,7 +471,7 @@ void CPad::Frame()
 					*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar12) + 9) =
 						*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar7) + 9);
 					puVar10 = puVar7 + 5;
-					puVar7 = puVar7 + 6;
+					puVar13 = puVar13 + 6;
 					*reinterpret_cast<u8*>(puVar12 + 5) = *reinterpret_cast<u8*>(puVar10);
 					iVar11 = *reinterpret_cast<int*>(reinterpret_cast<int>(_1b0_4_) + 8) * 0x40 + iVar14;
 					iVar14 = iVar14 + 4;
@@ -516,7 +516,7 @@ void CPad::Frame()
 				{
 					*puVar7 = static_cast<u16>(*puVar7 | uVar8);
 				}
-				puVar7 = puVar7 + 6;
+				puVar13 = puVar13 + 6;
 				iVar6 = iVar6 + 0x0C;
 				iVar19 = iVar19 + 4;
 				puVar13 = puVar13 + 2;
@@ -531,7 +531,7 @@ void CPad::Frame()
 	puVar13 = puVar7;
 	do
 	{
-		cVar9 = *reinterpret_cast<s8*>(puVar7 + 5);
+		cVar9 = *reinterpret_cast<s8*>(puVar13 + 5);
 		uVar15 = 0x80000000 >> gbaIdx;
 		if (cVar9 == -1)
 		{
@@ -570,7 +570,7 @@ void CPad::Frame()
 		_1a8_4_ = _1a8_4_ & ~uVar15;
 	flag_done:
 		gbaIdx = gbaIdx + 1;
-		puVar7 = puVar7 + 6;
+		puVar13 = puVar13 + 6;
 	} while (gbaIdx < 4);
 
 	if ((uVar16 & 0xF0000000) != 0)
@@ -578,7 +578,7 @@ void CPad::Frame()
 		PADReset(uVar16 & 0xF0000000);
 	}
 
-	MergePadInputs(this, puVar13, puVar18, puVar10);
+	MergePadInputs(this, puVar7, puVar18, puVar10);
 
 	if (_1bc_4_ >= 0)
 	{

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -81,6 +81,312 @@ inline void CPad::SaveReplayData()
     }
 }
 
+#pragma always_inline on
+#pragma inline_max_size 100000
+#pragma inline_max_total_size 100000
+static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* puVar10)
+{
+	int iVar14;
+	u8* p12;
+	u32 uVar17;
+	int iVar6;
+	u16* puVar7;
+	u16* puVar12;
+	u16 uVar8;
+	u32 uVar15;
+	s8 cVar9;
+	u32 uVar16;
+	float fVar2;
+	float fVar3;
+
+	fVar2 = kPadAnalogZero;
+	CPad::PadInput* merged = reinterpret_cast<CPad::PadInput*>(puVar10);
+	merged->buttonPrev[0] = merged->button[0];
+	uVar17 = 0;
+	merged->buttonDown[0] = 0;
+	merged->button[0] = 0;
+	merged->buttonPrev[1] = merged->button[1];
+	merged->buttonDown[1] = 0;
+	merged->button[1] = 0;
+	merged->stickBitsPrev = merged->stickBits;
+	merged->holdOverride = 0;
+	merged->digitalStickOverride = 0;
+	merged->stickBits = 0;
+	merged->stickBitsDown = 0;
+	merged->repeatButton = 0;
+	merged->buttonUp = 0;
+	merged->substickY = 0;
+	merged->substickX = 0;
+	merged->stickY = 0;
+	merged->stickX = 0;
+	merged->triggerRight = 0;
+	merged->triggerLeft = 0;
+	merged->substickYF = fVar2;
+	merged->substickXF = fVar2;
+	merged->stickYF = fVar2;
+	merged->stickXF = fVar2;
+	merged->triggerRightF = fVar2;
+	merged->triggerLeftF = fVar2;
+	merged->lockedButton[2] = 0;
+	merged->lockedButton[1] = 0;
+	merged->lockedButton[0] = 0;
+	merged->activeMask = 0;
+	iVar6 = reinterpret_cast<int>(pad);
+	do
+	{
+		p12 = reinterpret_cast<u8*>(iVar6 + 4);
+		puVar12 = reinterpret_cast<u16*>(p12);
+		puVar7 = puVar10;
+		for (iVar14 = 0; iVar14 < 2; iVar14++)
+		{
+			if ((iVar14 != 0) || (*reinterpret_cast<s8*>(puVar13 + 5) != -3))
+			{
+				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x30) | *puVar12);
+				if (iVar14 == 0)
+				{
+					uVar8 = *puVar18;
+					*reinterpret_cast<u16*>(p12 + 0x08) = *reinterpret_cast<u16*>(p12 + 0x0A);
+					uVar16 = (__cntlzw(1 - (uVar8 & 0x3FFF)) >> 5) & 0xFF;
+					*reinterpret_cast<s8*>(p12 + 0x40) = *reinterpret_cast<s8*>(puVar13 + 5);
+					*reinterpret_cast<u32*>(p12 + 0x50) = uVar16;
+					*reinterpret_cast<u32*>(p12 + 0x44) = 0;
+					*reinterpret_cast<u32*>(p12 + 0x38) = 0;
+					*reinterpret_cast<u32*>(p12 + 0x3C) = 0;
+					if ((*reinterpret_cast<s8*>(p12 + 0x40) == 0) || reinterpret_cast<CPad::Gba*>(puVar18)->noController)
+					{
+						if (reinterpret_cast<CPad::Gba*>(puVar18)->noController)
+						{
+							*puVar12 = puVar18[1];
+						}
+						else
+						{
+							*puVar12 = *puVar13;
+						}
+						if (*reinterpret_cast<u8*>(puVar13 + 3) >= 100)
+						{
+							*puVar12 = static_cast<u16>(*puVar12 | PAD_TRIGGER_L);
+						}
+						if (*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7) >= 100)
+						{
+							*puVar12 = static_cast<u16>(*puVar12 | PAD_TRIGGER_R);
+						}
+						if ((DbgMenuPcs.GetDbgFlagsRaw() & 0x100) != 0)
+						{
+							uVar16 = static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)) >> 0x1F;
+							if ((static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<u8*>(p12 + 0x14))) - uVar16) >= pad->m_stickDigitalThreshold) ||
+								((uVar16 = static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)) >> 0x1F),
+								 (static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15))) - uVar16) >= pad->m_stickDigitalThreshold)))
+							{
+								*puVar12 = static_cast<u16>(*puVar12 & 0xFFF0);
+								*reinterpret_cast<u32*>(p12 + 0x3C) = 1;
+								if (pad->m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)))
+								{
+									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_RIGHT);
+								}
+								if (-static_cast<int>(pad->m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)))
+								{
+									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_LEFT);
+								}
+								if (pad->m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)))
+								{
+									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_UP);
+								}
+								if (-static_cast<int>(pad->m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)))
+								{
+									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_DOWN);
+								}
+							}
+						}
+						*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
+						*reinterpret_cast<u8*>(p12 + 0x14) = *reinterpret_cast<u8*>(puVar13 + 1);
+						*reinterpret_cast<u16*>(p12 + 0x0A) = 0;
+						if (*reinterpret_cast<s8*>(p12 + 0x14) < 0)
+						{
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 1;
+						}
+						if (0 < *reinterpret_cast<s8*>(p12 + 0x14))
+						{
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 2;
+						}
+						*reinterpret_cast<u8*>(p12 + 0x15) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 3);
+						if (*reinterpret_cast<s8*>(p12 + 0x15) < 0)
+						{
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 4;
+						}
+						if (0 < *reinterpret_cast<s8*>(p12 + 0x15))
+						{
+							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 8;
+						}
+						fVar2 = kPadAnalogScale;
+						fVar3 = kPadTriggerMax;
+						*reinterpret_cast<u8*>(p12 + 0x16) = *reinterpret_cast<u8*>(puVar13 + 2);
+						*reinterpret_cast<u8*>(p12 + 0x17) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 5);
+						*reinterpret_cast<u8*>(p12 + 0x12) = *reinterpret_cast<u8*>(puVar13 + 3);
+						*reinterpret_cast<u8*>(p12 + 0x13) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7);
+						*reinterpret_cast<float*>(p12 + 0x20) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x14)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x24) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x15)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x28) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x16)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x2C) =
+							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x17)) * fVar2;
+						*reinterpret_cast<float*>(p12 + 0x18) =
+							static_cast<float>(*reinterpret_cast<u8*>(p12 + 0x12)) / fVar3;
+						*reinterpret_cast<float*>(p12 + 0x1C) =
+							static_cast<float>(*reinterpret_cast<u8*>(p12 + 0x13)) / fVar3;
+					}
+					else
+					{
+						*puVar12 = 0;
+						fVar2 = kPadAnalogZero;
+						*reinterpret_cast<u8*>(p12 + 0x14) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x15) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x16) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x17) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x12) = 0;
+						*reinterpret_cast<u8*>(p12 + 0x13) = 0;
+						*reinterpret_cast<float*>(p12 + 0x20) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x24) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x28) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x2C) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x18) = fVar2;
+						*reinterpret_cast<float*>(p12 + 0x1C) = fVar2;
+					}
+				}
+				else if (reinterpret_cast<CPad::Gba*>(puVar18)->connected)
+				{
+					uVar8 = puVar18[1];
+					*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
+					*puVar12 = uVar8;
+				}
+				puVar12[2] = static_cast<u16>(*puVar12 & (puVar12[0x26] ^ *puVar12));
+				if (iVar14 == 0)
+				{
+					*reinterpret_cast<u16*>(p12 + 0x0E) =
+						static_cast<u16>(puVar12[0x26] & (puVar12[0x26] ^ *puVar12));
+					*reinterpret_cast<u16*>(p12 + 0x0C) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x0A) &
+						                 (*reinterpret_cast<u16*>(p12 + 0x08) ^ *reinterpret_cast<u16*>(p12 + 0x0A)));
+					*reinterpret_cast<u16*>(p12 + 0x10) = static_cast<u16>(puVar12[0x26] & *puVar12 & 0x1F7F);
+					if (*reinterpret_cast<u16*>(p12 + 0x10) != 0)
+					{
+						*reinterpret_cast<int*>(p12 + 0x48) = *reinterpret_cast<int*>(p12 + 0x48) + 1;
+						if (*reinterpret_cast<u32*>(p12 + 0x48) < 0x10)
+						{
+							*reinterpret_cast<u16*>(p12 + 0x10) = 0;
+						}
+						else if ((*reinterpret_cast<u32*>(p12 + 0x48) & 1) != 0)
+						{
+							*reinterpret_cast<u16*>(p12 + 0x10) = 0;
+						}
+					}
+					else
+					{
+						*reinterpret_cast<u32*>(p12 + 0x48) = 0;
+					}
+					*reinterpret_cast<u16*>(p12 + 0x10) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x10) | puVar12[2]);
+					if (*reinterpret_cast<int*>(p12 + 0x38) != 0)
+					{
+						*reinterpret_cast<u16*>(p12 + 0x30) = *puVar12;
+						*reinterpret_cast<u16*>(p12 + 0x32) = puVar12[2];
+						*reinterpret_cast<u16*>(p12 + 0x34) = *reinterpret_cast<u16*>(p12 + 0x10);
+						*reinterpret_cast<u16*>(p12 + 0x0A) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x0C) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x10) = 0;
+						puVar12[2] = 0;
+						*reinterpret_cast<u16*>(p12 + 0x0E) = 0;
+						*puVar12 = 0;
+					}
+					else
+					{
+						*reinterpret_cast<u16*>(p12 + 0x34) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x32) = 0;
+						*reinterpret_cast<u16*>(p12 + 0x30) = 0;
+					}
+				}
+				puVar7[2] = static_cast<u16>(puVar7[2] | puVar12[2]);
+				*puVar7 = static_cast<u16>(*puVar7 | *puVar12);
+				if (iVar14 == 0)
+				{
+					u8* p10 = reinterpret_cast<u8*>(puVar10);
+					*reinterpret_cast<u32*>(p10 + 0x38) =
+						*reinterpret_cast<u32*>(p10 + 0x38) | *reinterpret_cast<u32*>(p12 + 0x38);
+					*reinterpret_cast<u32*>(p10 + 0x3C) =
+						*reinterpret_cast<u32*>(p10 + 0x3C) | *reinterpret_cast<u32*>(p12 + 0x3C);
+					*reinterpret_cast<u16*>(p10 + 0x0E) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0E) | *reinterpret_cast<u16*>(p12 + 0x0E));
+					*reinterpret_cast<u16*>(p10 + 0x0A) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0A) | *reinterpret_cast<u16*>(p12 + 0x0A));
+					*reinterpret_cast<u16*>(p10 + 0x0C) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0C) | *reinterpret_cast<u16*>(p12 + 0x0C));
+					*reinterpret_cast<s16*>(p10 + 0x10) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x10) | *reinterpret_cast<u16*>(p12 + 0x10));
+					*reinterpret_cast<u16*>(p10 + 0x32) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x32) | *reinterpret_cast<u16*>(p12 + 0x32));
+					*reinterpret_cast<u16*>(p10 + 0x30) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x30) | *reinterpret_cast<u16*>(p12 + 0x30));
+					*reinterpret_cast<u16*>(p10 + 0x34) =
+						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x34) | *reinterpret_cast<u16*>(p12 + 0x34));
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x14);
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x14)) >> 0x1F;
+					uVar16 = static_cast<int>(cVar9) >> 0x1F;
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x14))) - uVar15) <
+					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
+					{
+						*reinterpret_cast<s8*>(p10 + 0x14) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x20) = *reinterpret_cast<float*>(p12 + 0x20);
+					}
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x15);
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x15)) >> 0x1F;
+					uVar16 = static_cast<int>(cVar9) >> 0x1F;
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x15))) - uVar15) <
+					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
+					{
+						*reinterpret_cast<s8*>(p10 + 0x15) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x24) = *reinterpret_cast<float*>(p12 + 0x24);
+					}
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x16);
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x16)) >> 0x1F;
+					uVar16 = static_cast<int>(cVar9) >> 0x1F;
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x16))) - uVar15) <
+					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
+					{
+						*reinterpret_cast<s8*>(p10 + 0x16) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x28) = *reinterpret_cast<float*>(p12 + 0x28);
+					}
+					cVar9 = *reinterpret_cast<s8*>(p12 + 0x17);
+					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x17)) >> 0x1F;
+					uVar16 = static_cast<int>(cVar9) >> 0x1F;
+					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x17))) - uVar15) <
+					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
+					{
+						*reinterpret_cast<s8*>(p10 + 0x17) = cVar9;
+						*reinterpret_cast<float*>(p10 + 0x2C) = *reinterpret_cast<float*>(p12 + 0x2C);
+					}
+					if (*reinterpret_cast<u8*>(p10 + 0x12) < *reinterpret_cast<u8*>(p12 + 0x12))
+					{
+						*reinterpret_cast<u8*>(p10 + 0x12) = *reinterpret_cast<u8*>(p12 + 0x12);
+						*reinterpret_cast<float*>(p10 + 0x18) = *reinterpret_cast<float*>(p12 + 0x18);
+					}
+					if (*reinterpret_cast<u8*>(p10 + 0x13) < *reinterpret_cast<u8*>(p12 + 0x13))
+					{
+						*reinterpret_cast<u8*>(p10 + 0x13) = *reinterpret_cast<u8*>(p12 + 0x13);
+						*reinterpret_cast<float*>(p10 + 0x1C) = *reinterpret_cast<float*>(p12 + 0x1C);
+					}
+				}
+			}
+			puVar12 = puVar12 + 1;
+			puVar7 = puVar7 + 1;
+		}
+		uVar17 = uVar17 + 1;
+		puVar13 = puVar13 + 6;
+		puVar18 = puVar18 + 2;
+		iVar6 = iVar6 + 0x54;
+	} while (uVar17 < 4);
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80022168
@@ -275,298 +581,15 @@ void CPad::Frame()
 		PADReset(uVar16 & 0xF0000000);
 	}
 
-	fVar2 = kPadAnalogZero;
-	PadInput* merged = reinterpret_cast<PadInput*>(puVar10);
-	merged->buttonPrev[0] = merged->button[0];
-	uVar17 = 0;
-	merged->buttonDown[0] = 0;
-	merged->button[0] = 0;
-	merged->buttonPrev[1] = merged->button[1];
-	merged->buttonDown[1] = 0;
-	merged->button[1] = 0;
-	merged->stickBitsPrev = merged->stickBits;
-	merged->holdOverride = 0;
-	merged->digitalStickOverride = 0;
-	merged->stickBits = 0;
-	merged->stickBitsDown = 0;
-	merged->repeatButton = 0;
-	merged->buttonUp = 0;
-	merged->substickY = 0;
-	merged->substickX = 0;
-	merged->stickY = 0;
-	merged->stickX = 0;
-	merged->triggerRight = 0;
-	merged->triggerLeft = 0;
-	merged->substickYF = fVar2;
-	merged->substickXF = fVar2;
-	merged->stickYF = fVar2;
-	merged->stickXF = fVar2;
-	merged->triggerRightF = fVar2;
-	merged->triggerLeftF = fVar2;
-	merged->lockedButton[2] = 0;
-	merged->lockedButton[1] = 0;
-	merged->lockedButton[0] = 0;
-	merged->activeMask = 0;
-	iVar6 = reinterpret_cast<int>(self);
-	do
-	{
-		puVar12 = reinterpret_cast<u16*>(iVar6 + 4);
-		u8* p12 = reinterpret_cast<u8*>(iVar6 + 4);
-		puVar7 = puVar10;
-		for (iVar14 = 0; iVar14 < 2; iVar14++)
-		{
-			if ((iVar14 != 0) || (*reinterpret_cast<s8*>(puVar13 + 5) != -3))
-			{
-				puVar12[0x26] = static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x30) | *puVar12);
-				if (iVar14 == 0)
-				{
-					uVar8 = *puVar18;
-					*reinterpret_cast<u16*>(p12 + 0x08) = *reinterpret_cast<u16*>(p12 + 0x0A);
-					uVar16 = (__cntlzw(1 - (uVar8 & 0x3FFF)) >> 5) & 0xFF;
-					*reinterpret_cast<s8*>(p12 + 0x40) = *reinterpret_cast<s8*>(puVar13 + 5);
-					*reinterpret_cast<u32*>(p12 + 0x50) = uVar16;
-					*reinterpret_cast<u32*>(p12 + 0x44) = 0;
-					*reinterpret_cast<u32*>(p12 + 0x38) = 0;
-					*reinterpret_cast<u32*>(p12 + 0x3C) = 0;
-					if ((*reinterpret_cast<s8*>(p12 + 0x40) == 0) || reinterpret_cast<CPad::Gba*>(puVar18)->noController)
-					{
-						if (reinterpret_cast<CPad::Gba*>(puVar18)->noController)
-						{
-							*puVar12 = puVar18[1];
-						}
-						else
-						{
-							*puVar12 = *puVar13;
-						}
-						if (*reinterpret_cast<u8*>(puVar13 + 3) >= 100)
-						{
-							*puVar12 = static_cast<u16>(*puVar12 | PAD_TRIGGER_L);
-						}
-						if (*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7) >= 100)
-						{
-							*puVar12 = static_cast<u16>(*puVar12 | PAD_TRIGGER_R);
-						}
-						if ((DbgMenuPcs.GetDbgFlagsRaw() & 0x100) != 0)
-						{
-							uVar16 = static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)) >> 0x1F;
-							if ((static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<u8*>(p12 + 0x14))) - uVar16) >= m_stickDigitalThreshold) ||
-								((uVar16 = static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)) >> 0x1F),
-								 (static_cast<int>((uVar16 ^ static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15))) - uVar16) >= m_stickDigitalThreshold)))
-							{
-								*puVar12 = static_cast<u16>(*puVar12 & 0xFFF0);
-								*reinterpret_cast<u32*>(p12 + 0x3C) = 1;
-								if (m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)))
-								{
-									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_RIGHT);
-								}
-								if (-static_cast<int>(m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x14)))
-								{
-									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_LEFT);
-								}
-								if (m_stickDigitalThreshold <= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)))
-								{
-									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_UP);
-								}
-								if (-static_cast<int>(m_stickDigitalThreshold) >= static_cast<int>(*reinterpret_cast<s8*>(p12 + 0x15)))
-								{
-									*puVar12 = static_cast<u16>(*puVar12 | PAD_BUTTON_DOWN);
-								}
-							}
-						}
-						*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
-						*reinterpret_cast<u8*>(p12 + 0x14) = *reinterpret_cast<u8*>(puVar13 + 1);
-						*reinterpret_cast<u16*>(p12 + 0x0A) = 0;
-						if (*reinterpret_cast<s8*>(p12 + 0x14) < 0)
-						{
-							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 1;
-						}
-						if (0 < *reinterpret_cast<s8*>(p12 + 0x14))
-						{
-							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 2;
-						}
-						*reinterpret_cast<u8*>(p12 + 0x15) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 3);
-						if (*reinterpret_cast<s8*>(p12 + 0x15) < 0)
-						{
-							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 4;
-						}
-						if (0 < *reinterpret_cast<s8*>(p12 + 0x15))
-						{
-							*reinterpret_cast<u16*>(p12 + 0x0A) = *reinterpret_cast<u16*>(p12 + 0x0A) | 8;
-						}
-						fVar2 = kPadAnalogScale;
-						fVar3 = kPadTriggerMax;
-						*reinterpret_cast<u8*>(p12 + 0x16) = *reinterpret_cast<u8*>(puVar13 + 2);
-						*reinterpret_cast<u8*>(p12 + 0x17) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 5);
-						*reinterpret_cast<u8*>(p12 + 0x12) = *reinterpret_cast<u8*>(puVar13 + 3);
-						*reinterpret_cast<u8*>(p12 + 0x13) = *reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar13) + 7);
-						*reinterpret_cast<float*>(p12 + 0x20) =
-							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x14)) * fVar2;
-						*reinterpret_cast<float*>(p12 + 0x24) =
-							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x15)) * fVar2;
-						*reinterpret_cast<float*>(p12 + 0x28) =
-							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x16)) * fVar2;
-						*reinterpret_cast<float*>(p12 + 0x2C) =
-							static_cast<float>(*reinterpret_cast<s8*>(p12 + 0x17)) * fVar2;
-						*reinterpret_cast<float*>(p12 + 0x18) =
-							static_cast<float>(*reinterpret_cast<u8*>(p12 + 0x12)) / fVar3;
-						*reinterpret_cast<float*>(p12 + 0x1C) =
-							static_cast<float>(*reinterpret_cast<u8*>(p12 + 0x13)) / fVar3;
-					}
-					else
-					{
-						*puVar12 = 0;
-						fVar2 = kPadAnalogZero;
-						*reinterpret_cast<u8*>(p12 + 0x14) = 0;
-						*reinterpret_cast<u8*>(p12 + 0x15) = 0;
-						*reinterpret_cast<u8*>(p12 + 0x16) = 0;
-						*reinterpret_cast<u8*>(p12 + 0x17) = 0;
-						*reinterpret_cast<u8*>(p12 + 0x12) = 0;
-						*reinterpret_cast<u8*>(p12 + 0x13) = 0;
-						*reinterpret_cast<float*>(p12 + 0x20) = fVar2;
-						*reinterpret_cast<float*>(p12 + 0x24) = fVar2;
-						*reinterpret_cast<float*>(p12 + 0x28) = fVar2;
-						*reinterpret_cast<float*>(p12 + 0x2C) = fVar2;
-						*reinterpret_cast<float*>(p12 + 0x18) = fVar2;
-						*reinterpret_cast<float*>(p12 + 0x1C) = fVar2;
-					}
-				}
-				else if (reinterpret_cast<CPad::Gba*>(puVar18)->connected)
-				{
-					uVar8 = puVar18[1];
-					*reinterpret_cast<u32*>(p12 + 0x44) = *reinterpret_cast<u32*>(p12 + 0x44) | 1;
-					*puVar12 = uVar8;
-				}
-				puVar12[2] = static_cast<u16>(*puVar12 & (puVar12[0x26] ^ *puVar12));
-				if (iVar14 == 0)
-				{
-					*reinterpret_cast<u16*>(p12 + 0x0E) =
-						static_cast<u16>(puVar12[0x26] & (puVar12[0x26] ^ *puVar12));
-					*reinterpret_cast<u16*>(p12 + 0x0C) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x0A) &
-						                 (*reinterpret_cast<u16*>(p12 + 0x08) ^ *reinterpret_cast<u16*>(p12 + 0x0A)));
-					*reinterpret_cast<u16*>(p12 + 0x10) = static_cast<u16>(puVar12[0x26] & *puVar12 & 0x1F7F);
-					if (*reinterpret_cast<u16*>(p12 + 0x10) != 0)
-					{
-						*reinterpret_cast<int*>(p12 + 0x48) = *reinterpret_cast<int*>(p12 + 0x48) + 1;
-						if (*reinterpret_cast<u32*>(p12 + 0x48) < 0x10)
-						{
-							*reinterpret_cast<u16*>(p12 + 0x10) = 0;
-						}
-						else if ((*reinterpret_cast<u32*>(p12 + 0x48) & 1) != 0)
-						{
-							*reinterpret_cast<u16*>(p12 + 0x10) = 0;
-						}
-					}
-					else
-					{
-						*reinterpret_cast<u32*>(p12 + 0x48) = 0;
-					}
-					*reinterpret_cast<u16*>(p12 + 0x10) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p12 + 0x10) | puVar12[2]);
-					if (*reinterpret_cast<int*>(p12 + 0x38) != 0)
-					{
-						*reinterpret_cast<u16*>(p12 + 0x30) = *puVar12;
-						*reinterpret_cast<u16*>(p12 + 0x32) = puVar12[2];
-						*reinterpret_cast<u16*>(p12 + 0x34) = *reinterpret_cast<u16*>(p12 + 0x10);
-						*reinterpret_cast<u16*>(p12 + 0x0A) = 0;
-						*reinterpret_cast<u16*>(p12 + 0x0C) = 0;
-						*reinterpret_cast<u16*>(p12 + 0x10) = 0;
-						puVar12[2] = 0;
-						*reinterpret_cast<u16*>(p12 + 0x0E) = 0;
-						*puVar12 = 0;
-					}
-					else
-					{
-						*reinterpret_cast<u16*>(p12 + 0x34) = 0;
-						*reinterpret_cast<u16*>(p12 + 0x32) = 0;
-						*reinterpret_cast<u16*>(p12 + 0x30) = 0;
-					}
-				}
-				puVar7[2] = static_cast<u16>(puVar7[2] | puVar12[2]);
-				*puVar7 = static_cast<u16>(*puVar7 | *puVar12);
-				if (iVar14 == 0)
-				{
-					u8* p10 = reinterpret_cast<u8*>(puVar10);
-					*reinterpret_cast<u32*>(p10 + 0x38) =
-						*reinterpret_cast<u32*>(p10 + 0x38) | *reinterpret_cast<u32*>(p12 + 0x38);
-					*reinterpret_cast<u32*>(p10 + 0x3C) =
-						*reinterpret_cast<u32*>(p10 + 0x3C) | *reinterpret_cast<u32*>(p12 + 0x3C);
-					*reinterpret_cast<u16*>(p10 + 0x0E) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0E) | *reinterpret_cast<u16*>(p12 + 0x0E));
-					*reinterpret_cast<u16*>(p10 + 0x0A) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0A) | *reinterpret_cast<u16*>(p12 + 0x0A));
-					*reinterpret_cast<u16*>(p10 + 0x0C) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x0C) | *reinterpret_cast<u16*>(p12 + 0x0C));
-					*reinterpret_cast<s16*>(p10 + 0x10) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x10) | *reinterpret_cast<u16*>(p12 + 0x10));
-					*reinterpret_cast<u16*>(p10 + 0x32) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x32) | *reinterpret_cast<u16*>(p12 + 0x32));
-					*reinterpret_cast<u16*>(p10 + 0x30) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x30) | *reinterpret_cast<u16*>(p12 + 0x30));
-					*reinterpret_cast<u16*>(p10 + 0x34) =
-						static_cast<u16>(*reinterpret_cast<u16*>(p10 + 0x34) | *reinterpret_cast<u16*>(p12 + 0x34));
-					cVar9 = *reinterpret_cast<s8*>(p12 + 0x14);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x14)) >> 0x1F;
-					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x14))) - uVar15) <
-					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
-					{
-						*reinterpret_cast<s8*>(p10 + 0x14) = cVar9;
-						*reinterpret_cast<float*>(p10 + 0x20) = *reinterpret_cast<float*>(p12 + 0x20);
-					}
-					cVar9 = *reinterpret_cast<s8*>(p12 + 0x15);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x15)) >> 0x1F;
-					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x15))) - uVar15) <
-					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
-					{
-						*reinterpret_cast<s8*>(p10 + 0x15) = cVar9;
-						*reinterpret_cast<float*>(p10 + 0x24) = *reinterpret_cast<float*>(p12 + 0x24);
-					}
-					cVar9 = *reinterpret_cast<s8*>(p12 + 0x16);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x16)) >> 0x1F;
-					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x16))) - uVar15) <
-					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
-					{
-						*reinterpret_cast<s8*>(p10 + 0x16) = cVar9;
-						*reinterpret_cast<float*>(p10 + 0x28) = *reinterpret_cast<float*>(p12 + 0x28);
-					}
-					cVar9 = *reinterpret_cast<s8*>(p12 + 0x17);
-					uVar15 = static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x17)) >> 0x1F;
-					uVar16 = static_cast<int>(cVar9) >> 0x1F;
-					if (static_cast<int>((uVar15 ^ static_cast<int>(*reinterpret_cast<s8*>(p10 + 0x17))) - uVar15) <
-					    static_cast<int>((uVar16 ^ static_cast<int>(cVar9)) - uVar16))
-					{
-						*reinterpret_cast<s8*>(p10 + 0x17) = cVar9;
-						*reinterpret_cast<float*>(p10 + 0x2C) = *reinterpret_cast<float*>(p12 + 0x2C);
-					}
-					if (*reinterpret_cast<u8*>(p10 + 0x12) < *reinterpret_cast<u8*>(p12 + 0x12))
-					{
-						*reinterpret_cast<u8*>(p10 + 0x12) = *reinterpret_cast<u8*>(p12 + 0x12);
-						*reinterpret_cast<float*>(p10 + 0x18) = *reinterpret_cast<float*>(p12 + 0x18);
-					}
-					if (*reinterpret_cast<u8*>(p10 + 0x13) < *reinterpret_cast<u8*>(p12 + 0x13))
-					{
-						*reinterpret_cast<u8*>(p10 + 0x13) = *reinterpret_cast<u8*>(p12 + 0x13);
-						*reinterpret_cast<float*>(p10 + 0x1C) = *reinterpret_cast<float*>(p12 + 0x1C);
-					}
-				}
-			}
-			puVar12 = puVar12 + 1;
-			puVar7 = puVar7 + 1;
-		}
-		uVar17 = uVar17 + 1;
-		puVar13 = puVar13 + 6;
-		puVar18 = puVar18 + 2;
-		iVar6 = iVar6 + 0x54;
-	} while (uVar17 < 4);
+	MergePadInputs(this, puVar13, puVar18, puVar10);
 
 	if (_1bc_4_ >= 0)
 	{
 		_1bc_4_ = _1bc_4_ + 1;
 	}
 }
+
+#pragma always_inline off
 
 /*
  * --INFO--

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -398,8 +398,6 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* pu
  */
 void CPad::Frame()
 {
-	float fVar2;
-	float fVar3;
 	int iVar6;
 	u16 uVar1;
 	u16 uVar8;
@@ -414,7 +412,6 @@ void CPad::Frame()
 	u32 uVar15;
 	u32 gbaIdx;
 	u32 uVar16;
-	u32 uVar17;
 	u16* puVar18;
 	int iVar19;
 	CPad::Gba local_98[4];
@@ -527,11 +524,11 @@ void CPad::Frame()
 		}
 	}
 
-	puVar13 = reinterpret_cast<u16*>(local_88);
+	puVar7 = reinterpret_cast<u16*>(local_88);
 	puVar10 = reinterpret_cast<u16*>(self + 0x154);
 	uVar16 = 0;
 	gbaIdx = 0;
-	puVar7 = puVar13;
+	puVar13 = puVar7;
 	do
 	{
 		cVar9 = *reinterpret_cast<s8*>(puVar7 + 5);

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -471,7 +471,7 @@ void CPad::Frame()
 					*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar12) + 9) =
 						*reinterpret_cast<u8*>(reinterpret_cast<u8*>(puVar7) + 9);
 					puVar10 = puVar7 + 5;
-					puVar13 = puVar13 + 6;
+					puVar7 = puVar7 + 6;
 					*reinterpret_cast<u8*>(puVar12 + 5) = *reinterpret_cast<u8*>(puVar10);
 					iVar11 = *reinterpret_cast<int*>(reinterpret_cast<int>(_1b0_4_) + 8) * 0x40 + iVar14;
 					iVar14 = iVar14 + 4;
@@ -516,7 +516,7 @@ void CPad::Frame()
 				{
 					*puVar7 = static_cast<u16>(*puVar7 | uVar8);
 				}
-				puVar13 = puVar13 + 6;
+				puVar7 = puVar7 + 6;
 				iVar6 = iVar6 + 0x0C;
 				iVar19 = iVar19 + 4;
 				puVar13 = puVar13 + 2;


### PR DESCRIPTION
Raises main/pad from 96.71% to **97.39%** (+0.68). The whole gap was one function, `Frame__4CPadFv` (96.04% -> 96.85%, 2844b) — the old "pure coloring, not steerable" diagnosis was wrong; the register window IS source-steerable.

What landed:
- **Fresh per-loop IVs** (`port` for the SIProbe loop, `gbaIdx` for the GBA-flag loop) and dropping the `padIndex` copy — the old shared `uVar17` web coalesced with a block-scope copy and dragged the loop-1 IV from the target's r26 down to r23 (the brief's 3-reg window shift). Splitting the variable per loop gave each range its own rank. Also fixed the `cntlzw`/`rlwimi` connected-bit insert as a side effect.
- **R52 always-inline helper** (`MergePadInputs`, repo precedent gxfunc/p_map) wrapping the merged-pad init + per-port merge loop. Body locals declared in target order (`iVar14, p12, uVar17, iVar6, puVar7, puVar12`) land in volatile r9..r4 exactly as the original; params coalesce to r26/r28/r30. Loop-4 flagged lines 249 -> ~176.
- **Loop-3 web-order fixes**: init the local_88 base through the cursor-role-swapped pair (`puVar7` base passed to the helper, `puVar13` advancing in loop 3) — matches the target's `addi r26 / mr r27,r26` head and the helper-side r26 cursor.
- Inlined single-use `uVar8` temps in the helper; scratch decl-order tuning (`uVar15` before `cVar9`).

Confirmed residual walls (all attacked, all net-negative or no-op): the `uVar17=0`/zero-constant CSE in the merged block (target keeps two separate `li`s — untestable via placement, type, ternary, or pragmas); the `puVar18` helper param refusing to coalesce into caller r31 (pins r10, rotating the remaining scratch temps by +1); the replay record/playback loops' volatile permutation (helper wrap steered the named locals to exact target regs but lost net fuzzy twice); the loop-3 `uVar15`/`uVar16` r23/r25 swap. `__sinit` 99.09% is a vtable reloc-name diff (costs ~0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)