### PR TITLE
pad.h: replace offset-style CPad placeholder members with names (19 -> 0 junk; DOL byte-identical)

### DIFF
--- a/include/ffcc/pad.h
+++ b/include/ffcc/pad.h
@@ -63,21 +63,10 @@ public:
         ReplayFrame frames[0x1A5E0];
     };
 
-    struct PadInputRawView
-    {
-        short _4_2_;
-        short _6_2_;
-        short _8_2_;
-        short _a_2_;
-        unsigned char _c_1_[0x14];
-        short _20_2_;
-        unsigned char _22_1_[0x186];
-    };
-
     CPad()
     {
-        _1b4_4_ = 0;
-        _1b8_4_ = 0;
+        m_replayPlayback = 0;
+        m_replayWrite = 0;
     }
 
     void Init();
@@ -135,31 +124,16 @@ public:
     const PadInput* GetPadInputs() const { return m_padInputs; }
     PadInput* GetMergedPad() { return &GetPadInputs()[4]; }
     const PadInput* GetMergedPad() const { return &GetPadInputs()[4]; }
-    union {
-        PadInput m_padInputs[5];
-        PadInputRawView m_padInputsRaw;
-    };
-    unsigned int _1a8_4_;
-    void* _1ac_4_;
-    ReplayBuffer* m_replayBuffer;
-    int _1b4_4_;
-    int _1b8_4_;
-    int m_replayFrame;
-    union {
-        unsigned int _1c0_4_;
-        int _448_4_;
-        int m_debugPadPort;
-    };
-    union {
-        unsigned int _1c4_4_;
-        int _452_4_;
-        int m_debugPadLock;
-    };
-    union {
-        int _1c8_4_;
-        int _456_4_;
-        int m_stickDigitalThreshold;
-    };
+    PadInput m_padInputs[5];         // [0..3] per port, [4] = merged
+    unsigned int m_padConnectedMask; // one high bit per port; set on PAD_ERR_NONE/NOT_READY, cleared on NO_CONTROLLER/TRANSFER
+    void* m_replayStage;             // CMemory::CStage* backing the replay buffer (gdev only)
+    ReplayBuffer* m_replayBuffer;    // 0 when replay is disabled
+    int m_replayPlayback;            // set by -r: play back /replay.dat instead of recording
+    int m_replayWrite;               // set by -w
+    int m_replayFrame;               // playback frame index; < 0 disables the replay path
+    int m_debugPadPort;
+    int m_debugPadLock;
+    int m_stickDigitalThreshold;
 };
 
 typedef char CPad_PadInput_size_check[(sizeof(CPad::PadInput) == 0x54) ? 1 : -1];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,10 +36,10 @@ void main(int argc, char** argv)
 
             switch (argument[1]) {
             case 'r':
-                Pad._1b4_4_ = 1;
+                Pad.m_replayPlayback = 1;
                 break;
             case 'w':
-                Pad._1b8_4_ = 1;
+                Pad.m_replayWrite = 1;
                 break;
             }
         }

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -123,16 +123,16 @@ void CPad::Frame()
 		switch (padStatus[port].err) {
 		case PAD_ERR_NONE:
 		case PAD_ERR_NOT_READY:
-			_1a8_4_ |= mask;
+			m_padConnectedMask |= mask;
 			break;
 		case PAD_ERR_NO_CONTROLLER:
 			if (static_cast<u8>(Joybus.GBAReady(port)) == 0) {
 				resetMask |= mask;
 			}
-			_1a8_4_ &= ~mask;
+			m_padConnectedMask &= ~mask;
 			break;
 		case PAD_ERR_TRANSFER:
-			_1a8_4_ &= ~mask;
+			m_padConnectedMask &= ~mask;
 			break;
 		}
 	}
@@ -433,7 +433,7 @@ void CPad::Quit()
 		m_replayBuffer = 0;
 	}
 
