### PR TITLE
Match p_light bump light constructor

### DIFF
--- a/src/p_light.cpp
+++ b/src/p_light.cpp
@@ -1314,14 +1314,10 @@ void CLightPcs::CBumpLight::SetTexture(_GXTexMapID texMapID, int textureIdx)
  */
 CLightPcs::CLight::CLight()
 {
-    float f1 = kLightDefaultAttenFalloff;
-    float f2 = kLightZero;
-    float radius = kLightOne;
-
-    m_radius = radius;
-    m_offsetZ = f2;
-    m_offsetX = f2;
-    m_attenFalloff = f1;
+    m_radius = kLightOne;
+    m_offsetZ = kLightZero;
+    m_offsetX = kLightZero;
+    m_attenFalloff = kLightDefaultAttenFalloff;
     m_directionMode = 0;
     m_spotFn = 0;
     m_unk4D = 4;


### PR DESCRIPTION
## Summary
- Simplify `CLightPcs::CLight::CLight()` initialization to direct member assignments.
- This preserves the base light constructor match and fixes the inlined register allocation in `CLightPcs::CBumpLight::CBumpLight()`.

## Evidence
- `__ct__Q29CLightPcs10CBumpLightFv`: 98.913% -> 100.0% (92b matched)
- `__ct__Q29CLightPcs6CLightFv`: remains 100.0%
- `ninja` passes, including `build/GCCP01/main.dol: OK`
- Full report improved: code matched 792120 -> 792212 bytes, functions 3903 -> 3904

## Plausibility
The new source is the natural constructor form: assign members directly from their constants instead of carrying locals named after temporary registers. It reduces decompiler-shaped code while matching the target output.