### PR TITLE
wind: raise fuzzy match to 98.7% (cycle 8)

### DIFF
--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -315,9 +315,9 @@ found:
 	}
 
 	obj->type = 2;
-	obj->flagBits.active = 1;
-	float centerZ = pos->z;
 	float centerX = pos->x;
+	float centerZ = pos->z;
+	obj->flagBits.active = 1;
 
 	int id = m_nextId;
 	m_nextId = id + 1;

--- a/src/wind.cpp
+++ b/src/wind.cpp
@@ -315,8 +315,8 @@ found:
 	}
 
 	obj->type = 2;
-	float centerX = pos->x;
 	float centerZ = pos->z;
+	float centerX = pos->x;
 	obj->flagBits.active = 1;
 
 	int id = m_nextId;


### PR DESCRIPTION
Raises main/wind from 98.50% to 98.73% (data 100% throughout).

## Changes
- **AddSphere** 93.58% -> 95.68%: reorder the position-field loads (centerZ/centerX) ahead of the active-bitfield store so the `lfs` loads schedule before the `lbz/rlwimi/stb` read-modify-write, matching the target. Declaring centerZ before centerX fixes the center-field FPR pairing (f3/f0).

## Plausibility
Pure statement reordering inside the object-init block — the loads simply move a few lines earlier, which is exactly how the original setup sequence reads. No pragmas, no hacks, behavior identical.

## Remaining (walled)
- AddDiffuse 93.32%: radiusSq/centerZ compute-vs-load FPR tie-break, invariant under ~13 swept respellings.
- AddSphere residual: do/while loop emits subic. vs target mtctr; the for-loop form that yields mtctr splits obj/scan under the extra `life` param register pressure (net -0.96), so do/while is kept.
- Frame 99.95%: single fmadds operand-order tie-break; swapping fixes the line but reshuffles ternary-constant scheduling for a net loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)