### PR TITLE
materialman: raise fuzzy match to 99.60% (cycle 15)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2480,8 +2480,9 @@ void CMaterialMan::SetPosition(
         CPtrArray<CMapShadow*>* mapShadowArray = &MapMng.GetMapShadowArray();
         int candidateCount = 0;
 
-        for (unsigned int i = 0; i < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {
-            CMapShadow* shadow = (*mapShadowArray)[i];
+        int idx;
+        for (unsigned int i = 0; (idx = i) < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {
+            CMapShadow* shadow = (*mapShadowArray)[idx];
 
             if (shadow->m_targetEnabled[static_cast<int>(target)] == 0) {
                 continue;
@@ -2552,9 +2553,10 @@ void CMaterialMan::SetPosition(
         }
     } else {
         unsigned int i = 0;
+        int idx;
         CPtrArray<CMapShadow*>* mapShadowArray = &MapMng.GetMapShadowArray();
-        for (; i < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {
-            CMapShadow* shadow = (*mapShadowArray)[i];
+        for (; (idx = i) < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {
+            CMapShadow* shadow = (*mapShadowArray)[idx];
 
             if (shadow->m_targetEnabled[static_cast<int>(target)] == 0) {
                 continue;

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -3109,8 +3109,9 @@ void CMaterialSet::Create(CChunkFile& chunkFile, CTextureSet* textureSet, CMater
             case CHUNK_TIDX: {
                 {
                     unsigned long i;
-                    for (i = 0; i < static_cast<unsigned long>(m_materials.GetSize()); i++) {
-                        if (m_materials[i] == 0) {
+                    int idx;
+                    for (i = 0; (idx = i) < static_cast<unsigned long>(m_materials.GetSize()); i++) {
+                        if (m_materials[idx] == 0) {
                             goto slotFound;
                         }
                     }

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2616,8 +2616,9 @@ int CMaterialMan::GetCharaShadow(
     int outputCount = 0;
     int candidateCount = 0;
 
-    for (unsigned int i = 0; i < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {
-        CMapShadow* shadow = (*mapShadowArray)[i];
+    int idx;
+    for (unsigned int i = 0; (idx = i) < static_cast<unsigned int>(mapShadowArray->GetSize()); i++) {
+        CMapShadow* shadow = (*mapShadowArray)[idx];
         if (shadow->m_targetEnabled[0] == 0) {
             continue;
         }


### PR DESCRIPTION
## Summary
Raises `main/materialman` from baseline **99.511%** to **99.600%** by applying the R88 condition-assignment idiom to the counted `operator[]`/`GetAt` loops across three functions.

## Per-function gains
- **GetCharaShadow** 97.40% -> 99.69%: `for (i=0; (idx=i) < size; i++) { shadow = (*mapShadowArray)[idx]; }` — the `int idx` computed in the loop condition schedules the `mr r4,i` argument setup into the loop-test branch shadow, matching the target.
- **SetPosition** 97.46% -> 98.44%: same idiom applied to both inner loops (the `target==0` candidate-gather loop and the `else` direct-set loop).
- **Create** (CMaterialSet) 98.65% -> 98.94%: same idiom on the material-slot search loop (`m_materials[idx] == 0`).

## Why this is plausible source
The condition-assignment form `(idx = i) < count` is a common hand idiom for caching the subscript while testing the bound; the original FFCC code evidently used a separate signed index local for the array subscript (`int idx`) distinct from the unsigned loop counter, which is exactly what reproduces the target's instruction scheduling. No hacks, no fake symbols — pure control-flow/expression shape.

## Notes
A `signed` index is load-bearing: an `unsigned`/`unsigned long` idx is bit-identical to the original (no gain); only `int idx` lands the scheduling change.

Remaining residuals are documented register-coloring / anonymous-pool walls (SetShadowBit32 / SetPartFromTextureSet counter-vs-arg register numbering swap; the Cache* pair inlined this-vs-cursor swap; SetUnderWaterTex's compiler-generated int->double conversion-bias named-vs-anonymous double; Calc's literal-vs-named float pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)