### PR TITLE
memorycard: code matching to 99.76% (cycle 7)

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -476,6 +476,7 @@ unsigned int CMemoryCardMan::ChkCrc(Mc::SaveDat* saveData)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_propagation off
 void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::SaveDat& dstSave, int dstChar)
 {
     if (static_cast<unsigned int>(System.m_execParam) >= 3)
@@ -606,6 +607,7 @@ void CMemoryCardMan::Odekake(int mode, Mc::SaveDat& srcSave, int srcChar, Mc::Sa
     dstSave.m_random = Math.Rand(0x7FFFFFFF);
     dstSave.m_crc = CalcCrc(&dstSave);
 }
+#pragma opt_propagation reset
 
 /*
  * --INFO--


### PR DESCRIPTION
Scoped `#pragma opt_propagation off` on `CMemoryCardMan::Odekake` raises main/memorycard fuzzy from 99.70381% to 99.76155% (Odekake function 99.11% -> 99.62%), with no sibling-function or whole-DOL regression.

The opt_propagation-off scope matches the original's value-flow for Odekake (which inlines CalcCrc twice under Rand-call register pressure); the surrounding functions keep default optimization via a paired `#pragma opt_propagation reset`.

Findings (no other net-positive lever found):
- The two duplicated stores in MakeSaveData (the redundant `memcpy(save+0x11D0,...)` and `save[0x13DE]=...`) are REAL — the shipped binary contains both; removing either regresses the function. Not decomp errors.
- The SetLoadData srawi-vs-srwi signedness fix was re-tested under pragmas and remains net-negative (clears one flag but reschedules the adjacent extsb/lis pair).
- MakeSaveData (99.38%) and SetLoadData (99.52%) residuals are the canonicalized register-allocation tie-break wall (uniform save-buffer/rodata-base/Game-base r29<->r30 rank swap + counter swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)