### PR TITLE
memorycard: raise fuzzy match to 99.66% (cycle 12)

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -195,18 +195,16 @@ static inline u32 CalcSaveCrc(u8* data)
     u8* ptr = data;
     while (--count >= 0)
     {
-        u8 byte = *ptr;
+        crc = (crc << 8) ^ s_CrcTable[(crc >> 24) ^ *ptr];
         ptr++;
-        crc = (crc << 8) ^ s_CrcTable[(crc >> 24) ^ byte];
     }
 
     ptr = data + 0x20;
     count = 0x8BB0;
     while (--count >= 0)
     {
-        u8 byte = *ptr;
+        crc = (crc << 8) ^ s_CrcTable[(crc >> 24) ^ *ptr];
         ptr++;
-        crc = (crc << 8) ^ s_CrcTable[(crc >> 24) ^ byte];
     }
 
     return ~crc;
@@ -381,9 +379,9 @@ void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)
  */
 unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
 {
-    int count;
     unsigned char* ptr;
     unsigned char* ptr2;
+    int count;
     unsigned int crc;
     unsigned char* crcData;
 

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -382,6 +382,7 @@ unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
     unsigned char* ptr;
     unsigned char* ptr2;
     int count;
+    int count2;
     unsigned int crc;
     unsigned char* crcData;
 
@@ -404,8 +405,8 @@ unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
     }
 
     ptr2 = crcData + 0x20;
-    count = 0x8BB0;
-    while (--count >= 0)
+    count2 = 0x8BB0;
+    while (--count2 >= 0)
     {
         crc = (crc << 8) ^ s_CrcTable[(crc >> 24) ^ *ptr2];
         ptr2 += 1;

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -522,11 +522,10 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
         *reinterpret_cast<u32*>(dstCharData + 0x8D0) = *reinterpret_cast<u32*>(reinterpret_cast<u8*>(&srcSave) + 0x13D8);
 
         u8* dstWork = reinterpret_cast<u8*>(&dstSave) + dstChar * 0x200;
-        u8* item;
+        int itemOfs = dstChar * 8;
         int i = 0;
         do
         {
-            item = dstWork + dstChar * 8;
             for (int j = 0; j < 8; j++)
             {
                 u8 flag = 0;
@@ -534,8 +533,7 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
                 {
                     flag = 1;
                 }
-                item[0xC0] = flag != 0 ? 0x32 : 0;
-                item++;
+                dstWork[itemOfs + 0xC0 + j] = flag != 0 ? 0x32 : 0;
             }
             i++;
             dstWork += 0x40;

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1419,8 +1419,6 @@ void CMemoryCardMan::MakeSaveData()
     saveDat->m_rotateKey = static_cast<u8>(Math.Rand(0xFF));
     saveDat->m_flags = 0;
 
-    u8* letterSrc;
-    u8* letterDst;
     CGame::CGameWork* gameWork = &Game.m_gameWork;
     CGame* g = &Game;
     for (int i = 0; i < 4; i++)
@@ -1512,29 +1510,25 @@ void CMemoryCardMan::MakeSaveData()
         *reinterpret_cast<u32*>(dst + 0xEC) = caravanWork->m_gil;
         memcpy(dst + 0xF0, caravanWork->m_name, 0x10);
         *reinterpret_cast<u32*>(dst + 0x100) = caravanWork->m_letterCount;
-        letterSrc = reinterpret_cast<u8*>(caravanWork);
-        letterDst = dst;
         for (letter = 0; letter < 100; letter++)
         {
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->FlagsBits().m_attachmentIsGil =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->FlagsBits().m_attachmentIsGil;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->HeaderBitsRef().m_messageType =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->HeaderBitsRef().m_messageType;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->WordBitsRef().m_senderId =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->WordBitsRef().m_senderId;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->AttachmentBitsRef().m_value =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->AttachmentBitsRef().m_value;
-            memcpy(letterDst + 0x108, letterSrc + 0x3F0, 8);
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->FlagsBits().m_opened =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->FlagsBits().m_opened;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->FlagsBits().m_attachmentClaimed =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->FlagsBits().m_attachmentClaimed;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->FlagsBits().m_replySent =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->FlagsBits().m_replySent;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x104)->FlagsBits().m_hasReply =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x3EC)->FlagsBits().m_hasReply;
-            letterSrc += sizeof(CCaravanWork::CLetterWork);
-            letterDst += 0xC;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->FlagsBits().m_attachmentIsGil =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->FlagsBits().m_attachmentIsGil;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->HeaderBitsRef().m_messageType =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->HeaderBitsRef().m_messageType;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->WordBitsRef().m_senderId =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->WordBitsRef().m_senderId;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->AttachmentBitsRef().m_value =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->AttachmentBitsRef().m_value;
+            memcpy(dst + letter * 0xC + 0x108, reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3F0, 8);
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->FlagsBits().m_opened =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->FlagsBits().m_opened;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->FlagsBits().m_attachmentClaimed =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->FlagsBits().m_attachmentClaimed;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->FlagsBits().m_replySent =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->FlagsBits().m_replySent;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(dst + letter * 0xC + 0x104)->FlagsBits().m_hasReply =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + letter * 0xC + 0x3EC)->FlagsBits().m_hasReply;
         }
 
         for (int artifact = 0; artifact < 96; artifact++)

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -518,9 +518,7 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
         *reinterpret_cast<u32*>(dstCharData + 0x8BC) = *reinterpret_cast<u32*>(srcCharData + 0x8BC);
         dstCharData[0x8C2] = srcCharData[0x8C2];
         *reinterpret_cast<u32*>(dstCharData + 0x8C4) = *reinterpret_cast<u32*>(srcCharData + 0x8C4);
