### PR TITLE
cflat_r2system: onSystemFunc case fixes (cycle 51)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2410,7 +2410,7 @@ renderedDone:
         outResult = 0;
         break;
     case -0x27: {
-        if ((RuntimeDebugFlags(this) & CFlatRuntimeDebugFlag_ClassCollision) != 0) {
+        if ((this->m_debugFlags & CFlatRuntimeDebugFlag_ClassCollision) != 0) {
             Mtx drawMtx;
             Mtx viewMtx;
             CameraPcs.GetViewMatrix(viewMtx);
@@ -2846,7 +2846,7 @@ renderedDone:
             MenuPcs.GetMesMenu(a0)->Open(message, a1, a2, a3, a4, a5, a6);
         } else {
             if (GetNumMes__9CFlatDataFv(&System) >= 1U) {
-                System.Printf(const_cast<char*>("MesMenu no %d is null\n"), a0);
+                System.Printf(const_cast<char*>("\203\201\203b\203Z\201[\203W\203\201\203j\203\205\201[%d\202\315\202\240\202\350\202\334\202\271\202\361\201B\n"), a0);
             }
         }
         this->push(object, 0);
@@ -2858,7 +2858,7 @@ renderedDone:
             MenuPcs.GetMesMenu(*object->m_localBase)->CloseRequest(1);
         } else {
             if (GetNumMes__9CFlatDataFv(&System) >= 1U) {
-                System.Printf(const_cast<char*>("MesMenu no %d is null\n"), *object->m_localBase);
+                System.Printf(const_cast<char*>("\203\201\203b\203Z\201[\203W\203\201\203j\203\205\201[%d\202\315\202\240\202\350\202\334\202\271\202\361\201B\n"), *object->m_localBase);
             }
         }
         this->push(object, 0);
@@ -2870,7 +2870,7 @@ renderedDone:
             GetMes__9CFlatDataFi(MenuPcs.GetMesMenu(*object->m_localBase), object->m_localBase[1], object->m_localBase[2]);
         } else {
             if (GetNumMes__9CFlatDataFv(&System) >= 1U) {
-                System.Printf(const_cast<char*>("MesMenu no %d is null\n"), *object->m_localBase);
+                System.Printf(const_cast<char*>("\203\201\203b\203Z\201[\203W\203\201\203j\203\205\201[%d\202\315\202\240\202\350\202\334\202\271\202\361\201B\n"), *object->m_localBase);
             }
         }
         this->push(object, 0);
@@ -2884,7 +2884,7 @@ renderedDone:
             this->push(object, GetErrorLevel__7CSystemFv(MenuPcs.GetMesMenu(a0), a1));
         } else {
             if (GetNumMes__9CFlatDataFv(&System) >= 1U) {
-                System.Printf(const_cast<char*>("MesMenu no %d is null\n"), a0);
+                System.Printf(const_cast<char*>("\203\201\203b\203Z\201[\203W\203\201\203j\203\205\201[%d\202\315\202\240\202\350\202\334\202\271\202\361\201B\n"), a0);
             }
             this->push(object, 0);
         }
@@ -2905,7 +2905,7 @@ renderedDone:
     case -0x4D: {
         if (MenuPcs.GetMesMenu(*object->m_localBase) == 0) {
             if (GetNumMes__9CFlatDataFv(&System) >= 1U) {
-                System.Printf(const_cast<char*>("MesMenu no %d is null\n"), *object->m_localBase);
+                System.Printf(const_cast<char*>("\203\201\203b\203Z\201[\203W\203\201\203j\203\205\201[%d\202\315\202\240\202\350\202\334\202\271\202\361\201B\n"), *object->m_localBase);
             }
             this->push(object, 0);
             outResult = 0;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3905,7 +3905,7 @@ renderedDone:
         break;
     case -0xDC: {
         CRomLetterWork* letters = reinterpret_cast<CRomLetterWork*>(Game.m_romLetterWorkBase);
-        this->push(object, letters[*object->m_localBase].Word(object->m_localBase[1]));
+        this->push(object, reinterpret_cast<const unsigned short*>(&letters[*object->m_localBase])[object->m_localBase[1]]);
         outResult = 0;
         break;
     }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3273,7 +3273,7 @@ renderedDone:
         break;
     }
     case -0x82:
-        CFlatLetterEventEnabled() = static_cast<unsigned int>(*object->m_localBase);
+        this->m_letterEventEnabled = static_cast<unsigned int>(*object->m_localBase);
         this->push(object, 0);
         outResult = 0;
         break;
@@ -3779,7 +3779,7 @@ renderedDone:
         outResult = 0;
         break;
     case -0xCD:
-        gCFlatRuntime().ClearParmanent();
+        reinterpret_cast<CFlatRuntime&>(CFlat).ClearParmanent();
         this->push(object, 0);
         outResult = 0;
         break;


### PR DESCRIPTION
Four genuine per-case fixes in the giant onSystemFunc dispatch, raising the unit fuzzy match 94.92% -> 95.15% and the function 92.99% -> 93.32% (no whole-DOL regression: code 43.4395%, data 91.714325% unchanged).

- Case -0x27: replace RuntimeDebugFlags(this) linkage helper with direct this->m_debugFlags access -> mwcc inlines to lwz 0x129c(this) instead of bl RuntimeDebugFlags__FP13CFlatRuntime2.
- Case -0x82: write this->m_letterEventEnabled directly instead of via CFlatLetterEventEnabled() -> removes bl CFlatLetterEventEnabled__Fv.
- Case -0xCD: reinterpret_cast<CFlatRuntime&>(CFlat).ClearParmanent() -> mwcc inlines &CFlat instead of bl gCFlatRuntime__Fv.
- Case -0xDC: inline CRomLetterWork::Word() as a ushort[] index -> lhzx instead of bl Word__14CRomLetterWorkCFi.
- Restored the Japanese MesMenu-null printf string (was an English placeholder).

Remaining residual is the documented structural wall: target dedicates r28 to the function's string-literal pool base (held across the whole function, driven by the live gbaPath="dvd/gba/" local), which bumps outResult& from r28->r29 and cascades through the +8-byte frame-size difference (0x344 vs 0x33c) and the two-level switch dispatch. The two-level switch did not unlock, so the latent splits.txt data pairing fix does not apply. The li 0x2/and vs rlwinm idiom in case -0xE3 and the int->double bias-conversion divergence are backend-canonicalization / register-band, not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)