### PR TITLE
cmake: raise fuzzy match to 98.65% (cycle 32)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2221,8 +2221,7 @@ int CMenuPcs::CmakeTribeCtrl()
                     return 1;
                 }
 
-                CmakeState(this)->m_fieldSelect = static_cast<short>(fieldSelect - 1);
-                return 0;
+                CmakeState(this)->m_fieldSelect = static_cast<short>(CmakeState(this)->m_fieldSelect - 1);
             }
         }
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1975,16 +1975,8 @@ void CMenuPcs::CmakeTribeDraw()
 
     DrawCmakePreviewChara(this);
 
-    _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-    MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
+    SetCmakeBlendMatColor(alpha);
     a255 = 255.0f * alpha;
-    GXColor col;
-    col.r = 0xFF;
-    col.g = 0xFF;
-    col.b = 0xFF;
-    col.a = static_cast<unsigned char>(a255);
-    GXSetChanMatColor(GX_COLOR0A0, col);
     MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x61 : 0x3A));
     float boxW = 416.0f;
     float boxH = 240.0f;
@@ -1998,15 +1990,7 @@ void CMenuPcs::CmakeTribeDraw()
     DrawCmakeTitle(3, alpha, 1.0f);
     {
         int tribe = CmakeState(this)->m_select;
-        _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
-        MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));
-
-        GXColor crestCol;
-        crestCol.r = 0xFF;
-        crestCol.g = 0xFF;
-        crestCol.b = 0xFF;
-        crestCol.a = static_cast<unsigned char>(a255);
-        GXSetChanMatColor(GX_COLOR0A0, crestCol);
+        SetCmakeBlendMatColor(alpha);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0x31));
         MenuPcs.DrawRect(
             0,

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -852,10 +852,13 @@ void CMenuPcs::CmakeVillageDraw()
     SetCmakeFontColor(font, alpha);
 
     int tableBase = table * 5;
-    for (int i = 0; i < 5; i++) {
-        const char* rowText = s_NameEntryStr[tableBase + i];
+    const char* rowText;
+    int i;
+    int y;
+    for (i = 0, y = 0x6C; i < 5; i++, y += 0x20) {
+        rowText = s_NameEntryStr[tableBase + i];
         font->SetPosX(240.0f);
-        font->SetPosY(static_cast<float>(0x6C + i * 0x20));
+        font->SetPosY(static_cast<float>(y));
         font->Draw(rowText);
     }
 

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3052,6 +3052,7 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
 
     font->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(alpha255)).color);
 
+    const char* noStr;
     const char* yesStr = GetMenuStr(1);
     float yesW = static_cast<float>(font->GetWidth(yesStr));
     int yesX = 0x1D0;
@@ -3061,7 +3062,7 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
     font->SetPosY(369.0f);
     font->Draw(yesStr);
 
