### PR TITLE
cmake: source-shape RA fixes to 99.345% (cycle 39)

### DIFF
--- a/src/cmake.cpp
+++ b/src/cmake.cpp
@@ -3112,10 +3112,7 @@ void CMenuPcs::DrawCmakeName(int x, int y, char* text, float alpha)
     float nameW = 161.0f;
     int nameX = static_cast<int>(-(nameW / 2.0 - 400.0));
 
-    int baseY = 300;
-    if (x != 0) {
-        baseY = 0x130;
-    }
+    int baseY = (x != 0) ? 0x130 : 300;
 
     CFont* font = m_fonts[CMAKE_FONT_VALUE];
     font->SetShadow(1);


### PR DESCRIPTION
DrawCmakeName: rewrote `baseY` from a two-arm `if/assign` into a single ternary (`baseY = (x != 0) ? 0x130 : 300;`), which fixed the r30/r31 callee-saved coloring swap (baseY now colors into r31 / nameX into r30, matching target). Removed the entire 7-instruction ARG_MISMATCH cluster on that function. main/cmake unit 99.3405% -> 99.34498%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)