### PR TITLE
p_graphic: pragma-scoped RA fixes to 98.8% (cycle 17)

### DIFF
--- a/src/p_graphic.cpp
+++ b/src/p_graphic.cpp
@@ -212,6 +212,7 @@ inline void CGraphicPcs::drawSFCircle(int innerRadius, int outerRadius, int cent
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_lifetimes off
 void CGraphicPcs::drawScreenFade()
 {
     Mtx44 orthoMtx;
@@ -454,6 +455,7 @@ unsigned int CGraphicPcs::GetScreenFadeExecutingBit()
 
     return result;
 }
+#pragma opt_lifetimes reset
 
 /*
  * --INFO--


### PR DESCRIPTION
Scoped `#pragma opt_lifetimes off` on `drawScreenFade` raises main/p_graphic from 98.751% to 98.771% (fn 99.26 -> 99.31). The pragma recovers a few of the cascaded vertex-store lines around the hoisted int->double conversion bias; siblings drawSFCircle/drawBar unchanged, DOL fuzzy unchanged.

drawBar and drawSFCircle were full-matrix swept and remain at the cycle-16 GX-inline register-allocation ceiling (scheduling off is catastrophic here, -9 to -22, opposite of the sibling graphic GXWGFifo functions). No net-positive pragma exists for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)