### PR TITLE
RedExecute: genuine structural fixes (cycle 9)

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -2149,7 +2149,6 @@ static void _KeyOnControl()
     RedTrackDATA* track;
     RedVoiceDATA* voice;
     int volume;
-    int muteTrackNo;
     u32 bit;
 
     _VoiceEnvelopeCheck();
@@ -2229,8 +2228,7 @@ static void _KeyOnControl()
                     soundControl = RedSoundControlGet(REDSOUND_CONTROL_MUSIC_PRIMARY);
                     if (!(voice->m_track < soundControl->m_tracks) &&
                         (voice->m_track < RedSoundControlGetTrackEnd(soundControl))) {
-                        muteTrackNo = voice->m_track->m_trackNo;
-                        if ((RedMuteGetMask(muteTrackNo) & RedMuteGetWord(muteTrackNo)) == 0) {
+                        if ((RedMuteGetMask(voice->m_track->m_trackNo) & RedMuteGetWord(voice->m_track->m_trackNo)) == 0) {
                             volume = ((soundControl->m_volumeScale + 1) *
                                       (soundControl->m_volume >> REDSOUND_FIXED_SHIFT)) >>
                                      REDSOUND_CONTROL_VOLUME_SCALE_SHIFT;
@@ -2247,9 +2245,7 @@ static void _KeyOnControl()
                             &soundControl[REDSOUND_CONTROL_MUSIC_SECONDARY];
                         if (!(voice->m_track < secondaryControl->m_tracks) &&
                             (voice->m_track < RedSoundControlGetTrackEnd(secondaryControl))) {
-                            muteTrackNo = voice->m_track->m_trackNo;
-
-                            if ((RedMuteGetMask(muteTrackNo) & RedMuteGetWord(muteTrackNo)) == 0) {
+                            if ((RedMuteGetMask(voice->m_track->m_trackNo) & RedMuteGetWord(voice->m_track->m_trackNo)) == 0) {
                                 volume = ((secondaryControl->m_volumeScale + 1) *
                                           (secondaryControl->m_volume >> REDSOUND_FIXED_SHIFT)) >>
                                          REDSOUND_CONTROL_VOLUME_SCALE_SHIFT;


### PR DESCRIPTION
## _KeyOnControl (93.72% -> 94.83% fn, unit 98.10% -> 98.18%)
The mute check expanded `RedMuteGetMask(muteTrackNo) & RedMuteGetWord(muteTrackNo)`
from a cached local `muteTrackNo = voice->m_track->m_trackNo`. The target instead
re-reads `voice->m_track->m_trackNo` for each macro expansion, so the cache forced
an extra callee-saved register and inflated the frame from 0x30 to 0x40 (`stmw r20`
vs `stmw r26`). Inlining the member access at both call sites (and dropping the now
unused local) drops the cache and recovers a callee-saved register.

DOL fuzzy up, no RedSound sibling regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)