### PR TITLE
pppKeShpTail/ScreenBreak: structural fixes (cycle 1)

### DIFF
--- a/src/pppKeShpTail3X.cpp
+++ b/src/pppKeShpTail3X.cpp
@@ -265,12 +265,12 @@ void pppKeShpTail3XDraw(struct pppKeShpTail3X* obj, struct pppKeShpTail3XStep* s
     nextBaseY = history[nextIndex].y;
     segDz = nextBaseZ - posZ;
     segDy = nextBaseY - posY;
-    initialSeg.x = segDx;
-    initialSeg.y = segDy;
-    initialSeg.z = segDz;
     zeroVecA.z = kPppKeShpTail3XZero;
     zeroVecA.y = kPppKeShpTail3XZero;
     zeroVecA.x = kPppKeShpTail3XZero;
+    initialSeg.x = segDx;
+    initialSeg.y = segDy;
+    initialSeg.z = segDz;
     segLen = PSVECDistance(&zeroVecA, &initialSeg);
     segRemain = segLen;
     life = work->m_shapeData;


### PR DESCRIPTION
pppKeShpTail3XDraw: reorder zeroVecA stores before initialSeg stores to match target's store-emission order in the initial-segment setup block. Unit 99.18795% -> 99.21493% (flag count 183 -> 178).

pppKeShpTail2XDraw and pppScreenBreak InitPieceData examined and confirmed walled (FP/GPR callee-saved-band permutation + int-to-float bias-FPR liveness; all source-level hoists/reorders/type-changes regressed or were bit-identical).

DOL 98.11261% -> 98.11268%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)