### PR TITLE
cflat_r2system: onSystemFunc round 7 (cycle 57)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1367,13 +1367,9 @@ void CVector::operator=(const CVector& other)
  */
 CVector::CVector(const CVector& other)
 {
-    const float* src = &other.x;
-    float x = *src++;
-    float y = *src++;
-    this->x = x;
-    float z = *src;
-    this->y = y;
-    this->z = z;
+    this->x = other.x;
+    this->y = other.y;
+    this->z = other.z;
 }
 
 /*

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2193,9 +2193,10 @@ renderedDone:
                     const float scaleA = p1->m_distance - p0->m_distance;
                     const float scaleB = p2->m_distance - p1->m_distance;
                     const float scaleC = p3->m_distance - p2->m_distance;
-                    float segmentT = (kCFlatPadStickZero != scaleB)
-                                         ? (pathDistance - p1->m_distance) / scaleB
-                                         : kCFlatPadStickZero;
+                    float segmentT = kCFlatPadStickZero;
+                    if (kCFlatPadStickZero != scaleB) {
+                        segmentT = (pathDistance - p1->m_distance) / scaleB;
+                    }
 
                     Vec result;
                     CrossCheckEllipseCapsule__5CMathFP3VecPfP3VecP3VecfP3Vecff(

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1818,6 +1818,7 @@ int CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemFu
             char spec[256];
             char rendered[256];
             char line[264];
+            char* specBody = spec + 1;
             line[0] = '\0';
 
             for (int i = 0; i < object->m_argCount - 3; i++) {
@@ -1841,12 +1842,12 @@ int CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemFu
 
                 const int argIndex = i + 3;
                 unsigned int* localArgs = object->m_localBase;
-                char* scan;
+                char* scan = specBody;
                 if (spec[0] == '%') {
                     int fmtIndex = 1;
                     int width = 0;
                     int started = spec[1] == '0';
-                    for (char* digits = spec + 1; (*digits >= '0') && (*digits <= '9'); digits++) {
+                    for (char* digits = specBody; (*digits >= '0') && (*digits <= '9'); digits++) {
                         fmtIndex++;
                         width = (*digits - '0') + width * 10;
                     }
@@ -1874,7 +1875,6 @@ int CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemFu
                     }
                 } else {
 formatScan:
-                    scan = spec + 1;
                     while (*scan != '\0') {
                         unsigned int* slot = &localArgs[argIndex];
                         switch (*scan) {


### PR DESCRIPTION
Round 7 sweep of main/cflat_r2system. Unit 96.104% -> 96.170%, matched functions 94.05% -> 95.24% (two new 100% functions), DOL 43.504% -> 43.515%.

Cases landed:
- CVector copy ctor field-wise crack: rewriting the copy ctor body to strict field-by-field assignment makes the auto-inlined return-copy in operator+ and operator- match exactly (4->0 flags each, both now 100%). The standalone copy ctor takes a small one-body-two-contexts hit, but net is strongly positive (gained two whole functions).
- case -0x1a radius: rewrote the segmentT ternary as default-assign + if-statement matching Ghidra's `radius=0; if(0!=b) radius=(d-d)/b` shape (1474->1470 fn flags).
- Printf format loop: hoisted `char* specBody = spec+1` and reused it for both the digit-scan and format-scan loops, matching Ghidra's single pcVar45 cursor (1470->1463 fn flags).

Confirmed walls (triaged, not steerable): SetMapShadeColor index-r0-vs-r4 register coloring; r28/r29 push-result window; frame 0x33c-vs-0x344; string-pool-base CSE (r28-cached vs @stringBase0 remat, ~7 sites); CVector spline-math band; -0x1a baseIndex/segmentCount window; case -0x48 outResult=0 tail-duplication (inline form regresses globally); -0x9C lwzu base-residency; padType register window; jumptable/@NNN reloc names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)