### PR TITLE
p_MaterialEditor: raise fuzzy match to 98.8% (cycle 6)

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -254,36 +254,36 @@ void CMaterialEditorPcs::drawViewer()
                 case 'H':
                 if (static_cast<s16>(m_loadedTextureCount) > polygon->textureIndex) {
                     s16* textureHeader = m_textureHeader[polygon->textureIndex];
-                    float scaleU = static_cast<float>(LoadDouble(kMaterialEditorOneF64) / S16ToDouble(textureHeader[2]));
-                    float scaleV = static_cast<float>(LoadDouble(kMaterialEditorOneF64) / S16ToDouble(textureHeader[3]));
+                    float scaleU = static_cast<float>(LoadDouble(kMaterialEditorOneF64) / static_cast<double>(textureHeader[2]));
+                    float scaleV = static_cast<float>(LoadDouble(kMaterialEditorOneF64) / static_cast<double>(textureHeader[3]));
                     MaterialEditorPolygon* pp = polygon;
                     s16 u = pp->u0;
 
                     if (u < 0) {
-                        pp->texCoord[0][0] = (scaleU * S16ToFloat(u)) + LoadFloat(kMaterialEditorOneF);
+                        pp->texCoord[0][0] = (scaleU * static_cast<float>(u)) + LoadFloat(kMaterialEditorOneF);
                     } else {
-                        pp->texCoord[0][0] = scaleU * S16ToFloat(u);
+                        pp->texCoord[0][0] = scaleU * static_cast<float>(u);
                     }
                     pp = polygon;
                     u = pp->u1;
                     if (u < 0) {
-                        pp->texCoord[1][0] = (scaleU * S16ToFloat(u)) + LoadFloat(kMaterialEditorOneF);
+                        pp->texCoord[1][0] = (scaleU * static_cast<float>(u)) + LoadFloat(kMaterialEditorOneF);
                     } else {
-                        pp->texCoord[1][0] = scaleU * S16ToFloat(u);
+                        pp->texCoord[1][0] = scaleU * static_cast<float>(u);
                     }
                     pp = polygon;
                     u = pp->u2;
                     if (u < 0) {
-                        pp->texCoord[2][0] = (scaleU * S16ToFloat(u)) + LoadFloat(kMaterialEditorOneF);
+                        pp->texCoord[2][0] = (scaleU * static_cast<float>(u)) + LoadFloat(kMaterialEditorOneF);
                     } else {
-                        pp->texCoord[2][0] = scaleU * S16ToFloat(u);
+                        pp->texCoord[2][0] = scaleU * static_cast<float>(u);
                     }
                     pp = polygon;
                     u = pp->u3;
                     if (u < 0) {
-                        pp->texCoord[3][0] = (scaleU * S16ToFloat(u)) + LoadFloat(kMaterialEditorOneF);
+                        pp->texCoord[3][0] = (scaleU * static_cast<float>(u)) + LoadFloat(kMaterialEditorOneF);
                     } else {
-                        pp->texCoord[3][0] = scaleU * S16ToFloat(u);
+                        pp->texCoord[3][0] = scaleU * static_cast<float>(u);
                     }
 
                     int v;
@@ -305,13 +305,13 @@ void CMaterialEditorPcs::drawViewer()
                     }
 
                     pp = polygon;
-                    pp->texCoord[0][1] = -(scaleV * S16ToFloat(pp->v0) - LoadFloat(kMaterialEditorOneF));
+                    pp->texCoord[0][1] = -(scaleV * static_cast<float>(pp->v0) - LoadFloat(kMaterialEditorOneF));
                     pp = polygon;
-                    pp->texCoord[1][1] = -(scaleV * S16ToFloat(pp->v1) - LoadFloat(kMaterialEditorOneF));
+                    pp->texCoord[1][1] = -(scaleV * static_cast<float>(pp->v1) - LoadFloat(kMaterialEditorOneF));
                     pp = polygon;
-                    pp->texCoord[2][1] = -(scaleV * S16ToFloat(pp->v2) - LoadFloat(kMaterialEditorOneF));
+                    pp->texCoord[2][1] = -(scaleV * static_cast<float>(pp->v2) - LoadFloat(kMaterialEditorOneF));
                     pp = polygon;
