### PR TITLE
gbaque: ExecutQueue cmd 0x08 drop redundant index mask

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -832,7 +832,7 @@ void GbaQueue::ExecutQueue()
 							unsigned int cmdWord = queueWords[i];
 							unsigned char* bytes = reinterpret_cast<unsigned char*>(&cmdWord);
 							const int itemId =
-								reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[channel])->m_inventoryItems[bytes[2]];
+								reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[channel])->m_inventoryItems[static_cast<int>(bytes[2])];
 							reinterpret_cast<CCaravanWork*>(Game.m_scriptFoodBase[channel])->DeleteItemIdx(bytes[2], 1);
 							const unsigned short baseGil =
 								*reinterpret_cast<unsigned short*>(Game.unkCFlatData0[2] + itemId * 0x48 + 0x20);


### PR DESCRIPTION
`m_inventoryItems[bytes[2]]` emitted `clrlslwi` (mask &0xFF then <<1); the `lbz` already zero-extends so the mask is spurious. `static_cast<int>(bytes[2])` → plain `slwi`, matching target. Verified at merge parent: matched_code/data held, fuzzy +0.0067pp (gbaque unit). Re-land of #17587 on a fresh branch from current main (the original was provisioned behind main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)