### PR TITLE
cflat_r2system: onSystemFunc round 8 (cycle 58)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3061,12 +3061,12 @@ renderedDone:
         break;
     }
     case -0x60: {
+        const unsigned int blurA = static_cast<unsigned int>(__cntlzw(object->m_localBase[4]));
+        const unsigned int blurB = static_cast<unsigned int>(__cntlzw(object->m_localBase[5]));
         const int alpha = static_cast<int>(kCFlatAlphaMax * *reinterpret_cast<float*>(object->m_localBase + 3)) & 0xFF;
-        const unsigned int blurA = (static_cast<unsigned int>(__cntlzw(object->m_localBase[4])) >> 5) & 0xFF;
-        const unsigned int blurB = (static_cast<unsigned int>(__cntlzw(object->m_localBase[5])) >> 5) & 0xFF;
         GraphicPcs.SetBlurParameter(*object->m_localBase, static_cast<unsigned char>(object->m_localBase[1]),
             static_cast<unsigned char>(object->m_localBase[2]), static_cast<unsigned char>(alpha),
-            static_cast<unsigned char>(blurA), static_cast<unsigned char>(blurB),
+            static_cast<unsigned char>((blurA >> 5) & 0xFF), static_cast<unsigned char>((blurB >> 5) & 0xFF),
             static_cast<short>(object->m_localBase[6]));
         this->push(object, 0);
         outResult = 0;


### PR DESCRIPTION
Case -0x60 (SetBlurParameter): reorder so the two `__cntlzw` results are computed up front as raw locals (matching Ghidra's `uVar9`/`uVar31` locals at 0x800b3310 lines 1509-1510), then apply `>> 5 & 0xFF` at the call site. This lets mwcc fold both blur-amount conversions into combined `extrwi rN,rN,8,19` extracts (was emitting separate `clrlwi` masks before). Unit fuzzy 96.1695% -> 96.24773%.

Thorough sweep of remaining flagged regions confirmed all other structural divergences map to previously-documented walls (push-result r28/r29 window, frame 0x344-vs-0x33c, string-pool-base CSE conditional-Printf, debugDataBuffer -0x54..-0x57 identical-case CSE, -0x1A baseIndex/(mode&2) int->double CSE, CVector spline-band radius scheduling, drawLayer arg front-loading/liveness, kCFlatPadStickZero -0xE9 f30 cache-vs-reload, FindItem & 2 rlwinm-vs-and mask selection). The blur reorder was the only net-positive lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)