### PR TITLE
joybus: scoped pragma fixes to 99.193% (cycle 34)

### DIFF
--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6077,6 +6077,8 @@ int JoyBus::GetGBAStat(ThreadParam* threadParam)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma push
+#pragma opt_lifetimes off
 int JoyBus::ChgCtrlMode(int portIndex)
 {
     unsigned int word = 0;
@@ -6126,6 +6128,7 @@ int JoyBus::ChgCtrlMode(int portIndex)
 
     return ret;
 }
+#pragma pop
 
 /*
  * --INFO--

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -3623,6 +3623,8 @@ inline int JoyBus::WriteContext(ThreadParam* threadParam)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma push
+#pragma opt_common_subs off
 int JoyBus::InitialCode(ThreadParam* threadParam)
 {
     int result;
@@ -3770,6 +3772,7 @@ int JoyBus::InitialCode(ThreadParam* threadParam)
 
     return result;
 }
+#pragma pop
 
 /*
  * --INFO--

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -6328,6 +6328,8 @@ int JoyBus::GBAReady(int portIndex)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma push
+#pragma opt_propagation off
 int JoyBus::SendAllStat(int portIndex)
 {
     m_threadParams[portIndex].m_state = 0;
@@ -6366,6 +6368,7 @@ int JoyBus::SendAllStat(int portIndex)
 
     return 0;
 }
+#pragma pop
 
 
 /*

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -5310,6 +5310,8 @@ int JoyBus::SendCmd(ThreadParam* threadParam)
     return result;
 }
 
+#pragma push
+#pragma opt_propagation off
 /*
  * --INFO--
  * Address:	TODO
@@ -5411,6 +5413,7 @@ int JoyBus::SendBonusStr(ThreadParam* threadParam)
 
     return result;
 }
+#pragma pop
 
 /*
  * --INFO--


### PR DESCRIPTION
First scoped-pragma sweep of main/joybus (prior cycles were source-shape + the R100 signed-char + data fix; the file had never been pragma-swept). Ran the default pragma_sweep matrix per-function on every sub-100 function.

Net: 99.177185% -> 99.19317% (+0.0160). Four scoped wins, each tightly wrapped (push before fn signature, pop after closing brace), no sibling regression, DOL fuzzy 98.005%:
- SendBonusStr: opt_propagation off (98.50 -> 99.00 fn, +0.0086 unit)
- InitialCode: opt_common_subs off (99.67 -> 99.78 fn, +0.0051 unit)
- ChgCtrlMode: opt_lifetimes off (99.01 -> 99.32 fn, +0.0017 unit)
- SendAllStat: opt_propagation off (+0.0006 unit)

Existing committed pragmas preserved (LoadBin R91 combo, SendPpos opt_unroll_loops, RestartThread optimize_for_size).

Walled (all toggles +0.0000 or regress under scoped sweep): LoadBin/RestartThread (R91 checksum-tail already at local max), GBARecvSend, SendPlayerStat, SendMapObjDrawFlg, SendDataFile, SetCtrlMode, SetMoney, MakeJoyData, SendPpos, SetOpenMenu, SetMType, SendPlayerHP, ThreadMain. Confirms the c33 register-numbering/accumulator-coloring tie-break walls hold under pragmas for those functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)