### PR TITLE
pppYmDrawMdlTexAnm: opt_common_subs off (99.514->99.619% fuzzy)

### DIFF
--- a/src/pppYmDrawMdlTexAnm.cpp
+++ b/src/pppYmDrawMdlTexAnm.cpp
@@ -135,6 +135,7 @@ void pppRenderYmDrawMdlTexAnm(_pppPObject* object, pppYmDrawMdlTexAnmStep* step,
     pppDrawMesh(model, object->m_drawMatrixPtr, 1);
 }
 
+#pragma opt_common_subs off
 /*
  * --INFO--
  * PAL Address: 8008a604
@@ -237,6 +238,7 @@ void pppDestructYmDrawMdlTexAnm(_pppPObjLink* object, _pppCtrlTable* ctrl)
     work->m_tilesU = 0;
     work->m_wait = 0x200;
 }
+#pragma opt_common_subs reset
 
 /*
  * --INFO--


### PR DESCRIPTION
Scoped `#pragma opt_common_subs off` over pppFrameYmDrawMdlTexAnm and pppDestructYmDrawMdlTexAnm.

Both functions rewrite mapMesh m_uvPairs in a per-UV loop whose body is structurally identical to the target (divwu/mullw/subf frame math, lhax/sthx s16 loads, xoris 0x8000 int-to-double conversion) but diverges purely by register NUMBERING on the 0x4330 conversion bias (`lis rN,0x4330`) and the repeated `lwz rN,0x38(r30/r31)` m_uvPairs base reload. Disabling CSE changes the coloring of those reloads/biases to align more closely with the target.

Result (main/pppYmDrawMdlTexAnm unit):
- matched_code 45.1429% (held)
- matched_data 100.0% (held)
- fuzzy 99.51428% -> 99.61905% (+0.105)
- DIFF_ARG_MISMATCH: Destruct 19->8, Frame 21->6
- pppRenderYmDrawMdlTexAnm / pppConstructYmDrawMdlTexAnm stay at 100% (pragma scoped to exclude them)

Member offsets and loop/break structure verified correct vs target asm; no latent bug found. Remaining sub-100 is the residual register-numbering wall (R104/R105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)