### PR TITLE
maphit: raise fuzzy match to 99.54% (cycle 12)

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -1024,7 +1024,8 @@ cylinder_body:
         disc = capB * capB - (f32)(axisLen * -((2.0 * pz) - axisLen) + capC);
         if (disc > 0.0) {
             disc = sqrtf(disc);
-            f32 t = -capB - disc;
+            f32 negB = -capB;
+            f32 t = negB - disc;
             if ((t * localDirection.z) + pz >= axisLen) {
                 outT = t * tScale;
                 if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
@@ -1033,7 +1034,7 @@ cylinder_body:
                 return 0;
             }
 
-            t = -capB + disc;
+            t = negB + disc;
             if ((t * localDirection.z) + pz >= axisLen) {
                 outT = t * tScale;
                 if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -202,17 +202,15 @@ void CMapHit::Draw()
 void CMapHit::CheckHitCylinderNear(CMapCylinder* mapCylinder, Vec* position, unsigned short startFace, unsigned short faceCount, unsigned long mask)
 {
     unsigned int faceIndex = startFace;
-    unsigned int faceOffset = faceIndex * sizeof(CMapHitFace);
     int endFace = static_cast<unsigned short>(faceCount + startFace);
 
     g_hit_cyl = *mapCylinder;
     g_hit_mvec = *position;
 
     while (static_cast<int>(faceIndex) < endFace) {
-        g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
+        g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceIndex * sizeof(CMapHitFace)));
         CheckHitFaceCylinder(mask);
         faceIndex++;
-        faceOffset += sizeof(CMapHitFace);
     }
 }
 
