### PR TITLE
ymchtex b4: scoped opt_strength_reduction off on AfterDrawMeshCallback (unit 98.18->98.40%)

### DIFF
--- a/src/pppYmChangeTex.cpp
+++ b/src/pppYmChangeTex.cpp
@@ -353,6 +353,8 @@ void pppConstructYmChangeTex(pppYmChangeTex* ymChangeTex, _pppCtrlTable* data)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma push
+#pragma opt_strength_reduction off
 void ChangeTex_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void* param_3, int meshIdx, float (*) [4])
 {
 	pppYmChangeTexState* state = (pppYmChangeTexState*)param_2;
@@ -402,6 +404,7 @@ void ChangeTex_AfterDrawMeshCallback(CChara::CModel* model, void* param_2, void*
 		}
 	}
 }
+#pragma pop
 
 /*
  * --INFO--


### PR DESCRIPTION
Scoped `#pragma opt_strength_reduction off` around `ChangeTex_AfterDrawMeshCallback`.

- ChangeTex_AfterDrawMeshCallback: 97.17% -> 98.62% (flagged asm lines 44 -> 21)
- Unit main/pppYmChangeTex fuzzy: 98.17719% -> 98.39754% (+0.22)
- matched_code 6.163328% (non-decreasing), matched_data 100.0% (held)

The pragma is scoped via push/pop so it does not touch pppFrameYmChangeTex (which regresses under a file-wide application).

Remaining sub-100 functions (pppFrameYmChangeTex, pppDestructYmChangeTex, ChangeTex_DrawMeshDLCallback) are all uniform callee-saved register-window/numbering walls (R104/R105): identical opcodes, offsets, immediates, and member accesses vs target, differing only by a uniform +1/+2/+3 callee-saved register shift anchored on where `state`/`model` land. No source reorder or pragma (full standard + non-standard sweep run on each) flips the window; all attempts were flat or regressing. No latent offset/signedness/width/break bugs found — all member offsets match the STATIC_ASSERTs and Ghidra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)