### PR TITLE
pad: raise fuzzy match to 98.69% (cycle 9)

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -496,7 +496,7 @@ void CPad::Frame()
 			for (iVar11 = 0; iVar11 < 4; iVar11++)
 			{
 				uVar8 = *puVar7;
-				puVar10 = reinterpret_cast<u16*>(reinterpret_cast<int>(_1b0_4_) + iVar14 * 0x40 + iVar6 + 0x0C);
+				puVar10 = reinterpret_cast<u16*>(reinterpret_cast<int>(_1b0_4_) + iVar6 + iVar14 * 0x40 + 0x0C);
 				uVar2 = *puVar10;
 				*puVar7 = uVar2;
 				uVar2 = *reinterpret_cast<u8*>(puVar10 + 1);


### PR DESCRIPTION
Raises `main/pad` from 98.68043% to 98.68632%.

## What landed
**Frame__4CPadFv** (+0.0059): in the playback record-copy loop, wrote the byte-accumulator term first in the inlined dest-pointer index expression (`_1b0_4_ + iVar6 + iVar14*0x40 + 0xC` instead of `+ iVar14*0x40 + iVar6`), flipping mwcc's `add` operand order to match the target. Only lands when the index is inlined into the pointer cast (the frontend folds it); the same respelling on the named-temp form is bit-identical.

## Blocker
Both record-copy loops in Frame carry a uniform +1 callee-saved register-window shift (frame index `_1bc_4_` in r8 target / r9 ours; puVar7-base ↔ iVar14-accumulator swapped). This is the register-NUMBERING tie-break wall (cf. materialman SetShadowBit32, gxfunc r0-vs-r16) — resisted ~14 levers (init reorder, fresh accumulator, comma-cond restructure, for-update advances, do/while, cursor hoist, pointer-build order), all +0.0000 or negative. `__sinit_pad_cpp` (99.09%) is the `pTable$692+0x2c` vtable merged-thunk anchor wall (forbidden + unfixable). Unit is at a local maximum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)