### PR TITLE
Match p_light static initialization

### DIFF
--- a/include/ffcc/p_light.h
+++ b/include/ffcc/p_light.h
@@ -122,8 +122,4 @@ void setchanctrl(CLightPcs::TARGET, unsigned long);
 extern CLightPcs LightPcs;
 extern CLightPcs::CBumpLight* gCharaPartWorkPtr;
 
-inline CLightPcs::CLightPcs()
-{
-}
-
 #endif // _FFCC_P_LIGHT_H_

--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -68,24 +68,34 @@ void draw__9CLightPcsFv(CLightPcs*);
 void MakeLightMap__9CLightPcsFv(CLightPcs*);
 }
 
+inline CLightPcs::CLightPcs()
+{
+    static CProcessTableCallback s_lightTableDescCreate = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__9CLightPcsFv)};
+    static CProcessTableCallback s_lightTableDescDestroy = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__9CLightPcsFv)};
+    static CProcessTableCallback s_lightTableDescCalc = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__9CLightPcsFv)};
+    static CProcessTableCallback s_lightTableDescDraw = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__9CLightPcsFv)};
+    static CProcessTableCallback s_lightTableDescMakeLightMap = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(MakeLightMap__9CLightPcsFv)};
+    CProcessTable* table = &m_table;
+
+    table->m_fields.m_create = s_lightTableDescCreate;
+    table->m_fields.m_destroy = s_lightTableDescDestroy;
+    table->m_fields.m_entries[0].m_callback = s_lightTableDescCalc;
+    table->m_fields.m_entries[1].m_callback = s_lightTableDescDraw;
+    table->m_fields.m_entries[2].m_callback = s_lightTableDescMakeLightMap;
+}
+
 CLightPcs LightPcs;
 
-static CProcessTableCallback s_lightTableDescCreate = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__9CLightPcsFv)};
-static CProcessTableCallback s_lightTableDescDestroy = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__9CLightPcsFv)};
-static CProcessTableCallback s_lightTableDescCalc = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__9CLightPcsFv)};
-static CProcessTableCallback s_lightTableDescDraw = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(draw__9CLightPcsFv)};
-static CProcessTableCallback s_lightTableDescMakeLightMap = {0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(MakeLightMap__9CLightPcsFv)};
 CProcessTable CLightPcs::m_table = {
     const_cast<char*>(sLightPcsClassName),
     {
-        s_lightTableDescCreate.m_thisOffset, s_lightTableDescCreate.m_virtualOffset, s_lightTableDescCreate.m_function,
-        s_lightTableDescDestroy.m_thisOffset, s_lightTableDescDestroy.m_virtualOffset, s_lightTableDescDestroy.m_function,
-        s_lightTableDescCalc.m_thisOffset, s_lightTableDescCalc.m_virtualOffset, s_lightTableDescCalc.m_function,
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0,
         0x1C, 0,
-        s_lightTableDescDraw.m_thisOffset, s_lightTableDescDraw.m_virtualOffset, s_lightTableDescDraw.m_function,
+        0, 0, 0,
         0x2A, 0,
-        s_lightTableDescMakeLightMap.m_thisOffset, s_lightTableDescMakeLightMap.m_virtualOffset,
-        s_lightTableDescMakeLightMap.m_function,
+        0, 0, 0,
         0x2D, 1,
     },
 };


### PR DESCRIPTION
## Summary
- Move CLightPcs process-table callback setup into the constructor, matching the process-table pattern used by other matched process units.
- Leave the static m_table callback slots zero-initialized so __sinit_p_light_cpp performs the descriptor copies generated by the original source.
- Remove the empty inline CLightPcs constructor body from the header now that p_light.cpp provides the real inline constructor.

## Evidence
- ninja passes: build/GCCP01/main.dol OK
- main/p_light __sinit_p_light_cpp: 71.15116% (328b) -> 100.0% (344b)
- main/p_light .text: 98.66707% -> 99.670715%
- main/p_light .data remains 100.0%
- extab: 99.375% -> 100.0%; extabindex: 99.166664% -> 99.583336%
- Overall progress after build: All 42.72% matched, Game Code 29.68% matched

## Plausibility
This matches the established CProcessTable setup pattern already used by matched units like p_sample, p_sound, and p_game: descriptor statics live in the constructor and are copied into m_table during static initialization, rather than baking callbacks directly into the table data.