### PR TITLE
Revert #17566 (p_camera rodata claim regressed DOL matched_code)

### DIFF
--- a/config/GCCP01/splits.txt
+++ b/config/GCCP01/splits.txt
@@ -217,7 +217,7 @@ p_camera.cpp:
 	extabindex  start:0x8000BE18 end:0x8000BF08
 	.text       start:0x80036290 end:0x8003A5FC
 	.ctors      start:0x801D53E0 end:0x801D53E4
-	.rodata     start:0x801D7860 end:0x801D7968
+	.rodata     start:0x801D7860 end:0x801D78F4
 	.data       start:0x801E9030 end:0x801E9B24
 	.bss        start:0x80268790 end:0x80268C6C
 	.sdata      start:0x8032E520 end:0x8032E538

--- a/src/p_camera.cpp
+++ b/src/p_camera.cpp
@@ -82,6 +82,8 @@ extern const float kCameraDebugZoomStep;
 extern const float kCameraNegativeTenF;
 extern const float kCameraFiftyF;
 extern const float kCameraMinFov;
+extern const char s_p_camera_cpp[];
+extern const char sCameraInvalidFovFmt[0x40];
 unsigned char g_IsDbgDrawShadowPos;
 
 inline void* operator new(unsigned long, void* ptr)
@@ -1183,13 +1185,13 @@ void CCameraPcs::createFullShadow()
     CMapMng* map;
     char* fileName;
 
-    fileName = const_cast<char*>(__FILE__);
+    fileName = const_cast<char*>(s_p_camera_cpp);
     map = &MapMng;
     m_fullScreenShadow.m_shadowTexture = 0;
     m_fullScreenShadow.m_shadowTexture =
         new (map->m_stage, fileName, 0x3A5)
             u8[GXGetTexBufferSize(0x1E0, 0x1E0, GX_TF_I8, GX_FALSE, 0)];
-    fileName = const_cast<char*>(__FILE__);
+    fileName = const_cast<char*>(s_p_camera_cpp);
     map = &MapMng;
     m_fullScreenShadow.m_rampTexture = 0;
     rampTex = new (map->m_stage, fileName, 0x361)
@@ -1746,7 +1748,7 @@ void CCameraPcs::SetStdProjectionMatrix()
 
     if (fov < kCameraMinFov) {
         if (static_cast<unsigned int>(System.m_execParam) >= 1) {
-            System.Printf("!!!!!!!!!!!!!!!!!!FOV\202\314\222l\202\252\210\331\217\355\202\305\202\267\201B%f!!!!!!!!!!!!!!!!!!!!\012", fov);
+            System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
         }
         fov = kCameraDefaultFov;
     }
@@ -1841,7 +1843,7 @@ void CCameraPcs::calc()
     float fov = m_fov;
     if (fov < kCameraMinFov) {
         if (static_cast<unsigned int>(System.m_execParam) >= 1) {
-            System.Printf("!!!!!!!!!!!!!!!!!!FOV\202\314\222l\202\252\210\331\217\355\202\305\202\267\201B%f!!!!!!!!!!!!!!!!!!!!\012", fov);
+            System.Printf(const_cast<char*>(sCameraInvalidFovFmt), fov);
         }
         fov = kCameraDefaultFov;
     }


### PR DESCRIPTION
Reverts #17566. Isolation build at the merge parent vs HEAD showed #17566 was net-negative on the whole-DOL scoreboard:

- DOL matched_code 43.5040% -> 43.4971% (regressed)
- DOL matched_data 91.7143% -> 91.7159% (small gain)
- DOL fuzzy 98.1249% -> 98.1245% (regressed)
- p_camera unit itself regressed on ALL metrics: code 47.63->46.88, data 87.63->85.99, fuzzy 96.758->96.711

The per-section .rodata/.sdata gains the original PR reported were real, but extending the .rodata split to absorb auto_06_801D78F4_rodata added unmatched bytes to the unit total, and the inline-string source change perturbed code/fuzzy — net negative. Reverting to restore the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)