### PR TITLE
FunnyShape: x0 viewport coord s32 not u32 (matched_data +100 bytes)

### DIFF
--- a/src/FunnyShape.cpp
+++ b/src/FunnyShape.cpp
@@ -301,7 +301,7 @@ void CFunnyShape::RenderShape(FS_tagOAN3_SHAPE* shape, Vec2d offset, float angle
                 _GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_COPY);
             }
 
-            const u32 x0 = Div16Floor(S16At(entry, 0x10));
+            const s32 x0 = Div16Floor(S16At(entry, 0x10));
             const s32 y0 = Div16Floor(S16At(entry, 0x12));
             const s32 x1 = Div16Floor(S16At(entry, 0x14));
             const s32 y1 = Div16Floor(S16At(entry, 0x16));


### PR DESCRIPTION
RenderShape's `x0` was `u32` while its siblings `y0/x1/y1` (identical `Div16Floor(S16At(...))` signed viewport coords) are `s32` — a latent type inconsistency. The unsigned->float conversion emitted an extra `0x4330000000000000` bias double into `.sdata2` the target lacks. Fixing `x0` to `s32` removes it.

Verified at merge parent: **matched_code byte-identical (no exact-code loss), matched_data +0.0067pp (+100 exact bytes)**, FunnyShape unit data 26.67%->60.0%. The small fuzzy dip (-0.0009) is a downstream register-numbering cascade in the texcoord block — compiler register-allocation residual, not an exact-byte regression. Net-positive on exact bytes (the 100%-match goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)