### PR TITLE
Improve graphic makeSphere match

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1132,7 +1132,8 @@ void CGraphic::makeSphere()
             GXWGFifo.f32 = vertices[next0 * 3 + 0];
             GXWGFifo.f32 = vertices[next0 * 3 + 2];
 
-            int next1 = ringStart + ((seg + 2) % 8);
+            int ringBase = ringStart;
+            int next1 = ringBase + ((seg + 2) % 8);
             GXWGFifo.f32 = vertices[(i0 + 1) * 3 + 1];
             GXWGFifo.f32 = vertices[(i0 + 1) * 3 + 0];
             GXWGFifo.f32 = vertices[(i0 + 1) * 3 + 2];
@@ -1158,7 +1159,8 @@ void CGraphic::makeSphere()
                 idx2 = seg + ringPairBase;
             }
             GXWGFifo.f32 = vertices[idx2 * 3 + 1];
-            GXWGFifo.f32 = vertices[idx2 * 3 + 0];
+            int vertexIndex = idx2;
+            GXWGFifo.f32 = vertices[vertexIndex * 3 + 0];
             GXWGFifo.f32 = vertices[idx2 * 3 + 2];
 
             ringPairBase += 8;


### PR DESCRIPTION
## Summary
- Add two source-level temporaries in CGraphic::makeSphere to better match MWCC register allocation around sphere display-list vertex emission.
- Keeps the source behavior unchanged and scoped to main/graphic.

## Evidence
- Selected from B4 bucket using: python3 tools/agent_select_target.py --bucket B4 --bucket-file WORK_SPLIT.md
- build/tools/objdiff-cli diff -p . -u main/graphic -o build/b4_graphic_makeSphere_final.json makeSphere__8CGraphicFv
- makeSphere__8CGraphicFv: 85.90035% -> 86.5694%
- ninja passes

## Plausibility
- The change only names reused integer indices before array indexing; no hardcoded addresses, fake symbols, section forcing, or ABI hacks.