### PR TITLE
maphit: raise fuzzy match to 99.56% (cycle 13)

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -502,7 +502,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
 
     {
         PSVECScale(hitDirection, &g_hit_hpv, hitT);
-        PSVECAdd(&g_hit_cyl.m_bottom, &g_hit_hpv, &g_hit_hpv);
+        PSVECAdd(&cyl.m_bottom, &g_hit_hpv, &g_hit_hpv);
 
         Vec pushedHit;
         Vec scaledNormal;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -655,7 +655,7 @@ edge_loop:
                 CMapCylinder edgeCylinder;
                 edgeCylinder.m_bottom = previous;
                 edgeCylinder.m_axis = edge;
-                edgeCylinder.m_radius = g_hit_cyl.m_radius;
+                edgeCylinder.m_radius = cyl.m_radius;
 
                 float edgeT;
                 if (FindIntersection(rayStart, rayDirection, edgeCylinder, edgeT) != 0 &&

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -480,7 +480,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
         return 0;
     }
 
-    Vec* hitDirection = &cyl.m_axis;
+    Vec* hitDirection = reinterpret_cast<Vec*>(Ptr(&g_hit_cyl, 0x18));
     float dot = PSVECDotProduct(hitDirection, &g_hit_lpface->m_normal);
     if (dot >= kMapHitZero) {
         return 0;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -649,7 +649,7 @@ edge_loop:
                 Vec edge;
                 PSVECSubtract(&current, &previous, &edge);
 
-                Vec rayDirection = *hitDirection;
+                Vec rayDirection = *reinterpret_cast<Vec*>(Ptr(&g_hit_cyl, 0x18));
                 Vec rayStart = cyl.m_bottom;
 
                 CMapCylinder edgeCylinder;

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -508,7 +508,7 @@ int CMapHit::CheckHitFaceCylinder(unsigned long mask)
         Vec scaledNormal;
         Vec edgeStart;
         Vec edgeEnd;
-        PSVECScale(&g_hit_lpface->m_normal, &scaledNormal, g_hit_cyl.m_radius);
+        PSVECScale(&g_hit_lpface->m_normal, &scaledNormal, cyl.m_radius);
         PSVECSubtract(&g_hit_hpv, &scaledNormal, &pushedHit);
 
         unsigned int sideMask = 3;


### PR DESCRIPTION
Raises main/maphit from 99.516% to 99.560% (matched_data 65.2% -> 91.9%).

All gains in CheckHitFaceCylinder (98.14 -> 98.35):
- hitDirection computed via byte-offset Ptr(&g_hit_cyl, 0x18) — reproduces the target's two-step addi (base copy + 0x18 advance) and lands the hitDirection web at r28 matching the target rank; also flips the bss anchor reloc to the named g_hit_cyl symbol, jumping matched_data.
- rayDirection loaded through the same Ptr spelling.
- scaledNormal/edgeCylinder radius and PSVECAdd bottom respelled through the cyl reference (mixed ref/global spelling per R73 controls the region CSE-copy webs).

Remaining residuals are verified tie-break walls (~40 variants swept, all bit-identical or regressive): the this-param top-rank rotation in CheckHitFaceCylinder (every this-spelling canonicalizes; inline-wrapper route blocked by the goto-body always_inline FACT), the 5-arg wrapper offset-IV/endFace r30/r31 swap, Draw loop2 face/faceIndex split-web swap, and FindIntersection's negB/z-test scratch-FPR 2-cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)