### PR TITLE
p_graphic: raise fuzzy match to 96.9% (cycle 19)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -640,6 +640,15 @@ void CGraphicPcs::drawCopy()
  * JP Address: TODO
  * JP Size: TODO
  */
+static inline void setBarColor(GXColor& dst, const u32& colorWord)
+{
+    const GXColor* src = (const GXColor*)&colorWord;
+    dst.r = src->r;
+    dst.g = src->g;
+    dst.b = src->b;
+    dst.a = src->a;
+}
+
 void CGraphicPcs::drawBar()
 {
     Mtx44 ortho;
@@ -704,13 +713,8 @@ void CGraphicPcs::drawBar()
     for (; i < orderCount; i++) {
         const int priority = order->m_priority;
         const float lastTime = order->m_lastTime;
-        GXColor colorTmp;
-        *reinterpret_cast<u32*>(&colorTmp) = Math.Hsb2Rgb(hue / orderCount, 100, 100);
+        setBarColor(barColor, Math.Hsb2Rgb(hue / orderCount, 100, 100));
         const float width = (kGraphicScreenCenterX * lastTime) / kDebugBarFrameBudget;
-        barColor.r = colorTmp.r;
-        barColor.g = colorTmp.g;
-        barColor.b = colorTmp.b;
-        barColor.a = colorTmp.a;
 
         if (priority == 0x26) {
             drawSFRect(x, textFlag ? static_cast<float>(static_cast<int>(y)) : kDebugBarMoveBottom,
@@ -723,12 +727,7 @@ void CGraphicPcs::drawBar()
         }
 
         if (i == orderCount - 1) {
-            GXColor soundGX;
-            *reinterpret_cast<u32*>(&soundGX) = Math.Hsb2Rgb(0, 100, 100);
-            barColor.r = soundGX.r;
-            barColor.g = soundGX.g;
-            barColor.b = soundGX.b;
-            barColor.a = soundGX.a;
+            setBarColor(barColor, Math.Hsb2Rgb(0, 100, 100));
             const float soundWidth = (kGraphicScreenCenterX * Sound.GetPerformance()) / kDebugBarFrameBudget;
 
             drawSFRect(x, textFlag ? static_cast<float>(static_cast<int>(y)) : kDebugBarMoveBottom,
@@ -740,20 +739,10 @@ void CGraphicPcs::drawBar()
         y += kDebugBarLineStep;
     }
 
-    GXColor frameTmp;
-    *reinterpret_cast<u32*>(&frameTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFrameRateOver() != 0) ? CColor(0xFF, 0, 0, 0xFF) : CColor(0, 0xFF, 0, 0xFF)).color);
-    barColor.r = frameTmp.r;
-    barColor.g = frameTmp.g;
-    barColor.b = frameTmp.b;
-    barColor.a = frameTmp.a;
+    setBarColor(barColor, (u32)*reinterpret_cast<u32*>(&((Graphic.IsFrameRateOver() != 0) ? CColor(0xFF, 0, 0, 0xFF) : CColor(0, 0xFF, 0, 0xFF)).color));
     drawSFRect(kDebugBarLeft, kDebugIndicatorTop, kDebugIndicatorFrameRight, kDebugIndicatorBottom, barColor, barColor);
 
-    GXColor fifoTmp;
-    *reinterpret_cast<u32*>(&fifoTmp) = *reinterpret_cast<u32*>(&((Graphic.IsFifoOver() != 0) ? CColor(0xFF, 0, 0, 0xFF) : CColor(0, 0xFF, 0, 0xFF)).color);
-    barColor.r = fifoTmp.r;
-    barColor.g = fifoTmp.g;
-    barColor.b = fifoTmp.b;
-    barColor.a = fifoTmp.a;
+    setBarColor(barColor, (u32)*reinterpret_cast<u32*>(&((Graphic.IsFifoOver() != 0) ? CColor(0xFF, 0, 0, 0xFF) : CColor(0, 0xFF, 0, 0xFF)).color));
     drawSFRect(kDebugIndicatorFifoLeft, kDebugIndicatorTop, kDebugIndicatorFifoRight, kDebugIndicatorBottom, barColor, barColor);
 
     if (textFlag) {

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -761,8 +761,9 @@ void CGraphicPcs::drawBar()
 
         order = System.GetFirstOrder();
         x = kDebugBarLeft;
+        int i = 0;
         y = 0x10;
-        for (int i = 0; i < orderCount; i++) {
+        for (; i < orderCount; i++) {
             const int priority = order->m_priority;
             const float width = (kGraphicScreenCenterX * order->m_lastTime) / kDebugBarFrameBudget;
 

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -681,8 +681,9 @@ void CGraphicPcs::drawBar()
     _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
     _GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
 
-    int drawText = 0;
-    bool useDebugPad = false;
+    int drawText;
+    bool useDebugPad;
+    useDebugPad = drawText = 0;
     if ((Pad.m_debugPadLock != 0) || (Pad.m_debugPadPort != -1)) {
         useDebugPad = true;
     }

--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -911,14 +911,7 @@ void CGraphicPcs::drawBegin()
  */
 void CGraphicPcs::calc()
 {
-    for (int i = 0; i < 4; i++) {
-        if (m_screenFade[i].m_timer > 0 && i != 1) {
-            m_screenFade[i].m_timer--;
-            if (m_screenFade[i].m_timer == 0) {
-                m_screenFade[i].m_targetObj = 0;
-            }
-        }
-    }
+    calcScreenFade();
 }
 
 /*


### PR DESCRIPTION
Raises main/p_graphic from 96.83% to 96.89% (+0.06).

Per-function gains:
- calc: 98.7 -> 100% — original called the inline calcScreenFade() helper instead of open-coding the loop (R65 inlined-helper recovery)
- drawBar: 96.81 -> 96.93% — three fixes:
  - const-ref setBarColor(GXColor&, const u32&) inline helper: binding the Hsb2Rgb/CColor color words to a const-ref param materializes them as call-site anonymous staging temps, matching the target stack-slot interleave (R41/R24)
  - chained useDebugPad = drawText = 0 init defeats constprop (R64), recovering the deferred copy
  - second debug-text loop: i-before-y init order re-ranks the order/y callee-saved window (R70)

Remaining residuals are bit-identical-under-all-spellings volatile FPR pair swaps (zero/width, t/fadeWave, rect constant bands) — gxfunc-c7 tie-break wall signature; ~15 structural levers each verified bit-identical or regressing. __sinit (48.4%) is the known data.0 base-CSE wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)