### PR TITLE
p_chara: 97.05% -> 97.70%

### DIFF
--- a/include/ffcc/color.h
+++ b/include/ffcc/color.h
@@ -38,10 +38,10 @@ public:
 	CColor operator*(float scale) const
 	{
 		CColor out;
-		out.color.r = static_cast<unsigned char>(static_cast<int>(color.r * scale));
-		out.color.g = static_cast<unsigned char>(static_cast<int>(color.g * scale));
-		out.color.b = static_cast<unsigned char>(static_cast<int>(color.b * scale));
-		out.color.a = static_cast<unsigned char>(static_cast<int>(color.a * scale));
+		out.color.r = static_cast<unsigned char>(color.r * scale);
+		out.color.g = static_cast<unsigned char>(color.g * scale);
+		out.color.b = static_cast<unsigned char>(color.b * scale);
+		out.color.a = static_cast<unsigned char>(color.a * scale);
 		return out;
 	}
 	/*

--- a/include/ffcc/color.h
+++ b/include/ffcc/color.h
@@ -99,6 +99,15 @@ public:
 	}
 	CColor3(CColor3& other);
 	CColor3(_GXColor& other);
+	CColor3 operator*(const CColor& other) const
+	{
+		CColor3 result;
+		result.color.r = static_cast<unsigned char>((static_cast<int>(color.r) * other.color.r) / 255);
+		result.color.g = static_cast<unsigned char>((static_cast<int>(color.g) * other.color.g) / 255);
+		result.color.b = static_cast<unsigned char>((static_cast<int>(color.b) * other.color.b) / 255);
+		result.color.a = color.a;
+		return result;
+	}
 
 	GXColor color;
 };

--- a/include/ffcc/p_chara.h
+++ b/include/ffcc/p_chara.h
@@ -108,8 +108,8 @@ public:
         union {
             unsigned char m_drawListFlags;  // 0x190
             struct {
-                unsigned char m_drawListVisible : 1;
-                unsigned char : 7;
+                unsigned char m_flag_80 : 1;
+                unsigned char m_flag_lo : 7;
             } m_drawListFlagsBits;
         };
     };

--- a/include/ffcc/p_chara.h
+++ b/include/ffcc/p_chara.h
@@ -105,7 +105,13 @@ public:
         int m_asyncTextureVariant;          // 0x184
         int m_asyncState;                   // 0x188
         CFile::CHandle* m_asyncFileHandle;  // 0x18C
-        unsigned char m_drawListFlags;      // 0x190
+        union {
+            unsigned char m_drawListFlags;  // 0x190
+            struct {
+                unsigned char m_drawListVisible : 1;
+                unsigned char : 7;
+            } m_drawListFlagsBits;
+        };
     };
 
     class CLoadModel

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -571,12 +571,12 @@ void CCharaPcs::Init()
     m_charaAllocStage = 0;
     m_overlapEnabled = 0;
     CColor baseColor(0x00, 0x00, 0x40, 0x40);
-    m_texShadowColor = baseColor.color;
+    CopyColor(&m_texShadowColor, baseColor.color);
 
-    CVector baseVec(0.0f, 100.0f, 0.0f);
-    m_texShadowPos.x = baseVec.x;
-    m_texShadowPos.y = baseVec.y;
-    m_texShadowPos.z = baseVec.z;
+    Vec* constructedVec = CVector(0.0f, 100.0f, 0.0f);
+    m_texShadowPos.x = constructedVec->x;
+    m_texShadowPos.y = constructedVec->y;
+    m_texShadowPos.z = constructedVec->z;
     m_texShadowRadius = 500.0f;
     m_texShadowSize = 0x80;
     m_texShadowDistance = 100;

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -573,10 +573,10 @@ void CCharaPcs::Init()
     CColor baseColor(0x00, 0x00, 0x40, 0x40);
     CopyColor(&m_texShadowColor, baseColor.color);
 
-    Vec* constructedVec = CVector(0.0f, 100.0f, 0.0f);
-    m_texShadowPos.x = constructedVec->x;
-    m_texShadowPos.y = constructedVec->y;
-    m_texShadowPos.z = constructedVec->z;
+    CVector baseVec(0.0f, 100.0f, 0.0f);
+    m_texShadowPos.x = baseVec.x;
+    m_texShadowPos.y = baseVec.y;
+    m_texShadowPos.z = baseVec.z;
     m_texShadowRadius = 500.0f;
     m_texShadowSize = 0x80;
     m_texShadowDistance = 100;
@@ -2778,7 +2778,7 @@ void CCharaPcs::CHandle::draw(int drawPass, int immediatePass)
         delta.Normalize();
 
         CVector eye = modelPos + CVector(0.0f, 10.0f, 0.0f);
-        Vec* lookAtUp = CVector(0.0f, 1.0f, 0.0f);
+        CVector lookAtUp(0.0f, 1.0f, 0.0f);
         CVector shadowPos = modelPos + delta * static_cast<float>(CharaPcs.m_texShadowDistance) +
                             CVector(0.0f, 10.0f, 0.0f);
         C_MTXLookAt(m_shadowViewMtx, shadowPos, lookAtUp, eye);

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -2153,8 +2153,9 @@ CCharaPcs::CHandle::~CHandle()
 
     CharaPcs.releaseUnuseLoadModel(0);
     {
-        CLoadAnim** slotPtr = &m_animSlot[0];
-        for (int i = 0; i < 64; i++, slotPtr++) {
+        int i;
+        CLoadAnim** slotPtr;
+        for (i = 0, slotPtr = &m_animSlot[0]; i < 64; i++, slotPtr++) {
             CRef* animRef = *slotPtr;
             if (animRef != 0) {
                 ReleaseShared(*slotPtr);

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -2213,7 +2213,7 @@ void CCharaPcs::CHandle::ChangeTexture(
     for (unsigned int i = 0; i < static_cast<unsigned int>(LoadTextureArray(&CharaPcs)->GetSize()); i++) {
         CLoadTexture* it = (*LoadTextureArray(&CharaPcs))[i];
         if (it->m_keyTag == charaKind && static_cast<unsigned long>(it->m_keyId) == charaNo &&
-            it->m_variantTag == static_cast<int>(textureVariant)) {
+            static_cast<unsigned long>(it->m_variantTag) == textureVariant) {
             loadTexture = it;
             goto foundTexture;
         }

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -647,7 +647,7 @@ void CCharaPcs::create()
         sentinel->m_asyncFileHandle = 0;
         sentinel->m_fogBlend = 0.0f;
         sentinel->m_unk0x158 = 0;
-        sentinel->m_drawListFlags |= 0x80;
+        sentinel->m_drawListFlagsBits.m_drawListVisible = 1;
     }
 
     m_handleList = sentinel;
@@ -2113,7 +2113,7 @@ CCharaPcs::CHandle::CHandle()
 
 	m_fogBlend = 0.0f;
 	m_unk0x158 = 0;
-	m_drawListFlags |= 0x80;
+	m_drawListFlagsBits.m_drawListVisible = 1;
 }
 
 /*

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -2718,26 +2718,10 @@ void CCharaPcs::CHandle::draw(int drawPass, int immediatePass)
                     CharaPcs.m_viewerChoiceColor[phaseIndex + 1] * blendT;
         }
 
-        const CColor3& ambientBase = CColor3(CharaPcs.m_viewerAmbientColor[lightBank]);
-        CColor3 ambientShade;
-        ambientShade.color.r = static_cast<signed char>((static_cast<int>(ambientBase.color.r) * shade.color.r) / 255);
-        ambientShade.color.g = static_cast<signed char>((static_cast<int>(ambientBase.color.g) * shade.color.g) / 255);
-        ambientShade.color.b = static_cast<unsigned char>((static_cast<int>(ambientBase.color.b) * shade.color.b) / 255);
-        ambientShade.color.a = ambientBase.color.a;
-        CColor3 ambientColor(ambientShade);
-        _GXColor ambientGX = ambientColor.color;
-        LightPcs.SetAmbient(ambientGX);
+        LightPcs.SetAmbient((CColor3(CharaPcs.m_viewerAmbientColor[lightBank]) * shade).color);
 
         for (unsigned long i = 0; i < 3; i++) {
-            const CColor3& diffuseBase = CColor3(CharaPcs.m_viewerDiffuseColor[lightBank][i]);
-            CColor3 diffuseShade;
-            diffuseShade.color.r = static_cast<signed char>((static_cast<int>(diffuseBase.color.r) * shade.color.r) / 255);
-            diffuseShade.color.g = static_cast<unsigned char>((static_cast<int>(diffuseBase.color.g) * shade.color.g) / 255);
-            diffuseShade.color.b = static_cast<unsigned char>((static_cast<int>(diffuseBase.color.b) * shade.color.b) / 255);
-            diffuseShade.color.a = diffuseBase.color.a;
-            CColor3 diffuseColor(diffuseShade);
-            _GXColor diffuseGX = diffuseColor.color;
-            LightPcs.SetDiffuseColor(i, diffuseGX);
+            LightPcs.SetDiffuseColor(i, (CColor3(CharaPcs.m_viewerDiffuseColor[lightBank][i]) * shade).color);
         }
 
         Vec lightPos;

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -2962,8 +2962,8 @@ void CCharaPcs::CHandle::loadModelASyncFrame()
 
     if (m_asyncState == 2) {
         void* readBuffer = File.m_readBuffer;
-        int keyId = m_asyncCharaNo;
         int keyTag = m_asyncCharaKind;
+        int keyId = m_asyncCharaNo;
         CLoadModel* loadModel = new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_cpp), 0x5E8) CLoadModel;
         loadModel->m_keyTag = keyTag;
         loadModel->m_keyId = keyId;

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -2777,7 +2777,7 @@ void CCharaPcs::CHandle::draw(int drawPass, int immediatePass)
         delta.Normalize();
 
         CVector eye = modelPos + CVector(0.0f, 10.0f, 0.0f);
-        CVector lookAtUp(0.0f, 1.0f, 0.0f);
+        Vec* lookAtUp = CVector(0.0f, 1.0f, 0.0f);
         CVector shadowPos = modelPos + delta * static_cast<float>(CharaPcs.m_texShadowDistance) +
                             CVector(0.0f, 10.0f, 0.0f);
         C_MTXLookAt(m_shadowViewMtx, shadowPos, lookAtUp, eye);
@@ -2822,9 +2822,10 @@ void CCharaPcs::CHandle::draw(int drawPass, int immediatePass)
 
     if (drawPass == 1 || drawPass == 2) {
         if (drawPass == 2) {
-            const unsigned short shadowSize = static_cast<unsigned short>(CharaPcs.m_texShadowSize);
-            GXSetTexCopySrc(0, 0, shadowSize, shadowSize);
-            GXSetTexCopyDst(CharaPcs.m_texShadowSize, CharaPcs.m_texShadowSize, GX_CTF_R4, GX_FALSE);
+            GXSetTexCopySrc(0, 0, static_cast<unsigned short>(CharaPcs.m_texShadowSize),
+                            static_cast<unsigned short>(CharaPcs.m_texShadowSize));
+            GXSetTexCopyDst(static_cast<unsigned short>(CharaPcs.m_texShadowSize),
+                            static_cast<unsigned short>(CharaPcs.m_texShadowSize), GX_CTF_R4, GX_FALSE);
             m_shadowTexturePtr = reinterpret_cast<unsigned char*>(CharaPcs.m_texShadowTextureBase) +
                                  CharaPcs.m_texShadowTextureOffset;
             DCInvalidateRange(m_shadowTexturePtr, (CharaPcs.m_texShadowSize * CharaPcs.m_texShadowSize) / 2);

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -434,6 +434,14 @@ static inline _GXColor BlendColor(const _GXColor& a, const _GXColor& b, float t)
     return out;
 }
 
+static inline void CopyColor(_GXColor* dst, _GXColor src)
+{
+    dst->r = src.r;
+    dst->g = src.g;
+    dst->b = src.b;
+    dst->a = src.a;
+}
+
 static inline _GXColor ModulateColor(const _GXColor& src, const _GXColor& shade)
 {
     _GXColor out;
@@ -2789,48 +2797,26 @@ void CCharaPcs::CHandle::draw(int drawPass, int immediatePass)
 
     int restoreFog = 0;
     if (0.0f < m_fogBlend && (drawPass == 0 || drawPass == 4)) {
+        float fogStart;
+        float fogEnd;
         float invBlend = 1.0f - m_fogBlend;
         invBlend *= invBlend;
         float fogBlend = 1.0f - invBlend;
 
+        _GXColor graphicFogColor;
         float nearZ;
         float farZ;
         GetCameraClipPlanes(&nearZ, &farZ);
-        const float fogStart = Graphic.m_fogStart;
-        _GXColor graphicFogColor = Graphic.m_fogColor;
-        const float fogEnd = Graphic.m_fogEnd;
+        fogStart = Graphic.m_fogStart;
+        CopyColor(&graphicFogColor, Graphic.m_fogColor);
+        fogEnd = Graphic.m_fogEnd;
 
-        const CColor& white = CColor(0xFF, 0xFF, 0xFF, 0xFF);
-        CColor whitePart;
-        whitePart.color.r = static_cast<unsigned char>(static_cast<int>(static_cast<float>(white.color.r) * fogBlend));
-        whitePart.color.g = static_cast<unsigned char>(static_cast<int>(static_cast<float>(white.color.g) * fogBlend));
-        whitePart.color.b = static_cast<unsigned char>(static_cast<int>(static_cast<float>(white.color.b) * fogBlend));
-        whitePart.color.a = static_cast<unsigned char>(static_cast<int>(static_cast<float>(white.color.a) * fogBlend));
-        CColor whitePartCopy(whitePart);
-
-        const CColor& fogBase = CColor(graphicFogColor);
-        CColor fogPart;
-        const float fogRemainder = 1.0f - fogBlend;
-        fogPart.color.r = static_cast<unsigned char>(static_cast<int>(static_cast<float>(fogBase.color.r) * fogRemainder));
-        fogPart.color.g = static_cast<unsigned char>(static_cast<int>(static_cast<float>(fogBase.color.g) * fogRemainder));
-        fogPart.color.b = static_cast<unsigned char>(static_cast<int>(static_cast<float>(fogBase.color.b) * fogRemainder));
-        fogPart.color.a = static_cast<unsigned char>(static_cast<int>(static_cast<float>(fogBase.color.a) * fogRemainder));
-        CColor fogPartCopy(fogPart);
-
-        CColor blendedFog;
-        blendedFog.color.r = fogPartCopy.color.r + whitePartCopy.color.r;
-        blendedFog.color.g = fogPartCopy.color.g + whitePartCopy.color.g;
-        blendedFog.color.b = fogPartCopy.color.b + whitePartCopy.color.b;
-        blendedFog.color.a = fogPartCopy.color.a + whitePartCopy.color.a;
-        CColor blendedFogCopy(blendedFog);
-
-        _GXColor fogColor = blendedFogCopy.color;
         GXSetFog(GX_FOG_PERSP_LIN,
-                 fogStart * fogRemainder + nearZ * fogBlend,
-                 (fogEnd + 1.0f) * fogRemainder + (nearZ + 1.0f) * fogBlend,
+                 fogStart * (1.0f - fogBlend) + nearZ * fogBlend,
+                 (fogEnd + 1.0f) * (1.0f - fogBlend) + (nearZ + 1.0f) * fogBlend,
                  nearZ,
                  farZ,
-                 fogColor);
+                 (CColor(graphicFogColor) * (1.0f - fogBlend) + CColor(0xFF, 0xFF, 0xFF, 0xFF) * fogBlend).color);
         restoreFog = 1;
     }
 

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -647,7 +647,7 @@ void CCharaPcs::create()
         sentinel->m_asyncFileHandle = 0;
         sentinel->m_fogBlend = 0.0f;
         sentinel->m_unk0x158 = 0;
-        sentinel->m_drawListFlagsBits.m_drawListVisible = 1;
+        sentinel->m_drawListFlagsBits.m_flag_80 = 1;
     }
 
     m_handleList = sentinel;
@@ -2113,7 +2113,7 @@ CCharaPcs::CHandle::CHandle()
 
 	m_fogBlend = 0.0f;
 	m_unk0x158 = 0;
-	m_drawListFlagsBits.m_drawListVisible = 1;
+	m_drawListFlagsBits.m_flag_80 = 1;
 }
 
 /*

--- a/src/p_chara.cpp
+++ b/src/p_chara.cpp
@@ -2392,44 +2392,44 @@ foundModel:
         strcat(path, s_charaModelSuffix);
 
         CFile::CHandle* fileHandle = File.Open(path, 0, CFile::PRI_LOW);
-        if (fileHandle == 0) {
-            return 0;
-        }
-
-        File.Read(fileHandle);
-        File.SyncCompleted(fileHandle);
-
-        void* readBuffer = File.m_readBuffer;
-        loadModel = new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_cpp), 0x5E8) CLoadModel;
-        loadModel->m_keyTag = charaKind;
-        loadModel->m_keyId = static_cast<int>(charaNo);
-        loadModel->m_mergeFileId = mergeFileId;
-        loadModel->m_mergeFlags = mergeFlags;
-        LoadModelArray(&CharaPcs)->Add(loadModel);
-
-        CChara::CModel* model =
-            new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_cpp), 0x5F1) CChara::CModel;
-        model->Create(readBuffer, HandleModelStage(charaKind, 0));
-        loadModel->m_model = model;
-
-        m_modelLoadRef = loadModel;
-        File.Close(fileHandle);
-        m_modelLoadRef->AddRef();
-        m_model = m_modelLoadRef->m_model;
-        m_model->AddRef();
-
-        strcpy(path, basePath);
-        strcat(path, s_charaDynamicsSuffix);
-        fileHandle = File.Open(path, 0, CFile::PRI_LOW);
         if (fileHandle != 0) {
             File.Read(fileHandle);
             File.SyncCompleted(fileHandle);
-            void* dynamicsBuffer = File.m_readBuffer;
-            m_model->CreateDynamics(dynamicsBuffer, HandleModelStage(charaKind, 0));
+
+            void* readBuffer = File.m_readBuffer;
+            loadModel = new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_cpp), 0x5E8) CLoadModel;
+            loadModel->m_keyTag = charaKind;
+            loadModel->m_keyId = static_cast<int>(charaNo);
+            loadModel->m_mergeFileId = mergeFileId;
+            loadModel->m_mergeFlags = mergeFlags;
+            LoadModelArray(&CharaPcs)->Add(loadModel);
+
+            CChara::CModel* model =
+                new (CharaPcs.m_stage, const_cast<char*>(s_p_chara_cpp), 0x5F1) CChara::CModel;
+            model->Create(readBuffer, HandleModelStage(charaKind, 0));
+            loadModel->m_model = model;
+
+            m_modelLoadRef = loadModel;
             File.Close(fileHandle);
-            if (static_cast<unsigned int>(System.m_execParam) >= 1) {
-                System.Printf(const_cast<char*>(s_charaDynamicsLoadDvdFmt), charaKind, static_cast<int>(charaNo));
+            m_modelLoadRef->AddRef();
+            m_model = m_modelLoadRef->m_model;
+            m_model->AddRef();
+
+            strcpy(path, basePath);
+            strcat(path, s_charaDynamicsSuffix);
+            fileHandle = File.Open(path, 0, CFile::PRI_LOW);
+            if (fileHandle != 0) {
+                File.Read(fileHandle);
+                File.SyncCompleted(fileHandle);
+                void* dynamicsBuffer = File.m_readBuffer;
+                m_model->CreateDynamics(dynamicsBuffer, HandleModelStage(charaKind, 0));
+                File.Close(fileHandle);
+                if (static_cast<unsigned int>(System.m_execParam) >= 1) {
+                    System.Printf(const_cast<char*>(s_charaDynamicsLoadDvdFmt), charaKind, static_cast<int>(charaNo));
+                }
             }
+        } else {
+            return 0;
         }
     }
 


### PR DESCRIPTION
## What changed

`src/p_chara.cpp`, `include/ffcc/p_chara.h`, `include/ffcc/color.h`. 12 small commits, each scored on its own:

- **color.h**: `CColor::operator*(float)` now uses the implicit u8->float->u8 conversions (no explicit `int` cast). New `CColor3::operator*(const CColor&)` does the per-channel `(a*b)/255` modulate.
- **draw**: ambient and diffuse lighting are now inline `CColor3(...) * shade` expressions. The fog colour is now a `CColor` operator expression inside the `GXSetFog` call. A by-value `CopyColor` helper copies the fog colour. The tex-shadow copy size is passed inline to `GXSetTexCopySrc`/`GXSetTexCopyDst`. The block that open-coded every channel is gone.
- **CHandle() / create**: `m_drawListFlags` (0x190) now uses the repo's union+bitfield idiom (`m_flag_80 : 1`, positional name as in `charaobj.h`). Setting the bit is a real bitfield assignment, which gives the target's `li`/`rlwimi`. This replaces the old branch's `__rlwimi` intrinsic.
- **CHandle::LoadModel**: the DVD-open failure is now the `else` branch after the load body.
- **ChangeTexture**: the variant tag is compared as unsigned (`cmplw`, as in the target).
- **~CHandle, Init, loadModelASyncFrame**: local declaration order changed and `Init` uses `CopyColor`.

## Evidence (vs new main 4c9e9d5)

| | main | this PR |
|---|---|---|
| main/p_chara fuzzy | 97.046776% | **97.698944%** |
| overall fuzzy | 98.07041% | 98.10042% |
| main/chara_fur fuzzy | 93.715034% | 95.370285% |

`ninja` exits 0 and `build/GCCP01/ok` is present; the code is byte-identical (1242/1242 functions). Per-function on p_chara: draw 93.94->98.15, CHandle() 96.90->100.00, Init 97.83->99.00, ChangeTexture 96.26->97.25, create 99.00->99.97, LoadModel 90.97->91.85, ~CHandle 98.35->98.51, loadModelASyncFrame ->98.09.

## Notes

- **Side effect:** the `color.h` change also raises `main/chara_fur` (+1.66pp). No other unit moved.
- **Deliberate score cost:** two earlier commits in this branch used `Vec* p = CVector(...);`, which keeps a pointer to a destroyed temporary (UB). The last commit replaces both with named `CVector` locals. This costs -0.049pp on the unit (draw 98.58->98.15, Init 99.10->99.00).
- **Naming:** the bit at 0x190/0x80 is set but never read in this unit, so it has the positional name `m_flag_80` rather than a guessed meaning.
- No pointer-offset or byte-pointer idioms, intrinsics, fake labels or leftover debris are added. `/* --INFO-- */` headers are untouched. `draw` declares `fogStart`/`fogEnd` before assigning them to match the target's register order.

Produced by Claude agents following AGENTS.md, operated by @SirEnkido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)