### PR TITLE
sinit struct-copy: pooling crack (pool_data off) — p_menu + p_MaterialEditor

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -704,3 +704,5 @@ void CMaterialEditorPcs::Init()
 
     m_loadedTextureCount = 0;
 }
+
+#pragma pool_data off

--- a/src/p_menu.cpp
+++ b/src/p_menu.cpp
@@ -1881,3 +1881,5 @@ CTexture* CMenuPcs::GetTexture(CMenuPcs::TEX tex)
 {
     return m_textures[static_cast<int>(tex)];
 }
+
+#pragma pool_data off


### PR DESCRIPTION
## The wall
The `__sinit_*` functions inline a ctor that copies CProcessTableCallback descriptors into `m_table[N]`. TARGET materializes each descriptor address per-symbol (`lis/addi sym@ha/@l` + `lwzu`); OURS pooled every read off one `...data.0` base.

## The crack
An **EOF-scoped `#pragma pool_data off`** — placed after the last function so it only affects the compiler-generated `__sinit` emitted at end of TU — forces per-symbol descriptor addressing matching the target. Blast radius is just the sinit (every other function in each unit is byte-identical before/after, verified per-function).

- `p_menu` __sinit 77.83% → **98.35%** (unit 97.83 → 97.90)
- `p_MaterialEditor` __sinit 76.86% → **86.77%** (unit 96.70 → 99.41)

Whole-DOL: fuzzy 98.150856% → 98.15488%, `matched_code` unchanged (807096), no function regressions.

## What did NOT crack (measured negatives)
- `p_camera` 53.62→37.56, `p_tina` 61.88→55.18, `p_map` 62.23→41.09 under pool_data off — these named-whole-struct-copy ctors have extra member-ctor/vtable refs in their sinit that de-pool badly. **Left untouched.**
- Pragmas scoped *around the inline ctor* never reach `__sinit` (it's generated at EOF after pragma reset) — all-zero deltas.
- Global pool_data off, function-local statics, external linkage on descriptors: all regress p_map.
- pool_data off + {scheduling/size/lifetimes/cse/peephole}: none beat plain pool_data off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)