### PR TITLE
Fix menu money duplicate local

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -32,7 +32,6 @@ inline void CMenuPcs::MoneySetPlace(int row)
 	int digitPlace = 1;
 	int digitCount;
 	int digitIndex;
-	int digitCount;
 	int started = 0;
 	int gil;
 	signed char* place;


### PR DESCRIPTION
## Summary
- Remove a duplicated `digitCount` local declaration in `CMenuPcs::MoneySetPlace`.
- This fixes the current GCCP01 build after updating from `main`.

## Evidence
- `ninja` passes and regenerates the progress report.
- Progress remains unchanged, as this is a compile fix rather than an objdiff match improvement.

## Notes
- B4 target selection was run with `python3 tools/agent_select_target.py --bucket B4 --bucket-file WORK_SPLIT.md`.
- I investigated B4 candidates in `ME_AppRequest`, `p_light`, `file`, and `astar`, but reverted all experiments that did not improve objdiff or that regressed matches.