### PR TITLE
Match p_graphic static initializer

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -31,29 +31,29 @@ void preDrawEnvInit__11CGraphicPcsFv(CGraphicPcs*);
 void stdDrawEnvInit__11CGraphicPcsFv(CGraphicPcs*);
 }
 
-static CProcessTableCallback s_graphicTableDescCreate = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescDestroy = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescCalc = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescDrawWait = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawWait__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescDrawFlip = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawFlip__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescDrawBegin = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawBegin__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescDrawCopy = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawCopy__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescDrawEnd = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawEnd__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescPreDrawEnvInit = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(preDrawEnvInit__11CGraphicPcsFv)};
-static CProcessTableCallback s_graphicTableDescStdDrawEnvInit = {
-    0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(stdDrawEnvInit__11CGraphicPcsFv)};
-
 inline CGraphicPcs::CGraphicPcs()
 {
+    static CProcessTableCallback s_graphicTableDescCreate = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(create__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescDestroy = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(destroy__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescCalc = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(calc__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescDrawWait = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawWait__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescDrawFlip = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawFlip__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescDrawBegin = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawBegin__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescDrawCopy = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawCopy__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescDrawEnd = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(drawEnd__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescPreDrawEnvInit = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(preDrawEnvInit__11CGraphicPcsFv)};
+    static CProcessTableCallback s_graphicTableDescStdDrawEnvInit = {
+        0, 0xFFFFFFFF, reinterpret_cast<unsigned int>(stdDrawEnvInit__11CGraphicPcsFv)};
+
     CProcessTable* table = &m_table;
 
     table->m_fields.m_create = s_graphicTableDescCreate;


### PR DESCRIPTION
## Summary
- Move the CGraphicPcs process-table callback descriptors into the inline constructor as local statics, matching the established CProcess table construction pattern used by p_sample.
- This prevents MWCC from using one anonymous aggregate for the descriptor copies and makes __sinit_p_graphic_cpp match the target.

## Evidence
- ninja: build/GCCP01/main.dol OK
- objdiff __sinit_p_graphic_cpp: 48.42453% -> 100.0% (424b)
- report main/p_graphic fuzzy: 96.887886% -> 98.750984%
- report matched code: 2080 -> 2504 bytes
- report matched functions: 17/21 -> 18/21

## Plausibility
- Local static callback descriptors inside inline process constructors are already used in the repo (for example CSamplePcs), and this source shape matches the target static initializer without manual vtable/section tricks.