@@ -249,7 +247,7 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
     g_hit_mvec = *position;
 
     while (static_cast<int>(faceIndex) < endFace) {
-        g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceOffset));
+        g_hit_lpface = reinterpret_cast<CMapHitFace*>(Ptr(m_faces, faceIndex * sizeof(CMapHitFace)));
         g_hit_t_min = kMapHitInitialTMin;
 
         if (CheckHitFaceCylinder(mask) != 0) {
@@ -257,7 +255,6 @@ int CMapHit::CheckHitCylinder(CMapCylinder* mapCylinder, Vec* position, unsigned
         }
 
         faceIndex++;
-        faceOffset += sizeof(CMapHitFace);
     }
 
     return 0;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -946,11 +946,10 @@ int FindIntersection(const Vec& start, const Vec& direction, const CMapCylinder&
 
 cylinder_body:
     {
-        const f32 vx = localDirection.x;
         const f32 vy = localDirection.y;
         const f32 radialC = (px * px + py * py) - radiusSq;
-        const f32 radialB = px * vx + py * vy;
-        const f32 vxSq = vx * vx;
+        const f32 radialB = px * localDirection.x + py * vy;
+        const f32 vxSq = localDirection.x * localDirection.x;
         const f32 vySq = vy * vy;
         const f32 radialA = vxSq + vySq;
         f32 disc = radialB * radialB - radialA * radialC;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -647,8 +647,8 @@ edge_loop:
                 Vec edge;
                 PSVECSubtract(&current, &previous, &edge);
 
-                Vec rayStart = g_hit_cyl.m_bottom;
                 Vec rayDirection = *hitDirection;
+                Vec rayStart = g_hit_cyl.m_bottom;
 
                 CMapCylinder edgeCylinder;
                 edgeCylinder.m_bottom = previous;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -990,8 +990,9 @@ cylinder_body:
         disc = capB * capB - capC;
         if (disc > 0.0) {
             disc = sqrtf(disc);
+            f32 t;
             f32 negB = -capB;
-            f32 t = negB - disc;
+            t = negB - disc;
             if ((t * localDirection.z) + pz <= 0.0) {
                 outT = t * tScale;
                 if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
@@ -1023,8 +1024,9 @@ cylinder_body:
         disc = capB * capB - (f32)(axisLen * -((2.0 * pz) - axisLen) + capC);
         if (disc > 0.0) {
             disc = sqrtf(disc);
+            f32 t;
             f32 negB = -capB;
-            f32 t = negB - disc;
+            t = negB - disc;
             if ((t * localDirection.z) + pz >= axisLen) {
                 outT = t * tScale;
                 if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -1019,7 +1019,7 @@ cylinder_body:
             }
         }
 
-        capB = -((localDirection.z * axisLen) - capB);
+        capB = capB - (localDirection.z * axisLen);
         disc = capB * capB - (f32)(axisLen * -((2.0 * pz) - axisLen) + capC);
         if (disc > 0.0) {
             disc = sqrtf(disc);

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -648,7 +648,7 @@ edge_loop:
                 PSVECSubtract(&current, &previous, &edge);
 
                 Vec rayDirection = *hitDirection;
-                Vec rayStart = g_hit_cyl.m_bottom;
+                Vec rayStart = cyl.m_bottom;
 
                 CMapCylinder edgeCylinder;
                 edgeCylinder.m_bottom = previous;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -129,13 +129,15 @@ void CMapHit::Draw()
             GXColor colorBBytes = *reinterpret_cast<const GXColor*>(&mapIdGrp->m_secondaryColor);
 
             GXBegin(GX_TRIANGLES, GX_VTXFMT7, 3);
+            unsigned char* index = reinterpret_cast<unsigned char*>(face);
             int i = 0;
             while (i < static_cast<int>(face->m_vertexCount)) {
-                Vec* vertex = m_vertices + face->m_vertexIndices[i];
+                Vec* vertex = m_vertices + *reinterpret_cast<unsigned short*>(index + 0x48);
                 GXPosition3f32(vertex->x, vertex->y, vertex->z);
                 GXNormal3f32(face->m_normal.x, face->m_normal.y, face->m_normal.z);
                 GXColor4u8(colorABytes.r, colorABytes.g, colorABytes.b, colorABytes.a);
                 i++;
+                index += sizeof(unsigned short);
             }
 
             GXBegin(GX_TRIANGLES, GX_VTXFMT7, 3);

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -991,7 +991,8 @@ cylinder_body:
         disc = capB * capB - capC;
         if (disc > 0.0) {
             disc = sqrtf(disc);
-            f32 t = -capB - disc;
+            f32 negB = -capB;
+            f32 t = negB - disc;
             if ((t * localDirection.z) + pz <= 0.0) {
                 outT = t * tScale;
                 if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {
@@ -1000,7 +1001,7 @@ cylinder_body:
                 return 0;
             }
 
-            t = -capB + disc;
+            t = negB + disc;
             if ((t * localDirection.z) + pz <= 0.0) {
                 outT = t * tScale;
                 if (outT >= kMapHitZero && outT <= kMapHitUnitScale) {


### PR DESCRIPTION
Raises main/maphit from 99.40% to 99.54% (unit fuzzy, report.json).

Per-function work:
- **5-arg CheckHitCylinder/CheckHitCylinderNear wrappers** (99.30/99.40 -> 99.62/99.55): R86 synthetic-IV conversion — dropped the explicit faceOffset accumulator and spelled the face pointer as faceIndex * sizeof(CMapHitFace); the strength reducer now synthesizes the *0x50 offset IV with the target mulli/addi shape.
- **FindIntersection** (99.25 -> 99.73): named negB locals in both cap blocks, t declared before negB (decl-order re-rank), vx demoted to direct localDirection.x reads (R80 inverse respelling), and the cap capB update respelled as a direct subtraction (capB = capB - dirz*axisLen) so mwcc emits the in-place fnmsubs — that one fix cleared the whole 15-line sqrt-sequence FPR cascade.
- **Draw** (99.71 -> 99.83): section-1 inner vertex loop rewritten with the DrawWire-style explicit u16 byte cursor (i++ then index += 2), matching the target increment order.
- **CheckHitFaceCylinder** (98.2): rayStart/rayDirection init order swapped to fix their stack-slot assignment, rayStart copied through the cyl reference. The remaining ~85 flagged lines are a whole-band callee-saved rotation (this in r24 vs target r31) that is bit-identical under 15+ respellings (self pointer, register hints, decl/placement permutations, web-count changes) — gxfunc-style coloring tie-break wall.

Residual walls (bit-identical sweeps): the this-rank band rotation in CheckHitFaceCylinder, the offset-IV/endFace register swap in the 5-arg wrappers, Draw section-3 face/faceIndex swap, and a negB/z scratch-FPR 2-cycle in FindIntersection cap sub-blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)