### PR TITLE
memorycard: Odekake reconstruction (cycle 10)

### DIFF
--- a/src/memorycard.cpp
+++ b/src/memorycard.cpp
@@ -379,10 +379,10 @@ void CMemoryCardMan::CalcSaveDatHpMax(Mc::SaveDat* saveDat)
  */
 unsigned int CMemoryCardMan::CalcCrc(Mc::SaveDat* saveData)
 {
-    int count;
     unsigned char* ptr;
-    int count2;
     unsigned char* ptr2;
+    int count;
+    int count2;
     unsigned int crc;
     unsigned char* crcData;
 


### PR DESCRIPTION
Group the `ptr`/`ptr2` pointer locals before the `count`/`count2` counters in `CalcCrc`'s declaration block. `CalcCrc` is auto-inlined twice into `Odekake` (after each `Rand`), and mwcc colors the inlined CRC loops with the byte cursor in the higher scratch register (r8 then r7) and the loop count in the lower (r7 then r6) — matching the target. This collapses 20 of 21 flagged lines in Odekake.

- Odekake__14CMemoryCardMan: 99.62% -> 99.97% (one residual commutative `add r5,r6,r7` operand-order artifact, not source-steerable)
- main/memorycard unit: 99.762% -> 99.782%

Trade-off: standalone `CalcCrc` (148b) drops 100->98.11 because the standalone and inlined expansions of the same body demand opposite declaration orders; the much larger inlined Odekake (1572b) dominates, so the unit nets positive. Plausible source — pointers grouped, counts grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)