### PR TITLE
cmake: raise fuzzy match to 96.81% (cycle 27)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3502,9 +3502,10 @@ void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
         0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
-    int offsU = static_cast<int>(
-        -(static_cast<double>(40.0f * x - 40.0f) * 0.5) + 32.0);
-    float offs = static_cast<float>(offsU);
+    int baseX = ((page == 0) ? 0x116 : 0x116);
+    double offsCalc = -(static_cast<double>(40.0f * x - 40.0f) / 2.0) + 32.0;
+    float offs = static_cast<float>(static_cast<int>(offsCalc));
+    int offsU = static_cast<int>(offsCalc);
     MenuPcs.DrawRect(
         0, 278.0f, offs, 248.0f, 40.0f,
         0.0f, 264.0f, 1.0f, x, 0.0f);
@@ -3515,7 +3516,7 @@ void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x65 : 0x3E));
 
-    float titleX = static_cast<float>(static_cast<int>(static_cast<double>(offsU) + 20.0));
+    float titleX = static_cast<float>(static_cast<int>(baseX + 20.0));
     float titleY = static_cast<float>(static_cast<int>(static_cast<double>(offsU) + 8.0));
     MenuPcs.DrawRect(
         0, titleX, titleY, 208.0f, 24.0f,

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3607,8 +3607,9 @@ void CMenuPcs::DrawDiaryBase(int page, float alpha)
         0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(widePage ? 0x36 : 0x40));
+    int span;
     for (int x = 0x20; x < 0x260;) {
-        int span = 0x20;
+        span = 0x20;
         if ((0x260 - x) < span) {
             span = 0x260 - x;
         }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -863,7 +863,7 @@ void CMenuPcs::CmakeVillageDraw()
 
     DrawInit();
     if (villageWork->m_mode == 1 && villageWork->m_row < 5) {
-        int cursorLeft = 0xC8;
+        int cursorLeft = (villageWork->m_select == 0) ? 0xC8 : 0xC8;
         int wobble = static_cast<int>(System.m_frameCounter) % 8;
         DrawCursor(
             static_cast<int>(26.9f * static_cast<float>(villageWork->m_select) +
@@ -2558,7 +2558,7 @@ void CMenuPcs::CmakeNameDraw()
     DrawInit();
 
     if ((CmakeState(this)->m_mode == 1) && (CmakeState(this)->m_row < 5)) {
-        int cursorLeft = 0xC8;
+        int cursorLeft = (CmakeState(this)->m_select == 0) ? 0xC8 : 0xC8;
         int wobble = static_cast<int>(System.m_frameCounter) % 8;
         DrawCursor(
             static_cast<int>(26.9f * static_cast<float>(CmakeState(this)->m_select) +

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2369,7 +2369,7 @@ void CMenuPcs::CmakeSexDraw()
                                 static_cast<float>(wobble)) -
             maxWidth / 2.0);
         int cursorY = static_cast<int>(156.0f + static_cast<float>(sel * 0x28));
-        DrawCursor(cursorX, cursorY, alpha);
+        DrawCursor(cursorX, cursorY, 1.0f);
     }
 
 }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3078,16 +3078,19 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
 
     const char* yesStr = GetMenuStr(1);
     float yesW = static_cast<float>(font->GetWidth(yesStr));
-    int yesX = static_cast<int>(
-        (48.0f - yesW) / 2.0f + static_cast<float>(0x1D0));
+    int packed = (yesNoSel == 0) ? 0x01D00218 : 0x01D00218;
+    int yesX = packed >> 16;
+    yesX = static_cast<int>(
+        (48.0f - yesW) / 2.0f + static_cast<float>(yesX));
     font->SetPosX(static_cast<float>(yesX));
     font->SetPosY(369.0f);
     font->Draw(yesStr);
 
     const char* noStr = GetMenuStr(2);
     float noW = static_cast<float>(font->GetWidth(noStr));
-    int noX = static_cast<int>(
-        (48.0f - noW) / 2.0f + static_cast<float>(0x218));
+    int noX = packed & 0xFFFF;
+    noX = static_cast<int>(
+        (48.0f - noW) / 2.0f + static_cast<float>(noX));
     font->SetPosX(static_cast<float>(noX));
     font->SetPosY(369.0f);
     font->Draw(noStr);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2287,14 +2287,7 @@ void CMenuPcs::CmakeSexDraw()
     float alpha = CalcCmakeFadeAlpha(this);
     DrawWMFrame0(1, 1.0f);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-    GXColor backdropColor;
-    backdropColor.r = 0xFF;
-    backdropColor.g = 0xFF;
-    backdropColor.b = 0xFF;
-    backdropColor.a = 0xFF;
-    GXSetChanMatColor(GX_COLOR0A0, backdropColor);
+    SetCmakeBlendMatColor(1.0f);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x3F));
     MenuPcs.DrawRect(
         0, 0.0f, 24.0f, 32.0f, 336.0f,
@@ -2303,8 +2296,9 @@ void CMenuPcs::CmakeSexDraw()
         8, 608.0f, 24.0f, 32.0f, 336.0f,
         0.0f, 0.0f, 1.0f, 1.0f, 0.0f);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x40));
