### PR TITLE
util: raise fuzzy match to 99.35% (cycle 6)

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -872,10 +872,10 @@ void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColo
  */
 void CUtil::ClearZBufferRect(float x, float y, float width, float height)
 {
-    Mtx modelMtx;
+    Mtx44 screenMtx;
     Mtx cameraMtx;
     Mtx44 orthoMtx;
-    Mtx44 screenMtx;
+    Mtx modelMtx;
     GXColor white;
     float indMtx[2][3];
 
@@ -934,6 +934,7 @@ void CUtil::ClearZBufferRect(float x, float y, float width, float height)
     GXSetColorUpdate(GX_FALSE);
     GXSetAlphaUpdate(GX_FALSE);
 
+    GXColor quadColor = white;
     Vec v0 = pos1;
     Vec v1 = pos0;
 
@@ -941,19 +942,19 @@ void CUtil::ClearZBufferRect(float x, float y, float width, float height)
     GXWGFifo.f32 = v1.x;
     GXWGFifo.f32 = v1.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = *reinterpret_cast<u32*>(&white);
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
     GXWGFifo.f32 = v0.x;
     GXWGFifo.f32 = v1.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = *reinterpret_cast<u32*>(&white);
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
     GXWGFifo.f32 = v0.x;
     GXWGFifo.f32 = v0.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = *reinterpret_cast<u32*>(&white);
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
     GXWGFifo.f32 = v1.x;
     GXWGFifo.f32 = v0.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = *reinterpret_cast<u32*>(&white);
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
 
     PSMTXCopy(GetCameraMatrix(), cameraMtx);
     PSMTX44Copy(GetScreenMatrix(), screenMtx);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -124,47 +124,17 @@ int CUtil::GetNumPolygonFromDL(void* dlData, unsigned long)
         }
 
         if (vertexFormat == 2) {
-            u32 remaining = count;
-            if (count > 0) {
-                u32 blocks = remaining >> 3;
-
-                if (blocks != 0) {
-                    do {
-                        data += 0x50;
-                    } while (--blocks != 0);
-
-                    remaining &= 7;
-                    if (remaining == 0) {
-                        continue;
-                    }
-                }
-
-                do {
-                    data += 10;
-                } while (--remaining != 0);
+            int remaining = count;
+            while (remaining > 0) {
+                data += 10;
+                remaining--;
             }
         } else {
-            u32 remaining = count;
-            if (count <= 0) {
-                continue;
-            }
-
-            u32 blocks = remaining >> 3;
-
-            if (blocks != 0) {
-                do {
-                    data += 0x40;
-                } while (--blocks != 0);
-
-                remaining &= 7;
-                if (remaining == 0) {
-                    continue;
-                }
-            }
-
-            do {
+            int remaining = count;
+            while (remaining > 0) {
                 data += 8;
-            } while (--remaining != 0);
+                remaining--;
+            }
         }
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -463,7 +463,6 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
 
     if (color != 0) {
         GXColor quadColor = *color;
-        u32 colorValue = *reinterpret_cast<u32*>(&quadColor);
         Vec v0 = pos1;
         Vec v1 = pos0;
         float u1;
@@ -487,33 +486,32 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v2;
 
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v2;
     } else {
         GXColor quadColor = white;
-        u32 colorValue = *reinterpret_cast<u32*>(&quadColor);
         Vec v0 = pos1;
         Vec v1 = pos0;
         float u1;
@@ -537,28 +535,28 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v2;
 
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v2;
     }
@@ -657,7 +655,6 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
 
     if (color != 0) {
         GXColor quadColor = *color;
-        u32 colorValue = *reinterpret_cast<u32*>(&quadColor);
         Vec v0 = pos1;
         Vec v1 = pos0;
         float u1;
@@ -681,33 +678,32 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v2;
 
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v2;
     } else {
         GXColor quadColor = white;
-        u32 colorValue = *reinterpret_cast<u32*>(&quadColor);
         Vec v0 = pos1;
         Vec v1 = pos0;
         float u1;
@@ -731,28 +727,28 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v1.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v;
 
         GXWGFifo.f32 = v0.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u2;
         GXWGFifo.f32 = v2;
 
         GXWGFifo.f32 = v1.x;
         GXWGFifo.f32 = v0.y;
         GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = colorValue;
+        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
         GXWGFifo.f32 = u1;
         GXWGFifo.f32 = v2;
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,14 +8,6 @@ struct UtilHermiteBasis {
 	float m_value[4];
 };
 
-static const float kUtilZero = 0.0f;
-static const float kUtilOne = 1.0f;
-static const float kUtilOrthoBottom = 448.0f;
-static const float kUtilOrthoRight = 640.0f;
-static const float kUtilQuadDepth = -0.9999999f;
-static const float kUtilHermiteCoeff2 = 2.0f;
-static const float kUtilHermiteCoeff3 = 3.0f;
-static const float kUtilHermiteCoeffNeg2 = -2.0f;
 extern const UtilHermiteBasis kUtilHermiteBasis;
 extern Vec gUtilUpVector;
 
@@ -388,6 +380,11 @@ void CUtil::SetPaletteEnv(CTexture* texture)
 void CUtil::RenderTextureQuad(float x, float y, float width, float height, CTexture* texture, Vec2d* uv1, Vec2d* uv2,
                               _GXColor* color, _GXBlendFactor srcBlend, _GXBlendFactor dstBlend)
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+    extern const float kUtilOrthoBottom;
+    extern const float kUtilOrthoRight;
+
     Mtx44 screenMtx;
     Mtx cameraMtx;
     Mtx44 orthoMtx;
@@ -471,10 +468,10 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
         float v2;
 
         if (uv1 == 0 || uv2 == 0) {
-            u1 = kUtilZero;
-            v = kUtilZero;
-            u2 = kUtilOne;
-            v2 = kUtilOne;
+            u1 = 0.0f;
+            v = 0.0f;
+            u2 = 1.0f;
+            v2 = 1.0f;
         } else {
             u1 = uv1->x;
             v = uv1->y;
@@ -520,10 +517,10 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
         float v2;
 
         if (uv1 == 0 || uv2 == 0) {
-            u1 = kUtilZero;
-            v = kUtilZero;
-            u2 = kUtilOne;
-            v2 = kUtilOne;
+            u1 = 0.0f;
+            v = 0.0f;
+            u2 = 1.0f;
+            v2 = 1.0f;
         } else {
             u1 = uv1->x;
             v = uv1->y;
@@ -583,6 +580,11 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
 void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTexObj* texObj, Vec2d* uv1, Vec2d* uv2,
                               _GXColor* color, _GXBlendFactor srcBlend, _GXBlendFactor dstBlend)
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+    extern const float kUtilOrthoBottom;
+    extern const float kUtilOrthoRight;
+
     Mtx44 screenMtx;
     Mtx cameraMtx;
     Mtx44 orthoMtx;
@@ -663,10 +665,10 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
         float v2;
 
         if (uv1 == 0 || uv2 == 0) {
-            u1 = kUtilZero;
-            v = kUtilZero;
-            u2 = kUtilOne;
-            v2 = kUtilOne;
+            u1 = 0.0f;
+            v = 0.0f;
+            u2 = 1.0f;
+            v2 = 1.0f;
         } else {
             u1 = uv1->x;
             v = uv1->y;
@@ -712,10 +714,10 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
         float v2;
 
         if (uv1 == 0 || uv2 == 0) {
-            u1 = kUtilZero;
-            v = kUtilZero;
-            u2 = kUtilOne;
-            v2 = kUtilOne;
+            u1 = 0.0f;
+            v = 0.0f;
+            u2 = 1.0f;
+            v2 = 1.0f;
         } else {
             u1 = uv1->x;
             v = uv1->y;
@@ -774,6 +776,11 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
  */
 void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColor color)
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+    extern const float kUtilOrthoBottom;
+    extern const float kUtilOrthoRight;
+
     Mtx44 screenMtx;
     Mtx cameraMtx;
     Mtx44 orthoMtx;
@@ -871,6 +878,12 @@ void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColo
  */
 void CUtil::ClearZBufferRect(float x, float y, float width, float height)
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+    extern const float kUtilOrthoBottom;
+    extern const float kUtilOrthoRight;
+    extern const float kUtilQuadDepth;
+
     Mtx44 screenMtx;
     Mtx cameraMtx;
     Mtx44 orthoMtx;
@@ -994,6 +1007,11 @@ void CUtil::EndQuadEnv()
  */
 void CUtil::BeginQuadEnv()
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+    extern const float kUtilOrthoBottom;
+    extern const float kUtilOrthoRight;
+
     Mtx44 orthoMtx;
     Mtx modelMtx;
     float indMtx[2][3];
@@ -1056,6 +1074,9 @@ void CUtil::DisableIndMtx()
  */
 void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+
     u32* colorPtr = reinterpret_cast<u32*>(&color);
     float u1;
     float v1;
@@ -1130,6 +1151,9 @@ void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d
  */
 void CUtil::RenderQuad(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d* uv2)
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+
     u32* colorPtr = reinterpret_cast<u32*>(&color);
     float u0;
     float v0;
@@ -1295,6 +1319,11 @@ void CUtil::ConvI2FVector(Vec& out, S16Vec in, long shift)
  */
 void CUtil::GetSplinePos(Vec& out, Vec p0, Vec p1, Vec p2, Vec p3, float t, float scale)
 {
+    extern const float kUtilOne;
+    extern const float kUtilHermiteCoeff2;
+    extern const float kUtilHermiteCoeff3;
+    extern const float kUtilHermiteCoeffNeg2;
+
 	Vec tan0;
 	Vec tan1;
 
@@ -1365,6 +1394,11 @@ int CUtil::GetNoise(unsigned char noise)
  */
 void CUtil::SetOrthoEnv()
 {
+    extern const float kUtilZero;
+    extern const float kUtilOne;
+    extern const float kUtilOrthoBottom;
+    extern const float kUtilOrthoRight;
+
     Mtx modelMtx;
     Mtx44 orthoMtx;
 
@@ -1475,3 +1509,12 @@ void CUtil::Quit()
 {
 	// TODO
 }
+
+extern const float kUtilZero = 0.0f;
+extern const float kUtilOne = 1.0f;
+extern const float kUtilOrthoBottom = 448.0f;
+extern const float kUtilOrthoRight = 640.0f;
+extern const float kUtilQuadDepth = -0.9999999f;
+extern const float kUtilHermiteCoeff2 = 2.0f;
+extern const float kUtilHermiteCoeff3 = 3.0f;
+extern const float kUtilHermiteCoeffNeg2 = -2.0f;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -833,7 +833,6 @@ void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColo
     pos1.y = y2;
     pos1.z = kUtilZero;
     GXColor quadColor = color;
-    u32 colorValue = *reinterpret_cast<u32*>(&quadColor);
     Vec v0 = pos1;
     Vec v1 = pos0;
 
@@ -841,19 +840,19 @@ void CUtil::RenderColorQuad(float x, float y, float width, float height, _GXColo
     GXWGFifo.f32 = v1.x;
     GXWGFifo.f32 = v1.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = colorValue;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
     GXWGFifo.f32 = v0.x;
     GXWGFifo.f32 = v1.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = colorValue;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
     GXWGFifo.f32 = v0.x;
     GXWGFifo.f32 = v0.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = colorValue;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
     GXWGFifo.f32 = v1.x;
     GXWGFifo.f32 = v0.y;
     GXWGFifo.f32 = v1.z;
-    GXWGFifo.u32 = colorValue;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
 
     PSMTXCopy(GetCameraMatrix(), cameraMtx);
     PSMTX44Copy(GetScreenMatrix(), screenMtx);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1079,14 +1079,15 @@ void CUtil::RenderQuadTex2(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d
     }
 
     GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+    f32 x2;
     f32 x1 = pos1.x;
     f32 y1 = pos1.y;
     GXWGFifo.f32 = x1;
-    GXWGFifo.f32 = y1;
     f32 z1 = pos1.z;
-    GXWGFifo.f32 = z1;
+    GXWGFifo.f32 = y1;
     u32 rgba = *colorPtr;
-    f32 x2 = pos2.x;
+    GXWGFifo.f32 = z1;
+    x2 = pos2.x;
     GXWGFifo.u32 = rgba;
     f32 y2 = pos2.y;
     GXWGFifo.f32 = u1;
@@ -1152,14 +1153,15 @@ void CUtil::RenderQuad(Vec pos1, Vec pos2, _GXColor color, Vec2d* uv1, Vec2d* uv
     }
 
     GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+    f32 x2;
     f32 x1 = pos1.x;
     f32 y1 = pos1.y;
     GXWGFifo.f32 = x1;
-    GXWGFifo.f32 = y1;
     f32 z1 = pos1.z;
-    GXWGFifo.f32 = z1;
+    GXWGFifo.f32 = y1;
     u32 rgba = *colorPtr;
-    f32 x2 = pos2.x;
+    GXWGFifo.f32 = z1;
+    x2 = pos2.x;
     GXWGFifo.u32 = rgba;
     f32 y2 = pos2.y;
     GXWGFifo.f32 = u0;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -172,12 +172,12 @@ void CUtil::CalcBoundaryBoxQuantized(Vec* minOut, Vec* maxOut, S16Vec* vecs, uns
     }
 
     S16Vec finalMin = min;
-    S16Vec finalMax = max;
     int scale = 1 << shift;
 
     minOut->x = (float)finalMin.x / (float)scale;
     minOut->y = (float)finalMin.y / (float)scale;
     minOut->z = (float)finalMin.z / (float)scale;
+    S16Vec finalMax = max;
     maxOut->x = (float)finalMax.x / (float)scale;
     maxOut->y = (float)finalMax.y / (float)scale;
     maxOut->z = (float)finalMax.z / (float)scale;


### PR DESCRIPTION
Raises main/util from 98.24% to **99.35%** (+1.11). Functions at 100%: 19 -> 22.

Per-function gains:
- **GetNumPolygonFromDL 92.28 -> 99.69**: the old hand-unrolled quotient/remainder loops were replaced with plain `while (remaining > 0) { data += N; remaining--; }` countdown loops — mwcc's own unroller regenerates the target's exact x8 CTR (`srwi./mtctr/bdnz` + `andi.` remainder) shape (R44/R55 family).
- **RenderQuad 96.62 -> 100, RenderQuadTex2 96.93 -> 100**: adopted the RenderQuadNoTex vertex-staging idiom (`f32 x2;` declared before `x1/y1`, `z1` load interleaved between the first two fifo stores).
- **RenderTextureQuad (both) 98.7 -> 99.92**: dropped the hoisted `u32 colorValue` local (it pinned the color word in a callee-saved GPR); the fifo block now reads `*(u32*)&quadColor` so the word stays in its stack slot and reloads into r0, matching the target.
- **RenderColorQuad 98.96 -> 99.93**: same colorValue fix.
- **ClearZBufferRect 98.76 -> 99.93**: matrix locals reordered to the target frame layout (screenMtx, cameraMtx, orthoMtx, modelMtx) + restored the `GXColor quadColor = white;` copy the fifo reads.
- **CalcBoundaryBoxQuantized 96.64 -> 100**: moved the `finalMax` struct copy after the min conversions.
- **SetOrthoEnv/BeginQuadEnv/CalcUV/GetNoise -> 100** via R46: kUtil* float constants converted from file-scope `static const float` to block-scope `extern const float` declarations + C++-linkage definitions after all uses, so .text relocs are the named sdata2 symbols (kUtilZero_8032F888 etc.). The RTQ uv-default blocks keep plain literals to preserve the target's per-use constant reload (named externs there got CSE'd into a live register).

Remaining walls (attacked, no lever landed): ConvI2FVector (78.5, pure top-of-function scheduling around the compiler-generated int->float magic-double; locals/interleave/pragma sweeps all neutral or negative), GetSplinePos (96.1, scratch-FPR permutation; decl/operand-order sweeps neutral), ConvF2IVector pair (97.1/97.7, same FPR-window family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)