### PR TITLE
B4 map/obj: full-lever sweep fixes

### DIFF
--- a/src/partyobj.cpp
+++ b/src/partyobj.cpp
@@ -4268,7 +4268,6 @@ void CGPartyObj::SetBonusCondition(int useRandom, int bonus0, int bonus1, int bo
 	System.Printf(const_cast<char*>(msgBase + 0x114), bonusCount);
 
 	int chosenBonus[4];
-	int* chosenWrite = chosenBonus;
 	int chosenCount = 0;
 	CGame::CBossArtifactStage* bossArtifacts =
 		&Game.m_bossArtifactBase[Game.m_gameWork.m_bossArtifactStageIndex];
@@ -4299,8 +4298,7 @@ void CGPartyObj::SetBonusCondition(int useRandom, int bonus0, int bonus1, int bo
 				}
 			}
 
-			*chosenWrite++ = bonusIndex;
-			chosenCount++;
+			chosenBonus[chosenCount++] = bonusIndex;
 
 			reinterpret_cast<CCaravanWork*>(party->m_scriptHandle)
 			    ->SetBonusCondition(bossArtifacts->m_bonusConditions[bonusIndex]);


### PR DESCRIPTION
## Full-lever sweep — main/{gobjwork,gobject,mapobj,maphit,mapanim,mapocttree,map,partMng,partyobj,monobj}

### Landed fix
- **partyobj SetBonusCondition** (94.21% fn): the `chosenBonus`/`chosenWrite` duplicate-tracking array used a separate advancing pointer cursor (`*chosenWrite++`) where the target indexes by count. Rewrote to `chosenBonus[chosenCount++] = bonusIndex;` (R12 inverse — indexed store matching target `stwx base,idx`), removed the now-dead `chosenWrite`. Collapsed the INSERT/DELETE/REPLACE around the store. Unit 98.41561 -> 98.4614, matched_code held.

All other examined functions confirmed at compiler residual ceiling (register-numbering / scheduling / pool-naming / one-body-two-contexts) — see PR notes.
🤖 Generated with [Claude Code](https://claude.com/claude-code)