### PR TITLE
cflat_r2system: onSystemFunc round 6 (cycle 56)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3588,7 +3588,7 @@ renderedDone:
         outResult = 0;
         break;
     case -0xB0:
-        strcpy(Game.m_startScriptName, this->m_strBlob + this->m_strOffsets[*object->m_localBase]);
+        strcpy(Game.m_gameWork.m_townName, this->m_strBlob + this->m_strOffsets[*object->m_localBase]);
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2229,8 +2229,9 @@ renderedDone:
     case -0x1E:
         if (*object->m_localBase < 0x10) {
             CLine<64>& line = m_debugLines[*object->m_localBase];
+            int mask = object->m_localBase[1];
             line.pointCount = 0;
-            line.m_mask = object->m_localBase[1];
+            line.m_mask = mask;
         }
         this->push(object, 0);
         outResult = 0;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2080,7 +2080,7 @@ renderedDone:
         break;
     }
     case -0x1A: {
-        const unsigned int mode = *object->m_localBase;
+        const int mode = *object->m_localBase;
 
         float t = static_cast<float>(static_cast<int>(object->m_localBase[1])) /
                   static_cast<float>(static_cast<int>(object->m_localBase[2]));

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3573,7 +3573,9 @@ renderedDone:
         break;
     case -0xAF:
         this->push(
-            object, static_cast<int>(Game.m_caravanWorkArr[*object->m_localBase].m_name[object->m_localBase[1]]));
+            object,
+            static_cast<int>(
+                static_cast<signed char>(Game.m_caravanWorkArr[*object->m_localBase].m_name[object->m_localBase[1]])));
         outResult = 0;
         break;
     case -0xAE:


### PR DESCRIPTION
Round 6 on onSystemFunc. Unit 96.0606% -> 96.1040%, onSystemFunc fn 94.92% -> 94.976%. Whole-DOL matched_code held (807096), DOL fuzzy nudged up.

Cases fixed:
- **-0xB0**: strcpy destination was m_startScriptName (Game+0xC8F4); target reads Game+0x10a8 = m_gameWork.m_townName. Genuine latent member bug (the -0xB1 case directly above reads the same m_townName). Fixed addi r3,r5,0x10a8 vs addis/subi.
- **-0xAF**: push m_name[idx] now sign-extends (static_cast<signed char>) to emit the missing extsb; m_name is unsigned char so ours only zero-extended.
- **-0x1E**: hoist localBase[1] into an int mask local so the value stays live across the two m_debugLines[idx] stores, removing a redundant reload between pointCount and m_mask.
- **-0x1A**: declare mode as signed int so the (mode & 1) bit-mask tests use signed cmpwi (matching target) instead of cmplwi.

-0xB0 offset verdict: CONFIRMED genuine bug. Game+0x10a8 = m_gameWork (0x08) + m_townName (0x10A0). Source wrote m_startScriptName by mistake.

Remaining walls (not source-steerable): r28/r29 push-result window, frame 0x33c-vs-0x344, string-pool-base CSE, spec[fmtIndex] addressing, the CVector spline-math register band, and the (mode&2) CSE rematerialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)