### PR TITLE
game: raise fuzzy match to 99.18% (cycle 12)

### DIFF
--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -166,7 +166,7 @@ public:
     unsigned int m_romLetterWorkBase;       // 0xC5AC
     CGPartyObj* m_partyObjArr[4];           // 0xC5B0
     unsigned int m_scriptFoodBase[4];       // 0xC5C0
-    unsigned int m_scriptWork[8][8][2];     // 0xC5D0
+    unsigned int m_scriptWork[16][4][2];     // 0xC5D0
     unsigned int unk_flat3_0xc7d0;          // 0xC7D0
     unsigned int unk_flat3_count_0xc7d4;    // 0xC7D4
     unsigned int unk_flat3_field_1C_0xc7d8; // 0xC7D8

--- a/include/ffcc/game.h
+++ b/include/ffcc/game.h
@@ -99,7 +99,6 @@ public:
 
 public:
     CGame();
-    ~CGame();
 
     void Init();
     void Quit();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -782,6 +782,8 @@ void CGame::ChangeMap(int mapId, int mapVariant, int param4, int param5)
             param4 != 0 ? 0x580000 : 0,
             loadStep);
 
+        loadStep = param4;
+
         PartPcs.LoadFieldPdt(
             mapId,
             mapVariant,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -200,15 +200,6 @@ inline CGame::CGame()
 
 /*
  * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-CGame::~CGame()
-{
-}
-
-/*
- * --INFO--
  * PAL Address: 0x8001600c
  * PAL Size: 476b
  * EN Address: TODO

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1034,14 +1034,15 @@ void CGame::LoadInit()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGame::LoadScript(char* scriptData)
+static inline void loadPermanentScriptVars(char* scriptData)
 {
     int scriptOffset = 0;
-    int i = 0;
     int entryOffset = 0;
+    int i = 0;
 
     while (i < CFlatPermanentVarCount()) {
-        if ((CFlatPermanentVarFlagByte(entryOffset) & 0x20) != 0) {
+        int flagIndex = entryOffset + 1;
+        if ((CFlatPermanentVarDefs()[flagIndex] & 0x20) != 0) {
             CFlatPermanentVarWord(entryOffset) = *reinterpret_cast<u32*>(scriptData + scriptOffset);
             scriptOffset += 4;
         }
@@ -1049,6 +1050,11 @@ void CGame::LoadScript(char* scriptData)
         entryOffset += 4;
         i++;
     }
+}
+
+void CGame::LoadScript(char* scriptData)
+{
+    loadPermanentScriptVars(scriptData);
 }
 
 /*
@@ -1060,10 +1066,8 @@ void CGame::LoadScript(char* scriptData)
  * JP Address: TODO
  * JP Size: TODO
  */
-void CGame::SaveScript(char* scriptData)
+static inline void savePermanentScriptVars(char* scriptData)
 {
-    memset(scriptData, 0, kGameScriptSaveDataSize);
-
     int scriptOffset = 0;
     int entryOffset = 0;
     int i = 0;
@@ -1077,6 +1081,12 @@ void CGame::SaveScript(char* scriptData)
         entryOffset += 4;
         i++;
     }
+}
+
+void CGame::SaveScript(char* scriptData)
+{
+    memset(scriptData, 0, kGameScriptSaveDataSize);
+    savePermanentScriptVars(scriptData);
 }
 
 /*

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -581,12 +581,12 @@ void CGame::clearWork()
 
     unk_flat3_0xc7d0 = 0;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 8; i++) {
         for (j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
-            m_scriptWork[i + 4][j][0] = 0;
+            m_scriptWork[i + 8][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i + 4][j][1] = 0;
+            m_scriptWork[i + 8][j][1] = 0;
         }
     }
 
@@ -657,12 +657,12 @@ inline void CGame::clearWorkScript()
 
     unk_flat3_0xc7d0 = 0;
 
-    for (int i = 0; i < 4; i++) {
-        for (int j = 0; j < 8; j++) {
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
-            m_scriptWork[i + 4][j][0] = 0;
+            m_scriptWork[i + 8][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i + 4][j][1] = 0;
+            m_scriptWork[i + 8][j][1] = 0;
         }
     }
 
@@ -827,12 +827,12 @@ void CGame::ScriptChanged(char*, int)
 
     unk_flat3_0xc7d0 = 0;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 8; i++) {
         for (j = 0; j < 4; j++) {
             m_scriptWork[i][j][0] = 0;
-            m_scriptWork[i + 4][j][0] = 0;
+            m_scriptWork[i + 8][j][0] = 0;
             m_scriptWork[i][j][1] = 0;
-            m_scriptWork[i + 4][j][1] = 0;
+            m_scriptWork[i + 8][j][1] = 0;
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1069,11 +1069,12 @@ void CGame::LoadScript(char* scriptData)
 static inline void savePermanentScriptVars(char* scriptData)
 {
     int scriptOffset = 0;
-    int entryOffset = 0;
     int i = 0;
+    int entryOffset = 0;
 
     while (i < CFlatPermanentVarCount()) {
-        if ((CFlatPermanentVarFlagByte(entryOffset) & 0x20) != 0) {
+        int flagIndex = entryOffset + 1;
+        if ((CFlatPermanentVarDefs()[flagIndex] & 0x20) != 0) {
             *reinterpret_cast<u32*>(scriptData + scriptOffset) = CFlatPermanentVarWord(entryOffset);
             scriptOffset += 4;
         }

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1567,7 +1567,7 @@ void GbaQueue::LoadEnemyStat()
 				enemyEntry[3] = 0;
 			} else {
 				const int enemyDataBase = Game.unkCFlatData0[1] +
-				    reinterpret_cast<CMonWork*>(Game.m_scriptWork[4][0][i])->m_baseDataIndex * 0x1D0;
+				    reinterpret_cast<CMonWork*>(Game.m_scriptWork[8][0][i])->m_baseDataIndex * 0x1D0;
 				const unsigned int enemyKind = *reinterpret_cast<unsigned short*>(enemyDataBase + 0x10C);
 
 				if (enemyKind == 10) {
@@ -1578,7 +1578,7 @@ void GbaQueue::LoadEnemyStat()
 					enemyEntry[1] = 2;
 				}
 
-				CMonWork* enemyWork = reinterpret_cast<CMonWork*>(Game.m_scriptWork[4][0][i]);
+				CMonWork* enemyWork = reinterpret_cast<CMonWork*>(Game.m_scriptWork[8][0][i]);
 				CGObject* enemyObj = reinterpret_cast<CGObject*>(Game.m_scriptWork[0][0][i]);
 				enemyEntry[3] = static_cast<unsigned char>(enemyWork->m_baseDataIndex);
 				*reinterpret_cast<unsigned short*>(enemyEntry + 4) = enemyWork->m_hp;
@@ -4558,7 +4558,7 @@ int GbaQueue::GetScouterInfo(int channel, unsigned char* outData)
 		for (int i = 0; i < 0x40; i++) {
 			scouterEntry[0] = enemyEntry[0xB37];
 			if (scouterEntry[0] != 0) {
-				CMonWork* enemyWork = reinterpret_cast<CMonWork*>(Game.m_scriptWork[4][0][i]);
+				CMonWork* enemyWork = reinterpret_cast<CMonWork*>(Game.m_scriptWork[8][0][i]);
 				const int enemyDataBase = Game.unkCFlatData0[1] + enemyEntry[0xB37] * 0x1D0;
 
 				work = enemyWork->m_maxHp;
@@ -4743,7 +4743,7 @@ void GbaQueue::SetHitEnemy(int channel, int enemyIdx)
 
 	if (enemyIdx >= 0) {
 		enemyId = static_cast<short>(enemyIdx);
-		enemyType = static_cast<short>(*reinterpret_cast<unsigned short*>(Game.m_scriptWork[4][0][enemyIdx] + 0x1C));
+		enemyType = static_cast<short>(*reinterpret_cast<unsigned short*>(Game.m_scriptWork[8][0][enemyIdx] + 0x1C));
 	} else {
 		enemyType = enemyId = -1;
 	}

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2750,7 +2750,7 @@ void CGObject::SetClassWork(int ownerType, int workIndex)
         m_scriptHandle[3] = this;
         m_scriptHandle[2] = reinterpret_cast<void*>(workIndex);
         Game.m_scriptWork[0][0][workIndex] = reinterpret_cast<u32>(this);
-        Game.m_scriptWork[4][0][workIndex] = reinterpret_cast<u32>(m_scriptHandle);
+        Game.m_scriptWork[8][0][workIndex] = reinterpret_cast<u32>(m_scriptHandle);
         return;
 
     default:


### PR DESCRIPTION
Raises main/game from 98.94% to 99.18% (+0.23).

Per-function gains:
- ScriptChanged 99.96 -> 100% and clearWork 98.37 -> 98.38: m_scriptWork is really [16][4][2] (target's 0x20-stride/ctr-4 clear loop proves half-row rebasing); fixed a real under-clear bug (j<4 cleared only half of each row) and reshaped the array (bank-B refs [4][0] -> [8][0] in gbaque/gobject are offset-identical; all other units byte-identical).
- LoadScript 79.0 -> 85.7 / SaveScript 88.5 -> 96.2: R52 inline-helper wrap of the permanent-var transfer loops + explicit flagIndex temp + per-helper decl order. The remaining advancing-pointer-vs-indexed IV (lwzx r4,r3) resisted ~30 variants (int-domain casts, u32 indexing, volatile, opt_strength_reduction/global_optimizer pragmas, O1-O3, int return) — confirmed tie-break wall.
- ChangeMap 95.3 -> 96.9: loadStep is recomputed per call site (u8 reassignment between the two Load calls) — fixes the whole r28-r31 window rotation and per-site clrlwi. Residual is the or/srawi ternary temp-pair swap (4 sites), a register tie-break.
- CGame::~CGame removed from source (compiler-synthesized; DOL places it after __sinit) — byte-identical output, more faithful source.

Walls hit (documented for future cycles): script-loop pointer-IV folding; or/srawi select temp ordering; clearWork/loadCfd/Calc callee-saved invariant ranking; Exec Printf staging scratch r0-vs-r5; .data vtable emission position (g_CManager/__vt__5CGame before jumptables in target, end-of-TU in ours — drives the 38% .data match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)