### PR TITLE
FunnyShape: RenderShape FIFO load pipelining (structural fix)

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -75,8 +75,8 @@ static inline float RotateShapeY(const u8* entry, u32 xOffset, u32 yOffset, floa
 
 static inline void WriteVertex(const float* pos, u32 color, const float* tex)
 {
-    const volatile float* vpos = pos;
-    const volatile float* vtex = tex;
+    const float* vpos = pos;
+    const float* vtex = tex;
     GXWGFifo.f32 = vpos[0];
     GXWGFifo.f32 = vpos[1];
     GXWGFifo.f32 = vpos[2];


### PR DESCRIPTION
RenderShape WriteVertex read the pos/tex arrays through a `const volatile float*` pointer, forcing each FIFO store to be preceded 1:1 by a volatile (un-reorderable) load. The target reads them through a plain non-volatile pointer alias, letting mwcc software-pipeline the loads ~2 ahead of the volatile FIFO stores (matching the Ghidra reference, where the FIFO writes read plain locals).

Switching `const volatile float* vpos/vtex` to `const float* vpos/vtex` (keeping the alias to block value-propagation that would otherwise collapse the stack round-trip) restores the pipelined load pattern.

- RenderShape fn 92.17% -> 93.36%
- main/FunnyShape unit 96.46% -> 96.96%
- Whole-DOL matched_code flat (43.54062%, no regression)
- Structural flags: INSERT 17->13, DELETE 20->16, REPLACE 5->4

🤖 Generated with [Claude Code](https://claude.com/claude-code)