### PR TITLE
Improve wind AddSphere init ordering

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -315,9 +315,9 @@ found:
 	}
 
 	obj->type = 2;
+	obj->flagBits.active = 1;
 	float centerZ = pos->z;
 	float centerX = pos->x;
-	obj->flagBits.active = 1;
 
 	int id = m_nextId;
 	m_nextId = id + 1;


### PR DESCRIPTION
## Summary
- Move the AddSphere active-flag store before the position local loads, matching the target init scheduling more closely.
- Keep the change scoped to src/wind.cpp with no data/layout or linkage edits.

## Evidence
- ninja completed successfully.
- ninja build/GCCP01/ok: no work to do.
- AddSphere__5CWindFPC3Vecffi: 86.789474% -> 93.57895%.
- AddDiffuse__5CWindFPC3Vecfff remained at 93.31731%.

## Plausibility
This is a source-order-only change among independent initialization statements. It preserves the original field values while producing instruction scheduling closer to the shipped binary.