### PR TITLE
cflat_r2system: onSystemFunc round 16

### DIFF
--- a/src/cflat_r2system.cpp
+++ b/src/cflat_r2system.cpp
@@ -2299,7 +2299,7 @@ renderedDone:
         const float margin = localFloats[4];
         int found = 0;
         unsigned int bestLine = 0;
-        float bestDistance = kLineBoundsInitMin;
+        float bestDistance = FLOAT_80330B5C;
         float bestLineDistance = 0.0f;
 
         CLine<64>* lines = m_debugLines;


### PR DESCRIPTION
Round 16 deep probe on main/cflat_r2system onSystemFunc.

## Fixed
- **case -0x22** (line bounds search): `bestDistance` init used `kLineBoundsInitMin` (extern from sound.cpp), but the target reloc at this site is `FLOAT_80330B5C` (same address 0x80330B5C, already declared extern in this unit). Switched to `FLOAT_80330B5C` — resolves one flagged instruction (flag count 1197->1196). matched_code (6364) and whole-DOL (808080) unchanged, no regression.

## Investigated, confirmed at-ceiling (walls)
- **case -99/-0x4E/-0x42 extra-mov** (`mr r0,r3 ... mr r4,r0` vs target `mr r4,r3`): backend push-arg scheduling / R104-R105 allocation tie-break. Inlining intToClass into the call (drop named local) REGRESSED 97.908->97.904. Not source-steerable.
- **case -0x26/-0x27 ease `0.5*(1+s)`** (f2/f0 vs f3/f2): FPR allocation-priority numbering, same wall family.
- **case -0x1A spline** (eager-vs-deferred fsubs/fdivs around CrossCheckEllipseCapsule): skip-listed scheduling wall, confirmed.
- **case-8 MesMenu Printf** (lbl_801DA3B0 vs ...rodata.0 string-pool base, @2954/@2953 jumptable naming): skip-listed TECHNIQUE Exec/string-pool walls.
- **r28/r29 outResult-pointer window + frame-size offset shift**: skip-listed, dominate the remaining flag count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)