### PR TITLE
ME_USB_process: raise fuzzy match to 98.7% (cycle 8)

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -385,11 +385,11 @@ void CMaterialEditorPcs::SetUSBData()
 
             u8* tlutSrc;
             if (headerBuffer[1] == 4) {
-                tlutSrc = reinterpret_cast<u8*>(headerBuffer) + (headerBuffer[2] * headerBuffer[3]) / 2;
+                tlutSrc = reinterpret_cast<u8*>(headerBuffer + 8) + (headerBuffer[2] * headerBuffer[3]) / 2;
             } else {
-                tlutSrc = reinterpret_cast<u8*>(headerBuffer) + headerBuffer[2] * headerBuffer[3];
+                tlutSrc = reinterpret_cast<u8*>(headerBuffer + 8) + headerBuffer[2] * headerBuffer[3];
             }
-            memcpy(this->m_tlutData[this->m_loadedTextureCount], tlutSrc + 0x10, tlutDataSize);
+            memcpy(this->m_tlutData[this->m_loadedTextureCount], tlutSrc, tlutDataSize);
             DCFlushRange(this->m_tlutData[this->m_loadedTextureCount], tlutDataSize);
         }
 

--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -360,10 +360,11 @@ void CMaterialEditorPcs::SetUSBData()
             memcpy(this->m_textureData[this->m_loadedTextureCount], headerBuffer + 8, usb.m_sizeBytes - 0x10);
             DCFlushRange(this->m_textureData[this->m_loadedTextureCount], usb.m_sizeBytes - 0x10);
         } else if ((headerBuffer[1] == 4) || (headerBuffer[1] == 8)) {
+            CMemory& memory = Memory;
             int tlutEntries = headerBuffer[1] == 4 ? 0x10 : 0x100;
             int tlutDataSize = tlutEntries * 4;
             int imageDataSize = static_cast<int>(usb.m_sizeBytes) - 0x10 - tlutDataSize;
-            void* texData = Memory._Alloc(
+            void* texData = memory._Alloc(
                 imageDataSize, MaterialEditorStage(), const_cast<char*>(s_ME_USB_process_cpp), 0x31, 0);
 
             if (texData == 0) {


### PR DESCRIPTION
Raises main/ME_USB_process from 98.08% to 98.72% (+0.64), SetUSBData 98.06% -> 98.70%.

Two real source fixes in case 0x20 (texture upload):
- Bind a local CMemory& reference before the tlut-format ternary in the CI4/CI8 arm — matches the target's hoisted &Memory materialization ahead of the tlutEntries select (li 0x100/bne/li 0x10 ordering).
- Compute tlutSrc from `(u8*)(headerBuffer + 8) + pixelBytes` and memcpy it directly, instead of `(u8*)headerBuffer + pixelBytes` then `tlutSrc + 0x10` at the memcpy — matches the per-arm `add base,X; addi +0x10` shape (and the `headerBuffer + 8` idiom already used by the neighboring memcpys).

Remaining gap is the case-0x13 byte-swap loop register rotation (target IVs r23/r24 vs ours r25/r26 with the 21 hoisted swap-temp stack addresses shifted by two) plus matching volatile-window rotations in the case 0x10/0x12 float loops and case 0x31. ~30 source spellings (R77 intrinsic-wrapper nesting incl. the exact memorycard by-value form, R75/R36 decl orders, R64 chained init, strength-reduced offset, Vec-element indexing, while/do forms, scoped temps) all produce bit-identical objects — mwcc value-numbers every spelling to the same web set, the c7 wall verdict holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)