### PR TITLE
B4 sound/red: non-standard-pragma cracks (cycle 1)

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -1789,6 +1789,8 @@ void GbaQueue::GetPlayerPos(int channel, unsigned int* outData)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
+#pragma opt_propagation off
 void GbaQueue::GetEnemyPos(int channel, unsigned int* outData, int* outCount)
 {
     char localEnemyData[0x508];
@@ -1964,6 +1966,8 @@ void GbaQueue::GetTreasurePos(int channel, unsigned int* outData, int* outCount)
 	OSSignalSemaphore(accessSemaphores + channel);
 }
 
+#pragma opt_dead_assignments on
+#pragma opt_propagation on
 /*
  * --INFO--
  * PAL Address: 0x800CE3F8
@@ -3693,6 +3697,7 @@ inline void GbaQueue::SmithEnd(int channel)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
 int GbaQueue::MakeBuyData(int channel, char* outData)
 {
 char* itemNameScratch = new (GbaPcs.m_stage, const_cast<char*>(s_gbaque_cpp), 0xD79) char[kGbaQueueScratchTextSize];
@@ -3783,6 +3788,7 @@ System.Printf(const_cast<char*>(sGbaQueueMemoryAllocationErrorFmt), const_cast<c
 	return totalSize;
 }
 
+#pragma opt_dead_assignments on
 /*
  * --INFO--
  * PAL Address: 0x800cb0d0
@@ -4847,6 +4853,8 @@ void GbaQueue::SetControllerMode(int controllerMode)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
+#pragma opt_lifetimes off
 unsigned int GbaQueue::GetControllerMode()
 {
 	char mode;
@@ -4964,6 +4972,8 @@ void GbaQueue::OpenMenu(int channel, int menuId, int controlMode)
 	}
 }
 
+#pragma opt_dead_assignments on
+#pragma opt_lifetimes on
 /*
  * --INFO--
  * PAL Address: 0x800C9184
@@ -5007,6 +5017,8 @@ void GbaQueue::SetPauseMode(int mode)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
+#pragma opt_lifetimes off
 unsigned int GbaQueue::GetPauseMode()
 {
 	char mode;
@@ -5031,6 +5043,8 @@ unsigned int GbaQueue::GetPauseMode()
 	return result;
 }
 
+#pragma opt_dead_assignments on
+#pragma opt_lifetimes on
 /*
  * --INFO--
  * PAL Address: 0x800c9090

--- a/src/joybus.cpp
+++ b/src/joybus.cpp
@@ -2915,6 +2915,7 @@ int JoyBus::SendGBA(ThreadParam* threadParam)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma opt_dead_assignments off
 int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
 {
 
@@ -3241,6 +3242,7 @@ int JoyBus::GBARecvSend(ThreadParam* threadParam, unsigned int* cmdOut)
     return static_cast<int>(recvBit | sendBit);
 }
 
+#pragma opt_dead_assignments on
 /*
  * --INFO--
  * Address:	TODO
@@ -6512,6 +6514,7 @@ int JoyBus::SendMask(int, unsigned short)
  * Address:	TODO
  * Size:	TODO
  */
+#pragma opt_dead_assignments off
 int JoyBus::SetMoney(int portIndex, unsigned int money)
 {
     int result = 0;
@@ -6546,6 +6549,7 @@ int JoyBus::SetMoney(int portIndex, unsigned int money)
     return result;
 }
 
+#pragma opt_dead_assignments on
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
Systematic non-standard-pragma sweep across assigned units (RedSound/{Command,Execute,Driver,Entry,Stream}, sound, joybus, gbaque). Five variants per sub-100% function: opt_dead_assignments off; oda+opt_lifetimes off; oda+opt_propagation off; pool_data off; pool_strings on.

Verified net-positive flips (no whole-DOL matched_code regression):

joybus (99.1932 -> 99.2177):
- GBARecvSend  #pragma opt_dead_assignments off  (97.20 -> 97.37 fn)
- SetMoney     #pragma opt_dead_assignments off  (98.35 -> 100.00 fn)

gbaque (96.7461 -> 96.8247):
- GetEnemyPos       oda + opt_propagation off  (92.14 -> 95.45 fn)
- GetTreasurePos    oda + opt_propagation off  (93.95 -> 94.92 fn)
- GetControllerMode oda + opt_lifetimes off    (95.86 -> 96.43 fn)
- GetPauseMode      oda + opt_lifetimes off    (95.86 -> 96.43 fn)
- OpenMenu          oda + opt_lifetimes off    (96.43 -> 96.76 fn)
- MakeBuyData       #pragma opt_dead_assignments off (96.38 -> 96.47 fn)

Swept clean (no flip): RedCommand, RedExecute, RedDriver, RedEntry, RedStream, sound — all baseline winners. pool_data off consistently regressed (shared string/data pool); pool_strings on was a no-op everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)