### PR TITLE
gbaque: structural fixes (cycle 14)

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -832,7 +832,7 @@ void GbaQueue::ExecutQueue()
 							unsigned int cmdWord = queueWords[i];
 							unsigned char* bytes = reinterpret_cast<unsigned char*>(&cmdWord);
 							const int itemId =
-								reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[channel])->m_inventoryItems[bytes[2]];
+								reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[channel])->m_inventoryItems[static_cast<int>(bytes[2])];
 							reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[channel])->DeleteItemIdx(bytes[2], 1);
 							const unsigned short baseGil =
 								*reinterpret_cast<unsigned short*>(Game.unkCFlatData0[2] + itemId * 0x48 + 0x20);


### PR DESCRIPTION
ExecutQueue cmd-8 (case 0x08): casting the m_inventoryItems subscript index to int drops a redundant byte-mask (clrlslwi r6,r4,24,1 -> slwi r6,r4,1), matching the target. The lbz already zero-extends bytes[2] so the extra & 0xFF was spurious.

gbaque fuzzy: 96.73936% -> 96.74608%

🤖 Generated with [Claude Code](https://claude.com/claude-code)