### PR TITLE
[cross] Improve CBound constructor store ordering

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -23,8 +23,8 @@ public:
 	CBound();
 	CBound(float min, float max)
 	{
-		float hi = max;
 		float lo = min;
+		float hi = max;
 		m_min.z = lo;
 		m_min.y = lo;
 		m_min.x = lo;

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -32,7 +32,6 @@ inline void CMenuPcs::MoneySetPlace(int row)
 	int digitPlace = 1;
 	int digitCount;
 	int digitIndex;
-	int digitCount;
 	int started = 0;
 	int gil;
 	signed char* place;


### PR DESCRIPTION
## Summary
- Reorder the local temporaries in CBound(float min, float max) so the inlined constructor stores follow the target load/store order more closely.
- Remove a duplicate digitCount local in menu_money.cpp that currently blocks a clean full build from fresh main.

## Evidence
- ninja passes, including build/GCCP01/main.dol: OK.
- main/gobject report improved from 99.07639% to 99.09698%.
- CGObject::bgAttribCollision improved from 95.82609% to 96.195656%.
- Additional gobject movement after the header fix:
  - CalcSafePos: 99.503105% -> 99.596275%
  - SetPosBG: 99.50595% -> 99.82738%
  - bgNormalCollision: 99.7563% -> 99.79832%

## Plausibility
CBound(float min, float max) now initializes the lo temporary before hi, matching the constructor parameter order and the target inlined store ordering for map/collision bounds. This is a source-level ordering fix, not an address or section hack.