### PR TITLE
cflat_r2system: onSystemFunc round 3 (cycle 53)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2297,8 +2297,9 @@ renderedDone:
         float bestDistance = kLineBoundsInitMin;
         float bestLineDistance = 0.0f;
 
+        CLine<64>* lines = m_debugLines;
         for (unsigned int i = 0; i < 0x10; i++) {
-            CLine<64>& line = m_debugLines[i];
+            CLine<64>& line = lines[i];
             if (line.pointCount == 0 || (line.m_mask & mask) == 0 || line.IsInner(&target, margin) == 0) {
                 continue;
             }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2004,10 +2004,10 @@ renderedDone:
         outResult = 0;
         break;
     case -0xFD: {
-        const double stickX = Pad.GetLeftStickX(*object->m_localBase);
-        const double stickY = Pad.GetLeftStickY(*object->m_localBase);
-        *reinterpret_cast<float*>(object->m_localBase[1]) = static_cast<float>(stickX);
-        *reinterpret_cast<float*>(object->m_localBase[2]) = static_cast<float>(stickY);
+        const float stickX = Pad.GetLeftStickX(*object->m_localBase);
+        const float stickY = Pad.GetLeftStickY(*object->m_localBase);
+        *reinterpret_cast<float*>(object->m_localBase[1]) = stickX;
+        *reinterpret_cast<float*>(object->m_localBase[2]) = stickY;
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3077,7 +3077,7 @@ renderedDone:
         const int x = static_cast<int>(object->m_localBase[1]);
         const int group = (~(x - 1 | 1 - x) >> 31) & 3;
         Memory.SetDefaultGroup(group);
-        CharaPcs.LoadMergeFile(*object->m_localBase, object->m_localBase[1], 0);
+        CharaPcs.LoadMergeFile(*object->m_localBase, x, 0);
         Memory.ResetDefaultGroup();
         this->push(object, 0);
         outResult = 0;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2669,7 +2669,7 @@ renderedDone:
         outResult = 0;
         break;
     case -0x36:
-        this->EndParticleSlot(*object->m_localBase, object->m_localBase[1]);
+        this->EndParticleSlot(*object->m_localBase, 0);
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2716,12 +2716,12 @@ renderedDone:
         break;
     case -0x94: {
         float* bounds = reinterpret_cast<float*>(object->m_localBase);
-        ppvEnv->m_boxMinX = bounds[0];
-        ppvEnv->m_boxMaxX = bounds[1];
-        ppvEnv->m_boxMinY = bounds[2];
-        ppvEnv->m_boxMaxY = bounds[3];
-        ppvEnv->m_boxMinZ = bounds[4];
-        ppvEnv->m_boxMaxZ = bounds[5];
+        PartMng.m_pppEnvSt.m_boxMinX = bounds[0];
+        PartMng.m_pppEnvSt.m_boxMaxX = bounds[1];
+        PartMng.m_pppEnvSt.m_boxMinY = bounds[2];
+        PartMng.m_pppEnvSt.m_boxMaxY = bounds[3];
+        PartMng.m_pppEnvSt.m_boxMinZ = bounds[4];
+        PartMng.m_pppEnvSt.m_boxMaxZ = bounds[5];
         this->push(object, 0);
         outResult = 0;
         break;


### PR DESCRIPTION
Round 3 per-case sweep of onSystemFunc. Five genuine per-case fixes; unit
main/cflat_r2system 95.54% -> 95.83%, onSystemFunc 94.23% -> 94.61%,
whole-DOL 98.11261% -> 98.11742% (net positive).

- **case -0x22**: cache `m_debugLines` array base into a `CLine<64>*` before
  the line-search loop so the `this+0x1bdc` base is hoisted into a callee-saved
  register (target `addi r22,r30,0x1bdc`) with small in-loop displacements.
- **case -0x94**: write the box bounds through `PartMng.m_pppEnvSt` directly
  (ppvEnv aliases `&PartMng.m_pppEnvSt`) so the PartMng base materializes once
  with big field displacements, dropping the per-store `lwz ppvEnv` reloads.
- **case -0x61**: reuse the already-loaded `x` (= m_localBase[1], live in a
  callee-saved reg across SetDefaultGroup) as LoadMergeFile's second arg.
- **case -0xFD**: declare the GetLeftStickX/Y results as `float` not `double`,
  removing redundant `frsp` rounds before each stfs.
- **case -0x36**: EndParticleSlot's second arg is literal `0`, not
  m_localBase[1] (confirmed by the Ghidra ref of this function).

Residual is dominated by the documented two-level-switch register-window /
frame-size (0x33c vs 0x344) / push-result (r28 vs r29) clustering wall, which
is not source-steerable. Function is near its source-reachable ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)