### PR TITLE
fontman: raise fuzzy match to 98.71% (cycle 6)

### DIFF
--- a/include/ffcc/fontman.h
+++ b/include/ffcc/fontman.h
@@ -8,6 +8,7 @@
 #include <dolphin/gx.h>
 
 class CFont;
+struct CFontGlyphEntry;
 
 class CFontMan : public CManager
 {
@@ -60,7 +61,7 @@ public:
 	float GetWidth(const char* text) { return GetWidth(const_cast<char*>(text)); }
 	float GetWidth(unsigned short);
 
-	void searchChar(unsigned short);
+	CFontGlyphEntry* searchChar(unsigned short);
 	void getNextChar(char**, unsigned short*);
 
 	unsigned short m_glyphWidth;

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -74,15 +74,16 @@ static inline float LoadFloat(const float& value)
 float CFont::GetWidth(unsigned short ch)
 {
 	unsigned short* glyphBucket = m_glyphBuckets[ch & 0xFF];
-	CFontGlyphEntry* glyph = FirstGlyph(glyphBucket);
+	CFontGlyphEntry* entry = FirstGlyph(glyphBucket);
 	int count = static_cast<int>(*glyphBucket);
+	CFontGlyphEntry* glyph;
 
 	for (; count > 0; count--) {
-		if (static_cast<unsigned int>(glyph->m_codeHigh) != ((ch >> 8) & 0xFF)) {
-			glyph++;
-		} else {
+		if (static_cast<unsigned int>(entry->m_codeHigh) == ((ch >> 8) & 0xFF)) {
+			glyph = entry;
 			goto found_glyph;
 		}
+		entry++;
 	}
 	glyph = 0;
 
@@ -120,15 +121,14 @@ find_fallback:
 	glyphBucket = m_glyphBuckets[63];
 	CFontGlyphEntry* fallbackGlyph = FirstGlyph(glyphBucket);
 	for (count = static_cast<int>(*glyphBucket); count > 0; count--) {
-		if (static_cast<unsigned int>(fallbackGlyph->m_codeHigh) != 0) {
-			fallbackGlyph++;
-		} else {
+		if (static_cast<unsigned int>(fallbackGlyph->m_codeHigh) == 0) {
+			glyph = fallbackGlyph;
 			goto found_fallback_glyph;
 		}
+		fallbackGlyph++;
 	}
-	fallbackGlyph = 0;
+	glyph = 0;
 found_fallback_glyph:
-	glyph = fallbackGlyph;
 	if (glyph != 0) {
 		goto found_fallback;
 	}
@@ -160,11 +160,10 @@ float CFont::GetWidth(char* text)
 		float charWidth;
 
 		for (; count > 0; count--) {
-			if (static_cast<unsigned int>(glyph->m_codeHigh) != ((ch >> 8) & 0xFF)) {
-				glyph++;
-			} else {
+			if (static_cast<unsigned int>(glyph->m_codeHigh) == ((ch >> 8) & 0xFF)) {
 				goto found_glyph;
 			}
+			glyph++;
 		}
 		glyph = 0;
 
@@ -201,11 +200,10 @@ find_fallback:
 		CFontGlyphEntry* fallbackGlyph = FirstGlyph(glyphBucket);
 		count = static_cast<int>(*glyphBucket);
 		for (; count > 0; count--) {
-			if (fallbackGlyph->m_codeHigh != 0) {
-				fallbackGlyph++;
-			} else {
+			if (fallbackGlyph->m_codeHigh == 0) {
 				goto use_fallback_glyph;
 			}
+			fallbackGlyph++;
 		}
 		fallbackGlyph = 0;
 use_fallback_glyph:
@@ -248,11 +246,10 @@ void CFont::Draw(unsigned short ch)
 	int count = static_cast<int>(*glyphBucket);
 
 	for (; count > 0; count--) {
-		if (static_cast<unsigned int>(glyph->m_codeHigh) != ((ch >> 8) & 0xFF)) {
-			glyph++;
-		} else {
+		if (static_cast<unsigned int>(glyph->m_codeHigh) == ((ch >> 8) & 0xFF)) {
 			goto found_glyph;
 		}
+		glyph++;
 	}
 	glyph = 0;
 
@@ -262,11 +259,10 @@ found_glyph:
 		unsigned short* glyphBucket = m_glyphBuckets[63];
 		glyph = FirstGlyph(glyphBucket);
 		for (count = static_cast<int>(*glyphBucket); count > 0; count--) {
-			if (static_cast<unsigned int>(glyph->m_codeHigh) != 0) {
-				glyph++;
-			} else {
+			if (static_cast<unsigned int>(glyph->m_codeHigh) == 0) {
 				goto found_fallback;
 			}
+			glyph++;
 		}
 		glyph = 0;
 

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -147,20 +147,9 @@ float CFont::GetWidth(char* text)
 	goto read_char;
 
 	while (hasChar != 0) {
-		unsigned short* currentBucket = m_glyphBuckets[ch & 0xFF];
-		CFontGlyphEntry* glyph = FirstGlyph(currentBucket);
-		int count = static_cast<int>(*currentBucket);
+		CFontGlyphEntry* glyph = searchChar(ch);
 		float charWidth;
 
-		for (; count > 0; count--) {
-			if (static_cast<unsigned int>(glyph->m_codeHigh) == ((ch >> 8) & 0xFF)) {
-				goto found_glyph;
-			}
-			glyph++;
-		}
-		glyph = 0;
-
-found_glyph:
 		if (glyph == 0) {
 			goto find_fallback;
 		}
@@ -189,18 +178,7 @@ use_glyph:
 		goto add_width;
 
 find_fallback:
-		unsigned short* glyphBucket = m_glyphBuckets[63];
-		CFontGlyphEntry* fallbackGlyph = FirstGlyph(glyphBucket);
-		count = static_cast<int>(*glyphBucket);
-		for (; count > 0; count--) {
-			if (fallbackGlyph->m_codeHigh == 0) {
-				goto use_fallback_glyph;
-			}
-			fallbackGlyph++;
-		}
-		fallbackGlyph = 0;
-use_fallback_glyph:
-		glyph = fallbackGlyph;
+		glyph = searchChar('?');
 		if (glyph != 0) {
 			goto use_glyph;
 		}
@@ -234,33 +212,9 @@ read_char:
  */
 void CFont::Draw(unsigned short ch)
 {
-	unsigned short* glyphBucket = m_glyphBuckets[ch & 0xFF];
-	CFontGlyphEntry* glyph = FirstGlyph(glyphBucket);
-	int count = static_cast<int>(*glyphBucket);
-
-	for (; count > 0; count--) {
-		if (static_cast<unsigned int>(glyph->m_codeHigh) == ((ch >> 8) & 0xFF)) {
-			goto found_glyph;
-		}
-		glyph++;
-	}
-	glyph = 0;
-
-found_glyph:
-	CFontGlyphEntry* drawGlyph = glyph;
-	if (glyph == 0) {
-		unsigned short* glyphBucket = m_glyphBuckets[63];
-		glyph = FirstGlyph(glyphBucket);
-		for (count = static_cast<int>(*glyphBucket); count > 0; count--) {
-			if (static_cast<unsigned int>(glyph->m_codeHigh) == 0) {
-				goto found_fallback;
-			}
-			glyph++;
-		}
-		glyph = 0;
-
-found_fallback:
-		drawGlyph = glyph;
+	CFontGlyphEntry* drawGlyph = searchChar(ch);
+	if (drawGlyph == 0) {
+		drawGlyph = searchChar('?');
 		if (drawGlyph == 0) {
 			return;
 		}

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -257,11 +257,11 @@ void CFont::Draw(unsigned short ch)
 		y0 = FloorF(y0);
 	}
 
-	float advance = scaleX * (margin + static_cast<float>(drawWidth));
 	float u1 = u0 + static_cast<float>(drawWidth * 2);
 	float v1 = v0 + static_cast<float>(m_glyphHeight * 2);
 	float x1 = x0 + static_cast<float>(drawWidth) * scaleX;
 	float y1 = y0 + static_cast<float>(m_glyphHeight) * scaleY;
+	float advance = scaleX * (static_cast<float>(drawWidth) + margin);
 
 	if (renderFlagBits.snapPosition != 0) {
 		advance = FloorF(advance);

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -224,8 +224,8 @@ void CFont::Draw(unsigned short ch)
 	CFontRenderFlagBits& renderFlagBits = GetRenderFlagBits(renderFlags);
 	signed char sign = static_cast<signed char>(renderFlagBits.shadow);
 	int drawWidth;
-	int glyphOffset = (static_cast<unsigned int>(-static_cast<int>(sign) | static_cast<int>(sign)) >> 30 & 2) + 3;
-	unsigned char* glyphInfo = reinterpret_cast<unsigned char*>(drawGlyph) + glyphOffset;
+	unsigned int glyphOffset = static_cast<unsigned int>(-static_cast<int>(sign) | static_cast<int>(sign)) >> 30 & 2;
+	unsigned char* glyphInfo = reinterpret_cast<unsigned char*>(drawGlyph) + glyphOffset + 3;
 	int glyphIndex;
 	int row;
 	float u0;
@@ -241,7 +241,7 @@ void CFont::Draw(unsigned short ch)
 		drawWidth = static_cast<int>(m_glyphWidth);
 		glyphIndex = static_cast<int>(drawGlyph->m_textureIndex);
 		row = glyphIndex / m_glyphColumns;
-		u0 = static_cast<float>(drawWidth * (glyphIndex - row * m_glyphColumns) * 2);
+		u0 = static_cast<float>(m_glyphWidth * (glyphIndex - row * m_glyphColumns) * 2);
 		v0 = static_cast<float>(m_glyphHeight * row * 2);
 	}
 

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -665,34 +665,32 @@ void CFont::Create(void* filePtr, CMemory::CStage* stage)
                         chunkFile.Get(m_glyphData, chunk.m_size);
                     }
 
-                    unsigned short** glyphBucket = m_glyphBuckets;
                     unsigned short* bucket = static_cast<unsigned short*>(m_glyphData);
-                    for (int i = 0; i < 32; i++) {
-                        glyphBucket[0] = bucket;
+                    for (int i = 0; i < 256; i += 8) {
+                        m_glyphBuckets[i + 0] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[1] = bucket;
+                        m_glyphBuckets[i + 1] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[2] = bucket;
+                        m_glyphBuckets[i + 2] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[3] = bucket;
+                        m_glyphBuckets[i + 3] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[4] = bucket;
+                        m_glyphBuckets[i + 4] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[5] = bucket;
+                        m_glyphBuckets[i + 5] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[6] = bucket;
+                        m_glyphBuckets[i + 6] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket[7] = bucket;
+                        m_glyphBuckets[i + 7] = bucket;
                         bucket = bucket + static_cast<unsigned int>(*bucket) * 4;
                         bucket++;
-                        glyphBucket += 8;
                     }
                     break;
                 case 'TXTR':

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -24,17 +24,6 @@ static const char sFontManClassName[] = "CFontMan";
 
 CFontMan FontMan;
 
-namespace {
-struct CFontRenderFlagBits
-{
-	signed char shadow : 1;
-	signed char zCompare : 1;
-	signed char zUpdate : 1;
-	signed char fixedWidth : 1;
-	signed char snapPosition : 1;
-	signed char pad : 3;
-};
-
 struct CFontGlyphEntry
 {
 	u16 m_textureIndex;
@@ -44,6 +33,17 @@ struct CFontGlyphEntry
 	u8 m_shadowLeft;
 	u8 m_shadowWidth;
 	u8 m_pad;
+};
+
+namespace {
+struct CFontRenderFlagBits
+{
+	signed char shadow : 1;
+	signed char zCompare : 1;
+	signed char zUpdate : 1;
+	signed char fixedWidth : 1;
+	signed char snapPosition : 1;
+	signed char pad : 3;
 };
 
 inline CFontRenderFlagBits& GetRenderFlagBits(unsigned char& flags)
@@ -62,6 +62,22 @@ static inline float LoadFloat(const float& value)
 }
 }
 
+inline CFontGlyphEntry* CFont::searchChar(unsigned short ch)
+{
+	unsigned short* glyphBucket = m_glyphBuckets[ch & 0xFF];
+	CFontGlyphEntry* glyph = FirstGlyph(glyphBucket);
+	int count = static_cast<int>(*glyphBucket);
+	unsigned int code = (ch >> 8) & 0xFF;
+
+	for (; count > 0; count--) {
+		if (static_cast<unsigned int>(glyph->m_codeHigh) == code) {
+			return glyph;
+		}
+		glyph++;
+	}
+	return 0;
+}
+
 /*
  * --INFO--
  * PAL Address: 0x80091e58
@@ -73,21 +89,8 @@ static inline float LoadFloat(const float& value)
  */
 float CFont::GetWidth(unsigned short ch)
 {
-	unsigned short* glyphBucket = m_glyphBuckets[ch & 0xFF];
-	CFontGlyphEntry* entry = FirstGlyph(glyphBucket);
-	int count = static_cast<int>(*glyphBucket);
-	CFontGlyphEntry* glyph;
+	CFontGlyphEntry* glyph = searchChar(ch);
 
-	for (; count > 0; count--) {
-		if (static_cast<unsigned int>(entry->m_codeHigh) == ((ch >> 8) & 0xFF)) {
-			glyph = entry;
-			goto found_glyph;
-		}
-		entry++;
-	}
-	glyph = 0;
-
-found_glyph:
 	if (glyph == 0) {
 		goto find_fallback;
 	}
@@ -118,17 +121,7 @@ found_fallback:
 	return width;
 
 find_fallback:
-	glyphBucket = m_glyphBuckets[63];
-	CFontGlyphEntry* fallbackGlyph = FirstGlyph(glyphBucket);
-	for (count = static_cast<int>(*glyphBucket); count > 0; count--) {
-		if (static_cast<unsigned int>(fallbackGlyph->m_codeHigh) == 0) {
-			glyph = fallbackGlyph;
-			goto found_fallback_glyph;
-		}
-		fallbackGlyph++;
-	}
-	glyph = 0;
-found_fallback_glyph:
+	glyph = searchChar('?');
 	if (glyph != 0) {
 		goto found_fallback;
 	}

--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -60,6 +60,11 @@ static inline float LoadFloat(const float& value)
 {
 	return value;
 }
+
+static inline float FloorF(float value)
+{
+	return static_cast<float>(floor(value));
+}
 }
 
 inline CFontGlyphEntry* CFont::searchChar(unsigned short ch)
@@ -226,8 +231,8 @@ void CFont::Draw(unsigned short ch)
 	int drawWidth;
 	unsigned int glyphOffset = static_cast<unsigned int>(-static_cast<int>(sign) | static_cast<int>(sign)) >> 30 & 2;
 	unsigned char* glyphInfo = reinterpret_cast<unsigned char*>(drawGlyph) + glyphOffset + 3;
-	int glyphIndex;
 	int row;
+	int glyphIndex;
 	float u0;
 	float v0;
 
@@ -248,10 +253,8 @@ void CFont::Draw(unsigned short ch)
 	float x0 = posX;
 	float y0 = posY;
 	if (renderFlagBits.snapPosition != 0) {
-		double flooredX = floor(x0);
-		double flooredY = floor(y0);
-		x0 = static_cast<float>(flooredX);
-		y0 = static_cast<float>(flooredY);
+		x0 = FloorF(x0);
+		y0 = FloorF(y0);
 	}
 
 	float advance = scaleX * (margin + static_cast<float>(drawWidth));
@@ -261,8 +264,7 @@ void CFont::Draw(unsigned short ch)
 	float y1 = y0 + static_cast<float>(m_glyphHeight) * scaleY;
 
 	if (renderFlagBits.snapPosition != 0) {
-		double flooredAdvance = floor(advance);
-		advance = static_cast<float>(flooredAdvance);
+		advance = FloorF(advance);
 	}
 	posX += advance;
 


### PR DESCRIPTION
Raises main/fontman from 97.62% to 98.71% (+1.09).

## Per-function gains
- **Create** 99.58 -> **100%**: the m_glyphBuckets table fill is an indexed loop (`m_glyphBuckets[i + k]`, `i += 8` over 256) that mwcc strength-reduces to a `this`-relative cursor with 0x3c..0x58 displacements — not a pointer cursor.
- **GetWidth(Us)** 97.04 -> **99.93%**: reconstructed the inlined `CFont::searchChar(unsigned short)` helper (declared in fontman.h but previously undefined). Its early `return glyph;` emits the target's unfolded `bne+b` loop-exit pair (R40 return junction), and `searchChar('?')` reproduces the folded bucket-63/code-0 fallback. Loop-invariant `code` local declared after `count` fixes the volatile coloring.
- **Draw(Us)** 93.54 -> **96.48%**: named `glyphOffset` (without +3) + `base + glyphOffset + 3` materializes the target's `addi r30,r3,3`; fixedWidth arm recomputes u0 from `m_glyphWidth` (recovers `mr r31,r7`); `FloorF` inline wrapper (`(float)floor(v)`) reproduces the `frsp f0,f1; fmr` snap junctions; `advance` computed last with `(float)drawWidth + margin` order fixes the entire magic-double conversion slot layout (0x28/0x10/0x8/0x18/0x20).
- **GetWidth(Pc)** 93.66 -> **95.89%**: searchChar conversion fixed branch polarity in both loops.

## Remaining walls
- GetWidth(Pc): inner CTR loop keeps a redundant `subi` IV decrement when the helper inlines inside the outer string loop (count colors r3 vs target r0, shifting the volatile window); resisted do/while, goto-built outer loop, free-function helper, getNextChar reconstruction, register hints.
- Draw divw block: row/cols/width temp register rotation (row wants the lowest volatile); resisted decl orders, %-form, dropping the glyphIndex local.
- SetColor (89.7): 2-register software-pipelined byte interleave with the first load scheduled into the prologue; all interleave/named-temp source forms scored worse.
- kFont*IntToDoubleBias reloc-name lines: confirmed R46-caveat wall (compiler-generated conversion biases do not unify with named extern consts; object carries anonymous @269/@407 duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)