### PR TITLE
cflat_runtime2: Calc/CcClass2D structural fixes (cycle 8)

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1376,8 +1376,8 @@ void CFlatRuntime2::Calc()
 		saveData[3] = header[3];
 		saveData[4] = header[4];
 		saveData[5] = header[5];
-		saveData[6] = header[6];
-		saveData[7] = header[7];
+		reinterpret_cast<float*>(saveData)[6] = reinterpret_cast<float*>(header)[6];
+		reinterpret_cast<float*>(saveData)[7] = reinterpret_cast<float*>(header)[7];
 
 		u32 record[7];
 
@@ -1403,9 +1403,9 @@ void CFlatRuntime2::Calc()
 			objectData[1] = record[1];
 			objectData[2] = record[2];
 			objectData[3] = record[3];
-			objectData[4] = record[4];
-			objectData[5] = record[5];
-			objectData[6] = record[6];
+			reinterpret_cast<float*>(objectData)[4] = reinterpret_cast<float*>(record)[4];
+			reinterpret_cast<float*>(objectData)[5] = reinterpret_cast<float*>(record)[5];
+			reinterpret_cast<float*>(objectData)[6] = reinterpret_cast<float*>(record)[6];
 			objectData += 7;
 		}
 

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1721,11 +1721,7 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float angle,
 
 								*reinterpret_cast<float*>(&object->m_0x44) = distance;
 								objects[insertIndex] = object;
-								if (count + 1 < maxCount) {
-									count = count + 1;
-								} else {
-									count = maxCount;
-								}
+								count = (count + 1 < maxCount) ? (count + 1) : maxCount;
 							}
 						}
 					}

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1704,7 +1704,7 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float angle,
 								objects[count] = object;
 								count = count + 1;
 								if (count == maxCount) {
-									return count;
+									goto done;
 								}
 							} else {
 								int insertIndex = 0;
@@ -1734,6 +1734,7 @@ int CFlatRuntime2::CcClass2D(int flags, int classMask, Vec* center, float angle,
 			&CFlat, reinterpret_cast<CFlatRuntime::CObject*>(object)->m_next, 5));
 	}
 
+done:
 	return count;
 }
 

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1414,9 +1414,9 @@ void CFlatRuntime2::Calc()
 		objectData[1] = record[1];
 		objectData[2] = record[2];
 		objectData[3] = record[3];
-		objectData[4] = record[4];
-		objectData[5] = record[5];
-		objectData[6] = record[6];
+		reinterpret_cast<float*>(objectData)[4] = reinterpret_cast<float*>(record)[4];
+		reinterpret_cast<float*>(objectData)[5] = reinterpret_cast<float*>(record)[5];
+		reinterpret_cast<float*>(objectData)[6] = reinterpret_cast<float*>(record)[6];
 		delete[] saveData;
 	}
 

