### PR TITLE
cflat_r2class: onClassSystemFunc round 2 (cycle 52)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1586,9 +1586,10 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x52: {
+			CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(engineObject->m_scriptHandle);
 			unsigned int result = 0;
 			if ((object->m_localBase[0] & 2) != 0) {
-				result = reinterpret_cast<CCaravanWork*>(engineObject->m_scriptHandle)->FindItem(static_cast<int>(object->m_localBase[1])) >= 0 ? 2 : 0;
+				result = caravanWork->FindItem(static_cast<int>(object->m_localBase[1])) >= 0 ? 2 : 0;
 			}
 			PushValue(this, object, static_cast<int>(result));
 			outResult = 0;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1926,8 +1926,10 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x87: {
 			CChara::CModel* model = engineObject->m_charaModelHandle->m_model;
-			model->m_furLenScale = reinterpret_cast<float*>(object->m_localBase)[0];
-			model->m_furStep = reinterpret_cast<float*>(object->m_localBase)[1];
+			float furLenScale = reinterpret_cast<float*>(object->m_localBase)[0];
+			float furStep = reinterpret_cast<float*>(object->m_localBase)[1];
+			model->m_furLenScale = furLenScale;
+			model->m_furStep = furStep;
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1913,8 +1913,8 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			        static_cast<int>(object->m_localBase[2]),
 			        static_cast<int>(object->m_localBase[3]),
 			        static_cast<int>(object->m_localBase[4]),
-			        0,
-			        static_cast<int>(static_cast<signed char>(object->m_localBase[5]))));
+			        static_cast<int>(object->m_localBase[5]),
+			        static_cast<int>(object->m_localBase[6])));
 			outResult = 0;
 			break;
 		case -0x86: {


### PR DESCRIPTION
Deep per-case round 2 on onClassSystemFunc (~150-case bytecode interpreter switch).

Cases fixed:
- **case -0x52** (FindItem): hoist `engineObject->m_scriptHandle` into a `caravanWork` local before the `&2` test — target evaluates the scriptHandle pointer before the condition (value-liveness/hoist).
- **case -0x87** (fur params): read both `localBase[0]/[1]` floats into locals before storing to `model->m_furLenScale`/`m_furStep` — target reads both source floats then writes both (removes interleaved load/store + extra base reload).
- **case -0x85** (ShopRequest): LATENT BUG — source passed `localBase[4], 0, (signed char)localBase[5]` for args 5-7; target/asm loads 7 raw ints `localBase[0..6]`. Fixed to pass `localBase[5]` and `localBase[6]` as plain ints (dropped the spurious `0` literal and signed-char cast).

Results:
- onClassSystemFunc 96.54% -> 96.97%
- main/cflat_r2class unit 97.43% -> 97.70%
- whole-DOL 98.11309% -> 98.11459% (no regression)

Residual is dominated by the uniform stack-frame-offset cascade (frame-size walled), callee-saved register-window permutations (r26/r27, allocation-priority), the walled __opP3Vec operator-on-temp bl, the indexed-store add+sth-vs-addi+sthx form, and the -0x5F pppIsDeadCHandle tail-merge — all per the cycle-52 wall list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)