### PR TITLE
Use shared goout source string

### DIFF
--- a/src/goout.cpp
+++ b/src/goout.cpp
@@ -630,7 +630,7 @@ static inline const char* GetGoOutMessageLine(int languageId, int line)
     return g_strGooutMes[(languageId * 0x6E) + line];
 }
 
-static const char s_gooutCpp[] = "goout.cpp";
+extern const char s_gooutCpp[];
 
 static inline CGoOutSaveDatLayout& GoOutSaveDat(Mc::SaveDat* saveData)
 {


### PR DESCRIPTION
## Summary
- Change goout's s_gooutCpp from a local string definition to an extern reference.
- This removes the duplicate local rodata string and uses the configured shared symbol at 0x801E2F24.

## Evidence
- Built with ninja.
- Objdiff for main/goout Calc__10CGoOutMenuFv: .rodata improved from 99.832214% to 99.91963%.
- build/GCCP01/src/goout.o now has U s_gooutCpp instead of a local rodata definition.

## Plausibility
- The string is used only as the file/source argument for allocations, and config/GCCP01/symbols.txt already owns s_gooutCpp as a rodata symbol outside the goout split.
- Treating it as an extern avoids duplicating string data in goout.cpp.