### PR TITLE
p_camera: pragma-scoped RA fixes to 96.8% (cycle 16)

### DIFF
--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -737,6 +737,7 @@ void CCameraPcs::CalcQuake()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_lifetimes off
 void CCameraPcs::calc()
 {
     Mtx zRotMtx;
@@ -864,6 +865,7 @@ void CCameraPcs::calc()
     PSMTXMultVecSR(invMtx, &DirectionVec(), &DirectionVec());
     m_fromScript = 0;
 }
+#pragma opt_lifetimes on
 
 /*
  * --INFO--


### PR DESCRIPTION
Scoped optimizer pragma sweep on main/p_camera, baseline 96.74508%.

## Net-positive change
- **`#pragma opt_lifetimes off` on `CCameraPcs::calc`** (R104): 99.72% -> 99.84% on the function, unit 96.74508% -> 96.75666% (+0.0116). Tightly scoped (off before the signature, on after the closing brace). The default pragma matrix flagged opt_lifetimes=off as the sole net-positive lever; every other toggle and the raw optimization_level/scheduling matrices were +0 or regressed.

## Result
- main/p_camera: 96.74508% -> 96.75666%
- DOL total: 97.9146% -> 97.914696% (no collateral regression)

## Functions that stayed walled (all pragmas +0 or regress, incl. raw optimization_level 0-3 and scheduling 604/603/750)
- **createFullShadow (73.67%)** — the unit's whole headroom. The hand-unrolled 8-way swizzle loop is a synthetic-IV scratch-register rotation (R86/R97 canonicalized wall) plus a MapMng/s_p_camera_cpp base-emission-order swap; `opt_propagation off` (c21/R53) is already applied and is the local max. optimization_level 0-3, scheduling 604/603, sched off all regress; opt_strength_reduction off is a no-op.
- **drawShadowBegin (99.08%), calcMap (99.34%), GetShadowRect (99.50%)** — register-numbering/scheduling tie-breaks; optimize_for_size on is catastrophic (-7.9 on drawShadowBegin).
- **CalcQuake (99.94%), calcChara (99.95%), drawShadowEnd (99.99%)** — RA tie-breaks, no pragma helps.
- **__sinit_p_camera_cpp (53.62%)** — the R101 merged-base-CSE wall, skipped.

Blocker: the dominant residual (createFullShadow's synthetic-IV swizzle loop) is the documented register-rotation/scheduling tie-break that pragmas cannot reshape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)