### PR TITLE
cflat_r2system: onSystemFunc round 13

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3011,8 +3011,9 @@ renderedDone:
     }
     case -0x56: {
         int index = m_debugDataIndex;
+        const unsigned int value = *object->m_localBase;
         m_debugDataIndex = index + 1;
-        m_debugDataBuffer[index] = *object->m_localBase;
+        m_debugDataBuffer[index] = value;
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3717,10 +3717,6 @@ renderedDone:
         break;
     case -0xC5: {
         const float* localFloats = reinterpret_cast<float*>(object->m_localBase);
-        CVector position(
-            localFloats[4],
-            localFloats[5],
-            localFloats[6]);
         MapMng.SetMapObjWorldMapLightID(
             *object->m_localBase,
             CColor(
@@ -3728,7 +3724,7 @@ renderedDone:
                 static_cast<u8>(object->m_localBase[2]),
                 static_cast<u8>(object->m_localBase[3]),
                 0xFF),
-            position);
+            CVector(localFloats[4], localFloats[5], localFloats[6]));
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2597,11 +2597,8 @@ renderedDone:
         break;
     case -0x38: {
         const float* localFloats = reinterpret_cast<float*>(object->m_localBase);
-        CVector position(
-            localFloats[0],
-            localFloats[1],
-            localFloats[2]);
-        this->SetParticleWorkPos(position, localFloats[3]);
+        this->SetParticleWorkPos(
+            CVector(localFloats[0], localFloats[1], localFloats[2]), localFloats[3]);
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3765,8 +3765,8 @@ renderedDone:
         outResult = 0;
         break;
     case -0xC9: {
-        const float* localFloats = reinterpret_cast<float*>(object->m_localBase);
         int mapObjIndex = MapMng.GetMapObjIdx(static_cast<unsigned short>(*object->m_localBase));
+        const float* localFloats = reinterpret_cast<float*>(object->m_localBase);
         MapMng.SetMapObjTransRate(
             mapObjIndex, localFloats[1], localFloats[2], localFloats[3]);
         this->push(object, 0);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4109,7 +4109,7 @@ renderedDone:
         PartPcs.pppSetDebugHide(static_cast<unsigned char>(*object->m_localBase));
         this->push(object, 0);
         outResult = 0;
-        break;
+        // fallthrough
     case -0xF5:
         Sound.SeMaxVolume(*object->m_localBase);
         this->push(object, 0);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3742,18 +3742,20 @@ renderedDone:
         this->push(object, 0);
         outResult = 0;
         break;
-    case -0xC7:
+    case -0xC7: {
         const float* localFloats = reinterpret_cast<float*>(object->m_localBase);
         MenuPcs.m_battleHud.m_worldPos[0] = localFloats[0];
         MenuPcs.m_battleHud.m_worldPos[1] = localFloats[1];
         MenuPcs.m_battleHud.m_worldPos[2] = localFloats[2];
-        if (static_cast<int>(object->m_localBase[3]) < MenuPcs.m_battleHud.m_gaugeTarget) {
+        const int gaugeTarget = object->m_localBase[3];
+        if (gaugeTarget < MenuPcs.m_battleHud.m_gaugeTarget) {
             MenuPcs.m_battleHud.m_gaugeCounter = 0x10;
         }
-        MenuPcs.m_battleHud.m_gaugeTarget = object->m_localBase[3];
+        MenuPcs.m_battleHud.m_gaugeTarget = gaugeTarget;
         this->push(object, 0);
         outResult = 0;
         break;
+    }
     case -0xC8:
         if (GetNumMes__9CFlatDataFv(&System) >= 3U) {
             System.Printf(const_cast<char*>("\201\254\201\254\203X\203N\203\212\203v\203g\202\251\202\347cancelWaveAsync\202\265\202\334\202\265\202\275\201B\n"));

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2923,14 +2923,13 @@ renderedDone:
             }
             this->push(object, 0);
             outResult = 0;
-            break;
+        } else {
+            if (MenuPcs.GetMesMenu(a0)->IsUse() == 0) {
+                this->push(object, 0);
+                outResult = 0;
+            }
         }
-        if (MenuPcs.GetMesMenu(a0)->IsUse() == 0) {
-            this->push(object, 0);
-            outResult = 0;
-            break;
-        }
-        return 1;
+        break;
     }
     case -0x4F:
         MapMng.SetMeshCameraSemiTransRange(

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3477,16 +3477,14 @@ renderedDone:
         outResult = 0;
         break;
     case -0x9C: {
-        int cameraSlot = *object->m_localBase;
         int cameraFrame = object->m_localBase[1];
-        if ((CharaPcs.m_cameraData[cameraSlot] == 0) || (cameraFrame < 0) ||
-            (CharaPcs.m_cameraFrameCount[cameraSlot] <= cameraFrame)) {
+        CCharaPcs::CCameraFrame*& cameraSlotRef = CharaPcs.m_cameraData[*object->m_localBase];
+        if ((cameraSlotRef == 0) || (cameraFrame < 0) ||
+            (CharaPcs.m_cameraFrameCount[*object->m_localBase] <= cameraFrame)) {
             this->push(object, 0);
             outResult = 0;
-            break;
         }
 
-        CCharaPcs::CCameraFrame*& cameraSlotRef = CharaPcs.m_cameraData[cameraSlot];
         *reinterpret_cast<float*>(object->m_localBase[2]) = cameraSlotRef[cameraFrame].m_values[0].m_float;
         *reinterpret_cast<float*>(object->m_localBase[3]) = -cameraSlotRef[cameraFrame].m_values[1].m_float;
         *reinterpret_cast<float*>(object->m_localBase[4]) = -cameraSlotRef[cameraFrame].m_values[2].m_float;

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -3019,8 +3019,9 @@ renderedDone:
     }
     case -0x57: {
         int index = m_debugDataIndex;
+        const float value = *reinterpret_cast<float*>(object->m_localBase);
         m_debugDataIndex = index + 1;
-        m_debugDataBuffer[index] = *object->m_localBase;
+        m_debugDataBuffer[index] = *reinterpret_cast<const int*>(&value);
         this->push(object, 0);
         outResult = 0;
         break;


### PR DESCRIPTION
Round 13 on \`onSystemFunc\` (main/cflat_r2system). NINE source fixes, unit fuzzy 97.43554% -> 97.81782% (+0.382), whole-DOL matched_code flat at 807776 (no regression).

Cases fixed (each verified Ghidra-aligned, each its own commit):
- **-0x4D**: replaced explicit \`return 1\` in the IsUse()!=0 path with Ghidra's if/else-then-break so the case falls through to the shared \`return 1\` epilogue instead of an inline \`li r3,1; b\` block.
- **-0x57**: debug-data store reads the localBase value as a float (lfs) through a stack local then stores its bit pattern as int (stw) — float-load/int-store round-trip, distinct from -0x56's direct integer move.
- **-0x56**: read \`*object->m_localBase\` into a temp before bumping m_debugDataIndex, matching target's value-lwz-ahead-of-counter ordering.
- **-0x38**: pass the CVector inline as a temporary so the ctor's \`this\` return flows straight into \`__opR3Vec\` (no stack-addr reload).
- **-0x9C**: the camera-frame validity guard does push(0)/outResult=0 but does NOT break — it falls through into the unconditional copy + push(1); also hoisted cameraSlotRef before the guard.
- **-0xC7**: hoisted \`m_localBase[3]\` into a named local (CSE) so it is loaded once and reused for both the compare and the m_gaugeTarget store.
- **-0xC9**: declared localFloats after GetMapObjIdx so localBase is reloaded post-call instead of held in a callee-saved reg.
- **-0xC5**: pass the position CVector inline as a temporary (ct-then-immediate-opR3Vec), no reload.
- **-0xF4**: removed the break so the case falls through into -0xF5, matching Ghidra.

Ceiling assessment: remaining residual is dominated by known walls — the case -8 Printf-parser callee-saved register-band permutation, the spline (-0x1A) int-to-double conversion + phantom-point CVector-operator allocation, mixed int/float arg scheduling (SetDOFParameter/SetBlurParameter), the \`& N\` -> clrlwi-vs-(li N; and) backend constant-materialization choice (-0xE3/-0x61, same eager-li wall as gobject c31), the function-wide r28/r29 outResult-pointer window, and the subi-vs-addi@l reloc-naming on the CameraPcs/CharaPcs/Math/Game/GraphicPcs bases. Several remaining CVector-arg cases (-0x1B, -0x39, CcClass2D -0xC4) were tested for the inline-temporary lever and REGRESSED or were neutral, so they were left as-is. Likely near the practical ceiling for source-steerable gains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)