### PR TITLE
Improve graphic quad constant loads

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1513,13 +1513,15 @@ void CGraphic::RenderTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor
 	GXWGFifo.f32 = y1;
 	rgba1 = *(u32*)&color1;
 	GXWGFifo.f32 = z1;
-	tex0 = kGraphicZeroF;
+	const float* tex0Ptr = &kGraphicZeroF;
+	tex0 = *tex0Ptr;
 	GXWGFifo.u32 = rgba1;
 	x2 = pos2.x;
 	GXWGFifo.f32 = tex0;
 	rgba2 = *(u32*)&color2;
 	GXWGFifo.f32 = tex0;
-	tex1 = kGraphicOneF;
+	const float* tex1Ptr = &kGraphicOneF;
+	tex1 = *tex1Ptr;
 
 	GXWGFifo.f32 = x2;
 	y2 = pos2.y;


### PR DESCRIPTION
## Summary
- Force `RenderTexQuadGrouad` to load `kGraphicZeroF` and `kGraphicOneF` through named constant references instead of folded anonymous literals.
- Keeps the source behavior unchanged while matching the target's named `.sdata2` relocations more closely.

## Evidence
- `ninja` succeeds.
- `build/tools/objdiff-cli diff -p . -u main/graphic -o /tmp/graphic_quad_verified.json RenderTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor`
- `RenderTexQuadGrouad__8CGraphicF3Vec3Vec8_GXColor8_GXColor8_GXColor8_GXColor`: 88.545456% -> 89.181816%.
- Current/target function sizes remain 220b / 220b.

## Plausibility
- The target uses named `kGraphicZeroF` / `kGraphicOneF` relocations in this function.
- The pointer loads are a narrow MWCC source-shape adjustment that preserves the original draw order and FIFO writes.
