### PR TITLE
Improve CPad Frame constant relocations

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -97,7 +97,8 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16*& puVar18, u16* p
 	float fVar2;
 	float fVar3;
 
-	fVar2 = kPadAnalogZero;
+	const float* analogZero = &kPadAnalogZero;
+	fVar2 = *analogZero;
 	CPad::PadInput* merged = reinterpret_cast<CPad::PadInput*>(puVar10);
 	merged->buttonPrev[0] = merged->button[0];
 	uVar17 = 0;
@@ -236,7 +237,8 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16*& puVar18, u16* p
 					else
 					{
 						*puVar12 = 0;
-						fVar2 = kPadAnalogZero;
+						const float* fallbackZero = &kPadAnalogZero;
+						fVar2 = *fallbackZero;
 						*reinterpret_cast<u8*>(p12 + 0x14) = 0;
 						*reinterpret_cast<u8*>(p12 + 0x15) = 0;
 						*reinterpret_cast<u8*>(p12 + 0x16) = 0;


### PR DESCRIPTION
## Summary
- Force the two zero-initialization loads in CPad::Frame inlined merge helper to reference kPadAnalogZero by name.
- This removes two anonymous-literal relocation mismatches while keeping the surrounding FPR allocation intact.

## Evidence
- CPad::Frame: 98.383965% -> 98.39803% match.
- main/pad .text: 98.633255% -> 98.64505% match.
- Focused dump mismatch count: 190 -> 188.
- ninja passes, including build/GCCP01/main.dol: OK.

## Plausibility
- Uses the existing named-pointer constant-load idiom to preserve the original named small-data relocation.
- Avoids manual vtable, RTTI, or section forcing and leaves unrelated replay/register-order experiments out of the patch.