### PR TITLE
p_usb: raise fuzzy match to 100.0% (cycle 5)

### DIFF
--- a/src/p_usb.cpp
+++ b/src/p_usb.cpp
@@ -92,7 +92,8 @@ int CUSBPcs::SendDataCode(int code, void* src, int elemSize, int elemCount)
     value = (count + 0x5F) & ~0x1F;
     stage = (m_bigStage != (CMemory::CStage*)nullptr) ? m_bigStage : m_smallStage;
 
-    packet = reinterpret_cast<CDataHeader*>(new (stage, const_cast<char*>(s_p_usb_cpp), 0x1ca) unsigned char[value]);
+    unsigned char* raw = new (stage, const_cast<char*>(s_p_usb_cpp), 0x1ca) unsigned char[value];
+    packet = reinterpret_cast<CDataHeader*>(raw);
     packet->m_packetSize = value;
     packet->m_packetType = 4;
     packet->m_packetCode = Swap32((unsigned int)code);


### PR DESCRIPTION
Raises main/p_usb from 99.39% to **100.0%** (all 11 functions matched, 1320/1320 code bytes).

Single residual was in SendDataCode (98.5%): the m_packetSize store used the fresh new[] result in r3 where the target uses the cached copy in r30. Fix: stage the new[] result through a named `unsigned char* raw` local before casting to CDataHeader* — this breaks the r3 copy-propagation into the first field store, letting li r3,4 schedule early exactly as in the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)