### PR TITLE
main/astar getEscapePos -> 100% (matched_code 17.87% -> 26.23%)

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -178,6 +178,7 @@ unsigned char CAStar::calcSpecialPolygonGroup(Vec* pos)
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_dead_assignments off
 CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int forbiddenGroup)
 {
 	Vec escapeDir;
@@ -191,7 +192,8 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 
 	CAPos* aheadBest = (CAPos*)0;
 	CAPos* behindBest = (CAPos*)0;
-	double aheadBestDist = LoadFloat(kAStarEscapeInitialBestDist);
+	const float& initialBestDist = kAStarEscapeInitialBestDist;
+	double aheadBestDist = initialBestDist;
 	double behindBestDist = aheadBestDist;
 	int i = 0;
 
@@ -268,6 +270,7 @@ CAStar::CAPos* CAStar::getEscapePos(Vec& from, Vec& base, int startGroup, int fo
 
 	return behindBest;
 }
+#pragma opt_dead_assignments reset
 /*
  * --INFO--
  * Address:	TODO


### PR DESCRIPTION
## main/astar B4 grind (c2)

### Landed: getEscapePos fully matched
`getEscapePos__6CAStarFR3VecR3Vecii` (584 bytes) reached **100%** byte-match, lifting unit matched_code_percent from **17.869% -> 26.231%** (+8.36) and unit fuzzy 99.313 -> 99.422.

Two-part fix:
1. Scoped `#pragma opt_dead_assignments off` collapses the saved-register numbering window (target colored from/base/startGroup/forbiddenGroup + the portal loop pointer into r25-r29; ours used r29/r30/r31/r24/r25 — a uniform shift). With the pragma the window closes, dropping flagged lines 33 -> 3.
2. `const float& initialBestDist = kAStarEscapeInitialBestDist;` then `double aheadBestDist = initialBestDist;`. The original `LoadFloat()` wrapper materialized the init constant through a scratch f0 (extra fmr). A direct `double = kAStar...` const-assign emitted a double-pool `lfd @anon`. The `const float&` reference forces a single-precision `lfs kAStarEscapeInitialBestDist@sda21` straight into f30 with implicit widening, exactly matching target. Closed the last 3 lines.

### Walls confirmed (no net-positive lever; reverted)
- **addAstar / addRealTime**: portal-scan loop counter vs base-pointer get swapped volatile regs (r5<->r6, r4<->r5) — pure allocation tie-break. opt_dead_assignments/scheduling/peephole/optimize_for_size all neutral-or-worse.
- **calcPolygonGroup / calcSpecialPolygonGroup**: CMapCylinderRaw stack-frame offset divergence (0x68 vs 0xb4 band) + the zero-cost `@379` vs `kPolyGroupTopOffsetY@sda21` anon-pool reloc name. Swapping aabbMin/Max decl order and wrapping the +pos->y add in LoadFloat both regressed. opt_dead_assignments off regressed (52/25 flagged).
- **check** (1964b): dominated by an r29/r30/r31 saved-register numbering window across 40+ lines (unaffected by every pragma); one genuine extra `mr r28,r4` at the `other1Index = (unsigned char)other1` cast (clrlwi->r4->mr r28 vs target clrlwi->r28 directly) but it cannot reach 100% while the window stands.
- **drawAStar**: one `addi r27,r31,0x18` vs target `mr r27,r31` + `0x18(r27)` displacement-fold on the m_groupA/m_groupB cursor; rewriting the cursor as an indexed access regressed broadly (9 -> 20 flagged).

### No latent bugs found
Member offsets, breaks, and control flow all verified against the asm; the portal struct accesses and loop bounds are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)