### PR TITLE
joybus: raise fuzzy match to 99.0% (cycle 30)

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -184,7 +184,7 @@ public:
     void ClrArtiDatFlg(int);
     int MakeArtiData(int, char*);
     int GetTmpArtifactData(int, unsigned char*);
-    char GetRadarType(int);
+    int GetRadarType(int);
     void ClrRadarTypeFlg();
     unsigned int GetRadarMode(int);
     void SetRadarMode(int, int);

--- a/include/ffcc/joybus.h
+++ b/include/ffcc/joybus.h
@@ -208,7 +208,7 @@ public:
     unsigned char m_nextModeTypeArr[4];
     unsigned char m_modeXArr[4];
     unsigned char m_stateCodeArr[4];
-    unsigned char m_stateFlagArr[4];
+    char m_stateFlagArr[4];
 
     uchar m_threadInitFlag;
     bool m_binLoaded;

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -4438,7 +4438,7 @@ int GbaQueue::GetTmpArtifactData(int channel, unsigned char* outData)
  * JP Address: TODO
  * JP Size: TODO
  */
-char GbaQueue::GetRadarType(int channel)
+int GbaQueue::GetRadarType(int channel)
 {
 	OSSemaphore* semaphore = accessSemaphores + channel;
 	int radarType;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4010,21 +4010,33 @@ int JoyBus::SendDataFile(ThreadParam* threadParam)
                 dataBase = baseB;
                 totalSize = static_cast<unsigned short>(m_fileBaseB_dup);
             }
-            else if (st == 3 || st == 2 || st == 6 || st == 7 || st == 8 || st == 9)
-            {
-                unsigned char* letter = reinterpret_cast<unsigned char*>(m_letterBuffer[threadParam->m_portIndex]);
-                dataPtr = letter;
-                dataBase = letter;
-                totalSize = static_cast<unsigned short>(m_letterSizeArr[threadParam->m_portIndex]);
-            }
             else
             {
+                if (st == 3) goto letter_data;
+                if (st == 2) goto letter_data;
+                if (st == 6) goto letter_data;
+                if (st == 7) goto letter_data;
+                if (st == 8) goto letter_data;
+                if (st != 9) goto type_error;
+
+            letter_data:
+                {
+                    unsigned char* letter = reinterpret_cast<unsigned char*>(m_letterBuffer[threadParam->m_portIndex]);
+                    dataPtr = letter;
+                    dataBase = letter;
+                    totalSize = static_cast<unsigned short>(m_letterSizeArr[threadParam->m_portIndex]);
+                }
+                goto have_data;
+
+            type_error:
                 if ((unsigned int)System.m_execParam >= 1)
                 {
                     System.Printf(const_cast<char*>(s_send_type_error_fmt), threadParam->m_portIndex);
                 }
                 return -1;
             }
+
+        have_data:
 
             int blocks = totalSize / 0x2FD;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3145,8 +3145,9 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
 
             extern const unsigned int kJoyBusCmdOpMask;
             int newCount = 0;
+            int i;
 
-            for (int i = 0; i < (int)m_cmdCount[threadParam->m_portIndex]; ++i)
+            for (i = newCount; i < (int)m_cmdCount[threadParam->m_portIndex]; ++i)
             {
                 unsigned char op = (unsigned char)(*(unsigned char*)&m_cmdQueueData[threadParam->m_portIndex][i] & kJoyBusCmdOpMask);
 
@@ -3157,7 +3158,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
                 }
             }
 
