### PR TITLE
B4 long-tail A: structural fixes (cycle 1)

### DIFF
--- a/src/mapocttree.cpp
+++ b/src/mapocttree.cpp
@@ -750,8 +750,8 @@ void COctTree::ClearLight()
  */
 int CBound::CheckCross(CBound& other)
 {
-	bool xyOverlap;
 	bool overlap;
+	bool xyOverlap;
 	int xOverlap;
 
 	overlap = false;


### PR DESCRIPTION
## Genuine source fix

**mapocttree CCBound::CheckCross** (98.75% -> 99.61% fn): declared `overlap` before `xyOverlap`. The two bools share an initialization chain (`overlap = false; xyOverlap = overlap;`); declaration order determines their register roles. Reordering matched the target's r5/r6 assignment, dropping 6 structural flags to 1. The residual flag is a backend const-prop tie-break (`mr r6,r5` vs `li r6,0` on the `xyOverlap = overlap` copy) — not source-steerable.

## Triaged clean (residual = compiler class)

- **util/ConvI2FVector, ConvF2IVector(2d)**: int<->float double-bias conversion; pure FPR-numbering + anonymous-double-pool naming. div-hoist and symmetric-local variants regressed/bit-identical.
- **util/GetSplinePos**: FPR-renumbering throughout + one named-vs-anonymous float-pool flag (`kUtilOne@sda21` vs `@437@sda21`); source already references `kUtilOne`.
- **game/LoadScript, SaveScript**: zero-rematerialization tie-break (target two `li 0`, ours one `li`+`mr`); decl reorders regressed.
- **game/ChangeMap**: GPR-numbering (r4/r5 swap) + one MapPcs@l scheduling slip.
- **memory/alloc (CStage)**: split-block pointer-advance CSE/addressing tie-break; split1-early rewrite regressed.
- **memory/AddRef, Release, SetData**: zero-share register role + cntlzw-bool `rlwinm` mask-width backend artifact + short-index liveness.
- **gobject/IsAnimFinished**: early-blr vs merged-epilogue return tie-break; result-funnel rewrite regressed.
- **gobjwork/Init(CMonWork), GetNextCmdListIdx**: pointer-walk-vs-indexed strength-reduction; parameter-register allocation priority.
- **partyobj/putTargetParticle, statPut, SetBonusCondition**: named-vs-anonymous float-pool (FLOAT_80331xxx, source already uses named consts — data-layout wall) + stack-window + register-numbering.
- **partMng/pppGetNumFreePppMngSt**: loop-recognition (mtctr/bdnz vs subic./bne); for-loop conversion regressed hard.
- **mapobj/CheckHitCylinder(Near)**: equal-const-zero remat (cmake-c36 class, confirmed walled per memory).
- **mapanim/Interp**: pure register-numbering window.

## DOL
No regression; CheckCross net-positive (5 structural flags -> 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)