### PR TITLE
B4: extended-pragma cracks (cycle 1)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -527,6 +527,7 @@ void CGraphic::_WaitDrawDone(char* file, int line)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
 void CGraphic::Thread()
 {
     char* debugFmtBase = const_cast<char*>(sGraphicInitData);
@@ -603,6 +604,7 @@ void CGraphic::Thread()
         OSRestoreInterrupts(interrupts);
     }
 }
+#pragma opt_dead_assignments on
 
 /*
  * --INFO--


### PR DESCRIPTION
Extended-pragma discovery sweep across top walled non-cflat B4 functions, testing pragmas OUTSIDE the standard matrix (global_optimizer, opt_dead_assignments, readonly_strings, pool_data/pool_strings, opt_dead_code, inline_depth, opt_partial_redundancies).

## Verified crack
- **main/graphic `CGraphic::Thread`**: `#pragma opt_dead_assignments off` (scoped). Unit 97.9674 -> 98.2018 (+0.2344pp). DOL fuzzy +0.00193pp, matched_code held (43.51453, no drop), no other unit regressed.

## Confirmed closed (no untested pragma beats baseline)
p_graphic drawBar, graphic makeSphere, FunnyShape RenderShape, RedCommand _SePlayStart / _MusicPlayStart, gbaque GetCmdData / GetEquipData, p_minigame MngThreadMain, and the three member-ctor sinits __sinit_p_map/p_camera/p_tina (EOF-anchored — global_optimizer off and pool_data off both regress, as documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)