### PR TITLE
mes: 94.81% -> 94.89%

### DIFF
--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -912,6 +912,7 @@ int CMes::GetWait()
  * JP Address: TODO
  * JP Size: TODO
  */
+#pragma opt_lifetimes off
 void CMes::addString(char** text, int branchMode)
 {
 	int fontSel = mFontIndex;
@@ -1551,6 +1552,7 @@ void CMes::addString(char** text, int branchMode)
 		mLineHeight = (mCurrentY < mLineHeight) ? mLineHeight : mCurrentY;
 	}
 }
+#pragma opt_lifetimes reset
 
 /*
  * --INFO--

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -96,13 +96,6 @@ static inline int ReadTagS8(char** text)
 	return (int)ReadTagByte(text);
 }
 
-static inline unsigned short ReadMesChar(char** text)
-{
-	unsigned char* p = (unsigned char*)*text;
-	*text = (char*)(p + 1);
-	return *p;
-}
-
 static inline int ReadTagNibble(char** text)
 {
 	char* p = *text;

--- a/src/mes.cpp
+++ b/src/mes.cpp
@@ -949,7 +949,7 @@ void CMes::addString(char** text, int branchMode)
 	unsigned short uch;
 	while (running)
 	{
-		if ((uch = ReadMesChar(text)) == 0)
+		if ((uch = *(unsigned char*)(*text)++) == 0)
 		{
 			running = 0;
 			goto updateBounds;


### PR DESCRIPTION
## What changed

`CMes::addString` (`src/mes.cpp`):

- scoped `#pragma opt_lifetimes off` around the function (off/reset paired, house-accepted pattern)
- the next message byte is read via a direct `unsigned char` pointer dereference instead of the single-use `ReadMesChar` inline helper — this drops a return-temp `mr` the target does not have
- follow-up commit removes the now-unused `ReadMesChar` helper (no other call sites; score unchanged)

## Evidence

- `main/mes` fuzzy (report.json): **94.8078% → 94.8926%**
- All three intermediate scores in the commit messages were independently reproduced by rebuilding each revision
- `build/GCCP01/ok` passes

## Notes for review

- If the original source used `ReadMesChar` elsewhere in future matches, it can be trivially re-added; today it has no other call sites.
- Per WORK_SPLIT.md guidance, the scoped pragma should be retested for removal after future structural changes to this function.

---
Produced by Claude agents following `AGENTS.md` / `WORK_SPLIT.md`, operated by @SirEnkido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
