### PR TITLE
map: raise fuzzy match to 99.46% (cycle 18)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1964,7 +1964,7 @@ int CMapMng::ReadMpl(char* mapName)
         }
 
         if (filePtr == 0) {
-            if (static_cast<int>(System.m_execParam) >= 1) {
+            if (static_cast<unsigned int>(System.m_execParam) >= 1) {
                 System.Printf(const_cast<char*>(s_mapReadErrorFmt), strTmp);
             }
             return 0;


### PR DESCRIPTION
Bug-hunt of the Read* data-parser family in main/map (baseline 99.4445%).

## Real bug found and fixed
**ReadMpl execParam compare signedness.** The `filePtr == 0` error path compared `static_cast<int>(System.m_execParam) >= 1` (signed → `cmpwi`), while every other execParam guard in the file uses `unsigned int` (→ `cmplwi`). The target emits `cmplwi r0, 0x1` at this site. Changed the cast to `unsigned int` to match the sibling guards. This was a genuine signedness inconsistency, not codegen noise.

main/map: 99.4445% → 99.4555%

## Investigated, no source-fixable bug (RA/scheduling walls)
- **SetIdGrpColor (83.2%)**: field-copy read order vs Ghidra 8002fcb4 confirmed; reordering the r/g/b/a temp reads to match the Ghidra idiom did not convert — residual is the destination-base register (r3 vs r5) and load scheduling, pure register allocation.
- **SetMapObjAnim (96.1%)**: two diffs — an extra `mr` routing the operator[] result through r0, and a branch-polarity diff (`bne back; b out` vs `beq forward`) on the inner match. Both are RA/block-scheduling; `continue`-restructure was net-zero.
- **ReadMtx / ReadMid / ReadOtm**: all remaining flagged lines are consistent register-number shifts (same opcode, off-by-one callee-saved reg) with identical frame size and saved-reg count. ReadMid's final octTree loop pointer-walk variant regressed. No opcode-level signedness/addressing mismatches remain anywhere in the unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)