### PR TITLE
Avoid extra ptrarray accessors in map units

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,3 +1,4 @@
+#define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 #include "ffcc/map.h"
 #include "ffcc/chunkfile.h"
 #include "ffcc/math.h"

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -1,3 +1,4 @@
+#define FFCC_PTRARRAY_NO_INLINE_ACCESSORS
 #include "ffcc/ptrarray.h"
 #include "ffcc/p_map.h"
 #include "ffcc/gxfunc.h"


### PR DESCRIPTION
## Summary
- Define `FFCC_PTRARRAY_NO_INLINE_ACCESSORS` in `src/map.cpp` and `src/p_map.cpp`.
- This prevents those units from emitting extra weak `CPtrArray` accessor bodies and lets them reference the existing accessor definitions instead.

## Evidence
- `ninja` succeeds.
- Overall report totals are unchanged, but linkage now matches target objects for the affected accessors:
  - `main/map`: `GetSize__29CPtrArray<P15CMapLightHolder>Fv`, `__vc__29CPtrArray<P15CMapLightHolder>FUl`, and `__vc__22CPtrArray<P9CMaterial>FUl` are undefined in both target and rebuilt objects.
  - `main/p_map`: `GetSize__29CPtrArray<P15CMapLightHolder>Fv` and `__vc__29CPtrArray<P15CMapLightHolder>FUl` are undefined in both target and rebuilt objects.

## Plausibility
- This matches the existing pattern in related map units (`mapanim`, `mapshadow`, `maptexanim`) that include `ptrarray.h` without inline accessor emission.
- The change removes unintended local template instantiations rather than forcing generated code or data layout.