### PR TITLE
graphic: Thread drawSync-mask collapse (cycle 16, 97.967%)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -558,18 +558,8 @@ void CGraphic::Thread()
 
                 CSystem::COrder* order = System.GetOrder(drawSyncPart >> 8);
                 int drawSyncByte = static_cast<int>(static_cast<char>(drawSyncPart));
-                int orderIndex;
-                if (order != nullptr) {
-                    orderIndex = order->m_insertIndex;
-                } else {
-                    orderIndex = -1;
-                }
-                const char* orderName;
-                if (order != nullptr) {
-                    orderName = order->m_debugName;
-                } else {
-                    orderName = sGraphicUnknownOrderName;
-                }
+                int orderIndex = (order != nullptr) ? order->m_insertIndex : -1;
+                const char* orderName = (order != nullptr) ? order->m_debugName : sGraphicUnknownOrderName;
                 System.Printf(debugFmtBase + kGraphicCppDrawDoneFmt, m_drawDoneFile, m_drawDoneLine, orderName, orderIndex,
                               drawSyncByte);
             }

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -542,10 +542,9 @@ void CGraphic::Thread()
             debugCountdown--;
 
             if (debugCountdown == 0) {
-                u32 drawSyncRaw = GXReadDrawSync();
-                drawSyncRaw &= 0xFFFF;
-                int drawSyncPart = drawSyncRaw;
-                if ((drawSyncRaw & 0x8000) != 0) {
+                int drawSyncPart = GXReadDrawSync();
+                if ((drawSyncPart & 0x8000) != 0) {
+                    drawSyncPart &= 0xFFFF;
                     drawSyncPart &= 0x7FFF;
                     if (drawSyncPart == 0x7FFF) {
                         System.Printf(debugFmtBase + kGraphicCppPartControlDoneFmt, m_drawDoneFile, m_drawDoneLine);


### PR DESCRIPTION
Thread__8CGraphicFv: collapsed the two-variable drawSync mask (`drawSyncRaw`/`drawSyncPart`) into a single `int drawSyncPart`, matching the target's in-place `clrlwi r22,r3,16; ...; clrlwi r22,r22,17` masking instead of our extra `mr r22,r3` intermediate. Also rewrote the order-index/order-name null-checks as ternaries (cleaner, codegen-neutral).

Function: Thread 91.09% -> 91.75%. Unit main/graphic 97.940% -> 97.967%.

Confirmed walls (no net-positive lever found): RenderTexQuadGrouad (90.05) / RenderNoTexQuadGrouad (97.44) share the GXWGFifo base-register r3-vs-r5 post-call scratch-allocation wall (body byte-identical otherwise; pragma sweep + scheduling on/off all <= baseline). GetBackBufferRect2 (91.30) is the documented callee-saved-window off-by-one + clrlwi/clrrwi scheduling reorder. SetViewport/BeginFrame/RenderBlur residuals are the universal named-vs-anonymous sdata2 float-pool wall (kGraphicZeroF/OneF/HalfF64 -> @288/@289/@291); by-reference (LoadFloat) forcing the named symbol regressed scheduling 99.56->80.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)