### PR TITLE
ME_USB_process SetUSBData: hoist named sdata2 consts (98.721->98.746%)

### DIFF
--- a/src/ME_USB_process.cpp
+++ b/src/ME_USB_process.cpp
@@ -12,6 +12,10 @@
 static const char s_ME_USB_process_cpp[] = "ME_USB_process.cpp";
 extern "C" const char sMemAllocErrorSizeFmt[] = "MemAlloc Error!!! size=%d\n";
 
+extern const float kMapEditorZero = 0.0f;
+extern const float kMapEditorOne = 1.0f;
+extern const double kMapEditorS32ToDoubleBias = 4503601774854144.0;
+
 namespace {
 struct ViewerSRT {
     float transX;
@@ -478,7 +482,3 @@ void CMaterialEditorPcs::MemFree(void* ptr)
         Memory.Free(ptr);
     }
 }
-
-extern const float kMapEditorZero = 0.0f;
-extern const float kMapEditorOne = 1.0f;
-extern const double kMapEditorS32ToDoubleBias = 4503601774854144.0;


### PR DESCRIPTION
## Summary
Moves the three `extern const` sdata2 definitions (`kMapEditorZero`, `kMapEditorOne`, `kMapEditorS32ToDoubleBias`) from the bottom of `src/ME_USB_process.cpp` to the top, before `CMaterialEditorPcs::SetUSBData()` — matching the layout used in sibling files (`pad.cpp`, `itemobj.cpp`).

## Why it matches
With the named bias defined *before* the function, mwcc's `static_cast<f32>(s32)` lowering in the `case 0x10` `srt.transY/transZ` casts reuses the named `kMapEditorS32ToDoubleBias` (`0x8032FD08`) pool entry instead of emitting a duplicate anonymous `@551` double-bias constant. This:
- removes the redundant 8-byte `.sdata2` entry → `.sdata2` **80% -> 100%**
- matches the `lfd f2, kMapEditorS32ToDoubleBias@sda21` instruction (was `@551@sda21`)

## Results (main/ME_USB_process)
- SetUSBData fuzzy: 98.70401 -> 98.72073
- unit fuzzy: 98.72102 -> 98.74586
- matched_code / matched_data: non-decreasing

## Remaining walls (not source-steerable)
- `.text`: uniform callee-saved register-numbering window in the unrolled `case 0x13` StoreSwap loop (target index counter r24 / reload-base rotation vs ours r26 / pinned r22) — R104/R105 allocation tie-break. Full pragma sweep (oda/olt/osr/oprop/ofs and combos) all regress or are flat.
- `.data`: the 272-byte switch jump table is 0% — named-vs-anon jump-table reloc (`jumptable_801EA668` vs `@548`); mwcc auto-names it, same size, case order already matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)