### PR TITLE
pad: comprehensive sweep fixes

### DIFF
--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -379,8 +379,8 @@ static inline void MergePadInputs(CPad* pad, u16* puVar13, u16*& puVar18, u16* p
 			puVar7 = puVar7 + 1;
 		}
 		uVar17 = uVar17 + 1;
-		puVar13 = puVar13 + 6;
 		iVar6 = iVar6 + 0x54;
+		puVar13 = puVar13 + 6;
 		puVar18 = puVar18 + 2;
 	} while (uVar17 < 4);
 }


### PR DESCRIPTION
Comprehensive per-function sweep of main/pad.

## Landed fix
- **Frame: increment emission order** — swapped the per-port merge loop tail so `iVar6 += 0x54` precedes `puVar13 += 6`, matching the target's `addi` order. Resolved the two DIFF_ARG_MISMATCH flags at the loop back-edge. Frame 98.41% -> 98.44%, pad unit fuzzy 98.686% -> 98.712%. DOL matched_code unchanged (no regression).

## Walls confirmed (no source lever)
- Frame copy loops (replay record read/write) and the 4x abs-compare blocks: pure register-band permutations (R104/R105 allocation-priority numbering). Probe: reordering the abs LHS/RHS reads is canonicalized by mwcc (bit-identical).
- Frame `li r7,0` DELETE: eager-vs-deferred loop-counter zero materialization (documented gobject-c31/materialman-c23 backend scheduling wall).
- Float-pool naming (`kPadS32ToDoubleBias`/`kPadAnalogScale`/`kPadU32ToDoubleBias`/`kPadTriggerMax` vs anonymous `@NNN`): universal named-vs-anonymous sda2 pool reloc-metadata difference, zero byte cost.
- `__sinit_pad_cpp`: `pTable$692+0x2c` vs `__vt__4CPad` vtable-thunk symbol-naming, reloc-only, not source-steerable.

## Latent bugs
None found. Controller bitmask reads (signedness/width) all check out against Ghidra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)