### PR TITLE
memory: raise fuzzy match to 99.65% (cycle 6)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1908,14 +1908,16 @@ void CAmemCacheSet::AmemFreeLowPrio(int size)
     while (true) {
         CAmemCache* bestEntry = 0;
 
+        int offset = 0;
         for (int i = 0; i < m_cacheCount; i++) {
-            CAmemCache& entry = cacheEntryAt(this, i);
+            CAmemCache& entry = *reinterpret_cast<CAmemCache*>(reinterpret_cast<char*>(m_cacheTable) + offset);
             if (entry.m_inUse != 0 && entry.m_refCount == 0 && entry.m_dmaCopy != 0 &&
                 entry.m_cacheData != 0 && entry.m_size >= currentSize &&
                 static_cast<unsigned int>(entry.m_priority) < bestPriority) {
                 bestEntry = &entry;
                 bestPriority = static_cast<unsigned int>(entry.m_priority);
             }
+            offset += sizeof(CAmemCache);
         }
 
         if (bestEntry != 0) {


### PR DESCRIPTION
## Summary
Raises `main/memory` fuzzy match from 99.635% to 99.651%.

## Change
- **AmemFreeLowPrio** (98.95% -> 99.19%): rewrote the low-priority cache scan loop to walk a byte-offset cursor (`int offset; ...; offset += sizeof(CAmemCache)`) instead of `cacheEntryAt(this, i)` (= `m_cacheTable[i]`). This matches the target's register pairing — offset advancing in a low scratch register and the entry pointer computed as `base + offset` — eliminating the offset/entry-pointer register swap (R12/R44).

## Evidence
- main/memory: 99.635% -> 99.651% (report.json fuzzy_match_percent)
- Behavior is identical; the byte cursor is the same idiom already used in `CacheClear` and `Release` in this file.

## Walls hit (documented, not source-fixable)
- `amem_stateName[m_inUse == 0]` index mask (`rlwinm ...,29,3,29` vs `...,22,29`) — universal codegen-encoding detail, behaviorally identical for byte inputs; not reachable via any index-expression source form.
- Inlined `freeStageBlockBase` callee-saved register-window off-by-one (DestroyStage/AmemFreeLowPrio/Quit) — caller-liveness-driven, not steerable by local decl order.
- `alloc` split-block two-pointer and `AddRef`/`SetData` result-in-rN register coloring — all tested source variants regressed or were net-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)