### PR TITLE
mesmenu: 95.61% -> 97.00%

### DIFF
--- a/include/ffcc/mes.h
+++ b/include/ffcc/mes.h
@@ -7,6 +7,8 @@ class CGame;
 
 class CMes
 {
+    friend class CMesMenu;
+
 public:
     class CFlag
     {

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -644,15 +644,12 @@ void CMesMenu::onDraw()
         float titleAlpha = FLOAT_80330908 * stageBlend;
         MenuPcs.SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(titleAlpha)).Ref());
         unsigned int frameMask = m_menuIndex;
-        int maskU = 0x80;
-        int maskV = 0x38;
-        int frameNegX = -(int)(frameMask & 1);
-        float frameX = baseX - (float)(maskU & frameNegX);
-        float frameY = baseY - (float)(maskV & -(int)(frameMask >> 1 & 1));
+        float frameX = baseX - (float)((frameMask & 1) ? 0x80 : 0);
+        float frameY = baseY - (float)((frameMask >> 1 & 1) ? 0x38 : 0);
         MenuPcs.DrawRect(
             0, frameX, frameY, FLOAT_80330964, FLOAT_80330948,
-            (float)(maskU & ((int)(-(int)(frameMask & 2) | (int)(frameMask & 2)) >> 31)),
-            (float)(maskV & ((int)(frameNegX | (int)(frameMask & 1)) >> 31)), FLOAT_80330914, FLOAT_80330914,
+            (float)((frameMask & 2) ? 0x80 : 0),
+            (float)(((frameMask & 1) != 0) ? 0x38 : 0), FLOAT_80330914, FLOAT_80330914,
             FLOAT_803308d8);
 
         font->SetScale(FLOAT_8033094C);

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -889,9 +889,9 @@ void CMesMenu::onDraw()
             MenuPcs.SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(FLOAT_80330908 * stageBlend)).Ref());
 
             MenuPcs.DrawRect(
-                0, FLOAT_80330994 + *(float*)((char*)this + 0x3CB8),
-                (float)*(int*)((char*)this + 0x3D34) * *(float*)((char*)this + 0x3D40) +
-                    (FLOAT_803308e8 + *(float*)((char*)this + 0x3CBC) + *(float*)((char*)this + 0x3D3C)),
+                0, FLOAT_80330994 + m_mes.mBaseX,
+                (float)m_mes.mRubyHeight * m_mes.mRubySpacing +
+                    (FLOAT_803308e8 + m_mes.mBaseY + m_mes.mRubyY),
                 FLOAT_8033092c, FLOAT_8033092c, FLOAT_803308d8, FLOAT_803308d8, FLOAT_80330914, FLOAT_80330914, FLOAT_803308d8);
         }
         break;

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -645,10 +645,10 @@ void CMesMenu::onDraw()
         MenuPcs.SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(titleAlpha)).Ref());
         unsigned int frameMask = m_menuIndex;
         float frameX = baseX - (float)((frameMask & 1) ? 0x80 : 0);
-        float frameY = baseY - (float)((frameMask >> 1 & 1) ? 0x38 : 0);
+        float frameY = baseY - (float)((frameMask & 2) ? 0x38 : 0);
         MenuPcs.DrawRect(
             0, frameX, frameY, FLOAT_80330964, FLOAT_80330948,
-            (float)((frameMask & 2) ? 0x80 : 0),
+            (float)(((frameMask & 2) != 0) ? 0x80 : 0),
             (float)(((frameMask & 1) != 0) ? 0x38 : 0), FLOAT_80330914, FLOAT_80330914,
             FLOAT_803308d8);
 

--- a/src/mesmenu.cpp
+++ b/src/mesmenu.cpp
@@ -441,7 +441,7 @@ void CMesMenu::onDraw()
 {
     if ((m_menuIndex == 0) &&
         (static_cast<signed char>(static_cast<int>(static_cast<unsigned int>(CFlatGameFlags()) << 30) >> 31) != 0)) {
-        unsigned int iconFrame = 0;
+        int iconFrame = 0;
         int charaMode = Chara.MogFur().m_commandIndex;
         switch (charaMode) {
         case 0:
@@ -644,13 +644,15 @@ void CMesMenu::onDraw()
         float titleAlpha = FLOAT_80330908 * stageBlend;
         MenuPcs.SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(titleAlpha)).Ref());
         unsigned int frameMask = m_menuIndex;
+        int maskU = 0x80;
+        int maskV = 0x38;
         int frameNegX = -(int)(frameMask & 1);
-        float frameX = baseX - (float)(frameNegX & 0x80);
-        float frameY = baseY - (float)(-(int)(frameMask >> 1 & 1) & 0x38);
+        float frameX = baseX - (float)(maskU & frameNegX);
+        float frameY = baseY - (float)(maskV & -(int)(frameMask >> 1 & 1));
         MenuPcs.DrawRect(
             0, frameX, frameY, FLOAT_80330964, FLOAT_80330948,
-            (float)(((int)(-(int)(frameMask & 2) | (int)(frameMask & 2)) >> 31) & 0x80),
-            (float)(((int)(frameNegX | (int)(frameMask & 1)) >> 31) & 0x38), FLOAT_80330914, FLOAT_80330914,
+            (float)(maskU & ((int)(-(int)(frameMask & 2) | (int)(frameMask & 2)) >> 31)),
+            (float)(maskV & ((int)(frameNegX | (int)(frameMask & 1)) >> 31)), FLOAT_80330914, FLOAT_80330914,
             FLOAT_803308d8);
 
         font->SetScale(FLOAT_8033094C);
@@ -861,8 +863,10 @@ void CMesMenu::onDraw()
             MenuPcs.SetColor(CColor(0, 0, 0, static_cast<unsigned char>((FLOAT_803308ec * alpha255) * stageBlend)).Ref());
             float promptX = (float)(int)(FLOAT_803308f8 + drawX);
             float promptY = (float)(int)(FLOAT_8033092c + drawY);
-            float waveX = promptX + FLOAT_80330984 * (pulseScale * sinX);
-            float waveY = promptY - FLOAT_80330988 * (pulseScale * sinY);
+            float driftX = FLOAT_80330984 * (pulseScale * sinX);
+            float driftY = FLOAT_80330988 * (pulseScale * sinY);
+            float waveX = promptX + driftX;
+            float waveY = promptY - driftY;
             float fadeScale = FLOAT_80330914 - pulseScale;
             float rotation = FLOAT_8033091c * (FLOAT_803308e8 * (time - FLOAT_803308ec));
             MenuPcs.DrawRect(
@@ -881,15 +885,19 @@ void CMesMenu::onDraw()
         }
     }
 
