### PR TITLE
memorycard: raise fuzzy match to 99.5% (cycle 11)

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1501,10 +1501,10 @@ void CMemoryCardMan::MakeSaveData()
     u32 soundModeBit = static_cast<u32>(__cntlzw(Sound.GetSoundMode())) >> 5;
     save[0x13DF] = static_cast<u8>((static_cast<u32>(-static_cast<s32>(soundModeBit)) | soundModeBit) >> 31);
     save[0x13E0] = MakeSaveBool(Game.m_gameWork.m_gameInitFlag);
-    save[0x13E1] = MakeSaveBool(Game.m_gameWork.m_spModeFlags[0]);
-    save[0x13E2] = MakeSaveBool(Game.m_gameWork.m_spModeFlags[1]);
-    save[0x13E3] = MakeSaveBool(Game.m_gameWork.m_spModeFlags[2]);
-    save[0x13E4] = MakeSaveBool(Game.m_gameWork.m_spModeFlags[3]);
+    save[0x13E1] = MakeSaveBool(g->m_gameWork.m_spModeFlags[0]);
+    save[0x13E2] = MakeSaveBool(g->m_gameWork.m_spModeFlags[1]);
+    save[0x13E3] = MakeSaveBool(g->m_gameWork.m_spModeFlags[2]);
+    save[0x13E4] = MakeSaveBool(g->m_gameWork.m_spModeFlags[3]);
 
     for (int c = 0; c < 8; c++)
     {

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1508,8 +1508,8 @@ void CMemoryCardMan::MakeSaveData()
 
     for (int c = 0; c < 8; c++)
     {
-        u8* dst = save + 0x14D0 + c * 0x9C0;
         CCaravanWork* caravanWork = &Game.m_caravanWorkArr[c];
+        u8* dst = save + 0x14D0 + c * 0x9C0;
 
         int shopState = caravanWork->m_shopState;
         if (shopState != 0 && static_cast<s8>(caravanWork->unk_0xc1e) == 0)

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -590,41 +590,13 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
         memcpy(dstCharData + 0xBC, srcCharData + 0xBC, 0x0C);
 
         u8* srcWork = reinterpret_cast<u8*>(&srcSave) + (srcChar << 9) + (srcChar << 3);
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < 8; i++)
         {
-            srcWork[0xC0] = 0;
-            srcWork[0xC1] = 0;
-            srcWork[0xC2] = 0;
-            srcWork[0xC3] = 0;
-            srcWork[0xC4] = 0;
-            srcWork[0xC5] = 0;
-            srcWork[0xC6] = 0;
-            srcWork[0xC7] = 0;
-            srcWork[0x100] = 0;
-            srcWork[0x101] = 0;
-            srcWork[0x102] = 0;
-            srcWork[0x103] = 0;
-            srcWork[0x104] = 0;
-            srcWork[0x105] = 0;
-            srcWork[0x106] = 0;
-            srcWork[0x107] = 0;
-            srcWork[0x140] = 0;
-            srcWork[0x141] = 0;
-            srcWork[0x142] = 0;
-            srcWork[0x143] = 0;
-            srcWork[0x144] = 0;
-            srcWork[0x145] = 0;
-            srcWork[0x146] = 0;
-            srcWork[0x147] = 0;
-            srcWork[0x180] = 0;
-            srcWork[0x181] = 0;
-            srcWork[0x182] = 0;
-            srcWork[0x183] = 0;
-            srcWork[0x184] = 0;
-            srcWork[0x185] = 0;
-            srcWork[0x186] = 0;
-            srcWork[0x187] = 0;
-            srcWork += 0x100;
+            for (int j = 0; j < 8; j++)
+            {
+                srcWork[0xC0 + j] = 0;
+            }
+            srcWork += 0x40;
         }
 
         dstCharData[0x8C0] = 0;

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1508,8 +1508,9 @@ void CMemoryCardMan::MakeSaveData()
 
     for (int c = 0; c < 8; c++)
     {
-        CCaravanWork* caravanWork = &Game.m_caravanWorkArr[c];
+        int letter;
         u8* dst = save + 0x14D0 + c * 0x9C0;
+        CCaravanWork* caravanWork = &Game.m_caravanWorkArr[c];
 
         int shopState = caravanWork->m_shopState;
         if (shopState != 0 && static_cast<s8>(caravanWork->unk_0xc1e) == 0)
@@ -1556,7 +1557,7 @@ void CMemoryCardMan::MakeSaveData()
         *reinterpret_cast<u32*>(dst + 0x100) = caravanWork->m_letterCount;
         letterSrc = reinterpret_cast<u8*>(caravanWork);
         letterDst = dst;
-        for (int letter = 0; letter < 100; letter++)
+        for (letter = 0; letter < 100; letter++)
         {
             reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->FlagsBits().m_attachmentIsGil =
                 reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->FlagsBits().m_attachmentIsGil;

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -237,6 +237,11 @@ static inline u32* GetSaveEncodedWords(Mc::SaveDat* save)
     return &save->m_random;
 }
 
+static inline u32 LoadSwapped(u32* p)
+{
+    return __lwbrx(p, 0);
+}
+
 static inline void EncodeSaveData(char* saveBuffer)
 {
     Mc::SaveDat* const save = GetSaveDat(saveBuffer);
@@ -246,19 +251,19 @@ static inline void EncodeSaveData(char* saveBuffer)
     for (int count = 0; count < 0x5B6; count++)
     {
         u32 rotated = __rlwnm(ptr[0], rotAmount, 0, 31);
-        ptr[0] = __lwbrx(&rotated, 0);
+        ptr[0] = LoadSwapped(&rotated);
         rotated = __rlwnm(ptr[1], rotAmount, 0, 31);
-        ptr[1] = __lwbrx(&rotated, 0);
+        ptr[1] = LoadSwapped(&rotated);
         rotated = __rlwnm(ptr[2], rotAmount, 0, 31);
-        ptr[2] = __lwbrx(&rotated, 0);
+        ptr[2] = LoadSwapped(&rotated);
         rotated = __rlwnm(ptr[3], rotAmount, 0, 31);
-        ptr[3] = __lwbrx(&rotated, 0);
+        ptr[3] = LoadSwapped(&rotated);
         rotated = __rlwnm(ptr[4], rotAmount, 0, 31);
-        ptr[4] = __lwbrx(&rotated, 0);
+        ptr[4] = LoadSwapped(&rotated);
         rotated = __rlwnm(ptr[5], rotAmount, 0, 31);
-        ptr[5] = __lwbrx(&rotated, 0);
+        ptr[5] = LoadSwapped(&rotated);
         rotated = __rlwnm(ptr[6], rotAmount, 0, 31);
-        ptr[6] = __lwbrx(&rotated, 0);
+        ptr[6] = LoadSwapped(&rotated);
         ptr += 7;
     }
 }
@@ -272,19 +277,19 @@ static inline void DecodeSaveData(char* saveBuffer)
     for (int count = 0; count < 0x5B6; count++)
     {
         u32 word = ptr[0];
-        ptr[0] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[0] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         word = ptr[1];
-        ptr[1] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[1] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         word = ptr[2];
-        ptr[2] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[2] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         word = ptr[3];
-        ptr[3] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[3] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         word = ptr[4];
-        ptr[4] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[4] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         word = ptr[5];
-        ptr[5] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[5] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         word = ptr[6];
-        ptr[6] = __rlwnm(__lwbrx(&word, 0), rotAmount, 0, 31);
+        ptr[6] = __rlwnm(LoadSwapped(&word), rotAmount, 0, 31);
         ptr += 7;
     }
 }


### PR DESCRIPTION
Raises main/memorycard from 98.86% to 99.47% (+0.61).

Per-function gains:
- DecodeData 95.19 -> 100: introduced `LoadSwapped(u32*)` inline helper for the `__lwbrx` byte-swap — the helper's param web takes rank over the saveBuffer web, fixing the whole r3/r4/r5/r6 register rotation.
- EncodeData 95.29 -> 100: same helper applied to the encode loop (also nudged MakeSaveData's inlined copy).
- MakeSaveData 97.20 -> 98.94: caravanWork decl before dst in the caravan loop (dst lands in r22); spModeFlags spelled via `g` extends the Game web; letter/dst/caravanWork decl order maps the bottom callee-saved band (letter r23 > dst r22 > cw r21).
- Odekake 97.66 -> 98.97: de-garbled the x4-unrolled zero-store block back to the original nested 8x8 loop — mwcc's unroller regenerates the exact ctr=2 shape with the zero held in r3.

Remaining residuals (bit-identical under 30+ sweep variants, treated as walls): the staged serial/shop word-pair r0<->rN swap (3 sites), the saveDat/g/anchor callee-saved trio in MakeSaveData/SetLoadData, and the inlined CalcSaveCrc ptr/count volatile swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)