### PR TITLE
gobjwork: raise fuzzy match to 98.32% (cycle 24)

### DIFF
--- a/src/gobjwork.cpp
+++ b/src/gobjwork.cpp
@@ -2685,7 +2685,7 @@ int CCaravanWork::GetArtifactIncludeHpMax()
 				case 0xDF:
 					break;
 				case 0xE4:
-					hpMax += artifactValue;
+					hpMax = artifactValue + hpMax;
 					break;
 				}
 			}


### PR DESCRIPTION
Cycle-24 re-attack of the gobjwork c22/c23 walls with the newest levers (R88 int-idx, R100 signedness, R38 operand-order, R12/R44 byte-cursor, R46 sdata2-naming, R54/R70 web-placement).

## Landed
- **GetArtifactIncludeHpMax**: accumulator operand-order fix — `hpMax = artifactValue + hpMax` (value-first spelling) lands the accumulator in the target's higher scratch GPR (98.31937 -> 98.32142, fn 98.67 -> 98.80).

## Re-confirmed walls (all levers NET-ZERO/regress, do not re-grind)
- **SearchRomLetterWork** (4916B, the unit's whole headroom): pure inverse-coloring wall — target keeps outer-loop IVs volatile (`stmw r20`, 12 regs) and inner replace-search temps callee-saved; ours does the inverse (`stmw r21`). 643-line diff = one pervasive off-by-one band rotation driven by whole-function liveness. Goto+jumptable body blocks the R52 always_inline escape.
- **GetNextCmdListIdx / GetNumCombi**: whole-function callee-saved band rotations; Game-ptr hoist, decl-late, polarity forms all net-zero.
- **CMonWork::Init / CalcStatus**: commutative `add base,offset` canonicalization inside inlined GetStatusMultiplier + the universal `DOUBLE_803309A0` int->double-bias-pool naming wall (synthesized anonymous pool, invisible source conversion).
- **FGPutGil / SafeDeleteTempItem**: neg-in-place and increment-folding register tie-breaks; ours already closest.

Net: gobjwork 98.31937% -> 98.32142%. Ceiling is register-band rotation + bias-pool naming + commutative-add canonicalization, none source-steerable in mwcc 2.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)