### PR TITLE
joybus: raise fuzzy match to 99.06% (cycle 31)

### DIFF
--- a/include/ffcc/gbaque.h
+++ b/include/ffcc/gbaque.h
@@ -169,7 +169,7 @@ public:
     unsigned int GetMkSmithFlg(int);
     void ClrMkSmithFlg(int);
     void SetResetFlg(int);
-    unsigned char GetBonus(int);
+    int GetBonus(int);
     unsigned int GetArtifactFlg(int);
     void ClrArtifactFlg(int);
     int GetArtifactData(int, unsigned char*);

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -4147,11 +4147,11 @@ void GbaQueue::SetResetFlg(int channel)
  * JP Address: TODO
  * JP Size: TODO
  */
-unsigned char GbaQueue::GetBonus(int channel)
+int GbaQueue::GetBonus(int channel)
 {
 	char* compatibilityStr = reinterpret_cast<char*>(this) + 0x458;
 	OSWaitSemaphore(accessSemaphores + channel);
-	unsigned char value = static_cast<unsigned char>(compatibilityStr[channel * 0xDC + 0xCE]);
+	int value = static_cast<unsigned char>(compatibilityStr[channel * 0xDC + 0xCE]);
 	OSSignalSemaphore(accessSemaphores + channel);
 	return value;
 }

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5133,9 +5133,10 @@ void JoyBus::GetRecvBuffer(int playerIndex, unsigned char* outBuffer)
  */
 int JoyBus::SendMType(ThreadParam* threadParam, int modeType)
 {
+    unsigned int cmd = 0;
+
     ResetQueue(threadParam);
 
-    unsigned int cmd = 0;
     unsigned int cmd0 = 0;
     unsigned char* cmd0Bytes = reinterpret_cast<unsigned char*>(&cmd0);
     cmd0Bytes[0] = 0x10;

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5629,7 +5629,7 @@ int JoyBus::SendStrength(ThreadParam* threadParam)
 {
     unsigned int cmd = 0;
     unsigned char* cmdBytes = (unsigned char*)&cmd;
-    unsigned char strength[3];
+    unsigned char strength[0x10];
 
     GbaQue.GetStrengthData(threadParam->m_portIndex, strength);
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4870,7 +4870,6 @@ int JoyBus::SendCompatibility(ThreadParam* threadParam)
         break;
     }
     default:
-        result = 0;
         break;
     }
 
@@ -5067,7 +5066,6 @@ int JoyBus::SendFavorite(ThreadParam* threadParam)
         break;
     }
     default:
-        result = 0;
         break;
     }
 

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5015,7 +5015,7 @@ int JoyBus::SendMapObjDrawFlg(ThreadParam* threadParam)
  */
 int JoyBus::SendFavorite(ThreadParam* threadParam)
 {
-    int result = 0;
+    int result;
     unsigned char subState = threadParam->m_subState;
 
     switch (subState)

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4522,8 +4522,8 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             GbaQue.GetCaravanName((char*)body);
 
             signed char* p = (signed char*)&playerInfo;
-            unsigned char* cf = classFlags;
             unsigned char lowBits = 0;
+            unsigned char* cf = classFlags;
 
             for (int highBits = 0; highBits < 4; highBits++)
             {
@@ -4559,7 +4559,8 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
             body[0x8C] = playerData[threadParam->m_portIndex * 0xDC + 2];
 
             unsigned char* q = body + 0x8D;
-            memcpy(q, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x20), 3);
+            int statOffset = threadParam->m_portIndex * 0xDC;
+            memcpy(q, (unsigned char*)&playerInfo + statOffset + 0x20, 3);
 
             unsigned short statHalf = __lhbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x14);
             memcpy(q + 3, &statHalf, 2);
@@ -4572,7 +4573,8 @@ int JoyBus::SendPlayerStat(ThreadParam* threadParam)
 
             const int byteLen = compatLen + 0x97;
 
-            memcpy(q, (unsigned char*)&playerInfo + (threadParam->m_portIndex * 0xDC + 0x18), 8);
+            int statOffset2 = threadParam->m_portIndex * 0xDC;
+            memcpy(q, (unsigned char*)&playerInfo + statOffset2 + 0x18, 8);
 
             unsigned int statWord = __lwbrx(&playerInfo, threadParam->m_portIndex * 0xDC + 0x24);
             memcpy(q + 8, &statWord, sizeof(statWord));


### PR DESCRIPTION
Raises main/joybus from 98.99% to 99.06% (+0.073), matched functions 61 -> 65 (4 new exact matches).

## Wins
- **SendMType -> 100%**: `cmd = 0` declaration moved before the ResetQueue call (the original zero-stored the cmd word in the prologue).
- **SendStrength -> 100%**: the strength scratch buffer is 0x10 bytes, not 3 (frame 0x20 -> 0x30, slot order falls out).
- **SendFavorite -> 100%**: `default:` case leaves `result` uninitialized (matches the original's missing-init quirk) + lazy `int result;` (R18).
- **SendCompatibility**: same uninitialized-default archaeology (+0.016).
- **SendPlayerStat 96.88 -> 97.31**: named `statOffset` locals materialize the `port*0xDC` addi before the +0x18/+0x20 displacement folds; `lowBits` declared before `cf` re-ranks the loop's volatile web.
- **GetBonus returns int** (header + gbaque definition): kills the caller-side `clrlwi` zext in SendBonusStr and makes gbaque's GetBonus exact (`mr r3,r31` not `clrlwi`) — net positive in both units.

## Blockers (documented for next cycle)
- **LoadBin/RestartThread checksum tail**: the guarded 1-trip `mtctr` remainder requires a propagation-opaque `idx=0xBC`. Found a working opacity lever — an equal-arm ternary on a fresh local (`(file == 0) ? 0xBC : 0xBC`) defeats constprop where pragmas (`opt_propagation/unroll_loops/strength_reduction/global_optimizer/O1-O3`), chained inits, named webs, volatile, placement, and deferred-inline helper params all fold — and `#pragma optimize_for_size on` is the only suppressor of the runtime-trip x8 strip-mine (opt_unroll_loops off does NOT govern it). The combination reproduces the target's exact subfic/mtctr/cmpwi/bge/lbzx/bdnz structure, but the ternary's dead `cmplwi` + phi `mr` + (in LoadBin) the size-on `stmw` prologue cost slightly more than the tail gains (net -0.01..-0.13). Recorded as a near-miss recipe.
- SendMapObjDrawFlg/SetCtrlMode/SendPpos/SendDataFile/GBARecvSend residuals are callee-saved-web coloring tie-breaks: every respelling tried (R80 paired demote/promote, R75 decl reorder, R56 alias/reference locals, named sem/port locals, R74 one-case switch, R14 goto junction) was bit-identical or negative — the gxfunc-c7 TRUE-WALL signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)