### PR TITLE
maphit: raise fuzzy match to 99.40% (cycle 11)

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -44,18 +44,20 @@ extern inline float sqrtf(float x)
     } bits;
     int fpclass;
 
+    float result;
+
     if (x > 0.0f) {
         double guess = __frsqrte((double)x); // returns an approximation to
         guess = _half * guess * (_three - guess * guess * x); // now have 12 sig bits
         guess = _half * guess * (_three - guess * guess * x); // now have 24 sig bits
         guess = _half * guess * (_three - guess * guess * x); // now have 32 sig bits
-        x = (float)(x * guess);
-        return x;
+        result = (float)(x * guess);
+        return result;
     }
 
     if ((double)x < 0.0) {
-        x = NAN;
-        return x;
+        result = NAN;
+        return result;
     }
 
     bits.f = x;
@@ -80,10 +82,12 @@ extern inline float sqrtf(float x)
     }
 
     if (fpclass == 1) {
-        x = NAN;
+        result = NAN;
+    } else {
+        result = x;
     }
 
-    return x;
+    return result;
 }
 #else
 #ifdef __cplusplus

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -160,7 +160,7 @@ void CMapHit::Draw()
     GXSetVtxDesc(GX_VA_CLR0, GX_DIRECT);
 
     face = m_faces;
-    for (faceIndex = 0; faceIndex < static_cast<int>(m_faceCount); faceIndex++, face++) {
+    for (faceIndex = 0; faceIndex < static_cast<int>(m_faceCount); face++, faceIndex++) {
         if ((face->m_drawFlags & 1) != 0) {
             face->m_drawFlags = 0;
         } else {

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -437,6 +437,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
         return 0;
     }
 
+    CMapCylinder& cyl = g_hit_cyl;
     unsigned char boundsOverlap = 0;
     unsigned char partialOverlap = 0;
     int axisOverlap;
@@ -480,7 +481,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
         return 0;
     }
 
-    Vec* hitDirection = &g_hit_cyl.m_axis;
+    Vec* hitDirection = &cyl.m_axis;
     float dot = PSVECDotProduct(hitDirection, &g_hit_lpface->m_normal);
     if (dot >= kMapHitZero) {
         return 0;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -125,8 +125,8 @@ void CMapHit::Draw()
     while (faceIndex < m_faceCount) {
         if ((face->m_drawFlags & 1) == 0) {
             const CMapIdGrp* mapIdGrp = &MapMng.m_mapIdGrpArray[face->m_groupIndex];
-            const GXColor colorABytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_primaryColor);
-            const GXColor colorBBytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_secondaryColor);
+            GXColor colorABytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_primaryColor);
+            GXColor colorBBytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_secondaryColor);
 
             GXBegin(GX_TRIANGLES, GX_VTXFMT7, 3);
             int i = 0;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -649,9 +649,8 @@ edge_loop:
                 Vec edge;
                 PSVECSubtract(&current, &previous, &edge);
 
-                Vec rayDirection;
                 Vec rayStart = g_hit_cyl.m_bottom;
-                rayDirection = *hitDirection;
+                Vec rayDirection = *hitDirection;
 
                 CMapCylinder edgeCylinder;
                 edgeCylinder.m_bottom = previous;


### PR DESCRIPTION
Raises main/maphit 98.51% -> 99.40% (+0.89).

Per-function:
- CheckHitFaceCylinder 95.22 -> 98.16: attached `Vec rayDirection = *hitDirection;` init in the edge loop (word-copy instead of FPR copy, fixed the whole FindIntersection-call staging block and the stmw r15->r16 frame); `CMapCylinder& cyl = g_hit_cyl;` reference local (R56) re-ranked the IV web (r16/r17 IVs now match).
- Draw 98.24 -> 99.71: dropping `const` on the GXColor byte copies fixed the hoisted lbz r/g/b/a coloring in both color loops; `face++, faceIndex++` increment order in the section-3 for loop.
- FindIntersection 98.67 -> 99.25: rewrote include/math.h sqrtf with a separate `result` variable instead of mutating `x` in place — kills the early `fmr` param copy and reproduces the target's per-path result blocks. Net-positive across the repo (p_light +0.02, cflat_runtime2 +0.02, partyobj -0.01; total report up).

Remaining residuals (verified bit-identical under sweeps, TRUE-WALL signature): CheckHitFaceCylinder r24-r31 named-band rotation (`this`-rank — mh-ref/self-ptr/obj-ptr/verts-cache all canonicalized), 5-arg wrapper faceIndex/endFace/faceOffset 3-reg rotation, Draw section-3 face/faceIndex swap, FindIntersection f7/f8 scratch swap + anonymous-pool reloc names (cost ~zero per FACT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)