### PR TITLE
B4: cast-hoist associativity fixes (cycle 1)

### DIFF
--- a/src/charaobj.cpp
+++ b/src/charaobj.cpp
@@ -2963,7 +2963,8 @@ void CGCharaObj::setSta(int staIndex, int value)
 		}
 	}
 
-	reinterpret_cast<SCharaStaBlock*>(m_scriptHandle)->m_sta[staIndex] = static_cast<short>(clampedValue);
+	SCharaStaBlock* staStore = reinterpret_cast<SCharaStaBlock*>(m_scriptHandle);
+	staStore->m_sta[staIndex] = static_cast<short>(clampedValue);
 }
 
 /*


### PR DESCRIPTION
Generalizes the cast-hoist-associativity lever (PR #17610) across B4.

## Fix
- **charaobj::setSta** (97.79693% -> 97.812035% unit): the last `reinterpret_cast<SCharaStaBlock*>(m_scriptHandle)->m_sta[staIndex] = ...` inline cast emitted `sthx r30, r3, r0` (member offset 0x3e folded into the base via a separate `addi`, index applied x-form). Hoisted the cast to a named `SCharaStaBlock* staStore` local, flipping the index/offset associativity so mwcc now emits `sth r30, 0x3e(r3)` matching the target `add base,base,idx` + displacement form. The store-line addressing now matches (the residual `r30` vs `r31` on that line is a separate register-window numbering issue). DOL matched_code unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)