### PR TITLE
cflat_r2class: onClassSystemFunc round 11 (new levers)

### DIFF
--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1637,7 +1637,12 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 			break;
 		}
 		case -0x5F:
-			if (engineObject->m_charaModelHandle != 0 && PartMng.pppIsDeadCHandle(engineObject->m_charaModelHandle) != 0) {
+			if (engineObject->m_charaModelHandle != 0) {
+				if (PartMng.pppIsDeadCHandle(engineObject->m_charaModelHandle) != 0) {
+					PushValue(this, object, 0);
+					outResult = 0;
+				}
+			} else {
 				PushValue(this, object, 0);
 				outResult = 0;
 			}

--- a/src/cflat_r2class.cpp
+++ b/src/cflat_r2class.cpp
@@ -1816,7 +1816,7 @@ int CFlatRuntime2::onClassSystemFunc(CFlatRuntime::CObject* object, int, int com
 		case -0x79: {
 			signed char animList[8];
 			int animCount = 0;
-			int argCount = object->m_argCount - 1;
+			int argCount = reinterpret_cast<CFlatRuntime::CObject*>(engineObject)->m_argCount - 1;
 			if (argCount > 0) {
 				animList[0] = static_cast<signed char>(object->m_localBase[1]);
 				animCount = 1;


### PR DESCRIPTION
Applied the new Ghidra-driven lever set (developed on the sibling onSystemFunc r12-15) to onClassSystemFunc. cflat_r2class 98.42099% -> 98.60275% fuzzy; DOL matched_code held at 807776 (no regression).

## Fixes
- **case -0x5F** (missing-break / control-flow restructure, lever #1): Ghidra ground truth shows the case is nested if/else, not a single `&&`. Rewrote `if(handle!=0 && pppIsDead) push` into `if(handle==0) push; else if(pppIsDead) push`, so the handle==0 push block is emitted last (trailing-else order) exactly like the target. Fully matches the case (+0.18).
- **case -0x79** (wrong-base correction, Ghidra census): the case read `object->m_argCount` (r30) but Ghidra shows `m_argCount` is read off engineObject (r31). Switched to `engineObject`'s m_argCount; target `lha r3,0x36(r31)` now matches.

## Confirmed walls (left untouched, per SKIP list / Ghidra)
- `__opP3Vec` inserts on SetPosBG/moveVector/moveVectorH: class-B (no intervening call) — operator emitted unavoidably; inline-CVector tested, regressed.
- -0x7D polarity, -0x79 comparison loop-form (`subic./cmpwi` vs `subi/cmpw`), AnimStateWarn reloc-naming, value-eval-order scheduling (lines 1274/2122/1464), -0x8E carry base-CSE: all backend tie-breaks, not source-steerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)