### PR TITLE
map: raise fuzzy match to 99.41% (cycle 15)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2773,8 +2773,8 @@ void CMapMng::Draw()
 
                     CharaPcs.GetTexShadow(startIndex, batchCount, texObjs, shadowPositions, shadowMatrices);
 
-                    texMtx = 0x1E;
                     int stage = 0;
+                    texMtx = 0x1E;
                     for (int i = 0; i < batchCount; i++) {
                         GXLoadTexMtxImm(shadowMatrices[i], texMtx, GX_MTX3x4);
                         GXLoadTexObj(&texObjs[i], static_cast<GXTexMapID>(i));

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2609,10 +2609,9 @@ inline void setDbgLight(int lightId, Vec& lightDir, _GXColor& lightColor)
     Mtx cameraMtx;
     PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
 
-    float dirZ = lightDir.z;
-    float dirY = lightDir.y;
-
     v.x = kMapLargeDistance * -lightDir.x;
+    float dirY = lightDir.y;
+    float dirZ = lightDir.z;
     v.y = kMapLargeDistance * -dirY;
     v.z = kMapLargeDistance * -dirZ;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2609,8 +2609,8 @@ inline void setDbgLight(int lightId, Vec& lightDir, _GXColor& lightColor)
     Mtx cameraMtx;
     PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
 
-    float dirY = lightDir.y;
     float dirZ = lightDir.z;
+    float dirY = lightDir.y;
 
     v.x = kMapLargeDistance * -lightDir.x;
     v.y = kMapLargeDistance * -dirY;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2604,14 +2604,14 @@ inline void setDbgLight(int lightId, Vec& lightDir, _GXColor& lightColor)
     extern const float kMapZero;
     extern const float kMapTinyEpsilon;
 
+    GXLightObj lightObj;
+    Vec v;
     Mtx cameraMtx;
     PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
 
     float dirY = lightDir.y;
     float dirZ = lightDir.z;
 
-    GXLightObj lightObj;
-    Vec v;
     v.x = kMapLargeDistance * -lightDir.x;
     v.y = kMapLargeDistance * -dirY;
     v.z = kMapLargeDistance * -dirZ;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1493,10 +1493,11 @@ void CMapMng::LoadMapNoSyncCalc()
  */
 CMapObj* CMapMng::SearchChildMapObj(CMapObj* searchStart, CMapObj* parentObj)
 {
+    CMapObj* obj = searchStart;
     const int objCount = m_mapObjCount;
     CMapObj* mapObjEnd = m_mapObjArray + objCount;
 
-    for (CMapObj* obj = searchStart; obj < mapObjEnd; obj++) {
+    for (; obj < mapObjEnd; obj++) {
         if (obj->m_parent == parentObj) {
             return obj;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2744,6 +2744,7 @@ void CMapMng::Draw()
             GXSetZMode(1, GX_LEQUAL, 1);
             LightPcs.SetNumDiffuse(0);
 
+            int texMtx;
             int shadowCount = CharaPcs.GetNumTexShadow();
             if (shadowCount != 0) {
                 _GXTexObj texObjs[8];
@@ -2772,7 +2773,7 @@ void CMapMng::Draw()
 
                     CharaPcs.GetTexShadow(startIndex, batchCount, texObjs, shadowPositions, shadowMatrices);
 
-                    int texMtx = 0x1E;
+                    texMtx = 0x1E;
                     int stage = 0;
                     for (int i = 0; i < batchCount; i++) {
                         GXLoadTexMtxImm(shadowMatrices[i], texMtx, GX_MTX3x4);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2610,8 +2610,9 @@ inline void setDbgLight(int lightId, Vec& lightDir, _GXColor& lightColor)
     PSMTXCopy(CameraPcs.m_cameraMatrix, cameraMtx);
 
     v.x = kMapLargeDistance * -lightDir.x;
+    float dirZ;
     float dirY = lightDir.y;
-    float dirZ = lightDir.z;
+    dirZ = lightDir.z;
     v.y = kMapLargeDistance * -dirY;
     v.z = kMapLargeDistance * -dirZ;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2222,9 +2222,8 @@ int CMapMng::ReadOtm(char* mapName)
     }
 
     for (int i = 0; i < m_octTreeCount; i++) {
-        CMapObj* mapObj = m_octTreeArray[i].GetMapObject();
-        if (mapObj != 0) {
-            mapObj->m_octTreeIndex = static_cast<signed char>(i);
+        if (m_octTreeArray[i].GetMapObject() != 0) {
+            m_octTreeArray[i].GetMapObject()->m_octTreeIndex = static_cast<signed char>(i);
         }
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2928,16 +2928,12 @@ void CMapMng::Draw()
 
         CameraPcs.SetOffsetZBuff(kMapHitWireZOffset);
 
-        CMapObj* mapObj = MapMng.GetMapObjArray();
         for (int i = 0; i < m_mapObjCount; i++) {
-            mapObj->DrawHitWire();
-            mapObj++;
+            MapMng.m_mapObjArray[i].DrawHitWire();
         }
 
-        mapObj = MapMng.GetMapObjArray();
         for (int i = 0; i < m_mapObjCount; i++) {
-            mapObj->DrawHitNormal();
-            mapObj++;
+            MapMng.m_mapObjArray[i].DrawHitNormal();
         }
 
         CameraPcs.SetOffsetZBuff(kMapZero);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2315,6 +2315,8 @@ int CMapMng::ReadOtm(char* mapName)
  */
 int CMapMng::ReadMid(char* mapName)
 {
+    CFile::CHandle* handle;
+    int size;
     char* strTmp = g_StrTmp;
     sprintf(strTmp, const_cast<char*>(s_mapMidPathFmt), mapName);
     int ok = 1;
@@ -2325,7 +2327,7 @@ int CMapMng::ReadMid(char* mapName)
 
     void* filePtr;
     if (m_asyncLoadState.m_mapReadMode == 1) {
-        const int size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
+        size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
         filePtr = File.m_readBuffer;
 
         Memory.CopyFromAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>((size + 0x1F) & ~0x1F));
@@ -2333,19 +2335,19 @@ int CMapMng::ReadMid(char* mapName)
         CheckSum(filePtr, size);
         m_asyncLoadState.m_asyncReadIndex += 1;
     } else {
-        CFile::CHandle* fileHandle = File.Open(strTmp, 0, CFile::PRI_LOW);
-        if (fileHandle != 0) {
-            const int size = File.GetLength(fileHandle);
+        handle = File.Open(strTmp, 0, CFile::PRI_LOW);
+        if (handle != 0) {
+            size = File.GetLength(handle);
             if (m_asyncLoadState.m_mapReadMode == 3) {
-                File.ReadASync(fileHandle);
+                File.ReadASync(handle);
                 filePtr = reinterpret_cast<void*>(1);
-                m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = fileHandle;
+                m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = handle;
                 m_asyncLoadState.m_asyncOpenIndex += 1;
             } else {
-                File.Read(fileHandle);
-                File.SyncCompleted(fileHandle);
+                File.Read(handle);
+                File.SyncCompleted(handle);
                 filePtr = File.m_readBuffer;
-                File.Close(fileHandle);
+                File.Close(handle);
 
                 if (m_asyncLoadState.m_mapReadMode == 2) {
                     Memory.CopyToAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>(size));

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2243,8 +2243,9 @@ int CMapMng::ReadOtm(char* mapName)
     PSMTXIdentity(identity);
     m_rootMapObj->CalcMtx(identity, 1);
 
+    CMapObjAtr* attr;
     for (int i = 0; i < m_mapObjCount; i++) {
-        CMapObjAtr* attr = m_mapObjArray[i].m_attribute;
+        attr = m_mapObjArray[i].m_attribute;
         if (attr == 0) {
             continue;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1885,8 +1885,10 @@ int CMapMng::ReadMtx(char* mapName)
  */
 int CMapMng::ReadMpl(char* mapName)
 {
+    CFile::CHandle* handle;
     char* strTmp = g_StrTmp;
     int loadIndex = 0;
+    int size;
 
     MapMng.m_mapReadReady = 1;
 
@@ -1897,9 +1899,9 @@ int CMapMng::ReadMpl(char* mapName)
         if (m_asyncLoadState.m_mapReadMode == 1) {
             canRead = 1;
         } else {
-            CFile::CHandle* existsHandle = File.Open(strTmp, 0, CFile::PRI_LOW);
-            if (existsHandle != 0) {
-                File.Close(existsHandle);
+            handle = File.Open(strTmp, 0, CFile::PRI_LOW);
+            if (handle != 0) {
+                File.Close(handle);
                 canRead = 1;
             } else {
                 canRead = 0;
@@ -1925,7 +1927,7 @@ int CMapMng::ReadMpl(char* mapName)
 
         void* filePtr;
         if (m_asyncLoadState.m_mapReadMode == 1) {
-            const int size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
+            size = m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex];
             filePtr = File.m_readBuffer;
 
             Memory.CopyFromAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, (size + 0x1F) & ~0x1F);
@@ -1933,19 +1935,19 @@ int CMapMng::ReadMpl(char* mapName)
             CheckSum(filePtr, size);
             m_asyncLoadState.m_asyncReadIndex += 1;
         } else {
-            CFile::CHandle* fileHandle = File.Open(strTmp, 0, CFile::PRI_LOW);
-            if (fileHandle != 0) {
-                const int size = File.GetLength(fileHandle);
+            handle = File.Open(strTmp, 0, CFile::PRI_LOW);
+            if (handle != 0) {
+                size = File.GetLength(handle);
                 if (m_asyncLoadState.m_mapReadMode == 3) {
-                    File.ReadASync(fileHandle);
+                    File.ReadASync(handle);
                     filePtr = reinterpret_cast<void*>(1);
-                    m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = fileHandle;
+                    m_asyncLoadState.m_asyncHandles[m_asyncLoadState.m_asyncOpenIndex] = handle;
                     m_asyncLoadState.m_asyncOpenIndex += 1;
                 } else {
-                    File.Read(fileHandle);
-                    File.SyncCompleted(fileHandle);
+                    File.Read(handle);
+                    File.SyncCompleted(handle);
                     filePtr = File.m_readBuffer;
-                    File.Close(fileHandle);
+                    File.Close(handle);
                     if (m_asyncLoadState.m_mapReadMode == 2) {
                         Memory.CopyToAMemorySync(filePtr, m_asyncLoadState.m_mapLoadCursor, static_cast<unsigned long>(size));
                         m_asyncLoadState.m_fileSizes[m_asyncLoadState.m_asyncReadIndex] = size;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1889,7 +1889,7 @@ int CMapMng::ReadMpl(char* mapName)
     CFile::CHandle* handle;
     char* strTmp = g_StrTmp;
     int loadIndex = 0;
-    int size;
+    int size = 0;
 
     MapMng.m_mapReadReady = 1;
 


### PR DESCRIPTION
Raises main/map fuzzy match from 99.27% to 99.41% (+0.14) across 13 commits, attacking the c14 residuals.

## What changed
- **Draw (98.86 -> 99.49)**: tail DrawHitWire/DrawHitNormal loops rewritten from explicit pointer cursors to `MapMng.m_mapObjArray[i]` member indexing — the strength-reducer then anchors the IV at &MapMng with per-call `+0x954` displacement exactly like the target (R90 IV-anchor rule). Shadow-batch web fixed by hoisting `int texMtx;` declaration above `shadowCount` and initializing `stage` before `texMtx`.
- **setDbgLight (inlined twice in Draw)**: declaring `lightObj`/`v` before `cameraMtx` fixes the inline stack-slot layout; computing `v.x` before staging `dirY`/`dirZ` and using a decl-before/assign-after split for `dirZ` matches the target's load order and FPR assignment (f31=y, f30=z).
- **ReadMpl (98.80 -> 99.11)**: merged the per-arm `existsHandle`/`fileHandle` block locals into one function-scope `handle`, and the two per-arm `const int size` locals into one function-scope `int size = 0` — matching the original's single webs (handle r24, size r21).
- **ReadMid (99.37 -> 99.45)**: same function-scope handle/size recovery.
- **ReadOtm (99.08 -> 99.30)**: octTreeIndex loop reads `GetMapObject()` directly instead of staging through a named local; `attr` declared outside the spot-light loop; SearchChildMapObj declares the `obj` cursor before computing `mapObjEnd` (fixes the inlined copy's r4/r5 cursor/end assignment while keeping the standalone at 100%).

## Evidence
- objdiff report.json: main/map fuzzy_match_percent 99.268394 -> 99.407814 (total_code 21804).
- Per-function flagged-line counts dropped: Draw 98->38, ReadMpl 41->22, ReadOtm 56->~40, DestroyMap unchanged-walled.

## Plausibility
All changes are declaration-placement, scope, and spelling adjustments that look like natural 2003-era source (function-scope scratch locals reused across arms, shared loop indices, member-indexed loops). No pragmas, no pointer-offset tricks, no fake symbols.

## Known residual walls (fast verdicts, documented for the next cycle)
- SetIdGrpColor (83.2): staged color locals always color ascending from r7 while the target packs them into freed arg regs r4/r3 with the first-stored byte in r7 — invariant under ~25 staging/order/helper/struct-copy spellings (R92/R93/R90 all tested).
- SetMapObjAnim (96.1): `bne;b` un-inverted dispatch requires the sibling assign+goto idiom, but introducing the loop-local rotates three callee-saved webs (net negative under every decl order).
- Calc head (98.1): the `(u8)((s64)v - 2 >> 32) ^ 0x1e` carry-chain wants the 2 materialized in a register with an srwi-built high word — all sub/add/local-staging spellings diverge.
- Draw/DestroyMap loop-IV residual: target hosts many short webs in r26 / ranks shared `i` above compiler cursor IVs; binding is invariant to variable sharing and decl order (allocator tie-break class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)