### PR TITLE
Improve maphit static cylinder init

### DIFF
--- a/src/maphit.cpp
+++ b/src/maphit.cpp
@@ -32,8 +32,8 @@ extern "C" const char sOldMidFormat[] = {
     (char)0xC5, (char)0x82, (char)0xB7, (char)0x81, (char)0x42, (char)0x0A, (char)0x00,
 };
 
-CMapCylinder g_hit_cyl;
-CMapCylinder g_hit_cyl_min;
+CMapCylinder g_hit_cyl(kMapHitBoundsMinInit, kMapHitBoundsMaxInit);
+CMapCylinder g_hit_cyl_min(kMapHitBoundsMinInit, kMapHitBoundsMaxInit);
 Vec g_hit_mvec;
 Vec g_hit_mvec_min;
 Vec g_hit_hpv;


### PR DESCRIPTION
## Summary
- Explicitly construct the two global maphit cylinders with the existing bounds init constants.
- This improves the generated static initializer for `__sinit_maphit_cpp` without changing data layout or runtime values.

## Evidence
- `ninja` passes; `build/GCCP01/main.dol: OK`.
- `__sinit_maphit_cpp`: 97.1579% -> 99.47369%.
- Full progress after build: matched code 789676 / 1855224 bytes, 3903 / 4732 functions.
- `main/maphit` sections in final targeted diff: `.text` 99.425255%, `.rodata` 100%, `.bss` 100%, `.sbss` 100%, `.sdata2` 100%.

## Plausibility
The globals were already default-constructed with the same min/max constants through `CMapCylinder()`. Passing those constants explicitly expresses the original source initialization more directly and yields better static initializer code while preserving the same object layout and values.
