### PR TITLE
p_light: raise fuzzy match to 98.82% (cycle 6)

### DIFF
--- a/include/ffcc/p_light.h
+++ b/include/ffcc/p_light.h
@@ -101,7 +101,7 @@ public:
     void MakeLightMap();
     void SetBumpTexMatirx(float (*)[4], CLightPcs::CBumpLight*, Vec*, unsigned char);
     float (*GetBumpIndTexMtx())[3] { return reinterpret_cast<float (*)[3]>(&m_bumpTexScratch[12]); }
-    CBumpLight* GetBumpLight(CLightPcs::TARGET target, int index) { return &m_bumpLights[static_cast<int>(target) * 8 + index]; }
+    CBumpLight* GetBumpLight(CLightPcs::TARGET target, int index) { return &m_bumpLights[target][index]; }
 
     Mtx m_bumpTexMtx0;               // 0x04
     Mtx m_bumpTexMtx1;               // 0x34
@@ -112,7 +112,7 @@ public:
     u32 m_sceneLightCount;           // 0xB8
     CLight m_diffuseLights[8];       // 0xBC
     CLight m_sceneLights[0x20];      // 0x63C
-    CBumpLight m_bumpLights[0x20];   // 0x1C3C
+    CBumpLight m_bumpLights[4][8];   // 0x1C3C
     _GXColor m_mapLightColor[4];     // 0x433C
     float m_mapLightParams[9];       // 0x434C
     GXLightObj m_mapLightObj;        // 0x4370

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -126,7 +126,8 @@ inline void CLightPcs::CLight::Set(CLightPcs::CLight* light)
     if (m_range < kLightZero) {
         m_range = -m_range;
     }
-    m_range = m_range * kLightHalf * m_radius;
+    float range = m_range * kLightHalf;
+    m_range = range * m_radius;
 
     m_targetEnable[3] = 1;
     m_targetEnable[2] = 1;
