### PR TITLE
Improve memory heap title match

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1369,9 +1369,7 @@ void CMemory::CStage::drawHeapTitle(int y)
     }
 
     int srcLen = strlen(m_allocationSourceStr);
-    int sourceOffset = srcLen - 12;
-    sourceOffset &= ~(sourceOffset >> 31);
-    strcpy(line, m_allocationSourceStr + sourceOffset);
+    strcpy(line, m_allocationSourceStr + ((srcLen - 12) & ~((srcLen - 12) >> 31)));
     Graphic.DrawDebugStringDirect(0x10, y, line, 8);
 
     sprintf(line, s_drawHeapTitleFmt, m_allocCount,


### PR DESCRIPTION
## Summary
- Fold the heap-title source offset calculation into the strcpy argument in CMemory::CStage::drawHeapTitle.
- This matches the target expression ordering more closely without changing behavior.

## Evidence
- ninja: passed
- objdiff: drawHeapTitle__Q27CMemory6CStageFi improved from 97.85859% to 99.19192%, size unchanged at 396 bytes.

## Plausibility
- The source still computes the same clamped suffix offset for m_allocationSourceStr.
- This removes a temporary-only spelling and keeps the original heap-title formatting behavior intact.