### PR TITLE
p_minigame GbaThreadMain: group (0x16AC+self) in writeSrc addr calc (98.259->98.324%)

### DIFF
--- a/src/p_minigame.cpp
+++ b/src/p_minigame.cpp
@@ -942,7 +942,7 @@ context_proc:
             }
             else
             {
-                writeSrc = channel * 0x60 + (step - 1) * 4 + 0x16AC + self;
+                writeSrc = channel * 0x60 + (step - 1) * 4 + (0x16AC + self);
             }
             ret = GBAWrite(channel, writeSrc, param + 0xC0);
             if (!(ret == 0 && (param[0xC0] & GBA_JSTAT_FLAGS_MASK) == GBA_JSTAT_FLAGS_MASK))


### PR DESCRIPTION
## Summary
Single source fix in `CMiniGamePcs::GbaThreadMain` improving the unit's fuzzy match from 98.25869% to 98.32422% (+0.0655). matched_code and matched_data held non-decreasing.

In the `step != 0` GBAWrite path, the write-source address computation
```c
writeSrc = channel * 0x60 + (step - 1) * 4 + 0x16AC + self;
```
was reassociating `0x16AC` into the `(step-1)*4` term, producing the wrong add/addi grouping vs target. Grouping the constant with `self`:
```c
writeSrc = channel * 0x60 + (step - 1) * 4 + (0x16AC + self);
```
makes mwcc sum the two products first, then emit `addi ...,0x16ac`, matching the target's address-form. GbaThreadMain flagged lines 11 -> 6.

## Per-function sweep findings (no other net-positive lever)
- **GbaThreadMain** (5380B): fixed as above; residual 6 flags = jumptable anon-pool naming (zero scoreboard cost) + the writeSrc commutative-add register-window. Ceiling.
- **MngThreadMain** (2560B): 241 flags, dominated by uniform callee-saved register-NUMBERING window + prologue hoist-order. Existing PR #17604 pragma (oda/olt off) remains the local max. Walled.
- **MiniGameGo** (1492B): 125 flags = loop-entry runtime guard (target keeps `cmpwi 0xbd;bge`, ours const-folds) + unrolled-checksum accumulator register-window. Pragma sweep (for_size/strength_reduction/unroll/global_optimizer) all flat-or-worse. Walled.
- **OpenCallback** (980B): 16 flags = commutative-add operand-order (`add rD,r25,r0` vs `r0,r25`) + arg-save window across the `self + channel*0x60 + ofs` indexed accesses. Operand-order source swap had no effect; pragma sweep flat. Walled.
- **calc** (1244B): 1 flag = redundant tail `b` (backend tail-merge miss on case-2's if-exit vs post-if return). Inverted-guard restructure and pragma sweep (blockmerging/redundancy/etc) no effect. Ceiling.
- **create** (172B): 4 flags = constant-load scheduling order + whether the loop-prehoisted `1<<0` reuses the playerBit=0 register (`slw r0,r5,r6`) vs materializing a fresh zero. Register-window. Walled.

No latent member-offset/break bugs found vs Ghidra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)