### PR TITLE
util: raise fuzzy match to 99.40% (cycle 8)

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -368,6 +368,58 @@ void CUtil::SetPaletteEnv(CTexture* texture)
     GXLoadTlut(&texture->m_tlutObj1, GX_TLUT1);
 }
 
+#pragma always_inline on
+#pragma inline_max_size(10000)
+static inline void SendTexQuadVerts(Vec v1, Vec v0, GXColor quadColor, Vec2d* uv1, Vec2d* uv2)
+{
+    float v2;
+    float u2;
+    float v;
+    float u1;
+
+    if (uv1 == 0 || uv2 == 0) {
+        u1 = 0.0f;
+        v = 0.0f;
+        u2 = 1.0f;
+        v2 = 1.0f;
+    } else {
+        u1 = uv1->x;
+        v = uv1->y;
+        u2 = uv2->x;
+        v2 = uv2->y;
+    }
+
+    GXBegin(GX_QUADS, GX_VTXFMT7, 4);
+    GXWGFifo.f32 = v1.x;
+    GXWGFifo.f32 = v1.y;
+    GXWGFifo.f32 = v1.z;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
+    GXWGFifo.f32 = u1;
+    GXWGFifo.f32 = v;
+
+    GXWGFifo.f32 = v0.x;
+    GXWGFifo.f32 = v1.y;
+    GXWGFifo.f32 = v1.z;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
+    GXWGFifo.f32 = u2;
+    GXWGFifo.f32 = v;
+
+    GXWGFifo.f32 = v0.x;
+    GXWGFifo.f32 = v0.y;
+    GXWGFifo.f32 = v1.z;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
+    GXWGFifo.f32 = u2;
+    GXWGFifo.f32 = v2;
+
+    GXWGFifo.f32 = v1.x;
+    GXWGFifo.f32 = v0.y;
+    GXWGFifo.f32 = v1.z;
+    GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
+    GXWGFifo.f32 = u1;
+    GXWGFifo.f32 = v2;
+}
+#pragma always_inline off
+
 /*
  * --INFO--
  * PAL Address: 0x80023014
@@ -459,103 +511,9 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, CText
     pos1.z = kUtilZero;
 
     if (color != 0) {
-        GXColor quadColor = *color;
-        Vec v0 = pos1;
-        Vec v1 = pos0;
-        float u1;
-        float v;
-        float u2;
-        float v2;
-
-        if (uv1 == 0 || uv2 == 0) {
-            u1 = 0.0f;
-            v = 0.0f;
-            u2 = 1.0f;
-            v2 = 1.0f;
-        } else {
-            u1 = uv1->x;
-            v = uv1->y;
-            u2 = uv2->x;
-            v2 = uv2->y;
-        }
-
-        GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v2;
-
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v2;
+        SendTexQuadVerts(pos0, pos1, *color, uv1, uv2);
     } else {
-        GXColor quadColor = white;
-        Vec v0 = pos1;
-        Vec v1 = pos0;
-        float u1;
-        float v;
-        float u2;
-        float v2;
-
-        if (uv1 == 0 || uv2 == 0) {
-            u1 = 0.0f;
-            v = 0.0f;
-            u2 = 1.0f;
-            v2 = 1.0f;
-        } else {
-            u1 = uv1->x;
-            v = uv1->y;
-            u2 = uv2->x;
-            v2 = uv2->y;
-        }
-
-        GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v2;
-
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v2;
+        SendTexQuadVerts(pos0, pos1, white, uv1, uv2);
     }
 
     PSMTXCopy(GetCameraMatrix(), cameraMtx);
@@ -656,103 +614,9 @@ void CUtil::RenderTextureQuad(float x, float y, float width, float height, _GXTe
     pos1.z = kUtilZero;
 
     if (color != 0) {
-        GXColor quadColor = *color;
-        Vec v0 = pos1;
-        Vec v1 = pos0;
-        float u1;
-        float v;
-        float u2;
-        float v2;
-
-        if (uv1 == 0 || uv2 == 0) {
-            u1 = 0.0f;
-            v = 0.0f;
-            u2 = 1.0f;
-            v2 = 1.0f;
-        } else {
-            u1 = uv1->x;
-            v = uv1->y;
-            u2 = uv2->x;
-            v2 = uv2->y;
-        }
-
-        GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v2;
-
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v2;
+        SendTexQuadVerts(pos0, pos1, *color, uv1, uv2);
     } else {
-        GXColor quadColor = white;
-        Vec v0 = pos1;
-        Vec v1 = pos0;
-        float u1;
-        float v;
-        float u2;
-        float v2;
-
-        if (uv1 == 0 || uv2 == 0) {
-            u1 = 0.0f;
-            v = 0.0f;
-            u2 = 1.0f;
-            v2 = 1.0f;
-        } else {
-            u1 = uv1->x;
-            v = uv1->y;
-            u2 = uv2->x;
-            v2 = uv2->y;
-        }
-
-        GXBegin(GX_QUADS, GX_VTXFMT7, 4);
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v1.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v;
-
-        GXWGFifo.f32 = v0.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u2;
-        GXWGFifo.f32 = v2;
-
-        GXWGFifo.f32 = v1.x;
-        GXWGFifo.f32 = v0.y;
-        GXWGFifo.f32 = v1.z;
-        GXWGFifo.u32 = *reinterpret_cast<u32*>(&quadColor);
-        GXWGFifo.f32 = u1;
-        GXWGFifo.f32 = v2;
+        SendTexQuadVerts(pos0, pos1, white, uv1, uv2);
     }
 
     PSMTXCopy(GetCameraMatrix(), cameraMtx);


### PR DESCRIPTION
Raises main/util fuzzy match 99.38% -> 99.40%.

**What landed**
- Reconstructed the original inlined `SendTexQuadVerts(Vec v1, Vec v0, GXColor quadColor, Vec2d* uv1, Vec2d* uv2)` static helper shared by both `RenderTextureQuad` overloads (same pattern as the existing `RenderColorQuadVtx` helper in this file, including `always_inline` + `inline_max_size` pragmas). This replaces the four copy-pasted per-arm GXBegin/FIFO blocks and fixes the stack-slot classes the open-coded version could not reach: `quadColor` lands at 0xc below the GXSetChanAmb/MatColor staging temps, the `v0`/`v1` by-value Vec param copies land at 0x34/0x40 in the target's copy order, and the reversed uv decl order gives the target's f31..f28 role assignment. Both RTQ functions go 99.86 -> 99.94 (only anonymous-pool reloc-name lines remain, which score ~zero).
- Net -136 lines (de-duplication).

**Walls verified this cycle (bit-identical or regressing under every lever)**
- `ConvI2FVector` (78.5): pure prologue scheduling tie-break around the magic-double conversion. ~30 variants tried: R91 `optimize_for_size on` (+`use_lmw_stmw off`) is inert here; R93 byte-offset/ptr spellings, R94 scratch merges, decl orders, divisor staging, inline-helper reconstructions, and every optimizer pragma are VN-canonicalized to bit-identical output; `#pragma scheduling <cpu>` does perturb it but every model regresses (601: -0.83).
- `GetSplinePos` (96.4), `ConvF2IVector` (97.0), `ConvF2IVector2d` (97.5): whole-FPR-window rank rotation (accumulator-in-f0 vs named-local-in-f7); direct expressions, chained assignments, per-component locals, named-weight respellings, decl permutations, and R77 helper-param webs all collapse or are bit-identical.
- `GetNumPolygonFromDL` (99.69): r6/r8 web swap (`running` vs `vertexFormat`), resists all decl/spelling/loop-form levers.
- Remaining sub-100 lines on CalcUV/GetNoise/CalcBoundaryBoxQuantized/RTQ are anonymous `@NNN` vs hand-named pool reloc names — verified score-neutral by symbols.txt rename test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)