### PR TITLE
RedExecute _VolumeExecute: re-read m_volumeModFrames in tremolo ramp comparison

### DIFF
--- a/src/RedSound/RedExecute.cpp
+++ b/src/RedSound/RedExecute.cpp
@@ -1284,7 +1284,7 @@ static void _VolumeExecute(RedVoiceDATA* voice, int volume)
                 volumeScaleValue = voice->m_volumeModFrame;
                 voice->m_volumeModFrame = voice->m_volumeModFrame + 1;
                 tremoloVolume = (tremoloVolume * volumeScaleValue) / tremoloRampFrames;
-                if (voice->m_volumeModFrame >= tremoloRampFrames) {
+                if (voice->m_volumeModFrame >= voice->m_volumeModFrames) {
                     voice->m_volumeModFrames = 0;
                 }
             }


### PR DESCRIPTION
## Summary
`_VolumeExecute` (main/RedSound/RedExecute): the tremolo-ramp-frame completion check `if (voice->m_volumeModFrame >= tremoloRampFrames)` cached the divisor local (`tremoloRampFrames`) for the comparison RHS, but the target re-reads `voice->m_volumeModFrames` (offset 0x30) fresh from memory for that comparison. Changed the comparison to read the field directly. This emits the `lwz r0, 0x30(r31)` reload that the target has, removing one DIFF_DELETE and one DIFF_ARG_MISMATCH.

Function fuzzy 96.283% -> 96.976%. Global matched_code non-decreasing (808080 unchanged), matched_data unchanged.

## Findings (walls confirmed, not fixed)
- The dominant residual across RedSound/RedExecute is a whole-function callee-saved register-window swap (e.g. `voice` pointer = r29 target / r30 ours in `_SeTrackDataExecute`) and arg-evaluation scheduling (the PitchCompute `keyTranspose + pitchBend` load order in `_SeTrackDataExecute`/`_MusicTrackDataExecute`). Neither responds to decl-order swaps or scoped pragmas (opt_lifetimes/opt_dead_assignments/opt_propagation tried).
- `_SePlayStart`/`_MusicPlayStart` track-init blocks: ours uses 1-2 extra callee-saved registers for the ~40 zero-stores -> larger frame; register-pressure tie-break.
- `_MusicCrossPlaySequence`: eager materialization of `REDSOUND_MASTER_VOLUME_FULL_FIXED_HALF` (0x1F800) hoisted before the first division block (eager-li scheduling wall).
- `_VoiceDataAsign` randomSign/randomScale: target emits the CR-setting rlwinm. before the data-producing clrlwi; reverse of mwcc scheduling here (inlining the sign test regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)