-    const char* noStr = GetMenuStr(2);
+    noStr = GetMenuStr(2);
     float noW = static_cast<float>(font->GetWidth(noStr));
     int noX = 0x218;
     noX = static_cast<int>(

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -851,8 +851,8 @@ void CMenuPcs::CmakeVillageDraw()
     font->SetMargin(4.9f);
     SetCmakeFontColor(font, alpha);
 
-    int tableBase = table * 5;
     const char* rowText;
+    int tableBase = table * 5;
     int i;
     int y;
     for (i = 0, y = 0x6C; i < 5; i++, y += 0x20) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -487,6 +487,7 @@ static bool IsCmakeNameBlank(const char* name)
 
 static int IsDuplicateCmakeName(CMenuPcs* menu, const char* name)
 {
+    const char* nm = name;
     int found = false;
     unsigned char* entry = reinterpret_cast<unsigned char*>(&Game);
     for (int slot = 0; slot < 8; ++slot, entry += 0xC30) {
@@ -499,7 +500,7 @@ static int IsDuplicateCmakeName(CMenuPcs* menu, const char* name)
         if (*(entry + 0x1F96) == 1) {
             continue;
         }
-        if (strcmp(name, reinterpret_cast<char*>(entry + 0x17BA)) == 0) {
+        if (strcmp(nm, reinterpret_cast<char*>(entry + 0x17BA)) == 0) {
             found = true;
             break;
         }

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2528,6 +2528,7 @@ void CMenuPcs::CmakeNameDraw()
     }
 
     short table = CmakeState(this)->m_table;
+    int i;
     CFont* font = GetCmakeKeyboardFont(this);
     font->SetShadow(0);
     font->SetScale(1.0f);
@@ -2537,7 +2538,7 @@ void CMenuPcs::CmakeNameDraw()
     SetCmakeFontColor(font, alpha);
 
     int tableBase = table * 5;
-    for (int i = 0; i < 5; i++) {
+    for (i = 0; i < 5; i++) {
         const char* rowText = s_NameEntryStr[tableBase + i];
         font->SetPosX(240.0f);
         font->SetPosY(static_cast<float>(0x6C + i * 0x20));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2662,7 +2662,8 @@ int CMenuPcs::CmakeNameCtrl()
             }
             Sound.PlaySe(1, 0x40, 0x7F, 0);
         } else if ((repeat & 0x4) != 0) {
-            if (CmakeState(this)->m_row < (CmakeState(this)->m_select >= 10 ? 5 : 4)) {
+            short sel = CmakeState(this)->m_select;
+            if (CmakeState(this)->m_row < (sel >= 10 ? 5 : 4)) {
                 CmakeState(this)->m_row = static_cast<short>(CmakeState(this)->m_row + 1);
             } else {
                 CmakeState(this)->m_row = 0;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1533,9 +1533,7 @@ void CMenuPcs::CmakeResultDraw()
         } else if (i == 1) {
             value = GetMenuStr(static_cast<int>(s_CmakeInfo.m_gender) + 0x11);
         } else if (i == 2) {
-            value = GetTribeStr(static_cast<int>(s_CmakeInfo.m_tribe));
-
-            strcpy(tribeWithSlash, value);
+            strcpy(tribeWithSlash, GetTribeStr(static_cast<int>(s_CmakeInfo.m_tribe)));
             strcat(tribeWithSlash, "/", sizeof(tribeWithSlash));
             value = tribeWithSlash;
         } else {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2556,17 +2556,16 @@ void CMenuPcs::CmakeNameDraw()
         DrawCursor(cursorLeft, CmakeState(this)->m_row * 0x20 + 0x70, 1.0f);
     }
 
-    char* name = GetCmakeNameBuffer();
     int nameCursor = static_cast<int>(
         static_cast<unsigned int>(__cntlzw(static_cast<unsigned int>(1 - CmakeState(this)->m_mode))) >> 5);
     if (CmakeState(this)->m_row >= 5) {
         nameCursor = 0;
     }
-    unsigned int nameLen = strlen(name);
+    unsigned int nameLen = strlen(s_CmakeInfo.m_name);
     if (static_cast<int>(nameLen & (static_cast<int>(-nameLen | nameLen) >> 31)) >= 7) {
         nameCursor = 0;
     }
-    DrawCmakeName(0, nameCursor, name, alpha);
+    DrawCmakeName(0, nameCursor, s_CmakeInfo.m_name, alpha);
     DrawCmakeDecision((CmakeState(this)->m_row >= 5) ? 1 : 0, alpha);
 
     if (CmakeMcState(this) != 3) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1703,7 +1703,7 @@ void CMenuPcs::CmakeJobDraw()
         }
     }
 
-    DrawCmakePreviewChara(this);
+    DrawCmakePreviewCharaAlpha(this, 1.0f);
 
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
     MenuPcs.SetAttrFmt(static_cast<CMenuPcs::FMT>(0));

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1973,7 +1973,7 @@ void CMenuPcs::CmakeTribeDraw()
         }
     }
 
-    DrawCmakePreviewChara(this);
+    DrawCmakePreviewCharaAlpha(this, 1.0f);
 
     SetCmakeBlendMatColor(alpha);
     a255 = 255.0f * alpha;


### PR DESCRIPTION
Raises main/cmake from 98.47% to 98.65% (+0.18).

Per-function gains:
- CmakeNameDraw 96.81 -> 97.84: per-site `s_CmakeInfo.m_name` rematerialization instead of a cached `name` local (the single biggest win, +0.10 unit), plus `int i;` decl before `font` re-ranking the keyboard font-loop web.
- CmakeTribeCtrl 97.69 -> 98.80: `m_fieldSelect` reloaded from state (not the cached local) + fallthrough to the shared `return 0` tail instead of an explicit return (R76 return-path archaeology).
- CmakeVillageDraw 96.87 -> 96.94: explicit `y` IV in the font loop (`for (i=0,y=0x6C; ...; i++,y+=0x20)`) + `rowText` decl before `tableBase` — lands y/i/rowText/tableBase5 in the target registers.
- CmakeNameCtrl 97.05 -> 97.35: named `nm` copy of the dup-check name param; named `sel` load in the repeat&4 arm.
- CmakeTribeDraw 97.91 -> 97.97: both open-coded GXColor blocks replaced with `SetCmakeBlendMatColor(alpha)` calls (restores R41 inline-temp slot class) + flattened the `DrawCmakePreviewChara` wrapper (R41 nesting demotion).
- CmakeJobDraw 98.42 -> 98.44: same wrapper flatten.
- DrawCmakeYesNo 97.22 -> 97.29: `noStr` predecl at function top.
- CmakeResultDraw: `strcpy(buf, GetTribeStr(...))` direct nesting kills an `mr` junction.

What worked: per-site global remat over cached pointer locals, R76 fallthrough-vs-explicit-return mapping, R41 helper-call reconstruction + wrapper flattening, R75/R80-style decl re-ranking (direction differs per function — VillageDraw wants rowText/y demoted, NameDraw wants i promoted).

Confirmed walls (bit-identical or regressing under all spellings): preview-helper handleIndex r27-vs-r29 tie-break (4 sites), the `li 0xE5/0xC8/0x1D0` scratch-vs-home constant inits (propagation-off scoped pragma regresses each host function), the IsDuplicateCmakeName slot/found zero-CSE `mr`, the space-scan cursor `addi+mr` staging (NameCtrl/VillageCtrl), CalcSingCMake stwx-vs-add+stw addressing canonicalization, and the state-vs-select scratch inversion in the Ctrl arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)