### PR TITLE
cflat_r2system: onSystemFunc round 14

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -1794,7 +1794,7 @@ int CFlatRuntime2::onSystemFunc(CFlatRuntime::CObject* object, int, int systemFu
         if ((DbgMenuPcs.GetDbgFlag() & 0x100) != 0) {
             buttons &= ~0xC00;
         }
-        this->push(object, static_cast<short>(buttons));
+        this->push(object, buttons);
         outResult = 0;
         break;
     }
@@ -1932,7 +1932,7 @@ renderedDone:
         if ((DbgMenuPcs.GetDbgFlag() & 0x100) != 0) {
             buttons &= ~0xC00;
         }
-        this->push(object, static_cast<short>(buttons));
+        this->push(object, buttons);
         outResult = 0;
         break;
     }
@@ -1946,7 +1946,7 @@ renderedDone:
         if ((DbgMenuPcs.GetDbgFlag() & 0x100) != 0) {
             buttons &= ~0xC00;
         }
-        this->push(object, static_cast<short>(buttons));
+        this->push(object, buttons);
         outResult = 0;
         break;
     }

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2550,7 +2550,7 @@ renderedDone:
         const float angle2 = localFloats[2];
         Vec axis;
         axis.x = std::cosf(angle1);
-        axis.y = 0.0f;
+        axis.y = kCFlatPadStickZero;
         axis.z = std::sinf(angle1);
         Mtx matrix;
         Mtx rotation;
@@ -2563,9 +2563,9 @@ renderedDone:
         PSMTXRotAxisRad(rotation, &axis, angle2);
         PSMTXConcat(rotation, matrix, matrix);
 
-        axis.x = 0.0f;
-        axis.y = 1.0f;
-        axis.z = 0.0f;
+        axis.x = kCFlatPadStickZero;
+        axis.y = kCFlatOneF;
+        axis.z = kCFlatPadStickZero;
         PSMTXRotAxisRad(rotation, &axis, localFloats[3]);
         PSMTXConcat(rotation, matrix, matrix);
         CameraPcs.SetWorldMapMatrix(matrix);

--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -70,6 +70,8 @@ extern const float FLOAT_80330B44;
 extern const float FLOAT_80330B48;
 extern const float FLOAT_80330B4C;
 extern const float FLOAT_80330B5C;
+extern const float FLOAT_80330B60;
+extern const float FLOAT_80330B68;
 extern const float FLOAT_80330B88;
 extern const float FLOAT_80330B8C;
 extern const float FLOAT_80330B90;
@@ -2728,14 +2730,15 @@ renderedDone:
     }
     case -0xB4:
         PartMng.pppSetDeltaSlot(
-            *object->m_localBase, static_cast<long>(0.25f * *reinterpret_cast<float*>(object->m_localBase + 1)));
+            *object->m_localBase,
+            static_cast<long>(FLOAT_80330B60 * *reinterpret_cast<float*>(object->m_localBase + 1)));
         this->push(object, 0);
         outResult = 0;
         break;
     case -0xB5:
         PartMng.pppSetDeltaIdx(
             static_cast<short>(*object->m_localBase),
-            static_cast<long>(0.25f * *reinterpret_cast<float*>(object->m_localBase + 1)));
+            static_cast<long>(FLOAT_80330B60 * *reinterpret_cast<float*>(object->m_localBase + 1)));
         this->push(object, 0);
         outResult = 0;
         break;
@@ -2935,7 +2938,7 @@ renderedDone:
             *reinterpret_cast<float*>(object->m_localBase + 2),
             *reinterpret_cast<float*>(object->m_localBase + 3),
             *reinterpret_cast<float*>(object->m_localBase + 4),
-            (kCFlatDegrees180 * (2.0f * *reinterpret_cast<float*>(object->m_localBase + 5))) /
+            (kCFlatDegrees180 * (FLOAT_80330B68 * *reinterpret_cast<float*>(object->m_localBase + 5))) /
                 kCFlatPi);
         this->push(object, 0);
         outResult = 0;


### PR DESCRIPTION
Round 14 grind on main/cflat_r2system onSystemFunc (97.81782% -> 97.89464%).

Cases fixed:
- cases -5/-0xB/-0xC: drop redundant `static_cast<short>` on the push value (buttons is already `short`; the implicit short->int promotion defers the `extsh` to after the this/object arg setup, matching target). +6 flags, the highest-yield fix this round.
- case -0x34: use `kCFlatPadStickZero`/`kCFlatOneF` named consts instead of `0.0f`/`1.0f` literals (axis Vec init) so the sda21 refs resolve to the named symbols instead of anonymous pool entries. +3 flags.
- cases -0xB4/-0xB5/-0x4F: use `FLOAT_80330B60` (0.25f) and `FLOAT_80330B68` (2.0f) named externs instead of literals. +3 flags.

DOL matched_code unchanged at 807776 (no regression); matched_functions stable at 80/84.

Ceiling assessment: remaining residual is the confirmed-compiler wall set — the case-8 Printf-parser register-band + anonymous switch-jumptable naming, the spline divide-block control-shape, the message-menu string-pool offset divergence (0x4c/0x28, 0xe8/0xd4 stem from target keeping short JIS strings as named sdata2 symbols while ours pools them in rodata), the pervasive r28/r29 outResult+rodata-base allocation window, the DOUBLE_80330B98 int-to-double bias named-vs-anonymous pool, and FPR-numbering tie-breaks (f2/f3 on `1.0 - 0.5*(1.0+s)`). None are source-steerable without major string-table restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)