### PR TITLE
p_camera: raise fuzzy match to 96.75% (cycle 23)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1413,10 +1413,10 @@ void CCameraPcs::createFullShadow()
     m_fullScreenShadow.m_rampTexture = rampTex;
 
     for (i = 0; i < 0x100; i += 8) {
-        u32 v6 = i + 6;
-        u32 v7 = i + 7;
         u32 v3 = i + 3;
         u32 v4 = i + 4;
+        u32 v6 = i + 6;
+        u32 v7 = i + 7;
         u32 v5 = i + 5;
         u32 v2 = i + 2;
         u32 v1 = i + 1;

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -1642,8 +1642,10 @@ void CCameraPcs::drawShadowBegin()
             float sumX = m_shadowRectBound.m_min.x + m_shadowRectBound.m_max.x;
             float half = kCameraHalfF;
             float sumZ = m_shadowRectBound.m_min.z + m_shadowRectBound.m_max.z;
-            m_targetX = sumX * half;
-            m_targetZ = sumZ * half;
+            float tx = sumX * half;
+            float tz = sumZ * half;
+            m_targetX = tx;
+            m_targetZ = tz;
             m_targetY = m_fullScreenShadowPosition.y;
 
             depth = m_shadowRectBound.m_max.x - m_shadowRectBound.m_min.x;


### PR DESCRIPTION
Raises main/p_camera 96.737% -> 96.745%.

- createFullShadow (73.51 -> 73.67): hill-climbed the swizzle-loop temp decl order two more steps ([6,7,3,4,5,2,1] -> [3,4,6,7,5,2,1]) from a fresh double-swap neighborhood.
- drawShadowBegin (99.068 -> 99.083): staged the targetX/targetZ products through named tx/tz temps, fixing the f0/f1 store-register swap.

Wall findings (verified by bit-identical sweeps / regressions):
- The R53+R55 combo (opt_strength_reduction off on top of the existing opt_propagation off) is BIT-IDENTICAL on createFullShadow — strength reduction never fires in this loop. Same for opt_common_subs/loop_invariants/dead_assignments; scheduling/peephole/global_optimizer/O1 all regress hard. Lazy/scoped/interleaved temp forms all normalize to the decl-order canonical form. The remaining 26% of the function is the r28-extra-callee-saved window shift, and every structural lever for merging map+rampTexSize into r31 regresses.
- calcMap/CalcQuake named-constant residuals are the documented literal-vs-named-extern pool dichotomy (named externs regress the unit).
- calc/GetShadowRect FPR-role swaps are bit-identical under all decl/operand permutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)