### PR TITLE
graphic: raise fuzzy match to 97.79% (cycle 14)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1094,8 +1094,8 @@ void CGraphic::makeSphere()
             rowVertex[0] = x;
             rowVertex[1] = radius * (float)sin(kGraphicSphereSegmentAngle * (float)seg);
             vertices[vertexCount * 3 + 2] = radius * (float)cos(kGraphicSphereSegmentAngle * (float)seg);
-            rowVertex += 3;
             vertex += 3;
+            rowVertex += 3;
             vertexCount++;
         }
     }
@@ -1111,8 +1111,9 @@ void CGraphic::makeSphere()
     GXBeginDisplayList(m_sphereDisplayList, m_sphereDisplayListSize);
     GXBegin(GX_LINES, GX_VTXFMT0, 0xB0);
 
+    int ring = 0;
     int ringStart = 1;
-    for (int ring = 0; ring < 5; ring++) {
+    for (; ring < 5; ring++) {
         int current = ringStart;
         for (int seg = 0; seg < 8; seg += 2) {
             int i0 = current;

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1115,26 +1115,26 @@ void CGraphic::makeSphere()
     for (int ring = 0; ring < 5; ring++) {
         int current = ringStart;
         for (int seg = 0; seg < 8; seg += 2) {
-            GXWGFifo.f32 = vertices[current * 3 + 1];
-            GXWGFifo.f32 = vertices[current * 3 + 0];
-            GXWGFifo.f32 = vertices[current * 3 + 2];
+            int i0 = current;
+            current += 2;
+
+            GXWGFifo.f32 = vertices[i0 * 3 + 1];
+            GXWGFifo.f32 = vertices[i0 * 3 + 0];
+            GXWGFifo.f32 = vertices[i0 * 3 + 2];
 
             int next0 = ringStart + ((seg + 1) % 8);
             GXWGFifo.f32 = vertices[next0 * 3 + 1];
             GXWGFifo.f32 = vertices[next0 * 3 + 0];
             GXWGFifo.f32 = vertices[next0 * 3 + 2];
 
-            current++;
             int next1 = ringStart + ((seg + 2) % 8);
-            GXWGFifo.f32 = vertices[current * 3 + 1];
-            GXWGFifo.f32 = vertices[current * 3 + 0];
-            GXWGFifo.f32 = vertices[current * 3 + 2];
+            GXWGFifo.f32 = vertices[(i0 + 1) * 3 + 1];
+            GXWGFifo.f32 = vertices[(i0 + 1) * 3 + 0];
+            GXWGFifo.f32 = vertices[(i0 + 1) * 3 + 2];
 
             GXWGFifo.f32 = vertices[next1 * 3 + 1];
             GXWGFifo.f32 = vertices[next1 * 3 + 0];
             GXWGFifo.f32 = vertices[next1 * 3 + 2];
-
-            current++;
         }
         ringStart += 8;
     }

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1073,6 +1073,8 @@ void CGraphic::DrawSphere(float (*mtx)[4], _GXColor color)
 void CGraphic::makeSphere()
 {
     float vertices[126];
+    float* rowVertex;
+    float* vertex;
 
     int vertexCount = 0;
     vertices[0] = kGraphicSphereNegativeX;
@@ -1080,8 +1082,7 @@ void CGraphic::makeSphere()
     vertices[vertexCount * 3 + 2] = kGraphicZeroF;
 
     vertexCount++;
-    float* vertex = &vertices[vertexCount * 3];
-    float* rowVertex;
+    vertex = &vertices[vertexCount * 3];
 
     for (int ring = 0; ring < 5; ring++) {
         float pitch = (kGraphicSpherePi * (float)(ring + 1)) / kGraphicSphereRingDivisor;


### PR DESCRIPTION
Raises main/graphic from 97.61% to 97.79% (+0.18).

## makeSphere: 83.46% -> 85.90% (+2.44)
- Declared `rowVertex`/`vertex` pointer locals before `vertexCount` (fixes the user-local callee-saved trio r23/r24/r25).
- Loop 2 (ring-lines): introduced `i0` vertex-index temp with early `current += 2` and `(i0 + 1)` for the third vertex group — matches the target's early value-web update and staggered `%8` mod computation (+0.16 unit in one edit).
- Swapped `vertex += 3; rowVertex += 3;` increment order and moved the loop-2 ring counter declaration before `ringStart` to match target init order.

## Walls confirmed (bit-identical under all spellings tried)
- **SetCopyClear (86.8)**: target's 2-scratch rotated byte-copy of the unaligned `_GXColor` member + param-word reload resists field-by-field, chained-assign, pointer, memcpy and loop spellings.
- **Thread (91.1) / GetBackBufferRect (95.4) / GetBackBufferRect2 (91.3) / RenderTexQuadGrouad (88.5) / RenderNoTexQuadGrouad (97.4)**: all share the one-web-demoted-below-params register-window rotation (wakeup invariant / textureSize / dstOffset / FIFO-base r5-vs-r3). R69 splits, local copies, decl orders, ternary args (R47), `-inline auto,deferred` (R65), fifo pointer lvalue (R67) all bit-identical or regress — consistent with the documented graphic window-shift wall.
- R46 defs-at-end migration for kGraphic* pool constants regresses -0.97 (current mixed folding arrangement is optimal); reloc-name mismatches confirmed ~zero-cost.
- makeSphere loop-3 `+seg`-then-`+1` association and `ringPairBase += 8` placement are frontend-canonicalized (bit-identical sweeps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)