### PR TITLE
Improve CBound CheckCross local ordering

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -750,8 +750,8 @@ void COctTree::ClearLight()
  */
 int CBound::CheckCross(CBound& other)
 {
-	bool xyOverlap;
 	bool overlap;
+	bool xyOverlap;
 	int xOverlap;
 
 	overlap = false;


### PR DESCRIPTION
## Summary
- Reorder the local boolean declarations in CBound::CheckCross so MWCC assigns overlap and xyOverlap closer to the target.
- Keeps the original overlap logic unchanged while improving the generated code shape.

## Evidence
- CheckCross__6CBoundFR6CBound: 98.75% -> 99.117645% objdiff match.
- main/mapocttree report remains buildable; measured fuzzy match: 99.61061%.

## Verification
- ninja
- ninja build/GCCP01/ok
- build/tools/objdiff-cli diff -p . -u main/mapocttree -o - --format json-pretty CheckCross__6CBoundFR6CBound
