### PR TITLE
cflat_runtime: dispatch fn fixes (cycle 9)

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -340,7 +340,9 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 		}
 		case -3: {
 			CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
-			if ((static_cast<u32>(__cntlzw(static_cast<u32>(reinterpret_cast<u8*>(engineObject) - reinterpret_cast<u8*>(object)))) >> 5) == 0) {
+			if ((static_cast<u32>(__cntlzw(static_cast<u32>(reinterpret_cast<u8*>(engineObject) - reinterpret_cast<u8*>(object)))) >> 5) != 0) {
+				object->m_flagBits.m_deleteFlag = 1;
+			} else {
 				engineObject->m_previous->m_next = engineObject->m_next;
 				engineObject->m_next->m_previous = engineObject->m_previous;
 
@@ -353,8 +355,6 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 				engineObject->m_flagBits.m_constructFlag = 0;
 
 				onDeleteObject(engineObject);
-			} else {
-				object->m_flagBits.m_deleteFlag = 1;
 			}
 
 			*object->m_sp = 0;


### PR DESCRIPTION
systemFunc case -3: invert the `cntlzw>>5` if/else so the `m_deleteFlag=1` arm leads (falls through) and the free-list-removal block is branched-to, matching the target's `beq`-to-free-list block layout (was `bne`-over-else). cflat_runtime 97.2438% -> 97.4468%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)