### PR TITLE
mapobj: data pool re-attribution (cycle 14)

### DIFF
--- a/src/mapobj.cpp
+++ b/src/mapobj.cpp
@@ -59,6 +59,12 @@ extern const char sMapObjTooManyAttributesWarn[0x34] = {
     (char)0x82, (char)0xab, (char)0x82, (char)0xdc, (char)0x82, (char)0xb9, (char)0x82, (char)0xf1,
     (char)0x81, (char)0x42, (char)0x0a, (char)0x00,
 };
+extern const char s_CMapObjAtrPlaySta_801D71C0[] = "CMapObjAtrPlaySta";
+extern const char s_CMapObjAtr_801D71D4[] = "CMapObjAtr";
+extern const char s_CMapObjAtrMime_801D71E0[] = "CMapObjAtrMime";
+extern const char s_CMapObjAtrSpotLight_801D71F0[] = "CMapObjAtrSpotLight";
+extern const char s_CMapObjAtrPointLight_801D7204[] = "CMapObjAtrPointLight";
+extern const char s_CMapObjAtrMeshName_801D721C[] = "CMapObjAtrMeshName";
 _GXColor s_mapObjLightColor = {0xFF, 0xFF, 0xFF, 0xFF};
 
 inline void* operator new(unsigned long, void* ptr)


### PR DESCRIPTION
Defined the 6 `CMapObjAtr*` RTTI class-name strings as explicit named `extern const char[]` symbols in source order (PlaySta, Atr, Mime, SpotLight, PointLight, MeshName), placed before the `s_CPtrArray*` string defs. mwcc emits user data before compiler RTTI strings, so the named strings now occupy the target's 0x801D71C0-0x801D722F .rodata range with byte-exact content, pairing against the named `s_CMapObjAtr*_801D71xx` symbols.

Result (main/mapobj):
- matched_data 2.93% -> 37.46% (.rodata 74.6% -> 100%)
- matched_code 47.39% (unchanged), fuzzy 99.71% (unchanged)
- whole-DOL matched_data 91.686% -> 91.714%, matched_code unchanged

Remaining unit data deficit (.data vtables / .sdata RTTI structs) is a codegen wall: mwcc emits the vtable/RTTI structures in the inverse of the destructor source order, while the target uses forward (class-declaration) order. Flipping it would require reordering the out-of-line destructor definitions, which would move them off their pinned .text PAL addresses and break the 99.71% code match. Not source-steerable without regressing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)