### PR TITLE
Improve memorycard SetLoadData match

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -1235,7 +1235,7 @@ void CMemoryCardMan::SetLoadData()
     Game.m_gameWork.m_mcHasSerial = save[0x13DC];
     Sound.SetBgmMasterVolume(static_cast<s8>(save[0x13DD]));
     Sound.SetSeMasterVolume(static_cast<s8>(save[0x13DE]));
-    u32 soundMode = static_cast<u32>(__cntlzw(Sound.GetSoundMode())) >> 5;
+    int soundMode = static_cast<s32>(__cntlzw(Sound.GetSoundMode())) >> 5;
     Sound.SetStereo(soundMode);
 
     CGame* g = &Game;


### PR DESCRIPTION
## Summary
- Use a signed sound mode intermediate in CMemoryCardMan::SetLoadData before shifting the cntlzw result.
- Keeps behavior equivalent for the cntlzw range while matching the original instruction selection more closely.

## Evidence
- ninja: build succeeds, DOL check OK.
- objdiff main/memorycard SetLoadData__14CMemoryCardManFv: 99.128525% -> 99.51585%.
- objdiff main/memorycard .text: 99.6403% -> 99.70381%.
- No data/extab section movement in main/memorycard.