### PR TITLE
gobjwork: raise fuzzy match to 98.1% (cycle 21)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -466,7 +466,7 @@ void CCaravanWork::FGLetterOpen(int letterIdx)
 
 	int gil;
 	if (letter->AttachmentIsGil()) {
-		gil = letter->AttachmentValue() * 100;
+		gil = m_letters[letterIdx].AttachmentValue() * 100;
 	} else {
 		gil = 0;
 	}


### PR DESCRIPTION
## Summary
- **main/gobjwork: 98.01% -> 98.06%** (FGLetterOpen 86.51 -> 89.81)
- FGLetterOpen: spelled the post-call gil-attachment access as a direct `m_letters[letterIdx]` member expression instead of going through the `letter` pointer macro. This extends the `letterIdx*12` CSE temp's live range across the SystemCall, reproducing the target's extra callee-saved register (the c20 "dead mulli in r29" wall) — confirming the wall's root cause is a mixed pointer-local/direct-member spelling in the original.

## Wall verification (c20 open hypothesis follow-ups, all measured)
- `-inline auto,deferred` cflag (R65): does NOT touch FGLetterOpen/GetNextCmdListIdx and breaks 4 other functions (unit -2.4). No letter/cmd-list accessor methods exist in the target's 61-symbol set.
- Full CSE-unified FGLetterOpen form (signed `*12` multiply) reproduces the target's exact single-mulli structure but leaves a 3-register role permutation (mul/sum/this across r29-r31) that is bit-identical under naming, decl-split, decl-order, register-keyword and reference-local levers — true-wall signature, and it scores lower (83.2) than the mixed-spelling plateau (89.8).
- GetNextCmdListIdx / GetNumCombi / GetMagicCharge / DelCmdListAndItem / CalcStatus residuals are the same callee-saved/volatile rank permutation; game-ref, self-ref, local-copy, register hints, cond restructure, opt_common_subs off all bit-identical or negative.
- SearchRomLetterWork (94.4): target keeps loop-carried vars in volatiles descending from r9 with inner temps callee-saved (stmw r20 vs our r21). always_inline body-wrapper (R52) is refused by mwcc (goto/jumptable body emitted out-of-line); global_optimizer/scheduling/propagation/common_subs pragmas all regress; decl-placement sweeps negative. Walled.
- CMonWork::Init backupParam double-addi: volatile pointer, walk restructures, loop form, strength-reduction/propagation pragmas — bit-identical or negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)