### PR TITLE
Inline unused B4 helpers

### DIFF
--- a/src/FS_USB_Process.cpp
+++ b/src/FS_USB_Process.cpp
@@ -351,7 +351,7 @@ void CFunnyShapePcs::SetUSBData()
  * JP Address: TODO
  * JP Size: TODO
  */
-void CFunnyShapePcs::USBDataCallback(CUSBPcs::CDataHeader* header)
+inline void CFunnyShapePcs::USBDataCallback(CUSBPcs::CDataHeader* header)
 {
     CUSBStreamData* usb = UsbStream(this);
 

--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -723,7 +723,7 @@ void DrawGoOutMenu()
  * JP Address: TODO
  * JP Size: TODO
  */
-int getFreeCaravanIdx(Mc::SaveDat* saveData)
+inline int getFreeCaravanIdx(Mc::SaveDat* saveData)
 {
     g_freeCaravanIdx = FindFreeCaravanIdx(saveData);
     return g_freeCaravanIdx;

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -575,7 +575,7 @@ void CMapPcs::calcViewer()
  * JP Address: TODO
  * JP Size: TODO
  */
-void mapInitDrawEnv()
+inline void mapInitDrawEnv()
 {
     GXSetColorUpdate(GX_TRUE);
     GXSetAlphaUpdate(GX_FALSE);


### PR DESCRIPTION
## Summary
- Mark three PAL UNUSED B4 helpers as inline so they are retained as known source without emitting extra source-only code.
- Affected helpers: CFunnyShapePcs::USBDataCallback, getFreeCaravanIdx, and mapInitDrawEnv.

## Evidence
- Build: ninja passed.
- DOL check: ninja build/GCCP01/ok reported no work to do after the successful build.
- objdiff section cleanup:
  - main/FS_USB_Process source .text is now 3524 bytes, matching the target .text size; the source-only USBDataCallback symbol is gone.
  - main/p_map source .text dropped from 6620 to 6392 bytes after removing the source-only mapInitDrawEnv emission.
  - main/goout source .text dropped by 172 bytes after removing the source-only getFreeCaravanIdx emission.

## Plausibility
These functions were already marked PAL Address: UNUSED. Marking UNUSED functions inline is the established project pattern for keeping recovered source while avoiding extra emitted functions and extab/code noise.