### PR TITLE
p_graphic: raise fuzzy match to 96.9% (cycle 20)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -323,7 +323,7 @@ void CGraphicPcs::drawScreenFade()
                 pos.y += slotData->m_targetYOffs;
                 PSMTX44MultVec(worldScreenMtx, &pos, &pos);
 
-                const float sx = kGraphicScreenCenterX * pos.x + kGraphicScreenCenterX;
+                const float sx = pos.x * kGraphicScreenCenterX + kGraphicScreenCenterX;
                 const float sy = kGraphicScreenCenterY - kGraphicScreenCenterY * pos.y;
                 pos.x = sx;
                 pos.y = sy;


### PR DESCRIPTION
Raises main/p_graphic fuzzy match 96.886% -> 96.888%.

- drawScreenFade (99.26% -> 99.28%): sx centering math operand order (`pos.x * kGraphicScreenCenterX + kGraphicScreenCenterX`) matches the original FPR web creation order in the slot-2 circle-target block.

Cycle 20 verdict on the residual c19 walls (extensively swept this cycle, ~50 variants):
- drawSFCircle quad-loop GPR band, drawBar head/arm/indicator FPR bands, and drawScreenFade f28/f29 + scratch-FPR bands are all pure DIFF_ARG_MISMATCH register-number permutations that are bit-identical or regress under every known lever (R36/R48/R52/R54/R56/R58/R60/R70/R72/R75/R80/R86-R90, named-vs-direct, decl orders, pragma scopes, 5-arg overload, Ghidra-shape restructuring). They match the gxfunc-c7 TRUE-WALL signature (VN-canonicalized tie-breaks).
- Remaining named-vs-anonymous sda21 reloc diffs (kIntToDoubleBias/@716 etc.) are display-only (cost ~zero).
- __sinit (48.4%) is the known data.0-base CSE wall (skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)