-        u32 serial0 = *reinterpret_cast<u32*>(reinterpret_cast<u8*>(&srcSave) + 0x13D0);
-        *reinterpret_cast<u32*>(dstCharData + 0x8CC) = *reinterpret_cast<u32*>(reinterpret_cast<u8*>(&srcSave) + 0x13D4);
-        *reinterpret_cast<u32*>(dstCharData + 0x8C8) = serial0;
+        *reinterpret_cast<u64*>(dstCharData + 0x8C8) = *reinterpret_cast<u64*>(reinterpret_cast<u8*>(&srcSave) + 0x13D0);
         *reinterpret_cast<u32*>(dstCharData + 0x8D0) = *reinterpret_cast<u32*>(reinterpret_cast<u8*>(&srcSave) + 0x13D8);
 
         u8* dstWork = reinterpret_cast<u8*>(&dstSave) + dstChar * 0x200;
@@ -1234,9 +1232,7 @@ void CMemoryCardMan::SetLoadData()
     memcpy(Game.m_gameWork.m_townName, save + 0x10C0, 0x10);
     memcpy(Game.m_gameWork.m_eventFlags, save + 0x10D0, 0x100);
     memcpy(Game.m_gameWork.m_eventWork, save + 0x11D0, 0x200);
-    u32 serial0 = *reinterpret_cast<u32*>(save + 0x13D0);
-    Game.m_gameWork.m_mcSerial1 = *reinterpret_cast<u32*>(save + 0x13D4);
-    Game.m_gameWork.m_mcSerial0 = serial0;
+    *reinterpret_cast<u64*>(&Game.m_gameWork.m_mcSerial0) = *reinterpret_cast<u64*>(save + 0x13D0);
     Game.m_gameWork.m_mcRandom = *reinterpret_cast<u32*>(save + 0x13D8);
     Game.m_gameWork.m_mcHasSerial = save[0x13DC];
     Sound.SetBgmMasterVolume(static_cast<s8>(save[0x13DD]));
@@ -1361,9 +1357,7 @@ void CMemoryCardMan::SetLoadData()
         caravanWork->unk_0xc1e = src[0x8C2];
         caravanWork->m_shopRandSeed = *reinterpret_cast<int*>(src + 0x8C4);
         caravanWork->m_shopData0 = *reinterpret_cast<int*>(src + 0x8D0);
-        int shopData1 = *reinterpret_cast<int*>(src + 0x8C8);
-        caravanWork->m_shopData2 = *reinterpret_cast<int*>(src + 0x8CC);
-        caravanWork->m_shopData1 = shopData1;
+        *reinterpret_cast<u64*>(&caravanWork->m_shopData1) = *reinterpret_cast<u64*>(src + 0x8C8);
         caravanWork->m_baseDataIndex = *reinterpret_cast<int*>(src + 0x8D4);
         caravanWork->m_maxHp = caravanWork->GetArtifactIncludeHpMax();
 
@@ -1461,9 +1455,7 @@ void CMemoryCardMan::MakeSaveData()
     memcpy(save + 0x10D0, Game.m_gameWork.m_eventFlags, 0x100);
     memcpy(save + 0x11D0, Game.m_gameWork.m_eventWork, 0x200);
     memcpy(save + 0x11D0, Game.m_gameWork.m_eventWork, 0x200);
