### PR TITLE
ME_USB_process: raise fuzzy match to 98.0% (cycle 6)

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -332,7 +332,7 @@ mapshadow.cpp:
 	extab       start:0x80006AAC end:0x80006AC4
 	extabindex  start:0x8000C70C end:0x8000C730
 	.text       start:0x8004C71C end:0x8004CA08
-	.sdata2     start:0x8032FCF0 end:0x8032FD10
+	.sdata2     start:0x8032FCF0 end:0x8032FD00
 
 ME_USB_process.cpp:
 	extab       start:0x80006AC4 end:0x80006AD4
@@ -340,6 +340,7 @@ ME_USB_process.cpp:
 	.text       start:0x8004CA08 end:0x8004DCE8
 	.rodata     start:0x801D7D78 end:0x801D7DA8
 	.data       start:0x801EA668 end:0x801EA778
+	.sdata2     start:0x8032FD00 end:0x8032FD10
 
 ME_AppRequest.cpp:
 	extab       start:0x80006AD4 end:0x80006AFC

--- a/configure.py
+++ b/configure.py
@@ -546,7 +546,7 @@ config.libs = [
             Object(NonMatching, "materialman.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-inline auto,deferred", "-str reuse"]),
             Object(NonMatching, "math.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "ME_AppRequest.cpp"),
-            Object(NonMatching, "ME_USB_process.cpp", cflags=[*cflags_game_cpp_exceptions, "-sdata 0"]),
+            Object(NonMatching, "ME_USB_process.cpp", cflags=[*cflags_game_cpp_exceptions, "-sdata2 8"]),
             Object(NonMatching, "memory.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "memorycard.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse"]),
             Object(Matching, "menu.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -11,9 +11,6 @@
 
 static const char s_ME_USB_process_cpp[] = "ME_USB_process.cpp";
 extern "C" const char sMemAllocErrorSizeFmt[] = "MemAlloc Error!!! size=%d\n";
-extern "C" const float kMapEditorZero;
-extern "C" const float kMapEditorOne;
-extern "C" const double kMapEditorS32ToDoubleBias;
 
 namespace {
 struct ViewerSRT {
@@ -80,21 +77,6 @@ static inline void StoreSwapS16(s16* value)
     *value = __lhbrx(&raw, 0);
 }
 
-static inline f32 S32ToFloat(s32 value)
-{
-    union {
-        struct {
-            u32 hi;
-            u32 lo;
-        } words;
-        f64 value;
-    } cvt;
-
-    cvt.words.hi = 0x43300000;
-    cvt.words.lo = value ^ 0x80000000;
-    return static_cast<f32>(cvt.value - kMapEditorS32ToDoubleBias);
-}
-
 }
 
 /*
@@ -132,6 +114,8 @@ void CMaterialEditorPcs::SetUSBData()
         AddRsdList(&m_zlist1);
         break;
     case 0x10: {
+        extern const float kMapEditorZero;
+        extern const float kMapEditorOne;
         ViewerSRT srt;
         Vec minPos;
         Vec maxPos;
@@ -165,15 +149,18 @@ void CMaterialEditorPcs::SetUSBData()
         s32 xDiff = static_cast<s32>(maxPos.y - minPos.y);
         s32 yDiff = static_cast<s32>(maxPos.z - minPos.z);
 
+        srt.transX = kMapEditorZero;
+        srt.transZ = kMapEditorZero;
+        srt.transY = kMapEditorZero;
         srt.rotZ = kMapEditorZero;
-        srt.transY = S32ToFloat(-xDiff / 2);
         srt.rotY = kMapEditorZero;
         srt.rotX = kMapEditorZero;
         srt.scaleZ = kMapEditorOne;
         srt.scaleY = kMapEditorOne;
         srt.scaleX = kMapEditorOne;
-        srt.transZ = S32ToFloat(-yDiff * (xDiff / 0x14) - 10);
         srt.transX = kMapEditorZero;
+        srt.transY = static_cast<f32>(-xDiff / 2);
+        srt.transZ = static_cast<f32>(-yDiff * (xDiff / 0x14) - 10);
         CameraPcs.SetViewerSRT(reinterpret_cast<const SRT*>(&srt));
         break;
     }
@@ -356,10 +343,11 @@ void CMaterialEditorPcs::SetUSBData()
         memcpy(this->m_textureHeader[this->m_loadedTextureCount], headerBuffer, 0x10);
 
         if (headerBuffer[1] == 0x20) {
+            u32 dataBytes = usb.m_sizeBytes;
             void* texData = Memory._Alloc(
-                usb.m_sizeBytes - 0x10, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0);
+                dataBytes - 0x10, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0);
             if (texData == 0) {
-                System.Printf(const_cast<char*>(sMemAllocErrorSizeFmt), usb.m_sizeBytes - 0x10);
+                System.Printf(const_cast<char*>(sMemAllocErrorSizeFmt), dataBytes - 0x10);
             }
             this->m_textureData[this->m_loadedTextureCount] = texData;
             memcpy(this->m_textureData[this->m_loadedTextureCount], headerBuffer + 8, usb.m_sizeBytes - 0x10);
@@ -375,8 +363,10 @@ void CMaterialEditorPcs::SetUSBData()
                 System.Printf(const_cast<char*>(sMemAllocErrorSizeFmt), imageDataSize);
             }
             this->m_textureData[this->m_loadedTextureCount] = texData;
-            memcpy(this->m_textureData[this->m_loadedTextureCount], headerBuffer + 8, imageDataSize);
-            DCFlushRange(this->m_textureData[this->m_loadedTextureCount], imageDataSize);
+            memcpy(this->m_textureData[this->m_loadedTextureCount], headerBuffer + 8,
+                static_cast<int>(usb.m_sizeBytes) - 0x10 - tlutDataSize);
+            DCFlushRange(this->m_textureData[this->m_loadedTextureCount],
+                static_cast<int>(usb.m_sizeBytes) - 0x10 - tlutDataSize);
 
             void* tlutData = Memory._Alloc(
                 tlutDataSize, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0);
@@ -480,3 +470,6 @@ void CMaterialEditorPcs::MemFree(void* ptr)
         Memory.Free(ptr);
     }
 }
+
+extern const float kMapEditorZero = 0.0f;
+extern const float kMapEditorOne = 1.0f;

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -422,7 +422,7 @@ void CMaterialEditorPcs::SetUSBData()
             }
             heightFactor >>= 1;
         }
-        if ((heightFactor != 1) || (widthFactor != 1)) {
+        if ((heightFactor != 1) || (heightFactor != 1)) {
             isPowerOfTwo = 0;
         }
 

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -316,13 +316,13 @@ void CMaterialEditorPcs::SetUSBData()
     }
     case 0x20: {
         u32 allocSize = usb.m_sizeBytes;
-        s16* headerBuffer = static_cast<s16*>(
-            Memory._Alloc(allocSize, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0));
+        void* mem = Memory._Alloc(allocSize, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0);
 
-        if (headerBuffer == 0) {
+        if (mem == 0) {
             System.Printf(const_cast<char*>(sMemAllocErrorSizeFmt), allocSize);
         }
 
+        s16* headerBuffer = static_cast<s16*>(mem);
         void* headerDst =
             Memory._Alloc(0x10, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0);
         if (headerDst == 0) {

--- a/src/mapshadow.cpp
+++ b/src/mapshadow.cpp
@@ -13,9 +13,6 @@
 extern const double kMapShadowDepthBias;
 static const float kMapShadowScaleStep = 0.5f;
 static const double kMapShadowUnsignedDoubleBias = 4503599627370496.0;
-extern const float kMapEditorZero;
-extern const float kMapEditorOne;
-extern const double kMapEditorS32ToDoubleBias;
 
 static inline float LoadFloat(const float& value)
 {
@@ -138,7 +135,3 @@ void CMapShadow::Init()
 		                (float)(scaleBias * (double)scale), scaleStep * scale, scaleStep, scaleStep);
 	}
 }
-
-extern const float kMapEditorZero = 0.0f;
-extern const float kMapEditorOne = 1.0f;
-extern const double kMapEditorS32ToDoubleBias = 4503601774854144.0;


### PR DESCRIPTION
Raises main/ME_USB_process from 96.10% to 98.04% (+1.93). Whole gap was SetUSBData (4784b).

## What cracked the @sda21 extern-const wall
- **kMapEditor\* constants belong to this unit**: they sit at 0x8032FD00-FD10, immediately after mapshadow's own sdata2 — and mapshadow never uses them (it only hosted the definitions as a crutch from an old PR). Moved the definitions into ME_USB_process.cpp (block-scope `extern const` decls inside the function + definitions after all uses, map.cpp-style), moved the `.sdata2` split range from mapshadow to ME_USB_process, and dropped mapshadow's crutch definitions. mapshadow stays 100%.
- **`-sdata 0` was suppressing @sda21 references**: with the defs in-unit, mwcc still emitted @ha/@l pairs until the unit's `-sdata 0` flag was replaced with `-sdata2 8`. After that, `kMapEditorZero/One@sda21` single loads match the target exactly.
- **The "named" S32→double bias is just the compiler's pool constant**: replaced the manual union S32ToFloat helper with plain `static_cast<f32>(s32)` casts — mwcc generates the exact target shape (`lis 0x4330; xoris; stw; lfd; fsubs` with the bias CSE'd in f2). The `kMapEditorS32ToDoubleBias@sda21` reloc-name diff vs our anonymous `@551` costs zero.

## Other source fixes
- **Case 0x10**: original zero/one-initialized ALL 9 ViewerSRT fields, then re-assigned transX/transY/transZ (explains the duplicate transX store the simplified source dropped).
- **Case 0x20 CI branch**: target recomputes `(int)m_sizeBytes - 0x10 - tlutDataSize` fresh at the memcpy/DCFlushRange sites (member reload after calls) while keeping `imageDataSize` only for alloc+printf; RGBA8 branch caches `m_sizeBytes` in a local for alloc+printf only.
- **Case 0x20 header alloc**: staged through a `void* mem` temp, typed `headerBuffer` assigned between the two allocs (matches `mr. r15` then `mr r30, r15`).
- **Power-of-two check**: Ghidra confirms the original tested `heightFactor != 1` TWICE (`(h != 1) || (h != 1)` — original source typo); replicating it removes the spurious `cmplwi widthFactor` and matches the `bne; beq` pair.

## Remaining (walled)
Residual ~180 flagged lines are pure register-permutation tie-breaks: the case 0x13 byte-swap loop's 21-slot address-invariant window (IVs at r25/r26 vs target r23/r24 — resists IV decl position, strength-reduction form, helper wraps, staging-local splits; all variants byte-identical or regress), the case 0x10/0x12 float-loop temp windows, and the case 0x20 r14/r15/r16 permutation. The anonymous pool double sorts before the named Zero/One defs in .sdata2 (pool emits at function position), so that 16-byte section stays at 50% — the named-definition alternative costs more in .text (fsub+frsp vs fsubs).

Verified against fresh main: only main/ME_USB_process changes (whole-report 96.66559 -> 96.670616, no other unit moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)