### PR TITLE
materialman: pragma-scoped RA fixes to 99.633% (cycle 17)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1007,6 +1007,7 @@ void CMaterialMan::addtev_full_shadow(long index)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_common_subs off
 void CMaterialMan::SetUnderWaterTex()
 {
     int x = 0;
@@ -1043,6 +1044,7 @@ void CMaterialMan::SetUnderWaterTex()
 
     PSMTXConcat(matrixA, matrixB, m_underWaterTexMtx);
 }
+#pragma opt_common_subs reset
 
 /*
  * --INFO--

--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -2457,6 +2457,7 @@ void CMaterialMan::SetShadowBit32(CMapShadow::TARGET target, unsigned long* shad
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_common_subs off
 void CMaterialMan::SetPosition(
     CMapShadow::TARGET target,
     Vec* position,
@@ -2583,6 +2584,7 @@ void CMaterialMan::SetPosition(
         }
     }
 }
+#pragma opt_common_subs reset
 
 /*
  * --INFO--


### PR DESCRIPTION
Scoped `#pragma opt_common_subs off` (with `reset` after each function's closing brace) on two functions, raising main/materialman from 99.600% to 99.633% with no DOL collateral.

- **SetPosition**: opt_common_subs off, fn 98.44% -> 99.13% (+0.0158 unit)
- **SetUnderWaterTex**: opt_common_subs off, fn 98.48% -> 99.95% (+0.0171 unit)

Siblings (GetCharaShadow, SetMaterial) verified unregressed; whole-report verified no collateral.

Walled (full default pragma matrix swept, baseline won): SetShadowBit32, SetTextureSet, CMaterialSet::Create, both CMaterialSet Cache pair fns, SetMaterial, SetPartFromTextureSet, Calc, GetCharaShadow, SetMaterialPart. scheduling off regresses every materialman function; lmw/stmw is load-bearing unit-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)