### PR TITLE
Improve B4 memory and maphit matches

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -23,8 +23,8 @@ public:
 	CBound();
 	CBound(float min, float max)
 	{
-		float lo = min;
 		float hi = max;
+		float lo = min;
 		m_min.z = lo;
 		m_min.y = lo;
 		m_min.x = lo;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1908,16 +1908,14 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
     while (true) {
         CAmemCache* bestEntry = 0;
 
-        int offset = 0;
         for (int i = 0; i < m_cacheCount; i++) {
-            CAmemCache& entry = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
+            CAmemCache& entry = cacheEntryAt(this, i);
             if (entry.m_inUse != 0 && entry.m_refCount == 0 && entry.m_dmaCopy != 0 &&
                 entry.m_cacheData != 0 && entry.m_size >= currentSize &&
                 static_cast<unsigned int>(entry.m_priority) < bestPriority) {
                 bestEntry = &entry;
                 bestPriority = static_cast<unsigned int>(entry.m_priority);
             }
-            offset += sizeof(CAmemCache);
         }
 
         if (bestEntry != 0) {
@@ -1945,19 +1943,14 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
                 System.Printf(const_cast<char*>(strBase + 0x4c));
             }
 
-            int i;
-            int offset2;
-            i = 0;
-            offset2 = i;
-            for (; i < m_cacheCount; i++) {
-                CAmemCache& entry = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset2);
+            for (int i = 0; i < m_cacheCount; i++) {
+                CAmemCache& entry = cacheEntryAt(this, i);
                 if (((entry.m_inUse != 0) || (entry.m_cacheData != 0)) && (static_cast<unsigned int>(System.m_execParam) >= 3)) {
                     System.Printf(
                         const_cast<char*>(strBase + 0xd8), i, cacheStateName(entry),
                         cacheTypeName(entry), entry.m_refCount, entry.m_priority,
                         reinterpret_cast<int>(entry.m_cacheData));
                 }
-                offset2 += sizeof(CAmemCache);
             }
 
             if (static_cast<unsigned int>(System.m_execParam) >= 3) {


### PR DESCRIPTION
## Summary
- Replace AMEM low-priority cache table byte-offset loops with indexed cache entry access in `AmemFreeLowPrio`.
- Adjust `CBound(float, float)` local load order to better match maphit static initialization.

## Evidence
- `main/memory` .text: ~99.622% -> 99.635%.
- `AmemFreeLowPrio__13CAmemCacheSetFi`: 98.775% -> 98.953%.
- `main/maphit` .text: ~99.560% -> 99.566%.
- `__sinit_maphit_cpp`: 96.316% -> 98.737% in report.

## Validation
- `ninja` completed successfully.
- Full rebuild after the shared header change reported `build/GCCP01/main.dol: OK`.

## Plausibility
- The AMEM change removes manual cache-table byte-offset arithmetic in favor of the existing typed helper.
- The CBound constructor change preserves behavior and matches the target's min/max constant load order for maphit initialization.
