### PR TITLE
cmake: pragma-scoped RA fixes to 99.34% (cycle 38)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1775,6 +1775,7 @@ void CMenuPcs::CmakeJobClose()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_common_subs off
 int CMenuPcs::CmakeJobCtrl()
 {
     short repeat;
@@ -1889,6 +1890,7 @@ int CMenuPcs::CmakeJobCtrl()
     }
     return 0;
 }
+#pragma opt_common_subs on
 
 /*
  * --INFO--

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -1920,6 +1920,7 @@ void CMenuPcs::CmakeJobOpen()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_lifetimes off
 void CMenuPcs::CmakeTribeDraw()
 {
     CmakeMenuState* state = CmakeState(this);
@@ -2060,6 +2061,7 @@ void CMenuPcs::CmakeTribeDraw()
         }
     }
 }
+#pragma opt_lifetimes on
 
 /*
  * --INFO--
@@ -3455,6 +3457,7 @@ void CMenuPcs::DrawCrystal(int type, int frame, float alpha)
  * JP Size: TODO
  */
 #pragma opt_propagation off
+#pragma opt_lifetimes off
 void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
 {
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
@@ -3497,6 +3500,7 @@ void CMenuPcs::DrawCmakeTitle(int page, float x, float alpha)
         0, static_cast<float>(baseX), static_cast<float>(offsU), 208.0f, 24.0f,
         0.0f, static_cast<float>(page * 0x18), 1.0f, 1.0f, 0.0f);
 }
+#pragma opt_lifetimes on
 #pragma opt_propagation on
 
 /*

--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -2587,6 +2587,7 @@ void CMenuPcs::CmakeNameClose()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_common_subs off
 int CMenuPcs::CmakeNameCtrl()
 {
     short repeat;
@@ -2831,6 +2832,7 @@ int CMenuPcs::CmakeNameCtrl()
 
     return 0;
 }
+#pragma opt_common_subs on
 
 /*
  * --INFO--
@@ -2997,6 +2999,7 @@ void CMenuPcs::CmakeOpen()
  * JP Size: TODO
  */
 #pragma opt_propagation off
+#pragma opt_lifetimes off
 void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
 {
     _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_AND);
@@ -3064,6 +3067,7 @@ void CMenuPcs::DrawCmakeYesNo(int yesNoSel, float alpha)
         DrawCursor(cursorBase, 0x175, alpha);
     }
 }
+#pragma opt_lifetimes on
 #pragma opt_propagation on
 
 /*


### PR DESCRIPTION
Scoped-pragma register-allocation fixes that crack the c36/c37-documented 99.296% "ceiling" by flipping the exact register-numbering tie-breaks those cycles declared walls (font-ptr coloring cascade, ptr-vs-value reg swap on reloaded state). All five wins are per-function scoped and stack:

- `#pragma opt_common_subs off` on **CmakeJobCtrl** (+0.0166)
- `#pragma opt_common_subs off` on **CmakeNameCtrl** (+0.0102)
- `#pragma opt_lifetimes off` on **DrawCmakeYesNo** (+0.0147, stacked on the existing opt_propagation off)
- `#pragma opt_lifetimes off` on **DrawCmakeTitle** (+0.0026, stacked on existing opt_propagation off)
- `#pragma opt_lifetimes off` on **CmakeTribeDraw** (+0.0006)

main/cmake 99.2957% -> 99.3405%; whole DOL 97.930565% -> 97.93131%.

Note: pragma_sweep.py is unreliable for cmake because every function's natural end-anchor sits inside a `#ifndef VERSION_GCCP01` block, so the reset pragma is compiled out and leaks to EOF. Pragmas here are placed with the `on` reset after each function's closing brace but before the `#ifndef`, so the scope is correct in the GCCP01 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)