### PR TITLE
game: raise fuzzy match to 99.30% (cycle 10)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1056,7 +1056,7 @@ static inline void savePermanentScriptVars(char* scriptData)
     while (i < CFlatPermanentVarCount()) {
         int flagIndex = entryOffset + 1;
         if ((CFlatPermanentVarDefs()[flagIndex] & 0x20) != 0) {
-            *reinterpret_cast<u32*>(scriptData + scriptOffset) = CFlatPermanentVarWord(entryOffset);
+            reinterpret_cast<u32*>(scriptData)[scriptOffset / 4] = CFlatPermanentVarWord(entryOffset);
             scriptOffset += 4;
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1017,15 +1017,18 @@ void CGame::LoadInit()
  */
 static inline void loadPermanentScriptVars(char* scriptData)
 {
-    int n = 0;
+    int scriptOffset = 0;
     int i = 0;
+    int entryOffset = 0;
 
     while (i < CFlatPermanentVarCount()) {
-        if ((CFlatPermanentVarDefs()[i * 4 + 1] & 0x20) != 0) {
-            CFlatPermanentVarWord(i * 4) = reinterpret_cast<u32*>(scriptData)[n];
-            n++;
+        int flagIndex = entryOffset + 1;
+        if ((CFlatPermanentVarDefs()[flagIndex] & 0x20) != 0) {
+            CFlatPermanentVarWord(entryOffset) = reinterpret_cast<u32*>(scriptData)[scriptOffset / 4];
+            scriptOffset += 4;
         }
 
+        entryOffset += 4;
         i++;
     }
 }


### PR DESCRIPTION
Raises main/game from 99.18% to 99.30%.

## Wins
- **LoadScript** 85.95% -> 96.7%: rewrote the permanent-var load loop to use byte-offset iteration (separate entryOffset/scriptOffset/i, mirroring savePermanentScriptVars) and an indexed source read `reinterpret_cast<u32*>(scriptData)[scriptOffset/4]` instead of a strength-reduced pointer cursor. Matches the target's `lwzx rN, base, byteOffset` addressing.
- **SaveScript** 96.18% -> 100%-region: same indexed-store fix `reinterpret_cast<u32*>(scriptData)[scriptOffset/4] = ...` so scriptData stays in a fixed register with a separate advancing byte offset.

## Investigated, walled (register-allocation tie-breaks / documented naming walls)
- ChangeMap: branchless `(-x)|x >> 31` mask CSE lands in swapped registers; ternary restructurings all regress.
- GetBossArtifact: int->double bias is anonymous pool vs named kGameIntToDoubleBias (documented universal wall, zero-cost reloc name); plus an r28/r30 tie-break.
- GetTargetCursor, clearWork, Calc, loadCfd, Exec: callee-saved register-number tie-breaks (this-ptr vs cursor, base-ptr materialization order); confirmed no source restructuring improves them via sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)