### PR TITLE
map: raise fuzzy match to 99.44% (cycle 17)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2228,8 +2228,9 @@ int CMapMng::ReadOtm(char* mapName)
         }
     }
 
-    for (unsigned int i = 0; i < static_cast<unsigned int>(GetMapShadowArray().GetSize()); i++) {
-        GetMapShadowArray()[i]->Init();
+    int shadowIdx;
+    for (unsigned int i = 0; (shadowIdx = i) < static_cast<unsigned int>(GetMapShadowArray().GetSize()); i++) {
+        GetMapShadowArray()[shadowIdx]->Init();
     }
 
     m_rootMapObj = SearchChildMapObj(GetMapObjArray(), 0);


### PR DESCRIPTION
Raises `main/map` from 99.408% to 99.4445% (+0.037).

## What worked
**R88 condition-assignment idiom on ReadOtm's CMapShadow Init loop.** The target emits the `operator[]` index `mr r4,r25` in the loop-bottom branch shadow (right before `blt`), but ours emitted it at the loop top before the `__vc` call — a genuine code-motion (DIFF_INSERT/DIFF_DELETE) pair, not a register tie-break. Rewriting the loop as `int shadowIdx; for (unsigned int i=0; (shadowIdx = i) < (unsigned)GetMapShadowArray().GetSize(); i++) { ...[shadowIdx]->Init(); }` schedules the `mr` into the test block (the signed `int idx` value-numbers differently from the unsigned IV). ReadOtm flagged lines 37 -> 35.

## Walls confirmed (no net-positive change found)
- **SetIdGrpColor (83.24%)**: dest-pointer `add r5` (target, reuses mulli result) vs `add r3` (ours) + color-byte load order — Ghidra-exact field-copy form equals baseline bit-for-bit; all other spellings regress. Canonicalized RA tie-break.
- **SetMapObjAnim (96.09%)**: operator[] result-staging `mr r0` hop + inner-loop `bne/beq` polarity — all spellings bit-identical.
- **Calc (98.11%)**: 64-bit subtract `+0xFFFFFFFEu` (immediate `subic`) vs target's register-materialized `subfc`/`adde` — `+0xFFFFFFFEu` is the local max, all signed/unsigned alternatives regress.
- **DestroyMap (98.88%)**: uniform counter-vs-cursor register swap (counter r30/cursor r29 target vs counter r28/cursor r30 ours) — fresh-IV/explicit-cursor/count-local all regress.
- **Draw (99.49%)**, ReadMpl/ReadMtx/ReadMid: register-window permutations + zero-cost merged-rodata-vs-named anchor reloc names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)