### PR TITLE
graphic: raise fuzzy match to 97.93% (cycle 10)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -802,8 +802,10 @@ void CGraphic::DrawDebugString()
     GXSetNumTexGens(1);
     GXSetTexCoordGen2(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, 0x1E, GX_FALSE, 0x7D);
 
-    int y = 0x10;
-    for (u32 i = 0; i < static_cast<u32>(m_debugStringCount); ++i) {
+    int y;
+    u32 i = 0;
+    y = 0x10;
+    for (; i < static_cast<u32>(m_debugStringCount); ++i) {
         s16 xCell = m_debugStringPositions[i].x;
 
         if (xCell == -1) {


### PR DESCRIPTION
Raises `main/graphic` fuzzy match from baseline 97.924% to **97.927%**.

## What worked
- **DrawDebugString (99.46% -> 99.54%)** — split the `for` loop init: the unrelated `int y = 0x10;` local was emitting its `li r29,0x10` before the IV init `li r28,0`. Rewriting as `int y; u32 i = 0; y = 0x10; for(; cond; ++i)` puts the IV init first, matching the target's loop-head `li` emission order (R99).

## Confirmed walls (all levers regress or no-op)
- **GXWGFifo base register r3-vs-r5** (RenderTexQuadGrouad, RenderNoTexQuadGrouad) — pure RA tie-break for the AT_ADDRESS write-gather-pipe global; all color-ordering variants regress.
- **Register-window off-by-one** (GetBackBufferRect/Rect2, Thread) — `this` and the last GPR param ranked one reg off; hoisted-invariant ranking class.
- **makeSphere** — named-sdata2 sphere-constant CSE drops a callee-saved FPR (net negative) + second-half GX-emit-loop register permutation.
- **SetCopyClear** — interleaved 2-register _GXColor byte-copy lowering.
- **Named-vs-anonymous sdata2 constants** (SetViewport, BeginFrame, InitDebugString) — naming kGraphicZeroF/OneF/HalfF64 globally regresses the unit (99.56->80.41 on SetViewport); the literal/anonymous form is the unit-correct local max, reloc-name diff is zero-cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)