### PR TITLE
Improve font glyph search loop

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -74,7 +74,7 @@ inline CFontGlyphEntry* CFont::searchChar(unsigned short ch)
 	int count = static_cast<int>(*glyphBucket);
 	unsigned int code = (ch >> 8) & 0xFF;
 
-	for (; count > 0; count--) {
+	for (int i = 0; i < count; i++) {
 		if (static_cast<unsigned int>(glyph->m_codeHigh) == code) {
 			return glyph;
 		}


### PR DESCRIPTION
## Summary
- Rewrites the inline font glyph search loop to use a counted index loop instead of decrementing the search count directly.
- This removes the extra dead counter decrement in the inlined GetWidth(char*) glyph search path and better matches the target mtctr/bdnz shape.

## Evidence
- main/fontman code: 98.711205% -> 98.80664%
- GetWidth__5CFontFPc: 95.9406% -> 97.07921% in build/GCCP01/report.json
- Draw__5CFontFUs and SetColor__5CFontF8_GXColor unchanged in report.

## Validation
- ninja
- ninja build/GCCP01/ok