### PR TITLE
gobject: raise fuzzy match to 99.13% (cycle 28)

### DIFF
--- a/src/gobject.cpp
+++ b/src/gobject.cpp
@@ -977,14 +977,9 @@ void CGObject::objectCollision()
                         const float thisPush = static_cast<float>(m_pushParamA + m_pushParamB);
                         const float otherPush = static_cast<float>(other->m_pushParamA + other->m_pushParamB);
                         const float rawSplit = sBgAttrNormal + (thisPush - otherPush) / sCrossCheckOuterRadius;
-                        float split;
-                        if (rawSplit < sZeroFloat) {
-                            split = sZeroFloat;
-                        } else if (sAnimFrameOffset < rawSplit) {
-                            split = sAnimFrameOffset;
-                        } else {
-                            split = rawSplit;
-                        }
+                        float split = (rawSplit < sZeroFloat)
+                            ? sZeroFloat
+                            : ((sAnimFrameOffset < rawSplit) ? sAnimFrameOffset : rawSplit);
 
                         Vec& delta = scratch;
                         Vec scaledDelta;


### PR DESCRIPTION
Bug-hunt pass on main/gobject (baseline 99.097%).

## Real bug fixed
**objectCollision push-split clamp** (+0.037, fn 17->9 flagged lines): the three-way clamp `split = clamp(rawSplit, 0, sAnimFrameOffset)` was written as an if/else-if/else chain. The original accumulates the clamp result into a single callee-saved FPR (`fadds`/`fcmpo`/`bge`/`fmr` building one live value) rather than scratch FPRs + a late `fmr`. Rewriting as a nested ternary (`(x<lo)?lo:((hi<x)?hi:x)`) matches the target's branch-select codegen.

## Result
main/gobject 99.097% -> 99.13439% (47/60 functions exact).

## Walls re-confirmed (c27 findings hold; no new lever applied)
- onCreate: `-1` constant-web coloring r5-vs-r7 (canonicalized TRUE WALL).
- CCClass / CalcSafePos / bgWorldCollision / bgNormalCollision / move: FPR-numbering and commutative-fmuls/fadds operand-order tie-breaks (named-local respelling regresses).
- bgWorldCollision / bgAttribCollision: CVector ctor-temp stack-slot allocation shifts (RA-driven).
- anonymous `@NNN`-vs-named pool reloc names: zero fuzzy cost (converting `static const float`->`extern` regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)