### PR TITLE
cmake: raise fuzzy match to 99.0% (cycle 34)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2007,11 +2007,13 @@ void CMenuPcs::CmakeTribeDraw()
     tribeFont->DrawInit();
     tribeFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a255)).color);
 
+    int y = 0x88;
     for (int i = 0; i < 4; i++) {
         const char* txt = GetTribeStr(i);
         tribeFont->SetPosX(264.0f);
-        tribeFont->SetPosY(0x88 + i * 0x1C - 4.0f);
+        tribeFont->SetPosY(static_cast<float>(y) - 4.0f);
         tribeFont->Draw(txt);
+        y += 0x1C;
     }
 
     CFont* hairFont = m_fonts[CMAKE_FONT_VALUE];
@@ -2027,11 +2029,13 @@ void CMenuPcs::CmakeTribeDraw()
         hairBase += 4;
     }
 
+    y = 0x88;
     for (int i = 0; i < 4; i++) {
         const char* txt = GetHairStr(hairBase + i);
         hairFont->SetPosX(384.0f);
-        hairFont->SetPosY(0x88 + i * 0x1C - 4.0f);
+        hairFont->SetPosY(static_cast<float>(y) - 4.0f);
         hairFont->Draw(txt);
+        y += 0x1C;
     }
 
     DrawInit();

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3941,13 +3941,17 @@ void CMenuPcs::CalcSingCMake()
                     if ((down & 0x100) != 0) {
                         if (CmakeState(this)->m_select == 0) {
                             CmakeState(this)->m_resultDir = 1;
-                            *reinterpret_cast<int*>(MenuS32(this, 0x844) + CmakeSlot(this) * 0x14 + 4) = 3;
+                            int chgWork = CmakeSlot(this) * 0x14;
+                            chgWork += MenuS32(this, 0x844);
+                            *reinterpret_cast<int*>(chgWork + 4) = 3;
 
                             CCaravanWork* caravanWork;
                             int slot = static_cast<int>(CmakeSlot(this));
                             int modelNo = GetModelNo(static_cast<int>(s_CmakeInfo.m_tribe), static_cast<int>(s_CmakeInfo.m_hair),
                                 static_cast<int>(s_CmakeInfo.m_gender));
-                            *reinterpret_cast<int*>(MenuS32(this, 0x824) + slot * 0x34 + 8) = modelNo;
+                            int animWork = slot * 0x34;
+                            animWork += MenuS32(this, 0x824);
+                            *reinterpret_cast<int*>(animWork + 8) = modelNo;
 
                             caravanWork = &Game.m_caravanWorkArr[slot];
                             *reinterpret_cast<unsigned char*>(MenuS32(this, 0x828) + 10) = 1;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2789,13 +2789,14 @@ int CMenuPcs::CmakeNameCtrl()
             } else if ((down & 0x200) != 0) {
                 unsigned int bsLen0 = strlen(s_CmakeInfo.m_name);
                 if ((bsLen0 & (static_cast<int>(-bsLen0 | bsLen0) >> 31)) != 0) {
+                    const char* name = s_CmakeInfo.m_name;
                     int bsRet;
-                    unsigned int bsLen1 = strlen(s_CmakeInfo.m_name);
+                    unsigned int bsLen1 = strlen(name);
                     if ((bsLen1 & (static_cast<int>(-bsLen1 | bsLen1) >> 31)) == 0) {
                         bsRet = -1;
                     } else {
                         int bsPos = strlen(s_CmakeInfo.m_name);
-                        if ((__cntlzw(static_cast<unsigned int>(strlen(s_CmakeInfo.m_name))) >> 5 & 1) == 0) {
+                        if (-((__cntlzw(strlen(name)) & 0x20) >> 5) == 0) {
                             s_CmakeInfo.m_name[bsPos - 1] = '\0';
                         } else {
                             s_CmakeInfo.m_name[bsPos - 2] = '\0';

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -553,7 +553,9 @@ void CMenuPcs::DrawSingleCMakeChara(float alpha)
 void CMenuPcs::CalcSingleCMakeChara()
 {
     int slot = static_cast<int>(CmakeSlot(this));
-    unsigned char* modelWork = reinterpret_cast<unsigned char*>(MenuS32(this, 0x814) + slot * 0x50 + 0xA00);
+    int workOff = slot * 0x50 + 0xA00;
+    workOff += MenuS32(this, 0x814);
+    unsigned char* modelWork = reinterpret_cast<unsigned char*>(workOff);
 
     if (GetCmakeCharaHandle(this, slot)->m_model == nullptr ||
         *reinterpret_cast<unsigned int*>(reinterpret_cast<unsigned char*>(GetCmakeCharaHandle(this, slot)->m_model) + 0xB0) == 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1019,6 +1019,8 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             row = 5;
             Sound.PlaySe(2, 0x40, 0x7f, 0);
         } else if ((down & 0x100) != 0) {
+            short curTable;
+            short curSelect;
             short curRow = row;
             if (curRow >= 5) {
             unsigned int emptyLen = strlen(s_CmakeInfo.m_name);
@@ -1044,8 +1046,8 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             villageWork->m_resultDir = 1;
             return 1;
         } else {
-            short curTable = table;
-            short curSelect = select;
+            curSelect = select;
+            curTable = table;
             memset(picked, 0, 3);
             picked[0] = '\0';
             const char* rowText = s_NameEntryStr[curRow + curTable * 5];
@@ -2690,6 +2692,8 @@ int CMenuPcs::CmakeNameCtrl()
                 CmakeState(this)->m_row = 5;
                 Sound.PlaySe(2, 0x40, 0x7F, 0);
             } else if ((down & 0x100) != 0) {
+                short curTable;
+                short curSelect;
                 short curRow = CmakeState(this)->m_row;
                 if (curRow >= 5) {
                     int emptyLen = strlen(s_CmakeInfo.m_name);
@@ -2723,8 +2727,8 @@ int CMenuPcs::CmakeNameCtrl()
                         return 1;
                     }
                 } else {
-                    short curTable = CmakeState(this)->m_table;
-                    short curSelect = CmakeState(this)->m_select;
+                    curTable = CmakeState(this)->m_table;
+                    curSelect = CmakeState(this)->m_select;
                     char picked[12];
                     memset(picked, 0, 3);
                     picked[0] = '\0';

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -922,6 +922,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
     short& table = villageWork->m_table;
     short repeat;
     short down;
+    const char* name;
     char picked[8];
 
     bool padBusy = false;
@@ -1113,8 +1114,8 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         } else if ((down & 0x200) != 0) {
             unsigned int bsLen0 = strlen(s_CmakeInfo.m_name);
             if ((bsLen0 & (static_cast<int>(-bsLen0 | bsLen0) >> 31)) != 0) {
-                const char* name = s_CmakeInfo.m_name;
                 int bsRet;
+                name = s_CmakeInfo.m_name;
                 unsigned int bsLen1 = strlen(name);
                 if ((bsLen1 & (static_cast<int>(-bsLen1 | bsLen1) >> 31)) == 0) {
                     bsRet = -1;
@@ -2588,6 +2589,7 @@ int CMenuPcs::CmakeNameCtrl()
 {
     short repeat;
     short down;
+    const char* name;
 
     bool padBusy = false;
     int padLock = Pad.m_debugPadLock;
@@ -2797,8 +2799,8 @@ int CMenuPcs::CmakeNameCtrl()
             } else if ((down & 0x200) != 0) {
                 unsigned int bsLen0 = strlen(s_CmakeInfo.m_name);
                 if ((bsLen0 & (static_cast<int>(-bsLen0 | bsLen0) >> 31)) != 0) {
-                    const char* name = s_CmakeInfo.m_name;
                     int bsRet;
+                    name = s_CmakeInfo.m_name;
                     unsigned int bsLen1 = strlen(name);
                     if ((bsLen1 & (static_cast<int>(-bsLen1 | bsLen1) >> 31)) == 0) {
                         bsRet = -1;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1253,8 +1253,7 @@ void CMenuPcs::CmakeResultDraw1()
     labelFont->SetScale(1.0f);
     labelFont->DrawInit();
 
-    CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
-    labelFont->SetColor(color.color);
+    labelFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
 
     float labelWidths[4];
     for (int i = 0; i < 4; i++) {
@@ -1271,8 +1270,7 @@ void CMenuPcs::CmakeResultDraw1()
     valueFont->SetShadow(1);
     valueFont->SetScale(1.0f);
     valueFont->DrawInit();
-    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
-    valueFont->SetColor(valueColor.color);
+    valueFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
     valueFont->SetTlut(6);
 
     char tribeWithSlash[0x10];
@@ -1503,8 +1501,7 @@ void CMenuPcs::CmakeResultDraw()
     labelFont->SetScale(1.0f);
     labelFont->DrawInit();
 
-    CColor color(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
-    labelFont->SetColor(color.color);
+    labelFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
 
     float labelWidths[4];
     int labelY = 0x70;
@@ -1523,8 +1520,7 @@ void CMenuPcs::CmakeResultDraw()
     valueFont->SetShadow(1);
     valueFont->SetScale(1.0f);
     valueFont->DrawInit();
-    CColor valueColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha));
-    valueFont->SetColor(valueColor.color);
+    valueFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
     valueFont->SetTlut(6);
 
     char tribeWithSlash[0x10];

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2007,9 +2007,10 @@ void CMenuPcs::CmakeTribeDraw()
     tribeFont->DrawInit();
     tribeFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(a255)).color);
 
+    const char* txt;
     int y = 0x88;
     for (int i = 0; i < 4; i++) {
-        const char* txt = GetTribeStr(i);
+        txt = GetTribeStr(i);
         tribeFont->SetPosX(264.0f);
         tribeFont->SetPosY(static_cast<float>(y) - 4.0f);
         tribeFont->Draw(txt);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1042,7 +1042,9 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
                 return 0;
             }
 
-            StoreCmakeVillageName();
+            char* townName = Game.m_gameWork.m_townName;
+            memset(townName, 0, 17);
+            strcpy(townName, s_CmakeInfo.m_name);
             Sound.PlaySe(2, 0x40, 0x7f, 0);
             villageWork->m_resultDir = 1;
             return 1;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1021,6 +1021,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
         } else if ((down & 0x100) != 0) {
             short curTable;
             short curSelect;
+            const char* rowText;
             short curRow = row;
             if (curRow >= 5) {
             unsigned int emptyLen = strlen(s_CmakeInfo.m_name);
@@ -1049,7 +1050,7 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             curTable = table;
             curSelect = select;
             memset(picked, 0, 3);
-            const char* rowText = s_NameEntryStr[curRow + curTable * 5];
+            rowText = s_NameEntryStr[curRow + curTable * 5];
             picked[0] = '\0';
             int rowLen = strlen(rowText);
             if (rowLen != 0) {
@@ -2694,6 +2695,7 @@ int CMenuPcs::CmakeNameCtrl()
             } else if ((down & 0x100) != 0) {
                 short curTable;
                 short curSelect;
+                const char* rowText;
                 short curRow = CmakeState(this)->m_row;
                 if (curRow >= 5) {
                     int emptyLen = strlen(s_CmakeInfo.m_name);
@@ -2731,7 +2733,7 @@ int CMenuPcs::CmakeNameCtrl()
                     curSelect = CmakeState(this)->m_select;
                     char picked[12];
                     memset(picked, 0, 3);
-                    const char* rowText = s_NameEntryStr[curRow + curTable * 5];
+                    rowText = s_NameEntryStr[curRow + curTable * 5];
                     picked[0] = '\0';
                     int rowLen = strlen(rowText);
                     if (rowLen != 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2187,6 +2187,7 @@ int CMenuPcs::CmakeTribeCtrl()
                         GetWinSize(0x15, &winX, &winY, 0);
                         SetMcWinInfo(static_cast<int>(winX), static_cast<int>(winY));
                         CmakeMcState(this) = 0;
+                        return 0;
                     } else {
                         s_CmakeInfo.m_tribe = static_cast<signed char>(CmakeState(this)->m_select);
                         s_CmakeInfo.m_hair = static_cast<signed char>(CmakeState(this)->m_row);

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2500,10 +2500,10 @@ void CMenuPcs::CmakeNameDraw()
 
     if ((CmakeState(this)->m_mode == 1) && (CmakeState(this)->m_row < 5)) {
         short sel = CmakeState(this)->m_select;
-        int cursorBase = (CmakeState(this)->m_row < 5) ? 0xE5 : 0xE5;
+        int cellX = (CmakeState(this)->m_row < 5) ? 0xE5 : 0xE5;
         int cursorY = CmakeState(this)->m_row * 0x20 + 0x63;
-        int cellX = static_cast<int>(
-            26.9f * static_cast<float>(sel) + static_cast<float>(cursorBase));
+        cellX = static_cast<int>(
+            26.9f * static_cast<float>(sel) + static_cast<float>(cellX));
         SetCmakeBlendMatColor(1.0f);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 0x64 : 0x3D));
         MenuPcs.DrawRect(

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1046,11 +1046,11 @@ unsigned short CMenuPcs::CmakeVillageCtrl()
             villageWork->m_resultDir = 1;
             return 1;
         } else {
-            curSelect = select;
             curTable = table;
+            curSelect = select;
             memset(picked, 0, 3);
-            picked[0] = '\0';
             const char* rowText = s_NameEntryStr[curRow + curTable * 5];
+            picked[0] = '\0';
             int rowLen = strlen(rowText);
             if (rowLen != 0) {
                 int i = 0;
@@ -2731,8 +2731,8 @@ int CMenuPcs::CmakeNameCtrl()
                     curSelect = CmakeState(this)->m_select;
                     char picked[12];
                     memset(picked, 0, 3);
-                    picked[0] = '\0';
                     const char* rowText = s_NameEntryStr[curRow + curTable * 5];
+                    picked[0] = '\0';
                     int rowLen = strlen(rowText);
                     if (rowLen != 0) {
                         int i = 0;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -834,10 +834,10 @@ void CMenuPcs::CmakeVillageDraw()
 
     if (villageWork->m_mode == 1 && villageWork->m_row < 5) {
         short sel = villageWork->m_select;
-        int cursorBase = (villageWork->m_row < 5) ? 0xE5 : 0xE5;
+        int cursorX = (villageWork->m_row < 5) ? 0xE5 : 0xE5;
         int cursorY = villageWork->m_row * 0x20 + 0x63;
-        int cursorX = static_cast<int>(
-            26.9f * static_cast<float>(sel) + static_cast<float>(cursorBase));
+        cursorX = static_cast<int>(
+            26.9f * static_cast<float>(sel) + static_cast<float>(cursorX));
         SetCmakeBlendMatColor(1.0f);
         MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>((CmakeResult(this) != 0) ? 100 : 0x3D));
         MenuPcs.DrawRect(
@@ -2647,7 +2647,7 @@ int CMenuPcs::CmakeNameCtrl()
             Sound.PlaySe(1, 0x40, 0x7F, 0);
         } else if ((repeat & 0x4) != 0) {
             short sel = CmakeState(this)->m_select;
-            if (CmakeState(this)->m_row < (sel >= 10 ? 5 : 4)) {
+            if ((sel >= 10 ? 5 : 4) > CmakeState(this)->m_row) {
                 CmakeState(this)->m_row = static_cast<short>(CmakeState(this)->m_row + 1);
             } else {
                 CmakeState(this)->m_row = 0;

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1255,6 +1255,7 @@ void CMenuPcs::CmakeResultDraw1()
 
     labelFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
 
+    char tribeWithSlash[0x10];
     float labelWidths[4];
     for (int i = 0; i < 4; i++) {
         const char* txt = GetMenuStr(0x2A + i);
@@ -1273,7 +1274,6 @@ void CMenuPcs::CmakeResultDraw1()
     valueFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
     valueFont->SetTlut(6);
 
-    char tribeWithSlash[0x10];
     for (int i = 0; i < 4; i++) {
         const char* txt = "";
 
@@ -1503,6 +1503,7 @@ void CMenuPcs::CmakeResultDraw()
 
     labelFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
 
+    char tribeWithSlash[0x10];
     float labelWidths[4];
     int labelY = 0x70;
     for (int i = 0; i < 4; i++) {
@@ -1523,7 +1524,6 @@ void CMenuPcs::CmakeResultDraw()
     valueFont->SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(255.0f * alpha)).color);
     valueFont->SetTlut(6);
 
-    char tribeWithSlash[0x10];
     for (int i = 0; i < 4; i++) {
         const char* value = "";
         if (i == 0) {

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2797,7 +2797,6 @@ int CMenuPcs::CmakeNameCtrl()
                         }
                         Sound.PlaySe(2, 0x40, 0x7F, 0);
                     }
-                    return 0;
                 }
             } else if ((down & 0x200) != 0) {
                 unsigned int bsLen0 = strlen(s_CmakeInfo.m_name);


### PR DESCRIPTION
Raises main/cmake from 98.80% to 99.02% (report.json fuzzy_match_percent, re-measured after rebase onto main).

Per-function gains:
- CmakeNameCtrl 97.88 -> 98.7+: backspace block aligned to VillageCtrl's proven shape (named `name` pointer + `-((__cntlzw & 0x20) >> 5)` form); reversed bound compare in the repeat&4 arm; dropped a decompiler-inserted early `return 0` so the letter arm reaches the shared tail (R76).
- CmakeVillageCtrl 99.45 -> 99.7+ (4 flagged lines left): curTable/curSelect decl-hoist before curRow; rowText decl hoist + computed before picked[0]; open-coded StoreCmakeVillageName with a named townName pointer.
- CalcSingleCMakeChara 96.80 -> 99.45: workOff accumulation (`int workOff = slot*0x50 + 0xA00; workOff += MenuS32(...)`) defeats constant distribution into displacements (R78).
- CalcSingCMake 98.93 -> 99.65: same accumulate recipe on the two displacement stores (chgWork/animWork), +0.069 unit in one edit.
- CmakeTribeCtrl 99.50 -> 99.9 (2 flagged lines left): explicit `return 0` in the duplicate-name arm (R76 inverse).
- CmakeTribeDraw 97.97 -> 98.4+: shared named `y` IV re-initialized across both font loops; txt decl hoisted out of loop 1.
- CmakeResultDraw/Draw1: CColor ctor temps passed directly to SetColor (kills frame-slot reads); tribeWithSlash declared before labelWidths fixes array slot order.

What worked: R78 accumulate-into-the-variable (3 separate wins, biggest single lever), R76 return-path archaeology in both directions, decl-hoist web re-ranking, the VillageCtrl-proven backspace shape.

Confirmed walls (bit-identical or regressive under all attempted spellings): the `li r4,0; mr r5,r4` j=i synthetic-copy seed in the picked-char loops (4 sites); ptr/value scratch-pair numbering in the Ctrl select arms (descending vs ascending); the callee-saved band rotation in the Draw family (font/handleIndex webs, incl. JobDraw's mirrored temp-slot cluster); Game@l copy-prop direction (addi rN direct vs addi r3 + mr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)