--- a/tools/asm_match.py
+++ b/tools/asm_match.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""asm_match.py - decomp matching helper for FFCC-Decomp.
+
+Usage:
+  # list every code symbol in a unit with its match %, worst first
+  python3 /private/tmp/asm_match.py <worktree_dir> <unit>
+
+  # show an index-aligned TARGET(original) vs OURS(current build) asm diff for one
+  # function, with only mismatching regions printed (plus context). <sym> is a
+  # substring match against the (possibly mangled) symbol name.
+  python3 /private/tmp/asm_match.py <worktree_dir> <unit> <sym> [context]
+
+Notes:
+  - TARGET = the original/goal object (does NOT change when you edit source).
+  - OURS   = compiled from current source (this is what your edits move).
+  - Lines flagged ">>" carry a diff_kind (a real, counted mismatch). Branch-offset
+    differences without a diff_kind are just layout and are NOT penalized.
+  - DIFF_ARG_MISMATCH = identical opcode, different operand (usually register
+    allocation / a wrong local lifetime / wrong type). These ARE source-fixable.
+  - <none> on one side = an insert/delete (instruction count diverged).
+Run objdiff-cli first via this tool; it shells out to build/tools/objdiff-cli.
+"""
+import json, subprocess, sys, os
+
+def get_diff(wt, unit, sym=None):
+    cmd = [os.path.join(wt, "build/tools/objdiff-cli"), "diff",
+           "-p", ".", "-u", unit, "-o", "-"]
+    if sym:
+        cmd.append(sym)
+    r = subprocess.run(cmd, cwd=wt, capture_output=True, text=True)
+    if r.returncode != 0 and not r.stdout:
+        sys.exit(f"objdiff-cli failed:\n{r.stderr}")
+    return json.loads(r.stdout)
+
+def code_syms(side):
+    return {s["name"]: s for s in side["symbols"] if s.get("instructions")}
+
+def fmt(ins):
+    if not ins:
+        return "<none>"
+    i = ins.get("instruction")
+    if not i:
+        return "<none>"
+    return i.get("formatted", "<none>")
+
+def list_funcs(d):
+    L = code_syms(d["left"]); R = code_syms(d["right"])
+    names = set(L) | set(R)
+    rows = []
+    for n in names:
+        # match % lives on the section symbol entries; pull from whichever side has it
+        mp = None
+        for side in (d["left"], d["right"]):
+            for s in side["symbols"]:
+                if s["name"] == n and s.get("match_percent") is not None:
+                    mp = s["match_percent"]; break
+            if mp is not None: break
+        sz = (L.get(n) or R.get(n) or {}).get("size", "?")
+        rows.append((mp if mp is not None else -1.0, sz, n))
+    rows.sort(key=lambda x: x[0])
+    print(f"{'match%':>7}  {'size':>6}  symbol")
+    for mp, sz, n in rows:
+        print(f"{mp:7.2f}  {str(sz):>6}  {n}")
+
+def show_diff(d, sym, ctx):
+    L = code_syms(d["left"]); R = code_syms(d["right"])
+    cand = [n for n in (set(L) | set(R)) if sym in n]
+    if not cand:
+        sys.exit(f"no symbol matching {sym!r}. Run without <sym> to list symbols.")
+    name = sym if sym in cand else (max(cand, key=len) if len(cand) > 1 else cand[0])
+    l = L.get(name, {}).get("instructions", [])
+    r = R.get(name, {}).get("instructions", [])
+    n = max(len(l), len(r))
+    def diffkind(a, b):
+        return (a or {}).get("diff_kind") or (b or {}).get("diff_kind")
+    flagged = []
+    for i in range(n):
+        a = l[i] if i < len(l) else None
+        b = r[i] if i < len(r) else None
+        # Only diff_kind lines are real, scored mismatches. Pure branch-target
+        # offset differences (no diff_kind) are layout and objdiff ignores them.
+        if diffkind(a, b) is None and a is not None and b is not None:
+            continue
+        flagged.append(i)
+    keep = set()
+    for i in flagged:
+        for j in range(i - ctx, i + ctx + 1):
+            if 0 <= j < n: keep.add(j)
+    print(f"# {name}")
+    print(f"# TARGET(original) | OURS(current)   flagged lines = {len(flagged)} of {n}")
+    last = -2
+    for i in range(n):
+        if i not in keep:
+            continue
+        if i != last + 1:
+            print("        ...")
+        a = l[i] if i < len(l) else None
+        b = r[i] if i < len(r) else None
+        dk = (a or {}).get("diff_kind") or (b or {}).get("diff_kind")
+        is_flag = dk is not None or a is None or b is None
+        mark = ">>" if is_flag else "  "
+        tag = f" [{dk}]" if dk else (" [INS/DEL]" if (a is None or b is None) else "")
+        print(f"{mark}{i:5} {fmt(a):34} | {fmt(b):34}{tag}")
+        last = i
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__); sys.exit(1)
+    wt, unit = sys.argv[1], sys.argv[2]
+    sym = sys.argv[3] if len(sys.argv) > 3 else None
+    ctx = int(sys.argv[4]) if len(sys.argv) > 4 else 3
+    d = get_diff(wt, unit, sym)
+    if sym:
+        show_diff(d, sym, ctx)
+    else:
+        list_funcs(d)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Genuine structural fixes found via inline-mismatch + structural-shape hunt (not register-window).

## Calc (93.16% -> 98.25%)
The save-scene serialization stored `saveData[6,7]` (camera fov/zRotate) and `objectData[4,5,6]` (object rotBaseY/unk/radius) via integer word copies through the `header[]`/`record[]` stack arrays. The target keeps the last few `SwapToF32` float results live in FPRs and stores them directly with `stfs`. Rewrote those copies as `reinterpret_cast<float*>` float copies (matching the idiom already used for the SwapToF32 assignments), in both the per-object loop and the FFFFFFFF terminator record.

## CcClass2D (98.61% -> 99.92%)
- Insertion-sort count update `if (count+1<maxCount) count=count+1; else count=maxCount;` rewritten as the ternary select `count = (count+1<maxCount) ? (count+1) : maxCount;` — matches the target's single `addi r0,count,1` + `bge`/`mr` select instead of recomputing count+1.
- `flags & 4` early exit (`count == maxCount`) routed through a shared `done:` epilogue via `goto` instead of a separate `return count` block, matching the target's branch polarity and deferred `mr r3,count`.

## Walled (register-allocation priority, not source-steerable)
- Calc: the layer-loop `this`-cursor vs File-base window (r28<->r29), the objectData-cursor vs loop-sentinel window, and Pad-index/header-copy scratch swaps. Tried folding the 0x1770 base offset (regressed 98.25->97.37).
- drawLayer (95.72%) and Draw (98.87%): uniform callee-saved argument-band / font-pointer window shifts. The Draw worldUp anchoring (target reads `up` via the `sCFlatRuntime2ForwardVec` symbol) is a non-scored pool-name reloc; repurposing the const regressed data%.

Unit main/cflat_runtime2 98.683% -> 99.104%. No sibling cflat unit regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)