### PR TITLE
Match JoyBus filename pointer data

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -125,10 +125,10 @@ extern const u32 kPppYmMeltMaskBit0;
 extern const u32 kPppYmMeltMaskBit4;
 
 namespace JoyBusConst {
-static char* DVD_DIR = const_cast<char*>("dvd/gba/");
-static char* CLIENT_FILE = const_cast<char*>("ffcc_cli.bin");
-static char* OBJ_FILE = const_cast<char*>("objdat.spt");
-static char* ICON_FILE = const_cast<char*>("icon.dat");
+static char* DVD_DIR = const_cast<char*>(s_dvd_gba_dir);
+static char* CLIENT_FILE = const_cast<char*>(s_ffcc_cli_bin);
+static char* OBJ_FILE = const_cast<char*>(s_objdat_spt);
+static char* ICON_FILE = const_cast<char*>(s_icon_dat);
 const unsigned int CTRL_GBA = 0x10;
 const unsigned int JOY_CODE_MASK = 0x1;
 }


### PR DESCRIPTION
## Summary
- Point JoyBusConst filename pointers at the existing named s_* string objects instead of separate string literals.
- This matches the symbol layout for DVD_DIR__11JoyBusConst, CLIENT_FILE__11JoyBusConst, and OBJ_FILE__11JoyBusConst and also keeps ICON_FILE tied to s_icon_dat.

## Evidence
- ninja succeeds.
- build/tools/objdiff-cli diff -p . -u main/joybus -o - LoadBin__6JoyBusFv
  - .data: 0.0% -> 100.0% (size 28)
  - .sdata: 50.0% -> 100.0% (size 16)
  - .text: 99.16618% -> 99.16736% (size 51292)
  - .rodata, extab, and extabindex unchanged

## Plausibility
The PAL symbols already identify the string objects in .rodata and the JoyBusConst pointers in .sdata. Referencing those named objects is the natural source form for the observed pointer relocations, and avoids duplicate anonymous string literal storage.