-    if ((m_state == 1) && (m_mes.GetWait() == 3)) {
-        MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0));
-        MenuPcs.SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(FLOAT_80330908 * stageBlend)).Ref());
+    switch (m_state) {
+    case 1:
+        if (m_mes.GetWait() == 3) {
+            MenuPcs.SetTexture(static_cast<CMenuPcs::TEX>(0));
+            MenuPcs.SetColor(CColor(0xFF, 0xFF, 0xFF, static_cast<unsigned char>(FLOAT_80330908 * stageBlend)).Ref());
 
-        MenuPcs.DrawRect(
-            0, FLOAT_80330994 + *(float*)((char*)this + 0x3CB8),
-            (float)*(int*)((char*)this + 0x3D34) * *(float*)((char*)this + 0x3D40) +
-                (FLOAT_803308e8 + *(float*)((char*)this + 0x3CBC) + *(float*)((char*)this + 0x3D3C)),
-            FLOAT_8033092c, FLOAT_8033092c, FLOAT_803308d8, FLOAT_803308d8, FLOAT_80330914, FLOAT_80330914, FLOAT_803308d8);
+            MenuPcs.DrawRect(
+                0, FLOAT_80330994 + *(float*)((char*)this + 0x3CB8),
+                (float)*(int*)((char*)this + 0x3D34) * *(float*)((char*)this + 0x3D40) +
+                    (FLOAT_803308e8 + *(float*)((char*)this + 0x3CBC) + *(float*)((char*)this + 0x3D3C)),
+                FLOAT_8033092c, FLOAT_8033092c, FLOAT_803308d8, FLOAT_803308d8, FLOAT_80330914, FLOAT_80330914, FLOAT_803308d8);
+        }
+        break;
     }
 }
 


### PR DESCRIPTION
## What changed

All within `CMesMenu::onDraw` (`src/mesmenu.cpp`):

- unsigned → signed conversion for the icon frame index
- rewrote the branchless bit-mask frame-offset math as the ternary selects the target codegen implies — keeping the exact mix of condition forms that matches (`(frameMask & 2) ? …` vs `((frameMask & 2) != 0) ? …`); the inconsistency is what the target emits, not a style choice
- split the fused wave-drift expression into named `driftX`/`driftY` temporaries
- converted the end-of-function state check to a `switch` (single-case; the if-form does not reproduce the target's dispatch shape — this was measured, not guessed)
- follow-up commit: replaced the raw `(char*)this + 0x3CB8/0x3CBC/0x3D34/0x3D3C/0x3D40` casts in the state-1 `DrawRect` with real member access (`m_mes.mBaseX/mBaseY/mRubyHeight/mRubyY/mRubySpacing`), enabled by `friend class CMesMenu;` in `include/ffcc/mes.h` — verified byte-identical (DOL sha1 unchanged)

## Evidence

- `main/mesmenu` fuzzy (report.json): **95.61% → 97.00%** (96.996864)
- `build/GCCP01/ok` passes; DOL sha1 matches `config/GCCP01/build.sha1`
- Rebuilt in a clean worktree and independently re-verified before submission

## Notes for review

- The `friend` declaration touches the shared `include/ffcc/mes.h`; codegen impact is zero (byte-identical DOL). Inline accessors were the alternative but are more invasive.
- Pre-existing raw this-offset accesses remain in a different function of this file (~lines 1037–1113, several reaching into `m_mes`); left for a follow-up to keep this PR reviewable.

---
Produced by Claude agents following `AGENTS.md` / `WORK_SPLIT.md`, operated by @SirEnkido. Every intermediate score in the commit messages was verified against report.json at commit time; the final state was re-verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