+    int span;
     for (int x = 0x20; x < 0x260;) {
-        int span = 0x20;
+        span = 0x20;
         if ((0x260 - x) < span) {
             span = 0x260 - x;
         }
@@ -2316,16 +2310,8 @@ void CMenuPcs::CmakeSexDraw()
 
     DrawCmakePreviewChara(this);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-    GXColor panelColor;
-    panelColor.r = 0xFF;
-    panelColor.g = 0xFF;
-    panelColor.b = 0xFF;
+    SetCmakeBlendMatColor(alpha);
     a255 = 255.0f * alpha;
-    panelColor.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, panelColor);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     float sexW = 256.0f;
     float sexH = 162.4615478515625f;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3516,8 +3516,10 @@ void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
 
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x65 : 0x3E));
 
-    float titleX = static_cast<float>(static_cast<int>(baseX + 20.0));
-    float titleY = static_cast<float>(static_cast<int>(static_cast<double>(offsU) + 8.0));
+    baseX = static_cast<int>(baseX + 20.0);
+    offsU = static_cast<int>(static_cast<double>(offsU) + 8.0);
+    float titleX = static_cast<float>(baseX);
+    float titleY = static_cast<float>(offsU);
     MenuPcs.DrawRect(
         0, titleX, titleY, 208.0f, 24.0f,
         0.0f, static_cast<float>(page * 0x18), 1.0f, 1.0f, 0.0f);


### PR DESCRIPTION
Raises main/cmake from 96.44% to **96.81%** (+0.37).

Per-function gains:
- **DrawCmakeYesNo 90.81 -> 95.09**: the target's `li r27, 0x1D0`/`li r26, 0x218` + runtime magic-double conversions come from frontend-opaque int base coords. A single redundant ternary (two ternaries get re-folded) carrying both bases packed (`0x01D00218`, extracted via `>>16` / `&0xFFFF`) plus self-reassignment (`yesX = (int)((48.0f - w)/2.0f + (float)yesX)`) reproduces the conversion shape and the callee-saved register reuse.
- **DrawCmakeTitle 91.40 -> 96.15**: real coordinate bug — titleX is `278 + 20` (fixed band x), not `offsU + 20`; band x 278 carried as an opaque int (page ternary) in r29; dual `(int)` conversions of the offs double (one for the band y arg, one for offsU); self-reassigned conversion temps match the r28/r29 reuse.
- **CmakeSexDraw 94.61 -> 96.64**: real argument bug — the final `DrawCursor(..., alpha)` is `DrawCursor(..., 1.0f)` in the binary, which lets alpha's FPR die early and removes our extra f26 callee-save (frame 0xE0 -> 0xD0). Also converted open-coded blend/color blocks to the existing `SetCmakeBlendMatColor` helpers and moved the tile-loop `span` decl outside the loop (fixes IV register pairing).
- **DrawDiaryBase 94.03 -> 94.35**: `span` decl outside the tile loop.
- **CmakeVillageDraw 93.84 -> 94.11 / CmakeNameDraw +**: second redundant ternary for `cursorLeft = 0xC8` works when conditioned on a *different* memory load (`m_select`) than the existing `m_row` ternary — two ternaries on the same variable re-fold.

Technique notes (for TECHNIQUE.md): R27 refinement — mwcc's frontend folds a second redundant ternary in the same function unless its condition tests a different freshly-loaded value; a packed-constant single ternary + backend extraction is a reliable fallback for two opaque ints. Self-reassigning the converted int into its base variable reproduces the target's coalesced callee-saved register reuse around int->float->int roundtrips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)