### PR TITLE
p_usb: fix process table size

### DIFF
--- a/include/ffcc/p_usb.h
+++ b/include/ffcc/p_usb.h
@@ -5,8 +5,21 @@
 #include "ffcc/system.h"
 #include "ffcc/usb.h"
 
-typedef CProcessTable CUSBProcessTable;
-typedef int CUSBProcessTable_size_mismatch[(sizeof(CUSBProcessTable) == 0x15C) ? 1 : -1];
+struct CUSBProcessTable
+{
+    char* m_name;
+    union
+    {
+        u32 m_words[(0x11C - sizeof(char*)) / sizeof(u32)];
+        struct Fields
+        {
+            CProcessTableCallback m_create;
+            CProcessTableCallback m_destroy;
+            CProcessTableEntry m_entries[1];
+        } m_fields;
+    };
+};
+typedef int CUSBProcessTable_size_mismatch[(sizeof(CUSBProcessTable) == 0x11C) ? 1 : -1];
 
 class CUSBPcs : public CProcess
 {


### PR DESCRIPTION
## Summary
- Replace the generic CProcessTable alias for CUSBProcessTable with the USB-specific 0x11C table layout.
- Keep the normal callback/table field access used by CUSBPcs construction while matching the shipped m_table size from symbols.txt.

## Evidence
- B4 selector surfaced main/p_usb as a data opportunity after the checkpoint.
- ninja passes and regenerates build/GCCP01/report.json.
- main/p_usb report: code 1320/1320 (100%), data 476/940 (50.6383%), .data 93.387764%.
- objdiff for main/p_usb m_table__7CUSBPcs: size 284 (0x11C), match 100.0%.

## Plausibility
- config/GCCP01/symbols.txt lists m_table__7CUSBPcs as size 0x11C, unlike the generic 0x15C process tables.
- The new type preserves the same real table fields used by the constructor and pads the remaining table storage structurally instead of hardcoding generated data.