### PR TITLE
astar: raise fuzzy match to 99.31% (cycle 9)

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -46,11 +46,11 @@ struct CABlock
 	unsigned int m_words[16];
 };
 
-static inline CVector& SubVector(Vec* a, Vec* b)
+static inline CVector& SubVector(Vec* a, const CVector& b)
 {
 	CVector result;
 
-	PSVECSubtract(a, b, reinterpret_cast<Vec*>(&result));
+	PSVECSubtract(a, reinterpret_cast<Vec*>(const_cast<CVector*>(&b)), reinterpret_cast<Vec*>(&result));
 
 	return result;
 }
@@ -182,8 +182,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 {
 	Vec escapeDir;
 	Vec portalVec;
-	CVector baseVec(base);
-	const CVector& escapeDirSource = SubVector(CVector(from), baseVec);
+	const CVector& escapeDirSource = SubVector(CVector(from), CVector(base));
 
 	escapeDir.x = escapeDirSource.x;
 	escapeDir.y = escapeDirSource.y;
@@ -224,8 +223,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 
 				if (forbiddenGroup != otherGroup)
 				{
-					CVector portalDirBase(base);
-					const CVector& dirToPortalSource = SubVector(CVector(m_portals[i].m_position), portalDirBase);
+					const CVector& dirToPortalSource = SubVector(CVector(m_portals[i].m_position), CVector(base));
 
 					portalVec.x = dirToPortalSource.x;
 					portalVec.y = dirToPortalSource.y;
@@ -235,8 +233,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 					float dot = PSVECDotProduct(reinterpret_cast<Vec*>(&escapeDir),
 					                            reinterpret_cast<Vec*>(&portalVec));
 
-					CVector distBase(base);
-					const CVector& distVecSource = SubVector(CVector(m_portals[i].m_position), distBase);
+					const CVector& distVecSource = SubVector(CVector(m_portals[i].m_position), CVector(base));
 
 					portalVec.x = distVecSource.x;
 					portalVec.y = distVecSource.y;

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -306,9 +306,8 @@ void CAStar::addRealTime(CGPartyObj* gPartyObj)
 	}
 	else
 	{
-		int padIndex = 0;
-		padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
-		trig1 = Pad.GetPadInputs()[padIndex].buttonDown[0];
+		unsigned int resolvedIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
+		trig1 = Pad.GetPadInputs()[resolvedIndex].buttonDown[0];
 	}
 
 	if ((trig1 & 0x20) == 0)
@@ -329,9 +328,8 @@ void CAStar::addRealTime(CGPartyObj* gPartyObj)
 	}
 	else
 	{
-		int padIndex = 0;
-		padIndex &= ~-((__cntlzw(static_cast<unsigned int>(Pad.m_debugPadPort)) & 0x20) >> 5);
-		trig2 = Pad.GetPadInputs()[padIndex].button[0];
+		unsigned int resolvedIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;
+		trig2 = Pad.GetPadInputs()[resolvedIndex].button[0];
 	}
 
 	if ((trig2 & 0x40) == 0)


### PR DESCRIPTION
Raises main/astar from 99.22% to 99.31% (data steady at 98.52%).

## Changes
- **addRealTime** (98.49 → 99.04): the pad debug-input idiom's `padIndex &= ~-((__cntlzw(...)&0x20)>>5)` chain is mwcc's branchless lowering of an equal-arm ternary — replaced with `unsigned int resolvedIndex = (Pad.m_debugPadPort == 0) ? 0 : 0;` (matches the CPad::GetButtonDown body shape), fixing the whole li/cntlzw/andc/mulli register band at both sites (R91/R27).
- **getEscapePos** (98.64 → 98.70): the three named `CVector` base-copy locals were really ctor temporaries passed in the SubVector call (slot interleaving proved it), and SubVector's second parameter is `const CVector&` — the const-ref binding makes mwcc rematerialize the temp's slot address (`addi r4,r1,0x5c`) instead of pinning the ctor result in an extra callee-saved register; frame, stmw window, and all stack slots now match (R31/R72).

## Confirmed walls (bit-identical under all spellings tried)
- portalIndex↔strength-reduced-cursor rank swaps in addRealTime/addAstar (ternary forms, decl orders/placements, loop forms, ref/indexed spellings, pointer cursors, `register`, helper inlining all bit-identical or negative).
- calcPolygonGroup inlined-calcSpecialPolygonGroup config: full helper restructure converges structurally (slots/cyl regions/params match) but nets negative via alignment cascades; arm1 ctor-temp slot-pair order remains unreproducible.
- kPolyGroupTopOffsetY named-vs-@pool reloc: every named-reference spelling costs more code score than the reloc name gains.
- check/drawAStar residual 3-register rotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)