### PR TITLE
cflat_r2class: onClassSystemFunc structural fixes

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1615,21 +1615,27 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x5A:
-			reinterpret_cast<CGObjWork*>(engineObject->m_scriptHandle)->m_statusValues[object->m_localBase[0]] = static_cast<unsigned short>(object->m_localBase[1]);
+		case -0x5A: {
+			CGObjWork* work = reinterpret_cast<CGObjWork*>(engineObject->m_scriptHandle);
+			work->m_statusValues[object->m_localBase[0]] = static_cast<unsigned short>(object->m_localBase[1]);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x5C:
-			reinterpret_cast<CMonWork*>(engineObject->m_scriptHandle)->unk_0xd0[object->m_localBase[0]] = static_cast<unsigned short>(object->m_localBase[1]);
+		}
+		case -0x5C: {
+			CMonWork* work = reinterpret_cast<CMonWork*>(engineObject->m_scriptHandle);
+			work->unk_0xd0[object->m_localBase[0]] = static_cast<unsigned short>(object->m_localBase[1]);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
-		case -0x5D:
-			reinterpret_cast<CMonWork*>(engineObject->m_scriptHandle)->unk_0xf0[object->m_localBase[0]] = static_cast<unsigned short>(object->m_localBase[1]);
+		}
+		case -0x5D: {
+			CMonWork* work = reinterpret_cast<CMonWork*>(engineObject->m_scriptHandle);
+			work->unk_0xf0[object->m_localBase[0]] = static_cast<unsigned short>(object->m_localBase[1]);
 			PushValue(this, object, 0);
 			outResult = 0;
 			break;
+		}
 		case -0x5F:
 			if (engineObject->m_charaModelHandle != 0 && PartMng.pppIsDeadCHandle(engineObject->m_charaModelHandle) != 0) {
 				PushValue(this, object, 0);


### PR DESCRIPTION
Named CGObjWork*/CMonWork* work-locals for the status-array stores in cases -0x5A/-0x5C/-0x5D. Hoisting reinterpret_cast<...>(engineObject->m_scriptHandle) to a local flips the index/base associativity from addi+sthx (base+disp then indexed store) to add+sth (base+idx then disp store), matching the target and eliminating the 6 sthx/add structural mismatches plus their r6/r7 register-window cascade.

cflat_r2class fuzzy 98.2876% -> 98.42099%; whole-DOL fuzzy 98.18879% -> 98.189766% (matched_code unchanged at 807776).

🤖 Generated with [Claude Code](https://claude.com/claude-code)