### PR TITLE
game: raise fuzzy match to 99.18% (cycle 13)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -167,20 +167,8 @@ inline int CGBaseObj::GetCID()
     return 1;
 }
 
-/*
- * --INFO--
- * PAL Address: 0x800161f0
- * PAL Size: 32b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
 template <>
-CMapLightHolder* CPtrArray<CMapLightHolder*>::operator[](unsigned long index)
-{
-    return GetAt(index);
-}
+CMapLightHolder* CPtrArray<CMapLightHolder*>::operator[](unsigned long index);
 
 /*
  * --INFO--
@@ -1748,4 +1736,19 @@ inline CGame::CGameWork::CGameWork()
     m_chaliceElement = 1;
     strcpy(m_townName, m_languageId == 3 ? s_townNameTepa : s_townNameTipa);
     m_gameInitFlag = 1;
+}
+
+/*
+ * --INFO--
+ * PAL Address: 0x800161f0
+ * PAL Size: 32b
+ * EN Address: TODO
+ * EN Size: TODO
+ * JP Address: TODO
+ * JP Size: TODO
+ */
+template <>
+CMapLightHolder* CPtrArray<CMapLightHolder*>::operator[](unsigned long index)
+{
+    return GetAt(index);
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1029,18 +1029,15 @@ void CGame::LoadInit()
  */
 static inline void loadPermanentScriptVars(char* scriptData)
 {
-    int scriptOffset = 0;
-    int entryOffset = 0;
+    int n = 0;
     int i = 0;
 
     while (i < CFlatPermanentVarCount()) {
-        int flagIndex = entryOffset + 1;
-        if ((CFlatPermanentVarDefs()[flagIndex] & 0x20) != 0) {
-            CFlatPermanentVarWord(entryOffset) = *reinterpret_cast<u32*>(scriptData + scriptOffset);
-            scriptOffset += 4;
+        if ((CFlatPermanentVarDefs()[i * 4 + 1] & 0x20) != 0) {
+            CFlatPermanentVarWord(i * 4) = reinterpret_cast<u32*>(scriptData)[n];
+            n++;
         }
 
-        entryOffset += 4;
         i++;
     }
 }


### PR DESCRIPTION
## Summary
- main/game: 99.1768% -> 99.1789% (+0.0021), LoadScript 85.71 -> 85.95
- **LoadScript**: rewrote the permanent-script-var copy loop in word-index form (`m_tStatus`-style `i * 4` offsets + `((u32*)scriptData)[n]`), matching the matched `CFlatRuntime::ClearParmanent` idiom and improving the derived-IV init (`li`/`mr` pair).
- **clearWork** (structural, score-neutral but plausibility-positive): moved the `CPtrArray<CMapLightHolder*>::operator[]` explicit specialization definition after its callers (its PAL address 0x800161f0 places it last in the original TU). With the body no longer visible before use, both call sites now emit `bl __vc...` exactly like the target instead of the forwarder-eliminated `bl GetAt...` (flagged lines 42 -> 40).

## Walls hit (bit-identical under all spellings, R-sweeps exhausted)
- LoadScript/SaveScript pointer-IV folding (`lwzx` fixed-base+index vs advancing pointer): resisted R77 helpers (by-value, by-ref, local-temp), `opt_strength_reduction off`, `global_optimizer off`, `-inline auto,deferred` (unit -3.3), chained init, member-method `this` emulation, and Ghidra ptr-temp shapes. Direct-body (no helper) regresses, confirming the helper structure.
- ChangeMap `cond ? mask : 0` or/srawi scratch swap: polarity, casts, unsigned consts, shared inlined helper (R24) all neutral or negative.
- clearWork/Calc/loadCfd/GetTargetCursor/GetBossArtifact callee-saved web rotations: R56 refs, R75 decl hoists, R70 web-start moves, R38 sum reassociation all bit-identical or regressions.
- Named sdata2 constants (kGamePartyBoundsMinInit/MaxInit, kGameIntToDoubleBias): R46 def-after-use is bit-identical — confirmed reloc-name-only cost (zero).
- `ble` vs `beq` on the unsigned GetSize guard: every polarity/type spelling canonicalizes to beq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)