### PR TITLE
gobjwork: raise fuzzy match to 97.74% (cycle 19)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -971,10 +971,10 @@ int CCaravanWork::GetFoodRank(int playerIdx)
  */
 void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxResults)
 {
-	int foundCount = 0;
 	int bit0;
 	int bit1;
 	int bit2;
+	int foundCount = 0;
 
 	for (int i = 0; i < maxResults; i++) {
 		romLetterWork[i] = 0;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -406,7 +406,7 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 	memset(&m_letters[0], 0, sizeof(m_letters[0]));
 	m_letters[0].SetMessageType(letterType);
 	m_letters[0].m_words.m_word0 = (m_letters[0].m_words.m_word0 & 0xFFFC01FF) | ((senderId & 0x1FF) << 9);
-	m_letters[0].SetFlags((m_letters[0].Flags() & ~8) | ((hasMoneyFlag << 3) & 8));
+	m_letters[0].FlagsBits().m_attachmentIsGil = hasMoneyFlag;
 	int attachmentValue;
 	if (m_letters[0].AttachmentIsGil()) {
 		attachmentValue = moneyValue / 100;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2889,11 +2889,8 @@ void CMonWork::Init(int baseDataIndex, CRomWork* romWork, int)
 
 	if ((*reinterpret_cast<int*>(&Game.m_gameWork.m_scriptSysVal0) == 1) &&
 		(Game.m_gameWork.m_bossArtifactStageIndex < 0xF)) {
-		CGame::CBossArtifactStage* bossArtifacts =
-			&Game.m_bossArtifactBase[Game.m_gameWork.m_bossArtifactStageIndex];
-		short artifactScale = bossArtifacts->m_entries[8].m_values[0];
 		m_maxHp = (unsigned short)((float)m_maxHp *
-								   ((((float)artifactScale) * kGObjWorkStatusScaleStep) + kGObjWorkStatusScaleBase));
+								   ((((float)Game.m_bossArtifactBase[Game.m_gameWork.m_bossArtifactStageIndex].m_entries[8].m_values[0]) * kGObjWorkStatusScaleStep) + kGObjWorkStatusScaleBase));
 	}
 
 	m_hp = m_maxHp;

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1884,11 +1884,11 @@ void CCaravanWork::CalcStatus()
 			case 0xDB:
 				cmdBonus += value;
 				break;
-			case 0xE4:
-				hpBonus += value;
-				break;
 			case 0xDF:
 				magBonus += value;
+				break;
+			case 0xE4:
+				hpBonus += value;
 				break;
 			}
 		}

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -424,11 +424,7 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 	m_letters[0].m_half.m_tempVars[3] = static_cast<unsigned short>(itemD);
 
 	int nextCount = m_letterCount + 1;
-	int letterCount = 100;
-	if (nextCount < 100) {
-		letterCount = nextCount;
-	}
-	m_letterCount = letterCount;
+	m_letterCount = (nextCount < 100) ? nextCount : 100;
 
 	GbaQue.SetAddLetter(m_joybusCaravanId);
 }
@@ -1698,9 +1694,9 @@ void CCaravanWork::SafeDeleteTempItem()
 		System.Printf(const_cast<char*>(sNoWorldReturnItemWarning));
 	}
 
-	int totalSlots = 0;
 	int artifactIndex = 0;
 	CCaravanWork* artifactCur = this;
+	int totalSlots = 0;
 	for (int i = 50; i != 0; i--) {
 		if (artifactIndex < 96) {
 			int artifactId = artifactCur->m_artifacts[0];

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2182,18 +2182,21 @@ int CCaravanWork::GetCmdListItemName(int cmdListIdx, int* firstCmdIdx, int* item
 {
 	short numSlots;
 	int groupedCount;
+	int topIdx;
+	int extraOff = cmdListIdx * 2;
 
 	if (Game.m_gameWork.m_menuStageMode == 0) {
 		groupedCount = 1;
 	} else {
-		if (m_commandListExtra[cmdListIdx] == 0) {
+		short* cur = (short*)((char*)this + extraOff);
+		if (*(short*)((char*)cur + 0x214) == 0) {
 			groupedCount = 1;
 		} else {
-			int topIdx;
 			for (topIdx = cmdListIdx; topIdx >= 0; topIdx--) {
-				if (m_commandListExtra[topIdx] != -1) {
+				if (*(short*)((char*)cur + 0x214) != -1) {
 					break;
 				}
+				cur--;
 			}
 
 			groupedCount = 1;
@@ -2210,10 +2213,12 @@ int CCaravanWork::GetCmdListItemName(int cmdListIdx, int* firstCmdIdx, int* item
 	}
 
 	if (groupedCount > 1) {
+		short* cur2 = (short*)((char*)this + extraOff);
 		for (int n = cmdListIdx; n >= 0; n--) {
-			if (m_commandListExtra[cmdListIdx] != -1) {
+			if (*(short*)((char*)cur2 + 0x214) != -1) {
 				break;
 			}
+			cur2--;
 			cmdListIdx--;
 		}
 

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1905,11 +1905,7 @@ void CCaravanWork::CalcStatus()
 	}
 	m_numCmdListSlots = cmdSlotCap;
 
-	unsigned short cappedValue = 0x10;
-	if (m_maxHp < 0x10) {
-		cappedValue = m_maxHp;
-	}
-	m_maxHp = cappedValue;
+	m_maxHp = (m_maxHp < 0x10) ? m_maxHp : 0x10;
 
 	for (int equipIdx = 0; equipIdx < 4; equipIdx++) {
 		int equipSlot = m_equipment[equipIdx];


### PR DESCRIPTION
Raises main/gobjwork fuzzy match 97.31% -> 97.74% (+0.43).

Per-function gains:
- CMonWork::Init 94.00 -> 98.85: boss-artifact HP scale rewritten as a direct unsigned expression (drops the signed `short` cast + pointer temp; kills the spurious extsh/xoris signed-conversion sequence and matches the folded `lhz 0x60(base+idx*0x168)` addressing).
- AddLetter 91.02 -> 95.71: attachmentIsGil flag written as a real bitfield member assignment (R15) — fixed the whole callee-saved parameter band (r22-r31); letterCount clamp rewritten as a ternary select (R17).
- GetCmdListItemName 95.51 -> ~99: function-top `extraOff = cmdListIdx * 2` + byte-offset cursor pointers for the m_commandListExtra scans (house 0x214 offset-pointer idiom, matches the hoisted `slwi r11`), cursor-before-counter decrement order, topIdx decl hoisted.
- CCaravanWork::CalcStatus 99.10 -> 99.20: artifact-bonus case 0xDF reordered before 0xE4 (R9 source-order), maxHp clamp as ternary select.
- SearchRomLetterWork 93.83 -> 94.01: foundCount declared after the bit locals (decl-rank shift).
- SafeDeleteTempItem: totalSlots decl moved last.

Walls hit (documented for future cycles): FGLetterOpen's extra callee-saved mulli result (r29) resists named-offset locals, opt_propagation/opt_common_subs pragmas, and O1; GetNextCmdListIdx/SearchRomLetterWork whole-band register rotation resists reference locals, helper wraps (always_inline + inline_max_total_size nuked the unit), and decl permutations; AddLetter's 12-byte struct-copy pairing ([w0][w1,w2] vs [w0,w1][w2]) resists word-wise/memcpy/cursor forms; CMonWork::Init backupParam double-addi pattern resists loop/index rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)