### PR TITLE
wind: raise fuzzy match to 98.73% (cycle 7)

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -649,7 +649,7 @@ void CWind::Frame()
                 }
 
                 f1 = obj->baseDir;
-                obj->targetDir = f1 * f2 + obj->targetDir;
+                obj->targetDir = f2 * f1 + obj->targetDir;
                 f0 = obj->targetDir;
                 f1 = obj->baseDir;
                 f1 = (f0 < f1) ? f1 : ((kWindDirMaxOffset + f1 < f0) ? kWindDirMaxOffset + f1 : f0);

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -648,8 +648,8 @@ void CWind::Frame()
                     f1 = kWindDirNegativeJitter;
                 }
 
-                f2 = obj->baseDir;
-                obj->targetDir = f1 * f2 + obj->targetDir;
+                f0 = obj->baseDir;
+                obj->targetDir = f0 * f1 + obj->targetDir;
                 f0 = obj->targetDir;
                 f1 = obj->baseDir;
                 f1 = (f0 < f1) ? f1 : ((kWindDirMaxOffset + f1 < f0) ? kWindDirMaxOffset + f1 : f0);

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -643,13 +643,13 @@ void CWind::Frame()
                 (obj->curPower < kWindPowerLowThreshold * obj->basePower)) {
                 rnd = Math.Rand(3);
                 if (rnd == 0) {
-                    f2 = kWindDirPositiveJitter;
+                    f1 = kWindDirPositiveJitter;
                 } else {
-                    f2 = kWindDirNegativeJitter;
+                    f1 = kWindDirNegativeJitter;
                 }
 
-                f1 = obj->baseDir;
-                obj->targetDir = f2 * f1 + obj->targetDir;
+                f2 = obj->baseDir;
+                obj->targetDir = f1 * f2 + obj->targetDir;
                 f0 = obj->targetDir;
                 f1 = obj->baseDir;
                 f1 = (f0 < f1) ? f1 : ((kWindDirMaxOffset + f1 < f0) ? kWindDirMaxOffset + f1 : f0);


### PR DESCRIPTION
Raises main/wind from 98.70% to 98.73% (Frame 99.82 -> 99.95).

Changes (all in Frame, the targetDir-jitter site):
- fmadds operand swap on the targetDir accumulation (f2*f1 -> matches target rA/rC pair)
- jitter/baseDir local role swap (jitter staged in f1, baseDir in f2) fixed the lfs register pair
- baseDir staged through f0 with mem-first multiply order matched the final fmadds shape

Confirmed walls (bit-identical sweeps, R-counter levers exhausted):
- AddSphere (95.68): CTR-vs-coalesce tradeoff — every for/CTR form (decl orders, register hints, chained init R64, split assignment R69, assign-at-found, single-cursor) breaks the scan/obj coalesce into r8, inserting 8 mr copies (-0.96). The do-while subic form keeps r8 but loses mtctr/bdnz.
- AddDiffuse (93.32): radiusSq/centerZ f7/f9 FPR tie-break — all decl orders, R48/R50 placements, local eliminations, and staging spellings are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)