### PR TITLE
B4 tail sweep: texanim/file/mapanim/ME_AppRequest (cycle 1)

### DIFF
--- a/src/texanim.cpp
+++ b/src/texanim.cpp
@@ -244,8 +244,9 @@ void CTexAnimSet::SetTexGen()
  */
 inline int CTexAnim::Find(char* name)
 {
-    for (unsigned int i = 0; i < static_cast<unsigned int>(m_refData->m_texAnimSeqs.GetSize()); i++) {
-        CTexAnimSeq* seq = m_refData->m_texAnimSeqs[i];
+    unsigned long idx;
+    for (unsigned int i = 0; (idx = i) < static_cast<unsigned int>(m_refData->m_texAnimSeqs.GetSize()); i++) {
+        CTexAnimSeq* seq = m_refData->m_texAnimSeqs[idx];
         if (strcmp(name, seq->m_name) == 0) {
             return static_cast<int>(i);
         }


### PR DESCRIPTION
Batch sweep of four B4 tail units (each <6KB, 1-5 flagged functions).

## Results
| unit | before | after |
|---|---|---|
| main/texanim | 99.844 | **100.000** |
| main/file | 99.842 | 99.842 (walled) |
| main/mapanim | 99.828 | 99.828 (walled) |
| main/ME_AppRequest | 99.677 | 99.677 (walled) |

## What landed
**main/texanim -> 100%** (one edit): in the inlined `CTexAnim::Find` loop, the original computed the subscript index in the loop *condition* (`(idx = i) < count`), which places the `mr r4,r30` arg-setup in the loop-test block's branch shadow. `Change` 96.15 -> 100, and the same inlined-loop fix snapped `Duplicate`/`AddFrame`/`SetTexGen`/`Create` (99.7-99.8 each) to 100 simultaneously.

## Walled (fast verdicts, variants measured via report.json)
- **ME_AppRequest `ResetRsdList`** (1 instr of 79): target seeds the loop-invariant null-store register via `mr r29,r28` (copy of `i`'s zero) vs our `li r29,0`. R86 zero-seed signature; 13 spellings (chained init, redundant ternary, subscript/IV-restructure, named locals, `opt_propagation off`) all constant-fold back or rotate the web negatively.
- **mapanim `Interp`** (25 of 249 lines): pure volatile-register numbering swaps across three structurally-matched track loops. 12 variants (decl orders, inlined-helper reconstruction of the UNUSED `interp`, hybrid, staged temps, shared IV) all neutral or negative.
- **file `DrawError`** (28 of 424): coupled tie-break — callee-saved web merge ({usingFallbackFont,baseY,status} in r18) plus a bool-junction `clrlwi. r27` for `compactLayout`. Reproducing the clrlwi shape (u8/bool junction) breaks the merge (+1 callee-saved web, whole-prologue shift); forcing the merge (single reused variable) rotates font/compact homes. 10 combos all net-negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)