### PR TITLE
pad: raise fuzzy match to 98.33% (cycle 7)

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -83,7 +83,7 @@ inline void CPad::SaveReplayData()
 
 #pragma always_inline on
 #pragma inline_max_total_size(100000)
-static inline void MergePadInputs(CPad* pad, u16* puVar13, u16* puVar18, u16* puVar10)
+static inline void MergePadInputs(CPad* pad, u16* puVar13, u16*& puVar18, u16* puVar10)
 {
 	int iVar14;
 	u8* p12;
@@ -405,9 +405,9 @@ void CPad::Frame()
 	u16* puVar13;
 	int iVar14;
 	u32 port;
-	u32 uVar15;
-	u32 gbaIdx;
 	u32 uVar16;
+	u32 gbaIdx;
+	u32 uVar15;
 	u16* puVar18;
 	int iVar19;
 	CPad::Gba local_98[4];

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -397,12 +397,12 @@ void CPad::Frame()
 	int iVar6;
 	u16 uVar1;
 	u16 uVar8;
+	u16* puVar13;
 	u16* puVar7;
 	s8 cVar9;
 	u16* puVar10;
 	int iVar11;
 	u16* puVar12;
-	u16* puVar13;
 	int iVar14;
 	u32 port;
 	u32 uVar16;

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -397,11 +397,11 @@ void CPad::Frame()
 	int iVar6;
 	u16 uVar1;
 	u16 uVar8;
-	u16* puVar13;
-	u16* puVar7;
 	s8 cVar9;
 	u16* puVar10;
 	int iVar11;
+	u16* puVar7;
+	u16* puVar13;
 	u16* puVar12;
 	int iVar14;
 	u32 port;


### PR DESCRIPTION
Raises `main/pad` from 97.39% to **98.33%** (Frame 96.85% -> 97.96%).

Three source-level changes in `CPad::Frame` / `MergePadInputs`:
- **MergePadInputs `puVar18` passed by reference (R56)**: the Gba-array cursor param now coalesces into the caller's callee-saved r31 instead of being copied to a volatile (`mr r10,r31` eliminated), un-shifting the r10/r11 temp web across the whole helper body (+0.77).
- **uVar15/uVar16 declaration swap**: fixes the r23/r25 assignment in the GBA flag loop (+0.06).
- **Frame local declaration-order tuning** (puVar7/puVar13 moved after iVar11): fixes record/playback loop register roles (+0.11 net across two moves).

Remaining walls (probed extensively, all regress or normalize to identical binaries): uVar17-vs-store-zero constant web split in the merged block (R27 ternaries materialize a select; GVN re-merges all placement/named-zero forms), record/playback volatile permutation tied to the `_1bc_4_` web color (r5 vs r8), abs-merge temp rotation, and the kPad* named-extern relocs (R46 forms cost -0.09, confirming reloc-name-cost-zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)