### PR TITLE
B4 mid-tier: second-pass structural fixes

### DIFF
--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1889,8 +1889,8 @@ void CFlatRuntime2::drawLayer(
 	GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_S16, 0);
 	int tevStage = TextureMan.SetTextureTev(texture);
 
-	scaleX = static_cast<float>(width) * scaleX;
 	scaleY = static_cast<float>(height) * scaleY;
+	scaleX = static_cast<float>(width) * scaleX;
 	int u1 = texU + width;
 	int v1 = texV + height;
 	float xAnchor;


### PR DESCRIPTION
Second-pass structural re-attack on mid-tier B4 functions with the new lever set (cast-hoist, volatile-pipelining, float-store, signedness/width, CSE-hoist).

## Landed
- **cflat_runtime2 drawLayer**: reordered the `scaleY`/`scaleX` reassignment so `scaleY = height*scaleY` precedes `scaleX = width*scaleX`, nudging the FPR coloring. Unit 99.10354 -> 99.107445%.

## Re-confirmed compiler walls (no source lever found; net-negative or bit-identical)
- **RedExecute GetRandomData / PitchCompute / _PitchExecute**: GetRandomData = post-increment `addi` scheduling tie-break (post-inc inline regressed). PitchCompute = two synthesized magic-divide (`/12`, `%12`) chains sharing one `mulhw`, pure scheduling/scratch-reg numbering (shared-magic rewrite regressed). _PitchExecute = single `adjustedPitchDelta` spill-to-stack-vs-callee-saved decision drives a whole-function window shift (decl swap bit-identical).
- **gbaque GetEquipData / GetCmdData**: GetEquipData first loop wants `subfic/mtctr/bdnz` (CTR, no unroll) but the original do/while gives `subic./bne` and every counted-loop form triggers an x4 unroll that `opt_unroll_loops off` does not suppress. GetCmdData = Game-base recompute-vs-hoist downstream of a register-window shift; removing the `game` local regressed.
- **pppKeShpTail2X pppKeShpTail2XDraw**: uniform callee-saved FPR band permutation (target f14-f23 / ours f22-f31, same save count) + `byte==0`->bool `srwi`-vs-`extrwi` mask codegen + named-vs-anonymous int->double bias relocs (zero fuzzy cost). Allocation-priority wall.
- **joybus GBARecvSend**: 679-line function dominated by a +2/+3 callee-saved register-numbering shift (result held in callee-saved then `mr r5,rN` for SetQueue), the documented result-in-rN family.
- **p_graphic drawBar**: confirmed at ceiling per prior cycles — inlined drawSFRect GX-FIFO vertex register-window (r5/r6 + f2/f3) and the `useDebugPad=drawText=0` bool-normalize `srwi`, both unsteerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)