### PR TITLE
RedExecute _KeyOnControl: inline shakeFunc in shake loops (98.18399->98.19264%)

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -2143,7 +2143,6 @@ static void _KeyOnControl()
     RedVoiceStartMask voiceStartMask;
     RedKeyOnSlot* reserve;
     RedVoiceDATA* voiceData;
-    RedSwingFunc waveFunc;
     int shakeDepth;
     RedSoundCONTROL* soundControl;
     RedTrackDATA* track;
@@ -2173,10 +2172,9 @@ static void _KeyOnControl()
         track = soundControl->m_tracks;
         do {
             if ((track->m_command != 0) && (track->m_shakeFunc != 0)) {
-                waveFunc = track->m_shakeFunc;
                 shakeDepth = (track->m_shakeDepth >> REDSOUND_FIXED_SHIFT) + 1;
                 track->m_shakePan =
-                    (shakeDepth * waveFunc((u32)track->m_shakeOutput >> REDSOUND_FIXED_SHIFT)) >>
+                    (shakeDepth * track->m_shakeFunc((u32)track->m_shakeOutput >> REDSOUND_FIXED_SHIFT)) >>
                     REDSOUND_SHAKE_PAN_SCALE_SHIFT;
                 track->m_shakeOutput += track->m_shakeRate;
             }
@@ -2190,10 +2188,9 @@ static void _KeyOnControl()
         track = soundControl->m_tracks;
         do {
             if ((track->m_command != 0) && (track->m_shakeFunc != 0)) {
-                waveFunc = track->m_shakeFunc;
                 shakeDepth = (track->m_shakeDepth >> REDSOUND_FIXED_SHIFT) + 1;
                 track->m_shakePan =
-                    (shakeDepth * waveFunc((u32)track->m_shakeOutput >> REDSOUND_FIXED_SHIFT)) >>
+                    (shakeDepth * track->m_shakeFunc((u32)track->m_shakeOutput >> REDSOUND_FIXED_SHIFT)) >>
                     REDSOUND_SHAKE_PAN_SCALE_SHIFT;
                 track->m_shakeOutput += track->m_shakeRate;
             }
@@ -2206,10 +2203,9 @@ static void _KeyOnControl()
         track = soundControl->m_tracks;
         do {
             if ((track->m_command != 0) && (track->m_shakeFunc != 0)) {
-                waveFunc = track->m_shakeFunc;
                 shakeDepth = (track->m_shakeDepth >> REDSOUND_FIXED_SHIFT) + 1;
                 track->m_shakePan =
-                    (shakeDepth * waveFunc((u32)track->m_shakeOutput >> REDSOUND_FIXED_SHIFT)) >>
+                    (shakeDepth * track->m_shakeFunc((u32)track->m_shakeOutput >> REDSOUND_FIXED_SHIFT)) >>
                     REDSOUND_SHAKE_PAN_SCALE_SHIFT;
                 track->m_shakeOutput += track->m_shakeRate;
             }


### PR DESCRIPTION
## Summary
Single source fix in `main/RedSound/RedExecute` (`_KeyOnControl`).

In the three shake-pan loops, the cached local `waveFunc = track->m_shakeFunc` forced mwcc to load the function pointer (@0xb4) *before* the call argument (m_shakeOutput @0xc8). The target evaluates the argument first. Dropping the cache and calling `track->m_shakeFunc(...)` inline restores the target's load order. The now-unused `RedSwingFunc waveFunc` local is removed.

## Result
- `_KeyOnControl` fuzzy 94.83 -> 94.94 (flagged lines 101 -> 95)
- Unit RedExecute fuzzy 98.18399 -> 98.19264
- matched_code 5488 (flat), matched_data 2566 (flat)

## Sweep notes (no net-positive lever found; all confirmed walls)
- `_SeTrackDataExecute`, `SetVoiceVolumeMix`, `_SeMidiNoteExecute`, `MainControl`, `_MusicNoteExecute`, `_VolumeExecute`: uniform +N callee-saved register-NUMBERING window (we allocate a wider r18/r21-r31 range vs target r22/r25/r26-r31). Not source-steerable.
- `_PitchExecute`: confirmed the documented `adjustedPitchDelta=0` spill-to-stack wall (target spills, we keep in r30); cannot force the spill from source.
- `GetRandomData`: `m_RandomIndex++` post-increment scheduled early vs target deferred — backend tie-break (re-confirmed walled).
- `_MusicTrackDataExecute`: dropping the redundant `(s16)` casts on m_keyTranspose/m_pitchBend removes the extra extsh but churns the PitchCompute arg-load scheduling worse (fuzzy 98.19 -> 98.10) — the cast is load-bearing, kept.
- `_AdsrStart`: reusing the `stage` pointer for m_adsrStepAdd (stage[2]) regressed; kept `voice->m_adsrStepAdd`.
- Data sections .data/.sdata/.sbss/.sdata2 all at 100%; the residual matched_data gap is in extab/extabindex (code-derived, not source-editable). TU-wide pragma sweep (oda/olt/oprop/strength_reduction/pool_data and pairs) all flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)