### PR TITLE
joybus: raise fuzzy match to 99.18% (cycle 33)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -4306,7 +4306,7 @@ int JoyBus::SendPpos(ThreadParam* threadParam)
         int sent = m_pposWordIndex[threadParam->m_portIndex];
         unsigned int* wordPtr = &posWords[sent];
 
-        while (sent < (int)(unsigned char)m_cmdBuffer[4 + threadParam->m_portIndex])
+        while (sent < (int)(signed char)m_cmdBuffer[4 + threadParam->m_portIndex])
         {
             unsigned int word = *wordPtr;
 


### PR DESCRIPTION
Raises main/joybus fuzzy match 99.16899% → 99.17719%.

## Change
**SendPpos case 3 signed-char loop bound** — the case 3 word-send loop compared its bound `m_cmdBuffer[4 + portIndex]` as `(unsigned char)`, but the target sign-extends it (`extsb; cmpw`), matching the sibling case 1 loop which already used `(signed char)`. Changed case 3 to `(signed char)` to match. The original used signed in both arms; this was a real per-arm signedness bug.

## Method
Per-case signed-char audit (new R100): diff-grepped every counted loop's bound across sibling switch cases for an `extsb`/`lha` DELETE in the target; the unsigned arm was the bug.

## Walls confirmed (no net-positive change found)
- LoadBin/RestartThread share the identical unrolled GBA-checksum tail; the subtract-accumulator coloring (high reg in target, scratch r0 in ours) is the canonicalized RA tie-break — R91 pragma combo already applied is the local max.
- SetMoney/SetCtrlMode/SendMapObjDrawFlg/SendPlayerStat carry a uniform +1 callee-saved window shift (inlined-SetSendQueue cmd-word reload ranks highest in ours, lowest in target).
- SendBonusStr byteLen-accumulate operand order is canonicalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)