### PR TITLE
Let MaterialEditor use generated destructor

### DIFF
--- a/include/ffcc/p_MaterialEditor.h
+++ b/include/ffcc/p_MaterialEditor.h
@@ -81,8 +81,6 @@ public:
     static CProcessTable m_table;
 
     CMaterialEditorPcs() {}
-    ~CMaterialEditorPcs();
-
     void Init();
     void Quit();
     int GetTable(unsigned long);

--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -704,15 +704,3 @@ void CMaterialEditorPcs::Init()
 
     m_loadedTextureCount = 0;
 }
-/*
- * --INFO--
- * PAL Address: 0x8004c6a0
- * PAL Size: 124b
- * EN Address: TODO
- * EN Size: TODO
- * JP Address: TODO
- * JP Size: TODO
- */
-CMaterialEditorPcs::~CMaterialEditorPcs()
-{
-}


### PR DESCRIPTION
## Summary
- Remove the handwritten empty CMaterialEditorPcs destructor declaration/definition so MWCC generates it normally.
- This moves p_MaterialEditor static initialization/destructor emission closer to the target and improves exception metadata matching.

## Evidence
- ninja passes; build/GCCP01/main.dol: OK.
- main/p_MaterialEditor remains at 98.96056 fuzzy text match with .data and .rodata still 100%.
- extab now reports 98.07692 fuzzy match.
- extabindex now reports 98.95833 fuzzy match.

## Plausibility
- The removed destructor body was empty and only duplicated what the compiler can generate for the class.
- This follows the project rule to avoid manually writing generated destructor code when normal C++ can produce it.