-	CMemory::CStage* stage = reinterpret_cast<CMemory::CStage*>(_1ac_4_);
+	CMemory::CStage* stage = reinterpret_cast<CMemory::CStage*>(m_replayStage);
 	if (stage != 0)
 	{
 		Memory.DestroyStage(stage);
@@ -457,8 +457,8 @@ void CPad::Init()
 
 	PADInit();
 	memset(m_padInputs, 0, sizeof(m_padInputs));
-	_1a8_4_ = 0;
-	_1ac_4_ = 0;
+	m_padConnectedMask = 0;
+	m_replayStage = 0;
 	m_replayBuffer = 0;
 	m_replayFrame = 0;
 	m_debugPadPort = 0xFFFFFFFF;
@@ -466,12 +466,12 @@ void CPad::Init()
 
 	if (System.IsGdev())
 	{
-		_1ac_4_ = Memory.CreateStage(0x800000, const_cast<char*>(s_CPad), 1);
-		if (_1ac_4_ != 0)
+		m_replayStage = Memory.CreateStage(0x800000, const_cast<char*>(s_CPad), 1);
+		if (m_replayStage != 0)
 		{
-			m_replayBuffer = reinterpret_cast<ReplayBuffer*>(new (reinterpret_cast<CMemory::CStage*>(_1ac_4_), "pad.cpp", 0x54)
+			m_replayBuffer = reinterpret_cast<ReplayBuffer*>(new (reinterpret_cast<CMemory::CStage*>(m_replayStage), "pad.cpp", 0x54)
 				unsigned char[sizeof(ReplayBuffer)]);
-			if ((_1b4_4_ != 0) && ((fp = fopen(s_replay_dat, "rb")) != 0))
+			if ((m_replayPlayback != 0) && ((fp = fopen(s_replay_dat, "rb")) != 0))
 			{
 				fseek(fp, 0, 2);
 				size = ftell(fp);


### PR DESCRIPTION
## What changed
One commit on top of current main. It touches `include/ffcc/pad.h`, `src/pad.cpp` and `src/main.cpp`.

- Renames the four remaining offset-style `CPad` members, using how each one is used as evidence:
  - `_1a8_4_` -> `m_padConnectedMask`: a per-port high bit, set in `CPad::Frame` on `PAD_ERR_NONE`/`NOT_READY` and cleared on `NO_CONTROLLER`/`TRANSFER`.
  - `_1ac_4_` -> `m_replayStage`: holds the `Memory.CreateStage` result on gdev, and `Quit` destroys it.
  - `_1b4_4_` -> `m_replayPlayback`: set by the `-r` argument, and gates loading `/replay.dat` in `Init`.
  - `_1b8_4_` -> `m_replayWrite`: set by the `-w` argument.
- Removes the dead aliasing unions (`_1c0_4_`/`_448_4_`/`m_debugPadPort` etc.) and keeps only the named member in each.
- Removes the unused `PadInputRawView` / `m_padInputsRaw` view. `m_padInputs[5]` covers the same 0x1A4 bytes, so the layout is unchanged.

Upstream's native recovery of `pad.cpp` (f26dac3) had already removed the old `Frame`/`MergePadInputs` local-variable junk. This PR only covers what that recovery left.

## Evidence (vs current main)
- `ninja` succeeds and `build/GCCP01/ok` exists.
- `main.dol` md5 `c4b25d63bbc1d6abe985a91b673ae17b`, byte-identical to main.
- `main/pad` fuzzy match: 94.09198% -> 94.09198% (unchanged).
- Offset-style placeholder names in `include/ffcc/pad.h`: 19 -> 0.
- Ghidra auto-name regex on `src/pad.cpp`: 0 -> 0, already clean upstream.
- `/* --INFO-- */` headers are unchanged (4 before and after).

## Notes
- This PR only changes names and header tidiness; it adds no score or linkage.
- The member names come from how the code uses them, not from shipped symbols.
- No pointer-offset hacks, pragmas or UB idioms were added. The existing `reinterpret_cast<CMemory::CStage*>` on the `void*` stage member is unchanged from upstream.

Produced by Claude agents following AGENTS.md, operated by @SirEnkido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)