### PR TITLE
[cross] Fix CUSBPcs process table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -5,8 +5,21 @@
 #include "ffcc/system.h"
 #include "ffcc/usb.h"
 
-typedef CProcessTable CUSBProcessTable;
-typedef int CUSBProcessTable_size_mismatch[(sizeof(CUSBProcessTable) == 0x15C) ? 1 : -1];
+struct CUSBProcessTable
+{
+    char* m_name;
+    union
+    {
+        u32 m_words[(0x11C - sizeof(char*)) / sizeof(u32)];
+        struct Fields
+        {
+            CProcessTableCallback m_create;
+            CProcessTableCallback m_destroy;
+            CProcessTableEntry m_entries[1];
+        } m_fields;
+    };
+};
+typedef int CUSBProcessTable_size_mismatch[(sizeof(CUSBProcessTable) == 0x11C) ? 1 : -1];
 
 class CUSBPcs : public CProcess
 {


### PR DESCRIPTION
## Summary
- Replace the generic `CProcessTable` alias for `CUSBProcessTable` with the smaller USB-specific table layout.
- Keep the leading callback fields used by the constructor while matching the target `m_table__7CUSBPcs` size (`0x11C`).

## Evidence
- `ninja` passes.
- `ninja build/GCCP01/ok` passes.
- `build/tools/objdiff-cli diff -p . -u main/p_usb --format json`:
  - `m_table__7CUSBPcs`: 90.01405% -> 100.0%
  - `main/p_usb` `.data`: 92.38095% -> 93.387764%
  - `main/p_usb` `.text`: unchanged at 99.969696% in objdiff; report shows code 100.0%.

## Plausibility
The target symbols list `m_table__7CUSBPcs` as `0x11C`, smaller than the generic `CProcessTable` (`0x15C`). This keeps the same table front matter and callback layout while removing the overlarge generic table allocation.