### PR TITLE
Improve CBound CheckCross match

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -750,8 +750,8 @@ void COctTree::ClearLight()
  */
 int CBound::CheckCross(CBound& other)
 {
-	bool xyOverlap;
 	bool overlap;
+	bool xyOverlap;
 	int xOverlap;
 
 	overlap = false;


### PR DESCRIPTION
## Summary
- Reorder local bool declarations in `CBound::CheckCross` to improve MWCC register allocation.
- Keeps the collision overlap logic unchanged while moving the generated code closer to the target.

## Evidence
- `CheckCross__6CBoundFR6CBound`: 98.75% -> 99.117645% match in `main/mapocttree`.
- Current focused objdiff: `.text` 99.57616%, `CheckCross__6CBoundFR6CBound` 99.117645%.
- `ninja` completed successfully; `build/GCCP01/main.dol: OK`.

## Plausibility
- This is a normal source-level declaration-order change for two local boolean temporaries.
- No behavior, linkage, or data layout changes.