### PR TITLE
B4: optimize_for_size unroll cracks (cycle 1)

### DIFF
--- a/src/gbaque.cpp
+++ b/src/gbaque.cpp
@@ -3551,6 +3551,7 @@ void GbaQueue::SetShopFlg(int channel)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma optimize_for_size on
 int GbaQueue::GetEquipData(int channel, unsigned char* outData)
 {
 	unsigned char localPlayerData[0xDC];
@@ -3574,19 +3575,15 @@ int GbaQueue::GetEquipData(int channel, unsigned char* outData)
 	equipCount = 0;
 	itemPtr = localPlayerData;
 	indexPtr = equipIndices;
-	itemIndex = 0;
-	remaining = 0x40;
-	do {
+	for (i = 0; i < 0x40; i++) {
 		short itemId = *reinterpret_cast<short*>(itemPtr + 0x3A);
 		if ((itemId >= 0) && (itemId <= 0x9E)) {
-			*indexPtr = static_cast<unsigned char>(itemIndex);
+			*indexPtr = static_cast<unsigned char>(i);
 			equipCount++;
 			indexPtr++;
 		}
 		itemPtr += 2;
-		itemIndex++;
-		remaining--;
-	} while (remaining != 0);
+	}
 
 	int indexBytesS = equipCount + 1;
 	if ((indexBytesS & 3) != 0) {
@@ -3615,6 +3612,7 @@ int GbaQueue::GetEquipData(int channel, unsigned char* outData)
 
 	return dataSize;
 }
+#pragma optimize_for_size off
 
 /*
  * --INFO--


### PR DESCRIPTION
## gbaque GetEquipData — #pragma optimize_for_size on (96.82471% -> 96.82594%)

The first equip-scan loop was a hand-managed `do/while` countdown emitting
`subic./bne`, whereas the target uses a `mtctr`/`bdnz` single-body CTR loop.

- Rewriting it as `for (i = 0; i < 0x40; i++)` triggers the target's `mtctr`,
  but mwcc then re-unrolls the body x2.
- Scoped `#pragma optimize_for_size on` suppresses that re-unroll, collapsing
  back to the target's single-body CTR loop (identical 105-instr length,
  matched stmw/lmw frame).

Residual is the canonicalized callee-saved register-window permutation
(r26/r27/r29 rotation) — a backend RA tie-break, not source-steerable.

DOL: matched_code unchanged (807776), matched_functions unchanged (3932),
fuzzy 98.19551 -> 98.19553. No regressions; pragma scoped to GetEquipData only.

### Candidates probed, net-negative (reverted, not included)
- partMng `pppGetNumFreePppMngSt`: `for`+size DID collapse the unroll to
  mtctr/bdnz, but introduced a cursor-vs-base+offset register coloring
  (`add r5,r3,r4` recompute) that nets below the do/while baseline (98.033).
- ringmenu `onCalc`: `for`+size hurt the surrounding float-heavy code
  (96.454 -> 95.989); loop fully unrolled away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)