### PR TITLE
fontman: raise fuzzy match to 98.81% (cycle 8)

### DIFF
--- a/src/fontman.cpp
+++ b/src/fontman.cpp
@@ -240,13 +240,13 @@ void CFont::Draw(unsigned short ch)
 		glyphIndex = static_cast<int>(drawGlyph->m_textureIndex);
 		row = glyphIndex / m_glyphColumns;
 		drawWidth = static_cast<int>(glyphInfo[1]);
-		u0 = static_cast<float>((static_cast<int>(glyphInfo[0]) + m_glyphWidth * (glyphIndex - row * m_glyphColumns)) * 2);
+		u0 = static_cast<float>((static_cast<int>(glyphInfo[0]) + m_glyphWidth * (glyphIndex - m_glyphColumns * row)) * 2);
 		v0 = static_cast<float>(m_glyphHeight * row * 2);
 	} else {
 		drawWidth = static_cast<int>(m_glyphWidth);
 		glyphIndex = static_cast<int>(drawGlyph->m_textureIndex);
 		row = glyphIndex / m_glyphColumns;
-		u0 = static_cast<float>(m_glyphWidth * (glyphIndex - row * m_glyphColumns) * 2);
+		u0 = static_cast<float>(m_glyphWidth * (glyphIndex - m_glyphColumns * row) * 2);
 		v0 = static_cast<float>(m_glyphHeight * row * 2);
 	}
 


### PR DESCRIPTION
Raises main/fontman from 98.807% to 98.815%.

## Change
- **CFont::Draw(unsigned short)** — in both the fixed-width and proportional branches, the glyph index-multiply `glyphIndex - row * m_glyphColumns` is written member-first (`m_glyphColumns * row`). This flips mwcc to reuse the already-loaded `m_glyphColumns` register as the `mullw` first operand, matching the target's `mullw rD,row,cols` form (+0.0041 per branch, +0.0083 net).

## Plausibility
A trivial commutative reordering of the column-offset multiply; both forms are identical behavior and ordinary hand-source.

## Walls confirmed (no net-positive source change found)
- **SetColor (89.7%)**: first color-byte load r5-vs-r0 tie-break; every field-copy spelling regresses.
- **Draw(Us) (96.5%)**: the `divw` (row) result lands in r4 (target) vs r7 (ours), shifting the mullw register window by one; col-cache and modulo regress. GXTexCoord2u16 magic-double conversion interleave is a scheduler tie-break (staging regresses; posZ must stay a direct per-vertex member read).
- **GetWidth(char*) (97.0%)**: inlined searchChar glyph pointer colored to r4 (target) vs r3+`mr` (ours); searchChar is a shared inline so its body can't be respelled.
- **GetWidth(u16) (99.93%) / DrawInit (99.97%)**: each has a single residual line — the compiler-generated int→double magic bias references an anonymous pool double rather than the named `kFont*IntToDoubleBias` symbol. mwcc 2.4.2 never unifies its conversion-bias pool entry with a same-valued named extern (confirmed across linkage forms); the reloc-name difference costs ~zero. Universal conversion-bias wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)