### PR TITLE
Improve materialman chara shadow scan

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2675,8 +2675,8 @@ int CMaterialMan::GetCharaShadow(
     int outputOffset = outputCount * 4;
 
     ShadowCandidate* candidateRead = shadowCandidates;
-    float candidateDist;
     float maxDist = kMaterialMaxDistance;
+    float candidateDist;
     ShadowCandidate* nearest = 0;
     float nearestDist = kMaterialNearestDistanceInit;
     for (int i = 0; i < candidateCount; i++) {


### PR DESCRIPTION
## Summary
- Reordered the local distance temporaries in CMaterialMan::GetCharaShadow to match the nearby SetPosition nearest-candidate scan pattern.
- Keeps the max-distance sentinel in the target FPR and improves the generated scan code without changing behavior.

## Evidence
- ninja succeeds.
- main/materialman fuzzy match: 99.50785% -> 99.511024%.
- GetCharaShadow__12CMaterialManFiPP9CMaterialPPA4_fP3Vecffi: 97.22603% -> 97.39726%.

## Plausibility
- This is a source-level local declaration ordering fix matching an adjacent function with the same candidate-scan idiom, not a hardcoded output hack.