### PR TITLE
pppYmLaser: hoist trailEndColor + fix CMapCylinder min/max arg order (98.40->98.97%)

### DIFF
--- a/src/pppYmLaser.cpp
+++ b/src/pppYmLaser.cpp
@@ -201,6 +201,11 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppLaserStep* step, _pppCtrl
 			trailStartColor.g = trailColorG;
 			trailStartColor.b = trailColorB;
 			trailStartColor.a = (u8)alphaMax - alphaStep * j;
+			_GXColor trailEndColor;
+			trailEndColor.r = trailColorR;
+			trailEndColor.g = trailColorG;
+			trailEndColor.b = trailColorB;
+			trailEndColor.a = (u8)alphaMax - alphaStep * (j + 1);
 
 			GXPosition3f32(work->m_origin.x, work->m_origin.y, work->m_origin.z);
 			GXColor1u32(*(u32*)&trailStartColor);
@@ -210,11 +215,6 @@ extern "C" void pppRenderYmLaser(pppYmLaser* laser, pppLaserStep* step, _pppCtrl
 			GXColor1u32(*(u32*)&trailStartColor);
 			GXTexCoord2f32(u0, LoadLaserFloat(kPppYmLaserZero));
 
-			_GXColor trailEndColor;
-			trailEndColor.r = trailColorR;
-			trailEndColor.g = trailColorG;
-			trailEndColor.b = trailColorB;
-			trailEndColor.a = (u8)alphaMax - alphaStep * (j + 1);
 			GXPosition3f32(work->m_points[j + 1].x, work->m_points[j + 1].y, work->m_points[j + 1].z);
 			GXColor1u32(*(u32*)&trailEndColor);
 			GXTexCoord2f32(u1, LoadLaserFloat(kPppYmLaserZero));
@@ -371,8 +371,8 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppLaserStep* step, _pppCtrlT
 			pppCopyVector(work->m_points[j + 1], work->m_points[j]);
 		}
 
-		localB.x = kPppYmLaserZero;
-		localB.y = kPppYmLaserZero;
+		localB.x = LoadLaserFloat(kPppYmLaserZero);
+		localB.y = LoadLaserFloat(kPppYmLaserZero);
 		localB.z = work->m_length;
 
 		if (i == 0) {
@@ -401,10 +401,10 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppLaserStep* step, _pppCtrlT
 		pppSubVector(localA, work->m_points[i], work->m_origin);
 		PSVECScale(&localA, &localA, LoadLaserFloat(kPppYmLaserHitRayScale));
 
-		CMapCylinder cyl(LoadLaserFloat(kPppYmLaserCylinderMax), LoadLaserFloat(kPppYmLaserCylinderMin));
+		CMapCylinder cyl(LoadLaserFloat(kPppYmLaserCylinderMin), LoadLaserFloat(kPppYmLaserCylinderMax));
 		cyl.m_bottom = work->m_origin;
 		cyl.m_axis = localA;
-		cyl.m_radius = kPppYmLaserZero;
+		cyl.m_radius = LoadLaserFloat(kPppYmLaserZero);
 
 		int check = MapMng.CheckHitCylinderNear(&cyl, &localA, 0xffffffff);
 		int hit = 0;
@@ -419,8 +419,8 @@ extern "C" void pppFrameYmLaser(pppYmLaser* laser, pppLaserStep* step, _pppCtrlT
 		}
 
 		if (i == 0) {
-			localB.x = kPppYmLaserZero;
-			localB.y = kPppYmLaserZero;
+			localB.x = LoadLaserFloat(kPppYmLaserZero);
+			localB.y = LoadLaserFloat(kPppYmLaserZero);
 			localB.z = work->m_length;
 			PSMTXMultVec(tempMtx, &localB, &work->m_points[i]);
 		}


### PR DESCRIPTION
## main/pppYmLaser — fuzzy 98.398094 -> 98.971380 (+0.573)

matched_code 296 (held), matched_data 48 (held), DOL byte-exact.

### pppRenderYmLaser (98.05% fn)
Hoisted `trailEndColor.{r,g,b,a}` above the first `GXPosition3f32` in the trail-vertex loop so both per-vertex alpha values (`(u8)alphaMax - alphaStep*j` and `... *(j+1)`) are computed before any vertex emit. This matches the target's instruction schedule and removes the cluster of INSERT/DELETE divergences around the `j`/`j+1` alpha strength-reduction block. The remaining flags in this block are pure GPR/FPR register-numbering and GX-FIFO base-register (r4/r5) allocation walls.

### pppFrameYmLaser (98.84% fn)
**Latent bug fix:** `CMapCylinder(float min, float max)` initializes `m_bound(min, max)`, but the call passed `(CylinderMax, CylinderMin)` — inverting the bound (min got +1e10, max got -1e10) and emitting the two sda21 const loads in the wrong order. Swapped to `(CylinderMin, CylinderMax)`: corrects the bound, matches the target's CylinderMax-first evaluation order, and fixes the `.sdata2` pool ordering (43.5% -> 52.2%).

Also wrapped the direct `kPppYmLaserZero` assignments (`localB.x/.y`, `cyl.m_radius`) in `LoadLaserFloat()` so they reference the named sdata2 symbol like the target instead of an anonymous pool entry.

### Walls confirmed (skipped)
- pppFrameYmLaser is otherwise a uniform callee-saved register-NUMBERING window (work ptr r29 target / r31 ours; loop vars r30/r31 vs r29/r30) — R104/R105.
- `fcmpu cr0,f0,f1` vs `f1,f0` operand-order: backend tie-break, comparison-order swap had no effect.
- The single remaining `clrlwi r15,r15,24` re-mask of `(u8)alphaMax`: CSE/scheduling inside the register-windowed block.
- Named-vs-anon sdata2 pool address-suffix display flags carry zero scoreboard cost.
- Pragma sweep (lifetimes/propagation/common_subs/strength_reduction/dead_assignments) found no wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)