### PR TITLE
game: pragma-scoped RA fixes to 99.33% (cycle 12)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1173,6 +1173,7 @@ void CGame::Draw()
 	gCFlatRuntime().SystemCall(0, 1, 6, 0, 0, 0);
 }
 
+#pragma opt_propagation off
 /*
  * --INFO--
  * PAL Address: 0x8001440c
@@ -1223,6 +1224,7 @@ int CGame::GetBossArtifact(int ratioIndex, int amount)
         entriesByteOffset + stageBase * (int)sizeof(CBossArtifactEntry));
 }
 
+#pragma opt_propagation on
 /*
  * --INFO--
  * PAL Address: 0x800143ec


### PR DESCRIPTION
Scoped optimizer pragma on the one function in main/game where it lands net-positive:

- **GetBossArtifact**: `#pragma opt_propagation off` — 97.99 -> 99.16 (fn). Preserves the target's per-site rematerialization of the artifact-base / threshold-compare address (the c11 base-last-vs-base-early + r28<->r30 callee-saved-swap wall).

Unit main/game 99.297424% -> 99.33486% (+0.0374). DOL fuzzy 97.97334% -> 97.97353% (no collateral regression).

Full default on/off pragma matrix (+ pair combos) swept on all 9 sub-100 functions (skipped __sinit); GetBossArtifact is the only net-positive. LoadScript/ChangeMap/SaveScript/GetTargetCursor/Exec/clearWork/Calc/loadCfd re-confirmed walled (named-pool-vs-anonymous reloc + register-window numbering tie-breaks) under every toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)