### PR TITLE
astar: raise fuzzy match to 99.22% (cycle 8)

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -657,7 +657,7 @@ void CAStar::check(int startGroup, int goalGroup, CATemp& temp)
 						*reinterpret_cast<CABlock*>(m_bestPath.m_visited) = *reinterpret_cast<CABlock*>(level1.m_visited);
 						*reinterpret_cast<CABlock*>(m_bestPath.m_path) = *reinterpret_cast<CABlock*>(level1.m_path);
 						m_bestPath.m_pathLength = level1.m_pathLength;
-						m_bestPath.m_cost = level1.m_cost;
+						m_bestPath.m_cost = LoadFloat(level1.m_cost);
 					}
 				}
 				else

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -404,7 +404,7 @@ void CAStar::addRealTime(CGPartyObj* gPartyObj)
 		CAPos& p = m_portals[i];
 
 		bool used = false;
-		if (p.m_groupA != 0 && p.m_groupB != 0)
+		if (m_portals[i].m_groupA != 0 && m_portals[i].m_groupB != 0)
 		{
 			used = true;
 		}

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -550,7 +550,7 @@ void CAStar::calcAStar()
 {
 	memset(m_routeTable, 0, sizeof(m_routeTable));
 
-	for (unsigned int to = 0; to < 64; ++to)
+	for (int to = 0; to < 64; ++to)
 	{
 		for (int from = 0; from < 64; ++from)
 		{
@@ -565,7 +565,7 @@ void CAStar::calcAStar()
 
 			memset(&temp, 0, sizeof(temp));
 
-			check(from, to, temp);
+			check(from, (int)(unsigned int)to, temp);
 
 			if (m_bestPath.m_cost < LoadFloat(kInfiniteCost))
 			{


### PR DESCRIPTION
Raises main/astar from 99.03% to 99.22% (+0.19).

## Changes
- **calcAStar 98.52% -> 100% (exact)**: the `to` loop variable is `int` (signed compares `cmpw`/`cmpwi` against `from` and the 0x40 bound), with an unsigned-typed pass-through at the `check()` call site that reproduces the original's value-numbering (R71: the compare bound was a differently-typed expression).
- **addRealTime 98.09% -> 98.49%**: the debug-print loop's exists-guard reads `m_portals[i].m_groupA/B` directly while the Printf args go through the `CAPos& p` reference (R73 mixed spelling) — restores the target's per-arg byte reloads instead of a cached guard load.
- **check 99.06% -> 99.28%**: `m_bestPath.m_cost = LoadFloat(level1.m_cost);` — the const-ref binding forces the target's fresh `lfs` before the store instead of reusing the compare's FPR (R72-family).

## Confirmed walls (bit-identical or regressing under every spelling)
- Pad debug-input idiom coloring (`padIndex`/base/port web r0/r3/r4 rotation) — identical mismatch exists in MenuUtil's GetMenuPress sites; helper-inline, named-local, expression-demotion forms all canonicalize or regress.
- portalIndex-vs-strength-reduced-cursor rank swap (addRealTime/addAstar search loops): for/while forms bit-identical; pointer-walk, do/while, decl/placement moves all regress.
- getEscapePos whole-band callee-saved permutation: decl-order and reference-rerank sweeps are bit-identical.
- calcPolygonGroup arm1 was verified to be an inlined `calcSpecialPolygonGroup(pos)` call under `-inline auto,deferred` (branch structure + cyl slots align, flagged lines 38->25), but the config nets -0.01 unit (ctor-temp slot pairs and check protection costs) — left out; documented for a future cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)