### PR TITLE
p_map: LoadMap stage-no slot aliases g_MapHitDrawMode (reloc match)

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -180,7 +180,6 @@ inline CMapPcs::CMapPcs()
 }
 
 CMapPcs MapPcs;
-extern unsigned int s_loadedStageNo__7CMapPcs;
 extern unsigned int s_loadedMapNo__7CMapPcs;
 CRelProfile g_mapStage;
 CRelProfile g_mapSection;
@@ -288,12 +287,12 @@ void CMapPcs::createViewer()
  */
 void CMapPcs::LoadMap(int stageNo, int mapNo, void* mapPtr, unsigned long mapSize, unsigned char mode)
 {
-    unsigned int prevStageNo = s_loadedStageNo__7CMapPcs;
+    unsigned int prevStageNo = reinterpret_cast<unsigned int&>(g_MapHitDrawMode);
     unsigned int prevMapNo = s_loadedMapNo__7CMapPcs;
     Vec cameraPos;
     char mapPath[0x104];
 
-    s_loadedStageNo__7CMapPcs = stageNo;
+    reinterpret_cast<unsigned int&>(g_MapHitDrawMode) = stageNo;
     s_loadedMapNo__7CMapPcs = mapNo;
     sprintf(mapPath, s_dvd_map_stage_map_fmt, stageNo, mapNo);
 
@@ -372,7 +371,7 @@ void CMapPcs::LoadMap(int stageNo, int mapNo, void* mapPtr, unsigned long mapSiz
     }
 
     if (mode == 2) {
-        s_loadedStageNo__7CMapPcs = prevStageNo;
+        reinterpret_cast<unsigned int&>(g_MapHitDrawMode) = prevStageNo;
         s_loadedMapNo__7CMapPcs = prevMapNo;
     }
 }


### PR DESCRIPTION
## What

`CMapPcs::LoadMap` saves/restores the loaded stage number to/from the
4-byte `.sbss` slot at `0x8032ECC0`. In the target this slot is owned by
`g_MapHitDrawMode` (defined in `map.cpp`, paired with the adjacent
`s_loadedMapNo__7CMapPcs` at `0x8032ECC4`).

Our build referenced a phantom external `s_loadedStageNo__7CMapPcs`
(undefined in any TU), so the `@sda21` relocs resolved to the wrong
symbol. Aliasing the slot via `reinterpret_cast<unsigned int&>(g_MapHitDrawMode)`
makes the three loads/stores resolve to `g_MapHitDrawMode`, matching the
target.

## Result

- `LoadMap__7CMapPcsFiiPvUlUc` 99.93% -> 100% (3 flagged -> 0 flagged).
- Removes the unresolved phantom symbol `s_loadedStageNo__7CMapPcs`.
- Whole-DOL fuzzy unchanged (the 3 instructions were already
  byte-identical; only the reloc symbol-name metadata differed), no
  regression. Pure data/reloc-pairing correctness.

## Investigated but walled (no change landed)

- `__sinit_p_map_cpp` (62%): the inlined `CMapPcs::CMapPcs()` struct-copy
  of 24 `CProcessTableCallback` descriptors into `m_table`. Target
  materializes each descriptor address per-symbol (frame 0x80); ours
  pools them off a common `data.0` base (frame 0x90). `#pragma pool_data off`
  switches to per-symbol addressing but regresses to 41% (frame collapses
  to 0x60, scheduling diverges). Full pragma sweep on the constructor is
  all-neutral or negative. Compiler pooling/scheduling wall.
- `drawAfter`/`drawAfterViewer` (99.93%): `kPMapBoundMinInit`/`Max`
  named-vs-anonymous `@521`/`@522` sda2 pool reloc. Zero fuzzy cost
  (identical bytes); anti-fold pointer-deref regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)