### PR TITLE
Match joybus file name pointer data

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -125,10 +125,10 @@ extern const u32 kPppYmMeltMaskBit0;
 extern const u32 kPppYmMeltMaskBit4;
 
 namespace JoyBusConst {
-static char* DVD_DIR = const_cast<char*>("dvd/gba/");
-static char* CLIENT_FILE = const_cast<char*>("ffcc_cli.bin");
-static char* OBJ_FILE = const_cast<char*>("objdat.spt");
-static char* ICON_FILE = const_cast<char*>("icon.dat");
+static char* DVD_DIR = const_cast<char*>(s_dvd_gba_dir);
+static char* CLIENT_FILE = const_cast<char*>(s_ffcc_cli_bin);
+static char* OBJ_FILE = const_cast<char*>(s_objdat_spt);
+static char* ICON_FILE = const_cast<char*>(s_icon_dat);
 const unsigned int CTRL_GBA = 0x10;
 const unsigned int JOY_CODE_MASK = 0x1;
 }


### PR DESCRIPTION
## Summary
- Initialize JoyBusConst file-name pointers from the existing named string objects instead of duplicate string literals.
- Removes the bad pointer relocation targets for the joybus file-name constants.

## Objdiff evidence
Before -> after for main/joybus:
- .data: 0.0000% -> 100.0000%
- .sdata: 50.0000% -> 100.0000%
- .text: 99.1662% -> 99.1674%
- InitialCode__6JoyBusFP11ThreadParam: 99.6488% -> 99.6739%

## Verification
- ninja
- build/tools/objdiff-cli diff -p . -u main/joybus -o /tmp/joybus_after.json --format json