### PR TITLE
Match memory card CRC calculation

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -379,10 +379,10 @@ void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)
  */
 unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
 {
-    unsigned char* ptr;
-    unsigned char* ptr2;
     int count;
+    unsigned char* ptr;
     int count2;
+    unsigned char* ptr2;
     unsigned int crc;
     unsigned char* crcData;
 


### PR DESCRIPTION
## Summary
- Reordered the local declarations in CMemoryCardMan::CalcCrc so MWCC allocates the CRC loop pointer/counter registers like the target.
- Keeps the existing CRC logic unchanged and mirrors the already-matching CRC loop style used nearby.

## Evidence
- ninja passes for GCCP01.
- build/tools/objdiff-cli diff -p . -u main/memorycard -o - CalcCrc__14CMemoryCardManFPQ22Mc7SaveDat reports match_percent: 100.0, size 148, and zero instruction diffs.
- Build progress increased matched code by 148 bytes and matched functions by 1.

## Plausibility
- This is source-level local ordering only: no address constants, fake symbols, section forcing, or generated ctor/dtor/vtable hacks.
- The resulting function is the same straightforward two-pass CRC calculation over the save data regions.