### PR TITLE
B4: signedness/width type fixes (cycle 1)

### DIFF
--- a/include/ffcc/p_menu.h
+++ b/include/ffcc/p_menu.h
@@ -796,7 +796,7 @@ public:
     int m_singleMenuTextureLoadIndex;
     int m_singleMenuTextureLoadState;
     union {
-        unsigned short m_battleStateFlag;
+        short m_battleStateFlag;
         short m_cmdLayoutFlag;
         short m_singleMenuMode;
     };

--- a/src/wm_menu.cpp
+++ b/src/wm_menu.cpp
@@ -11508,7 +11508,7 @@ LAB_next:
 				fontF8->SetColor(CColor(0xFF, 0xFF, 0xFF, 0xFF).color);
 				fontF8->SetTlut(0x19);
 				const unsigned int msgId =
-					__cntlzw(static_cast<unsigned int>(static_cast<int>(*reinterpret_cast<char*>(slotData + 0x42)))) >> 5;
+					static_cast<unsigned int>(__cntlzw(static_cast<unsigned int>(static_cast<int>(*reinterpret_cast<char*>(slotData + 0x42))))) >> 5;
 				const int width = static_cast<int>(fontF8->GetWidth(const_cast<char*>(GetMcStr(msgId))));
 				const double* pHd1 = &DOUBLE_803313F8;
 				const float* pD8f1 = &FLOAT_803314D8;


### PR DESCRIPTION
Signedness/width type-consistency audit across B4 low-fuzzy functions. Each fix corrects a local/member/cast whose signedness was wrong vs the target's instruction.

- **MenuUtil** `DrawHelpMessageUS`: `m_battleStateFlag` was `unsigned short` in a union whose other members (`m_cmdLayoutFlag`, `m_singleMenuMode`) are signed `short`. The `static_cast<int>(m_battleStateFlag)` read sign-extends in the target (`lha`) but ours zero-extended (`lhz`). Made it signed `short` to match. MenuUtil fuzzy 96.269 -> 96.281, DOL fuzzy up, matched_code/data held.
- **wm_menu** `DrawMCList`: the `__cntlzw(...) >> 5` msgId computation treated the (non-negative) cntlzw result as signed `int`, emitting an arithmetic `srawi`; the sibling site already wraps it in `static_cast<unsigned int>`. Wrapping here matches the target's logical `srwi r19,r0,5`. wm_menu fuzzy 95.036 -> 95.038, DOL fuzzy up, matched_code held.

matched_code and matched_data held exactly (no exact bytes lost); DOL fuzzy net up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)