### PR TITLE
cflat_r2system: onSystemFunc round 4 arg-audit (cycle 54)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2426,7 +2426,7 @@ renderedDone:
             _GXSetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
             _GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
             GXSetNumChans(1);
-            GXSetChanCtrl(GX_COLOR0A0, GX_FALSE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_SPOT);
+            GXSetChanCtrl(GX_COLOR0, GX_FALSE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_SPOT);
             GXSetChanCtrl(GX_ALPHA0, GX_FALSE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_NONE);
             GXClearVtxDesc();
             GXSetVtxDesc(GX_VA_POS, GX_DIRECT);


### PR DESCRIPTION
Round 4 GHIDRA-ARG-AUDIT pass on onSystemFunc.

## Fixed
- **case -0x27 GXSetChanCtrl chan**: first `GXSetChanCtrl` passed `GX_COLOR0A0` (enum 4) where the target loads `li r3,0x0` = `GX_COLOR0`. Genuine GX enum bug — the channel for the color stage should be GX_COLOR0, not the combined GX_COLOR0A0. The second call (GX_ALPHA0, enum 2) already matched. Confirmed via GXChannelID enum (GX_COLOR0=0, GX_ALPHA0=2, GX_COLOR0A0=4) and the target immediate.

cflat_r2system unit 95.82563% -> 95.82576%, onSystemFunc ~94.61% (byte alignment dominated by the systemic callee-saved window shift, but the corrected immediate now matches). DOL 98.12089%, no regression.

## Ceiling assessment
The residual is dominated by two non-source-steerable walls already cataloged: the function-wide r29-vs-r28 callee-saved register-window shift (every `stw r0,0x0(r29)` push-result store, 30+ sites) and the 0x344-vs-0x33c stack-frame-offset family, plus the string-pool-base CSE (target holds a single string-table base `lbl_801DA3B0` in r28 and addresses every Printf format string as `r28+off`; ours rematerializes `@stringBase0@ha/@l` per call — the dominant late-function diff). The `1 << *m_localBase` button-bit shift, the abs idiom (case -0x13), and case -0x1A bit-extraction/divide-ordering are all pure register-numbering or already-walled. No further genuine arg/literal/offset/signedness bugs found after a full immediate census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)