### PR TITLE
mapobj: raise fuzzy match to 99.71% (cycle 6)

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -959,8 +959,7 @@ int CMapObj::ReadOtmObj(CChunkFile& chunkFile)
             if (MapMng.m_shadowKeyInfoCount >= 4) {
                 break;
             }
-            CMapShadowKeyInfo* keyInfo = &MapMng.m_shadowKeyInfos[MapMng.m_shadowKeyInfoCount];
-            MapMng.m_shadowKeyInfoCount++;
+            CMapShadowKeyInfo* keyInfo = &MapMng.m_shadowKeyInfos[MapMng.m_shadowKeyInfoCount++];
             keyInfo->m_key = chunkFile.Get4();
             keyInfo->m_frame = static_cast<short>(static_cast<int>(chunkFile.GetF4()));
             keyInfo->m_unknown06 = chunkFile.Get1();


### PR DESCRIPTION
Raises `main/mapobj` from 99.70458% to **99.70952%** (28/32 functions matched).

## Change
`ReadOtmObj` (CHUNK_SHKI case): fuse the post-increment into the array subscript —
`&MapMng.m_shadowKeyInfos[MapMng.m_shadowKeyInfoCount++]` instead of indexing then
incrementing on a separate statement. This makes mwcc reuse the count register for
the post-increment store (`addi count,count,1; sth count`) matching the target,
instead of spilling the increment to a scratch r0.

## Remaining ceiling (RA tie-break walls)
All other diffs in the unit are register-allocation tie-breaks, confirmed
bit-identical under every source sweep:
- `ReadOtmObj`: callee-saved band permutation driven by switch-tree pivot constant
  coloring (CHUNK_MIME `0x4d494d45` in r16-vs-r21; parentIdx r17-vs-r16) — unmoved by
  decl-order, chained-init, comma-init, and VTX-loop restructuring sweeps.
- `CheckHitCylinder`/`CheckHitCylinderNear`: single `mr r5,r4`-vs-`li r5,0` dual-zero
  scratch tie-break; chained `y=x=0` is a no-op.
- `Draw`: single fcmpu FPR f0/f1 assignment on `kMapObjOne != m_zBufferOffset`;
  swapping operands regresses both sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)