### PR TITLE
p_graphic: raise fuzzy match to 96.8% (cycle 18)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -736,8 +736,8 @@ void CGraphicPcs::drawBar()
         }
 
         order = System.GetNextOrder(order);
-        y += kDebugBarLineStep;
         hue += 0x168;
+        y += kDebugBarLineStep;
     }
 
     GXColor frameTmp;

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -327,28 +327,12 @@ void CGraphicPcs::drawScreenFade()
                 const float sy = kGraphicScreenCenterY - kGraphicScreenCenterY * pos.y;
                 pos.x = sx;
                 pos.y = sy;
-                float clampedX = kGraphicZero;
-                if (!(sx < clampedX)) goto checkMaxX;
-                goto storeX;
-            checkMaxX:
-                clampedX = kGraphicScreenWidth;
-                if (!(clampedX < sx)) goto useX;
-                goto storeX;
-            useX:
-                clampedX = sx;
-            storeX:
+                float clampedX = 0.0f;
+                clampedX = (sx < clampedX) ? clampedX : ((kGraphicScreenWidth < sx) ? kGraphicScreenWidth : sx);
                 pos.x = clampedX;
                 {
-                    float clampedY = kGraphicZero;
-                    if (!(pos.y < clampedY)) goto checkMaxY;
-                    goto storeY;
-                checkMaxY:
-                    clampedY = kGraphicScreenHeight;
-                    if (!(clampedY < pos.y)) goto useY;
-                    goto storeY;
-                useY:
-                    clampedY = pos.y;
-                storeY:
+                    float clampedY = 0.0f;
+                    clampedY = (pos.y < clampedY) ? clampedY : ((kGraphicScreenHeight < pos.y) ? kGraphicScreenHeight : pos.y);
                     pos.y = clampedY;
                 }
 


### PR DESCRIPTION
Raises main/p_graphic from 96.56% to 96.83% (cycle 18).

Per-function gains:
- drawScreenFade: 98.67% -> 99.26%. Rewrote the slot-2 mode-1 screen-coordinate clamps from goto chains to self-then nested ternaries with literal 0.0f inits (R17 wind refinement + R60 literal-vs-named dichotomy). This reproduces the target's unfolded `bge body; b join` clamp pairs and the per-clamp zero reloads instead of one CSE'd kGraphicZero load + fmr.
- drawBar: 96.78% -> 96.81%. Swapped the hue/y loop-increment statement order to match the target's emission order.

Remaining diffs are confirmed allocator-tie-break walls (swept 40+ variants, all neutral or regressing): volatile scratch-FPR/GPR creation-order permutations around the inlined drawSFRect FIFO blocks, the staging-slot interleave of named GXColor locals vs by-value arg copies in drawBar, the t/fadeWave f28/f29 callee-saved swap, the kIntToDoubleBias anonymous-pool reloc naming, and the known __sinit data.0 anchoring wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)