### PR TITLE
cflat_runtime: objectFrame inline-mismatch fixes (cycle 8)

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -936,11 +936,12 @@ int CFlatRuntime::objectFrame(CFlatRuntime::CObject* object)
 			unsigned int* sp = object->m_sp;
 			unsigned int* top = --object->m_sp;
 			const u32 systemValue = sp[-2];
+			const int valIndex = static_cast<int>(systemValue) >> 13;
 			if (((systemValue >> 12) & 1) != 0) {
 				CObject* target = reinterpret_cast<CObject*>(intToClass(systemValue & 0xFFF));
-				onSetClassSystemVal(static_cast<int>(systemValue) >> 13, target, reinterpret_cast<CStack*>(top), 0);
+				onSetClassSystemVal(valIndex, target, reinterpret_cast<CStack*>(top), 0);
 			} else {
-				onSetSystemVal(static_cast<int>(systemValue) >> 13, reinterpret_cast<CStack*>(top), 0);
+				onSetSystemVal(valIndex, reinterpret_cast<CStack*>(top), 0);
 			}
 			break;
 		}
@@ -949,11 +950,12 @@ int CFlatRuntime::objectFrame(CFlatRuntime::CObject* object)
 			unsigned int* sp = object->m_sp;
 			unsigned int* top = --object->m_sp;
 			const u32 systemValue = sp[-2];
+			const int valIndex = static_cast<int>(systemValue) >> 13;
 			if (((systemValue >> 12) & 1) != 0) {
 				CObject* target = reinterpret_cast<CObject*>(intToClass(systemValue & 0xFFF));
-				onSetClassSystemVal(static_cast<int>(systemValue) >> 13, target, reinterpret_cast<CStack*>(top), 1);
+				onSetClassSystemVal(valIndex, target, reinterpret_cast<CStack*>(top), 1);
 			} else {
-				onSetSystemVal(static_cast<int>(systemValue) >> 13, reinterpret_cast<CStack*>(top), 1);
+				onSetSystemVal(valIndex, reinterpret_cast<CStack*>(top), 1);
 			}
 			break;
 		}
@@ -962,11 +964,12 @@ int CFlatRuntime::objectFrame(CFlatRuntime::CObject* object)
 			unsigned int* sp = object->m_sp;
 			unsigned int* top = --object->m_sp;
 			const u32 systemValue = sp[-2];
+			const int valIndex = static_cast<int>(systemValue) >> 13;
 			if (((systemValue >> 12) & 1) != 0) {
 				CObject* target = reinterpret_cast<CObject*>(intToClass(systemValue & 0xFFF));
-				onSetClassSystemVal(static_cast<int>(systemValue) >> 13, target, reinterpret_cast<CStack*>(top), -1);
+				onSetClassSystemVal(valIndex, target, reinterpret_cast<CStack*>(top), -1);
 			} else {
-				onSetSystemVal(static_cast<int>(systemValue) >> 13, reinterpret_cast<CStack*>(top), -1);
+				onSetSystemVal(valIndex, reinterpret_cast<CStack*>(top), -1);
 			}
 			break;
 		}


### PR DESCRIPTION
Hoisted `static_cast<int>(systemValue) >> 13` into a single `valIndex` local before the class-vs-system branch in the three set-system-value bytecode cases (0x13/0x16, 0x14/0x17, 0x15/0x18) of `objectFrame`. The target computes this shift once into a callee-saved register (r26) and reuses it across both the `intToClass` and `onSet*SystemVal` calls; our source recomputed it as two separate sub-expressions in each branch, emitting a late `srawi` after the call.

objectFrame fn 95.50% -> 95.93%, cflat_runtime unit 97.09% -> 97.24%, DOL 98.08982% -> 98.09113% (no collateral regression on cflat_runtime2/r2system/r2class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)