### PR TITLE
Match mapocttree cylinder hit traversal

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -750,8 +750,8 @@ void COctTree::ClearLight()
  */
 int CBound::CheckCross(CBound& other)
 {
-	bool overlap;
 	bool xyOverlap;
+	bool overlap;
 	int xOverlap;
 
 	overlap = false;


### PR DESCRIPTION
## Summary
- Reorder the local overlap flags in CBound::CheckCross so the inlined register allocation matches the target traversal functions.
- Brings both cylinder-hit recursive traversals and their public wrappers to 100% in report.json.

## Evidence
- ninja passes.
- report.json main/mapocttree: text fuzzy 99.97071%, matched functions 29/30, matched code 11336/11608.
- CheckHitCylinderNear__8COctTreeFP12CMapCylinderP3VecUl: 100.0%.
- CheckHitCylinderNear_r__8COctTreeFP8COctNode: 100.0% (was 97.92411% by objdiff before this change).
- CheckHitCylinder__8COctTreeFP12CMapCylinderP3VecUl: 100.0%.
- CheckHitCylinder_r__8COctTreeFP8COctNode: 100.0% (was 98.14741% by objdiff before this change).

## Plausibility
- The change is a source-level local declaration ordering adjustment in an existing helper, with no fake symbols, address constants, section forcing, or behavior changes.