-    u32 mcSerial0 = Game.m_gameWork.m_mcSerial0;
-    *reinterpret_cast<u32*>(save + 0x13D4) = Game.m_gameWork.m_mcSerial1;
-    *reinterpret_cast<u32*>(save + 0x13D0) = mcSerial0;
+    *reinterpret_cast<u64*>(save + 0x13D0) = *reinterpret_cast<u64*>(&Game.m_gameWork.m_mcSerial0);
     *reinterpret_cast<u32*>(save + 0x13D8) = Game.m_gameWork.m_mcRandom;
     save[0x13DC] = Game.m_gameWork.m_mcHasSerial;
     save[0x13DD] = static_cast<u8>(Sound.GetBgmMasterVolume());
@@ -1576,9 +1568,7 @@ void CMemoryCardMan::MakeSaveData()
         dst[0x8C2] = caravanWork->unk_0xc1e;
         *reinterpret_cast<int*>(dst + 0x8C4) = caravanWork->m_shopRandSeed;
         *reinterpret_cast<int*>(dst + 0x8D0) = caravanWork->m_shopData0;
-        int shopData1 = caravanWork->m_shopData1;
-        *reinterpret_cast<int*>(dst + 0x8CC) = caravanWork->m_shopData2;
-        *reinterpret_cast<int*>(dst + 0x8C8) = shopData1;
+        *reinterpret_cast<u64*>(dst + 0x8C8) = *reinterpret_cast<u64*>(&caravanWork->m_shopData1);
         *reinterpret_cast<int*>(dst + 0x8D4) = caravanWork->m_baseDataIndex;
     }
 

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1247,8 +1247,6 @@ void CMemoryCardMan::SetLoadData()
     gameWork->m_spModeFlags[2] = MakeLoadBool(static_cast<s8>(save[0x13E3]));
     gameWork->m_spModeFlags[3] = MakeLoadBool(static_cast<s8>(save[0x13E4]));
 
-    u8* letterSrc;
-    u8* letterDst;
     int count;
     int i;
     for (int c = 0; c < 8; c++)
@@ -1303,29 +1301,25 @@ void CMemoryCardMan::SetLoadData()
         caravanWork->m_gil = *reinterpret_cast<int*>(src + 0xEC);
         memcpy(caravanWork->m_name, src + 0xF0, 0x10);
         caravanWork->m_letterCount = *reinterpret_cast<int*>(src + 0x100);
-        letterSrc = src;
-        letterDst = reinterpret_cast<u8*>(caravanWork);
         for (count = 0; count < 100; count++)
         {
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->FlagsBits().m_attachmentIsGil =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->FlagsBits().m_attachmentIsGil;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->HeaderBitsRef().m_messageType =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->HeaderBitsRef().m_messageType;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->WordBitsRef().m_senderId =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->WordBitsRef().m_senderId;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->AttachmentBitsRef().m_value =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->AttachmentBitsRef().m_value;
-            memcpy(letterDst + 0x3F0, letterSrc + 0x108, 8);
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->FlagsBits().m_opened =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->FlagsBits().m_opened;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->FlagsBits().m_attachmentClaimed =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->FlagsBits().m_attachmentClaimed;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->FlagsBits().m_replySent =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->FlagsBits().m_replySent;
-            reinterpret_cast<CCaravanWork::CLetterWork*>(letterDst + 0x3EC)->FlagsBits().m_hasReply =
-                reinterpret_cast<CCaravanWork::CLetterWork*>(letterSrc + 0x104)->FlagsBits().m_hasReply;
-            letterSrc += 0xC;
-            letterDst += sizeof(CCaravanWork::CLetterWork);
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->FlagsBits().m_attachmentIsGil =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->FlagsBits().m_attachmentIsGil;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->HeaderBitsRef().m_messageType =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->HeaderBitsRef().m_messageType;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->WordBitsRef().m_senderId =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->WordBitsRef().m_senderId;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->AttachmentBitsRef().m_value =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->AttachmentBitsRef().m_value;
+            memcpy(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3F0, src + count * 0xC + 0x108, 8);
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->FlagsBits().m_opened =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->FlagsBits().m_opened;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->FlagsBits().m_attachmentClaimed =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->FlagsBits().m_attachmentClaimed;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->FlagsBits().m_replySent =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->FlagsBits().m_replySent;
+            reinterpret_cast<CCaravanWork::CLetterWork*>(reinterpret_cast<u8*>(caravanWork) + count * 0xC + 0x3EC)->FlagsBits().m_hasReply =
+                reinterpret_cast<CCaravanWork::CLetterWork*>(src + count * 0xC + 0x104)->FlagsBits().m_hasReply;
         }
 
         for (int artifact = 0; artifact < 96; artifact++)

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1240,12 +1240,12 @@ void CMemoryCardMan::SetLoadData()
     u32 soundMode = static_cast<u32>(__cntlzw(Sound.GetSoundMode())) >> 5;
     Sound.SetStereo(soundMode);
 
