### PR TITLE
cflat_r2class: onClassSystemFunc round 6 (cycle 56)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1590,9 +1590,10 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		}
 		case -0x52: {
 			CCaravanWork* caravanWork = reinterpret_cast<CCaravanWork*>(engineObject->m_scriptHandle);
+			int findItemId = static_cast<int>(object->m_localBase[1]);
 			unsigned int result = 0;
 			if ((object->m_localBase[0] & 2) != 0) {
-				result = caravanWork->FindItem(static_cast<int>(object->m_localBase[1])) >= 0 ? 2 : 0;
+				result = caravanWork->FindItem(findItemId) >= 0 ? 2 : 0;
 			}
 			PushValue(this, object, static_cast<int>(result));
 			outResult = 0;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1907,20 +1907,19 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x85:
-			PushValue(
-			    this,
-			    object,
-			    reinterpret_cast<CCaravanWork*>(engineObject->m_scriptHandle)->ShopRequest(
-			        static_cast<int>(object->m_localBase[0]),
-			        static_cast<int>(object->m_localBase[1]),
-			        static_cast<int>(object->m_localBase[2]),
-			        static_cast<int>(object->m_localBase[3]),
-			        static_cast<int>(object->m_localBase[4]),
-			        static_cast<int>(object->m_localBase[5]),
-			        static_cast<int>(object->m_localBase[6])));
+		case -0x85: {
+			int shopResult = reinterpret_cast<CCaravanWork*>(engineObject->m_scriptHandle)->ShopRequest(
+			    static_cast<int>(object->m_localBase[0]),
+			    static_cast<int>(object->m_localBase[1]),
+			    static_cast<int>(object->m_localBase[2]),
+			    static_cast<int>(object->m_localBase[3]),
+			    static_cast<int>(object->m_localBase[4]),
+			    static_cast<int>(object->m_localBase[5]),
+			    static_cast<int>(object->m_localBase[6]));
+			PushValue(this, object, shopResult);
 			outResult = 0;
 			break;
+		}
 		case -0x86: {
 			CChara::CModel* model = engineObject->m_charaModelHandle->m_model;
 			model->m_flags10CBits.m_flag10C_40 = static_cast<signed char>(object->m_localBase[0]);


### PR DESCRIPTION
Two value-evaluation-order fixes on onClassSystemFunc (unit 98.05072% -> 98.148346%, fn flags 273 -> 266, whole-DOL matched_code held at 43.503963%).

- case -0x52 (FindItem): hoist `object->m_localBase[1]` into a named local before the `m_localBase[0] & 2` branch so it is evaluated unconditionally, matching the target's `lwz r4,0x4(r4)` load ahead of the `rlwinm./beq`.
- case -0x85 (ShopRequest): assign the ShopRequest return value to a named local before PushValue (matches Ghidra's `uVar6` form); mwcc then stages the result through r0 (`mr r0,r3; mr r5,r0`) into the push arg register, matching the target.

Remaining residual is the deep, exhausted allocation walls: the pervasive object(r30)/engineObject(r31) coloring swap in the back half, the r26/r27 callee-saved band + frame 0x33c-vs-0x344, the class-B __opP3Vec cases (-0x1D moveVector retried this round = REGRESS 97.66, confirmed walled; -0x36 moveVectorH), the indexed-store add+sth vs addi+sthx, the -0x75 operand-swap, the -0x79 loop-form, and named-vs-raw reloc pools (System/AnimStateWarn). At ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)