### PR TITLE
cflat_r2system: onSystemFunc case -0x1A shared modeBits hoist

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2078,6 +2078,7 @@ renderedDone:
     }
     case -0x1A: {
         const int mode = *object->m_localBase;
+        const unsigned int modeBits = mode & 3;
 
         float t = static_cast<float>(static_cast<int>(object->m_localBase[1])) /
                   static_cast<float>(static_cast<int>(object->m_localBase[2]));
@@ -2169,13 +2170,12 @@ renderedDone:
             *reinterpret_cast<float*>(object->m_localBase[4]) = result.y;
             *reinterpret_cast<float*>(object->m_localBase[5]) = result.z;
         } else {
-            int easeMode = mode & 3;
-            if (easeMode == 3) {
+            if (modeBits == 3) {
                 float s = std::sinf(kCFlatPi * t + kCFlatHalfPi);
                 t = kCFlatOneF - kCFlatHalfF * (kCFlatOneF + s);
-            } else if (easeMode == 1) {
+            } else if (modeBits == 1) {
                 t = kCFlatOneF + std::sinf(kCFlatHalfPi * t + kCFlatThreeHalfPi);
-            } else if (easeMode == 2) {
+            } else if (modeBits == 2) {
                 t = std::sinf(kCFlatHalfPi * t);
             }
 


### PR DESCRIPTION
Hoist `mode & 3` to a single function-scope `modeBits` in case -0x1A, matching the target's `uVar9 = mode & 3` which is computed once and shared between the `(mode & 4)` test region and the easing-mode `== 3/1/2` chain. Eliminates one redundant `clrlwi` (the ease branch previously recomputed `mode & 3` into a separate `easeMode` local).

Unit fuzzy 97.32954% -> 97.33389%, DOL matched_code unchanged (807776).

🤖 Generated with [Claude Code](https://claude.com/claude-code)