-    CGame::CGameWork* gameWork = &Game.m_gameWork;
-    gameWork->m_gameInitFlag = MakeLoadBool(static_cast<s8>(save[0x13E0]));
-    gameWork->m_spModeFlags[0] = MakeLoadBool(static_cast<s8>(save[0x13E1]));
-    gameWork->m_spModeFlags[1] = MakeLoadBool(static_cast<s8>(save[0x13E2]));
-    gameWork->m_spModeFlags[2] = MakeLoadBool(static_cast<s8>(save[0x13E3]));
-    gameWork->m_spModeFlags[3] = MakeLoadBool(static_cast<s8>(save[0x13E4]));
+    CGame* g = &Game;
+    g->m_gameWork.m_gameInitFlag = MakeLoadBool(static_cast<s8>(save[0x13E0]));
+    g->m_gameWork.m_spModeFlags[0] = MakeLoadBool(static_cast<s8>(save[0x13E1]));
+    g->m_gameWork.m_spModeFlags[1] = MakeLoadBool(static_cast<s8>(save[0x13E2]));
+    g->m_gameWork.m_spModeFlags[2] = MakeLoadBool(static_cast<s8>(save[0x13E3]));
+    g->m_gameWork.m_spModeFlags[3] = MakeLoadBool(static_cast<s8>(save[0x13E4]));
 
     int count;
     int i;
@@ -1359,14 +1359,14 @@ void CMemoryCardMan::SetLoadData()
 
     for (unsigned int i = 0; i < 4; i++)
     {
-        int idx = gameWork->m_wmBackupParams[i];
+        int idx = g->m_gameWork.m_wmBackupParams[i];
         if (Game.m_caravanWorkArr[idx].m_shopState == 0)
         {
-            gameWork->m_wmBackupParams[i] = -1;
+            g->m_gameWork.m_wmBackupParams[i] = -1;
         }
         if (Game.m_caravanWorkArr[idx].m_shopBusyFlag != 0)
         {
-            gameWork->m_wmBackupParams[i] = -1;
+            g->m_gameWork.m_wmBackupParams[i] = -1;
         }
     }
 

--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1419,7 +1419,6 @@ void CMemoryCardMan::MakeSaveData()
     saveDat->m_rotateKey = static_cast<u8>(Math.Rand(0xFF));
     saveDat->m_flags = 0;
 
-    CGame::CGameWork* gameWork = &Game.m_gameWork;
     CGame* g = &Game;
     for (int i = 0; i < 4; i++)
     {
@@ -1465,7 +1464,7 @@ void CMemoryCardMan::MakeSaveData()
     {
         int letter;
         u8* dst = save + 0x14D0 + c * 0x9C0;
-        CCaravanWork* caravanWork = &Game.m_caravanWorkArr[c];
+        CCaravanWork* caravanWork = &g->m_caravanWorkArr[c];
 
         int shopState = caravanWork->m_shopState;
         if (shopState != 0 && static_cast<s8>(caravanWork->unk_0xc1e) == 0)


### PR DESCRIPTION
Raises main/memorycard from 99.47% to 99.66% (+0.19).

Per-function:
- Odekake: 98.97 -> 99.47 (inlined CalcCrc register roles via decl order + split loop counters; u64 serial copy; item cursor -> hoisted offset + index form)
- SetLoadData: 98.66 -> 99.13 (letter-loop accumulators -> index*stride per R86; CGame* g pointer like MakeSaveData fixes wmBackup IV anchor; u64 mcSerial/shopData copies)
- MakeSaveData: 98.94 -> 99.38 (letter-loop index*stride; caravan loop via g; u64 pair copies; CalcSaveCrc byte-temp drop)
- CalcCrc standalone: 100 -> 98.11 (net trade: the decl order that fixes both inline expansions in Odekake costs 10 lines in the standalone; unit-net strongly positive)

Key finds:
- The "staged word-pair r0<->rN swap" sites (mcSerial, shopData x5) are u64 copies in the original — `*(u64*)dst = *(u64*)src` reproduces the load-load/store-store pair with the long web in r0 exactly.
- R86 confirmed twice: converting letterSrc/letterDst accumulators to index*stride expressions lets the strength-reducer synthesize the inner-loop IVs, rotating the whole callee-saved assignment to match.
- SetLoadData's trailing wmBackup loop IV anchored at &Game (disp 0x20) requires the access web to be a CGame* local (g), not a CGameWork* — same spelling MakeSaveData already used.

Remaining residuals are bit-identical under all spellings tried (coloring tie-breaks): SetLoadData c/count color swap and volume-arg r0 staging, MakeSaveData save/rodata-base rank swap + one mr staging copy, Odekake add-operand order + one li placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)