### PR TITLE
cflat_runtime: dispatcher cast/arg fixes (cycle 10)

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -222,7 +222,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 									}
 								}
 								rendered[outLen] = '\0';
-								strcat(rendered, spec + 1 + fmtIndex);
+								strcat(rendered, &spec[fmtIndex + 1]);
 							} else {
 								scan = spec + 1;
 								while (*scan != '\0') {


### PR DESCRIPTION
## systemFunc: &spec[fmtIndex+1] addressing (98.43% -> 99.53%)
In `CFlatRuntime::systemFunc`, the printf-style `%`-spec renderer wrote the
strcat tail as `spec + 1 + fmtIndex`. mwcc CSE-folded the `spec + fmtIndex`
subexpression from the earlier `spec[fmtIndex] == 'b'` test, producing
`(spec+fmtIndex)+1` address arithmetic and a separate `add`+`lbz` instead of
the target's `lbzx`+`extsb` indexed signed-char access. Rewriting as
`&spec[fmtIndex + 1]` makes mwcc emit the target's `(spec+1)+fmtIndex`
addressing and resolves the line 114-115 / 144-146 REPLACE/DELETE cluster.

Unit cflat_runtime 97.4468% -> 97.5683%. cflat_runtime2 unchanged (99.10%).
DOL matched_code stable. No regression to shared cflat_r2system/r2class.

## Walled (no net-positive source lever found this cycle)
- SystemCall / request / objectFrame: 0xd0-vs-0xc0 frame-size spill window
  (target reserves 4 extra stack slots) + whole-function r3/r4 callee-saved
  register permutation. All flags cascade from these; immediate-constant
  census found every li/addi/cmpwi value correct.
- createObject: free-node-scan 3-way register rotation.
- cflat_runtime2 drawLayer: +1 callee-saved GPR window (r22-r30) + scaleX/scaleY
  f28/f29 FPR-coloring swap; int->float magic-double conversion entangled.
- cflat_runtime2 Calc: r28/r29 window + late-vs-early CameraPcs+0x8cc address
  hoist; `+=` and field-cache variants regress.
- systemFunc residual: backend double-`beq` short-circuit emission in the
  inner `&&`/`||` while condition (all condition restructurings regress or tie).

Spurious-narrowing-cast vein confirmed exhausted: zero ours-only extsb/extsh
remain across all dispatcher functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)