### PR TITLE
cflat_r2class: onClassSystemFunc round 8 (cycle 58)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1879,7 +1879,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			moveVector.x = static_cast<float>(sin(rotX)) * static_cast<float>(cos(rotY));
 			moveVector.y = static_cast<float>(sin(rotY));
 			moveVector.z = static_cast<float>(cos(rotX)) * static_cast<float>(cos(rotY));
-			engineObject->MoveVector(&moveVector, params[2], static_cast<int>(object->m_localBase[3]), 0, 0, 1);
+			engineObject->MoveVector(&moveVector, reinterpret_cast<float*>(object->m_localBase)[2], static_cast<int>(object->m_localBase[3]), 0, 0, 1);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1733,8 +1733,9 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			if (useDebugPad) {
 				buttons = 0;
 			} else {
+				int port = Pad.m_debugPadPort;
 				unsigned int slot = static_cast<unsigned int>(playerIndex)
-				    & ~((static_cast<int>(~(Pad.m_debugPadPort - playerIndex | playerIndex - Pad.m_debugPadPort)) >> 31));
+				    & ~((static_cast<int>(~((port - playerIndex) | (playerIndex - port))) >> 31));
 				buttons = *reinterpret_cast<unsigned int*>(reinterpret_cast<u8*>(&Pad) + 0x54 + slot * 0x54);
 			}
 			PushValue(this, object, static_cast<int>(buttons));


### PR DESCRIPTION
Round 8 sweep of onClassSystemFunc. Two genuine fixes landed (unit 98.252% -> 98.288%, fn 97.78% -> 97.91%, whole-DOL matched_code unchanged at 807292).

- **case -0x73**: hoisted `Pad.m_debugPadPort` into a local `int port`. The `~((port-idx) | (idx-port))` expression now folds into a single `nor` matching the target, eliminating the spurious `or r0,r3,r0` + `nor r0,r0,r0` (=`~`) pair. Full instruction sequence (subf/subf/nor/srawi/andc) now matches; residual is pure register-numbering (Pad base r5/r6 vs r3/r4 — allocation-priority wall).
- **case -0x54**: read `object->m_localBase[2]` inline in the MoveVector call (rather than via the cached `params` pointer). Defeats the base-pointer CSE so the post-trig arg loads `lfs f1,0x8(r5)` reload `0xc(r30)` fresh, matching the target instead of caching the base in callee-saved r26.

Swept all remaining flagged lines; the rest are confirmed walls: __opP3Vec class-A-without-intervening-call (asm 45/519) and class-B (329/678/727/837); frame 0x33c/0x344 stack-offset cascade; object(r30)/engineObject(r31) coloring; indexed sthx 1163-1188; -0x5F short-circuit dup; -0x75 caravanWork operand-swap (named-local = bit-identical, swap adds a cmpw flag); GraphicPcs r7/r8 allocation numbering; f2/f3/f4 cos coloring; -0x8E carry base-vs-value CSE tie-break; reloc/jumptable name flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)