### PR TITLE
Improve CBound constructor ordering for maphit

### DIFF
--- a/include/ffcc/mapocttree.h
+++ b/include/ffcc/mapocttree.h
@@ -23,8 +23,8 @@ public:
 	CBound();
 	CBound(float min, float max)
 	{
-		float hi = max;
 		float lo = min;
+		float hi = max;
 		m_min.z = lo;
 		m_min.y = lo;
 		m_min.x = lo;


### PR DESCRIPTION
## Summary
- Reordered the local temporaries in the inline CBound(float min, float max) constructor so the min value is materialized before max.
- This matches the source shape used by the inlined CBound construction in maphit edge-cylinder setup.

## Evidence
- ninja: passes
- main/maphit CheckHitFaceCylinder__7CMapHitFUl: 98.22783% -> 98.29739% objdiff match
- Final report keeps main/maphit at 99.56029% fuzzy match with data still 100% matched.

## Plausibility
- The constructor now follows the natural parameter/use order: min temporary first, then max temporary, then min fields followed by max fields.
- No address hacks, section forcing, or fake symbols.