### PR TITLE
ME_USB_process: raise fuzzy match to 98.08% (cycle 7)

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -480,3 +480,4 @@ void CMaterialEditorPcs::MemFree(void* ptr)
 
 extern const float kMapEditorZero = 0.0f;
 extern const float kMapEditorOne = 1.0f;
+extern const double kMapEditorS32ToDoubleBias = 4503601774854144.0;

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -186,7 +186,9 @@ void CMaterialEditorPcs::SetUSBData()
         memset(rsdItem->ptr18, 0, usb.m_sizeBytes * 0x70);
         memcpy(rsdItem->ptr18, usb.m_data, usb.m_sizeBytes * 0x70);
 
-        for (u32 offset = 0, i = 0; i < usb.m_sizeBytes; offset += 0x70, i++) {
+        u32 offset;
+        u32 i;
+        for (i = 0, offset = 0; i < usb.m_sizeBytes; offset += 0x70, i++) {
             StoreSwapS16(reinterpret_cast<s16*>(reinterpret_cast<u8*>(rsdItem->ptr18) + offset + 0x00));
             StoreSwapU16(reinterpret_cast<u16*>(reinterpret_cast<u8*>(rsdItem->ptr18) + offset + 0x02));
             StoreSwap32(reinterpret_cast<u32*>(reinterpret_cast<u8*>(rsdItem->ptr18) + offset + 0x04));
@@ -304,13 +306,14 @@ void CMaterialEditorPcs::SetUSBData()
         RSDITEM* rsdItem = this->GetRsdItem()->rsdItem;
         memcpy(dstBuffer, usb.m_data, usb.m_sizeBytes);
 
-        u32 dstOffset = 0;
-        for (u32 i = 0; i < usb.m_sizeBytes; i++) {
+        u32 i;
+        u32 dstOffset;
+        for (i = 0, dstOffset = 0; i < usb.m_sizeBytes; dstOffset += 0x70, i++) {
             u8 value = *dstBuffer;
+            u8* writeBase = static_cast<u8*>(rsdItem->ptr18);
             u32 writeOffset = dstOffset + 0x1A;
-            dstOffset += 0x70;
             dstBuffer++;
-            static_cast<u8*>(rsdItem->ptr18)[writeOffset] = value;
+            writeBase[writeOffset] = value;
         }
 
         if (src != 0) {

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -137,7 +137,9 @@ void CMaterialEditorPcs::SetUSBData()
 
         memcpy(rsdItem->ptr10, usb.m_data, usb.m_sizeBytes * 0xC);
 
-        for (u32 offset = 0, i = 0; i < usb.m_sizeBytes; offset += 0xC, i++) {
+        u32 offset;
+        u32 i;
+        for (i = 0, offset = 0; i < usb.m_sizeBytes; offset += 0xC, i++) {
             StoreSwapFloat(reinterpret_cast<f32*>(reinterpret_cast<u8*>(rsdItem->ptr10) + offset + 0x0));
             StoreSwapNegFloat(reinterpret_cast<f32*>(reinterpret_cast<u8*>(rsdItem->ptr10) + offset + 0x4));
             StoreSwapNegFloat(reinterpret_cast<f32*>(reinterpret_cast<u8*>(rsdItem->ptr10) + offset + 0x8));
@@ -241,7 +243,9 @@ void CMaterialEditorPcs::SetUSBData()
 
         memcpy(rsdItem->ptr14, usb.m_data, usb.m_sizeBytes * 0xC);
 
-        for (u32 offset = 0, i = 0; i < usb.m_sizeBytes; offset += 0xC, i++) {
+        u32 offset;
+        u32 i;
+        for (i = 0, offset = 0; i < usb.m_sizeBytes; offset += 0xC, i++) {
             StoreSwapFloat(reinterpret_cast<f32*>(reinterpret_cast<u8*>(rsdItem->ptr14) + offset + 0x0));
             StoreSwapNegFloat(reinterpret_cast<f32*>(reinterpret_cast<u8*>(rsdItem->ptr14) + offset + 0x4));
             StoreSwapNegFloat(reinterpret_cast<f32*>(reinterpret_cast<u8*>(rsdItem->ptr14) + offset + 0x8));


### PR DESCRIPTION
Raises main/ME_USB_process from 98.04% to 98.08% fuzzy (SetUSBData 98.01 -> 98.06), and data match from 17.0% to 21.3%.

What landed:
- Cases 0x10/0x12 (float swap loops): split IV declarations (`u32 offset; u32 i;`) with i-first init order — matches the target's `li` init emission (counter initialized first while offset keeps the lower register binding).
- Case 0x13: same i-first init form so the IV roles (counter/offset) align with the target's li pair.
- Case 0x31: named `writeBase` local for the ptr18 store base + both IVs moved into the for-header with i-first declaration — fixes the offset/writeOffset/base volatile web (r5/r0/r3 now match; only an i/value swap remains).
- Defined `kMapEditorS32ToDoubleBias` (the s32->double conversion bias double symbols.txt places in this unit's .sdata2) — .sdata2 now matches 100%, unit data 17.0% -> 21.3%.

Walls confirmed (extensively swept, all regress or are binary-identical):
- Case 0x13 byte-swap loop: the 21 hoisted swap-temp address invariants sit one 2-register rotation off (target IVs r23/r24 vs ours r25/r26). Tried R56-EXT by-ref helper params, R52 always_inline row/record helpers (+inline_max_total_size), value-returning swap helpers, open-coded named temps, derived i*0x70 offsets, while/do forms, decl/init permutations — every structural variant is either bit-identical or regresses. This is the documented register tie-break wall (R52 residual class).
- Float-loop scratch window (inv addrs r8/r6/r0 vs r6/r5/r0) and SRT f3/f5 swap behave the same way: source order changes produce bit-identical binaries.
- Remaining .data 0% is the switch jump table, which tracks code layout and resolves only with full code match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)