### PR TITLE
B4: Ghidra wrong-base/member latent-bug fixes (cycle 1)

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -4167,9 +4167,8 @@ renderedDone:
         outResult = 0;
         break;
     case -0xFC:
-        *reinterpret_cast<int*>(reinterpret_cast<char*>(&DbgMenuPcs) + 0x10844) = *object->m_localBase;
-        *reinterpret_cast<unsigned int*>(reinterpret_cast<char*>(&DbgMenuPcs) + 0x10848) =
-            object->m_localBase[1];
+        AStar.m_flags = *object->m_localBase;
+        AStar.m_hitAttributeMask = object->m_localBase[1];
         this->push(object, 0);
         outResult = 0;
         break;

--- a/src/monobj.cpp
+++ b/src/monobj.cpp
@@ -571,7 +571,7 @@ void CGMonObj::setRepop(int mode)
 	if ((mode != 0) && (option = static_cast<int>(*reinterpret_cast<short*>(&Game.m_gameWork.m_optionValue)), option < 9)) {
 		unsigned long long bit = 1ULL << reinterpret_cast<int>(scriptHandle[2]);
 		unsigned long long spawnBits =
-			(static_cast<unsigned long long>(CFlatSpawnBitHi(option)) << 32) | CFlatSpawnBitLo(option);
+			(static_cast<unsigned long long>(CFlatSpawnBitLo(option)) << 32) | CFlatSpawnBitHi(option);
 		if ((spawnBits & bit) != 0) {
 			*reinterpret_cast<unsigned short*>(reinterpret_cast<unsigned char*>(scriptHandle) + 0x1C) = 0;
 			object->m_bgColMask = 0;

--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -3082,7 +3082,7 @@ void CGPartyObj::checkTargetParticle()
 	delta.y = deltaResult.y;
 	delta.z = deltaResult.z;
 	if (FLOAT_80331a78 < PSVECMag(&delta)) {
-		m_rotationY = atan2(delta.x, delta.z);
+		m_rotTargetY = atan2(delta.x, delta.z);
 	}
 }
 


### PR DESCRIPTION
Systematic cross-reference of member/base reads vs Ghidra across B4 handler/dispatch functions. Three Ghidra-confirmed latent bugs found and fixed (each a correctness bug + match improvement); DOL matched_code stable, no regression.

## Fixes

**1. cflat_r2system onSystemFunc case -0xFC — wrong global object**
Source wrote `*(int*)((char*)&DbgMenuPcs + 0x10844)` / `+0x10848`. Ghidra labeled this `DbgMenuPcs._10844_4_` (a nearest-symbol artifact), but `DbgMenuPcs(0x80306708)+0x10844 = 0x80316F4C` is not where the original writes. Target asm relocates against `AStar@ha/@l` and stores to `0x0(AStar)`/`0x4(AStar)` = `0x80309184`/`0x80309188` = `AStar.m_flags` / `AStar.m_hitAttributeMask`. Source was writing to an entirely wrong global; fixed to the named `AStar` members.

**2. partyobj checkTargetParticle — wrong member**
The `atan2(delta.x, delta.z)` result was stored into `m_rotationY` (this+0x178). Ghidra ground truth: `*(float*)(param_1 + 0x1b4) = (float)atan2(...)`, i.e. the member at this+0x1b4 = `m_rotTargetY`. Target asm stores to `0x1b4(this)`. Fixed `m_rotationY` -> `m_rotTargetY`.

**3. monobj setRepop — swapped spawn-bit hi/lo word pairing**
Source built `spawnBits = (CFlatSpawnBitHi<<32) | CFlatSpawnBitLo` then `& bit`, pairing m_lo(0x12f0) with the low word and m_hi(0x12f4) with the high word. Ghidra ground truth pairs them the OPPOSITE way: `field_0x12f4 & (uint)bit` (m_hi with low word) and `field_0x12f0 & (bit>>32)` (m_lo with high word). Swapped to `(Lo<<32)|Hi` so the word pairing and the CFlat load order match the target.

## Functions audited clean (register/CSE/scheduling, not member bugs)
gbaque (GetMapObjInfo, MakeSmithData — Ghidra-confirmed correct), onSystemFunc SetDOF/SetBlur arg loads, onClassSystemFunc carry, gobjwork CMonWork::Init (cursor-advance codegen), goout CalcGoOut, charaobj onDamage, monobj isValidTarget (no Ghidra ref), map SetIdGrpColor (case-order codegen wall, not a member bug — structural rewrites regressed), mapobj ReadOtmObj (known base-order wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)