### PR TITLE
cflat_r2class: onClassSystemFunc round 4 (cycle 54)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -2055,12 +2055,9 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x9E:
-			{
-				float* params = reinterpret_cast<float*>(object->m_localBase);
-				engineObject->m_groundHitOffset.x += params[0];
-				engineObject->m_groundHitOffset.y += params[1];
-				engineObject->m_groundHitOffset.z += params[2];
-			}
+			engineObject->m_groundHitOffset.x += reinterpret_cast<float*>(object->m_localBase)[0];
+			engineObject->m_groundHitOffset.y += reinterpret_cast<float*>(object->m_localBase)[1];
+			engineObject->m_groundHitOffset.z += reinterpret_cast<float*>(object->m_localBase)[2];
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;


### PR DESCRIPTION
Case -0x9E (m_groundHitOffset += params): dropped the cached `float* params`
local and read `reinterpret_cast<float*>(object->m_localBase)[N]` directly at
each of the three component adds. The target reloads object->m_localBase before
each component (R13 lazy-reload) instead of pinning the pointer in a callee-saved
register.

Unit cflat_r2class 97.70% -> 97.77%; onClassSystemFunc flagged 301 -> 297.
Whole-DOL matched_code unchanged (807096), DOL fuzzy 98.150856 -> 98.151340.

Remaining residual confirmed at the documented walls (opP3Vec CVector-by-value
bl, frame/temp-slot +0xc cascade, -0x79 unrolled-if loop-form, -0x5F
pppIsDeadCHandle tail-merge, indexed-store sth/sthx, register-numbering swaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)