### PR TITLE
gobjwork: raise fuzzy match to 98.01% (cycle 20)

### DIFF
--- a/include/ffcc/gobjwork.h
+++ b/include/ffcc/gobjwork.h
@@ -132,6 +132,14 @@ public:
             unsigned int m_word1;
             unsigned int m_word2;
         };
+        struct WordPair {
+            unsigned int m_word1;
+            unsigned int m_word2;
+        };
+        struct SplitWords {
+            unsigned int m_word0;
+            WordPair m_pair;
+        };
         struct FlagBits {
             unsigned char m_opened : 1;
             unsigned char m_attachmentClaimed : 1;
@@ -204,6 +212,7 @@ public:
         union {
             Halfwords m_half;
             Words m_words;
+            SplitWords m_split;
         };
     };
 

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1404,9 +1404,9 @@ void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxRe
 		for (int i = 0; i < 4; i++) {
 			const unsigned short cmpType = curLetter->m_compareRules[i].m_rule;
 			const int sourceType = (cmpType >> 11) & 3;
-			const int sourceIdx = cmpType & 0x7FF;
 
 			if (sourceType != 3) {
+				const int sourceIdx = cmpType & 0x7FF;
 				switch (sourceType) {
 				case 0:
 					switch (sourceIdx) {

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -1473,11 +1473,12 @@ void CCaravanWork::SearchRomLetterWork(CRomLetterWork **romLetterWork, int maxRe
 			for (int i = 0; i < 8; i++) {
 				const unsigned short evtRule = curLetter->m_eventRules[i];
 				const int sourceType = (evtRule >> 11) & 3;
-				const int sourceIdx = evtRule & 0x7FF;
 
 				if (sourceType == 3) {
 					continue;
 				}
+
+				const int sourceIdx = evtRule & 0x7FF;
 
 				switch (sourceType) {
 				case 1:

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -400,7 +400,7 @@ void CCaravanWork::AddLetter(int letterType, int senderId, int moneyValue, int h
 							 int itemA, int itemB, int itemC, int itemD)
 {
 	for (int i = 99; i > 0; i--) {
-		m_letters[i] = m_letters[i - 1];
+		m_letters[i].m_split = m_letters[i - 1].m_split;
 	}
 
 	memset(&m_letters[0], 0, sizeof(m_letters[0]));

--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2533,6 +2533,8 @@ void CCaravanWork::CheckAndResetCurrentWeaponIdx(int weaponIdx)
 void CCaravanWork::SortBeforeReturnWorldMap()
 {
 	char* fmtBase = sWorldMapSortFormatBlock;
+	short lhs;
+	short rhs;
 
 	memset(m_commandListExtra, 0, sizeof(m_commandListExtra));
 
@@ -2550,7 +2552,7 @@ void CCaravanWork::SortBeforeReturnWorldMap()
 
 	for (int i = 0; i < 0x3F; i++) {
 		for (int j = i + 1; j < 0x40; j++) {
-			short lhs = m_inventoryItems[i];
+			lhs = m_inventoryItems[i];
 
 			if (lhs <= 0) {
 				if (m_inventoryItems[j] <= 0) {
@@ -2574,7 +2576,7 @@ void CCaravanWork::SortBeforeReturnWorldMap()
 					}
 				}
 			} else {
-				short rhs = m_inventoryItems[j];
+				rhs = m_inventoryItems[j];
 				if ((rhs > 0) && (lhs > rhs)) {
 					m_inventoryItems[i] = rhs;
 					m_inventoryItems[j] = lhs;


### PR DESCRIPTION
Raises main/gobjwork from 97.74% to 98.01% (+0.27), matched functions 44 -> 46.

Per-function gains:
- AddLetter 95.71% -> 100%: the 12-byte CLetterWork copy loop pairs [w0][w1,w2] only when written as a SplitWords union-view struct assignment (u32 + nested 2-word pair); whole-struct, memcpy, per-word, and cast forms all chunk [w0,w1][w2] (R51 with the EXACT split mattering).
- SearchRomLetterWork 94.01% -> 94.44%: in both rule loops the original computes sourceIdx (rule & 0x7FF) AFTER the sourceType==3 early-out, not alongside it - moving the decl inside the guard matched the target clrlwi placement in eventRules and compareRules.
- SortBeforeReturnWorldMap 98.54% -> ~99.6%: lhs/rhs swap temps declared at function top (90s decl style) rank below i/j and land in r6 as in the target.

Walls hit (documented for future cycles): FGLetterOpen dead mulli-in-r29, GetNextCmdListIdx/GetNumCombi callee-saved band rotation, and CMonWork::Init backupParam double-addi are all bit-identical under every variant class tried (named locals, by-ref/inline helpers incl. always_inline+inline_max_size wrappers, R64 chained inits, pre/post-inc and volatile pointer forms, opt pragmas, -inline auto,deferred unit cflag). The cmd-list family (GetMagicCharge, DelCmdListAndItem, GetCmdListItemName, SafeDeleteTempItem, CalcStatus) shares a volatile-pool direction inversion (target assigns named-local temps descending from r9/r11, ours ascending) that no source or flag form reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)