-                    pp->texCoord[3][1] = -(scaleV * S16ToFloat(pp->v3) - LoadFloat(kMaterialEditorOneF));
+                    pp->texCoord[3][1] = -(scaleV * static_cast<float>(pp->v3) - LoadFloat(kMaterialEditorOneF));
                     DCStoreRange(polygon, sizeof(MaterialEditorPolygon));
 
                     if (textureHeader[1] == 0x20) {

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -378,13 +378,14 @@ void CMaterialEditorPcs::drawViewer()
                 GXSetArray(GX_VA_CLR0, polygon->_30, 4);
                 GXSetArray(GX_VA_TEX0, polygon->texCoord, 8);
 
-                u32 vertexIndex[8];
-                vertexIndex[4] = polygon->index0;
-                vertexIndex[5] = polygon->index1;
-                vertexIndex[6] = polygon->index2;
-                vertexIndex[0] = 0;
-                vertexIndex[1] = 1;
-                vertexIndex[2] = 2;
+                u32 posIndex[4];
+                u32 clrIndex[4];
+                posIndex[0] = polygon->index0;
+                posIndex[1] = polygon->index1;
+                posIndex[2] = polygon->index2;
+                clrIndex[0] = 0;
+                clrIndex[1] = 1;
+                clrIndex[2] = 2;
 
                 if (flags == 0) {
                     GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
@@ -392,16 +393,14 @@ void CMaterialEditorPcs::drawViewer()
                 if (flags == 1) {
                     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
                     vertexCount = 4;
-                    vertexIndex[6] = polygon->index3;
-                    vertexIndex[7] = polygon->index2;
-                    vertexIndex[2] = 3;
-                    vertexIndex[3] = 2;
+                    posIndex[2] = polygon->index3;
+                    posIndex[3] = polygon->index2;
+                    clrIndex[2] = 3;
+                    clrIndex[3] = 2;
                 }
 
-                s8 i = 0;
+                u8 i = 0;
                 while (i < vertexCount) {
-                    u32* posIndex = &vertexIndex[4];
-                    u32* clrIndex = &vertexIndex[0];
                     u32 pos = posIndex[i];
                     u32 clr = clrIndex[i];
                     i++;

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -291,19 +291,19 @@ void CMaterialEditorPcs::drawViewer()
                     int v;
                     v = polygon->v0;
                     if (v < 0) {
-                        polygon->v0 = v * -1;
+                        polygon->v0 = v * -1U;
                     }
                     v = polygon->v1;
                     if (v < 0) {
-                        polygon->v1 = v * -1;
+                        polygon->v1 = v * -1U;
                     }
                     v = polygon->v2;
                     if (v < 0) {
-                        polygon->v2 = v * -1;
+                        polygon->v2 = v * -1U;
                     }
                     v = polygon->v3;
                     if (v < 0) {
-                        polygon->v3 = v * -1;
+                        polygon->v3 = v * -1U;
                     }
 
                     pp = polygon;
@@ -399,10 +399,12 @@ void CMaterialEditorPcs::drawViewer()
                     clrIndex[3] = 2;
                 }
 
+                u32 pos;
+                u32 clr;
                 u8 i = 0;
                 while (i < vertexCount) {
-                    u32 pos = posIndex[i];
-                    u32 clr = clrIndex[i];
+                    pos = posIndex[i];
+                    clr = clrIndex[i];
                     i++;
                     GXWGFifo.u16 = static_cast<u16>(pos);
                     GXWGFifo.u16 = static_cast<u16>(pos);

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -165,6 +165,8 @@ void CMaterialEditorPcs::drawViewer()
         return;
     }
 
+    GXColor blue;
+    GXColor red;
     ZLIST* zlist = &m_zlist1;
     _ZLISTITEM* it = zlist->m_root.m_previous;
     while (it != 0) {
@@ -328,8 +330,6 @@ void CMaterialEditorPcs::drawViewer()
                         GXSetNumTevStages(3);
                         GXSetNumTexGens(1);
 
-                        GXColor red;
-                        GXColor blue;
                         red.r = 0xff;
                         red.g = 0xff;
                         red.b = 0;

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -319,7 +319,7 @@ void CMaterialEditorPcs::drawViewer()
                     if (textureHeader[1] == 0x20) {
                         GXSetNumTevStages(1);
                         GXSetNumTexGens(1);
-                        GXLoadTexObj(m_texObj[polygon->textureIndex], GX_TEXMAP0);
+                        GXLoadTexObj(m_texObj[polygon->textureIndex], static_cast<_GXTexMapID>(polygon->textureIndex));
                         _GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_TEXC, GX_CC_RASC, GX_CC_ZERO);
                         _GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
                         _GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_TEXA, GX_CA_RASA, GX_CA_ZERO);
@@ -399,15 +399,13 @@ void CMaterialEditorPcs::drawViewer()
                     clrIndex[3] = 2;
                 }
 
-                u32 pos;
                 u32 clr;
                 u8 i = 0;
                 while (i < vertexCount) {
-                    pos = posIndex[i];
+                    GXWGFifo.u16 = static_cast<u16>(posIndex[i]);
+                    GXWGFifo.u16 = static_cast<u16>(posIndex[i]);
                     clr = clrIndex[i];
                     i++;
-                    GXWGFifo.u16 = static_cast<u16>(pos);
-                    GXWGFifo.u16 = static_cast<u16>(pos);
                     GXWGFifo.u8 = static_cast<u8>(clr);
                     GXWGFifo.u16 = static_cast<u16>(clr);
                 }


### PR DESCRIPTION
Raises main/p_MaterialEditor from 96.54% to 98.78% (drawViewer 95.93% -> 99.86%).

What landed (all in drawViewer):
- Replaced the inline S16ToFloat/S16ToDouble union helpers with native s16->float/double casts. mwcc's own conversion temps coalesce into the shared scratch slots the target has (frame 0xf0 -> 0xa0) and emit the target's fsubs single-precision form instead of fsub+frsp (+1.43).
- Split the single u32 vertexIndex[8] into separate posIndex[4]/clrIndex[4] arrays so the two loop base pointers don't CSE into one, and rewrote the FIFO loop with u8 i (+0.46).
- Declaration-order fix: declared blue/red at function top before it, keeping the matColor = ambColor initializer attached, matching the target's stack-slot order blue > red > it > matColor (+0.01 then enabling later wins).
- pos/clr value declarations hoisted, FIFO writes interleaved (pos stores before clr load) so posBase/fifo/clrBase get the target's volatile-register ranks, with pos as an unnamed expression (scratch r0) and clr named (+0.08).
- v * -1U (unsigned multiply) defeats the neg fold and produces the target's mulli r0,r0,-1 at all 4 sites (+0.18).
- GXLoadTexObj in the 0x20 block: target passes the texture index itself as the texmap arg (one CSE'd lhax into r4, no li r4,0) - Ghidra confirms a one-arg-tracked call (+0.08).

Residual (2 flagged lines in drawViewer): the switch emitter's extra bge-to-join (every empty-case/default/goto variant either adds a cmpwi or collapses to bne), and the kMaterialEditorDefaultColorRgba named-vs-anonymous pool reloc (using the named constant changes copy codegen, -1.06). __sinit remains the known p_* data.0 base-CSE wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)