### PR TITLE
Fix joybus send type error string

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -117,7 +117,7 @@ static const char s_thread_init_end[] = "JoyBus::ThreadInit end\n";
 static const char s_recv_type_differ_warn_fmt[] = "(%d):%s(%d): Warning: Recv data type differ!!\n";
 static const char s_joybus_cpp[] = "joybus.cpp";
 static const char s_ppos_cnt_error_fmt[] = "(%d) Error: m_PposCnt error(%d)\n";
-static const char s_send_type_error_fmt[] = "(%d): Error: send type error(%02x)\n";
+static const char s_send_type_error_fmt[] = "(%d): Error:send type error(%02x)\n";
 static const char s_map_filename_fmt[] = "m%02d_%d.mcd";
 static const char s_mem_alloc_error_fmt[] = "%s(%d): Error: memory allocation error\n";
 


### PR DESCRIPTION
## Summary
- Match the target joybus send-type error format string by removing the extra space after `Error:`.
- This aligns the source rodata bytes with the target object for `s_send_type_error_fmt`.

## Evidence
- `ninja` completed successfully.
- `build/tools/objdiff-cli diff -p . -u main/joybus -o /tmp/joybus_final.json --format json`
- Final joybus `.rodata`: `96.98349%`.
- Verified both target and rebuilt source objects contain `(%d): Error:send type error(%02x)\n` and not the spaced variant.

## Plausibility
- This is a direct correction of a shipped debug/error format string byte sequence, not a compiler coaxing change.