@@ -387,11 +388,9 @@ CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs
  */
 inline CLightPcs::CBumpLight* CLightPcs::GetFreeBumpLight(CLightPcs::TARGET target)
 {
-    CBumpLight* bumpLights = m_bumpLights[target];
-
     for (int i = 0; i < 8; i++) {
-        if (bumpLights[i].m_hasTexture == 0) {
-            return &bumpLights[i];
+        if (m_bumpLights[target][i].m_hasTexture == 0) {
+            return &m_bumpLights[target][i];
         }
     }
 

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -328,7 +328,8 @@ void CLightPcs::draw()
 void CLightPcs::Add(CLightPcs::CLight* light)
 {
     CLight sceneLight;
-    sceneLight.Set(light);
+    CLight* sp = &sceneLight;
+    sp->Set(light);
 
     u32 idx = m_sceneLightCount;
     m_sceneLightCount = idx + 1;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -352,7 +352,7 @@ CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs
     CBumpLight* bumpLight = GetFreeBumpLight(target);
 
     if (bumpLight == 0) {
-        if (static_cast<int>(System.m_execParam) >= 1) {
+        if (static_cast<u32>(System.m_execParam) >= 1) {
             System.Printf(const_cast<char*>(sLightTextureFullMsg));
         }
         return 0;
@@ -1167,9 +1167,9 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
     nrm[0][2] = out[0][2];
     nrm[1][2] = out[1][2];
     nrm[2][2] = out[2][2];
-    nrm[0][3] = kLightZero;
-    nrm[1][3] = kLightZero;
-    nrm[2][3] = kLightZero;
+    nrm[0][3] = 0.0f;
+    nrm[1][3] = 0.0f;
+    nrm[2][3] = 0.0f;
     GXLoadNrmMtxImm(nrm, 0);
 
     if ((bump != nullptr) && (bump->m_hasTexture != 0)) {

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -210,8 +210,8 @@ int CLightPcs::GetTable(unsigned long index)
 void CLightPcs::create()
 {
     for (int i = 0; i < 0x20; i++) {
-        m_bumpLights[i].m_hasTexture = 0;
-        m_bumpLights[i].m_textureData = 0;
+        m_bumpLights[0][i].m_hasTexture = 0;
+        m_bumpLights[0][i].m_textureData = 0;
     }
 }
 
@@ -241,18 +241,16 @@ void CLightPcs::destroy()
  */
 void CLightPcs::DestroyBumpLightAll(CLightPcs::TARGET target)
 {
-    u32 idx = static_cast<u32>(target) * 8;
-
-    for (u32 i = 0; i < 8; i++, idx++) {
-        if (m_bumpLights[idx].m_textureData != 0) {
-            bool hasTexture = m_bumpLights[idx].m_textureData != 0;
+    for (u32 i = 0; i < 8; i++) {
+        if (m_bumpLights[target][i].m_textureData != 0) {
+            bool hasTexture = m_bumpLights[target][i].m_textureData != 0;
             if (hasTexture) {
-                Memory.Free(m_bumpLights[idx].m_textureData);
-                m_bumpLights[idx].m_textureData = 0;
+                Memory.Free(m_bumpLights[target][i].m_textureData);
+                m_bumpLights[target][i].m_textureData = 0;
             }
 
-            m_bumpLights[idx].m_hasTexture = 0;
-            m_bumpLights[idx].m_useViewSpace = 0;
+            m_bumpLights[target][i].m_hasTexture = 0;
+            m_bumpLights[target][i].m_useViewSpace = 0;
         }
     }
 }
@@ -389,7 +387,7 @@ CLightPcs::CBumpLight* CLightPcs::AddBump(CLightPcs::CLight* srcLight, CLightPcs
  */
 inline CLightPcs::CBumpLight* CLightPcs::GetFreeBumpLight(CLightPcs::TARGET target)
 {
-    CBumpLight* bumpLights = &m_bumpLights[target * 8];
+    CBumpLight* bumpLights = m_bumpLights[target];
 
     for (int i = 0; i < 8; i++) {
         if (bumpLights[i].m_hasTexture == 0) {
@@ -1052,13 +1050,11 @@ void CLightPcs::MakeLightMap()
 
     for (u32 target = 0; target < 4; target++) {
         u32 i = 0;
-        CBumpLight* bumpLight = &m_bumpLights[target * 8];
         do {
-            if (bumpLight->m_hasTexture != 0) {
-                bumpLight->MakeLightMap();
+            if (m_bumpLights[target][i].m_hasTexture != 0) {
+                m_bumpLights[target][i].MakeLightMap();
             }
             i++;
-            bumpLight++;
         } while (i < 8);
     }
 

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1197,10 +1197,10 @@ void CLightPcs::SetBumpTexMatirx(float (*mat)[4], CLightPcs::CBumpLight* bump, V
             float* scratch = m_bumpTexScratch;
 
             float mtxScale = kBumpTexMtxScale;
-            float scrollScale = kBumpTexScrollScale;
-            float zero = kLightZero;
-            scratch[0] = kBumpTexScrollScale;
             float half = kLightHalf;
+            float zero = kLightZero;
+            float scrollScale = kBumpTexScrollScale;
+            scratch[0] = scrollScale;
             scratch[6] = scrollScale;
             scratch[10] = zero;
             scratch[5] = zero;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -953,11 +953,14 @@ void CLightPcs::CBumpLight::MakeLightMap()
             GXBegin((GXPrimitive)0x98, (GXVtxFmt)0, 0x42);
 
             for (u32 x = 0; x < 0x21; x++) {
-                float x0 = dFactor * (float)y * dScale - dHalf;
+                float t0 = dFactor * (float)y;
+                float x0 = t0 * dScale - dHalf;
                 float xd0 = x0 / dInv;
-                float x1 = dFactor * (float)(y + 1) * dScale - dHalf;
+                float t1 = dFactor * (float)(y + 1);
+                float x1 = t1 * dScale - dHalf;
                 float xd1 = x1 / dInv;
-                float z0 = dFactor * (float)x * dScale - dHalf;
+                float tz = dFactor * (float)x;
+                float z0 = tz * dScale - dHalf;
                 float zd = z0 / dInv;
                 float dist0 = z0 * z0 + x0 * x0;
                 if (dist0 < dHalf) {

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -923,11 +923,9 @@ void CLightPcs::CBumpLight::MakeLightMap()
     float dScale = kBumpLightMapGridStep;
     float dHalf = kLightOne;
     static float tParam[4] = {48.0f, 128.0f, 256.0f, 512.0f};
+    int offset = 0;
     float* lightScale = tParam;
     float dFactor = kBumpLightMapCoordScale;
-    float dInv = kBumpLightNormalDivisor;
-    int offset = 0;
-    float dW = kBumpLightMapVertexZ;
 
     for (int i = 0; i < (int)(unsigned int)m_textureCount; i++) {
         u8* texDst = m_textureData + offset;
@@ -948,6 +946,8 @@ void CLightPcs::CBumpLight::MakeLightMap()
 
         GXLoadLightObjImm(&lightObj, (GXLightID)1);
 
+        float dInv = kBumpLightNormalDivisor;
+        float dW = kBumpLightMapVertexZ;
         u32 y = 0;
         do {
             GXBegin((GXPrimitive)0x98, (GXVtxFmt)0, 0x42);

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -241,19 +241,18 @@ void CLightPcs::destroy()
  */
 void CLightPcs::DestroyBumpLightAll(CLightPcs::TARGET target)
 {
-    CBumpLight* bumpLights = m_bumpLights;
-    CBumpLight* light = &bumpLights[static_cast<int>(target) * 8];
+    u32 idx = static_cast<u32>(target) * 8;
 
-    for (u32 i = 0; i < 8; i++) {
-        if (light[i].m_textureData != 0) {
-            bool hasTexture = light[i].m_textureData != 0;
+    for (u32 i = 0; i < 8; i++, idx++) {
+        if (m_bumpLights[idx].m_textureData != 0) {
+            bool hasTexture = m_bumpLights[idx].m_textureData != 0;
             if (hasTexture) {
-                Memory.Free(light[i].m_textureData);
-                light[i].m_textureData = 0;
+                Memory.Free(m_bumpLights[idx].m_textureData);
+                m_bumpLights[idx].m_textureData = 0;
             }
 
-            light[i].m_hasTexture = 0;
-            light[i].m_useViewSpace = 0;
+            m_bumpLights[idx].m_hasTexture = 0;
+            m_bumpLights[idx].m_useViewSpace = 0;
         }
     }
 }

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -930,7 +930,7 @@ void CLightPcs::CBumpLight::MakeLightMap()
     float dW = kBumpLightMapVertexZ;
 
     for (int i = 0; i < (int)(unsigned int)m_textureCount; i++) {
-        int texBase = (int)m_textureData;
+        u8* texDst = m_textureData + offset;
         GXLightObj lightObj;
         GXInitSpecularDir(&lightObj, eyeDir.x, eyeDir.y, eyeDir.z);
 
@@ -948,22 +948,20 @@ void CLightPcs::CBumpLight::MakeLightMap()
 
         GXLoadLightObjImm(&lightObj, (GXLightID)1);
 
-        int y = 0;
+        u32 y = 0;
         do {
-            unsigned int yBase = y;
             GXBegin((GXPrimitive)0x98, (GXVtxFmt)0, 0x42);
 
-            float x0 = dFactor * (float)yBase * dScale - dHalf;
-            float dx0 = x0;
-            float x1 = dFactor * (float)(yBase + 1) * dScale - dHalf;
-            float dx1 = x1;
+            float x0 = dFactor * (float)y * dScale - dHalf;
+            float xd0 = x0 / dInv;
+            float x1 = dFactor * (float)(y + 1) * dScale - dHalf;
+            float xd1 = x1 / dInv;
 
-            int inner = 0x21;
-            unsigned int x = 0;
-            do {
+            for (u32 x = 0; x < 0x21; x++) {
                 float z0 = dFactor * (float)x * dScale - dHalf;
-                float dz0 = z0;
-                float dist0 = dx0 * dx0 + dz0 * dz0;
+                float zd = z0 / dInv;
+                float zSq = z0 * z0;
+                float dist0 = x0 * x0 + zSq;
                 if (dist0 < dHalf) {
                     dist0 = sqrtf(dHalf - dist0);
                 } else {
@@ -971,11 +969,11 @@ void CLightPcs::CBumpLight::MakeLightMap()
                 }
 
                 GXWGFifo.f32 = x0;
-                float dist1 = dx1 * dx1 + dz0 * dz0;
+                float dist1 = x1 * x1 + zSq;
                 GXWGFifo.f32 = z0;
                 GXWGFifo.f32 = dW;
-                GXWGFifo.f32 = dx0 / dInv;
-                GXWGFifo.f32 = dz0 / dInv;
+                GXWGFifo.f32 = xd0;
+                GXWGFifo.f32 = zd;
                 GXWGFifo.f32 = dist0;
 
                 if (dist1 < dHalf) {
@@ -987,20 +985,17 @@ void CLightPcs::CBumpLight::MakeLightMap()
                 GXWGFifo.f32 = x1;
                 GXWGFifo.f32 = z0;
                 GXWGFifo.f32 = dW;
-                GXWGFifo.f32 = dx1 / dInv;
-                GXWGFifo.f32 = dz0 / dInv;
+                GXWGFifo.f32 = xd1;
+                GXWGFifo.f32 = zd;
                 GXWGFifo.f32 = dist1;
+            }
 
-                inner--;
-                x++;
-            } while (inner != 0);
-
-            y = yBase + 1;
+            y++;
         } while (y < 0x20);
 
         GXSetTexCopySrc(0, 0, 0x40, 0x40);
         GXSetTexCopyDst((unsigned short)0x40, (unsigned short)0x40, (GXTexFmt)3, (unsigned char)0);
-        GXCopyTex(reinterpret_cast<void*>(texBase + offset), 1);
+        GXCopyTex(texDst, 1);
         GXPixModeSync();
 
         offset += copySize;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -952,16 +952,14 @@ void CLightPcs::CBumpLight::MakeLightMap()
         do {
             GXBegin((GXPrimitive)0x98, (GXVtxFmt)0, 0x42);
 
-            float x0 = dFactor * (float)y * dScale - dHalf;
-            float xd0 = x0 / dInv;
-            float x1 = dFactor * (float)(y + 1) * dScale - dHalf;
-            float xd1 = x1 / dInv;
-
             for (u32 x = 0; x < 0x21; x++) {
+                float x0 = dFactor * (float)y * dScale - dHalf;
+                float xd0 = x0 / dInv;
+                float x1 = dFactor * (float)(y + 1) * dScale - dHalf;
+                float xd1 = x1 / dInv;
                 float z0 = dFactor * (float)x * dScale - dHalf;
                 float zd = z0 / dInv;
-                float zSq = z0 * z0;
-                float dist0 = x0 * x0 + zSq;
+                float dist0 = z0 * z0 + x0 * x0;
                 if (dist0 < dHalf) {
                     dist0 = sqrtf(dHalf - dist0);
                 } else {
@@ -969,7 +967,7 @@ void CLightPcs::CBumpLight::MakeLightMap()
                 }
 
                 GXWGFifo.f32 = x0;
-                float dist1 = x1 * x1 + zSq;
+                float dist1 = z0 * z0 + x1 * x1;
                 GXWGFifo.f32 = z0;
                 GXWGFifo.f32 = dW;
                 GXWGFifo.f32 = xd0;

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -921,12 +921,9 @@ void CLightPcs::CBumpLight::MakeLightMap()
     }
 
     int copySize = GXGetTexBufferSize(0x40, 0x40, 3, 0, 0);
-    float dScale = kBumpLightMapGridStep;
-    float dHalf = kLightOne;
     static float tParam[4] = {48.0f, 128.0f, 256.0f, 512.0f};
     int offset = 0;
     float* lightScale = tParam;
-    float dFactor = kBumpLightMapCoordScale;
 
     for (int i = 0; i < (int)(unsigned int)m_textureCount; i++) {
         u8* texDst = m_textureData + offset;
@@ -947,14 +944,18 @@ void CLightPcs::CBumpLight::MakeLightMap()
 
         GXLoadLightObjImm(&lightObj, (GXLightID)1);
 
-        float dInv = kBumpLightNormalDivisor;
         float dW = kBumpLightMapVertexZ;
+        float dInv = kBumpLightNormalDivisor;
         u32 y = 0;
         do {
             GXBegin((GXPrimitive)0x98, (GXVtxFmt)0, 0x42);
 
+            float fy = (float)y;
+            float dFactor = kBumpLightMapCoordScale;
+            float dHalf = kLightOne;
+            float dScale = kBumpLightMapGridStep;
             for (u32 x = 0; x < 0x21; x++) {
-                float t0 = dFactor * (float)y;
+                float t0 = dFactor * fy;
                 float x0 = t0 * dScale - dHalf;
                 float xd0 = x0 / dInv;
                 float t1 = dFactor * (float)(y + 1);

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -226,33 +226,8 @@ void CLightPcs::create()
  */
 void CLightPcs::destroy()
 {
-    u32 i = 0;
-    do {
-        if (m_bumpLights[i + 8].m_textureData != 0) {
-            bool hasTexture = m_bumpLights[i + 8].m_textureData != 0;
-            if (hasTexture) {
-                Memory.Free(m_bumpLights[i + 8].m_textureData);
-                m_bumpLights[i + 8].m_textureData = 0;
-            }
-            m_bumpLights[i + 8].m_hasTexture = 0;
-            m_bumpLights[i + 8].m_useViewSpace = 0;
-        }
-        i++;
-    } while (i < 8);
-
-    i = 0;
-    do {
-        if (m_bumpLights[i].m_textureData != 0) {
-            bool hasTexture = m_bumpLights[i].m_textureData != 0;
-            if (hasTexture) {
-                Memory.Free(m_bumpLights[i].m_textureData);
-                m_bumpLights[i].m_textureData = 0;
-            }
-            m_bumpLights[i].m_hasTexture = 0;
-            m_bumpLights[i].m_useViewSpace = 0;
-        }
-        i++;
-    } while (i < 8);
+    DestroyBumpLightAll(static_cast<TARGET>(1));
+    DestroyBumpLightAll(static_cast<TARGET>(0));
 }
 
 /*


### PR DESCRIPTION
Raises main/p_light from 96.82% to **98.82%** (+2.00). Matched functions 18 → 22 of 28.

## Key changes
- **`m_bumpLights` is really `CBumpLight[4][8]`** (4 TARGETs x 8 lights, identical layout): the 2D declaration makes mwcc fold the array base + row offset into load displacements with this-rebased cursors, taking `destroy`, `DestroyBumpLightAll`, and `CLightPcs::MakeLightMap` to **100%** in one stroke, and fixing the GetFreeBumpLight inline shape in `AddBump`.
- **`destroy` = two inlined `DestroyBumpLightAll` calls** (TARGET 1 then 0) — reproduces the saved `this` in r25, per-loop cursor copies, and the three distinct zero registers per loop. 84.6 → 100.
- **`Add` 94.9 → 100**: binding the scene-light temp through an escaped pointer (`CLight* sp = &sceneLight; sp->Set(light);`) produces the original's +1 callee-saved window (stmw r20) and the exact copy-phase split.
- **`CBumpLight::MakeLightMap` 93.1 → 97.9**: per-vertex x0/x1 computation (LICM-hoists to the target's position), precomputed divides, inline squares for the fmadds fusion, CTR inner loop, u32 y, hoisted `texDst = m_textureData + offset`, and dW/dInv/coord-scale declaration placement matching the target's FPR ranks.
- Smaller wins: `Set` m_range multiply split, unsigned `m_execParam` compare, `GXLoadNrmMtxImm` zero literals, SetBumpTexMatirx scratch-constant decl order.

## Evidence
- objdiff report.json fuzzy_match_percent: 96.82 → 98.82; matched_code 31.6% → 52.6%.
- Remaining gaps: `__sinit` (known data-anchoring wall) and single-register tie-break residue in MakeLightMap/ctor/AddBump.

The 2D array, the destroy-delegates-to-DestroyBumpLightAll structure, and the per-vertex math read as natural original source, not coaxing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)