### PR TITLE
cflat_runtime: new-lever pass

### DIFF
--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -181,7 +181,7 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 						while (true) {
 							char specChar;
 							int specLen = 0;
-							while (((specChar = *format) != '\0') && ((specLen == 0) || (specChar != '%'))) {
+							while (((specChar = *format) != '\0') && ((specLen == 0) || ((specLen != 0) && (specChar != '%')))) {
 								format++;
 								spec[specLen] = specChar;
 								specLen++;

--- a/src/cflat_runtime.cpp
+++ b/src/cflat_runtime.cpp
@@ -310,8 +310,8 @@ int CFlatRuntime::systemFunc(CFlatRuntime::CObject* object, int systemKind, int 
 			goto done;
 		}
 		case -2: {
-			CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
 			const u32 scriptGroup = *object->m_localBase;
+			CObject* const engineObject = reinterpret_cast<CObject*>(object->m_engineObject);
 
 			engineObject->m_next->m_previous = engineObject->m_previous;
 			engineObject->m_previous->m_next = engineObject->m_next;

--- a/src/cflat_runtime2.cpp
+++ b/src/cflat_runtime2.cpp
@@ -1626,20 +1626,16 @@ void CFlatRuntime2::Draw()
  */
 void CFlatRuntime2::AddDebugDrawCC(Vec* from, Vec* to, float radius, int bit7, int bit6)
 {
-	u8* runtime = reinterpret_cast<u8*>(this);
-	int& count = DebugDrawCCCount(runtime);
+	if (static_cast<unsigned int>(m_debugDrawCCCount) < 0x10U) {
+		m_debugDrawCCEntries[m_debugDrawCCCount].m_from = *from;
+		m_debugDrawCCEntries[m_debugDrawCCCount].m_to = *to;
 
-	if (static_cast<unsigned int>(count) < 0x10U) {
-		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_from = *from;
-		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_to = *to;
+		m_debugDrawCCEntries[m_debugDrawCCCount].m_flagBits.m_bit7 = bit7;
+		m_debugDrawCCEntries[m_debugDrawCCCount].m_flagBits.m_bit6 = bit6;
 
-		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_flagBits.m_bit7 = bit7;
-		reinterpret_cast<CFlatRuntime2*>(runtime)->m_debugDrawCCEntries[count].m_flagBits.m_bit6 = bit6;
-
-		const int index = count;
-		count = index + 1;
-		CFlatRuntime2::CDebugDrawCC* entry = reinterpret_cast<CFlatRuntime2::CDebugDrawCC*>(&count + 1) + index;
-		entry->m_radius = radius;
+		const int index = m_debugDrawCCCount;
+		m_debugDrawCCCount = index + 1;
+		m_debugDrawCCEntries[index].m_radius = radius;
 		return;
 	}
 


### PR DESCRIPTION
New-lever pass on main/cflat_runtime and main/cflat_runtime2 (developed on onSystemFunc r12-15).

## Landed
- **systemFunc** (cflat_runtime): two fixes, 19 -> 6 flags.
  - *Control-shape*: restored the redundant inner spec-loop condition `(specLen != 0) && (specChar != '%')` (Ghidra ground truth) — re-emits the `beq` the target has, our simplified form dropped (19 -> 18).
  - *Defer/decl-order*: case -2 declares `scriptGroup` before `engineObject` — collapsed the entire r6<->r7 register window (18 -> 6). Remaining 6 are jumptable-naming + a 2-line scheduling tie-break (walls).
- **AddDebugDrawCC** (cflat_runtime2): 15 -> 0 flags (fully matched). Dropped the cached `int& count` reference and the manual-cast entry pointer; read `m_debugDrawCCCount` fresh each access via member-direct access (drop-ref-for-displacement). Restores the target's `-0x32e4(base)` big-displacement form vs our `lwzu`-rebased pointer.

## Result
- cflat_runtime: 97.5683% -> 97.6096%
- cflat_runtime2: 99.1074% -> 99.1350%
- DOL matched_code: 807776 -> 808080 (+304), fuzzy held

## Walled (verified, no net gain)
- getNumFreeObject: 4 dispatch-tail flags are a shared `li r3,0; blr` epilogue artifact; if-chain restructure (Ghidra shape) regressed to 149 flags — the switch form is the local max.
- Destroy: rebase-vs-displacement crackable, but the displacement form forces a 2nd callee-saved reg (`this` can't coalesce with the cursor across the two Destroy calls) -> net regress.
- CcClass2D: 5 flags all named-const-vs-anonymous-pool (`FLOAT_80330144`/`DOUBLE_8033016x` vs `@190x`); mwcc 2.4.2 never unifies its generated pool const with a same-valued named extern (R99 wall).
- resetSpawnBit: 5 flags are an r0<->r4 materialization tie-break (index-multiply vs zero const); ref-local respelling regressed.
- SystemCall/request/objectFrame: register-window band cascades from the documented frame-size walls (prevReqFlag0, 0xd0-vs-0xc0) — skipped per scope. GetCodeInfo/systemFunc residual: switch-jumptable-naming wall.
- CreateDebug: {r25-r28} 3-cursor loop-rotation band over nested-scope locals (createObject-class rotation wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)