### PR TITLE
[cross] Claim maphit literal pool

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -151,6 +151,7 @@ util.cpp:
 	.data       start:0x801E88B8 end:0x801E88D4
 	.sdata      start:0x8032E488 end:0x8032E498
 	.sbss       start:0x8032EC70 end:0x8032EC74
+	.sdata2     start:0x8032F888 end:0x8032F8C0
 
 maphit.cpp:
 	extab       start:0x80005E00 end:0x80005E60
@@ -160,7 +161,7 @@ maphit.cpp:
 	.rodata     start:0x801D7088 end:0x801D70B0
 	.bss        start:0x80245640 end:0x802456F0
 	.sbss       start:0x8032EC78 end:0x8032EC9C
-	.sdata2     start:0x8032F888 end:0x8032F8B4
+	.sdata2     start:0x8032F8C0 end:0x8032F930
 
 mapmesh.cpp:
 	extab       start:0x80005E60 end:0x80005EC8

--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -6,20 +6,25 @@
 
 #include <math.h>
 
-extern "C" const float kMapHitBoundsMinInit;
-extern "C" const float kMapHitBoundsMaxInit;
-extern "C" const float kMapHitInitialTMin;
-extern "C" const float kMapHitEdgeBackoff;
-extern "C" const float kMapHitFaceBackoff;
-extern "C" const float kMapHitUnitScale;
-extern "C" const float kMapHitZero;
-extern "C" const float kMapHitRadiusSlideScale;
-extern "C" const float kMapHitSlideTLimit;
-extern "C" const double kMapHitEdgeMaxT;
-extern "C" const float kMapHitEdgeMinT;
-extern "C" const float kMapHitVertexOffsetScale;
-extern "C" const float kMapHitRadiusScale;
-extern "C" const double kMapHitRadiusBase;
+extern "C" const float kMapHitInitialTMin = 10.0f;
+extern "C" const float kMapHitEdgeBackoff = 0.5f;
+extern "C" const float kMapHitFaceBackoff = 0.30000001192092896f;
+extern "C" const float kMapHitUnitScale = 1.0f;
+extern "C" const float kMapHitZero = 0.0f;
+extern "C" const float kMapHitRadiusSlideScale = 1.0499999523162842f;
+extern "C" const float kMapHitSlideTLimit = -3.0f;
+extern "C" const double kMapHitEdgeMaxT = 1.0;
+extern "C" const float kMapHitEdgeMinT = -0.009999999776482582f;
+extern "C" const float kMapHitBoundsMinInit = 10000000000.0f;
+extern "C" const float kMapHitBoundsMaxInit = -10000000000.0f;
+extern "C" const float kMapHitVertexOffsetScale = 0.10000000149011612f;
+extern "C" const float kMapHitRadiusScale = 4.0f;
+extern "C" const double kMapHitRadiusBase = -1.0;
+extern "C" const double DOUBLE_8032F908 = 0.999999999999;
+extern "C" const double DOUBLE_8032F910 = 0.0;
+extern "C" const double DOUBLE_8032F918 = 0.5;
+extern "C" const double DOUBLE_8032F920 = 3.0;
+extern "C" const double DOUBLE_8032F928 = 2.0;
 static const char s_maphit_cpp[] = "maphit.cpp";
 extern "C" const char sOldMidFormat[] = {
     (char)0x8C, (char)0xC3, (char)0x82, (char)0xA2, (char)0x20, (char)0x4D, (char)0x49, (char)0x44,

--- a/src/menu_money.cpp
+++ b/src/menu_money.cpp
@@ -32,7 +32,6 @@ inline void CMenuPcs::MoneySetPlace(int row)
 	int digitPlace = 1;
 	int digitCount;
 	int digitIndex;
-	int digitCount;
 	int started = 0;
 	int gil;
 	signed char* place;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -11,6 +11,9 @@ struct UtilHermiteBasis {
 extern const UtilHermiteBasis kUtilHermiteBasis;
 extern Vec gUtilUpVector;
 
+extern const float kUtilZero = 0.0f;
+extern const float kUtilOne = 1.0f;
+
 static inline MtxPtr GetCameraMatrix()
 {
     return CameraPcs.m_cameraMatrix;
@@ -1360,8 +1363,6 @@ void CUtil::Quit()
 	// TODO
 }
 
-extern const float kUtilZero = 0.0f;
-extern const float kUtilOne = 1.0f;
 extern const float kUtilOrthoBottom = 448.0f;
 extern const float kUtilOrthoRight = 640.0f;
 extern const float kUtilQuadDepth = -0.9999999f;


### PR DESCRIPTION
## Summary
- assign the util/maphit .sdata2 boundary so maphit owns 0x8032F8C0..0x8032F930
- define the maphit literal pool in source address order, including the trailing double constants
- move kUtilZero/kUtilOne earlier so util's newly claimed pool starts in the target order
- remove a duplicate local declaration in menu_money that blocked a clean ninja build

## Evidence
- ninja: build/GCCP01/main.dol OK
- main/maphit objdiff: .sdata2 63.04348% (44 bytes) -> 100.0% (112 bytes)
- main/maphit report: .sdata2 112 bytes at 100.0%, .text 10516 bytes at 99.566376%
- main/util report: new .sdata2 section 56 bytes at 93.10345%; individual kUtil* symbols and lbl_8032F8B8 match
- main/menu_money report: builds cleanly; .sdata2 72 bytes at 100.0%, .text 5804 bytes at 93.48587%

## Plausibility
The split follows the contiguous literal pool visible in the DOL around the known maphit +0x7c gap. The constants are normal source-level data definitions, not section-forcing or address hacks.