### PR TITLE
cflat_r2class: onClassSystemFunc round 5 cast-vein (cycle 55)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1351,13 +1351,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x2D: {
+			CVector attackOffset(reinterpret_cast<float*>(object->m_localBase)[3],
+			                     reinterpret_cast<float*>(object->m_localBase)[4],
+			                     reinterpret_cast<float*>(object->m_localBase)[5]);
 			engineObject->SetAttackCol(
 			    static_cast<int>(object->m_localBase[0]),
 			    RuntimeString(this, object->m_localBase[1]),
 			    reinterpret_cast<float*>(object->m_localBase)[2],
-			    CVector(reinterpret_cast<float*>(object->m_localBase)[3],
-			            reinterpret_cast<float*>(object->m_localBase)[4],
-			            reinterpret_cast<float*>(object->m_localBase)[5]));
+			    reinterpret_cast<Vec*>(&attackOffset));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1384,13 +1384,15 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x2F: {
-			float* params = reinterpret_cast<float*>(object->m_localBase);
+			CVector damageOffset(reinterpret_cast<float*>(object->m_localBase)[4],
+			                     reinterpret_cast<float*>(object->m_localBase)[5],
+			                     reinterpret_cast<float*>(object->m_localBase)[6]);
 			engineObject->SetDamageCol(
 			    static_cast<int>(object->m_localBase[0]),
 			    RuntimeString(this, object->m_localBase[1]),
-			    params[2],
-			    params[3],
-			    CVector(params[4], params[5], params[6]));
+			    reinterpret_cast<float*>(object->m_localBase)[2],
+			    reinterpret_cast<float*>(object->m_localBase)[3],
+			    reinterpret_cast<Vec*>(&damageOffset));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;


### PR DESCRIPTION
Round 5 on main/cflat_r2class onClassSystemFunc.

The PRIMARY spurious-narrowing-cast vein was EMPTY here: confirmed no extsb/extsh appears only-in-ours before any bl (the int-typed handler params are already fed un-narrowed). Instead the wins came from the SECONDARY veins: dropping the spurious __opP3Vec conversion call + R13 lazy-reload.

Cases fixed (Vec* method calls that build a CVector then immediately do an intervening RuntimeString call — target holds the CVector address in a callee-saved reg, ours emitted a spurious bl __opP3Vec + cached m_localBase):

- case -0x2D SetAttackCol: named CVector local + reinterpret_cast<Vec*>(&local) instead of CVector-by-value temporary → drops bl __opP3Vec, matches target's direct (Vec*) cast of the ct result. 97.76664% → 97.87218%.
- case -0x2F SetDamageCol: same fix, plus stop caching `float* params` (target reloads object->m_localBase fresh into scratch per Ghidra). 97.87218% → 98.05072%.

Net: cflat_r2class unit 97.76664% → 98.05072% (+0.284). Whole-DOL matched_code held at 43.503963% (no regression).

Ceiling: the remaining 4 bl __opP3Vec inserts (SetPosBG x2, moveVector, moveVectorH) are WALLED — those cases pass the CVector as the final argument with no intervening call, so the target uses the ct return value directly (mr r4,r3) and any source form that takes &local rematerializes the address (regresses). Verified: temporary form, (Vec*)temp C-cast, reinterpret_cast<Vec*>(&local), and no-cache reloads all regress or are bit-identical with the operator call retained. Other residual flags are documented walls: frame 0x33c-vs-0x344 uniform offset shift, f2/f3/f4 FPR coloring around cos, indexed-store add+sth vs addi+sthx, -0x79 subic.-vs-subi loop-form, and @NNN/System@ reloc-name noise (ignored per metric calibration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)