### PR TITLE
memorycard: raise fuzzy match to 98.9% (cycle 10)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -548,7 +548,7 @@ config.libs = [
             Object(NonMatching, "ME_AppRequest.cpp"),
             Object(NonMatching, "ME_USB_process.cpp", cflags=[*cflags_game_cpp_exceptions, "-sdata2 8"]),
             Object(NonMatching, "memory.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
-            Object(NonMatching, "memorycard.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse"]),
+            Object(NonMatching, "memorycard.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse", "-inline auto,deferred"]),
             Object(Matching, "menu.cpp", extra_cflags=["-RTTI on", "-sdata 8", "-str reuse,pool,readonly"]),
             Object(NonMatching, "menu_arti.cpp"),
             Object(NonMatching, "menu_cmd.cpp", extra_cflags=["-str reuse,pool,readonly"]),

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -808,12 +808,17 @@ int CMemoryCardMan::DummyLoad()
     }
 
     memset(m_saveBuffer, 0, kMemoryCardSaveBufferSize);
+    char* readBuf = m_saveBuffer;
+    if (readBuf == nullptr)
+    {
+        readBuf = m_saveBuffer;
+    }
     m_opDoneFlag = 0;
     m_state = 8;
 
     result = CARDReadAsync(
         &m_fileInfo,
-        m_saveBuffer,
+        readBuf,
         kMemoryCardSaveBufferSize,
         0x4000,
         &Attach
@@ -1063,12 +1068,17 @@ int CMemoryCardMan::DummySave()
 
         SetMcIconImage();
 
+        char* writeBuf = m_saveBuffer;
+        if (writeBuf == nullptr)
+        {
+            writeBuf = m_saveBuffer;
+        }
         m_opDoneFlag = 0;
         m_state = 9;
 
         result = CARDWriteAsync(
             &m_fileInfo,
-            m_saveBuffer,
+            writeBuf,
             0x4000,
             0,
             &Attach
@@ -1151,12 +1161,17 @@ int CMemoryCardMan::DummySave()
 
     MakeSaveData();
 
+    char* writeBuf2 = m_saveBuffer;
+    if (writeBuf2 == nullptr)
+    {
+        writeBuf2 = m_saveBuffer;
+    }
     m_opDoneFlag = 0;
     m_state = 9;
 
     result = CARDWriteAsync(
         &m_fileInfo,
-        m_saveBuffer,
+        writeBuf2,
         kMemoryCardSaveBufferSize,
         0x4000,
         &Attach

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1249,9 +1249,8 @@ int CMemoryCardMan::DummySave()
 void CMemoryCardMan::SetLoadData()
 {
     u8* save = reinterpret_cast<u8*>(m_saveBuffer);
-    Mc::SaveDat* saveDat = GetSaveDat(save);
 
-    if (memcmp(saveDat->m_maker, CardConst::MCDAT_MAKER, strlen(CardConst::MCDAT_MAKER)) != 0)
+    if (memcmp(GetSaveDat(save)->m_maker, CardConst::MCDAT_MAKER, strlen(CardConst::MCDAT_MAKER)) != 0)
     {
         if (static_cast<unsigned int>(System.m_execParam) >= 1)
         {
@@ -1259,7 +1258,7 @@ void CMemoryCardMan::SetLoadData()
         }
         return;
     }
-    if (memcmp(saveDat->m_title, CardConst::MCDAT_TITLE, strlen(CardConst::MCDAT_TITLE)) != 0)
+    if (memcmp(GetSaveDat(save)->m_title, CardConst::MCDAT_TITLE, strlen(CardConst::MCDAT_TITLE)) != 0)
     {
         if (static_cast<unsigned int>(System.m_execParam) >= 1)
         {
@@ -1267,7 +1266,7 @@ void CMemoryCardMan::SetLoadData()
         }
         return;
     }
-    if (memcmp(saveDat->m_machine, CardConst::MCDAT_MACHINE, strlen(CardConst::MCDAT_MACHINE)) != 0)
+    if (memcmp(GetSaveDat(save)->m_machine, CardConst::MCDAT_MACHINE, strlen(CardConst::MCDAT_MACHINE)) != 0)
     {
         if (static_cast<unsigned int>(System.m_execParam) >= 1)
         {
@@ -1275,7 +1274,7 @@ void CMemoryCardMan::SetLoadData()
         }
         return;
     }
-    if (memcmp(saveDat->m_version, CardConst::MCDAT_VERSION, strlen(CardConst::MCDAT_VERSION)) != 0)
+    if (memcmp(GetSaveDat(save)->m_version, CardConst::MCDAT_VERSION, strlen(CardConst::MCDAT_VERSION)) != 0)
     {
         if (static_cast<unsigned int>(System.m_execParam) >= 1)
         {
@@ -1283,7 +1282,7 @@ void CMemoryCardMan::SetLoadData()
         }
         return;
     }
-    if (saveDat->m_region != 'E')
+    if (GetSaveDat(save)->m_region != 'E')
     {
         if (static_cast<unsigned int>(System.m_execParam) >= 1)
         {

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -735,6 +735,62 @@ void CMemoryCardMan::CnvPlayTime(unsigned int frames, int* hours, int* minutes)
  * Address:	TODO
  * Size:	TODO
  */
+void CMemoryCardMan::McWrite(char* buffer, int length, int offset)
+{
+    if (buffer == nullptr)
+    {
+        buffer = m_saveBuffer;
+    }
+
+    m_opDoneFlag = 0;
+    m_state = 9;
+
+    int result = CARDWriteAsync(
+        &m_fileInfo,
+        buffer,
+        length,
+        offset,
+        &Attach
+    );
+
+    if (result < 0)
+    {
+        m_opDoneFlag = 1;
+    }
+
+    m_result = result;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CMemoryCardMan::McRead(char* buffer, int length, int offset)
+{
+    if (buffer == nullptr)
+    {
+        buffer = m_saveBuffer;
+    }
+
+    m_opDoneFlag = 0;
+    m_state = 8;
+
+    int result = CARDReadAsync(&m_fileInfo, buffer, length, offset, &Attach);
+
+    if (result < 0)
+    {
+        m_opDoneFlag = 1;
+    }
+
+    m_result = result;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
 int CMemoryCardMan::DummyLoad()
 {
     int result;
@@ -808,28 +864,7 @@ int CMemoryCardMan::DummyLoad()
     }
 
     memset(m_saveBuffer, 0, kMemoryCardSaveBufferSize);
-    char* readBuf = m_saveBuffer;
-    if (readBuf == nullptr)
-    {
-        readBuf = m_saveBuffer;
-    }
-    m_opDoneFlag = 0;
-    m_state = 8;
-
-    result = CARDReadAsync(
-        &m_fileInfo,
-        readBuf,
-        kMemoryCardSaveBufferSize,
-        0x4000,
-        &Attach
-    );
-
-    if (result < 0)
-    {
-        m_opDoneFlag = 1;
-    }
-
-    m_result = result;
+    McRead(m_saveBuffer, kMemoryCardSaveBufferSize, 0x4000);
 
     // Wait for read to finish
     while ((((u32)(-((unsigned int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
@@ -1068,27 +1103,7 @@ int CMemoryCardMan::DummySave()
 
         SetMcIconImage();
 
-        char* writeBuf = m_saveBuffer;
-        if (writeBuf == nullptr)
-        {
-            writeBuf = m_saveBuffer;
-        }
-        m_opDoneFlag = 0;
-        m_state = 9;
-
-        result = CARDWriteAsync(
-            &m_fileInfo,
-            writeBuf,
-            0x4000,
-            0,
-            &Attach
-        );
-
-        if (result < 0)
-        {
-            m_opDoneFlag = 1;
-        }
-        m_result = result;
+        McWrite(m_saveBuffer, 0x4000, 0);
 
         while ((((u32)(-((unsigned int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
         {
@@ -1161,27 +1176,7 @@ int CMemoryCardMan::DummySave()
 
     MakeSaveData();
 
-    char* writeBuf2 = m_saveBuffer;
-    if (writeBuf2 == nullptr)
-    {
-        writeBuf2 = m_saveBuffer;
-    }
-    m_opDoneFlag = 0;
-    m_state = 9;
-
-    result = CARDWriteAsync(
-        &m_fileInfo,
-        writeBuf2,
-        kMemoryCardSaveBufferSize,
-        0x4000,
-        &Attach
-    );
-
-    if (result < 0)
-    {
-        m_opDoneFlag = 1;
-    }
-    m_result = result;
+    McWrite(m_saveBuffer, kMemoryCardSaveBufferSize, 0x4000);
 
     while ((((u32)(-((unsigned int)m_opDoneFlag) | (int)m_opDoneFlag)) >> 31) != 1)
     {
@@ -1767,62 +1762,6 @@ void CMemoryCardMan::McFormat(int chan)
         chan,
         &Attach
     );
-
-    if (result < 0)
-    {
-        m_opDoneFlag = 1;
-    }
-
-    m_result = result;
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CMemoryCardMan::McWrite(char* buffer, int length, int offset)
-{
-    if (buffer == nullptr)
-    {
-        buffer = m_saveBuffer;
-    }
-
-    m_opDoneFlag = 0;
-    m_state = 9;
-
-    int result = CARDWriteAsync(
-        &m_fileInfo,
-        buffer,
-        length,
-        offset,
-        &Attach
-    );
-
-    if (result < 0)
-    {
-        m_opDoneFlag = 1;
-    }
-
-    m_result = result;
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CMemoryCardMan::McRead(char* buffer, int length, int offset)
-{
-    if (buffer == nullptr)
-    {
-        buffer = m_saveBuffer;
-    }
-
-    m_opDoneFlag = 0;
-    m_state = 8;
-
-    int result = CARDReadAsync(&m_fileInfo, buffer, length, offset, &Attach);
 
     if (result < 0)
     {

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -520,10 +520,11 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
         *reinterpret_cast<u32*>(dstCharData + 0x8D0) = *reinterpret_cast<u32*>(reinterpret_cast<u8*>(&srcSave) + 0x13D8);
 
         u8* dstWork = reinterpret_cast<u8*>(&dstSave) + dstChar * 0x200;
+        u8* item;
         int i = 0;
         do
         {
-            u8* item = dstWork + dstChar * 8;
+            item = dstWork + dstChar * 8;
             for (int j = 0; j < 8; j++)
             {
                 u8 flag = 0;

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -735,62 +735,6 @@ void CMemoryCardMan::CnvPlayTime(unsigned int frames, int* hours, int* minutes)
  * Address:	TODO
  * Size:	TODO
  */
-void CMemoryCardMan::McWrite(char* buffer, int length, int offset)
-{
-    if (buffer == nullptr)
-    {
-        buffer = m_saveBuffer;
-    }
-
-    m_opDoneFlag = 0;
-    m_state = 9;
-
-    int result = CARDWriteAsync(
-        &m_fileInfo,
-        buffer,
-        length,
-        offset,
-        &Attach
-    );
-
-    if (result < 0)
-    {
-        m_opDoneFlag = 1;
-    }
-
-    m_result = result;
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
-void CMemoryCardMan::McRead(char* buffer, int length, int offset)
-{
-    if (buffer == nullptr)
-    {
-        buffer = m_saveBuffer;
-    }
-
-    m_opDoneFlag = 0;
-    m_state = 8;
-
-    int result = CARDReadAsync(&m_fileInfo, buffer, length, offset, &Attach);
-
-    if (result < 0)
-    {
-        m_opDoneFlag = 1;
-    }
-
-    m_result = result;
-}
-
-/*
- * --INFO--
- * Address:	TODO
- * Size:	TODO
- */
 int CMemoryCardMan::DummyLoad()
 {
     int result;
@@ -1762,6 +1706,62 @@ void CMemoryCardMan::McFormat(int chan)
         chan,
         &Attach
     );
+
+    if (result < 0)
+    {
+        m_opDoneFlag = 1;
+    }
+
+    m_result = result;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CMemoryCardMan::McWrite(char* buffer, int length, int offset)
+{
+    if (buffer == nullptr)
+    {
+        buffer = m_saveBuffer;
+    }
+
+    m_opDoneFlag = 0;
+    m_state = 9;
+
+    int result = CARDWriteAsync(
+        &m_fileInfo,
+        buffer,
+        length,
+        offset,
+        &Attach
+    );
+
+    if (result < 0)
+    {
+        m_opDoneFlag = 1;
+    }
+
+    m_result = result;
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void CMemoryCardMan::McRead(char* buffer, int length, int offset)
+{
+    if (buffer == nullptr)
+    {
+        buffer = m_saveBuffer;
+    }
+
+    m_opDoneFlag = 0;
+    m_state = 8;
+
+    int result = CARDReadAsync(&m_fileInfo, buffer, length, offset, &Attach);
 
     if (result < 0)
     {

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -2187,6 +2187,23 @@ void Detach(long currentSlot, long result)
  * Address:	TODO
  * Size:	TODO
  */
+static inline int FindCardFile(char* filename, CARDStat* stat)
+{
+    int fileNo = 0;
+    while (fileNo < 0x7F)
+    {
+        if (CARDGetStatus(1, fileNo, stat) >= 0)
+        {
+            if (strcmp(filename, reinterpret_cast<char*>(stat)) == 0)
+            {
+                return fileNo;
+            }
+        }
+        fileNo++;
+    }
+    return -1;
+}
+
 void CMemoryCardMan::DebugReadWrite(int isWrite, char* filename, void* buffer, int length)
 {
     int success = 0;
@@ -2228,26 +2245,8 @@ checkResult:
                     goto readFile;
                 }
 
-                result = 0;
-                while (result < 0x7F)
-                {
-                    if (CARDGetStatus(1, result, &stat) < 0)
-                    {
-                        goto nextFile;
-                    }
-                    if (strcmp(filename, reinterpret_cast<char*>(&stat)) != 0)
-                    {
-                        goto nextFile;
-                    }
-                    goto foundFile;
+                result = FindCardFile(filename, &stat);
 
-nextFile:
-                    result++;
-                }
-
-                result = -1;
-
-foundFile:
                 if ((result >= 0) && (CARDFastOpen(1, result, &fileInfo) >= 0))
                 {
 readFile:

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1330,19 +1330,12 @@ void CMemoryCardMan::SetLoadData()
         u8* src = save + 0x14D0 + c * 0x9C0;
         CCaravanWork* caravanWork = &Game.m_caravanWorkArr[c];
 
-        count = 0;
-        i = count;
-        if (i < 64)
+        for (i = count = 0; i < 64; i++)
         {
-            int trip = 64 - i;
-            do
+            if (*reinterpret_cast<s16*>(src + 0x3C + i * 2) != -1)
             {
-                if (*reinterpret_cast<s16*>(src + 0x3C + i * 2) != -1)
-                {
-                    count++;
-                }
-                i++;
-            } while (--trip != 0);
+                count++;
+            }
         }
         if (count != *reinterpret_cast<u16*>(src + 0x28))
         {


### PR DESCRIPTION
Raises main/memorycard from 98.10% to 98.86% (cycle 10).

Per-function gains:
- DummyLoad 98.46 -> 100% and DummySave 98.55 -> 100%: the "dead lwz+cmplwi m_saveBuffer" blocks are inline expansions of the real McRead/McWrite (with their `if (buffer == NULL) buffer = m_saveBuffer;` guard whose then-arm folds away, leaving the bare compare). Calls restored + `-inline auto,deferred` (repo-precedent flag) so the later-defined methods inline while keeping the original function order (PAL map order preserved).
- DebugReadWrite 99.13 -> 100%: the file-search goto web is an inlined `FindCardFile` helper; its early `return fileNo` reproduces the unfolded `bne; b` junction (R40).
- SetLoadData 96.09 -> 98.66: `for (i = count = 0; ...)` chained assignment defeats constprop and restores the target's guarded mtctr/bdnz item-count loop (new lever, R33-family); dropped the `saveDat` alias to unify the save-pointer web.
- Odekake 97.56 -> 97.66: hoisted the letter `item` cursor declaration out of the do-loop.

Walls (heavily swept, ~50 variants, all canonical): DecodeData/EncodeData r3/r4 web swap (&word vs saveBuffer coloring is invariant under helper/by-ref/register/decl/volatile/array/pragma forms); the callee-saved r20-r27 band rotation in SetLoadData/MakeSaveData caravan loops (explicit cursors, scope moves, decl orders all emit identical code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)