### PR TITLE
Fix p_map hit profile static object

### DIFF
--- a/include/ffcc/p_map.h
+++ b/include/ffcc/p_map.h
@@ -7,6 +7,7 @@
 #include "ffcc/system.h"
 
 struct Vec;
+class CRelProfile;
 
 class CMapPcs : public CProcess
 {
@@ -50,7 +51,7 @@ private:
 };
 
 extern CMapPcs MapPcs;
-extern unsigned char g_hit_prof;
+extern CRelProfile g_hit_prof;
 extern unsigned char g_map_calc_prof;
 extern unsigned char g_map_draw_prof;
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -184,7 +184,7 @@ extern unsigned int s_loadedStageNo__7CMapPcs;
 extern unsigned int s_loadedMapNo__7CMapPcs;
 CRelProfile g_mapStage;
 CRelProfile g_mapSection;
-unsigned char g_hit_prof ATTRIBUTE_ALIGN(4);
+CRelProfile g_hit_prof;
 unsigned char g_map_calc_prof ATTRIBUTE_ALIGN(4);
 unsigned char g_map_draw_prof ATTRIBUTE_ALIGN(4);
 static const float kPMapBoundMinInit = 10000000000.0f;


### PR DESCRIPTION
## Summary
- Change `g_hit_prof` from an aligned byte into the third `CRelProfile` object registered by `__sinit_p_map_cpp`.
- Expose `CRelProfile` as an incomplete type in `p_map.h` so the declaration matches the source definition.

## Evidence
- `ninja` passes.
- `ninja build/GCCP01/ok` passes.
- Overall matched data: 1,257,394 -> 1,257,805 (+411 bytes).
- `main/p_map` fuzzy: 95.10549 -> 95.521225.
- `main/p_map` data: 60.129078 -> 74.86555.
- `main/p_map` `.bss`: now 100.0% with the third global-object registration slot present.
- `__sinit_p_map_cpp`: 67.86475 -> 70.59426.

## Plausibility
The PAL static initializer registers `g_mapStage`, `g_mapSection`, and `g_hit_prof` with `CRelProfile::~CRelProfile`. Treating `g_hit_prof` as the same profile object type removes the byte placeholder and lets the compiler emit the missing global-object registration state normally.