### PR TITLE
B4: opt_dead_assignments window cracks B (cycle 1)

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -1888,6 +1888,8 @@ static inline unsigned int MiniGameCrc8(unsigned int value)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
+#pragma opt_lifetimes off
 void CMiniGamePcs::MngThreadMain(void*)
 {
     unsigned char* self = reinterpret_cast<unsigned char*>(this);
@@ -2186,6 +2188,8 @@ next_player:
     }
 }
 
+#pragma opt_lifetimes on
+#pragma opt_dead_assignments on
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
p_minigame MngThreadMain: scoped `#pragma opt_dead_assignments off` + `#pragma opt_lifetimes off` matches the target's retained debug/counter-loop stores. Unit main/p_minigame 98.2544 -> 98.25869 (+0.0043pp). DOL fuzzy +0.00003pp, matched_code held (807292, no collateral regress).

Swept opt_dead_assignments off (single + paired with opt_lifetimes/opt_propagation/scheduling/opt_common_subs off) across the documented register-window walls: gxfunc _InitGxFunc/initTevRegs, p_minigame MiniGameGo, RedCommand _SePlayStart/_MusicPlayStart, RedExecute _PitchExecute/_SeTrackDataExecute, RedDriver Init/_MusicCrossPlaySequence, FunnyShape RenderShape, ME_USB_process SetUSBData, pad Frame — all +0.0000 or regress (confirmed closed). Only MngThreadMain's oda+nolifetimes pair beat baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)