### PR TITLE
p_camera: data pairing fix (cycle 1)

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -217,7 +217,7 @@ p_camera.cpp:
 	extabindex  start:0x8000BE18 end:0x8000BF08
 	.text       start:0x80036290 end:0x8003A5FC
 	.ctors      start:0x801D53E0 end:0x801D53E4
-	.rodata     start:0x801D7860 end:0x801D78F4
+	.rodata     start:0x801D7860 end:0x801D7968
 	.data       start:0x801E9030 end:0x801E9B24
 	.bss        start:0x80268790 end:0x80268C6C
 	.sdata      start:0x8032E520 end:0x8032E538

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -82,8 +82,6 @@ extern const float kCameraDebugZoomStep;
 extern const float kCameraNegativeTenF;
 extern const float kCameraFiftyF;
 extern const float kCameraMinFov;
-extern const char s_p_camera_cpp[];
-extern const char sCameraInvalidFovFmt[0x40];
 unsigned char g_IsDbgDrawShadowPos;
 
 inline void* operator new(unsigned long, void* ptr)
@@ -1185,13 +1183,13 @@ void CCameraPcs::createFullShadow()
     CMapMng* map;
     char* fileName;
 
-    fileName = const_cast<char*>(s_p_camera_cpp);
+    fileName = const_cast<char*>(__FILE__);
     map = &MapMng;
     m_fullScreenShadow.m_shadowTexture = 0;
     m_fullScreenShadow.m_shadowTexture =
         new (map->m_stage, fileName, 0x3A5)
             u8[GXGetTexBufferSize(0x1E0, 0x1E0, GX_TF_I8, GX_FALSE, 0)];
-    fileName = const_cast<char*>(s_p_camera_cpp);
+    fileName = const_cast<char*>(__FILE__);
     map = &MapMng;
     m_fullScreenShadow.m_rampTexture = 0;
     rampTex = new (map->m_stage, fileName, 0x361)
@@ -1748,7 +1746,7 @@ void CCameraPcs::SetStdProjectionMatrix()
 
     if (fov < kCameraMinFov) {
         if (static_cast<unsigned int>(System.m_execParam) >= 1) {
-            System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
+            System.Printf("!!!!!!!!!!!!!!!!!!FOV\202\314\222l\202\252\210\331\217\355\202\305\202\267\201B%f!!!!!!!!!!!!!!!!!!!!\012", fov);
         }
         fov = kCameraDefaultFov;
     }
@@ -1843,7 +1841,7 @@ void CCameraPcs::calc()
     float fov = m_fov;
     if (fov < kCameraMinFov) {
         if (static_cast<unsigned int>(System.m_execParam) >= 1) {
-            System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
+            System.Printf("!!!!!!!!!!!!!!!!!!FOV\202\314\222l\202\252\210\331\217\355\202\305\202\267\201B%f!!!!!!!!!!!!!!!!!!!!\012", fov);
         }
         fov = kCameraDefaultFov;
     }


### PR DESCRIPTION
Root cause: the p_camera `.rodata` split was cut short at 0x801D78F4, orphaning the unit's own RTTI class-name strings (`CCameraPcs`/`CManager`/`CProcess`), the `__FILE__` string, and the FOV-error format string into an auto-generated raw-byte split. Our build separately re-emitted the RTTI class-name strings inside p_camera.o, overflowing the 148-byte .rodata range to 181 bytes and leaving the RTTI struct name-pointer relocations unpaired (.sdata 72.2%).

Fix:
- Extend the p_camera `.rodata` split end to 0x801D7968 so the unit claims its full string pool (the auto split is then absorbed).
- Emit the filename (`__FILE__`) and FOV format string as inline anonymous literals at their use sites, so mwcc pools them in first-use order AFTER the compiler-generated RTTI class-name strings, reproducing the target layout: [7 table strings][RTTI x3][`__FILE__`][fovfmt].

Result:
- `.sdata` 72.2% -> 100% (RTTI name-pointer relocs now pair correctly)
- `.rodata` 89.6% -> 98.85% (residual 6 bytes = pooled-literal vs `char[0x40]`-array 4-byte alignment of the format string; not source-steerable without breaking pool emission order)
- Whole-DOL matched_data 91.7143% -> 91.7159% (net positive, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)