### PR TITLE
p_MaterialEditor: pool_data off cracks sinit (unit 96.70->99.41%)

### DIFF
--- a/src/p_MaterialEditor.cpp
+++ b/src/p_MaterialEditor.cpp
@@ -704,3 +704,5 @@ void CMaterialEditorPcs::Init()
 
     m_loadedTextureCount = 0;
 }
+
+#pragma pool_data off


### PR DESCRIPTION
EOF-scoped `#pragma pool_data off` forces per-symbol descriptor addressing in the compiler-generated `__sinit_p_MaterialEditor_cpp`, matching the target. Verified at the merge parent: DOL matched_code unchanged (43.50396%), matched_data +0.007pp (91.71755->91.72453%), fuzzy +0.0013pp; p_MaterialEditor unit 96.70->99.41%, zero function regressions.

Supersedes the p_MaterialEditor portion of #17584 (which was branch-behind-main and would have reverted #17583/pppMana2). The same lever also helps p_menu (different bucket — left for that owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)