### PR TITLE
goout: raise fuzzy match to 99.63% (cycle 18)

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -1408,8 +1408,8 @@ void CGoOutMenu::SetGoOutMode(unsigned char mode)
         {
         const int cardChannel = m_accessCardChannel;
         const int saveIndex = m_accessSaveIndex;
-        m_cardChannel = static_cast<char>(cardChannel);
         m_saveIndex = static_cast<char>(saveIndex);
+        m_cardChannel = static_cast<char>(cardChannel);
         MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
         }
         m_memCardBuffer = MenuPcs.m_goOutTransferSaveData;
@@ -1702,8 +1702,8 @@ card_connected:;
                 m_accessCardChannel = 0;
                 const int cardChannel = m_accessCardChannel;
                 const int saveIndex = m_accessSaveIndex;
-                m_cardChannel = static_cast<char>(cardChannel);
                 m_saveIndex = static_cast<char>(saveIndex);
+                m_cardChannel = static_cast<char>(cardChannel);
                 MenuPcs.m_mcCtrl.m_cardChannel = cardChannel;
                 SetGoOutMode(10);
             }


### PR DESCRIPTION
Raises main/goout 99.6285 -> 99.6298 (+0.0013).

What landed:
- CalcGoOut case-9 cardChannel/saveIndex block: swap the m_saveIndex/m_cardChannel store statement order to match the target's lwz 0x10-before-0xc load scheduling (CalcGoOut 99.714 -> 99.716).
- SetGoOutMode post-Odekake block: same store-order swap (SetGoOutMode 99.952 -> 99.957).

Residuals confirmed walled this cycle (each swept 5-25 source variants, all bit-identical or regressing):
- Calc (98.79): this<->MenuPcs r30/r31 rank swap. Target ranks the MenuPcs invariant web above the `this` param web; every naming spelling (pointer local, reference local, global reference, partial-site spellings), statement placement, decl placement, and pragma (O1/O2/O3, opt_common_subs, scheduling, peephole) is bit-identical or regresses. Param-vs-invariant rank appears un-steerable here.
- CalcGoOut/CalcDel `next` first-def-site fold: ours folds the first junction site's `next` web into r0 (target stages in r5), which then flips the lock-CSE/zero-web r5/r6 colors at all later sites. Uninit-arm form materializes the web but callee-saved (live across calls); hoisted-init, goto-to-zero-label, shared-arm restructures, helper result vars, decl init/order all regress or no-op.
- SetDelMode languageId chain and SetMenuStr indexBase: single-use named locals demoted to r0/promoted to r26; accumulate/split/fold respellings bit-identical or regress.
- DrawGoOutMenu addi-into-scratch+mr for the g_pGoOutMenu init: all binding/order forms regress -0.04.
- cflags (-inline auto,deferred / -str reuse / -RTTI+sdata / -use_lmw_stmw) and mw_version (1.3.2r/2.0/2.0p1) bit-identical for this unit; jumptable @NNN reloc names are display-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)