### PR TITLE
main: raise fuzzy match to 100.0% (cycle 1)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,10 +61,9 @@ void main(int argc, char** argv)
  */
 void game(int argc, char** argv)
 {
-    int i;
     int copyScriptName;
     int parseLanguage;
-    char** argument;
+    int i;
 
     Game.Init();
     strcpy(Game.m_startScriptName, kDefaultScriptName);
@@ -72,32 +71,32 @@ void game(int argc, char** argv)
     if (argc != 0) {
         copyScriptName = 0;
         parseLanguage = 0;
-        for (i = 1, argument = argv + 1; i < argc; i++, argument++) {
+        for (i = 1; i < argc; i++) {
             if (copyScriptName) {
-                strcpy(Game.m_startScriptName, *argument);
+                strcpy(Game.m_startScriptName, argv[i]);
                 copyScriptName = 0;
             } else if (parseLanguage) {
-                int cmp = strcmp(*argument, kLanguageArgUs);
+                int cmp = strcmp(argv[i], kLanguageArgUs);
                 if (cmp == 0) {
                     Game.m_gameWork.m_languageId = 1;
                 } else {
-                    cmp = strcmp(*argument, kLanguageArgUk);
+                    cmp = strcmp(argv[i], kLanguageArgUk);
                     if (cmp == 0) {
                         Game.m_gameWork.m_languageId = 1;
                     } else {
-                        cmp = strcmp(*argument, kLanguageArgGr);
+                        cmp = strcmp(argv[i], kLanguageArgGr);
                         if (cmp == 0) {
                             Game.m_gameWork.m_languageId = 2;
                         } else {
-                            cmp = strcmp(*argument, kLanguageArgIt);
+                            cmp = strcmp(argv[i], kLanguageArgIt);
                             if (cmp == 0) {
                                 Game.m_gameWork.m_languageId = 3;
                             } else {
-                                cmp = strcmp(*argument, kLanguageArgFr);
+                                cmp = strcmp(argv[i], kLanguageArgFr);
                                 if (cmp == 0) {
                                     Game.m_gameWork.m_languageId = 4;
                                 } else {
-                                    cmp = strcmp(*argument, kLanguageArgSp);
+                                    cmp = strcmp(argv[i], kLanguageArgSp);
                                     if (cmp == 0) {
                                         Game.m_gameWork.m_languageId = 5;
                                     } else {
@@ -110,9 +109,9 @@ void game(int argc, char** argv)
                 }
                 parseLanguage = 0;
             } else {
-                char c = (*argument)[0];
+                char c = (argv[i])[0];
                 if ((c == '-') || (c == '/')) {
-                    c = (*argument)[1];
+                    c = (argv[i])[1];
                     switch (c) {
                     case 'f':
                         copyScriptName = 1;


### PR DESCRIPTION
Raises `main/main` from 99.46% to **100.0%** (680/680 code bytes, both functions bit-identical).

## What changed (src/main.cpp, `game__FiPPc`)
The remaining 0.54% was a cyclic register-allocation permutation among three values: the loop counter `i`, the argv cursor, and the CSE'd `Game.m_startScriptName` pointer (target r30/r27/r26 vs ours r26/r30/r27).

Two source-level fixes resolved it:
1. **Replaced the explicit `char** argument` cursor with `argv[i]` indexing** — mwcc's strength reduction recreates the derived induction pointer itself (preheader `addi rX, argv, 4`, latch `addi rX, rX, 4` before `i++`), which puts the cursor and script-name temp in the correct relative color order (r27/r26).
2. **Moved `int i;` to the end of the local declarations** (`copyScriptName, parseLanguage, i`) — this lifts `i`'s coloring priority to r30, completing the match.

Verified via `build/GCCP01/report.json`: fuzzy 100.0, matched_code 680/680, matched_data 72/72, matched_functions 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)