### PR TITLE
main/pppChangeTex: match meshList++ emission order in pppFrameChangeTex loops (98.388->98.443% fuzzy)

### DIFF
--- a/src/pppChangeTex.cpp
+++ b/src/pppChangeTex.cpp
@@ -155,7 +155,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, ChangeTexStep* step, _pppCtrlTab
 		    const_cast<char*>(s_pppChangeTex_cpp), 0x166);
 
 		GXColor** colorArray = work->m_meshColorArrays;
-		for (unsigned int meshIdx = 0; meshIdx < model0->m_data->m_meshCount; meshIdx++) {
+		for (unsigned int meshIdx = 0; meshIdx < model0->m_data->m_meshCount; meshIdx++, meshList++) {
 			ChangeTexMeshData* meshData = meshList->m_data;
 			if (strcmp(meshData->m_name, reinterpret_cast<const char*>(&sPppChangeTexMeshObjectName)) == 0) {
 				gUtil.CalcBoundaryBoxQuantized(&work->m_bboxMin, &work->m_bboxMax, meshList->m_workPositions,
@@ -188,7 +188,6 @@ void pppFrameChangeTex(pppChangeTex* changeTex, ChangeTexStep* step, _pppCtrlTab
 			memset(*colorArray, 0, meshList->m_data->m_vertexCount * sizeof(GXColor));
 
 			colorArray++;
-			meshList++;
 		}
 	}
 
@@ -210,7 +209,7 @@ void pppFrameChangeTex(pppChangeTex* changeTex, ChangeTexStep* step, _pppCtrlTab
 	             ((float)colorBlock->m_color.rgba[3] / LoadFloat(kPppChangeTexAlphaScale)));
 
 	meshList = ChangeTexMeshes(model0);
-	for (unsigned int meshIdx = 0; meshIdx < model0->m_data->m_meshCount; meshIdx++) {
+	for (unsigned int meshIdx = 0; meshIdx < model0->m_data->m_meshCount; meshIdx++, meshList++) {
 		GXColor* colors = work->m_meshColorArrays[meshIdx];
 		unsigned int vertCount;
 		for (unsigned int v = 0; (vertCount = meshList->m_data->m_vertexCount, v < vertCount); v++) {
@@ -230,7 +229,6 @@ void pppFrameChangeTex(pppChangeTex* changeTex, ChangeTexStep* step, _pppCtrlTab
 		}
 
 		DCFlushRange(colors, vertCount * sizeof(GXColor));
-		meshList++;
 	}
 }
 


### PR DESCRIPTION
## Summary
Moves `meshList++` from a trailing loop-body statement into the `for`-header increment clause in **both** loops of `pppFrameChangeTex` (the alloc loop and the per-mesh color-update loop).

This matches the target's trailing-increment emission order: `colorArray++ / hidden [meshIdx] cursor / meshIdx++ / meshList++`. Previously mwcc emitted `meshList++` second (right after the body), shifting the whole increment block out of target order.

## Results (main/pppChangeTex)
- fuzzy: 98.38779% -> 98.44275% (+0.055)
- matched_code: 7.633588% (flat)
- matched_data: 100.0% (flat)
- pppFrameChangeTex flagged lines: 72 -> 68

## Walls confirmed (no source lever, proven + reverted)
- **Register-numbering window** dominates all four sub-100 fns: `work`/`colorBlock` colored r26/r25 (ours) vs r23/r22 (target), a uniform +2/+3 callee-saved permutation (same save range r18-r31, same frame). pppDestructChangeTex is 100% this. Decl-swap regressed (75 flags); pragma sweep (oda/olt/oprop/osr + combos) no improvement.
- AfterDrawMeshCallback: the `lwz m_displayListCount` vs `ori fullTevBits` DELETE/INSERT is backend scheduling (reordering source did not move it).
- DrawMeshDLCallback inlined SetChangeTexReflectionState: scratch-register permutation (drawTevBits-const vs MaterialMan-base materialization order).

No latent behavioral bugs found; all member offsets/breaks verified against the STATIC_ASSERTs and Ghidra-shaped control flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)