### PR TITLE
B4: signedness-audit fixes (98.071%)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1556,7 +1556,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x48:
 			engineObject->m_stepSlopeLimit = reinterpret_cast<float*>(object->m_localBase)[1];
-			if (object->m_localBase[0] != 0) {
+			if (static_cast<int>(object->m_localBase[0]) != 0) {
 				engineObject->m_lookAtTimer = engineObject->m_stepSlopeLimit;
 			}
 			PushValue(this, object, 0);

--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -318,7 +318,7 @@ void GbaQueue::LoadAll()
 
 	spModeBits = 0;
 	for (i = 0; i < 4; i++) {
-		if (Game.m_gameWork.m_spModeFlags[i] != 0) {
+		if (static_cast<int>(Game.m_gameWork.m_spModeFlags[i]) != 0) {
 			spModeBits = static_cast<char>(spModeBits | (1 << i));
 		}
 	}


### PR DESCRIPTION
Fresh R100 signedness re-audit across all B4 sub-100 units. Scanned every sub-100% function for sign-handling opcode-REPLACE pairs (extsb/extsh/lha/cmplwi/cmpwi/srawi/srwi/cmplw/cmpw) and fixed the two that were genuine signed/unsigned source-cast bugs.

- **gbaque LoadAll**: `Game.m_gameWork.m_spModeFlags[i] != 0` compiled to four unsigned `cmplwi` (the field is `unsigned char[4]`); the target uses signed `cmpwi` on the int-promoted byte. Cast the read to `int` so mwcc emits `lbz` + `cmpwi` (no extsb), matching the original. 96.712% -> 96.739%.
- **cflat_r2class onClassSystemFunc case -0x48**: `object->m_localBase[0] != 0` compiled to unsigned `cmplwi` (`m_localBase` is `unsigned int*`); the target uses signed `cmpwi`. Cast to `int`, consistent with sibling cases -0x8C / -0x4F which already cast. 96.404% -> 96.448%.

Whole-DOL fuzzy 98.07019% -> 98.07104%; matched_code unchanged (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)