### PR TITLE
cflat_r2system: onSystemFunc pool_strings string-pool-base crack (97.33%)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1746,6 +1746,7 @@ void CLine<64>::CalcBound()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma pool_strings on
 int CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemFunc, int& outResult)
 {
     char* gbaPath = const_cast<char*>("dvd/gba/");
@@ -4192,6 +4193,7 @@ renderedDone:
 
     return 1;
 }
+#pragma pool_strings off
 
 /*
  * --INFO--


### PR DESCRIPTION
The onSystemFunc__13CFlatRuntime2 wall was framed as a stack-frame-size delta (0x344 vs 0x33c). Investigation showed the **frame sizes are identical** (target and ours both `stwu r1,-0xda0`); the 8-byte figure was a stack-LOCAL offset shift, a *consequence* not the cause.

The real driver: the target groups all 27 inline debug format-string literals into one contiguous per-function rodata pool (`lbl_801DA3B0`/`lbl_801DA3E4`, size 0x368) and hoists its base into a callee-saved register, reaching every `System.Printf` format via `addi rN,base,OFFSET`. Under the unit's `-str reuse` mwcc rematerialized each string from a separate merged-pool base instead — which also pushed `outResult` into a different callee-saved register, driving the ~250 `stw r0,0x0(rN)` flags and the switch-discriminant register band.

`#pragma pool_strings on` scoped to onSystemFunc forces the contiguous per-function pool + hoisted base, matching the target structure.

Measured (whole-DOL, no regression):
- unit main/cflat_r2system 96.24773 -> 97.32954 (+1.08)
- onSystemFunc fn 95.131 -> 96.560 (+1.43)
- whole-DOL fuzzy 98.16622 -> 98.18444; matched_code 807292 (unchanged), matched_functions 3931 (unchanged)

Residual is a pure r28<->r29 allocation-priority swap on the compiler-synthesized pool base (no source token names it). Full per-function pragma sweep confirms pool_strings-on is the local maximum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)