-            for (int i = 0; i < 0x20; ++i)
+            for (i = 0; i < 0x20; ++i)
             {
                 if (i < newCount)
                 {
@@ -3188,8 +3189,9 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
 
             extern const unsigned int kJoyBusCmdOpMask;
             int newCount = 0;
+            int i;
 
-            for (int i = 0; i < (int)m_cmdCount[threadParam->m_portIndex]; ++i)
+            for (i = newCount; i < (int)m_cmdCount[threadParam->m_portIndex]; ++i)
             {
                 unsigned char op = (unsigned char)(*(unsigned char*)&m_cmdQueueData[threadParam->m_portIndex][i] & kJoyBusCmdOpMask);
 
@@ -3200,7 +3202,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
                 }
             }
 
-            for (int i = 0; i < 0x20; ++i)
+            for (i = 0; i < 0x20; ++i)
             {
                 if (i < newCount)
                 {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1216,8 +1216,8 @@ timeout_expiry:
 
             if ((int)GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
             {
-                unsigned int money = GbaQue.GetMoney(threadParam->m_portIndex);
-                if (SetMoney(threadParam->m_portIndex, money) == 0)
+                localBuf = GbaQue.GetMoney(threadParam->m_portIndex);
+                if (SetMoney(threadParam->m_portIndex, localBuf) == 0)
                 {
                     GbaQue.ClrMoneyFlg(threadParam->m_portIndex);
                 }
@@ -1287,8 +1287,8 @@ timeout_expiry:
 
             if ((int)GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
             {
-                unsigned int money = GbaQue.GetMoney(threadParam->m_portIndex);
-                if (SetMoney(threadParam->m_portIndex, money) == 0)
+                localBuf = GbaQue.GetMoney(threadParam->m_portIndex);
+                if (SetMoney(threadParam->m_portIndex, localBuf) == 0)
                 {
                     GbaQue.ClrMoneyFlg(threadParam->m_portIndex);
                 }
@@ -2492,7 +2492,7 @@ timeout_expiry:
             threadParam->m_errorRetry++;
             m_ctrlModeArr[threadParam->m_portIndex] = 0;
 
-            if (GbaQue.GetControllerMode() != 0)
+            if ((unsigned char)GbaQue.GetControllerMode() != 0)
                 m_nextModeTypeArr[threadParam->m_portIndex] = 4;
             else
                 m_nextModeTypeArr[threadParam->m_portIndex] = 0;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3108,13 +3108,15 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
                 }
                 else
                 {
+                    ThreadParam* tp = &m_threadParams[threadParam->m_portIndex];
+
                     unsigned int resendCmd = 0;
                     unsigned char* resendBytes = reinterpret_cast<unsigned char*>(&resendCmd);
                     resendBytes[0] = 0x07;
                     resendBytes[1] = 0x15;
                     resendBytes[2] = 0;
 
-                    SetSendQueue(&m_threadParams[threadParam->m_portIndex], resendCmd);
+                    SetSendQueue(tp, resendCmd);
 
                     {
                         OSSemaphore* sem;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2073,6 +2073,7 @@ timeout_expiry:
 
         case 0x3B:
         {
+            m_stateFlagArr[threadParam->m_portIndex] = 0;
             int res = GBARecvSend(threadParam, &localBuf);
             if (res >= 0)
             {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5417,15 +5417,20 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
                 }
 
                 int bonusIndex = GbaQue.GetBonus(bonusPort);
-                strcpy((char*)bonusStr, Game.m_cFlatDataArr[1].TableStrings(7)[bonusIndex * 2]);
+                char* q = (char*)bonusStr;
 
-                int firstLen = strlen((char*)bonusStr);
+                strcpy(q, Game.m_cFlatDataArr[1].TableStrings(7)[bonusIndex * 2]);
+
+                int firstLen = strlen(q);
+                q += firstLen;
                 byteLen = firstLen + 1;
-                strcpy((char*)(bonusStr + firstLen + 1), Game.m_cFlatDataArr[1].TableStrings(7)[bonusIndex * 2 + 1]);
+                q++;
+                byteLen++;
 
-                byteLen = byteLen + 1;
-                byteLen = byteLen + strlen((char*)(bonusStr + firstLen + 1));
-                byteLen = byteLen + 1;
+                strcpy(q, Game.m_cFlatDataArr[1].TableStrings(7)[bonusIndex * 2 + 1]);
+
+                byteLen += strlen(q);
+                byteLen++;
             }
             else
             {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -298,7 +298,7 @@ void JoyBus::CreateInit()
         }
     }
 
-    char path[140];
+    char path[128];
     strcpy(path, JoyBusConst::DVD_DIR);
 
     strcat(path, JoyBusConst::OBJ_FILE);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4273,7 +4273,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         m_pposWordIndex[threadParam->m_portIndex] += sent;
 
         // Done with all player-pos words?
-        if (m_pposWordIndex[threadParam->m_portIndex] >= (int)(signed char)m_cmdBuffer[threadParam->m_portIndex])
+        if ((int)(signed char)m_cmdBuffer[threadParam->m_portIndex] <= m_pposWordIndex[threadParam->m_portIndex])
         {
             m_cmdBuffer[threadParam->m_portIndex] = 0;
             m_pposWordIndex[threadParam->m_portIndex] = 0;
@@ -4326,7 +4326,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
 
         m_pposWordIndex[threadParam->m_portIndex] += sent;
 
-        if (m_pposWordIndex[threadParam->m_portIndex] >= (int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex])
+        if ((int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex] <= m_pposWordIndex[threadParam->m_portIndex])
         {
             state += 1;
             m_cmdBuffer[4 + threadParam->m_portIndex] = 0;
@@ -4382,7 +4382,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
 
         m_pposWordIndex[threadParam->m_portIndex] += sent;
 
-        if (m_pposWordIndex[threadParam->m_portIndex] >= (int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex])
+        if ((int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex] <= m_pposWordIndex[threadParam->m_portIndex])
         {
             state = 0;
             m_cmdBuffer[4 + threadParam->m_portIndex] = 0;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6201,10 +6201,11 @@ int JoyBus::SetCtrlMode(int portIndex, int controlMode)
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
 
-    unsigned char modeFlag =
-        (signed char)(((unsigned int)(-controlMode | controlMode)) >> 31);
+    JoyBus* jb = (JoyBus*)((char*)this + portIndex * sizeof(ThreadParam));
 
-    if (GbaQue.IsSingleMode(m_threadParams[portIndex].m_portIndex))
+    unsigned char modeFlag = (controlMode != 0);
+
+    if (GbaQue.IsSingleMode(jb->m_threadParams[0].m_portIndex))
 	{
         modeFlag = 0;
 	}
@@ -6221,18 +6222,18 @@ int JoyBus::SetCtrlMode(int portIndex, int controlMode)
     }
     else
     {
-        OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
+        OSWaitSemaphore(&m_accessSemaphores[jb->m_threadParams[0].m_portIndex]);
 
-        if ((int)m_cmdCount[m_threadParams[portIndex].m_portIndex] >= 0x40)
+        if ((int)m_cmdCount[jb->m_threadParams[0].m_portIndex] >= 0x40)
         {
-            OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
+            OSSignalSemaphore(&m_accessSemaphores[jb->m_threadParams[0].m_portIndex]);
             result = -1;
         }
         else
         {
-            m_cmdQueueData[m_threadParams[portIndex].m_portIndex][m_cmdCount[m_threadParams[portIndex].m_portIndex]] = cmdWord;
-            m_cmdCount[m_threadParams[portIndex].m_portIndex]++;
-            OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
+            m_cmdQueueData[jb->m_threadParams[0].m_portIndex][m_cmdCount[jb->m_threadParams[0].m_portIndex]] = cmdWord;
+            m_cmdCount[jb->m_threadParams[0].m_portIndex]++;
+            OSSignalSemaphore(&m_accessSemaphores[jb->m_threadParams[0].m_portIndex]);
             result = 0;
         }
     }
@@ -6240,7 +6241,7 @@ int JoyBus::SetCtrlMode(int portIndex, int controlMode)
     // If successful, update local mode tracking
     if (result == 0)
     {
-        m_ctrlModeArr[m_threadParams[portIndex].m_portIndex] = modeFlag;
+        m_ctrlModeArr[jb->m_threadParams[0].m_portIndex] = modeFlag;
     }
 
     return result;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4853,30 +4853,7 @@ int JoyBus::SendCompatibility(ThreadParam* threadParam)
             port = threadParam->m_portIndex;
             unsigned int word = *(unsigned int*)&m_joyDataPacketBuffer[port][2 + m_txWordIndex[port] * 4];
 
-            if (static_cast<signed char>(m_threadRunningMask) == 0)
-            {
-                result = 0;
-            }
-            else
-            {
-                OSWaitSemaphore(&m_accessSemaphores[port]);
-
-                port = threadParam->m_portIndex;
-                if ((int)m_cmdCount[port] >= 0x40)
-                {
-                    OSSignalSemaphore(&m_accessSemaphores[port]);
-                    result = -1;
-                }
-                else
-                {
-                    m_cmdQueueData[port][m_cmdCount[port]] = word;
-                    m_cmdCount[threadParam->m_portIndex]++;
-
-                    OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
-
-                    result = 0;
-                }
-            }
+            result = SetSendQueue(threadParam, word);
         
         break;
     }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6454,7 +6454,7 @@ int JoyBus::SendResult(int portIndex, int param3, int param4, int param5)
 {
     unsigned char a = static_cast<signed char>(param4);
     unsigned char b = static_cast<unsigned char>(param5);
-    signed char firstByte = static_cast<unsigned char>(7 - (unsigned char)(param3 == 0));
+    signed char firstByte = (param3 == 0) ? 6 : 7;
 
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6576,84 +6576,33 @@ int JoyBus::SetMoney(int portIndex, unsigned int money)
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
 
-	// TODO: This 3E check feels like a < 40 check in shorts (ie size 20, cmp < 20). Might need to unfuck some of this.
-
     // Need room for *two* commands (this early check is against the caller's portIndex)
     if ((int)m_cmdCount[portIndex] >= 0x3E)
 	{
         return -1;
     }
 
-	{
-		cmdBytes[0] = 0x1A;
-		cmdBytes[1] = 0;
-		cmdBytes[2] = money >> 24;
-		cmdBytes[3] = money >> 16;
-		unsigned int word = cmd;
+    cmdBytes[0] = 0x1A;
+    cmdBytes[1] = 0;
+    cmdBytes[2] = money >> 24;
+    cmdBytes[3] = money >> 16;
 
-		if (static_cast<signed char>(m_threadRunningMask) == 0)
-		{
-			result = 0;
-		}
-		else
-		{
+    result = SetSendQueue(&m_threadParams[portIndex], cmd);
 
-			OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
+    if (result != 0)
+    {
+        return result;
+    }
 
-			if ((int)m_cmdCount[m_threadParams[portIndex].m_portIndex] >= 0x40)
-			{
-				OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-				result = -1;
-			}
-			else
-			{
-				m_cmdQueueData[m_threadParams[portIndex].m_portIndex][m_cmdCount[m_threadParams[portIndex].m_portIndex]] = word;
-				m_cmdCount[m_threadParams[portIndex].m_portIndex]++;
-				OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-				result = 0;
-			}
-		}
+    cmd = 0;
+    cmdBytes[0] = 0x5A;
+    cmdBytes[1] = money >> 8;
+    cmdBytes[2] = money;
 
-		if (result != 0)
-		{
-			return result;
-		}
-	}
+    result = SetSendQueue(&m_threadParams[portIndex], cmd);
 
-	{
-		cmd = 0;
-		cmdBytes[0] = 0x5A;
-		cmdBytes[1] = money >> 8;
-		cmdBytes[2] = money;
-		unsigned int word = cmd;
-
-		if (static_cast<signed char>(m_threadRunningMask) == 0)
-		{
-			result = 0;
-		}
-		else
-		{
-
-			OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-
-			if ((int)m_cmdCount[m_threadParams[portIndex].m_portIndex] >= 0x40)
-			{
-				OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-				result = -1;
-			}
-			else
-			{
-				m_cmdQueueData[m_threadParams[portIndex].m_portIndex][m_cmdCount[m_threadParams[portIndex].m_portIndex]] = word;
-				m_cmdCount[m_threadParams[portIndex].m_portIndex]++;
-				OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-				result = 0;
-			}
-		}
-	}
-
-		return result;
+    return result;
 }
-
 
 /*
  * --INFO--

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -1066,7 +1066,7 @@ timeout_expiry:
             int radarType = GbaQue.GetRadarType(threadParam->m_portIndex);
             if ((int)GbaQue.GetStageFlg(threadParam->m_portIndex) == 0 && radarType == 2)
             {
-                if ((char)GbaQue.GetChgScouFlg(threadParam->m_portIndex) != 0 ||
+                if ((int)GbaQue.GetChgScouFlg(threadParam->m_portIndex) != 0 ||
                     (m_stateFlagArr[threadParam->m_portIndex] != 0 &&
                      m_stateCodeArr[threadParam->m_portIndex] == 0))
                 {
@@ -1147,7 +1147,7 @@ timeout_expiry:
             if ((int)GbaQue.GetStageFlg(threadParam->m_portIndex) != 0 && (int)GbaQue.GetScrFlg() != 0)
             {
                 ResetQueue(threadParam);
-                threadParam->m_subState = 0;
+                threadParam->m_pposCounter = 0;
                 if (SendMapNo(threadParam) < 0)
                 {
                     goto sleep_retry;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -380,7 +380,7 @@ void JoyBus::Destroy()
 
     m_threadInitFlag = 1;
 
-    while (static_cast<signed char>(Joybus.m_threadRunningMask) != 0)
+    while ((signed char)Joybus.m_threadRunningMask)
     {
     }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4532,23 +4532,25 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             body[0x8B] = playerData[0x2AB];
             body[0x8C] = playerData[threadParam->m_portIndex * 0xDC + 2];
 
-            memcpy(&body[0x8D], &playerData[threadParam->m_portIndex * 0xDC + 0x20], 3);
+            body += 0x8D;
+            memcpy(body, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x20), 3);
 
             unsigned short statHalf = __lhbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x14);
-            memcpy(&body[0x90], &statHalf, 2);
+            memcpy(body + 3, &statHalf, 2);
 
-            unsigned char* compatBody = &body[0x92];
+            body += 5;
 
-            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, compatBody);
+            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, body);
+            const int byteLen = compatLen + 0x97;
 
-            memcpy(compatBody + compatLen, &playerData[threadParam->m_portIndex * 0xDC + 0x18], 8);
+            body += compatLen;
+
+            memcpy(body, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x18), 8);
 
             unsigned int statWord = __lwbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x24);
-            memcpy(compatBody + compatLen + 8, &statWord, sizeof(statWord));
+            memcpy(body + 8, &statWord, sizeof(statWord));
 
-            const int byteLen = compatLen + 0xA3;
-
-            int wordCount = MakeJoyData((char*)payload, byteLen, (unsigned int*)(void*)(m_joyDataPacketBuffer[threadParam->m_portIndex] + 2));
+            int wordCount = MakeJoyData((char*)payload, byteLen + 0xC, (unsigned int*)(void*)(m_joyDataPacketBuffer[threadParam->m_portIndex] + 2));
 
             if (wordCount < 0)
             {

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -241,7 +241,7 @@ JoyBus::~JoyBus()
  * Address:	TODO
  * Size:	TODO
  */
-void JoyBus::CreateInit()
+inline void JoyBus::Init()
 {
     memset(m_sendBuffer, 0, sizeof(m_sendBuffer));
     memset(m_stageFlags, 0, sizeof(m_stageFlags));
@@ -276,6 +276,16 @@ void JoyBus::CreateInit()
             m_stateFlagArr[i] = zeroB;
         }
     }
+}
+
+/*
+ * --INFO--
+ * Address:	TODO
+ * Size:	TODO
+ */
+void JoyBus::CreateInit()
+{
+    Init();
 
     if (m_gbaBootImage == 0)
     {
@@ -401,39 +411,7 @@ void JoyBus::Destroy()
         }
     }
 
-    memset(m_sendBuffer, 0, sizeof(m_sendBuffer));
-    memset(m_stageFlags, 0, sizeof(m_stageFlags));
-    memset(m_cmdQueueData, 0, sizeof(m_cmdQueueData));
-    memset(m_recvQueueEntriesArr, 0, sizeof(m_recvQueueEntriesArr));
-    memset(m_threadParams, 0, sizeof(m_threadParams));
-    memset(m_perThreadTemp, 0, sizeof(m_perThreadTemp));
-    memset(m_recvBuffer, 0, sizeof(m_recvBuffer));
-
-    m_mapId = 0xFF;
-    m_stageId = 0xFF;
-
-    {
-        int i = 0;
-        unsigned char zeroB = (unsigned char)i;
-        unsigned int zeroW = (unsigned int)i;
-
-        for (; i < 4; i++)
-        {
-            m_threadParams[i].m_gbaStatus = 1;
-            m_threadParams[i].m_padType = 0x40;
-
-            m_cmdCount[i] = zeroW;
-            m_secCmdCount[i] = zeroW;
-
-            OSInitSemaphore(&m_accessSemaphores[i], 1);
-
-            m_ctrlModeArr[i] = zeroB;
-            m_nextModeTypeArr[i] = zeroB;
-            m_modeXArr[i] = zeroB;
-            m_stateCodeArr[i] = 0xFF;
-            m_stateFlagArr[i] = zeroB;
-        }
-    }
+    Init();
 
     m_fileBaseA_dup = 0;
     m_fileBaseB_dup = 0;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -581,6 +581,7 @@ void JoyBus::ThreadMain(void* arg)
     unsigned int localBuf;
     unsigned int localWord;
     unsigned int localCmd;
+    unsigned int hitInfo;
     unsigned short localCrc[2];
 
     threadParam->m_gbaStatus = GBAReset(threadParam->m_portIndex, &threadParam->m_unk3);
@@ -1076,7 +1077,7 @@ timeout_expiry:
 
                 if ((int)GbaQue.GetChgHitFlg(threadParam->m_portIndex) != 0)
                 {
-                    unsigned int hitInfo = GbaQue.GetHitEInfo(threadParam->m_portIndex);
+                    hitInfo = GbaQue.GetHitEInfo(threadParam->m_portIndex);
                     if (SendHitEnemy(threadParam->m_portIndex, (char)reinterpret_cast<short*>(&hitInfo)[0],
                                      reinterpret_cast<short*>(&hitInfo)[1]) < 0)
                     {
@@ -1216,8 +1217,8 @@ timeout_expiry:
 
             if ((int)GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
             {
-                localBuf = GbaQue.GetMoney(threadParam->m_portIndex);
-                if (SetMoney(threadParam->m_portIndex, localBuf) == 0)
+                localWord = GbaQue.GetMoney(threadParam->m_portIndex);
+                if (SetMoney(threadParam->m_portIndex, localWord) == 0)
                 {
                     GbaQue.ClrMoneyFlg(threadParam->m_portIndex);
                 }
@@ -1287,8 +1288,8 @@ timeout_expiry:
 
             if ((int)GbaQue.GetMoneyFlg(threadParam->m_portIndex) == 1)
             {
-                localBuf = GbaQue.GetMoney(threadParam->m_portIndex);
-                if (SetMoney(threadParam->m_portIndex, localBuf) == 0)
+                localWord = GbaQue.GetMoney(threadParam->m_portIndex);
+                if (SetMoney(threadParam->m_portIndex, localWord) == 0)
                 {
                     GbaQue.ClrMoneyFlg(threadParam->m_portIndex);
                 }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6862,12 +6862,11 @@ void JoyBus::RestartThread()
 
         OSResumeThread(threadCursor->m_threads);
 
-        int bit = 1 << i;
+        Joybus.m_threadRunningMask |= (1 << i);
         i = i + 1;
-        Joybus.m_threadRunningMask |= bit;
 
-        threadCursor = (JoyBus*)((char*)threadCursor + sizeof(Joybus.m_threads[0]));
         paramCursor = (JoyBus*)((char*)paramCursor + sizeof(Joybus.m_threadParams[0]));
+        threadCursor = (JoyBus*)((char*)threadCursor + sizeof(Joybus.m_threads[0]));
     } while ((int)i < 4);
 
     if ((unsigned int)System.m_execParam >= 2)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3108,7 +3108,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
                 }
                 else
                 {
-                    ThreadParam* tp = &m_threadParams[threadParam->m_portIndex];
+                    JoyBus* jb = (JoyBus*)((char*)this + threadParam->m_portIndex * sizeof(ThreadParam));
 
                     unsigned int resendCmd = 0;
                     unsigned char* resendBytes = reinterpret_cast<unsigned char*>(&resendCmd);
@@ -3116,7 +3116,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
                     resendBytes[1] = 0x15;
                     resendBytes[2] = 0;
 
-                    SetSendQueue(tp, resendCmd);
+                    SetSendQueue(jb->m_threadParams, resendCmd);
 
                     {
                         OSSemaphore* sem;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4498,9 +4498,8 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             signed char* p = (signed char*)&playerInfo;
             unsigned char* cf = classFlags;
             unsigned char lowBits = 0;
-            unsigned char highBits = 0;
 
-            for (int count = 0; count < 4; count++)
+            for (int highBits = 0; highBits < 4; highBits++)
             {
                 if (p[0x16] != 0)
                 {
@@ -4517,7 +4516,6 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
                 p        += 0xDC;
                 lowBits  += 0x10;
-                highBits += 1;
             }
 
             memcpy(&body[0x80], classFlags, sizeof(classFlags));

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3151,11 +3151,15 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             {
                 unsigned char op = (unsigned char)(*(unsigned char*)&m_cmdQueueData[threadParam->m_portIndex][i] & kJoyBusCmdOpMask);
 
-                if (op == 0x0A || op == 0x10 || op == 0x14 ||
-                    op == 0x1B || op == 0x13 || op == 0x09)
-                {
-                    m_recvQueueEntriesArr[threadParam->m_portIndex][newCount++] = m_cmdQueueData[threadParam->m_portIndex][i];
-                }
+                if (op == 0x0A) goto keep_a;
+                if (op == 0x10) goto keep_a;
+                if (op == 0x14) goto keep_a;
+                if (op == 0x1B) goto keep_a;
+                if (op == 0x13) goto keep_a;
+                if (op != 0x09) goto skip_a;
+            keep_a:
+                m_recvQueueEntriesArr[threadParam->m_portIndex][newCount++] = m_cmdQueueData[threadParam->m_portIndex][i];
+            skip_a:;
             }
 
             for (i = 0; i < 0x20; ++i)
@@ -3195,11 +3199,15 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
             {
                 unsigned char op = (unsigned char)(*(unsigned char*)&m_cmdQueueData[threadParam->m_portIndex][i] & kJoyBusCmdOpMask);
 
-                if (op == 0x0A || op == 0x10 || op == 0x14 ||
-                    op == 0x1B || op == 0x13 || op == 0x09)
-                {
-                    m_recvQueueEntriesArr[threadParam->m_portIndex][newCount++] = m_cmdQueueData[threadParam->m_portIndex][i];
-                }
+                if (op == 0x0A) goto keep_b;
+                if (op == 0x10) goto keep_b;
+                if (op == 0x14) goto keep_b;
+                if (op == 0x1B) goto keep_b;
+                if (op == 0x13) goto keep_b;
+                if (op != 0x09) goto skip_b;
+            keep_b:
+                m_recvQueueEntriesArr[threadParam->m_portIndex][newCount++] = m_cmdQueueData[threadParam->m_portIndex][i];
+            skip_b:;
             }
 
             for (i = 0; i < 0x20; ++i)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4536,7 +4536,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             memcpy(&body[0x8D], &playerData[threadParam->m_portIndex * 0xDC + 0x20], 3);
 
-            unsigned short statHalf = __lhbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x14], 0);
+            unsigned short statHalf = __lhbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x14);
             memcpy(&body[0x90], &statHalf, 2);
 
             unsigned char* compatBody = &body[0x92];
@@ -4545,7 +4545,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             memcpy(compatBody + compatLen, &playerData[threadParam->m_portIndex * 0xDC + 0x18], 8);
 
-            unsigned int statWord = __lwbrx(&playerData[threadParam->m_portIndex * 0xDC + 0x24], 0);
+            unsigned int statWord = __lwbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x24);
             memcpy(compatBody + compatLen + 8, &statWord, sizeof(statWord));
 
             const int byteLen = compatLen + 0xA3;
@@ -4608,7 +4608,7 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
     {
         m_txWordIndex[threadParam->m_portIndex]++;
 
-        if (m_txWordCount[threadParam->m_portIndex] <= m_txWordIndex[threadParam->m_portIndex])
+        if (m_txWordIndex[threadParam->m_portIndex] >= m_txWordCount[threadParam->m_portIndex])
         {
             GbaQue.ClrCompatibilityFlg(threadParam->m_portIndex);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6837,11 +6837,11 @@ void JoyBus::RestartThread()
 
     memset(Joybus.m_threadParams, 0, sizeof(Joybus.m_threadParams));
 
-    unsigned int i = 0;
+    unsigned int i;
     JoyBus* paramCursor = &Joybus;
 
-    Joybus.m_threadInitFlag = 0;
-    Joybus.m_threadRunningMask = 0;
+    Joybus.m_threadInitFlag = i = 0;
+    Joybus.m_threadRunningMask = i;
 
     JoyBus* threadCursor = paramCursor;
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5156,10 +5156,7 @@ int JoyBus::SendMType(ThreadParam* threadParam, int modeType)
 
     result = SetSendQueue(threadParam, word);
 
-    if (result != 0)
-	{
-        return result;
-	}
+    if (result != 0) goto out;
 
     m_modeXArr[threadParam->m_portIndex] = m_nextModeTypeArr[threadParam->m_portIndex];
     m_nextModeTypeArr[threadParam->m_portIndex] = (unsigned char)modeType;
@@ -5173,6 +5170,7 @@ int JoyBus::SendMType(ThreadParam* threadParam, int modeType)
         m_ctrlModeArr[threadParam->m_portIndex] = 1;
 	}
 
+out:
     return result;
 }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4532,23 +4532,24 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             body[0x8B] = playerData[0x2AB];
             body[0x8C] = playerData[threadParam->m_portIndex * 0xDC + 2];
 
-            body += 0x8D;
-            memcpy(body, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x20), 3);
+            unsigned char* q = body + 0x8D;
+            memcpy(q, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x20), 3);
 
             unsigned short statHalf = __lhbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x14);
-            memcpy(body + 3, &statHalf, 2);
+            memcpy(q + 3, &statHalf, 2);
 
-            body += 5;
+            q += 5;
 
-            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, body);
+            int compatLen = GbaQue.GetCompatibility(threadParam->m_portIndex, q);
+
+            q += compatLen;
+
             const int byteLen = compatLen + 0x97;
 
-            body += compatLen;
-
-            memcpy(body, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x18), 8);
+            memcpy(q, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x18), 8);
 
             unsigned int statWord = __lwbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x24);
-            memcpy(body + 8, &statWord, sizeof(statWord));
+            memcpy(q + 8, &statWord, sizeof(statWord));
 
             int wordCount = MakeJoyData((char*)payload, byteLen + 0xC, (unsigned int*)(void*)(m_joyDataPacketBuffer[threadParam->m_portIndex] + 2));
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6904,7 +6904,6 @@ int JoyBus::SendUseItem(int portIndex, char itemId)
  */
 int JoyBus::SendHitEnemy(int portIndex, char enemyId, short hitValue)
 {
-    unsigned int result = 0;
     unsigned short hit = hitValue;
     unsigned int cmd = 0;
     unsigned char* cmdBytes = reinterpret_cast<unsigned char*>(&cmd);
@@ -6912,27 +6911,8 @@ int JoyBus::SendHitEnemy(int portIndex, char enemyId, short hitValue)
     cmdBytes[0] = 0x22;
     cmdBytes[1] = enemyId;
     *reinterpret_cast<unsigned short*>(cmdBytes + 2) = __lhbrx(&hit, 0);
-    unsigned int word = cmd;
 
-    if (static_cast<signed char>(m_threadRunningMask) == 0) {
-        return result;
-    }
-
-    OSWaitSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-
-    unsigned int port = m_threadParams[portIndex].m_portIndex;
-    if (static_cast<int>(m_cmdCount[port]) >= 0x40) {
-        OSSignalSemaphore(&m_accessSemaphores[port]);
-        result = 0xFFFFFFFF;
-    } else {
-        m_cmdQueueData[port][m_cmdCount[port]] = word;
-        port = m_threadParams[portIndex].m_portIndex;
-        m_cmdCount[port]++;
-        OSSignalSemaphore(&m_accessSemaphores[m_threadParams[portIndex].m_portIndex]);
-        result = 0;
-    }
-
-    return result;
+    return SetSendQueue(&m_threadParams[portIndex], cmd);
 }
 
 /*

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5070,29 +5070,7 @@ int JoyBus::SendFavorite(ThreadParam* threadParam)
             unsigned int port = threadParam->m_portIndex;
             unsigned int word = *(unsigned int*)&m_joyDataPacketBuffer[port][2 + m_txWordIndex[port] * 4];
 
-            if (static_cast<signed char>(m_threadRunningMask) == 0)
-            {
-                result = 0;
-            }
-            else
-            {
-                OSWaitSemaphore(&m_accessSemaphores[port]);
-
-                port = threadParam->m_portIndex;
-                if ((int)m_cmdCount[port] >= 0x40)
-                {
-                    OSSignalSemaphore(&m_accessSemaphores[port]);
-                    result = -1;
-                }
-                else
-                {
-                    m_cmdQueueData[port][m_cmdCount[port]] = word;
-                    m_cmdCount[threadParam->m_portIndex]++;
-
-                    OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
-                    result = 0;
-                }
-            }
+                result = SetSendQueue(threadParam, word);
 
             threadParam->m_subState = (unsigned char)(threadParam->m_subState + 1);
 
@@ -5103,29 +5081,7 @@ int JoyBus::SendFavorite(ThreadParam* threadParam)
         unsigned int port = threadParam->m_portIndex;
         unsigned int word = *(unsigned int*)&m_joyDataPacketBuffer[port][2 + m_txWordIndex[port] * 4];
 
-        if (static_cast<signed char>(m_threadRunningMask) == 0)
-        {
-            result = 0;
-        }
-        else
-        {
-            OSWaitSemaphore(&m_accessSemaphores[port]);
-
-            port = threadParam->m_portIndex;
-            if ((int)m_cmdCount[port] >= 0x40)
-            {
-                OSSignalSemaphore(&m_accessSemaphores[port]);
-                result = -1;
-            }
-            else
-            {
-                m_cmdQueueData[port][m_cmdCount[port]] = word;
-                m_cmdCount[threadParam->m_portIndex]++;
-
-                OSSignalSemaphore(&m_accessSemaphores[threadParam->m_portIndex]);
-                result = 0;
-            }
-        }
+        result = SetSendQueue(threadParam, word);
 
         break;
     }


### PR DESCRIPTION
Raises main/joybus from 98.28% to 98.99% (+0.71).

## Key recoveries
- **Recovered inlined `JoyBus::Init()`** — the identical memsets+port-loop block in CreateInit/Destroy was a real helper (declared in the header, never defined); defining it inline and calling from both pushed CreateInit to **100%** and Destroy to **99.4%** (+0.12 unit in one edit).
- **Cracked the "result-in-rN wall"**: SendHitEnemy (92.1 -> **100%**), SetMoney, SendFavorite, SendCompatibility were open-coded copies of `SetSendQueue`; restoring the real call (auto-inlined by `-inline auto,deferred`) reproduces the target's return junctions (R40).
- **Real bugs found vs DOL** (R16/R30 family): ThreadMain reset wrote `m_subState` instead of `m_pposCounter`; case 0x3B was missing `m_stateFlagArr[port] = 0`; SendPlayerStat/SendPpos comparison operand order; `m_stateFlagArr` is `char` (signed extsb tests); `GetRadarType` returns `int`.
- **Idioms**: `__lhbrx/__lwbrx(base, offset)` two-arg form (SendPlayerStat +1.6 on fn); advancing payload cursors (R19) in SendPlayerStat/SendBonusStr; if-goto dispatch chains in GBARecvSend/SendDataFile (defeats range-merge, +0.065/+0.024); `JoyBus*` cursor idiom for inlined SetSendQueue sites (GBARecvSend/SetCtrlMode); RestartThread chained `i`/flag zero inits (R64); SendResult ternary -> 100%.

## Per-function (sub-100 worst, before -> after)
- SendHitEnemy 92.06 -> 100, CreateInit 96.05 -> 100, SendResult 97.38 -> 100
- Destroy 93.40 -> 99.42, SendFavorite 97.51 -> ~99.6, SetMoney 96.74 -> 98.35
- GBARecvSend 94.92 -> 97.20, SendPlayerStat 93.94 -> 96.88, SendDataFile 96.59 -> 97.58
- SendPpos 96.40 -> 98.21, SendBonusStr 97.71 -> 98.22, SetCtrlMode 96.15 -> 97.76
- RestartThread 92.08 -> 92.91, ThreadMain 99.07 -> 99.4+

## Walls (confirmed, not ground)
- LoadBin/RestartThread checksum tail: target's guarded 1-trip `mtctr` remainder loop needs an opaque idx that no source spelling reproduces (ternary/chain/loop-regen all tested).
- SendMapObjDrawFlg `beq .+8; b` junction refolds under every goto/junction-temp spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)