### PR TITLE
Match memory heap used label

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -83,7 +83,7 @@ extern const char* amem_stateName[2] = {
 };
 extern const char sHeapWalkerNewline[] = "\n";
 static const char sHeapWalkerFree[] = "FREE";
-static const char sHeapWalkerUsed[] = "USED";
+static const char sHeapWalkerUsed[] = "USE ";
 extern const float kMemoryDrawOrthoBottom = 448.0f;
 extern const float kMemoryDrawOrthoRight = 640.0f;
 extern const float kMemoryDrawOrthoFar = -100.0f;


### PR DESCRIPTION
## Summary
- Change the memory heap walker used-state label from `USED` to the target's fixed-width `USE ` text.
- This matches the target .sdata2 bytes for `sHeapWalkerUsed` and completes the memory .sdata2 section.

## Evidence
- `ninja` passes.
- `main/memory` data improves from 94.9839% to 95.35546%.
- `main/memory` .sdata2 improves to 100.0%.
- `sHeapWalkerUsed` reports 100.0% in objdiff.
- Text score remains unchanged at 99.62326%.