### PR TITLE
graphic: raise fuzzy match to 97.03% (cycle 12)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1350,61 +1350,59 @@ _GXTexObj* CGraphic::GetBackBufferRect(int& x, int& y, int& width, int& height, 
         height += 1;
     }
 
-    if ((xEnd >= 0) && (yEnd >= 0)) {
-        GXRenderModeObj* renderMode = m_renderMode;
-        int efbWidth = static_cast<int>(renderMode->fbWidth);
-
-        if ((x <= efbWidth) && (yEnd >= 0) && (y <= static_cast<int>(renderMode->efbHeight)) &&
-            (width > 0) && (height > 0)) {
-            if (xEnd > efbWidth) {
-                width -= (xEnd - efbWidth);
-                xEnd = static_cast<int>(m_renderMode->fbWidth);
-            }
-
-            if (x < 0) {
-                width += x;
-                x = 0;
-            }
-
-            if (y < 0) {
-                height += y;
-                y = 0;
-            }
-
-            int efbHeight = static_cast<int>(m_renderMode->efbHeight);
-            if (yEnd > efbHeight) {
-                height -= (yEnd - efbHeight);
-                yEnd = static_cast<int>(m_renderMode->efbHeight);
-            }
-
-            if (((xEnd - x) != 0) && ((yEnd - y) != 0)) {
-                int texFormat = 6;
-                int textureSize = width * height * 4;
-                int maxTextureSize =
-                    (((static_cast<int>(m_renderMode->fbWidth) + 0xF) & 0xFFF0) *
-                         static_cast<int>(m_renderMode->efbHeight) * 2) +
-                    0x46000;
-                if (maxTextureSize < textureSize) {
-                    texFormat = 4;
-                    textureSize /= 2;
-                }
-
-                GXSetTexCopySrc(x & 0xFFFF, y & 0xFFFF, width & 0xFFFF, height & 0xFFFF);
-                GXSetTexCopyDst(width & 0xFFFF, height & 0xFFFF, static_cast<_GXTexFmt>(texFormat), GX_FALSE);
-                DCInvalidateRange(m_scratchTextureBuffer, textureSize);
-                GXCopyTex(m_scratchTextureBuffer, doClear);
-                GXPixModeSync();
-                GXInvalidateTexAll();
-                GXInitTexObj(&m_backBufferTexObj, m_scratchTextureBuffer, width & 0xFFFF, height & 0xFFFF,
-                             static_cast<_GXTexFmt>(texFormat), GX_CLAMP, GX_CLAMP, GX_FALSE);
-                GXInitTexObjLOD(&m_backBufferTexObj, GX_LINEAR, GX_LINEAR, kGraphicZeroF, kGraphicZeroF,
-                                kGraphicZeroF, GX_FALSE, GX_FALSE, GX_ANISO_1);
-                return &m_backBufferTexObj;
-            }
-        }
+    if ((xEnd < 0) || (yEnd < 0) || (x > static_cast<int>(m_renderMode->fbWidth)) || (yEnd < 0) ||
+        (y > static_cast<int>(m_renderMode->efbHeight)) || (width <= 0) || (height <= 0)) {
+        return 0;
     }
 
-    return 0;
+    int efbWidth = static_cast<int>(m_renderMode->fbWidth);
+    if (xEnd > efbWidth) {
+        width -= (xEnd - efbWidth);
+        xEnd = static_cast<int>(m_renderMode->fbWidth);
+    }
+
+    if (x < 0) {
+        width += x;
+        x = 0;
+    }
+
+    if (y < 0) {
+        height += y;
+        y = 0;
+    }
+
+    int efbHeight = static_cast<int>(m_renderMode->efbHeight);
+    if (yEnd > efbHeight) {
+        height -= (yEnd - efbHeight);
+        yEnd = static_cast<int>(m_renderMode->efbHeight);
+    }
+
+    if (((xEnd - x) != 0) && ((yEnd - y) != 0)) {
+        int texFormat = 6;
+        int textureSize = width * height * 4;
+        int maxTextureSize =
+            (((static_cast<int>(m_renderMode->fbWidth) + 0xF) & 0xFFF0) *
+                 static_cast<int>(m_renderMode->efbHeight) * 2) +
+            0x46000;
+        if (maxTextureSize < textureSize) {
+            texFormat = 4;
+            textureSize /= 2;
+        }
+
+        GXSetTexCopySrc(x & 0xFFFF, y & 0xFFFF, width & 0xFFFF, height & 0xFFFF);
+        GXSetTexCopyDst(width & 0xFFFF, height & 0xFFFF, static_cast<_GXTexFmt>(texFormat), GX_FALSE);
+        DCInvalidateRange(m_scratchTextureBuffer, textureSize);
+        GXCopyTex(m_scratchTextureBuffer, doClear);
+        GXPixModeSync();
+        GXInvalidateTexAll();
+        GXInitTexObj(&m_backBufferTexObj, m_scratchTextureBuffer, width & 0xFFFF, height & 0xFFFF,
+                     static_cast<_GXTexFmt>(texFormat), GX_CLAMP, GX_CLAMP, GX_FALSE);
+        GXInitTexObjLOD(&m_backBufferTexObj, GX_LINEAR, GX_LINEAR, kGraphicZeroF, kGraphicZeroF,
+                        kGraphicZeroF, GX_FALSE, GX_FALSE, GX_ANISO_1);
+    } else {
+        return 0;
+    }
+    return &m_backBufferTexObj;
 }
 
 /*

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1419,9 +1419,17 @@ void CGraphic::GetBackBufferRect2(void* dstBuffer, _GXTexObj* texObj, int x, int
 {
     int xEnd = x + width;
     int yEnd = y + height;
-    if ((xEnd >= 0) && (yEnd >= 0) && (x <= m_renderMode->fbWidth) &&
-        ((yEnd >= 0) && (y <= m_renderMode->efbHeight)) &&
-        ((width > 0) && ((height > 0) && (xEnd != x))) && (yEnd != y)) {
+    if ((xEnd < 0) || (yEnd < 0) || (x > m_renderMode->fbWidth) || (yEnd < 0) || (y > m_renderMode->efbHeight) ||
+        (width <= 0) || (height <= 0)) {
+        return;
+    }
+    if (xEnd - x == 0) {
+        return;
+    }
+    if (yEnd - y == 0) {
+        return;
+    }
+    {
         void* textureBase;
         int textureSize = GXGetTexBufferSize((u16)width, (u16)height, format, GX_FALSE, GX_FALSE);
         textureBase =

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1088,11 +1088,10 @@ void CGraphic::makeSphere()
         float radius = kGraphicSphereNegativeX * (float)sin(pitch);
 
         for (int seg = 0; seg < 8; seg++) {
-            float yaw = kGraphicSphereSegmentAngle * (float)seg;
             int vertexIndex = vertexCount * 3;
             vertex[0] = x;
-            vertex[1] = radius * (float)sin(yaw);
-            vertices[vertexIndex + 2] = radius * (float)cos(yaw);
+            vertex[1] = radius * (float)sin(kGraphicSphereSegmentAngle * (float)seg);
+            vertices[vertexIndex + 2] = radius * (float)cos(kGraphicSphereSegmentAngle * (float)seg);
             vertex += 3;
             vertexCount++;
         }

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -917,14 +917,12 @@ void CGraphic::DrawDebugStringDirect(unsigned long x, unsigned long y, char* tex
             GXBegin((GXPrimitive)0x80, (GXVtxFmt)0, (u16)((count & 0x3FFF) << 2));
             for (int i = 0; i < count; i++) {
                 int px = x + i * charSize;
-                int glyph = *lineStart - 0x20;
+                int glyph = lineStart[i] - 0x20;
                 int tx = (glyph % 8) * 16;
                 int ty = (glyph / 8) * 16;
 
-                lineStart++;
-
                 GXWGFifo.s16 = px;
-                GXWGFifo.u16 = (s16)y;
+                GXWGFifo.u16 = y;
                 GXWGFifo.s16 = 0;
                 GXWGFifo.s16 = tx;
                 GXWGFifo.s16 = ty;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1488,9 +1488,9 @@ void CGraphic::RenderTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor
 	float z1;
 	float y2;
 	u32 rgba1;
-	u32 rgba4;
-	u32 rgba2;
 	u32 rgba3;
+	u32 rgba2;
+	u32 rgba4;
 
 	x1 = pos1.x;
 	y1 = pos1.y;


### PR DESCRIPTION
Raises main/graphic from 96.89% to 97.03% (+0.15).

Per-function gains:
- GetBackBufferRect 94.41 -> 95.45: early-return || guard chain (reproduces the inline shared return-0 block + unfolded bgt-over-fail on the last test) and if/else return layout (else `return 0` emitted after the then-body, matching the target fail/success block order).
- GetBackBufferRect2 89.63 -> 91.30: same early-return guard restructure with separate `(xEnd - x == 0)` / `(yEnd - y == 0)` subtract-form early returns (subf. codegen).
- DrawDebugStringDirect 96.20 -> 97.60: indexed glyph cursor (`lineStart[i]` instead of an advancing pointer, giving the target volatile-cursor strength reduction) + raw `y` fifo store without the (s16) cast that hoisted a spurious extsh (changes only landed combined; each alone regressed).
- RenderTexQuadGrouad 88.36 -> 88.55: rgba3/rgba4 decl-order swap.
- makeSphere 80.14 -> 80.28: yaw as unnamed CSE expression in sin/cos args (matches target scratch-FPR numbering f26/f25/f24).

Walls hit (resisted R44/R52/R54/R56/R58 levers): the allocator-rotation family (one value at the bottom callee-saved reg with the param band shifted up: wakeup in Thread, textureSize in GetBackBufferRect, dstOffset in GetBackBufferRect2, efbBufferSize in Init, str in DrawDebugStringDirect); the GX FIFO base-register rank (r5 vs r3) in the quad renderers; makeSphere generation-loop dual-cursor/byte-IV shape (all restructures matched the frame but lost net score); RenderDOF stack-slot layout (decl permutations compile identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)