### PR TITLE
graphic: pragma-scoped RA fixes to 97.9% (cycle 11)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -1485,6 +1485,7 @@ void CGraphic::GetBackBufferRect2(void* dstBuffer, _GXTexObj* texObj, int x, int
     }
 }
 
+#pragma scheduling off
 /*
  * --INFO--
  * PAL Address: 800178a4
@@ -1552,6 +1553,7 @@ void CGraphic::RenderTexQuadGrouad(Vec pos1, Vec pos2, _GXColor color1, _GXColor
 	GXWGFifo.f32 = tex1;
 }
 
+#pragma scheduling on
 /*
  * --INFO--
  * PAL Address: 800177f0


### PR DESCRIPTION
Scoped `#pragma scheduling off` on `CGraphic::RenderTexQuadGrouad` cracks part of the GXWGFifo r3-vs-r5 register/scheduling wall: the fn rises 89.18% -> 90.05%, lifting main/graphic 97.9273% -> 97.9399% (DOL net +0.0001, no collateral regression).

The pragma is scoped tightly (off before the fn, restored `on` before the sibling RenderNoTexQuadGrouad) because `scheduling off` REGRESSES the sibling -0.108 — its FIFO stores want the scheduled order.

Full pragma sweep (default on/off toggle matrix + raw optimization_level 1/2/3) was run on every sub-100% function: makeSphere, SetCopyClear, GetBackBufferRect, GetBackBufferRect2, Thread, RenderNoTexQuadGrouad, DrawDebugString, SetViewport, BeginFrame, InitDebugString, Init, RenderDOF, CreateSmallBackTexture, RenderBlur — all remain walled (every combo net-zero or negative). The hypothesis that optimization_level would re-rank the GetBackBufferRect/Rect2/Thread register-window off-by-one was disproved (optlevel 1/2/3 all no-op-or-negative there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)