### PR TITLE
B4: matched_data fixes (cycle 1)

### DIFF
--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -53,15 +53,15 @@ extern const float kGraphicSphereNegativeX = -1.0f;
 extern const double kGraphicHalfF64 = 4503599627370496.0;
 extern const float kGraphicSpherePi = 3.1415927410125732f;
 extern const double DOUBLE_8032F6E8 = 4503601774854144.0;
-extern const float kGraphicSmallBackTextureWidth;
-extern const float kGraphicSmallBackTextureHeight;
+extern const float kGraphicSmallBackTextureWidth = 320.0f;
+extern const float kGraphicSmallBackTextureHeight = 224.0f;
 extern const float FLOAT_8032F6F8 = 16777215.0f;
 extern const float FLOAT_8032F6FC = 0.7f;
 extern const float kGraphicSphereRingDivisor = 6.0f;
 extern const float kGraphicSphereSegmentAngle = 0.7853981852531433f;
-extern const float kGraphicBlurAlphaScale;
-extern const float kGraphicNoiseTexScaleU;
-extern const float kGraphicNoiseTexScaleV;
+extern const float kGraphicBlurAlphaScale = -100.0f;
+extern const float kGraphicNoiseTexScaleU = 0.015625f;
+extern const float kGraphicNoiseTexScaleV = 0.010416667163372f;
 extern const char sGraphicUnknownOrderName[4] = "---";
 
 static inline float CameraNearZ()
@@ -2059,8 +2059,3 @@ void CGraphic::DestroyTempBuffer()
 	}
 }
 
-extern const float kGraphicSmallBackTextureWidth = 320.0f;
-extern const float kGraphicSmallBackTextureHeight = 224.0f;
-extern const float kGraphicBlurAlphaScale = -100.0f;
-extern const float kGraphicNoiseTexScaleU = 0.015625f;
-extern const float kGraphicNoiseTexScaleV = 0.010416667163372f;


### PR DESCRIPTION
Section-attribute data fix for main/graphic.

Five const floats (kGraphicSmallBackTextureWidth/Height, kGraphicBlurAlphaScale, kGraphicNoiseTexScaleU/V) were defined at the bottom of graphic.cpp as `extern const float X = ...;`, which landed them in .sdata and spawned duplicate anonymous .sdata2 pool slots. Moving the initializers up to their already-address-ordered declaration sites places them in .sdata2 at the correct offsets.

Verified at the merge parent (origin/main):
- DOL matched_data 91.72802 -> 91.73393 (+0.0059)
- DOL matched_code 43.543053 -> 43.543053 (unchanged, no regression)
- DOL fuzzy 98.195366 -> 98.195366 (unchanged)
- main/graphic .sdata2 75% -> 100%; unit data 97.91% -> 98.10%; code held at 73.91%

🤖 Generated with [Claude Code](https://claude.com/claude-code)