### PR TITLE
Fix menu_money build failure

### DIFF
--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -32,7 +32,6 @@ inline void CMenuPcs::MoneySetPlace(int row)
 	int digitPlace = 1;
 	int digitCount;
 	int digitIndex;
-	int digitCount;
 	int started = 0;
 	int gil;
 	signed char* place;


### PR DESCRIPTION
## Summary
- Remove the duplicate local `digitCount` declaration in `CMenuPcs::MoneySetPlace`.
- Restores clean compilation when `menu_money.cpp` is rebuilt during the B4 target campaign.

## Evidence
- `ninja` completes successfully.
- Build output reports `build/GCCP01/main.dol: OK` and regenerates `build/GCCP01/report.json`.

## Notes
- This was found while rebuilding bucket B4 targets from a fresh branch. The attempted B4 source-shape experiments were reverted because they did not improve objdiff.