### PR TITLE
cflat_r2class: onClassSystemFunc round 7 (cycle 57)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -2054,11 +2054,12 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x9D:
-			PushValue(
-			    this, object, static_cast<unsigned int>(reinterpret_cast<CGPrgObj*>(engineObject)->GetClassControl(static_cast<int>(object->m_localBase[0]))));
+		case -0x9D: {
+			unsigned int classControl = static_cast<unsigned int>(reinterpret_cast<CGPrgObj*>(engineObject)->GetClassControl(static_cast<int>(object->m_localBase[0])));
+			PushValue(this, object, classControl);
 			outResult = 0;
 			break;
+		}
 		case -0x9E:
 			engineObject->m_groundHitOffset.x += reinterpret_cast<float*>(object->m_localBase)[0];
 			engineObject->m_groundHitOffset.y += reinterpret_cast<float*>(object->m_localBase)[1];

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1504,17 +1504,18 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			outResult = 0;
 			break;
 		case -0x3B: {
+			unsigned int* localBase = object->m_localBase;
 			CGraphicPcs::ScreenFadeSlot* slot = &GraphicPcs.m_screenFade[2];
-			slot->m_invert = static_cast<int>(object->m_localBase[0]);
+			slot->m_invert = static_cast<int>(localBase[0]);
 			slot->m_mode = 1;
 			slot->m_targetObj = engineObject;
-			slot->m_targetYOffs = reinterpret_cast<float*>(object->m_localBase)[1];
-			slot->m_colorA.r = static_cast<unsigned char>(object->m_localBase[2]);
-			slot->m_colorA.g = static_cast<unsigned char>(object->m_localBase[3]);
-			slot->m_colorA.b = static_cast<unsigned char>(object->m_localBase[4]);
+			slot->m_targetYOffs = reinterpret_cast<float*>(localBase)[1];
+			slot->m_colorA.r = static_cast<unsigned char>(localBase[2]);
+			slot->m_colorA.g = static_cast<unsigned char>(localBase[3]);
+			slot->m_colorA.b = static_cast<unsigned char>(localBase[4]);
 			slot->m_colorA.a = 0xFF;
-			slot->m_timer = static_cast<int>(object->m_localBase[5]);
-			slot->m_duration = static_cast<int>(object->m_localBase[5]);
+			slot->m_timer = static_cast<int>(localBase[5]);
+			slot->m_duration = static_cast<int>(localBase[5]);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1963,12 +1963,14 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x8E:
+		case -0x8E: {
+			int carryIndex = static_cast<int>(object->m_localBase[0]);
 			reinterpret_cast<CGPartyObj*>(engineObject)
-			    ->carry(static_cast<int>(object->m_localBase[0]), static_cast<CGObject*>(this->intToClass(static_cast<int>(object->m_localBase[1]))), static_cast<int>(object->m_localBase[2]));
+			    ->carry(carryIndex, static_cast<CGObject*>(this->intToClass(static_cast<int>(object->m_localBase[1]))), static_cast<int>(object->m_localBase[2]));
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
+		}
 		case -0x8D:
 			reinterpret_cast<CGPartyObj*>(engineObject)->commandFinished();
 			PushValue(this, object, 0);


### PR DESCRIPTION
Three value-evaluation-order fixes on onClassSystemFunc (fn 96.97% -> 97.78%, unit 98.148% -> 98.252%).

- case -0x8E (carry): named local for m_localBase[0] before the intToClass() call so arg0 stays live across the call (removed the late-load INSERT/DELETE).
- case -0x9D (GetClassControl): result captured into a named local before PushValue, matching the target's r0-staging (case fully matched).
- case -0x3B (ScreenFade): cache object->m_localBase before the GraphicPcs slot pointer so the localBase load lands in the target's register first.

DOL matched_code unchanged (43.51453%); no regressions.

Remaining residual is all walls: base/this register-coloring numbering, class-B __opP3Vec, indexed add+sth vs addi+sthx, branch polarity, the -0x5F short-circuit duplication, the SetAnimSlot subic./cmpw loop-form, and the extrwi-vs-mr scheduling tie-break (confirmed not source-steerable this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)