### PR TITLE
FS_USB_Process: raise fuzzy match to 99.71% (cycle 1)

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -193,8 +193,10 @@ void CFunnyShapePcs::SetUSBData()
         *reinterpret_cast<s16*>(AnmData(this) + 16) = LoadSwap16(*reinterpret_cast<s16*>(AnmData(this) + 16));
         *reinterpret_cast<s16*>(AnmData(this) + 18) = LoadSwap16(*reinterpret_cast<s16*>(AnmData(this) + 18));
 
-        int groupOffset = 0;
-        for (int i = 0; i < *reinterpret_cast<s16*>(AnmData(this) + 6); i++) {
+        int groupOffset;
+        int i = 0;
+        groupOffset = 0;
+        for (; i < *reinterpret_cast<s16*>(AnmData(this) + 6); i++) {
             u8* group = AnmData(this) + groupOffset;
             if (i != 0) {
                 *reinterpret_cast<s16*>(group + 0x10) = LoadSwap16(*reinterpret_cast<s16*>(group + 0x10));

--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -285,9 +285,9 @@ void CFunnyShapePcs::SetUSBData()
         mesh->flags = LoadSwap16(mesh->flags);
         mesh->count = LoadSwap16(mesh->count);
 
-        int i = 0;
-        int dst24 = 0;
         int dst2c = 0;
+        int dst24 = 0;
+        int i = 0;
         for (; i < m_funnyShape.m_shape.count;
              i++, dst24 += 0x24, dst2c += 0x2C) {
             if ((m_funnyShape.m_shape.flags & 8) != 0) {

--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -193,11 +193,9 @@ void CFunnyShapePcs::SetUSBData()
         *reinterpret_cast<s16*>(AnmData(this) + 16) = LoadSwap16(*reinterpret_cast<s16*>(AnmData(this) + 16));
         *reinterpret_cast<s16*>(AnmData(this) + 18) = LoadSwap16(*reinterpret_cast<s16*>(AnmData(this) + 18));
 
-        int groupOffset;
         int i = 0;
-        groupOffset = 0;
         for (; i < *reinterpret_cast<s16*>(AnmData(this) + 6); i++) {
-            u8* group = AnmData(this) + groupOffset;
+            u8* group = AnmData(this) + i * 8;
             if (i != 0) {
                 *reinterpret_cast<s16*>(group + 0x10) = LoadSwap16(*reinterpret_cast<s16*>(group + 0x10));
                 *reinterpret_cast<s16*>(group + 0x12) = LoadSwap16(*reinterpret_cast<s16*>(group + 0x12));
@@ -258,7 +256,6 @@ void CFunnyShapePcs::SetUSBData()
                 }
 
             }
-            groupOffset += 8;
         }
         DCStoreRange(m_funnyShape.m_anm.anmData, usb->m_sizeBytes);
         FunnyShape(this)->InitAnmWork();

--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -284,10 +284,10 @@ void CFunnyShapePcs::SetUSBData()
         mesh->flags = LoadSwap16(mesh->flags);
         mesh->count = LoadSwap16(mesh->count);
 
-        int dst2c = 0;
-        int dst24 = 0;
-        int i = 0;
-        for (; i < m_funnyShape.m_shape.count;
+        int dst2c;
+        int dst24;
+        int i;
+        for (i = 0, dst24 = 0, dst2c = 0; i < m_funnyShape.m_shape.count;
              i++, dst24 += 0x24, dst2c += 0x2C) {
             if ((m_funnyShape.m_shape.flags & 8) != 0) {
                 u8* src = meshData + 0x10;

--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -193,8 +193,6 @@ void CFunnyShapePcs::SetUSBData()
         *reinterpret_cast<s16*>(AnmData(this) + 16) = LoadSwap16(*reinterpret_cast<s16*>(AnmData(this) + 16));
         *reinterpret_cast<s16*>(AnmData(this) + 18) = LoadSwap16(*reinterpret_cast<s16*>(AnmData(this) + 18));
 
-        int src2c;
-        int src24;
         int groupOffset = 0;
         for (int i = 0; i < *reinterpret_cast<s16*>(AnmData(this) + 6); i++) {
             u8* group = AnmData(this) + groupOffset;
@@ -208,16 +206,14 @@ void CFunnyShapePcs::SetUSBData()
             list[0] = LoadSwap16(list[0]);
             list[1] = LoadSwap16(list[1]);
 
-            src2c = 0;
-            src24 = 0;
             int j = 0;
             int dst24 = 0;
             int dst2c = 0;
             for (; j < static_cast<s16>(list[1]);
-                 src2c += 0x2C, src24 += 0x24, j++, dst24 += 0x24, dst2c += 0x2C) {
+                 j++, dst24 += 0x24, dst2c += 0x2C) {
                 if ((list[0] & 8) != 0) {
                     u8* src = listData + 0x10;
-                    src += src2c;
+                    src += j * 0x2C;
                     u32* p32 = reinterpret_cast<u32*>(src);
                     StoreSwap32(&p32[0]);
                     StoreSwap32(&p32[1]);
@@ -240,7 +236,7 @@ void CFunnyShapePcs::SetUSBData()
                     DCStoreRange(dst, 0x2C);
                 } else {
                     u8* src = listData + 0x10;
-                    src += src24;
+                    src += j * 0x24;
                     u32* p32 = reinterpret_cast<u32*>(src);
                     StoreSwap32(&p32[0]);
                     StoreSwap32(&p32[1]);
@@ -289,16 +285,14 @@ void CFunnyShapePcs::SetUSBData()
         mesh->flags = LoadSwap16(mesh->flags);
         mesh->count = LoadSwap16(mesh->count);
 
-        int src2c = 0;
-        int src24 = 0;
         int i = 0;
         int dst24 = 0;
         int dst2c = 0;
         for (; i < m_funnyShape.m_shape.count;
-             src2c += 0x2C, src24 += 0x24, i++, dst24 += 0x24, dst2c += 0x2C) {
+             i++, dst24 += 0x24, dst2c += 0x2C) {
             if ((m_funnyShape.m_shape.flags & 8) != 0) {
                 u8* src = meshData + 0x10;
-                src += src2c;
+                src += i * 0x2C;
                 u32* p32 = reinterpret_cast<u32*>(src);
                 StoreSwap32(&p32[0]);
                 StoreSwap32(&p32[1]);
@@ -321,7 +315,7 @@ void CFunnyShapePcs::SetUSBData()
                 DCStoreRange(dst, 0x2C);
             } else {
                 u8* src = meshData + 0x10;
-                src += src24;
+                src += i * 0x24;
                 u32* p32 = reinterpret_cast<u32*>(src);
                 StoreSwap32(&p32[0]);
                 StoreSwap32(&p32[1]);


### PR DESCRIPTION
Raises main/FS_USB_Process (SetUSBData, 3524b) from 99.09% to 99.71% (+0.62).

Key finding: the original's per-element src offsets in the case-11 and case-16 swap loops were **strength-reduced induction variables** from `j * 0x2C` / `j * 0x24` index expressions, not explicit accumulator variables — same for case 11's `groupOffset` (`i * 8`). Spelling them as multiplied index expressions lets mwcc synthesize the IVs with the target's `li`/`mr`-seeded preheader inits, and the resulting web-count changes cascaded the global register allocation into place (case-5 `tmp` r30→r26 matching, case-16 IVs r26/r27 matching).

Changes:
- case 11/16 inner loops: `src += j * 0x2C` / `j * 0x24` IV spelling replaces explicit src2c/src24 accumulators
- case 11 outer loop: `groupOffset` replaced by `i * 8` IV; `i` init emitted before group addressing
- case 16: user decl order dst2c, dst24, i + inits moved into the for-init clause (i, dst24, dst2c order)

Residual (10 flagged lines): case-11 IV zero-seed source (target seeds both IVs from dst2c's li; ours chains from the first IV) and case-16 dst24/dst2c register pair (r24/r25 vs r22/r21) — both resisted ~45 sweep variants (decl orders, init placement, for-init forms, types, pragmas with repo precedent, shared-variable forms, VN-duplicate uses); bit-identical or regressing across the board — RA tie-break wall signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)