### PR TITLE
gobject: raise fuzzy match to 99.1% (cycle 26)

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -24,12 +24,13 @@ public:
 	CBound(float min, float max)
 	{
 		float lo = min;
+		float hi = max;
 		m_min.z = lo;
 		m_min.y = lo;
 		m_min.x = lo;
-		m_max.z = max;
-		m_max.y = max;
-		m_max.x = max;
+		m_max.z = hi;
+		m_max.y = hi;
+		m_max.x = hi;
 	}
 	static void SetFrustum(Vec&, float(*)[4]);
 	int CheckFrustum0(CBound&);

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -699,7 +699,7 @@ void CGObject::move()
             moveVec.x = sZeroFloat;
 
             u32 miniGameFlags = DbgMenuPcs.GetDbgFlagsRaw();
-            if ((miniGameFlags & 0x100) != 0 && moveVec.x == sZeroFloat) {
+            if ((miniGameFlags & 0x100) != 0 && moveVec.x == sZeroFloat && moveVec.x == sZeroFloat) {
                 const float stickX = GetMovePadStickX(static_cast<s8>(m_animStateMisc));
                 moveVec.x = moveVec.x - stickX;
                 const float stickY = GetMovePadStickY(static_cast<s8>(m_animStateMisc));

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -3064,9 +3064,13 @@ int CGObject::IsAnimFinished(int mode)
         hasModel = true;
     }
 
-    if (hasModel) {
+    if (!hasModel) {
+        goto returnOne;
+    }
+    {
         slot = m_currentAnimSlot;
         if (slot == -1) {
+        returnOne:
             return 1;
         }
         {
@@ -3119,8 +3123,6 @@ int CGObject::IsAnimFinished(int mode)
             return result & 0xFF;
         }
     }
-
-    return 1;
 }
 #pragma pop
 

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -343,7 +343,7 @@ extern "C" const double sPitchLookCutoff = 0.7853981852531433; // DOUBLE_803303e
 extern "C" const float sLookBlendScale;            // FLOAT_803303f0 (0.001)
 extern "C" const float sFarVisibleDepth;           // FLOAT_803303f4 (10000)
 extern "C" const float sNearVisibleDepth;          // FLOAT_803303f8 (750)
-extern const double DOUBLE_80330400 = 0.0010000000474974513;   // 3f50624de0000000 = (double)0.001f
+// DOUBLE_80330400 defined at end of file
 
 /*
  * --INFO--
@@ -1060,6 +1060,7 @@ void CGObject::bgCollision()
  */
 void CGObject::bgNormalCollision()
 {
+    extern const double DOUBLE_80330400;
     if (fabs(static_cast<double>(m_groundHitOffset.x)) < DOUBLE_80330400) {
         m_groundHitOffset.x = sZeroFloat;
     }
@@ -1273,8 +1274,7 @@ void CGObject::bgWorldCollision()
         Vec delta;
 
         MapMng.m_hitMapObj->CalcHitPosition(&radial);
-        const Vec& newOffset = vecSub(reinterpret_cast<CVector&>(radial), CVector(m_worldPosition));
-        m_groundHitOffset = delta = newOffset;
+        m_groundHitOffset = delta = vecSub(reinterpret_cast<CVector&>(radial), CVector(m_worldPosition));
 
         if ((MapMng.GetMapIdGrpArray()[gMapHitFace->m_groupIndex].m_mask & 0x20) == 0) {
             m_stateFlags0Bits.unk0 = 1;
@@ -1972,6 +1972,7 @@ void CGObject::update()
         }
     }
 
+    extern const double DOUBLE_80330400;
     m_groundHitOffset.x *= m_moveOffset.x;
     m_groundHitOffset.y *= m_moveOffset.y;
     m_groundHitOffset.z *= m_moveOffset.z;
@@ -3654,3 +3655,5 @@ int CGObject::GetCID()
 {
 	return 5;
 }
+
+extern const double DOUBLE_80330400 = 0.0010000000474974513;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1081,11 +1081,12 @@ void CGObject::bgNormalCollision()
     pos.y += sStepProbeHeight + m_capsuleHalfHeight;
 
     unsigned int retry = 4;
-    const double epsilon = DOUBLE_80330400;
+    double epsilon;
     float boundMax;
     float boundMin;
     boundMin = sHugeCylinderExtent;
     boundMax = sNegHugeCylinderExtent;
+    epsilon = DOUBLE_80330400;
     do {
         const unsigned long hitMask = m_bgHitMask;
         const float radius = m_capsuleHalfHeight;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -2671,9 +2671,12 @@ void CGObject::boundCheck()
     PSMTX44Concat(screenMtx, clipMtx, screenMtx);
 
     if ((m_charaModelHandle != 0) && (m_charaModelHandle->m_model != 0)) {
-        const float zero = sZeroFloat;
-        const float oneF = sAnimFrameOffset;
-        const float clipLimit = sNegativeOne;
+        float clipLimit;
+        float oneF;
+        float zero;
+        zero = sZeroFloat;
+        oneF = sAnimFrameOffset;
+        clipLimit = sNegativeOne;
 
         clipMask = 0x1F;
         s32 i = 0;

--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -1076,16 +1076,20 @@ void CGObject::bgNormalCollision()
     }
 
     Vec move = m_groundHitOffset;
-    move.y = sZeroFloat;
+    move.y = 0.0f;
     Vec pos = m_worldPosition;
     pos.y += sStepProbeHeight + m_capsuleHalfHeight;
 
     unsigned int retry = 4;
     const double epsilon = DOUBLE_80330400;
+    float boundMax;
+    float boundMin;
+    boundMin = sHugeCylinderExtent;
+    boundMax = sNegHugeCylinderExtent;
     do {
         const unsigned long hitMask = m_bgHitMask;
         const float radius = m_capsuleHalfHeight;
-        CMapCylinder bodyCylinder(sHugeCylinderExtent, sNegHugeCylinderExtent);
+        CMapCylinder bodyCylinder(boundMin, boundMax);
         bodyCylinder.m_bottom = pos;
         bodyCylinder.m_axis = move;
         bodyCylinder.m_radius = radius;


### PR DESCRIPTION
Raises main/gobject from 98.98% to **99.10%** (whole-report net +0.0002 including a shared-header change verified across all units).

Per-function gains:
- **IsAnimFinished 96.22 -> 98.72**: goto-shared `return 1` block — the `!hasModel` and `slot == -1` early returns share one physical `li r3,1; blr` block (R14/R76 return-path archaeology).
- **move 98.44 -> 98.59**: duplicated NaN-conjunct `moveVec.x == sZeroFloat && moveVec.x == sZeroFloat` reproduces the target's dead double-bne on stale cr0 (R81 family).
- **boundCheck 99.82 -> 100.00**: reverse decl-then-assign for the zero/one/negOne constant batch (R36/R75 — later-declared local gets the lower callee-saved FPR).
- **bgNormalCollision 98.93 -> 99.76**: staged cylinder bounds through decl-ordered named locals + late epsilon assignment placement + per-site zero remat (`0.0f` literal where the target reloads); named `DOUBLE_80330400` reloc via block-scope extern decls + definition after all uses (R46).
- **bgWorldCollision 99.23 -> 99.34**: chained `m_groundHitOffset = delta = vecSub(...)` (R33) restores the helper-out temp slot order.
- **CBound ctor (shared header)**: symmetric `lo`/`hi` staging re-ranks cylinder-setup scratch FPRs across gobject's four CMapCylinder sites (gobject +0.02, maphit -0.027, whole-report net positive — verified).

Confirmed walls (bit-identical under all spellings/pragma sweeps): onCreate 92.14 (li r0 ctr-seed scheduling collision rotates the -1/cursor/scratch GPR web — gxfunc-c7-class coloring tie-break; plain-loop R86 rewrites, named-pin clusters, scheduling pragmas all regress), bgAttribCollision 96.20 (mr r7,r3 ctor-result vacate, twice), CCClass FPR rotation, InitWork r12 vtable staging, update/objectCollision residual reg webs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)