### PR TITLE
materialman: SetMaterial non-GX register fixes (cycle 23)

### DIFF
--- a/src/materialman.cpp
+++ b/src/materialman.cpp
@@ -1426,7 +1426,7 @@ void CMaterialMan::SetMaterial(CMaterialSet* materialSet, int materialIndex, int
             tevColor3.g = 0;
             tevColor3.b = 0xFF;
             tevColor3.a = 0xFF;
-            GXSetTevColor(GX_TEVREG2, tevColor2);
+            GXSetTevColor(GX_TEVREG1, tevColor2);
             GXSetTevColor(static_cast<GXTevRegID>(3), tevColor3);
             GXSetTexCoordGen2(static_cast<GXTexCoordID>(m_texCoordIdCurShadow), GX_TG_MTX2x4, GX_TG_TEX0, 0x3C, GX_FALSE, 0x7D);
             _GXSetTevSwapModeTable(1, 0, 3, 3, 3);


### PR DESCRIPTION
Fixed a real constant bug in CMaterialMan::SetMaterial: the first of two consecutive GXSetTevColor calls in the tevBit&0x200 branch used GX_TEVREG2 (enum value 3) where the target uses GX_TEVREG1 (value 2). The second call already used reg 3, so the source was setting the same TEV register twice. Correcting the first to GX_TEVREG1 matches the target li r3,0x2 and is the correct behavior (sets TEVREG1 then TEVREG2).

main/materialman unit 99.63314% -> 99.63326%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)